### PR TITLE
Prepare s2n_config_set_psk_selection_callback to someday be async

### DIFF
--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -34,14 +34,23 @@ struct s2n_psk_test_case {
 
 uint16_t s2n_test_customer_wire_index_choice;
 static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn,
-        struct s2n_offered_psk_list *psk_identity_list, uint16_t *chosen_wire_index)
+        struct s2n_offered_psk_list *psk_identity_list)
 {
-    *chosen_wire_index = s2n_test_customer_wire_index_choice;
+    struct s2n_offered_psk offered_psk = { 0 };
+    uint16_t idx = 0;
+    while(s2n_offered_psk_list_has_next(psk_identity_list)) {
+        POSIX_GUARD(s2n_offered_psk_list_next(psk_identity_list, &offered_psk));
+        if (idx == s2n_test_customer_wire_index_choice) {
+            POSIX_GUARD(s2n_offered_psk_list_choose_psk(psk_identity_list, &offered_psk));
+            break;
+        }
+        idx++;
+    };
     return S2N_SUCCESS;
 }
 
 static int s2n_test_error_select_psk_identity_callback(struct s2n_connection *conn,
-        struct s2n_offered_psk_list *psk_identity_list, uint16_t *chosen_wire_index)
+        struct s2n_offered_psk_list *psk_identity_list)
 {
     POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);
 }
@@ -340,71 +349,6 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(conn));
             EXPECT_SUCCESS(s2n_stuffer_free(&out));
         }
-    }
-
-    /* Test: s2n_match_psk_identity */
-    {
-        struct s2n_psk_parameters params = { 0 };
-        EXPECT_OK(s2n_psk_parameters_init(&params));
-
-        struct s2n_array *known_psks = &params.psk_list;
-
-        struct s2n_blob wire_identity = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&wire_identity, test_identity, sizeof(test_identity)));
-
-        /* Safety checks */
-        {
-            struct s2n_psk *match = NULL;
-            EXPECT_ERROR_WITH_ERRNO(s2n_match_psk_identity(NULL, &wire_identity, &match), S2N_ERR_NULL);
-            EXPECT_ERROR_WITH_ERRNO(s2n_match_psk_identity(known_psks, NULL, &match), S2N_ERR_NULL);
-            EXPECT_ERROR_WITH_ERRNO(s2n_match_psk_identity(known_psks, &wire_identity, NULL), S2N_ERR_NULL);
-        }
-
-        /* Test: No known PSKs */
-        {
-            struct s2n_psk *match = NULL;
-            EXPECT_OK(s2n_match_psk_identity(known_psks, &wire_identity, &match));
-            EXPECT_NULL(match);
-        }
-
-        /* Test: No match exists */
-        {
-            struct s2n_psk *different_identity = NULL;
-            EXPECT_OK(s2n_array_pushback(known_psks, (void**) &different_identity));
-            EXPECT_OK(s2n_psk_init(different_identity, S2N_PSK_TYPE_EXTERNAL));
-            EXPECT_SUCCESS(s2n_psk_set_identity(different_identity, test_identity_2, sizeof(test_identity_2)));
-
-            struct s2n_psk *match = NULL;
-            EXPECT_OK(s2n_match_psk_identity(known_psks, &wire_identity, &match));
-            EXPECT_NULL(match);
-        }
-
-        struct s2n_psk *expected_match = NULL;
-
-        /* Test: Match exists */
-        {
-            EXPECT_OK(s2n_array_pushback(known_psks, (void**) &expected_match));
-            EXPECT_OK(s2n_psk_init(expected_match, S2N_PSK_TYPE_EXTERNAL));
-            EXPECT_SUCCESS(s2n_psk_set_identity(expected_match, test_identity, sizeof(test_identity)));
-
-            struct s2n_psk *match = NULL;
-            EXPECT_OK(s2n_match_psk_identity(known_psks, &wire_identity, &match));
-            EXPECT_EQUAL(match, expected_match);
-        }
-
-        /* Test: Multiple matches exist */
-        {
-            struct s2n_psk *another_match = NULL;
-            EXPECT_OK(s2n_array_pushback(known_psks, (void**) &another_match));
-            EXPECT_OK(s2n_psk_init(another_match, S2N_PSK_TYPE_EXTERNAL));
-            EXPECT_SUCCESS(s2n_psk_set_identity(another_match, test_identity, sizeof(test_identity)));
-
-            struct s2n_psk *match = NULL;
-            EXPECT_OK(s2n_match_psk_identity(known_psks, &wire_identity, &match));
-            EXPECT_EQUAL(match, expected_match);
-        }
-
-        EXPECT_OK(s2n_psk_parameters_wipe(&params));
     }
 
     /* Test: s2n_select_psk_identity */

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -24,10 +24,8 @@
 #include "tls/s2n_security_policies.h"
 #include "tls/s2n_tls13.h"
 
-static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn,
-        struct s2n_offered_psk_list *psk_identity_list, uint16_t *chosen_wire_index)
+static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn, struct s2n_offered_psk_list *psk_identity_list)
 {
-    *chosen_wire_index = 0;
     return S2N_SUCCESS;
 }
 

--- a/tests/unit/s2n_self_talk_psk_test.c
+++ b/tests/unit/s2n_self_talk_psk_test.c
@@ -126,10 +126,18 @@ static s2n_result validate_chosen_psk(struct s2n_connection *server_conn, uint8_
     return S2N_RESULT_OK;
 }
 
-static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn,
-        struct s2n_offered_psk_list *psk_identity_list, uint16_t *chosen_wire_index)
+static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn, struct s2n_offered_psk_list *psk_identity_list)
 {
-    *chosen_wire_index = TEST_SHARED_PSK_WIRE_INDEX_2;
+    struct s2n_offered_psk offered_psk = { 0 };
+    uint16_t idx = 0;
+    while(s2n_offered_psk_list_has_next(psk_identity_list)) {
+        POSIX_GUARD(s2n_offered_psk_list_next(psk_identity_list, &offered_psk));
+        if (idx == TEST_SHARED_PSK_WIRE_INDEX_2) {
+            POSIX_GUARD(s2n_offered_psk_list_choose_psk(psk_identity_list, &offered_psk));
+            break;
+        }
+        idx++;
+    };
     return S2N_SUCCESS;
 }
 

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -140,39 +140,6 @@ static int s2n_client_psk_send(struct s2n_connection *conn, struct s2n_stuffer *
     return S2N_SUCCESS;
 }
 
-/* Match a PSK identity received from the client against the server's known PSK identities.
- * This method compares a single client identity to all server identities.
- *
- * While both the client's offered identities and whether a match was found are public, we should make an attempt
- * to keep the server's known identities a secret. We will make comparisons to the server's identities constant
- * time (to hide partial matches) and not end the search early when a match is found (to hide the ordering).
- *
- * Keeping these comparisons constant time is not high priority. There's no known attack using these timings,
- * and an attacker could probably guess the server's known identities just by observing the public identities
- * sent by clients.
- */
-static S2N_RESULT s2n_match_psk_identity(struct s2n_array *known_psks, const struct s2n_blob *wire_identity,
-        struct s2n_psk **match)
-{
-    RESULT_ENSURE_REF(match);
-    RESULT_ENSURE_REF(wire_identity);
-    RESULT_ENSURE_REF(known_psks);
-    *match = NULL;
-    for (size_t i = 0; i < known_psks->len; i++) {
-        struct s2n_psk *psk = NULL;
-        RESULT_GUARD(s2n_array_get(known_psks, i, (void**)&psk));
-        RESULT_ENSURE_REF(psk);
-        RESULT_ENSURE_REF(psk->identity.data);
-        RESULT_ENSURE_REF(wire_identity->data);
-        uint32_t compare_size = MIN(wire_identity->size, psk->identity.size);
-        if (s2n_constant_time_equals(psk->identity.data, wire_identity->data, compare_size)
-            & (psk->identity.size == wire_identity->size) & (!*match)) {
-            *match = psk;
-        }
-    }
-    return S2N_RESULT_OK;
-}
-
 /* Find the first of the server's PSK identities that matches the client's identities.
  * This method compares all server identities to all client identities.
  *
@@ -200,7 +167,7 @@ static S2N_RESULT s2n_select_psk_identity(struct s2n_connection *conn, struct s2
         struct s2n_offered_psk client_psk = { 0 };
         uint16_t wire_index = 0;
 
-        RESULT_GUARD_POSIX(s2n_offered_psk_list_reset(client_identity_list));
+        RESULT_GUARD_POSIX(s2n_offered_psk_list_reread(client_identity_list));
         while(s2n_offered_psk_list_has_next(client_identity_list)) {
             RESULT_GUARD_POSIX(s2n_offered_psk_list_next(client_identity_list, &client_psk));
             uint16_t compare_size = MIN(client_psk.identity.size, server_psk->identity.size);
@@ -222,16 +189,13 @@ static S2N_RESULT s2n_client_psk_recv_identity_list(struct s2n_connection *conn,
     RESULT_ENSURE_REF(conn);
     RESULT_ENSURE_REF(wire_identities_in);
 
-    struct s2n_offered_psk_list identity_list = { .wire_data = *wire_identities_in };
+    struct s2n_offered_psk_list identity_list = {
+        .conn = conn,
+        .wire_data = *wire_identities_in,
+    };
 
     if (conn->config->psk_selection_cb) {
-        RESULT_GUARD_POSIX(conn->config->psk_selection_cb(conn, &identity_list, &conn->psk_params.chosen_psk_wire_index));
-
-        struct s2n_offered_psk chosen_identity = { 0 };
-        RESULT_GUARD(s2n_offered_psk_list_get_index(&identity_list, conn->psk_params.chosen_psk_wire_index,
-                &chosen_identity));
-
-        RESULT_GUARD(s2n_match_psk_identity(&conn->psk_params.psk_list, &chosen_identity.identity, &conn->psk_params.chosen_psk));
+        RESULT_GUARD_POSIX(conn->config->psk_selection_cb(conn, &identity_list));
     } else {
         RESULT_GUARD(s2n_select_psk_identity(conn, &identity_list));
     }

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -63,13 +63,14 @@ S2N_CLEANUP_RESULT s2n_psk_parameters_wipe_secrets(struct s2n_psk_parameters *pa
 
 struct s2n_offered_psk {
     struct s2n_blob identity;
+    uint16_t wire_index;
 };
 
 struct s2n_offered_psk_list {
+    struct s2n_connection *conn;
     struct s2n_stuffer wire_data;
+    uint16_t wire_index;
 };
-S2N_RESULT s2n_offered_psk_list_get_index(struct s2n_offered_psk_list *list, uint16_t psk_index,
-        struct s2n_offered_psk *offered_psk);
 
 S2N_RESULT s2n_finish_psk_extension(struct s2n_connection *conn);
 
@@ -104,9 +105,9 @@ int s2n_offered_psk_get_identity(struct s2n_offered_psk *psk, uint8_t** identity
 struct s2n_offered_psk_list;
 bool s2n_offered_psk_list_has_next(struct s2n_offered_psk_list *psk_list);
 int s2n_offered_psk_list_next(struct s2n_offered_psk_list *psk_list, struct s2n_offered_psk *psk);
-int s2n_offered_psk_list_reset(struct s2n_offered_psk_list *psk_list);
+int s2n_offered_psk_list_reread(struct s2n_offered_psk_list *psk_list);
+int s2n_offered_psk_list_choose_psk(struct s2n_offered_psk_list *psk_list, struct s2n_offered_psk *psk);
 
 typedef int (*s2n_psk_selection_callback)(struct s2n_connection *conn,
-                                          struct s2n_offered_psk_list *psk_list,
-                                          uint16_t *chosen_wire_index);
+                                          struct s2n_offered_psk_list *psk_list);
 int s2n_config_set_psk_selection_callback(struct s2n_config *config, s2n_psk_selection_callback cb);


### PR DESCRIPTION
### Description of changes: 

Let's see if I can explain this!

Currently, if we want to make `s2n_config_set_psk_selection_callback` asynchronous, it would need to follow the async pattern used by [session tickets](https://github.com/aws/s2n-tls/blob/main/api/s2n.h#L96). A customer's callback implementation would need to return a special "S2N_CALLBACK_BLOCKED" return value to mark the callback blocked. If `s2n_negotiate` was invoked again, it would invoke the callback again. Eventually during an execution of `s2n_negotiate`, the customer's implementation of the callback would not return "S2N_CALLBACK_BLOCKED", and the handshake would continue.

This model works. However, it requires a special return value and calls the callback repeatedly.

I prefer the model used by the [async pkey feature](https://github.com/aws/s2n-tls/blob/main/api/s2n.h#L544-L552). In that model, the callback is only invoked once. Before it is invoked, we sets a special "blocked" state on the connection and pass a structure to the customer. The customer interacts with that structure, without needing to call `s2n_negotiate` again. If `s2n_negotiate` is called, it can block very early and not redo any unnecessary work, because there is a "blocked" state for it to check. Eventually, the customer calls a method on the object to set the result of the operation and to indicate that they're done with it, unblocking the connection.

I think this is a much cleaner (and more extensible) approach to asynchronous operations, and we should probably mimic it on other APIs going forwards. The key is that the customer needs to be able to return the result of the asynchronous operation from outside of the callback itself. For that to be true, the callback CANNOT include any output arguments, like `s2n_psk_selection_callback`'s `chosen_wire_index`.

The changes I made: 
* Change the signature of s2n_psk_selection_callback to only operate on an opaque structure
* Rename `s2n_offered_psk_list_reset` to `s2n_offered_psk_list_reread`. I think this makes it clear that you're just reseting the list, not any chosen PSK.
* Move `s2n_match_psk_identity` from extensions/s2n_client_psk.c to s2n_psk.c. No changes were actually made to the method.
* Refactor the existing `s2n_match_psk_identity` tests into `s2n_offered_psk_list_choose_psk` tests. `s2n_offered_psk_list_choose_psk` is basically just a wrapper around `s2n_match_psk_identity`, so we don't need to test the static method separately anymore.
* Get rid of s2n_offered_psk_list_get_index. It's no longer needed.

### Call-outs:

Rather than making a `s2n_offered_psk_list_choose_psk` on the s2n_offered_psk_list, we could make a `s2n_connection_choose_offered_psk` on the connection. That would theoretically work just as well, even if the method was asynchronous. I prefer this organization because we're making the context of the method very clear by operating on the offered psk list directly.

### Testing:

Unit tests.

 Is this a refactor change? Yes. Existing tests pass; all I had to update was the test implementations of the callback.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
