### PR TITLE
Reduce memory used for handshake arrays

### DIFF
--- a/tests/saw/spec/handshake/s2n_handshake_io.cry
+++ b/tests/saw/spec/handshake/s2n_handshake_io.cry
@@ -170,7 +170,7 @@ IS_TLS13_HANDSHAKE conn = conn.actual_protocol_version == S2N_TLS13
 ACTIVE_STATE_MACHINE : connection -> [20]handshake_action
 ACTIVE_STATE_MACHINE conn = if IS_TLS13_HANDSHAKE conn then tls13_state_machine else state_machine # zero
 
-ACTIVE_HANDSHAKES : connection -> [1024][32][32]
+ACTIVE_HANDSHAKES : connection -> [128][32][32]
 ACTIVE_HANDSHAKES conn = if IS_TLS13_HANDSHAKE conn then tls13_handshakes else handshakes
 
 ACTIVE_MESSAGE : connection -> [32]
@@ -257,8 +257,8 @@ state_machine_fn m =
   else zero
 
 // A model of the tls1.3 handshake state machine (array handshakes in C)
-tls13_handshakes : [1024][32][32]
-tls13_handshakes = [tls13_handshakes_fn h | h <- [0..1023]]
+tls13_handshakes : [128][32][32]
+tls13_handshakes = [tls13_handshakes_fn h | h <- [0..127]]
 
 // A function that gives the tls1.3 handshake sequence for each valid handshake_type.
 tls13_handshakes_fn: [32] -> [32][32]
@@ -285,8 +285,8 @@ tls13_handshakes_fn handshk =
   else zero
 
 // A model of the handshake state machine (array handshakes in C)
-handshakes : [1024][32][32]
-handshakes = [handshakes_fn h | h <- [0..1023]]
+handshakes : [128][32][32]
+handshakes = [handshakes_fn h | h <- [0..127]]
 
 // A function that gives the handshake sequence for each valid handshake_type.
 // This is a sparse encoding of the handshakes array (which is sparse too).
@@ -481,16 +481,17 @@ RESUME : [32]
 RESUME = zero # 0x01
 FULL_HANDSHAKE : [32]
 FULL_HANDSHAKE = zero # 0x02
-PERFECT_FORWARD_SECRECY : [32]
-PERFECT_FORWARD_SECRECY= zero # 0x04
-OCSP_STATUS : [32]
-OCSP_STATUS = zero # 0x08
-WITH_SESSION_TICKET : [32]
-WITH_SESSION_TICKET = zero # 0x20
 CLIENT_AUTH : [32]
-CLIENT_AUTH = zero # 0x10
+CLIENT_AUTH = zero # 0x04
 NO_CLIENT_CERT : [32]
-NO_CLIENT_CERT = zero # 0x40
+NO_CLIENT_CERT = zero # 0x08
+
+PERFECT_FORWARD_SECRECY : [32]
+PERFECT_FORWARD_SECRECY= zero # 0x10
+OCSP_STATUS : [32]
+OCSP_STATUS = zero # 0x20
+WITH_SESSION_TICKET : [32]
+WITH_SESSION_TICKET = zero # 0x40
 
 S2N_TLS13 : [8]
 S2N_TLS13 = 34

--- a/tests/unit/s2n_cert_chain_and_key_test.c
+++ b/tests/unit/s2n_cert_chain_and_key_test.c
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
         EXPECT_SUCCESS(s2n_set_server_name(client_conn, "www.alligator.com"));
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
-        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
         EXPECT_EQUAL(num_times_cb_executed, NUM_TIED_CERTS - 1);
         struct s2n_cert_chain_and_key *selected_cert = s2n_connection_get_selected_cert(server_conn);
         /* The last alligator certificate should have the highest priority */
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
-        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
         EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_client_auth_handshake_test.c
+++ b/tests/unit/s2n_client_auth_handshake_test.c
@@ -83,10 +83,10 @@ int s2n_test_client_auth_negotiation(struct s2n_config *server_config, struct s2
     /* Negotiate handshake */
     EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
-    EXPECT_TRUE(IS_CLIENT_AUTH_HANDSHAKE(server_conn->handshake.handshake_type));
-    EXPECT_TRUE(IS_CLIENT_AUTH_HANDSHAKE(client_conn->handshake.handshake_type));
-    EXPECT_EQUAL(IS_CLIENT_AUTH_NO_CERT(server_conn->handshake.handshake_type), no_cert);
-    EXPECT_EQUAL(IS_CLIENT_AUTH_NO_CERT(client_conn->handshake.handshake_type), no_cert);
+    EXPECT_TRUE(IS_CLIENT_AUTH_HANDSHAKE(server_conn));
+    EXPECT_TRUE(IS_CLIENT_AUTH_HANDSHAKE(client_conn));
+    EXPECT_EQUAL(IS_CLIENT_AUTH_NO_CERT(server_conn), no_cert);
+    EXPECT_EQUAL(IS_CLIENT_AUTH_NO_CERT(client_conn), no_cert);
 
     const char *app_data_str = "APPLICATION_DATA";
     EXPECT_EQUAL(strcmp(app_data_str, s2n_connection_get_last_message_name(client_conn)), 0);
@@ -252,7 +252,7 @@ int s2n_test_client_auth_message_by_message(bool no_cert)
     } else {
         EXPECT_EQUAL(client_conn->handshake.handshake_type, NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | MIDDLEBOX_COMPAT);
 
-        /*Client sends CertVerify */
+        /* Client sends CertVerify */
         EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), CLIENT_CERT_VERIFY);
         EXPECT_SUCCESS(s2n_handshake_write_io(client_conn));
     }

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -192,11 +192,11 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
             EXPECT_EQUAL(server_conn->handshake_params.our_chain_and_key, expected_cert_chain);
             EXPECT_EQUAL(server_conn->secure.conn_sig_scheme.sig_alg, expected_sig_alg);
 
-            EXPECT_TRUE(IS_NEGOTIATED(server_conn->handshake.handshake_type));
-            EXPECT_TRUE(IS_NEGOTIATED(client_conn->handshake.handshake_type));
+            EXPECT_TRUE(IS_NEGOTIATED(server_conn));
+            EXPECT_TRUE(IS_NEGOTIATED(client_conn));
 
-            EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
-            EXPECT_TRUE(IS_FULL_HANDSHAKE(client_conn->handshake.handshake_type));
+            EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
+            EXPECT_TRUE(IS_FULL_HANDSHAKE(client_conn));
 
             EXPECT_STRING_EQUAL(s2n_connection_get_last_message_name(server_conn), "APPLICATION_DATA");
             EXPECT_STRING_EQUAL(s2n_connection_get_last_message_name(client_conn), "APPLICATION_DATA");

--- a/tests/unit/s2n_handshake_type_test.c
+++ b/tests/unit/s2n_handshake_type_test.c
@@ -1,0 +1,276 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include <sys/param.h>
+
+#include "tls/s2n_connection.h"
+
+#define S2N_FIRST_COMMON_HANDSHAKE_FLAG NEGOTIATED
+#define S2N_LAST_COMMON_HANDSHAKE_FLAG NO_CLIENT_CERT
+#define S2N_FIRST_TLS12_HANDSHAKE_FLAG TLS12_PERFECT_FORWARD_SECRECY
+#define S2N_LAST_TLS12_HANDSHAKE_FLAG WITH_SESSION_TICKET
+#define S2N_FIRST_TLS13_HANDSHAKE_FLAG HELLO_RETRY_REQUEST
+#define S2N_LAST_TLS13_HANDSHAKE_FLAG MIDDLEBOX_COMPAT
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Sanity check test setup */
+    EXPECT_EQUAL(S2N_FIRST_COMMON_HANDSHAKE_FLAG, 1);
+    EXPECT_TRUE(S2N_FIRST_COMMON_HANDSHAKE_FLAG < S2N_LAST_COMMON_HANDSHAKE_FLAG);
+    EXPECT_EQUAL(S2N_FIRST_TLS12_HANDSHAKE_FLAG, S2N_LAST_COMMON_HANDSHAKE_FLAG * 2);
+    EXPECT_TRUE(S2N_FIRST_TLS12_HANDSHAKE_FLAG < S2N_LAST_TLS12_HANDSHAKE_FLAG);
+    EXPECT_EQUAL(S2N_FIRST_TLS13_HANDSHAKE_FLAG, S2N_LAST_COMMON_HANDSHAKE_FLAG * 2);
+    EXPECT_TRUE(S2N_FIRST_TLS13_HANDSHAKE_FLAG < S2N_LAST_TLS13_HANDSHAKE_FLAG);
+    EXPECT_EQUAL(MAX(S2N_LAST_TLS12_HANDSHAKE_FLAG, S2N_LAST_TLS13_HANDSHAKE_FLAG), S2N_HANDSHAKES_COUNT / 2);
+
+    /* Test s2n_handshake_type_reset */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(conn);
+
+        conn->handshake.handshake_type = 0x12AB;
+        EXPECT_OK(s2n_handshake_type_reset(conn));
+        EXPECT_EQUAL(conn->handshake.handshake_type, 0);
+
+        EXPECT_OK(s2n_handshake_type_set_flag(conn, FULL_HANDSHAKE));
+        EXPECT_OK(s2n_handshake_type_reset(conn));
+        EXPECT_EQUAL(conn->handshake.handshake_type, 0);
+
+        EXPECT_OK(s2n_handshake_type_set_flag(conn, 0xFFFF));
+        EXPECT_OK(s2n_handshake_type_reset(conn));
+        EXPECT_EQUAL(conn->handshake.handshake_type, 0);
+
+        EXPECT_OK(s2n_handshake_type_set_flag(conn, 0));
+        EXPECT_OK(s2n_handshake_type_reset(conn));
+        EXPECT_EQUAL(conn->handshake.handshake_type, 0);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test s2n_handshake_type_set_flag */
+    {
+        /* Safety */
+        EXPECT_ERROR_WITH_ERRNO(s2n_handshake_type_set_flag(NULL, 0), S2N_ERR_NULL);
+
+        /* Sets all common flags */
+        for (s2n_handshake_type_flag flag = S2N_FIRST_COMMON_HANDSHAKE_FLAG; flag <= S2N_LAST_COMMON_HANDSHAKE_FLAG; flag++) {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+
+            conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_OK(s2n_handshake_type_set_flag(conn, flag));
+            EXPECT_EQUAL(conn->handshake.handshake_type, flag);
+
+            EXPECT_OK(s2n_handshake_type_reset(conn));
+
+            conn->actual_protocol_version = S2N_TLS13;
+            EXPECT_OK(s2n_handshake_type_set_flag(conn, flag));
+            EXPECT_EQUAL(conn->handshake.handshake_type, flag);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    /* Test s2n_handshake_type_check_flag */
+    {
+        /* Safety */
+        EXPECT_FALSE(s2n_handshake_type_check_flag(NULL, 0));
+
+        /* Check when common flags set */
+        for (s2n_handshake_type_flag flag = S2N_FIRST_COMMON_HANDSHAKE_FLAG; flag <= S2N_LAST_COMMON_HANDSHAKE_FLAG; flag++) {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+
+            /* All flags set */
+            {
+                conn->handshake.handshake_type = 0xFFFF;
+
+                conn->actual_protocol_version = S2N_TLS12;
+                EXPECT_TRUE(s2n_handshake_type_check_flag(conn, flag));
+
+                conn->actual_protocol_version = S2N_TLS13;
+                EXPECT_TRUE(s2n_handshake_type_check_flag(conn, flag));
+            }
+
+            /* No flags set */
+            {
+                conn->handshake.handshake_type = 0;
+
+                conn->actual_protocol_version = S2N_TLS12;
+                EXPECT_FALSE(s2n_handshake_type_check_flag(conn, flag));
+
+                conn->actual_protocol_version = S2N_TLS13;
+                EXPECT_FALSE(s2n_handshake_type_check_flag(conn, flag));
+            }
+
+            /* One flag set */
+            {
+                conn->handshake.handshake_type = flag;
+
+                conn->actual_protocol_version = S2N_TLS12;
+                EXPECT_TRUE(s2n_handshake_type_check_flag(conn, flag));
+
+                conn->actual_protocol_version = S2N_TLS13;
+                EXPECT_TRUE(s2n_handshake_type_check_flag(conn, flag));
+            }
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    /* Test s2n_handshake_type_set_tls12_flag */
+    {
+        /* Safety */
+        EXPECT_ERROR_WITH_ERRNO(s2n_handshake_type_set_tls12_flag(NULL, 0), S2N_ERR_NULL);
+
+        /* Sets all TLS1.2 flags */
+        for (s2n_tls12_handshake_type_flag flag = S2N_FIRST_TLS12_HANDSHAKE_FLAG; flag <= S2N_LAST_TLS12_HANDSHAKE_FLAG; flag++) {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+
+            conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_OK(s2n_handshake_type_set_tls12_flag(conn, flag));
+            EXPECT_EQUAL(conn->handshake.handshake_type, flag);
+
+            EXPECT_OK(s2n_handshake_type_reset(conn));
+
+            conn->actual_protocol_version = S2N_TLS13;
+            EXPECT_ERROR_WITH_ERRNO(s2n_handshake_type_set_tls12_flag(conn, flag), S2N_ERR_HANDSHAKE_STATE);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    /* Test s2n_handshake_type_check_tls12_flag */
+    {
+        /* Safety */
+        EXPECT_FALSE(s2n_handshake_type_check_tls12_flag(NULL, 0));
+
+        /* Check when common flags set */
+        for (s2n_tls12_handshake_type_flag flag = S2N_FIRST_TLS12_HANDSHAKE_FLAG; flag <= S2N_LAST_TLS12_HANDSHAKE_FLAG; flag++) {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+
+            /* All flags set */
+            {
+                conn->handshake.handshake_type = 0xFFFF;
+
+                conn->actual_protocol_version = S2N_TLS12;
+                EXPECT_TRUE(s2n_handshake_type_check_tls12_flag(conn, flag));
+
+                conn->actual_protocol_version = S2N_TLS13;
+                EXPECT_FALSE(s2n_handshake_type_check_tls12_flag(conn, flag));
+            }
+
+            /* No flags set */
+            {
+                conn->handshake.handshake_type = 0;
+
+                conn->actual_protocol_version = S2N_TLS12;
+                EXPECT_FALSE(s2n_handshake_type_check_tls12_flag(conn, flag));
+
+                conn->actual_protocol_version = S2N_TLS13;
+                EXPECT_FALSE(s2n_handshake_type_check_tls12_flag(conn, flag));
+            }
+
+            /* One flag set */
+            {
+                conn->handshake.handshake_type = flag;
+
+                conn->actual_protocol_version = S2N_TLS12;
+                EXPECT_TRUE(s2n_handshake_type_check_tls12_flag(conn, flag));
+
+                conn->actual_protocol_version = S2N_TLS13;
+                EXPECT_FALSE(s2n_handshake_type_check_tls12_flag(conn, flag));
+            }
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    /* Test s2n_handshake_type_set_tls13_flag */
+    {
+        /* Safety */
+        EXPECT_ERROR_WITH_ERRNO(s2n_handshake_type_set_tls13_flag(NULL, 0), S2N_ERR_NULL);
+
+        /* Sets all TLS1.3 flags */
+        for (s2n_tls13_handshake_type_flag flag = S2N_FIRST_TLS13_HANDSHAKE_FLAG; flag <= S2N_LAST_TLS13_HANDSHAKE_FLAG; flag++) {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+
+            conn->actual_protocol_version = S2N_TLS13;
+            EXPECT_OK(s2n_handshake_type_set_tls13_flag(conn, flag));
+            EXPECT_EQUAL(conn->handshake.handshake_type, flag);
+
+            conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_ERROR_WITH_ERRNO(s2n_handshake_type_set_tls13_flag(conn, flag), S2N_ERR_HANDSHAKE_STATE);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    /* Test s2n_handshake_type_check_tls13_flag */
+    {
+        /* Safety */
+        EXPECT_FALSE(s2n_handshake_type_check_tls13_flag(NULL, 0));
+
+        /* Check when common flags set */
+        for (s2n_tls13_handshake_type_flag flag = S2N_FIRST_TLS13_HANDSHAKE_FLAG; flag <= S2N_LAST_TLS13_HANDSHAKE_FLAG; flag++) {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+
+            /* All flags set */
+            {
+                conn->handshake.handshake_type = 0xFFFF;
+
+                conn->actual_protocol_version = S2N_TLS12;
+                EXPECT_FALSE(s2n_handshake_type_check_tls13_flag(conn, flag));
+
+                conn->actual_protocol_version = S2N_TLS13;
+                EXPECT_TRUE(s2n_handshake_type_check_tls13_flag(conn, flag));
+            }
+
+            /* No flags set */
+            {
+                conn->handshake.handshake_type = 0;
+
+                conn->actual_protocol_version = S2N_TLS12;
+                EXPECT_FALSE(s2n_handshake_type_check_tls13_flag(conn, flag));
+
+                conn->actual_protocol_version = S2N_TLS13;
+                EXPECT_FALSE(s2n_handshake_type_check_tls13_flag(conn, flag));
+            }
+
+            /* One flag set */
+            {
+                conn->handshake.handshake_type = flag;
+
+                conn->actual_protocol_version = S2N_TLS12;
+                EXPECT_FALSE(s2n_handshake_type_check_tls13_flag(conn, flag));
+
+                conn->actual_protocol_version = S2N_TLS13;
+                EXPECT_TRUE(s2n_handshake_type_check_tls13_flag(conn, flag));
+            }
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_self_talk_psk_test.c
+++ b/tests/unit/s2n_self_talk_psk_test.c
@@ -21,11 +21,10 @@
 #define TEST_PSK_HMAC S2N_PSK_HMAC_SHA256
 
 #define ARE_FULL_HANDSHAKES(client, server) \
-    (IS_FULL_HANDSHAKE(client->handshake.handshake_type) && IS_FULL_HANDSHAKE(server->handshake.handshake_type))
+    (IS_FULL_HANDSHAKE(client) && IS_FULL_HANDSHAKE(server))
 
-#define IS_CLIENT_AUTH(client, server)                          \
-    (IS_CLIENT_AUTH_HANDSHAKE(client->handshake.handshake_type) \
-     && IS_CLIENT_AUTH_HANDSHAKE(server->handshake.handshake_type))
+#define IS_CLIENT_AUTH(client, server) \
+    (IS_CLIENT_AUTH_HANDSHAKE(client) && IS_CLIENT_AUTH_HANDSHAKE(server))
 
 #define IS_HELLO_RETRY(client, server)                          \
     (((client->handshake.handshake_type) & HELLO_RETRY_REQUEST) \

--- a/tests/unit/s2n_self_talk_quic_support_test.c
+++ b/tests/unit/s2n_self_talk_quic_support_test.c
@@ -105,8 +105,8 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(server_conn->session_id_len, 0);
 
     /* Verify handshake not MIDDLEBOX_COMPAT (QUIC does not use middlebox compat mode) */
-    EXPECT_FALSE(IS_MIDDLEBOX_COMPAT_MODE(client_conn->handshake.handshake_type));
-    EXPECT_FALSE(IS_MIDDLEBOX_COMPAT_MODE(server_conn->handshake.handshake_type));
+    EXPECT_FALSE(IS_MIDDLEBOX_COMPAT_MODE(client_conn));
+    EXPECT_FALSE(IS_MIDDLEBOX_COMPAT_MODE(server_conn));
 
     /* Verify secret handler collected secrets */
     for (size_t i = 1; i < S2N_SECRET_TYPE_COUNT; i++) {

--- a/tests/unit/s2n_self_talk_session_id_test.c
+++ b/tests/unit/s2n_self_talk_session_id_test.c
@@ -169,7 +169,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
     }
 
     /* Make sure we did a full handshake */
-    if (!IS_FULL_HANDSHAKE(conn->handshake.handshake_type)) {
+    if (!IS_FULL_HANDSHAKE(conn)) {
         result = 2;
     }
 
@@ -226,7 +226,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
     }
 
     /* Make sure we did a abbreviated handshake */
-    if (!IS_RESUMPTION_HANDSHAKE(conn->handshake.handshake_type)) {
+    if (!IS_RESUMPTION_HANDSHAKE(conn)) {
         result = 11;
     }
 
@@ -378,7 +378,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_connection_get_session_id(conn, session_id_from_server, MAX_KEY_LEN), s2n_connection_get_session_id_length(conn));
 
         /* Make sure we did a full TLS1.2 handshake */
-        EXPECT_TRUE(IS_FULL_HANDSHAKE(conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(conn));
         EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS12);
 
         /* Ensure the message was delivered */
@@ -421,7 +421,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(0, memcmp(session_id_from_client, session_id_from_server, MAX_KEY_LEN));
 
         /* Make sure we did a abbreviated handshake */
-        EXPECT_TRUE(IS_RESUMPTION_HANDSHAKE(conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_RESUMPTION_HANDSHAKE(conn));
 
         /* Ensure the message was delivered */
         memset(buffer, 0, sizeof(buffer));

--- a/tests/unit/s2n_server_server_name_extension_test.c
+++ b/tests/unit/s2n_server_server_name_extension_test.c
@@ -27,9 +27,6 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13());
 
-    EXPECT_TRUE(IS_RESUMPTION_HANDSHAKE(S2N_TEST_RESUMPTION_HANDSHAKE));
-    EXPECT_FALSE(IS_RESUMPTION_HANDSHAKE(S2N_TEST_NOT_RESUMPTION_HANDSHAKE));
-
     /* should_send */
     {
         struct s2n_connection *conn;

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -145,8 +145,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that the server did a full handshake and issued NST */
-        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
-        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
+        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
 
         /* Verify that the client received NST */
         serialized_session_state_length = s2n_connection_get_session_length(client_conn);
@@ -190,8 +190,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that the server did a full handshake and did not issue NST */
-        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
-        EXPECT_FALSE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
+        EXPECT_FALSE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
 
         EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 
@@ -232,9 +232,9 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that the server did an abbreviated handshake and not issue NST */
-        EXPECT_TRUE(IS_RESUMPTION_HANDSHAKE(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_RESUMPTION_HANDSHAKE(server_conn));
         EXPECT_TRUE(s2n_connection_is_session_resumed(server_conn));
-        EXPECT_FALSE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
+        EXPECT_FALSE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
 
         /* Verify that client_ticket is same as before because server didn't issue a NST */
         uint8_t old_session_ticket[S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TLS12_TICKET_SIZE_IN_BYTES];
@@ -295,8 +295,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that the server did an abbreviated handshake and issued NST */
-        EXPECT_TRUE(IS_RESUMPTION_HANDSHAKE(server_conn->handshake.handshake_type));
-        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_RESUMPTION_HANDSHAKE(server_conn));
+        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
 
         /* Verify that client_ticket is not same as before because server issued a NST */
         uint8_t old_session_ticket[S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TLS12_TICKET_SIZE_IN_BYTES];
@@ -358,8 +358,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that the server did an abbreviated handshake and did not issue a NST */
-        EXPECT_TRUE(IS_RESUMPTION_HANDSHAKE(server_conn->handshake.handshake_type));
-        EXPECT_FALSE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_RESUMPTION_HANDSHAKE(server_conn));
+        EXPECT_FALSE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
 
         /* Verify that client_ticket is same as before because server did not issue a NST */
         uint8_t old_session_ticket[S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TLS12_TICKET_SIZE_IN_BYTES];
@@ -410,8 +410,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that the server did a full handshake and issued NST */
-        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
-        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
+        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
 
         /* Verify that the client received NST */
         serialized_session_state_length = s2n_connection_get_session_length(client_conn);
@@ -471,8 +471,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that the server did a full handshake and issued NST */
-        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
-        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
+        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
 
         /* Verify that the server has only the unexpired key */
         EXPECT_OK(s2n_set_get(server_config->ticket_keys, 0, (void **)&ticket_key));
@@ -539,8 +539,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that the server did a full handshake and issued NST */
-        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
-        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
+        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
 
         /* Verify that the client received NST */
         serialized_session_state_length = s2n_connection_get_session_length(client_conn);
@@ -586,8 +586,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that the server did a full handshake and did not issue NST */
-        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
-        EXPECT_FALSE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
+        EXPECT_FALSE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
 
         /* Verify that client_ticket is empty */
         EXPECT_EQUAL(s2n_connection_get_session(client_conn, serialized_session_state, serialized_session_state_length), 1 + 1 + client_conn->session_id_len + S2N_STATE_SIZE_IN_BYTES);
@@ -709,8 +709,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that the server did a full handshake and issued NST */
-        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
-        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
+        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
 
         /* Verify that the client received NST which is encrypted using a key which is at it's peak encryption */
         serialized_session_state_length = s2n_connection_get_session_length(client_conn);
@@ -770,8 +770,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that the server did a full handshake and issued NST */
-        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
-        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
+        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
 
         /* Verify that the client received NST which is encrypted using a key which is at it's peak encryption */
         serialized_session_state_length = s2n_connection_get_session_length(client_conn);
@@ -838,8 +838,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that the server did a full handshake and issued NST */
-        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
-        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
+        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
 
         /* Verify that the client received NST which is encrypted using a key which is at it's peak encryption */
         serialized_session_state_length = s2n_connection_get_session_length(client_conn);
@@ -898,8 +898,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Verify that the server did a full handshake and issued NST */
-        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
-        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
+        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
 
         /* Verify that the client received NST which is encrypted using a key which is at it's peak encryption */
         serialized_session_state_length = s2n_connection_get_session_length(client_conn);
@@ -952,8 +952,8 @@ int main(int argc, char **argv)
 
         /* Verify that the server did a full handshake and did not issue NST since client
          * auth is enabled in server mode */
-        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn->handshake.handshake_type));
-        EXPECT_FALSE(IS_ISSUING_NEW_SESSION_TICKET(server_conn->handshake.handshake_type));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
+        EXPECT_FALSE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
 
         EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 

--- a/tests/unit/s2n_tls12_handshake_test.c
+++ b/tests/unit/s2n_tls12_handshake_test.c
@@ -351,9 +351,23 @@ int main(int argc, char **argv)
         }
     }
 
+    /* Test: TLS1.2 handshake type name maximum size is set correctly.
+     * The maximum size is the size of a name with all flags set. */
+    {
+        size_t correct_size = 0;
+        for (size_t i = 0; i < s2n_array_len(tls12_handshake_type_names); i++) {
+            correct_size += strlen(tls12_handshake_type_names[i]);
+        }
+        if (correct_size > MAX_HANDSHAKE_TYPE_LEN) {
+            fprintf(stderr, "\nMAX_HANDSHAKE_TYPE_LEN should be at least %lu\n", (unsigned long) correct_size);
+            FAIL_MSG("MAX_HANDSHAKE_TYPE_LEN wrong for TLS1.2 handshakes");
+        }
+    }
+
     /* Test: TLS 1.2 handshake types are all properly printed */
     {
         struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        conn->actual_protocol_version = S2N_TLS12;
 
         conn->handshake.handshake_type = INITIAL;
         EXPECT_STRING_EQUAL("INITIAL", s2n_connection_get_handshake_type_name(conn));
@@ -361,10 +375,10 @@ int main(int argc, char **argv)
         conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
         EXPECT_STRING_EQUAL("NEGOTIATED|FULL_HANDSHAKE", s2n_connection_get_handshake_type_name(conn));
 
-        const char* all_flags_handshake_type_name = "NEGOTIATED|FULL_HANDSHAKE|TLS12_PERFECT_FORWARD_SECRECY|"
-                "OCSP_STATUS|CLIENT_AUTH|WITH_SESSION_TICKET|NO_CLIENT_CERT";
-        conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY | \
-                OCSP_STATUS | CLIENT_AUTH | WITH_SESSION_TICKET | NO_CLIENT_CERT;
+        const char* all_flags_handshake_type_name = "NEGOTIATED|FULL_HANDSHAKE|CLIENT_AUTH|NO_CLIENT_CERT|"
+                "TLS12_PERFECT_FORWARD_SECRECY|OCSP_STATUS|WITH_SESSION_TICKET";
+        conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | NO_CLIENT_CERT | \
+                TLS12_PERFECT_FORWARD_SECRECY | OCSP_STATUS | WITH_SESSION_TICKET;
         EXPECT_STRING_EQUAL(all_flags_handshake_type_name, s2n_connection_get_handshake_type_name(conn));
 
         const char *handshake_type_name;

--- a/tls/Makefile
+++ b/tls/Makefile
@@ -19,7 +19,7 @@ SUB_BUILDS = $(patsubst %/Makefile, %, $(wildcard */Makefile))
 
 BITCODE_DIR?=../tests/saw/bitcode/
 
-BCS_1=s2n_handshake_io.bc s2n_connection.bc s2n_kex.bc
+BCS_1=s2n_handshake_io.bc s2n_handshake_type.bc s2n_connection.bc s2n_kex.bc
 BCS=$(addprefix $(BITCODE_DIR), $(BCS_1))
 
 .PHONY : all

--- a/tls/extensions/s2n_server_server_name.c
+++ b/tls/extensions/s2n_server_server_name.c
@@ -33,7 +33,7 @@ const s2n_extension_type s2n_server_server_name_extension = {
 
 static bool s2n_server_name_should_send(struct s2n_connection *conn)
 {
-    return conn && conn->server_name_used && !IS_RESUMPTION_HANDSHAKE(conn->handshake.handshake_type);
+    return conn && conn->server_name_used && !IS_RESUMPTION_HANDSHAKE(conn);
 }
 
 static int s2n_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out)

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1070,8 +1070,8 @@ int s2n_connection_client_cert_used(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
 
-    if ((conn->handshake.handshake_type & CLIENT_AUTH) && is_handshake_complete(conn)) {
-        if (conn->handshake.handshake_type & NO_CLIENT_CERT) {
+    if (IS_CLIENT_AUTH_HANDSHAKE(conn) && is_handshake_complete(conn)) {
+        if (IS_CLIENT_AUTH_NO_CERT(conn)) {
             return 0;
         }
         return 1;

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -19,6 +19,7 @@
 #include <s2n.h>
 
 #include "tls/s2n_crypto.h"
+#include "tls/s2n_handshake_type.h"
 #include "tls/s2n_signature_algorithms.h"
 #include "tls/s2n_tls_parameters.h"
 
@@ -147,49 +148,8 @@ struct s2n_handshake {
     uint8_t server_finished[S2N_TLS_SECRET_LEN];
     uint8_t client_finished[S2N_TLS_SECRET_LEN];
 
-    /* Handshake type is a bitset, with the following
-       bit positions */
+    /* Which message-order affecting features are enabled */
     uint32_t handshake_type;
-
-/* Has the handshake been negotiated yet? */
-#define INITIAL                     0x00
-#define NEGOTIATED                  0x01
-#define IS_NEGOTIATED( type ) ( (type) & NEGOTIATED )
-
-/* Handshake is a full handshake  */
-#define FULL_HANDSHAKE              0x02
-#define IS_FULL_HANDSHAKE( type )   ( (type) & FULL_HANDSHAKE )
-#define IS_RESUMPTION_HANDSHAKE( type ) ( !IS_FULL_HANDSHAKE( (type) ) && IS_NEGOTIATED ( (type) ) )
-
-/* Handshake uses perfect forward secrecy */
-#define TLS12_PERFECT_FORWARD_SECRECY 0x04
-
-/* Handshake needs OCSP status message */
-#define OCSP_STATUS                 0x08
-#define IS_OCSP_STAPLED( type ) ( ( (type) & OCSP_STATUS ) != 0 )
-
-/* Handshake should request a Client Certificate */
-#define CLIENT_AUTH                 0x10
-#define IS_CLIENT_AUTH_HANDSHAKE( type )   ( (type) & CLIENT_AUTH )
-
-/* Session Resumption via session-tickets */
-#define WITH_SESSION_TICKET         0x20
-#define IS_ISSUING_NEW_SESSION_TICKET( type )   ( (type) & WITH_SESSION_TICKET )
-
-/* Handshake requested a Client Certificate but did not get one */
-#define NO_CLIENT_CERT              0x40
-#define IS_CLIENT_AUTH_NO_CERT( type )   ( IS_CLIENT_AUTH_HANDSHAKE( (type) ) && ( (type) & NO_CLIENT_CERT) )
-
-/* A HelloRetryRequest was needed to proceed with the handshake */
-#define HELLO_RETRY_REQUEST         0x80
-
-/* Disguise a TLS1.3 handshake as a TLS1.2 handshake for backwards compatibility
- * with some middleboxes: https://tools.ietf.org/html/rfc8446#appendix-D.4 */
-#define MIDDLEBOX_COMPAT            0x100
-#define IS_MIDDLEBOX_COMPAT_MODE( type ) ( (type) & MIDDLEBOX_COMPAT )
-
-#define WITH_EARLY_DATA             0x200
-#define IS_EARLY_DATA_HANDSHAKE( type ) ( (type) & WITH_EARLY_DATA )
 
     /* Which handshake message number are we processing */
     int message_number;

--- a/tls/s2n_handshake_type.c
+++ b/tls/s2n_handshake_type.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tls/s2n_connection.h"
+#include "tls/s2n_handshake_type.h"
+#include "utils/s2n_safety.h"
+
+S2N_RESULT s2n_handshake_type_set_flag(struct s2n_connection *conn, s2n_handshake_type_flag flag)
+{
+    RESULT_ENSURE_REF(conn);
+    conn->handshake.handshake_type |= flag;
+    return S2N_RESULT_OK;
+}
+
+bool s2n_handshake_type_check_flag(struct s2n_connection *conn, s2n_handshake_type_flag flag)
+{
+    return conn && (conn->handshake.handshake_type & flag);
+}
+
+S2N_RESULT s2n_handshake_type_set_tls12_flag(struct s2n_connection *conn, s2n_tls12_handshake_type_flag flag)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE(s2n_connection_get_protocol_version(conn) < S2N_TLS13, S2N_ERR_HANDSHAKE_STATE);
+    conn->handshake.handshake_type |= flag;
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_handshake_type_unset_tls12_flag(struct s2n_connection *conn, s2n_tls12_handshake_type_flag flag)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE(s2n_connection_get_protocol_version(conn) < S2N_TLS13, S2N_ERR_HANDSHAKE_STATE);
+    conn->handshake.handshake_type &= ~(flag);
+    return S2N_RESULT_OK;
+}
+
+bool s2n_handshake_type_check_tls12_flag(struct s2n_connection *conn, s2n_tls12_handshake_type_flag flag)
+{
+    return conn && s2n_connection_get_protocol_version(conn) < S2N_TLS13
+            && (conn->handshake.handshake_type & flag);
+}
+
+S2N_RESULT s2n_handshake_type_set_tls13_flag(struct s2n_connection *conn, s2n_tls13_handshake_type_flag flag)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE(s2n_connection_get_protocol_version(conn) >= S2N_TLS13, S2N_ERR_HANDSHAKE_STATE);
+    conn->handshake.handshake_type |= flag;
+    return S2N_RESULT_OK;
+}
+
+bool s2n_handshake_type_check_tls13_flag(struct s2n_connection *conn, s2n_tls13_handshake_type_flag flag)
+{
+    return conn && s2n_connection_get_protocol_version(conn) >= S2N_TLS13
+            && (conn->handshake.handshake_type & flag);
+}
+
+S2N_RESULT s2n_handshake_type_reset(struct s2n_connection *conn)
+{
+    RESULT_ENSURE_REF(conn);
+    conn->handshake.handshake_type = 0;
+    return S2N_RESULT_OK;
+}

--- a/tls/s2n_handshake_type.h
+++ b/tls/s2n_handshake_type.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "utils/s2n_result.h"
+
+/* Maximum number of valid handshakes */
+#define S2N_HANDSHAKES_COUNT        128
+
+#define IS_NEGOTIATED(conn)                 \
+    ( s2n_handshake_type_check_flag(conn, NEGOTIATED) )
+
+#define IS_FULL_HANDSHAKE(conn)             \
+    ( s2n_handshake_type_check_flag(conn, FULL_HANDSHAKE) )
+
+#define IS_RESUMPTION_HANDSHAKE(conn)       \
+    ( !IS_FULL_HANDSHAKE(conn) && IS_NEGOTIATED(conn) )
+
+#define IS_CLIENT_AUTH_HANDSHAKE(conn)      \
+    ( s2n_handshake_type_check_flag(conn, CLIENT_AUTH) )
+
+#define IS_CLIENT_AUTH_NO_CERT(conn)        \
+    ( IS_CLIENT_AUTH_HANDSHAKE(conn) && s2n_handshake_type_check_flag(conn, NO_CLIENT_CERT) )
+
+#define IS_TLS12_PERFECT_FORWARD_SECRECY_HANDSHAKE(conn) \
+    ( s2n_handshake_type_check_tls12_flag(conn, TLS12_PERFECT_FORWARD_SECRECY) )
+
+#define IS_OCSP_STAPLED(conn)               \
+    ( s2n_handshake_type_check_tls12_flag(conn, OCSP_STATUS) )
+
+#define IS_ISSUING_NEW_SESSION_TICKET(conn) \
+    ( s2n_handshake_type_check_tls12_flag(conn, WITH_SESSION_TICKET) )
+
+#define IS_HELLO_RETRY_HANDSHAKE(conn)      \
+    ( s2n_handshake_type_check_tls13_flag(conn, HELLO_RETRY_REQUEST) )
+
+#define IS_MIDDLEBOX_COMPAT_MODE(conn)      \
+    ( s2n_handshake_type_check_tls13_flag(conn, MIDDLEBOX_COMPAT) )
+
+#define WITH_EARLY_DATA(conn)               \
+    ( s2n_handshake_type_check_tls13_flag(conn, WITH_EARLY_DATA) )
+
+typedef enum {
+    INITIAL                         = 0,
+    NEGOTIATED                      = 1,
+    FULL_HANDSHAKE                  = 2,
+    CLIENT_AUTH                     = 4,
+    NO_CLIENT_CERT                  = 8,
+} s2n_handshake_type_flag;
+
+S2N_RESULT s2n_handshake_type_set_flag(struct s2n_connection *conn, s2n_handshake_type_flag flag);
+bool s2n_handshake_type_check_flag(struct s2n_connection *conn, s2n_handshake_type_flag flag);
+
+typedef enum {
+    TLS12_PERFECT_FORWARD_SECRECY   = 16,
+    OCSP_STATUS                     = 32,
+    WITH_SESSION_TICKET             = 64,
+} s2n_tls12_handshake_type_flag;
+
+S2N_RESULT s2n_handshake_type_set_tls12_flag(struct s2n_connection *conn, s2n_tls12_handshake_type_flag flag);
+S2N_RESULT s2n_handshake_type_unset_tls12_flag(struct s2n_connection *conn, s2n_tls12_handshake_type_flag flag);
+bool s2n_handshake_type_check_tls12_flag(struct s2n_connection *conn, s2n_tls12_handshake_type_flag flag);
+
+typedef enum {
+    HELLO_RETRY_REQUEST             = 16,
+    MIDDLEBOX_COMPAT                = 32,
+    WITH_EARLY_DATA                 = 64,
+} s2n_tls13_handshake_type_flag;
+
+S2N_RESULT s2n_handshake_type_set_tls13_flag(struct s2n_connection *conn, s2n_tls13_handshake_type_flag flag);
+bool s2n_handshake_type_check_tls13_flag(struct s2n_connection *conn, s2n_tls13_handshake_type_flag flag);
+
+S2N_RESULT s2n_handshake_type_reset(struct s2n_connection *conn);

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -344,7 +344,7 @@ int s2n_connection_get_session_length(struct s2n_connection *conn)
 int s2n_connection_is_session_resumed(struct s2n_connection *conn)
 {
     return conn && (s2n_connection_get_protocol_version(conn) < S2N_TLS13)
-           && IS_RESUMPTION_HANDSHAKE(conn->handshake.handshake_type);
+           && IS_RESUMPTION_HANDSHAKE(conn);
 }
 
 int s2n_connection_is_ocsp_stapled(struct s2n_connection *conn)
@@ -354,7 +354,7 @@ int s2n_connection_is_ocsp_stapled(struct s2n_connection *conn)
     if (conn->actual_protocol_version >= S2N_TLS13) {
         return (s2n_server_can_send_ocsp(conn) || s2n_server_sent_ocsp(conn));
     } else {
-        return IS_OCSP_STAPLED(conn->handshake.handshake_type);
+        return IS_OCSP_STAPLED(conn);
     }
 }
 
@@ -632,13 +632,11 @@ int s2n_decrypt_session_ticket(struct s2n_connection *conn)
         /* Check if a key in encrypt-decrypt state is available */
         if (s2n_config_is_encrypt_decrypt_key_available(conn->config) == 1) {
             conn->session_ticket_status = S2N_NEW_TICKET;
-            conn->handshake.handshake_type |= WITH_SESSION_TICKET;
-
-            return 0;
+            POSIX_GUARD_RESULT(s2n_handshake_type_set_tls12_flag(conn, WITH_SESSION_TICKET));
+            return S2N_SUCCESS;
         }
     }
-
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_encrypt_session_cache(struct s2n_connection *conn, struct s2n_stuffer *to)


### PR DESCRIPTION
### Description of changes: 

After https://github.com/aws/s2n-tls/pull/2594/files, the handshake array length doubled again from 512 to 1024 bytes. That's a total of 1024 (handshakes count) * 32 (handshake length) * 2 (message type size) * 2 (both TLS1.2 and TLS1.3) = 131KB of memory just for the handshakes, plus the 1024 (handshakes count) * 115 (string buffer) = 117KB for the handshake type name arrays. That's a total of 248KB of mostly empty memory.

A change to the handshake arrays themselves like switching to a perfect hash would probably require major refactoring of the SAW proofs, which currently rely on being able to compare arrays directly.

Instead, this solution takes advantage of the fact that the TLS1.2 and TLS1.3 handshake types share only a few handshake type flags. We allow those handshake type flags to be reused between versions. For example, now both OCSP_STATUS and MIDDLEBOX_COMPAT are "32", so the meaning changes depending on the version. We prevent accidentally setting OCSP_STATUS when MIDDLEBOX_COMPAT was intended by checking the version when both getting and setting the flags.

After this fix, the handshakes take up 128 * 32 * 2 * 2 + 128 * 115 = 31K bytes.

### Call-outs:

* **Why different methods for handling TLS12 and TLS13 flags?** Because common, TLS12, and TLS13 flags are all different enum types, we can use separate methods to enforce that an attempt to set/get a TLS12 flag always goes through the method that checks that the protocol version is TLS12. Trying to pass a TLS12 flag to a method that expects a TLS13 flag will produce a compiler error with some compilers (like clang): https://godbolt.org/z/cdzcY9 This will cause our CI to fail, as any of the build that use clang (currently just the fuzzers) will fail: https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nOmnibus/build/s2nOmnibus%3A6d2ccecf-98c5-4767-b2eb-d5c634c0683d/?region=us-west-2

### Testing:

Unit tests, updated SAW tests.

* Is this a refactor change? Yes. I've done my best to only make exact swaps / minor changes to existing tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
