### PR TITLE
Consolidate handshake pause logic

### DIFF
--- a/tests/unit/s2n_handshake_io_async_test.c
+++ b/tests/unit/s2n_handshake_io_async_test.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <s2n.h>
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "utils/s2n_result.h"
+
+/* Get access to s2n_handshake_read_io */
+#include "tls/s2n_handshake_io.c"
+
+bool async_blocked = false;
+size_t blocking_handler_count = 0;
+static int s2n_blocking_handler(struct s2n_connection *conn)
+{
+    blocking_handler_count++;
+    if (async_blocked) {
+        POSIX_BAIL(S2N_ERR_ASYNC_BLOCKED);
+    }
+    return S2N_SUCCESS;
+}
+
+static int s2n_error_handler(struct s2n_connection *conn)
+{
+    POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Async blocking errors block handshake negotiation */
+    {
+        const size_t repeat_count = 10;
+
+        DEFER_CLEANUP(struct s2n_stuffer io_buffer = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&io_buffer, 0));
+
+        /* Write handles async blocking */
+        {
+            tls13_state_machine[CLIENT_HELLO].handler[S2N_CLIENT] = s2n_blocking_handler;
+            tls13_state_machine[SERVER_HELLO].handler[S2N_CLIENT] = s2n_error_handler;
+
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(NULL, &io_buffer, conn));
+
+            /* Consistently blocks */
+            async_blocked = true;
+            blocking_handler_count = 0;
+            for (size_t i = 0; i < repeat_count; i++) {
+                EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked), S2N_ERR_ASYNC_BLOCKED);
+                EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_APPLICATION_INPUT);
+                EXPECT_EQUAL(s2n_stuffer_data_available(&io_buffer), 0);
+            }
+            EXPECT_EQUAL(blocking_handler_count, repeat_count);
+
+            /* If unblocked, continues. Fails to read next message because there is no next message. */
+            async_blocked = false;
+            blocking_handler_count = 0;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked), S2N_ERR_IO);
+            EXPECT_EQUAL(blocking_handler_count, 1);
+
+            /* Only wrote one record/message */
+            EXPECT_EQUAL(s2n_stuffer_data_available(&io_buffer), S2N_TLS_RECORD_HEADER_LENGTH + TLS_HANDSHAKE_HEADER_LENGTH);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Use the output of writing to test reading */
+        EXPECT_SUCCESS(s2n_stuffer_reread(&io_buffer));
+
+        /* Read handles async blocking */
+        {
+            state_machine[CLIENT_HELLO].handler[S2N_SERVER] = s2n_blocking_handler;
+            state_machine[SERVER_HELLO].handler[S2N_SERVER] = s2n_error_handler;
+
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
+            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&io_buffer, NULL, conn));
+
+            /* Consistently blocks */
+            async_blocked = true;
+            blocking_handler_count = 0;
+            for (size_t i = 0; i < repeat_count; i++) {
+                EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked), S2N_ERR_ASYNC_BLOCKED);
+                EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_APPLICATION_INPUT);
+                EXPECT_EQUAL(s2n_stuffer_data_available(&io_buffer), 0);
+            }
+            EXPECT_EQUAL(blocking_handler_count, repeat_count);
+
+            /* If unblocked, continues */
+            async_blocked = false;
+            blocking_handler_count = 0;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked), S2N_ERR_UNIMPLEMENTED);
+            EXPECT_EQUAL(blocking_handler_count, 1);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    END_TEST();
+}

--- a/tls/s2n_async_pkey.c
+++ b/tls/s2n_async_pkey.c
@@ -166,7 +166,6 @@ S2N_RESULT s2n_async_pkey_decrypt_async(struct s2n_connection *conn, struct s2n_
     RESULT_GUARD_POSIX(s2n_dup(init_decrypted, &decrypt->decrypted));
 
     /* Block the handshake and set async state to invoking to block async states */
-    RESULT_GUARD_POSIX(s2n_conn_set_handshake_read_block(conn));
     conn->handshake.async_state = S2N_ASYNC_INVOKING_CALLBACK;
 
     /* Move op to tmp to avoid DEFER_CLEANUP freeing the op, as it will be owned by callback */
@@ -236,7 +235,6 @@ S2N_RESULT s2n_async_pkey_sign_async(struct s2n_connection *conn, s2n_signature_
     RESULT_GUARD_POSIX(s2n_hash_copy(&sign->digest, digest));
 
     /* Block the handshake and set async state to invoking to block async states */
-    RESULT_GUARD_POSIX(s2n_conn_set_handshake_read_block(conn));
     conn->handshake.async_state = S2N_ASYNC_INVOKING_CALLBACK;
 
     /* Move op to tmp to avoid DEFER_CLEANUP freeing the op, as it will be owned by callback */

--- a/tls/s2n_async_pkey.h
+++ b/tls/s2n_async_pkey.h
@@ -44,7 +44,6 @@ struct s2n_async_pkey_op;
             case S2N_ASYNC_INVOKED_COMPLETE:                               \
                 /* clean up state and return a success from handler */     \
                 __tmp_conn->handshake.async_state = S2N_ASYNC_NOT_INVOKED; \
-                POSIX_GUARD(s2n_conn_clear_handshake_read_block(__tmp_conn));    \
                 return S2N_SUCCESS;                                        \
         }                                                                  \
     } while (0)

--- a/tls/s2n_establish_session.c
+++ b/tls/s2n_establish_session.c
@@ -32,8 +32,6 @@
  * provided session ID in its cache. */
 int s2n_establish_session(struct s2n_connection *conn)
 {
-    POSIX_GUARD(s2n_conn_set_handshake_read_block(conn));
-
     /* Start by receiving and processing the entire CLIENT_HELLO message */
     if (!conn->handshake.client_hello_received) {
         POSIX_GUARD(s2n_client_hello_recv(conn));
@@ -47,8 +45,6 @@ int s2n_establish_session(struct s2n_connection *conn)
         /* We've selected the parameters for the handshake, update the required hashes for this connection */
         POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));
     }
-
-    POSIX_GUARD(s2n_conn_clear_handshake_read_block(conn));
 
     return 0;
 }

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -175,8 +175,6 @@ struct s2n_handshake {
 extern message_type_t s2n_conn_get_current_message_type(struct s2n_connection *conn);
 extern int s2n_conn_set_handshake_type(struct s2n_connection *conn);
 extern int s2n_conn_set_handshake_no_client_cert(struct s2n_connection *conn);
-extern int s2n_conn_set_handshake_read_block(struct s2n_connection *conn);
-extern int s2n_conn_clear_handshake_read_block(struct s2n_connection *conn);
 extern int s2n_handshake_require_all_hashes(struct s2n_handshake *handshake);
 extern uint8_t s2n_handshake_is_hash_required(struct s2n_handshake *handshake, s2n_hash_algorithm hash_alg);
 extern int s2n_conn_update_required_handshake_hashes(struct s2n_connection *conn);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -869,24 +869,6 @@ int s2n_conn_set_handshake_no_client_cert(struct s2n_connection *conn)
     return 0;
 }
 
-int s2n_conn_set_handshake_read_block(struct s2n_connection *conn)
-{
-    POSIX_ENSURE_REF(conn);
-
-    conn->handshake.paused = 1;
-
-    return 0;
-}
-
-int s2n_conn_clear_handshake_read_block(struct s2n_connection *conn)
-{
-    POSIX_ENSURE_REF(conn);
-
-    conn->handshake.paused = 0;
-
-    return 0;
-}
-
 const char *s2n_connection_get_last_message_name(struct s2n_connection *conn)
 {
     PTR_ENSURE_REF(conn);
@@ -1322,6 +1304,9 @@ static int s2n_handle_retry_state(struct s2n_connection *conn)
         S2N_ERROR_PRESERVE_ERRNO();
     }
 
+    /* Resume the handshake */
+    conn->handshake.paused = false;
+
     if (!CONNECTION_IS_WRITER(conn)) {
         /* We're done parsing the record, reset everything */
         POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
@@ -1397,6 +1382,7 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
 
                 if (s2n_errno == S2N_ERR_ASYNC_BLOCKED) {
                     *blocked = S2N_BLOCKED_ON_APPLICATION_INPUT;
+                    conn->handshake.paused = true;
                 } else if (s2n_errno == S2N_ERR_EARLY_DATA_BLOCKED) {
                     *blocked = S2N_BLOCKED_ON_EARLY_DATA;
                 }
@@ -1416,6 +1402,7 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
 
                 if (s2n_errno == S2N_ERR_ASYNC_BLOCKED) {
                     *blocked = S2N_BLOCKED_ON_APPLICATION_INPUT;
+                    conn->handshake.paused = true;
                 } else if (s2n_errno == S2N_ERR_EARLY_DATA_BLOCKED) {
                     *blocked = S2N_BLOCKED_ON_EARLY_DATA;
                 }


### PR DESCRIPTION
### Description of changes: 

Just a minor improvement to the handshake async flow. We don't need to re-implement the pause logic every time we add a new async handler: we could just pause whenever we get an async blocking error, and then unpause once the handler succeeds. This reduces the surface area for future mistakes.

### Testing:

I added a new unit test, and the existing async pkey tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
