### PR TITLE
dont await close_notify for a closed connection

### DIFF
--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -550,7 +550,7 @@ int main(int argc, char *const *argv)
         s2n_blocked_status blocked;
         int shutdown_rc = s2n_shutdown(conn, &blocked);
         if (shutdown_rc == -1 && blocked != S2N_BLOCKED_ON_READ) {
-            fprintf(stderr, "We only expect to error if we are awaiting a close_notify alert.\n");
+            fprintf(stderr, "Unexpected error during shutdown: '%s'\n", s2n_strerror(s2n_errno, "NULL"));
             exit(1);
         }
 

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -544,7 +544,7 @@ int main(int argc, char *const *argv)
         }
 
         s2n_blocked_status blocked;
-        s2n_shutdown(conn, &blocked);
+        GUARD_EXIT(s2n_shutdown(conn, &blocked), "Error shutting down connection");
 
         GUARD_EXIT(s2n_connection_free(conn), "Error freeing connection");
 

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -543,9 +543,10 @@ int main(int argc, char *const *argv)
             echo(conn, sockfd);
         }
 
-        /* TODO: Some integration tests fail with this change. This is a work around until we fix those. */
-        /* After the integration tests are fixed, the below shutdown and `if` clause should be replaced with: */
-        /* GUARD_EXIT(s2n_shutdown(conn, &blocked), "Error shutting down connection"); */
+        /* The following call can block on receiving a close_notify if we initiate the shutdown or if the */
+        /* peer fails to send a close_notify. */
+        /* TODO: However, we should expect to receive a close_notify from the peer and shutdown gracefully. */
+        /* Please see tracking issue for more detail: https://github.com/aws/s2n-tls/issues/2692 */
         s2n_blocked_status blocked;
         int shutdown_rc = s2n_shutdown(conn, &blocked);
         if (shutdown_rc == -1 && blocked != S2N_BLOCKED_ON_READ) {

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -549,7 +549,8 @@ int main(int argc, char *const *argv)
         s2n_blocked_status blocked;
         int shutdown_rc = s2n_shutdown(conn, &blocked);
         if (shutdown_rc == -1 && blocked != S2N_BLOCKED_ON_READ) {
-            return -1;
+            fprintf(stderr, "We only expect to error if we are awaiting a close_notify alert.\n");
+            exit(1);
         }
 
         GUARD_EXIT(s2n_connection_free(conn), "Error freeing connection");

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -543,8 +543,14 @@ int main(int argc, char *const *argv)
             echo(conn, sockfd);
         }
 
+        /* TODO: Some integration tests fail with this change. This is a work around until we fix those. */
+        /* After the integration tests are fixed, the below shutdown and `if` clause should be replaced with: */
+        /* GUARD_EXIT(s2n_shutdown(conn, &blocked), "Error shutting down connection"); */
         s2n_blocked_status blocked;
-        GUARD_EXIT(s2n_shutdown(conn, &blocked), "Error shutting down connection");
+        int shutdown_rc = s2n_shutdown(conn, &blocked);
+        if (shutdown_rc == -1 && blocked == S2N_BLOCKED_ON_READ) {
+            return -1;
+        }
 
         GUARD_EXIT(s2n_connection_free(conn), "Error freeing connection");
 

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -548,7 +548,9 @@ int main(int argc, char *const *argv)
         /* GUARD_EXIT(s2n_shutdown(conn, &blocked), "Error shutting down connection"); */
         s2n_blocked_status blocked;
         int shutdown_rc = s2n_shutdown(conn, &blocked);
-        if (shutdown_rc == -1 && blocked == S2N_BLOCKED_ON_READ) {
+
+        // if (0 or if (-1 and blocked_read))
+        if (shutdown_rc == -1 && blocked != S2N_BLOCKED_ON_READ) {
             return -1;
         }
 

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -548,8 +548,6 @@ int main(int argc, char *const *argv)
         /* GUARD_EXIT(s2n_shutdown(conn, &blocked), "Error shutting down connection"); */
         s2n_blocked_status blocked;
         int shutdown_rc = s2n_shutdown(conn, &blocked);
-
-        // if (0 or if (-1 and blocked_read))
         if (shutdown_rc == -1 && blocked != S2N_BLOCKED_ON_READ) {
             return -1;
         }

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -372,8 +372,14 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
         echo(conn, fd);
     }
 
+    /* TODO: Some integration tests fail with this change. This is a work around until we fix those. */
+    /* After the integration tests are fixed, the below shutdown and `if` clause should be replaced with: */
+    /* GUARD_EXIT(s2n_shutdown(conn, &blocked), "Error shutting down connection"); */
     s2n_blocked_status blocked;
-    GUARD_RETURN(s2n_shutdown(conn, &blocked), "Error shutting down connection");
+    int shutdown_rc = s2n_shutdown(conn, &blocked);
+    if (shutdown_rc == -1 && blocked != S2N_BLOCKED_ON_READ) {
+        return -1;
+    }
 
     GUARD_RETURN(s2n_connection_wipe(conn), "Error wiping connection");
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -378,7 +378,8 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
     s2n_blocked_status blocked;
     int shutdown_rc = s2n_shutdown(conn, &blocked);
     if (shutdown_rc == -1 && blocked != S2N_BLOCKED_ON_READ) {
-        return -1;
+        fprintf(stderr, "We only expect to error if we are awaiting a close_notify alert.\n");
+        exit(1);
     }
 
     GUARD_RETURN(s2n_connection_wipe(conn), "Error wiping connection");

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -379,7 +379,7 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
     s2n_blocked_status blocked;
     int shutdown_rc = s2n_shutdown(conn, &blocked);
     if (shutdown_rc == -1 && blocked != S2N_BLOCKED_ON_READ) {
-        fprintf(stderr, "We only expect to error if we are awaiting a close_notify alert.\n");
+        fprintf(stderr, "Unexpected error during shutdown: '%s'\n", s2n_strerror(s2n_errno, "NULL"));
         exit(1);
     }
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -373,7 +373,7 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
     }
 
     s2n_blocked_status blocked;
-    s2n_shutdown(conn, &blocked);
+    GUARD_RETURN(s2n_shutdown(conn, &blocked), "Error shutting down connection");
 
     GUARD_RETURN(s2n_connection_wipe(conn), "Error wiping connection");
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -372,9 +372,10 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
         echo(conn, fd);
     }
 
-    /* TODO: Some integration tests fail with this change. This is a work around until we fix those. */
-    /* After the integration tests are fixed, the below shutdown and `if` clause should be replaced with: */
-    /* GUARD_EXIT(s2n_shutdown(conn, &blocked), "Error shutting down connection"); */
+    /* The following call can block on receiving a close_notify if we initiate the shutdown or if the */
+    /* peer fails to send a close_notify. */
+    /* TODO: However, we should expect to receive a close_notify from the peer and shutdown gracefully. */
+    /* Please see tracking issue for more detail: https://github.com/aws/s2n-tls/issues/2692 */
     s2n_blocked_status blocked;
     int shutdown_rc = s2n_shutdown(conn, &blocked);
     if (shutdown_rc == -1 && blocked != S2N_BLOCKED_ON_READ) {

--- a/tests/unit/s2n_alerts_test.c
+++ b/tests/unit/s2n_alerts_test.c
@@ -43,7 +43,9 @@ int main(int argc, char **argv)
 
             /* Write and process the alert */
             EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->in, not_close_notify_alert, sizeof(not_close_notify_alert)));
-            EXPECT_FAILURE(s2n_process_alert_fragment(conn));
+
+            /* This fails due to the alert. This is ok since we are only testing that close_notify_received was set */
+            EXPECT_FAILURE_WITH_ERRNO(s2n_process_alert_fragment(conn), S2N_ERR_ALERT);
 
             /* Verify state after alert */
             EXPECT_FALSE(conn->close_notify_received);

--- a/tests/unit/s2n_alerts_test.c
+++ b/tests/unit/s2n_alerts_test.c
@@ -24,7 +24,7 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
-    /* Test S2N_TLS_ALERT_CLOSE_NOTIFY and did_recv_close_notify */
+    /* Test S2N_TLS_ALERT_CLOSE_NOTIFY and close_notify_received */
     {
         const uint8_t close_notify_alert[] = {  2 /* AlertLevel = fatal */,
                                                 0 /* AlertDescription = close_notify */ };
@@ -33,48 +33,40 @@ int main(int argc, char **argv)
                                                    10 /* AlertDescription = unexpected_msg */ };
 
 
-        /* Don't mark did_recv_close_notify = true if we receive an alert other than close_notify alert */
+        /* Don't mark close_notify_received = true if we receive an alert other than close_notify alert */
         {
-            struct s2n_config *config;
-            EXPECT_NOT_NULL(config = s2n_config_new());
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
             /* Verify state prior to alert */
-            EXPECT_FALSE(conn->did_recv_close_notify);
+            EXPECT_FALSE(conn->close_notify_received);
 
             /* Write and process the alert */
             EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->in, not_close_notify_alert, sizeof(not_close_notify_alert)));
             EXPECT_FAILURE(s2n_process_alert_fragment(conn));
 
             /* Verify state after alert */
-            EXPECT_FALSE(conn->did_recv_close_notify);
+            EXPECT_FALSE(conn->close_notify_received);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
-            EXPECT_SUCCESS(s2n_config_free(config));
         }
 
-        /* Mark did_recv_close_notify = true if we receive a close_notify alert */
+        /* Mark close_notify_received = true if we receive a close_notify alert */
         {
-            struct s2n_config *config;
-            EXPECT_NOT_NULL(config = s2n_config_new());
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
             /* Verify state prior to alert */
-            EXPECT_FALSE(conn->did_recv_close_notify);
+            EXPECT_FALSE(conn->close_notify_received);
 
             /* Write and process the alert */
             EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->in, close_notify_alert, sizeof(close_notify_alert)));
             EXPECT_SUCCESS(s2n_process_alert_fragment(conn));
 
             /* Verify state after alert */
-            EXPECT_TRUE(conn->did_recv_close_notify);
+            EXPECT_TRUE(conn->close_notify_received);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
-            EXPECT_SUCCESS(s2n_config_free(config));
         }
 
     }

--- a/tests/unit/s2n_self_talk_shutdown_test.c
+++ b/tests/unit/s2n_self_talk_shutdown_test.c
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
         EXPECT_FALSE(server_conn->close_notify_received);
         EXPECT_FALSE(client_conn->close_notify_received);
 
-        /* Verify successful shutdown. Server initiated. */
+        /* Verify successful shutdown */
         EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(server_conn, &server_blocked), S2N_ERR_IO_BLOCKED);
         EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));
         EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
@@ -69,7 +69,7 @@ int main(int argc, char **argv)
         EXPECT_FALSE(server_conn->close_notify_received);
         EXPECT_FALSE(client_conn->close_notify_received);
 
-        /* Verify successful shutdown. Server initiated. */
+        /* Verify successful shutdown. */
         EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(client_conn, &client_blocked), S2N_ERR_IO_BLOCKED);
         EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
         EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));

--- a/tests/unit/s2n_self_talk_shutdown_test.c
+++ b/tests/unit/s2n_self_talk_shutdown_test.c
@@ -47,8 +47,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
 
         /* Verify state after alert */
-        EXPECT_SUCCESS(server_conn->close_notify_received);
-        EXPECT_SUCCESS(client_conn->close_notify_received);
+        EXPECT_TRUE(server_conn->close_notify_received);
+        EXPECT_TRUE(client_conn->close_notify_received);
 
         /* Cleanup */
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -80,8 +80,55 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));
 
         /* Verify state after alert */
-        EXPECT_SUCCESS(server_conn->close_notify_received);
+        EXPECT_TRUE(server_conn->close_notify_received);
         EXPECT_SUCCESS(client_conn->close_notify_received);
+
+        /* Cleanup */
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+    }
+
+    /* Verify successful shutdown. Client and Server initiated. */
+    {
+        /* Setup connections */
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+        /* /1* Create nonblocking pipes *1/ */
+        /* struct s2n_test_io_pair io_pair; */
+        /* EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair)); */
+        /* EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair)); */
+        /* EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair)); */
+
+        struct s2n_stuffer server_input;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_input, 0));
+        struct s2n_stuffer server_output;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_output, 0));
+
+        struct s2n_stuffer client_input;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_input, 0));
+        struct s2n_stuffer client_output;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_output, 0));
+
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_input, &server_output, server_conn));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&client_input, &client_output, client_conn));
+
+
+        /* Verify state prior to alert */
+        EXPECT_FALSE(server_conn->close_notify_received);
+        EXPECT_FALSE(client_conn->close_notify_received);
+
+        s2n_blocked_status server_blocked;
+        s2n_blocked_status client_blocked;
+
+        /* /1* Verify successful shutdown. Server initiated. *1/ */
+        /* EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(client_conn, &client_blocked), S2N_ERR_IO_BLOCKED); */
+        /* EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked)); */
+        /* EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked)); */
+
+        /* Verify state after alert */
+        /* EXPECT_TRUE(server_conn->close_notify_received); */
+        /* EXPECT_TRUE(client_conn->close_notify_received); */
 
         /* Cleanup */
         EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_self_talk_shutdown_test.c
+++ b/tests/unit/s2n_self_talk_shutdown_test.c
@@ -21,6 +21,7 @@ int main(int argc, char **argv)
     BEGIN_TEST();
 
     struct s2n_connection *client_conn, *server_conn;
+    s2n_blocked_status server_blocked, client_blocked;
 
     /* Verify successful shutdown. Server initiated. */
     {
@@ -37,9 +38,6 @@ int main(int argc, char **argv)
         /* Verify state prior to alert */
         EXPECT_FALSE(server_conn->close_notify_received);
         EXPECT_FALSE(client_conn->close_notify_received);
-
-        s2n_blocked_status server_blocked;
-        s2n_blocked_status client_blocked;
 
         /* Verify successful shutdown. Server initiated. */
         EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(server_conn, &server_blocked), S2N_ERR_IO_BLOCKED);
@@ -71,9 +69,6 @@ int main(int argc, char **argv)
         EXPECT_FALSE(server_conn->close_notify_received);
         EXPECT_FALSE(client_conn->close_notify_received);
 
-        s2n_blocked_status server_blocked;
-        s2n_blocked_status client_blocked;
-
         /* Verify successful shutdown. Server initiated. */
         EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(client_conn, &client_blocked), S2N_ERR_IO_BLOCKED);
         EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
@@ -81,52 +76,7 @@ int main(int argc, char **argv)
 
         /* Verify state after alert */
         EXPECT_TRUE(server_conn->close_notify_received);
-        EXPECT_SUCCESS(client_conn->close_notify_received);
-
-        /* Cleanup */
-        EXPECT_SUCCESS(s2n_connection_free(server_conn));
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-    }
-
-    /* Verify successful shutdown. Client and Server initiated. */
-    {
-        /* Setup connections */
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-
-        /* /1* Create nonblocking pipes *1/ */
-        /* struct s2n_test_io_pair io_pair; */
-        /* EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair)); */
-        /* EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair)); */
-        /* EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair)); */
-
-        struct s2n_stuffer server_input, server_output;
-        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_input, 0));
-        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_output, 0));
-
-        /* struct s2n_stuffer client_input, client_output; */
-        /* EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_input, 0)); */
-        /* EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_output, 0)); */
-
-        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_input, &server_output, server_conn));
-        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_output, &server_input, client_conn));
-
-
-        /* Verify state prior to alert */
-        EXPECT_FALSE(server_conn->close_notify_received);
-        EXPECT_FALSE(client_conn->close_notify_received);
-
-        s2n_blocked_status server_blocked;
-        s2n_blocked_status client_blocked;
-
-        /* Verify successful shutdown. Server initiated. */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(client_conn, &client_blocked), S2N_ERR_IO_BLOCKED);
-        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
-        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));
-
-        /* Verify state after alert */
-        EXPECT_TRUE(server_conn->close_notify_received);
-        EXPECT_SUCCESS(client_conn->close_notify_received);
+        EXPECT_TRUE(client_conn->close_notify_received);
 
         /* Cleanup */
         EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_self_talk_shutdown_test.c
+++ b/tests/unit/s2n_self_talk_shutdown_test.c
@@ -16,122 +16,17 @@
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 
-#include "tls/s2n_quic_support.h"
-
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
-    /* Verify successful shutdown. Server only. */
-    {
-        /* Setup connections */
-        struct s2n_connection *client_conn, *server_conn;
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-
-        /* Setup config */
-        struct s2n_cert_chain_and_key *chain_and_key;
-        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
-                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
-        struct s2n_config *config;
-        EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
-        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-
-        /* Create nonblocking pipes */
-        struct s2n_test_io_pair io_pair;
-        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
-        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
-        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
-
-        /* Verify state prior to alert */
-        EXPECT_FALSE(server_conn->close_notify_received);
-        EXPECT_FALSE(client_conn->close_notify_received);
-
-        s2n_blocked_status server_blocked;
-
-        /* Verify successful shutdown. Server initiated. */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(server_conn, &server_blocked), S2N_ERR_IO_BLOCKED);
-
-        /* Verify state after alert */
-        EXPECT_SUCCESS(server_conn->close_notify_received);
-        EXPECT_SUCCESS(client_conn->close_notify_received);
-
-        /* Cleanup */
-        EXPECT_SUCCESS(s2n_connection_free(server_conn));
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
-        EXPECT_SUCCESS(s2n_config_free(config));
-    }
-
-    /* Verify successful shutdown. Client only. */
-    {
-        /* Setup connections */
-        struct s2n_connection *client_conn, *server_conn;
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-
-        /* Setup config */
-        struct s2n_cert_chain_and_key *chain_and_key;
-        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
-                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
-        struct s2n_config *config;
-        EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
-        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-
-        /* Create nonblocking pipes */
-        struct s2n_test_io_pair io_pair;
-        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
-        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
-        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
-
-        /* Verify state prior to alert */
-        EXPECT_FALSE(server_conn->close_notify_received);
-        EXPECT_FALSE(client_conn->close_notify_received);
-
-        s2n_blocked_status client_blocked;
-
-        /* Verify successful shutdown. Server initiated. */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(client_conn, &client_blocked), S2N_ERR_IO_BLOCKED);
-
-        /* Verify state after alert */
-        EXPECT_SUCCESS(server_conn->close_notify_received);
-        EXPECT_SUCCESS(client_conn->close_notify_received);
-
-        /* Cleanup */
-        EXPECT_SUCCESS(s2n_connection_free(server_conn));
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
-        EXPECT_SUCCESS(s2n_config_free(config));
-    }
+    struct s2n_connection *client_conn, *server_conn;
 
     /* Verify successful shutdown. Server initiated. */
     {
         /* Setup connections */
-        struct s2n_connection *client_conn, *server_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-
-        /* Setup config */
-        struct s2n_cert_chain_and_key *chain_and_key;
-        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
-                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
-        struct s2n_config *config;
-        EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
-        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
         /* Create nonblocking pipes */
         struct s2n_test_io_pair io_pair;
@@ -158,29 +53,13 @@ int main(int argc, char **argv)
         /* Cleanup */
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
-        EXPECT_SUCCESS(s2n_config_free(config));
     }
 
     /* Verify successful shutdown. Client initiated. */
     {
         /* Setup connections */
-        struct s2n_connection *client_conn, *server_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-
-        /* Setup config */
-        struct s2n_cert_chain_and_key *chain_and_key;
-        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
-                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
-        struct s2n_config *config;
-        EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
-        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
         /* Create nonblocking pipes */
         struct s2n_test_io_pair io_pair;
@@ -207,50 +86,6 @@ int main(int argc, char **argv)
         /* Cleanup */
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
-        EXPECT_SUCCESS(s2n_config_free(config));
-    }
-
-    /* Verify successful shutdown. Client and Server initiated. */
-    {
-        /* Setup connections */
-        struct s2n_connection *client_conn, *server_conn;
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-
-        /* Setup config */
-        struct s2n_cert_chain_and_key *chain_and_key;
-        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
-                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
-        struct s2n_config *config;
-        EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
-        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-
-        /* Create nonblocking pipes */
-        struct s2n_test_io_pair io_pair;
-        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
-        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
-        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
-
-        /* Verify state prior to alert */
-        EXPECT_FALSE(server_conn->close_notify_received);
-        EXPECT_FALSE(client_conn->close_notify_received);
-
-        /* Verify state when we dont call shutdown. Not a very interesting test case. */
-        EXPECT_FALSE(server_conn->close_notify_received);
-        EXPECT_FALSE(client_conn->close_notify_received);
-
-        /* Cleanup */
-        EXPECT_SUCCESS(s2n_connection_free(server_conn));
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
-        EXPECT_SUCCESS(s2n_config_free(config));
     }
 
     END_TEST();

--- a/tests/unit/s2n_self_talk_shutdown_test.c
+++ b/tests/unit/s2n_self_talk_shutdown_test.c
@@ -100,18 +100,16 @@ int main(int argc, char **argv)
         /* EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair)); */
         /* EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair)); */
 
-        struct s2n_stuffer server_input;
+        struct s2n_stuffer server_input, server_output;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_input, 0));
-        struct s2n_stuffer server_output;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_output, 0));
 
-        struct s2n_stuffer client_input;
-        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_input, 0));
-        struct s2n_stuffer client_output;
-        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_output, 0));
+        /* struct s2n_stuffer client_input, client_output; */
+        /* EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_input, 0)); */
+        /* EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_output, 0)); */
 
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_input, &server_output, server_conn));
-        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&client_input, &client_output, client_conn));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_output, &server_input, client_conn));
 
 
         /* Verify state prior to alert */
@@ -121,14 +119,14 @@ int main(int argc, char **argv)
         s2n_blocked_status server_blocked;
         s2n_blocked_status client_blocked;
 
-        /* /1* Verify successful shutdown. Server initiated. *1/ */
-        /* EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(client_conn, &client_blocked), S2N_ERR_IO_BLOCKED); */
-        /* EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked)); */
-        /* EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked)); */
+        /* Verify successful shutdown. Server initiated. */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(client_conn, &client_blocked), S2N_ERR_IO_BLOCKED);
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
+        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));
 
         /* Verify state after alert */
-        /* EXPECT_TRUE(server_conn->close_notify_received); */
-        /* EXPECT_TRUE(client_conn->close_notify_received); */
+        EXPECT_TRUE(server_conn->close_notify_received);
+        EXPECT_SUCCESS(client_conn->close_notify_received);
 
         /* Cleanup */
         EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_self_talk_shutdown_test.c
+++ b/tests/unit/s2n_self_talk_shutdown_test.c
@@ -1,0 +1,259 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "tls/s2n_quic_support.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Verify successful shutdown. Server only. */
+    {
+        /* Setup connections */
+        struct s2n_connection *client_conn, *server_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+        /* Setup config */
+        struct s2n_cert_chain_and_key *chain_and_key;
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair;
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+
+        /* Verify state prior to alert */
+        EXPECT_FALSE(server_conn->close_notify_received);
+        EXPECT_FALSE(client_conn->close_notify_received);
+
+        s2n_blocked_status server_blocked;
+
+        /* Verify successful shutdown. Server initiated. */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(server_conn, &server_blocked), S2N_ERR_IO_BLOCKED);
+
+        /* Verify state after alert */
+        EXPECT_SUCCESS(server_conn->close_notify_received);
+        EXPECT_SUCCESS(client_conn->close_notify_received);
+
+        /* Cleanup */
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Verify successful shutdown. Client only. */
+    {
+        /* Setup connections */
+        struct s2n_connection *client_conn, *server_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+        /* Setup config */
+        struct s2n_cert_chain_and_key *chain_and_key;
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair;
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+
+        /* Verify state prior to alert */
+        EXPECT_FALSE(server_conn->close_notify_received);
+        EXPECT_FALSE(client_conn->close_notify_received);
+
+        s2n_blocked_status client_blocked;
+
+        /* Verify successful shutdown. Server initiated. */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(client_conn, &client_blocked), S2N_ERR_IO_BLOCKED);
+
+        /* Verify state after alert */
+        EXPECT_SUCCESS(server_conn->close_notify_received);
+        EXPECT_SUCCESS(client_conn->close_notify_received);
+
+        /* Cleanup */
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Verify successful shutdown. Server initiated. */
+    {
+        /* Setup connections */
+        struct s2n_connection *client_conn, *server_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+        /* Setup config */
+        struct s2n_cert_chain_and_key *chain_and_key;
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair;
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+
+        /* Verify state prior to alert */
+        EXPECT_FALSE(server_conn->close_notify_received);
+        EXPECT_FALSE(client_conn->close_notify_received);
+
+        s2n_blocked_status server_blocked;
+        s2n_blocked_status client_blocked;
+
+        /* Verify successful shutdown. Server initiated. */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(server_conn, &server_blocked), S2N_ERR_IO_BLOCKED);
+        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
+
+        /* Verify state after alert */
+        EXPECT_SUCCESS(server_conn->close_notify_received);
+        EXPECT_SUCCESS(client_conn->close_notify_received);
+
+        /* Cleanup */
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Verify successful shutdown. Client initiated. */
+    {
+        /* Setup connections */
+        struct s2n_connection *client_conn, *server_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+        /* Setup config */
+        struct s2n_cert_chain_and_key *chain_and_key;
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair;
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+
+        /* Verify state prior to alert */
+        EXPECT_FALSE(server_conn->close_notify_received);
+        EXPECT_FALSE(client_conn->close_notify_received);
+
+        s2n_blocked_status server_blocked;
+        s2n_blocked_status client_blocked;
+
+        /* Verify successful shutdown. Server initiated. */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(client_conn, &client_blocked), S2N_ERR_IO_BLOCKED);
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
+        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));
+
+        /* Verify state after alert */
+        EXPECT_SUCCESS(server_conn->close_notify_received);
+        EXPECT_SUCCESS(client_conn->close_notify_received);
+
+        /* Cleanup */
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Verify successful shutdown. Client and Server initiated. */
+    {
+        /* Setup connections */
+        struct s2n_connection *client_conn, *server_conn;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+
+        /* Setup config */
+        struct s2n_cert_chain_and_key *chain_and_key;
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair;
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+
+        /* Verify state prior to alert */
+        EXPECT_FALSE(server_conn->close_notify_received);
+        EXPECT_FALSE(client_conn->close_notify_received);
+
+        /* Verify state when we dont call shutdown. Not a very interesting test case. */
+        EXPECT_FALSE(server_conn->close_notify_received);
+        EXPECT_FALSE(client_conn->close_notify_received);
+
+        /* Cleanup */
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    END_TEST();
+}
+
+

--- a/tests/unit/s2n_shutdown_test.c
+++ b/tests/unit/s2n_shutdown_test.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "tls/s2n_alerts.h"
+#include "tls/s2n_shutdown.c"
+
+#define ALERT_LEN (sizeof(uint16_t))
+
+int mock_send_impl(void *io_context, const uint8_t *buf, uint32_t len)
+{
+    return len;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    const uint8_t close_notify_alert[] = {  2 /* AlertLevel = fatal */,
+                                            0 /* AlertDescription = close_notify */ };
+
+    /* Test s2n_shutdown */
+    {
+
+        /* If send and recv impl are NULL always proceed with shutdown  */
+        {
+            struct s2n_config *config;
+            EXPECT_NOT_NULL(config = s2n_config_new());
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+            /* Verify state prior to alert */
+            EXPECT_FALSE(conn->did_recv_close_notify);
+
+            /* Write and process the alert */
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->in, close_notify_alert, sizeof(close_notify_alert)));
+            EXPECT_SUCCESS(s2n_process_alert_fragment(conn));
+
+            /* Verify state after alert */
+            EXPECT_TRUE(conn->did_recv_close_notify);
+
+            s2n_blocked_status blocked;
+            EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
+        }
+
+        /* Await close_notify if did_recv_close_notify is not set */
+        {
+            struct s2n_config *config;
+            EXPECT_NOT_NULL(config = s2n_config_new());
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+            /* Set mock send impl */
+            EXPECT_SUCCESS(s2n_connection_set_send_cb(conn, &mock_send_impl));
+
+            /* Verify state prior to alert */
+            EXPECT_FALSE(conn->did_recv_close_notify);
+
+            s2n_blocked_status blocked;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(conn, &blocked), S2N_ERR_IO);
+            EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
+
+            /* Verify state after shutdown attempt */
+            EXPECT_FALSE(conn->did_recv_close_notify);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
+        }
+
+        /* Do not await close_notify if did_recv_close_notify is set */
+        {
+            struct s2n_config *config;
+            EXPECT_NOT_NULL(config = s2n_config_new());
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+            /* Set mock send impl */
+            EXPECT_SUCCESS(s2n_connection_set_send_cb(conn, &mock_send_impl));
+
+            /* Verify state prior to alert */
+            EXPECT_FALSE(conn->did_recv_close_notify);
+
+            /* Write and process the alert */
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->in, close_notify_alert, sizeof(close_notify_alert)));
+            EXPECT_SUCCESS(s2n_process_alert_fragment(conn));
+
+            /* Verify state after alert */
+            EXPECT_TRUE(conn->did_recv_close_notify);
+
+            s2n_blocked_status blocked;
+            EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
+            EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+
+            /* Verify state after shutdown attempt */
+            EXPECT_TRUE(conn->did_recv_close_notify);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
+        }
+
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_shutdown_test.c
+++ b/tests/unit/s2n_shutdown_test.c
@@ -60,8 +60,17 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
+            /* --------------------- */
             /* Set mock send impl */
             EXPECT_SUCCESS(s2n_connection_set_send_cb(conn, &mock_send_impl));
+
+            /* struct s2n_stuffer input; */
+            /* EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0)); */
+            /* /1* struct s2n_stuffer o; *1/ */
+            /* /1* EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&o, 0)); *1/ */
+            /* EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn)); */
+
+            /* --------------------- */
 
             /* Verify state prior to alert */
             EXPECT_FALSE(conn->close_notify_received);

--- a/tests/unit/s2n_shutdown_test.c
+++ b/tests/unit/s2n_shutdown_test.c
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
         /* Await close_notify if close_notify_received is not set */
         {
             struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
             struct s2n_stuffer input;
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));

--- a/tests/unit/s2n_shutdown_test.c
+++ b/tests/unit/s2n_shutdown_test.c
@@ -54,6 +54,8 @@ int main(int argc, char **argv)
             EXPECT_FALSE(conn->close_notify_received);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&input));
+            EXPECT_SUCCESS(s2n_stuffer_free(&output));
         }
 
         /* Do not await close_notify if close_notify_received is set */
@@ -85,6 +87,8 @@ int main(int argc, char **argv)
             EXPECT_TRUE(conn->close_notify_received);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&input));
+            EXPECT_SUCCESS(s2n_stuffer_free(&output));
         }
 
     }

--- a/tests/unit/s2n_shutdown_test.c
+++ b/tests/unit/s2n_shutdown_test.c
@@ -14,6 +14,9 @@
  */
 
 #include "s2n_test.h"
+
+#include "testlib/s2n_testlib.h"
+
 #include "tls/s2n_alerts.h"
 #include "tls/s2n_shutdown.c"
 

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -102,6 +102,7 @@ int s2n_process_alert_fragment(struct s2n_connection *conn)
             /* Close notifications are handled as shutdowns */
             if (conn->alert_in_data[1] == S2N_TLS_ALERT_CLOSE_NOTIFY) {
                 conn->closed = 1;
+                conn->did_recv_close_notify = true;
                 return 0;
             }
 

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -102,7 +102,7 @@ int s2n_process_alert_fragment(struct s2n_connection *conn)
             /* Close notifications are handled as shutdowns */
             if (conn->alert_in_data[1] == S2N_TLS_ALERT_CLOSE_NOTIFY) {
                 conn->closed = 1;
-                conn->did_recv_close_notify = true;
+                conn->close_notify_received = true;
                 return 0;
             }
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -329,6 +329,9 @@ struct s2n_connection {
     /* Connection overrides server_max_early_data_size */
     unsigned server_max_early_data_size_overridden:1;
 
+    /* Have we received a close notify alert from the peer. */
+    unsigned did_recv_close_notify:1;
+
     /* Bitmap to represent preferred list of keyshare for client to generate and send keyshares in the ClientHello message.
      * The least significant bit (lsb), if set, indicates that the client must send an empty keyshare list.
      * Each bit value in the bitmap indiciates the corresponding curve in the ecc_preferences list for which a key share needs to be generated.

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -330,7 +330,7 @@ struct s2n_connection {
     unsigned server_max_early_data_size_overridden:1;
 
     /* Have we received a close notify alert from the peer. */
-    unsigned did_recv_close_notify:1;
+    unsigned close_notify_received:1;
 
     /* Bitmap to represent preferred list of keyshare for client to generate and send keyshares in the ClientHello message.
      * The least significant bit (lsb), if set, indicates that the client must send an empty keyshare list.

--- a/tls/s2n_shutdown.c
+++ b/tls/s2n_shutdown.c
@@ -49,7 +49,7 @@ int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status * more)
     }
 
     /* Dont expect to receive another close notify alert if we have already received it */
-    if (!conn->did_recv_close_notify) {
+    if (!conn->close_notify_received) {
         /* Fails with S2N_ERR_SHUTDOWN_RECORD_TYPE or S2N_ERR_ALERT on receipt of anything but a close_notify */
         POSIX_GUARD(s2n_recv_close_notify(conn, more));
     }

--- a/tls/s2n_shutdown.c
+++ b/tls/s2n_shutdown.c
@@ -48,8 +48,11 @@ int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status * more)
         conn->in_status = ENCRYPTED;
     }
 
-    /* Fails with S2N_ERR_SHUTDOWN_RECORD_TYPE or S2N_ERR_ALERT on receipt of anything but a close_notify */
-    POSIX_GUARD(s2n_recv_close_notify(conn, more));
+    /* Dont expect to receive another close notify alert if we have already received it */
+    if (!conn->did_recv_close_notify) {
+        /* Fails with S2N_ERR_SHUTDOWN_RECORD_TYPE or S2N_ERR_ALERT on receipt of anything but a close_notify */
+        POSIX_GUARD(s2n_recv_close_notify(conn, more));
+    }
 
     return 0;
 }


### PR DESCRIPTION
### Resolved issues:

 resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.

### Description of changes: 
The shutdown method always waits for a close notify. However if the close notify is client initiated, then the client closes its write channel and wont send another close notify. Therefore if a server receives a close notify then it should not expect to receive another.

### Call-outs:

The integration tests currently rely on the broken behavior. This issue tracks the fix: https://github.com/aws/s2n-tls/issues/2692

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
GDB was used to verify receiving and sending close_notify alerts and the connection ending.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?


### manual integation test with s2n and openssl

We expect the connections to shutdown gracefully

```
**SERVER**    **CLIENT**     **PEER_TO_INITIATE_CLOSE_NOTIFY**
---------------------------------------
s2nd          s_client      server
---------------------------------------
./bin/s2nd -X --self-service-blinding --non-blocking --key ../tests/pems/ecdsa_p384_pkcs1_key.pem --cert ../tests/pems/ecdsa_p384_pkcs1_cert.pem --insecure -c test_all -T --negotiate localhost 8000

openssl s_client -connect localhost:8000 -debug -tlsextdebug -state -tls1_3 -ciphersuites TLS_CHACHA20_POLY1305_SHA256

---------------------------------------
s2nd          s_client      client
---------------------------------------
./bin/s2nd -X --self-service-blinding --non-blocking --key ../tests/pems/ecdsa_p384_pkcs1_key.pem --cert ../tests/pems/ecdsa_p384_pkcs1_cert.pem --insecure -c test_all -T localhost 8000

echo "Q" | openssl s_client -connect localhost:8000 -debug -tlsextdebug -state -tls1_3 -ciphersuites TLS_CHACHA20_POLY1305_SHA256


---------------------------------------
s_server      s2nc          server
---------------------------------------
openssl s_server -accept localhost:8000 -debug -tlsextdebug -key ../tests/pems/ecdsa_p384_pkcs1_key.pem -cert ../tests/pems/ecdsa_p384_pkcs1_cert.pem

./bin/s2nc --non-blocking --insecure -c test_all -T --echo localhost 8000

<< send command "Q" to openssl s_server

---------------------------------------
s_server      s2nc          client
---------------------------------------
openssl s_server -accept localhost:8000 -debug -tlsextdebug -key ../tests/pems/ecdsa_p384_pkcs1_key.pem -cert ../tests/pems/ecdsa_p384_pkcs1_cert.pem

./bin/s2nc --non-blocking --insecure -c test_all -T localhost 8000


```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
