### PR TITLE
Safeguard linker flags on Apple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,9 @@ target_compile_options(${PROJECT_NAME} PRIVATE -pedantic -std=gnu99 -Wall -Werro
         -Wa,--noexecstack
 )
 
-set(CMAKE_SHARED_LINKER_FLAGS -Wl,-z,noexecstack,-z,relro,-z,now)
+if(NOT APPLE)
+    set(CMAKE_SHARED_LINKER_FLAGS -Wl,-z,noexecstack,-z,relro,-z,now)
+endif()
 
 if(S2N_NO_PQ)
     target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_NO_PQ)


### PR DESCRIPTION
### Resolved issues:

Related to #2707

### Description of changes: 

Only apply the noexecstack linker flags on non-Apple systems as they are GCC specific. Otherwise you will get the following failure:

```
[202/203] Linking C shared library lib/libs2n.dylib
FAILED: lib/libs2n.dylib 
: && /Users/runner/miniforge3/conda-bld/s2n_1617685018927/_build_env/bin/x86_64-apple-darwin13.4.0-clang -march=core2 -mtune=haswell -mssse3 -ftree-vectorize -fPIC -fPIE -fstack-protector-strong -O2 -pipe -isystem /Users/runner/miniforge3/conda-bld/s2n_1617685018927/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place/include -fdebug-prefix-map=/Users/runner/miniforge3/conda-bld/s2n_1617685018927/work=/usr/local/src/conda/s2n-1.0.4 -fdebug-prefix-map=/Users/runner/miniforge3/conda-bld/s2n_1617685018927/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place=/usr/local/src/conda-prefix -O3 -DNDEBUG -isysroot /Applications/Xcode_12.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -mmacosx-version-min=10.9 -dynamiclib -Wl,-headerpad_max_install_names -Wl,-z,noexecstack,-z,relro,-z,now -o lib/libs2n.dylib -install_name @rpath/libs2n.dylib CMakeFiles/s2n.dir/crypto/s2n_aead_cipher_aes_gcm.c.o CMakeFiles/s2n.dir/crypto/s2n_aead_cipher_chacha20_poly1305.c.o CMakeFiles/s2n.dir/crypto/s2n_cbc_cipher_3des.c.o CMakeFiles/s2n.dir/crypto/s2n_cbc_cipher_aes.c.o CMakeFiles/s2n.dir/crypto/s2n_certificate.c.o CMakeFiles/s2n.dir/crypto/s2n_cipher.c.o CMakeFiles/s2n.dir/crypto/s2n_composite_cipher_aes_sha.c.o CMakeFiles/s2n.dir/crypto/s2n_crypto.c.o CMakeFiles/s2n.dir/crypto/s2n_dhe.c.o CMakeFiles/s2n.dir/crypto/s2n_drbg.c.o CMakeFiles/s2n.dir/crypto/s2n_ecc_evp.c.o CMakeFiles/s2n.dir/crypto/s2n_ecdsa.c.o CMakeFiles/s2n.dir/crypto/s2n_evp.c.o CMakeFiles/s2n.dir/crypto/s2n_fips.c.o CMakeFiles/s2n.dir/crypto/s2n_hash.c.o CMakeFiles/s2n.dir/crypto/s2n_hkdf.c.o CMakeFiles/s2n.dir/crypto/s2n_hmac.c.o CMakeFiles/s2n.dir/crypto/s2n_openssl_x509.c.o CMakeFiles/s2n.dir/crypto/s2n_pkey.c.o CMakeFiles/s2n.dir/crypto/s2n_rsa.c.o CMakeFiles/s2n.dir/crypto/s2n_rsa_pss.c.o CMakeFiles/s2n.dir/crypto/s2n_rsa_signing.c.o CMakeFiles/s2n.dir/crypto/s2n_sequence.c.o CMakeFiles/s2n.dir/crypto/s2n_stream_cipher_null.c.o CMakeFiles/s2n.dir/crypto/s2n_stream_cipher_rc4.c.o CMakeFiles/s2n.dir/crypto/s2n_tls13_keys.c.o CMakeFiles/s2n.dir/error/s2n_errno.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r1/aes_ctr_prf.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r1/bike_r1_kem.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r1/converts_portable.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r1/decode.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r1/error.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r1/gf2x_mul.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r1/gf2x_portable.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r1/openssl_utils.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r1/parallel_hash.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r1/sampling.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r1/sampling_portable.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r1/secure_decode_portable.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r1/utilities.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r2/aes_ctr_prf.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r2/bike_r2_kem.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r2/decode.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r2/error.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r2/gf2x_mul.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r2/gf2x_portable.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r2/openssl_utils.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r2/sampling.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r2/sampling_portable.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r2/secure_decode_portable.c.o CMakeFiles/s2n.dir/pq-crypto/bike_r2/utilities.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_90s_r2/aes256ctr.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_90s_r2/aes_c.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_90s_r2/cbd.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_90s_r2/indcpa.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_90s_r2/kyber_90s_r2_kem.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_90s_r2/ntt.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_90s_r2/poly.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_90s_r2/polyvec.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_90s_r2/reduce.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_90s_r2/sha2_c.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_90s_r2/verify.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_r2/cbd.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_r2/fips202_kyber_r2.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_r2/indcpa.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_r2/kyber_r2_kem.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_r2/ntt.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_r2/poly.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_r2/polyvec.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_r2/reduce.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_r2/symmetric-fips202.c.o CMakeFiles/s2n.dir/pq-crypto/kyber_r2/verify.c.o CMakeFiles/s2n.dir/pq-crypto/s2n_pq.c.o CMakeFiles/s2n.dir/pq-crypto/s2n_pq_random.c.o CMakeFiles/s2n.dir/pq-crypto/sike_r1/P503_r1.c.o CMakeFiles/s2n.dir/pq-crypto/sike_r1/fips202_r1.c.o CMakeFiles/s2n.dir/pq-crypto/sike_r1/fp_generic_r1.c.o CMakeFiles/s2n.dir/pq-crypto/sike_r1/sike_r1_kem.c.o CMakeFiles/s2n.dir/pq-crypto/sike_r2/P434.c.o CMakeFiles/s2n.dir/pq-crypto/sike_r2/fips202.c.o CMakeFiles/s2n.dir/stuffer/s2n_stuffer.c.o CMakeFiles/s2n.dir/stuffer/s2n_stuffer_base64.c.o CMakeFiles/s2n.dir/stuffer/s2n_stuffer_file.c.o CMakeFiles/s2n.dir/stuffer/s2n_stuffer_network_order.c.o CMakeFiles/s2n.dir/stuffer/s2n_stuffer_pem.c.o CMakeFiles/s2n.dir/stuffer/s2n_stuffer_text.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_client_alpn.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_client_early_data_indication.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_client_key_share.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_client_max_frag_len.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_client_pq_kem.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_client_psk.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_client_renegotiation_info.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_client_sct_list.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_client_server_name.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_client_session_ticket.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_client_signature_algorithms.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_client_status_request.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_client_supported_groups.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_client_supported_versions.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_cookie.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_ec_point_format.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_extension_list.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_extension_type.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_extension_type_lists.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_key_share.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_nst_early_data_indication.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_psk_key_exchange_modes.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_quic_transport_params.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_server_alpn.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_server_certificate_status.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_server_early_data_indication.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_server_key_share.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_server_max_fragment_length.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_server_psk.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_server_renegotiation_info.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_server_sct_list.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_server_server_name.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_server_session_ticket.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_server_signature_algorithms.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_server_status_request.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_server_supported_versions.c.o CMakeFiles/s2n.dir/tls/extensions/s2n_supported_versions.c.o CMakeFiles/s2n.dir/tls/s2n_aead.c.o CMakeFiles/s2n.dir/tls/s2n_alerts.c.o CMakeFiles/s2n.dir/tls/s2n_async_pkey.c.o CMakeFiles/s2n.dir/tls/s2n_auth_selection.c.o CMakeFiles/s2n.dir/tls/s2n_cbc.c.o CMakeFiles/s2n.dir/tls/s2n_change_cipher_spec.c.o CMakeFiles/s2n.dir/tls/s2n_cipher_preferences.c.o CMakeFiles/s2n.dir/tls/s2n_cipher_suites.c.o CMakeFiles/s2n.dir/tls/s2n_client_cert.c.o CMakeFiles/s2n.dir/tls/s2n_client_cert_verify.c.o CMakeFiles/s2n.dir/tls/s2n_client_finished.c.o CMakeFiles/s2n.dir/tls/s2n_client_hello.c.o CMakeFiles/s2n.dir/tls/s2n_client_key_exchange.c.o CMakeFiles/s2n.dir/tls/s2n_config.c.o CMakeFiles/s2n.dir/tls/s2n_connection.c.o CMakeFiles/s2n.dir/tls/s2n_connection_evp_digests.c.o CMakeFiles/s2n.dir/tls/s2n_early_data.c.o CMakeFiles/s2n.dir/tls/s2n_early_data_io.c.o CMakeFiles/s2n.dir/tls/s2n_ecc_preferences.c.o CMakeFiles/s2n.dir/tls/s2n_encrypted_extensions.c.o CMakeFiles/s2n.dir/tls/s2n_establish_session.c.o CMakeFiles/s2n.dir/tls/s2n_handshake.c.o CMakeFiles/s2n.dir/tls/s2n_handshake_io.c.o CMakeFiles/s2n.dir/tls/s2n_handshake_transcript.c.o CMakeFiles/s2n.dir/tls/s2n_handshake_type.c.o CMakeFiles/s2n.dir/tls/s2n_kem.c.o CMakeFiles/s2n.dir/tls/s2n_kem_preferences.c.o CMakeFiles/s2n.dir/tls/s2n_kex.c.o CMakeFiles/s2n.dir/tls/s2n_key_log.c.o CMakeFiles/s2n.dir/tls/s2n_key_update.c.o CMakeFiles/s2n.dir/tls/s2n_ocsp_stapling.c.o CMakeFiles/s2n.dir/tls/s2n_post_handshake.c.o CMakeFiles/s2n.dir/tls/s2n_prf.c.o CMakeFiles/s2n.dir/tls/s2n_protocol_preferences.c.o CMakeFiles/s2n.dir/tls/s2n_psk.c.o CMakeFiles/s2n.dir/tls/s2n_quic_support.c.o CMakeFiles/s2n.dir/tls/s2n_record_read.c.o CMakeFiles/s2n.dir/tls/s2n_record_read_aead.c.o CMakeFiles/s2n.dir/tls/s2n_record_read_cbc.c.o CMakeFiles/s2n.dir/tls/s2n_record_read_composite.c.o CMakeFiles/s2n.dir/tls/s2n_record_read_stream.c.o CMakeFiles/s2n.dir/tls/s2n_record_write.c.o CMakeFiles/s2n.dir/tls/s2n_recv.c.o CMakeFiles/s2n.dir/tls/s2n_resume.c.o CMakeFiles/s2n.dir/tls/s2n_security_policies.c.o CMakeFiles/s2n.dir/tls/s2n_send.c.o CMakeFiles/s2n.dir/tls/s2n_server_cert.c.o CMakeFiles/s2n.dir/tls/s2n_server_cert_request.c.o CMakeFiles/s2n.dir/tls/s2n_server_done.c.o CMakeFiles/s2n.dir/tls/s2n_server_extensions.c.o CMakeFiles/s2n.dir/tls/s2n_server_finished.c.o CMakeFiles/s2n.dir/tls/s2n_server_hello.c.o CMakeFiles/s2n.dir/tls/s2n_server_hello_retry.c.o CMakeFiles/s2n.dir/tls/s2n_server_key_exchange.c.o CMakeFiles/s2n.dir/tls/s2n_server_new_session_ticket.c.o CMakeFiles/s2n.dir/tls/s2n_shutdown.c.o CMakeFiles/s2n.dir/tls/s2n_signature_algorithms.c.o CMakeFiles/s2n.dir/tls/s2n_signature_scheme.c.o CMakeFiles/s2n.dir/tls/s2n_tls.c.o CMakeFiles/s2n.dir/tls/s2n_tls13.c.o CMakeFiles/s2n.dir/tls/s2n_tls13_certificate_verify.c.o CMakeFiles/s2n.dir/tls/s2n_tls13_handshake.c.o CMakeFiles/s2n.dir/tls/s2n_x509_validator.c.o CMakeFiles/s2n.dir/utils/s2n_array.c.o CMakeFiles/s2n.dir/utils/s2n_asn1_time.c.o CMakeFiles/s2n.dir/utils/s2n_blob.c.o CMakeFiles/s2n.dir/utils/s2n_ensure.c.o CMakeFiles/s2n.dir/utils/s2n_init.c.o CMakeFiles/s2n.dir/utils/s2n_map.c.o CMakeFiles/s2n.dir/utils/s2n_mem.c.o CMakeFiles/s2n.dir/utils/s2n_random.c.o CMakeFiles/s2n.dir/utils/s2n_result.c.o CMakeFiles/s2n.dir/utils/s2n_rfc5952.c.o CMakeFiles/s2n.dir/utils/s2n_safety.c.o CMakeFiles/s2n.dir/utils/s2n_set.c.o CMakeFiles/s2n.dir/utils/s2n_socket.c.o CMakeFiles/s2n.dir/utils/s2n_str.c.o CMakeFiles/s2n.dir/utils/s2n_timer.c.o  /Users/runner/miniforge3/conda-bld/s2n_1617685018927/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place/lib/libcrypto.dylib  -lc  -lm && :
ld: unknown option: -z
clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
```

### Testing:

Tested this by compiling the `s2n` package on conda-forge.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
