### PR TITLE
Remove hidden symbols requirements from the s2nc/s2nd test applications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,18 @@ target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURR
 
 target_include_directories(${PROJECT_NAME} PRIVATE $<TARGET_PROPERTY:LibCrypto::Crypto,INTERFACE_INCLUDE_DIRECTORIES>)
 
+add_executable(s2nc "bin/s2nc.c" "bin/echo.c" "bin/https.c" "bin/common.c")
+target_link_libraries(s2nc ${PROJECT_NAME})
+target_include_directories(s2nc PRIVATE $<TARGET_PROPERTY:LibCrypto::Crypto,INTERFACE_INCLUDE_DIRECTORIES>)
+target_include_directories(s2nc PRIVATE api)
+target_compile_options(s2nc PRIVATE -std=gnu99 -D_POSIX_C_SOURCE=200112L)
+
+add_executable(s2nd "bin/s2nd.c" "bin/echo.c" "bin/https.c" "bin/common.c")
+target_link_libraries(s2nd ${PROJECT_NAME})
+target_include_directories(s2nd PRIVATE $<TARGET_PROPERTY:LibCrypto::Crypto,INTERFACE_INCLUDE_DIRECTORIES>)
+target_include_directories(s2nd PRIVATE api)
+target_compile_options(s2nd PRIVATE -std=gnu99 -D_POSIX_C_SOURCE=200112L)
+
 include(CTest)
 if (BUILD_TESTING)
     enable_testing()
@@ -294,17 +306,6 @@ if (BUILD_TESTING)
 
     endforeach(test_case)
 
-    add_executable(s2nc "bin/s2nc.c" "bin/echo.c" "bin/https.c" "bin/common.c")
-    target_link_libraries(s2nc ${PROJECT_NAME})
-    target_include_directories(s2nc PRIVATE $<TARGET_PROPERTY:LibCrypto::Crypto,INTERFACE_INCLUDE_DIRECTORIES>)
-    target_include_directories(s2nc PRIVATE api)
-    target_compile_options(s2nc PRIVATE -std=gnu99 -D_POSIX_C_SOURCE=200112L)
-
-    add_executable(s2nd "bin/s2nd.c" "bin/echo.c" "bin/https.c" "bin/common.c")
-    target_link_libraries(s2nd ${PROJECT_NAME})
-    target_include_directories(s2nd PRIVATE $<TARGET_PROPERTY:LibCrypto::Crypto,INTERFACE_INCLUDE_DIRECTORIES>)
-    target_include_directories(s2nd PRIVATE api)
-    target_compile_options(s2nd PRIVATE -std=gnu99 -D_POSIX_C_SOURCE=200112L)
 
     if(BENCHMARK)
         find_package(benchmark REQUIRED)

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -612,6 +612,9 @@ extern int s2n_config_set_key_log_cb(struct s2n_config *config, s2n_key_log_fn c
 S2N_API
 extern int s2n_config_enable_cert_req_dss_legacy_compat(struct s2n_config *config);
 
+S2N_API
+extern int s2n_connection_set_keyshare_by_name_for_testing(struct s2n_connection *conn, const char* curve_name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -74,9 +74,8 @@ int negotiate(struct s2n_connection *conn, int fd)
     s2n_blocked_status blocked;
     while (s2n_negotiate(conn, &blocked) != S2N_SUCCESS) {
         if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
-            fprintf(stderr, "Failed to negotiate: '%s'. %s\n",
-                    s2n_strerror(s2n_errno, "EN"),
-                    s2n_strerror_debug(s2n_errno, "EN"));
+            fprintf(stderr, "Failed to negotiate: '%s'.\n",
+                    s2n_strerror(s2n_errno, "EN"));
             fprintf(stderr, "Alert: %d\n",
                     s2n_connection_get_alert(conn));
             S2N_ERROR_PRESERVE_ERRNO();
@@ -95,19 +94,19 @@ int negotiate(struct s2n_connection *conn, int fd)
 
     if ((client_hello_version = s2n_connection_get_client_hello_version(conn)) < 0) {
         fprintf(stderr, "Could not get client hello version\n");
-        POSIX_BAIL(S2N_ERR_CLIENT_HELLO_VERSION);
+        return S2N_FAILURE;
     }
     if ((client_protocol_version = s2n_connection_get_client_protocol_version(conn)) < 0) {
         fprintf(stderr, "Could not get client protocol version\n");
-        POSIX_BAIL(S2N_ERR_CLIENT_PROTOCOL_VERSION);
+        return S2N_FAILURE;
     }
     if ((server_protocol_version = s2n_connection_get_server_protocol_version(conn)) < 0) {
         fprintf(stderr, "Could not get server protocol version\n");
-        POSIX_BAIL(S2N_ERR_SERVER_PROTOCOL_VERSION);
+        return S2N_FAILURE;
     }
     if ((actual_protocol_version = s2n_connection_get_actual_protocol_version(conn)) < 0) {
         fprintf(stderr, "Could not get actual protocol version\n");
-        POSIX_BAIL(S2N_ERR_ACTUAL_PROTOCOL_VERSION);
+        return S2N_FAILURE;
     }
     printf("CONNECTED:\n");
     printf("Client hello version: %d\n", client_hello_version);
@@ -254,14 +253,14 @@ int echo(struct s2n_connection *conn, int sockfd)
                         (readers[0].revents & POLLERR ) ? 1 : 0,
                         (readers[0].revents & POLLHUP ) ? 1 : 0,
                         (readers[0].revents & POLLNVAL ) ? 1 : 0);
-                POSIX_BAIL(S2N_ERR_POLLING_FROM_SOCKET);
+                return S2N_FAILURE;
             }
 
             if (readers[1].revents & (POLLERR | POLLNVAL)) {
                 fprintf(stderr, "Error polling from socket: err=%d nval=%d\n",
                         (readers[1].revents & POLLERR ) ? 1 : 0,
                         (readers[1].revents & POLLNVAL ) ? 1 : 0);
-                POSIX_BAIL(S2N_ERR_POLLING_FROM_SOCKET);
+                return S2N_FAILURE;
             }
         }
     } while (p < 0 && errno == EINTR);

--- a/bin/https.c
+++ b/bin/https.c
@@ -25,11 +25,11 @@ static char str_buffer[STRING_LEN];
 static s2n_blocked_status blocked;
 
 struct buffer {
-    char buf[STRING_LEN];
+    uint8_t buf[STRING_LEN];
     uint16_t index;
 };
 
-struct buffer response_buffer = { };
+struct buffer response_buffer;
 
 #define SEND(...) do { \
     sprintf(str_buffer, __VA_ARGS__); \


### PR DESCRIPTION
### Resolved issues:

Fixes #2671
Fixes #2401

### Description of changes: 

The s2nc and s2nd applications rely on internal s2n functions to build. This is ok when linking statically. However, when shared libraries are built s2nc and s2nd fail to link and break the build system. This happens because symbols have a visibility of "hidden" by default.

By removing the use of internal symbols the applications build and link correctly.

### Call-outs:

We lose error code specificity with this change. We also have to introduce a testing api call.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
