### PR TITLE
Ensure s2n_rand_cleanup_thread will not prevent the random util to reallocate

### DIFF
--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -308,5 +308,12 @@ int main(int argc, char **argv)
         }
     }
 
+    /* Ensure that s2n_rand_cleanup_thread will not prevent the random util to reallocate */
+    blob.size = 100;
+    for (int t = 1; t < 8; t++) {
+        EXPECT_OK(s2n_rand_cleanup_thread());
+        EXPECT_OK(s2n_get_public_random_data(&blob));
+    }
+
     END_TEST();
 }

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -310,6 +310,7 @@ S2N_RESULT s2n_rand_cleanup_thread(void)
 {
     GUARD_AS_RESULT(s2n_drbg_wipe(&per_thread_private_drbg));
     GUARD_AS_RESULT(s2n_drbg_wipe(&per_thread_public_drbg));
+    zero_if_forked = 0;
 
     return S2N_RESULT_OK;
 }


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

The idea is to make `s2n_cleanup` works better with thread pools - when a thread finishes and calls `s2n_cleanup`, it can release the drbg contexts and when the thread gets reused it can still have the ability to reallocate those contexts.

### Call-outs:

### Testing:

Unit tested, and added the use case in `s2n_random_test`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
