### PR TITLE
utils: add s2n_result implementation

### DIFF
--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -24,6 +24,7 @@
 
 #include "error/s2n_errno.h"
 #include "utils/s2n_safety.h"
+#include "utils/s2n_result.h"
 
 int test_count;
 
@@ -120,6 +121,7 @@ int test_count;
         EXPECT_NOT_NULL(s2n_debug_str); \
         RESET_ERRNO(); \
     } while(0)
+#define EXPECT_RESULT_ERROR( function_call )  EXPECT_TRUE( s2n_result_is_error(function_call) )
 
 #define EXPECT_FAILURE_WITH_ERRNO_NO_RESET( function_call, err ) \
     do { \
@@ -135,6 +137,7 @@ int test_count;
     } while(0)
 
 #define EXPECT_SUCCESS( function_call )  EXPECT_NOT_EQUAL( (function_call) ,  -1 )
+#define EXPECT_RESULT_OK( function_call )  EXPECT_TRUE( s2n_result_is_ok(function_call) )
 
 #define EXPECT_BYTEARRAY_EQUAL( p1, p2, l ) EXPECT_EQUAL( memcmp( (p1), (p2), (l) ), 0 )
 #define EXPECT_BYTEARRAY_NOT_EQUAL( p1, p2, l ) EXPECT_NOT_EQUAL( memcmp( (p1), (p2), (l) ), 0 )

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -236,7 +236,9 @@ static int s2n_find_cert_matches(struct s2n_map *domain_name_to_cert_map,
         uint8_t *match_exists)
 {
     struct s2n_blob map_value;
-    if (s2n_map_lookup(domain_name_to_cert_map, dns_name, &map_value) == 1) {
+    bool key_found = false;
+    GUARD_AS_POSIX(s2n_map_lookup(domain_name_to_cert_map, dns_name, &map_value, &key_found));
+    if (key_found) {
         struct certs_by_type *value = (void *) map_value.data;
         for (int i = 0; i < S2N_CERT_TYPE_COUNT; i++) {
             matches[i] = value->certs[i];

--- a/utils/s2n_map.h
+++ b/utils/s2n_map.h
@@ -19,14 +19,15 @@
 #include "crypto/s2n_hash.h"
 
 #include "utils/s2n_blob.h"
+#include "utils/s2n_result.h"
 
 struct s2n_map;
 
 extern struct s2n_map *s2n_map_new();
 extern struct s2n_map *s2n_map_new_with_initial_capacity(uint32_t capacity);
-extern int s2n_map_add(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value);
-extern int s2n_map_put(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value);
-extern int s2n_map_complete(struct s2n_map *map);
-extern int s2n_map_unlock(struct s2n_map *map);
-extern int s2n_map_lookup(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value);
-extern int s2n_map_free(struct s2n_map *map);
+extern S2N_RESULT s2n_map_add(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value);
+extern S2N_RESULT s2n_map_put(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value);
+extern S2N_RESULT s2n_map_complete(struct s2n_map *map);
+extern S2N_RESULT s2n_map_unlock(struct s2n_map *map);
+extern S2N_RESULT s2n_map_lookup(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value, bool *key_found);
+extern S2N_RESULT s2n_map_free(struct s2n_map *map);

--- a/utils/s2n_result.c
+++ b/utils/s2n_result.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * The goal of s2n_result is to provide a strongly-typed error
+ * signal value, which provides the compiler with enough information
+ * to catch bugs.
+ *
+ * Historically, s2n has used int to signal errors. This has caused a few issues:
+ *
+ * ## GUARD in a function returning integer types
+ *
+ * There is no compiler error if `GUARD(nested_call());` is used in a function
+ * that is meant to return integer type - not a error signal.
+ *
+ * ```c
+ * uint8_t s2n_answer_to_the_ultimate_question() {
+ *   GUARD(s2n_sleep_for_years(7500000));
+ *   return 42;
+ * }
+ * ```
+ *
+ * In this function we intended to return a `uint8_t` but used a
+ * `GUARD` which will return -1 if the call fails. This can lead to
+ * very subtle bugs.
+ *
+ * ## `GUARD`ing a function returning any integer type
+ *
+ * There is no compiler error if `GUARD(nested_call());` is used
+ * on a function that doesn't actually return an error signal
+ *
+ * ```c
+ * int s2n_deep_thought() {
+ *   GUARD(s2n_answer_to_the_ultimate_question());
+ *   return 0;
+ * }
+ * ```
+ *
+ * In this function we intended guard against a failure of
+ * `s2n_answer_to_the_ultimate_question` but that function doesn't
+ * actually return an error signal. Again, this can lead to sublte
+ * bugs.
+ *
+ * ## Ignored error signals
+ *
+ * Without the `warn_unused_result` function attribute, the compiler
+ * provides no warning when forgetting to `GUARD` a function. Missing
+ * a `GUARD` can lead to subtle bugs.
+ *
+ * ```c
+ * int s2n_answer_to_the_ultimate_question() {
+ *   s2n_sleep_for_years(7500000); // <- THIS SHOULD BE GUARDED!!!
+ *   return 42;
+ * }
+ * ```
+ *
+ * # Solution
+ *
+ * s2n_result provides a newtype declaration, which is popular in
+ * languages like [Haskell](https://wiki.haskell.org/Newtype) and
+ * [Rust](https://doc.rust-lang.org/rust-by-example/generics/new_types.html).
+ *
+ * Functions that return S2N_RESULT are automatically marked with the
+ * `warn_unused_result` attribute, which ensures they are GUARDed.
+ */
+
+#include <s2n.h>
+#include <stdbool.h>
+#include "s2n_result.h"
+
+/* used to signal a successful function return */
+const s2n_result S2N_RESULT_OK = { S2N_SUCCESS };
+
+/* used to signal an error while executing a function */
+const s2n_result S2N_RESULT_ERROR = { S2N_FAILURE };
+
+/* returns true when the result is S2N_RESULT_OK */
+bool s2n_result_is_ok(s2n_result result)
+{
+    return result.__error_signal == S2N_SUCCESS;
+}
+
+/* returns true when the result is S2N_RESULT_ERROR */
+bool s2n_result_is_error(s2n_result result)
+{
+    return result.__error_signal == S2N_FAILURE;
+}

--- a/utils/s2n_result.h
+++ b/utils/s2n_result.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <s2n.h>
+#include <stdbool.h>
+
+/* A value which indicates the outcome of a function */
+typedef struct {
+    int __error_signal;
+} s2n_result;
+
+/* used to signal a successful function return */
+extern const s2n_result S2N_RESULT_OK;
+/* used to signal an error while executing a function */
+extern const s2n_result S2N_RESULT_ERROR;
+
+#if defined(__clang__) || defined(__GNUC__)
+#define S2N_RESULT_MUST_USE __attribute__((warn_unused_result))
+#else
+#define S2N_RESULT_MUST_USE
+#endif
+
+/* returns true when the result is S2N_RESULT_OK */
+S2N_RESULT_MUST_USE bool s2n_result_is_ok(s2n_result result);
+
+/* returns true when the result is S2N_RESULT_ERROR */
+S2N_RESULT_MUST_USE bool s2n_result_is_error(s2n_result result);
+
+/* used in function declarations to signal function fallibility */
+#define S2N_RESULT S2N_RESULT_MUST_USE s2n_result
+
+/* s2n_result GUARD helpers */
+/* note: eventually this will just alias GUARD and be deprecated once everything is using s2n_result */
+#define GUARD_RESULT( x )               do {if ( s2n_result_is_error(x) ) return S2N_RESULT_ERROR;} while (0)
+#define GUARD_AS_RESULT( x )            do {if ( (x) < 0 ) return S2N_RESULT_ERROR;} while (0)
+#define GUARD_AS_POSIX( x )             do {if ( s2n_result_is_error(x) ) return S2N_FAILURE;} while (0)
+#define GUARD_RESULT_GOTO( x, label )   do {if ( s2n_result_is_error(x) ) goto label;} while (0)
+#define GUARD_RESULT_PTR( x )           do {if ( s2n_result_is_error(x) ) return NULL;} while (0)
+
+/* s2n_result ERROR helpers */
+/* note: eventually this will just alias S2N_ERROR and be deprecated once everything is using s2n_result */
+#define S2N_ERROR_RESULT( x )      do { _S2N_ERROR( ( x ) ); return S2N_RESULT_ERROR; } while (0)
+#define S2N_ERROR_RESULT_PRESERVE_ERRNO() do { return S2N_RESULT_ERROR; } while (0)
+#define S2N_ERROR_RESULT_PTR( x )  do { _S2N_ERROR( ( x ) ); return NULL; } while (0)
+#define S2N_ERROR_RESULT_IF( cond , x ) do { if ( cond ) { S2N_ERROR_RESULT( x ); }} while (0)


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

**Issue # (if available):** 
Part 1 for #1782 and #1783

**Description of changes:** 

The goal of s2n_result is to provide a strongly-typed error signal value, which provides the compiler with enough information to catch bugs.

Historically, s2n has used int to signal errors. This has caused a few issues:

## GUARD in a function returning integer types

There is no compiler error if `GUARD(nested_call());` is used in a function that is meant to return integer type - not a error signal.

```c
uint8_t s2n_answer_to_the_ultimate_question() {
  GUARD(s2n_sleep_for_years(7500000));
  return 42;
}
```

In this function we intended to return a `uint8_t` but used a `GUARD` which will return -1 if the call fails. This can lead to very subtle bugs.

## `GUARD`ing a function returning any integer type

There is no compiler error if `GUARD(nested_call());` is used on a function that doesn't actually return an error signal

```c
int s2n_deep_thought() {
  GUARD(s2n_answer_to_the_ultimate_question());
  return 0;
}
```

In this function we intended guard against a failure of `s2n_answer_to_the_ultimate_question` but that function doesn't actually return an error signal. Again, this can lead to sublte
bugs.

## Ignored error signals

Without the `warn_unused_result` function attribute, the compiler provides no warning when forgetting to `GUARD` a function. Missing a `GUARD` can lead to subtle bugs.

```c
int s2n_answer_to_the_ultimate_question() {
  s2n_sleep_for_years(7500000); // <- THIS SHOULD BE GUARDED!!!
  return 42;
}
```

# Solution

s2n_result provides a newtype declaration, which is popular in languages like [Haskell](https://wiki.haskell.org/Newtype) and [Rust](https://doc.rust-lang.org/rust-by-example/generics/new_types.html).

Functions that return S2N_RESULT are automatically marked with the `warn_unused_result` attribute, which ensures they are GUARDed.

### Follow up
Over the next week I will gradually be moving functions to return `S2N_RESULT` instead of `int`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
