### PR TITLE
utils: remove the usage of S2N_ERROR_IF in favor of POSIX_ENSURE

### DIFF
--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -166,10 +166,8 @@ int cache_store_callback(struct s2n_connection *conn, void *ctx, uint64_t ttl, c
 {
     struct session_cache_entry *cache = ctx;
 
-    POSIX_ENSURE(key_size > 0, S2N_ERR_INVALID_ARGUMENT);
-    POSIX_ENSURE(key_size <= MAX_KEY_LEN, S2N_ERR_INVALID_ARGUMENT);
-    POSIX_ENSURE(value_size > 0, S2N_ERR_INVALID_ARGUMENT);
-    POSIX_ENSURE(value_size <= MAX_VAL_LEN, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE_INCLUSIVE_RANGE(1, key_size, MAX_KEY_LEN);
+    POSIX_ENSURE_INCLUSIVE_RANGE(1, value_size, MAX_VAL_LEN);
 
     uint8_t idx = ((const uint8_t *)key)[0];
 
@@ -186,8 +184,7 @@ int cache_retrieve_callback(struct s2n_connection *conn, void *ctx, const void *
 {
     struct session_cache_entry *cache = ctx;
 
-    POSIX_ENSURE(key_size > 0, S2N_ERR_INVALID_ARGUMENT);
-    POSIX_ENSURE(key_size <= MAX_KEY_LEN, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE_INCLUSIVE_RANGE(1, key_size, MAX_KEY_LEN);
 
     uint8_t idx = ((const uint8_t *)key)[0];
 
@@ -210,8 +207,7 @@ int cache_delete_callback(struct s2n_connection *conn, void *ctx, const void *ke
 {
     struct session_cache_entry *cache = ctx;
 
-    POSIX_ENSURE(key_size > 0, S2N_ERR_INVALID_ARGUMENT);
-    POSIX_ENSURE(key_size <= MAX_KEY_LEN, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE_INCLUSIVE_RANGE(1, key_size, MAX_KEY_LEN);
 
     uint8_t idx = ((const uint8_t *)key)[0];
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -166,8 +166,10 @@ int cache_store_callback(struct s2n_connection *conn, void *ctx, uint64_t ttl, c
 {
     struct session_cache_entry *cache = ctx;
 
-    S2N_ERROR_IF(key_size == 0 || key_size > MAX_KEY_LEN, S2N_ERR_INVALID_ARGUMENT);
-    S2N_ERROR_IF(value_size == 0 || value_size > MAX_VAL_LEN, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE(key_size > 0, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE(key_size <= MAX_KEY_LEN, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE(value_size > 0, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE(value_size <= MAX_VAL_LEN, S2N_ERR_INVALID_ARGUMENT);
 
     uint8_t idx = ((const uint8_t *)key)[0];
 
@@ -184,13 +186,14 @@ int cache_retrieve_callback(struct s2n_connection *conn, void *ctx, const void *
 {
     struct session_cache_entry *cache = ctx;
 
-    S2N_ERROR_IF(key_size == 0 || key_size > MAX_KEY_LEN, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE(key_size > 0, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE(key_size <= MAX_KEY_LEN, S2N_ERR_INVALID_ARGUMENT);
 
     uint8_t idx = ((const uint8_t *)key)[0];
 
-    S2N_ERROR_IF(cache[idx].key_len != key_size, S2N_ERR_INVALID_ARGUMENT);
-    S2N_ERROR_IF(memcmp(cache[idx].key, key, key_size), S2N_ERR_INVALID_ARGUMENT);
-    S2N_ERROR_IF(*value_size < cache[idx].value_len, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE(cache[idx].key_len == key_size, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE(memcmp(cache[idx].key, key, key_size) == 0, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE(*value_size >= cache[idx].value_len, S2N_ERR_INVALID_ARGUMENT);
 
     *value_size = cache[idx].value_len;
     memcpy(value, cache[idx].value, cache[idx].value_len);
@@ -207,12 +210,15 @@ int cache_delete_callback(struct s2n_connection *conn, void *ctx, const void *ke
 {
     struct session_cache_entry *cache = ctx;
 
-    S2N_ERROR_IF(key_size == 0 || key_size > MAX_KEY_LEN, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE(key_size > 0, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE(key_size <= MAX_KEY_LEN, S2N_ERR_INVALID_ARGUMENT);
 
     uint8_t idx = ((const uint8_t *)key)[0];
 
-    S2N_ERROR_IF(cache[idx].key_len != 0 && cache[idx].key_len != key_size, S2N_ERR_INVALID_ARGUMENT);
-    S2N_ERROR_IF(cache[idx].key_len != 0 && memcmp(cache[idx].key, key, key_size), S2N_ERR_INVALID_ARGUMENT);
+    if (cache[idx].key_len != 0) {
+        POSIX_ENSURE(cache[idx].key_len == key_size, S2N_ERR_INVALID_ARGUMENT);
+        POSIX_ENSURE(memcmp(cache[idx].key, key, key_size) == 0, S2N_ERR_INVALID_ARGUMENT);
+    }
 
     cache[idx].key_len = 0;
     cache[idx].value_len = 0;
@@ -726,7 +732,7 @@ int main(int argc, char *const *argv)
             GUARD_EXIT(fstat(fd, &st), "Error fstat-ing session ticket key file");
 
             st_key = mmap(0, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
-            S2N_ERROR_IF(st_key == MAP_FAILED, S2N_ERR_MMAP);
+            ENSURE_POSIX(st_key != MAP_FAILED, S2N_ERR_MMAP);
 
             st_key_length = st.st_size;
 

--- a/codebuild/bin/grep_simple_mistakes.sh
+++ b/codebuild/bin/grep_simple_mistakes.sh
@@ -81,12 +81,25 @@ done
 # warn if any local variables called "index" are used because they are considered to shadow that declaration. 
 S2N_FILES_ASSERT_VARIABLE_NAME_INDEX=$(find "$PWD" -type f -name "s2n*.[ch]")
 for file in $S2N_FILES_ASSERT_VARIABLE_NAME_INDEX; do
-
-RESULT_VARIABLE_NAME_INDEX=`gcc -fpreprocessed -dD -E -w $file | grep -v '"' | grep '[\*|,|;|[:space:]]index[;|,|\)|[:space:]]'`
+  RESULT_VARIABLE_NAME_INDEX=`gcc -fpreprocessed -dD -E -w $file | grep -v '"' | grep '[\*|,|;|[:space:]]index[;|,|\)|[:space:]]'`
   if [ "${#RESULT_VARIABLE_NAME_INDEX}" != "0" ]; then
-  FAILED=1
-  printf "\e[1;34mGrep for variable name 'index' check failed in $file:\e[0m\n$RESULT_VARIABLE_NAME_INDEX\n\n"
+    FAILED=1
+    printf "\e[1;34mGrep for variable name 'index' check failed in $file:\e[0m\n$RESULT_VARIABLE_NAME_INDEX\n\n"
   fi
+done
+
+## Assert that there are no new uses of S2N_ERROR_IF
+# TODO add crypto, tls (see https://github.com/aws/s2n-tls/issues/2635)
+S2N_ERROR_IF_FREE="bin error pq-crypto scram stuffer utils tests"
+for dir in $S2N_ERROR_IF_FREE; do
+  files=$(find "$dir" -type f -name "*.c" -path "*")
+  for file in $files; do
+    result=`grep -Ern 'S2N_ERROR_IF' $file`
+    if [ "${#result}" != "0" ]; then
+      FAILED=1
+      printf "\e[1;34mUsage of 'S2N_ERROR_IF' check failed. Use 'POSIX_ENSURE' instead in $file:\e[0m\n$result\n\n"
+    fi
+  done
 done
 
 if [ $FAILED == 1 ]; then

--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -282,7 +282,6 @@ extern __thread const char *s2n_debug_str;
 #define S2N_ERROR_PRESERVE_ERRNO() do { return -1; } while (0)
 #define S2N_ERROR_PTR( x )  do { _S2N_ERROR( ( x ) ); return NULL; } while (0)
 #define S2N_ERROR_IF( cond , x ) do { if ( cond ) { S2N_ERROR( x ); }} while (0)
-#define S2N_ERROR_IF_PTR( cond , x ) do { if ( cond ) { S2N_ERROR_PTR( x ); }} while (0)
 #define S2N_ERROR_IS_BLOCKING( x )    ( s2n_error_get_type(x) == S2N_ERR_T_BLOCKED )
 
 /**

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -212,7 +212,7 @@ int s2n_stuffer_wipe(struct s2n_stuffer *stuffer)
 int s2n_stuffer_skip_read(struct s2n_stuffer *stuffer, uint32_t n)
 {
     PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
-    S2N_ERROR_IF(s2n_stuffer_data_available(stuffer) < n, S2N_ERR_STUFFER_OUT_OF_DATA);
+    POSIX_ENSURE(s2n_stuffer_data_available(stuffer) >= n, S2N_ERR_STUFFER_OUT_OF_DATA);
 
     stuffer->read_cursor += n;
     return S2N_SUCCESS;
@@ -366,7 +366,7 @@ int s2n_stuffer_reserve_space(struct s2n_stuffer *stuffer, uint32_t n)
 {
     PRECONDITION_POSIX(s2n_stuffer_validate(stuffer));
     if (s2n_stuffer_space_remaining(stuffer) < n) {
-        S2N_ERROR_IF(!stuffer->growable, S2N_ERR_STUFFER_IS_FULL);
+        POSIX_ENSURE(stuffer->growable, S2N_ERR_STUFFER_IS_FULL);
         /* Always grow a stuffer by at least 1k */
         const uint32_t growth = MAX(n - s2n_stuffer_space_remaining(stuffer), S2N_MIN_STUFFER_GROWTH_IN_BYTES);
         uint32_t new_size = 0;

--- a/stuffer/s2n_stuffer_base64.c
+++ b/stuffer/s2n_stuffer_base64.c
@@ -101,24 +101,19 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
         /* The first two characters can never be '=' and in general
          * everything has to be a valid character.
          */
-        POSIX_ENSURE(value1 != 64, S2N_ERR_INVALID_BASE64);
-        POSIX_ENSURE(value2 != 64, S2N_ERR_INVALID_BASE64);
-        POSIX_ENSURE(value2 != 255, S2N_ERR_INVALID_BASE64);
-        POSIX_ENSURE(value3 != 255, S2N_ERR_INVALID_BASE64);
-        POSIX_ENSURE(value4 != 255, S2N_ERR_INVALID_BASE64);
+        POSIX_ENSURE(!(value1 == 64 || value2 == 64 || value2 == 255 || value3 == 255 || value4 == 255), S2N_ERR_INVALID_BASE64);
 
         if (o.data[2] == '=') {
             /* If there is only one output byte, then the second value
              * should have none of its bottom four bits set.
              */
-            POSIX_ENSURE(o.data[3] == '=', S2N_ERR_INVALID_BASE64);
-            POSIX_ENSURE((value2 & 0x0f) == 0, S2N_ERR_INVALID_BASE64);
+            POSIX_ENSURE(!(o.data[3] != '=' || value2 & 0x0f), S2N_ERR_INVALID_BASE64);
             bytes_this_round = 1;
             value3 = 0;
             value4 = 0;
         } else if (o.data[3] == '=') {
             /* The last two bits of the final value should be unset */
-            POSIX_ENSURE((value3 & 0x03) == 0, S2N_ERR_INVALID_BASE64);
+            POSIX_ENSURE(!(value3 & 0x03), S2N_ERR_INVALID_BASE64);
 
             bytes_this_round = 2;
             value4 = 0;

--- a/stuffer/s2n_stuffer_base64.c
+++ b/stuffer/s2n_stuffer_base64.c
@@ -101,19 +101,24 @@ int s2n_stuffer_read_base64(struct s2n_stuffer *stuffer, struct s2n_stuffer *out
         /* The first two characters can never be '=' and in general
          * everything has to be a valid character.
          */
-        S2N_ERROR_IF(value1 == 64 || value2 == 64 || value2 == 255 || value3 == 255 || value4 == 255, S2N_ERR_INVALID_BASE64);
+        POSIX_ENSURE(value1 != 64, S2N_ERR_INVALID_BASE64);
+        POSIX_ENSURE(value2 != 64, S2N_ERR_INVALID_BASE64);
+        POSIX_ENSURE(value2 != 255, S2N_ERR_INVALID_BASE64);
+        POSIX_ENSURE(value3 != 255, S2N_ERR_INVALID_BASE64);
+        POSIX_ENSURE(value4 != 255, S2N_ERR_INVALID_BASE64);
 
         if (o.data[2] == '=') {
             /* If there is only one output byte, then the second value
              * should have none of its bottom four bits set.
              */
-            S2N_ERROR_IF(o.data[3] != '=' || value2 & 0x0f, S2N_ERR_INVALID_BASE64);
+            POSIX_ENSURE(o.data[3] == '=', S2N_ERR_INVALID_BASE64);
+            POSIX_ENSURE((value2 & 0x0f) == 0, S2N_ERR_INVALID_BASE64);
             bytes_this_round = 1;
             value3 = 0;
             value4 = 0;
         } else if (o.data[3] == '=') {
             /* The last two bits of the final value should be unset */
-            S2N_ERROR_IF(value3 & 0x03, S2N_ERR_INVALID_BASE64);
+            POSIX_ENSURE((value3 & 0x03) == 0, S2N_ERR_INVALID_BASE64);
 
             bytes_this_round = 2;
             value4 = 0;

--- a/stuffer/s2n_stuffer_file.c
+++ b/stuffer/s2n_stuffer_file.c
@@ -38,11 +38,11 @@ int s2n_stuffer_recv_from_fd(struct s2n_stuffer *stuffer, const int rfd, const u
     ssize_t r = 0;
     do {
         r = read(rfd, stuffer->blob.data + stuffer->write_cursor, len);
-        S2N_ERROR_IF(r < 0 && errno != EINTR, S2N_ERR_READ);
+        POSIX_ENSURE(r >= 0 || errno == EINTR, S2N_ERR_READ);
     } while (r < 0);
 
     /* Record just how many bytes we have written */
-    S2N_ERROR_IF(r > UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    POSIX_ENSURE(r <= UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
     GUARD(s2n_stuffer_skip_write(stuffer, (uint32_t)r));
     if (bytes_written != NULL) *bytes_written = r;
     return S2N_SUCCESS;
@@ -61,10 +61,10 @@ int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, const int wfd, const uin
     ssize_t w = 0;
     do {
         w = write(wfd, stuffer->blob.data + stuffer->read_cursor, len);
-        S2N_ERROR_IF(w < 0 && errno != EINTR, S2N_ERR_WRITE);
+        POSIX_ENSURE(w >= 0 || errno == EINTR, S2N_ERR_WRITE);
     } while (w < 0);
 
-    S2N_ERROR_IF(w > UINT32_MAX - stuffer->read_cursor, S2N_ERR_INTEGER_OVERFLOW);
+    POSIX_ENSURE(w <= UINT32_MAX - stuffer->read_cursor, S2N_ERR_INTEGER_OVERFLOW);
     stuffer->read_cursor += w;
     if (bytes_sent != NULL) *bytes_sent = w;
     return S2N_SUCCESS;

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -157,11 +157,11 @@ int s2n_stuffer_write_uint64(struct s2n_stuffer *stuffer, const uint64_t u)
 static int length_matches_value_check(uint32_t value, uint8_t length)
 {
     /* Value is represented as a uint32_t, so shouldn't be assumed larger */
-    S2N_ERROR_IF(length > sizeof(uint32_t), S2N_ERR_SIZE_MISMATCH);
+    POSIX_ENSURE(length <= sizeof(uint32_t), S2N_ERR_SIZE_MISMATCH);
 
     if (length < sizeof(uint32_t)) {
         /* Value should be less than the maximum for its length */
-        S2N_ERROR_IF(value >= (0x01 << (length * 8)), S2N_ERR_SIZE_MISMATCH);
+        POSIX_ENSURE(value < (0x01 << (length * 8)), S2N_ERR_SIZE_MISMATCH);
     }
 
     return S2N_SUCCESS;

--- a/tests/fuzz/s2n_client_cert_verify_recv_test.c
+++ b/tests/fuzz/s2n_client_cert_verify_recv_test.c
@@ -129,7 +129,7 @@ int s2n_fuzz_init(int *argc, char **argv[])
     server_config = s2n_config_new();
     GUARD(s2n_config_add_cert_chain_and_key(server_config, certificate_chain, private_key));
     s2n_pkey_type pkey_type;
-    S2N_ERROR_IF(s2n_config_get_num_default_certs(server_config) == 0, S2N_ERR_NUM_DEFAULT_CERTIFICATES);
+    POSIX_ENSURE(s2n_config_get_num_default_certs(server_config) != 0, S2N_ERR_NUM_DEFAULT_CERTIFICATES);
     struct s2n_cert_chain_and_key *cert = s2n_config_get_single_default_cert(server_config);
     notnull_check(cert);
     GUARD(s2n_asn1der_to_public_key_and_type(&public_key, &pkey_type, &cert->cert_chain->head->raw));

--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -119,7 +119,7 @@ static int check_client_server_agreed_kem(const uint8_t iana_value[S2N_TLS_CIPHE
     GUARD(s2n_choose_kem_with_peer_pref_list(iana_value, &client_kem_blob, server_kem_pref_list, num_server_supported_kems, &negotiated_kem));
     GUARD_NONNULL(negotiated_kem);
 
-    S2N_ERROR_IF(negotiated_kem->kem_extension_id != expected_kem_id, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
+    POSIX_ENSURE(negotiated_kem->kem_extension_id == expected_kem_id, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
 
     return 0;
 }

--- a/tests/unit/s2n_rsa_pss_test.c
+++ b/tests/unit/s2n_rsa_pss_test.c
@@ -148,7 +148,7 @@ int main(int argc, char **argv)
 
         /* Parse the leaf cert for the public key and certificate type */
         EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&public_key, &pkey_type, &chain_and_key->cert_chain->head->raw));
-        S2N_ERROR_IF(pkey_type == S2N_PKEY_TYPE_UNKNOWN, S2N_ERR_CERT_TYPE_UNSUPPORTED);
+        EXPECT_NOT_EQUAL(pkey_type, S2N_PKEY_TYPE_UNKNOWN);
         EXPECT_SUCCESS(s2n_cert_set_cert_type(chain_and_key->cert_chain->head, pkey_type));
 
         struct s2n_pkey *private_key = chain_and_key->private_key;
@@ -228,8 +228,8 @@ int main(int argc, char **argv)
         /* Parse the cert for the public key and certificate type */
         EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&root_public_key, &root_pkey_type, &root_chain_and_key->cert_chain->head->raw));
         EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&leaf_public_key, &leaf_pkey_type, &leaf_chain_and_key->cert_chain->head->raw));
-        S2N_ERROR_IF(root_pkey_type == S2N_PKEY_TYPE_UNKNOWN, S2N_ERR_CERT_TYPE_UNSUPPORTED);
-        S2N_ERROR_IF(leaf_pkey_type == S2N_PKEY_TYPE_UNKNOWN, S2N_ERR_CERT_TYPE_UNSUPPORTED);
+        EXPECT_NOT_EQUAL(root_pkey_type, S2N_PKEY_TYPE_UNKNOWN);
+        EXPECT_NOT_EQUAL(leaf_pkey_type, S2N_PKEY_TYPE_UNKNOWN);
 
         EXPECT_SUCCESS(s2n_cert_set_cert_type(root_chain_and_key->cert_chain->head, root_pkey_type));
         EXPECT_SUCCESS(s2n_cert_set_cert_type(leaf_chain_and_key->cert_chain->head, leaf_pkey_type));
@@ -305,7 +305,7 @@ int main(int argc, char **argv)
 
         /* Parse the leaf cert for the public key and certificate type */
         EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&public_key, &pkey_type, &chain_and_key->cert_chain->head->raw));
-        S2N_ERROR_IF(pkey_type == S2N_PKEY_TYPE_UNKNOWN, S2N_ERR_CERT_TYPE_UNSUPPORTED);
+        EXPECT_NOT_EQUAL(pkey_type, S2N_PKEY_TYPE_UNKNOWN);
         EXPECT_SUCCESS(s2n_cert_set_cert_type(chain_and_key->cert_chain->head, pkey_type));
 
         struct s2n_pkey *private_key = chain_and_key->private_key;

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -110,14 +110,14 @@ int s2n_hex_string_to_bytes(const uint8_t *str, struct s2n_blob *blob)
     uint32_t len = strlen((const char*)str);
     /* protects against overflows */
     gte_check(blob->size, len / 2);
-    S2N_ERROR_IF(len % 2 != 0, S2N_ERR_INVALID_HEX);
+    POSIX_ENSURE(len % 2 == 0, S2N_ERR_INVALID_HEX);
 
     for (size_t i = 0; i < len; i += 2) {
         uint8_t high_nibble = hex_inverse[str[i]];
-        S2N_ERROR_IF(high_nibble == 255, S2N_ERR_INVALID_HEX);
+        POSIX_ENSURE(high_nibble != 255, S2N_ERR_INVALID_HEX);
 
         uint8_t low_nibble = hex_inverse[str[i + 1]];
-        S2N_ERROR_IF(low_nibble == 255, S2N_ERR_INVALID_HEX);
+        POSIX_ENSURE(low_nibble != 255, S2N_ERR_INVALID_HEX);
         blob->data[i / 2] = high_nibble << 4 | low_nibble;
     }
 

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -47,10 +47,10 @@ int s2n_init(void)
     GUARD_POSIX(s2n_extension_type_init());
     GUARD_AS_POSIX(s2n_pq_init());
 
-    S2N_ERROR_IF(atexit(s2n_cleanup_atexit) != 0, S2N_ERR_ATEXIT);
+    POSIX_ENSURE_OK(atexit(s2n_cleanup_atexit), S2N_ERR_ATEXIT);
 
     if (getenv("S2N_PRINT_STACKTRACE")) {
-      s2n_stack_traces_enabled_set(true);
+        s2n_stack_traces_enabled_set(true);
     }
 
     return 0;

--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -88,7 +88,7 @@ struct s2n_map *s2n_map_new()
 
 struct s2n_map *s2n_map_new_with_initial_capacity(uint32_t capacity)
 {
-    S2N_ERROR_IF_PTR(capacity == 0, S2N_ERR_MAP_INVALID_MAP_SIZE);
+    PTR_ENSURE(capacity != 0, S2N_ERR_MAP_INVALID_MAP_SIZE);
     struct s2n_blob mem = {0};
     struct s2n_map *map;
 

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -97,7 +97,7 @@ static int s2n_mem_malloc_mlock_impl(void **ptr, uint32_t requested, uint32_t *a
     GUARD(s2n_align_to(requested, page_size, &allocate));
 
     *ptr = NULL;
-    POSIX_ENSURE_OK(posix_memalign(ptr, page_size, allocate), S2N_ERR_ALLOC);
+    POSIX_ENSURE(posix_memalign(ptr, page_size, allocate) == 0, S2N_ERR_ALLOC);
     *allocated = allocate;
 
 /*
@@ -193,7 +193,9 @@ int s2n_realloc(struct s2n_blob *b, uint32_t size)
     }
 
     struct s2n_blob new_memory = {.data = NULL, .size = size, .allocated = 0, .growable = 1};
-    POSIX_GUARD(s2n_mem_malloc_cb((void **) &new_memory.data, new_memory.size, &new_memory.allocated));
+    if (s2n_mem_malloc_cb((void **) &new_memory.data, new_memory.size, &new_memory.allocated) != 0) {
+        S2N_ERROR_PRESERVE_ERRNO();
+    }
 
     POSIX_ENSURE(new_memory.allocated >= new_memory.size, S2N_ERR_ALLOC);
     POSIX_ENSURE(new_memory.data != NULL, S2N_ERR_ALLOC);

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -97,7 +97,7 @@ static int s2n_mem_malloc_mlock_impl(void **ptr, uint32_t requested, uint32_t *a
     GUARD(s2n_align_to(requested, page_size, &allocate));
 
     *ptr = NULL;
-    S2N_ERROR_IF(posix_memalign(ptr, page_size, allocate) != 0, S2N_ERR_ALLOC);
+    POSIX_ENSURE_OK(posix_memalign(ptr, page_size, allocate), S2N_ERR_ALLOC);
     *allocated = allocate;
 
 /*
@@ -117,7 +117,7 @@ static int s2n_mem_malloc_mlock_impl(void **ptr, uint32_t requested, uint32_t *a
         S2N_ERROR(S2N_ERR_MLOCK);
     }
 
-    S2N_ERROR_IF(*ptr == NULL, S2N_ERR_ALLOC);
+    POSIX_ENSURE(*ptr != NULL, S2N_ERR_ALLOC);
 
     return S2N_SUCCESS;
 }
@@ -125,7 +125,7 @@ static int s2n_mem_malloc_mlock_impl(void **ptr, uint32_t requested, uint32_t *a
 static int s2n_mem_malloc_no_mlock_impl(void **ptr, uint32_t requested, uint32_t *allocated)
 {
     *ptr = malloc(requested);
-    S2N_ERROR_IF(*ptr == NULL, S2N_ERR_ALLOC);
+    POSIX_ENSURE(*ptr != NULL, S2N_ERR_ALLOC);
     *allocated = requested;
 
     return S2N_SUCCESS;
@@ -134,7 +134,7 @@ static int s2n_mem_malloc_no_mlock_impl(void **ptr, uint32_t requested, uint32_t
 int s2n_mem_set_callbacks(s2n_mem_init_callback mem_init_callback, s2n_mem_cleanup_callback mem_cleanup_callback,
                           s2n_mem_malloc_callback mem_malloc_callback, s2n_mem_free_callback mem_free_callback)
 {
-    S2N_ERROR_IF(initialized == true, S2N_ERR_INITIALIZED);
+    POSIX_ENSURE(!initialized, S2N_ERR_INITIALIZED);
 
     notnull_check(mem_init_callback);
     notnull_check(mem_cleanup_callback);
@@ -151,7 +151,7 @@ int s2n_mem_set_callbacks(s2n_mem_init_callback mem_init_callback, s2n_mem_clean
 
 int s2n_alloc(struct s2n_blob *b, uint32_t size)
 {
-    S2N_ERROR_IF(initialized == false, S2N_ERR_NOT_INITIALIZED);
+    POSIX_ENSURE(initialized, S2N_ERR_NOT_INITIALIZED);
     notnull_check(b);
     const struct s2n_blob temp = {0};
     *b = temp;
@@ -171,9 +171,9 @@ bool s2n_blob_is_growable(const struct s2n_blob* b)
  */
 int s2n_realloc(struct s2n_blob *b, uint32_t size)
 {
-    S2N_ERROR_IF(initialized == false, S2N_ERR_NOT_INITIALIZED);
+    POSIX_ENSURE(initialized, S2N_ERR_NOT_INITIALIZED);
     notnull_check(b);
-    S2N_ERROR_IF(!s2n_blob_is_growable(b), S2N_ERR_RESIZE_STATIC_BLOB);
+    POSIX_ENSURE(s2n_blob_is_growable(b), S2N_ERR_RESIZE_STATIC_BLOB);
     if (size == 0) {
         return s2n_free(b);
     }
@@ -193,12 +193,10 @@ int s2n_realloc(struct s2n_blob *b, uint32_t size)
     }
 
     struct s2n_blob new_memory = {.data = NULL, .size = size, .allocated = 0, .growable = 1};
-    if(s2n_mem_malloc_cb((void **) &new_memory.data, new_memory.size, &new_memory.allocated) != 0) {
-        S2N_ERROR_PRESERVE_ERRNO();
-    }
+    POSIX_GUARD(s2n_mem_malloc_cb((void **) &new_memory.data, new_memory.size, &new_memory.allocated));
 
-    S2N_ERROR_IF(new_memory.allocated < new_memory.size, S2N_ERR_ALLOC);
-    S2N_ERROR_IF(new_memory.data == NULL, S2N_ERR_ALLOC);
+    POSIX_ENSURE(new_memory.allocated >= new_memory.size, S2N_ERR_ALLOC);
+    POSIX_ENSURE(new_memory.data != NULL, S2N_ERR_ALLOC);
 
     if (b->size) {
         memcpy_check(new_memory.data, b->data, b->size);
@@ -230,7 +228,7 @@ int s2n_free_object(uint8_t **p_data, uint32_t size)
 
 int s2n_dup(struct s2n_blob *from, struct s2n_blob *to)
 {
-    S2N_ERROR_IF(initialized == false, S2N_ERR_NOT_INITIALIZED);
+    POSIX_ENSURE(initialized, S2N_ERR_NOT_INITIALIZED);
     eq_check(to->size, 0);
     eq_check(to->data, NULL);
     ne_check(from->size, 0);
@@ -264,7 +262,7 @@ uint32_t s2n_mem_get_page_size(void)
 
 int s2n_mem_cleanup(void)
 {
-    S2N_ERROR_IF(initialized == false, S2N_ERR_NOT_INITIALIZED);
+    POSIX_ENSURE(initialized, S2N_ERR_NOT_INITIALIZED);
     GUARD(s2n_mem_cleanup_cb());
 
     initialized = false;
@@ -280,8 +278,8 @@ int s2n_free(struct s2n_blob *b)
        has been freed */
     int zero_rc = s2n_blob_zero(b);
 
-    S2N_ERROR_IF(initialized == false, S2N_ERR_NOT_INITIALIZED);
-    S2N_ERROR_IF(!s2n_blob_is_growable(b), S2N_ERR_FREE_STATIC_BLOB);
+    POSIX_ENSURE(initialized, S2N_ERR_NOT_INITIALIZED);
+    POSIX_ENSURE(s2n_blob_is_growable(b), S2N_ERR_FREE_STATIC_BLOB);
 
     GUARD(s2n_mem_free_cb(b->data, b->allocated));
 
@@ -293,7 +291,7 @@ int s2n_free(struct s2n_blob *b)
 }
 
 int s2n_blob_zeroize_free(struct s2n_blob *b) {
-    S2N_ERROR_IF(initialized == false, S2N_ERR_NOT_INITIALIZED);
+    POSIX_ENSURE(initialized, S2N_ERR_NOT_INITIALIZED);
     notnull_check(b);
 
     GUARD(s2n_blob_zero(b));

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -204,7 +204,7 @@ int s2n_align_to(uint32_t initial, uint32_t alignment, uint32_t* out)
     const uint64_t i = initial;
     const uint64_t a = alignment;
     const uint64_t result = a * (((i - 1) / a) + 1);
-    S2N_ERROR_IF(result > UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    POSIX_ENSURE(result <= UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
     *out = (uint32_t) result;
     return S2N_SUCCESS;
 }
@@ -213,7 +213,7 @@ int s2n_mul_overflow(uint32_t a, uint32_t b, uint32_t* out)
 {
     notnull_check(out);
     const uint64_t result = ((uint64_t) a) * ((uint64_t) b);
-    S2N_ERROR_IF(result > UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    POSIX_ENSURE(result <= UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
     *out = (uint32_t) result;
     return S2N_SUCCESS;
 }
@@ -222,7 +222,7 @@ int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out)
 {
     notnull_check(out);
     uint64_t result = ((uint64_t) a) + ((uint64_t) b);
-    S2N_ERROR_IF(result > UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
+    POSIX_ENSURE(result <= UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
     *out = (uint32_t) result;
     return S2N_SUCCESS;
 }
@@ -230,7 +230,7 @@ int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out)
 int s2n_sub_overflow(uint32_t a, uint32_t b, uint32_t* out)
 {
     notnull_check(out);
-    S2N_ERROR_IF(a < b, S2N_ERR_INTEGER_OVERFLOW);
+    POSIX_ENSURE(a >= b, S2N_ERR_INTEGER_OVERFLOW);
     *out = a - b;
     return S2N_SUCCESS;
 }


### PR DESCRIPTION
### Resolved issues:

Partially progress for #2635 

### Description of changes: 

This removes usage of the `S2N_ERROR_IF` in `bin`, `stuffer`, `tests`, and `utils`. It also adds a check to the "simple mistakes" script to make sure we don't introduce additional uses in those directories.