### PR TITLE
Allow s2n_init() to be called multiple times

### DIFF
--- a/tests/unit/s2n_utils_test.c
+++ b/tests/unit/s2n_utils_test.c
@@ -54,6 +54,8 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13());
+    /* s2n_init() should be idempotent. */
+    EXPECT_SUCCESS(s2n_init());
     EXPECT_FAILURE(requested_bigger_than_max());
     EXPECT_SUCCESS(succesful_stack_blob());
     END_TEST();

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -28,6 +28,7 @@
 #include "openssl/opensslv.h"
 
 #include "pq-crypto/s2n_pq.h"
+static int s2n_initialized = 0;
 
 static void s2n_cleanup_atexit(void);
 
@@ -38,6 +39,14 @@ unsigned long s2n_get_openssl_version(void)
 
 int s2n_init(void)
 {
+    /* s2n has already been initialized be a previous call to setup the library.
+     * This can occur when multiple components within a process have a dependency on s2n
+     * and try to initialize the library on process start.
+     */
+    if (s2n_initialized) {
+        return 0;
+    }
+
     POSIX_GUARD(s2n_fips_init());
     POSIX_GUARD(s2n_mem_init());
     POSIX_GUARD_RESULT(s2n_rand_init());
@@ -53,6 +62,7 @@ int s2n_init(void)
         s2n_stack_traces_enabled_set(true);
     }
 
+    s2n_initialized = 1;
     return 0;
 }
 
@@ -61,6 +71,10 @@ int s2n_cleanup(void)
     /* s2n_cleanup is supposed to be called from each thread before exiting,
      * so ensure that whatever clean ups we have here are thread safe */
     POSIX_GUARD_RESULT(s2n_rand_cleanup_thread());
+    /* This isn't strictly necessary as it isn't currently possible to call s2n_init() again after a call to
+     * s2n_cleanup().
+     */
+    s2n_initialized = 0;
     return 0;
 }
 

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -297,6 +297,11 @@ extern int s2n_sub_overflow(uint32_t a, uint32_t b, uint32_t* out);
 #define GUARD_RESULT_NONNULL( x )                   RESULT_GUARD_PTR(x)
 
 /**
+ * Ensures `x` is ok, otherwise the function will return
+ */
+#define GUARD_RESULT_VOID( x )                   __S2N_ENSURE(s2n_result_is_ok(x), return)
+
+/**
  * Ensures `x` is not a OpenSSL error, otherwise the function will `BAIL` with `error`
  */
 /* TODO: use the OSSL error code in error reporting https://github.com/awslabs/s2n/issues/705 */
@@ -316,6 +321,12 @@ extern int s2n_sub_overflow(uint32_t a, uint32_t b, uint32_t* out);
  * Ensures `x` is not `NULL`, otherwise the function will return a POSIX error (`-1`)
  */
 #define GUARD_POSIX_NONNULL( x )                    POSIX_GUARD_PTR(x)
+
+/**
+ * Ensures `x` is not a POSIX error, otherwise the function will return
+ */
+#define GUARD_POSIX_VOID( x )                       __S2N_ENSURE((x) >= S2N_SUCCESS, return )
+
 
 /**
  * Ensures `x` is not a OpenSSL error, otherwise the function will `BAIL` with `error`


### PR DESCRIPTION
Subsequent calls to s2n_init() without a call to s2n_cleanup() will now
return success and reuse the previously initialized library state.

This change is to accommodate use cases where multiple libraries/threads
within a process have a dependency on s2n and attempt to call s2n_init()
indepdently. For example, consider a case where a webserver library
tries to call s2n_init() every time a thread is spawned. For these use
cases I think it is simplest to allow all subsequent calls to s2n_init()
to succeed.

Alternatively, we could try to keep some global state in the application
to guard all code paths that touch s2n_init(), but this can be a large
effort that requires coordination between all libraries in a process.

### Testing:
Called s2n_init() twice in a unit test.
