### PR TITLE
Add send/recv version to socket API. 

### DIFF
--- a/utils/s2n_socket.h
+++ b/utils/s2n_socket.h
@@ -33,7 +33,7 @@ struct s2n_socket_read_io_context {
 struct s2n_socket_write_io_context {
     /* The peer's fd */
     int fd;
-    
+
     /* Original TCP_CORK socket option settings before s2n takes over the fd */
     unsigned int original_cork_is_set:1;
     int original_cork_val;
@@ -50,4 +50,7 @@ extern int s2n_socket_write_uncork(struct s2n_connection *conn);
 extern int s2n_socket_set_read_size(struct s2n_connection *conn, int size);
 extern int s2n_socket_read(void *io_context, uint8_t *buf, uint32_t len);
 extern int s2n_socket_write(void *io_context, const uint8_t *buf, uint32_t len);
+extern int s2n_socket_recv(void *io_context, uint8_t *buf, uint32_t len);
+extern int s2n_socket_send(void *io_context, const uint8_t *buf, uint32_t len);
 extern int s2n_socket_is_ipv6(int fd, uint8_t *ipv6);
+


### PR DESCRIPTION
Dispatch to these methods in s2n_connection_set_xxx_fd methods.

_Please note that while we are transitioning from travis-ci to AWS CodeBuld, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 

**Description of changes:** 
For socket descriptors use send/recv methods. They are faster and return more precise error codes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
