### PR TITLE
Print negotiated signature scheme.

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -374,6 +374,8 @@ extern int s2n_connection_get_session_id_length(struct s2n_connection *conn);
 S2N_API
 extern int s2n_connection_get_session_id(struct s2n_connection *conn, uint8_t *session_id, size_t max_length);
 S2N_API
+extern int s2n_connection_get_signature_scheme(struct s2n_connection *conn);
+S2N_API
 extern int s2n_connection_is_session_resumed(struct s2n_connection *conn);
 S2N_API
 extern int s2n_connection_is_ocsp_stapled(struct s2n_connection *conn);

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -91,6 +91,7 @@ int negotiate(struct s2n_connection *conn, int fd)
     int client_protocol_version;
     int server_protocol_version;
     int actual_protocol_version;
+    int signature_scheme;
 
     if ((client_hello_version = s2n_connection_get_client_hello_version(conn)) < 0) {
         fprintf(stderr, "Could not get client hello version\n");
@@ -108,11 +109,16 @@ int negotiate(struct s2n_connection *conn, int fd)
         fprintf(stderr, "Could not get actual protocol version\n");
         S2N_ERROR(S2N_ERR_ACTUAL_PROTOCOL_VERSION);
     }
+    if ((signature_scheme = s2n_connection_get_signature_scheme(conn)) < 0) {
+        fprintf(stderr, "Could not get signature scheme\n");
+        S2N_ERROR(S2N_ERR_INVALID_SIGNATURE_SCHEME);
+    }
     printf("CONNECTED:\n");
     printf("Client hello version: %d\n", client_hello_version);
     printf("Client protocol version: %d\n", client_protocol_version);
     printf("Server protocol version: %d\n", server_protocol_version);
     printf("Actual protocol version: %d\n", actual_protocol_version);
+    printf("Signature scheme: 0x%04x\n", signature_scheme);
 
     if (s2n_get_server_name(conn)) {
         printf("Server name: %s\n", s2n_get_server_name(conn));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -826,6 +826,13 @@ int s2n_connection_get_signature_preferences(struct s2n_connection *conn, const 
 
 }
 
+int s2n_connection_get_signature_scheme(struct s2n_connection *conn)
+{
+    notnull_check(conn);
+
+    return conn->secure.conn_sig_scheme.iana_value;
+}
+
 int s2n_connection_get_ecc_preferences(struct s2n_connection *conn, const struct s2n_ecc_preferences **ecc_preferences)
 {
     notnull_check(conn);


### PR DESCRIPTION
### Resolved issues:

 resolves #1456 

### Description of changes: 

Print the signature scheme, primarily for testing in s2nc/d.

### Call-outs:


### Testing:

Local unit tests, manual s2nd run:

connecting with openssl s_client:
```
$ S2N_PRINT_STACKTRACE=1 S2N_INTEG_TEST=1 DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:./lib/ ./bin/s2nd localhost 9999 -c default_tls13 --https-server --tls13
Running s2nd in simple https server mode
Listening on localhost:9999
CONNECTED:
Client hello version: 33
Client protocol version: 34
Server protocol version: 34
Actual protocol version: 34
Signature scheme: 0x0804
Server name: localhost
Curve: x25519
KEM: NONE
Cipher negotiated: TLS_AES_256_GCM_SHA384
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
