### PR TITLE
Debug: Add NSS Key Log Support

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -163,6 +163,9 @@ extern int s2n_config_add_ticket_crypto_key(struct s2n_config *config,
                                             uint8_t *key, uint32_t key_len,
                                             uint64_t intro_time_in_seconds_from_epoch);
 
+typedef void s2n_keylog_callback_fn(struct s2n_connection *conn, const char *line, void *ctx);
+extern int s2n_config_set_keylog_cb(struct s2n_config *config, s2n_keylog_callback_fn keylog_callback, void *ctx);
+
 typedef enum { S2N_SERVER, S2N_CLIENT } s2n_mode;
 extern struct s2n_connection *s2n_connection_new(s2n_mode mode);
 extern int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *config);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -813,6 +813,19 @@ Sets whether or not a should terminate connection on WARNING alert from peer. `a
 - `S2N_ALERT_FAIL_ON_WARNINGS` - default behavior: s2n will terminate conneciton if peer sends WARNING alert.
 - `S2N_ALERT_IGNORE_WARNINGS` - with the exception of `close_notify` s2n will ignore all WARNING alerts and keep communicating with its peer.
 
+### s2n\_set\_keylog\_cb
+
+```c
+typedef void s2n_keylog_callback_fn(struct s2n_connection *conn, const char *line, void *ctx);
+extern int s2n_config_set_keylog_cb(struct s2n_config *config, s2n_keylog_callback_fn keylog_callback, void *ctx);
+```
+
+**s2n_set_keylog_cb** allows the caller to set a callback function that will be
+called after each handshake and that will receive a key log line suitable for use
+with any [NSS Key Log Format](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format)
+compatible tool like Wireshark. Implementations should write the `line`, followed
+by a new line, to a log file.
+
 ## Certificate-related functions
 
 ### s2n\_cert\_chain\_and\_key\_new

--- a/tests/unit/s2n_keylog_test.c
+++ b/tests/unit/s2n_keylog_test.c
@@ -1,0 +1,185 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "testlib/s2n_testlib.h"
+
+#include <unistd.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <s2n.h>
+
+#include "crypto/s2n_fips.h"
+
+#include "tls/s2n_connection.h"
+#include "tls/s2n_handshake.h"
+#include "tls/s2n_cipher_preferences.h"
+#include "tls/s2n_cipher_suites.h"
+#include "utils/s2n_safety.h"
+
+static int try_handshake(struct s2n_connection *server_conn, struct s2n_connection *client_conn)
+{
+    s2n_blocked_status server_blocked;
+    s2n_blocked_status client_blocked;
+
+    int tries = 0;
+    do {
+        int client_rc = s2n_negotiate(client_conn, &client_blocked);
+        if (!(client_rc == 0 || (client_blocked && errno == EAGAIN))) {
+            return -1;
+        }
+
+        int server_rc = s2n_negotiate(server_conn, &server_blocked);
+        if (!(server_rc == 0 || (server_blocked && errno == EAGAIN))) {
+            return -1;
+        }
+
+        tries += 1;
+        if (tries == 100) {
+            return -1;
+        }
+    } while (client_blocked || server_blocked);
+
+    uint8_t server_shutdown = 0;
+    uint8_t client_shutdown = 0;
+    do {
+        if (!server_shutdown) {
+            int server_rc = s2n_shutdown(server_conn, &server_blocked);
+            if (server_rc == 0) {
+                server_shutdown = 1;
+            } else if (!(server_blocked && errno == EAGAIN)) {
+                return -1;
+            }
+        }
+
+        if (!client_shutdown) {
+            int client_rc = s2n_shutdown(client_conn, &client_blocked);
+            if (client_rc == 0) {
+                client_shutdown = 1;
+            } else if (!(client_blocked && errno == EAGAIN)) {
+                return -1;
+            }
+        }
+    } while (!server_shutdown || !client_shutdown);
+
+    return 0;
+}
+
+int test_conn(struct s2n_config *server_config, struct s2n_config *client_config) {
+    struct s2n_connection *client_conn;
+    struct s2n_connection *server_conn;
+    server_conn = s2n_connection_new(S2N_SERVER);
+    notnull_check(server_conn);
+    int server_to_client[2];
+    int client_to_server[2];
+
+    /* Create nonblocking pipes */
+    GUARD(pipe(server_to_client));
+    GUARD(pipe(client_to_server));
+    for (int i = 0; i < 2; i++) {
+       ne_check(fcntl(server_to_client[i], F_SETFL, fcntl(server_to_client[i], F_GETFL) | O_NONBLOCK), -1);
+       ne_check(fcntl(client_to_server[i], F_SETFL, fcntl(client_to_server[i], F_GETFL) | O_NONBLOCK), -1);
+    }
+
+    client_conn = s2n_connection_new(S2N_CLIENT);
+    notnull_check(client_conn);
+    GUARD(s2n_connection_set_read_fd(client_conn, server_to_client[0]));
+    GUARD(s2n_connection_set_write_fd(client_conn, client_to_server[1]));
+    GUARD(s2n_connection_set_config(client_conn, client_config));
+
+    GUARD(s2n_connection_set_read_fd(server_conn, client_to_server[0]));
+    GUARD(s2n_connection_set_write_fd(server_conn, server_to_client[1]));
+    GUARD(s2n_connection_set_config(server_conn, server_config));
+
+    GUARD(try_handshake(server_conn, client_conn));
+
+    GUARD(s2n_connection_free(server_conn));
+    GUARD(s2n_connection_free(client_conn));
+
+    for (int i = 0; i < 2; i++) {
+       GUARD(close(server_to_client[i]));
+       GUARD(close(client_to_server[i]));
+    }
+
+    return 0;
+}
+
+void check_keylog(struct s2n_connection *conn, const char *line, void *ctx)
+{
+    char *keylog_cb_invocations = (char *)ctx;
+
+    for (int i = 0; i < 10; i++) {
+        if (!keylog_cb_invocations[i * 256]) {
+            strncpy(&keylog_cb_invocations[i * 256], line, 255);
+            return;
+        }
+    }
+}
+
+int main(int argc, char **argv)
+{
+
+    BEGIN_TEST();
+
+    char keylog_cb_invocations[10][256] = { { "" } };
+
+    {
+        struct s2n_config *server_config, *client_config;
+        char *cert_chain_pem;
+        char *private_key_pem;
+        char *dhparams_pem;
+
+        EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(dhparams_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+
+        EXPECT_NOT_NULL(server_config = s2n_config_new());
+
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_DHPARAMS, dhparams_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(server_config, cert_chain_pem, private_key_pem));
+        EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
+        EXPECT_SUCCESS(s2n_config_set_keylog_cb(server_config, check_keylog, &keylog_cb_invocations[0][0]));
+
+        GUARD_NONNULL(client_config = s2n_config_new());
+        GUARD(s2n_config_set_unsafe_for_testing(client_config));
+
+        EXPECT_SUCCESS(s2n_config_set_verification_ca_location(client_config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
+
+        EXPECT_SUCCESS(test_conn(server_config, client_config));
+
+        EXPECT_SUCCESS(s2n_config_free(server_config));
+        EXPECT_SUCCESS(s2n_config_free(client_config));
+        free(cert_chain_pem);
+        free(private_key_pem);
+        free(dhparams_pem);
+
+        /* Both client and server should have logged the same line */
+        EXPECT_NOT_EQUAL(keylog_cb_invocations[0], 0);
+        EXPECT_NOT_EQUAL(keylog_cb_invocations[1], 0);
+        EXPECT_BYTEARRAY_EQUAL(keylog_cb_invocations[0], "CLIENT_RANDOM ", sizeof("CLIENT_RANDOM ") - 1);
+        EXPECT_STRING_EQUAL(keylog_cb_invocations[0], keylog_cb_invocations[1]);
+    }
+
+    END_TEST();
+    return 0;
+}
+

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -122,6 +122,8 @@ static int s2n_config_init(struct s2n_config *config)
     config->max_verify_cert_chain_depth = 0;
     config->max_verify_cert_chain_depth_set = 0;
     config->cert_tiebreak_cb = NULL;
+    config->keylog_cb = NULL;
+    config->keylog_cb_ctx = NULL;
 
     GUARD(s2n_config_setup_default(config));
     if (s2n_is_tls13_enabled()) {
@@ -644,6 +646,16 @@ int s2n_config_accept_max_fragment_length(struct s2n_config *config)
     notnull_check(config);
 
     config->accept_mfl = 1;
+
+    return 0;
+}
+
+int s2n_config_set_keylog_cb(struct s2n_config *config, s2n_keylog_callback_fn keylog_callback, void *ctx)
+{
+    notnull_check(config);
+
+    config->keylog_cb = keylog_callback;
+    config->keylog_cb_ctx = ctx;
 
     return 0;
 }

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -84,6 +84,9 @@ struct s2n_config {
 
     s2n_alert_behavior alert_behavior;
 
+    s2n_keylog_callback_fn *keylog_cb;
+    void *keylog_cb_ctx;
+
     /* Return TRUE if the host should be trusted, If FALSE this will likely be called again for every host/alternative name
      * in the certificate. If any respond TRUE. If none return TRUE, the cert will be considered untrusted. */
     uint8_t (*verify_host) (const char *host_name, size_t host_name_len, void *data);


### PR DESCRIPTION
**Issue # (if available):** #817 

**Description of changes:** Add NSS-compatible Key Log support

**Remarks**:

* One change I'm quite certain you'll want is to conditionally compile the code in, and preferably opt-in rather than opt-out. Since there are several ways to do this (cmake option, API) I've skipped that for now. Let's iterate on this PR!
* What about error checking? I omitted it on purpose, because it feels wrong to me to error out of a connection just because writing debug logs to the disk failed..
* This feature will need some (minor) work for TLS 1.3 compatibility: [See Mozilla's logs](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

(This is a repost of #818 that was closed prematurely by a bot and now cannot be reopened because I rebased my branch. CCing reviewers of original PR: @colmmacc, @baldwinmatt and @zz85.)