### PR TITLE
Use builtin platform detection in Openssl 1.1.x install

### DIFF
--- a/.travis/install_openssl_1_1_1.sh
+++ b/.travis/install_openssl_1_1_1.sh
@@ -17,22 +17,26 @@ set -ex
 pushd "$(pwd)"
 
 usage() {
-    echo "install_openssl_1_1_1.sh build_dir install_dir"
+    echo "install_openssl_1_1_1.sh build_dir install_dir [release_name]"
     exit 1
 }
 
-if [ "$#" -ne "2" ]; then
+if [ "$#" -lt "2" ]; then
     usage
 fi
 
 BUILD_DIR=$1
 INSTALL_DIR=$2
-RELEASE=1_1_1g
+
+# Default to the latest 1.1.1 release if user didn't provide anything.
+RELEASE=${3:-'1.1.1-latest'}
 
 cd "$BUILD_DIR"
-curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_${RELEASE}.zip --output OpenSSL_${RELEASE}.zip
-unzip OpenSSL_${RELEASE}.zip
-cd openssl-OpenSSL_${RELEASE}
+curl --retry 3 -L https://www.openssl.org/source/openssl-${RELEASE}.tar.gz --output OpenSSL_${RELEASE}.tar.gz
+# Need to do this for cases where the untar'd directory name is not trivially predictable.
+mkdir -p OpenSSL_${RELEASE}
+tar xzf OpenSSL_${RELEASE}.tar.gz -C OpenSSL_${RELEASE} --strip-components 1
+cd OpenSSL_${RELEASE}
 
 # This should work across all platforms we support.
 CONFIGURE="./config -d"

--- a/.travis/install_openssl_1_1_1.sh
+++ b/.travis/install_openssl_1_1_1.sh
@@ -17,17 +17,16 @@ set -ex
 pushd "$(pwd)"
 
 usage() {
-    echo "install_openssl_1_1_1.sh build_dir install_dir travis_platform"
+    echo "install_openssl_1_1_1.sh build_dir install_dir"
     exit 1
 }
 
-if [ "$#" -ne "3" ]; then
+if [ "$#" -ne "2" ]; then
     usage
 fi
 
 BUILD_DIR=$1
 INSTALL_DIR=$2
-PLATFORM=$3
 RELEASE=1_1_1g
 
 cd "$BUILD_DIR"
@@ -35,14 +34,8 @@ curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_${RELEASE}.
 unzip OpenSSL_${RELEASE}.zip
 cd openssl-OpenSSL_${RELEASE}
 
-if [ "$PLATFORM" == "linux" ]; then
-    CONFIGURE="./config -d"
-elif [ "$PLATFORM" == "osx" ]; then
-    CONFIGURE="./Configure darwin64-x86_64-cc"
-else
-    echo "Invalid platform! $PLATFORM"
-    usage
-fi
+# This should work across all platforms we support.
+CONFIGURE="./config -d"
 
 # Use g3 to get debug symbols in libcrypto to chase memory leaks
 $CONFIGURE -g3 -fPIC              \

--- a/.travis/install_openssl_1_1_x_master.sh
+++ b/.travis/install_openssl_1_1_x_master.sh
@@ -17,17 +17,16 @@ set -ex
 pushd "$(pwd)"
 
 usage() {
-    echo "install_openssl_1_1_x_master.sh build_dir install_dir travis_platform"
+    echo "install_openssl_1_1_x_master.sh build_dir install_dir"
     exit 1
 }
 
-if [ "$#" -ne "3" ]; then
+if [ "$#" -ne "2" ]; then
     usage
 fi
 
 BUILD_DIR=$1
 INSTALL_DIR=$2
-PLATFORM=$3
 
 cd "$BUILD_DIR"
 
@@ -35,14 +34,8 @@ git clone https://github.com/openssl/openssl.git
 
 cd openssl
 
-if [ "$PLATFORM" == "linux" ]; then
-    CONFIGURE="./config -d"
-elif [ "$PLATFORM" == "osx" ]; then
-    CONFIGURE="./Configure darwin64-x86_64-cc"
-else
-    echo "Invalid platform! $PLATFORM"
-    usage
-fi
+# This should work across all platforms we support.
+CONFIGURE="./config -d"
 
 # Use g3 to get debug symbols in libcrypto to chase memory leaks
 $CONFIGURE -g3 -fPIC              \

--- a/codebuild/bin/install_default_dependencies.sh
+++ b/codebuild/bin/install_default_dependencies.sh
@@ -16,6 +16,7 @@
 set -ex
 source codebuild/bin/s2n_setup_env.sh
 
+OPENSSL_1_1_1_DEFAULT_VERSION="1.1.1g"
 
  # Install latest version of clang, clang++, and llvm-symbolizer. Needed for fuzzing.
 if [[ "$TESTS" == "fuzz" || "$TESTS" == "ALL" || "$LATEST_CLANG" == "true" ]]; then
@@ -33,7 +34,7 @@ fi
 if [[ ("$S2N_LIBCRYPTO" == "openssl-1.1.1") || ("$TESTS" == "integration" || "$TESTS" == "integrationv2" || "$TESTS" == "ALL" ) ]]; then
     if [[ ! -x "$OPENSSL_1_1_1_INSTALL_DIR/bin/openssl" ]]; then
       mkdir -p "$OPENSSL_1_1_1_INSTALL_DIR"||true
-      codebuild/bin/install_openssl_1_1_1.sh "$(mktemp -d)" "$OPENSSL_1_1_1_INSTALL_DIR" > /dev/null ;
+      codebuild/bin/install_openssl_1_1_1.sh "$(mktemp -d)" "$OPENSSL_1_1_1_INSTALL_DIR" "$OPENSSL_1_1_1_DEFAULT_VERSION" > /dev/null ;
     fi
 fi
 

--- a/codebuild/bin/install_default_dependencies.sh
+++ b/codebuild/bin/install_default_dependencies.sh
@@ -33,7 +33,7 @@ fi
 if [[ ("$S2N_LIBCRYPTO" == "openssl-1.1.1") || ("$TESTS" == "integration" || "$TESTS" == "integrationv2" || "$TESTS" == "ALL" ) ]]; then
     if [[ ! -x "$OPENSSL_1_1_1_INSTALL_DIR/bin/openssl" ]]; then
       mkdir -p "$OPENSSL_1_1_1_INSTALL_DIR"||true
-      codebuild/bin/install_openssl_1_1_1.sh "$(mktemp -d)" "$OPENSSL_1_1_1_INSTALL_DIR" "$OS_NAME" > /dev/null ;
+      codebuild/bin/install_openssl_1_1_1.sh "$(mktemp -d)" "$OPENSSL_1_1_1_INSTALL_DIR" > /dev/null ;
     fi
 fi
 

--- a/codebuild/bin/install_openssl_1_1_1.sh
+++ b/codebuild/bin/install_openssl_1_1_1.sh
@@ -17,17 +17,16 @@ set -ex
 pushd "$(pwd)"
 
 usage() {
-    echo "install_openssl_1_1_1.sh build_dir install_dir os_name"
+    echo "install_openssl_1_1_1.sh build_dir install_dir"
     exit 1
 }
 
-if [ "$#" -ne "3" ]; then
+if [ "$#" -ne "2" ]; then
     usage
 fi
 
 BUILD_DIR=$1
 INSTALL_DIR=$2
-OS_NAME=$3
 source codebuild/bin/jobs.sh
 RELEASE=1_1_1g
 
@@ -36,14 +35,8 @@ curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_${RELEASE}.
 unzip OpenSSL_${RELEASE}.zip
 cd openssl-OpenSSL_${RELEASE}
 
-if [ "$OS_NAME" == "linux" ]; then
-    CONFIGURE="./config -d"
-elif [ "$OS_NAME" == "osx" ]; then
-    CONFIGURE="./Configure darwin64-x86_64-cc"
-else
-    echo "Invalid platform! $OS_NAME"
-    usage
-fi
+# This should work across all platforms we support.
+CONFIGURE="./config -d"
 
 # Use g3 to get debug symbols in libcrypto to chase memory leaks
 $CONFIGURE -g3 -fPIC              \

--- a/codebuild/bin/install_openssl_1_1_1.sh
+++ b/codebuild/bin/install_openssl_1_1_1.sh
@@ -17,23 +17,27 @@ set -ex
 pushd "$(pwd)"
 
 usage() {
-    echo "install_openssl_1_1_1.sh build_dir install_dir"
+    echo "install_openssl_1_1_1.sh build_dir install_dir [release_name]"
     exit 1
 }
 
-if [ "$#" -ne "2" ]; then
+if [ "$#" -lt "2" ]; then
     usage
 fi
 
 BUILD_DIR=$1
 INSTALL_DIR=$2
 source codebuild/bin/jobs.sh
-RELEASE=1_1_1g
+
+# Default to the latest 1.1.1 release if user didn't provide anything.
+RELEASE=${3:-'1.1.1-latest'}
 
 cd "$BUILD_DIR"
-curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_${RELEASE}.zip --output OpenSSL_${RELEASE}.zip
-unzip OpenSSL_${RELEASE}.zip
-cd openssl-OpenSSL_${RELEASE}
+curl --retry 3 -L https://www.openssl.org/source/openssl-${RELEASE}.tar.gz --output OpenSSL_${RELEASE}.tar.gz
+# Need to do this for cases where the untar'd directory name is not trivially predictable.
+mkdir -p OpenSSL_${RELEASE}
+tar xzf OpenSSL_${RELEASE}.tar.gz -C OpenSSL_${RELEASE} --strip-components 1
+cd OpenSSL_${RELEASE}
 
 # This should work across all platforms we support.
 CONFIGURE="./config -d"


### PR DESCRIPTION
This change only impacts the MacOS build. After this change this
script will auto detect the new darwin64-arm64-cc target for M1
Macs.

