### PR TITLE
Add client early data indication extension

### DIFF
--- a/tests/unit/s2n_client_early_data_indication_test.c
+++ b/tests/unit/s2n_client_early_data_indication_test.c
@@ -1,0 +1,294 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "tls/extensions/s2n_early_data_indication.h"
+#include "tls/extensions/s2n_client_psk.h"
+#include "tls/s2n_tls13.h"
+#include "tls/s2n_tls.h"
+
+#define TEST_VALUE "test"
+
+static S2N_RESULT s2n_append_test_psk(struct s2n_connection *conn, uint32_t max_early_data,
+        const struct s2n_cipher_suite *cipher_suite)
+{
+    /* We're assuming the index will only take one digit */
+    ENSURE_LT(conn->psk_params.psk_list.len, 10);
+    uint8_t buffer[sizeof(TEST_VALUE) + 1] = { 0 };
+    snprintf((char*) buffer, sizeof(buffer), "%s%u", TEST_VALUE, conn->psk_params.psk_list.len);
+
+    DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
+    GUARD_AS_RESULT(s2n_psk_set_identity(psk, buffer, sizeof(buffer)));
+    GUARD_AS_RESULT(s2n_psk_set_secret(psk, buffer, sizeof(buffer)));
+    psk->hmac_alg = cipher_suite->prf_alg;
+    if (max_early_data > 0) {
+        GUARD_AS_RESULT(s2n_psk_configure_early_data(psk, max_early_data,
+                cipher_suite->iana_value[0], cipher_suite->iana_value[1]));
+    }
+    GUARD_AS_RESULT(s2n_connection_append_psk(conn, psk));
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_set_early_data_app_protocol(struct s2n_connection *conn, struct s2n_blob *app_protocol)
+{
+    struct s2n_psk *psk = NULL;
+    GUARD_RESULT(s2n_array_get(&conn->psk_params.psk_list, 0, (void**) &psk));
+    GUARD_AS_RESULT(s2n_psk_set_application_protocol(psk, app_protocol->data, app_protocol->size));
+    return S2N_RESULT_OK;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test s2n_client_early_data_indication_should_send */
+    {
+        /* Safety check */
+        EXPECT_FALSE(s2n_client_early_data_indication_extension.should_send(NULL));
+
+        const uint32_t nonzero_max_early_data = 10;
+
+        /* All checks pass: send extension */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_psk(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384));
+
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /** Don't send if no PSK extension is sent.
+         *
+         *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+         *= type=test
+         *# When a PSK is used and early data is allowed for that PSK, the client
+         *# can send Application Data in its first flight of messages.  If the
+         *# client opts to do so, it MUST supply both the "pre_shared_key" and
+         *# "early_data" extensions.
+         */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+
+            EXPECT_FALSE(s2n_client_psk_extension.should_send(conn));
+            EXPECT_FALSE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /** Don't send when performing a retry.
+         *
+         *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+         *= type=test
+         *# A client MUST NOT include the
+         *# "early_data" extension in its followup ClientHello.
+         */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_psk(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384));
+
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_set_hello_retry_required(conn));
+            EXPECT_FALSE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Don't send if no early data allowed by first PSK */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+
+            EXPECT_OK(s2n_append_test_psk(conn, 0, &s2n_tls13_aes_256_gcm_sha384));
+            EXPECT_OK(s2n_append_test_psk(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384));
+            EXPECT_FALSE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_OK(s2n_psk_parameters_wipe(&conn->psk_params));
+            EXPECT_OK(s2n_append_test_psk(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384));
+            EXPECT_OK(s2n_append_test_psk(conn, 0, &s2n_tls13_aes_256_gcm_sha384));
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Don't send if protocol version too low */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_psk(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384));
+
+            conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_FALSE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            conn->actual_protocol_version = S2N_TLS13;
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            conn->actual_protocol_version = S2N_TLS13 + 1;
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Don't send if cipher suite not allowed by cipher preferences */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+
+            EXPECT_OK(s2n_append_test_psk(conn, nonzero_max_early_data, &s2n_rsa_with_rc4_128_md5));
+            EXPECT_FALSE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_OK(s2n_psk_parameters_wipe(&conn->psk_params));
+            EXPECT_OK(s2n_append_test_psk(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384));
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Don't send if application layer protocol not allowed by preferences */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_psk(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384));
+
+            uint8_t app_protocol_data[] = "protocol preference";
+            uint8_t other_app_protocol_data[] = "different protocol";
+            struct s2n_blob app_protocol = { 0 }, empty_app_protocol = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&app_protocol, app_protocol_data, sizeof(app_protocol_data)));
+
+            /* No early data alp, empty alpn preferences: send */
+            EXPECT_OK(s2n_set_early_data_app_protocol(conn, &empty_app_protocol));
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            /* Early data alp, empty alpn preferences: don't send */
+            EXPECT_OK(s2n_set_early_data_app_protocol(conn, &app_protocol));
+            EXPECT_FALSE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, other_app_protocol_data,
+                    sizeof(other_app_protocol_data)));
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, other_app_protocol_data,
+                    sizeof(other_app_protocol_data)));
+
+            /* No early data alp, non-empty alpn preferences: send */
+            EXPECT_OK(s2n_set_early_data_app_protocol(conn, &empty_app_protocol));
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            /* alpn preferences don't contain alp: don't send */
+            EXPECT_OK(s2n_set_early_data_app_protocol(conn, &app_protocol));
+            EXPECT_FALSE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_append_protocol_preference(conn, app_protocol.data, app_protocol.size));
+
+            /* alpn preferences contain alp: send */
+            EXPECT_OK(s2n_set_early_data_app_protocol(conn, &app_protocol));
+            EXPECT_TRUE(s2n_client_early_data_indication_extension.should_send(conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    /* Test s2n_client_early_data_indiction_recv */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(conn);
+        conn->actual_protocol_version = S2N_TLS13;
+
+        /* Successful if not retry */
+        conn->early_data_state = S2N_UNKNOWN_EARLY_DATA_STATE;
+        EXPECT_SUCCESS(s2n_client_early_data_indication_extension.recv(conn, NULL));
+        EXPECT_EQUAL(conn->early_data_state, S2N_EARLY_DATA_REQUESTED);
+
+        /**
+         *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+         *= type=test
+         *# A client MUST NOT include the
+         *# "early_data" extension in its followup ClientHello.
+         */
+        conn->early_data_state = S2N_UNKNOWN_EARLY_DATA_STATE;
+        EXPECT_SUCCESS(s2n_set_hello_retry_required(conn));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_client_early_data_indication_extension.recv(conn, NULL),
+                S2N_ERR_UNSUPPORTED_EXTENSION);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test state transitions */
+    {
+        /* When early data requested */
+        {
+            struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(client_conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_psk(client_conn, 1, &s2n_tls13_aes_256_gcm_sha384));
+            EXPECT_EQUAL(client_conn->early_data_state, S2N_UNKNOWN_EARLY_DATA_STATE);
+
+            struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(server_conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_psk(server_conn, 1, &s2n_tls13_aes_256_gcm_sha384));
+            EXPECT_EQUAL(server_conn->early_data_state, S2N_UNKNOWN_EARLY_DATA_STATE);
+
+            EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
+                    s2n_stuffer_data_available(&client_conn->handshake.io)));
+            EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+
+            EXPECT_EQUAL(client_conn->early_data_state, S2N_EARLY_DATA_REQUESTED);
+            EXPECT_EQUAL(server_conn->early_data_state, S2N_EARLY_DATA_REQUESTED);
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+
+        /* When early data not requested */
+        {
+            struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(client_conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_psk(client_conn, 0, &s2n_tls13_aes_256_gcm_sha384));
+            EXPECT_EQUAL(client_conn->early_data_state, S2N_UNKNOWN_EARLY_DATA_STATE);
+
+            struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(server_conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_psk(server_conn, 0, &s2n_tls13_aes_256_gcm_sha384));
+            EXPECT_EQUAL(server_conn->early_data_state, S2N_UNKNOWN_EARLY_DATA_STATE);
+
+            EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
+                    s2n_stuffer_data_available(&client_conn->handshake.io)));
+            EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+
+            EXPECT_EQUAL(client_conn->early_data_state, S2N_EARLY_DATA_NOT_REQUESTED);
+            EXPECT_EQUAL(server_conn->early_data_state, S2N_EARLY_DATA_NOT_REQUESTED);
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_client_early_data_indication_test.c
+++ b/tests/unit/s2n_client_early_data_indication_test.c
@@ -26,10 +26,14 @@
 static S2N_RESULT s2n_append_test_psk(struct s2n_connection *conn, uint32_t max_early_data,
         const struct s2n_cipher_suite *cipher_suite)
 {
+    ENSURE_REF(conn);
+    ENSURE_REF(cipher_suite);
+
     /* We're assuming the index will only take one digit */
-    ENSURE_LT(conn->psk_params.psk_list.len, 10);
     uint8_t buffer[sizeof(TEST_VALUE) + 1] = { 0 };
-    snprintf((char*) buffer, sizeof(buffer), "%s%u", TEST_VALUE, conn->psk_params.psk_list.len);
+    int r = snprintf((char*) buffer, sizeof(buffer), "%s%u", TEST_VALUE, conn->psk_params.psk_list.len);
+    ENSURE_GT(r, 0);
+    ENSURE_LT(r, sizeof(buffer));
 
     DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
     GUARD_AS_RESULT(s2n_psk_set_identity(psk, buffer, sizeof(buffer)));
@@ -45,6 +49,9 @@ static S2N_RESULT s2n_append_test_psk(struct s2n_connection *conn, uint32_t max_
 
 static S2N_RESULT s2n_set_early_data_app_protocol(struct s2n_connection *conn, struct s2n_blob *app_protocol)
 {
+    ENSURE_REF(conn);
+    ENSURE_REF(app_protocol);
+
     struct s2n_psk *psk = NULL;
     GUARD_RESULT(s2n_array_get(&conn->psk_params.psk_list, 0, (void**) &psk));
     GUARD_AS_RESULT(s2n_psk_set_application_protocol(psk, app_protocol->data, app_protocol->size));

--- a/tls/extensions/s2n_client_early_data_indication.c
+++ b/tls/extensions/s2n_client_early_data_indication.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <s2n.h>
+
+#include "tls/extensions/s2n_early_data_indication.h"
+
+#include "tls/extensions/s2n_client_psk.h"
+#include "tls/s2n_cipher_suites.h"
+#include "tls/s2n_early_data.h"
+#include "tls/s2n_protocol_preferences.h"
+#include "tls/s2n_tls13.h"
+#include "utils/s2n_safety.h"
+
+static S2N_RESULT s2n_early_data_config_is_possible(struct s2n_connection *conn)
+{
+    ENSURE_REF(conn);
+
+    struct s2n_psk *first_psk = NULL;
+    GUARD_RESULT(s2n_array_get(&conn->psk_params.psk_list, 0, (void**) &first_psk));
+    ENSURE_REF(first_psk);
+
+    struct s2n_early_data_config *config = &first_psk->early_data_config;
+
+    /* Must support early data */
+    ENSURE_GT(config->max_early_data_size, 0);
+
+    /* Early data must require a protocol than we could negotiate */
+    ENSURE_GTE(s2n_connection_get_protocol_version(conn), config->protocol_version);
+    ENSURE_GTE(s2n_connection_get_protocol_version(conn), S2N_TLS13);
+
+    const struct s2n_cipher_preferences *cipher_preferences = NULL;
+    GUARD_AS_RESULT(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+    ENSURE_REF(cipher_preferences);
+
+    /* Early data must require a supported cipher */
+    bool match = false;
+    for (uint8_t i = 0; i < cipher_preferences->count; i++) {
+        if (cipher_preferences->suites[i] == config->cipher_suite) {
+            match = true;
+            break;
+        }
+    }
+    ENSURE_EQ(match, true);
+
+    /* If early data specifies an application protocol, it must be supported by protocol preferences */
+    if (config->application_protocol.size > 0) {
+        struct s2n_blob *application_protocols = NULL;
+        GUARD_AS_RESULT(s2n_connection_get_protocol_preferences(conn, &application_protocols));
+        ENSURE_REF(application_protocols);
+
+        match = false;
+        GUARD_RESULT(s2n_protocol_preferences_contain(application_protocols, &config->application_protocol, &match));
+        ENSURE_EQ(match, true);
+    }
+
+    return S2N_RESULT_OK;
+}
+
+static bool s2n_client_early_data_indication_should_send(struct s2n_connection *conn)
+{
+    return s2n_result_is_ok(s2n_early_data_config_is_possible(conn))
+            /**
+             *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+             *# A client MUST NOT include the
+             *# "early_data" extension in its followup ClientHello.
+             **/
+            && !s2n_is_hello_retry_handshake(conn)
+            /**
+             *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+             *# When a PSK is used and early data is allowed for that PSK, the client
+             *# can send Application Data in its first flight of messages.  If the
+             *# client opts to do so, it MUST supply both the "pre_shared_key" and
+             *# "early_data" extensions.
+             */
+            && s2n_client_psk_extension.should_send(conn);
+}
+
+static int s2n_client_early_data_indication_is_missing(struct s2n_connection *conn)
+{
+    return S2N_RESULT_TO_POSIX(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_NOT_REQUESTED));
+}
+
+/**
+ * The client version of this extension is empty, so we don't read/write any data.
+ *
+ *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+ *# The "extension_data" field of this extension contains an
+ *# "EarlyDataIndication" value.
+ *#
+ *#     struct {} Empty;
+ *#
+ *#     struct {
+ *#         select (Handshake.msg_type) {
+ **
+ *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+ *#             case client_hello:         Empty;
+ **
+ *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+ *#         };
+ *#     } EarlyDataIndication;
+ **/
+
+static int s2n_client_early_data_indication_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    return S2N_RESULT_TO_POSIX(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_REQUESTED));
+}
+
+static int s2n_client_early_data_indiction_recv(struct s2n_connection *conn, struct s2n_stuffer *in)
+{
+    /**
+     *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+     *# A client MUST NOT include the
+     *# "early_data" extension in its followup ClientHello.
+     */
+    ENSURE_POSIX(!s2n_is_hello_retry_handshake(conn), S2N_ERR_UNSUPPORTED_EXTENSION);
+
+    return S2N_RESULT_TO_POSIX(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_REQUESTED));
+}
+
+const s2n_extension_type s2n_client_early_data_indication_extension = {
+    .iana_value = TLS_EXTENSION_EARLY_DATA,
+    .is_response = false,
+    .send = s2n_client_early_data_indication_send,
+    .recv = s2n_client_early_data_indiction_recv,
+    .should_send = s2n_client_early_data_indication_should_send,
+    .if_missing = s2n_client_early_data_indication_is_missing,
+};

--- a/tls/extensions/s2n_client_early_data_indication.c
+++ b/tls/extensions/s2n_client_early_data_indication.c
@@ -32,13 +32,13 @@ static S2N_RESULT s2n_early_data_config_is_possible(struct s2n_connection *conn)
     GUARD_RESULT(s2n_array_get(&conn->psk_params.psk_list, 0, (void**) &first_psk));
     ENSURE_REF(first_psk);
 
-    struct s2n_early_data_config *config = &first_psk->early_data_config;
+    struct s2n_early_data_config *early_data_config = &first_psk->early_data_config;
 
     /* Must support early data */
-    ENSURE_GT(config->max_early_data_size, 0);
+    ENSURE_GT(early_data_config->max_early_data_size, 0);
 
     /* Early data must require a protocol than we could negotiate */
-    ENSURE_GTE(s2n_connection_get_protocol_version(conn), config->protocol_version);
+    ENSURE_GTE(s2n_connection_get_protocol_version(conn), early_data_config->protocol_version);
     ENSURE_GTE(s2n_connection_get_protocol_version(conn), S2N_TLS13);
 
     const struct s2n_cipher_preferences *cipher_preferences = NULL;
@@ -48,7 +48,7 @@ static S2N_RESULT s2n_early_data_config_is_possible(struct s2n_connection *conn)
     /* Early data must require a supported cipher */
     bool match = false;
     for (uint8_t i = 0; i < cipher_preferences->count; i++) {
-        if (cipher_preferences->suites[i] == config->cipher_suite) {
+        if (cipher_preferences->suites[i] == early_data_config->cipher_suite) {
             match = true;
             break;
         }
@@ -56,13 +56,13 @@ static S2N_RESULT s2n_early_data_config_is_possible(struct s2n_connection *conn)
     ENSURE_EQ(match, true);
 
     /* If early data specifies an application protocol, it must be supported by protocol preferences */
-    if (config->application_protocol.size > 0) {
+    if (early_data_config->application_protocol.size > 0) {
         struct s2n_blob *application_protocols = NULL;
         GUARD_AS_RESULT(s2n_connection_get_protocol_preferences(conn, &application_protocols));
         ENSURE_REF(application_protocols);
 
         match = false;
-        GUARD_RESULT(s2n_protocol_preferences_contain(application_protocols, &config->application_protocol, &match));
+        GUARD_RESULT(s2n_protocol_preferences_contain(application_protocols, &early_data_config->application_protocol, &match));
         ENSURE_EQ(match, true);
     }
 

--- a/tls/extensions/s2n_early_data_indication.h
+++ b/tls/extensions/s2n_early_data_indication.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/extensions/s2n_extension_type.h"
+
+extern const s2n_extension_type s2n_client_early_data_indication_extension;

--- a/tls/extensions/s2n_extension_type.h
+++ b/tls/extensions/s2n_extension_type.h
@@ -64,6 +64,7 @@ static const uint16_t s2n_supported_extensions[] = {
     TLS_QUIC_TRANSPORT_PARAMETERS,
     TLS_EXTENSION_PSK_KEY_EXCHANGE_MODES,
     TLS_EXTENSION_PRE_SHARED_KEY,
+    TLS_EXTENSION_EARLY_DATA,
 };
 
 typedef char s2n_extension_bitfield[S2N_SUPPORTED_EXTENSIONS_BITFIELD_LEN];

--- a/tls/extensions/s2n_extension_type_lists.c
+++ b/tls/extensions/s2n_extension_type_lists.c
@@ -31,6 +31,7 @@
 #include "tls/extensions/s2n_client_supported_groups.h"
 #include "tls/extensions/s2n_client_pq_kem.h"
 #include "tls/extensions/s2n_client_psk.h"
+#include "tls/extensions/s2n_early_data_indication.h"
 #include "tls/extensions/s2n_psk_key_exchange_modes.h"
 #include "tls/extensions/s2n_client_renegotiation_info.h"
 #include "tls/extensions/s2n_ec_point_format.h"
@@ -65,6 +66,7 @@ static const s2n_extension_type *const client_hello_extensions[] = {
         &s2n_client_cookie_extension,
         &s2n_quic_transport_parameters_extension,
         &s2n_psk_key_exchange_modes_extension,
+        &s2n_client_early_data_indication_extension,
         &s2n_client_psk_extension /* MUST be last */
 };
 

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -403,6 +403,11 @@ int s2n_client_hello_send(struct s2n_connection *conn)
      * to be calculated AFTER we finish writing the entire extension list. */
     GUARD_AS_POSIX(s2n_finish_psk_extension(conn));
 
+    /* If early data was not requested as part of the ClientHello, it never will be. */
+    if (conn->early_data_state == S2N_UNKNOWN_EARLY_DATA_STATE) {
+        GUARD_AS_POSIX(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_NOT_REQUESTED));
+    }
+
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -620,7 +620,7 @@ bool s2n_is_hello_retry_message(struct s2n_connection *conn)
 
 bool s2n_is_hello_retry_handshake(struct s2n_connection *conn)
 {
-    return conn->handshake.handshake_type & HELLO_RETRY_REQUEST;
+    return conn && (conn->handshake.handshake_type & HELLO_RETRY_REQUEST);
 }
 
 static S2N_RESULT s2n_conn_set_tls13_handshake_type(struct s2n_connection *conn) {

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -106,6 +106,7 @@
 #define TLS_EXTENSION_RENEGOTIATION_INFO   65281
 
 /* TLS 1.3 extensions from https://tools.ietf.org/html/rfc8446#section-4.2 */
+#define TLS_EXTENSION_EARLY_DATA             42
 #define TLS_EXTENSION_SUPPORTED_VERSIONS     43
 #define TLS_EXTENSION_COOKIE                 44
 #define TLS_EXTENSION_PSK_KEY_EXCHANGE_MODES 45


### PR DESCRIPTION
### Resolved issues:
partially addresses https://github.com/aws/s2n-tls/issues/2565

### Description of changes: 

Add the empty client early_data_indication extension. The bulk of the extension's logic revolves around whether or not to send the extension. We should only send it if there exists a valid set of parameters we could negotiate to meet the early data requirements.

### Callouts:
* There are still some HRR issues un-addressed; this PR only prevents the extension from being sent on a retry. The complete HRR story will be addressed separately.

### Testing:

Unit + functional tests.
