### PR TITLE
Early data config should use cipher suite instead of iana value

### DIFF
--- a/tests/unit/s2n_cipher_suites_test.c
+++ b/tests/unit/s2n_cipher_suites_test.c
@@ -71,5 +71,74 @@ int main()
         }
     }
 
+    /* Test s2n_iana_to_cipher_suite */
+    {
+        /* Safety */
+        {
+            uint8_t iana[S2N_TLS_CIPHER_SUITE_LEN] = { 0 };
+            struct s2n_cipher_suite *cipher_suite = NULL;
+            EXPECT_ERROR_WITH_ERRNO(s2n_iana_to_cipher_suite(NULL, &cipher_suite), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_iana_to_cipher_suite(iana, NULL), S2N_ERR_NULL);
+        }
+
+        /* Known values */
+        {
+            uint8_t null_iana[S2N_TLS_CIPHER_SUITE_LEN] = { 0 };
+            struct s2n_cipher_suite *cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
+            EXPECT_OK(s2n_iana_to_cipher_suite(null_iana, &cipher_suite));
+            EXPECT_EQUAL(cipher_suite, NULL);
+
+            uint8_t tls12_iana[] = { TLS_RSA_WITH_AES_128_CBC_SHA };
+            cipher_suite = NULL;
+            EXPECT_OK(s2n_iana_to_cipher_suite(tls12_iana, &cipher_suite));
+            EXPECT_EQUAL(cipher_suite, &s2n_rsa_with_aes_128_cbc_sha);
+
+            cipher_suite = NULL;
+            EXPECT_OK(s2n_iana_to_cipher_suite(s2n_tls13_aes_256_gcm_sha384.iana_value, &cipher_suite));
+            EXPECT_EQUAL(cipher_suite, &s2n_tls13_aes_256_gcm_sha384);
+        }
+
+        /* Conversion is correct for all supported cipher suites */
+        {
+            struct s2n_cipher_suite *actual_cipher_suite = NULL;
+            struct s2n_cipher_suite *expected_cipher_suite = NULL;
+            for (size_t i = 0; i < cipher_preferences_test_all.count; i++) {
+                expected_cipher_suite = cipher_preferences_test_all.suites[i];
+                actual_cipher_suite = NULL;
+
+                EXPECT_OK(s2n_iana_to_cipher_suite(expected_cipher_suite->iana_value, &actual_cipher_suite));
+                EXPECT_EQUAL(expected_cipher_suite, actual_cipher_suite);
+            }
+        }
+
+        /* Conversion is correct for all possible iana values */
+        {
+            size_t supported_i = 0;
+            struct s2n_cipher_suite *expected_cipher_suite = NULL;
+            struct s2n_cipher_suite *actual_cipher_suite = NULL;
+            uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN] = { 0 };
+            for(size_t i0 = 0; i0 <= UINT8_MAX; i0++) {
+                iana_value[0] = i0;
+                for (size_t i1 = 0; i1 <= UINT8_MAX; i1++) {
+                    iana_value[1] = i1;
+
+                    EXPECT_OK(s2n_iana_to_cipher_suite(iana_value, &actual_cipher_suite));
+
+                    bool is_supported = supported_i < cipher_preferences_test_all.count
+                            && memcmp(iana_value, cipher_preferences_test_all.suites[supported_i]->iana_value, S2N_TLS_CIPHER_SUITE_LEN) == 0;
+                    if (is_supported) {
+                        expected_cipher_suite = cipher_preferences_test_all.suites[supported_i];
+                        supported_i++;
+                    } else {
+                        expected_cipher_suite = NULL;
+                    }
+
+                    EXPECT_EQUAL(expected_cipher_suite, actual_cipher_suite);
+                }
+            }
+            EXPECT_EQUAL(supported_i, cipher_preferences_test_all.count);
+        }
+    }
+
     END_TEST();
 }

--- a/tests/unit/s2n_cipher_suites_test.c
+++ b/tests/unit/s2n_cipher_suites_test.c
@@ -85,7 +85,7 @@ int main()
         {
             uint8_t null_iana[S2N_TLS_CIPHER_SUITE_LEN] = { 0 };
             struct s2n_cipher_suite *cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            EXPECT_OK(s2n_iana_to_cipher_suite(null_iana, &cipher_suite));
+            EXPECT_ERROR_WITH_ERRNO(s2n_iana_to_cipher_suite(null_iana, &cipher_suite), S2N_ERR_CIPHER_NOT_SUPPORTED);
             EXPECT_EQUAL(cipher_suite, NULL);
 
             uint8_t tls12_iana[] = { TLS_RSA_WITH_AES_128_CBC_SHA };
@@ -114,7 +114,6 @@ int main()
         /* Conversion is correct for all possible iana values */
         {
             size_t supported_i = 0;
-            struct s2n_cipher_suite *expected_cipher_suite = NULL;
             struct s2n_cipher_suite *actual_cipher_suite = NULL;
             uint8_t iana_value[S2N_TLS_CIPHER_SUITE_LEN] = { 0 };
             for(size_t i0 = 0; i0 <= UINT8_MAX; i0++) {
@@ -122,18 +121,19 @@ int main()
                 for (size_t i1 = 0; i1 <= UINT8_MAX; i1++) {
                     iana_value[1] = i1;
 
-                    EXPECT_OK(s2n_iana_to_cipher_suite(iana_value, &actual_cipher_suite));
+                    s2n_result r = s2n_iana_to_cipher_suite(iana_value, &actual_cipher_suite);
 
                     bool is_supported = supported_i < cipher_preferences_test_all.count
                             && memcmp(iana_value, cipher_preferences_test_all.suites[supported_i]->iana_value, S2N_TLS_CIPHER_SUITE_LEN) == 0;
                     if (is_supported) {
-                        expected_cipher_suite = cipher_preferences_test_all.suites[supported_i];
+                        EXPECT_OK(r);
+                        EXPECT_EQUAL(actual_cipher_suite, cipher_preferences_test_all.suites[supported_i]);
                         supported_i++;
                     } else {
-                        expected_cipher_suite = NULL;
+                        EXPECT_ERROR_WITH_ERRNO(r, S2N_ERR_CIPHER_NOT_SUPPORTED);
+                        EXPECT_NULL(actual_cipher_suite);
                     }
 
-                    EXPECT_EQUAL(expected_cipher_suite, actual_cipher_suite);
                 }
             }
             EXPECT_EQUAL(supported_i, cipher_preferences_test_all.count);

--- a/tests/unit/s2n_cipher_suites_test.c
+++ b/tests/unit/s2n_cipher_suites_test.c
@@ -71,30 +71,30 @@ int main()
         }
     }
 
-    /* Test s2n_iana_to_cipher_suite */
+    /* Test s2n_cipher_suite_from_iana */
     {
         /* Safety */
         {
             uint8_t iana[S2N_TLS_CIPHER_SUITE_LEN] = { 0 };
             struct s2n_cipher_suite *cipher_suite = NULL;
-            EXPECT_ERROR_WITH_ERRNO(s2n_iana_to_cipher_suite(NULL, &cipher_suite), S2N_ERR_NULL);
-            EXPECT_ERROR_WITH_ERRNO(s2n_iana_to_cipher_suite(iana, NULL), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_cipher_suite_from_iana(NULL, &cipher_suite), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_cipher_suite_from_iana(iana, NULL), S2N_ERR_NULL);
         }
 
         /* Known values */
         {
             uint8_t null_iana[S2N_TLS_CIPHER_SUITE_LEN] = { 0 };
             struct s2n_cipher_suite *cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            EXPECT_ERROR_WITH_ERRNO(s2n_iana_to_cipher_suite(null_iana, &cipher_suite), S2N_ERR_CIPHER_NOT_SUPPORTED);
+            EXPECT_ERROR_WITH_ERRNO(s2n_cipher_suite_from_iana(null_iana, &cipher_suite), S2N_ERR_CIPHER_NOT_SUPPORTED);
             EXPECT_EQUAL(cipher_suite, NULL);
 
             uint8_t tls12_iana[] = { TLS_RSA_WITH_AES_128_CBC_SHA };
             cipher_suite = NULL;
-            EXPECT_OK(s2n_iana_to_cipher_suite(tls12_iana, &cipher_suite));
+            EXPECT_OK(s2n_cipher_suite_from_iana(tls12_iana, &cipher_suite));
             EXPECT_EQUAL(cipher_suite, &s2n_rsa_with_aes_128_cbc_sha);
 
             cipher_suite = NULL;
-            EXPECT_OK(s2n_iana_to_cipher_suite(s2n_tls13_aes_256_gcm_sha384.iana_value, &cipher_suite));
+            EXPECT_OK(s2n_cipher_suite_from_iana(s2n_tls13_aes_256_gcm_sha384.iana_value, &cipher_suite));
             EXPECT_EQUAL(cipher_suite, &s2n_tls13_aes_256_gcm_sha384);
         }
 
@@ -106,7 +106,7 @@ int main()
                 expected_cipher_suite = cipher_preferences_test_all.suites[i];
                 actual_cipher_suite = NULL;
 
-                EXPECT_OK(s2n_iana_to_cipher_suite(expected_cipher_suite->iana_value, &actual_cipher_suite));
+                EXPECT_OK(s2n_cipher_suite_from_iana(expected_cipher_suite->iana_value, &actual_cipher_suite));
                 EXPECT_EQUAL(expected_cipher_suite, actual_cipher_suite);
             }
         }
@@ -121,7 +121,7 @@ int main()
                 for (size_t i1 = 0; i1 <= UINT8_MAX; i1++) {
                     iana_value[1] = i1;
 
-                    s2n_result r = s2n_iana_to_cipher_suite(iana_value, &actual_cipher_suite);
+                    s2n_result r = s2n_cipher_suite_from_iana(iana_value, &actual_cipher_suite);
 
                     bool is_supported = supported_i < cipher_preferences_test_all.count
                             && memcmp(iana_value, cipher_preferences_test_all.suites[supported_i]->iana_value, S2N_TLS_CIPHER_SUITE_LEN) == 0;

--- a/tests/unit/s2n_early_data_test.c
+++ b/tests/unit/s2n_early_data_test.c
@@ -221,16 +221,30 @@ int main(int argc, char **argv)
         /* Set valid configuration */
         {
             uint32_t expected_max_early_data_size = 1000;
-            uint8_t expected_cipher_suite[] = { 0x01, 0xAB };
+            const struct s2n_cipher_suite *expected_cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
-            struct s2n_psk psk = { 0 };
-            EXPECT_SUCCESS(s2n_psk_configure_early_data(&psk, expected_max_early_data_size,
-                    expected_cipher_suite[0], expected_cipher_suite[1]));
+            DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
+            EXPECT_SUCCESS(s2n_psk_configure_early_data(psk, expected_max_early_data_size,
+                    expected_cipher_suite->iana_value[0], expected_cipher_suite->iana_value[1]));
 
-            EXPECT_EQUAL(psk.early_data_config.max_early_data_size, expected_max_early_data_size);
-            EXPECT_EQUAL(psk.early_data_config.protocol_version, S2N_TLS13);
-            EXPECT_BYTEARRAY_EQUAL(psk.early_data_config.cipher_suite_iana, expected_cipher_suite,
-                    sizeof(expected_cipher_suite));
+            EXPECT_EQUAL(psk->early_data_config.max_early_data_size, expected_max_early_data_size);
+            EXPECT_EQUAL(psk->early_data_config.protocol_version, S2N_TLS13);
+            EXPECT_EQUAL(psk->early_data_config.cipher_suite, expected_cipher_suite);
+        }
+
+        /* Set cipher suite must match hmac algorithm */
+        {
+            DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
+            const struct s2n_cipher_suite *cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
+
+            psk->hmac_alg = cipher_suite->prf_alg + 1;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_psk_configure_early_data(psk, 1,
+                    cipher_suite->iana_value[0], cipher_suite->iana_value[1]), S2N_ERR_INVALID_ARGUMENT);
+
+            psk->hmac_alg = cipher_suite->prf_alg;
+            EXPECT_SUCCESS(s2n_psk_configure_early_data(psk, 1,
+                    cipher_suite->iana_value[0], cipher_suite->iana_value[1]));
+            EXPECT_EQUAL(psk->early_data_config.cipher_suite, cipher_suite);
         }
     }
 
@@ -310,6 +324,51 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_psk_set_context(psk, test_value, 0));
         EXPECT_EQUAL(psk->early_data_config.context.size, 0);
         EXPECT_EQUAL(psk->early_data_config.context.allocated, 0);
+    }
+
+    /* Test s2n_early_data_config_clone */
+    {
+        const uint8_t test_bad_value[] = "wrong";
+        const uint8_t test_apln[] = "protocol";
+        const uint8_t test_context[] = "context";
+        const uint32_t test_max_early_data = 10;
+        const struct s2n_cipher_suite *test_cipher_suite = &s2n_tls13_chacha20_poly1305_sha256;
+
+        for (size_t called_directly = 0; called_directly < 2; called_directly++) {
+            struct s2n_psk *original = s2n_external_psk_new();
+            EXPECT_NOT_NULL(original);
+            EXPECT_SUCCESS(s2n_psk_configure_early_data(original, test_max_early_data,
+                    test_cipher_suite->iana_value[0], test_cipher_suite->iana_value[1]));
+            EXPECT_SUCCESS(s2n_psk_set_application_protocol(original, test_apln, sizeof(test_apln)));
+            EXPECT_SUCCESS(s2n_psk_set_context(original, test_context, sizeof(test_context)));
+
+            DEFER_CLEANUP(struct s2n_psk *clone = s2n_external_psk_new(), s2n_psk_free);
+            EXPECT_SUCCESS(s2n_psk_set_application_protocol(clone, test_bad_value, sizeof(test_bad_value)));
+            EXPECT_NOT_NULL(clone);
+
+            if (called_directly) {
+                EXPECT_OK(s2n_early_data_config_clone(clone, &original->early_data_config));
+            } else {
+                EXPECT_SUCCESS(s2n_psk_set_identity(original, test_bad_value, sizeof(test_bad_value)));
+                EXPECT_SUCCESS(s2n_psk_set_secret(original, test_bad_value, sizeof(test_bad_value)));
+                EXPECT_OK(s2n_psk_clone(clone, original));
+            }
+
+            /* Free the original to ensure they share no memory */
+            EXPECT_SUCCESS(s2n_psk_free(&original));
+
+            /* existing alpn is replaced by original's alpn */
+            EXPECT_EQUAL(clone->early_data_config.application_protocol.size, sizeof(test_apln));
+            EXPECT_BYTEARRAY_EQUAL(clone->early_data_config.application_protocol.data, test_apln, sizeof(test_apln));
+
+            /* new context is allocated for original's context */
+            EXPECT_EQUAL(clone->early_data_config.context.size, sizeof(test_context));
+            EXPECT_BYTEARRAY_EQUAL(clone->early_data_config.context.data, test_context, sizeof(test_context));
+
+            /* other values are copied */
+            EXPECT_EQUAL(clone->early_data_config.max_early_data_size, test_max_early_data);
+            EXPECT_EQUAL(clone->early_data_config.cipher_suite, test_cipher_suite);
+        }
     }
 
     END_TEST();

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -115,6 +115,48 @@ int main(int argc, char **argv)
         EXPECT_BYTEARRAY_EQUAL(psk.secret.data, TEST_VALUE_2, sizeof(TEST_VALUE_2));
     }
 
+    /* Test s2n_psk_clone */
+    {
+        const uint8_t test_bad_value[] = "wrong";
+        const uint8_t test_identity[] = "identity";
+        const uint8_t test_secret[] = "secret";
+        const uint8_t test_early_secret[] = "early_secret";
+        const s2n_hmac_algorithm test_hmac = S2N_HMAC_SHA384;
+
+        struct s2n_psk *original = s2n_external_psk_new();
+        EXPECT_NOT_NULL(original);
+        EXPECT_SUCCESS(s2n_psk_set_identity(original, test_identity, sizeof(test_identity)));
+        EXPECT_SUCCESS(s2n_psk_set_secret(original, test_secret, sizeof(test_secret)));
+        EXPECT_SUCCESS(s2n_alloc(&original->early_secret, sizeof(test_early_secret)));
+        EXPECT_MEMCPY_SUCCESS(original->early_secret.data, test_early_secret, original->early_secret.size);
+        original->hmac_alg = test_hmac;
+
+        DEFER_CLEANUP(struct s2n_psk *clone = s2n_external_psk_new(), s2n_psk_free);
+        EXPECT_SUCCESS(s2n_psk_set_identity(clone, test_bad_value, sizeof(test_bad_value)));
+        EXPECT_SUCCESS(s2n_psk_set_secret(clone, test_bad_value, sizeof(test_bad_value)));
+        EXPECT_NOT_NULL(clone);
+
+        EXPECT_OK(s2n_psk_clone(clone, original));
+
+        /* Free the original to ensure they share no memory */
+        EXPECT_SUCCESS(s2n_psk_free(&original));
+
+        /* existing identity is replaced by original's identity */
+        EXPECT_EQUAL(clone->identity.size, sizeof(test_identity));
+        EXPECT_BYTEARRAY_EQUAL(clone->identity.data, test_identity, sizeof(test_identity));
+
+        /* new secret is replaced by original's secret */
+        EXPECT_EQUAL(clone->secret.size, sizeof(test_secret));
+        EXPECT_BYTEARRAY_EQUAL(clone->secret.data, test_secret, sizeof(test_secret));
+
+        /* early secret is allocated for original's early secret */
+        EXPECT_EQUAL(clone->early_secret.size, sizeof(test_early_secret));
+        EXPECT_BYTEARRAY_EQUAL(clone->early_secret.data, test_early_secret, sizeof(test_early_secret));
+
+        /* other values are copied */
+        EXPECT_EQUAL(clone->hmac_alg, test_hmac);
+    }
+
     /* Test s2n_psk_wipe */
     {
         const uint8_t test_value[] = TEST_VALUE_1;

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -136,6 +136,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_psk_set_secret(clone, test_bad_value, sizeof(test_bad_value)));
         EXPECT_NOT_NULL(clone);
 
+        /* Check that the blobs weren't shallow copied */
+        EXPECT_NOT_EQUAL(original->identity.data, clone->identity.data);
+        EXPECT_NOT_EQUAL(original->secret.data, clone->secret.data);
+        EXPECT_NOT_EQUAL(original->early_secret.data, clone->early_secret.data);
+
         EXPECT_OK(s2n_psk_clone(clone, original));
 
         /* Free the original to ensure they share no memory */

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1098,7 +1098,7 @@ S2N_RESULT s2n_iana_to_cipher_suite(const uint8_t iana[], struct s2n_cipher_suit
             low = mid + 1;
         }
     }
-    return S2N_RESULT_OK;
+    BAIL(S2N_ERR_CIPHER_NOT_SUPPORTED);
 }
 
 int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_CIPHER_SUITE_LEN])

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1074,7 +1074,7 @@ int s2n_cipher_suites_cleanup(void)
     return 0;
 }
 
-S2N_RESULT s2n_iana_to_cipher_suite(const uint8_t iana[], struct s2n_cipher_suite **cipher_suite)
+S2N_RESULT s2n_cipher_suite_from_iana(const uint8_t iana[], struct s2n_cipher_suite **cipher_suite)
 {
     ENSURE_REF(cipher_suite);
     *cipher_suite = NULL;

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1074,6 +1074,33 @@ int s2n_cipher_suites_cleanup(void)
     return 0;
 }
 
+S2N_RESULT s2n_iana_to_cipher_suite(const uint8_t iana[], struct s2n_cipher_suite **cipher_suite)
+{
+    ENSURE_REF(cipher_suite);
+    *cipher_suite = NULL;
+    ENSURE_REF(iana);
+
+    int low = 0;
+    int top = s2n_array_len(s2n_all_cipher_suites) - 1;
+
+    /* Perform a textbook binary search */
+    while (low <= top) {
+        /* Check in the middle */
+        size_t mid = low + ((top - low) / 2);
+        int m = memcmp(s2n_all_cipher_suites[mid]->iana_value, iana, S2N_TLS_CIPHER_SUITE_LEN);
+
+        if (m == 0) {
+            *cipher_suite = s2n_all_cipher_suites[mid];
+            return S2N_RESULT_OK;
+        } else if (m > 0) {
+            top = mid - 1;
+        } else if (m < 0) {
+            low = mid + 1;
+        }
+    }
+    return S2N_RESULT_OK;
+}
+
 int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_CIPHER_SUITE_LEN])
 {
     notnull_check(conn);

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -160,7 +160,7 @@ extern struct s2n_cipher_suite s2n_tls13_chacha20_poly1305_sha256;
 
 extern int s2n_cipher_suites_init(void);
 extern int s2n_cipher_suites_cleanup(void);
-S2N_RESULT s2n_iana_to_cipher_suite(const uint8_t iana[S2N_TLS_CIPHER_SUITE_LEN], struct s2n_cipher_suite **cipher_suite);
+S2N_RESULT s2n_cipher_suite_from_iana(const uint8_t iana[S2N_TLS_CIPHER_SUITE_LEN], struct s2n_cipher_suite **cipher_suite);
 extern int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_CIPHER_SUITE_LEN]);
 extern int s2n_set_cipher_as_sslv2_server(struct s2n_connection *conn, uint8_t * wire, uint16_t count);
 extern int s2n_set_cipher_as_tls_server(struct s2n_connection *conn, uint8_t * wire, uint16_t count);

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -160,7 +160,7 @@ extern struct s2n_cipher_suite s2n_tls13_chacha20_poly1305_sha256;
 
 extern int s2n_cipher_suites_init(void);
 extern int s2n_cipher_suites_cleanup(void);
-S2N_RESULT s2n_iana_to_cipher_suite(const uint8_t iana[], struct s2n_cipher_suite **cipher_suite);
+S2N_RESULT s2n_iana_to_cipher_suite(const uint8_t iana[S2N_TLS_CIPHER_SUITE_LEN], struct s2n_cipher_suite **cipher_suite);
 extern int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_CIPHER_SUITE_LEN]);
 extern int s2n_set_cipher_as_sslv2_server(struct s2n_connection *conn, uint8_t * wire, uint16_t count);
 extern int s2n_set_cipher_as_tls_server(struct s2n_connection *conn, uint8_t * wire, uint16_t count);

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -160,6 +160,7 @@ extern struct s2n_cipher_suite s2n_tls13_chacha20_poly1305_sha256;
 
 extern int s2n_cipher_suites_init(void);
 extern int s2n_cipher_suites_cleanup(void);
+S2N_RESULT s2n_iana_to_cipher_suite(const uint8_t iana[], struct s2n_cipher_suite **cipher_suite);
 extern int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_CIPHER_SUITE_LEN]);
 extern int s2n_set_cipher_as_sslv2_server(struct s2n_connection *conn, uint8_t * wire, uint16_t count);
 extern int s2n_set_cipher_as_tls_server(struct s2n_connection *conn, uint8_t * wire, uint16_t count);

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -57,7 +57,7 @@ int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data_si
     const uint8_t cipher_suite_iana[] = { cipher_suite_first_byte, cipher_suite_second_byte };
     struct s2n_cipher_suite *cipher_suite = NULL;
     GUARD_AS_POSIX(s2n_iana_to_cipher_suite(cipher_suite_iana, &cipher_suite));
-    ENSURE_POSIX(cipher_suite != NULL, S2N_ERR_INVALID_ARGUMENT);
+    notnull_check(cipher_suite);
     ENSURE_POSIX(cipher_suite->prf_alg == psk->hmac_alg, S2N_ERR_INVALID_ARGUMENT);
 
     psk->early_data_config.max_early_data_size = max_early_data_size;

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -56,7 +56,7 @@ int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data_si
 
     const uint8_t cipher_suite_iana[] = { cipher_suite_first_byte, cipher_suite_second_byte };
     struct s2n_cipher_suite *cipher_suite = NULL;
-    GUARD_AS_POSIX(s2n_iana_to_cipher_suite(cipher_suite_iana, &cipher_suite));
+    GUARD_AS_POSIX(s2n_cipher_suite_from_iana(cipher_suite_iana, &cipher_suite));
     notnull_check(cipher_suite);
     ENSURE_POSIX(cipher_suite->prf_alg == psk->hmac_alg, S2N_ERR_INVALID_ARGUMENT);
 

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -16,6 +16,7 @@
 #include "tls/s2n_early_data.h"
 
 #include "tls/s2n_connection.h"
+#include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_psk.h"
 #include "utils/s2n_safety.h"
 #include "utils/s2n_mem.h"
@@ -52,10 +53,16 @@ int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data_si
         uint8_t cipher_suite_first_byte, uint8_t cipher_suite_second_byte)
 {
     notnull_check(psk);
+
+    const uint8_t cipher_suite_iana[] = { cipher_suite_first_byte, cipher_suite_second_byte };
+    struct s2n_cipher_suite *cipher_suite = NULL;
+    GUARD_AS_POSIX(s2n_iana_to_cipher_suite(cipher_suite_iana, &cipher_suite));
+    ENSURE_POSIX(cipher_suite != NULL, S2N_ERR_INVALID_ARGUMENT);
+    ENSURE_POSIX(cipher_suite->prf_alg == psk->hmac_alg, S2N_ERR_INVALID_ARGUMENT);
+
     psk->early_data_config.max_early_data_size = max_early_data_size;
     psk->early_data_config.protocol_version = S2N_TLS13;
-    psk->early_data_config.cipher_suite_iana[0] = cipher_suite_first_byte;
-    psk->early_data_config.cipher_suite_iana[1] = cipher_suite_second_byte;
+    psk->early_data_config.cipher_suite = cipher_suite;
     return S2N_SUCCESS;
 }
 
@@ -81,4 +88,25 @@ int s2n_psk_set_context(struct s2n_psk *psk, const uint8_t *context, uint16_t si
     GUARD(s2n_realloc(context_blob, size));
     memcpy_check(context_blob->data, context, size);
     return S2N_SUCCESS;
+}
+
+S2N_RESULT s2n_early_data_config_clone(struct s2n_psk *new_psk, struct s2n_early_data_config *old_config)
+{
+    ENSURE_REF(old_config);
+    ENSURE_REF(new_psk);
+
+    struct s2n_early_data_config config_copy = new_psk->early_data_config;
+
+    /* Copy all fields from the old_config EXCEPT the blobs, which we need to reallocate. */
+    new_psk->early_data_config = *old_config;
+    new_psk->early_data_config.application_protocol = config_copy.application_protocol;
+    new_psk->early_data_config.context = config_copy.context;
+
+    /* Clone / realloc blobs */
+    GUARD_AS_RESULT(s2n_psk_set_application_protocol(new_psk, old_config->application_protocol.data,
+            old_config->application_protocol.size));
+    GUARD_AS_RESULT(s2n_psk_set_context(new_psk, old_config->context.data,
+            old_config->context.size));
+
+    return S2N_RESULT_OK;
 }

--- a/tls/s2n_early_data.h
+++ b/tls/s2n_early_data.h
@@ -21,6 +21,8 @@
 #include "utils/s2n_blob.h"
 #include "utils/s2n_result.h"
 
+struct s2n_psk;
+
 typedef enum {
     S2N_UNKNOWN_EARLY_DATA_STATE = 0,
     S2N_EARLY_DATA_REQUESTED,
@@ -36,15 +38,15 @@ S2N_RESULT s2n_connection_set_early_data_state(struct s2n_connection *conn, s2n_
 struct s2n_early_data_config {
     uint32_t max_early_data_size;
     uint8_t protocol_version;
-    uint8_t cipher_suite_iana[S2N_TLS_CIPHER_SUITE_LEN];
+    struct s2n_cipher_suite *cipher_suite;
     struct s2n_blob application_protocol;
     struct s2n_blob context;
 };
 S2N_CLEANUP_RESULT s2n_early_data_config_free(struct s2n_early_data_config *config);
+S2N_RESULT s2n_early_data_config_clone(struct s2n_psk *new_psk, struct s2n_early_data_config *old_config);
 
 /* Public Interface -- will be made visible and moved to s2n.h when the 0RTT feature is released */
 
-struct s2n_psk;
 int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data_size,
         uint8_t cipher_suite_first_byte, uint8_t cipher_suite_second_byte);
 int s2n_psk_set_application_protocol(struct s2n_psk *psk, const uint8_t *application_protocol, uint8_t size);

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -46,6 +46,7 @@ struct s2n_psk {
 };
 S2N_RESULT s2n_psk_init(struct s2n_psk *psk, s2n_psk_type type);
 S2N_CLEANUP_RESULT s2n_psk_wipe(struct s2n_psk *psk);
+S2N_RESULT s2n_psk_clone(struct s2n_psk *new_psk, struct s2n_psk *original_psk);
 
 struct s2n_psk_parameters {
     struct s2n_array psk_list;


### PR DESCRIPTION
### Description of changes: 

While working on the early data extensions, I found a couple issues with how external PSKs are configured to use early data:
1. Having to compare to a byte array iana value complicated the code. This change switches to storing the early data's required cipher suite as a pointer to the S2N cipher suite structure instead of an iana value. I also added validation that the early data cipher suite matches the PSK hmac algorithm, just to catch one possible customer mistake.
2. s2n_connection_append_psk wasn't cloning the early data config when it cloned the PSK. I corrected this and added tested clone methods. With this change, any new field added to the PSK will be shallow-copied even if the clone method isn't updated, which might prevent this mistake in the future.

### Call-outs:

* **s2n_iana_to_cipher_suite looks familiar 🤔**: It's s2n_cipher_suite_from_wire, back from [the dead](https://github.com/aws/s2n-tls/commit/7a3e8292ded7fd1f118a5c9cdd73f56c79047bf1). We removed it too soon.

### Testing:

Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
