### PR TITLE
Make some alpn operations reuseable

### DIFF
--- a/tests/unit/s2n_protocol_preferences_test.c
+++ b/tests/unit/s2n_protocol_preferences_test.c
@@ -14,7 +14,9 @@
  */
 
 #include "s2n_test.h"
+#include "tls/extensions/s2n_client_alpn.h"
 #include "tls/s2n_connection.h"
+#include "tls/s2n_protocol_preferences.h"
 
 #include <s2n.h>
 
@@ -158,6 +160,137 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(conn->application_protocols_overridden.size, 0);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test s2n_protocol_preference_read */
+    {
+        /* Safety checks */
+        {
+            struct s2n_stuffer stuffer = { 0 };
+            struct s2n_blob blob = { 0 };
+            EXPECT_ERROR_WITH_ERRNO(s2n_protocol_preference_read(NULL, &blob), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_protocol_preference_read(&stuffer, NULL), S2N_ERR_NULL);
+        }
+
+        /* Read malformed value */
+        {
+            struct s2n_stuffer input = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&input, sizeof(protocol1) + 10));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&input, protocol1, sizeof(protocol1)));
+
+            struct s2n_blob result = { 0 };
+            EXPECT_ERROR(s2n_protocol_preference_read(&input, &result));
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&input));
+        }
+
+        /* Read valid value */
+        {
+            struct s2n_stuffer input = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&input, sizeof(protocol1)));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&input, protocol1, sizeof(protocol1)));
+
+            struct s2n_blob result = { 0 };
+            EXPECT_OK(s2n_protocol_preference_read(&input, &result));
+            EXPECT_EQUAL(result.size, sizeof(protocol1));
+            EXPECT_BYTEARRAY_EQUAL(result.data, protocol1, sizeof(protocol1));
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&input));
+        }
+
+        /* Read what we write */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, protocol1, sizeof(protocol1)));
+            EXPECT_SUCCESS(s2n_client_alpn_extension.send(conn, &conn->handshake.io));
+
+            /* Skip list size */
+            EXPECT_SUCCESS(s2n_stuffer_skip_read(&conn->handshake.io, sizeof(uint16_t)));
+
+            struct s2n_blob result = { 0 };
+            EXPECT_OK(s2n_protocol_preference_read(&conn->handshake.io, &result));
+            EXPECT_EQUAL(result.size, sizeof(protocol1));
+            EXPECT_BYTEARRAY_EQUAL(result.data, protocol1, sizeof(protocol1));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    /* s2n_protocol_preferences_contain */
+    {
+        uint8_t protocol3[] = "protocol3";
+        struct s2n_blob target = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&target, protocol3, sizeof(protocol3)));
+
+        /* Safety checks */
+        {
+            struct s2n_blob blob = { 0 };
+            bool match = false;
+            EXPECT_ERROR_WITH_ERRNO(s2n_protocol_preferences_contain(NULL, &blob, &match), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_protocol_preferences_contain(&blob, NULL, &match), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_protocol_preferences_contain(&blob, &blob, NULL), S2N_ERR_NULL);
+        }
+
+        /* No supported protocols */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+
+            bool result = true;
+            EXPECT_OK(s2n_protocol_preferences_contain(&conn->application_protocols_overridden, &target, &result));
+            EXPECT_FALSE(result);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Error: malformed preferences */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, protocol1, sizeof(protocol1)));
+            conn->application_protocols_overridden.size--;
+
+            bool result = true;
+            EXPECT_ERROR(s2n_protocol_preferences_contain(&conn->application_protocols_overridden, &target, &result));
+            EXPECT_FALSE(result);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* No match */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, protocol1, sizeof(protocol1)));
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, protocol2, sizeof(protocol2)));
+
+            bool result = true;
+            EXPECT_OK(s2n_protocol_preferences_contain(&conn->application_protocols_overridden, &target, &result));
+            EXPECT_FALSE(result);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Match */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, protocol1, sizeof(protocol1)));
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, protocol3, sizeof(protocol3)));
+
+            bool result = false;
+            EXPECT_OK(s2n_protocol_preferences_contain(&conn->application_protocols_overridden, &target, &result));
+            EXPECT_TRUE(result);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
     }
 
     END_TEST();

--- a/tls/extensions/s2n_client_alpn.c
+++ b/tls/extensions/s2n_client_alpn.c
@@ -19,6 +19,7 @@
 #include "tls/extensions/s2n_client_alpn.h"
 
 #include "tls/extensions/s2n_extension_type.h"
+#include "tls/s2n_protocol_preferences.h"
 #include "tls/s2n_tls.h"
 #include "tls/s2n_tls_parameters.h"
 
@@ -60,7 +61,6 @@ static int s2n_client_alpn_send(struct s2n_connection *conn, struct s2n_stuffer 
 static int s2n_client_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     uint16_t size_of_all;
-    struct s2n_stuffer client_protos = {0};
     struct s2n_stuffer server_protos = {0};
 
     struct s2n_blob *server_app_protocols;
@@ -83,35 +83,23 @@ static int s2n_client_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer 
     notnull_check(client_app_protocols.data);
 
     /* Find a matching protocol */
-    GUARD(s2n_stuffer_init(&client_protos, &client_app_protocols));
-    GUARD(s2n_stuffer_write(&client_protos, &client_app_protocols));
     GUARD(s2n_stuffer_init(&server_protos, server_app_protocols));
-    GUARD(s2n_stuffer_write(&server_protos, server_app_protocols));
+    GUARD(s2n_stuffer_skip_write(&server_protos, server_app_protocols->size));
 
-    while (s2n_stuffer_data_available(&server_protos)) {
-        uint8_t length;
-        uint8_t server_protocol[255];
-        GUARD(s2n_stuffer_read_uint8(&server_protos, &length));
-        GUARD(s2n_stuffer_read_bytes(&server_protos, server_protocol, length));
+    while (s2n_stuffer_data_available(&server_protos) > 0) {
+        struct s2n_blob server_protocol = { 0 };
+        ENSURE_POSIX(s2n_result_is_ok(s2n_protocol_preference_read(&server_protos, &server_protocol)),
+                S2N_ERR_BAD_MESSAGE);
 
-        while (s2n_stuffer_data_available(&client_protos)) {
-            uint8_t client_length;
-            GUARD(s2n_stuffer_read_uint8(&client_protos, &client_length));
-            S2N_ERROR_IF(client_length > s2n_stuffer_data_available(&client_protos), S2N_ERR_BAD_MESSAGE);
-            if (client_length != length) {
-                GUARD(s2n_stuffer_skip_read(&client_protos, client_length));
-            } else {
-                uint8_t client_protocol[255];
-                GUARD(s2n_stuffer_read_bytes(&client_protos, client_protocol, client_length));
-                if (memcmp(client_protocol, server_protocol, client_length) == 0) {
-                    memcpy_check(conn->application_protocol, client_protocol, client_length);
-                    conn->application_protocol[client_length] = '\0';
-                    return S2N_SUCCESS;
-                }
-            }
+        bool is_match = false;
+        ENSURE_POSIX(s2n_result_is_ok(s2n_protocol_preferences_contain(&client_app_protocols, &server_protocol, &is_match)),
+                S2N_ERR_BAD_MESSAGE);
+
+        if (is_match) {
+            memcpy_check(conn->application_protocol, server_protocol.data, server_protocol.size);
+            conn->application_protocol[server_protocol.size] = '\0';
+            return S2N_SUCCESS;
         }
-
-        GUARD(s2n_stuffer_reread(&client_protos));
     }
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_client_alpn.c
+++ b/tls/extensions/s2n_client_alpn.c
@@ -88,7 +88,7 @@ static int s2n_client_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer 
 
     while (s2n_stuffer_data_available(&server_protos) > 0) {
         struct s2n_blob server_protocol = { 0 };
-        ENSURE_POSIX(s2n_result_is_ok(s2n_protocol_preference_read(&server_protos, &server_protocol)),
+        ENSURE_POSIX(s2n_result_is_ok(s2n_protocol_preferences_read(&server_protos, &server_protocol)),
                 S2N_ERR_BAD_MESSAGE);
 
         bool is_match = false;

--- a/tls/s2n_protocol_preferences.c
+++ b/tls/s2n_protocol_preferences.c
@@ -17,6 +17,45 @@
 #include "error/s2n_errno.h"
 #include "utils/s2n_safety.h"
 
+S2N_RESULT s2n_protocol_preference_read(struct s2n_stuffer *input, struct s2n_blob *protocol)
+{
+    ENSURE_REF(input);
+    ENSURE_REF(protocol);
+
+    uint8_t length = 0;
+    GUARD_AS_RESULT(s2n_stuffer_read_uint8(input, &length));
+    ENSURE_GT(length, 0);
+
+    uint8_t *data = s2n_stuffer_raw_read(input, length);
+    ENSURE_REF(data);
+
+    GUARD_AS_RESULT(s2n_blob_init(protocol, data, length));
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_protocol_preferences_contain(struct s2n_blob *application_protocols, struct s2n_blob *protocol, bool *match_found)
+{
+    ENSURE_REF(match_found);
+    *match_found = false;
+    ENSURE_REF(application_protocols);
+    ENSURE_REF(protocol);
+
+    struct s2n_stuffer app_protocols_stuffer = { 0 };
+    GUARD_AS_RESULT(s2n_stuffer_init(&app_protocols_stuffer, application_protocols));
+    GUARD_AS_RESULT(s2n_stuffer_skip_write(&app_protocols_stuffer, application_protocols->size));
+
+    while (s2n_stuffer_data_available(&app_protocols_stuffer) > 0) {
+        struct s2n_blob match_against = { 0 };
+        GUARD_RESULT(s2n_protocol_preference_read(&app_protocols_stuffer, &match_against));
+
+        if (match_against.size == protocol->size && memcmp(match_against.data, protocol->data, protocol->size) == 0) {
+            *match_found = true;
+            return S2N_RESULT_OK;
+        }
+    }
+    return S2N_RESULT_OK;
+}
+
 S2N_RESULT s2n_protocol_preferences_append(struct s2n_blob *application_protocols, const uint8_t *protocol, uint8_t protocol_len)
 {
     ENSURE_MUT(application_protocols);

--- a/tls/s2n_protocol_preferences.c
+++ b/tls/s2n_protocol_preferences.c
@@ -17,39 +17,39 @@
 #include "error/s2n_errno.h"
 #include "utils/s2n_safety.h"
 
-S2N_RESULT s2n_protocol_preference_read(struct s2n_stuffer *input, struct s2n_blob *protocol)
+S2N_RESULT s2n_protocol_preferences_read(struct s2n_stuffer *protocol_preferences, struct s2n_blob *protocol)
 {
-    ENSURE_REF(input);
+    ENSURE_REF(protocol_preferences);
     ENSURE_REF(protocol);
 
     uint8_t length = 0;
-    GUARD_AS_RESULT(s2n_stuffer_read_uint8(input, &length));
+    GUARD_AS_RESULT(s2n_stuffer_read_uint8(protocol_preferences, &length));
     ENSURE_GT(length, 0);
 
-    uint8_t *data = s2n_stuffer_raw_read(input, length);
+    uint8_t *data = s2n_stuffer_raw_read(protocol_preferences, length);
     ENSURE_REF(data);
 
     GUARD_AS_RESULT(s2n_blob_init(protocol, data, length));
     return S2N_RESULT_OK;
 }
 
-S2N_RESULT s2n_protocol_preferences_contain(struct s2n_blob *application_protocols, struct s2n_blob *protocol, bool *match_found)
+S2N_RESULT s2n_protocol_preferences_contain(struct s2n_blob *protocol_preferences, struct s2n_blob *protocol, bool *contains)
 {
-    ENSURE_REF(match_found);
-    *match_found = false;
-    ENSURE_REF(application_protocols);
+    ENSURE_REF(contains);
+    *contains = false;
+    ENSURE_REF(protocol_preferences);
     ENSURE_REF(protocol);
 
     struct s2n_stuffer app_protocols_stuffer = { 0 };
-    GUARD_AS_RESULT(s2n_stuffer_init(&app_protocols_stuffer, application_protocols));
-    GUARD_AS_RESULT(s2n_stuffer_skip_write(&app_protocols_stuffer, application_protocols->size));
+    GUARD_AS_RESULT(s2n_stuffer_init(&app_protocols_stuffer, protocol_preferences));
+    GUARD_AS_RESULT(s2n_stuffer_skip_write(&app_protocols_stuffer, protocol_preferences->size));
 
     while (s2n_stuffer_data_available(&app_protocols_stuffer) > 0) {
         struct s2n_blob match_against = { 0 };
-        GUARD_RESULT(s2n_protocol_preference_read(&app_protocols_stuffer, &match_against));
+        GUARD_RESULT(s2n_protocol_preferences_read(&app_protocols_stuffer, &match_against));
 
         if (match_against.size == protocol->size && memcmp(match_against.data, protocol->data, protocol->size) == 0) {
-            *match_found = true;
+            *contains = true;
             return S2N_RESULT_OK;
         }
     }

--- a/tls/s2n_protocol_preferences.h
+++ b/tls/s2n_protocol_preferences.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <s2n.h>
+
+#include "utils/s2n_result.h"
+
+S2N_RESULT s2n_protocol_preference_read(struct s2n_stuffer *input, struct s2n_blob *protocol);
+S2N_RESULT s2n_protocol_preferences_contain(struct s2n_blob *application_protocols, struct s2n_blob *protocol, bool *match_found);

--- a/tls/s2n_protocol_preferences.h
+++ b/tls/s2n_protocol_preferences.h
@@ -19,5 +19,5 @@
 
 #include "utils/s2n_result.h"
 
-S2N_RESULT s2n_protocol_preference_read(struct s2n_stuffer *input, struct s2n_blob *protocol);
-S2N_RESULT s2n_protocol_preferences_contain(struct s2n_blob *application_protocols, struct s2n_blob *protocol, bool *match_found);
+S2N_RESULT s2n_protocol_preferences_read(struct s2n_stuffer *protocol_preferences, struct s2n_blob *protocol);
+S2N_RESULT s2n_protocol_preferences_contain(struct s2n_blob *protocol_preferences, struct s2n_blob *protocol, bool *contains);


### PR DESCRIPTION
### Description of changes: 

The client version of the early data extension needs to be able to check that a given alpn value is supported by the connection's alpn preferences. Currently, that logic lives in the client alpn extension. This change moves it out of that extension into a more general set of functions that the early data extension can leverage.

### Call-outs:

* These functions are only currently used by the client alpn extension. The early data extension will be added in a separate commit.

### Testing:

New unit tests to verify the functions I abstracted out. I didn't change the existing client alpn tests, and they continue to pass.
