### PR TITLE
Add api to configure max early data for new tickets

### DIFF
--- a/tests/unit/s2n_early_data_test.c
+++ b/tests/unit/s2n_early_data_test.c
@@ -820,7 +820,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_get_max_early_data_size(conn, &actual_bytes));
             EXPECT_EQUAL(actual_bytes, psk_limit);
 
-            /* server limit is lower, but PSK is external: use PSK limit */
+            /* server limit is lower and PSK is resumption: use server limit */
             server_limit = psk_limit - 1;
             EXPECT_SUCCESS(s2n_connection_set_server_max_early_data_size(conn, server_limit));
             EXPECT_SUCCESS(s2n_connection_get_max_early_data_size(conn, &actual_bytes));

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -111,6 +111,8 @@ struct s2n_config {
 
     s2n_session_ticket_fn session_ticket_cb;
     void *session_ticket_ctx;
+
+    uint32_t server_max_early_data_size;
 };
 
 int s2n_config_defaults_init(void);

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -326,6 +326,9 @@ struct s2n_connection {
      */
     unsigned early_data_expected:1;
 
+    /* Connection overrides server_max_early_data_size */
+    unsigned server_max_early_data_size_overridden:1;
+
     /* Bitmap to represent preferred list of keyshare for client to generate and send keyshares in the ClientHello message.
      * The least significant bit (lsb), if set, indicates that the client must send an empty keyshare list.
      * Each bit value in the bitmap indiciates the corresponding curve in the ecc_preferences list for which a key share needs to be generated.
@@ -344,6 +347,7 @@ struct s2n_connection {
     uint16_t tickets_sent;
 
     s2n_early_data_state early_data_state;
+    uint32_t server_max_early_data_size;
 };
 
 int s2n_connection_is_managed_corked(const struct s2n_connection *s2n_connection);

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -322,6 +322,11 @@ int s2n_connection_get_max_early_data_size(struct s2n_connection *conn, uint32_t
     POSIX_ENSURE_REF(first_psk);
     *max_early_data_size = first_psk->early_data_config.max_early_data_size;
 
+    /* For the server, we should use the minimum of the limit retrieved from the ticket
+     * and the current limit being set for new tickets.
+     * This is defensive: even if more early data was previously allowed, the server may not be
+     * willing or able to handle that much early data now.
+     */
     if (conn->mode == S2N_SERVER && first_psk->type == S2N_PSK_TYPE_RESUMPTION) {
         uint32_t server_max_early_data_size = 0;
         POSIX_GUARD_RESULT(s2n_early_data_get_server_max_size(conn, &server_max_early_data_size));

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -324,8 +324,12 @@ int s2n_connection_get_max_early_data_size(struct s2n_connection *conn, uint32_t
 
     /* For the server, we should use the minimum of the limit retrieved from the ticket
      * and the current limit being set for new tickets.
+     *
      * This is defensive: even if more early data was previously allowed, the server may not be
      * willing or able to handle that much early data now.
+     *
+     * We don't do this for external PSKs because the server has intentionally set the limit
+     * while setting up this connection, not during a previous connection.
      */
     if (conn->mode == S2N_SERVER && first_psk->type == S2N_PSK_TYPE_RESUMPTION) {
         uint32_t server_max_early_data_size = 0;

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -130,6 +130,34 @@ S2N_RESULT s2n_early_data_accept_or_reject(struct s2n_connection *conn)
     return S2N_RESULT_OK;
 }
 
+int s2n_config_set_server_max_early_data_size(struct s2n_config *config, uint32_t max_early_data_size)
+{
+    POSIX_ENSURE_REF(config);
+    config->server_max_early_data_size = max_early_data_size;
+    return S2N_SUCCESS;
+}
+
+int s2n_connection_set_server_max_early_data_size(struct s2n_connection *conn, uint32_t max_early_data_size)
+{
+    POSIX_ENSURE_REF(conn);
+    conn->server_max_early_data_size = max_early_data_size;
+    conn->server_max_early_data_size_overridden = true;
+    return S2N_SUCCESS;
+}
+
+S2N_RESULT s2n_early_data_get_server_max_size(struct s2n_connection *conn, uint32_t *max_early_data_size)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(max_early_data_size);
+    if (conn->server_max_early_data_size_overridden) {
+        *max_early_data_size = conn->server_max_early_data_size;
+    } else {
+        RESULT_ENSURE_REF(conn->config);
+        *max_early_data_size = conn->config->server_max_early_data_size;
+    }
+    return S2N_RESULT_OK;
+}
+
 S2N_CLEANUP_RESULT s2n_early_data_config_free(struct s2n_early_data_config *config)
 {
     if (config == NULL) {

--- a/tls/s2n_early_data.h
+++ b/tls/s2n_early_data.h
@@ -48,7 +48,12 @@ S2N_RESULT s2n_early_data_config_clone(struct s2n_psk *new_psk, struct s2n_early
 bool s2n_early_data_is_valid_for_connection(struct s2n_connection *conn);
 S2N_RESULT s2n_early_data_accept_or_reject(struct s2n_connection *conn);
 
+S2N_RESULT s2n_early_data_get_server_max_size(struct s2n_connection *conn, uint32_t *max_early_data_size);
+
 /* Public Interface -- will be made visible and moved to s2n.h when the 0RTT feature is released */
+
+int s2n_config_set_server_max_early_data_size(struct s2n_config *config, uint32_t max_early_data_size);
+int s2n_connection_set_server_max_early_data_size(struct s2n_connection *conn, uint32_t max_early_data_size);
 
 int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data_size,
         uint8_t cipher_suite_first_byte, uint8_t cipher_suite_second_byte);


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/2571

### Description of changes: 

Add APIs to configure the max_early_data_size to be set on new tickets.

### Call-outs:

"_set_server_max_early_data" was the name suggested in the design review, but I'm not super happy with it. Other possibilities:
* _set_max_early_data_size_for_new_tickets
* _set_new_ticket_max_early_data_size
* _set_resumption_max_early_data_size

### Testing:

Basic unit tests

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
