### PR TITLE
Reduce fuzz timeouts due to codebuild timeout limits.

### DIFF
--- a/codebuild/bin/install_shellcheck.sh
+++ b/codebuild/bin/install_shellcheck.sh
@@ -34,7 +34,7 @@ if [ "$#" -ne "0" ]; then
 fi
 
 case "$OS_NAME" in
-  "amazon linux")
+  "amazon linux"|"linux")
     which shellcheck || install_shellcheck
     ;;
   "darwin" )

--- a/codebuild/fuzz_afl_codebuild.config
+++ b/codebuild/fuzz_afl_codebuild.config
@@ -16,7 +16,7 @@ source_version:
 # secondary-artifacts, and can be a comma sep. list
 artifact_secondary_identifiers: logs
 artifact_s3_bucket: s2n-build-artifacts
-env: TESTS=fuzz AFL_FUZZ=true FUZZ_TIMEOUT_SEC=28000
+env: TESTS=fuzz AFL_FUZZ=true FUZZ_TIMEOUT_SEC=27400
 
 # Auto-populate CloudWatch events based on the file glob "tests/fuzz/s2n_*test.c"
 [ScheduledTemplate:../tests/fuzz]

--- a/codebuild/fuzz_codebuild.config
+++ b/codebuild/fuzz_codebuild.config
@@ -19,7 +19,7 @@ source_version:
 # secondary-artifacts, and can be a comma sep. list
 artifact_secondary_identifiers: logs
 artifact_s3_bucket: s2n-build-artifacts
-env: TESTS=fuzz FUZZ_TIMEOUT_SEC=28000
+env: TESTS=fuzz FUZZ_TIMEOUT_SEC=27400
 
 [CloudWatchEvent:s2n_bike_r1_recv_ciphertext_fuzz_test]
 start_time: 05:00

--- a/tests/fuzz/runFuzzTest.sh
+++ b/tests/fuzz/runFuzzTest.sh
@@ -91,7 +91,7 @@ if [[ ${AFL_FUZZ} == "true" && ${FUZZ_COVERAGE} != "true" ]]; then
     returncode=$?
     # See the timeout man page for specifics
     if [[ ${returncode} -ne 124 ]]; then
-	    printf "\033[33;1mWARNING!\033[0m AFL exited with an unexpected return value: %8d" ${returncode}
+        printf "\033[33;1mWARNING!\033[0m AFL exited with an unexpected return value: %8d" ${returncode}
     fi
     set -e
     CRASH_COUNT=$(sed -n -e 's/^unique_crashes *: //p' ./results/${TEST_NAME}/fuzzer_stats)


### PR DESCRIPTION
Fix Ubuntu test-dep installs.
Indentation.

### Resolved issues:

 resolves CI scheduled build error

### Description of changes: 

One scheduled build is failing because codebuild is timing out before the fuzz test stops.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
