### PR TITLE
External PSK Integration testing

### DIFF
--- a/bin/common.h
+++ b/bin/common.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <stdint.h>
+#define S2N_MAX_NO_OF_PSKS_IN_LIST 10
 
 #define GUARD_EXIT(x, msg)  \
   do {                      \


### PR DESCRIPTION
### Resolved issues:

 https://github.com/aws/s2n-tls/issues/2326

### Description of changes: 

To test external PSKs we need to extend the ability of  `s2nc` client to append/set the psk_list supported by the client. This includes inputting the psk_identity, psk_secret and its corresponding HMAC algorithm from a csv file, constructing an external psk using `s2n_external_psk_new`, setting the psk identity, psk secret and hmac  alg using `s2n_psk_set_identity`, `s2n_psk_set_secret` and `s2n_psk_set_hmac` and using the `s2n_connection_append_psk` to append the constructed  `s2n_external_psk_new` psk to the client connection. 

Similarly on the server side, we need to extend the ability of the `s2nd` server to  select a `chosen_psk_wire_index` from a list of `s2n_offered_psks` by setting the `s2n_config_set_psk_selection_callback` function.


### Call-outs:
 
Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 

We use two files to input the psks, namely: 

- A CSV file which contains the psk identity, psk secret and s2n_psk_hmac alg (s2nc). Ex: 
```
testid, 3456789876543234567876543234543, 0
client_1, 123456654321234567654321, 0
test_psk_identity, 654323456765432, 2
ID500, 2356547876, 0
```
- A CSV file with just a list of offered psk identities (s2nd). Ex:

```
test_ci, testid, client_1, test_psk_identity, ID501
```

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? These changes are to enable integration testing. A successful integration test with other providers (Openssl, BoringSSL etc) will verify the change is correct. 

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
