### PR TITLE
Small Update for s2nc Command Line Options parsing

### DIFF
--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -51,8 +51,7 @@ void usage()
     fprintf(stderr, "  -c [version_string]\n");
     fprintf(stderr, "  --ciphers [version_string]\n");
     fprintf(stderr, "    Set the cipher preference version string. Defaults to \"default\". See USAGE-GUIDE.md\n");
-    fprintf(stderr, "  -e\n");
-    fprintf(stderr, "  --echo\n");
+    fprintf(stderr, "  -e,--echo\n");
     fprintf(stderr, "    Listen to stdin after TLS Connection is established and echo it to the Server\n");
     fprintf(stderr, "  -h,--help\n");
     fprintf(stderr, "    Display this message and quit.\n");
@@ -62,7 +61,7 @@ void usage()
     fprintf(stderr, "\n");
     fprintf(stderr, "  -s,--status\n");
     fprintf(stderr, "    Request the OCSP status of the remote server certificate\n");
-    fprintf(stderr, "  --mfl\n");
+    fprintf(stderr, "  -m,--mfl\n");
     fprintf(stderr, "    Request maximum fragment length from: 512, 1024, 2048, 4096\n");
     fprintf(stderr, "  -f,--ca-file [file path]\n");
     fprintf(stderr, "    Location of trust store CA file (PEM format). If neither -f or -d are specified. System defaults will be used.\n");
@@ -70,9 +69,9 @@ void usage()
     fprintf(stderr, "    Directory containing hashed trusted certs. If neither -f or -d are specified. System defaults will be used.\n");
     fprintf(stderr, "  -i,--insecure\n");
     fprintf(stderr, "    Turns off certification validation altogether.\n");
-    fprintf(stderr, "  --cert [file path]\n");
+    fprintf(stderr, "  -l,--cert [file path]\n");
     fprintf(stderr, "    Path to a PEM encoded certificate. Optional. Will only be used for client auth\n");
-    fprintf(stderr, "  --key [file path]\n");
+    fprintf(stderr, "  -k,--key [file path]\n");
     fprintf(stderr, "    Path to a PEM encoded private key that matches cert. Will only be used for client auth\n");
     fprintf(stderr, "  -r,--reconnect\n");
     fprintf(stderr, "    Drop and re-make the connection using Session ticket. If session ticket is disabled, then re-make the connection using Session-ID \n");
@@ -84,7 +83,7 @@ void usage()
     fprintf(stderr, "    Set dynamic record timeout threshold\n");
     fprintf(stderr, "  -C,--corked-io\n");
     fprintf(stderr, "    Turn on corked io\n");
-    fprintf(stderr, "  --non-blocking\n");
+    fprintf(stderr, "  -B,--non-blocking\n");
     fprintf(stderr, "    Set the non-blocking flag on the connection's socket.\n");
     fprintf(stderr, "  -K ,--keyshares\n");
     fprintf(stderr, "    Colon separated list of curve names.\n"
@@ -288,7 +287,7 @@ int main(int argc, char *const *argv)
 
     while (1) {
         int option_index = 0;
-        int c = getopt_long(argc, argv, "a:c:ehn:sf:d:l:k:D:t:irTCK:", long_options, &option_index);
+        int c = getopt_long(argc, argv, "a:c:ehn:m:sf:d:l:k:D:t:irTCK:BL:", long_options, &option_index);
         if (c == -1) {
             break;
         }


### PR DESCRIPTION
### Resolved issues:
I did not post an issue. Feel free to close this PR if the changes are undesirable.

### Description of changes: 

The help string, switch statement, and optstring were out of sync.

* Updated help string to be in sync with code.
* Updated opt string with missing options.

### Call-outs:
I did not yet check s2nd for the same issues. If these changes are wanted, I can go and do the same for s2nd.

### Testing:
Exercised the commandline options for s2nc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
