### PR TITLE
Add method to perform a partial handshake

### DIFF
--- a/tests/testlib/s2n_test_server_client.c
+++ b/tests/testlib/s2n_test_server_client.c
@@ -15,41 +15,61 @@
 
 #include "testlib/s2n_testlib.h"
 
-static int s2n_try_negotiate(struct s2n_connection *conn, bool *is_done, bool peer_is_done)
+S2N_RESULT s2n_validate_negotiate_result(int result, bool peer_is_done, bool *is_done)
 {
-    s2n_blocked_status blocked;
-    int rc = s2n_negotiate(conn, &blocked);
-
     /* If we succeeded, we're done. */
-    if(rc == S2N_SUCCESS) {
-        *is_done = true;
-        return S2N_SUCCESS;
+    if(result == S2N_SUCCESS) {
+       *is_done = true;
+       return S2N_RESULT_OK;
     }
 
     /* If we failed for any error other than 'blocked', propagate the error. */
     if(s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
-        S2N_ERROR_PRESERVE_ERRNO();
+        return S2N_RESULT_ERROR;
     }
 
     /* If we're blocked but our peer is done writing, propagate the error. */
     if(peer_is_done) {
-        S2N_ERROR_PRESERVE_ERRNO();
+        return S2N_RESULT_ERROR;
     }
 
     *is_done = false;
-    return S2N_SUCCESS;
+    return S2N_RESULT_OK;
 }
 
 int s2n_negotiate_test_server_and_client(struct s2n_connection *server_conn, struct s2n_connection *client_conn)
 {
-    bool server_done = 0, client_done = 0;
+    bool server_done = false, client_done = false;
+    s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+    int rc = 0;
 
     do {
-        POSIX_GUARD(s2n_try_negotiate(client_conn, &client_done, server_done));
-        POSIX_GUARD(s2n_try_negotiate(server_conn, &server_done, client_done));
+        rc = s2n_negotiate(client_conn, &blocked);
+        POSIX_GUARD_RESULT(s2n_validate_negotiate_result(rc, server_done, &client_done));
+
+        rc = s2n_negotiate(server_conn, &blocked);
+        POSIX_GUARD_RESULT(s2n_validate_negotiate_result(rc, client_done, &server_done));
     } while (!client_done || !server_done);
 
     return S2N_SUCCESS;
+}
+
+S2N_RESULT s2n_negotiate_test_server_and_client_until_message(struct s2n_connection *server_conn,
+        struct s2n_connection *client_conn, message_type_t message_type)
+{
+    bool server_done = false, client_done = false;
+    s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+    int rc = 0;
+
+    do {
+        rc = s2n_negotiate_until_message(client_conn, &blocked, message_type);
+        RESULT_GUARD(s2n_validate_negotiate_result(rc, server_done, &client_done));
+
+        rc = s2n_negotiate_until_message(server_conn, &blocked, message_type);
+        RESULT_GUARD(s2n_validate_negotiate_result(rc, client_done, &server_done));
+    } while (!client_done || !server_done);
+
+    return S2N_RESULT_OK;
 }
 
 int s2n_shutdown_test_server_and_client(struct s2n_connection *server_conn, struct s2n_connection *client_conn)

--- a/tests/testlib/s2n_testlib.h
+++ b/tests/testlib/s2n_testlib.h
@@ -153,6 +153,8 @@ int s2n_test_cert_chain_and_key_new(struct s2n_cert_chain_and_key **chain_and_ke
         const char *cert_chain_file, const char *private_key_file);
 
 int s2n_negotiate_test_server_and_client(struct s2n_connection *server_conn, struct s2n_connection *client_conn);
+S2N_RESULT s2n_negotiate_test_server_and_client_until_message(struct s2n_connection *server_conn,
+        struct s2n_connection *client_conn, message_type_t message_type);
 int s2n_shutdown_test_server_and_client(struct s2n_connection *server_conn, struct s2n_connection *client_conn);
 
 int s2n_test_kem_with_kat(const struct s2n_kem *kem, const char *kat_file);

--- a/tests/unit/s2n_handshake_partial_test.c
+++ b/tests/unit/s2n_handshake_partial_test.c
@@ -65,8 +65,8 @@ int main()
         {
             struct s2n_connection conn = { 0 };
             s2n_blocked_status blocked = 0;
-            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_until_message(NULL, &blocked, CLIENT_HELLO), S2N_ERR_NULL);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_until_message(&conn, NULL, CLIENT_HELLO), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_negotiate_until_message(NULL, &blocked, CLIENT_HELLO), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_negotiate_until_message(&conn, NULL, CLIENT_HELLO), S2N_ERR_NULL);
         }
 
         /* If message is never encountered, complete the handshake */
@@ -108,9 +108,24 @@ int main()
             EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), CLIENT_HELLO);
 
             EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
+                    CLIENT_HELLO));
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), CLIENT_HELLO);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), CLIENT_HELLO);
+
+            EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
                     SERVER_HELLO));
             EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), SERVER_HELLO);
             EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_HELLO);
+
+            EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
+                    SERVER_HELLO));
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), SERVER_HELLO);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_HELLO);
+
+            EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
+                    APPLICATION_DATA));
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
 
             EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
                     APPLICATION_DATA));

--- a/tests/unit/s2n_handshake_partial_test.c
+++ b/tests/unit/s2n_handshake_partial_test.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "tls/s2n_handshake.h"
+
+#include "tls/s2n_tls.h"
+#include "tls/s2n_record.h"
+
+static S2N_RESULT s2n_get_test_client_and_server(struct s2n_connection **client_conn, struct s2n_connection **server_conn,
+        struct s2n_config *config)
+{
+    *client_conn = s2n_connection_new(S2N_CLIENT);
+    RESULT_ENSURE_REF(*client_conn);
+
+    *server_conn = s2n_connection_new(S2N_SERVER);
+    RESULT_ENSURE_REF(*server_conn);
+
+    RESULT_GUARD_POSIX(s2n_connection_set_config(*client_conn, config));
+    RESULT_GUARD_POSIX(s2n_connection_set_config(*server_conn, config));
+
+    struct s2n_test_io_pair io_pair = { 0 };
+    RESULT_GUARD_POSIX(s2n_io_pair_init_non_blocking(&io_pair));
+    RESULT_GUARD_POSIX(s2n_connections_set_io_pair(*client_conn, *server_conn, &io_pair));
+
+    return S2N_RESULT_OK;
+}
+
+int main()
+{
+    BEGIN_TEST();
+
+    const uint8_t test_psk_data[] = "very secret";
+    DEFER_CLEANUP(struct s2n_psk *test_psk = s2n_external_psk_new(), s2n_psk_free);
+    EXPECT_SUCCESS(s2n_psk_set_identity(test_psk, test_psk_data, sizeof(test_psk_data)));
+    EXPECT_SUCCESS(s2n_psk_set_secret(test_psk, test_psk_data, sizeof(test_psk_data)));
+    EXPECT_SUCCESS(s2n_psk_configure_early_data(test_psk, 100, 0x13, 0x01));
+
+    struct s2n_cert_chain_and_key *cert_chain = NULL;
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&cert_chain,
+            S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+
+    struct s2n_config *config = s2n_config_new();
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
+    EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+
+    /* Test s2n_negotiate_until_message */
+    {
+        /* Safety */
+        {
+            struct s2n_connection conn = { 0 };
+            s2n_blocked_status blocked = 0;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_until_message(NULL, &blocked, CLIENT_HELLO), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_until_message(&conn, NULL, CLIENT_HELLO), S2N_ERR_NULL);
+        }
+
+        /* If message is never encountered, complete the handshake */
+        {
+            struct s2n_connection *client_conn = NULL, *server_conn = NULL;
+            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config));
+
+            EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
+                    SERVER_KEY));
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+
+        /* Can stop on a given message */
+        {
+            struct s2n_connection *client_conn = NULL, *server_conn = NULL;
+            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config));
+
+            EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
+                    SERVER_CERT_VERIFY));
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), SERVER_CERT_VERIFY);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_CERT_VERIFY);
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+
+        /* Can be called repeatedly */
+        {
+            struct s2n_connection *client_conn = NULL, *server_conn = NULL;
+            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config));
+
+            EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
+                    CLIENT_HELLO));
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), CLIENT_HELLO);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), CLIENT_HELLO);
+
+            EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
+                    SERVER_HELLO));
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), SERVER_HELLO);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), SERVER_HELLO);
+
+            EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
+                    APPLICATION_DATA));
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+
+        /* Can continue as normal after stopping */
+        {
+            struct s2n_connection *client_conn = NULL, *server_conn = NULL;
+            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config));
+
+            EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
+                    CLIENT_FINISHED));
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), CLIENT_FINISHED);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), CLIENT_FINISHED);
+
+            EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+
+        /* Can stop on END_OF_EARLY_DATA when using early data, then continue.
+         * (This is the non-test use case for this feature) */
+        {
+            struct s2n_connection *client_conn = NULL, *server_conn = NULL;
+            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config));
+
+            EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
+            EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
+
+            EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
+                    END_OF_EARLY_DATA));
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), END_OF_EARLY_DATA);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), END_OF_EARLY_DATA);
+
+            EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
+
+            EXPECT_TRUE(WITH_EARLY_DATA(client_conn));
+            EXPECT_TRUE(WITH_EARLY_DATA(server_conn));
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+    }
+
+    EXPECT_SUCCESS(s2n_config_free(config));
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_free(cert_chain));
+    END_TEST();
+}

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -251,28 +251,13 @@ static int s2n_connection_zero(struct s2n_connection *conn, int mode, struct s2n
     /* Zero the whole connection structure */
     POSIX_CHECKED_MEMSET(conn, 0, sizeof(struct s2n_connection));
 
-    conn->send = NULL;
-    conn->recv = NULL;
-    conn->send_io_context = NULL;
-    conn->recv_io_context = NULL;
     conn->mode = mode;
-    conn->close_notify_queued = 0;
-    conn->client_session_resumed = 0;
-    conn->current_user_data_consumed = 0;
     conn->initial.cipher_suite = &s2n_null_cipher_suite;
     conn->secure.cipher_suite = &s2n_null_cipher_suite;
-    conn->initial.kem_params.kem = NULL;
-    conn->secure.kem_params.kem = NULL;
     conn->server = &conn->initial;
     conn->client = &conn->initial;
     conn->max_outgoing_fragment_length = S2N_DEFAULT_FRAGMENT_LENGTH;
-    conn->mfl_code = S2N_TLS_MAX_FRAG_LEN_EXT_NONE;
-    conn->handshake.handshake_type = INITIAL;
-    conn->handshake.message_number = 0;
-    conn->handshake.paused = 0;
-    conn->verify_host_fn = NULL;
-    conn->verify_host_fn_overridden = 0;
-    conn->data_for_verify_host = NULL;
+    conn->handshake.end_of_messages = APPLICATION_DATA;
     s2n_connection_set_config(conn, config);
 
     return 0;

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -338,11 +338,12 @@ struct s2n_cert_chain_and_key *s2n_get_compatible_cert_chain_and_key(struct s2n_
  * (This is not an issue for EndOfEarlyData because encryption and message order requirements force
  * EndOfEarlyData to always be the first and only handshake message in its handshake record)
  */
-int s2n_negotiate_until_message(struct s2n_connection *conn, s2n_blocked_status *blocked, message_type_t end_message)
+S2N_RESULT s2n_negotiate_until_message(struct s2n_connection *conn, s2n_blocked_status *blocked, message_type_t end_message)
 {
-    POSIX_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn);
     conn->handshake.end_of_messages = end_message;
     int r = s2n_negotiate(conn, blocked);
     conn->handshake.end_of_messages = APPLICATION_DATA;
-    return r;
+    RESULT_GUARD_POSIX(r);
+    return S2N_RESULT_OK;
 }

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -188,4 +188,4 @@ struct s2n_cert_chain_and_key *s2n_get_compatible_cert_chain_and_key(struct s2n_
 int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct s2n_blob *data);
 S2N_RESULT s2n_quic_read_handshake_message(struct s2n_connection *conn, uint8_t *message_type);
 S2N_RESULT s2n_quic_write_handshake_message(struct s2n_connection *conn, struct s2n_blob *in);
-int s2n_negotiate_until_message(struct s2n_connection *conn, s2n_blocked_status *blocked, message_type_t end_message);
+S2N_RESULT s2n_negotiate_until_message(struct s2n_connection *conn, s2n_blocked_status *blocked, message_type_t end_message);

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -155,6 +155,10 @@ struct s2n_handshake {
     /* Which handshake message number are we processing */
     int message_number;
 
+    /* Last message in the handshake. Unless using early data or testing,
+     * should always be APPLICATION_DATA. */
+    message_type_t end_of_messages;
+
     /* State of the async pkey operation during handshake */
     s2n_async_state async_state;
 
@@ -184,3 +188,4 @@ struct s2n_cert_chain_and_key *s2n_get_compatible_cert_chain_and_key(struct s2n_
 int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct s2n_blob *data);
 S2N_RESULT s2n_quic_read_handshake_message(struct s2n_connection *conn, uint8_t *message_type);
 S2N_RESULT s2n_quic_write_handshake_message(struct s2n_connection *conn, struct s2n_blob *in);
+int s2n_negotiate_until_message(struct s2n_connection *conn, s2n_blocked_status *blocked, message_type_t end_message);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1118,9 +1118,7 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
         POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
 
         /* We're done with the record, wipe it */
-        POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
-        POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
-        conn->in_status = ENCRYPTED;
+        POSIX_GUARD_RESULT(s2n_wipe_record(conn));
 
         /* Advance the state machine if this was an expected message */
         if (EXPECTED_RECORD_TYPE(conn) == TLS_CHANGE_CIPHER_SPEC && !CONNECTION_IS_WRITER(conn)) {
@@ -1274,7 +1272,7 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(blocked);
 
-    while (ACTIVE_STATE(conn).writer != 'B') {
+    while (ACTIVE_STATE(conn).writer != 'B' && ACTIVE_MESSAGE(conn) != conn->handshake.end_of_messages) {
         errno = 0;
         s2n_errno = S2N_ERR_OK;
 


### PR DESCRIPTION
### Resolved issues:

Partially covers https://github.com/aws/s2n-tls/issues/2569 and https://github.com/aws/s2n-tls/issues/2570

### Description of changes: 

Allows us to perform partial handshakes, stopping before a predetermined message. This enables early data, as well as some fun unit testing opportunities-- we'll no longer have to jump through hoops to make assertions at a particular point in the handshake.

### Call-outs:

From the comment on s2n_negotiate_until_message:
```
/* This method will work when testing S2N, and for the EndOfEarlyData message.
 *
 * However, it will NOT work for arbitrary message types when potentially receiving records
 * that contain multiple messages, like when talking to a non-S2N TLS implementation. If the "end_message"
 * is not the first message in a multi-message record, negotiation will not stop.
 * (This is not an issue for EndOfEarlyData because encryption and message order requirements force
 * EndOfEarlyData to always be the first and only handshake message in its handshake record)
 */
```
We COULD support multi-message records some day, but it's more complicated and unnecessary for both the testing and early data use cases.

### Testing:

Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
