### PR TITLE
Add early data callback

### DIFF
--- a/tests/unit/s2n_early_data_test.c
+++ b/tests/unit/s2n_early_data_test.c
@@ -84,6 +84,25 @@ static S2N_RESULT s2n_test_config_buffers_freed(struct s2n_early_data_config *co
     return S2N_RESULT_OK;
 }
 
+static int s2n_test_early_data_cb(struct s2n_connection *conn, struct s2n_offered_early_data *early_data)
+{
+    POSIX_ENSURE_REF(conn);
+
+    uint16_t context_len = 0;
+    POSIX_GUARD(s2n_offered_early_data_get_context_length(early_data, &context_len));
+    POSIX_ENSURE_EQ(context_len, 1);
+
+    uint8_t context = 0;
+    POSIX_GUARD(s2n_offered_early_data_get_context(early_data, &context, 1));
+
+    if (context) {
+        POSIX_GUARD(s2n_offered_early_data_reject(early_data));
+    } else {
+        POSIX_GUARD(s2n_offered_early_data_accept(early_data));
+    }
+    return S2N_SUCCESS;
+}
+
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
@@ -596,6 +615,45 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
+
+        /* Triggers callback to let application reject early data */
+        {
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_NOT_NULL(config);
+
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
+            EXPECT_OK(s2n_append_test_chosen_psk_with_early_data(conn, nonzero_max_early_data, &s2n_tls13_aes_256_gcm_sha384));
+            EXPECT_SUCCESS(s2n_connection_set_early_data_expected(conn));
+            conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
+            conn->actual_protocol_version = S2N_TLS13;
+
+            /* Without callback set, accepts early data */
+            conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
+            EXPECT_OK(s2n_early_data_accept_or_reject(conn));
+            EXPECT_EQUAL(conn->early_data_state, S2N_EARLY_DATA_ACCEPTED);
+
+            uint8_t reject_early_data = false;
+            EXPECT_SUCCESS(s2n_config_set_early_data_cb(config, s2n_test_early_data_cb));
+
+            /* With callback set, may still accept early data */
+            conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
+            EXPECT_SUCCESS(s2n_psk_set_context(conn->psk_params.chosen_psk, &reject_early_data, sizeof(reject_early_data)));
+            EXPECT_OK(s2n_early_data_accept_or_reject(conn));
+            EXPECT_EQUAL(conn->early_data_state, S2N_EARLY_DATA_ACCEPTED);
+
+            /* With callback set, may reject early data */
+            reject_early_data = true;
+            conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
+            EXPECT_SUCCESS(s2n_psk_set_context(conn->psk_params.chosen_psk, &reject_early_data, sizeof(reject_early_data)));
+            EXPECT_OK(s2n_early_data_accept_or_reject(conn));
+            EXPECT_EQUAL(conn->early_data_state, S2N_EARLY_DATA_REJECTED);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
+        }
     }
 
     /* Test s2n_connection_get_early_data_status */
@@ -1105,6 +1163,128 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_early_data_validate_recv(&conn));
 
         EXPECT_SUCCESS(s2n_connection_free(valid_connection));
+    }
+
+    /* Test s2n_config_set_early_data_cb */
+    {
+        struct s2n_config *config = s2n_config_new();
+
+        /* Safety */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_early_data_cb(NULL, s2n_test_early_data_cb), S2N_ERR_NULL);
+        EXPECT_EQUAL(config->early_data_cb, 0);
+
+        /* Set callback */
+        EXPECT_SUCCESS(s2n_config_set_early_data_cb(config, s2n_test_early_data_cb));
+        EXPECT_EQUAL(config->early_data_cb, s2n_test_early_data_cb);
+
+        /* Clear callback */
+        EXPECT_SUCCESS(s2n_config_set_early_data_cb(config, NULL));
+        EXPECT_EQUAL(config->early_data_cb, NULL);
+
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Test s2n_offered_early_data_get_context and s2n_offered_early_data_get_context_length */
+    {
+        struct s2n_offered_early_data early_data = { 0 };
+        const uint8_t context[] = "psk context";
+        const uint8_t empty_context[sizeof(context)] = { 0 };
+        uint8_t actual_context[sizeof(context)] = { 0 };
+        uint16_t length = 1;
+
+        /* Safety */
+        {
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_early_data_get_context_length(NULL, &length), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_early_data_get_context(NULL, actual_context, 1), S2N_ERR_NULL);
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_early_data_get_context_length(&early_data, NULL), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_early_data_get_context(&early_data, NULL, 1), S2N_ERR_NULL);
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_early_data_get_context_length(&early_data, &length), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_early_data_get_context(&early_data, actual_context, 1), S2N_ERR_NULL);
+
+            early_data.conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_early_data_get_context_length(&early_data, &length), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_early_data_get_context(&early_data, actual_context, 1), S2N_ERR_NULL);
+            EXPECT_SUCCESS(s2n_connection_free(early_data.conn));
+        }
+
+        /* No context */
+        {
+            early_data.conn = s2n_connection_new(S2N_SERVER);
+            DEFER_CLEANUP(struct s2n_psk *test_psk = s2n_test_psk_new(early_data.conn), s2n_psk_free);
+            early_data.conn->psk_params.chosen_psk = test_psk;
+
+            EXPECT_SUCCESS(s2n_offered_early_data_get_context_length(&early_data, &length));
+            EXPECT_EQUAL(length, 0);
+
+            EXPECT_SUCCESS(s2n_offered_early_data_get_context(&early_data, actual_context, 0));
+            EXPECT_BYTEARRAY_EQUAL(actual_context, empty_context, sizeof(empty_context));
+
+            EXPECT_SUCCESS(s2n_offered_early_data_get_context(&early_data, actual_context, sizeof(actual_context)));
+            EXPECT_BYTEARRAY_EQUAL(actual_context, empty_context, sizeof(empty_context));
+
+            EXPECT_SUCCESS(s2n_connection_free(early_data.conn));
+        }
+
+        /* Context */
+        {
+            early_data.conn = s2n_connection_new(S2N_SERVER);
+            DEFER_CLEANUP(struct s2n_psk *test_psk = s2n_test_psk_new(early_data.conn), s2n_psk_free);
+            EXPECT_SUCCESS(s2n_psk_set_context(test_psk, context, sizeof(context)));
+            early_data.conn->psk_params.chosen_psk = test_psk;
+
+            EXPECT_SUCCESS(s2n_offered_early_data_get_context_length(&early_data, &length));
+            EXPECT_EQUAL(length, sizeof(context));
+
+            EXPECT_SUCCESS(s2n_offered_early_data_get_context(&early_data, actual_context, sizeof(actual_context)));
+            EXPECT_BYTEARRAY_EQUAL(actual_context, context, sizeof(context));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_early_data_get_context(&early_data, actual_context, 1),
+                    S2N_ERR_INSUFFICIENT_MEM_SIZE);
+
+            EXPECT_SUCCESS(s2n_connection_free(early_data.conn));
+        }
+    }
+
+    /* Test s2n_offered_early_data_reject */
+    {
+        struct s2n_offered_early_data early_data = { .conn = NULL };
+
+        /* Safety */
+        {
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_early_data_reject(NULL), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_early_data_reject(&early_data), S2N_ERR_NULL);
+        }
+
+        /* Reject early data */
+        {
+            early_data.conn = s2n_connection_new(S2N_SERVER);
+            early_data.conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
+            EXPECT_SUCCESS(s2n_offered_early_data_reject(&early_data));
+            EXPECT_EQUAL(early_data.conn->early_data_state, S2N_EARLY_DATA_REJECTED);
+            EXPECT_SUCCESS(s2n_connection_free(early_data.conn));
+        }
+    }
+
+    /* Test s2n_offered_early_data_accept */
+    {
+        struct s2n_offered_early_data early_data = { .conn = NULL };
+
+        /* Safety */
+        {
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_early_data_accept(NULL), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_early_data_accept(&early_data), S2N_ERR_NULL);
+        }
+
+        /* Accept early data */
+        {
+            early_data.conn = s2n_connection_new(S2N_SERVER);
+            early_data.conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
+            EXPECT_SUCCESS(s2n_offered_early_data_accept(&early_data));
+            EXPECT_EQUAL(early_data.conn->early_data_state, S2N_EARLY_DATA_ACCEPTED);
+            EXPECT_SUCCESS(s2n_connection_free(early_data.conn));
+        }
     }
 
     END_TEST();

--- a/tests/unit/s2n_early_data_test.c
+++ b/tests/unit/s2n_early_data_test.c
@@ -96,9 +96,9 @@ static int s2n_test_early_data_cb(struct s2n_connection *conn, struct s2n_offere
     POSIX_GUARD(s2n_offered_early_data_get_context(early_data, &context, 1));
 
     if (context) {
-        POSIX_GUARD(s2n_offered_early_data_reject(early_data));
-    } else {
         POSIX_GUARD(s2n_offered_early_data_accept(early_data));
+    } else {
+        POSIX_GUARD(s2n_offered_early_data_reject(early_data));
     }
     return S2N_SUCCESS;
 }
@@ -635,19 +635,19 @@ int main(int argc, char **argv)
             EXPECT_OK(s2n_early_data_accept_or_reject(conn));
             EXPECT_EQUAL(conn->early_data_state, S2N_EARLY_DATA_ACCEPTED);
 
-            uint8_t reject_early_data = false;
+            uint8_t accept_early_data = true;
             EXPECT_SUCCESS(s2n_config_set_early_data_cb(config, s2n_test_early_data_cb));
 
             /* With callback set, may still accept early data */
             conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
-            EXPECT_SUCCESS(s2n_psk_set_context(conn->psk_params.chosen_psk, &reject_early_data, sizeof(reject_early_data)));
+            EXPECT_SUCCESS(s2n_psk_set_context(conn->psk_params.chosen_psk, &accept_early_data, sizeof(accept_early_data)));
             EXPECT_OK(s2n_early_data_accept_or_reject(conn));
             EXPECT_EQUAL(conn->early_data_state, S2N_EARLY_DATA_ACCEPTED);
 
             /* With callback set, may reject early data */
-            reject_early_data = true;
+            accept_early_data = false;
             conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
-            EXPECT_SUCCESS(s2n_psk_set_context(conn->psk_params.chosen_psk, &reject_early_data, sizeof(reject_early_data)));
+            EXPECT_SUCCESS(s2n_psk_set_context(conn->psk_params.chosen_psk, &accept_early_data, sizeof(accept_early_data)));
             EXPECT_OK(s2n_early_data_accept_or_reject(conn));
             EXPECT_EQUAL(conn->early_data_state, S2N_EARLY_DATA_REJECTED);
 

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -116,6 +116,8 @@ struct s2n_config {
     s2n_session_ticket_fn session_ticket_cb;
     void *session_ticket_ctx;
 
+    s2n_early_data_cb early_data_cb;
+
     uint32_t server_max_early_data_size;
 
     s2n_psk_mode psk_mode;

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -135,7 +135,16 @@ S2N_RESULT s2n_early_data_accept_or_reject(struct s2n_connection *conn)
         return S2N_RESULT_OK;
     }
 
-    RESULT_GUARD(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_ACCEPTED));
+    /* If early data would otherwise be accepted, let the application apply any additional restrictions.
+     * For example, an application could use this callback to implement anti-replay protections.
+     */
+    RESULT_ENSURE_REF(conn->config);
+    if (conn->config->early_data_cb) {
+        struct s2n_offered_early_data offered_early_data = { .conn = conn };
+        RESULT_GUARD_POSIX(conn->config->early_data_cb(conn, &offered_early_data));
+    } else {
+        RESULT_GUARD(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_ACCEPTED));
+    }
     return S2N_RESULT_OK;
 }
 
@@ -332,5 +341,61 @@ int s2n_connection_get_max_early_data_size(struct s2n_connection *conn, uint32_t
         *max_early_data_size = MIN(*max_early_data_size, server_max_early_data_size);
     }
 
+    return S2N_SUCCESS;
+}
+
+int s2n_config_set_early_data_cb(struct s2n_config *config, s2n_early_data_cb cb)
+{
+    POSIX_ENSURE_REF(config);
+    config->early_data_cb = cb;
+    return S2N_SUCCESS;
+}
+
+int s2n_offered_early_data_get_context_length(struct s2n_offered_early_data *early_data, uint16_t *context_len)
+{
+    POSIX_ENSURE_REF(context_len);
+    POSIX_ENSURE_REF(early_data);
+    struct s2n_connection *conn = early_data->conn;
+
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->psk_params.chosen_psk);
+    struct s2n_early_data_config *early_data_config = &conn->psk_params.chosen_psk->early_data_config;
+
+    *context_len = early_data_config->context.size;
+
+    return S2N_SUCCESS;
+}
+
+int s2n_offered_early_data_get_context(struct s2n_offered_early_data *early_data, uint8_t *context, uint16_t max_len)
+{
+    POSIX_ENSURE_REF(context);
+    POSIX_ENSURE_REF(early_data);
+    struct s2n_connection *conn = early_data->conn;
+
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->psk_params.chosen_psk);
+    struct s2n_early_data_config *early_data_config = &conn->psk_params.chosen_psk->early_data_config;
+
+    POSIX_ENSURE(early_data_config->context.size <= max_len, S2N_ERR_INSUFFICIENT_MEM_SIZE);
+    POSIX_CHECKED_MEMCPY(context, early_data_config->context.data, early_data_config->context.size);
+
+    return S2N_SUCCESS;
+}
+
+int s2n_offered_early_data_reject(struct s2n_offered_early_data *early_data)
+{
+    POSIX_ENSURE_REF(early_data);
+    struct s2n_connection *conn = early_data->conn;
+    POSIX_ENSURE_REF(conn);
+    POSIX_GUARD_RESULT(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_REJECTED));
+    return S2N_SUCCESS;
+}
+
+int s2n_offered_early_data_accept(struct s2n_offered_early_data *early_data)
+{
+    POSIX_ENSURE_REF(early_data);
+    struct s2n_connection *conn = early_data->conn;
+    POSIX_ENSURE_REF(conn);
+    POSIX_GUARD_RESULT(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_ACCEPTED));
     return S2N_SUCCESS;
 }

--- a/tls/s2n_early_data.h
+++ b/tls/s2n_early_data.h
@@ -45,6 +45,10 @@ struct s2n_early_data_config {
 S2N_CLEANUP_RESULT s2n_early_data_config_free(struct s2n_early_data_config *config);
 S2N_RESULT s2n_early_data_config_clone(struct s2n_psk *new_psk, struct s2n_early_data_config *old_config);
 
+struct s2n_offered_early_data {
+    struct s2n_connection *conn;
+};
+
 bool s2n_early_data_is_valid_for_connection(struct s2n_connection *conn);
 S2N_RESULT s2n_early_data_accept_or_reject(struct s2n_connection *conn);
 
@@ -82,3 +86,11 @@ int s2n_send_early_data(struct s2n_connection *conn, const uint8_t *data, ssize_
         ssize_t *data_sent, s2n_blocked_status *blocked);
 int s2n_recv_early_data(struct s2n_connection *conn, uint8_t *data, ssize_t max_data_len,
         ssize_t *data_received, s2n_blocked_status *blocked);
+
+struct s2n_offered_early_data;
+typedef int (*s2n_early_data_cb)(struct s2n_connection *conn, struct s2n_offered_early_data *early_data);
+int s2n_config_set_early_data_cb(struct s2n_config *config, s2n_early_data_cb cb);
+int s2n_offered_early_data_get_context_length(struct s2n_offered_early_data *early_data, uint16_t *context_len);
+int s2n_offered_early_data_get_context(struct s2n_offered_early_data *early_data, uint8_t *context, uint16_t max_len);
+int s2n_offered_early_data_reject(struct s2n_offered_early_data *early_data);
+int s2n_offered_early_data_accept(struct s2n_offered_early_data *early_data);


### PR DESCRIPTION
### Resolved issues:

partially addresses https://github.com/aws/s2n-tls/issues/2576

### Description of changes: 

S2N will automatically reject early data if the connection does not meet specific requirements laid out in the RFC, such as negotiating an application protocol that matches the application protocol associated with the PSK. However, customers or applications may have additional requirements that must be met before early data can be accepted by a particular connection. Anti-replay protection is the most obvious example; customers might need to check that a ticket or ClientHello has not been used before. 

### Call-outs:
* This PR is for a synchronous callback. This change will make it asynchronous: https://github.com/lrstewart/s2n/compare/0rtt_misc_reject...lrstewart:0rtt_misc_reject_async
* **Why not put the accept/reject operations directly on the connection?** While we could technically reject early data at any time before the EncryptedExtensions, we can only accept early data after this callback is triggered. Before this callback, the early data hasn't been verified to match the connection, so could be invalid. So if we wanted to make the accept/reject operations accessible outside of this callback, they'd have to be more like "no comment"/reject. I think customers would find that more confusing.
* **Why not put the context getter on the connection?** I don't feel as strongly about this one. But I do think it makes more sense to only be accessible during the callback, because we won't have access to a session resumption context until we've chosen, decrypted, and de-serialized an identity.

### Testing:

Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
