### PR TITLE
Enable -Wsign-compare

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,7 @@ set(CMAKE_C_FLAGS_DEBUGOPT "")
 
 target_compile_options(${PROJECT_NAME} PRIVATE -pedantic -std=gnu99 -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts
         -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security
-        -Wno-missing-braces)
+        -Wno-missing-braces -Wsign-compare)
 
 if(S2N_NO_PQ_ASM)
     target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_NO_PQ_ASM)

--- a/bin/common.c
+++ b/bin/common.c
@@ -34,7 +34,7 @@ char *load_file_to_cstring(const char *path)
         return NULL;
     }
 
-    const long int pem_file_size = ftell(pem_file);
+    const ssize_t pem_file_size = ftell(pem_file);
     if (pem_file_size < 0) {
         fprintf(stderr, "Failed calling ftell: '%s'\n", strerror(errno));
         fclose(pem_file);
@@ -50,7 +50,7 @@ char *load_file_to_cstring(const char *path)
         return NULL;
     }
 
-    if (fread(pem_out, sizeof(char), pem_file_size, pem_file) < pem_file_size) {
+    if (fread(pem_out, sizeof(char), pem_file_size, pem_file) < (size_t)pem_file_size) {
         fprintf(stderr, "Failed reading file: '%s'\n", strerror(errno));
         free(pem_out);
         fclose(pem_file);

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -252,7 +252,7 @@ int main(int argc, char *const *argv)
     int echo_input = 0;
     int use_corked_io = 0;
     int use_tls13 = 0;
-    int keyshares_count = 0;
+    size_t keyshares_count = 0;
     char keyshares[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT][S2N_MAX_ECC_CURVE_NAME_LENGTH];
     char *input = NULL;
     char *token = NULL;

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -196,7 +196,7 @@ int cache_retrieve_callback(struct s2n_connection *conn, void *ctx, const void *
     *value_size = cache[index].value_len;
     memcpy(value, cache[index].value, cache[index].value_len);
 
-    for (int i = 0; i < key_size; i++) {
+    for (size_t i = 0; i < key_size; i++) {
         printf("%02x", ((const uint8_t *)key)[i]);
     }
     printf("\n");

--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -34,9 +34,9 @@ static int s2n_cbc_cipher_3des_encrypt(struct s2n_session_key *key, struct s2n_b
 
     GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
-    int len = out->size;
+    int len = (int)out->size;
     GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
-    S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
+    S2N_ERROR_IF(len != (int)in->size, S2N_ERR_ENCRYPT);
 
     return 0;
 }
@@ -47,7 +47,7 @@ static int s2n_cbc_cipher_3des_decrypt(struct s2n_session_key *key, struct s2n_b
 
     GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
-    int len = out->size;
+    int len = (int)out->size;
     GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
 
     return 0;

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -39,9 +39,9 @@ static int s2n_cbc_cipher_aes_encrypt(struct s2n_session_key *key, struct s2n_bl
 
     GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
-    int len = out->size;
+    int len = (int)out->size;
     GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
-    S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
+    S2N_ERROR_IF(len != (int)in->size, S2N_ERR_ENCRYPT);
 
     return 0;
 }
@@ -51,7 +51,7 @@ int s2n_cbc_cipher_aes_decrypt(struct s2n_session_key *key, struct s2n_blob *iv,
     gte_check(out->size, in->size);
 
     GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
-    int len = out->size;
+    int len = (int)out->size;
     GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
 
     return 0;

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -31,7 +31,7 @@
     acceptable in DRBG */
 int s2n_increment_drbg_counter(struct s2n_blob *counter)
 {
-    for (int i = counter->size - 1; i >= 0; i--) {
+    for (size_t i = counter->size - 1; i >= 0; i--) {
         counter->data[i] += 1;
         if (counter->data[i]) {
             break;
@@ -60,10 +60,10 @@ static int s2n_drbg_bits(struct s2n_drbg *drbg, struct s2n_blob *out)
 
     struct s2n_blob value = {0};
     GUARD(s2n_blob_init(&value, drbg->v, sizeof(drbg->v)));
-    int block_aligned_size = out->size - (out->size % S2N_DRBG_BLOCK_SIZE);
+    uint32_t block_aligned_size = out->size - (out->size % S2N_DRBG_BLOCK_SIZE);
 
     /* Per NIST SP800-90A 10.2.1.2: */
-    for (int i = 0; i < block_aligned_size; i += S2N_DRBG_BLOCK_SIZE) {
+    for (size_t i = 0; i < block_aligned_size; i += S2N_DRBG_BLOCK_SIZE) {
         GUARD(s2n_increment_drbg_counter(&value));
         GUARD(s2n_drbg_block_encrypt(drbg->ctx, drbg->v, out->data + i));
         drbg->bytes_used += S2N_DRBG_BLOCK_SIZE;
@@ -90,12 +90,12 @@ static int s2n_drbg_update(struct s2n_drbg *drbg, struct s2n_blob *provided_data
 
     s2n_stack_blob(temp_blob, s2n_drbg_seed_size(drgb), S2N_DRBG_MAX_SEED_SIZE);
 
-    eq_check(provided_data->size, s2n_drbg_seed_size(drbg));
+    eq_check(provided_data->size, (uint32_t)s2n_drbg_seed_size(drbg));
 
     GUARD(s2n_drbg_bits(drbg, &temp_blob));
 
     /* XOR in the provided data */
-    for (int i = 0; i < provided_data->size; i++) {
+    for (size_t i = 0; i < provided_data->size; i++) {
         temp_blob.data[i] ^= provided_data->data[i];
     }
 
@@ -119,7 +119,7 @@ static int s2n_drbg_seed(struct s2n_drbg *drbg, struct s2n_blob *ps)
         GUARD_AS_POSIX(s2n_get_urandom_data(&blob));
     }
 
-    for (int i = 0; i < ps->size; i++) {
+    for (size_t i = 0; i < ps->size; i++) {
         blob.data[i] ^= ps->data[i];
     }
 

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -31,7 +31,7 @@
     acceptable in DRBG */
 int s2n_increment_drbg_counter(struct s2n_blob *counter)
 {
-    for (size_t i = counter->size - 1; i >= 0; i--) {
+    for (int32_t i = (int32_t)(counter->size - 1); i >= 0; i--) {
         counter->data[i] += 1;
         if (counter->data[i]) {
             break;

--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -467,9 +467,9 @@ int s2n_ecc_evp_find_supported_curve(struct s2n_blob *iana_ids, const struct s2n
 
     GUARD(s2n_stuffer_init(&iana_ids_in, iana_ids));
     GUARD(s2n_stuffer_write(&iana_ids_in, iana_ids));
-    for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
+    for (size_t i = 0; i < s2n_all_supported_curves_list_len; i++) {
         const struct s2n_ecc_named_curve *supported_curve = s2n_all_supported_curves_list[i];
-        for (int j = 0; j < iana_ids->size / 2; j++) {
+        for (size_t j = 0; j < iana_ids->size / 2; j++) {
             uint16_t iana_id;
             GUARD(s2n_stuffer_read_uint16(&iana_ids_in, &iana_id));
             if (supported_curve->iana_id == iana_id) {

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -267,7 +267,7 @@ int s2n_hmac_digest_two_compression_rounds(struct s2n_hmac_state *state, void *o
      * 17 bytes if the block size is 128.
      */
     const uint8_t space_left = (state->hash_block_size == 128) ? 17 : 9;
-    if (state->currently_in_hash_block > (state->hash_block_size - space_left)) {
+    if (state->currently_in_hash_block > (uint32_t)(state->hash_block_size - space_left)) {
         return 0;
     }
 

--- a/crypto/s2n_stream_cipher_rc4.c
+++ b/crypto/s2n_stream_cipher_rc4.c
@@ -30,10 +30,10 @@ static int s2n_stream_cipher_rc4_encrypt(struct s2n_session_key *key, struct s2n
 {
     gte_check(out->size, in->size);
 
-    int len = out->size;
+    int len = (int)out->size;
     GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
 
-    S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
+    S2N_ERROR_IF(len != (int)in->size, S2N_ERR_ENCRYPT);
 
     return 0;
 }
@@ -42,10 +42,10 @@ static int s2n_stream_cipher_rc4_decrypt(struct s2n_session_key *key, struct s2n
 {
     gte_check(out->size, in->size);
 
-    int len = out->size;
+    int len = (int)out->size;
     GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
 
-    S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
+    S2N_ERROR_IF(len != (int)in->size, S2N_ERR_ENCRYPT);
 
     return 0;
 }

--- a/s2n.mk
+++ b/s2n.mk
@@ -39,7 +39,7 @@ else
 endif
 
 DEFAULT_CFLAGS += -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized \
-                 -Wshadow  -Wcast-align -Wwrite-strings -fPIC -Wno-missing-braces\
+                 -Wshadow  -Wcast-align -Wwrite-strings -fPIC -Wno-missing-braces -Wsign-compare \
                  -D_POSIX_C_SOURCE=200809L -O2 -I$(LIBCRYPTO_ROOT)/include/ \
                  -I$(S2N_ROOT)/api/ -I$(S2N_ROOT) -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security \
                  -D_FORTIFY_SOURCE=2 -fgnu89-inline 

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -163,7 +163,8 @@ static int length_matches_value_check(uint32_t value, uint8_t length)
 
     if (length < sizeof(uint32_t)) {
         /* Value should be less than the maximum for its length */
-        S2N_ERROR_IF(value >= (0x01 << (length * 8)), S2N_ERR_SIZE_MISMATCH);
+        const uint32_t size_max = 1 << (length * 8);
+        S2N_ERROR_IF(value >= size_max, S2N_ERR_SIZE_MISMATCH);
     }
 
     return S2N_SUCCESS;

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -73,7 +73,7 @@ int s2n_stuffer_read_expected_str(struct s2n_stuffer *stuffer, const char *expec
 /* Read from stuffer until the target string is found, or until there is no more data. */
 int s2n_stuffer_skip_read_until(struct s2n_stuffer *stuffer, const char *target)
 {
-    int len = strlen(target);
+    uint32_t len = strlen(target);
     while (s2n_stuffer_data_available(stuffer) >= len) {
         GUARD(s2n_stuffer_skip_to_char(stuffer, target[0]));
         char *actual = s2n_stuffer_raw_read(stuffer, len);

--- a/tests/testlib/s2n_connection_test_utils.c
+++ b/tests/testlib/s2n_connection_test_utils.c
@@ -36,7 +36,7 @@ int s2n_fd_set_non_blocking(int fd) {
 static int buffer_read(void *io_context, uint8_t *buf, uint32_t len)
 {
     struct s2n_stuffer *in_buf;
-    int n_read, n_avail;
+    uint32_t n_read, n_avail;
 
 
     if (buf == NULL) {
@@ -171,7 +171,7 @@ int s2n_io_pair_close_one_end(struct s2n_test_io_pair *io_pair, int mode_to_clos
 
 void s2n_print_connection(struct s2n_connection *conn, const char *marker)
 {
-    int i;
+    uint32_t i;
 
     printf("marker: %s\n", marker);
     printf("HEADER IN Stuffer (write: %d, read: %d, size: %d)\n", conn->header_in.write_cursor, conn->header_in.read_cursor, conn->header_in.blob.size);

--- a/tests/testlib/s2n_stuffer_hex.c
+++ b/tests/testlib/s2n_stuffer_hex.c
@@ -40,7 +40,7 @@ static int s2n_stuffer_read_n_bits_hex(struct s2n_stuffer *stuffer, uint8_t n, u
     /* Start with u = 0 */
     *u = 0;
 
-    for (int i = 0; i < b.size; i++) {
+    for (size_t i = 0; i < b.size; i++) {
         *u <<= 4;
         if (b.data[i] >= '0' && b.data[i] <= '9') {
             *u |= b.data[i] - '0';
@@ -60,7 +60,7 @@ int s2n_stuffer_read_hex(struct s2n_stuffer *stuffer, struct s2n_stuffer *out, u
 {
     gte_check(s2n_stuffer_space_remaining(out), n);
 
-    for (int i = 0; i < n; i++) {
+    for (size_t i = 0; i < n; i++) {
         uint8_t c;
         GUARD(s2n_stuffer_read_uint8_hex(stuffer, &c));
         GUARD(s2n_stuffer_write_uint8(out, c));
@@ -73,7 +73,7 @@ int s2n_stuffer_write_hex(struct s2n_stuffer *stuffer, struct s2n_stuffer *in, u
 {
     gte_check(s2n_stuffer_space_remaining(stuffer), n * 2);
 
-    for (int i = 0; i < n; i++) {
+    for (size_t i = 0; i < n; i++) {
         uint8_t c;
         GUARD(s2n_stuffer_read_uint8(in, &c));
         GUARD(s2n_stuffer_write_uint8_hex(stuffer, c));
@@ -130,7 +130,7 @@ static int s2n_stuffer_write_n_bits_hex(struct s2n_stuffer *stuffer, uint8_t n, 
 
     lte_check(n, 64);
 
-    for (int i = b.size; i > 0; i--) {
+    for (size_t i = b.size; i > 0; i--) {
         b.data[i - 1] = hex[u & 0x0f];
         u >>= 4;
     }
@@ -168,7 +168,7 @@ int s2n_stuffer_alloc_ro_from_hex_string(struct s2n_stuffer *stuffer, const char
 
     GUARD(s2n_stuffer_alloc(stuffer, strlen(str) / 2));
 
-    for (int i = 0; i < strlen(str); i += 2) {
+    for (size_t i = 0; i < strlen(str); i += 2) {
         uint8_t u = 0;
 
         if (str[i] >= '0' && str[i] <= '9') {

--- a/tests/testlib/s2n_test_certs.c
+++ b/tests/testlib/s2n_test_certs.c
@@ -56,7 +56,7 @@ int s2n_read_test_pem(const char *pem_path, char *pem_out, long int max_size)
         S2N_ERROR(S2N_ERR_NOMEM);
     }
 
-    if (fread(pem_out, sizeof(char), pem_file_size, pem_file) < pem_file_size) {
+    if (fread(pem_out, sizeof(char), pem_file_size, pem_file) < (size_t)pem_file_size) {
         S2N_ERROR(S2N_ERR_IO);
     }
 

--- a/tests/unit/s2n_array_test.c
+++ b/tests/unit/s2n_array_test.c
@@ -28,14 +28,14 @@ struct array_element {
 int main(int argc, char **argv)
 {
     struct s2n_array *array;
-    int element_size = sizeof(struct array_element);
+    size_t element_size = sizeof(struct array_element);
     uint32_t len = 0;
     uint32_t capacity = 0;
 
     BEGIN_TEST();
     struct array_element elements[NUM_OF_ELEMENTS] = {0};
 
-    for (int i = 0; i < NUM_OF_ELEMENTS; i++) {
+    for (size_t i = 0; i < NUM_OF_ELEMENTS; i++) {
         elements[i].first = i;
         elements[i].second = 'a' + i;
     }

--- a/tests/unit/s2n_async_pkey_test.c
+++ b/tests/unit/s2n_async_pkey_test.c
@@ -159,7 +159,7 @@ int main(int argc, char **argv)
         &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
     };
 
-    for(int i=0; i < sizeof(test_cipher_suites)/sizeof(test_cipher_suites[0]); i++) {
+    for(size_t i=0; i < sizeof(test_cipher_suites)/sizeof(test_cipher_suites[0]); i++) {
         struct s2n_cipher_preferences server_cipher_preferences = {
             .count = 1,
             .suites = &test_cipher_suites[i],

--- a/tests/unit/s2n_cbc_verify_test.c
+++ b/tests/unit/s2n_cbc_verify_test.c
@@ -70,8 +70,8 @@ static void summarize(uint64_t *list, int n, uint64_t *count, uint64_t *avg, uin
     *count = 0;
     uint64_t sum = 0;
     uint64_t sum_squares = 0;
-    uint64_t min = 0xFFFFFFFF;
-    uint64_t max = 0;
+    int64_t min = 0xFFFFFFFF;
+    int64_t max = 0;
 
     for (int i = 0; i < n; i++) {
         int64_t value = list[ i ];

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -120,10 +120,10 @@ static int negotiate_kem(const uint8_t client_extensions[], const size_t client_
     server_conn->secure.kem_params.kem = NULL;
 
     /* Send the client hello */
-    eq_check(write(io_pair->client_write, record_header, record_header_len),record_header_len);
-    eq_check(write(io_pair->client_write, message_header, message_header_len),message_header_len);
-    eq_check(write(io_pair->client_write, client_hello_message, client_hello_len),client_hello_len);
-    eq_check(write(io_pair->client_write, client_extensions, client_extensions_len),client_extensions_len);
+    eq_check(write(io_pair->client_write, record_header, record_header_len),(int)record_header_len);
+    eq_check(write(io_pair->client_write, message_header, message_header_len),(int)message_header_len);
+    eq_check(write(io_pair->client_write, client_hello_message, client_hello_len),(int)client_hello_len);
+    eq_check(write(io_pair->client_write, client_extensions, client_extensions_len),(int)client_extensions_len);
 
     GUARD(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
     if (s2n_negotiate(server_conn, &server_blocked) == 0) {
@@ -818,7 +818,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_ocsp_reply = s2n_connection_get_ocsp_response(client_conn, &length));
         EXPECT_EQUAL(length, sizeof(server_ocsp_status));
 
-        for (int i = 0; i < sizeof(server_ocsp_status); i++) {
+        for (size_t i = 0; i < sizeof(server_ocsp_status); i++) {
             EXPECT_EQUAL(server_ocsp_reply[i], server_ocsp_status[i]);
         }
 
@@ -876,7 +876,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_ocsp_reply = s2n_connection_get_ocsp_response(client_conn, &length));
         EXPECT_EQUAL(length, sizeof(server_ocsp_status));
 
-        for (int i = 0; i < sizeof(server_ocsp_status); i++) {
+        for (size_t i = 0; i < sizeof(server_ocsp_status); i++) {
             EXPECT_EQUAL(server_ocsp_reply[i], server_ocsp_status[i]);
         }
 

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -449,7 +449,7 @@ int main(int argc, char **argv)
         };
         int server_name_extension_len = sizeof(server_name_extension);
 
-        int client_extensions_len = sizeof(client_extensions);
+        size_t client_extensions_len = sizeof(client_extensions);
         uint8_t client_hello_prefix[] = {
             /* Protocol version TLS 1.2 */
             0x03, 0x03,
@@ -610,7 +610,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(memcmp(client_hello->extensions.raw.data, client_extensions, client_extensions_len));
 
         /* Verify s2n_client_hello_get_extensions_length correct */
-        EXPECT_EQUAL(s2n_client_hello_get_extensions_length(client_hello), client_extensions_len);
+        EXPECT_EQUAL(s2n_client_hello_get_extensions_length(client_hello), (ssize_t)client_extensions_len);
 
         /* Verify s2n_client_hello_get_extensions correct */
         uint8_t *extensions_out;
@@ -618,7 +618,7 @@ int main(int argc, char **argv)
         /* Verify s2n_client_hello_get_extensions retrieves the full cipher_suites when its len <= max_len */
         EXPECT_TRUE(client_hello->extensions.raw.size < S2N_LARGE_RECORD_LENGTH);
         EXPECT_NOT_NULL(extensions_out = malloc(S2N_LARGE_RECORD_LENGTH));
-        EXPECT_EQUAL(client_extensions_len, s2n_client_hello_get_extensions(client_hello, extensions_out, S2N_LARGE_RECORD_LENGTH));
+        EXPECT_EQUAL((ssize_t)client_extensions_len, s2n_client_hello_get_extensions(client_hello, extensions_out, S2N_LARGE_RECORD_LENGTH));
         EXPECT_SUCCESS(memcmp(extensions_out, client_extensions, client_extensions_len));
         free(extensions_out);
         extensions_out = NULL;

--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -53,12 +53,11 @@ int main(int argc, char **argv)
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-        int key_share_size;
-        EXPECT_SUCCESS(key_share_size = s2n_extensions_client_key_share_size(conn));
+        uint32_t key_share_size = s2n_extensions_client_key_share_size(conn);
+        EXPECT_TRUE(key_share_size > 0);
 
         /* should produce the same result if called twice */
-        int key_share_size_again;
-        EXPECT_SUCCESS(key_share_size_again = s2n_extensions_client_key_share_size(conn));
+        uint32_t key_share_size_again = s2n_extensions_client_key_share_size(conn);
         EXPECT_EQUAL(key_share_size, key_share_size_again);
 
         /* should equal the size of the data written on send */

--- a/tests/unit/s2n_ecc_evp_test.c
+++ b/tests/unit/s2n_ecc_evp_test.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
     BEGIN_TEST();
     {
         /* Test generate ephemeral keys for all supported curves */
-        for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
+        for (size_t i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params evp_params = {0};
             /* Server generates a key */
             evp_params.negotiated_curve = s2n_all_supported_curves_list[i];
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
     }
     {
         /* Test failure case for generate ephemeral key  when the negotiated curve is not set */
-        for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
+        for (size_t i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params evp_params = {0};
             /* Server generates a key */
             evp_params.negotiated_curve = NULL;
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
     }
     {
         /* Test generate ephemeral key and compute shared key for all supported curves */
-        for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
+        for (size_t i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params server_params = {0};
             struct s2n_ecc_evp_params client_params = {0};
             struct s2n_blob server_shared = {0};
@@ -85,8 +85,8 @@ int main(int argc, char **argv) {
     {
         /* Test failure case for computing shared key for all supported curves when the server
         and client curves donot match */
-        for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
-            for (int j = 0; j < s2n_all_supported_curves_list_len; j++) {
+        for (size_t i = 0; i < s2n_all_supported_curves_list_len; i++) {
+            for (size_t j = 0; j < s2n_all_supported_curves_list_len; j++) {
                 struct s2n_ecc_evp_params server_params = {0};
                 struct s2n_ecc_evp_params client_params = {0};
                 struct s2n_blob server_shared = {0};
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
     }
     {
         /* Test s2n_ecc_evp_write_params_point for all supported curves */
-        for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
+        for (size_t i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params test_params = {0};
             struct s2n_stuffer wire;
             uint8_t legacy_form;
@@ -151,7 +151,7 @@ int main(int argc, char **argv) {
     }
     {
         /* TEST s2n_ecc_evp_read_params_point for all supported curves */
-        for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
+        for (size_t i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params write_params = {0};
             struct s2n_blob point_blob;
             struct s2n_stuffer wire;
@@ -177,7 +177,7 @@ int main(int argc, char **argv) {
     }
     {
         /* TEST s2n_ecc_evp_parse_params_point for all supported curves */
-        for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
+        for (size_t i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params write_params = {0};
             struct s2n_ecc_evp_params read_params = {0};
             struct s2n_blob point_blob;
@@ -207,7 +207,7 @@ int main(int argc, char **argv) {
     }
     {
         /* Test read/write/parse params for all supported curves */
-        for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
+        for (size_t i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params write_params = {0};
             struct s2n_ecc_evp_params read_params = {0};
             struct s2n_stuffer wire;
@@ -240,7 +240,7 @@ int main(int argc, char **argv) {
     }
     {
         /* Test generate/read/write/parse and compute shared secrets for all supported curves */
-        for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
+        for (size_t i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params server_params = {0};
             struct s2n_ecc_evp_params read_params = {0};
             struct s2n_ecc_evp_params client_params = {0}; 
@@ -294,7 +294,7 @@ int main(int argc, char **argv) {
     }
     {
         /* Test generate->write->read->compute_shared with all supported curves */
-    for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
+    for (size_t i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params server_params = {0}, client_params = {0};
             struct s2n_stuffer wire;
             struct s2n_blob server_shared, client_shared, ecdh_params_sent, ecdh_params_received;

--- a/tests/unit/s2n_ecdsa_test.c
+++ b/tests/unit/s2n_ecdsa_test.c
@@ -149,7 +149,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_hash_new(&hash_one));
     EXPECT_SUCCESS(s2n_hash_new(&hash_two));
 
-    for (int i = 0; i < s2n_array_len(supported_hash_algorithms); i++) {
+    for (size_t i = 0; i < s2n_array_len(supported_hash_algorithms); i++) {
         int hash_alg = supported_hash_algorithms[i];
         
         if (!s2n_hash_is_available(hash_alg)) {

--- a/tests/unit/s2n_extension_type_test.c
+++ b/tests/unit/s2n_extension_type_test.c
@@ -95,7 +95,7 @@ int main()
         EXPECT_EQUAL(s2n_extension_iana_value_to_id(65280), s2n_unsupported_extension);
 
         /* Every supported extension can be handled */
-        for (int i = 0; i < S2N_SUPPORTED_EXTENSIONS_COUNT; i++) {
+        for (size_t i = 0; i < S2N_SUPPORTED_EXTENSIONS_COUNT; i++) {
             EXPECT_EQUAL(s2n_extension_iana_value_to_id(s2n_supported_extensions[i]), i);
         }
     }
@@ -118,7 +118,7 @@ int main()
     /* Test bitfield behavior */
     {
         s2n_extension_bitfield test_bitfield = { 0 };
-        for (int i = 0; i < S2N_SUPPORTED_EXTENSIONS_COUNT; i++) {
+        for (size_t i = 0; i < S2N_SUPPORTED_EXTENSIONS_COUNT; i++) {
             uint16_t iana = s2n_supported_extensions[i];
             s2n_extension_type_id id = s2n_extension_iana_value_to_id(iana);
 

--- a/tests/unit/s2n_mem_allocator_test.c
+++ b/tests/unit/s2n_mem_allocator_test.c
@@ -129,7 +129,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
     /* Active application bytes consumed is reset to 0 in before writing data. */
     /* Its value should equal to bytes written after writing */
     ssize_t bytes_written = s2n_send(conn, buffer, i, &blocked);
-    if (bytes_written != conn->active_application_bytes_consumed) {
+    if ((uint64_t)bytes_written != conn->active_application_bytes_consumed) {
         exit(0);
     }
 

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
     EXPECT_NOT_EQUAL(vm_data_initial, -1);
 
     /* Allocate all connections */
-    for (int i = 0; i < connectionsToUse; i++)
+    for (size_t i = 0; i < connectionsToUse; i++)
     {
         struct s2n_connection *client_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
@@ -134,7 +134,7 @@ int main(int argc, char **argv)
     ssize_t vm_data_after_allocation = get_vm_data_size();
     EXPECT_NOT_EQUAL(vm_data_after_allocation, -1);
 
-    for (int i = 0; i < connectionsToUse; i++) {
+    for (size_t i = 0; i < connectionsToUse; i++) {
         EXPECT_SUCCESS(s2n_connections_set_io_pair(clients[ i ], servers[ i ], &io_pair));
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(servers[i], clients[i]));
@@ -143,21 +143,21 @@ int main(int argc, char **argv)
     ssize_t vm_data_after_handshakes = get_vm_data_size();
     EXPECT_NOT_EQUAL(vm_data_after_handshakes, -1);
 
-    for (int i = 0; i < connectionsToUse; i++) {
+    for (size_t i = 0; i < connectionsToUse; i++) {
         EXPECT_SUCCESS(s2n_connection_free_handshake(servers[i]));
         EXPECT_SUCCESS(s2n_connection_free_handshake(clients[i]));
     }
     ssize_t vm_data_after_free_handshake = get_vm_data_size();
     EXPECT_NOT_EQUAL(vm_data_after_free_handshake, -1);
 
-    for (int i = 0; i < connectionsToUse; i++) {
+    for (size_t i = 0; i < connectionsToUse; i++) {
         EXPECT_SUCCESS(s2n_connection_release_buffers(servers[i]));
         EXPECT_SUCCESS(s2n_connection_release_buffers(clients[i]));
     }
     ssize_t vm_data_after_release_buffers = get_vm_data_size();
     EXPECT_NOT_EQUAL(vm_data_after_release_buffers, -1);
 
-    for (int i = 0; i < connectionsToUse; i++) {
+    for (size_t i = 0; i < connectionsToUse; i++) {
         EXPECT_SUCCESS(s2n_connection_free(clients[i]));
         EXPECT_SUCCESS(s2n_connection_free(servers[i]));
     }

--- a/tests/unit/s2n_pem_test.c
+++ b/tests/unit/s2n_pem_test.c
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
     EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
 
-    for (int i = 0; i < s2n_array_len(valid_pem_pairs); i++) {
+    for (size_t i = 0; i < s2n_array_len(valid_pem_pairs); i++) {
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_SUCCESS(s2n_read_test_pem(valid_pem_pairs[i][0], cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem(valid_pem_pairs[i][1], private_key_pem, S2N_MAX_TEST_PEM_SIZE));
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(config));
     }
 
-    for (int i = 0; i < s2n_array_len(invalid_pem_pairs); i++) {
+    for (size_t i = 0; i < s2n_array_len(invalid_pem_pairs); i++) {
         EXPECT_SUCCESS(s2n_read_test_pem(invalid_pem_pairs[i][0], cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem(invalid_pem_pairs[i][1], private_key_pem, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());

--- a/tests/unit/s2n_rc4_test.c
+++ b/tests/unit/s2n_rc4_test.c
@@ -64,12 +64,12 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure.server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
     conn->actual_protocol_version = S2N_TLS11;
 
-    for (int i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
+    for (size_t i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = {.data = random_data,.size = i };
-        int bytes_written;
+        uint32_t bytes_written;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
-        EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
+        EXPECT_SUCCESS((int)(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in)));
 
         if (i <= S2N_DEFAULT_FRAGMENT_LENGTH - 20) {
             EXPECT_EQUAL(bytes_written, i);

--- a/tests/unit/s2n_record_size_test.c
+++ b/tests/unit/s2n_record_size_test.c
@@ -158,7 +158,7 @@ int main(int argc, char **argv)
         S2N_BLOB_FROM_HEX(iv, "0123456789abcdef01234567");
 
         /* copy iv bytes from input data */
-        for (int i = 0; i < iv.size; i++) {
+        for (size_t i = 0; i < iv.size; i++) {
             implicit_iv[i] = iv.data[i];
         }
 

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -245,10 +245,11 @@ int main(int argc, char **argv)
 
         /* The last byte of out should indicate how much padding there was */
         uint8_t p = conn->out.blob.data[conn->out.write_cursor - 1];
-        EXPECT_EQUAL(5 + bytes_written + 20 + p + 1, s2n_stuffer_data_available(&conn->out));
+        const uint32_t remaining = 5 + bytes_written + 20 + p + 1;
+        EXPECT_EQUAL(remaining, s2n_stuffer_data_available(&conn->out));
 
         /* Check that the last 'p' bytes are all set to 'p' */
-        for (int j = 0; j <= p; j++) {
+        for (uint8_t j = 0; j <= p; j++) {
             EXPECT_EQUAL(conn->out.blob.data[5 + bytes_written + 20 + j], p);
         }
 
@@ -312,10 +313,11 @@ int main(int argc, char **argv)
 
         /* The last byte of out should indicate how much padding there was */
         uint8_t p = conn->out.blob.data[conn->out.write_cursor - 1];
-        EXPECT_EQUAL(5 + bytes_written + 20 + 16 + p + 1, s2n_stuffer_data_available(&conn->out));
+        const uint32_t remaining = 5 + bytes_written + 20 + 16 + p + 1;
+        EXPECT_EQUAL(remaining, s2n_stuffer_data_available(&conn->out));
 
         /* Check that the last 'p' bytes are all set to 'p' */
-        for (int j = 0; j <= p; j++) {
+        for (uint8_t j = 0; j <= p; j++) {
             EXPECT_EQUAL(conn->out.blob.data[5 + bytes_written + 16 + 20 + j], p);
         }
 

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
         sleep(1);
         char buffer[1];
         /* Fist flush on half closed pipe should get EPIPE */
-        size_t w = s2n_send(conn, buffer, 1, &blocked);
+        ssize_t w = s2n_send(conn, buffer, 1, &blocked);
         EXPECT_EQUAL(w, -1);
         EXPECT_EQUAL(s2n_errno, S2N_ERR_IO);
         EXPECT_EQUAL(errno, EPIPE);

--- a/tests/unit/s2n_self_talk_nonblocking_test.c
+++ b/tests/unit/s2n_self_talk_nonblocking_test.c
@@ -71,7 +71,7 @@ int mock_client(struct s2n_test_io_pair *io_pair, uint8_t *expected_data, uint32
         shutdown_rc = s2n_shutdown(client_conn, &blocked);
     } while(shutdown_rc != 0);
 
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0; i < size; i++) {
         if (buffer[i] != expected_data[i]) {
             return 1;
         }
@@ -92,13 +92,13 @@ int mock_client_iov(struct s2n_test_io_pair *io_pair, struct iovec *iov, uint32_
     struct s2n_config *client_config;
     s2n_blocked_status blocked;
     int result = 0;
-    int total_size = 0, i;
+    uint32_t total_size = 0, i;
 
     for (i = 0; i < iov_size; i++) {
         total_size += iov[i].iov_len;
     }
     uint8_t *buffer = malloc(total_size + iov[0].iov_len);
-    int buffer_offs = 0;
+    uint32_t buffer_offs = 0;
 
     /* Give the server a chance to listen */
     sleep(1);

--- a/tests/unit/s2n_self_talk_session_id_test.c
+++ b/tests/unit/s2n_self_talk_session_id_test.c
@@ -189,7 +189,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
         result = 5;
     }
 
-    if (s2n_connection_get_session(conn, serialized_session_state, serialized_session_state_length) != serialized_session_state_length) {
+    if ((size_t)s2n_connection_get_session(conn, serialized_session_state, serialized_session_state_length) != serialized_session_state_length) {
         result = 6;
     }
 

--- a/tests/unit/s2n_self_talk_test.c
+++ b/tests/unit/s2n_self_talk_test.c
@@ -82,7 +82,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
     /* Active application bytes consumed is reset to 0 in before writing data. */
     /* Its value should equal to bytes written after writing */
     ssize_t bytes_written = s2n_send(conn, buffer, i, &blocked);
-    if (bytes_written != conn->active_application_bytes_consumed) {
+    if ((uint64_t)bytes_written != conn->active_application_bytes_consumed) {
         exit(0);
     }
 

--- a/tests/unit/s2n_self_talk_tls13_test.c
+++ b/tests/unit/s2n_self_talk_tls13_test.c
@@ -77,7 +77,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
     /* Active application bytes consumed is reset to 0 in before writing data. */
     /* Its value should equal to bytes written after writing */
     ssize_t bytes_written = s2n_send(conn, buffer, i, &blocked);
-    if (bytes_written != conn->active_application_bytes_consumed) {
+    if ((uint64_t)bytes_written != conn->active_application_bytes_consumed) {
         exit(1);
     }
 

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -285,7 +285,7 @@ int main(int argc, char **argv)
     {
         const struct s2n_ecc_preferences *ecc_pref = NULL;
          /* Shared Secret Size: x25519 (32), p-256 (32), p-384 (48) */
-        int shared_secret_size[3] = { 32, 32, 48 };
+        uint32_t shared_secret_size[3] = { 32, 32, 48 };
         if (!s2n_is_evp_apis_supported()) {
         /* Shared Secret Size: p-256 (32), p-384 (48) */
             shared_secret_size[1] = 48;  

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
     struct s2n_ticket_key *ticket_key;
     uint32_t ticket_keys_len = 0;
 
-    size_t serialized_session_state_length = 0;
+    int serialized_session_state_length = 0;
     uint8_t s2n_state_with_session_id = S2N_STATE_WITH_SESSION_ID;
     uint8_t serialized_session_state[S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TICKET_SIZE_IN_BYTES + S2N_STATE_SIZE_IN_BYTES] = { 0 };
 

--- a/tests/unit/s2n_stuffer_base64_test.c
+++ b/tests/unit/s2n_stuffer_base64_test.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_stuffer_alloc(&entropy, 50));
     EXPECT_SUCCESS(s2n_stuffer_alloc(&mirror, 50));
 
-    for (int i = entropy.blob.size; i > 0; i--) {
+    for (size_t i = entropy.blob.size; i > 0; i--) {
         EXPECT_SUCCESS(s2n_stuffer_wipe(&stuffer));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&entropy));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&mirror));

--- a/tests/unit/s2n_stuffer_network_order_test.c
+++ b/tests/unit/s2n_stuffer_network_order_test.c
@@ -73,14 +73,14 @@ int main(int argc, char **argv)
             uint32_t actual_value;
             uint32_t test_values[] = { 0x000001, 0x0000FF, 0xABCDEF, 0xFFFFFF };
 
-            for (int i = 0; i < s2n_array_len(test_values); i++) {
+            for (size_t i = 0; i < s2n_array_len(test_values); i++) {
                 EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, test_values[i], byte_length));
                 EXPECT_SUCCESS(s2n_stuffer_read_uint24(&stuffer, &actual_value));
                 EXPECT_EQUAL(test_values[i], actual_value);
             }
 
             uint16_t prime = 257;
-            for (uint32_t i = 0; i < 0xFFFFFF - prime; i += prime) {
+            for (uint32_t i = 0; i < (size_t)(0xFFFFFF - prime); i += prime) {
                 EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, i, byte_length));
                 EXPECT_SUCCESS(s2n_stuffer_read_uint24(&stuffer, &actual_value));
                 EXPECT_EQUAL(i, actual_value);
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
             uint32_t actual_value;
             uint32_t test_values[] = { 0x00000001, 0x000000FF, 0xABCDEF12, UINT32_MAX };
 
-            for (int i = 0; i < s2n_array_len(test_values); i++) {
+            for (size_t i = 0; i < s2n_array_len(test_values); i++) {
                 EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, test_values[i], byte_length));
                 EXPECT_SUCCESS(s2n_stuffer_read_uint32(&stuffer, &actual_value));
                 EXPECT_EQUAL(test_values[i], actual_value);
@@ -278,7 +278,7 @@ int main(int argc, char **argv)
 
         /* Happy cases */
         uint16_t test_sizes[] = { 0, 1, 5, 0x88, 0xF0, 0xFF };
-        for( int i = 0; i < s2n_array_len(test_sizes); i++) {
+        for( size_t i = 0; i < s2n_array_len(test_sizes); i++) {
             EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &reservation));
 
             EXPECT_SUCCESS(s2n_stuffer_skip_write(&stuffer, test_sizes[i]));

--- a/tests/unit/s2n_tls12_handshake_test.c
+++ b/tests/unit/s2n_tls12_handshake_test.c
@@ -43,7 +43,7 @@ static int s2n_test_expected_handler(struct s2n_connection* conn)
 }
 
 static int s2n_setup_handler_to_expect(message_type_t expected, uint8_t direction) {
-    for (int i = 0; i < sizeof(tls13_state_machine) / sizeof(struct s2n_handshake_action); i++) {
+    for (size_t i = 0; i < sizeof(tls13_state_machine) / sizeof(struct s2n_handshake_action); i++) {
         tls13_state_machine[i].handler[0] = s2n_test_handler;
         tls13_state_machine[i].handler[1] = s2n_test_handler;
     }
@@ -282,7 +282,7 @@ int main(int argc, char **argv)
 
         conn->handshake.handshake_type = test_handshake_type;
 
-        for (int i=0; i < sizeof(expected) / sizeof(char *); i++) {
+        for (size_t i=0; i < sizeof(expected) / sizeof(char *); i++) {
             conn->handshake.message_number = i;
             EXPECT_STRING_EQUAL(expected[i], s2n_connection_get_last_message_name(conn));
         }

--- a/tests/unit/s2n_tls13_cert_verify_test.c
+++ b/tests/unit/s2n_tls13_cert_verify_test.c
@@ -378,7 +378,7 @@ int main(int argc, char **argv)
 
     EXPECT_SUCCESS(s2n_enable_tls13());
 
-    for (int i = 0; i < sizeof(test_cases) / sizeof(struct s2n_tls13_cert_verify_test); i++) {
+    for (size_t i = 0; i < sizeof(test_cases) / sizeof(struct s2n_tls13_cert_verify_test); i++) {
         /* Run all tests for server sending and client receiving/verifying cert_verify message */
         run_tests(&test_cases[i], S2N_CLIENT);
 

--- a/tests/unit/s2n_tls13_client_finished_test.c
+++ b/tests/unit/s2n_tls13_client_finished_test.c
@@ -40,18 +40,18 @@ int main(int argc, char **argv)
             s2n_tls13_chacha20_poly1305_sha256
         };
 
-        int hash_sizes[] = {
+        uint32_t hash_sizes[] = {
             32, 48, 32
         };
 
-        for (int i = 0; i < 3; i++) {
+        for (size_t i = 0; i < 3; i++) {
             struct s2n_connection *client_conn;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure.cipher_suite = &cipher_suites[i];
 
-            int hash_size = hash_sizes[i];
+            uint32_t hash_size = hash_sizes[i];
 
             EXPECT_SUCCESS(s2n_tls13_client_finished_send(client_conn));
             EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->handshake.io), hash_size);

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -221,7 +221,7 @@ int main(int argc, char **argv)
         s2n_mode modes[] = { S2N_CLIENT, S2N_SERVER };
 
         /* we ensure this works in both client and server modes */
-        for (int m = 0; m < s2n_array_len(modes); m++) {
+        for (size_t m = 0; m < s2n_array_len(modes); m++) {
             for (int i = 0; i < S2N_MAX_HANDSHAKE_LENGTH; i++) {
                 struct s2n_connection *conn;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(modes[m]));
@@ -252,7 +252,7 @@ int main(int argc, char **argv)
         }
 
         /* test that pre tls1.3 code paths are unaffected */
-        for (int m = 0; m < s2n_array_len(modes); m++) {
+        for (size_t m = 0; m < s2n_array_len(modes); m++) {
             for (int i = 0; i < S2N_MAX_HANDSHAKE_LENGTH; i++) {
                 struct s2n_connection *conn;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(modes[m]));
@@ -290,7 +290,7 @@ int main(int argc, char **argv)
         s2n_mode modes[] = { S2N_CLIENT, S2N_SERVER };
 
         /* we ensure this works in both client and server modes */
-        for (int m = 0; m < s2n_array_len(modes); m++) {
+        for (size_t m = 0; m < s2n_array_len(modes); m++) {
             for (int i = 0; i < S2N_MAX_HANDSHAKE_LENGTH; i++) {
                 struct s2n_connection *conn;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(modes[m]));
@@ -341,7 +341,7 @@ int main(int argc, char **argv)
         }
 
         /* Test pre 1.3 code paths are unaffected */
-        for (int m = 0; m < s2n_array_len(modes); m++) {
+        for (size_t m = 0; m < s2n_array_len(modes); m++) {
             for (int i = 0; i < S2N_MAX_HANDSHAKE_LENGTH; i++) {
                 struct s2n_connection *conn;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(modes[m]));

--- a/tests/unit/s2n_tls13_prf_test.c
+++ b/tests/unit/s2n_tls13_prf_test.c
@@ -75,25 +75,25 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_string(&expected_expanded_in, expected_expanded_hex_in));
 
     /* Parse the hex */
-    for (int i = 0; i < sizeof(client_handshake_message); i++) {
+    for (size_t i = 0; i < sizeof(client_handshake_message); i++) {
         uint8_t c;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&client_handshake_message_in, &c));
         client_handshake_message[i] = c;
     }
 
-    for (int i = 0; i < sizeof(server_handshake_message); i++) {
+    for (size_t i = 0; i < sizeof(server_handshake_message); i++) {
         uint8_t c;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&server_handshake_message_in, &c));
         server_handshake_message[i] = c;
     }
 
-    for (int i = 0; i < sizeof(expected_secret); i++) {
+    for (size_t i = 0; i < sizeof(expected_secret); i++) {
         uint8_t c;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&expected_secret_in, &c));
         expected_secret[i] = c;
     }
 
-    for (int i = 0; i < sizeof(expected_expanded); i++) {
+    for (size_t i = 0; i < sizeof(expected_expanded); i++) {
         uint8_t c;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&expected_expanded_in, &c));
         expected_expanded[i] = c;

--- a/tests/unit/s2n_tls13_record_aead_test.c
+++ b/tests/unit/s2n_tls13_record_aead_test.c
@@ -234,7 +234,7 @@ int main(int argc, char **argv)
         S2N_BLOB_FROM_HEX(iv, "5d313eb2671276ee13000b30");
 
         /* copy iv bytes from input data */
-        for (int i = 0; i < iv.size; i++) {
+        for (size_t i = 0; i < iv.size; i++) {
             implicit_iv[i] = iv.data[i];
         }
 
@@ -256,7 +256,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(conn->out.blob.data[1], 3);
         EXPECT_EQUAL(conn->out.blob.data[2], 3);
         /* Verify payload length */
-        EXPECT_EQUAL((conn->out.blob.data[3] << 8) + conn->out.blob.data[4], protected_record.size);
+        EXPECT_EQUAL((uint32_t)((conn->out.blob.data[3] << 8) + conn->out.blob.data[4]), protected_record.size);
 
         /* Make a slice of output bytes to verify */
         struct s2n_blob out = {
@@ -290,7 +290,7 @@ int main(int argc, char **argv)
         S2N_BLOB_FROM_HEX(iv, "5d313eb2671276ee13000b30");
 
         /* copy iv bytes from input data */
-        for (int i = 0; i < iv.size; i++) {
+        for (size_t i = 0; i < iv.size; i++) {
             implicit_iv[i] = iv.data[i];
         }
 
@@ -339,7 +339,7 @@ int main(int argc, char **argv)
     /* Test that CCS in TLS 1.3 modes should be sent without encryption */
     {
         s2n_mode modes[] = { S2N_SERVER, S2N_CLIENT };
-        for (int m = 0; m < s2n_array_len(modes); m++) {
+        for (size_t m = 0; m < s2n_array_len(modes); m++) {
             struct s2n_connection *conn;
             struct s2n_cipher_suite *cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
             EXPECT_NOT_NULL(conn = s2n_connection_new(modes[m]));
@@ -360,7 +360,7 @@ int main(int argc, char **argv)
             S2N_BLOB_FROM_HEX(iv, "5d313eb2671276ee13000b30");
 
             /* copy iv bytes from input data */
-            for (int i = 0; i < iv.size; i++) {
+            for (size_t i = 0; i < iv.size; i++) {
                 conn->secure.server_implicit_iv[i] = iv.data[i];
                 conn->secure.client_implicit_iv[i] = iv.data[i];
             }

--- a/tests/unit/s2n_tls13_server_finished_test.c
+++ b/tests/unit/s2n_tls13_server_finished_test.c
@@ -40,18 +40,18 @@ int main(int argc, char **argv)
             s2n_tls13_chacha20_poly1305_sha256
         };
 
-        int hash_sizes[] = {
+        uint32_t hash_sizes[] = {
             32, 48, 32
         };
 
-        for (int i = 0; i < 3; i++) {
+        for (size_t i = 0; i < 3; i++) {
             struct s2n_connection *server_conn;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
 
             server_conn->actual_protocol_version = S2N_TLS13;
             server_conn->secure.cipher_suite = &cipher_suites[i];
 
-            int hash_size = hash_sizes[i];
+            uint32_t hash_size = hash_sizes[i];
 
             EXPECT_SUCCESS(s2n_tls13_server_finished_send(server_conn));
             EXPECT_EQUAL(s2n_stuffer_data_available(&server_conn->handshake.io), hash_size);

--- a/tests/unit/s2n_tls13_state_machine_handshake_test.c
+++ b/tests/unit/s2n_tls13_state_machine_handshake_test.c
@@ -50,7 +50,7 @@ static int s2n_test_expected_handler(struct s2n_connection* conn)
 }
 
 static int s2n_setup_handler_to_expect(message_type_t expected, uint8_t direction) {
-    for (int i = 0; i < s2n_array_len(tls13_state_machine); i++) {
+    for (size_t i = 0; i < s2n_array_len(tls13_state_machine); i++) {
         tls13_state_machine[i].handler[0] = s2n_test_handler;
         tls13_state_machine[i].handler[1] = s2n_test_handler;
     }
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
     }
 
     /* Use handler stubs to avoid errors in handler implementation */
-    for (int i = 0; i < s2n_array_len(tls13_state_machine); i++) {
+    for (size_t i = 0; i < s2n_array_len(tls13_state_machine); i++) {
         tls13_state_machine[i].handler[0] = s2n_test_handler;
         tls13_state_machine[i].handler[1] = s2n_test_handler;
     }
@@ -394,7 +394,7 @@ int main(int argc, char **argv)
 
         conn->handshake.handshake_type = test_handshake_type;
 
-        for (int i = 0; i < s2n_array_len(expected); i++) {
+        for (size_t i = 0; i < s2n_array_len(expected); i++) {
             conn->handshake.message_number = i;
             EXPECT_STRING_EQUAL(expected[i], s2n_connection_get_last_message_name(conn));
         }
@@ -415,7 +415,7 @@ int main(int argc, char **argv)
 
         conn->handshake.handshake_type = test_handshake_type;
 
-        for (int i = 0; i < s2n_array_len(expected); i++) {
+        for (size_t i = 0; i < s2n_array_len(expected); i++) {
             conn->handshake.message_number = i;
             EXPECT_STRING_EQUAL(expected[i], s2n_connection_get_last_message_name(conn));
         }

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
         server_conn->actual_protocol_version = S2N_TLS13;
 
         s2n_parsed_extensions_list parsed_extension_list = { 0 };
-        for (int i=0; i < s2n_array_len(tls13_extensions); i++) {
+        for (size_t i=0; i < s2n_array_len(tls13_extensions); i++) {
             s2n_extension_type_id extension_id;
             EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(tls13_extensions[i]->iana_value, &extension_id));
             s2n_parsed_extension *parsed_extension = &parsed_extension_list.parsed_extensions[extension_id];

--- a/tls/extensions/s2n_client_supported_groups.c
+++ b/tls/extensions/s2n_client_supported_groups.c
@@ -104,9 +104,9 @@ int s2n_parse_client_supported_groups_list(struct s2n_connection *conn, struct s
     iana_ids->data = s2n_stuffer_raw_write(&iana_ids_in, iana_ids->size);
 
     uint16_t iana_id;
-    for (int i = 0; i < iana_ids->size / sizeof(iana_id); i++) {
+    for (size_t i = 0; i < iana_ids->size / sizeof(iana_id); i++) {
         GUARD(s2n_stuffer_read_uint16(&iana_ids_in, &iana_id));
-        for (int j = 0; j < ecc_pref->count; j++) {
+        for (size_t j = 0; j < ecc_pref->count; j++) {
             const struct s2n_ecc_named_curve *supported_curve = ecc_pref->ecc_curves[j];
             if (supported_curve->iana_id == iana_id) {
                 supported_groups[j] = supported_curve;

--- a/tls/extensions/s2n_extension_type.c
+++ b/tls/extensions/s2n_extension_type.c
@@ -34,12 +34,12 @@ s2n_extension_type_id s2n_extension_ianas_to_ids[S2N_MAX_INDEXED_EXTENSION_IANA]
 int s2n_extension_type_init()
 {
     /* Initialize to s2n_unsupported_extension */
-    for (int i = 0; i < S2N_MAX_INDEXED_EXTENSION_IANA; i++) {
+    for (size_t i = 0; i < S2N_MAX_INDEXED_EXTENSION_IANA; i++) {
         s2n_extension_ianas_to_ids[i] = s2n_unsupported_extension;
     }
 
     /* Reverse the mapping */
-    for (int i = 0; i < S2N_SUPPORTED_EXTENSIONS_COUNT; i++) {
+    for (size_t i = 0; i < S2N_SUPPORTED_EXTENSIONS_COUNT; i++) {
         uint16_t iana_value = s2n_supported_extensions[i];
         if (iana_value < S2N_MAX_INDEXED_EXTENSION_IANA) {
             s2n_extension_ianas_to_ids[iana_value] = i;
@@ -61,7 +61,7 @@ s2n_extension_type_id s2n_extension_iana_value_to_id(const uint16_t iana_value)
 
     /* Fall back to the full list. We can handle this more
      * efficiently later if our extension list gets long. */
-    for (int i = 0; i < S2N_SUPPORTED_EXTENSIONS_COUNT; i++) {
+    for (size_t i = 0; i < S2N_SUPPORTED_EXTENSIONS_COUNT; i++) {
         if (s2n_supported_extensions[i] == iana_value) {
             return i;
         }

--- a/tls/s2n_cbc.c
+++ b/tls/s2n_cbc.c
@@ -87,10 +87,10 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
     }
 
     /* Check the maximum amount that could theoretically be padding */
-    int check = MIN(255, (payload_and_padding_size - 1));
+    uint32_t check = MIN(255, (payload_and_padding_size - 1));
 
-    int cutoff = check - padding_length;
-    for (int i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
+    uint32_t cutoff = check - padding_length;
+    for (size_t i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
         uint8_t mask = ~(0xff << ((i >= cutoff) * 8));
         mismatches |= (decrypted->data[j] ^ padding_length) & mask;
     }

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1117,7 +1117,7 @@ int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_C
 
 static int s2n_wire_ciphers_contain(const uint8_t *match, const uint8_t *wire, uint32_t count, uint32_t cipher_suite_len)
 {
-    for (int i = 0; i < count; i++) {
+    for (size_t i = 0; i < count; i++) {
         const uint8_t *theirs = wire + (i * cipher_suite_len) + (cipher_suite_len - S2N_TLS_CIPHER_SUITE_LEN);
 
         if (!memcmp(match, theirs, S2N_TLS_CIPHER_SUITE_LEN)) {

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -520,7 +520,7 @@ int s2n_config_set_cert_chain_and_key_defaults(struct s2n_config *config,
 
     /* Validate certs being set before clearing auto-chosen defaults or previously set defaults */
     struct certs_by_type new_defaults = {{ 0 }};
-    for (int i = 0; i < num_cert_key_pairs; i++) {
+    for (size_t i = 0; i < num_cert_key_pairs; i++) {
         notnull_check(cert_key_pairs[i]);
         s2n_pkey_type cert_type = s2n_cert_chain_and_key_get_pkey_type(cert_key_pairs[i]);
         S2N_ERROR_IF(new_defaults.certs[cert_type] != NULL, S2N_ERR_MULTIPLE_DEFAULT_CERTIFICATES_PER_AUTH_TYPE);
@@ -528,7 +528,7 @@ int s2n_config_set_cert_chain_and_key_defaults(struct s2n_config *config,
     }
 
     GUARD(s2n_config_clear_default_certificates(config));
-    for (int i = 0; i < num_cert_key_pairs; i++) {
+    for (size_t i = 0; i < num_cert_key_pairs; i++) {
         s2n_pkey_type cert_type = s2n_cert_chain_and_key_get_pkey_type(cert_key_pairs[i]);
         config->default_certs_by_type.certs[cert_type] = cert_key_pairs[i];
     }

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1087,11 +1087,14 @@ int s2n_connection_get_session_id(struct s2n_connection *conn, uint8_t *session_
     notnull_check(conn);
     notnull_check(session_id);
 
-    int session_id_len = s2n_connection_get_session_id_length(conn);
+    const int session_id_len = s2n_connection_get_session_id_length(conn);
+    GUARD(session_id_len);
 
-    S2N_ERROR_IF(session_id_len > max_length, S2N_ERR_SESSION_ID_TOO_LONG);
+    const size_t session_id_size = session_id_len;
 
-    memcpy_check(session_id, conn->session_id, session_id_len);
+    S2N_ERROR_IF(session_id_size> max_length, S2N_ERR_SESSION_ID_TOO_LONG);
+
+    memcpy_check(session_id, conn->session_id, session_id_size);
 
     return session_id_len;
 }

--- a/tls/s2n_ecc_preferences.c
+++ b/tls/s2n_ecc_preferences.c
@@ -55,7 +55,7 @@ int s2n_check_ecc_preferences_curves_list(const struct s2n_ecc_preferences *ecc_
     for (int i = 0; i < ecc_preferences->count; i++) {
         const struct s2n_ecc_named_curve *named_curve = ecc_preferences->ecc_curves[i];
         int curve_found = 0;
-        for (int j = 0; j < s2n_all_supported_curves_list_len; j++) {
+        for (size_t j = 0; j < s2n_all_supported_curves_list_len; j++) {
             if (named_curve->iana_id == s2n_all_supported_curves_list[j]->iana_id) {
                 curve_found = 1;
                 break; 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -660,7 +660,7 @@ const char *s2n_connection_get_handshake_type_name(struct s2n_connection *conn)
     char *p = handshake_type_str[handshake_type];
     char *end = p + sizeof(handshake_type_str[0]);
 
-    for (int i = 0; i < s2n_array_len(handshake_type_names); ++i) {
+    for (size_t i = 0; i < s2n_array_len(handshake_type_names); ++i) {
         if (handshake_type & (1 << i)) {
             p = s2n_strcpy(p, end, handshake_type_names[i]);
         }

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -251,7 +251,7 @@ int s2n_cipher_suite_to_kem(const uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN], 
     /* cppcheck-suppress knownConditionTrueFalse */
     ENSURE_POSIX(kem_mapping[0].kem_count > 0, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
 
-    for (int i = 0; i < s2n_array_len(kem_mapping); i++) {
+    for (size_t i = 0; i < s2n_array_len(kem_mapping); i++) {
         const struct s2n_iana_to_kem *candidate = &kem_mapping[i];
         if (memcmp(iana_value, candidate->iana_value, S2N_TLS_CIPHER_SUITE_LEN) == 0) {
             *compatible_params = candidate;
@@ -265,7 +265,7 @@ int s2n_get_kem_from_extension_id(kem_extension_size kem_id, const struct s2n_ke
     /* cppcheck-suppress knownConditionTrueFalse */
     ENSURE_POSIX(kem_mapping[0].kem_count > 0, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
 
-    for (int i = 0; i < s2n_array_len(kem_mapping); i++) {
+    for (size_t i = 0; i < s2n_array_len(kem_mapping); i++) {
         const struct s2n_iana_to_kem *iana_to_kem = &kem_mapping[i];
 
         for (int j = 0; j < iana_to_kem->kem_count; j++) {

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -301,7 +301,7 @@ static int s2n_p_hash(struct s2n_prf_working_space *ws, s2n_hmac_algorithm alg, 
 
         uint32_t bytes_to_xor = MIN(outputlen, digest_size);
 
-        for (int i = 0; i < bytes_to_xor; i++) {
+        for (size_t i = 0; i < bytes_to_xor; i++) {
             *output ^= ws->tls.digest1[i];
             output++;
             outputlen--;

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -261,13 +261,14 @@ int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, si
     notnull_check(conn);
     notnull_check(session);
 
-    int len = s2n_connection_get_session_length(conn);
+    const int len = s2n_connection_get_session_length(conn);
+    const size_t size = len;
 
     if (len == 0) {
         return 0;
     }
 
-    S2N_ERROR_IF(len > max_length, S2N_ERR_SERIALIZED_SESSION_STATE_TOO_LONG);
+    S2N_ERROR_IF(size > max_length, S2N_ERR_SERIALIZED_SESSION_STATE_TOO_LONG);
 
     struct s2n_blob serialized_data = {0};
     GUARD(s2n_blob_init(&serialized_data, session, len));

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -117,10 +117,10 @@ ssize_t s2n_sendv_with_offset(struct s2n_connection *conn, const struct iovec *b
     }
 
     /* Defensive check against an invalid retry */
-    if (offs) {
+    if (offs > 0) {
         const struct iovec* _bufs = bufs;
         ssize_t _count = count;
-        while (offs >= _bufs->iov_len && _count > 0) {
+        while ((size_t)offs >= _bufs->iov_len && _count > 0) {
             offs -= _bufs->iov_len;
             _bufs++;
             _count--;
@@ -128,7 +128,7 @@ ssize_t s2n_sendv_with_offset(struct s2n_connection *conn, const struct iovec *b
         bufs = _bufs;
         count = _count;
     }
-    for (int i = 0; i < count; i++) {
+    for (ssize_t i = 0; i < count; i++) {
         total_size += bufs[i].iov_len;
     }
     total_size -= offs;

--- a/tls/s2n_server_cert_request.c
+++ b/tls/s2n_server_cert_request.c
@@ -72,8 +72,8 @@ static int s2n_recv_client_cert_preferences(struct s2n_stuffer *in, s2n_cert_typ
     notnull_check(their_cert_type_pref_list);
 
     /* Iterate through our preference list from most to least preferred, and return the first match that we find. */
-    for (int our_cert_pref_idx = 0; our_cert_pref_idx < sizeof(s2n_cert_type_preference_list); our_cert_pref_idx++) {
-        for (int their_cert_idx = 0; their_cert_idx < cert_types_len; their_cert_idx++) {
+    for (size_t our_cert_pref_idx = 0; our_cert_pref_idx < sizeof(s2n_cert_type_preference_list); our_cert_pref_idx++) {
+        for (size_t their_cert_idx = 0; their_cert_idx < cert_types_len; their_cert_idx++) {
             if (their_cert_type_pref_list[their_cert_idx] == s2n_cert_type_preference_list[our_cert_pref_idx]) {
                 *chosen_cert_type_out = s2n_cert_type_preference_list[our_cert_pref_idx];
                 return 0;

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -68,7 +68,7 @@ int s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint32_t of
 int s2n_blob_char_to_lower(struct s2n_blob *b)
 {
     uint8_t *ptr = b->data;
-    for (int i = 0; i < b->size; i++ ) {
+    for (size_t i = 0; i < b->size; i++ ) {
         *ptr = tolower(*ptr);
         ptr++;
     }
@@ -108,7 +108,7 @@ int s2n_hex_string_to_bytes(const char *str, struct s2n_blob *blob)
     gte_check(blob->size, len / 2);
     S2N_ERROR_IF(len % 2 != 0, S2N_ERR_INVALID_HEX);
 
-    for (int i = 0; i < len; i += 2) {
+    for (size_t i = 0; i < len; i += 2) {
         uint8_t high_nibble = hex_inverse[(uint8_t) str[i]];
         S2N_ERROR_IF(high_nibble == 255, S2N_ERR_INVALID_HEX);
 

--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -63,7 +63,7 @@ static S2N_RESULT s2n_map_embiggen(struct s2n_map *map, uint32_t capacity)
     tmp.immutable = 0;
     tmp.sha256 = map->sha256;
 
-    for (int i = 0; i < map->capacity; i++) {
+    for (size_t i = 0; i < map->capacity; i++) {
         if (map->table[i].key.size) {
             GUARD_RESULT(s2n_map_add(&tmp, &map->table[i].key, &map->table[i].value));
             GUARD_AS_RESULT(s2n_free(&map->table[i].key));
@@ -227,7 +227,7 @@ S2N_RESULT s2n_map_lookup(struct s2n_map *map, struct s2n_blob *key, struct s2n_
 S2N_RESULT s2n_map_free(struct s2n_map *map)
 {
     /* Free the keys and values */
-    for (int i = 0; i < map->capacity; i++) {
+    for (size_t i = 0; i < map->capacity; i++) {
         if (map->table[i].key.size) {
             GUARD_AS_RESULT(s2n_free(&map->table[i].key));
             GUARD_AS_RESULT(s2n_free(&map->table[i].value));

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -62,7 +62,7 @@ int s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, uint32_t len)
     S2N_PUBLIC_INPUT(len);
 
     uint8_t xor = 0;
-    for (int i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
         /* Invariants must hold for each execution of the loop
 	 * and at loop exit, hence the <= */
         S2N_INVARIENT(i <= len);
@@ -93,7 +93,7 @@ int s2n_constant_time_copy_or_dont(uint8_t * dest, const uint8_t * src, uint32_t
     /* dont = 0 : mask = 0xff */
     /* dont > 0 : mask = 0x00 */
 
-    for (int i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
         uint8_t old = dest[i];
         uint8_t diff = (old ^ src[i]) & mask;
         dest[i] = old ^ diff;


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 None.

### Description of changes: 

Be consistent in data types. the common pattern of:

```
for (int i = 0 ; i < uint32_t; i++) {
}
````

just works due to implicit integer promotion, however we should be explicit about our types and avoid any undefined behavior when an `int` is less than 32 bits.

### Call-outs:

A few places I had to cast, i tried to be reasonable and ensure we wouldn't overflow, however may have missed some.  most of this was in the test files.

Openssl APIs take an `(int *)`, so in those instances, convert to an `int` on assignment and compare, being explicit by casting.

### Testing:

No additional testing required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
