### PR TITLE
[0RTT] Add early data handshakes

### DIFF
--- a/tests/saw/spec/handshake/s2n_handshake_io.cry
+++ b/tests/saw/spec/handshake/s2n_handshake_io.cry
@@ -167,7 +167,7 @@ type handshake = {handshake_type : [32]
 IS_TLS13_HANDSHAKE : connection -> Bit
 IS_TLS13_HANDSHAKE conn = conn.actual_protocol_version == S2N_TLS13
 
-ACTIVE_STATE_MACHINE : connection -> [19]handshake_action
+ACTIVE_STATE_MACHINE : connection -> [20]handshake_action
 ACTIVE_STATE_MACHINE conn = if IS_TLS13_HANDSHAKE conn then tls13_state_machine else state_machine # zero
 
 ACTIVE_HANDSHAKES : connection -> [1024][32][32]
@@ -210,8 +210,8 @@ mkAct : [8] -> [8] -> [8] -> handshake_action
 mkAct r m w = {record_type = r, message_type = m, writer = w}
 
 // A model of the tls1.3 handshake states (array state_machine in C)
-tls13_state_machine : [19]handshake_action
-tls13_state_machine = [tls13_state_machine_fn m | m <- [0..18]]
+tls13_state_machine : [20]handshake_action
+tls13_state_machine = [tls13_state_machine_fn m | m <- [0..19]]
 
 // Function that tells a handshake_action for a given tls1.3 state
 tls13_state_machine_fn : [5] -> handshake_action
@@ -232,8 +232,8 @@ tls13_state_machine_fn m =
   else zero
 
 // A model of the handshake states (array state_machine in C)
-state_machine : [19]handshake_action
-state_machine = [state_machine_fn m | m <- [0..18]]
+state_machine : [20]handshake_action
+state_machine = [state_machine_fn m | m <- [0..19]]
 
 // Function that tells a handshake_action for a given state
 state_machine_fn : [5] -> handshake_action
@@ -512,7 +512,7 @@ SERVER_CHANGE_CIPHER_SPEC = 13
 SERVER_FINISHED = 14
 ENCRYPTED_EXTENSIONS = 15
 SERVER_CERT_VERIFY = 16
-APPLICATION_DATA = 18
+APPLICATION_DATA = 19
 
 //TLS record type
 TLS_CHANGE_CIPHER_SPEC = 20

--- a/tests/saw/spec/handshake/s2n_handshake_io.cry
+++ b/tests/saw/spec/handshake/s2n_handshake_io.cry
@@ -170,7 +170,7 @@ IS_TLS13_HANDSHAKE conn = conn.actual_protocol_version == S2N_TLS13
 ACTIVE_STATE_MACHINE : connection -> [19]handshake_action
 ACTIVE_STATE_MACHINE conn = if IS_TLS13_HANDSHAKE conn then tls13_state_machine else state_machine # zero
 
-ACTIVE_HANDSHAKES : connection -> [512][32][32]
+ACTIVE_HANDSHAKES : connection -> [1024][32][32]
 ACTIVE_HANDSHAKES conn = if IS_TLS13_HANDSHAKE conn then tls13_handshakes else handshakes
 
 ACTIVE_MESSAGE : connection -> [32]
@@ -257,8 +257,8 @@ state_machine_fn m =
   else zero
 
 // A model of the tls1.3 handshake state machine (array handshakes in C)
-tls13_handshakes : [512][32][32]
-tls13_handshakes = [tls13_handshakes_fn h | h <- [0..511]]
+tls13_handshakes : [1024][32][32]
+tls13_handshakes = [tls13_handshakes_fn h | h <- [0..1023]]
 
 // A function that gives the tls1.3 handshake sequence for each valid handshake_type.
 tls13_handshakes_fn: [32] -> [32][32]
@@ -285,8 +285,8 @@ tls13_handshakes_fn handshk =
   else zero
 
 // A model of the handshake state machine (array handshakes in C)
-handshakes : [512][32][32]
-handshakes = [handshakes_fn h | h <- [0..511]]
+handshakes : [1024][32][32]
+handshakes = [handshakes_fn h | h <- [0..1023]]
 
 // A function that gives the handshake sequence for each valid handshake_type.
 // This is a sparse encoding of the handshakes array (which is sparse too).

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -113,3 +113,13 @@ S2N_RESULT s2n_early_data_config_clone(struct s2n_psk *new_psk, struct s2n_early
 
     return S2N_RESULT_OK;
 }
+
+int s2n_end_of_early_data_send(struct s2n_connection *conn)
+{
+    return S2N_RESULT_TO_POSIX(s2n_connection_set_early_data_state(conn, S2N_END_OF_EARLY_DATA));
+}
+
+int s2n_end_of_early_data_recv(struct s2n_connection *conn)
+{
+    return S2N_RESULT_TO_POSIX(s2n_connection_set_early_data_state(conn, S2N_END_OF_EARLY_DATA));
+}

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -32,6 +32,7 @@
 #define TLS_CLIENT_HELLO               1
 #define TLS_SERVER_HELLO               2
 #define TLS_SERVER_NEW_SESSION_TICKET  4
+#define TLS_END_OF_EARLY_DATA          5
 #define TLS_ENCRYPTED_EXTENSIONS       8
 #define TLS_CERTIFICATE               11
 #define TLS_SERVER_KEY                12
@@ -67,6 +68,7 @@ typedef enum {
     ENCRYPTED_EXTENSIONS,
     SERVER_CERT_VERIFY,
     HELLO_RETRY_MSG,
+    END_OF_EARLY_DATA,
 
     APPLICATION_DATA,
 } message_type_t;
@@ -185,6 +187,9 @@ struct s2n_handshake {
  * with some middleboxes: https://tools.ietf.org/html/rfc8446#appendix-D.4 */
 #define MIDDLEBOX_COMPAT            0x100
 #define IS_MIDDLEBOX_COMPAT_MODE( type ) ( (type) & MIDDLEBOX_COMPAT )
+
+#define WITH_EARLY_DATA             0x200
+#define IS_EARLY_DATA_HANDSHAKE( type ) ( (type) & WITH_EARLY_DATA )
 
     /* Which handshake message number are we processing */
     int message_number;

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -70,6 +70,8 @@ extern int s2n_tls13_client_finished_send(struct s2n_connection *conn);
 extern int s2n_tls13_client_finished_recv(struct s2n_connection *conn);
 extern int s2n_tls13_server_finished_send(struct s2n_connection *conn);
 extern int s2n_tls13_server_finished_recv(struct s2n_connection *conn);
+extern int s2n_end_of_early_data_send(struct s2n_connection *conn);
+extern int s2n_end_of_early_data_recv(struct s2n_connection *conn);
 extern int s2n_process_client_hello(struct s2n_connection *conn);
 extern int s2n_handshake_write_header(struct s2n_stuffer *out, uint8_t message_type);
 extern int s2n_handshake_finish_header(struct s2n_stuffer *out);


### PR DESCRIPTION
### Resolved issues:

https://github.com/awslabs/s2n/issues/2566

### Description of changes: 

Add a new handshake type + handshakes for early data. The early data handshakes contain END_OF_EARLY_DATA messages and handle middlebox compatibility mode slightly differently.

### Call-outs:

* We're doubling the size of the handshake arrays again, which really doesn't seem sustainable.

### Testing:

 Unit tests. In particular, I added new state machine tests that verify middlebox compatibility mode + WITH_EARLY_DATA modifies existing handshakes as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
