### PR TITLE
util: remove S2N_RESULT_TO_POSIX macro to reduce confusion

### DIFF
--- a/tls/extensions/s2n_client_early_data_indication.c
+++ b/tls/extensions/s2n_client_early_data_indication.c
@@ -90,7 +90,8 @@ static bool s2n_client_early_data_indication_should_send(struct s2n_connection *
 
 static int s2n_client_early_data_indication_is_missing(struct s2n_connection *conn)
 {
-    return S2N_RESULT_TO_POSIX(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_NOT_REQUESTED));
+    POSIX_GUARD_RESULT(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_NOT_REQUESTED));
+    return S2N_SUCCESS;
 }
 
 /**
@@ -115,7 +116,8 @@ static int s2n_client_early_data_indication_is_missing(struct s2n_connection *co
 
 static int s2n_client_early_data_indication_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    return S2N_RESULT_TO_POSIX(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_REQUESTED));
+    POSIX_GUARD_RESULT(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_REQUESTED));
+    return S2N_SUCCESS;
 }
 
 static int s2n_client_early_data_indiction_recv(struct s2n_connection *conn, struct s2n_stuffer *in)
@@ -127,7 +129,8 @@ static int s2n_client_early_data_indiction_recv(struct s2n_connection *conn, str
      */
     ENSURE_POSIX(!s2n_is_hello_retry_handshake(conn), S2N_ERR_UNSUPPORTED_EXTENSION);
 
-    return S2N_RESULT_TO_POSIX(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_REQUESTED));
+    POSIX_GUARD_RESULT(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_REQUESTED));
+    return S2N_SUCCESS;
 }
 
 const s2n_extension_type s2n_client_early_data_indication_extension = {

--- a/tls/s2n_async_pkey.h
+++ b/tls/s2n_async_pkey.h
@@ -56,10 +56,10 @@ struct s2n_async_pkey_op;
  * call, we use a macro which directly returns the result of s2n_async* operation forcing compiler to error out on
  * unreachable code and forcing developer to use on_complete function instead */
 #define S2N_ASYNC_PKEY_DECRYPT(conn, encrypted, init_decrypted, on_complete) \
-    return S2N_RESULT_TO_POSIX(s2n_async_pkey_decrypt(conn, encrypted, init_decrypted, on_complete));
+    return s2n_result_is_ok(s2n_async_pkey_decrypt(conn, encrypted, init_decrypted, on_complete)) ? S2N_SUCCESS : S2N_FAILURE;
 
 #define S2N_ASYNC_PKEY_SIGN(conn, sig_alg, digest, on_complete) \
-    return S2N_RESULT_TO_POSIX(s2n_async_pkey_sign(conn, sig_alg, digest, on_complete));
+    return s2n_result_is_ok(s2n_async_pkey_sign(conn, sig_alg, digest, on_complete)) ? S2N_SUCCESS : S2N_FAILURE;
 
 int s2n_async_pkey_op_perform(struct s2n_async_pkey_op *op, s2n_cert_private_key *key);
 int s2n_async_pkey_op_apply(struct s2n_async_pkey_op *op, struct s2n_connection *conn);

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -116,10 +116,12 @@ S2N_RESULT s2n_early_data_config_clone(struct s2n_psk *new_psk, struct s2n_early
 
 int s2n_end_of_early_data_send(struct s2n_connection *conn)
 {
-    return S2N_RESULT_TO_POSIX(s2n_connection_set_early_data_state(conn, S2N_END_OF_EARLY_DATA));
+    POSIX_GUARD_RESULT(s2n_connection_set_early_data_state(conn, S2N_END_OF_EARLY_DATA));
+    return S2N_SUCCESS;
 }
 
 int s2n_end_of_early_data_recv(struct s2n_connection *conn)
 {
-    return S2N_RESULT_TO_POSIX(s2n_connection_set_early_data_state(conn, S2N_END_OF_EARLY_DATA));
+    POSIX_GUARD_RESULT(s2n_connection_set_early_data_state(conn, S2N_END_OF_EARLY_DATA));
+    return S2N_SUCCESS;
 }

--- a/tls/s2n_protocol_preferences.c
+++ b/tls/s2n_protocol_preferences.c
@@ -139,20 +139,24 @@ S2N_RESULT s2n_protocol_preferences_set(struct s2n_blob *application_protocols, 
 
 int s2n_config_set_protocol_preferences(struct s2n_config *config, const char *const *protocols, int protocol_count)
 {
-    return S2N_RESULT_TO_POSIX(s2n_protocol_preferences_set(&config->application_protocols, protocols, protocol_count));
+    POSIX_GUARD_RESULT(s2n_protocol_preferences_set(&config->application_protocols, protocols, protocol_count));
+    return S2N_SUCCESS;
 }
 
 int s2n_config_append_protocol_preference(struct s2n_config *config, const uint8_t *protocol, uint8_t protocol_len)
 {
-    return S2N_RESULT_TO_POSIX(s2n_protocol_preferences_append(&config->application_protocols, protocol, protocol_len));
+    POSIX_GUARD_RESULT(s2n_protocol_preferences_append(&config->application_protocols, protocol, protocol_len));
+    return S2N_SUCCESS;
 }
 
 int s2n_connection_set_protocol_preferences(struct s2n_connection *conn, const char * const *protocols, int protocol_count)
 {
-    return S2N_RESULT_TO_POSIX(s2n_protocol_preferences_set(&conn->application_protocols_overridden, protocols, protocol_count));
+    POSIX_GUARD_RESULT(s2n_protocol_preferences_set(&conn->application_protocols_overridden, protocols, protocol_count));
+    return S2N_SUCCESS;
 }
 
 int s2n_connection_append_protocol_preference(struct s2n_connection *conn, const uint8_t *protocol, uint8_t protocol_len)
 {
-    return S2N_RESULT_TO_POSIX(s2n_protocol_preferences_append(&conn->application_protocols_overridden, protocol, protocol_len));
+    POSIX_GUARD_RESULT(s2n_protocol_preferences_append(&conn->application_protocols_overridden, protocol, protocol_len));
+    return S2N_SUCCESS;
 }

--- a/utils/s2n_result.h
+++ b/utils/s2n_result.h
@@ -58,6 +58,3 @@ void s2n_result_ignore(s2n_result result);
  * We need a version of s2n_result which can be ignored.
  */
 #define S2N_CLEANUP_RESULT s2n_result
-
-/* converts the S2N_RESULT into posix error codes */
-#define S2N_RESULT_TO_POSIX( x ) (s2n_result_is_ok(x) ? S2N_SUCCESS : S2N_FAILURE)


### PR DESCRIPTION
### Description of changes: 

We have a `S2N_RESULT_TO_POSIX` macro that converts a `s2n_result` to a POSIX error signal. This can cause confusion around in which contexts it should be used, as opposed to `GUARD`.

This change removes the macro entirely and replaces any use of them with the appropriate safe alternative.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
