### PR TITLE
Parse multiple post-handshake messages in a record

### DIFF
--- a/tests/unit/s2n_post_handshake_test.c
+++ b/tests/unit/s2n_post_handshake_test.c
@@ -108,8 +108,8 @@ int main(int argc, char **argv)
 
         /* Functional test: Multiple post handshake messages can be received in the same record */
         {
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
             conn->actual_protocol_version = S2N_TLS13;
             conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
             uint8_t num_key_updates = 3;
@@ -121,11 +121,9 @@ int main(int argc, char **argv)
                 struct s2n_blob key_update_message = { 0 };
                 EXPECT_SUCCESS(s2n_blob_init(&key_update_message, data, sizeof(data)));
                 EXPECT_SUCCESS(s2n_key_update_write(&key_update_message));
-                EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->out, key_update_message.data, key_update_message.size));
+                EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->in, key_update_message.data, key_update_message.size));
             }
 
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
-            EXPECT_EQUAL(s2n_stuffer_data_available(&conn->in), num_key_updates * (KEY_UPDATE_MESSAGE_SIZE));
             EXPECT_SUCCESS(s2n_post_handshake_recv(conn));
 
             /* All three key update messages have been read */

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -303,4 +303,5 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(output, test_cases[i].expected_output);
         }
     }
+    END_TEST();
 }

--- a/tls/s2n_post_handshake.c
+++ b/tls/s2n_post_handshake.c
@@ -36,12 +36,12 @@ int s2n_post_handshake_recv(struct s2n_connection *conn)
         GUARD(s2n_stuffer_read_uint8(&conn->in, &post_handshake_id));
         GUARD(s2n_stuffer_read_uint24(&conn->in, &message_length));
 
-        struct s2n_blob post_handshake_blob = {0};
+        struct s2n_blob post_handshake_blob = { 0 };
         uint8_t *message_data = s2n_stuffer_raw_read(&conn->in, message_length);
         notnull_check(message_data);
         GUARD(s2n_blob_init(&post_handshake_blob, message_data, message_length));
 
-        struct s2n_stuffer post_handshake_stuffer = {0};
+        struct s2n_stuffer post_handshake_stuffer = { 0 };
         GUARD(s2n_stuffer_init(&post_handshake_stuffer, &post_handshake_blob));
         GUARD(s2n_stuffer_skip_write(&post_handshake_stuffer, message_length));
 

--- a/tls/s2n_post_handshake.c
+++ b/tls/s2n_post_handshake.c
@@ -32,26 +32,28 @@ int s2n_post_handshake_recv(struct s2n_connection *conn)
     uint32_t message_length;
     S2N_ERROR_IF(conn->actual_protocol_version != S2N_TLS13, S2N_ERR_BAD_MESSAGE);
 
-    GUARD(s2n_stuffer_read_uint8(&conn->in, &post_handshake_id));
-    GUARD(s2n_stuffer_read_uint24(&conn->in, &message_length));
+    while(s2n_stuffer_data_available(&conn->in)) {
+        GUARD(s2n_stuffer_read_uint8(&conn->in, &post_handshake_id));
+        GUARD(s2n_stuffer_read_uint24(&conn->in, &message_length));
 
-    struct s2n_blob post_handshake_blob = {0};
-    uint8_t *message_data = s2n_stuffer_raw_read(&conn->in, message_length);
-    notnull_check(message_data);
-    GUARD(s2n_blob_init(&post_handshake_blob, message_data, message_length));
+        struct s2n_blob post_handshake_blob = {0};
+        uint8_t *message_data = s2n_stuffer_raw_read(&conn->in, message_length);
+        notnull_check(message_data);
+        GUARD(s2n_blob_init(&post_handshake_blob, message_data, message_length));
 
-    struct s2n_stuffer post_handshake_stuffer = {0};
-    GUARD(s2n_stuffer_init(&post_handshake_stuffer, &post_handshake_blob));
-    GUARD(s2n_stuffer_skip_write(&post_handshake_stuffer, message_length));
+        struct s2n_stuffer post_handshake_stuffer = {0};
+        GUARD(s2n_stuffer_init(&post_handshake_stuffer, &post_handshake_blob));
+        GUARD(s2n_stuffer_skip_write(&post_handshake_stuffer, message_length));
 
-    switch (post_handshake_id) 
-    {
-        case TLS_KEY_UPDATE:
-            GUARD(s2n_key_update_recv(conn, &post_handshake_stuffer));
-            break;
-        default:
-            /* Ignore all other messages */
-            break;
+        switch (post_handshake_id)
+        {
+            case TLS_KEY_UPDATE:
+                GUARD(s2n_key_update_recv(conn, &post_handshake_stuffer));
+                break;
+            default:
+                /* Ignore all other messages */
+                break;
+        }
     }
 
     return S2N_SUCCESS;


### PR DESCRIPTION
### Resolved issues:

 resolves #2487

### Description of changes: 
Change post_handshake_recv so that it parses multiple post_handshake messages on a single record.
### Call-outs:
s2n sends at most one handshake message per record, which is why I don't test post_handshake_recv by calling post_handshake_send multiple times.
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
Functional test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
