### PR TITLE
Created GDB flag to remove optimizations

### DIFF
--- a/s2n.mk
+++ b/s2n.mk
@@ -116,6 +116,10 @@ ifdef S2N_DEBUG
 	CFLAGS += ${DEBUG_CFLAGS}
 endif
 
+ifdef S2N_GDB
+	CFLAGS += ${DEBUG_CFLAGS} -Og
+endif
+
 # Prepare CPPFLAGS by stripping out the unsupported options
 CPPFLAGS = ${CFLAGS}
 CPPFLAGS:=$(filter-out -Wimplicit,${CPPFLAGS})

--- a/s2n.mk
+++ b/s2n.mk
@@ -112,12 +112,13 @@ ifdef S2N_ADDRESS_SANITIZER
 	CFLAGS += -fsanitize=address -fuse-ld=gold -DS2N_ADDRESS_SANITIZER=1 ${DEBUG_CFLAGS}
 endif
 
-ifdef S2N_DEBUG
-	CFLAGS += ${DEBUG_CFLAGS}
+ifdef S2N_GDB
+    S2N_DEBUG = 1
+    CFLAGS += -Og
 endif
 
-ifdef S2N_GDB
-	CFLAGS += ${DEBUG_CFLAGS} -Og
+ifdef S2N_DEBUG
+	CFLAGS += ${DEBUG_CFLAGS}
 endif
 
 # Prepare CPPFLAGS by stripping out the unsupported options


### PR DESCRIPTION
### Resolved issues:

 N/A
### Description of changes: 

S2N_DEBUG enables most of the settings necessary to debug S2N code
in GDB, but leaves -O2 in the gcc command. This leads to annoying
and unpredictable GDB behavior when trying to step through functions.

I added a S2N_GDB flag that appends -Og to the gcc command, which allows us to step through the code successfully.
### Call-outs:
A previous pr that tried to address this issue is here: https://github.com/aws/s2n-tls/pull/1985. This was never merged because changing S2N_DEBUG affects valgrind tests. 
### Comparison between a regular make and a S2N_GDB make:

make: 
```
cc -Wl,--no-as-needed -std=c99 -Wcast-qual -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow  -Wcast-align -Wwrite-strings -fPIC -Wno-missing-braces -D_POSIX_C_SOURCE=200809L -O2 -I/home/ubuntu/s2n/libcrypto-root/include/ -I/home/ubuntu/s2n/api/ -I/home/ubuntu/s2n -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security -D_FORTIFY_SOURCE=2 -fgnu89-inline -fvisibility=hidden -DS2N_EXPORTS -Wstack-protector -fstack-protector-all -DS2N_HAVE_EXECINFO -DS2N_CPUID_AVAILABLE -DS2N___RESTRICT__SUPPORTED -o s2n_state_machine_viz s2n_state_machine_viz.c -z relro -z now -z noexecstack ../../lib/libs2n.a -L/home/ubuntu/s2n/libcrypto-root/lib -lcrypto -pthread -ldl -lrt
```
S2N_GDB=1 make:
```
cc -Wl,--no-as-needed -std=c99 -Wcast-qual -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized -Wshadow  -Wcast-align -Wwrite-strings -fPIC -Wno-missing-braces -D_POSIX_C_SOURCE=200809L -O2 -I/home/ubuntu/s2n/libcrypto-root/include/ -I/home/ubuntu/s2n/api/ -I/home/ubuntu/s2n -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security -D_FORTIFY_SOURCE=2 -fgnu89-inline -fvisibility=hidden -DS2N_EXPORTS -Wstack-protector -fstack-protector-all -DS2N_HAVE_EXECINFO -DS2N_CPUID_AVAILABLE -DS2N___RESTRICT__SUPPORTED -Og -g3 -ggdb -fno-omit-frame-pointer -fno-optimize-sibling-calls -o s2n_state_machine_viz s2n_state_machine_viz.c -z relro -z now -z noexecstack ../../lib/libs2n.a -L/home/ubuntu/s2n/libcrypto-root/lib -lcrypto -pthread -ldl -lrt
```
 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
