### PR TITLE
Compare s2nc libcrypto to S2N_LIBCRYPTO

### DIFF
--- a/codebuild/bin/install_awslc.sh
+++ b/codebuild/bin/install_awslc.sh
@@ -28,12 +28,14 @@ BUILD_DIR=$1
 INSTALL_DIR=$2
 source codebuild/bin/jobs.sh
 
-cd "$BUILD_DIR"
-git clone https://github.com/awslabs/aws-lc.git
-mkdir build
-cd build
+# Disable go proxy.  see https://github.com/golang/go/issues/33985
+go env -w GOPRIVATE="*"
 
-cmake ../aws-lc -GNinja -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
+cd "$BUILD_DIR"
+git clone --depth 1 https://github.com/awslabs/aws-lc.git
+cd aws-lc
+cmake . -Bbuild -GNinja -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
+cd build
 ninja -j "${JOBS}" install
 
 popd

--- a/codebuild/bin/s2n_override_paths.sh
+++ b/codebuild/bin/s2n_override_paths.sh
@@ -15,7 +15,11 @@
 set -ex
 
 # Add all of our test dependencies to the PATH. Use Openssl 1.1.1 so the latest openssl is used for s_client
-# integration tests.
+# and clang in integration and fuzz tests.
 export PATH=$PYTHON_INSTALL_DIR/bin:$OPENSSL_1_1_1_INSTALL_DIR/bin:$GNUTLS_INSTALL_DIR/bin:$SAW_INSTALL_DIR/bin:$Z3_INSTALL_DIR/bin:$SCAN_BUILD_INSTALL_DIR/bin:$PRLIMIT_INSTALL_DIR/bin:$LATEST_CLANG_INSTALL_DIR/bin:`pwd`/codebuild/bin:~/.local/bin:$PATH
+
+# Needed for integration tests so openssl from the path above will work.
+# Note that LIBCRYPTO_ROOT is also being appended in the integration tests (both are needed);
+# e.g. https://github.com/aws/s2n-tls/blob/main/tests/integration/Makefile#L51
 export LD_LIBRARY_PATH=$OPENSSL_1_1_1_INSTALL_DIR/lib:$LD_LIBRARY_PATH; 
 export DYLD_LIBRARY_PATH=$OPENSSL_1_1_1_INSTALL_DIR/lib:$LD_LIBRARY_PATH;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,9 +13,10 @@
 # permissions and limitations under the License.
 #
 
+# BoringSSL/AWS-lc does not have an `openssl version` command.
 OPENSSL_VERSION=$(shell $(LIBCRYPTO_ROOT)/bin/openssl version 2> /dev/null || echo 1)
 ifeq (${OPENSSL_VERSION}, 1)
-	COMPILE_INFO=Compiled with the missing version of openssl
+	COMPILE_INFO=Unable to find openssl version - or LIBCRYPTO_ROOT is pointing at BoringSSL/AWS-lc
 else
 	COMPILE_INFO=Compiled with ${OPENSSL_VERSION}.
 endif

--- a/tests/integration/s2n_tls13_handshake_tests.py
+++ b/tests/integration/s2n_tls13_handshake_tests.py
@@ -24,7 +24,7 @@ import uuid
 
 from common.s2n_test_common import wait_for_output
 from common.s2n_test_openssl import run_openssl_connection_test
-from common.s2n_test_scenario import get_scenarios, Mode, Cipher, Version, Curve
+from common.s2n_test_scenario import get_scenarios, Mode, Cipher, Version, Curve, get_libcrypto_match
 from common.s2n_test_reporting import Result, Status
 import common.s2n_test_common as util
 import time
@@ -121,7 +121,12 @@ def main():
     port = args.port
 
     failed = 0
-
+    libcrypto_matches, libcrypto_msg = get_libcrypto_match()
+    if libcrypto_matches:
+        print("\n\ts2nc libcrypto matches S2N_LIBCRYPTO")
+    else:
+        print("\tPossible mismatch of LibCrypto: \n\t%s" % libcrypto_msg)
+        failed+=1
     print("\n\tRunning TLS1.3 handshake tests with openssl: %s" % os.popen('openssl version').read())
     failed += run_openssl_connection_test(get_scenarios(host, port, versions=[Version.TLS13], s2n_modes=Mode.all(), ciphers=Cipher.all()))
     print("\n\tRunning TLS1.3 HRR tests with openssl: %s" % os.popen('openssl version').read())


### PR DESCRIPTION
### Resolved issues:

Not seeing one.

### Description of changes:

Our CI can use a few different LibCrypto libraries based on the env variable S2N_LIBCRYPTO.  In some cases , our test client/server executables are linked against a different libcrypto than we expect.

Compare the libcrypto linked to s2nc with S2N_LIBCRYPTO and output a warning if they don't match.

### Call-outs:

If not using OpenSSL and the name of the library is not in the path, this check will be a false negative (which is why we're not failing the test).

The AWS-LC install script suffers from the same `go proxy` issues as in #2677 ; added a line to disable it.

Added some comments to the s2n_override_paths scripts about the need for both openssl111 and S2N_LIBCRYPTO to be in the path/LD_LIBRARY_PATH at the same time.

### Testing:

#### Happy path with awslc
s2n built with S2N_LIBCRYPTO=awslc make
```
s2n-dev@16600b99da90:/s2n/tests/integration$ S2N_LIBCRYPTO=awslc LD_LIBRARY_PATH=/s2n/test-deps/awslc/lib make tls13
( \
DYLD_LIBRARY_PATH="../../lib/:../testlib/:/lib:$DYLD_LIBRARY_PATH" \
LD_LIBRARY_PATH="../../lib/:../testlib/:/lib:$LD_LIBRARY_PATH" \
S2N_INTEG_TEST=1 \
python3 s2n_tls13_handshake_tests.py 127.0.0.1 8888; \
)

        s2nc libcrypto matches S2N_LIBCRYPTO

        Running TLS1.3 handshake tests with openssl: OpenSSL 1.1.1  11 Sep 2018

```

#### Incorrectly setting LD_LIBRARY_PATH causes linker to choose OS Libcrypto

```
s2n-dev@16600b99da90:/s2n/tests/integration$ S2N_LIBCRYPTO=awslc LD_LIBRARY_PATH=/dev/null make tls13
( \
DYLD_LIBRARY_PATH="../../lib/:../testlib/:/lib:$DYLD_LIBRARY_PATH" \
LD_LIBRARY_PATH="../../lib/:../testlib/:/lib:$LD_LIBRARY_PATH" \
S2N_INTEG_TEST=1 \
python3 s2n_tls13_handshake_tests.py 127.0.0.1 8888; \
)
        Possible mismatch of LibCrypto:
                ../../bin/s2nc libcrypto uncertain; expected: awslc
                 found: /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
