### PR TITLE
Improve s2n_strcpy() to handle 1 byte arguments

### DIFF
--- a/utils/s2n_str.c
+++ b/utils/s2n_str.c
@@ -23,7 +23,7 @@ char *s2n_strcpy(char *buf, char *last, const char *str) {
 #pragma CPROVER check push
 #pragma CPROVER check disable "pointer"
 
-    if (buf >= last) {
+    if (buf > last) {
         return buf;
     }
 
@@ -40,7 +40,7 @@ char *s2n_strcpy(char *buf, char *last, const char *str) {
     size_t bytes_to_copy = MIN(last - buf - 1, strlen(str));
 
     char *p = buf;
-    if (bytes_to_copy > 0) {
+    if (bytes_to_copy > 1) {
         p = (char *)memcpy(buf, str, bytes_to_copy) + bytes_to_copy;
     }
     *p = '\0';


### PR DESCRIPTION
### Resolved issues:

s2n_strcpy() currently does nothing if it is invoked to copy a 1 byte string (returning early due to the buf >= last check).

### Description of changes: 

  To provide a more consistent behavior (that it NULL terminates the destination) and avoiding bugs, the ideal case would be to zero out the destination if a 1 byte buffer is submitted.  This patch does that.  

### Call-outs:

Ideally we should also document the behavior for some odd cases like that (the usage inside S2N itself is pretty much simple, but I'm afraid of other projects copying the code and misusing it).

### Testing:

I've done a simple C code that implements the s2n_strcpy() and added a few printouts and changed parameters to observe the output.  Not worth committing those tests though since it is pretty trivial to observe the code logic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
