### PR TITLE
Make server_name send check more efficient

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1177,7 +1177,8 @@ const char *s2n_get_server_name(struct s2n_connection *conn);
 
 **s2n_get_server_name** returns the server name associated with a connection,
 or NULL if none is found. This can be used by a server to determine which server
-name the client is using.
+name the client is using. This function returns the first ServerName entry in the ServerNameList
+sent by the client. Subsequent entries are not returned.
 
 ### s2n\_connection\_set\_blinding
 

--- a/tls/extensions/s2n_client_server_name.c
+++ b/tls/extensions/s2n_client_server_name.c
@@ -39,7 +39,7 @@ const s2n_extension_type s2n_client_server_name_extension = {
 
 static bool s2n_client_server_name_should_send(struct s2n_connection *conn)
 {
-    return conn && strlen(conn->server_name) > 0;
+    return conn && conn->server_name[0] != '\0';
 }
 
 static int s2n_client_server_name_send(struct s2n_connection *conn, struct s2n_stuffer *out)

--- a/tls/extensions/s2n_client_server_name.c
+++ b/tls/extensions/s2n_client_server_name.c
@@ -58,6 +58,9 @@ static int s2n_client_server_name_send(struct s2n_connection *conn, struct s2n_s
     return S2N_SUCCESS;
 }
 
+/* Read the extension up to the first item in ServerNameList. Store the first entry's length in server_name_len.
+ * For now s2n ignores all subsequent items in ServerNameList.
+ */
 static int s2n_client_server_name_check(struct s2n_connection *conn, struct s2n_stuffer *extension, uint16_t *server_name_len)
 {
     POSIX_ENSURE_REF(conn);


### PR DESCRIPTION
Tiny change avoid iterating over entire string to check for empty.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? existing tests
