### PR TITLE
Added client deserialization method

### DIFF
--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -36,14 +36,14 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_psk_init(&psk, S2N_PSK_TYPE_EXTERNAL));
         EXPECT_EQUAL(psk.type, S2N_PSK_TYPE_EXTERNAL);
         EXPECT_EQUAL(psk.hmac_alg, S2N_HMAC_SHA256);
-        EXPECT_EQUAL(psk.obfuscated_ticket_age, 0);
+        EXPECT_EQUAL(psk.ticket_age_add, 0);
         EXPECT_EQUAL(psk.ticket_issue_time, 0);
         EXPECT_EQUAL(psk.early_data_config.max_early_data_size, 0);
 
         EXPECT_OK(s2n_psk_init(&psk, S2N_PSK_TYPE_RESUMPTION));
         EXPECT_EQUAL(psk.type, S2N_PSK_TYPE_RESUMPTION);
         EXPECT_EQUAL(psk.hmac_alg, S2N_HMAC_SHA256);
-        EXPECT_EQUAL(psk.obfuscated_ticket_age, 0);
+        EXPECT_EQUAL(psk.ticket_age_add, 0);
         EXPECT_EQUAL(psk.ticket_issue_time, 0);
         EXPECT_EQUAL(psk.early_data_config.max_early_data_size, 0);
     }
@@ -758,7 +758,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(actual_psk->secret.size, input_psk->secret.size);
             EXPECT_BYTEARRAY_EQUAL(actual_psk->secret.data, input_psk->secret.data, input_psk->secret.size);
             EXPECT_EQUAL(actual_psk->hmac_alg, S2N_HMAC_SHA384);
-            EXPECT_EQUAL(actual_psk->obfuscated_ticket_age, 0);
+            EXPECT_EQUAL(actual_psk->ticket_age_add, 0);
             EXPECT_EQUAL(actual_psk->ticket_issue_time, 0);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -37,12 +37,14 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(psk.type, S2N_PSK_TYPE_EXTERNAL);
         EXPECT_EQUAL(psk.hmac_alg, S2N_HMAC_SHA256);
         EXPECT_EQUAL(psk.obfuscated_ticket_age, 0);
+        EXPECT_EQUAL(psk.ticket_issue_time, 0);
         EXPECT_EQUAL(psk.early_data_config.max_early_data_size, 0);
 
         EXPECT_OK(s2n_psk_init(&psk, S2N_PSK_TYPE_RESUMPTION));
         EXPECT_EQUAL(psk.type, S2N_PSK_TYPE_RESUMPTION);
         EXPECT_EQUAL(psk.hmac_alg, S2N_HMAC_SHA256);
         EXPECT_EQUAL(psk.obfuscated_ticket_age, 0);
+        EXPECT_EQUAL(psk.ticket_issue_time, 0);
         EXPECT_EQUAL(psk.early_data_config.max_early_data_size, 0);
     }
 
@@ -757,6 +759,7 @@ int main(int argc, char **argv)
             EXPECT_BYTEARRAY_EQUAL(actual_psk->secret.data, input_psk->secret.data, input_psk->secret.size);
             EXPECT_EQUAL(actual_psk->hmac_alg, S2N_HMAC_SHA384);
             EXPECT_EQUAL(actual_psk->obfuscated_ticket_age, 0);
+            EXPECT_EQUAL(actual_psk->ticket_issue_time, 0);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -23,14 +23,22 @@
 
 #define S2N_TLS13_STATE_SIZE_WITHOUT_SECRET S2N_MAX_STATE_SIZE_IN_BYTES - S2N_TLS_SECRET_LEN
 
-#define TICKET_ISSUE_TIME 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 
-#define TICKET_AGE_ADD 0x01, 0x01, 0x01, 0x01
+#define TICKET_ISSUE_TIME_BYTES 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07
+#define TICKET_AGE_ADD_BYTES 0x01, 0x01, 0x01, 0x01
+#define TICKET_AGE_ADD 16843009
 #define SECRET_LEN 0x02
 #define SECRET 0x03, 0x04
 #define CLIENT_TICKET 0x10, 0x10
 
+uint64_t ticket_issue_time = 283686952306183;
 static int s2n_test_session_ticket_callback(struct s2n_connection *conn, struct s2n_session_ticket *ticket)
 {
+    return S2N_SUCCESS;
+}
+
+static int mock_time(void *data, uint64_t *nanoseconds)
+{
+    *nanoseconds = ticket_issue_time;
     return S2N_SUCCESS;
 }
 
@@ -177,7 +185,7 @@ int main(int argc, char **argv)
                 S2N_TLS12_SERIALIZED_FORMAT_VERSION,
                 S2N_TLS12,
                 TLS_RSA_WITH_AES_128_GCM_SHA256,
-                TICKET_ISSUE_TIME,
+                TICKET_ISSUE_TIME_BYTES,
             };
 
             struct s2n_blob ticket_blob = { 0 };
@@ -207,8 +215,8 @@ int main(int argc, char **argv)
                 S2N_TLS13_SERIALIZED_FORMAT_VERSION,
                 S2N_TLS13,
                 TLS_AES_128_GCM_SHA256,
-                TICKET_ISSUE_TIME,
-                TICKET_AGE_ADD,
+                TICKET_ISSUE_TIME_BYTES,
+                TICKET_AGE_ADD_BYTES,
                 SECRET_LEN,
                 SECRET,
             };
@@ -241,22 +249,9 @@ int main(int argc, char **argv)
             EXPECT_BYTEARRAY_EQUAL(psk->secret.data, secret, sizeof(secret));
 
             EXPECT_EQUAL(psk->hmac_alg, S2N_HMAC_SHA256);
-            
-            uint8_t ticket_age_add[] = { TICKET_AGE_ADD };
-            uint32_t expected_ticket_age_add = ticket_age_add[0] | (ticket_age_add[1] << 8) | \
-                                              (ticket_age_add[2] << 16) | (ticket_age_add[3] << 24);
-            EXPECT_EQUAL(psk->obfuscated_ticket_age, expected_ticket_age_add);
 
-            uint8_t ticket_issue_time[] = { TICKET_ISSUE_TIME };
-            struct s2n_blob ticket_issue_time_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&ticket_issue_time_blob, ticket_issue_time, sizeof(ticket_issue_time)));
-            
-            struct s2n_stuffer ticket_issue_time_stuffer = { 0 };
-            EXPECT_SUCCESS(s2n_stuffer_init(&ticket_issue_time_stuffer, &ticket_issue_time_blob));
-            EXPECT_SUCCESS(s2n_stuffer_skip_write(&ticket_issue_time_stuffer, sizeof(ticket_issue_time)));
-            uint64_t expected_ticket_issue_time = 0;
-            EXPECT_SUCCESS(s2n_stuffer_read_uint64(&ticket_issue_time_stuffer, &expected_ticket_issue_time));
-            EXPECT_EQUAL(psk->ticket_issue_time, expected_ticket_issue_time);
+            EXPECT_EQUAL(psk->ticket_age_add, TICKET_AGE_ADD);
+            EXPECT_EQUAL(psk->ticket_issue_time, ticket_issue_time);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
@@ -266,12 +261,17 @@ int main(int argc, char **argv)
             struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
             EXPECT_NOT_NULL(conn);
 
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_NOT_NULL(config);
+            EXPECT_SUCCESS(s2n_config_set_wall_clock(config, mock_time, NULL));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
             conn->actual_protocol_version = S2N_TLS13;
             conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
             DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 0, .session_secret = test_session_secret };
+            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = TICKET_AGE_ADD, .session_secret = test_session_secret };
 
             /* Initialize client ticket */
             uint8_t client_ticket[] = { CLIENT_TICKET };
@@ -281,7 +281,24 @@ int main(int argc, char **argv)
             EXPECT_OK(s2n_serialize_resumption_state(conn, &ticket_fields, &stuffer));
             EXPECT_OK(s2n_client_deserialize_session_state(conn, &stuffer));
 
+            /* Check PSK values are correct */
+            struct s2n_psk *psk = NULL;
+            EXPECT_OK(s2n_array_get(&conn->psk_params.psk_list, 0, (void**) &psk));
+            EXPECT_NOT_NULL(psk);
+
+            EXPECT_EQUAL(psk->type, S2N_PSK_TYPE_RESUMPTION);
+            S2N_BLOB_EXPECT_EQUAL(psk->identity, conn->client_ticket);
+
+            EXPECT_EQUAL(psk->secret.size, test_session_secret.size);
+            EXPECT_BYTEARRAY_EQUAL(psk->secret.data, test_session_secret.data, test_session_secret.size);
+
+            EXPECT_EQUAL(psk->hmac_alg, S2N_HMAC_SHA384);
+
+            EXPECT_EQUAL(psk->ticket_age_add, TICKET_AGE_ADD);
+            EXPECT_EQUAL(psk->ticket_issue_time, ticket_issue_time);
+
             EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
         }
 
         /* Functional test: The TLS1.2 client can deserialize what it serializes */

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -70,10 +70,10 @@ int main(int argc, char **argv)
 
         uint8_t s_data[S2N_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = { 0 };
         struct s2n_blob state_blob = { 0 };
-        POSIX_GUARD(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
+        EXPECT_SUCCESS(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
         struct s2n_stuffer output = { 0 };
 
-        POSIX_GUARD(s2n_stuffer_init(&output, &state_blob));
+        EXPECT_SUCCESS(s2n_stuffer_init(&output, &state_blob));
         EXPECT_SUCCESS(s2n_tls12_serialize_resumption_state(conn, &output));
 
         uint8_t serial_id = 0;
@@ -292,7 +292,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(psk->secret.size, test_session_secret.size);
             EXPECT_BYTEARRAY_EQUAL(psk->secret.data, test_session_secret.data, test_session_secret.size);
 
-            EXPECT_EQUAL(psk->hmac_alg, S2N_HMAC_SHA384);
+            EXPECT_EQUAL(psk->hmac_alg, conn->secure.cipher_suite->prf_alg);
 
             EXPECT_EQUAL(psk->ticket_age_add, TICKET_AGE_ADD);
             EXPECT_EQUAL(psk->ticket_issue_time, ticket_issue_time);
@@ -311,10 +311,10 @@ int main(int argc, char **argv)
 
             uint8_t s_data[S2N_STATE_SIZE_IN_BYTES] = { 0 };
             struct s2n_blob state_blob = { 0 };
-            POSIX_GUARD(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
+            EXPECT_SUCCESS(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
             struct s2n_stuffer stuffer = { 0 };
 
-            POSIX_GUARD(s2n_stuffer_init(&stuffer, &state_blob));
+            EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &state_blob));
 
             EXPECT_OK(s2n_serialize_resumption_state(conn, NULL, &stuffer));
             EXPECT_OK(s2n_client_deserialize_session_state(conn, &stuffer));

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -14,14 +14,20 @@
  */
 
 #include "s2n_test.h"
-
+#include "tests/testlib/s2n_testlib.h"
 #include "tls/s2n_tls.h"
-#include "utils/s2n_safety.h"
 #include "tls/s2n_resume.h"
 /* To test static function */
 #include "tls/s2n_resume.c"
+#include "utils/s2n_safety.h"
 
 #define S2N_TLS13_STATE_SIZE_WITHOUT_SECRET S2N_MAX_STATE_SIZE_IN_BYTES - S2N_TLS_SECRET_LEN
+
+#define TICKET_ISSUE_TIME 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 
+#define TICKET_AGE_ADD 0x01, 0x01, 0x01, 0x01
+#define SECRET_LEN 0x02
+#define SECRET 0x03, 0x04
+#define CLIENT_TICKET 0x10, 0x10
 
 static int s2n_test_session_ticket_callback(struct s2n_connection *conn, struct s2n_session_ticket *ticket)
 {
@@ -158,6 +164,143 @@ int main(int argc, char **argv)
 
             ticket_fields.session_secret.size = UINT8_MAX + 1;
             EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(conn, &ticket_fields, &output), S2N_ERR_SAFETY);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    /* s2n_client_deserialize_session_state */
+    {
+        /* Deserialized ticket sets correct connection values for session resumption in TLS1.2 */
+        {
+            uint8_t tls12_ticket[S2N_STATE_SIZE_IN_BYTES] = {
+                S2N_TLS12_SERIALIZED_FORMAT_VERSION,
+                S2N_TLS12,
+                TLS_RSA_WITH_AES_128_GCM_SHA256,
+                TICKET_ISSUE_TIME,
+            };
+
+            struct s2n_blob ticket_blob = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, tls12_ticket, sizeof(tls12_ticket)));
+            struct s2n_stuffer ticket_stuffer = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_init(&ticket_stuffer, &ticket_blob));
+            EXPECT_SUCCESS(s2n_stuffer_skip_write(&ticket_stuffer, sizeof(tls12_ticket) - S2N_TLS_SECRET_LEN));
+            /* The secret needs to be written to the ticket separately as it has a fixed length */
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&ticket_stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
+
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+
+            EXPECT_OK(s2n_client_deserialize_session_state(conn, &ticket_stuffer));
+
+            EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS12);
+            EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_rsa_with_aes_128_gcm_sha256);
+
+            EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, conn->secure.master_secret, S2N_TLS_SECRET_LEN);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Deserialized ticket sets correct PSK values for session resumption in TLS1.3 */
+        {
+            uint8_t tls13_ticket[] = {
+                S2N_TLS13_SERIALIZED_FORMAT_VERSION,
+                S2N_TLS13,
+                TLS_AES_128_GCM_SHA256,
+                TICKET_ISSUE_TIME,
+                TICKET_AGE_ADD,
+                SECRET_LEN,
+                SECRET,
+            };
+
+            struct s2n_blob ticket_blob = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, tls13_ticket, sizeof(tls13_ticket)));
+            struct s2n_stuffer ticket_stuffer = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_init(&ticket_stuffer, &ticket_blob));
+            EXPECT_SUCCESS(s2n_stuffer_skip_write(&ticket_stuffer, sizeof(tls13_ticket)));
+
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+
+            /* Initialize client ticket */
+            uint8_t client_ticket[] = { CLIENT_TICKET };
+            EXPECT_SUCCESS(s2n_realloc(&conn->client_ticket, sizeof(client_ticket)));
+            EXPECT_MEMCPY_SUCCESS(conn->client_ticket.data, client_ticket, sizeof(client_ticket));
+
+            EXPECT_OK(s2n_client_deserialize_session_state(conn, &ticket_stuffer));
+
+            struct s2n_psk *psk = NULL;
+            EXPECT_OK(s2n_array_get(&conn->psk_params.psk_list, 0, (void**) &psk));
+            EXPECT_NOT_NULL(psk);
+
+            EXPECT_EQUAL(psk->type, S2N_PSK_TYPE_RESUMPTION);
+            S2N_BLOB_EXPECT_EQUAL(psk->identity, conn->client_ticket);
+
+            EXPECT_EQUAL(psk->secret.size, SECRET_LEN);
+            uint8_t secret[] = { SECRET };
+            EXPECT_BYTEARRAY_EQUAL(psk->secret.data, secret, sizeof(secret));
+
+            EXPECT_EQUAL(psk->hmac_alg, S2N_HMAC_SHA256);
+            
+            uint8_t ticket_age_add[] = { TICKET_AGE_ADD };
+            uint32_t expected_ticket_age_add = ticket_age_add[0] | (ticket_age_add[1] << 8) | \
+                                              (ticket_age_add[2] << 16) | (ticket_age_add[3] << 24);
+            EXPECT_EQUAL(psk->obfuscated_ticket_age, expected_ticket_age_add);
+
+            uint8_t ticket_issue_time[] = { TICKET_ISSUE_TIME };
+            struct s2n_blob ticket_issue_time_blob = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&ticket_issue_time_blob, ticket_issue_time, sizeof(ticket_issue_time)));
+            
+            struct s2n_stuffer ticket_issue_time_stuffer = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_init(&ticket_issue_time_stuffer, &ticket_issue_time_blob));
+            EXPECT_SUCCESS(s2n_stuffer_skip_write(&ticket_issue_time_stuffer, sizeof(ticket_issue_time)));
+            uint64_t expected_ticket_issue_time = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint64(&ticket_issue_time_stuffer, &expected_ticket_issue_time));
+            EXPECT_EQUAL(psk->ticket_issue_time, expected_ticket_issue_time);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Functional test: The TLS1.3 client can deserialize what it serializes */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+
+            conn->actual_protocol_version = S2N_TLS13;
+            conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
+            DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 0, .session_secret = test_session_secret };
+
+            /* Initialize client ticket */
+            uint8_t client_ticket[] = { CLIENT_TICKET };
+            EXPECT_SUCCESS(s2n_realloc(&conn->client_ticket, sizeof(client_ticket)));
+            EXPECT_MEMCPY_SUCCESS(conn->client_ticket.data, client_ticket, sizeof(client_ticket));
+
+            EXPECT_OK(s2n_serialize_resumption_state(conn, &ticket_fields, &stuffer));
+            EXPECT_OK(s2n_client_deserialize_session_state(conn, &stuffer));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Functional test: The TLS1.2 client can deserialize what it serializes */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+
+            conn->actual_protocol_version = S2N_TLS12;
+            conn->secure.cipher_suite = &s2n_rsa_with_aes_128_gcm_sha256;
+
+            uint8_t s_data[S2N_STATE_SIZE_IN_BYTES] = { 0 };
+            struct s2n_blob state_blob = { 0 };
+            POSIX_GUARD(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
+            struct s2n_stuffer stuffer = { 0 };
+
+            POSIX_GUARD(s2n_stuffer_init(&stuffer, &state_blob));
+
+            EXPECT_OK(s2n_serialize_resumption_state(conn, NULL, &stuffer));
+            EXPECT_OK(s2n_client_deserialize_session_state(conn, &stuffer));
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -30,7 +30,7 @@
 #define SECRET 0x03, 0x04
 #define CLIENT_TICKET 0x10, 0x10
 
-uint64_t ticket_issue_time = 283686952306183;
+const uint64_t ticket_issue_time = 283686952306183;
 static int s2n_test_session_ticket_callback(struct s2n_connection *conn, struct s2n_session_ticket *ticket)
 {
     return S2N_SUCCESS;

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -41,6 +41,7 @@ struct s2n_psk {
     struct s2n_blob secret;
     s2n_hmac_algorithm hmac_alg;
     uint32_t obfuscated_ticket_age;
+    uint64_t ticket_issue_time;
     struct s2n_blob early_secret;
     struct s2n_early_data_config early_data_config;
 };

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -40,7 +40,7 @@ struct s2n_psk {
     struct s2n_blob identity;
     struct s2n_blob secret;
     s2n_hmac_algorithm hmac_alg;
-    uint32_t obfuscated_ticket_age;
+    uint32_t ticket_age_add;
     uint64_t ticket_issue_time;
     struct s2n_blob early_secret;
     struct s2n_early_data_config early_data_config;

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -151,32 +151,90 @@ int s2n_client_serialize_resumption_state(struct s2n_connection *conn, struct s2
     return 0;
 }
 
-static int s2n_client_deserialize_session_state(struct s2n_connection *conn, struct s2n_stuffer *from)
-{
-    if (s2n_stuffer_data_available(from) < S2N_STATE_SIZE_IN_BYTES) {
-        POSIX_BAIL(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
-    }
+static S2N_RESULT s2n_tls12_client_deserialize_session_state(struct s2n_connection *conn, struct s2n_stuffer *from)
+{   
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(from);
 
-    uint8_t format;
-    uint64_t then;
+    RESULT_ENSURE(s2n_stuffer_data_available(from) == (S2N_STATE_SIZE_IN_BYTES - S2N_STATE_FORMAT_LEN), 
+        S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
 
-    POSIX_GUARD(s2n_stuffer_read_uint8(from, &format));
-    if (format != S2N_TLS12_SERIALIZED_FORMAT_VERSION) {
-        POSIX_BAIL(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
-    }
-
-    POSIX_GUARD(s2n_stuffer_read_uint8(from, &conn->actual_protocol_version));
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(from, &conn->actual_protocol_version));
 
     uint8_t *cipher_suite_wire = s2n_stuffer_raw_read(from, S2N_TLS_CIPHER_SUITE_LEN);
-    POSIX_ENSURE_REF(cipher_suite_wire);
-    POSIX_GUARD(s2n_set_cipher_as_client(conn, cipher_suite_wire));
+    RESULT_ENSURE_REF(cipher_suite_wire);
+    RESULT_GUARD_POSIX(s2n_set_cipher_as_client(conn, cipher_suite_wire));
 
-    POSIX_GUARD(s2n_stuffer_read_uint64(from, &then));
+    uint64_t then;
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint64(from, &then));
 
     /* Last but not least, put the master secret in place */
-    POSIX_GUARD(s2n_stuffer_read_bytes(from, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
+    RESULT_GUARD_POSIX(s2n_stuffer_read_bytes(from, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
 
-    return 0;
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_tls13_client_deserialize_session_state(struct s2n_connection *conn, struct s2n_stuffer *from)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(from);
+
+    uint8_t protocol_version = 0;
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(from, &protocol_version));
+    ENSURE_EQ(protocol_version, S2N_TLS13);
+
+    uint8_t iana_id[S2N_TLS_CIPHER_SUITE_LEN] = { 0 };
+    RESULT_GUARD_POSIX(s2n_stuffer_read_bytes(from, iana_id, S2N_TLS_CIPHER_SUITE_LEN));
+    struct s2n_cipher_suite *cipher_suite = NULL;
+    GUARD_RESULT(s2n_cipher_suite_from_iana(iana_id, &cipher_suite));
+    ENSURE_REF(cipher_suite);
+
+    uint64_t ticket_issue_time = 0;
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint64(from, &ticket_issue_time));
+
+    uint32_t ticket_age_add = 0;
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint32(from, &ticket_age_add));
+
+    uint8_t secret_len = 0;
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(from, &secret_len));
+    ENSURE_LTE(secret_len, S2N_TLS_SECRET_LEN);
+    
+    uint8_t secret[S2N_TLS_SECRET_LEN] = { 0 };
+    RESULT_GUARD_POSIX(s2n_stuffer_read_bytes(from, secret, secret_len));
+
+    /* Construct a PSK from ticket values */
+    struct s2n_psk *psk = NULL;
+    GUARD_RESULT(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &psk));
+    ENSURE_REF(psk);
+
+    GUARD_RESULT(s2n_psk_init(psk, S2N_PSK_TYPE_RESUMPTION));
+
+    RESULT_GUARD_POSIX(s2n_psk_set_identity(psk, conn->client_ticket.data, conn->client_ticket.size));
+    RESULT_GUARD_POSIX(s2n_psk_set_secret(psk, secret, secret_len));
+
+    psk->hmac_alg = cipher_suite->prf_alg;
+    psk->ticket_issue_time = ticket_issue_time;
+    psk->obfuscated_ticket_age = ticket_age_add;
+
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_client_deserialize_session_state(struct s2n_connection *conn, struct s2n_stuffer *from)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(from);
+
+    uint8_t format = 0;
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(from, &format));
+
+    if (format == S2N_TLS12_SERIALIZED_FORMAT_VERSION) {
+        RESULT_GUARD(s2n_tls12_client_deserialize_session_state(conn, from));
+    } else if (format == S2N_TLS13_SERIALIZED_FORMAT_VERSION) {
+        RESULT_GUARD(s2n_tls13_client_deserialize_session_state(conn, from));
+    } else {
+        RESULT_BAIL(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
+    }
+    return S2N_RESULT_OK;
 }
 
 static int s2n_client_deserialize_with_session_id(struct s2n_connection *conn, struct s2n_stuffer *from)
@@ -192,7 +250,7 @@ static int s2n_client_deserialize_with_session_id(struct s2n_connection *conn, s
     conn->session_id_len = session_id_len;
     POSIX_GUARD(s2n_stuffer_read_bytes(from, conn->session_id, session_id_len));
 
-    POSIX_GUARD(s2n_client_deserialize_session_state(conn, from));
+    POSIX_GUARD_RESULT(s2n_client_deserialize_session_state(conn, from));
 
     return 0;
 }
@@ -209,7 +267,7 @@ static int s2n_client_deserialize_with_session_ticket(struct s2n_connection *con
     POSIX_GUARD(s2n_realloc(&conn->client_ticket, session_ticket_len));
     POSIX_GUARD(s2n_stuffer_read(from, &conn->client_ticket));
 
-    POSIX_GUARD(s2n_client_deserialize_session_state(conn, from));
+    POSIX_GUARD_RESULT(s2n_client_deserialize_session_state(conn, from));
 
     return 0;
 }

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -223,7 +223,7 @@ S2N_RESULT s2n_tls13_server_nst_write(struct s2n_connection *conn, struct s2n_st
     RESULT_GUARD_POSIX(s2n_stuffer_reserve_uint24(output, &message_size));
 
     uint32_t ticket_lifetime_in_secs = 0;
-    GUARD_RESULT(s2n_generate_ticket_lifetime(conn, &ticket_lifetime_in_secs));
+    RESULT_GUARD(s2n_generate_ticket_lifetime(conn, &ticket_lifetime_in_secs));
     RESULT_GUARD_POSIX(s2n_stuffer_write_uint32(output, ticket_lifetime_in_secs));
 
     /* Get random data to use as ticket_age_add value */
@@ -236,15 +236,15 @@ S2N_RESULT s2n_tls13_server_nst_write(struct s2n_connection *conn, struct s2n_st
      *#  The server MUST generate a fresh value
      *#  for each ticket it sends.
      **/
-    GUARD_RESULT(s2n_get_private_random_data(&random_data));
-    GUARD_RESULT(s2n_generate_ticket_age_add(&random_data, &ticket_fields.ticket_age_add));
+    RESULT_GUARD(s2n_get_private_random_data(&random_data));
+    RESULT_GUARD(s2n_generate_ticket_age_add(&random_data, &ticket_fields.ticket_age_add));
     RESULT_GUARD_POSIX(s2n_stuffer_write_uint32(output, ticket_fields.ticket_age_add));
 
     /* Write ticket nonce */
     uint8_t nonce_data[sizeof(uint16_t)] = { 0 };
     struct s2n_blob nonce = { 0 };
     RESULT_GUARD_POSIX(s2n_blob_init(&nonce, nonce_data, sizeof(nonce_data)));
-    GUARD_RESULT(s2n_generate_ticket_nonce(conn->tickets_sent, &nonce));
+    RESULT_GUARD(s2n_generate_ticket_nonce(conn->tickets_sent, &nonce));
     RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(output, nonce.size));
     RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(output, nonce.data, nonce.size));
 


### PR DESCRIPTION
### Resolved issues:

 resolves #2495

### Description of changes: 

Adds TLS1.3 client deserialization method. Also rearranged some TLS1.2 client deserialization and added tests for it. 
### Call-outs:

I added a field called ticket_issue_time to the psk struct. This is because we want to dynamically generate the obfuscated ticket age when we send the psks, so we will need this value in the future. Also I renamed the psk obfuscated_ticket_age to ticket_age_add as we can always generate the obfuscated ticket age when we need it.

### Testing:
Unit tests/functional tests.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
