### PR TITLE
Set early data context for new session tickets

### DIFF
--- a/tests/unit/s2n_early_data_test.c
+++ b/tests/unit/s2n_early_data_test.c
@@ -940,14 +940,14 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(conn->server_early_data_context.size, sizeof(data));
         EXPECT_BYTEARRAY_EQUAL(conn->server_early_data_context.data, data, sizeof(data));
 
+        /* Clear context */
+        EXPECT_SUCCESS(s2n_connection_set_server_early_data_context(conn, NULL, 0));
+        EXPECT_EQUAL(conn->server_early_data_context.size, 0);
+
         /* Set context again */
         EXPECT_SUCCESS(s2n_connection_set_server_early_data_context(conn, data, 1));
         EXPECT_EQUAL(conn->server_early_data_context.size, 1);
         EXPECT_BYTEARRAY_EQUAL(conn->server_early_data_context.data, data, 1);
-
-        /* Clear context */
-        EXPECT_SUCCESS(s2n_connection_set_server_early_data_context(conn, NULL, 0));
-        EXPECT_EQUAL(conn->server_early_data_context.size, 0);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }

--- a/tests/unit/s2n_early_data_test.c
+++ b/tests/unit/s2n_early_data_test.c
@@ -924,6 +924,34 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
+    /* Test s2n_connection_set_server_early_data_context */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        const uint8_t data[] = "hello world";
+
+        /* Safety */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_set_server_early_data_context(NULL, data, 1), S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_set_server_early_data_context(conn, NULL, 1), S2N_ERR_NULL);
+        EXPECT_EQUAL(conn->server_early_data_context.size, 0);
+        EXPECT_EQUAL(conn->server_early_data_context.allocated, 0);
+
+        /* Set context */
+        EXPECT_SUCCESS(s2n_connection_set_server_early_data_context(conn, data, sizeof(data)));
+        EXPECT_EQUAL(conn->server_early_data_context.size, sizeof(data));
+        EXPECT_BYTEARRAY_EQUAL(conn->server_early_data_context.data, data, sizeof(data));
+
+        /* Set context again */
+        EXPECT_SUCCESS(s2n_connection_set_server_early_data_context(conn, data, 1));
+        EXPECT_EQUAL(conn->server_early_data_context.size, 1);
+        EXPECT_BYTEARRAY_EQUAL(conn->server_early_data_context.data, data, 1);
+
+        /* Clear context */
+        EXPECT_SUCCESS(s2n_connection_set_server_early_data_context(conn, NULL, 0));
+        EXPECT_EQUAL(conn->server_early_data_context.size, 0);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
     /* Test s2n_early_data_record_bytes */
     {
         /* Safety check */

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -657,6 +657,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     POSIX_GUARD(s2n_free(&conn->application_protocols_overridden));
     POSIX_GUARD(s2n_free(&conn->our_quic_transport_parameters));
     POSIX_GUARD(s2n_free(&conn->peer_quic_transport_parameters));
+    POSIX_GUARD(s2n_free(&conn->server_early_data_context));
 
     /* Allocate memory for handling handshakes */
     POSIX_GUARD(s2n_stuffer_resize(&conn->handshake.io, S2N_LARGE_RECORD_LENGTH));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -469,6 +469,7 @@ int s2n_connection_free(struct s2n_connection *conn)
     POSIX_GUARD(s2n_free(&conn->status_response));
     POSIX_GUARD(s2n_free(&conn->our_quic_transport_parameters));
     POSIX_GUARD(s2n_free(&conn->peer_quic_transport_parameters));
+    POSIX_GUARD(s2n_free(&conn->server_early_data_context));
     POSIX_GUARD(s2n_stuffer_free(&conn->in));
     POSIX_GUARD(s2n_stuffer_free(&conn->out));
     POSIX_GUARD(s2n_stuffer_free(&conn->handshake.io));

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -356,6 +356,7 @@ struct s2n_connection {
 
     s2n_early_data_state early_data_state;
     uint32_t server_max_early_data_size;
+    struct s2n_blob server_early_data_context;
 };
 
 int s2n_connection_is_managed_corked(const struct s2n_connection *s2n_connection);

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -167,6 +167,18 @@ S2N_RESULT s2n_early_data_get_server_max_size(struct s2n_connection *conn, uint3
     return S2N_RESULT_OK;
 }
 
+int s2n_connection_set_server_early_data_context(struct s2n_connection *conn, const uint8_t *context, uint16_t context_size)
+{
+    POSIX_ENSURE_REF(conn);
+    if (context_size > 0) {
+        POSIX_ENSURE_REF(context);
+    }
+
+    POSIX_GUARD(s2n_realloc(&conn->server_early_data_context, context_size));
+    POSIX_CHECKED_MEMCPY(conn->server_early_data_context.data, context, context_size);
+    return S2N_SUCCESS;
+}
+
 S2N_CLEANUP_RESULT s2n_early_data_config_free(struct s2n_early_data_config *config)
 {
     if (config == NULL) {

--- a/tls/s2n_early_data.h
+++ b/tls/s2n_early_data.h
@@ -58,6 +58,7 @@ S2N_RESULT s2n_early_data_validate_recv(struct s2n_connection *conn);
 
 int s2n_config_set_server_max_early_data_size(struct s2n_config *config, uint32_t max_early_data_size);
 int s2n_connection_set_server_max_early_data_size(struct s2n_connection *conn, uint32_t max_early_data_size);
+int s2n_connection_set_server_early_data_context(struct s2n_connection *conn, const uint8_t *context, uint16_t context_size);
 
 int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data_size,
         uint8_t cipher_suite_first_byte, uint8_t cipher_suite_second_byte);


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/2571

### Description of changes: 

All PSKs may include an optional context for use by https://github.com/aws/s2n-tls/pull/2715 to let the application accept/reject early data. While the context is manually configured for individual external PSKs, the server needs to incorporate the context for resumption PSKs into the new session tickets issued.

### Call-outs:

This PR does not start using the server early data context when issuing new tickets. That requires some messy updates to the serialization logic to handle variable-sized tickets, and will be reviewed separately.

### Testing:

Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
