### PR TITLE
[0RTT] Add ClientHello version of the early data indication extension

### DIFF
--- a/tests/unit/s2n_client_early_data_indication_test.c
+++ b/tests/unit/s2n_client_early_data_indication_test.c
@@ -29,7 +29,7 @@ static S2N_RESULT s2n_append_test_psk(struct s2n_connection *conn, uint32_t max_
     /* We're assuming the index will only take one digit */
     ENSURE_LT(conn->psk_params.psk_list.len, 10);
     uint8_t buffer[sizeof(TEST_VALUE) + 1] = { 0 };
-    snprintf((char*) buffer, sizeof(buffer), "%s%d", TEST_VALUE, conn->psk_params.psk_list.len);
+    snprintf((char*) buffer, sizeof(buffer), "%s%u", TEST_VALUE, conn->psk_params.psk_list.len);
 
     DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
     GUARD_AS_RESULT(s2n_psk_set_identity(psk, buffer, sizeof(buffer)));

--- a/tests/unit/s2n_client_early_data_indication_test.c
+++ b/tests/unit/s2n_client_early_data_indication_test.c
@@ -1,0 +1,293 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "tls/extensions/s2n_early_data_indication.h"
+#include "tls/extensions/s2n_client_psk.h"
+#include "tls/s2n_tls13.h"
+#include "tls/s2n_tls.h"
+
+#define TEST_VALUE "test"
+
+static S2N_RESULT s2n_append_test_psk(struct s2n_connection *conn, uint32_t max_early_data,
+        const uint8_t (*cipher_suite_iana)[2])
+{
+    /* We're assuming the index will only take one digit */
+    ENSURE_LT(conn->psk_params.psk_list.len, 10);
+    uint8_t buffer[sizeof(TEST_VALUE) + 1] = { 0 };
+    snprintf((char*) buffer, sizeof(buffer), "%s%d", TEST_VALUE, conn->psk_params.psk_list.len);
+
+    DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
+    GUARD_AS_RESULT(s2n_psk_set_identity(psk, buffer, sizeof(buffer)));
+    GUARD_AS_RESULT(s2n_psk_set_secret(psk, buffer, sizeof(buffer)));
+    if (max_early_data > 0) {
+        GUARD_AS_RESULT(s2n_psk_configure_early_data(psk, max_early_data,
+                (*cipher_suite_iana)[0], (*cipher_suite_iana)[1]));
+    }
+    GUARD_AS_RESULT(s2n_connection_append_psk(conn, psk));
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_set_early_data_app_protocol(struct s2n_connection *conn, struct s2n_blob *app_protocol)
+{
+    struct s2n_psk *psk;
+    GUARD_RESULT(s2n_array_get(&conn->psk_params.psk_list, 0, (void**) &psk));
+    GUARD_AS_RESULT(s2n_psk_set_application_protocol(psk, app_protocol->data, app_protocol->size));
+    return S2N_RESULT_OK;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test s2n_client_early_data_indication_should_send */
+    {
+        /* Safety check */
+        EXPECT_FALSE(s2n_client_early_data_indication_extension.should_send(NULL));
+
+        const uint32_t nonzero_max_early_data = 10;
+
+        /* All checks pass: send extension */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_psk(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384.iana_value));
+
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /** Don't send if no PSK extension is sent.
+         *
+         *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+         *= type=test
+         *# When a PSK is used and early data is allowed for that PSK, the client
+         *# can send Application Data in its first flight of messages.  If the
+         *# client opts to do so, it MUST supply both the "pre_shared_key" and
+         *# "early_data" extensions.
+         **/
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+
+            EXPECT_FALSE(s2n_client_psk_extension.should_send(conn));
+            EXPECT_FALSE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /** Don't send when performing a retry.
+         *
+         *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+         *= type=test
+         *# A client MUST NOT include the
+         *# "early_data" extension in its followup ClientHello.
+         **/
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_psk(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384.iana_value));
+
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_set_hello_retry_required(conn));
+            EXPECT_FALSE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Don't send if no early data allowed by first PSK */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+
+            EXPECT_OK(s2n_append_test_psk(conn, 0, &s2n_tls13_aes_256_gcm_sha384.iana_value));
+            EXPECT_OK(s2n_append_test_psk(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384.iana_value));
+            EXPECT_FALSE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_OK(s2n_psk_parameters_wipe(&conn->psk_params));
+            EXPECT_OK(s2n_append_test_psk(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384.iana_value));
+            EXPECT_OK(s2n_append_test_psk(conn, 0, &s2n_tls13_aes_256_gcm_sha384.iana_value));
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Don't send if protocol version too low */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_psk(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384.iana_value));
+
+            conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_FALSE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            conn->actual_protocol_version = S2N_TLS13;
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            conn->actual_protocol_version = S2N_TLS13 + 1;
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Don't send if cipher suite not allowed by cipher preferences */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+
+            EXPECT_OK(s2n_append_test_psk(conn, nonzero_max_early_data, &s2n_rsa_with_rc4_128_md5.iana_value));
+            EXPECT_FALSE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_OK(s2n_psk_parameters_wipe(&conn->psk_params));
+            EXPECT_OK(s2n_append_test_psk(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384.iana_value));
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Don't send if application layer protocol not allowed by preferences */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_psk(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384.iana_value));
+
+            uint8_t app_protocol_data[] = "protocol preference";
+            uint8_t other_app_protocol_data[] = "different protocol";
+            struct s2n_blob app_protocol = { 0 }, empty_app_protocol = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&app_protocol, app_protocol_data, sizeof(app_protocol_data)));
+
+            /* No early data alp, empty alpn preferences: send */
+            EXPECT_OK(s2n_set_early_data_app_protocol(conn, &empty_app_protocol));
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            /* Early data alp, empty alpn preferences: don't send */
+            EXPECT_OK(s2n_set_early_data_app_protocol(conn, &app_protocol));
+            EXPECT_FALSE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, other_app_protocol_data,
+                    sizeof(other_app_protocol_data)));
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, other_app_protocol_data,
+                    sizeof(other_app_protocol_data)));
+
+            /* No early data alp, non-empty alpn preferences: send */
+            EXPECT_OK(s2n_set_early_data_app_protocol(conn, &empty_app_protocol));
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            /* alpn preferences don't contain alp: don't send */
+            EXPECT_OK(s2n_set_early_data_app_protocol(conn, &app_protocol));
+            EXPECT_FALSE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, app_protocol.data, app_protocol.size));
+
+            /* alpn preferences contain alp: send */
+            EXPECT_OK(s2n_set_early_data_app_protocol(conn, &app_protocol));
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    /* Test s2n_client_early_data_indiction_recv */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(conn);
+        conn->actual_protocol_version = S2N_TLS13;
+
+        /* Successful if not retry */
+        conn->early_data_state = S2N_UNKNOWN_EARLY_DATA_STATE;
+        EXPECT_SUCCESS(s2n_client_early_data_indication_extension.recv(conn, NULL));
+        EXPECT_EQUAL(conn->early_data_state, S2N_EARLY_DATA_REQUESTED);
+
+        /**
+         *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+         *= type=test
+         *# A client MUST NOT include the
+         *# "early_data" extension in its followup ClientHello.
+         **/
+        conn->early_data_state = S2N_UNKNOWN_EARLY_DATA_STATE;
+        EXPECT_SUCCESS(s2n_set_hello_retry_required(conn));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_client_early_data_indication_extension.recv(conn, NULL),
+                S2N_ERR_UNSUPPORTED_EXTENSION);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test state transitions */
+    {
+        /* When early data requested */
+        {
+            struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(client_conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_psk(client_conn, 1, &s2n_tls13_aes_256_gcm_sha384.iana_value));
+            EXPECT_EQUAL(client_conn->early_data_state, S2N_UNKNOWN_EARLY_DATA_STATE);
+
+            struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(server_conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_psk(server_conn, 1, &s2n_tls13_aes_256_gcm_sha384.iana_value));
+            EXPECT_EQUAL(server_conn->early_data_state, S2N_UNKNOWN_EARLY_DATA_STATE);
+
+            EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
+                    s2n_stuffer_data_available(&client_conn->handshake.io)));
+            EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+
+            EXPECT_EQUAL(client_conn->early_data_state, S2N_EARLY_DATA_REQUESTED);
+            EXPECT_EQUAL(server_conn->early_data_state, S2N_EARLY_DATA_REQUESTED);
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+
+        /* When early data not requested */
+        {
+            struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(client_conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_psk(client_conn, 0, &s2n_tls13_aes_256_gcm_sha384.iana_value));
+            EXPECT_EQUAL(client_conn->early_data_state, S2N_UNKNOWN_EARLY_DATA_STATE);
+
+            struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(server_conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_psk(server_conn, 0, &s2n_tls13_aes_256_gcm_sha384.iana_value));
+            EXPECT_EQUAL(server_conn->early_data_state, S2N_UNKNOWN_EARLY_DATA_STATE);
+
+            EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
+                    s2n_stuffer_data_available(&client_conn->handshake.io)));
+            EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+
+            EXPECT_EQUAL(client_conn->early_data_state, S2N_EARLY_DATA_NOT_REQUESTED);
+            EXPECT_EQUAL(server_conn->early_data_state, S2N_EARLY_DATA_NOT_REQUESTED);
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_early_data_test.c
+++ b/tests/unit/s2n_early_data_test.c
@@ -38,6 +38,11 @@ static S2N_RESULT s2n_test_all_early_data_sequences(struct s2n_connection *conn,
 {
     s2n_early_data_state current_state = conn->early_data_state;
     for (s2n_early_data_state next_state = 0; next_state < S2N_EARLY_DATA_STATES_COUNT; next_state++) {
+        /* We always allow no-op transitions, so ignore them */
+        if (next_state == current_state) {
+            continue;
+        }
+
         conn->early_data_state = current_state;
 
         bool actual_valid = s2n_result_is_ok(s2n_connection_set_early_data_state(conn, next_state));
@@ -103,8 +108,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn);
 
             conn->early_data_state = 0;
-            EXPECT_ERROR_WITH_ERRNO(s2n_connection_set_early_data_state(conn, S2N_UNKNOWN_EARLY_DATA_STATE),
-                    S2N_ERR_INVALID_EARLY_DATA_STATE);
+            EXPECT_OK(s2n_connection_set_early_data_state(conn, S2N_UNKNOWN_EARLY_DATA_STATE));
 
             conn->early_data_state = 0;
             EXPECT_ERROR_WITH_ERRNO(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_STATES_COUNT),

--- a/tests/unit/s2n_protocol_preferences_test.c
+++ b/tests/unit/s2n_protocol_preferences_test.c
@@ -14,7 +14,9 @@
  */
 
 #include "s2n_test.h"
+#include "tls/extensions/s2n_client_alpn.h"
 #include "tls/s2n_connection.h"
+#include "tls/s2n_protocol_preferences.h"
 
 #include <s2n.h>
 
@@ -29,6 +31,7 @@ int main(int argc, char **argv)
     const size_t protocol1_len = strlen((const char *)protocol1);
     const uint8_t protocol2[] = "protocol abc 2";
     const size_t protocol2_len = strlen((const char *)protocol2);
+    uint8_t protocol3[] = "protocol3";
 
     const uint8_t large_value[255] = { 0 };
 
@@ -158,6 +161,145 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(conn->application_protocols_overridden.size, 0);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test s2n_protocol_preference_read */
+    {
+        /* Safety checks */
+        {
+            struct s2n_stuffer stuffer = { 0 };
+            struct s2n_blob blob = { 0 };
+            EXPECT_ERROR_WITH_ERRNO(s2n_protocol_preference_read(&stuffer, NULL), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_protocol_preference_read(NULL, &blob), S2N_ERR_NULL);
+        }
+
+        /* Read malformed value */
+        {
+            struct s2n_stuffer input = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&input, sizeof(protocol1) + 10));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&input, protocol1, sizeof(protocol1)));
+
+            struct s2n_blob result = { 0 };
+            EXPECT_ERROR(s2n_protocol_preference_read(&input, &result));
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&input));
+        }
+
+        /* Read valid value */
+        {
+            struct s2n_stuffer input = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&input, sizeof(protocol1)));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&input, protocol1, sizeof(protocol1)));
+
+            struct s2n_blob result = { 0 };
+            EXPECT_OK(s2n_protocol_preference_read(&input, &result));
+            EXPECT_EQUAL(result.size, sizeof(protocol1));
+            EXPECT_BYTEARRAY_EQUAL(result.data, protocol1, sizeof(protocol1));
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&input));
+        }
+
+        /* Read what we write */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, protocol1, sizeof(protocol1)));
+            EXPECT_SUCCESS(s2n_client_alpn_extension.send(conn, &conn->handshake.io));
+
+            /* Skip list size */
+            EXPECT_SUCCESS(s2n_stuffer_skip_read(&conn->handshake.io, sizeof(uint16_t)));
+
+            struct s2n_blob result = { 0 };
+            EXPECT_OK(s2n_protocol_preference_read(&conn->handshake.io, &result));
+            EXPECT_EQUAL(result.size, sizeof(protocol1));
+            EXPECT_BYTEARRAY_EQUAL(result.data, protocol1, sizeof(protocol1));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    /* s2n_protocol_preferences_contain */
+    {
+        /* Safety checks */
+        {
+            struct s2n_blob blob = { 0 };
+            bool match = false;
+            EXPECT_ERROR_WITH_ERRNO(s2n_protocol_preferences_contain(&blob, NULL, &match), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_protocol_preferences_contain(NULL, &blob, &match), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_protocol_preferences_contain(&blob, &blob, NULL), S2N_ERR_NULL);
+        }
+
+        /* No supported protocols */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+
+            struct s2n_blob target = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&target, protocol3, sizeof(protocol3)));
+
+            bool result = true;
+            EXPECT_OK(s2n_protocol_preferences_contain(&conn->application_protocols_overridden, &target, &result));
+            EXPECT_FALSE(result);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Error: malformed preferences */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, protocol1, sizeof(protocol1)));
+            conn->application_protocols_overridden.size--;
+
+            struct s2n_blob target = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&target, protocol3, sizeof(protocol3)));
+
+            bool result = true;
+            EXPECT_ERROR(s2n_protocol_preferences_contain(&conn->application_protocols_overridden, &target, &result));
+            EXPECT_FALSE(result);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* No match */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, protocol1, sizeof(protocol1)));
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, protocol2, sizeof(protocol2)));
+
+            struct s2n_blob target = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&target, protocol3, sizeof(protocol3)));
+
+            bool result = true;
+            EXPECT_OK(s2n_protocol_preferences_contain(&conn->application_protocols_overridden, &target, &result));
+            EXPECT_FALSE(result);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Match */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, protocol1, sizeof(protocol1)));
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, protocol3, sizeof(protocol3)));
+
+            struct s2n_blob target = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&target, protocol3, sizeof(protocol3)));
+
+            bool result = false;
+            EXPECT_OK(s2n_protocol_preferences_contain(&conn->application_protocols_overridden, &target, &result));
+            EXPECT_TRUE(result);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
     }
 
     END_TEST();

--- a/tls/extensions/s2n_client_alpn.c
+++ b/tls/extensions/s2n_client_alpn.c
@@ -19,6 +19,7 @@
 #include "tls/extensions/s2n_client_alpn.h"
 
 #include "tls/extensions/s2n_extension_type.h"
+#include "tls/s2n_protocol_preferences.h"
 #include "tls/s2n_tls.h"
 #include "tls/s2n_tls_parameters.h"
 
@@ -60,7 +61,6 @@ static int s2n_client_alpn_send(struct s2n_connection *conn, struct s2n_stuffer 
 static int s2n_client_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     uint16_t size_of_all;
-    struct s2n_stuffer client_protos = {0};
     struct s2n_stuffer server_protos = {0};
 
     struct s2n_blob *server_app_protocols;
@@ -83,35 +83,23 @@ static int s2n_client_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer 
     notnull_check(client_app_protocols.data);
 
     /* Find a matching protocol */
-    GUARD(s2n_stuffer_init(&client_protos, &client_app_protocols));
-    GUARD(s2n_stuffer_write(&client_protos, &client_app_protocols));
     GUARD(s2n_stuffer_init(&server_protos, server_app_protocols));
-    GUARD(s2n_stuffer_write(&server_protos, server_app_protocols));
+    GUARD(s2n_stuffer_skip_write(&server_protos, server_app_protocols->size));
 
-    while (s2n_stuffer_data_available(&server_protos)) {
-        uint8_t length;
-        uint8_t server_protocol[255];
-        GUARD(s2n_stuffer_read_uint8(&server_protos, &length));
-        GUARD(s2n_stuffer_read_bytes(&server_protos, server_protocol, length));
+    while (s2n_stuffer_data_available(&server_protos) > 0) {
+        struct s2n_blob server_protocol = { 0 };
+        ENSURE_POSIX(s2n_result_is_ok(s2n_protocol_preference_read(&server_protos, &server_protocol)),
+                S2N_ERR_BAD_MESSAGE);
 
-        while (s2n_stuffer_data_available(&client_protos)) {
-            uint8_t client_length;
-            GUARD(s2n_stuffer_read_uint8(&client_protos, &client_length));
-            S2N_ERROR_IF(client_length > s2n_stuffer_data_available(&client_protos), S2N_ERR_BAD_MESSAGE);
-            if (client_length != length) {
-                GUARD(s2n_stuffer_skip_read(&client_protos, client_length));
-            } else {
-                uint8_t client_protocol[255];
-                GUARD(s2n_stuffer_read_bytes(&client_protos, client_protocol, client_length));
-                if (memcmp(client_protocol, server_protocol, client_length) == 0) {
-                    memcpy_check(conn->application_protocol, client_protocol, client_length);
-                    conn->application_protocol[client_length] = '\0';
-                    return S2N_SUCCESS;
-                }
-            }
+        bool is_match = false;
+        ENSURE_POSIX(s2n_result_is_ok(s2n_protocol_preferences_contain(&client_app_protocols, &server_protocol, &is_match)),
+                S2N_ERR_BAD_MESSAGE);
+
+        if (is_match) {
+            memcpy_check(conn->application_protocol, server_protocol.data, server_protocol.size);
+            conn->application_protocol[server_protocol.size] = '\0';
+            return S2N_SUCCESS;
         }
-
-        GUARD(s2n_stuffer_reread(&client_protos));
     }
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_client_early_data_indication.c
+++ b/tls/extensions/s2n_client_early_data_indication.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <s2n.h>
+
+#include "tls/extensions/s2n_early_data_indication.h"
+
+#include "tls/extensions/s2n_client_psk.h"
+#include "tls/s2n_cipher_suites.h"
+#include "tls/s2n_early_data.h"
+#include "tls/s2n_protocol_preferences.h"
+#include "tls/s2n_tls13.h"
+#include "utils/s2n_safety.h"
+
+static S2N_RESULT s2n_early_data_config_is_possible(struct s2n_connection *conn)
+{
+    ENSURE_REF(conn);
+
+    struct s2n_psk *first_psk = NULL;
+    GUARD_RESULT(s2n_array_get(&conn->psk_params.psk_list, 0, (void**) &first_psk));
+    ENSURE_REF(first_psk);
+
+    struct s2n_early_data_config *config = &first_psk->early_data_config;
+
+    /* Must support early data */
+    ENSURE_GT(config->max_early_data_size, 0);
+
+    /* Early data must require a protocol than we could negotiate */
+    ENSURE_GTE(s2n_connection_get_protocol_version(conn), config->protocol_version);
+    ENSURE_GTE(s2n_connection_get_protocol_version(conn), S2N_TLS13);
+
+    const struct s2n_cipher_preferences *cipher_preferences = NULL;
+    GUARD_AS_RESULT(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+    ENSURE_REF(cipher_preferences);
+
+    /* Early data must require a supported cipher */
+    bool match = false;
+    for (uint8_t i = 0; i < cipher_preferences->count; i++) {
+        if (memcmp(cipher_preferences->suites[i]->iana_value, config->cipher_suite_iana, S2N_TLS_CIPHER_SUITE_LEN) == 0) {
+            match = true;
+            break;
+        }
+    }
+    ENSURE_EQ(match, true);
+
+    /* If early data specifies an application protocol, it must be supported by protocol preferences */
+    if (config->application_protocol.size > 0) {
+        struct s2n_blob *application_protocols = NULL;
+        GUARD_AS_RESULT(s2n_connection_get_protocol_preferences(conn, &application_protocols));
+        ENSURE_REF(application_protocols);
+
+        match = false;
+        GUARD_RESULT(s2n_protocol_preferences_contain(application_protocols, &config->application_protocol, &match));
+        ENSURE_EQ(match, true);
+    }
+
+    return S2N_RESULT_OK;
+}
+
+static bool s2n_client_early_data_indication_should_send(struct s2n_connection *conn)
+{
+    return s2n_result_is_ok(s2n_early_data_config_is_possible(conn))
+            /**
+             *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+             *# A client MUST NOT include the
+             *# "early_data" extension in its followup ClientHello.
+             **/
+            && !s2n_is_hello_retry_handshake(conn)
+            /**
+             *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+             *# When a PSK is used and early data is allowed for that PSK, the client
+             *# can send Application Data in its first flight of messages.  If the
+             *# client opts to do so, it MUST supply both the "pre_shared_key" and
+             *# "early_data" extensions.
+             */
+            && s2n_client_psk_extension.should_send(conn);
+}
+
+static int s2n_client_early_data_indication_is_missing(struct s2n_connection *conn)
+{
+    return S2N_RESULT_TO_POSIX(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_NOT_REQUESTED));
+}
+
+/**
+ * The client version of this extension is empty, so we don't read/write any data.
+ *
+ *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+ *# The "extension_data" field of this extension contains an
+ *# "EarlyDataIndication" value.
+ *#
+ *#    struct {} Empty;
+ *#
+ *#    struct {
+ *#        select (Handshake.msg_type) {
+ **
+ *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+ *#            case client_hello:         Empty;
+ **
+ *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+ *#        };
+ *#    } EarlyDataIndication;
+ **/
+
+static int s2n_client_early_data_indication_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    return S2N_RESULT_TO_POSIX(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_REQUESTED));
+}
+
+static int s2n_client_early_data_indiction_recv(struct s2n_connection *conn, struct s2n_stuffer *in)
+{
+    /**
+     *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+     *# A client MUST NOT include the
+     *# "early_data" extension in its followup ClientHello.
+     **/
+    ENSURE_POSIX(!s2n_is_hello_retry_handshake(conn), S2N_ERR_UNSUPPORTED_EXTENSION);
+
+    return S2N_RESULT_TO_POSIX(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_REQUESTED));
+}
+
+const s2n_extension_type s2n_client_early_data_indication_extension = {
+    .iana_value = TLS_EXTENSION_EARLY_DATA,
+    .is_response = false,
+    .send = s2n_client_early_data_indication_send,
+    .recv = s2n_client_early_data_indiction_recv,
+    .should_send = s2n_client_early_data_indication_should_send,
+    .if_missing = s2n_client_early_data_indication_is_missing,
+};

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -30,6 +30,7 @@
 
 static int s2n_client_psk_send(struct s2n_connection *conn, struct s2n_stuffer *out);
 static int s2n_client_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+static int s2n_client_psk_is_missing(struct s2n_connection *conn);
 
 const s2n_extension_type s2n_client_psk_extension = {
     .iana_value = TLS_EXTENSION_PRE_SHARED_KEY,
@@ -37,8 +38,21 @@ const s2n_extension_type s2n_client_psk_extension = {
     .send = s2n_client_psk_send,
     .recv = s2n_client_psk_recv,
     .should_send = s2n_client_psk_should_send,
-    .if_missing = s2n_extension_noop_if_missing,
+    .if_missing = s2n_client_psk_is_missing,
 };
+
+int s2n_client_psk_is_missing(struct s2n_connection *conn)
+{
+    /**
+     *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+     *# When a PSK is used and early data is allowed for that PSK, the client
+     *# can send Application Data in its first flight of messages.  If the
+     *# client opts to do so, it MUST supply both the "pre_shared_key" and
+     *# "early_data" extensions.
+     */
+    ENSURE_POSIX(conn->early_data_state != S2N_EARLY_DATA_REQUESTED, S2N_ERR_UNSUPPORTED_EXTENSION);
+    return S2N_SUCCESS;
+}
 
 bool s2n_client_psk_should_send(struct s2n_connection *conn)
 {

--- a/tls/extensions/s2n_early_data_indication.h
+++ b/tls/extensions/s2n_early_data_indication.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/extensions/s2n_extension_type.h"
+
+extern const s2n_extension_type s2n_client_early_data_indication_extension;

--- a/tls/extensions/s2n_extension_type.h
+++ b/tls/extensions/s2n_extension_type.h
@@ -64,6 +64,7 @@ static const uint16_t s2n_supported_extensions[] = {
     TLS_QUIC_TRANSPORT_PARAMETERS,
     TLS_EXTENSION_PSK_KEY_EXCHANGE_MODES,
     TLS_EXTENSION_PRE_SHARED_KEY,
+    TLS_EXTENSION_EARLY_DATA,
 };
 
 typedef char s2n_extension_bitfield[S2N_SUPPORTED_EXTENSIONS_BITFIELD_LEN];

--- a/tls/extensions/s2n_extension_type_lists.c
+++ b/tls/extensions/s2n_extension_type_lists.c
@@ -31,6 +31,7 @@
 #include "tls/extensions/s2n_client_supported_groups.h"
 #include "tls/extensions/s2n_client_pq_kem.h"
 #include "tls/extensions/s2n_client_psk.h"
+#include "tls/extensions/s2n_early_data_indication.h"
 #include "tls/extensions/s2n_psk_key_exchange_modes.h"
 #include "tls/extensions/s2n_client_renegotiation_info.h"
 #include "tls/extensions/s2n_ec_point_format.h"
@@ -65,6 +66,7 @@ static const s2n_extension_type *const client_hello_extensions[] = {
         &s2n_client_cookie_extension,
         &s2n_quic_transport_parameters_extension,
         &s2n_psk_key_exchange_modes_extension,
+        &s2n_client_early_data_indication_extension,
         &s2n_client_psk_extension /* MUST be last */
 };
 

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -403,6 +403,11 @@ int s2n_client_hello_send(struct s2n_connection *conn)
      * to be calculated AFTER we finish writing the entire extension list. */
     GUARD_AS_POSIX(s2n_finish_psk_extension(conn));
 
+    /* If early data was not requested as part of the ClientHello, it never will be. */
+    if (conn->early_data_state == S2N_UNKNOWN_EARLY_DATA_STATE) {
+        GUARD_AS_POSIX(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_NOT_REQUESTED));
+    }
+
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -82,3 +82,19 @@ int s2n_psk_set_context(struct s2n_psk *psk, const uint8_t *context, uint16_t si
     memcpy_check(context_blob->data, context, size);
     return S2N_SUCCESS;
 }
+
+S2N_RESULT s2n_early_data_config_clone(struct s2n_psk *new_psk, struct s2n_early_data_config *old_config)
+{
+    ENSURE_REF(old_config);
+
+    GUARD_AS_RESULT(s2n_psk_configure_early_data(new_psk, old_config->max_early_data_size,
+            old_config->cipher_suite_iana[0], old_config->cipher_suite_iana[1]));
+
+    GUARD_AS_RESULT(s2n_psk_set_application_protocol(new_psk, old_config->application_protocol.data,
+            old_config->application_protocol.size));
+
+    GUARD_AS_RESULT(s2n_psk_set_context(new_psk, old_config->context.data,
+            old_config->context.size));
+
+    return S2N_RESULT_OK;
+}

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -31,6 +31,9 @@ const s2n_early_data_state valid_previous_states[] = {
 S2N_RESULT s2n_connection_set_early_data_state(struct s2n_connection *conn, s2n_early_data_state next_state)
 {
     ENSURE_REF(conn);
+    if (conn->early_data_state == next_state) {
+        return S2N_RESULT_OK;
+    }
     ENSURE(next_state < S2N_EARLY_DATA_STATES_COUNT, S2N_ERR_INVALID_EARLY_DATA_STATE);
     ENSURE(next_state != S2N_UNKNOWN_EARLY_DATA_STATE, S2N_ERR_INVALID_EARLY_DATA_STATE);
     ENSURE(conn->early_data_state == valid_previous_states[next_state], S2N_ERR_INVALID_EARLY_DATA_STATE);

--- a/tls/s2n_early_data.h
+++ b/tls/s2n_early_data.h
@@ -21,6 +21,8 @@
 #include "utils/s2n_blob.h"
 #include "utils/s2n_result.h"
 
+struct s2n_psk;
+
 typedef enum {
     S2N_UNKNOWN_EARLY_DATA_STATE = 0,
     S2N_EARLY_DATA_REQUESTED,
@@ -41,10 +43,10 @@ struct s2n_early_data_config {
     struct s2n_blob context;
 };
 S2N_CLEANUP_RESULT s2n_early_data_config_free(struct s2n_early_data_config *config);
+S2N_RESULT s2n_early_data_config_clone(struct s2n_psk *new_psk, struct s2n_early_data_config *old_config);
 
 /* Public Interface -- will be made visible and moved to s2n.h when the 0RTT feature is released */
 
-struct s2n_psk;
 int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data_size,
         uint8_t cipher_suite_first_byte, uint8_t cipher_suite_second_byte);
 int s2n_psk_set_application_protocol(struct s2n_psk *psk, const uint8_t *application_protocol, uint8_t size);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -620,7 +620,7 @@ bool s2n_is_hello_retry_message(struct s2n_connection *conn)
 
 bool s2n_is_hello_retry_handshake(struct s2n_connection *conn)
 {
-    return conn->handshake.handshake_type & HELLO_RETRY_REQUEST;
+    return conn && (conn->handshake.handshake_type & HELLO_RETRY_REQUEST);
 }
 
 static S2N_RESULT s2n_conn_set_tls13_handshake_type(struct s2n_connection *conn) {

--- a/tls/s2n_protocol_preferences.h
+++ b/tls/s2n_protocol_preferences.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <s2n.h>
+
+#include "utils/s2n_result.h"
+
+S2N_RESULT s2n_protocol_preference_read(struct s2n_stuffer *input, struct s2n_blob *protocol);
+S2N_RESULT s2n_protocol_preferences_contain(struct s2n_blob *application_protocols, struct s2n_blob *protocol, bool *match_found);

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -79,7 +79,7 @@ S2N_RESULT s2n_psk_clone(struct s2n_psk *new_psk, struct s2n_psk *original_psk)
         return S2N_RESULT_OK;
     }
     ENSURE_REF(new_psk);
-    GUARD_RESULT(s2n_psk_init(new_psk, original_psk->type));
+    new_psk->type = original_psk->type;
     new_psk->hmac_alg = original_psk->hmac_alg;
     GUARD_AS_RESULT(s2n_psk_set_identity(new_psk, original_psk->identity.data, original_psk->identity.size));
     GUARD_AS_RESULT(s2n_psk_set_secret(new_psk, original_psk->secret.data, original_psk->secret.size));

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -73,6 +73,21 @@ int s2n_psk_set_secret(struct s2n_psk *psk, const uint8_t *secret, uint16_t secr
     return S2N_SUCCESS;
 }
 
+S2N_RESULT s2n_psk_clone(struct s2n_psk *new_psk, struct s2n_psk *original_psk)
+{
+    if (original_psk == NULL) {
+        return S2N_RESULT_OK;
+    }
+    ENSURE_REF(new_psk);
+    GUARD_RESULT(s2n_psk_init(new_psk, original_psk->type));
+    new_psk->hmac_alg = original_psk->hmac_alg;
+    GUARD_AS_RESULT(s2n_psk_set_identity(new_psk, original_psk->identity.data, original_psk->identity.size));
+    GUARD_AS_RESULT(s2n_psk_set_secret(new_psk, original_psk->secret.data, original_psk->secret.size));
+    GUARD_RESULT(s2n_early_data_config_clone(new_psk, &original_psk->early_data_config));
+
+    return S2N_RESULT_OK;
+}
+
 S2N_CLEANUP_RESULT s2n_psk_wipe(struct s2n_psk *psk)
 {
     if (psk == NULL) {
@@ -474,15 +489,9 @@ int s2n_connection_append_psk(struct s2n_connection *conn, struct s2n_psk *input
     }
 
     DEFER_CLEANUP(struct s2n_psk new_psk = { 0 }, s2n_psk_wipe);
-    ENSURE_POSIX(s2n_result_is_ok(s2n_psk_init(&new_psk, S2N_PSK_TYPE_EXTERNAL)), S2N_ERR_INVALID_ARGUMENT);
-    ENSURE_POSIX(s2n_psk_set_identity(&new_psk, input_psk->identity.data, input_psk->identity.size) == S2N_SUCCESS,
-            S2N_ERR_INVALID_ARGUMENT);
-    ENSURE_POSIX(s2n_psk_set_secret(&new_psk, input_psk->secret.data, input_psk->secret.size) == S2N_SUCCESS,
-            S2N_ERR_INVALID_ARGUMENT);
-    new_psk.hmac_alg = input_psk->hmac_alg;
-
+    ENSURE_POSIX(s2n_result_is_ok(s2n_psk_clone(&new_psk, input_psk)), S2N_ERR_INVALID_ARGUMENT);
     GUARD_AS_POSIX(s2n_array_insert_and_copy(psk_list, psk_list->len, &new_psk));
-    ZERO_TO_DISABLE_DEFER_CLEANUP(new_psk);
 
+    ZERO_TO_DISABLE_DEFER_CLEANUP(new_psk);
     return S2N_SUCCESS;
 }

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -46,6 +46,7 @@ struct s2n_psk {
 };
 S2N_RESULT s2n_psk_init(struct s2n_psk *psk, s2n_psk_type type);
 S2N_CLEANUP_RESULT s2n_psk_wipe(struct s2n_psk *psk);
+S2N_RESULT s2n_psk_clone(struct s2n_psk *new_psk, struct s2n_psk *original_psk);
 
 struct s2n_psk_parameters {
     struct s2n_array psk_list;

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -106,6 +106,7 @@
 #define TLS_EXTENSION_RENEGOTIATION_INFO   65281
 
 /* TLS 1.3 extensions from https://tools.ietf.org/html/rfc8446#section-4.2 */
+#define TLS_EXTENSION_EARLY_DATA             42
 #define TLS_EXTENSION_SUPPORTED_VERSIONS     43
 #define TLS_EXTENSION_COOKIE                 44
 #define TLS_EXTENSION_PSK_KEY_EXCHANGE_MODES 45


### PR DESCRIPTION
### Resolved issues:

Partially addresses https://github.com/aws/s2n-tls/issues/2565
Split the change into two because the prerequisite fixes made the diffs long.

### Description of changes: 

Add the ClientHello version of the early data indication extension. The extension itself is empty; the bulk of the logic is in deciding whether or not to send it. We shouldn't send the extension if a valid early data connection could never be negotiated with the configuration required by the first PSK.

### Call-outs:

* **Why allow no-ops in the early data state machine?** It makes retries easier. Re-sending a ClientHello that has already not requested early data should be acceptable; early data is just still not requested.
* **Hello Retries:** There are still issues with hello retries not addressed by this change. I address them separately here: https://github.com/lrstewart/s2n/compare/0rtt_extension_client...lrstewart:0rtt_extension_client_hrr?expand=1
* **Large diff:** If the PR is still too large, I can split the first two commits into a separate PR.

### Testing:

Unit tests and functional tests.

Compliance report:
<img width="409" alt="Screen Shot 2021-02-19 at 6 02 32 PM" src="https://user-images.githubusercontent.com/22861302/108579637-ba5d9980-72dc-11eb-9dc4-331a0f3fe076.png">
<img width="700" alt="Screen Shot 2021-02-19 at 6 02 12 PM" src="https://user-images.githubusercontent.com/22861302/108579634-b92c6c80-72dc-11eb-8822-9d4467602919.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
