### PR TITLE
Renamed S2N_MAXIMUM_FRAGMENT_ to S2N_DEFAULT_FRAGMENT_. Updated default leng...

### DIFF
--- a/tests/unit/s2n_3des_test.c
+++ b/tests/unit/s2n_3des_test.c
@@ -36,13 +36,13 @@ int main(int argc, char **argv)
     uint8_t mac_key[] = "sample mac key";
     uint8_t des3_key[] = "12345678901234567890123";
     struct s2n_blob des3 = {.data = des3_key,.size = sizeof(des3_key) };
-    uint8_t random_data[S2N_MAXIMUM_FRAGMENT_LENGTH + 1];
+    uint8_t random_data[S2N_DEFAULT_FRAGMENT_LENGTH + 1];
 
     BEGIN_TEST();
 
     EXPECT_SUCCESS(s2n_init());
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-    EXPECT_SUCCESS(s2n_get_random_data(random_data, S2N_MAXIMUM_FRAGMENT_LENGTH + 1));
+    EXPECT_SUCCESS(s2n_get_random_data(random_data, S2N_DEFAULT_FRAGMENT_LENGTH + 1));
 
     /* Peer and we are in sync */
     conn->server = &conn->active;
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_hmac_init(&conn->active.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     conn->actual_protocol_version = S2N_TLS11;
 
-    int max_aligned_fragment = S2N_MAXIMUM_FRAGMENT_LENGTH - (S2N_MAXIMUM_FRAGMENT_LENGTH % 8);
+    int max_aligned_fragment = S2N_DEFAULT_FRAGMENT_LENGTH - (S2N_DEFAULT_FRAGMENT_LENGTH % 8);
     for (int i = 0; i <= max_aligned_fragment + 1; i++) {
         struct s2n_blob in = {.data = random_data,.size = i };
         int bytes_written;

--- a/tests/unit/s2n_aes_test.c
+++ b/tests/unit/s2n_aes_test.c
@@ -38,13 +38,13 @@ int main(int argc, char **argv)
     uint8_t aes256_key[] = "1234567890123456789012345678901";
     struct s2n_blob aes128 = {.data = aes128_key,.size = sizeof(aes128_key) };
     struct s2n_blob aes256 = {.data = aes256_key,.size = sizeof(aes256_key) };
-    uint8_t random_data[S2N_MAXIMUM_FRAGMENT_LENGTH + 1];
+    uint8_t random_data[S2N_DEFAULT_FRAGMENT_LENGTH + 1];
 
     BEGIN_TEST();
 
     EXPECT_SUCCESS(s2n_init());
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-    EXPECT_SUCCESS(s2n_get_random_data(random_data, S2N_MAXIMUM_FRAGMENT_LENGTH + 1));
+    EXPECT_SUCCESS(s2n_get_random_data(random_data, S2N_DEFAULT_FRAGMENT_LENGTH + 1));
 
     /* Peer and we are in sync */
     conn->server = &conn->active;
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_hmac_init(&conn->active.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     conn->actual_protocol_version = S2N_TLS11;
 
-    int max_aligned_fragment = S2N_MAXIMUM_FRAGMENT_LENGTH - (S2N_MAXIMUM_FRAGMENT_LENGTH % 16);
+    int max_aligned_fragment = S2N_DEFAULT_FRAGMENT_LENGTH - (S2N_DEFAULT_FRAGMENT_LENGTH % 16);
     for (int i = 0; i <= max_aligned_fragment + 1; i++) {
         struct s2n_blob in = {.data = random_data,.size = i };
         int bytes_written;
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_hmac_init(&conn->active.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     conn->actual_protocol_version = S2N_TLS11;
 
-    max_aligned_fragment = S2N_MAXIMUM_FRAGMENT_LENGTH - (S2N_MAXIMUM_FRAGMENT_LENGTH % 16);
+    max_aligned_fragment = S2N_DEFAULT_FRAGMENT_LENGTH - (S2N_DEFAULT_FRAGMENT_LENGTH % 16);
     for (int i = 0; i <= max_aligned_fragment + 1; i++) {
         struct s2n_blob in = {.data = random_data,.size = i };
         int bytes_written;

--- a/tests/unit/s2n_cbc_verify_test.c
+++ b/tests/unit/s2n_cbc_verify_test.c
@@ -115,21 +115,21 @@ int main(int argc, char **argv)
 {
     struct s2n_connection *conn;
     uint8_t mac_key[] = "sample mac key";
-    uint8_t fragment[S2N_MAXIMUM_FRAGMENT_LENGTH];
-    uint8_t random_data[S2N_MAXIMUM_FRAGMENT_LENGTH];
+    uint8_t fragment[S2N_DEFAULT_FRAGMENT_LENGTH];
+    uint8_t random_data[S2N_DEFAULT_FRAGMENT_LENGTH];
     struct s2n_hmac_state check_mac, record_mac;
 
     BEGIN_TEST();
 
     EXPECT_SUCCESS(s2n_init());
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-    EXPECT_SUCCESS(s2n_get_random_data(random_data, S2N_MAXIMUM_FRAGMENT_LENGTH));
+    EXPECT_SUCCESS(s2n_get_random_data(random_data, S2N_DEFAULT_FRAGMENT_LENGTH));
 
     /* Emulate TLS1.2 */
     conn->actual_protocol_version = S2N_TLS12;
 
     /* Try every 16 bytes to simulate block alignments */
-    for (int i = 288; i < S2N_MAXIMUM_FRAGMENT_LENGTH; i += 16) {
+    for (int i = 288; i < S2N_DEFAULT_FRAGMENT_LENGTH; i += 16) {
 
         EXPECT_SUCCESS(s2n_hmac_init(&record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
 

--- a/tests/unit/s2n_rc4_test.c
+++ b/tests/unit/s2n_rc4_test.c
@@ -36,13 +36,13 @@ int main(int argc, char **argv)
     uint8_t mac_key[] = "sample mac key";
     uint8_t rc4_key[] = "123456789012345";
     struct s2n_blob key_iv = {.data = rc4_key,.size = sizeof(rc4_key) };
-    uint8_t random_data[S2N_MAXIMUM_FRAGMENT_LENGTH + 1];
+    uint8_t random_data[S2N_DEFAULT_FRAGMENT_LENGTH + 1];
 
     BEGIN_TEST();
 
     EXPECT_SUCCESS(s2n_init());
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-    EXPECT_SUCCESS(s2n_get_random_data(random_data, S2N_MAXIMUM_FRAGMENT_LENGTH + 1));
+    EXPECT_SUCCESS(s2n_get_random_data(random_data, S2N_DEFAULT_FRAGMENT_LENGTH + 1));
 
     /* Peer and we are in sync */
     conn->server = &conn->active;
@@ -56,17 +56,17 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_hmac_init(&conn->active.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     conn->actual_protocol_version = S2N_TLS11;
 
-    for (int i = 0; i <= S2N_MAXIMUM_FRAGMENT_LENGTH + 1; i++) {
+    for (int i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = {.data = random_data,.size = i };
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
         EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
-        if (i <= S2N_MAXIMUM_FRAGMENT_LENGTH - 20) {
+        if (i <= S2N_DEFAULT_FRAGMENT_LENGTH - 20) {
             EXPECT_EQUAL(bytes_written, i);
         } else {
-            EXPECT_EQUAL(bytes_written, S2N_MAXIMUM_FRAGMENT_LENGTH - 20);
+            EXPECT_EQUAL(bytes_written, S2N_DEFAULT_FRAGMENT_LENGTH - 20);
         }
 
         uint16_t predicted_length = bytes_written + 20;

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -62,13 +62,13 @@ int main(int argc, char **argv)
     uint8_t mac_key[] = "sample mac key";
     struct s2n_blob fixed_iv = {.data = mac_key,.size = sizeof(mac_key) };
     struct s2n_hmac_state check_mac;
-    uint8_t random_data[S2N_MAXIMUM_FRAGMENT_LENGTH + 1];
+    uint8_t random_data[S2N_DEFAULT_FRAGMENT_LENGTH + 1];
 
     BEGIN_TEST();
 
     EXPECT_SUCCESS(s2n_init());
     EXPECT_SUCCESS(s2n_hmac_init(&check_mac, S2N_HMAC_SHA1, fixed_iv.data, fixed_iv.size));
-    EXPECT_SUCCESS(s2n_get_random_data(random_data, S2N_MAXIMUM_FRAGMENT_LENGTH + 1));
+    EXPECT_SUCCESS(s2n_get_random_data(random_data, S2N_DEFAULT_FRAGMENT_LENGTH + 1));
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
     /* Peer and we are in sync */
@@ -78,17 +78,17 @@ int main(int argc, char **argv)
     conn->active.cipher_suite = &s2n_null_cipher_suite;
     conn->actual_protocol_version = S2N_TLS11;
 
-    for (int i = 0; i <= S2N_MAXIMUM_FRAGMENT_LENGTH + 1; i++) {
+    for (int i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = {.data = random_data,.size = i };
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
         EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
-        if (i < S2N_MAXIMUM_FRAGMENT_LENGTH) {
+        if (i < S2N_DEFAULT_FRAGMENT_LENGTH) {
             EXPECT_EQUAL(bytes_written, i);
         } else {
-            EXPECT_EQUAL(bytes_written, S2N_MAXIMUM_FRAGMENT_LENGTH);
+            EXPECT_EQUAL(bytes_written, S2N_DEFAULT_FRAGMENT_LENGTH);
         }
 
         EXPECT_EQUAL(conn->out.blob.data[0], TLS_APPLICATION_DATA);
@@ -118,7 +118,7 @@ int main(int argc, char **argv)
     conn->active.cipher_suite = &s2n_null_cipher_suite;
     conn->actual_protocol_version = S2N_TLS11;
 
-    for (int i = 0; i <= S2N_MAXIMUM_FRAGMENT_LENGTH + 1; i++) {
+    for (int i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = {.data = random_data,.size = i };
         int bytes_written;
 
@@ -128,10 +128,10 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
         EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
-        if (i < S2N_MAXIMUM_FRAGMENT_LENGTH - 20) {
+        if (i < S2N_DEFAULT_FRAGMENT_LENGTH - 20) {
             EXPECT_EQUAL(bytes_written, i);
         } else {
-            EXPECT_EQUAL(bytes_written, S2N_MAXIMUM_FRAGMENT_LENGTH - 20);
+            EXPECT_EQUAL(bytes_written, S2N_DEFAULT_FRAGMENT_LENGTH - 20);
         }
 
         uint16_t predicted_length = bytes_written + 20;
@@ -199,7 +199,7 @@ int main(int argc, char **argv)
     conn->actual_protocol_version = S2N_TLS10;
     conn->active.cipher_suite = &mock_block_cipher_suite;
 
-    uint16_t max_aligned_fragment = S2N_MAXIMUM_FRAGMENT_LENGTH - (S2N_MAXIMUM_FRAGMENT_LENGTH % 16);
+    uint16_t max_aligned_fragment = S2N_DEFAULT_FRAGMENT_LENGTH - (S2N_DEFAULT_FRAGMENT_LENGTH % 16);
     for (int i = 0; i <= max_aligned_fragment + 1; i++) {
         struct s2n_blob in = {.data = random_data,.size = i };
         int bytes_written;
@@ -267,7 +267,7 @@ int main(int argc, char **argv)
     conn->actual_protocol_version = S2N_TLS11;
     conn->active.cipher_suite = &mock_block_cipher_suite;
 
-    max_aligned_fragment = S2N_MAXIMUM_FRAGMENT_LENGTH - (S2N_MAXIMUM_FRAGMENT_LENGTH % 16);
+    max_aligned_fragment = S2N_DEFAULT_FRAGMENT_LENGTH - (S2N_DEFAULT_FRAGMENT_LENGTH % 16);
     for (int i = 0; i <= max_aligned_fragment + 1; i++) {
         struct s2n_blob in = {.data = random_data,.size = i };
         int bytes_written;

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -79,7 +79,7 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
     blob.size = S2N_ALERT_LENGTH;
 
     GUARD_PTR(s2n_stuffer_init(&conn->writer_alert_out, &blob));
-    GUARD_PTR(s2n_stuffer_alloc(&conn->out, S2N_MAXIMUM_RECORD_LENGTH));
+    GUARD_PTR(s2n_stuffer_alloc(&conn->out, S2N_DEFAULT_RECORD_LENGTH));
 
     /* Initialize the growable stuffers. Zero length at first, but the resize
      * in _wipe will fix that 
@@ -158,10 +158,10 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     GUARD(s2n_stuffer_wipe(&conn->out));
 
     /* Allocate or resize to their original sizes */
-    GUARD(s2n_stuffer_resize(&conn->in, S2N_MAXIMUM_FRAGMENT_LENGTH));
+    GUARD(s2n_stuffer_resize(&conn->in, S2N_DEFAULT_FRAGMENT_LENGTH));
 
     /* Allocate memory for handling handshakes */
-    GUARD(s2n_stuffer_resize(&conn->handshake.io, S2N_MAXIMUM_RECORD_LENGTH));
+    GUARD(s2n_stuffer_resize(&conn->handshake.io, S2N_DEFAULT_RECORD_LENGTH));
 
     /* Clone the stuffers */
     /* ignore gcc 4.7 address warnings because dest is allocated on the stack */
@@ -184,7 +184,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     conn->active.cipher_suite = &s2n_null_cipher_suite;
     conn->server = &conn->active;
     conn->client = &conn->active;
-    conn->max_fragment_length = S2N_MAXIMUM_FRAGMENT_LENGTH;
+    conn->max_fragment_length = S2N_DEFAULT_FRAGMENT_LENGTH;
     conn->handshake.state = CLIENT_HELLO;
     GUARD(s2n_hash_init(&conn->handshake.client_md5, S2N_HASH_MD5));
     GUARD(s2n_hash_init(&conn->handshake.client_sha1, S2N_HASH_SHA1));

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -65,9 +65,9 @@
 
 /* s2n uses a record length that is aligned to the dominant internet MTU;
  * 1500 bytes, minus 20 bytes for an IP header, minus 20 bytes for a tcp
- * header */
-#define S2N_MAXIMUM_RECORD_LENGTH (1500 - 20 - 20)
-#define S2N_MAXIMUM_FRAGMENT_LENGTH (S2N_MAXIMUM_RECORD_LENGTH - S2N_TLS_RECORD_HEADER_LENGTH)
+ * header and 20 bytes for tcp options (timestamp, sack etc) */
+#define S2N_DEFAULT_RECORD_LENGTH (1500 - 20 - 20 - 20)
+#define S2N_DEFAULT_FRAGMENT_LENGTH (S2N_DEFAULT_RECORD_LENGTH - S2N_TLS_RECORD_HEADER_LENGTH)
 
 /* Put a 64k cap on the size of any handshake message */
 #define S2N_MAXIMUM_HANDSHAKE_MESSAGE_LENGTH (64 * 1024)


### PR DESCRIPTION
Two Changes
1) Renamed record size constant from s2n_max_fragment... to s2n_default_fragment... 
2) Reduced the default fragment size by 20 bytes to account for tcp options overhead (timestamp, sack)
