### PR TITLE
Include early data config in session tickets

### DIFF
--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -518,6 +518,7 @@ int main(int argc, char **argv)
             const uint32_t test_max_early_data_size = 100;
             const uint8_t test_early_data_context[] = "test context";
             const uint8_t test_app_protocol[] = "test protocol";
+            const uint8_t test_app_protocol_len = strlen((const char *)test_app_protocol);
 
             struct s2n_config *config = s2n_config_new();
             EXPECT_NOT_NULL(config);
@@ -552,8 +553,8 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(psk->early_data_config.protocol_version, S2N_TLS13);
             EXPECT_EQUAL(psk->early_data_config.max_early_data_size, test_max_early_data_size);
             EXPECT_EQUAL(psk->early_data_config.cipher_suite, &s2n_tls13_aes_256_gcm_sha384);
-            EXPECT_EQUAL(psk->early_data_config.application_protocol.size, strlen((const char*) test_app_protocol));
-            EXPECT_BYTEARRAY_EQUAL(psk->early_data_config.application_protocol.data, test_app_protocol, sizeof(test_app_protocol));
+            EXPECT_EQUAL(psk->early_data_config.application_protocol.size, test_app_protocol_len);
+            EXPECT_BYTEARRAY_EQUAL(psk->early_data_config.application_protocol.data, test_app_protocol, test_app_protocol_len);
             EXPECT_EQUAL(psk->early_data_config.context.size, sizeof(test_early_data_context));
             EXPECT_BYTEARRAY_EQUAL(psk->early_data_config.context.data, test_early_data_context, sizeof(test_early_data_context));
 

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -631,7 +631,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_free(config));
         }
 
-        /* Test with large ticket - TLS13_EXPECTED_CLIENT_TICKET_SIZE is correct */
+        /* Test with large ticket - TLS13_FIXED_CLIENT_TICKET_SIZE is correct */
         {
             struct s2n_config *config = s2n_config_new();
             EXPECT_NOT_NULL(config);
@@ -652,6 +652,8 @@ int main(int argc, char **argv)
             server_conn->actual_protocol_version = S2N_TLS13;
             /* Cipher suite with max key size */
             server_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
+            /* Early data information extends ticket */
+            EXPECT_SUCCESS(s2n_connection_set_server_max_early_data_size(server_conn, 10));
 
             DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
@@ -660,13 +662,42 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_skip_read(&stuffer, sizeof(uint8_t) + SIZEOF_UINT24));
             EXPECT_OK(s2n_tls13_server_nst_recv(client_conn, &stuffer));
 
-            if (cb_session_data_len != TLS13_EXPECTED_CLIENT_TICKET_SIZE) {
-                fprintf(stdout, "\nTLS13_EXPECTED_CLIENT_TICKET_SIZE (%i) should be %i\n",
-                        TLS13_EXPECTED_CLIENT_TICKET_SIZE, (int) cb_session_data_len);
+            if (cb_session_data_len != TLS13_FIXED_CLIENT_TICKET_SIZE) {
+                fprintf(stdout, "\nTLS13_FIXED_CLIENT_TICKET_SIZE (%i) should be %i\n",
+                        TLS13_FIXED_CLIENT_TICKET_SIZE, (int) cb_session_data_len);
             }
-            EXPECT_EQUAL(cb_session_data_len, TLS13_EXPECTED_CLIENT_TICKET_SIZE);
+            EXPECT_EQUAL(cb_session_data_len, TLS13_FIXED_CLIENT_TICKET_SIZE);
 
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
+        }
+
+        /* Can't write ticket larger than allowed size of a PSK identity */
+        {
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_NOT_NULL(config);
+            EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, 1));
+            EXPECT_SUCCESS(s2n_config_set_session_ticket_cb(config, s2n_test_session_ticket_cb, NULL));
+            EXPECT_SUCCESS(s2n_setup_test_ticket_key(config));
+
+            struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(server_conn);
+            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+            server_conn->actual_protocol_version = S2N_TLS13;
+            server_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
+            EXPECT_SUCCESS(s2n_connection_set_server_max_early_data_size(server_conn, 10));
+
+            /* Set context to be UINT16_MAX */
+            uint8_t early_data_context[UINT16_MAX] = { 0 };
+            EXPECT_SUCCESS(s2n_connection_set_server_early_data_context(server_conn,
+                    early_data_context, sizeof(early_data_context)));
+
+            DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+            EXPECT_ERROR_WITH_ERRNO(s2n_tls13_server_nst_write(server_conn, &stuffer), S2N_ERR_SIZE_MISMATCH);
+
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
             EXPECT_SUCCESS(s2n_config_free(config));
         }
@@ -841,11 +872,11 @@ int main(int argc, char **argv)
             EXPECT_OK(s2n_tls13_server_nst_send(conn, &blocked));
 
             uint32_t expected_max_size = s2n_stuffer_data_available(&output) - S2N_TLS_RECORD_HEADER_LENGTH;
-            if (TLS13_EXPECTED_NEW_SESSION_TICKET_SIZE != expected_max_size) {
-                fprintf(stdout, "\nTLS13_EXPECTED_NEW_SESSION_TICKET_SIZE (%i) should be %i\n",
-                        TLS13_EXPECTED_NEW_SESSION_TICKET_SIZE, expected_max_size);
+            if (TLS13_FIXED_NEW_SESSION_TICKET_SIZE != expected_max_size) {
+                fprintf(stdout, "\nTLS13_FIXED_NEW_SESSION_TICKET_SIZE (%i) should be %i\n",
+                        TLS13_FIXED_NEW_SESSION_TICKET_SIZE, expected_max_size);
             }
-            EXPECT_EQUAL(TLS13_EXPECTED_NEW_SESSION_TICKET_SIZE, expected_max_size);
+            EXPECT_EQUAL(TLS13_FIXED_NEW_SESSION_TICKET_SIZE, expected_max_size);
 
             EXPECT_SUCCESS(s2n_stuffer_free(&output));
             EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tls/extensions/s2n_nst_early_data_indication.c
+++ b/tls/extensions/s2n_nst_early_data_indication.c
@@ -58,7 +58,9 @@ static int s2n_nst_early_data_indication_send(struct s2n_connection *conn, struc
 static int s2n_nst_early_data_indiction_recv(struct s2n_connection *conn, struct s2n_stuffer *in)
 {
     POSIX_ENSURE_REF(conn);
-    POSIX_GUARD(s2n_stuffer_read_uint32(in, &conn->server_max_early_data_size));
+    uint32_t server_max_early_data = 0;
+    POSIX_GUARD(s2n_stuffer_read_uint32(in, &server_max_early_data));
+    POSIX_GUARD(s2n_connection_set_server_max_early_data_size(conn, server_max_early_data));
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -231,6 +231,7 @@ static S2N_RESULT s2n_tls13_client_deserialize_session_state(struct s2n_connecti
     RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(from, &secret_len));
     RESULT_ENSURE_LTE(secret_len, S2N_TLS_SECRET_LEN);
     uint8_t *secret_data = s2n_stuffer_raw_read(from, secret_len);
+    RESULT_ENSURE_REF(secret_data);
     RESULT_GUARD_POSIX(s2n_psk_set_secret(&psk, secret_data, secret_len));
 
     uint32_t max_early_data_size = 0;
@@ -243,11 +244,13 @@ static S2N_RESULT s2n_tls13_client_deserialize_session_state(struct s2n_connecti
         uint8_t app_proto_size = 0;
         RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(from, &app_proto_size));
         uint8_t *app_proto_data = s2n_stuffer_raw_read(from, app_proto_size);
+        RESULT_ENSURE_REF(app_proto_data);
         RESULT_GUARD_POSIX(s2n_psk_set_application_protocol(&psk, app_proto_data, app_proto_size));
 
         uint16_t early_data_context_size = 0;
         RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(from, &early_data_context_size));
         uint8_t *early_data_context_data = s2n_stuffer_raw_read(from, early_data_context_size);
+        RESULT_ENSURE_REF(early_data_context_data);
         RESULT_GUARD_POSIX(s2n_psk_set_context(&psk, early_data_context_data, early_data_context_size));
     }
 
@@ -656,6 +659,7 @@ int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_ticket_fi
     POSIX_GUARD(s2n_stuffer_skip_read(&copy_for_encryption, unencrypted_size));
     uint32_t state_blob_size = s2n_stuffer_data_available(&copy_for_encryption);
     uint8_t *state_blob_data = s2n_stuffer_raw_read(&copy_for_encryption, state_blob_size);
+    POSIX_ENSURE_REF(state_blob_data);
     POSIX_GUARD(s2n_blob_init(&state_blob, state_blob_data, state_blob_size));
 
     POSIX_GUARD(s2n_aes256_gcm.io.aead.encrypt(&aes_ticket_key, &iv, &aad_blob, &state_blob, &state_blob));

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -32,10 +32,22 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_random.h"
 
-#define TLS13_FIXED_NEW_SESSION_TICKET_SIZE     143
-#define TLS13_FIXED_CLIENT_TICKET_SIZE          188
-#define TLS13_VARIABLE_TICKET_FIELD_SIZE(conn) \
-    ( strlen(conn->application_protocol) + conn->server_early_data_context.size )
+/*
+ * We want to allocate the right amount of memory for the ticket / NewSessionTicket message.
+ *
+ * Some fields in the ticket are of a constant size (like the cipher suite iana) or have a
+ * predictable and reasonable maximum size (like the secret). However, others (like the early data
+ * context) can vary wildly and do not have a reasonable maximum size we can use. Therefore the
+ * total amount of memory needed is:
+ *
+ * SIZE = FIXED_SIZE + VARIABLE_SIZE(conn)
+ *
+ * The correctness of these sizes are enforced via unit tests.
+ */
+#define S2N_TLS13_VARIABLE_SESSION_STATE_SIZE(conn) ( ((uint8_t) strlen(conn->application_protocol)) + conn->server_early_data_context.size )
+
+#define S2N_TLS13_NEW_SESSION_TICKET_SIZE(conn)     ( 143 + S2N_TLS13_VARIABLE_SESSION_STATE_SIZE(conn) )
+#define S2N_TLS13_CLIENT_SESSION_TICKET_SIZE(conn)  ( 75 + conn->client_ticket.size + S2N_TLS13_VARIABLE_SESSION_STATE_SIZE(conn) )
 
 int s2n_server_nst_recv(struct s2n_connection *conn) {
     POSIX_GUARD(s2n_stuffer_read_uint32(&conn->handshake.io, &conn->ticket_lifetime_hint));
@@ -110,8 +122,7 @@ S2N_RESULT s2n_tls13_server_nst_send(struct s2n_connection *conn, s2n_blocked_st
     RESULT_ENSURE(conn->tickets_sent <= conn->tickets_to_send, S2N_ERR_INTEGER_OVERFLOW);
 
     DEFER_CLEANUP(struct s2n_stuffer nst_stuffer = { 0 }, s2n_stuffer_free);
-    RESULT_GUARD_POSIX(s2n_stuffer_growable_alloc(&nst_stuffer,
-            TLS13_FIXED_NEW_SESSION_TICKET_SIZE + TLS13_VARIABLE_TICKET_FIELD_SIZE(conn)));
+    RESULT_GUARD_POSIX(s2n_stuffer_growable_alloc(&nst_stuffer, S2N_TLS13_NEW_SESSION_TICKET_SIZE(conn)));
 
     while (conn->tickets_to_send - conn->tickets_sent > 0) {
         RESULT_GUARD(s2n_tls13_server_nst_write(conn, &nst_stuffer));
@@ -321,8 +332,7 @@ S2N_RESULT s2n_tls13_server_nst_recv(struct s2n_connection *conn, struct s2n_stu
 
         /* Serialize resumption state */
         DEFER_CLEANUP(struct s2n_stuffer session_stuffer = { 0 }, s2n_stuffer_free);
-        RESULT_GUARD_POSIX(s2n_stuffer_growable_alloc(&session_stuffer,
-                TLS13_FIXED_NEW_SESSION_TICKET_SIZE + TLS13_VARIABLE_TICKET_FIELD_SIZE(conn)));
+        RESULT_GUARD_POSIX(s2n_stuffer_growable_alloc(&session_stuffer, S2N_TLS13_CLIENT_SESSION_TICKET_SIZE(conn)));
         RESULT_GUARD_POSIX(s2n_client_serialize_resumption_state(conn, &ticket_fields, &session_stuffer));
 
         session_stuffer.blob.size = s2n_stuffer_data_available(&session_stuffer);

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -32,15 +32,8 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_random.h"
 
-#define TLS13_MAX_NEW_SESSION_TICKET_SIZE sizeof(uint8_t)  + /* message type   */ \
-                                          SIZEOF_UINT24    + /* message length */ \
-                                          sizeof(uint32_t) + /* ticket lifetime */ \
-                                          sizeof(uint32_t) + /* ticket age add */ \
-                                          sizeof(uint8_t)  + /* nonce length */ \
-                                          sizeof(uint16_t) + /* nonce */ \
-                                          sizeof(uint16_t) + /* ticket length */ \
-                                          S2N_MAX_TICKET_SIZE_IN_BYTES + /* ticket */ \
-                                          sizeof(uint16_t)   /* extensions length */
+#define TLS13_EXPECTED_NEW_SESSION_TICKET_SIZE 136
+#define TLS13_EXPECTED_CLIENT_TICKET_SIZE 177
 
 int s2n_server_nst_recv(struct s2n_connection *conn) {
     POSIX_GUARD(s2n_stuffer_read_uint32(&conn->handshake.io, &conn->ticket_lifetime_hint));
@@ -113,18 +106,22 @@ S2N_RESULT s2n_tls13_server_nst_send(struct s2n_connection *conn, s2n_blocked_st
     }
 
     RESULT_ENSURE(conn->tickets_sent <= conn->tickets_to_send, S2N_ERR_INTEGER_OVERFLOW);
-    while (conn->tickets_to_send - conn->tickets_sent > 0) {
-        uint8_t nst_data[TLS13_MAX_NEW_SESSION_TICKET_SIZE] = { 0 };
-        struct s2n_blob nst_blob = { 0 };
-        struct s2n_stuffer nst_stuffer = { 0 };
-        RESULT_GUARD_POSIX(s2n_blob_init(&nst_blob, nst_data, sizeof(nst_data)));
-        RESULT_GUARD_POSIX(s2n_stuffer_init(&nst_stuffer, &nst_blob));
 
+    DEFER_CLEANUP(struct s2n_stuffer nst_stuffer = { 0 }, s2n_stuffer_free);
+    RESULT_GUARD_POSIX(s2n_stuffer_growable_alloc(&nst_stuffer, TLS13_EXPECTED_NEW_SESSION_TICKET_SIZE));
+
+    while (conn->tickets_to_send - conn->tickets_sent > 0) {
         RESULT_GUARD(s2n_tls13_server_nst_write(conn, &nst_stuffer));
-        nst_blob.size = s2n_stuffer_data_available(&nst_stuffer);
+
+        struct s2n_blob nst_blob = { 0 };
+        uint16_t nst_size = s2n_stuffer_data_available(&nst_stuffer);
+        uint8_t *nst_data = s2n_stuffer_raw_read(&nst_stuffer, nst_size);
+        RESULT_ENSURE_REF(nst_data);
+        RESULT_GUARD_POSIX(s2n_blob_init(&nst_blob, nst_data, nst_size));
 
         RESULT_GUARD_POSIX(s2n_record_write(conn, TLS_HANDSHAKE, &nst_blob));
         RESULT_GUARD_POSIX(s2n_flush(conn, blocked));
+        RESULT_GUARD_POSIX(s2n_stuffer_wipe(&nst_stuffer));
     }
 
     return S2N_RESULT_OK;
@@ -253,20 +250,11 @@ S2N_RESULT s2n_tls13_server_nst_write(struct s2n_connection *conn, struct s2n_st
     uint8_t session_secret_data[S2N_TLS13_SECRET_MAX_LEN] = { 0 };
     RESULT_GUARD_POSIX(s2n_generate_session_secret(conn, &nonce, session_secret_data, &ticket_fields.session_secret));
 
-    /* Create ticket */
-    uint8_t ticket_data[S2N_MAX_TICKET_SIZE_IN_BYTES] = { 0 };
-    struct s2n_blob ticket_blob = { 0 };
-    struct s2n_stuffer session_ticket = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&ticket_blob, ticket_data, sizeof(ticket_data)));
-    RESULT_GUARD_POSIX(s2n_stuffer_init(&session_ticket, &ticket_blob));
-    RESULT_GUARD_POSIX(s2n_encrypt_session_ticket(conn, &ticket_fields, &session_ticket));
-    /* The encrypted ticket may be less than S2N_MAX_TICKET_SIZE_IN_BYTES */
-    ticket_blob.size = s2n_stuffer_data_available(&session_ticket);
-
-    /* Write session ticket */
-    RESULT_ENSURE(ticket_blob.size <= UINT8_MAX, S2N_ERR_SAFETY);
-    RESULT_GUARD_POSIX(s2n_stuffer_write_uint16(output, ticket_blob.size));
-    RESULT_GUARD_POSIX(s2n_stuffer_write(output, &ticket_blob));
+    /* Write ticket */
+    struct s2n_stuffer_reservation ticket_size = { 0 };
+    RESULT_GUARD_POSIX(s2n_stuffer_reserve_uint16(output, &ticket_size));
+    RESULT_GUARD_POSIX(s2n_encrypt_session_ticket(conn, &ticket_fields, output));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_vector_size(&ticket_size));
 
     RESULT_GUARD_POSIX(s2n_extension_list_send(S2N_EXTENSION_LIST_NST, conn, output));
 

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -32,8 +32,10 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_random.h"
 
-#define TLS13_EXPECTED_NEW_SESSION_TICKET_SIZE 136
-#define TLS13_EXPECTED_CLIENT_TICKET_SIZE 177
+#define TLS13_FIXED_NEW_SESSION_TICKET_SIZE     143
+#define TLS13_FIXED_CLIENT_TICKET_SIZE          188
+#define TLS13_VARIABLE_TICKET_FIELD_SIZE(conn) \
+    ( strlen(conn->application_protocol) + conn->server_early_data_context.size )
 
 int s2n_server_nst_recv(struct s2n_connection *conn) {
     POSIX_GUARD(s2n_stuffer_read_uint32(&conn->handshake.io, &conn->ticket_lifetime_hint));
@@ -108,7 +110,8 @@ S2N_RESULT s2n_tls13_server_nst_send(struct s2n_connection *conn, s2n_blocked_st
     RESULT_ENSURE(conn->tickets_sent <= conn->tickets_to_send, S2N_ERR_INTEGER_OVERFLOW);
 
     DEFER_CLEANUP(struct s2n_stuffer nst_stuffer = { 0 }, s2n_stuffer_free);
-    RESULT_GUARD_POSIX(s2n_stuffer_growable_alloc(&nst_stuffer, TLS13_EXPECTED_NEW_SESSION_TICKET_SIZE));
+    RESULT_GUARD_POSIX(s2n_stuffer_growable_alloc(&nst_stuffer,
+            TLS13_FIXED_NEW_SESSION_TICKET_SIZE + TLS13_VARIABLE_TICKET_FIELD_SIZE(conn)));
 
     while (conn->tickets_to_send - conn->tickets_sent > 0) {
         RESULT_GUARD(s2n_tls13_server_nst_write(conn, &nst_stuffer));
@@ -318,7 +321,8 @@ S2N_RESULT s2n_tls13_server_nst_recv(struct s2n_connection *conn, struct s2n_stu
 
         /* Serialize resumption state */
         DEFER_CLEANUP(struct s2n_stuffer session_stuffer = { 0 }, s2n_stuffer_free);
-        RESULT_GUARD_POSIX(s2n_stuffer_growable_alloc(&session_stuffer, TLS13_EXPECTED_CLIENT_TICKET_SIZE));
+        RESULT_GUARD_POSIX(s2n_stuffer_growable_alloc(&session_stuffer,
+                TLS13_FIXED_NEW_SESSION_TICKET_SIZE + TLS13_VARIABLE_TICKET_FIELD_SIZE(conn)));
         RESULT_GUARD_POSIX(s2n_client_serialize_resumption_state(conn, &ticket_fields, &session_stuffer));
 
         session_stuffer.blob.size = s2n_stuffer_data_available(&session_stuffer);


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/2573

### Description of changes: 

Follow-up to https://github.com/aws/s2n-tls/pull/2718
We need to serialize the early data configuration-- max_early_data, application_protocol, and context-- into TLS1.3 tickets. The actual serialize / client deserialize part is fairly straightforward, but the current logic assumes that tickets are a set size. Because both the application_protocol and early data context have huge variation in their possible size, the ticket logic needed to be updated to handle variable-sized tickets.

### Call-outs:
* This covers the server issuing tickets and the client deserializing them into PSKs. It does NOT cover the server deserializing them. @maddeleine has a separate PR out to add the non-early-data server de-serialization logic: https://github.com/aws/s2n-tls/pull/2709 Once that is merged, I'll incorporate early data.
* **Why use magic numbers for TLS13_FIXED_NEW_SESSION_TICKET_SIZE  and TLS13_FIXED_CLIENT_TICKET_SIZE?** With all the fields that needed to be included, the non-magic numbers were getting too complicated to actually visually verify. I believe it's actually more readable / useable to use magic numbers and enforce their correctness via tests.

### Testing:

Existing NST / client deserialization tests pass. Added tests that enable early data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
