### PR TITLE
Add s2n_config_set_security_policy and s2n_connection_set_security_policy

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -31,7 +31,7 @@ extern "C" {
 #include <stdio.h>
 #include <sys/uio.h>
 
-#include "utils/s2n_annotations.h"
+#include "utils/s2n_compiler.h"
 
 /* Function return code  */
 #define S2N_SUCCESS 0
@@ -216,7 +216,8 @@ extern int s2n_config_set_max_cert_chain_depth(struct s2n_config *config, uint16
 
 S2N_API
 extern int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem);
-S2N_DEPRECATED
+
+S2N_DEPRECATED("Cipher preferences are set through security policies")
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);
 S2N_API
 extern int s2n_config_set_security_policy(struct s2n_config *config, const struct s2n_security_policy *policy);
@@ -327,7 +328,7 @@ extern int s2n_connection_set_blinding(struct s2n_connection *conn, s2n_blinding
 S2N_API
 extern uint64_t s2n_connection_get_delay(struct s2n_connection *conn);
 
-S2N_DEPRECATED
+S2N_DEPRECATED("Cipher preferences are set through security policies")
 extern int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);
 S2N_API
 extern int s2n_connection_set_security_policy(struct s2n_connection *conn, const struct s2n_security_policy *policy);

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -31,6 +31,8 @@ extern "C" {
 #include <stdio.h>
 #include <sys/uio.h>
 
+#include "utils/s2n_annotations.h"
+
 /* Function return code  */
 #define S2N_SUCCESS 0
 #define S2N_FAILURE -1
@@ -67,6 +69,12 @@ extern int s2n_error_get_type(int error);
 
 struct s2n_config;
 struct s2n_connection;
+struct s2n_security_policy;
+
+extern const struct s2n_security_policy *S2N_SECURITY_POLICY_DEFAULT;
+extern const struct s2n_security_policy *S2N_SECURITY_POLICY_DEFAULT_TLS13;
+extern const struct s2n_security_policy *S2N_SECURITY_POLICY_20170210;
+extern const struct s2n_security_policy *S2N_SECURITY_POLICY_20190801;
 
 S2N_API
 extern unsigned long s2n_get_openssl_version(void);
@@ -208,8 +216,10 @@ extern int s2n_config_set_max_cert_chain_depth(struct s2n_config *config, uint16
 
 S2N_API
 extern int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem);
-S2N_API
+S2N_DEPRECATED
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);
+S2N_API
+extern int s2n_config_set_security_policy(struct s2n_config *config, const struct s2n_security_policy *policy);
 S2N_API
 extern int s2n_config_set_protocol_preferences(struct s2n_config *config, const char * const *protocols, int protocol_count);
 typedef enum { S2N_STATUS_REQUEST_NONE = 0, S2N_STATUS_REQUEST_OCSP = 1 } s2n_status_request_type;
@@ -317,8 +327,10 @@ extern int s2n_connection_set_blinding(struct s2n_connection *conn, s2n_blinding
 S2N_API
 extern uint64_t s2n_connection_get_delay(struct s2n_connection *conn);
 
-S2N_API
+S2N_DEPRECATED
 extern int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);
+S2N_API
+extern int s2n_connection_set_security_policy(struct s2n_connection *conn, const struct s2n_security_policy *policy);
 S2N_API
 extern int s2n_connection_set_protocol_preferences(struct s2n_connection *conn, const char * const *protocols, int protocol_count);
 S2N_API

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -217,7 +217,7 @@ extern int s2n_config_set_max_cert_chain_depth(struct s2n_config *config, uint16
 S2N_API
 extern int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem);
 
-S2N_DEPRECATED("Cipher preferences are set through security policies")
+S2N_API
 extern int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);
 S2N_API
 extern int s2n_config_set_security_policy(struct s2n_config *config, const struct s2n_security_policy *policy);
@@ -328,7 +328,7 @@ extern int s2n_connection_set_blinding(struct s2n_connection *conn, s2n_blinding
 S2N_API
 extern uint64_t s2n_connection_get_delay(struct s2n_connection *conn);
 
-S2N_DEPRECATED("Cipher preferences are set through security policies")
+S2N_API
 extern int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);
 S2N_API
 extern int s2n_connection_set_security_policy(struct s2n_connection *conn, const struct s2n_security_policy *policy);

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -119,7 +119,10 @@ static void setup_s2n_config(struct s2n_config *config, const char *cipher_prefs
         exit(1);
     }
 
-    GUARD_EXIT(s2n_config_set_cipher_preferences(config, cipher_prefs), "Error setting cipher prefs");
+    const struct s2n_security_policy *policy;
+    GUARD_EXIT(s2n_find_security_policy_from_version(cipher_prefs, &policy), "Error finding policy");
+
+    GUARD_EXIT(s2n_config_set_security_policy(config, policy), "Error setting cipher prefs");
 
     GUARD_EXIT(s2n_config_set_status_request_type(config, type), "OCSP validation is not supported by the linked libCrypto implementation. It cannot be set.");
 

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -120,9 +120,9 @@ static void setup_s2n_config(struct s2n_config *config, const char *cipher_prefs
     }
 
     const struct s2n_security_policy *policy;
-    GUARD_EXIT(s2n_find_security_policy_from_version(cipher_prefs, &policy), "Error finding policy");
+    GUARD_EXIT(s2n_find_security_policy_from_version(cipher_prefs, &policy), "Error finding security policy");
 
-    GUARD_EXIT(s2n_config_set_security_policy(config, policy), "Error setting cipher prefs");
+    GUARD_EXIT(s2n_config_set_security_policy(config, policy), "Error setting security policy");
 
     GUARD_EXIT(s2n_config_set_status_request_type(config, type), "OCSP validation is not supported by the linked libCrypto implementation. It cannot be set.");
 

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -120,6 +120,8 @@ static void setup_s2n_config(struct s2n_config *config, const char *cipher_prefs
     }
 
     const struct s2n_security_policy *policy;
+    /* Using unsupported function to prevent changing the s2nc/s2nd interface for integration tests */
+    /* https://github.com/awslabs/s2n/issues/2378 */
     GUARD_EXIT(s2n_find_security_policy_from_version(cipher_prefs, &policy), "Error finding security policy");
 
     GUARD_EXIT(s2n_config_set_security_policy(config, policy), "Error setting security policy");

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -684,7 +684,7 @@ int main(int argc, char *const *argv)
     GUARD_EXIT(s2n_config_add_dhparams(config, dhparams), "Error adding DH parameters");
 
     const struct s2n_security_policy *policy;
-    GUARD_EXIT(s2n_find_security_policy_from_version(cipher_prefs, &policy), "Error finding policy");
+    GUARD_EXIT(s2n_find_security_policy_from_version(cipher_prefs, &policy), "Error finding security policy");
     GUARD_EXIT(s2n_config_set_security_policy(config, policy),"Error setting security policy");
 
     GUARD_EXIT(s2n_config_set_cache_store_callback(config, cache_store_callback, session_cache), "Error setting cache store callback");

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -41,6 +41,8 @@
 #include <s2n.h>
 #include "common.h"
 
+#include "tls/s2n_connection.h"
+#include "tls/s2n_tls13.h"
 #include "utils/s2n_safety.h"
 
 #define MAX_CERTIFICATES 50
@@ -681,7 +683,9 @@ int main(int argc, char *const *argv)
 
     GUARD_EXIT(s2n_config_add_dhparams(config, dhparams), "Error adding DH parameters");
 
-    GUARD_EXIT(s2n_config_set_cipher_preferences(config, cipher_prefs),"Error setting cipher prefs");
+    const struct s2n_security_policy *policy;
+    GUARD_EXIT(s2n_find_security_policy_from_version(cipher_prefs, &policy), "Error finding policy");
+    GUARD_EXIT(s2n_config_set_security_policy(config, policy),"Error setting security policy");
 
     GUARD_EXIT(s2n_config_set_cache_store_callback(config, cache_store_callback, session_cache), "Error setting cache store callback");
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -41,8 +41,7 @@
 #include <s2n.h>
 #include "common.h"
 
-#include "tls/s2n_connection.h"
-#include "tls/s2n_tls13.h"
+#include "tls/s2n_security_policies.h"
 #include "utils/s2n_safety.h"
 
 #define MAX_CERTIFICATES 50
@@ -684,6 +683,8 @@ int main(int argc, char *const *argv)
     GUARD_EXIT(s2n_config_add_dhparams(config, dhparams), "Error adding DH parameters");
 
     const struct s2n_security_policy *policy;
+    /* Using unsupported function to prevent changing the s2nc/s2nd interface for integration tests */
+    /* https://github.com/awslabs/s2n/issues/2378 */
     GUARD_EXIT(s2n_find_security_policy_from_version(cipher_prefs, &policy), "Error finding security policy");
     GUARD_EXIT(s2n_config_set_security_policy(config, policy),"Error setting security policy");
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -506,11 +506,12 @@ combinations are called *security policies*. This function is simply a wrapper f
 ### s2n\_config\_set\_cipher\_preferences
 
 ```c
+S2N_DEPRECATED
 int s2n_config_set_cipher_preferences(struct s2n_config *config,
                                       const char *version);
 ```
 
-**s2n_config_set_cipher_preferences** sets the security policy that includes the cipher/kem/signature/ecc preferences and protocol version.
+*This API is deprecated* **s2n_config_set_cipher_preferences** sets the security policy that includes the cipher/kem/signature/ecc preferences and protocol version.
 
 The following chart maps the security policy version to protocol version and ciphertsuites supported:
 
@@ -1120,10 +1121,11 @@ This function is a wrapper for **s2n_connection_set_cipher_preferences**.
 ### s2n\_connection\_set\_cipher\_preferences
 
 ```c
+S2N_DEPRECATED
 int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);
 ```
 
-**s2n_connection_set_cipher_preferences** sets the cipher preference override for the
+*This API is deprecated* **s2n_connection_set_cipher_preferences** sets the cipher preference override for the
 s2n_connection. Calling this function is not necessary unless you want to set the
 cipher preferences on the connection to something different than what is in the s2n_config.
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -370,9 +370,9 @@ This string is useful to include when reporting issues to the s2n development te
 Example:
 
 ```
-if (s2n_config_set_cipher_preferences(config, prefs) < 0) {
-    printf("Setting cipher prefs failed! %s : %s", s2n_strerror(s2n_errno, "EN"), s2n_strerror_debug(s2n_errno, "EN"));
-    return -1;
+if (s2n_config_set_versioned_security_policy(config, version) < 0) {
+    printf("Setting security policy failed! %s : %s", s2n_strerror(s2n_errno, "EN"), s2n_strerror_debug(s2n_errno, "EN"));
+    return S2N_FAILURE;
 }
 ```
 
@@ -490,6 +490,18 @@ int s2n_config_free(struct s2n_config *config);
 ```
 
 **s2n_config_free** frees the memory associated with an **s2n_config** object.
+
+### s2n\_config\_set\_security\_policy
+
+```c
+int s2n_config_set_versioned_security_policy(struct s2n_config *config,
+                                      const char *version);
+```
+
+**s2n_config_set_versioned_security_policy** S2N makes opinionated decisions about which ciphers,
+key encapsualtion mechanisms, signature algorithms, and curves can be used together. These
+combinations are called *security policies*. This function is simply a wrapper for
+*s2n_config_set_cipher_preferences*. The name better describes the behavior behind the scenes.
 
 ### s2n\_config\_set\_cipher\_preferences
 
@@ -1091,6 +1103,18 @@ is supported by a given cipher preferences. It returns
 -  1 if the connection satisfies the cipher suite 
 -  0 if it does not
 - -1 on any other errors
+
+
+### s2n\_connection\_set\_security\_policy
+
+```c
+int s2n_connection_set_versioned_security_policy(struct s2n_connection *conn, const char *version);
+```
+
+**s2n_connection_set_versioned_security_policy** sets the security policy override for the
+s2n_connection. Calling this function is not necessary unless you want to set the
+security policy on the connection to something different than what is in the s2n_config.
+This function is a wrapper for **s2n_connection_set_cipher_preferences**.
 
 
 ### s2n\_connection\_set\_cipher\_preferences

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -370,7 +370,7 @@ This string is useful to include when reporting issues to the s2n development te
 Example:
 
 ```
-if (s2n_config_set_versioned_security_policy(config, version) < 0) {
+if (s2n_config_set_security_policy(config, policy) < 0) {
     printf("Setting security policy failed! %s : %s", s2n_strerror(s2n_errno, "EN"), s2n_strerror_debug(s2n_errno, "EN"));
     return S2N_FAILURE;
 }
@@ -494,11 +494,11 @@ int s2n_config_free(struct s2n_config *config);
 ### s2n\_config\_set\_security\_policy
 
 ```c
-int s2n_config_set_versioned_security_policy(struct s2n_config *config,
-                                      const char *version);
+int s2n_config_set_security_policy(struct s2n_config *config,
+                                      const struct s2n_security_policy *policy);
 ```
 
-**s2n_config_set_versioned_security_policy** S2N makes opinionated decisions about which ciphers,
+**s2n_config_set_security_policy** S2N makes opinionated decisions about which ciphers,
 key encapsualtion mechanisms, signature algorithms, and curves can be used together. These
 combinations are called *security policies*. This function is simply a wrapper for
 *s2n_config_set_cipher_preferences*. The name better describes the behavior behind the scenes.
@@ -1109,10 +1109,10 @@ is supported by a given cipher preferences. It returns
 ### s2n\_connection\_set\_security\_policy
 
 ```c
-int s2n_connection_set_versioned_security_policy(struct s2n_connection *conn, const char *version);
+int s2n_connection_set_security_policy(struct s2n_connection *conn, const struct s2n_security_policy *policy);
 ```
 
-**s2n_connection_set_versioned_security_policy** sets the security policy override for the
+**s2n_connection_set_security_policy** sets the security policy override for the
 s2n_connection. Calling this function is not necessary unless you want to set the
 security policy on the connection to something different than what is in the s2n_config.
 This function is a wrapper for **s2n_connection_set_cipher_preferences**.

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -370,8 +370,8 @@ This string is useful to include when reporting issues to the s2n development te
 Example:
 
 ```
-if (s2n_config_set_security_policy(config, policy) < 0) {
-    printf("Setting security policy failed! %s : %s", s2n_strerror(s2n_errno, "EN"), s2n_strerror_debug(s2n_errno, "EN"));
+if (s2n_config_set_cipher_preferences(config, prefs) < 0) {
+    printf("Setting cipher prefs failed! %s : %s", s2n_strerror(s2n_errno, "EN"), s2n_strerror_debug(s2n_errno, "EN"));
     return S2N_FAILURE;
 }
 ```
@@ -491,26 +491,14 @@ int s2n_config_free(struct s2n_config *config);
 
 **s2n_config_free** frees the memory associated with an **s2n_config** object.
 
-### s2n\_config\_set\_security\_policy
-
-```c
-int s2n_config_set_security_policy(struct s2n_config *config,
-                                      const struct s2n_security_policy *policy);
-```
-
-**s2n_config_set_security_policy** S2N makes opinionated decisions about which ciphers,
-key encapsualtion mechanisms, signature algorithms, and curves can be used together. These
-combinations are called *security policies*. 
-
 ### s2n\_config\_set\_cipher\_preferences
 
 ```c
-S2N_DEPRECATED
 int s2n_config_set_cipher_preferences(struct s2n_config *config,
                                       const char *version);
 ```
 
-*This API is deprecated* **s2n_config_set_cipher_preferences** sets the security policy that includes the cipher/kem/signature/ecc preferences and protocol version.
+**s2n_config_set_cipher_preferences** sets the security policy that includes the cipher/kem/signature/ecc preferences and protocol version.
 
 The following chart maps the security policy version to protocol version and ciphertsuites supported:
 
@@ -1104,27 +1092,13 @@ is supported by a given cipher preferences. It returns
 -  0 if it does not
 - -1 on any other errors
 
-
-### s2n\_connection\_set\_security\_policy
-
-```c
-int s2n_connection_set_security_policy(struct s2n_connection *conn, const struct s2n_security_policy *policy);
-```
-
-**s2n_connection_set_security_policy** sets the security policy override for the
-s2n_connection. Calling this function is not necessary unless you want to set the
-security policy on the connection to something different than what is in the s2n_config.
-This function is a wrapper for **s2n_connection_set_cipher_preferences**.
-
-
 ### s2n\_connection\_set\_cipher\_preferences
 
 ```c
-S2N_DEPRECATED
 int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);
 ```
 
-*This API is deprecated* **s2n_connection_set_cipher_preferences** sets the cipher preference override for the
+**s2n_connection_set_cipher_preferences** sets the cipher preference override for the
 s2n_connection. Calling this function is not necessary unless you want to set the
 cipher preferences on the connection to something different than what is in the s2n_config.
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -500,8 +500,7 @@ int s2n_config_set_security_policy(struct s2n_config *config,
 
 **s2n_config_set_security_policy** S2N makes opinionated decisions about which ciphers,
 key encapsualtion mechanisms, signature algorithms, and curves can be used together. These
-combinations are called *security policies*. This function is simply a wrapper for
-*s2n_config_set_cipher_preferences*. The name better describes the behavior behind the scenes.
+combinations are called *security policies*. 
 
 ### s2n\_config\_set\_cipher\_preferences
 

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -274,45 +274,33 @@ int main(int argc, char **argv)
     {
         struct s2n_config *config = s2n_config_new();
 
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+        EXPECT_SUCCESS(s2n_config_set_security_policy(config, S2N_SECURITY_POLICY_DEFAULT));
         EXPECT_EQUAL(config->security_policy, &security_policy_20170210);
         EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_20170210);
         EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_null);
         EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20140601);
         EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_20140601);
 
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20170210"));
+        EXPECT_SUCCESS(s2n_config_set_security_policy(config, S2N_SECURITY_POLICY_20170210));
         EXPECT_EQUAL(config->security_policy, &security_policy_20170210);
         EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_20170210);
         EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_null);
         EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20140601);
         EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_20140601);
 
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+        EXPECT_SUCCESS(s2n_config_set_security_policy(config, S2N_SECURITY_POLICY_DEFAULT_TLS13));
         EXPECT_EQUAL(config->security_policy, &security_policy_20190801);
         EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_20190801);
         EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_null);
         EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20200207);
         EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
 
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20190801"));
+        EXPECT_SUCCESS(s2n_config_set_security_policy(config, S2N_SECURITY_POLICY_20190801));
         EXPECT_EQUAL(config->security_policy, &security_policy_20190801);
         EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_20190801);
         EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_null);
         EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20200207);
         EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
-
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "null"));
-        EXPECT_EQUAL(config->security_policy, &security_policy_null);
-        EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_null);
-        EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_null);
-        EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_null);
-        EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_null);
-
-        EXPECT_FAILURE(s2n_config_set_cipher_preferences(config, NULL));
-
-        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_cipher_preferences(config, "notathing"),
-                S2N_ERR_INVALID_SECURITY_POLICY);
 
         s2n_config_free(config);
     }

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -310,6 +310,47 @@ int main(int argc, char **argv)
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
         s2n_connection_set_config(conn, config);
 
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default"));
+        EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
+        EXPECT_EQUAL(security_policy, &security_policy_20170210);
+        EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_20170210);
+        EXPECT_EQUAL(security_policy->kem_preferences, &kem_preferences_null);
+        EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20140601);
+        EXPECT_EQUAL(security_policy->ecc_preferences, &s2n_ecc_preferences_20140601);
+
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20170210"));
+        EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
+        EXPECT_EQUAL(security_policy, &security_policy_20170210);
+        EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_20170210);
+        EXPECT_EQUAL(security_policy->kem_preferences, &kem_preferences_null);
+        EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20140601);
+        EXPECT_EQUAL(security_policy->ecc_preferences, &s2n_ecc_preferences_20140601);
+
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+        EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
+        EXPECT_EQUAL(security_policy, &security_policy_20190801);
+        EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_20190801);
+        EXPECT_EQUAL(security_policy->kem_preferences, &kem_preferences_null);
+        EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20200207);
+        EXPECT_EQUAL(security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
+
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20190801"));
+        EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
+        EXPECT_EQUAL(security_policy, &security_policy_20190801);
+        EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_20190801);
+        EXPECT_EQUAL(security_policy->kem_preferences, &kem_preferences_null);
+        EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20200207);
+        EXPECT_EQUAL(security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
+
+        s2n_config_free(config);
+        s2n_connection_free(conn);
+    }
+    {
+        struct s2n_config *config = s2n_config_new();
+
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        s2n_connection_set_config(conn, config);
+
         EXPECT_SUCCESS(s2n_connection_set_security_policy(conn, S2N_SECURITY_POLICY_DEFAULT));
         EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
         EXPECT_EQUAL(security_policy, &security_policy_20170210);

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -322,7 +322,7 @@ int main(int argc, char **argv)
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
         s2n_connection_set_config(conn, config);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default"));
+        EXPECT_SUCCESS(s2n_connection_set_security_policy(conn, S2N_SECURITY_POLICY_DEFAULT));
         EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
         EXPECT_EQUAL(security_policy, &security_policy_20170210);
         EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_20170210);
@@ -330,7 +330,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20140601);
         EXPECT_EQUAL(security_policy->ecc_preferences, &s2n_ecc_preferences_20140601);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20170210"));
+        EXPECT_SUCCESS(s2n_connection_set_security_policy(conn, S2N_SECURITY_POLICY_20170210));
         EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
         EXPECT_EQUAL(security_policy, &security_policy_20170210);
         EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_20170210);
@@ -338,7 +338,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20140601);
         EXPECT_EQUAL(security_policy->ecc_preferences, &s2n_ecc_preferences_20140601);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+        EXPECT_SUCCESS(s2n_connection_set_security_policy(conn, S2N_SECURITY_POLICY_DEFAULT_TLS13));
         EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
         EXPECT_EQUAL(security_policy, &security_policy_20190801);
         EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_20190801);
@@ -346,16 +346,13 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20200207);
         EXPECT_EQUAL(security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20190801"));
+        EXPECT_SUCCESS(s2n_connection_set_security_policy(conn, S2N_SECURITY_POLICY_20190801));
         EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
         EXPECT_EQUAL(security_policy, &security_policy_20190801);
         EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_20190801);
         EXPECT_EQUAL(security_policy->kem_preferences, &kem_preferences_null);
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20200207);
         EXPECT_EQUAL(security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
-
-        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_set_cipher_preferences(conn, "notathing"),
-                S2N_ERR_INVALID_SECURITY_POLICY);
 
         s2n_config_free(config);
         s2n_connection_free(conn);

--- a/tls/extensions/s2n_extension_list.c
+++ b/tls/extensions/s2n_extension_list.c
@@ -17,8 +17,6 @@
 #include "s2n_extension_type.h"
 #include "s2n_extension_type_lists.h"
 
-#include <s2n.h>
-
 #include "error/s2n_errno.h"
 #include "utils/s2n_safety.h"
 

--- a/tls/extensions/s2n_extension_type.c
+++ b/tls/extensions/s2n_extension_type.c
@@ -13,8 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#include <s2n.h>
-
 #include "error/s2n_errno.h"
 #include "tls/extensions/s2n_extension_type.h"
 #include "tls/s2n_connection.h"

--- a/tls/extensions/s2n_extension_type_lists.c
+++ b/tls/extensions/s2n_extension_type_lists.c
@@ -13,8 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#include <s2n.h>
-
 #include "tls/extensions/s2n_extension_type_lists.h"
 #include "tls/s2n_connection.h"
 

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -14,7 +14,6 @@
  */
 
 #include "tls/s2n_cipher_preferences.h"
-#include <s2n.h>
 #include <stdint.h>
 #include <strings.h>
 #include "tls/s2n_config.h"

--- a/tls/s2n_client_cert.c
+++ b/tls/s2n_client_cert.c
@@ -13,8 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#include <s2n.h>
-
 #include "crypto/s2n_certificate.h"
 #include "error/s2n_errno.h"
 #include "tls/s2n_cipher_suites.h"

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -13,8 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#include <s2n.h>
-
 #include "error/s2n_errno.h"
 
 #include "tls/s2n_connection.h"

--- a/tls/s2n_client_hello.h
+++ b/tls/s2n_client_hello.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <stdint.h>
-#include <s2n.h>
 
 #include "stuffer/s2n_stuffer.h"
 #include "tls/extensions/s2n_extension_list.h"

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -15,7 +15,6 @@
 
 #pragma once
 
-#include "api/s2n.h"
 #include "crypto/s2n_certificate.h"
 #include "crypto/s2n_dhe.h"
 #include "tls/s2n_resume.h"

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -20,7 +20,6 @@
 #include <time.h>
 #include <unistd.h>
 
-#include <s2n.h>
 #include <stdbool.h>
 
 #include "crypto/s2n_fips.h"

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <errno.h>
-#include <s2n.h>
 #include <signal.h>
 #include <stdint.h>
 

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <stdint.h>
-#include <s2n.h>
 
 #include "tls/s2n_crypto.h"
 #include "tls/s2n_signature_algorithms.h"

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -16,7 +16,6 @@
 #include <sys/param.h>
 
 #include <errno.h>
-#include <s2n.h>
 
 #include "error/s2n_errno.h"
 

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -20,7 +20,6 @@
 #include <unistd.h>
 
 #include <errno.h>
-#include <s2n.h>
 
 #include "error/s2n_errno.h"
 

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -14,8 +14,6 @@
  */
 #include <math.h>
 
-#include <s2n.h>
-
 #include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -57,6 +57,7 @@ const struct s2n_security_policy security_policy_20190802 = {
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
 };
+const struct s2n_security_policy *S2N_SECURITY_POLICY_20190802 = &security_policy_20190802;
 
 const struct s2n_security_policy security_policy_20170405 = {
     .minimum_protocol_version = S2N_TLS10,
@@ -65,6 +66,7 @@ const struct s2n_security_policy security_policy_20170405 = {
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
 };
+const struct s2n_security_policy *S2N_SECURITY_POLICY_20170405 = &security_policy_20170405;
 
 const struct s2n_security_policy security_policy_elb_2015_04 = {
     .minimum_protocol_version = S2N_TLS10,

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -109,5 +109,3 @@ bool s2n_pq_kem_is_extension_required(const struct s2n_security_policy *security
 bool s2n_security_policy_supports_tls13(const struct s2n_security_policy *security_policy);
 int s2n_find_security_policy_from_version(const char *version, const struct s2n_security_policy **security_policy);
 int s2n_validate_kem_preferences(const struct s2n_kem_preferences *kem_preferences, bool pq_kem_extension_required);
-int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);
-int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -20,7 +20,6 @@
 #include "tls/s2n_kem_preferences.h"
 #include "tls/s2n_signature_scheme.h"
 #include "tls/s2n_ecc_preferences.h"
-#include "utils/s2n_annotations.h"
 
 struct s2n_security_policy {
     uint8_t minimum_protocol_version;

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -20,6 +20,7 @@
 #include "tls/s2n_kem_preferences.h"
 #include "tls/s2n_signature_scheme.h"
 #include "tls/s2n_ecc_preferences.h"
+#include "utils/s2n_annotations.h"
 
 struct s2n_security_policy {
     uint8_t minimum_protocol_version;
@@ -103,10 +104,10 @@ extern const struct s2n_security_policy security_policy_20190122;
 extern const struct s2n_security_policy security_policy_null;
 
 int s2n_security_policies_init();
-int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);
-int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);
 bool s2n_ecc_is_extension_required(const struct s2n_security_policy *security_policy);
 bool s2n_pq_kem_is_extension_required(const struct s2n_security_policy *security_policy);
 bool s2n_security_policy_supports_tls13(const struct s2n_security_policy *security_policy);
 int s2n_find_security_policy_from_version(const char *version, const struct s2n_security_policy **security_policy);
 int s2n_validate_kem_preferences(const struct s2n_kem_preferences *kem_preferences, bool pq_kem_extension_required);
+int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *version);
+int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -15,7 +15,6 @@
 
 #include <sys/param.h>
 #include <errno.h>
-#include <s2n.h>
 
 #include "error/s2n_errno.h"
 

--- a/tls/s2n_tls13.h
+++ b/tls/s2n_tls13.h
@@ -23,15 +23,8 @@
 extern "C" {
 #endif
 
-#if S2N_GCC_VERSION_AT_LEAST(4, 5, 0)
-    S2N_API
-    __attribute__((deprecated("The use of TLS1.3 is configured through security policies")))
-    extern int s2n_enable_tls13();
-#else
-    S2N_API
-    __attribute__((deprecated))
-    extern int s2n_enable_tls13();
-#endif
+S2N_DEPRECATED("The use of TLS1.3 is configured through security policies")
+extern int s2n_enable_tls13();
 
 #ifdef __cplusplus
 }

--- a/tls/s2n_tls13.h
+++ b/tls/s2n_tls13.h
@@ -23,8 +23,9 @@
 extern "C" {
 #endif
 
+S2N_API
 S2N_DEPRECATED("The use of TLS1.3 is configured through security policies")
-extern int s2n_enable_tls13();
+int s2n_enable_tls13();
 
 #ifdef __cplusplus
 }

--- a/utils/s2n_annotations.h
+++ b/utils/s2n_annotations.h
@@ -17,6 +17,3 @@
 /* For compilation purposes, these annotations are no-ops */
 #define S2N_PUBLIC_INPUT(__a)
 #define S2N_INVARIENT(__a)
-
-/* Help declare the visibility of functions */
-#define S2N_DEPRECATED __attribute__((deprecated))

--- a/utils/s2n_annotations.h
+++ b/utils/s2n_annotations.h
@@ -17,3 +17,6 @@
 /* For compilation purposes, these annotations are no-ops */
 #define S2N_PUBLIC_INPUT(__a)
 #define S2N_INVARIENT(__a)
+
+/* Help declare the visibility of functions */
+#define S2N_DEPRECATED __attribute__((deprecated))

--- a/utils/s2n_compiler.h
+++ b/utils/s2n_compiler.h
@@ -22,3 +22,9 @@
 #define S2N_GCC_VERSION_AT_LEAST(major, minor, patch_level) \
     ((S2N_GCC_VERSION) >= ((major) * 10000 + (minor) * 100 + (patch_level)))
 
+
+#if S2N_GCC_VERSION_AT_LEAST(4, 5, 0)
+#   define S2N_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#else
+#   define S2N_DEPRECATED(msg) __attribute__((deprecated))
+#endif


### PR DESCRIPTION
### Resolved issues:

 resolves #2079

### Description of changes: 

Add new APIs, s2n_config_set_versioned_security_policy and s2n_connection_set_versioned_security_policy.

 * Update usage guide
 * Update security policy unit tests to use the new setter

### Call-outs:

This API simply wraps s2n_{config, connection}_set_cipher_preferences. Calling this function makes it clear what is happening behind the scenes (security policy change) opposed to setting only cipher preferences.

### Testing:

Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
