### PR TITLE
Adding prefix s2n_cert for s2n certificate APIs

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -487,7 +487,7 @@ extern int s2n_cert_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key
  * @param cert_length This return value represents the length of the certificate.
  */
 S2N_API
-extern int s2n_cert_get_cert_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length);
+extern int s2n_cert_get_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length);
 
 /**
  * Returns the validated peer certificate chain as a `s2n_cert_chain_and_key` opaque object.

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -446,7 +446,7 @@ extern struct s2n_cert_chain_and_key *s2n_connection_get_selected_cert(struct s2
  * @param cert_length This return value represents the length of the s2n certificate chain `chain_and_key`.
  */
 S2N_API
-extern int s2n_get_cert_chain_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
+extern int s2n_cert_get_cert_chain_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
 
 /**
  * Returns the certificate `out_cert` present at the index `cert_idx` of the certificate chain `chain_and_key`.
@@ -459,7 +459,7 @@ extern int s2n_get_cert_chain_length(const struct s2n_cert_chain_and_key *chain_
  * @param cert_length This return value represents the length of the s2n certificate chain `chain_and_key`.
  */
 S2N_API
-extern int s2n_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, const uint32_t cert_idx);
+extern int s2n_cert_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, const uint32_t cert_idx);
 
 /**
  * Returns the s2n certificate in DER format along with its length.
@@ -487,7 +487,7 @@ extern int s2n_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *cha
  * @param cert_length This return value represents the length of the certificate.
  */
 S2N_API
-extern int s2n_get_cert_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length);
+extern int s2n_cert_get_cert_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length);
 
 /**
  * Returns the validated peer certificate chain as a `s2n_cert_chain_and_key` opaque object.

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -446,7 +446,7 @@ extern struct s2n_cert_chain_and_key *s2n_connection_get_selected_cert(struct s2
  * @param cert_length This return value represents the length of the s2n certificate chain `chain_and_key`.
  */
 S2N_API
-extern int s2n_cert_get_cert_chain_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
+extern int s2n_cert_chain_get_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
 
 /**
  * Returns the certificate `out_cert` present at the index `cert_idx` of the certificate chain `chain_and_key`.
@@ -459,7 +459,7 @@ extern int s2n_cert_get_cert_chain_length(const struct s2n_cert_chain_and_key *c
  * @param cert_length This return value represents the length of the s2n certificate chain `chain_and_key`.
  */
 S2N_API
-extern int s2n_cert_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, const uint32_t cert_idx);
+extern int s2n_cert_chain_get_cert(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, const uint32_t cert_idx);
 
 /**
  * Returns the s2n certificate in DER format along with its length.

--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -553,7 +553,7 @@ s2n_cert_private_key *s2n_cert_chain_and_key_get_private_key(struct s2n_cert_cha
     return chain_and_key->private_key;
 }
 
-int s2n_get_cert_chain_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length)
+int s2n_cert_get_cert_chain_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length)
 {
     POSIX_ENSURE_REF(chain_and_key);
     POSIX_ENSURE_REF(cert_length);
@@ -570,7 +570,7 @@ int s2n_get_cert_chain_length(const struct s2n_cert_chain_and_key *chain_and_key
     return S2N_SUCCESS;
 }
 
-int s2n_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert,
+int s2n_cert_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert,
                                  const uint32_t cert_idx)
 {
     POSIX_ENSURE_REF(chain_and_key);
@@ -595,7 +595,7 @@ int s2n_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *chain_and_
     return S2N_SUCCESS;
 }
 
-int s2n_get_cert_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length)
+int s2n_cert_get_cert_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length)
 {
     POSIX_ENSURE_REF(cert);
     POSIX_ENSURE_REF(out_cert_der);

--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -553,7 +553,7 @@ s2n_cert_private_key *s2n_cert_chain_and_key_get_private_key(struct s2n_cert_cha
     return chain_and_key->private_key;
 }
 
-int s2n_cert_get_cert_chain_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length)
+int s2n_cert_chain_get_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length)
 {
     POSIX_ENSURE_REF(chain_and_key);
     POSIX_ENSURE_REF(cert_length);
@@ -570,7 +570,7 @@ int s2n_cert_get_cert_chain_length(const struct s2n_cert_chain_and_key *chain_an
     return S2N_SUCCESS;
 }
 
-int s2n_cert_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert,
+int s2n_cert_chain_get_cert(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert,
                                  const uint32_t cert_idx)
 {
     POSIX_ENSURE_REF(chain_and_key);

--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -595,7 +595,7 @@ int s2n_cert_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *chain
     return S2N_SUCCESS;
 }
 
-int s2n_cert_get_cert_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length)
+int s2n_cert_get_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length)
 {
     POSIX_ENSURE_REF(cert);
     POSIX_ENSURE_REF(out_cert_der);

--- a/crypto/s2n_certificate.h
+++ b/crypto/s2n_certificate.h
@@ -73,9 +73,9 @@ int s2n_create_cert_chain_from_stuffer(struct s2n_cert_chain *cert_chain_out, st
 int s2n_cert_chain_and_key_set_cert_chain(struct s2n_cert_chain_and_key *cert_and_key, const char *cert_chain_pem);
 int s2n_cert_chain_and_key_set_private_key(struct s2n_cert_chain_and_key *cert_and_key, const char *private_key_pem);
 s2n_pkey_type s2n_cert_chain_and_key_get_pkey_type(struct s2n_cert_chain_and_key *chain_and_key);
-int s2n_get_cert_chain_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
-int s2n_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, const uint32_t cert_idx);
-int s2n_get_cert_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length);
+int s2n_cert_get_cert_chain_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
+int s2n_cert_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, const uint32_t cert_idx);
+int s2n_cert_get_cert_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length);
 int s2n_cert_chain_free(struct s2n_cert_chain *cert_chain);
 int s2n_cert_get_x509_extension_value_length(struct s2n_cert *cert, const uint8_t *oid, uint32_t *ext_value_len);
 int s2n_cert_get_x509_extension_value(struct s2n_cert *cert, const uint8_t *oid, uint8_t *ext_value, uint32_t *ext_value_len, bool *critical);

--- a/crypto/s2n_certificate.h
+++ b/crypto/s2n_certificate.h
@@ -73,8 +73,8 @@ int s2n_create_cert_chain_from_stuffer(struct s2n_cert_chain *cert_chain_out, st
 int s2n_cert_chain_and_key_set_cert_chain(struct s2n_cert_chain_and_key *cert_and_key, const char *cert_chain_pem);
 int s2n_cert_chain_and_key_set_private_key(struct s2n_cert_chain_and_key *cert_and_key, const char *private_key_pem);
 s2n_pkey_type s2n_cert_chain_and_key_get_pkey_type(struct s2n_cert_chain_and_key *chain_and_key);
-int s2n_cert_get_cert_chain_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
-int s2n_cert_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, const uint32_t cert_idx);
+int s2n_cert_chain_get_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
+int s2n_cert_chain_get_cert(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, const uint32_t cert_idx);
 int s2n_cert_get_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length);
 int s2n_cert_chain_free(struct s2n_cert_chain *cert_chain);
 int s2n_cert_get_x509_extension_value_length(struct s2n_cert *cert, const uint8_t *oid, uint32_t *ext_value_len);

--- a/crypto/s2n_certificate.h
+++ b/crypto/s2n_certificate.h
@@ -75,7 +75,7 @@ int s2n_cert_chain_and_key_set_private_key(struct s2n_cert_chain_and_key *cert_a
 s2n_pkey_type s2n_cert_chain_and_key_get_pkey_type(struct s2n_cert_chain_and_key *chain_and_key);
 int s2n_cert_get_cert_chain_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
 int s2n_cert_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, const uint32_t cert_idx);
-int s2n_cert_get_cert_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length);
+int s2n_cert_get_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length);
 int s2n_cert_chain_free(struct s2n_cert_chain *cert_chain);
 int s2n_cert_get_x509_extension_value_length(struct s2n_cert *cert, const uint8_t *oid, uint32_t *ext_value_len);
 int s2n_cert_get_x509_extension_value(struct s2n_cert *cert, const uint8_t *oid, uint8_t *ext_value, uint32_t *ext_value_len, bool *critical);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1426,29 +1426,29 @@ Return the certificate that was used during the TLS handshake.
 This function returns NULL if the certificate selection phase of the handshake has not completed
  or if a certificate was not requested by the peer.
 
-### s2n\_get\_cert\_chain\_length
+### s2n\_cert\_get\_cert\_chain\_length
 
 ```c
-int s2n_get_cert_chain_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
+int s2n_cert_get_cert_chain_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
 ```
 
-**s2n_get_cert_chain_length** gets the length of the certificate chain `chain_and_key`. If the certificate chain `chain_and_key` is NULL an error is thrown.
+**s2n_cert_get_cert_chain_length** gets the length of the certificate chain `chain_and_key`. If the certificate chain `chain_and_key` is NULL an error is thrown.
 
-### s2n\_get\_cert\_from\_cert\_chain
+### s2n\_cert_\_get\_cert\_from\_cert\_chain
 
 ```c
-int s2n_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, const uint32_t cert_idx);
+int s2n_cert_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, const uint32_t cert_idx);
 ```
 
-**s2n_get_cert_from_cert_chain** gets the certificate `out_cert` present at the index `cert_idx` of the certificate chain `chain_and_key`.  If the certificate chain `chain_and_key` is NULL or the certificate index value is not in the acceptable range for the input certificate chain, an error is thrown. Note that the index of the head_cert is zero.
+**s2n_cert_get_cert_from_cert_chain** gets the certificate `out_cert` present at the index `cert_idx` of the certificate chain `chain_and_key`.  If the certificate chain `chain_and_key` is NULL or the certificate index value is not in the acceptable range for the input certificate chain, an error is thrown. Note that the index of the head_cert is zero.
 
-### s2n\_get\_cert\_der
+### s2n\_cert\_get\_cert\_der
 
 ```c
-int s2n_get_cert_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length);
+int s2n_cert_get_cert_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length);
 ```
 
-**s2n_get_cert_der** gets the certificate `cert` in .der format which is returned in the buffer `out_cert_der`, `cert_len` represents the length of the certificate. 
+**s2n_cert_get_cert_der** gets the certificate `cert` in .der format which is returned in the buffer `out_cert_der`, `cert_len` represents the length of the certificate. 
 
 ### s2n\_connection\_get_peer\_cert\_chain
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1442,13 +1442,13 @@ int s2n_cert_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *chain
 
 **s2n_cert_get_cert_from_cert_chain** gets the certificate `out_cert` present at the index `cert_idx` of the certificate chain `chain_and_key`.  If the certificate chain `chain_and_key` is NULL or the certificate index value is not in the acceptable range for the input certificate chain, an error is thrown. Note that the index of the head_cert is zero.
 
-### s2n\_cert\_get\_cert\_der
+### s2n\_cert\_get\_der
 
 ```c
-int s2n_cert_get_cert_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length);
+int s2n_cert_get_der(const struct s2n_cert *cert, const uint8_t **out_cert_der, uint32_t *cert_length);
 ```
 
-**s2n_cert_get_cert_der** gets the certificate `cert` in .der format which is returned in the buffer `out_cert_der`, `cert_len` represents the length of the certificate. 
+**s2n_cert_get_der** gets the certificate `cert` in .der format which is returned in the buffer `out_cert_der`, `cert_len` represents the length of the certificate. 
 
 ### s2n\_connection\_get_peer\_cert\_chain
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1426,21 +1426,21 @@ Return the certificate that was used during the TLS handshake.
 This function returns NULL if the certificate selection phase of the handshake has not completed
  or if a certificate was not requested by the peer.
 
-### s2n\_cert\_get\_cert\_chain\_length
+### s2n\_cert\_chain\_get\_length
 
 ```c
-int s2n_cert_get_cert_chain_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
+int s2n_cert_chain_get_length(const struct s2n_cert_chain_and_key *chain_and_key, uint32_t *cert_length);
 ```
 
-**s2n_cert_get_cert_chain_length** gets the length of the certificate chain `chain_and_key`. If the certificate chain `chain_and_key` is NULL an error is thrown.
+**s2n_cert_chain_get_length** gets the length of the certificate chain `chain_and_key`. If the certificate chain `chain_and_key` is NULL an error is thrown.
 
-### s2n\_cert_\_get\_cert\_from\_cert\_chain
+### s2n\_cert_\_chain\_get\_cert
 
 ```c
-int s2n_cert_get_cert_from_cert_chain(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, const uint32_t cert_idx);
+int s2n_cert_chain_get_cert(const struct s2n_cert_chain_and_key *chain_and_key, struct s2n_cert **out_cert, const uint32_t cert_idx);
 ```
 
-**s2n_cert_get_cert_from_cert_chain** gets the certificate `out_cert` present at the index `cert_idx` of the certificate chain `chain_and_key`.  If the certificate chain `chain_and_key` is NULL or the certificate index value is not in the acceptable range for the input certificate chain, an error is thrown. Note that the index of the head_cert is zero.
+**s2n_cert_chain_get_cert** gets the certificate `out_cert` present at the index `cert_idx` of the certificate chain `chain_and_key`.  If the certificate chain `chain_and_key` is NULL or the certificate index value is not in the acceptable range for the input certificate chain, an error is thrown. Note that the index of the head_cert is zero.
 
 ### s2n\_cert\_get\_der
 

--- a/tests/unit/s2n_certificate_test.c
+++ b/tests/unit/s2n_certificate_test.c
@@ -47,7 +47,7 @@ static S2N_RESULT s2n_compare_cert_chain(struct s2n_connection *conn, struct s2n
     ENSURE_REF(conn);
     ENSURE_REF(test_peer_chain);
     uint32_t cert_chain_length = 0;
-    RESULT_GUARD_POSIX(s2n_cert_get_cert_chain_length(test_peer_chain, &cert_chain_length));
+    RESULT_GUARD_POSIX(s2n_cert_chain_get_length(test_peer_chain, &cert_chain_length));
     DEFER_CLEANUP(STACK_OF(X509) *cert_chain_validated = X509_STORE_CTX_get1_chain(conn->x509_validator.store_ctx),
                   s2n_openssl_x509_stack_pop_free);
     ENSURE_REF(cert_chain_validated);
@@ -62,7 +62,7 @@ static S2N_RESULT s2n_compare_cert_chain(struct s2n_connection *conn, struct s2n
         ENSURE_REF(cert_data_from_validator);
         ENSURE_GT(cert_size_from_validator, 0);
 
-        RESULT_GUARD_POSIX(s2n_cert_get_cert_from_cert_chain(test_peer_chain, &cur_cert, cert_idx));
+        RESULT_GUARD_POSIX(s2n_cert_chain_get_cert(test_peer_chain, &cur_cert, cert_idx));
         ENSURE_REF(cur_cert);
         ENSURE_EQ(cert_size_from_validator, cur_cert->raw.size);
         ENSURE_EQ(memcmp(cert_data_from_validator, cur_cert->raw.data, cur_cert->raw.size), 0);
@@ -97,43 +97,43 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(
         s2n_test_cert_chain_and_key_new(&chain_and_key, S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
 
-    /* Test s2n_cert_get_cert_chain_length */ 
+    /* Test s2n_cert_chain_get_length */ 
     {
         uint32_t length = 0;
 
         /* Safety checks */
         {
-            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_get_cert_chain_length(NULL, &length), S2N_ERR_NULL);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_get_cert_chain_length(chain_and_key, NULL), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_chain_get_length(NULL, &length), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_chain_get_length(chain_and_key, NULL), S2N_ERR_NULL);
         }
 
         /* Test success case */
-        EXPECT_SUCCESS(s2n_cert_get_cert_chain_length(chain_and_key, &length));
+        EXPECT_SUCCESS(s2n_cert_chain_get_length(chain_and_key, &length));
         EXPECT_EQUAL(length, S2N_DEFAULT_TEST_CERT_CHAIN_LENGTH);
 
     }
 
-    /* Test s2n_cert_get_cert_from_cert_chain */
+    /* Test s2n_cert_chain_get_cert */
     {
         struct s2n_cert *out_cert = NULL;
         uint32_t cert_idx = 0;
 
         /* Safety checks */
         {
-            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_get_cert_from_cert_chain(NULL, &out_cert, cert_idx), S2N_ERR_NULL);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_get_cert_from_cert_chain(chain_and_key, NULL, cert_idx), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_chain_get_cert(NULL, &out_cert, cert_idx), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_chain_get_cert(chain_and_key, NULL, cert_idx), S2N_ERR_NULL);
         }
 
         struct s2n_cert *cur_cert = chain_and_key->cert_chain->head;
 
         /* Test error case for invalid cert_idx, the valid range of cert_idx is 0 to cert_chain_length - 1 */  
         cert_idx = S2N_DEFAULT_TEST_CERT_CHAIN_LENGTH;
-        EXPECT_FAILURE_WITH_ERRNO(s2n_cert_get_cert_from_cert_chain(chain_and_key, &out_cert, cert_idx), S2N_ERR_NO_CERT_FOUND);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_cert_chain_get_cert(chain_and_key, &out_cert, cert_idx), S2N_ERR_NO_CERT_FOUND);
 
         /* Test success case */
         for (size_t i = 0; i < S2N_DEFAULT_TEST_CERT_CHAIN_LENGTH; i++)
         {
-            EXPECT_SUCCESS(s2n_cert_get_cert_from_cert_chain(chain_and_key, &out_cert, i));
+            EXPECT_SUCCESS(s2n_cert_chain_get_cert(chain_and_key, &out_cert, i));
             EXPECT_NOT_NULL(cur_cert);
             EXPECT_EQUAL(out_cert, cur_cert);
             cur_cert = cur_cert->next;

--- a/tests/unit/s2n_certificate_test.c
+++ b/tests/unit/s2n_certificate_test.c
@@ -141,7 +141,7 @@ int main(int argc, char **argv)
 
     }
 
-    /* Test s2n_cert_get_cert_der */ 
+    /* Test s2n_cert_get_der */ 
     {
         struct s2n_cert *cert = chain_and_key->cert_chain->head;
         const uint8_t *out_cert_der = NULL;
@@ -149,12 +149,12 @@ int main(int argc, char **argv)
 
         /* Safety checks */
         {
-            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_get_cert_der(NULL, &out_cert_der, &cert_len), S2N_ERR_NULL);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_get_cert_der(cert, NULL, &cert_len), S2N_ERR_NULL);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_get_cert_der(cert, &out_cert_der, NULL), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_get_der(NULL, &out_cert_der, &cert_len), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_get_der(cert, NULL, &cert_len), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_get_der(cert, &out_cert_der, NULL), S2N_ERR_NULL);
         }
 
-        EXPECT_SUCCESS(s2n_cert_get_cert_der(cert, &out_cert_der, &cert_len));
+        EXPECT_SUCCESS(s2n_cert_get_der(cert, &out_cert_der, &cert_len));
         EXPECT_EQUAL(cert_len, cert->raw.size); 
         EXPECT_BYTEARRAY_EQUAL(out_cert_der, cert->raw.data, cert_len);
     }


### PR DESCRIPTION
### Description of changes: 
Adds a prefix `s2n_cert` to the s2n-tls certificate APIs. 

Related to: https://github.com/aws/s2n-tls/pull/2702#discussion_r609053511

### Call-outs:
This change includes changes in `api/s2n.h` for the recently added APIs in https://github.com/aws/s2n-tls/issues/2651.

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? Unit testing

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? Naming change. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
