### PR TITLE
Add early traffic secrets 

### DIFF
--- a/crypto/s2n_tls13_keys.c
+++ b/crypto/s2n_tls13_keys.c
@@ -34,7 +34,7 @@
  * when the relevant TLS 1.3 features are worked on.
  *
  * [x] binder_key
- * [ ] client_early_traffic_secret
+ * [x] client_early_traffic_secret
  * [ ] early_exporter_master_secret
  * [x] client_handshake_traffic_secret
  * [x] server_handshake_traffic_secret

--- a/crypto/s2n_tls13_keys.h
+++ b/crypto/s2n_tls13_keys.h
@@ -74,12 +74,11 @@ extern const struct s2n_blob s2n_tls13_label_traffic_secret_iv;
 int s2n_tls13_keys_init(struct s2n_tls13_keys *handshake, s2n_hmac_algorithm alg);
 int s2n_tls13_keys_free(struct s2n_tls13_keys *keys);
 int s2n_tls13_derive_binder_key(struct s2n_tls13_keys *keys, struct s2n_psk *psk);
-int s2n_tls13_derive_early_secrets(struct s2n_tls13_keys *handshake, struct s2n_psk *psk);
-int s2n_tls13_derive_handshake_secrets(struct s2n_tls13_keys *handshake,
-                                        const struct s2n_blob *ecdhe,
-                                        struct s2n_hash_state *client_server_hello_hash,
-                                        struct s2n_blob *client_secret,
-                                        struct s2n_blob *server_secret);
+int s2n_tls13_derive_early_secret(struct s2n_tls13_keys *handshake, struct s2n_psk *psk);
+int s2n_tls13_derive_early_traffic_secret(struct s2n_tls13_keys *keys, struct s2n_hash_state *client_hello_hash, struct s2n_blob *secret);
+int s2n_tls13_extract_handshake_secret(struct s2n_tls13_keys *keys, const struct s2n_blob *ecdhe);
+int s2n_tls13_derive_handshake_traffic_secret(struct s2n_tls13_keys *keys, struct s2n_hash_state *client_server_hello_hash,
+        struct s2n_blob *secret, s2n_mode mode);
 int s2n_tls13_extract_master_secret(struct s2n_tls13_keys *handshake);
 int s2n_tls13_derive_application_secret(struct s2n_tls13_keys *handshake, struct s2n_hash_state *hashes, struct s2n_blob *secret_blob, s2n_mode mode);
 

--- a/tests/cbmc/proofs/s2n_hex_string_to_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_hex_string_to_bytes/Makefile
@@ -35,13 +35,15 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
 REMOVE_FUNCTION_BODY += s2n_calculate_stacktrace
 
 UNWINDSET += strlen.0:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+UNWINDSET += s2n_hex_string_to_bytes_harness.0:$(shell echo $$((1 + $(MAX_STRING_LEN))))
 UNWINDSET += s2n_hex_string_to_bytes.2:$(shell echo $$((1 + $(MAX_STRING_LEN))))
 UNWINDSET += s2n_hex_string_to_bytes.3:$(shell echo $$((1 + $(MAX_STRING_LEN))))
 UNWINDSET += s2n_hex_string_to_bytes.6:$(shell echo $$((1 + $(MAX_STRING_LEN))))
 UNWINDSET += s2n_hex_string_to_bytes.9:$(shell echo $$((1 + $(MAX_STRING_LEN))))
-UNWINDSET += s2n_hex_string_to_bytes.16:$(shell echo $$((1 + $(MAX_STRING_LEN))))
 UNWINDSET += s2n_hex_string_to_bytes.12:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+UNWINDSET += s2n_hex_string_to_bytes.13:$(shell echo $$((1 + $(MAX_STRING_LEN))))
 UNWINDSET += s2n_hex_string_to_bytes.15:$(shell echo $$((1 + $(MAX_STRING_LEN))))
+UNWINDSET += s2n_hex_string_to_bytes.16:$(shell echo $$((1 + $(MAX_STRING_LEN))))
 UNWINDSET += s2n_hex_string_to_bytes.17:$(shell echo $$((1 + $(MAX_STRING_LEN))))
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_hex_string_to_bytes/s2n_hex_string_to_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_hex_string_to_bytes/s2n_hex_string_to_bytes_harness.c
@@ -35,9 +35,14 @@ void s2n_hex_string_to_bytes_harness()
 
     /* Operation under verification. */
     if (s2n_hex_string_to_bytes(str, blob) == S2N_SUCCESS) {
-        size_t strLength = strlen(str);
-        assert(blob->size >= (strLength / 2));
+        size_t strLength = 0;
+        for (size_t i = 0; i < strlen(str); i++) {
+            if (str[i] != ' ') {
+                strLength++;
+            }
+        }
         assert(strLength % 2 == 0);
+        assert(blob->size == (strLength / 2));
     } else {
         assert(blob->allocated == old_blob.allocated);
         assert(blob->growable == old_blob.growable);

--- a/tests/unit/s2n_tls13_handshake_early_data_test.c
+++ b/tests/unit/s2n_tls13_handshake_early_data_test.c
@@ -341,6 +341,11 @@ int main()
          *#       5e 5b fb c3 88 e9 33 43 69 40 93 93 4a e4 d3 57 00 08 00 2a 00
          *#       04 00 00 04 00
          */
+        /* Skip past the message type, message size, ticket lifetime,
+         * ticket age add, nonce, and ticket size:
+         *                                     04 00 00 c9 00 00 00 1e fa d6 aa
+         *        c5 02 00 00 00 b2
+         */
         S2N_BLOB_FROM_HEX(psk_identity,
                                    "2c 03 5d 82 93 59 ee 5f f7 af 4e c9 00 00 00 \
                   00 26 2a 64 94 dc 48 6d 2c 8a 34 cb 33 fa 90 bf 1b 00 70 ad 3c \
@@ -351,7 +356,11 @@ int main()
                   5b 3f 7d 8f 92 f2 28 bd a4 0d da 72 14 70 f9 fb f2 97 b5 ae a6 \
                   17 64 6f ac 5c 03 27 2e 97 07 27 c6 21 a7 91 41 ef 5f 7d e6 50 \
                   5e 5b fb c3 88 e9 33 43 69 40 93 93 4a e4 d3 57");
-        const uint32_t max_early_data = 0x0400;
+        /* Skip past the total extensions size, early data extension type,
+         * and early data extension size:                         00 08 00 2a 00
+         *        04
+         */
+        const uint32_t max_early_data = 0x00000400;
 
         /**
          *= https://tools.ietf.org/rfc/rfc8448#section-4

--- a/tests/unit/s2n_tls13_handshake_early_data_test.c
+++ b/tests/unit/s2n_tls13_handshake_early_data_test.c
@@ -1,0 +1,608 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "tls/s2n_handshake.h"
+#include "tls/s2n_record.h"
+#include "tls/s2n_tls13_handshake.h"
+
+#include "utils/s2n_array.h"
+#include "utils/s2n_mem.h"
+
+/* Just to get access to the static functions / variables we need to test */
+#include "tls/s2n_handshake_io.c"
+#include "tls/s2n_tls13_handshake.c"
+#include "tls/s2n_handshake_transcript.c"
+
+#define S2N_SECRET_TYPE_COUNT 5
+
+const uint8_t empty_secret[S2N_TLS13_SECRET_MAX_LEN] = { 0 };
+message_type_t empty_handshake[S2N_MAX_HANDSHAKE_LENGTH] = { 0 };
+
+static int s2n_check_traffic_secret_order(void* context, struct s2n_connection *conn,
+                                          s2n_secret_type_t secret_type,
+                                          uint8_t *secret, uint8_t secret_size)
+{
+    uint8_t *secrets_handled = (uint8_t *) context;
+    secrets_handled[secret_type] += 1;
+
+    switch(secret_type) {
+        case S2N_CLIENT_EARLY_TRAFFIC_SECRET:
+            /* For the timing: must be calculated on the ClientHello */
+            /* For the digest: must be calculated on the ClientHello */
+            POSIX_ENSURE_EQ(s2n_conn_get_current_message_type(conn), CLIENT_HELLO);
+            /* For the extracted secret: must be calculated before all other secrets */
+            POSIX_ENSURE_EQ(secrets_handled[S2N_CLIENT_HANDSHAKE_TRAFFIC_SECRET], 0);
+            POSIX_ENSURE_EQ(secrets_handled[S2N_SERVER_HANDSHAKE_TRAFFIC_SECRET], 0);
+            POSIX_ENSURE_EQ(secrets_handled[S2N_CLIENT_APPLICATION_TRAFFIC_SECRET], 0);
+            POSIX_ENSURE_EQ(secrets_handled[S2N_SERVER_APPLICATION_TRAFFIC_SECRET], 0);
+            break;
+        case S2N_CLIENT_HANDSHAKE_TRAFFIC_SECRET:
+            /* For the timing: must be calculated before the ClientCert or ClientFinished */
+            for (uint16_t i = 0; i < conn->handshake.message_number; i++) {
+                POSIX_ENSURE_NE(tls13_handshakes[conn->handshake.handshake_type][i], CLIENT_CERT);
+                POSIX_ENSURE_NE(tls13_handshakes[conn->handshake.handshake_type][i], CLIENT_FINISHED);
+            }
+            /* For the digest: no requirements. We use a stored copy of the ServerHello digest. */
+            /* For the extracted secret: must be calculated before application secrets */
+            POSIX_ENSURE_EQ(secrets_handled[S2N_CLIENT_APPLICATION_TRAFFIC_SECRET], 0);
+            POSIX_ENSURE_EQ(secrets_handled[S2N_SERVER_APPLICATION_TRAFFIC_SECRET], 0);
+            break;
+        case S2N_SERVER_HANDSHAKE_TRAFFIC_SECRET:
+            /* For the timing: must be calculated before EncryptedExtensions */
+            for (uint16_t i = 0; i <= conn->handshake.message_number; i++) {
+                POSIX_ENSURE_NE(tls13_handshakes[conn->handshake.handshake_type][i], ENCRYPTED_EXTENSIONS);
+            }
+            /* For the digest: no requirements. We use a stored copy of the ServerHello digest. */
+            /* For the extracted secret: must be calculated before application secrets */
+            POSIX_ENSURE_EQ(secrets_handled[S2N_CLIENT_APPLICATION_TRAFFIC_SECRET], 0);
+            POSIX_ENSURE_EQ(secrets_handled[S2N_SERVER_APPLICATION_TRAFFIC_SECRET], 0);
+            break;
+        case S2N_CLIENT_APPLICATION_TRAFFIC_SECRET:
+        case S2N_SERVER_APPLICATION_TRAFFIC_SECRET:
+            /* For the timing: must be calculated before ApplicationData */
+            for (uint16_t i = 0; i <= conn->handshake.message_number; i++) {
+                POSIX_ENSURE_NE(tls13_handshakes[conn->handshake.handshake_type][i], APPLICATION_DATA);
+            }
+            /* For the digest: no requirements. We use a stored copy of the ServerFinished digest. */
+            /* For the extracted secret: no requirements */
+            break;
+    }
+
+    return S2N_SUCCESS;
+}
+
+static S2N_RESULT s2n_setup_tls13_secrets_prereqs(struct s2n_connection *conn)
+{
+    conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
+    RESULT_GUARD_POSIX(s2n_tls13_conn_copy_hash(conn, &conn->handshake.server_hello_copy));
+    RESULT_GUARD_POSIX(s2n_tls13_conn_copy_hash(conn, &conn->handshake.server_finished_copy));
+
+    const struct s2n_ecc_preferences *ecc_pref = NULL;
+    RESULT_GUARD_POSIX(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    RESULT_ENSURE_REF(ecc_pref);
+
+    conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+    conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+    RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.server_ecc_evp_params));
+    RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+
+    uint8_t test_value[SHA256_DIGEST_LENGTH] = "test";
+    DEFER_CLEANUP(struct s2n_psk *s2n_test_psk = s2n_external_psk_new(), s2n_psk_free);
+    EXPECT_SUCCESS(s2n_psk_set_identity(s2n_test_psk, test_value, sizeof(test_value)));
+    EXPECT_SUCCESS(s2n_psk_set_secret(s2n_test_psk, test_value, sizeof(test_value)));
+    EXPECT_SUCCESS(s2n_alloc(&s2n_test_psk->early_secret, sizeof(test_value)));
+    EXPECT_SUCCESS(s2n_psk_configure_early_data(s2n_test_psk, 1,
+            s2n_tls13_aes_128_gcm_sha256.iana_value[0], s2n_tls13_aes_128_gcm_sha256.iana_value[1]));
+    RESULT_GUARD_POSIX(s2n_connection_append_psk(conn, s2n_test_psk));
+
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_test_key_schedule(s2n_mode mode, uint16_t handshake_type, s2n_early_data_state *early_data_transitions,
+        bool *valid_test_case)
+{
+    RESULT_ENSURE_REF(valid_test_case);
+    *valid_test_case = false;
+
+    /* Ignore empty handshakes */
+    if (memcmp(tls13_handshakes[handshake_type], empty_handshake, sizeof(empty_handshake)) == 0) {
+        return S2N_RESULT_OK;
+    }
+
+    /* Ignore incomplete handshakes */
+    if (!(handshake_type & NEGOTIATED)) {
+        return S2N_RESULT_OK;
+    }
+
+    /* WITH_EARLY_DATA only makes sense if the early data is accepted */
+    bool includes_end_of_early_data_message = (handshake_type & WITH_EARLY_DATA);
+    bool requires_end_of_early_data_message = (early_data_transitions[END_OF_EARLY_DATA]);
+    if (requires_end_of_early_data_message != includes_end_of_early_data_message) {
+        return S2N_RESULT_OK;
+    }
+
+    struct s2n_config *config = s2n_config_new();
+    /* Enable QUIC to enable the secret callbacks. This does not affect the key schedule,
+     * since QUIC also uses TLS to generate early data secrets. */
+    config->quic_enabled = true;
+
+    uint8_t secrets_handled[S2N_SECRET_TYPE_COUNT] = { 0 };
+    for (uint16_t message_number = 0; message_number < S2N_MAX_HANDSHAKE_LENGTH; message_number++) {
+        struct s2n_connection *conn = s2n_connection_new(mode);
+        RESULT_ENSURE_REF(conn);
+        RESULT_GUARD_POSIX(s2n_connection_set_config(conn, config));
+        RESULT_GUARD(s2n_setup_tls13_secrets_prereqs(conn));
+
+        conn->actual_protocol_version = S2N_TLS13;
+        conn->handshake.handshake_type = handshake_type;
+        conn->handshake.message_number = message_number;
+
+        if (s2n_conn_get_current_message_type(conn) == APPLICATION_DATA) {
+            RESULT_GUARD_POSIX(s2n_connection_free(conn));
+            break;
+        }
+
+        /* Set traffic secret validation.
+         * This performs the bulk of the testing. */
+        RESULT_GUARD_POSIX(s2n_connection_set_secret_callback(conn, s2n_check_traffic_secret_order, secrets_handled));
+
+        /* Set early data state */
+        conn->early_data_state = early_data_transitions[CLIENT_HELLO];
+        for (size_t i = 1; i <= message_number; i++) {
+            s2n_early_data_state next_state = early_data_transitions[tls13_handshakes[handshake_type][i]];
+            /* Skip empty state transitions */
+            if (next_state == S2N_UNKNOWN_EARLY_DATA_STATE) {
+                continue;
+            }
+            /* Skip duplicate ClientHellos */
+            if ((tls13_handshakes[handshake_type][i] == CLIENT_HELLO)) {
+                continue;
+            }
+            RESULT_GUARD(s2n_connection_set_early_data_state(conn, next_state));
+        }
+
+        RESULT_GUARD_POSIX(s2n_tls13_handle_secrets(conn));
+        RESULT_GUARD_POSIX(s2n_connection_free(conn));
+    }
+
+    RESULT_ENSURE_EQ(secrets_handled[S2N_CLIENT_HANDSHAKE_TRAFFIC_SECRET], 1);
+    RESULT_ENSURE_EQ(secrets_handled[S2N_SERVER_HANDSHAKE_TRAFFIC_SECRET], 1);
+    RESULT_ENSURE_EQ(secrets_handled[S2N_CLIENT_APPLICATION_TRAFFIC_SECRET], 1);
+    RESULT_ENSURE_EQ(secrets_handled[S2N_SERVER_APPLICATION_TRAFFIC_SECRET], 1);
+
+    /* The client calculates the early traffic secret if it attempts early data */
+    if ((mode == S2N_CLIENT) && (early_data_transitions[CLIENT_HELLO] == S2N_EARLY_DATA_REQUESTED)) {
+        RESULT_ENSURE_EQ(secrets_handled[S2N_CLIENT_EARLY_TRAFFIC_SECRET], 1);
+    /* The server calculates the early traffic secret if it accepts early data */
+    } else if ((mode == S2N_SERVER) && (handshake_type & WITH_EARLY_DATA)) {
+        RESULT_ENSURE_EQ(secrets_handled[S2N_CLIENT_EARLY_TRAFFIC_SECRET], 1);
+    } else {
+        RESULT_ENSURE_EQ(secrets_handled[S2N_CLIENT_EARLY_TRAFFIC_SECRET], 0);
+    }
+
+    RESULT_GUARD_POSIX(s2n_config_free(config));
+    *valid_test_case = true;
+    return S2N_RESULT_OK;
+}
+
+int main()
+{
+    BEGIN_TEST();
+
+    /* Test key schedule */
+    {
+        bool valid_test_case = false;
+
+        const size_t early_data_not_requested_i = 0;
+        const size_t early_data_rejected_i = 1;
+        const size_t early_data_accepted_i = 2;
+
+        s2n_early_data_state client_early_data_transitions[][APPLICATION_DATA] = {
+                /* early data never requested */
+                { [CLIENT_HELLO] = S2N_EARLY_DATA_NOT_REQUESTED },
+                /* early data rejected */
+                { [CLIENT_HELLO] = S2N_EARLY_DATA_REQUESTED, [HELLO_RETRY_MSG] = S2N_EARLY_DATA_REJECTED,
+                        [ENCRYPTED_EXTENSIONS] = S2N_EARLY_DATA_REJECTED },
+                /* early data accepted */
+                { [CLIENT_HELLO] = S2N_EARLY_DATA_REQUESTED, [HELLO_RETRY_MSG] = S2N_EARLY_DATA_REJECTED,
+                        [ENCRYPTED_EXTENSIONS] = S2N_EARLY_DATA_ACCEPTED, [END_OF_EARLY_DATA] = S2N_END_OF_EARLY_DATA },
+        };
+        s2n_early_data_state server_early_data_transitions[][APPLICATION_DATA] = {
+                /* early data never requested */
+                { [CLIENT_HELLO] = S2N_EARLY_DATA_NOT_REQUESTED },
+                /* early data rejected */
+                { [CLIENT_HELLO] = S2N_EARLY_DATA_REJECTED },
+                /* early data accepted */
+                { [CLIENT_HELLO] = S2N_EARLY_DATA_ACCEPTED, [END_OF_EARLY_DATA] = S2N_END_OF_EARLY_DATA },
+        };
+
+        /* Sanity check: Test invalid cases are ignored */
+        {
+            /* Incomplete handshake */
+            EXPECT_OK(s2n_test_key_schedule(S2N_CLIENT, 0,
+                    client_early_data_transitions[early_data_accepted_i], &valid_test_case));
+            EXPECT_FALSE(valid_test_case);
+
+            /* Invalid handshake type */
+            EXPECT_OK(s2n_test_key_schedule(S2N_CLIENT, NEGOTIATED | FULL_HANDSHAKE | WITH_EARLY_DATA,
+                    client_early_data_transitions[early_data_accepted_i], &valid_test_case));
+            EXPECT_FALSE(valid_test_case);
+
+            /* WITH_EARLY_DATA handshake type, but early data not accepted */
+            EXPECT_OK(s2n_test_key_schedule(S2N_CLIENT, NEGOTIATED | WITH_EARLY_DATA,
+                    client_early_data_transitions[early_data_rejected_i], &valid_test_case));
+            EXPECT_FALSE(valid_test_case);
+
+            /* Not WITH_EARLY_DATA handshake type, but early data accepted */
+            EXPECT_OK(s2n_test_key_schedule(S2N_CLIENT, NEGOTIATED,
+                    client_early_data_transitions[early_data_accepted_i], &valid_test_case));
+            EXPECT_FALSE(valid_test_case);
+        }
+
+        /* Test a specific known cases */
+        {
+            /* Early data not requested */
+            EXPECT_OK(s2n_test_key_schedule(S2N_CLIENT, NEGOTIATED,
+                    client_early_data_transitions[early_data_not_requested_i], &valid_test_case));
+            EXPECT_TRUE(valid_test_case);
+            EXPECT_OK(s2n_test_key_schedule(S2N_SERVER, NEGOTIATED,
+                    server_early_data_transitions[early_data_not_requested_i], &valid_test_case));
+            EXPECT_TRUE(valid_test_case);
+
+            /* Early data rejected with HRR */
+            EXPECT_OK(s2n_test_key_schedule(S2N_CLIENT, NEGOTIATED | HELLO_RETRY_REQUEST,
+                    client_early_data_transitions[early_data_rejected_i], &valid_test_case));
+            EXPECT_TRUE(valid_test_case);
+
+            /* Early data rejected with extension */
+            EXPECT_OK(s2n_test_key_schedule(S2N_CLIENT, NEGOTIATED,
+                    client_early_data_transitions[early_data_rejected_i], &valid_test_case));
+            EXPECT_TRUE(valid_test_case);
+            EXPECT_OK(s2n_test_key_schedule(S2N_SERVER, NEGOTIATED,
+                    server_early_data_transitions[early_data_rejected_i], &valid_test_case));
+            EXPECT_TRUE(valid_test_case);
+
+            /* Early data accepted */
+            EXPECT_OK(s2n_test_key_schedule(S2N_CLIENT, NEGOTIATED | WITH_EARLY_DATA,
+                    client_early_data_transitions[early_data_accepted_i], &valid_test_case));
+            EXPECT_TRUE(valid_test_case);
+            EXPECT_OK(s2n_test_key_schedule(S2N_SERVER, NEGOTIATED | WITH_EARLY_DATA,
+                    server_early_data_transitions[early_data_accepted_i], &valid_test_case));
+            EXPECT_TRUE(valid_test_case);
+        }
+
+        /* Test all client cases */
+        for (size_t state_i = 0; state_i < s2n_array_len(client_early_data_transitions); state_i++) {
+            for (uint16_t handshake_type = 0; handshake_type < S2N_HANDSHAKES_COUNT; handshake_type++) {
+                EXPECT_OK(s2n_test_key_schedule(S2N_CLIENT, handshake_type, client_early_data_transitions[state_i],
+                        &valid_test_case));
+            }
+        }
+
+        /* Test all server_cases */
+        for (size_t state_i = 0; state_i < s2n_array_len(server_early_data_transitions); state_i++) {
+            for (uint16_t handshake_type = 0; handshake_type < S2N_HANDSHAKES_COUNT; handshake_type++) {
+                EXPECT_OK(s2n_test_key_schedule(S2N_SERVER, handshake_type, server_early_data_transitions[state_i],
+                        &valid_test_case));
+            }
+        }
+    }
+
+    /* Test early data encryption */
+    {
+        /**
+         *= https://tools.ietf.org/rfc/rfc8448#section-3
+         *= type=test
+         *# {server}  generate resumption secret "tls13 resumption":
+         *#
+         *#    PRK (32 octets):  7d f2 35 f2 03 1d 2a 05 12 87 d0 2b 02 41 b0 bf
+         *#       da f8 6c c8 56 23 1f 2d 5a ba 46 c4 34 ec 19 6c
+         *#
+         *#    hash (2 octets):  00 00
+         *#
+         *#    info (22 octets):  00 20 10 74 6c 73 31 33 20 72 65 73 75 6d 70 74
+         *#       69 6f 6e 02 00 00
+         *#
+         *#    expanded (32 octets):  4e cd 0e b6 ec 3b 4d 87 f5 d6 02 8f 92 2c
+         *#       a4 c5 85 1a 27 7f d4 13 11 c9 e6 2d 2c 94 92 e1 c4 f3
+         */
+        S2N_BLOB_FROM_HEX(psk_secret,"4e cd 0e b6 ec 3b 4d 87 f5 d6 02 8f 92 2c \
+                  a4 c5 85 1a 27 7f d4 13 11 c9 e6 2d 2c 94 92 e1 c4 f3");
+
+        /**
+         *= https://tools.ietf.org/rfc/rfc8448#section-3
+         *= type=test
+         *# {server}  construct a NewSessionTicket handshake message:
+         *#
+         *#    NewSessionTicket (205 octets):  04 00 00 c9 00 00 00 1e fa d6 aa
+         *#       c5 02 00 00 00 b2 2c 03 5d 82 93 59 ee 5f f7 af 4e c9 00 00 00
+         *#       00 26 2a 64 94 dc 48 6d 2c 8a 34 cb 33 fa 90 bf 1b 00 70 ad 3c
+         *#       49 88 83 c9 36 7c 09 a2 be 78 5a bc 55 cd 22 60 97 a3 a9 82 11
+         *#       72 83 f8 2a 03 a1 43 ef d3 ff 5d d3 6d 64 e8 61 be 7f d6 1d 28
+         *#       27 db 27 9c ce 14 50 77 d4 54 a3 66 4d 4e 6d a4 d2 9e e0 37 25
+         *#       a6 a4 da fc d0 fc 67 d2 ae a7 05 29 51 3e 3d a2 67 7f a5 90 6c
+         *#       5b 3f 7d 8f 92 f2 28 bd a4 0d da 72 14 70 f9 fb f2 97 b5 ae a6
+         *#       17 64 6f ac 5c 03 27 2e 97 07 27 c6 21 a7 91 41 ef 5f 7d e6 50
+         *#       5e 5b fb c3 88 e9 33 43 69 40 93 93 4a e4 d3 57 00 08 00 2a 00
+         *#       04 00 00 04 00
+         */
+        S2N_BLOB_FROM_HEX(psk_identity,
+                                   "2c 03 5d 82 93 59 ee 5f f7 af 4e c9 00 00 00 \
+                  00 26 2a 64 94 dc 48 6d 2c 8a 34 cb 33 fa 90 bf 1b 00 70 ad 3c \
+                  49 88 83 c9 36 7c 09 a2 be 78 5a bc 55 cd 22 60 97 a3 a9 82 11 \
+                  72 83 f8 2a 03 a1 43 ef d3 ff 5d d3 6d 64 e8 61 be 7f d6 1d 28 \
+                  27 db 27 9c ce 14 50 77 d4 54 a3 66 4d 4e 6d a4 d2 9e e0 37 25 \
+                  a6 a4 da fc d0 fc 67 d2 ae a7 05 29 51 3e 3d a2 67 7f a5 90 6c \
+                  5b 3f 7d 8f 92 f2 28 bd a4 0d da 72 14 70 f9 fb f2 97 b5 ae a6 \
+                  17 64 6f ac 5c 03 27 2e 97 07 27 c6 21 a7 91 41 ef 5f 7d e6 50 \
+                  5e 5b fb c3 88 e9 33 43 69 40 93 93 4a e4 d3 57");
+        const uint32_t max_early_data = 0x0400;
+
+        /**
+         *= https://tools.ietf.org/rfc/rfc8448#section-4
+         *= type=test
+         *# {client}  send handshake record:
+         *#
+         *#    payload (512 octets):  01 00 01 fc 03 03 1b c3 ce b6 bb e3 9c ff
+         *#       93 83 55 b5 a5 0a db 6d b2 1b 7a 6a f6 49 d7 b4 bc 41 9d 78 76
+         *#       48 7d 95 00 00 06 13 01 13 03 13 02 01 00 01 cd 00 00 00 0b 00
+         *#       09 00 00 06 73 65 72 76 65 72 ff 01 00 01 00 00 0a 00 14 00 12
+         *#       00 1d 00 17 00 18 00 19 01 00 01 01 01 02 01 03 01 04 00 33 00
+         *#       26 00 24 00 1d 00 20 e4 ff b6 8a c0 5f 8d 96 c9 9d a2 66 98 34
+         *#       6c 6b e1 64 82 ba dd da fe 05 1a 66 b4 f1 8d 66 8f 0b 00 2a 00
+         *#       00 00 2b 00 03 02 03 04 00 0d 00 20 00 1e 04 03 05 03 06 03 02
+         *#       03 08 04 08 05 08 06 04 01 05 01 06 01 02 01 04 02 05 02 06 02
+         *#       02 02 00 2d 00 02 01 01 00 1c 00 02 40 01 00 15 00 57 00 00 00
+         *#       00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+         *#       00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+         *#       00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+         *#       00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+         *#       00 29 00 dd 00 b8 00 b2 2c 03 5d 82 93 59 ee 5f f7 af 4e c9 00
+         *#       00 00 00 26 2a 64 94 dc 48 6d 2c 8a 34 cb 33 fa 90 bf 1b 00 70
+         *#       ad 3c 49 88 83 c9 36 7c 09 a2 be 78 5a bc 55 cd 22 60 97 a3 a9
+         *#       82 11 72 83 f8 2a 03 a1 43 ef d3 ff 5d d3 6d 64 e8 61 be 7f d6
+         *#       1d 28 27 db 27 9c ce 14 50 77 d4 54 a3 66 4d 4e 6d a4 d2 9e e0
+         *#       37 25 a6 a4 da fc d0 fc 67 d2 ae a7 05 29 51 3e 3d a2 67 7f a5
+         *#       90 6c 5b 3f 7d 8f 92 f2 28 bd a4 0d da 72 14 70 f9 fb f2 97 b5
+         *#       ae a6 17 64 6f ac 5c 03 27 2e 97 07 27 c6 21 a7 91 41 ef 5f 7d
+         *#       e6 50 5e 5b fb c3 88 e9 33 43 69 40 93 93 4a e4 d3 57 fa d6 aa
+         *#       cb 00 21 20 3a dd 4f b2 d8 fd f8 22 a0 ca 3c f7 67 8e f5 e8 8d
+         *#       ae 99 01 41 c5 92 4d 57 bb 6f a3 1b 9e 5f 9d
+         */
+        S2N_BLOB_FROM_HEX(client_hello_msg,
+                                     "01 00 01 fc 03 03 1b c3 ce b6 bb e3 9c ff \
+                  93 83 55 b5 a5 0a db 6d b2 1b 7a 6a f6 49 d7 b4 bc 41 9d 78 76 \
+                  48 7d 95 00 00 06 13 01 13 03 13 02 01 00 01 cd 00 00 00 0b 00 \
+                  09 00 00 06 73 65 72 76 65 72 ff 01 00 01 00 00 0a 00 14 00 12 \
+                  00 1d 00 17 00 18 00 19 01 00 01 01 01 02 01 03 01 04 00 33 00 \
+                  26 00 24 00 1d 00 20 e4 ff b6 8a c0 5f 8d 96 c9 9d a2 66 98 34 \
+                  6c 6b e1 64 82 ba dd da fe 05 1a 66 b4 f1 8d 66 8f 0b 00 2a 00 \
+                  00 00 2b 00 03 02 03 04 00 0d 00 20 00 1e 04 03 05 03 06 03 02 \
+                  03 08 04 08 05 08 06 04 01 05 01 06 01 02 01 04 02 05 02 06 02 \
+                  02 02 00 2d 00 02 01 01 00 1c 00 02 40 01 00 15 00 57 00 00 00 \
+                  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 \
+                  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 \
+                  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 \
+                  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 \
+                  00 29 00 dd 00 b8 00 b2 2c 03 5d 82 93 59 ee 5f f7 af 4e c9 00 \
+                  00 00 00 26 2a 64 94 dc 48 6d 2c 8a 34 cb 33 fa 90 bf 1b 00 70 \
+                  ad 3c 49 88 83 c9 36 7c 09 a2 be 78 5a bc 55 cd 22 60 97 a3 a9 \
+                  82 11 72 83 f8 2a 03 a1 43 ef d3 ff 5d d3 6d 64 e8 61 be 7f d6 \
+                  1d 28 27 db 27 9c ce 14 50 77 d4 54 a3 66 4d 4e 6d a4 d2 9e e0 \
+                  37 25 a6 a4 da fc d0 fc 67 d2 ae a7 05 29 51 3e 3d a2 67 7f a5 \
+                  90 6c 5b 3f 7d 8f 92 f2 28 bd a4 0d da 72 14 70 f9 fb f2 97 b5 \
+                  ae a6 17 64 6f ac 5c 03 27 2e 97 07 27 c6 21 a7 91 41 ef 5f 7d \
+                  e6 50 5e 5b fb c3 88 e9 33 43 69 40 93 93 4a e4 d3 57 fa d6 aa \
+                  cb 00 21 20 3a dd 4f b2 d8 fd f8 22 a0 ca 3c f7 67 8e f5 e8 8d \
+                  ae 99 01 41 c5 92 4d 57 bb 6f a3 1b 9e 5f 9d")
+        /**
+         *= https://tools.ietf.org/rfc/rfc8448#section-4
+         *= type=test
+         *#
+         *#    complete record (517 octets):  16 03 01 02 00 01 00 01 fc 03 03 1b
+         *#       c3 ce b6 bb e3 9c ff 93 83 55 b5 a5 0a db 6d b2 1b 7a 6a f6 49
+         *#       d7 b4 bc 41 9d 78 76 48 7d 95 00 00 06 13 01 13 03 13 02 01 00
+         *#       01 cd 00 00 00 0b 00 09 00 00 06 73 65 72 76 65 72 ff 01 00 01
+         *#       00 00 0a 00 14 00 12 00 1d 00 17 00 18 00 19 01 00 01 01 01 02
+         *#       01 03 01 04 00 33 00 26 00 24 00 1d 00 20 e4 ff b6 8a c0 5f 8d
+         *#       96 c9 9d a2 66 98 34 6c 6b e1 64 82 ba dd da fe 05 1a 66 b4 f1
+         *#       8d 66 8f 0b 00 2a 00 00 00 2b 00 03 02 03 04 00 0d 00 20 00 1e
+         *#       04 03 05 03 06 03 02 03 08 04 08 05 08 06 04 01 05 01 06 01 02
+         *#       01 04 02 05 02 06 02 02 02 00 2d 00 02 01 01 00 1c 00 02 40 01
+         *#       00 15 00 57 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+         *#       00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+         *#       00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+         *#       00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+         *#       00 00 00 00 00 00 00 00 29 00 dd 00 b8 00 b2 2c 03 5d 82 93 59
+         *#       ee 5f f7 af 4e c9 00 00 00 00 26 2a 64 94 dc 48 6d 2c 8a 34 cb
+         *#       33 fa 90 bf 1b 00 70 ad 3c 49 88 83 c9 36 7c 09 a2 be 78 5a bc
+         *#       55 cd 22 60 97 a3 a9 82 11 72 83 f8 2a 03 a1 43 ef d3 ff 5d d3
+         *#       6d 64 e8 61 be 7f d6 1d 28 27 db 27 9c ce 14 50 77 d4 54 a3 66
+         *#       4d 4e 6d a4 d2 9e e0 37 25 a6 a4 da fc d0 fc 67 d2 ae a7 05 29
+         *#       51 3e 3d a2 67 7f a5 90 6c 5b 3f 7d 8f 92 f2 28 bd a4 0d da 72
+         *#       14 70 f9 fb f2 97 b5 ae a6 17 64 6f ac 5c 03 27 2e 97 07 27 c6
+         *#       21 a7 91 41 ef 5f 7d e6 50 5e 5b fb c3 88 e9 33 43 69 40 93 93
+         *#       4a e4 d3 57 fa d6 aa cb 00 21 20 3a dd 4f b2 d8 fd f8 22 a0 ca
+         *#       3c f7 67 8e f5 e8 8d ae 99 01 41 c5 92 4d 57 bb 6f a3 1b 9e 5f
+         *#       9d
+         */
+        S2N_BLOB_FROM_HEX(ch_record,         "16 03 01 02 00 01 00 01 fc 03 03 1b \
+                  c3 ce b6 bb e3 9c ff 93 83 55 b5 a5 0a db 6d b2 1b 7a 6a f6 49 \
+                  d7 b4 bc 41 9d 78 76 48 7d 95 00 00 06 13 01 13 03 13 02 01 00 \
+                  01 cd 00 00 00 0b 00 09 00 00 06 73 65 72 76 65 72 ff 01 00 01 \
+                  00 00 0a 00 14 00 12 00 1d 00 17 00 18 00 19 01 00 01 01 01 02 \
+                  01 03 01 04 00 33 00 26 00 24 00 1d 00 20 e4 ff b6 8a c0 5f 8d \
+                  96 c9 9d a2 66 98 34 6c 6b e1 64 82 ba dd da fe 05 1a 66 b4 f1 \
+                  8d 66 8f 0b 00 2a 00 00 00 2b 00 03 02 03 04 00 0d 00 20 00 1e \
+                  04 03 05 03 06 03 02 03 08 04 08 05 08 06 04 01 05 01 06 01 02 \
+                  01 04 02 05 02 06 02 02 02 00 2d 00 02 01 01 00 1c 00 02 40 01 \
+                  00 15 00 57 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 \
+                  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 \
+                  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 \
+                  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 \
+                  00 00 00 00 00 00 00 00 29 00 dd 00 b8 00 b2 2c 03 5d 82 93 59 \
+                  ee 5f f7 af 4e c9 00 00 00 00 26 2a 64 94 dc 48 6d 2c 8a 34 cb \
+                  33 fa 90 bf 1b 00 70 ad 3c 49 88 83 c9 36 7c 09 a2 be 78 5a bc \
+                  55 cd 22 60 97 a3 a9 82 11 72 83 f8 2a 03 a1 43 ef d3 ff 5d d3 \
+                  6d 64 e8 61 be 7f d6 1d 28 27 db 27 9c ce 14 50 77 d4 54 a3 66 \
+                  4d 4e 6d a4 d2 9e e0 37 25 a6 a4 da fc d0 fc 67 d2 ae a7 05 29 \
+                  51 3e 3d a2 67 7f a5 90 6c 5b 3f 7d 8f 92 f2 28 bd a4 0d da 72 \
+                  14 70 f9 fb f2 97 b5 ae a6 17 64 6f ac 5c 03 27 2e 97 07 27 c6 \
+                  21 a7 91 41 ef 5f 7d e6 50 5e 5b fb c3 88 e9 33 43 69 40 93 93 \
+                  4a e4 d3 57 fa d6 aa cb 00 21 20 3a dd 4f b2 d8 fd f8 22 a0 ca \
+                  3c f7 67 8e f5 e8 8d ae 99 01 41 c5 92 4d 57 bb 6f a3 1b 9e 5f \
+                  9d");
+
+        /**
+         *= https://tools.ietf.org/rfc/rfc8448#section-4
+         *= type=test
+         *# {client}  extract secret "early":
+         *#
+         *#    salt:  0 (all zero octets)
+         *#
+         *#    IKM (32 octets):  4e cd 0e b6 ec 3b 4d 87 f5 d6 02 8f 92 2c a4 c5
+         *#       85 1a 27 7f d4 13 11 c9 e6 2d 2c 94 92 e1 c4 f3
+         *#
+         *#    secret (32 octets):  9b 21 88 e9 b2 fc 6d 64 d7 1d c3 29 90 0e 20
+         *#       bb 41 91 50 00 f6 78 aa 83 9c bb 79 7c b7 d8 33 2c
+         */
+        S2N_BLOB_FROM_HEX(early_secret,
+                                   "9b 21 88 e9 b2 fc 6d 64 d7 1d c3 29 90 0e 20 \
+                  bb 41 91 50 00 f6 78 aa 83 9c bb 79 7c b7 d8 33 2c");
+
+        /**
+         *= https://tools.ietf.org/rfc/rfc8448#section-4
+         *= type=test
+         *# {client}  derive write traffic keys for early application data:
+         *#
+         *# PRK (32 octets):  3f bb e6 a6 0d eb 66 c3 0a 32 79 5a ba 0e ff 7e
+         *#       aa 10 10 55 86 e7 be 5c 09 67 8d 63 b6 ca ab 62
+         *#
+         *# key info (13 octets):  00 10 09 74 6c 73 31 33 20 6b 65 79 00
+         *#
+         *# key expanded (16 octets):  92 02 05 a5 b7 bf 21 15 e6 fc 5c 29 42
+         *#       83 4f 54
+         *#
+         *# iv info (12 octets):  00 0c 08 74 6c 73 31 33 20 69 76 00
+         *#
+         *# iv expanded (12 octets):  6d 47 5f 09 93 c8 e5 64 61 0d b2 b9
+         */
+        S2N_BLOB_FROM_HEX(iv,        "6d 47 5f 09 93 c8 e5 64 61 0d b2 b9");
+
+        /**
+         *= https://tools.ietf.org/rfc/rfc8448#section-4
+         *= type=test
+         *# {client}  send application_data record:
+         *#
+         *#    payload (6 octets):  41 42 43 44 45 46
+         */
+        S2N_BLOB_FROM_HEX(payload, "41 42 43 44 45 46");
+        /**
+         *= https://tools.ietf.org/rfc/rfc8448#section-4
+         *= type=test
+         *#
+         *#    complete record (28 octets):  17 03 03 00 17 ab 1d f4 20 e7 5c 45
+         *#       7a 7c c5 d2 84 4f 76 d5 ae e4 b4 ed bf 04 9b e0
+         */
+        S2N_BLOB_FROM_HEX(complete_record,  "17 03 03 00 17 ab 1d f4 20 e7 5c 45 \
+                  7a 7c c5 d2 84 4f 76 d5 ae e4 b4 ed bf 04 9b e0");
+
+        /* Test client early data encryption against known client outputs */
+        {
+            struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(client_conn);
+            client_conn->actual_protocol_version = S2N_TLS13;
+            client_conn->server_protocol_version = S2N_TLS13;
+
+            struct s2n_psk *psk = NULL;
+            EXPECT_OK(s2n_array_pushback(&client_conn->psk_params.psk_list, (void**) &psk));
+            psk->hmac_alg = S2N_HMAC_SHA256;
+            EXPECT_SUCCESS(s2n_psk_configure_early_data(psk, max_early_data, 0x13, 0x01));
+
+            /* Rewrite early secret with known early secret. */
+            EXPECT_SUCCESS(s2n_dup(&early_secret, &psk->early_secret));
+
+            /* Rewrite hashes with known ClientHello */
+            EXPECT_SUCCESS(s2n_hash_update(&client_conn->handshake.sha256,
+                    client_hello_msg.data, client_hello_msg.size));
+
+            client_conn->handshake.message_number = 0;
+            client_conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
+            EXPECT_SUCCESS(s2n_tls13_handle_secrets(client_conn));
+
+            /* Check early secret secret set correctly */
+            EXPECT_BYTEARRAY_EQUAL(client_conn->secure.rsa_premaster_secret, early_secret.data, early_secret.size);
+
+            /* Check IV calculated correctly */
+            EXPECT_BYTEARRAY_EQUAL(client_conn->secure.client_implicit_iv, iv.data, iv.size);
+
+            /* Check payload encrypted correctly */
+            EXPECT_SUCCESS(s2n_record_write(client_conn, TLS_APPLICATION_DATA, &payload));
+            EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->out), complete_record.size);
+            EXPECT_BYTEARRAY_EQUAL(client_conn->out.blob.data, complete_record.data, complete_record.size);
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        }
+
+/* The known ClientHello uses the x25519 curve,
+ * which the S2N server won't accept if the EVP APIs are not supported */
+#if EVP_APIS_SUPPORTED
+        /* Test server early data encryption with known client inputs */
+        {
+            struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(server_conn);
+            EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
+
+            DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
+            psk->type = S2N_PSK_TYPE_RESUMPTION;
+            EXPECT_SUCCESS(s2n_psk_set_identity(psk, psk_identity.data, psk_identity.size));
+            EXPECT_SUCCESS(s2n_psk_set_secret(psk, psk_secret.data, psk_secret.size));
+            EXPECT_SUCCESS(s2n_psk_configure_early_data(psk, max_early_data, 0x13, 0x01));
+            EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, psk));
+
+            DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
+            DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, S2N_DEFAULT_RECORD_LENGTH));
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, S2N_DEFAULT_RECORD_LENGTH));
+            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, server_conn));
+
+            EXPECT_SUCCESS(s2n_stuffer_write(&input, &ch_record));
+
+            s2n_blocked_status blocked = 0;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(server_conn, &blocked), S2N_ERR_IO_BLOCKED);
+            EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), END_OF_EARLY_DATA);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&input), 0);
+
+            EXPECT_SUCCESS(s2n_stuffer_write(&input, &complete_record));
+
+            DEFER_CLEANUP(struct s2n_blob actual_payload = { 0 }, s2n_free);
+            EXPECT_SUCCESS(s2n_alloc(&actual_payload, payload.size));
+            int r = s2n_recv(server_conn, actual_payload.data, actual_payload.size, &blocked);
+            EXPECT_EQUAL(r, payload.size);
+            EXPECT_BYTEARRAY_EQUAL(actual_payload.data, payload.data, payload.size);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&input), 0);
+
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+#endif
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_tls13_handshake_state_machine_test.c
+++ b/tests/unit/s2n_tls13_handshake_state_machine_test.c
@@ -478,6 +478,7 @@ int main(int argc, char **argv)
 
             conn->handshake.handshake_type = 0;
             conn->handshake.message_number = 0;
+            conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
             EXPECT_EQUAL(ACTIVE_MESSAGE(conn), CLIENT_HELLO);
             EXPECT_SUCCESS(s2n_setup_handler_to_expect(CLIENT_HELLO, S2N_SERVER));
 

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -397,7 +397,7 @@ int main(int argc, char **argv) {
              * the client & server traffic secrets */
             DEFER_CLEANUP(struct s2n_tls13_keys secrets = {0}, s2n_tls13_keys_free);
             EXPECT_SUCCESS(s2n_tls13_keys_init(&secrets, test_vector->cipher_suite->prf_alg));
-            EXPECT_SUCCESS(s2n_tls13_derive_early_secrets(&secrets, NULL));
+            EXPECT_SUCCESS(s2n_tls13_derive_early_secret(&secrets, NULL));
 
             DEFER_CLEANUP(struct s2n_hash_state hash_state, s2n_hash_free);
             EXPECT_SUCCESS(s2n_hash_new(&hash_state));
@@ -407,8 +407,9 @@ int main(int argc, char **argv) {
             s2n_tls13_key_blob(client_traffic_secret, secrets.size);
             s2n_tls13_key_blob(server_traffic_secret, secrets.size);
 
-            EXPECT_SUCCESS(s2n_tls13_derive_handshake_secrets(&secrets, &client_calculated_shared_secret,
-                    &hash_state, &client_traffic_secret, &server_traffic_secret));
+            EXPECT_SUCCESS(s2n_tls13_extract_handshake_secret(&secrets, &client_calculated_shared_secret));
+            EXPECT_SUCCESS(s2n_tls13_derive_handshake_traffic_secret(&secrets, &hash_state, &client_traffic_secret, S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_tls13_derive_handshake_traffic_secret(&secrets, &hash_state, &server_traffic_secret, S2N_SERVER));
 
             /* Assert correctness of traffic secrets */
             EXPECT_EQUAL(test_vector->expected_client_traffic_secret->size, client_traffic_secret.size);

--- a/tests/unit/s2n_tls13_keys_test.c
+++ b/tests/unit/s2n_tls13_keys_test.c
@@ -14,6 +14,7 @@
  */
 
 #include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
 
 #include <string.h>
 
@@ -182,7 +183,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_tls13_keys_init(&secrets, S2N_HMAC_SHA256));
 
     /* Derive Early Secrets */
-    EXPECT_SUCCESS(s2n_tls13_derive_early_secrets(&secrets, NULL));
+    EXPECT_SUCCESS(s2n_tls13_derive_early_secret(&secrets, NULL));
 
     S2N_BLOB_EXPECT_EQUAL(secrets.extract_secret, expected_early_secret);
     S2N_BLOB_EXPECT_EQUAL(secrets.derive_secret, expect_derived_handshake_secret);
@@ -201,7 +202,9 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_hash_copy(&hash_state_copy, &hash_state));
 
     /* Derive Handshake Secrets */
-    EXPECT_SUCCESS(s2n_tls13_derive_handshake_secrets(&secrets, &ecdhe, &hash_state_copy, &client_handshake_secret, &server_handshake_secret));
+    EXPECT_SUCCESS(s2n_tls13_extract_handshake_secret(&secrets, &ecdhe));
+    EXPECT_SUCCESS(s2n_tls13_derive_handshake_traffic_secret(&secrets, &hash_state_copy, &client_handshake_secret, S2N_CLIENT));
+    EXPECT_SUCCESS(s2n_tls13_derive_handshake_traffic_secret(&secrets, &hash_state_copy, &server_handshake_secret, S2N_SERVER));
 
     /* this checks that the original hash state can still be used to derive a hash without being affected by the derive function */
     s2n_tls13_key_blob(client_server_hello_hash, secrets.size);
@@ -331,7 +334,7 @@ int main(int argc, char **argv)
         S2N_BLOB_EXPECT_EQUAL(test_keys.derive_secret, expected_binder_key);
     }
 
-    /* Test s2n_tls13_derive_early_secrets produces the correct secret when a psk is set. Values
+    /* Test s2n_tls13_derive_early_secret produces the correct secret when a psk is set. Values
      * are taken from https://tools.ietf.org/html/rfc8448#section-4 */
     {
         S2N_BLOB_FROM_HEX(resumption_early_secret,
@@ -346,12 +349,12 @@ int main(int argc, char **argv)
         DEFER_CLEANUP(struct s2n_tls13_keys test_keys = { 0 }, s2n_tls13_keys_free);
         EXPECT_SUCCESS(s2n_tls13_keys_init(&test_keys, test_psk.hmac_alg));
 
-        EXPECT_SUCCESS(s2n_tls13_derive_early_secrets(&test_keys, &test_psk));
+        EXPECT_SUCCESS(s2n_tls13_derive_early_secret(&test_keys, &test_psk));
 
         S2N_BLOB_EXPECT_EQUAL(test_keys.derive_secret, expected_derived_secret);
     }
 
-    /* s2n_tls13_derive_early_secrets will error using a psk with an empty early secret */
+    /* s2n_tls13_derive_early_secret will error using a psk with an empty early secret */
     {
         struct s2n_blob empty_blob = { .data = NULL, .size = 0 };
 
@@ -362,7 +365,122 @@ int main(int argc, char **argv)
         DEFER_CLEANUP(struct s2n_tls13_keys test_keys = { 0 }, s2n_tls13_keys_free);
         EXPECT_SUCCESS(s2n_tls13_keys_init(&test_keys, test_psk.hmac_alg));
 
-        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_derive_early_secrets(&test_keys, &test_psk), S2N_ERR_SAFETY);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_derive_early_secret(&test_keys, &test_psk), S2N_ERR_SAFETY);
+    }
+
+    /* Test s2n_tls13_derive_early_traffic_secret */
+    {
+        /** ClientHello record needed for hash.
+         *
+         *= https://tools.ietf.org/rfc/rfc8448#section-4
+         *= type=test
+         *# {client}  send handshake record:
+         *#
+         *#    payload (512 octets):  01 00 01 fc 03 03 1b c3 ce b6 bb e3 9c ff
+         *#       93 83 55 b5 a5 0a db 6d b2 1b 7a 6a f6 49 d7 b4 bc 41 9d 78 76
+         *#       48 7d 95 00 00 06 13 01 13 03 13 02 01 00 01 cd 00 00 00 0b 00
+         *#       09 00 00 06 73 65 72 76 65 72 ff 01 00 01 00 00 0a 00 14 00 12
+         *#       00 1d 00 17 00 18 00 19 01 00 01 01 01 02 01 03 01 04 00 33 00
+         *#       26 00 24 00 1d 00 20 e4 ff b6 8a c0 5f 8d 96 c9 9d a2 66 98 34
+         *#       6c 6b e1 64 82 ba dd da fe 05 1a 66 b4 f1 8d 66 8f 0b 00 2a 00
+         *#       00 00 2b 00 03 02 03 04 00 0d 00 20 00 1e 04 03 05 03 06 03 02
+         *#       03 08 04 08 05 08 06 04 01 05 01 06 01 02 01 04 02 05 02 06 02
+         *#       02 02 00 2d 00 02 01 01 00 1c 00 02 40 01 00 15 00 57 00 00 00
+         *#       00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+         *#       00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+         *#       00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+         *#       00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+         *#       00 29 00 dd 00 b8 00 b2 2c 03 5d 82 93 59 ee 5f f7 af 4e c9 00
+         *#       00 00 00 26 2a 64 94 dc 48 6d 2c 8a 34 cb 33 fa 90 bf 1b 00 70
+         *#       ad 3c 49 88 83 c9 36 7c 09 a2 be 78 5a bc 55 cd 22 60 97 a3 a9
+         *#       82 11 72 83 f8 2a 03 a1 43 ef d3 ff 5d d3 6d 64 e8 61 be 7f d6
+         *#       1d 28 27 db 27 9c ce 14 50 77 d4 54 a3 66 4d 4e 6d a4 d2 9e e0
+         *#       37 25 a6 a4 da fc d0 fc 67 d2 ae a7 05 29 51 3e 3d a2 67 7f a5
+         *#       90 6c 5b 3f 7d 8f 92 f2 28 bd a4 0d da 72 14 70 f9 fb f2 97 b5
+         *#       ae a6 17 64 6f ac 5c 03 27 2e 97 07 27 c6 21 a7 91 41 ef 5f 7d
+         *#       e6 50 5e 5b fb c3 88 e9 33 43 69 40 93 93 4a e4 d3 57 fa d6 aa
+         *#       cb 00 21 20 3a dd 4f b2 d8 fd f8 22 a0 ca 3c f7 67 8e f5 e8 8d
+         *#       ae 99 01 41 c5 92 4d 57 bb 6f a3 1b 9e 5f 9d
+         */
+        S2N_BLOB_FROM_HEX(payload,   "01 00 01 fc 03 03 1b c3 ce b6 bb e3 9c ff \
+                  93 83 55 b5 a5 0a db 6d b2 1b 7a 6a f6 49 d7 b4 bc 41 9d 78 76 \
+                  48 7d 95 00 00 06 13 01 13 03 13 02 01 00 01 cd 00 00 00 0b 00 \
+                  09 00 00 06 73 65 72 76 65 72 ff 01 00 01 00 00 0a 00 14 00 12 \
+                  00 1d 00 17 00 18 00 19 01 00 01 01 01 02 01 03 01 04 00 33 00 \
+                  26 00 24 00 1d 00 20 e4 ff b6 8a c0 5f 8d 96 c9 9d a2 66 98 34 \
+                  6c 6b e1 64 82 ba dd da fe 05 1a 66 b4 f1 8d 66 8f 0b 00 2a 00 \
+                  00 00 2b 00 03 02 03 04 00 0d 00 20 00 1e 04 03 05 03 06 03 02 \
+                  03 08 04 08 05 08 06 04 01 05 01 06 01 02 01 04 02 05 02 06 02 \
+                  02 02 00 2d 00 02 01 01 00 1c 00 02 40 01 00 15 00 57 00 00 00 \
+                  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 \
+                  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 \
+                  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 \
+                  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 \
+                  00 29 00 dd 00 b8 00 b2 2c 03 5d 82 93 59 ee 5f f7 af 4e c9 00 \
+                  00 00 00 26 2a 64 94 dc 48 6d 2c 8a 34 cb 33 fa 90 bf 1b 00 70 \
+                  ad 3c 49 88 83 c9 36 7c 09 a2 be 78 5a bc 55 cd 22 60 97 a3 a9 \
+                  82 11 72 83 f8 2a 03 a1 43 ef d3 ff 5d d3 6d 64 e8 61 be 7f d6 \
+                  1d 28 27 db 27 9c ce 14 50 77 d4 54 a3 66 4d 4e 6d a4 d2 9e e0 \
+                  37 25 a6 a4 da fc d0 fc 67 d2 ae a7 05 29 51 3e 3d a2 67 7f a5 \
+                  90 6c 5b 3f 7d 8f 92 f2 28 bd a4 0d da 72 14 70 f9 fb f2 97 b5 \
+                  ae a6 17 64 6f ac 5c 03 27 2e 97 07 27 c6 21 a7 91 41 ef 5f 7d \
+                  e6 50 5e 5b fb c3 88 e9 33 43 69 40 93 93 4a e4 d3 57 fa d6 aa \
+                  cb 00 21 20 3a dd 4f b2 d8 fd f8 22 a0 ca 3c f7 67 8e f5 e8 8d \
+                  ae 99 01 41 c5 92 4d 57 bb 6f a3 1b 9e 5f 9d")
+
+        /**
+         *= https://tools.ietf.org/rfc/rfc8448#section-4
+         *= type=test
+         *# {client}  derive secret "tls13 c e traffic":
+         *#
+         *#    PRK (32 octets):  9b 21 88 e9 b2 fc 6d 64 d7 1d c3 29 90 0e 20 bb
+         *#       41 91 50 00 f6 78 aa 83 9c bb 79 7c b7 d8 33 2c
+         **/
+        S2N_BLOB_FROM_HEX(prk,  "9b 21 88 e9 b2 fc 6d 64 d7 1d c3 29 90 0e 20 bb \
+                  41 91 50 00 f6 78 aa 83 9c bb 79 7c b7 d8 33 2c");
+        /**
+         *= https://tools.ietf.org/rfc/rfc8448#section-4
+         *= type=test
+         *#
+         *#    hash (32 octets):  08 ad 0f a0 5d 7c 72 33 b1 77 5b a2 ff 9f 4c 5b
+         *#       8b 59 27 6b 7f 22 7f 13 a9 76 24 5f 5d 96 09 13
+         */
+        S2N_BLOB_FROM_HEX(hash,  "08 ad 0f a0 5d 7c 72 33 b1 77 5b a2 ff 9f 4c 5b \
+                  8b 59 27 6b 7f 22 7f 13 a9 76 24 5f 5d 96 09 13");
+        /**
+         *= https://tools.ietf.org/rfc/rfc8448#section-4
+         *= type=test
+         *#
+         *#    info (53 octets):  00 20 11 74 6c 73 31 33 20 63 20 65 20 74 72 61
+         *#       66 66 69 63 20 08 ad 0f a0 5d 7c 72 33 b1 77 5b a2 ff 9f 4c 5b
+         *#       8b 59 27 6b 7f 22 7f 13 a9 76 24 5f 5d 96 09 13
+         *#
+         *#    expanded (32 octets):  3f bb e6 a6 0d eb 66 c3 0a 32 79 5a ba 0e
+         *#       ff 7e aa 10 10 55 86 e7 be 5c 09 67 8d 63 b6 ca ab 62
+         */
+        S2N_BLOB_FROM_HEX(expanded,  "3f bb e6 a6 0d eb 66 c3 0a 32 79 5a ba 0e \
+                  ff 7e aa 10 10 55 86 e7 be 5c 09 67 8d 63 b6 ca ab 62");
+
+        DEFER_CLEANUP(struct s2n_tls13_keys test_keys = { 0 }, s2n_tls13_keys_free);
+        EXPECT_SUCCESS(s2n_tls13_keys_init(&test_keys, S2N_HMAC_SHA256));
+        test_keys.extract_secret = prk;
+
+        DEFER_CLEANUP(struct s2n_hash_state client_hello_hash = {0}, s2n_hash_free);
+        EXPECT_SUCCESS(s2n_hash_new(&client_hello_hash));
+        EXPECT_SUCCESS(s2n_hash_init(&client_hello_hash, S2N_HASH_SHA256));
+        EXPECT_SUCCESS(s2n_hash_update(&client_hello_hash, payload.data, payload.size));
+
+        /* Sanity check: Verify the hash is correct */
+        s2n_tls13_key_blob(actual_hash, test_keys.size);
+        DEFER_CLEANUP(struct s2n_hash_state hkdf_hash_copy, s2n_hash_free);
+        EXPECT_SUCCESS(s2n_hash_new(&hkdf_hash_copy));
+        EXPECT_SUCCESS(s2n_hash_copy(&hkdf_hash_copy, &client_hello_hash));
+        EXPECT_SUCCESS(s2n_hash_digest(&hkdf_hash_copy, actual_hash.data, actual_hash.size));
+        S2N_BLOB_EXPECT_EQUAL(actual_hash, hash);
+
+        s2n_tls13_key_blob(early_traffic_secret, test_keys.size);
+        EXPECT_SUCCESS(s2n_tls13_derive_early_traffic_secret(&test_keys, &client_hello_hash, &early_traffic_secret));
+        S2N_BLOB_EXPECT_EQUAL(early_traffic_secret, expanded);
     }
 
     END_TEST();

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -69,6 +69,7 @@ static int s2n_connection_new_hashes(struct s2n_connection *conn)
     POSIX_GUARD(s2n_hash_new(&conn->handshake.prf_md5_hash_copy));
     POSIX_GUARD(s2n_hash_new(&conn->handshake.prf_sha1_hash_copy));
     POSIX_GUARD(s2n_hash_new(&conn->handshake.prf_tls12_hash_copy));
+    POSIX_GUARD(s2n_hash_new(&conn->handshake.server_hello_copy));
     POSIX_GUARD(s2n_hash_new(&conn->handshake.server_finished_copy));
     POSIX_GUARD(s2n_hash_new(&conn->prf_space.ssl3.md5));
     POSIX_GUARD(s2n_hash_new(&conn->prf_space.ssl3.sha1));
@@ -114,6 +115,7 @@ static int s2n_connection_init_hashes(struct s2n_connection *conn)
     POSIX_GUARD(s2n_hash_init(&conn->handshake.sha512, S2N_HASH_SHA512));
     POSIX_GUARD(s2n_hash_init(&conn->handshake.ccv_hash_copy, S2N_HASH_NONE));
     POSIX_GUARD(s2n_hash_init(&conn->handshake.prf_tls12_hash_copy, S2N_HASH_NONE));
+    POSIX_GUARD(s2n_hash_init(&conn->handshake.server_hello_copy, S2N_HASH_NONE));
     POSIX_GUARD(s2n_hash_init(&conn->handshake.server_finished_copy, S2N_HASH_NONE));
     POSIX_GUARD(s2n_hash_init(&conn->handshake.prf_sha1_hash_copy, S2N_HASH_SHA1));
     POSIX_GUARD(s2n_hash_init(&conn->prf_space.ssl3.sha1, S2N_HASH_SHA1));
@@ -335,6 +337,7 @@ static int s2n_connection_reset_hashes(struct s2n_connection *conn)
     POSIX_GUARD(s2n_hash_reset(&conn->handshake.prf_md5_hash_copy));
     POSIX_GUARD(s2n_hash_reset(&conn->handshake.prf_sha1_hash_copy));
     POSIX_GUARD(s2n_hash_reset(&conn->handshake.prf_tls12_hash_copy));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.server_hello_copy));
     POSIX_GUARD(s2n_hash_reset(&conn->handshake.server_finished_copy));
     POSIX_GUARD(s2n_hash_reset(&conn->prf_space.ssl3.md5));
     POSIX_GUARD(s2n_hash_reset(&conn->prf_space.ssl3.sha1));
@@ -402,6 +405,7 @@ static int s2n_connection_free_hashes(struct s2n_connection *conn)
     POSIX_GUARD(s2n_hash_free(&conn->handshake.prf_md5_hash_copy));
     POSIX_GUARD(s2n_hash_free(&conn->handshake.prf_sha1_hash_copy));
     POSIX_GUARD(s2n_hash_free(&conn->handshake.prf_tls12_hash_copy));
+    POSIX_GUARD(s2n_hash_free(&conn->handshake.server_hello_copy));
     POSIX_GUARD(s2n_hash_free(&conn->handshake.server_finished_copy));
     POSIX_GUARD(s2n_hash_free(&conn->prf_space.ssl3.md5));
     POSIX_GUARD(s2n_hash_free(&conn->prf_space.ssl3.sha1));
@@ -581,6 +585,7 @@ int s2n_connection_free_handshake(struct s2n_connection *conn)
     POSIX_GUARD(s2n_hash_reset(&conn->handshake.prf_md5_hash_copy));
     POSIX_GUARD(s2n_hash_reset(&conn->handshake.prf_sha1_hash_copy));
     POSIX_GUARD(s2n_hash_reset(&conn->handshake.prf_tls12_hash_copy));
+    POSIX_GUARD(s2n_hash_reset(&conn->handshake.server_hello_copy));
     POSIX_GUARD(s2n_hash_reset(&conn->handshake.server_finished_copy));
 
     /* Wipe the buffers we are going to free */

--- a/tls/s2n_connection_evp_digests.c
+++ b/tls/s2n_connection_evp_digests.c
@@ -48,6 +48,7 @@ int s2n_connection_save_hash_state(struct s2n_connection_hash_handles *hash_hand
     hash_handles->prf_md5_hash_copy = conn->handshake.prf_md5_hash_copy.digest.high_level;
     hash_handles->prf_sha1_hash_copy = conn->handshake.prf_sha1_hash_copy.digest.high_level;
     hash_handles->prf_tls12_hash_copy = conn->handshake.prf_tls12_hash_copy.digest.high_level;
+    hash_handles->server_hello_copy = conn->handshake.server_hello_copy.digest.high_level;
     hash_handles->server_finished_copy = conn->handshake.server_finished_copy.digest.high_level;
 
     /* Preserve only the handlers for SSLv3 PRF hash state pointers to avoid re-allocation */
@@ -109,6 +110,7 @@ int s2n_connection_restore_hash_state(struct s2n_connection *conn, struct s2n_co
     conn->handshake.prf_md5_hash_copy.digest.high_level = hash_handles->prf_md5_hash_copy;
     conn->handshake.prf_sha1_hash_copy.digest.high_level = hash_handles->prf_sha1_hash_copy;
     conn->handshake.prf_tls12_hash_copy.digest.high_level = hash_handles->prf_tls12_hash_copy;
+    conn->handshake.server_hello_copy.digest.high_level = hash_handles->server_hello_copy;
     conn->handshake.server_finished_copy.digest.high_level = hash_handles->server_finished_copy;
 
     /* Restore s2n_connection handlers for SSLv3 PRF hash states */

--- a/tls/s2n_connection_evp_digests.h
+++ b/tls/s2n_connection_evp_digests.h
@@ -41,6 +41,7 @@ struct s2n_connection_hash_handles {
     struct s2n_hash_evp_digest prf_md5_hash_copy;
     struct s2n_hash_evp_digest prf_sha1_hash_copy;
     struct s2n_hash_evp_digest prf_tls12_hash_copy;
+    struct s2n_hash_evp_digest server_hello_copy;
     struct s2n_hash_evp_digest server_finished_copy;
     struct s2n_hash_evp_digest prf_md5;
 

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -138,6 +138,7 @@ struct s2n_handshake {
     struct s2n_hash_state prf_sha1_hash_copy;
     /*Used for TLS 1.2 PRF */
     struct s2n_hash_state prf_tls12_hash_copy;
+    struct s2n_hash_state server_hello_copy;
     struct s2n_hash_state server_finished_copy;
 
     /* Hash algorithms required for this handshake. The set of required hashes can be reduced as session parameters are

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -162,22 +162,97 @@ int s2n_tls13_compute_shared_secret(struct s2n_connection *conn, struct s2n_blob
 
     POSIX_GUARD_RESULT(s2n_connection_wipe_all_keyshares(conn));
 
+    /* It would make more sense to wipe the PSK secrets in s2n_tls13_handle_early_secret,
+     * but at that point we don't know whether or not the server will request a HRR request
+     * and we'll have to use the secrets again.
+     *
+     * Instead, wipe them here when we wipe all the other connection secrets. */
+    POSIX_GUARD_RESULT(s2n_psk_parameters_wipe_secrets(&conn->psk_params));
+
     return S2N_SUCCESS;
 }
 
-/*
- * This function executes after Server Hello is processed
- * and handshake hashes are computed. It produces and configure
- * the shared secret, handshake secrets, handshake traffic keys,
- * and finished keys.
- */
-int s2n_tls13_handle_handshake_secrets(struct s2n_connection *conn)
+int s2n_tls13_handle_early_secret(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
+
+    struct s2n_psk *psk = conn->psk_params.chosen_psk;
+
+    /* If the client is sending early data, then the client will need to calculate
+     * the early secret before the server chooses a PSK. */
+    if (conn->mode == S2N_CLIENT && conn->early_data_state == S2N_EARLY_DATA_REQUESTED) {
+        POSIX_GUARD_RESULT(s2n_array_get(&conn->psk_params.psk_list, 0, (void**) &psk));
+        POSIX_ENSURE_REF(psk);
+
+        /* We need to set the early data cipher suite so that the secret derivation
+         * logic uses the right hmac algorithm.
+         */
+        POSIX_ENSURE_REF(psk->early_data_config.cipher_suite);
+        conn->secure.cipher_suite = psk->early_data_config.cipher_suite;
+    }
+
+    /* get tls13 key context */
+    s2n_tls13_connection_keys(secrets, conn);
+
+    /* derive early secrets */
+    POSIX_GUARD(s2n_tls13_derive_early_secret(&secrets, psk));
+
+    return S2N_SUCCESS;
+}
+
+
+int s2n_tls13_handle_early_traffic_secret(struct s2n_connection *conn)
+{
+    POSIX_ENSURE_REF(conn);
+
+    /* get tls13 key context */
+    s2n_tls13_connection_keys(secrets, conn);
+
+    struct s2n_hash_state hash_state = {0};
+    POSIX_GUARD(s2n_handshake_get_hash_state(conn, secrets.hash_algorithm, &hash_state));
+
+    s2n_stack_blob(early_traffic_secret, secrets.size, S2N_TLS13_SECRET_MAX_LEN);
+    POSIX_GUARD(s2n_tls13_derive_early_traffic_secret(&secrets, &hash_state, &early_traffic_secret));
+
+    /* trigger callbacks */
+    if (conn->secret_cb && conn->config->quic_enabled) {
+        POSIX_GUARD(conn->secret_cb(conn->secret_cb_context, conn, S2N_CLIENT_EARLY_TRAFFIC_SECRET,
+                early_traffic_secret.data, early_traffic_secret.size));
+    }
+    s2n_result_ignore(s2n_key_log_tls13_secret(conn, &early_traffic_secret, S2N_CLIENT_EARLY_TRAFFIC_SECRET));
+
+    /* produce traffic key */
+    s2n_tls13_key_blob(early_traffic_key, conn->secure.cipher_suite->record_alg->cipher->key_material_size);
+    struct s2n_blob app_iv = { .data = conn->secure.client_implicit_iv, .size = S2N_TLS13_FIXED_IV_LEN };
+    POSIX_GUARD(s2n_tls13_derive_traffic_keys(&secrets, &early_traffic_secret, &early_traffic_key, &app_iv));
+
+    POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.client_key));
+    if (conn->mode == S2N_CLIENT) {
+        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure.client_key, &early_traffic_key));
+    } else {
+        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure.client_key, &early_traffic_key));
+    }
+
+    /* configure client crypto parameters early */
+    conn->client = &conn->secure;
+
+    /* According to https://tools.ietf.org/html/rfc8446#section-5.3:
+     * Each sequence number is set to zero at the beginning of a connection and
+     * whenever the key is changed
+     */
+    POSIX_GUARD(s2n_zero_sequence_number(conn, S2N_CLIENT));
+
+    return S2N_SUCCESS;
+}
+
+int s2n_tls13_handle_handshake_master_secret(struct s2n_connection *conn)
+{
+    POSIX_ENSURE_REF(conn);
+
     const struct s2n_ecc_preferences *ecc_preferences = NULL;
     POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
     POSIX_ENSURE_REF(ecc_preferences);
-    
+
     /* get tls13 key context */
     s2n_tls13_connection_keys(secrets, conn);
 
@@ -185,68 +260,79 @@ int s2n_tls13_handle_handshake_secrets(struct s2n_connection *conn)
     DEFER_CLEANUP(struct s2n_blob shared_secret = { 0 }, s2n_free);
     POSIX_GUARD(s2n_tls13_compute_shared_secret(conn, &shared_secret));
 
-    /* derive early secrets */
-    POSIX_GUARD(s2n_tls13_derive_early_secrets(&secrets, conn->psk_params.chosen_psk));
-    /* Wipe the PSK secrets as they are no longer required */
-    POSIX_GUARD_RESULT(s2n_psk_parameters_wipe_secrets(&conn->psk_params));
+    POSIX_GUARD(s2n_tls13_extract_handshake_secret(&secrets, &shared_secret));
 
-    /* produce handshake secrets */
-    s2n_stack_blob(client_hs_secret, secrets.size, S2N_TLS13_SECRET_MAX_LEN);
-    s2n_stack_blob(server_hs_secret, secrets.size, S2N_TLS13_SECRET_MAX_LEN);
+    return 0;
+}
 
-    struct s2n_hash_state hash_state = {0};
-    POSIX_GUARD(s2n_handshake_get_hash_state(conn, secrets.hash_algorithm, &hash_state));
-    POSIX_GUARD(s2n_tls13_derive_handshake_secrets(&secrets, &shared_secret, &hash_state, &client_hs_secret, &server_hs_secret));
+int s2n_tls13_handle_handshake_traffic_secret(struct s2n_connection *conn, s2n_mode mode)
+{
+    POSIX_ENSURE_REF(conn);
+
+    /* get tls13 key context */
+    s2n_tls13_connection_keys(secrets, conn);
+    bool is_sending_secret = (mode == conn->mode);
+
+    /* produce handshake secret */
+    s2n_stack_blob(hs_secret, secrets.size, S2N_TLS13_SECRET_MAX_LEN);
+
+    uint8_t *finished_data, *implicit_iv_data;
+    struct s2n_session_key *session_key;
+    s2n_secret_type_t secret_type;
+    if (mode == S2N_CLIENT) {
+        finished_data = conn->handshake.client_finished;
+        implicit_iv_data = conn->secure.client_implicit_iv;
+        session_key = &conn->secure.client_key;
+        secret_type = S2N_CLIENT_HANDSHAKE_TRAFFIC_SECRET;
+        conn->client = &conn->secure;
+    } else {
+        finished_data = conn->handshake.server_finished;
+        implicit_iv_data = conn->secure.server_implicit_iv;
+        session_key = &conn->secure.server_key;
+        secret_type = S2N_SERVER_HANDSHAKE_TRAFFIC_SECRET;
+        conn->server = &conn->secure;
+    }
+
+    struct s2n_hash_state *hash_state;
+    POSIX_GUARD_PTR(hash_state = &conn->handshake.server_hello_copy);
+
+    POSIX_GUARD(s2n_tls13_derive_handshake_traffic_secret(&secrets, hash_state, &hs_secret, mode));
 
     /* trigger secret callbacks */
     if (conn->secret_cb && conn->config->quic_enabled) {
-        POSIX_GUARD(conn->secret_cb(conn->secret_cb_context, conn, S2N_CLIENT_HANDSHAKE_TRAFFIC_SECRET,
-                client_hs_secret.data, client_hs_secret.size));
-        POSIX_GUARD(conn->secret_cb(conn->secret_cb_context, conn, S2N_SERVER_HANDSHAKE_TRAFFIC_SECRET,
-                server_hs_secret.data, server_hs_secret.size));
+        POSIX_GUARD(conn->secret_cb(conn->secret_cb_context, conn, secret_type, hs_secret.data, hs_secret.size));
     }
-
-    s2n_result_ignore(s2n_key_log_tls13_secret(conn, &client_hs_secret, S2N_CLIENT_HANDSHAKE_TRAFFIC_SECRET));
-    s2n_result_ignore(s2n_key_log_tls13_secret(conn, &server_hs_secret, S2N_SERVER_HANDSHAKE_TRAFFIC_SECRET));
+    s2n_result_ignore(s2n_key_log_tls13_secret(conn, &hs_secret, secret_type));
 
     /* produce handshake traffic keys and configure record algorithm */
-    s2n_tls13_key_blob(server_hs_key, conn->secure.cipher_suite->record_alg->cipher->key_material_size);
-    struct s2n_blob server_hs_iv = { .data = conn->secure.server_implicit_iv, .size = S2N_TLS13_FIXED_IV_LEN };
-    POSIX_GUARD(s2n_tls13_derive_traffic_keys(&secrets, &server_hs_secret, &server_hs_key, &server_hs_iv));
+    s2n_tls13_key_blob(hs_key, conn->secure.cipher_suite->record_alg->cipher->key_material_size);
+    struct s2n_blob hs_iv = { .data = implicit_iv_data, .size = S2N_TLS13_FIXED_IV_LEN };
+    POSIX_GUARD(s2n_tls13_derive_traffic_keys(&secrets, &hs_secret, &hs_key, &hs_iv));
 
-    s2n_tls13_key_blob(client_hs_key, conn->secure.cipher_suite->record_alg->cipher->key_material_size);
-    struct s2n_blob client_hs_iv = { .data = conn->secure.client_implicit_iv, .size = S2N_TLS13_FIXED_IV_LEN };
-    POSIX_GUARD(s2n_tls13_derive_traffic_keys(&secrets, &client_hs_secret, &client_hs_key, &client_hs_iv));
-
-    POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.server_key));
-    POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->init(&conn->secure.client_key));
-
-    if (conn->mode == S2N_CLIENT) {
-        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure.server_key, &server_hs_key));
-        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure.client_key, &client_hs_key));
+    POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->init(session_key));
+    if (is_sending_secret) {
+        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(session_key, &hs_key));
     } else {
-        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure.server_key, &server_hs_key));
-        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure.client_key, &client_hs_key));
+        POSIX_GUARD(conn->secure.cipher_suite->record_alg->cipher->set_decryption_key(session_key, &hs_key));
     }
 
     /* calculate server + client finished keys and store them in handshake struct */
-    struct s2n_blob server_finished_key = { .data = conn->handshake.server_finished, .size = secrets.size };
-    struct s2n_blob client_finished_key = { .data = conn->handshake.client_finished, .size = secrets.size };
-    POSIX_GUARD(s2n_tls13_derive_finished_key(&secrets, &server_hs_secret, &server_finished_key));
-    POSIX_GUARD(s2n_tls13_derive_finished_key(&secrets, &client_hs_secret, &client_finished_key));
+    struct s2n_blob finished_key = { .data = finished_data, .size = secrets.size };
+    POSIX_GUARD(s2n_tls13_derive_finished_key(&secrets, &hs_secret, &finished_key));
 
     /* According to https://tools.ietf.org/html/rfc8446#section-5.3:
      * Each sequence number is set to zero at the beginning of a connection and
      * whenever the key is changed
      */
-    POSIX_GUARD(s2n_zero_sequence_number(conn, S2N_CLIENT));
-    POSIX_GUARD(s2n_zero_sequence_number(conn, S2N_SERVER));
+    POSIX_GUARD(s2n_zero_sequence_number(conn, mode));
 
     return 0;
 }
 
 static int s2n_tls13_handle_application_secret(struct s2n_connection *conn, s2n_mode mode)
 {
+    POSIX_ENSURE_REF(conn);
+
     /* get tls13 key context */
     s2n_tls13_connection_keys(keys, conn);
     bool is_sending_secret = (mode == conn->mode);
@@ -308,6 +394,7 @@ static int s2n_tls13_handle_application_secret(struct s2n_connection *conn, s2n_
  */
 static int s2n_tls13_handle_master_secret(struct s2n_connection *conn)
 {
+    POSIX_ENSURE_REF(conn);
     s2n_tls13_connection_keys(keys, conn);
     POSIX_GUARD(s2n_tls13_extract_master_secret(&keys));
     return S2N_SUCCESS;
@@ -315,6 +402,7 @@ static int s2n_tls13_handle_master_secret(struct s2n_connection *conn)
 
 static int s2n_tls13_handle_resumption_master_secret(struct s2n_connection *conn)
 {
+    POSIX_ENSURE_REF(conn);
     s2n_tls13_connection_keys(keys, conn);
     
     struct s2n_hash_state hash_state = {0};
@@ -326,31 +414,35 @@ static int s2n_tls13_handle_resumption_master_secret(struct s2n_connection *conn
     return S2N_SUCCESS;
 }
 
-int s2n_tls13_handle_secrets(struct s2n_connection *conn)
+int s2n_tls13_client_handle_secrets(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
-    if (conn->actual_protocol_version < S2N_TLS13) {
-        return S2N_SUCCESS;
-    }
-
     switch(s2n_conn_get_current_message_type(conn)) {
-        case SERVER_HELLO:
-            POSIX_GUARD(s2n_tls13_handle_handshake_secrets(conn));
-            /* Set negotiated crypto parameters for encryption */
-            conn->server = &conn->secure;
-            conn->client = &conn->secure;
-            break;
-        case SERVER_FINISHED:
-            if (conn->mode == S2N_SERVER) {
-                POSIX_GUARD(s2n_tls13_handle_master_secret(conn));
-                POSIX_GUARD(s2n_tls13_handle_application_secret(conn, S2N_SERVER));
+        case CLIENT_HELLO:
+            if (conn->early_data_state == S2N_EARLY_DATA_REQUESTED) {
+                POSIX_GUARD(s2n_tls13_handle_early_secret(conn));
+                POSIX_GUARD(s2n_tls13_handle_early_traffic_secret(conn));
             }
+            break;
+        case SERVER_HELLO:
+            POSIX_GUARD(s2n_tls13_handle_early_secret(conn));
+            POSIX_GUARD(s2n_tls13_handle_handshake_master_secret(conn));
+            POSIX_GUARD(s2n_tls13_handle_handshake_traffic_secret(conn, S2N_SERVER));
+            if (conn->early_data_state == S2N_EARLY_DATA_NOT_REQUESTED) {
+                POSIX_GUARD(s2n_tls13_handle_handshake_traffic_secret(conn, S2N_CLIENT));
+            }
+            break;
+        case ENCRYPTED_EXTENSIONS:
+            if (conn->early_data_state == S2N_EARLY_DATA_REJECTED) {
+                POSIX_GUARD(s2n_tls13_handle_handshake_traffic_secret(conn, S2N_CLIENT));
+            }
+            break;
+        case END_OF_EARLY_DATA:
+            POSIX_GUARD(s2n_tls13_handle_handshake_traffic_secret(conn, S2N_CLIENT));
             break;
         case CLIENT_FINISHED:
-            if (conn->mode == S2N_CLIENT) {
-                POSIX_GUARD(s2n_tls13_handle_master_secret(conn));
-                POSIX_GUARD(s2n_tls13_handle_application_secret(conn, S2N_SERVER));
-            }
+            POSIX_GUARD(s2n_tls13_handle_master_secret(conn));
+            POSIX_GUARD(s2n_tls13_handle_application_secret(conn, S2N_SERVER));
             POSIX_GUARD(s2n_tls13_handle_application_secret(conn, S2N_CLIENT));
             POSIX_GUARD(s2n_tls13_handle_resumption_master_secret(conn));
             break;
@@ -358,6 +450,57 @@ int s2n_tls13_handle_secrets(struct s2n_connection *conn)
             break;
     }
     return S2N_SUCCESS;
+}
+
+static int s2n_tls13_server_handle_secrets(struct s2n_connection *conn)
+{
+    POSIX_ENSURE_REF(conn);
+    switch(s2n_conn_get_current_message_type(conn)) {
+        case CLIENT_HELLO:
+            POSIX_GUARD(s2n_tls13_handle_early_secret(conn));
+            if (conn->early_data_state == S2N_EARLY_DATA_ACCEPTED) {
+                POSIX_GUARD(s2n_tls13_handle_early_traffic_secret(conn));
+            }
+            break;
+        case SERVER_HELLO:
+            POSIX_GUARD(s2n_tls13_handle_handshake_master_secret(conn));
+            POSIX_GUARD(s2n_tls13_handle_handshake_traffic_secret(conn, S2N_SERVER));
+            if (conn->early_data_state != S2N_EARLY_DATA_ACCEPTED) {
+                POSIX_GUARD(s2n_tls13_handle_handshake_traffic_secret(conn, S2N_CLIENT));
+            }
+            break;
+        case SERVER_FINISHED:
+            if (conn->early_data_state != S2N_EARLY_DATA_ACCEPTED) {
+                POSIX_GUARD(s2n_tls13_handle_master_secret(conn));
+                POSIX_GUARD(s2n_tls13_handle_application_secret(conn, S2N_SERVER));
+            }
+            break;
+        case END_OF_EARLY_DATA:
+            POSIX_GUARD(s2n_tls13_handle_handshake_traffic_secret(conn, S2N_CLIENT));
+            POSIX_GUARD(s2n_tls13_handle_master_secret(conn));
+            POSIX_GUARD(s2n_tls13_handle_application_secret(conn, S2N_SERVER));
+            break;
+        case CLIENT_FINISHED:
+            POSIX_GUARD(s2n_tls13_handle_application_secret(conn, S2N_CLIENT));
+            POSIX_GUARD(s2n_tls13_handle_resumption_master_secret(conn));
+            break;
+        default:
+            break;
+    }
+    return S2N_SUCCESS;
+}
+
+int s2n_tls13_handle_secrets(struct s2n_connection *conn)
+{
+    POSIX_ENSURE_REF(conn);
+    if (conn->actual_protocol_version < S2N_TLS13) {
+        return S2N_SUCCESS;
+    }
+    if (conn->mode == S2N_CLIENT) {
+        return s2n_tls13_client_handle_secrets(conn);
+    } else {
+        return s2n_tls13_server_handle_secrets(conn);
+    }
 }
 
 int s2n_update_application_traffic_keys(struct s2n_connection *conn, s2n_mode mode, keyupdate_status status)


### PR DESCRIPTION
### Resolved issues:

https://github.com/aws/s2n-tls/issues/2567

### Description of changes: 

We add one last secret to our key derivation logic: the client_early_traffic_secret. It's derived from the early secret if we will be using early data.

### Callouts:

* **Should we clean this up?** Early data does appear to have pushed our simple "key schedule" to the breaking point. I've opened an issue to clean things up, but a complete refactor is out of scope for now: https://github.com/aws/s2n-tls/issues/2646
* **s2n_hex_string_to_bytes**: I updated this method to ignore whitespace so that our known value tests can more closely visually match the RFC.

### Testing:

I largely left the existing handshake tests (except a few cleanups) and added new tests for early data. This makes me confident that adding the early secret logic doesn't affect any previous handshakes. I also included both client and server known-value tests verifying that we can encrypt early data with the early data traffic secret.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
