### PR TITLE
Make early data callback async 

### DIFF
--- a/crypto/s2n_hkdf.c
+++ b/crypto/s2n_hkdf.c
@@ -51,8 +51,9 @@ static int s2n_hkdf_expand(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, 
     uint8_t prev[MAX_DIGEST_SIZE] = { 0 };
 
     uint32_t done_len = 0;
-    uint8_t hash_len;
+    uint8_t hash_len = 0;
     POSIX_GUARD(s2n_hmac_digest_size(alg, &hash_len));
+    POSIX_ENSURE_GT(hash_len, 0);
     uint32_t total_rounds = output->size / hash_len;
     if (output->size % hash_len) {
         total_rounds++;

--- a/tests/unit/s2n_client_early_data_indication_test.c
+++ b/tests/unit/s2n_client_early_data_indication_test.c
@@ -296,7 +296,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
                     s2n_stuffer_data_available(&client_conn->handshake.io)));
-            EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+            EXPECT_SUCCESS(s2n_establish_session(server_conn));
 
             EXPECT_EQUAL(client_conn->early_data_state, S2N_EARLY_DATA_NOT_REQUESTED);
             EXPECT_EQUAL(server_conn->early_data_state, S2N_EARLY_DATA_NOT_REQUESTED);
@@ -323,7 +323,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
                     s2n_stuffer_data_available(&client_conn->handshake.io)));
-            EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+            EXPECT_SUCCESS(s2n_establish_session(server_conn));
 
             EXPECT_EQUAL(client_conn->early_data_state, S2N_EARLY_DATA_REQUESTED);
             EXPECT_EQUAL(server_conn->early_data_state, S2N_EARLY_DATA_REJECTED);
@@ -351,7 +351,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
                     s2n_stuffer_data_available(&client_conn->handshake.io)));
-            EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+            EXPECT_SUCCESS(s2n_establish_session(server_conn));
 
             EXPECT_EQUAL(client_conn->early_data_state, S2N_EARLY_DATA_REQUESTED);
             EXPECT_EQUAL(server_conn->early_data_state, S2N_EARLY_DATA_ACCEPTED);
@@ -379,7 +379,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
                     s2n_stuffer_data_available(&client_conn->handshake.io)));
-            EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+            EXPECT_SUCCESS(s2n_establish_session(server_conn));
 
             EXPECT_EQUAL(client_conn->early_data_state, S2N_EARLY_DATA_NOT_REQUESTED);
             EXPECT_EQUAL(server_conn->early_data_state, S2N_EARLY_DATA_NOT_REQUESTED);
@@ -425,7 +425,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
                     s2n_stuffer_data_available(&client_conn->handshake.io)));
-            EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+            EXPECT_SUCCESS(s2n_establish_session(server_conn));
             EXPECT_EQUAL(client_conn->early_data_state, S2N_EARLY_DATA_REQUESTED);
 
             /* Force a retry */
@@ -479,7 +479,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
                     s2n_stuffer_data_available(&client_conn->handshake.io)));
-            EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+            EXPECT_SUCCESS(s2n_establish_session(server_conn));
             EXPECT_EQUAL(client_conn->early_data_state, S2N_EARLY_DATA_REQUESTED);
             EXPECT_EQUAL(server_conn->early_data_state, S2N_EARLY_DATA_REJECTED);
 

--- a/tests/unit/s2n_server_early_data_indication_test.c
+++ b/tests/unit/s2n_server_early_data_indication_test.c
@@ -26,7 +26,7 @@ static S2N_RESULT s2n_exchange_hellos(struct s2n_connection *client_conn, struct
     RESULT_GUARD_POSIX(s2n_client_hello_send(client_conn));
     RESULT_GUARD_POSIX(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
             s2n_stuffer_data_available(&client_conn->handshake.io)));
-    RESULT_GUARD_POSIX(s2n_client_hello_recv(server_conn));
+    RESULT_GUARD_POSIX(s2n_establish_session(server_conn));
 
     RESULT_GUARD_POSIX(s2n_server_hello_send(server_conn));
     RESULT_GUARD_POSIX(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io,

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -298,9 +298,6 @@ int s2n_process_client_hello(struct s2n_connection *conn)
     /* Now choose the ciphers we have certs for. */
     POSIX_GUARD(s2n_set_cipher_as_tls_server(conn, client_hello->cipher_suites.data, client_hello->cipher_suites.size / 2));
 
-    /* Check that early data requirements are met, if early data requested */
-    POSIX_GUARD_RESULT(s2n_early_data_accept_or_reject(conn));
-
     /* If we're using a PSK, we don't need to choose a signature algorithm or certificate,
      * because no additional auth is required. */
     if (conn->psk_params.chosen_psk != NULL) {

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -113,6 +113,10 @@ S2N_RESULT s2n_early_data_accept_or_reject(struct s2n_connection *conn)
         return S2N_RESULT_OK;
     }
 
+    if (conn->handshake.early_data_async_state.conn) {
+        RESULT_BAIL(S2N_ERR_ASYNC_BLOCKED);
+    }
+
     /**
      *= https://tools.ietf.org/rfc/rfc8446#section-4.2.10
      *# If any of these checks fail, the server MUST NOT respond with the
@@ -137,11 +141,17 @@ S2N_RESULT s2n_early_data_accept_or_reject(struct s2n_connection *conn)
 
     /* If early data would otherwise be accepted, let the application apply any additional restrictions.
      * For example, an application could use this callback to implement anti-replay protections.
+     *
+     * This callback can be either synchronous or asynchronous. The handshake will not proceed until
+     * the application either accepts or rejects early data.
      */
     RESULT_ENSURE_REF(conn->config);
     if (conn->config->early_data_cb) {
-        struct s2n_offered_early_data offered_early_data = { .conn = conn };
-        RESULT_GUARD_POSIX(conn->config->early_data_cb(conn, &offered_early_data));
+        conn->handshake.early_data_async_state.conn = conn;
+        RESULT_GUARD_POSIX(conn->config->early_data_cb(conn, &conn->handshake.early_data_async_state));
+        if (conn->early_data_state == S2N_EARLY_DATA_REQUESTED) {
+            RESULT_BAIL(S2N_ERR_ASYNC_BLOCKED);
+        }
     } else {
         RESULT_GUARD(s2n_connection_set_early_data_state(conn, S2N_EARLY_DATA_ACCEPTED));
     }

--- a/tls/s2n_establish_session.c
+++ b/tls/s2n_establish_session.c
@@ -40,6 +40,7 @@ int s2n_establish_session(struct s2n_connection *conn)
         conn->handshake.client_hello_received = 1;
     }
 
+    POSIX_GUARD_RESULT(s2n_early_data_accept_or_reject(conn));
     POSIX_GUARD(s2n_conn_set_handshake_type(conn));
 
     if (conn->client_hello_version != S2N_SSLv2)

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -162,6 +162,10 @@ struct s2n_handshake {
     /* State of the async pkey operation during handshake */
     s2n_async_state async_state;
 
+    /* State of the async early data callback.
+     * If not initialized, then the callback has not been triggered yet. */
+    struct s2n_offered_early_data early_data_async_state;
+
     /* Indicates the CLIENT_HELLO message has been completely received */
     unsigned client_hello_received:1;
 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1348,6 +1348,7 @@ static int s2n_handle_retry_state(struct s2n_connection *conn)
     } else {
         /* The read handler processed the record successfully, we are done with this
          * record. Advance the state machine. */
+        POSIX_GUARD(s2n_tls13_handle_secrets(conn));
         POSIX_GUARD(s2n_advance_message(conn));
     }
 


### PR DESCRIPTION
### Resolved issues:

 resolves #2576

### Description of changes: 

Makes the early data callback asynchronous. Since the primary use case for the callback is anti-reply protection, which will likely involve consulting some sort of data store, most customers will want to call it asynchronously. 

### Call-outs:
* **What's with crypto/s2n_hkdf.c?** I didn't set up a test properly and found a possible divide by zero error, so I added a safety check.
* **Why add the call to `s2n_tls13_handle_secrets`?** This is correcting a bug. Previously, we called `s2n_advance_message` when retrying after an async block, but we did NOT call `s2n_tls13_handle_secrets`. See [here](https://github.com/aws/s2n-tls/blob/be77f5abde13c7de6b701199a15b2f2733bdc0a4/tls/s2n_handshake_io.c#L1348-L1352). This led us to skip some secret calculations and led to decryption issues.

### Testing:

Unit and functional tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
