### PR TITLE
utils: apply safety macro codemod script

### DIFF
--- a/bin/echo.c
+++ b/bin/echo.c
@@ -94,19 +94,19 @@ int negotiate(struct s2n_connection *conn, int fd)
 
     if ((client_hello_version = s2n_connection_get_client_hello_version(conn)) < 0) {
         fprintf(stderr, "Could not get client hello version\n");
-        S2N_ERROR(S2N_ERR_CLIENT_HELLO_VERSION);
+        POSIX_BAIL(S2N_ERR_CLIENT_HELLO_VERSION);
     }
     if ((client_protocol_version = s2n_connection_get_client_protocol_version(conn)) < 0) {
         fprintf(stderr, "Could not get client protocol version\n");
-        S2N_ERROR(S2N_ERR_CLIENT_PROTOCOL_VERSION);
+        POSIX_BAIL(S2N_ERR_CLIENT_PROTOCOL_VERSION);
     }
     if ((server_protocol_version = s2n_connection_get_server_protocol_version(conn)) < 0) {
         fprintf(stderr, "Could not get server protocol version\n");
-        S2N_ERROR(S2N_ERR_SERVER_PROTOCOL_VERSION);
+        POSIX_BAIL(S2N_ERR_SERVER_PROTOCOL_VERSION);
     }
     if ((actual_protocol_version = s2n_connection_get_actual_protocol_version(conn)) < 0) {
         fprintf(stderr, "Could not get actual protocol version\n");
-        S2N_ERROR(S2N_ERR_ACTUAL_PROTOCOL_VERSION);
+        POSIX_BAIL(S2N_ERR_ACTUAL_PROTOCOL_VERSION);
     }
     printf("CONNECTED:\n");
     printf("Client hello version: %d\n", client_hello_version);
@@ -253,14 +253,14 @@ int echo(struct s2n_connection *conn, int sockfd)
                         (readers[0].revents & POLLERR ) ? 1 : 0,
                         (readers[0].revents & POLLHUP ) ? 1 : 0,
                         (readers[0].revents & POLLNVAL ) ? 1 : 0);
-                S2N_ERROR(S2N_ERR_POLLING_FROM_SOCKET);
+                POSIX_BAIL(S2N_ERR_POLLING_FROM_SOCKET);
             }
 
             if (readers[1].revents & (POLLERR | POLLNVAL)) {
                 fprintf(stderr, "Error polling from socket: err=%d nval=%d\n",
                         (readers[1].revents & POLLERR ) ? 1 : 0,
                         (readers[1].revents & POLLNVAL ) ? 1 : 0);
-                S2N_ERROR(S2N_ERR_POLLING_FROM_SOCKET);
+                POSIX_BAIL(S2N_ERR_POLLING_FROM_SOCKET);
             }
         }
     } while (p < 0 && errno == EINTR);

--- a/bin/https.c
+++ b/bin/https.c
@@ -28,12 +28,12 @@ static s2n_blocked_status blocked;
 
 #define SEND(...) do { \
     sprintf(str_buffer, __VA_ARGS__); \
-    GUARD(s2n_send(conn, str_buffer, strlen(str_buffer), &blocked)); \
+    POSIX_GUARD(s2n_send(conn, str_buffer, strlen(str_buffer), &blocked)); \
 } while (0)
 
 #define BUFFER(...) do { \
     sprintf(str_buffer, __VA_ARGS__); \
-    GUARD(s2n_stuffer_write_bytes(&stuffer, (const uint8_t *)str_buffer, strlen(str_buffer))); \
+    POSIX_GUARD(s2n_stuffer_write_bytes(&stuffer, (const uint8_t *)str_buffer, strlen(str_buffer))); \
 } while (0)
 
 static int flush(uint32_t left, uint8_t *buffer, struct s2n_connection *conn, s2n_blocked_status *blocked_status)
@@ -69,7 +69,7 @@ int bench_handler(struct s2n_connection *conn, uint32_t bench) {
 
     while (bytes_remaining) {
         uint32_t buffer_remaining = bytes_remaining < len ? bytes_remaining : len;
-        GUARD(flush(buffer_remaining, big_buff, conn, &blocked));
+        POSIX_GUARD(flush(buffer_remaining, big_buff, conn, &blocked));
         bytes_remaining -= buffer_remaining;
     }
 
@@ -89,7 +89,7 @@ int https(struct s2n_connection *conn, uint32_t bench)
     }
 
     DEFER_CLEANUP(struct s2n_stuffer stuffer, s2n_stuffer_free);
-    GUARD(s2n_stuffer_growable_alloc(&stuffer, 1024));
+    POSIX_GUARD(s2n_stuffer_growable_alloc(&stuffer, 1024));
 
     BUFFER("<html><body><h1>Hello from s2n server</h1><pre>");
 
@@ -115,10 +115,10 @@ int https(struct s2n_connection *conn, uint32_t bench)
     uint32_t content_length = s2n_stuffer_data_available(&stuffer);
 
     uint8_t *content = s2n_stuffer_raw_read(&stuffer, content_length);
-    notnull_check(content);
+    POSIX_ENSURE_REF(content);
 
     HEADERS(content_length);
-    GUARD(flush(content_length, content, conn, &blocked));
+    POSIX_GUARD(flush(content_length, content, conn, &blocked));
 
     return S2N_SUCCESS;
 }

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -728,7 +728,7 @@ int main(int argc, char *const *argv)
             GUARD_EXIT(fstat(fd, &st), "Error fstat-ing session ticket key file");
 
             st_key = mmap(0, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
-            ENSURE_POSIX(st_key != MAP_FAILED, S2N_ERR_MMAP);
+            POSIX_ENSURE(st_key != MAP_FAILED, S2N_ERR_MMAP);
 
             st_key_length = st.st_size;
 

--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -49,22 +49,22 @@ static uint8_t s2n_aead_cipher_aes256_gcm_available()
 
 static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *aad, struct s2n_blob *in, struct s2n_blob *out)
 {
-    notnull_check(in);
-    notnull_check(out);
-    notnull_check(iv);
-    notnull_check(key);
-    notnull_check(aad);
+    POSIX_ENSURE_REF(in);
+    POSIX_ENSURE_REF(out);
+    POSIX_ENSURE_REF(iv);
+    POSIX_ENSURE_REF(key);
+    POSIX_ENSURE_REF(aad);
 
     /* The size of the |in| blob includes the size of the data and the size of the AES-GCM tag */
-    gte_check(in->size, S2N_TLS_GCM_TAG_LEN);
-    gte_check(out->size, in->size);
-    eq_check(iv->size, S2N_TLS_GCM_IV_LEN);
+    POSIX_ENSURE_GTE(in->size, S2N_TLS_GCM_TAG_LEN);
+    POSIX_ENSURE_GTE(out->size, in->size);
+    POSIX_ENSURE_EQ(iv->size, S2N_TLS_GCM_IV_LEN);
 
     /* Adjust input length to account for the Tag length */
     size_t in_len = in->size - S2N_TLS_GCM_TAG_LEN;
     size_t out_len = 0;
 
-    GUARD_OSSL(EVP_AEAD_CTX_seal(key->evp_aead_ctx, out->data, &out_len, out->size, iv->data, iv->size, in->data, in_len, aad->data, aad->size), S2N_ERR_ENCRYPT);
+    POSIX_GUARD_OSSL(EVP_AEAD_CTX_seal(key->evp_aead_ctx, out->data, &out_len, out->size, iv->data, iv->size, in->data, in_len, aad->data, aad->size), S2N_ERR_ENCRYPT);
 
     S2N_ERROR_IF((in_len + S2N_TLS_GCM_TAG_LEN) != out_len, S2N_ERR_ENCRYPT);
 
@@ -73,19 +73,19 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
 
 static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *aad, struct s2n_blob *in, struct s2n_blob *out)
 {
-    notnull_check(in);
-    notnull_check(out);
-    notnull_check(iv);
-    notnull_check(key);
-    notnull_check(aad);
+    POSIX_ENSURE_REF(in);
+    POSIX_ENSURE_REF(out);
+    POSIX_ENSURE_REF(iv);
+    POSIX_ENSURE_REF(key);
+    POSIX_ENSURE_REF(aad);
 
-    gte_check(in->size, S2N_TLS_GCM_TAG_LEN);
-    gte_check(out->size, in->size - S2N_TLS_GCM_TAG_LEN);
-    eq_check(iv->size, S2N_TLS_GCM_IV_LEN);
+    POSIX_ENSURE_GTE(in->size, S2N_TLS_GCM_TAG_LEN);
+    POSIX_ENSURE_GTE(out->size, in->size - S2N_TLS_GCM_TAG_LEN);
+    POSIX_ENSURE_EQ(iv->size, S2N_TLS_GCM_IV_LEN);
 
     size_t out_len = 0;
 
-    GUARD_OSSL(EVP_AEAD_CTX_open(key->evp_aead_ctx, out->data, &out_len, out->size, iv->data, iv->size, in->data, in->size, aad->data, aad->size), S2N_ERR_DECRYPT);
+    POSIX_GUARD_OSSL(EVP_AEAD_CTX_open(key->evp_aead_ctx, out->data, &out_len, out->size, iv->data, iv->size, in->data, in->size, aad->data, aad->size), S2N_ERR_DECRYPT);
 
     S2N_ERROR_IF((in->size - S2N_TLS_GCM_TAG_LEN) != out_len, S2N_ERR_ENCRYPT);
 
@@ -94,55 +94,55 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
 
 static int s2n_aead_cipher_aes128_gcm_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    notnull_check(key);
-    notnull_check(in);
+    POSIX_ENSURE_REF(key);
+    POSIX_ENSURE_REF(in);
 
-    eq_check(in->size, S2N_TLS_AES_128_GCM_KEY_LEN);
+    POSIX_ENSURE_EQ(in->size, S2N_TLS_AES_128_GCM_KEY_LEN);
 
-    GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_128_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_128_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
 
     return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes256_gcm_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    notnull_check(key);
-    notnull_check(in);
+    POSIX_ENSURE_REF(key);
+    POSIX_ENSURE_REF(in);
 
-    eq_check(in->size, S2N_TLS_AES_256_GCM_KEY_LEN);
+    POSIX_ENSURE_EQ(in->size, S2N_TLS_AES_256_GCM_KEY_LEN);
 
-    GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_256_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_256_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
 
     return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes128_gcm_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    notnull_check(key);
-    notnull_check(in);
+    POSIX_ENSURE_REF(key);
+    POSIX_ENSURE_REF(in);
 
-    eq_check(in->size, S2N_TLS_AES_128_GCM_KEY_LEN);
+    POSIX_ENSURE_EQ(in->size, S2N_TLS_AES_128_GCM_KEY_LEN);
 
-    GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_128_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_128_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
 
     return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes256_gcm_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    notnull_check(key);
-    notnull_check(in);
+    POSIX_ENSURE_REF(key);
+    POSIX_ENSURE_REF(in);
 
-    eq_check(in->size, S2N_TLS_AES_256_GCM_KEY_LEN);
+    POSIX_ENSURE_EQ(in->size, S2N_TLS_AES_256_GCM_KEY_LEN);
 
-    GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_256_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_AEAD_CTX_init(key->evp_aead_ctx, EVP_aead_aes_256_gcm(), in->data, in->size, S2N_TLS_GCM_TAG_LEN, NULL), S2N_ERR_KEY_INIT);
 
     return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes_gcm_init(struct s2n_session_key *key)
 {
-    notnull_check(key);
+    POSIX_ENSURE_REF(key);
 
     EVP_AEAD_CTX_zero(key->evp_aead_ctx);
 
@@ -151,7 +151,7 @@ static int s2n_aead_cipher_aes_gcm_init(struct s2n_session_key *key)
 
 static int s2n_aead_cipher_aes_gcm_destroy_key(struct s2n_session_key *key)
 {
-    notnull_check(key);
+    POSIX_ENSURE_REF(key);
 
     EVP_AEAD_CTX_cleanup(key->evp_aead_ctx);
 
@@ -163,12 +163,12 @@ static int s2n_aead_cipher_aes_gcm_destroy_key(struct s2n_session_key *key)
 static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *aad, struct s2n_blob *in, struct s2n_blob *out)
 {
     /* The size of the |in| blob includes the size of the data and the size of the ChaCha20-Poly1305 tag */
-    gte_check(in->size, S2N_TLS_GCM_TAG_LEN);
-    gte_check(out->size, in->size);
-    eq_check(iv->size, S2N_TLS_GCM_IV_LEN);
+    POSIX_ENSURE_GTE(in->size, S2N_TLS_GCM_TAG_LEN);
+    POSIX_ENSURE_GTE(out->size, in->size);
+    POSIX_ENSURE_EQ(iv->size, S2N_TLS_GCM_IV_LEN);
 
     /* Initialize the IV */
-    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
     /* Adjust input length and buffer pointer to account for the Tag length */
     int in_len = in->size - S2N_TLS_GCM_TAG_LEN;
@@ -176,19 +176,19 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
 
     int out_len;
     /* Specify the AAD */
-    GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size), S2N_ERR_ENCRYPT);
+    POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size), S2N_ERR_ENCRYPT);
 
     /* Encrypt the data */
-    GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &out_len, in->data, in_len), S2N_ERR_ENCRYPT);
+    POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &out_len, in->data, in_len), S2N_ERR_ENCRYPT);
 
     /* When using AES-GCM, *out_len is the number of bytes written by EVP_EncryptUpdate. Since the tag is not written during this call, we do not take S2N_TLS_GCM_TAG_LEN into account */
     S2N_ERROR_IF(in_len != out_len, S2N_ERR_ENCRYPT);
 
     /* Finalize */
-    GUARD_OSSL(EVP_EncryptFinal_ex(key->evp_cipher_ctx, out->data, &out_len), S2N_ERR_ENCRYPT);
+    POSIX_GUARD_OSSL(EVP_EncryptFinal_ex(key->evp_cipher_ctx, out->data, &out_len), S2N_ERR_ENCRYPT);
 
     /* write the tag */
-    GUARD_OSSL(EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_GET_TAG, S2N_TLS_GCM_TAG_LEN, tag_data), S2N_ERR_ENCRYPT);
+    POSIX_GUARD_OSSL(EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_GET_TAG, S2N_TLS_GCM_TAG_LEN, tag_data), S2N_ERR_ENCRYPT);
 
     /* When using AES-GCM, EVP_EncryptFinal_ex does not write any bytes. So, we should expect *out_len = 0. */
     S2N_ERROR_IF(0 != out_len, S2N_ERR_ENCRYPT);
@@ -198,23 +198,23 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
 
 static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *aad, struct s2n_blob *in, struct s2n_blob *out)
 {
-    gte_check(in->size, S2N_TLS_GCM_TAG_LEN);
-    gte_check(out->size, in->size);
-    eq_check(iv->size, S2N_TLS_GCM_IV_LEN);
+    POSIX_ENSURE_GTE(in->size, S2N_TLS_GCM_TAG_LEN);
+    POSIX_ENSURE_GTE(out->size, in->size);
+    POSIX_ENSURE_EQ(iv->size, S2N_TLS_GCM_IV_LEN);
 
     /* Initialize the IV */
-    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
     /* Adjust input length and buffer pointer to account for the Tag length */
     int in_len = in->size - S2N_TLS_GCM_TAG_LEN;
     uint8_t *tag_data = in->data + in->size - S2N_TLS_GCM_TAG_LEN;
 
     /* Set the TAG */
-    GUARD_OSSL(EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_TAG, S2N_TLS_GCM_TAG_LEN, tag_data), S2N_ERR_DECRYPT);
+    POSIX_GUARD_OSSL(EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_TAG, S2N_TLS_GCM_TAG_LEN, tag_data), S2N_ERR_DECRYPT);
 
     int out_len;
     /* Specify the AAD */
-    GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size), S2N_ERR_DECRYPT);
+    POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size), S2N_ERR_DECRYPT);
 
     int evp_decrypt_rc = 1;
     /* Decrypt the data, but don't short circuit tag verification. EVP_Decrypt* return 0 on failure, 1 for success. */
@@ -232,52 +232,52 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
 
 static int s2n_aead_cipher_aes128_gcm_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    eq_check(in->size, S2N_TLS_AES_128_GCM_KEY_LEN);
+    POSIX_ENSURE_EQ(in->size, S2N_TLS_AES_128_GCM_KEY_LEN);
 
-    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_gcm(), NULL, NULL, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_gcm(), NULL, NULL, NULL), S2N_ERR_KEY_INIT);
 
     EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
 
-    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes256_gcm_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    eq_check(in->size, S2N_TLS_AES_256_GCM_KEY_LEN);
+    POSIX_ENSURE_EQ(in->size, S2N_TLS_AES_256_GCM_KEY_LEN);
 
-    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_gcm(), NULL, NULL, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_gcm(), NULL, NULL, NULL), S2N_ERR_KEY_INIT);
 
     EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
 
-    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes128_gcm_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    eq_check(in->size, S2N_TLS_AES_128_GCM_KEY_LEN);
+    POSIX_ENSURE_EQ(in->size, S2N_TLS_AES_128_GCM_KEY_LEN);
 
-    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_gcm(), NULL, NULL, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_gcm(), NULL, NULL, NULL), S2N_ERR_KEY_INIT);
 
     EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
 
-    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return S2N_SUCCESS;
 }
 
 static int s2n_aead_cipher_aes256_gcm_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    eq_check(in->size, S2N_TLS_AES_256_GCM_KEY_LEN);
+    POSIX_ENSURE_EQ(in->size, S2N_TLS_AES_256_GCM_KEY_LEN);
 
-    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_gcm(), NULL, NULL, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_gcm(), NULL, NULL, NULL), S2N_ERR_KEY_INIT);
 
     EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_IVLEN, S2N_TLS_GCM_IV_LEN, NULL);
 
-    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return S2N_SUCCESS;
 }

--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -30,12 +30,12 @@ static uint8_t s2n_cbc_cipher_3des_available()
 
 static int s2n_cbc_cipher_3des_encrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *in, struct s2n_blob *out)
 {
-    gte_check(out->size, in->size);
+    POSIX_ENSURE_GTE(out->size, in->size);
 
-    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
     int len = out->size;
-    GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
+    POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
     S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
 
     return 0;
@@ -43,32 +43,32 @@ static int s2n_cbc_cipher_3des_encrypt(struct s2n_session_key *key, struct s2n_b
 
 static int s2n_cbc_cipher_3des_decrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *in, struct s2n_blob *out)
 {
-    gte_check(out->size, in->size);
+    POSIX_ENSURE_GTE(out->size, in->size);
 
-    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
     int len = out->size;
-    GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
+    POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
 
     return 0;
 }
 
 static int s2n_cbc_cipher_3des_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    eq_check(in->size, 192 / 8);
+    POSIX_ENSURE_EQ(in->size, 192 / 8);
 
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 }
 
 static int s2n_cbc_cipher_3des_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    eq_check(in->size, 192 / 8);
+    POSIX_ENSURE_EQ(in->size, 192 / 8);
 
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 }

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -35,12 +35,12 @@ static uint8_t s2n_cbc_cipher_aes256_available()
 
 static int s2n_cbc_cipher_aes_encrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *in, struct s2n_blob *out)
 {
-    gte_check(out->size, in->size);
+    POSIX_ENSURE_GTE(out->size, in->size);
 
-    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
     int len = out->size;
-    GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
+    POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
     S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
 
     return 0;
@@ -48,52 +48,52 @@ static int s2n_cbc_cipher_aes_encrypt(struct s2n_session_key *key, struct s2n_bl
 
 int s2n_cbc_cipher_aes_decrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *in, struct s2n_blob *out)
 {
-    gte_check(out->size, in->size);
+    POSIX_ENSURE_GTE(out->size, in->size);
 
-    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
     int len = out->size;
-    GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
+    POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
 
     return 0;
 }
 
 int s2n_cbc_cipher_aes128_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    eq_check(in->size, 128 / 8);
+    POSIX_ENSURE_EQ(in->size, 128 / 8);
 
     /* Always returns 1 */
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 }
 
 static int s2n_cbc_cipher_aes128_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    eq_check(in->size, 128 / 8);
+    POSIX_ENSURE_EQ(in->size, 128 / 8);
 
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 }
 
 static int s2n_cbc_cipher_aes256_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    eq_check(in->size, 256 / 8);
+    POSIX_ENSURE_EQ(in->size, 256 / 8);
 
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 }
 
 int s2n_cbc_cipher_aes256_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    eq_check(in->size, 256 / 8);
+    POSIX_ENSURE_EQ(in->size, 256 / 8);
 
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
-    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 }

--- a/crypto/s2n_cipher.c
+++ b/crypto/s2n_cipher.c
@@ -24,10 +24,10 @@
 
 int s2n_session_key_alloc(struct s2n_session_key *key)
 {
-    eq_check(key->evp_cipher_ctx, NULL);
-    notnull_check(key->evp_cipher_ctx = EVP_CIPHER_CTX_new());
+    POSIX_ENSURE_EQ(key->evp_cipher_ctx, NULL);
+    POSIX_ENSURE_REF(key->evp_cipher_ctx = EVP_CIPHER_CTX_new());
 #if defined(S2N_CIPHER_AEAD_API_AVAILABLE)
-    eq_check(key->evp_aead_ctx, NULL);
+    POSIX_ENSURE_EQ(key->evp_aead_ctx, NULL);
     key->evp_aead_ctx = OPENSSL_malloc(sizeof(EVP_AEAD_CTX));
     if (key->evp_aead_ctx == NULL) {
         EVP_CIPHER_CTX_free(key->evp_cipher_ctx);

--- a/crypto/s2n_dhe.c
+++ b/crypto/s2n_dhe.c
@@ -72,14 +72,14 @@ static const BIGNUM *s2n_get_g_dh_param(struct s2n_dh_params *dh_params)
 
 static int s2n_check_p_g_dh_params(struct s2n_dh_params *dh_params)
 {
-    notnull_check(dh_params);
-    notnull_check(dh_params->dh);
+    POSIX_ENSURE_REF(dh_params);
+    POSIX_ENSURE_REF(dh_params->dh);
 
     const BIGNUM *p = s2n_get_p_dh_param(dh_params);
     const BIGNUM *g = s2n_get_g_dh_param(dh_params);
 
-    notnull_check(g);
-    notnull_check(p);
+    POSIX_ENSURE_REF(g);
+    POSIX_ENSURE_REF(p);
 
     S2N_ERROR_IF(DH_size(dh_params->dh) < S2N_MIN_DH_PRIME_SIZE_BYTES, S2N_ERR_DH_PARAMS_CREATE);
     S2N_ERROR_IF(BN_is_zero(g), S2N_ERR_DH_PARAMS_CREATE);
@@ -92,7 +92,7 @@ static int s2n_check_pub_key_dh_params(struct s2n_dh_params *dh_params)
 {
     const BIGNUM *pub_key = s2n_get_Ys_dh_param(dh_params);
 
-    notnull_check(pub_key);
+    POSIX_ENSURE_REF(pub_key);
 
     S2N_ERROR_IF(BN_is_zero(pub_key), S2N_ERR_DH_PARAMS_CREATE);
 
@@ -102,9 +102,9 @@ static int s2n_check_pub_key_dh_params(struct s2n_dh_params *dh_params)
 static int s2n_set_p_g_Ys_dh_params(struct s2n_dh_params *dh_params, struct s2n_blob *p, struct s2n_blob *g,
                                     struct s2n_blob *Ys)
 {
-    ENSURE_POSIX(p->size <= INT_MAX, S2N_ERR_INTEGER_OVERFLOW);
-    ENSURE_POSIX(g->size <= INT_MAX, S2N_ERR_INTEGER_OVERFLOW);
-    ENSURE_POSIX(Ys->size <= INT_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    POSIX_ENSURE(p->size <= INT_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    POSIX_ENSURE(g->size <= INT_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    POSIX_ENSURE(Ys->size <= INT_MAX, S2N_ERR_INTEGER_OVERFLOW);
     BIGNUM *bn_p  = BN_bin2bn(( const unsigned char * )p->data, p->size, NULL);
     BIGNUM *bn_g  = BN_bin2bn(( const unsigned char * )g->data, g->size, NULL);
     BIGNUM *bn_Ys = BN_bin2bn(( const unsigned char * )Ys->data, Ys->size, NULL);
@@ -113,10 +113,10 @@ static int s2n_set_p_g_Ys_dh_params(struct s2n_dh_params *dh_params, struct s2n_
     /* Per https://www.openssl.org/docs/man1.1.0/crypto/DH_get0_pqg.html:
 	* values that have been passed in should not be freed directly after this function has been called
 	*/
-    GUARD_OSSL(DH_set0_pqg(dh_params->dh, bn_p, NULL, bn_g), S2N_ERR_DH_PARAMS_CREATE);
+    POSIX_GUARD_OSSL(DH_set0_pqg(dh_params->dh, bn_p, NULL, bn_g), S2N_ERR_DH_PARAMS_CREATE);
 
     /* Same as DH_set0_pqg */
-    GUARD_OSSL(DH_set0_key(dh_params->dh, bn_Ys, NULL), S2N_ERR_DH_PARAMS_CREATE);
+    POSIX_GUARD_OSSL(DH_set0_key(dh_params->dh, bn_Ys, NULL), S2N_ERR_DH_PARAMS_CREATE);
 #else
     dh_params->dh->p       = bn_p;
     dh_params->dh->g       = bn_g;
@@ -128,34 +128,34 @@ static int s2n_set_p_g_Ys_dh_params(struct s2n_dh_params *dh_params, struct s2n_
 
 int s2n_check_all_dh_params(struct s2n_dh_params *dh_params)
 {
-    GUARD(s2n_check_p_g_dh_params(dh_params));
-    GUARD(s2n_check_pub_key_dh_params(dh_params));
+    POSIX_GUARD(s2n_check_p_g_dh_params(dh_params));
+    POSIX_GUARD(s2n_check_pub_key_dh_params(dh_params));
 
     return S2N_SUCCESS;
 }
 
 int s2n_pkcs3_to_dh_params(struct s2n_dh_params *dh_params, struct s2n_blob *pkcs3)
 {
-    notnull_check(dh_params);
-    PRECONDITION_POSIX(s2n_blob_validate(pkcs3));
+    POSIX_ENSURE_REF(dh_params);
+    POSIX_PRECONDITION(s2n_blob_validate(pkcs3));
 
     uint8_t *original_ptr = pkcs3->data;
     dh_params->dh         = d2i_DHparams(NULL, ( const unsigned char ** )( void * )&pkcs3->data, pkcs3->size);
-    GUARD(s2n_check_p_g_dh_params(dh_params));
+    POSIX_GUARD(s2n_check_p_g_dh_params(dh_params));
     if (pkcs3->data - original_ptr != pkcs3->size) {
         DH_free(dh_params->dh);
-        S2N_ERROR(S2N_ERR_INVALID_PKCS3);
+        POSIX_BAIL(S2N_ERR_INVALID_PKCS3);
     }
     pkcs3->data = original_ptr;
 
     /* Require at least 2048 bits for the DH size */
     if (DH_size(dh_params->dh) < S2N_MIN_DH_PRIME_SIZE_BYTES) {
         DH_free(dh_params->dh);
-        S2N_ERROR(S2N_ERR_DH_TOO_SMALL);
+        POSIX_BAIL(S2N_ERR_DH_TOO_SMALL);
     }
 
     /* Check the generator and prime */
-    GUARD(s2n_dh_params_check(dh_params));
+    POSIX_GUARD(s2n_dh_params_check(dh_params));
 
     return S2N_SUCCESS;
 }
@@ -163,25 +163,25 @@ int s2n_pkcs3_to_dh_params(struct s2n_dh_params *dh_params, struct s2n_blob *pkc
 int s2n_dh_p_g_Ys_to_dh_params(struct s2n_dh_params *server_dh_params, struct s2n_blob *p, struct s2n_blob *g,
                                struct s2n_blob *Ys)
 {
-    ENSURE_POSIX_REF(server_dh_params);
-    PRECONDITION_POSIX(s2n_blob_validate(p));
-    PRECONDITION_POSIX(s2n_blob_validate(g));
-    PRECONDITION_POSIX(s2n_blob_validate(Ys));
+    POSIX_ENSURE_REF(server_dh_params);
+    POSIX_PRECONDITION(s2n_blob_validate(p));
+    POSIX_PRECONDITION(s2n_blob_validate(g));
+    POSIX_PRECONDITION(s2n_blob_validate(Ys));
 
     server_dh_params->dh = DH_new();
-    ENSURE_POSIX(server_dh_params->dh != NULL, S2N_ERR_DH_PARAMS_CREATE);
+    POSIX_ENSURE(server_dh_params->dh != NULL, S2N_ERR_DH_PARAMS_CREATE);
 
-    GUARD(s2n_set_p_g_Ys_dh_params(server_dh_params, p, g, Ys));
-    GUARD(s2n_check_all_dh_params(server_dh_params));
+    POSIX_GUARD(s2n_set_p_g_Ys_dh_params(server_dh_params, p, g, Ys));
+    POSIX_GUARD(s2n_check_all_dh_params(server_dh_params));
 
     return S2N_SUCCESS;
 }
 
 int s2n_dh_params_to_p_g_Ys(struct s2n_dh_params *server_dh_params, struct s2n_stuffer *out, struct s2n_blob *output)
 {
-    GUARD(s2n_check_all_dh_params(server_dh_params));
-    PRECONDITION_POSIX(s2n_stuffer_validate(out));
-    PRECONDITION_POSIX(s2n_blob_validate(output));
+    POSIX_GUARD(s2n_check_all_dh_params(server_dh_params));
+    POSIX_PRECONDITION(s2n_stuffer_validate(out));
+    POSIX_PRECONDITION(s2n_blob_validate(output));
 
     const BIGNUM *bn_p  = s2n_get_p_dh_param(server_dh_params);
     const BIGNUM *bn_g  = s2n_get_g_dh_param(server_dh_params);
@@ -195,22 +195,22 @@ int s2n_dh_params_to_p_g_Ys(struct s2n_dh_params *server_dh_params, struct s2n_s
     uint8_t *Ys = NULL;
 
     output->data = s2n_stuffer_raw_write(out, 0);
-    notnull_check(output->data);
+    POSIX_ENSURE_REF(output->data);
 
-    GUARD(s2n_stuffer_write_uint16(out, p_size));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, p_size));
     p = s2n_stuffer_raw_write(out, p_size);
-    notnull_check(p);
-    ENSURE_POSIX(BN_bn2bin(bn_p, p) == p_size, S2N_ERR_DH_SERIALIZING);
+    POSIX_ENSURE_REF(p);
+    POSIX_ENSURE(BN_bn2bin(bn_p, p) == p_size, S2N_ERR_DH_SERIALIZING);
 
-    GUARD(s2n_stuffer_write_uint16(out, g_size));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, g_size));
     g = s2n_stuffer_raw_write(out, g_size);
-    notnull_check(g);
-    ENSURE_POSIX(BN_bn2bin(bn_g, g) == g_size, S2N_ERR_DH_SERIALIZING);
+    POSIX_ENSURE_REF(g);
+    POSIX_ENSURE(BN_bn2bin(bn_g, g) == g_size, S2N_ERR_DH_SERIALIZING);
 
-    GUARD(s2n_stuffer_write_uint16(out, Ys_size));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, Ys_size));
     Ys = s2n_stuffer_raw_write(out, Ys_size);
-    notnull_check(Ys);
-    ENSURE_POSIX(BN_bn2bin(bn_Ys, Ys) == Ys_size, S2N_ERR_DH_SERIALIZING);
+    POSIX_ENSURE_REF(Ys);
+    POSIX_ENSURE(BN_bn2bin(bn_Ys, Ys) == Ys_size, S2N_ERR_DH_SERIALIZING);
 
     output->size = p_size + 2 + g_size + 2 + Ys_size + 2;
 
@@ -225,40 +225,40 @@ int s2n_dh_compute_shared_secret_as_client(struct s2n_dh_params *server_dh_param
     uint16_t             client_pub_key_size = 0;
     int                  shared_key_size = 0;
 
-    GUARD(s2n_dh_params_check(server_dh_params));
-    GUARD(s2n_dh_params_copy(server_dh_params, &client_params));
-    GUARD(s2n_dh_generate_ephemeral_key(&client_params));
-    GUARD(s2n_alloc(shared_key, DH_size(server_dh_params->dh)));
+    POSIX_GUARD(s2n_dh_params_check(server_dh_params));
+    POSIX_GUARD(s2n_dh_params_copy(server_dh_params, &client_params));
+    POSIX_GUARD(s2n_dh_generate_ephemeral_key(&client_params));
+    POSIX_GUARD(s2n_alloc(shared_key, DH_size(server_dh_params->dh)));
 
     const BIGNUM *client_pub_key_bn = s2n_get_Ys_dh_param(&client_params);
-    ENSURE_POSIX_REF(client_pub_key_bn);
+    POSIX_ENSURE_REF(client_pub_key_bn);
     client_pub_key_size             = BN_num_bytes(client_pub_key_bn);
-    GUARD(s2n_stuffer_write_uint16(Yc_out, client_pub_key_size));
+    POSIX_GUARD(s2n_stuffer_write_uint16(Yc_out, client_pub_key_size));
     client_pub_key = s2n_stuffer_raw_write(Yc_out, client_pub_key_size);
     if (client_pub_key == NULL) {
-        GUARD(s2n_free(shared_key));
-        GUARD(s2n_dh_params_free(&client_params));
-        S2N_ERROR(S2N_ERR_DH_WRITING_PUBLIC_KEY);
+        POSIX_GUARD(s2n_free(shared_key));
+        POSIX_GUARD(s2n_dh_params_free(&client_params));
+        POSIX_BAIL(S2N_ERR_DH_WRITING_PUBLIC_KEY);
     }
 
     if (BN_bn2bin(client_pub_key_bn, client_pub_key) != client_pub_key_size) {
-        GUARD(s2n_free(shared_key));
-        GUARD(s2n_dh_params_free(&client_params));
-        S2N_ERROR(S2N_ERR_DH_COPYING_PUBLIC_KEY);
+        POSIX_GUARD(s2n_free(shared_key));
+        POSIX_GUARD(s2n_dh_params_free(&client_params));
+        POSIX_BAIL(S2N_ERR_DH_COPYING_PUBLIC_KEY);
     }
 
     /* server_dh_params already validated */
     const BIGNUM *server_pub_key_bn = s2n_get_Ys_dh_param(server_dh_params);
     shared_key_size                 = DH_compute_key(shared_key->data, server_pub_key_bn, client_params.dh);
     if (shared_key_size < 0) {
-        GUARD(s2n_free(shared_key));
-        GUARD(s2n_dh_params_free(&client_params));
-        S2N_ERROR(S2N_ERR_DH_SHARED_SECRET);
+        POSIX_GUARD(s2n_free(shared_key));
+        POSIX_GUARD(s2n_dh_params_free(&client_params));
+        POSIX_BAIL(S2N_ERR_DH_SHARED_SECRET);
     }
 
     shared_key->size = shared_key_size;
 
-    GUARD(s2n_dh_params_free(&client_params));
+    POSIX_GUARD(s2n_dh_params_free(&client_params));
 
     return S2N_SUCCESS;
 }
@@ -271,23 +271,23 @@ int s2n_dh_compute_shared_secret_as_server(struct s2n_dh_params *server_dh_param
     int             shared_key_size = 0;
     BIGNUM *        pub_key = NULL;
 
-    GUARD(s2n_check_all_dh_params(server_dh_params));
+    POSIX_GUARD(s2n_check_all_dh_params(server_dh_params));
 
-    GUARD(s2n_stuffer_read_uint16(Yc_in, &Yc_length));
+    POSIX_GUARD(s2n_stuffer_read_uint16(Yc_in, &Yc_length));
     Yc.size = Yc_length;
     Yc.data = s2n_stuffer_raw_read(Yc_in, Yc.size);
-    notnull_check(Yc.data);
+    POSIX_ENSURE_REF(Yc.data);
 
     pub_key = BN_bin2bn(( const unsigned char * )Yc.data, Yc.size, NULL);
-    notnull_check(pub_key);
+    POSIX_ENSURE_REF(pub_key);
     int server_dh_params_size = DH_size(server_dh_params->dh);
-    ENSURE_POSIX(server_dh_params_size <= INT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
-    GUARD(s2n_alloc(shared_key, server_dh_params_size));
+    POSIX_ENSURE(server_dh_params_size <= INT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    POSIX_GUARD(s2n_alloc(shared_key, server_dh_params_size));
 
     shared_key_size = DH_compute_key(shared_key->data, pub_key, server_dh_params->dh);
     if (shared_key_size <= 0) {
         BN_free(pub_key);
-        S2N_ERROR(S2N_ERR_DH_SHARED_SECRET);
+        POSIX_BAIL(S2N_ERR_DH_SHARED_SECRET);
     }
 
     shared_key->size = shared_key_size;
@@ -299,39 +299,39 @@ int s2n_dh_compute_shared_secret_as_server(struct s2n_dh_params *server_dh_param
 
 int s2n_dh_params_check(struct s2n_dh_params *dh_params)
 {
-    notnull_check(dh_params);
-    notnull_check(dh_params->dh);
+    POSIX_ENSURE_REF(dh_params);
+    POSIX_ENSURE_REF(dh_params->dh);
     int codes = 0;
 
-    GUARD_OSSL(DH_check(dh_params->dh, &codes), S2N_ERR_DH_PARAMETER_CHECK);
-    ENSURE_POSIX(codes == 0, S2N_ERR_DH_PARAMETER_CHECK);
+    POSIX_GUARD_OSSL(DH_check(dh_params->dh, &codes), S2N_ERR_DH_PARAMETER_CHECK);
+    POSIX_ENSURE(codes == 0, S2N_ERR_DH_PARAMETER_CHECK);
 
     return S2N_SUCCESS;
 }
 
 int s2n_dh_params_copy(struct s2n_dh_params *from, struct s2n_dh_params *to)
 {
-    GUARD(s2n_check_p_g_dh_params(from));
-    notnull_check(to);
+    POSIX_GUARD(s2n_check_p_g_dh_params(from));
+    POSIX_ENSURE_REF(to);
 
     to->dh = DHparams_dup(from->dh);
-    ENSURE_POSIX(to->dh != NULL, S2N_ERR_DH_COPYING_PARAMETERS);
+    POSIX_ENSURE(to->dh != NULL, S2N_ERR_DH_COPYING_PARAMETERS);
 
     return S2N_SUCCESS;
 }
 
 int s2n_dh_generate_ephemeral_key(struct s2n_dh_params *dh_params)
 {
-    GUARD(s2n_check_p_g_dh_params(dh_params));
+    POSIX_GUARD(s2n_check_p_g_dh_params(dh_params));
 
-    GUARD_OSSL(DH_generate_key(dh_params->dh), S2N_ERR_DH_GENERATING_PARAMETERS);
+    POSIX_GUARD_OSSL(DH_generate_key(dh_params->dh), S2N_ERR_DH_GENERATING_PARAMETERS);
 
     return S2N_SUCCESS;
 }
 
 int s2n_dh_params_free(struct s2n_dh_params *dh_params)
 {
-    notnull_check(dh_params);
+    POSIX_ENSURE_REF(dh_params);
     DH_free(dh_params->dh);
     dh_params->dh = NULL;
 

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -44,28 +44,28 @@ int s2n_increment_drbg_counter(struct s2n_blob *counter)
 
 static int s2n_drbg_block_encrypt(EVP_CIPHER_CTX * ctx, uint8_t in[S2N_DRBG_BLOCK_SIZE], uint8_t out[S2N_DRBG_BLOCK_SIZE])
 {
-    notnull_check(ctx);
+    POSIX_ENSURE_REF(ctx);
     int len = S2N_DRBG_BLOCK_SIZE;
-    GUARD_OSSL(EVP_EncryptUpdate(ctx, out, &len, in, S2N_DRBG_BLOCK_SIZE), S2N_ERR_DRBG);
-    eq_check(len, S2N_DRBG_BLOCK_SIZE);
+    POSIX_GUARD_OSSL(EVP_EncryptUpdate(ctx, out, &len, in, S2N_DRBG_BLOCK_SIZE), S2N_ERR_DRBG);
+    POSIX_ENSURE_EQ(len, S2N_DRBG_BLOCK_SIZE);
 
     return 0;
 }
 
 static int s2n_drbg_bits(struct s2n_drbg *drbg, struct s2n_blob *out)
 {
-    notnull_check(drbg);
-    notnull_check(drbg->ctx);
-    notnull_check(out);
+    POSIX_ENSURE_REF(drbg);
+    POSIX_ENSURE_REF(drbg->ctx);
+    POSIX_ENSURE_REF(out);
 
     struct s2n_blob value = {0};
-    GUARD(s2n_blob_init(&value, drbg->v, sizeof(drbg->v)));
+    POSIX_GUARD(s2n_blob_init(&value, drbg->v, sizeof(drbg->v)));
     int block_aligned_size = out->size - (out->size % S2N_DRBG_BLOCK_SIZE);
 
     /* Per NIST SP800-90A 10.2.1.2: */
     for (int i = 0; i < block_aligned_size; i += S2N_DRBG_BLOCK_SIZE) {
-        GUARD(s2n_increment_drbg_counter(&value));
-        GUARD(s2n_drbg_block_encrypt(drbg->ctx, drbg->v, out->data + i));
+        POSIX_GUARD(s2n_increment_drbg_counter(&value));
+        POSIX_GUARD(s2n_drbg_block_encrypt(drbg->ctx, drbg->v, out->data + i));
         drbg->bytes_used += S2N_DRBG_BLOCK_SIZE;
     }
 
@@ -74,25 +74,25 @@ static int s2n_drbg_bits(struct s2n_drbg *drbg, struct s2n_blob *out)
     }
 
     uint8_t spare_block[S2N_DRBG_BLOCK_SIZE];
-    GUARD(s2n_increment_drbg_counter(&value));
-    GUARD(s2n_drbg_block_encrypt(drbg->ctx, drbg->v, spare_block));
+    POSIX_GUARD(s2n_increment_drbg_counter(&value));
+    POSIX_GUARD(s2n_drbg_block_encrypt(drbg->ctx, drbg->v, spare_block));
     drbg->bytes_used += S2N_DRBG_BLOCK_SIZE;
 
-    memcpy_check(out->data + block_aligned_size, spare_block, out->size - block_aligned_size);
+    POSIX_CHECKED_MEMCPY(out->data + block_aligned_size, spare_block, out->size - block_aligned_size);
 
     return 0;
 }
 
 static int s2n_drbg_update(struct s2n_drbg *drbg, struct s2n_blob *provided_data)
 {
-    notnull_check(drbg);
-    notnull_check(drbg->ctx);
+    POSIX_ENSURE_REF(drbg);
+    POSIX_ENSURE_REF(drbg->ctx);
 
     s2n_stack_blob(temp_blob, s2n_drbg_seed_size(drgb), S2N_DRBG_MAX_SEED_SIZE);
 
-    eq_check(provided_data->size, s2n_drbg_seed_size(drbg));
+    POSIX_ENSURE_EQ(provided_data->size, s2n_drbg_seed_size(drbg));
 
-    GUARD(s2n_drbg_bits(drbg, &temp_blob));
+    POSIX_GUARD(s2n_drbg_bits(drbg, &temp_blob));
 
     /* XOR in the provided data */
     for (int i = 0; i < provided_data->size; i++) {
@@ -100,26 +100,26 @@ static int s2n_drbg_update(struct s2n_drbg *drbg, struct s2n_blob *provided_data
     }
 
     /* Update the key and value */
-    GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, NULL, NULL, temp_blob.data, NULL), S2N_ERR_DRBG);
+    POSIX_GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, NULL, NULL, temp_blob.data, NULL), S2N_ERR_DRBG);
 
-    memcpy_check(drbg->v, temp_blob.data + s2n_drbg_key_size(drbg), S2N_DRBG_BLOCK_SIZE);
+    POSIX_CHECKED_MEMCPY(drbg->v, temp_blob.data + s2n_drbg_key_size(drbg), S2N_DRBG_BLOCK_SIZE);
 
     return 0;
 }
 
 static int s2n_drbg_mix_in_entropy(struct s2n_drbg *drbg, struct s2n_blob *entropy, struct s2n_blob *ps)
 {
-    notnull_check(drbg);
-    notnull_check(drbg->ctx);
-    notnull_check(entropy);
+    POSIX_ENSURE_REF(drbg);
+    POSIX_ENSURE_REF(drbg->ctx);
+    POSIX_ENSURE_REF(entropy);
 
-    gte_check(entropy->size, ps->size);
+    POSIX_ENSURE_GTE(entropy->size, ps->size);
 
     for (int i = 0; i < ps->size; i++) {
         entropy->data[i] ^= ps->data[i];
     }
 
-    GUARD(s2n_drbg_update(drbg, entropy));
+    POSIX_GUARD(s2n_drbg_update(drbg, entropy));
 
     return 0;
 }
@@ -128,8 +128,8 @@ static int s2n_drbg_seed(struct s2n_drbg *drbg, struct s2n_blob *ps)
 {
     s2n_stack_blob(blob, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
 
-    GUARD_AS_POSIX(s2n_get_seed_entropy(&blob));
-    GUARD(s2n_drbg_mix_in_entropy(drbg, &blob, ps));
+    POSIX_GUARD_RESULT(s2n_get_seed_entropy(&blob));
+    POSIX_GUARD(s2n_drbg_mix_in_entropy(drbg, &blob, ps));
 
     drbg->bytes_used = 0;
 
@@ -140,8 +140,8 @@ static int s2n_drbg_mix(struct s2n_drbg *drbg, struct s2n_blob *ps)
 {
     s2n_stack_blob(blob, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
 
-    GUARD_AS_POSIX(s2n_get_mix_entropy(&blob));
-    GUARD(s2n_drbg_mix_in_entropy(drbg, &blob, ps));
+    POSIX_GUARD_RESULT(s2n_get_mix_entropy(&blob));
+    POSIX_GUARD(s2n_drbg_mix_in_entropy(drbg, &blob, ps));
 
     drbg->mixes += 1;
 
@@ -150,7 +150,7 @@ static int s2n_drbg_mix(struct s2n_drbg *drbg, struct s2n_blob *ps)
 
 int s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personalization_string, const s2n_drbg_mode mode)
 {
-    notnull_check(drbg);
+    POSIX_ENSURE_REF(drbg);
 
     drbg->ctx = EVP_CIPHER_CTX_new();
     S2N_ERROR_IF(!drbg->ctx, S2N_ERR_DRBG);
@@ -159,57 +159,57 @@ int s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personalization
 
     switch(mode) {
         case S2N_AES_128_CTR_NO_DF_PR:
-            GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, EVP_aes_128_ecb(), NULL, NULL, NULL), S2N_ERR_DRBG);
+            POSIX_GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, EVP_aes_128_ecb(), NULL, NULL, NULL), S2N_ERR_DRBG);
             break;
         case S2N_AES_256_CTR_NO_DF_PR:
-            GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, EVP_aes_256_ecb(), NULL, NULL, NULL), S2N_ERR_DRBG);
+            POSIX_GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, EVP_aes_256_ecb(), NULL, NULL, NULL), S2N_ERR_DRBG);
             break;
         default:
-            S2N_ERROR(S2N_ERR_DRBG);
+            POSIX_BAIL(S2N_ERR_DRBG);
     }
 
-    lte_check(s2n_drbg_key_size(drbg), S2N_DRBG_MAX_KEY_SIZE);
-    lte_check(s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
+    POSIX_ENSURE_LTE(s2n_drbg_key_size(drbg), S2N_DRBG_MAX_KEY_SIZE);
+    POSIX_ENSURE_LTE(s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
 
     static const uint8_t zero_key[S2N_DRBG_MAX_KEY_SIZE] = {0};
 
     /* Start off with zeroed data, per 10.2.1.3.1 item 4 and 5 */
     memset(drbg->v, 0, sizeof(drbg->v));
-    GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, NULL, NULL, zero_key, NULL), S2N_ERR_DRBG);
+    POSIX_GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, NULL, NULL, zero_key, NULL), S2N_ERR_DRBG);
 
     /* Copy the personalization string */
     s2n_stack_blob(ps, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
-    GUARD(s2n_blob_zero(&ps));
+    POSIX_GUARD(s2n_blob_zero(&ps));
 
-    memcpy_check(ps.data, personalization_string->data, MIN(ps.size, personalization_string->size));
+    POSIX_CHECKED_MEMCPY(ps.data, personalization_string->data, MIN(ps.size, personalization_string->size));
 
     /* Seed the DRBG */
-    GUARD(s2n_drbg_seed(drbg, &ps));
+    POSIX_GUARD(s2n_drbg_seed(drbg, &ps));
 
     return 0;
 }
 
 int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob)
 {
-    notnull_check(drbg);
-    notnull_check(drbg->ctx);
+    POSIX_ENSURE_REF(drbg);
+    POSIX_ENSURE_REF(drbg->ctx);
     s2n_stack_blob(zeros, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
 
     S2N_ERROR_IF(blob->size > S2N_DRBG_GENERATE_LIMIT, S2N_ERR_DRBG_REQUEST_SIZE);
 
     /* Always mix in additional entropy, for prediction resistance */
-    GUARD(s2n_drbg_mix(drbg, &zeros));
-    GUARD(s2n_drbg_bits(drbg, blob));
-    GUARD(s2n_drbg_update(drbg, &zeros));
+    POSIX_GUARD(s2n_drbg_mix(drbg, &zeros));
+    POSIX_GUARD(s2n_drbg_bits(drbg, blob));
+    POSIX_GUARD(s2n_drbg_update(drbg, &zeros));
 
     return 0;
 }
 
 int s2n_drbg_wipe(struct s2n_drbg *drbg)
 {
-    notnull_check(drbg);
+    POSIX_ENSURE_REF(drbg);
     if (drbg->ctx) {
-        GUARD_OSSL(EVP_CIPHER_CTX_cleanup(drbg->ctx), S2N_ERR_DRBG);
+        POSIX_GUARD_OSSL(EVP_CIPHER_CTX_cleanup(drbg->ctx), S2N_ERR_DRBG);
 
         EVP_CIPHER_CTX_free(drbg->ctx);
         drbg->ctx = NULL;
@@ -221,8 +221,8 @@ int s2n_drbg_wipe(struct s2n_drbg *drbg)
 
 int s2n_drbg_bytes_used(struct s2n_drbg *drbg, uint64_t *bytes_used)
 {
-    notnull_check(drbg);
-    notnull_check(bytes_used);
+    POSIX_ENSURE_REF(drbg);
+    POSIX_ENSURE_REF(bytes_used);
     *bytes_used = drbg->bytes_used;
     return 0;
 }

--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -116,8 +116,8 @@ static int s2n_ecc_evp_generate_key_x25519(const struct s2n_ecc_named_curve *nam
                   EVP_PKEY_CTX_free_pointer);
     S2N_ERROR_IF(pctx == NULL, S2N_ERR_ECDHE_GEN_KEY);
 
-    GUARD_OSSL(EVP_PKEY_keygen_init(pctx), S2N_ERR_ECDHE_GEN_KEY);
-    GUARD_OSSL(EVP_PKEY_keygen(pctx, evp_pkey), S2N_ERR_ECDHE_GEN_KEY);
+    POSIX_GUARD_OSSL(EVP_PKEY_keygen_init(pctx), S2N_ERR_ECDHE_GEN_KEY);
+    POSIX_GUARD_OSSL(EVP_PKEY_keygen(pctx, evp_pkey), S2N_ERR_ECDHE_GEN_KEY);
     S2N_ERROR_IF(evp_pkey == NULL, S2N_ERR_ECDHE_GEN_KEY);
 
     return 0;
@@ -129,33 +129,33 @@ static int s2n_ecc_evp_generate_key_nist_curves(const struct s2n_ecc_named_curve
     DEFER_CLEANUP(EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL), EVP_PKEY_CTX_free_pointer);
     S2N_ERROR_IF(pctx == NULL, S2N_ERR_ECDHE_GEN_KEY);
 
-    GUARD_OSSL(EVP_PKEY_paramgen_init(pctx), S2N_ERR_ECDHE_GEN_KEY);
-    GUARD_OSSL(EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx, named_curve->libcrypto_nid), S2N_ERR_ECDHE_GEN_KEY);
+    POSIX_GUARD_OSSL(EVP_PKEY_paramgen_init(pctx), S2N_ERR_ECDHE_GEN_KEY);
+    POSIX_GUARD_OSSL(EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx, named_curve->libcrypto_nid), S2N_ERR_ECDHE_GEN_KEY);
 
     DEFER_CLEANUP(EVP_PKEY *params = NULL, EVP_PKEY_free_pointer);
-    GUARD_OSSL(EVP_PKEY_paramgen(pctx, &params), S2N_ERR_ECDHE_GEN_KEY);
+    POSIX_GUARD_OSSL(EVP_PKEY_paramgen(pctx, &params), S2N_ERR_ECDHE_GEN_KEY);
     S2N_ERROR_IF(params == NULL, S2N_ERR_ECDHE_GEN_KEY);
 
     DEFER_CLEANUP(EVP_PKEY_CTX *kctx = EVP_PKEY_CTX_new(params, NULL), EVP_PKEY_CTX_free_pointer);
     S2N_ERROR_IF(kctx == NULL, S2N_ERR_ECDHE_GEN_KEY);
 
-    GUARD_OSSL(EVP_PKEY_keygen_init(kctx), S2N_ERR_ECDHE_GEN_KEY);
-    GUARD_OSSL(EVP_PKEY_keygen(kctx, evp_pkey), S2N_ERR_ECDHE_GEN_KEY);
+    POSIX_GUARD_OSSL(EVP_PKEY_keygen_init(kctx), S2N_ERR_ECDHE_GEN_KEY);
+    POSIX_GUARD_OSSL(EVP_PKEY_keygen(kctx, evp_pkey), S2N_ERR_ECDHE_GEN_KEY);
     S2N_ERROR_IF(evp_pkey == NULL, S2N_ERR_ECDHE_GEN_KEY);
 
     return 0;
 }
 
 static int s2n_ecc_evp_generate_own_key(const struct s2n_ecc_named_curve *named_curve, EVP_PKEY **evp_pkey) {
-    notnull_check(named_curve);
+    POSIX_ENSURE_REF(named_curve);
     S2N_ERROR_IF(named_curve->generate_key == NULL, S2N_ERR_ECDHE_GEN_KEY);
 
     return named_curve->generate_key(named_curve, evp_pkey);
 }
 
 static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_public, uint16_t iana_id, struct s2n_blob *shared_secret) {
-    notnull_check(peer_public);
-    notnull_check(own_key);
+    POSIX_ENSURE_REF(peer_public);
+    POSIX_ENSURE_REF(own_key);
 
     /* From RFC 8446 Section 4.2.8.2: For the curves secp256r1 and secp384r1 peers MUST validate each other's
      * public value Q by ensuring that the point is a valid point on the elliptic curve.
@@ -164,7 +164,7 @@ static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_p
     if (iana_id == TLS_EC_CURVE_SECP_256_R1 || iana_id == TLS_EC_CURVE_SECP_384_R1) {
         DEFER_CLEANUP(EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(peer_public), EC_KEY_free_pointer);
         S2N_ERROR_IF(ec_key == NULL, S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
-        GUARD_OSSL(EC_KEY_check_key(ec_key), S2N_ERR_ECDHE_SHARED_SECRET);
+        POSIX_GUARD_OSSL(EC_KEY_check_key(ec_key), S2N_ERR_ECDHE_SHARED_SECRET);
     }
 
     size_t shared_secret_size;
@@ -172,21 +172,21 @@ static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_p
     DEFER_CLEANUP(EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(own_key, NULL), EVP_PKEY_CTX_free_pointer);
     S2N_ERROR_IF(ctx == NULL, S2N_ERR_ECDHE_SHARED_SECRET);
 
-    GUARD_OSSL(EVP_PKEY_derive_init(ctx), S2N_ERR_ECDHE_SHARED_SECRET);
-    GUARD_OSSL(EVP_PKEY_derive_set_peer(ctx, peer_public), S2N_ERR_ECDHE_SHARED_SECRET);
-    GUARD_OSSL(EVP_PKEY_derive(ctx, NULL, &shared_secret_size), S2N_ERR_ECDHE_SHARED_SECRET);
-    GUARD(s2n_alloc(shared_secret, shared_secret_size));
+    POSIX_GUARD_OSSL(EVP_PKEY_derive_init(ctx), S2N_ERR_ECDHE_SHARED_SECRET);
+    POSIX_GUARD_OSSL(EVP_PKEY_derive_set_peer(ctx, peer_public), S2N_ERR_ECDHE_SHARED_SECRET);
+    POSIX_GUARD_OSSL(EVP_PKEY_derive(ctx, NULL, &shared_secret_size), S2N_ERR_ECDHE_SHARED_SECRET);
+    POSIX_GUARD(s2n_alloc(shared_secret, shared_secret_size));
 
     if (EVP_PKEY_derive(ctx, shared_secret->data, &shared_secret_size) != 1) {
-        GUARD(s2n_free(shared_secret));
-        S2N_ERROR(S2N_ERR_ECDHE_SHARED_SECRET);
+        POSIX_GUARD(s2n_free(shared_secret));
+        POSIX_BAIL(S2N_ERR_ECDHE_SHARED_SECRET);
     }
 
     return 0;
 }
 
 int s2n_ecc_evp_generate_ephemeral_key(struct s2n_ecc_evp_params *ecc_evp_params) {
-    notnull_check(ecc_evp_params->negotiated_curve);
+    POSIX_ENSURE_REF(ecc_evp_params->negotiated_curve);
     S2N_ERROR_IF(ecc_evp_params->evp_pkey != NULL, S2N_ERR_ECDHE_GEN_KEY);
     S2N_ERROR_IF(s2n_ecc_evp_generate_own_key(ecc_evp_params->negotiated_curve, &ecc_evp_params->evp_pkey) != 0,
                  S2N_ERR_ECDHE_GEN_KEY);
@@ -197,44 +197,44 @@ int s2n_ecc_evp_generate_ephemeral_key(struct s2n_ecc_evp_params *ecc_evp_params
 int s2n_ecc_evp_compute_shared_secret_from_params(struct s2n_ecc_evp_params *private_ecc_evp_params,
                                                   struct s2n_ecc_evp_params *public_ecc_evp_params,
                                                   struct s2n_blob *shared_key) {
-    notnull_check(private_ecc_evp_params->negotiated_curve);
-    notnull_check(private_ecc_evp_params->evp_pkey);
-    notnull_check(public_ecc_evp_params->negotiated_curve);
-    notnull_check(public_ecc_evp_params->evp_pkey);
+    POSIX_ENSURE_REF(private_ecc_evp_params->negotiated_curve);
+    POSIX_ENSURE_REF(private_ecc_evp_params->evp_pkey);
+    POSIX_ENSURE_REF(public_ecc_evp_params->negotiated_curve);
+    POSIX_ENSURE_REF(public_ecc_evp_params->evp_pkey);
     S2N_ERROR_IF(private_ecc_evp_params->negotiated_curve->iana_id != public_ecc_evp_params->negotiated_curve->iana_id,
                  S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
-    GUARD(s2n_ecc_evp_compute_shared_secret(private_ecc_evp_params->evp_pkey, public_ecc_evp_params->evp_pkey,
+    POSIX_GUARD(s2n_ecc_evp_compute_shared_secret(private_ecc_evp_params->evp_pkey, public_ecc_evp_params->evp_pkey,
                                             private_ecc_evp_params->negotiated_curve->iana_id, shared_key));
     return 0;
 }
 
 int s2n_ecc_evp_compute_shared_secret_as_server(struct s2n_ecc_evp_params *ecc_evp_params,
                                             struct s2n_stuffer *Yc_in, struct s2n_blob *shared_key) {
-    notnull_check(ecc_evp_params->negotiated_curve);
-    notnull_check(ecc_evp_params->evp_pkey);
-    notnull_check(Yc_in);
+    POSIX_ENSURE_REF(ecc_evp_params->negotiated_curve);
+    POSIX_ENSURE_REF(ecc_evp_params->evp_pkey);
+    POSIX_ENSURE_REF(Yc_in);
 
     uint8_t client_public_len;
     struct s2n_blob client_public_blob = {0};
 
     DEFER_CLEANUP(EVP_PKEY *peer_key = EVP_PKEY_new(), EVP_PKEY_free_pointer);
     S2N_ERROR_IF(peer_key == NULL, S2N_ERR_BAD_MESSAGE);
-    GUARD(s2n_stuffer_read_uint8(Yc_in, &client_public_len));
+    POSIX_GUARD(s2n_stuffer_read_uint8(Yc_in, &client_public_len));
     client_public_blob.size = client_public_len;
     client_public_blob.data = s2n_stuffer_raw_read(Yc_in, client_public_blob.size);
-    notnull_check(client_public_blob.data);
+    POSIX_ENSURE_REF(client_public_blob.data);
 
 #if EVP_APIS_SUPPORTED
     if (ecc_evp_params->negotiated_curve->libcrypto_nid == NID_X25519) {
-        GUARD(EVP_PKEY_set_type(peer_key, ecc_evp_params->negotiated_curve->libcrypto_nid));
+        POSIX_GUARD(EVP_PKEY_set_type(peer_key, ecc_evp_params->negotiated_curve->libcrypto_nid));
     } else {
         DEFER_CLEANUP(EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL), EVP_PKEY_CTX_free_pointer);
         S2N_ERROR_IF(pctx == NULL, S2N_ERR_ECDHE_SERIALIZING);
-        GUARD_OSSL(EVP_PKEY_paramgen_init(pctx), S2N_ERR_ECDHE_SERIALIZING);
-        GUARD_OSSL(EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx, ecc_evp_params->negotiated_curve->libcrypto_nid), S2N_ERR_ECDHE_SERIALIZING);
-        GUARD_OSSL(EVP_PKEY_paramgen(pctx, &peer_key), S2N_ERR_ECDHE_SERIALIZING);
+        POSIX_GUARD_OSSL(EVP_PKEY_paramgen_init(pctx), S2N_ERR_ECDHE_SERIALIZING);
+        POSIX_GUARD_OSSL(EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx, ecc_evp_params->negotiated_curve->libcrypto_nid), S2N_ERR_ECDHE_SERIALIZING);
+        POSIX_GUARD_OSSL(EVP_PKEY_paramgen(pctx, &peer_key), S2N_ERR_ECDHE_SERIALIZING);
     }
-    GUARD_OSSL(EVP_PKEY_set1_tls_encodedpoint(peer_key, client_public_blob.data, client_public_blob.size),
+    POSIX_GUARD_OSSL(EVP_PKEY_set1_tls_encodedpoint(peer_key, client_public_blob.data, client_public_blob.size),
                S2N_ERR_ECDHE_SERIALIZING);
 #else
     DEFER_CLEANUP(EC_KEY *ec_key = EC_KEY_new_by_curve_name(ecc_evp_params->negotiated_curve->libcrypto_nid),
@@ -245,7 +245,7 @@ int s2n_ecc_evp_compute_shared_secret_as_server(struct s2n_ecc_evp_params *ecc_e
     S2N_ERROR_IF(point == NULL, S2N_ERR_BAD_MESSAGE);
 
     int success = EC_KEY_set_public_key(ec_key, point);
-    GUARD_OSSL(EVP_PKEY_set1_EC_KEY(peer_key, ec_key), S2N_ERR_ECDHE_SERIALIZING);
+    POSIX_GUARD_OSSL(EVP_PKEY_set1_EC_KEY(peer_key, ec_key), S2N_ERR_ECDHE_SERIALIZING);
     S2N_ERROR_IF(success == 0, S2N_ERR_BAD_MESSAGE);
 #endif
 
@@ -259,20 +259,20 @@ int s2n_ecc_evp_compute_shared_secret_as_client(struct s2n_ecc_evp_params *ecc_e
 
     DEFER_CLEANUP(struct s2n_ecc_evp_params client_params = {0}, s2n_ecc_evp_params_free);
 
-    notnull_check(ecc_evp_params->negotiated_curve);
+    POSIX_ENSURE_REF(ecc_evp_params->negotiated_curve);
     client_params.negotiated_curve = ecc_evp_params->negotiated_curve;
-    GUARD(s2n_ecc_evp_generate_own_key(client_params.negotiated_curve, &client_params.evp_pkey));
+    POSIX_GUARD(s2n_ecc_evp_generate_own_key(client_params.negotiated_curve, &client_params.evp_pkey));
     S2N_ERROR_IF(client_params.evp_pkey == NULL, S2N_ERR_ECDHE_GEN_KEY);
 
     if (s2n_ecc_evp_compute_shared_secret(client_params.evp_pkey, ecc_evp_params->evp_pkey,
                                           ecc_evp_params->negotiated_curve->iana_id, shared_key) != S2N_SUCCESS) {
-        S2N_ERROR(S2N_ERR_ECDHE_SHARED_SECRET);
+        POSIX_BAIL(S2N_ERR_ECDHE_SHARED_SECRET);
     }
 
-    GUARD(s2n_stuffer_write_uint8(Yc_out, client_params.negotiated_curve->share_size));
+    POSIX_GUARD(s2n_stuffer_write_uint8(Yc_out, client_params.negotiated_curve->share_size));
 
     if (s2n_ecc_evp_write_params_point(&client_params, Yc_out) != 0) {
-        S2N_ERROR(S2N_ERR_ECDHE_SERIALIZING);
+        POSIX_BAIL(S2N_ERR_ECDHE_SERIALIZING);
     }
     return 0;
 
@@ -297,50 +297,50 @@ static EC_POINT *s2n_ecc_evp_blob_to_point(struct s2n_blob *blob, const EC_KEY *
     const EC_GROUP *group = EC_KEY_get0_group(ec_key);
     EC_POINT *point = EC_POINT_new(group);
     if (point == NULL) {
-        S2N_ERROR_PTR(S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+        PTR_BAIL(S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
     }
     if (EC_POINT_oct2point(group, point, blob->data, blob->size, NULL) != 1) {
         EC_POINT_free(point);
-        S2N_ERROR_PTR(S2N_ERR_BAD_MESSAGE);
+        PTR_BAIL(S2N_ERR_BAD_MESSAGE);
     }
     return point;
 }
 #endif
 
 int s2n_ecc_evp_read_params_point(struct s2n_stuffer *in, int point_size, struct s2n_blob *point_blob) {
-    notnull_check(in);
-    notnull_check(point_blob);
-    gte_check(point_size, 0);
+    POSIX_ENSURE_REF(in);
+    POSIX_ENSURE_REF(point_blob);
+    POSIX_ENSURE_GTE(point_size, 0);
 
     /* Extract point from stuffer */
     point_blob->size = point_size;
     point_blob->data = s2n_stuffer_raw_read(in, point_size);
-    notnull_check(point_blob->data);
+    POSIX_ENSURE_REF(point_blob->data);
 
     return 0;
 }
 
 int s2n_ecc_evp_read_params(struct s2n_stuffer *in, struct s2n_blob *data_to_verify,
                             struct s2n_ecdhe_raw_server_params *raw_server_ecc_params) {
-    notnull_check(in);
+    POSIX_ENSURE_REF(in);
     uint8_t curve_type;
     uint8_t point_length;
 
     /* Remember where we started reading the data */
     data_to_verify->data = s2n_stuffer_raw_read(in, 0);
-    notnull_check(data_to_verify->data);
+    POSIX_ENSURE_REF(data_to_verify->data);
 
     /* Read the curve */
-    GUARD(s2n_stuffer_read_uint8(in, &curve_type));
+    POSIX_GUARD(s2n_stuffer_read_uint8(in, &curve_type));
     S2N_ERROR_IF(curve_type != TLS_EC_CURVE_TYPE_NAMED, S2N_ERR_BAD_MESSAGE);
     raw_server_ecc_params->curve_blob.data =  s2n_stuffer_raw_read(in, 2);
-    notnull_check(raw_server_ecc_params->curve_blob.data);
+    POSIX_ENSURE_REF(raw_server_ecc_params->curve_blob.data);
     raw_server_ecc_params->curve_blob.size = 2;
 
     /* Read the point */
-    GUARD(s2n_stuffer_read_uint8(in, &point_length));
+    POSIX_GUARD(s2n_stuffer_read_uint8(in, &point_length));
 
-    GUARD(s2n_ecc_evp_read_params_point(in, point_length, &raw_server_ecc_params->point_blob));
+    POSIX_GUARD(s2n_ecc_evp_read_params_point(in, point_length, &raw_server_ecc_params->point_blob));
 
     /* curve type (1) + iana (2) + key share size (1) + key share */
     data_to_verify->size = point_length + 4;
@@ -349,10 +349,10 @@ int s2n_ecc_evp_read_params(struct s2n_stuffer *in, struct s2n_blob *data_to_ver
 }
 
 int s2n_ecc_evp_write_params_point(struct s2n_ecc_evp_params *ecc_evp_params, struct s2n_stuffer *out) {
-    notnull_check(ecc_evp_params);
-    notnull_check(ecc_evp_params->negotiated_curve);
-    notnull_check(ecc_evp_params->evp_pkey);
-    notnull_check(out);
+    POSIX_ENSURE_REF(ecc_evp_params);
+    POSIX_ENSURE_REF(ecc_evp_params->negotiated_curve);
+    POSIX_ENSURE_REF(ecc_evp_params->evp_pkey);
+    POSIX_ENSURE_REF(out);
 
 #if EVP_APIS_SUPPORTED
     struct s2n_blob point_blob = {0};
@@ -361,12 +361,12 @@ int s2n_ecc_evp_write_params_point(struct s2n_ecc_evp_params *ecc_evp_params, st
     size_t size = EVP_PKEY_get1_tls_encodedpoint(ecc_evp_params->evp_pkey, &encoded_point);
     if (size != ecc_evp_params->negotiated_curve->share_size) {
         OPENSSL_free(encoded_point);
-        S2N_ERROR(S2N_ERR_ECDHE_SERIALIZING);
+        POSIX_BAIL(S2N_ERR_ECDHE_SERIALIZING);
     }
     else {
         point_blob.data = s2n_stuffer_raw_write(out, ecc_evp_params->negotiated_curve->share_size);
-        notnull_check(point_blob.data);
-        memcpy_check(point_blob.data, encoded_point, size);
+        POSIX_ENSURE_REF(point_blob.data);
+        POSIX_CHECKED_MEMCPY(point_blob.data, encoded_point, size);
         OPENSSL_free(encoded_point);
     }
 #else
@@ -379,35 +379,35 @@ int s2n_ecc_evp_write_params_point(struct s2n_ecc_evp_params *ecc_evp_params, st
     const EC_GROUP *group = EC_KEY_get0_group(ec_key);
     S2N_ERROR_IF(point == NULL || group == NULL, S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
-    GUARD(s2n_ecc_evp_calculate_point_length(point, group, &point_len));
+    POSIX_GUARD(s2n_ecc_evp_calculate_point_length(point, group, &point_len));
     S2N_ERROR_IF(point_len != ecc_evp_params->negotiated_curve->share_size, S2N_ERR_ECDHE_SERIALIZING);
     point_blob.data = s2n_stuffer_raw_write(out, point_len);
-    notnull_check(point_blob.data);
+    POSIX_ENSURE_REF(point_blob.data);
     point_blob.size = point_len;
 
-    GUARD(s2n_ecc_evp_write_point_data_snug(point, group, &point_blob));
+    POSIX_GUARD(s2n_ecc_evp_write_point_data_snug(point, group, &point_blob));
 #endif
     return 0;
 }
 
 int s2n_ecc_evp_write_params(struct s2n_ecc_evp_params *ecc_evp_params, struct s2n_stuffer *out,
                              struct s2n_blob *written) {
-    notnull_check(ecc_evp_params);
-    notnull_check(ecc_evp_params->negotiated_curve);
-    notnull_check(ecc_evp_params->evp_pkey);
-    notnull_check(out);
-    notnull_check(written);
+    POSIX_ENSURE_REF(ecc_evp_params);
+    POSIX_ENSURE_REF(ecc_evp_params->negotiated_curve);
+    POSIX_ENSURE_REF(ecc_evp_params->evp_pkey);
+    POSIX_ENSURE_REF(out);
+    POSIX_ENSURE_REF(written);
 
     uint8_t key_share_size = ecc_evp_params->negotiated_curve->share_size;
     /* Remember where the written data starts */
     written->data = s2n_stuffer_raw_write(out, 0);
-    notnull_check(written->data);
+    POSIX_ENSURE_REF(written->data);
 
-    GUARD(s2n_stuffer_write_uint8(out, TLS_EC_CURVE_TYPE_NAMED));
-    GUARD(s2n_stuffer_write_uint16(out, ecc_evp_params->negotiated_curve->iana_id));
-    GUARD(s2n_stuffer_write_uint8(out, key_share_size));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, TLS_EC_CURVE_TYPE_NAMED));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, ecc_evp_params->negotiated_curve->iana_id));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, key_share_size));
 
-    GUARD(s2n_ecc_evp_write_params_point(ecc_evp_params, out));
+    POSIX_GUARD(s2n_ecc_evp_write_params_point(ecc_evp_params, out));
 
     /* key share + key share size (1) + iana (2) + curve type (1) */
     written->size = key_share_size + 4;
@@ -416,8 +416,8 @@ int s2n_ecc_evp_write_params(struct s2n_ecc_evp_params *ecc_evp_params, struct s
 }
 
 int s2n_ecc_evp_parse_params_point(struct s2n_blob *point_blob, struct s2n_ecc_evp_params *ecc_evp_params) {
-    notnull_check(point_blob->data);
-    notnull_check(ecc_evp_params->negotiated_curve);
+    POSIX_ENSURE_REF(point_blob->data);
+    POSIX_ENSURE_REF(ecc_evp_params->negotiated_curve);
     S2N_ERROR_IF(point_blob->size != ecc_evp_params->negotiated_curve->share_size, S2N_ERR_ECDHE_SERIALIZING);
 
 #if EVP_APIS_SUPPORTED
@@ -426,16 +426,16 @@ int s2n_ecc_evp_parse_params_point(struct s2n_blob *point_blob, struct s2n_ecc_e
             ecc_evp_params->evp_pkey = EVP_PKEY_new();
         }
         S2N_ERROR_IF(ecc_evp_params->evp_pkey == NULL, S2N_ERR_BAD_MESSAGE);
-        GUARD(EVP_PKEY_set_type(ecc_evp_params->evp_pkey, ecc_evp_params->negotiated_curve->libcrypto_nid));
+        POSIX_GUARD(EVP_PKEY_set_type(ecc_evp_params->evp_pkey, ecc_evp_params->negotiated_curve->libcrypto_nid));
     }
     else {
         DEFER_CLEANUP(EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL), EVP_PKEY_CTX_free_pointer);
         S2N_ERROR_IF(pctx == NULL, S2N_ERR_ECDHE_SERIALIZING);
-        GUARD_OSSL(EVP_PKEY_paramgen_init(pctx), S2N_ERR_ECDHE_SERIALIZING);
-        GUARD_OSSL(EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx, ecc_evp_params->negotiated_curve->libcrypto_nid), S2N_ERR_ECDHE_SERIALIZING);
-        GUARD_OSSL(EVP_PKEY_paramgen(pctx, &ecc_evp_params->evp_pkey), S2N_ERR_ECDHE_SERIALIZING);
+        POSIX_GUARD_OSSL(EVP_PKEY_paramgen_init(pctx), S2N_ERR_ECDHE_SERIALIZING);
+        POSIX_GUARD_OSSL(EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx, ecc_evp_params->negotiated_curve->libcrypto_nid), S2N_ERR_ECDHE_SERIALIZING);
+        POSIX_GUARD_OSSL(EVP_PKEY_paramgen(pctx, &ecc_evp_params->evp_pkey), S2N_ERR_ECDHE_SERIALIZING);
     }
-    GUARD_OSSL(EVP_PKEY_set1_tls_encodedpoint(ecc_evp_params->evp_pkey, point_blob->data, point_blob->size),
+    POSIX_GUARD_OSSL(EVP_PKEY_set1_tls_encodedpoint(ecc_evp_params->evp_pkey, point_blob->data, point_blob->size),
                S2N_ERR_ECDHE_SERIALIZING);
 #else
     if (ecc_evp_params->evp_pkey == NULL) {
@@ -454,7 +454,7 @@ int s2n_ecc_evp_parse_params_point(struct s2n_blob *point_blob, struct s2n_ecc_e
     /* Set the point as the public key */
     int success = EC_KEY_set_public_key(ec_key, point);
 
-    GUARD_OSSL(EVP_PKEY_set1_EC_KEY(ecc_evp_params->evp_pkey,ec_key), S2N_ERR_ECDHE_SERIALIZING);
+    POSIX_GUARD_OSSL(EVP_PKEY_set1_EC_KEY(ecc_evp_params->evp_pkey,ec_key), S2N_ERR_ECDHE_SERIALIZING);
 
     /* EC_KEY_set_public_key returns 1 on success, 0 on failure */
     S2N_ERROR_IF(success == 0, S2N_ERR_BAD_MESSAGE);
@@ -474,22 +474,22 @@ int s2n_ecc_evp_parse_params(struct s2n_ecdhe_raw_server_params *raw_server_ecc_
 int s2n_ecc_evp_find_supported_curve(struct s2n_blob *iana_ids, const struct s2n_ecc_named_curve **found) {
     struct s2n_stuffer iana_ids_in = {0};
 
-    GUARD(s2n_stuffer_init(&iana_ids_in, iana_ids));
-    GUARD(s2n_stuffer_write(&iana_ids_in, iana_ids));
+    POSIX_GUARD(s2n_stuffer_init(&iana_ids_in, iana_ids));
+    POSIX_GUARD(s2n_stuffer_write(&iana_ids_in, iana_ids));
     for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
         const struct s2n_ecc_named_curve *supported_curve = s2n_all_supported_curves_list[i];
         for (int j = 0; j < iana_ids->size / 2; j++) {
             uint16_t iana_id;
-            GUARD(s2n_stuffer_read_uint16(&iana_ids_in, &iana_id));
+            POSIX_GUARD(s2n_stuffer_read_uint16(&iana_ids_in, &iana_id));
             if (supported_curve->iana_id == iana_id) {
                 *found = supported_curve;
                 return 0;
             }
         }
-        GUARD(s2n_stuffer_reread(&iana_ids_in));
+        POSIX_GUARD(s2n_stuffer_reread(&iana_ids_in));
     }
 
-    S2N_ERROR(S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+    POSIX_BAIL(S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 }
 
 int s2n_ecc_evp_params_free(struct s2n_ecc_evp_params *ecc_evp_params) {

--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -33,14 +33,14 @@
 
 S2N_RESULT s2n_ecdsa_der_signature_size(const struct s2n_pkey *pkey, uint32_t *size_out)
 {
-    ENSURE_REF(pkey);
-    ENSURE_REF(size_out);
+    RESULT_ENSURE_REF(pkey);
+    RESULT_ENSURE_REF(size_out);
 
     const struct s2n_ecdsa_key *ecdsa_key = &pkey->key.ecdsa_key;
-    ENSURE_REF(ecdsa_key->ec_key);
+    RESULT_ENSURE_REF(ecdsa_key->ec_key);
 
     const int size = ECDSA_size(ecdsa_key->ec_key);
-    GUARD_AS_RESULT(size);
+    RESULT_GUARD_POSIX(size);
     *size_out = size;
 
     return S2N_RESULT_OK;
@@ -52,21 +52,21 @@ static int s2n_ecdsa_sign(const struct s2n_pkey *priv, s2n_signature_algorithm s
     sig_alg_check(sig_alg, S2N_SIGNATURE_ECDSA);
 
     const s2n_ecdsa_private_key *key = &priv->key.ecdsa_key;
-    notnull_check(key->ec_key);
+    POSIX_ENSURE_REF(key->ec_key);
 
     uint8_t digest_length;
-    GUARD(s2n_hash_digest_size(digest->alg, &digest_length));
-    lte_check(digest_length, S2N_MAX_DIGEST_LEN);
+    POSIX_GUARD(s2n_hash_digest_size(digest->alg, &digest_length));
+    POSIX_ENSURE_LTE(digest_length, S2N_MAX_DIGEST_LEN);
 
     uint8_t digest_out[S2N_MAX_DIGEST_LEN];
-    GUARD(s2n_hash_digest(digest, digest_out, digest_length));
+    POSIX_GUARD(s2n_hash_digest(digest, digest_out, digest_length));
 
     unsigned int signature_size = signature->size;
-    GUARD_OSSL(ECDSA_sign(0, digest_out, digest_length, signature->data, &signature_size, key->ec_key), S2N_ERR_SIGN);
+    POSIX_GUARD_OSSL(ECDSA_sign(0, digest_out, digest_length, signature->data, &signature_size, key->ec_key), S2N_ERR_SIGN);
     S2N_ERROR_IF(signature_size > signature->size, S2N_ERR_SIZE_MISMATCH);
     signature->size = signature_size;
 
-    GUARD(s2n_hash_reset(digest));
+    POSIX_GUARD(s2n_hash_reset(digest));
     
     return 0;
 }
@@ -77,19 +77,19 @@ static int s2n_ecdsa_verify(const struct s2n_pkey *pub, s2n_signature_algorithm 
     sig_alg_check(sig_alg, S2N_SIGNATURE_ECDSA);
 
     const s2n_ecdsa_public_key *key = &pub->key.ecdsa_key;
-    notnull_check(key->ec_key);
+    POSIX_ENSURE_REF(key->ec_key);
 
     uint8_t digest_length;
-    GUARD(s2n_hash_digest_size(digest->alg, &digest_length));
-    lte_check(digest_length, S2N_MAX_DIGEST_LEN);
+    POSIX_GUARD(s2n_hash_digest_size(digest->alg, &digest_length));
+    POSIX_ENSURE_LTE(digest_length, S2N_MAX_DIGEST_LEN);
 
     uint8_t digest_out[S2N_MAX_DIGEST_LEN];
-    GUARD(s2n_hash_digest(digest, digest_out, digest_length));
+    POSIX_GUARD(s2n_hash_digest(digest, digest_out, digest_length));
     
     /* ECDSA_verify ignores the first parameter */
-    GUARD_OSSL(ECDSA_verify(0, digest_out, digest_length, signature->data, signature->size, key->ec_key), S2N_ERR_VERIFY_SIGNATURE);
+    POSIX_GUARD_OSSL(ECDSA_verify(0, digest_out, digest_length, signature->data, signature->size, key->ec_key), S2N_ERR_VERIFY_SIGNATURE);
 
-    GUARD(s2n_hash_reset(digest));
+    POSIX_GUARD(s2n_hash_reset(digest));
     
     return 0;
 }
@@ -102,20 +102,20 @@ static int s2n_ecdsa_keys_match(const struct s2n_pkey *pub, const struct s2n_pke
     DEFER_CLEANUP(struct s2n_hash_state state_out = { 0 }, s2n_hash_free);
 
     /* s2n_hash_new only allocates memory when using high-level EVP hashes, currently restricted to FIPS mode. */
-    GUARD(s2n_hash_new(&state_in));
-    GUARD(s2n_hash_new(&state_out));
+    POSIX_GUARD(s2n_hash_new(&state_in));
+    POSIX_GUARD(s2n_hash_new(&state_out));
 
-    GUARD(s2n_hash_init(&state_in, S2N_HASH_SHA1));
-    GUARD(s2n_hash_init(&state_out, S2N_HASH_SHA1));
-    GUARD(s2n_hash_update(&state_in, input, sizeof(input)));
-    GUARD(s2n_hash_update(&state_out, input, sizeof(input)));
+    POSIX_GUARD(s2n_hash_init(&state_in, S2N_HASH_SHA1));
+    POSIX_GUARD(s2n_hash_init(&state_out, S2N_HASH_SHA1));
+    POSIX_GUARD(s2n_hash_update(&state_in, input, sizeof(input)));
+    POSIX_GUARD(s2n_hash_update(&state_out, input, sizeof(input)));
 
     uint32_t size = 0;
-    GUARD_AS_POSIX(s2n_ecdsa_der_signature_size(priv, &size));
-    GUARD(s2n_alloc(&signature, size));
+    POSIX_GUARD_RESULT(s2n_ecdsa_der_signature_size(priv, &size));
+    POSIX_GUARD(s2n_alloc(&signature, size));
 
-    GUARD(s2n_ecdsa_sign(priv, S2N_SIGNATURE_ECDSA, &state_in, &signature));
-    GUARD(s2n_ecdsa_verify(pub, S2N_SIGNATURE_ECDSA, &state_out, &signature));
+    POSIX_GUARD(s2n_ecdsa_sign(priv, S2N_SIGNATURE_ECDSA, &state_in, &signature));
+    POSIX_GUARD(s2n_ecdsa_verify(pub, S2N_SIGNATURE_ECDSA, &state_out, &signature));
 
     return 0;
 }
@@ -136,7 +136,7 @@ static int s2n_ecdsa_key_free(struct s2n_pkey *pkey)
 static int s2n_ecdsa_check_key_exists(const struct s2n_pkey *pkey)
 {
     const struct s2n_ecdsa_key *ecdsa_key = &pkey->key.ecdsa_key;
-    notnull_check(ecdsa_key->ec_key);
+    POSIX_ENSURE_REF(ecdsa_key->ec_key);
     return 0;
 }
 
@@ -172,12 +172,12 @@ int s2n_ecdsa_pkey_init(struct s2n_pkey *pkey) {
 
 int s2n_ecdsa_pkey_matches_curve(const struct s2n_ecdsa_key *ecdsa_key, const struct s2n_ecc_named_curve *curve)
 {
-    notnull_check(ecdsa_key);
-    notnull_check(ecdsa_key->ec_key);
-    notnull_check(curve);
+    POSIX_ENSURE_REF(ecdsa_key);
+    POSIX_ENSURE_REF(ecdsa_key->ec_key);
+    POSIX_ENSURE_REF(curve);
 
     int curve_id = EC_GROUP_get_curve_name(EC_KEY_get0_group(ecdsa_key->ec_key));
-    eq_check(curve_id, curve->libcrypto_nid);
+    POSIX_ENSURE_EQ(curve_id, curve->libcrypto_nid);
 
     return 0;
 }

--- a/crypto/s2n_evp.c
+++ b/crypto/s2n_evp.c
@@ -20,7 +20,7 @@
 
 int s2n_digest_allow_md5_for_fips(struct s2n_evp_digest *evp_digest)
 {
-    notnull_check(evp_digest);
+    POSIX_ENSURE_REF(evp_digest);
     /* This is only to be used for EVP digests that will require MD5 to be used
      * to comply with the TLS 1.0 and 1.1 RFC's for the PRF. MD5 cannot be used
      * outside of the TLS 1.0 and 1.1 PRF when in FIPS mode.
@@ -35,7 +35,7 @@ int s2n_digest_allow_md5_for_fips(struct s2n_evp_digest *evp_digest)
 
 S2N_RESULT s2n_digest_is_md5_allowed_for_fips(struct s2n_evp_digest *evp_digest, bool *out)
 {
-    ENSURE_REF(out);
+    RESULT_ENSURE_REF(out);
     *out = false;
 #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     if (evp_digest && evp_digest->ctx && s2n_is_in_fips_mode() && EVP_MD_CTX_test_flags(evp_digest->ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW)) {

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -24,7 +24,7 @@
 
 int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out)
 {
-    ENSURE_POSIX(S2N_MEM_IS_WRITABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
+    POSIX_ENSURE(S2N_MEM_IS_WRITABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
     switch (alg) {
     case S2N_HASH_NONE:     *out = 0;                    break;
     case S2N_HASH_MD5:      *out = MD5_DIGEST_LENGTH;    break;
@@ -35,7 +35,7 @@ int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out)
     case S2N_HASH_SHA512:   *out = SHA512_DIGEST_LENGTH; break;
     case S2N_HASH_MD5_SHA1: *out = MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH; break;
     default:
-        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
     return S2N_SUCCESS;
 }
@@ -45,7 +45,7 @@ int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out)
  * If this ever becomes untrue, this would require fixing*/
 int s2n_hash_block_size(s2n_hash_algorithm alg, uint64_t *block_size)
 {
-    ENSURE_POSIX(S2N_MEM_IS_WRITABLE(block_size, sizeof(*block_size)), S2N_ERR_PRECONDITION_VIOLATION);
+    POSIX_ENSURE(S2N_MEM_IS_WRITABLE(block_size, sizeof(*block_size)), S2N_ERR_PRECONDITION_VIOLATION);
     switch(alg) {
     case S2N_HASH_NONE:       *block_size = 64;   break;
     case S2N_HASH_MD5:        *block_size = 64;   break;
@@ -56,7 +56,7 @@ int s2n_hash_block_size(s2n_hash_algorithm alg, uint64_t *block_size)
     case S2N_HASH_SHA512:     *block_size = 128;  break;
     case S2N_HASH_MD5_SHA1:   *block_size = 64;   break;
     default:
-        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
     return S2N_SUCCESS;
 }
@@ -84,7 +84,7 @@ bool s2n_hash_is_available(s2n_hash_algorithm alg)
 
 int s2n_hash_is_ready_for_input(struct s2n_hash_state *state)
 {
-    PRECONDITION_POSIX(s2n_hash_state_validate(state));
+    POSIX_PRECONDITION(s2n_hash_state_validate(state));
     return state->is_ready_for_input;
 }
 
@@ -105,30 +105,30 @@ static int s2n_low_level_hash_init(struct s2n_hash_state *state, s2n_hash_algori
     case S2N_HASH_NONE:
         break;
     case S2N_HASH_MD5:
-        GUARD_OSSL(MD5_Init(&state->digest.low_level.md5), S2N_ERR_HASH_INIT_FAILED);
+        POSIX_GUARD_OSSL(MD5_Init(&state->digest.low_level.md5), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA1:
-        GUARD_OSSL(SHA1_Init(&state->digest.low_level.sha1), S2N_ERR_HASH_INIT_FAILED);
+        POSIX_GUARD_OSSL(SHA1_Init(&state->digest.low_level.sha1), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA224:
-        GUARD_OSSL(SHA224_Init(&state->digest.low_level.sha224), S2N_ERR_HASH_INIT_FAILED);
+        POSIX_GUARD_OSSL(SHA224_Init(&state->digest.low_level.sha224), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA256:
-        GUARD_OSSL(SHA256_Init(&state->digest.low_level.sha256), S2N_ERR_HASH_INIT_FAILED);
+        POSIX_GUARD_OSSL(SHA256_Init(&state->digest.low_level.sha256), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA384:
-        GUARD_OSSL(SHA384_Init(&state->digest.low_level.sha384), S2N_ERR_HASH_INIT_FAILED);
+        POSIX_GUARD_OSSL(SHA384_Init(&state->digest.low_level.sha384), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA512:
-        GUARD_OSSL(SHA512_Init(&state->digest.low_level.sha512), S2N_ERR_HASH_INIT_FAILED);
+        POSIX_GUARD_OSSL(SHA512_Init(&state->digest.low_level.sha512), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
-        GUARD_OSSL(SHA1_Init(&state->digest.low_level.md5_sha1.sha1), S2N_ERR_HASH_INIT_FAILED);;
-        GUARD_OSSL(MD5_Init(&state->digest.low_level.md5_sha1.md5), S2N_ERR_HASH_INIT_FAILED);;
+        POSIX_GUARD_OSSL(SHA1_Init(&state->digest.low_level.md5_sha1.sha1), S2N_ERR_HASH_INIT_FAILED);;
+        POSIX_GUARD_OSSL(MD5_Init(&state->digest.low_level.md5_sha1.md5), S2N_ERR_HASH_INIT_FAILED);;
         break;
 
     default:
-        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
     state->alg = alg;
@@ -140,38 +140,38 @@ static int s2n_low_level_hash_init(struct s2n_hash_state *state, s2n_hash_algori
 
 static int s2n_low_level_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
-    ENSURE_POSIX(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+    POSIX_ENSURE(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
     switch (state->alg) {
     case S2N_HASH_NONE:
         break;
     case S2N_HASH_MD5:
-        GUARD_OSSL(MD5_Update(&state->digest.low_level.md5, data, size), S2N_ERR_HASH_UPDATE_FAILED);
+        POSIX_GUARD_OSSL(MD5_Update(&state->digest.low_level.md5, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     case S2N_HASH_SHA1:
-        GUARD_OSSL(SHA1_Update(&state->digest.low_level.sha1, data, size), S2N_ERR_HASH_UPDATE_FAILED);
+        POSIX_GUARD_OSSL(SHA1_Update(&state->digest.low_level.sha1, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     case S2N_HASH_SHA224:
-        GUARD_OSSL(SHA224_Update(&state->digest.low_level.sha224, data, size), S2N_ERR_HASH_UPDATE_FAILED);
+        POSIX_GUARD_OSSL(SHA224_Update(&state->digest.low_level.sha224, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     case S2N_HASH_SHA256:
-        GUARD_OSSL(SHA256_Update(&state->digest.low_level.sha256, data, size), S2N_ERR_HASH_UPDATE_FAILED);
+        POSIX_GUARD_OSSL(SHA256_Update(&state->digest.low_level.sha256, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     case S2N_HASH_SHA384:
-        GUARD_OSSL(SHA384_Update(&state->digest.low_level.sha384, data, size), S2N_ERR_HASH_UPDATE_FAILED);
+        POSIX_GUARD_OSSL(SHA384_Update(&state->digest.low_level.sha384, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     case S2N_HASH_SHA512:
-        GUARD_OSSL(SHA512_Update(&state->digest.low_level.sha512, data, size), S2N_ERR_HASH_UPDATE_FAILED);
+        POSIX_GUARD_OSSL(SHA512_Update(&state->digest.low_level.sha512, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
-        GUARD_OSSL(SHA1_Update(&state->digest.low_level.md5_sha1.sha1, data, size), S2N_ERR_HASH_UPDATE_FAILED);
-        GUARD_OSSL(MD5_Update(&state->digest.low_level.md5_sha1.md5, data, size), S2N_ERR_HASH_UPDATE_FAILED);
+        POSIX_GUARD_OSSL(SHA1_Update(&state->digest.low_level.md5_sha1.sha1, data, size), S2N_ERR_HASH_UPDATE_FAILED);
+        POSIX_GUARD_OSSL(MD5_Update(&state->digest.low_level.md5_sha1.md5, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     default:
-        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
-    ENSURE_POSIX(size <= (UINT64_MAX - state->currently_in_hash), S2N_ERR_INTEGER_OVERFLOW);
+    POSIX_ENSURE(size <= (UINT64_MAX - state->currently_in_hash), S2N_ERR_INTEGER_OVERFLOW);
     state->currently_in_hash += size;
 
     return S2N_SUCCESS;
@@ -179,42 +179,42 @@ static int s2n_low_level_hash_update(struct s2n_hash_state *state, const void *d
 
 static int s2n_low_level_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 {
-    ENSURE_POSIX(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+    POSIX_ENSURE(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
     switch (state->alg) {
     case S2N_HASH_NONE:
         break;
     case S2N_HASH_MD5:
-        eq_check(size, MD5_DIGEST_LENGTH);
-        GUARD_OSSL(MD5_Final(out, &state->digest.low_level.md5), S2N_ERR_HASH_DIGEST_FAILED);
+        POSIX_ENSURE_EQ(size, MD5_DIGEST_LENGTH);
+        POSIX_GUARD_OSSL(MD5_Final(out, &state->digest.low_level.md5), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_SHA1:
-        eq_check(size, SHA_DIGEST_LENGTH);
-        GUARD_OSSL(SHA1_Final(out, &state->digest.low_level.sha1), S2N_ERR_HASH_DIGEST_FAILED);
+        POSIX_ENSURE_EQ(size, SHA_DIGEST_LENGTH);
+        POSIX_GUARD_OSSL(SHA1_Final(out, &state->digest.low_level.sha1), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_SHA224:
-        eq_check(size, SHA224_DIGEST_LENGTH);
-        GUARD_OSSL(SHA224_Final(out, &state->digest.low_level.sha224), S2N_ERR_HASH_DIGEST_FAILED);
+        POSIX_ENSURE_EQ(size, SHA224_DIGEST_LENGTH);
+        POSIX_GUARD_OSSL(SHA224_Final(out, &state->digest.low_level.sha224), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_SHA256:
-        eq_check(size, SHA256_DIGEST_LENGTH);
-        GUARD_OSSL(SHA256_Final(out, &state->digest.low_level.sha256), S2N_ERR_HASH_DIGEST_FAILED);
+        POSIX_ENSURE_EQ(size, SHA256_DIGEST_LENGTH);
+        POSIX_GUARD_OSSL(SHA256_Final(out, &state->digest.low_level.sha256), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_SHA384:
-        eq_check(size, SHA384_DIGEST_LENGTH);
-        GUARD_OSSL(SHA384_Final(out, &state->digest.low_level.sha384), S2N_ERR_HASH_DIGEST_FAILED);
+        POSIX_ENSURE_EQ(size, SHA384_DIGEST_LENGTH);
+        POSIX_GUARD_OSSL(SHA384_Final(out, &state->digest.low_level.sha384), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_SHA512:
-        eq_check(size, SHA512_DIGEST_LENGTH);
-        GUARD_OSSL(SHA512_Final(out, &state->digest.low_level.sha512), S2N_ERR_HASH_DIGEST_FAILED);
+        POSIX_ENSURE_EQ(size, SHA512_DIGEST_LENGTH);
+        POSIX_GUARD_OSSL(SHA512_Final(out, &state->digest.low_level.sha512), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
-        eq_check(size, MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH);
-        GUARD_OSSL(SHA1_Final(((uint8_t *) out) + MD5_DIGEST_LENGTH, &state->digest.low_level.md5_sha1.sha1), S2N_ERR_HASH_DIGEST_FAILED);
-        GUARD_OSSL(MD5_Final(out, &state->digest.low_level.md5_sha1.md5), S2N_ERR_HASH_DIGEST_FAILED);
+        POSIX_ENSURE_EQ(size, MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH);
+        POSIX_GUARD_OSSL(SHA1_Final(((uint8_t *) out) + MD5_DIGEST_LENGTH, &state->digest.low_level.md5_sha1.sha1), S2N_ERR_HASH_DIGEST_FAILED);
+        POSIX_GUARD_OSSL(MD5_Final(out, &state->digest.low_level.md5_sha1.md5), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     default:
-        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
     state->currently_in_hash = 0;
@@ -224,7 +224,7 @@ static int s2n_low_level_hash_digest(struct s2n_hash_state *state, void *out, ui
 
 static int s2n_low_level_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
 {
-    memcpy_check(to, from, sizeof(struct s2n_hash_state));
+    POSIX_CHECKED_MEMCPY(to, from, sizeof(struct s2n_hash_state));
     return 0;
 }
 
@@ -245,8 +245,8 @@ static int s2n_low_level_hash_free(struct s2n_hash_state *state)
 
 static int s2n_evp_hash_new(struct s2n_hash_state *state)
 {
-    notnull_check(state->digest.high_level.evp.ctx = S2N_EVP_MD_CTX_NEW());
-    notnull_check(state->digest.high_level.evp_md5_secondary.ctx = S2N_EVP_MD_CTX_NEW());
+    POSIX_ENSURE_REF(state->digest.high_level.evp.ctx = S2N_EVP_MD_CTX_NEW());
+    POSIX_ENSURE_REF(state->digest.high_level.evp_md5_secondary.ctx = S2N_EVP_MD_CTX_NEW());
     state->is_ready_for_input = 0;
     state->currently_in_hash = 0;
 
@@ -260,41 +260,41 @@ static int s2n_evp_hash_allow_md5_for_fips(struct s2n_hash_state *state)
      * outside of the TLS 1.0 and 1.1 PRF when in FIPS mode. When needed, this must
      * be called prior to s2n_hash_init().
      */
-    GUARD(s2n_digest_allow_md5_for_fips(&state->digest.high_level.evp_md5_secondary));
+    POSIX_GUARD(s2n_digest_allow_md5_for_fips(&state->digest.high_level.evp_md5_secondary));
     return s2n_digest_allow_md5_for_fips(&state->digest.high_level.evp);
 }
 
 static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 {
-    notnull_check(state->digest.high_level.evp.ctx);
-    notnull_check(state->digest.high_level.evp_md5_secondary.ctx);
+    POSIX_ENSURE_REF(state->digest.high_level.evp.ctx);
+    POSIX_ENSURE_REF(state->digest.high_level.evp_md5_secondary.ctx);
     switch (alg) {
     case S2N_HASH_NONE:
         break;
     case S2N_HASH_MD5:
-        GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_md5(), NULL), S2N_ERR_HASH_INIT_FAILED);
+        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_md5(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA1:
-      GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha1(), NULL), S2N_ERR_HASH_INIT_FAILED);
+      POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha1(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA224:
-        GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha224(), NULL), S2N_ERR_HASH_INIT_FAILED);
+        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha224(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA256:
-        GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha256(), NULL), S2N_ERR_HASH_INIT_FAILED);
+        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha256(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA384:
-        GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha384(), NULL), S2N_ERR_HASH_INIT_FAILED);
+        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha384(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_SHA512:
-        GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha512(), NULL), S2N_ERR_HASH_INIT_FAILED);
+        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha512(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
-        GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha1(), NULL), S2N_ERR_HASH_INIT_FAILED);
-        GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp_md5_secondary.ctx, EVP_md5(), NULL), S2N_ERR_HASH_INIT_FAILED);
+        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha1(), NULL), S2N_ERR_HASH_INIT_FAILED);
+        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp_md5_secondary.ctx, EVP_md5(), NULL), S2N_ERR_HASH_INIT_FAILED);
         break;
     default:
-        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
     state->alg = alg;
@@ -306,7 +306,7 @@ static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm al
 
 static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
-    ENSURE_POSIX(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+    POSIX_ENSURE(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
     switch (state->alg) {
     case S2N_HASH_NONE:
@@ -317,20 +317,20 @@ static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, u
     case S2N_HASH_SHA256:
     case S2N_HASH_SHA384:
     case S2N_HASH_SHA512:
-        notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
-        GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp.ctx, data, size), S2N_ERR_HASH_UPDATE_FAILED);
+        POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
+        POSIX_GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp.ctx, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
-        notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
-        notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp_md5_secondary.ctx));
-        GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp.ctx, data, size), S2N_ERR_HASH_UPDATE_FAILED);
-        GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp_md5_secondary.ctx, data, size), S2N_ERR_HASH_UPDATE_FAILED);
+        POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
+        POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp_md5_secondary.ctx));
+        POSIX_GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp.ctx, data, size), S2N_ERR_HASH_UPDATE_FAILED);
+        POSIX_GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp_md5_secondary.ctx, data, size), S2N_ERR_HASH_UPDATE_FAILED);
         break;
     default:
-        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
-    ENSURE_POSIX(size <= (UINT64_MAX - state->currently_in_hash), S2N_ERR_INTEGER_OVERFLOW);
+    POSIX_ENSURE(size <= (UINT64_MAX - state->currently_in_hash), S2N_ERR_INTEGER_OVERFLOW);
     state->currently_in_hash += size;
 
     return S2N_SUCCESS;
@@ -338,12 +338,12 @@ static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, u
 
 static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 {
-    ENSURE_POSIX(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+    POSIX_ENSURE(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
     unsigned int digest_size = size;
     uint8_t expected_digest_size;
-    GUARD(s2n_hash_digest_size(state->alg, &expected_digest_size));
-    eq_check(digest_size, expected_digest_size);
+    POSIX_GUARD(s2n_hash_digest_size(state->alg, &expected_digest_size));
+    POSIX_ENSURE_EQ(digest_size, expected_digest_size);
 
     /* Used for S2N_HASH_MD5_SHA1 case to specify the exact size of each digest. */
     uint8_t sha1_digest_size;
@@ -359,24 +359,24 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
     case S2N_HASH_SHA256:
     case S2N_HASH_SHA384:
     case S2N_HASH_SHA512:
-        notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
-        ENSURE_POSIX(EVP_MD_CTX_size(state->digest.high_level.evp.ctx) <= digest_size, S2N_ERR_HASH_DIGEST_FAILED);
-        GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, out, &digest_size), S2N_ERR_HASH_DIGEST_FAILED);
+        POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
+        POSIX_ENSURE(EVP_MD_CTX_size(state->digest.high_level.evp.ctx) <= digest_size, S2N_ERR_HASH_DIGEST_FAILED);
+        POSIX_GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, out, &digest_size), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
-        notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
-        notnull_check(EVP_MD_CTX_md(state->digest.high_level.evp_md5_secondary.ctx));
-        GUARD(s2n_hash_digest_size(S2N_HASH_SHA1, &sha1_digest_size));
+        POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
+        POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp_md5_secondary.ctx));
+        POSIX_GUARD(s2n_hash_digest_size(S2N_HASH_SHA1, &sha1_digest_size));
         sha1_primary_digest_size = sha1_digest_size;
         md5_secondary_digest_size = digest_size - sha1_primary_digest_size;
-        ENSURE_POSIX(EVP_MD_CTX_size(state->digest.high_level.evp.ctx) <= sha1_digest_size, S2N_ERR_HASH_DIGEST_FAILED);
-        ENSURE_POSIX(EVP_MD_CTX_size(state->digest.high_level.evp_md5_secondary.ctx) <= md5_secondary_digest_size, S2N_ERR_HASH_DIGEST_FAILED);
+        POSIX_ENSURE(EVP_MD_CTX_size(state->digest.high_level.evp.ctx) <= sha1_digest_size, S2N_ERR_HASH_DIGEST_FAILED);
+        POSIX_ENSURE(EVP_MD_CTX_size(state->digest.high_level.evp_md5_secondary.ctx) <= md5_secondary_digest_size, S2N_ERR_HASH_DIGEST_FAILED);
 
-        GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, ((uint8_t *) out) + MD5_DIGEST_LENGTH, &sha1_primary_digest_size), S2N_ERR_HASH_DIGEST_FAILED);
-        GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp_md5_secondary.ctx, out, &md5_secondary_digest_size), S2N_ERR_HASH_DIGEST_FAILED);
+        POSIX_GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, ((uint8_t *) out) + MD5_DIGEST_LENGTH, &sha1_primary_digest_size), S2N_ERR_HASH_DIGEST_FAILED);
+        POSIX_GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp_md5_secondary.ctx, out, &md5_secondary_digest_size), S2N_ERR_HASH_DIGEST_FAILED);
         break;
     default:
-        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
     state->currently_in_hash = 0;
@@ -391,9 +391,9 @@ static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *f
     case S2N_HASH_NONE:
         break;
     case S2N_HASH_MD5:
-        GUARD_AS_POSIX(s2n_digest_is_md5_allowed_for_fips(&from->digest.high_level.evp, &is_md5_allowed_for_fips));
+        POSIX_GUARD_RESULT(s2n_digest_is_md5_allowed_for_fips(&from->digest.high_level.evp, &is_md5_allowed_for_fips));
         if (is_md5_allowed_for_fips) {
-            GUARD(s2n_hash_allow_md5_for_fips(to));
+            POSIX_GUARD(s2n_hash_allow_md5_for_fips(to));
         }
         FALL_THROUGH;
     case S2N_HASH_SHA1:
@@ -401,21 +401,21 @@ static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *f
     case S2N_HASH_SHA256:
     case S2N_HASH_SHA384:
     case S2N_HASH_SHA512:
-        notnull_check(to->digest.high_level.evp.ctx);
-        GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp.ctx, from->digest.high_level.evp.ctx), S2N_ERR_HASH_COPY_FAILED);
+        POSIX_ENSURE_REF(to->digest.high_level.evp.ctx);
+        POSIX_GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp.ctx, from->digest.high_level.evp.ctx), S2N_ERR_HASH_COPY_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
-        notnull_check(to->digest.high_level.evp.ctx);
-        notnull_check(to->digest.high_level.evp_md5_secondary.ctx);
-        GUARD_AS_POSIX(s2n_digest_is_md5_allowed_for_fips(&from->digest.high_level.evp, &is_md5_allowed_for_fips));
+        POSIX_ENSURE_REF(to->digest.high_level.evp.ctx);
+        POSIX_ENSURE_REF(to->digest.high_level.evp_md5_secondary.ctx);
+        POSIX_GUARD_RESULT(s2n_digest_is_md5_allowed_for_fips(&from->digest.high_level.evp, &is_md5_allowed_for_fips));
         if (is_md5_allowed_for_fips) {
-            GUARD(s2n_hash_allow_md5_for_fips(to));
+            POSIX_GUARD(s2n_hash_allow_md5_for_fips(to));
         }
-        GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp.ctx, from->digest.high_level.evp.ctx), S2N_ERR_HASH_COPY_FAILED);
-        GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp_md5_secondary.ctx, from->digest.high_level.evp_md5_secondary.ctx), S2N_ERR_HASH_COPY_FAILED);
+        POSIX_GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp.ctx, from->digest.high_level.evp.ctx), S2N_ERR_HASH_COPY_FAILED);
+        POSIX_GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp_md5_secondary.ctx, from->digest.high_level.evp_md5_secondary.ctx), S2N_ERR_HASH_COPY_FAILED);
         break;
     default:
-        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 
     to->hash_impl = from->hash_impl;
@@ -430,19 +430,19 @@ static int s2n_evp_hash_reset(struct s2n_hash_state *state)
 {
     int reset_md5_for_fips = 0;
     bool is_md5_allowed_for_fips = false;
-    GUARD_AS_POSIX(s2n_digest_is_md5_allowed_for_fips(&state->digest.high_level.evp, &is_md5_allowed_for_fips));
+    POSIX_GUARD_RESULT(s2n_digest_is_md5_allowed_for_fips(&state->digest.high_level.evp, &is_md5_allowed_for_fips));
     if ((state->alg == S2N_HASH_MD5 || state->alg == S2N_HASH_MD5_SHA1) && is_md5_allowed_for_fips) {
         reset_md5_for_fips = 1;
     }
 
-    GUARD_OSSL(S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp.ctx), S2N_ERR_HASH_WIPE_FAILED);
+    POSIX_GUARD_OSSL(S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp.ctx), S2N_ERR_HASH_WIPE_FAILED);
 
     if (state->alg == S2N_HASH_MD5_SHA1) {
-        GUARD_OSSL(S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp_md5_secondary.ctx), S2N_ERR_HASH_WIPE_FAILED);
+        POSIX_GUARD_OSSL(S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp_md5_secondary.ctx), S2N_ERR_HASH_WIPE_FAILED);
     }
 
     if (reset_md5_for_fips) {
-        GUARD(s2n_hash_allow_md5_for_fips(state));
+        POSIX_GUARD(s2n_hash_allow_md5_for_fips(state));
     }
 
     /* hash_init resets the ready_for_input and currently_in_hash fields. */
@@ -490,97 +490,97 @@ static int s2n_hash_set_impl(struct s2n_hash_state *state)
 
 int s2n_hash_new(struct s2n_hash_state *state)
 {
-    notnull_check(state);
+    POSIX_ENSURE_REF(state);
     /* Set hash_impl on initial hash creation.
      * When in FIPS mode, the EVP API's must be used for hashes.
      */
-    GUARD(s2n_hash_set_impl(state));
+    POSIX_GUARD(s2n_hash_set_impl(state));
 
-    notnull_check(state->hash_impl->alloc);
+    POSIX_ENSURE_REF(state->hash_impl->alloc);
 
-    GUARD(state->hash_impl->alloc(state));
+    POSIX_GUARD(state->hash_impl->alloc(state));
     return S2N_SUCCESS;
 }
 
 S2N_RESULT s2n_hash_state_validate(struct s2n_hash_state *state)
 {
-    ENSURE_REF(state);
+    RESULT_ENSURE_REF(state);
     return S2N_RESULT_OK;
 }
 
 int s2n_hash_allow_md5_for_fips(struct s2n_hash_state *state)
 {
-    notnull_check(state);
+    POSIX_ENSURE_REF(state);
     /* Ensure that hash_impl is set, as it may have been reset for s2n_hash_state on s2n_connection_wipe.
      * When in FIPS mode, the EVP API's must be used for hashes.
      */
-    GUARD(s2n_hash_set_impl(state));
+    POSIX_GUARD(s2n_hash_set_impl(state));
 
-    notnull_check(state->hash_impl->allow_md5_for_fips);
+    POSIX_ENSURE_REF(state->hash_impl->allow_md5_for_fips);
 
     return state->hash_impl->allow_md5_for_fips(state);
 }
 
 int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 {
-    notnull_check(state);
+    POSIX_ENSURE_REF(state);
     /* Ensure that hash_impl is set, as it may have been reset for s2n_hash_state on s2n_connection_wipe.
      * When in FIPS mode, the EVP API's must be used for hashes.
      */
-    GUARD(s2n_hash_set_impl(state));
+    POSIX_GUARD(s2n_hash_set_impl(state));
 
     bool is_md5_allowed_for_fips = false;
-    GUARD_AS_POSIX(s2n_digest_is_md5_allowed_for_fips(&state->digest.high_level.evp, &is_md5_allowed_for_fips));
+    POSIX_GUARD_RESULT(s2n_digest_is_md5_allowed_for_fips(&state->digest.high_level.evp, &is_md5_allowed_for_fips));
 
     if (s2n_hash_is_available(alg) ||
        ((alg == S2N_HASH_MD5 || alg == S2N_HASH_MD5_SHA1) && is_md5_allowed_for_fips)) {
         /* s2n will continue to initialize an "unavailable" hash when s2n is in FIPS mode and
          * FIPS is forcing the hash to be made available.
          */
-        notnull_check(state->hash_impl->init);
+        POSIX_ENSURE_REF(state->hash_impl->init);
 
         return state->hash_impl->init(state, alg);
     } else {
-        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
 }
 
 int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
-    PRECONDITION_POSIX(s2n_hash_state_validate(state));
-    ENSURE_POSIX(S2N_MEM_IS_READABLE(data, size), S2N_ERR_PRECONDITION_VIOLATION);
-    notnull_check(state->hash_impl->update);
+    POSIX_PRECONDITION(s2n_hash_state_validate(state));
+    POSIX_ENSURE(S2N_MEM_IS_READABLE(data, size), S2N_ERR_PRECONDITION_VIOLATION);
+    POSIX_ENSURE_REF(state->hash_impl->update);
 
     return state->hash_impl->update(state, data, size);
 }
 
 int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 {
-    PRECONDITION_POSIX(s2n_hash_state_validate(state));
-    ENSURE_POSIX(S2N_MEM_IS_READABLE(out, size), S2N_ERR_PRECONDITION_VIOLATION);
-    notnull_check(state->hash_impl->digest);
+    POSIX_PRECONDITION(s2n_hash_state_validate(state));
+    POSIX_ENSURE(S2N_MEM_IS_READABLE(out, size), S2N_ERR_PRECONDITION_VIOLATION);
+    POSIX_ENSURE_REF(state->hash_impl->digest);
 
     return state->hash_impl->digest(state, out, size);
 }
 
 int s2n_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
 {
-    PRECONDITION_POSIX(s2n_hash_state_validate(to));
-    PRECONDITION_POSIX(s2n_hash_state_validate(from));
-    notnull_check(from->hash_impl->copy);
+    POSIX_PRECONDITION(s2n_hash_state_validate(to));
+    POSIX_PRECONDITION(s2n_hash_state_validate(from));
+    POSIX_ENSURE_REF(from->hash_impl->copy);
 
     return from->hash_impl->copy(to, from);
 }
 
 int s2n_hash_reset(struct s2n_hash_state *state)
 {
-    notnull_check(state);
+    POSIX_ENSURE_REF(state);
     /* Ensure that hash_impl is set, as it may have been reset for s2n_hash_state on s2n_connection_wipe.
      * When in FIPS mode, the EVP API's must be used for hashes.
      */
-    GUARD(s2n_hash_set_impl(state));
+    POSIX_GUARD(s2n_hash_set_impl(state));
 
-    notnull_check(state->hash_impl->reset);
+    POSIX_ENSURE_REF(state->hash_impl->reset);
 
     return state->hash_impl->reset(state);
 }
@@ -594,18 +594,18 @@ int s2n_hash_free(struct s2n_hash_state *state)
     /* Ensure that hash_impl is set, as it may have been reset for s2n_hash_state on s2n_connection_wipe.
      * When in FIPS mode, the EVP API's must be used for hashes.
      */
-    GUARD(s2n_hash_set_impl(state));
+    POSIX_GUARD(s2n_hash_set_impl(state));
 
-    notnull_check(state->hash_impl->free);
+    POSIX_ENSURE_REF(state->hash_impl->free);
 
     return state->hash_impl->free(state);
 }
 
 int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t *out)
 {
-    PRECONDITION_POSIX(s2n_hash_state_validate(state));
-    ENSURE_POSIX(S2N_MEM_IS_WRITABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
-    ENSURE_POSIX(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+    POSIX_PRECONDITION(s2n_hash_state_validate(state));
+    POSIX_ENSURE(S2N_MEM_IS_WRITABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
+    POSIX_ENSURE(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
     *out = state->currently_in_hash;
     return S2N_SUCCESS;
@@ -615,11 +615,11 @@ int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t 
 /* Calculate, in constant time, the number of bytes currently in the hash_block */
 int s2n_hash_const_time_get_currently_in_hash_block(struct s2n_hash_state *state, uint64_t *out)
 {
-    PRECONDITION_POSIX(s2n_hash_state_validate(state));
-    ENSURE_POSIX(S2N_MEM_IS_WRITABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
-    ENSURE_POSIX(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+    POSIX_PRECONDITION(s2n_hash_state_validate(state));
+    POSIX_ENSURE(S2N_MEM_IS_WRITABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
+    POSIX_ENSURE(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
     uint64_t hash_block_size;
-    GUARD(s2n_hash_block_size(state->alg, &hash_block_size));
+    POSIX_GUARD(s2n_hash_block_size(state->alg, &hash_block_size));
 
     /* Requires that hash_block_size is a power of 2. This is true for all hashes we currently support
      * If this ever becomes untrue, this would require fixing this*/

--- a/crypto/s2n_hkdf.c
+++ b/crypto/s2n_hkdf.c
@@ -34,13 +34,13 @@ int s2n_hkdf_extract(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, const 
                      const struct s2n_blob *key, struct s2n_blob *pseudo_rand_key)
 {
     uint8_t hmac_size;
-    GUARD(s2n_hmac_digest_size(alg, &hmac_size));
+    POSIX_GUARD(s2n_hmac_digest_size(alg, &hmac_size));
     pseudo_rand_key->size = hmac_size;
-    GUARD(s2n_hmac_init(hmac, alg, salt->data, salt->size));
-    GUARD(s2n_hmac_update(hmac, key->data, key->size));
-    GUARD(s2n_hmac_digest(hmac, pseudo_rand_key->data, pseudo_rand_key->size));
+    POSIX_GUARD(s2n_hmac_init(hmac, alg, salt->data, salt->size));
+    POSIX_GUARD(s2n_hmac_update(hmac, key->data, key->size));
+    POSIX_GUARD(s2n_hmac_digest(hmac, pseudo_rand_key->data, pseudo_rand_key->size));
 
-    GUARD(s2n_hmac_reset(hmac));
+    POSIX_GUARD(s2n_hmac_reset(hmac));
 
     return 0;
 }
@@ -52,7 +52,7 @@ static int s2n_hkdf_expand(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, 
 
     uint32_t done_len = 0;
     uint8_t hash_len;
-    GUARD(s2n_hmac_digest_size(alg, &hash_len));
+    POSIX_GUARD(s2n_hmac_digest_size(alg, &hash_len));
     uint32_t total_rounds = output->size / hash_len;
     if (output->size % hash_len) {
         total_rounds++;
@@ -62,24 +62,24 @@ static int s2n_hkdf_expand(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, 
 
     for (uint32_t curr_round = 1; curr_round <= total_rounds; curr_round++) {
         uint32_t cat_len;
-        GUARD(s2n_hmac_init(hmac, alg, pseudo_rand_key->data, pseudo_rand_key->size));
+        POSIX_GUARD(s2n_hmac_init(hmac, alg, pseudo_rand_key->data, pseudo_rand_key->size));
         if (curr_round != 1) {
-            GUARD(s2n_hmac_update(hmac, prev, hash_len));
+            POSIX_GUARD(s2n_hmac_update(hmac, prev, hash_len));
         }
-        GUARD(s2n_hmac_update(hmac, info->data, info->size));
-        GUARD(s2n_hmac_update(hmac, &curr_round, 1));
-        GUARD(s2n_hmac_digest(hmac, prev, hash_len));
+        POSIX_GUARD(s2n_hmac_update(hmac, info->data, info->size));
+        POSIX_GUARD(s2n_hmac_update(hmac, &curr_round, 1));
+        POSIX_GUARD(s2n_hmac_digest(hmac, prev, hash_len));
 
         cat_len = hash_len;
         if (done_len + hash_len > output->size) {
             cat_len = output->size - done_len;
         }
 
-        memcpy_check(output->data + done_len, prev, cat_len);
+        POSIX_CHECKED_MEMCPY(output->data + done_len, prev, cat_len);
 
         done_len += cat_len;
     
-        GUARD(s2n_hmac_reset(hmac));
+        POSIX_GUARD(s2n_hmac_reset(hmac));
     }
 
     return 0;
@@ -96,19 +96,19 @@ int s2n_hkdf_expand_label(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, c
     /* RFC8446 specifies that labels must be 12 characters or less, to avoid
     ** incurring two hash rounds.
     */
-    lte_check(label->size, 12);
+    POSIX_ENSURE_LTE(label->size, 12);
 
-    GUARD(s2n_blob_init(&hkdf_label_blob, hkdf_label_buf, sizeof(hkdf_label_buf)));
-    GUARD(s2n_stuffer_init(&hkdf_label, &hkdf_label_blob));
-    GUARD(s2n_stuffer_write_uint16(&hkdf_label, output->size));
-    GUARD(s2n_stuffer_write_uint8(&hkdf_label, label->size + sizeof("tls13 ") - 1));
-    GUARD(s2n_stuffer_write_str(&hkdf_label, "tls13 "));
-    GUARD(s2n_stuffer_write(&hkdf_label, label));
-    GUARD(s2n_stuffer_write_uint8(&hkdf_label, context->size));
-    GUARD(s2n_stuffer_write(&hkdf_label, context));
+    POSIX_GUARD(s2n_blob_init(&hkdf_label_blob, hkdf_label_buf, sizeof(hkdf_label_buf)));
+    POSIX_GUARD(s2n_stuffer_init(&hkdf_label, &hkdf_label_blob));
+    POSIX_GUARD(s2n_stuffer_write_uint16(&hkdf_label, output->size));
+    POSIX_GUARD(s2n_stuffer_write_uint8(&hkdf_label, label->size + sizeof("tls13 ") - 1));
+    POSIX_GUARD(s2n_stuffer_write_str(&hkdf_label, "tls13 "));
+    POSIX_GUARD(s2n_stuffer_write(&hkdf_label, label));
+    POSIX_GUARD(s2n_stuffer_write_uint8(&hkdf_label, context->size));
+    POSIX_GUARD(s2n_stuffer_write(&hkdf_label, context));
 
     hkdf_label_blob.size = s2n_stuffer_data_available(&hkdf_label);
-    GUARD(s2n_hkdf_expand(hmac, alg, secret, &hkdf_label_blob, output));
+    POSIX_GUARD(s2n_hkdf_expand(hmac, alg, secret, &hkdf_label_blob, output));
 
     return 0;
 }
@@ -119,8 +119,8 @@ int s2n_hkdf(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, const struct s
     uint8_t prk_pad[MAX_DIGEST_SIZE];
     struct s2n_blob pseudo_rand_key = {.data = prk_pad,.size = sizeof(prk_pad) };
 
-    GUARD(s2n_hkdf_extract(hmac, alg, salt, key, &pseudo_rand_key));
-    GUARD(s2n_hkdf_expand(hmac, alg, &pseudo_rand_key, info, output));
+    POSIX_GUARD(s2n_hkdf_extract(hmac, alg, salt, key, &pseudo_rand_key));
+    POSIX_GUARD(s2n_hkdf_expand(hmac, alg, &pseudo_rand_key, info, output));
 
     return 0;
 }

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -30,7 +30,7 @@
 
 int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
 {
-    ENSURE_POSIX(S2N_MEM_IS_WRITABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
+    POSIX_ENSURE(S2N_MEM_IS_WRITABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
     switch(hash_alg) {
     case S2N_HASH_NONE:       *out = S2N_HMAC_NONE;   break;
     case S2N_HASH_MD5:        *out = S2N_HMAC_MD5;    break;
@@ -41,14 +41,14 @@ int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
     case S2N_HASH_SHA512:     *out = S2N_HMAC_SHA512; break;
     case S2N_HASH_MD5_SHA1:   /* Fall through ... */
     default:
-        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
     return S2N_SUCCESS;
 }
 
 int s2n_hmac_hash_alg(s2n_hmac_algorithm hmac_alg, s2n_hash_algorithm *out)
 {
-    ENSURE_POSIX(S2N_MEM_IS_WRITABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
+    POSIX_ENSURE(S2N_MEM_IS_WRITABLE(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
     switch(hmac_alg) {
     case S2N_HMAC_NONE:       *out = S2N_HASH_NONE;   break;
     case S2N_HMAC_MD5:        *out = S2N_HASH_MD5;    break;
@@ -60,7 +60,7 @@ int s2n_hmac_hash_alg(s2n_hmac_algorithm hmac_alg, s2n_hash_algorithm *out)
     case S2N_HMAC_SSLv3_MD5:  *out = S2N_HASH_MD5;    break;
     case S2N_HMAC_SSLv3_SHA1: *out = S2N_HASH_SHA1;   break;
     default:
-        S2N_ERROR(S2N_ERR_HMAC_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HMAC_INVALID_ALGORITHM);
     }
     return S2N_SUCCESS;
 }
@@ -68,8 +68,8 @@ int s2n_hmac_hash_alg(s2n_hmac_algorithm hmac_alg, s2n_hash_algorithm *out)
 int s2n_hmac_digest_size(s2n_hmac_algorithm hmac_alg, uint8_t *out)
 {
     s2n_hash_algorithm hash_alg;
-    GUARD(s2n_hmac_hash_alg(hmac_alg, &hash_alg));
-    GUARD(s2n_hash_digest_size(hash_alg, out));
+    POSIX_GUARD(s2n_hmac_hash_alg(hmac_alg, &hash_alg));
+    POSIX_GUARD(s2n_hash_digest_size(hash_alg, out));
     return S2N_SUCCESS;
 }
 
@@ -99,15 +99,15 @@ static int s2n_sslv3_mac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm a
         state->xor_pad[i] = 0x36;
     }
 
-    GUARD(s2n_hash_update(&state->inner_just_key, key, klen));
-    GUARD(s2n_hash_update(&state->inner_just_key, state->xor_pad, state->xor_pad_size));
+    POSIX_GUARD(s2n_hash_update(&state->inner_just_key, key, klen));
+    POSIX_GUARD(s2n_hash_update(&state->inner_just_key, state->xor_pad, state->xor_pad_size));
 
     for (int i = 0; i < state->xor_pad_size; i++) {
         state->xor_pad[i] = 0x5c;
     }
 
-    GUARD(s2n_hash_update(&state->outer_just_key, key, klen));
-    GUARD(s2n_hash_update(&state->outer_just_key, state->xor_pad, state->xor_pad_size));
+    POSIX_GUARD(s2n_hash_update(&state->outer_just_key, key, klen));
+    POSIX_GUARD(s2n_hash_update(&state->outer_just_key, state->xor_pad, state->xor_pad_size));
 
     return S2N_SUCCESS;
 }
@@ -117,31 +117,31 @@ static int s2n_tls_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm al
     memset(&state->xor_pad, 0, sizeof(state->xor_pad));
 
     if (klen > state->xor_pad_size) {
-        GUARD(s2n_hash_update(&state->outer, key, klen));
-        GUARD(s2n_hash_digest(&state->outer, state->digest_pad, state->digest_size));
-        memcpy_check(state->xor_pad, state->digest_pad, state->digest_size);
+        POSIX_GUARD(s2n_hash_update(&state->outer, key, klen));
+        POSIX_GUARD(s2n_hash_digest(&state->outer, state->digest_pad, state->digest_size));
+        POSIX_CHECKED_MEMCPY(state->xor_pad, state->digest_pad, state->digest_size);
     } else {
-        memcpy_check(state->xor_pad, key, klen);
+        POSIX_CHECKED_MEMCPY(state->xor_pad, key, klen);
     }
 
     for (int i = 0; i < state->xor_pad_size; i++) {
         state->xor_pad[i] ^= 0x36;
     }
 
-    GUARD(s2n_hash_update(&state->inner_just_key, state->xor_pad, state->xor_pad_size));
+    POSIX_GUARD(s2n_hash_update(&state->inner_just_key, state->xor_pad, state->xor_pad_size));
 
     /* 0x36 xor 0x5c == 0x6a */
     for (int i = 0; i < state->xor_pad_size; i++) {
         state->xor_pad[i] ^= 0x6a;
     }
 
-    GUARD(s2n_hash_update(&state->outer_just_key, state->xor_pad, state->xor_pad_size));
+    POSIX_GUARD(s2n_hash_update(&state->outer_just_key, state->xor_pad, state->xor_pad_size));
     return S2N_SUCCESS;
 }
 
 int s2n_hmac_xor_pad_size(s2n_hmac_algorithm hmac_alg, uint16_t *xor_pad_size)
 {
-    ENSURE_POSIX(S2N_MEM_IS_WRITABLE(xor_pad_size, sizeof(*xor_pad_size)), S2N_ERR_PRECONDITION_VIOLATION);
+    POSIX_ENSURE(S2N_MEM_IS_WRITABLE(xor_pad_size, sizeof(*xor_pad_size)), S2N_ERR_PRECONDITION_VIOLATION);
     switch(hmac_alg) {
     case S2N_HMAC_NONE:       *xor_pad_size = 64;   break;
     case S2N_HMAC_MD5:        *xor_pad_size = 64;   break;
@@ -153,14 +153,14 @@ int s2n_hmac_xor_pad_size(s2n_hmac_algorithm hmac_alg, uint16_t *xor_pad_size)
     case S2N_HMAC_SSLv3_MD5:  *xor_pad_size = 48;   break;
     case S2N_HMAC_SSLv3_SHA1: *xor_pad_size = 40;   break;
     default:
-        S2N_ERROR(S2N_ERR_HMAC_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HMAC_INVALID_ALGORITHM);
     }
     return S2N_SUCCESS;
 }
 
 int s2n_hmac_hash_block_size(s2n_hmac_algorithm hmac_alg, uint16_t *block_size)
 {
-    ENSURE_POSIX(S2N_MEM_IS_WRITABLE(block_size, sizeof(*block_size)), S2N_ERR_PRECONDITION_VIOLATION);
+    POSIX_ENSURE(S2N_MEM_IS_WRITABLE(block_size, sizeof(*block_size)), S2N_ERR_PRECONDITION_VIOLATION);
     switch(hmac_alg) {
     case S2N_HMAC_NONE:       *block_size = 64;   break;
     case S2N_HMAC_MD5:        *block_size = 64;   break;
@@ -172,63 +172,63 @@ int s2n_hmac_hash_block_size(s2n_hmac_algorithm hmac_alg, uint16_t *block_size)
     case S2N_HMAC_SSLv3_MD5:  *block_size = 64;   break;
     case S2N_HMAC_SSLv3_SHA1: *block_size = 64;   break;
     default:
-        S2N_ERROR(S2N_ERR_HMAC_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HMAC_INVALID_ALGORITHM);
     }
     return S2N_SUCCESS;
 }
 
 int s2n_hmac_new(struct s2n_hmac_state *state)
 {
-    ENSURE_POSIX_REF(state);
-    GUARD(s2n_hash_new(&state->inner));
-    GUARD(s2n_hash_new(&state->inner_just_key));
-    GUARD(s2n_hash_new(&state->outer));
-    GUARD(s2n_hash_new(&state->outer_just_key));
-    POSTCONDITION_POSIX(s2n_hmac_state_validate(state));
+    POSIX_ENSURE_REF(state);
+    POSIX_GUARD(s2n_hash_new(&state->inner));
+    POSIX_GUARD(s2n_hash_new(&state->inner_just_key));
+    POSIX_GUARD(s2n_hash_new(&state->outer));
+    POSIX_GUARD(s2n_hash_new(&state->outer_just_key));
+    POSIX_POSTCONDITION(s2n_hmac_state_validate(state));
     return S2N_SUCCESS;
 }
 
 S2N_RESULT s2n_hmac_state_validate(struct s2n_hmac_state *state)
 {
-    ENSURE_REF(state);
-    GUARD_RESULT(s2n_hash_state_validate(&state->inner));
-    GUARD_RESULT(s2n_hash_state_validate(&state->inner_just_key));
-    GUARD_RESULT(s2n_hash_state_validate(&state->outer));
-    GUARD_RESULT(s2n_hash_state_validate(&state->outer_just_key));
+    RESULT_ENSURE_REF(state);
+    RESULT_GUARD(s2n_hash_state_validate(&state->inner));
+    RESULT_GUARD(s2n_hash_state_validate(&state->inner_just_key));
+    RESULT_GUARD(s2n_hash_state_validate(&state->outer));
+    RESULT_GUARD(s2n_hash_state_validate(&state->outer_just_key));
     return S2N_RESULT_OK;
 }
 
 int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen)
 {
-    notnull_check(state);
+    POSIX_ENSURE_REF(state);
     if (!s2n_hmac_is_available(alg)) {
         /* Prevent hmacs from being used if they are not available. */
-        S2N_ERROR(S2N_ERR_HMAC_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HMAC_INVALID_ALGORITHM);
     }
 
     state->alg = alg;
-    GUARD(s2n_hmac_hash_block_size(alg, &state->hash_block_size));
+    POSIX_GUARD(s2n_hmac_hash_block_size(alg, &state->hash_block_size));
     state->currently_in_hash_block = 0;
-    GUARD(s2n_hmac_xor_pad_size(alg, &state->xor_pad_size));
-    GUARD(s2n_hmac_digest_size(alg, &state->digest_size));
+    POSIX_GUARD(s2n_hmac_xor_pad_size(alg, &state->xor_pad_size));
+    POSIX_GUARD(s2n_hmac_digest_size(alg, &state->digest_size));
 
-    gte_check(sizeof(state->xor_pad), state->xor_pad_size);
-    gte_check(sizeof(state->digest_pad), state->digest_size);
+    POSIX_ENSURE_GTE(sizeof(state->xor_pad), state->xor_pad_size);
+    POSIX_ENSURE_GTE(sizeof(state->digest_pad), state->digest_size);
     /* key needs to be as large as the biggest block size */
-    gte_check(sizeof(state->xor_pad), state->hash_block_size);
+    POSIX_ENSURE_GTE(sizeof(state->xor_pad), state->hash_block_size);
 
     s2n_hash_algorithm hash_alg;
-    GUARD(s2n_hmac_hash_alg(alg, &hash_alg));
+    POSIX_GUARD(s2n_hmac_hash_alg(alg, &hash_alg));
 
-    GUARD(s2n_hash_init(&state->inner, hash_alg));
-    GUARD(s2n_hash_init(&state->inner_just_key, hash_alg));
-    GUARD(s2n_hash_init(&state->outer, hash_alg));
-    GUARD(s2n_hash_init(&state->outer_just_key, hash_alg));
+    POSIX_GUARD(s2n_hash_init(&state->inner, hash_alg));
+    POSIX_GUARD(s2n_hash_init(&state->inner_just_key, hash_alg));
+    POSIX_GUARD(s2n_hash_init(&state->outer, hash_alg));
+    POSIX_GUARD(s2n_hash_init(&state->outer_just_key, hash_alg));
 
     if (alg == S2N_HMAC_SSLv3_SHA1 || alg == S2N_HMAC_SSLv3_MD5) {
-        GUARD(s2n_sslv3_mac_init(state, alg, key, klen));
+        POSIX_GUARD(s2n_sslv3_mac_init(state, alg, key, klen));
     } else {
-        GUARD(s2n_tls_hmac_init(state, alg, key, klen));
+        POSIX_GUARD(s2n_tls_hmac_init(state, alg, key, klen));
     }
 
     /* Once we have produced inner_just_key and outer_just_key, don't need the key material in xor_pad, so wipe it.
@@ -236,15 +236,15 @@ int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const vo
      * this also prevents uninitilized bytes being used.
      */
     memset(&state->xor_pad, 0, sizeof(state->xor_pad));
-    GUARD(s2n_hmac_reset(state));
+    POSIX_GUARD(s2n_hmac_reset(state));
 
     return S2N_SUCCESS;
 }
 
 int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
 {
-    PRECONDITION_POSIX(s2n_hmac_state_validate(state));
-    ENSURE_POSIX(state->hash_block_size != 0, S2N_ERR_PRECONDITION_VIOLATION);
+    POSIX_PRECONDITION(s2n_hmac_state_validate(state));
+    POSIX_ENSURE(state->hash_block_size != 0, S2N_ERR_PRECONDITION_VIOLATION);
     /* Keep track of how much of the current hash block is full
      *
      * Why the 4294949760 constant in this code? 4294949760 is the highest 32-bit
@@ -267,9 +267,9 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
      * smaller number of cycles if the input is "small".
      */
     const uint32_t HIGHEST_32_BIT = 4294949760;
-    ENSURE_POSIX(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
+    POSIX_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
     uint32_t value = (HIGHEST_32_BIT + size) % state->hash_block_size;
-    GUARD(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
+    POSIX_GUARD(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
     state->currently_in_hash_block %= state->hash_block_size;
 
     return s2n_hash_update(&state->inner, in, size);
@@ -277,10 +277,10 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
 
 int s2n_hmac_digest(struct s2n_hmac_state *state, void *out, uint32_t size)
 {
-    PRECONDITION_POSIX(s2n_hmac_state_validate(state));
-    GUARD(s2n_hash_digest(&state->inner, state->digest_pad, state->digest_size));
-    GUARD(s2n_hash_copy(&state->outer, &state->outer_just_key));
-    GUARD(s2n_hash_update(&state->outer, state->digest_pad, state->digest_size));
+    POSIX_PRECONDITION(s2n_hmac_state_validate(state));
+    POSIX_GUARD(s2n_hash_digest(&state->inner, state->digest_pad, state->digest_size));
+    POSIX_GUARD(s2n_hash_copy(&state->outer, &state->outer_just_key));
+    POSIX_GUARD(s2n_hash_update(&state->outer, state->digest_pad, state->digest_size));
 
     return s2n_hash_digest(&state->outer, out, size);
 }
@@ -288,7 +288,7 @@ int s2n_hmac_digest(struct s2n_hmac_state *state, void *out, uint32_t size)
 int s2n_hmac_digest_two_compression_rounds(struct s2n_hmac_state *state, void *out, uint32_t size)
 {
     /* Do the "real" work of this function. */
-    GUARD(s2n_hmac_digest(state, out, size));
+    POSIX_GUARD(s2n_hmac_digest(state, out, size));
 
     /* If there were 9 or more bytes of space left in the current hash block
      * then the serialized length, plus an 0x80 byte, will have fit in that block.
@@ -304,7 +304,7 @@ int s2n_hmac_digest_two_compression_rounds(struct s2n_hmac_state *state, void *o
     }
 
     /* Can't reuse a hash after it has been finalized, so reset and push another block in */
-    GUARD(s2n_hash_reset(&state->inner));
+    POSIX_GUARD(s2n_hash_reset(&state->inner));
 
     /* No-op s2n_hash_update to normalize timing and guard against Lucky13. This does not affect the value of *out. */
     return s2n_hash_update(&state->inner, state->xor_pad, state->hash_block_size);
@@ -313,10 +313,10 @@ int s2n_hmac_digest_two_compression_rounds(struct s2n_hmac_state *state, void *o
 int s2n_hmac_free(struct s2n_hmac_state *state)
 {
     if (state) {
-        GUARD(s2n_hash_free(&state->inner));
-        GUARD(s2n_hash_free(&state->inner_just_key));
-        GUARD(s2n_hash_free(&state->outer));
-        GUARD(s2n_hash_free(&state->outer_just_key));
+        POSIX_GUARD(s2n_hash_free(&state->inner));
+        POSIX_GUARD(s2n_hash_free(&state->inner_just_key));
+        POSIX_GUARD(s2n_hash_free(&state->outer));
+        POSIX_GUARD(s2n_hash_free(&state->outer_just_key));
     }
 
     return S2N_SUCCESS;
@@ -324,14 +324,14 @@ int s2n_hmac_free(struct s2n_hmac_state *state)
 
 int s2n_hmac_reset(struct s2n_hmac_state *state)
 {
-    PRECONDITION_POSIX(s2n_hmac_state_validate(state));
-    ENSURE_POSIX(state->hash_block_size != 0, S2N_ERR_PRECONDITION_VIOLATION);
-    GUARD(s2n_hash_copy(&state->inner, &state->inner_just_key));
+    POSIX_PRECONDITION(s2n_hmac_state_validate(state));
+    POSIX_ENSURE(state->hash_block_size != 0, S2N_ERR_PRECONDITION_VIOLATION);
+    POSIX_GUARD(s2n_hash_copy(&state->inner, &state->inner_just_key));
 
     uint64_t bytes_in_hash;
-    GUARD(s2n_hash_get_currently_in_hash_total(&state->inner, &bytes_in_hash));
+    POSIX_GUARD(s2n_hash_get_currently_in_hash_total(&state->inner, &bytes_in_hash));
     bytes_in_hash %= state->hash_block_size;
-    ENSURE_POSIX(bytes_in_hash <= UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    POSIX_ENSURE(bytes_in_hash <= UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
     /* The length of the key is not private, so don't need to do tricky math here */
     state->currently_in_hash_block = bytes_in_hash;
     return S2N_SUCCESS;
@@ -344,8 +344,8 @@ int s2n_hmac_digest_verify(const void *a, const void *b, uint32_t len)
 
 int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
 {
-    PRECONDITION_POSIX(s2n_hmac_state_validate(to));
-    PRECONDITION_POSIX(s2n_hmac_state_validate(from));
+    POSIX_PRECONDITION(s2n_hmac_state_validate(to));
+    POSIX_PRECONDITION(s2n_hmac_state_validate(from));
     /* memcpy cannot be used on s2n_hmac_state as the underlying s2n_hash implementation's
      * copy must be used. This is enforced when the s2n_hash implementation is s2n_evp_hash.
      */
@@ -355,16 +355,16 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
     to->xor_pad_size = from->xor_pad_size;
     to->digest_size = from->digest_size;
 
-    GUARD(s2n_hash_copy(&to->inner, &from->inner));
-    GUARD(s2n_hash_copy(&to->inner_just_key, &from->inner_just_key));
-    GUARD(s2n_hash_copy(&to->outer, &from->outer));
-    GUARD(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
+    POSIX_GUARD(s2n_hash_copy(&to->inner, &from->inner));
+    POSIX_GUARD(s2n_hash_copy(&to->inner_just_key, &from->inner_just_key));
+    POSIX_GUARD(s2n_hash_copy(&to->outer, &from->outer));
+    POSIX_GUARD(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
 
 
-    memcpy_check(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
-    memcpy_check(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
-    POSTCONDITION_POSIX(s2n_hmac_state_validate(to));
-    POSTCONDITION_POSIX(s2n_hmac_state_validate(from));
+    POSIX_CHECKED_MEMCPY(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
+    POSIX_CHECKED_MEMCPY(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
+    POSIX_POSTCONDITION(s2n_hmac_state_validate(to));
+    POSIX_POSTCONDITION(s2n_hmac_state_validate(from));
     return S2N_SUCCESS;
 }
 
@@ -374,8 +374,8 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
  */
 int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
 {
-    ENSURE_POSIX_REF(backup);
-    PRECONDITION_POSIX(s2n_hmac_state_validate(hmac));
+    POSIX_ENSURE_REF(backup);
+    POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
     backup->inner = hmac->inner.digest.high_level;
     backup->inner_just_key = hmac->inner_just_key.digest.high_level;
     backup->outer = hmac->outer.digest.high_level;
@@ -385,12 +385,12 @@ int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_
 
 int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
 {
-    ENSURE_POSIX_REF(backup);
-    PRECONDITION_POSIX(s2n_hmac_state_validate(hmac));
+    POSIX_ENSURE_REF(backup);
+    POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
     hmac->inner.digest.high_level = backup->inner;
     hmac->inner_just_key.digest.high_level = backup->inner_just_key;
     hmac->outer.digest.high_level = backup->outer;
     hmac->outer_just_key.digest.high_level = backup->outer_just_key;
-    POSTCONDITION_POSIX(s2n_hmac_state_validate(hmac));
+    POSIX_POSTCONDITION(s2n_hmac_state_validate(hmac));
     return S2N_SUCCESS;
 }

--- a/crypto/s2n_openssl.h
+++ b/crypto/s2n_openssl.h
@@ -37,7 +37,7 @@
     (OPENSSL_VERSION_NUMBER >= ((major << 28) + (minor << 20) + (fix << 12)))
 
 #if (S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0)) && (!defined(OPENSSL_IS_BORINGSSL)) && (!defined(OPENSSL_IS_AWSLC))
-#define s2n_evp_ctx_init(ctx) GUARD_OSSL(EVP_CIPHER_CTX_init(ctx), S2N_ERR_DRBG)
+#define s2n_evp_ctx_init(ctx) POSIX_GUARD_OSSL(EVP_CIPHER_CTX_init(ctx), S2N_ERR_DRBG)
 #else
 #define s2n_evp_ctx_init(ctx) EVP_CIPHER_CTX_init(ctx)
 #endif

--- a/crypto/s2n_pkey.c
+++ b/crypto/s2n_pkey.c
@@ -51,26 +51,26 @@ int s2n_pkey_setup_for_type(struct s2n_pkey *pkey, s2n_pkey_type pkey_type)
             return s2n_rsa_pss_pkey_init(pkey);
         case S2N_PKEY_TYPE_SENTINEL:
         case S2N_PKEY_TYPE_UNKNOWN:
-            S2N_ERROR(S2N_ERR_CERT_TYPE_UNSUPPORTED);
+            POSIX_BAIL(S2N_ERR_CERT_TYPE_UNSUPPORTED);
     }
-    S2N_ERROR(S2N_ERR_CERT_TYPE_UNSUPPORTED);
+    POSIX_BAIL(S2N_ERR_CERT_TYPE_UNSUPPORTED);
 }
 
 int s2n_pkey_check_key_exists(const struct s2n_pkey *pkey)
 {
-    notnull_check(pkey->pkey);
-    notnull_check(pkey->check_key);
+    POSIX_ENSURE_REF(pkey->pkey);
+    POSIX_ENSURE_REF(pkey->check_key);
 
     return pkey->check_key(pkey);
 }
 
 S2N_RESULT s2n_pkey_size(const struct s2n_pkey *pkey, uint32_t *size_out)
 {
-    ENSURE_REF(pkey);
-    ENSURE_REF(pkey->size);
-    ENSURE_REF(size_out);
+    RESULT_ENSURE_REF(pkey);
+    RESULT_ENSURE_REF(pkey->size);
+    RESULT_ENSURE_REF(size_out);
 
-    GUARD_RESULT(pkey->size(pkey, size_out));
+    RESULT_GUARD(pkey->size(pkey, size_out));
 
     return S2N_RESULT_OK;
 }
@@ -78,7 +78,7 @@ S2N_RESULT s2n_pkey_size(const struct s2n_pkey *pkey, uint32_t *size_out)
 int s2n_pkey_sign(const struct s2n_pkey *pkey, s2n_signature_algorithm sig_alg,
         struct s2n_hash_state *digest, struct s2n_blob *signature)
 {
-    notnull_check(pkey->sign);
+    POSIX_ENSURE_REF(pkey->sign);
     
     return pkey->sign(pkey, sig_alg, digest, signature);
 }
@@ -86,29 +86,29 @@ int s2n_pkey_sign(const struct s2n_pkey *pkey, s2n_signature_algorithm sig_alg,
 int s2n_pkey_verify(const struct s2n_pkey *pkey, s2n_signature_algorithm sig_alg,
         struct s2n_hash_state *digest, struct s2n_blob *signature)
 {
-    notnull_check(pkey);
-    notnull_check(pkey->verify);
+    POSIX_ENSURE_REF(pkey);
+    POSIX_ENSURE_REF(pkey->verify);
 
     return pkey->verify(pkey, sig_alg, digest, signature);
 }
 
 int s2n_pkey_encrypt(const struct s2n_pkey *pkey, struct s2n_blob *in, struct s2n_blob *out)
 {
-    notnull_check(pkey->encrypt);
+    POSIX_ENSURE_REF(pkey->encrypt);
 
     return pkey->encrypt(pkey, in, out);
 }
 
 int s2n_pkey_decrypt(const struct s2n_pkey *pkey, struct s2n_blob *in, struct s2n_blob *out)
 {
-    notnull_check(pkey->decrypt);
+    POSIX_ENSURE_REF(pkey->decrypt);
 
     return pkey->decrypt(pkey, in, out);
 }
 
 int s2n_pkey_match(const struct s2n_pkey *pub_key, const struct s2n_pkey *priv_key)
 {
-    notnull_check(pub_key->match);
+    POSIX_ENSURE_REF(pub_key->match);
 
     S2N_ERROR_IF(pub_key->match != priv_key->match, S2N_ERR_KEY_MISMATCH);
 
@@ -118,7 +118,7 @@ int s2n_pkey_match(const struct s2n_pkey *pub_key, const struct s2n_pkey *priv_k
 int s2n_pkey_free(struct s2n_pkey *key)
 {
     if (key != NULL && key->free != NULL) {
-        GUARD(key->free(key));
+        POSIX_GUARD(key->free(key));
     }
 
     if (key->pkey != NULL) {
@@ -141,7 +141,7 @@ int s2n_asn1der_to_private_key(struct s2n_pkey *priv_key, struct s2n_blob *asn1d
     /* If key parsing is successful, d2i_AutoPrivateKey increments *key_to_parse to the byte following the parsed data */
     uint32_t parsed_len = key_to_parse - asn1der->data;
     if (parsed_len != asn1der->size) {
-        S2N_ERROR(S2N_ERR_DECODE_PRIVATE_KEY);
+        POSIX_BAIL(S2N_ERR_DECODE_PRIVATE_KEY);
     }
 
     /* Initialize s2n_pkey according to key type */
@@ -171,7 +171,7 @@ int s2n_asn1der_to_private_key(struct s2n_pkey *priv_key, struct s2n_blob *asn1d
         ret = s2n_evp_pkey_to_ecdsa_private_key(&priv_key->key.ecdsa_key, evp_private_key);
         break;
     default:
-        S2N_ERROR(S2N_ERR_DECODE_PRIVATE_KEY);
+        POSIX_BAIL(S2N_ERR_DECODE_PRIVATE_KEY);
     }
     
     priv_key->pkey = evp_private_key;
@@ -195,7 +195,7 @@ int s2n_asn1der_to_public_key_and_type(struct s2n_pkey *pub_key, s2n_pkey_type *
     /* Some TLS clients in the wild send extra trailing bytes after the Certificate.
      * Allow this in s2n for backwards compatibility with existing clients. */
     uint32_t trailing_bytes = asn1der->size - parsed_len;
-    ENSURE_POSIX(trailing_bytes <= S2N_MAX_ALLOWED_CERT_TRAILING_BYTES, S2N_ERR_DECODE_CERTIFICATE);
+    POSIX_ENSURE(trailing_bytes <= S2N_MAX_ALLOWED_CERT_TRAILING_BYTES, S2N_ERR_DECODE_CERTIFICATE);
 
     DEFER_CLEANUP(EVP_PKEY *evp_public_key = X509_get_pubkey(cert), EVP_PKEY_free_pointer);
     S2N_ERROR_IF(evp_public_key == NULL, S2N_ERR_DECODE_CERTIFICATE);
@@ -230,7 +230,7 @@ int s2n_asn1der_to_public_key_and_type(struct s2n_pkey *pub_key, s2n_pkey_type *
         *pkey_type_out = S2N_PKEY_TYPE_ECDSA;
         break;
     default:
-        S2N_ERROR(S2N_ERR_DECODE_CERTIFICATE);
+        POSIX_BAIL(S2N_ERR_DECODE_CERTIFICATE);
     }
 
     pub_key->pkey = evp_public_key;

--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -37,24 +37,24 @@ static S2N_RESULT s2n_rsa_modulus_check(RSA *rsa)
     const BIGNUM *n = NULL;
     /* RSA still owns the memory for n */
     RSA_get0_key(rsa, &n, NULL, NULL);
-    ENSURE_REF(n);
+    RESULT_ENSURE_REF(n);
 #else
-    ENSURE_REF(rsa->n);
+    RESULT_ENSURE_REF(rsa->n);
 #endif
     return S2N_RESULT_OK;
 }
 
 static S2N_RESULT s2n_rsa_encrypted_size(const struct s2n_pkey *key, uint32_t *size_out)
 {
-    ENSURE_REF(key);
-    ENSURE_REF(size_out);
+    RESULT_ENSURE_REF(key);
+    RESULT_ENSURE_REF(size_out);
 
     const struct s2n_rsa_key *rsa_key = &key->key.rsa_key;
-    ENSURE_REF(rsa_key->rsa);
-    GUARD_RESULT(s2n_rsa_modulus_check(rsa_key->rsa));
+    RESULT_ENSURE_REF(rsa_key->rsa);
+    RESULT_GUARD(s2n_rsa_modulus_check(rsa_key->rsa));
 
     const int size = RSA_size(rsa_key->rsa);
-    GUARD_AS_RESULT(size);
+    RESULT_GUARD_POSIX(size);
     *size_out = size;
 
     return S2N_RESULT_OK;
@@ -69,7 +69,7 @@ static int s2n_rsa_sign(const struct s2n_pkey *priv, s2n_signature_algorithm sig
         case S2N_SIGNATURE_RSA_PSS_RSAE:
             return s2n_rsa_pss_sign(priv, digest, signature);
         default:
-            S2N_ERROR(S2N_ERR_INVALID_SIGNATURE_ALGORITHM);
+            POSIX_BAIL(S2N_ERR_INVALID_SIGNATURE_ALGORITHM);
     }
 
     return S2N_SUCCESS;
@@ -84,7 +84,7 @@ static int s2n_rsa_verify(const struct s2n_pkey *pub, s2n_signature_algorithm si
         case S2N_SIGNATURE_RSA_PSS_RSAE:
             return s2n_rsa_pss_verify(pub, digest, signature);
         default:
-            S2N_ERROR(S2N_ERR_INVALID_SIGNATURE_ALGORITHM);
+            POSIX_BAIL(S2N_ERR_INVALID_SIGNATURE_ALGORITHM);
     }
 
     return S2N_SUCCESS;
@@ -93,7 +93,7 @@ static int s2n_rsa_verify(const struct s2n_pkey *pub, s2n_signature_algorithm si
 static int s2n_rsa_encrypt(const struct s2n_pkey *pub, struct s2n_blob *in, struct s2n_blob *out)
 {
     uint32_t size = 0;
-    GUARD_AS_POSIX(s2n_rsa_encrypted_size(pub, &size));
+    POSIX_GUARD_RESULT(s2n_rsa_encrypted_size(pub, &size));
     S2N_ERROR_IF(out->size < size, S2N_ERR_NOMEM);
 
     const s2n_rsa_public_key *key = &pub->key.rsa_key;
@@ -109,12 +109,12 @@ static int s2n_rsa_decrypt(const struct s2n_pkey *priv, struct s2n_blob *in, str
     unsigned char intermediate[ 4096 ];
     uint32_t      expected_size = 0;
 
-    GUARD_AS_POSIX(s2n_rsa_encrypted_size(priv, &expected_size));
+    POSIX_GUARD_RESULT(s2n_rsa_encrypted_size(priv, &expected_size));
 
     S2N_ERROR_IF(expected_size > sizeof(intermediate), S2N_ERR_NOMEM);
     S2N_ERROR_IF(out->size > sizeof(intermediate), S2N_ERR_NOMEM);
 
-    GUARD_AS_POSIX(s2n_get_public_random_data(out));
+    POSIX_GUARD_RESULT(s2n_get_public_random_data(out));
 
     const s2n_rsa_private_key *key = &priv->key.rsa_key;
     int r = RSA_private_decrypt(in->size, ( unsigned char * )in->data, intermediate, key->rsa, RSA_NO_PADDING);
@@ -134,13 +134,13 @@ static int s2n_rsa_keys_match(const struct s2n_pkey *pub, const struct s2n_pkey 
     plain_in.size = sizeof(plain_inpad);
 
     enc.data = encpad;
-    GUARD_AS_POSIX(s2n_rsa_encrypted_size(pub, &enc.size));
-    lte_check(enc.size, sizeof(encpad));
-    GUARD(s2n_rsa_encrypt(pub, &plain_in, &enc));
+    POSIX_GUARD_RESULT(s2n_rsa_encrypted_size(pub, &enc.size));
+    POSIX_ENSURE_LTE(enc.size, sizeof(encpad));
+    POSIX_GUARD(s2n_rsa_encrypt(pub, &plain_in, &enc));
 
     plain_out.data = plain_outpad;
     plain_out.size = sizeof(plain_outpad);
-    GUARD(s2n_rsa_decrypt(priv, &enc, &plain_out));
+    POSIX_GUARD(s2n_rsa_decrypt(priv, &enc, &plain_out));
 
     S2N_ERROR_IF(memcmp(plain_in.data, plain_out.data, plain_in.size), S2N_ERR_KEY_MISMATCH);
 
@@ -161,7 +161,7 @@ static int s2n_rsa_key_free(struct s2n_pkey *pkey)
 static int s2n_rsa_check_key_exists(const struct s2n_pkey *pkey)
 {
     const struct s2n_rsa_key *rsa_key = &pkey->key.rsa_key;
-    notnull_check(rsa_key->rsa);
+    POSIX_ENSURE_REF(rsa_key->rsa);
     return 0;
 }
 

--- a/crypto/s2n_rsa_pss.c
+++ b/crypto/s2n_rsa_pss.c
@@ -43,12 +43,12 @@ int s2n_is_rsa_pss_certs_supported()
 
 static S2N_RESULT s2n_rsa_pss_size(const struct s2n_pkey *key, uint32_t *size_out)
 {
-    ENSURE_REF(key);
-    ENSURE_REF(size_out);
+    RESULT_ENSURE_REF(key);
+    RESULT_ENSURE_REF(size_out);
 
     /* For more info, see: https://www.openssl.org/docs/man1.1.0/man3/EVP_PKEY_size.html */
     const int size = EVP_PKEY_size(key->pkey);
-    GUARD_AS_RESULT(size);
+    RESULT_GUARD_POSIX(size);
     *size_out = size;
 
     return S2N_RESULT_OK;
@@ -68,7 +68,7 @@ static int s2n_rsa_is_private_key(RSA *rsa_key)
 int s2n_rsa_pss_key_sign(const struct s2n_pkey *priv, s2n_signature_algorithm sig_alg,
         struct s2n_hash_state *digest, struct s2n_blob *signature_out)
 {
-    notnull_check(priv);
+    POSIX_ENSURE_REF(priv);
     sig_alg_check(sig_alg, S2N_SIGNATURE_RSA_PSS_PSS);
 
     /* Not Possible to Sign with Public Key */
@@ -80,7 +80,7 @@ int s2n_rsa_pss_key_sign(const struct s2n_pkey *priv, s2n_signature_algorithm si
 int s2n_rsa_pss_key_verify(const struct s2n_pkey *pub, s2n_signature_algorithm sig_alg,
         struct s2n_hash_state *digest, struct s2n_blob *signature_in)
 {
-    notnull_check(pub);
+    POSIX_ENSURE_REF(pub);
     sig_alg_check(sig_alg, S2N_SIGNATURE_RSA_PSS_PSS);
 
     /* Using Private Key to Verify means the public/private keys were likely swapped, and likely indicates a bug. */
@@ -93,22 +93,22 @@ static int s2n_rsa_pss_validate_sign_verify_match(const struct s2n_pkey *pub, co
 {
     /* Generate a random blob to sign and verify */
     s2n_stack_blob(random_data, RSA_PSS_SIGN_VERIFY_RANDOM_BLOB_SIZE, RSA_PSS_SIGN_VERIFY_RANDOM_BLOB_SIZE);
-    GUARD_AS_POSIX(s2n_get_private_random_data(&random_data));
+    POSIX_GUARD_RESULT(s2n_get_private_random_data(&random_data));
 
     /* Sign/Verify API's only accept Hashes, so hash our Random Data */
     DEFER_CLEANUP(struct s2n_hash_state sign_hash = {0}, s2n_hash_free);
     DEFER_CLEANUP(struct s2n_hash_state verify_hash = {0}, s2n_hash_free);
-    GUARD(s2n_hash_new(&sign_hash));
-    GUARD(s2n_hash_new(&verify_hash));
-    GUARD(s2n_hash_init(&sign_hash, S2N_HASH_SHA256));
-    GUARD(s2n_hash_init(&verify_hash, S2N_HASH_SHA256));
-    GUARD(s2n_hash_update(&sign_hash, random_data.data, random_data.size));
-    GUARD(s2n_hash_update(&verify_hash, random_data.data, random_data.size));
+    POSIX_GUARD(s2n_hash_new(&sign_hash));
+    POSIX_GUARD(s2n_hash_new(&verify_hash));
+    POSIX_GUARD(s2n_hash_init(&sign_hash, S2N_HASH_SHA256));
+    POSIX_GUARD(s2n_hash_init(&verify_hash, S2N_HASH_SHA256));
+    POSIX_GUARD(s2n_hash_update(&sign_hash, random_data.data, random_data.size));
+    POSIX_GUARD(s2n_hash_update(&verify_hash, random_data.data, random_data.size));
 
     /* Sign and Verify the Hash of the Random Blob */
     s2n_stack_blob(signature_data, RSA_PSS_SIGN_VERIFY_SIGNATURE_SIZE, RSA_PSS_SIGN_VERIFY_SIGNATURE_SIZE);
-    GUARD(s2n_rsa_pss_key_sign(priv, S2N_SIGNATURE_RSA_PSS_PSS, &sign_hash, &signature_data));
-    GUARD(s2n_rsa_pss_key_verify(pub, S2N_SIGNATURE_RSA_PSS_PSS, &verify_hash, &signature_data));
+    POSIX_GUARD(s2n_rsa_pss_key_sign(priv, S2N_SIGNATURE_RSA_PSS_PSS, &sign_hash, &signature_data));
+    POSIX_GUARD(s2n_rsa_pss_key_verify(pub, S2N_SIGNATURE_RSA_PSS_PSS, &verify_hash, &signature_data));
 
     return 0;
 }
@@ -124,11 +124,11 @@ static int s2n_rsa_validate_params_equal(const RSA *pub, const RSA *priv)
     RSA_get0_key(priv, &priv_val_n, &priv_val_e, NULL);
 
     if (pub_val_e == NULL || priv_val_e == NULL) {
-        S2N_ERROR(S2N_ERR_KEY_CHECK);
+        POSIX_BAIL(S2N_ERR_KEY_CHECK);
     }
 
     if (pub_val_n == NULL || priv_val_n == NULL) {
-        S2N_ERROR(S2N_ERR_KEY_CHECK);
+        POSIX_BAIL(S2N_ERR_KEY_CHECK);
     }
 
     S2N_ERROR_IF(BN_cmp(pub_val_e, priv_val_e) != 0, S2N_ERR_KEY_MISMATCH);
@@ -139,8 +139,8 @@ static int s2n_rsa_validate_params_equal(const RSA *pub, const RSA *priv)
 
 static int s2n_rsa_validate_params_match(const struct s2n_pkey *pub, const struct s2n_pkey *priv)
 {
-    notnull_check(pub);
-    notnull_check(priv);
+    POSIX_ENSURE_REF(pub);
+    POSIX_ENSURE_REF(priv);
 
     /* OpenSSL Documentation Links:
      *  - https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_get0_RSA.html
@@ -149,10 +149,10 @@ static int s2n_rsa_validate_params_match(const struct s2n_pkey *pub, const struc
     RSA *pub_rsa_key = pub->key.rsa_key.rsa;
     RSA *priv_rsa_key = priv->key.rsa_key.rsa;
 
-    notnull_check(pub_rsa_key);
-    notnull_check(priv_rsa_key);
+    POSIX_ENSURE_REF(pub_rsa_key);
+    POSIX_ENSURE_REF(priv_rsa_key);
 
-    GUARD(s2n_rsa_validate_params_equal(pub_rsa_key, priv_rsa_key));
+    POSIX_GUARD(s2n_rsa_validate_params_equal(pub_rsa_key, priv_rsa_key));
 
     return 0;
 }
@@ -160,15 +160,15 @@ static int s2n_rsa_validate_params_match(const struct s2n_pkey *pub, const struc
 
 static int s2n_rsa_pss_keys_match(const struct s2n_pkey *pub, const struct s2n_pkey *priv)
 {
-    notnull_check(pub);
-    notnull_check(pub->pkey);
-    notnull_check(priv);
-    notnull_check(priv->pkey);
+    POSIX_ENSURE_REF(pub);
+    POSIX_ENSURE_REF(pub->pkey);
+    POSIX_ENSURE_REF(priv);
+    POSIX_ENSURE_REF(priv->pkey);
 
-    GUARD(s2n_rsa_validate_params_match(pub, priv));
+    POSIX_GUARD(s2n_rsa_validate_params_match(pub, priv));
 
     /* Validate that verify(sign(message)) for a random message is verified correctly */
-    GUARD(s2n_rsa_pss_validate_sign_verify_match(pub, priv));
+    POSIX_GUARD(s2n_rsa_pss_validate_sign_verify_match(pub, priv));
 
     return 0;
 }
@@ -193,7 +193,7 @@ int s2n_evp_pkey_to_rsa_pss_public_key(struct s2n_rsa_key *rsa_key, EVP_PKEY *pk
 int s2n_evp_pkey_to_rsa_pss_private_key(struct s2n_rsa_key *rsa_key, EVP_PKEY *pkey)
 {
     RSA *priv_rsa_key = EVP_PKEY_get0_RSA(pkey);
-    notnull_check(priv_rsa_key);
+    POSIX_ENSURE_REF(priv_rsa_key);
 
     /* Documentation: https://www.openssl.org/docs/man1.1.1/man3/RSA_check_key.html */
     S2N_ERROR_IF(!s2n_rsa_is_private_key(priv_rsa_key), S2N_ERR_KEY_MISMATCH);
@@ -201,7 +201,7 @@ int s2n_evp_pkey_to_rsa_pss_private_key(struct s2n_rsa_key *rsa_key, EVP_PKEY *p
     /* Check that the mandatory properties of a RSA Private Key are valid.
      *  - Documentation: https://www.openssl.org/docs/man1.1.1/man3/RSA_check_key.html
      */
-    GUARD_OSSL(RSA_check_key(priv_rsa_key), S2N_ERR_KEY_CHECK);
+    POSIX_GUARD_OSSL(RSA_check_key(priv_rsa_key), S2N_ERR_KEY_CHECK);
 
     rsa_key->rsa = priv_rsa_key;
     return 0;
@@ -209,7 +209,7 @@ int s2n_evp_pkey_to_rsa_pss_private_key(struct s2n_rsa_key *rsa_key, EVP_PKEY *p
 
 int s2n_rsa_pss_pkey_init(struct s2n_pkey *pkey)
 {
-    GUARD(s2n_rsa_pkey_init(pkey));
+    POSIX_GUARD(s2n_rsa_pkey_init(pkey));
 
     pkey->size = &s2n_rsa_pss_size;
     pkey->sign = &s2n_rsa_pss_key_sign;
@@ -230,17 +230,17 @@ int s2n_rsa_pss_pkey_init(struct s2n_pkey *pkey)
 
 int s2n_evp_pkey_to_rsa_pss_public_key(struct s2n_rsa_key *rsa_pss_key, EVP_PKEY *pkey)
 {
-    S2N_ERROR(S2N_RSA_PSS_NOT_SUPPORTED);
+    POSIX_BAIL(S2N_RSA_PSS_NOT_SUPPORTED);
 }
 
 int s2n_evp_pkey_to_rsa_pss_private_key(struct s2n_rsa_key *rsa_pss_key, EVP_PKEY *pkey)
 {
-    S2N_ERROR(S2N_RSA_PSS_NOT_SUPPORTED);
+    POSIX_BAIL(S2N_RSA_PSS_NOT_SUPPORTED);
 }
 
 int s2n_rsa_pss_pkey_init(struct s2n_pkey *pkey)
 {
-    S2N_ERROR(S2N_RSA_PSS_NOT_SUPPORTED);
+    POSIX_BAIL(S2N_RSA_PSS_NOT_SUPPORTED);
 }
 
 #endif

--- a/crypto/s2n_sequence.c
+++ b/crypto/s2n_sequence.c
@@ -45,7 +45,7 @@ int s2n_increment_sequence_number(struct s2n_blob *sequence_number)
 
 int s2n_sequence_number_to_uint64(struct s2n_blob *sequence_number, uint64_t *output)
 {
-    notnull_check(sequence_number);
+    POSIX_ENSURE_REF(sequence_number);
 
     uint8_t shift = 0;
     *output = 0;

--- a/crypto/s2n_signature.h
+++ b/crypto/s2n_signature.h
@@ -16,7 +16,7 @@
 
 #include "tls/s2n_tls_parameters.h"
 
-#define sig_alg_check(a, b)  do { if ( (a) != (b) ) { S2N_ERROR(S2N_ERR_INVALID_SIGNATURE_ALGORITHM); } } while(0)
+#define sig_alg_check(a, b)  do { if ( (a) != (b) ) { POSIX_BAIL(S2N_ERR_INVALID_SIGNATURE_ALGORITHM); } } while(0)
 
 typedef enum {
     S2N_SIGNATURE_ANONYMOUS = TLS_SIGNATURE_ALGORITHM_ANONYMOUS,

--- a/crypto/s2n_stream_cipher_null.c
+++ b/crypto/s2n_stream_cipher_null.c
@@ -30,7 +30,7 @@ static int s2n_stream_cipher_null_endecrypt(struct s2n_session_key *key, struct 
     S2N_ERROR_IF(out->size < in->size, S2N_ERR_SIZE_MISMATCH);
 
     if (in->data != out->data) {
-        memcpy_check(out->data, in->data, out->size);
+        POSIX_CHECKED_MEMCPY(out->data, in->data, out->size);
     }
     return 0;
 }

--- a/crypto/s2n_stream_cipher_rc4.c
+++ b/crypto/s2n_stream_cipher_rc4.c
@@ -28,10 +28,10 @@ static uint8_t s2n_stream_cipher_rc4_available()
 
 static int s2n_stream_cipher_rc4_encrypt(struct s2n_session_key *key, struct s2n_blob *in, struct s2n_blob *out)
 {
-    gte_check(out->size, in->size);
+    POSIX_ENSURE_GTE(out->size, in->size);
 
     int len = out->size;
-    GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
+    POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
 
     S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
 
@@ -40,10 +40,10 @@ static int s2n_stream_cipher_rc4_encrypt(struct s2n_session_key *key, struct s2n
 
 static int s2n_stream_cipher_rc4_decrypt(struct s2n_session_key *key, struct s2n_blob *in, struct s2n_blob *out)
 {
-    gte_check(out->size, in->size);
+    POSIX_ENSURE_GTE(out->size, in->size);
 
     int len = out->size;
-    GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
+    POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
 
     S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
 
@@ -52,16 +52,16 @@ static int s2n_stream_cipher_rc4_decrypt(struct s2n_session_key *key, struct s2n
 
 static int s2n_stream_cipher_rc4_set_encryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    eq_check(in->size, 16);
-    GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    POSIX_ENSURE_EQ(in->size, 16);
+    POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 }
 
 static int s2n_stream_cipher_rc4_set_decryption_key(struct s2n_session_key *key, struct s2n_blob *in)
 {
-    eq_check(in->size, 16);
-    GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    POSIX_ENSURE_EQ(in->size, 16);
+    POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_rc4(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
 }

--- a/crypto/s2n_tls13_keys.c
+++ b/crypto/s2n_tls13_keys.c
@@ -97,15 +97,15 @@ static const struct s2n_blob zero_length_blob = { .data = NULL, .size = 0 };
 /* Message transcript hash based on selected HMAC algorithm */
 static int s2n_tls13_transcript_message_hash(struct s2n_tls13_keys *keys, const struct s2n_blob *message, struct s2n_blob *message_digest)
 {
-    notnull_check(keys);
-    notnull_check(message);
-    notnull_check(message_digest);
+    POSIX_ENSURE_REF(keys);
+    POSIX_ENSURE_REF(message);
+    POSIX_ENSURE_REF(message_digest);
 
     DEFER_CLEANUP(struct s2n_hash_state hash_state, s2n_hash_free);
-    GUARD(s2n_hash_new(&hash_state));
-    GUARD(s2n_hash_init(&hash_state, keys->hash_algorithm));
-    GUARD(s2n_hash_update(&hash_state, message->data, message->size));
-    GUARD(s2n_hash_digest(&hash_state, message_digest->data, message_digest->size));
+    POSIX_GUARD(s2n_hash_new(&hash_state));
+    POSIX_GUARD(s2n_hash_init(&hash_state, keys->hash_algorithm));
+    POSIX_GUARD(s2n_hash_update(&hash_state, message->data, message->size));
+    POSIX_GUARD(s2n_hash_digest(&hash_state, message_digest->data, message_digest->size));
 
     return 0;
 }
@@ -115,14 +115,14 @@ static int s2n_tls13_transcript_message_hash(struct s2n_tls13_keys *keys, const 
  */
 int s2n_tls13_keys_init(struct s2n_tls13_keys *keys, s2n_hmac_algorithm alg)
 {
-    notnull_check(keys);
+    POSIX_ENSURE_REF(keys);
 
     keys->hmac_algorithm = alg;
-    GUARD(s2n_hmac_hash_alg(alg, &keys->hash_algorithm));
-    GUARD(s2n_hash_digest_size(keys->hash_algorithm, &keys->size));
-    GUARD(s2n_blob_init(&keys->extract_secret, keys->extract_secret_bytes, keys->size));
-    GUARD(s2n_blob_init(&keys->derive_secret, keys->derive_secret_bytes, keys->size));
-    GUARD(s2n_hmac_new(&keys->hmac));
+    POSIX_GUARD(s2n_hmac_hash_alg(alg, &keys->hash_algorithm));
+    POSIX_GUARD(s2n_hash_digest_size(keys->hash_algorithm, &keys->size));
+    POSIX_GUARD(s2n_blob_init(&keys->extract_secret, keys->extract_secret_bytes, keys->size));
+    POSIX_GUARD(s2n_blob_init(&keys->derive_secret, keys->derive_secret_bytes, keys->size));
+    POSIX_GUARD(s2n_hmac_new(&keys->hmac));
 
     return 0;
 }
@@ -131,9 +131,9 @@ int s2n_tls13_keys_init(struct s2n_tls13_keys *keys, s2n_hmac_algorithm alg)
  * Frees any allocation
  */
 int s2n_tls13_keys_free(struct s2n_tls13_keys *keys) {
-    notnull_check(keys);
+    POSIX_ENSURE_REF(keys);
 
-    GUARD(s2n_hmac_free(&keys->hmac));
+    POSIX_GUARD(s2n_hmac_free(&keys->hmac));
 
     return 0;
 }
@@ -143,14 +143,14 @@ int s2n_tls13_keys_free(struct s2n_tls13_keys *keys) {
  */
 int s2n_tls13_derive_binder_key(struct s2n_tls13_keys *keys, struct s2n_psk *psk)
 {
-    notnull_check(keys);
-    notnull_check(psk);
+    POSIX_ENSURE_REF(keys);
+    POSIX_ENSURE_REF(psk);
 
     struct s2n_blob *early_secret = &keys->extract_secret;
     struct s2n_blob *binder_key = &keys->derive_secret;
 
     /* Extract the early secret */
-    GUARD(s2n_hkdf_extract(&keys->hmac, keys->hmac_algorithm, &zero_length_blob,
+    POSIX_GUARD(s2n_hkdf_extract(&keys->hmac, keys->hmac_algorithm, &zero_length_blob,
             &psk->secret, early_secret));
 
     /* Choose the correct label for the psk type */
@@ -163,8 +163,8 @@ int s2n_tls13_derive_binder_key(struct s2n_tls13_keys *keys, struct s2n_psk *psk
 
     /* Derive the binder_key */
     s2n_tls13_key_blob(message_digest, keys->size);
-    GUARD(s2n_tls13_transcript_message_hash(keys, &zero_length_blob, &message_digest));
-    GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, early_secret,
+    POSIX_GUARD(s2n_tls13_transcript_message_hash(keys, &zero_length_blob, &message_digest));
+    POSIX_GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, early_secret,
         label_blob, &message_digest, binder_key));
 
     return S2N_SUCCESS;
@@ -175,26 +175,26 @@ int s2n_tls13_derive_binder_key(struct s2n_tls13_keys *keys, struct s2n_psk *psk
  */
 int s2n_tls13_derive_early_secrets(struct s2n_tls13_keys *keys, struct s2n_psk *psk)
 {
-    notnull_check(keys);
+    POSIX_ENSURE_REF(keys);
 
     /* Early Secret */
     if (psk == NULL) {
         /* in 1-RTT, PSK is 0-filled of key length */
         s2n_tls13_key_blob(psk_ikm, keys->size);
 
-        GUARD(s2n_hkdf_extract(&keys->hmac, keys->hmac_algorithm, &zero_length_blob, &psk_ikm, &keys->extract_secret));
+        POSIX_GUARD(s2n_hkdf_extract(&keys->hmac, keys->hmac_algorithm, &zero_length_blob, &psk_ikm, &keys->extract_secret));
     } else {
         /* Sanity check that an early secret exists and its size is equal to the extract secret size */
-        eq_check(psk->early_secret.size, keys->extract_secret.size);
-        memcpy_check(keys->extract_secret.data, psk->early_secret.data, psk->early_secret.size);
+        POSIX_ENSURE_EQ(psk->early_secret.size, keys->extract_secret.size);
+        POSIX_CHECKED_MEMCPY(keys->extract_secret.data, psk->early_secret.data, psk->early_secret.size);
     }
 
     /* client_early_traffic_secret and early_exporter_master_secret can be derived here */
 
     /* derive next secret */
     s2n_tls13_key_blob(message_digest, keys->size);
-    GUARD(s2n_tls13_transcript_message_hash(keys, &zero_length_blob, &message_digest));
-    GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, &keys->extract_secret,
+    POSIX_GUARD(s2n_tls13_transcript_message_hash(keys, &zero_length_blob, &message_digest));
+    POSIX_GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, &keys->extract_secret,
         &s2n_tls13_label_derived_secret, &message_digest, &keys->derive_secret));
 
     return S2N_SUCCESS;
@@ -209,32 +209,32 @@ int s2n_tls13_derive_handshake_secrets(struct s2n_tls13_keys *keys,
                                         struct s2n_blob *client_secret,
                                         struct s2n_blob *server_secret)
 {
-    notnull_check(keys);
-    notnull_check(ecdhe);
-    notnull_check(client_server_hello_hash);
-    notnull_check(client_secret);
-    notnull_check(server_secret);
+    POSIX_ENSURE_REF(keys);
+    POSIX_ENSURE_REF(ecdhe);
+    POSIX_ENSURE_REF(client_server_hello_hash);
+    POSIX_ENSURE_REF(client_secret);
+    POSIX_ENSURE_REF(server_secret);
 
     /* Handshake Secret */
-    GUARD(s2n_hkdf_extract(&keys->hmac, keys->hmac_algorithm, &keys->derive_secret, ecdhe, &keys->extract_secret));
+    POSIX_GUARD(s2n_hkdf_extract(&keys->hmac, keys->hmac_algorithm, &keys->derive_secret, ecdhe, &keys->extract_secret));
 
     s2n_tls13_key_blob(message_digest, keys->size);
 
     /* copy the hash */
     DEFER_CLEANUP(struct s2n_hash_state hkdf_hash_copy, s2n_hash_free);
-    GUARD(s2n_hash_new(&hkdf_hash_copy));
-    GUARD(s2n_hash_copy(&hkdf_hash_copy, client_server_hello_hash));
+    POSIX_GUARD(s2n_hash_new(&hkdf_hash_copy));
+    POSIX_GUARD(s2n_hash_copy(&hkdf_hash_copy, client_server_hello_hash));
     s2n_hash_digest(&hkdf_hash_copy, message_digest.data, message_digest.size);
 
     /* produce client + server traffic secrets */
-    GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, &keys->extract_secret,
+    POSIX_GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, &keys->extract_secret,
         &s2n_tls13_label_client_handshake_traffic_secret, &message_digest, client_secret));
-    GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, &keys->extract_secret,
+    POSIX_GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, &keys->extract_secret,
         &s2n_tls13_label_server_handshake_traffic_secret, &message_digest, server_secret));
 
     /* derive next secret */
-    GUARD(s2n_tls13_transcript_message_hash(keys, &zero_length_blob, &message_digest));
-    GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, &keys->extract_secret,
+    POSIX_GUARD(s2n_tls13_transcript_message_hash(keys, &zero_length_blob, &message_digest));
+    POSIX_GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, &keys->extract_secret,
         &s2n_tls13_label_derived_secret, &message_digest, &keys->derive_secret));
 
     return 0;
@@ -245,16 +245,16 @@ int s2n_tls13_extract_master_secret(struct s2n_tls13_keys *keys)
     s2n_tls13_key_blob(empty_key, keys->size);
 
     /* Extract master secret from derived secret */
-    GUARD(s2n_hkdf_extract(&keys->hmac, keys->hmac_algorithm, &keys->derive_secret, &empty_key, &keys->extract_secret));
+    POSIX_GUARD(s2n_hkdf_extract(&keys->hmac, keys->hmac_algorithm, &keys->derive_secret, &empty_key, &keys->extract_secret));
 
     return S2N_SUCCESS;
 }
 
 int s2n_tls13_derive_application_secret(struct s2n_tls13_keys *keys, struct s2n_hash_state *hashes, struct s2n_blob *secret_blob, s2n_mode mode)
 {
-    notnull_check(keys);
-    notnull_check(hashes);
-    notnull_check(secret_blob);
+    POSIX_ENSURE_REF(keys);
+    POSIX_ENSURE_REF(hashes);
+    POSIX_ENSURE_REF(secret_blob);
 
     const struct s2n_blob *label_blob;
     if (mode == S2N_CLIENT) {
@@ -270,12 +270,12 @@ int s2n_tls13_derive_application_secret(struct s2n_tls13_keys *keys, struct s2n_
 
     /* copy the hashes into the message_digest */
     DEFER_CLEANUP(struct s2n_hash_state hkdf_hash_copy, s2n_hash_free);
-    GUARD(s2n_hash_new(&hkdf_hash_copy));
-    GUARD(s2n_hash_copy(&hkdf_hash_copy, hashes));
-    GUARD(s2n_hash_digest(&hkdf_hash_copy, message_digest.data, message_digest.size));
+    POSIX_GUARD(s2n_hash_new(&hkdf_hash_copy));
+    POSIX_GUARD(s2n_hash_copy(&hkdf_hash_copy, hashes));
+    POSIX_GUARD(s2n_hash_digest(&hkdf_hash_copy, message_digest.data, message_digest.size));
 
     /* Derive traffic secret from master secret */
-    GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, &keys->extract_secret,
+    POSIX_GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, &keys->extract_secret,
         label_blob, &message_digest, secret_blob));
 
     return S2N_SUCCESS;
@@ -286,14 +286,14 @@ int s2n_tls13_derive_application_secret(struct s2n_tls13_keys *keys, struct s2n_
  */
 int s2n_tls13_derive_traffic_keys(struct s2n_tls13_keys *keys, struct s2n_blob *secret, struct s2n_blob *key, struct s2n_blob *iv)
 {
-    notnull_check(keys);
-    notnull_check(secret);
-    notnull_check(key);
-    notnull_check(iv);
+    POSIX_ENSURE_REF(keys);
+    POSIX_ENSURE_REF(secret);
+    POSIX_ENSURE_REF(key);
+    POSIX_ENSURE_REF(iv);
 
-    GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, secret,
+    POSIX_GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, secret,
         &s2n_tls13_label_traffic_secret_key, &zero_length_blob, key));
-    GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, secret,
+    POSIX_GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, secret,
         &s2n_tls13_label_traffic_secret_iv, &zero_length_blob, iv));
     return 0;
 }
@@ -304,7 +304,7 @@ int s2n_tls13_derive_traffic_keys(struct s2n_tls13_keys *keys, struct s2n_blob *
  */
 int s2n_tls13_derive_finished_key(struct s2n_tls13_keys *keys, struct s2n_blob *secret_key, struct s2n_blob *output_finish_key)
 {
-    GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, secret_key, &s2n_tls13_label_finished, &zero_length_blob, output_finish_key));
+    POSIX_GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, secret_key, &s2n_tls13_label_finished, &zero_length_blob, output_finish_key));
 
     return 0;
 }
@@ -321,11 +321,11 @@ int s2n_tls13_calculate_finished_mac(struct s2n_tls13_keys *keys, struct s2n_blo
 
     /* Make a copy of the hash state */
     DEFER_CLEANUP(struct s2n_hash_state hash_state_copy, s2n_hash_free);
-    GUARD(s2n_hash_new(&hash_state_copy));
-    GUARD(s2n_hash_copy(&hash_state_copy, hash_state));
-    GUARD(s2n_hash_digest(&hash_state_copy, transcript_hash.data, transcript_hash.size));
+    POSIX_GUARD(s2n_hash_new(&hash_state_copy));
+    POSIX_GUARD(s2n_hash_copy(&hash_state_copy, hash_state));
+    POSIX_GUARD(s2n_hash_digest(&hash_state_copy, transcript_hash.data, transcript_hash.size));
 
-    GUARD(s2n_hkdf_extract(&keys->hmac, keys->hmac_algorithm, finished_key, &transcript_hash, finished_verify));
+    POSIX_GUARD(s2n_hkdf_extract(&keys->hmac, keys->hmac_algorithm, finished_key, &transcript_hash, finished_verify));
 
     return 0;
 }
@@ -335,11 +335,11 @@ int s2n_tls13_calculate_finished_mac(struct s2n_tls13_keys *keys, struct s2n_blo
  */
 int s2n_tls13_update_application_traffic_secret(struct s2n_tls13_keys *keys, struct s2n_blob *old_secret, struct s2n_blob *new_secret)
 {
-    notnull_check(keys);
-    notnull_check(old_secret);
-    notnull_check(new_secret);
+    POSIX_ENSURE_REF(keys);
+    POSIX_ENSURE_REF(old_secret);
+    POSIX_ENSURE_REF(new_secret);
 
-    GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, old_secret,
+    POSIX_GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, old_secret,
                                 &s2n_tls13_label_application_traffic_secret_update, &zero_length_blob, new_secret));
 
     return 0;
@@ -347,23 +347,23 @@ int s2n_tls13_update_application_traffic_secret(struct s2n_tls13_keys *keys, str
 
 int s2n_tls13_derive_resumption_master_secret(struct s2n_tls13_keys *keys, struct s2n_hash_state *hashes, struct s2n_blob *secret_blob)
 {
-    notnull_check(keys);
-    notnull_check(hashes);
-    notnull_check(secret_blob);
+    POSIX_ENSURE_REF(keys);
+    POSIX_ENSURE_REF(hashes);
+    POSIX_ENSURE_REF(secret_blob);
 
     /* Sanity check that input hash is of expected type */
-    ENSURE_POSIX(keys->hash_algorithm == hashes->alg, S2N_ERR_HASH_INVALID_ALGORITHM);
+    POSIX_ENSURE(keys->hash_algorithm == hashes->alg, S2N_ERR_HASH_INVALID_ALGORITHM);
 
     s2n_tls13_key_blob(message_digest, keys->size);
 
     /* Copy the hashes into the message_digest */
     DEFER_CLEANUP(struct s2n_hash_state hkdf_hash_copy, s2n_hash_free);
-    GUARD(s2n_hash_new(&hkdf_hash_copy));
-    GUARD(s2n_hash_copy(&hkdf_hash_copy, hashes));
-    GUARD(s2n_hash_digest(&hkdf_hash_copy, message_digest.data, message_digest.size));
+    POSIX_GUARD(s2n_hash_new(&hkdf_hash_copy));
+    POSIX_GUARD(s2n_hash_copy(&hkdf_hash_copy, hashes));
+    POSIX_GUARD(s2n_hash_digest(&hkdf_hash_copy, message_digest.data, message_digest.size));
 
     /* Derive master session resumption from master secret */
-    GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, &keys->extract_secret,
+    POSIX_GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, &keys->extract_secret,
         &s2n_tls13_label_resumption_master_secret, &message_digest, secret_blob));
 
     return S2N_SUCCESS;
@@ -372,13 +372,13 @@ int s2n_tls13_derive_resumption_master_secret(struct s2n_tls13_keys *keys, struc
 S2N_RESULT s2n_tls13_derive_session_ticket_secret(struct s2n_tls13_keys *keys, struct s2n_blob *resumption_secret, 
         struct s2n_blob *ticket_nonce, struct s2n_blob *secret_blob)
 {
-    ENSURE_REF(keys);
-    ENSURE_REF(resumption_secret);
-    ENSURE_REF(ticket_nonce);
-    ENSURE_REF(secret_blob);
+    RESULT_ENSURE_REF(keys);
+    RESULT_ENSURE_REF(resumption_secret);
+    RESULT_ENSURE_REF(ticket_nonce);
+    RESULT_ENSURE_REF(secret_blob);
 
     /* Derive session ticket secret from master session resumption secret */
-    GUARD_AS_RESULT(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, resumption_secret,
+    RESULT_GUARD_POSIX(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, resumption_secret,
         &s2n_tls13_label_session_ticket_secret, ticket_nonce, secret_blob));
 
     return S2N_RESULT_OK;

--- a/pq-crypto/bike_r1/aes_ctr_prf.c
+++ b/pq-crypto/bike_r1/aes_ctr_prf.c
@@ -27,7 +27,7 @@ init_aes_ctr_prf_state(OUT aes_ctr_prf_state_t *s,
   bike_static_assert(sizeof(*seed) == sizeof(key.raw), seed_size_equals_ky_size);
   memcpy(key.raw, seed->raw, sizeof(key.raw));
 
-  GUARD(aes256_key_expansion(&s->ks_ptr, &key));
+  POSIX_GUARD(aes256_key_expansion(&s->ks_ptr, &key));
 
   // Initialize buffer and counter
   s->ctr.u.qw[0]    = 0;
@@ -59,7 +59,7 @@ perform_aes(OUT uint8_t *ct, IN OUT aes_ctr_prf_state_t *s)
     BIKE_ERROR(E_AES_OVER_USED);
   }
 
-  GUARD(aes256_enc(ct, s->ctr.u.bytes, &s->ks_ptr));
+  POSIX_GUARD(aes256_enc(ct, s->ctr.u.bytes, &s->ks_ptr));
 
   s->ctr.u.qw[0]++;
   s->rem_invokations--;
@@ -91,11 +91,11 @@ aes_ctr_prf(OUT uint8_t *a, IN OUT aes_ctr_prf_state_t *s, IN const uint32_t len
   // Copy full AES blocks
   while((len - idx) >= AES256_BLOCK_SIZE)
   {
-    GUARD(perform_aes(&a[idx], s));
+    POSIX_GUARD(perform_aes(&a[idx], s));
     idx += AES256_BLOCK_SIZE;
   }
 
-  GUARD(perform_aes(s->buffer.u.bytes, s));
+  POSIX_GUARD(perform_aes(s->buffer.u.bytes, s));
 
   // Copy the tail
   s->pos = len - idx;

--- a/pq-crypto/bike_r1/bike_r1_kem.c
+++ b/pq-crypto/bike_r1/bike_r1_kem.c
@@ -78,18 +78,18 @@ encrypt(OUT ct_t *ct,
   p_pk[1].val   = pk->val[1];
 
   DMSG("    Sampling m.\n");
-  GUARD(sample_uniform_r_bits(&m.val, seed, NO_RESTRICTION));
+  POSIX_GUARD(sample_uniform_r_bits(&m.val, seed, NO_RESTRICTION));
 
   DMSG("    Calculating the ciphertext.\n");
 
-  GUARD(gf2x_mod_mul((uint64_t *)&p_ct[0], (uint64_t *)&m, (uint64_t *)&p_pk[0]));
-  GUARD(gf2x_mod_mul((uint64_t *)&p_ct[1], (uint64_t *)&m, (uint64_t *)&p_pk[1]));
+  POSIX_GUARD(gf2x_mod_mul((uint64_t *)&p_ct[0], (uint64_t *)&m, (uint64_t *)&p_pk[0]));
+  POSIX_GUARD(gf2x_mod_mul((uint64_t *)&p_ct[1], (uint64_t *)&m, (uint64_t *)&p_pk[1]));
 
   DMSG("    Addding Error to the ciphertext.\n");
 
-  GUARD(
+  POSIX_GUARD(
       gf2x_add(p_ct[0].val.raw, p_ct[0].val.raw, splitted_e->val[0].raw, R_SIZE));
-  GUARD(
+  POSIX_GUARD(
       gf2x_add(p_ct[1].val.raw, p_ct[1].val.raw, splitted_e->val[1].raw, R_SIZE));
 
   // Copy the data outside
@@ -113,12 +113,12 @@ calc_pk(OUT pk_t *pk, IN const seed_t *g_seed, IN const pad_sk_t p_sk)
   // Intialized padding to zero
   DEFER_CLEANUP(padded_r_t g = {0}, padded_r_cleanup);
 
-  GUARD(sample_uniform_r_bits(&g.val, g_seed, MUST_BE_ODD));
+  POSIX_GUARD(sample_uniform_r_bits(&g.val, g_seed, MUST_BE_ODD));
 
   // Calculate (g0, g1) = (g*h1, g*h0)
-  GUARD(gf2x_mod_mul((uint64_t *)&p_pk[0], (const uint64_t *)&g,
+  POSIX_GUARD(gf2x_mod_mul((uint64_t *)&p_pk[0], (const uint64_t *)&g,
                      (const uint64_t *)&p_sk[1]));
-  GUARD(gf2x_mod_mul((uint64_t *)&p_pk[1], (const uint64_t *)&g,
+  POSIX_GUARD(gf2x_mod_mul((uint64_t *)&p_pk[1], (const uint64_t *)&g,
                      (const uint64_t *)&p_sk[0]));
 
   // Copy the data to the output parameters.
@@ -156,7 +156,7 @@ get_ss(OUT ss_t *out, IN const e_t *e)
 int
 BIKE1_L1_R1_crypto_kem_keypair(OUT unsigned char *pk, OUT unsigned char *sk)
 {
-  ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+  POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
   // Convert to this implementation types
   pk_t *l_pk = (pk_t *)pk;
@@ -177,14 +177,14 @@ BIKE1_L1_R1_crypto_kem_keypair(OUT unsigned char *pk, OUT unsigned char *sk)
   DMSG("    Calculating the secret key.\n");
 
   // h0 and h1 use the same context
-  GUARD(init_aes_ctr_prf_state(&h_prf_state, MAX_AES_INVOKATION, &seeds.seed[0]));
+  POSIX_GUARD(init_aes_ctr_prf_state(&h_prf_state, MAX_AES_INVOKATION, &seeds.seed[0]));
 
-  GUARD(generate_sparse_rep((uint64_t *)&p_sk[0], l_sk.wlist[0].val, DV, R_BITS,
+  POSIX_GUARD(generate_sparse_rep((uint64_t *)&p_sk[0], l_sk.wlist[0].val, DV, R_BITS,
                             sizeof(p_sk[0]), &h_prf_state));
   // Copy data
   l_sk.bin[0] = p_sk[0].val;
 
-  GUARD(generate_sparse_rep((uint64_t *)&p_sk[1], l_sk.wlist[1].val, DV, R_BITS,
+  POSIX_GUARD(generate_sparse_rep((uint64_t *)&p_sk[1], l_sk.wlist[1].val, DV, R_BITS,
                             sizeof(p_sk[1]), &h_prf_state));
 
   // Copy data
@@ -192,7 +192,7 @@ BIKE1_L1_R1_crypto_kem_keypair(OUT unsigned char *pk, OUT unsigned char *sk)
 
   DMSG("    Calculating the public key.\n");
 
-  GUARD(calc_pk(l_pk, &seeds.seed[1], p_sk));
+  POSIX_GUARD(calc_pk(l_pk, &seeds.seed[1], p_sk));
 
   memcpy(sk, &l_sk, sizeof(l_sk));
 
@@ -214,7 +214,7 @@ BIKE1_L1_R1_crypto_kem_enc(OUT unsigned char *     ct,
                            IN const unsigned char *pk)
 {
   DMSG("  Enter crypto_kem_enc.\n");
-  ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+  POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
   // Convert to this implementation types
   const pk_t *l_pk = (const pk_t *)pk;
@@ -231,11 +231,11 @@ BIKE1_L1_R1_crypto_kem_enc(OUT unsigned char *     ct,
 
   // Random data generator
   // Using first seed
-  GUARD(init_aes_ctr_prf_state(&e_prf_state, MAX_AES_INVOKATION, &seeds.seed[0]));
+  POSIX_GUARD(init_aes_ctr_prf_state(&e_prf_state, MAX_AES_INVOKATION, &seeds.seed[0]));
 
   DMSG("    Generating error.\n");
   ALIGN(8) compressed_idx_t_t dummy;
-  GUARD(generate_sparse_rep((uint64_t *)&e, dummy.val, T1, N_BITS, sizeof(e),
+  POSIX_GUARD(generate_sparse_rep((uint64_t *)&e, dummy.val, T1, N_BITS, sizeof(e),
                             &e_prf_state));
 
   print("e:  ", (uint64_t *)&e.val, sizeof(e) * 8);
@@ -250,7 +250,7 @@ BIKE1_L1_R1_crypto_kem_enc(OUT unsigned char *     ct,
   // Computing ct = enc(pk, e)
   // Using second seed
   DMSG("    Encrypting.\n");
-  GUARD(encrypt(l_ct, l_pk, &seeds.seed[1], &splitted_e));
+  POSIX_GUARD(encrypt(l_ct, l_pk, &seeds.seed[1], &splitted_e));
 
   DMSG("    Generating shared secret.\n");
   get_ss(l_ss, &e.val);
@@ -269,7 +269,7 @@ BIKE1_L1_R1_crypto_kem_dec(OUT unsigned char *     ss,
                            IN const unsigned char *sk)
 {
   DMSG("  Enter crypto_kem_dec.\n");
-  ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+  POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
   // Convert to this implementation types
   const ct_t *l_ct = (const ct_t *)ct;
@@ -284,10 +284,10 @@ BIKE1_L1_R1_crypto_kem_dec(OUT unsigned char *     ss,
   DEFER_CLEANUP(e_t merged_e = {0}, e_cleanup);
 
   DMSG("  Computing s.\n");
-  GUARD(compute_syndrome(&syndrome, l_ct, &l_sk));
+  POSIX_GUARD(compute_syndrome(&syndrome, l_ct, &l_sk));
 
   DMSG("  Decoding.\n");
-  GUARD(decode(&e, &syndrome, l_ct, &l_sk));
+  POSIX_GUARD(decode(&e, &syndrome, l_ct, &l_sk));
 
   // Check if the error weight equals T1
   if(T1 != r_bits_vector_weight(&e.val[0]) + r_bits_vector_weight(&e.val[1]))

--- a/pq-crypto/bike_r1/decode.c
+++ b/pq-crypto/bike_r1/decode.c
@@ -96,12 +96,12 @@ compute_syndrome(OUT syndrome_t *syndrome, IN const ct_t *ct, IN const sk_t *sk)
   pad_ct[1].val = ct->val[1];
 
   // Compute s = c0*h0 + c1*h1:
-  GUARD(gf2x_mod_mul((uint64_t *)&pad_s[0], (uint64_t *)&pad_ct[0],
+  POSIX_GUARD(gf2x_mod_mul((uint64_t *)&pad_s[0], (uint64_t *)&pad_ct[0],
                      (uint64_t *)&pad_sk[0]));
-  GUARD(gf2x_mod_mul((uint64_t *)&pad_s[1], (uint64_t *)&pad_ct[1],
+  POSIX_GUARD(gf2x_mod_mul((uint64_t *)&pad_s[1], (uint64_t *)&pad_ct[1],
                      (uint64_t *)&pad_sk[1]));
 
-  GUARD(gf2x_add(pad_s[0].val.raw, pad_s[0].val.raw, pad_s[1].val.raw, R_SIZE));
+  POSIX_GUARD(gf2x_add(pad_s[0].val.raw, pad_s[0].val.raw, pad_s[1].val.raw, R_SIZE));
 
   memcpy((uint8_t *)syndrome->qw, pad_s[0].val.raw, R_SIZE);
   dup(syndrome);
@@ -118,13 +118,13 @@ recompute_syndrome(OUT syndrome_t *syndrome,
   ct_t tmp_ct = *ct;
 
   // Adapt the ciphertext
-  GUARD(gf2x_add(tmp_ct.val[0].raw, tmp_ct.val[0].raw, splitted_e->val[0].raw,
+  POSIX_GUARD(gf2x_add(tmp_ct.val[0].raw, tmp_ct.val[0].raw, splitted_e->val[0].raw,
                  R_SIZE));
-  GUARD(gf2x_add(tmp_ct.val[1].raw, tmp_ct.val[1].raw, splitted_e->val[1].raw,
+  POSIX_GUARD(gf2x_add(tmp_ct.val[1].raw, tmp_ct.val[1].raw, splitted_e->val[1].raw,
                  R_SIZE));
 
   // Recompute the syndrome
-  GUARD(compute_syndrome(syndrome, &tmp_ct, sk));
+  POSIX_GUARD(compute_syndrome(syndrome, &tmp_ct, sk));
 
   return SUCCESS;
 }
@@ -334,7 +334,7 @@ decode(OUT split_e_t *e,
     DMSG("    Weight of syndrome: %lu\n", r_bits_vector_weight((r_t *)s.qw));
 
     find_err1(e, &black_e, &gray_e, &s, sk->wlist, threshold);
-    GUARD(recompute_syndrome(&s, ct, sk, e));
+    POSIX_GUARD(recompute_syndrome(&s, ct, sk, e));
 #ifdef BGF_DECODER
     if(iter >= 1)
     {
@@ -346,14 +346,14 @@ decode(OUT split_e_t *e,
     DMSG("    Weight of syndrome: %lu\n", r_bits_vector_weight((r_t *)s.qw));
 
     find_err2(e, &black_e, &s, sk->wlist, ((DV + 1) / 2) + 1);
-    GUARD(recompute_syndrome(&s, ct, sk, e));
+    POSIX_GUARD(recompute_syndrome(&s, ct, sk, e));
 
     DMSG("    Weight of e: %lu\n",
          r_bits_vector_weight(&e->val[0]) + r_bits_vector_weight(&e->val[1]));
     DMSG("    Weight of syndrome: %lu\n", r_bits_vector_weight((r_t *)s.qw));
 
     find_err2(e, &gray_e, &s, sk->wlist, ((DV + 1) / 2) + 1);
-    GUARD(recompute_syndrome(&s, ct, sk, e));
+    POSIX_GUARD(recompute_syndrome(&s, ct, sk, e));
   }
 
   if(r_bits_vector_weight((r_t *)s.qw) > 0)

--- a/pq-crypto/bike_r1/openssl_utils.c
+++ b/pq-crypto/bike_r1/openssl_utils.c
@@ -108,15 +108,15 @@ ossl_add(OUT uint8_t      res_bin[R_SIZE],
     BIKE_ERROR(EXTERNAL_LIB_ERROR_OPENSSL);
   }
 
-  GUARD(ossl_bin2bn(a, a_bin, R_SIZE));
-  GUARD(ossl_bin2bn(b, b_bin, R_SIZE));
+  POSIX_GUARD(ossl_bin2bn(a, a_bin, R_SIZE));
+  POSIX_GUARD(ossl_bin2bn(b, b_bin, R_SIZE));
 
   if(BN_GF2m_add(r, a, b) == 0)
   {
     BIKE_ERROR(EXTERNAL_LIB_ERROR_OPENSSL);
   }
 
-  GUARD(ossl_bn2bin(res_bin, r, R_SIZE));
+  POSIX_GUARD(ossl_bn2bin(res_bin, r, R_SIZE));
 
   return SUCCESS;
 }
@@ -176,10 +176,10 @@ cyclic_product(OUT uint8_t      res_bin[R_SIZE],
     BIKE_ERROR(EXTERNAL_LIB_ERROR_OPENSSL);
   }
 
-  GUARD(ossl_bin2bn(a, a_bin, R_SIZE));
-  GUARD(ossl_bin2bn(b, b_bin, R_SIZE));
-  GUARD(ossl_cyclic_product(r, a, b, bn_ctx));
-  GUARD(ossl_bn2bin(res_bin, r, R_SIZE));
+  POSIX_GUARD(ossl_bin2bn(a, a_bin, R_SIZE));
+  POSIX_GUARD(ossl_bin2bn(b, b_bin, R_SIZE));
+  POSIX_GUARD(ossl_cyclic_product(r, a, b, bn_ctx));
+  POSIX_GUARD(ossl_bn2bin(res_bin, r, R_SIZE));
 
   return SUCCESS;
 }

--- a/pq-crypto/bike_r1/sampling.c
+++ b/pq-crypto/bike_r1/sampling.c
@@ -20,7 +20,7 @@ get_rand_mod_len(OUT uint32_t *    rand_pos,
   do
   {
     // Generate 128bit of random numbers
-    GUARD(aes_ctr_prf((uint8_t *)rand_pos, prf_state, sizeof(*rand_pos)));
+    POSIX_GUARD(aes_ctr_prf((uint8_t *)rand_pos, prf_state, sizeof(*rand_pos)));
 
     // Mask only relevant bits
     (*rand_pos) &= mask;
@@ -56,7 +56,7 @@ sample_uniform_r_bits_with_fixed_prf_context(OUT r_t *r,
                                              IN const must_be_odd_t   must_be_odd)
 {
   // Generate random data
-  GUARD(aes_ctr_prf(r->raw, prf_state, R_SIZE));
+  POSIX_GUARD(aes_ctr_prf(r->raw, prf_state, R_SIZE));
 
   // Mask upper bits of the MSByte
   r->raw[R_SIZE - 1] &= MASK(R_BITS + 8 - (R_SIZE * 8));
@@ -104,7 +104,7 @@ generate_sparse_rep(OUT uint64_t *    a,
   // Generate weight rand numbers
   do
   {
-    GUARD(get_rand_mod_len(&wlist[ctr], len, prf_state));
+    POSIX_GUARD(get_rand_mod_len(&wlist[ctr], len, prf_state));
     ctr += is_new(wlist, ctr);
   } while(ctr < weight);
 

--- a/pq-crypto/bike_r1/sampling.h
+++ b/pq-crypto/bike_r1/sampling.h
@@ -53,9 +53,9 @@ sample_uniform_r_bits(OUT r_t *r,
   // For the seedexpander
   DEFER_CLEANUP(aes_ctr_prf_state_t prf_state = {0}, aes_ctr_prf_state_cleanup);
 
-  GUARD(init_aes_ctr_prf_state(&prf_state, MAX_AES_INVOKATION, seed));
+  POSIX_GUARD(init_aes_ctr_prf_state(&prf_state, MAX_AES_INVOKATION, seed));
 
-  GUARD(sample_uniform_r_bits_with_fixed_prf_context(r, &prf_state, must_be_odd));
+  POSIX_GUARD(sample_uniform_r_bits_with_fixed_prf_context(r, &prf_state, must_be_odd));
 
   return SUCCESS;
 }

--- a/pq-crypto/bike_r2/aes_ctr_prf.c
+++ b/pq-crypto/bike_r2/aes_ctr_prf.c
@@ -27,7 +27,7 @@ init_aes_ctr_prf_state(OUT aes_ctr_prf_state_t *s,
   bike_static_assert(sizeof(*seed) == sizeof(key.raw), seed_size_equals_ky_size);
   memcpy(key.raw, seed->raw, sizeof(key.raw));
 
-  GUARD(aes256_key_expansion(&s->ks_ptr, &key));
+  POSIX_GUARD(aes256_key_expansion(&s->ks_ptr, &key));
 
   // Initialize buffer and counter
   s->ctr.u.qw[0]    = 0;
@@ -59,7 +59,7 @@ perform_aes(OUT uint8_t *ct, IN OUT aes_ctr_prf_state_t *s)
     BIKE_ERROR(E_AES_OVER_USED);
   }
 
-  GUARD(aes256_enc(ct, s->ctr.u.bytes, &s->ks_ptr));
+  POSIX_GUARD(aes256_enc(ct, s->ctr.u.bytes, &s->ks_ptr));
 
   s->ctr.u.qw[0]++;
   s->rem_invokations--;
@@ -91,11 +91,11 @@ aes_ctr_prf(OUT uint8_t *a, IN OUT aes_ctr_prf_state_t *s, IN const uint32_t len
   // Copy full AES blocks
   while((len - idx) >= AES256_BLOCK_SIZE)
   {
-    GUARD(perform_aes(&a[idx], s));
+    POSIX_GUARD(perform_aes(&a[idx], s));
     idx += AES256_BLOCK_SIZE;
   }
 
-  GUARD(perform_aes(s->buffer.u.bytes, s));
+  POSIX_GUARD(perform_aes(s->buffer.u.bytes, s));
 
   // Copy the tail
   s->pos = len - idx;

--- a/pq-crypto/bike_r2/decode.c
+++ b/pq-crypto/bike_r2/decode.c
@@ -96,12 +96,12 @@ compute_syndrome(OUT syndrome_t *syndrome, IN const ct_t *ct, IN const sk_t *sk)
   pad_ct[1].val = ct->val[1];
 
   // Compute s = c0*h0 + c1*h1:
-  GUARD(gf2x_mod_mul((uint64_t *)&pad_s[0], (uint64_t *)&pad_ct[0],
+  POSIX_GUARD(gf2x_mod_mul((uint64_t *)&pad_s[0], (uint64_t *)&pad_ct[0],
                      (uint64_t *)&pad_sk[0]));
-  GUARD(gf2x_mod_mul((uint64_t *)&pad_s[1], (uint64_t *)&pad_ct[1],
+  POSIX_GUARD(gf2x_mod_mul((uint64_t *)&pad_s[1], (uint64_t *)&pad_ct[1],
                      (uint64_t *)&pad_sk[1]));
 
-  GUARD(gf2x_add(pad_s[0].val.raw, pad_s[0].val.raw, pad_s[1].val.raw, R_SIZE));
+  POSIX_GUARD(gf2x_add(pad_s[0].val.raw, pad_s[0].val.raw, pad_s[1].val.raw, R_SIZE));
 
   memcpy((uint8_t *)syndrome->qw, pad_s[0].val.raw, R_SIZE);
   dup(syndrome);
@@ -118,13 +118,13 @@ recompute_syndrome(OUT syndrome_t *syndrome,
   ct_t tmp_ct = *ct;
 
   // Adapt the ciphertext
-  GUARD(gf2x_add(tmp_ct.val[0].raw, tmp_ct.val[0].raw, splitted_e->val[0].raw,
+  POSIX_GUARD(gf2x_add(tmp_ct.val[0].raw, tmp_ct.val[0].raw, splitted_e->val[0].raw,
                  R_SIZE));
-  GUARD(gf2x_add(tmp_ct.val[1].raw, tmp_ct.val[1].raw, splitted_e->val[1].raw,
+  POSIX_GUARD(gf2x_add(tmp_ct.val[1].raw, tmp_ct.val[1].raw, splitted_e->val[1].raw,
                  R_SIZE));
 
   // Recompute the syndrome
-  GUARD(compute_syndrome(syndrome, &tmp_ct, sk));
+  POSIX_GUARD(compute_syndrome(syndrome, &tmp_ct, sk));
 
   return SUCCESS;
 }
@@ -334,7 +334,7 @@ decode(OUT split_e_t *e,
     DMSG("    Weight of syndrome: %lu\n", r_bits_vector_weight((r_t *)s.qw));
 
     find_err1(e, &black_e, &gray_e, &s, sk->wlist, threshold);
-    GUARD(recompute_syndrome(&s, ct, sk, e));
+    POSIX_GUARD(recompute_syndrome(&s, ct, sk, e));
 #ifdef BGF_DECODER
     if(iter >= 1)
     {
@@ -346,14 +346,14 @@ decode(OUT split_e_t *e,
     DMSG("    Weight of syndrome: %lu\n", r_bits_vector_weight((r_t *)s.qw));
 
     find_err2(e, &black_e, &s, sk->wlist, ((DV + 1) / 2) + 1);
-    GUARD(recompute_syndrome(&s, ct, sk, e));
+    POSIX_GUARD(recompute_syndrome(&s, ct, sk, e));
 
     DMSG("    Weight of e: %lu\n",
          r_bits_vector_weight(&e->val[0]) + r_bits_vector_weight(&e->val[1]));
     DMSG("    Weight of syndrome: %lu\n", r_bits_vector_weight((r_t *)s.qw));
 
     find_err2(e, &gray_e, &s, sk->wlist, ((DV + 1) / 2) + 1);
-    GUARD(recompute_syndrome(&s, ct, sk, e));
+    POSIX_GUARD(recompute_syndrome(&s, ct, sk, e));
   }
 
   if(r_bits_vector_weight((r_t *)s.qw) > 0)

--- a/pq-crypto/bike_r2/openssl_utils.c
+++ b/pq-crypto/bike_r2/openssl_utils.c
@@ -108,15 +108,15 @@ ossl_add(OUT uint8_t      res_bin[R_SIZE],
     BIKE_ERROR(EXTERNAL_LIB_ERROR_OPENSSL);
   }
 
-  GUARD(ossl_bin2bn(a, a_bin, R_SIZE));
-  GUARD(ossl_bin2bn(b, b_bin, R_SIZE));
+  POSIX_GUARD(ossl_bin2bn(a, a_bin, R_SIZE));
+  POSIX_GUARD(ossl_bin2bn(b, b_bin, R_SIZE));
 
   if(BN_GF2m_add(r, a, b) == 0)
   {
     BIKE_ERROR(EXTERNAL_LIB_ERROR_OPENSSL);
   }
 
-  GUARD(ossl_bn2bin(res_bin, r, R_SIZE));
+  POSIX_GUARD(ossl_bn2bin(res_bin, r, R_SIZE));
 
   return SUCCESS;
 }
@@ -176,10 +176,10 @@ cyclic_product(OUT uint8_t      res_bin[R_SIZE],
     BIKE_ERROR(EXTERNAL_LIB_ERROR_OPENSSL);
   }
 
-  GUARD(ossl_bin2bn(a, a_bin, R_SIZE));
-  GUARD(ossl_bin2bn(b, b_bin, R_SIZE));
-  GUARD(ossl_cyclic_product(r, a, b, bn_ctx));
-  GUARD(ossl_bn2bin(res_bin, r, R_SIZE));
+  POSIX_GUARD(ossl_bin2bn(a, a_bin, R_SIZE));
+  POSIX_GUARD(ossl_bin2bn(b, b_bin, R_SIZE));
+  POSIX_GUARD(ossl_cyclic_product(r, a, b, bn_ctx));
+  POSIX_GUARD(ossl_bn2bin(res_bin, r, R_SIZE));
 
   return SUCCESS;
 }

--- a/pq-crypto/bike_r2/sampling.c
+++ b/pq-crypto/bike_r2/sampling.c
@@ -20,7 +20,7 @@ get_rand_mod_len(OUT uint32_t *    rand_pos,
   do
   {
     // Generate 128bit of random numbers
-    GUARD(aes_ctr_prf((uint8_t *)rand_pos, prf_state, sizeof(*rand_pos)));
+    POSIX_GUARD(aes_ctr_prf((uint8_t *)rand_pos, prf_state, sizeof(*rand_pos)));
 
     // Mask only relevant bits
     (*rand_pos) &= mask;
@@ -56,7 +56,7 @@ sample_uniform_r_bits_with_fixed_prf_context(OUT r_t *r,
                                              IN const must_be_odd_t   must_be_odd)
 {
   // Generate random data
-  GUARD(aes_ctr_prf(r->raw, prf_state, R_SIZE));
+  POSIX_GUARD(aes_ctr_prf(r->raw, prf_state, R_SIZE));
 
   // Mask upper bits of the MSByte
   r->raw[R_SIZE - 1] &= MASK(R_BITS + 8 - (R_SIZE * 8));
@@ -104,7 +104,7 @@ generate_sparse_rep(OUT uint64_t *    a,
   // Generate weight rand numbers
   do
   {
-    GUARD(get_rand_mod_len(&wlist[ctr], len, prf_state));
+    POSIX_GUARD(get_rand_mod_len(&wlist[ctr], len, prf_state));
     ctr += is_new(wlist, ctr);
   } while(ctr < weight);
 

--- a/pq-crypto/bike_r2/sampling.h
+++ b/pq-crypto/bike_r2/sampling.h
@@ -53,9 +53,9 @@ sample_uniform_r_bits(OUT r_t *r,
   // For the seedexpander
   DEFER_CLEANUP(aes_ctr_prf_state_t prf_state = {0}, aes_ctr_prf_state_cleanup);
 
-  GUARD(init_aes_ctr_prf_state(&prf_state, MAX_AES_INVOKATION, seed));
+  POSIX_GUARD(init_aes_ctr_prf_state(&prf_state, MAX_AES_INVOKATION, seed));
 
-  GUARD(sample_uniform_r_bits_with_fixed_prf_context(r, &prf_state, must_be_odd));
+  POSIX_GUARD(sample_uniform_r_bits_with_fixed_prf_context(r, &prf_state, must_be_odd));
 
   return SUCCESS;
 }

--- a/pq-crypto/kyber_90s_r2/indcpa.c
+++ b/pq-crypto/kyber_90s_r2/indcpa.c
@@ -188,7 +188,7 @@ int PQCLEAN_KYBER51290S_CLEAN_indcpa_keypair(uint8_t *pk, uint8_t *sk) {
     uint8_t *noiseseed = buf + KYBER_SYMBYTES;
     uint8_t nonce = 0;
 
-    GUARD_AS_POSIX(s2n_get_random_bytes(buf, KYBER_SYMBYTES));
+    POSIX_GUARD_RESULT(s2n_get_random_bytes(buf, KYBER_SYMBYTES));
     hash_g(buf, buf, KYBER_SYMBYTES);
 
     gen_a(a, publicseed);

--- a/pq-crypto/kyber_90s_r2/kyber_90s_r2_kem.c
+++ b/pq-crypto/kyber_90s_r2/kyber_90s_r2_kem.c
@@ -22,14 +22,14 @@
 * Returns 0 (success)
 **************************************************/
 int kyber_512_90s_r2_crypto_kem_keypair(uint8_t *pk, uint8_t *sk) {
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
     size_t i;
     PQCLEAN_KYBER51290S_CLEAN_indcpa_keypair(pk, sk);
     for (i = 0; i < KYBER_INDCPA_PUBLICKEYBYTES; i++) {
         sk[i + KYBER_INDCPA_SECRETKEYBYTES] = pk[i];
     }
     hash_h(sk + KYBER_SECRETKEYBYTES - 2 * KYBER_SYMBYTES, pk, KYBER_PUBLICKEYBYTES);
-    GUARD_AS_POSIX(s2n_get_random_bytes(sk + KYBER_SECRETKEYBYTES - KYBER_SYMBYTES, KYBER_SYMBYTES)); /* Value z for pseudo-random output on reject */
+    POSIX_GUARD_RESULT(s2n_get_random_bytes(sk + KYBER_SECRETKEYBYTES - KYBER_SYMBYTES, KYBER_SYMBYTES)); /* Value z for pseudo-random output on reject */
     return 0;
 }
 
@@ -46,11 +46,11 @@ int kyber_512_90s_r2_crypto_kem_keypair(uint8_t *pk, uint8_t *sk) {
 * Returns 0 (success)
 **************************************************/
 int kyber_512_90s_r2_crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk) {
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
     uint8_t  kr[2 * KYBER_SYMBYTES];                                   /* Will contain key, coins */
     uint8_t buf[2 * KYBER_SYMBYTES];
 
-    GUARD_AS_POSIX(s2n_get_random_bytes(buf, KYBER_SYMBYTES));
+    POSIX_GUARD_RESULT(s2n_get_random_bytes(buf, KYBER_SYMBYTES));
     hash_h(buf, buf, KYBER_SYMBYTES);                                        /* Don't release system RNG output */
 
     hash_h(buf + KYBER_SYMBYTES, pk, KYBER_PUBLICKEYBYTES);                  /* Multitarget countermeasure for coins + contributory KEM */
@@ -78,7 +78,7 @@ int kyber_512_90s_r2_crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk)
 * On failure, ss will contain a pseudo-random value.
 **************************************************/
 int kyber_512_90s_r2_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk) {
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
     size_t i;
     uint8_t fail;
     uint8_t cmp[KYBER_CIPHERTEXTBYTES];

--- a/pq-crypto/kyber_r2/indcpa.c
+++ b/pq-crypto/kyber_r2/indcpa.c
@@ -188,7 +188,7 @@ int PQCLEAN_KYBER512_CLEAN_indcpa_keypair(uint8_t *pk, uint8_t *sk) {
     uint8_t *noiseseed = buf + KYBER_SYMBYTES;
     uint8_t nonce = 0;
 
-    GUARD_AS_POSIX(s2n_get_random_bytes(buf, KYBER_SYMBYTES));
+    POSIX_GUARD_RESULT(s2n_get_random_bytes(buf, KYBER_SYMBYTES));
     hash_g(buf, buf, KYBER_SYMBYTES);
 
     gen_a(a, publicseed);

--- a/pq-crypto/kyber_r2/kyber_r2_kem.c
+++ b/pq-crypto/kyber_r2/kyber_r2_kem.c
@@ -22,14 +22,14 @@
 * Returns 0 (success)
 **************************************************/
 int kyber_512_r2_crypto_kem_keypair(uint8_t *pk, uint8_t *sk) {
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
     size_t i;
     PQCLEAN_KYBER512_CLEAN_indcpa_keypair(pk, sk);
     for (i = 0; i < KYBER_INDCPA_PUBLICKEYBYTES; i++) {
         sk[i + KYBER_INDCPA_SECRETKEYBYTES] = pk[i];
     }
     hash_h(sk + KYBER_SECRETKEYBYTES - 2 * KYBER_SYMBYTES, pk, KYBER_PUBLICKEYBYTES);
-    GUARD_AS_POSIX(s2n_get_random_bytes(sk + KYBER_SECRETKEYBYTES - KYBER_SYMBYTES, KYBER_SYMBYTES));	/* Value z for pseudo-random output on reject */
+    POSIX_GUARD_RESULT(s2n_get_random_bytes(sk + KYBER_SECRETKEYBYTES - KYBER_SYMBYTES, KYBER_SYMBYTES));	/* Value z for pseudo-random output on reject */
     return 0;
 }
 
@@ -46,11 +46,11 @@ int kyber_512_r2_crypto_kem_keypair(uint8_t *pk, uint8_t *sk) {
 * Returns 0 (success)
 **************************************************/
 int kyber_512_r2_crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk) {
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
     uint8_t  kr[2 * KYBER_SYMBYTES];                                   /* Will contain key, coins */
     uint8_t buf[2 * KYBER_SYMBYTES];
 
-    GUARD_AS_POSIX(s2n_get_random_bytes(buf, KYBER_SYMBYTES));
+    POSIX_GUARD_RESULT(s2n_get_random_bytes(buf, KYBER_SYMBYTES));
     hash_h(buf, buf, KYBER_SYMBYTES);                                        /* Don't release system RNG output */
 
     hash_h(buf + KYBER_SYMBYTES, pk, KYBER_PUBLICKEYBYTES);                  /* Multitarget countermeasure for coins + contributory KEM */
@@ -78,7 +78,7 @@ int kyber_512_r2_crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk) {
 * On failure, ss will contain a pseudo-random value.
 **************************************************/
 int kyber_512_r2_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk) {
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
     size_t i;
     uint8_t fail;
     uint8_t cmp[KYBER_CIPHERTEXTBYTES];

--- a/pq-crypto/s2n_pq.c
+++ b/pq-crypto/s2n_pq.c
@@ -116,7 +116,7 @@ S2N_RESULT s2n_try_enable_sikep434r2_asm() {
 }
 
 S2N_RESULT s2n_pq_init() {
-    ENSURE_OK(s2n_try_enable_sikep434r2_asm(), S2N_ERR_SAFETY);
+    RESULT_ENSURE_OK(s2n_try_enable_sikep434r2_asm(), S2N_ERR_SAFETY);
 
     return S2N_RESULT_OK;
 }

--- a/pq-crypto/s2n_pq_random.c
+++ b/pq-crypto/s2n_pq_random.c
@@ -23,21 +23,21 @@ static S2N_RESULT s2n_get_random_bytes_default(uint8_t *buffer, uint32_t num_byt
 static s2n_get_random_bytes_callback s2n_get_random_bytes_cb = s2n_get_random_bytes_default;
 
 S2N_RESULT s2n_get_random_bytes(uint8_t *buffer, uint32_t num_bytes) {
-    ENSURE_REF(buffer);
-    GUARD_RESULT(s2n_get_random_bytes_cb(buffer, num_bytes));
+    RESULT_ENSURE_REF(buffer);
+    RESULT_GUARD(s2n_get_random_bytes_cb(buffer, num_bytes));
 
     return S2N_RESULT_OK;
 }
 
 static S2N_RESULT s2n_get_random_bytes_default(uint8_t *buffer, uint32_t num_bytes) {
     struct s2n_blob out = { .data = buffer, .size = num_bytes };
-    GUARD_RESULT(s2n_get_private_random_data(&out));
+    RESULT_GUARD(s2n_get_private_random_data(&out));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_set_rand_bytes_callback_for_testing(s2n_get_random_bytes_callback rand_bytes_callback) {
-    ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
+    RESULT_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
 
     s2n_get_random_bytes_cb = rand_bytes_callback;
 

--- a/pq-crypto/sike_r1/sidh_r1.c
+++ b/pq-crypto/sike_r1/sidh_r1.c
@@ -63,7 +63,7 @@ int random_mod_order_B(unsigned char* random_digits)
     unsigned long long nbytes = NBITS_TO_NBYTES(OBOB_BITS-1);
 
     clear_words((void*)random_digits, MAXWORDS_ORDER);
-    GUARD_AS_POSIX(s2n_get_random_bytes(random_digits, nbytes));
+    POSIX_GUARD_RESULT(s2n_get_random_bytes(random_digits, nbytes));
     random_digits[nbytes-1] &= MASK_BOB;     // Masking last byte
 
     return S2N_SUCCESS;

--- a/pq-crypto/sike_r1/sike_r1_kem.c
+++ b/pq-crypto/sike_r1/sike_r1_kem.c
@@ -16,13 +16,13 @@ int SIKE_P503_r1_crypto_kem_keypair(unsigned char *pk, unsigned char *sk)
 { // SIKE's key generation
   // Outputs: secret key sk (SIKE_P503_R1_SECRET_KEY_BYTES = MSG_BYTES + SECRETKEY_B_BYTES + SIKE_P503_R1_PUBLIC_KEY_BYTES bytes)
   //          public key pk (SIKE_P503_R1_PUBLIC_KEY_BYTES bytes)
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
     digit_t _sk[SECRETKEY_B_BYTES/sizeof(digit_t)];
 
     // Generate lower portion of secret key sk <- s||SK
-    GUARD_AS_POSIX(s2n_get_random_bytes(sk, MSG_BYTES));
-    GUARD(random_mod_order_B((unsigned char*)_sk));
+    POSIX_GUARD_RESULT(s2n_get_random_bytes(sk, MSG_BYTES));
+    POSIX_GUARD(random_mod_order_B((unsigned char*)_sk));
 
     // Generate public key pk
     EphemeralKeyGeneration_B(_sk, pk);
@@ -40,7 +40,7 @@ int SIKE_P503_r1_crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsi
   // Input:   public key pk         (SIKE_P503_R1_PUBLIC_KEY_BYTES bytes)
   // Outputs: shared secret ss      (SIKE_P503_R1_SHARED_SECRET_BYTES bytes)
   //          ciphertext message ct (SIKE_P503_R1_CIPHERTEXT_BYTES = SIKE_P503_R1_PUBLIC_KEY_BYTES + MSG_BYTES bytes)
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
     const uint16_t G = 0;
     const uint16_t H = 1;
@@ -55,7 +55,7 @@ int SIKE_P503_r1_crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsi
     unsigned int i;
 
     // Generate ephemeralsk <- G(m||pk) mod oA
-    GUARD_AS_POSIX(s2n_get_random_bytes(temp, MSG_BYTES));
+    POSIX_GUARD_RESULT(s2n_get_random_bytes(temp, MSG_BYTES));
     memcpy(&temp[MSG_BYTES], pk, SIKE_P503_R1_PUBLIC_KEY_BYTES);
     cshake256_simple(ephemeralsk.b, SECRETKEY_A_BYTES, G, temp, SIKE_P503_R1_PUBLIC_KEY_BYTES+MSG_BYTES);
 
@@ -82,7 +82,7 @@ int SIKE_P503_r1_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, cons
   // Input:   secret key sk         (SIKE_P503_R1_SECRET_KEY_BYTES = MSG_BYTES + SECRETKEY_B_BYTES + SIKE_P503_R1_PUBLIC_KEY_BYTES bytes)
   //          ciphertext message ct (SIKE_P503_R1_CIPHERTEXT_BYTES = SIKE_P503_R1_PUBLIC_KEY_BYTES + MSG_BYTES bytes)
   // Outputs: shared secret ss      (SIKE_P503_R1_SHARED_SECRET_BYTES bytes)
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
     const uint16_t G = 0;
     const uint16_t H = 1;

--- a/pq-crypto/sike_r2/sidh.c
+++ b/pq-crypto/sike_r2/sidh.c
@@ -19,14 +19,14 @@ static void init_basis(const digit_t *gen, f2elm_t *XP, f2elm_t *XQ, f2elm_t *XR
 
 int random_mod_order_A(unsigned char *random_digits) { // Generation of Alice's secret key
                                                         // Outputs random value in [0, 2^eA - 1]
-    GUARD_AS_POSIX(s2n_get_random_bytes(random_digits, SECRETKEY_A_BYTES));
+    POSIX_GUARD_RESULT(s2n_get_random_bytes(random_digits, SECRETKEY_A_BYTES));
     random_digits[SECRETKEY_A_BYTES - 1] &= MASK_ALICE; // Masking last byte
     return S2N_SUCCESS;
 }
 
 int random_mod_order_B(unsigned char *random_digits) { // Generation of Bob's secret key
                                                         // Outputs random value in [0, 2^Floor(Log(2, oB)) - 1]
-    GUARD_AS_POSIX(s2n_get_random_bytes(random_digits, SECRETKEY_B_BYTES));
+    POSIX_GUARD_RESULT(s2n_get_random_bytes(random_digits, SECRETKEY_B_BYTES));
     random_digits[SECRETKEY_B_BYTES - 1] &= MASK_BOB; // Masking last byte
     return S2N_SUCCESS;
 }

--- a/pq-crypto/sike_r2/sike_r2_kem.c
+++ b/pq-crypto/sike_r2/sike_r2_kem.c
@@ -15,13 +15,13 @@ int SIKE_P434_r2_crypto_kem_keypair(unsigned char *pk, unsigned char *sk) {
     // SIKE's key generation
     // Outputs: secret key sk (CRYPTO_SECRETKEYBYTES = MSG_BYTES + SECRETKEY_B_BYTES + CRYPTO_PUBLICKEYBYTES bytes)
     //          public key pk (CRYPTO_PUBLICKEYBYTES bytes)
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
     digit_t _sk[(SECRETKEY_B_BYTES / sizeof(digit_t)) + 1];
 
     // Generate lower portion of secret key sk <- s||SK
-    GUARD_AS_POSIX(s2n_get_random_bytes(sk, MSG_BYTES));
-    GUARD(random_mod_order_B((unsigned char *)_sk));
+    POSIX_GUARD_RESULT(s2n_get_random_bytes(sk, MSG_BYTES));
+    POSIX_GUARD(random_mod_order_B((unsigned char *)_sk));
 
     // Generate public key pk
     EphemeralKeyGeneration_B(_sk, pk);
@@ -39,7 +39,7 @@ int SIKE_P434_r2_crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsi
     // Input:   public key pk         (CRYPTO_PUBLICKEYBYTES bytes)
     // Outputs: shared secret ss      (CRYPTO_BYTES bytes)
     //          ciphertext message ct (CRYPTO_CIPHERTEXTBYTES = CRYPTO_PUBLICKEYBYTES + MSG_BYTES bytes)
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
     union {
         unsigned char b[SECRETKEY_A_BYTES];
@@ -50,7 +50,7 @@ int SIKE_P434_r2_crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsi
     unsigned char temp[CRYPTO_CIPHERTEXTBYTES + MSG_BYTES];
 
     // Generate ephemeralsk <- G(m||pk) mod oA
-    GUARD_AS_POSIX(s2n_get_random_bytes(temp, MSG_BYTES));
+    POSIX_GUARD_RESULT(s2n_get_random_bytes(temp, MSG_BYTES));
     memcpy(&temp[MSG_BYTES], pk, CRYPTO_PUBLICKEYBYTES);
     shake256(ephemeralsk.b, SECRETKEY_A_BYTES, temp, CRYPTO_PUBLICKEYBYTES + MSG_BYTES);
 
@@ -78,7 +78,7 @@ int SIKE_P434_r2_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, cons
     // Input:   secret key sk         (CRYPTO_SECRETKEYBYTES = MSG_BYTES + SECRETKEY_B_BYTES + CRYPTO_PUBLICKEYBYTES bytes)
     //          ciphertext message ct (CRYPTO_CIPHERTEXTBYTES = CRYPTO_PUBLICKEYBYTES + MSG_BYTES bytes)
     // Outputs: shared secret ss      (CRYPTO_BYTES bytes)
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
     union {
         unsigned char b[SECRETKEY_A_BYTES];

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -29,13 +29,13 @@ S2N_RESULT s2n_stuffer_validate(const struct s2n_stuffer* stuffer)
      * Note that we do not assert any properties on the alloced, growable, and tainted fields,
      * as all possible combinations of boolean values in those fields are valid.
      */
-    ENSURE_REF(stuffer);
-    GUARD_RESULT(s2n_blob_validate(&stuffer->blob));
+    RESULT_ENSURE_REF(stuffer);
+    RESULT_GUARD(s2n_blob_validate(&stuffer->blob));
 
     /* <= is valid because we can have a fully written/read stuffer */
-    DEBUG_ENSURE(stuffer->high_water_mark <= stuffer->blob.size, S2N_ERR_SAFETY);
-    DEBUG_ENSURE(stuffer->write_cursor <= stuffer->high_water_mark, S2N_ERR_SAFETY);
-    DEBUG_ENSURE(stuffer->read_cursor <= stuffer->write_cursor, S2N_ERR_SAFETY);
+    RESULT_DEBUG_ENSURE(stuffer->high_water_mark <= stuffer->blob.size, S2N_ERR_SAFETY);
+    RESULT_DEBUG_ENSURE(stuffer->write_cursor <= stuffer->high_water_mark, S2N_ERR_SAFETY);
+    RESULT_DEBUG_ENSURE(stuffer->read_cursor <= stuffer->write_cursor, S2N_ERR_SAFETY);
     return S2N_RESULT_OK;
 }
 
@@ -46,15 +46,15 @@ S2N_RESULT s2n_stuffer_reservation_validate(const struct s2n_stuffer_reservation
      * for CBMC (see https://github.com/awslabs/s2n/issues/2290). We can roll back
      * this change once CBMC can handle common subexpression elimination.
      */
-    ENSURE_REF(reservation);
+    RESULT_ENSURE_REF(reservation);
     const struct s2n_stuffer_reservation reserve_obj = *reservation;
-    GUARD_RESULT(s2n_stuffer_validate(reserve_obj.stuffer));
+    RESULT_GUARD(s2n_stuffer_validate(reserve_obj.stuffer));
     const struct s2n_stuffer stuffer_obj = *(reserve_obj.stuffer);
-    ENSURE(stuffer_obj.blob.size >= reserve_obj.length, S2N_ERR_SAFETY);
+    RESULT_ENSURE(stuffer_obj.blob.size >= reserve_obj.length, S2N_ERR_SAFETY);
 
     if (reserve_obj.length > 0) {
-        ENSURE(reserve_obj.write_cursor < stuffer_obj.write_cursor, S2N_ERR_SAFETY);
-        ENSURE(
+        RESULT_ENSURE(reserve_obj.write_cursor < stuffer_obj.write_cursor, S2N_ERR_SAFETY);
+        RESULT_ENSURE(
             S2N_MEM_IS_WRITABLE(stuffer_obj.blob.data + reserve_obj.write_cursor, reserve_obj.length),
             S2N_ERR_SAFETY
         );
@@ -65,8 +65,8 @@ S2N_RESULT s2n_stuffer_reservation_validate(const struct s2n_stuffer_reservation
 
 int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)
 {
-    ENSURE_POSIX_MUT(stuffer);
-    PRECONDITION_POSIX(s2n_blob_validate(in));
+    POSIX_ENSURE_MUT(stuffer);
+    POSIX_PRECONDITION(s2n_blob_validate(in));
     stuffer->blob = *in;
     stuffer->read_cursor = 0;
     stuffer->write_cursor = 0;
@@ -79,24 +79,24 @@ int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)
 
 int s2n_stuffer_alloc(struct s2n_stuffer *stuffer, const uint32_t size)
 {
-    notnull_check(stuffer);
+    POSIX_ENSURE_REF(stuffer);
     *stuffer = (struct s2n_stuffer) {0};
-    GUARD(s2n_alloc(&stuffer->blob, size));
-    GUARD(s2n_stuffer_init(stuffer, &stuffer->blob));
+    POSIX_GUARD(s2n_alloc(&stuffer->blob, size));
+    POSIX_GUARD(s2n_stuffer_init(stuffer, &stuffer->blob));
 
     stuffer->alloced = 1;
 
-    POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_growable_alloc(struct s2n_stuffer *stuffer, const uint32_t size)
 {
-    GUARD(s2n_stuffer_alloc(stuffer, size));
+    POSIX_GUARD(s2n_stuffer_alloc(stuffer, size));
 
     stuffer->growable = 1;
 
-    POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 
@@ -104,7 +104,7 @@ int s2n_stuffer_free(struct s2n_stuffer *stuffer)
 {
     if (stuffer != NULL) {
         if (stuffer->alloced) {
-            GUARD(s2n_free(&stuffer->blob));
+            POSIX_GUARD(s2n_free(&stuffer->blob));
         }
         *stuffer = (struct s2n_stuffer) {0};
     }
@@ -113,9 +113,9 @@ int s2n_stuffer_free(struct s2n_stuffer *stuffer)
 
 int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    ENSURE_POSIX(!stuffer->tainted, S2N_ERR_RESIZE_TAINTED_STUFFER);
-    ENSURE_POSIX(stuffer->growable, S2N_ERR_RESIZE_STATIC_STUFFER);
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_ENSURE(!stuffer->tainted, S2N_ERR_RESIZE_TAINTED_STUFFER);
+    POSIX_ENSURE(stuffer->growable, S2N_ERR_RESIZE_STATIC_STUFFER);
 
     if (size == stuffer->blob.size) {
         return S2N_SUCCESS;
@@ -127,53 +127,53 @@ int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)
     }
 
     if (size < stuffer->blob.size) {
-        memset_check(stuffer->blob.data + size, S2N_WIPE_PATTERN, (stuffer->blob.size - size));
+        POSIX_CHECKED_MEMSET(stuffer->blob.data + size, S2N_WIPE_PATTERN, (stuffer->blob.size - size));
         if (stuffer->read_cursor > size) stuffer->read_cursor = size;
         if (stuffer->write_cursor > size) stuffer->write_cursor = size;
         if (stuffer->high_water_mark > size) stuffer->high_water_mark = size;
         stuffer->blob.size = size;
-        POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
+        POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
         return S2N_SUCCESS;
     }
 
-    GUARD(s2n_realloc(&stuffer->blob, size));
-    POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_GUARD(s2n_realloc(&stuffer->blob, size));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_resize_if_empty(struct s2n_stuffer *stuffer, const uint32_t size)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
     if (stuffer->blob.data == NULL) {
-        ENSURE_POSIX(!stuffer->tainted, S2N_ERR_RESIZE_TAINTED_STUFFER);
-        ENSURE_POSIX(stuffer->growable, S2N_ERR_RESIZE_STATIC_STUFFER);
-        GUARD(s2n_realloc(&stuffer->blob, size));
+        POSIX_ENSURE(!stuffer->tainted, S2N_ERR_RESIZE_TAINTED_STUFFER);
+        POSIX_ENSURE(stuffer->growable, S2N_ERR_RESIZE_STATIC_STUFFER);
+        POSIX_GUARD(s2n_realloc(&stuffer->blob, size));
     }
-    POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_rewrite(struct s2n_stuffer *stuffer)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
     stuffer->write_cursor = 0;
     stuffer->read_cursor = 0;
-    POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_rewind_read(struct s2n_stuffer *stuffer, const uint32_t size)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    ENSURE_POSIX(stuffer->read_cursor >= size, S2N_ERR_STUFFER_OUT_OF_DATA);
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_ENSURE(stuffer->read_cursor >= size, S2N_ERR_STUFFER_OUT_OF_DATA);
     stuffer->read_cursor -= size;
-    POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_reread(struct s2n_stuffer *stuffer)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
     stuffer->read_cursor = 0;
     return S2N_SUCCESS;
 }
@@ -186,7 +186,7 @@ int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t size)
 
     /* We know that size is now less than write_cursor */
     stuffer->write_cursor -= size;
-    memset_check(stuffer->blob.data + stuffer->write_cursor, S2N_WIPE_PATTERN, size);
+    POSIX_CHECKED_MEMSET(stuffer->blob.data + stuffer->write_cursor, S2N_WIPE_PATTERN, size);
     stuffer->read_cursor = MIN(stuffer->read_cursor, stuffer->write_cursor);
 
     return S2N_SUCCESS;
@@ -199,7 +199,7 @@ bool s2n_stuffer_is_consumed(struct s2n_stuffer *stuffer) {
 int s2n_stuffer_wipe(struct s2n_stuffer *stuffer)
 {
     if (!s2n_stuffer_is_wiped(stuffer)) {
-        memset_check(stuffer->blob.data, S2N_WIPE_PATTERN, stuffer->high_water_mark);
+        POSIX_CHECKED_MEMSET(stuffer->blob.data, S2N_WIPE_PATTERN, stuffer->high_water_mark);
     }
 
     stuffer->tainted = 0;
@@ -211,7 +211,7 @@ int s2n_stuffer_wipe(struct s2n_stuffer *stuffer)
 
 int s2n_stuffer_skip_read(struct s2n_stuffer *stuffer, uint32_t n)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
     POSIX_ENSURE(s2n_stuffer_data_available(stuffer) >= n, S2N_ERR_STUFFER_OUT_OF_DATA);
 
     stuffer->read_cursor += n;
@@ -220,7 +220,7 @@ int s2n_stuffer_skip_read(struct s2n_stuffer *stuffer, uint32_t n)
 
 void *s2n_stuffer_raw_read(struct s2n_stuffer *stuffer, uint32_t data_len)
 {
-    GUARD_PTR(s2n_stuffer_skip_read(stuffer, data_len));
+    PTR_GUARD_POSIX(s2n_stuffer_skip_read(stuffer, data_len));
 
     stuffer->tainted = 1;
 
@@ -229,62 +229,62 @@ void *s2n_stuffer_raw_read(struct s2n_stuffer *stuffer, uint32_t data_len)
 
 int s2n_stuffer_read(struct s2n_stuffer *stuffer, struct s2n_blob *out)
 {
-    notnull_check(out);
+    POSIX_ENSURE_REF(out);
 
     return s2n_stuffer_read_bytes(stuffer, out->data, out->size);
 }
 
 int s2n_stuffer_erase_and_read(struct s2n_stuffer *stuffer, struct s2n_blob *out)
 {
-    GUARD(s2n_stuffer_skip_read(stuffer, out->size));
+    POSIX_GUARD(s2n_stuffer_skip_read(stuffer, out->size));
 
     void *ptr = stuffer->blob.data + stuffer->read_cursor - out->size;
-    ENSURE_POSIX(S2N_MEM_IS_READABLE(ptr, out->size), S2N_ERR_NULL);
+    POSIX_ENSURE(S2N_MEM_IS_READABLE(ptr, out->size), S2N_ERR_NULL);
 
-    memcpy_check(out->data, ptr, out->size);
-    memset_check(ptr, 0, out->size);
+    POSIX_CHECKED_MEMCPY(out->data, ptr, out->size);
+    POSIX_CHECKED_MEMSET(ptr, 0, out->size);
 
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_read_bytes(struct s2n_stuffer *stuffer, uint8_t * data, uint32_t size)
 {
-    notnull_check(data);
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    GUARD(s2n_stuffer_skip_read(stuffer, size));
-    notnull_check(stuffer->blob.data);
+    POSIX_ENSURE_REF(data);
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_GUARD(s2n_stuffer_skip_read(stuffer, size));
+    POSIX_ENSURE_REF(stuffer->blob.data);
     void *ptr = stuffer->blob.data + stuffer->read_cursor - size;
 
-    memcpy_check(data, ptr, size);
+    POSIX_CHECKED_MEMCPY(data, ptr, size);
 
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_erase_and_read_bytes(struct s2n_stuffer *stuffer, uint8_t * data, uint32_t size)
 {
-    GUARD(s2n_stuffer_skip_read(stuffer, size));
-    notnull_check(stuffer->blob.data);
+    POSIX_GUARD(s2n_stuffer_skip_read(stuffer, size));
+    POSIX_ENSURE_REF(stuffer->blob.data);
     void *ptr = stuffer->blob.data + stuffer->read_cursor - size;
 
-    memcpy_check(data, ptr, size);
-    memset_check(ptr, 0, size);
+    POSIX_CHECKED_MEMCPY(data, ptr, size);
+    POSIX_CHECKED_MEMSET(ptr, 0, size);
 
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_skip_write(struct s2n_stuffer *stuffer, const uint32_t n)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    GUARD(s2n_stuffer_reserve_space(stuffer, n));
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_GUARD(s2n_stuffer_reserve_space(stuffer, n));
     stuffer->write_cursor += n;
     stuffer->high_water_mark = MAX(stuffer->write_cursor, stuffer->high_water_mark);
-    POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 
 void *s2n_stuffer_raw_write(struct s2n_stuffer *stuffer, const uint32_t data_len)
 {
-    GUARD_PTR(s2n_stuffer_skip_write(stuffer, data_len));
+    PTR_GUARD_POSIX(s2n_stuffer_skip_write(stuffer, data_len));
 
     stuffer->tainted = 1;
 
@@ -293,37 +293,37 @@ void *s2n_stuffer_raw_write(struct s2n_stuffer *stuffer, const uint32_t data_len
 
 int s2n_stuffer_write(struct s2n_stuffer *stuffer, const struct s2n_blob *in)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    PRECONDITION_POSIX(s2n_blob_validate(in));
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_PRECONDITION(s2n_blob_validate(in));
     return s2n_stuffer_write_bytes(stuffer, in->data, in->size);
 }
 
 int s2n_stuffer_write_bytes(struct s2n_stuffer *stuffer, const uint8_t * data, const uint32_t size)
 {
-    ENSURE_POSIX(S2N_MEM_IS_READABLE(data, size), S2N_ERR_SAFETY);
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    GUARD(s2n_stuffer_skip_write(stuffer, size));
+    POSIX_ENSURE(S2N_MEM_IS_READABLE(data, size), S2N_ERR_SAFETY);
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_GUARD(s2n_stuffer_skip_write(stuffer, size));
 
     void *ptr = stuffer->blob.data + stuffer->write_cursor - size;
-    ENSURE_POSIX(S2N_MEM_IS_READABLE(ptr, size), S2N_ERR_NULL);
+    POSIX_ENSURE(S2N_MEM_IS_READABLE(ptr, size), S2N_ERR_NULL);
 
     if (ptr == data) {
-        POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
+        POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
         return S2N_SUCCESS;
     }
 
-    memcpy_check(ptr, data, size);
+    POSIX_CHECKED_MEMCPY(ptr, data, size);
 
-    POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_writev_bytes(struct s2n_stuffer *stuffer, const struct iovec* iov, size_t iov_count, uint32_t offs, uint32_t size)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    notnull_check(iov);
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_ENSURE_REF(iov);
     void *ptr = s2n_stuffer_raw_write(stuffer, size);
-    ENSURE_POSIX(S2N_MEM_IS_READABLE(ptr, size), S2N_ERR_NULL);
+    POSIX_ENSURE(S2N_MEM_IS_READABLE(ptr, size), S2N_ERR_NULL);
 
     size_t size_left = size, to_skip = offs;
     for (int i = 0; i < iov_count; i++) {
@@ -332,12 +332,12 @@ int s2n_stuffer_writev_bytes(struct s2n_stuffer *stuffer, const struct iovec* io
             continue;
         }
         size_t iov_len_op = iov[i].iov_len - to_skip;
-        ENSURE_POSIX(iov_len_op <= UINT32_MAX, S2N_FAILURE);
+        POSIX_ENSURE(iov_len_op <= UINT32_MAX, S2N_FAILURE);
         uint32_t iov_len = (uint32_t)iov_len_op;
         uint32_t iov_size_to_take = MIN(size_left, iov_len);
-        notnull_check(iov[i].iov_base);
-        ENSURE_POSIX(to_skip < iov[i].iov_len, S2N_FAILURE);
-        memcpy_check(ptr, ((uint8_t*)(iov[i].iov_base)) + to_skip, iov_size_to_take);
+        POSIX_ENSURE_REF(iov[i].iov_base);
+        POSIX_ENSURE(to_skip < iov[i].iov_len, S2N_FAILURE);
+        POSIX_CHECKED_MEMCPY(ptr, ((uint8_t*)(iov[i].iov_base)) + to_skip, iov_size_to_take);
         size_left -= iov_size_to_take;
         if (size_left == 0) {
             break;
@@ -351,29 +351,29 @@ int s2n_stuffer_writev_bytes(struct s2n_stuffer *stuffer, const struct iovec* io
 
 static int s2n_stuffer_copy_impl(struct s2n_stuffer *from, struct s2n_stuffer *to, const uint32_t len)
 {
-    GUARD(s2n_stuffer_skip_read(from, len));
-    GUARD(s2n_stuffer_skip_write(to, len));
+    POSIX_GUARD(s2n_stuffer_skip_read(from, len));
+    POSIX_GUARD(s2n_stuffer_skip_write(to, len));
 
     uint8_t *from_ptr = from->blob.data + from->read_cursor - len;
     uint8_t *to_ptr = to->blob.data + to->write_cursor - len;
 
-    memcpy_check(to_ptr, from_ptr, len);
+    POSIX_CHECKED_MEMCPY(to_ptr, from_ptr, len);
 
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_reserve_space(struct s2n_stuffer *stuffer, uint32_t n)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
     if (s2n_stuffer_space_remaining(stuffer) < n) {
         POSIX_ENSURE(stuffer->growable, S2N_ERR_STUFFER_IS_FULL);
         /* Always grow a stuffer by at least 1k */
         const uint32_t growth = MAX(n - s2n_stuffer_space_remaining(stuffer), S2N_MIN_STUFFER_GROWTH_IN_BYTES);
         uint32_t new_size = 0;
-        GUARD(s2n_add_overflow(stuffer->blob.size, growth, &new_size));
-        GUARD(s2n_stuffer_resize(stuffer, new_size));
+        POSIX_GUARD(s2n_add_overflow(stuffer->blob.size, growth, &new_size));
+        POSIX_GUARD(s2n_stuffer_resize(stuffer, new_size));
     }
-    POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 
@@ -396,16 +396,16 @@ int s2n_stuffer_copy(struct s2n_stuffer *from, struct s2n_stuffer *to, const uin
 
 int s2n_stuffer_extract_blob(struct s2n_stuffer *stuffer, struct s2n_blob *out)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    notnull_check(out);
-    GUARD(s2n_realloc(out , s2n_stuffer_data_available(stuffer)));
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_ENSURE_REF(out);
+    POSIX_GUARD(s2n_realloc(out , s2n_stuffer_data_available(stuffer)));
 
     if (s2n_stuffer_data_available(stuffer) > 0) {
-        memcpy_check(out->data,
+        POSIX_CHECKED_MEMCPY(out->data,
                      stuffer->blob.data + stuffer->read_cursor,
                      s2n_stuffer_data_available(stuffer));
     }
 
-    POSTCONDITION_POSIX(s2n_blob_validate(out));
+    POSIX_POSTCONDITION(s2n_blob_validate(out));
     return S2N_SUCCESS;
 }

--- a/stuffer/s2n_stuffer_base64.c
+++ b/stuffer/s2n_stuffer_base64.c
@@ -74,8 +74,8 @@ bool s2n_is_base64_char(unsigned char c)
  */
 int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    PRECONDITION_POSIX(s2n_stuffer_validate(out));
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_PRECONDITION(s2n_stuffer_validate(out));
     int bytes_this_round = 3;
     s2n_stack_blob(o, 4, 4);
 
@@ -84,7 +84,7 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
             break;
         }
 
-        GUARD(s2n_stuffer_read(stuffer, &o));
+        POSIX_GUARD(s2n_stuffer_read(stuffer, &o));
 
         uint8_t value1 = b64_inverse[o.data[0]];
         uint8_t value2 = b64_inverse[o.data[1]];
@@ -95,7 +95,7 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
         if (value1 == 255) {
             /* Undo the read */
             stuffer->read_cursor -= o.size;
-            S2N_ERROR(S2N_ERR_INVALID_BASE64);
+            POSIX_BAIL(S2N_ERR_INVALID_BASE64);
         }
 
         /* The first two characters can never be '=' and in general
@@ -120,7 +120,7 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
         }
 
         /* Advance by bytes_this_round, and then fill in the data */
-        GUARD(s2n_stuffer_skip_write(out, bytes_this_round));
+        POSIX_GUARD(s2n_stuffer_skip_write(out, bytes_this_round));
         uint8_t *ptr = out->blob.data + out->write_cursor - bytes_this_round;
 
         /* value1 maps to the first 6 bits of the first data byte */
@@ -147,13 +147,13 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
 
 int s2n_stuffer_write_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *in)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    PRECONDITION_POSIX(s2n_stuffer_validate(in));
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_PRECONDITION(s2n_stuffer_validate(in));
     s2n_stack_blob(o, 4, 4);
     s2n_stack_blob(i, 3, 3);
 
     while (s2n_stuffer_data_available(in) > 2) {
-        GUARD(s2n_stuffer_read(in, &i));
+        POSIX_GUARD(s2n_stuffer_read(in, &i));
 
         /* Take the top 6-bits of the first data byte  */
         o.data[0] = b64[(i.data[0] >> 2) & 0x3f];
@@ -172,13 +172,13 @@ int s2n_stuffer_write_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *in
          */
         o.data[3] = b64[i.data[2] & 0x3f];
 
-        GUARD(s2n_stuffer_write(stuffer, &o));
+        POSIX_GUARD(s2n_stuffer_write(stuffer, &o));
     }
 
     if (s2n_stuffer_data_available(in)) {
         /* Read just one byte */
         i.size = 1;
-        GUARD(s2n_stuffer_read(in, &i));
+        POSIX_GUARD(s2n_stuffer_read(in, &i));
         uint8_t c = i.data[0];
 
         /* We at least one data byte left to encode, encode
@@ -196,13 +196,13 @@ int s2n_stuffer_write_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *in
             o.data[2] = '=';
         } else {
             /* Read the last byte */
-            GUARD(s2n_stuffer_read(in, &i));
+            POSIX_GUARD(s2n_stuffer_read(in, &i));
 
             o.data[1] = b64[((c << 4) & 0x30) | ((i.data[0] >> 4) & 0x0f)];
             o.data[2] = b64[((i.data[0] << 2) & 0x3c)];
         }
 
-        GUARD(s2n_stuffer_write(stuffer, &o));
+        POSIX_GUARD(s2n_stuffer_write(stuffer, &o));
     }
 
     return S2N_SUCCESS;

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -23,8 +23,8 @@
 /* Writes length bytes of input to stuffer, in network order, starting from the smallest byte of input. */
 int s2n_stuffer_write_network_order(struct s2n_stuffer *stuffer, const uint64_t input, const uint8_t length)
 {
-    ENSURE_POSIX(length <= sizeof(input), S2N_ERR_SAFETY);
-    GUARD(s2n_stuffer_skip_write(stuffer, length));
+    POSIX_ENSURE(length <= sizeof(input), S2N_ERR_SAFETY);
+    POSIX_GUARD(s2n_stuffer_skip_write(stuffer, length));
     uint8_t *data = stuffer->blob.data + stuffer->write_cursor - length;
 
     for (int i = 0; i < length; i++) {
@@ -32,43 +32,43 @@ int s2n_stuffer_write_network_order(struct s2n_stuffer *stuffer, const uint64_t 
         uint8_t shift = (length - i - 1) * CHAR_BIT;
         data[i] = (input >> (shift)) & UINT8_MAX;
     }
-    POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_reserve(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservation *reservation, const uint8_t length)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    notnull_check(reservation);
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_ENSURE_REF(reservation);
 
     *reservation = (struct s2n_stuffer_reservation) {.stuffer = stuffer, .write_cursor = stuffer->write_cursor, .length = length};
 
-    GUARD(s2n_stuffer_skip_write(stuffer, reservation->length));
-    memset_check(stuffer->blob.data + reservation->write_cursor, S2N_WIPE_PATTERN, reservation->length);
-    POSTCONDITION_POSIX(s2n_stuffer_reservation_validate(reservation));
+    POSIX_GUARD(s2n_stuffer_skip_write(stuffer, reservation->length));
+    POSIX_CHECKED_MEMSET(stuffer->blob.data + reservation->write_cursor, S2N_WIPE_PATTERN, reservation->length);
+    POSIX_POSTCONDITION(s2n_stuffer_reservation_validate(reservation));
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_read_uint8(struct s2n_stuffer *stuffer, uint8_t * u)
 {
-    GUARD(s2n_stuffer_read_bytes(stuffer, u, sizeof(uint8_t)));
+    POSIX_GUARD(s2n_stuffer_read_bytes(stuffer, u, sizeof(uint8_t)));
 
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_write_uint8(struct s2n_stuffer *stuffer, const uint8_t u)
 {
-    GUARD(s2n_stuffer_write_bytes(stuffer, &u, sizeof(u)));
+    POSIX_GUARD(s2n_stuffer_write_bytes(stuffer, &u, sizeof(u)));
 
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_read_uint16(struct s2n_stuffer *stuffer, uint16_t * u)
 {
-    notnull_check(u);
+    POSIX_ENSURE_REF(u);
     uint8_t data[sizeof(uint16_t)];
 
-    GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
+    POSIX_GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
 
     *u = data[0] << 8;
     *u |= data[1];
@@ -88,10 +88,10 @@ int s2n_stuffer_reserve_uint16(struct s2n_stuffer *stuffer, struct s2n_stuffer_r
 
 int s2n_stuffer_read_uint24(struct s2n_stuffer *stuffer, uint32_t * u)
 {
-    notnull_check(u);
+    POSIX_ENSURE_REF(u);
     uint8_t data[SIZEOF_UINT24];
 
-    GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
+    POSIX_GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
 
     *u = data[0] << 16;
     *u |= data[1] << 8;
@@ -112,10 +112,10 @@ int s2n_stuffer_reserve_uint24(struct s2n_stuffer *stuffer, struct s2n_stuffer_r
 
 int s2n_stuffer_read_uint32(struct s2n_stuffer *stuffer, uint32_t * u)
 {
-    notnull_check(u);
+    POSIX_ENSURE_REF(u);
     uint8_t data[sizeof(uint32_t)];
 
-    GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
+    POSIX_GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
 
     *u = ((uint32_t) data[0]) << 24;
     *u |= data[1] << 16;
@@ -132,10 +132,10 @@ int s2n_stuffer_write_uint32(struct s2n_stuffer *stuffer, const uint32_t u)
 
 int s2n_stuffer_read_uint64(struct s2n_stuffer *stuffer, uint64_t * u)
 {
-    notnull_check(u);
+    POSIX_ENSURE_REF(u);
     uint8_t data[sizeof(uint64_t)];
 
-    GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
+    POSIX_GUARD(s2n_stuffer_read_bytes(stuffer, data, sizeof(data)));
 
     *u = ((uint64_t) data[0]) << 56;
     *u |= ((uint64_t) data[1]) << 48;
@@ -170,17 +170,17 @@ static int length_matches_value_check(uint32_t value, uint8_t length)
 static int s2n_stuffer_write_reservation_impl(struct s2n_stuffer_reservation* reservation, const uint32_t u)
 {
     reservation->stuffer->write_cursor = reservation->write_cursor;
-    PRECONDITION_POSIX(s2n_stuffer_validate(reservation->stuffer));
+    POSIX_PRECONDITION(s2n_stuffer_validate(reservation->stuffer));
 
-    GUARD(length_matches_value_check(u, reservation->length));
-    GUARD(s2n_stuffer_write_network_order(reservation->stuffer, u, reservation->length));
-    POSTCONDITION_POSIX(s2n_stuffer_validate(reservation->stuffer));
+    POSIX_GUARD(length_matches_value_check(u, reservation->length));
+    POSIX_GUARD(s2n_stuffer_write_network_order(reservation->stuffer, u, reservation->length));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(reservation->stuffer));
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_write_reservation(struct s2n_stuffer_reservation* reservation, const uint32_t u)
 {
-    PRECONDITION_POSIX(s2n_stuffer_reservation_validate(reservation));
+    POSIX_PRECONDITION(s2n_stuffer_reservation_validate(reservation));
     uint32_t old_write_cursor = reservation->stuffer->write_cursor;
     int result = s2n_stuffer_write_reservation_impl(reservation, u);
     reservation->stuffer->write_cursor = old_write_cursor;
@@ -189,9 +189,9 @@ int s2n_stuffer_write_reservation(struct s2n_stuffer_reservation* reservation, c
 
 int s2n_stuffer_write_vector_size(struct s2n_stuffer_reservation* reservation)
 {
-    PRECONDITION_POSIX(s2n_stuffer_reservation_validate(reservation));
+    POSIX_PRECONDITION(s2n_stuffer_reservation_validate(reservation));
     uint32_t size = 0;
-    GUARD(s2n_sub_overflow(reservation->stuffer->write_cursor, reservation->write_cursor, &size));
-    GUARD(s2n_sub_overflow(size, reservation->length, &size));
+    POSIX_GUARD(s2n_sub_overflow(reservation->stuffer->write_cursor, reservation->write_cursor, &size));
+    POSIX_GUARD(s2n_sub_overflow(size, reservation->length, &size));
     return s2n_stuffer_write_reservation(reservation, size);
 }

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -26,24 +26,24 @@ int s2n_stuffer_peek_char(struct s2n_stuffer *s2n_stuffer, char *c)
     if (r == S2N_SUCCESS) {
         s2n_stuffer->read_cursor--;
     }
-    POSTCONDITION_POSIX(s2n_stuffer_validate(s2n_stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(s2n_stuffer));
     return r;
 }
 
 /* Peeks in stuffer to see if expected string is present. */
 int s2n_stuffer_peek_check_for_str(struct s2n_stuffer *s2n_stuffer, const char *expected)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(s2n_stuffer));
+    POSIX_PRECONDITION(s2n_stuffer_validate(s2n_stuffer));
     uint32_t orig_read_pos = s2n_stuffer->read_cursor;
     int rc = s2n_stuffer_read_expected_str(s2n_stuffer, expected);
     s2n_stuffer->read_cursor = orig_read_pos;
-    POSTCONDITION_POSIX(s2n_stuffer_validate(s2n_stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(s2n_stuffer));
     return rc;
 }
 
 int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer, uint32_t *skipped)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(s2n_stuffer));
+    POSIX_PRECONDITION(s2n_stuffer_validate(s2n_stuffer));
     uint32_t initial_read_cursor = s2n_stuffer->read_cursor;
     while (s2n_stuffer->read_cursor < s2n_stuffer->write_cursor) {
         switch (s2n_stuffer->blob.data[s2n_stuffer->read_cursor]) {
@@ -59,73 +59,73 @@ int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer, uint32_t *skipp
     }
     finished:
     if(skipped != NULL) *skipped = s2n_stuffer->read_cursor - initial_read_cursor;
-    POSTCONDITION_POSIX(s2n_stuffer_validate(s2n_stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(s2n_stuffer));
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_read_expected_str(struct s2n_stuffer *stuffer, const char *expected)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    notnull_check(expected);
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_ENSURE_REF(expected);
     size_t expected_length = strlen(expected);
     if (expected_length == 0) {
         return S2N_SUCCESS;
     }
-    ENSURE_POSIX(s2n_stuffer_data_available(stuffer) >= expected_length, S2N_ERR_STUFFER_OUT_OF_DATA);
+    POSIX_ENSURE(s2n_stuffer_data_available(stuffer) >= expected_length, S2N_ERR_STUFFER_OUT_OF_DATA);
     uint8_t *actual = stuffer->blob.data + stuffer->read_cursor;
-    notnull_check(actual);
-    ENSURE_POSIX(!memcmp(actual, expected, expected_length), S2N_ERR_STUFFER_NOT_FOUND);
+    POSIX_ENSURE_REF(actual);
+    POSIX_ENSURE(!memcmp(actual, expected, expected_length), S2N_ERR_STUFFER_NOT_FOUND);
     stuffer->read_cursor += expected_length;
-    POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 
 /* Read from stuffer until the target string is found, or until there is no more data. */
 int s2n_stuffer_skip_read_until(struct s2n_stuffer *stuffer, const char *target)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    notnull_check(target);
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_ENSURE_REF(target);
     const int len = strlen(target);
     if (len == 0) {
         return S2N_SUCCESS;
     }
     while (s2n_stuffer_data_available(stuffer) >= len) {
-        GUARD(s2n_stuffer_skip_to_char(stuffer, target[0]));
-        GUARD(s2n_stuffer_skip_read(stuffer, len));
+        POSIX_GUARD(s2n_stuffer_skip_to_char(stuffer, target[0]));
+        POSIX_GUARD(s2n_stuffer_skip_read(stuffer, len));
         uint8_t *actual = stuffer->blob.data + stuffer->read_cursor - len;
-        notnull_check(actual);
+        POSIX_ENSURE_REF(actual);
 
         if (strncmp((char*)actual, target, len) == 0){
             return S2N_SUCCESS;
         } else {
             /* If string doesn't match, rewind stuffer to 1 byte after last read */
-            GUARD(s2n_stuffer_rewind_read(stuffer, len - 1));
+            POSIX_GUARD(s2n_stuffer_rewind_read(stuffer, len - 1));
             continue;
         }
     }
-    POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 
 /* Skips the stuffer until the first instance of the target character or until there is no more data. */
 int s2n_stuffer_skip_to_char(struct s2n_stuffer *stuffer, const char target)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
     while (s2n_stuffer_data_available(stuffer) > 0) {
         if (stuffer->blob.data[stuffer->read_cursor] == target) {
             break;
         }
         stuffer->read_cursor += 1;
     }
-    POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 
 /* Skips an expected character in the stuffer between min and max times */
 int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, const uint32_t min, const uint32_t max, uint32_t *skipped)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    ENSURE_POSIX(min <= max, S2N_ERR_SAFETY);
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_ENSURE(min <= max, S2N_ERR_SAFETY);
 
     uint32_t skip = 0;
     while (stuffer->read_cursor < stuffer->write_cursor && skip < max) {
@@ -136,33 +136,33 @@ int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expec
             break;
         }
     }
-    ENSURE_POSIX(skip >= min, S2N_ERR_STUFFER_NOT_FOUND);
+    POSIX_ENSURE(skip >= min, S2N_ERR_STUFFER_NOT_FOUND);
     if(skipped != NULL) *skipped = skip;
-    POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 
 /* Read a line of text. Agnostic to LF or CR+LF line endings. */
 int s2n_stuffer_read_line(struct s2n_stuffer *stuffer, struct s2n_stuffer *token)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    PRECONDITION_POSIX(s2n_stuffer_validate(token));
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_PRECONDITION(s2n_stuffer_validate(token));
     /* Consume an LF terminated line */
-    GUARD(s2n_stuffer_read_token(stuffer, token, '\n'));
+    POSIX_GUARD(s2n_stuffer_read_token(stuffer, token, '\n'));
 
     /* Snip off the carriage return if it's present */
     if ((s2n_stuffer_data_available(token) > 0) && (token->blob.data[(token->write_cursor - 1)] == '\r')) {
         token->write_cursor--;
     }
-    POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    POSTCONDITION_POSIX(s2n_stuffer_validate(token));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(token));
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_read_token(struct s2n_stuffer *stuffer, struct s2n_stuffer *token, char delim)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    PRECONDITION_POSIX(s2n_stuffer_validate(token));
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_PRECONDITION(s2n_stuffer_validate(token));
     uint32_t token_size = 0;
 
     while ((stuffer->read_cursor + token_size) < stuffer->write_cursor) {
@@ -172,23 +172,23 @@ int s2n_stuffer_read_token(struct s2n_stuffer *stuffer, struct s2n_stuffer *toke
         token_size++;
     }
 
-    GUARD(s2n_stuffer_copy(stuffer, token, token_size));
+    POSIX_GUARD(s2n_stuffer_copy(stuffer, token, token_size));
 
     /* Consume the delimiter too */
     if (stuffer->read_cursor < stuffer->write_cursor) {
         stuffer->read_cursor++;
     }
 
-    POSTCONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    POSTCONDITION_POSIX(s2n_stuffer_validate(token));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(token));
     return S2N_SUCCESS;
 }
 
 int s2n_stuffer_alloc_ro_from_string(struct s2n_stuffer *stuffer, const char *str)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    notnull_check(str);
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_ENSURE_REF(str);
     uint32_t length = strlen(str);
-    GUARD(s2n_stuffer_alloc(stuffer, length + 1));
+    POSIX_GUARD(s2n_stuffer_alloc(stuffer, length + 1));
     return s2n_stuffer_write_bytes(stuffer, (const uint8_t *)str, length);
 }

--- a/tests/cbmc/stubs/s2n_hash_copy.c
+++ b/tests/cbmc/stubs/s2n_hash_copy.c
@@ -21,9 +21,9 @@
 
 int s2n_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
 {
-    PRECONDITION_POSIX(s2n_hash_state_validate(to));
-    PRECONDITION_POSIX(s2n_hash_state_validate(from));
-    notnull_check(from->hash_impl->copy);
+    POSIX_PRECONDITION(s2n_hash_state_validate(to));
+    POSIX_PRECONDITION(s2n_hash_state_validate(from));
+    POSIX_ENSURE_REF(from->hash_impl->copy);
 
     /* return from->hash_impl->copy(to, from); */
     return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;

--- a/tests/cbmc/stubs/s2n_hash_digest.c
+++ b/tests/cbmc/stubs/s2n_hash_digest.c
@@ -21,9 +21,9 @@
 
 int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 {
-    PRECONDITION_POSIX(s2n_hash_state_validate(state));
-    ENSURE_POSIX(S2N_MEM_IS_READABLE(out, size), S2N_ERR_PRECONDITION_VIOLATION);
-    notnull_check(state->hash_impl->digest);
+    POSIX_PRECONDITION(s2n_hash_state_validate(state));
+    POSIX_ENSURE(S2N_MEM_IS_READABLE(out, size), S2N_ERR_PRECONDITION_VIOLATION);
+    POSIX_ENSURE_REF(state->hash_impl->digest);
 
     /* return state->hash_impl->digest(state, out, size); */
     return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;

--- a/tests/cbmc/stubs/s2n_hash_reset.c
+++ b/tests/cbmc/stubs/s2n_hash_reset.c
@@ -21,8 +21,8 @@
 
 int s2n_hash_reset(struct s2n_hash_state *state)
 {
-    notnull_check(state);
-    notnull_check(state->hash_impl->reset);
+    POSIX_ENSURE_REF(state);
+    POSIX_ENSURE_REF(state->hash_impl->reset);
 
     /* return state->hash_impl->reset(state); */
     return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;

--- a/tests/cbmc/stubs/s2n_hash_update.c
+++ b/tests/cbmc/stubs/s2n_hash_update.c
@@ -21,9 +21,9 @@
 
 int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
-    PRECONDITION_POSIX(s2n_hash_state_validate(state));
-    ENSURE_POSIX(S2N_MEM_IS_READABLE(data, size), S2N_ERR_PRECONDITION_VIOLATION);
-    notnull_check(state->hash_impl->update);
+    POSIX_PRECONDITION(s2n_hash_state_validate(state));
+    POSIX_ENSURE(S2N_MEM_IS_READABLE(data, size), S2N_ERR_PRECONDITION_VIOLATION);
+    POSIX_ENSURE_REF(state->hash_impl->update);
 
     /* return state->hash_impl->update(state, data, size); */
     return nondet_bool() ? S2N_SUCCESS : S2N_FAILURE;

--- a/tests/cbmc/stubs/s2n_stuffer_read_base64.c
+++ b/tests/cbmc/stubs/s2n_stuffer_read_base64.c
@@ -21,8 +21,8 @@
 
 int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    PRECONDITION_POSIX(s2n_stuffer_validate(out));
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_PRECONDITION(s2n_stuffer_validate(out));
     /*
      * This is stub is incomplete and it needs to update stuffer
      * cursors appropriately https://github.com/awslabs/s2n/issues/2173.

--- a/tests/cbmc/stubs/s2n_stuffer_read_expected_str.c
+++ b/tests/cbmc/stubs/s2n_stuffer_read_expected_str.c
@@ -21,8 +21,8 @@
 
 int s2n_stuffer_read_expected_str(struct s2n_stuffer *s2n_stuffer, const char *expected)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(s2n_stuffer));
-    notnull_check(expected);
+    POSIX_PRECONDITION(s2n_stuffer_validate(s2n_stuffer));
+    POSIX_ENSURE_REF(expected);
     /*
      * This is stub is incomplete and it needs to update stuffer
      * cursors appropriately https://github.com/awslabs/s2n/issues/2173.

--- a/tests/cbmc/stubs/s2n_stuffer_skip_expected_char.c
+++ b/tests/cbmc/stubs/s2n_stuffer_skip_expected_char.c
@@ -23,8 +23,8 @@
 int s2n_stuffer_skip_expected_char(struct s2n_stuffer *stuffer, const char expected, const uint32_t min,
                                    const uint32_t max, uint32_t *skipped)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    ENSURE_POSIX(min <= max, S2N_FAILURE);
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    POSIX_ENSURE(min <= max, S2N_FAILURE);
     /*
      * This is stub is incomplete and it needs to update stuffer
      * cursors appropriately https://github.com/awslabs/s2n/issues/2173.

--- a/tests/cbmc/stubs/s2n_stuffer_skip_to_char.c
+++ b/tests/cbmc/stubs/s2n_stuffer_skip_to_char.c
@@ -21,7 +21,7 @@
 
 int s2n_stuffer_skip_to_char(struct s2n_stuffer *stuffer, const char target)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
     /*
      * This is stub is incomplete and it needs to update stuffer
      * cursors appropriately https://github.com/awslabs/s2n/issues/2173.

--- a/tests/cbmc/stubs/s2n_stuffer_skip_whitespace.c
+++ b/tests/cbmc/stubs/s2n_stuffer_skip_whitespace.c
@@ -21,7 +21,7 @@
 
 int s2n_stuffer_skip_whitespace(struct s2n_stuffer *s2n_stuffer, uint32_t *skipped)
 {
-    PRECONDITION_POSIX(s2n_stuffer_validate(s2n_stuffer));
+    POSIX_PRECONDITION(s2n_stuffer_validate(s2n_stuffer));
     /*
      * This is stub is incomplete and it needs to update stuffer
      * cursors appropriately https://github.com/awslabs/s2n/issues/2173.

--- a/tests/fuzz/LD_PRELOAD/global_overrides.c
+++ b/tests/fuzz/LD_PRELOAD/global_overrides.c
@@ -33,7 +33,7 @@ int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob) {
      * This function should generate non-zero values since this function may be called repeatedly at startup until a
      * non-zero value is generated.
      */
-    GUARD_AS_POSIX(s2n_get_public_random_data(blob));
+    POSIX_GUARD_RESULT(s2n_get_public_random_data(blob));
     drbg->bytes_used += blob->size;
     return S2N_SUCCESS;
 }
@@ -52,8 +52,8 @@ int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, const int wfd, const uin
     typedef int (*orig_s2n_stuffer_send_to_fd_func_type)(struct s2n_stuffer *stuffer, const int wfd, const uint32_t len, uint32_t *bytes_sent);
     orig_s2n_stuffer_send_to_fd_func_type orig_s2n_stuffer_send_to_fd;
     orig_s2n_stuffer_send_to_fd = (orig_s2n_stuffer_send_to_fd_func_type) dlsym(RTLD_NEXT, "s2n_stuffer_send_to_fd");
-    GUARD_NONNULL(orig_s2n_stuffer_send_to_fd);
-    GUARD(orig_s2n_stuffer_send_to_fd(stuffer, wfd, len, bytes_sent));
+    POSIX_GUARD_PTR(orig_s2n_stuffer_send_to_fd);
+    POSIX_GUARD(orig_s2n_stuffer_send_to_fd(stuffer, wfd, len, bytes_sent));
     return S2N_SUCCESS;
 }
 

--- a/tests/fuzz/s2n_bike_r1_recv_ciphertext_fuzz_test.c
+++ b/tests/fuzz/s2n_bike_r1_recv_ciphertext_fuzz_test.c
@@ -30,13 +30,13 @@ static struct s2n_kem_params kem_params = { .kem = &s2n_bike1_l1_r1 };
 
 int s2n_fuzz_init(int *argc, char **argv[])
 {
-    GUARD(s2n_kem_recv_ciphertext_fuzz_test_init(KAT_FILE_NAME, &kem_params));
+    POSIX_GUARD(s2n_kem_recv_ciphertext_fuzz_test_init(KAT_FILE_NAME, &kem_params));
     return S2N_SUCCESS;
 }
 
 int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
-    GUARD(s2n_kem_recv_ciphertext_fuzz_test(buf, len, &kem_params));
+    POSIX_GUARD(s2n_kem_recv_ciphertext_fuzz_test(buf, len, &kem_params));
     return S2N_SUCCESS;
 }
 

--- a/tests/fuzz/s2n_bike_r1_recv_public_key_fuzz_test.c
+++ b/tests/fuzz/s2n_bike_r1_recv_public_key_fuzz_test.c
@@ -26,7 +26,7 @@
 static struct s2n_kem_params kem_params = { .kem = &s2n_bike1_l1_r1 };
 
 int s2n_fuzz_test(const uint8_t *buf, size_t len) {
-    GUARD(s2n_kem_recv_public_key_fuzz_test(buf, len, &kem_params));
+    POSIX_GUARD(s2n_kem_recv_public_key_fuzz_test(buf, len, &kem_params));
     return S2N_SUCCESS;
 }
 

--- a/tests/fuzz/s2n_bike_r2_recv_ciphertext_fuzz_test.c
+++ b/tests/fuzz/s2n_bike_r2_recv_ciphertext_fuzz_test.c
@@ -30,13 +30,13 @@ static struct s2n_kem_params kem_params = { .kem = &s2n_bike1_l1_r2 };
 
 int s2n_fuzz_init(int *argc, char **argv[])
 {
-    GUARD(s2n_kem_recv_ciphertext_fuzz_test_init(KAT_FILE_NAME, &kem_params));
+    POSIX_GUARD(s2n_kem_recv_ciphertext_fuzz_test_init(KAT_FILE_NAME, &kem_params));
     return S2N_SUCCESS;
 }
 
 int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
-    GUARD(s2n_kem_recv_ciphertext_fuzz_test(buf, len, &kem_params));
+    POSIX_GUARD(s2n_kem_recv_ciphertext_fuzz_test(buf, len, &kem_params));
     return S2N_SUCCESS;
 }
 

--- a/tests/fuzz/s2n_bike_r2_recv_public_key_fuzz_test.c
+++ b/tests/fuzz/s2n_bike_r2_recv_public_key_fuzz_test.c
@@ -26,7 +26,7 @@
 static struct s2n_kem_params kem_params = { .kem = &s2n_bike1_l1_r2 };
 
 int s2n_fuzz_test(const uint8_t *buf, size_t len) {
-    GUARD(s2n_kem_recv_public_key_fuzz_test(buf, len, &kem_params));
+    POSIX_GUARD(s2n_kem_recv_public_key_fuzz_test(buf, len, &kem_params));
     return S2N_SUCCESS;
 }
 

--- a/tests/fuzz/s2n_client_ccs_recv_test.c
+++ b/tests/fuzz/s2n_client_ccs_recv_test.c
@@ -42,12 +42,12 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Setup */
     struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
-    notnull_check(server_conn);
-    GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
+    POSIX_ENSURE_REF(server_conn);
+    POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
 
     /* Pull a byte off the libfuzzer input and use it to set parameters */
     uint8_t randval = 0;
-    GUARD(s2n_stuffer_read_uint8(&server_conn->handshake.io, &randval));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&server_conn->handshake.io, &randval));
     server_conn->actual_protocol_version = TLS_VERSIONS[(randval & 0x03) % s2n_array_len(TLS_VERSIONS)];
     server_conn->secure.cipher_suite = cipher_prefs->suites[(randval >> 2) % cipher_prefs->count];
 
@@ -57,7 +57,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     s2n_client_ccs_recv(server_conn);
 
     /* Cleanup */
-    GUARD(s2n_connection_free(server_conn));
+    POSIX_GUARD(s2n_connection_free(server_conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_client_cert_verify_recv_test.c
+++ b/tests/fuzz/s2n_client_cert_verify_recv_test.c
@@ -127,12 +127,12 @@ int s2n_fuzz_init(int *argc, char **argv[])
 {
     /* Set up Server Config */
     server_config = s2n_config_new();
-    GUARD(s2n_config_add_cert_chain_and_key(server_config, certificate_chain, private_key));
+    POSIX_GUARD(s2n_config_add_cert_chain_and_key(server_config, certificate_chain, private_key));
     s2n_pkey_type pkey_type;
     POSIX_ENSURE(s2n_config_get_num_default_certs(server_config) != 0, S2N_ERR_NUM_DEFAULT_CERTIFICATES);
     struct s2n_cert_chain_and_key *cert = s2n_config_get_single_default_cert(server_config);
-    notnull_check(cert);
-    GUARD(s2n_asn1der_to_public_key_and_type(&public_key, &pkey_type, &cert->cert_chain->head->raw));
+    POSIX_ENSURE_REF(cert);
+    POSIX_GUARD(s2n_asn1der_to_public_key_and_type(&public_key, &pkey_type, &cert->cert_chain->head->raw));
 
     return S2N_SUCCESS;
 }
@@ -144,13 +144,13 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Setup */
     struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
-    notnull_check(server_conn);
-    GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
+    POSIX_ENSURE_REF(server_conn);
+    POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
     server_conn->secure.client_public_key.key.rsa_key.rsa = public_key.key.rsa_key.rsa;
 
     /* Pull a byte off the libfuzzer input and use it to set parameters */
     uint8_t randval = 0;
-    GUARD(s2n_stuffer_read_uint8(&server_conn->handshake.io, &randval));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&server_conn->handshake.io, &randval));
     server_conn->actual_protocol_version = TLS_VERSIONS[randval % s2n_array_len(TLS_VERSIONS)];
 
     /* Run Test
@@ -163,7 +163,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     server_conn->secure.client_public_key.key.rsa_key.rsa = NULL;
 
     /* Cleanup */
-    GUARD(s2n_connection_free(server_conn));
+    POSIX_GUARD(s2n_connection_free(server_conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_client_finished_recv_test.c
+++ b/tests/fuzz/s2n_client_finished_recv_test.c
@@ -31,8 +31,8 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     /* Setup */
     struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
-    notnull_check(server_conn);
-    GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
+    POSIX_ENSURE_REF(server_conn);
+    POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
 
     /* We do not use a GUARD macro here as there may not be enough bytes to write the necessary
      * amount, and the result of a failed read_bytes call is an acceptable test input. */
@@ -44,7 +44,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     s2n_client_finished_recv(server_conn);
 
     /* Cleanup */
-    GUARD(s2n_connection_free(server_conn));
+    POSIX_GUARD(s2n_connection_free(server_conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_client_fuzz_test.c
+++ b/tests/fuzz/s2n_client_fuzz_test.c
@@ -172,9 +172,9 @@ static struct s2n_config *client_config;
 int s2n_fuzz_init(int *argc, char **argv[])
 {
     /* Set up Server Config */
-    notnull_check(client_config = s2n_config_new());
-    GUARD(s2n_config_add_cert_chain_and_key(client_config, certificate_chain, private_key));
-    GUARD(s2n_config_add_dhparams(client_config, dhparams));
+    POSIX_ENSURE_REF(client_config = s2n_config_new());
+    POSIX_GUARD(s2n_config_add_cert_chain_and_key(client_config, certificate_chain, private_key));
+    POSIX_GUARD(s2n_config_add_dhparams(client_config, dhparams));
 
     return S2N_SUCCESS;
 }
@@ -184,17 +184,17 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     S2N_FUZZ_ENSURE_MIN_LEN(len, S2N_TLS_RECORD_HEADER_LENGTH);
 
     struct s2n_stuffer in = {0};
-    GUARD(s2n_stuffer_alloc(&in, len));
-    GUARD(s2n_stuffer_write_bytes(&in, buf, len));
+    POSIX_GUARD(s2n_stuffer_alloc(&in, len));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&in, buf, len));
 
     /* Set up Server Connection */
     struct s2n_connection *client_conn;
-    notnull_check(client_conn = s2n_connection_new(S2N_CLIENT));
-    GUARD(s2n_connection_set_recv_cb(client_conn, &buffer_read));
-    GUARD(s2n_connection_set_send_cb(client_conn, &buffer_write));
-    GUARD(s2n_connection_set_recv_ctx(client_conn, &in));
-    GUARD(s2n_connection_set_config(client_conn, client_config));
-    GUARD(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
+    POSIX_ENSURE_REF(client_conn = s2n_connection_new(S2N_CLIENT));
+    POSIX_GUARD(s2n_connection_set_recv_cb(client_conn, &buffer_read));
+    POSIX_GUARD(s2n_connection_set_send_cb(client_conn, &buffer_write));
+    POSIX_GUARD(s2n_connection_set_recv_ctx(client_conn, &in));
+    POSIX_GUARD(s2n_connection_set_config(client_conn, client_config));
+    POSIX_GUARD(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
     client_conn->delay = 0;
 
     /* Let Server receive data and attempt Negotiation */
@@ -207,8 +207,8 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Clean up */
     s2n_shutdown(client_conn, &client_blocked);
-    GUARD(s2n_connection_free(client_conn));
-    GUARD(s2n_stuffer_free(&in));
+    POSIX_GUARD(s2n_connection_free(client_conn));
+    POSIX_GUARD(s2n_stuffer_free(&in));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_encrypted_extensions_recv_test.c
+++ b/tests/fuzz/s2n_encrypted_extensions_recv_test.c
@@ -36,7 +36,7 @@ static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
 
 int s2n_fuzz_init(int *argc, char **argv[])
 {
-    GUARD(s2n_enable_tls13());
+    POSIX_GUARD(s2n_enable_tls13());
     return S2N_SUCCESS;
 }
 
@@ -47,12 +47,12 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Setup */
     struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
-    notnull_check(client_conn);
-    GUARD(s2n_stuffer_write_bytes(&client_conn->handshake.io, buf, len));
+    POSIX_ENSURE_REF(client_conn);
+    POSIX_GUARD(s2n_stuffer_write_bytes(&client_conn->handshake.io, buf, len));
 
     /* Pull a byte from the libfuzzer input and use it to set parameters */
     uint8_t randval = 0;
-    GUARD(s2n_stuffer_read_uint8(&client_conn->handshake.io, &randval));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&client_conn->handshake.io, &randval));
     client_conn->actual_protocol_version = TLS_VERSIONS[randval % s2n_array_len(TLS_VERSIONS)];
 
     /* Run Test
@@ -61,7 +61,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     s2n_extension_list_recv(S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS, client_conn, &client_conn->handshake.io);
 
     /* Cleanup */
-    GUARD(s2n_connection_free(client_conn));
+    POSIX_GUARD(s2n_connection_free(client_conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_extensions_client_key_share_recv_test.c
+++ b/tests/fuzz/s2n_extensions_client_key_share_recv_test.c
@@ -37,7 +37,7 @@ static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
 
 int s2n_fuzz_init(int *argc, char **argv[])
 {
-    GUARD(s2n_enable_tls13());
+    POSIX_GUARD(s2n_enable_tls13());
     return S2N_SUCCESS;
 }
 
@@ -48,15 +48,15 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Setup */
     struct s2n_stuffer fuzz_stuffer = {0};
-    GUARD(s2n_stuffer_alloc(&fuzz_stuffer, len));
-    GUARD(s2n_stuffer_write_bytes(&fuzz_stuffer, buf, len));
+    POSIX_GUARD(s2n_stuffer_alloc(&fuzz_stuffer, len));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&fuzz_stuffer, buf, len));
 
     struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
-    notnull_check(server_conn);
+    POSIX_ENSURE_REF(server_conn);
 
     /* Pull a byte off the libfuzzer input and use it to set parameters */
     uint8_t randval = 0;
-    GUARD(s2n_stuffer_read_uint8(&fuzz_stuffer, &randval));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&fuzz_stuffer, &randval));
     server_conn->actual_protocol_version = TLS_VERSIONS[randval % s2n_array_len(TLS_VERSIONS)];
 
     /* Run Test
@@ -65,8 +65,8 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     s2n_extensions_client_key_share_recv(server_conn, &fuzz_stuffer);
 
     /* Cleanup */
-    GUARD(s2n_connection_free(server_conn));
-    GUARD(s2n_stuffer_free(&fuzz_stuffer));
+    POSIX_GUARD(s2n_connection_free(server_conn));
+    POSIX_GUARD(s2n_stuffer_free(&fuzz_stuffer));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_extensions_client_supported_versions_recv_test.c
+++ b/tests/fuzz/s2n_extensions_client_supported_versions_recv_test.c
@@ -38,7 +38,7 @@ static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
 
 int s2n_fuzz_init(int *argc, char **argv[])
 {
-    GUARD(s2n_enable_tls13());
+    POSIX_GUARD(s2n_enable_tls13());
     return S2N_SUCCESS;
 }
 
@@ -49,15 +49,15 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Setup */
     struct s2n_stuffer fuzz_stuffer = {0};
-    GUARD(s2n_stuffer_alloc(&fuzz_stuffer, len));
-    GUARD(s2n_stuffer_write_bytes(&fuzz_stuffer, buf, len));
+    POSIX_GUARD(s2n_stuffer_alloc(&fuzz_stuffer, len));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&fuzz_stuffer, buf, len));
 
     struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
-    notnull_check(server_conn);
+    POSIX_ENSURE_REF(server_conn);
 
     /* Pull a byte off the libfuzzer input and use it to set parameters */
     uint8_t randval = 0;
-    GUARD(s2n_stuffer_read_uint8(&fuzz_stuffer, &randval));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&fuzz_stuffer, &randval));
     server_conn->server_protocol_version = TLS_VERSIONS[randval % s2n_array_len(TLS_VERSIONS)];
 
     server_conn->config = s2n_config_new();
@@ -68,9 +68,9 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     s2n_extensions_client_supported_versions_recv(server_conn, &fuzz_stuffer);
 
     /* Cleanup */
-    GUARD(s2n_config_free(server_conn->config));
-    GUARD(s2n_connection_free(server_conn));
-    GUARD(s2n_stuffer_free(&fuzz_stuffer));
+    POSIX_GUARD(s2n_config_free(server_conn->config));
+    POSIX_GUARD(s2n_connection_free(server_conn));
+    POSIX_GUARD(s2n_stuffer_free(&fuzz_stuffer));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_extensions_server_supported_versions_recv_test.c
+++ b/tests/fuzz/s2n_extensions_server_supported_versions_recv_test.c
@@ -36,7 +36,7 @@ static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
 
 int s2n_fuzz_init(int *argc, char **argv[])
 {
-    GUARD(s2n_enable_tls13());
+    POSIX_GUARD(s2n_enable_tls13());
     return S2N_SUCCESS;
 }
 
@@ -47,16 +47,16 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Setup */
     struct s2n_stuffer fuzz_stuffer = {0};
-    GUARD(s2n_stuffer_alloc(&fuzz_stuffer, len));
-    GUARD(s2n_stuffer_write_bytes(&fuzz_stuffer, buf, len));
+    POSIX_GUARD(s2n_stuffer_alloc(&fuzz_stuffer, len));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&fuzz_stuffer, buf, len));
 
     struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
-    notnull_check(client_conn);
+    POSIX_ENSURE_REF(client_conn);
     client_conn->config = s2n_config_new();
 
     /* Pull a byte off the libfuzzer input and use it to set parameters */
     uint8_t randval = 0;
-    GUARD(s2n_stuffer_read_uint8(&fuzz_stuffer, &randval));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&fuzz_stuffer, &randval));
     client_conn->client_protocol_version = TLS_VERSIONS[randval % s2n_array_len(TLS_VERSIONS)];
 
     /* Run Test
@@ -65,9 +65,9 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     s2n_extensions_server_supported_versions_recv(client_conn, &fuzz_stuffer);
 
     /* Cleanup */
-    GUARD(s2n_config_free(client_conn->config));
-    GUARD(s2n_connection_free(client_conn));
-    GUARD(s2n_stuffer_free(&fuzz_stuffer));
+    POSIX_GUARD(s2n_config_free(client_conn->config));
+    POSIX_GUARD(s2n_connection_free(client_conn));
+    POSIX_GUARD(s2n_stuffer_free(&fuzz_stuffer));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_hybrid_ecdhe_bike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_bike_r1_fuzz_test.c
@@ -46,8 +46,8 @@ static int setup_connection(struct s2n_connection *server_conn)
     server_conn->actual_protocol_version = S2N_TLS12;
 
     const struct s2n_ecc_preferences *ecc_preferences = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
-    notnull_check(ecc_preferences);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
+    POSIX_ENSURE_REF(ecc_preferences);
 
     server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
@@ -55,8 +55,8 @@ static int setup_connection(struct s2n_connection *server_conn)
     server_conn->secure.cipher_suite = &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
-    GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
     return S2N_SUCCESS;
 }
@@ -64,9 +64,9 @@ static int setup_connection(struct s2n_connection *server_conn)
 int s2n_fuzz_init(int *argc, char **argv[])
 {
     struct s2n_blob *public_key = &server_kem_params.public_key;
-    GUARD(s2n_alloc(public_key, BIKE1_L1_R1_PUBLIC_KEY_BYTES));
-    GUARD_AS_POSIX(s2n_kem_generate_keypair(&server_kem_params));
-    GUARD(s2n_free(public_key));
+    POSIX_GUARD(s2n_alloc(public_key, BIKE1_L1_R1_PUBLIC_KEY_BYTES));
+    POSIX_GUARD_RESULT(s2n_kem_generate_keypair(&server_kem_params));
+    POSIX_GUARD(s2n_free(public_key));
 
     return S2N_SUCCESS;
 }
@@ -74,12 +74,12 @@ int s2n_fuzz_init(int *argc, char **argv[])
 int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     struct s2n_connection *server_conn;
-    notnull_check(server_conn = s2n_connection_new(S2N_SERVER));
-    GUARD(setup_connection(server_conn));
+    POSIX_ENSURE_REF(server_conn = s2n_connection_new(S2N_SERVER));
+    POSIX_GUARD(setup_connection(server_conn));
 
     /* You can't write 0 bytes to a stuffer but attempting to call s2n_client_key_recv with 0 data is an interesting test */
     if (len > 0) {
-        GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
     }
 
     /* The missing GUARD is because s2n_client_key_recv might fail due to bad input which is okay, the connection
@@ -88,7 +88,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
      * to be recv'd successfully. */
     s2n_client_key_recv(server_conn);
 
-    GUARD(s2n_connection_free(server_conn));
+    POSIX_GUARD(s2n_connection_free(server_conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_hybrid_ecdhe_bike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_bike_r2_fuzz_test.c
@@ -46,8 +46,8 @@ static int setup_connection(struct s2n_connection *server_conn)
     server_conn->actual_protocol_version = S2N_TLS12;
 
     const struct s2n_ecc_preferences *ecc_preferences = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
-    notnull_check(ecc_preferences);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
+    POSIX_ENSURE_REF(ecc_preferences);
 
     server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
@@ -55,8 +55,8 @@ static int setup_connection(struct s2n_connection *server_conn)
     server_conn->secure.cipher_suite = &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
-    GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
     return S2N_SUCCESS;
 }
@@ -64,9 +64,9 @@ static int setup_connection(struct s2n_connection *server_conn)
 int s2n_fuzz_init(int *argc, char **argv[])
 {
     struct s2n_blob *public_key = &server_kem_params.public_key;
-    GUARD(s2n_alloc(public_key, BIKE1_L1_R2_PUBLIC_KEY_BYTES));
-    GUARD_AS_POSIX(s2n_kem_generate_keypair(&server_kem_params));
-    GUARD(s2n_free(public_key));
+    POSIX_GUARD(s2n_alloc(public_key, BIKE1_L1_R2_PUBLIC_KEY_BYTES));
+    POSIX_GUARD_RESULT(s2n_kem_generate_keypair(&server_kem_params));
+    POSIX_GUARD(s2n_free(public_key));
 
     return S2N_SUCCESS;
 }
@@ -74,12 +74,12 @@ int s2n_fuzz_init(int *argc, char **argv[])
 int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     struct s2n_connection *server_conn;
-    notnull_check(server_conn = s2n_connection_new(S2N_SERVER));
-    GUARD(setup_connection(server_conn));
+    POSIX_ENSURE_REF(server_conn = s2n_connection_new(S2N_SERVER));
+    POSIX_GUARD(setup_connection(server_conn));
 
     /* You can't write 0 bytes to a stuffer but attempting to call s2n_client_key_recv with 0 data is an interesting test */
     if (len > 0) {
-        GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
     }
 
     /* The missing GUARD is because s2n_client_key_recv might fail due to bad input which is okay, the connection
@@ -88,7 +88,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
      * to be recv'd successfully. */
     s2n_client_key_recv(server_conn);
 
-    GUARD(s2n_connection_free(server_conn));
+    POSIX_GUARD(s2n_connection_free(server_conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_hybrid_ecdhe_kyber_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_kyber_r2_fuzz_test.c
@@ -46,8 +46,8 @@ static int setup_connection(struct s2n_connection *server_conn)
     server_conn->actual_protocol_version = S2N_TLS12;
 
     const struct s2n_ecc_preferences *ecc_preferences = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
-    notnull_check(ecc_preferences);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
+    POSIX_ENSURE_REF(ecc_preferences);
 
     server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
@@ -55,8 +55,8 @@ static int setup_connection(struct s2n_connection *server_conn)
     server_conn->secure.cipher_suite = &s2n_ecdhe_kyber_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
-    GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
     return S2N_SUCCESS;
 }
@@ -64,9 +64,9 @@ static int setup_connection(struct s2n_connection *server_conn)
 int s2n_fuzz_init(int *argc, char **argv[])
 {
     struct s2n_blob *public_key = &server_kem_params.public_key;
-    GUARD(s2n_alloc(public_key, KYBER_512_R2_PUBLIC_KEY_BYTES));
-    GUARD_AS_POSIX(s2n_kem_generate_keypair(&server_kem_params));
-    GUARD(s2n_free(public_key));
+    POSIX_GUARD(s2n_alloc(public_key, KYBER_512_R2_PUBLIC_KEY_BYTES));
+    POSIX_GUARD_RESULT(s2n_kem_generate_keypair(&server_kem_params));
+    POSIX_GUARD(s2n_free(public_key));
 
     return S2N_SUCCESS;
 }
@@ -74,12 +74,12 @@ int s2n_fuzz_init(int *argc, char **argv[])
 int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     struct s2n_connection *server_conn;
-    notnull_check(server_conn = s2n_connection_new(S2N_SERVER));
-    GUARD(setup_connection(server_conn));
+    POSIX_ENSURE_REF(server_conn = s2n_connection_new(S2N_SERVER));
+    POSIX_GUARD(setup_connection(server_conn));
 
     /* You can't write 0 bytes to a stuffer but attempting to call s2n_client_key_recv with 0 data is an interesting test */
     if (len > 0) {
-        GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
     }
 
     /* The missing GUARD is because s2n_client_key_recv might fail due to bad input which is okay, the connection
@@ -88,7 +88,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
      * to be recv'd successfully. */
     s2n_client_key_recv(server_conn);
 
-    GUARD(s2n_connection_free(server_conn));
+    POSIX_GUARD(s2n_connection_free(server_conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_hybrid_ecdhe_sike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_sike_r1_fuzz_test.c
@@ -46,8 +46,8 @@ static int setup_connection(struct s2n_connection *server_conn)
     server_conn->actual_protocol_version = S2N_TLS12;
 
     const struct s2n_ecc_preferences *ecc_preferences = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
-    notnull_check(ecc_preferences);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
+    POSIX_ENSURE_REF(ecc_preferences);
 
     server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
@@ -55,8 +55,8 @@ static int setup_connection(struct s2n_connection *server_conn)
     server_conn->secure.cipher_suite = &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
-    GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
     return S2N_SUCCESS;
 }
@@ -64,9 +64,9 @@ static int setup_connection(struct s2n_connection *server_conn)
 int s2n_fuzz_init(int *argc, char **argv[])
 {
     struct s2n_blob *public_key = &server_kem_params.public_key;
-    GUARD(s2n_alloc(public_key, SIKE_P503_R1_PUBLIC_KEY_BYTES));
-    GUARD_AS_POSIX(s2n_kem_generate_keypair(&server_kem_params));
-    GUARD(s2n_free(public_key));
+    POSIX_GUARD(s2n_alloc(public_key, SIKE_P503_R1_PUBLIC_KEY_BYTES));
+    POSIX_GUARD_RESULT(s2n_kem_generate_keypair(&server_kem_params));
+    POSIX_GUARD(s2n_free(public_key));
 
     return S2N_SUCCESS;
 }
@@ -74,12 +74,12 @@ int s2n_fuzz_init(int *argc, char **argv[])
 int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     struct s2n_connection *server_conn;
-    notnull_check(server_conn = s2n_connection_new(S2N_SERVER));
-    GUARD(setup_connection(server_conn));
+    POSIX_ENSURE_REF(server_conn = s2n_connection_new(S2N_SERVER));
+    POSIX_GUARD(setup_connection(server_conn));
 
     /* You can't write 0 bytes to a stuffer but attempting to call s2n_client_key_recv with 0 data is an interesting test */
     if (len > 0) {
-        GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
     }
 
     /* The missing GUARD is because s2n_client_key_recv might fail due to bad input which is okay, the connection
@@ -88,7 +88,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
      * to be recv'd successfully. */
     s2n_client_key_recv(server_conn);
 
-    GUARD(s2n_connection_free(server_conn));
+    POSIX_GUARD(s2n_connection_free(server_conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_hybrid_ecdhe_sike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_sike_r2_fuzz_test.c
@@ -46,8 +46,8 @@ static int setup_connection(struct s2n_connection *server_conn)
     server_conn->actual_protocol_version = S2N_TLS12;
 
     const struct s2n_ecc_preferences *ecc_preferences = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
-    notnull_check(ecc_preferences);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
+    POSIX_ENSURE_REF(ecc_preferences);
 
     server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
@@ -55,8 +55,8 @@ static int setup_connection(struct s2n_connection *server_conn)
     server_conn->secure.cipher_suite = &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
-    GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
 
     return S2N_SUCCESS;
 }
@@ -64,9 +64,9 @@ static int setup_connection(struct s2n_connection *server_conn)
 int s2n_fuzz_init(int *argc, char **argv[])
 {
     struct s2n_blob *public_key = &server_kem_params.public_key;
-    GUARD(s2n_alloc(public_key, SIKE_P434_R2_PUBLIC_KEY_BYTES));
-    GUARD_AS_POSIX(s2n_kem_generate_keypair(&server_kem_params));
-    GUARD(s2n_free(public_key));
+    POSIX_GUARD(s2n_alloc(public_key, SIKE_P434_R2_PUBLIC_KEY_BYTES));
+    POSIX_GUARD_RESULT(s2n_kem_generate_keypair(&server_kem_params));
+    POSIX_GUARD(s2n_free(public_key));
 
     return S2N_SUCCESS;
 }
@@ -74,12 +74,12 @@ int s2n_fuzz_init(int *argc, char **argv[])
 int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     struct s2n_connection *server_conn;
-    notnull_check(server_conn = s2n_connection_new(S2N_SERVER));
-    GUARD(setup_connection(server_conn));
+    POSIX_ENSURE_REF(server_conn = s2n_connection_new(S2N_SERVER));
+    POSIX_GUARD(setup_connection(server_conn));
 
     /* You can't write 0 bytes to a stuffer but attempting to call s2n_client_key_recv with 0 data is an interesting test */
     if (len > 0) {
-        GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
     }
 
     /* The missing GUARD is because s2n_client_key_recv might fail due to bad input which is okay, the connection
@@ -88,7 +88,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
      * to be recv'd successfully. */
     s2n_client_key_recv(server_conn);
 
-    GUARD(s2n_connection_free(server_conn));
+    POSIX_GUARD(s2n_connection_free(server_conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_kyber_r2_recv_ciphertext_fuzz_test.c
+++ b/tests/fuzz/s2n_kyber_r2_recv_ciphertext_fuzz_test.c
@@ -30,13 +30,13 @@ static struct s2n_kem_params kem_params = { .kem = &s2n_kyber_512_r2 };
 
 int s2n_fuzz_init(int *argc, char **argv[])
 {
-    GUARD(s2n_kem_recv_ciphertext_fuzz_test_init(KAT_FILE_NAME, &kem_params));
+    POSIX_GUARD(s2n_kem_recv_ciphertext_fuzz_test_init(KAT_FILE_NAME, &kem_params));
     return S2N_SUCCESS;
 }
 
 int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
-    GUARD(s2n_kem_recv_ciphertext_fuzz_test(buf, len, &kem_params));
+    POSIX_GUARD(s2n_kem_recv_ciphertext_fuzz_test(buf, len, &kem_params));
     return S2N_SUCCESS;
 }
 

--- a/tests/fuzz/s2n_kyber_r2_recv_public_key_fuzz_test.c
+++ b/tests/fuzz/s2n_kyber_r2_recv_public_key_fuzz_test.c
@@ -26,7 +26,7 @@
 static struct s2n_kem_params kem_params = { .kem = &s2n_kyber_512_r2 };
 
 int s2n_fuzz_test(const uint8_t *buf, size_t len) {
-    GUARD(s2n_kem_recv_public_key_fuzz_test(buf, len, &kem_params));
+    POSIX_GUARD(s2n_kem_recv_public_key_fuzz_test(buf, len, &kem_params));
     return S2N_SUCCESS;
 }
 

--- a/tests/fuzz/s2n_openssl_diff_pem_parsing_test.c
+++ b/tests/fuzz/s2n_openssl_diff_pem_parsing_test.c
@@ -69,7 +69,7 @@ static int s2n_parse_cert_chain(struct s2n_stuffer *in)
 
     /* Allocate the memory for the chain and key */
     if (s2n_create_cert_chain_from_stuffer(chain_and_key->cert_chain, in) != S2N_SUCCESS) {
-        GUARD(s2n_cert_chain_and_key_free(chain_and_key));
+        POSIX_GUARD(s2n_cert_chain_and_key_free(chain_and_key));
         return S2N_SUCCESS;
     }
 
@@ -88,15 +88,15 @@ static int s2n_parse_cert_chain(struct s2n_stuffer *in)
 int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     struct s2n_stuffer in = {0};
-    GUARD(s2n_stuffer_alloc(&in, len + 1));
-    GUARD(s2n_stuffer_write_bytes(&in, buf, len));
+    POSIX_GUARD(s2n_stuffer_alloc(&in, len + 1));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&in, buf, len));
     in.blob.data[len] = 0;
 
     uint8_t openssl_chain_len = openssl_parse_cert_chain(&in);
-    GUARD(s2n_stuffer_reread(&in));
+    POSIX_GUARD(s2n_stuffer_reread(&in));
 
     uint8_t s2n_chain_len = s2n_parse_cert_chain(&in);
-    GUARD(s2n_stuffer_free(&in));
+    POSIX_GUARD(s2n_stuffer_free(&in));
 
     if (openssl_chain_len > s2n_chain_len) {
         /* If we return -1 here, then this fuzz test will fail if OpenSSL is able to parse a messy PEM file that s2n

--- a/tests/fuzz/s2n_recv_client_supported_groups_test.c
+++ b/tests/fuzz/s2n_recv_client_supported_groups_test.c
@@ -36,7 +36,7 @@ static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
 
 int s2n_fuzz_init(int *argc, char **argv[])
 {
-    GUARD(s2n_enable_tls13());
+    POSIX_GUARD(s2n_enable_tls13());
     return S2N_SUCCESS;
 }
 
@@ -47,15 +47,15 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Setup */
     struct s2n_stuffer fuzz_stuffer = {0};
-    GUARD(s2n_stuffer_alloc(&fuzz_stuffer, len + 1));
-    GUARD(s2n_stuffer_write_bytes(&fuzz_stuffer, buf, len));
+    POSIX_GUARD(s2n_stuffer_alloc(&fuzz_stuffer, len + 1));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&fuzz_stuffer, buf, len));
 
     struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
-    notnull_check(server_conn);
+    POSIX_ENSURE_REF(server_conn);
 
     /* Pull a byte off the libfuzzer input and use it to set parameters */
     uint8_t randval = 0;
-    GUARD(s2n_stuffer_read_uint8(&fuzz_stuffer, &randval));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&fuzz_stuffer, &randval));
     server_conn->actual_protocol_version = TLS_VERSIONS[(randval & 0x0F) % s2n_array_len(TLS_VERSIONS)];
     server_conn->server_protocol_version = TLS_VERSIONS[(randval >> 4) % s2n_array_len(TLS_VERSIONS)];
 
@@ -65,8 +65,8 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     s2n_recv_client_supported_groups(server_conn, &fuzz_stuffer);
 
     /* Cleanup */
-    GUARD(s2n_connection_free(server_conn));
-    GUARD(s2n_stuffer_free(&fuzz_stuffer));
+    POSIX_GUARD(s2n_connection_free(server_conn));
+    POSIX_GUARD(s2n_stuffer_free(&fuzz_stuffer));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_server_ccs_recv_test.c
+++ b/tests/fuzz/s2n_server_ccs_recv_test.c
@@ -41,12 +41,12 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Setup */
     struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
-    notnull_check(client_conn);
-    GUARD(s2n_stuffer_write_bytes(&client_conn->handshake.io, buf, len));
+    POSIX_ENSURE_REF(client_conn);
+    POSIX_GUARD(s2n_stuffer_write_bytes(&client_conn->handshake.io, buf, len));
 
     /* Pull a byte off the libfuzzer input and use it to set parameters */
     uint8_t randval = 0;
-    GUARD(s2n_stuffer_read_uint8(&client_conn->handshake.io, &randval));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&client_conn->handshake.io, &randval));
     client_conn->actual_protocol_version = TLS_VERSIONS[(randval & 0x03) % s2n_array_len(TLS_VERSIONS)];
     client_conn->secure.cipher_suite = cipher_prefs->suites[(randval >> 2) % cipher_prefs->count];
 
@@ -56,7 +56,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     s2n_server_ccs_recv(client_conn);
 
     /* Cleanup */
-    GUARD(s2n_connection_free(client_conn));
+    POSIX_GUARD(s2n_connection_free(client_conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_server_extensions_recv_test.c
+++ b/tests/fuzz/s2n_server_extensions_recv_test.c
@@ -39,7 +39,7 @@ static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
 
 int s2n_fuzz_init(int *argc, char **argv[])
 {
-    GUARD(s2n_enable_tls13());
+    POSIX_GUARD(s2n_enable_tls13());
     return S2N_SUCCESS;
 }
 
@@ -50,15 +50,15 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Setup */
     struct s2n_stuffer fuzz_stuffer = {0};
-    GUARD(s2n_stuffer_alloc(&fuzz_stuffer, len + 1));
-    GUARD(s2n_stuffer_write_bytes(&fuzz_stuffer, buf, len));
+    POSIX_GUARD(s2n_stuffer_alloc(&fuzz_stuffer, len + 1));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&fuzz_stuffer, buf, len));
 
     struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
-    notnull_check(client_conn);
+    POSIX_ENSURE_REF(client_conn);
 
     /* Pull a byte off the libfuzzer input and use it to set parameters */
     uint8_t randval = 0;
-    GUARD(s2n_stuffer_read_uint8(&fuzz_stuffer, &randval));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&fuzz_stuffer, &randval));
     client_conn->actual_protocol_version = TLS_VERSIONS[(randval & 0x0F) % s2n_array_len(TLS_VERSIONS)];
     client_conn->client_protocol_version = TLS_VERSIONS[(randval >> 4) % s2n_array_len(TLS_VERSIONS)];
 
@@ -68,8 +68,8 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     s2n_server_extensions_recv(client_conn, &fuzz_stuffer);
 
     /* Cleanup */
-    GUARD(s2n_connection_free(client_conn));
-    GUARD(s2n_stuffer_free(&fuzz_stuffer));
+    POSIX_GUARD(s2n_connection_free(client_conn));
+    POSIX_GUARD(s2n_stuffer_free(&fuzz_stuffer));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_server_finished_recv_test.c
+++ b/tests/fuzz/s2n_server_finished_recv_test.c
@@ -36,12 +36,12 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Setup */
     struct s2n_connection *client_conn = s2n_connection_new(S2N_SERVER);
-    notnull_check(client_conn);
-    GUARD(s2n_stuffer_write_bytes(&client_conn->handshake.io, buf, len));
+    POSIX_ENSURE_REF(client_conn);
+    POSIX_GUARD(s2n_stuffer_write_bytes(&client_conn->handshake.io, buf, len));
 
     /* Pull a byte off the libfuzzer input and use it to set parameters */
     uint8_t randval = 0;
-    GUARD(s2n_stuffer_read_uint8(&client_conn->handshake.io, &randval));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&client_conn->handshake.io, &randval));
     client_conn->actual_protocol_version = TLS_VERSIONS[randval % s2n_array_len(TLS_VERSIONS)];
 
     uint8_t finished_len = S2N_TLS_FINISHED_LEN;
@@ -59,7 +59,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     s2n_server_finished_recv(client_conn);
 
     /* Cleanup */
-    GUARD(s2n_connection_free(client_conn));
+    POSIX_GUARD(s2n_connection_free(client_conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_server_fuzz_test.c
+++ b/tests/fuzz/s2n_server_fuzz_test.c
@@ -175,9 +175,9 @@ static struct s2n_config *server_config;
 int s2n_fuzz_init(int *argc, char **argv[])
 {
     /* Set up Server Config */
-    notnull_check(server_config = s2n_config_new());
-    GUARD(s2n_config_add_cert_chain_and_key(server_config, certificate_chain, private_key));
-    GUARD(s2n_config_add_dhparams(server_config, dhparams));
+    POSIX_ENSURE_REF(server_config = s2n_config_new());
+    POSIX_GUARD(s2n_config_add_cert_chain_and_key(server_config, certificate_chain, private_key));
+    POSIX_GUARD(s2n_config_add_dhparams(server_config, dhparams));
 
     return S2N_SUCCESS;
 }
@@ -187,17 +187,17 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     S2N_FUZZ_ENSURE_MIN_LEN(len, S2N_TLS_RECORD_HEADER_LENGTH);
 
     struct s2n_stuffer in = {0};
-    GUARD(s2n_stuffer_alloc(&in, len));
-    GUARD(s2n_stuffer_write_bytes(&in, buf, len));
+    POSIX_GUARD(s2n_stuffer_alloc(&in, len));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&in, buf, len));
 
     /* Set up Server Connection */
     struct s2n_connection *server_conn;
-    notnull_check(server_conn = s2n_connection_new(S2N_SERVER));
-    GUARD(s2n_connection_set_recv_cb(server_conn, &buffer_read));
-    GUARD(s2n_connection_set_send_cb(server_conn, &buffer_write));
-    GUARD(s2n_connection_set_recv_ctx(server_conn, &in));
-    GUARD(s2n_connection_set_config(server_conn, server_config));
-    GUARD(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
+    POSIX_ENSURE_REF(server_conn = s2n_connection_new(S2N_SERVER));
+    POSIX_GUARD(s2n_connection_set_recv_cb(server_conn, &buffer_read));
+    POSIX_GUARD(s2n_connection_set_send_cb(server_conn, &buffer_write));
+    POSIX_GUARD(s2n_connection_set_recv_ctx(server_conn, &in));
+    POSIX_GUARD(s2n_connection_set_config(server_conn, server_config));
+    POSIX_GUARD(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
     server_conn->delay = 0;
 
     /* Let Server receive data and attempt Negotiation */
@@ -210,8 +210,8 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Clean up */
 
-    GUARD(s2n_connection_free(server_conn));
-    GUARD(s2n_stuffer_free(&in));
+    POSIX_GUARD(s2n_connection_free(server_conn));
+    POSIX_GUARD(s2n_stuffer_free(&in));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_server_hello_recv_test.c
+++ b/tests/fuzz/s2n_server_hello_recv_test.c
@@ -39,13 +39,13 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     /* Setup */
     client_config = s2n_config_new();
     struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
-    GUARD(s2n_connection_set_config(client_conn, client_config));
-    notnull_check(client_conn);
-    GUARD(s2n_stuffer_write_bytes(&client_conn->handshake.io, buf, len));
+    POSIX_GUARD(s2n_connection_set_config(client_conn, client_config));
+    POSIX_ENSURE_REF(client_conn);
+    POSIX_GUARD(s2n_stuffer_write_bytes(&client_conn->handshake.io, buf, len));
 
     /* Pull a byte off the libfuzzer input and use it to set parameters */
     uint8_t randval = 0;
-    GUARD(s2n_stuffer_read_uint8(&client_conn->handshake.io, &randval));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&client_conn->handshake.io, &randval));
     client_conn->client_protocol_version = TLS_VERSIONS[(randval & 0x0f) % s2n_array_len(TLS_VERSIONS)];
     client_conn->server_protocol_version = TLS_VERSIONS[(randval >> 4) % s2n_array_len(TLS_VERSIONS)];
     /* Run Test
@@ -54,8 +54,8 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     s2n_server_hello_recv(client_conn);
 
     /* Cleanup */
-    GUARD(s2n_config_free(client_config));
-    GUARD(s2n_connection_free(client_conn));
+    POSIX_GUARD(s2n_config_free(client_config));
+    POSIX_GUARD(s2n_connection_free(client_conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_sike_r1_recv_ciphertext_fuzz_test.c
+++ b/tests/fuzz/s2n_sike_r1_recv_ciphertext_fuzz_test.c
@@ -30,13 +30,13 @@ static struct s2n_kem_params kem_params = { .kem = &s2n_sike_p503_r1 };
 
 int s2n_fuzz_init(int *argc, char **argv[])
 {
-    GUARD(s2n_kem_recv_ciphertext_fuzz_test_init(KAT_FILE_NAME, &kem_params));
+    POSIX_GUARD(s2n_kem_recv_ciphertext_fuzz_test_init(KAT_FILE_NAME, &kem_params));
     return S2N_SUCCESS;
 }
 
 int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
-    GUARD(s2n_kem_recv_ciphertext_fuzz_test(buf, len, &kem_params));
+    POSIX_GUARD(s2n_kem_recv_ciphertext_fuzz_test(buf, len, &kem_params));
     return S2N_SUCCESS;
 }
 

--- a/tests/fuzz/s2n_sike_r1_recv_public_key_fuzz_test.c
+++ b/tests/fuzz/s2n_sike_r1_recv_public_key_fuzz_test.c
@@ -26,7 +26,7 @@
 static struct s2n_kem_params kem_params = { .kem = &s2n_sike_p503_r1 };
 
 int s2n_fuzz_test(const uint8_t *buf, size_t len) {
-    GUARD(s2n_kem_recv_public_key_fuzz_test(buf, len, &kem_params));
+    POSIX_GUARD(s2n_kem_recv_public_key_fuzz_test(buf, len, &kem_params));
     return S2N_SUCCESS;
 }
 

--- a/tests/fuzz/s2n_sike_r2_recv_ciphertext_fuzz_test.c
+++ b/tests/fuzz/s2n_sike_r2_recv_ciphertext_fuzz_test.c
@@ -31,20 +31,20 @@ static struct s2n_kem_params kem_params = { .kem = &s2n_sike_p434_r2 };
 
 int s2n_fuzz_init(int *argc, char **argv[])
 {
-    GUARD(s2n_kem_recv_ciphertext_fuzz_test_init(KAT_FILE_NAME, &kem_params));
+    POSIX_GUARD(s2n_kem_recv_ciphertext_fuzz_test_init(KAT_FILE_NAME, &kem_params));
     return S2N_SUCCESS;
 }
 
 int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     /* Test the portable C code */
-    GUARD_AS_POSIX(s2n_disable_sikep434r2_asm());
-    GUARD(s2n_kem_recv_ciphertext_fuzz_test(buf, len, &kem_params));
+    POSIX_GUARD_RESULT(s2n_disable_sikep434r2_asm());
+    POSIX_GUARD(s2n_kem_recv_ciphertext_fuzz_test(buf, len, &kem_params));
 
     /* Test the assembly, if available; if not, don't bother testing the C again */
-    GUARD_AS_POSIX(s2n_try_enable_sikep434r2_asm());
+    POSIX_GUARD_RESULT(s2n_try_enable_sikep434r2_asm());
     if (s2n_sikep434r2_asm_is_enabled()) {
-        GUARD(s2n_kem_recv_ciphertext_fuzz_test(buf, len, &kem_params));
+        POSIX_GUARD(s2n_kem_recv_ciphertext_fuzz_test(buf, len, &kem_params));
     }
 
     return S2N_SUCCESS;

--- a/tests/fuzz/s2n_sike_r2_recv_public_key_fuzz_test.c
+++ b/tests/fuzz/s2n_sike_r2_recv_public_key_fuzz_test.c
@@ -28,13 +28,13 @@ static struct s2n_kem_params kem_params = { .kem = &s2n_sike_p434_r2 };
 
 int s2n_fuzz_test(const uint8_t *buf, size_t len) {
     /* Test the portable C code */
-    GUARD_AS_POSIX(s2n_disable_sikep434r2_asm());
-    GUARD(s2n_kem_recv_public_key_fuzz_test(buf, len, &kem_params));
+    POSIX_GUARD_RESULT(s2n_disable_sikep434r2_asm());
+    POSIX_GUARD(s2n_kem_recv_public_key_fuzz_test(buf, len, &kem_params));
 
     /* Test the assembly, if available; if not, don't bother testing the C again */
-    GUARD_AS_POSIX(s2n_try_enable_sikep434r2_asm());
+    POSIX_GUARD_RESULT(s2n_try_enable_sikep434r2_asm());
     if (s2n_sikep434r2_asm_is_enabled()) {
-        GUARD(s2n_kem_recv_public_key_fuzz_test(buf, len, &kem_params));
+        POSIX_GUARD(s2n_kem_recv_public_key_fuzz_test(buf, len, &kem_params));
     }
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_stuffer_pem_fuzz_test.c
+++ b/tests/fuzz/s2n_stuffer_pem_fuzz_test.c
@@ -33,20 +33,20 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     struct s2n_stuffer in = {0};
     struct s2n_stuffer out = {0};
 
-    GUARD(s2n_stuffer_alloc(&in, len + 1));
-    GUARD(s2n_stuffer_alloc(&out, len));
-    GUARD(s2n_stuffer_write_bytes(&in, buf, len));
+    POSIX_GUARD(s2n_stuffer_alloc(&in, len + 1));
+    POSIX_GUARD(s2n_stuffer_alloc(&out, len));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&in, buf, len));
 
     s2n_stuffer_certificate_from_pem(&in, &out);
 
     /* Reset in and out buffers */
-    GUARD(s2n_stuffer_reread(&in));
-    GUARD(s2n_stuffer_wipe(&out));
+    POSIX_GUARD(s2n_stuffer_reread(&in));
+    POSIX_GUARD(s2n_stuffer_wipe(&out));
 
     s2n_stuffer_dhparams_from_pem(&in, &out);
 
-    GUARD(s2n_stuffer_free(&in));
-    GUARD(s2n_stuffer_free(&out));
+    POSIX_GUARD(s2n_stuffer_free(&in));
+    POSIX_GUARD(s2n_stuffer_free(&out));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_tls13_cert_req_recv_test.c
+++ b/tests/fuzz/s2n_tls13_cert_req_recv_test.c
@@ -37,17 +37,17 @@ int s2n_fuzz_init(int *argc, char **argv[])
 {
     /* Initialize test chain and key */
     cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE);
-    notnull_check(cert_chain);
+    POSIX_ENSURE_REF(cert_chain);
     private_key = malloc(S2N_MAX_TEST_PEM_SIZE);
-    notnull_check(private_key);
+    POSIX_ENSURE_REF(private_key);
     default_cert = s2n_cert_chain_and_key_new();
-    notnull_check(default_cert);
+    POSIX_ENSURE_REF(default_cert);
     client_config = s2n_config_new();
-    notnull_check(client_config);
-    GUARD(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
-    GUARD(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
-    GUARD(s2n_cert_chain_and_key_load_pem(default_cert, cert_chain, private_key));
-    GUARD(s2n_config_add_cert_chain_and_key_to_store(client_config, default_cert));
+    POSIX_ENSURE_REF(client_config);
+    POSIX_GUARD(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
+    POSIX_GUARD(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
+    POSIX_GUARD(s2n_cert_chain_and_key_load_pem(default_cert, cert_chain, private_key));
+    POSIX_GUARD(s2n_config_add_cert_chain_and_key_to_store(client_config, default_cert));
     return S2N_SUCCESS;
 }
 
@@ -55,9 +55,9 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     /* Setup */
     struct s2n_connection *client_conn = s2n_connection_new(S2N_SERVER);
-    notnull_check(client_conn);
-    GUARD(s2n_connection_set_config(client_conn, client_config));
-    GUARD(s2n_stuffer_write_bytes(&client_conn->handshake.io, buf, len));
+    POSIX_ENSURE_REF(client_conn);
+    POSIX_GUARD(s2n_connection_set_config(client_conn, client_config));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&client_conn->handshake.io, buf, len));
 
     /* Run Test
      * Do not use GUARD macro here since the connection memory hasn't been freed.
@@ -65,7 +65,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     s2n_tls13_cert_req_recv(client_conn);
 
     /* Cleanup */
-    GUARD(s2n_connection_free(client_conn));
+    POSIX_GUARD(s2n_connection_free(client_conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_tls13_cert_verify_recv_test.c
+++ b/tests/fuzz/s2n_tls13_cert_verify_recv_test.c
@@ -37,17 +37,17 @@ int s2n_fuzz_init(int *argc, char **argv[])
 {
     /* Initialize test chain and key */
     cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE);
-    notnull_check(cert_chain);
+    POSIX_ENSURE_REF(cert_chain);
     private_key = malloc(S2N_MAX_TEST_PEM_SIZE);
-    notnull_check(private_key);
+    POSIX_ENSURE_REF(private_key);
     default_cert = s2n_cert_chain_and_key_new();
-    notnull_check(default_cert);
+    POSIX_ENSURE_REF(default_cert);
     conn_config = s2n_config_new();
-    notnull_check(conn_config);
-    GUARD(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
-    GUARD(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
-    GUARD(s2n_cert_chain_and_key_load_pem(default_cert, cert_chain, private_key));
-    GUARD(s2n_config_add_cert_chain_and_key_to_store(conn_config, default_cert));
+    POSIX_ENSURE_REF(conn_config);
+    POSIX_GUARD(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
+    POSIX_GUARD(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
+    POSIX_GUARD(s2n_cert_chain_and_key_load_pem(default_cert, cert_chain, private_key));
+    POSIX_GUARD(s2n_config_add_cert_chain_and_key_to_store(conn_config, default_cert));
 
     return S2N_SUCCESS;
 }
@@ -59,13 +59,13 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Setup */
     struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
-    notnull_check(conn);
-    GUARD(s2n_connection_set_config(conn, conn_config));
-    GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, buf, len));
+    POSIX_ENSURE_REF(conn);
+    POSIX_GUARD(s2n_connection_set_config(conn, conn_config));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, buf, len));
 
     /* Pull a byte off the libfuzzer input and use it to set the connection mode */
     uint8_t randval = 0;
-    GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, &randval));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, &randval));
     if (randval % 2) {
         conn->mode = S2N_CLIENT;
     }
@@ -76,7 +76,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     s2n_tls13_cert_verify_recv(conn);
 
     /* Cleanup */
-    GUARD(s2n_connection_free(conn));
+    POSIX_GUARD(s2n_connection_free(conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_tls13_client_finished_recv_test.c
+++ b/tests/fuzz/s2n_tls13_client_finished_recv_test.c
@@ -46,16 +46,16 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Setup */
     struct s2n_connection *server_conn = s2n_connection_new(S2N_CLIENT);
-    notnull_check(server_conn);
-    GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
+    POSIX_ENSURE_REF(server_conn);
+    POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
 
     /* Pull a byte off the libfuzzer input and use it to set parameters */
     uint8_t randval = 0;
     s2n_hash_algorithm num_hash_bytes = 0;
-    GUARD(s2n_stuffer_read_uint8(&server_conn->handshake.io, &randval));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&server_conn->handshake.io, &randval));
     server_conn->actual_protocol_version = TLS_VERSIONS[(randval & 0x03) % s2n_array_len(TLS_VERSIONS)];
     server_conn->secure.cipher_suite = cipher_prefs->suites[(randval >> 2) % cipher_prefs->count];
-    GUARD(s2n_hmac_hash_alg(server_conn->secure.cipher_suite->prf_alg, &num_hash_bytes));
+    POSIX_GUARD(s2n_hmac_hash_alg(server_conn->secure.cipher_suite->prf_alg, &num_hash_bytes));
 
     /* We do not use a GUARD macro here as there may not be enough bytes to write the necessary
      * amount, and the result of a failed read_bytes call is an acceptable test input. */
@@ -67,7 +67,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     s2n_tls13_client_finished_recv(server_conn);
 
     /* Cleanup */
-    GUARD(s2n_connection_free(server_conn));
+    POSIX_GUARD(s2n_connection_free(server_conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_tls13_server_finished_recv_test.c
+++ b/tests/fuzz/s2n_tls13_server_finished_recv_test.c
@@ -46,16 +46,16 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Setup */
     struct s2n_connection *client_conn = s2n_connection_new(S2N_SERVER);
-    notnull_check(client_conn);
-    GUARD(s2n_stuffer_write_bytes(&client_conn->handshake.io, buf, len));
+    POSIX_ENSURE_REF(client_conn);
+    POSIX_GUARD(s2n_stuffer_write_bytes(&client_conn->handshake.io, buf, len));
 
     /* Pull a byte off the libfuzzer input and use it to set parameters */
     uint8_t randval = 0;
     s2n_hash_algorithm num_hash_bytes = 0;
-    GUARD(s2n_stuffer_read_uint8(&client_conn->handshake.io, &randval));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&client_conn->handshake.io, &randval));
     client_conn->actual_protocol_version = TLS_VERSIONS[(randval & 0x03) % s2n_array_len(TLS_VERSIONS)];
     client_conn->secure.cipher_suite = cipher_prefs->suites[(randval >> 2) % cipher_prefs->count];
-    GUARD(s2n_hmac_hash_alg(client_conn->secure.cipher_suite->prf_alg, &num_hash_bytes));
+    POSIX_GUARD(s2n_hmac_hash_alg(client_conn->secure.cipher_suite->prf_alg, &num_hash_bytes));
 
     /* We do not use a GUARD macro here as there may not be enough bytes to write the necessary
      * amount, and the result of a failed read_bytes call is an acceptable test input. */
@@ -67,7 +67,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     s2n_tls13_server_finished_recv(client_conn);
 
     /* Cleanup */
-    GUARD(s2n_connection_free(client_conn));
+    POSIX_GUARD(s2n_connection_free(client_conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/saw/bike_r1/patch/sampling.c.patch
+++ b/tests/saw/bike_r1/patch/sampling.c.patch
@@ -8,7 +8,7 @@
 21a27
 >     __breakpoint__get_rand_mod_len_loop(&rand_pos, &len, &prf_state, &mask, &res);
 23c29
-<     GUARD(aes_ctr_prf((uint8_t *)rand_pos, prf_state, sizeof(*rand_pos)));
+<     POSIX_GUARD(aes_ctr_prf((uint8_t *)rand_pos, prf_state, sizeof(*rand_pos)));
 ---
 >     OLD_GUARD(aes_ctr_prf((uint8_t *)rand_pos, prf_state, sizeof(*rand_pos)), res, EXIT);
 36c42,43
@@ -22,7 +22,7 @@
 102a112
 >   ret_t res = SUCCESS;
 107c117,118
-<     GUARD(get_rand_mod_len(&wlist[ctr], len, prf_state));
+<     POSIX_GUARD(get_rand_mod_len(&wlist[ctr], len, prf_state));
 ---
 >     __breakpoint__generate_sparse_rep_loop(&a, &wlist, &weight, &len, &padded_len, &prf_state, &res, &ctr);
 >     OLD_GUARD(get_rand_mod_len(&wlist[ctr], len, prf_state), res, EXIT);

--- a/tests/saw/bike_r2/patch/aes_ctr_prf.c.patch
+++ b/tests/saw/bike_r2/patch/aes_ctr_prf.c.patch
@@ -3,10 +3,10 @@
 ---
 > perform_aes(IN OUT aes_ctr_prf_state_t *s, OUT uint8_t *ct)
 94c94
-<     GUARD(perform_aes(&a[idx], s));
+<     POSIX_GUARD(perform_aes(&a[idx], s));
 ---
->     GUARD(perform_aes(s, &a[idx]));
+>     POSIX_GUARD(perform_aes(s, &a[idx]));
 98c98
-<   GUARD(perform_aes(s->buffer.u.bytes, s));
+<   POSIX_GUARD(perform_aes(s->buffer.u.bytes, s));
 ---
->   GUARD(perform_aes(s, s->buffer.u.bytes));
+>   POSIX_GUARD(perform_aes(s, s->buffer.u.bytes));

--- a/tests/saw/bike_r2/patch/sampling.c.patch
+++ b/tests/saw/bike_r2/patch/sampling.c.patch
@@ -8,7 +8,7 @@
 21a27
 >     __breakpoint__get_rand_mod_len_loop(&rand_pos, &len, &prf_state, &mask, &res);
 23c29
-<     GUARD(aes_ctr_prf((uint8_t *)rand_pos, prf_state, sizeof(*rand_pos)));
+<     POSIX_GUARD(aes_ctr_prf((uint8_t *)rand_pos, prf_state, sizeof(*rand_pos)));
 ---
 >     OLD_GUARD(aes_ctr_prf((uint8_t *)rand_pos, prf_state, sizeof(*rand_pos)), res, EXIT);
 36c42,43
@@ -22,7 +22,7 @@
 102a112
 >   ret_t res = SUCCESS;
 107c117,118
-<     GUARD(get_rand_mod_len(&wlist[ctr], len, prf_state));
+<     POSIX_GUARD(get_rand_mod_len(&wlist[ctr], len, prf_state));
 ---
 >     __breakpoint__generate_sparse_rep_loop(&a, &wlist, &weight, &len, &padded_len, &prf_state, &res, &ctr);
 >     OLD_GUARD(get_rand_mod_len(&wlist[ctr], len, prf_state), res, EXIT);

--- a/tests/saw/failure_tests/cork_one.patch
+++ b/tests/saw/failure_tests/cork_one.patch
@@ -5,8 +5,8 @@ index fd9eb0d..51f4c53 100644
 @@ -242,6 +242,7 @@ static int s2n_advance_message(struct s2n_connection *conn)
          if (s2n_connection_is_managed_corked(conn)) {
              /* Set TCP_CORK/NOPUSH */
-             GUARD(s2n_socket_write_cork(conn));
-+            GUARD(s2n_socket_write_cork(conn));
+             POSIX_GUARD(s2n_socket_write_cork(conn));
++            POSIX_GUARD(s2n_socket_write_cork(conn));
          }
  
          return 0;

--- a/tests/saw/failure_tests/cork_two.patch
+++ b/tests/saw/failure_tests/cork_two.patch
@@ -5,8 +5,8 @@ index fd9eb0d..11734ac 100644
 @@ -242,6 +242,7 @@ static int s2n_advance_message(struct s2n_connection *conn)
          if (s2n_connection_is_managed_corked(conn)) {
              /* Set TCP_CORK/NOPUSH */
-             GUARD(s2n_socket_write_cork(conn));
-+            GUARD(s2n_socket_write_uncork(conn));
+             POSIX_GUARD(s2n_socket_write_cork(conn));
++            POSIX_GUARD(s2n_socket_write_uncork(conn));
          }
  
          return 0;

--- a/tests/saw/failure_tests/sha_bad_magic_mod.patch
+++ b/tests/saw/failure_tests/sha_bad_magic_mod.patch
@@ -7,7 +7,7 @@ diff -r -u s2n/crypto/s2n_hmac.c s2n_break/crypto/s2n_hmac.c
       */
 -    const uint32_t HIGHEST_32_BIT = 4294949760;
 +    const uint32_t HIGHEST_32_BIT = 4294949761;
-     ENSURE_POSIX(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
+     POSIX_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
      uint32_t value = (HIGHEST_32_BIT + size) % state->hash_block_size;
 Binary files s2n/.git/index and s2n_break/.git/index differ
 Only in s2n/tests/saw: bad_magic_mod.patch

--- a/tests/sidetrail/working/patches/cbc.patch
+++ b/tests/sidetrail/working/patches/cbc.patch
@@ -36,13 +36,13 @@ index b37efb0..077d214 100644
      }
      
 -    uint8_t mac_digest_size;
--    GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));
+-    POSIX_GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));
 +    uint8_t mac_digest_size = DIGEST_SIZE;;
 +    //GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));
  
      /* The record has to be at least big enough to contain the MAC,
       * plus the padding length byte */
-     gt_check(decrypted->size, mac_digest_size);
+     POSIX_ENSURE_GT(decrypted->size, mac_digest_size);
  
      int payload_and_padding_size = decrypted->size - mac_digest_size;
 +    __VERIFIER_assert(payload_and_padding_size <= MAX_SIZE - 20);
@@ -55,7 +55,7 @@ index b37efb0..077d214 100644
      int payload_length = MAX(payload_and_padding_size - padding_length - 1, 0);
  
 @@ -82,20 +107,21 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
-     GUARD(s2n_hmac_update(copy, decrypted->data + payload_length + mac_digest_size, decrypted->size - payload_length - mac_digest_size - 1));
+     POSIX_GUARD(s2n_hmac_update(copy, decrypted->data + payload_length + mac_digest_size, decrypted->size - payload_length - mac_digest_size - 1));
  
      /* SSLv3 doesn't specify what the padding should actually be */
 -    if (conn->actual_protocol_version == S2N_SSLv3) {
@@ -79,8 +79,8 @@ index b37efb0..077d214 100644
 +    /*     mismatches |= (decrypted->data[j] ^ padding_length) & mask; */
 +    /* } */
  
--    GUARD(s2n_hmac_reset(copy));
-+    /* GUARD(s2n_hmac_reset(copy)); */
+-    POSIX_GUARD(s2n_hmac_reset(copy));
++    /* POSIX_GUARD(s2n_hmac_reset(copy)); */
  
      if (mismatches) {
-         S2N_ERROR(S2N_ERR_CBC_VERIFY);
+         POSIX_BAIL(S2N_ERR_CBC_VERIFY);

--- a/tests/sidetrail/working/patches/hmac.patch
+++ b/tests/sidetrail/working/patches/hmac.patch
@@ -15,22 +15,22 @@ index 3405781..3beeacf 100644
 @@ -268,7 +271,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
       */
      const uint32_t HIGHEST_32_BIT = 4294949760;
-     ENSURE_POSIX(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
+     POSIX_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
 -    uint32_t value = (HIGHEST_32_BIT + size) % state->hash_block_size;
 +    uint32_t value = (size) % state->hash_block_size;
-     GUARD(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
+     POSIX_GUARD(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
      state->currently_in_hash_block %= state->hash_block_size;
 
 @@ -361,8 +364,8 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
-     GUARD(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
+     POSIX_GUARD(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
 
 
--    memcpy_check(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
--    memcpy_check(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
+-    POSIX_CHECKED_MEMCPY(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
+-    POSIX_CHECKED_MEMCPY(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
 +    //memcpy_check(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
 +    //memcpy_check(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
-     POSTCONDITION_POSIX(s2n_hmac_state_validate(to));
-     POSTCONDITION_POSIX(s2n_hmac_state_validate(from));
+     POSIX_POSTCONDITION(s2n_hmac_state_validate(to));
+     POSIX_POSTCONDITION(s2n_hmac_state_validate(from));
      return S2N_SUCCESS;
 @@ -372,25 +375,25 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
  /* Preserve the handlers for hmac state pointers to avoid re-allocation
@@ -38,8 +38,8 @@ index 3405781..3beeacf 100644
   */
 -int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
 -{
--    ENSURE_POSIX_REF(backup);
--    PRECONDITION_POSIX(s2n_hmac_state_validate(hmac));
+-    POSIX_ENSURE_REF(backup);
+-    POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
 -    backup->inner = hmac->inner.digest.high_level;
 -    backup->inner_just_key = hmac->inner_just_key.digest.high_level;
 -    backup->outer = hmac->outer.digest.high_level;
@@ -49,19 +49,19 @@ index 3405781..3beeacf 100644
 -
 -int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
 -{
--    ENSURE_POSIX_REF(backup);
--    PRECONDITION_POSIX(s2n_hmac_state_validate(hmac));
+-    POSIX_ENSURE_REF(backup);
+-    POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
 -    hmac->inner.digest.high_level = backup->inner;
 -    hmac->inner_just_key.digest.high_level = backup->inner_just_key;
 -    hmac->outer.digest.high_level = backup->outer;
 -    hmac->outer_just_key.digest.high_level = backup->outer_just_key;
--    POSTCONDITION_POSIX(s2n_hmac_state_validate(hmac));
+-    POSIX_POSTCONDITION(s2n_hmac_state_validate(hmac));
 -    return S2N_SUCCESS;
 -}
 +// int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
 +// {
-+//     ENSURE_POSIX_REF(backup);
-+//     PRECONDITION_POSIX(s2n_hmac_state_validate(hmac));
++//     POSIX_ENSURE_REF(backup);
++//     POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
 +//     backup->inner = hmac->inner.digest.high_level;
 +//     backup->inner_just_key = hmac->inner_just_key.digest.high_level;
 +//     backup->outer = hmac->outer.digest.high_level;
@@ -71,13 +71,13 @@ index 3405781..3beeacf 100644
 +//
 +// int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
 +// {
-+//     ENSURE_POSIX_REF(backup);
-+//     PRECONDITION_POSIX(s2n_hmac_state_validate(hmac));
++//     POSIX_ENSURE_REF(backup);
++//     POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
 +//     hmac->inner.digest.high_level = backup->inner;
 +//     hmac->inner_just_key.digest.high_level = backup->inner_just_key;
 +//     hmac->outer.digest.high_level = backup->outer;
 +//     hmac->outer_just_key.digest.high_level = backup->outer_just_key;
-+//     POSTCONDITION_POSIX(s2n_hmac_state_validate(hmac));
++//     POSIX_POSTCONDITION(s2n_hmac_state_validate(hmac));
 +//     return S2N_SUCCESS;
 +// }
 diff --git a/tests/sidetrail/working/s2n-cbc/crypto/s2n_hmac.h b/tests/sidetrail/working/s2n-cbc/crypto/s2n_hmac.h

--- a/tests/sidetrail/working/patches/safety.patch
+++ b/tests/sidetrail/working/patches/safety.patch
@@ -9,8 +9,8 @@ index ae8e5783..cc06a2d0 100644
 -    S2N_PUBLIC_INPUT(a);
 -    S2N_PUBLIC_INPUT(b);
 -    S2N_PUBLIC_INPUT(len);
-     ENSURE_POSIX((a == NULL) || S2N_MEM_IS_READABLE(a, len), S2N_ERR_SAFETY);
-     ENSURE_POSIX((b == NULL) || S2N_MEM_IS_READABLE(b, len), S2N_ERR_SAFETY);
+     POSIX_ENSURE((a == NULL) || S2N_MEM_IS_READABLE(a, len), S2N_ERR_SAFETY);
+     POSIX_ENSURE((b == NULL) || S2N_MEM_IS_READABLE(b, len), S2N_ERR_SAFETY);
 
 @@ -90,10 +87,6 @@ bool s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, const uint32
   */

--- a/tests/sidetrail/working/s2n-cbc/stubs/s2n_hash.c
+++ b/tests/sidetrail/working/s2n-cbc/stubs/s2n_hash.c
@@ -34,7 +34,7 @@ int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out)
     case S2N_HASH_SHA512:   *out = SHA512_DIGEST_LENGTH; break;
     case S2N_HASH_MD5_SHA1: *out = MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH; break;
     default:
-        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
     return 0;
 }

--- a/tests/sidetrail/working/s2n-record-read-cbc-negative-test/record_read_cbc.patch
+++ b/tests/sidetrail/working/s2n-record-read-cbc-negative-test/record_read_cbc.patch
@@ -14,17 +14,17 @@ index bb06523..60a2eed 100644
 @@ -86,6 +88,8 @@ int s2n_record_parse_cbc(
  
      /* Subtract the padding length */
-     gt_check(en.size, 0);
+     POSIX_ENSURE_GT(en.size, 0);
 +    //After hmac verification padding_length is declassified
 +    en.data[en.size - 1] = g_padding_length;
      uint32_t out = 0;
-     GUARD(s2n_sub_overflow(payload_length, en.data[en.size - 1] + 1, &out));
+     POSIX_GUARD(s2n_sub_overflow(payload_length, en.data[en.size - 1] + 1, &out));
      payload_length = out;
 @@ -107,6 +111,7 @@ int s2n_record_parse_cbc(
  
      /* Padding */
      if (s2n_verify_cbc(conn, mac, &en) < 0) {
 +        __VERIFIER_assume(0);
-         GUARD(s2n_stuffer_wipe(&conn->in));
-         S2N_ERROR(S2N_ERR_BAD_MESSAGE);
+         POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
+         POSIX_BAIL(S2N_ERR_BAD_MESSAGE);
      }

--- a/tests/sidetrail/working/s2n-record-read-cbc/record_read_cbc.patch
+++ b/tests/sidetrail/working/s2n-record-read-cbc/record_read_cbc.patch
@@ -14,17 +14,17 @@ index bb06523..60a2eed 100644
 @@ -86,6 +88,8 @@ int s2n_record_parse_cbc(
  
      /* Subtract the padding length */
-     gt_check(en.size, 0);
+     POSIX_ENSURE_GT(en.size, 0);
 +    //After hmac verification padding_length is declassified
 +    en.data[en.size - 1] = g_padding_length;
      uint32_t out = 0;
-     GUARD(s2n_sub_overflow(payload_length, en.data[en.size - 1] + 1, &out));
+     POSIX_GUARD(s2n_sub_overflow(payload_length, en.data[en.size - 1] + 1, &out));
      payload_length = out;
 @@ -107,6 +111,7 @@ int s2n_record_parse_cbc(
  
      /* Padding */
      if (s2n_verify_cbc(conn, mac, &en) < 0) {
 +        __VERIFIER_assume(0);
-         GUARD(s2n_stuffer_wipe(&conn->in));
-         S2N_ERROR(S2N_ERR_BAD_MESSAGE);
+         POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
+         POSIX_BAIL(S2N_ERR_BAD_MESSAGE);
      }

--- a/tests/sidetrail/working/s2n-record-read-composite/record_read.patch
+++ b/tests/sidetrail/working/s2n-record-read-composite/record_read.patch
@@ -14,9 +14,9 @@ index b57207a0..5109c47f 100644
 @@ -88,6 +90,8 @@ int s2n_record_parse_composite(
  
      /* Subtract the padding length */
-     gt_check(en.size, 0);
+     POSIX_ENSURE_GT(en.size, 0);
 +    //After hmac verification padding_length is declassified
 +    en.data[en.size - 1] = g_padding_length;
      uint32_t out = 0;
-     GUARD(s2n_sub_overflow(payload_length, en.data[en.size - 1] + 1, &out));
+     POSIX_GUARD(s2n_sub_overflow(payload_length, en.data[en.size - 1] + 1, &out));
      payload_length = out;

--- a/tests/sidetrail/working/stubs/s2n_hash.c
+++ b/tests/sidetrail/working/stubs/s2n_hash.c
@@ -34,7 +34,7 @@ int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out)
     case S2N_HASH_SHA512:   *out = SHA512_DIGEST_LENGTH; break;
     case S2N_HASH_MD5_SHA1: *out = MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH; break;
     default:
-        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
     }
     return 0;
 }

--- a/tests/sidetrail/working/stubs/s2n_mem.c
+++ b/tests/sidetrail/working/stubs/s2n_mem.c
@@ -28,7 +28,7 @@ static long page_size = 4096;
 
 int s2n_mem_init(void)
 {
-    GUARD(page_size = sysconf(_SC_PAGESIZE));
+    POSIX_GUARD(page_size = sysconf(_SC_PAGESIZE));
 
     return 0;
 }
@@ -44,7 +44,7 @@ int s2n_alloc(struct s2n_blob *b, uint32_t size)
     b->data = NULL;
     b->size = 0;
     b->allocated = 0;
-    GUARD(s2n_realloc(b, size));
+    POSIX_GUARD(s2n_realloc(b, size));
     return 0;
 }
 
@@ -65,7 +65,7 @@ int s2n_realloc(struct s2n_blob *b, uint32_t size)
 
     void *data = realloc(b->data, size);
     if (!data) {
-        S2N_ERROR(S2N_ERR_ALLOC);
+        POSIX_BAIL(S2N_ERR_ALLOC);
     }
 
     b->data = data;
@@ -86,12 +86,12 @@ int s2n_free(struct s2n_blob *b)
 
 int s2n_dup(struct s2n_blob *from, struct s2n_blob *to)
 {
-    eq_check(to->size, 0);
-    eq_check(to->data, NULL);
+    POSIX_ENSURE_EQ(to->size, 0);
+    POSIX_ENSURE_EQ(to->data, NULL);
 
-    GUARD(s2n_alloc(to, from->size));
+    POSIX_GUARD(s2n_alloc(to, from->size));
     
-    memcpy_check(to->data, from->data, to->size);
+    POSIX_CHECKED_MEMCPY(to->data, from->data, to->size);
 
     return 0;
 }

--- a/tests/testlib/s2n_connection_test_utils.c
+++ b/tests/testlib/s2n_connection_test_utils.c
@@ -88,12 +88,12 @@ static int buffer_write(void *io_context, const uint8_t *buf, uint32_t len)
 int s2n_connection_set_io_stuffers(struct s2n_stuffer *input, struct s2n_stuffer *output, struct s2n_connection *conn)
 {
     /* Set Up Callbacks*/
-    GUARD(s2n_connection_set_recv_cb(conn, &buffer_read));
-    GUARD(s2n_connection_set_send_cb(conn, &buffer_write));
+    POSIX_GUARD(s2n_connection_set_recv_cb(conn, &buffer_read));
+    POSIX_GUARD(s2n_connection_set_send_cb(conn, &buffer_write));
 
     /* Set up Callback Contexts to use stuffers */
-    GUARD(s2n_connection_set_recv_ctx(conn, input));
-    GUARD(s2n_connection_set_send_ctx(conn, output));
+    POSIX_GUARD(s2n_connection_set_recv_ctx(conn, input));
+    POSIX_GUARD(s2n_connection_set_send_ctx(conn, output));
 
     return 0;
 }
@@ -104,7 +104,7 @@ int s2n_io_pair_init(struct s2n_test_io_pair *io_pair)
 
     int socket_pair[2];
 
-    GUARD(socketpair(AF_UNIX, SOCK_STREAM, 0, socket_pair));
+    POSIX_GUARD(socketpair(AF_UNIX, SOCK_STREAM, 0, socket_pair));
 
     io_pair->client = socket_pair[0];
     io_pair->server = socket_pair[1];
@@ -114,10 +114,10 @@ int s2n_io_pair_init(struct s2n_test_io_pair *io_pair)
 
 int s2n_io_pair_init_non_blocking(struct s2n_test_io_pair *io_pair)
 {
-    GUARD(s2n_io_pair_init(io_pair));
+    POSIX_GUARD(s2n_io_pair_init(io_pair));
 
-    GUARD(s2n_fd_set_non_blocking(io_pair->client));
-    GUARD(s2n_fd_set_non_blocking(io_pair->server));
+    POSIX_GUARD(s2n_fd_set_non_blocking(io_pair->client));
+    POSIX_GUARD(s2n_fd_set_non_blocking(io_pair->server));
 
     return 0;
 }
@@ -125,9 +125,9 @@ int s2n_io_pair_init_non_blocking(struct s2n_test_io_pair *io_pair)
 int s2n_connection_set_io_pair(struct s2n_connection *conn, struct s2n_test_io_pair *io_pair)
 {
     if (conn->mode == S2N_CLIENT) {
-        GUARD(s2n_connection_set_fd(conn, io_pair->client));
+        POSIX_GUARD(s2n_connection_set_fd(conn, io_pair->client));
     } else if (conn->mode == S2N_SERVER) {
-        GUARD(s2n_connection_set_fd(conn, io_pair->server));
+        POSIX_GUARD(s2n_connection_set_fd(conn, io_pair->server));
     }
 
     return 0;
@@ -136,24 +136,24 @@ int s2n_connection_set_io_pair(struct s2n_connection *conn, struct s2n_test_io_p
 int s2n_connections_set_io_pair(struct s2n_connection *client, struct s2n_connection *server,
                                 struct s2n_test_io_pair *io_pair)
 {
-    GUARD(s2n_connection_set_io_pair(client, io_pair));
-    GUARD(s2n_connection_set_io_pair(server, io_pair));
+    POSIX_GUARD(s2n_connection_set_io_pair(client, io_pair));
+    POSIX_GUARD(s2n_connection_set_io_pair(server, io_pair));
     return 0;
 }
 
 int s2n_io_pair_close(struct s2n_test_io_pair *io_pair)
 {
-    GUARD(s2n_io_pair_close_one_end(io_pair, S2N_CLIENT));
-    GUARD(s2n_io_pair_close_one_end(io_pair, S2N_SERVER));
+    POSIX_GUARD(s2n_io_pair_close_one_end(io_pair, S2N_CLIENT));
+    POSIX_GUARD(s2n_io_pair_close_one_end(io_pair, S2N_SERVER));
     return 0;
 }
 
 int s2n_io_pair_close_one_end(struct s2n_test_io_pair *io_pair, int mode_to_close)
 {
     if (mode_to_close == S2N_CLIENT) {
-        GUARD(close(io_pair->client));
+        POSIX_GUARD(close(io_pair->client));
     } else if(mode_to_close == S2N_SERVER) {
-        GUARD(close(io_pair->server));
+        POSIX_GUARD(close(io_pair->server));
     }
     return 0;
 }
@@ -161,9 +161,9 @@ int s2n_io_pair_close_one_end(struct s2n_test_io_pair *io_pair, int mode_to_clos
 int s2n_io_pair_shutdown_one_end(struct s2n_test_io_pair *io_pair, int mode_to_close, int how)
 {
     if (mode_to_close == S2N_CLIENT) {
-        GUARD(shutdown(io_pair->client, how));
+        POSIX_GUARD(shutdown(io_pair->client, how));
     } else if(mode_to_close == S2N_SERVER) {
-        GUARD(shutdown(io_pair->server, how));
+        POSIX_GUARD(shutdown(io_pair->server, how));
     }
     return 0;
 }
@@ -212,7 +212,7 @@ void s2n_print_connection(struct s2n_connection *conn, const char *marker)
 
 int s2n_set_connection_hello_retry_flags(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     conn->handshake.message_number = 1;
     conn->handshake.handshake_type = NEGOTIATED | HELLO_RETRY_REQUEST | FULL_HANDSHAKE;
@@ -222,7 +222,7 @@ int s2n_set_connection_hello_retry_flags(struct s2n_connection *conn)
 
 int s2n_connection_set_all_protocol_versions(struct s2n_connection *conn, uint8_t version)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     conn->server_protocol_version = version;
     conn->client_protocol_version = version;

--- a/tests/testlib/s2n_extension_test_utils.c
+++ b/tests/testlib/s2n_extension_test_utils.c
@@ -20,7 +20,7 @@ const s2n_parsed_extension EMPTY_PARSED_EXTENSIONS[S2N_PARSED_EXTENSIONS_COUNT] 
 
 int s2n_connection_allow_all_response_extensions(struct s2n_connection *conn)
 {
-    memset_check(&conn->extension_requests_received, 0xFF, S2N_SUPPORTED_EXTENSIONS_BITFIELD_LEN);
-    memset_check(&conn->extension_requests_sent, 0xFF, S2N_SUPPORTED_EXTENSIONS_BITFIELD_LEN);
+    POSIX_CHECKED_MEMSET(&conn->extension_requests_received, 0xFF, S2N_SUPPORTED_EXTENSIONS_BITFIELD_LEN);
+    POSIX_CHECKED_MEMSET(&conn->extension_requests_sent, 0xFF, S2N_SUPPORTED_EXTENSIONS_BITFIELD_LEN);
     return S2N_SUCCESS;
 }

--- a/tests/testlib/s2n_pq_hybrid_test_utils.c
+++ b/tests/testlib/s2n_pq_hybrid_test_utils.c
@@ -35,7 +35,7 @@ struct s2n_blob hybrid_kat_entropy_blob = {.size = SEED_LENGTH, .data = hybrid_k
 struct s2n_drbg drbg_for_hybrid_kats;
 
 int s2n_hybrid_pq_rand_init(void) {
-    ENSURE_POSIX(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
+    POSIX_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
     return S2N_SUCCESS;
 }
 
@@ -45,10 +45,10 @@ int s2n_hybrid_pq_rand_cleanup(void) {
 
 /* We use "seed" from the KAT file for both the seed entropy and mix entropy for DRBG */
 int s2n_hybrid_pq_entropy(void *ptr, uint32_t size) {
-    ENSURE_POSIX(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
-    notnull_check(ptr);
-    lte_check(size, hybrid_kat_entropy_blob.size);
-    memcpy_check(ptr, hybrid_kat_entropy_buff, size);
+    POSIX_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
+    POSIX_ENSURE_REF(ptr);
+    POSIX_ENSURE_LTE(size, hybrid_kat_entropy_blob.size);
+    POSIX_CHECKED_MEMCPY(ptr, hybrid_kat_entropy_buff, size);
 
     return S2N_SUCCESS;
 }
@@ -58,150 +58,150 @@ static int setup_connection(struct s2n_connection *conn, const struct s2n_kem *k
     conn->actual_protocol_version = S2N_TLS12;
 
     const struct s2n_ecc_preferences *ecc_preferences = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
-    GUARD_NONNULL(ecc_preferences);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
+    POSIX_GUARD_PTR(ecc_preferences);
 
     conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     conn->secure.kem_params.kem = kem;
     conn->secure.cipher_suite = cipher_suite;
     conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
-    GUARD(s2n_connection_set_cipher_preferences(conn, cipher_pref_version));
+    POSIX_GUARD(s2n_connection_set_cipher_preferences(conn, cipher_pref_version));
     return S2N_SUCCESS;
 }
 
 int s2n_test_hybrid_ecdhe_kem_with_kat(const struct s2n_kem *kem, struct s2n_cipher_suite *cipher_suite,
         const char *cipher_pref_version, const char * kat_file_name, uint32_t server_key_message_length,
         uint32_t client_key_message_length) {
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
     /* Part 1 setup a client and server connection with everything they need for a key exchange */
     struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-    GUARD_NONNULL(client_conn = s2n_connection_new(S2N_CLIENT));
-    GUARD_NONNULL(server_conn = s2n_connection_new(S2N_SERVER));
+    POSIX_GUARD_PTR(client_conn = s2n_connection_new(S2N_CLIENT));
+    POSIX_GUARD_PTR(server_conn = s2n_connection_new(S2N_SERVER));
 
     struct s2n_config *server_config = NULL, *client_config = NULL;
 
-    GUARD_NONNULL(client_config = s2n_config_new());
-    GUARD(s2n_config_set_unsafe_for_testing(client_config));
-    GUARD(s2n_connection_set_config(client_conn, client_config));
+    POSIX_GUARD_PTR(client_config = s2n_config_new());
+    POSIX_GUARD(s2n_config_set_unsafe_for_testing(client_config));
+    POSIX_GUARD(s2n_connection_set_config(client_conn, client_config));
 
     /* Part 1.1 setup server's keypair and the give the client the certificate */
     char *cert_chain = NULL;
     char *private_key = NULL;
     char *client_chain = NULL;
-    GUARD_NONNULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
-    GUARD_NONNULL(private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
-    GUARD_NONNULL(client_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
-    GUARD_NONNULL(server_config = s2n_config_new());
-    GUARD(s2n_read_test_pem(S2N_RSA_2048_PKCS1_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
-    GUARD(s2n_read_test_pem(S2N_RSA_2048_PKCS1_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
-    GUARD(s2n_read_test_pem(S2N_RSA_2048_PKCS1_LEAF_CERT, client_chain, S2N_MAX_TEST_PEM_SIZE));
+    POSIX_GUARD_PTR(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
+    POSIX_GUARD_PTR(private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
+    POSIX_GUARD_PTR(client_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
+    POSIX_GUARD_PTR(server_config = s2n_config_new());
+    POSIX_GUARD(s2n_read_test_pem(S2N_RSA_2048_PKCS1_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
+    POSIX_GUARD(s2n_read_test_pem(S2N_RSA_2048_PKCS1_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
+    POSIX_GUARD(s2n_read_test_pem(S2N_RSA_2048_PKCS1_LEAF_CERT, client_chain, S2N_MAX_TEST_PEM_SIZE));
 
     struct s2n_cert_chain_and_key *chain_and_key = NULL;
-    GUARD_NONNULL(chain_and_key = s2n_cert_chain_and_key_new());
-    GUARD(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain, private_key));
-    GUARD(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
-    GUARD(s2n_connection_set_config(server_conn, server_config));
+    POSIX_GUARD_PTR(chain_and_key = s2n_cert_chain_and_key_new());
+    POSIX_GUARD(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain, private_key));
+    POSIX_GUARD(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+    POSIX_GUARD(s2n_connection_set_config(server_conn, server_config));
 
-    GUARD(s2n_choose_sig_scheme_from_peer_preference_list(server_conn, &server_conn->handshake_params.client_sig_hash_algs,
+    POSIX_GUARD(s2n_choose_sig_scheme_from_peer_preference_list(server_conn, &server_conn->handshake_params.client_sig_hash_algs,
             &server_conn->secure.conn_sig_scheme));
 
     DEFER_CLEANUP(struct s2n_stuffer certificate_in = {0}, s2n_stuffer_free);
-    GUARD(s2n_stuffer_alloc(&certificate_in, S2N_MAX_TEST_PEM_SIZE));
+    POSIX_GUARD(s2n_stuffer_alloc(&certificate_in, S2N_MAX_TEST_PEM_SIZE));
     DEFER_CLEANUP(struct s2n_stuffer certificate_out = {0}, s2n_stuffer_free);
-    GUARD(s2n_stuffer_alloc(&certificate_out, S2N_MAX_TEST_PEM_SIZE));
+    POSIX_GUARD(s2n_stuffer_alloc(&certificate_out, S2N_MAX_TEST_PEM_SIZE));
 
     struct s2n_blob temp_blob = {0};
-    GUARD(s2n_blob_init(&temp_blob, (uint8_t *) client_chain, strlen(client_chain) + 1));
-    GUARD(s2n_stuffer_write(&certificate_in, &temp_blob));
-    GUARD(s2n_stuffer_certificate_from_pem(&certificate_in, &certificate_out));
+    POSIX_GUARD(s2n_blob_init(&temp_blob, (uint8_t *) client_chain, strlen(client_chain) + 1));
+    POSIX_GUARD(s2n_stuffer_write(&certificate_in, &temp_blob));
+    POSIX_GUARD(s2n_stuffer_certificate_from_pem(&certificate_in, &certificate_out));
 
     temp_blob.size = s2n_stuffer_data_available(&certificate_out);
     temp_blob.data = s2n_stuffer_raw_read(&certificate_out, temp_blob.size);
     s2n_pkey_type pkey_type = {0};
-    GUARD(s2n_asn1der_to_public_key_and_type(&client_conn->secure.server_public_key, &pkey_type, &temp_blob));
+    POSIX_GUARD(s2n_asn1der_to_public_key_and_type(&client_conn->secure.server_public_key, &pkey_type, &temp_blob));
 
     server_conn->handshake_params.our_chain_and_key = chain_and_key;
 
-    GUARD(setup_connection(server_conn, kem, cipher_suite, cipher_pref_version));
-    GUARD(setup_connection(client_conn, kem, cipher_suite, cipher_pref_version));
+    POSIX_GUARD(setup_connection(server_conn, kem, cipher_suite, cipher_pref_version));
+    POSIX_GUARD(setup_connection(client_conn, kem, cipher_suite, cipher_pref_version));
 
 #if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
     /* Set the DRBG to the state that was used to generate this test vector. */
     FILE *kat_file = fopen(kat_file_name, "r");
-    GUARD_NONNULL(kat_file);
-    GUARD(ReadHex(kat_file, hybrid_kat_entropy_blob.data, SEED_LENGTH, "seed = "));
+    POSIX_GUARD_PTR(kat_file);
+    POSIX_GUARD(ReadHex(kat_file, hybrid_kat_entropy_blob.data, SEED_LENGTH, "seed = "));
 
     s2n_stack_blob(personalization_string, SEED_LENGTH, SEED_LENGTH);
-    GUARD(s2n_rand_set_callbacks(s2n_hybrid_pq_rand_init, s2n_hybrid_pq_rand_cleanup, s2n_hybrid_pq_entropy,
+    POSIX_GUARD(s2n_rand_set_callbacks(s2n_hybrid_pq_rand_init, s2n_hybrid_pq_rand_cleanup, s2n_hybrid_pq_entropy,
             s2n_hybrid_pq_entropy));
-    GUARD(s2n_drbg_instantiate(&drbg_for_hybrid_kats, &personalization_string, S2N_AES_256_CTR_NO_DF_PR));
-    GUARD_AS_POSIX(s2n_set_private_drbg_for_test(drbg_for_hybrid_kats));
+    POSIX_GUARD(s2n_drbg_instantiate(&drbg_for_hybrid_kats, &personalization_string, S2N_AES_256_CTR_NO_DF_PR));
+    POSIX_GUARD_RESULT(s2n_set_private_drbg_for_test(drbg_for_hybrid_kats));
 #endif
 
     /* Part 2 server sends key first */
-    GUARD(s2n_server_key_send(server_conn));
+    POSIX_GUARD(s2n_server_key_send(server_conn));
 
     /* Part 2.1 verify the results as best we can */
-    eq_check(server_conn->handshake.io.write_cursor, server_key_message_length);
+    POSIX_ENSURE_EQ(server_conn->handshake.io.write_cursor, server_key_message_length);
     struct s2n_blob server_key_message = {.size = server_key_message_length, .data = s2n_stuffer_raw_read(&server_conn->handshake.io, server_key_message_length)};
 
 #if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
     /* Part 2.1.1 if we're running in known answer mode check the server's key exchange message matches the expected value */
     uint8_t *expected_server_key_message = NULL;
-    GUARD_NONNULL(expected_server_key_message = malloc(server_key_message_length));
-    GUARD(ReadHex(kat_file, expected_server_key_message, server_key_message_length, "expected_server_key_exchange = "));
+    POSIX_GUARD_PTR(expected_server_key_message = malloc(server_key_message_length));
+    POSIX_GUARD(ReadHex(kat_file, expected_server_key_message, server_key_message_length, "expected_server_key_exchange = "));
 
     /* Compare byte arrays for equality */
-    eq_check(memcmp(expected_server_key_message, server_key_message.data, server_key_message_length), 0);
+    POSIX_ENSURE_EQ(memcmp(expected_server_key_message, server_key_message.data, server_key_message_length), 0);
 #endif
 
     /* Part 2.2 copy server's message to the client's stuffer */
     s2n_stuffer_write(&client_conn->handshake.io, &server_key_message);
 
     /* Part 3 client recvs the server's key and sends the client key exchange message */
-    GUARD(s2n_server_key_recv(client_conn));
-    GUARD(s2n_client_key_send(client_conn));
+    POSIX_GUARD(s2n_server_key_recv(client_conn));
+    POSIX_GUARD(s2n_client_key_send(client_conn));
 
     /* Part 3.1 verify the results as best we can */
-    eq_check(client_conn->handshake.io.write_cursor - client_conn->handshake.io.read_cursor, client_key_message_length);
+    POSIX_ENSURE_EQ(client_conn->handshake.io.write_cursor - client_conn->handshake.io.read_cursor, client_key_message_length);
     struct s2n_blob client_key_message = {.size = client_key_message_length, .data = s2n_stuffer_raw_read(&client_conn->handshake.io, client_key_message_length)};
 
 #if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
     /* Part 3.1.1 if we're running in known answer mode check the client's key exchange message matches the expected value */
     uint8_t *expected_client_key_message = NULL;
-    GUARD_NONNULL(expected_client_key_message = malloc(client_key_message_length));
-    GUARD(ReadHex(kat_file, expected_client_key_message, client_key_message_length, "expected_client_key_exchange = "));
+    POSIX_GUARD_PTR(expected_client_key_message = malloc(client_key_message_length));
+    POSIX_GUARD(ReadHex(kat_file, expected_client_key_message, client_key_message_length, "expected_client_key_exchange = "));
 
     /* Compare byte arrays for equality */
-    eq_check(memcmp(expected_client_key_message, client_key_message.data, client_key_message_length), 0);
+    POSIX_ENSURE_EQ(memcmp(expected_client_key_message, client_key_message.data, client_key_message_length), 0);
 #endif
 
     /* Part 3.2 copy the client's message back to the server's stuffer */
     s2n_stuffer_write(&server_conn->handshake.io, &client_key_message);
 
     /* Part 4 server receives the client's message */
-    GUARD(s2n_client_key_recv(server_conn));
+    POSIX_GUARD(s2n_client_key_recv(server_conn));
 
     /* Part 4.1 verify results as best we can, the client and server should at least have the same master secret */
     /* Compare byte arrays for equality */
-    eq_check(memcmp(server_conn->secure.master_secret, client_conn->secure.master_secret, S2N_TLS_SECRET_LEN), 0);
+    POSIX_ENSURE_EQ(memcmp(server_conn->secure.master_secret, client_conn->secure.master_secret, S2N_TLS_SECRET_LEN), 0);
 
 #if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
     /* Part 4.1.1 if we're running in known answer mode check that both the client and server got the expected master secret
      * from the RSP_FILE */
     uint8_t expected_master_secret[S2N_TLS_SECRET_LEN];
-    GUARD(ReadHex(kat_file, expected_master_secret, S2N_TLS_SECRET_LEN, "expected_master_secret = "));
+    POSIX_GUARD(ReadHex(kat_file, expected_master_secret, S2N_TLS_SECRET_LEN, "expected_master_secret = "));
     /* Compare byte arrays for equality */
-    eq_check(memcmp(expected_master_secret, client_conn->secure.master_secret, S2N_TLS_SECRET_LEN), 0);
-    eq_check(memcmp(expected_master_secret, server_conn->secure.master_secret, S2N_TLS_SECRET_LEN), 0);
+    POSIX_ENSURE_EQ(memcmp(expected_master_secret, client_conn->secure.master_secret, S2N_TLS_SECRET_LEN), 0);
+    POSIX_ENSURE_EQ(memcmp(expected_master_secret, server_conn->secure.master_secret, S2N_TLS_SECRET_LEN), 0);
 #endif
 
-    GUARD(s2n_cert_chain_and_key_free(chain_and_key));
-    GUARD(s2n_connection_free(client_conn));
-    GUARD(s2n_connection_free(server_conn));
-    GUARD(s2n_config_free(server_config));
-    GUARD(s2n_config_free(client_config));
+    POSIX_GUARD(s2n_cert_chain_and_key_free(chain_and_key));
+    POSIX_GUARD(s2n_connection_free(client_conn));
+    POSIX_GUARD(s2n_connection_free(server_conn));
+    POSIX_GUARD(s2n_config_free(server_config));
+    POSIX_GUARD(s2n_config_free(client_config));
     free(cert_chain);
     free(client_chain);
     free(private_key);

--- a/tests/testlib/s2n_pq_kat_test_utils.c
+++ b/tests/testlib/s2n_pq_kat_test_utils.c
@@ -31,7 +31,7 @@ struct s2n_blob kat_entropy_blob = {.size = SEED_LENGTH, .data = kat_entropy_buf
 struct s2n_drbg drbg_for_pq_kats;
 
 int s2n_pq_kat_rand_init(void) {
-    ENSURE_POSIX(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
+    POSIX_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
     return S2N_SUCCESS;
 }
 
@@ -41,10 +41,10 @@ int s2n_pq_kat_rand_cleanup(void) {
 
 /* The seed entropy is taken from the NIST KAT file. */
 int s2n_pq_kat_seed_entropy(void *ptr, uint32_t size) {
-    ENSURE_POSIX(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
-    notnull_check(ptr);
-    eq_check(size, kat_entropy_blob.size);
-    memcpy_check(ptr, kat_entropy_buff, size);
+    POSIX_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
+    POSIX_ENSURE_REF(ptr);
+    POSIX_ENSURE_EQ(size, kat_entropy_blob.size);
+    POSIX_CHECKED_MEMCPY(ptr, kat_entropy_buff, size);
 
     return S2N_SUCCESS;
 }
@@ -59,32 +59,32 @@ static int s2n_pq_kat_mix_entropy(void *ptr, uint32_t size) {
  * prediction resistance that is built in to s2n's DRBG modes. The PQ KATs were generated
  * using AES 256 CTR NO DF NO PR. */
 static S2N_RESULT s2n_drbg_generate_for_pq_kat_tests(struct s2n_drbg *drbg, struct s2n_blob *blob) {
-    ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
-    ENSURE_REF(drbg);
-    ENSURE_REF(drbg->ctx);
+    RESULT_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
+    RESULT_ENSURE_REF(drbg);
+    RESULT_ENSURE_REF(drbg->ctx);
     uint8_t zeros_buffer[S2N_DRBG_MAX_SEED_SIZE] = { 0 };
     struct s2n_blob zeros = { .data = zeros_buffer, .size = s2n_drbg_seed_size(drbg) };
 
-    ENSURE(blob->size <= S2N_DRBG_GENERATE_LIMIT, S2N_ERR_DRBG_REQUEST_SIZE);
+    RESULT_ENSURE(blob->size <= S2N_DRBG_GENERATE_LIMIT, S2N_ERR_DRBG_REQUEST_SIZE);
 
     /* We do NOT mix in additional entropy */
-    GUARD_AS_RESULT(s2n_drbg_bits(drbg, blob));
-    GUARD_AS_RESULT(s2n_drbg_update(drbg, &zeros));
+    RESULT_GUARD_POSIX(s2n_drbg_bits(drbg, blob));
+    RESULT_GUARD_POSIX(s2n_drbg_update(drbg, &zeros));
 
     return S2N_RESULT_OK;
 }
 
 /* Adapted from s2n_random.c::s2n_get_private_random_data(). */
 static S2N_RESULT s2n_get_random_data_for_pq_kat_tests(struct s2n_blob *blob) {
-    ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
+    RESULT_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
     uint32_t offset = 0;
     uint32_t remaining = blob->size;
 
     while(remaining) {
         struct s2n_blob slice = { 0 };
 
-        GUARD_AS_RESULT(s2n_blob_slice(blob, &slice, offset, MIN(remaining, S2N_DRBG_GENERATE_LIMIT)));;
-        GUARD_RESULT(s2n_drbg_generate_for_pq_kat_tests(&drbg_for_pq_kats, &slice));
+        RESULT_GUARD_POSIX(s2n_blob_slice(blob, &slice, offset, MIN(remaining, S2N_DRBG_GENERATE_LIMIT)));;
+        RESULT_GUARD(s2n_drbg_generate_for_pq_kat_tests(&drbg_for_pq_kats, &slice));
 
         remaining -= slice.size;
         offset += slice.size;
@@ -94,84 +94,84 @@ static S2N_RESULT s2n_get_random_data_for_pq_kat_tests(struct s2n_blob *blob) {
 }
 
 S2N_RESULT s2n_get_random_bytes_for_pq_kat_tests(uint8_t *buffer, uint32_t num_bytes) {
-    ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
+    RESULT_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
     struct s2n_blob out = { .data = buffer, .size = num_bytes };
 
-    GUARD_RESULT(s2n_get_random_data_for_pq_kat_tests(&out));
+    RESULT_GUARD(s2n_get_random_data_for_pq_kat_tests(&out));
 
     return S2N_RESULT_OK;
 }
 
 int s2n_test_kem_with_kat(const struct s2n_kem *kem, const char *kat_file_name) {
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
-    ENSURE_POSIX(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
 
-    notnull_check(kem);
+    POSIX_ENSURE_REF(kem);
 
     FILE *kat_file = fopen(kat_file_name, "r");
-    notnull_check(kat_file);
+    POSIX_ENSURE_REF(kat_file);
 
     uint8_t *ct, *client_shared_secret, *pk, *sk, *server_shared_secret, *pk_answer, *sk_answer, *ct_answer, *ss_answer;
     /* Client side variables */
-    notnull_check(ct = malloc(kem->ciphertext_length));
-    notnull_check(client_shared_secret = malloc(kem->shared_secret_key_length));
+    POSIX_ENSURE_REF(ct = malloc(kem->ciphertext_length));
+    POSIX_ENSURE_REF(client_shared_secret = malloc(kem->shared_secret_key_length));
 
     /* Server side variables */
-    notnull_check(pk = malloc(kem->public_key_length));
-    notnull_check(sk = malloc(kem->private_key_length));
-    notnull_check(server_shared_secret = malloc(kem->shared_secret_key_length));
+    POSIX_ENSURE_REF(pk = malloc(kem->public_key_length));
+    POSIX_ENSURE_REF(sk = malloc(kem->private_key_length));
+    POSIX_ENSURE_REF(server_shared_secret = malloc(kem->shared_secret_key_length));
 
     /* Known answer variables */
-    notnull_check(pk_answer = malloc(kem->public_key_length));
-    notnull_check(sk_answer = malloc(kem->private_key_length));
-    notnull_check(ct_answer = malloc(kem->ciphertext_length));
-    notnull_check(ss_answer = malloc(kem->shared_secret_key_length));
+    POSIX_ENSURE_REF(pk_answer = malloc(kem->public_key_length));
+    POSIX_ENSURE_REF(sk_answer = malloc(kem->private_key_length));
+    POSIX_ENSURE_REF(ct_answer = malloc(kem->ciphertext_length));
+    POSIX_ENSURE_REF(ss_answer = malloc(kem->shared_secret_key_length));
 
     s2n_stack_blob(personalization_string, SEED_LENGTH, SEED_LENGTH);
-    GUARD(s2n_rand_set_callbacks(s2n_pq_kat_rand_init, s2n_pq_kat_rand_cleanup, s2n_pq_kat_seed_entropy,
+    POSIX_GUARD(s2n_rand_set_callbacks(s2n_pq_kat_rand_init, s2n_pq_kat_rand_cleanup, s2n_pq_kat_seed_entropy,
             s2n_pq_kat_mix_entropy));
-    GUARD_AS_POSIX(s2n_set_rand_bytes_callback_for_testing(s2n_get_random_bytes_for_pq_kat_tests));
+    POSIX_GUARD_RESULT(s2n_set_rand_bytes_callback_for_testing(s2n_get_random_bytes_for_pq_kat_tests));
 
     for (size_t i = 0; i < NUM_OF_KATS; i++) {
         /* Verify test index */
         int32_t count = 0;
-        GUARD(FindMarker(kat_file, "count = "));
-        gt_check(fscanf(kat_file, "%d", &count), 0);
-        eq_check(count, i);
+        POSIX_GUARD(FindMarker(kat_file, "count = "));
+        POSIX_ENSURE_GT(fscanf(kat_file, "%d", &count), 0);
+        POSIX_ENSURE_EQ(count, i);
 
         /* Set the DRBG to the state that was used to generate this test vector. We instantiate the DRBG
          * as S2N_AES_256_CTR_NO_DF_PR; since the NIST KATs were generated without prediction resistance,
          * we use the custom function s2n_drbg_generate_for_pq_kat_tests() defined above to turn off the
          * prediction resistance. */
-        GUARD(ReadHex(kat_file, kat_entropy_blob.data, SEED_LENGTH, "seed = "));
-        GUARD(s2n_drbg_instantiate(&drbg_for_pq_kats, &personalization_string, S2N_AES_256_CTR_NO_DF_PR));
+        POSIX_GUARD(ReadHex(kat_file, kat_entropy_blob.data, SEED_LENGTH, "seed = "));
+        POSIX_GUARD(s2n_drbg_instantiate(&drbg_for_pq_kats, &personalization_string, S2N_AES_256_CTR_NO_DF_PR));
 
         /* Generate the public/private key pair */
-        GUARD(kem->generate_keypair(pk, sk));
+        POSIX_GUARD(kem->generate_keypair(pk, sk));
 
         /* Create a shared secret and use the public key to encrypt it */
-        GUARD(kem->encapsulate(ct, client_shared_secret, pk));
+        POSIX_GUARD(kem->encapsulate(ct, client_shared_secret, pk));
 
         /* Use the private key to decrypt the ct to get the shared secret */
-        GUARD(kem->decapsulate(server_shared_secret, ct, sk));
+        POSIX_GUARD(kem->decapsulate(server_shared_secret, ct, sk));
 
         /* Read the KAT values */
-        GUARD(ReadHex(kat_file, pk_answer, kem->public_key_length, "pk = "));
-        GUARD(ReadHex(kat_file, sk_answer, kem->private_key_length, "sk = "));
-        GUARD(ReadHex(kat_file, ct_answer, kem->ciphertext_length, "ct = "));
-        GUARD(ReadHex(kat_file, ss_answer, kem->shared_secret_key_length, "ss = "));
+        POSIX_GUARD(ReadHex(kat_file, pk_answer, kem->public_key_length, "pk = "));
+        POSIX_GUARD(ReadHex(kat_file, sk_answer, kem->private_key_length, "sk = "));
+        POSIX_GUARD(ReadHex(kat_file, ct_answer, kem->ciphertext_length, "ct = "));
+        POSIX_GUARD(ReadHex(kat_file, ss_answer, kem->shared_secret_key_length, "ss = "));
 
         /* Test the client and server got the same value */
-        eq_check(memcmp(client_shared_secret, server_shared_secret, kem->shared_secret_key_length), 0);
+        POSIX_ENSURE_EQ(memcmp(client_shared_secret, server_shared_secret, kem->shared_secret_key_length), 0);
 
         /* Compare the KAT values */
-        eq_check(memcmp(pk_answer, pk, kem->public_key_length), 0);
-        eq_check(memcmp(sk_answer, sk, kem->private_key_length), 0);
-        eq_check(memcmp(ct_answer, ct, kem->ciphertext_length), 0);
-        eq_check(memcmp(ss_answer, server_shared_secret, kem->shared_secret_key_length ), 0);
+        POSIX_ENSURE_EQ(memcmp(pk_answer, pk, kem->public_key_length), 0);
+        POSIX_ENSURE_EQ(memcmp(sk_answer, sk, kem->private_key_length), 0);
+        POSIX_ENSURE_EQ(memcmp(ct_answer, ct, kem->ciphertext_length), 0);
+        POSIX_ENSURE_EQ(memcmp(ss_answer, server_shared_secret, kem->shared_secret_key_length ), 0);
 
         /* Wipe the DRBG; it will reseed for each KAT test vector. */
-        GUARD(s2n_drbg_wipe(&drbg_for_pq_kats));
+        POSIX_GUARD(s2n_drbg_wipe(&drbg_for_pq_kats));
     }
     fclose(kat_file);
     free(ct);

--- a/tests/testlib/s2n_test_certs.c
+++ b/tests/testlib/s2n_test_certs.c
@@ -30,11 +30,11 @@ int s2n_test_cert_chain_and_key_new(struct s2n_cert_chain_and_key **chain_and_ke
     char cert_chain_pem[S2N_MAX_TEST_PEM_SIZE];
     char private_key_pem[S2N_MAX_TEST_PEM_SIZE];
 
-    GUARD(s2n_read_test_pem(cert_chain_file, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
-    GUARD(s2n_read_test_pem(private_key_file, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+    POSIX_GUARD(s2n_read_test_pem(cert_chain_file, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+    POSIX_GUARD(s2n_read_test_pem(private_key_file, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
 
     POSIX_GUARD_PTR(*chain_and_key = s2n_cert_chain_and_key_new());
-    GUARD(s2n_cert_chain_and_key_load_pem(*chain_and_key, cert_chain_pem, private_key_pem));
+    POSIX_GUARD(s2n_cert_chain_and_key_load_pem(*chain_and_key, cert_chain_pem, private_key_pem));
 
     return S2N_SUCCESS;
 }
@@ -43,7 +43,7 @@ int s2n_read_test_pem(const char *pem_path, char *pem_out, long int max_size)
 {
     FILE *pem_file = fopen(pem_path, "rb");
     if (!pem_file) {
-        S2N_ERROR(S2N_ERR_NULL);
+        POSIX_BAIL(S2N_ERR_NULL);
     }
 
     /* Make sure we can fit the pem into the output buffer */
@@ -53,11 +53,11 @@ int s2n_read_test_pem(const char *pem_path, char *pem_out, long int max_size)
     rewind(pem_file);
 
     if (max_size < (pem_file_size + 1)) {
-        S2N_ERROR(S2N_ERR_NOMEM);
+        POSIX_BAIL(S2N_ERR_NOMEM);
     }
 
     if (fread(pem_out, sizeof(char), pem_file_size, pem_file) < pem_file_size) {
-        S2N_ERROR(S2N_ERR_IO);
+        POSIX_BAIL(S2N_ERR_IO);
     }
 
     pem_out[pem_file_size] = '\0';

--- a/tests/testlib/s2n_test_server_client.c
+++ b/tests/testlib/s2n_test_server_client.c
@@ -45,8 +45,8 @@ int s2n_negotiate_test_server_and_client(struct s2n_connection *server_conn, str
     bool server_done = 0, client_done = 0;
 
     do {
-        GUARD(s2n_try_negotiate(client_conn, &client_done, server_done));
-        GUARD(s2n_try_negotiate(server_conn, &server_done, client_done));
+        POSIX_GUARD(s2n_try_negotiate(client_conn, &client_done, server_done));
+        POSIX_GUARD(s2n_try_negotiate(server_conn, &server_done, client_done));
     } while (!client_done || !server_done);
 
     return S2N_SUCCESS;

--- a/tests/testlib/s2n_testlib_ecc_keys.c
+++ b/tests/testlib/s2n_testlib_ecc_keys.c
@@ -21,8 +21,8 @@
 
 int s2n_public_ecc_keys_are_equal(struct s2n_ecc_evp_params *params_1, struct s2n_ecc_evp_params *params_2)
 {
-    notnull_check(params_1);
-    notnull_check(params_2);
+    POSIX_ENSURE_REF(params_1);
+    POSIX_ENSURE_REF(params_2);
 
     struct s2n_stuffer point_stuffer;
     int size = params_1->negotiated_curve->share_size;
@@ -31,17 +31,17 @@ int s2n_public_ecc_keys_are_equal(struct s2n_ecc_evp_params *params_1, struct s2
         return 0;
     }
 
-    GUARD(s2n_stuffer_alloc(&point_stuffer, size * 2));
+    POSIX_GUARD(s2n_stuffer_alloc(&point_stuffer, size * 2));
 
     uint8_t *point_1 = s2n_stuffer_raw_write(&point_stuffer, 0);
-    GUARD(s2n_ecc_evp_write_params_point(params_1, &point_stuffer));
+    POSIX_GUARD(s2n_ecc_evp_write_params_point(params_1, &point_stuffer));
 
     uint8_t *point_2 = s2n_stuffer_raw_write(&point_stuffer, 0);
-    GUARD(s2n_ecc_evp_write_params_point(params_2, &point_stuffer));
+    POSIX_GUARD(s2n_ecc_evp_write_params_point(params_2, &point_stuffer));
 
     int result = memcmp(point_1, point_2, size) == 0;
 
-    GUARD(s2n_stuffer_free(&point_stuffer));
+    POSIX_GUARD(s2n_stuffer_free(&point_stuffer));
 
     return result;
 }

--- a/tests/unit/s2n_aead_aes_test.c
+++ b/tests/unit/s2n_aead_aes_test.c
@@ -33,17 +33,17 @@
 
 static int destroy_server_keys(struct s2n_connection *server_conn)
 {
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->destroy_key(&server_conn->initial.server_key));
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->destroy_key(&server_conn->initial.client_key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->destroy_key(&server_conn->initial.server_key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->destroy_key(&server_conn->initial.client_key));
     return 0;
 }
 
 static int setup_server_keys(struct s2n_connection *server_conn, struct s2n_blob *key)
 {
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->init(&server_conn->initial.server_key));
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->init(&server_conn->initial.client_key));
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->set_encryption_key(&server_conn->initial.server_key, key));
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->set_decryption_key(&server_conn->initial.client_key, key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->init(&server_conn->initial.server_key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->init(&server_conn->initial.client_key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->set_encryption_key(&server_conn->initial.server_key, key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->set_decryption_key(&server_conn->initial.client_key, key));
 
     return 0;
 }

--- a/tests/unit/s2n_aead_chacha20_poly1305_test.c
+++ b/tests/unit/s2n_aead_chacha20_poly1305_test.c
@@ -34,17 +34,17 @@
 
 static int destroy_server_keys(struct s2n_connection *server_conn)
 {
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->destroy_key(&server_conn->initial.server_key));
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->destroy_key(&server_conn->initial.client_key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->destroy_key(&server_conn->initial.server_key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->destroy_key(&server_conn->initial.client_key));
     return 0;
 }
 
 static int setup_server_keys(struct s2n_connection *server_conn, struct s2n_blob *key)
 {
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->init(&server_conn->initial.server_key));
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->init(&server_conn->initial.client_key));
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->set_encryption_key(&server_conn->initial.server_key, key));
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->set_decryption_key(&server_conn->initial.client_key, key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->init(&server_conn->initial.server_key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->init(&server_conn->initial.client_key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->set_encryption_key(&server_conn->initial.server_key, key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->set_decryption_key(&server_conn->initial.client_key, key));
 
     return 0;
 }
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
 
     /* test the chacha20_poly1305 cipher */
     conn->initial.cipher_suite->record_alg = &s2n_record_alg_chacha20_poly1305;
-    GUARD(setup_server_keys(conn, &chacha20_poly1305_key));
+    POSIX_GUARD(setup_server_keys(conn, &chacha20_poly1305_key));
 
     int max_fragment = S2N_SMALL_FRAGMENT_LENGTH;
     for (size_t i = 0; i <= max_fragment + 1; i++) {
@@ -182,8 +182,8 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
-        GUARD(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.server_key));
-        GUARD(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.client_key));
+        POSIX_GUARD(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.server_key));
+        POSIX_GUARD(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.client_key));
 
         /* Tamper with the TAG and ensure decryption fails */
         for (size_t j = 0; j < S2N_TLS_CHACHA20_POLY1305_TAG_LEN; j++) {
@@ -208,8 +208,8 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
-            GUARD(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.server_key));
-            GUARD(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.client_key));
+            POSIX_GUARD(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.server_key));
+            POSIX_GUARD(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.client_key));
         }
 
         /* Tamper with the encrypted payload in the ciphertext and ensure decryption fails */
@@ -235,8 +235,8 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
-            GUARD(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.server_key));
-            GUARD(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.client_key));
+            POSIX_GUARD(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.server_key));
+            POSIX_GUARD(conn->initial.cipher_suite->record_alg->cipher->destroy_key(&conn->initial.client_key));
         }
     }
 

--- a/tests/unit/s2n_async_pkey_test.c
+++ b/tests/unit/s2n_async_pkey_test.c
@@ -101,13 +101,13 @@ static int try_handshake(struct s2n_connection *server_conn, struct s2n_connecti
         }
 
         if (server_blocked == S2N_BLOCKED_ON_APPLICATION_INPUT) {
-            GUARD(handler(server_conn));
+            POSIX_GUARD(handler(server_conn));
         }
 
         EXPECT_NOT_EQUAL(++tries, 5);
     } while (client_blocked || server_blocked);
 
-    GUARD(s2n_shutdown_test_server_and_client(server_conn, client_conn));
+    POSIX_GUARD(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 
     return S2N_SUCCESS;
 }

--- a/tests/unit/s2n_auth_selection_test.c
+++ b/tests/unit/s2n_auth_selection_test.c
@@ -51,14 +51,14 @@ static int s2n_test_auth_combo(struct s2n_connection *conn,
 {
     struct s2n_cert_chain_and_key *actual_cert_chain;
 
-    GUARD(s2n_is_cipher_suite_valid_for_auth(conn, cipher_suite));
+    POSIX_GUARD(s2n_is_cipher_suite_valid_for_auth(conn, cipher_suite));
     conn->secure.cipher_suite = cipher_suite;
 
-    GUARD(s2n_is_sig_scheme_valid_for_auth(conn, sig_scheme));
+    POSIX_GUARD(s2n_is_sig_scheme_valid_for_auth(conn, sig_scheme));
     conn->secure.conn_sig_scheme.sig_alg = sig_scheme->sig_alg;
 
-    GUARD(s2n_select_certs_for_server_auth(conn, &actual_cert_chain));
-    eq_check(actual_cert_chain, expected_cert_chain);
+    POSIX_GUARD(s2n_select_certs_for_server_auth(conn, &actual_cert_chain));
+    POSIX_ENSURE_EQ(actual_cert_chain, expected_cert_chain);
     return S2N_SUCCESS;
 }
 

--- a/tests/unit/s2n_cert_chain_and_key_test.c
+++ b/tests/unit/s2n_cert_chain_and_key_test.c
@@ -29,7 +29,7 @@
 
 struct s2n_connection *create_conn(s2n_mode mode, struct s2n_config *config) {
     struct s2n_connection *conn = s2n_connection_new(mode);
-    GUARD_PTR(s2n_connection_set_config(conn, config));
+    PTR_GUARD_POSIX(s2n_connection_set_config(conn, config));
     return conn;
 }
 

--- a/tests/unit/s2n_certificate_extensions_test.c
+++ b/tests/unit/s2n_certificate_extensions_test.c
@@ -35,39 +35,39 @@ s2n_pkey_type actual_cert_pkey_type;
 static int s2n_skip_cert_chain_size(struct s2n_stuffer *stuffer)
 {
     uint32_t cert_chain_size;
-    GUARD(s2n_stuffer_read_uint24(stuffer, &cert_chain_size));
-    eq_check(cert_chain_size, s2n_stuffer_data_available(stuffer));
+    POSIX_GUARD(s2n_stuffer_read_uint24(stuffer, &cert_chain_size));
+    POSIX_ENSURE_EQ(cert_chain_size, s2n_stuffer_data_available(stuffer));
     return S2N_SUCCESS;
 }
 
 static int s2n_skip_cert(struct s2n_stuffer *stuffer)
 {
     uint32_t cert_size;
-    GUARD(s2n_stuffer_read_uint24(stuffer, &cert_size));
-    GUARD(s2n_stuffer_skip_read(stuffer, cert_size));
+    POSIX_GUARD(s2n_stuffer_read_uint24(stuffer, &cert_size));
+    POSIX_GUARD(s2n_stuffer_skip_read(stuffer, cert_size));
     return S2N_SUCCESS;
 }
 
 static int s2n_x509_validator_validate_cert_chain_test(struct s2n_connection *conn, struct s2n_stuffer *stuffer)
 {
-    GUARD(s2n_skip_cert_chain_size(stuffer));
+    POSIX_GUARD(s2n_skip_cert_chain_size(stuffer));
     uint32_t cert_chain_size = s2n_stuffer_data_available(stuffer);
 
     uint8_t *cert_chain_data;
-    notnull_check(cert_chain_data = s2n_stuffer_raw_read(stuffer, cert_chain_size));
+    POSIX_ENSURE_REF(cert_chain_data = s2n_stuffer_raw_read(stuffer, cert_chain_size));
 
-    GUARD(s2n_x509_validator_validate_cert_chain(&conn->x509_validator, conn,
+    POSIX_GUARD(s2n_x509_validator_validate_cert_chain(&conn->x509_validator, conn,
             cert_chain_data, cert_chain_size, &actual_cert_pkey_type, &public_key));
 
-    GUARD(s2n_pkey_free(&public_key));
+    POSIX_GUARD(s2n_pkey_free(&public_key));
     return S2N_SUCCESS;
 }
 
 static int s2n_write_test_cert(struct s2n_stuffer *stuffer, struct s2n_cert_chain_and_key *chain_and_key)
 {
     struct s2n_blob *cert = &chain_and_key->cert_chain->head->raw;
-    GUARD(s2n_stuffer_write_uint24(stuffer, cert->size));
-    GUARD(s2n_stuffer_write_bytes(stuffer, cert->data, cert->size));
+    POSIX_GUARD(s2n_stuffer_write_uint24(stuffer, cert->size));
+    POSIX_GUARD(s2n_stuffer_write_bytes(stuffer, cert->data, cert->size));
     return S2N_SUCCESS;
 }
 
@@ -75,11 +75,11 @@ static int s2n_setup_connection_for_ocsp_validate_test(struct s2n_connection **c
 {
     struct s2n_connection *nconn;
 
-    notnull_check(nconn = s2n_connection_new(S2N_SERVER));
+    POSIX_ENSURE_REF(nconn = s2n_connection_new(S2N_SERVER));
     nconn->actual_protocol_version = S2N_TLS13;
     nconn->handshake_params.our_chain_and_key = chain_and_key;
 
-    GUARD(s2n_connection_allow_all_response_extensions(nconn));
+    POSIX_GUARD(s2n_connection_allow_all_response_extensions(nconn));
     nconn->status_type = S2N_STATUS_REQUEST_OCSP;
 
     *conn = nconn;
@@ -240,7 +240,7 @@ int main(int argc, char **argv)
         /* Test: extensions only processed for >= TLS1.3 */
         {
             struct s2n_connection *setup_conn;
-            GUARD(s2n_setup_connection_for_ocsp_validate_test(&setup_conn, chain_and_key));
+            POSIX_GUARD(s2n_setup_connection_for_ocsp_validate_test(&setup_conn, chain_and_key));
 
             DEFER_CLEANUP(struct s2n_stuffer stuffer, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
@@ -254,7 +254,7 @@ int main(int argc, char **argv)
             /* TLS1.2 does NOT process extensions */
             {
                 struct s2n_connection *conn;
-                GUARD(s2n_setup_connection_for_ocsp_validate_test(&conn, chain_and_key));
+                POSIX_GUARD(s2n_setup_connection_for_ocsp_validate_test(&conn, chain_and_key));
 
                 EXPECT_SUCCESS(s2n_stuffer_reread(&stuffer));
                 conn->actual_protocol_version = S2N_TLS12;
@@ -270,7 +270,7 @@ int main(int argc, char **argv)
             /* TLS1.3 DOES process extensions */
             {
                 struct s2n_connection *conn;
-                GUARD(s2n_setup_connection_for_ocsp_validate_test(&conn, chain_and_key));
+                POSIX_GUARD(s2n_setup_connection_for_ocsp_validate_test(&conn, chain_and_key));
 
                 EXPECT_SUCCESS(s2n_stuffer_reread(&stuffer));
                 conn->actual_protocol_version = S2N_TLS13;
@@ -293,7 +293,7 @@ int main(int argc, char **argv)
             /* Extensions on second cert ignored */
             {
                 struct s2n_connection *conn;
-                GUARD(s2n_setup_connection_for_ocsp_validate_test(&conn, chain_and_key));
+                POSIX_GUARD(s2n_setup_connection_for_ocsp_validate_test(&conn, chain_and_key));
 
                 DEFER_CLEANUP(struct s2n_stuffer stuffer, s2n_stuffer_free);
                 EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
@@ -316,7 +316,7 @@ int main(int argc, char **argv)
             /* Extensions on first cert processed */
             {
                 struct s2n_connection *conn;
-                GUARD(s2n_setup_connection_for_ocsp_validate_test(&conn, chain_and_key));
+                POSIX_GUARD(s2n_setup_connection_for_ocsp_validate_test(&conn, chain_and_key));
 
                 DEFER_CLEANUP(struct s2n_stuffer stuffer, s2n_stuffer_free);
                 EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -25,13 +25,13 @@
 #include "tls/s2n_security_policies.h"
 
 static s2n_result s2n_conn_set_chosen_psk(struct s2n_connection *conn) {
-    ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn);
 
     uint8_t psk_identity[] = "psk identity";
-    GUARD_RESULT(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &conn->psk_params.chosen_psk));
-    ENSURE_REF(conn->psk_params.chosen_psk);
-    GUARD_RESULT(s2n_psk_init(conn->psk_params.chosen_psk, S2N_PSK_TYPE_EXTERNAL));
-    GUARD_AS_RESULT(s2n_psk_set_identity(conn->psk_params.chosen_psk, psk_identity, sizeof(psk_identity)));
+    RESULT_GUARD(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &conn->psk_params.chosen_psk));
+    RESULT_ENSURE_REF(conn->psk_params.chosen_psk);
+    RESULT_GUARD(s2n_psk_init(conn->psk_params.chosen_psk, S2N_PSK_TYPE_EXTERNAL));
+    RESULT_GUARD_POSIX(s2n_psk_set_identity(conn->psk_params.chosen_psk, psk_identity, sizeof(psk_identity)));
 
     return S2N_RESULT_OK;
 }

--- a/tests/unit/s2n_client_cert_verify_test.c
+++ b/tests/unit/s2n_client_cert_verify_test.c
@@ -37,7 +37,7 @@ static S2N_RESULT test_size(const struct s2n_pkey *pkey, uint32_t *size_out)
 static int test_sign(const struct s2n_pkey *priv_key, s2n_signature_algorithm sig_alg,
         struct s2n_hash_state *digest, struct s2n_blob *signature)
 {
-    memcpy_check(signature->data, test_signature_data, test_signature_size);
+    POSIX_CHECKED_MEMCPY(signature->data, test_signature_data, test_signature_size);
     signature->size = test_signature_size;
     return S2N_SUCCESS;
 }

--- a/tests/unit/s2n_client_early_data_indication_test.c
+++ b/tests/unit/s2n_client_early_data_indication_test.c
@@ -26,35 +26,35 @@
 static S2N_RESULT s2n_append_test_psk(struct s2n_connection *conn, uint32_t max_early_data,
         const struct s2n_cipher_suite *cipher_suite)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(cipher_suite);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(cipher_suite);
 
     /* We're assuming the index will only take one digit */
     uint8_t buffer[sizeof(TEST_VALUE) + 1] = { 0 };
     int r = snprintf((char*) buffer, sizeof(buffer), "%s%u", TEST_VALUE, conn->psk_params.psk_list.len);
-    ENSURE_GT(r, 0);
-    ENSURE_LT(r, sizeof(buffer));
+    RESULT_ENSURE_GT(r, 0);
+    RESULT_ENSURE_LT(r, sizeof(buffer));
 
     DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
-    GUARD_AS_RESULT(s2n_psk_set_identity(psk, buffer, sizeof(buffer)));
-    GUARD_AS_RESULT(s2n_psk_set_secret(psk, buffer, sizeof(buffer)));
+    RESULT_GUARD_POSIX(s2n_psk_set_identity(psk, buffer, sizeof(buffer)));
+    RESULT_GUARD_POSIX(s2n_psk_set_secret(psk, buffer, sizeof(buffer)));
     psk->hmac_alg = cipher_suite->prf_alg;
     if (max_early_data > 0) {
-        GUARD_AS_RESULT(s2n_psk_configure_early_data(psk, max_early_data,
+        RESULT_GUARD_POSIX(s2n_psk_configure_early_data(psk, max_early_data,
                 cipher_suite->iana_value[0], cipher_suite->iana_value[1]));
     }
-    GUARD_AS_RESULT(s2n_connection_append_psk(conn, psk));
+    RESULT_GUARD_POSIX(s2n_connection_append_psk(conn, psk));
     return S2N_RESULT_OK;
 }
 
 static S2N_RESULT s2n_set_early_data_app_protocol(struct s2n_connection *conn, struct s2n_blob *app_protocol)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(app_protocol);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(app_protocol);
 
     struct s2n_psk *psk = NULL;
-    GUARD_RESULT(s2n_array_get(&conn->psk_params.psk_list, 0, (void**) &psk));
-    GUARD_AS_RESULT(s2n_psk_set_application_protocol(psk, app_protocol->data, app_protocol->size));
+    RESULT_GUARD(s2n_array_get(&conn->psk_params.psk_list, 0, (void**) &psk));
+    RESULT_GUARD_POSIX(s2n_psk_set_application_protocol(psk, app_protocol->data, app_protocol->size));
     return S2N_RESULT_OK;
 }
 

--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
             const struct s2n_ecc_preferences *ecc_pref = NULL;
-            GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+            POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
             EXPECT_NOT_NULL(ecc_pref);
 
             conn->actual_protocol_version = S2N_TLS13;
@@ -199,7 +199,7 @@ int main(int argc, char **argv)
                 conn->security_policy_override = &test_security_policy;
 
                 const struct s2n_kem_preferences *kem_pref = NULL;
-                GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+                POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
                 EXPECT_NOT_NULL(kem_pref);
 
                 conn->secure.server_kem_group_params.kem_group = kem_pref->tls13_kem_groups[0];
@@ -217,7 +217,7 @@ int main(int argc, char **argv)
                     conn->security_policy_override = &test_security_policy;
 
                     const struct s2n_kem_preferences *kem_pref = NULL;
-                    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+                    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
                     EXPECT_NOT_NULL(kem_pref);
 
                     conn->secure.server_kem_group_params.kem_group = kem_pref->tls13_kem_groups[0];
@@ -386,12 +386,12 @@ int main(int argc, char **argv)
         /* Obtain the transcript hash recreated within the HelloRetryRequest message */
         struct s2n_hash_state server_hash, server_hash_state;
         uint8_t server_digest_out[S2N_MAX_DIGEST_LEN];
-        GUARD(s2n_handshake_get_hash_state(server_conn, server_keys.hash_algorithm, &server_hash_state));
+        POSIX_GUARD(s2n_handshake_get_hash_state(server_conn, server_keys.hash_algorithm, &server_hash_state));
 
-        GUARD(s2n_hash_new(&server_hash));
-        GUARD(s2n_hash_copy(&server_hash, &server_hash_state));
-        GUARD(s2n_hash_digest(&server_hash, server_digest_out, hash_digest_length));
-        GUARD(s2n_hash_free(&server_hash));
+        POSIX_GUARD(s2n_hash_new(&server_hash));
+        POSIX_GUARD(s2n_hash_copy(&server_hash, &server_hash_state));
+        POSIX_GUARD(s2n_hash_digest(&server_hash, server_digest_out, hash_digest_length));
+        POSIX_GUARD(s2n_hash_free(&server_hash));
 
         struct s2n_blob server_blob;
         EXPECT_SUCCESS(s2n_blob_init(&server_blob, server_digest_out, hash_digest_length));
@@ -410,12 +410,12 @@ int main(int argc, char **argv)
         /* Obtain the transcript hash recreated within ClientHello2 message */
         struct s2n_hash_state client_hash, client_hash_state;
         uint8_t client_digest_out[S2N_MAX_DIGEST_LEN];
-        GUARD(s2n_handshake_get_hash_state(client_conn, client_keys.hash_algorithm, &client_hash_state));
+        POSIX_GUARD(s2n_handshake_get_hash_state(client_conn, client_keys.hash_algorithm, &client_hash_state));
 
-        GUARD(s2n_hash_new(&client_hash));
-        GUARD(s2n_hash_copy(&client_hash, &client_hash_state));
-        GUARD(s2n_hash_digest(&client_hash, client_digest_out, hash_digest_length));
-        GUARD(s2n_hash_free(&client_hash));
+        POSIX_GUARD(s2n_hash_new(&client_hash));
+        POSIX_GUARD(s2n_hash_copy(&client_hash, &client_hash_state));
+        POSIX_GUARD(s2n_hash_digest(&client_hash, client_digest_out, hash_digest_length));
+        POSIX_GUARD(s2n_hash_free(&client_hash));
 
         struct s2n_blob client_blob;
         EXPECT_SUCCESS(s2n_blob_init(&client_blob, client_digest_out, hash_digest_length));

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -442,7 +442,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default"));
 
             const struct s2n_security_policy *security_policy;
-            GUARD(s2n_connection_get_security_policy(conn, &security_policy));
+            POSIX_GUARD(s2n_connection_get_security_policy(conn, &security_policy));
             EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
 
             EXPECT_SUCCESS(s2n_client_hello_send(conn));
@@ -463,7 +463,7 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all"));
 
-            GUARD(s2n_connection_get_security_policy(client_conn, &security_policy));
+            POSIX_GUARD(s2n_connection_get_security_policy(client_conn, &security_policy));
             EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
 
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
@@ -481,7 +481,7 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "test_all_tls12"));
 
-            GUARD(s2n_connection_get_security_policy(server_conn, &security_policy));
+            POSIX_GUARD(s2n_connection_get_security_policy(server_conn, &security_policy));
             EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
 
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io, s2n_stuffer_data_available(&client_conn->handshake.io)));
@@ -744,7 +744,7 @@ int main(int argc, char **argv)
         /* Verify the collected client hello matches what was sent except for the zero-ed client random */
         EXPECT_NOT_NULL(expected_client_hello = malloc(sent_client_hello_len));
         EXPECT_MEMCPY_SUCCESS(expected_client_hello, sent_client_hello, sent_client_hello_len);
-        memset_check(expected_client_hello + client_random_offset, 0, S2N_TLS_RANDOM_DATA_LEN);
+        POSIX_CHECKED_MEMSET(expected_client_hello + client_random_offset, 0, S2N_TLS_RANDOM_DATA_LEN);
         EXPECT_SUCCESS(memcmp(collected_client_hello, expected_client_hello, sent_client_hello_len));
 
         /* Verify s2n_client_hello_get_raw_message_length correct */

--- a/tests/unit/s2n_client_key_share_extension_pq_test.c
+++ b/tests/unit/s2n_client_key_share_extension_pq_test.c
@@ -1038,45 +1038,45 @@ int main() {
  * pointing to the beginning of the hybrid share. After copying, rewinds *from so
  * that read cursor is at the original position. */
 static int s2n_copy_pq_share(struct s2n_stuffer *from, struct s2n_blob *to, const struct s2n_kem_group *kem_group) {
-    notnull_check(from);
-    notnull_check(to);
-    notnull_check(kem_group);
+    POSIX_ENSURE_REF(from);
+    POSIX_ENSURE_REF(to);
+    POSIX_ENSURE_REF(kem_group);
 
-    GUARD(s2n_alloc(to, kem_group->kem->public_key_length));
+    POSIX_GUARD(s2n_alloc(to, kem_group->kem->public_key_length));
     /* Skip all the two-byte IDs/sizes and the ECC portion of the share */
-    GUARD(s2n_stuffer_skip_read(from, 10 + kem_group->curve->share_size));
-    GUARD(s2n_stuffer_read(from, to));
-    GUARD(s2n_stuffer_rewind_read(from, 10 + kem_group->curve->share_size + kem_group->kem->public_key_length));
+    POSIX_GUARD(s2n_stuffer_skip_read(from, 10 + kem_group->curve->share_size));
+    POSIX_GUARD(s2n_stuffer_read(from, to));
+    POSIX_GUARD(s2n_stuffer_rewind_read(from, 10 + kem_group->curve->share_size + kem_group->kem->public_key_length));
 
     return S2N_SUCCESS;
 }
 
 static int s2n_generate_pq_hybrid_key_share_for_test(struct s2n_stuffer *out, struct s2n_kem_group_params *kem_group_params) {
-    notnull_check(out);
-    notnull_check(kem_group_params);
+    POSIX_ENSURE_REF(out);
+    POSIX_ENSURE_REF(kem_group_params);
 
     /* This function should never be called when PQ is disabled */
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
     const struct s2n_kem_group *kem_group = kem_group_params->kem_group;
-    notnull_check(kem_group);
+    POSIX_ENSURE_REF(kem_group);
 
-    GUARD(s2n_stuffer_write_uint16(out, kem_group->iana_id));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, kem_group->iana_id));
 
     struct s2n_stuffer_reservation total_share_size = {0};
-    GUARD(s2n_stuffer_reserve_uint16(out, &total_share_size));
+    POSIX_GUARD(s2n_stuffer_reserve_uint16(out, &total_share_size));
 
     struct s2n_ecc_evp_params *ecc_params = &kem_group_params->ecc_params;
     ecc_params->negotiated_curve = kem_group->curve;
-    GUARD(s2n_stuffer_write_uint16(out, ecc_params->negotiated_curve->share_size));
-    GUARD(s2n_ecc_evp_generate_ephemeral_key(ecc_params));
-    GUARD(s2n_ecc_evp_write_params_point(ecc_params, out));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, ecc_params->negotiated_curve->share_size));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(ecc_params));
+    POSIX_GUARD(s2n_ecc_evp_write_params_point(ecc_params, out));
 
     struct s2n_kem_params *kem_params = &kem_group_params->kem_params;
     kem_params->kem = kem_group->kem;
-    GUARD(s2n_kem_send_public_key(out, kem_params));
+    POSIX_GUARD(s2n_kem_send_public_key(out, kem_params));
 
-    GUARD(s2n_stuffer_write_vector_size(&total_share_size));
+    POSIX_GUARD(s2n_stuffer_write_vector_size(&total_share_size));
 
     return S2N_SUCCESS;
 }

--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -448,7 +448,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(ecc_preferences);
 
             /* Setup the client to have received a HelloRetryRequest */
-            memcpy_check(client_conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
+            POSIX_CHECKED_MEMCPY(client_conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(client_conn, S2N_TLS13));
             EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(client_conn));
             client_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
@@ -919,12 +919,12 @@ int main(int argc, char **argv)
 
 static int s2n_test_rewrite_length(struct s2n_stuffer *stuffer)
 {
-    notnull_check(stuffer);
+    POSIX_ENSURE_REF(stuffer);
 
     int length = s2n_stuffer_data_available(stuffer) - S2N_SIZE_OF_CLIENT_SHARE_SIZE;
-    GUARD(s2n_stuffer_rewrite(stuffer));
-    GUARD(s2n_stuffer_write_uint16(stuffer, length));
-    GUARD(s2n_stuffer_skip_write(stuffer, length));
+    POSIX_GUARD(s2n_stuffer_rewrite(stuffer));
+    POSIX_GUARD(s2n_stuffer_write_uint16(stuffer, length));
+    POSIX_GUARD(s2n_stuffer_skip_write(stuffer, length));
     return 0;
 }
 
@@ -938,8 +938,8 @@ static int s2n_write_key_share(struct s2n_stuffer *out,
         uint16_t iana_value, uint16_t share_size,
         const struct s2n_ecc_named_curve *existing_curve)
 {
-    notnull_check(out);
-    notnull_check(existing_curve);
+    POSIX_ENSURE_REF(out);
+    POSIX_ENSURE_REF(existing_curve);
 
     struct s2n_ecc_evp_params ecc_evp_params;
     const struct s2n_ecc_named_curve test_curve = {
@@ -953,10 +953,10 @@ static int s2n_write_key_share(struct s2n_stuffer *out,
     ecc_evp_params.negotiated_curve = &test_curve;
     ecc_evp_params.evp_pkey = NULL;
     if (s2n_ecdhe_parameters_send(&ecc_evp_params, out) < 0) {
-        GUARD(s2n_ecc_evp_params_free(&ecc_evp_params));
+        POSIX_GUARD(s2n_ecc_evp_params_free(&ecc_evp_params));
         return 1; 
     }
 
-    GUARD(s2n_ecc_evp_params_free(&ecc_evp_params));
+    POSIX_GUARD(s2n_ecc_evp_params_free(&ecc_evp_params));
     return 0;
 }

--- a/tests/unit/s2n_client_pq_kem_extension_test.c
+++ b/tests/unit/s2n_client_pq_kem_extension_test.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
             /* Should write ids */
             uint16_t actual_id;
             for (size_t i = 0; i < kem_preferences->kem_count; i++) {
-                GUARD(s2n_stuffer_read_uint16(&stuffer, &actual_id));
+                POSIX_GUARD(s2n_stuffer_read_uint16(&stuffer, &actual_id));
                 EXPECT_EQUAL(actual_id, kem_preferences->kems[i]->kem_extension_id);
             }
 

--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -43,14 +43,14 @@ static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn,
 static int s2n_test_error_select_psk_identity_callback(struct s2n_connection *conn,
         struct s2n_offered_psk_list *psk_identity_list, uint16_t *chosen_wire_index)
 {
-    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+    POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);
 }
 
 static S2N_RESULT s2n_write_test_identity(struct s2n_stuffer *out, struct s2n_blob *identity)
 {
-    GUARD_AS_RESULT(s2n_stuffer_write_uint16(out, identity->size));
-    GUARD_AS_RESULT(s2n_stuffer_write(out, identity));
-    GUARD_AS_RESULT(s2n_stuffer_write_uint32(out, 0));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint16(out, identity->size));
+    RESULT_GUARD_POSIX(s2n_stuffer_write(out, identity));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint32(out, 0));
     return S2N_RESULT_OK;
 }
 

--- a/tests/unit/s2n_client_signature_algorithms_extension_test.c
+++ b/tests/unit/s2n_client_signature_algorithms_extension_test.c
@@ -85,9 +85,9 @@ int main(int argc, char **argv)
 
         struct s2n_stuffer signature_algorithms_extension;
         EXPECT_SUCCESS(s2n_stuffer_alloc(&signature_algorithms_extension, 2 + (sig_hash_algs.len * 2)));
-        GUARD(s2n_stuffer_write_uint16(&signature_algorithms_extension, sig_hash_algs.len * 2));
+        POSIX_GUARD(s2n_stuffer_write_uint16(&signature_algorithms_extension, sig_hash_algs.len * 2));
         for (int i = 0; i < sig_hash_algs.len; i++) {
-            GUARD(s2n_stuffer_write_uint16(&signature_algorithms_extension, sig_hash_algs.iana_list[i]));
+            POSIX_GUARD(s2n_stuffer_write_uint16(&signature_algorithms_extension, sig_hash_algs.iana_list[i]));
         }
 
         /* If only unknown algorithms are offered, expect choosing a scheme to fail for TLS1.3 */
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
         };
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-        GUARD(s2n_connection_set_config(conn, config));
+        POSIX_GUARD(s2n_connection_set_config(conn, config));
 
         struct s2n_stuffer signature_algorithms_extension;
         EXPECT_SUCCESS(s2n_stuffer_alloc(&signature_algorithms_extension, 2 + (sig_hash_algs.len * 2)));

--- a/tests/unit/s2n_client_supported_groups_extension_test.c
+++ b/tests/unit/s2n_client_supported_groups_extension_test.c
@@ -399,7 +399,7 @@ int main()
             EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, 100));
             EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, 101));
             EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, 102));
-            GUARD(s2n_stuffer_write_vector_size(&group_list_len));
+            POSIX_GUARD(s2n_stuffer_write_vector_size(&group_list_len));
 
             EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
             EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
@@ -445,7 +445,7 @@ int main()
             EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &group_list_len));
             EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, client_kem_pref->tls13_kem_groups[0]->iana_id));
             EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, client_ecc_pref->ecc_curves[0]->iana_id));
-            GUARD(s2n_stuffer_write_vector_size(&group_list_len));
+            POSIX_GUARD(s2n_stuffer_write_vector_size(&group_list_len));
 
             EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
             EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
@@ -491,7 +491,7 @@ int main()
                 EXPECT_SUCCESS(s2n_stuffer_reserve_uint16(&stuffer, &group_list_len));
                 EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, client_kem_pref->tls13_kem_groups[0]->iana_id));
                 EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, client_ecc_pref->ecc_curves[0]->iana_id));
-                GUARD(s2n_stuffer_write_vector_size(&group_list_len));
+                POSIX_GUARD(s2n_stuffer_write_vector_size(&group_list_len));
 
                 EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
                 EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
@@ -601,9 +601,9 @@ int main()
 
         struct s2n_stuffer supported_groups_extension;
         EXPECT_SUCCESS(s2n_stuffer_alloc(&supported_groups_extension, 2 + ec_curves_count * 2));
-        GUARD(s2n_stuffer_write_uint16(&supported_groups_extension, ec_curves_count * 2));
+        POSIX_GUARD(s2n_stuffer_write_uint16(&supported_groups_extension, ec_curves_count * 2));
         for (int i = 0; i < ec_curves_count; i++) {
-            GUARD(s2n_stuffer_write_uint16(&supported_groups_extension, unsupported_curves[i].iana_id));
+            POSIX_GUARD(s2n_stuffer_write_uint16(&supported_groups_extension, unsupported_curves[i].iana_id));
         }
 
         /* Force a bad value for the negotiated curve so we know extension was parsed and the curve was set to NULL */

--- a/tests/unit/s2n_client_supported_versions_extension_test.c
+++ b/tests/unit/s2n_client_supported_versions_extension_test.c
@@ -32,16 +32,16 @@
 
 int get_alert(struct s2n_connection *conn) {
     uint8_t error[2];
-    GUARD(s2n_stuffer_read_bytes(&conn->reader_alert_out, error, 2));
+    POSIX_GUARD(s2n_stuffer_read_bytes(&conn->reader_alert_out, error, 2));
     return error[1];
 }
 
 int write_test_supported_versions_list(struct s2n_stuffer *list, uint8_t *supported_versions, uint8_t length) {
-    GUARD(s2n_stuffer_write_uint8(list, length * S2N_TLS_PROTOCOL_VERSION_LEN));
+    POSIX_GUARD(s2n_stuffer_write_uint8(list, length * S2N_TLS_PROTOCOL_VERSION_LEN));
 
     for (int i = 0; i < length; i++) {
-        GUARD(s2n_stuffer_write_uint8(list, supported_versions[i] / 10));
-        GUARD(s2n_stuffer_write_uint8(list, supported_versions[i] % 10));
+        POSIX_GUARD(s2n_stuffer_write_uint8(list, supported_versions[i] / 10));
+        POSIX_GUARD(s2n_stuffer_write_uint8(list, supported_versions[i] % 10));
     }
 
     return 0;
@@ -156,10 +156,10 @@ int main(int argc, char **argv)
         struct s2n_stuffer extension;
         s2n_stuffer_alloc(&extension, invalid_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN + 1);
 
-        GUARD(s2n_stuffer_write_uint8(&extension, invalid_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN));
+        POSIX_GUARD(s2n_stuffer_write_uint8(&extension, invalid_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN));
 
         for (int i = 0; i < invalid_version_list_length; i++) {
-            GUARD(s2n_stuffer_write_uint16(&extension, invalid_version_list[i]));
+            POSIX_GUARD(s2n_stuffer_write_uint16(&extension, invalid_version_list[i]));
         }
 
         EXPECT_FAILURE_WITH_ERRNO(s2n_client_supported_versions_extension.recv(server_conn, &extension), S2N_ERR_BAD_MESSAGE);
@@ -180,10 +180,10 @@ int main(int argc, char **argv)
         struct s2n_stuffer extension;
         s2n_stuffer_alloc(&extension, grease_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN + 1);
 
-        GUARD(s2n_stuffer_write_uint8(&extension, grease_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN));
+        POSIX_GUARD(s2n_stuffer_write_uint8(&extension, grease_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN));
 
         for (int i = 0; i < grease_version_list_length; i++) {
-            GUARD(s2n_stuffer_write_uint16(&extension, grease_version_list[i]));
+            POSIX_GUARD(s2n_stuffer_write_uint16(&extension, grease_version_list[i]));
         }
 
         EXPECT_SUCCESS(s2n_client_supported_versions_extension.recv(server_conn, &extension));
@@ -207,10 +207,10 @@ int main(int argc, char **argv)
         struct s2n_stuffer extension;
         s2n_stuffer_alloc(&extension, invalid_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN + 1);
 
-        GUARD(s2n_stuffer_write_uint8(&extension, invalid_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN));
+        POSIX_GUARD(s2n_stuffer_write_uint8(&extension, invalid_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN));
 
         for (int i = 0; i < invalid_version_list_length; i++) {
-            GUARD(s2n_stuffer_write_uint16(&extension, invalid_version_list[i]));
+            POSIX_GUARD(s2n_stuffer_write_uint16(&extension, invalid_version_list[i]));
         }
 
         EXPECT_SUCCESS(s2n_client_supported_versions_extension.recv(server_conn, &extension));

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -263,7 +263,7 @@ int nist_fake_128_entropy_data(void *data, uint32_t size)
 {
     struct s2n_blob blob = {.data = data, .size = size};
 
-    GUARD(s2n_stuffer_read(&nist_aes128_reference_entropy, &blob));
+    POSIX_GUARD(s2n_stuffer_read(&nist_aes128_reference_entropy, &blob));
 
     return 0;
 }
@@ -272,7 +272,7 @@ int nist_fake_256_entropy_data(void *data, uint32_t size)
 {
     struct s2n_blob blob = {.data = data, .size = size};
 
-    GUARD(s2n_stuffer_read(&nist_aes256_reference_entropy, &blob));
+    POSIX_GUARD(s2n_stuffer_read(&nist_aes256_reference_entropy, &blob));
 
     return 0;
 }
@@ -283,9 +283,9 @@ int check_drgb_version(s2n_drbg_mode mode, int (*generator)(void *, uint32_t), i
     DEFER_CLEANUP(struct s2n_stuffer personalization = {0}, s2n_stuffer_free);
     DEFER_CLEANUP(struct s2n_stuffer returned_bits = {0}, s2n_stuffer_free);
     DEFER_CLEANUP(struct s2n_stuffer reference_values = {0}, s2n_stuffer_free);
-    GUARD(s2n_stuffer_alloc_ro_from_hex_string(&personalization, personalization_hex));
-    GUARD(s2n_stuffer_alloc_ro_from_hex_string(&returned_bits, returned_bits_hex));
-    GUARD(s2n_stuffer_alloc_ro_from_hex_string(&reference_values, reference_values_hex));
+    POSIX_GUARD(s2n_stuffer_alloc_ro_from_hex_string(&personalization, personalization_hex));
+    POSIX_GUARD(s2n_stuffer_alloc_ro_from_hex_string(&returned_bits, returned_bits_hex));
+    POSIX_GUARD(s2n_stuffer_alloc_ro_from_hex_string(&reference_values, reference_values_hex));
 
     for (int i = 0; i < 14; i++) {
         uint8_t ps[S2N_DRBG_MAX_SEED_SIZE] = {0};
@@ -293,45 +293,45 @@ int check_drgb_version(s2n_drbg_mode mode, int (*generator)(void *, uint32_t), i
         struct s2n_blob personalization_string = {.data = ps, .size = personalization_size};
 
         /* Read the next personalization string */
-        GUARD(s2n_stuffer_read(&personalization, &personalization_string));
+        POSIX_GUARD(s2n_stuffer_read(&personalization, &personalization_string));
 
         /* Over-ride the entropy sources */
-        GUARD(s2n_rand_set_callbacks(nist_fake_entropy_init_cleanup, nist_fake_entropy_init_cleanup, generator, generator));
+        POSIX_GUARD(s2n_rand_set_callbacks(nist_fake_entropy_init_cleanup, nist_fake_entropy_init_cleanup, generator, generator));
 
         /* Instantiate the DRBG */
-        GUARD(s2n_drbg_instantiate(&nist_drbg, &personalization_string, mode));
+        POSIX_GUARD(s2n_drbg_instantiate(&nist_drbg, &personalization_string, mode));
 
         uint8_t nist_v[16];
 
-        GUARD(s2n_stuffer_read_bytes(&reference_values, nist_v, sizeof(nist_v)));
-        eq_check(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)), 0);
+        POSIX_GUARD(s2n_stuffer_read_bytes(&reference_values, nist_v, sizeof(nist_v)));
+        POSIX_ENSURE_EQ(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)), 0);
 
         /* Generate 512 bits (FIRST CALL) */
         uint8_t out[64];
         struct s2n_blob generated = {.data = out, .size = 64 };
-        GUARD(s2n_drbg_generate(&nist_drbg, &generated));
+        POSIX_GUARD(s2n_drbg_generate(&nist_drbg, &generated));
 
-        GUARD(s2n_stuffer_read_bytes(&reference_values, nist_v, sizeof(nist_v)));
-        eq_check(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)), 0);
+        POSIX_GUARD(s2n_stuffer_read_bytes(&reference_values, nist_v, sizeof(nist_v)));
+        POSIX_ENSURE_EQ(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)), 0);
 
         /* Generate another 512 bits (SECOND CALL) */
-        GUARD(s2n_drbg_generate(&nist_drbg, &generated));
+        POSIX_GUARD(s2n_drbg_generate(&nist_drbg, &generated));
 
-        GUARD(s2n_stuffer_read_bytes(&reference_values, nist_v, sizeof(nist_v)));
-        eq_check(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)), 0);
+        POSIX_GUARD(s2n_stuffer_read_bytes(&reference_values, nist_v, sizeof(nist_v)));
+        POSIX_ENSURE_EQ(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)), 0);
 
         uint8_t nist_returned_bits[64];
-        GUARD(s2n_stuffer_read_bytes(&returned_bits, nist_returned_bits,
+        POSIX_GUARD(s2n_stuffer_read_bytes(&returned_bits, nist_returned_bits,
                                      sizeof(nist_returned_bits)));
-        eq_check(memcmp(nist_returned_bits, out, sizeof(nist_returned_bits)), 0);
+        POSIX_ENSURE_EQ(memcmp(nist_returned_bits, out, sizeof(nist_returned_bits)), 0);
 
         if (mode == S2N_AES_128_CTR_NO_DF_PR || mode == S2N_AES_256_CTR_NO_DF_PR){
-            eq_check(nist_drbg.mixes, 2);
+            POSIX_ENSURE_EQ(nist_drbg.mixes, 2);
         } else {
-            S2N_ERROR(S2N_ERR_DRBG);
+            POSIX_BAIL(S2N_ERR_DRBG);
         }
 
-        GUARD(s2n_drbg_wipe(&nist_drbg));
+        POSIX_GUARD(s2n_drbg_wipe(&nist_drbg));
     }
     return 0;
 }
@@ -378,7 +378,7 @@ int main(int argc, char **argv)
      * a common error is to incorrectly fill the last (not-aligned) bytes. Sometimes
      * they are left unchanged and sometimes a single byte is copied in. We ensure
      * that the last 15 bytes are not all equal to guard against this. */
-    memset_check((void*)data, 0, 31);
+    POSIX_CHECKED_MEMSET((void*)data, 0, 31);
     blob.size = 31;
     EXPECT_SUCCESS(s2n_drbg_generate(&aes128_drbg, &blob));
     bool bytes_are_all_equal = true;
@@ -390,7 +390,7 @@ int main(int argc, char **argv)
     }
     EXPECT_FALSE(bytes_are_all_equal);
 
-    memset_check((void*)data, 0, 31);
+    POSIX_CHECKED_MEMSET((void*)data, 0, 31);
     blob.size = 31;
     EXPECT_SUCCESS(s2n_drbg_generate(&aes256_pr_drbg, &blob));
     bytes_are_all_equal = true;

--- a/tests/unit/s2n_early_data_test.c
+++ b/tests/unit/s2n_early_data_test.c
@@ -56,10 +56,10 @@ static S2N_RESULT s2n_test_all_early_data_sequences(struct s2n_connection *conn,
             }
         }
 
-        ENSURE_EQ(actual_valid, expected_valid);
+        RESULT_ENSURE_EQ(actual_valid, expected_valid);
 
         if (expected_valid) {
-            GUARD_RESULT(s2n_test_all_early_data_sequences(conn, i + 1,
+            RESULT_GUARD(s2n_test_all_early_data_sequences(conn, i + 1,
                     valid_early_state_sequences, valid_early_state_sequences_len));
         }
     }
@@ -68,19 +68,19 @@ static S2N_RESULT s2n_test_all_early_data_sequences(struct s2n_connection *conn,
 
 static S2N_RESULT s2n_alloc_test_config_buffers(struct s2n_early_data_config *config)
 {
-    GUARD_AS_RESULT(s2n_alloc(&config->application_protocol, TEST_SIZE));
-    ENSURE_NE(config->application_protocol.size, 0);
-    GUARD_AS_RESULT(s2n_alloc(&config->context, TEST_SIZE));
-    ENSURE_NE(config->context.size, 0);
+    RESULT_GUARD_POSIX(s2n_alloc(&config->application_protocol, TEST_SIZE));
+    RESULT_ENSURE_NE(config->application_protocol.size, 0);
+    RESULT_GUARD_POSIX(s2n_alloc(&config->context, TEST_SIZE));
+    RESULT_ENSURE_NE(config->context.size, 0);
     return S2N_RESULT_OK;
 }
 
 static S2N_RESULT s2n_test_config_buffers_freed(struct s2n_early_data_config *config)
 {
-    ENSURE_EQ(config->application_protocol.data, NULL);
-    ENSURE_EQ(config->application_protocol.size, 0);
-    ENSURE_EQ(config->context.data, NULL);
-    ENSURE_EQ(config->context.size, 0);
+    RESULT_ENSURE_EQ(config->application_protocol.data, NULL);
+    RESULT_ENSURE_EQ(config->application_protocol.size, 0);
+    RESULT_ENSURE_EQ(config->context.data, NULL);
+    RESULT_ENSURE_EQ(config->context.size, 0);
     return S2N_RESULT_OK;
 }
 

--- a/tests/unit/s2n_extension_list_process_test.c
+++ b/tests/unit/s2n_extension_list_process_test.c
@@ -34,9 +34,9 @@ static int s2n_setup_test_parsed_extension(const s2n_extension_type *extension_t
 {
     parsed_extension->extension_type = extension_type->iana_value;
 
-    GUARD(extension_type->send(conn, stuffer));
+    POSIX_GUARD(extension_type->send(conn, stuffer));
     uint16_t extension_size = s2n_stuffer_data_available(stuffer);
-    GUARD(s2n_blob_init(&parsed_extension->extension, s2n_stuffer_raw_read(stuffer, extension_size), extension_size));
+    POSIX_GUARD(s2n_blob_init(&parsed_extension->extension, s2n_stuffer_raw_read(stuffer, extension_size), extension_size));
 
     return S2N_SUCCESS;
 }

--- a/tests/unit/s2n_extensions_server_key_share_select_test.c
+++ b/tests/unit/s2n_extensions_server_key_share_select_test.c
@@ -237,7 +237,7 @@ int main() {
             client_params0->ecc_params.negotiated_curve = kem_group0->curve;
             /* The PQ public key is fake; that's good enough for this test */
             EXPECT_SUCCESS(s2n_alloc(&client_params0->kem_params.public_key, kem_group0->kem->public_key_length));
-            memset_check(client_params0->kem_params.public_key.data, 1, kem_group0->kem->public_key_length);
+            POSIX_CHECKED_MEMSET(client_params0->kem_params.public_key.data, 1, kem_group0->kem->public_key_length);
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params0->ecc_params));
 
             EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn),
@@ -333,7 +333,7 @@ int main() {
             client_params1->ecc_params.negotiated_curve = kem_group1->curve;
             EXPECT_SUCCESS(s2n_alloc(&client_params1->kem_params.public_key, kem_group1->kem->public_key_length));
             /* The PQ public key is fake; that's good enough for this test */
-            memset_check(client_params1->kem_params.public_key.data, 1, kem_group1->kem->public_key_length);
+            POSIX_CHECKED_MEMSET(client_params1->kem_params.public_key.data, 1, kem_group1->kem->public_key_length);
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params1->ecc_params));
 
             EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
@@ -381,7 +381,7 @@ int main() {
                 client_params->ecc_params.negotiated_curve = kem_group->curve;
                 EXPECT_SUCCESS(s2n_alloc(&client_params->kem_params.public_key, kem_group->kem->public_key_length));
                 /* The PQ public key is fake; that's good enough for this test */
-                memset_check(client_params->kem_params.public_key.data, 1, kem_group->kem->public_key_length);
+                POSIX_CHECKED_MEMSET(client_params->kem_params.public_key.data, 1, kem_group->kem->public_key_length);
                 EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params->ecc_params));
             }
 
@@ -488,7 +488,7 @@ int main() {
                 client_params->ecc_params.negotiated_curve = kem_group->curve;
                 EXPECT_SUCCESS(s2n_alloc(&client_params->kem_params.public_key, kem_group->kem->public_key_length));
                 /* The PQ public key is fake; that's good enough for this test */
-                memset_check(client_params->kem_params.public_key.data, 1, kem_group->kem->public_key_length);
+                POSIX_CHECKED_MEMSET(client_params->kem_params.public_key.data, 1, kem_group->kem->public_key_length);
                 EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params->ecc_params));
             }
             for (size_t i = 0; i < ecc_pref->count; i++) {

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -120,7 +120,7 @@ static int try_handshake(struct s2n_connection *server_conn, struct s2n_connecti
         EXPECT_NOT_EQUAL(++tries, 5);
     } while (client_blocked || server_blocked);
 
-    GUARD(s2n_shutdown_test_server_and_client(server_conn, client_conn));
+    POSIX_GUARD(s2n_shutdown_test_server_and_client(server_conn, client_conn));
     return S2N_SUCCESS;
 }
 
@@ -185,7 +185,7 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
         async_pkey_op_performed = 0;
 
         if (!expect_failure) {
-            GUARD(try_handshake(server_conn, client_conn));
+            POSIX_GUARD(try_handshake(server_conn, client_conn));
 
             EXPECT_STRING_EQUAL(s2n_connection_get_cipher(server_conn), expected_cipher->name);
 
@@ -209,7 +209,7 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
                 EXPECT_EQUAL(async_pkey_op_performed, 0);
             }
         } else {
-            eq_check(try_handshake(server_conn, client_conn), -1);
+            POSIX_ENSURE_EQ(try_handshake(server_conn, client_conn), -1);
             EXPECT_STRING_NOT_EQUAL(s2n_connection_get_last_message_name(server_conn), "APPLICATION_DATA");
             EXPECT_STRING_NOT_EQUAL(s2n_connection_get_last_message_name(client_conn), "APPLICATION_DATA");
             EXPECT_EQUAL(async_pkey_op_called, 0);

--- a/tests/unit/s2n_hash_test.c
+++ b/tests/unit/s2n_hash_test.c
@@ -39,17 +39,17 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13());
 
-    GUARD(s2n_hash_new(&hash));
+    POSIX_GUARD(s2n_hash_new(&hash));
     EXPECT_FALSE(s2n_hash_is_ready_for_input(&hash));
     EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
-    GUARD(s2n_hash_new(&copy));
+    POSIX_GUARD(s2n_hash_new(&copy));
     EXPECT_FALSE(s2n_hash_is_ready_for_input(&copy));
     EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&copy, &bytes_in_hash));
 
     if (s2n_hash_is_available(S2N_HASH_MD5)) {
         /* Try MD5 */
         uint8_t md5_digest_size;
-        GUARD(s2n_hash_digest_size(S2N_HASH_MD5, &md5_digest_size));
+        POSIX_GUARD(s2n_hash_digest_size(S2N_HASH_MD5, &md5_digest_size));
         EXPECT_EQUAL(md5_digest_size, 16);
         EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_MD5));
         EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
         /* Reference value from command line md5sum */
         EXPECT_EQUAL(memcmp(output_pad, "59ca0efa9f5633cb0371bbc0355478d8", 16 * 2), 0);
 
-        GUARD(s2n_hash_reset(&hash));
+        POSIX_GUARD(s2n_hash_reset(&hash));
         EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
         EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
         EXPECT_EQUAL(bytes_in_hash, 0);
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
 
     /* Try SHA1 */
     uint8_t sha1_digest_size;
-    GUARD(s2n_hash_digest_size(S2N_HASH_SHA1, &sha1_digest_size));
+    POSIX_GUARD(s2n_hash_digest_size(S2N_HASH_SHA1, &sha1_digest_size));
     EXPECT_EQUAL(sha1_digest_size, 20);
     EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_SHA1));
     EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
@@ -192,7 +192,7 @@ int main(int argc, char **argv)
     /* Reference value from command line sha1sum */
     EXPECT_EQUAL(memcmp(output_pad, "4afd618f797f0c6bd85b2035338bb26c62ab0dbc", 20 * 2), 0);
 
-    GUARD(s2n_hash_reset(&hash));
+    POSIX_GUARD(s2n_hash_reset(&hash));
     EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
     EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
     EXPECT_EQUAL(bytes_in_hash, 0);
@@ -200,7 +200,7 @@ int main(int argc, char **argv)
 
     /* Try SHA224 and test s2n_hash_free */
     uint8_t sha224_digest_size;
-    GUARD(s2n_hash_digest_size(S2N_HASH_SHA224, &sha224_digest_size));
+    POSIX_GUARD(s2n_hash_digest_size(S2N_HASH_SHA224, &sha224_digest_size));
     EXPECT_EQUAL(sha224_digest_size, 28);
     EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_SHA224));
     EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
@@ -229,12 +229,12 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(memcmp(output_pad, "f771a839cff678857feee21492184ca7a456ac3cf57e78057b7beaf5", 28 * 2), 0);
 
     /* Try SHA256 using a freed hash state */
-    GUARD(s2n_hash_new(&hash));
+    POSIX_GUARD(s2n_hash_new(&hash));
     EXPECT_FALSE(s2n_hash_is_ready_for_input(&hash));
     EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
 
     uint8_t sha256_digest_size;
-    GUARD(s2n_hash_digest_size(S2N_HASH_SHA256, &sha256_digest_size));
+    POSIX_GUARD(s2n_hash_digest_size(S2N_HASH_SHA256, &sha256_digest_size));
     EXPECT_EQUAL(sha256_digest_size, 32);
     EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_SHA256));
     EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
@@ -258,7 +258,7 @@ int main(int argc, char **argv)
     /* Reference value from command line sha256sum */
     EXPECT_EQUAL(memcmp(output_pad, "0ba904eae8773b70c75333db4de2f3ac45a8ad4ddba1b242f0b3cfc199391dd8", 32 * 2), 0);
 
-    GUARD(s2n_hash_reset(&hash));
+    POSIX_GUARD(s2n_hash_reset(&hash));
     EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
     EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
     EXPECT_EQUAL(bytes_in_hash, 0);
@@ -266,7 +266,7 @@ int main(int argc, char **argv)
 
     /* Try SHA384 */
     uint8_t sha384_digest_size;
-    GUARD(s2n_hash_digest_size(S2N_HASH_SHA384, &sha384_digest_size));
+    POSIX_GUARD(s2n_hash_digest_size(S2N_HASH_SHA384, &sha384_digest_size));
     EXPECT_EQUAL(sha384_digest_size, 48);
     EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_SHA384));
     EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
@@ -290,7 +290,7 @@ int main(int argc, char **argv)
     /* Reference value from command line sha384sum */
     EXPECT_EQUAL(memcmp(output_pad, "f7f8f1b9d5a9a61742eeda26c20990282ac08dabda14e70376fcb4c8b46198a9959ea9d7d194b38520eed5397ffe6d8e", 48 * 2), 0);
 
-    GUARD(s2n_hash_reset(&hash));
+    POSIX_GUARD(s2n_hash_reset(&hash));
     EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));
     EXPECT_SUCCESS(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
     EXPECT_EQUAL(bytes_in_hash, 0);
@@ -298,7 +298,7 @@ int main(int argc, char **argv)
 
     /* Try SHA512 */
     uint8_t sha512_digest_size;
-    GUARD(s2n_hash_digest_size(S2N_HASH_SHA512, &sha512_digest_size));
+    POSIX_GUARD(s2n_hash_digest_size(S2N_HASH_SHA512, &sha512_digest_size));
     EXPECT_EQUAL(sha512_digest_size, 64);
     EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_SHA512));
     EXPECT_TRUE(s2n_hash_is_ready_for_input(&hash));

--- a/tests/unit/s2n_hmac_test.c
+++ b/tests/unit/s2n_hmac_test.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv)
     if (s2n_hmac_is_available(S2N_HMAC_SSLv3_MD5)) {
         /* Try SSLv3 MD5 */
         uint8_t hmac_sslv3_md5_size;
-        GUARD(s2n_hmac_digest_size(S2N_HMAC_SSLv3_MD5, &hmac_sslv3_md5_size));
+        POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_SSLv3_MD5, &hmac_sslv3_md5_size));
         EXPECT_EQUAL(hmac_sslv3_md5_size, 16);
         EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_SSLv3_MD5, sekrit, strlen((char *)sekrit)));
         EXPECT_SUCCESS(s2n_hmac_update(&hmac, hello, strlen((char *)hello)));
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
     if (s2n_hmac_is_available(S2N_HMAC_SSLv3_SHA1)) {
         /* Try SSLv3 SHA1 */
         uint8_t hmac_sslv3_sha1_size;
-        GUARD(s2n_hmac_digest_size(S2N_HMAC_SSLv3_SHA1, &hmac_sslv3_sha1_size));
+        POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_SSLv3_SHA1, &hmac_sslv3_sha1_size));
         EXPECT_EQUAL(hmac_sslv3_sha1_size, 20);
         EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_SSLv3_SHA1, sekrit, strlen((char *)sekrit)));
         EXPECT_SUCCESS(s2n_hmac_update(&hmac, hello, strlen((char *)hello)));
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
     if (s2n_hmac_is_available(S2N_HMAC_MD5)) {
         /* Try MD5 */
         uint8_t hmac_md5_size;
-        GUARD(s2n_hmac_digest_size(S2N_HMAC_MD5, &hmac_md5_size));
+        POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_MD5, &hmac_md5_size));
         EXPECT_EQUAL(hmac_md5_size, 16);
         EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_MD5, sekrit, strlen((char *)sekrit)));
         EXPECT_SUCCESS(s2n_hmac_update(&hmac, hello, strlen((char *)hello)));
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
 
     /* Try SHA1 */
     uint8_t hmac_sha1_size;
-    GUARD(s2n_hmac_digest_size(S2N_HMAC_SHA1, &hmac_sha1_size));
+    POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_SHA1, &hmac_sha1_size));
     EXPECT_EQUAL(hmac_sha1_size, 20);
     EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_SHA1, sekrit, strlen((char *)sekrit)));
     EXPECT_SUCCESS(s2n_hmac_update(&hmac, hello, strlen((char *)hello)));
@@ -215,7 +215,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_hmac_new(&hmac));
 
     uint8_t hmac_sha224_size;
-    GUARD(s2n_hmac_digest_size(S2N_HMAC_SHA224, &hmac_sha224_size));
+    POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_SHA224, &hmac_sha224_size));
     EXPECT_EQUAL(hmac_sha224_size, 28);
     EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_SHA224, sekrit, strlen((char *)sekrit)));
     EXPECT_SUCCESS(s2n_hmac_update(&hmac, hello, strlen((char *)hello)));
@@ -234,7 +234,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_hmac_new(&hmac));
 
     uint8_t hmac_sha256_size;
-    GUARD(s2n_hmac_digest_size(S2N_HMAC_SHA256, &hmac_sha256_size));
+    POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_SHA256, &hmac_sha256_size));
     EXPECT_EQUAL(hmac_sha256_size, 32);
     EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_SHA256, sekrit, strlen((char *)sekrit)));
     EXPECT_SUCCESS(s2n_hmac_update(&hmac, hello, strlen((char *)hello)));
@@ -253,7 +253,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_hmac_new(&hmac));
 
     uint8_t hmac_sha384_size;
-    GUARD(s2n_hmac_digest_size(S2N_HMAC_SHA384, &hmac_sha384_size));
+    POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_SHA384, &hmac_sha384_size));
     EXPECT_EQUAL(hmac_sha384_size, 48);
     EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_SHA384, sekrit, strlen((char *)sekrit)));
     EXPECT_SUCCESS(s2n_hmac_update(&hmac, hello, strlen((char *)hello)));
@@ -272,7 +272,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_hmac_new(&hmac));
 
     uint8_t hmac_sha512_size;
-    GUARD(s2n_hmac_digest_size(S2N_HMAC_SHA512, &hmac_sha512_size));
+    POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_SHA512, &hmac_sha512_size));
     EXPECT_EQUAL(hmac_sha512_size, 64);
     EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_SHA512, sekrit, strlen((char *)sekrit)));
     EXPECT_SUCCESS(s2n_hmac_update(&hmac, hello, strlen((char *)hello)));

--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -41,40 +41,40 @@ static const uint8_t sike_iana[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_ECDHE_SIKE_RSA_
 static const uint8_t classic_ecdhe_iana[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA };
 
 int alloc_test_kem_params(struct s2n_kem_params *kem_params) {
-    GUARD(s2n_alloc(&(kem_params->private_key), TEST_PRIVATE_KEY_LENGTH));
+    POSIX_GUARD(s2n_alloc(&(kem_params->private_key), TEST_PRIVATE_KEY_LENGTH));
     struct s2n_stuffer private_key_stuffer = {0};
-    GUARD(s2n_stuffer_init(&private_key_stuffer, &(kem_params->private_key)));
-    GUARD(s2n_stuffer_write_bytes(&private_key_stuffer, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LENGTH));
+    POSIX_GUARD(s2n_stuffer_init(&private_key_stuffer, &(kem_params->private_key)));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&private_key_stuffer, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LENGTH));
 
-    GUARD(s2n_alloc(&(kem_params->public_key), TEST_PUBLIC_KEY_LENGTH));
+    POSIX_GUARD(s2n_alloc(&(kem_params->public_key), TEST_PUBLIC_KEY_LENGTH));
     struct s2n_stuffer public_key_stuffer = {0};
-    GUARD(s2n_stuffer_init(&public_key_stuffer, &(kem_params->public_key)));
-    GUARD(s2n_stuffer_write_bytes(&public_key_stuffer, TEST_PUBLIC_KEY, TEST_PUBLIC_KEY_LENGTH));
+    POSIX_GUARD(s2n_stuffer_init(&public_key_stuffer, &(kem_params->public_key)));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&public_key_stuffer, TEST_PUBLIC_KEY, TEST_PUBLIC_KEY_LENGTH));
 
-    GUARD(s2n_alloc(&(kem_params->shared_secret), TEST_SHARED_SECRET_LENGTH));
+    POSIX_GUARD(s2n_alloc(&(kem_params->shared_secret), TEST_SHARED_SECRET_LENGTH));
     struct s2n_stuffer shared_secret_stuffer = {0};
-    GUARD(s2n_stuffer_init(&shared_secret_stuffer, &(kem_params->shared_secret)));
-    GUARD(s2n_stuffer_write_bytes(&shared_secret_stuffer, TEST_SHARED_SECRET, TEST_SHARED_SECRET_LENGTH));
+    POSIX_GUARD(s2n_stuffer_init(&shared_secret_stuffer, &(kem_params->shared_secret)));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&shared_secret_stuffer, TEST_SHARED_SECRET, TEST_SHARED_SECRET_LENGTH));
 
-    ne_check(0, kem_params->private_key.allocated);
-    ne_check(0, kem_params->public_key.allocated);
-    ne_check(0, kem_params->shared_secret.allocated);
+    POSIX_ENSURE_NE(0, kem_params->private_key.allocated);
+    POSIX_ENSURE_NE(0, kem_params->public_key.allocated);
+    POSIX_ENSURE_NE(0, kem_params->shared_secret.allocated);
 
     return S2N_SUCCESS;
 }
 
 int assert_kem_params_free(struct s2n_kem_params *kem_params) {
-    eq_check(NULL, kem_params->private_key.data);
-    eq_check(0, kem_params->private_key.size);
-    eq_check(0, kem_params->private_key.allocated);
+    POSIX_ENSURE_EQ(NULL, kem_params->private_key.data);
+    POSIX_ENSURE_EQ(0, kem_params->private_key.size);
+    POSIX_ENSURE_EQ(0, kem_params->private_key.allocated);
 
-    eq_check(NULL, kem_params->public_key.data);
-    eq_check(0, kem_params->public_key.size);
-    eq_check(0, kem_params->public_key.allocated);
+    POSIX_ENSURE_EQ(NULL, kem_params->public_key.data);
+    POSIX_ENSURE_EQ(0, kem_params->public_key.size);
+    POSIX_ENSURE_EQ(0, kem_params->public_key.allocated);
 
-    eq_check(NULL, kem_params->shared_secret.data);
-    eq_check(0, kem_params->shared_secret.size);
-    eq_check(0, kem_params->shared_secret.allocated);
+    POSIX_ENSURE_EQ(NULL, kem_params->shared_secret.data);
+    POSIX_ENSURE_EQ(0, kem_params->shared_secret.size);
+    POSIX_ENSURE_EQ(0, kem_params->shared_secret.allocated);
 
     return S2N_SUCCESS;
 }
@@ -87,15 +87,15 @@ int s2n_test_generate_keypair(unsigned char *public_key, unsigned char *private_
 }
 int s2n_test_encrypt(unsigned char *ciphertext, unsigned char *shared_secret, const unsigned char *public_key)
 {
-    GUARD(memcmp(public_key, TEST_PUBLIC_KEY, TEST_PUBLIC_KEY_LENGTH));
+    POSIX_GUARD(memcmp(public_key, TEST_PUBLIC_KEY, TEST_PUBLIC_KEY_LENGTH));
     memset(ciphertext, TEST_CIPHERTEXT_LENGTH, TEST_CIPHERTEXT_LENGTH);
     memset(shared_secret, TEST_SHARED_SECRET_LENGTH, TEST_SHARED_SECRET_LENGTH);
     return 0;
 }
 int s2n_test_decrypt(unsigned char *shared_secret, const unsigned char *ciphertext, const unsigned char *private_key)
 {
-    GUARD(memcmp(ciphertext, TEST_CIPHERTEXT, TEST_CIPHERTEXT_LENGTH));
-    GUARD(memcmp(private_key, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LENGTH));
+    POSIX_GUARD(memcmp(ciphertext, TEST_CIPHERTEXT, TEST_CIPHERTEXT_LENGTH));
+    POSIX_GUARD(memcmp(private_key, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LENGTH));
     memset(shared_secret, TEST_SHARED_SECRET_LENGTH, TEST_SHARED_SECRET_LENGTH);
     return 0;
 }
@@ -115,9 +115,9 @@ static int check_client_server_agreed_kem(const uint8_t iana_value[S2N_TLS_CIPHE
     const struct s2n_kem *negotiated_kem = NULL;
     struct s2n_blob client_kem_blob = { 0 };
     /* Each KEM ID is 2 bytes */
-    GUARD(s2n_blob_init(&client_kem_blob, client_kem_ids, 2 * num_client_kems));
-    GUARD(s2n_choose_kem_with_peer_pref_list(iana_value, &client_kem_blob, server_kem_pref_list, num_server_supported_kems, &negotiated_kem));
-    GUARD_NONNULL(negotiated_kem);
+    POSIX_GUARD(s2n_blob_init(&client_kem_blob, client_kem_ids, 2 * num_client_kems));
+    POSIX_GUARD(s2n_choose_kem_with_peer_pref_list(iana_value, &client_kem_blob, server_kem_pref_list, num_server_supported_kems, &negotiated_kem));
+    POSIX_GUARD_PTR(negotiated_kem);
 
     POSIX_ENSURE(negotiated_kem->kem_extension_id == expected_kem_id, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
 
@@ -154,11 +154,11 @@ int main(int argc, char **argv)
         struct s2n_kem_params client_kem_params = { 0 };
         client_kem_params.kem = &s2n_test_kem;
         /* This would be handled by client/server key exchange methods which isn't being tested */
-        GUARD(s2n_alloc(&client_kem_params.public_key, TEST_PUBLIC_KEY_LENGTH));
+        POSIX_GUARD(s2n_alloc(&client_kem_params.public_key, TEST_PUBLIC_KEY_LENGTH));
         memset(client_kem_params.public_key.data, TEST_PUBLIC_KEY_LENGTH, TEST_PUBLIC_KEY_LENGTH);
 
         DEFER_CLEANUP(struct s2n_blob ciphertext = { 0 }, s2n_free);
-        GUARD(s2n_alloc(&ciphertext, TEST_CIPHERTEXT_LENGTH));
+        POSIX_GUARD(s2n_alloc(&ciphertext, TEST_CIPHERTEXT_LENGTH));
 
         EXPECT_OK(s2n_kem_encapsulate(&client_kem_params, &ciphertext));
         EXPECT_EQUAL(TEST_SHARED_SECRET_LENGTH, client_kem_params.shared_secret.size);
@@ -392,10 +392,10 @@ int main(int argc, char **argv)
         /* Fill the kem_group_params with secrets */
         EXPECT_SUCCESS(alloc_test_kem_params(&kem_group_params.kem_params));
         struct s2n_stuffer wire;
-        GUARD(s2n_stuffer_growable_alloc(&wire, 1024));
+        POSIX_GUARD(s2n_stuffer_growable_alloc(&wire, 1024));
         kem_group_params.ecc_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
-        GUARD(s2n_ecdhe_parameters_send(&kem_group_params.ecc_params, &wire));
-        GUARD(s2n_stuffer_free(&wire));
+        POSIX_GUARD(s2n_ecdhe_parameters_send(&kem_group_params.ecc_params, &wire));
+        POSIX_GUARD(s2n_stuffer_free(&wire));
         EXPECT_NOT_NULL(kem_group_params.ecc_params.evp_pkey);
 
         /* Ensure that secrets have been freed */
@@ -457,7 +457,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer, &io_blob));
 
         EXPECT_SUCCESS(s2n_alloc(&(kem_params.public_key), TEST_PUBLIC_KEY_LENGTH));
-        memcpy_check(kem_params.public_key.data, TEST_PUBLIC_KEY, TEST_PUBLIC_KEY_LENGTH);
+        POSIX_CHECKED_MEMCPY(kem_params.public_key.data, TEST_PUBLIC_KEY, TEST_PUBLIC_KEY_LENGTH);
 
         EXPECT_SUCCESS(s2n_kem_send_ciphertext(&io_stuffer, &kem_params));
 
@@ -507,7 +507,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer, &io_blob));
 
         s2n_alloc(&(kem_params.private_key), TEST_PRIVATE_KEY_LENGTH);
-        memcpy_check(kem_params.private_key.data, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LENGTH);
+        POSIX_CHECKED_MEMCPY(kem_params.private_key.data, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LENGTH);
 
         /* {0, 5} = length of ciphertext to follow
          * {5, 5, 5, 5, 5} = test ciphertext */
@@ -548,7 +548,7 @@ int main(int argc, char **argv)
 
         /* The given ciphertext length doesn't match the KEM's actual ciphertext length */
         EXPECT_SUCCESS(s2n_alloc(&(kem_params.private_key), TEST_PRIVATE_KEY_LENGTH));
-        memcpy_check(kem_params.private_key.data, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LENGTH);
+        POSIX_CHECKED_MEMCPY(kem_params.private_key.data, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LENGTH);
         DEFER_CLEANUP(struct s2n_blob io_blob_3 = { 0 }, s2n_free);
         EXPECT_SUCCESS(s2n_alloc(&io_blob_3, TEST_CIPHERTEXT_LENGTH + 2));
         struct s2n_stuffer io_stuffer_3 = { 0 };

--- a/tests/unit/s2n_kex_with_kem_test.c
+++ b/tests/unit/s2n_kex_with_kem_test.c
@@ -54,12 +54,12 @@ static int do_kex_with_kem(struct s2n_cipher_suite *cipher_suite, const char *se
     struct s2n_connection *client_conn;
     struct s2n_connection *server_conn;
 
-    GUARD_NONNULL(client_conn = s2n_connection_new(S2N_CLIENT));
-    GUARD_NONNULL(server_conn = s2n_connection_new(S2N_SERVER));
+    POSIX_GUARD_PTR(client_conn = s2n_connection_new(S2N_CLIENT));
+    POSIX_GUARD_PTR(server_conn = s2n_connection_new(S2N_SERVER));
 
     const struct s2n_security_policy *security_policy = NULL;
-    GUARD(s2n_find_security_policy_from_version(security_policy_version, &security_policy));
-    GUARD_NONNULL(security_policy);
+    POSIX_GUARD(s2n_find_security_policy_from_version(security_policy_version, &security_policy));
+    POSIX_GUARD_PTR(security_policy);
 
     client_conn->secure.kem_params.kem = negotiated_kem;
     client_conn->secure.cipher_suite = cipher_suite;
@@ -71,68 +71,68 @@ static int do_kex_with_kem(struct s2n_cipher_suite *cipher_suite, const char *se
 
     /* Part 1: Server calls send_key */
     struct s2n_blob data_to_sign = {0};
-    GUARD(s2n_kem_server_key_send(server_conn, &data_to_sign));
+    POSIX_GUARD(s2n_kem_server_key_send(server_conn, &data_to_sign));
     /* 2 extra bytes for the kem extension id and 2 additional bytes for the length of the public key sent over the wire. */
     const uint32_t KEM_PUBLIC_KEY_MESSAGE_SIZE = (*negotiated_kem).public_key_length + 4;
-    eq_check(data_to_sign.size, KEM_PUBLIC_KEY_MESSAGE_SIZE);
+    POSIX_ENSURE_EQ(data_to_sign.size, KEM_PUBLIC_KEY_MESSAGE_SIZE);
 
-    eq_check((*negotiated_kem).private_key_length, server_conn->secure.kem_params.private_key.size);
+    POSIX_ENSURE_EQ((*negotiated_kem).private_key_length, server_conn->secure.kem_params.private_key.size);
     struct s2n_blob server_key_message = {.size = KEM_PUBLIC_KEY_MESSAGE_SIZE, .data = s2n_stuffer_raw_read(&server_conn->handshake.io,
             KEM_PUBLIC_KEY_MESSAGE_SIZE)};
-    GUARD_NONNULL(server_key_message.data);
+    POSIX_GUARD_PTR(server_key_message.data);
 
     /* The KEM public key should get written directly to the server's handshake IO; kem_params.public_key
      * should point to NULL */
-    eq_check(NULL, server_conn->secure.kem_params.public_key.data);
-    eq_check(0, server_conn->secure.kem_params.public_key.size);
+    POSIX_ENSURE_EQ(NULL, server_conn->secure.kem_params.public_key.data);
+    POSIX_ENSURE_EQ(0, server_conn->secure.kem_params.public_key.size);
 
     /* Part 1.1: feed that to the client */
-    GUARD(s2n_stuffer_write(&client_conn->handshake.io, &server_key_message));
+    POSIX_GUARD(s2n_stuffer_write(&client_conn->handshake.io, &server_key_message));
 
     /* Part 2: Client calls recv_read and recv_parse */
     struct s2n_kex_raw_server_data raw_params = {0};
     struct s2n_blob data_to_verify = {0};
-    GUARD(s2n_kem_server_key_recv_read_data(client_conn, &data_to_verify, &raw_params));
-    eq_check(data_to_verify.size, KEM_PUBLIC_KEY_MESSAGE_SIZE);
+    POSIX_GUARD(s2n_kem_server_key_recv_read_data(client_conn, &data_to_verify, &raw_params));
+    POSIX_ENSURE_EQ(data_to_verify.size, KEM_PUBLIC_KEY_MESSAGE_SIZE);
 
     if (s2n_kem_server_key_recv_parse_data(client_conn, &raw_params) != 0) {
         /* Tests with incompatible parameters are expected to fail here;
          * we want to clean up the connections before failing. */
-        GUARD(s2n_connection_free(client_conn));
-        GUARD(s2n_connection_free(server_conn));
+        POSIX_GUARD(s2n_connection_free(client_conn));
+        POSIX_GUARD(s2n_connection_free(server_conn));
         S2N_ERROR_PRESERVE_ERRNO();
     }
 
-    eq_check((*negotiated_kem).public_key_length, client_conn->secure.kem_params.public_key.size);
+    POSIX_ENSURE_EQ((*negotiated_kem).public_key_length, client_conn->secure.kem_params.public_key.size);
 
     /* Part 3: Client calls send_key. The additional 2 bytes are for the ciphertext length sent over the wire */
     const uint32_t KEM_CIPHERTEXT_MESSAGE_SIZE = (*negotiated_kem).ciphertext_length + 2;
     struct s2n_blob *client_shared_key = &(client_conn->secure.kem_params.shared_secret);
-    GUARD(s2n_kem_client_key_send(client_conn, client_shared_key));
+    POSIX_GUARD(s2n_kem_client_key_send(client_conn, client_shared_key));
     struct s2n_blob client_key_message = {.size = KEM_CIPHERTEXT_MESSAGE_SIZE, .data = s2n_stuffer_raw_read(&client_conn->handshake.io,
             KEM_CIPHERTEXT_MESSAGE_SIZE)};
-    GUARD_NONNULL(client_key_message.data);
+    POSIX_GUARD_PTR(client_key_message.data);
 
     /* Part 3.1: Send that back to the server */
-    GUARD(s2n_stuffer_write(&server_conn->handshake.io, &client_key_message));
+    POSIX_GUARD(s2n_stuffer_write(&server_conn->handshake.io, &client_key_message));
 
     /* Part 4: Call client key recv */
     struct s2n_blob *server_shared_key = &(server_conn->secure.kem_params.shared_secret);
-    GUARD(s2n_kem_client_key_recv(server_conn, server_shared_key));
-    eq_check(memcmp(client_shared_key->data, server_shared_key->data, (*negotiated_kem).shared_secret_key_length), 0);
+    POSIX_GUARD(s2n_kem_client_key_recv(server_conn, server_shared_key));
+    POSIX_ENSURE_EQ(memcmp(client_shared_key->data, server_shared_key->data, (*negotiated_kem).shared_secret_key_length), 0);
 
-    GUARD(s2n_connection_free(client_conn));
-    GUARD(s2n_connection_free(server_conn));
+    POSIX_GUARD(s2n_connection_free(client_conn));
+    POSIX_GUARD(s2n_connection_free(server_conn));
 
     return 0;
 }
 
 static int assert_pq_disabled_checks(struct s2n_cipher_suite *cipher_suite, const char *security_policy_version, const struct s2n_kem *negotiated_kem) {
     struct s2n_connection *server_conn;
-    GUARD_NONNULL(server_conn = s2n_connection_new(S2N_SERVER));
+    POSIX_GUARD_PTR(server_conn = s2n_connection_new(S2N_SERVER));
     const struct s2n_security_policy *security_policy = NULL;
-    GUARD(s2n_find_security_policy_from_version(security_policy_version, &security_policy));
-    GUARD_NONNULL(security_policy);
+    POSIX_GUARD(s2n_find_security_policy_from_version(security_policy_version, &security_policy));
+    POSIX_GUARD_PTR(security_policy);
     server_conn->secure.kem_params.kem = negotiated_kem;
     server_conn->secure.cipher_suite = cipher_suite;
     server_conn->security_policy_override = security_policy;
@@ -142,14 +142,14 @@ static int assert_pq_disabled_checks(struct s2n_cipher_suite *cipher_suite, cons
      * s2n_configure_kem() (s2n_hybrid_ecdhe_kem.configure_connection) should return S2N_RESULT_ERROR
      *     set s2n_errno to S2N_ERR_PQ_DISABLED */
     bool connection_supported = true;
-    GUARD_AS_POSIX(s2n_hybrid_ecdhe_kem.connection_supported(cipher_suite, server_conn, &connection_supported));
-    eq_check(connection_supported, false);
+    POSIX_GUARD_RESULT(s2n_hybrid_ecdhe_kem.connection_supported(cipher_suite, server_conn, &connection_supported));
+    POSIX_ENSURE_EQ(connection_supported, false);
 
-    eq_check(s2n_result_is_error(s2n_hybrid_ecdhe_kem.configure_connection(cipher_suite, server_conn)), true);
+    POSIX_ENSURE_EQ(s2n_result_is_error(s2n_hybrid_ecdhe_kem.configure_connection(cipher_suite, server_conn)), true);
 
-    eq_check(s2n_errno, S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE_EQ(s2n_errno, S2N_ERR_PQ_DISABLED);
 
-    GUARD(s2n_connection_free(server_conn));
+    POSIX_GUARD(s2n_connection_free(server_conn));
     s2n_errno = 0;
     s2n_debug_str = NULL;
 

--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -121,7 +121,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             server_conn->actual_protocol_version = S2N_TLS13;
             server_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            memcpy_check(server_conn->secure.client_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(server_conn->secure.client_app_secret, application_secret.data, application_secret.size);
 
             server_conn->secure.client_sequence_number[0] = 1; 
             /* Write the key update request to the correct stuffer */
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            memcpy_check(client_conn->secure.server_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(client_conn->secure.server_app_secret, application_secret.data, application_secret.size);
 
             client_conn->secure.server_sequence_number[0] = 1; 
             /* Write the key update request to the correct stuffer */
@@ -165,7 +165,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            memcpy_check(client_conn->secure.client_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(client_conn->secure.client_app_secret, application_secret.data, application_secret.size);
             uint8_t zeroed_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN] = {0};
 
             /* Setup io */
@@ -192,7 +192,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            memcpy_check(client_conn->secure.client_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(client_conn->secure.client_app_secret, application_secret.data, application_secret.size);
             uint8_t zeroed_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN] = {0};
 
             /* Setup io */
@@ -222,7 +222,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            memcpy_check(client_conn->secure.client_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(client_conn->secure.client_app_secret, application_secret.data, application_secret.size);
             uint8_t expected_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN] = {0};
 
             /* Setup io */

--- a/tests/unit/s2n_override_openssl_random_test.c
+++ b/tests/unit/s2n_override_openssl_random_test.c
@@ -54,7 +54,7 @@ struct s2n_stuffer test_entropy;
 int s2n_entropy_generator(void *data, uint32_t size)
 {
     struct s2n_blob blob = { .data = data, .size = size };
-    GUARD(s2n_stuffer_read(&test_entropy, &blob));
+    POSIX_GUARD(s2n_stuffer_read(&test_entropy, &blob));
     return 0;
 }
 
@@ -114,8 +114,8 @@ int main(int argc, char **argv)
     DEFER_CLEANUP(struct s2n_stuffer out_stuffer = {0}, s2n_stuffer_free);
     struct s2n_blob out_blob = {0};
     EXPECT_SUCCESS(s2n_stuffer_alloc(&out_stuffer, 4096));
-    GUARD(s2n_dh_generate_ephemeral_key(&dh_params));
-    GUARD(s2n_dh_params_to_p_g_Ys(&dh_params, &out_stuffer, &out_blob));
+    POSIX_GUARD(s2n_dh_generate_ephemeral_key(&dh_params));
+    POSIX_GUARD(s2n_dh_params_to_p_g_Ys(&dh_params, &out_stuffer, &out_blob));
 
     EXPECT_OK(s2n_get_private_random_bytes_used(&bytes_used));
     EXPECT_EQUAL(bytes_used, 352);

--- a/tests/unit/s2n_psk_offered_test.c
+++ b/tests/unit/s2n_psk_offered_test.c
@@ -19,9 +19,9 @@
 
 static S2N_RESULT s2n_write_test_identity(struct s2n_stuffer *out, const uint8_t *identity, uint16_t identity_size)
 {
-    GUARD_AS_RESULT(s2n_stuffer_write_uint16(out, identity_size));
-    GUARD_AS_RESULT(s2n_stuffer_write_bytes(out, identity, identity_size));
-    GUARD_AS_RESULT(s2n_stuffer_write_uint32(out, 0));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint16(out, identity_size));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(out, identity, identity_size));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint32(out, 0));
     return S2N_RESULT_OK;
 }
 
@@ -199,7 +199,7 @@ int main(int argc, char **argv)
     /* Test s2n_offered_psk_new */
     {
         struct s2n_offered_psk zeroed_psk = { 0 };
-        memset_check(&zeroed_psk, 0, sizeof(struct s2n_offered_psk));
+        POSIX_CHECKED_MEMSET(&zeroed_psk, 0, sizeof(struct s2n_offered_psk));
         DEFER_CLEANUP(struct s2n_offered_psk *new_psk = s2n_offered_psk_new(), s2n_offered_psk_free);
         EXPECT_NOT_NULL(new_psk);
 

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -670,7 +670,7 @@ int main(int argc, char **argv)
 
             for (s2n_hmac_algorithm hmac_alg = S2N_HMAC_SHA1; hmac_alg <= S2N_HMAC_SHA384; hmac_alg++) {
                 uint8_t hash_size = 0;
-                GUARD(s2n_hmac_digest_size(hmac_alg, &hash_size));
+                POSIX_GUARD(s2n_hmac_digest_size(hmac_alg, &hash_size));
 
                 uint8_t binder_size = 0;
                 EXPECT_SUCCESS(s2n_stuffer_read_uint8(&out, &binder_size));

--- a/tests/unit/s2n_quic_support_io_test.c
+++ b/tests/unit/s2n_quic_support_io_test.c
@@ -33,59 +33,59 @@ static S2N_RESULT s2n_setup_conn(struct s2n_connection *conn)
 {
     conn->actual_protocol_version = S2N_TLS13;
 
-    GUARD_AS_RESULT(s2n_stuffer_wipe(&input_stuffer));
-    GUARD_AS_RESULT(s2n_stuffer_wipe(&output_stuffer));
-    GUARD_AS_RESULT(s2n_connection_set_io_stuffers(&input_stuffer, &output_stuffer, conn));
+    RESULT_GUARD_POSIX(s2n_stuffer_wipe(&input_stuffer));
+    RESULT_GUARD_POSIX(s2n_stuffer_wipe(&output_stuffer));
+    RESULT_GUARD_POSIX(s2n_connection_set_io_stuffers(&input_stuffer, &output_stuffer, conn));
 
     return S2N_RESULT_OK;
 }
 
 static S2N_RESULT s2n_setup_conn_for_client_hello(struct s2n_connection *conn)
 {
-    GUARD_RESULT(s2n_setup_conn(conn));
+    RESULT_GUARD(s2n_setup_conn(conn));
     conn->handshake.handshake_type = INITIAL;
     conn->handshake.message_number = 0;
-    ENSURE_EQ(s2n_conn_get_current_message_type(conn), CLIENT_HELLO);
+    RESULT_ENSURE_EQ(s2n_conn_get_current_message_type(conn), CLIENT_HELLO);
     return S2N_RESULT_OK;
 }
 
 static S2N_RESULT s2n_setup_conn_for_server_hello(struct s2n_connection *conn)
 {
-    GUARD_RESULT(s2n_setup_conn(conn));
+    RESULT_GUARD(s2n_setup_conn(conn));
 
     /* Use arbitrary cipher suite */
     conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
     /* Setup secrets */
     const struct s2n_ecc_preferences *ecc_preferences = NULL;
-    GUARD_AS_RESULT(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
+    RESULT_GUARD_POSIX(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
     conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_preferences->ecc_curves[0];
     if(conn->secure.server_ecc_evp_params.evp_pkey == NULL) {
-        GUARD_AS_RESULT(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.server_ecc_evp_params));
+        RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.server_ecc_evp_params));
     }
     if(conn->secure.client_ecc_evp_params[0].evp_pkey == NULL) {
-        GUARD_AS_RESULT(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+        RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
     }
 
     /* Set handshake to write message */
     conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
     conn->handshake.message_number = 1;
-    ENSURE_EQ(s2n_conn_get_current_message_type(conn), SERVER_HELLO);
+    RESULT_ENSURE_EQ(s2n_conn_get_current_message_type(conn), SERVER_HELLO);
 
     return S2N_RESULT_OK;
 }
 
 static S2N_RESULT s2n_write_test_message(struct s2n_blob *out, message_type_t message_type)
 {
-    GUARD_AS_RESULT(s2n_alloc(out, TEST_DATA_SIZE + TLS_HANDSHAKE_HEADER_LENGTH));
+    RESULT_GUARD_POSIX(s2n_alloc(out, TEST_DATA_SIZE + TLS_HANDSHAKE_HEADER_LENGTH));
 
     struct s2n_stuffer stuffer;
-    GUARD_AS_RESULT(s2n_stuffer_init(&stuffer, out));
+    RESULT_GUARD_POSIX(s2n_stuffer_init(&stuffer, out));
 
-    GUARD_AS_RESULT(s2n_stuffer_write_uint8(&stuffer, message_type));
-    GUARD_AS_RESULT(s2n_stuffer_write_uint24(&stuffer, TEST_DATA_SIZE));
-    GUARD_AS_RESULT(s2n_stuffer_write_bytes(&stuffer, TEST_DATA, TEST_DATA_SIZE));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(&stuffer, message_type));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint24(&stuffer, TEST_DATA_SIZE));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(&stuffer, TEST_DATA, TEST_DATA_SIZE));
 
     return S2N_RESULT_OK;
 }
@@ -330,10 +330,10 @@ int main(int argc, char **argv)
 
             /* Write the record: record type, protocol version,
              *                   handshake message size, handshake message */
-            GUARD(s2n_stuffer_write_uint8(&input_stuffer, TLS_HANDSHAKE));
-            GUARD(s2n_stuffer_write_uint8(&input_stuffer, 3));
-            GUARD(s2n_stuffer_write_uint8(&input_stuffer, 3));
-            GUARD(s2n_stuffer_write_uint16(&input_stuffer, server_hello.size));
+            POSIX_GUARD(s2n_stuffer_write_uint8(&input_stuffer, TLS_HANDSHAKE));
+            POSIX_GUARD(s2n_stuffer_write_uint8(&input_stuffer, 3));
+            POSIX_GUARD(s2n_stuffer_write_uint8(&input_stuffer, 3));
+            POSIX_GUARD(s2n_stuffer_write_uint16(&input_stuffer, server_hello.size));
             EXPECT_SUCCESS(s2n_stuffer_write(&input_stuffer, &server_hello));
 
             EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked_status), S2N_ERR_BAD_MESSAGE);
@@ -350,11 +350,11 @@ int main(int argc, char **argv)
 
             /* Write the record: record type, protocol version,
              *                   record data size, standard "0x01" record data */
-            GUARD(s2n_stuffer_write_uint8(&input_stuffer, TLS_CHANGE_CIPHER_SPEC));
-            GUARD(s2n_stuffer_write_uint8(&input_stuffer, 3));
-            GUARD(s2n_stuffer_write_uint8(&input_stuffer, 3));
-            GUARD(s2n_stuffer_write_uint16(&input_stuffer, 1));
-            GUARD(s2n_stuffer_write_uint8(&input_stuffer, 1));
+            POSIX_GUARD(s2n_stuffer_write_uint8(&input_stuffer, TLS_CHANGE_CIPHER_SPEC));
+            POSIX_GUARD(s2n_stuffer_write_uint8(&input_stuffer, 3));
+            POSIX_GUARD(s2n_stuffer_write_uint8(&input_stuffer, 3));
+            POSIX_GUARD(s2n_stuffer_write_uint16(&input_stuffer, 1));
+            POSIX_GUARD(s2n_stuffer_write_uint8(&input_stuffer, 1));
 
             EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked_status), S2N_ERR_BAD_MESSAGE);
 

--- a/tests/unit/s2n_record_size_test.c
+++ b/tests/unit/s2n_record_size_test.c
@@ -41,18 +41,18 @@
 
 static int destroy_server_keys(struct s2n_connection *server_conn)
 {
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->destroy_key(&server_conn->initial.server_key));
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->destroy_key(&server_conn->initial.client_key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->destroy_key(&server_conn->initial.server_key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->destroy_key(&server_conn->initial.client_key));
 
     return S2N_SUCCESS;
 }
 
 static int setup_server_keys(struct s2n_connection *server_conn, struct s2n_blob *key)
 {
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->init(&server_conn->initial.server_key));
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->init(&server_conn->initial.client_key));
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->set_encryption_key(&server_conn->initial.server_key, key));
-    GUARD(server_conn->initial.cipher_suite->record_alg->cipher->set_decryption_key(&server_conn->initial.client_key, key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->init(&server_conn->initial.server_key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->init(&server_conn->initial.client_key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->set_encryption_key(&server_conn->initial.server_key, key));
+    POSIX_GUARD(server_conn->initial.cipher_suite->record_alg->cipher->set_decryption_key(&server_conn->initial.client_key, key));
 
     return S2N_SUCCESS;
 }

--- a/tests/unit/s2n_release_non_empty_buffers_test.c
+++ b/tests/unit/s2n_release_non_empty_buffers_test.c
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
         if (errno == EAGAIN || errno == EWOULDBLOCK) {
             continue;
         } else {
-            GUARD(ret);
+            POSIX_GUARD(ret);
         }
     }
 
@@ -168,7 +168,7 @@ int main(int argc, char **argv)
         if (errno == EAGAIN || errno == EWOULDBLOCK) {
             continue;
         } else {
-            GUARD(ret);
+            POSIX_GUARD(ret);
         }
 
         ret = s2n_recv(conn, buf, sizeof(buf), &blocked);

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -51,10 +51,10 @@ int main(int argc, char **argv)
 
         uint8_t s_data[S2N_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = { 0 };
         struct s2n_blob state_blob = { 0 };
-        GUARD(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
+        POSIX_GUARD(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
         struct s2n_stuffer output = { 0 };
 
-        GUARD(s2n_stuffer_init(&output, &state_blob));
+        POSIX_GUARD(s2n_stuffer_init(&output, &state_blob));
         EXPECT_SUCCESS(s2n_tls12_serialize_resumption_state(conn, &output));
 
         uint8_t serial_id = 0;

--- a/tests/unit/s2n_rsa_pss_test.c
+++ b/tests/unit/s2n_rsa_pss_test.c
@@ -27,9 +27,9 @@
 int s2n_flip_random_bit(struct s2n_blob *blob) {
     /* Flip a random bit in the blob */
     uint64_t byte_flip_pos;
-    GUARD_AS_POSIX(s2n_public_random(blob->size, &byte_flip_pos));
+    POSIX_GUARD_RESULT(s2n_public_random(blob->size, &byte_flip_pos));
     uint64_t bit_flip_pos;
-    GUARD_AS_POSIX(s2n_public_random(8, &bit_flip_pos));
+    POSIX_GUARD_RESULT(s2n_public_random(8, &bit_flip_pos));
 
     uint8_t mask = 0x01 << (uint8_t)bit_flip_pos;
     blob->data[byte_flip_pos] ^= mask;

--- a/tests/unit/s2n_safety_test.c
+++ b/tests/unit/s2n_safety_test.c
@@ -46,74 +46,74 @@
 
 static int failure_gte()
 {
-    gte_check(0, 1);
+    POSIX_ENSURE_GTE(0, 1);
 
     return 0;
 }
 
 static int success_gte()
 {
-    gte_check(0, 0);
-    gte_check(1, 0);
+    POSIX_ENSURE_GTE(0, 0);
+    POSIX_ENSURE_GTE(1, 0);
 
     return 0;
 }
 
 static int failure_gt()
 {
-    gt_check(0, 0);
-    gt_check(0, 1);
+    POSIX_ENSURE_GT(0, 0);
+    POSIX_ENSURE_GT(0, 1);
 
     return 0;
 }
 
 static int success_gt()
 {
-    gt_check(1, 0);
+    POSIX_ENSURE_GT(1, 0);
 
     return 0;
 }
 
 static int failure_lte()
 {
-    lte_check(1, 0);
+    POSIX_ENSURE_LTE(1, 0);
 
     return 0;
 }
 
 static int success_lte()
 {
-    lte_check(1, 1);
-    lte_check(0, 1);
+    POSIX_ENSURE_LTE(1, 1);
+    POSIX_ENSURE_LTE(0, 1);
 
     return 0;
 }
 
 static int failure_lt()
 {
-    lt_check(1, 0);
-    lt_check(1, 1);
+    POSIX_ENSURE_LT(1, 0);
+    POSIX_ENSURE_LT(1, 1);
 
     return 0;
 }
 
 static int success_lt()
 {
-    lt_check(0, 1);
+    POSIX_ENSURE_LT(0, 1);
 
     return 0;
 }
 
 static int success_notnull()
 {
-    notnull_check(&"");
+    POSIX_ENSURE_REF(&"");
 
     return 0;
 }
 
 static int failure_notnull()
 {
-    notnull_check(NULL);
+    POSIX_ENSURE_REF(NULL);
 
     return 0;
 }
@@ -123,7 +123,7 @@ static int success_memcpy()
     char dst[1024];
     char src[1024] = {0};
 
-    memcpy_check(dst, src, 1024);
+    POSIX_CHECKED_MEMCPY(dst, src, 1024);
 
     return 0;
 }
@@ -133,65 +133,65 @@ static int failure_memcpy()
     char src[1024];
     char *ptr = NULL;
 
-    memcpy_check(ptr, src, 1024);
+    POSIX_CHECKED_MEMCPY(ptr, src, 1024);
 
     return 0;
 }
 
 static int success_inclusive_range()
 {
-    inclusive_range_check(0, 0, 2);
-    inclusive_range_check(0, 1, 2);
-    inclusive_range_check(0, 2, 2);
+    POSIX_ENSURE_INCLUSIVE_RANGE(0, 0, 2);
+    POSIX_ENSURE_INCLUSIVE_RANGE(0, 1, 2);
+    POSIX_ENSURE_INCLUSIVE_RANGE(0, 2, 2);
 
     return 0;
 }
 
 static int failure_inclusive_range_too_high()
 {
-    inclusive_range_check(0, 3, 2);
+    POSIX_ENSURE_INCLUSIVE_RANGE(0, 3, 2);
 
     return 0;
 }
 
 static int failure_inclusive_range_too_low()
 {
-    inclusive_range_check(0, -1, 2);
+    POSIX_ENSURE_INCLUSIVE_RANGE(0, -1, 2);
 
     return 0;
 }
 
 static int success_exclusive_range()
 {
-    exclusive_range_check(0, 1, 2);
+    POSIX_ENSURE_EXCLUSIVE_RANGE(0, 1, 2);
 
     return 0;
 }
 
 static int failure_exclusive_range_too_high()
 {
-    exclusive_range_check(0, 3, 2);
+    POSIX_ENSURE_EXCLUSIVE_RANGE(0, 3, 2);
 
     return 0;
 }
 
 static int failure_exclusive_range_too_low()
 {
-    exclusive_range_check(0, -1, 2);
+    POSIX_ENSURE_EXCLUSIVE_RANGE(0, -1, 2);
 
     return 0;
 }
 
 static int failure_exclusive_range_eq_high()
 {
-    exclusive_range_check(0, 2, 2);
+    POSIX_ENSURE_EXCLUSIVE_RANGE(0, 2, 2);
 
     return 0;
 }
 
 static int failure_exclusive_range_eq_low()
 {
-    exclusive_range_check(0, 0, 2);
+    POSIX_ENSURE_EXCLUSIVE_RANGE(0, 0, 2);
 
     return 0;
 }

--- a/tests/unit/s2n_self_talk_key_log_test.c
+++ b/tests/unit/s2n_self_talk_key_log_test.c
@@ -22,8 +22,8 @@ static int s2n_test_key_log_cb(void* context, struct s2n_connection *conn,
                                    uint8_t *logline, size_t len)
 {
     struct s2n_stuffer* stuffer = (struct s2n_stuffer*)context;
-    GUARD(s2n_stuffer_write_bytes(stuffer, logline, len));
-    GUARD(s2n_stuffer_write_uint8(stuffer, '\n'));
+    POSIX_GUARD(s2n_stuffer_write_bytes(stuffer, logline, len));
+    POSIX_GUARD(s2n_stuffer_write_uint8(stuffer, '\n'));
 
     return S2N_SUCCESS;
 }
@@ -31,31 +31,31 @@ static int s2n_test_key_log_cb(void* context, struct s2n_connection *conn,
 S2N_RESULT s2n_test_check_tls12(struct s2n_stuffer *stuffer)
 {
     size_t len = s2n_stuffer_data_available(stuffer);
-    ENSURE_GT(len, 0);
+    RESULT_ENSURE_GT(len, 0);
     char *out = (char *)s2n_stuffer_raw_read(stuffer, len);
-    ENSURE_REF(out);
+    RESULT_ENSURE_REF(out);
     /**
      * rather than writing a full parser, we'll just make sure it at least
      * wrote the labels we would expect for TLS 1.2
      */
-    ENSURE_REF(strstr(out, "CLIENT_RANDOM "));
+    RESULT_ENSURE_REF(strstr(out, "CLIENT_RANDOM "));
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_test_check_tls13(struct s2n_stuffer *stuffer)
 {
     size_t len = s2n_stuffer_data_available(stuffer);
-    ENSURE_GT(len, 0);
+    RESULT_ENSURE_GT(len, 0);
     char *out = (char *)s2n_stuffer_raw_read(stuffer, len);
-    ENSURE_REF(out);
+    RESULT_ENSURE_REF(out);
     /**
      * rather than writing a full parser, we'll just make sure it at least
      * wrote the labels we would expect for TLS 1.3
      */
-    ENSURE_REF(strstr(out, "CLIENT_HANDSHAKE_TRAFFIC_SECRET "));
-    ENSURE_REF(strstr(out, "SERVER_HANDSHAKE_TRAFFIC_SECRET "));
-    ENSURE_REF(strstr(out, "CLIENT_TRAFFIC_SECRET_0 "));
-    ENSURE_REF(strstr(out, "SERVER_TRAFFIC_SECRET_0 "));
+    RESULT_ENSURE_REF(strstr(out, "CLIENT_HANDSHAKE_TRAFFIC_SECRET "));
+    RESULT_ENSURE_REF(strstr(out, "SERVER_HANDSHAKE_TRAFFIC_SECRET "));
+    RESULT_ENSURE_REF(strstr(out, "CLIENT_TRAFFIC_SECRET_0 "));
+    RESULT_ENSURE_REF(strstr(out, "SERVER_TRAFFIC_SECRET_0 "));
     return S2N_RESULT_OK;
 }
 

--- a/tests/unit/s2n_self_talk_nonblocking_test.c
+++ b/tests/unit/s2n_self_talk_nonblocking_test.c
@@ -47,7 +47,7 @@ int mock_client(struct s2n_test_io_pair *io_pair, uint8_t *expected_data, uint32
     client_config = s2n_config_new();
     s2n_config_disable_x509_verification(client_config);
     s2n_connection_set_config(client_conn, client_config);
-    GUARD(s2n_config_set_cipher_preferences(client_config, "test_all"));
+    POSIX_GUARD(s2n_config_set_cipher_preferences(client_config, "test_all"));
 
     s2n_connection_set_io_pair(client_conn, io_pair);
 
@@ -108,7 +108,7 @@ int mock_client_iov(struct s2n_test_io_pair *io_pair, struct iovec *iov, uint32_
     client_config = s2n_config_new();
     s2n_config_disable_x509_verification(client_config);
     s2n_connection_set_config(client_conn, client_config);
-    GUARD(s2n_config_set_cipher_preferences(client_config, "test_all"));
+    POSIX_GUARD(s2n_config_set_cipher_preferences(client_config, "test_all"));
 
     s2n_connection_set_io_pair(client_conn, io_pair);
 
@@ -183,9 +183,9 @@ int test_send(int use_tls13, int use_iov, int prefer_throughput)
     EXPECT_SUCCESS(s2n_config_add_dhparams(config, dhparams_pem));
 
     if (use_tls13) {
-        GUARD(s2n_config_set_cipher_preferences(config, "test_all"));
+        POSIX_GUARD(s2n_config_set_cipher_preferences(config, "test_all"));
     } else {
-        GUARD(s2n_config_set_cipher_preferences(config, "test_all_tls12"));
+        POSIX_GUARD(s2n_config_set_cipher_preferences(config, "test_all_tls12"));
     }
 
     /* Get some random data to send/receive */

--- a/tests/unit/s2n_self_talk_psk_test.c
+++ b/tests/unit/s2n_self_talk_psk_test.c
@@ -49,16 +49,16 @@ uint8_t test_other_server_data[] = "test other server data";
 static s2n_result setup_psk(struct s2n_connection *conn, const uint8_t *test_identity_data, uint16_t test_identity_size,
                             const uint8_t *test_secret_data, uint16_t test_secret_size, s2n_psk_hmac test_hmac)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(test_identity_data);
-    ENSURE_REF(test_secret_data);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(test_identity_data);
+    RESULT_ENSURE_REF(test_secret_data);
 
     struct s2n_psk *psk = s2n_external_psk_new();
-    GUARD_AS_RESULT(s2n_psk_set_identity(psk, test_identity_data, test_identity_size));
-    GUARD_AS_RESULT(s2n_psk_set_secret(psk, test_secret_data, test_secret_size));
-    GUARD_AS_RESULT(s2n_psk_set_hmac(psk, test_hmac));
-    GUARD_AS_RESULT(s2n_connection_append_psk(conn, psk));
-    GUARD_AS_RESULT(s2n_psk_free(&psk));
+    RESULT_GUARD_POSIX(s2n_psk_set_identity(psk, test_identity_data, test_identity_size));
+    RESULT_GUARD_POSIX(s2n_psk_set_secret(psk, test_secret_data, test_secret_size));
+    RESULT_GUARD_POSIX(s2n_psk_set_hmac(psk, test_hmac));
+    RESULT_GUARD_POSIX(s2n_connection_append_psk(conn, psk));
+    RESULT_GUARD_POSIX(s2n_psk_free(&psk));
     EXPECT_NULL(psk);
 
     return S2N_RESULT_OK;
@@ -66,7 +66,7 @@ static s2n_result setup_psk(struct s2n_connection *conn, const uint8_t *test_ide
 
 static s2n_result setup_client_psks(struct s2n_connection *client_conn)
 {
-    ENSURE_REF(client_conn);
+    RESULT_ENSURE_REF(client_conn);
 
     /* Setup other client PSK */
     EXPECT_OK(setup_psk(client_conn, test_other_client_data, sizeof(test_other_client_data), test_other_client_data,
@@ -83,7 +83,7 @@ static s2n_result setup_client_psks(struct s2n_connection *client_conn)
 
 static s2n_result setup_server_psks(struct s2n_connection *server_conn)
 {
-    ENSURE_REF(server_conn);
+    RESULT_ENSURE_REF(server_conn);
 
     /* Setup first shared PSK for server */
     EXPECT_OK(setup_psk(server_conn, test_shared_identity, sizeof(test_shared_identity), test_shared_secret,
@@ -100,8 +100,8 @@ static s2n_result setup_server_psks(struct s2n_connection *server_conn)
 
 static s2n_result setup_psks_with_no_match(struct s2n_connection *client_conn, struct s2n_connection *server_conn)
 {
-    ENSURE_REF(client_conn);
-    ENSURE_REF(server_conn);
+    RESULT_ENSURE_REF(client_conn);
+    RESULT_ENSURE_REF(server_conn);
 
     /* Setup other client PSK */
     EXPECT_OK(setup_psk(client_conn, test_other_client_data, sizeof(test_other_client_data), test_other_client_data,
@@ -116,13 +116,13 @@ static s2n_result setup_psks_with_no_match(struct s2n_connection *client_conn, s
 static s2n_result validate_chosen_psk(struct s2n_connection *server_conn, uint8_t *psk_identity_data,
                                       size_t psk_identity_size, size_t chosen_index)
 {
-    ENSURE_REF(server_conn);
-    ENSURE_REF(psk_identity_data);
-    ENSURE_REF(server_conn->psk_params.chosen_psk);
+    RESULT_ENSURE_REF(server_conn);
+    RESULT_ENSURE_REF(psk_identity_data);
+    RESULT_ENSURE_REF(server_conn->psk_params.chosen_psk);
 
-    ENSURE_EQ(server_conn->psk_params.chosen_psk->identity.size, psk_identity_size);
-    ENSURE_EQ(memcmp(server_conn->psk_params.chosen_psk->identity.data, psk_identity_data, psk_identity_size), 0);
-    ENSURE_EQ(server_conn->psk_params.chosen_psk_wire_index, chosen_index);
+    RESULT_ENSURE_EQ(server_conn->psk_params.chosen_psk->identity.size, psk_identity_size);
+    RESULT_ENSURE_EQ(memcmp(server_conn->psk_params.chosen_psk->identity.data, psk_identity_data, psk_identity_size), 0);
+    RESULT_ENSURE_EQ(server_conn->psk_params.chosen_psk_wire_index, chosen_index);
 
     return S2N_RESULT_OK;
 }

--- a/tests/unit/s2n_self_talk_session_id_test.c
+++ b/tests/unit/s2n_self_talk_session_id_test.c
@@ -353,8 +353,8 @@ int main(int argc, char **argv)
         /* Although we disable session ticket, as long as session cache
          * callbacks are binded, session ticket key storage would be initialized
          */
-        GUARD(s2n_config_set_session_cache_onoff(config, 1));
-        GUARD(config->wall_clock(config->sys_clock_ctx, &now));
+        POSIX_GUARD(s2n_config_set_session_cache_onoff(config, 1));
+        POSIX_GUARD(config->wall_clock(config->sys_clock_ctx, &now));
         EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(config, ticket_key_name, strlen((char*)ticket_key_name), ticket_key, sizeof(ticket_key), now/ONE_SEC_IN_NANOS));
 
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));

--- a/tests/unit/s2n_send_key_update_test.c
+++ b/tests/unit/s2n_send_key_update_test.c
@@ -50,20 +50,20 @@ static int s2n_test_init_encryption(struct s2n_connection *conn)
     uint8_t *client_implicit_iv = conn->client->client_implicit_iv;
  
     /* Initialize record algorithm */
-    GUARD(cipher_suite->record_alg->cipher->init(server_session_key));
-    GUARD(cipher_suite->record_alg->cipher->init(client_session_key));
-    GUARD(cipher_suite->record_alg->cipher->set_encryption_key(server_session_key, &key));
-    GUARD(cipher_suite->record_alg->cipher->set_encryption_key(client_session_key, &key));
-    GUARD(cipher_suite->record_alg->cipher->set_decryption_key(server_session_key, &key));
-    GUARD(cipher_suite->record_alg->cipher->set_decryption_key(client_session_key, &key));
+    POSIX_GUARD(cipher_suite->record_alg->cipher->init(server_session_key));
+    POSIX_GUARD(cipher_suite->record_alg->cipher->init(client_session_key));
+    POSIX_GUARD(cipher_suite->record_alg->cipher->set_encryption_key(server_session_key, &key));
+    POSIX_GUARD(cipher_suite->record_alg->cipher->set_encryption_key(client_session_key, &key));
+    POSIX_GUARD(cipher_suite->record_alg->cipher->set_decryption_key(server_session_key, &key));
+    POSIX_GUARD(cipher_suite->record_alg->cipher->set_decryption_key(client_session_key, &key));
 
     /* Initialized secrets */
-    memcpy_check(conn->secure.server_app_secret, application_secret.data, application_secret.size);
-    memcpy_check(conn->secure.client_app_secret, application_secret.data, application_secret.size);
+    POSIX_CHECKED_MEMCPY(conn->secure.server_app_secret, application_secret.data, application_secret.size);
+    POSIX_CHECKED_MEMCPY(conn->secure.client_app_secret, application_secret.data, application_secret.size);
  
     /* Copy iv bytes from input data */
-    memcpy_check(server_implicit_iv, iv.data, iv.size);
-    memcpy_check(client_implicit_iv, iv.data, iv.size);
+    POSIX_CHECKED_MEMCPY(server_implicit_iv, iv.data, iv.size);
+    POSIX_CHECKED_MEMCPY(client_implicit_iv, iv.data, iv.size);
  
     return S2N_SUCCESS;
 }

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -53,9 +53,9 @@ static int configure_tls13_connection(struct s2n_connection *conn)
 
     conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
     conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-    GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
-    GUARD(s2n_stuffer_wipe(&conn->handshake.io));
-    GUARD(s2n_connection_allow_all_response_extensions(conn));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
+    POSIX_GUARD(s2n_connection_allow_all_response_extensions(conn));
 
     return 0;
 }

--- a/tests/unit/s2n_server_hello_retry_test.c
+++ b/tests/unit/s2n_server_hello_retry_test.c
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
 
         struct s2n_stuffer* extension_stuffer = &server_conn->handshake.io;
 
-        memcpy_check(server_conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
+        POSIX_CHECKED_MEMCPY(server_conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
         EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
         server_conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
         server_conn->secure.client_ecc_evp_params[0].negotiated_curve = s2n_all_supported_curves_list[0];
@@ -232,7 +232,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[0]));
 
         /* Setup the client to receive a HelloRetryRequest */
-        memcpy_check(client_conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
+        POSIX_CHECKED_MEMCPY(client_conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
         EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(client_conn, S2N_TLS13));
 
         /* Setup the handshake type and message number to simulate a condition where a HelloRetry should be sent */
@@ -295,7 +295,7 @@ int main(int argc, char **argv)
         struct s2n_blob compare_blob;
 
         struct s2n_hash_state hash_state, client_hello1_hash;
-        GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
+        POSIX_GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
 
         uint8_t client_hello1_digest_out[S2N_MAX_DIGEST_LEN];
         EXPECT_SUCCESS(s2n_hash_new(&client_hello1_hash));
@@ -310,7 +310,7 @@ int main(int argc, char **argv)
 
         struct s2n_hash_state recreated_hash;
         uint8_t recreated_transcript_digest_out[S2N_MAX_DIGEST_LEN];
-        GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
+        POSIX_GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
         EXPECT_SUCCESS(s2n_hash_new(&recreated_hash));
         EXPECT_SUCCESS(s2n_hash_copy(&recreated_hash, &hash_state));
         EXPECT_SUCCESS(s2n_hash_digest(&recreated_hash, recreated_transcript_digest_out, hash_digest_length));

--- a/tests/unit/s2n_server_hello_test.c
+++ b/tests/unit/s2n_server_hello_test.c
@@ -46,13 +46,13 @@ const uint8_t tls11_downgrade_protection_check_bytes[] = {
 
 static S2N_RESULT s2n_test_client_hello(struct s2n_connection *client_conn, struct s2n_connection *server_conn)
 {
-    GUARD_AS_RESULT(s2n_client_hello_send(client_conn));
-    GUARD_AS_RESULT(s2n_stuffer_copy(&client_conn->handshake.io,
+    RESULT_GUARD_POSIX(s2n_client_hello_send(client_conn));
+    RESULT_GUARD_POSIX(s2n_stuffer_copy(&client_conn->handshake.io,
             &server_conn->handshake.io, s2n_stuffer_data_available(&client_conn->handshake.io)));
-    GUARD_AS_RESULT(s2n_client_hello_recv(server_conn));
+    RESULT_GUARD_POSIX(s2n_client_hello_recv(server_conn));
 
-    GUARD_AS_RESULT(s2n_stuffer_wipe(&client_conn->handshake.io));
-    GUARD_AS_RESULT(s2n_stuffer_wipe(&server_conn->handshake.io));
+    RESULT_GUARD_POSIX(s2n_stuffer_wipe(&client_conn->handshake.io));
+    RESULT_GUARD_POSIX(s2n_stuffer_wipe(&server_conn->handshake.io));
 
     return S2N_RESULT_OK;
 }
@@ -414,9 +414,9 @@ int main(int argc, char **argv)
 
         /* Verify that a TLS13 client does not error due to the downgrade */
         struct s2n_stuffer *client_stuffer = &client_conn->handshake.io;
-        GUARD(s2n_enable_tls13());
+        POSIX_GUARD(s2n_enable_tls13());
         EXPECT_SUCCESS(s2n_server_hello_recv(client_conn));
-        GUARD(s2n_disable_tls13());
+        POSIX_GUARD(s2n_disable_tls13());
         EXPECT_EQUAL(s2n_stuffer_data_available(client_stuffer), 0);
 
         EXPECT_SUCCESS(s2n_config_free(client_config));

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -971,21 +971,21 @@ int main(int argc, char **argv)
 static int s2n_read_server_key_share_hybrid_test_vectors(const struct s2n_kem_group *kem_group, struct s2n_blob *pq_private_key,
         struct s2n_stuffer *pq_shared_secret, struct s2n_stuffer *key_share_payload) {
     FILE *kat_file = fopen("kats/tls13_server_hybrid_key_share_recv.kat", "r");
-    notnull_check(kat_file);
+    POSIX_ENSURE_REF(kat_file);
 
     /* 50 should be plenty big enough to hold the entire marker string */
     char marker[50] = "kem_group = ";
     strcat(marker, kem_group->name);
-    GUARD(FindMarker(kat_file, marker));
+    POSIX_GUARD(FindMarker(kat_file, marker));
 
-    GUARD(s2n_alloc(pq_private_key, kem_group->kem->private_key_length));
-    GUARD(ReadHex(kat_file, pq_private_key->data, kem_group->kem->private_key_length, "pq_private_key = "));
+    POSIX_GUARD(s2n_alloc(pq_private_key, kem_group->kem->private_key_length));
+    POSIX_GUARD(ReadHex(kat_file, pq_private_key->data, kem_group->kem->private_key_length, "pq_private_key = "));
     pq_private_key->size = kem_group->kem->private_key_length;
 
-    GUARD(s2n_stuffer_alloc(pq_shared_secret, kem_group->kem->shared_secret_key_length));
+    POSIX_GUARD(s2n_stuffer_alloc(pq_shared_secret, kem_group->kem->shared_secret_key_length));
     uint8_t *pq_shared_secret_ptr = s2n_stuffer_raw_write(pq_shared_secret, kem_group->kem->shared_secret_key_length);
-    notnull_check(pq_shared_secret_ptr);
-    GUARD(ReadHex(kat_file, pq_shared_secret_ptr, kem_group->kem->shared_secret_key_length, "pq_shared_secret = "));
+    POSIX_ENSURE_REF(pq_shared_secret_ptr);
+    POSIX_GUARD(ReadHex(kat_file, pq_shared_secret_ptr, kem_group->kem->shared_secret_key_length, "pq_shared_secret = "));
 
     size_t key_share_payload_size =
               S2N_SIZE_OF_NAMED_GROUP
@@ -995,10 +995,10 @@ static int s2n_read_server_key_share_hybrid_test_vectors(const struct s2n_kem_gr
             + S2N_SIZE_OF_KEY_SHARE_SIZE
             + kem_group->kem->ciphertext_length;
 
-    GUARD(s2n_stuffer_alloc(key_share_payload, key_share_payload_size));
+    POSIX_GUARD(s2n_stuffer_alloc(key_share_payload, key_share_payload_size));
     uint8_t *key_share_payload_ptr = s2n_stuffer_raw_write(key_share_payload, key_share_payload_size);
-    notnull_check(key_share_payload_ptr);
-    GUARD(ReadHex(kat_file, key_share_payload_ptr, key_share_payload_size, "server_key_share_payload = "));
+    POSIX_ENSURE_REF(key_share_payload_ptr);
+    POSIX_GUARD(ReadHex(kat_file, key_share_payload_ptr, key_share_payload_size, "server_key_share_payload = "));
 
     fclose(kat_file);
     return S2N_SUCCESS;

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -31,8 +31,8 @@
 
 static int s2n_setup_test_keys(struct s2n_connection *conn, struct s2n_config *config)
 {
-    notnull_check(conn);
-    notnull_check(config);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(config);
 
     /**
      *= https://tools.ietf.org/rfc/rfc5869#appendix-A.1

--- a/tests/unit/s2n_server_psk_extension_test.c
+++ b/tests/unit/s2n_server_psk_extension_test.c
@@ -29,23 +29,23 @@ uint8_t test_secret[] = "test secret";
 
 static s2n_result setup_client_psks(struct s2n_connection *client_conn)
 {
-    ENSURE_REF(client_conn);
+    RESULT_ENSURE_REF(client_conn);
 
     /* Setup other client PSK */
     uint8_t other_client_data[] = "other client data";
     struct s2n_psk *other_client_psk = NULL;
-    GUARD_RESULT(s2n_array_pushback(&client_conn->psk_params.psk_list, (void**) &other_client_psk));
-    GUARD_RESULT(s2n_psk_init(other_client_psk, S2N_PSK_TYPE_EXTERNAL));
-    GUARD_AS_RESULT(s2n_psk_set_identity(other_client_psk, other_client_data, sizeof(other_client_data)));
-    GUARD_AS_RESULT(s2n_psk_set_secret(other_client_psk, other_client_data, sizeof(other_client_data)));
+    RESULT_GUARD(s2n_array_pushback(&client_conn->psk_params.psk_list, (void**) &other_client_psk));
+    RESULT_GUARD(s2n_psk_init(other_client_psk, S2N_PSK_TYPE_EXTERNAL));
+    RESULT_GUARD_POSIX(s2n_psk_set_identity(other_client_psk, other_client_data, sizeof(other_client_data)));
+    RESULT_GUARD_POSIX(s2n_psk_set_secret(other_client_psk, other_client_data, sizeof(other_client_data)));
     other_client_psk->hmac_alg = S2N_HMAC_SHA256;
 
     /* Setup shared PSK for client */
     struct s2n_psk *shared_psk = NULL;
-    GUARD_RESULT(s2n_array_pushback(&client_conn->psk_params.psk_list, (void**) &shared_psk));
-    GUARD_RESULT(s2n_psk_init(shared_psk, S2N_PSK_TYPE_EXTERNAL));
-    GUARD_AS_RESULT(s2n_psk_set_identity(shared_psk, test_identity, sizeof(test_identity)));
-    GUARD_AS_RESULT(s2n_psk_set_secret(shared_psk, test_secret, sizeof(test_secret)));
+    RESULT_GUARD(s2n_array_pushback(&client_conn->psk_params.psk_list, (void**) &shared_psk));
+    RESULT_GUARD(s2n_psk_init(shared_psk, S2N_PSK_TYPE_EXTERNAL));
+    RESULT_GUARD_POSIX(s2n_psk_set_identity(shared_psk, test_identity, sizeof(test_identity)));
+    RESULT_GUARD_POSIX(s2n_psk_set_secret(shared_psk, test_secret, sizeof(test_secret)));
     shared_psk->hmac_alg = TEST_PSK_HMAC;
 
     return S2N_RESULT_OK;
@@ -53,23 +53,23 @@ static s2n_result setup_client_psks(struct s2n_connection *client_conn)
 
 static s2n_result setup_server_psks(struct s2n_connection *server_conn)
 {
-    ENSURE_REF(server_conn);
+    RESULT_ENSURE_REF(server_conn);
 
     /* Setup shared PSK for server */
     struct s2n_psk *shared_psk = NULL;
-    GUARD_RESULT(s2n_array_pushback(&server_conn->psk_params.psk_list, (void**) &shared_psk));
-    GUARD_RESULT(s2n_psk_init(shared_psk, S2N_PSK_TYPE_EXTERNAL));
-    GUARD_AS_RESULT(s2n_psk_set_identity(shared_psk, test_identity, sizeof(test_identity)));
-    GUARD_AS_RESULT(s2n_psk_set_secret(shared_psk, test_secret, sizeof(test_secret)));
+    RESULT_GUARD(s2n_array_pushback(&server_conn->psk_params.psk_list, (void**) &shared_psk));
+    RESULT_GUARD(s2n_psk_init(shared_psk, S2N_PSK_TYPE_EXTERNAL));
+    RESULT_GUARD_POSIX(s2n_psk_set_identity(shared_psk, test_identity, sizeof(test_identity)));
+    RESULT_GUARD_POSIX(s2n_psk_set_secret(shared_psk, test_secret, sizeof(test_secret)));
     shared_psk->hmac_alg = TEST_PSK_HMAC;
 
     /* Setup other server PSK */
     uint8_t other_server_data[] = "other server data";
     struct s2n_psk *other_server_psk = NULL;
-    GUARD_RESULT(s2n_array_pushback(&server_conn->psk_params.psk_list, (void**) &other_server_psk));
-    GUARD_RESULT(s2n_psk_init(other_server_psk, S2N_PSK_TYPE_EXTERNAL));
-    GUARD_AS_RESULT(s2n_psk_set_identity(other_server_psk, other_server_data, sizeof(other_server_data)));
-    GUARD_AS_RESULT(s2n_psk_set_secret(other_server_psk, other_server_data, sizeof(other_server_data)));
+    RESULT_GUARD(s2n_array_pushback(&server_conn->psk_params.psk_list, (void**) &other_server_psk));
+    RESULT_GUARD(s2n_psk_init(other_server_psk, S2N_PSK_TYPE_EXTERNAL));
+    RESULT_GUARD_POSIX(s2n_psk_set_identity(other_server_psk, other_server_data, sizeof(other_server_data)));
+    RESULT_GUARD_POSIX(s2n_psk_set_secret(other_server_psk, other_server_data, sizeof(other_server_data)));
     other_server_psk->hmac_alg = S2N_HMAC_SHA224;
 
     return S2N_RESULT_OK;

--- a/tests/unit/s2n_server_supported_versions_extension_test.c
+++ b/tests/unit/s2n_server_supported_versions_extension_test.c
@@ -27,10 +27,10 @@
 #include "utils/s2n_safety.h"
 
 int write_test_supported_version(struct s2n_stuffer *list, uint8_t supported_version) {
-    GUARD(s2n_stuffer_write_uint8(list, S2N_TLS_PROTOCOL_VERSION_LEN));
+    POSIX_GUARD(s2n_stuffer_write_uint8(list, S2N_TLS_PROTOCOL_VERSION_LEN));
 
-    GUARD(s2n_stuffer_write_uint8(list, supported_version / 10));
-    GUARD(s2n_stuffer_write_uint8(list, supported_version % 10));
+    POSIX_GUARD(s2n_stuffer_write_uint8(list, supported_version / 10));
+    POSIX_GUARD(s2n_stuffer_write_uint8(list, supported_version % 10));
 
     return 0;
 }

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -134,7 +134,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(server_config, S2N_SESSION_STATE_CONFIGURABLE_LIFETIME_IN_SECS));
 
         /* Add one ST key */
-        GUARD(server_config->wall_clock(server_config->sys_clock_ctx, &now));
+        POSIX_GUARD(server_config->wall_clock(server_config->sys_clock_ctx, &now));
         EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(server_config, ticket_key_name1, strlen((char *)ticket_key_name1), ticket_key1, sizeof(ticket_key1), now/ONE_SEC_IN_NANOS));
 
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
@@ -880,7 +880,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(server_config, S2N_SESSION_STATE_CONFIGURABLE_LIFETIME_IN_SECS));
 
         /* Add a key. After 1 hour it will be considered an encrypt-decrypt key. */
-        GUARD(server_config->wall_clock(server_config->sys_clock_ctx, &now));
+        POSIX_GUARD(server_config->wall_clock(server_config->sys_clock_ctx, &now));
         EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(server_config, ticket_key_name1, strlen((char *)ticket_key_name1), ticket_key1, sizeof(ticket_key1), (now/ONE_SEC_IN_NANOS) + 3600));
 
         /* Add a key. After 1 hour it will reach it's peak */
@@ -975,13 +975,13 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         /* Setup stuffers value containing the valid key name, valid iv and invalid encrypted blob */
-        GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, ticket_key_name1, sizeof(ticket_key_name1)));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, ticket_key_name1, sizeof(ticket_key_name1)));
 
         uint8_t valid_iv[S2N_TLS_GCM_IV_LEN] = {0};
-        GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, valid_iv, sizeof(valid_iv)));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, valid_iv, sizeof(valid_iv)));
 
         uint8_t invalid_en_data[S2N_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = {0};
-        GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, invalid_en_data, sizeof(invalid_en_data)));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, invalid_en_data, sizeof(invalid_en_data)));
 
         server_conn->session_ticket_status = S2N_DECRYPT_TICKET;
         EXPECT_FAILURE_WITH_ERRNO(s2n_decrypt_session_ticket(server_conn), S2N_ERR_DECRYPT);
@@ -1001,13 +1001,13 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         /* Setup stuffers value containing the invalid key name, valid iv and invalid encrypted blob */
-        GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, ticket_key_name2, sizeof(ticket_key_name2)));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, ticket_key_name2, sizeof(ticket_key_name2)));
 
         uint8_t valid_iv[S2N_TLS_GCM_IV_LEN] = {0};
-        GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, valid_iv, sizeof(valid_iv)));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, valid_iv, sizeof(valid_iv)));
 
         uint8_t invalid_en_data[S2N_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = {0};
-        GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, invalid_en_data, sizeof(invalid_en_data)));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, invalid_en_data, sizeof(invalid_en_data)));
 
         server_conn->session_ticket_status = S2N_DECRYPT_TICKET;
         EXPECT_FAILURE_WITH_ERRNO(s2n_decrypt_session_ticket(server_conn), S2N_ERR_KEY_USED_IN_SESSION_TICKET_NOT_FOUND);

--- a/tests/unit/s2n_stacktrace_test.c
+++ b/tests/unit/s2n_stacktrace_test.c
@@ -21,7 +21,7 @@
 
 int raises_error()
 {
-  S2N_ERROR(S2N_ERR_INVALID_ARGUMENT);
+  POSIX_BAIL(S2N_ERR_INVALID_ARGUMENT);
 }
 
 int main(int argc, char **argv)

--- a/tests/unit/s2n_testlib_test.c
+++ b/tests/unit/s2n_testlib_test.c
@@ -34,8 +34,8 @@ int main(int argc, char **argv)
 
         /* Create nonblocking pipes */
         struct s2n_test_io_pair io_pair;
-        GUARD(s2n_io_pair_init_non_blocking(&io_pair));
-        GUARD(s2n_connection_set_io_pair(server_conn, &io_pair));
+        POSIX_GUARD(s2n_io_pair_init_non_blocking(&io_pair));
+        POSIX_GUARD(s2n_connection_set_io_pair(server_conn, &io_pair));
 
         /* This should NEVER fail with an error related to blocked IO. */
         EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_test_server_and_client(server_conn, NULL), S2N_ERR_NULL);

--- a/tests/unit/s2n_tls12_handshake_test.c
+++ b/tests/unit/s2n_tls12_handshake_test.c
@@ -58,29 +58,29 @@ static int s2n_setup_handler_to_expect(message_type_t expected, uint8_t directio
 
 static int s2n_test_write_header(struct s2n_stuffer *output, uint8_t record_type, uint8_t message_type)
 {
-    GUARD(s2n_stuffer_write_uint8(output, record_type));
+    POSIX_GUARD(s2n_stuffer_write_uint8(output, record_type));
 
     /* TLS1.2 protocol version */
-    GUARD(s2n_stuffer_write_uint8(output, 3));
-    GUARD(s2n_stuffer_write_uint8(output, 3));
+    POSIX_GUARD(s2n_stuffer_write_uint8(output, 3));
+    POSIX_GUARD(s2n_stuffer_write_uint8(output, 3));
 
     if (record_type == TLS_HANDSHAKE) {
         /* Total message size */
-        GUARD(s2n_stuffer_write_uint16(output, 4));
+        POSIX_GUARD(s2n_stuffer_write_uint16(output, 4));
 
-        GUARD(s2n_stuffer_write_uint8(output, message_type));
+        POSIX_GUARD(s2n_stuffer_write_uint8(output, message_type));
 
         /* Handshake message data size */
-        GUARD(s2n_stuffer_write_uint24(output, 0));
+        POSIX_GUARD(s2n_stuffer_write_uint24(output, 0));
         return 0;
     }
 
     if (record_type == TLS_CHANGE_CIPHER_SPEC) {
         /* Total message size */
-        GUARD(s2n_stuffer_write_uint16(output, 1));
+        POSIX_GUARD(s2n_stuffer_write_uint16(output, 1));
 
         /* change spec is always just 0x01 */
-        GUARD(s2n_stuffer_write_uint8(output, 1));
+        POSIX_GUARD(s2n_stuffer_write_uint8(output, 1));
         return 0;
     }
 

--- a/tests/unit/s2n_tls13_client_finished_test.c
+++ b/tests/unit/s2n_tls13_client_finished_test.c
@@ -23,8 +23,8 @@
 
 static int reset_stuffers(struct s2n_stuffer *reread, struct s2n_stuffer *wipe)
 {
-    GUARD(s2n_stuffer_reread(reread));
-    GUARD(s2n_stuffer_wipe(wipe));
+    POSIX_GUARD(s2n_stuffer_reread(reread));
+    POSIX_GUARD(s2n_stuffer_wipe(wipe));
     return 0;
 }
 

--- a/tests/unit/s2n_tls13_handshake_state_machine_test.c
+++ b/tests/unit/s2n_tls13_handshake_state_machine_test.c
@@ -66,29 +66,29 @@ static int s2n_setup_handler_to_expect(message_type_t expected, uint8_t directio
 
 static int s2n_test_write_header(struct s2n_stuffer *output, uint8_t record_type, uint8_t message_type)
 {
-    GUARD(s2n_stuffer_write_uint8(output, record_type));
+    POSIX_GUARD(s2n_stuffer_write_uint8(output, record_type));
 
     /* TLS1.2 protocol version */
-    GUARD(s2n_stuffer_write_uint8(output, 3));
-    GUARD(s2n_stuffer_write_uint8(output, 3));
+    POSIX_GUARD(s2n_stuffer_write_uint8(output, 3));
+    POSIX_GUARD(s2n_stuffer_write_uint8(output, 3));
 
     if (record_type == TLS_HANDSHAKE) {
         /* Total message size */
-        GUARD(s2n_stuffer_write_uint16(output, 4));
+        POSIX_GUARD(s2n_stuffer_write_uint16(output, 4));
 
-        GUARD(s2n_stuffer_write_uint8(output, message_type));
+        POSIX_GUARD(s2n_stuffer_write_uint8(output, message_type));
 
         /* Handshake message data size */
-        GUARD(s2n_stuffer_write_uint24(output, 0));
+        POSIX_GUARD(s2n_stuffer_write_uint24(output, 0));
         return 0;
     }
 
     if (record_type == TLS_CHANGE_CIPHER_SPEC) {
         /* Total message size */
-        GUARD(s2n_stuffer_write_uint16(output, 1));
+        POSIX_GUARD(s2n_stuffer_write_uint16(output, 1));
 
         /* change spec is always just 0x01 */
-        GUARD(s2n_stuffer_write_uint8(output, 1));
+        POSIX_GUARD(s2n_stuffer_write_uint8(output, 1));
         return 0;
     }
 
@@ -568,7 +568,7 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
             conn->actual_protocol_version = S2N_TLS13;
-            GUARD(s2n_connection_set_client_auth_type(conn, S2N_CERT_AUTH_OPTIONAL));
+            POSIX_GUARD(s2n_connection_set_client_auth_type(conn, S2N_CERT_AUTH_OPTIONAL));
 
             struct s2n_stuffer input;
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));

--- a/tests/unit/s2n_tls13_server_cert_test.c
+++ b/tests/unit/s2n_tls13_server_cert_test.c
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
         /* convert certificate chain hex to bytes*/
         struct s2n_blob tls13_cert = {0};
         EXPECT_SUCCESS(s2n_alloc(&tls13_cert, strlen(tls13_cert_chain_hex) / 2 ));
-        GUARD(s2n_hex_string_to_bytes((uint8_t*)tls13_cert_chain_hex, &tls13_cert));
+        POSIX_GUARD(s2n_hex_string_to_bytes((uint8_t*)tls13_cert_chain_hex, &tls13_cert));
 
         S2N_BLOB_FROM_HEX(tls13_cert_chain, tls13_cert_hex);
 

--- a/tests/unit/s2n_tls13_server_finished_test.c
+++ b/tests/unit/s2n_tls13_server_finished_test.c
@@ -23,8 +23,8 @@
 
 static int reset_stuffers(struct s2n_stuffer *reread, struct s2n_stuffer *wipe)
 {
-    GUARD(s2n_stuffer_reread(reread));
-    GUARD(s2n_stuffer_wipe(wipe));
+    POSIX_GUARD(s2n_stuffer_reread(reread));
+    POSIX_GUARD(s2n_stuffer_wipe(wipe));
     return 0;
 }
 

--- a/tests/unit/s2n_tls_hybrid_prf_test.c
+++ b/tests/unit/s2n_tls_hybrid_prf_test.c
@@ -54,9 +54,9 @@ int main(int argc, char **argv)
     for (uint32_t i = 0; i < NUM_TEST_VECTORS; i++) {
         /* Verify test index */
         uint32_t count = 0;
-        GUARD(FindMarker(kat_file, "count = "));
-        gt_check(fscanf(kat_file, "%u", &count), 0);
-        eq_check(count, i);
+        POSIX_GUARD(FindMarker(kat_file, "count = "));
+        POSIX_ENSURE_GT(fscanf(kat_file, "%u", &count), 0);
+        POSIX_ENSURE_EQ(count, i);
 
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
@@ -68,26 +68,26 @@ int main(int argc, char **argv)
         uint32_t premaster_kem_secret_length = 0;
         uint32_t client_key_exchange_message_length = 0;
 
-        GUARD(ReadHex(kat_file, premaster_classic_secret, PREMASTER_CLASSIC_SECRET_LENGTH, "premaster_classic_secret = "));
+        POSIX_GUARD(ReadHex(kat_file, premaster_classic_secret, PREMASTER_CLASSIC_SECRET_LENGTH, "premaster_classic_secret = "));
 
-        GUARD(FindMarker(kat_file, "premaster_kem_secret_length = "));
-        gt_check(fscanf(kat_file, "%u", &premaster_kem_secret_length), 0);
+        POSIX_GUARD(FindMarker(kat_file, "premaster_kem_secret_length = "));
+        POSIX_ENSURE_GT(fscanf(kat_file, "%u", &premaster_kem_secret_length), 0);
 
         uint8_t *premaster_kem_secret;
-        notnull_check(premaster_kem_secret = malloc(premaster_kem_secret_length));
-        GUARD(ReadHex(kat_file, premaster_kem_secret, premaster_kem_secret_length, "premaster_kem_secret = "));
+        POSIX_ENSURE_REF(premaster_kem_secret = malloc(premaster_kem_secret_length));
+        POSIX_GUARD(ReadHex(kat_file, premaster_kem_secret, premaster_kem_secret_length, "premaster_kem_secret = "));
 
-        GUARD(ReadHex(kat_file, client_random, CLIENT_RANDOM_LENGTH, "client_random = "));
-        GUARD(ReadHex(kat_file, server_random, SERVER_RANDOM_LENGTH, "server_random = "));
+        POSIX_GUARD(ReadHex(kat_file, client_random, CLIENT_RANDOM_LENGTH, "client_random = "));
+        POSIX_GUARD(ReadHex(kat_file, server_random, SERVER_RANDOM_LENGTH, "server_random = "));
 
-        GUARD(FindMarker(kat_file, "client_key_exchange_message_length = "));
-        gt_check(fscanf(kat_file, "%u", &client_key_exchange_message_length), 0);
+        POSIX_GUARD(FindMarker(kat_file, "client_key_exchange_message_length = "));
+        POSIX_ENSURE_GT(fscanf(kat_file, "%u", &client_key_exchange_message_length), 0);
 
         uint8_t *client_key_exchange_message;
-        notnull_check(client_key_exchange_message = malloc(client_key_exchange_message_length));
-        GUARD(ReadHex(kat_file, client_key_exchange_message, client_key_exchange_message_length, "client_key_exchange_message = "));
+        POSIX_ENSURE_REF(client_key_exchange_message = malloc(client_key_exchange_message_length));
+        POSIX_GUARD(ReadHex(kat_file, client_key_exchange_message, client_key_exchange_message_length, "client_key_exchange_message = "));
 
-        GUARD(ReadHex(kat_file, expected_master_secret, MASTER_SECRET_LENGTH, "master_secret = "));
+        POSIX_GUARD(ReadHex(kat_file, expected_master_secret, MASTER_SECRET_LENGTH, "master_secret = "));
 
         struct s2n_blob classic_pms = {.data = premaster_classic_secret, .size = PREMASTER_CLASSIC_SECRET_LENGTH};
         struct s2n_blob kem_pms = {.data = premaster_kem_secret, .size = premaster_kem_secret_length};

--- a/tests/unit/s2n_utils_test.c
+++ b/tests/unit/s2n_utils_test.c
@@ -21,7 +21,7 @@
 
 #define test_stack_blob_success(test_name, macro_name, requested, max) int test_name() {\
 macro_name(test_name ## blob, requested, max); \
-eq_check(test_name ## blob.size, requested); \
+POSIX_ENSURE_EQ(test_name ## blob.size, requested); \
 return 0; \
 }
 
@@ -33,19 +33,19 @@ test_stack_blob_success(success_equal_smaller, s2n_stack_blob, 10, 100)
 int requested_bigger_than_max() {
     s2n_stack_blob(foo, 11, 10);
     /* This should never be reached due to the above failure */
-    eq_check(foo.allocated, 0);
+    POSIX_ENSURE_EQ(foo.allocated, 0);
 
     return 0;
 }
 
 int succesful_stack_blob() {
     s2n_stack_blob(foo, 10, 10);
-    eq_check(foo.size, 10);
-    eq_check(foo.allocated, 0);
+    POSIX_ENSURE_EQ(foo.size, 10);
+    POSIX_ENSURE_EQ(foo.allocated, 0);
 
     s2n_stack_blob(foo2, 1, 10);
-    eq_check(foo2.size, 1);
-    eq_check(foo2.allocated, 0);
+    POSIX_ENSURE_EQ(foo2.size, 1);
+    POSIX_ENSURE_EQ(foo2.allocated, 0);
 
     return 0;
 }

--- a/tls/extensions/s2n_client_alpn.c
+++ b/tls/extensions/s2n_client_alpn.c
@@ -49,11 +49,11 @@ static bool s2n_client_alpn_should_send(struct s2n_connection *conn)
 static int s2n_client_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     struct s2n_blob *client_app_protocols;
-    GUARD(s2n_connection_get_protocol_preferences(conn, &client_app_protocols));
-    notnull_check(client_app_protocols);
+    POSIX_GUARD(s2n_connection_get_protocol_preferences(conn, &client_app_protocols));
+    POSIX_ENSURE_REF(client_app_protocols);
 
-    GUARD(s2n_stuffer_write_uint16(out, client_app_protocols->size));
-    GUARD(s2n_stuffer_write(out, client_app_protocols));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, client_app_protocols->size));
+    POSIX_GUARD(s2n_stuffer_write(out, client_app_protocols));
 
     return S2N_SUCCESS;
 }
@@ -64,14 +64,14 @@ static int s2n_client_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer 
     struct s2n_stuffer server_protos = {0};
 
     struct s2n_blob *server_app_protocols;
-    GUARD(s2n_connection_get_protocol_preferences(conn, &server_app_protocols));
+    POSIX_GUARD(s2n_connection_get_protocol_preferences(conn, &server_app_protocols));
 
     if (!server_app_protocols->size) {
         /* No protocols configured, nothing to do */
         return S2N_SUCCESS;
     }
 
-    GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
+    POSIX_GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
     if (size_of_all > s2n_stuffer_data_available(extension) || size_of_all < 3) {
         /* Malformed length, ignore the extension */
         return S2N_SUCCESS;
@@ -80,23 +80,23 @@ static int s2n_client_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer 
     struct s2n_blob client_app_protocols = { 0 };
     client_app_protocols.size = size_of_all;
     client_app_protocols.data = s2n_stuffer_raw_read(extension, size_of_all);
-    notnull_check(client_app_protocols.data);
+    POSIX_ENSURE_REF(client_app_protocols.data);
 
     /* Find a matching protocol */
-    GUARD(s2n_stuffer_init(&server_protos, server_app_protocols));
-    GUARD(s2n_stuffer_skip_write(&server_protos, server_app_protocols->size));
+    POSIX_GUARD(s2n_stuffer_init(&server_protos, server_app_protocols));
+    POSIX_GUARD(s2n_stuffer_skip_write(&server_protos, server_app_protocols->size));
 
     while (s2n_stuffer_data_available(&server_protos) > 0) {
         struct s2n_blob server_protocol = { 0 };
-        ENSURE_POSIX(s2n_result_is_ok(s2n_protocol_preferences_read(&server_protos, &server_protocol)),
+        POSIX_ENSURE(s2n_result_is_ok(s2n_protocol_preferences_read(&server_protos, &server_protocol)),
                 S2N_ERR_BAD_MESSAGE);
 
         bool is_match = false;
-        ENSURE_POSIX(s2n_result_is_ok(s2n_protocol_preferences_contain(&client_app_protocols, &server_protocol, &is_match)),
+        POSIX_ENSURE(s2n_result_is_ok(s2n_protocol_preferences_contain(&client_app_protocols, &server_protocol, &is_match)),
                 S2N_ERR_BAD_MESSAGE);
 
         if (is_match) {
-            memcpy_check(conn->application_protocol, server_protocol.data, server_protocol.size);
+            POSIX_CHECKED_MEMCPY(conn->application_protocol, server_protocol.data, server_protocol.size);
             conn->application_protocol[server_protocol.size] = '\0';
             return S2N_SUCCESS;
         }

--- a/tls/extensions/s2n_client_early_data_indication.c
+++ b/tls/extensions/s2n_client_early_data_indication.c
@@ -26,24 +26,24 @@
 
 static S2N_RESULT s2n_early_data_config_is_possible(struct s2n_connection *conn)
 {
-    ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn);
 
     struct s2n_psk *first_psk = NULL;
-    GUARD_RESULT(s2n_array_get(&conn->psk_params.psk_list, 0, (void**) &first_psk));
-    ENSURE_REF(first_psk);
+    RESULT_GUARD(s2n_array_get(&conn->psk_params.psk_list, 0, (void**) &first_psk));
+    RESULT_ENSURE_REF(first_psk);
 
     struct s2n_early_data_config *early_data_config = &first_psk->early_data_config;
 
     /* Must support early data */
-    ENSURE_GT(early_data_config->max_early_data_size, 0);
+    RESULT_ENSURE_GT(early_data_config->max_early_data_size, 0);
 
     /* Early data must require a protocol than we could negotiate */
-    ENSURE_GTE(s2n_connection_get_protocol_version(conn), early_data_config->protocol_version);
-    ENSURE_GTE(s2n_connection_get_protocol_version(conn), S2N_TLS13);
+    RESULT_ENSURE_GTE(s2n_connection_get_protocol_version(conn), early_data_config->protocol_version);
+    RESULT_ENSURE_GTE(s2n_connection_get_protocol_version(conn), S2N_TLS13);
 
     const struct s2n_cipher_preferences *cipher_preferences = NULL;
-    GUARD_AS_RESULT(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
-    ENSURE_REF(cipher_preferences);
+    RESULT_GUARD_POSIX(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+    RESULT_ENSURE_REF(cipher_preferences);
 
     /* Early data must require a supported cipher */
     bool match = false;
@@ -53,17 +53,17 @@ static S2N_RESULT s2n_early_data_config_is_possible(struct s2n_connection *conn)
             break;
         }
     }
-    ENSURE_EQ(match, true);
+    RESULT_ENSURE_EQ(match, true);
 
     /* If early data specifies an application protocol, it must be supported by protocol preferences */
     if (early_data_config->application_protocol.size > 0) {
         struct s2n_blob *application_protocols = NULL;
-        GUARD_AS_RESULT(s2n_connection_get_protocol_preferences(conn, &application_protocols));
-        ENSURE_REF(application_protocols);
+        RESULT_GUARD_POSIX(s2n_connection_get_protocol_preferences(conn, &application_protocols));
+        RESULT_ENSURE_REF(application_protocols);
 
         match = false;
-        GUARD_RESULT(s2n_protocol_preferences_contain(application_protocols, &early_data_config->application_protocol, &match));
-        ENSURE_EQ(match, true);
+        RESULT_GUARD(s2n_protocol_preferences_contain(application_protocols, &early_data_config->application_protocol, &match));
+        RESULT_ENSURE_EQ(match, true);
     }
 
     return S2N_RESULT_OK;
@@ -127,7 +127,7 @@ static int s2n_client_early_data_indiction_recv(struct s2n_connection *conn, str
      *# A client MUST NOT include the
      *# "early_data" extension in its followup ClientHello.
      */
-    ENSURE_POSIX(!s2n_is_hello_retry_handshake(conn), S2N_ERR_UNSUPPORTED_EXTENSION);
+    POSIX_ENSURE(!s2n_is_hello_retry_handshake(conn), S2N_ERR_UNSUPPORTED_EXTENSION);
 
     POSIX_GUARD_RESULT(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_REQUESTED));
     return S2N_SUCCESS;

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -63,13 +63,13 @@ const s2n_extension_type s2n_client_key_share_extension = {
 
 static int s2n_generate_preferred_ecc_key_shares(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     uint8_t preferred_key_shares = conn->preferred_key_shares;
     struct s2n_ecc_evp_params *ecc_evp_params = NULL;
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    POSIX_ENSURE_REF(ecc_pref);
 
     /* If lsb is set, skip keyshare generation for all curve */
     if (S2N_IS_KEY_SHARE_LIST_EMPTY(preferred_key_shares)) {
@@ -81,7 +81,7 @@ static int s2n_generate_preferred_ecc_key_shares(struct s2n_connection *conn, st
         if (S2N_IS_KEY_SHARE_REQUESTED(preferred_key_shares, i)) {
             ecc_evp_params = &conn->secure.client_ecc_evp_params[i];
             ecc_evp_params->negotiated_curve = ecc_pref->ecc_curves[i];
-            GUARD(s2n_ecdhe_parameters_send(ecc_evp_params, out));
+            POSIX_GUARD(s2n_ecdhe_parameters_send(ecc_evp_params, out));
         }
     }
 
@@ -90,28 +90,28 @@ static int s2n_generate_preferred_ecc_key_shares(struct s2n_connection *conn, st
 
 static int s2n_generate_default_ecc_key_share(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    POSIX_ENSURE_REF(ecc_pref);
 
     struct s2n_ecc_evp_params *ecc_evp_params = NULL;
     ecc_evp_params = &conn->secure.client_ecc_evp_params[0];
     ecc_evp_params->negotiated_curve = ecc_pref->ecc_curves[0];
-    GUARD(s2n_ecdhe_parameters_send(ecc_evp_params, out));
+    POSIX_GUARD(s2n_ecdhe_parameters_send(ecc_evp_params, out));
 
     return S2N_SUCCESS;
 }
 
 static int s2n_generate_pq_hybrid_key_share(struct s2n_stuffer *out, struct s2n_kem_group_params *kem_group_params) {
-    notnull_check(out);
-    notnull_check(kem_group_params);
+    POSIX_ENSURE_REF(out);
+    POSIX_ENSURE_REF(kem_group_params);
 
     /* This function should never be called when PQ is disabled */
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
     const struct s2n_kem_group *kem_group = kem_group_params->kem_group;
-    notnull_check(kem_group);
+    POSIX_ENSURE_REF(kem_group);
 
     /* The structure of the PQ share is:
      *    IANA ID (2 bytes)
@@ -120,29 +120,29 @@ static int s2n_generate_pq_hybrid_key_share(struct s2n_stuffer *out, struct s2n_
      * || ECC key share (variable bytes)
      * || size of PQ key share (2 bytes)
      * || PQ key share (variable bytes) */
-    GUARD(s2n_stuffer_write_uint16(out, kem_group->iana_id));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, kem_group->iana_id));
 
     struct s2n_stuffer_reservation total_share_size = {0};
-    GUARD(s2n_stuffer_reserve_uint16(out, &total_share_size));
+    POSIX_GUARD(s2n_stuffer_reserve_uint16(out, &total_share_size));
 
     struct s2n_ecc_evp_params *ecc_params = &kem_group_params->ecc_params;
     ecc_params->negotiated_curve = kem_group->curve;
-    GUARD(s2n_stuffer_write_uint16(out, ecc_params->negotiated_curve->share_size));
-    GUARD(s2n_ecc_evp_generate_ephemeral_key(ecc_params));
-    GUARD(s2n_ecc_evp_write_params_point(ecc_params, out));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, ecc_params->negotiated_curve->share_size));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(ecc_params));
+    POSIX_GUARD(s2n_ecc_evp_write_params_point(ecc_params, out));
 
     struct s2n_kem_params *kem_params = &kem_group_params->kem_params;
     kem_params->kem = kem_group->kem;
-    GUARD(s2n_kem_send_public_key(out, kem_params));
+    POSIX_GUARD(s2n_kem_send_public_key(out, kem_params));
 
-    GUARD(s2n_stuffer_write_vector_size(&total_share_size));
+    POSIX_GUARD(s2n_stuffer_write_vector_size(&total_share_size));
 
     return S2N_SUCCESS;
 }
 
 static int s2n_generate_default_pq_hybrid_key_share(struct s2n_connection *conn, struct s2n_stuffer *out) {
-    notnull_check(conn);
-    notnull_check(out);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(out);
 
     /* Client should skip sending PQ groups/key shares if PQ is disabled */
     if (!s2n_pq_is_enabled()) {
@@ -150,8 +150,8 @@ static int s2n_generate_default_pq_hybrid_key_share(struct s2n_connection *conn,
     }
 
     const struct s2n_kem_preferences *kem_pref = NULL;
-    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
-    notnull_check(kem_pref);
+    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+    POSIX_ENSURE_REF(kem_pref);
 
     if (kem_pref->tls13_kem_group_count == 0) {
         return S2N_SUCCESS;
@@ -161,29 +161,29 @@ static int s2n_generate_default_pq_hybrid_key_share(struct s2n_connection *conn,
     struct s2n_kem_group_params *kem_group_params = &conn->secure.client_kem_group_params[0];
     kem_group_params->kem_group = kem_pref->tls13_kem_groups[0];
 
-    GUARD(s2n_generate_pq_hybrid_key_share(out, kem_group_params));
+    POSIX_GUARD(s2n_generate_pq_hybrid_key_share(out, kem_group_params));
 
     return S2N_SUCCESS;
 }
 
 static int s2n_wipe_all_client_keyshares(struct s2n_connection *conn) {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    POSIX_ENSURE_REF(ecc_pref);
 
     const struct s2n_kem_preferences *kem_pref = NULL;
-    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
-    notnull_check(kem_pref);
+    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+    POSIX_ENSURE_REF(kem_pref);
 
     for (size_t i = 0; i < ecc_pref->count; i++) {
-        GUARD(s2n_ecc_evp_params_free(&conn->secure.client_ecc_evp_params[i]));
+        POSIX_GUARD(s2n_ecc_evp_params_free(&conn->secure.client_ecc_evp_params[i]));
         conn->secure.client_ecc_evp_params[i].negotiated_curve = NULL;
     }
 
     for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-        GUARD(s2n_kem_group_free(&conn->secure.client_kem_group_params[i]));
+        POSIX_GUARD(s2n_kem_group_free(&conn->secure.client_kem_group_params[i]));
         conn->secure.client_kem_group_params[i].kem_group = NULL;
         conn->secure.client_kem_group_params[i].kem_params.kem = NULL;
         conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve = NULL;
@@ -194,67 +194,67 @@ static int s2n_wipe_all_client_keyshares(struct s2n_connection *conn) {
 
 static int s2n_send_hrr_ecc_keyshare(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     const struct s2n_ecc_named_curve *server_negotiated_curve = NULL;
     struct s2n_ecc_evp_params *ecc_evp_params = NULL;
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    POSIX_ENSURE_REF(ecc_pref);
 
     server_negotiated_curve = conn->secure.server_ecc_evp_params.negotiated_curve;
-    ENSURE_POSIX(server_negotiated_curve != NULL, S2N_ERR_BAD_KEY_SHARE);
-    ENSURE_POSIX(s2n_ecc_preferences_includes_curve(ecc_pref, server_negotiated_curve->iana_id),
+    POSIX_ENSURE(server_negotiated_curve != NULL, S2N_ERR_BAD_KEY_SHARE);
+    POSIX_ENSURE(s2n_ecc_preferences_includes_curve(ecc_pref, server_negotiated_curve->iana_id),
             S2N_ERR_INVALID_HELLO_RETRY);
 
     for (size_t i = 0; i < ecc_pref->count; i++) {
         if (ecc_pref->ecc_curves[i]->iana_id == server_negotiated_curve->iana_id) {
             ecc_evp_params = &conn->secure.client_ecc_evp_params[i];
-            ENSURE_POSIX(ecc_evp_params->evp_pkey == NULL, S2N_ERR_INVALID_HELLO_RETRY);
+            POSIX_ENSURE(ecc_evp_params->evp_pkey == NULL, S2N_ERR_INVALID_HELLO_RETRY);
         }
     }
 
     /* None of the previously generated keyshares were selected for negotiation, so wipe them */
-    GUARD(s2n_wipe_all_client_keyshares(conn));
+    POSIX_GUARD(s2n_wipe_all_client_keyshares(conn));
     /* Generate the keyshare for the server negotiated curve */
     ecc_evp_params->negotiated_curve = server_negotiated_curve;
-    GUARD(s2n_ecdhe_parameters_send(ecc_evp_params, out));
+    POSIX_GUARD(s2n_ecdhe_parameters_send(ecc_evp_params, out));
 
     return S2N_SUCCESS;
 }
 
 static int s2n_send_hrr_pq_hybrid_keyshare(struct s2n_connection *conn, struct s2n_stuffer *out) {
-    notnull_check(conn);
-    notnull_check(out);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(out);
 
     /* If PQ is disabled, the client should not have sent any PQ IDs
      * in the supported_groups list of the initial ClientHello */
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
     const struct s2n_kem_preferences *kem_pref = NULL;
-    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
-    notnull_check(kem_pref);
+    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+    POSIX_ENSURE_REF(kem_pref);
 
     const struct s2n_kem_group *server_negotiated_kem_group = conn->secure.server_kem_group_params.kem_group;
-    ENSURE_POSIX(server_negotiated_kem_group != NULL, S2N_ERR_INVALID_HELLO_RETRY);
-    ENSURE_POSIX(s2n_kem_preferences_includes_tls13_kem_group(kem_pref, server_negotiated_kem_group->iana_id),
+    POSIX_ENSURE(server_negotiated_kem_group != NULL, S2N_ERR_INVALID_HELLO_RETRY);
+    POSIX_ENSURE(s2n_kem_preferences_includes_tls13_kem_group(kem_pref, server_negotiated_kem_group->iana_id),
             S2N_ERR_INVALID_HELLO_RETRY);
     struct s2n_kem_group_params *kem_group_params = NULL;
 
     for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
         if (kem_pref->tls13_kem_groups[i]->iana_id == server_negotiated_kem_group->iana_id) {
             kem_group_params = &conn->secure.client_kem_group_params[i];
-            ENSURE_POSIX(kem_group_params->kem_group == NULL, S2N_ERR_INVALID_HELLO_RETRY);
-            ENSURE_POSIX(kem_group_params->ecc_params.evp_pkey == NULL, S2N_ERR_INVALID_HELLO_RETRY);
-            ENSURE_POSIX(kem_group_params->kem_params.private_key.data == NULL, S2N_ERR_INVALID_HELLO_RETRY);
+            POSIX_ENSURE(kem_group_params->kem_group == NULL, S2N_ERR_INVALID_HELLO_RETRY);
+            POSIX_ENSURE(kem_group_params->ecc_params.evp_pkey == NULL, S2N_ERR_INVALID_HELLO_RETRY);
+            POSIX_ENSURE(kem_group_params->kem_params.private_key.data == NULL, S2N_ERR_INVALID_HELLO_RETRY);
         }
     }
 
     /* None of the previously generated keyshares were selected for negotiation, so wipe them */
-    GUARD(s2n_wipe_all_client_keyshares(conn));
+    POSIX_GUARD(s2n_wipe_all_client_keyshares(conn));
     /* Generate the keyshare for the server negotiated KEM group */
     kem_group_params->kem_group = server_negotiated_kem_group;
-    GUARD(s2n_generate_pq_hybrid_key_share(out, kem_group_params));
+    POSIX_GUARD(s2n_generate_pq_hybrid_key_share(out, kem_group_params));
 
     return S2N_SUCCESS;
 }
@@ -264,13 +264,13 @@ static int s2n_send_hrr_pq_hybrid_keyshare(struct s2n_connection *conn, struct s
  * replace the list of shares with a list containing a single
  * KeyShareEntry from the indicated group.*/
 static int s2n_send_hrr_keyshare(struct s2n_connection *conn, struct s2n_stuffer *out) {
-    notnull_check(conn);
-    notnull_check(out);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(out);
 
     if (conn->secure.server_kem_group_params.kem_group != NULL) {
-        GUARD(s2n_send_hrr_pq_hybrid_keyshare(conn, out));
+        POSIX_GUARD(s2n_send_hrr_pq_hybrid_keyshare(conn, out));
     } else {
-        GUARD(s2n_send_hrr_ecc_keyshare(conn, out));
+        POSIX_GUARD(s2n_send_hrr_ecc_keyshare(conn, out));
     }
 
     return S2N_SUCCESS;
@@ -279,45 +279,45 @@ static int s2n_send_hrr_keyshare(struct s2n_connection *conn, struct s2n_stuffer
 static int s2n_ecdhe_supported_curves_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     if (!conn->preferred_key_shares) {
-        GUARD(s2n_generate_default_ecc_key_share(conn, out));
+        POSIX_GUARD(s2n_generate_default_ecc_key_share(conn, out));
         return S2N_SUCCESS;
     }
 
-    GUARD(s2n_generate_preferred_ecc_key_shares(conn, out));
+    POSIX_GUARD(s2n_generate_preferred_ecc_key_shares(conn, out));
     return S2N_SUCCESS;
 }
 
 static int s2n_client_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     struct s2n_stuffer_reservation shares_size = {0};
-    GUARD(s2n_stuffer_reserve_uint16(out, &shares_size));
+    POSIX_GUARD(s2n_stuffer_reserve_uint16(out, &shares_size));
 
     if (s2n_is_hello_retry_handshake(conn)) {
-        GUARD(s2n_send_hrr_keyshare(conn, out));
+        POSIX_GUARD(s2n_send_hrr_keyshare(conn, out));
     } else {
-        GUARD(s2n_generate_default_pq_hybrid_key_share(conn, out));
-        GUARD(s2n_ecdhe_supported_curves_send(conn, out));
+        POSIX_GUARD(s2n_generate_default_pq_hybrid_key_share(conn, out));
+        POSIX_GUARD(s2n_ecdhe_supported_curves_send(conn, out));
     }
 
-    GUARD(s2n_stuffer_write_vector_size(&shares_size));
+    POSIX_GUARD(s2n_stuffer_write_vector_size(&shares_size));
 
     return S2N_SUCCESS;
 }
 
 static int s2n_client_key_share_parse_ecc(struct s2n_stuffer *key_share, const struct s2n_ecc_named_curve *curve,
         struct s2n_ecc_evp_params *ecc_params) {
-    notnull_check(key_share);
-    notnull_check(curve);
-    notnull_check(ecc_params);
+    POSIX_ENSURE_REF(key_share);
+    POSIX_ENSURE_REF(curve);
+    POSIX_ENSURE_REF(ecc_params);
 
     struct s2n_blob point_blob = { 0 };
-    GUARD(s2n_ecc_evp_read_params_point(key_share, curve->share_size, &point_blob));
+    POSIX_GUARD(s2n_ecc_evp_read_params_point(key_share, curve->share_size, &point_blob));
 
     /* Ignore curves with points we can't parse */
     ecc_params->negotiated_curve = curve;
     if (s2n_ecc_evp_parse_params_point(&point_blob, ecc_params) != S2N_SUCCESS) {
         ecc_params->negotiated_curve = NULL;
-        GUARD(s2n_ecc_evp_params_free(ecc_params));
+        POSIX_GUARD(s2n_ecc_evp_params_free(ecc_params));
     }
 
     return S2N_SUCCESS;
@@ -325,13 +325,13 @@ static int s2n_client_key_share_parse_ecc(struct s2n_stuffer *key_share, const s
 
 static int s2n_client_key_share_recv_ecc(struct s2n_connection *conn, struct s2n_stuffer *key_share,
         uint16_t curve_iana_id, bool *match) {
-    notnull_check(conn);
-    notnull_check(key_share);
-    notnull_check(match);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(key_share);
+    POSIX_ENSURE_REF(match);
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    POSIX_ENSURE_REF(ecc_pref);
 
     const struct s2n_ecc_named_curve *curve = NULL;
     struct s2n_ecc_evp_params *client_ecc_params = NULL;
@@ -358,7 +358,7 @@ static int s2n_client_key_share_recv_ecc(struct s2n_connection *conn, struct s2n
         return S2N_SUCCESS;
     }
 
-    GUARD(s2n_client_key_share_parse_ecc(key_share, curve, client_ecc_params));
+    POSIX_GUARD(s2n_client_key_share_parse_ecc(key_share, curve, client_ecc_params));
     /* negotiated_curve will be non-NULL if the key share was parsed successfully */
     if (client_ecc_params->negotiated_curve) {
         *match = true;
@@ -369,13 +369,13 @@ static int s2n_client_key_share_recv_ecc(struct s2n_connection *conn, struct s2n
 
 static int s2n_client_key_share_recv_pq_hybrid(struct s2n_connection *conn, struct s2n_stuffer *key_share,
         uint16_t kem_group_iana_id, bool *match) {
-    notnull_check(conn);
-    notnull_check(key_share);
-    notnull_check(match);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(key_share);
+    POSIX_ENSURE_REF(match);
 
     const struct s2n_kem_preferences *kem_pref = NULL;
-    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
-    notnull_check(kem_pref);
+    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+    POSIX_ENSURE_REF(kem_pref);
 
     /* Ignore key share if PQ is not enabled */
     if (!s2n_pq_is_enabled()) {
@@ -408,13 +408,13 @@ static int s2n_client_key_share_recv_pq_hybrid(struct s2n_connection *conn, stru
     }
 
     uint16_t ec_share_size = 0;
-    GUARD(s2n_stuffer_read_uint16(key_share, &ec_share_size));
+    POSIX_GUARD(s2n_stuffer_read_uint16(key_share, &ec_share_size));
     /* Ignore KEM groups with unexpected ECC share sizes */
     if (ec_share_size != kem_group->curve->share_size) {
         return S2N_SUCCESS;
     }
 
-    GUARD(s2n_client_key_share_parse_ecc(key_share, kem_group->curve, &client_kem_group_params->ecc_params));
+    POSIX_GUARD(s2n_client_key_share_parse_ecc(key_share, kem_group->curve, &client_kem_group_params->ecc_params));
     /* If we were unable to parse the EC portion of the share, negotiated_curve
      * will be NULL, and we should ignore the entire key share. */
     if (!client_kem_group_params->ecc_params.negotiated_curve) {
@@ -429,7 +429,7 @@ static int s2n_client_key_share_recv_pq_hybrid(struct s2n_connection *conn, stru
         client_kem_group_params->kem_params.kem = NULL;
         client_kem_group_params->ecc_params.negotiated_curve = NULL;
         /* s2n_kem_group_free() will free both the ECC and KEM params */
-        GUARD(s2n_kem_group_free(client_kem_group_params));
+        POSIX_GUARD(s2n_kem_group_free(client_kem_group_params));
         return S2N_SUCCESS;
     }
 
@@ -439,24 +439,24 @@ static int s2n_client_key_share_recv_pq_hybrid(struct s2n_connection *conn, stru
 }
 
 static int s2n_client_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension) {
-    notnull_check(conn);
-    notnull_check(extension);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(extension);
 
     if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
         return S2N_SUCCESS;
     }
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    POSIX_ENSURE_REF(ecc_pref);
 
     const struct s2n_kem_preferences *kem_pref = NULL;
-    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
-    notnull_check(kem_pref);
+    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+    POSIX_ENSURE_REF(kem_pref);
 
     uint16_t key_shares_size;
-    GUARD(s2n_stuffer_read_uint16(extension, &key_shares_size));
-    ENSURE_POSIX(s2n_stuffer_data_available(extension) >= key_shares_size, S2N_ERR_BAD_MESSAGE);
+    POSIX_GUARD(s2n_stuffer_read_uint16(extension, &key_shares_size));
+    POSIX_ENSURE(s2n_stuffer_data_available(extension) >= key_shares_size, S2N_ERR_BAD_MESSAGE);
 
     uint16_t named_group, share_size;
     bool match_found = false;
@@ -464,28 +464,28 @@ static int s2n_client_key_share_recv(struct s2n_connection *conn, struct s2n_stu
     uint32_t bytes_processed = 0;
 
     while (bytes_processed < key_shares_size) {
-        GUARD(s2n_stuffer_read_uint16(extension, &named_group));
-        GUARD(s2n_stuffer_read_uint16(extension, &share_size));
+        POSIX_GUARD(s2n_stuffer_read_uint16(extension, &named_group));
+        POSIX_GUARD(s2n_stuffer_read_uint16(extension, &share_size));
 
-        ENSURE_POSIX(s2n_stuffer_data_available(extension) >= share_size, S2N_ERR_BAD_MESSAGE);
+        POSIX_ENSURE(s2n_stuffer_data_available(extension) >= share_size, S2N_ERR_BAD_MESSAGE);
         bytes_processed += share_size + S2N_SIZE_OF_NAMED_GROUP + S2N_SIZE_OF_KEY_SHARE_SIZE;
 
         struct s2n_blob key_share_blob = { .size = share_size, .data = s2n_stuffer_raw_read(extension, share_size) };
-        notnull_check(key_share_blob.data);
+        POSIX_ENSURE_REF(key_share_blob.data);
         struct s2n_stuffer key_share = { 0 };
-        GUARD(s2n_stuffer_init(&key_share, &key_share_blob));
-        GUARD(s2n_stuffer_skip_write(&key_share, share_size));
+        POSIX_GUARD(s2n_stuffer_init(&key_share, &key_share_blob));
+        POSIX_GUARD(s2n_stuffer_skip_write(&key_share, share_size));
 
         /* Try to parse the share as ECC, then as PQ/hybrid; will ignore
          * shares for unrecognized groups. */
-        GUARD(s2n_client_key_share_recv_ecc(conn, &key_share, named_group, &match_found));
-        GUARD(s2n_client_key_share_recv_pq_hybrid(conn, &key_share, named_group, &match_found));
+        POSIX_GUARD(s2n_client_key_share_recv_ecc(conn, &key_share, named_group, &match_found));
+        POSIX_GUARD(s2n_client_key_share_recv_pq_hybrid(conn, &key_share, named_group, &match_found));
     }
 
     /* If there were no matching key shares, then we received an empty key share extension
      * or we didn't match a key share with a supported group. We should send a retry. */
     if (!match_found) {
-        GUARD(s2n_set_hello_retry_required(conn));
+        POSIX_GUARD(s2n_set_hello_retry_required(conn));
     }
 
     return S2N_SUCCESS;
@@ -495,11 +495,11 @@ static int s2n_client_key_share_recv(struct s2n_connection *conn, struct s2n_stu
 
 uint32_t s2n_extensions_client_key_share_size(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    POSIX_ENSURE_REF(ecc_pref);
 
     uint32_t s2n_client_key_share_extension_size = S2N_SIZE_OF_EXTENSION_TYPE
             + S2N_SIZE_OF_EXTENSION_DATA_SIZE

--- a/tls/extensions/s2n_client_max_frag_len.c
+++ b/tls/extensions/s2n_client_max_frag_len.c
@@ -52,7 +52,7 @@ static int s2n_client_max_frag_len_recv(struct s2n_connection *conn, struct s2n_
     }
 
     uint8_t mfl_code;
-    GUARD(s2n_stuffer_read_uint8(extension, &mfl_code));
+    POSIX_GUARD(s2n_stuffer_read_uint8(extension, &mfl_code));
     if (mfl_code > S2N_TLS_MAX_FRAG_LEN_4096 || mfl_code_to_length[mfl_code] > S2N_TLS_MAXIMUM_FRAGMENT_LENGTH) {
         return S2N_SUCCESS;
     }

--- a/tls/extensions/s2n_client_pq_kem.c
+++ b/tls/extensions/s2n_client_pq_kem.c
@@ -49,12 +49,12 @@ static bool s2n_client_pq_kem_should_send(struct s2n_connection *conn)
 static int s2n_client_pq_kem_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     const struct s2n_kem_preferences *kem_preferences = NULL;
-    GUARD(s2n_connection_get_kem_preferences(conn, &kem_preferences));
-    notnull_check(kem_preferences);
+    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_preferences));
+    POSIX_ENSURE_REF(kem_preferences);
 
-    GUARD(s2n_stuffer_write_uint16(out, kem_preferences->kem_count * sizeof(kem_extension_size)));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, kem_preferences->kem_count * sizeof(kem_extension_size)));
     for (int i = 0; i < kem_preferences->kem_count; i++) {
-        GUARD(s2n_stuffer_write_uint16(out, kem_preferences->kems[i]->kem_extension_id));
+        POSIX_GUARD(s2n_stuffer_write_uint16(out, kem_preferences->kems[i]->kem_extension_id));
     }
 
     return S2N_SUCCESS;
@@ -70,7 +70,7 @@ static int s2n_client_pq_kem_recv(struct s2n_connection *conn, struct s2n_stuffe
         return S2N_SUCCESS;
     }
 
-    GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
+    POSIX_GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
     if (size_of_all > s2n_stuffer_data_available(extension) || size_of_all % sizeof(kem_extension_size)) {
         /* Malformed length, ignore the extension */
         return S2N_SUCCESS;
@@ -78,7 +78,7 @@ static int s2n_client_pq_kem_recv(struct s2n_connection *conn, struct s2n_stuffe
 
     proposed_kems->size = size_of_all;
     proposed_kems->data = s2n_stuffer_raw_read(extension, proposed_kems->size);
-    notnull_check(proposed_kems->data);
+    POSIX_ENSURE_REF(proposed_kems->data);
 
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -43,7 +43,7 @@ const s2n_extension_type s2n_client_psk_extension = {
 
 int s2n_client_psk_is_missing(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     /* If the PSK extension is missing, we must not have received
      * a request for early data.
@@ -54,7 +54,7 @@ int s2n_client_psk_is_missing(struct s2n_connection *conn)
      *# client opts to do so, it MUST supply both the "pre_shared_key" and
      *# "early_data" extensions.
      */
-    ENSURE_POSIX(conn->early_data_state != S2N_EARLY_DATA_REQUESTED, S2N_ERR_UNSUPPORTED_EXTENSION);
+    POSIX_ENSURE(conn->early_data_state != S2N_EARLY_DATA_REQUESTED, S2N_ERR_UNSUPPORTED_EXTENSION);
     return S2N_SUCCESS;
 }
 
@@ -91,20 +91,20 @@ bool s2n_client_psk_should_send(struct s2n_connection *conn)
 
 static int s2n_client_psk_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     struct s2n_psk_parameters *psk_params = &conn->psk_params;
     struct s2n_array *psk_list = &psk_params->psk_list;
 
     struct s2n_stuffer_reservation identity_list_size;
-    GUARD(s2n_stuffer_reserve_uint16(out, &identity_list_size));
+    POSIX_GUARD(s2n_stuffer_reserve_uint16(out, &identity_list_size));
 
     uint16_t binder_list_size = SIZE_OF_BINDER_LIST_SIZE;
 
     for (size_t i = 0; i < psk_list->len; i++) {
         struct s2n_psk *psk = NULL;
-        GUARD_AS_POSIX(s2n_array_get(psk_list, i, (void**) &psk));
-        notnull_check(psk);
+        POSIX_GUARD_RESULT(s2n_array_get(psk_list, i, (void**) &psk));
+        POSIX_ENSURE_REF(psk);
 
         /**
          *= https://tools.ietf.org/rfc/rfc8446#section-4.1.4
@@ -117,17 +117,17 @@ static int s2n_client_psk_send(struct s2n_connection *conn, struct s2n_stuffer *
         }
 
         /* Write the identity */
-        GUARD(s2n_stuffer_write_uint16(out, psk->identity.size));
-        GUARD(s2n_stuffer_write(out, &psk->identity));
-        GUARD(s2n_stuffer_write_uint32(out, 0));
+        POSIX_GUARD(s2n_stuffer_write_uint16(out, psk->identity.size));
+        POSIX_GUARD(s2n_stuffer_write(out, &psk->identity));
+        POSIX_GUARD(s2n_stuffer_write_uint32(out, 0));
 
         /* Calculate binder size */
         uint8_t hash_size = 0;
-        GUARD(s2n_hmac_digest_size(psk->hmac_alg, &hash_size));
+        POSIX_GUARD(s2n_hmac_digest_size(psk->hmac_alg, &hash_size));
         binder_list_size += hash_size + SIZE_OF_BINDER_SIZE;
     }
 
-    GUARD(s2n_stuffer_write_vector_size(&identity_list_size));
+    POSIX_GUARD(s2n_stuffer_write_vector_size(&identity_list_size));
 
     /* Calculating the binders requires a complete ClientHello, and at this point
      * the extension size, extension list size, and message size are all blank.
@@ -135,7 +135,7 @@ static int s2n_client_psk_send(struct s2n_connection *conn, struct s2n_stuffer *
      * We'll write placeholder data to ensure the extension and extension list sizes
      * are calculated correctly, then rewrite the binders with real data later. */
     psk_params->binder_list_size = binder_list_size;
-    GUARD(s2n_stuffer_skip_write(out, binder_list_size));
+    POSIX_GUARD(s2n_stuffer_skip_write(out, binder_list_size));
 
     return S2N_SUCCESS;
 }
@@ -154,16 +154,16 @@ static int s2n_client_psk_send(struct s2n_connection *conn, struct s2n_stuffer *
 static S2N_RESULT s2n_match_psk_identity(struct s2n_array *known_psks, const struct s2n_blob *wire_identity,
         struct s2n_psk **match)
 {
-    ENSURE_REF(match);
-    ENSURE_REF(wire_identity);
-    ENSURE_REF(known_psks);
+    RESULT_ENSURE_REF(match);
+    RESULT_ENSURE_REF(wire_identity);
+    RESULT_ENSURE_REF(known_psks);
     *match = NULL;
     for (size_t i = 0; i < known_psks->len; i++) {
         struct s2n_psk *psk = NULL;
-        GUARD_RESULT(s2n_array_get(known_psks, i, (void**)&psk));
-        ENSURE_REF(psk);
-        ENSURE_REF(psk->identity.data);
-        ENSURE_REF(wire_identity->data);
+        RESULT_GUARD(s2n_array_get(known_psks, i, (void**)&psk));
+        RESULT_ENSURE_REF(psk);
+        RESULT_ENSURE_REF(psk->identity.data);
+        RESULT_ENSURE_REF(wire_identity->data);
         uint32_t compare_size = MIN(wire_identity->size, psk->identity.size);
         if (s2n_constant_time_equals(psk->identity.data, wire_identity->data, compare_size)
             & (psk->identity.size == wire_identity->size) & (!*match)) {
@@ -186,23 +186,23 @@ static S2N_RESULT s2n_match_psk_identity(struct s2n_array *known_psks, const str
  */
 static S2N_RESULT s2n_select_psk_identity(struct s2n_connection *conn, struct s2n_offered_psk_list *client_identity_list)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(client_identity_list);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(client_identity_list);
 
     struct s2n_array *server_psks = &conn->psk_params.psk_list;
     conn->psk_params.chosen_psk = NULL;
 
     for (size_t i = 0; i < server_psks->len; i++) {
         struct s2n_psk *server_psk = NULL;
-        GUARD_RESULT(s2n_array_get(server_psks, i, (void**) &server_psk));
-        ENSURE_REF(server_psk);
+        RESULT_GUARD(s2n_array_get(server_psks, i, (void**) &server_psk));
+        RESULT_ENSURE_REF(server_psk);
 
         struct s2n_offered_psk client_psk = { 0 };
         uint16_t wire_index = 0;
 
-        GUARD_AS_RESULT(s2n_offered_psk_list_reset(client_identity_list));
+        RESULT_GUARD_POSIX(s2n_offered_psk_list_reset(client_identity_list));
         while(s2n_offered_psk_list_has_next(client_identity_list)) {
-            GUARD_AS_RESULT(s2n_offered_psk_list_next(client_identity_list, &client_psk));
+            RESULT_GUARD_POSIX(s2n_offered_psk_list_next(client_identity_list, &client_psk));
             uint16_t compare_size = MIN(client_psk.identity.size, server_psk->identity.size);
             if (s2n_constant_time_equals(client_psk.identity.data, server_psk->identity.data, compare_size)
                     & (client_psk.identity.size == server_psk->identity.size)
@@ -213,111 +213,111 @@ static S2N_RESULT s2n_select_psk_identity(struct s2n_connection *conn, struct s2
             wire_index++;
         };
     }
-    ENSURE_REF(conn->psk_params.chosen_psk);
+    RESULT_ENSURE_REF(conn->psk_params.chosen_psk);
     return S2N_RESULT_OK;
 }
 
 static S2N_RESULT s2n_client_psk_recv_identity_list(struct s2n_connection *conn, struct s2n_stuffer *wire_identities_in)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(wire_identities_in);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(wire_identities_in);
 
     struct s2n_offered_psk_list identity_list = { .wire_data = *wire_identities_in };
 
     if (conn->config->psk_selection_cb) {
-        GUARD_AS_RESULT(conn->config->psk_selection_cb(conn, &identity_list, &conn->psk_params.chosen_psk_wire_index));
+        RESULT_GUARD_POSIX(conn->config->psk_selection_cb(conn, &identity_list, &conn->psk_params.chosen_psk_wire_index));
 
         struct s2n_offered_psk chosen_identity = { 0 };
-        GUARD_RESULT(s2n_offered_psk_list_get_index(&identity_list, conn->psk_params.chosen_psk_wire_index,
+        RESULT_GUARD(s2n_offered_psk_list_get_index(&identity_list, conn->psk_params.chosen_psk_wire_index,
                 &chosen_identity));
 
-        GUARD_RESULT(s2n_match_psk_identity(&conn->psk_params.psk_list, &chosen_identity.identity, &conn->psk_params.chosen_psk));
+        RESULT_GUARD(s2n_match_psk_identity(&conn->psk_params.psk_list, &chosen_identity.identity, &conn->psk_params.chosen_psk));
     } else {
-        GUARD_RESULT(s2n_select_psk_identity(conn, &identity_list));
+        RESULT_GUARD(s2n_select_psk_identity(conn, &identity_list));
     }
-    ENSURE_REF(conn->psk_params.chosen_psk);
+    RESULT_ENSURE_REF(conn->psk_params.chosen_psk);
     return S2N_RESULT_OK;
 }
 
 static S2N_RESULT s2n_client_psk_recv_binder_list(struct s2n_connection *conn, struct s2n_blob *partial_client_hello,
         struct s2n_stuffer *wire_binders_in)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(wire_binders_in);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(wire_binders_in);
 
     uint16_t wire_index = 0;
     while (s2n_stuffer_data_available(wire_binders_in) > 0) {
         uint8_t wire_binder_size = 0;
-        GUARD_AS_RESULT(s2n_stuffer_read_uint8(wire_binders_in, &wire_binder_size));
+        RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(wire_binders_in, &wire_binder_size));
 
         uint8_t *wire_binder_data;
-        ENSURE_REF(wire_binder_data = s2n_stuffer_raw_read(wire_binders_in, wire_binder_size));
+        RESULT_ENSURE_REF(wire_binder_data = s2n_stuffer_raw_read(wire_binders_in, wire_binder_size));
 
         struct s2n_blob wire_binder = { 0 };
-        GUARD_AS_RESULT(s2n_blob_init(&wire_binder, wire_binder_data, wire_binder_size));
+        RESULT_GUARD_POSIX(s2n_blob_init(&wire_binder, wire_binder_data, wire_binder_size));
 
         if (wire_index == conn->psk_params.chosen_psk_wire_index) {
-            GUARD_AS_RESULT(s2n_psk_verify_binder(conn, conn->psk_params.chosen_psk,
+            RESULT_GUARD_POSIX(s2n_psk_verify_binder(conn, conn->psk_params.chosen_psk,
                     partial_client_hello, &wire_binder));
             return S2N_RESULT_OK;
         }
         wire_index++;
     }
-    BAIL(S2N_ERR_BAD_MESSAGE);
+    RESULT_BAIL(S2N_ERR_BAD_MESSAGE);
 }
 
 static S2N_RESULT s2n_client_psk_recv_identities(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn);
 
     uint16_t identity_list_size = 0;
-    GUARD_AS_RESULT(s2n_stuffer_read_uint16(extension, &identity_list_size));
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(extension, &identity_list_size));
 
     uint8_t *identity_list_data;
-    ENSURE_REF(identity_list_data = s2n_stuffer_raw_read(extension, identity_list_size));
+    RESULT_ENSURE_REF(identity_list_data = s2n_stuffer_raw_read(extension, identity_list_size));
 
     struct s2n_blob identity_list_blob = { 0 };
-    GUARD_AS_RESULT(s2n_blob_init(&identity_list_blob, identity_list_data, identity_list_size));
+    RESULT_GUARD_POSIX(s2n_blob_init(&identity_list_blob, identity_list_data, identity_list_size));
 
     struct s2n_stuffer identity_list = { 0 };
-    GUARD_AS_RESULT(s2n_stuffer_init(&identity_list, &identity_list_blob));
-    GUARD_AS_RESULT(s2n_stuffer_skip_write(&identity_list, identity_list_blob.size));
+    RESULT_GUARD_POSIX(s2n_stuffer_init(&identity_list, &identity_list_blob));
+    RESULT_GUARD_POSIX(s2n_stuffer_skip_write(&identity_list, identity_list_blob.size));
 
     return s2n_client_psk_recv_identity_list(conn, &identity_list);
 }
 
 static S2N_RESULT s2n_client_psk_recv_binders(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn);
 
     uint16_t binder_list_size = 0;
-    GUARD_AS_RESULT(s2n_stuffer_read_uint16(extension, &binder_list_size));
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(extension, &binder_list_size));
 
     uint8_t *binder_list_data;
-    ENSURE_REF(binder_list_data = s2n_stuffer_raw_read(extension, binder_list_size));
+    RESULT_ENSURE_REF(binder_list_data = s2n_stuffer_raw_read(extension, binder_list_size));
 
     struct s2n_blob binder_list_blob = { 0 };
-    GUARD_AS_RESULT(s2n_blob_init(&binder_list_blob, binder_list_data, binder_list_size));
+    RESULT_GUARD_POSIX(s2n_blob_init(&binder_list_blob, binder_list_data, binder_list_size));
 
     struct s2n_stuffer binder_list = { 0 };
-    GUARD_AS_RESULT(s2n_stuffer_init(&binder_list, &binder_list_blob));
-    GUARD_AS_RESULT(s2n_stuffer_skip_write(&binder_list, binder_list_blob.size));
+    RESULT_GUARD_POSIX(s2n_stuffer_init(&binder_list, &binder_list_blob));
+    RESULT_GUARD_POSIX(s2n_stuffer_skip_write(&binder_list, binder_list_blob.size));
 
     /* Record the ClientHello message up to but not including the binder list.
      * This is required to calculate the binder for the chosen PSK. */
     struct s2n_blob partial_client_hello = { 0 };
     const struct s2n_stuffer *client_hello = &conn->handshake.io;
     uint32_t binders_size = binder_list_blob.size + SIZE_OF_BINDER_LIST_SIZE;
-    ENSURE_GTE(client_hello->write_cursor, binders_size);
+    RESULT_ENSURE_GTE(client_hello->write_cursor, binders_size);
     uint16_t partial_client_hello_size = client_hello->write_cursor - binders_size;
-    GUARD_AS_RESULT(s2n_blob_slice(&client_hello->blob, &partial_client_hello, 0, partial_client_hello_size));
+    RESULT_GUARD_POSIX(s2n_blob_slice(&client_hello->blob, &partial_client_hello, 0, partial_client_hello_size));
 
     return s2n_client_psk_recv_binder_list(conn, &partial_client_hello, &binder_list);
 }
 
 int s2n_client_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
         return S2N_SUCCESS;
@@ -331,11 +331,11 @@ int s2n_client_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extensi
      *# the handshake with an "illegal_parameter" alert.
      */
     s2n_extension_type_id psk_ext_id;
-    GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_PRE_SHARED_KEY, &psk_ext_id));
-    ne_check(conn->client_hello.extensions.count, 0);
+    POSIX_GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_PRE_SHARED_KEY, &psk_ext_id));
+    POSIX_ENSURE_NE(conn->client_hello.extensions.count, 0);
     uint16_t last_wire_index = conn->client_hello.extensions.count - 1;
     uint16_t extension_wire_index = conn->client_hello.extensions.parsed_extensions[psk_ext_id].wire_index;
-    ENSURE_POSIX(extension_wire_index == last_wire_index, S2N_ERR_UNSUPPORTED_EXTENSION);
+    POSIX_ENSURE(extension_wire_index == last_wire_index, S2N_ERR_UNSUPPORTED_EXTENSION);
 
     /**
      *= https://tools.ietf.org/rfc/rfc8446#section-4.2.9
@@ -346,16 +346,16 @@ int s2n_client_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extensi
      * required to be the last extension sent in the list.
      */
     s2n_extension_type_id psk_ke_mode_ext_id;
-    GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_PSK_KEY_EXCHANGE_MODES, &psk_ke_mode_ext_id));
-    ENSURE_POSIX(S2N_CBIT_TEST(conn->extension_requests_received, psk_ke_mode_ext_id), S2N_ERR_MISSING_EXTENSION);
+    POSIX_GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_PSK_KEY_EXCHANGE_MODES, &psk_ke_mode_ext_id));
+    POSIX_ENSURE(S2N_CBIT_TEST(conn->extension_requests_received, psk_ke_mode_ext_id), S2N_ERR_MISSING_EXTENSION);
 
     if (conn->psk_params.psk_ke_mode == S2N_PSK_DHE_KE) {
         s2n_extension_type_id key_share_ext_id;
-        GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_KEY_SHARE, &key_share_ext_id));
+        POSIX_GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_KEY_SHARE, &key_share_ext_id));
         /* A key_share extension must have been received in order to use a pre-shared key
          * in (EC)DHE key exchange mode.
          */
-        ENSURE_POSIX(S2N_CBIT_TEST(conn->extension_requests_received, key_share_ext_id), S2N_ERR_MISSING_EXTENSION);
+        POSIX_ENSURE(S2N_CBIT_TEST(conn->extension_requests_received, key_share_ext_id), S2N_ERR_MISSING_EXTENSION);
     } else {
         /* s2n currently only supports pre-shared keys in (EC)DHE key exchange mode. If we receive keys with any other
          * exchange mode we fall back to a full handshake.
@@ -380,7 +380,7 @@ int s2n_client_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extensi
          *# value is not present or does not validate, the server MUST abort the
          *# handshake.
          */
-        GUARD_AS_POSIX(s2n_client_psk_recv_binders(conn, extension));
+        POSIX_GUARD_RESULT(s2n_client_psk_recv_binders(conn, extension));
     }
 
     /* At this point, we have either chosen a PSK or fallen back to a full handshake. */

--- a/tls/extensions/s2n_client_renegotiation_info.c
+++ b/tls/extensions/s2n_client_renegotiation_info.c
@@ -36,7 +36,7 @@ static int s2n_client_renegotiation_recv(struct s2n_connection *conn, struct s2n
 {
     /* RFC5746 Section 3.2: The renegotiated_connection field is of zero length for the initial handshake. */
     uint8_t renegotiated_connection_len;
-    GUARD(s2n_stuffer_read_uint8(extension, &renegotiated_connection_len));
+    POSIX_GUARD(s2n_stuffer_read_uint8(extension, &renegotiated_connection_len));
     S2N_ERROR_IF(s2n_stuffer_data_available(extension) || renegotiated_connection_len, S2N_ERR_NON_EMPTY_RENEGOTIATION_INFO);
 
     conn->secure_renegotiation = 1;

--- a/tls/extensions/s2n_client_server_name.c
+++ b/tls/extensions/s2n_client_server_name.c
@@ -45,41 +45,41 @@ static bool s2n_client_server_name_should_send(struct s2n_connection *conn)
 static int s2n_client_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     struct s2n_stuffer_reservation server_name_list_size = {0};
-    GUARD(s2n_stuffer_reserve_uint16(out, &server_name_list_size));
+    POSIX_GUARD(s2n_stuffer_reserve_uint16(out, &server_name_list_size));
 
     /* NameType, as described by RFC6066.
      * host_name is currently the only possible NameType defined. */
-    GUARD(s2n_stuffer_write_uint8(out, S2N_NAME_TYPE_HOST_NAME));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, S2N_NAME_TYPE_HOST_NAME));
 
-    GUARD(s2n_stuffer_write_uint16(out, strlen(conn->server_name)));
-    GUARD(s2n_stuffer_write_bytes(out, (const uint8_t *) conn->server_name, strlen(conn->server_name)));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, strlen(conn->server_name)));
+    POSIX_GUARD(s2n_stuffer_write_bytes(out, (const uint8_t *) conn->server_name, strlen(conn->server_name)));
 
-    GUARD(s2n_stuffer_write_vector_size(&server_name_list_size));
+    POSIX_GUARD(s2n_stuffer_write_vector_size(&server_name_list_size));
     return S2N_SUCCESS;
 }
 
 static int s2n_client_server_name_check(struct s2n_connection *conn, struct s2n_stuffer *extension, uint16_t *server_name_len)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     uint16_t size_of_all;
-    GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
-    lte_check(size_of_all, s2n_stuffer_data_available(extension));
+    POSIX_GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
+    POSIX_ENSURE_LTE(size_of_all, s2n_stuffer_data_available(extension));
 
     uint8_t server_name_type;
-    GUARD(s2n_stuffer_read_uint8(extension, &server_name_type));
-    eq_check(server_name_type, S2N_NAME_TYPE_HOST_NAME);
+    POSIX_GUARD(s2n_stuffer_read_uint8(extension, &server_name_type));
+    POSIX_ENSURE_EQ(server_name_type, S2N_NAME_TYPE_HOST_NAME);
 
-    GUARD(s2n_stuffer_read_uint16(extension, server_name_len));
-    lt_check(*server_name_len, sizeof(conn->server_name));
-    lte_check(*server_name_len, s2n_stuffer_data_available(extension));
+    POSIX_GUARD(s2n_stuffer_read_uint16(extension, server_name_len));
+    POSIX_ENSURE_LT(*server_name_len, sizeof(conn->server_name));
+    POSIX_ENSURE_LTE(*server_name_len, s2n_stuffer_data_available(extension));
 
     return S2N_SUCCESS;
 }
 
 static int s2n_client_server_name_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     /* Exit early if we've already parsed the server name */
     if (conn->server_name[0]) {
@@ -93,8 +93,8 @@ static int s2n_client_server_name_recv(struct s2n_connection *conn, struct s2n_s
     }
 
     uint8_t *server_name;
-    notnull_check(server_name = s2n_stuffer_raw_read(extension, server_name_len));
-    memcpy_check(conn->server_name, server_name, server_name_len);
+    POSIX_ENSURE_REF(server_name = s2n_stuffer_raw_read(extension, server_name_len));
+    POSIX_CHECKED_MEMCPY(conn->server_name, server_name, server_name_len);
 
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_client_session_ticket.c
+++ b/tls/extensions/s2n_client_session_ticket.c
@@ -43,7 +43,7 @@ static bool s2n_client_session_ticket_should_send(struct s2n_connection *conn)
 
 static int s2n_client_session_ticket_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    GUARD(s2n_stuffer_write(out, &conn->client_ticket));
+    POSIX_GUARD(s2n_stuffer_write(out, &conn->client_ticket));
     return S2N_SUCCESS;
 }
 
@@ -61,7 +61,7 @@ static int s2n_client_session_ticket_recv(struct s2n_connection *conn, struct s2
 
     if (s2n_stuffer_data_available(extension) == S2N_TLS12_TICKET_SIZE_IN_BYTES) {
         conn->session_ticket_status = S2N_DECRYPT_TICKET;
-        GUARD(s2n_stuffer_copy(extension, &conn->client_ticket_to_decrypt, S2N_TLS12_TICKET_SIZE_IN_BYTES));
+        POSIX_GUARD(s2n_stuffer_copy(extension, &conn->client_ticket_to_decrypt, S2N_TLS12_TICKET_SIZE_IN_BYTES));
     } else if (s2n_config_is_encrypt_decrypt_key_available(conn->config) == 1) {
         conn->session_ticket_status = S2N_NEW_TICKET;
     }

--- a/tls/extensions/s2n_client_status_request.c
+++ b/tls/extensions/s2n_client_status_request.c
@@ -42,20 +42,20 @@ static bool s2n_client_status_request_should_send(struct s2n_connection *conn)
 
 static int s2n_client_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    GUARD(s2n_stuffer_write_uint8(out, (uint8_t) conn->config->status_request_type));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, (uint8_t) conn->config->status_request_type));
 
     /* responder_id_list
      *
      * From https://tools.ietf.org/html/rfc6066#section-8:
      * A zero-length "responder_id_list" sequence has the special meaning that the responders are implicitly
      * known to the server, e.g., by prior arrangement */
-    GUARD(s2n_stuffer_write_uint16(out, 0));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, 0));
 
     /* request_extensions
      *
      * From https://tools.ietf.org/html/rfc6066#section-8:
      * A zero-length "request_extensions" value means that there are no extensions. */
-    GUARD(s2n_stuffer_write_uint16(out, 0));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, 0));
 
     return S2N_SUCCESS;
 }
@@ -68,7 +68,7 @@ static int s2n_client_status_request_recv(struct s2n_connection *conn, struct s2
     }
 
     uint8_t type;
-    GUARD(s2n_stuffer_read_uint8(extension, &type));
+    POSIX_GUARD(s2n_stuffer_read_uint8(extension, &type));
     if (type != (uint8_t) S2N_STATUS_REQUEST_OCSP) {
         /* We only support OCSP (type 1), ignore the extension */
         return S2N_SUCCESS;

--- a/tls/extensions/s2n_client_supported_groups.c
+++ b/tls/extensions/s2n_client_supported_groups.c
@@ -48,33 +48,33 @@ bool s2n_extension_should_send_if_ecc_enabled(struct s2n_connection *conn)
 
 static int s2n_client_supported_groups_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    POSIX_ENSURE_REF(ecc_pref);
 
     const struct s2n_kem_preferences *kem_pref = NULL;
-    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
-    notnull_check(kem_pref);
+    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+    POSIX_ENSURE_REF(kem_pref);
 
     /* Group list len */
     struct s2n_stuffer_reservation group_list_len = { 0 };
-    GUARD(s2n_stuffer_reserve_uint16(out, &group_list_len));
+    POSIX_GUARD(s2n_stuffer_reserve_uint16(out, &group_list_len));
 
     /* Send KEM groups list first */
     if (s2n_connection_get_protocol_version(conn) >= S2N_TLS13 && s2n_pq_is_enabled()) {
         for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-            GUARD(s2n_stuffer_write_uint16(out, kem_pref->tls13_kem_groups[i]->iana_id));
+            POSIX_GUARD(s2n_stuffer_write_uint16(out, kem_pref->tls13_kem_groups[i]->iana_id));
         }
     }
 
     /* Then send curve list */
     for (size_t i = 0; i < ecc_pref->count; i++) {
-        GUARD(s2n_stuffer_write_uint16(out, ecc_pref->ecc_curves[i]->iana_id));
+        POSIX_GUARD(s2n_stuffer_write_uint16(out, ecc_pref->ecc_curves[i]->iana_id));
     }
 
-    GUARD(s2n_stuffer_write_vector_size(&group_list_len));
+    POSIX_GUARD(s2n_stuffer_write_vector_size(&group_list_len));
 
     return S2N_SUCCESS;
 }
@@ -83,11 +83,11 @@ static int s2n_client_supported_groups_send(struct s2n_connection *conn, struct 
  * mutually_supported_kem_groups array based on the received IANA ID. Will
  * ignore unrecognized IANA IDs (and return success). */
 static int s2n_client_supported_groups_recv_iana_id(struct s2n_connection *conn, uint16_t iana_id) {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    POSIX_ENSURE_REF(ecc_pref);
 
     for (size_t i = 0; i < ecc_pref->count; i++) {
         const struct s2n_ecc_named_curve *supported_curve = ecc_pref->ecc_curves[i];
@@ -103,8 +103,8 @@ static int s2n_client_supported_groups_recv_iana_id(struct s2n_connection *conn,
     }
 
     const struct s2n_kem_preferences *kem_pref = NULL;
-    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
-    notnull_check(kem_pref);
+    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+    POSIX_ENSURE_REF(kem_pref);
 
     for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
         const struct s2n_kem_group *supported_kem_group = kem_pref->tls13_kem_groups[i];
@@ -118,15 +118,15 @@ static int s2n_client_supported_groups_recv_iana_id(struct s2n_connection *conn,
 }
 
 static int s2n_choose_supported_group(struct s2n_connection *conn) {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    POSIX_ENSURE_REF(ecc_pref);
 
     const struct s2n_kem_preferences *kem_pref = NULL;
-    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
-    notnull_check(kem_pref);
+    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+    POSIX_ENSURE_REF(kem_pref);
 
     /* Ensure that only the intended group will be non-NULL (if no group is chosen, everything
      * should be NULL). */
@@ -160,11 +160,11 @@ static int s2n_choose_supported_group(struct s2n_connection *conn) {
 }
 
 static int s2n_client_supported_groups_recv(struct s2n_connection *conn, struct s2n_stuffer *extension) {
-    notnull_check(conn);
-    notnull_check(extension);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(extension);
 
     uint16_t size_of_all;
-    GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
+    POSIX_GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
     if (size_of_all > s2n_stuffer_data_available(extension) || (size_of_all % sizeof(uint16_t))) {
         /* Malformed length, ignore the extension */
         return S2N_SUCCESS;
@@ -172,11 +172,11 @@ static int s2n_client_supported_groups_recv(struct s2n_connection *conn, struct 
 
     for (size_t i = 0; i < (size_of_all / sizeof(uint16_t)); i++) {
         uint16_t iana_id;
-        GUARD(s2n_stuffer_read_uint16(extension, &iana_id));
-        GUARD(s2n_client_supported_groups_recv_iana_id(conn, iana_id));
+        POSIX_GUARD(s2n_stuffer_read_uint16(extension, &iana_id));
+        POSIX_GUARD(s2n_client_supported_groups_recv_iana_id(conn, iana_id));
     }
 
-    GUARD(s2n_choose_supported_group(conn));
+    POSIX_GUARD(s2n_choose_supported_group(conn));
 
     return S2N_SUCCESS;
 }
@@ -185,12 +185,12 @@ static int s2n_client_supported_groups_recv(struct s2n_connection *conn, struct 
 
 int s2n_extensions_client_supported_groups_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    GUARD(s2n_extension_send(&s2n_client_supported_groups_extension, conn, out));
+    POSIX_GUARD(s2n_extension_send(&s2n_client_supported_groups_extension, conn, out));
 
     /* The original send method also sent ec point formats. To avoid breaking
      * anything, I'm going to let it continue writing point formats.
      */
-    GUARD(s2n_extension_send(&s2n_client_ec_point_format_extension, conn, out));
+    POSIX_GUARD(s2n_extension_send(&s2n_client_ec_point_format_extension, conn, out));
 
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_client_supported_versions.c
+++ b/tls/extensions/s2n_client_supported_versions.c
@@ -60,14 +60,14 @@ static int s2n_client_supported_versions_send(struct s2n_connection *conn, struc
 {
     uint8_t highest_supported_version = conn->client_protocol_version;
     uint8_t minimum_supported_version;
-    GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
+    POSIX_GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
 
     uint8_t version_list_length = highest_supported_version - minimum_supported_version + 1;
-    GUARD(s2n_stuffer_write_uint8(out, version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN));
 
     for (uint8_t i = highest_supported_version; i >= minimum_supported_version; i--) {
-        GUARD(s2n_stuffer_write_uint8(out, i / 10));
-        GUARD(s2n_stuffer_write_uint8(out, i % 10));
+        POSIX_GUARD(s2n_stuffer_write_uint8(out, i / 10));
+        POSIX_GUARD(s2n_stuffer_write_uint8(out, i % 10));
     }
 
     return S2N_SUCCESS;
@@ -76,10 +76,10 @@ static int s2n_client_supported_versions_send(struct s2n_connection *conn, struc
 static int s2n_extensions_client_supported_versions_process(struct s2n_connection *conn, struct s2n_stuffer *extension) {
     uint8_t highest_supported_version = conn->server_protocol_version;
     uint8_t minimum_supported_version;
-    GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
+    POSIX_GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
 
     uint8_t size_of_version_list;
-    GUARD(s2n_stuffer_read_uint8(extension, &size_of_version_list));
+    POSIX_GUARD(s2n_stuffer_read_uint8(extension, &size_of_version_list));
     S2N_ERROR_IF(size_of_version_list != s2n_stuffer_data_available(extension), S2N_ERR_BAD_MESSAGE);
     S2N_ERROR_IF(size_of_version_list % S2N_TLS_PROTOCOL_VERSION_LEN != 0, S2N_ERR_BAD_MESSAGE);
 
@@ -88,7 +88,7 @@ static int s2n_extensions_client_supported_versions_process(struct s2n_connectio
 
     for (int i = 0; i < size_of_version_list; i += S2N_TLS_PROTOCOL_VERSION_LEN) {
         uint8_t client_version_parts[S2N_TLS_PROTOCOL_VERSION_LEN];
-        GUARD(s2n_stuffer_read_bytes(extension, client_version_parts, S2N_TLS_PROTOCOL_VERSION_LEN));
+        POSIX_GUARD(s2n_stuffer_read_bytes(extension, client_version_parts, S2N_TLS_PROTOCOL_VERSION_LEN));
 
         /* If the client version is outside of our supported versions, then ignore the value.
          * S2N does not support SSLv2 except for upgrading connections. Since this extension is
@@ -127,7 +127,7 @@ static int s2n_client_supported_versions_recv(struct s2n_connection *conn, struc
 
     if (s2n_extensions_client_supported_versions_process(conn, in) < 0) {
         s2n_queue_reader_unsupported_protocol_version_alert(conn);
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
+        POSIX_BAIL(S2N_ERR_BAD_MESSAGE);
     }
     return S2N_SUCCESS;
 }
@@ -136,7 +136,7 @@ static int s2n_client_supported_versions_recv(struct s2n_connection *conn, struc
 
 int s2n_extensions_client_supported_versions_size(struct s2n_connection *conn) {
     uint8_t minimum_supported_version;
-    GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
+    POSIX_GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
     uint8_t highest_supported_version = conn->client_protocol_version;
 
     uint8_t version_list_length = highest_supported_version - minimum_supported_version + 1;

--- a/tls/extensions/s2n_cookie.c
+++ b/tls/extensions/s2n_cookie.c
@@ -50,27 +50,27 @@ static bool s2n_cookie_should_send(struct s2n_connection *conn)
 
 static int s2n_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     uint16_t cookie_size = s2n_stuffer_data_available(&conn->cookie_stuffer);
-    GUARD(s2n_stuffer_write_uint16(out, cookie_size));
-    GUARD(s2n_stuffer_copy(&conn->cookie_stuffer, out, cookie_size));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, cookie_size));
+    POSIX_GUARD(s2n_stuffer_copy(&conn->cookie_stuffer, out, cookie_size));
     return S2N_SUCCESS;
 }
 
 static int s2n_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
         return S2N_SUCCESS;
     }
 
     uint16_t cookie_len;
-    GUARD(s2n_stuffer_read_uint16(extension, &cookie_len));
-    ENSURE_POSIX(s2n_stuffer_data_available(extension) == cookie_len, S2N_ERR_BAD_MESSAGE);
+    POSIX_GUARD(s2n_stuffer_read_uint16(extension, &cookie_len));
+    POSIX_ENSURE(s2n_stuffer_data_available(extension) == cookie_len, S2N_ERR_BAD_MESSAGE);
 
-    GUARD(s2n_stuffer_wipe(&conn->cookie_stuffer));
-    GUARD(s2n_stuffer_resize(&conn->cookie_stuffer, cookie_len));
-    GUARD(s2n_stuffer_copy(extension, &conn->cookie_stuffer, cookie_len));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->cookie_stuffer));
+    POSIX_GUARD(s2n_stuffer_resize(&conn->cookie_stuffer, cookie_len));
+    POSIX_GUARD(s2n_stuffer_copy(extension, &conn->cookie_stuffer, cookie_len));
     return S2N_SUCCESS;
 }
 
@@ -78,7 +78,7 @@ static int s2n_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *exte
 
 int s2n_extensions_cookie_size(struct s2n_connection *conn)
 {
-    GUARD(s2n_stuffer_reread(&conn->cookie_stuffer));
+    POSIX_GUARD(s2n_stuffer_reread(&conn->cookie_stuffer));
 
     if (s2n_stuffer_data_available(&conn->cookie_stuffer) == 0) {
         return 0;

--- a/tls/extensions/s2n_ec_point_format.c
+++ b/tls/extensions/s2n_ec_point_format.c
@@ -54,10 +54,10 @@ static bool s2n_server_ec_point_format_should_send(struct s2n_connection *conn)
 static int s2n_ec_point_format_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     /* Point format list len. We only support one. */
-    GUARD(s2n_stuffer_write_uint8(out, 1));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, 1));
 
     /* Only allow uncompressed format */
-    GUARD(s2n_stuffer_write_uint8(out, TLS_EC_POINT_FORMAT_UNCOMPRESSED));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, TLS_EC_POINT_FORMAT_UNCOMPRESSED));
 
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_extension_list.c
+++ b/tls/extensions/s2n_extension_list.c
@@ -29,46 +29,46 @@ static const s2n_parsed_extension empty_parsed_extensions[S2N_PARSED_EXTENSIONS_
 int s2n_extension_list_send(s2n_extension_list_id list_type, struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     s2n_extension_type_list *extension_type_list;
-    GUARD(s2n_extension_type_list_get(list_type, &extension_type_list));
+    POSIX_GUARD(s2n_extension_type_list_get(list_type, &extension_type_list));
 
     struct s2n_stuffer_reservation total_extensions_size = {0};
-    GUARD(s2n_stuffer_reserve_uint16(out, &total_extensions_size));
+    POSIX_GUARD(s2n_stuffer_reserve_uint16(out, &total_extensions_size));
 
     for (int i = 0; i < extension_type_list->count; i++) {
-        GUARD(s2n_extension_send(extension_type_list->extension_types[i], conn, out));
+        POSIX_GUARD(s2n_extension_send(extension_type_list->extension_types[i], conn, out));
     }
 
-    GUARD(s2n_stuffer_write_vector_size(&total_extensions_size));
+    POSIX_GUARD(s2n_stuffer_write_vector_size(&total_extensions_size));
     return S2N_SUCCESS;
 }
 
 int s2n_extension_list_recv(s2n_extension_list_id list_type, struct s2n_connection *conn, struct s2n_stuffer *in)
 {
     s2n_parsed_extensions_list parsed_extension_list = { 0 };
-    GUARD(s2n_extension_list_parse(in, &parsed_extension_list));
-    GUARD(s2n_extension_list_process(list_type, conn, &parsed_extension_list));
+    POSIX_GUARD(s2n_extension_list_parse(in, &parsed_extension_list));
+    POSIX_GUARD(s2n_extension_list_process(list_type, conn, &parsed_extension_list));
     return S2N_SUCCESS;
 }
 
 static int s2n_extension_process_impl(const s2n_extension_type *extension_type, s2n_extension_type_id extension_id,
         struct s2n_connection *conn, s2n_parsed_extension *parsed_extensions)
 {
-    notnull_check(extension_type);
-    notnull_check(parsed_extensions);
+    POSIX_ENSURE_REF(extension_type);
+    POSIX_ENSURE_REF(parsed_extensions);
 
     if (s2n_parsed_extension_is_empty(&parsed_extensions[extension_id])) {
-        GUARD(s2n_extension_is_missing(extension_type, conn));
+        POSIX_GUARD(s2n_extension_is_missing(extension_type, conn));
         return S2N_SUCCESS;
     }
 
-    ENSURE_POSIX(parsed_extensions[extension_id].extension_type == extension_type->iana_value,
+    POSIX_ENSURE(parsed_extensions[extension_id].extension_type == extension_type->iana_value,
             S2N_ERR_INVALID_PARSED_EXTENSIONS);
 
     struct s2n_stuffer extension_stuffer;
-    GUARD(s2n_stuffer_init(&extension_stuffer, &parsed_extensions[extension_id].extension));
-    GUARD(s2n_stuffer_skip_write(&extension_stuffer, parsed_extensions[extension_id].extension.size));
+    POSIX_GUARD(s2n_stuffer_init(&extension_stuffer, &parsed_extensions[extension_id].extension));
+    POSIX_GUARD(s2n_stuffer_skip_write(&extension_stuffer, parsed_extensions[extension_id].extension.size));
 
-    GUARD(s2n_extension_recv(extension_type, conn, &extension_stuffer));
+    POSIX_GUARD(s2n_extension_recv(extension_type, conn, &extension_stuffer));
 
     return S2N_SUCCESS;
 }
@@ -76,11 +76,11 @@ static int s2n_extension_process_impl(const s2n_extension_type *extension_type, 
 int s2n_extension_process(const s2n_extension_type *extension_type, struct s2n_connection *conn,
         s2n_parsed_extensions_list *parsed_extension_list)
 {
-    notnull_check(parsed_extension_list);
-    notnull_check(extension_type);
+    POSIX_ENSURE_REF(parsed_extension_list);
+    POSIX_ENSURE_REF(extension_type);
 
     s2n_extension_type_id extension_id;
-    GUARD(s2n_extension_supported_iana_value_to_id(extension_type->iana_value, &extension_id));
+    POSIX_GUARD(s2n_extension_supported_iana_value_to_id(extension_type->iana_value, &extension_id));
 
     int result = s2n_extension_process_impl(extension_type, extension_id, conn, parsed_extension_list->parsed_extensions);
 
@@ -94,13 +94,13 @@ int s2n_extension_process(const s2n_extension_type *extension_type, struct s2n_c
 int s2n_extension_list_process(s2n_extension_list_id list_type, struct s2n_connection *conn,
         s2n_parsed_extensions_list *parsed_extension_list)
 {
-    notnull_check(parsed_extension_list);
+    POSIX_ENSURE_REF(parsed_extension_list);
 
     s2n_extension_type_list *extension_type_list;
-    GUARD(s2n_extension_type_list_get(list_type, &extension_type_list));
+    POSIX_GUARD(s2n_extension_type_list_get(list_type, &extension_type_list));
 
     for (int i = 0; i < extension_type_list->count; i++) {
-        GUARD(s2n_extension_process(extension_type_list->extension_types[i],
+        POSIX_GUARD(s2n_extension_process(extension_type_list->extension_types[i],
                 conn, parsed_extension_list));
     }
 
@@ -122,19 +122,19 @@ int s2n_extension_list_process(s2n_extension_list_id list_type, struct s2n_conne
 
 static int s2n_extension_parse(struct s2n_stuffer *in, s2n_parsed_extension *parsed_extensions, uint16_t *wire_index)
 {
-    notnull_check(parsed_extensions);
-    notnull_check(wire_index);
+    POSIX_ENSURE_REF(parsed_extensions);
+    POSIX_ENSURE_REF(wire_index);
 
     uint16_t extension_type;
-    ENSURE_POSIX(s2n_stuffer_read_uint16(in, &extension_type) == S2N_SUCCESS,
+    POSIX_ENSURE(s2n_stuffer_read_uint16(in, &extension_type) == S2N_SUCCESS,
             S2N_ERR_BAD_MESSAGE);
 
     uint16_t extension_size;
-    ENSURE_POSIX(s2n_stuffer_read_uint16(in, &extension_size) == S2N_SUCCESS,
+    POSIX_ENSURE(s2n_stuffer_read_uint16(in, &extension_size) == S2N_SUCCESS,
             S2N_ERR_BAD_MESSAGE);
 
     uint8_t *extension_data = s2n_stuffer_raw_read(in, extension_size);
-    ENSURE_POSIX(extension_data != NULL, S2N_ERR_BAD_MESSAGE);
+    POSIX_ENSURE(extension_data != NULL, S2N_ERR_BAD_MESSAGE);
 
     s2n_extension_type_id extension_id;
     if (s2n_extension_supported_iana_value_to_id(extension_type, &extension_id) != S2N_SUCCESS) {
@@ -145,13 +145,13 @@ static int s2n_extension_parse(struct s2n_stuffer *in, s2n_parsed_extension *par
     s2n_parsed_extension *parsed_extension = &parsed_extensions[extension_id];
 
     /* Error if extension is a duplicate */
-    ENSURE_POSIX(s2n_parsed_extension_is_empty(parsed_extension),
+    POSIX_ENSURE(s2n_parsed_extension_is_empty(parsed_extension),
             S2N_ERR_DUPLICATE_EXTENSION);
 
     /* Fill in parsed extension */
     parsed_extension->extension_type = extension_type;
     parsed_extension->wire_index = *wire_index;
-    GUARD(s2n_blob_init(&parsed_extension->extension, extension_data, extension_size));
+    POSIX_GUARD(s2n_blob_init(&parsed_extension->extension, extension_data, extension_size));
     (*wire_index)++;
 
     return S2N_SUCCESS;
@@ -159,10 +159,10 @@ static int s2n_extension_parse(struct s2n_stuffer *in, s2n_parsed_extension *par
 
 int s2n_extension_list_parse(struct s2n_stuffer *in, s2n_parsed_extensions_list *parsed_extension_list)
 {
-    notnull_check(in);
-    notnull_check(parsed_extension_list);
+    POSIX_ENSURE_REF(in);
+    POSIX_ENSURE_REF(parsed_extension_list);
 
-    memset_check((s2n_parsed_extension*) parsed_extension_list->parsed_extensions,
+    POSIX_CHECKED_MEMSET((s2n_parsed_extension*) parsed_extension_list->parsed_extensions,
             0, sizeof(parsed_extension_list->parsed_extensions));
 
     uint16_t total_extensions_size;
@@ -171,17 +171,17 @@ int s2n_extension_list_parse(struct s2n_stuffer *in, s2n_parsed_extensions_list 
     }
 
     uint8_t *extensions_data = s2n_stuffer_raw_read(in, total_extensions_size);
-    ENSURE_POSIX(extensions_data != NULL, S2N_ERR_BAD_MESSAGE);
+    POSIX_ENSURE(extensions_data != NULL, S2N_ERR_BAD_MESSAGE);
 
-    GUARD(s2n_blob_init(&parsed_extension_list->raw, extensions_data, total_extensions_size));
+    POSIX_GUARD(s2n_blob_init(&parsed_extension_list->raw, extensions_data, total_extensions_size));
 
     struct s2n_stuffer extensions_stuffer;
-    GUARD(s2n_stuffer_init(&extensions_stuffer, &parsed_extension_list->raw));
-    GUARD(s2n_stuffer_skip_write(&extensions_stuffer, total_extensions_size));
+    POSIX_GUARD(s2n_stuffer_init(&extensions_stuffer, &parsed_extension_list->raw));
+    POSIX_GUARD(s2n_stuffer_skip_write(&extensions_stuffer, total_extensions_size));
 
     uint16_t wire_index = 0;
     while (s2n_stuffer_data_available(&extensions_stuffer)) {
-        GUARD(s2n_extension_parse(&extensions_stuffer, parsed_extension_list->parsed_extensions, &wire_index));
+        POSIX_GUARD(s2n_extension_parse(&extensions_stuffer, parsed_extension_list->parsed_extensions, &wire_index));
     }
 
     parsed_extension_list->count = wire_index;

--- a/tls/extensions/s2n_extension_type_lists.c
+++ b/tls/extensions/s2n_extension_type_lists.c
@@ -137,8 +137,8 @@ static s2n_extension_type_list extension_lists[] = {
 
 int s2n_extension_type_list_get(s2n_extension_list_id list_type, s2n_extension_type_list **extension_list)
 {
-    notnull_check(extension_list);
-    lt_check(list_type, s2n_array_len(extension_lists));
+    POSIX_ENSURE_REF(extension_list);
+    POSIX_ENSURE_LT(list_type, s2n_array_len(extension_lists));
 
     *extension_list = &extension_lists[list_type];
     return S2N_SUCCESS;

--- a/tls/extensions/s2n_key_share.c
+++ b/tls/extensions/s2n_key_share.c
@@ -19,15 +19,15 @@
 
 int s2n_ecdhe_parameters_send(struct s2n_ecc_evp_params *ecc_evp_params, struct s2n_stuffer *out)
 {
-    notnull_check(out);
-    notnull_check(ecc_evp_params);
-    notnull_check(ecc_evp_params->negotiated_curve);
+    POSIX_ENSURE_REF(out);
+    POSIX_ENSURE_REF(ecc_evp_params);
+    POSIX_ENSURE_REF(ecc_evp_params->negotiated_curve);
 
-    GUARD(s2n_stuffer_write_uint16(out, ecc_evp_params->negotiated_curve->iana_id));
-    GUARD(s2n_stuffer_write_uint16(out, ecc_evp_params->negotiated_curve->share_size));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, ecc_evp_params->negotiated_curve->iana_id));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, ecc_evp_params->negotiated_curve->share_size));
 
-    GUARD(s2n_ecc_evp_generate_ephemeral_key(ecc_evp_params));
-    GUARD(s2n_ecc_evp_write_params_point(ecc_evp_params, out));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(ecc_evp_params));
+    POSIX_GUARD(s2n_ecc_evp_write_params_point(ecc_evp_params, out));
 
     return 0;
 }

--- a/tls/extensions/s2n_psk_key_exchange_modes.c
+++ b/tls/extensions/s2n_psk_key_exchange_modes.c
@@ -43,26 +43,26 @@ static bool s2n_psk_key_exchange_modes_should_send(struct s2n_connection *conn)
 
 static int s2n_psk_key_exchange_modes_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
-    GUARD(s2n_stuffer_write_uint8(out, PSK_KEY_EXCHANGE_MODE_SIZE));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, PSK_KEY_EXCHANGE_MODE_SIZE));
 
     /* s2n currently only supports pre-shared keys with (EC)DHE key establishment */
-    GUARD(s2n_stuffer_write_uint8(out, TLS_PSK_DHE_KE_MODE));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, TLS_PSK_DHE_KE_MODE));
 
     return S2N_SUCCESS;
 }
 
 static int s2n_psk_key_exchange_modes_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
         return S2N_SUCCESS;
     }
 
     uint8_t psk_ke_mode_list_len;
-    GUARD(s2n_stuffer_read_uint8(extension, &psk_ke_mode_list_len));
+    POSIX_GUARD(s2n_stuffer_read_uint8(extension, &psk_ke_mode_list_len));
     if (psk_ke_mode_list_len > s2n_stuffer_data_available(extension)) {
         /* Malformed length, ignore the extension */
         return S2N_SUCCESS;
@@ -70,7 +70,7 @@ static int s2n_psk_key_exchange_modes_recv(struct s2n_connection *conn, struct s
 
     for (size_t i = 0; i < psk_ke_mode_list_len; i++) {
         uint8_t wire_psk_ke_mode;
-        GUARD(s2n_stuffer_read_uint8(extension, &wire_psk_ke_mode));
+        POSIX_GUARD(s2n_stuffer_read_uint8(extension, &wire_psk_ke_mode));
         
         /* s2n currently only supports pre-shared keys with (EC)DHE key establishment */
         if (wire_psk_ke_mode == TLS_PSK_DHE_KE_MODE) {

--- a/tls/extensions/s2n_quic_transport_params.c
+++ b/tls/extensions/s2n_quic_transport_params.c
@@ -36,33 +36,33 @@ static bool s2n_quic_transport_params_should_send(struct s2n_connection *conn)
 
 static int s2n_quic_transport_params_if_missing(struct s2n_connection *conn)
 {
-    notnull_check(conn);
-    notnull_check(conn->config);
-    ENSURE_POSIX(!conn->config->quic_enabled, S2N_ERR_MISSING_EXTENSION);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->config);
+    POSIX_ENSURE(!conn->config->quic_enabled, S2N_ERR_MISSING_EXTENSION);
     return S2N_SUCCESS;
 }
 
 static int s2n_quic_transport_params_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    notnull_check(conn);
-    notnull_check(out);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(out);
 
     if (conn->our_quic_transport_parameters.size) {
-        GUARD(s2n_stuffer_write(out, &conn->our_quic_transport_parameters));
+        POSIX_GUARD(s2n_stuffer_write(out, &conn->our_quic_transport_parameters));
     }
     return S2N_SUCCESS;
 }
 
 static int s2n_quic_transport_params_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    notnull_check(conn);
-    notnull_check(extension);
-    notnull_check(conn->config);
-    ENSURE_POSIX(conn->config->quic_enabled, S2N_ERR_UNSUPPORTED_EXTENSION);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(extension);
+    POSIX_ENSURE_REF(conn->config);
+    POSIX_ENSURE(conn->config->quic_enabled, S2N_ERR_UNSUPPORTED_EXTENSION);
 
     if (s2n_stuffer_data_available(extension)) {
-        GUARD(s2n_alloc(&conn->peer_quic_transport_parameters, s2n_stuffer_data_available(extension)));
-        GUARD(s2n_stuffer_read(extension, &conn->peer_quic_transport_parameters));
+        POSIX_GUARD(s2n_alloc(&conn->peer_quic_transport_parameters, s2n_stuffer_data_available(extension)));
+        POSIX_GUARD(s2n_stuffer_read(extension, &conn->peer_quic_transport_parameters));
     }
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -35,82 +35,82 @@ const s2n_extension_type s2n_server_key_share_extension = {
 };
 
 static int s2n_server_key_share_generate_pq_hybrid(struct s2n_connection *conn, struct s2n_stuffer *out) {
-    notnull_check(out);
-    notnull_check(conn);
+    POSIX_ENSURE_REF(out);
+    POSIX_ENSURE_REF(conn);
 
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
     struct s2n_kem_group_params *server_kem_group_params = &conn->secure.server_kem_group_params;
 
-    notnull_check(server_kem_group_params->kem_group);
-    GUARD(s2n_stuffer_write_uint16(out, server_kem_group_params->kem_group->iana_id));
+    POSIX_ENSURE_REF(server_kem_group_params->kem_group);
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, server_kem_group_params->kem_group->iana_id));
 
     struct s2n_stuffer_reservation total_share_size = { 0 };
-    GUARD(s2n_stuffer_reserve_uint16(out, &total_share_size));
+    POSIX_GUARD(s2n_stuffer_reserve_uint16(out, &total_share_size));
 
     struct s2n_ecc_evp_params *server_ecc_params = &server_kem_group_params->ecc_params;
-    notnull_check(server_ecc_params->negotiated_curve);
-    GUARD(s2n_stuffer_write_uint16(out, server_ecc_params->negotiated_curve->share_size));
-    GUARD(s2n_ecc_evp_generate_ephemeral_key(server_ecc_params));
-    GUARD(s2n_ecc_evp_write_params_point(server_ecc_params, out));
+    POSIX_ENSURE_REF(server_ecc_params->negotiated_curve);
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, server_ecc_params->negotiated_curve->share_size));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(server_ecc_params));
+    POSIX_GUARD(s2n_ecc_evp_write_params_point(server_ecc_params, out));
 
-    notnull_check(conn->secure.chosen_client_kem_group_params);
+    POSIX_ENSURE_REF(conn->secure.chosen_client_kem_group_params);
     struct s2n_kem_params *client_kem_params = &conn->secure.chosen_client_kem_group_params->kem_params;
-    notnull_check(client_kem_params->public_key.data);
+    POSIX_ENSURE_REF(client_kem_params->public_key.data);
     /* s2n_kem_send_ciphertext() will generate the PQ shared secret and use
      * the client's public key to encapsulate; the PQ shared secret will be
      * stored in client_kem_params, and will be used during the hybrid shared
      * secret derivation. */
-    GUARD(s2n_kem_send_ciphertext(out, client_kem_params));
+    POSIX_GUARD(s2n_kem_send_ciphertext(out, client_kem_params));
 
-    GUARD(s2n_stuffer_write_vector_size(&total_share_size));
+    POSIX_GUARD(s2n_stuffer_write_vector_size(&total_share_size));
     return S2N_SUCCESS;
 }
 
 /* Check that client has sent a corresponding key share for the server's KEM group */
 int s2n_server_key_share_send_check_pq_hybrid(struct s2n_connection *conn) {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
-    notnull_check(conn->secure.server_kem_group_params.kem_group);
-    notnull_check(conn->secure.server_kem_group_params.kem_params.kem);
-    notnull_check(conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
+    POSIX_ENSURE_REF(conn->secure.server_kem_group_params.kem_group);
+    POSIX_ENSURE_REF(conn->secure.server_kem_group_params.kem_params.kem);
+    POSIX_ENSURE_REF(conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
 
     const struct s2n_kem_group *server_kem_group = conn->secure.server_kem_group_params.kem_group;
 
     const struct s2n_kem_preferences *kem_pref = NULL;
-    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
-    notnull_check(kem_pref);
+    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+    POSIX_ENSURE_REF(kem_pref);
 
-    ENSURE_POSIX(s2n_kem_preferences_includes_tls13_kem_group(kem_pref, server_kem_group->iana_id),
+    POSIX_ENSURE(s2n_kem_preferences_includes_tls13_kem_group(kem_pref, server_kem_group->iana_id),
             S2N_ERR_KEM_UNSUPPORTED_PARAMS);
 
     struct s2n_kem_group_params *client_params = conn->secure.chosen_client_kem_group_params;
-    notnull_check(client_params);
+    POSIX_ENSURE_REF(client_params);
 
-    ENSURE_POSIX(client_params->kem_group == server_kem_group, S2N_ERR_BAD_KEY_SHARE);
+    POSIX_ENSURE(client_params->kem_group == server_kem_group, S2N_ERR_BAD_KEY_SHARE);
 
-    ENSURE_POSIX(client_params->ecc_params.negotiated_curve == server_kem_group->curve, S2N_ERR_BAD_KEY_SHARE);
-    ENSURE_POSIX(client_params->ecc_params.evp_pkey != NULL, S2N_ERR_BAD_KEY_SHARE);
+    POSIX_ENSURE(client_params->ecc_params.negotiated_curve == server_kem_group->curve, S2N_ERR_BAD_KEY_SHARE);
+    POSIX_ENSURE(client_params->ecc_params.evp_pkey != NULL, S2N_ERR_BAD_KEY_SHARE);
 
-    ENSURE_POSIX(client_params->kem_params.kem == server_kem_group->kem, S2N_ERR_BAD_KEY_SHARE);
-    ENSURE_POSIX(client_params->kem_params.public_key.size == server_kem_group->kem->public_key_length, S2N_ERR_BAD_KEY_SHARE);
-    ENSURE_POSIX(client_params->kem_params.public_key.data != NULL, S2N_ERR_BAD_KEY_SHARE);
+    POSIX_ENSURE(client_params->kem_params.kem == server_kem_group->kem, S2N_ERR_BAD_KEY_SHARE);
+    POSIX_ENSURE(client_params->kem_params.public_key.size == server_kem_group->kem->public_key_length, S2N_ERR_BAD_KEY_SHARE);
+    POSIX_ENSURE(client_params->kem_params.public_key.data != NULL, S2N_ERR_BAD_KEY_SHARE);
 
     return S2N_SUCCESS;
 }
 
 /* Check that client has sent a corresponding key share for the server's EC curve */
 int s2n_server_key_share_send_check_ecdhe(struct s2n_connection *conn) {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    POSIX_ENSURE_REF(ecc_pref);
 
     const struct s2n_ecc_named_curve *server_curve = conn->secure.server_ecc_evp_params.negotiated_curve;
-    notnull_check(server_curve);
+    POSIX_ENSURE_REF(server_curve);
 
     struct s2n_ecc_evp_params *client_params = NULL;
     for (size_t i = 0; i < ecc_pref->count; i++) {
@@ -120,22 +120,22 @@ int s2n_server_key_share_send_check_ecdhe(struct s2n_connection *conn) {
         }
     }
 
-    notnull_check(client_params);
-    ENSURE_POSIX(client_params->negotiated_curve == server_curve, S2N_ERR_BAD_KEY_SHARE);
-    ENSURE_POSIX(client_params->evp_pkey != NULL, S2N_ERR_BAD_KEY_SHARE);
+    POSIX_ENSURE_REF(client_params);
+    POSIX_ENSURE(client_params->negotiated_curve == server_curve, S2N_ERR_BAD_KEY_SHARE);
+    POSIX_ENSURE(client_params->evp_pkey != NULL, S2N_ERR_BAD_KEY_SHARE);
 
     return S2N_SUCCESS;
 }
 
 static int s2n_server_key_share_send(struct s2n_connection *conn, struct s2n_stuffer *out) {
-    notnull_check(conn);
-    notnull_check(out);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(out);
 
     const struct s2n_ecc_named_curve *curve = conn->secure.server_ecc_evp_params.negotiated_curve;
     const struct s2n_kem_group *kem_group = conn->secure.server_kem_group_params.kem_group;
 
     /* Boolean XOR: exactly one of {server_curve, server_kem_group} should be non-null. */
-    ENSURE_POSIX((curve == NULL) != (kem_group == NULL), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+    POSIX_ENSURE((curve == NULL) != (kem_group == NULL), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
     /* Retry requests only require the selected named group, not an actual share.
      * https://tools.ietf.org/html/rfc8446#section-4.2.8 */
@@ -147,16 +147,16 @@ static int s2n_server_key_share_send(struct s2n_connection *conn, struct s2n_stu
             named_group_id = kem_group->iana_id;
         }
 
-        GUARD(s2n_stuffer_write_uint16(out, named_group_id));
+        POSIX_GUARD(s2n_stuffer_write_uint16(out, named_group_id));
         return S2N_SUCCESS;
     }
 
     if (curve != NULL) {
-        GUARD(s2n_server_key_share_send_check_ecdhe(conn));
-        GUARD(s2n_ecdhe_parameters_send(&conn->secure.server_ecc_evp_params, out));
+        POSIX_GUARD(s2n_server_key_share_send_check_ecdhe(conn));
+        POSIX_GUARD(s2n_ecdhe_parameters_send(&conn->secure.server_ecc_evp_params, out));
     } else {
-        GUARD(s2n_server_key_share_send_check_pq_hybrid(conn));
-        GUARD(s2n_server_key_share_generate_pq_hybrid(conn, out));
+        POSIX_GUARD(s2n_server_key_share_send_check_pq_hybrid(conn));
+        POSIX_GUARD(s2n_server_key_share_generate_pq_hybrid(conn, out));
     }
 
     return S2N_SUCCESS;
@@ -164,20 +164,20 @@ static int s2n_server_key_share_send(struct s2n_connection *conn, struct s2n_stu
 
 static int s2n_server_key_share_recv_pq_hybrid(struct s2n_connection *conn, uint16_t named_group_iana,
         struct s2n_stuffer *extension) {
-    notnull_check(conn);
-    notnull_check(extension);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(extension);
 
     /* If PQ is disabled, the client should not have sent any PQ IDs
      * in the supported_groups list of the initial ClientHello */
-    ENSURE_POSIX(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
     const struct s2n_kem_preferences *kem_pref = NULL;
-    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
-    notnull_check(kem_pref);
+    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+    POSIX_ENSURE_REF(kem_pref);
 
     /* This check should have been done higher up, but including it here as well for extra defense.
      * Uses S2N_ERR_ECDHE_UNSUPPORTED_CURVE for backward compatibility. */
-    ENSURE_POSIX(s2n_kem_preferences_includes_tls13_kem_group(kem_pref, named_group_iana), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+    POSIX_ENSURE(s2n_kem_preferences_includes_tls13_kem_group(kem_pref, named_group_iana), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
     size_t kem_group_index = 0;
     for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
@@ -200,29 +200,29 @@ static int s2n_server_key_share_recv_pq_hybrid(struct s2n_connection *conn, uint
     }
 
     /* Ensure that the server's key share corresponds with a key share previously sent by the client */
-    ENSURE_POSIX(conn->secure.client_kem_group_params[kem_group_index].kem_params.private_key.data != NULL,
+    POSIX_ENSURE(conn->secure.client_kem_group_params[kem_group_index].kem_params.private_key.data != NULL,
                  S2N_ERR_BAD_KEY_SHARE);
-    ENSURE_POSIX(conn->secure.client_kem_group_params[kem_group_index].ecc_params.evp_pkey != NULL,
+    POSIX_ENSURE(conn->secure.client_kem_group_params[kem_group_index].ecc_params.evp_pkey != NULL,
             S2N_ERR_BAD_KEY_SHARE);
-    notnull_check(conn->secure.client_kem_group_params[kem_group_index].kem_group);
-    eq_check(conn->secure.client_kem_group_params[kem_group_index].kem_group->iana_id, named_group_iana);
+    POSIX_ENSURE_REF(conn->secure.client_kem_group_params[kem_group_index].kem_group);
+    POSIX_ENSURE_EQ(conn->secure.client_kem_group_params[kem_group_index].kem_group->iana_id, named_group_iana);
     conn->secure.chosen_client_kem_group_params = &conn->secure.client_kem_group_params[kem_group_index];
 
     uint16_t received_total_share_size;
-    GUARD(s2n_stuffer_read_uint16(extension, &received_total_share_size));
-    ENSURE_POSIX(received_total_share_size == server_kem_group_params->kem_group->server_share_size, S2N_ERR_BAD_KEY_SHARE);
-    ENSURE_POSIX(s2n_stuffer_data_available(extension) == received_total_share_size, S2N_ERR_BAD_KEY_SHARE);
+    POSIX_GUARD(s2n_stuffer_read_uint16(extension, &received_total_share_size));
+    POSIX_ENSURE(received_total_share_size == server_kem_group_params->kem_group->server_share_size, S2N_ERR_BAD_KEY_SHARE);
+    POSIX_ENSURE(s2n_stuffer_data_available(extension) == received_total_share_size, S2N_ERR_BAD_KEY_SHARE);
 
     /* Parse ECC key share */
     uint16_t ecc_share_size;
     struct s2n_blob point_blob;
-    GUARD(s2n_stuffer_read_uint16(extension, &ecc_share_size));
-    ENSURE_POSIX(s2n_ecc_evp_read_params_point(extension, ecc_share_size, &point_blob) == S2N_SUCCESS, S2N_ERR_BAD_KEY_SHARE);
-    ENSURE_POSIX(s2n_ecc_evp_parse_params_point(&point_blob, &server_kem_group_params->ecc_params) == S2N_SUCCESS, S2N_ERR_BAD_KEY_SHARE);
-    ENSURE_POSIX(server_kem_group_params->ecc_params.evp_pkey != NULL, S2N_ERR_BAD_KEY_SHARE);
+    POSIX_GUARD(s2n_stuffer_read_uint16(extension, &ecc_share_size));
+    POSIX_ENSURE(s2n_ecc_evp_read_params_point(extension, ecc_share_size, &point_blob) == S2N_SUCCESS, S2N_ERR_BAD_KEY_SHARE);
+    POSIX_ENSURE(s2n_ecc_evp_parse_params_point(&point_blob, &server_kem_group_params->ecc_params) == S2N_SUCCESS, S2N_ERR_BAD_KEY_SHARE);
+    POSIX_ENSURE(server_kem_group_params->ecc_params.evp_pkey != NULL, S2N_ERR_BAD_KEY_SHARE);
 
     /* Parse the PQ KEM key share */
-    ENSURE_POSIX(s2n_kem_recv_ciphertext(extension, &conn->secure.chosen_client_kem_group_params->kem_params) == S2N_SUCCESS,
+    POSIX_ENSURE(s2n_kem_recv_ciphertext(extension, &conn->secure.chosen_client_kem_group_params->kem_params) == S2N_SUCCESS,
             S2N_ERR_BAD_KEY_SHARE);
 
     return S2N_SUCCESS;
@@ -230,15 +230,15 @@ static int s2n_server_key_share_recv_pq_hybrid(struct s2n_connection *conn, uint
 
 static int s2n_server_key_share_recv_ecc(struct s2n_connection *conn, uint16_t named_group_iana,
         struct s2n_stuffer *extension) {
-    notnull_check(conn);
-    notnull_check(extension);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(extension);
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    POSIX_ENSURE_REF(ecc_pref);
 
     /* This check should have been done higher up, but including it here as well for extra defense. */
-    ENSURE_POSIX(s2n_ecc_preferences_includes_curve(ecc_pref, named_group_iana),
+    POSIX_ENSURE(s2n_ecc_preferences_includes_curve(ecc_pref, named_group_iana),
             S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
     size_t supported_curve_index = 0;
@@ -264,7 +264,7 @@ static int s2n_server_key_share_recv_ecc(struct s2n_connection *conn, uint16_t n
 
     uint16_t share_size;
     S2N_ERROR_IF(s2n_stuffer_data_available(extension) < sizeof(share_size), S2N_ERR_BAD_KEY_SHARE);
-    GUARD(s2n_stuffer_read_uint16(extension, &share_size));
+    POSIX_GUARD(s2n_stuffer_read_uint16(extension, &share_size));
     S2N_ERROR_IF(s2n_stuffer_data_available(extension) < share_size, S2N_ERR_BAD_KEY_SHARE);
 
     /* Proceed to parse share */
@@ -290,27 +290,27 @@ static int s2n_server_key_share_recv(struct s2n_connection *conn, struct s2n_stu
         return S2N_SUCCESS;
     }
 
-    notnull_check(conn);
-    notnull_check(extension);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(extension);
 
     uint16_t negotiated_named_group_iana = 0;
     S2N_ERROR_IF(s2n_stuffer_data_available(extension) < sizeof(negotiated_named_group_iana), S2N_ERR_BAD_KEY_SHARE);
-    GUARD(s2n_stuffer_read_uint16(extension, &negotiated_named_group_iana));
+    POSIX_GUARD(s2n_stuffer_read_uint16(extension, &negotiated_named_group_iana));
 
     const struct s2n_kem_preferences *kem_pref = NULL;
-    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
-    notnull_check(kem_pref);
+    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+    POSIX_ENSURE_REF(kem_pref);
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    POSIX_ENSURE_REF(ecc_pref);
 
     if (s2n_ecc_preferences_includes_curve(ecc_pref, negotiated_named_group_iana)) {
-        GUARD(s2n_server_key_share_recv_ecc(conn, negotiated_named_group_iana, extension));
+        POSIX_GUARD(s2n_server_key_share_recv_ecc(conn, negotiated_named_group_iana, extension));
     } else if (s2n_kem_preferences_includes_tls13_kem_group(kem_pref, negotiated_named_group_iana)) {
-        GUARD(s2n_server_key_share_recv_pq_hybrid(conn, negotiated_named_group_iana, extension));
+        POSIX_GUARD(s2n_server_key_share_recv_pq_hybrid(conn, negotiated_named_group_iana, extension));
     } else {
-        S2N_ERROR(S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+        POSIX_BAIL(S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
     }
 
     return S2N_SUCCESS;
@@ -318,15 +318,15 @@ static int s2n_server_key_share_recv(struct s2n_connection *conn, struct s2n_stu
 
 /* Selects highest priority mutually supported key share, or indicates need for HRR */
 int s2n_extensions_server_key_share_select(struct s2n_connection *conn) {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    POSIX_ENSURE_REF(ecc_pref);
 
     const struct s2n_kem_preferences *kem_pref = NULL;
-    GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
-    notnull_check(kem_pref);
+    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
+    POSIX_ENSURE_REF(kem_pref);
 
     /* Boolean XOR check. When receiving the supported_groups extension, s2n server
      * should (exclusively) set either server_curve or server_kem_group based on the
@@ -337,7 +337,7 @@ int s2n_extensions_server_key_share_select(struct s2n_connection *conn) {
      * is an error.) */
     const struct s2n_ecc_named_curve *server_curve = conn->secure.server_ecc_evp_params.negotiated_curve;
     const struct s2n_kem_group *server_kem_group = conn->secure.server_kem_group_params.kem_group;
-    ENSURE_POSIX((server_curve == NULL) != (server_kem_group == NULL), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+    POSIX_ENSURE((server_curve == NULL) != (server_kem_group == NULL), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
     /* To avoid extra round trips, we prefer to negotiate a group for which we have already
      * received a key share (even if it is different than the group previously chosen). In
@@ -345,8 +345,8 @@ int s2n_extensions_server_key_share_select(struct s2n_connection *conn) {
      * support PQ, but the client sent only EC key shares, then we will negotiate ECHDE. */
     for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
         if (conn->secure.mutually_supported_kem_groups[i] && conn->secure.client_kem_group_params[i].kem_group) {
-            notnull_check(conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve);
-            notnull_check(conn->secure.client_kem_group_params[i].kem_params.kem);
+            POSIX_ENSURE_REF(conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve);
+            POSIX_ENSURE_REF(conn->secure.client_kem_group_params[i].kem_params.kem);
 
             conn->secure.server_kem_group_params.kem_group = conn->secure.client_kem_group_params[i].kem_group;
             conn->secure.server_kem_group_params.ecc_params.negotiated_curve = conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve;
@@ -372,7 +372,7 @@ int s2n_extensions_server_key_share_select(struct s2n_connection *conn) {
 
     /* Server and client have mutually supported groups, but the client did not send key
      * shares for any of them. Send HRR indicating the server's preference. */
-    GUARD(s2n_set_hello_retry_required(conn));
+    POSIX_GUARD(s2n_set_hello_retry_required(conn));
     return S2N_SUCCESS;
 }
 

--- a/tls/extensions/s2n_server_max_fragment_length.c
+++ b/tls/extensions/s2n_server_max_fragment_length.c
@@ -44,18 +44,18 @@ static bool s2n_max_fragment_length_should_send(struct s2n_connection *conn)
 
 static int s2n_max_fragment_length_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    notnull_check(conn);
-    GUARD(s2n_stuffer_write_uint8(out, conn->mfl_code));
+    POSIX_ENSURE_REF(conn);
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, conn->mfl_code));
     return S2N_SUCCESS;
 }
 
 static int s2n_max_fragment_length_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    notnull_check(conn);
-    notnull_check(conn->config);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->config);
 
     uint8_t mfl_code;
-    GUARD(s2n_stuffer_read_uint8(extension, &mfl_code));
+    POSIX_GUARD(s2n_stuffer_read_uint8(extension, &mfl_code));
     S2N_ERROR_IF(mfl_code != conn->config->mfl_code, S2N_ERR_MAX_FRAG_LEN_MISMATCH);
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_server_psk.c
+++ b/tls/extensions/s2n_server_psk.c
@@ -44,17 +44,17 @@ static bool s2n_server_psk_should_send(struct s2n_connection *conn)
 
 static int s2n_server_psk_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     /* Send the index of the chosen PSK that is stored on the connection. */
-    GUARD(s2n_stuffer_write_uint16(out, conn->psk_params.chosen_psk_wire_index));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, conn->psk_params.chosen_psk_wire_index));
 
     return S2N_SUCCESS;
 }
 
 static int s2n_server_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
         return S2N_SUCCESS;
@@ -65,8 +65,8 @@ static int s2n_server_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *
      * A key_share extension MUST have been received in order to use a pre-shared key in (EC)DHE key exchange mode.
      */
     s2n_extension_type_id key_share_ext_id;
-    GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_KEY_SHARE, &key_share_ext_id));
-    ENSURE_POSIX(S2N_CBIT_TEST(conn->extension_requests_received, key_share_ext_id), S2N_ERR_MISSING_EXTENSION);
+    POSIX_GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_KEY_SHARE, &key_share_ext_id));
+    POSIX_ENSURE(S2N_CBIT_TEST(conn->extension_requests_received, key_share_ext_id), S2N_ERR_MISSING_EXTENSION);
 
     /* From RFC section: https://tools.ietf.org/html/rfc8446#section-4.2.8.1
      * Any future values that are allocated must ensure that the transmitted protocol messages
@@ -76,16 +76,16 @@ static int s2n_server_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *
     conn->psk_params.psk_ke_mode = S2N_PSK_DHE_KE;
 
     uint16_t chosen_psk_wire_index = 0;
-    GUARD(s2n_stuffer_read_uint16(extension, &chosen_psk_wire_index));
+    POSIX_GUARD(s2n_stuffer_read_uint16(extension, &chosen_psk_wire_index));
 
     /* From RFC section: https://tools.ietf.org/html/rfc8446#section-4.2.11 
      * Clients MUST verify that the server's selected_identity is within the
      * range supplied by the client.
      */
-    ENSURE_POSIX(chosen_psk_wire_index < conn->psk_params.psk_list.len, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE(chosen_psk_wire_index < conn->psk_params.psk_list.len, S2N_ERR_INVALID_ARGUMENT);
     conn->psk_params.chosen_psk_wire_index = chosen_psk_wire_index;
 
-    GUARD_AS_POSIX(s2n_array_get(&conn->psk_params.psk_list, conn->psk_params.chosen_psk_wire_index,
+    POSIX_GUARD_RESULT(s2n_array_get(&conn->psk_params.psk_list, conn->psk_params.chosen_psk_wire_index,
                                  (void **)&conn->psk_params.chosen_psk));
 
     return S2N_SUCCESS;

--- a/tls/extensions/s2n_server_renegotiation_info.c
+++ b/tls/extensions/s2n_server_renegotiation_info.c
@@ -45,7 +45,7 @@ static bool s2n_renegotiation_info_should_send(struct s2n_connection *conn)
 static int s2n_renegotiation_info_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     /* renegotiated_connection length. Zero since we don't support renegotiation. */
-    GUARD(s2n_stuffer_write_uint8(out, 0));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, 0));
     return S2N_SUCCESS;
 }
 
@@ -55,11 +55,11 @@ static int s2n_renegotiation_info_recv(struct s2n_connection *conn, struct s2n_s
      * the "renegotiated_connection" field is zero, and if it is not, MUST
      * abort the handshake. */
     uint8_t renegotiated_connection_len;
-    GUARD(s2n_stuffer_read_uint8(extension, &renegotiated_connection_len));
+    POSIX_GUARD(s2n_stuffer_read_uint8(extension, &renegotiated_connection_len));
     S2N_ERROR_IF(s2n_stuffer_data_available(extension), S2N_ERR_NON_EMPTY_RENEGOTIATION_INFO);
     S2N_ERROR_IF(renegotiated_connection_len, S2N_ERR_NON_EMPTY_RENEGOTIATION_INFO);
 
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     conn->secure_renegotiation = 1;
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_server_sct_list.c
+++ b/tls/extensions/s2n_server_sct_list.c
@@ -41,27 +41,27 @@ static bool s2n_server_sct_list_should_send(struct s2n_connection *conn)
 
 int s2n_server_sct_list_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     struct s2n_blob *sct_list = &conn->handshake_params.our_chain_and_key->sct_list;
 
-    notnull_check(sct_list);
-    GUARD(s2n_stuffer_write(out, sct_list));
+    POSIX_ENSURE_REF(sct_list);
+    POSIX_GUARD(s2n_stuffer_write(out, sct_list));
 
     return S2N_SUCCESS;
 }
 
 int s2n_server_sct_list_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     struct s2n_blob sct_list;
     size_t data_available = s2n_stuffer_data_available(extension);
-    GUARD(s2n_blob_init(&sct_list,
+    POSIX_GUARD(s2n_blob_init(&sct_list,
             s2n_stuffer_raw_read(extension, data_available),
             data_available));
-    notnull_check(sct_list.data);
+    POSIX_ENSURE_REF(sct_list.data);
 
-    GUARD(s2n_dup(&sct_list, &conn->ct_response));
+    POSIX_GUARD(s2n_dup(&sct_list, &conn->ct_response));
 
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_server_server_name.c
+++ b/tls/extensions/s2n_server_server_name.c
@@ -44,7 +44,7 @@ static int s2n_server_name_send(struct s2n_connection *conn, struct s2n_stuffer 
 
 static int s2n_server_name_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     /* Read nothing. The extension just needs to exist. */
     conn->server_name_used = 1;
     return S2N_SUCCESS;

--- a/tls/extensions/s2n_server_session_ticket.c
+++ b/tls/extensions/s2n_server_session_ticket.c
@@ -40,7 +40,7 @@ static bool s2n_session_ticket_should_send(struct s2n_connection *conn)
 static int s2n_session_ticket_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     /* Read nothing. The extension just needs to exist. */
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     conn->session_ticket_status = S2N_NEW_TICKET;
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_server_status_request.c
+++ b/tls/extensions/s2n_server_status_request.c
@@ -39,7 +39,7 @@ static bool s2n_server_status_request_should_send(struct s2n_connection *conn)
 int s2n_server_status_request_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     /* Read nothing. The extension just needs to exist. */
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     conn->status_type = S2N_STATUS_REQUEST_OCSP;
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_server_supported_versions.c
+++ b/tls/extensions/s2n_server_supported_versions.c
@@ -52,8 +52,8 @@ const s2n_extension_type s2n_server_supported_versions_extension = {
 
 static int s2n_server_supported_versions_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    GUARD(s2n_stuffer_write_uint8(out, conn->server_protocol_version / 10));
-    GUARD(s2n_stuffer_write_uint8(out, conn->server_protocol_version % 10));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, conn->server_protocol_version / 10));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, conn->server_protocol_version % 10));
 
     return S2N_SUCCESS;
 }
@@ -62,16 +62,16 @@ static int s2n_extensions_server_supported_versions_process(struct s2n_connectio
 {
     uint8_t highest_supported_version = conn->client_protocol_version;
     uint8_t minimum_supported_version;
-    GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
+    POSIX_GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
 
     uint8_t server_version_parts[S2N_TLS_PROTOCOL_VERSION_LEN];
-    GUARD(s2n_stuffer_read_bytes(extension, server_version_parts, S2N_TLS_PROTOCOL_VERSION_LEN));
+    POSIX_GUARD(s2n_stuffer_read_bytes(extension, server_version_parts, S2N_TLS_PROTOCOL_VERSION_LEN));
 
     uint16_t server_version = (server_version_parts[0] * 10) + server_version_parts[1];
 
-    gte_check(server_version, S2N_TLS13);
-    lte_check(server_version, highest_supported_version);
-    gte_check(server_version, minimum_supported_version);
+    POSIX_ENSURE_GTE(server_version, S2N_TLS13);
+    POSIX_ENSURE_LTE(server_version, highest_supported_version);
+    POSIX_ENSURE_GTE(server_version, minimum_supported_version);
 
     conn->server_protocol_version = server_version;
     

--- a/tls/extensions/s2n_supported_versions.c
+++ b/tls/extensions/s2n_supported_versions.c
@@ -24,7 +24,7 @@
 int s2n_connection_get_minimum_supported_version(struct s2n_connection *conn, uint8_t *min_version)
 {
     const struct s2n_security_policy *security_policy;
-    GUARD(s2n_connection_get_security_policy(conn, &security_policy));
+    POSIX_GUARD(s2n_connection_get_security_policy(conn, &security_policy));
     *min_version = security_policy->minimum_protocol_version;
 
     return 0;

--- a/tls/s2n_aead.c
+++ b/tls/s2n_aead.c
@@ -25,11 +25,11 @@
 S2N_RESULT s2n_aead_aad_init(const struct s2n_connection *conn, uint8_t * sequence_number, uint8_t content_type, uint16_t record_length, struct s2n_stuffer *ad)
 {
     /* ad = seq_num || record_type || version || length */
-    GUARD_AS_RESULT(s2n_stuffer_write_bytes(ad, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
-    GUARD_AS_RESULT(s2n_stuffer_write_uint8(ad, content_type));
-    GUARD_AS_RESULT(s2n_stuffer_write_uint8(ad, conn->actual_protocol_version / 10));
-    GUARD_AS_RESULT(s2n_stuffer_write_uint8(ad, conn->actual_protocol_version % 10));
-    GUARD_AS_RESULT(s2n_stuffer_write_uint16(ad, record_length));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(ad, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(ad, content_type));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(ad, conn->actual_protocol_version / 10));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(ad, conn->actual_protocol_version % 10));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint16(ad, record_length));
 
     return S2N_RESULT_OK;
 }
@@ -37,8 +37,8 @@ S2N_RESULT s2n_aead_aad_init(const struct s2n_connection *conn, uint8_t * sequen
 /* Prepares an AAD (additional authentication data) for a TLS 1.3 AEAD record */
 S2N_RESULT s2n_tls13_aead_aad_init(uint16_t record_length, uint8_t tag_length, struct s2n_stuffer *additional_data)
 {
-    ENSURE_GT(tag_length, 0);
-    ENSURE_REF(additional_data);
+    RESULT_ENSURE_GT(tag_length, 0);
+    RESULT_ENSURE_REF(additional_data);
 
     /*
      * tls1.3 additional_data = opaque_type || legacy_record_version || length
@@ -67,12 +67,12 @@ S2N_RESULT s2n_tls13_aead_aad_init(uint16_t record_length, uint8_t tag_length, s
      */
 
     uint16_t length = record_length + tag_length;
-    ENSURE(length <= (1 << 14) + 256, S2N_ERR_RECORD_LIMIT);
+    RESULT_ENSURE(length <= (1 << 14) + 256, S2N_ERR_RECORD_LIMIT);
 
-    GUARD_AS_RESULT(s2n_stuffer_write_uint8(additional_data, TLS_APPLICATION_DATA)); /* fixed to 0x17 */
-    GUARD_AS_RESULT(s2n_stuffer_write_uint8(additional_data, 3)); /* TLS record layer              */
-    GUARD_AS_RESULT(s2n_stuffer_write_uint8(additional_data, 3)); /* version fixed at 1.2 (0x0303) */
-    GUARD_AS_RESULT(s2n_stuffer_write_uint16(additional_data, length));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(additional_data, TLS_APPLICATION_DATA)); /* fixed to 0x17 */
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(additional_data, 3)); /* TLS record layer              */
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(additional_data, 3)); /* version fixed at 1.2 (0x0303) */
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint16(additional_data, length));
 
     return S2N_RESULT_OK;
 }

--- a/tls/s2n_async_pkey.c
+++ b/tls/s2n_async_pkey.c
@@ -94,7 +94,7 @@ DEFINE_POINTER_CLEANUP_FUNC(struct s2n_async_pkey_op *, s2n_async_pkey_op_free);
 
 static S2N_RESULT s2n_async_get_actions(s2n_async_pkey_op_type type, const struct s2n_async_pkey_op_actions **actions)
 {
-    ENSURE_REF(actions);
+    RESULT_ENSURE_REF(actions);
 
     switch (type) {
         case S2N_ASYNC_DECRYPT:
@@ -111,13 +111,13 @@ static S2N_RESULT s2n_async_get_actions(s2n_async_pkey_op_type type, const struc
 
 static S2N_RESULT s2n_async_pkey_op_allocate(struct s2n_async_pkey_op **op)
 {
-    ENSURE_REF(op);
-    ENSURE(*op == NULL, S2N_ERR_SAFETY);
+    RESULT_ENSURE_REF(op);
+    RESULT_ENSURE(*op == NULL, S2N_ERR_SAFETY);
 
     /* allocate memory */
     DEFER_CLEANUP(struct s2n_blob mem = {0}, s2n_free);
-    GUARD_AS_RESULT(s2n_alloc(&mem, sizeof(struct s2n_async_pkey_op)));
-    GUARD_AS_RESULT(s2n_blob_zero(&mem));
+    RESULT_GUARD_POSIX(s2n_alloc(&mem, sizeof(struct s2n_async_pkey_op)));
+    RESULT_GUARD_POSIX(s2n_blob_zero(&mem));
 
     *op = (void *) mem.data;
     if (s2n_blob_init(&mem, NULL, 0) != S2N_SUCCESS) {
@@ -130,15 +130,15 @@ static S2N_RESULT s2n_async_pkey_op_allocate(struct s2n_async_pkey_op **op)
 S2N_RESULT s2n_async_pkey_decrypt(struct s2n_connection *conn, struct s2n_blob *encrypted,
                                   struct s2n_blob *init_decrypted, s2n_async_pkey_decrypt_complete on_complete)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(encrypted);
-    ENSURE_REF(init_decrypted);
-    ENSURE_REF(on_complete);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(encrypted);
+    RESULT_ENSURE_REF(init_decrypted);
+    RESULT_ENSURE_REF(on_complete);
 
     if (conn->config->async_pkey_cb) {
-        GUARD_RESULT(s2n_async_pkey_decrypt_async(conn, encrypted, init_decrypted, on_complete));
+        RESULT_GUARD(s2n_async_pkey_decrypt_async(conn, encrypted, init_decrypted, on_complete));
     } else {
-        GUARD_RESULT(s2n_async_pkey_decrypt_sync(conn, encrypted, init_decrypted, on_complete));
+        RESULT_GUARD(s2n_async_pkey_decrypt_sync(conn, encrypted, init_decrypted, on_complete));
     }
 
     return S2N_RESULT_OK;
@@ -147,14 +147,14 @@ S2N_RESULT s2n_async_pkey_decrypt(struct s2n_connection *conn, struct s2n_blob *
 S2N_RESULT s2n_async_pkey_decrypt_async(struct s2n_connection *conn, struct s2n_blob *encrypted,
                                         struct s2n_blob *init_decrypted, s2n_async_pkey_decrypt_complete on_complete)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(encrypted);
-    ENSURE_REF(init_decrypted);
-    ENSURE_REF(on_complete);
-    ENSURE(conn->handshake.async_state == S2N_ASYNC_NOT_INVOKED, S2N_ERR_ASYNC_MORE_THAN_ONE);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(encrypted);
+    RESULT_ENSURE_REF(init_decrypted);
+    RESULT_ENSURE_REF(on_complete);
+    RESULT_ENSURE(conn->handshake.async_state == S2N_ASYNC_NOT_INVOKED, S2N_ERR_ASYNC_MORE_THAN_ONE);
 
     DEFER_CLEANUP(struct s2n_async_pkey_op *op = NULL, s2n_async_pkey_op_free_pointer);
-    GUARD_RESULT(s2n_async_pkey_op_allocate(&op));
+    RESULT_GUARD(s2n_async_pkey_op_allocate(&op));
 
     op->type = S2N_ASYNC_DECRYPT;
     op->conn = conn;
@@ -162,38 +162,38 @@ S2N_RESULT s2n_async_pkey_decrypt_async(struct s2n_connection *conn, struct s2n_
     struct s2n_async_pkey_decrypt_data *decrypt = &op->op.decrypt;
     decrypt->on_complete                        = on_complete;
 
-    GUARD_AS_RESULT(s2n_dup(encrypted, &decrypt->encrypted));
-    GUARD_AS_RESULT(s2n_dup(init_decrypted, &decrypt->decrypted));
+    RESULT_GUARD_POSIX(s2n_dup(encrypted, &decrypt->encrypted));
+    RESULT_GUARD_POSIX(s2n_dup(init_decrypted, &decrypt->decrypted));
 
     /* Block the handshake and set async state to invoking to block async states */
-    GUARD_AS_RESULT(s2n_conn_set_handshake_read_block(conn));
+    RESULT_GUARD_POSIX(s2n_conn_set_handshake_read_block(conn));
     conn->handshake.async_state = S2N_ASYNC_INVOKING_CALLBACK;
 
     /* Move op to tmp to avoid DEFER_CLEANUP freeing the op, as it will be owned by callback */
     struct s2n_async_pkey_op *tmp_op = op;
     op = NULL;
 
-    ENSURE(conn->config->async_pkey_cb(conn, tmp_op) == S2N_SUCCESS, S2N_ERR_ASYNC_CALLBACK_FAILED);
+    RESULT_ENSURE(conn->config->async_pkey_cb(conn, tmp_op) == S2N_SUCCESS, S2N_ERR_ASYNC_CALLBACK_FAILED);
 
     /* Set state to waiting to allow op to be consumed by connection */
     conn->handshake.async_state = S2N_ASYNC_INVOKED_WAITING;
 
     /* Return an async blocked error to drop out of s2n_negotiate loop */
-    BAIL(S2N_ERR_ASYNC_BLOCKED);
+    RESULT_BAIL(S2N_ERR_ASYNC_BLOCKED);
 }
 
 S2N_RESULT s2n_async_pkey_decrypt_sync(struct s2n_connection *conn, struct s2n_blob *encrypted,
                                        struct s2n_blob *init_decrypted, s2n_async_pkey_decrypt_complete on_complete)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(encrypted);
-    ENSURE_REF(init_decrypted);
-    ENSURE_REF(on_complete);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(encrypted);
+    RESULT_ENSURE_REF(init_decrypted);
+    RESULT_ENSURE_REF(on_complete);
 
     const struct s2n_pkey *pkey = conn->handshake_params.our_chain_and_key->private_key;
 
     bool rsa_failed = s2n_pkey_decrypt(pkey, encrypted, init_decrypted) != S2N_SUCCESS;
-    GUARD_AS_RESULT(on_complete(conn, rsa_failed, init_decrypted));
+    RESULT_GUARD_POSIX(on_complete(conn, rsa_failed, init_decrypted));
 
     return S2N_RESULT_OK;
 }
@@ -201,14 +201,14 @@ S2N_RESULT s2n_async_pkey_decrypt_sync(struct s2n_connection *conn, struct s2n_b
 S2N_RESULT s2n_async_pkey_sign(struct s2n_connection *conn, s2n_signature_algorithm sig_alg,
                                struct s2n_hash_state *digest, s2n_async_pkey_sign_complete on_complete)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(digest);
-    ENSURE_REF(on_complete);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(digest);
+    RESULT_ENSURE_REF(on_complete);
 
     if (conn->config->async_pkey_cb) {
-        GUARD_RESULT(s2n_async_pkey_sign_async(conn, sig_alg, digest, on_complete));
+        RESULT_GUARD(s2n_async_pkey_sign_async(conn, sig_alg, digest, on_complete));
     } else {
-        GUARD_RESULT(s2n_async_pkey_sign_sync(conn, sig_alg, digest, on_complete));
+        RESULT_GUARD(s2n_async_pkey_sign_sync(conn, sig_alg, digest, on_complete));
     }
 
     return S2N_RESULT_OK;
@@ -217,13 +217,13 @@ S2N_RESULT s2n_async_pkey_sign(struct s2n_connection *conn, s2n_signature_algori
 S2N_RESULT s2n_async_pkey_sign_async(struct s2n_connection *conn, s2n_signature_algorithm sig_alg,
                                      struct s2n_hash_state *digest, s2n_async_pkey_sign_complete on_complete)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(digest);
-    ENSURE_REF(on_complete);
-    ENSURE(conn->handshake.async_state == S2N_ASYNC_NOT_INVOKED, S2N_ERR_ASYNC_MORE_THAN_ONE);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(digest);
+    RESULT_ENSURE_REF(on_complete);
+    RESULT_ENSURE(conn->handshake.async_state == S2N_ASYNC_NOT_INVOKED, S2N_ERR_ASYNC_MORE_THAN_ONE);
 
     DEFER_CLEANUP(struct s2n_async_pkey_op *op = NULL, s2n_async_pkey_op_free_pointer);
-    GUARD_RESULT(s2n_async_pkey_op_allocate(&op));
+    RESULT_GUARD(s2n_async_pkey_op_allocate(&op));
 
     op->type = S2N_ASYNC_SIGN;
     op->conn = conn;
@@ -232,58 +232,58 @@ S2N_RESULT s2n_async_pkey_sign_async(struct s2n_connection *conn, s2n_signature_
     sign->on_complete                     = on_complete;
     sign->sig_alg                         = sig_alg;
 
-    GUARD_AS_RESULT(s2n_hash_new(&sign->digest));
-    GUARD_AS_RESULT(s2n_hash_copy(&sign->digest, digest));
+    RESULT_GUARD_POSIX(s2n_hash_new(&sign->digest));
+    RESULT_GUARD_POSIX(s2n_hash_copy(&sign->digest, digest));
 
     /* Block the handshake and set async state to invoking to block async states */
-    GUARD_AS_RESULT(s2n_conn_set_handshake_read_block(conn));
+    RESULT_GUARD_POSIX(s2n_conn_set_handshake_read_block(conn));
     conn->handshake.async_state = S2N_ASYNC_INVOKING_CALLBACK;
 
     /* Move op to tmp to avoid DEFER_CLEANUP freeing the op, as it will be owned by callback */
     struct s2n_async_pkey_op *tmp_op = op;
     op = NULL;
 
-    ENSURE(conn->config->async_pkey_cb(conn, tmp_op) == S2N_SUCCESS, S2N_ERR_ASYNC_CALLBACK_FAILED);
+    RESULT_ENSURE(conn->config->async_pkey_cb(conn, tmp_op) == S2N_SUCCESS, S2N_ERR_ASYNC_CALLBACK_FAILED);
 
     /* Set state to waiting to allow op to be consumed by connection */
     conn->handshake.async_state = S2N_ASYNC_INVOKED_WAITING;
 
     /* Return an async blocked error to drop out of s2n_negotiate loop */
-    BAIL(S2N_ERR_ASYNC_BLOCKED);
+    RESULT_BAIL(S2N_ERR_ASYNC_BLOCKED);
 }
 
 S2N_RESULT s2n_async_pkey_sign_sync(struct s2n_connection *conn, s2n_signature_algorithm sig_alg,
                                     struct s2n_hash_state *digest, s2n_async_pkey_sign_complete on_complete)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(digest);
-    ENSURE_REF(on_complete);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(digest);
+    RESULT_ENSURE_REF(on_complete);
 
     const struct s2n_pkey *pkey = conn->handshake_params.our_chain_and_key->private_key;
     DEFER_CLEANUP(struct s2n_blob signed_content = { 0 }, s2n_free);
 
     uint32_t maximum_signature_length = 0;
-    GUARD_RESULT(s2n_pkey_size(pkey, &maximum_signature_length));
-    GUARD_AS_RESULT(s2n_alloc(&signed_content, maximum_signature_length));
+    RESULT_GUARD(s2n_pkey_size(pkey, &maximum_signature_length));
+    RESULT_GUARD_POSIX(s2n_alloc(&signed_content, maximum_signature_length));
 
-    GUARD_AS_RESULT(s2n_pkey_sign(pkey, sig_alg, digest, &signed_content));
+    RESULT_GUARD_POSIX(s2n_pkey_sign(pkey, sig_alg, digest, &signed_content));
 
-    GUARD_AS_RESULT(on_complete(conn, &signed_content));
+    RESULT_GUARD_POSIX(on_complete(conn, &signed_content));
 
     return S2N_RESULT_OK;
 }
 
 int s2n_async_pkey_op_perform(struct s2n_async_pkey_op *op, s2n_cert_private_key *key)
 {
-    ENSURE_POSIX_REF(op);
-    ENSURE_POSIX_REF(key);
-    ENSURE_POSIX(!op->complete, S2N_ERR_ASYNC_ALREADY_PERFORMED);
+    POSIX_ENSURE_REF(op);
+    POSIX_ENSURE_REF(key);
+    POSIX_ENSURE(!op->complete, S2N_ERR_ASYNC_ALREADY_PERFORMED);
 
     const struct s2n_async_pkey_op_actions *actions = NULL;
-    GUARD_AS_POSIX(s2n_async_get_actions(op->type, &actions));
-    notnull_check(actions);
+    POSIX_GUARD_RESULT(s2n_async_get_actions(op->type, &actions));
+    POSIX_ENSURE_REF(actions);
 
-    GUARD_AS_POSIX(actions->perform(op, key));
+    POSIX_GUARD_RESULT(actions->perform(op, key));
 
     op->complete = true;
 
@@ -292,52 +292,52 @@ int s2n_async_pkey_op_perform(struct s2n_async_pkey_op *op, s2n_cert_private_key
 
 int s2n_async_pkey_op_apply(struct s2n_async_pkey_op *op, struct s2n_connection *conn)
 {
-    ENSURE_POSIX_REF(op);
-    ENSURE_POSIX_REF(conn);
-    ENSURE_POSIX(op->complete, S2N_ERR_ASYNC_NOT_PERFORMED);
-    ENSURE_POSIX(!op->applied, S2N_ERR_ASYNC_ALREADY_APPLIED);
+    POSIX_ENSURE_REF(op);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE(op->complete, S2N_ERR_ASYNC_NOT_PERFORMED);
+    POSIX_ENSURE(!op->applied, S2N_ERR_ASYNC_ALREADY_APPLIED);
     /* We could have just used op->conn and removed a conn argument, but we want caller
      * to be explicit about connection it wants to resume. Plus this gives more
      * protections in cases if caller frees connection object and then tries to resume
      * the connection. */
-    ENSURE_POSIX(op->conn == conn, S2N_ERR_ASYNC_WRONG_CONNECTION);
-    ENSURE_POSIX(conn->handshake.async_state != S2N_ASYNC_INVOKING_CALLBACK, S2N_ERR_ASYNC_APPLY_WHILE_INVOKING);
-    ENSURE_POSIX(conn->handshake.async_state == S2N_ASYNC_INVOKED_WAITING, S2N_ERR_ASYNC_WRONG_CONNECTION);
+    POSIX_ENSURE(op->conn == conn, S2N_ERR_ASYNC_WRONG_CONNECTION);
+    POSIX_ENSURE(conn->handshake.async_state != S2N_ASYNC_INVOKING_CALLBACK, S2N_ERR_ASYNC_APPLY_WHILE_INVOKING);
+    POSIX_ENSURE(conn->handshake.async_state == S2N_ASYNC_INVOKED_WAITING, S2N_ERR_ASYNC_WRONG_CONNECTION);
 
     const struct s2n_async_pkey_op_actions *actions = NULL;
-    GUARD_AS_POSIX(s2n_async_get_actions(op->type, &actions));
-    notnull_check(actions);
+    POSIX_GUARD_RESULT(s2n_async_get_actions(op->type, &actions));
+    POSIX_ENSURE_REF(actions);
 
-    GUARD_AS_POSIX(actions->apply(op, conn));
+    POSIX_GUARD_RESULT(actions->apply(op, conn));
 
     op->applied                 = true;
     conn->handshake.async_state = S2N_ASYNC_INVOKED_COMPLETE;
 
     /* Free up the decrypt/sign structs to avoid storing secrets for too long */
-    GUARD_AS_POSIX(actions->free(op));
+    POSIX_GUARD_RESULT(actions->free(op));
 
     return S2N_SUCCESS;
 }
 
 int s2n_async_pkey_op_free(struct s2n_async_pkey_op *op)
 {
-    ENSURE_POSIX_REF(op);
+    POSIX_ENSURE_REF(op);
     const struct s2n_async_pkey_op_actions *actions = NULL;
-    GUARD_AS_POSIX(s2n_async_get_actions(op->type, &actions));
-    notnull_check(actions);
+    POSIX_GUARD_RESULT(s2n_async_get_actions(op->type, &actions));
+    POSIX_ENSURE_REF(actions);
 
     /* If applied the decrypt/sign structs were released in apply call */
-    if (!op->applied) { GUARD_AS_POSIX(actions->free(op)); }
+    if (!op->applied) { POSIX_GUARD_RESULT(actions->free(op)); }
 
-    GUARD_POSIX(s2n_free_object(( uint8_t ** )&op, sizeof(struct s2n_async_pkey_op)));
+    POSIX_GUARD(s2n_free_object(( uint8_t ** )&op, sizeof(struct s2n_async_pkey_op)));
 
     return S2N_SUCCESS;
 }
 
 S2N_RESULT s2n_async_pkey_decrypt_perform(struct s2n_async_pkey_op *op, s2n_cert_private_key *pkey)
 {
-    ENSURE_REF(op);
-    ENSURE_REF(pkey);
+    RESULT_ENSURE_REF(op);
+    RESULT_ENSURE_REF(pkey);
 
     struct s2n_async_pkey_decrypt_data *decrypt = &op->op.decrypt;
 
@@ -348,66 +348,66 @@ S2N_RESULT s2n_async_pkey_decrypt_perform(struct s2n_async_pkey_op *op, s2n_cert
 
 S2N_RESULT s2n_async_pkey_decrypt_apply(struct s2n_async_pkey_op *op, struct s2n_connection *conn)
 {
-    ENSURE_REF(op);
-    ENSURE_REF(conn);
+    RESULT_ENSURE_REF(op);
+    RESULT_ENSURE_REF(conn);
 
     struct s2n_async_pkey_decrypt_data *decrypt = &op->op.decrypt;
 
-    GUARD_AS_RESULT(decrypt->on_complete(conn, decrypt->rsa_failed, &decrypt->decrypted));
+    RESULT_GUARD_POSIX(decrypt->on_complete(conn, decrypt->rsa_failed, &decrypt->decrypted));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_async_pkey_decrypt_free(struct s2n_async_pkey_op *op)
 {
-    ENSURE_REF(op);
+    RESULT_ENSURE_REF(op);
 
     struct s2n_async_pkey_decrypt_data *decrypt = &op->op.decrypt;
 
-    GUARD_AS_RESULT(s2n_blob_zero(&decrypt->decrypted));
-    GUARD_AS_RESULT(s2n_blob_zero(&decrypt->encrypted));
-    GUARD_AS_RESULT(s2n_free(&decrypt->decrypted));
-    GUARD_AS_RESULT(s2n_free(&decrypt->encrypted));
+    RESULT_GUARD_POSIX(s2n_blob_zero(&decrypt->decrypted));
+    RESULT_GUARD_POSIX(s2n_blob_zero(&decrypt->encrypted));
+    RESULT_GUARD_POSIX(s2n_free(&decrypt->decrypted));
+    RESULT_GUARD_POSIX(s2n_free(&decrypt->encrypted));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_async_pkey_sign_perform(struct s2n_async_pkey_op *op, s2n_cert_private_key *pkey)
 {
-    ENSURE_REF(op);
-    ENSURE_REF(pkey);
+    RESULT_ENSURE_REF(op);
+    RESULT_ENSURE_REF(pkey);
 
     struct s2n_async_pkey_sign_data *sign = &op->op.sign;
 
     uint32_t maximum_signature_length = 0;
-    GUARD_RESULT(s2n_pkey_size(pkey, &maximum_signature_length));
-    GUARD_AS_RESULT(s2n_alloc(&sign->signature, maximum_signature_length));
+    RESULT_GUARD(s2n_pkey_size(pkey, &maximum_signature_length));
+    RESULT_GUARD_POSIX(s2n_alloc(&sign->signature, maximum_signature_length));
 
-    GUARD_AS_RESULT(s2n_pkey_sign(pkey, sign->sig_alg, &sign->digest, &sign->signature));
+    RESULT_GUARD_POSIX(s2n_pkey_sign(pkey, sign->sig_alg, &sign->digest, &sign->signature));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_async_pkey_sign_apply(struct s2n_async_pkey_op *op, struct s2n_connection *conn)
 {
-    ENSURE_REF(op);
-    ENSURE_REF(conn);
+    RESULT_ENSURE_REF(op);
+    RESULT_ENSURE_REF(conn);
 
     struct s2n_async_pkey_sign_data *sign = &op->op.sign;
 
-    GUARD_AS_RESULT(sign->on_complete(conn, &sign->signature));
+    RESULT_GUARD_POSIX(sign->on_complete(conn, &sign->signature));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_async_pkey_sign_free(struct s2n_async_pkey_op *op)
 {
-    ENSURE_REF(op);
+    RESULT_ENSURE_REF(op);
 
     struct s2n_async_pkey_sign_data *sign = &op->op.sign;
 
-    GUARD_AS_RESULT(s2n_hash_free(&sign->digest));
-    GUARD_AS_RESULT(s2n_free(&sign->signature));
+    RESULT_GUARD_POSIX(s2n_hash_free(&sign->digest));
+    RESULT_GUARD_POSIX(s2n_free(&sign->signature));
 
     return S2N_RESULT_OK;
 }

--- a/tls/s2n_async_pkey.h
+++ b/tls/s2n_async_pkey.h
@@ -32,19 +32,19 @@ struct s2n_async_pkey_op;
 #define S2N_ASYNC_PKEY_GUARD(conn)                                         \
     do {                                                                   \
         __typeof(conn) __tmp_conn = (conn);                                \
-        GUARD_NONNULL(__tmp_conn);                                         \
+        POSIX_GUARD_PTR(__tmp_conn);                                         \
         switch (conn->handshake.async_state) {                             \
             case S2N_ASYNC_NOT_INVOKED:                                    \
                 break;                                                     \
                                                                            \
             case S2N_ASYNC_INVOKING_CALLBACK:                              \
             case S2N_ASYNC_INVOKED_WAITING:                                \
-                BAIL_POSIX(S2N_ERR_ASYNC_BLOCKED);                         \
+                POSIX_BAIL(S2N_ERR_ASYNC_BLOCKED);                         \
                                                                            \
             case S2N_ASYNC_INVOKED_COMPLETE:                               \
                 /* clean up state and return a success from handler */     \
                 __tmp_conn->handshake.async_state = S2N_ASYNC_NOT_INVOKED; \
-                GUARD(s2n_conn_clear_handshake_read_block(__tmp_conn));    \
+                POSIX_GUARD(s2n_conn_clear_handshake_read_block(__tmp_conn));    \
                 return S2N_SUCCESS;                                        \
         }                                                                  \
     } while (0)

--- a/tls/s2n_auth_selection.c
+++ b/tls/s2n_auth_selection.c
@@ -52,9 +52,9 @@ static int s2n_get_auth_method_for_cert_type(s2n_pkey_type cert_type, s2n_authen
             return S2N_SUCCESS;
         case S2N_PKEY_TYPE_UNKNOWN:
         case S2N_PKEY_TYPE_SENTINEL:
-            S2N_ERROR(S2N_ERR_CERT_TYPE_UNSUPPORTED);
+            POSIX_BAIL(S2N_ERR_CERT_TYPE_UNSUPPORTED);
     }
-    S2N_ERROR(S2N_ERR_CERT_TYPE_UNSUPPORTED);
+    POSIX_BAIL(S2N_ERR_CERT_TYPE_UNSUPPORTED);
 }
 
 static int s2n_get_cert_type_for_sig_alg(s2n_signature_algorithm sig_alg, s2n_pkey_type *cert_type)
@@ -71,17 +71,17 @@ static int s2n_get_cert_type_for_sig_alg(s2n_signature_algorithm sig_alg, s2n_pk
             *cert_type = S2N_PKEY_TYPE_RSA_PSS;
             return S2N_SUCCESS;
         case S2N_SIGNATURE_ANONYMOUS:
-            S2N_ERROR(S2N_ERR_INVALID_SIGNATURE_ALGORITHM);
+            POSIX_BAIL(S2N_ERR_INVALID_SIGNATURE_ALGORITHM);
     }
-    S2N_ERROR(S2N_ERR_INVALID_SIGNATURE_ALGORITHM);
+    POSIX_BAIL(S2N_ERR_INVALID_SIGNATURE_ALGORITHM);
 }
 
 static int s2n_is_sig_alg_valid_for_cipher_suite(s2n_signature_algorithm sig_alg, struct s2n_cipher_suite *cipher_suite)
 {
-    notnull_check(cipher_suite);
+    POSIX_ENSURE_REF(cipher_suite);
 
     s2n_pkey_type cert_type_for_sig_alg;
-    GUARD(s2n_get_cert_type_for_sig_alg(sig_alg, &cert_type_for_sig_alg));
+    POSIX_GUARD(s2n_get_cert_type_for_sig_alg(sig_alg, &cert_type_for_sig_alg));
 
     /* Non-ephemeral key exchange methods require encryption, and RSA-PSS certificates
      * do not support encryption.
@@ -90,7 +90,7 @@ static int s2n_is_sig_alg_valid_for_cipher_suite(s2n_signature_algorithm sig_alg
      * algorithm that requires RSA-PSS certificates is not valid.
      */
     if (cipher_suite->key_exchange_alg != NULL && !cipher_suite->key_exchange_alg->is_ephemeral) {
-        ne_check(cert_type_for_sig_alg, S2N_PKEY_TYPE_RSA_PSS);
+        POSIX_ENSURE_NE(cert_type_for_sig_alg, S2N_PKEY_TYPE_RSA_PSS);
     }
 
     /* If a cipher suite includes an auth method, then the signature algorithm
@@ -98,8 +98,8 @@ static int s2n_is_sig_alg_valid_for_cipher_suite(s2n_signature_algorithm sig_alg
      */
     if (cipher_suite->auth_method != S2N_AUTHENTICATION_METHOD_SENTINEL) {
         s2n_authentication_method auth_method_for_sig_alg;
-        GUARD(s2n_get_auth_method_for_cert_type(cert_type_for_sig_alg, &auth_method_for_sig_alg));
-        eq_check(cipher_suite->auth_method, auth_method_for_sig_alg);
+        POSIX_GUARD(s2n_get_auth_method_for_cert_type(cert_type_for_sig_alg, &auth_method_for_sig_alg));
+        POSIX_ENSURE_EQ(cipher_suite->auth_method, auth_method_for_sig_alg);
     }
 
     return S2N_SUCCESS;
@@ -107,22 +107,22 @@ static int s2n_is_sig_alg_valid_for_cipher_suite(s2n_signature_algorithm sig_alg
 
 static int s2n_certs_exist_for_sig_scheme(struct s2n_connection *conn, const struct s2n_signature_scheme *sig_scheme)
 {
-    notnull_check(sig_scheme);
+    POSIX_ENSURE_REF(sig_scheme);
 
     s2n_pkey_type cert_type;
-    GUARD(s2n_get_cert_type_for_sig_alg(sig_scheme->sig_alg, &cert_type));
+    POSIX_GUARD(s2n_get_cert_type_for_sig_alg(sig_scheme->sig_alg, &cert_type));
 
     /* A valid cert must exist for the authentication method. */
     struct s2n_cert_chain_and_key *cert = s2n_get_compatible_cert_chain_and_key(conn, cert_type);
-    notnull_check(cert);
+    POSIX_ENSURE_REF(cert);
 
     /* For sig_algs that include a curve, the group must also match. */
     if (sig_scheme->signature_curve != NULL) {
-        notnull_check(cert->private_key);
-        notnull_check(cert->cert_chain);
-        notnull_check(cert->cert_chain->head);
-        eq_check(cert->cert_chain->head->pkey_type, S2N_PKEY_TYPE_ECDSA);
-        GUARD(s2n_ecdsa_pkey_matches_curve(&cert->private_key->key.ecdsa_key, sig_scheme->signature_curve));
+        POSIX_ENSURE_REF(cert->private_key);
+        POSIX_ENSURE_REF(cert->cert_chain);
+        POSIX_ENSURE_REF(cert->cert_chain->head);
+        POSIX_ENSURE_EQ(cert->cert_chain->head->pkey_type, S2N_PKEY_TYPE_ECDSA);
+        POSIX_GUARD(s2n_ecdsa_pkey_matches_curve(&cert->private_key->key.ecdsa_key, sig_scheme->signature_curve));
     }
 
     return S2N_SUCCESS;
@@ -136,7 +136,7 @@ static int s2n_certs_exist_for_auth_method(struct s2n_connection *conn, s2n_auth
 
     s2n_authentication_method auth_method_for_cert_type;
     for (int i = 0; i < S2N_CERT_TYPE_COUNT; i++) {
-        GUARD(s2n_get_auth_method_for_cert_type(i, &auth_method_for_cert_type));
+        POSIX_GUARD(s2n_get_auth_method_for_cert_type(i, &auth_method_for_cert_type));
 
         if (auth_method != auth_method_for_cert_type) {
             continue;
@@ -146,7 +146,7 @@ static int s2n_certs_exist_for_auth_method(struct s2n_connection *conn, s2n_auth
             return S2N_SUCCESS;
         }
     }
-    S2N_ERROR(S2N_ERR_CERT_TYPE_UNSUPPORTED);
+    POSIX_BAIL(S2N_ERR_CERT_TYPE_UNSUPPORTED);
 }
 
 /* TLS1.3 ciphers are always valid, as they don't include an auth method.
@@ -158,9 +158,9 @@ static int s2n_certs_exist_for_auth_method(struct s2n_connection *conn, s2n_auth
  */
 int s2n_is_cipher_suite_valid_for_auth(struct s2n_connection *conn, struct s2n_cipher_suite *cipher_suite)
 {
-    notnull_check(cipher_suite);
+    POSIX_ENSURE_REF(cipher_suite);
 
-    GUARD(s2n_certs_exist_for_auth_method(conn, cipher_suite->auth_method));
+    POSIX_GUARD(s2n_certs_exist_for_auth_method(conn, cipher_suite->auth_method));
 
     return S2N_SUCCESS;
 }
@@ -174,17 +174,17 @@ int s2n_is_cipher_suite_valid_for_auth(struct s2n_connection *conn, struct s2n_c
  */
 int s2n_is_sig_scheme_valid_for_auth(struct s2n_connection *conn, const struct s2n_signature_scheme *sig_scheme)
 {
-    notnull_check(conn);
-    notnull_check(sig_scheme);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(sig_scheme);
 
     struct s2n_cipher_suite *cipher_suite = conn->secure.cipher_suite;
-    notnull_check(cipher_suite);
+    POSIX_ENSURE_REF(cipher_suite);
 
-    GUARD(s2n_certs_exist_for_sig_scheme(conn, sig_scheme));
+    POSIX_GUARD(s2n_certs_exist_for_sig_scheme(conn, sig_scheme));
 
     /* For the client side, signature algorithm does not need to match the cipher suite. */
     if (conn->mode == S2N_SERVER) {
-        GUARD(s2n_is_sig_alg_valid_for_cipher_suite(sig_scheme->sig_alg, cipher_suite));
+        POSIX_GUARD(s2n_is_sig_alg_valid_for_cipher_suite(sig_scheme->sig_alg, cipher_suite));
     }
     return S2N_SUCCESS;
 }
@@ -200,11 +200,11 @@ int s2n_is_sig_scheme_valid_for_auth(struct s2n_connection *conn, const struct s
  */
 int s2n_is_cert_type_valid_for_auth(struct s2n_connection *conn, s2n_pkey_type cert_type)
 {
-    notnull_check(conn);
-    notnull_check(conn->secure.cipher_suite);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->secure.cipher_suite);
 
     s2n_authentication_method auth_method;
-    GUARD(s2n_get_auth_method_for_cert_type(cert_type, &auth_method));
+    POSIX_GUARD(s2n_get_auth_method_for_cert_type(cert_type, &auth_method));
 
     if (conn->secure.cipher_suite->auth_method != S2N_AUTHENTICATION_METHOD_SENTINEL) {
         S2N_ERROR_IF(auth_method != conn->secure.cipher_suite->auth_method, S2N_ERR_CERT_TYPE_UNSUPPORTED);
@@ -219,10 +219,10 @@ int s2n_is_cert_type_valid_for_auth(struct s2n_connection *conn, s2n_pkey_type c
  */
 int s2n_select_certs_for_server_auth(struct s2n_connection *conn, struct s2n_cert_chain_and_key **chosen_certs)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     s2n_pkey_type cert_type;
-    GUARD(s2n_get_cert_type_for_sig_alg(conn->secure.conn_sig_scheme.sig_alg, &cert_type));
+    POSIX_GUARD(s2n_get_cert_type_for_sig_alg(conn->secure.conn_sig_scheme.sig_alg, &cert_type));
 
     *chosen_certs = s2n_get_compatible_cert_chain_and_key(conn, cert_type);
     S2N_ERROR_IF(*chosen_certs == NULL, S2N_ERR_CERT_TYPE_UNSUPPORTED);

--- a/tls/s2n_change_cipher_spec.c
+++ b/tls/s2n_change_cipher_spec.c
@@ -32,7 +32,7 @@ int s2n_basic_ccs_recv(struct s2n_connection *conn)
 {
     uint8_t type;
 
-    GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, &type));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, &type));
     S2N_ERROR_IF(type != CHANGE_CIPHER_SPEC_TYPE, S2N_ERR_BAD_MESSAGE);
 
     return 0;
@@ -40,14 +40,14 @@ int s2n_basic_ccs_recv(struct s2n_connection *conn)
 
 int s2n_client_ccs_recv(struct s2n_connection *conn)
 {
-    GUARD(s2n_basic_ccs_recv(conn));
+    POSIX_GUARD(s2n_basic_ccs_recv(conn));
 
     /* Zero the sequence number */
     struct s2n_blob seq = {.data = conn->secure.client_sequence_number,.size = sizeof(conn->secure.client_sequence_number) };
-    GUARD(s2n_blob_zero(&seq));
+    POSIX_GUARD(s2n_blob_zero(&seq));
 
     /* Compute the finished message */
-    GUARD(s2n_prf_client_finished(conn));
+    POSIX_GUARD(s2n_prf_client_finished(conn));
 
     /* Update the client to use the cipher-suite */
     conn->client = &conn->secure;
@@ -55,21 +55,21 @@ int s2n_client_ccs_recv(struct s2n_connection *conn)
     /* Flush any partial alert messages that were pending.
      * If we don't do this, an attacker can inject a 1-byte alert message into the handshake
      * and cause later, valid alerts to be processed incorrectly. */
-    GUARD(s2n_stuffer_wipe(&conn->alert_in));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->alert_in));
 
     return 0;
 }
 
 int s2n_server_ccs_recv(struct s2n_connection *conn)
 {
-    GUARD(s2n_basic_ccs_recv(conn));
+    POSIX_GUARD(s2n_basic_ccs_recv(conn));
 
     /* Zero the sequence number */
     struct s2n_blob seq = {.data = conn->secure.server_sequence_number,.size = sizeof(conn->secure.server_sequence_number) };
-    GUARD(s2n_blob_zero(&seq));
+    POSIX_GUARD(s2n_blob_zero(&seq));
 
     /* Compute the finished message */
-    GUARD(s2n_prf_server_finished(conn));
+    POSIX_GUARD(s2n_prf_server_finished(conn));
 
     /* Update the secure state to active, and point the client at the active state */
     conn->server = &conn->secure;
@@ -77,14 +77,14 @@ int s2n_server_ccs_recv(struct s2n_connection *conn)
     /* Flush any partial alert messages that were pending.
      * If we don't do this, an attacker can inject a 1-byte alert message into the handshake
      * and cause later, valid alerts to be processed incorrectly. */
-    GUARD(s2n_stuffer_wipe(&conn->alert_in));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->alert_in));
 
     return 0;
 }
 
 int s2n_ccs_send(struct s2n_connection *conn)
 {
-    GUARD(s2n_stuffer_write_uint8(&conn->handshake.io, CHANGE_CIPHER_SPEC_TYPE));
+    POSIX_GUARD(s2n_stuffer_write_uint8(&conn->handshake.io, CHANGE_CIPHER_SPEC_TYPE));
 
     return 0;
 }

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -34,25 +34,25 @@ int s2n_client_cert_verify_recv(struct s2n_connection *conn)
 
     if(conn->actual_protocol_version >= S2N_TLS12){
         /* Verify the SigScheme picked by the Client was in the preference list we sent (or is the default SigScheme) */
-        GUARD(s2n_get_and_validate_negotiated_signature_scheme(conn, in, &chosen_sig_scheme));
+        POSIX_GUARD(s2n_get_and_validate_negotiated_signature_scheme(conn, in, &chosen_sig_scheme));
     }
     uint16_t signature_size;
     struct s2n_blob signature = {0};
-    GUARD(s2n_stuffer_read_uint16(in, &signature_size));
+    POSIX_GUARD(s2n_stuffer_read_uint16(in, &signature_size));
     signature.size = signature_size;
     signature.data = s2n_stuffer_raw_read(in, signature.size);
-    notnull_check(signature.data);
+    POSIX_ENSURE_REF(signature.data);
 
     /* Use a copy of the hash state since the verify digest computation may modify the running hash state we need later. */
     struct s2n_hash_state hash_state = {0};
-    GUARD(s2n_handshake_get_hash_state(conn, chosen_sig_scheme.hash_alg, &hash_state));
-    GUARD(s2n_hash_copy(&conn->handshake.ccv_hash_copy, &hash_state));
+    POSIX_GUARD(s2n_handshake_get_hash_state(conn, chosen_sig_scheme.hash_alg, &hash_state));
+    POSIX_GUARD(s2n_hash_copy(&conn->handshake.ccv_hash_copy, &hash_state));
 
     /* Verify the signature */
-    GUARD(s2n_pkey_verify(&conn->secure.client_public_key, chosen_sig_scheme.sig_alg, &conn->handshake.ccv_hash_copy, &signature));
+    POSIX_GUARD(s2n_pkey_verify(&conn->secure.client_public_key, chosen_sig_scheme.sig_alg, &conn->handshake.ccv_hash_copy, &signature));
 
     /* Client certificate has been verified. Minimize required handshake hash algs */
-    GUARD(s2n_conn_update_required_handshake_hashes(conn));
+    POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));
 
     return 0;
 }
@@ -65,28 +65,28 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
 
     if (conn->actual_protocol_version >= S2N_TLS12) {
         chosen_sig_scheme =  conn->secure.client_cert_sig_scheme;
-        GUARD(s2n_stuffer_write_uint16(out, conn->secure.client_cert_sig_scheme.iana_value));
+        POSIX_GUARD(s2n_stuffer_write_uint16(out, conn->secure.client_cert_sig_scheme.iana_value));
     }
 
     /* Use a copy of the hash state since the verify digest computation may modify the running hash state we need later. */
     struct s2n_hash_state hash_state = {0};
-    GUARD(s2n_handshake_get_hash_state(conn, chosen_sig_scheme.hash_alg, &hash_state));
-    GUARD(s2n_hash_copy(&conn->handshake.ccv_hash_copy, &hash_state));
+    POSIX_GUARD(s2n_handshake_get_hash_state(conn, chosen_sig_scheme.hash_alg, &hash_state));
+    POSIX_GUARD(s2n_hash_copy(&conn->handshake.ccv_hash_copy, &hash_state));
 
     struct s2n_cert_chain_and_key *cert_chain_and_key = conn->handshake_params.our_chain_and_key;
 
     DEFER_CLEANUP(struct s2n_blob signature = {0}, s2n_free);
     uint32_t max_signature_size = 0;
-    GUARD_AS_POSIX(s2n_pkey_size(cert_chain_and_key->private_key, &max_signature_size));
-    GUARD(s2n_alloc(&signature, max_signature_size));
+    POSIX_GUARD_RESULT(s2n_pkey_size(cert_chain_and_key->private_key, &max_signature_size));
+    POSIX_GUARD(s2n_alloc(&signature, max_signature_size));
 
-    GUARD(s2n_pkey_sign(cert_chain_and_key->private_key, chosen_sig_scheme.sig_alg, &conn->handshake.ccv_hash_copy, &signature));
+    POSIX_GUARD(s2n_pkey_sign(cert_chain_and_key->private_key, chosen_sig_scheme.sig_alg, &conn->handshake.ccv_hash_copy, &signature));
 
-    GUARD(s2n_stuffer_write_uint16(out, signature.size));
-    GUARD(s2n_stuffer_write(out, &signature));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, signature.size));
+    POSIX_GUARD(s2n_stuffer_write(out, &signature));
 
     /* Client certificate has been verified. Minimize required handshake hash algs */
-    GUARD(s2n_conn_update_required_handshake_hashes(conn));
+    POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));
 
     return 0;
 }

--- a/tls/s2n_client_finished.c
+++ b/tls/s2n_client_finished.c
@@ -30,7 +30,7 @@ int s2n_client_finished_recv(struct s2n_connection *conn)
     uint8_t *our_version;
     our_version = conn->handshake.client_finished;
     uint8_t *their_version = s2n_stuffer_raw_read(&conn->handshake.io, S2N_TLS_FINISHED_LEN);
-    notnull_check(their_version);
+    POSIX_ENSURE_REF(their_version);
 
     S2N_ERROR_IF(!s2n_constant_time_equals(our_version, their_version, S2N_TLS_FINISHED_LEN) || conn->handshake.rsa_failed, S2N_ERR_BAD_MESSAGE);
 
@@ -40,25 +40,25 @@ int s2n_client_finished_recv(struct s2n_connection *conn)
 int s2n_client_finished_send(struct s2n_connection *conn)
 {
     uint8_t *our_version;
-    GUARD(s2n_prf_client_finished(conn));
+    POSIX_GUARD(s2n_prf_client_finished(conn));
 
     struct s2n_blob seq = {.data = conn->secure.client_sequence_number,.size = sizeof(conn->secure.client_sequence_number) };
-    GUARD(s2n_blob_zero(&seq));
+    POSIX_GUARD(s2n_blob_zero(&seq));
     our_version = conn->handshake.client_finished;
 
     /* Update the server to use the cipher suite */
     conn->client = &conn->secure;
 
     if (conn->actual_protocol_version == S2N_SSLv3) {
-        GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, our_version, S2N_SSL_FINISHED_LEN));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, our_version, S2N_SSL_FINISHED_LEN));
     } else {
-        GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, our_version, S2N_TLS_FINISHED_LEN));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, our_version, S2N_TLS_FINISHED_LEN));
     }
     return 0;
 }
 
 int s2n_tls13_client_finished_recv(struct s2n_connection *conn) {
-    eq_check(conn->actual_protocol_version, S2N_TLS13);
+    POSIX_ENSURE_EQ(conn->actual_protocol_version, S2N_TLS13);
 
     uint8_t length = s2n_stuffer_data_available(&conn->handshake.io);
     S2N_ERROR_IF(length == 0, S2N_ERR_BAD_MESSAGE);
@@ -72,39 +72,39 @@ int s2n_tls13_client_finished_recv(struct s2n_connection *conn) {
 
     /* get transcript hash */
     struct s2n_hash_state hash_state = {0};
-    GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
+    POSIX_GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
 
     struct s2n_blob finished_key = {0};
-    GUARD(s2n_blob_init(&finished_key, conn->handshake.client_finished, keys.size));
+    POSIX_GUARD(s2n_blob_init(&finished_key, conn->handshake.client_finished, keys.size));
 
     s2n_tls13_key_blob(client_finished_mac, keys.size);
-    GUARD(s2n_tls13_calculate_finished_mac(&keys, &finished_key, &hash_state, &client_finished_mac));
+    POSIX_GUARD(s2n_tls13_calculate_finished_mac(&keys, &finished_key, &hash_state, &client_finished_mac));
 
-    GUARD(s2n_tls13_mac_verify(&keys, &client_finished_mac, &wire_finished_mac));
+    POSIX_GUARD(s2n_tls13_mac_verify(&keys, &client_finished_mac, &wire_finished_mac));
 
     return 0;
 }
 
 int s2n_tls13_client_finished_send(struct s2n_connection *conn) {
-    eq_check(conn->actual_protocol_version, S2N_TLS13);
+    POSIX_ENSURE_EQ(conn->actual_protocol_version, S2N_TLS13);
 
     /* get tls13 keys */
     s2n_tls13_connection_keys(keys, conn);
 
     /* get transcript hash */
     struct s2n_hash_state hash_state = {0};
-    GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
+    POSIX_GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
 
     /* look up finished secret key */
     struct s2n_blob finished_key = {0};
-    GUARD(s2n_blob_init(&finished_key, conn->handshake.client_finished, keys.size));
+    POSIX_GUARD(s2n_blob_init(&finished_key, conn->handshake.client_finished, keys.size));
 
     /* generate the hashed message authenticated code */
     s2n_stack_blob(client_finished_mac, keys.size, S2N_TLS13_SECRET_MAX_LEN);
-    GUARD(s2n_tls13_calculate_finished_mac(&keys, &finished_key, &hash_state, &client_finished_mac));
+    POSIX_GUARD(s2n_tls13_calculate_finished_mac(&keys, &finished_key, &hash_state, &client_finished_mac));
 
     /* write to handshake io */
-    GUARD(s2n_stuffer_write(&conn->handshake.io, &client_finished_mac));
+    POSIX_GUARD(s2n_stuffer_write(&conn->handshake.io, &client_finished_mac));
 
     return 0;
 }

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -58,8 +58,8 @@ static uint32_t min_size(struct s2n_blob *blob, uint32_t max_length) {
 
 static S2N_RESULT s2n_generate_client_session_id(struct s2n_connection *conn)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(conn->config);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn->config);
 
     /* Session id already generated - no-op */
     if (conn->session_id_len) {
@@ -78,76 +78,76 @@ static S2N_RESULT s2n_generate_client_session_id(struct s2n_connection *conn)
     }
 
     struct s2n_blob session_id = {0};
-    GUARD_AS_RESULT(s2n_blob_init(&session_id, conn->session_id, S2N_TLS_SESSION_ID_MAX_LEN));
-    GUARD_RESULT(s2n_get_public_random_data(&session_id));
+    RESULT_GUARD_POSIX(s2n_blob_init(&session_id, conn->session_id, S2N_TLS_SESSION_ID_MAX_LEN));
+    RESULT_GUARD(s2n_get_public_random_data(&session_id));
     conn->session_id_len = S2N_TLS_SESSION_ID_MAX_LEN;
 
     return S2N_RESULT_OK;
 }
 
 ssize_t s2n_client_hello_get_raw_message_length(struct s2n_client_hello *ch) {
-    notnull_check(ch);
+    POSIX_ENSURE_REF(ch);
 
     return ch->raw_message.blob.size;
 }
 
 ssize_t s2n_client_hello_get_raw_message(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length)
 {
-    notnull_check(ch);
-    notnull_check(out);
+    POSIX_ENSURE_REF(ch);
+    POSIX_ENSURE_REF(out);
 
     uint32_t len = min_size(&ch->raw_message.blob, max_length);
 
     struct s2n_stuffer *raw_message = &ch->raw_message;
-    GUARD(s2n_stuffer_reread(raw_message));
-    GUARD(s2n_stuffer_read_bytes(raw_message, out, len));
+    POSIX_GUARD(s2n_stuffer_reread(raw_message));
+    POSIX_GUARD(s2n_stuffer_read_bytes(raw_message, out, len));
 
     return len;
 }
 
 ssize_t s2n_client_hello_get_cipher_suites_length(struct s2n_client_hello *ch) {
-    notnull_check(ch);
+    POSIX_ENSURE_REF(ch);
 
     return ch->cipher_suites.size;
 }
 
 ssize_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length)
 {
-    notnull_check(ch);
-    notnull_check(out);
-    notnull_check(ch->cipher_suites.data);
+    POSIX_ENSURE_REF(ch);
+    POSIX_ENSURE_REF(out);
+    POSIX_ENSURE_REF(ch->cipher_suites.data);
 
     uint32_t len = min_size(&ch->cipher_suites, max_length);
 
-    memcpy_check(out, &ch->cipher_suites.data, len);
+    POSIX_CHECKED_MEMCPY(out, &ch->cipher_suites.data, len);
 
     return len;
 }
 
 ssize_t s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch) {
-    notnull_check(ch);
+    POSIX_ENSURE_REF(ch);
 
     return ch->extensions.raw.size;
 }
 
 ssize_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length)
 {
-    notnull_check(ch);
-    notnull_check(out);
-    notnull_check(ch->extensions.raw.data);
+    POSIX_ENSURE_REF(ch);
+    POSIX_ENSURE_REF(out);
+    POSIX_ENSURE_REF(ch->extensions.raw.data);
 
     uint32_t len = min_size(&ch->extensions.raw, max_length);
 
-    memcpy_check(out, &ch->extensions.raw.data, len);
+    POSIX_CHECKED_MEMCPY(out, &ch->extensions.raw.data, len);
 
     return len;
 }
 
 int s2n_client_hello_free(struct s2n_client_hello *client_hello)
 {
-    notnull_check(client_hello);
+    POSIX_ENSURE_REF(client_hello);
 
-    GUARD(s2n_stuffer_free(&client_hello->raw_message));
+    POSIX_GUARD(s2n_stuffer_free(&client_hello->raw_message));
 
     /* These point to data in the raw_message stuffer,
        so we don't need to free them */
@@ -159,27 +159,27 @@ int s2n_client_hello_free(struct s2n_client_hello *client_hello)
 
 int s2n_collect_client_hello(struct s2n_connection *conn, struct s2n_stuffer *source)
 {
-    notnull_check(conn);
-    notnull_check(source);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(source);
 
     uint32_t size = s2n_stuffer_data_available(source);
     S2N_ERROR_IF(size == 0, S2N_ERR_BAD_MESSAGE);
 
     struct s2n_client_hello *ch = &conn->client_hello;
 
-    GUARD(s2n_stuffer_resize(&ch->raw_message, size));
-    GUARD(s2n_stuffer_copy(source, &ch->raw_message, size));
+    POSIX_GUARD(s2n_stuffer_resize(&ch->raw_message, size));
+    POSIX_GUARD(s2n_stuffer_copy(source, &ch->raw_message, size));
 
     return 0;
 }
 
 static int s2n_parse_client_hello(struct s2n_connection *conn)
 {
-    notnull_check(conn);
-    GUARD(s2n_collect_client_hello(conn, &conn->handshake.io));
+    POSIX_ENSURE_REF(conn);
+    POSIX_GUARD(s2n_collect_client_hello(conn, &conn->handshake.io));
 
     if (conn->client_hello_version == S2N_SSLv2) {
-        GUARD(s2n_sslv2_client_hello_recv(conn));
+        POSIX_GUARD(s2n_sslv2_client_hello_recv(conn));
         return S2N_SUCCESS;
     }
 
@@ -189,8 +189,8 @@ static int s2n_parse_client_hello(struct s2n_connection *conn)
 
     uint8_t client_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
 
-    GUARD(s2n_stuffer_read_bytes(in, client_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
-    GUARD(s2n_stuffer_erase_and_read_bytes(in, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_stuffer_read_bytes(in, client_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
+    POSIX_GUARD(s2n_stuffer_erase_and_read_bytes(in, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
 
     /* Protocol version in the ClientHello is fixed at 0x0303(TLS 1.2) for
      * future versions of TLS. Therefore, we will negotiate down if a client sends
@@ -199,28 +199,28 @@ static int s2n_parse_client_hello(struct s2n_connection *conn)
     conn->client_protocol_version = MIN((client_protocol_version[0] * 10) + client_protocol_version[1], S2N_TLS12);
     conn->client_hello_version = conn->client_protocol_version;
 
-    GUARD(s2n_stuffer_read_uint8(in, &conn->session_id_len));
+    POSIX_GUARD(s2n_stuffer_read_uint8(in, &conn->session_id_len));
     S2N_ERROR_IF(conn->session_id_len > S2N_TLS_SESSION_ID_MAX_LEN || conn->session_id_len > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
 
-    GUARD(s2n_stuffer_read_bytes(in, conn->session_id, conn->session_id_len));
+    POSIX_GUARD(s2n_stuffer_read_bytes(in, conn->session_id, conn->session_id_len));
 
     uint16_t cipher_suites_length = 0;
-    GUARD(s2n_stuffer_read_uint16(in, &cipher_suites_length));
-    ENSURE_POSIX(cipher_suites_length > 0, S2N_ERR_BAD_MESSAGE);
-    ENSURE_POSIX(cipher_suites_length % S2N_TLS_CIPHER_SUITE_LEN == 0, S2N_ERR_BAD_MESSAGE);
+    POSIX_GUARD(s2n_stuffer_read_uint16(in, &cipher_suites_length));
+    POSIX_ENSURE(cipher_suites_length > 0, S2N_ERR_BAD_MESSAGE);
+    POSIX_ENSURE(cipher_suites_length % S2N_TLS_CIPHER_SUITE_LEN == 0, S2N_ERR_BAD_MESSAGE);
    
     client_hello->cipher_suites.size = cipher_suites_length;
     client_hello->cipher_suites.data = s2n_stuffer_raw_read(in, cipher_suites_length);
-    notnull_check(client_hello->cipher_suites.data);
+    POSIX_ENSURE_REF(client_hello->cipher_suites.data);
 
     /* Don't choose the cipher yet, read the extensions first */
     uint8_t num_compression_methods = 0;
-    GUARD(s2n_stuffer_read_uint8(in, &num_compression_methods));
-    GUARD(s2n_stuffer_skip_read(in, num_compression_methods));
+    POSIX_GUARD(s2n_stuffer_read_uint8(in, &num_compression_methods));
+    POSIX_GUARD(s2n_stuffer_skip_read(in, num_compression_methods));
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    POSIX_ENSURE_REF(ecc_pref);
 
     /* This is going to be our fallback if the client has no preference. */
     /* A TLS-compliant application MUST support key exchange with secp256r1 (NIST P-256) */
@@ -228,7 +228,7 @@ static int s2n_parse_client_hello(struct s2n_connection *conn)
     /* - https://tools.ietf.org/html/rfc8446#section-9.1 */
     conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
 
-    GUARD(s2n_extension_list_parse(in, &conn->client_hello.extensions));
+    POSIX_GUARD(s2n_extension_list_parse(in, &conn->client_hello.extensions));
 
     return S2N_SUCCESS;
 }
@@ -240,7 +240,7 @@ int s2n_process_client_hello(struct s2n_connection *conn)
     struct s2n_client_hello *client_hello = &conn->client_hello;
 
     const struct s2n_security_policy *security_policy;
-    GUARD(s2n_connection_get_security_policy(conn, &security_policy));
+    POSIX_GUARD(s2n_connection_get_security_policy(conn, &security_policy));
 
     /* Ensure that highest supported version is set correctly */
     if (!s2n_security_policy_supports_tls13(security_policy)) {
@@ -252,11 +252,11 @@ int s2n_process_client_hello(struct s2n_connection *conn)
      * To keep the version in client_hello intact for the extension retrieval APIs, process a copy instead.
      */
     s2n_parsed_extensions_list copy_of_parsed_extensions = conn->client_hello.extensions;
-    GUARD(s2n_extension_list_process(S2N_EXTENSION_LIST_CLIENT_HELLO, conn, &copy_of_parsed_extensions));
+    POSIX_GUARD(s2n_extension_list_process(S2N_EXTENSION_LIST_CLIENT_HELLO, conn, &copy_of_parsed_extensions));
 
     /* After parsing extensions, select a curve and corresponding keyshare to use */
     if (conn->actual_protocol_version >= S2N_TLS13) {
-        GUARD(s2n_extensions_server_key_share_select(conn));
+        POSIX_GUARD(s2n_extensions_server_key_share_select(conn));
     }
 
     /* for pre TLS 1.3 connections, protocol selection is not done in supported_versions extensions, so do it here */
@@ -265,19 +265,19 @@ int s2n_process_client_hello(struct s2n_connection *conn)
     }
 
     if (conn->client_protocol_version < security_policy->minimum_protocol_version) {
-        GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
-        S2N_ERROR(S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+        POSIX_GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
+        POSIX_BAIL(S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
     }
 
     if (conn->config->quic_enabled) {
-        ENSURE_POSIX(conn->actual_protocol_version >= S2N_TLS13, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+        POSIX_ENSURE(conn->actual_protocol_version >= S2N_TLS13, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
     }
 
     /* Find potential certificate matches before we choose the cipher. */
-    GUARD(s2n_conn_find_name_matching_certs(conn));
+    POSIX_GUARD(s2n_conn_find_name_matching_certs(conn));
 
     /* Now choose the ciphers we have certs for. */
-    GUARD(s2n_set_cipher_as_tls_server(conn, client_hello->cipher_suites.data, client_hello->cipher_suites.size / 2));
+    POSIX_GUARD(s2n_set_cipher_as_tls_server(conn, client_hello->cipher_suites.data, client_hello->cipher_suites.size / 2));
 
     /* If we're using a PSK, we don't need to choose a signature algorithm or certificate,
      * because no additional auth is required. */
@@ -286,12 +286,12 @@ int s2n_process_client_hello(struct s2n_connection *conn)
     }
 
     /* And set the signature and hash algorithm used for key exchange signatures */
-    GUARD(s2n_choose_sig_scheme_from_peer_preference_list(conn,
+    POSIX_GUARD(s2n_choose_sig_scheme_from_peer_preference_list(conn,
         &conn->handshake_params.client_sig_hash_algs,
         &conn->secure.conn_sig_scheme));
 
     /* And finally, set the certs specified by the final auth + sig_alg combo. */
-    GUARD(s2n_select_certs_for_server_auth(conn, &conn->handshake_params.our_chain_and_key));
+    POSIX_GUARD(s2n_select_certs_for_server_auth(conn, &conn->handshake_params.our_chain_and_key));
 
     return S2N_SUCCESS;
 }
@@ -299,7 +299,7 @@ int s2n_process_client_hello(struct s2n_connection *conn)
 int s2n_client_hello_recv(struct s2n_connection *conn)
 {
     /* Parse client hello */
-    GUARD(s2n_parse_client_hello(conn));
+    POSIX_GUARD(s2n_parse_client_hello(conn));
 
     /* If the CLIENT_HELLO has already been parsed, then we should not call
      * the client_hello_cb a second time. */
@@ -311,8 +311,8 @@ int s2n_client_hello_recv(struct s2n_connection *conn)
         if (conn->config->client_hello_cb) {
             int rc = conn->config->client_hello_cb(conn, conn->config->client_hello_cb_ctx);
             if (rc < 0) {
-                GUARD(s2n_queue_reader_handshake_failure_alert(conn));
-                S2N_ERROR(S2N_ERR_CANCELLED);
+                POSIX_GUARD(s2n_queue_reader_handshake_failure_alert(conn));
+                POSIX_BAIL(S2N_ERR_CANCELLED);
             }
             if (rc) {
                 conn->server_name_used = 1;
@@ -321,7 +321,7 @@ int s2n_client_hello_recv(struct s2n_connection *conn)
     }
 
     if (conn->client_hello_version != S2N_SSLv2) {
-        GUARD(s2n_process_client_hello(conn));
+        POSIX_GUARD(s2n_process_client_hello(conn));
     }
 
     return 0;
@@ -330,10 +330,10 @@ int s2n_client_hello_recv(struct s2n_connection *conn)
 int s2n_client_hello_send(struct s2n_connection *conn)
 {
     const struct s2n_security_policy *security_policy;
-    GUARD(s2n_connection_get_security_policy(conn, &security_policy));
+    POSIX_GUARD(s2n_connection_get_security_policy(conn, &security_policy));
 
     const struct s2n_cipher_preferences *cipher_preferences = security_policy->cipher_preferences;
-    notnull_check(cipher_preferences);
+    POSIX_ENSURE_REF(cipher_preferences);
 
     /* Check whether cipher preference supports TLS 1.3. If it doesn't,
        our highest supported version is S2N_TLS12 */
@@ -347,65 +347,65 @@ int s2n_client_hello_send(struct s2n_connection *conn)
     uint8_t client_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN] = {0};
 
     struct s2n_blob b = {0};
-    GUARD(s2n_blob_init(&b, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_blob_init(&b, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
     /* Create the client random data */
-    GUARD(s2n_stuffer_init(&client_random, &b));
+    POSIX_GUARD(s2n_stuffer_init(&client_random, &b));
 
     struct s2n_blob r = {0};
-    GUARD(s2n_blob_init(&r, s2n_stuffer_raw_write(&client_random, S2N_TLS_RANDOM_DATA_LEN), S2N_TLS_RANDOM_DATA_LEN));
-    notnull_check(r.data);
-    GUARD_AS_POSIX(s2n_get_public_random_data(&r));
+    POSIX_GUARD(s2n_blob_init(&r, s2n_stuffer_raw_write(&client_random, S2N_TLS_RANDOM_DATA_LEN), S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_ENSURE_REF(r.data);
+    POSIX_GUARD_RESULT(s2n_get_public_random_data(&r));
 
     uint8_t reported_protocol_version = MIN(conn->client_protocol_version, S2N_TLS12);
     client_protocol_version[0] = reported_protocol_version / 10;
     client_protocol_version[1] = reported_protocol_version % 10;
     conn->client_hello_version = reported_protocol_version;
 
-    GUARD(s2n_stuffer_write_bytes(out, client_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
-    GUARD(s2n_stuffer_copy(&client_random, out, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_stuffer_write_bytes(out, client_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
+    POSIX_GUARD(s2n_stuffer_copy(&client_random, out, S2N_TLS_RANDOM_DATA_LEN));
 
-    GUARD_AS_POSIX(s2n_generate_client_session_id(conn));
-    GUARD(s2n_stuffer_write_uint8(out, conn->session_id_len));
+    POSIX_GUARD_RESULT(s2n_generate_client_session_id(conn));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, conn->session_id_len));
     if (conn->session_id_len > 0) {
-        GUARD(s2n_stuffer_write_bytes(out, conn->session_id, conn->session_id_len));
+        POSIX_GUARD(s2n_stuffer_write_bytes(out, conn->session_id, conn->session_id_len));
     }
 
     /* Reserve space for size of the list of available ciphers */
     struct s2n_stuffer_reservation available_cipher_suites_size;
-    GUARD(s2n_stuffer_reserve_uint16(out, &available_cipher_suites_size));
+    POSIX_GUARD(s2n_stuffer_reserve_uint16(out, &available_cipher_suites_size));
 
     /* Now, write the IANA values of every available cipher suite in our list */
     for (int i = 0; i < security_policy->cipher_preferences->count; i++ ) {
         if (cipher_preferences->suites[i]->available &&
                 cipher_preferences->suites[i]->minimum_required_tls_version <= conn->client_protocol_version) {
-            GUARD(s2n_stuffer_write_bytes(out, security_policy->cipher_preferences->suites[i]->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
+            POSIX_GUARD(s2n_stuffer_write_bytes(out, security_policy->cipher_preferences->suites[i]->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
         }
     }
 
     /* Lastly, write TLS_EMPTY_RENEGOTIATION_INFO_SCSV so that server knows it's an initial handshake (RFC5746 Section 3.4) */
     uint8_t renegotiation_info_scsv[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_EMPTY_RENEGOTIATION_INFO_SCSV };
-    GUARD(s2n_stuffer_write_bytes(out, renegotiation_info_scsv, S2N_TLS_CIPHER_SUITE_LEN));
+    POSIX_GUARD(s2n_stuffer_write_bytes(out, renegotiation_info_scsv, S2N_TLS_CIPHER_SUITE_LEN));
 
     /* Write size of the list of available ciphers */
-    GUARD(s2n_stuffer_write_vector_size(&available_cipher_suites_size));
+    POSIX_GUARD(s2n_stuffer_write_vector_size(&available_cipher_suites_size));
 
     /* Zero compression methods */
-    GUARD(s2n_stuffer_write_uint8(out, 1));
-    GUARD(s2n_stuffer_write_uint8(out, 0));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, 1));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, 0));
 
     /* Write the extensions */
-    GUARD(s2n_extension_list_send(S2N_EXTENSION_LIST_CLIENT_HELLO, conn, out));
+    POSIX_GUARD(s2n_extension_list_send(S2N_EXTENSION_LIST_CLIENT_HELLO, conn, out));
 
     /* Once the message is complete, finish calculating the PSK binders.
      *
      * The PSK binders require all the sizes in the ClientHello to be written correctly,
      * including the extension size and extension list size, and therefore have
      * to be calculated AFTER we finish writing the entire extension list. */
-    GUARD_AS_POSIX(s2n_finish_psk_extension(conn));
+    POSIX_GUARD_RESULT(s2n_finish_psk_extension(conn));
 
     /* If early data was not requested as part of the ClientHello, it never will be. */
     if (conn->early_data_state == S2N_UNKNOWN_EARLY_DATA_STATE) {
-        GUARD_AS_POSIX(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_NOT_REQUESTED));
+        POSIX_GUARD_RESULT(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_NOT_REQUESTED));
     }
 
     return S2N_SUCCESS;
@@ -418,54 +418,54 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
     struct s2n_stuffer *in = &client_hello->raw_message;
 
     const struct s2n_security_policy *security_policy;
-    GUARD(s2n_connection_get_security_policy(conn, &security_policy));
+    POSIX_GUARD(s2n_connection_get_security_policy(conn, &security_policy));
 
     if (conn->client_protocol_version < security_policy->minimum_protocol_version) {
-        GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
-        S2N_ERROR(S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+        POSIX_GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
+        POSIX_BAIL(S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
     }
     conn->actual_protocol_version = MIN(conn->client_protocol_version, conn->server_protocol_version);
 
     /* We start 5 bytes into the record */
     uint16_t cipher_suites_length;
-    GUARD(s2n_stuffer_read_uint16(in, &cipher_suites_length));
-    ENSURE_POSIX(cipher_suites_length > 0, S2N_ERR_BAD_MESSAGE);
-    ENSURE_POSIX(cipher_suites_length % S2N_SSLv2_CIPHER_SUITE_LEN == 0, S2N_ERR_BAD_MESSAGE);
+    POSIX_GUARD(s2n_stuffer_read_uint16(in, &cipher_suites_length));
+    POSIX_ENSURE(cipher_suites_length > 0, S2N_ERR_BAD_MESSAGE);
+    POSIX_ENSURE(cipher_suites_length % S2N_SSLv2_CIPHER_SUITE_LEN == 0, S2N_ERR_BAD_MESSAGE);
 
     uint16_t session_id_length;
-    GUARD(s2n_stuffer_read_uint16(in, &session_id_length));
+    POSIX_GUARD(s2n_stuffer_read_uint16(in, &session_id_length));
 
     uint16_t challenge_length;
-    GUARD(s2n_stuffer_read_uint16(in, &challenge_length));
+    POSIX_GUARD(s2n_stuffer_read_uint16(in, &challenge_length));
 
     S2N_ERROR_IF(challenge_length > S2N_TLS_RANDOM_DATA_LEN, S2N_ERR_BAD_MESSAGE);
 
     client_hello->cipher_suites.size = cipher_suites_length;
     client_hello->cipher_suites.data = s2n_stuffer_raw_read(in, cipher_suites_length);
-    notnull_check(client_hello->cipher_suites.data);
+    POSIX_ENSURE_REF(client_hello->cipher_suites.data);
 
     /* Find potential certificate matches before we choose the cipher. */
-    GUARD(s2n_conn_find_name_matching_certs(conn));
+    POSIX_GUARD(s2n_conn_find_name_matching_certs(conn));
 
-    GUARD(s2n_set_cipher_as_sslv2_server(conn, client_hello->cipher_suites.data, client_hello->cipher_suites.size / S2N_SSLv2_CIPHER_SUITE_LEN));
-    GUARD(s2n_choose_default_sig_scheme(conn, &conn->secure.conn_sig_scheme));
-    GUARD(s2n_select_certs_for_server_auth(conn, &conn->handshake_params.our_chain_and_key));
+    POSIX_GUARD(s2n_set_cipher_as_sslv2_server(conn, client_hello->cipher_suites.data, client_hello->cipher_suites.size / S2N_SSLv2_CIPHER_SUITE_LEN));
+    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &conn->secure.conn_sig_scheme));
+    POSIX_GUARD(s2n_select_certs_for_server_auth(conn, &conn->handshake_params.our_chain_and_key));
 
     S2N_ERROR_IF(session_id_length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
     if (session_id_length > 0 && session_id_length <= S2N_TLS_SESSION_ID_MAX_LEN) {
-        GUARD(s2n_stuffer_read_bytes(in, conn->session_id, session_id_length));
+        POSIX_GUARD(s2n_stuffer_read_bytes(in, conn->session_id, session_id_length));
         conn->session_id_len = (uint8_t) session_id_length;
     } else {
-        GUARD(s2n_stuffer_skip_read(in, session_id_length));
+        POSIX_GUARD(s2n_stuffer_skip_read(in, session_id_length));
     }
 
     struct s2n_blob b = {0};
-    GUARD(s2n_blob_init(&b, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_blob_init(&b, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
 
     b.data += S2N_TLS_RANDOM_DATA_LEN - challenge_length;
     b.size -= S2N_TLS_RANDOM_DATA_LEN - challenge_length;
 
-    GUARD(s2n_stuffer_read(in, &b));
+    POSIX_GUARD(s2n_stuffer_read(in, &b));
 
     return 0;
 }
@@ -473,15 +473,15 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
 static int s2n_client_hello_get_parsed_extension(s2n_tls_extension_type extension_type,
         s2n_parsed_extensions_list *parsed_extension_list, s2n_parsed_extension **parsed_extension)
 {
-    notnull_check(parsed_extension_list);
-    notnull_check(parsed_extension);
+    POSIX_ENSURE_REF(parsed_extension_list);
+    POSIX_ENSURE_REF(parsed_extension);
 
     s2n_extension_type_id extension_type_id;
-    GUARD(s2n_extension_supported_iana_value_to_id(extension_type, &extension_type_id));
+    POSIX_GUARD(s2n_extension_supported_iana_value_to_id(extension_type, &extension_type_id));
 
     s2n_parsed_extension *found_parsed_extension = &parsed_extension_list->parsed_extensions[extension_type_id];
-    notnull_check(found_parsed_extension->extension.data);
-    ENSURE_POSIX(found_parsed_extension->extension_type == extension_type, S2N_ERR_INVALID_PARSED_EXTENSIONS);
+    POSIX_ENSURE_REF(found_parsed_extension->extension.data);
+    POSIX_ENSURE(found_parsed_extension->extension_type == extension_type, S2N_ERR_INVALID_PARSED_EXTENSIONS);
 
     *parsed_extension = found_parsed_extension;
     return S2N_SUCCESS;
@@ -489,7 +489,7 @@ static int s2n_client_hello_get_parsed_extension(s2n_tls_extension_type extensio
 
 ssize_t s2n_client_hello_get_extension_length(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type)
 {
-    notnull_check(ch);
+    POSIX_ENSURE_REF(ch);
 
     s2n_parsed_extension *parsed_extension = NULL;
     if (s2n_client_hello_get_parsed_extension(extension_type, &ch->extensions, &parsed_extension) != S2N_SUCCESS) {
@@ -501,8 +501,8 @@ ssize_t s2n_client_hello_get_extension_length(struct s2n_client_hello *ch, s2n_t
 
 ssize_t s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length)
 {
-    notnull_check(ch);
-    notnull_check(out);
+    POSIX_ENSURE_REF(ch);
+    POSIX_ENSURE_REF(out);
 
     s2n_parsed_extension *parsed_extension = NULL;
     if (s2n_client_hello_get_parsed_extension(extension_type, &ch->extensions, &parsed_extension) != S2N_SUCCESS) {
@@ -510,6 +510,6 @@ ssize_t s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tl
     }
 
     uint32_t len = min_size(&parsed_extension->extension, max_length);
-    memcpy_check(out, parsed_extension->extension.data, len);
+    POSIX_CHECKED_MEMCPY(out, parsed_extension->extension.data, len);
     return len;
 }

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -46,8 +46,8 @@ static int s2n_rsa_client_key_recv_complete(struct s2n_connection *conn, bool rs
 static int s2n_hybrid_client_action(struct s2n_connection *conn, struct s2n_blob *combined_shared_key,
         s2n_kex_client_key_method kex_method, uint32_t *cursor, s2n_stuffer_action stuffer_action)
 {
-    notnull_check(kex_method);
-    notnull_check(stuffer_action);
+    POSIX_ENSURE_REF(kex_method);
+    POSIX_ENSURE_REF(stuffer_action);
     struct s2n_stuffer *io = &conn->handshake.io;
     const struct s2n_kex *hybrid_kex_0 = conn->secure.cipher_suite->key_exchange_alg->hybrid[0];
     const struct s2n_kex *hybrid_kex_1 = conn->secure.cipher_suite->key_exchange_alg->hybrid[1];
@@ -55,26 +55,26 @@ static int s2n_hybrid_client_action(struct s2n_connection *conn, struct s2n_blob
     /* Keep a copy to the start of the entire hybrid client key exchange message for the hybrid PRF */
     struct s2n_blob *client_key_exchange_message = &conn->secure.client_key_exchange_message;
     client_key_exchange_message->data = stuffer_action(io, 0);
-    notnull_check(client_key_exchange_message->data);
+    POSIX_ENSURE_REF(client_key_exchange_message->data);
     const uint32_t start_cursor = *cursor;
 
     DEFER_CLEANUP(struct s2n_blob shared_key_0 = {0}, s2n_free);
-    GUARD_AS_POSIX(kex_method(hybrid_kex_0, conn, &shared_key_0));
+    POSIX_GUARD_RESULT(kex_method(hybrid_kex_0, conn, &shared_key_0));
 
     struct s2n_blob *shared_key_1 = &(conn->secure.kem_params.shared_secret);
-    GUARD_AS_POSIX(kex_method(hybrid_kex_1, conn, shared_key_1));
+    POSIX_GUARD_RESULT(kex_method(hybrid_kex_1, conn, shared_key_1));
 
     const uint32_t end_cursor = *cursor;
-    gte_check(end_cursor, start_cursor);
+    POSIX_ENSURE_GTE(end_cursor, start_cursor);
     client_key_exchange_message->size = end_cursor - start_cursor;
 
-    GUARD(s2n_alloc(combined_shared_key, shared_key_0.size + shared_key_1->size));
+    POSIX_GUARD(s2n_alloc(combined_shared_key, shared_key_0.size + shared_key_1->size));
     struct s2n_stuffer stuffer_combiner = {0};
-    GUARD(s2n_stuffer_init(&stuffer_combiner, combined_shared_key));
-    GUARD(s2n_stuffer_write(&stuffer_combiner, &shared_key_0));
-    GUARD(s2n_stuffer_write(&stuffer_combiner, shared_key_1));
+    POSIX_GUARD(s2n_stuffer_init(&stuffer_combiner, combined_shared_key));
+    POSIX_GUARD(s2n_stuffer_write(&stuffer_combiner, &shared_key_0));
+    POSIX_GUARD(s2n_stuffer_write(&stuffer_combiner, shared_key_1));
 
-    GUARD(s2n_kem_free(&conn->secure.kem_params));
+    POSIX_GUARD(s2n_kem_free(&conn->secure.kem_params));
 
     return 0;
 }
@@ -82,17 +82,17 @@ static int s2n_hybrid_client_action(struct s2n_connection *conn, struct s2n_blob
 static int s2n_calculate_keys(struct s2n_connection *conn, struct s2n_blob *shared_key)
 {
     /* Turn the pre-master secret into a master secret */
-    GUARD_AS_POSIX(s2n_kex_tls_prf(conn->secure.cipher_suite->key_exchange_alg, conn, shared_key));
+    POSIX_GUARD_RESULT(s2n_kex_tls_prf(conn->secure.cipher_suite->key_exchange_alg, conn, shared_key));
     /* Erase the pre-master secret */
-    GUARD(s2n_blob_zero(shared_key));
+    POSIX_GUARD(s2n_blob_zero(shared_key));
     if (shared_key->allocated) {
-        GUARD(s2n_free(shared_key));
+        POSIX_GUARD(s2n_free(shared_key));
     }
     /* Expand the keys */
-    GUARD(s2n_prf_key_expansion(conn));
+    POSIX_GUARD(s2n_prf_key_expansion(conn));
     /* Save the master secret in the cache */
     if (s2n_allowed_to_cache_connection(conn)) {
-        GUARD(s2n_store_to_cache(conn));
+        POSIX_GUARD(s2n_store_to_cache(conn));
     }
     /* log the secret, if needed */
     s2n_result_ignore(s2n_key_log_tls12_secret(conn));
@@ -102,7 +102,7 @@ static int s2n_calculate_keys(struct s2n_connection *conn, struct s2n_blob *shar
 int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared_key)
 {
     /* Set shared_key before async guard to pass the proper shared_key to the caller upon async completion */
-    notnull_check(shared_key);
+    POSIX_ENSURE_REF(shared_key);
     shared_key->data = conn->secure.rsa_premaster_secret;
     shared_key->size = S2N_TLS_SECRET_LEN;
 
@@ -115,7 +115,7 @@ int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared
     if (conn->actual_protocol_version == S2N_SSLv3) {
         length = s2n_stuffer_data_available(in);
     } else {
-        GUARD(s2n_stuffer_read_uint16(in, &length));
+        POSIX_GUARD(s2n_stuffer_read_uint16(in, &length));
     }
 
     S2N_ERROR_IF(length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
@@ -130,11 +130,11 @@ int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared
 
     /* Decrypt the pre-master secret */
     struct s2n_blob encrypted = {.size = length, .data = s2n_stuffer_raw_read(in, length)};
-    notnull_check(encrypted.data);
-    gt_check(encrypted.size, 0);
+    POSIX_ENSURE_REF(encrypted.data);
+    POSIX_ENSURE_GT(encrypted.size, 0);
 
     /* First: use a random pre-master secret */
-    GUARD_AS_POSIX(s2n_get_private_random_data(shared_key));
+    POSIX_GUARD_RESULT(s2n_get_private_random_data(shared_key));
     conn->secure.rsa_premaster_secret[0] = client_hello_protocol_version[0];
     conn->secure.rsa_premaster_secret[1] = client_hello_protocol_version[1];
 
@@ -148,7 +148,7 @@ int s2n_rsa_client_key_recv_complete(struct s2n_connection *conn, bool rsa_faile
     /* Avoid copying the same buffer for the case where async pkey is not used */
     if (conn->secure.rsa_premaster_secret != decrypted->data) {
         /* Copy (maybe) decrypted data into shared key */
-        memcpy_check(conn->secure.rsa_premaster_secret, decrypted->data, S2N_TLS_SECRET_LEN);
+        POSIX_CHECKED_MEMCPY(conn->secure.rsa_premaster_secret, decrypted->data, S2N_TLS_SECRET_LEN);
     }
 
     /* Get client hello protocol version for comparison with decrypted data */
@@ -171,9 +171,9 @@ int s2n_dhe_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared
     struct s2n_stuffer *in = &conn->handshake.io;
 
     /* Get the shared key */
-    GUARD(s2n_dh_compute_shared_secret_as_server(&conn->secure.server_dh_params, in, shared_key));
+    POSIX_GUARD(s2n_dh_compute_shared_secret_as_server(&conn->secure.server_dh_params, in, shared_key));
     /* We don't need the server params any more */
-    GUARD(s2n_dh_params_free(&conn->secure.server_dh_params));
+    POSIX_GUARD(s2n_dh_params_free(&conn->secure.server_dh_params));
     return 0;
 }
 
@@ -182,9 +182,9 @@ int s2n_ecdhe_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shar
     struct s2n_stuffer *in = &conn->handshake.io;
 
     /* Get the shared key */
-    GUARD(s2n_ecc_evp_compute_shared_secret_as_server(&conn->secure.server_ecc_evp_params, in, shared_key));
+    POSIX_GUARD(s2n_ecc_evp_compute_shared_secret_as_server(&conn->secure.server_ecc_evp_params, in, shared_key));
     /* We don't need the server params any more */
-    GUARD(s2n_ecc_evp_params_free(&conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_ecc_evp_params_free(&conn->secure.server_ecc_evp_params));
     return 0;
 }
 
@@ -200,10 +200,10 @@ int s2n_kem_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared
      *
      * So, we assert that the caller already has *shared_key pointing
      * to kem_params.shared_secret. */
-    notnull_check(shared_key);
+    POSIX_ENSURE_REF(shared_key);
     S2N_ERROR_IF(shared_key != &(conn->secure.kem_params.shared_secret), S2N_ERR_SAFETY);
 
-    GUARD(s2n_kem_recv_ciphertext(&(conn->handshake.io), &(conn->secure.kem_params)));
+    POSIX_GUARD(s2n_kem_recv_ciphertext(&(conn->handshake.io), &(conn->secure.kem_params)));
 
     return 0;
 }
@@ -219,29 +219,29 @@ int s2n_client_key_recv(struct s2n_connection *conn)
     const struct s2n_kex *key_exchange = conn->secure.cipher_suite->key_exchange_alg;
     struct s2n_blob shared_key = {0};
 
-    GUARD_AS_POSIX(s2n_kex_client_key_recv(key_exchange, conn, &shared_key));
+    POSIX_GUARD_RESULT(s2n_kex_client_key_recv(key_exchange, conn, &shared_key));
 
-    GUARD(s2n_calculate_keys(conn, &shared_key));
+    POSIX_GUARD(s2n_calculate_keys(conn, &shared_key));
     return 0;
 }
 
 int s2n_dhe_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared_key)
 {
     struct s2n_stuffer *out = &conn->handshake.io;
-    GUARD(s2n_dh_compute_shared_secret_as_client(&conn->secure.server_dh_params, out, shared_key));
+    POSIX_GUARD(s2n_dh_compute_shared_secret_as_client(&conn->secure.server_dh_params, out, shared_key));
 
     /* We don't need the server params any more */
-    GUARD(s2n_dh_params_free(&conn->secure.server_dh_params));
+    POSIX_GUARD(s2n_dh_params_free(&conn->secure.server_dh_params));
     return 0;
 }
 
 int s2n_ecdhe_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared_key)
 {
     struct s2n_stuffer *out = &conn->handshake.io;
-    GUARD(s2n_ecc_evp_compute_shared_secret_as_client(&conn->secure.server_ecc_evp_params, out, shared_key));
+    POSIX_GUARD(s2n_ecc_evp_compute_shared_secret_as_client(&conn->secure.server_ecc_evp_params, out, shared_key));
 
     /* We don't need the server params any more */
-    GUARD(s2n_ecc_evp_params_free(&conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_ecc_evp_params_free(&conn->secure.server_ecc_evp_params));
     return 0;
 }
 
@@ -255,32 +255,32 @@ int s2n_rsa_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared
     shared_key->data = conn->secure.rsa_premaster_secret;
     shared_key->size = S2N_TLS_SECRET_LEN;
 
-    GUARD_AS_POSIX(s2n_get_private_random_data(shared_key));
+    POSIX_GUARD_RESULT(s2n_get_private_random_data(shared_key));
 
     /* Over-write the first two bytes with the client hello version, per RFC2246/RFC4346/RFC5246 7.4.7.1.
      * The latest version supported by client (as seen from the the client hello version) are <= TLS1.2
      * for all clients, because TLS 1.3 clients freezes the TLS1.2 legacy version in client hello.
      */
-    memcpy_check(conn->secure.rsa_premaster_secret, client_hello_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN);
+    POSIX_CHECKED_MEMCPY(conn->secure.rsa_premaster_secret, client_hello_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN);
 
     uint32_t encrypted_size = 0;
-    GUARD_AS_POSIX(s2n_pkey_size(&conn->secure.server_public_key, &encrypted_size));
+    POSIX_GUARD_RESULT(s2n_pkey_size(&conn->secure.server_public_key, &encrypted_size));
     S2N_ERROR_IF(encrypted_size > 0xffff, S2N_ERR_SIZE_MISMATCH);
 
     if (conn->actual_protocol_version > S2N_SSLv3) {
-        GUARD(s2n_stuffer_write_uint16(&conn->handshake.io, encrypted_size));
+        POSIX_GUARD(s2n_stuffer_write_uint16(&conn->handshake.io, encrypted_size));
     }
 
     struct s2n_blob encrypted = {0};
     encrypted.data = s2n_stuffer_raw_write(&conn->handshake.io, encrypted_size);
     encrypted.size = encrypted_size;
-    notnull_check(encrypted.data);
+    POSIX_ENSURE_REF(encrypted.data);
 
     /* Encrypt the secret and send it on */
-    GUARD(s2n_pkey_encrypt(&conn->secure.server_public_key, shared_key, &encrypted));
+    POSIX_GUARD(s2n_pkey_encrypt(&conn->secure.server_public_key, shared_key, &encrypted));
 
     /* We don't need the key any more, so free it */
-    GUARD(s2n_pkey_free(&conn->secure.server_public_key));
+    POSIX_GUARD(s2n_pkey_free(&conn->secure.server_public_key));
     return 0;
 }
 
@@ -296,10 +296,10 @@ int s2n_kem_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared
      *
      * So, we assert that the caller already has *shared_key pointing
      * to kem_params.shared_secret. */
-    notnull_check(shared_key);
+    POSIX_ENSURE_REF(shared_key);
     S2N_ERROR_IF(shared_key != &(conn->secure.kem_params.shared_secret), S2N_ERR_SAFETY);
 
-    GUARD(s2n_kem_send_ciphertext(&(conn->handshake.io), &(conn->secure.kem_params)));
+    POSIX_GUARD(s2n_kem_send_ciphertext(&(conn->handshake.io), &(conn->secure.kem_params)));
 
     return 0;
 }
@@ -315,8 +315,8 @@ int s2n_client_key_send(struct s2n_connection *conn)
     const struct s2n_kex *key_exchange = conn->secure.cipher_suite->key_exchange_alg;
     struct s2n_blob shared_key = {0};
 
-    GUARD_AS_POSIX(s2n_kex_client_key_send(key_exchange, conn, &shared_key));
+    POSIX_GUARD_RESULT(s2n_kex_client_key_send(key_exchange, conn, &shared_key));
 
-    GUARD(s2n_calculate_keys(conn, &shared_key));
+    POSIX_GUARD(s2n_calculate_keys(conn, &shared_key));
     return 0;
 }

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -41,7 +41,7 @@ static int monotonic_clock(void *data, uint64_t *nanoseconds)
 {
     struct timespec current_time = {0};
 
-    GUARD(clock_gettime(S2N_CLOCK_HW, &current_time));
+    POSIX_GUARD(clock_gettime(S2N_CLOCK_HW, &current_time));
 
     *nanoseconds = (uint64_t)current_time.tv_sec * 1000000000ull;
     *nanoseconds += current_time.tv_nsec;
@@ -53,7 +53,7 @@ static int wall_clock(void *data, uint64_t *nanoseconds)
 {
     struct timespec current_time = {0};
 
-    GUARD(clock_gettime(S2N_CLOCK_SYS, &current_time));
+    POSIX_GUARD(clock_gettime(S2N_CLOCK_SYS, &current_time));
 
     *nanoseconds = (uint64_t)current_time.tv_sec * 1000000000ull;
     *nanoseconds += current_time.tv_nsec;
@@ -67,19 +67,19 @@ static struct s2n_config s2n_default_tls13_config = {0};
 
 static int s2n_config_setup_default(struct s2n_config *config)
 {
-    GUARD(s2n_config_set_cipher_preferences(config, "default"));
+    POSIX_GUARD(s2n_config_set_cipher_preferences(config, "default"));
     return S2N_SUCCESS;
 }
 
 static int s2n_config_setup_tls13(struct s2n_config *config)
 {
-    GUARD(s2n_config_set_cipher_preferences(config, "default_tls13"));
+    POSIX_GUARD(s2n_config_set_cipher_preferences(config, "default_tls13"));
     return S2N_SUCCESS;
 }
 
 static int s2n_config_setup_fips(struct s2n_config *config)
 {
-    GUARD(s2n_config_set_cipher_preferences(config, "default_fips"));
+    POSIX_GUARD(s2n_config_set_cipher_preferences(config, "default_fips"));
     return S2N_SUCCESS;
 }
 
@@ -100,18 +100,18 @@ static int s2n_config_init(struct s2n_config *config)
     config->client_cert_auth_type = S2N_CERT_AUTH_NONE;
     config->check_ocsp = 1;
 
-    GUARD(s2n_config_setup_default(config));
+    POSIX_GUARD(s2n_config_setup_default(config));
     if (s2n_use_default_tls13_config()) {
-        GUARD(s2n_config_setup_tls13(config));
+        POSIX_GUARD(s2n_config_setup_tls13(config));
     } else if (s2n_is_in_fips_mode()) {
-        GUARD(s2n_config_setup_fips(config));
+        POSIX_GUARD(s2n_config_setup_fips(config));
     }
 
-    GUARD_NONNULL(config->domain_name_to_cert_map = s2n_map_new_with_initial_capacity(1));
-    GUARD_AS_POSIX(s2n_map_complete(config->domain_name_to_cert_map));
+    POSIX_GUARD_PTR(config->domain_name_to_cert_map = s2n_map_new_with_initial_capacity(1));
+    POSIX_GUARD_RESULT(s2n_map_complete(config->domain_name_to_cert_map));
 
     s2n_x509_trust_store_init_empty(&config->trust_store);
-    GUARD(s2n_x509_trust_store_from_system_defaults(&config->trust_store));
+    POSIX_GUARD(s2n_x509_trust_store_from_system_defaults(&config->trust_store));
 
     return 0;
 }
@@ -121,11 +121,11 @@ static int s2n_config_cleanup(struct s2n_config *config)
     s2n_x509_trust_store_wipe(&config->trust_store);
     config->check_ocsp = 0;
 
-    GUARD(s2n_config_free_session_ticket_keys(config));
-    GUARD(s2n_config_free_cert_chain_and_key(config));
-    GUARD(s2n_config_free_dhparams(config));
-    GUARD(s2n_free(&config->application_protocols));
-    GUARD_AS_POSIX(s2n_map_free(config->domain_name_to_cert_map));
+    POSIX_GUARD(s2n_config_free_session_ticket_keys(config));
+    POSIX_GUARD(s2n_config_free_cert_chain_and_key(config));
+    POSIX_GUARD(s2n_config_free_dhparams(config));
+    POSIX_GUARD(s2n_free(&config->application_protocols));
+    POSIX_GUARD_RESULT(s2n_map_free(config->domain_name_to_cert_map));
 
     return 0;
 }
@@ -134,8 +134,8 @@ static int s2n_config_update_domain_name_to_cert_map(struct s2n_config *config,
                                                      struct s2n_blob *name,
                                                      struct s2n_cert_chain_and_key *cert_key_pair)
 {
-    notnull_check(config);
-    notnull_check(name);
+    POSIX_ENSURE_REF(config);
+    POSIX_ENSURE_REF(name);
 
     struct s2n_map *domain_name_to_cert_map = config->domain_name_to_cert_map;
     /* s2n_map does not allow zero-size key */
@@ -145,16 +145,16 @@ static int s2n_config_update_domain_name_to_cert_map(struct s2n_config *config,
     s2n_pkey_type cert_type = s2n_cert_chain_and_key_get_pkey_type(cert_key_pair);
     struct s2n_blob s2n_map_value = { 0 };
     bool key_found = false;
-    GUARD_AS_POSIX(s2n_map_lookup(domain_name_to_cert_map, name, &s2n_map_value, &key_found));
+    POSIX_GUARD_RESULT(s2n_map_lookup(domain_name_to_cert_map, name, &s2n_map_value, &key_found));
     if (!key_found) {
         struct certs_by_type value = {{ 0 }};
         value.certs[cert_type] = cert_key_pair;
         s2n_map_value.data = (uint8_t *) &value;
         s2n_map_value.size = sizeof(struct certs_by_type);
 
-        GUARD_AS_POSIX(s2n_map_unlock(domain_name_to_cert_map));
-        GUARD_AS_POSIX(s2n_map_add(domain_name_to_cert_map, name, &s2n_map_value));
-        GUARD_AS_POSIX(s2n_map_complete(domain_name_to_cert_map));
+        POSIX_GUARD_RESULT(s2n_map_unlock(domain_name_to_cert_map));
+        POSIX_GUARD_RESULT(s2n_map_add(domain_name_to_cert_map, name, &s2n_map_value));
+        POSIX_GUARD_RESULT(s2n_map_complete(domain_name_to_cert_map));
     } else {
         struct certs_by_type *value = (void *) s2n_map_value.data;;
         if (value->certs[cert_type] == NULL) {
@@ -183,21 +183,21 @@ static int s2n_config_build_domain_name_to_cert_map(struct s2n_config *config, s
 {
 
     uint32_t cn_len = 0;
-    GUARD_AS_POSIX(s2n_array_num_elements(cert_key_pair->cn_names, &cn_len));
+    POSIX_GUARD_RESULT(s2n_array_num_elements(cert_key_pair->cn_names, &cn_len));
     uint32_t san_len = 0;
-    GUARD_AS_POSIX(s2n_array_num_elements(cert_key_pair->san_names, &san_len));
+    POSIX_GUARD_RESULT(s2n_array_num_elements(cert_key_pair->san_names, &san_len));
 
     if (san_len == 0) {
         for (uint32_t i = 0; i < cn_len; i++) {
             struct s2n_blob *cn_name = NULL;
-            GUARD_AS_POSIX(s2n_array_get(cert_key_pair->cn_names, i, (void **)&cn_name));
-            GUARD(s2n_config_update_domain_name_to_cert_map(config, cn_name, cert_key_pair));
+            POSIX_GUARD_RESULT(s2n_array_get(cert_key_pair->cn_names, i, (void **)&cn_name));
+            POSIX_GUARD(s2n_config_update_domain_name_to_cert_map(config, cn_name, cert_key_pair));
         }
     } else {
         for (uint32_t i = 0; i < san_len; i++) {
             struct s2n_blob *san_name = NULL;
-            GUARD_AS_POSIX(s2n_array_get(cert_key_pair->san_names, i, (void **)&san_name));
-            GUARD(s2n_config_update_domain_name_to_cert_map(config, san_name, cert_key_pair));
+            POSIX_GUARD_RESULT(s2n_array_get(cert_key_pair->san_names, i, (void **)&san_name));
+            POSIX_GUARD(s2n_config_update_domain_name_to_cert_map(config, san_name, cert_key_pair));
         }
     }
 
@@ -228,16 +228,16 @@ int s2n_config_set_unsafe_for_testing(struct s2n_config *config)
 int s2n_config_defaults_init(void)
 {
     /* Set up default */
-    GUARD(s2n_config_init(&s2n_default_config));
-    GUARD(s2n_config_setup_default(&s2n_default_config));
+    POSIX_GUARD(s2n_config_init(&s2n_default_config));
+    POSIX_GUARD(s2n_config_setup_default(&s2n_default_config));
 
     /* Set up fips defaults */
-    GUARD(s2n_config_init(&s2n_default_fips_config));
-    GUARD(s2n_config_setup_fips(&s2n_default_fips_config));
+    POSIX_GUARD(s2n_config_init(&s2n_default_fips_config));
+    POSIX_GUARD(s2n_config_setup_fips(&s2n_default_fips_config));
 
     /* Set up TLS 1.3 defaults */
-    GUARD(s2n_config_init(&s2n_default_tls13_config));
-    GUARD(s2n_config_setup_tls13(&s2n_default_tls13_config));
+    POSIX_GUARD(s2n_config_init(&s2n_default_tls13_config));
+    POSIX_GUARD(s2n_config_setup_tls13(&s2n_default_tls13_config));
 
     return S2N_SUCCESS;
 }
@@ -254,8 +254,8 @@ struct s2n_config *s2n_config_new(void)
     struct s2n_blob allocator = {0};
     struct s2n_config *new_config;
 
-    GUARD_PTR(s2n_alloc(&allocator, sizeof(struct s2n_config)));
-    GUARD_PTR(s2n_blob_zero(&allocator));
+    PTR_GUARD_POSIX(s2n_alloc(&allocator, sizeof(struct s2n_config)));
+    PTR_GUARD_POSIX(s2n_blob_zero(&allocator));
 
     new_config = (struct s2n_config *)(void *)allocator.data;
     if (s2n_config_init(new_config) != S2N_SUCCESS) {
@@ -283,11 +283,11 @@ static int s2n_verify_unique_ticket_key_comparator(const void *a, const void *b)
 int s2n_config_init_session_ticket_keys(struct s2n_config *config)
 {
     if (config->ticket_keys == NULL) {
-      notnull_check(config->ticket_keys = s2n_set_new(sizeof(struct s2n_ticket_key), s2n_config_store_ticket_key_comparator));
+      POSIX_ENSURE_REF(config->ticket_keys = s2n_set_new(sizeof(struct s2n_ticket_key), s2n_config_store_ticket_key_comparator));
     }
 
     if (config->ticket_key_hashes == NULL) {
-      notnull_check(config->ticket_key_hashes = s2n_set_new(SHA_DIGEST_LENGTH, s2n_verify_unique_ticket_key_comparator));
+      POSIX_ENSURE_REF(config->ticket_key_hashes = s2n_set_new(SHA_DIGEST_LENGTH, s2n_verify_unique_ticket_key_comparator));
     }
 
     return 0;
@@ -296,11 +296,11 @@ int s2n_config_init_session_ticket_keys(struct s2n_config *config)
 int s2n_config_free_session_ticket_keys(struct s2n_config *config)
 {
     if (config->ticket_keys != NULL) {
-        GUARD_AS_POSIX(s2n_set_free_p(&config->ticket_keys));
+        POSIX_GUARD_RESULT(s2n_set_free_p(&config->ticket_keys));
     }
 
     if (config->ticket_key_hashes != NULL) {
-        GUARD_AS_POSIX(s2n_set_free_p(&config->ticket_key_hashes));
+        POSIX_GUARD_RESULT(s2n_set_free_p(&config->ticket_key_hashes));
     }
 
     return 0;
@@ -322,10 +322,10 @@ int s2n_config_free_cert_chain_and_key(struct s2n_config *config)
 int s2n_config_free_dhparams(struct s2n_config *config)
 {
     if (config->dhparams) {
-        GUARD(s2n_dh_params_free(config->dhparams));
+        POSIX_GUARD(s2n_dh_params_free(config->dhparams));
     }
 
-    GUARD(s2n_free_object((uint8_t **)&config->dhparams, sizeof(struct s2n_dh_params)));
+    POSIX_GUARD(s2n_free_object((uint8_t **)&config->dhparams, sizeof(struct s2n_dh_params)));
     return 0;
 }
 
@@ -333,28 +333,28 @@ int s2n_config_free(struct s2n_config *config)
 {
     s2n_config_cleanup(config);
 
-    GUARD(s2n_free_object((uint8_t **)&config, sizeof(struct s2n_config)));
+    POSIX_GUARD(s2n_free_object((uint8_t **)&config, sizeof(struct s2n_config)));
     return 0;
 }
 
 int s2n_config_get_client_auth_type(struct s2n_config *config, s2n_cert_auth_type *client_auth_type)
 {
-    notnull_check(config);
-    notnull_check(client_auth_type);
+    POSIX_ENSURE_REF(config);
+    POSIX_ENSURE_REF(client_auth_type);
     *client_auth_type = config->client_cert_auth_type;
     return 0;
 }
 
 int s2n_config_set_client_auth_type(struct s2n_config *config, s2n_cert_auth_type client_auth_type)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
     config->client_cert_auth_type = client_auth_type;
     return 0;
 }
 
 int s2n_config_set_ct_support_level(struct s2n_config *config, s2n_ct_support_level type)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
     config->ct_type = type;
 
     return 0;
@@ -362,7 +362,7 @@ int s2n_config_set_ct_support_level(struct s2n_config *config, s2n_ct_support_le
 
 int s2n_config_set_alert_behavior(struct s2n_config *config, s2n_alert_behavior alert_behavior)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
 
     switch (alert_behavior) {
         case S2N_ALERT_FAIL_ON_WARNINGS:
@@ -370,7 +370,7 @@ int s2n_config_set_alert_behavior(struct s2n_config *config, s2n_alert_behavior 
             config->alert_behavior = alert_behavior;
             break;
         default:
-            S2N_ERROR(S2N_ERR_INVALID_ARGUMENT);
+            POSIX_BAIL(S2N_ERR_INVALID_ARGUMENT);
     }
 
     return 0;
@@ -378,7 +378,7 @@ int s2n_config_set_alert_behavior(struct s2n_config *config, s2n_alert_behavior 
 
 int s2n_config_set_verify_host_callback(struct s2n_config *config, s2n_verify_host_fn verify_host_fn, void *data)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
     config->verify_host = verify_host_fn;
     config->data_for_verify_host = data;
     return 0;
@@ -386,7 +386,7 @@ int s2n_config_set_verify_host_callback(struct s2n_config *config, s2n_verify_ho
 
 int s2n_config_set_check_stapled_ocsp_response(struct s2n_config *config, uint8_t check_ocsp)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
     S2N_ERROR_IF(check_ocsp && !s2n_x509_ocsp_stapling_supported(), S2N_ERR_OCSP_NOT_SUPPORTED);
     config->check_ocsp = check_ocsp;
     return 0;
@@ -394,7 +394,7 @@ int s2n_config_set_check_stapled_ocsp_response(struct s2n_config *config, uint8_
 
 int s2n_config_disable_x509_verification(struct s2n_config *config)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
     s2n_x509_trust_store_wipe(&config->trust_store);
     config->disable_x509_validation = 1;
     return 0;
@@ -402,7 +402,7 @@ int s2n_config_disable_x509_verification(struct s2n_config *config)
 
 int s2n_config_set_max_cert_chain_depth(struct s2n_config *config, uint16_t max_depth)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
     S2N_ERROR_IF(max_depth == 0, S2N_ERR_INVALID_ARGUMENT);
 
     config->max_verify_cert_chain_depth = max_depth;
@@ -415,7 +415,7 @@ int s2n_config_set_status_request_type(struct s2n_config *config, s2n_status_req
 {
     S2N_ERROR_IF(type == S2N_STATUS_REQUEST_OCSP && !s2n_x509_ocsp_stapling_supported(), S2N_ERR_OCSP_NOT_SUPPORTED);
 
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
     config->status_request_type = type;
 
     return 0;
@@ -423,17 +423,17 @@ int s2n_config_set_status_request_type(struct s2n_config *config, s2n_status_req
 
 int s2n_config_add_pem_to_trust_store(struct s2n_config *config, const char *pem)
 {
-    notnull_check(config);
-    notnull_check(pem);
+    POSIX_ENSURE_REF(config);
+    POSIX_ENSURE_REF(pem);
 
-    GUARD(s2n_x509_trust_store_add_pem(&config->trust_store, pem));
+    POSIX_GUARD(s2n_x509_trust_store_add_pem(&config->trust_store, pem));
 
     return 0;
 }
 
 int s2n_config_set_verification_ca_location(struct s2n_config *config, const char *ca_pem_filename, const char *ca_dir)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
     int err_code = s2n_x509_trust_store_from_ca_file(&config->trust_store, ca_pem_filename, ca_dir);
 
     if (!err_code) {
@@ -447,9 +447,9 @@ int s2n_config_set_verification_ca_location(struct s2n_config *config, const cha
 int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cert_chain_pem, const char *private_key_pem)
 {
     struct s2n_cert_chain_and_key *chain_and_key;
-    notnull_check(chain_and_key = s2n_cert_chain_and_key_new());
-    GUARD(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
-    GUARD(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+    POSIX_ENSURE_REF(chain_and_key = s2n_cert_chain_and_key_new());
+    POSIX_GUARD(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
+    POSIX_GUARD(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
     config->cert_allocated = 1;
 
     return 0;
@@ -457,10 +457,10 @@ int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cer
 
 int s2n_config_add_cert_chain_and_key_to_store(struct s2n_config *config, struct s2n_cert_chain_and_key *cert_key_pair)
 {
-    notnull_check(config->domain_name_to_cert_map);
-    notnull_check(cert_key_pair);
+    POSIX_ENSURE_REF(config->domain_name_to_cert_map);
+    POSIX_ENSURE_REF(cert_key_pair);
 
-    GUARD(s2n_config_build_domain_name_to_cert_map(config, cert_key_pair));
+    POSIX_GUARD(s2n_config_build_domain_name_to_cert_map(config, cert_key_pair));
 
     if (!config->default_certs_are_explicit) {
         /* Attempt to auto set default based on ordering. ie: first RSA cert is the default, first ECDSA cert is the
@@ -476,7 +476,7 @@ int s2n_config_add_cert_chain_and_key_to_store(struct s2n_config *config, struct
 
 int s2n_config_set_async_pkey_callback(struct s2n_config *config, s2n_async_pkey_fn fn)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
 
     config->async_pkey_cb = fn;
 
@@ -485,7 +485,7 @@ int s2n_config_set_async_pkey_callback(struct s2n_config *config, s2n_async_pkey
 
 int s2n_config_clear_default_certificates(struct s2n_config *config)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
     for (int i = 0; i < S2N_CERT_TYPE_COUNT; i++) {
         config->default_certs_by_type.certs[i] = NULL;
     }
@@ -496,21 +496,21 @@ int s2n_config_set_cert_chain_and_key_defaults(struct s2n_config *config,
                                                struct s2n_cert_chain_and_key **cert_key_pairs,
                                                uint32_t num_cert_key_pairs)
 {
-    notnull_check(config);
-    notnull_check(cert_key_pairs);
+    POSIX_ENSURE_REF(config);
+    POSIX_ENSURE_REF(cert_key_pairs);
     S2N_ERROR_IF(num_cert_key_pairs < 1 || num_cert_key_pairs > S2N_CERT_TYPE_COUNT,
             S2N_ERR_NUM_DEFAULT_CERTIFICATES);
 
     /* Validate certs being set before clearing auto-chosen defaults or previously set defaults */
     struct certs_by_type new_defaults = {{ 0 }};
     for (int i = 0; i < num_cert_key_pairs; i++) {
-        notnull_check(cert_key_pairs[i]);
+        POSIX_ENSURE_REF(cert_key_pairs[i]);
         s2n_pkey_type cert_type = s2n_cert_chain_and_key_get_pkey_type(cert_key_pairs[i]);
         S2N_ERROR_IF(new_defaults.certs[cert_type] != NULL, S2N_ERR_MULTIPLE_DEFAULT_CERTIFICATES_PER_AUTH_TYPE);
         new_defaults.certs[cert_type] = cert_key_pairs[i];
     }
 
-    GUARD(s2n_config_clear_default_certificates(config));
+    POSIX_GUARD(s2n_config_clear_default_certificates(config));
     for (int i = 0; i < num_cert_key_pairs; i++) {
         s2n_pkey_type cert_type = s2n_cert_chain_and_key_get_pkey_type(cert_key_pairs[i]);
         config->default_certs_by_type.certs[cert_type] = cert_key_pairs[i];
@@ -528,7 +528,7 @@ int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem)
     struct s2n_blob mem = {0};
 
     /* Allocate the memory for the chain and key struct */
-    GUARD(s2n_alloc(&mem, sizeof(struct s2n_dh_params)));
+    POSIX_GUARD(s2n_alloc(&mem, sizeof(struct s2n_dh_params)));
     config->dhparams = (struct s2n_dh_params *)(void *)mem.data;
 
     if (s2n_stuffer_alloc_ro_from_string(&dhparams_in_stuffer, dhparams_pem) != S2N_SUCCESS) {
@@ -541,20 +541,20 @@ int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem)
     }
 
     /* Convert pem to asn1 and asn1 to the private key */
-    GUARD(s2n_stuffer_dhparams_from_pem(&dhparams_in_stuffer, &dhparams_out_stuffer));
+    POSIX_GUARD(s2n_stuffer_dhparams_from_pem(&dhparams_in_stuffer, &dhparams_out_stuffer));
 
     dhparams_blob.size = s2n_stuffer_data_available(&dhparams_out_stuffer);
     dhparams_blob.data = s2n_stuffer_raw_read(&dhparams_out_stuffer, dhparams_blob.size);
-    notnull_check(dhparams_blob.data);
+    POSIX_ENSURE_REF(dhparams_blob.data);
 
-    GUARD(s2n_pkcs3_to_dh_params(config->dhparams, &dhparams_blob));
+    POSIX_GUARD(s2n_pkcs3_to_dh_params(config->dhparams, &dhparams_blob));
 
     return 0;
 }
 
 extern int s2n_config_set_wall_clock(struct s2n_config *config, s2n_clock_time_nanoseconds clock_fn, void *ctx)
 {
-    notnull_check(clock_fn);
+    POSIX_ENSURE_REF(clock_fn);
 
     config->wall_clock = clock_fn;
     config->sys_clock_ctx = ctx;
@@ -564,7 +564,7 @@ extern int s2n_config_set_wall_clock(struct s2n_config *config, s2n_clock_time_n
 
 extern int s2n_config_set_monotonic_clock(struct s2n_config *config, s2n_clock_time_nanoseconds clock_fn, void *ctx)
 {
-    notnull_check(clock_fn);
+    POSIX_ENSURE_REF(clock_fn);
 
     config->monotonic_clock = clock_fn;
     config->monotonic_clock_ctx = ctx;
@@ -574,7 +574,7 @@ extern int s2n_config_set_monotonic_clock(struct s2n_config *config, s2n_clock_t
 
 int s2n_config_set_cache_store_callback(struct s2n_config *config, s2n_cache_store_callback cache_store_callback, void *data)
 {
-    notnull_check(cache_store_callback);
+    POSIX_ENSURE_REF(cache_store_callback);
 
     config->cache_store = cache_store_callback;
     config->cache_store_data = data;
@@ -584,7 +584,7 @@ int s2n_config_set_cache_store_callback(struct s2n_config *config, s2n_cache_sto
 
 int s2n_config_set_cache_retrieve_callback(struct s2n_config *config, s2n_cache_retrieve_callback cache_retrieve_callback, void *data)
 {
-    notnull_check(cache_retrieve_callback);
+    POSIX_ENSURE_REF(cache_retrieve_callback);
 
     config->cache_retrieve = cache_retrieve_callback;
     config->cache_retrieve_data = data;
@@ -594,7 +594,7 @@ int s2n_config_set_cache_retrieve_callback(struct s2n_config *config, s2n_cache_
 
 int s2n_config_set_cache_delete_callback(struct s2n_config *config, s2n_cache_delete_callback cache_delete_callback, void *data)
 {
-    notnull_check(cache_delete_callback);
+    POSIX_ENSURE_REF(cache_delete_callback);
 
     config->cache_delete = cache_delete_callback;
     config->cache_delete_data = data;
@@ -604,25 +604,25 @@ int s2n_config_set_cache_delete_callback(struct s2n_config *config, s2n_cache_de
 
 int s2n_config_set_extension_data(struct s2n_config *config, s2n_tls_extension_type type, const uint8_t *data, uint32_t length)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
 
     if (s2n_config_get_num_default_certs(config) == 0) {
-        S2N_ERROR(S2N_ERR_UPDATING_EXTENSION);
+        POSIX_BAIL(S2N_ERR_UPDATING_EXTENSION);
     }
     struct s2n_cert_chain_and_key *config_chain_and_key = s2n_config_get_single_default_cert(config);
-    notnull_check(config_chain_and_key);
+    POSIX_ENSURE_REF(config_chain_and_key);
 
     switch (type) {
         case S2N_EXTENSION_CERTIFICATE_TRANSPARENCY:
             {
-                GUARD(s2n_cert_chain_and_key_set_sct_list(config_chain_and_key, data, length));
+                POSIX_GUARD(s2n_cert_chain_and_key_set_sct_list(config_chain_and_key, data, length));
             } break;
         case S2N_EXTENSION_OCSP_STAPLING:
             {
-                GUARD(s2n_cert_chain_and_key_set_ocsp_data(config_chain_and_key, data, length));
+                POSIX_GUARD(s2n_cert_chain_and_key_set_ocsp_data(config_chain_and_key, data, length));
             } break;
         default:
-            S2N_ERROR(S2N_ERR_UNRECOGNIZED_EXTENSION);
+            POSIX_BAIL(S2N_ERR_UNRECOGNIZED_EXTENSION);
     }
 
     return 0;
@@ -638,7 +638,7 @@ int s2n_config_set_client_hello_cb(struct s2n_config *config, s2n_client_hello_f
 
 int s2n_config_send_max_fragment_length(struct s2n_config *config, s2n_max_frag_len mfl_code)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
 
     S2N_ERROR_IF(mfl_code > S2N_TLS_MAX_FRAG_LEN_4096, S2N_ERR_INVALID_MAX_FRAG_LEN);
 
@@ -649,7 +649,7 @@ int s2n_config_send_max_fragment_length(struct s2n_config *config, s2n_max_frag_
 
 int s2n_config_accept_max_fragment_length(struct s2n_config *config)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
 
     config->accept_mfl = 1;
 
@@ -659,7 +659,7 @@ int s2n_config_accept_max_fragment_length(struct s2n_config *config)
 int s2n_config_set_session_state_lifetime(struct s2n_config *config,
                                           uint64_t lifetime_in_secs)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
 
     config->session_state_lifetime_in_nanos = (lifetime_in_secs * ONE_SEC_IN_NANOS);
     return 0;
@@ -667,7 +667,7 @@ int s2n_config_set_session_state_lifetime(struct s2n_config *config,
 
 int s2n_config_set_session_tickets_onoff(struct s2n_config *config, uint8_t enabled)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
 
     if (config->use_tickets == enabled) {
         return 0;
@@ -677,9 +677,9 @@ int s2n_config_set_session_tickets_onoff(struct s2n_config *config, uint8_t enab
 
     /* session ticket || session id is enabled */
     if (enabled) {
-        GUARD(s2n_config_init_session_ticket_keys(config));
+        POSIX_GUARD(s2n_config_init_session_ticket_keys(config));
     } else if (!config->use_session_cache) {
-        GUARD(s2n_config_free_session_ticket_keys(config));
+        POSIX_GUARD(s2n_config_free_session_ticket_keys(config));
     }
 
     return 0;
@@ -687,14 +687,14 @@ int s2n_config_set_session_tickets_onoff(struct s2n_config *config, uint8_t enab
 
 int s2n_config_set_session_cache_onoff(struct s2n_config *config, uint8_t enabled)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
     if (enabled && config->cache_store && config->cache_retrieve && config->cache_delete) {
-        GUARD(s2n_config_init_session_ticket_keys(config));
+        POSIX_GUARD(s2n_config_init_session_ticket_keys(config));
         config->use_session_cache = 1;
     }
     else {
         if (!config->use_tickets) {
-            GUARD(s2n_config_free_session_ticket_keys(config));
+            POSIX_GUARD(s2n_config_free_session_ticket_keys(config));
         }
         config->use_session_cache = 0;
     }
@@ -704,7 +704,7 @@ int s2n_config_set_session_cache_onoff(struct s2n_config *config, uint8_t enable
 int s2n_config_set_ticket_encrypt_decrypt_key_lifetime(struct s2n_config *config,
                                                        uint64_t lifetime_in_secs)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
 
     config->encrypt_decrypt_key_lifetime_in_nanos = (lifetime_in_secs * ONE_SEC_IN_NANOS);
     return 0;
@@ -713,7 +713,7 @@ int s2n_config_set_ticket_encrypt_decrypt_key_lifetime(struct s2n_config *config
 int s2n_config_set_ticket_decrypt_key_lifetime(struct s2n_config *config,
                                                uint64_t lifetime_in_secs)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
 
     config->decrypt_key_lifetime_in_nanos = (lifetime_in_secs * ONE_SEC_IN_NANOS);
     return 0;
@@ -724,21 +724,21 @@ int s2n_config_add_ticket_crypto_key(struct s2n_config *config,
                                      uint8_t *key, uint32_t key_len,
                                      uint64_t intro_time_in_seconds_from_epoch)
 {
-    notnull_check(config);
-    notnull_check(name);
-    notnull_check(key);
+    POSIX_ENSURE_REF(config);
+    POSIX_ENSURE_REF(name);
+    POSIX_ENSURE_REF(key);
 
     /* both session ticket and session cache encryption/decryption can use the same key mechanism */
     if (!config->use_tickets && !config->use_session_cache) {
         return 0;
     }
 
-    GUARD(s2n_config_wipe_expired_ticket_crypto_keys(config, -1));
+    POSIX_GUARD(s2n_config_wipe_expired_ticket_crypto_keys(config, -1));
 
     S2N_ERROR_IF(key_len == 0, S2N_ERR_INVALID_TICKET_KEY_LENGTH);
 
     uint32_t ticket_keys_len = 0;
-    GUARD_AS_POSIX(s2n_set_len(config->ticket_keys, &ticket_keys_len));
+    POSIX_GUARD_RESULT(s2n_set_len(config->ticket_keys, &ticket_keys_len));
     S2N_ERROR_IF(ticket_keys_len >= S2N_MAX_TICKET_KEYS, S2N_ERR_TICKET_KEY_LIMIT);
 
     S2N_ERROR_IF(name_len == 0 || name_len > S2N_TICKET_KEY_NAME_LEN || s2n_find_ticket_key(config, name), S2N_ERR_INVALID_TICKET_KEY_NAME_OR_NAME_LENGTH);
@@ -751,45 +751,45 @@ int s2n_config_add_ticket_crypto_key(struct s2n_config *config,
 
     struct s2n_ticket_key *session_ticket_key;
     DEFER_CLEANUP(struct s2n_blob allocator = {0}, s2n_free);
-    GUARD(s2n_alloc(&allocator, sizeof(struct s2n_ticket_key)));
+    POSIX_GUARD(s2n_alloc(&allocator, sizeof(struct s2n_ticket_key)));
     session_ticket_key = (struct s2n_ticket_key *) (void *) allocator.data;
 
     DEFER_CLEANUP(struct s2n_hmac_state hmac = {0}, s2n_hmac_free);
 
-    GUARD(s2n_hmac_new(&hmac));
-    GUARD(s2n_hkdf(&hmac, S2N_HMAC_SHA256, &salt, &in_key, &info, &out_key));
+    POSIX_GUARD(s2n_hmac_new(&hmac));
+    POSIX_GUARD(s2n_hkdf(&hmac, S2N_HMAC_SHA256, &salt, &in_key, &info, &out_key));
 
     DEFER_CLEANUP(struct s2n_hash_state hash = {0}, s2n_hash_free);
     uint8_t hash_output[SHA_DIGEST_LENGTH];
 
-    GUARD(s2n_hash_new(&hash));
-    GUARD(s2n_hash_init(&hash, S2N_HASH_SHA1));
-    GUARD(s2n_hash_update(&hash, out_key.data, out_key.size));
-    GUARD(s2n_hash_digest(&hash, hash_output, SHA_DIGEST_LENGTH));
+    POSIX_GUARD(s2n_hash_new(&hash));
+    POSIX_GUARD(s2n_hash_init(&hash, S2N_HASH_SHA1));
+    POSIX_GUARD(s2n_hash_update(&hash, out_key.data, out_key.size));
+    POSIX_GUARD(s2n_hash_digest(&hash, hash_output, SHA_DIGEST_LENGTH));
 
-    GUARD_AS_POSIX(s2n_set_len(config->ticket_keys, &ticket_keys_len));
+    POSIX_GUARD_RESULT(s2n_set_len(config->ticket_keys, &ticket_keys_len));
     if (ticket_keys_len >= S2N_MAX_TICKET_KEY_HASHES) {
-        GUARD_AS_POSIX(s2n_set_free_p(&config->ticket_key_hashes));
-        notnull_check(config->ticket_key_hashes = s2n_set_new(SHA_DIGEST_LENGTH, s2n_verify_unique_ticket_key_comparator));
+        POSIX_GUARD_RESULT(s2n_set_free_p(&config->ticket_key_hashes));
+        POSIX_ENSURE_REF(config->ticket_key_hashes = s2n_set_new(SHA_DIGEST_LENGTH, s2n_verify_unique_ticket_key_comparator));
     }
 
     /* Insert hash key into a sorted array at known index */
-    GUARD_AS_POSIX(s2n_set_add(config->ticket_key_hashes, hash_output));
+    POSIX_GUARD_RESULT(s2n_set_add(config->ticket_key_hashes, hash_output));
 
-    memcpy_check(session_ticket_key->key_name, name, S2N_TICKET_KEY_NAME_LEN);
-    memcpy_check(session_ticket_key->aes_key, out_key.data, S2N_AES256_KEY_LEN);
+    POSIX_CHECKED_MEMCPY(session_ticket_key->key_name, name, S2N_TICKET_KEY_NAME_LEN);
+    POSIX_CHECKED_MEMCPY(session_ticket_key->aes_key, out_key.data, S2N_AES256_KEY_LEN);
     out_key.data = output_pad + S2N_AES256_KEY_LEN;
-    memcpy_check(session_ticket_key->implicit_aad, out_key.data, S2N_TICKET_AAD_IMPLICIT_LEN);
+    POSIX_CHECKED_MEMCPY(session_ticket_key->implicit_aad, out_key.data, S2N_TICKET_AAD_IMPLICIT_LEN);
 
     if (intro_time_in_seconds_from_epoch == 0) {
         uint64_t now;
-        GUARD(config->wall_clock(config->sys_clock_ctx, &now));
+        POSIX_GUARD(config->wall_clock(config->sys_clock_ctx, &now));
         session_ticket_key->intro_timestamp = now;
     } else {
         session_ticket_key->intro_timestamp = (intro_time_in_seconds_from_epoch * ONE_SEC_IN_NANOS);
     }
 
-    GUARD(s2n_config_store_ticket_key(config, session_ticket_key));
+    POSIX_GUARD(s2n_config_store_ticket_key(config, session_ticket_key));
 
     return 0;
 }
@@ -802,7 +802,7 @@ int s2n_config_set_cert_tiebreak_callback(struct s2n_config *config, s2n_cert_ti
 
 struct s2n_cert_chain_and_key *s2n_config_get_single_default_cert(struct s2n_config *config)
 {
-    notnull_check_ptr(config);
+    PTR_ENSURE_REF(config);
     struct s2n_cert_chain_and_key *cert = NULL;
 
     for (int i = S2N_CERT_TYPE_COUNT - 1; i >= 0; i--) {
@@ -815,7 +815,7 @@ struct s2n_cert_chain_and_key *s2n_config_get_single_default_cert(struct s2n_con
 
 int s2n_config_get_num_default_certs(struct s2n_config *config)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
     int num_certs = 0;
     for (int i = 0; i < S2N_CERT_TYPE_COUNT; i++) {
         if (config->default_certs_by_type.certs[i] != NULL) {
@@ -828,21 +828,21 @@ int s2n_config_get_num_default_certs(struct s2n_config *config)
 
 int s2n_config_enable_cert_req_dss_legacy_compat(struct s2n_config *config)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
     config->cert_req_dss_legacy_compat_enabled = 1;
     return S2N_SUCCESS;
 }
 
 int s2n_config_set_psk_selection_callback(struct s2n_config *config, s2n_psk_selection_callback cb)
 {
-    notnull_check(config);
-    notnull_check(cb);
+    POSIX_ENSURE_REF(config);
+    POSIX_ENSURE_REF(cb);
     config->psk_selection_cb = cb;
     return S2N_SUCCESS;
 }
 
 int s2n_config_set_key_log_cb(struct s2n_config *config, s2n_key_log_fn callback, void *ctx) {
-    ENSURE_POSIX_MUT(config);
+    POSIX_ENSURE_MUT(config);
 
     config->key_log_cb = callback;
     config->key_log_ctx = ctx;

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -58,22 +58,22 @@
 static int s2n_connection_new_hashes(struct s2n_connection *conn)
 {
     /* Allocate long-term memory for the Connection's hash states */
-    GUARD(s2n_hash_new(&conn->handshake.md5));
-    GUARD(s2n_hash_new(&conn->handshake.sha1));
-    GUARD(s2n_hash_new(&conn->handshake.sha224));
-    GUARD(s2n_hash_new(&conn->handshake.sha256));
-    GUARD(s2n_hash_new(&conn->handshake.sha384));
-    GUARD(s2n_hash_new(&conn->handshake.sha512));
-    GUARD(s2n_hash_new(&conn->handshake.md5_sha1));
-    GUARD(s2n_hash_new(&conn->handshake.ccv_hash_copy));
-    GUARD(s2n_hash_new(&conn->handshake.prf_md5_hash_copy));
-    GUARD(s2n_hash_new(&conn->handshake.prf_sha1_hash_copy));
-    GUARD(s2n_hash_new(&conn->handshake.prf_tls12_hash_copy));
-    GUARD(s2n_hash_new(&conn->handshake.server_finished_copy));
-    GUARD(s2n_hash_new(&conn->prf_space.ssl3.md5));
-    GUARD(s2n_hash_new(&conn->prf_space.ssl3.sha1));
-    GUARD(s2n_hash_new(&conn->initial.signature_hash));
-    GUARD(s2n_hash_new(&conn->secure.signature_hash));
+    POSIX_GUARD(s2n_hash_new(&conn->handshake.md5));
+    POSIX_GUARD(s2n_hash_new(&conn->handshake.sha1));
+    POSIX_GUARD(s2n_hash_new(&conn->handshake.sha224));
+    POSIX_GUARD(s2n_hash_new(&conn->handshake.sha256));
+    POSIX_GUARD(s2n_hash_new(&conn->handshake.sha384));
+    POSIX_GUARD(s2n_hash_new(&conn->handshake.sha512));
+    POSIX_GUARD(s2n_hash_new(&conn->handshake.md5_sha1));
+    POSIX_GUARD(s2n_hash_new(&conn->handshake.ccv_hash_copy));
+    POSIX_GUARD(s2n_hash_new(&conn->handshake.prf_md5_hash_copy));
+    POSIX_GUARD(s2n_hash_new(&conn->handshake.prf_sha1_hash_copy));
+    POSIX_GUARD(s2n_hash_new(&conn->handshake.prf_tls12_hash_copy));
+    POSIX_GUARD(s2n_hash_new(&conn->handshake.server_finished_copy));
+    POSIX_GUARD(s2n_hash_new(&conn->prf_space.ssl3.md5));
+    POSIX_GUARD(s2n_hash_new(&conn->prf_space.ssl3.sha1));
+    POSIX_GUARD(s2n_hash_new(&conn->initial.signature_hash));
+    POSIX_GUARD(s2n_hash_new(&conn->secure.signature_hash));
 
     return 0;
 }
@@ -84,7 +84,7 @@ static int s2n_connection_init_hashes(struct s2n_connection *conn)
 
     if (s2n_hash_is_available(S2N_HASH_MD5)) {
         /* Only initialize hashes that use MD5 if available. */
-        GUARD(s2n_hash_init(&conn->prf_space.ssl3.md5, S2N_HASH_MD5));
+        POSIX_GUARD(s2n_hash_init(&conn->prf_space.ssl3.md5, S2N_HASH_MD5));
     }
 
 
@@ -93,32 +93,32 @@ static int s2n_connection_init_hashes(struct s2n_connection *conn)
      * NIST Special Publication 800-52 Revision 1.
      */
     if (s2n_is_in_fips_mode()) {
-        GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.md5));
-        GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.prf_md5_hash_copy));
+        POSIX_GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.md5));
+        POSIX_GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.prf_md5_hash_copy));
 
         /* Do not check s2n_hash_is_available before initialization. Allow MD5 and
          * SHA-1 for both fips and non-fips mode. This is required to perform the
          * signature checks in the CertificateVerify message in TLS 1.0 and TLS 1.1.
          * This is approved per Nist SP 800-52r1.*/
-        GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.md5_sha1));
+        POSIX_GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.md5_sha1));
     }
 
-    GUARD(s2n_hash_init(&conn->handshake.md5, S2N_HASH_MD5));
-    GUARD(s2n_hash_init(&conn->handshake.prf_md5_hash_copy, S2N_HASH_MD5));
-    GUARD(s2n_hash_init(&conn->handshake.md5_sha1, S2N_HASH_MD5_SHA1));
+    POSIX_GUARD(s2n_hash_init(&conn->handshake.md5, S2N_HASH_MD5));
+    POSIX_GUARD(s2n_hash_init(&conn->handshake.prf_md5_hash_copy, S2N_HASH_MD5));
+    POSIX_GUARD(s2n_hash_init(&conn->handshake.md5_sha1, S2N_HASH_MD5_SHA1));
 
-    GUARD(s2n_hash_init(&conn->handshake.sha1, S2N_HASH_SHA1));
-    GUARD(s2n_hash_init(&conn->handshake.sha224, S2N_HASH_SHA224));
-    GUARD(s2n_hash_init(&conn->handshake.sha256, S2N_HASH_SHA256));
-    GUARD(s2n_hash_init(&conn->handshake.sha384, S2N_HASH_SHA384));
-    GUARD(s2n_hash_init(&conn->handshake.sha512, S2N_HASH_SHA512));
-    GUARD(s2n_hash_init(&conn->handshake.ccv_hash_copy, S2N_HASH_NONE));
-    GUARD(s2n_hash_init(&conn->handshake.prf_tls12_hash_copy, S2N_HASH_NONE));
-    GUARD(s2n_hash_init(&conn->handshake.server_finished_copy, S2N_HASH_NONE));
-    GUARD(s2n_hash_init(&conn->handshake.prf_sha1_hash_copy, S2N_HASH_SHA1));
-    GUARD(s2n_hash_init(&conn->prf_space.ssl3.sha1, S2N_HASH_SHA1));
-    GUARD(s2n_hash_init(&conn->initial.signature_hash, S2N_HASH_NONE));
-    GUARD(s2n_hash_init(&conn->secure.signature_hash, S2N_HASH_NONE));
+    POSIX_GUARD(s2n_hash_init(&conn->handshake.sha1, S2N_HASH_SHA1));
+    POSIX_GUARD(s2n_hash_init(&conn->handshake.sha224, S2N_HASH_SHA224));
+    POSIX_GUARD(s2n_hash_init(&conn->handshake.sha256, S2N_HASH_SHA256));
+    POSIX_GUARD(s2n_hash_init(&conn->handshake.sha384, S2N_HASH_SHA384));
+    POSIX_GUARD(s2n_hash_init(&conn->handshake.sha512, S2N_HASH_SHA512));
+    POSIX_GUARD(s2n_hash_init(&conn->handshake.ccv_hash_copy, S2N_HASH_NONE));
+    POSIX_GUARD(s2n_hash_init(&conn->handshake.prf_tls12_hash_copy, S2N_HASH_NONE));
+    POSIX_GUARD(s2n_hash_init(&conn->handshake.server_finished_copy, S2N_HASH_NONE));
+    POSIX_GUARD(s2n_hash_init(&conn->handshake.prf_sha1_hash_copy, S2N_HASH_SHA1));
+    POSIX_GUARD(s2n_hash_init(&conn->prf_space.ssl3.sha1, S2N_HASH_SHA1));
+    POSIX_GUARD(s2n_hash_init(&conn->initial.signature_hash, S2N_HASH_NONE));
+    POSIX_GUARD(s2n_hash_init(&conn->secure.signature_hash, S2N_HASH_NONE));
 
     return 0;
 }
@@ -126,12 +126,12 @@ static int s2n_connection_init_hashes(struct s2n_connection *conn)
 static int s2n_connection_new_hmacs(struct s2n_connection *conn)
 {
     /* Allocate long-term memory for the Connection's HMAC states */
-    GUARD(s2n_hmac_new(&conn->initial.client_record_mac));
-    GUARD(s2n_hmac_new(&conn->initial.server_record_mac));
-    GUARD(s2n_hmac_new(&conn->initial.record_mac_copy_workspace));
-    GUARD(s2n_hmac_new(&conn->secure.client_record_mac));
-    GUARD(s2n_hmac_new(&conn->secure.server_record_mac));
-    GUARD(s2n_hmac_new(&conn->secure.record_mac_copy_workspace));
+    POSIX_GUARD(s2n_hmac_new(&conn->initial.client_record_mac));
+    POSIX_GUARD(s2n_hmac_new(&conn->initial.server_record_mac));
+    POSIX_GUARD(s2n_hmac_new(&conn->initial.record_mac_copy_workspace));
+    POSIX_GUARD(s2n_hmac_new(&conn->secure.client_record_mac));
+    POSIX_GUARD(s2n_hmac_new(&conn->secure.server_record_mac));
+    POSIX_GUARD(s2n_hmac_new(&conn->secure.record_mac_copy_workspace));
 
     return 0;
 }
@@ -139,12 +139,12 @@ static int s2n_connection_new_hmacs(struct s2n_connection *conn)
 static int s2n_connection_init_hmacs(struct s2n_connection *conn)
 {
     /* Initialize all of the Connection's HMAC states */
-    GUARD(s2n_hmac_init(&conn->initial.client_record_mac, S2N_HMAC_NONE, NULL, 0));
-    GUARD(s2n_hmac_init(&conn->initial.server_record_mac, S2N_HMAC_NONE, NULL, 0));
-    GUARD(s2n_hmac_init(&conn->initial.record_mac_copy_workspace, S2N_HMAC_NONE, NULL, 0));
-    GUARD(s2n_hmac_init(&conn->secure.client_record_mac, S2N_HMAC_NONE, NULL, 0));
-    GUARD(s2n_hmac_init(&conn->secure.server_record_mac, S2N_HMAC_NONE, NULL, 0));
-    GUARD(s2n_hmac_init(&conn->secure.record_mac_copy_workspace, S2N_HMAC_NONE, NULL, 0));
+    POSIX_GUARD(s2n_hmac_init(&conn->initial.client_record_mac, S2N_HMAC_NONE, NULL, 0));
+    POSIX_GUARD(s2n_hmac_init(&conn->initial.server_record_mac, S2N_HMAC_NONE, NULL, 0));
+    POSIX_GUARD(s2n_hmac_init(&conn->initial.record_mac_copy_workspace, S2N_HMAC_NONE, NULL, 0));
+    POSIX_GUARD(s2n_hmac_init(&conn->secure.client_record_mac, S2N_HMAC_NONE, NULL, 0));
+    POSIX_GUARD(s2n_hmac_init(&conn->secure.server_record_mac, S2N_HMAC_NONE, NULL, 0));
+    POSIX_GUARD(s2n_hmac_init(&conn->secure.record_mac_copy_workspace, S2N_HMAC_NONE, NULL, 0));
 
     return 0;
 }
@@ -152,15 +152,15 @@ static int s2n_connection_init_hmacs(struct s2n_connection *conn)
 struct s2n_connection *s2n_connection_new(s2n_mode mode)
 {
     struct s2n_blob blob = {0};
-    GUARD_PTR(s2n_alloc(&blob, sizeof(struct s2n_connection)));
-    GUARD_PTR(s2n_blob_zero(&blob));
+    PTR_GUARD_POSIX(s2n_alloc(&blob, sizeof(struct s2n_connection)));
+    PTR_GUARD_POSIX(s2n_blob_zero(&blob));
 
     /* Cast 'through' void to acknowledge that we are changing alignment,
      * which is ok, as blob.data is always aligned.
      */
     struct s2n_connection* conn = (struct s2n_connection *)(void *)blob.data;
 
-    GUARD_PTR(s2n_connection_set_config(conn, s2n_fetch_default_config()));
+    PTR_GUARD_POSIX(s2n_connection_set_config(conn, s2n_fetch_default_config()));
 
     conn->mode = mode;
     conn->blinding = S2N_BUILT_IN_BLINDING;
@@ -184,62 +184,62 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
 
     /* Allocate the fixed-size stuffers */
     blob = (struct s2n_blob) {0};
-    GUARD_PTR(s2n_blob_init(&blob, conn->alert_in_data, S2N_ALERT_LENGTH));
-    GUARD_PTR(s2n_stuffer_init(&conn->alert_in, &blob));
+    PTR_GUARD_POSIX(s2n_blob_init(&blob, conn->alert_in_data, S2N_ALERT_LENGTH));
+    PTR_GUARD_POSIX(s2n_stuffer_init(&conn->alert_in, &blob));
 
     blob = (struct s2n_blob) {0};
-    GUARD_PTR(s2n_blob_init(&blob, conn->reader_alert_out_data, S2N_ALERT_LENGTH));
-    GUARD_PTR(s2n_stuffer_init(&conn->reader_alert_out, &blob));
+    PTR_GUARD_POSIX(s2n_blob_init(&blob, conn->reader_alert_out_data, S2N_ALERT_LENGTH));
+    PTR_GUARD_POSIX(s2n_stuffer_init(&conn->reader_alert_out, &blob));
 
     blob = (struct s2n_blob) {0};
-    GUARD_PTR(s2n_blob_init(&blob, conn->writer_alert_out_data, S2N_ALERT_LENGTH));
-    GUARD_PTR(s2n_stuffer_init(&conn->writer_alert_out, &blob));
+    PTR_GUARD_POSIX(s2n_blob_init(&blob, conn->writer_alert_out_data, S2N_ALERT_LENGTH));
+    PTR_GUARD_POSIX(s2n_stuffer_init(&conn->writer_alert_out, &blob));
 
     blob = (struct s2n_blob) {0};
-    GUARD_PTR(s2n_blob_init(&blob, conn->ticket_ext_data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
-    GUARD_PTR(s2n_stuffer_init(&conn->client_ticket_to_decrypt, &blob));
+    PTR_GUARD_POSIX(s2n_blob_init(&blob, conn->ticket_ext_data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
+    PTR_GUARD_POSIX(s2n_stuffer_init(&conn->client_ticket_to_decrypt, &blob));
 
     /* Allocate long term key memory */
-    GUARD_PTR(s2n_session_key_alloc(&conn->secure.client_key));
-    GUARD_PTR(s2n_session_key_alloc(&conn->secure.server_key));
-    GUARD_PTR(s2n_session_key_alloc(&conn->initial.client_key));
-    GUARD_PTR(s2n_session_key_alloc(&conn->initial.server_key));
+    PTR_GUARD_POSIX(s2n_session_key_alloc(&conn->secure.client_key));
+    PTR_GUARD_POSIX(s2n_session_key_alloc(&conn->secure.server_key));
+    PTR_GUARD_POSIX(s2n_session_key_alloc(&conn->initial.client_key));
+    PTR_GUARD_POSIX(s2n_session_key_alloc(&conn->initial.server_key));
 
     /* Allocate long term hash and HMAC memory */
-    GUARD_PTR(s2n_prf_new(conn));
+    PTR_GUARD_POSIX(s2n_prf_new(conn));
 
-    GUARD_PTR(s2n_connection_new_hashes(conn));
-    GUARD_PTR(s2n_connection_init_hashes(conn));
+    PTR_GUARD_POSIX(s2n_connection_new_hashes(conn));
+    PTR_GUARD_POSIX(s2n_connection_init_hashes(conn));
 
-    GUARD_PTR(s2n_connection_new_hmacs(conn));
-    GUARD_PTR(s2n_connection_init_hmacs(conn));
+    PTR_GUARD_POSIX(s2n_connection_new_hmacs(conn));
+    PTR_GUARD_POSIX(s2n_connection_init_hmacs(conn));
 
     /* Initialize the growable stuffers. Zero length at first, but the resize
      * in _wipe will fix that
      */
     blob = (struct s2n_blob) {0};
-    GUARD_PTR(s2n_blob_init(&blob, conn->header_in_data, S2N_TLS_RECORD_HEADER_LENGTH));
-    GUARD_PTR(s2n_stuffer_init(&conn->header_in, &blob));
-    GUARD_PTR(s2n_stuffer_growable_alloc(&conn->out, 0));
-    GUARD_PTR(s2n_stuffer_growable_alloc(&conn->in, 0));
-    GUARD_PTR(s2n_stuffer_growable_alloc(&conn->handshake.io, 0));
-    GUARD_PTR(s2n_stuffer_growable_alloc(&conn->client_hello.raw_message, 0));
-    GUARD_PTR(s2n_connection_wipe(conn));
-    GUARD_RESULT_PTR(s2n_timer_start(conn->config, &conn->write_timer));
+    PTR_GUARD_POSIX(s2n_blob_init(&blob, conn->header_in_data, S2N_TLS_RECORD_HEADER_LENGTH));
+    PTR_GUARD_POSIX(s2n_stuffer_init(&conn->header_in, &blob));
+    PTR_GUARD_POSIX(s2n_stuffer_growable_alloc(&conn->out, 0));
+    PTR_GUARD_POSIX(s2n_stuffer_growable_alloc(&conn->in, 0));
+    PTR_GUARD_POSIX(s2n_stuffer_growable_alloc(&conn->handshake.io, 0));
+    PTR_GUARD_POSIX(s2n_stuffer_growable_alloc(&conn->client_hello.raw_message, 0));
+    PTR_GUARD_POSIX(s2n_connection_wipe(conn));
+    PTR_GUARD_RESULT(s2n_timer_start(conn->config, &conn->write_timer));
 
     /* Initialize the cookie stuffer with zero length. If a cookie extension
      * is received, the stuffer will be resized according to the cookie length */
-    GUARD_PTR(s2n_stuffer_growable_alloc(&conn->cookie_stuffer, 0));
+    PTR_GUARD_POSIX(s2n_stuffer_growable_alloc(&conn->cookie_stuffer, 0));
 
     return conn;
 }
 
 static int s2n_connection_free_keys(struct s2n_connection *conn)
 {
-    GUARD(s2n_session_key_free(&conn->secure.client_key));
-    GUARD(s2n_session_key_free(&conn->secure.server_key));
-    GUARD(s2n_session_key_free(&conn->initial.client_key));
-    GUARD(s2n_session_key_free(&conn->initial.server_key));
+    POSIX_GUARD(s2n_session_key_free(&conn->secure.client_key));
+    POSIX_GUARD(s2n_session_key_free(&conn->secure.server_key));
+    POSIX_GUARD(s2n_session_key_free(&conn->initial.client_key));
+    POSIX_GUARD(s2n_session_key_free(&conn->initial.server_key));
 
     return 0;
 }
@@ -247,7 +247,7 @@ static int s2n_connection_free_keys(struct s2n_connection *conn)
 static int s2n_connection_zero(struct s2n_connection *conn, int mode, struct s2n_config *config)
 {
     /* Zero the whole connection structure */
-    memset_check(conn, 0, sizeof(struct s2n_connection));
+    POSIX_CHECKED_MEMSET(conn, 0, sizeof(struct s2n_connection));
 
     conn->send = NULL;
     conn->recv = NULL;
@@ -284,29 +284,29 @@ static int s2n_connection_wipe_keys(struct s2n_connection *conn)
             && conn->secure.cipher_suite->record_alg
             && conn->secure.cipher_suite->record_alg->cipher
             && conn->secure.cipher_suite->record_alg->cipher->destroy_key) {
-        GUARD(conn->secure.cipher_suite->record_alg->cipher->destroy_key(&conn->secure.client_key));
-        GUARD(conn->secure.cipher_suite->record_alg->cipher->destroy_key(&conn->secure.server_key));
+        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->destroy_key(&conn->secure.client_key));
+        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->destroy_key(&conn->secure.server_key));
     }
 
     /* Free any server key received (we may not have completed a
      * handshake, so this may not have been free'd yet) */
-    GUARD(s2n_pkey_free(&conn->secure.server_public_key));
-    GUARD(s2n_pkey_zero_init(&conn->secure.server_public_key));
-    GUARD(s2n_pkey_free(&conn->secure.client_public_key));
-    GUARD(s2n_pkey_zero_init(&conn->secure.client_public_key));
+    POSIX_GUARD(s2n_pkey_free(&conn->secure.server_public_key));
+    POSIX_GUARD(s2n_pkey_zero_init(&conn->secure.server_public_key));
+    POSIX_GUARD(s2n_pkey_free(&conn->secure.client_public_key));
+    POSIX_GUARD(s2n_pkey_zero_init(&conn->secure.client_public_key));
     s2n_x509_validator_wipe(&conn->x509_validator);
-    GUARD(s2n_dh_params_free(&conn->secure.server_dh_params));
-    GUARD(s2n_ecc_evp_params_free(&conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_dh_params_free(&conn->secure.server_dh_params));
+    POSIX_GUARD(s2n_ecc_evp_params_free(&conn->secure.server_ecc_evp_params));
     for (int i=0; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
-        GUARD(s2n_ecc_evp_params_free(&conn->secure.client_ecc_evp_params[i]));
+        POSIX_GUARD(s2n_ecc_evp_params_free(&conn->secure.client_ecc_evp_params[i]));
     }
-    GUARD(s2n_kem_group_free(&conn->secure.server_kem_group_params));
+    POSIX_GUARD(s2n_kem_group_free(&conn->secure.server_kem_group_params));
     for (int i = 0; i < S2N_SUPPORTED_KEM_GROUPS_COUNT; i++) {
-        GUARD(s2n_kem_group_free(&conn->secure.client_kem_group_params[i]));
+        POSIX_GUARD(s2n_kem_group_free(&conn->secure.client_kem_group_params[i]));
     }
-    GUARD(s2n_kem_free(&conn->secure.kem_params));
-    GUARD(s2n_free(&conn->secure.client_cert_chain));
-    GUARD(s2n_free(&conn->ct_response));
+    POSIX_GUARD(s2n_kem_free(&conn->secure.kem_params));
+    POSIX_GUARD(s2n_free(&conn->secure.client_cert_chain));
+    POSIX_GUARD(s2n_free(&conn->ct_response));
 
     return 0;
 }
@@ -314,22 +314,22 @@ static int s2n_connection_wipe_keys(struct s2n_connection *conn)
 static int s2n_connection_reset_hashes(struct s2n_connection *conn)
 {
     /* Reset all of the Connection's hash states */
-    GUARD(s2n_hash_reset(&conn->handshake.md5));
-    GUARD(s2n_hash_reset(&conn->handshake.sha1));
-    GUARD(s2n_hash_reset(&conn->handshake.sha224));
-    GUARD(s2n_hash_reset(&conn->handshake.sha256));
-    GUARD(s2n_hash_reset(&conn->handshake.sha384));
-    GUARD(s2n_hash_reset(&conn->handshake.sha512));
-    GUARD(s2n_hash_reset(&conn->handshake.md5_sha1));
-    GUARD(s2n_hash_reset(&conn->handshake.ccv_hash_copy));
-    GUARD(s2n_hash_reset(&conn->handshake.prf_md5_hash_copy));
-    GUARD(s2n_hash_reset(&conn->handshake.prf_sha1_hash_copy));
-    GUARD(s2n_hash_reset(&conn->handshake.prf_tls12_hash_copy));
-    GUARD(s2n_hash_reset(&conn->handshake.server_finished_copy));
-    GUARD(s2n_hash_reset(&conn->prf_space.ssl3.md5));
-    GUARD(s2n_hash_reset(&conn->prf_space.ssl3.sha1));
-    GUARD(s2n_hash_reset(&conn->initial.signature_hash));
-    GUARD(s2n_hash_reset(&conn->secure.signature_hash));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.md5));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha1));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha224));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha256));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha384));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha512));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.md5_sha1));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.ccv_hash_copy));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.prf_md5_hash_copy));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.prf_sha1_hash_copy));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.prf_tls12_hash_copy));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.server_finished_copy));
+    POSIX_GUARD(s2n_hash_reset(&conn->prf_space.ssl3.md5));
+    POSIX_GUARD(s2n_hash_reset(&conn->prf_space.ssl3.sha1));
+    POSIX_GUARD(s2n_hash_reset(&conn->initial.signature_hash));
+    POSIX_GUARD(s2n_hash_reset(&conn->secure.signature_hash));
 
     return 0;
 }
@@ -337,12 +337,12 @@ static int s2n_connection_reset_hashes(struct s2n_connection *conn)
 static int s2n_connection_reset_hmacs(struct s2n_connection *conn)
 {
     /* Reset all of the Connection's HMAC states */
-    GUARD(s2n_hmac_reset(&conn->initial.client_record_mac));
-    GUARD(s2n_hmac_reset(&conn->initial.server_record_mac));
-    GUARD(s2n_hmac_reset(&conn->initial.record_mac_copy_workspace));
-    GUARD(s2n_hmac_reset(&conn->secure.client_record_mac));
-    GUARD(s2n_hmac_reset(&conn->secure.server_record_mac));
-    GUARD(s2n_hmac_reset(&conn->secure.record_mac_copy_workspace));
+    POSIX_GUARD(s2n_hmac_reset(&conn->initial.client_record_mac));
+    POSIX_GUARD(s2n_hmac_reset(&conn->initial.server_record_mac));
+    POSIX_GUARD(s2n_hmac_reset(&conn->initial.record_mac_copy_workspace));
+    POSIX_GUARD(s2n_hmac_reset(&conn->secure.client_record_mac));
+    POSIX_GUARD(s2n_hmac_reset(&conn->secure.server_record_mac));
+    POSIX_GUARD(s2n_hmac_reset(&conn->secure.record_mac_copy_workspace));
 
     return 0;
 }
@@ -354,8 +354,8 @@ static int s2n_connection_free_io_contexts(struct s2n_connection *conn)
         return 0;
     }
 
-    GUARD(s2n_free_object((uint8_t **)&conn->send_io_context, sizeof(struct s2n_socket_write_io_context)));
-    GUARD(s2n_free_object((uint8_t **)&conn->recv_io_context, sizeof(struct s2n_socket_read_io_context)));
+    POSIX_GUARD(s2n_free_object((uint8_t **)&conn->send_io_context, sizeof(struct s2n_socket_write_io_context)));
+    POSIX_GUARD(s2n_free_object((uint8_t **)&conn->recv_io_context, sizeof(struct s2n_socket_read_io_context)));
 
     return 0;
 }
@@ -363,14 +363,14 @@ static int s2n_connection_free_io_contexts(struct s2n_connection *conn)
 static int s2n_connection_wipe_io(struct s2n_connection *conn)
 {
     if (s2n_connection_is_managed_corked(conn) && conn->recv){
-        GUARD(s2n_socket_read_restore(conn));
+        POSIX_GUARD(s2n_socket_read_restore(conn));
     }
     if (s2n_connection_is_managed_corked(conn) && conn->send){
-        GUARD(s2n_socket_write_restore(conn));
+        POSIX_GUARD(s2n_socket_write_restore(conn));
     }
 
     /* Remove all I/O-related members */
-    GUARD(s2n_connection_free_io_contexts(conn));
+    POSIX_GUARD(s2n_connection_free_io_contexts(conn));
     conn->managed_io = 0;
     conn->send = NULL;
     conn->recv = NULL;
@@ -381,22 +381,22 @@ static int s2n_connection_wipe_io(struct s2n_connection *conn)
 static int s2n_connection_free_hashes(struct s2n_connection *conn)
 {
     /* Free all of the Connection's hash states */
-    GUARD(s2n_hash_free(&conn->handshake.md5));
-    GUARD(s2n_hash_free(&conn->handshake.sha1));
-    GUARD(s2n_hash_free(&conn->handshake.sha224));
-    GUARD(s2n_hash_free(&conn->handshake.sha256));
-    GUARD(s2n_hash_free(&conn->handshake.sha384));
-    GUARD(s2n_hash_free(&conn->handshake.sha512));
-    GUARD(s2n_hash_free(&conn->handshake.md5_sha1));
-    GUARD(s2n_hash_free(&conn->handshake.ccv_hash_copy));
-    GUARD(s2n_hash_free(&conn->handshake.prf_md5_hash_copy));
-    GUARD(s2n_hash_free(&conn->handshake.prf_sha1_hash_copy));
-    GUARD(s2n_hash_free(&conn->handshake.prf_tls12_hash_copy));
-    GUARD(s2n_hash_free(&conn->handshake.server_finished_copy));
-    GUARD(s2n_hash_free(&conn->prf_space.ssl3.md5));
-    GUARD(s2n_hash_free(&conn->prf_space.ssl3.sha1));
-    GUARD(s2n_hash_free(&conn->initial.signature_hash));
-    GUARD(s2n_hash_free(&conn->secure.signature_hash));
+    POSIX_GUARD(s2n_hash_free(&conn->handshake.md5));
+    POSIX_GUARD(s2n_hash_free(&conn->handshake.sha1));
+    POSIX_GUARD(s2n_hash_free(&conn->handshake.sha224));
+    POSIX_GUARD(s2n_hash_free(&conn->handshake.sha256));
+    POSIX_GUARD(s2n_hash_free(&conn->handshake.sha384));
+    POSIX_GUARD(s2n_hash_free(&conn->handshake.sha512));
+    POSIX_GUARD(s2n_hash_free(&conn->handshake.md5_sha1));
+    POSIX_GUARD(s2n_hash_free(&conn->handshake.ccv_hash_copy));
+    POSIX_GUARD(s2n_hash_free(&conn->handshake.prf_md5_hash_copy));
+    POSIX_GUARD(s2n_hash_free(&conn->handshake.prf_sha1_hash_copy));
+    POSIX_GUARD(s2n_hash_free(&conn->handshake.prf_tls12_hash_copy));
+    POSIX_GUARD(s2n_hash_free(&conn->handshake.server_finished_copy));
+    POSIX_GUARD(s2n_hash_free(&conn->prf_space.ssl3.md5));
+    POSIX_GUARD(s2n_hash_free(&conn->prf_space.ssl3.sha1));
+    POSIX_GUARD(s2n_hash_free(&conn->initial.signature_hash));
+    POSIX_GUARD(s2n_hash_free(&conn->secure.signature_hash));
 
     return 0;
 }
@@ -404,12 +404,12 @@ static int s2n_connection_free_hashes(struct s2n_connection *conn)
 static int s2n_connection_free_hmacs(struct s2n_connection *conn)
 {
     /* Free all of the Connection's HMAC states */
-    GUARD(s2n_hmac_free(&conn->initial.client_record_mac));
-    GUARD(s2n_hmac_free(&conn->initial.server_record_mac));
-    GUARD(s2n_hmac_free(&conn->initial.record_mac_copy_workspace));
-    GUARD(s2n_hmac_free(&conn->secure.client_record_mac));
-    GUARD(s2n_hmac_free(&conn->secure.server_record_mac));
-    GUARD(s2n_hmac_free(&conn->secure.record_mac_copy_workspace));
+    POSIX_GUARD(s2n_hmac_free(&conn->initial.client_record_mac));
+    POSIX_GUARD(s2n_hmac_free(&conn->initial.server_record_mac));
+    POSIX_GUARD(s2n_hmac_free(&conn->initial.record_mac_copy_workspace));
+    POSIX_GUARD(s2n_hmac_free(&conn->secure.client_record_mac));
+    POSIX_GUARD(s2n_hmac_free(&conn->secure.server_record_mac));
+    POSIX_GUARD(s2n_hmac_free(&conn->secure.record_mac_copy_workspace));
 
     return 0;
 }
@@ -450,40 +450,40 @@ static uint8_t s2n_default_verify_host(const char *host_name, size_t len, void *
 
 int s2n_connection_free(struct s2n_connection *conn)
 {
-    GUARD(s2n_connection_wipe_keys(conn));
-    GUARD(s2n_connection_free_keys(conn));
-    GUARD_AS_POSIX(s2n_psk_parameters_wipe(&conn->psk_params));
+    POSIX_GUARD(s2n_connection_wipe_keys(conn));
+    POSIX_GUARD(s2n_connection_free_keys(conn));
+    POSIX_GUARD_RESULT(s2n_psk_parameters_wipe(&conn->psk_params));
 
-    GUARD(s2n_prf_free(conn));
+    POSIX_GUARD(s2n_prf_free(conn));
 
-    GUARD(s2n_connection_reset_hashes(conn));
-    GUARD(s2n_connection_free_hashes(conn));
+    POSIX_GUARD(s2n_connection_reset_hashes(conn));
+    POSIX_GUARD(s2n_connection_free_hashes(conn));
 
-    GUARD(s2n_connection_reset_hmacs(conn));
-    GUARD(s2n_connection_free_hmacs(conn));
+    POSIX_GUARD(s2n_connection_reset_hmacs(conn));
+    POSIX_GUARD(s2n_connection_free_hmacs(conn));
 
-    GUARD(s2n_connection_free_io_contexts(conn));
+    POSIX_GUARD(s2n_connection_free_io_contexts(conn));
 
-    GUARD(s2n_free(&conn->client_ticket));
-    GUARD(s2n_free(&conn->status_response));
-    GUARD(s2n_free(&conn->our_quic_transport_parameters));
-    GUARD(s2n_free(&conn->peer_quic_transport_parameters));
-    GUARD(s2n_stuffer_free(&conn->in));
-    GUARD(s2n_stuffer_free(&conn->out));
-    GUARD(s2n_stuffer_free(&conn->handshake.io));
+    POSIX_GUARD(s2n_free(&conn->client_ticket));
+    POSIX_GUARD(s2n_free(&conn->status_response));
+    POSIX_GUARD(s2n_free(&conn->our_quic_transport_parameters));
+    POSIX_GUARD(s2n_free(&conn->peer_quic_transport_parameters));
+    POSIX_GUARD(s2n_stuffer_free(&conn->in));
+    POSIX_GUARD(s2n_stuffer_free(&conn->out));
+    POSIX_GUARD(s2n_stuffer_free(&conn->handshake.io));
     s2n_x509_validator_wipe(&conn->x509_validator);
-    GUARD(s2n_client_hello_free(&conn->client_hello));
-    GUARD(s2n_free(&conn->application_protocols_overridden));
-    GUARD(s2n_stuffer_free(&conn->cookie_stuffer));
-    GUARD(s2n_free_object((uint8_t **)&conn, sizeof(struct s2n_connection)));
+    POSIX_GUARD(s2n_client_hello_free(&conn->client_hello));
+    POSIX_GUARD(s2n_free(&conn->application_protocols_overridden));
+    POSIX_GUARD(s2n_stuffer_free(&conn->cookie_stuffer));
+    POSIX_GUARD(s2n_free_object((uint8_t **)&conn, sizeof(struct s2n_connection)));
 
     return 0;
 }
 
 int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *config)
 {
-    notnull_check(conn);
-    notnull_check(config);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(config);
 
     if (conn->config == config) {
         return 0;
@@ -491,7 +491,7 @@ int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *co
 
     /* We only support one client certificate */
     if (s2n_config_get_num_default_certs(config) > 1 && conn->mode == S2N_CLIENT) {
-        S2N_ERROR(S2N_ERR_TOO_MANY_CERTIFICATES);
+        POSIX_BAIL(S2N_ERR_TOO_MANY_CERTIFICATES);
     }
 
     s2n_x509_validator_wipe(&conn->x509_validator);
@@ -505,10 +505,10 @@ int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *co
     int8_t dont_need_x509_validation = (conn->mode == S2N_SERVER) && (auth_type == S2N_CERT_AUTH_NONE);
 
     if (config->disable_x509_validation || dont_need_x509_validation) {
-        GUARD(s2n_x509_validator_init_no_x509_validation(&conn->x509_validator));
+        POSIX_GUARD(s2n_x509_validator_init_no_x509_validation(&conn->x509_validator));
     }
     else {
-        GUARD(s2n_x509_validator_init(&conn->x509_validator, &config->trust_store, config->check_ocsp));
+        POSIX_GUARD(s2n_x509_validator_init(&conn->x509_validator, &config->trust_store, config->check_ocsp));
         if (!conn->verify_host_fn_overridden) {
             if (config->verify_host != NULL) {
                 conn->verify_host_fn = config->verify_host;
@@ -520,7 +520,7 @@ int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *co
         }
 
         if (config->max_verify_cert_chain_depth_set) {
-            GUARD(s2n_x509_validator_set_max_chain_depth(&conn->x509_validator, config->max_verify_cert_chain_depth));
+            POSIX_GUARD(s2n_x509_validator_set_max_chain_depth(&conn->x509_validator, config->max_verify_cert_chain_depth));
         }
     }
     conn->tickets_to_send = config->initial_tickets_to_send;
@@ -542,51 +542,51 @@ void *s2n_connection_get_ctx(struct s2n_connection *conn)
 
 int s2n_connection_release_buffers(struct s2n_connection *conn)
 {
-    notnull_check(conn);
-    PRECONDITION_POSIX(s2n_stuffer_validate(&conn->out));
-    PRECONDITION_POSIX(s2n_stuffer_validate(&conn->in));
+    POSIX_ENSURE_REF(conn);
+    POSIX_PRECONDITION(s2n_stuffer_validate(&conn->out));
+    POSIX_PRECONDITION(s2n_stuffer_validate(&conn->in));
 
-    ENSURE_POSIX(s2n_stuffer_is_consumed(&conn->out), S2N_ERR_STUFFER_HAS_UNPROCESSED_DATA);
-    GUARD(s2n_stuffer_resize(&conn->out, 0));
+    POSIX_ENSURE(s2n_stuffer_is_consumed(&conn->out), S2N_ERR_STUFFER_HAS_UNPROCESSED_DATA);
+    POSIX_GUARD(s2n_stuffer_resize(&conn->out, 0));
 
-    ENSURE_POSIX(s2n_stuffer_is_consumed(&conn->in), S2N_ERR_STUFFER_HAS_UNPROCESSED_DATA);
-    GUARD(s2n_stuffer_resize(&conn->in, 0));
+    POSIX_ENSURE(s2n_stuffer_is_consumed(&conn->in), S2N_ERR_STUFFER_HAS_UNPROCESSED_DATA);
+    POSIX_GUARD(s2n_stuffer_resize(&conn->in, 0));
 
-    POSTCONDITION_POSIX(s2n_stuffer_validate(&conn->out));
-    POSTCONDITION_POSIX(s2n_stuffer_validate(&conn->in));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(&conn->out));
+    POSIX_POSTCONDITION(s2n_stuffer_validate(&conn->in));
     return S2N_SUCCESS;
 }
 
 int s2n_connection_free_handshake(struct s2n_connection *conn)
 {
     /* We are done with the handshake */
-    GUARD(s2n_hash_reset(&conn->handshake.md5));
-    GUARD(s2n_hash_reset(&conn->handshake.sha1));
-    GUARD(s2n_hash_reset(&conn->handshake.sha224));
-    GUARD(s2n_hash_reset(&conn->handshake.sha256));
-    GUARD(s2n_hash_reset(&conn->handshake.sha384));
-    GUARD(s2n_hash_reset(&conn->handshake.sha512));
-    GUARD(s2n_hash_reset(&conn->handshake.md5_sha1));
-    GUARD(s2n_hash_reset(&conn->handshake.ccv_hash_copy));
-    GUARD(s2n_hash_reset(&conn->handshake.prf_md5_hash_copy));
-    GUARD(s2n_hash_reset(&conn->handshake.prf_sha1_hash_copy));
-    GUARD(s2n_hash_reset(&conn->handshake.prf_tls12_hash_copy));
-    GUARD(s2n_hash_reset(&conn->handshake.server_finished_copy));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.md5));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha1));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha224));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha256));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha384));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha512));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.md5_sha1));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.ccv_hash_copy));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.prf_md5_hash_copy));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.prf_sha1_hash_copy));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.prf_tls12_hash_copy));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.server_finished_copy));
 
     /* Wipe the buffers we are going to free */
-    GUARD(s2n_stuffer_wipe(&conn->handshake.io));
-    GUARD(s2n_stuffer_wipe(&conn->client_hello.raw_message));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->client_hello.raw_message));
 
     /* Truncate buffers to save memory, we are done with the handshake */
-    GUARD(s2n_stuffer_resize(&conn->handshake.io, 0));
-    GUARD(s2n_stuffer_resize(&conn->client_hello.raw_message, 0));
+    POSIX_GUARD(s2n_stuffer_resize(&conn->handshake.io, 0));
+    POSIX_GUARD(s2n_stuffer_resize(&conn->client_hello.raw_message, 0));
 
     /* We can free extension data we no longer need */
-    GUARD(s2n_free(&conn->client_ticket));
-    GUARD(s2n_free(&conn->status_response));
-    GUARD(s2n_free(&conn->our_quic_transport_parameters));
-    GUARD(s2n_free(&conn->application_protocols_overridden));
-    GUARD(s2n_stuffer_free(&conn->cookie_stuffer));
+    POSIX_GUARD(s2n_free(&conn->client_ticket));
+    POSIX_GUARD(s2n_free(&conn->status_response));
+    POSIX_GUARD(s2n_free(&conn->our_quic_transport_parameters));
+    POSIX_GUARD(s2n_free(&conn->application_protocols_overridden));
+    POSIX_GUARD(s2n_stuffer_free(&conn->cookie_stuffer));
 
     return 0;
 }
@@ -616,37 +616,37 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     struct s2n_connection_hmac_handles hmac_handles = {0};
 
     /* Wipe all of the sensitive stuff */
-    GUARD(s2n_connection_wipe_keys(conn));
-    GUARD(s2n_connection_reset_hashes(conn));
-    GUARD(s2n_connection_reset_hmacs(conn));
-    GUARD(s2n_stuffer_wipe(&conn->alert_in));
-    GUARD(s2n_stuffer_wipe(&conn->reader_alert_out));
-    GUARD(s2n_stuffer_wipe(&conn->writer_alert_out));
-    GUARD(s2n_stuffer_wipe(&conn->client_ticket_to_decrypt));
-    GUARD(s2n_stuffer_wipe(&conn->handshake.io));
-    GUARD(s2n_stuffer_wipe(&conn->client_hello.raw_message));
-    GUARD(s2n_stuffer_wipe(&conn->header_in));
-    GUARD(s2n_stuffer_wipe(&conn->in));
-    GUARD(s2n_stuffer_wipe(&conn->out));
+    POSIX_GUARD(s2n_connection_wipe_keys(conn));
+    POSIX_GUARD(s2n_connection_reset_hashes(conn));
+    POSIX_GUARD(s2n_connection_reset_hmacs(conn));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->alert_in));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->reader_alert_out));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->writer_alert_out));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->client_ticket_to_decrypt));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->client_hello.raw_message));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->out));
 
-    GUARD_AS_POSIX(s2n_psk_parameters_wipe(&conn->psk_params));
+    POSIX_GUARD_RESULT(s2n_psk_parameters_wipe(&conn->psk_params));
 
     /* Wipe the I/O-related info and restore the original socket if necessary */
-    GUARD(s2n_connection_wipe_io(conn));
+    POSIX_GUARD(s2n_connection_wipe_io(conn));
 
-    GUARD(s2n_free(&conn->client_ticket));
-    GUARD(s2n_free(&conn->status_response));
-    GUARD(s2n_free(&conn->application_protocols_overridden));
-    GUARD(s2n_free(&conn->our_quic_transport_parameters));
-    GUARD(s2n_free(&conn->peer_quic_transport_parameters));
+    POSIX_GUARD(s2n_free(&conn->client_ticket));
+    POSIX_GUARD(s2n_free(&conn->status_response));
+    POSIX_GUARD(s2n_free(&conn->application_protocols_overridden));
+    POSIX_GUARD(s2n_free(&conn->our_quic_transport_parameters));
+    POSIX_GUARD(s2n_free(&conn->peer_quic_transport_parameters));
 
     /* Allocate memory for handling handshakes */
-    GUARD(s2n_stuffer_resize(&conn->handshake.io, S2N_LARGE_RECORD_LENGTH));
+    POSIX_GUARD(s2n_stuffer_resize(&conn->handshake.io, S2N_LARGE_RECORD_LENGTH));
 
     /* Truncate the message buffers to save memory, we will dynamically resize it as needed */
-    GUARD(s2n_stuffer_resize(&conn->client_hello.raw_message, 0));
-    GUARD(s2n_stuffer_resize(&conn->in, 0));
-    GUARD(s2n_stuffer_resize(&conn->out, 0));
+    POSIX_GUARD(s2n_stuffer_resize(&conn->client_hello.raw_message, 0));
+    POSIX_GUARD(s2n_stuffer_resize(&conn->in, 0));
+    POSIX_GUARD(s2n_stuffer_resize(&conn->out, 0));
 
     /* Remove context associated with connection */
     conn->context = NULL;
@@ -661,53 +661,53 @@ int s2n_connection_wipe(struct s2n_connection *conn)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Waddress"
 #endif
-    memcpy_check(&alert_in, &conn->alert_in, sizeof(struct s2n_stuffer));
-    memcpy_check(&reader_alert_out, &conn->reader_alert_out, sizeof(struct s2n_stuffer));
-    memcpy_check(&writer_alert_out, &conn->writer_alert_out, sizeof(struct s2n_stuffer));
-    memcpy_check(&client_ticket_to_decrypt, &conn->client_ticket_to_decrypt, sizeof(struct s2n_stuffer));
-    memcpy_check(&handshake_io, &conn->handshake.io, sizeof(struct s2n_stuffer));
-    memcpy_check(&client_hello_raw_message, &conn->client_hello.raw_message, sizeof(struct s2n_stuffer));
-    memcpy_check(&header_in, &conn->header_in, sizeof(struct s2n_stuffer));
-    memcpy_check(&in, &conn->in, sizeof(struct s2n_stuffer));
-    memcpy_check(&out, &conn->out, sizeof(struct s2n_stuffer));
-    memcpy_check(&initial_client_key, &conn->initial.client_key, sizeof(struct s2n_session_key));
-    memcpy_check(&initial_server_key, &conn->initial.server_key, sizeof(struct s2n_session_key));
-    memcpy_check(&secure_client_key, &conn->secure.client_key, sizeof(struct s2n_session_key));
-    memcpy_check(&secure_server_key, &conn->secure.server_key, sizeof(struct s2n_session_key));
-    GUARD(s2n_connection_save_prf_state(&prf_handles, conn));
-    GUARD(s2n_connection_save_hash_state(&hash_handles, conn));
-    GUARD(s2n_connection_save_hmac_state(&hmac_handles, conn));
+    POSIX_CHECKED_MEMCPY(&alert_in, &conn->alert_in, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&reader_alert_out, &conn->reader_alert_out, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&writer_alert_out, &conn->writer_alert_out, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&client_ticket_to_decrypt, &conn->client_ticket_to_decrypt, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&handshake_io, &conn->handshake.io, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&client_hello_raw_message, &conn->client_hello.raw_message, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&header_in, &conn->header_in, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&in, &conn->in, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&out, &conn->out, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&initial_client_key, &conn->initial.client_key, sizeof(struct s2n_session_key));
+    POSIX_CHECKED_MEMCPY(&initial_server_key, &conn->initial.server_key, sizeof(struct s2n_session_key));
+    POSIX_CHECKED_MEMCPY(&secure_client_key, &conn->secure.client_key, sizeof(struct s2n_session_key));
+    POSIX_CHECKED_MEMCPY(&secure_server_key, &conn->secure.server_key, sizeof(struct s2n_session_key));
+    POSIX_GUARD(s2n_connection_save_prf_state(&prf_handles, conn));
+    POSIX_GUARD(s2n_connection_save_hash_state(&hash_handles, conn));
+    POSIX_GUARD(s2n_connection_save_hmac_state(&hmac_handles, conn));
 #if S2N_GCC_VERSION_AT_LEAST(4,6,0)
 #pragma GCC diagnostic pop
 #endif
 
-    GUARD(s2n_connection_zero(conn, mode, config));
+    POSIX_GUARD(s2n_connection_zero(conn, mode, config));
 
-    memcpy_check(&conn->alert_in, &alert_in, sizeof(struct s2n_stuffer));
-    memcpy_check(&conn->reader_alert_out, &reader_alert_out, sizeof(struct s2n_stuffer));
-    memcpy_check(&conn->writer_alert_out, &writer_alert_out, sizeof(struct s2n_stuffer));
-    memcpy_check(&conn->client_ticket_to_decrypt, &client_ticket_to_decrypt, sizeof(struct s2n_stuffer));
-    memcpy_check(&conn->handshake.io, &handshake_io, sizeof(struct s2n_stuffer));
-    memcpy_check(&conn->client_hello.raw_message, &client_hello_raw_message, sizeof(struct s2n_stuffer));
-    memcpy_check(&conn->header_in, &header_in, sizeof(struct s2n_stuffer));
-    memcpy_check(&conn->in, &in, sizeof(struct s2n_stuffer));
-    memcpy_check(&conn->out, &out, sizeof(struct s2n_stuffer));
-    memcpy_check(&conn->initial.client_key, &initial_client_key, sizeof(struct s2n_session_key));
-    memcpy_check(&conn->initial.server_key, &initial_server_key, sizeof(struct s2n_session_key));
-    memcpy_check(&conn->secure.client_key, &secure_client_key, sizeof(struct s2n_session_key));
-    memcpy_check(&conn->secure.server_key, &secure_server_key, sizeof(struct s2n_session_key));
-    GUARD(s2n_connection_restore_prf_state(conn, &prf_handles));
-    GUARD(s2n_connection_restore_hash_state(conn, &hash_handles));
-    GUARD(s2n_connection_restore_hmac_state(conn, &hmac_handles));
+    POSIX_CHECKED_MEMCPY(&conn->alert_in, &alert_in, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&conn->reader_alert_out, &reader_alert_out, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&conn->writer_alert_out, &writer_alert_out, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&conn->client_ticket_to_decrypt, &client_ticket_to_decrypt, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&conn->handshake.io, &handshake_io, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&conn->client_hello.raw_message, &client_hello_raw_message, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&conn->header_in, &header_in, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&conn->in, &in, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&conn->out, &out, sizeof(struct s2n_stuffer));
+    POSIX_CHECKED_MEMCPY(&conn->initial.client_key, &initial_client_key, sizeof(struct s2n_session_key));
+    POSIX_CHECKED_MEMCPY(&conn->initial.server_key, &initial_server_key, sizeof(struct s2n_session_key));
+    POSIX_CHECKED_MEMCPY(&conn->secure.client_key, &secure_client_key, sizeof(struct s2n_session_key));
+    POSIX_CHECKED_MEMCPY(&conn->secure.server_key, &secure_server_key, sizeof(struct s2n_session_key));
+    POSIX_GUARD(s2n_connection_restore_prf_state(conn, &prf_handles));
+    POSIX_GUARD(s2n_connection_restore_hash_state(conn, &hash_handles));
+    POSIX_GUARD(s2n_connection_restore_hmac_state(conn, &hmac_handles));
 
     /* Re-initialize hash and hmac states */
-    GUARD(s2n_connection_init_hashes(conn));
-    GUARD(s2n_connection_init_hmacs(conn));
+    POSIX_GUARD(s2n_connection_init_hashes(conn));
+    POSIX_GUARD(s2n_connection_init_hmacs(conn));
 
-    GUARD_AS_POSIX(s2n_psk_parameters_init(&conn->psk_params));
+    POSIX_GUARD_RESULT(s2n_psk_parameters_init(&conn->psk_params));
 
     /* Require all handshakes hashes. This set can be reduced as the handshake progresses. */
-    GUARD(s2n_handshake_require_all_hashes(&conn->handshake));
+    POSIX_GUARD(s2n_handshake_require_all_hashes(&conn->handshake));
 
     if (conn->mode == S2N_SERVER) {
         /* Start with the highest protocol version so that the highest common protocol version can be selected */
@@ -753,10 +753,10 @@ int s2n_connection_set_send_cb(struct s2n_connection *conn, s2n_send_fn send)
 
 int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **der_cert_chain_out, uint32_t *cert_chain_len)
 {
-    notnull_check(conn);
-    notnull_check(der_cert_chain_out);
-    notnull_check(cert_chain_len);
-    notnull_check(conn->secure.client_cert_chain.data);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(der_cert_chain_out);
+    POSIX_ENSURE_REF(cert_chain_len);
+    POSIX_ENSURE_REF(conn->secure.client_cert_chain.data);
 
     *der_cert_chain_out = conn->secure.client_cert_chain.data;
     *cert_chain_len = conn->secure.client_cert_chain.size;
@@ -766,100 +766,100 @@ int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **
 
 int s2n_connection_get_cipher_preferences(struct s2n_connection *conn, const struct s2n_cipher_preferences **cipher_preferences)
 {
-    notnull_check(conn);
-    notnull_check(conn->config);
-    notnull_check(cipher_preferences);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->config);
+    POSIX_ENSURE_REF(cipher_preferences);
 
     if (conn->security_policy_override != NULL) {
         *cipher_preferences = conn->security_policy_override->cipher_preferences;
     } else if (conn->config->security_policy != NULL) {
         *cipher_preferences = conn->config->security_policy->cipher_preferences;
     } else {
-        S2N_ERROR(S2N_ERR_INVALID_CIPHER_PREFERENCES);
+        POSIX_BAIL(S2N_ERR_INVALID_CIPHER_PREFERENCES);
     }
 
-    notnull_check(*cipher_preferences);
+    POSIX_ENSURE_REF(*cipher_preferences);
     return 0;
 }
 
 int s2n_connection_get_security_policy(struct s2n_connection *conn, const struct s2n_security_policy **security_policy)
 {
-    notnull_check(conn);
-    notnull_check(conn->config);
-    notnull_check(security_policy);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->config);
+    POSIX_ENSURE_REF(security_policy);
 
     if (conn->security_policy_override != NULL) {
         *security_policy = conn->security_policy_override;
     } else if (conn->config->security_policy != NULL) {
         *security_policy = conn->config->security_policy;
     } else {
-        S2N_ERROR(S2N_ERR_INVALID_SECURITY_POLICY);
+        POSIX_BAIL(S2N_ERR_INVALID_SECURITY_POLICY);
     }
 
-    notnull_check(*security_policy);
+    POSIX_ENSURE_REF(*security_policy);
     return 0;
 }
 
 int s2n_connection_get_kem_preferences(struct s2n_connection *conn, const struct s2n_kem_preferences **kem_preferences)
 {
-    notnull_check(conn);
-    notnull_check(conn->config);
-    notnull_check(kem_preferences);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->config);
+    POSIX_ENSURE_REF(kem_preferences);
 
     if (conn->security_policy_override != NULL) {
         *kem_preferences = conn->security_policy_override->kem_preferences;
     } else if (conn->config->security_policy != NULL) {
         *kem_preferences = conn->config->security_policy->kem_preferences;
     } else {
-        S2N_ERROR(S2N_ERR_INVALID_KEM_PREFERENCES);
+        POSIX_BAIL(S2N_ERR_INVALID_KEM_PREFERENCES);
     }
 
-    notnull_check(*kem_preferences);
+    POSIX_ENSURE_REF(*kem_preferences);
     return 0;
 }
 
 int s2n_connection_get_signature_preferences(struct s2n_connection *conn, const struct s2n_signature_preferences **signature_preferences)
 {
-    notnull_check(conn);
-    notnull_check(conn->config);
-    notnull_check(signature_preferences);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->config);
+    POSIX_ENSURE_REF(signature_preferences);
 
     if (conn->security_policy_override != NULL) {
         *signature_preferences = conn->security_policy_override->signature_preferences;
     } else if (conn->config->security_policy != NULL) {
         *signature_preferences = conn->config->security_policy->signature_preferences;
     } else {
-        S2N_ERROR(S2N_ERR_INVALID_SIGNATURE_ALGORITHMS_PREFERENCES);
+        POSIX_BAIL(S2N_ERR_INVALID_SIGNATURE_ALGORITHMS_PREFERENCES);
     }
 
-    notnull_check(*signature_preferences);
+    POSIX_ENSURE_REF(*signature_preferences);
     return 0;
 
 }
 
 int s2n_connection_get_ecc_preferences(struct s2n_connection *conn, const struct s2n_ecc_preferences **ecc_preferences)
 {
-    notnull_check(conn);
-    notnull_check(conn->config);
-    notnull_check(ecc_preferences);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->config);
+    POSIX_ENSURE_REF(ecc_preferences);
 
     if (conn->security_policy_override != NULL) {
         *ecc_preferences = conn->security_policy_override->ecc_preferences;
     } else if (conn->config->security_policy != NULL) {
         *ecc_preferences = conn->config->security_policy->ecc_preferences;
     } else {
-        S2N_ERROR(S2N_ERR_INVALID_ECC_PREFERENCES);
+        POSIX_BAIL(S2N_ERR_INVALID_ECC_PREFERENCES);
     }
 
-    notnull_check(*ecc_preferences);
+    POSIX_ENSURE_REF(*ecc_preferences);
     return 0;
 
 }
 
 int s2n_connection_get_protocol_preferences(struct s2n_connection *conn, struct s2n_blob **protocol_preferences)
 {
-    notnull_check(conn);
-    notnull_check(protocol_preferences);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(protocol_preferences);
 
     *protocol_preferences = NULL;
     if (conn->application_protocols_overridden.size > 0) {
@@ -868,14 +868,14 @@ int s2n_connection_get_protocol_preferences(struct s2n_connection *conn, struct 
         *protocol_preferences = &conn->config->application_protocols;
     }
 
-    notnull_check(*protocol_preferences);
+    POSIX_ENSURE_REF(*protocol_preferences);
     return 0;
 }
 
 int s2n_connection_get_client_auth_type(struct s2n_connection *conn, s2n_cert_auth_type *client_cert_auth_type)
 {
-    notnull_check(conn);
-    notnull_check(client_cert_auth_type);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(client_cert_auth_type);
 
     if (conn->client_cert_auth_type_overridden) {
         *client_cert_auth_type = conn->client_cert_auth_type;
@@ -898,8 +898,8 @@ int s2n_connection_set_read_fd(struct s2n_connection *conn, int rfd)
     struct s2n_blob ctx_mem = {0};
     struct s2n_socket_read_io_context *peer_socket_ctx;
 
-    GUARD(s2n_alloc(&ctx_mem, sizeof(struct s2n_socket_read_io_context)));
-    GUARD(s2n_blob_zero(&ctx_mem));
+    POSIX_GUARD(s2n_alloc(&ctx_mem, sizeof(struct s2n_socket_read_io_context)));
+    POSIX_GUARD(s2n_blob_zero(&ctx_mem));
 
     peer_socket_ctx = (struct s2n_socket_read_io_context *)(void *)ctx_mem.data;
     peer_socket_ctx->fd = rfd;
@@ -911,7 +911,7 @@ int s2n_connection_set_read_fd(struct s2n_connection *conn, int rfd)
     /* This is only needed if the user is using corked io.
      * Take the snapshot in case optimized io is enabled after setting the fd.
      */
-    GUARD(s2n_socket_read_snapshot(conn));
+    POSIX_GUARD(s2n_socket_read_snapshot(conn));
 
     return 0;
 }
@@ -921,7 +921,7 @@ int s2n_connection_set_write_fd(struct s2n_connection *conn, int wfd)
     struct s2n_blob ctx_mem = {0};
     struct s2n_socket_write_io_context *peer_socket_ctx;
 
-    GUARD(s2n_alloc(&ctx_mem, sizeof(struct s2n_socket_write_io_context)));
+    POSIX_GUARD(s2n_alloc(&ctx_mem, sizeof(struct s2n_socket_write_io_context)));
 
     peer_socket_ctx = (struct s2n_socket_write_io_context *)(void *)ctx_mem.data;
     peer_socket_ctx->fd = wfd;
@@ -933,7 +933,7 @@ int s2n_connection_set_write_fd(struct s2n_connection *conn, int wfd)
     /* This is only needed if the user is using corked io.
      * Take the snapshot in case optimized io is enabled after setting the fd.
      */
-    GUARD(s2n_socket_write_snapshot(conn));
+    POSIX_GUARD(s2n_socket_write_snapshot(conn));
 
     uint8_t ipv6;
     if (0 == s2n_socket_is_ipv6(wfd, &ipv6)) {
@@ -947,8 +947,8 @@ int s2n_connection_set_write_fd(struct s2n_connection *conn, int wfd)
 
 int s2n_connection_set_fd(struct s2n_connection *conn, int fd)
 {
-    GUARD(s2n_connection_set_read_fd(conn, fd));
-    GUARD(s2n_connection_set_write_fd(conn, fd));
+    POSIX_GUARD(s2n_connection_set_read_fd(conn, fd));
+    POSIX_GUARD(s2n_connection_set_write_fd(conn, fd));
     return 0;
 }
 
@@ -956,7 +956,7 @@ int s2n_connection_use_corked_io(struct s2n_connection *conn)
 {
     if (!conn->managed_io) {
         /* Caller shouldn't be trying to set s2n IO corked on non-s2n-managed IO */
-        S2N_ERROR(S2N_ERR_CORK_SET_ON_UNMANAGED);
+        POSIX_BAIL(S2N_ERR_CORK_SET_ON_UNMANAGED);
     }
     conn->corked_io = 1;
 
@@ -975,21 +975,21 @@ uint64_t s2n_connection_get_wire_bytes_out(struct s2n_connection *conn)
 
 const char *s2n_connection_get_cipher(struct s2n_connection *conn)
 {
-    notnull_check_ptr(conn);
-    notnull_check_ptr(conn->secure.cipher_suite);
+    PTR_ENSURE_REF(conn);
+    PTR_ENSURE_REF(conn->secure.cipher_suite);
 
     return conn->secure.cipher_suite->name;
 }
 
 int s2n_connection_get_cipher_iana_value(struct s2n_connection *conn, uint8_t *first, uint8_t *second)
 {
-    ENSURE_POSIX_REF(conn);
-    ENSURE_POSIX_REF(conn->secure.cipher_suite);
-    ENSURE_POSIX_MUT(first);
-    ENSURE_POSIX_MUT(second);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->secure.cipher_suite);
+    POSIX_ENSURE_MUT(first);
+    POSIX_ENSURE_MUT(second);
 
     /* ensure we've negotiated a cipher suite */
-    ENSURE_POSIX(
+    POSIX_ENSURE(
         memcmp(
             conn->secure.cipher_suite->iana_value,
             s2n_null_cipher_suite.iana_value,
@@ -1007,7 +1007,7 @@ int s2n_connection_get_cipher_iana_value(struct s2n_connection *conn, uint8_t *f
 
 const char *s2n_connection_get_curve(struct s2n_connection *conn)
 {
-    notnull_check_ptr(conn);
+    PTR_ENSURE_REF(conn);
 
     if (!conn->secure.server_ecc_evp_params.negotiated_curve) {
         return "NONE";
@@ -1018,7 +1018,7 @@ const char *s2n_connection_get_curve(struct s2n_connection *conn)
 
 const char *s2n_connection_get_kem_name(struct s2n_connection *conn)
 {
-    notnull_check_ptr(conn);
+    PTR_ENSURE_REF(conn);
 
     if (!conn->secure.kem_params.kem) {
         return "NONE";
@@ -1029,7 +1029,7 @@ const char *s2n_connection_get_kem_name(struct s2n_connection *conn)
 
 const char *s2n_connection_get_kem_group_name(struct s2n_connection *conn)
 {
-    notnull_check_ptr(conn);
+    PTR_ENSURE_REF(conn);
 
     if (!conn->secure.chosen_client_kem_group_params || !conn->secure.chosen_client_kem_group_params->kem_group) {
         return "NONE";
@@ -1040,35 +1040,35 @@ const char *s2n_connection_get_kem_group_name(struct s2n_connection *conn)
 
 int s2n_connection_get_client_protocol_version(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     return conn->client_protocol_version;
 }
 
 int s2n_connection_get_server_protocol_version(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     return conn->server_protocol_version;
 }
 
 int s2n_connection_get_actual_protocol_version(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     return conn->actual_protocol_version;
 }
 
 int s2n_connection_get_client_hello_version(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     return conn->client_hello_version;
 }
 
 int s2n_connection_client_cert_used(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     if ((conn->handshake.handshake_type & CLIENT_AUTH) && is_handshake_complete(conn)) {
         if (conn->handshake.handshake_type & NO_CLIENT_CERT) {
@@ -1081,41 +1081,41 @@ int s2n_connection_client_cert_used(struct s2n_connection *conn)
 
 int s2n_connection_get_alert(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     S2N_ERROR_IF(s2n_stuffer_data_available(&conn->alert_in) != 2, S2N_ERR_NO_ALERT);
 
     uint8_t alert_code = 0;
-    GUARD(s2n_stuffer_read_uint8(&conn->alert_in, &alert_code));
-    GUARD(s2n_stuffer_read_uint8(&conn->alert_in, &alert_code));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&conn->alert_in, &alert_code));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&conn->alert_in, &alert_code));
 
     return alert_code;
 }
 
 int s2n_set_server_name(struct s2n_connection *conn, const char *server_name)
 {
-    notnull_check(conn);
-    notnull_check(server_name);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(server_name);
 
     S2N_ERROR_IF(conn->mode != S2N_CLIENT, S2N_ERR_CLIENT_MODE);
 
     int len = strlen(server_name);
     S2N_ERROR_IF(len > S2N_MAX_SERVER_NAME, S2N_ERR_SERVER_NAME_TOO_LONG);
 
-    memcpy_check(conn->server_name, server_name, len);
+    POSIX_CHECKED_MEMCPY(conn->server_name, server_name, len);
 
     return 0;
 }
 
 const char *s2n_get_server_name(struct s2n_connection *conn)
 {
-    notnull_check_ptr(conn);
+    PTR_ENSURE_REF(conn);
 
     if (conn->server_name[0]) {
         return conn->server_name;
     }
 
-    GUARD_PTR(s2n_extension_process(&s2n_client_server_name_extension, conn, &conn->client_hello.extensions));
+    PTR_GUARD_POSIX(s2n_extension_process(&s2n_client_server_name_extension, conn, &conn->client_hello.extensions));
 
     if (!conn->server_name[0]) {
         return NULL;
@@ -1126,7 +1126,7 @@ const char *s2n_get_server_name(struct s2n_connection *conn)
 
 const char *s2n_get_application_protocol(struct s2n_connection *conn)
 {
-    notnull_check_ptr(conn);
+    PTR_ENSURE_REF(conn);
 
     if (strlen(conn->application_protocol) == 0) {
         return NULL;
@@ -1137,27 +1137,27 @@ const char *s2n_get_application_protocol(struct s2n_connection *conn)
 
 int s2n_connection_get_session_id_length(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     return conn->session_id_len;
 }
 
 int s2n_connection_get_session_id(struct s2n_connection *conn, uint8_t *session_id, size_t max_length)
 {
-    notnull_check(conn);
-    notnull_check(session_id);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(session_id);
 
     int session_id_len = s2n_connection_get_session_id_length(conn);
 
     S2N_ERROR_IF(session_id_len > max_length, S2N_ERR_SESSION_ID_TOO_LONG);
 
-    memcpy_check(session_id, conn->session_id, session_id_len);
+    POSIX_CHECKED_MEMCPY(session_id, conn->session_id, session_id_len);
 
     return session_id_len;
 }
 
 int s2n_connection_set_blinding(struct s2n_connection *conn, s2n_blinding blinding)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     conn->blinding = blinding;
 
     return 0;
@@ -1174,7 +1174,7 @@ uint64_t s2n_connection_get_delay(struct s2n_connection *conn)
 
     uint64_t elapsed;
     /* This will cast -1 to max uint64_t */
-    GUARD_AS_POSIX(s2n_timer_elapsed(conn->config, &conn->write_timer, &elapsed));
+    POSIX_GUARD_RESULT(s2n_timer_elapsed(conn->config, &conn->write_timer, &elapsed));
 
     if (elapsed > conn->delay) {
         return 0;
@@ -1185,7 +1185,7 @@ uint64_t s2n_connection_get_delay(struct s2n_connection *conn)
 
 int s2n_connection_kill(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     conn->closed = 1;
 
@@ -1194,12 +1194,12 @@ int s2n_connection_kill(struct s2n_connection *conn)
 
     /* Keep track of the delay so that it can be enforced */
     uint64_t rand_delay = 0;
-    GUARD_AS_POSIX(s2n_public_random(max - min, &rand_delay));
+    POSIX_GUARD_RESULT(s2n_public_random(max - min, &rand_delay));
 
     conn->delay = min + rand_delay;
 
     /* Restart the write timer */
-    GUARD_AS_POSIX(s2n_timer_start(conn->config, &conn->write_timer));
+    POSIX_GUARD_RESULT(s2n_timer_start(conn->config, &conn->write_timer));
 
     if (conn->blinding == S2N_BUILT_IN_BLINDING) {
         struct timespec sleep_time = {.tv_sec = conn->delay / ONE_S,.tv_nsec = conn->delay % ONE_S };
@@ -1216,8 +1216,8 @@ int s2n_connection_kill(struct s2n_connection *conn)
 
 const uint8_t *s2n_connection_get_ocsp_response(struct s2n_connection *conn, uint32_t * length)
 {
-    notnull_check_ptr(conn);
-    notnull_check_ptr(length);
+    PTR_ENSURE_REF(conn);
+    PTR_ENSURE_REF(length);
 
     *length = conn->status_response.size;
     return conn->status_response.data;
@@ -1225,7 +1225,7 @@ const uint8_t *s2n_connection_get_ocsp_response(struct s2n_connection *conn, uin
 
 int s2n_connection_prefer_throughput(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     if (!conn->mfl_code) {
         conn->max_outgoing_fragment_length = S2N_LARGE_FRAGMENT_LENGTH;
@@ -1236,7 +1236,7 @@ int s2n_connection_prefer_throughput(struct s2n_connection *conn)
 
 int s2n_connection_prefer_low_latency(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     if (!conn->mfl_code) {
         conn->max_outgoing_fragment_length = S2N_SMALL_FRAGMENT_LENGTH;
@@ -1247,7 +1247,7 @@ int s2n_connection_prefer_low_latency(struct s2n_connection *conn)
 
 int s2n_connection_set_dynamic_record_threshold(struct s2n_connection *conn, uint32_t resize_threshold, uint16_t timeout_threshold)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     S2N_ERROR_IF(resize_threshold > S2N_TLS_MAX_RESIZE_THRESHOLD, S2N_ERR_INVALID_DYNAMIC_THRESHOLD);
 
     conn->dynamic_record_resize_threshold = resize_threshold;
@@ -1256,7 +1256,7 @@ int s2n_connection_set_dynamic_record_threshold(struct s2n_connection *conn, uin
 }
 
 int s2n_connection_set_verify_host_callback(struct s2n_connection *conn, s2n_verify_host_fn verify_host_fn, void *data) {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     conn->verify_host_fn = verify_host_fn;
     conn->data_for_verify_host = data;
@@ -1267,9 +1267,9 @@ int s2n_connection_set_verify_host_callback(struct s2n_connection *conn, s2n_ver
 
 int s2n_connection_recv_stuffer(struct s2n_stuffer *stuffer, struct s2n_connection *conn, uint32_t len)
 {
-    notnull_check(conn->recv);
+    POSIX_ENSURE_REF(conn->recv);
     /* Make sure we have enough space to write */
-    GUARD(s2n_stuffer_reserve_space(stuffer, len));
+    POSIX_GUARD(s2n_stuffer_reserve_space(stuffer, len));
 
     int r = 0;
     do {
@@ -1279,16 +1279,16 @@ int s2n_connection_recv_stuffer(struct s2n_stuffer *stuffer, struct s2n_connecti
     } while (r < 0);
 
     /* Record just how many bytes we have written */
-    GUARD(s2n_stuffer_skip_write(stuffer, r));
+    POSIX_GUARD(s2n_stuffer_skip_write(stuffer, r));
     return r;
 }
 
 int s2n_connection_send_stuffer(struct s2n_stuffer *stuffer, struct s2n_connection *conn, uint32_t len)
 {
-    notnull_check(conn);
-    notnull_check(conn->send);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->send);
     if (conn->write_fd_broken) {
-        S2N_ERROR(S2N_ERR_SEND_STUFFER_TO_CONN);
+        POSIX_BAIL(S2N_ERR_SEND_STUFFER_TO_CONN);
     }
     /* Make sure we even have the data */
     S2N_ERROR_IF(s2n_stuffer_data_available(stuffer) < len, S2N_ERR_STUFFER_OUT_OF_DATA);
@@ -1303,13 +1303,13 @@ int s2n_connection_send_stuffer(struct s2n_stuffer *stuffer, struct s2n_connecti
         S2N_ERROR_IF(w < 0 && errno != EINTR, S2N_ERR_SEND_STUFFER_TO_CONN);
     } while (w < 0);
 
-    GUARD(s2n_stuffer_skip_read(stuffer, w));
+    POSIX_GUARD(s2n_stuffer_skip_read(stuffer, w));
     return w;
 }
 
 int s2n_connection_is_managed_corked(const struct s2n_connection *s2n_connection)
 {
-    notnull_check(s2n_connection);
+    POSIX_ENSURE_REF(s2n_connection);
 
     return (s2n_connection->managed_io && s2n_connection->corked_io);
 }
@@ -1327,14 +1327,14 @@ const uint8_t *s2n_connection_get_sct_list(struct s2n_connection *conn, uint32_t
 int s2n_connection_is_client_auth_enabled(struct s2n_connection *s2n_connection)
 {
     s2n_cert_auth_type auth_type;
-    GUARD(s2n_connection_get_client_auth_type(s2n_connection, &auth_type));
+    POSIX_GUARD(s2n_connection_get_client_auth_type(s2n_connection, &auth_type));
 
     return (auth_type != S2N_CERT_AUTH_NONE);
 }
 
 struct s2n_cert_chain_and_key *s2n_connection_get_selected_cert(struct s2n_connection *conn)
 {
-    notnull_check_ptr(conn);
+    PTR_ENSURE_REF(conn);
     return conn->handshake_params.our_chain_and_key;
 }
 
@@ -1356,8 +1356,8 @@ uint8_t s2n_connection_get_protocol_version(const struct s2n_connection *conn)
 
 int s2n_connection_set_keyshare_by_name_for_testing(struct s2n_connection *conn, const char* curve_name)
 {
-    ENSURE_POSIX(S2N_IN_TEST, S2N_ERR_NOT_IN_TEST);
-    notnull_check(conn);
+    POSIX_ENSURE(S2N_IN_TEST, S2N_ERR_NOT_IN_TEST);
+    POSIX_ENSURE_REF(conn);
 
     if (!strcmp(curve_name, "none")) {
         S2N_SET_KEY_SHARE_LIST_EMPTY(conn->preferred_key_shares);
@@ -1365,8 +1365,8 @@ int s2n_connection_set_keyshare_by_name_for_testing(struct s2n_connection *conn,
     }
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    notnull_check(ecc_pref);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    POSIX_ENSURE_REF(ecc_pref);
 
     for (size_t i = 0; i < ecc_pref->count; i++) {
         if (!strcmp(ecc_pref->ecc_curves[i]->name, curve_name)) {
@@ -1375,5 +1375,5 @@ int s2n_connection_set_keyshare_by_name_for_testing(struct s2n_connection *conn,
         }
     }
 
-    S2N_ERROR(S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+    POSIX_BAIL(S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 }

--- a/tls/s2n_connection_evp_digests.c
+++ b/tls/s2n_connection_evp_digests.c
@@ -24,7 +24,7 @@
 int s2n_connection_save_prf_state(struct s2n_connection_prf_handles *prf_handles, struct s2n_connection *conn)
 {
     /* Preserve only the handlers for TLS PRF p_hash pointers to avoid re-allocation */
-    GUARD(s2n_hmac_save_evp_hash_state(&prf_handles->p_hash_s2n_hmac, &conn->prf_space.tls.p_hash.s2n_hmac));
+    POSIX_GUARD(s2n_hmac_save_evp_hash_state(&prf_handles->p_hash_s2n_hmac, &conn->prf_space.tls.p_hash.s2n_hmac));
     prf_handles->p_hash_evp_hmac = conn->prf_space.tls.p_hash.evp_hmac;
 
     return 0;
@@ -69,12 +69,12 @@ int s2n_connection_save_hash_state(struct s2n_connection_hash_handles *hash_hand
  */
 int s2n_connection_save_hmac_state(struct s2n_connection_hmac_handles *hmac_handles, struct s2n_connection *conn)
 {
-    GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->initial_client, &conn->initial.client_record_mac));
-    GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->initial_server, &conn->initial.server_record_mac));
-    GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->initial_client_copy, &conn->initial.record_mac_copy_workspace));
-    GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->secure_client, &conn->secure.client_record_mac));
-    GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->secure_server, &conn->secure.server_record_mac));
-    GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->secure_client_copy, &conn->secure.record_mac_copy_workspace));
+    POSIX_GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->initial_client, &conn->initial.client_record_mac));
+    POSIX_GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->initial_server, &conn->initial.server_record_mac));
+    POSIX_GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->initial_client_copy, &conn->initial.record_mac_copy_workspace));
+    POSIX_GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->secure_client, &conn->secure.client_record_mac));
+    POSIX_GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->secure_server, &conn->secure.server_record_mac));
+    POSIX_GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->secure_client_copy, &conn->secure.record_mac_copy_workspace));
     return 0;
 }
 
@@ -85,7 +85,7 @@ int s2n_connection_save_hmac_state(struct s2n_connection_hmac_handles *hmac_hand
 int s2n_connection_restore_prf_state(struct s2n_connection *conn, struct s2n_connection_prf_handles *prf_handles)
 {
     /* Restore s2n_connection handlers for TLS PRF p_hash */
-    GUARD(s2n_hmac_restore_evp_hash_state(&prf_handles->p_hash_s2n_hmac, &conn->prf_space.tls.p_hash.s2n_hmac));
+    POSIX_GUARD(s2n_hmac_restore_evp_hash_state(&prf_handles->p_hash_s2n_hmac, &conn->prf_space.tls.p_hash.s2n_hmac));
     conn->prf_space.tls.p_hash.evp_hmac = prf_handles->p_hash_evp_hmac;
 
     return 0;
@@ -130,11 +130,11 @@ int s2n_connection_restore_hash_state(struct s2n_connection *conn, struct s2n_co
  */
 int s2n_connection_restore_hmac_state(struct s2n_connection *conn, struct s2n_connection_hmac_handles *hmac_handles)
 {
-    GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->initial_client, &conn->initial.client_record_mac));
-    GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->initial_server, &conn->initial.server_record_mac));
-    GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->initial_client_copy, &conn->initial.record_mac_copy_workspace));
-    GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->secure_client, &conn->secure.client_record_mac));
-    GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->secure_server, &conn->secure.server_record_mac));
-    GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->secure_client_copy, &conn->secure.record_mac_copy_workspace));
+    POSIX_GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->initial_client, &conn->initial.client_record_mac));
+    POSIX_GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->initial_server, &conn->initial.server_record_mac));
+    POSIX_GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->initial_client_copy, &conn->initial.record_mac_copy_workspace));
+    POSIX_GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->secure_client, &conn->secure.client_record_mac));
+    POSIX_GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->secure_server, &conn->secure.server_record_mac));
+    POSIX_GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->secure_client_copy, &conn->secure.record_mac_copy_workspace));
     return 0;
 }

--- a/tls/s2n_ecc_preferences.c
+++ b/tls/s2n_ecc_preferences.c
@@ -88,7 +88,7 @@ int s2n_check_ecc_preferences_curves_list(const struct s2n_ecc_preferences *ecc_
         }
         check *= curve_found; 
         if (check == 0) {
-            S2N_ERROR(S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+            POSIX_BAIL(S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
         }
     }
     return S2N_SUCCESS;

--- a/tls/s2n_encrypted_extensions.c
+++ b/tls/s2n_encrypted_extensions.c
@@ -36,20 +36,20 @@
 
 int s2n_encrypted_extensions_send(struct s2n_connection *conn)
 {
-    notnull_check(conn);
-    ENSURE_POSIX(conn->actual_protocol_version >= S2N_TLS13, S2N_ERR_BAD_MESSAGE);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE(conn->actual_protocol_version >= S2N_TLS13, S2N_ERR_BAD_MESSAGE);
 
     struct s2n_stuffer *out = &conn->handshake.io;
-    GUARD(s2n_extension_list_send(S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS, conn, out));
+    POSIX_GUARD(s2n_extension_list_send(S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS, conn, out));
     return S2N_SUCCESS;
 }
 
 int s2n_encrypted_extensions_recv(struct s2n_connection *conn)
 {
-    notnull_check(conn);
-    ENSURE_POSIX(conn->actual_protocol_version >= S2N_TLS13, S2N_ERR_BAD_MESSAGE);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE(conn->actual_protocol_version >= S2N_TLS13, S2N_ERR_BAD_MESSAGE);
 
     struct s2n_stuffer *in = &conn->handshake.io;
-    GUARD(s2n_extension_list_recv(S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS, conn, in));
+    POSIX_GUARD(s2n_extension_list_recv(S2N_EXTENSION_LIST_ENCRYPTED_EXTENSIONS, conn, in));
     return S2N_SUCCESS;
 }

--- a/tls/s2n_establish_session.c
+++ b/tls/s2n_establish_session.c
@@ -32,23 +32,23 @@
  * provided session ID in its cache. */
 int s2n_establish_session(struct s2n_connection *conn)
 {
-    GUARD(s2n_conn_set_handshake_read_block(conn));
+    POSIX_GUARD(s2n_conn_set_handshake_read_block(conn));
 
     /* Start by receiving and processing the entire CLIENT_HELLO message */
     if (!conn->handshake.client_hello_received) {
-        GUARD(s2n_client_hello_recv(conn));
+        POSIX_GUARD(s2n_client_hello_recv(conn));
         conn->handshake.client_hello_received = 1;
     }
 
-    GUARD(s2n_conn_set_handshake_type(conn));
+    POSIX_GUARD(s2n_conn_set_handshake_type(conn));
 
     if (conn->client_hello_version != S2N_SSLv2)
     {
         /* We've selected the parameters for the handshake, update the required hashes for this connection */
-        GUARD(s2n_conn_update_required_handshake_hashes(conn));
+        POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));
     }
 
-    GUARD(s2n_conn_clear_handshake_read_block(conn));
+    POSIX_GUARD(s2n_conn_clear_handshake_read_block(conn));
 
     return 0;
 }

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -32,11 +32,11 @@ int s2n_handshake_write_header(struct s2n_stuffer *out, uint8_t message_type)
     S2N_ERROR_IF(s2n_stuffer_data_available(out), S2N_ERR_HANDSHAKE_STATE);
 
     /* Write the message header */
-    GUARD(s2n_stuffer_write_uint8(out, message_type));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, message_type));
 
     /* Leave the length blank for now */
     uint16_t length = 0;
-    GUARD(s2n_stuffer_write_uint24(out, length));
+    POSIX_GUARD(s2n_stuffer_write_uint24(out, length));
 
     return 0;
 }
@@ -49,10 +49,10 @@ int s2n_handshake_finish_header(struct s2n_stuffer *out)
     uint16_t payload = length - TLS_HANDSHAKE_HEADER_LENGTH;
 
     /* Write the message header */
-    GUARD(s2n_stuffer_rewrite(out));
-    GUARD(s2n_stuffer_skip_write(out, 1));
-    GUARD(s2n_stuffer_write_uint24(out, payload));
-    GUARD(s2n_stuffer_skip_write(out, payload));
+    POSIX_GUARD(s2n_stuffer_rewrite(out));
+    POSIX_GUARD(s2n_stuffer_skip_write(out, 1));
+    POSIX_GUARD(s2n_stuffer_write_uint24(out, payload));
+    POSIX_GUARD(s2n_stuffer_skip_write(out, payload));
 
     return 0;
 }
@@ -62,15 +62,15 @@ int s2n_handshake_parse_header(struct s2n_connection *conn, uint8_t * message_ty
     S2N_ERROR_IF(s2n_stuffer_data_available(&conn->handshake.io) < TLS_HANDSHAKE_HEADER_LENGTH, S2N_ERR_SIZE_MISMATCH);
 
     /* read the message header */
-    GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, message_type));
-    GUARD(s2n_stuffer_read_uint24(&conn->handshake.io, length));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, message_type));
+    POSIX_GUARD(s2n_stuffer_read_uint24(&conn->handshake.io, length));
 
     return 0;
 }
 
 static int s2n_handshake_get_hash_state_ptr(struct s2n_connection *conn, s2n_hash_algorithm hash_alg, struct s2n_hash_state **hash_state)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     switch (hash_alg) {
     case S2N_HASH_MD5:
@@ -95,7 +95,7 @@ static int s2n_handshake_get_hash_state_ptr(struct s2n_connection *conn, s2n_has
         *hash_state = &conn->handshake.md5_sha1;
         break;
     default:
-        S2N_ERROR(S2N_ERR_HASH_INVALID_ALGORITHM);
+        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
         break;
     }
 
@@ -105,9 +105,9 @@ static int s2n_handshake_get_hash_state_ptr(struct s2n_connection *conn, s2n_has
 int s2n_handshake_reset_hash_state(struct s2n_connection *conn, s2n_hash_algorithm hash_alg)
 {
     struct s2n_hash_state *hash_state_ptr = NULL;
-    GUARD(s2n_handshake_get_hash_state_ptr(conn, hash_alg, &hash_state_ptr));
+    POSIX_GUARD(s2n_handshake_get_hash_state_ptr(conn, hash_alg, &hash_state_ptr));
 
-    GUARD(s2n_hash_reset(hash_state_ptr));
+    POSIX_GUARD(s2n_hash_reset(hash_state_ptr));
 
     return 0;
 }
@@ -121,10 +121,10 @@ int s2n_handshake_reset_hash_state(struct s2n_connection *conn, s2n_hash_algorit
  */
 int s2n_handshake_get_hash_state(struct s2n_connection *conn, s2n_hash_algorithm hash_alg, struct s2n_hash_state *hash_state)
 {
-    notnull_check(hash_state);
+    POSIX_ENSURE_REF(hash_state);
 
     struct s2n_hash_state *hash_state_ptr = NULL;
-    GUARD(s2n_handshake_get_hash_state_ptr(conn, hash_alg, &hash_state_ptr));
+    POSIX_GUARD(s2n_handshake_get_hash_state_ptr(conn, hash_alg, &hash_state_ptr));
 
     *hash_state = *hash_state_ptr;
 
@@ -161,11 +161,11 @@ int s2n_conn_update_required_handshake_hashes(struct s2n_connection *conn)
     message_type_t handshake_message = s2n_conn_get_current_message_type(conn);
     const uint8_t client_cert_verify_done = (handshake_message >= CLIENT_CERT_VERIFY) ? 1 : 0;
     s2n_cert_auth_type client_cert_auth_type;
-    GUARD(s2n_connection_get_client_auth_type(conn, &client_cert_auth_type));
+    POSIX_GUARD(s2n_connection_get_client_auth_type(conn, &client_cert_auth_type));
 
     /* If client authentication is possible, all hashes are needed until we're past CLIENT_CERT_VERIFY. */
     if ((client_cert_auth_type != S2N_CERT_AUTH_NONE) && !client_cert_verify_done) {
-        GUARD(s2n_handshake_require_all_hashes(&conn->handshake));
+        POSIX_GUARD(s2n_handshake_require_all_hashes(&conn->handshake));
         return 0;
     }
 
@@ -174,8 +174,8 @@ int s2n_conn_update_required_handshake_hashes(struct s2n_connection *conn)
     case S2N_SSLv3:
     case S2N_TLS10:
     case S2N_TLS11:
-        GUARD(s2n_handshake_require_hash(&conn->handshake, S2N_HASH_MD5));
-        GUARD(s2n_handshake_require_hash(&conn->handshake, S2N_HASH_SHA1));
+        POSIX_GUARD(s2n_handshake_require_hash(&conn->handshake, S2N_HASH_MD5));
+        POSIX_GUARD(s2n_handshake_require_hash(&conn->handshake, S2N_HASH_SHA1));
         break;
     case S2N_TLS12:
         /* fall through */
@@ -184,8 +184,8 @@ int s2n_conn_update_required_handshake_hashes(struct s2n_connection *conn)
         /* For TLS 1.2 and TLS 1.3, the cipher suite defines the PRF hash alg */
         s2n_hmac_algorithm prf_alg = conn->secure.cipher_suite->prf_alg;
         s2n_hash_algorithm hash_alg;
-        GUARD(s2n_hmac_hash_alg(prf_alg, &hash_alg));
-        GUARD(s2n_handshake_require_hash(&conn->handshake, hash_alg));
+        POSIX_GUARD(s2n_hmac_hash_alg(prf_alg, &hash_alg));
+        POSIX_GUARD(s2n_handshake_require_hash(&conn->handshake, hash_alg));
         break;
     }
     }
@@ -216,7 +216,7 @@ int s2n_conn_update_required_handshake_hashes(struct s2n_connection *conn)
 int s2n_create_wildcard_hostname(struct s2n_stuffer *hostname_stuffer, struct s2n_stuffer *output)
 {
     /* Find the end of the first label */
-    GUARD(s2n_stuffer_skip_to_char(hostname_stuffer, '.'));
+    POSIX_GUARD(s2n_stuffer_skip_to_char(hostname_stuffer, '.'));
 
     /* No first label found */
     if (s2n_stuffer_data_available(hostname_stuffer) == 0) {
@@ -224,10 +224,10 @@ int s2n_create_wildcard_hostname(struct s2n_stuffer *hostname_stuffer, struct s2
     }
 
     /* Slap a single wildcard character to be the first label in output */
-    GUARD(s2n_stuffer_write_uint8(output, '*'));
+    POSIX_GUARD(s2n_stuffer_write_uint8(output, '*'));
 
     /* Simply copy the rest of the input to the output. */
-    GUARD(s2n_stuffer_copy(hostname_stuffer, output, s2n_stuffer_data_available(hostname_stuffer)));
+    POSIX_GUARD(s2n_stuffer_copy(hostname_stuffer, output, s2n_stuffer_data_available(hostname_stuffer)));
 
     return 0;
 }
@@ -239,7 +239,7 @@ static int s2n_find_cert_matches(struct s2n_map *domain_name_to_cert_map,
 {
     struct s2n_blob map_value;
     bool key_found = false;
-    GUARD_AS_POSIX(s2n_map_lookup(domain_name_to_cert_map, dns_name, &map_value, &key_found));
+    POSIX_GUARD_RESULT(s2n_map_lookup(domain_name_to_cert_map, dns_name, &map_value, &key_found));
     if (key_found) {
         struct certs_by_type *value = (void *) map_value.data;
         for (int i = 0; i < S2N_CERT_TYPE_COUNT; i++) {
@@ -265,17 +265,17 @@ int s2n_conn_find_name_matching_certs(struct s2n_connection *conn)
     }
     const char *name = conn->server_name;
     struct s2n_blob hostname_blob = { .data = (uint8_t *) (uintptr_t) name, .size = strlen(name) };
-    lte_check(hostname_blob.size, S2N_MAX_SERVER_NAME);
+    POSIX_ENSURE_LTE(hostname_blob.size, S2N_MAX_SERVER_NAME);
     char normalized_hostname[S2N_MAX_SERVER_NAME + 1] = { 0 };
-    memcpy_check(normalized_hostname, hostname_blob.data, hostname_blob.size);
+    POSIX_CHECKED_MEMCPY(normalized_hostname, hostname_blob.data, hostname_blob.size);
     struct s2n_blob normalized_name = { .data = (uint8_t *) normalized_hostname, .size = hostname_blob.size };
-    GUARD(s2n_blob_char_to_lower(&normalized_name));
+    POSIX_GUARD(s2n_blob_char_to_lower(&normalized_name));
     struct s2n_stuffer normalized_hostname_stuffer;
-    GUARD(s2n_stuffer_init(&normalized_hostname_stuffer, &normalized_name));
-    GUARD(s2n_stuffer_skip_write(&normalized_hostname_stuffer, normalized_name.size));
+    POSIX_GUARD(s2n_stuffer_init(&normalized_hostname_stuffer, &normalized_name));
+    POSIX_GUARD(s2n_stuffer_skip_write(&normalized_hostname_stuffer, normalized_name.size));
 
     /* Find the exact matches for the ServerName */
-    GUARD(s2n_find_cert_matches(conn->config->domain_name_to_cert_map,
+    POSIX_GUARD(s2n_find_cert_matches(conn->config->domain_name_to_cert_map,
                 &normalized_name,
                 conn->handshake_params.exact_sni_matches,
                 &(conn->handshake_params.exact_sni_match_exists)));
@@ -285,8 +285,8 @@ int s2n_conn_find_name_matching_certs(struct s2n_connection *conn)
         char wildcard_hostname[S2N_MAX_SERVER_NAME + 1] = { 0 };
         struct s2n_blob wildcard_blob = { .data = (uint8_t *) wildcard_hostname, .size = sizeof(wildcard_hostname) };
         struct s2n_stuffer wildcard_stuffer;
-        GUARD(s2n_stuffer_init(&wildcard_stuffer, &wildcard_blob));
-        GUARD(s2n_create_wildcard_hostname(&normalized_hostname_stuffer, &wildcard_stuffer));
+        POSIX_GUARD(s2n_stuffer_init(&wildcard_stuffer, &wildcard_blob));
+        POSIX_GUARD(s2n_create_wildcard_hostname(&normalized_hostname_stuffer, &wildcard_stuffer));
         const uint32_t wildcard_len = s2n_stuffer_data_available(&wildcard_stuffer);
 
         /* Couldn't create a valid wildcard from the input */
@@ -296,7 +296,7 @@ int s2n_conn_find_name_matching_certs(struct s2n_connection *conn)
 
         /* The client's SNI is wildcardified, do an exact match against the set of server certs. */
         wildcard_blob.size = wildcard_len;
-        GUARD(s2n_find_cert_matches(conn->config->domain_name_to_cert_map,
+        POSIX_GUARD(s2n_find_cert_matches(conn->config->domain_name_to_cert_map,
                     &wildcard_blob,
                     conn->handshake_params.wc_sni_matches,
                     &(conn->handshake_params.wc_sni_match_exists)));

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -52,13 +52,13 @@ struct s2n_handshake_action {
 static int s2n_always_fail_send(struct s2n_connection *conn)
 {
     /* This state should never be sending a handshake message. */
-    S2N_ERROR(S2N_ERR_HANDSHAKE_UNREACHABLE);
+    POSIX_BAIL(S2N_ERR_HANDSHAKE_UNREACHABLE);
 }
 
 static int s2n_always_fail_recv(struct s2n_connection *conn)
 {
     /* This state should never have an incoming handshake message. */
-    S2N_ERROR(S2N_ERR_HANDSHAKE_UNREACHABLE);
+    POSIX_BAIL(S2N_ERR_HANDSHAKE_UNREACHABLE);
 }
 
 /* Client and Server handlers for each message type we support.  
@@ -574,7 +574,7 @@ static int s2n_advance_message(struct s2n_connection *conn)
     }
 
     /* Set TCP_QUICKACK to avoid artificial delay during the handshake */
-    GUARD(s2n_socket_quickack(conn));
+    POSIX_GUARD(s2n_socket_quickack(conn));
 
     /* If optimized io hasn't been enabled or if the caller started out with a corked socket,
      * we don't mess with it
@@ -592,7 +592,7 @@ static int s2n_advance_message(struct s2n_connection *conn)
     if (ACTIVE_STATE(conn).writer == this_mode) {
         if (s2n_connection_is_managed_corked(conn)) {
             /* Set TCP_CORK/NOPUSH */
-            GUARD(s2n_socket_write_cork(conn));
+            POSIX_GUARD(s2n_socket_write_cork(conn));
         }
 
         return 0;
@@ -601,7 +601,7 @@ static int s2n_advance_message(struct s2n_connection *conn)
     /* We're the new reader, or we reached the "B" writer stage indicating that
        we're at the application data stage  - uncork the data */
     if (s2n_connection_is_managed_corked(conn)) {
-        GUARD(s2n_socket_write_uncork(conn));
+        POSIX_GUARD(s2n_socket_write_uncork(conn));
     }
 
     return 0;
@@ -613,7 +613,7 @@ int s2n_generate_new_client_session_id(struct s2n_connection *conn)
         struct s2n_blob session_id = { .data = conn->session_id, .size = S2N_TLS_SESSION_ID_MAX_LEN };
 
         /* Generate a new session id */
-        GUARD_AS_POSIX(s2n_get_public_random_data(&session_id));
+        POSIX_GUARD_RESULT(s2n_get_public_random_data(&session_id));
         conn->session_id_len = S2N_TLS_SESSION_ID_MAX_LEN;
     }
 
@@ -623,9 +623,9 @@ int s2n_generate_new_client_session_id(struct s2n_connection *conn)
 /* Lets the server flag whether a HelloRetryRequest is needed while processing extensions */
 int s2n_set_hello_retry_required(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
-    ENSURE_POSIX(conn->actual_protocol_version >= S2N_TLS13, S2N_ERR_INVALID_HELLO_RETRY);
+    POSIX_ENSURE(conn->actual_protocol_version >= S2N_TLS13, S2N_ERR_INVALID_HELLO_RETRY);
     conn->handshake.handshake_type |= HELLO_RETRY_REQUEST;
 
     return S2N_SUCCESS;
@@ -642,7 +642,7 @@ bool s2n_is_hello_retry_handshake(struct s2n_connection *conn)
 }
 
 static S2N_RESULT s2n_conn_set_tls13_handshake_type(struct s2n_connection *conn) {
-    ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn);
 
     if (conn->handshake.handshake_type & HELLO_RETRY_REQUEST) {
         conn->handshake.handshake_type = HELLO_RETRY_REQUEST;
@@ -662,7 +662,7 @@ static S2N_RESULT s2n_conn_set_tls13_handshake_type(struct s2n_connection *conn)
     }
 
     s2n_cert_auth_type client_cert_auth_type;
-    GUARD_AS_RESULT(s2n_connection_get_client_auth_type(conn, &client_cert_auth_type));
+    RESULT_GUARD_POSIX(s2n_connection_get_client_auth_type(conn, &client_cert_auth_type));
 
     if (conn->mode == S2N_CLIENT && client_cert_auth_type == S2N_CERT_AUTH_REQUIRED
             && conn->handshake.handshake_type & FULL_HANDSHAKE) {
@@ -686,7 +686,7 @@ static S2N_RESULT s2n_conn_set_tls13_handshake_type(struct s2n_connection *conn)
 int s2n_conn_set_handshake_type(struct s2n_connection *conn)
 {
     if (IS_TLS13_HANDSHAKE(conn)) {
-        GUARD_AS_POSIX(s2n_conn_set_tls13_handshake_type(conn));
+        POSIX_GUARD_RESULT(s2n_conn_set_tls13_handshake_type(conn));
         return S2N_SUCCESS;
     }
 
@@ -696,7 +696,7 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
     conn->handshake.handshake_type = NEGOTIATED;
 
     s2n_cert_auth_type client_cert_auth_type;
-    GUARD(s2n_connection_get_client_auth_type(conn, &client_cert_auth_type));
+    POSIX_GUARD(s2n_connection_get_client_auth_type(conn, &client_cert_auth_type));
 
     if (conn->mode == S2N_CLIENT && client_cert_auth_type == S2N_CERT_AUTH_REQUIRED) {
         /* If we're a client, and Client Auth is REQUIRED, then the Client must expect the CLIENT_CERT_REQ Message */
@@ -741,13 +741,13 @@ skip_cache_lookup:
     }
 
     /* If we're doing full handshake, generate a new session id. */
-    GUARD(s2n_generate_new_client_session_id(conn));
+    POSIX_GUARD(s2n_generate_new_client_session_id(conn));
 
     /* If we get this far, it's a full handshake */
     conn->handshake.handshake_type |= FULL_HANDSHAKE;
 
     bool is_ephemeral = false;
-    GUARD_AS_POSIX(s2n_kex_is_ephemeral(conn->secure.cipher_suite->key_exchange_alg, &is_ephemeral));
+    POSIX_GUARD_RESULT(s2n_kex_is_ephemeral(conn->secure.cipher_suite->key_exchange_alg, &is_ephemeral));
     if (is_ephemeral) {
         conn->handshake.handshake_type |= TLS12_PERFECT_FORWARD_SECRECY;
     }
@@ -762,7 +762,7 @@ skip_cache_lookup:
 int s2n_conn_set_handshake_no_client_cert(struct s2n_connection *conn)
 {
     s2n_cert_auth_type client_cert_auth_type;
-    GUARD(s2n_connection_get_client_auth_type(conn, &client_cert_auth_type));
+    POSIX_GUARD(s2n_connection_get_client_auth_type(conn, &client_cert_auth_type));
     S2N_ERROR_IF(client_cert_auth_type != S2N_CERT_AUTH_OPTIONAL, S2N_ERR_BAD_MESSAGE);
 
     conn->handshake.handshake_type |= NO_CLIENT_CERT;
@@ -772,7 +772,7 @@ int s2n_conn_set_handshake_no_client_cert(struct s2n_connection *conn)
 
 int s2n_conn_set_handshake_read_block(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     conn->handshake.paused = 1;
 
@@ -781,7 +781,7 @@ int s2n_conn_set_handshake_read_block(struct s2n_connection *conn)
 
 int s2n_conn_clear_handshake_read_block(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     conn->handshake.paused = 0;
 
@@ -790,14 +790,14 @@ int s2n_conn_clear_handshake_read_block(struct s2n_connection *conn)
 
 const char *s2n_connection_get_last_message_name(struct s2n_connection *conn)
 {
-    notnull_check_ptr(conn);
+    PTR_ENSURE_REF(conn);
 
     return message_names[ACTIVE_MESSAGE(conn)];
 }
 
 const char *s2n_connection_get_handshake_type_name(struct s2n_connection *conn)
 {
-    notnull_check_ptr(conn);
+    PTR_ENSURE_REF(conn);
 
     int handshake_type = conn->handshake.handshake_type;
 
@@ -842,11 +842,11 @@ static int s2n_handshake_write_io(struct s2n_connection *conn)
      */
     if (s2n_stuffer_is_wiped(&conn->handshake.io)) {
         if (record_type == TLS_HANDSHAKE) {
-            GUARD(s2n_handshake_write_header(&conn->handshake.io, ACTIVE_STATE(conn).message_type));
+            POSIX_GUARD(s2n_handshake_write_header(&conn->handshake.io, ACTIVE_STATE(conn).message_type));
         }
-        GUARD(ACTIVE_STATE(conn).handler[conn->mode] (conn));
+        POSIX_GUARD(ACTIVE_STATE(conn).handler[conn->mode] (conn));
         if (record_type == TLS_HANDSHAKE) {
-            GUARD(s2n_handshake_finish_header(&conn->handshake.io));
+            POSIX_GUARD(s2n_handshake_finish_header(&conn->handshake.io));
         }
     }
 
@@ -854,36 +854,36 @@ static int s2n_handshake_write_io(struct s2n_connection *conn)
     struct s2n_blob out = {0};
     while (s2n_stuffer_data_available(&conn->handshake.io) > 0) {
         uint16_t max_payload_size = 0;
-        GUARD_AS_POSIX(s2n_record_max_write_payload_size(conn, &max_payload_size));
+        POSIX_GUARD_RESULT(s2n_record_max_write_payload_size(conn, &max_payload_size));
         out.size = MIN(s2n_stuffer_data_available(&conn->handshake.io), max_payload_size);
 
         out.data = s2n_stuffer_raw_read(&conn->handshake.io, out.size);
-        notnull_check(out.data);
+        POSIX_ENSURE_REF(out.data);
 
         if (conn->config->quic_enabled) {
-            GUARD_AS_POSIX(s2n_quic_write_handshake_message(conn, &out));
+            POSIX_GUARD_RESULT(s2n_quic_write_handshake_message(conn, &out));
         } else {
-            GUARD(s2n_record_write(conn, record_type, &out));
+            POSIX_GUARD(s2n_record_write(conn, record_type, &out));
         }
 
         /* MD5 and SHA sum the handshake data too */
         if (record_type == TLS_HANDSHAKE) {
-            GUARD(s2n_conn_update_handshake_hashes(conn, &out));
+            POSIX_GUARD(s2n_conn_update_handshake_hashes(conn, &out));
         }
 
         /* Actually send the record. We could block here. Assume the caller will call flush before coming back. */
-        GUARD(s2n_flush(conn, &blocked));
+        POSIX_GUARD(s2n_flush(conn, &blocked));
     }
 
     /* We're done sending the last record, reset everything */
-    GUARD(s2n_stuffer_wipe(&conn->out));
-    GUARD(s2n_stuffer_wipe(&conn->handshake.io));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->out));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
 
     /* Update the secrets, if necessary */
-    GUARD(s2n_tls13_handle_secrets(conn));
+    POSIX_GUARD(s2n_tls13_handle_secrets(conn));
 
     /* Advance the state machine */
-    GUARD(s2n_advance_message(conn));
+    POSIX_GUARD(s2n_advance_message(conn));
 
     return 0;
 }
@@ -902,16 +902,16 @@ static int s2n_read_full_handshake_message(struct s2n_connection *conn, uint8_t 
          * what we can and then continue to the next record read iteration.
          */
         if (s2n_stuffer_data_available(&conn->in) < (TLS_HANDSHAKE_HEADER_LENGTH - current_handshake_data)) {
-            GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, s2n_stuffer_data_available(&conn->in)));
+            POSIX_GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, s2n_stuffer_data_available(&conn->in)));
             return 1;
         }
 
         /* Get the remainder of the header */
-        GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, (TLS_HANDSHAKE_HEADER_LENGTH - current_handshake_data)));
+        POSIX_GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, (TLS_HANDSHAKE_HEADER_LENGTH - current_handshake_data)));
     }
 
     uint32_t handshake_message_length;
-    GUARD(s2n_handshake_parse_header(conn, message_type, &handshake_message_length));
+    POSIX_GUARD(s2n_handshake_parse_header(conn, message_type, &handshake_message_length));
 
     S2N_ERROR_IF(handshake_message_length > S2N_MAXIMUM_HANDSHAKE_MESSAGE_LENGTH, S2N_ERR_BAD_MESSAGE);
 
@@ -919,7 +919,7 @@ static int s2n_read_full_handshake_message(struct s2n_connection *conn, uint8_t 
     bytes_to_take = MIN(bytes_to_take, s2n_stuffer_data_available(&conn->in));
 
     /* If the record is handshake data, add it to the handshake buffer */
-    GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, bytes_to_take));
+    POSIX_GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, bytes_to_take));
 
     /* If we have the whole handshake message, then success */
     if (s2n_stuffer_data_available(&conn->handshake.io) == handshake_message_length) {
@@ -927,7 +927,7 @@ static int s2n_read_full_handshake_message(struct s2n_connection *conn, uint8_t 
     }
 
     /* We don't have the whole message, so we'll need to go again */
-    GUARD(s2n_stuffer_reread(&conn->handshake.io));
+    POSIX_GUARD(s2n_stuffer_reread(&conn->handshake.io));
 
     return 1;
 }
@@ -937,16 +937,16 @@ static int s2n_handshake_conn_update_hashes(struct s2n_connection *conn)
     uint8_t message_type;
     uint32_t handshake_message_length;
 
-    GUARD(s2n_stuffer_reread(&conn->handshake.io));
-    GUARD(s2n_handshake_parse_header(conn, &message_type, &handshake_message_length));
+    POSIX_GUARD(s2n_stuffer_reread(&conn->handshake.io));
+    POSIX_GUARD(s2n_handshake_parse_header(conn, &message_type, &handshake_message_length));
 
     struct s2n_blob handshake_record = {0};
     handshake_record.data = conn->handshake.io.blob.data;
     handshake_record.size = TLS_HANDSHAKE_HEADER_LENGTH + handshake_message_length;
-    notnull_check(handshake_record.data);
+    POSIX_ENSURE_REF(handshake_record.data);
 
     /* MD5 and SHA sum the handshake data too */
-    GUARD(s2n_conn_update_handshake_hashes(conn, &handshake_record));
+    POSIX_GUARD(s2n_conn_update_handshake_hashes(conn, &handshake_record));
 
     return 0;
 }
@@ -957,23 +957,23 @@ static int s2n_handshake_handle_sslv2(struct s2n_connection *conn)
 
     /* Add the message to our handshake hashes */
     struct s2n_blob hashed = {.data = conn->header_in.blob.data + 2,.size = 3 };
-    GUARD(s2n_conn_update_handshake_hashes(conn, &hashed));
+    POSIX_GUARD(s2n_conn_update_handshake_hashes(conn, &hashed));
 
     hashed.data = conn->in.blob.data;
     hashed.size = s2n_stuffer_data_available(&conn->in);
-    GUARD(s2n_conn_update_handshake_hashes(conn, &hashed));
+    POSIX_GUARD(s2n_conn_update_handshake_hashes(conn, &hashed));
 
     /* Handle an SSLv2 client hello */
-    GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, s2n_stuffer_data_available(&conn->in)));
+    POSIX_GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, s2n_stuffer_data_available(&conn->in)));
     /* Set the client hello version */
     conn->client_hello_version = S2N_SSLv2;
     /* Execute the state machine handler */
     int r = ACTIVE_STATE(conn).handler[conn->mode](conn);
-    GUARD(s2n_stuffer_wipe(&conn->handshake.io));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
 
     /* We're done with the record, wipe it */
-    GUARD(s2n_stuffer_wipe(&conn->header_in));
-    GUARD(s2n_stuffer_wipe(&conn->in));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
     if (r < 0) {
         /* Don't invoke blinding on some of the common errors */
         switch (s2n_errno) {
@@ -988,7 +988,7 @@ static int s2n_handshake_handle_sslv2(struct s2n_connection *conn)
                 S2N_ERROR_PRESERVE_ERRNO();
                 break;
             default:
-                GUARD(s2n_connection_kill(conn));
+                POSIX_GUARD(s2n_connection_kill(conn));
         }
 
         return r;
@@ -997,14 +997,14 @@ static int s2n_handshake_handle_sslv2(struct s2n_connection *conn)
     conn->in_status = ENCRYPTED;
 
     /* Advance the state machine */
-    GUARD(s2n_advance_message(conn));
+    POSIX_GUARD(s2n_advance_message(conn));
 
     return 0;
 }
 
 static int s2n_try_delete_session_cache(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     if (s2n_allowed_to_cache_connection(conn) > 0) {
         conn->config->cache_delete(conn, conn->config->cache_delete_data, conn->session_id, conn->session_id_len);
@@ -1030,14 +1030,14 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
      * If using TCP, read a record. If using QUIC, read a message. */
     if (conn->config->quic_enabled) {
         record_type = TLS_HANDSHAKE;
-        GUARD_AS_POSIX(s2n_quic_read_handshake_message(conn, &message_type));
+        POSIX_GUARD_RESULT(s2n_quic_read_handshake_message(conn, &message_type));
     } else {
-        GUARD(s2n_read_full_record(conn, &record_type, &isSSLv2));
+        POSIX_GUARD(s2n_read_full_record(conn, &record_type, &isSSLv2));
     }
 
     if (isSSLv2) {
         S2N_ERROR_IF(record_type != SSLv2_CLIENT_HELLO, S2N_ERR_BAD_MESSAGE);
-        GUARD(s2n_handshake_handle_sslv2(conn));
+        POSIX_GUARD(s2n_handshake_handle_sslv2(conn));
     }
 
     /* Now we have a record, but it could be a partial fragment of a message, or it might
@@ -1050,37 +1050,37 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
          * However, when operating in QUIC mode, S2N should not accept ANY CCS messages,
          * including these unexpected ones.*/
         if (!IS_TLS13_HANDSHAKE(conn) || conn->config->quic_enabled) {
-            ENSURE_POSIX(EXPECTED_RECORD_TYPE(conn) == TLS_CHANGE_CIPHER_SPEC, S2N_ERR_BAD_MESSAGE);
-            ENSURE_POSIX(!CONNECTION_IS_WRITER(conn), S2N_ERR_BAD_MESSAGE);
+            POSIX_ENSURE(EXPECTED_RECORD_TYPE(conn) == TLS_CHANGE_CIPHER_SPEC, S2N_ERR_BAD_MESSAGE);
+            POSIX_ENSURE(!CONNECTION_IS_WRITER(conn), S2N_ERR_BAD_MESSAGE);
         }
 
         S2N_ERROR_IF(s2n_stuffer_data_available(&conn->in) != 1, S2N_ERR_BAD_MESSAGE);
 
-        GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, s2n_stuffer_data_available(&conn->in)));
-        GUARD(CCS_STATE(conn).handler[conn->mode] (conn));
-        GUARD(s2n_stuffer_wipe(&conn->handshake.io));
+        POSIX_GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, s2n_stuffer_data_available(&conn->in)));
+        POSIX_GUARD(CCS_STATE(conn).handler[conn->mode] (conn));
+        POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
 
         /* We're done with the record, wipe it */
-        GUARD(s2n_stuffer_wipe(&conn->header_in));
-        GUARD(s2n_stuffer_wipe(&conn->in));
+        POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
+        POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
         conn->in_status = ENCRYPTED;
 
         /* Advance the state machine if this was an expected message */
         if (EXPECTED_RECORD_TYPE(conn) == TLS_CHANGE_CIPHER_SPEC && !CONNECTION_IS_WRITER(conn)) {
-            GUARD(s2n_advance_message(conn));
+            POSIX_GUARD(s2n_advance_message(conn));
         }
 
         return 0;
     } else if (record_type != TLS_HANDSHAKE) {
         if (record_type == TLS_ALERT) {
-            GUARD(s2n_process_alert_fragment(conn));
+            POSIX_GUARD(s2n_process_alert_fragment(conn));
         }
 
         /* Ignore record types that we don't support */
 
         /* We're done with the record, wipe it */
-        GUARD(s2n_stuffer_wipe(&conn->header_in));
-        GUARD(s2n_stuffer_wipe(&conn->in));
+        POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
+        POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
         conn->in_status = ENCRYPTED;
         return 0;
     }
@@ -1092,28 +1092,28 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
         /* We're done with negotiating but we have trailing data in this record. Bail on the handshake. */
         S2N_ERROR_IF(EXPECTED_RECORD_TYPE(conn) == TLS_APPLICATION_DATA, S2N_ERR_BAD_MESSAGE);
         int r;
-        GUARD((r = s2n_read_full_handshake_message(conn, &message_type)));
+        POSIX_GUARD((r = s2n_read_full_handshake_message(conn, &message_type)));
 
         /* Do we need more data? This happens for message fragmentation */
         if (r == 1) {
             /* Break out of this inner loop, but since we're not changing the state, the
              * outer loop in s2n_handshake_io() will read another record.
              */
-            GUARD(s2n_stuffer_wipe(&conn->header_in));
-            GUARD(s2n_stuffer_wipe(&conn->in));
+            POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
+            POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
             conn->in_status = ENCRYPTED;
             return 0;
         }
 
         s2n_cert_auth_type client_cert_auth_type;
-        GUARD(s2n_connection_get_client_auth_type(conn, &client_cert_auth_type));
+        POSIX_GUARD(s2n_connection_get_client_auth_type(conn, &client_cert_auth_type));
 
         /* If we're a Client, and received a ClientCertRequest message, and ClientAuth
          * is set to optional, then switch the State Machine that we're using to expect the ClientCertRequest. */
         if (conn->mode == S2N_CLIENT
                 && client_cert_auth_type == S2N_CERT_AUTH_OPTIONAL
                 && message_type == TLS_CERT_REQ) {
-            ENSURE_POSIX(conn->handshake.handshake_type & FULL_HANDSHAKE, S2N_ERR_HANDSHAKE_STATE);
+            POSIX_ENSURE(conn->handshake.handshake_type & FULL_HANDSHAKE, S2N_ERR_HANDSHAKE_STATE);
             conn->handshake.handshake_type |= CLIENT_AUTH;
         }
 
@@ -1125,18 +1125,18 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
             conn->handshake.handshake_type &= ~OCSP_STATUS;
         }
 
-        ENSURE_POSIX(record_type == EXPECTED_RECORD_TYPE(conn), S2N_ERR_BAD_MESSAGE);
-        ENSURE_POSIX(message_type == EXPECTED_MESSAGE_TYPE(conn), S2N_ERR_BAD_MESSAGE);
-        ENSURE_POSIX(!CONNECTION_IS_WRITER(conn), S2N_ERR_BAD_MESSAGE);
+        POSIX_ENSURE(record_type == EXPECTED_RECORD_TYPE(conn), S2N_ERR_BAD_MESSAGE);
+        POSIX_ENSURE(message_type == EXPECTED_MESSAGE_TYPE(conn), S2N_ERR_BAD_MESSAGE);
+        POSIX_ENSURE(!CONNECTION_IS_WRITER(conn), S2N_ERR_BAD_MESSAGE);
 
         /* Call the relevant handler */
         r = ACTIVE_STATE(conn).handler[conn->mode] (conn);
 
         /* Don't update handshake hashes until after the handler has executed since some handlers need to read the
          * hash values before they are updated. */
-        GUARD(s2n_handshake_conn_update_hashes(conn));
+        POSIX_GUARD(s2n_handshake_conn_update_hashes(conn));
 
-        GUARD(s2n_stuffer_wipe(&conn->handshake.io));
+        POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
 
         if (r < 0) {
             /* Don't invoke blinding on some of the common errors */
@@ -1152,22 +1152,22 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
                     S2N_ERROR_PRESERVE_ERRNO();
                     break;
                 default:
-                    GUARD(s2n_connection_kill(conn));
+                    POSIX_GUARD(s2n_connection_kill(conn));
             }
 
             return r;
         }
 
         /* Update the secrets, if necessary */
-        GUARD(s2n_tls13_handle_secrets(conn));
+        POSIX_GUARD(s2n_tls13_handle_secrets(conn));
 
         /* Advance the state machine */
-        GUARD(s2n_advance_message(conn));
+        POSIX_GUARD(s2n_advance_message(conn));
     }
 
     /* We're done with the record, wipe it */
-    GUARD(s2n_stuffer_wipe(&conn->header_in));
-    GUARD(s2n_stuffer_wipe(&conn->in));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
     conn->in_status = ENCRYPTED;
 
     return 0;
@@ -1189,8 +1189,8 @@ static int s2n_handle_retry_state(struct s2n_connection *conn)
 
     if (!CONNECTION_IS_WRITER(conn)) {
         /* We're done parsing the record, reset everything */
-        GUARD(s2n_stuffer_wipe(&conn->header_in));
-        GUARD(s2n_stuffer_wipe(&conn->in));
+        POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
+        POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
         conn->in_status = ENCRYPTED;
     }
 
@@ -1200,7 +1200,7 @@ static int s2n_handle_retry_state(struct s2n_connection *conn)
             s2n_try_delete_session_cache(conn);
         }
 
-        GUARD(s2n_connection_kill(conn));
+        POSIX_GUARD(s2n_connection_kill(conn));
         S2N_ERROR_PRESERVE_ERRNO();
     }
 
@@ -1208,12 +1208,12 @@ static int s2n_handle_retry_state(struct s2n_connection *conn)
         /* If we're the writer and handler just finished, update the record header if
          * needed and let the s2n_handshake_write_io write the data to the socket */
         if (EXPECTED_RECORD_TYPE(conn) == TLS_HANDSHAKE) {
-            GUARD(s2n_handshake_finish_header(&conn->handshake.io));
+            POSIX_GUARD(s2n_handshake_finish_header(&conn->handshake.io));
         }
     } else {
         /* The read handler processed the record successfully, we are done with this
          * record. Advance the state machine. */
-        GUARD(s2n_advance_message(conn));
+        POSIX_GUARD(s2n_advance_message(conn));
     }
 
     return 0;
@@ -1221,20 +1221,20 @@ static int s2n_handle_retry_state(struct s2n_connection *conn)
 
 int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
 {
-    notnull_check(conn);
-    notnull_check(blocked);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(blocked);
 
     while (ACTIVE_STATE(conn).writer != 'B') {
         errno = 0;
         s2n_errno = S2N_ERR_OK;
 
         /* Flush any pending I/O or alert messages */
-        GUARD(s2n_flush(conn, blocked));
+        POSIX_GUARD(s2n_flush(conn, blocked));
 
         /* If the handshake was paused, retry the current message */
         if (conn->handshake.paused) {
             *blocked = S2N_BLOCKED_ON_APPLICATION_INPUT;
-            GUARD(s2n_handle_retry_state(conn));
+            POSIX_GUARD(s2n_handle_retry_state(conn));
         }
 
         if (CONNECTION_IS_WRITER(conn)) {
@@ -1287,10 +1287,10 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
 
         /* If the handshake has just ended, free up memory */
         if (ACTIVE_STATE(conn).writer == 'B') {
-            GUARD(s2n_stuffer_resize(&conn->handshake.io, 0));
+            POSIX_GUARD(s2n_stuffer_resize(&conn->handshake.io, 0));
 
             /* Send any pending post-handshake messages */
-            GUARD(s2n_post_handshake_send(conn, blocked));
+            POSIX_GUARD(s2n_post_handshake_send(conn, blocked));
         }
     }
 

--- a/tls/s2n_handshake_transcript.c
+++ b/tls/s2n_handshake_transcript.c
@@ -25,20 +25,20 @@
 #define MESSAGE_HASH_HEADER_LENGTH  4
 
 static int s2n_tls13_conn_copy_server_finished_hash(struct s2n_connection *conn) {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     s2n_tls13_connection_keys(keys, conn);
     struct s2n_hash_state hash_state = {0};
 
-    GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
-    GUARD(s2n_hash_copy(&conn->handshake.server_finished_copy, &hash_state));
+    POSIX_GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
+    POSIX_GUARD(s2n_hash_copy(&conn->handshake.server_finished_copy, &hash_state));
 
     return 0;
 }
 
 int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct s2n_blob *data)
 {
-    notnull_check(conn);
-    notnull_check(data);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(data);
 
     if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_MD5)) {
         /* The handshake MD5 hash state will fail the s2n_hash_is_available() check
@@ -47,11 +47,11 @@ int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct s2n_blo
          * PRF, which is required to comply with the TLS 1.0 and 1.1 RFCs and is approved
          * as per NIST Special Publication 800-52 Revision 1.
          */
-        GUARD(s2n_hash_update(&conn->handshake.md5, data->data, data->size));
+        POSIX_GUARD(s2n_hash_update(&conn->handshake.md5, data->data, data->size));
     }
 
     if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA1)) {
-        GUARD(s2n_hash_update(&conn->handshake.sha1, data->data, data->size));
+        POSIX_GUARD(s2n_hash_update(&conn->handshake.sha1, data->data, data->size));
     }
 
     const uint8_t md5_sha1_required = (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_MD5) &&
@@ -63,30 +63,30 @@ int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct s2n_blo
          * CertificateVerify message and the PRF. NIST SP 800-52r1 approves use
          * of MD5_SHA1 for these use cases (see footnotes 15 and 20, and section
          * 3.3.2) */
-        GUARD(s2n_hash_update(&conn->handshake.md5_sha1, data->data, data->size));
+        POSIX_GUARD(s2n_hash_update(&conn->handshake.md5_sha1, data->data, data->size));
     }
 
     if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA224)) {
-        GUARD(s2n_hash_update(&conn->handshake.sha224, data->data, data->size));
+        POSIX_GUARD(s2n_hash_update(&conn->handshake.sha224, data->data, data->size));
     }
 
     if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA256)) {
-        GUARD(s2n_hash_update(&conn->handshake.sha256, data->data, data->size));
+        POSIX_GUARD(s2n_hash_update(&conn->handshake.sha256, data->data, data->size));
     }
 
     if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA384)) {
-        GUARD(s2n_hash_update(&conn->handshake.sha384, data->data, data->size));
+        POSIX_GUARD(s2n_hash_update(&conn->handshake.sha384, data->data, data->size));
     }
 
     if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA512)) {
-        GUARD(s2n_hash_update(&conn->handshake.sha512, data->data, data->size));
+        POSIX_GUARD(s2n_hash_update(&conn->handshake.sha512, data->data, data->size));
     }
 
     /* Copy the CLIENT_HELLO -> SERVER_FINISHED hash.
      * TLS1.3 will need it later to calculate the application secrets. */
     if (s2n_connection_get_protocol_version(conn) >= S2N_TLS13 &&
             s2n_conn_get_current_message_type(conn) == SERVER_FINISHED) {
-        GUARD(s2n_tls13_conn_copy_server_finished_hash(conn));
+        POSIX_GUARD(s2n_tls13_conn_copy_server_finished_hash(conn));
     }
 
     return 0;
@@ -99,7 +99,7 @@ int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct s2n_blo
  */
 int s2n_server_hello_retry_recreate_transcript(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     s2n_tls13_connection_keys(keys, conn);
     uint8_t hash_digest_length = keys.size;
@@ -112,24 +112,24 @@ int s2n_server_hello_retry_recreate_transcript(struct s2n_connection *conn)
     /* Grab the current transcript hash to use as the ClientHello1 value. */
     struct s2n_hash_state hash_state, client_hello1_hash;
     uint8_t client_hello1_digest_out[S2N_MAX_DIGEST_LEN];
-    GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
+    POSIX_GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
 
-    GUARD(s2n_hash_new(&client_hello1_hash));
-    GUARD(s2n_hash_copy(&client_hello1_hash, &hash_state));
-    GUARD(s2n_hash_digest(&client_hello1_hash, client_hello1_digest_out, hash_digest_length));
-    GUARD(s2n_hash_free(&client_hello1_hash));
+    POSIX_GUARD(s2n_hash_new(&client_hello1_hash));
+    POSIX_GUARD(s2n_hash_copy(&client_hello1_hash, &hash_state));
+    POSIX_GUARD(s2n_hash_digest(&client_hello1_hash, client_hello1_digest_out, hash_digest_length));
+    POSIX_GUARD(s2n_hash_free(&client_hello1_hash));
 
     /* Step 1: Reset the hash state */
-    GUARD(s2n_handshake_reset_hash_state(conn, keys.hash_algorithm));
+    POSIX_GUARD(s2n_handshake_reset_hash_state(conn, keys.hash_algorithm));
 
     /* Step 2: Update the transcript with the synthetic message */
     struct s2n_blob msg_blob = {0};
-    GUARD(s2n_blob_init(&msg_blob, msghdr, MESSAGE_HASH_HEADER_LENGTH));
-    GUARD(s2n_conn_update_handshake_hashes(conn, &msg_blob));
+    POSIX_GUARD(s2n_blob_init(&msg_blob, msghdr, MESSAGE_HASH_HEADER_LENGTH));
+    POSIX_GUARD(s2n_conn_update_handshake_hashes(conn, &msg_blob));
 
     /* Step 3: Update the transcript with the ClientHello1 hash */
-    GUARD(s2n_blob_init(&msg_blob, client_hello1_digest_out, hash_digest_length));
-    GUARD(s2n_conn_update_handshake_hashes(conn, &msg_blob));
+    POSIX_GUARD(s2n_blob_init(&msg_blob, client_hello1_digest_out, hash_digest_length));
+    POSIX_GUARD(s2n_conn_update_handshake_hashes(conn, &msg_blob));
 
     return 0;
 }

--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -26,9 +26,9 @@
 
 static S2N_RESULT s2n_check_rsa_key(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn, bool *is_supported)
 {
-    ENSURE_REF(cipher_suite);
-    ENSURE_REF(conn);
-    ENSURE_REF(is_supported);
+    RESULT_ENSURE_REF(cipher_suite);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(is_supported);
 
     *is_supported = s2n_get_compatible_cert_chain_and_key(conn, S2N_PKEY_TYPE_RSA) != NULL;
 
@@ -37,10 +37,10 @@ static S2N_RESULT s2n_check_rsa_key(const struct s2n_cipher_suite *cipher_suite,
 
 static S2N_RESULT s2n_check_dhe(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn, bool *is_supported)
 {
-    ENSURE_REF(cipher_suite);
-    ENSURE_REF(conn);
-    ENSURE_REF(conn->config);
-    ENSURE_REF(is_supported);
+    RESULT_ENSURE_REF(cipher_suite);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn->config);
+    RESULT_ENSURE_REF(is_supported);
 
     *is_supported = conn->config->dhparams != NULL;
 
@@ -49,9 +49,9 @@ static S2N_RESULT s2n_check_dhe(const struct s2n_cipher_suite *cipher_suite, str
 
 static S2N_RESULT s2n_check_ecdhe(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn, bool *is_supported)
 {
-    ENSURE_REF(cipher_suite);
-    ENSURE_REF(conn);
-    ENSURE_REF(is_supported);
+    RESULT_ENSURE_REF(cipher_suite);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(is_supported);
 
     *is_supported = conn->secure.server_ecc_evp_params.negotiated_curve != NULL;
 
@@ -60,16 +60,16 @@ static S2N_RESULT s2n_check_ecdhe(const struct s2n_cipher_suite *cipher_suite, s
 
 static S2N_RESULT s2n_check_kem(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn, bool *is_supported)
 {
-    ENSURE_REF(cipher_suite);
-    ENSURE_REF(conn);
-    ENSURE_REF(is_supported);
+    RESULT_ENSURE_REF(cipher_suite);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(is_supported);
 
     /* If any of the necessary conditions are not met, we will return early and indicate KEM is not supported. */
     *is_supported = false;
 
     const struct s2n_kem_preferences *kem_preferences = NULL;
-    GUARD_AS_RESULT(s2n_connection_get_kem_preferences(conn, &kem_preferences));
-    ENSURE_REF(kem_preferences);
+    RESULT_GUARD_POSIX(s2n_connection_get_kem_preferences(conn, &kem_preferences));
+    RESULT_ENSURE_REF(kem_preferences);
 
     if (!s2n_pq_is_enabled() || kem_preferences->kem_count == 0) {
         return S2N_RESULT_OK;
@@ -80,7 +80,7 @@ static S2N_RESULT s2n_check_kem(const struct s2n_cipher_suite *cipher_suite, str
         return S2N_RESULT_OK;
     }
 
-    ENSURE_REF(supported_params);
+    RESULT_ENSURE_REF(supported_params);
     if (supported_params->kem_count == 0) {
         return S2N_RESULT_OK;
     }
@@ -107,24 +107,24 @@ static S2N_RESULT s2n_check_kem(const struct s2n_cipher_suite *cipher_suite, str
 
 static S2N_RESULT s2n_configure_kem(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)
 {
-    ENSURE_REF(cipher_suite);
-    ENSURE_REF(conn);
+    RESULT_ENSURE_REF(cipher_suite);
+    RESULT_ENSURE_REF(conn);
 
-    ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
+    RESULT_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 
     const struct s2n_kem_preferences *kem_preferences = NULL;
-    GUARD_AS_RESULT(s2n_connection_get_kem_preferences(conn, &kem_preferences));
-    ENSURE_REF(kem_preferences);
+    RESULT_GUARD_POSIX(s2n_connection_get_kem_preferences(conn, &kem_preferences));
+    RESULT_ENSURE_REF(kem_preferences);
 
     struct s2n_blob *proposed_kems = &(conn->secure.client_pq_kem_extension);
     const struct s2n_kem *chosen_kem = NULL;
     if (proposed_kems == NULL || proposed_kems->data == NULL) {
         /* If the client did not send a PQ KEM extension, then the server can pick its preferred parameter */
-        GUARD_AS_RESULT(s2n_choose_kem_without_peer_pref_list(cipher_suite->iana_value, kem_preferences->kems,
+        RESULT_GUARD_POSIX(s2n_choose_kem_without_peer_pref_list(cipher_suite->iana_value, kem_preferences->kems,
                 kem_preferences->kem_count, &chosen_kem));
     } else {
         /* If the client did send a PQ KEM extension, then the server must find a mutually supported parameter. */
-        GUARD_AS_RESULT(s2n_choose_kem_with_peer_pref_list(cipher_suite->iana_value, proposed_kems, kem_preferences->kems,
+        RESULT_GUARD_POSIX(s2n_choose_kem_with_peer_pref_list(cipher_suite->iana_value, proposed_kems, kem_preferences->kems,
                 kem_preferences->kem_count, &chosen_kem));
     }
 
@@ -139,14 +139,14 @@ static S2N_RESULT s2n_no_op_configure(const struct s2n_cipher_suite *cipher_suit
 
 static S2N_RESULT s2n_check_hybrid_ecdhe_kem(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn, bool *is_supported)
 {
-    ENSURE_REF(cipher_suite);
-    ENSURE_REF(conn);
-    ENSURE_REF(is_supported);
+    RESULT_ENSURE_REF(cipher_suite);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(is_supported);
 
     bool ecdhe_supported = false;
     bool kem_supported = false;
-    GUARD_RESULT(s2n_check_ecdhe(cipher_suite, conn, &ecdhe_supported));
-    GUARD_RESULT(s2n_check_kem(cipher_suite, conn, &kem_supported));
+    RESULT_GUARD(s2n_check_ecdhe(cipher_suite, conn, &ecdhe_supported));
+    RESULT_GUARD(s2n_check_kem(cipher_suite, conn, &kem_supported));
 
     *is_supported = ecdhe_supported && kem_supported;
 
@@ -215,33 +215,33 @@ const struct s2n_kex s2n_hybrid_ecdhe_kem = {
 
 S2N_RESULT s2n_kex_supported(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn, bool *is_supported)
 {
-    ENSURE_REF(cipher_suite);
-    ENSURE_REF(cipher_suite->key_exchange_alg);
-    ENSURE_REF(cipher_suite->key_exchange_alg->connection_supported);
-    ENSURE_REF(conn);
-    ENSURE_REF(is_supported);
+    RESULT_ENSURE_REF(cipher_suite);
+    RESULT_ENSURE_REF(cipher_suite->key_exchange_alg);
+    RESULT_ENSURE_REF(cipher_suite->key_exchange_alg->connection_supported);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(is_supported);
 
-    GUARD_RESULT(cipher_suite->key_exchange_alg->connection_supported(cipher_suite, conn, is_supported));
+    RESULT_GUARD(cipher_suite->key_exchange_alg->connection_supported(cipher_suite, conn, is_supported));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_configure_kex(const struct s2n_cipher_suite *cipher_suite, struct s2n_connection *conn)
 {
-    ENSURE_REF(cipher_suite);
-    ENSURE_REF(cipher_suite->key_exchange_alg);
-    ENSURE_REF(cipher_suite->key_exchange_alg->configure_connection);
-    ENSURE_REF(conn);
+    RESULT_ENSURE_REF(cipher_suite);
+    RESULT_ENSURE_REF(cipher_suite->key_exchange_alg);
+    RESULT_ENSURE_REF(cipher_suite->key_exchange_alg->configure_connection);
+    RESULT_ENSURE_REF(conn);
 
-    GUARD_RESULT(cipher_suite->key_exchange_alg->configure_connection(cipher_suite, conn));
+    RESULT_GUARD(cipher_suite->key_exchange_alg->configure_connection(cipher_suite, conn));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_kex_is_ephemeral(const struct s2n_kex *kex, bool *is_ephemeral)
 {
-    ENSURE_REF(kex);
-    ENSURE_REF(is_ephemeral);
+    RESULT_ENSURE_REF(kex);
+    RESULT_ENSURE_REF(is_ephemeral);
 
     *is_ephemeral = kex->is_ephemeral;
 
@@ -250,12 +250,12 @@ S2N_RESULT s2n_kex_is_ephemeral(const struct s2n_kex *kex, bool *is_ephemeral)
 
 S2N_RESULT s2n_kex_server_key_recv_parse_data(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_kex_raw_server_data *raw_server_data)
 {
-    ENSURE_REF(kex);
-    ENSURE_REF(kex->server_key_recv_parse_data);
-    ENSURE_REF(conn);
-    ENSURE_REF(raw_server_data);
+    RESULT_ENSURE_REF(kex);
+    RESULT_ENSURE_REF(kex->server_key_recv_parse_data);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(raw_server_data);
 
-    GUARD_AS_RESULT(kex->server_key_recv_parse_data(conn, raw_server_data));
+    RESULT_GUARD_POSIX(kex->server_key_recv_parse_data(conn, raw_server_data));
 
     return S2N_RESULT_OK;
 }
@@ -263,60 +263,60 @@ S2N_RESULT s2n_kex_server_key_recv_parse_data(const struct s2n_kex *kex, struct 
 S2N_RESULT s2n_kex_server_key_recv_read_data(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_verify,
         struct s2n_kex_raw_server_data *raw_server_data)
 {
-    ENSURE_REF(kex);
-    ENSURE_REF(kex->server_key_recv_read_data);
-    ENSURE_REF(conn);
-    ENSURE_REF(data_to_verify);
+    RESULT_ENSURE_REF(kex);
+    RESULT_ENSURE_REF(kex->server_key_recv_read_data);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(data_to_verify);
 
-    GUARD_AS_RESULT(kex->server_key_recv_read_data(conn, data_to_verify, raw_server_data));
+    RESULT_GUARD_POSIX(kex->server_key_recv_read_data(conn, data_to_verify, raw_server_data));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_kex_server_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *data_to_sign)
 {
-    ENSURE_REF(kex);
-    ENSURE_REF(kex->server_key_send);
-    ENSURE_REF(conn);
-    ENSURE_REF(data_to_sign);
+    RESULT_ENSURE_REF(kex);
+    RESULT_ENSURE_REF(kex->server_key_send);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(data_to_sign);
 
-    GUARD_AS_RESULT(kex->server_key_send(conn, data_to_sign));
+    RESULT_GUARD_POSIX(kex->server_key_send(conn, data_to_sign));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_kex_client_key_recv(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key)
 {
-    ENSURE_REF(kex);
-    ENSURE_REF(kex->client_key_recv);
-    ENSURE_REF(conn);
-    ENSURE_REF(shared_key);
+    RESULT_ENSURE_REF(kex);
+    RESULT_ENSURE_REF(kex->client_key_recv);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(shared_key);
 
-    GUARD_AS_RESULT(kex->client_key_recv(conn, shared_key));
+    RESULT_GUARD_POSIX(kex->client_key_recv(conn, shared_key));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_kex_client_key_send(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key)
 {
-    ENSURE_REF(kex);
-    ENSURE_REF(kex->client_key_send);
-    ENSURE_REF(conn);
-    ENSURE_REF(shared_key);
+    RESULT_ENSURE_REF(kex);
+    RESULT_ENSURE_REF(kex->client_key_send);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(shared_key);
 
-    GUARD_AS_RESULT(kex->client_key_send(conn, shared_key));
+    RESULT_GUARD_POSIX(kex->client_key_send(conn, shared_key));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_kex_tls_prf(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *premaster_secret)
 {
-    ENSURE_REF(kex);
-    ENSURE_REF(kex->prf);
-    ENSURE_REF(conn);
-    ENSURE_REF(premaster_secret);
+    RESULT_ENSURE_REF(kex);
+    RESULT_ENSURE_REF(kex->prf);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(premaster_secret);
 
-    GUARD_AS_RESULT(kex->prf(conn, premaster_secret));
+    RESULT_GUARD_POSIX(kex->prf(conn, premaster_secret));
 
     return S2N_RESULT_OK;
 }

--- a/tls/s2n_key_log.c
+++ b/tls/s2n_key_log.c
@@ -52,8 +52,8 @@
 
 S2N_RESULT s2n_key_log_hex_encode(struct s2n_stuffer *output, uint8_t *bytes, size_t len)
 {
-    ENSURE_MUT(output);
-    ENSURE_REF(bytes);
+    RESULT_ENSURE_MUT(output);
+    RESULT_ENSURE_REF(bytes);
 
     const uint8_t chars[] = "0123456789abcdef";
 
@@ -61,8 +61,8 @@ S2N_RESULT s2n_key_log_hex_encode(struct s2n_stuffer *output, uint8_t *bytes, si
         uint8_t upper = bytes[i] >> 4;
         uint8_t lower = bytes[i] & 0x0f;
 
-        GUARD_AS_RESULT(s2n_stuffer_write_uint8(output, chars[upper]));
-        GUARD_AS_RESULT(s2n_stuffer_write_uint8(output, chars[lower]));
+        RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(output, chars[upper]));
+        RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(output, chars[lower]));
     }
 
     return S2N_RESULT_OK;
@@ -70,9 +70,9 @@ S2N_RESULT s2n_key_log_hex_encode(struct s2n_stuffer *output, uint8_t *bytes, si
 
 S2N_RESULT s2n_key_log_tls13_secret(struct s2n_connection *conn, struct s2n_blob *secret, s2n_secret_type_t secret_type)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(conn->config);
-    ENSURE_REF(secret);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn->config);
+    RESULT_ENSURE_REF(secret);
 
     /* only emit keys if the callback has been set */
     if (!conn->config->key_log_cb) {
@@ -121,15 +121,15 @@ S2N_RESULT s2n_key_log_tls13_secret(struct s2n_connection *conn, struct s2n_blob
         + secret->size * HEX_ENCODING_SIZE;
 
     DEFER_CLEANUP(struct s2n_stuffer output, s2n_stuffer_free);
-    GUARD_AS_RESULT(s2n_stuffer_alloc(&output, len));
+    RESULT_GUARD_POSIX(s2n_stuffer_alloc(&output, len));
 
-    GUARD_AS_RESULT(s2n_stuffer_write_bytes(&output, label, label_size));
-    GUARD_RESULT(s2n_key_log_hex_encode(&output, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
-    GUARD_AS_RESULT(s2n_stuffer_write_uint8(&output, ' '));
-    GUARD_RESULT(s2n_key_log_hex_encode(&output, secret->data, secret->size));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(&output, label, label_size));
+    RESULT_GUARD(s2n_key_log_hex_encode(&output, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(&output, ' '));
+    RESULT_GUARD(s2n_key_log_hex_encode(&output, secret->data, secret->size));
 
     uint8_t *data = s2n_stuffer_raw_read(&output, len);
-    ENSURE_REF(data);
+    RESULT_ENSURE_REF(data);
 
     conn->config->key_log_cb(conn->config->key_log_ctx, conn, data, len);
 
@@ -138,8 +138,8 @@ S2N_RESULT s2n_key_log_tls13_secret(struct s2n_connection *conn, struct s2n_blob
 
 S2N_RESULT s2n_key_log_tls12_secret(struct s2n_connection *conn)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(conn->config);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn->config);
 
     /* only emit keys if the callback has been set */
     if (!conn->config->key_log_cb) {
@@ -157,15 +157,15 @@ S2N_RESULT s2n_key_log_tls12_secret(struct s2n_connection *conn)
         + S2N_TLS_SECRET_LEN * HEX_ENCODING_SIZE;
 
     DEFER_CLEANUP(struct s2n_stuffer output, s2n_stuffer_free);
-    GUARD_AS_RESULT(s2n_stuffer_alloc(&output, len));
+    RESULT_GUARD_POSIX(s2n_stuffer_alloc(&output, len));
 
-    GUARD_AS_RESULT(s2n_stuffer_write_bytes(&output, label, label_size));
-    GUARD_RESULT(s2n_key_log_hex_encode(&output, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
-    GUARD_AS_RESULT(s2n_stuffer_write_uint8(&output, ' '));
-    GUARD_RESULT(s2n_key_log_hex_encode(&output, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(&output, label, label_size));
+    RESULT_GUARD(s2n_key_log_hex_encode(&output, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(&output, ' '));
+    RESULT_GUARD(s2n_key_log_hex_encode(&output, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
 
     uint8_t *data = s2n_stuffer_raw_read(&output, len);
-    ENSURE_REF(data);
+    RESULT_ENSURE_REF(data);
 
     conn->config->key_log_cb(conn->config->key_log_ctx, conn, data, len);
 

--- a/tls/s2n_key_update.c
+++ b/tls/s2n_key_update.c
@@ -31,20 +31,20 @@ int s2n_check_record_limit(struct s2n_connection *conn, struct s2n_blob *sequenc
 
 int s2n_key_update_recv(struct s2n_connection *conn, struct s2n_stuffer *request)
 {
-    notnull_check(conn);
-    ENSURE_POSIX(!conn->config->quic_enabled, S2N_ERR_BAD_MESSAGE);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE(!conn->config->quic_enabled, S2N_ERR_BAD_MESSAGE);
 
     uint8_t key_update_request;
-    GUARD(s2n_stuffer_read_uint8(request, &key_update_request));
+    POSIX_GUARD(s2n_stuffer_read_uint8(request, &key_update_request));
     S2N_ERROR_IF(key_update_request != S2N_KEY_UPDATE_NOT_REQUESTED && key_update_request != S2N_KEY_UPDATE_REQUESTED,
             S2N_ERR_BAD_MESSAGE);
     conn->key_update_pending = key_update_request;
 
     /* Update peer's key since a key_update was received */
     if (conn->mode == S2N_CLIENT){
-        GUARD(s2n_update_application_traffic_keys(conn, S2N_SERVER, RECEIVING));
+        POSIX_GUARD(s2n_update_application_traffic_keys(conn, S2N_SERVER, RECEIVING));
     } else {
-        GUARD(s2n_update_application_traffic_keys(conn, S2N_CLIENT, RECEIVING));
+        POSIX_GUARD(s2n_update_application_traffic_keys(conn, S2N_CLIENT, RECEIVING));
     }
 
     return S2N_SUCCESS;
@@ -52,33 +52,33 @@ int s2n_key_update_recv(struct s2n_connection *conn, struct s2n_stuffer *request
 
 int s2n_key_update_send(struct s2n_connection *conn, s2n_blocked_status *blocked) 
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     struct s2n_blob sequence_number = {0};
     if (conn->mode == S2N_CLIENT) {
-        GUARD(s2n_blob_init(&sequence_number, conn->secure.client_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
+        POSIX_GUARD(s2n_blob_init(&sequence_number, conn->secure.client_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
     } else {
-        GUARD(s2n_blob_init(&sequence_number, conn->secure.server_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
+        POSIX_GUARD(s2n_blob_init(&sequence_number, conn->secure.server_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
     }
 
-    GUARD(s2n_check_record_limit(conn, &sequence_number));
+    POSIX_GUARD(s2n_check_record_limit(conn, &sequence_number));
 
     if (conn->key_update_pending) {
         uint8_t key_update_data[S2N_KEY_UPDATE_MESSAGE_SIZE];
         struct s2n_blob key_update_blob = {0};
-        GUARD(s2n_blob_init(&key_update_blob, key_update_data, sizeof(key_update_data)));
+        POSIX_GUARD(s2n_blob_init(&key_update_blob, key_update_data, sizeof(key_update_data)));
 
         /* Write key update message */
-        GUARD(s2n_key_update_write(&key_update_blob));
+        POSIX_GUARD(s2n_key_update_write(&key_update_blob));
 
         /* Encrypt the message */
-        GUARD(s2n_record_write(conn, TLS_HANDSHAKE,  &key_update_blob));
+        POSIX_GUARD(s2n_record_write(conn, TLS_HANDSHAKE,  &key_update_blob));
 
         /* Update encryption key */
-        GUARD(s2n_update_application_traffic_keys(conn, conn->mode, SENDING));
+        POSIX_GUARD(s2n_update_application_traffic_keys(conn, conn->mode, SENDING));
         conn->key_update_pending = false;
 
-        GUARD(s2n_flush(conn, blocked));
+        POSIX_GUARD(s2n_flush(conn, blocked));
     }
 
     return S2N_SUCCESS;
@@ -86,28 +86,28 @@ int s2n_key_update_send(struct s2n_connection *conn, s2n_blocked_status *blocked
 
 int s2n_key_update_write(struct s2n_blob *out)
 {
-    notnull_check(out);
+    POSIX_ENSURE_REF(out);
 
     struct s2n_stuffer key_update_stuffer = {0};
-    GUARD(s2n_stuffer_init(&key_update_stuffer, out));
-    GUARD(s2n_stuffer_write_uint8(&key_update_stuffer, TLS_KEY_UPDATE));
-    GUARD(s2n_stuffer_write_uint24(&key_update_stuffer, S2N_KEY_UPDATE_LENGTH));
+    POSIX_GUARD(s2n_stuffer_init(&key_update_stuffer, out));
+    POSIX_GUARD(s2n_stuffer_write_uint8(&key_update_stuffer, TLS_KEY_UPDATE));
+    POSIX_GUARD(s2n_stuffer_write_uint24(&key_update_stuffer, S2N_KEY_UPDATE_LENGTH));
 
     /* s2n currently does not require peers to update their encryption keys. */
-    GUARD(s2n_stuffer_write_uint8(&key_update_stuffer, S2N_KEY_UPDATE_NOT_REQUESTED));
+    POSIX_GUARD(s2n_stuffer_write_uint8(&key_update_stuffer, S2N_KEY_UPDATE_NOT_REQUESTED));
 
     return S2N_SUCCESS;
 }
 
 int s2n_check_record_limit(struct s2n_connection *conn, struct s2n_blob *sequence_number)
 {
-    notnull_check(conn);
-    notnull_check(sequence_number);
-    notnull_check(conn->secure.cipher_suite);
-    notnull_check(conn->secure.cipher_suite->record_alg);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(sequence_number);
+    POSIX_ENSURE_REF(conn->secure.cipher_suite);
+    POSIX_ENSURE_REF(conn->secure.cipher_suite->record_alg);
 
     uint64_t output = 0;
-    GUARD(s2n_sequence_number_to_uint64(sequence_number, &output));
+    POSIX_GUARD(s2n_sequence_number_to_uint64(sequence_number, &output));
 
     if (output + 1 > conn->secure.cipher_suite->record_alg->encryption_limit) {
         conn->key_update_pending = true;

--- a/tls/s2n_ocsp_stapling.c
+++ b/tls/s2n_ocsp_stapling.c
@@ -28,7 +28,7 @@
 int s2n_server_status_send(struct s2n_connection *conn)
 {
     if (s2n_server_can_send_ocsp(conn)) {
-        GUARD(s2n_server_certificate_status_send(conn, &conn->handshake.io));
+        POSIX_GUARD(s2n_server_certificate_status_send(conn, &conn->handshake.io));
     }
 
     return 0;

--- a/tls/s2n_post_handshake.c
+++ b/tls/s2n_post_handshake.c
@@ -26,29 +26,29 @@
  */
 int s2n_post_handshake_recv(struct s2n_connection *conn) 
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     uint8_t post_handshake_id;
     uint32_t message_length;
     S2N_ERROR_IF(conn->actual_protocol_version != S2N_TLS13, S2N_ERR_BAD_MESSAGE);
 
     while(s2n_stuffer_data_available(&conn->in)) {
-        GUARD(s2n_stuffer_read_uint8(&conn->in, &post_handshake_id));
-        GUARD(s2n_stuffer_read_uint24(&conn->in, &message_length));
+        POSIX_GUARD(s2n_stuffer_read_uint8(&conn->in, &post_handshake_id));
+        POSIX_GUARD(s2n_stuffer_read_uint24(&conn->in, &message_length));
 
         struct s2n_blob post_handshake_blob = { 0 };
         uint8_t *message_data = s2n_stuffer_raw_read(&conn->in, message_length);
-        notnull_check(message_data);
-        GUARD(s2n_blob_init(&post_handshake_blob, message_data, message_length));
+        POSIX_ENSURE_REF(message_data);
+        POSIX_GUARD(s2n_blob_init(&post_handshake_blob, message_data, message_length));
 
         struct s2n_stuffer post_handshake_stuffer = { 0 };
-        GUARD(s2n_stuffer_init(&post_handshake_stuffer, &post_handshake_blob));
-        GUARD(s2n_stuffer_skip_write(&post_handshake_stuffer, message_length));
+        POSIX_GUARD(s2n_stuffer_init(&post_handshake_stuffer, &post_handshake_blob));
+        POSIX_GUARD(s2n_stuffer_skip_write(&post_handshake_stuffer, message_length));
 
         switch (post_handshake_id)
         {
             case TLS_KEY_UPDATE:
-                GUARD(s2n_key_update_recv(conn, &post_handshake_stuffer));
+                POSIX_GUARD(s2n_key_update_recv(conn, &post_handshake_stuffer));
                 break;
             default:
                 /* Ignore all other messages */
@@ -61,10 +61,10 @@ int s2n_post_handshake_recv(struct s2n_connection *conn)
 
 int s2n_post_handshake_send(struct s2n_connection *conn, s2n_blocked_status *blocked)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
-    GUARD(s2n_key_update_send(conn, blocked));
-    GUARD_AS_POSIX(s2n_tls13_server_nst_send(conn, blocked));
+    POSIX_GUARD(s2n_key_update_send(conn, blocked));
+    POSIX_GUARD_RESULT(s2n_tls13_server_nst_send(conn, blocked));
 
     return S2N_SUCCESS;
 }

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -28,9 +28,9 @@
 
 S2N_RESULT s2n_psk_init(struct s2n_psk *psk, s2n_psk_type type)
 {
-    ENSURE_MUT(psk);
+    RESULT_ENSURE_MUT(psk);
 
-    CHECKED_MEMSET(psk, 0, sizeof(struct s2n_psk));
+    RESULT_CHECKED_MEMSET(psk, 0, sizeof(struct s2n_psk));
     psk->hmac_alg = S2N_HMAC_SHA256;
     psk->type = type;
 
@@ -40,10 +40,10 @@ S2N_RESULT s2n_psk_init(struct s2n_psk *psk, s2n_psk_type type)
 struct s2n_psk* s2n_external_psk_new()
 {
     DEFER_CLEANUP(struct s2n_blob mem = { 0 }, s2n_free);
-    GUARD_PTR(s2n_alloc(&mem, sizeof(struct s2n_psk)));
+    PTR_GUARD_POSIX(s2n_alloc(&mem, sizeof(struct s2n_psk)));
 
     struct s2n_psk *psk = (struct s2n_psk*)(void*) mem.data;
-    GUARD_RESULT_PTR(s2n_psk_init(psk, S2N_PSK_TYPE_EXTERNAL));
+    PTR_GUARD_RESULT(s2n_psk_init(psk, S2N_PSK_TYPE_EXTERNAL));
 
     ZERO_TO_DISABLE_DEFER_CLEANUP(mem);
     return psk;
@@ -51,24 +51,24 @@ struct s2n_psk* s2n_external_psk_new()
 
 int s2n_psk_set_identity(struct s2n_psk *psk, const uint8_t *identity, uint16_t identity_size)
 {
-    notnull_check(psk);
-    notnull_check(identity);
-    ENSURE_POSIX(identity_size != 0, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE_REF(psk);
+    POSIX_ENSURE_REF(identity);
+    POSIX_ENSURE(identity_size != 0, S2N_ERR_INVALID_ARGUMENT);
 
-    GUARD(s2n_realloc(&psk->identity, identity_size));
-    memcpy_check(psk->identity.data, identity, identity_size);
+    POSIX_GUARD(s2n_realloc(&psk->identity, identity_size));
+    POSIX_CHECKED_MEMCPY(psk->identity.data, identity, identity_size);
 
     return S2N_SUCCESS;
 }
 
 int s2n_psk_set_secret(struct s2n_psk *psk, const uint8_t *secret, uint16_t secret_size)
 {
-    notnull_check(psk);
-    notnull_check(secret);
-    ENSURE_POSIX(secret_size != 0, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE_REF(psk);
+    POSIX_ENSURE_REF(secret);
+    POSIX_ENSURE(secret_size != 0, S2N_ERR_INVALID_ARGUMENT);
 
-    GUARD(s2n_realloc(&psk->secret, secret_size));
-    memcpy_check(psk->secret.data, secret, secret_size);
+    POSIX_GUARD(s2n_realloc(&psk->secret, secret_size));
+    POSIX_CHECKED_MEMCPY(psk->secret.data, secret, secret_size);
 
     return S2N_SUCCESS;
 }
@@ -78,7 +78,7 @@ S2N_RESULT s2n_psk_clone(struct s2n_psk *new_psk, struct s2n_psk *original_psk)
     if (original_psk == NULL) {
         return S2N_RESULT_OK;
     }
-    ENSURE_REF(new_psk);
+    RESULT_ENSURE_REF(new_psk);
 
     struct s2n_psk psk_copy = *new_psk;
 
@@ -90,11 +90,11 @@ S2N_RESULT s2n_psk_clone(struct s2n_psk *new_psk, struct s2n_psk *original_psk)
     new_psk->early_data_config = psk_copy.early_data_config;
 
     /* Clone / realloc blobs */
-    GUARD_AS_RESULT(s2n_psk_set_identity(new_psk, original_psk->identity.data, original_psk->identity.size));
-    GUARD_AS_RESULT(s2n_psk_set_secret(new_psk, original_psk->secret.data, original_psk->secret.size));
-    GUARD_AS_RESULT(s2n_realloc(&new_psk->early_secret, original_psk->early_secret.size));
-    CHECKED_MEMCPY(new_psk->early_secret.data, original_psk->early_secret.data, original_psk->early_secret.size);
-    GUARD_RESULT(s2n_early_data_config_clone(new_psk, &original_psk->early_data_config));
+    RESULT_GUARD_POSIX(s2n_psk_set_identity(new_psk, original_psk->identity.data, original_psk->identity.size));
+    RESULT_GUARD_POSIX(s2n_psk_set_secret(new_psk, original_psk->secret.data, original_psk->secret.size));
+    RESULT_GUARD_POSIX(s2n_realloc(&new_psk->early_secret, original_psk->early_secret.size));
+    RESULT_CHECKED_MEMCPY(new_psk->early_secret.data, original_psk->early_secret.data, original_psk->early_secret.size);
+    RESULT_GUARD(s2n_early_data_config_clone(new_psk, &original_psk->early_data_config));
 
     return S2N_RESULT_OK;
 }
@@ -105,10 +105,10 @@ S2N_CLEANUP_RESULT s2n_psk_wipe(struct s2n_psk *psk)
         return S2N_RESULT_OK;
     }
 
-    GUARD_AS_RESULT(s2n_free(&psk->early_secret));
-    GUARD_AS_RESULT(s2n_free(&psk->identity));
-    GUARD_AS_RESULT(s2n_free(&psk->secret));
-    GUARD_RESULT(s2n_early_data_config_free(&psk->early_data_config));
+    RESULT_GUARD_POSIX(s2n_free(&psk->early_secret));
+    RESULT_GUARD_POSIX(s2n_free(&psk->identity));
+    RESULT_GUARD_POSIX(s2n_free(&psk->secret));
+    RESULT_GUARD(s2n_early_data_config_free(&psk->early_data_config));
 
     return S2N_RESULT_OK;
 }
@@ -118,15 +118,15 @@ int s2n_psk_free(struct s2n_psk **psk)
     if (psk == NULL) {
         return S2N_SUCCESS;
     }
-    GUARD_AS_POSIX(s2n_psk_wipe(*psk));
+    POSIX_GUARD_RESULT(s2n_psk_wipe(*psk));
     return s2n_free_object((uint8_t **) psk, sizeof(struct s2n_psk));
 }
 
 S2N_RESULT s2n_psk_parameters_init(struct s2n_psk_parameters *params)
 {
-    ENSURE_REF(params);
-    CHECKED_MEMSET(params, 0, sizeof(struct s2n_psk_parameters));
-    GUARD_RESULT(s2n_array_init(&params->psk_list, sizeof(struct s2n_psk)));
+    RESULT_ENSURE_REF(params);
+    RESULT_CHECKED_MEMSET(params, 0, sizeof(struct s2n_psk_parameters));
+    RESULT_GUARD(s2n_array_init(&params->psk_list, sizeof(struct s2n_psk)));
     return S2N_RESULT_OK;
 }
 
@@ -136,60 +136,60 @@ static S2N_RESULT s2n_psk_offered_psk_size(struct s2n_psk *psk, uint32_t *size)
           + sizeof(uint32_t)    /* obfuscated ticket age */
           + sizeof(uint8_t)     /* binder size */;
 
-    GUARD_AS_RESULT(s2n_add_overflow(*size, psk->identity.size, size));
+    RESULT_GUARD_POSIX(s2n_add_overflow(*size, psk->identity.size, size));
 
     uint8_t binder_size = 0;
-    GUARD_AS_RESULT(s2n_hmac_digest_size(psk->hmac_alg, &binder_size));
-    GUARD_AS_RESULT(s2n_add_overflow(*size, binder_size, size));
+    RESULT_GUARD_POSIX(s2n_hmac_digest_size(psk->hmac_alg, &binder_size));
+    RESULT_GUARD_POSIX(s2n_add_overflow(*size, binder_size, size));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_psk_parameters_offered_psks_size(struct s2n_psk_parameters *params, uint32_t *size)
 {
-    ENSURE_REF(params);
-    ENSURE_REF(size);
+    RESULT_ENSURE_REF(params);
+    RESULT_ENSURE_REF(size);
 
     *size = sizeof(uint16_t)    /* identity list size */
           + sizeof(uint16_t)    /* binder list size */;
 
     for (uint32_t i = 0; i < params->psk_list.len; i++) {
         struct s2n_psk *psk = NULL;
-        GUARD_RESULT(s2n_array_get(&params->psk_list, i, (void**)&psk));
-        ENSURE_REF(psk);
+        RESULT_GUARD(s2n_array_get(&params->psk_list, i, (void**)&psk));
+        RESULT_ENSURE_REF(psk);
 
         uint32_t psk_size = 0;
-        GUARD_RESULT(s2n_psk_offered_psk_size(psk, &psk_size));
-        GUARD_AS_RESULT(s2n_add_overflow(*size, psk_size, size));
+        RESULT_GUARD(s2n_psk_offered_psk_size(psk, &psk_size));
+        RESULT_GUARD_POSIX(s2n_add_overflow(*size, psk_size, size));
     }
     return S2N_RESULT_OK;
 }
 
 S2N_CLEANUP_RESULT s2n_psk_parameters_wipe(struct s2n_psk_parameters *params)
 {
-    ENSURE_REF(params);
+    RESULT_ENSURE_REF(params);
 
     for (size_t i = 0; i < params->psk_list.len; i++) {
         struct s2n_psk *psk = NULL;
-        GUARD_RESULT(s2n_array_get(&params->psk_list, i, (void**)&psk));
-        GUARD_RESULT(s2n_psk_wipe(psk));
+        RESULT_GUARD(s2n_array_get(&params->psk_list, i, (void**)&psk));
+        RESULT_GUARD(s2n_psk_wipe(psk));
     }
-    GUARD_AS_RESULT(s2n_free(&params->psk_list.mem));
-    GUARD_RESULT(s2n_psk_parameters_init(params));
+    RESULT_GUARD_POSIX(s2n_free(&params->psk_list.mem));
+    RESULT_GUARD(s2n_psk_parameters_init(params));
 
     return S2N_RESULT_OK;
 }
 
 S2N_CLEANUP_RESULT s2n_psk_parameters_wipe_secrets(struct s2n_psk_parameters *params)
 {
-    ENSURE_REF(params);
+    RESULT_ENSURE_REF(params);
 
     for (size_t i = 0; i < params->psk_list.len; i++) {
         struct s2n_psk *psk = NULL;
-        GUARD_RESULT(s2n_array_get(&params->psk_list, i, (void**)&psk));
-        ENSURE_REF(psk);
-        GUARD_AS_RESULT(s2n_free(&psk->early_secret));
-        GUARD_AS_RESULT(s2n_free(&psk->secret));
+        RESULT_GUARD(s2n_array_get(&params->psk_list, i, (void**)&psk));
+        RESULT_ENSURE_REF(psk);
+        RESULT_GUARD_POSIX(s2n_free(&psk->early_secret));
+        RESULT_GUARD_POSIX(s2n_free(&psk->secret));
     }
 
     return S2N_RESULT_OK;
@@ -202,56 +202,56 @@ bool s2n_offered_psk_list_has_next(struct s2n_offered_psk_list *psk_list)
 
 S2N_RESULT s2n_offered_psk_list_read_next(struct s2n_offered_psk_list *psk_list, struct s2n_offered_psk *psk)
 {
-    ENSURE_REF(psk_list);
-    ENSURE_MUT(psk);
+    RESULT_ENSURE_REF(psk_list);
+    RESULT_ENSURE_MUT(psk);
 
     uint16_t identity_size = 0;
-    GUARD_AS_RESULT(s2n_stuffer_read_uint16(&psk_list->wire_data, &identity_size));
-    ENSURE_GT(identity_size, 0);
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&psk_list->wire_data, &identity_size));
+    RESULT_ENSURE_GT(identity_size, 0);
 
     uint8_t *identity_data = NULL;
     identity_data = s2n_stuffer_raw_read(&psk_list->wire_data, identity_size);
-    ENSURE_REF(identity_data);
+    RESULT_ENSURE_REF(identity_data);
 
     /**
      *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
      *# For identities established externally, an obfuscated_ticket_age of 0 SHOULD be
      *# used, and servers MUST ignore the value.
      */
-    GUARD_AS_RESULT(s2n_stuffer_skip_read(&psk_list->wire_data, sizeof(uint32_t)));
+    RESULT_GUARD_POSIX(s2n_stuffer_skip_read(&psk_list->wire_data, sizeof(uint32_t)));
 
-    GUARD_AS_RESULT(s2n_blob_init(&psk->identity, identity_data, identity_size));
+    RESULT_GUARD_POSIX(s2n_blob_init(&psk->identity, identity_data, identity_size));
     return S2N_RESULT_OK;
 }
 
 int s2n_offered_psk_list_next(struct s2n_offered_psk_list *psk_list, struct s2n_offered_psk *psk)
 {
-    notnull_check(psk_list);
-    notnull_check(psk);
+    POSIX_ENSURE_REF(psk_list);
+    POSIX_ENSURE_REF(psk);
     *psk = (struct s2n_offered_psk){ 0 };
-    ENSURE_POSIX(s2n_offered_psk_list_has_next(psk_list), S2N_ERR_STUFFER_OUT_OF_DATA);
-    ENSURE_POSIX(s2n_result_is_ok(s2n_offered_psk_list_read_next(psk_list, psk)), S2N_ERR_BAD_MESSAGE);
+    POSIX_ENSURE(s2n_offered_psk_list_has_next(psk_list), S2N_ERR_STUFFER_OUT_OF_DATA);
+    POSIX_ENSURE(s2n_result_is_ok(s2n_offered_psk_list_read_next(psk_list, psk)), S2N_ERR_BAD_MESSAGE);
     return S2N_SUCCESS;
 }
 
 int s2n_offered_psk_list_reset(struct s2n_offered_psk_list *psk_list)
 {
-    notnull_check(psk_list);
+    POSIX_ENSURE_REF(psk_list);
     return s2n_stuffer_reread(&psk_list->wire_data);
 }
 
 S2N_RESULT s2n_offered_psk_list_get_index(struct s2n_offered_psk_list *psk_list, uint16_t psk_index, struct s2n_offered_psk *psk)
 {
-    ENSURE_REF(psk_list);
-    ENSURE_MUT(psk);
+    RESULT_ENSURE_REF(psk_list);
+    RESULT_ENSURE_MUT(psk);
 
     /* We don't want to lose our original place in the list, so copy it */
     struct s2n_offered_psk_list psk_list_copy = { .wire_data = psk_list->wire_data };
-    GUARD_AS_RESULT(s2n_offered_psk_list_reset(&psk_list_copy));
+    RESULT_GUARD_POSIX(s2n_offered_psk_list_reset(&psk_list_copy));
 
     uint16_t count = 0;
     while(count <= psk_index) {
-        GUARD_AS_RESULT(s2n_offered_psk_list_next(&psk_list_copy, psk));
+        RESULT_GUARD_POSIX(s2n_offered_psk_list_next(&psk_list_copy, psk));
         count++;
     }
     return S2N_RESULT_OK;
@@ -260,8 +260,8 @@ S2N_RESULT s2n_offered_psk_list_get_index(struct s2n_offered_psk_list *psk_list,
 struct s2n_offered_psk* s2n_offered_psk_new()
 {
     DEFER_CLEANUP(struct s2n_blob mem = { 0 }, s2n_free);
-    GUARD_PTR(s2n_alloc(&mem, sizeof(struct s2n_offered_psk)));
-    GUARD_PTR(s2n_blob_zero(&mem));
+    PTR_GUARD_POSIX(s2n_alloc(&mem, sizeof(struct s2n_offered_psk)));
+    PTR_GUARD_POSIX(s2n_blob_zero(&mem));
 
     struct s2n_offered_psk *psk = (struct s2n_offered_psk*)(void*) mem.data;
 
@@ -279,9 +279,9 @@ int s2n_offered_psk_free(struct s2n_offered_psk **psk)
 
 int s2n_offered_psk_get_identity(struct s2n_offered_psk *psk, uint8_t** identity, uint16_t *size)
 {
-    notnull_check(psk);
-    notnull_check(identity);
-    notnull_check(size);
+    POSIX_ENSURE_REF(psk);
+    POSIX_ENSURE_REF(identity);
+    POSIX_ENSURE_REF(size);
     *identity = psk->identity.data;
     *size = psk->identity.size;
     return S2N_SUCCESS;
@@ -293,27 +293,27 @@ int s2n_offered_psk_get_identity(struct s2n_offered_psk *psk, uint8_t** identity
 int s2n_psk_calculate_binder_hash(struct s2n_connection *conn, s2n_hmac_algorithm hmac_alg,
         const struct s2n_blob *partial_client_hello, struct s2n_blob *output_binder_hash)
 {
-    notnull_check(partial_client_hello);
-    notnull_check(output_binder_hash);
+    POSIX_ENSURE_REF(partial_client_hello);
+    POSIX_ENSURE_REF(output_binder_hash);
 
     /* Retrieve the current transcript.
      * The current transcript will be empty unless this handshake included a HelloRetryRequest. */
     struct s2n_hash_state current_hash_state = {0};
 
     s2n_hash_algorithm hash_alg;
-    GUARD(s2n_hmac_hash_alg(hmac_alg, &hash_alg));
-    GUARD(s2n_handshake_get_hash_state(conn, hash_alg, &current_hash_state));
+    POSIX_GUARD(s2n_hmac_hash_alg(hmac_alg, &hash_alg));
+    POSIX_GUARD(s2n_handshake_get_hash_state(conn, hash_alg, &current_hash_state));
 
     /* Copy the current transcript to avoid modifying the original. */
     DEFER_CLEANUP(struct s2n_hash_state hash_copy, s2n_hash_free);
-    GUARD(s2n_hash_new(&hash_copy));
-    GUARD(s2n_hash_copy(&hash_copy, &current_hash_state));
+    POSIX_GUARD(s2n_hash_new(&hash_copy));
+    POSIX_GUARD(s2n_hash_copy(&hash_copy, &current_hash_state));
 
     /* Add the partial client hello to the transcript. */
-    GUARD(s2n_hash_update(&hash_copy, partial_client_hello->data, partial_client_hello->size));
+    POSIX_GUARD(s2n_hash_update(&hash_copy, partial_client_hello->data, partial_client_hello->size));
 
     /* Get the transcript digest */
-    GUARD(s2n_hash_digest(&hash_copy, output_binder_hash->data, output_binder_hash->size));
+    POSIX_GUARD(s2n_hash_digest(&hash_copy, output_binder_hash->data, output_binder_hash->size));
 
     return S2N_SUCCESS;
 }
@@ -326,29 +326,29 @@ int s2n_psk_calculate_binder_hash(struct s2n_connection *conn, s2n_hmac_algorith
 int s2n_psk_calculate_binder(struct s2n_psk *psk, const struct s2n_blob *binder_hash,
         struct s2n_blob *output_binder)
 {
-    notnull_check(psk);
-    notnull_check(binder_hash);
-    notnull_check(output_binder);
+    POSIX_ENSURE_REF(psk);
+    POSIX_ENSURE_REF(binder_hash);
+    POSIX_ENSURE_REF(output_binder);
 
     DEFER_CLEANUP(struct s2n_tls13_keys psk_keys, s2n_tls13_keys_free);
-    GUARD(s2n_tls13_keys_init(&psk_keys, psk->hmac_alg));
-    eq_check(binder_hash->size, psk_keys.size);
-    eq_check(output_binder->size, psk_keys.size);
+    POSIX_GUARD(s2n_tls13_keys_init(&psk_keys, psk->hmac_alg));
+    POSIX_ENSURE_EQ(binder_hash->size, psk_keys.size);
+    POSIX_ENSURE_EQ(output_binder->size, psk_keys.size);
 
     /* Make sure the early secret is saved on the psk structure for later use */
-    GUARD(s2n_realloc(&psk->early_secret, psk_keys.size));
-    GUARD(s2n_blob_init(&psk_keys.extract_secret, psk->early_secret.data, psk_keys.size));
+    POSIX_GUARD(s2n_realloc(&psk->early_secret, psk_keys.size));
+    POSIX_GUARD(s2n_blob_init(&psk_keys.extract_secret, psk->early_secret.data, psk_keys.size));
 
     /* Derive the binder key */
-    GUARD(s2n_tls13_derive_binder_key(&psk_keys, psk));
+    POSIX_GUARD(s2n_tls13_derive_binder_key(&psk_keys, psk));
     struct s2n_blob *binder_key = &psk_keys.derive_secret;
 
     /* Expand the binder key into the finished key */
     s2n_tls13_key_blob(finished_key, psk_keys.size);
-    GUARD(s2n_tls13_derive_finished_key(&psk_keys, binder_key, &finished_key));
+    POSIX_GUARD(s2n_tls13_derive_finished_key(&psk_keys, binder_key, &finished_key));
 
     /* HMAC the binder hash with the binder finished key */
-    GUARD(s2n_hkdf_extract(&psk_keys.hmac, psk_keys.hmac_algorithm, &finished_key, binder_hash, output_binder));
+    POSIX_GUARD(s2n_hkdf_extract(&psk_keys.hmac, psk_keys.hmac_algorithm, &finished_key, binder_hash, output_binder));
 
     return S2N_SUCCESS;
 }
@@ -356,24 +356,24 @@ int s2n_psk_calculate_binder(struct s2n_psk *psk, const struct s2n_blob *binder_
 int s2n_psk_verify_binder(struct s2n_connection *conn, struct s2n_psk *psk,
         const struct s2n_blob *partial_client_hello, struct s2n_blob *binder_to_verify)
 {
-    notnull_check(psk);
-    notnull_check(binder_to_verify);
+    POSIX_ENSURE_REF(psk);
+    POSIX_ENSURE_REF(binder_to_verify);
 
     DEFER_CLEANUP(struct s2n_tls13_keys psk_keys, s2n_tls13_keys_free);
-    GUARD(s2n_tls13_keys_init(&psk_keys, psk->hmac_alg));
-    eq_check(binder_to_verify->size, psk_keys.size);
+    POSIX_GUARD(s2n_tls13_keys_init(&psk_keys, psk->hmac_alg));
+    POSIX_ENSURE_EQ(binder_to_verify->size, psk_keys.size);
 
     /* Calculate the binder hash from the transcript */
     s2n_tls13_key_blob(binder_hash, psk_keys.size);
-    GUARD(s2n_psk_calculate_binder_hash(conn, psk->hmac_alg, partial_client_hello, &binder_hash));
+    POSIX_GUARD(s2n_psk_calculate_binder_hash(conn, psk->hmac_alg, partial_client_hello, &binder_hash));
 
     /* Calculate the expected binder from the binder hash */
     s2n_tls13_key_blob(expected_binder, psk_keys.size);
-    GUARD(s2n_psk_calculate_binder(psk, &binder_hash, &expected_binder));
+    POSIX_GUARD(s2n_psk_calculate_binder(psk, &binder_hash, &expected_binder));
 
     /* Verify the expected binder matches the given binder.
      * This operation must be constant time. */
-    GUARD(s2n_tls13_mac_verify(&psk_keys, &expected_binder, binder_to_verify));
+    POSIX_GUARD(s2n_tls13_mac_verify(&psk_keys, &expected_binder, binder_to_verify));
 
     return S2N_SUCCESS;
 }
@@ -381,15 +381,15 @@ int s2n_psk_verify_binder(struct s2n_connection *conn, struct s2n_psk *psk,
 static S2N_RESULT s2n_psk_write_binder(struct s2n_connection *conn, struct s2n_psk *psk,
         const struct s2n_blob *binder_hash, struct s2n_stuffer *out)
 {
-    ENSURE_REF(binder_hash);
+    RESULT_ENSURE_REF(binder_hash);
 
     struct s2n_blob binder;
     uint8_t binder_data[S2N_TLS13_SECRET_MAX_LEN] = { 0 };
-    GUARD_AS_RESULT(s2n_blob_init(&binder, binder_data, binder_hash->size));
+    RESULT_GUARD_POSIX(s2n_blob_init(&binder, binder_data, binder_hash->size));
 
-    GUARD_AS_RESULT(s2n_psk_calculate_binder(psk, binder_hash, &binder));
-    GUARD_AS_RESULT(s2n_stuffer_write_uint8(out, binder.size));
-    GUARD_AS_RESULT(s2n_stuffer_write(out, &binder));
+    RESULT_GUARD_POSIX(s2n_psk_calculate_binder(psk, binder_hash, &binder));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(out, binder.size));
+    RESULT_GUARD_POSIX(s2n_stuffer_write(out, &binder));
 
     return S2N_RESULT_OK;
 }
@@ -397,8 +397,8 @@ static S2N_RESULT s2n_psk_write_binder(struct s2n_connection *conn, struct s2n_p
 static S2N_RESULT s2n_psk_write_binder_list(struct s2n_connection *conn, const struct s2n_blob *partial_client_hello,
         struct s2n_stuffer *out)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(partial_client_hello);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(partial_client_hello);
 
     struct s2n_psk_parameters *psk_params = &conn->psk_params;
     struct s2n_array *psk_list = &psk_params->psk_list;
@@ -409,13 +409,13 @@ static S2N_RESULT s2n_psk_write_binder_list(struct s2n_connection *conn, const s
     struct s2n_blob binder_hashes[S2N_HASH_ALG_COUNT] = { 0 };
 
     struct s2n_stuffer_reservation binder_list_size = { 0 };
-    GUARD_AS_RESULT(s2n_stuffer_reserve_uint16(out, &binder_list_size));
+    RESULT_GUARD_POSIX(s2n_stuffer_reserve_uint16(out, &binder_list_size));
 
     /* Write binder for every psk */
     for (size_t i = 0; i < psk_list->len; i++) {
         struct s2n_psk *psk = NULL;
-        GUARD_RESULT(s2n_array_get(psk_list, i, (void**) &psk));
-        ENSURE_REF(psk);
+        RESULT_GUARD(s2n_array_get(psk_list, i, (void**) &psk));
+        RESULT_ENSURE_REF(psk);
 
         /**
          *= https://tools.ietf.org/rfc/rfc8446#section-4.1.4
@@ -433,21 +433,21 @@ static S2N_RESULT s2n_psk_write_binder_list(struct s2n_connection *conn, const s
         struct s2n_blob *binder_hash = &binder_hashes[psk->hmac_alg];
         if (binder_hash->size == 0) {
             uint8_t hash_size = 0;
-            GUARD_AS_RESULT(s2n_hmac_digest_size(psk->hmac_alg, &hash_size));
-            GUARD_AS_RESULT(s2n_blob_init(binder_hash, binder_hashes_data[psk->hmac_alg], hash_size));
-            GUARD_AS_RESULT(s2n_psk_calculate_binder_hash(conn, psk->hmac_alg, partial_client_hello, binder_hash));
+            RESULT_GUARD_POSIX(s2n_hmac_digest_size(psk->hmac_alg, &hash_size));
+            RESULT_GUARD_POSIX(s2n_blob_init(binder_hash, binder_hashes_data[psk->hmac_alg], hash_size));
+            RESULT_GUARD_POSIX(s2n_psk_calculate_binder_hash(conn, psk->hmac_alg, partial_client_hello, binder_hash));
         }
 
-        GUARD_RESULT(s2n_psk_write_binder(conn, psk, binder_hash, out));
+        RESULT_GUARD(s2n_psk_write_binder(conn, psk, binder_hash, out));
     }
-    GUARD_AS_RESULT(s2n_stuffer_write_vector_size(&binder_list_size));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_vector_size(&binder_list_size));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_finish_psk_extension(struct s2n_connection *conn)
 {
-    ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn);
 
     if (!conn->psk_params.binder_list_size) {
         return S2N_RESULT_OK;
@@ -457,66 +457,66 @@ S2N_RESULT s2n_finish_psk_extension(struct s2n_connection *conn)
     struct s2n_psk_parameters *psk_params = &conn->psk_params;
 
     /* Fill in the correct message size. */
-    GUARD_AS_RESULT(s2n_handshake_finish_header(client_hello));
+    RESULT_GUARD_POSIX(s2n_handshake_finish_header(client_hello));
 
     /* Remove the empty space allocated for the binder list.
      * It was originally added to ensure the extension / extension list / message sizes
      * were properly calculated. */
-    GUARD_AS_RESULT(s2n_stuffer_wipe_n(client_hello, psk_params->binder_list_size));
+    RESULT_GUARD_POSIX(s2n_stuffer_wipe_n(client_hello, psk_params->binder_list_size));
 
     /* Store the partial client hello for use in calculating the binder hash. */
     struct s2n_blob partial_client_hello = { 0 };
-    GUARD_AS_RESULT(s2n_blob_init(&partial_client_hello, client_hello->blob.data,
+    RESULT_GUARD_POSIX(s2n_blob_init(&partial_client_hello, client_hello->blob.data,
             s2n_stuffer_data_available(client_hello)));
 
-    GUARD_RESULT(s2n_psk_write_binder_list(conn, &partial_client_hello, client_hello));
+    RESULT_GUARD(s2n_psk_write_binder_list(conn, &partial_client_hello, client_hello));
     return S2N_RESULT_OK;
 }
 
 int s2n_psk_set_hmac(struct s2n_psk *psk, s2n_psk_hmac hmac)
 {
-    notnull_check(psk);
+    POSIX_ENSURE_REF(psk);
     switch(hmac) {
         case S2N_PSK_HMAC_SHA224:     psk->hmac_alg = S2N_HMAC_SHA224; break;
         case S2N_PSK_HMAC_SHA256:     psk->hmac_alg = S2N_HMAC_SHA256; break;
         case S2N_PSK_HMAC_SHA384:     psk->hmac_alg = S2N_HMAC_SHA384; break;
         default:
-            S2N_ERROR(S2N_ERR_HMAC_INVALID_ALGORITHM);
+            POSIX_BAIL(S2N_ERR_HMAC_INVALID_ALGORITHM);
     }
     return S2N_SUCCESS;
 }
 
 int s2n_connection_append_psk(struct s2n_connection *conn, struct s2n_psk *input_psk)
 {
-    notnull_check(conn);
-    notnull_check(input_psk);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(input_psk);
     struct s2n_array *psk_list = &conn->psk_params.psk_list;
     
     /* Check for duplicate identities */
     for (uint32_t j = 0; j < psk_list->len; j++) {
         struct s2n_psk *existing_psk = NULL;
-        GUARD_AS_POSIX(s2n_array_get(psk_list, j, (void**) &existing_psk));
-        notnull_check(existing_psk);
+        POSIX_GUARD_RESULT(s2n_array_get(psk_list, j, (void**) &existing_psk));
+        POSIX_ENSURE_REF(existing_psk);
 
         bool duplicate = existing_psk->identity.size == input_psk->identity.size
                 && memcmp(existing_psk->identity.data, input_psk->identity.data, existing_psk->identity.size) == 0;
-        ENSURE_POSIX(!duplicate, S2N_ERR_DUPLICATE_PSK_IDENTITIES);
+        POSIX_ENSURE(!duplicate, S2N_ERR_DUPLICATE_PSK_IDENTITIES);
     }
 
     /* Verify the PSK list will fit in the ClientHello pre_shared_key extension */
     if (conn->mode == S2N_CLIENT) {
         uint32_t list_size = 0;
-        GUARD_AS_POSIX(s2n_psk_parameters_offered_psks_size(&conn->psk_params, &list_size));
+        POSIX_GUARD_RESULT(s2n_psk_parameters_offered_psks_size(&conn->psk_params, &list_size));
 
         uint32_t psk_size = 0;
-        GUARD_AS_POSIX(s2n_psk_offered_psk_size(input_psk, &psk_size));
+        POSIX_GUARD_RESULT(s2n_psk_offered_psk_size(input_psk, &psk_size));
 
-        ENSURE_POSIX(list_size + psk_size + S2N_EXTENSION_HEADER_LENGTH <= UINT16_MAX, S2N_ERR_OFFERED_PSKS_TOO_LONG);
+        POSIX_ENSURE(list_size + psk_size + S2N_EXTENSION_HEADER_LENGTH <= UINT16_MAX, S2N_ERR_OFFERED_PSKS_TOO_LONG);
     }
 
     DEFER_CLEANUP(struct s2n_psk new_psk = { 0 }, s2n_psk_wipe);
-    ENSURE_POSIX(s2n_result_is_ok(s2n_psk_clone(&new_psk, input_psk)), S2N_ERR_INVALID_ARGUMENT);
-    GUARD_AS_POSIX(s2n_array_insert_and_copy(psk_list, psk_list->len, &new_psk));
+    POSIX_ENSURE(s2n_result_is_ok(s2n_psk_clone(&new_psk, input_psk)), S2N_ERR_INVALID_ARGUMENT);
+    POSIX_GUARD_RESULT(s2n_array_insert_and_copy(psk_list, psk_list->len, &new_psk));
 
     ZERO_TO_DISABLE_DEFER_CLEANUP(new_psk);
     return S2N_SUCCESS;

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -37,7 +37,7 @@ S2N_RESULT s2n_read_in_bytes(struct s2n_connection *conn, struct s2n_stuffer *ou
 
 int s2n_config_enable_quic(struct s2n_config *config)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
     config->quic_enabled = true;
     return S2N_SUCCESS;
 }
@@ -45,11 +45,11 @@ int s2n_config_enable_quic(struct s2n_config *config)
 int s2n_connection_set_quic_transport_parameters(struct s2n_connection *conn,
         const uint8_t *data_buffer, uint16_t data_len)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
-    GUARD(s2n_free(&conn->our_quic_transport_parameters));
-    GUARD(s2n_alloc(&conn->our_quic_transport_parameters, data_len));
-    memcpy_check(conn->our_quic_transport_parameters.data, data_buffer, data_len);
+    POSIX_GUARD(s2n_free(&conn->our_quic_transport_parameters));
+    POSIX_GUARD(s2n_alloc(&conn->our_quic_transport_parameters, data_len));
+    POSIX_CHECKED_MEMCPY(conn->our_quic_transport_parameters.data, data_buffer, data_len);
 
     return S2N_SUCCESS;
 }
@@ -57,9 +57,9 @@ int s2n_connection_set_quic_transport_parameters(struct s2n_connection *conn,
 int s2n_connection_get_quic_transport_parameters(struct s2n_connection *conn,
         const uint8_t **data_buffer, uint16_t *data_len)
 {
-    notnull_check(conn);
-    notnull_check(data_buffer);
-    notnull_check(data_len);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(data_buffer);
+    POSIX_ENSURE_REF(data_len);
 
     *data_buffer = conn->peer_quic_transport_parameters.data;
     *data_len = conn->peer_quic_transport_parameters.size;
@@ -69,8 +69,8 @@ int s2n_connection_get_quic_transport_parameters(struct s2n_connection *conn,
 
 int s2n_connection_set_secret_callback(struct s2n_connection *conn, s2n_secret_cb cb_func, void *ctx)
 {
-    notnull_check(conn);
-    notnull_check(cb_func);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(cb_func);
 
     conn->secret_cb = cb_func;
     conn->secret_cb_context = ctx;
@@ -83,19 +83,19 @@ int s2n_connection_set_secret_callback(struct s2n_connection *conn, s2n_secret_c
  */
 S2N_RESULT s2n_quic_read_handshake_message(struct s2n_connection *conn, uint8_t *message_type)
 {
-    ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn);
 
     /* Allocate stuffer space now so that we don't have to realloc later in the handshake. */
-    GUARD_AS_RESULT(s2n_stuffer_resize_if_empty(&conn->in, S2N_EXPECTED_QUIC_MESSAGE_SIZE));
+    RESULT_GUARD_POSIX(s2n_stuffer_resize_if_empty(&conn->in, S2N_EXPECTED_QUIC_MESSAGE_SIZE));
 
-    GUARD_RESULT(s2n_read_in_bytes(conn, &conn->handshake.io, TLS_HANDSHAKE_HEADER_LENGTH));
+    RESULT_GUARD(s2n_read_in_bytes(conn, &conn->handshake.io, TLS_HANDSHAKE_HEADER_LENGTH));
 
     uint32_t message_len;
-    GUARD_AS_RESULT(s2n_handshake_parse_header(conn, message_type, &message_len));
-    GUARD_AS_RESULT(s2n_stuffer_reread(&conn->handshake.io));
+    RESULT_GUARD_POSIX(s2n_handshake_parse_header(conn, message_type, &message_len));
+    RESULT_GUARD_POSIX(s2n_stuffer_reread(&conn->handshake.io));
 
-    ENSURE(message_len < S2N_MAXIMUM_HANDSHAKE_MESSAGE_LENGTH, S2N_ERR_BAD_MESSAGE);
-    GUARD_RESULT(s2n_read_in_bytes(conn, &conn->in, message_len));
+    RESULT_ENSURE(message_len < S2N_MAXIMUM_HANDSHAKE_MESSAGE_LENGTH, S2N_ERR_BAD_MESSAGE);
+    RESULT_GUARD(s2n_read_in_bytes(conn, &conn->in, message_len));
 
     return S2N_RESULT_OK;
 }
@@ -105,11 +105,11 @@ S2N_RESULT s2n_quic_read_handshake_message(struct s2n_connection *conn, uint8_t 
  */
 S2N_RESULT s2n_quic_write_handshake_message(struct s2n_connection *conn, struct s2n_blob *in)
 {
-    ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn);
 
     /* Allocate stuffer space now so that we don't have to realloc later in the handshake. */
-    GUARD_AS_RESULT(s2n_stuffer_resize_if_empty(&conn->out, S2N_EXPECTED_QUIC_MESSAGE_SIZE));
+    RESULT_GUARD_POSIX(s2n_stuffer_resize_if_empty(&conn->out, S2N_EXPECTED_QUIC_MESSAGE_SIZE));
 
-    GUARD_AS_RESULT(s2n_stuffer_write(&conn->out, in));
+    RESULT_GUARD_POSIX(s2n_stuffer_write(&conn->out, in));
     return S2N_RESULT_OK;
 }

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -41,15 +41,15 @@ int s2n_sslv2_record_header_parse(
 
     S2N_ERROR_IF(s2n_stuffer_data_available(in) < S2N_TLS_RECORD_HEADER_LENGTH, S2N_ERR_BAD_MESSAGE);
 
-    GUARD(s2n_stuffer_read_uint16(in, fragment_length));
+    POSIX_GUARD(s2n_stuffer_read_uint16(in, fragment_length));
 
     /* Adjust to account for the 3 bytes of payload data we consumed in the header */
     *fragment_length -= 3;
 
-    GUARD(s2n_stuffer_read_uint8(in, record_type));
+    POSIX_GUARD(s2n_stuffer_read_uint8(in, record_type));
 
     uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
-    GUARD(s2n_stuffer_read_bytes(in, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
+    POSIX_GUARD(s2n_stuffer_read_bytes(in, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
 
     *client_protocol_version = (protocol_version[0] * 10) + protocol_version[1];
 
@@ -65,10 +65,10 @@ int s2n_record_header_parse(
 
     S2N_ERROR_IF(s2n_stuffer_data_available(in) < S2N_TLS_RECORD_HEADER_LENGTH, S2N_ERR_BAD_MESSAGE);
 
-    GUARD(s2n_stuffer_read_uint8(in, content_type));
+    POSIX_GUARD(s2n_stuffer_read_uint8(in, content_type));
 
     uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
-    GUARD(s2n_stuffer_read_bytes(in, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
+    POSIX_GUARD(s2n_stuffer_read_bytes(in, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
 
     const uint8_t version = (protocol_version[0] * 10) + protocol_version[1];
     /* https://tools.ietf.org/html/rfc5246#appendix-E.1 states that servers must accept any value {03,XX} as the record
@@ -82,13 +82,13 @@ int s2n_record_header_parse(
     S2N_ERROR_IF(conn->actual_protocol_version_established &&
         MIN(conn->actual_protocol_version, S2N_TLS12) /* check against legacy record version (1.2) in tls 1.3 */
         != version, S2N_ERR_BAD_MESSAGE);
-    GUARD(s2n_stuffer_read_uint16(in, fragment_length));
+    POSIX_GUARD(s2n_stuffer_read_uint16(in, fragment_length));
 
     /* Some servers send fragments that are above the maximum length.  (e.g.
      * Openssl 1.0.1, so we don't check if the fragment length is >
      * S2N_TLS_MAXIMUM_FRAGMENT_LENGTH. The on-the-wire max is 65k
      */
-    GUARD(s2n_stuffer_reread(in));
+    POSIX_GUARD(s2n_stuffer_reread(in));
 
     return 0;
 }
@@ -115,7 +115,7 @@ int s2n_record_parse(struct s2n_connection *conn)
 {
     uint8_t content_type;
     uint16_t encrypted_length;
-    GUARD(s2n_record_header_parse(conn, &content_type, &encrypted_length));
+    POSIX_GUARD(s2n_record_header_parse(conn, &content_type, &encrypted_length));
 
     struct s2n_crypto_parameters *current_client_crypto = conn->client;
     struct s2n_crypto_parameters *current_server_crypto = conn->server;
@@ -145,19 +145,19 @@ int s2n_record_parse(struct s2n_connection *conn)
 
     switch (cipher_suite->record_alg->cipher->type) {
     case S2N_AEAD:
-        GUARD(s2n_record_parse_aead(cipher_suite, conn, content_type, encrypted_length, implicit_iv, mac, sequence_number, session_key));
+        POSIX_GUARD(s2n_record_parse_aead(cipher_suite, conn, content_type, encrypted_length, implicit_iv, mac, sequence_number, session_key));
         break;
     case S2N_CBC:
-        GUARD(s2n_record_parse_cbc(cipher_suite, conn, content_type, encrypted_length, implicit_iv, mac, sequence_number, session_key));
+        POSIX_GUARD(s2n_record_parse_cbc(cipher_suite, conn, content_type, encrypted_length, implicit_iv, mac, sequence_number, session_key));
         break;
     case S2N_COMPOSITE:
-        GUARD(s2n_record_parse_composite(cipher_suite, conn, content_type, encrypted_length, implicit_iv, mac, sequence_number, session_key));
+        POSIX_GUARD(s2n_record_parse_composite(cipher_suite, conn, content_type, encrypted_length, implicit_iv, mac, sequence_number, session_key));
         break;
     case S2N_STREAM:
-        GUARD(s2n_record_parse_stream(cipher_suite, conn, content_type, encrypted_length, implicit_iv, mac, sequence_number, session_key));
+        POSIX_GUARD(s2n_record_parse_stream(cipher_suite, conn, content_type, encrypted_length, implicit_iv, mac, sequence_number, session_key));
         break;
     default:
-        S2N_ERROR(S2N_ERR_CIPHER_TYPE);
+        POSIX_BAIL(S2N_ERR_CIPHER_TYPE);
         break;
     }
 
@@ -181,7 +181,7 @@ int s2n_tls13_parse_record_type(struct s2n_stuffer *stuffer, uint8_t *record_typ
     S2N_ERROR_IF(bytes_left > S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH + 16, S2N_ERR_MAX_INNER_PLAINTEXT_SIZE);
 
     /* set cursor to the end of the stuffer */
-    GUARD(s2n_stuffer_skip_read(stuffer, bytes_left));
+    POSIX_GUARD(s2n_stuffer_skip_read(stuffer, bytes_left));
 
     /* Record type should have values greater than zero.
      * If zero, treat as padding, keep reading and wiping from the back
@@ -190,18 +190,18 @@ int s2n_tls13_parse_record_type(struct s2n_stuffer *stuffer, uint8_t *record_typ
     *record_type = 0;
     while (*record_type == 0) {
         /* back the cursor by one to read off the last byte */
-        GUARD(s2n_stuffer_rewind_read(stuffer, 1));
+        POSIX_GUARD(s2n_stuffer_rewind_read(stuffer, 1));
 
         /* set the record type */
-        GUARD(s2n_stuffer_read_uint8(stuffer, record_type));
+        POSIX_GUARD(s2n_stuffer_read_uint8(stuffer, record_type));
 
         /* wipe the last byte at the end of the stuffer */
-        GUARD(s2n_stuffer_wipe_n(stuffer, 1));
+        POSIX_GUARD(s2n_stuffer_wipe_n(stuffer, 1));
     }
 
     /* only the original plaintext should remain */
     /* now reset the read cursor at where it should be */
-    GUARD(s2n_stuffer_reread(stuffer));
+    POSIX_GUARD(s2n_stuffer_reread(stuffer));
 
     /* Even in the incorrect case above with up to 16 extra bytes, we should never see too much data after unpadding */
     S2N_ERROR_IF(s2n_stuffer_data_available(stuffer) > S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH - 1, S2N_ERR_MAX_INNER_PLAINTEXT_SIZE);

--- a/tls/s2n_record_read_aead.c
+++ b/tls/s2n_record_read_aead.c
@@ -46,19 +46,19 @@ int s2n_record_parse_aead(
     s2n_stack_blob(aad, is_tls13_record ? S2N_TLS13_AAD_LEN : S2N_TLS_MAX_AAD_LEN, S2N_TLS_MAX_AAD_LEN);
 
     struct s2n_blob en = {.size = encrypted_length,.data = s2n_stuffer_raw_read(&conn->in, encrypted_length) };
-    notnull_check(en.data);
+    POSIX_ENSURE_REF(en.data);
     /* In AEAD mode, the explicit IV is in the record */
-    gte_check(en.size, cipher_suite->record_alg->cipher->io.aead.record_iv_size);
+    POSIX_ENSURE_GTE(en.size, cipher_suite->record_alg->cipher->io.aead.record_iv_size);
 
     uint8_t aad_iv[S2N_TLS_MAX_IV_LEN] = { 0 };
     struct s2n_blob iv = {.data = aad_iv,.size = sizeof(aad_iv) };
     struct s2n_stuffer iv_stuffer = {0};
-    GUARD(s2n_stuffer_init(&iv_stuffer, &iv));
+    POSIX_GUARD(s2n_stuffer_init(&iv_stuffer, &iv));
 
     if (cipher_suite->record_alg->flags & S2N_TLS12_AES_GCM_AEAD_NONCE) {
         /* Partially explicit nonce. See RFC 5288 Section 3 */
-        GUARD(s2n_stuffer_write_bytes(&iv_stuffer, implicit_iv, cipher_suite->record_alg->cipher->io.aead.fixed_iv_size));
-        GUARD(s2n_stuffer_write_bytes(&iv_stuffer, en.data, cipher_suite->record_alg->cipher->io.aead.record_iv_size));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&iv_stuffer, implicit_iv, cipher_suite->record_alg->cipher->io.aead.fixed_iv_size));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&iv_stuffer, en.data, cipher_suite->record_alg->cipher->io.aead.record_iv_size));
     } else if (cipher_suite->record_alg->flags & S2N_TLS12_CHACHA_POLY_AEAD_NONCE || is_tls13_record) {
         /* Fully implicit nonce.
          * This is introduced with ChaChaPoly with RFC 7905 Section 2
@@ -68,14 +68,14 @@ int s2n_record_parse_aead(
          * to align and xor-ed with the 96-bit IV.
          **/
         uint8_t four_zeroes[4] = { 0 };
-        GUARD(s2n_stuffer_write_bytes(&iv_stuffer, four_zeroes, 4));
-        GUARD(s2n_stuffer_write_bytes(&iv_stuffer, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&iv_stuffer, four_zeroes, 4));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&iv_stuffer, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
         for (int i = 0; i < cipher_suite->record_alg->cipher->io.aead.fixed_iv_size; i++) {
             S2N_INVARIANT(i <= cipher_suite->record_alg->cipher->io.aead.fixed_iv_size);
             aad_iv[i] = aad_iv[i] ^ implicit_iv[i];
         }
     } else {
-        S2N_ERROR(S2N_ERR_INVALID_NONCE_TYPE);
+        POSIX_BAIL(S2N_ERR_INVALID_NONCE_TYPE);
     }
 
     /* Set the IV size to the amount of data written */
@@ -83,17 +83,17 @@ int s2n_record_parse_aead(
 
     uint16_t payload_length = encrypted_length;
     /* remove the AEAD overhead from the record size */
-    gte_check(payload_length, cipher_suite->record_alg->cipher->io.aead.record_iv_size + cipher_suite->record_alg->cipher->io.aead.tag_size);
+    POSIX_ENSURE_GTE(payload_length, cipher_suite->record_alg->cipher->io.aead.record_iv_size + cipher_suite->record_alg->cipher->io.aead.tag_size);
     payload_length -= cipher_suite->record_alg->cipher->io.aead.record_iv_size;
     payload_length -= cipher_suite->record_alg->cipher->io.aead.tag_size;
 
     struct s2n_stuffer ad_stuffer = {0};
-    GUARD(s2n_stuffer_init(&ad_stuffer, &aad));
+    POSIX_GUARD(s2n_stuffer_init(&ad_stuffer, &aad));
 
     if (is_tls13_record) {
-        GUARD_AS_POSIX(s2n_tls13_aead_aad_init(payload_length, cipher_suite->record_alg->cipher->io.aead.tag_size, &ad_stuffer));
+        POSIX_GUARD_RESULT(s2n_tls13_aead_aad_init(payload_length, cipher_suite->record_alg->cipher->io.aead.tag_size, &ad_stuffer));
     } else {
-        GUARD_AS_POSIX(s2n_aead_aad_init(conn, sequence_number, content_type, payload_length, &ad_stuffer));
+        POSIX_GUARD_RESULT(s2n_aead_aad_init(conn, sequence_number, content_type, payload_length, &ad_stuffer));
     }
 
     /* Decrypt stuff! */
@@ -102,25 +102,25 @@ int s2n_record_parse_aead(
     en.data += cipher_suite->record_alg->cipher->io.aead.record_iv_size;
 
     /* Check that we have some data to decrypt */
-    ne_check(en.size, 0);
+    POSIX_ENSURE_NE(en.size, 0);
 
-    GUARD(cipher_suite->record_alg->cipher->io.aead.decrypt(session_key, &iv, &aad, &en, &en));
+    POSIX_GUARD(cipher_suite->record_alg->cipher->io.aead.decrypt(session_key, &iv, &aad, &en, &en));
     struct s2n_blob seq = {.data = sequence_number,.size = S2N_TLS_SEQUENCE_NUM_LEN };
-    GUARD(s2n_increment_sequence_number(&seq));
+    POSIX_GUARD(s2n_increment_sequence_number(&seq));
 
     /* O.k., we've successfully read and decrypted the record, now we need to align the stuffer
      * for reading the plaintext data.
      */
-    GUARD(s2n_stuffer_reread(&conn->in));
-    GUARD(s2n_stuffer_reread(&conn->header_in));
+    POSIX_GUARD(s2n_stuffer_reread(&conn->in));
+    POSIX_GUARD(s2n_stuffer_reread(&conn->header_in));
 
     /* Skip the IV, if any */
     if (conn->actual_protocol_version >= S2N_TLS12) {
-        GUARD(s2n_stuffer_skip_read(&conn->in, cipher_suite->record_alg->cipher->io.aead.record_iv_size));
+        POSIX_GUARD(s2n_stuffer_skip_read(&conn->in, cipher_suite->record_alg->cipher->io.aead.record_iv_size));
     }
 
     /* Truncate and wipe the MAC and any padding */
-    GUARD(s2n_stuffer_wipe_n(&conn->in, s2n_stuffer_data_available(&conn->in) - payload_length));
+    POSIX_GUARD(s2n_stuffer_wipe_n(&conn->in, s2n_stuffer_data_available(&conn->in) - payload_length));
     conn->in_status = PLAINTEXT;
 
     return 0;

--- a/tls/s2n_record_read_cbc.c
+++ b/tls/s2n_record_read_cbc.c
@@ -45,85 +45,85 @@ int s2n_record_parse_cbc(
 
     /* Add the header to the HMAC */
     uint8_t *header = s2n_stuffer_raw_read(&conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH);
-    notnull_check(header);
+    POSIX_ENSURE_REF(header);
 
-    lte_check(cipher_suite->record_alg->cipher->io.cbc.record_iv_size, S2N_TLS_MAX_IV_LEN);
+    POSIX_ENSURE_LTE(cipher_suite->record_alg->cipher->io.cbc.record_iv_size, S2N_TLS_MAX_IV_LEN);
 
     /* For TLS >= 1.1 the IV is in the packet */
     if (conn->actual_protocol_version > S2N_TLS10) {
-        GUARD(s2n_stuffer_read(&conn->in, &iv));
-        gte_check(encrypted_length, iv.size);
+        POSIX_GUARD(s2n_stuffer_read(&conn->in, &iv));
+        POSIX_ENSURE_GTE(encrypted_length, iv.size);
         encrypted_length -= iv.size;
     }
 
     struct s2n_blob en = {.size = encrypted_length,.data = s2n_stuffer_raw_read(&conn->in, encrypted_length) };
-    notnull_check(en.data);
+    POSIX_ENSURE_REF(en.data);
 
     uint16_t payload_length = encrypted_length;
     uint8_t mac_digest_size;
-    GUARD(s2n_hmac_digest_size(mac->alg, &mac_digest_size));
+    POSIX_GUARD(s2n_hmac_digest_size(mac->alg, &mac_digest_size));
 
-    gte_check(payload_length, mac_digest_size);
+    POSIX_ENSURE_GTE(payload_length, mac_digest_size);
     payload_length -= mac_digest_size;
 
     /* Decrypt stuff! */
     /* Check that we have some data to decrypt */
-    ne_check(en.size, 0);
+    POSIX_ENSURE_NE(en.size, 0);
 
     /* ... and that we have a multiple of the block size */
-    eq_check(en.size % iv.size, 0);
+    POSIX_ENSURE_EQ(en.size % iv.size, 0);
 
     /* Copy the last encrypted block to be the next IV */
     if (conn->actual_protocol_version < S2N_TLS11) {
-        memcpy_check(ivpad, en.data + en.size - iv.size, iv.size);
+        POSIX_CHECKED_MEMCPY(ivpad, en.data + en.size - iv.size, iv.size);
     }
 
-    GUARD(cipher_suite->record_alg->cipher->io.cbc.decrypt(session_key, &iv, &en, &en));
+    POSIX_GUARD(cipher_suite->record_alg->cipher->io.cbc.decrypt(session_key, &iv, &en, &en));
 
     if (conn->actual_protocol_version < S2N_TLS11) {
-        memcpy_check(implicit_iv, ivpad, iv.size);
+        POSIX_CHECKED_MEMCPY(implicit_iv, ivpad, iv.size);
     }
 
     /* Subtract the padding length */
-    gt_check(en.size, 0);
+    POSIX_ENSURE_GT(en.size, 0);
     uint32_t out = 0;
-    GUARD(s2n_sub_overflow(payload_length, en.data[en.size - 1] + 1, &out));
+    POSIX_GUARD(s2n_sub_overflow(payload_length, en.data[en.size - 1] + 1, &out));
     payload_length = out;
     /* Update the MAC */
     header[3] = (payload_length >> 8);
     header[4] = payload_length & 0xff;
-    GUARD(s2n_hmac_reset(mac));
-    GUARD(s2n_hmac_update(mac, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
+    POSIX_GUARD(s2n_hmac_reset(mac));
+    POSIX_GUARD(s2n_hmac_update(mac, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
 
     if (conn->actual_protocol_version == S2N_SSLv3) {
-        GUARD(s2n_hmac_update(mac, header, 1));
-        GUARD(s2n_hmac_update(mac, header + 3, 2));
+        POSIX_GUARD(s2n_hmac_update(mac, header, 1));
+        POSIX_GUARD(s2n_hmac_update(mac, header + 3, 2));
     } else {
-        GUARD(s2n_hmac_update(mac, header, S2N_TLS_RECORD_HEADER_LENGTH));
+        POSIX_GUARD(s2n_hmac_update(mac, header, S2N_TLS_RECORD_HEADER_LENGTH));
     }
 
     struct s2n_blob seq = {.data = sequence_number,.size = S2N_TLS_SEQUENCE_NUM_LEN };
-    GUARD(s2n_increment_sequence_number(&seq));
+    POSIX_GUARD(s2n_increment_sequence_number(&seq));
 
     /* Padding */
     if (s2n_verify_cbc(conn, mac, &en) < 0) {
-        GUARD(s2n_stuffer_wipe(&conn->in));
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
+        POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
+        POSIX_BAIL(S2N_ERR_BAD_MESSAGE);
     }
 
     /* O.k., we've successfully read and decrypted the record, now we need to align the stuffer
      * for reading the plaintext data.
      */
-    GUARD(s2n_stuffer_reread(&conn->in));
-    GUARD(s2n_stuffer_reread(&conn->header_in));
+    POSIX_GUARD(s2n_stuffer_reread(&conn->in));
+    POSIX_GUARD(s2n_stuffer_reread(&conn->header_in));
 
     /* Skip the IV, if any */
     if (conn->actual_protocol_version > S2N_TLS10) {
-        GUARD(s2n_stuffer_skip_read(&conn->in, cipher_suite->record_alg->cipher->io.cbc.record_iv_size));
+        POSIX_GUARD(s2n_stuffer_skip_read(&conn->in, cipher_suite->record_alg->cipher->io.cbc.record_iv_size));
     }
 
     /* Truncate and wipe the MAC and any padding */
-    GUARD(s2n_stuffer_wipe_n(&conn->in, s2n_stuffer_data_available(&conn->in) - payload_length));
+    POSIX_GUARD(s2n_stuffer_wipe_n(&conn->in, s2n_stuffer_data_available(&conn->in) - payload_length));
     conn->in_status = PLAINTEXT;
 
     return 0;

--- a/tls/s2n_record_read_stream.c
+++ b/tls/s2n_record_read_stream.c
@@ -41,57 +41,57 @@ int s2n_record_parse_stream(
 {
     /* Add the header to the HMAC */
     uint8_t *header = s2n_stuffer_raw_read(&conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH);
-    notnull_check(header);
+    POSIX_ENSURE_REF(header);
 
     struct s2n_blob en = {.size = encrypted_length,.data = s2n_stuffer_raw_read(&conn->in, encrypted_length) };
-    notnull_check(en.data);
+    POSIX_ENSURE_REF(en.data);
 
     uint16_t payload_length = encrypted_length;
     uint8_t mac_digest_size;
-    GUARD(s2n_hmac_digest_size(mac->alg, &mac_digest_size));
+    POSIX_GUARD(s2n_hmac_digest_size(mac->alg, &mac_digest_size));
 
-    gte_check(payload_length, mac_digest_size);
+    POSIX_ENSURE_GTE(payload_length, mac_digest_size);
     payload_length -= mac_digest_size;
 
     /* Decrypt stuff! */
-    GUARD(cipher_suite->record_alg->cipher->io.stream.decrypt(session_key, &en, &en));
+    POSIX_GUARD(cipher_suite->record_alg->cipher->io.stream.decrypt(session_key, &en, &en));
 
     /* Update the MAC */
     header[3] = (payload_length >> 8);
     header[4] = payload_length & 0xff;
-    GUARD(s2n_hmac_reset(mac));
-    GUARD(s2n_hmac_update(mac, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
+    POSIX_GUARD(s2n_hmac_reset(mac));
+    POSIX_GUARD(s2n_hmac_update(mac, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
 
     if (conn->actual_protocol_version == S2N_SSLv3) {
-        GUARD(s2n_hmac_update(mac, header, 1));
-        GUARD(s2n_hmac_update(mac, header + 3, 2));
+        POSIX_GUARD(s2n_hmac_update(mac, header, 1));
+        POSIX_GUARD(s2n_hmac_update(mac, header + 3, 2));
     } else {
-        GUARD(s2n_hmac_update(mac, header, S2N_TLS_RECORD_HEADER_LENGTH));
+        POSIX_GUARD(s2n_hmac_update(mac, header, S2N_TLS_RECORD_HEADER_LENGTH));
     }
 
     struct s2n_blob seq = {.data = sequence_number,.size = S2N_TLS_SEQUENCE_NUM_LEN };
-    GUARD(s2n_increment_sequence_number(&seq));
+    POSIX_GUARD(s2n_increment_sequence_number(&seq));
 
     /* MAC check for streaming ciphers - no padding */
-    GUARD(s2n_hmac_update(mac, en.data, payload_length));
+    POSIX_GUARD(s2n_hmac_update(mac, en.data, payload_length));
 
     uint8_t check_digest[S2N_MAX_DIGEST_LEN];
-    lte_check(mac_digest_size, sizeof(check_digest));
-    GUARD(s2n_hmac_digest(mac, check_digest, mac_digest_size));
+    POSIX_ENSURE_LTE(mac_digest_size, sizeof(check_digest));
+    POSIX_GUARD(s2n_hmac_digest(mac, check_digest, mac_digest_size));
 
     if (s2n_hmac_digest_verify(en.data + payload_length, check_digest, mac_digest_size) < 0) {
-        GUARD(s2n_stuffer_wipe(&conn->in));
-        S2N_ERROR(S2N_ERR_BAD_MESSAGE);
+        POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
+        POSIX_BAIL(S2N_ERR_BAD_MESSAGE);
     }
 
     /* O.k., we've successfully read and decrypted the record, now we need to align the stuffer
      * for reading the plaintext data.
      */
-    GUARD(s2n_stuffer_reread(&conn->in));
-    GUARD(s2n_stuffer_reread(&conn->header_in));
+    POSIX_GUARD(s2n_stuffer_reread(&conn->in));
+    POSIX_GUARD(s2n_stuffer_reread(&conn->header_in));
 
     /* Truncate and wipe the MAC and any padding */
-    GUARD(s2n_stuffer_wipe_n(&conn->in, s2n_stuffer_data_available(&conn->in) - payload_length));
+    POSIX_GUARD(s2n_stuffer_wipe_n(&conn->in, s2n_stuffer_data_available(&conn->in) - payload_length));
     conn->in_status = PLAINTEXT;
 
     return 0;

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -47,12 +47,12 @@ S2N_RESULT s2n_read_in_bytes(struct s2n_connection *conn, struct s2n_stuffer *ou
         int r = s2n_connection_recv_stuffer(output, conn, remaining);
         if (r == 0) {
             conn->closed = 1;
-            BAIL(S2N_ERR_CLOSED);
+            RESULT_BAIL(S2N_ERR_CLOSED);
         } else if (r < 0) {
             if (errno == EWOULDBLOCK || errno == EAGAIN) {
-                BAIL(S2N_ERR_IO_BLOCKED);
+                RESULT_BAIL(S2N_ERR_IO_BLOCKED);
             }
-            BAIL(S2N_ERR_IO);
+            RESULT_BAIL(S2N_ERR_IO);
         }
         conn->wire_bytes_in += r;
     }
@@ -70,10 +70,10 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
         *record_type = TLS_APPLICATION_DATA;
         return S2N_SUCCESS;
     }
-    GUARD(s2n_stuffer_resize_if_empty(&conn->in, S2N_LARGE_FRAGMENT_LENGTH));
+    POSIX_GUARD(s2n_stuffer_resize_if_empty(&conn->in, S2N_LARGE_FRAGMENT_LENGTH));
 
     /* Read the record until we at least have a header */
-    GUARD_AS_POSIX(s2n_read_in_bytes(conn, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
+    POSIX_GUARD_RESULT(s2n_read_in_bytes(conn, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
 
     uint16_t fragment_length;
 
@@ -83,18 +83,18 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
         *isSSLv2 = 1;
 
         if (s2n_sslv2_record_header_parse(conn, record_type, &conn->client_protocol_version, &fragment_length) < 0) {
-            GUARD(s2n_connection_kill(conn));
+            POSIX_GUARD(s2n_connection_kill(conn));
             S2N_ERROR_PRESERVE_ERRNO();
         }
     } else {
         if (s2n_record_header_parse(conn, record_type, &fragment_length) < 0) {
-            GUARD(s2n_connection_kill(conn));
+            POSIX_GUARD(s2n_connection_kill(conn));
             S2N_ERROR_PRESERVE_ERRNO();
         }
     }
 
     /* Read enough to have the whole record */
-    GUARD_AS_POSIX(s2n_read_in_bytes(conn, &conn->in, fragment_length));
+    POSIX_GUARD_RESULT(s2n_read_in_bytes(conn, &conn->in, fragment_length));
 
     if (*isSSLv2) {
         return 0;
@@ -102,7 +102,7 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
 
     /* Decrypt and parse the record */
     if (s2n_record_parse(conn) < 0) {
-        GUARD(s2n_connection_kill(conn));
+        POSIX_GUARD(s2n_connection_kill(conn));
         S2N_ERROR_PRESERVE_ERRNO();
     }
 
@@ -111,7 +111,7 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
     * is decrypted.
     */
     if (conn->actual_protocol_version == S2N_TLS13 && *record_type == TLS_APPLICATION_DATA) {
-        GUARD(s2n_tls13_parse_record_type(&conn->in, record_type));
+        POSIX_GUARD(s2n_tls13_parse_record_type(&conn->in, record_type));
     }
 
     return 0;
@@ -163,22 +163,22 @@ ssize_t s2n_recv_impl(struct s2n_connection * conn, void *buf, ssize_t size, s2n
             switch (record_type)
             {
                 case TLS_ALERT:
-                    GUARD(s2n_process_alert_fragment(conn));
-                    GUARD(s2n_flush(conn, blocked));
+                    POSIX_GUARD(s2n_process_alert_fragment(conn));
+                    POSIX_GUARD(s2n_flush(conn, blocked));
                     break;
                 case TLS_HANDSHAKE:
-                    GUARD(s2n_post_handshake_recv(conn));
+                    POSIX_GUARD(s2n_post_handshake_recv(conn));
                     break;
             }
-            GUARD(s2n_stuffer_wipe(&conn->header_in));
-            GUARD(s2n_stuffer_wipe(&conn->in));
+            POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
+            POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
             conn->in_status = ENCRYPTED;
             continue;
         }
 
         out.size = MIN(size, s2n_stuffer_data_available(&conn->in));
 
-        GUARD(s2n_stuffer_erase_and_read(&conn->in, &out));
+        POSIX_GUARD(s2n_stuffer_erase_and_read(&conn->in, &out));
         bytes_read += out.size;
 
         out.data += out.size;
@@ -186,8 +186,8 @@ ssize_t s2n_recv_impl(struct s2n_connection * conn, void *buf, ssize_t size, s2n
 
         /* Are we ready for more encrypted data? */
         if (s2n_stuffer_data_available(&conn->in) == 0) {
-            GUARD(s2n_stuffer_wipe(&conn->header_in));
-            GUARD(s2n_stuffer_wipe(&conn->in));
+            POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
+            POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
             conn->in_status = ENCRYPTED;
         }
 
@@ -206,7 +206,7 @@ ssize_t s2n_recv_impl(struct s2n_connection * conn, void *buf, ssize_t size, s2n
 
 ssize_t s2n_recv(struct s2n_connection * conn, void *buf, ssize_t size, s2n_blocked_status * blocked)
 {
-    ENSURE_POSIX(!conn->recv_in_use, S2N_ERR_REENTRANCY);
+    POSIX_ENSURE(!conn->recv_in_use, S2N_ERR_REENTRANCY);
     conn->recv_in_use = true;
     ssize_t result = s2n_recv_impl(conn, buf, size, blocked);
     conn->recv_in_use = false;
@@ -223,14 +223,14 @@ int s2n_recv_close_notify(struct s2n_connection *conn, s2n_blocked_status * bloc
     int isSSLv2;
     *blocked = S2N_BLOCKED_ON_READ;
 
-    GUARD(s2n_read_full_record(conn, &record_type, &isSSLv2));
+    POSIX_GUARD(s2n_read_full_record(conn, &record_type, &isSSLv2));
 
     S2N_ERROR_IF(isSSLv2, S2N_ERR_BAD_MESSAGE);
 
     S2N_ERROR_IF(record_type != TLS_ALERT, S2N_ERR_SHUTDOWN_RECORD_TYPE);
 
     /* Only succeeds for an incoming close_notify alert */
-    GUARD(s2n_process_alert_fragment(conn));
+    POSIX_GUARD(s2n_process_alert_fragment(conn));
 
     *blocked = S2N_NOT_BLOCKED;
     return 0;

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -39,28 +39,28 @@ int s2n_allowed_to_cache_connection(struct s2n_connection *conn)
 
     struct s2n_config *config = conn->config;
 
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
     return config->use_session_cache;
 }
 
 static int s2n_tls12_serialize_resumption_state(struct s2n_connection *conn, struct s2n_stuffer *to)
 {
-    notnull_check(conn);
-    notnull_check(to);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(to);
 
     uint64_t now;
 
     S2N_ERROR_IF(s2n_stuffer_space_remaining(to) < S2N_STATE_SIZE_IN_BYTES, S2N_ERR_STUFFER_IS_FULL);
 
     /* Get the time */
-    GUARD(conn->config->wall_clock(conn->config->sys_clock_ctx, &now));
+    POSIX_GUARD(conn->config->wall_clock(conn->config->sys_clock_ctx, &now));
 
     /* Write the entry */
-    GUARD(s2n_stuffer_write_uint8(to, S2N_TLS12_SERIALIZED_FORMAT_VERSION));
-    GUARD(s2n_stuffer_write_uint8(to, conn->actual_protocol_version));
-    GUARD(s2n_stuffer_write_bytes(to, conn->secure.cipher_suite->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
-    GUARD(s2n_stuffer_write_uint64(to, now));
-    GUARD(s2n_stuffer_write_bytes(to, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
+    POSIX_GUARD(s2n_stuffer_write_uint8(to, S2N_TLS12_SERIALIZED_FORMAT_VERSION));
+    POSIX_GUARD(s2n_stuffer_write_uint8(to, conn->actual_protocol_version));
+    POSIX_GUARD(s2n_stuffer_write_bytes(to, conn->secure.cipher_suite->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
+    POSIX_GUARD(s2n_stuffer_write_uint64(to, now));
+    POSIX_GUARD(s2n_stuffer_write_bytes(to, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
 
     return 0;
 }
@@ -68,23 +68,23 @@ static int s2n_tls12_serialize_resumption_state(struct s2n_connection *conn, str
 static S2N_RESULT s2n_tls13_serialize_resumption_state(struct s2n_connection *conn, struct s2n_ticket_fields *ticket_fields,
         struct s2n_stuffer *out)
 {
-    ENSURE_REF(conn);
-    ENSURE_REF(ticket_fields);
-    ENSURE_REF(out);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(ticket_fields);
+    RESULT_ENSURE_REF(out);
 
     uint64_t current_time = 0;
 
     /* Get the time */
-    GUARD_AS_RESULT(conn->config->wall_clock(conn->config->sys_clock_ctx, &current_time));
+    RESULT_GUARD_POSIX(conn->config->wall_clock(conn->config->sys_clock_ctx, &current_time));
 
-    GUARD_AS_RESULT(s2n_stuffer_write_uint8(out, S2N_TLS13_SERIALIZED_FORMAT_VERSION));
-    GUARD_AS_RESULT(s2n_stuffer_write_uint8(out, conn->actual_protocol_version));
-    GUARD_AS_RESULT(s2n_stuffer_write_bytes(out, conn->secure.cipher_suite->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
-    GUARD_AS_RESULT(s2n_stuffer_write_uint64(out, current_time));
-    GUARD_AS_RESULT(s2n_stuffer_write_uint32(out, ticket_fields->ticket_age_add));
-    ENSURE_LTE(ticket_fields->session_secret.size, UINT8_MAX);
-    GUARD_AS_RESULT(s2n_stuffer_write_uint8(out, ticket_fields->session_secret.size));
-    GUARD_AS_RESULT(s2n_stuffer_write_bytes(out, ticket_fields->session_secret.data, ticket_fields->session_secret.size));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(out, S2N_TLS13_SERIALIZED_FORMAT_VERSION));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(out, conn->actual_protocol_version));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(out, conn->secure.cipher_suite->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint64(out, current_time));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint32(out, ticket_fields->ticket_age_add));
+    RESULT_ENSURE_LTE(ticket_fields->session_secret.size, UINT8_MAX);
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(out, ticket_fields->session_secret.size));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(out, ticket_fields->session_secret.data, ticket_fields->session_secret.size));
 
     return S2N_RESULT_OK;
 }
@@ -93,9 +93,9 @@ static S2N_RESULT s2n_serialize_resumption_state(struct s2n_connection *conn, st
         struct s2n_stuffer *out)
 {
     if(conn->actual_protocol_version < S2N_TLS13) {
-        GUARD_AS_RESULT(s2n_tls12_serialize_resumption_state(conn, out));
+        RESULT_GUARD_POSIX(s2n_tls12_serialize_resumption_state(conn, out));
     } else {
-        GUARD_RESULT(s2n_tls13_serialize_resumption_state(conn, ticket_fields, out));
+        RESULT_GUARD(s2n_tls13_serialize_resumption_state(conn, ticket_fields, out));
     }
     return S2N_RESULT_OK;
 }
@@ -108,25 +108,25 @@ static int s2n_deserialize_resumption_state(struct s2n_connection *conn, struct 
 
     S2N_ERROR_IF(s2n_stuffer_data_available(from) < S2N_STATE_SIZE_IN_BYTES, S2N_ERR_STUFFER_OUT_OF_DATA);
 
-    GUARD(s2n_stuffer_read_uint8(from, &format));
+    POSIX_GUARD(s2n_stuffer_read_uint8(from, &format));
     S2N_ERROR_IF(format != S2N_TLS12_SERIALIZED_FORMAT_VERSION, S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
 
-    GUARD(s2n_stuffer_read_uint8(from, &protocol_version));
+    POSIX_GUARD(s2n_stuffer_read_uint8(from, &protocol_version));
     S2N_ERROR_IF(protocol_version != conn->actual_protocol_version, S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
 
-    GUARD(s2n_stuffer_read_bytes(from, cipher_suite, S2N_TLS_CIPHER_SUITE_LEN));
+    POSIX_GUARD(s2n_stuffer_read_bytes(from, cipher_suite, S2N_TLS_CIPHER_SUITE_LEN));
     S2N_ERROR_IF(memcmp(conn->secure.cipher_suite->iana_value, cipher_suite, S2N_TLS_CIPHER_SUITE_LEN), S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
 
     uint64_t now;
-    GUARD(conn->config->wall_clock(conn->config->sys_clock_ctx, &now));
+    POSIX_GUARD(conn->config->wall_clock(conn->config->sys_clock_ctx, &now));
 
     uint64_t then;
-    GUARD(s2n_stuffer_read_uint64(from, &then));
+    POSIX_GUARD(s2n_stuffer_read_uint64(from, &then));
     S2N_ERROR_IF(then > now, S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
     S2N_ERROR_IF(now - then > conn->config->session_state_lifetime_in_nanos, S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
 
     /* Last but not least, put the master secret in place */
-    GUARD(s2n_stuffer_read_bytes(from, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
+    POSIX_GUARD(s2n_stuffer_read_bytes(from, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
 
     return 0;
 }
@@ -135,18 +135,18 @@ static int s2n_client_serialize_resumption_state(struct s2n_connection *conn, st
 {
     /* Serialize session ticket */
    if (conn->config->use_tickets && conn->client_ticket.size > 0) {
-       GUARD(s2n_stuffer_write_uint8(to, S2N_STATE_WITH_SESSION_TICKET));
-       GUARD(s2n_stuffer_write_uint16(to, conn->client_ticket.size));
-       GUARD(s2n_stuffer_write(to, &conn->client_ticket));
+       POSIX_GUARD(s2n_stuffer_write_uint8(to, S2N_STATE_WITH_SESSION_TICKET));
+       POSIX_GUARD(s2n_stuffer_write_uint16(to, conn->client_ticket.size));
+       POSIX_GUARD(s2n_stuffer_write(to, &conn->client_ticket));
    } else {
        /* Serialize session id */
-       GUARD(s2n_stuffer_write_uint8(to, S2N_STATE_WITH_SESSION_ID));
-       GUARD(s2n_stuffer_write_uint8(to, conn->session_id_len));
-       GUARD(s2n_stuffer_write_bytes(to, conn->session_id, conn->session_id_len));
+       POSIX_GUARD(s2n_stuffer_write_uint8(to, S2N_STATE_WITH_SESSION_ID));
+       POSIX_GUARD(s2n_stuffer_write_uint8(to, conn->session_id_len));
+       POSIX_GUARD(s2n_stuffer_write_bytes(to, conn->session_id, conn->session_id_len));
    }
 
     /* Serialize session state */
-    GUARD_AS_POSIX(s2n_serialize_resumption_state(conn, NULL, to));
+    POSIX_GUARD_RESULT(s2n_serialize_resumption_state(conn, NULL, to));
 
     return 0;
 }
@@ -154,27 +154,27 @@ static int s2n_client_serialize_resumption_state(struct s2n_connection *conn, st
 static int s2n_client_deserialize_session_state(struct s2n_connection *conn, struct s2n_stuffer *from)
 {
     if (s2n_stuffer_data_available(from) < S2N_STATE_SIZE_IN_BYTES) {
-        S2N_ERROR(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
+        POSIX_BAIL(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
     }
 
     uint8_t format;
     uint64_t then;
 
-    GUARD(s2n_stuffer_read_uint8(from, &format));
+    POSIX_GUARD(s2n_stuffer_read_uint8(from, &format));
     if (format != S2N_TLS12_SERIALIZED_FORMAT_VERSION) {
-        S2N_ERROR(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
+        POSIX_BAIL(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
     }
 
-    GUARD(s2n_stuffer_read_uint8(from, &conn->actual_protocol_version));
+    POSIX_GUARD(s2n_stuffer_read_uint8(from, &conn->actual_protocol_version));
 
     uint8_t *cipher_suite_wire = s2n_stuffer_raw_read(from, S2N_TLS_CIPHER_SUITE_LEN);
-    notnull_check(cipher_suite_wire);
-    GUARD(s2n_set_cipher_as_client(conn, cipher_suite_wire));
+    POSIX_ENSURE_REF(cipher_suite_wire);
+    POSIX_GUARD(s2n_set_cipher_as_client(conn, cipher_suite_wire));
 
-    GUARD(s2n_stuffer_read_uint64(from, &then));
+    POSIX_GUARD(s2n_stuffer_read_uint64(from, &then));
 
     /* Last but not least, put the master secret in place */
-    GUARD(s2n_stuffer_read_bytes(from, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
+    POSIX_GUARD(s2n_stuffer_read_bytes(from, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
 
     return 0;
 }
@@ -182,17 +182,17 @@ static int s2n_client_deserialize_session_state(struct s2n_connection *conn, str
 static int s2n_client_deserialize_with_session_id(struct s2n_connection *conn, struct s2n_stuffer *from)
 {
     uint8_t session_id_len;
-    GUARD(s2n_stuffer_read_uint8(from, &session_id_len));
+    POSIX_GUARD(s2n_stuffer_read_uint8(from, &session_id_len));
 
     if (session_id_len == 0 || session_id_len > S2N_TLS_SESSION_ID_MAX_LEN
         || session_id_len > s2n_stuffer_data_available(from)) {
-        S2N_ERROR(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
+        POSIX_BAIL(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
     }
 
     conn->session_id_len = session_id_len;
-    GUARD(s2n_stuffer_read_bytes(from, conn->session_id, session_id_len));
+    POSIX_GUARD(s2n_stuffer_read_bytes(from, conn->session_id, session_id_len));
 
-    GUARD(s2n_client_deserialize_session_state(conn, from));
+    POSIX_GUARD(s2n_client_deserialize_session_state(conn, from));
 
     return 0;
 }
@@ -200,16 +200,16 @@ static int s2n_client_deserialize_with_session_id(struct s2n_connection *conn, s
 static int s2n_client_deserialize_with_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *from)
 {
     uint16_t session_ticket_len;
-    GUARD(s2n_stuffer_read_uint16(from, &session_ticket_len));
+    POSIX_GUARD(s2n_stuffer_read_uint16(from, &session_ticket_len));
 
     if (session_ticket_len == 0 || session_ticket_len > s2n_stuffer_data_available(from)) {
-        S2N_ERROR(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
+        POSIX_BAIL(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
     }
 
-    GUARD(s2n_realloc(&conn->client_ticket, session_ticket_len));
-    GUARD(s2n_stuffer_read(from, &conn->client_ticket));
+    POSIX_GUARD(s2n_realloc(&conn->client_ticket, session_ticket_len));
+    POSIX_GUARD(s2n_stuffer_read(from, &conn->client_ticket));
 
-    GUARD(s2n_client_deserialize_session_state(conn, from));
+    POSIX_GUARD(s2n_client_deserialize_session_state(conn, from));
 
     return 0;
 }
@@ -217,17 +217,17 @@ static int s2n_client_deserialize_with_session_ticket(struct s2n_connection *con
 static int s2n_client_deserialize_resumption_state(struct s2n_connection *conn, struct s2n_stuffer *from)
 {
     uint8_t format;
-    GUARD(s2n_stuffer_read_uint8(from, &format));
+    POSIX_GUARD(s2n_stuffer_read_uint8(from, &format));
 
     switch (format) {
     case S2N_STATE_WITH_SESSION_ID:
-        GUARD(s2n_client_deserialize_with_session_id(conn, from));
+        POSIX_GUARD(s2n_client_deserialize_with_session_id(conn, from));
         break;
     case S2N_STATE_WITH_SESSION_TICKET:
-        GUARD(s2n_client_deserialize_with_session_ticket(conn, from));
+        POSIX_GUARD(s2n_client_deserialize_with_session_ticket(conn, from));
         break;
     default:
-        S2N_ERROR(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
+        POSIX_BAIL(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
     }
 
     return 0;
@@ -240,20 +240,20 @@ int s2n_resume_from_cache(struct s2n_connection *conn)
 
     uint8_t data[S2N_TLS12_TICKET_SIZE_IN_BYTES] = { 0 };
     struct s2n_blob entry = {0};
-    GUARD(s2n_blob_init(&entry, data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
+    POSIX_GUARD(s2n_blob_init(&entry, data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
     uint64_t size = entry.size;
     int result = conn->config->cache_retrieve(conn, conn->config->cache_retrieve_data, conn->session_id, conn->session_id_len, entry.data, &size);
     if (result == S2N_CALLBACK_BLOCKED) {
-        S2N_ERROR(S2N_ERR_ASYNC_BLOCKED);
+        POSIX_BAIL(S2N_ERR_ASYNC_BLOCKED);
     }
-    GUARD(result);
+    POSIX_GUARD(result);
 
     S2N_ERROR_IF(size != entry.size, S2N_ERR_SIZE_MISMATCH);
 
     struct s2n_stuffer from = {0};
-    GUARD(s2n_stuffer_init(&from, &entry));
-    GUARD(s2n_stuffer_write(&from, &entry));
-    GUARD(s2n_decrypt_session_cache(conn, &from));
+    POSIX_GUARD(s2n_stuffer_init(&from, &entry));
+    POSIX_GUARD(s2n_stuffer_write(&from, &entry));
+    POSIX_GUARD(s2n_decrypt_session_cache(conn, &from));
 
     return 0;
 }
@@ -262,7 +262,7 @@ int s2n_store_to_cache(struct s2n_connection *conn)
 {
     uint8_t data[S2N_TLS12_TICKET_SIZE_IN_BYTES] = { 0 };
     struct s2n_blob entry = {0};
-    GUARD(s2n_blob_init(&entry, data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
+    POSIX_GUARD(s2n_blob_init(&entry, data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
     struct s2n_stuffer to = {0};
 
     /* session_id_len should always be >0 since either the Client provided a SessionId or the Server generated a new
@@ -270,8 +270,8 @@ int s2n_store_to_cache(struct s2n_connection *conn)
     S2N_ERROR_IF(conn->session_id_len == 0, S2N_ERR_SESSION_ID_TOO_SHORT);
     S2N_ERROR_IF(conn->session_id_len > S2N_TLS_SESSION_ID_MAX_LEN, S2N_ERR_SESSION_ID_TOO_LONG);
 
-    GUARD(s2n_stuffer_init(&to, &entry));
-    GUARD(s2n_encrypt_session_cache(conn, &to));
+    POSIX_GUARD(s2n_stuffer_init(&to, &entry));
+    POSIX_GUARD(s2n_encrypt_session_cache(conn, &to));
 
     /* Store to the cache */
     conn->config->cache_store(conn, conn->config->cache_store_data, S2N_TLS_SESSION_CACHE_TTL, conn->session_id, conn->session_id_len, entry.data, entry.size);
@@ -281,24 +281,24 @@ int s2n_store_to_cache(struct s2n_connection *conn)
 
 int s2n_connection_set_session(struct s2n_connection *conn, const uint8_t *session, size_t length)
 {
-    notnull_check(conn);
-    notnull_check(session);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(session);
 
     DEFER_CLEANUP(struct s2n_blob session_data = {0}, s2n_free);
-    GUARD(s2n_alloc(&session_data, length));
+    POSIX_GUARD(s2n_alloc(&session_data, length));
     memcpy(session_data.data, session, length);
 
     struct s2n_stuffer from = {0};
-    GUARD(s2n_stuffer_init(&from, &session_data));
-    GUARD(s2n_stuffer_write(&from, &session_data));
-    GUARD(s2n_client_deserialize_resumption_state(conn, &from));
+    POSIX_GUARD(s2n_stuffer_init(&from, &session_data));
+    POSIX_GUARD(s2n_stuffer_write(&from, &session_data));
+    POSIX_GUARD(s2n_client_deserialize_resumption_state(conn, &from));
     return 0;
 }
 
 int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, size_t max_length)
 {
-    notnull_check(conn);
-    notnull_check(session);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(session);
 
     int len = s2n_connection_get_session_length(conn);
 
@@ -309,19 +309,19 @@ int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, si
     S2N_ERROR_IF(len > max_length, S2N_ERR_SERIALIZED_SESSION_STATE_TOO_LONG);
 
     struct s2n_blob serialized_data = {0};
-    GUARD(s2n_blob_init(&serialized_data, session, len));
-    GUARD(s2n_blob_zero(&serialized_data));
+    POSIX_GUARD(s2n_blob_init(&serialized_data, session, len));
+    POSIX_GUARD(s2n_blob_zero(&serialized_data));
 
     struct s2n_stuffer to = {0};
-    GUARD(s2n_stuffer_init(&to, &serialized_data));
-    GUARD(s2n_client_serialize_resumption_state(conn, &to));
+    POSIX_GUARD(s2n_stuffer_init(&to, &serialized_data));
+    POSIX_GUARD(s2n_client_serialize_resumption_state(conn, &to));
 
     return len;
 }
 
 int s2n_connection_get_session_ticket_lifetime_hint(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     S2N_ERROR_IF(!(conn->config->use_tickets && conn->client_ticket.size > 0), S2N_ERR_SESSION_TICKET_NOT_SUPPORTED);
 
     /* Session resumption using session ticket */
@@ -349,7 +349,7 @@ int s2n_connection_is_session_resumed(struct s2n_connection *conn)
 
 int s2n_connection_is_ocsp_stapled(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     if (conn->actual_protocol_version >= S2N_TLS13) {
         return (s2n_server_can_send_ocsp(conn) || s2n_server_sent_ocsp(conn));
@@ -362,15 +362,15 @@ int s2n_config_is_encrypt_decrypt_key_available(struct s2n_config *config)
 {
     uint64_t now;
     struct s2n_ticket_key *ticket_key = NULL;
-    GUARD(config->wall_clock(config->sys_clock_ctx, &now));
-    notnull_check(config->ticket_keys);
+    POSIX_GUARD(config->wall_clock(config->sys_clock_ctx, &now));
+    POSIX_ENSURE_REF(config->ticket_keys);
 
     uint32_t ticket_keys_len = 0;
-    GUARD_AS_POSIX(s2n_set_len(config->ticket_keys, &ticket_keys_len));
+    POSIX_GUARD_RESULT(s2n_set_len(config->ticket_keys, &ticket_keys_len));
 
     for (uint32_t i = ticket_keys_len; i > 0; i--) {
         uint32_t idx = i - 1;
-        GUARD_AS_POSIX(s2n_set_get(config->ticket_keys, idx, (void **)&ticket_key));
+        POSIX_GUARD_RESULT(s2n_set_get(config->ticket_keys, idx, (void **)&ticket_key));
         uint64_t key_intro_time = ticket_key->intro_timestamp;
 
         if (key_intro_time < now
@@ -397,7 +397,7 @@ int s2n_compute_weight_of_encrypt_decrypt_keys(struct s2n_config *config,
 
     /* Compute weight of encrypt-decrypt keys */
     for (int i = 0; i < num_encrypt_decrypt_keys; i++) {
-        GUARD_AS_POSIX(s2n_set_get(config->ticket_keys, encrypt_decrypt_keys_index[i], (void **)&ticket_key));
+        POSIX_GUARD_RESULT(s2n_set_get(config->ticket_keys, encrypt_decrypt_keys_index[i], (void **)&ticket_key));
 
         uint64_t key_intro_time = ticket_key->intro_timestamp;
         uint64_t key_encryption_peak_time = key_intro_time + (config->encrypt_decrypt_key_lifetime_in_nanos / 2);
@@ -416,7 +416,7 @@ int s2n_compute_weight_of_encrypt_decrypt_keys(struct s2n_config *config,
 
     /* Pick a random number in [0, 1). Using 53 bits (IEEE 754 double-precision floats). */
     uint64_t random_int = 0;
-    GUARD_AS_POSIX(s2n_public_random(pow(2, 53), &random_int));
+    POSIX_GUARD_RESULT(s2n_public_random(pow(2, 53), &random_int));
     double random = (double)random_int / (double)pow(2, 53);
 
     /* Compute cumulative weight of encrypt-decrypt keys */
@@ -432,7 +432,7 @@ int s2n_compute_weight_of_encrypt_decrypt_keys(struct s2n_config *config,
         }
     }
 
-    S2N_ERROR(S2N_ERR_ENCRYPT_DECRYPT_KEY_SELECTION_FAILED);
+    POSIX_BAIL(S2N_ERR_ENCRYPT_DECRYPT_KEY_SELECTION_FAILED);
 }
 
 /* This function is used in s2n_encrypt_session_ticket in order for s2n to
@@ -445,15 +445,15 @@ struct s2n_ticket_key *s2n_get_ticket_encrypt_decrypt_key(struct s2n_config *con
     struct s2n_ticket_key *ticket_key = NULL;
 
     uint64_t now;
-    GUARD_PTR(config->wall_clock(config->sys_clock_ctx, &now));
-    notnull_check_ptr(config->ticket_keys);
+    PTR_GUARD_POSIX(config->wall_clock(config->sys_clock_ctx, &now));
+    PTR_ENSURE_REF(config->ticket_keys);
 
     uint32_t ticket_keys_len = 0;
-    GUARD_RESULT_PTR(s2n_set_len(config->ticket_keys, &ticket_keys_len));
+    PTR_GUARD_RESULT(s2n_set_len(config->ticket_keys, &ticket_keys_len));
 
     for (uint32_t i = ticket_keys_len; i > 0; i--) {
         uint32_t idx = i - 1;
-        GUARD_RESULT_PTR(s2n_set_get(config->ticket_keys, idx, (void **)&ticket_key));
+        PTR_GUARD_RESULT(s2n_set_get(config->ticket_keys, idx, (void **)&ticket_key));
         uint64_t key_intro_time = ticket_key->intro_timestamp;
 
         if (key_intro_time < now
@@ -464,18 +464,18 @@ struct s2n_ticket_key *s2n_get_ticket_encrypt_decrypt_key(struct s2n_config *con
     }
 
     if (num_encrypt_decrypt_keys == 0) {
-        S2N_ERROR_PTR(S2N_ERR_NO_TICKET_ENCRYPT_DECRYPT_KEY);
+        PTR_BAIL(S2N_ERR_NO_TICKET_ENCRYPT_DECRYPT_KEY);
     }
 
     if (num_encrypt_decrypt_keys == 1) {
-        GUARD_RESULT_PTR(s2n_set_get(config->ticket_keys, encrypt_decrypt_keys_index[0], (void **)&ticket_key));
+        PTR_GUARD_RESULT(s2n_set_get(config->ticket_keys, encrypt_decrypt_keys_index[0], (void **)&ticket_key));
         return ticket_key;
     }
 
     int8_t idx;
-    GUARD_PTR(idx = s2n_compute_weight_of_encrypt_decrypt_keys(config, encrypt_decrypt_keys_index, num_encrypt_decrypt_keys, now));
+    PTR_GUARD_POSIX(idx = s2n_compute_weight_of_encrypt_decrypt_keys(config, encrypt_decrypt_keys_index, num_encrypt_decrypt_keys, now));
 
-    GUARD_RESULT_PTR(s2n_set_get(config->ticket_keys, idx, (void **)&ticket_key));
+    PTR_GUARD_RESULT(s2n_set_get(config->ticket_keys, idx, (void **)&ticket_key));
     return ticket_key;
 }
 
@@ -486,14 +486,14 @@ struct s2n_ticket_key *s2n_find_ticket_key(struct s2n_config *config, const uint
 {
     uint64_t now;
     struct s2n_ticket_key *ticket_key = NULL;
-    GUARD_PTR(config->wall_clock(config->sys_clock_ctx, &now));
-    notnull_check_ptr(config->ticket_keys);
+    PTR_GUARD_POSIX(config->wall_clock(config->sys_clock_ctx, &now));
+    PTR_ENSURE_REF(config->ticket_keys);
 
     uint32_t ticket_keys_len = 0;
-    GUARD_RESULT_PTR(s2n_set_len(config->ticket_keys, &ticket_keys_len));
+    PTR_GUARD_RESULT(s2n_set_len(config->ticket_keys, &ticket_keys_len));
 
     for (uint32_t i = 0; i < ticket_keys_len; i++) {
-        GUARD_RESULT_PTR(s2n_set_get(config->ticket_keys, i, (void **)&ticket_key));
+        PTR_GUARD_RESULT(s2n_set_get(config->ticket_keys, i, (void **)&ticket_key));
 
         if (memcmp(ticket_key->key_name, name, S2N_TICKET_KEY_NAME_LEN) == 0) {
 
@@ -520,11 +520,11 @@ int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_ticket_fi
 
     uint8_t iv_data[S2N_TLS_GCM_IV_LEN] = { 0 };
     struct s2n_blob iv = {0};
-    GUARD(s2n_blob_init(&iv, iv_data, sizeof(iv_data)));
+    POSIX_GUARD(s2n_blob_init(&iv, iv_data, sizeof(iv_data)));
 
     uint8_t aad_data[S2N_TICKET_AAD_LEN] = { 0 };
     struct s2n_blob aad_blob = {0};
-    GUARD(s2n_blob_init(&aad_blob, aad_data, sizeof(aad_data)));
+    POSIX_GUARD(s2n_blob_init(&aad_blob, aad_data, sizeof(aad_data)));
     struct s2n_stuffer aad = {0};
 
     key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
@@ -532,37 +532,37 @@ int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_ticket_fi
     /* No keys loaded by the user or the keys are either in decrypt-only or expired state */
     S2N_ERROR_IF(!key, S2N_ERR_NO_TICKET_ENCRYPT_DECRYPT_KEY);
 
-    GUARD(s2n_stuffer_write_bytes(to, key->key_name, S2N_TICKET_KEY_NAME_LEN));
+    POSIX_GUARD(s2n_stuffer_write_bytes(to, key->key_name, S2N_TICKET_KEY_NAME_LEN));
 
-    GUARD_AS_POSIX(s2n_get_public_random_data(&iv));
-    GUARD(s2n_stuffer_write(to, &iv));
+    POSIX_GUARD_RESULT(s2n_get_public_random_data(&iv));
+    POSIX_GUARD(s2n_stuffer_write(to, &iv));
 
-    GUARD(s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN));
-    GUARD(s2n_session_key_alloc(&aes_ticket_key));
-    GUARD(s2n_aes256_gcm.init(&aes_ticket_key));
-    GUARD(s2n_aes256_gcm.set_encryption_key(&aes_ticket_key, &aes_key_blob));
+    POSIX_GUARD(s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN));
+    POSIX_GUARD(s2n_session_key_alloc(&aes_ticket_key));
+    POSIX_GUARD(s2n_aes256_gcm.init(&aes_ticket_key));
+    POSIX_GUARD(s2n_aes256_gcm.set_encryption_key(&aes_ticket_key, &aes_key_blob));
 
-    GUARD(s2n_stuffer_init(&aad, &aad_blob));
-    GUARD(s2n_stuffer_write_bytes(&aad, key->implicit_aad, S2N_TICKET_AAD_IMPLICIT_LEN));
-    GUARD(s2n_stuffer_write_bytes(&aad, key->key_name, S2N_TICKET_KEY_NAME_LEN));
+    POSIX_GUARD(s2n_stuffer_init(&aad, &aad_blob));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&aad, key->implicit_aad, S2N_TICKET_AAD_IMPLICIT_LEN));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&aad, key->key_name, S2N_TICKET_KEY_NAME_LEN));
 
     struct s2n_blob state_blob = { 0 };
     struct s2n_stuffer state = { 0 };
 
     uint8_t s_data[S2N_MAX_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = { 0 };
-    GUARD(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
-    GUARD(s2n_stuffer_init(&state, &state_blob));
-    GUARD_AS_POSIX(s2n_serialize_resumption_state(conn, ticket_fields, &state));
+    POSIX_GUARD(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
+    POSIX_GUARD(s2n_stuffer_init(&state, &state_blob));
+    POSIX_GUARD_RESULT(s2n_serialize_resumption_state(conn, ticket_fields, &state));
     
     /* Get the correct session resumption ticket size */
     state_blob.size = s2n_stuffer_data_available(&state) + S2N_TLS_GCM_TAG_LEN;
 
-    GUARD(s2n_aes256_gcm.io.aead.encrypt(&aes_ticket_key, &iv, &aad_blob, &state_blob, &state_blob));
+    POSIX_GUARD(s2n_aes256_gcm.io.aead.encrypt(&aes_ticket_key, &iv, &aad_blob, &state_blob, &state_blob));
 
-    GUARD(s2n_stuffer_write(to, &state_blob));
+    POSIX_GUARD(s2n_stuffer_write(to, &state_blob));
 
-    GUARD(s2n_aes256_gcm.destroy_key(&aes_ticket_key));
-    GUARD(s2n_session_key_free(&aes_ticket_key));
+    POSIX_GUARD(s2n_aes256_gcm.destroy_key(&aes_ticket_key));
+    POSIX_GUARD(s2n_session_key_free(&aes_ticket_key));
 
     return 0;
 }
@@ -578,52 +578,52 @@ int s2n_decrypt_session_ticket(struct s2n_connection *conn)
 
     uint8_t iv_data[S2N_TLS_GCM_IV_LEN] = { 0 };
     struct s2n_blob iv = { 0 };
-    GUARD(s2n_blob_init(&iv, iv_data, sizeof(iv_data)));
+    POSIX_GUARD(s2n_blob_init(&iv, iv_data, sizeof(iv_data)));
 
     uint8_t aad_data[S2N_TICKET_AAD_LEN] = { 0 };
     struct s2n_blob aad_blob = {0};
-    GUARD(s2n_blob_init(&aad_blob, aad_data, sizeof(aad_data)));
+    POSIX_GUARD(s2n_blob_init(&aad_blob, aad_data, sizeof(aad_data)));
     struct s2n_stuffer aad = {0};
 
     uint8_t s_data[S2N_STATE_SIZE_IN_BYTES] = { 0 };
     struct s2n_blob state_blob = {0};
-    GUARD(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
+    POSIX_GUARD(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
     struct s2n_stuffer state = {0};
 
     uint8_t en_data[S2N_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = {0};
     struct s2n_blob en_blob = {0};
-    GUARD(s2n_blob_init(&en_blob, en_data, sizeof(en_data)));
+    POSIX_GUARD(s2n_blob_init(&en_blob, en_data, sizeof(en_data)));
 
     from = &conn->client_ticket_to_decrypt;
-    GUARD(s2n_stuffer_read_bytes(from, key_name, S2N_TICKET_KEY_NAME_LEN));
+    POSIX_GUARD(s2n_stuffer_read_bytes(from, key_name, S2N_TICKET_KEY_NAME_LEN));
 
     key = s2n_find_ticket_key(conn->config, key_name);
 
     /* Key has expired; do full handshake with New Session Ticket (NST) */
     S2N_ERROR_IF(!key, S2N_ERR_KEY_USED_IN_SESSION_TICKET_NOT_FOUND);
 
-    GUARD(s2n_stuffer_read(from, &iv));
+    POSIX_GUARD(s2n_stuffer_read(from, &iv));
 
     s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN);
-    GUARD(s2n_session_key_alloc(&aes_ticket_key));
-    GUARD(s2n_aes256_gcm.init(&aes_ticket_key));
-    GUARD(s2n_aes256_gcm.set_decryption_key(&aes_ticket_key, &aes_key_blob));
+    POSIX_GUARD(s2n_session_key_alloc(&aes_ticket_key));
+    POSIX_GUARD(s2n_aes256_gcm.init(&aes_ticket_key));
+    POSIX_GUARD(s2n_aes256_gcm.set_decryption_key(&aes_ticket_key, &aes_key_blob));
 
-    GUARD(s2n_stuffer_init(&aad, &aad_blob));
-    GUARD(s2n_stuffer_write_bytes(&aad, key->implicit_aad, S2N_TICKET_AAD_IMPLICIT_LEN));
-    GUARD(s2n_stuffer_write_bytes(&aad, key->key_name, S2N_TICKET_KEY_NAME_LEN));
+    POSIX_GUARD(s2n_stuffer_init(&aad, &aad_blob));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&aad, key->implicit_aad, S2N_TICKET_AAD_IMPLICIT_LEN));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&aad, key->key_name, S2N_TICKET_KEY_NAME_LEN));
 
-    GUARD(s2n_stuffer_read(from, &en_blob));
+    POSIX_GUARD(s2n_stuffer_read(from, &en_blob));
 
-    GUARD(s2n_aes256_gcm.io.aead.decrypt(&aes_ticket_key, &iv, &aad_blob, &en_blob, &en_blob));
+    POSIX_GUARD(s2n_aes256_gcm.io.aead.decrypt(&aes_ticket_key, &iv, &aad_blob, &en_blob, &en_blob));
 
-    GUARD(s2n_stuffer_init(&state, &state_blob));
-    GUARD(s2n_stuffer_write_bytes(&state, en_data, S2N_STATE_SIZE_IN_BYTES));
+    POSIX_GUARD(s2n_stuffer_init(&state, &state_blob));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&state, en_data, S2N_STATE_SIZE_IN_BYTES));
 
-    GUARD(s2n_deserialize_resumption_state(conn, &state));
+    POSIX_GUARD(s2n_deserialize_resumption_state(conn, &state));
 
     uint64_t now;
-    GUARD(conn->config->wall_clock(conn->config->sys_clock_ctx, &now));
+    POSIX_GUARD(conn->config->wall_clock(conn->config->sys_clock_ctx, &now));
 
     /* If the key is in decrypt-only state, then a new key is assigned
      * for the ticket.
@@ -657,51 +657,51 @@ int s2n_decrypt_session_cache(struct s2n_connection *conn, struct s2n_stuffer *f
 
     uint8_t iv_data[S2N_TLS_GCM_IV_LEN] = { 0 };
     struct s2n_blob iv = {0};
-    GUARD(s2n_blob_init(&iv, iv_data, sizeof(iv_data)));
+    POSIX_GUARD(s2n_blob_init(&iv, iv_data, sizeof(iv_data)));
 
     uint8_t aad_data[S2N_TICKET_AAD_LEN] = { 0 };
     struct s2n_blob aad_blob = {0};
-    GUARD(s2n_blob_init(&aad_blob, aad_data, sizeof(aad_data)));
+    POSIX_GUARD(s2n_blob_init(&aad_blob, aad_data, sizeof(aad_data)));
     struct s2n_stuffer aad = {0};
 
     uint8_t s_data[S2N_STATE_SIZE_IN_BYTES] = { 0 };
     struct s2n_blob state_blob = {0};
-    GUARD(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
+    POSIX_GUARD(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
     struct s2n_stuffer state = {0};
 
     uint8_t en_data[S2N_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = {0};
     struct s2n_blob en_blob = {0};
-    GUARD(s2n_blob_init(&en_blob, en_data, sizeof(en_data)));
+    POSIX_GUARD(s2n_blob_init(&en_blob, en_data, sizeof(en_data)));
 
-    GUARD(s2n_stuffer_read_bytes(from, key_name, S2N_TICKET_KEY_NAME_LEN));
+    POSIX_GUARD(s2n_stuffer_read_bytes(from, key_name, S2N_TICKET_KEY_NAME_LEN));
 
     key = s2n_find_ticket_key(conn->config, key_name);
 
     /* Key has expired; do full handshake with New Session Ticket (NST) */
     S2N_ERROR_IF(!key, S2N_ERR_KEY_USED_IN_SESSION_TICKET_NOT_FOUND);
 
-    GUARD(s2n_stuffer_read(from, &iv));
+    POSIX_GUARD(s2n_stuffer_read(from, &iv));
 
     s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN);
-    GUARD(s2n_session_key_alloc(&aes_ticket_key));
-    GUARD(s2n_aes256_gcm.init(&aes_ticket_key));
-    GUARD(s2n_aes256_gcm.set_decryption_key(&aes_ticket_key, &aes_key_blob));
+    POSIX_GUARD(s2n_session_key_alloc(&aes_ticket_key));
+    POSIX_GUARD(s2n_aes256_gcm.init(&aes_ticket_key));
+    POSIX_GUARD(s2n_aes256_gcm.set_decryption_key(&aes_ticket_key, &aes_key_blob));
 
-    GUARD(s2n_stuffer_init(&aad, &aad_blob));
-    GUARD(s2n_stuffer_write_bytes(&aad, key->implicit_aad, S2N_TICKET_AAD_IMPLICIT_LEN));
-    GUARD(s2n_stuffer_write_bytes(&aad, key->key_name, S2N_TICKET_KEY_NAME_LEN));
+    POSIX_GUARD(s2n_stuffer_init(&aad, &aad_blob));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&aad, key->implicit_aad, S2N_TICKET_AAD_IMPLICIT_LEN));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&aad, key->key_name, S2N_TICKET_KEY_NAME_LEN));
 
-    GUARD(s2n_stuffer_read(from, &en_blob));
+    POSIX_GUARD(s2n_stuffer_read(from, &en_blob));
 
-    GUARD(s2n_aes256_gcm.io.aead.decrypt(&aes_ticket_key, &iv, &aad_blob, &en_blob, &en_blob));
+    POSIX_GUARD(s2n_aes256_gcm.io.aead.decrypt(&aes_ticket_key, &iv, &aad_blob, &en_blob, &en_blob));
 
-    GUARD(s2n_stuffer_init(&state, &state_blob));
-    GUARD(s2n_stuffer_write_bytes(&state, en_data, S2N_STATE_SIZE_IN_BYTES));
+    POSIX_GUARD(s2n_stuffer_init(&state, &state_blob));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&state, en_data, S2N_STATE_SIZE_IN_BYTES));
 
-    GUARD(s2n_deserialize_resumption_state(conn, &state));
+    POSIX_GUARD(s2n_deserialize_resumption_state(conn, &state));
 
-    GUARD(s2n_aes256_gcm.destroy_key(&aes_ticket_key));
-    GUARD(s2n_session_key_free(&aes_ticket_key));
+    POSIX_GUARD(s2n_aes256_gcm.destroy_key(&aes_ticket_key));
+    POSIX_GUARD(s2n_session_key_free(&aes_ticket_key));
 
     return 0;
 }
@@ -721,14 +721,14 @@ int s2n_config_wipe_expired_ticket_crypto_keys(struct s2n_config *config, int8_t
     }
 
     uint64_t now;
-    GUARD(config->wall_clock(config->sys_clock_ctx, &now));
-    notnull_check(config->ticket_keys);
+    POSIX_GUARD(config->wall_clock(config->sys_clock_ctx, &now));
+    POSIX_ENSURE_REF(config->ticket_keys);
 
     uint32_t ticket_keys_len = 0;
-    GUARD_AS_POSIX(s2n_set_len(config->ticket_keys, &ticket_keys_len));
+    POSIX_GUARD_RESULT(s2n_set_len(config->ticket_keys, &ticket_keys_len));
 
     for (uint32_t i = 0; i < ticket_keys_len; i++) {
-        GUARD_AS_POSIX(s2n_set_get(config->ticket_keys, i, (void **)&ticket_key));
+        POSIX_GUARD_RESULT(s2n_set_get(config->ticket_keys, i, (void **)&ticket_key));
         if (now >= ticket_key->intro_timestamp +
                    config->encrypt_decrypt_key_lifetime_in_nanos + config->decrypt_key_lifetime_in_nanos) {
             expired_keys_index[num_of_expired_keys] = i;
@@ -738,7 +738,7 @@ int s2n_config_wipe_expired_ticket_crypto_keys(struct s2n_config *config, int8_t
 
 end:
     for (int j = 0; j < num_of_expired_keys; j++) {
-        GUARD_AS_POSIX(s2n_set_remove(config->ticket_keys, expired_keys_index[j] - j));
+        POSIX_GUARD_RESULT(s2n_set_remove(config->ticket_keys, expired_keys_index[j] - j));
     }
 
     return 0;
@@ -748,13 +748,13 @@ end:
 int s2n_config_store_ticket_key(struct s2n_config *config, struct s2n_ticket_key *key)
 {
     /* Keys are stored from oldest to newest */
-    GUARD_AS_POSIX(s2n_set_add(config->ticket_keys, key));
+    POSIX_GUARD_RESULT(s2n_set_add(config->ticket_keys, key));
     return S2N_SUCCESS;
 }
 
 int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num)
 {
-    notnull_check(config);
+    POSIX_ENSURE_REF(config);
 
     config->initial_tickets_to_send = num;
 
@@ -762,10 +762,10 @@ int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num)
 }
 
 int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num) {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     uint32_t out = conn->tickets_to_send + num;
-    ENSURE_POSIX(out <= UINT16_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    POSIX_ENSURE(out <= UINT16_MAX, S2N_ERR_INTEGER_OVERFLOW);
     conn->tickets_to_send = out;
 
     return S2N_SUCCESS;

--- a/tls/s2n_server_cert.c
+++ b/tls/s2n_server_cert.c
@@ -27,29 +27,29 @@ int s2n_server_cert_recv(struct s2n_connection *conn)
 {
     if (conn->actual_protocol_version == S2N_TLS13) {
         uint8_t certificate_request_context_len;
-        GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, &certificate_request_context_len));
+        POSIX_GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, &certificate_request_context_len));
         S2N_ERROR_IF(certificate_request_context_len != 0, S2N_ERR_BAD_MESSAGE);
     }
 
     uint32_t size_of_all_certificates;
-    GUARD(s2n_stuffer_read_uint24(&conn->handshake.io, &size_of_all_certificates));
+    POSIX_GUARD(s2n_stuffer_read_uint24(&conn->handshake.io, &size_of_all_certificates));
 
     S2N_ERROR_IF(size_of_all_certificates > s2n_stuffer_data_available(&conn->handshake.io) || size_of_all_certificates < 3, S2N_ERR_BAD_MESSAGE);
 
     s2n_cert_public_key public_key;
-    GUARD(s2n_pkey_zero_init(&public_key));
+    POSIX_GUARD(s2n_pkey_zero_init(&public_key));
 
     s2n_pkey_type actual_cert_pkey_type;
     struct s2n_blob cert_chain = {0};
     cert_chain.size = size_of_all_certificates;
     cert_chain.data = s2n_stuffer_raw_read(&conn->handshake.io, size_of_all_certificates);
-    notnull_check(cert_chain.data);
+    POSIX_ENSURE_REF(cert_chain.data);
 
-    GUARD(s2n_x509_validator_validate_cert_chain(&conn->x509_validator, conn, cert_chain.data,
+    POSIX_GUARD(s2n_x509_validator_validate_cert_chain(&conn->x509_validator, conn, cert_chain.data,
                          cert_chain.size, &actual_cert_pkey_type, &public_key));
 
-    GUARD(s2n_is_cert_type_valid_for_auth(conn, actual_cert_pkey_type));
-    GUARD(s2n_pkey_setup_for_type(&public_key, actual_cert_pkey_type));
+    POSIX_GUARD(s2n_is_cert_type_valid_for_auth(conn, actual_cert_pkey_type));
+    POSIX_GUARD(s2n_pkey_setup_for_type(&public_key, actual_cert_pkey_type));
     conn->secure.server_public_key = public_key;
 
     return 0;
@@ -62,10 +62,10 @@ int s2n_server_cert_send(struct s2n_connection *conn)
         /* server's certificate request context should always be of zero length */
         /* https://tools.ietf.org/html/rfc8446#section-4.4.2 */
         uint8_t certificate_request_context_len = 0;
-        GUARD(s2n_stuffer_write_uint8(&conn->handshake.io, certificate_request_context_len));
+        POSIX_GUARD(s2n_stuffer_write_uint8(&conn->handshake.io, certificate_request_context_len));
     }
 
-    GUARD(s2n_send_cert_chain(conn, &conn->handshake.io, conn->handshake_params.our_chain_and_key));
+    POSIX_GUARD(s2n_send_cert_chain(conn, &conn->handshake.io, conn->handshake_params.our_chain_and_key));
 
     return 0;
 }

--- a/tls/s2n_server_cert_request.c
+++ b/tls/s2n_server_cert_request.c
@@ -69,17 +69,17 @@ static int s2n_cert_type_to_pkey_type(s2n_cert_type cert_type_in, s2n_pkey_type 
             *pkey_type_out = S2N_PKEY_TYPE_ECDSA;
             return 0;
         default:
-            S2N_ERROR(S2N_CERT_ERR_TYPE_UNSUPPORTED);
+            POSIX_BAIL(S2N_CERT_ERR_TYPE_UNSUPPORTED);
     }
 }
 
 static int s2n_recv_client_cert_preferences(struct s2n_stuffer *in, s2n_cert_type *chosen_cert_type_out)
 {
     uint8_t cert_types_len;
-    GUARD(s2n_stuffer_read_uint8(in, &cert_types_len));
+    POSIX_GUARD(s2n_stuffer_read_uint8(in, &cert_types_len));
 
     uint8_t *their_cert_type_pref_list = s2n_stuffer_raw_read(in, cert_types_len);
-    notnull_check(their_cert_type_pref_list);
+    POSIX_ENSURE_REF(their_cert_type_pref_list);
 
     /* Iterate through our preference list from most to least preferred, and return the first match that we find. */
     for (int our_cert_pref_idx = 0; our_cert_pref_idx < sizeof(s2n_cert_type_preference_list); our_cert_pref_idx++) {
@@ -91,17 +91,17 @@ static int s2n_recv_client_cert_preferences(struct s2n_stuffer *in, s2n_cert_typ
         }
     }
 
-    S2N_ERROR(S2N_ERR_CERT_TYPE_UNSUPPORTED);
+    POSIX_BAIL(S2N_ERR_CERT_TYPE_UNSUPPORTED);
 }
 
 static int s2n_set_cert_chain_as_client(struct s2n_connection *conn)
 {
     if (s2n_config_get_num_default_certs(conn->config) > 0) {
-        GUARD(s2n_choose_sig_scheme_from_peer_preference_list(conn, &conn->handshake_params.server_sig_hash_algs,
+        POSIX_GUARD(s2n_choose_sig_scheme_from_peer_preference_list(conn, &conn->handshake_params.server_sig_hash_algs,
                                                                &conn->secure.client_cert_sig_scheme));
 
         struct s2n_cert_chain_and_key *cert = s2n_config_get_single_default_cert(conn->config);
-        notnull_check(cert);
+        POSIX_ENSURE_REF(cert);
         conn->handshake_params.our_chain_and_key = cert;
     }
 
@@ -114,13 +114,13 @@ int s2n_tls13_cert_req_recv(struct s2n_connection *conn)
 
     /* read request context length */
     uint8_t request_context_length;
-    GUARD(s2n_stuffer_read_uint8(in, &request_context_length));
+    POSIX_GUARD(s2n_stuffer_read_uint8(in, &request_context_length));
     /* RFC 8446: This field SHALL be zero length unless used for the post-handshake authentication */
     S2N_ERROR_IF(request_context_length != 0, S2N_ERR_BAD_MESSAGE);
 
-    GUARD(s2n_extension_list_recv(S2N_EXTENSION_LIST_CERT_REQ, conn, in));
+    POSIX_GUARD(s2n_extension_list_recv(S2N_EXTENSION_LIST_CERT_REQ, conn, in));
 
-    GUARD(s2n_set_cert_chain_as_client(conn));
+    POSIX_GUARD(s2n_set_cert_chain_as_client(conn));
 
     return S2N_SUCCESS;
 }
@@ -130,26 +130,26 @@ int s2n_cert_req_recv(struct s2n_connection *conn)
     struct s2n_stuffer *in = &conn->handshake.io;
 
     s2n_cert_type cert_type = 0;
-    GUARD(s2n_recv_client_cert_preferences(in, &cert_type));
-    GUARD(s2n_cert_type_to_pkey_type(cert_type, &conn->secure.client_cert_pkey_type));
+    POSIX_GUARD(s2n_recv_client_cert_preferences(in, &cert_type));
+    POSIX_GUARD(s2n_cert_type_to_pkey_type(cert_type, &conn->secure.client_cert_pkey_type));
 
     if (conn->actual_protocol_version == S2N_TLS12) {
-        GUARD(s2n_recv_supported_sig_scheme_list(in, &conn->handshake_params.server_sig_hash_algs));
+        POSIX_GUARD(s2n_recv_supported_sig_scheme_list(in, &conn->handshake_params.server_sig_hash_algs));
     }
 
     uint16_t cert_authorities_len = 0;
-    GUARD(s2n_stuffer_read_uint16(in, &cert_authorities_len));
+    POSIX_GUARD(s2n_stuffer_read_uint16(in, &cert_authorities_len));
 
     /* For now we don't parse X.501 encoded CA Distinguished Names.
      * Don't fail just yet as we still may succeed if we provide
      * right certificate or if ClientAuth is optional. */
-    GUARD(s2n_stuffer_skip_read(in, cert_authorities_len));
+    POSIX_GUARD(s2n_stuffer_skip_read(in, cert_authorities_len));
 
     /* In the future we may have more advanced logic to match a set of configured certificates against
      * The cert authorities extension and the signature algorithms advertised.
      * For now, this will just set the only certificate configured.
      */
-    GUARD(s2n_set_cert_chain_as_client(conn));
+    POSIX_GUARD(s2n_set_cert_chain_as_client(conn));
 
     return 0;
 }
@@ -159,9 +159,9 @@ int s2n_tls13_cert_req_send(struct s2n_connection *conn)
     struct s2n_stuffer *out = &conn->handshake.io;
 
     /* Write 0 length request context https://tools.ietf.org/html/rfc8446#section-4.3.2 */
-    GUARD(s2n_stuffer_write_uint8(out, 0));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, 0));
 
-    GUARD(s2n_extension_list_send(S2N_EXTENSION_LIST_CERT_REQ, conn, out));
+    POSIX_GUARD(s2n_extension_list_send(S2N_EXTENSION_LIST_CERT_REQ, conn, out));
 
     return S2N_SUCCESS;
 }
@@ -174,24 +174,24 @@ int s2n_cert_req_send(struct s2n_connection *conn)
     if (conn->config->cert_req_dss_legacy_compat_enabled) {
         client_cert_preference_list_size = sizeof(s2n_cert_type_preference_list_legacy_dss);
     }
-    GUARD(s2n_stuffer_write_uint8(out, client_cert_preference_list_size));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, client_cert_preference_list_size));
 
     for (int i = 0; i < client_cert_preference_list_size; i++) {
         if (conn->config->cert_req_dss_legacy_compat_enabled) {
-            GUARD(s2n_stuffer_write_uint8(out, s2n_cert_type_preference_list_legacy_dss[i]));
+            POSIX_GUARD(s2n_stuffer_write_uint8(out, s2n_cert_type_preference_list_legacy_dss[i]));
         } else {
-            GUARD(s2n_stuffer_write_uint8(out, s2n_cert_type_preference_list[i]));
+            POSIX_GUARD(s2n_stuffer_write_uint8(out, s2n_cert_type_preference_list[i]));
         }
     }
 
     if (conn->actual_protocol_version == S2N_TLS12) {
-        GUARD(s2n_send_supported_sig_scheme_list(conn, out));
+        POSIX_GUARD(s2n_send_supported_sig_scheme_list(conn, out));
     }
 
     /* RFC 5246 7.4.4 - If the certificate_authorities list is empty, then the
      * client MAY send any certificate of the appropriate ClientCertificateType */
     uint16_t acceptable_cert_authorities_len = 0;
-    GUARD(s2n_stuffer_write_uint16(out, acceptable_cert_authorities_len));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, acceptable_cert_authorities_len));
 
     return 0;
 }

--- a/tls/s2n_server_extensions.c
+++ b/tls/s2n_server_extensions.c
@@ -30,11 +30,11 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
     uint32_t data_available_before_extensions = s2n_stuffer_data_available(out);
 
     if (s2n_is_hello_retry_message(conn)) {
-        GUARD(s2n_extension_list_send(S2N_EXTENSION_LIST_HELLO_RETRY_REQUEST, conn, out));
+        POSIX_GUARD(s2n_extension_list_send(S2N_EXTENSION_LIST_HELLO_RETRY_REQUEST, conn, out));
     } else if (conn->actual_protocol_version >= S2N_TLS13) {
-        GUARD(s2n_extension_list_send(S2N_EXTENSION_LIST_SERVER_HELLO_TLS13, conn, out));
+        POSIX_GUARD(s2n_extension_list_send(S2N_EXTENSION_LIST_SERVER_HELLO_TLS13, conn, out));
     } else {
-        GUARD(s2n_extension_list_send(S2N_EXTENSION_LIST_SERVER_HELLO_DEFAULT, conn, out));
+        POSIX_GUARD(s2n_extension_list_send(S2N_EXTENSION_LIST_SERVER_HELLO_DEFAULT, conn, out));
     }
 
     /* The ServerHello extension list size (uint16_t) is NOT written if the list is empty.
@@ -47,7 +47,7 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
      * so will never produce an empty list.
      */
     if(s2n_stuffer_data_available(out) - data_available_before_extensions == S2N_EMPTY_EXTENSION_LIST_SIZE) {
-        GUARD(s2n_stuffer_wipe_n(out, S2N_EMPTY_EXTENSION_LIST_SIZE));
+        POSIX_GUARD(s2n_stuffer_wipe_n(out, S2N_EMPTY_EXTENSION_LIST_SIZE));
     }
 
     return S2N_SUCCESS;
@@ -56,20 +56,20 @@ int s2n_server_extensions_send(struct s2n_connection *conn, struct s2n_stuffer *
 int s2n_server_extensions_recv(struct s2n_connection *conn, struct s2n_stuffer *in)
 {
     s2n_parsed_extensions_list parsed_extension_list = { 0 };
-    GUARD(s2n_extension_list_parse(in, &parsed_extension_list));
+    POSIX_GUARD(s2n_extension_list_parse(in, &parsed_extension_list));
 
     /* Process supported_versions first so that we know which extensions list to use.
      * - If the supported_versions extension exists, then it will set server_protocol_version.
      * - If the supported_versions extension does not exist, then the server_protocol_version will remain
      *   unknown and we will use the default list of allowed extension types. */
-    GUARD(s2n_extension_process(&s2n_server_supported_versions_extension, conn, &parsed_extension_list));
+    POSIX_GUARD(s2n_extension_process(&s2n_server_supported_versions_extension, conn, &parsed_extension_list));
 
     if (s2n_is_hello_retry_message(conn)) {
-        GUARD(s2n_extension_list_process(S2N_EXTENSION_LIST_HELLO_RETRY_REQUEST, conn, &parsed_extension_list));
+        POSIX_GUARD(s2n_extension_list_process(S2N_EXTENSION_LIST_HELLO_RETRY_REQUEST, conn, &parsed_extension_list));
     } else if (conn->server_protocol_version >= S2N_TLS13) {
-        GUARD(s2n_extension_list_process(S2N_EXTENSION_LIST_SERVER_HELLO_TLS13, conn, &parsed_extension_list));
+        POSIX_GUARD(s2n_extension_list_process(S2N_EXTENSION_LIST_SERVER_HELLO_TLS13, conn, &parsed_extension_list));
     } else {
-        GUARD(s2n_extension_list_process(S2N_EXTENSION_LIST_SERVER_HELLO_DEFAULT, conn, &parsed_extension_list));
+        POSIX_GUARD(s2n_extension_list_process(S2N_EXTENSION_LIST_SERVER_HELLO_DEFAULT, conn, &parsed_extension_list));
     }
 
     return S2N_SUCCESS;

--- a/tls/s2n_server_finished.c
+++ b/tls/s2n_server_finished.c
@@ -37,7 +37,7 @@ int s2n_server_finished_recv(struct s2n_connection *conn)
     }
 
     uint8_t *their_version = s2n_stuffer_raw_read(&conn->handshake.io, length);
-    notnull_check(their_version);
+    POSIX_ENSURE_REF(their_version);
 
     S2N_ERROR_IF(!s2n_constant_time_equals(our_version, their_version, length), S2N_ERR_BAD_MESSAGE);
 
@@ -50,7 +50,7 @@ int s2n_server_finished_send(struct s2n_connection *conn)
     int length = S2N_TLS_FINISHED_LEN;
 
     /* Compute the finished message */
-    GUARD(s2n_prf_server_finished(conn));
+    POSIX_GUARD(s2n_prf_server_finished(conn));
 
     our_version = conn->handshake.server_finished;
 
@@ -58,17 +58,17 @@ int s2n_server_finished_send(struct s2n_connection *conn)
         length = S2N_SSL_FINISHED_LEN;
     }
 
-    GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, our_version, length));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, our_version, length));
 
     /* Zero the sequence number */
     struct s2n_blob seq = {.data = conn->secure.server_sequence_number,.size = S2N_TLS_SEQUENCE_NUM_LEN };
-    GUARD(s2n_blob_zero(&seq));
+    POSIX_GUARD(s2n_blob_zero(&seq));
 
     /* Update the secure state to active, and point the client at the active state */
     conn->server = &conn->secure;
 
     if (s2n_connection_is_session_resumed(conn)) {
-        GUARD(s2n_prf_key_expansion(conn));
+        POSIX_GUARD(s2n_prf_key_expansion(conn));
     }
 
     return 0;
@@ -76,7 +76,7 @@ int s2n_server_finished_send(struct s2n_connection *conn)
 
 
 int s2n_tls13_server_finished_recv(struct s2n_connection *conn) {
-    eq_check(conn->actual_protocol_version, S2N_TLS13);
+    POSIX_ENSURE_EQ(conn->actual_protocol_version, S2N_TLS13);
 
     uint8_t length = s2n_stuffer_data_available(&conn->handshake.io);
     S2N_ERROR_IF(length == 0, S2N_ERR_BAD_MESSAGE);
@@ -90,42 +90,42 @@ int s2n_tls13_server_finished_recv(struct s2n_connection *conn) {
 
     /* get transcript hash */
     struct s2n_hash_state hash_state = {0};
-    GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
+    POSIX_GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
 
     /* look up finished secret key */
     struct s2n_blob finished_key = {0};
-    GUARD(s2n_blob_init(&finished_key, conn->handshake.server_finished, keys.size));
+    POSIX_GUARD(s2n_blob_init(&finished_key, conn->handshake.server_finished, keys.size));
 
     /* generate the hashed message authenticated code */
     s2n_tls13_key_blob(server_finished_mac, keys.size);
-    GUARD(s2n_tls13_calculate_finished_mac(&keys, &finished_key, &hash_state, &server_finished_mac));
+    POSIX_GUARD(s2n_tls13_calculate_finished_mac(&keys, &finished_key, &hash_state, &server_finished_mac));
 
     /* compare mac with received message */
-    GUARD(s2n_tls13_mac_verify(&keys, &server_finished_mac, &wire_finished_mac));
+    POSIX_GUARD(s2n_tls13_mac_verify(&keys, &server_finished_mac, &wire_finished_mac));
 
     return 0;
 }
 
 int s2n_tls13_server_finished_send(struct s2n_connection *conn) {
-    eq_check(conn->actual_protocol_version, S2N_TLS13);
+    POSIX_ENSURE_EQ(conn->actual_protocol_version, S2N_TLS13);
 
     /* get tls13 keys */
     s2n_tls13_connection_keys(keys, conn);
 
     /* get transcript hash */
     struct s2n_hash_state hash_state = {0};
-    GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
+    POSIX_GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
 
     /* look up finished secret key */
     struct s2n_blob finished_key = {0};
-    GUARD(s2n_blob_init(&finished_key, conn->handshake.server_finished, keys.size));
+    POSIX_GUARD(s2n_blob_init(&finished_key, conn->handshake.server_finished, keys.size));
 
     /* generate the hashed message authenticated code */
     s2n_tls13_key_blob(server_finished_mac, keys.size);
-    GUARD(s2n_tls13_calculate_finished_mac(&keys, &finished_key, &hash_state, &server_finished_mac));
+    POSIX_GUARD(s2n_tls13_calculate_finished_mac(&keys, &finished_key, &hash_state, &server_finished_mac));
 
     /* write to handshake io */
-    GUARD(s2n_stuffer_write(&conn->handshake.io, &server_finished_mac));
+    POSIX_GUARD(s2n_stuffer_write(&conn->handshake.io, &server_finished_mac));
 
     return 0;
 }

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -51,26 +51,26 @@ const uint8_t tls11_downgrade_protection_bytes[] = {
 };
 
 static int s2n_hello_retry_validate(struct s2n_connection *conn) {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
-    ENSURE_POSIX(memcmp(hello_retry_req_random, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN) == 0,
+    POSIX_ENSURE(memcmp(hello_retry_req_random, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN) == 0,
                  S2N_ERR_INVALID_HELLO_RETRY);
 
     return S2N_SUCCESS;
 }
 
 static int s2n_client_detect_downgrade_mechanism(struct s2n_connection *conn) {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     uint8_t *downgrade_bytes = &conn->secure.server_random[S2N_TLS_RANDOM_DATA_LEN - S2N_DOWNGRADE_PROTECTION_SIZE];
 
     /* Detect downgrade attacks according to RFC 8446 section 4.1.3 */
     if (conn->client_protocol_version == S2N_TLS13 && conn->server_protocol_version == S2N_TLS12) {
         if (s2n_constant_time_equals(downgrade_bytes, tls12_downgrade_protection_bytes, S2N_DOWNGRADE_PROTECTION_SIZE)) {
-            S2N_ERROR(S2N_ERR_PROTOCOL_DOWNGRADE_DETECTED);
+            POSIX_BAIL(S2N_ERR_PROTOCOL_DOWNGRADE_DETECTED);
         }
     } else if (conn->client_protocol_version == S2N_TLS13 && conn->server_protocol_version <= S2N_TLS11) {
         if (s2n_constant_time_equals(downgrade_bytes, tls11_downgrade_protection_bytes, S2N_DOWNGRADE_PROTECTION_SIZE)) {
-            S2N_ERROR(S2N_ERR_PROTOCOL_DOWNGRADE_DETECTED);
+            POSIX_BAIL(S2N_ERR_PROTOCOL_DOWNGRADE_DETECTED);
         }
     }
 
@@ -78,16 +78,16 @@ static int s2n_client_detect_downgrade_mechanism(struct s2n_connection *conn) {
 }
 
 static int s2n_server_add_downgrade_mechanism(struct s2n_connection *conn) {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     uint8_t *downgrade_bytes = &conn->secure.server_random[S2N_TLS_RANDOM_DATA_LEN - S2N_DOWNGRADE_PROTECTION_SIZE];
 
     /* Protect against downgrade attacks according to RFC 8446 section 4.1.3 */
     if (conn->server_protocol_version >= S2N_TLS13 && conn->actual_protocol_version == S2N_TLS12) {
         /* TLS1.3 servers MUST use a special random value when negotiating TLS1.2 */
-        memcpy_check(downgrade_bytes, tls12_downgrade_protection_bytes, S2N_DOWNGRADE_PROTECTION_SIZE);
+        POSIX_CHECKED_MEMCPY(downgrade_bytes, tls12_downgrade_protection_bytes, S2N_DOWNGRADE_PROTECTION_SIZE);
     } else if (conn->server_protocol_version >= S2N_TLS13 && conn->actual_protocol_version <= S2N_TLS11) {
         /* TLS1.3 servers MUST, use a special random value when negotiating TLS1.1 or below */
-        memcpy_check(downgrade_bytes, tls11_downgrade_protection_bytes, S2N_DOWNGRADE_PROTECTION_SIZE);
+        POSIX_CHECKED_MEMCPY(downgrade_bytes, tls11_downgrade_protection_bytes, S2N_DOWNGRADE_PROTECTION_SIZE);
     }
 
     return 0;
@@ -95,7 +95,7 @@ static int s2n_server_add_downgrade_mechanism(struct s2n_connection *conn) {
 
 static int s2n_server_hello_parse(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     struct s2n_stuffer *in = &conn->handshake.io;
     uint8_t compression_method;
@@ -103,44 +103,44 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
     uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
     uint8_t session_id[S2N_TLS_SESSION_ID_MAX_LEN];
 
-    GUARD(s2n_stuffer_read_bytes(in, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
-    GUARD(s2n_stuffer_read_bytes(in, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_stuffer_read_bytes(in, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
+    POSIX_GUARD(s2n_stuffer_read_bytes(in, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
 
     /* If the client receives a second HelloRetryRequest in the same connection, it MUST send an error. */
     if (s2n_hello_retry_validate(conn) == S2N_SUCCESS) {
-        ENSURE_POSIX(!s2n_is_hello_retry_handshake(conn), S2N_ERR_INVALID_HELLO_RETRY);
-        GUARD(s2n_set_hello_retry_required(conn));
+        POSIX_ENSURE(!s2n_is_hello_retry_handshake(conn), S2N_ERR_INVALID_HELLO_RETRY);
+        POSIX_GUARD(s2n_set_hello_retry_required(conn));
     }
 
-    GUARD(s2n_stuffer_read_uint8(in, &session_id_len));
+    POSIX_GUARD(s2n_stuffer_read_uint8(in, &session_id_len));
     S2N_ERROR_IF(session_id_len > S2N_TLS_SESSION_ID_MAX_LEN, S2N_ERR_BAD_MESSAGE);
-    GUARD(s2n_stuffer_read_bytes(in, session_id, session_id_len));
+    POSIX_GUARD(s2n_stuffer_read_bytes(in, session_id, session_id_len));
 
     uint8_t *cipher_suite_wire = s2n_stuffer_raw_read(in, S2N_TLS_CIPHER_SUITE_LEN);
-    notnull_check(cipher_suite_wire);
+    POSIX_ENSURE_REF(cipher_suite_wire);
 
-    GUARD(s2n_stuffer_read_uint8(in, &compression_method));
+    POSIX_GUARD(s2n_stuffer_read_uint8(in, &compression_method));
     S2N_ERROR_IF(compression_method != S2N_TLS_COMPRESSION_METHOD_NULL, S2N_ERR_BAD_MESSAGE);
 
-    GUARD(s2n_server_extensions_recv(conn, in));
+    POSIX_GUARD(s2n_server_extensions_recv(conn, in));
 
     if (conn->server_protocol_version >= S2N_TLS13) {
         S2N_ERROR_IF(session_id_len != conn->session_id_len || memcmp(session_id, conn->session_id, session_id_len), S2N_ERR_BAD_MESSAGE);
         conn->actual_protocol_version = conn->server_protocol_version;
-        GUARD(s2n_set_cipher_as_client(conn, cipher_suite_wire));
+        POSIX_GUARD(s2n_set_cipher_as_client(conn, cipher_suite_wire));
     } else {
         conn->server_protocol_version = (uint8_t)(protocol_version[0] * 10) + protocol_version[1];
 
         S2N_ERROR_IF(s2n_client_detect_downgrade_mechanism(conn), S2N_ERR_PROTOCOL_DOWNGRADE_DETECTED);
-        ENSURE_POSIX(!conn->config->quic_enabled, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+        POSIX_ENSURE(!conn->config->quic_enabled, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 
         const struct s2n_security_policy *security_policy;
-        GUARD(s2n_connection_get_security_policy(conn, &security_policy));
+        POSIX_GUARD(s2n_connection_get_security_policy(conn, &security_policy));
 
         if (conn->server_protocol_version < security_policy->minimum_protocol_version
                 || conn->server_protocol_version > conn->client_protocol_version) {
-            GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
-            S2N_ERROR(S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+            POSIX_GUARD(s2n_queue_reader_unsupported_protocol_version_alert(conn));
+            POSIX_BAIL(S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
         }
 
         uint8_t actual_protocol_version = MIN(conn->server_protocol_version, conn->client_protocol_version);
@@ -155,14 +155,14 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
             conn->client_session_resumed = 1;
         } else {
             conn->session_id_len = session_id_len;
-            memcpy_check(conn->session_id, session_id, session_id_len);
+            POSIX_CHECKED_MEMCPY(conn->session_id, session_id, session_id_len);
             conn->actual_protocol_version = actual_protocol_version;
-            GUARD(s2n_set_cipher_as_client(conn, cipher_suite_wire));
+            POSIX_GUARD(s2n_set_cipher_as_client(conn, cipher_suite_wire));
             /* Erase master secret which might have been set for session resumption */
-            memset_check((uint8_t *)conn->secure.master_secret, 0, S2N_TLS_SECRET_LEN);
+            POSIX_CHECKED_MEMSET((uint8_t *)conn->secure.master_secret, 0, S2N_TLS_SECRET_LEN);
 
             /* Erase client session ticket which might have been set for session resumption */
-            GUARD(s2n_free(&conn->client_ticket));
+            POSIX_GUARD(s2n_free(&conn->client_ticket));
         }
     }
 
@@ -171,38 +171,38 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
 
 int s2n_server_hello_recv(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     /* Read the message off the wire */
-    GUARD(s2n_server_hello_parse(conn));
+    POSIX_GUARD(s2n_server_hello_parse(conn));
 
     conn->actual_protocol_version_established = 1;
 
-    GUARD(s2n_conn_set_handshake_type(conn));
+    POSIX_GUARD(s2n_conn_set_handshake_type(conn));
 
     /* If this is a HelloRetryRequest, we don't process the ServerHello.
      * Instead we proceed with retry logic. */
     if (s2n_is_hello_retry_message(conn)) {
-        GUARD(s2n_server_hello_retry_recv(conn));
+        POSIX_GUARD(s2n_server_hello_retry_recv(conn));
         return 0;
     }
 
     if (s2n_connection_is_session_resumed(conn)) {
-        GUARD(s2n_prf_key_expansion(conn));
+        POSIX_GUARD(s2n_prf_key_expansion(conn));
     }
 
     /* Choose a default signature scheme */
-    GUARD(s2n_choose_default_sig_scheme(conn, &conn->secure.conn_sig_scheme));
+    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &conn->secure.conn_sig_scheme));
 
     /* Update the required hashes for this connection */
-    GUARD(s2n_conn_update_required_handshake_hashes(conn));
+    POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));
 
     return 0;
 }
 
 int s2n_server_hello_write_message(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     /* The actual_protocol_version is set while processing the CLIENT_HELLO message, so
      * it could be S2N_TLS13. SERVER_HELLO should always respond with the legacy version.
@@ -212,38 +212,38 @@ int s2n_server_hello_write_message(struct s2n_connection *conn)
     protocol_version[0] = (uint8_t)(legacy_protocol_version / 10);
     protocol_version[1] = (uint8_t)(legacy_protocol_version % 10);
 
-    GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
-    GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
-    GUARD(s2n_stuffer_write_uint8(&conn->handshake.io, conn->session_id_len));
-    GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, conn->session_id, conn->session_id_len));
-    GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, conn->secure.cipher_suite->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
-    GUARD(s2n_stuffer_write_uint8(&conn->handshake.io, S2N_TLS_COMPRESSION_METHOD_NULL));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_stuffer_write_uint8(&conn->handshake.io, conn->session_id_len));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, conn->session_id, conn->session_id_len));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, conn->secure.cipher_suite->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
+    POSIX_GUARD(s2n_stuffer_write_uint8(&conn->handshake.io, S2N_TLS_COMPRESSION_METHOD_NULL));
 
     return 0;
 }
 
 int s2n_server_hello_send(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     struct s2n_stuffer server_random = {0};
     struct s2n_blob b = {0};
-    GUARD(s2n_blob_init(&b, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_blob_init(&b, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
 
     /* Create the server random data */
-    GUARD(s2n_stuffer_init(&server_random, &b));
+    POSIX_GUARD(s2n_stuffer_init(&server_random, &b));
 
     struct s2n_blob rand_data = {0};
-    GUARD(s2n_blob_init(&rand_data, s2n_stuffer_raw_write(&server_random, S2N_TLS_RANDOM_DATA_LEN), S2N_TLS_RANDOM_DATA_LEN));
-    notnull_check(rand_data.data);
-    GUARD_AS_POSIX(s2n_get_public_random_data(&rand_data));
+    POSIX_GUARD(s2n_blob_init(&rand_data, s2n_stuffer_raw_write(&server_random, S2N_TLS_RANDOM_DATA_LEN), S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_ENSURE_REF(rand_data.data);
+    POSIX_GUARD_RESULT(s2n_get_public_random_data(&rand_data));
 
     /* Add a downgrade detection mechanism if required */
-    GUARD(s2n_server_add_downgrade_mechanism(conn));
+    POSIX_GUARD(s2n_server_add_downgrade_mechanism(conn));
 
-    GUARD(s2n_server_hello_write_message(conn));
+    POSIX_GUARD(s2n_server_hello_write_message(conn));
 
-    GUARD(s2n_server_extensions_send(conn, &conn->handshake.io));
+    POSIX_GUARD(s2n_server_extensions_send(conn, &conn->handshake.io));
 
     conn->actual_protocol_version_established = 1;
 

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -38,9 +38,9 @@ static int s2n_server_key_send_write_signature(struct s2n_connection *conn, stru
 
 int s2n_server_key_recv(struct s2n_connection *conn)
 {
-    notnull_check(conn);
-    notnull_check(conn->secure.cipher_suite);
-    notnull_check(conn->secure.cipher_suite->key_exchange_alg);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->secure.cipher_suite);
+    POSIX_ENSURE_REF(conn->secure.cipher_suite->key_exchange_alg);
 
     struct s2n_hash_state *signature_hash = &conn->secure.signature_hash;
     const struct s2n_kex *key_exchange = conn->secure.cipher_suite->key_exchange_alg;
@@ -49,39 +49,39 @@ int s2n_server_key_recv(struct s2n_connection *conn)
 
     /* Read the KEX data */
     struct s2n_kex_raw_server_data kex_data = {0};
-    GUARD_AS_POSIX(s2n_kex_server_key_recv_read_data(key_exchange, conn, &data_to_verify, &kex_data));
+    POSIX_GUARD_RESULT(s2n_kex_server_key_recv_read_data(key_exchange, conn, &data_to_verify, &kex_data));
 
     /* Add common signature data */
     struct s2n_signature_scheme active_sig_scheme;
     if (conn->actual_protocol_version == S2N_TLS12) {
         /* Verify the SigScheme picked by the Server was in the preference list we sent (or is the default SigScheme) */
-        GUARD(s2n_get_and_validate_negotiated_signature_scheme(conn, in, &active_sig_scheme));
+        POSIX_GUARD(s2n_get_and_validate_negotiated_signature_scheme(conn, in, &active_sig_scheme));
     } else {
         active_sig_scheme = conn->secure.conn_sig_scheme;
     }
-    GUARD(s2n_hash_init(signature_hash, active_sig_scheme.hash_alg));
-    GUARD(s2n_hash_update(signature_hash, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
-    GUARD(s2n_hash_update(signature_hash, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_hash_init(signature_hash, active_sig_scheme.hash_alg));
+    POSIX_GUARD(s2n_hash_update(signature_hash, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_hash_update(signature_hash, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
 
     /* Add KEX specific data */
-    GUARD(s2n_hash_update(signature_hash, data_to_verify.data, data_to_verify.size));
+    POSIX_GUARD(s2n_hash_update(signature_hash, data_to_verify.data, data_to_verify.size));
 
     /* Verify the signature */
     uint16_t signature_length;
-    GUARD(s2n_stuffer_read_uint16(in, &signature_length));
+    POSIX_GUARD(s2n_stuffer_read_uint16(in, &signature_length));
 
     struct s2n_blob signature = {.size = signature_length, .data = s2n_stuffer_raw_read(in, signature_length)};
-    notnull_check(signature.data);
-    gt_check(signature_length, 0);
+    POSIX_ENSURE_REF(signature.data);
+    POSIX_ENSURE_GT(signature_length, 0);
 
     S2N_ERROR_IF(s2n_pkey_verify(&conn->secure.server_public_key, active_sig_scheme.sig_alg,signature_hash, &signature) < 0,
             S2N_ERR_BAD_MESSAGE);
 
     /* We don't need the key any more, so free it */
-    GUARD(s2n_pkey_free(&conn->secure.server_public_key));
+    POSIX_GUARD(s2n_pkey_free(&conn->secure.server_public_key));
 
     /* Parse the KEX data into whatever form needed and save it to the connection object */
-    GUARD_AS_POSIX(s2n_kex_server_key_recv_parse_data(key_exchange, conn, &kex_data));
+    POSIX_GUARD_RESULT(s2n_kex_server_key_recv_parse_data(key_exchange, conn, &kex_data));
     return 0;
 }
 
@@ -89,13 +89,13 @@ int s2n_ecdhe_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_
 {
     struct s2n_stuffer *in = &conn->handshake.io;
 
-    GUARD(s2n_ecc_evp_read_params(in, data_to_verify, &raw_server_data->ecdhe_data));
+    POSIX_GUARD(s2n_ecc_evp_read_params(in, data_to_verify, &raw_server_data->ecdhe_data));
     return 0;
 }
 
 int s2n_ecdhe_server_key_recv_parse_data(struct s2n_connection *conn, struct s2n_kex_raw_server_data *raw_server_data)
 {
-    GUARD(s2n_ecc_evp_parse_params(&raw_server_data->ecdhe_data, &conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_ecc_evp_parse_params(&raw_server_data->ecdhe_data, &conn->secure.server_ecc_evp_params));
 
     return 0;
 }
@@ -111,23 +111,23 @@ int s2n_dhe_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_bl
 
     /* Keep a copy to the start of the whole structure for the signature check */
     data_to_verify->data = s2n_stuffer_raw_read(in, 0);
-    notnull_check(data_to_verify->data);
+    POSIX_ENSURE_REF(data_to_verify->data);
 
     /* Read each of the three elements in */
-    GUARD(s2n_stuffer_read_uint16(in, &p_length));
+    POSIX_GUARD(s2n_stuffer_read_uint16(in, &p_length));
     dhe_data->p.size = p_length;
     dhe_data->p.data = s2n_stuffer_raw_read(in, p_length);
-    notnull_check(dhe_data->p.data);
+    POSIX_ENSURE_REF(dhe_data->p.data);
 
-    GUARD(s2n_stuffer_read_uint16(in, &g_length));
+    POSIX_GUARD(s2n_stuffer_read_uint16(in, &g_length));
     dhe_data->g.size = g_length;
     dhe_data->g.data = s2n_stuffer_raw_read(in, g_length);
-    notnull_check(dhe_data->g.data);
+    POSIX_ENSURE_REF(dhe_data->g.data);
 
-    GUARD(s2n_stuffer_read_uint16(in, &Ys_length));
+    POSIX_GUARD(s2n_stuffer_read_uint16(in, &Ys_length));
     dhe_data->Ys.size = Ys_length;
     dhe_data->Ys.data = s2n_stuffer_raw_read(in, Ys_length);
-    notnull_check(dhe_data->Ys.data);
+    POSIX_ENSURE_REF(dhe_data->Ys.data);
 
     /* Now we know the total size of the structure */
     data_to_verify->size = 2 + p_length + 2 + g_length + 2 + Ys_length;
@@ -139,7 +139,7 @@ int s2n_dhe_server_key_recv_parse_data(struct s2n_connection *conn, struct s2n_k
     struct s2n_dhe_raw_server_points dhe_data = raw_server_data->dhe_data;
 
     /* Copy the DH details */
-    GUARD(s2n_dh_p_g_Ys_to_dh_params(&conn->secure.server_dh_params, &dhe_data.p, &dhe_data.g, &dhe_data.Ys));
+    POSIX_GUARD(s2n_dh_p_g_Ys_to_dh_params(&conn->secure.server_dh_params, &dhe_data.p, &dhe_data.g, &dhe_data.Ys));
     return 0;
 }
 
@@ -150,23 +150,23 @@ int s2n_kem_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_bl
 
     /* Keep a copy to the start of the whole structure for the signature check */
     data_to_verify->data = s2n_stuffer_raw_read(in, 0);
-    notnull_check(data_to_verify->data);
+    POSIX_ENSURE_REF(data_to_verify->data);
 
     /* the server sends the KEM ID */
     kem_data->kem_name.data = s2n_stuffer_raw_read(in, 2);
-    notnull_check(kem_data->kem_name.data);
+    POSIX_ENSURE_REF(kem_data->kem_name.data);
     kem_data->kem_name.size = 2;
 
     struct s2n_stuffer kem_id_stuffer = { 0 };
     uint8_t kem_id_arr[2];
     kem_extension_size kem_id;
     struct s2n_blob kem_id_blob = { .data = kem_id_arr, .size = s2n_array_len(kem_id_arr) };
-    GUARD(s2n_stuffer_init(&kem_id_stuffer, &kem_id_blob));
-    GUARD(s2n_stuffer_write(&kem_id_stuffer, &(kem_data->kem_name)));
-    GUARD(s2n_stuffer_read_uint16(&kem_id_stuffer, &kem_id));
+    POSIX_GUARD(s2n_stuffer_init(&kem_id_stuffer, &kem_id_blob));
+    POSIX_GUARD(s2n_stuffer_write(&kem_id_stuffer, &(kem_data->kem_name)));
+    POSIX_GUARD(s2n_stuffer_read_uint16(&kem_id_stuffer, &kem_id));
 
-    GUARD(s2n_get_kem_from_extension_id(kem_id, &(conn->secure.kem_params.kem)));
-    GUARD(s2n_kem_recv_public_key(in, &(conn->secure.kem_params)));
+    POSIX_GUARD(s2n_get_kem_from_extension_id(kem_id, &(conn->secure.kem_params.kem)));
+    POSIX_GUARD(s2n_kem_recv_public_key(in, &(conn->secure.kem_params)));
 
     kem_data->raw_public_key.data = conn->secure.kem_params.public_key.data;
     kem_data->raw_public_key.size = conn->secure.kem_params.public_key.size;
@@ -182,8 +182,8 @@ int s2n_kem_server_key_recv_parse_data(struct s2n_connection *conn, struct s2n_k
 
     /* Check that the server's requested kem is supported by the client */
     const struct s2n_kem_preferences *kem_preferences = NULL;
-    GUARD(s2n_connection_get_kem_preferences(conn, &kem_preferences));
-    notnull_check(kem_preferences);
+    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_preferences));
+    POSIX_ENSURE_REF(kem_preferences);
 
     const struct s2n_cipher_suite *cipher_suite = conn->secure.cipher_suite;
     const struct s2n_kem *match = NULL;
@@ -198,21 +198,21 @@ int s2n_kem_server_key_recv_parse_data(struct s2n_connection *conn, struct s2n_k
 
 int s2n_hybrid_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_blob *total_data_to_verify, struct s2n_kex_raw_server_data *raw_server_data)
 {
-    notnull_check(conn);
-    notnull_check(conn->secure.cipher_suite);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->secure.cipher_suite);
     const struct s2n_kex *kex = conn->secure.cipher_suite->key_exchange_alg;
     const struct s2n_kex *hybrid_kex_0 = kex->hybrid[0];
     const struct s2n_kex *hybrid_kex_1 = kex->hybrid[1];
 
     /* Keep a copy to the start of the whole structure for the signature check */
     total_data_to_verify->data = s2n_stuffer_raw_read(&conn->handshake.io, 0);
-    notnull_check(total_data_to_verify->data);
+    POSIX_ENSURE_REF(total_data_to_verify->data);
 
     struct s2n_blob data_to_verify_0 = {0};
-    GUARD_AS_POSIX(s2n_kex_server_key_recv_read_data(hybrid_kex_0, conn, &data_to_verify_0, raw_server_data));
+    POSIX_GUARD_RESULT(s2n_kex_server_key_recv_read_data(hybrid_kex_0, conn, &data_to_verify_0, raw_server_data));
 
     struct s2n_blob data_to_verify_1 = {0};
-    GUARD_AS_POSIX(s2n_kex_server_key_recv_read_data(hybrid_kex_1, conn, &data_to_verify_1, raw_server_data));
+    POSIX_GUARD_RESULT(s2n_kex_server_key_recv_read_data(hybrid_kex_1, conn, &data_to_verify_1, raw_server_data));
 
     total_data_to_verify->size = data_to_verify_0.size + data_to_verify_1.size;
     return 0;
@@ -220,14 +220,14 @@ int s2n_hybrid_server_key_recv_read_data(struct s2n_connection *conn, struct s2n
 
 int s2n_hybrid_server_key_recv_parse_data(struct s2n_connection *conn, struct s2n_kex_raw_server_data *raw_server_data)
 {
-    notnull_check(conn);
-    notnull_check(conn->secure.cipher_suite);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->secure.cipher_suite);
     const struct s2n_kex *kex = conn->secure.cipher_suite->key_exchange_alg;
     const struct s2n_kex *hybrid_kex_0 = kex->hybrid[0];
     const struct s2n_kex *hybrid_kex_1 = kex->hybrid[1];
 
-    GUARD_AS_POSIX(s2n_kex_server_key_recv_parse_data(hybrid_kex_0, conn, raw_server_data));
-    GUARD_AS_POSIX(s2n_kex_server_key_recv_parse_data(hybrid_kex_1, conn, raw_server_data));
+    POSIX_GUARD_RESULT(s2n_kex_server_key_recv_parse_data(hybrid_kex_0, conn, raw_server_data));
+    POSIX_GUARD_RESULT(s2n_kex_server_key_recv_parse_data(hybrid_kex_1, conn, raw_server_data));
     return 0;
 }
 
@@ -241,20 +241,20 @@ int s2n_server_key_send(struct s2n_connection *conn)
     struct s2n_blob data_to_sign = {0};
 
     /* Call the negotiated key exchange method to send it's data */
-    GUARD_AS_POSIX(s2n_kex_server_key_send(key_exchange, conn, &data_to_sign));
+    POSIX_GUARD_RESULT(s2n_kex_server_key_send(key_exchange, conn, &data_to_sign));
 
     /* Add common signature data */
     if (conn->actual_protocol_version == S2N_TLS12) {
-        GUARD(s2n_stuffer_write_uint16(out, conn->secure.conn_sig_scheme.iana_value));
+        POSIX_GUARD(s2n_stuffer_write_uint16(out, conn->secure.conn_sig_scheme.iana_value));
     }
 
     /* Add the random data to the hash */
-    GUARD(s2n_hash_init(signature_hash, conn->secure.conn_sig_scheme.hash_alg));
-    GUARD(s2n_hash_update(signature_hash, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
-    GUARD(s2n_hash_update(signature_hash, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_hash_init(signature_hash, conn->secure.conn_sig_scheme.hash_alg));
+    POSIX_GUARD(s2n_hash_update(signature_hash, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_hash_update(signature_hash, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
 
     /* Add KEX specific data to the hash */
-    GUARD(s2n_hash_update(signature_hash, data_to_sign.data, data_to_sign.size));
+    POSIX_GUARD(s2n_hash_update(signature_hash, data_to_sign.data, data_to_sign.size));
 
     S2N_ASYNC_PKEY_SIGN(conn, conn->secure.conn_sig_scheme.sig_alg, signature_hash, s2n_server_key_send_write_signature);
 }
@@ -264,10 +264,10 @@ int s2n_ecdhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data
     struct s2n_stuffer *out = &conn->handshake.io;
 
     /* Generate an ephemeral key and  */
-    GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.server_ecc_evp_params));
 
     /* Write it out and calculate the data to sign later */
-    GUARD(s2n_ecc_evp_write_params(&conn->secure.server_ecc_evp_params, out, data_to_sign));
+    POSIX_GUARD(s2n_ecc_evp_write_params(&conn->secure.server_ecc_evp_params, out, data_to_sign));
     return 0;
 }
 
@@ -276,13 +276,13 @@ int s2n_dhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_t
     struct s2n_stuffer *out = &conn->handshake.io;
 
     /* Duplicate the DH key from the config */
-    GUARD(s2n_dh_params_copy(conn->config->dhparams, &conn->secure.server_dh_params));
+    POSIX_GUARD(s2n_dh_params_copy(conn->config->dhparams, &conn->secure.server_dh_params));
 
     /* Generate an ephemeral key */
-    GUARD(s2n_dh_generate_ephemeral_key(&conn->secure.server_dh_params));
+    POSIX_GUARD(s2n_dh_generate_ephemeral_key(&conn->secure.server_dh_params));
 
     /* Write it out and calculate the data to sign later */
-    GUARD(s2n_dh_params_to_p_g_Ys(&conn->secure.server_dh_params, out, data_to_sign));
+    POSIX_GUARD(s2n_dh_params_to_p_g_Ys(&conn->secure.server_dh_params, out, data_to_sign));
     return 0;
 }
 
@@ -292,10 +292,10 @@ int s2n_kem_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_t
     const struct s2n_kem *kem = conn->secure.kem_params.kem;
 
     data_to_sign->data = s2n_stuffer_raw_write(out, 0);
-    notnull_check(data_to_sign->data);
+    POSIX_ENSURE_REF(data_to_sign->data);
 
-    GUARD(s2n_stuffer_write_uint16(out, kem->kem_extension_id));
-    GUARD(s2n_kem_send_public_key(out, &(conn->secure.kem_params)));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, kem->kem_extension_id));
+    POSIX_GUARD(s2n_kem_send_public_key(out, &(conn->secure.kem_params)));
 
     data_to_sign->size = sizeof(kem_extension_size) + sizeof(kem_public_key_size) +  kem->public_key_length;
 
@@ -304,21 +304,21 @@ int s2n_kem_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_t
 
 int s2n_hybrid_server_key_send(struct s2n_connection *conn, struct s2n_blob *total_data_to_sign)
 {
-    notnull_check(conn);
-    notnull_check(conn->secure.cipher_suite);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->secure.cipher_suite);
     const struct s2n_kex *kex = conn->secure.cipher_suite->key_exchange_alg;
     const struct s2n_kex *hybrid_kex_0 = kex->hybrid[0];
     const struct s2n_kex *hybrid_kex_1 = kex->hybrid[1];
 
     /* Keep a copy to the start of the whole structure for the signature check */
     total_data_to_sign->data = s2n_stuffer_raw_write(&conn->handshake.io, 0);
-    notnull_check(total_data_to_sign->data);
+    POSIX_ENSURE_REF(total_data_to_sign->data);
 
     struct s2n_blob data_to_verify_0 = {0};
-    GUARD_AS_POSIX(s2n_kex_server_key_send(hybrid_kex_0, conn, &data_to_verify_0));
+    POSIX_GUARD_RESULT(s2n_kex_server_key_send(hybrid_kex_0, conn, &data_to_verify_0));
 
     struct s2n_blob data_to_verify_1 = {0};
-    GUARD_AS_POSIX(s2n_kex_server_key_send(hybrid_kex_1, conn, &data_to_verify_1));
+    POSIX_GUARD_RESULT(s2n_kex_server_key_send(hybrid_kex_1, conn, &data_to_verify_1));
 
     total_data_to_sign->size = data_to_verify_0.size + data_to_verify_1.size;
     return 0;
@@ -328,8 +328,8 @@ int s2n_server_key_send_write_signature(struct s2n_connection *conn, struct s2n_
 {
     struct s2n_stuffer *out = &conn->handshake.io;
 
-    GUARD(s2n_stuffer_write_uint16(out, signature->size));
-    GUARD(s2n_stuffer_write_bytes(out, signature->data, signature->size));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, signature->size));
+    POSIX_GUARD(s2n_stuffer_write_bytes(out, signature->data, signature->size));
 
     return 0;
 }

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -43,15 +43,15 @@
                                           sizeof(uint16_t)   /* extensions length */
 
 int s2n_server_nst_recv(struct s2n_connection *conn) {
-    GUARD(s2n_stuffer_read_uint32(&conn->handshake.io, &conn->ticket_lifetime_hint));
+    POSIX_GUARD(s2n_stuffer_read_uint32(&conn->handshake.io, &conn->ticket_lifetime_hint));
 
     uint16_t session_ticket_len;
-    GUARD(s2n_stuffer_read_uint16(&conn->handshake.io, &session_ticket_len));
+    POSIX_GUARD(s2n_stuffer_read_uint16(&conn->handshake.io, &session_ticket_len));
 
     if (session_ticket_len > 0) {
-        GUARD(s2n_realloc(&conn->client_ticket, session_ticket_len));
+        POSIX_GUARD(s2n_realloc(&conn->client_ticket, session_ticket_len));
 
-        GUARD(s2n_stuffer_read(&conn->handshake.io, &conn->client_ticket));
+        POSIX_GUARD(s2n_stuffer_read(&conn->handshake.io, &conn->client_ticket));
     }
 
     return 0;
@@ -67,47 +67,47 @@ int s2n_server_nst_send(struct s2n_connection *conn)
 
     /* When server changes it's mind mid handshake send lifetime hint and session ticket length as zero */
     if (!conn->config->use_tickets) {
-        GUARD(s2n_stuffer_write_uint32(&conn->handshake.io, 0));
-        GUARD(s2n_stuffer_write_uint16(&conn->handshake.io, 0));
+        POSIX_GUARD(s2n_stuffer_write_uint32(&conn->handshake.io, 0));
+        POSIX_GUARD(s2n_stuffer_write_uint16(&conn->handshake.io, 0));
 
         return 0;
     }
 
     if (!s2n_server_sending_nst(conn)) {
-        S2N_ERROR(S2N_ERR_SENDING_NST);
+        POSIX_BAIL(S2N_ERR_SENDING_NST);
     }
 
-    GUARD(s2n_stuffer_init(&to, &entry));
-    GUARD(s2n_stuffer_write_uint32(&conn->handshake.io, lifetime_hint_in_secs));
-    GUARD(s2n_stuffer_write_uint16(&conn->handshake.io, session_ticket_len));
+    POSIX_GUARD(s2n_stuffer_init(&to, &entry));
+    POSIX_GUARD(s2n_stuffer_write_uint32(&conn->handshake.io, lifetime_hint_in_secs));
+    POSIX_GUARD(s2n_stuffer_write_uint16(&conn->handshake.io, session_ticket_len));
 
-    GUARD(s2n_encrypt_session_ticket(conn, NULL, &to));
-    GUARD(s2n_stuffer_write(&conn->handshake.io, &to.blob));
+    POSIX_GUARD(s2n_encrypt_session_ticket(conn, NULL, &to));
+    POSIX_GUARD(s2n_stuffer_write(&conn->handshake.io, &to.blob));
 
     return 0;
 }
 
 S2N_RESULT s2n_tls13_server_nst_send(struct s2n_connection *conn, s2n_blocked_status *blocked)
 {
-    ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn);
 
     if (conn->mode != S2N_SERVER || conn->actual_protocol_version < S2N_TLS13) {
         return S2N_RESULT_OK;
     }
 
-    ENSURE(conn->tickets_sent <= conn->tickets_to_send, S2N_ERR_INTEGER_OVERFLOW);
+    RESULT_ENSURE(conn->tickets_sent <= conn->tickets_to_send, S2N_ERR_INTEGER_OVERFLOW);
     while (conn->tickets_to_send - conn->tickets_sent > 0) {
         uint8_t nst_data[TLS13_MAX_NEW_SESSION_TICKET_SIZE] = { 0 };
         struct s2n_blob nst_blob = { 0 };
         struct s2n_stuffer nst_stuffer = { 0 };
-        GUARD_AS_RESULT(s2n_blob_init(&nst_blob, nst_data, sizeof(nst_data)));
-        GUARD_AS_RESULT(s2n_stuffer_init(&nst_stuffer, &nst_blob));
+        RESULT_GUARD_POSIX(s2n_blob_init(&nst_blob, nst_data, sizeof(nst_data)));
+        RESULT_GUARD_POSIX(s2n_stuffer_init(&nst_stuffer, &nst_blob));
 
-        GUARD_AS_RESULT(s2n_tls13_server_nst_write(conn, &nst_stuffer));
+        RESULT_GUARD_POSIX(s2n_tls13_server_nst_write(conn, &nst_stuffer));
         nst_blob.size = s2n_stuffer_data_available(&nst_stuffer);
 
-        GUARD_AS_RESULT(s2n_record_write(conn, TLS_HANDSHAKE, &nst_blob));
-        GUARD_AS_RESULT(s2n_flush(conn, blocked));
+        RESULT_GUARD_POSIX(s2n_record_write(conn, TLS_HANDSHAKE, &nst_blob));
+        RESULT_GUARD_POSIX(s2n_flush(conn, blocked));
     }
     return S2N_RESULT_OK;
 }
@@ -120,8 +120,8 @@ S2N_RESULT s2n_tls13_server_nst_send(struct s2n_connection *conn, s2n_blocked_st
  **/
 static S2N_RESULT s2n_generate_ticket_lifetime(struct s2n_connection *conn, uint32_t *ticket_lifetime) 
 {
-    ENSURE_REF(conn);
-    ENSURE_MUT(ticket_lifetime);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_MUT(ticket_lifetime);
 
     uint32_t key_lifetime_in_secs = conn->config->decrypt_key_lifetime_in_nanos / ONE_SEC_IN_NANOS;
     uint32_t session_lifetime_in_secs = conn->config->session_state_lifetime_in_nanos / ONE_SEC_IN_NANOS;
@@ -143,11 +143,11 @@ static S2N_RESULT s2n_generate_ticket_lifetime(struct s2n_connection *conn, uint
  **/
 static S2N_RESULT s2n_generate_ticket_nonce(uint16_t value, struct s2n_blob *output)
 {
-    ENSURE_MUT(output);
+    RESULT_ENSURE_MUT(output);
 
     struct s2n_stuffer stuffer = { 0 };
-    GUARD_AS_RESULT(s2n_stuffer_init(&stuffer, output));
-    GUARD_AS_RESULT(s2n_stuffer_write_uint16(&stuffer, value));
+    RESULT_GUARD_POSIX(s2n_stuffer_init(&stuffer, output));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_uint16(&stuffer, value));
 
     return S2N_RESULT_OK;
 }
@@ -160,81 +160,81 @@ static S2N_RESULT s2n_generate_ticket_nonce(uint16_t value, struct s2n_blob *out
  **/
 static S2N_RESULT s2n_generate_ticket_age_add(struct s2n_blob *random_data, uint32_t *ticket_age_add)
 {
-    ENSURE_REF(random_data);
-    ENSURE_REF(ticket_age_add);
+    RESULT_ENSURE_REF(random_data);
+    RESULT_ENSURE_REF(ticket_age_add);
 
     struct s2n_stuffer stuffer = { 0 };
-    GUARD_AS_RESULT(s2n_stuffer_init(&stuffer, random_data));
-    GUARD_AS_RESULT(s2n_stuffer_skip_write(&stuffer, random_data->size));
-    GUARD_AS_RESULT(s2n_stuffer_read_uint32(&stuffer, ticket_age_add));
+    RESULT_GUARD_POSIX(s2n_stuffer_init(&stuffer, random_data));
+    RESULT_GUARD_POSIX(s2n_stuffer_skip_write(&stuffer, random_data->size));
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint32(&stuffer, ticket_age_add));
 
     return S2N_RESULT_OK;
 }
 
 int s2n_tls13_server_nst_write(struct s2n_connection *conn, struct s2n_stuffer *output)
 {
-    notnull_check(conn);
-    notnull_check(output);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(output);
 
     /* Write message type because session resumption in TLS13 is a post-handshake message */
-    GUARD(s2n_stuffer_write_uint8(output, TLS_SERVER_NEW_SESSION_TICKET));
+    POSIX_GUARD(s2n_stuffer_write_uint8(output, TLS_SERVER_NEW_SESSION_TICKET));
 
     struct s2n_stuffer_reservation message_size = { 0 };
-    GUARD(s2n_stuffer_reserve_uint24(output, &message_size));
+    POSIX_GUARD(s2n_stuffer_reserve_uint24(output, &message_size));
 
     uint32_t ticket_lifetime_in_secs = 0;
-    GUARD_AS_POSIX(s2n_generate_ticket_lifetime(conn, &ticket_lifetime_in_secs));
-    GUARD(s2n_stuffer_write_uint32(output, ticket_lifetime_in_secs));
+    POSIX_GUARD_RESULT(s2n_generate_ticket_lifetime(conn, &ticket_lifetime_in_secs));
+    POSIX_GUARD(s2n_stuffer_write_uint32(output, ticket_lifetime_in_secs));
 
     /* Get random data to use as ticket_age_add value */
     struct s2n_ticket_fields ticket_fields = { 0 };
     uint8_t data[sizeof(uint32_t)] = { 0 };
     struct s2n_blob random_data = { 0 };
-    GUARD(s2n_blob_init(&random_data, data, sizeof(data)));
+    POSIX_GUARD(s2n_blob_init(&random_data, data, sizeof(data)));
     /** 
      *= https://tools.ietf.org/rfc/rfc8446#section-4.6.1
      *#  The server MUST generate a fresh value
      *#  for each ticket it sends.
      **/
-    GUARD_AS_POSIX(s2n_get_private_random_data(&random_data));
-    GUARD_AS_POSIX(s2n_generate_ticket_age_add(&random_data, &ticket_fields.ticket_age_add));
-    GUARD(s2n_stuffer_write_uint32(output, ticket_fields.ticket_age_add));
+    POSIX_GUARD_RESULT(s2n_get_private_random_data(&random_data));
+    POSIX_GUARD_RESULT(s2n_generate_ticket_age_add(&random_data, &ticket_fields.ticket_age_add));
+    POSIX_GUARD(s2n_stuffer_write_uint32(output, ticket_fields.ticket_age_add));
 
     /* Write ticket nonce */
     uint8_t nonce_data[sizeof(uint16_t)] = { 0 };
     struct s2n_blob nonce = { 0 };
-    GUARD(s2n_blob_init(&nonce, nonce_data, sizeof(nonce_data)));
-    GUARD_AS_POSIX(s2n_generate_ticket_nonce(conn->tickets_sent, &nonce));
-    GUARD(s2n_stuffer_write_uint8(output, nonce.size));
-    GUARD(s2n_stuffer_write_bytes(output, nonce.data, nonce.size));
+    POSIX_GUARD(s2n_blob_init(&nonce, nonce_data, sizeof(nonce_data)));
+    POSIX_GUARD_RESULT(s2n_generate_ticket_nonce(conn->tickets_sent, &nonce));
+    POSIX_GUARD(s2n_stuffer_write_uint8(output, nonce.size));
+    POSIX_GUARD(s2n_stuffer_write_bytes(output, nonce.data, nonce.size));
 
     /* Derive individual session ticket secret */
     s2n_tls13_connection_keys(secrets, conn);
     struct s2n_blob master_secret = { 0 };
-    GUARD(s2n_blob_init(&master_secret, conn->resumption_master_secret, sizeof(conn->resumption_master_secret)));
+    POSIX_GUARD(s2n_blob_init(&master_secret, conn->resumption_master_secret, sizeof(conn->resumption_master_secret)));
     uint8_t session_secret_data[S2N_TLS13_SECRET_MAX_LEN] = { 0 };
-    GUARD(s2n_blob_init(&ticket_fields.session_secret, session_secret_data, secrets.size));
-    GUARD_AS_POSIX(s2n_tls13_derive_session_ticket_secret(&secrets, &master_secret, &nonce, &ticket_fields.session_secret));
+    POSIX_GUARD(s2n_blob_init(&ticket_fields.session_secret, session_secret_data, secrets.size));
+    POSIX_GUARD_RESULT(s2n_tls13_derive_session_ticket_secret(&secrets, &master_secret, &nonce, &ticket_fields.session_secret));
 
     /* Create ticket */
     uint8_t ticket_data[S2N_MAX_TICKET_SIZE_IN_BYTES] = { 0 };
     struct s2n_blob ticket_blob = { 0 };
     struct s2n_stuffer session_ticket = { 0 };
-    GUARD(s2n_blob_init(&ticket_blob, ticket_data, sizeof(ticket_data)));
-    GUARD(s2n_stuffer_init(&session_ticket, &ticket_blob));
-    GUARD(s2n_encrypt_session_ticket(conn, &ticket_fields, &session_ticket));
+    POSIX_GUARD(s2n_blob_init(&ticket_blob, ticket_data, sizeof(ticket_data)));
+    POSIX_GUARD(s2n_stuffer_init(&session_ticket, &ticket_blob));
+    POSIX_GUARD(s2n_encrypt_session_ticket(conn, &ticket_fields, &session_ticket));
 
     /* Write session ticket */
-    ENSURE_POSIX(s2n_stuffer_data_available(&session_ticket) <= UINT8_MAX, S2N_ERR_SAFETY);
-    GUARD(s2n_stuffer_write_uint8(output, s2n_stuffer_data_available(&session_ticket)));
-    GUARD(s2n_stuffer_write(output, &session_ticket.blob));
+    POSIX_ENSURE(s2n_stuffer_data_available(&session_ticket) <= UINT8_MAX, S2N_ERR_SAFETY);
+    POSIX_GUARD(s2n_stuffer_write_uint8(output, s2n_stuffer_data_available(&session_ticket)));
+    POSIX_GUARD(s2n_stuffer_write(output, &session_ticket.blob));
 
     /* Write size of new session ticket extensions */
-    GUARD(s2n_stuffer_write_uint16(output, 0));
+    POSIX_GUARD(s2n_stuffer_write_uint16(output, 0));
 
-    GUARD(s2n_stuffer_write_vector_size(&message_size));
+    POSIX_GUARD(s2n_stuffer_write_vector_size(&message_size));
 
-    ENSURE_POSIX(conn->tickets_sent < UINT16_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    POSIX_ENSURE(conn->tickets_sent < UINT16_MAX, S2N_ERR_INTEGER_OVERFLOW);
     conn->tickets_sent++;
 
     return S2N_SUCCESS;

--- a/tls/s2n_shutdown.c
+++ b/tls/s2n_shutdown.c
@@ -23,8 +23,8 @@
 
 int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status * more)
 {
-    notnull_check(conn);
-    notnull_check(more);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(more);
 
     /* Treat this call as a no-op if already wiped */
     if (conn->send == NULL && conn->recv == NULL) {
@@ -32,24 +32,24 @@ int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status * more)
     }
 
     uint64_t elapsed;
-    GUARD_AS_POSIX(s2n_timer_elapsed(conn->config, &conn->write_timer, &elapsed));
+    POSIX_GUARD_RESULT(s2n_timer_elapsed(conn->config, &conn->write_timer, &elapsed));
     S2N_ERROR_IF(elapsed < conn->delay, S2N_ERR_SHUTDOWN_PAUSED);
 
     /* Queue our close notify, once. Use warning level so clients don't give up */
-    GUARD(s2n_queue_writer_close_alert_warning(conn));
+    POSIX_GUARD(s2n_queue_writer_close_alert_warning(conn));
 
     /* Write it */
-    GUARD(s2n_flush(conn, more));
+    POSIX_GUARD(s2n_flush(conn, more));
 
     /* Assume caller isn't interested in pending incoming data */
     if (conn->in_status == PLAINTEXT) {
-        GUARD(s2n_stuffer_wipe(&conn->header_in));
-        GUARD(s2n_stuffer_wipe(&conn->in));
+        POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
+        POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
         conn->in_status = ENCRYPTED;
     }
 
     /* Fails with S2N_ERR_SHUTDOWN_RECORD_TYPE or S2N_ERR_ALERT on receipt of anything but a close_notify */
-    GUARD(s2n_recv_close_notify(conn, more));
+    POSIX_GUARD(s2n_recv_close_notify(conn, more));
 
     return 0;
 }

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -31,14 +31,14 @@
 static int s2n_signature_scheme_valid_to_offer(struct s2n_connection *conn, const struct s2n_signature_scheme *scheme)
 {
     /* We don't know what protocol version we will eventually negotiate, but we know that it won't be any higher. */
-    gte_check(conn->actual_protocol_version, scheme->minimum_protocol_version);
+    POSIX_ENSURE_GTE(conn->actual_protocol_version, scheme->minimum_protocol_version);
 
     if (!s2n_is_rsa_pss_signing_supported()) {
-        ne_check(scheme->sig_alg, S2N_SIGNATURE_RSA_PSS_RSAE);
+        POSIX_ENSURE_NE(scheme->sig_alg, S2N_SIGNATURE_RSA_PSS_RSAE);
     }
 
     if (!s2n_is_rsa_pss_certs_supported()) {
-        ne_check(scheme->sig_alg, S2N_SIGNATURE_RSA_PSS_PSS);
+        POSIX_ENSURE_NE(scheme->sig_alg, S2N_SIGNATURE_RSA_PSS_PSS);
     }
 
     return 0;
@@ -46,23 +46,23 @@ static int s2n_signature_scheme_valid_to_offer(struct s2n_connection *conn, cons
 
 static int s2n_signature_scheme_valid_to_accept(struct s2n_connection *conn, const struct s2n_signature_scheme *scheme)
 {
-    notnull_check(scheme);
+    POSIX_ENSURE_REF(scheme);
 
-    GUARD(s2n_signature_scheme_valid_to_offer(conn, scheme));
+    POSIX_GUARD(s2n_signature_scheme_valid_to_offer(conn, scheme));
 
     if (scheme->maximum_protocol_version != S2N_UNKNOWN_PROTOCOL_VERSION) {
-        lte_check(conn->actual_protocol_version, scheme->maximum_protocol_version);
+        POSIX_ENSURE_LTE(conn->actual_protocol_version, scheme->maximum_protocol_version);
     }
 
     return 0;
 }
 
 static int s2n_is_signature_scheme_usable(struct s2n_connection *conn, const struct s2n_signature_scheme *candidate) {
-    notnull_check(conn);
-    notnull_check(candidate);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(candidate);
 
-    GUARD(s2n_signature_scheme_valid_to_accept(conn, candidate));
-    GUARD(s2n_is_sig_scheme_valid_for_auth(conn, candidate));
+    POSIX_GUARD(s2n_signature_scheme_valid_to_accept(conn, candidate));
+    POSIX_GUARD(s2n_is_sig_scheme_valid_for_auth(conn, candidate));
 
     return S2N_SUCCESS;
 }
@@ -70,13 +70,13 @@ static int s2n_is_signature_scheme_usable(struct s2n_connection *conn, const str
 static int s2n_choose_sig_scheme(struct s2n_connection *conn, struct s2n_sig_scheme_list *peer_wire_prefs,
                           struct s2n_signature_scheme *chosen_scheme_out)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     const struct s2n_signature_preferences *signature_preferences = NULL;
-    GUARD(s2n_connection_get_signature_preferences(conn, &signature_preferences));
-    notnull_check(signature_preferences);
+    POSIX_GUARD(s2n_connection_get_signature_preferences(conn, &signature_preferences));
+    POSIX_ENSURE_REF(signature_preferences);
 
     struct s2n_cipher_suite *cipher_suite = conn->secure.cipher_suite;
-    notnull_check(cipher_suite);
+    POSIX_ENSURE_REF(cipher_suite);
 
     for (size_t i = 0; i < signature_preferences->count; i++) {
         const struct s2n_signature_scheme *candidate = signature_preferences->signature_schemes[i];
@@ -102,13 +102,13 @@ static int s2n_choose_sig_scheme(struct s2n_connection *conn, struct s2n_sig_sch
 /* similar to s2n_choose_sig_scheme() without matching client's preference */
 static int s2n_tls13_default_sig_scheme(struct s2n_connection *conn, struct s2n_signature_scheme *chosen_scheme_out)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     const struct s2n_signature_preferences *signature_preferences = NULL;
-    GUARD(s2n_connection_get_signature_preferences(conn, &signature_preferences));
-    notnull_check(signature_preferences);
+    POSIX_GUARD(s2n_connection_get_signature_preferences(conn, &signature_preferences));
+    POSIX_ENSURE_REF(signature_preferences);
 
     struct s2n_cipher_suite *cipher_suite = conn->secure.cipher_suite;
-    notnull_check(cipher_suite);
+    POSIX_ENSURE_REF(cipher_suite);
 
     for (size_t i = 0; i < signature_preferences->count; i++) {
         const struct s2n_signature_scheme *candidate = signature_preferences->signature_schemes[i];
@@ -121,18 +121,18 @@ static int s2n_tls13_default_sig_scheme(struct s2n_connection *conn, struct s2n_
         return S2N_SUCCESS;
     }
 
-    S2N_ERROR(S2N_ERR_INVALID_SIGNATURE_SCHEME);
+    POSIX_BAIL(S2N_ERR_INVALID_SIGNATURE_SCHEME);
 }
 
 int s2n_get_and_validate_negotiated_signature_scheme(struct s2n_connection *conn, struct s2n_stuffer *in,
                                              struct s2n_signature_scheme *chosen_sig_scheme)
 {
     uint16_t actual_iana_val;
-    GUARD(s2n_stuffer_read_uint16(in, &actual_iana_val));
+    POSIX_GUARD(s2n_stuffer_read_uint16(in, &actual_iana_val));
 
     const struct s2n_signature_preferences *signature_preferences = NULL;
-    GUARD(s2n_connection_get_signature_preferences(conn, &signature_preferences));
-    notnull_check(signature_preferences);
+    POSIX_GUARD(s2n_connection_get_signature_preferences(conn, &signature_preferences));
+    POSIX_ENSURE_REF(signature_preferences);
 
     for (size_t i = 0; i < signature_preferences->count; i++) {
         const struct s2n_signature_scheme *candidate = signature_preferences->signature_schemes[i];
@@ -151,7 +151,7 @@ int s2n_get_and_validate_negotiated_signature_scheme(struct s2n_connection *conn
      * This means that an s2n client will accept the default SignatureScheme from a TLS server, even if the client did
      * not send it in it's ClientHello. This pre-TLS1.3 behavior is an intentional choice to maximize support. */
     struct s2n_signature_scheme default_scheme;
-    GUARD(s2n_choose_default_sig_scheme(conn, &default_scheme));
+    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &default_scheme));
 
     if ((conn->actual_protocol_version <= S2N_TLS12)
             && (s2n_signature_scheme_valid_to_accept(conn, &default_scheme) == S2N_SUCCESS)
@@ -161,14 +161,14 @@ int s2n_get_and_validate_negotiated_signature_scheme(struct s2n_connection *conn
         return S2N_SUCCESS;
     }
 
-    S2N_ERROR(S2N_ERR_INVALID_SIGNATURE_SCHEME);
+    POSIX_BAIL(S2N_ERR_INVALID_SIGNATURE_SCHEME);
 }
 
 int s2n_choose_default_sig_scheme(struct s2n_connection *conn, struct s2n_signature_scheme *sig_scheme_out)
 {
-    notnull_check(conn);
-    notnull_check(conn->secure.cipher_suite);
-    notnull_check(sig_scheme_out);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->secure.cipher_suite);
+    POSIX_ENSURE_REF(sig_scheme_out);
 
     s2n_authentication_method cipher_suite_auth_method = conn->secure.cipher_suite->auth_method;
 
@@ -194,22 +194,22 @@ int s2n_choose_default_sig_scheme(struct s2n_connection *conn, struct s2n_signat
 int s2n_choose_sig_scheme_from_peer_preference_list(struct s2n_connection *conn, struct s2n_sig_scheme_list *peer_wire_prefs,
                                                         struct s2n_signature_scheme *sig_scheme_out)
 {
-    notnull_check(conn);
-    notnull_check(sig_scheme_out);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(sig_scheme_out);
 
     struct s2n_signature_scheme chosen_scheme;
 
     if (conn->actual_protocol_version < S2N_TLS13) {
-        GUARD(s2n_choose_default_sig_scheme(conn, &chosen_scheme));
+        POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &chosen_scheme));
     } else {
         /* Pick a default signature algorithm in TLS 1.3 https://tools.ietf.org/html/rfc8446#section-4.4.2.2 */
-        GUARD(s2n_tls13_default_sig_scheme(conn, &chosen_scheme));
+        POSIX_GUARD(s2n_tls13_default_sig_scheme(conn, &chosen_scheme));
     }
 
     /* SignatureScheme preference list was first added in TLS 1.2. It will be empty in older TLS versions. */
     if (peer_wire_prefs != NULL && peer_wire_prefs->len > 0) {
         /* Use a best effort approach to selecting a signature scheme matching client's preferences */
-        GUARD(s2n_choose_sig_scheme(conn, peer_wire_prefs, &chosen_scheme));
+        POSIX_GUARD(s2n_choose_sig_scheme(conn, peer_wire_prefs, &chosen_scheme));
     }
 
     *sig_scheme_out = chosen_scheme;
@@ -220,15 +220,15 @@ int s2n_choose_sig_scheme_from_peer_preference_list(struct s2n_connection *conn,
 int s2n_send_supported_sig_scheme_list(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     const struct s2n_signature_preferences *signature_preferences = NULL;
-    GUARD(s2n_connection_get_signature_preferences(conn, &signature_preferences));
-    notnull_check(signature_preferences);
+    POSIX_GUARD(s2n_connection_get_signature_preferences(conn, &signature_preferences));
+    POSIX_ENSURE_REF(signature_preferences);
 
-    GUARD(s2n_stuffer_write_uint16(out, s2n_supported_sig_scheme_list_size(conn)));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, s2n_supported_sig_scheme_list_size(conn)));
 
     for (size_t i = 0; i < signature_preferences->count; i++) {
         const struct s2n_signature_scheme *const scheme = signature_preferences->signature_schemes[i];
         if (0 == s2n_signature_scheme_valid_to_offer(conn, scheme)) {
-            GUARD(s2n_stuffer_write_uint16(out, scheme->iana_value));
+            POSIX_GUARD(s2n_stuffer_write_uint16(out, scheme->iana_value));
         }
     }
 
@@ -243,8 +243,8 @@ int s2n_supported_sig_scheme_list_size(struct s2n_connection *conn)
 int s2n_supported_sig_schemes_count(struct s2n_connection *conn)
 {
     const struct s2n_signature_preferences *signature_preferences = NULL;
-    GUARD(s2n_connection_get_signature_preferences(conn, &signature_preferences));
-    notnull_check(signature_preferences);
+    POSIX_GUARD(s2n_connection_get_signature_preferences(conn, &signature_preferences));
+    POSIX_ENSURE_REF(signature_preferences);
 
     uint8_t count = 0;
     for (size_t i = 0; i < signature_preferences->count; i++) {
@@ -258,7 +258,7 @@ int s2n_supported_sig_schemes_count(struct s2n_connection *conn)
 int s2n_recv_supported_sig_scheme_list(struct s2n_stuffer *in, struct s2n_sig_scheme_list *sig_hash_algs)
 {
     uint16_t length_of_all_pairs;
-    GUARD(s2n_stuffer_read_uint16(in, &length_of_all_pairs));
+    POSIX_GUARD(s2n_stuffer_read_uint16(in, &length_of_all_pairs));
     if (length_of_all_pairs > s2n_stuffer_data_available(in)) {
         /* Malformed length, ignore the extension */
         return 0;
@@ -266,21 +266,21 @@ int s2n_recv_supported_sig_scheme_list(struct s2n_stuffer *in, struct s2n_sig_sc
 
     if (length_of_all_pairs % 2) {
         /* Pairs occur in two byte lengths. Malformed length, ignore the extension and skip ahead */
-        GUARD(s2n_stuffer_skip_read(in, length_of_all_pairs));
+        POSIX_GUARD(s2n_stuffer_skip_read(in, length_of_all_pairs));
         return 0;
     }
 
     int pairs_available = length_of_all_pairs / 2;
 
     if (pairs_available > TLS_SIGNATURE_SCHEME_LIST_MAX_LEN) {
-        S2N_ERROR(S2N_ERR_TOO_MANY_SIGNATURE_SCHEMES);
+        POSIX_BAIL(S2N_ERR_TOO_MANY_SIGNATURE_SCHEMES);
     }
     
     sig_hash_algs->len = 0;
 
     for (size_t i = 0; i < pairs_available; i++) {
         uint16_t sig_scheme = 0;
-        GUARD(s2n_stuffer_read_uint16(in, &sig_scheme));
+        POSIX_GUARD(s2n_stuffer_read_uint16(in, &sig_scheme));
 
         sig_hash_algs->iana_list[sig_hash_algs->len] = sig_scheme;
         sig_hash_algs->len += 1;

--- a/tls/s2n_tls13.c
+++ b/tls/s2n_tls13.c
@@ -46,7 +46,7 @@ int s2n_enable_tls13()
  */
 int s2n_disable_tls13()
 {
-    ENSURE_POSIX(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
+    POSIX_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
     s2n_highest_protocol_version = S2N_TLS12;
     s2n_use_default_tls13_config_flag = false;
     return S2N_SUCCESS;
@@ -59,7 +59,7 @@ int s2n_disable_tls13()
  */
 int s2n_reset_tls13()
 {
-    ENSURE_POSIX(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
+    POSIX_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
     s2n_highest_protocol_version = S2N_TLS13;
     s2n_use_default_tls13_config_flag = false;
     return S2N_SUCCESS;

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -20,21 +20,21 @@
 
 static int s2n_zero_sequence_number(struct s2n_connection *conn, s2n_mode mode)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     struct s2n_blob sequence_number;
     if (mode == S2N_CLIENT) {
-        GUARD(s2n_blob_init(&sequence_number, conn->secure.client_sequence_number, sizeof(conn->secure.client_sequence_number)));
+        POSIX_GUARD(s2n_blob_init(&sequence_number, conn->secure.client_sequence_number, sizeof(conn->secure.client_sequence_number)));
     } else {
-        GUARD(s2n_blob_init(&sequence_number, conn->secure.server_sequence_number, sizeof(conn->secure.server_sequence_number)));
+        POSIX_GUARD(s2n_blob_init(&sequence_number, conn->secure.server_sequence_number, sizeof(conn->secure.server_sequence_number)));
     }
-    GUARD(s2n_blob_zero(&sequence_number));
+    POSIX_GUARD(s2n_blob_zero(&sequence_number));
     return S2N_SUCCESS;
 }
 
 int s2n_tls13_mac_verify(struct s2n_tls13_keys *keys, struct s2n_blob *finished_verify, struct s2n_blob *wire_verify)
 {
-    notnull_check(wire_verify->data);
-    eq_check(wire_verify->size, keys->size);
+    POSIX_ENSURE_REF(wire_verify->data);
+    POSIX_ENSURE_EQ(wire_verify->size, keys->size);
 
     S2N_ERROR_IF(!s2n_constant_time_equals(finished_verify->data, wire_verify->data, keys->size), S2N_ERR_BAD_MESSAGE);
 
@@ -46,35 +46,35 @@ int s2n_tls13_mac_verify(struct s2n_tls13_keys *keys, struct s2n_blob *finished_
  */
 static int s2n_tls13_keys_init_with_ref(struct s2n_tls13_keys *handshake, s2n_hmac_algorithm alg, uint8_t * extract,  uint8_t * derive)
 {
-    notnull_check(handshake);
+    POSIX_ENSURE_REF(handshake);
 
     handshake->hmac_algorithm = alg;
-    GUARD(s2n_hmac_hash_alg(alg, &handshake->hash_algorithm));
-    GUARD(s2n_hash_digest_size(handshake->hash_algorithm, &handshake->size));
-    GUARD(s2n_blob_init(&handshake->extract_secret, extract, handshake->size));
-    GUARD(s2n_blob_init(&handshake->derive_secret, derive, handshake->size));
-    GUARD(s2n_hmac_new(&handshake->hmac));
+    POSIX_GUARD(s2n_hmac_hash_alg(alg, &handshake->hash_algorithm));
+    POSIX_GUARD(s2n_hash_digest_size(handshake->hash_algorithm, &handshake->size));
+    POSIX_GUARD(s2n_blob_init(&handshake->extract_secret, extract, handshake->size));
+    POSIX_GUARD(s2n_blob_init(&handshake->derive_secret, derive, handshake->size));
+    POSIX_GUARD(s2n_hmac_new(&handshake->hmac));
 
     return 0;
 }
 
 int s2n_tls13_keys_from_conn(struct s2n_tls13_keys *keys, struct s2n_connection *conn)
 {
-    GUARD(s2n_tls13_keys_init_with_ref(keys, conn->secure.cipher_suite->prf_alg, conn->secure.rsa_premaster_secret, conn->secure.master_secret));
+    POSIX_GUARD(s2n_tls13_keys_init_with_ref(keys, conn->secure.cipher_suite->prf_alg, conn->secure.rsa_premaster_secret, conn->secure.master_secret));
 
     return 0;
 }
 
 int s2n_tls13_compute_ecc_shared_secret(struct s2n_connection *conn, struct s2n_blob *shared_secret) {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     const struct s2n_ecc_preferences *ecc_preferences = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
-    notnull_check(ecc_preferences);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
+    POSIX_ENSURE_REF(ecc_preferences);
 
     struct s2n_ecc_evp_params *server_key = &conn->secure.server_ecc_evp_params;
-    notnull_check(server_key);
-    notnull_check(server_key->negotiated_curve);
+    POSIX_ENSURE_REF(server_key);
+    POSIX_ENSURE_REF(server_key->negotiated_curve);
     /* for now we do this tedious loop to find the matching client key selection.
      * this can be simplified if we get an index or a pointer to a specific key */
     int selection = -1;
@@ -87,12 +87,12 @@ int s2n_tls13_compute_ecc_shared_secret(struct s2n_connection *conn, struct s2n_
 
     S2N_ERROR_IF(selection < 0, S2N_ERR_BAD_KEY_SHARE);
     struct s2n_ecc_evp_params *client_key = &conn->secure.client_ecc_evp_params[selection];
-    notnull_check(client_key);
+    POSIX_ENSURE_REF(client_key);
 
     if (conn->mode == S2N_CLIENT) {
-        GUARD(s2n_ecc_evp_compute_shared_secret_from_params(client_key, server_key, shared_secret));
+        POSIX_GUARD(s2n_ecc_evp_compute_shared_secret_from_params(client_key, server_key, shared_secret));
     } else {
-        GUARD(s2n_ecc_evp_compute_shared_secret_from_params(server_key, client_key, shared_secret));
+        POSIX_GUARD(s2n_ecc_evp_compute_shared_secret_from_params(server_key, client_key, shared_secret));
     }
 
     return 0;
@@ -101,53 +101,53 @@ int s2n_tls13_compute_ecc_shared_secret(struct s2n_connection *conn, struct s2n_
 /* Computes the ECDHE+PQKEM hybrid shared secret as defined in
  * https://tools.ietf.org/html/draft-stebila-tls-hybrid-design */
 int s2n_tls13_compute_pq_hybrid_shared_secret(struct s2n_connection *conn, struct s2n_blob *shared_secret) {
-    notnull_check(conn);
-    notnull_check(shared_secret);
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(shared_secret);
 
     /* conn->secure.server_ecc_evp_params should be set only during a classic/non-hybrid handshake */
-    eq_check(NULL, conn->secure.server_ecc_evp_params.negotiated_curve);
-    eq_check(NULL, conn->secure.server_ecc_evp_params.evp_pkey);
+    POSIX_ENSURE_EQ(NULL, conn->secure.server_ecc_evp_params.negotiated_curve);
+    POSIX_ENSURE_EQ(NULL, conn->secure.server_ecc_evp_params.evp_pkey);
 
     struct s2n_kem_group_params *server_kem_group_params = &conn->secure.server_kem_group_params;
-    notnull_check(server_kem_group_params);
+    POSIX_ENSURE_REF(server_kem_group_params);
     struct s2n_ecc_evp_params *server_ecc_params = &server_kem_group_params->ecc_params;
-    notnull_check(server_ecc_params);
+    POSIX_ENSURE_REF(server_ecc_params);
 
     struct s2n_kem_group_params *client_kem_group_params = conn->secure.chosen_client_kem_group_params;
-    notnull_check(client_kem_group_params);
+    POSIX_ENSURE_REF(client_kem_group_params);
     struct s2n_ecc_evp_params *client_ecc_params = &client_kem_group_params->ecc_params;
-    notnull_check(client_ecc_params);
+    POSIX_ENSURE_REF(client_ecc_params);
 
     DEFER_CLEANUP(struct s2n_blob ecdhe_shared_secret = { 0 }, s2n_blob_zeroize_free);
 
     /* Compute the ECDHE shared secret, and retrieve the PQ shared secret. */
     if (conn->mode == S2N_CLIENT) {
-        GUARD(s2n_ecc_evp_compute_shared_secret_from_params(client_ecc_params, server_ecc_params, &ecdhe_shared_secret));
+        POSIX_GUARD(s2n_ecc_evp_compute_shared_secret_from_params(client_ecc_params, server_ecc_params, &ecdhe_shared_secret));
     } else {
-        GUARD(s2n_ecc_evp_compute_shared_secret_from_params(server_ecc_params, client_ecc_params, &ecdhe_shared_secret));
+        POSIX_GUARD(s2n_ecc_evp_compute_shared_secret_from_params(server_ecc_params, client_ecc_params, &ecdhe_shared_secret));
     }
 
     struct s2n_blob *pq_shared_secret = &client_kem_group_params->kem_params.shared_secret;
-    notnull_check(pq_shared_secret);
-    notnull_check(pq_shared_secret->data);
+    POSIX_ENSURE_REF(pq_shared_secret);
+    POSIX_ENSURE_REF(pq_shared_secret->data);
 
     const struct s2n_kem_group *negotiated_kem_group = conn->secure.server_kem_group_params.kem_group;
-    notnull_check(negotiated_kem_group);
-    notnull_check(negotiated_kem_group->kem);
+    POSIX_ENSURE_REF(negotiated_kem_group);
+    POSIX_ENSURE_REF(negotiated_kem_group->kem);
 
-    eq_check(pq_shared_secret->size, negotiated_kem_group->kem->shared_secret_key_length);
+    POSIX_ENSURE_EQ(pq_shared_secret->size, negotiated_kem_group->kem->shared_secret_key_length);
 
     /* Construct the concatenated/hybrid shared secret */
     uint32_t hybrid_shared_secret_size = ecdhe_shared_secret.size + negotiated_kem_group->kem->shared_secret_key_length;
-    GUARD(s2n_alloc(shared_secret, hybrid_shared_secret_size));
+    POSIX_GUARD(s2n_alloc(shared_secret, hybrid_shared_secret_size));
     struct s2n_stuffer stuffer_combiner = { 0 };
-    GUARD(s2n_stuffer_init(&stuffer_combiner, shared_secret));
-    GUARD(s2n_stuffer_write(&stuffer_combiner, &ecdhe_shared_secret));
-    GUARD(s2n_stuffer_write(&stuffer_combiner, pq_shared_secret));
+    POSIX_GUARD(s2n_stuffer_init(&stuffer_combiner, shared_secret));
+    POSIX_GUARD(s2n_stuffer_write(&stuffer_combiner, &ecdhe_shared_secret));
+    POSIX_GUARD(s2n_stuffer_write(&stuffer_combiner, pq_shared_secret));
 
     /* No longer need PQ shared secret or ECC keys */
-    GUARD(s2n_kem_group_free(server_kem_group_params));
-    GUARD(s2n_kem_group_free(client_kem_group_params));
+    POSIX_GUARD(s2n_kem_group_free(server_kem_group_params));
+    POSIX_GUARD(s2n_kem_group_free(client_kem_group_params));
 
     return S2N_SUCCESS;
 }
@@ -158,12 +158,12 @@ static int s2n_tls13_pq_hybrid_supported(struct s2n_connection *conn) {
 
 int s2n_tls13_compute_shared_secret(struct s2n_connection *conn, struct s2n_blob *shared_secret)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
 
     if (s2n_tls13_pq_hybrid_supported(conn)) {
-        GUARD(s2n_tls13_compute_pq_hybrid_shared_secret(conn, shared_secret));
+        POSIX_GUARD(s2n_tls13_compute_pq_hybrid_shared_secret(conn, shared_secret));
     } else {
-        GUARD(s2n_tls13_compute_ecc_shared_secret(conn, shared_secret));
+        POSIX_GUARD(s2n_tls13_compute_ecc_shared_secret(conn, shared_secret));
     }
 
     return S2N_SUCCESS;
@@ -177,36 +177,36 @@ int s2n_tls13_compute_shared_secret(struct s2n_connection *conn, struct s2n_blob
  */
 int s2n_tls13_handle_handshake_secrets(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     const struct s2n_ecc_preferences *ecc_preferences = NULL;
-    GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
-    notnull_check(ecc_preferences);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
+    POSIX_ENSURE_REF(ecc_preferences);
     
     /* get tls13 key context */
     s2n_tls13_connection_keys(secrets, conn);
 
     /* get shared secret */
     DEFER_CLEANUP(struct s2n_blob shared_secret = { 0 }, s2n_free);
-    GUARD(s2n_tls13_compute_shared_secret(conn, &shared_secret));
+    POSIX_GUARD(s2n_tls13_compute_shared_secret(conn, &shared_secret));
 
     /* derive early secrets */
-    GUARD(s2n_tls13_derive_early_secrets(&secrets, conn->psk_params.chosen_psk));
+    POSIX_GUARD(s2n_tls13_derive_early_secrets(&secrets, conn->psk_params.chosen_psk));
     /* Wipe the PSK secrets as they are no longer required */
-    GUARD_AS_POSIX(s2n_psk_parameters_wipe_secrets(&conn->psk_params));
+    POSIX_GUARD_RESULT(s2n_psk_parameters_wipe_secrets(&conn->psk_params));
 
     /* produce handshake secrets */
     s2n_stack_blob(client_hs_secret, secrets.size, S2N_TLS13_SECRET_MAX_LEN);
     s2n_stack_blob(server_hs_secret, secrets.size, S2N_TLS13_SECRET_MAX_LEN);
 
     struct s2n_hash_state hash_state = {0};
-    GUARD(s2n_handshake_get_hash_state(conn, secrets.hash_algorithm, &hash_state));
-    GUARD(s2n_tls13_derive_handshake_secrets(&secrets, &shared_secret, &hash_state, &client_hs_secret, &server_hs_secret));
+    POSIX_GUARD(s2n_handshake_get_hash_state(conn, secrets.hash_algorithm, &hash_state));
+    POSIX_GUARD(s2n_tls13_derive_handshake_secrets(&secrets, &shared_secret, &hash_state, &client_hs_secret, &server_hs_secret));
 
     /* trigger secret callbacks */
     if (conn->secret_cb && conn->config->quic_enabled) {
-        GUARD(conn->secret_cb(conn->secret_cb_context, conn, S2N_CLIENT_HANDSHAKE_TRAFFIC_SECRET,
+        POSIX_GUARD(conn->secret_cb(conn->secret_cb_context, conn, S2N_CLIENT_HANDSHAKE_TRAFFIC_SECRET,
                 client_hs_secret.data, client_hs_secret.size));
-        GUARD(conn->secret_cb(conn->secret_cb_context, conn, S2N_SERVER_HANDSHAKE_TRAFFIC_SECRET,
+        POSIX_GUARD(conn->secret_cb(conn->secret_cb_context, conn, S2N_SERVER_HANDSHAKE_TRAFFIC_SECRET,
                 server_hs_secret.data, server_hs_secret.size));
     }
 
@@ -216,41 +216,41 @@ int s2n_tls13_handle_handshake_secrets(struct s2n_connection *conn)
     /* produce handshake traffic keys and configure record algorithm */
     s2n_tls13_key_blob(server_hs_key, conn->secure.cipher_suite->record_alg->cipher->key_material_size);
     struct s2n_blob server_hs_iv = { .data = conn->secure.server_implicit_iv, .size = S2N_TLS13_FIXED_IV_LEN };
-    GUARD(s2n_tls13_derive_traffic_keys(&secrets, &server_hs_secret, &server_hs_key, &server_hs_iv));
+    POSIX_GUARD(s2n_tls13_derive_traffic_keys(&secrets, &server_hs_secret, &server_hs_key, &server_hs_iv));
 
     s2n_tls13_key_blob(client_hs_key, conn->secure.cipher_suite->record_alg->cipher->key_material_size);
     struct s2n_blob client_hs_iv = { .data = conn->secure.client_implicit_iv, .size = S2N_TLS13_FIXED_IV_LEN };
-    GUARD(s2n_tls13_derive_traffic_keys(&secrets, &client_hs_secret, &client_hs_key, &client_hs_iv));
+    POSIX_GUARD(s2n_tls13_derive_traffic_keys(&secrets, &client_hs_secret, &client_hs_key, &client_hs_iv));
 
-    GUARD(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.server_key));
-    GUARD(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.client_key));
+    POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.server_key));
+    POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.client_key));
 
     if (conn->mode == S2N_CLIENT) {
-        GUARD(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure.server_key, &server_hs_key));
-        GUARD(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure.client_key, &client_hs_key));
+        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure.server_key, &server_hs_key));
+        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure.client_key, &client_hs_key));
     } else {
-        GUARD(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure.server_key, &server_hs_key));
-        GUARD(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure.client_key, &client_hs_key));
+        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure.server_key, &server_hs_key));
+        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure.client_key, &client_hs_key));
     }
 
     /* calculate server + client finished keys and store them in handshake struct */
     struct s2n_blob server_finished_key = { .data = conn->handshake.server_finished, .size = secrets.size };
     struct s2n_blob client_finished_key = { .data = conn->handshake.client_finished, .size = secrets.size };
-    GUARD(s2n_tls13_derive_finished_key(&secrets, &server_hs_secret, &server_finished_key));
-    GUARD(s2n_tls13_derive_finished_key(&secrets, &client_hs_secret, &client_finished_key));
+    POSIX_GUARD(s2n_tls13_derive_finished_key(&secrets, &server_hs_secret, &server_finished_key));
+    POSIX_GUARD(s2n_tls13_derive_finished_key(&secrets, &client_hs_secret, &client_finished_key));
 
     /* since shared secret has been computed, clean up keys */
-    GUARD(s2n_ecc_evp_params_free(&conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_ecc_evp_params_free(&conn->secure.server_ecc_evp_params));
     for (int i = 0; i < ecc_preferences->count; i++) {
-        GUARD(s2n_ecc_evp_params_free(&conn->secure.client_ecc_evp_params[i]));
+        POSIX_GUARD(s2n_ecc_evp_params_free(&conn->secure.client_ecc_evp_params[i]));
     }
 
     /* According to https://tools.ietf.org/html/rfc8446#section-5.3:
      * Each sequence number is set to zero at the beginning of a connection and
      * whenever the key is changed
      */
-    GUARD(s2n_zero_sequence_number(conn, S2N_CLIENT));
-    GUARD(s2n_zero_sequence_number(conn, S2N_SERVER));
+    POSIX_GUARD(s2n_zero_sequence_number(conn, S2N_CLIENT));
+    POSIX_GUARD(s2n_zero_sequence_number(conn, S2N_SERVER));
 
     return 0;
 }
@@ -278,15 +278,15 @@ static int s2n_tls13_handle_application_secret(struct s2n_connection *conn, s2n_
 
     /* use frozen hashes during the server finished state */
     struct s2n_hash_state *hash_state;
-    GUARD_NONNULL(hash_state = &conn->handshake.server_finished_copy);
+    POSIX_GUARD_PTR(hash_state = &conn->handshake.server_finished_copy);
 
     /* calculate secret */
     struct s2n_blob app_secret = { .data = app_secret_data, .size = keys.size };
-    GUARD(s2n_tls13_derive_application_secret(&keys, hash_state, &app_secret, mode));
+    POSIX_GUARD(s2n_tls13_derive_application_secret(&keys, hash_state, &app_secret, mode));
 
     /* trigger secret callback */
     if (conn->secret_cb && conn->config->quic_enabled) {
-        GUARD(conn->secret_cb(conn->secret_cb_context, conn, secret_type,
+        POSIX_GUARD(conn->secret_cb(conn->secret_cb_context, conn, secret_type,
                 app_secret.data, app_secret.size));
     }
 
@@ -295,20 +295,20 @@ static int s2n_tls13_handle_application_secret(struct s2n_connection *conn, s2n_
     /* derive key from secret */
     s2n_tls13_key_blob(app_key, conn->secure.cipher_suite->record_alg->cipher->key_material_size);
     struct s2n_blob app_iv = { .data = implicit_iv_data, .size = S2N_TLS13_FIXED_IV_LEN };
-    GUARD(s2n_tls13_derive_traffic_keys(&keys, &app_secret, &app_key, &app_iv));
+    POSIX_GUARD(s2n_tls13_derive_traffic_keys(&keys, &app_secret, &app_key, &app_iv));
 
     /* update record algorithm secrets */
     if (is_sending_secret) {
-        GUARD(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(session_key, &app_key));
+        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(session_key, &app_key));
     } else {
-        GUARD(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(session_key, &app_key));
+        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(session_key, &app_key));
     }
 
     /* According to https://tools.ietf.org/html/rfc8446#section-5.3:
      * Each sequence number is set to zero at the beginning of a connection and
      * whenever the key is changed
      */
-    GUARD(s2n_zero_sequence_number(conn, mode));
+    POSIX_GUARD(s2n_zero_sequence_number(conn, mode));
 
     return S2N_SUCCESS;
 }
@@ -319,7 +319,7 @@ static int s2n_tls13_handle_application_secret(struct s2n_connection *conn, s2n_
 static int s2n_tls13_handle_master_secret(struct s2n_connection *conn)
 {
     s2n_tls13_connection_keys(keys, conn);
-    GUARD(s2n_tls13_extract_master_secret(&keys));
+    POSIX_GUARD(s2n_tls13_extract_master_secret(&keys));
     return S2N_SUCCESS;
 }
 
@@ -328,41 +328,41 @@ static int s2n_tls13_handle_resumption_master_secret(struct s2n_connection *conn
     s2n_tls13_connection_keys(keys, conn);
     
     struct s2n_hash_state hash_state = {0};
-    GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
+    POSIX_GUARD(s2n_handshake_get_hash_state(conn, keys.hash_algorithm, &hash_state));
     
     struct s2n_blob resumption_master_secret = {0};
-    GUARD(s2n_blob_init(&resumption_master_secret, conn->resumption_master_secret, keys.size));
-    GUARD(s2n_tls13_derive_resumption_master_secret(&keys, &hash_state, &resumption_master_secret));
+    POSIX_GUARD(s2n_blob_init(&resumption_master_secret, conn->resumption_master_secret, keys.size));
+    POSIX_GUARD(s2n_tls13_derive_resumption_master_secret(&keys, &hash_state, &resumption_master_secret));
     return S2N_SUCCESS;
 }
 
 int s2n_tls13_handle_secrets(struct s2n_connection *conn)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     if (conn->actual_protocol_version < S2N_TLS13) {
         return S2N_SUCCESS;
     }
 
     switch(s2n_conn_get_current_message_type(conn)) {
         case SERVER_HELLO:
-            GUARD(s2n_tls13_handle_handshake_secrets(conn));
+            POSIX_GUARD(s2n_tls13_handle_handshake_secrets(conn));
             /* Set negotiated crypto parameters for encryption */
             conn->server = &conn->secure;
             conn->client = &conn->secure;
             break;
         case SERVER_FINISHED:
             if (conn->mode == S2N_SERVER) {
-                GUARD(s2n_tls13_handle_master_secret(conn));
-                GUARD(s2n_tls13_handle_application_secret(conn, S2N_SERVER));
+                POSIX_GUARD(s2n_tls13_handle_master_secret(conn));
+                POSIX_GUARD(s2n_tls13_handle_application_secret(conn, S2N_SERVER));
             }
             break;
         case CLIENT_FINISHED:
             if (conn->mode == S2N_CLIENT) {
-                GUARD(s2n_tls13_handle_master_secret(conn));
-                GUARD(s2n_tls13_handle_application_secret(conn, S2N_SERVER));
+                POSIX_GUARD(s2n_tls13_handle_master_secret(conn));
+                POSIX_GUARD(s2n_tls13_handle_application_secret(conn, S2N_SERVER));
             }
-            GUARD(s2n_tls13_handle_application_secret(conn, S2N_CLIENT));
-            GUARD(s2n_tls13_handle_resumption_master_secret(conn));
+            POSIX_GUARD(s2n_tls13_handle_application_secret(conn, S2N_CLIENT));
+            POSIX_GUARD(s2n_tls13_handle_resumption_master_secret(conn));
             break;
         default:
             break;
@@ -372,7 +372,7 @@ int s2n_tls13_handle_secrets(struct s2n_connection *conn)
 
 int s2n_update_application_traffic_keys(struct s2n_connection *conn, s2n_mode mode, keyupdate_status status)
 {
-    notnull_check(conn);
+    POSIX_ENSURE_REF(conn);
     
     /* get tls13 key context */
     s2n_tls13_connection_keys(keys, conn);
@@ -383,28 +383,28 @@ int s2n_update_application_traffic_keys(struct s2n_connection *conn, s2n_mode mo
 
     if (mode == S2N_CLIENT) {
         old_key = &conn->secure.client_key;
-        GUARD(s2n_blob_init(&old_app_secret, conn->secure.client_app_secret, keys.size));
-        GUARD(s2n_blob_init(&app_iv, conn->secure.client_implicit_iv, S2N_TLS13_FIXED_IV_LEN));
+        POSIX_GUARD(s2n_blob_init(&old_app_secret, conn->secure.client_app_secret, keys.size));
+        POSIX_GUARD(s2n_blob_init(&app_iv, conn->secure.client_implicit_iv, S2N_TLS13_FIXED_IV_LEN));
     } else {
         old_key = &conn->secure.server_key;
-        GUARD(s2n_blob_init(&old_app_secret, conn->secure.server_app_secret, keys.size));
-        GUARD(s2n_blob_init(&app_iv, conn->secure.server_implicit_iv, S2N_TLS13_FIXED_IV_LEN));  
+        POSIX_GUARD(s2n_blob_init(&old_app_secret, conn->secure.server_app_secret, keys.size));
+        POSIX_GUARD(s2n_blob_init(&app_iv, conn->secure.server_implicit_iv, S2N_TLS13_FIXED_IV_LEN));  
     }
 
     /* Produce new application secret */
     s2n_stack_blob(app_secret_update, keys.size, S2N_TLS13_SECRET_MAX_LEN);
 
     /* Derives next generation of traffic secret */
-    GUARD(s2n_tls13_update_application_traffic_secret(&keys, &old_app_secret, &app_secret_update));
+    POSIX_GUARD(s2n_tls13_update_application_traffic_secret(&keys, &old_app_secret, &app_secret_update));
 
     s2n_tls13_key_blob(app_key, conn->secure.cipher_suite->record_alg->cipher->key_material_size);
 
     /* Derives next generation of traffic key */
-    GUARD(s2n_tls13_derive_traffic_keys(&keys, &app_secret_update, &app_key, &app_iv));
+    POSIX_GUARD(s2n_tls13_derive_traffic_keys(&keys, &app_secret_update, &app_key, &app_iv));
     if (status == RECEIVING) {
-        GUARD(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(old_key, &app_key));
+        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(old_key, &app_key));
     } else {
-        GUARD(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(old_key, &app_key));
+        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(old_key, &app_key));
     }
 
     /* According to https://tools.ietf.org/html/rfc8446#section-5.3:
@@ -412,12 +412,12 @@ int s2n_update_application_traffic_keys(struct s2n_connection *conn, s2n_mode mo
      * whenever the key is changed; the first record transmitted under a particular traffic key
      * MUST use sequence number 0.
      */
-    GUARD(s2n_zero_sequence_number(conn, mode));
+    POSIX_GUARD(s2n_zero_sequence_number(conn, mode));
     
     /* Save updated secret */
     struct s2n_stuffer old_secret_stuffer = {0};
-    GUARD(s2n_stuffer_init(&old_secret_stuffer, &old_app_secret));
-    GUARD(s2n_stuffer_write_bytes(&old_secret_stuffer, app_secret_update.data, keys.size));
+    POSIX_GUARD(s2n_stuffer_init(&old_secret_stuffer, &old_app_secret));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&old_secret_stuffer, app_secret_update.data, keys.size));
 
     return S2N_SUCCESS;
 }

--- a/tls/s2n_tls13_handshake.h
+++ b/tls/s2n_tls13_handshake.h
@@ -25,12 +25,12 @@ int s2n_tls13_mac_verify(struct s2n_tls13_keys *keys, struct s2n_blob *finished_
 
 #define s2n_get_hash_state(hash_state, alg, conn) \
     struct s2n_hash_state hash_state = {0}; \
-    GUARD(s2n_handshake_get_hash_state(conn, alg, &hash_state));
+    POSIX_GUARD(s2n_handshake_get_hash_state(conn, alg, &hash_state));
 
 /* Creates a reference to tls13_keys from connection */
 #define s2n_tls13_connection_keys(keys, conn) \
     DEFER_CLEANUP(struct s2n_tls13_keys keys = {0}, s2n_tls13_keys_free);\
-    GUARD(s2n_tls13_keys_from_conn(&keys, conn));
+    POSIX_GUARD(s2n_tls13_keys_from_conn(&keys, conn));
 
 int s2n_tls13_keys_from_conn(struct s2n_tls13_keys *keys, struct s2n_connection *conn);
 

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -23,35 +23,35 @@
 S2N_RESULT s2n_array_validate(const struct s2n_array *array)
 {
     uint32_t mem_size = 0;
-    ENSURE_REF(array);
-    GUARD_RESULT(s2n_blob_validate(&array->mem));
-    ENSURE_NE(array->element_size, 0);
-    GUARD_AS_RESULT(s2n_mul_overflow(array->len, array->element_size, &mem_size));
-    ENSURE_GTE(array->mem.size, mem_size);
+    RESULT_ENSURE_REF(array);
+    RESULT_GUARD(s2n_blob_validate(&array->mem));
+    RESULT_ENSURE_NE(array->element_size, 0);
+    RESULT_GUARD_POSIX(s2n_mul_overflow(array->len, array->element_size, &mem_size));
+    RESULT_ENSURE_GTE(array->mem.size, mem_size);
     return S2N_RESULT_OK;
 }
 
 static S2N_RESULT s2n_array_enlarge(struct s2n_array *array, uint32_t capacity)
 {
-    ENSURE_REF(array);
+    RESULT_ENSURE_REF(array);
 
     /* Acquire the memory */
     uint32_t mem_needed;
-    GUARD_AS_RESULT(s2n_mul_overflow(array->element_size, capacity, &mem_needed));
-    GUARD_AS_RESULT(s2n_realloc(&array->mem, mem_needed));
+    RESULT_GUARD_POSIX(s2n_mul_overflow(array->element_size, capacity, &mem_needed));
+    RESULT_GUARD_POSIX(s2n_realloc(&array->mem, mem_needed));
 
     /* Zero the extened part */
     uint32_t array_elements_size;
-    GUARD_AS_RESULT(s2n_mul_overflow(array->element_size, array->len, &array_elements_size));
-    CHECKED_MEMSET(array->mem.data + array_elements_size, 0, array->mem.size - array_elements_size);
-    GUARD_RESULT(s2n_array_validate(array));
+    RESULT_GUARD_POSIX(s2n_mul_overflow(array->element_size, array->len, &array_elements_size));
+    RESULT_CHECKED_MEMSET(array->mem.data + array_elements_size, 0, array->mem.size - array_elements_size);
+    RESULT_GUARD(s2n_array_validate(array));
     return S2N_RESULT_OK;
 }
 
 struct s2n_array *s2n_array_new(uint32_t element_size)
 {
     struct s2n_blob mem = {0};
-    GUARD_PTR(s2n_alloc(&mem, sizeof(struct s2n_array)));
+    PTR_GUARD_POSIX(s2n_alloc(&mem, sizeof(struct s2n_array)));
 
     struct s2n_array *array = (void *) mem.data;
 
@@ -59,7 +59,7 @@ struct s2n_array *s2n_array_new(uint32_t element_size)
 
     if (s2n_result_is_error(s2n_array_enlarge(array, S2N_INITIAL_ARRAY_SIZE))) {
         /* Avoid memory leak if allocation fails */
-        GUARD_PTR(s2n_free(&mem));
+        PTR_GUARD_POSIX(s2n_free(&mem));
         return NULL;
     }
     return array;
@@ -67,26 +67,26 @@ struct s2n_array *s2n_array_new(uint32_t element_size)
 
 S2N_RESULT s2n_array_init(struct s2n_array *array, uint32_t element_size)
 {
-    ENSURE_REF(array);
+    RESULT_ENSURE_REF(array);
 
     *array = (struct s2n_array){.element_size = element_size};
 
-    GUARD_RESULT(s2n_array_validate(array));
+    RESULT_GUARD(s2n_array_validate(array));
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_array_pushback(struct s2n_array *array, void **element)
 {
-    GUARD_RESULT(s2n_array_validate(array));
-    ENSURE_REF(element);
+    RESULT_GUARD(s2n_array_validate(array));
+    RESULT_ENSURE_REF(element);
     return s2n_array_insert(array, array->len, element);
 }
 
 S2N_RESULT s2n_array_get(struct s2n_array *array, uint32_t idx, void **element)
 {
-    GUARD_RESULT(s2n_array_validate(array));
-    ENSURE_REF(element);
-    ENSURE(idx < array->len, S2N_ERR_ARRAY_INDEX_OOB);
+    RESULT_GUARD(s2n_array_validate(array));
+    RESULT_ENSURE_REF(element);
+    RESULT_ENSURE(idx < array->len, S2N_ERR_ARRAY_INDEX_OOB);
     *element = array->mem.data + (array->element_size * idx);
     return S2N_RESULT_OK;
 }
@@ -94,28 +94,28 @@ S2N_RESULT s2n_array_get(struct s2n_array *array, uint32_t idx, void **element)
 S2N_RESULT s2n_array_insert_and_copy(struct s2n_array *array, uint32_t idx, void* element)
 {
     void* insert_location = NULL;
-    GUARD_RESULT(s2n_array_insert(array, idx, &insert_location));
-    CHECKED_MEMCPY(insert_location, element, array->element_size);
+    RESULT_GUARD(s2n_array_insert(array, idx, &insert_location));
+    RESULT_CHECKED_MEMCPY(insert_location, element, array->element_size);
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_array_insert(struct s2n_array *array, uint32_t idx, void **element)
 {
-    GUARD_RESULT(s2n_array_validate(array));
-    ENSURE_REF(element);
+    RESULT_GUARD(s2n_array_validate(array));
+    RESULT_ENSURE_REF(element);
     /* index == len is ok since we're about to add one element */
-    ENSURE(idx <= array->len, S2N_ERR_ARRAY_INDEX_OOB);
+    RESULT_ENSURE(idx <= array->len, S2N_ERR_ARRAY_INDEX_OOB);
 
     /* We are about to add one more element to the array. Add capacity if necessary */
     uint32_t current_capacity = 0;
-    GUARD_RESULT(s2n_array_capacity(array, &current_capacity));
+    RESULT_GUARD(s2n_array_capacity(array, &current_capacity));
 
     if (array->len >= current_capacity) {
         /* Enlarge the array */
         uint32_t new_capacity = 0;
-        GUARD_AS_RESULT(s2n_mul_overflow(current_capacity, 2, &new_capacity));
+        RESULT_GUARD_POSIX(s2n_mul_overflow(current_capacity, 2, &new_capacity));
         new_capacity = MAX(new_capacity, S2N_INITIAL_ARRAY_SIZE);
-        GUARD_RESULT(s2n_array_enlarge(array, new_capacity));
+        RESULT_GUARD(s2n_array_enlarge(array, new_capacity));
     }
 
     /* If we are adding at an existing index, slide everything down. */
@@ -128,14 +128,14 @@ S2N_RESULT s2n_array_insert(struct s2n_array *array, uint32_t idx, void **elemen
     *element = array->mem.data + array->element_size * idx;
     array->len++;
 
-    GUARD_RESULT(s2n_array_validate(array));
+    RESULT_GUARD(s2n_array_validate(array));
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_array_remove(struct s2n_array *array, uint32_t idx)
 {
-    GUARD_RESULT(s2n_array_validate(array));
-    ENSURE(idx < array->len, S2N_ERR_ARRAY_INDEX_OOB);
+    RESULT_GUARD(s2n_array_validate(array));
+    RESULT_ENSURE(idx < array->len, S2N_ERR_ARRAY_INDEX_OOB);
 
     /* If the removed element is the last one, no need to move anything.
      * Otherwise, shift everything down */
@@ -147,7 +147,7 @@ S2N_RESULT s2n_array_remove(struct s2n_array *array, uint32_t idx)
     array->len--;
 
     /* After shifting, zero the last element */
-    CHECKED_MEMSET(array->mem.data + array->element_size * array->len,
+    RESULT_CHECKED_MEMSET(array->mem.data + array->element_size * array->len,
                    0,
                    array->element_size);
 
@@ -156,8 +156,8 @@ S2N_RESULT s2n_array_remove(struct s2n_array *array, uint32_t idx)
 
 S2N_RESULT s2n_array_num_elements(struct s2n_array *array, uint32_t *len)
 {
-    GUARD_RESULT(s2n_array_validate(array));
-    ENSURE_MUT(len);
+    RESULT_GUARD(s2n_array_validate(array));
+    RESULT_ENSURE_MUT(len);
 
     *len = array->len;
 
@@ -166,8 +166,8 @@ S2N_RESULT s2n_array_num_elements(struct s2n_array *array, uint32_t *len)
 
 S2N_RESULT s2n_array_capacity(struct s2n_array *array, uint32_t *capacity)
 {
-    GUARD_RESULT(s2n_array_validate(array));
-    ENSURE_MUT(capacity);
+    RESULT_GUARD(s2n_array_validate(array));
+    RESULT_ENSURE_MUT(capacity);
 
     *capacity = array->mem.size / array->element_size;
 
@@ -176,21 +176,21 @@ S2N_RESULT s2n_array_capacity(struct s2n_array *array, uint32_t *capacity)
 
 S2N_RESULT s2n_array_free_p(struct s2n_array **parray)
 {
-    ENSURE_REF(parray);
+    RESULT_ENSURE_REF(parray);
     struct s2n_array *array = *parray;
 
-    ENSURE_REF(array);
+    RESULT_ENSURE_REF(array);
     /* Free the elements */
-    GUARD_AS_RESULT(s2n_free(&array->mem));
+    RESULT_GUARD_POSIX(s2n_free(&array->mem));
 
     /* And finally the array */
-    GUARD_AS_RESULT(s2n_free_object((uint8_t **)parray, sizeof(struct s2n_array)));
+    RESULT_GUARD_POSIX(s2n_free_object((uint8_t **)parray, sizeof(struct s2n_array)));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_array_free(struct s2n_array *array)
 {
-    ENSURE_REF(array);
+    RESULT_ENSURE_REF(array);
     return s2n_array_free_p(&array);
 }

--- a/utils/s2n_asn1_time.c
+++ b/utils/s2n_asn1_time.c
@@ -62,7 +62,7 @@ static inline void get_current_timesettings(long *gmt_offset, int *is_dst) {
     *is_dst = time_ptr.tm_isdst;
 }
 
-#define PARSE_DIGIT(c, d)  do { ENSURE(isdigit(c), S2N_ERR_SAFETY); d = c - '0'; } while(0)
+#define PARSE_DIGIT(c, d)  do { RESULT_ENSURE(isdigit(c), S2N_ERR_SAFETY); d = c - '0'; } while(0)
 
 /* this is just a standard state machine for ASN1 date format... nothing special.
  * just do a character at a time and change the state per character encountered.
@@ -255,15 +255,15 @@ S2N_RESULT s2n_asn1_time_to_nano_since_epoch_ticks(const char *asn1_time, uint32
 
     while (state < FINISHED && current_pos < str_len) {
         char current_char = asn1_time[current_pos];
-        ENSURE_OK(process_state(&state, current_char, &args), S2N_ERR_INVALID_ARGUMENT);
+        RESULT_ENSURE_OK(process_state(&state, current_char, &args), S2N_ERR_INVALID_ARGUMENT);
         current_pos++;
     }
 
     /* state on subsecond means no timezone info was found and we assume local time */
-    ENSURE(state == FINISHED || state == ON_SUBSECOND, S2N_ERR_INVALID_ARGUMENT);
+    RESULT_ENSURE(state == FINISHED || state == ON_SUBSECOND, S2N_ERR_INVALID_ARGUMENT);
 
     time_t clock_data = mktime(&args.time);
-    ENSURE_GTE(clock_data, 0);
+    RESULT_ENSURE_GTE(clock_data, 0);
 
     /* ASN1 + and - is in format HHMM. We need to convert it to seconds for the adjustment */
     long gmt_offset = (args.offset_hours * 3600) + (args.offset_minutes * 60);
@@ -280,7 +280,7 @@ S2N_RESULT s2n_asn1_time_to_nano_since_epoch_ticks(const char *asn1_time, uint32
         gmt_offset -= args.time.tm_isdst != is_dst ? (args.time.tm_isdst - is_dst) * 3600 : 0;
     }
 
-    ENSURE_GTE(clock_data, gmt_offset);
+    RESULT_ENSURE_GTE(clock_data, gmt_offset);
 
     /* convert to nanoseconds and add the timezone offset. */
     *ticks = ((uint64_t) clock_data - gmt_offset) * 1000000000;

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -26,57 +26,57 @@
 
 S2N_RESULT s2n_blob_validate(const struct s2n_blob* b)
 {
-    ENSURE_REF(b);
-    DEBUG_ENSURE(S2N_IMPLIES(b->data == NULL, b->size == 0), S2N_ERR_SAFETY);
-    DEBUG_ENSURE(S2N_IMPLIES(b->data == NULL, b->allocated == 0), S2N_ERR_SAFETY);
-    DEBUG_ENSURE(S2N_IMPLIES(b->growable == 0, b->allocated == 0), S2N_ERR_SAFETY);
-    DEBUG_ENSURE(S2N_IMPLIES(b->growable != 0, b->size <= b->allocated), S2N_ERR_SAFETY);
-    DEBUG_ENSURE(S2N_MEM_IS_READABLE(b->data, b->allocated), S2N_ERR_SAFETY);
-    DEBUG_ENSURE(S2N_MEM_IS_READABLE(b->data, b->size), S2N_ERR_SAFETY);
+    RESULT_ENSURE_REF(b);
+    RESULT_DEBUG_ENSURE(S2N_IMPLIES(b->data == NULL, b->size == 0), S2N_ERR_SAFETY);
+    RESULT_DEBUG_ENSURE(S2N_IMPLIES(b->data == NULL, b->allocated == 0), S2N_ERR_SAFETY);
+    RESULT_DEBUG_ENSURE(S2N_IMPLIES(b->growable == 0, b->allocated == 0), S2N_ERR_SAFETY);
+    RESULT_DEBUG_ENSURE(S2N_IMPLIES(b->growable != 0, b->size <= b->allocated), S2N_ERR_SAFETY);
+    RESULT_DEBUG_ENSURE(S2N_MEM_IS_READABLE(b->data, b->allocated), S2N_ERR_SAFETY);
+    RESULT_DEBUG_ENSURE(S2N_MEM_IS_READABLE(b->data, b->size), S2N_ERR_SAFETY);
     return S2N_RESULT_OK;
 }
 
 int s2n_blob_init(struct s2n_blob *b, uint8_t * data, uint32_t size)
 {
-    ENSURE_POSIX_REF(b);
-    ENSURE_POSIX(S2N_MEM_IS_READABLE(data, size), S2N_ERR_SAFETY);
+    POSIX_ENSURE_REF(b);
+    POSIX_ENSURE(S2N_MEM_IS_READABLE(data, size), S2N_ERR_SAFETY);
     *b = (struct s2n_blob) {.data = data, .size = size, .allocated = 0, .growable = 0};
-    POSTCONDITION_POSIX(s2n_blob_validate(b));
+    POSIX_POSTCONDITION(s2n_blob_validate(b));
     return S2N_SUCCESS;
 }
 
 int s2n_blob_zero(struct s2n_blob *b)
 {
-    PRECONDITION_POSIX(s2n_blob_validate(b));
-    memset_check(b->data, 0, MAX(b->allocated, b->size));
-    POSTCONDITION_POSIX(s2n_blob_validate(b));
+    POSIX_PRECONDITION(s2n_blob_validate(b));
+    POSIX_CHECKED_MEMSET(b->data, 0, MAX(b->allocated, b->size));
+    POSIX_POSTCONDITION(s2n_blob_validate(b));
     return S2N_SUCCESS;
 }
 
 int s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint32_t offset, uint32_t size)
 {
-    PRECONDITION_POSIX(s2n_blob_validate(b));
-    PRECONDITION_POSIX(s2n_blob_validate(slice));
+    POSIX_PRECONDITION(s2n_blob_validate(b));
+    POSIX_PRECONDITION(s2n_blob_validate(slice));
 
     uint32_t slice_size = 0;
-    GUARD(s2n_add_overflow(offset, size, &slice_size));
-    ENSURE_POSIX(b->size >= slice_size, S2N_ERR_SIZE_MISMATCH);
+    POSIX_GUARD(s2n_add_overflow(offset, size, &slice_size));
+    POSIX_ENSURE(b->size >= slice_size, S2N_ERR_SIZE_MISMATCH);
     slice->data = b->data + offset;
     slice->size = size;
     slice->growable = 0;
     slice->allocated = 0;
 
-    POSTCONDITION_POSIX(s2n_blob_validate(slice));
+    POSIX_POSTCONDITION(s2n_blob_validate(slice));
     return S2N_SUCCESS;
 }
 
 int s2n_blob_char_to_lower(struct s2n_blob *b)
 {
-    PRECONDITION_POSIX(s2n_blob_validate(b));
+    POSIX_PRECONDITION(s2n_blob_validate(b));
     for (size_t i = 0; i < b->size; i++) {
         b->data[i] = tolower(b->data[i]);
     }
-    POSTCONDITION_POSIX(s2n_blob_validate(b));
+    POSIX_POSTCONDITION(s2n_blob_validate(b));
     return S2N_SUCCESS;
 }
 
@@ -105,11 +105,11 @@ static const uint8_t hex_inverse[256] = {
  * string needs to a valid hex and blob needs to be large enough */
 int s2n_hex_string_to_bytes(const uint8_t *str, struct s2n_blob *blob)
 {
-    ENSURE_POSIX_REF(str);
-    PRECONDITION_POSIX(s2n_blob_validate(blob));
+    POSIX_ENSURE_REF(str);
+    POSIX_PRECONDITION(s2n_blob_validate(blob));
     uint32_t len = strlen((const char*)str);
     /* protects against overflows */
-    gte_check(blob->size, len / 2);
+    POSIX_ENSURE_GTE(blob->size, len / 2);
     POSIX_ENSURE(len % 2 == 0, S2N_ERR_INVALID_HEX);
 
     for (size_t i = 0; i < len; i += 2) {
@@ -121,6 +121,6 @@ int s2n_hex_string_to_bytes(const uint8_t *str, struct s2n_blob *blob)
         blob->data[i / 2] = high_nibble << 4 | low_nibble;
     }
 
-    POSTCONDITION_POSIX(s2n_blob_validate(blob));
+    POSIX_POSTCONDITION(s2n_blob_validate(blob));
     return S2N_SUCCESS;
 }

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -50,9 +50,9 @@ extern int s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint
 #define s2n_stack_blob(name, requested_size, maximum)			\
     size_t name ## _requested_size = (requested_size);			\
     uint8_t name ## _buf[(maximum)] = {0};				\
-    lte_check(name ## _requested_size, (maximum));			\
+    POSIX_ENSURE_LTE(name ## _requested_size, (maximum));			\
     struct s2n_blob name = {0};						\
-    GUARD(s2n_blob_init(&name, name ## _buf, name ## _requested_size))
+    POSIX_GUARD(s2n_blob_init(&name, name ## _buf, name ## _requested_size))
 
 #define S2N_BLOB_LABEL(name, str) \
     static uint8_t name##_data[] = str;   \
@@ -64,4 +64,4 @@ extern int s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint
  * because sizeof needs to refer to the buffer length rather than a pointer size */
 #define S2N_BLOB_FROM_HEX( name, hex ) \
     s2n_stack_blob(name, (sizeof(hex) - 1) / 2, (sizeof(hex) - 1) / 2); \
-    GUARD(s2n_hex_string_to_bytes((const uint8_t*)hex, &name));
+    POSIX_GUARD(s2n_hex_string_to_bytes((const uint8_t*)hex, &name));

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -38,14 +38,14 @@ unsigned long s2n_get_openssl_version(void)
 
 int s2n_init(void)
 {
-    GUARD_POSIX(s2n_fips_init());
-    GUARD_POSIX(s2n_mem_init());
-    GUARD_AS_POSIX(s2n_rand_init());
-    GUARD_POSIX(s2n_cipher_suites_init());
-    GUARD_POSIX(s2n_security_policies_init());
-    GUARD_POSIX(s2n_config_defaults_init());
-    GUARD_POSIX(s2n_extension_type_init());
-    GUARD_AS_POSIX(s2n_pq_init());
+    POSIX_GUARD(s2n_fips_init());
+    POSIX_GUARD(s2n_mem_init());
+    POSIX_GUARD_RESULT(s2n_rand_init());
+    POSIX_GUARD(s2n_cipher_suites_init());
+    POSIX_GUARD(s2n_security_policies_init());
+    POSIX_GUARD(s2n_config_defaults_init());
+    POSIX_GUARD(s2n_extension_type_init());
+    POSIX_GUARD_RESULT(s2n_pq_init());
 
     POSIX_ENSURE_OK(atexit(s2n_cleanup_atexit), S2N_ERR_ATEXIT);
 
@@ -60,7 +60,7 @@ int s2n_cleanup(void)
 {
     /* s2n_cleanup is supposed to be called from each thread before exiting,
      * so ensure that whatever clean ups we have here are thread safe */
-    GUARD_AS_POSIX(s2n_rand_cleanup_thread());
+    POSIX_GUARD_RESULT(s2n_rand_cleanup_thread());
     return 0;
 }
 

--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -39,10 +39,10 @@ static S2N_RESULT s2n_map_slot(const struct s2n_map *map, struct s2n_blob *key, 
     } digest;
 
     DEFER_CLEANUP(struct s2n_hash_state sha256 = {0}, s2n_hash_free);
-    GUARD_AS_RESULT(s2n_hash_new(&sha256));
-    GUARD_AS_RESULT(s2n_hash_init(&sha256, S2N_HASH_SHA256));
-    GUARD_AS_RESULT(s2n_hash_update(&sha256, key->data, key->size));
-    GUARD_AS_RESULT(s2n_hash_digest(&sha256, digest.u8, sizeof(digest)));
+    RESULT_GUARD_POSIX(s2n_hash_new(&sha256));
+    RESULT_GUARD_POSIX(s2n_hash_init(&sha256, S2N_HASH_SHA256));
+    RESULT_GUARD_POSIX(s2n_hash_update(&sha256, key->data, key->size));
+    RESULT_GUARD_POSIX(s2n_hash_digest(&sha256, digest.u8, sizeof(digest)));
 
     *slot = digest.u32[0] % map->capacity;
     return S2N_RESULT_OK;
@@ -53,10 +53,10 @@ static S2N_RESULT s2n_map_embiggen(struct s2n_map *map, uint32_t capacity)
     struct s2n_blob mem = {0};
     struct s2n_map tmp = {0};
 
-    ENSURE(!map->immutable, S2N_ERR_MAP_IMMUTABLE);
+    RESULT_ENSURE(!map->immutable, S2N_ERR_MAP_IMMUTABLE);
 
-    GUARD_AS_RESULT(s2n_alloc(&mem, (capacity * sizeof(struct s2n_map_entry))));
-    GUARD_AS_RESULT(s2n_blob_zero(&mem));
+    RESULT_GUARD_POSIX(s2n_alloc(&mem, (capacity * sizeof(struct s2n_map_entry))));
+    RESULT_GUARD_POSIX(s2n_blob_zero(&mem));
 
     tmp.capacity = capacity;
     tmp.size = 0;
@@ -65,12 +65,12 @@ static S2N_RESULT s2n_map_embiggen(struct s2n_map *map, uint32_t capacity)
 
     for (int i = 0; i < map->capacity; i++) {
         if (map->table[i].key.size) {
-            GUARD_RESULT(s2n_map_add(&tmp, &map->table[i].key, &map->table[i].value));
-            GUARD_AS_RESULT(s2n_free(&map->table[i].key));
-            GUARD_AS_RESULT(s2n_free(&map->table[i].value));
+            RESULT_GUARD(s2n_map_add(&tmp, &map->table[i].key, &map->table[i].value));
+            RESULT_GUARD_POSIX(s2n_free(&map->table[i].key));
+            RESULT_GUARD_POSIX(s2n_free(&map->table[i].value));
         }
     }
-    GUARD_AS_RESULT(s2n_free_object((uint8_t **)&map->table, map->capacity * sizeof(struct s2n_map_entry)));
+    RESULT_GUARD_POSIX(s2n_free_object((uint8_t **)&map->table, map->capacity * sizeof(struct s2n_map_entry)));
 
     /* Clone the temporary map */
     map->capacity = tmp.capacity;
@@ -92,7 +92,7 @@ struct s2n_map *s2n_map_new_with_initial_capacity(uint32_t capacity)
     struct s2n_blob mem = {0};
     struct s2n_map *map;
 
-    GUARD_POSIX_PTR(s2n_alloc(&mem, sizeof(struct s2n_map)));
+    PTR_GUARD_POSIX(s2n_alloc(&mem, sizeof(struct s2n_map)));
 
     map = (void *) mem.data;
     map->capacity = 0;
@@ -100,22 +100,22 @@ struct s2n_map *s2n_map_new_with_initial_capacity(uint32_t capacity)
     map->immutable = 0;
     map->table = NULL;
 
-    GUARD_RESULT_PTR(s2n_map_embiggen(map, capacity));
+    PTR_GUARD_RESULT(s2n_map_embiggen(map, capacity));
 
     return map;
 }
 
 S2N_RESULT s2n_map_add(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value)
 {
-    ENSURE(!map->immutable, S2N_ERR_MAP_IMMUTABLE);
+    RESULT_ENSURE(!map->immutable, S2N_ERR_MAP_IMMUTABLE);
 
     if (map->capacity < (map->size * 2)) {
         /* Embiggen the map */
-        GUARD_RESULT(s2n_map_embiggen(map, map->capacity * 2));
+        RESULT_GUARD(s2n_map_embiggen(map, map->capacity * 2));
     }
 
     uint32_t slot = 0;
-    GUARD_RESULT(s2n_map_slot(map, key, &slot));
+    RESULT_GUARD(s2n_map_slot(map, key, &slot));
 
     /* Linear probing until we find an empty slot */
     while(map->table[slot].key.size) {
@@ -127,11 +127,11 @@ S2N_RESULT s2n_map_add(struct s2n_map *map, struct s2n_blob *key, struct s2n_blo
         }
 
         /* We found a duplicate key */
-        BAIL(S2N_ERR_MAP_DUPLICATE);
+        RESULT_BAIL(S2N_ERR_MAP_DUPLICATE);
     }
 
-    GUARD_AS_RESULT(s2n_dup(key, &map->table[slot].key));
-    GUARD_AS_RESULT(s2n_dup(value, &map->table[slot].value));
+    RESULT_GUARD_POSIX(s2n_dup(key, &map->table[slot].key));
+    RESULT_GUARD_POSIX(s2n_dup(value, &map->table[slot].value));
     map->size++;
 
     return S2N_RESULT_OK;
@@ -139,15 +139,15 @@ S2N_RESULT s2n_map_add(struct s2n_map *map, struct s2n_blob *key, struct s2n_blo
 
 S2N_RESULT s2n_map_put(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value)
 {
-    ENSURE(!map->immutable, S2N_ERR_MAP_IMMUTABLE);
+    RESULT_ENSURE(!map->immutable, S2N_ERR_MAP_IMMUTABLE);
 
     if (map->capacity < (map->size * 2)) {
         /* Embiggen the map */
-        GUARD_RESULT(s2n_map_embiggen(map, map->capacity * 2));
+        RESULT_GUARD(s2n_map_embiggen(map, map->capacity * 2));
     }
 
     uint32_t slot = 0;
-    GUARD_RESULT(s2n_map_slot(map, key, &slot));
+    RESULT_GUARD(s2n_map_slot(map, key, &slot));
 
     /* Linear probing until we find an empty slot */
     while(map->table[slot].key.size) {
@@ -159,14 +159,14 @@ S2N_RESULT s2n_map_put(struct s2n_map *map, struct s2n_blob *key, struct s2n_blo
         }
 
         /* We found a duplicate key that will be overwritten */
-        GUARD_AS_RESULT(s2n_free(&map->table[slot].key));
-        GUARD_AS_RESULT(s2n_free(&map->table[slot].value));
+        RESULT_GUARD_POSIX(s2n_free(&map->table[slot].key));
+        RESULT_GUARD_POSIX(s2n_free(&map->table[slot].value));
         map->size--;
         break;
     }
 
-    GUARD_AS_RESULT(s2n_dup(key, &map->table[slot].key));
-    GUARD_AS_RESULT(s2n_dup(value, &map->table[slot].value));
+    RESULT_GUARD_POSIX(s2n_dup(key, &map->table[slot].key));
+    RESULT_GUARD_POSIX(s2n_dup(value, &map->table[slot].value));
     map->size++;
 
     return S2N_RESULT_OK;
@@ -188,10 +188,10 @@ S2N_RESULT s2n_map_unlock(struct s2n_map *map)
 
 S2N_RESULT s2n_map_lookup(const struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value, bool *key_found)
 {
-    ENSURE(map->immutable, S2N_ERR_MAP_MUTABLE);
+    RESULT_ENSURE(map->immutable, S2N_ERR_MAP_MUTABLE);
 
     uint32_t slot = 0;
-    GUARD_RESULT(s2n_map_slot(map, key, &slot));
+    RESULT_GUARD(s2n_map_slot(map, key, &slot));
     const uint32_t initial_slot = slot;
 
     while(map->table[slot].key.size) {
@@ -225,16 +225,16 @@ S2N_RESULT s2n_map_free(struct s2n_map *map)
     /* Free the keys and values */
     for (int i = 0; i < map->capacity; i++) {
         if (map->table[i].key.size) {
-            GUARD_AS_RESULT(s2n_free(&map->table[i].key));
-            GUARD_AS_RESULT(s2n_free(&map->table[i].value));
+            RESULT_GUARD_POSIX(s2n_free(&map->table[i].key));
+            RESULT_GUARD_POSIX(s2n_free(&map->table[i].value));
         }
     }
 
     /* Free the table */
-    GUARD_AS_RESULT(s2n_free_object((uint8_t **)&map->table, map->capacity * sizeof(struct s2n_map_entry)));
+    RESULT_GUARD_POSIX(s2n_free_object((uint8_t **)&map->table, map->capacity * sizeof(struct s2n_map_entry)));
 
     /* And finally the map */
-    GUARD_AS_RESULT(s2n_free_object((uint8_t **)&map, sizeof(struct s2n_map)));
+    RESULT_GUARD_POSIX(s2n_free_object((uint8_t **)&map, sizeof(struct s2n_map)));
 
     return S2N_RESULT_OK;
 }

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -108,18 +108,18 @@ int s2n_rand_set_callbacks(s2n_rand_init_callback rand_init_callback,
 
 S2N_RESULT s2n_get_seed_entropy(struct s2n_blob *blob)
 {
-    ENSURE_REF(blob);
+    RESULT_ENSURE_REF(blob);
 
-    GUARD_AS_RESULT(s2n_rand_seed_cb(blob->data, blob->size));
+    RESULT_GUARD_POSIX(s2n_rand_seed_cb(blob->data, blob->size));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_get_mix_entropy(struct s2n_blob *blob)
 {
-    ENSURE_REF(blob);
+    RESULT_ENSURE_REF(blob);
 
-    GUARD_AS_RESULT(s2n_rand_mix_cb(blob->data, blob->size));
+    RESULT_GUARD_POSIX(s2n_rand_mix_cb(blob->data, blob->size));
 
     return S2N_RESULT_OK;
 }
@@ -138,10 +138,10 @@ static inline S2N_RESULT s2n_defend_if_forked(void)
 
     if (zero_if_forked == 0) {
         /* Clean up the old drbg first */
-        GUARD_RESULT(s2n_rand_cleanup_thread());
+        RESULT_GUARD(s2n_rand_cleanup_thread());
         /* Instantiate the new ones */
-        GUARD_AS_RESULT(s2n_drbg_instantiate(&per_thread_public_drbg, &public, S2N_AES_128_CTR_NO_DF_PR));
-        GUARD_AS_RESULT(s2n_drbg_instantiate(&per_thread_private_drbg, &private, S2N_AES_128_CTR_NO_DF_PR));
+        RESULT_GUARD_POSIX(s2n_drbg_instantiate(&per_thread_public_drbg, &public, S2N_AES_128_CTR_NO_DF_PR));
+        RESULT_GUARD_POSIX(s2n_drbg_instantiate(&per_thread_private_drbg, &private, S2N_AES_128_CTR_NO_DF_PR));
         zero_if_forked_ptr = zeroed_when_forked_page;
         zero_if_forked = 1;
     }
@@ -151,7 +151,7 @@ static inline S2N_RESULT s2n_defend_if_forked(void)
 
 S2N_RESULT s2n_get_public_random_data(struct s2n_blob *blob)
 {
-    GUARD_RESULT(s2n_defend_if_forked());
+    RESULT_GUARD(s2n_defend_if_forked());
 
     uint32_t offset = 0;
     uint32_t remaining = blob->size;
@@ -159,9 +159,9 @@ S2N_RESULT s2n_get_public_random_data(struct s2n_blob *blob)
     while(remaining) {
         struct s2n_blob slice = { 0 };
 
-        GUARD_AS_RESULT(s2n_blob_slice(blob, &slice, offset, MIN(remaining, S2N_DRBG_GENERATE_LIMIT)));;
+        RESULT_GUARD_POSIX(s2n_blob_slice(blob, &slice, offset, MIN(remaining, S2N_DRBG_GENERATE_LIMIT)));;
 
-        GUARD_AS_RESULT(s2n_drbg_generate(&per_thread_public_drbg, &slice));
+        RESULT_GUARD_POSIX(s2n_drbg_generate(&per_thread_public_drbg, &slice));
 
         remaining -= slice.size;
         offset += slice.size;
@@ -172,7 +172,7 @@ S2N_RESULT s2n_get_public_random_data(struct s2n_blob *blob)
 
 S2N_RESULT s2n_get_private_random_data(struct s2n_blob *blob)
 {
-    GUARD_RESULT(s2n_defend_if_forked());
+    RESULT_GUARD(s2n_defend_if_forked());
 
     uint32_t offset = 0;
     uint32_t remaining = blob->size;
@@ -180,9 +180,9 @@ S2N_RESULT s2n_get_private_random_data(struct s2n_blob *blob)
     while(remaining) {
         struct s2n_blob slice = { 0 };
 
-        GUARD_AS_RESULT(s2n_blob_slice(blob, &slice, offset, MIN(remaining, S2N_DRBG_GENERATE_LIMIT)));;
+        RESULT_GUARD_POSIX(s2n_blob_slice(blob, &slice, offset, MIN(remaining, S2N_DRBG_GENERATE_LIMIT)));;
 
-        GUARD_AS_RESULT(s2n_drbg_generate(&per_thread_private_drbg, &slice));
+        RESULT_GUARD_POSIX(s2n_drbg_generate(&per_thread_private_drbg, &slice));
 
         remaining -= slice.size;
         offset += slice.size;
@@ -193,19 +193,19 @@ S2N_RESULT s2n_get_private_random_data(struct s2n_blob *blob)
 
 S2N_RESULT s2n_get_public_random_bytes_used(uint64_t *bytes_used)
 {
-    GUARD_AS_RESULT(s2n_drbg_bytes_used(&per_thread_public_drbg, bytes_used));
+    RESULT_GUARD_POSIX(s2n_drbg_bytes_used(&per_thread_public_drbg, bytes_used));
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_get_private_random_bytes_used(uint64_t *bytes_used)
 {
-    GUARD_AS_RESULT(s2n_drbg_bytes_used(&per_thread_private_drbg, bytes_used));
+    RESULT_GUARD_POSIX(s2n_drbg_bytes_used(&per_thread_private_drbg, bytes_used));
     return S2N_RESULT_OK;
 }
 
 static int s2n_rand_urandom_impl(void *ptr, uint32_t size)
 {
-    ENSURE_POSIX(entropy_fd != UNINITIALIZED_ENTROPY_FD, S2N_ERR_NOT_INITIALIZED);
+    POSIX_ENSURE(entropy_fd != UNINITIALIZED_ENTROPY_FD, S2N_ERR_NOT_INITIALIZED);
 
     uint8_t *data = ptr;
     uint32_t n = size;
@@ -260,11 +260,11 @@ S2N_RESULT s2n_public_random(int64_t bound, uint64_t *output)
 {
     uint64_t r;
 
-    ENSURE_GT(bound, 0);
+    RESULT_ENSURE_GT(bound, 0);
 
     while (1) {
         struct s2n_blob blob = {.data = (void *)&r, sizeof(r) };
-        GUARD_RESULT(s2n_get_public_random_data(&blob));
+        RESULT_GUARD(s2n_get_public_random_data(&blob));
 
         /* Imagine an int was one byte and UINT_MAX was 256. If the
          * caller asked for s2n_random(129, ...) we'd end up in
@@ -326,7 +326,7 @@ static int s2n_rand_init_impl(void)
         if (errno == EINTR) {
             goto OPEN;
         }
-        S2N_ERROR(S2N_ERR_OPEN_RANDOM);
+        POSIX_BAIL(S2N_ERR_OPEN_RANDOM);
     }
 
     if (s2n_cpu_supports_rdrand()) {
@@ -340,51 +340,51 @@ S2N_RESULT s2n_rand_init(void)
 {
     uint32_t pagesize;
 
-    GUARD_AS_RESULT(s2n_rand_init_cb());
+    RESULT_GUARD_POSIX(s2n_rand_init_cb());
 
     pagesize = s2n_mem_get_page_size();
 
     /* We need a single-aligned page for our protected memory region */
-    ENSURE(posix_memalign(&zeroed_when_forked_page, pagesize, pagesize) == S2N_SUCCESS, S2N_ERR_OPEN_RANDOM);
-    ENSURE(zeroed_when_forked_page != NULL, S2N_ERR_OPEN_RANDOM);
+    RESULT_ENSURE(posix_memalign(&zeroed_when_forked_page, pagesize, pagesize) == S2N_SUCCESS, S2N_ERR_OPEN_RANDOM);
+    RESULT_ENSURE(zeroed_when_forked_page != NULL, S2N_ERR_OPEN_RANDOM);
 
     /* Initialized to zero to ensure that we seed our DRBGs */
     zero_if_forked = 0;
 
     /* INHERIT_ZERO and WIPEONFORK reset a page to all-zeroes when a fork occurs */
 #if defined(MAP_INHERIT_ZERO)
-    ENSURE(minherit(zeroed_when_forked_page, pagesize, MAP_INHERIT_ZERO) != S2N_FAILURE, S2N_ERR_OPEN_RANDOM);
+    RESULT_ENSURE(minherit(zeroed_when_forked_page, pagesize, MAP_INHERIT_ZERO) != S2N_FAILURE, S2N_ERR_OPEN_RANDOM);
 #endif
 
 #if defined(MADV_WIPEONFORK)
-    ENSURE(madvise(zeroed_when_forked_page, pagesize, MADV_WIPEONFORK) == S2N_SUCCESS, S2N_ERR_OPEN_RANDOM);
+    RESULT_ENSURE(madvise(zeroed_when_forked_page, pagesize, MADV_WIPEONFORK) == S2N_SUCCESS, S2N_ERR_OPEN_RANDOM);
 #endif
 
     /* For defence in depth */
-    ENSURE(pthread_atfork(NULL, NULL, s2n_on_fork) == S2N_SUCCESS, S2N_ERR_OPEN_RANDOM);
+    RESULT_ENSURE(pthread_atfork(NULL, NULL, s2n_on_fork) == S2N_SUCCESS, S2N_ERR_OPEN_RANDOM);
 
     /* Seed everything */
-    GUARD_RESULT(s2n_defend_if_forked());
+    RESULT_GUARD(s2n_defend_if_forked());
 
 #if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
     /* Create an engine */
     ENGINE *e = ENGINE_new();
 
-    ENSURE(e != NULL, S2N_ERR_OPEN_RANDOM);
-    GUARD_RESULT_OSSL(ENGINE_set_id(e, "s2n_rand"), S2N_ERR_OPEN_RANDOM);
-    GUARD_RESULT_OSSL(ENGINE_set_name(e, "s2n entropy generator"), S2N_ERR_OPEN_RANDOM);
-    GUARD_RESULT_OSSL(ENGINE_set_flags(e, ENGINE_FLAGS_NO_REGISTER_ALL), S2N_ERR_OPEN_RANDOM);
-    GUARD_RESULT_OSSL(ENGINE_set_init_function(e, s2n_openssl_compat_init), S2N_ERR_OPEN_RANDOM);
-    GUARD_RESULT_OSSL(ENGINE_set_RAND(e, &s2n_openssl_rand_method), S2N_ERR_OPEN_RANDOM);
-    GUARD_RESULT_OSSL(ENGINE_add(e), S2N_ERR_OPEN_RANDOM);
-    GUARD_RESULT_OSSL(ENGINE_free(e) , S2N_ERR_OPEN_RANDOM);
+    RESULT_ENSURE(e != NULL, S2N_ERR_OPEN_RANDOM);
+    RESULT_GUARD_OSSL(ENGINE_set_id(e, "s2n_rand"), S2N_ERR_OPEN_RANDOM);
+    RESULT_GUARD_OSSL(ENGINE_set_name(e, "s2n entropy generator"), S2N_ERR_OPEN_RANDOM);
+    RESULT_GUARD_OSSL(ENGINE_set_flags(e, ENGINE_FLAGS_NO_REGISTER_ALL), S2N_ERR_OPEN_RANDOM);
+    RESULT_GUARD_OSSL(ENGINE_set_init_function(e, s2n_openssl_compat_init), S2N_ERR_OPEN_RANDOM);
+    RESULT_GUARD_OSSL(ENGINE_set_RAND(e, &s2n_openssl_rand_method), S2N_ERR_OPEN_RANDOM);
+    RESULT_GUARD_OSSL(ENGINE_add(e), S2N_ERR_OPEN_RANDOM);
+    RESULT_GUARD_OSSL(ENGINE_free(e) , S2N_ERR_OPEN_RANDOM);
 
     /* Use that engine for rand() */
     e = ENGINE_by_id("s2n_rand");
-    ENSURE(e != NULL, S2N_ERR_OPEN_RANDOM);
-    GUARD_RESULT_OSSL(ENGINE_init(e), S2N_ERR_OPEN_RANDOM);
-    GUARD_RESULT_OSSL(ENGINE_set_default(e, ENGINE_METHOD_RAND), S2N_ERR_OPEN_RANDOM);
-    GUARD_RESULT_OSSL(ENGINE_free(e), S2N_ERR_OPEN_RANDOM);
+    RESULT_ENSURE(e != NULL, S2N_ERR_OPEN_RANDOM);
+    RESULT_GUARD_OSSL(ENGINE_init(e), S2N_ERR_OPEN_RANDOM);
+    RESULT_GUARD_OSSL(ENGINE_set_default(e, ENGINE_METHOD_RAND), S2N_ERR_OPEN_RANDOM);
+    RESULT_GUARD_OSSL(ENGINE_free(e), S2N_ERR_OPEN_RANDOM);
 #endif
 
     return S2N_RESULT_OK;
@@ -392,9 +392,9 @@ S2N_RESULT s2n_rand_init(void)
 
 static int s2n_rand_cleanup_impl(void)
 {
-    ENSURE_POSIX(entropy_fd != UNINITIALIZED_ENTROPY_FD, S2N_ERR_NOT_INITIALIZED);
+    POSIX_ENSURE(entropy_fd != UNINITIALIZED_ENTROPY_FD, S2N_ERR_NOT_INITIALIZED);
 
-    GUARD(close(entropy_fd));
+    POSIX_GUARD(close(entropy_fd));
     entropy_fd = UNINITIALIZED_ENTROPY_FD;
 
     return S2N_SUCCESS;
@@ -402,7 +402,7 @@ static int s2n_rand_cleanup_impl(void)
 
 S2N_RESULT s2n_rand_cleanup(void)
 {
-    GUARD_AS_RESULT(s2n_rand_cleanup_cb());
+    RESULT_GUARD_POSIX(s2n_rand_cleanup_cb());
 
 #if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
     /* Cleanup our rand ENGINE in libcrypto */
@@ -424,8 +424,8 @@ S2N_RESULT s2n_rand_cleanup(void)
 
 S2N_RESULT s2n_rand_cleanup_thread(void)
 {
-    GUARD_AS_RESULT(s2n_drbg_wipe(&per_thread_private_drbg));
-    GUARD_AS_RESULT(s2n_drbg_wipe(&per_thread_public_drbg));
+    RESULT_GUARD_POSIX(s2n_drbg_wipe(&per_thread_private_drbg));
+    RESULT_GUARD_POSIX(s2n_drbg_wipe(&per_thread_public_drbg));
 
     return S2N_RESULT_OK;
 }
@@ -436,8 +436,8 @@ S2N_RESULT s2n_rand_cleanup_thread(void)
  */
 S2N_RESULT s2n_set_private_drbg_for_test(struct s2n_drbg drbg)
 {
-    ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
-    GUARD_AS_RESULT(s2n_drbg_wipe(&per_thread_private_drbg));
+    RESULT_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
+    RESULT_GUARD_POSIX(s2n_drbg_wipe(&per_thread_private_drbg));
 
     per_thread_private_drbg = drbg;
     return S2N_RESULT_OK;
@@ -465,7 +465,7 @@ static int s2n_rand_rdrand_impl(void *data, uint32_t size)
         uint8_t u8[8];
     } output;
 
-    GUARD(s2n_stuffer_init(&stuffer, &out));
+    POSIX_GUARD(s2n_stuffer_init(&stuffer, &out));
     while ((space_remaining = s2n_stuffer_space_remaining(&stuffer))) {
         unsigned char success = 0;
         output.u64 = 0;
@@ -534,15 +534,15 @@ static int s2n_rand_rdrand_impl(void *data, uint32_t size)
             }
         }
 
-        ENSURE_POSIX(success, S2N_ERR_RDRAND_FAILED);
+        POSIX_ENSURE(success, S2N_ERR_RDRAND_FAILED);
 
         int data_to_fill = MIN(sizeof(output), space_remaining);
 
-        GUARD_POSIX(s2n_stuffer_write_bytes(&stuffer, output.u8, data_to_fill));
+        POSIX_GUARD(s2n_stuffer_write_bytes(&stuffer, output.u8, data_to_fill));
     }
 
     return S2N_SUCCESS;
 #else
-    BAIL_POSIX(S2N_ERR_UNSUPPORTED_CPU);
+    POSIX_BAIL(S2N_ERR_UNSUPPORTED_CPU);
 #endif
 }

--- a/utils/s2n_result.c
+++ b/utils/s2n_result.c
@@ -27,7 +27,7 @@
  *
  * ```c
  * uint8_t s2n_answer_to_the_ultimate_question() {
- *   GUARD(s2n_sleep_for_years(7500000));
+ *   POSIX_GUARD(s2n_sleep_for_years(7500000));
  *   return 42;
  * }
  * ```
@@ -43,7 +43,7 @@
  *
  * ```c
  * int s2n_deep_thought() {
- *   GUARD(s2n_answer_to_the_ultimate_question());
+ *   POSIX_GUARD(s2n_answer_to_the_ultimate_question());
  *   return 0;
  * }
  * ```

--- a/utils/s2n_rfc5952.c
+++ b/utils/s2n_rfc5952.c
@@ -31,7 +31,7 @@ S2N_RESULT s2n_inet_ntop(int af, const void *addr, struct s2n_blob *dst)
     uint8_t *cursor = dst->data;
 
     if (af == AF_INET) {
-        ENSURE(dst->size >= sizeof("111.222.333.444"), S2N_ERR_SIZE_MISMATCH);
+        RESULT_ENSURE(dst->size >= sizeof("111.222.333.444"), S2N_ERR_SIZE_MISMATCH);
 
         for (int i = 0; i < 4; i++) {
             if (bytes[i] / 100) {
@@ -50,7 +50,7 @@ S2N_RESULT s2n_inet_ntop(int af, const void *addr, struct s2n_blob *dst)
     }
 
     if (af == AF_INET6) {
-        ENSURE(dst->size >= sizeof("1111:2222:3333:4444:5555:6666:7777:8888"), S2N_ERR_SIZE_MISMATCH);
+        RESULT_ENSURE(dst->size >= sizeof("1111:2222:3333:4444:5555:6666:7777:8888"), S2N_ERR_SIZE_MISMATCH);
 
         /* See Section 4 of RFC5952 for the rules we are going to follow here
          *
@@ -131,5 +131,5 @@ S2N_RESULT s2n_inet_ntop(int af, const void *addr, struct s2n_blob *dst)
         return S2N_RESULT_OK;
     }
 
-    BAIL(S2N_ERR_INVALID_ARGUMENT);
+    RESULT_BAIL(S2N_ERR_INVALID_ARGUMENT);
 }

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -60,8 +60,8 @@ bool s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, const uint32
     S2N_PUBLIC_INPUT(a);
     S2N_PUBLIC_INPUT(b);
     S2N_PUBLIC_INPUT(len);
-    ENSURE_POSIX((a == NULL) || S2N_MEM_IS_READABLE(a, len), S2N_ERR_SAFETY);
-    ENSURE_POSIX((b == NULL) || S2N_MEM_IS_READABLE(b, len), S2N_ERR_SAFETY);
+    POSIX_ENSURE((a == NULL) || S2N_MEM_IS_READABLE(a, len), S2N_ERR_SAFETY);
+    POSIX_ENSURE((b == NULL) || S2N_MEM_IS_READABLE(b, len), S2N_ERR_SAFETY);
 
     if (len != 0 && (a == NULL || b == NULL)) {
         return false;
@@ -195,8 +195,8 @@ int s2n_in_unit_test_set(bool newval)
 
 int s2n_align_to(uint32_t initial, uint32_t alignment, uint32_t* out)
 {
-    notnull_check(out);
-    ENSURE_POSIX(alignment != 0, S2N_ERR_SAFETY);
+    POSIX_ENSURE_REF(out);
+    POSIX_ENSURE(alignment != 0, S2N_ERR_SAFETY);
     if (initial == 0) {
         *out = 0;
         return S2N_SUCCESS;
@@ -211,7 +211,7 @@ int s2n_align_to(uint32_t initial, uint32_t alignment, uint32_t* out)
 
 int s2n_mul_overflow(uint32_t a, uint32_t b, uint32_t* out)
 {
-    notnull_check(out);
+    POSIX_ENSURE_REF(out);
     const uint64_t result = ((uint64_t) a) * ((uint64_t) b);
     POSIX_ENSURE(result <= UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
     *out = (uint32_t) result;
@@ -220,7 +220,7 @@ int s2n_mul_overflow(uint32_t a, uint32_t b, uint32_t* out)
 
 int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out)
 {
-    notnull_check(out);
+    POSIX_ENSURE_REF(out);
     uint64_t result = ((uint64_t) a) + ((uint64_t) b);
     POSIX_ENSURE(result <= UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
     *out = (uint32_t) result;
@@ -229,7 +229,7 @@ int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out)
 
 int s2n_sub_overflow(uint32_t a, uint32_t b, uint32_t* out)
 {
-    notnull_check(out);
+    POSIX_ENSURE_REF(out);
     POSIX_ENSURE(a >= b, S2N_ERR_INTEGER_OVERFLOW);
     *out = a - b;
     return S2N_SUCCESS;

--- a/utils/s2n_set.c
+++ b/utils/s2n_set.c
@@ -23,8 +23,8 @@
 
 S2N_RESULT s2n_set_validate(const struct s2n_set *set)
 {
-    ENSURE_REF(set);
-    GUARD_RESULT(s2n_array_validate(set->data));
+    RESULT_ENSURE_REF(set);
+    RESULT_GUARD(s2n_array_validate(set->data));
     return S2N_RESULT_OK;
 }
 
@@ -32,14 +32,14 @@ S2N_RESULT s2n_set_validate(const struct s2n_set *set)
  * Returns an error if the element already exists */
 static S2N_RESULT s2n_set_binary_search(struct s2n_set *set, void *element, uint32_t* out)
 {
-    GUARD_RESULT(s2n_set_validate(set));
-    ENSURE(S2N_MEM_IS_READABLE(element, set->data->element_size), S2N_ERR_NULL);
-    ENSURE_REF(out);
+    RESULT_GUARD(s2n_set_validate(set));
+    RESULT_ENSURE(S2N_MEM_IS_READABLE(element, set->data->element_size), S2N_ERR_NULL);
+    RESULT_ENSURE_REF(out);
     struct s2n_array *array = set->data;
     int (*comparator)(const void*, const void*) = set->comparator;
 
     uint32_t len = 0;
-    GUARD_RESULT(s2n_array_num_elements(array, &len));
+    RESULT_GUARD(s2n_array_num_elements(array, &len));
 
     if (len == 0) {
         *out = 0;
@@ -53,12 +53,12 @@ static S2N_RESULT s2n_set_binary_search(struct s2n_set *set, void *element, uint
     while (low <= top) {
         int64_t mid = low + ((top - low) / 2);
         void* array_element = NULL;
-        GUARD_RESULT(s2n_array_get(array, mid, &array_element));
+        RESULT_GUARD(s2n_array_get(array, mid, &array_element));
         int m = comparator(array_element, element);
 
         /* the element is already in the set */
         if (m == 0) {
-            BAIL(S2N_ERR_SET_DUPLICATE_VALUE);
+            RESULT_BAIL(S2N_ERR_SET_DUPLICATE_VALUE);
         }
 
         if (m > 0) {
@@ -74,13 +74,13 @@ static S2N_RESULT s2n_set_binary_search(struct s2n_set *set, void *element, uint
 
 struct s2n_set *s2n_set_new(uint32_t element_size, int (*comparator)(const void*, const void*))
 {
-    notnull_check_ptr(comparator);
+    PTR_ENSURE_REF(comparator);
     struct s2n_blob mem = {0};
-    GUARD_POSIX_PTR(s2n_alloc(&mem, sizeof(struct s2n_set)));
+    PTR_GUARD_POSIX(s2n_alloc(&mem, sizeof(struct s2n_set)));
     struct s2n_set *set = (void *) mem.data;
     *set = (struct s2n_set) {.data = s2n_array_new(element_size), .comparator = comparator};
     if(set->data == NULL) {
-        GUARD_POSIX_PTR(s2n_free(&mem));
+        PTR_GUARD_POSIX(s2n_free(&mem));
         return NULL;
     }
     return set;
@@ -88,43 +88,43 @@ struct s2n_set *s2n_set_new(uint32_t element_size, int (*comparator)(const void*
 
 S2N_RESULT s2n_set_add(struct s2n_set *set, void *element)
 {
-    GUARD_RESULT(s2n_set_validate(set));
+    RESULT_GUARD(s2n_set_validate(set));
 
     uint32_t idx = 0;
-    GUARD_RESULT(s2n_set_binary_search(set, element, &idx));
-    GUARD_RESULT(s2n_array_insert_and_copy(set->data, idx, element));
+    RESULT_GUARD(s2n_set_binary_search(set, element, &idx));
+    RESULT_GUARD(s2n_array_insert_and_copy(set->data, idx, element));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_set_get(struct s2n_set *set, uint32_t idx, void **element)
 {
-    GUARD_RESULT(s2n_set_validate(set));
-    ENSURE_REF(element);
+    RESULT_GUARD(s2n_set_validate(set));
+    RESULT_ENSURE_REF(element);
 
-    GUARD_RESULT(s2n_array_get(set->data, idx, element));
+    RESULT_GUARD(s2n_array_get(set->data, idx, element));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_set_remove(struct s2n_set *set, uint32_t idx)
 {
-    GUARD_RESULT(s2n_set_validate(set));
-    GUARD_RESULT(s2n_array_remove(set->data, idx));
+    RESULT_GUARD(s2n_set_validate(set));
+    RESULT_GUARD(s2n_array_remove(set->data, idx));
 
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_set_free_p(struct s2n_set **pset)
 {
-    ENSURE_REF(pset);
+    RESULT_ENSURE_REF(pset);
     struct s2n_set *set = *pset;
 
-    ENSURE_REF(set);
-    GUARD_RESULT(s2n_array_free(set->data));
+    RESULT_ENSURE_REF(set);
+    RESULT_GUARD(s2n_array_free(set->data));
 
     /* And finally the set object. */
-    GUARD_AS_RESULT(s2n_free_object((uint8_t **)pset, sizeof(struct s2n_set)));
+    RESULT_GUARD_POSIX(s2n_free_object((uint8_t **)pset, sizeof(struct s2n_set)));
 
     return S2N_RESULT_OK;
 
@@ -132,16 +132,16 @@ S2N_RESULT s2n_set_free_p(struct s2n_set **pset)
 
 S2N_RESULT s2n_set_free(struct s2n_set *set)
 {
-    ENSURE_REF(set);
+    RESULT_ENSURE_REF(set);
     return s2n_set_free_p(&set);
 }
 
 
 S2N_RESULT s2n_set_len(struct s2n_set *set, uint32_t *len)
 {
-    GUARD_RESULT(s2n_set_validate(set));
+    RESULT_GUARD(s2n_set_validate(set));
 
-    GUARD_RESULT(s2n_array_num_elements(set->data, len));
+    RESULT_GUARD(s2n_array_num_elements(set->data, len));
 
     return S2N_RESULT_OK;
 }

--- a/utils/s2n_timer.c
+++ b/utils/s2n_timer.c
@@ -21,7 +21,7 @@
 
 S2N_RESULT s2n_timer_start(struct s2n_config *config, struct s2n_timer *timer)
 {
-    GUARD_AS_RESULT(config->monotonic_clock(config->monotonic_clock_ctx, &timer->time));
+    RESULT_GUARD_POSIX(config->monotonic_clock(config->monotonic_clock_ctx, &timer->time));
 
     return S2N_RESULT_OK;
 }
@@ -30,7 +30,7 @@ S2N_RESULT s2n_timer_elapsed(struct s2n_config *config, struct s2n_timer *timer,
 {
     uint64_t current_time;
 
-    GUARD_AS_RESULT(config->monotonic_clock(config->monotonic_clock_ctx, &current_time));
+    RESULT_GUARD_POSIX(config->monotonic_clock(config->monotonic_clock_ctx, &current_time));
 
     *nanoseconds = current_time - timer->time;
 
@@ -41,7 +41,7 @@ S2N_RESULT s2n_timer_reset(struct s2n_config *config, struct s2n_timer *timer, u
 {
     uint64_t previous_time = timer->time;
 
-    GUARD_RESULT(s2n_timer_start(config, timer));
+    RESULT_GUARD(s2n_timer_start(config, timer));
 
     *nanoseconds = timer->time - previous_time;
 


### PR DESCRIPTION
This is an application of the codemod script created in #2339 

After this PR is merged, existing branches will need to run the following to reduce merge issues:

```
./scripts/s2n_safety_explicit_context/codemod.sh
```

The script will walk you through each location for each macro and ask for your approval.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
