### PR TITLE
Fix for failing resume test

### DIFF
--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -318,6 +318,11 @@ int main(int argc, char **argv)
             struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
             EXPECT_NOT_NULL(conn);
 
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_NOT_NULL(config);
+            EXPECT_SUCCESS(s2n_config_set_wall_clock(config, mock_time, NULL));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
             /* Initialize client ticket */
             uint8_t client_ticket[] = { CLIENT_TICKET };
             EXPECT_SUCCESS(s2n_realloc(&conn->client_ticket, sizeof(client_ticket)));
@@ -333,6 +338,7 @@ int main(int argc, char **argv)
             EXPECT_ERROR_WITH_ERRNO(s2n_client_deserialize_session_state(conn, &ticket_stuffer), S2N_ERR_PSK_MODE);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
         }
 
         /* Functional test: The TLS1.3 client can deserialize what it serializes */


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Lindsay and I both added separate validation checks to the same function around the same time, and when these merged it caused an issue. This pr fixes the failing test.
### Call-outs:

### Testing:
Tests now pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
