### PR TITLE
Add support for riscv64

### DIFF
--- a/pq-crypto/sike_r2/P434_internal.h
+++ b/pq-crypto/sike_r2/P434_internal.h
@@ -24,6 +24,9 @@
 #elif (TARGET == TARGET_PPC64)
 #define NWORDS_FIELD 7
 #define p434_ZERO_WORDS 3
+#elif (TARGET == TARGET_RISCV64)
+#define NWORDS_FIELD 7
+#define p434_ZERO_WORDS 3
 #endif
 
 // Basic constants

--- a/pq-crypto/sike_r2/config.h
+++ b/pq-crypto/sike_r2/config.h
@@ -41,6 +41,7 @@
 #define TARGET_ARM 3
 #define TARGET_ARM64 4
 #define TARGET_PPC64 5
+#define TARGET_RISCV64 6
 
 #if defined(__x86_64__)
 #define TARGET TARGET_AMD64
@@ -68,6 +69,12 @@ typedef uint64_t digit_t;  // Unsigned 64-bit digit
 typedef uint32_t hdigit_t; // Unsigned 32-bit digit
 #elif defined(__powerpc64__)
 #define TARGET TARGET_PPC64
+#define RADIX 64
+#define LOG2RADIX 6
+typedef uint64_t digit_t;  // Unsigned 64-bit digit
+typedef uint32_t hdigit_t; // Unsigned 32-bit digit
+#elif defined(__riscv) && (__riscv_xlen == 64)
+#define TARGET TARGET_RISCV64
 #define RADIX 64
 #define LOG2RADIX 6
 typedef uint64_t digit_t;  // Unsigned 64-bit digit


### PR DESCRIPTION
### Description of changes: 
Add support for riscv64 by trivially copying configurations from other 64-bit platform.
This PR is similar to #2533 .

### Testing:
Save the content below to `s2n-rv64.nix`, and then run `nix-build ./s2n-rv64.nix` to test building.
```nix
let
  # Get current master of nixpkgs
  pkgs = import (fetchTarball {
    url = "https://github.com/nixos/nixpkgs/archive/1d982f3677cf9df4cbd5095558a6d954d97e3cc2.tar.gz";
    sha256 = "03xq6nfbfjvkvqq17fk2riy1g5lljgpsgw6hdsw95ffd67wp2s0c";
  }) {
    # Overlay nixpkgs with our modified s2n
    overlays = [
      (self: super: {
        # Override s2n
        s2n = super.s2n.overrideAttrs (old: {
          # Fetch current master of s2n-tls.
          version = "master-61e32ad-rv64";
          src = self.fetchFromGitHub {
            owner = "aws";
            repo = "s2n-tls";
            rev = "61e32ad84ca0a43071722556eaf057245335ef7c";
            sha256 = "08w1w5kfxf5lnn6j82wnnnnxl8jwg67qmngcs52yrcplqh5wg8hv";
          };

          # Add our patch
          patches = (old.patches or []) ++ [
            (super.fetchpatch  {
              url = "https://github.com/awslabs/s2n/commit/d9c725c8d25a771ce134321aa678397687c7ca0b.patch";
              sha256 = "05vhizgd46nydxm1ks4szlx2n3sa45lhkrzrjf15csk6xqlfy8v6";
            })
          ];
        });
      })
    ];
  };

# Cross-compile s2n to riscv64 and save output to symlink `result`.
in pkgs.pkgsCross.riscv64.s2n
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
