### PR TITLE
Disable optimization when running with S2N_DEBUG

### DIFF
--- a/s2n.mk
+++ b/s2n.mk
@@ -40,7 +40,7 @@ endif
 
 DEFAULT_CFLAGS += -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized \
                  -Wshadow  -Wcast-align -Wwrite-strings -fPIC -Wno-missing-braces\
-                 -D_POSIX_C_SOURCE=200809L -O2 -I$(LIBCRYPTO_ROOT)/include/ \
+                 -D_POSIX_C_SOURCE=200809L -I$(LIBCRYPTO_ROOT)/include/ \
                  -I$(S2N_ROOT)/api/ -I$(S2N_ROOT) -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security \
                  -D_FORTIFY_SOURCE=2 -fgnu89-inline 
 
@@ -118,7 +118,9 @@ ifdef S2N_ADDRESS_SANITIZER
 endif
 
 ifdef S2N_DEBUG
-	CFLAGS += ${DEBUG_CFLAGS}
+	CFLAGS += ${DEBUG_CFLAGS} -O0
+else
+	CFLAGS += -O2
 endif
 
 # Prints more information when running tests


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._

### Description of changes: 

S2N_DEBUG enables most of the settings necessary to debug S2N code
in GDB, but leaves -O2 in the gcc command. This leads to annoying
and unpredictable GDB behavior when trying to step through functions.

We should turn off optimizations when building for debugging.

### Testing:

Existing tests pass. 

`make` runs commands like:
```
cc -std=c99 -Wcast-qual -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow  -Wcast-align -Wwrite-strings -fPIC -Wno-missing-braces -D_POSIX_C_SOURCE=200809L -I/home/ubuntu/s2n/libcrypto-root/include/ -I/home/ubuntu/s2n/api/ -I/home/ubuntu/s2n -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security -D_FORTIFY_SOURCE=2 -fgnu89-inline  -Wstack-protector -fstack-protector-all -DS2N_HAVE_EXECINFO -O2   -c -o pq_random.o pq_random.c
```

`S2N_DEBUG=1 make` runs commands like:
```
cc -std=c99 -Wcast-qual -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow  -Wcast-align -Wwrite-strings -fPIC -Wno-missing-braces -D_POSIX_C_SOURCE=200809L -I/home/ubuntu/s2n/libcrypto-root/include/ -I/home/ubuntu/s2n/api/ -I/home/ubuntu/s2n -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security -D_FORTIFY_SOURCE=2 -fgnu89-inline  -Wstack-protector -fstack-protector-all -DS2N_HAVE_EXECINFO -g3 -ggdb -fno-omit-frame-pointer -fno-optimize-sibling-calls -O0   -c -o pq_random.o pq_random.c
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
