### PR TITLE
ci: cache cppcheck results

### DIFF
--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -13,6 +13,8 @@ jobs:
     env:
       CPPCHECK_INSTALL_DIR: test-deps/cppcheck
       CPPCHECK_CACHE_DIR: test-deps/cppcheck-cache
+      # GHA has 2 cores available: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+      JOBS: 2
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -13,8 +13,8 @@ jobs:
     env:
       CPPCHECK_INSTALL_DIR: test-deps/cppcheck
       CPPCHECK_CACHE_DIR: test-deps/cppcheck-cache
-      # GHA has 2 cores available: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-      JOBS: 2
+      # GHA has 2 cores (4 threads) available: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+      JOBS: 4
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -12,13 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CPPCHECK_INSTALL_DIR: test-deps/cppcheck
+      CPPCHECK_CACHE_DIR: test-deps/cppcheck-cache
     steps:
       - uses: actions/checkout@v2
 
       - name: Setup
         run: source ./codebuild/bin/s2n_setup_env.sh
 
-      - name: Cache
+      - name: Cache cppcheck
         id: cache
         uses: actions/cache@v2.1.4
         continue-on-error: true
@@ -29,6 +30,15 @@ jobs:
       - name: Install
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./codebuild/bin/install_cppcheck.sh "$CPPCHECK_INSTALL_DIR"
+
+      - name: Cache checks
+        uses: actions/cache@v2.1.4
+        continue-on-error: true
+        with:
+          path: ${{ env.CPPCHECK_CACHE_DIR }}
+          key: cppcheck-2.3-${{ env.CPPCHECK_CACHE_DIR }}-${{ hashFiles('**/*.[ch]') }}
+          restore-keys: |
+            cppcheck-2.3-${{ env.CPPCHECK_CACHE_DIR }}-
 
       - name: Check
         run: ./codebuild/bin/run_cppcheck.sh "$CPPCHECK_INSTALL_DIR"


### PR DESCRIPTION
Cppcheck has an option to store artifacts and use them later for incremental checking of only modified files. This change enables caching of these artifacts in the GHA cache, which should hopefully speed up this job.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
