### PR TITLE
Added nst callback

### DIFF
--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -24,9 +24,11 @@
 #define S2N_TLS13_STATE_SIZE_WITHOUT_SECRET S2N_MAX_STATE_SIZE_IN_BYTES - S2N_TLS_SECRET_LEN
 
 static int s2n_test_session_ticket_callback(struct s2n_connection *conn,
-                                         uint8_t *session_id_data, size_t session_id_len,
-                                         uint8_t *session_data, size_t session_len,
-                                         uint32_t session_lifetime)
+                                            uint8_t *session_id_data,
+                                            size_t session_id_len,
+                                            uint8_t *session_data,
+                                            size_t session_len,
+                                            uint32_t session_lifetime)
 {
     return S2N_SUCCESS;
 }

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -24,10 +24,8 @@
 #define S2N_TLS13_STATE_SIZE_WITHOUT_SECRET S2N_MAX_STATE_SIZE_IN_BYTES - S2N_TLS_SECRET_LEN
 
 static int s2n_test_session_ticket_callback(struct s2n_connection *conn,
-                                            uint8_t *session_id_data,
-                                            size_t session_id_len,
-                                            uint8_t *session_data,
-                                            size_t session_len,
+                                            uint8_t *session_id_data, size_t session_id_len,
+                                            uint8_t *session_data, size_t session_len,
                                             uint32_t session_lifetime)
 {
     return S2N_SUCCESS;

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -352,10 +352,9 @@ int main(int argc, char **argv)
         struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
-        /* Safety checks */
+        /* Safety check */
         {
             EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_session_ticket_callback(NULL, s2n_test_session_ticket_callback), S2N_ERR_NULL);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_session_ticket_callback(config, NULL), S2N_ERR_NULL);
         }
 
         EXPECT_NULL(config->session_ticket_cb);

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -399,7 +399,6 @@ int main(int argc, char **argv)
 
     /* s2n_session_ticket_get_lifetime */
     {
-
         /* Safety checks */
         {
             struct s2n_session_ticket session_ticket = { 0 };

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -501,6 +501,5 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
         EXPECT_SUCCESS(s2n_config_free(config));
     }
-
     END_TEST();
 }

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -72,22 +72,6 @@ static int s2n_setup_test_keys(struct s2n_connection *conn, struct s2n_config *c
     return S2N_SUCCESS;
 }
 
-bool s2n_test_session_ticket_callback_flag = false;
-static int s2n_test_session_ticket_callback(struct s2n_connection *conn,
-                                         uint8_t *session_id_data, size_t session_id_len,
-                                         uint8_t *session_data, size_t session_len,
-                                         uint32_t session_lifetime)
-{
-    EXPECT_EQUAL(session_id_len, 0);
-    EXPECT_NULL(session_id_data);
-    EXPECT_TRUE(session_len > 0);
-    EXPECT_NOT_NULL(session_data);
-    EXPECT_TRUE(session_lifetime > 0);
-    s2n_test_session_ticket_callback_flag = true;
-
-    return S2N_SUCCESS;
-}
-
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
@@ -516,34 +500,6 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
         EXPECT_SUCCESS(s2n_config_free(config));
-    }
-
-    /* s2n_server_nst_recv */
-    {
-        /* Functional test: session_ticket_cb is called when receiving a new ticket in TLS1.2 */
-        {
-            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
-            EXPECT_NOT_NULL(conn);
-
-            struct s2n_config *config = s2n_config_new();
-            EXPECT_NOT_NULL(config);
-
-            conn->actual_protocol_version = S2N_TLS12;
-            conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            conn->session_ticket_status = S2N_NEW_TICKET;
-
-            EXPECT_SUCCESS(s2n_config_set_session_ticket_callback(config, s2n_test_session_ticket_callback));
-            EXPECT_SUCCESS(s2n_setup_test_keys(conn, config));
-            
-            EXPECT_SUCCESS(s2n_server_nst_send(conn));
-            EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
-            EXPECT_SUCCESS(s2n_server_nst_recv(conn));
-
-            EXPECT_TRUE(s2n_test_session_ticket_callback_flag);
-
-            EXPECT_SUCCESS(s2n_config_free(config));
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-        }
     }
 
     END_TEST();

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -528,7 +528,6 @@ int main(int argc, char **argv)
             struct s2n_config *config = s2n_config_new();
             EXPECT_NOT_NULL(config);
 
-            uint64_t current_time = 0;
             conn->actual_protocol_version = S2N_TLS12;
             conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
             conn->session_ticket_status = S2N_NEW_TICKET;

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -59,7 +59,7 @@ static int s2n_test_session_ticket_callback(struct s2n_connection *conn, struct 
 
     /* Store the callback data for comparison at the end of the connection. */
     EXPECT_SUCCESS(s2n_session_ticket_get_data_len(ticket, &cb_session_data_len));
-    EXPECT_SUCCESS(s2n_session_ticket_get_data(ticket, cb_session_data));
+    EXPECT_SUCCESS(s2n_session_ticket_get_data(ticket, sizeof(cb_session_data), cb_session_data));
     EXPECT_SUCCESS(s2n_session_ticket_get_lifetime(ticket, &cb_session_lifetime));
 
     return S2N_SUCCESS;

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -51,21 +51,16 @@ static int mock_time(void *data, uint64_t *nanoseconds)
 
 uint8_t cb_session_data[S2N_TLS12_SESSION_SIZE] = { 0 };
 size_t cb_session_data_len = 0;
-size_t cb_session_lifetime = 0;
+uint32_t cb_session_lifetime = 0;
 static int s2n_test_session_ticket_callback(struct s2n_connection *conn, struct s2n_session_ticket *ticket)
 {
     EXPECT_NOT_NULL(conn);
     EXPECT_NOT_NULL(ticket);
 
     /* Store the callback data for comparison at the end of the connection. */
-    uint8_t *data = NULL;
-    size_t data_len = 0;
-    size_t session_lifetime = 0;
-    EXPECT_SUCCESS(s2n_session_ticket_get_data(ticket, &data, &data_len));
-    cb_session_data_len = data_len;
-    EXPECT_MEMCPY_SUCCESS(cb_session_data, data, cb_session_data_len);
-    EXPECT_SUCCESS(s2n_session_ticket_get_lifetime(ticket, &session_lifetime));
-    cb_session_lifetime = session_lifetime;
+    EXPECT_SUCCESS(s2n_session_ticket_get_data_len(ticket, &cb_session_data_len));
+    EXPECT_SUCCESS(s2n_session_ticket_get_data(ticket, cb_session_data));
+    EXPECT_SUCCESS(s2n_session_ticket_get_lifetime(ticket, &cb_session_lifetime));
 
     return S2N_SUCCESS;
 }
@@ -1077,7 +1072,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
 
         /* Client will use callback when server nst is received */
-        EXPECT_SUCCESS(s2n_config_set_session_ticket_callback(client_config, s2n_test_session_ticket_callback));
+        EXPECT_SUCCESS(s2n_config_set_session_ticket_cb(client_config, s2n_test_session_ticket_callback, NULL));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -109,7 +109,8 @@ struct s2n_config {
     s2n_key_log_fn key_log_cb;
     void *key_log_ctx;
 
-    s2n_session_ticket_cb session_ticket_cb;
+    s2n_session_ticket_fn session_ticket_cb;
+    void *session_ticket_ctx;
 };
 
 int s2n_config_defaults_init(void);

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -108,6 +108,8 @@ struct s2n_config {
 
     s2n_key_log_fn key_log_cb;
     void *key_log_ctx;
+
+    s2n_session_ticket_cb session_ticket_cb;
 };
 
 int s2n_config_defaults_init(void);

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -768,3 +768,12 @@ int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t 
 
     return S2N_SUCCESS;
 }
+
+int s2n_config_set_session_ticket_callback(struct s2n_config *config, s2n_session_ticket_cb cb)
+{
+    ENSURE_POSIX_MUT(config);
+
+    config->session_ticket_cb = cb;
+
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -777,3 +777,24 @@ int s2n_config_set_session_ticket_callback(struct s2n_config *config, s2n_sessio
 
     return S2N_SUCCESS;
 }
+
+int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, uint8_t **data, size_t *data_len)
+{
+    POSIX_ENSURE_REF(ticket);
+    POSIX_ENSURE_REF(data);
+    POSIX_ENSURE_REF(data_len);
+
+    *data = ticket->ticket_data.data;
+    *data_len = ticket->ticket_data.size;
+
+    return S2N_SUCCESS;
+}
+int s2n_session_ticket_get_lifetime(struct s2n_session_ticket *ticket, size_t *session_lifetime)
+{
+    POSIX_ENSURE_REF(ticket);
+    POSIX_ENSURE_REF(session_lifetime);
+
+    *session_lifetime = ticket->session_lifetime;
+
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -789,6 +789,7 @@ int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, uint8_t **dat
 
     return S2N_SUCCESS;
 }
+
 int s2n_session_ticket_get_lifetime(struct s2n_session_ticket *ticket, size_t *session_lifetime)
 {
     POSIX_ENSURE_REF(ticket);

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -787,11 +787,12 @@ int s2n_session_ticket_get_data_len(struct s2n_session_ticket *ticket, size_t *d
     return S2N_SUCCESS;
 }
 
-int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, uint8_t *data)
+int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, size_t max_data_len, uint8_t *data)
 {
     POSIX_ENSURE_REF(ticket);
     POSIX_ENSURE_MUT(data);
 
+    POSIX_ENSURE(ticket->ticket_data.size <= max_data_len, S2N_ERR_SERIALIZED_SESSION_STATE_TOO_LONG);
     POSIX_CHECKED_MEMCPY(data, ticket->ticket_data.data, ticket->ticket_data.size);
 
     return S2N_SUCCESS;

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -769,28 +769,35 @@ int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t 
     return S2N_SUCCESS;
 }
 
-int s2n_config_set_session_ticket_callback(struct s2n_config *config, s2n_session_ticket_cb cb)
+int s2n_config_set_session_ticket_cb(struct s2n_config *config, s2n_session_ticket_fn callback, void *ctx)
 {
-    ENSURE_POSIX_MUT(config);
+    POSIX_ENSURE_MUT(config);
 
-    config->session_ticket_cb = cb;
-
+    config->session_ticket_cb = callback;
+    config->session_ticket_ctx = ctx;
     return S2N_SUCCESS;
 }
 
-int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, uint8_t **data, size_t *data_len)
+int s2n_session_ticket_get_data_len(struct s2n_session_ticket *ticket, size_t *data_len)
 {
     POSIX_ENSURE_REF(ticket);
-    POSIX_ENSURE_REF(data);
-    POSIX_ENSURE_REF(data_len);
+    POSIX_ENSURE_MUT(data_len);
 
-    *data = ticket->ticket_data.data;
     *data_len = ticket->ticket_data.size;
+    return S2N_SUCCESS;
+}
+
+int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, uint8_t *data)
+{
+    POSIX_ENSURE_REF(ticket);
+    POSIX_ENSURE_MUT(data);
+
+    POSIX_CHECKED_MEMCPY(data, ticket->ticket_data.data, ticket->ticket_data.size);
 
     return S2N_SUCCESS;
 }
 
-int s2n_session_ticket_get_lifetime(struct s2n_session_ticket *ticket, size_t *session_lifetime)
+int s2n_session_ticket_get_lifetime(struct s2n_session_ticket *ticket, uint32_t *session_lifetime)
 {
     POSIX_ENSURE_REF(ticket);
     POSIX_ENSURE_REF(session_lifetime);

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -51,6 +51,11 @@
 #define S2N_GREATER_OR_EQUAL            1
 #define S2N_LESS_THAN                  -1
 
+#define S2N_TLS12_SESSION_SIZE          S2N_STATE_FORMAT_LEN + \
+                                        S2N_SESSION_TICKET_SIZE_LEN + \
+                                        S2N_TLS12_TICKET_SIZE_IN_BYTES + \
+                                        S2N_STATE_SIZE_IN_BYTES
+
 struct s2n_connection;
 struct s2n_config;
 
@@ -100,8 +105,12 @@ extern int s2n_store_to_cache(struct s2n_connection *conn);
 int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num);
 int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num);
 
-typedef int (*s2n_session_ticket_cb)(struct s2n_connection *conn,
-                                     uint8_t *session_id_data, size_t session_id_len,
-                                     uint8_t *session_data, size_t session_len,
-                                     uint32_t session_lifetime);
+struct s2n_session_ticket {
+    struct s2n_blob ticket_data;
+    uint32_t session_lifetime;
+};
+
+typedef int (*s2n_session_ticket_cb)(struct s2n_connection *conn, struct s2n_session_ticket *ticket);
 int s2n_config_set_session_ticket_callback(struct s2n_config *config, s2n_session_ticket_cb cb);
+int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, uint8_t **data, size_t *data_len);
+int s2n_session_ticket_get_lifetime(struct s2n_session_ticket *ticket, size_t *session_lifetime);

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -101,7 +101,9 @@ int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num);
 int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num);
 
 typedef int (*s2n_session_ticket_cb)(struct s2n_connection *conn,
-                                         uint8_t *session_id_data, size_t session_id_len,
-                                         uint8_t *session_data, size_t session_len,
-                                         uint32_t session_lifetime);
+                                     uint8_t *session_id_data,
+                                     size_t session_id_len,
+                                     uint8_t *session_data,
+                                     size_t session_len,
+                                     uint32_t session_lifetime);
 int s2n_config_set_session_ticket_callback(struct s2n_config *config, s2n_session_ticket_cb cb);

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -114,5 +114,5 @@ struct s2n_session_ticket;
 typedef int (*s2n_session_ticket_fn)(struct s2n_connection *conn, struct s2n_session_ticket *ticket);
 int s2n_config_set_session_ticket_cb(struct s2n_config *config, s2n_session_ticket_fn callback, void *ctx);
 int s2n_session_ticket_get_data_len(struct s2n_session_ticket *ticket, size_t *data_len);
-int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, uint8_t *data);
+int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, size_t max_data_len, uint8_t *data);
 int s2n_session_ticket_get_lifetime(struct s2n_session_ticket *ticket, uint32_t *session_lifetime);

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -76,6 +76,11 @@ struct s2n_ticket_fields {
     uint32_t ticket_age_add;
 };
 
+struct s2n_session_ticket {
+    struct s2n_blob ticket_data;
+    uint32_t session_lifetime;
+};
+
 extern struct s2n_ticket_key *s2n_find_ticket_key(struct s2n_config *config, const uint8_t *name);
 extern int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_ticket_fields *ticket_fields, struct s2n_stuffer *to);
 extern int s2n_decrypt_session_ticket(struct s2n_connection *conn);
@@ -105,12 +110,9 @@ extern int s2n_store_to_cache(struct s2n_connection *conn);
 int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num);
 int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num);
 
-struct s2n_session_ticket {
-    struct s2n_blob ticket_data;
-    uint32_t session_lifetime;
-};
-
-typedef int (*s2n_session_ticket_cb)(struct s2n_connection *conn, struct s2n_session_ticket *ticket);
-int s2n_config_set_session_ticket_callback(struct s2n_config *config, s2n_session_ticket_cb cb);
-int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, uint8_t **data, size_t *data_len);
-int s2n_session_ticket_get_lifetime(struct s2n_session_ticket *ticket, size_t *session_lifetime);
+struct s2n_session_ticket;
+typedef int (*s2n_session_ticket_fn)(struct s2n_connection *conn, struct s2n_session_ticket *ticket);
+int s2n_config_set_session_ticket_cb(struct s2n_config *config, s2n_session_ticket_fn callback, void *ctx);
+int s2n_session_ticket_get_data_len(struct s2n_session_ticket *ticket, size_t *data_len);
+int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, uint8_t *data);
+int s2n_session_ticket_get_lifetime(struct s2n_session_ticket *ticket, uint32_t *session_lifetime);

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -99,3 +99,9 @@ extern int s2n_store_to_cache(struct s2n_connection *conn);
  * once we release the session resumption API. */
 int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num);
 int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num);
+
+typedef int (*s2n_session_ticket_cb)(struct s2n_connection *conn,
+                                         uint8_t *session_id_data, size_t session_id_len,
+                                         uint8_t *session_data, size_t session_len,
+                                         uint32_t session_lifetime);
+int s2n_config_set_session_ticket_callback(struct s2n_config *config, s2n_session_ticket_cb cb);

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -101,9 +101,7 @@ int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num);
 int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num);
 
 typedef int (*s2n_session_ticket_cb)(struct s2n_connection *conn,
-                                     uint8_t *session_id_data,
-                                     size_t session_id_len,
-                                     uint8_t *session_data,
-                                     size_t session_len,
+                                     uint8_t *session_id_data, size_t session_id_len,
+                                     uint8_t *session_data, size_t session_len,
                                      uint32_t session_lifetime);
 int s2n_config_set_session_ticket_callback(struct s2n_config *config, s2n_session_ticket_cb cb);

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -55,6 +55,7 @@ int s2n_server_nst_recv(struct s2n_connection *conn) {
 
         if (conn->config->session_ticket_cb != NULL) {
             size_t session_len = s2n_connection_get_session_length(conn);
+            POSIX_ENSURE_GTE(S2N_TLS12_SESSION_SIZE, session_len);
             uint8_t session_data[S2N_TLS12_SESSION_SIZE] = { 0 };
             GUARD(s2n_connection_get_session(conn, session_data, session_len));
             uint32_t session_lifetime = s2n_connection_get_session_ticket_lifetime_hint(conn);

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -54,7 +54,6 @@ int s2n_server_nst_recv(struct s2n_connection *conn) {
         POSIX_GUARD(s2n_stuffer_read(&conn->handshake.io, &conn->client_ticket));
 
         if (conn->config->session_ticket_cb != NULL) {
-
             size_t session_id_len = s2n_connection_get_session_id_length(conn);
             uint8_t session_id[S2N_TLS_SESSION_ID_MAX_LEN] = { 0 };
             GUARD(s2n_connection_get_session_id(conn, session_id, session_id_len));


### PR DESCRIPTION
### Resolved issues:

 resolves ##2488
### Description of changes: 

Adds callback to inform customer of new session ticket arrival. Additionally, implements this callback in TLS1.2 when a nst is received.
### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
### Testing:

Unit tests

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
