### PR TITLE
Don't allow non-post handshake messages to be received post handshake

### DIFF
--- a/tests/unit/s2n_early_data_io_test.c
+++ b/tests/unit/s2n_early_data_io_test.c
@@ -531,9 +531,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
 
-        /* s2n_recv fails if it encounters a handshake message instead of early data.
-         * Because of the restriction that we only read early data on the EndOfEarlyData state,
-         * we could only encounter the EndOfEarlyData message. */
+        /* s2n_recv fails if it encounters a handshake message instead of early data. */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
             EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
@@ -545,12 +543,19 @@ int main(int argc, char **argv)
 
             s2n_blocked_status blocked = S2N_NOT_BLOCKED;
             uint8_t test_buffer[TEST_MAX_EARLY_DATA_SIZE] = { 0 };
-
             EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
                     END_OF_EARLY_DATA));
+
+            /* Client sends the EndOfEarlyData handshake message */
             EXPECT_SUCCESS(s2n_connection_set_end_of_early_data(client_conn));
             EXPECT_SUCCESS(s2n_negotiate(client_conn, &blocked));
 
+            /* Server fails to read the EndOfEarlyData handshake message via s2n_recv.
+             * s2n_recv can only process post-handshake messages, and EndOfEarlyData is not a post-handshake
+             * message.
+             * We should have read the EndOfEarlyData handshake message via s2n_negotiate.
+             */
+            EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), END_OF_EARLY_DATA);
             EXPECT_FAILURE_WITH_ERRNO(s2n_recv(server_conn, test_buffer, sizeof(test_buffer), &blocked),
                     S2N_ERR_BAD_MESSAGE);
 

--- a/tests/unit/s2n_post_handshake_test.c
+++ b/tests/unit/s2n_post_handshake_test.c
@@ -25,6 +25,11 @@
 #include "tls/s2n_post_handshake.h"
 #include "utils/s2n_safety.h"
 
+/* Include to get access to the handshake state machine
+ * to verify we don't allow its messages post-handshake.
+ */
+#include "tls/s2n_handshake_io.c"
+
 #define KEY_UPDATE_MESSAGE_SIZE sizeof(uint8_t) + /* message id */  \
                                 SIZEOF_UINT24   + /* message len */ \
                                 sizeof(uint8_t)   /* message */
@@ -131,6 +136,47 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
+
+        /* No non-post handshake messages can be received.
+         * This means that no handshake message that appears in the handshake state machine
+         * should be allowed.
+         */
+        {
+            /* For TLS1.2 */
+            for (size_t i = 0; i < s2n_array_len(state_machine); i++) {
+                if (state_machine[i].record_type != TLS_HANDSHAKE) {
+                    break;
+                }
+
+                struct s2n_connection *conn;
+                EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+                conn->actual_protocol_version = S2N_TLS13;
+
+                EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->in, state_machine[i].message_type));
+                EXPECT_SUCCESS(s2n_stuffer_write_uint24(&conn->in, 0));
+                EXPECT_FAILURE_WITH_ERRNO(s2n_post_handshake_recv(conn), S2N_ERR_BAD_MESSAGE);
+
+                EXPECT_SUCCESS(s2n_connection_free(conn));
+            }
+
+            /* For TLS1.3 */
+            for (size_t i = 0; i < s2n_array_len(tls13_state_machine); i++) {
+                if (tls13_state_machine[i].record_type != TLS_HANDSHAKE) {
+                    break;
+                }
+
+                struct s2n_connection *conn;
+                EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+                conn->actual_protocol_version = S2N_TLS13;
+
+                EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->in, tls13_state_machine[i].message_type));
+                EXPECT_SUCCESS(s2n_stuffer_write_uint24(&conn->in, 0));
+                EXPECT_FAILURE_WITH_ERRNO(s2n_post_handshake_recv(conn), S2N_ERR_BAD_MESSAGE);
+
+                EXPECT_SUCCESS(s2n_connection_free(conn));
+            }
+        }
+
     }
 
     /* post_handshake_send */

--- a/tls/s2n_post_handshake.c
+++ b/tls/s2n_post_handshake.c
@@ -49,6 +49,22 @@ int s2n_post_handshake_recv(struct s2n_connection *conn)
             case TLS_SERVER_NEW_SESSION_TICKET:
                 POSIX_GUARD_RESULT(s2n_tls13_server_nst_recv(conn, &post_handshake_stuffer));
                 break;
+            case TLS_HELLO_REQUEST:
+            case TLS_CLIENT_HELLO:
+            case TLS_SERVER_HELLO:
+            case TLS_END_OF_EARLY_DATA:
+            case TLS_ENCRYPTED_EXTENSIONS:
+            case TLS_CERTIFICATE:
+            case TLS_SERVER_KEY:
+            case TLS_CERT_REQ:
+            case TLS_SERVER_HELLO_DONE:
+            case TLS_CERT_VERIFY:
+            case TLS_CLIENT_KEY:
+            case TLS_FINISHED:
+            case TLS_SERVER_CERT_STATUS:
+                /* All other known handshake messages should be rejected */
+                POSIX_BAIL(S2N_ERR_BAD_MESSAGE);
+                break;
             default:
                 /* Ignore all other messages */
                 break;


### PR DESCRIPTION
### Description of changes: 

Currently, S2N ignores any handshake message encountered post-handshake that isn't one of the known post-handshake messages. However, we should really only be ignoring completely unknown messages: if we know a message shouldn't be received post-handshake, that is an error.

### Testing:

Unit tests. I made sure I covered all handshake messages by iterating over the state machine states.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
