### PR TITLE
tools: Add to docker image for debugging

### DIFF
--- a/codebuild/bin/install_shellcheck.sh
+++ b/codebuild/bin/install_shellcheck.sh
@@ -34,7 +34,7 @@ if [ "$#" -ne "0" ]; then
 fi
 
 case "$OS_NAME" in
-  "amazon linux")
+  "linux")
     which shellcheck || install_shellcheck
     ;;
   "darwin" )

--- a/codebuild/bin/install_ubuntu_dependencies.sh
+++ b/codebuild/bin/install_ubuntu_dependencies.sh
@@ -22,7 +22,7 @@ sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo add-apt-repository ppa:longsleep/golang-backports -y
 sudo apt-get update -o Acquire::CompressionTypes::Order::=gz
 
-DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python3-pip python3-testresources llvm curl git tox cmake libtool ninja-build golang-go quilt"
+DEPENDENCIES="unzip make indent iproute2 kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gdb gdbserver gcc g++ zlibc zlib1g-dev python3-pip python3-testresources llvm curl git tox cmake libtool ninja-build golang-go quilt vim"
 
 
 if [[ -n "$GCC_VERSION" ]] && [[ "$GCC_VERSION" != "NONE" ]]; then

--- a/codebuild/bin/s2n_install_test_dependencies.sh
+++ b/codebuild/bin/s2n_install_test_dependencies.sh
@@ -14,7 +14,7 @@
 #
 
 
-set -ex
+set -e
 
 # Install missing test dependencies. If the install directory already exists, cached artifacts will be used
 # for that dependency.
@@ -23,23 +23,21 @@ if [[ ! -d test-deps ]]; then
     mkdir test-deps ;
 fi
 
-#Install & Run shell check before installing dependencies
-echo "Installing ShellCheck..."
-codebuild/bin/install_shellcheck.sh
-echo "Running ShellCheck..."
-find ./codebuild -type f -name '*.sh' -exec shellcheck -Cnever -s bash {} \;
 
-if [[ "$OS_NAME" == "linux" ]]; then
+if [[ "$DISTRO" == "ubuntu" ]]; then
     # Only run ubuntu install outside of CodeBuild
     if [ ! "${CODEBUILD_BUILD_NUMBER}" ]; then
         codebuild/bin/install_ubuntu_dependencies.sh;
     fi
+    # Install & Run shell check.
+    echo "Installing ShellCheck..."
+    codebuild/bin/install_shellcheck.sh
+    echo "Running ShellCheck..."
+    find ./codebuild -type f -name '*.sh' -exec shellcheck -Cnever -s bash {} \;
 fi
 
 if [[ "$OS_NAME" == "darwin" ]]; then
     codebuild/bin/install_osx_dependencies.sh;
 fi
-
-codebuild/bin/install_default_dependencies.sh
 
 echo "Success"

--- a/docker-images/Makefile
+++ b/docker-images/Makefile
@@ -1,5 +1,21 @@
 REPOSITORY_URI ?= awslabs/s2n-dev
+SHELL=/bin/bash
+DOCKER_COMPOSE:=$(shell which docker-compose)
 
-build:
-	@cp -R ../codebuild/ ./codebuild/
-	@REPOSITORY_URI=$(REPOSITORY_URI) docker-compose build
+.PHONEY: all
+all: clean build
+
+setup:
+	@cp -fR ../codebuild/ ./codebuild/
+
+.PHONEY: build clean
+build: setup
+	@REPOSITORY_URI=$(REPOSITORY_URI) $(DOCKER_COMPOSE) build
+run:
+	@REPOSITORY_URI=$(REPOSITORY_URI) $(DOCKER_COMPOSE) run ubuntu_18.04_gcc9
+veryclean:
+	docker system prune --volumes -f
+clean:
+	@rm -rf ./codebuild
+login:
+	@eval $$(aws ecr get-login --no-include-email);

--- a/docker-images/README.md
+++ b/docker-images/README.md
@@ -1,0 +1,37 @@
+### Docker images
+
+We'd like to make it faster and easier to setup a development environment for s2n using [Docker](https://www.docker.com/) containers.
+
+All of the following commands assume you have Docker setup and running, have permissions, and are in the s2n/docker-images directory of the [s2n](https://github.com/awslabs/s2n) repo.
+The Makefile in this directory wraps some convenient commands.
+
+### Building
+
+If you'd like to build the container:
+
+```
+make build
+```
+
+### Publishing
+
+We don't currently make containers available publicly.  The makefile contains a way
+ to login to AWS ECR, where images can be stored privately.
+If you set the REPOSITORY_URI ahead of time, you don't need to re-tag the image (step 2).
+
+ ```
+ make login
+ docker tag <lastimage> <ECR_URL>:ubuntu_18.04_gcc9
+ docker push <ECR_URL>:ubuntu_18.04_gcc9
+ ```
+
+
+
+### Running
+
+Currently the makefile attempts to present the s2n folder to the container.  On some platforms
+you must explicitly give docker permission to share folders.  If you have an already built container on ECR, be sure to set the REPOSITORY_URI, e.g. `export REPOSITORY_URI=$AWS_ACCOUNTNUMBER.dkr.ecr.us-west-2.amazonaws.com/linux-docker-images`
+
+```
+make run
+```

--- a/docker-images/docker-compose.yml
+++ b/docker-images/docker-compose.yml
@@ -14,16 +14,7 @@
 
 version: '3.7'
 services:
-  ubuntu_18.04_openssl-1.0.2_gcc9:
-    build:
-      args:
-        UBUNTU_VERSION: 18.04
-        OPENSSL_VERSION: openssl-1.0.2
-        GCC_VERSION: 9
-      context: ./
-      dockerfile: ./ubuntu/Dockerfile
-    image: ${REPOSITORY_URI}:ubuntu_18.04_openssl-1.0.2_gcc9
-  ubuntu_18.04_openssl-1.1.1_gcc9:
+  ubuntu_18.04_gcc9:
     build:
       args:
         UBUNTU_VERSION: 18.04
@@ -31,22 +22,6 @@ services:
         GCC_VERSION: 9
       context: ./
       dockerfile: ./ubuntu/Dockerfile
-    image: ${REPOSITORY_URI}:ubuntu_18.04_openssl-1.1.1_gcc9
-  ubuntu_18.04_openssl-libressl_gcc9:
-    build:
-      args:
-        UBUNTU_VERSION: 18.04
-        OPENSSL_VERSION: libressl
-        GCC_VERSION: 9
-      context: ./
-      dockerfile: ./ubuntu/Dockerfile
-    image: ${REPOSITORY_URI}:ubuntu_18.04_libressl_gcc9
-  ubuntu_18.04_openssl-boringssl_gcc9:
-    build:
-      args:
-        UBUNTU_VERSION: 18.04
-        OPENSSL_VERSION: boringssl
-        GCC_VERSION: 9
-      context: ./
-      dockerfile: ./ubuntu/Dockerfile
-    image: ${REPOSITORY_URI}:ubuntu_18.04_boringssl_gcc9
+    image: ${REPOSITORY_URI}:ubuntu_18.04_gcc9
+    volumes:
+      - "$PWD/../../s2n:/s2n"


### PR DESCRIPTION
### Resolved issues:

### Description of changes: 

Adds gdb and iproute2, needed for debugging and integration tests, respectively. Also fixes a bug in the shellcheck install.

Removed all the different flavors of openssl as separate containers since we're actually installing all of them on container [build](https://github.com/awslabs/s2n/blob/main/docker-images/ubuntu/Dockerfile#L69).

Created a docker readme to explain the Makefile.

### Call-outs:

Running the container using the makefile may not work correctly on all platforms/situations, feedback needed.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? by hand at this point: `make build && make run`

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
