### PR TITLE
Add context to PSK selection callback

### DIFF
--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -140,21 +140,22 @@ int main(int argc, char **argv)
     {
         struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
-
-        /* Safety checks */
-        {
-            EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_psk_selection_callback(NULL, s2n_test_select_psk_identity_callback,
-                    NULL), S2N_ERR_NULL);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_psk_selection_callback(config, NULL, NULL), S2N_ERR_NULL);
-        }
-
         uint8_t context = 13;
 
+        /* Safety check */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_psk_selection_callback(
+                NULL, s2n_test_select_psk_identity_callback, &context), S2N_ERR_NULL);
         EXPECT_NULL(config->psk_selection_cb);
         EXPECT_NULL(config->psk_selection_ctx);
+
         EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(config, s2n_test_select_psk_identity_callback, &context));
         EXPECT_EQUAL(config->psk_selection_cb, s2n_test_select_psk_identity_callback);
         EXPECT_EQUAL(config->psk_selection_ctx, &context);
+
+        EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(config, NULL, NULL));
+        EXPECT_NULL(config->psk_selection_cb);
+        EXPECT_NULL(config->psk_selection_ctx);
+
         EXPECT_SUCCESS(s2n_config_free(config));
     }
 

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -25,7 +25,8 @@
 #include "tls/s2n_security_policies.h"
 #include "tls/s2n_tls13.h"
 
-static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn, struct s2n_offered_psk_list *psk_identity_list)
+static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn, void *context,
+        struct s2n_offered_psk_list *psk_identity_list)
 {
     return S2N_SUCCESS;
 }
@@ -142,13 +143,18 @@ int main(int argc, char **argv)
 
         /* Safety checks */
         {
-            EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_psk_selection_callback(NULL, s2n_test_select_psk_identity_callback), S2N_ERR_NULL);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_psk_selection_callback(config, NULL), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_psk_selection_callback(NULL, s2n_test_select_psk_identity_callback,
+                    NULL), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_psk_selection_callback(config, NULL, NULL), S2N_ERR_NULL);
         }
 
+        uint8_t context = 13;
+
         EXPECT_NULL(config->psk_selection_cb);
-        EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(config, s2n_test_select_psk_identity_callback));
+        EXPECT_NULL(config->psk_selection_ctx);
+        EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(config, s2n_test_select_psk_identity_callback, &context));
         EXPECT_EQUAL(config->psk_selection_cb, s2n_test_select_psk_identity_callback);
+        EXPECT_EQUAL(config->psk_selection_ctx, &context);
         EXPECT_SUCCESS(s2n_config_free(config));
     }
 

--- a/tests/unit/s2n_self_talk_psk_test.c
+++ b/tests/unit/s2n_self_talk_psk_test.c
@@ -126,7 +126,8 @@ static s2n_result validate_chosen_psk(struct s2n_connection *server_conn, uint8_
     return S2N_RESULT_OK;
 }
 
-static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn, struct s2n_offered_psk_list *psk_identity_list)
+static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn, void *context,
+        struct s2n_offered_psk_list *psk_identity_list)
 {
     struct s2n_offered_psk offered_psk = { 0 };
     uint16_t idx = 0;
@@ -206,7 +207,7 @@ int main(int argc, char **argv)
         EXPECT_OK(setup_server_psks(server_conn));
 
         /* Set the customer callback to select PSK identity */ 
-        EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(server_conn->config, s2n_test_select_psk_identity_callback));
+        EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(server_conn->config, s2n_test_select_psk_identity_callback, NULL));
         EXPECT_EQUAL(server_conn->config->psk_selection_cb, s2n_test_select_psk_identity_callback);
 
         /* Negotiate handshake */

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -184,6 +184,7 @@ static S2N_RESULT s2n_select_psk_identity(struct s2n_connection *conn, struct s2
 static S2N_RESULT s2n_client_psk_recv_identity_list(struct s2n_connection *conn, struct s2n_stuffer *wire_identities_in)
 {
     RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn->config);
     RESULT_ENSURE_REF(wire_identities_in);
 
     struct s2n_offered_psk_list identity_list = {
@@ -192,7 +193,7 @@ static S2N_RESULT s2n_client_psk_recv_identity_list(struct s2n_connection *conn,
     };
 
     if (conn->config->psk_selection_cb) {
-        RESULT_GUARD_POSIX(conn->config->psk_selection_cb(conn, &identity_list));
+        RESULT_GUARD_POSIX(conn->config->psk_selection_cb(conn, conn->config->psk_selection_ctx, &identity_list));
     } else {
         RESULT_GUARD(s2n_select_psk_identity(conn, &identity_list));
     }

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -846,11 +846,12 @@ int s2n_config_enable_cert_req_dss_legacy_compat(struct s2n_config *config)
     return S2N_SUCCESS;
 }
 
-int s2n_config_set_psk_selection_callback(struct s2n_config *config, s2n_psk_selection_callback cb)
+int s2n_config_set_psk_selection_callback(struct s2n_config *config, s2n_psk_selection_callback cb, void *context)
 {
     POSIX_ENSURE_REF(config);
     POSIX_ENSURE_REF(cb);
     config->psk_selection_cb = cb;
+    config->psk_selection_ctx = context;
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -849,7 +849,6 @@ int s2n_config_enable_cert_req_dss_legacy_compat(struct s2n_config *config)
 int s2n_config_set_psk_selection_callback(struct s2n_config *config, s2n_psk_selection_callback cb, void *context)
 {
     POSIX_ENSURE_REF(config);
-    POSIX_ENSURE_REF(cb);
     config->psk_selection_cb = cb;
     config->psk_selection_ctx = context;
     return S2N_SUCCESS;

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -106,7 +106,9 @@ struct s2n_config {
     uint16_t max_verify_cert_chain_depth;
 
     s2n_async_pkey_fn async_pkey_cb;
+
     s2n_psk_selection_callback psk_selection_cb;
+    void *psk_selection_ctx;
 
     s2n_key_log_fn key_log_cb;
     void *key_log_ctx;

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -115,6 +115,6 @@ int s2n_offered_psk_list_next(struct s2n_offered_psk_list *psk_list, struct s2n_
 int s2n_offered_psk_list_reread(struct s2n_offered_psk_list *psk_list);
 int s2n_offered_psk_list_choose_psk(struct s2n_offered_psk_list *psk_list, struct s2n_offered_psk *psk);
 
-typedef int (*s2n_psk_selection_callback)(struct s2n_connection *conn,
+typedef int (*s2n_psk_selection_callback)(struct s2n_connection *conn, void *context,
                                           struct s2n_offered_psk_list *psk_list);
-int s2n_config_set_psk_selection_callback(struct s2n_config *config, s2n_psk_selection_callback cb);
+int s2n_config_set_psk_selection_callback(struct s2n_config *config, s2n_psk_selection_callback cb, void *context);


### PR DESCRIPTION
### Resolved issues:

https://github.com/aws/s2n-tls/pull/2689#pullrequestreview-626579369

### Description of changes: 

Add a context argument to `s2n_config_set_psk_selection_callback`. This lets customers pass custom information to the callback. This is required for S2N callbacks.

### Testing:

Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
