### PR TITLE
Avoid SELinux execmem denial

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,9 @@ set(CMAKE_C_FLAGS_DEBUGOPT "")
 
 target_compile_options(${PROJECT_NAME} PRIVATE -pedantic -std=gnu99 -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts
         -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security
-        -Wno-missing-braces -fvisibility=hidden -DS2N_EXPORTS)
+        -Wno-missing-braces -fvisibility=hidden -DS2N_EXPORTS
+        -Wa,--noexecstack # make assembler output compatible with SELinux
+)
 
 if(S2N_NO_PQ)
     target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_NO_PQ)


### PR DESCRIPTION
Trying to run binaries linked with [aws-crt-cpp](https://github.com/awslabs/aws-crt-cpp) are currently blocked by SELinux on e.g. Debian 9.2:
```
type=AVC msg=audit(1615809428.519:809): avc:  denied  { execmem }
```
The program linked to the SDK shows it requires an executable stack:
```
$ execstack -q program
X program
```

This is because s2n-tls code compiled from assembly files does not get marked as not needing an executable stack which happens automatically for C code.

This PR adds the `--noexecstack` assembler flag to mark the code not needing executable  stack.

After this change `execstack` shows the program not requiring executable stack and SELinux doesn't block the execution of the program.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
