### PR TITLE
ci: bump the asan coverage instance type to large

### DIFF
--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -283,7 +283,7 @@ batch:
       buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         privileged-mode: true
-        compute-type: BUILD_GENERAL1_SMALL
+        compute-type: BUILD_GENERAL1_LARGE
         variables:
           TESTS: asan
           GCC_VERSION: '6'
@@ -297,7 +297,7 @@ batch:
       buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         privileged-mode: true
-        compute-type: BUILD_GENERAL1_SMALL
+        compute-type: BUILD_GENERAL1_LARGE
         variables:
           TESTS: asan
           GCC_VERSION: '6'


### PR DESCRIPTION
### Resolved issues:

Fixes #2629 

### Description of changes: 

The current ASAN instance types are small which seems to lead to memory exhaustion failures. This change bumps the instance sizes to large

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
