### PR TITLE
Make HRRs work with early data

### DIFF
--- a/tests/unit/s2n_client_key_share_extension_pq_test.c
+++ b/tests/unit/s2n_client_key_share_extension_pq_test.c
@@ -30,6 +30,7 @@
 #include "pq-crypto/s2n_pq.h"
 
 #define HELLO_RETRY_MSG_NO 1
+#define MEM_FOR_EXTENSION 4096
 
 static int s2n_generate_pq_hybrid_key_share_for_test(struct s2n_stuffer *out, struct s2n_kem_group_params *kem_group_params);
 static int s2n_copy_pq_share(struct s2n_stuffer *from, struct s2n_blob *to, const struct s2n_kem_group *kem_group);
@@ -172,7 +173,7 @@ int main() {
                         const struct s2n_kem_group *test_kem_group = kem_pref->tls13_kem_groups[0];
 
                         DEFER_CLEANUP(struct s2n_stuffer key_share_extension = {0}, s2n_stuffer_free);
-                        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 4096));
+                        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, MEM_FOR_EXTENSION));
                         EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &key_share_extension));
 
                         /* First, assert that the client saved its private keys correctly in the connection state
@@ -264,10 +265,9 @@ int main() {
                         EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_pref));
                         EXPECT_NOT_NULL(kem_pref);
 
-                        /* This is for pre-HRR set up; force the client to generate it's default hybrid key share
-                         * so that we can confirm that s2n_send_hrr_pq_hybrid_keyshare wipes it correctly. */
+                        /* This is for pre-HRR set up: force the client to generate its default hybrid key share. */
                         DEFER_CLEANUP(struct s2n_stuffer key_share_extension = {0}, s2n_stuffer_free);
-                        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 4096));
+                        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, MEM_FOR_EXTENSION));
                         EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &key_share_extension));
                         EXPECT_SUCCESS(s2n_stuffer_wipe(&key_share_extension));
                         /* Quick sanity check */
@@ -296,19 +296,18 @@ int main() {
                         EXPECT_NOT_NULL(kem_group_params->ecc_params.evp_pkey);
 
                         /* Assert that the client didn't generate/save any key shares that it wasn't supposed to */
-                        for (size_t kem_group_index = 0;
-                             kem_group_index < kem_pref->tls13_kem_group_count; kem_group_index++) {
-                            if (kem_group_index == chosen_index) {
+                        for (size_t kem_group_i = 0; kem_group_i < kem_pref->tls13_kem_group_count; kem_group_i++) {
+                            if (kem_group_i == chosen_index || kem_group_i == 0) {
                                 continue;
                             }
-                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_group);
-                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_params.kem);
-                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_params.private_key.data);
-                            EXPECT_EQUAL(conn->secure.client_kem_group_params[kem_group_index].kem_params.private_key.size,0);
-                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].ecc_params.negotiated_curve);
-                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].ecc_params.evp_pkey);
+                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_i].kem_group);
+                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_i].kem_params.kem);
+                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_i].kem_params.private_key.data);
+                            EXPECT_EQUAL(conn->secure.client_kem_group_params[kem_group_i].kem_params.private_key.size,0);
+                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_i].ecc_params.negotiated_curve);
+                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_i].ecc_params.evp_pkey);
                         }
-                        for (size_t ecc_index = 0; ecc_index < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; ecc_index++) {
+                        for (size_t ecc_index = 1; ecc_index < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; ecc_index++) {
                             EXPECT_NULL(conn->secure.client_ecc_evp_params[ecc_index].negotiated_curve);
                             EXPECT_NULL(conn->secure.client_ecc_evp_params[ecc_index].evp_pkey);
                         }
@@ -349,6 +348,76 @@ int main() {
 
                         EXPECT_SUCCESS(s2n_connection_free(conn));
                     }
+
+                    /* Test sending in response to HRR for early data */
+                    {
+                        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+                        conn->security_policy_override = &test_security_policy;
+                        EXPECT_NOT_NULL(conn);
+
+                        const struct s2n_ecc_preferences *ecc_preferences = NULL;
+                        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
+                        EXPECT_NOT_NULL(ecc_preferences);
+
+                        const struct s2n_kem_preferences *kem_pref = NULL;
+                        EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_pref));
+                        EXPECT_NOT_NULL(kem_pref);
+
+                        struct s2n_stuffer first_extension = { 0 }, second_extension = { 0 };
+                        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&first_extension, MEM_FOR_EXTENSION));
+                        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&second_extension, MEM_FOR_EXTENSION));
+
+                        EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &first_extension));
+
+                        conn->secure.server_kem_group_params.kem_group = conn->secure.client_kem_group_params[0].kem_group;
+                        conn->secure.server_kem_group_params.ecc_params.negotiated_curve =
+                                conn->secure.client_kem_group_params[0].ecc_params.negotiated_curve;
+
+                        /* Setup the client to have received a HelloRetryRequest */
+                        EXPECT_MEMCPY_SUCCESS(conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
+                        EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(conn, S2N_TLS13));
+                        EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(conn));
+                        conn->early_data_state = S2N_EARLY_DATA_REJECTED;
+
+                        EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &second_extension));
+
+                        uint16_t first_sent_key_shares_size = 0, second_sent_key_shares_size = 0;
+                        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&first_extension, &first_sent_key_shares_size));
+                        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&second_extension, &second_sent_key_shares_size));
+                        EXPECT_EQUAL(first_sent_key_shares_size, s2n_stuffer_data_available(&first_extension));
+                        EXPECT_EQUAL(second_sent_key_shares_size, s2n_stuffer_data_available(&second_extension));
+                        EXPECT_TRUE(second_sent_key_shares_size < first_sent_key_shares_size);
+
+                        uint16_t first_sent_hybrid_iana_id = 0, second_sent_hybrid_iana_id = 0;
+                        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&first_extension, &first_sent_hybrid_iana_id));
+                        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&second_extension, &second_sent_hybrid_iana_id));
+                        EXPECT_EQUAL(first_sent_hybrid_iana_id, conn->secure.client_kem_group_params[0].kem_group->iana_id);
+                        EXPECT_EQUAL(second_sent_hybrid_iana_id, second_sent_hybrid_iana_id);
+
+                        uint16_t first_total_hybrid_share_size = 0, second_total_hybrid_share_size = 0;
+                        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&first_extension, &first_total_hybrid_share_size));
+                        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&second_extension, &second_total_hybrid_share_size));
+                        EXPECT_TRUE(first_total_hybrid_share_size < s2n_stuffer_data_available(&first_extension));
+                        EXPECT_EQUAL(second_total_hybrid_share_size, s2n_stuffer_data_available(&second_extension));
+
+                        uint16_t first_ecc_share_size = 0, second_ecc_share_size = 0;
+                        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&first_extension, &first_ecc_share_size));
+                        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&second_extension, &second_ecc_share_size));
+                        EXPECT_EQUAL(first_ecc_share_size, second_ecc_share_size);
+
+                        uint8_t *first_ecc_share_data = NULL, *second_ecc_share_data = NULL;
+                        EXPECT_NOT_NULL(first_ecc_share_data = s2n_stuffer_raw_read(&first_extension, first_ecc_share_size));
+                        EXPECT_NOT_NULL(second_ecc_share_data = s2n_stuffer_raw_read(&second_extension, second_ecc_share_size));
+                        EXPECT_BYTEARRAY_EQUAL(first_ecc_share_data, second_ecc_share_data, first_ecc_share_size);
+
+                        uint16_t second_pq_share_size = 0;
+                        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&second_extension, &second_pq_share_size));
+                        EXPECT_EQUAL(second_pq_share_size, s2n_stuffer_data_available(&second_extension));
+
+                        EXPECT_SUCCESS(s2n_stuffer_free(&first_extension));
+                        EXPECT_SUCCESS(s2n_stuffer_free(&second_extension));
+                        EXPECT_SUCCESS(s2n_connection_free(conn));
+                    }
                 }
 
                 /* Test failure when server chooses a KEM group that is not in the client's preferences */
@@ -364,7 +433,7 @@ int main() {
                     conn->secure.server_kem_group_params.kem_group = &s2n_secp256r1_bike1_l1_r2;
 
                     DEFER_CLEANUP(struct s2n_stuffer key_share_extension = {0}, s2n_stuffer_free);
-                    EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 4096));
+                    EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, MEM_FOR_EXTENSION));
                     EXPECT_FAILURE_WITH_ERRNO(s2n_client_key_share_extension.send(conn, &key_share_extension), S2N_ERR_INVALID_HELLO_RETRY);
 
                     EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_tls13_compute_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_compute_shared_secret_test.c
@@ -23,11 +23,21 @@
 
 #include "tls/s2n_tls13_handshake.c"
 #include "tls/s2n_security_policies.h"
+#include "tls/s2n_tls.h"
 
 int main(int argc, char **argv) {
 
     BEGIN_TEST();
-    EXPECT_SUCCESS(s2n_disable_tls13());
+
+    struct s2n_cert_chain_and_key *cert_chain = NULL;
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&cert_chain,
+            S2N_ECDSA_P384_PKCS1_CERT_CHAIN, S2N_ECDSA_P384_PKCS1_KEY));
+    EXPECT_NOT_NULL(cert_chain);
+
+    struct s2n_config *config = s2n_config_new();
+    EXPECT_NOT_NULL(config);
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
 
     struct s2n_connection *client_conn;
 
@@ -107,6 +117,40 @@ int main(int argc, char **argv) {
         EXPECT_SUCCESS(s2n_tls13_compute_shared_secret(client_conn, &client_shared_secret));
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
+    }
+
+    /* This test ensures that the shared secrets computed by a client and server after negotiation match */
+    {
+        client_conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
+                s2n_stuffer_data_available(&client_conn->handshake.io)));
+        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+
+        EXPECT_SUCCESS(s2n_server_hello_send(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io,
+                s2n_stuffer_data_available(&server_conn->handshake.io)));
+        EXPECT_SUCCESS(s2n_server_hello_recv(client_conn));
+
+        DEFER_CLEANUP(struct s2n_blob client_shared_secret = {0}, s2n_free);
+        EXPECT_SUCCESS(s2n_tls13_compute_shared_secret(client_conn, &client_shared_secret));
+        EXPECT_TRUE(client_shared_secret.size > 0);
+
+        DEFER_CLEANUP(struct s2n_blob server_shared_secret = {0}, s2n_free);
+        EXPECT_SUCCESS(s2n_tls13_compute_shared_secret(server_conn, &server_shared_secret));
+        EXPECT_TRUE(server_shared_secret.size > 0);
+
+        S2N_BLOB_EXPECT_EQUAL(server_shared_secret, client_shared_secret);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
     }
 
     END_TEST();

--- a/tests/unit/s2n_tls13_compute_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_compute_shared_secret_test.c
@@ -153,5 +153,8 @@ int main(int argc, char **argv) {
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
     }
 
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_free(cert_chain));
+    EXPECT_SUCCESS(s2n_config_free(config));
+
     END_TEST();
 }

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -184,17 +184,8 @@ int main(int argc, char **argv)
 
         EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, client_conn->secure.server_ecc_evp_params.negotiated_curve);
 
-        DEFER_CLEANUP(struct s2n_blob server_shared_secret = { 0 }, s2n_free);
-        DEFER_CLEANUP(struct s2n_blob client_shared_secret = { 0 }, s2n_free);
-
         client_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
         server_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
-
-        /* test that ecdhe shared secret generation matches */
-        EXPECT_SUCCESS(s2n_tls13_compute_shared_secret(server_conn, &server_shared_secret));
-        EXPECT_SUCCESS(s2n_tls13_compute_shared_secret(client_conn, &client_shared_secret));
-
-        S2N_BLOB_EXPECT_EQUAL(server_shared_secret, client_shared_secret);
 
         /* test handle handshake secrets */
         EXPECT_SUCCESS(s2n_tls13_handle_handshake_secrets(server_conn));

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -128,7 +128,9 @@ static int s2n_generate_pq_hybrid_key_share(struct s2n_stuffer *out, struct s2n_
     struct s2n_ecc_evp_params *ecc_params = &kem_group_params->ecc_params;
     ecc_params->negotiated_curve = kem_group->curve;
     POSIX_GUARD(s2n_stuffer_write_uint16(out, ecc_params->negotiated_curve->share_size));
-    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(ecc_params));
+    if (ecc_params->evp_pkey == NULL) {
+        POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(ecc_params));
+    }
     POSIX_GUARD(s2n_ecc_evp_write_params_point(ecc_params, out));
 
     struct s2n_kem_params *kem_params = &kem_group_params->kem_params;
@@ -166,56 +168,28 @@ static int s2n_generate_default_pq_hybrid_key_share(struct s2n_connection *conn,
     return S2N_SUCCESS;
 }
 
-static int s2n_wipe_all_client_keyshares(struct s2n_connection *conn) {
-    POSIX_ENSURE_REF(conn);
-
-    const struct s2n_ecc_preferences *ecc_pref = NULL;
-    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    POSIX_ENSURE_REF(ecc_pref);
-
-    const struct s2n_kem_preferences *kem_pref = NULL;
-    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
-    POSIX_ENSURE_REF(kem_pref);
-
-    for (size_t i = 0; i < ecc_pref->count; i++) {
-        POSIX_GUARD(s2n_ecc_evp_params_free(&conn->secure.client_ecc_evp_params[i]));
-        conn->secure.client_ecc_evp_params[i].negotiated_curve = NULL;
-    }
-
-    for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-        POSIX_GUARD(s2n_kem_group_free(&conn->secure.client_kem_group_params[i]));
-        conn->secure.client_kem_group_params[i].kem_group = NULL;
-        conn->secure.client_kem_group_params[i].kem_params.kem = NULL;
-        conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve = NULL;
-    }
-
-    return S2N_SUCCESS;
-}
-
 static int s2n_send_hrr_ecc_keyshare(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     POSIX_ENSURE_REF(conn);
-    const struct s2n_ecc_named_curve *server_negotiated_curve = NULL;
-    struct s2n_ecc_evp_params *ecc_evp_params = NULL;
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
     POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
     POSIX_ENSURE_REF(ecc_pref);
 
-    server_negotiated_curve = conn->secure.server_ecc_evp_params.negotiated_curve;
+    const struct s2n_ecc_named_curve *server_negotiated_curve = conn->secure.server_ecc_evp_params.negotiated_curve;
     POSIX_ENSURE(server_negotiated_curve != NULL, S2N_ERR_BAD_KEY_SHARE);
     POSIX_ENSURE(s2n_ecc_preferences_includes_curve(ecc_pref, server_negotiated_curve->iana_id),
             S2N_ERR_INVALID_HELLO_RETRY);
 
+    struct s2n_ecc_evp_params *ecc_evp_params = NULL;
     for (size_t i = 0; i < ecc_pref->count; i++) {
         if (ecc_pref->ecc_curves[i]->iana_id == server_negotiated_curve->iana_id) {
             ecc_evp_params = &conn->secure.client_ecc_evp_params[i];
-            POSIX_ENSURE(ecc_evp_params->evp_pkey == NULL, S2N_ERR_INVALID_HELLO_RETRY);
+            break;
         }
     }
+    POSIX_ENSURE_REF(ecc_evp_params);
 
-    /* None of the previously generated keyshares were selected for negotiation, so wipe them */
-    POSIX_GUARD(s2n_wipe_all_client_keyshares(conn));
     /* Generate the keyshare for the server negotiated curve */
     ecc_evp_params->negotiated_curve = server_negotiated_curve;
     POSIX_GUARD(s2n_ecdhe_parameters_send(ecc_evp_params, out));
@@ -244,14 +218,11 @@ static int s2n_send_hrr_pq_hybrid_keyshare(struct s2n_connection *conn, struct s
     for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
         if (kem_pref->tls13_kem_groups[i]->iana_id == server_negotiated_kem_group->iana_id) {
             kem_group_params = &conn->secure.client_kem_group_params[i];
-            POSIX_ENSURE(kem_group_params->kem_group == NULL, S2N_ERR_INVALID_HELLO_RETRY);
-            POSIX_ENSURE(kem_group_params->ecc_params.evp_pkey == NULL, S2N_ERR_INVALID_HELLO_RETRY);
-            POSIX_ENSURE(kem_group_params->kem_params.private_key.data == NULL, S2N_ERR_INVALID_HELLO_RETRY);
+            break;
         }
     }
+    POSIX_ENSURE_REF(kem_group_params);
 
-    /* None of the previously generated keyshares were selected for negotiation, so wipe them */
-    POSIX_GUARD(s2n_wipe_all_client_keyshares(conn));
     /* Generate the keyshare for the server negotiated KEM group */
     kem_group_params->kem_group = server_negotiated_kem_group;
     POSIX_GUARD(s2n_generate_pq_hybrid_key_share(out, kem_group_params));

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -128,6 +128,9 @@ static int s2n_generate_pq_hybrid_key_share(struct s2n_stuffer *out, struct s2n_
     struct s2n_ecc_evp_params *ecc_params = &kem_group_params->ecc_params;
     ecc_params->negotiated_curve = kem_group->curve;
     POSIX_GUARD(s2n_stuffer_write_uint16(out, ecc_params->negotiated_curve->share_size));
+
+    /* If we received a HRR for any reason other than to request a different key share,
+     * we might have already generated the key. */
     if (ecc_params->evp_pkey == NULL) {
         POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(ecc_params));
     }

--- a/tls/extensions/s2n_key_share.c
+++ b/tls/extensions/s2n_key_share.c
@@ -26,7 +26,9 @@ int s2n_ecdhe_parameters_send(struct s2n_ecc_evp_params *ecc_evp_params, struct 
     POSIX_GUARD(s2n_stuffer_write_uint16(out, ecc_evp_params->negotiated_curve->iana_id));
     POSIX_GUARD(s2n_stuffer_write_uint16(out, ecc_evp_params->negotiated_curve->share_size));
 
-    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(ecc_evp_params));
+    if (ecc_evp_params->evp_pkey == NULL) {
+        POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(ecc_evp_params));
+    }
     POSIX_GUARD(s2n_ecc_evp_write_params_point(ecc_evp_params, out));
 
     return 0;

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -349,6 +349,8 @@ int s2n_connection_kill(struct s2n_connection *conn);
 int s2n_connection_send_stuffer(struct s2n_stuffer *stuffer, struct s2n_connection *conn, uint32_t len);
 int s2n_connection_recv_stuffer(struct s2n_stuffer *stuffer, struct s2n_connection *conn, uint32_t len);
 
+S2N_RESULT s2n_connection_wipe_all_keyshares(struct s2n_connection *conn);
+
 int s2n_connection_get_cipher_preferences(struct s2n_connection *conn, const struct s2n_cipher_preferences **cipher_preferences);
 int s2n_connection_get_security_policy(struct s2n_connection *conn, const struct s2n_security_policy **security_policy);
 int s2n_connection_get_kem_preferences(struct s2n_connection *conn, const struct s2n_kem_preferences **kem_preferences);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -628,6 +628,20 @@ int s2n_set_hello_retry_required(struct s2n_connection *conn)
     POSIX_ENSURE(conn->actual_protocol_version >= S2N_TLS13, S2N_ERR_INVALID_HELLO_RETRY);
     conn->handshake.handshake_type |= HELLO_RETRY_REQUEST;
 
+    /* HelloRetryRequests also indicate rejection of early data.
+     *
+     *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+     *# A server which receives an "early_data" extension MUST behave in one
+     *# of three ways:
+     *
+     *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
+     *# -  Request that the client send another ClientHello by responding
+     *#    with a HelloRetryRequest.
+     **/
+    if (conn->early_data_state == S2N_EARLY_DATA_REQUESTED) {
+        POSIX_GUARD_RESULT(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_REJECTED));
+    }
+
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -232,7 +232,7 @@ S2N_RESULT s2n_kem_generate_keypair(struct s2n_kem_params *kem_params)
     RESULT_ENSURE(kem_params->public_key.size == kem->public_key_length, S2N_ERR_SAFETY);
 
     /* Need to save the private key for decapsulation */
-    RESULT_GUARD_POSIX(s2n_alloc(&kem_params->private_key, kem->private_key_length));
+    RESULT_GUARD_POSIX(s2n_realloc(&kem_params->private_key, kem->private_key_length));
 
     GUARD_PQ_AS_RESULT(kem->generate_keypair(kem_params->public_key.data, kem_params->private_key.data));
     return S2N_RESULT_OK;

--- a/tls/s2n_server_hello_retry.c
+++ b/tls/s2n_server_hello_retry.c
@@ -130,7 +130,7 @@ int s2n_server_hello_retry_recv(struct s2n_connection *conn)
      *# "illegal_parameter" alert if the HelloRetryRequest would not result
      *# in any change in the ClientHello.
      */
-    POSIX_ENSURE(conn->early_data_state == S2N_EARLY_DATA_REJECTED || new_key_share_requested,
+    POSIX_ENSURE((conn->early_data_state == S2N_EARLY_DATA_REJECTED) || new_key_share_requested,
             S2N_ERR_INVALID_HELLO_RETRY);
 
     /* Update transcript hash */


### PR DESCRIPTION
### Description of changes: 

Previously, the only valid HRR was in response to a missing key share. We considered any HRR that did not change the key shares invalid. However, early data can be rejected via a HRR request, which does not have to also include changes to the key shares. Supporting this required:
* Removing many of the "sanity" checks in the client key share extension that validated that the right key shares were or weren't generated. 
* Moving the key share cleanup logic to after we use the shares to generate a secret. Cleaning up some shares but not others was getting too complex.
* Rejecting early data whenever a HRR is triggered
* Only rejecting a HRR as invalid if it doesn't change key shares OR reject a request for early data.

### Call-outs:

* We reuse existing ECC key shares on the second ClientHello, but NOT PQ key shares. The PQ key share logic currently doesn't save the PQ public key shares it generates, so it would take a larger rewrite to reuse them. I don't think it's necessary to make the handshake work, although @bbutch might want to weigh in on how expensive PQ key shares are to generate.

### Testing:

Unit and functional tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
