### PR TITLE
Link binaries against -lrt

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -16,7 +16,13 @@
 all: s2nc s2nd
 include ../s2n.mk
 
-LDFLAGS += -L../lib/ -ls2n -lcrypto -lrt
+ifeq ($(shell uname),Darwin)
+    LIBS = -lcrypto
+else
+    LIBS = -lcrypto -lrt
+endif
+
+LDFLAGS += -L../lib/ -ls2n ${LIBS}
 CRUFT += s2nc s2nd
 
 s2nc: s2nc.c echo.c

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -22,10 +22,16 @@ include ../../s2n.mk
 
 CRUFT += $(wildcard *_test)
 
+ifeq ($(shell uname),Darwin)
+    LIBS = -lcrypto -lpthread -lm
+else
+    LIBS = -lcrypto -lpthread -lm -lrt
+endif
+
 # Suppress the unreachable code warning, because tests involve what should be
 # unreachable code
 CFLAGS += -Wno-unreachable-code -I../../ -I../../api/
-LDFLAGS += -L../../lib/ -L../testlib/ -ltests2n -ls2n -lcrypto -lpthread -lm -lrt
+LDFLAGS += -L../../lib/ -L../testlib/ -ltests2n -ls2n ${LIBS}
 
 run_tests: build_tests
 	(for test in *_test ; do DYLD_LIBRARY_PATH="../../lib/:../testlib/:$$DYLD_LIBRARY_PATH" LD_LIBRARY_PATH="../../lib/:../testlib/:$$LD_LIBRARY_PATH" ./$$test || exit 1 ; done )


### PR DESCRIPTION
compilation was failing on ubuntu after pulling the latest master.  I added -lrt to the Makefiles for the binaries and now it is working again
