### PR TITLE
APIs to get s2n cert in DER format

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -424,6 +424,14 @@ extern int s2n_connection_is_ocsp_stapled(struct s2n_connection *conn);
 
 S2N_API
 extern struct s2n_cert_chain_and_key *s2n_connection_get_selected_cert(struct s2n_connection *conn);
+S2N_API
+extern int s2n_connection_get_peer_cert_chain(struct s2n_connection *conn, struct s2n_cert_chain_and_key **s2n_cert_chain_and_key);
+S2N_API
+extern int s2n_get_cert_chain_length(struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
+S2N_API
+extern int s2n_get_cert_from_cert_chain(struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, uint32_t cert_idx);
+S2N_API
+extern int s2n_get_cert_der(struct s2n_cert *cert, uint8_t **out_cert_der, uint32_t *cert_length);
 
 S2N_API
 extern uint64_t s2n_connection_get_wire_bytes_in(struct s2n_connection *conn);

--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -532,3 +532,53 @@ s2n_cert_private_key *s2n_cert_chain_and_key_get_private_key(struct s2n_cert_cha
     PTR_ENSURE_REF(chain_and_key);
     return chain_and_key->private_key;
 }
+
+int s2n_get_cert_chain_length(struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length)
+{
+    POSIX_ENSURE_REF(chain_and_key);
+
+    struct s2n_cert *head_cert = chain_and_key->cert_chain->head;
+    POSIX_ENSURE_REF(head_cert);
+    *cert_length = 1;
+    struct s2n_cert *next_cert = head_cert->next;
+    while (next_cert != NULL) {
+        *cert_length += 1;
+        next_cert = next_cert->next;
+    }
+
+    return S2N_SUCCESS;
+}
+
+int s2n_get_cert_from_cert_chain(struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert,
+                                 uint32_t cert_idx)
+{
+    POSIX_ENSURE_REF(chain_and_key);
+    POSIX_ENSURE_REF(out_cert);
+
+    uint32_t cert_chain_length = 0;
+    POSIX_GUARD(s2n_get_cert_chain_length(chain_and_key, &cert_chain_length));
+    POSIX_ENSURE_LT(cert_idx, cert_chain_length);
+
+    struct s2n_cert *cur_cert = chain_and_key->cert_chain->head;
+    POSIX_ENSURE_REF(cur_cert);
+
+    for (size_t i = 1; i <= cert_idx; i++) {
+        POSIX_ENSURE_REF(cur_cert->next);
+        cur_cert = cur_cert->next;
+    }
+
+    *out_cert = cur_cert;
+
+    return S2N_SUCCESS;
+}
+
+int s2n_get_cert_der(struct s2n_cert *cert, uint8_t **out_cert_der, uint32_t *cert_length)
+{
+    POSIX_ENSURE_REF(cert);
+    POSIX_ENSURE_REF(out_cert_der);
+
+    *out_cert_der = cert->raw.data;
+    *cert_length = cert->raw.size;
+
+    return S2N_SUCCESS;
+}

--- a/crypto/s2n_certificate.h
+++ b/crypto/s2n_certificate.h
@@ -73,3 +73,6 @@ int s2n_create_cert_chain_from_stuffer(struct s2n_cert_chain *cert_chain_out, st
 int s2n_cert_chain_and_key_set_cert_chain(struct s2n_cert_chain_and_key *cert_and_key, const char *cert_chain_pem);
 int s2n_cert_chain_and_key_set_private_key(struct s2n_cert_chain_and_key *cert_and_key, const char *private_key_pem);
 s2n_pkey_type s2n_cert_chain_and_key_get_pkey_type(struct s2n_cert_chain_and_key *chain_and_key);
+int s2n_get_cert_chain_length(struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
+int s2n_get_cert_from_cert_chain(struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, uint32_t cert_idx);
+int s2n_get_cert_der(struct s2n_cert *cert, uint8_t **out_cert_der, uint32_t *cert_length);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1388,6 +1388,38 @@ Return the certificate that was used during the TLS handshake.
 This function returns NULL if the certificate selection phase of the handshake has not completed
  or if a certificate was not requested by the peer.
 
+### s2n\_connection\_get_peer\_cert\_chain
+
+```c
+int s2n_connection_get_peer_cert_chain(struct s2n_connection *conn, struct s2n_cert_chain_and_key **s2n_cert_chain_and_key);
+```
+
+**s2n_connection_get_peer_cert_chain** gets the peer certificate from the connection object. 
+
+### s2n\_get\_cert\_chain\_length
+
+```c
+int s2n_get_cert_chain_length(struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
+```
+
+**s2n_get_cert_chain_length** gets the length of the certificate chain `chain_and_key`. If the certificate chain `chain_and_key` is NULL an error is thrown. If the certificate chain contains only one ceritificate the length returned is equal to one. 
+
+### s2n\_get\_cert\_from\_cert\_chain
+
+```c
+int s2n_get_cert_from_cert_chain(struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, uint32_t cert_idx);
+```
+
+**s2n_get_cert_from_cert_chain** gets the certificate `out_cert` present at the index `cert_idx` of the certificate chain `chain_and_key`.  If the certificate chain `chain_and_key` is NULL or the certificate index value is not in the acceptable range for the input certificate chain, an error is thrown. Note that the index of the head_cert is zero.
+
+### s2n\_get\_cert\_der
+
+```c
+int s2n_get_cert_der(struct s2n_cert *cert, uint8_t **out_cert_der, uint32_t *cert_length);
+```
+
+**s2n_get_cert_der** gets the certificate `cert` in .der format which is returned in the buffer `out_cert_der`, `cert_len` represents the length of the certificate. 
+
 ### Session Resumption Related calls
 
 ```c

--- a/tests/unit/s2n_certificate_test.c
+++ b/tests/unit/s2n_certificate_test.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include <s2n.h>
+#include "utils/s2n_safety.h"
+
+#define S2N_DEFAULT_TEST_CERT_CHAIN_LENGTH 3
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
+    EXPECT_SUCCESS(
+        s2n_test_cert_chain_and_key_new(&chain_and_key, S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+
+    /* Test s2n_get_cert_chain_length */ 
+    {
+        uint32_t length = 0;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_get_cert_chain_length(NULL, &length), S2N_ERR_NULL);
+        EXPECT_SUCCESS(s2n_get_cert_chain_length(chain_and_key, &length));
+        EXPECT_EQUAL(length, S2N_DEFAULT_TEST_CERT_CHAIN_LENGTH);
+    }
+
+    /* Test s2n_get_cert_from_cert_chain */
+    {
+        struct s2n_cert *out_cert = NULL;
+        uint32_t cert_idx = 0;
+
+        /* Safety checks */
+        {
+            EXPECT_FAILURE_WITH_ERRNO(s2n_get_cert_from_cert_chain(NULL, &out_cert, cert_idx), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_get_cert_from_cert_chain(chain_and_key, NULL, cert_idx), S2N_ERR_NULL);
+            /* The valid range of cert_idx is 0 to cert_chain_length - 1 */  
+            cert_idx = S2N_DEFAULT_TEST_CERT_CHAIN_LENGTH; 
+            EXPECT_FAILURE_WITH_ERRNO(s2n_get_cert_from_cert_chain(chain_and_key, &out_cert, cert_idx), S2N_ERR_SAFETY);
+        }
+
+        struct s2n_cert *cur_cert = chain_and_key->cert_chain->head;
+
+        for (size_t i = 0; i < S2N_DEFAULT_TEST_CERT_CHAIN_LENGTH; i++)
+        {
+            EXPECT_SUCCESS(s2n_get_cert_from_cert_chain(chain_and_key, &out_cert, i));
+            EXPECT_NOT_NULL(cur_cert);
+            EXPECT_EQUAL(out_cert, cur_cert);
+            cur_cert = cur_cert->next;
+        }
+    }
+
+    /* Test s2n_get_cert_der */ 
+    {
+        struct s2n_cert *cert = chain_and_key->cert_chain->head;
+        uint8_t *out_cert_der = NULL;
+        uint32_t cert_len = 0;
+
+        /* Safety checks */
+        {
+            EXPECT_FAILURE_WITH_ERRNO(s2n_get_cert_der(NULL, &out_cert_der, &cert_len), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_get_cert_der(cert, NULL, &cert_len), S2N_ERR_NULL);
+        }
+
+        EXPECT_SUCCESS(s2n_get_cert_der(cert, &out_cert_der, &cert_len));
+        EXPECT_EQUAL(cert_len, cert->raw.size); 
+        EXPECT_BYTEARRAY_EQUAL(out_cert_der, cert->raw.data, cert_len);
+    }
+
+    /* Test s2n_connection_get_peer_cert_chain */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        POSIX_ENSURE_REF(conn);
+
+        struct s2n_cert_chain_and_key *cert_chain_and_key = NULL;
+        EXPECT_NULL(conn->handshake_params.our_chain_and_key);
+
+        /* Safety checks */
+        {
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_peer_cert_chain(NULL, &cert_chain_and_key), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_peer_cert_chain(conn, &cert_chain_and_key), S2N_ERR_NULL);
+        }
+
+        /* Initialize cert chain */
+        conn->handshake_params.our_chain_and_key = chain_and_key;
+        EXPECT_SUCCESS(s2n_connection_get_peer_cert_chain(conn, &cert_chain_and_key));
+        EXPECT_EQUAL(chain_and_key, cert_chain_and_key); 
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));       
+    }
+
+    END_TEST();
+}

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -774,6 +774,17 @@ int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **
     return 0;
 }
 
+int s2n_connection_get_peer_cert_chain(struct s2n_connection *conn, struct s2n_cert_chain_and_key **cert_chain_and_key)
+{
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(cert_chain_and_key);
+    POSIX_ENSURE_REF(conn->handshake_params.our_chain_and_key);
+
+    *cert_chain_and_key = conn->handshake_params.our_chain_and_key;
+
+    return S2N_SUCCESS;
+}
+
 int s2n_connection_get_cipher_preferences(struct s2n_connection *conn, const struct s2n_cipher_preferences **cipher_preferences)
 {
     POSIX_ENSURE_REF(conn);

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -360,6 +360,7 @@ int s2n_connection_get_protocol_preferences(struct s2n_connection *conn, struct 
 int s2n_connection_set_client_auth_type(struct s2n_connection *conn, s2n_cert_auth_type cert_auth_type);
 int s2n_connection_get_client_auth_type(struct s2n_connection *conn, s2n_cert_auth_type *client_cert_auth_type);
 int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **der_cert_chain_out, uint32_t *cert_chain_len);
+int s2n_connection_get_peer_cert_chain(struct s2n_connection *conn, struct s2n_cert_chain_and_key **cert_chain_and_key);
 uint8_t s2n_connection_get_protocol_version(const struct s2n_connection *conn);
 /* `none` keyword represents a list of empty keyshares */
 int s2n_connection_set_keyshare_by_name_for_testing(struct s2n_connection *conn, const char* curve_name);


### PR DESCRIPTION
### Description of changes: 

Provides the following API to get the s2n certificate in DER format. Th certificate retrieved could be used by s2n-tls customers to parse/inspect the cert for their specific use-cases. For ex: A customer could parse the x509 certificate to obtain the `Subject Name`, `Common Name`,` Subject Public Key Info` and `Validity period`. 

```
int s2n_get_cert_der(struct s2n_cert *cert, uint8_t **out_cert_der, uint32_t *cert_length);
```

In order to get each certificate in the s2n certificate chain, the following APIs has been added: 
```
int s2n_connection_get_peer_cert_chain(struct s2n_connection *conn, struct s2n_cert_chain_and_key **s2n_cert_chain_and_key);
```

The `s2n_cert` object can be obtained using the `s2n_get_cert_from_cert_chain`  API that gets the `s2n_cert` object  from the `cert_chain_and_key` inputted. 

```
 int s2n_get_cert_from_cert_chain(struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, uint32_t cert_idx);
 ```
 
We also provide the following API to obtain the cert chain length. 
```
 int s2n_get_cert_chain_length(struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
 ```

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? Unit Tested.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
