### PR TITLE
Add bitflag to enable early data

### DIFF
--- a/tests/unit/s2n_early_data_io_test.c
+++ b/tests/unit/s2n_early_data_io_test.c
@@ -73,6 +73,54 @@ int main(int argc, char **argv)
 
     /* Test s2n_negotiate with early data */
     {
+        /* Early data not supported by server */
+        {
+            struct s2n_connection *client_conn = NULL, *server_conn = NULL;
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+
+            EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
+            EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(client_conn));
+
+            EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+            EXPECT_FALSE(WITH_EARLY_DATA(client_conn));
+            EXPECT_FALSE(WITH_EARLY_DATA(server_conn));
+            EXPECT_FALSE(IS_FULL_HANDSHAKE(client_conn));
+            EXPECT_FALSE(IS_FULL_HANDSHAKE(server_conn));
+            EXPECT_FALSE(IS_HELLO_RETRY_HANDSHAKE(client_conn));
+            EXPECT_FALSE(IS_HELLO_RETRY_HANDSHAKE(server_conn));
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+
+        /* Early data not supported by client */
+        {
+            struct s2n_connection *client_conn = NULL, *server_conn = NULL;
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+
+            EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
+            EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(server_conn));
+
+            EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+            EXPECT_FALSE(WITH_EARLY_DATA(client_conn));
+            EXPECT_FALSE(WITH_EARLY_DATA(server_conn));
+            EXPECT_FALSE(IS_FULL_HANDSHAKE(client_conn));
+            EXPECT_FALSE(IS_FULL_HANDSHAKE(server_conn));
+            EXPECT_FALSE(IS_HELLO_RETRY_HANDSHAKE(client_conn));
+            EXPECT_FALSE(IS_HELLO_RETRY_HANDSHAKE(server_conn));
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        }
+
         /* Early data accepted */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
@@ -80,6 +128,8 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(client_conn));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(server_conn));
 
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
@@ -103,6 +153,8 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk_without_early_data));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(client_conn));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(server_conn));
 
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
@@ -126,6 +178,8 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(client_conn));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(server_conn));
             client_conn->security_policy_override = &retry_policy;
 
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
@@ -150,6 +204,8 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config_with_cert));
             EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config_with_cert));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(client_conn));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(server_conn));
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
 
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));

--- a/tests/unit/s2n_early_data_test.c
+++ b/tests/unit/s2n_early_data_test.c
@@ -531,21 +531,29 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn);
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
             EXPECT_OK(s2n_append_test_chosen_psk_with_early_data(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384));
-            conn->actual_protocol_version = S2N_TLS13;
             conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
 
+            /* Early data not enabled */
+            conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
+            conn->actual_protocol_version = S2N_TLS13;
+            EXPECT_OK(s2n_early_data_accept_or_reject(conn));
+            EXPECT_EQUAL(conn->early_data_state, S2N_EARLY_DATA_REJECTED);
+
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(conn));
+
+            /* Early data not requested */
             conn->early_data_state = S2N_EARLY_DATA_NOT_REQUESTED;
+            conn->actual_protocol_version = S2N_TLS13;
             EXPECT_OK(s2n_early_data_accept_or_reject(conn));
             EXPECT_EQUAL(conn->early_data_state, S2N_EARLY_DATA_NOT_REQUESTED);
 
-            conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
             /* Set wrong protocol version */
+            conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
             conn->actual_protocol_version = S2N_TLS12;
             EXPECT_OK(s2n_early_data_accept_or_reject(conn));
             EXPECT_EQUAL(conn->early_data_state, S2N_EARLY_DATA_REJECTED);
 
             conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
-            /* Set right protocol version */
             conn->actual_protocol_version = S2N_TLS13;
             EXPECT_OK(s2n_early_data_accept_or_reject(conn));
             EXPECT_EQUAL(conn->early_data_state, S2N_EARLY_DATA_ACCEPTED);
@@ -559,21 +567,29 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn);
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
             EXPECT_OK(s2n_append_test_chosen_psk_with_early_data(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384));
-            conn->actual_protocol_version = S2N_TLS13;
             conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
 
+            /* Early data not enabled */
+            conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
+            conn->actual_protocol_version = S2N_TLS13;
+            EXPECT_OK(s2n_early_data_accept_or_reject(conn));
+            EXPECT_EQUAL(conn->early_data_state, S2N_EARLY_DATA_REQUESTED);
+
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(conn));
+
+            /* Early data not requested */
             conn->early_data_state = S2N_EARLY_DATA_NOT_REQUESTED;
+            conn->actual_protocol_version = S2N_TLS13;
             EXPECT_OK(s2n_early_data_accept_or_reject(conn));
             EXPECT_EQUAL(conn->early_data_state, S2N_EARLY_DATA_NOT_REQUESTED);
 
-            conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
             /* Set wrong protocol version */
+            conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
             conn->actual_protocol_version = S2N_TLS12;
             EXPECT_OK(s2n_early_data_accept_or_reject(conn));
             EXPECT_EQUAL(conn->early_data_state, S2N_EARLY_DATA_REJECTED);
 
             conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
-            /* Set right protocol version */
             conn->actual_protocol_version = S2N_TLS13;
             EXPECT_OK(s2n_early_data_accept_or_reject(conn));
             EXPECT_EQUAL(conn->early_data_state, S2N_EARLY_DATA_REQUESTED);

--- a/tests/unit/s2n_handshake_partial_test.c
+++ b/tests/unit/s2n_handshake_partial_test.c
@@ -162,6 +162,8 @@ int main()
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(client_conn));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(server_conn));
 
             EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
                     END_OF_EARLY_DATA));

--- a/tests/unit/s2n_server_early_data_indication_test.c
+++ b/tests/unit/s2n_server_early_data_indication_test.c
@@ -141,11 +141,13 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn);
             EXPECT_OK(s2n_append_test_chosen_psk_with_early_data(client_conn, 0, expected_cipher_suite));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, security_policy));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(client_conn));
 
             struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
             EXPECT_NOT_NULL(server_conn);
             EXPECT_OK(s2n_append_test_chosen_psk_with_early_data(server_conn, 0, expected_cipher_suite));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, security_policy));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(server_conn));
 
             EXPECT_OK(s2n_exchange_hellos(client_conn, server_conn));
             EXPECT_EQUAL(client_conn->early_data_state, S2N_EARLY_DATA_NOT_REQUESTED);
@@ -179,11 +181,13 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn);
             EXPECT_OK(s2n_append_test_chosen_psk_with_early_data(client_conn, nonzero_max_early_data, expected_cipher_suite));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, security_policy));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(client_conn));
 
             struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
             EXPECT_NOT_NULL(server_conn);
             EXPECT_OK(s2n_append_test_chosen_psk_with_early_data(server_conn, nonzero_max_early_data, expected_cipher_suite));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, security_policy));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(server_conn));
 
             EXPECT_OK(s2n_exchange_hellos(client_conn, server_conn));
             EXPECT_EQUAL(client_conn->early_data_state, S2N_EARLY_DATA_REQUESTED);
@@ -213,11 +217,13 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn);
             EXPECT_OK(s2n_append_test_chosen_psk_with_early_data(client_conn, nonzero_max_early_data, expected_cipher_suite));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, security_policy));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(client_conn));
 
             struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
             EXPECT_NOT_NULL(server_conn);
             EXPECT_OK(s2n_append_test_chosen_psk_with_early_data(server_conn, 0, expected_cipher_suite));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, security_policy));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(server_conn));
 
             EXPECT_OK(s2n_exchange_hellos(client_conn, server_conn));
             EXPECT_EQUAL(client_conn->early_data_state, S2N_EARLY_DATA_REQUESTED);
@@ -250,11 +256,13 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn);
             EXPECT_OK(s2n_append_test_chosen_psk_with_early_data(client_conn, nonzero_max_early_data, expected_cipher_suite));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, security_policy));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(client_conn));
 
             struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
             EXPECT_NOT_NULL(server_conn);
             EXPECT_OK(s2n_append_test_chosen_psk_with_early_data(server_conn, nonzero_max_early_data, expected_cipher_suite));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, security_policy));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(server_conn));
 
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,

--- a/tests/unit/s2n_tls13_handshake_early_data_test.c
+++ b/tests/unit/s2n_tls13_handshake_early_data_test.c
@@ -577,6 +577,7 @@ int main()
             EXPECT_NOT_NULL(server_conn);
             EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(server_conn));
 
             DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
             psk->type = S2N_PSK_TYPE_RESUMPTION;

--- a/tls/extensions/s2n_client_early_data_indication.c
+++ b/tls/extensions/s2n_client_early_data_indication.c
@@ -72,6 +72,7 @@ static S2N_RESULT s2n_early_data_config_is_possible(struct s2n_connection *conn)
 static bool s2n_client_early_data_indication_should_send(struct s2n_connection *conn)
 {
     return s2n_result_is_ok(s2n_early_data_config_is_possible(conn))
+            && conn && conn->early_data_expected
             /**
              *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
              *# A client MUST NOT include the

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -319,6 +319,12 @@ struct s2n_connection {
     /* Key update data */
     unsigned key_update_pending:1;
 
+    /* Early data supported by caller.
+     * If a caller does not use any APIs that support early data,
+     * do not negotiate early data.
+     */
+    unsigned early_data_expected:1;
+
     /* Bitmap to represent preferred list of keyshare for client to generate and send keyshares in the ClientHello message.
      * The least significant bit (lsb), if set, indicates that the client must send an empty keyshare list.
      * Each bit value in the bitmap indiciates the corresponding curve in the ecc_preferences list for which a key share needs to be generated.

--- a/tls/s2n_early_data.h
+++ b/tls/s2n_early_data.h
@@ -54,3 +54,5 @@ int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data_si
         uint8_t cipher_suite_first_byte, uint8_t cipher_suite_second_byte);
 int s2n_psk_set_application_protocol(struct s2n_psk *psk, const uint8_t *application_protocol, uint8_t size);
 int s2n_psk_set_context(struct s2n_psk *psk, const uint8_t *context, uint16_t size);
+
+int s2n_connection_set_early_data_expected(struct s2n_connection *conn);


### PR DESCRIPTION
### Related issues:
https://github.com/aws/s2n-tls/issues/2570

### Description of changes: 

Early data should only be negotiated if the caller is prepared to handle the resulting ApplicationData. Otherwise, a server may agree to accept early data when the application has not actually implemented a mechanism to read early data. A client application would just send zero early data, which is not an error but is unnecessary.

### Testing:

Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
