### PR TITLE
Refactor x509 validator to retrieve and store the validated cert chain 

### DIFF
--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -1581,8 +1581,8 @@ int main(int argc, char **argv) {
                         s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &pkey_type, &public_key_out));
 
             EXPECT_EQUAL(0, verify_data.callback_invoked);
-            EXPECT_EQUAL(connection->secure.client_cert_chain.size, chain_len);
-            EXPECT_BYTEARRAY_EQUAL(connection->secure.client_cert_chain.data, chain_data, connection->secure.client_cert_chain.size);
+            EXPECT_EQUAL(connection->secure.peer_cert_chain.size, chain_len);
+            EXPECT_BYTEARRAY_EQUAL(connection->secure.peer_cert_chain.data, chain_data, connection->secure.peer_cert_chain.size);
 
             s2n_pkey_free(&public_key_out);
             s2n_x509_validator_wipe(&validator);

--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -1584,7 +1584,7 @@ int main(int argc, char **argv) {
             EXPECT_EQUAL(connection->secure.peer_cert_chain.size, chain_len);
             EXPECT_BYTEARRAY_EQUAL(connection->secure.peer_cert_chain.data, chain_data, connection->secure.peer_cert_chain.size);
 
-            s2n_pkey_free(&public_key_out);
+            EXPECT_SUCCESS(s2n_pkey_free(&public_key_out));
             s2n_x509_validator_wipe(&validator);
             EXPECT_SUCCESS(s2n_connection_free(connection));
         }

--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -1611,14 +1611,12 @@ int main(int argc, char **argv) {
 
             DEFER_CLEANUP(struct s2n_stuffer cert_chain_stuffer = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_init(&cert_chain_stuffer, &connection->secure.peer_cert_chain));
-            EXPECT_SUCCESS(s2n_stuffer_write(&cert_chain_stuffer, &connection->secure.peer_cert_chain));
+            EXPECT_SUCCESS(s2n_stuffer_skip_write(&cert_chain_stuffer, connection->secure.peer_cert_chain.size));
  
             size_t cert_idx = 0;
-            while (s2n_stuffer_data_available(&cert_chain_stuffer) && cert_idx < sk_X509_num(validator.cert_chain_validated)) {
+            while (s2n_stuffer_data_available(&cert_chain_stuffer) > 0 && cert_idx < sk_X509_num(validator.cert_chain_validated)) {
                 uint32_t cert_size_from_conn = 0;
                 EXPECT_SUCCESS(s2n_stuffer_read_uint24(&cert_chain_stuffer, &cert_size_from_conn));
-                EXPECT_TRUE((s2n_stuffer_data_available(&cert_chain_stuffer) > cert_size_from_conn)
-                                                       && (cert_size_from_conn > 0));
                 uint8_t *cert_data_from_conn = s2n_stuffer_raw_read(&cert_chain_stuffer, cert_size_from_conn);
                 EXPECT_NOT_NULL(cert_data_from_conn);
 

--- a/tls/s2n_client_cert.c
+++ b/tls/s2n_client_cert.c
@@ -65,7 +65,6 @@ int s2n_client_cert_recv(struct s2n_connection *conn)
     POSIX_GUARD(s2n_pkey_setup_for_type(&public_key, pkey_type));
     
     POSIX_GUARD(s2n_pkey_check_key_exists(&public_key));
-    POSIX_GUARD(s2n_dup(&client_cert_chain, &conn->secure.client_cert_chain));
     conn->secure.client_public_key = public_key;
     
     return 0;

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -317,7 +317,7 @@ static int s2n_connection_wipe_keys(struct s2n_connection *conn)
     POSIX_GUARD(s2n_dh_params_free(&conn->secure.server_dh_params));
     POSIX_GUARD_RESULT(s2n_connection_wipe_all_keyshares(conn));
     POSIX_GUARD(s2n_kem_free(&conn->secure.kem_params));
-    POSIX_GUARD(s2n_free(&conn->secure.client_cert_chain));
+    POSIX_GUARD(s2n_free(&conn->secure.peer_cert_chain));
     POSIX_GUARD(s2n_free(&conn->ct_response));
 
     return 0;
@@ -771,10 +771,12 @@ int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(der_cert_chain_out);
     POSIX_ENSURE_REF(cert_chain_len);
-    POSIX_ENSURE_REF(conn->secure.client_cert_chain.data);
+    POSIX_ENSURE_REF(conn->secure.peer_cert_chain.data);
 
-    *der_cert_chain_out = conn->secure.client_cert_chain.data;
-    *cert_chain_len = conn->secure.client_cert_chain.size;
+    POSIX_ENSURE(conn->mode == S2N_SERVER, S2N_ERR_INVALID_STATE);
+
+    *der_cert_chain_out = conn->secure.peer_cert_chain.data;
+    *cert_chain_len = conn->secure.peer_cert_chain.size;
 
     return 0;
 }

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -47,7 +47,7 @@ struct s2n_crypto_parameters {
 
     struct s2n_signature_scheme conn_sig_scheme;
 
-    struct s2n_blob client_cert_chain;
+    struct s2n_blob peer_cert_chain;
     s2n_pkey_type client_cert_pkey_type;
 
     struct s2n_signature_scheme client_cert_sig_scheme;

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -149,6 +149,7 @@ int s2n_x509_validator_init_no_x509_validation(struct s2n_x509_validator *valida
     validator->max_chain_depth = DEFAULT_MAX_CHAIN_DEPTH;
     validator->state = INIT;
     validator->cert_chain_from_wire = sk_X509_new_null();
+    validator->cert_chain_validated = NULL;
 
     return 0;
 }
@@ -165,6 +166,7 @@ int s2n_x509_validator_init(struct s2n_x509_validator *validator, struct s2n_x50
         POSIX_ENSURE_REF(validator->store_ctx);
     }
     validator->cert_chain_from_wire = sk_X509_new_null();
+    validator->cert_chain_validated = NULL;
     validator->state = INIT;
 
     return 0;
@@ -182,6 +184,10 @@ void s2n_x509_validator_wipe(struct s2n_x509_validator *validator) {
         validator->store_ctx = NULL;
     }
     wipe_cert_chain(validator->cert_chain_from_wire);
+    if (validator->cert_chain_validated != NULL) {
+       wipe_cert_chain(validator->cert_chain_validated);
+       validator->cert_chain_validated = NULL;
+    }
     validator->cert_chain_from_wire = NULL;
     validator->trust_store = NULL;
     validator->skip_cert_validation = 0;
@@ -376,6 +382,33 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
 
         S2N_ERROR_IF(op_code <= 0, S2N_ERR_CERT_UNTRUSTED);
         validator->state = VALIDATED;
+        /* X509_STORE_CTX_get1_chain() returns a validated cert chain if a previous call to X509_verify_cert() was successful.
+         * X509_STORE_CTX_get0_chain() is a better API because it doesn't return a copy. But it's not available for Openssl 1.0.2.
+        * Therefore, we call this variant and clean it up during s2n_x509_validator_wipe.
+        * See the comments here:
+        * https://www.openssl.org/docs/man1.0.2/man3/X509_STORE_CTX_get1_chain.html
+        */
+        validator->cert_chain_validated = X509_STORE_CTX_get1_chain(validator->store_ctx);
+    }
+
+    if (validator->state == VALIDATED) {
+        DEFER_CLEANUP(struct s2n_stuffer cert_chain_out_stuffer = {0}, s2n_stuffer_free);
+        POSIX_GUARD(s2n_stuffer_growable_alloc(&cert_chain_out_stuffer, 0));
+
+        for (size_t cert_idx = 0; cert_idx < sk_X509_num(validator->cert_chain_validated); cert_idx++) {
+            X509 *cert = sk_X509_value(validator->cert_chain_validated, cert_idx);
+            struct s2n_blob asn1cert = { 0 };
+            int encoded_data_len = i2d_X509(cert, &asn1cert.data);
+            POSIX_ENSURE_GT(encoded_data_len, 0);
+            asn1cert.size = encoded_data_len;
+            POSIX_GUARD(s2n_stuffer_write_uint24(&cert_chain_out_stuffer, asn1cert.size));
+            POSIX_GUARD(s2n_stuffer_write_bytes(&cert_chain_out_stuffer, asn1cert.data, asn1cert.size));
+            OPENSSL_free(asn1cert.data);
+        }
+
+        POSIX_GUARD(s2n_dup(&cert_chain_out_stuffer.blob, &conn->secure.client_cert_chain));
+    } else {
+        POSIX_GUARD(s2n_dup(&cert_chain_blob, &conn->secure.client_cert_chain));
     }
 
     if (conn->actual_protocol_version >= S2N_TLS13) {

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -184,10 +184,8 @@ void s2n_x509_validator_wipe(struct s2n_x509_validator *validator) {
         validator->store_ctx = NULL;
     }
     wipe_cert_chain(validator->cert_chain_from_wire);
-    if (validator->cert_chain_validated != NULL) {
-       wipe_cert_chain(validator->cert_chain_validated);
-       validator->cert_chain_validated = NULL;
-    }
+    wipe_cert_chain(validator->cert_chain_validated);
+    validator->cert_chain_validated = NULL;
     validator->cert_chain_from_wire = NULL;
     validator->trust_store = NULL;
     validator->skip_cert_validation = 0;
@@ -395,20 +393,20 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
         POSIX_GUARD(s2n_dup(&cert_chain_blob, &conn->secure.peer_cert_chain));
     } else if (validator->state == VALIDATED) {
         DEFER_CLEANUP(struct s2n_stuffer cert_chain_out_stuffer = { 0 }, s2n_stuffer_free);
-        POSIX_GUARD(s2n_stuffer_growable_alloc(&cert_chain_out_stuffer, 0));
+        POSIX_GUARD(s2n_stuffer_growable_alloc(&cert_chain_out_stuffer, cert_chain_len));
 
         for (size_t cert_idx = 0; cert_idx < sk_X509_num(validator->cert_chain_validated); cert_idx++) {
             X509 *cert = sk_X509_value(validator->cert_chain_validated, cert_idx);
-            struct s2n_blob asn1cert = { 0 };
-            int encoded_data_len = i2d_X509(cert, &asn1cert.data);
+            uint8_t *cert_data = NULL;
+            int encoded_data_len = i2d_X509(cert, &cert_data);
             POSIX_ENSURE_GT(encoded_data_len, 0);
-            asn1cert.size = encoded_data_len;
-            POSIX_GUARD(s2n_stuffer_write_uint24(&cert_chain_out_stuffer, asn1cert.size));
-            POSIX_GUARD(s2n_stuffer_write_bytes(&cert_chain_out_stuffer, asn1cert.data, asn1cert.size));
-            OPENSSL_free(asn1cert.data);
+            POSIX_GUARD(s2n_stuffer_write_uint24(&cert_chain_out_stuffer, encoded_data_len));
+            POSIX_GUARD(s2n_stuffer_write_bytes(&cert_chain_out_stuffer, cert_data, encoded_data_len));
+            OPENSSL_free(cert_data);
         }
 
         POSIX_GUARD(s2n_dup(&cert_chain_out_stuffer.blob, &conn->secure.peer_cert_chain));
+        conn->secure.peer_cert_chain.size = s2n_stuffer_data_available(&cert_chain_out_stuffer);
     }
 
     if (conn->actual_protocol_version >= S2N_TLS13) {

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -406,9 +406,9 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_chain(struct s2n_x509_
             OPENSSL_free(asn1cert.data);
         }
 
-        POSIX_GUARD(s2n_dup(&cert_chain_out_stuffer.blob, &conn->secure.client_cert_chain));
+        POSIX_GUARD(s2n_dup(&cert_chain_out_stuffer.blob, &conn->secure.peer_cert_chain));
     } else {
-        POSIX_GUARD(s2n_dup(&cert_chain_blob, &conn->secure.client_cert_chain));
+        POSIX_GUARD(s2n_dup(&cert_chain_blob, &conn->secure.peer_cert_chain));
     }
 
     if (conn->actual_protocol_version >= S2N_TLS13) {

--- a/tls/s2n_x509_validator.h
+++ b/tls/s2n_x509_validator.h
@@ -61,6 +61,7 @@ struct s2n_x509_validator {
     uint8_t check_stapled_ocsp;
     uint16_t max_chain_depth;
     STACK_OF(X509) *cert_chain_from_wire;
+    STACK_OF(X509) *cert_chain_validated;
     int state;
 };
 


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/2655
 resolves https://github.com/aws/s2n-tls/issues/2652

### Description of changes: 


In-order to store the peer certificate chain, in this PR we rename the `conn->secure.client_cert_chain` blob to `conn->secure.peer_cert_chain` and re-purpose the existing [s2n_blob](https://github.com/aws/s2n-tls/blob/main/tls/s2n_crypto.h#L50) to store the peer certificate.  

```diff
struct s2n_crypto_parameters {
..
-    struct s2n_blob client_cert_chain;
+   struct s2n_blob peer_cert_chain;
}
```

The `conn->secure.peer_cert_chain` paramater will be initialized on the [s2n_server_cert_recv](https://github.com/aws/s2n-tls/blob/main/tls/s2n_server_cert.c#L53) and [s2n_client_cert_recv](https://github.com/aws/s2n-tls/blob/main/tls/s2n_client_cert.c#L68) calls after the cert chain is validated during this function call: [s2n_x509_validator_validate_cert_chain](https://github.com/aws/s2n-tls/blob/c72576f6fdc676d0b747ae9add033829c1d3e5c8/tls/s2n_x509_validator.c#L291).

For `s2n_connection_get_peer_cert_chain ` API to return only the _validated_ cert chains we require the `conn->secure.peer_cert_chain`  to store only the _validated_ cert chain when skip_validation flag is not set using this API: `s2n_config_disable_x509_verification`.  This issue https://github.com/aws/s2n-tls/issues/2652 introduces `conn->secure.peer_cert_chain` paramater that stores the peer cert chain obtained from the wire. However we should only be storing the  _validated_ cert chain. The `conn->secure.peer_cert_chain` paramater must be initialized on the [s2n_server_cert_recv](https://github.com/aws/s2n-tls/blob/main/tls/s2n_server_cert.c#L53) and [s2n_client_cert_recv](https://github.com/aws/s2n-tls/blob/main/tls/s2n_client_cert.c#L68) calls after the cert chain is validated with the  _validated_ cert chain.

In this PR,  we retrieve the _validated_ cert chains after the [s2n_x509_validator_validate_cert_chain](https://github.com/aws/s2n-tls/blob/c72576f6fdc676d0b747ae9add033829c1d3e5c8/tls/s2n_x509_validator.c#L291)  validation is completed on the [s2n_server_cert_recv](https://github.com/aws/s2n-tls/blob/main/tls/s2n_server_cert.c#L48) and  [s2n_client_cert_recv](https://github.com/aws/s2n-tls/blob/main/tls/s2n_client_cert.c#L60)by refactoring the [s2n_x509_validator_validate_cert_chain](https://github.com/aws/s2n-tls/blob/c72576f6fdc676d0b747ae9add033829c1d3e5c8/tls/s2n_x509_validator.c#L291) function to retrieve the validated cert and store it on the connection object `conn->secure.peer_cert_chain` directly

### Call-out

- For customers who skip validation checks by setting the  `validator->skip_cert_validation` flag  using the API `s2n_config_disable_x509_verification`  we store the full cert chain from the wire on `conn->secure.peer_cert_chain`. 

- Current customers who do not skip validation checks and expect the full cert chain will be affected, as we are now returning only the _validated_ cert chain.


### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? Unit Tests.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? Yes, older unit and integration tests pass for the changes. 
 
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
