### PR TITLE
Faster cbmc coverage

### DIFF
--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -253,7 +253,7 @@ logs/property.xml: $(ENTRY_GOTO).goto
 	$(call DO_CBMC,$(CBMCFLAGS) --show-properties --xml-ui,$<,$@)
 
 logs/coverage.xml: $(ENTRY_GOTO).goto
-	$(call DO_CBMC,$(CBMC_UNWINDSET) --cover location --xml-ui,$<,$@)
+	$(call DO_CBMC,--unwind 1 $(CBMC_UNWINDSET) --cover location --xml-ui,$<,$@)
 
 cbmc: logs/cbmc.log
 

--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -253,7 +253,7 @@ logs/property.xml: $(ENTRY_GOTO).goto
 	$(call DO_CBMC,$(CBMCFLAGS) --show-properties --xml-ui,$<,$@)
 
 logs/coverage.xml: $(ENTRY_GOTO).goto
-	$(call DO_CBMC,$(filter-out --unwinding-assertions,$(CBMCFLAGS)) --cover location --xml-ui,$<,$@)
+	$(call DO_CBMC,$(CBMC_UNWINDSET) --cover location --xml-ui,$<,$@)
 
 cbmc: logs/cbmc.log
 

--- a/tests/cbmc/source/cbmc_utils.c
+++ b/tests/cbmc/source/cbmc_utils.c
@@ -68,6 +68,9 @@ int nondet_compare(const void *const a, const void *const b) {
 }
 
 int __CPROVER_uninterpreted_compare(const void *const a, const void *const b);
+bool __CPROVER_uninterpreted_equals(const void *const a, const void *const b);
+uint64_t __CPROVER_uninterpreted_hasher(const void *const a);
+
 int uninterpreted_compare(const void *const a, const void *const b) {
     assert(a != NULL);
     assert(b != NULL);
@@ -89,8 +92,6 @@ bool nondet_equals(const void *const a, const void *const b) {
     return nondet_bool();
 }
 
-bool __CPROVER_uninterpreted_equals(const void *const a, const void *const b);
-uint64_t __CPROVER_uninterpreted_hasher(const void *const a);
 /**
  * Add assumptions that equality is reflexive and symmetric. Don't bother with
  * transitivity because it doesn't cause any spurious proof failures on hash-table


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

None
### Description of changes: 
1. There was an order of definition problem that was causing a warning in CBMC builds. Fixed. 
1. Currently, we rerun property checking when doing coverage checking in CBMC.  This duplicates work, and makes coverage checking very slow.  Removing this redundant work makes coverage checking an order of magnitude faster.
### Call-outs:

None
### Testing:

Re-ran proofs locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
