### PR TITLE
Fixed -Werror=strict-prototypes failure on s2n_error_location

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -58,7 +58,7 @@ extern __thread int s2n_errno;
  * in runtimes where thread-local variables may not be easily accessible.
  */
 S2N_API
-extern int *s2n_errno_location();
+extern int *s2n_errno_location(void);
 
 typedef enum {
     S2N_ERR_T_OK=0,


### PR DESCRIPTION
### Resolved issues:

 ```
s2n/api/s2n.h:61:1: error: function declaration isn’t a prototype [-Werror=strict-prototypes]
 extern int *s2n_errno_location();
 ^~~~~~
```

### Description of changes: 

Trivial change, should not affect anything, just brings this declaration into standards compliance.

### Testing:

Compile with -Werror=strict-prototypes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
