### PR TITLE
Start s2n_errno codes with ERR_OK

### DIFF
--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -30,6 +30,7 @@ struct s2n_error_translation
 };
 
 struct s2n_error_translation EN[] = { 
+    { S2N_ERR_OK, "no error" },
     { S2N_ERR_KEY_INIT, "error initializing encryption key" },
     { S2N_ERR_ENCRYPT, "error encrypting data" },
     { S2N_ERR_DECRYPT, "error decrypting data" },

--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -21,6 +21,7 @@
 extern __thread const char *s2n_debug_str;
 
 typedef enum {
+    S2N_ERR_OK,
     S2N_ERR_KEY_INIT,
     S2N_ERR_ENCRYPT,
     S2N_ERR_DECRYPT,


### PR DESCRIPTION
Default zero errno shouldn't point to an error.
