### PR TITLE
Add API to accept client's max fragment length on a connection basis

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -236,6 +236,8 @@ S2N_API
 extern int s2n_config_send_max_fragment_length(struct s2n_config *config, s2n_max_frag_len mfl_code);
 S2N_API
 extern int s2n_config_accept_max_fragment_length(struct s2n_config *config);
+S2N_API
+extern int s2n_connection_accept_max_fragment_length(struct s2n_connection *conn);
 
 S2N_API
 extern int s2n_config_set_session_state_lifetime(struct s2n_config *config, uint64_t lifetime_in_secs);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1231,6 +1231,17 @@ to the s2n_client_hello structure holding the client hello message sent by the c
 NULL is returned if the connection has not yet received and parsed the client hello.
 Earliest point during the handshake when this structure is available for use is in the client_hello_callback (see **s2n_config_set_client_hello_cb**).
 
+### s2n\_connection\_accept\_max\_fragment\_length
+
+```c
+int s2n_connection_accept_max_fragment_length(struct s2n_connection *conn);
+```
+
+For a given s2n_connection,, **s2n_connection_accept_max_fragment_length** allows the server to opt-in to accept
+client's TLS maximum fragment length extension requests.
+If this API is not called, and client requests the extension, server will ignore the
+request and continue TLS handshake with default maximum fragment length of 8k bytes
+
 ### s2n\_client\_hello\_get\_raw\_message
 
 ```c

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -145,7 +145,7 @@ static int negotiate_kem(const uint8_t client_extensions[], const size_t client_
     free(private_key);
 
     eq_check(negotiated_kem_id, expected_kem_id);
-    
+
     return 0;
 }
 
@@ -153,7 +153,7 @@ int main(int argc, char **argv)
 {
     char *cert_chain;
     char *private_key;
-    
+
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13());
 
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        
+
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
         EXPECT_SUCCESS(s2n_config_free(server_config));
         EXPECT_SUCCESS(s2n_config_free(client_config));
@@ -261,7 +261,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        
+
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
 
         EXPECT_SUCCESS(s2n_config_free(server_config));
@@ -374,7 +374,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
 
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
-        
+
         EXPECT_SUCCESS(s2n_config_free(server_config));
     }
 
@@ -485,7 +485,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_errno, S2N_ERR_DUPLICATE_EXTENSION);
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
-        
+
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
 
         EXPECT_SUCCESS(s2n_config_free(server_config));
@@ -578,7 +578,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
 
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
-        
+
         EXPECT_SUCCESS(s2n_config_free(server_config));
     }
 
@@ -659,11 +659,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
         s2n_negotiate(server_conn, &server_blocked);
         EXPECT_EQUAL(s2n_errno, S2N_ERR_NON_EMPTY_RENEGOTIATION_INFO);
-        
+
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
         EXPECT_SUCCESS(s2n_config_free(server_config));
-        
+
         /* Clear pipe since negotiation failed mid-handshake */
         EXPECT_SUCCESS(read(io_pair.client, buf, sizeof(buf)));
     }
@@ -696,7 +696,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(server_config, cert_chain, private_key));
-        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, S2N_EXTENSION_OCSP_STAPLING, 
+        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, S2N_EXTENSION_OCSP_STAPLING,
                     server_ocsp_status, sizeof(server_ocsp_status)));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
@@ -714,7 +714,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        
+
         EXPECT_SUCCESS(s2n_config_free(server_config));
         EXPECT_SUCCESS(s2n_config_free(client_config));
     }
@@ -779,11 +779,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
 
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
-        
+
         EXPECT_SUCCESS(s2n_config_free(server_config));
         EXPECT_SUCCESS(s2n_config_free(client_config));
     }
-    
+
     /* Test with s2n_config_set_extension_data(). Can be removed once API is deprecated */
     if(s2n_x509_ocsp_stapling_supported()) {
         struct s2n_connection *client_conn;
@@ -797,7 +797,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(client_config, 0));
         EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
         EXPECT_SUCCESS(s2n_config_set_status_request_type(client_config, S2N_STATUS_REQUEST_OCSP));
-        
+
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
@@ -805,7 +805,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(server_config, cert_chain, private_key));
-        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, S2N_EXTENSION_OCSP_STAPLING, 
+        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, S2N_EXTENSION_OCSP_STAPLING,
                     server_ocsp_status, sizeof(server_ocsp_status)));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -867,7 +867,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(server_config, cert_chain, private_key));
-        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, S2N_EXTENSION_OCSP_STAPLING, 
+        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, S2N_EXTENSION_OCSP_STAPLING,
                     server_ocsp_status, sizeof(server_ocsp_status)));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
@@ -889,7 +889,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        
+
         EXPECT_SUCCESS(s2n_config_free(server_config));
         EXPECT_SUCCESS(s2n_config_free(client_config));
     }
@@ -988,7 +988,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(server_config, cert_chain, private_key));
-        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, S2N_EXTENSION_CERTIFICATE_TRANSPARENCY, 
+        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, S2N_EXTENSION_CERTIFICATE_TRANSPARENCY,
                     sct_list, sizeof(sct_list)));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
@@ -1040,7 +1040,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(server_config, cert_chain, private_key));
-        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, S2N_EXTENSION_CERTIFICATE_TRANSPARENCY, 
+        EXPECT_SUCCESS(s2n_config_set_extension_data(server_config, S2N_EXTENSION_CERTIFICATE_TRANSPARENCY,
                     sct_list, sizeof(sct_list)));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
@@ -1054,7 +1054,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        
+
         EXPECT_SUCCESS(s2n_config_free(server_config));
         EXPECT_SUCCESS(s2n_config_free(client_config));
     }
@@ -1107,7 +1107,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        
+
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
 
         EXPECT_SUCCESS(s2n_config_free(server_config));
@@ -1117,55 +1117,61 @@ int main(int argc, char **argv)
     /* Client requests 512, 1024, 2048, and 4096 maximum fragment lengths */
     for (uint8_t mfl_code = S2N_TLS_MAX_FRAG_LEN_512; mfl_code <= S2N_TLS_MAX_FRAG_LEN_4096; mfl_code++)
     {
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
-        struct s2n_config *client_config;
-        struct s2n_cert_chain_and_key *chain_and_key;
+        for (uint8_t connection_config = 0; connection_config <= 1; connection_config++) {
+            struct s2n_connection *client_conn;
+            struct s2n_connection *server_conn;
+            struct s2n_config *server_config;
+            struct s2n_config *client_config;
+            struct s2n_cert_chain_and_key *chain_and_key;
 
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        client_conn->actual_protocol_version = S2N_TLS12;
-        client_conn->server_protocol_version = S2N_TLS12;
-        client_conn->client_protocol_version = S2N_TLS12;
+            EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+            client_conn->actual_protocol_version = S2N_TLS12;
+            client_conn->server_protocol_version = S2N_TLS12;
+            client_conn->client_protocol_version = S2N_TLS12;
 
-        EXPECT_NOT_NULL(client_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(client_config, 0));
-        EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
+            EXPECT_NOT_NULL(client_config = s2n_config_new());
+            EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(client_config, 0));
+            EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
 
-        EXPECT_SUCCESS(s2n_config_send_max_fragment_length(client_config, mfl_code));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
+            EXPECT_SUCCESS(s2n_config_send_max_fragment_length(client_config, mfl_code));
+            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
-        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        server_conn->actual_protocol_version = S2N_TLS12;
-        server_conn->server_protocol_version = S2N_TLS12;
-        server_conn->client_protocol_version = S2N_TLS12;
+            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+            server_conn->actual_protocol_version = S2N_TLS12;
+            server_conn->server_protocol_version = S2N_TLS12;
+            server_conn->client_protocol_version = S2N_TLS12;
 
-        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+            EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
-        EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_accept_max_fragment_length(server_config));
-        EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain, private_key));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+            EXPECT_NOT_NULL(server_config = s2n_config_new());
+            if (connection_config) {
+                EXPECT_SUCCESS(s2n_config_accept_max_fragment_length(server_config));
+            } else {
+                EXPECT_SUCCESS(s2n_connection_accept_max_fragment_length(server_conn));
+            }
+            EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain, private_key));
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
-        /* Preference should be ignored as the TlS Maximum Fragment Length Extension is Set */
-        EXPECT_SUCCESS(s2n_connection_prefer_throughput(server_conn));
+            /* Preference should be ignored as the TlS Maximum Fragment Length Extension is Set */
+            EXPECT_SUCCESS(s2n_connection_prefer_throughput(server_conn));
 
-        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+            EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
-        EXPECT_EQUAL(server_conn->max_outgoing_fragment_length, mfl_code_to_length[mfl_code]);
-        EXPECT_EQUAL(server_conn->mfl_code, mfl_code);
+            EXPECT_EQUAL(server_conn->max_outgoing_fragment_length, mfl_code_to_length[mfl_code]);
+            EXPECT_EQUAL(server_conn->mfl_code, mfl_code);
 
-        EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
+            EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 
-        EXPECT_SUCCESS(s2n_connection_free(server_conn));
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
 
-        EXPECT_SUCCESS(s2n_config_free(server_config));
-        EXPECT_SUCCESS(s2n_config_free(client_config));
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+
+            EXPECT_SUCCESS(s2n_config_free(server_config));
+            EXPECT_SUCCESS(s2n_config_free(client_config));
+        }
     }
 
     /* Client requests invalid maximum fragment length */
@@ -1211,7 +1217,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        
+
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
 
         EXPECT_SUCCESS(s2n_config_free(server_config));
@@ -1260,7 +1266,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        
+
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
 
         EXPECT_SUCCESS(s2n_config_free(server_config));

--- a/tls/extensions/s2n_client_max_frag_len.c
+++ b/tls/extensions/s2n_client_max_frag_len.c
@@ -47,7 +47,7 @@ static int s2n_client_max_frag_len_send(struct s2n_connection *conn, struct s2n_
 
 static int s2n_client_max_frag_len_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    // we accept mfl only when enabled in s2n_config or in the connection
+    /* we accept mfl only when enabled in s2n_config or in the connection */
     if (!(conn->config->accept_mfl || conn->accept_mfl)) {
         return S2N_SUCCESS;
     }

--- a/tls/extensions/s2n_client_max_frag_len.c
+++ b/tls/extensions/s2n_client_max_frag_len.c
@@ -47,7 +47,8 @@ static int s2n_client_max_frag_len_send(struct s2n_connection *conn, struct s2n_
 
 static int s2n_client_max_frag_len_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    if (!conn->config->accept_mfl) {
+    // we accept mfl only when enabled in s2n_config or in the connection
+    if (!(conn->config->accept_mfl || conn->accept_mfl)) {
         return S2N_SUCCESS;
     }
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -556,6 +556,14 @@ int s2n_connection_release_buffers(struct s2n_connection *conn)
     return S2N_SUCCESS;
 }
 
+int s2n_connection_accept_max_fragment_length(struct s2n_connection *conn) {
+    notnull_check(conn);
+
+    conn->accept_mfl = 1;
+
+    return 0;
+}
+
 int s2n_connection_free_handshake(struct s2n_connection *conn)
 {
     /* We are done with the handshake */

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -101,6 +101,9 @@ struct s2n_connection {
     /* whether the connection address is ipv6 or not */
     unsigned ipv6:1;
 
+    /* if true, server will accept client's Maximum Fragment Length request for this request */
+    unsigned accept_mfl:1;
+
     /* Whether server_name extension was used to make a decision on cert selection.
      * RFC6066 Section 3 states that server which used server_name to make a decision
      * on certificate or security settings has to send an empty server_name.


### PR DESCRIPTION
### Description of changes: 
- `s2n_connection_accept_max_fragment_length(conn)` is the connection-
  oriented version of `s2n_config_accept_max_fragment_length(config)`

- accepting mfl may have side effects, so this flag gives finer grain control for enabling it

### Call-outs:
- with this change, s2n server respects mfl when either the bits of config->enable_mfl or conn->enable_mfl is flipped.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
