### PR TITLE
Centralize and correct ">= S2N_TLS13" checks for extensions

### DIFF
--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -572,7 +572,7 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_enable_tls13());
             server_conn->actual_protocol_version = S2N_TLS12;
-            EXPECT_SUCCESS(s2n_client_key_share_extension.recv(server_conn, &key_share_extension));
+            EXPECT_SUCCESS(s2n_extension_recv(&s2n_client_key_share_extension, server_conn, &key_share_extension));
             EXPECT_EQUAL(s2n_stuffer_data_available(&key_share_extension), key_share_extension_size);
 
             EXPECT_SUCCESS(s2n_enable_tls13());

--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -132,10 +132,13 @@ int main(int argc, char **argv)
 
         EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &psk));
 
+        /* If send is called with a NULL stuffer, it will fail.
+         * So a failure indicates that send was called.
+         */
         conn->actual_protocol_version = S2N_TLS12;
-        EXPECT_FALSE(s2n_client_psk_extension.should_send(conn));
+        EXPECT_SUCCESS(s2n_extension_send(&s2n_client_psk_extension, conn, NULL));
         conn->actual_protocol_version = S2N_TLS13;
-        EXPECT_TRUE(s2n_client_psk_extension.should_send(conn));
+        EXPECT_FAILURE(s2n_extension_send(&s2n_client_psk_extension, conn, NULL));
 
         /* Only send the extension after a retry if at least one PSK matches the cipher suite */
         {
@@ -926,7 +929,7 @@ int main(int argc, char **argv)
 
             /* Should be a no-op if using TLS1.2 */
             conn->actual_protocol_version = S2N_TLS12;
-            EXPECT_SUCCESS(s2n_client_psk_recv(conn, &extension));
+            EXPECT_SUCCESS(s2n_extension_recv(&s2n_client_psk_extension, conn, &extension));
             EXPECT_NULL(conn->psk_params.chosen_psk);
             EXPECT_EQUAL(s2n_stuffer_data_available(&extension), sizeof(extension_data));
 

--- a/tests/unit/s2n_extension_type_test.c
+++ b/tests/unit/s2n_extension_type_test.c
@@ -14,6 +14,7 @@
  */
 
 #include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
 
 #include "tls/extensions/s2n_extension_type.h"
 #include "utils/s2n_bitmap.h"
@@ -375,6 +376,113 @@ int main()
             S2N_CBIT_SET(conn.extension_requests_sent, test_extension_id);
             EXPECT_FAILURE_WITH_ERRNO(s2n_extension_is_missing(&extension_type_with_error_if_missing, &conn),
                     S2N_ERR_MISSING_EXTENSION);
+        }
+    }
+
+    {
+        EXPECT_SUCCESS(s2n_reset_tls13());
+
+        /* Functional test: minimum-TLS1.3 extensions only used for TLS1.3 */
+        {
+            struct s2n_cert_chain_and_key *cert_chain = NULL;
+            EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&cert_chain,
+                    S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
+            EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all"));
+
+            uint16_t key_shares_id = s2n_extension_iana_value_to_id(TLS_EXTENSION_KEY_SHARE);
+
+            /* Both TLS1.3 */
+            {
+                struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+                EXPECT_NOT_NULL(client_conn);
+                EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+                struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+                EXPECT_NOT_NULL(server_conn);
+                EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+                struct s2n_test_io_pair io_pair = { 0 };
+                EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+                EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+                /* All expected CLIENT_HELLO extensions sent and received */
+                EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, SERVER_HELLO));
+                EXPECT_TRUE(S2N_CBIT_TEST(client_conn->extension_requests_sent, key_shares_id));
+                EXPECT_TRUE(S2N_CBIT_TEST(server_conn->extension_requests_received, key_shares_id));
+
+                /* All expected SERVER_HELLO extensions sent and received */
+                EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, ENCRYPTED_EXTENSIONS));
+                EXPECT_TRUE(S2N_CBIT_TEST(client_conn->extension_requests_received, key_shares_id));
+                EXPECT_TRUE(S2N_CBIT_TEST(server_conn->extension_requests_sent, key_shares_id));
+
+                EXPECT_SUCCESS(s2n_connection_free(client_conn));
+                EXPECT_SUCCESS(s2n_connection_free(server_conn));
+            }
+
+            /* Client TLS1.2 */
+            {
+                struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+                EXPECT_NOT_NULL(client_conn);
+                EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+                EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "test_all_tls12"));
+
+                struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+                EXPECT_NOT_NULL(server_conn);
+                EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+                struct s2n_test_io_pair io_pair = { 0 };
+                EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+                EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+                /* No expected CLIENT_HELLO extensions sent and received */
+                EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, SERVER_HELLO));
+                EXPECT_FALSE(S2N_CBIT_TEST(client_conn->extension_requests_sent, key_shares_id));
+                EXPECT_FALSE(S2N_CBIT_TEST(server_conn->extension_requests_received, key_shares_id));
+
+                /* No expected SERVER_HELLO extensions sent and received */
+                EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, ENCRYPTED_EXTENSIONS));
+                EXPECT_FALSE(S2N_CBIT_TEST(client_conn->extension_requests_received, key_shares_id));
+                EXPECT_FALSE(S2N_CBIT_TEST(server_conn->extension_requests_sent, key_shares_id));
+
+                EXPECT_SUCCESS(s2n_connection_free(client_conn));
+                EXPECT_SUCCESS(s2n_connection_free(server_conn));
+            }
+
+            /* Server TLS1.2 */
+            {
+                struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+                EXPECT_NOT_NULL(client_conn);
+                EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+                struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+                EXPECT_NOT_NULL(server_conn);
+                EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+                EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "test_all_tls12"));
+
+                struct s2n_test_io_pair io_pair = { 0 };
+                EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+                EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+                /* Expected CLIENT_HELLO extensions sent, but not received */
+                EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, SERVER_HELLO));
+                EXPECT_TRUE(S2N_CBIT_TEST(client_conn->extension_requests_sent, key_shares_id));
+                EXPECT_FALSE(S2N_CBIT_TEST(server_conn->extension_requests_received, key_shares_id));
+
+                /* No expected SERVER_HELLO extensions sent and received */
+                EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, ENCRYPTED_EXTENSIONS));
+                EXPECT_FALSE(S2N_CBIT_TEST(client_conn->extension_requests_received, key_shares_id));
+                EXPECT_FALSE(S2N_CBIT_TEST(server_conn->extension_requests_sent, key_shares_id));
+
+                EXPECT_SUCCESS(s2n_connection_free(client_conn));
+                EXPECT_SUCCESS(s2n_connection_free(server_conn));
+            }
+
+            EXPECT_SUCCESS(s2n_config_free(config));
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(cert_chain));
         }
     }
 

--- a/tests/unit/s2n_psk_key_exchange_modes_extension_test.c
+++ b/tests/unit/s2n_psk_key_exchange_modes_extension_test.c
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_write_uint8(&out, PSK_KEY_EXCHANGE_MODE_SIZE));
             EXPECT_SUCCESS(s2n_stuffer_write_uint8(&out, TLS_PSK_DHE_KE_MODE));
 
-            EXPECT_SUCCESS(s2n_psk_key_exchange_modes_extension.recv(conn, &out));
+            EXPECT_SUCCESS(s2n_extension_recv(&s2n_psk_key_exchange_modes_extension, conn, &out));
             EXPECT_EQUAL(conn->psk_params.psk_ke_mode, S2N_PSK_KE_UNKNOWN);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -293,7 +293,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[0]));
 
                 client_conn->actual_protocol_version = S2N_TLS12;
-                EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &extension_stuffer));
+                EXPECT_SUCCESS(s2n_extension_recv(&s2n_server_key_share_extension, client_conn, &extension_stuffer));
                 EXPECT_NULL(client_conn->secure.server_ecc_evp_params.negotiated_curve);
                 EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&extension_stuffer), 0);
 

--- a/tests/unit/s2n_server_psk_extension_test.c
+++ b/tests/unit/s2n_server_psk_extension_test.c
@@ -88,22 +88,22 @@ int main(int argc, char **argv)
 
         EXPECT_FALSE(s2n_server_psk_extension.should_send(NULL));
 
-        conn->actual_protocol_version = S2N_TLS12;
-        EXPECT_FALSE(s2n_server_psk_extension.should_send(conn));
-        conn->actual_protocol_version = S2N_TLS13;
-        EXPECT_FALSE(s2n_server_psk_extension.should_send(conn));
-
         EXPECT_OK(s2n_array_pushback(&conn->psk_params.psk_list, (void**) &psk));
-
-        conn->actual_protocol_version = S2N_TLS12;
-        EXPECT_FALSE(s2n_server_psk_extension.should_send(conn));
-        conn->actual_protocol_version = S2N_TLS13;
         EXPECT_FALSE(s2n_server_psk_extension.should_send(conn));
 
         conn->psk_params.chosen_psk_wire_index = 0;
         EXPECT_OK(s2n_array_get(&conn->psk_params.psk_list, conn->psk_params.chosen_psk_wire_index,
                                 (void **)&conn->psk_params.chosen_psk));
         EXPECT_TRUE(s2n_server_psk_extension.should_send(conn));
+
+        /* If send is called with a NULL stuffer, it will fail.
+         * So a failure indicates that send was called.
+         */
+        EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
+        conn->actual_protocol_version = S2N_TLS12;
+        EXPECT_SUCCESS(s2n_extension_send(&s2n_server_psk_extension, conn, NULL));
+        conn->actual_protocol_version = S2N_TLS13;
+        EXPECT_FAILURE(s2n_extension_send(&s2n_server_psk_extension, conn, NULL));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
@@ -158,7 +158,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_write_uint16(&out, chosen_psk_wire_index));
 
             EXPECT_NULL(conn->psk_params.chosen_psk);
-            EXPECT_SUCCESS(s2n_server_psk_extension.recv(conn, &out));
+            EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
+            EXPECT_SUCCESS(s2n_extension_recv(&s2n_server_psk_extension, conn, &out));
             EXPECT_NULL(conn->psk_params.chosen_psk);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(s2n_is_valid_tls13_cipher(s2n_tls13_chacha20_poly1305_sha256.iana_value));
     }
 
-    /* Server does not parse TLS 1.3 extensions unless TLS 1.3 enabled */
+    /* Server does not parse TLS 1.3 extensions unless TLS 1.3 negotiated */
     {
         s2n_extension_type_list *tls13_server_hello_extensions = NULL;
         EXPECT_SUCCESS(s2n_extension_type_list_get(S2N_EXTENSION_LIST_SERVER_HELLO_TLS13, &tls13_server_hello_extensions));
@@ -162,14 +162,14 @@ int main(int argc, char **argv)
             parsed_extension->extension = extension_data.blob;
             parsed_extension->extension_type = tls13_extension_type->iana_value;
 
-            server_conn->server_protocol_version = S2N_TLS12;
+            server_conn->actual_protocol_version = S2N_TLS12;
             EXPECT_SUCCESS(s2n_extension_process(tls13_extension_type, server_conn, &parsed_extension_list));
 
             /* Create parsed extension again, because s2n_extension_process cleared the last one */
             parsed_extension->extension = extension_data.blob;
             parsed_extension->extension_type = tls13_extension_type->iana_value;
 
-            server_conn->server_protocol_version = S2N_TLS13;
+            server_conn->actual_protocol_version = S2N_TLS13;
             EXPECT_FAILURE(s2n_extension_process(tls13_extension_type, server_conn, &parsed_extension_list));
         }
 

--- a/tls/extensions/s2n_client_early_data_indication.c
+++ b/tls/extensions/s2n_client_early_data_indication.c
@@ -43,10 +43,6 @@ static S2N_RESULT s2n_setup_middlebox_compat_for_early_data(struct s2n_connectio
 {
     RESULT_ENSURE_REF(conn);
 
-    if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
-        return S2N_RESULT_OK;
-    }
-
     if (s2n_is_middlebox_compat_enabled(conn)) {
         RESULT_GUARD(s2n_handshake_type_set_tls13_flag(conn, MIDDLEBOX_COMPAT));
         RESULT_GUARD(s2n_handshake_type_set_tls13_flag(conn, EARLY_CLIENT_CCS));

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -54,10 +54,11 @@ static int s2n_client_key_share_recv(struct s2n_connection *conn, struct s2n_stu
 
 const s2n_extension_type s2n_client_key_share_extension = {
     .iana_value = TLS_EXTENSION_KEY_SHARE,
+    .minimum_version = S2N_TLS13,
     .is_response = false,
     .send = s2n_client_key_share_send,
     .recv = s2n_client_key_share_recv,
-    .should_send = s2n_extension_send_if_tls13_connection,
+    .should_send = s2n_extension_always_send,
     .if_missing = s2n_extension_noop_if_missing,
 };
 
@@ -415,10 +416,6 @@ static int s2n_client_key_share_recv_pq_hybrid(struct s2n_connection *conn, stru
 static int s2n_client_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension) {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(extension);
-
-    if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
-        return S2N_SUCCESS;
-    }
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
     POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -34,6 +34,7 @@ static int s2n_client_psk_is_missing(struct s2n_connection *conn);
 
 const s2n_extension_type s2n_client_psk_extension = {
     .iana_value = TLS_EXTENSION_PRE_SHARED_KEY,
+    .minimum_version = S2N_TLS13,
     .is_response = false,
     .send = s2n_client_psk_send,
     .recv = s2n_client_psk_recv,
@@ -61,10 +62,6 @@ int s2n_client_psk_is_missing(struct s2n_connection *conn)
 bool s2n_client_psk_should_send(struct s2n_connection *conn)
 {
     if (conn == NULL) {
-        return false;
-    }
-
-    if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
         return false;
     }
 
@@ -318,10 +315,6 @@ static S2N_RESULT s2n_client_psk_recv_binders(struct s2n_connection *conn, struc
 int s2n_client_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     POSIX_ENSURE_REF(conn);
-
-    if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
-        return S2N_SUCCESS;
-    }
 
     /**
      *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11

--- a/tls/extensions/s2n_cookie.c
+++ b/tls/extensions/s2n_cookie.c
@@ -36,6 +36,7 @@ static int s2n_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *exte
 
 const s2n_extension_type s2n_server_cookie_extension = {
     .iana_value = TLS_EXTENSION_COOKIE,
+    .minimum_version = S2N_TLS13,
     .is_response = false,
     .send = s2n_cookie_send,
     .recv = s2n_cookie_recv,

--- a/tls/extensions/s2n_cookie.c
+++ b/tls/extensions/s2n_cookie.c
@@ -22,6 +22,7 @@
 
 const s2n_extension_type s2n_client_cookie_extension = {
     .iana_value = TLS_EXTENSION_COOKIE,
+    .minimum_version = S2N_TLS13,
     .is_response = true,
     .send = s2n_extension_send_noop,
     .recv = s2n_extension_recv_noop,
@@ -44,8 +45,7 @@ const s2n_extension_type s2n_server_cookie_extension = {
 
 static bool s2n_cookie_should_send(struct s2n_connection *conn)
 {
-    return s2n_extension_send_if_tls13_connection(conn)
-            && conn && s2n_stuffer_data_available(&conn->cookie_stuffer) > 0;
+    return conn && s2n_stuffer_data_available(&conn->cookie_stuffer) > 0;
 }
 
 static int s2n_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out)
@@ -60,9 +60,6 @@ static int s2n_cookie_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 static int s2n_cookie_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     POSIX_ENSURE_REF(conn);
-    if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
-        return S2N_SUCCESS;
-    }
 
     uint16_t cookie_len;
     POSIX_GUARD(s2n_stuffer_read_uint16(extension, &cookie_len));

--- a/tls/extensions/s2n_extension_type.h
+++ b/tls/extensions/s2n_extension_type.h
@@ -35,6 +35,7 @@ struct s2n_connection;
 typedef struct {
     uint16_t iana_value;
     unsigned is_response:1;
+    uint16_t minimum_version;
 
     int (*send) (struct s2n_connection *conn, struct s2n_stuffer *out);
     int (*recv) (struct s2n_connection *conn, struct s2n_stuffer *in);

--- a/tls/extensions/s2n_psk_key_exchange_modes.c
+++ b/tls/extensions/s2n_psk_key_exchange_modes.c
@@ -28,6 +28,7 @@ static int s2n_psk_key_exchange_modes_recv(struct s2n_connection *conn, struct s
 
 const s2n_extension_type s2n_psk_key_exchange_modes_extension = {
     .iana_value = TLS_EXTENSION_PSK_KEY_EXCHANGE_MODES,
+    .minimum_version = S2N_TLS13,
     .is_response = false,
     .send = s2n_psk_key_exchange_modes_send,
     .recv = s2n_psk_key_exchange_modes_recv,
@@ -56,10 +57,6 @@ static int s2n_psk_key_exchange_modes_send(struct s2n_connection *conn, struct s
 static int s2n_psk_key_exchange_modes_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     POSIX_ENSURE_REF(conn);
-
-    if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
-        return S2N_SUCCESS;
-    }
 
     uint8_t psk_ke_mode_list_len;
     POSIX_GUARD(s2n_stuffer_read_uint8(extension, &psk_ke_mode_list_len));

--- a/tls/extensions/s2n_quic_transport_params.c
+++ b/tls/extensions/s2n_quic_transport_params.c
@@ -69,6 +69,7 @@ static int s2n_quic_transport_params_recv(struct s2n_connection *conn, struct s2
 
 const s2n_extension_type s2n_quic_transport_parameters_extension = {
     .iana_value = TLS_QUIC_TRANSPORT_PARAMETERS,
+    .minimum_version = S2N_TLS13,
     .is_response = false,
     .send = s2n_quic_transport_params_send,
     .recv = s2n_quic_transport_params_recv,

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -27,10 +27,11 @@ static int s2n_server_key_share_recv(struct s2n_connection *conn, struct s2n_stu
 
 const s2n_extension_type s2n_server_key_share_extension = {
     .iana_value = TLS_EXTENSION_KEY_SHARE,
+    .minimum_version = S2N_TLS13,
     .is_response = false,
     .send = s2n_server_key_share_send,
     .recv = s2n_server_key_share_recv,
-    .should_send = s2n_extension_send_if_tls13_connection,
+    .should_send = s2n_extension_always_send,
     .if_missing = s2n_extension_noop_if_missing,
 };
 
@@ -286,10 +287,6 @@ static int s2n_server_key_share_recv_ecc(struct s2n_connection *conn, uint16_t n
  */
 static int s2n_server_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
-        return S2N_SUCCESS;
-    }
-
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(extension);
 

--- a/tls/extensions/s2n_server_psk.c
+++ b/tls/extensions/s2n_server_psk.c
@@ -28,6 +28,7 @@ static int s2n_server_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *
 
 const s2n_extension_type s2n_server_psk_extension = {
     .iana_value = TLS_EXTENSION_PRE_SHARED_KEY,
+    .minimum_version = S2N_TLS13,
     .is_response = true,
     .send = s2n_server_psk_send,
     .recv = s2n_server_psk_recv,
@@ -38,8 +39,7 @@ const s2n_extension_type s2n_server_psk_extension = {
 static bool s2n_server_psk_should_send(struct s2n_connection *conn)
 {
     /* Only send a server pre_shared_key extension if a chosen PSK is set on the connection */
-    return conn && s2n_connection_get_protocol_version(conn) >= S2N_TLS13
-            && conn->psk_params.chosen_psk;
+    return conn->psk_params.chosen_psk;
 }
 
 static int s2n_server_psk_send(struct s2n_connection *conn, struct s2n_stuffer *out)
@@ -55,10 +55,6 @@ static int s2n_server_psk_send(struct s2n_connection *conn, struct s2n_stuffer *
 static int s2n_server_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     POSIX_ENSURE_REF(conn);
-
-    if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
-        return S2N_SUCCESS;
-    }
 
     /* Currently in s2n, only (EC)DHE key exchange mode is supported.
      * Any other mode selected by the server is invalid because it was not offered by the client.

--- a/tls/extensions/s2n_server_psk.c
+++ b/tls/extensions/s2n_server_psk.c
@@ -39,7 +39,7 @@ const s2n_extension_type s2n_server_psk_extension = {
 static bool s2n_server_psk_should_send(struct s2n_connection *conn)
 {
     /* Only send a server pre_shared_key extension if a chosen PSK is set on the connection */
-    return conn->psk_params.chosen_psk;
+    return conn && conn->psk_params.chosen_psk;
 }
 
 static int s2n_server_psk_send(struct s2n_connection *conn, struct s2n_stuffer *out)


### PR DESCRIPTION
### Description of changes: 

We have "protocol version >= S2N_TLS13" checks spread across the extensions. Let's put them in one place to make it easier to do them right.

This also corrects a problem where we were using s2n_connection_get_protocol_version, which falls back to conn->server_protocol_version on the server if conn->actual_protocol_version isn't set. That's wrong, because it leads to tls1.3-enabled servers parsing tls1.3 extensions even when negotiating tls1.2: In tls1.2, actual_protocol_version isn't set until AFTER the client extensions are processed.

### Call-outs:

The first commit in this PR ("Resolve conflict between 516a99e and abed2a3") is also in a separate PR: https://github.com/aws/s2n-tls/pull/2698

### Testing:

Unit tests.
* Is this a refactor change? Yes. Instead of removing the individual extension .recv and .should_send implementation tests, I just switched them to testing s2n_extension_recv and s2n_extension_send instead, which hit the new code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
