### PR TITLE
Remove test only flag for subset keyshare(s) support

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -222,6 +222,7 @@ extern uint64_t s2n_connection_get_delay(struct s2n_connection *conn);
 extern int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);
 extern int s2n_connection_set_protocol_preferences(struct s2n_connection *conn, const char * const *protocols, int protocol_count);
 extern int s2n_set_server_name(struct s2n_connection *conn, const char *server_name);
+extern int s2n_connection_set_keyshare_by_name(struct s2n_connection *conn, const char* curve_name);
 extern const char *s2n_get_server_name(struct s2n_connection *conn);
 extern const char *s2n_get_application_protocol(struct s2n_connection *conn);
 extern const uint8_t *s2n_connection_get_ocsp_response(struct s2n_connection *conn, uint32_t *length);

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -467,7 +467,7 @@ int main(int argc, char *const *argv)
 
         for (size_t i = 0; i < keyshares_count; i++) {
             if (keyshares[i]) {
-                GUARD_EXIT(s2n_connection_set_keyshare_by_name_for_testing(conn, keyshares[i]), "Error setting keyshares to generate");
+                GUARD_EXIT(s2n_connection_set_keyshare_by_name(conn, keyshares[i]), "Error setting keyshares to generate");
             }
         }
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1074,6 +1074,24 @@ const char *s2n_get_server_name(struct s2n_connection *conn);
 or NULL if none is found. This can be used by a server to determine which server
 name the client is using.
 
+### s2n\_connection\_set\_keyshare\_by\_name
+
+```c
+int s2n_connection_set_keyshare_by_name(struct s2n_connection *conn, const char* curve_name);
+```
+
+**s2n_connection_set_keyshare_by_name** sets the keyshare preference for the connection.
+Note that the keyword `none` represents a list of empty keyshares.
+The `curve_name` must correspond to a supported group configured in the security_policy->ecc_preferences list.
+By default, s2n sets the keyshare preference to the highest priority supported group in the ecc_preferences list. 
+Example Usage:
+```c
+s2n_connection_set_keyshare_by_name(conn, "none");
+s2n_connection_set_keyshare_by_name(conn, "x25519");
+s2n_connection_set_keyshare_by_name(conn, "secp256r1");
+s2n_connection_set_keyshare_by_name(conn, "secp384r1");
+```
+
 ### s2n\_connection\_set\_blinding
 
 ```c

--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -131,14 +131,14 @@ int main(int argc, char **argv)
         }
         
         /* Test that s2n_client_key_share_extension.send sends empty client key share list when
-         * s2n_connection_set_keyshare_by_name_for_testing is called with 'none' */
+         * s2n_connection_set_keyshare_by_name is called with 'none' */
         {
             struct s2n_stuffer key_share_extension;
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             /* Force the client to send an empty list of keyshares */
-            EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(conn, "none"));
+            EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name(conn, "none"));
 
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 0));
 
@@ -162,7 +162,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             /* Force the client to send only p-256 keyshare in keyshare list */
-            EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(conn, "secp256r1"));
+            EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name(conn, "secp256r1"));
 
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 0));
 
@@ -197,8 +197,8 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             /* Force the client to send only p-256 and p-384 keyshares in keyshare list */
-            EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(conn, "secp256r1"));
-            EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(conn, "secp384r1"));
+            EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name(conn, "secp256r1"));
+            EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name(conn, "secp384r1"));
 
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 0));
 

--- a/tests/unit/s2n_connection_preferred_keyshare_test.c
+++ b/tests/unit/s2n_connection_preferred_keyshare_test.c
@@ -33,12 +33,12 @@ int main(int argc, char **argv)
 
     /* Test error case for setting preferred keyshares prior to ecc_preferences being configured */
     {
-        EXPECT_FAILURE(s2n_connection_set_keyshare_by_name_for_testing(conn, "secp256r1"));
+        EXPECT_FAILURE(s2n_connection_set_keyshare_by_name(conn, "secp256r1"));
     }
     /* Test sending empty keyshare */
     {
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(conn, "none"));
+        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name(conn, "none"));
         /* lsb is set */
         EXPECT_TRUE(S2N_IS_KEY_SHARE_LIST_EMPTY(conn->preferred_key_shares));
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(ecc_pref);
         /* Test success for setting preferred keyshares bitmap for curve p-256 after ecc_preferences is configured
          * Default security policy has ecc_preferences in the following order: p-256, p-384 */
-        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(conn, "secp256r1"));
+        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name(conn, "secp256r1"));
         /* lsb is not set */
         EXPECT_FALSE(S2N_IS_KEY_SHARE_LIST_EMPTY(conn->preferred_key_shares));
         /* Bitmap value for p-256 set is 00000010 */
@@ -73,12 +73,12 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
         /* Default security policy for TLS1.3 has ecc_preferences in the following order: x25519, p-256, p-384.*/
-        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(conn, "x25519"));
+        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name(conn, "x25519"));
         /* lsb is not set */
         EXPECT_FALSE(S2N_IS_KEY_SHARE_LIST_EMPTY(conn->preferred_key_shares));
         /* Bitmap value for x25519 set is 00000010 */
         EXPECT_TRUE(S2N_IS_KEY_SHARE_REQUESTED(conn->preferred_key_shares, 1));
-        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(conn, "secp384r1"));
+        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name(conn, "secp384r1"));
         /* Bitmap value for p-384 and x25519 set is 00001010 */
         EXPECT_FALSE(S2N_IS_KEY_SHARE_REQUESTED(conn->preferred_key_shares, 2));
         EXPECT_TRUE(S2N_IS_KEY_SHARE_REQUESTED(conn->preferred_key_shares, 3));
@@ -89,12 +89,12 @@ int main(int argc, char **argv)
     /* Test sending duplicate keyshares */
     {
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(conn, "secp256r1"));
+        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name(conn, "secp256r1"));
         /* lsb is not set */
         EXPECT_FALSE(S2N_IS_KEY_SHARE_LIST_EMPTY(conn->preferred_key_shares));
         /* Bitmap value for p-256 set is 00000010 */
         EXPECT_TRUE(S2N_IS_KEY_SHARE_REQUESTED(conn->preferred_key_shares, 1));
-        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(conn, "secp256r1"));
+        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name(conn, "secp256r1"));
         EXPECT_TRUE(S2N_IS_KEY_SHARE_REQUESTED(conn->preferred_key_shares, 1));
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
@@ -103,12 +103,12 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_TRUE(!(conn->preferred_key_shares | 0));
 
-        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(conn, "secp256r1"));
+        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name(conn, "secp256r1"));
         /* lsb is not set */
         EXPECT_FALSE(S2N_IS_KEY_SHARE_LIST_EMPTY(conn->preferred_key_shares));
         /* Bitmap value for p-256 set is 00000010 */
         EXPECT_TRUE(S2N_IS_KEY_SHARE_REQUESTED(conn->preferred_key_shares, 1));
-        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(conn, "secp384r1"));
+        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name(conn, "secp384r1"));
         /* Bitmap value for p-256 and p-384 set is 00000110 */
         EXPECT_TRUE(S2N_IS_KEY_SHARE_REQUESTED(conn->preferred_key_shares, 2));
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
     {
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_TRUE(!(conn->preferred_key_shares | 0));
-        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_set_keyshare_by_name_for_testing(conn, "x448"),
+        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_set_keyshare_by_name(conn, "x448"),
                                   S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
         EXPECT_TRUE(conn->preferred_key_shares == 0);
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -131,7 +131,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20190802"));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
         /* x25519 is not present in the security_policy "20190802"  */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_set_keyshare_by_name_for_testing(conn, "x25519"),
+        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_set_keyshare_by_name(conn, "x25519"),
                                   S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
         EXPECT_TRUE(conn->preferred_key_shares == 0);
         EXPECT_SUCCESS(s2n_config_free(config));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1295,9 +1295,8 @@ uint8_t s2n_connection_get_protocol_version(const struct s2n_connection *conn)
     return conn->server_protocol_version;
 }
 
-int s2n_connection_set_keyshare_by_name_for_testing(struct s2n_connection *conn, const char* curve_name)
+int s2n_connection_set_keyshare_by_name(struct s2n_connection *conn, const char* curve_name)
 {
-    ENSURE_POSIX(S2N_IN_TEST, S2N_ERR_NOT_IN_TEST);
     notnull_check(conn);
 
     if (!strcmp(curve_name, "none")) {

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -334,5 +334,3 @@ int s2n_connection_set_client_auth_type(struct s2n_connection *conn, s2n_cert_au
 int s2n_connection_get_client_auth_type(struct s2n_connection *conn, s2n_cert_auth_type *client_cert_auth_type);
 int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **der_cert_chain_out, uint32_t *cert_chain_len);
 uint8_t s2n_connection_get_protocol_version(const struct s2n_connection *conn);
-/* `none` keyword represents a list of empty keyshares */
-int s2n_connection_set_keyshare_by_name_for_testing(struct s2n_connection *conn, const char* curve_name);


### PR DESCRIPTION
_Please note that while we are transitioning from travis-ci to AWS CodeBuild, some tests are run on each platform. Non-AWS contributors will temporarily be unable to see CodeBuild results. We apologize for the inconvenience._
### Resolved issues:

 resolves https://github.com/awslabs/s2n/issues/2009

### Description of changes: 

Enable subset keyshare(s) support within s2n by: 

-  removing the test only flag present in the API: https://github.com/awslabs/s2n/blob/master/tls/s2n_connection.c#L1300
- updating the function name https://github.com/awslabs/s2n/blob/master/tls/s2n_connection.c#L1298
- updates USAGE-GUIDE.md

### Call-outs:

This change enables susbset keyshare(s) full support within s2n.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
