### PR TITLE
Support deprioritizing AES when signaled by client

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1501,6 +1501,15 @@ S2N_API int s2n_offered_early_data_reject(struct s2n_offered_early_data *early_d
  */
 S2N_API int s2n_offered_early_data_accept(struct s2n_offered_early_data *early_data);
 
+/**
+ * Control whether s2n should prioritize ChaCha20 when lack of AES acceleration is detected.
+ *
+ * @param config the config to modify.
+ * @param enabled 1 to enable detection, 0 to disable.
+ * @return a POSIX error signal.
+ */
+S2N_API int s2n_config_set_unaccelerated_aes_detection(struct s2n_config *config, bool enabled);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -77,9 +77,34 @@ struct s2n_cipher_suite *cipher_suites_20210831[] = {
     &s2n_rsa_with_aes_128_cbc_sha
 };
 
+/* Same as 202110831, but with ChaCha20 prioritized ahead of AES-GCM. */
+struct s2n_cipher_suite *cipher_suites_20210831_chacha[] = {
+    &s2n_tls13_chacha20_poly1305_sha256,
+    &s2n_tls13_aes_128_gcm_sha256,
+    &s2n_tls13_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_chacha20_poly1305_sha256,
+    &s2n_ecdhe_rsa_with_chacha20_poly1305_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_128_cbc_sha256,
+    &s2n_rsa_with_aes_128_cbc_sha
+};
+
 const struct s2n_cipher_preferences cipher_preferences_20210831 = {
     .count = s2n_array_len(cipher_suites_20210831),
     .suites = cipher_suites_20210831,
+    /* Cipher preferences to use when client is detected to not support AES-NI. */
+    .unaccelerated_aes_suites_count = s2n_array_len(cipher_suites_20210831_chacha),
+    .unaccelerated_aes_suites = cipher_suites_20210831_chacha,
 };
 
 /* s2n's list of cipher suites, in order of preference, as of 2014-06-01 */

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -23,6 +23,15 @@
 struct s2n_cipher_preferences {
     uint8_t count;
     struct s2n_cipher_suite **suites;
+
+    /* Preferences to use when the peer is detected to not have AES hardware acceleration.
+     * Currently, AES is the only crypto operation that may have a wide gap in performance compared to
+     * an "equivalently" secure alternative(ChaCha20) depending on the peer's implementation/platform.
+     * For now, this mechanism is specific to solve the AES problem. As more cases of "crypto performance"
+     * variance come up, we may consider generalizing this mechanism.
+     */
+    uint8_t unaccelerated_aes_suites_count;
+    struct s2n_cipher_suite **unaccelerated_aes_suites;
 };
 
 extern const struct s2n_cipher_preferences cipher_preferences_20140601;

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -24,6 +24,7 @@
 #include "crypto/s2n_hmac.h"
 
 #include <stdint.h>
+#include <stdbool.h>
 
 /* Key exchange flags that can be OR'ed */
 #define S2N_KEY_EXCHANGE_DH       0x01  /* Diffie-Hellman key exchange, including ephemeral */
@@ -168,3 +169,4 @@ extern int s2n_set_cipher_as_sslv2_server(struct s2n_connection *conn, uint8_t *
 extern int s2n_set_cipher_as_tls_server(struct s2n_connection *conn, uint8_t * wire, uint16_t count);
 bool s2n_cipher_suite_requires_ecc_extension(struct s2n_cipher_suite *cipher);
 bool s2n_cipher_suite_requires_pq_extension(struct s2n_cipher_suite *cipher);
+bool s2n_wire_ciphers_unaccelerated_aes_detected(uint8_t *wire, uint16_t count);

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -924,3 +924,10 @@ int s2n_config_get_ctx(struct s2n_config *config, void **ctx) {
 
     return S2N_SUCCESS;
 }
+
+int s2n_config_set_unaccelerated_aes_detection(struct s2n_config *config, bool enabled)
+{
+    POSIX_ENSURE_REF(config);
+    config->detect_unaccelerated_aes = enabled;
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -55,6 +55,8 @@ struct s2n_config {
      * but async signing must be enabled. Use this flag to enforce that restriction.
      */
     unsigned no_signing_key:1;
+    /* If true, s2n server will detect lack of AES acceleration on client and prioritize ChaCha20-Poly1035. */
+    bool detect_unaccelerated_aes;
 
     struct s2n_dh_params *dhparams;
     /* Needed until we can deprecate s2n_config_add_cert_chain_and_key. This is


### PR DESCRIPTION
Using a signalling mechanism that is implemented by a few well known web
browser clients[1]. For s2n_cipher_preferences that enable this feature,
s2n server will prioritize ChaCha20 ciphers over AES when the client's
preference list prioritizes ChaCha20 over AES.

This interface for this change(enabled via an opaque s2n cipher
preference string) differs from what other libraries have done.
Other libraries use an explicit flag for "ChaCha20 flipping"[2] or
introduce new concepts to cipher syntax language[3].

Moving forward, I do not expect every case of crypto performance variance
to be signalled with a cipher suite.

### Pending items for this change:
- [ ] Get agreement that this is the right external API for this feature
- [ ] New unit test for `s2n_wire_ciphers_detect_unaccelerated_aes`
- [ ] New integration test to verify the specific behavior: s2n server negotiates ChaCha20 when client prioritizes ChaCha20 above aes. 
- [ ] Doc update

[1] https://codereview.chromium.org/91913002
[2] https://github.com/openssl/openssl/commit/e1c7871de80029b81824df4d59edc6de5293835f
[3] https://boringssl.googlesource.com/boringssl/+/858a88daf27975f67d9f63e18f95645be2886bfb

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
