### PR TITLE
Adding integration test for external psks with s2nd and s2nc

### DIFF
--- a/bin/common.c
+++ b/bin/common.c
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+#include "common.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -74,4 +75,21 @@ int key_log_callback(void *file, struct s2n_connection *conn, uint8_t *logline, 
     }
 
     return fflush((FILE *)file);
+}
+
+int get_s2n_psk_hmac(s2n_psk_hmac *psk_hmac, char *hmac_str)
+{
+    notnull_check(psk_hmac);
+    notnull_check(hmac_str);
+
+    if (strcmp(hmac_str, "S2N_PSK_HMAC_SHA224") == 0) {
+        *psk_hmac = S2N_PSK_HMAC_SHA224;
+    } else if (strcmp(hmac_str, "S2N_PSK_HMAC_SHA256") == 0) {
+        *psk_hmac = S2N_PSK_HMAC_SHA256;
+    } else if (strcmp(hmac_str, "S2N_PSK_HMAC_SHA384") == 0) {
+        *psk_hmac = S2N_PSK_HMAC_SHA384;
+    } else {
+        return S2N_FAILURE;
+    }
+    return S2N_SUCCESS;
 }

--- a/bin/common.h
+++ b/bin/common.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <stdint.h>
+#include "tls/s2n_psk.h"
+#include "utils/s2n_safety.h"
 
 #define GUARD_EXIT(x, msg)  \
   do {                      \
@@ -33,6 +35,8 @@
     }                        \
   } while (0)
 
+#define S2N_MAX_NO_OF_PSKS_IN_LIST 10
+
 void print_s2n_error(const char *app_error);
 int echo(struct s2n_connection *conn, int sockfd);
 int negotiate(struct s2n_connection *conn, int sockfd);
@@ -40,3 +44,4 @@ int https(struct s2n_connection *conn, uint32_t bench);
 int key_log_callback(void *ctx, struct s2n_connection *conn, uint8_t *logline, size_t len);
 
 char *load_file_to_cstring(const char *path);
+int get_s2n_psk_hmac(s2n_psk_hmac *psk_hmac, char *hmac_str);

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -31,6 +31,7 @@
 
 #include "crypto/s2n_rsa.h"
 #include "crypto/s2n_pkey.h"
+#include "tls/s2n_connection.h"
 
 #define STDIO_BUFSIZE  10240
 
@@ -70,6 +71,8 @@ static int wait_for_event(int fd, s2n_blocked_status blocked)
 
 int negotiate(struct s2n_connection *conn, int fd)
 {
+    notnull_check(conn);
+
     s2n_blocked_status blocked;
     while (s2n_negotiate(conn, &blocked) != S2N_SUCCESS) {
         if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
@@ -135,6 +138,10 @@ int negotiate(struct s2n_connection *conn, int fd)
     printf("Cipher negotiated: %s\n", s2n_connection_get_cipher(conn));
     if (s2n_connection_is_session_resumed(conn)) {
         printf("Resumed session\n");
+    }
+
+    if (conn->psk_params.chosen_psk) {
+        printf("\nPSK has been chosen with wire index: %d\n", conn->psk_params.chosen_psk_wire_index);
     }
 
     return 0;

--- a/tests/integrationv2/test_external_psk.py
+++ b/tests/integrationv2/test_external_psk.py
@@ -1,0 +1,79 @@
+import copy
+import os
+import pytest
+import time
+
+from configuration import available_ports, TLS13_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS
+from common import ProviderOptions, Protocols, data_bytes, Curves
+from fixtures import managed_process
+from providers import Provider, S2N, OpenSSL
+from utils import invalid_test_parameters, get_parameter_name
+
+CLIENT_PSK_PARAMETERS = [ 
+    ['--psk', 'id,secret,S2N_PSK_HMAC_SHA256'],  # No shared PSK 
+    ['--psk', 'id1,secret1,S2N_PSK_HMAC_SHA224', # Shared PSK at the wire index 1
+     '--psk', 'shared_id,shared_secret,S2N_PSK_HMAC_SHA256'],
+    ['--psk', 'id,secret,S2N_PSK_HMAC_SHA224',   # Shared PSK at the wire index 2
+     '--psk', 'id1,secret1,S2N_PSK_HMAC_SHA256',
+     '--psk', 'shared_id,shared_secret,S2N_PSK_HMAC_SHA256'],
+    ['--psk', 'id,secret,S2N_PSK_HMAC_SHA512',   # Invalid psk hmac algorithm obtained 
+     '--psk', 'shared_id,shared_secret,S2N_PSK_HMAC_SHA256']
+]
+
+SERVER_PSK_PARAMETERS = [
+    ['--psk', 'psk_id,psk_secret,S2N_PSK_HMAC_SHA384',
+     '--psk', 'shared_id,shared_secret,S2N_PSK_HMAC_SHA256'],
+]
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
+@pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
+@pytest.mark.parametrize("client_psk_params", CLIENT_PSK_PARAMETERS, ids=get_parameter_name)
+@pytest.mark.parametrize("server_psk_params", SERVER_PSK_PARAMETERS, ids=get_parameter_name)
+def test_external_psk_s2nc_with_s2nd(managed_process, cipher, protocol, client_psk_params, server_psk_params):
+    port = next(available_ports)
+
+    random_bytes = data_bytes(64)
+    client_options = ProviderOptions(
+        mode=S2N.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=cipher,
+        data_to_send=random_bytes,
+        insecure=True,
+        extra_flags=client_psk_params,
+        protocol=protocol)
+    
+    server_options = copy.copy(client_options)
+    server_options.data_to_send = None
+    server_options.mode = Provider.ServerMode
+    server_options.extra_flags = server_psk_params
+
+    # Passing the type of client and server as a parameter will
+    # allow us to use a fixture to enumerate all possibilities.
+    server = managed_process(S2N, server_options, timeout=5)
+    client = managed_process(S2N, client_options, timeout=5)
+
+    idx = CLIENT_PSK_PARAMETERS.index(client_psk_params)
+    
+    for results in client.get_results():
+        assert results.exception is None
+        if idx == 0: 
+            assert b"PSK has been chosen with wire index" not in results.stdout
+            assert results.exit_code == 0
+        elif idx == 1 or idx == 2: 
+            assert bytes("PSK has been chosen with wire index: {}".format(idx).encode('utf-8')) in results.stdout
+            assert results.exit_code == 0
+        elif idx == 3: 
+            assert b"Invalid psk hmac algorithm" in results.stderr
+            assert results.exit_code != 0
+    
+    for results in server.get_results():
+        assert results.exception is None
+        if idx == 0: 
+            assert b"PSK has been chosen with wire index" not in results.stdout
+        elif idx == 1 or idx == 2:
+            assert bytes("PSK has been chosen with wire index: {}".format(idx).encode('utf-8')) in results.stdout
+            assert results.exit_code == 0
+        elif idx == 3:
+            assert results.exit_code != 0


### PR DESCRIPTION
### Resolved issues:

#2326

### Description of changes: 

To test external PSKs we need to extend the ability  of s2nd and s2nc to append/set the psk_list supported by the client. This includes inputting the psk_identity, psk_secret and its corresponding psk hmac algorithm and constructing an external psk using `s2n_external_psk_new`, setting the psk identity, psk secret and psk hmac algorithm using `s2n_psk_set_identity`, `s2n_psk_set_secret` and `s2n_psk_set_hmac` and using the `s2n_connection_append_psk`  to append the constructed s2n_external_psk_new psk to the client connection. Additionally on the server side, we need to extend the ability of the s2nd server to select a `chosen_psk_wire_index` from a list of `s2n_offered_psks` by setting the `s2n_config_set_psk_selection_callback` function.

```
s2nc --psk psk_identity_1, psk_secret_1, psk_hmac_alg_1  --psk psk_identity_2, psk_secret_2, psk_hmac_alg_2 ... --psk psk_identity_n, psk_secret_n, psk_hmac_alg_n
```

and 

```
s2nd --psk psk_identity_1, psk_secret_1, psk_hmac_alg_1  --psk psk_identity_2, psk_secret_2, psk_hmac_alg_2 ... --psk psk_identity_n, psk_secret_n, psk_hmac_alg_n
 ```

### Call-outs:

- The choice of using command line parameters over using a file to obtain the psk paramaters was made for keeping it simple and  easy to use. We can always revert to using a file if the need to expand arises. 
- The S2N_MAX_NO_OF_PSKS_IN_LIST is set to an arbitary number of 10 
- This PR only integ tests s2nc with s2nd. I will be adding s2nd/s2nc with other providers to different PRs. 
 
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? Integration Tests. 

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
