### PR TITLE
ci: disable go proxy

### DIFF
--- a/codebuild/bin/install_boringssl.sh
+++ b/codebuild/bin/install_boringssl.sh
@@ -29,6 +29,9 @@ INSTALL_DIR=$2
 source codebuild/bin/jobs.sh
 cd "$BUILD_DIR"
 
+# Disable go proxy.  see https://github.com/golang/go/issues/33985
+go env GOPRIVATE=*
+
 # BoringSSL doesn't have tags or versions in the Github repo.
 # This commit represents the latest version that S2N is compatible
 # with. It prevents our build system from breaking when BoringSSL


### PR DESCRIPTION
### Resolved issues:

insatll_boringssl fails in some environments.

### Description of changes: 

Disabling go's proxy allows the install to succeed.

### Call-outs:

Not super familiar with go flags/options, might not work everywhere.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? locally, might be helpful.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
