### PR TITLE
External PSK integration tests

### DIFF
--- a/bin/common.c
+++ b/bin/common.c
@@ -101,9 +101,9 @@ static const uint8_t hex_inverse[256] = {
 
 int s2n_str_hex_to_bytes(const uint8_t *hex, uint8_t *out_bytes, uint32_t *out_bytes_len)
 {
-    GUARD_EXIT_NULL(hex, "The hex-encoded string read is NULL\n");
-    GUARD_EXIT_NULL(out_bytes, "The output bytes buffer is NULL\n");
-    GUARD_EXIT_NULL(out_bytes_len, "The output bytes buffer length is NULL\n");
+    GUARD_EXIT_NULL(hex);
+    GUARD_EXIT_NULL(out_bytes);
+    GUARD_EXIT_NULL(out_bytes_len);
 
     uint32_t len_with_spaces = strlen((const char*)hex);
     size_t i = 0, j = 0;
@@ -138,8 +138,8 @@ int s2n_str_hex_to_bytes(const uint8_t *hex, uint8_t *out_bytes, uint32_t *out_b
 
 static int s2n_get_psk_hmac_alg(s2n_psk_hmac *psk_hmac, char *hmac_str)
 {
-    GUARD_EXIT_NULL(psk_hmac, "PSK HMAC is NULL");
-    GUARD_EXIT_NULL(hmac_str, "HMAC string is NULL");
+    GUARD_EXIT_NULL(psk_hmac);
+    GUARD_EXIT_NULL(hmac_str);
 
     if (strcmp(hmac_str, "S2N_PSK_HMAC_SHA256") == 0) {
         *psk_hmac = S2N_PSK_HMAC_SHA256;
@@ -153,12 +153,12 @@ static int s2n_get_psk_hmac_alg(s2n_psk_hmac *psk_hmac, char *hmac_str)
 
 int s2n_setup_external_psk(struct s2n_psk *psk_list[S2N_MAX_PSK_LIST_LENGTH], size_t *psk_idx, char *params)
 {
-    GUARD_EXIT_NULL(psk_list, "PSK list is NULL");
-    GUARD_EXIT_NULL(psk_idx, "PSK index is NULL");
-    GUARD_EXIT_NULL(params, "PSK parameters is NULL");
+    GUARD_EXIT_NULL(psk_list);
+    GUARD_EXIT_NULL(psk_idx);
+    GUARD_EXIT_NULL(params);
 
     struct s2n_psk *psk = s2n_external_psk_new();
-    GUARD_EXIT_NULL(psk, "Error initializing PSK, NULL value obtained");
+    GUARD_EXIT_NULL(psk);
     /* Default HMAC algorithm is S2N_PSK_HMAC_SHA256 */
     s2n_psk_hmac psk_hmac_alg = S2N_PSK_HMAC_SHA256;
     size_t idx = 0;
@@ -172,7 +172,8 @@ int s2n_setup_external_psk(struct s2n_psk *psk_list[S2N_MAX_PSK_LIST_LENGTH], si
                 break;
             case 1:
                 secret_len = strlen(token) / 2;
-                GUARD_EXIT_NULL(secret = malloc(secret_len), "Error allocating memory for psk secret");
+                secret = malloc(secret_len);
+                GUARD_EXIT_NULL(secret);
                 GUARD_EXIT(s2n_str_hex_to_bytes((const uint8_t *)token, secret, &secret_len), "Error converting hex-encoded psk secret to bytes");
                 GUARD_EXIT(s2n_psk_set_secret(psk, (const uint8_t *)secret, secret_len), "Error setting psk secret");
                 free(secret);

--- a/bin/common.c
+++ b/bin/common.c
@@ -114,17 +114,20 @@ int s2n_str_hex_to_bytes(const uint8_t *hex, uint8_t *out_bytes, uint32_t *out_b
         }
 
         uint8_t high_nibble = hex_inverse[hex[j]];
-        if (high_nibble != 255) {
-            fprintf(stderr, "Invalid HEX encountered!");
+        if (high_nibble == 255) {
+            fprintf(stderr, "Invalid HEX encountered!\n");
+            return S2N_FAILURE;
         }
 
         uint8_t low_nibble = hex_inverse[hex[j + 1]];
-        if (low_nibble != 255) {
-            fprintf(stderr, "Invalid HEX encountered!");
+        if (low_nibble == 255) {
+            fprintf(stderr, "Invalid HEX encountered!\n");
+            return S2N_FAILURE;
         }
 
         if(*out_bytes_len < i) {
-            fprintf(stderr, "Insufficient memory for bytes buffer, try increasing the allocation size!");
+            fprintf(stderr, "Insufficient memory for bytes buffer, try increasing the allocation size!\n");
+            return S2N_FAILURE;
         }
         out_bytes[i] = high_nibble << 4 | low_nibble;
 
@@ -171,16 +174,16 @@ int s2n_setup_external_psk(struct s2n_psk *psk_list[S2N_MAX_PSK_LIST_LENGTH], si
                              "Error setting psk identity");
                 break;
             case 1:
-                secret_len = strlen(token) / 2;
+                secret_len = strlen(token);
                 secret = malloc(secret_len);
                 GUARD_EXIT_NULL(secret);
-                GUARD_EXIT(s2n_str_hex_to_bytes((const uint8_t *)token, secret, &secret_len), "Error converting hex-encoded psk secret to bytes");
-                GUARD_EXIT(s2n_psk_set_secret(psk, (const uint8_t *)secret, secret_len), "Error setting psk secret");
+                GUARD_EXIT(s2n_str_hex_to_bytes((const uint8_t *)token, secret, &secret_len), "Error converting hex-encoded psk secret to bytes\n");
+                GUARD_EXIT(s2n_psk_set_secret(psk, secret, secret_len), "Error setting psk secret\n");
                 free(secret);
                 break;
             case 2:
-                GUARD_EXIT(s2n_get_psk_hmac_alg(&psk_hmac_alg, token), "Invalid psk hmac algorithm");
-                GUARD_EXIT(s2n_psk_set_hmac(psk, psk_hmac_alg), "Error setting psk hmac algorithm");
+                GUARD_EXIT(s2n_get_psk_hmac_alg(&psk_hmac_alg, token), "Invalid psk hmac algorithm\n");
+                GUARD_EXIT(s2n_psk_set_hmac(psk, psk_hmac_alg), "Error setting psk hmac algorithm\n");
                 break;
             default:
                 break;

--- a/bin/common.c
+++ b/bin/common.c
@@ -94,13 +94,13 @@ static int s2n_get_psk_hmac_alg(s2n_psk_hmac *psk_hmac, char *hmac_str)
     return S2N_SUCCESS;
 }
 
-int s2n_setup_external_psk(struct s2n_array *psk_list, char *params)
+int s2n_setup_external_psk(struct s2n_psk *psk_list[S2N_MAX_PSK_LIST_LENGTH], size_t *psk_idx, char *params)
 {
     POSIX_ENSURE_REF(psk_list);
+    POSIX_ENSURE_REF(psk_idx);
     POSIX_ENSURE_REF(params);
 
-    struct s2n_psk *psk = NULL;
-    POSIX_GUARD_RESULT(s2n_array_pushback(psk_list, (void **)&psk));
+    struct s2n_psk *psk = s2n_external_psk_new();
     POSIX_ENSURE_REF(psk);
     POSIX_GUARD_RESULT(s2n_psk_init(psk, S2N_PSK_TYPE_EXTERNAL));
     /* Default HMAC algorithm is S2N_PSK_HMAC_SHA256 */
@@ -129,5 +129,6 @@ int s2n_setup_external_psk(struct s2n_array *psk_list, char *params)
         }
     }
 
+    psk_list[(*psk_idx)++] = psk;
     return S2N_SUCCESS;
 }

--- a/bin/common.h
+++ b/bin/common.h
@@ -16,6 +16,9 @@
 #pragma once
 
 #include <stdint.h>
+#include "tls/s2n_psk.h"
+#include "utils/s2n_blob.h"
+#include "utils/s2n_safety.h"
 
 #define GUARD_EXIT(x, msg)  \
   do {                      \
@@ -40,3 +43,4 @@ int https(struct s2n_connection *conn, uint32_t bench);
 int key_log_callback(void *ctx, struct s2n_connection *conn, uint8_t *logline, size_t len);
 
 char *load_file_to_cstring(const char *path);
+int s2n_setup_external_psk(struct s2n_array *psk_list, char *params);

--- a/bin/common.h
+++ b/bin/common.h
@@ -37,13 +37,13 @@
 #define S2N_OPTIONALLY_ENABLE_FIPS_MODE()
 #endif
 
-#define GUARD_EXIT_NULL(x, msg)  \
-  do {                           \
-    if (x == NULL) {             \
-      print_s2n_error(msg);      \
-      exit(1);                   \
-    }                            \
-  } while (0)
+#define GUARD_EXIT_NULL(x)                                 \
+    do {                                                   \
+        if (x == NULL) {                                   \
+            fprintf(stderr, "NULL pointer encountered\n"); \
+            exit(1);                                       \
+        }                                                  \
+    } while (0)
 
 #define GUARD_EXIT(x, msg)  \
   do {                      \

--- a/bin/common.h
+++ b/bin/common.h
@@ -70,4 +70,5 @@ int https(struct s2n_connection *conn, uint32_t bench);
 int key_log_callback(void *ctx, struct s2n_connection *conn, uint8_t *logline, size_t len);
 
 char *load_file_to_cstring(const char *path);
+int s2n_str_hex_to_bytes(const uint8_t *hex, uint8_t *out_bytes, uint32_t *out_bytes_len);
 int s2n_setup_external_psk(struct s2n_psk *psk_list[S2N_MAX_PSK_LIST_LENGTH], size_t *psk_idx, char *params);

--- a/bin/common.h
+++ b/bin/common.h
@@ -22,16 +22,17 @@
 #ifdef OPENSSL_FIPS
 #include <openssl/err.h>
 
-#define S2N_OPTIONALLY_ENABLE_FIPS_MODE() \
-    do { \
-        if (FIPS_mode_set(1) == 0) { \
-            unsigned long fips_rc = ERR_get_error(); \
-            char ssl_error_buf[256]; \
-            fprintf(stderr, "s2nd failed to enter FIPS mode with RC: %lu; String: %s\n", fips_rc, ERR_error_string(fips_rc, ssl_error_buf)); \
-            return 1; \
-        } \
-        printf("s2nd entered FIPS mode\n"); \
-    } while (0)
+#define S2N_OPTIONALLY_ENABLE_FIPS_MODE()                                                             \
+        do {                                                                                          \
+            if (FIPS_mode_set(1) == 0) {                                                              \
+                unsigned long fips_rc = ERR_get_error();                                              \
+                char          ssl_error_buf[ 256 ];                                                   \
+                fprintf(stderr, "s2nd failed to enter FIPS mode with RC: %lu; String: %s\n", fips_rc, \
+                        ERR_error_string(fips_rc, ssl_error_buf));                                    \
+                return 1;                                                                             \
+            }                                                                                         \
+            printf("s2nd entered FIPS mode\n");                                                       \
+        } while (0)
 
 #else
 #define S2N_OPTIONALLY_ENABLE_FIPS_MODE()

--- a/bin/common.h
+++ b/bin/common.h
@@ -16,8 +16,16 @@
 #pragma once
 
 #include <stdint.h>
+/* Remove once the PSK feature is released i.e PSK APIs are made visible and moved to s2n.h */
 #include "tls/s2n_psk.h"
-#include "utils/s2n_safety.h"
+
+#define GUARD_EXIT_NULL(x, msg)  \
+  do {                           \
+    if (x == NULL) {             \
+      print_s2n_error(msg);      \
+      exit(1);                   \
+    }                            \
+  } while (0)
 
 #define GUARD_EXIT(x, msg)  \
   do {                      \

--- a/bin/common.h
+++ b/bin/common.h
@@ -17,7 +17,6 @@
 
 #include <stdint.h>
 #include "tls/s2n_psk.h"
-#include "utils/s2n_blob.h"
 #include "utils/s2n_safety.h"
 
 #define GUARD_EXIT(x, msg)  \
@@ -36,6 +35,8 @@
     }                        \
   } while (0)
 
+#define S2N_MAX_PSK_LIST_LENGTH 10
+
 void print_s2n_error(const char *app_error);
 int echo(struct s2n_connection *conn, int sockfd);
 int negotiate(struct s2n_connection *conn, int sockfd);
@@ -43,4 +44,4 @@ int https(struct s2n_connection *conn, uint32_t bench);
 int key_log_callback(void *ctx, struct s2n_connection *conn, uint8_t *logline, size_t len);
 
 char *load_file_to_cstring(const char *path);
-int s2n_setup_external_psk(struct s2n_array *psk_list, char *params);
+int s2n_setup_external_psk(struct s2n_psk *psk_list[S2N_MAX_PSK_LIST_LENGTH], size_t *psk_idx, char *params);

--- a/bin/common.h
+++ b/bin/common.h
@@ -19,6 +19,24 @@
 /* Remove once the PSK feature is released i.e PSK APIs are made visible and moved to s2n.h */
 #include "tls/s2n_psk.h"
 
+#ifdef OPENSSL_FIPS
+#include <openssl/err.h>
+
+#define S2N_OPTIONALLY_ENABLE_FIPS_MODE() \
+    do { \
+        if (FIPS_mode_set(1) == 0) { \
+            unsigned long fips_rc = ERR_get_error(); \
+            char ssl_error_buf[256]; \
+            fprintf(stderr, "s2nd failed to enter FIPS mode with RC: %lu; String: %s\n", fips_rc, ERR_error_string(fips_rc, ssl_error_buf)); \
+            return 1; \
+        } \
+        printf("s2nd entered FIPS mode\n"); \
+    } while (0)
+
+#else
+#define S2N_OPTIONALLY_ENABLE_FIPS_MODE()
+#endif
+
 #define GUARD_EXIT_NULL(x, msg)  \
   do {                           \
     if (x == NULL) {             \

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -150,9 +150,9 @@ int negotiate(struct s2n_connection *conn, int fd)
         uint8_t chosen_psk_type = 0; 
         GUARD_EXIT(s2n_psk_get_type(&chosen_psk, &chosen_psk_type), "Error getting chosen psk type\n");
         printf("Chosen PSK type: %s\n", (chosen_psk_type) ? "S2N_PSK_TYPE_EXTERNAL" : "S2N_PSK_TYPE_RESUMPTION");
-        
-        uint8_t *identity = NULL; 
-        identity = malloc(identity_length);
+
+        uint8_t *identity = malloc(identity_length);
+        GUARD_EXIT_NULL(identity);
         GUARD_EXIT(s2n_psk_get_identity(&chosen_psk, identity, &identity_length), "Error getting chosen psk identity\n");
         printf("Chosen PSK identity: %s\n", identity);
         free(identity);

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -31,6 +31,7 @@
 
 #include "crypto/s2n_rsa.h"
 #include "crypto/s2n_pkey.h"
+#include "tls/s2n_connection.h"
 
 #define STDIO_BUFSIZE  10240
 
@@ -71,6 +72,8 @@ static int wait_for_event(int fd, s2n_blocked_status blocked)
 
 int negotiate(struct s2n_connection *conn, int fd)
 {
+    POSIX_ENSURE_REF(conn);
+
     s2n_blocked_status blocked;
     while (s2n_negotiate(conn, &blocked) != S2N_SUCCESS) {
         if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
@@ -136,6 +139,11 @@ int negotiate(struct s2n_connection *conn, int fd)
     printf("Cipher negotiated: %s\n", s2n_connection_get_cipher(conn));
     if (s2n_connection_is_session_resumed(conn)) {
         printf("Resumed session\n");
+    }
+
+    if (conn->psk_params.chosen_psk) {
+        printf("Chosen PSK type: %s\n", (conn->psk_params.chosen_psk->type) ? "S2N_PSK_TYPE_EXTERNAL" : "S2N_PSK_TYPE_RESUMPTION");
+        printf("Chosen PSK identity: %s\n", conn->psk_params.chosen_psk->identity.data);
     }
 
     return 0;

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -31,7 +31,6 @@
 
 #include "crypto/s2n_rsa.h"
 #include "crypto/s2n_pkey.h"
-#include "tls/s2n_connection.h"
 #include "common.h"
 
 #define STDIO_BUFSIZE  10240
@@ -142,9 +141,11 @@ int negotiate(struct s2n_connection *conn, int fd)
         printf("Resumed session\n");
     }
 
-    if (conn->psk_params.chosen_psk) {
-        printf("Chosen PSK type: %s\n", (conn->psk_params.chosen_psk->type) ? "S2N_PSK_TYPE_EXTERNAL" : "S2N_PSK_TYPE_RESUMPTION");
-        printf("Chosen PSK identity: %s\n", conn->psk_params.chosen_psk->identity.data);
+    struct s2n_psk chosen_psk = { 0 };
+    GUARD_EXIT(s2n_connection_get_chosen_psk(conn, &chosen_psk), "Error getting chosen psk from the connection");
+    if (chosen_psk.identity != NULL) {
+        printf("Chosen PSK type: %s\n", (chosen_psk.type) ? "S2N_PSK_TYPE_EXTERNAL" : "S2N_PSK_TYPE_RESUMPTION");
+        printf("Chosen PSK identity: %s\n", chosen_psk.identity.data);
     }
 
     return 0;

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -32,6 +32,7 @@
 #include "crypto/s2n_rsa.h"
 #include "crypto/s2n_pkey.h"
 #include "tls/s2n_connection.h"
+#include "common.h"
 
 #define STDIO_BUFSIZE  10240
 
@@ -72,7 +73,7 @@ static int wait_for_event(int fd, s2n_blocked_status blocked)
 
 int negotiate(struct s2n_connection *conn, int fd)
 {
-    POSIX_ENSURE_REF(conn);
+    GUARD_EXIT_NULL(conn);
 
     s2n_blocked_status blocked;
     while (s2n_negotiate(conn, &blocked) != S2N_SUCCESS) {

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -142,10 +142,20 @@ int negotiate(struct s2n_connection *conn, int fd)
     }
 
     struct s2n_psk chosen_psk = { 0 };
-    GUARD_EXIT(s2n_connection_get_chosen_psk(conn, &chosen_psk), "Error getting chosen psk from the connection");
-    if (chosen_psk.identity != NULL) {
-        printf("Chosen PSK type: %s\n", (chosen_psk.type) ? "S2N_PSK_TYPE_EXTERNAL" : "S2N_PSK_TYPE_RESUMPTION");
-        printf("Chosen PSK identity: %s\n", chosen_psk.identity.data);
+    GUARD_EXIT(s2n_connection_get_chosen_psk(conn, &chosen_psk), "Error getting chosen psk from the connection\n");
+    uint16_t identity_length = 0;
+    GUARD_EXIT(s2n_psk_get_identity_length(&chosen_psk, &identity_length), "Error getting chosen psk identity length\n");
+    
+    if (identity_length != 0) {
+        uint8_t chosen_psk_type = 0; 
+        GUARD_EXIT(s2n_psk_get_type(&chosen_psk, &chosen_psk_type), "Error getting chosen psk type\n");
+        printf("Chosen PSK type: %s\n", (chosen_psk_type) ? "S2N_PSK_TYPE_EXTERNAL" : "S2N_PSK_TYPE_RESUMPTION");
+        
+        uint8_t *identity = NULL; 
+        identity = malloc(identity_length);
+        GUARD_EXIT(s2n_psk_get_identity(&chosen_psk, identity, &identity_length), "Error getting chosen psk identity\n");
+        printf("Chosen PSK identity: %s\n", identity);
+        free(identity);
     }
 
     return 0;

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -35,6 +35,7 @@
 #include <error/s2n_errno.h>
 
 #include "tls/s2n_connection.h"
+#include "utils/s2n_safety.h"
 
 #define S2N_MAX_ECC_CURVE_NAME_LENGTH 10
 
@@ -378,7 +379,7 @@ int main(int argc, char *const *argv)
             key_log_path = optarg;
             break;
         case 'P':
-            POSIX_GUARD(s2n_setup_external_psk(psk_list, &psk_idx, optarg));
+            GUARD_EXIT(s2n_setup_external_psk(psk_list, &psk_idx, optarg), "Error setting external PSK parameters");
             break;
         case '?':
         default:
@@ -521,7 +522,7 @@ int main(int argc, char *const *argv)
         for (size_t i = 0; i < psk_idx; i++) {
             struct s2n_psk *psk = psk_list[i];
             GUARD_EXIT(s2n_connection_append_psk(conn, psk), "Error appending psk to the connection");
-            POSIX_GUARD(s2n_psk_free(&psk));
+            GUARD_EXIT(s2n_psk_free(&psk), "Error freeing psk");
         }
 
         /* See echo.c */

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -93,7 +93,7 @@ void usage()
     fprintf(stderr, "    Enable NSS key logging into the provided path\n");
     fprintf(stderr, "  -P --psk <psk-identity,psk-secret,psk-hmac-alg> \n"
                     "    A comma separated list of psk paramaters specified in an order namely: psk_identity, psk_secret and psk_hmac_alg.\n"
-                    "    There are no whitespaces allowed before of after the comma.\n"
+                    "    Note that the psk-secret is hex-encoded. There are no whitespaces allowed before of after the comma.\n"
                     "    Ex: --psk psk_id,psk_secret,S2N_PSK_HMAC_SHA256 --psk shared_id,shared_secret,S2N_PSK_HMAC_SHA384.\n");
     fprintf(stderr, "\n");
     exit(1);
@@ -262,7 +262,8 @@ int main(int argc, char *const *argv)
     char *token = NULL;
     const char *key_log_path = NULL;
     FILE *key_log_file = NULL;
-    struct s2n_array *psk_list = NULL;
+    struct s2n_psk *psk_list[S2N_MAX_PSK_LIST_LENGTH] = { NULL };
+    size_t psk_idx = 0;
 
     GUARD_EXIT(s2n_init(), "Error running s2n_init()");
 
@@ -377,10 +378,7 @@ int main(int argc, char *const *argv)
             key_log_path = optarg;
             break;
         case 'P':
-            psk_list = s2n_array_new(sizeof(struct s2n_array));
-            POSIX_ENSURE_REF(psk_list);
-            POSIX_GUARD_RESULT(s2n_array_init(psk_list, sizeof(struct s2n_psk)));
-            POSIX_GUARD(s2n_setup_external_psk(psk_list, optarg));
+            POSIX_GUARD(s2n_setup_external_psk(psk_list, &psk_idx, optarg));
             break;
         case '?':
         default:
@@ -520,10 +518,10 @@ int main(int argc, char *const *argv)
             GUARD_EXIT(s2n_connection_set_session(conn, session_state, session_state_length), "Error setting session state in connection");
         }
 
-        for (size_t i = 0; i < psk_list->len; i++) {
-            struct s2n_psk *psk = NULL;
-            POSIX_GUARD_RESULT(s2n_array_get(psk_list, i, (void**) &psk));
-            GUARD_EXIT(s2n_connection_append_psk(conn, psk), "Error appending psk");
+        for (size_t i = 0; i < psk_idx; i++) {
+            struct s2n_psk *psk = psk_list[i];
+            GUARD_EXIT(s2n_connection_append_psk(conn, psk), "Error appending psk to the connection");
+            POSIX_GUARD(s2n_psk_free(&psk));
         }
 
         /* See echo.c */
@@ -581,10 +579,6 @@ int main(int argc, char *const *argv)
 
     if (key_log_file) {
         fclose(key_log_file);
-    }
-
-    if (psk_list) {
-        POSIX_GUARD_RESULT(s2n_array_free(psk_list));
     }
 
     GUARD_EXIT(s2n_cleanup(), "Error running s2n_cleanup()");

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -92,8 +92,8 @@ void usage()
     fprintf(stderr, "  -L --key-log <path>\n");
     fprintf(stderr, "    Enable NSS key logging into the provided path\n");
     fprintf(stderr, "  -P --psk <psk-identity,psk-secret,psk-hmac-alg> \n"
-                    "    A comma separated list of psk paramaters specified in an order namely: psk_identity, psk_secret and psk_hmac_alg.\n"
-                    "    Note that the psk-secret is hex-encoded. There are no whitespaces allowed before of after the comma.\n"
+                    "    A comma-separated list of psk parameters in this order: psk_identity, psk_secret and psk_hmac_alg.\n"
+                    "    Note that the psk-secret is hex-encoded. There are no whitespaces allowed before or after the comma.\n"
                     "    Ex: --psk psk_id,psk_secret,S2N_PSK_HMAC_SHA256 --psk shared_id,shared_secret,S2N_PSK_HMAC_SHA384.\n");
     fprintf(stderr, "\n");
     exit(1);

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -292,8 +292,8 @@ void usage()
     fprintf(stderr, "  -L --key-log <path>\n");
     fprintf(stderr, "    Enable NSS key logging into the provided path\n");
     fprintf(stderr, "  -P --psk <psk-identity,psk-secret,psk-hmac-alg> \n"
-                    "    A comma separated list of psk paramaters specified in an order namely: psk_identity, psk_secret and psk_hmac_alg.\n"
-                    "    Note that the psk-secret is hex-encoded. There are no whitespaces allowed before of after the comma.\n"
+                    "    A comma-separated list of psk parameters in this order: : psk_identity, psk_secret and psk_hmac_alg.\n"
+                    "    Note that the psk-secret is hex-encoded. There are no whitespaces allowed before or after the comma.\n"
                     "    Ex: --psk psk_id,psk_secret,S2N_PSK_HMAC_SHA256 --psk shared_id,shared_secret,S2N_PSK_HMAC_SHA384.\n");
     fprintf(stderr, "  -h,--help\n");
     fprintf(stderr, "    Display this message and quit.\n");

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -292,7 +292,7 @@ void usage()
     fprintf(stderr, "  -L --key-log <path>\n");
     fprintf(stderr, "    Enable NSS key logging into the provided path\n");
     fprintf(stderr, "  -P --psk <psk-identity,psk-secret,psk-hmac-alg> \n"
-                    "    A comma-separated list of psk parameters in this order: : psk_identity, psk_secret and psk_hmac_alg.\n"
+                    "    A comma-separated list of psk parameters in this order: psk_identity, psk_secret and psk_hmac_alg.\n"
                     "    Note that the psk-secret is hex-encoded. There are no whitespaces allowed before or after the comma.\n"
                     "    Ex: --psk psk_id,psk_secret,S2N_PSK_HMAC_SHA256 --psk shared_id,shared_secret,S2N_PSK_HMAC_SHA384.\n");
     fprintf(stderr, "  -h,--help\n");
@@ -365,7 +365,7 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
     for (size_t i = 0; i < settings.psk_idx; i++) {
         struct s2n_psk *psk = settings.psk_list[i];
         GUARD_EXIT(s2n_connection_append_psk(conn, psk), "Error appending psk");
-        POSIX_GUARD(s2n_psk_free(&psk));
+        GUARD_EXIT(s2n_psk_free(&psk), "Error freeing psk");
     }
 
     if (negotiate(conn, fd) != S2N_SUCCESS) {
@@ -574,7 +574,7 @@ int main(int argc, char *const *argv)
             key_log_path = optarg;
             break;
         case 'P':
-            POSIX_GUARD(s2n_setup_external_psk(conn_settings.psk_list, &conn_settings.psk_idx, optarg));
+            GUARD_EXIT(s2n_setup_external_psk(conn_settings.psk_list, &conn_settings.psk_idx, optarg), "Error setting external PSK parameters");
             break;
         case '?':
         default:

--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -144,6 +144,14 @@ batch:
         variables:
           INTEGV2_TEST: test_well_known_endpoints
 
+    - identifier: s2nIntegrationV2ExternalPSK
+      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          INTEGV2_TEST: test_external_psk
+
     # Individual Integration tests
     - identifier: s2nIntegrationBoringSSLGcc9
       buildspec: codebuild/spec/buildspec_ubuntu.yml

--- a/tests/integrationv2/test_external_psk.py
+++ b/tests/integrationv2/test_external_psk.py
@@ -1,0 +1,183 @@
+import copy
+import os
+import pytest
+import time
+
+from configuration import available_ports
+from common import ProviderOptions, Protocols, data_bytes, Ciphers
+from fixtures import managed_process
+from providers import S2N, OpenSSL
+from utils import invalid_test_parameters, get_parameter_name
+
+shared_psk_identity = '2c035d829359ee5ff7af4ec900000000262a6494dc486d2c8a34cb33fa90bf1b00'\
+                      '70ad3c498883c9367c09a2be785abc55cd226097a3a982117283f82a03a143efd3'\
+                      'ff5dd36d64e861be7fd61d2827db279cce145077d454a3664d4e6da4d29ee03725'\
+                      'a6a4dafcd0fc67d2aea70529513e3da2677fa5906c5b3f7d8f92f228bda40dda72'\
+                      '1470f9fbf297b5aea617646fac5c03272e970727c621a79141ef5f7de6505e5bfb'\
+                      'c388e93343694093934ae4d357fad6aacb'
+
+shared_psk_secret = '4ecd0eb6ec3b4d87f5d6028f922ca4c5851a277fd41311c9e62d2c9492e1c4f3'
+
+s2n_known_value_psk = '2c035d829359ee5ff7af4ec900000000262a6494dc486d2c8a34cb33fa90bf1b00'\
+                      '70ad3c498883c9367c09a2be785abc55cd226097a3a982117283f82a03a143efd3'\
+                      'ff5dd36d64e861be7fd61d2827db279cce145077d454a3664d4e6da4d29ee03725'\
+                      'a6a4dafcd0fc67d2aea70529513e3da2677fa5906c5b3f7d8f92f228bda40dda72'\
+                      '1470f9fbf297b5aea617646fac5c03272e970727c621a79141ef5f7de6505e5bfb'\
+                      'c388e93343694093934ae4d357fad6aacb,'\
+                      '4ecd0eb6ec3b4d87f5d6028f922ca4c5851a277fd41311c9e62d2c9492e1c4f3,'\
+                      'S2N_PSK_HMAC_SHA256'
+
+s2n_client_only_psk = 's2n_client_psk_identity,'\
+                      'aea617646faaea6d,'\
+                      'S2N_PSK_HMAC_SHA384'\
+
+s2n_server_only_psk = 's2n_server_psk_identity,'\
+                      'a6a4dafcd0fc67d2a,'\
+                      'S2N_PSK_HMAC_SHA256'\
+
+s2n_invalid_hmac_psk = 'psk_identity,'\
+                       'aea617646faaea6d,'\
+                       'S2N_PSK_HMAC_SHA512'\
+
+S2N_CLIENT_PSK_PARAMETERS = [ 
+    [ '--psk', s2n_client_only_psk ],
+    [ '--psk', s2n_known_value_psk ], 
+    [ '--psk', s2n_invalid_hmac_psk ],
+    [ '--psk', s2n_client_only_psk, '--psk', s2n_known_value_psk ], 
+]
+
+S2N_SERVER_PSK_PARAMETERS = [
+    [ '--psk', s2n_server_only_psk ],
+    [ '--psk', s2n_known_value_psk ],
+    [ '--psk', s2n_invalid_hmac_psk ],
+    [ '--psk', s2n_server_only_psk, '--psk', s2n_known_value_psk ], 
+]
+
+OPENSSL_SERVER_PSK_PARAMETER = [ '-psk_identity', shared_psk_identity, '--psk', shared_psk_secret, '-nocert' ]
+OPENSSL_CLIENT_PSK_PARAMETER = [ '-psk_identity', shared_psk_identity, '--psk', shared_psk_secret ]
+
+def s2n_assert_chosen_psk(idx, results):
+    if idx == 0:
+        assert b"Chosen PSK wire index" not in results.stdout
+        assert results.exit_code != 0
+    elif idx % 2 == 1:
+        assert b"Chosen PSK type: S2N_PSK_TYPE_EXTERNAL" in results.stdout
+        assert bytes("Chosen PSK identity: {}".format(shared_psk_identity).encode('utf-8')) in results.stdout
+        assert results.exit_code == 0
+    elif idx == 2:
+        assert b"Invalid psk hmac algorithm" in results.stderr
+        assert results.exit_code != 0
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("client_psk_params", S2N_CLIENT_PSK_PARAMETERS, ids=get_parameter_name)
+def test_external_psk_s2nc_with_s2nd(managed_process, client_psk_params):
+    port = next(available_ports)
+
+    random_bytes = data_bytes(64)
+    client_options = ProviderOptions(
+        mode=S2N.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=Ciphers.CHACHA20_POLY1305_SHA256,
+        data_to_send=random_bytes,
+        insecure=True,
+        extra_flags=client_psk_params,
+        protocol=Protocols.TLS13)
+    
+    idx = S2N_CLIENT_PSK_PARAMETERS.index(client_psk_params)
+    server_psk_params = S2N_SERVER_PSK_PARAMETERS[idx]
+
+    server_options = copy.copy(client_options)
+    server_options.data_to_send = None
+    server_options.mode = S2N.ServerMode
+    server_options.extra_flags = server_psk_params
+
+    server = managed_process(S2N, server_options, timeout=20)
+    client = managed_process(S2N, client_options, timeout=20)
+
+    for results in client.get_results():
+        s2n_assert_chosen_psk(idx, results)
+        assert results.exception is None
+
+    for results in server.get_results():
+        s2n_assert_chosen_psk(idx, results)
+        assert results.exception is None
+
+pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("s2n_client_psk_params", S2N_CLIENT_PSK_PARAMETERS, ids=get_parameter_name)
+def test_external_psk_s2nc_with_openssl_server(managed_process, s2n_client_psk_params):
+    port = next(available_ports)
+
+    random_bytes = data_bytes(64)
+    client_options = ProviderOptions(
+        mode=S2N.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=Ciphers.CHACHA20_POLY1305_SHA256,
+        data_to_send=random_bytes,
+        insecure=True,
+        extra_flags=s2n_client_psk_params,
+        protocol=Protocols.TLS13)
+
+    server_options = copy.copy(client_options)
+    server_options.data_to_send = None
+    server_options.mode = OpenSSL.ServerMode
+    server_options.extra_flags = OPENSSL_SERVER_PSK_PARAMETER
+    idx = S2N_CLIENT_PSK_PARAMETERS.index(s2n_client_psk_params)
+    server = managed_process(OpenSSL, server_options, timeout=20)
+    client = managed_process(S2N, client_options, timeout=20)
+
+    for results in client.get_results():
+        s2n_assert_chosen_psk(idx, results)
+        assert results.exception is None
+
+    for results in server.get_results():
+        if idx == 0:
+            assert b"PSK warning: client identity not what we expected" in results.stdout
+            assert results.exception is None
+            assert results.exit_code == 0
+        elif idx % 2 == 1:
+            assert b"PSK key given, setting server callback" in results.stdout
+            assert results.exception is None
+            assert results.exit_code == 0
+        else:
+            assert results.exit_code != 0
+
+pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("s2n_server_psk_params", S2N_SERVER_PSK_PARAMETERS, ids=get_parameter_name)
+def test_external_psk_s2nd_with_openssl_client(managed_process, s2n_server_psk_params):
+    port = next(available_ports)
+
+    random_bytes = data_bytes(64)
+    client_options = ProviderOptions(
+        mode=OpenSSL.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=Ciphers.CHACHA20_POLY1305_SHA256,
+        data_to_send=random_bytes,
+        insecure=True,
+        extra_flags=OPENSSL_CLIENT_PSK_PARAMETER,
+        protocol=Protocols.TLS13)
+
+    server_options = copy.copy(client_options)
+    server_options.data_to_send = None
+    server_options.mode = S2N.ServerMode
+    server_options.extra_flags = s2n_server_psk_params
+    idx = S2N_SERVER_PSK_PARAMETERS.index(s2n_server_psk_params)
+    server = managed_process(S2N, server_options, timeout=20)
+    client = managed_process(OpenSSL, client_options, timeout=20)
+
+    for results in server.get_results():
+        s2n_assert_chosen_psk(idx, results)
+        assert results.exception is None
+
+    for results in client.get_results():
+        if idx == 0:
+            assert results.exception is None
+            assert results.exit_code != 0
+        elif idx % 2 == 1:
+            assert b"PSK key given, setting client callback" in results.stdout
+            assert results.exception is None
+            assert results.exit_code == 0
+        else:
+            assert results.exit_code != 0

--- a/tests/integrationv2/test_external_psk.py
+++ b/tests/integrationv2/test_external_psk.py
@@ -4,17 +4,18 @@ import pytest
 import time
 
 from configuration import available_ports
-from common import ProviderOptions, Protocols, data_bytes, Ciphers
+from common import ProviderOptions, Protocols, data_bytes, Ciphers, Certificates
 from fixtures import managed_process
 from providers import S2N, OpenSSL
 from utils import invalid_test_parameters, get_parameter_name
 
+# Test Vectors from https://tools.ietf.org/html/rfc8448#section-4 
 shared_psk_identity = '2c035d829359ee5ff7af4ec900000000262a6494dc486d2c8a34cb33fa90bf1b00'\
                       '70ad3c498883c9367c09a2be785abc55cd226097a3a982117283f82a03a143efd3'\
                       'ff5dd36d64e861be7fd61d2827db279cce145077d454a3664d4e6da4d29ee03725'\
                       'a6a4dafcd0fc67d2aea70529513e3da2677fa5906c5b3f7d8f92f228bda40dda72'\
                       '1470f9fbf297b5aea617646fac5c03272e970727c621a79141ef5f7de6505e5bfb'\
-                      'c388e93343694093934ae4d357fad6aacb'
+                      'c388e93343694093934ae4d357'
 
 shared_psk_secret = '4ecd0eb6ec3b4d87f5d6028f922ca4c5851a277fd41311c9e62d2c9492e1c4f3'
 
@@ -23,50 +24,70 @@ s2n_known_value_psk = '2c035d829359ee5ff7af4ec900000000262a6494dc486d2c8a34cb33f
                       'ff5dd36d64e861be7fd61d2827db279cce145077d454a3664d4e6da4d29ee03725'\
                       'a6a4dafcd0fc67d2aea70529513e3da2677fa5906c5b3f7d8f92f228bda40dda72'\
                       '1470f9fbf297b5aea617646fac5c03272e970727c621a79141ef5f7de6505e5bfb'\
-                      'c388e93343694093934ae4d357fad6aacb,'\
+                      'c388e93343694093934ae4d357,'\
                       '4ecd0eb6ec3b4d87f5d6028f922ca4c5851a277fd41311c9e62d2c9492e1c4f3,'\
                       'S2N_PSK_HMAC_SHA256'
 
+# Arbitrary Test vectors
 s2n_client_only_psk = 's2n_client_psk_identity,'\
-                      'aea617646faaea6d,'\
+                      'a6dadae4567876,'\
                       'S2N_PSK_HMAC_SHA384'\
 
 s2n_server_only_psk = 's2n_server_psk_identity,'\
-                      'a6a4dafcd0fc67d2a,'\
+                      'a64dafcd0fc67d2a,'\
                       'S2N_PSK_HMAC_SHA256'\
 
+s2n_shared_psk = 's2n_psk_identity,'\
+                 'f9bf29b5aea6aea7,'\
+                 'S2N_PSK_HMAC_SHA256'\
+
 s2n_invalid_hmac_psk = 'psk_identity,'\
-                       'aea617646faaea6d,'\
+                       'f9bf29b5aea6aea7,'\
                        'S2N_PSK_HMAC_SHA512'\
 
 S2N_CLIENT_PSK_PARAMETERS = [ 
     [ '--psk', s2n_client_only_psk ],
     [ '--psk', s2n_known_value_psk ], 
     [ '--psk', s2n_invalid_hmac_psk ],
-    [ '--psk', s2n_client_only_psk, '--psk', s2n_known_value_psk ], 
+    [ '--psk', s2n_client_only_psk, '--psk', s2n_shared_psk ], 
 ]
 
 S2N_SERVER_PSK_PARAMETERS = [
     [ '--psk', s2n_server_only_psk ],
     [ '--psk', s2n_known_value_psk ],
     [ '--psk', s2n_invalid_hmac_psk ],
-    [ '--psk', s2n_server_only_psk, '--psk', s2n_known_value_psk ], 
+    [ '--psk', s2n_server_only_psk, '--psk', s2n_shared_psk ], 
 ]
 
-OPENSSL_SERVER_PSK_PARAMETER = [ '-psk_identity', shared_psk_identity, '--psk', shared_psk_secret, '-nocert' ]
-OPENSSL_CLIENT_PSK_PARAMETER = [ '-psk_identity', shared_psk_identity, '--psk', shared_psk_secret ]
+OPENSSL_PSK_PARAMETER = [ '-psk_identity', shared_psk_identity, '--psk', shared_psk_secret ]
 
-def s2n_assert_chosen_psk(idx, results):
+def s2n_assert_chosen_psk(idx, results, random_bytes, is_s2nd=False, is_peer_openssl_server=False):
     if idx == 0:
-        assert b"Chosen PSK wire index" not in results.stdout
-        assert results.exit_code != 0
-    elif idx % 2 == 1:
+        assert b"Chosen PSK type: S2N_PSK_TYPE_EXTERNAL" not in results.stdout
+        assert b"Chosen PSK identity" not in results.stdout
+        if is_s2nd:
+            assert random_bytes in results.stdout
+            assert results.exit_code == 0
+        if is_peer_openssl_server:
+            assert b"Failed to negotiate: 'TLS alert received'. Error encountered in s2n_alerts.c line 122" in results.stderr
+            assert results.exit_code != 0
+        else:
+            assert results.exit_code == 0
+    elif idx == 1:
         assert b"Chosen PSK type: S2N_PSK_TYPE_EXTERNAL" in results.stdout
         assert bytes("Chosen PSK identity: {}".format(shared_psk_identity).encode('utf-8')) in results.stdout
-        assert results.exit_code == 0
+        if is_s2nd:
+            assert random_bytes in results.stdout
+        assert results.exit_code == 0   
     elif idx == 2:
         assert b"Invalid psk hmac algorithm" in results.stderr
         assert results.exit_code != 0
+    elif idx == 3: 
+        assert b"Chosen PSK type: S2N_PSK_TYPE_EXTERNAL" in results.stdout
+        assert b"Chosen PSK identity: s2n_psk_identity" in results.stdout
+        if is_s2nd:
+            assert random_bytes in results.stdout
+        assert results.exit_code == 0
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("client_psk_params", S2N_CLIENT_PSK_PARAMETERS, ids=get_parameter_name)
@@ -80,13 +101,15 @@ def test_external_psk_s2nc_with_s2nd(managed_process, client_psk_params):
         port=port,
         cipher=Ciphers.CHACHA20_POLY1305_SHA256,
         data_to_send=random_bytes,
-        insecure=True,
+        key=Certificates.ECDSA_256.key,
+        cert=Certificates.ECDSA_256.cert,
+        trust_store=Certificates.ECDSA_256.cert,
+        insecure=False,
         extra_flags=client_psk_params,
         protocol=Protocols.TLS13)
     
     idx = S2N_CLIENT_PSK_PARAMETERS.index(client_psk_params)
     server_psk_params = S2N_SERVER_PSK_PARAMETERS[idx]
-
     server_options = copy.copy(client_options)
     server_options.data_to_send = None
     server_options.mode = S2N.ServerMode
@@ -96,15 +119,15 @@ def test_external_psk_s2nc_with_s2nd(managed_process, client_psk_params):
     client = managed_process(S2N, client_options, timeout=20)
 
     for results in client.get_results():
-        s2n_assert_chosen_psk(idx, results)
+        s2n_assert_chosen_psk(idx, results, random_bytes)
         assert results.exception is None
 
     for results in server.get_results():
-        s2n_assert_chosen_psk(idx, results)
+        s2n_assert_chosen_psk(idx, results, random_bytes, True)
         assert results.exception is None
 
 pytest.mark.uncollect_if(func=invalid_test_parameters)
-@pytest.mark.parametrize("s2n_client_psk_params", S2N_CLIENT_PSK_PARAMETERS, ids=get_parameter_name)
+@pytest.mark.parametrize("s2n_client_psk_params", S2N_CLIENT_PSK_PARAMETERS[:3], ids=get_parameter_name)
 def test_external_psk_s2nc_with_openssl_server(managed_process, s2n_client_psk_params):
     port = next(available_ports)
 
@@ -115,25 +138,29 @@ def test_external_psk_s2nc_with_openssl_server(managed_process, s2n_client_psk_p
         port=port,
         cipher=Ciphers.CHACHA20_POLY1305_SHA256,
         data_to_send=random_bytes,
-        insecure=True,
+        insecure=False,
+        key=Certificates.ECDSA_256.key,
+        cert=Certificates.ECDSA_256.cert,
+        trust_store=Certificates.ECDSA_256.cert,
         extra_flags=s2n_client_psk_params,
         protocol=Protocols.TLS13)
 
     server_options = copy.copy(client_options)
     server_options.data_to_send = None
     server_options.mode = OpenSSL.ServerMode
-    server_options.extra_flags = OPENSSL_SERVER_PSK_PARAMETER
+    server_options.extra_flags = OPENSSL_PSK_PARAMETER
     idx = S2N_CLIENT_PSK_PARAMETERS.index(s2n_client_psk_params)
     server = managed_process(OpenSSL, server_options, timeout=20)
     client = managed_process(S2N, client_options, timeout=20)
 
     for results in client.get_results():
-        s2n_assert_chosen_psk(idx, results)
+        s2n_assert_chosen_psk(idx, results, random_bytes, False, True)
         assert results.exception is None
 
     for results in server.get_results():
         if idx == 0:
             assert b"PSK warning: client identity not what we expected" in results.stdout
+            assert b"error:141F906E:SSL routines:tls_parse_ctos_psk:bad extension:ssl/statem/extensions_srvr.c:1272" in results.stderr
             assert results.exception is None
             assert results.exit_code == 0
         elif idx % 2 == 1:
@@ -144,7 +171,7 @@ def test_external_psk_s2nc_with_openssl_server(managed_process, s2n_client_psk_p
             assert results.exit_code != 0
 
 pytest.mark.uncollect_if(func=invalid_test_parameters)
-@pytest.mark.parametrize("s2n_server_psk_params", S2N_SERVER_PSK_PARAMETERS, ids=get_parameter_name)
+@pytest.mark.parametrize("s2n_server_psk_params", S2N_SERVER_PSK_PARAMETERS[:3], ids=get_parameter_name)
 def test_external_psk_s2nd_with_openssl_client(managed_process, s2n_server_psk_params):
     port = next(available_ports)
 
@@ -155,8 +182,11 @@ def test_external_psk_s2nd_with_openssl_client(managed_process, s2n_server_psk_p
         port=port,
         cipher=Ciphers.CHACHA20_POLY1305_SHA256,
         data_to_send=random_bytes,
-        insecure=True,
-        extra_flags=OPENSSL_CLIENT_PSK_PARAMETER,
+        key=Certificates.ECDSA_256.key,
+        cert=Certificates.ECDSA_256.cert,
+        trust_store=Certificates.ECDSA_256.cert,
+        insecure=False,
+        extra_flags=OPENSSL_PSK_PARAMETER,
         protocol=Protocols.TLS13)
 
     server_options = copy.copy(client_options)
@@ -168,13 +198,13 @@ def test_external_psk_s2nd_with_openssl_client(managed_process, s2n_server_psk_p
     client = managed_process(OpenSSL, client_options, timeout=20)
 
     for results in server.get_results():
-        s2n_assert_chosen_psk(idx, results)
+        s2n_assert_chosen_psk(idx, results, random_bytes, True)
         assert results.exception is None
 
     for results in client.get_results():
         if idx == 0:
             assert results.exception is None
-            assert results.exit_code != 0
+            assert results.exit_code == 0
         elif idx % 2 == 1:
             assert b"PSK key given, setting client callback" in results.stdout
             assert results.exception is None

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -434,7 +434,7 @@ int main(int argc, char **argv)
             "ff5dd36d64e861be7fd61d2827db279cce145077d454a3664d4e6da4d29ee03725"
             "a6a4dafcd0fc67d2aea70529513e3da2677fa5906c5b3f7d8f92f228bda40dda72"
             "1470f9fbf297b5aea617646fac5c03272e970727c621a79141ef5f7de6505e5bfb"
-            "c388e93343694093934ae4d357fad6aacb");
+            "c388e93343694093934ae4d357");
         S2N_BLOB_FROM_HEX(client_hello_prefix,
             "010001fc03031bc3ceb6bbe39cff938355b5a50adb6db21b7a6af649d7b4bc419d"
             "7876487d95000006130113031302010001cd0000000b0009000006736572766572"

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -1004,7 +1004,6 @@ int main(int argc, char **argv)
         struct s2n_connection *conn = NULL;
         DEFER_CLEANUP(struct s2n_psk *chosen_psk = s2n_external_psk_new(), s2n_psk_free);
         const uint8_t test_identity[] = "identity";
-        const uint8_t test_secret[] = "secret";
 
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
@@ -1018,14 +1017,13 @@ int main(int argc, char **argv)
 
         DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
         EXPECT_SUCCESS(s2n_psk_set_identity(psk, test_identity, sizeof(test_identity)));
-        EXPECT_SUCCESS(s2n_psk_set_secret(psk, test_secret, sizeof(test_secret)));
 
         conn->psk_params.chosen_psk = psk;
         EXPECT_SUCCESS(s2n_connection_get_chosen_psk(conn, chosen_psk));
         EXPECT_EQUAL(chosen_psk->identity.size, sizeof(test_identity));
         EXPECT_BYTEARRAY_EQUAL(chosen_psk->identity.data, test_identity, sizeof(test_identity));  
-        EXPECT_EQUAL(chosen_psk->secret.size, sizeof(test_secret));
-        EXPECT_BYTEARRAY_EQUAL(chosen_psk->secret.data, test_secret, sizeof(test_secret));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
     /* Test s2n_psk_get_type */

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -999,5 +999,34 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
+    /* Test: s2n_connection_get_chosen_psk */
+    {
+            struct s2n_connection *conn = NULL;
+             DEFER_CLEANUP(struct s2n_psk *chosen_psk = s2n_external_psk_new(), s2n_psk_free);
+            const uint8_t test_identity[] = "identity";
+            const uint8_t test_secret[] = "secret";
+
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_chosen_psk(NULL, chosen_psk), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_chosen_psk(conn, NULL), S2N_ERR_NULL);
+    
+            EXPECT_NULL(conn->psk_params.chosen_psk);
+            EXPECT_SUCCESS(s2n_connection_get_chosen_psk(conn, chosen_psk));
+            EXPECT_EQUAL(chosen_psk->identity.size, 0);
+            EXPECT_NULL(chosen_psk->identity.data);
+
+            DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
+            EXPECT_SUCCESS(s2n_psk_set_identity(psk, test_identity, sizeof(test_identity)));
+            EXPECT_SUCCESS(s2n_psk_set_secret(psk, test_secret, sizeof(test_secret)));
+
+            conn->psk_params.chosen_psk = psk;
+            EXPECT_SUCCESS(s2n_connection_get_chosen_psk(conn, chosen_psk));
+            EXPECT_EQUAL(chosen_psk->identity.size, sizeof(test_identity));
+            EXPECT_BYTEARRAY_EQUAL(chosen_psk->identity.data, test_identity, sizeof(test_identity));  
+            EXPECT_EQUAL(chosen_psk->secret.size, sizeof(test_secret));
+            EXPECT_BYTEARRAY_EQUAL(chosen_psk->identity.data, test_secret, sizeof(test_secret));
+    }
+
     END_TEST();
 }

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -1001,31 +1001,85 @@ int main(int argc, char **argv)
 
     /* Test: s2n_connection_get_chosen_psk */
     {
-            struct s2n_connection *conn = NULL;
-             DEFER_CLEANUP(struct s2n_psk *chosen_psk = s2n_external_psk_new(), s2n_psk_free);
-            const uint8_t test_identity[] = "identity";
-            const uint8_t test_secret[] = "secret";
+        struct s2n_connection *conn = NULL;
+        DEFER_CLEANUP(struct s2n_psk *chosen_psk = s2n_external_psk_new(), s2n_psk_free);
+        const uint8_t test_identity[] = "identity";
+        const uint8_t test_secret[] = "secret";
 
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_chosen_psk(NULL, chosen_psk), S2N_ERR_NULL);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_chosen_psk(conn, NULL), S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_chosen_psk(NULL, chosen_psk), S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_chosen_psk(conn, NULL), S2N_ERR_NULL);
     
-            EXPECT_NULL(conn->psk_params.chosen_psk);
-            EXPECT_SUCCESS(s2n_connection_get_chosen_psk(conn, chosen_psk));
-            EXPECT_EQUAL(chosen_psk->identity.size, 0);
-            EXPECT_NULL(chosen_psk->identity.data);
+        EXPECT_NULL(conn->psk_params.chosen_psk);
+        EXPECT_SUCCESS(s2n_connection_get_chosen_psk(conn, chosen_psk));
+        EXPECT_EQUAL(chosen_psk->identity.size, 0);
+        EXPECT_NULL(chosen_psk->identity.data);
 
-            DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
-            EXPECT_SUCCESS(s2n_psk_set_identity(psk, test_identity, sizeof(test_identity)));
-            EXPECT_SUCCESS(s2n_psk_set_secret(psk, test_secret, sizeof(test_secret)));
+        DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
+        EXPECT_SUCCESS(s2n_psk_set_identity(psk, test_identity, sizeof(test_identity)));
+        EXPECT_SUCCESS(s2n_psk_set_secret(psk, test_secret, sizeof(test_secret)));
 
-            conn->psk_params.chosen_psk = psk;
-            EXPECT_SUCCESS(s2n_connection_get_chosen_psk(conn, chosen_psk));
-            EXPECT_EQUAL(chosen_psk->identity.size, sizeof(test_identity));
-            EXPECT_BYTEARRAY_EQUAL(chosen_psk->identity.data, test_identity, sizeof(test_identity));  
-            EXPECT_EQUAL(chosen_psk->secret.size, sizeof(test_secret));
-            EXPECT_BYTEARRAY_EQUAL(chosen_psk->identity.data, test_secret, sizeof(test_secret));
+        conn->psk_params.chosen_psk = psk;
+        EXPECT_SUCCESS(s2n_connection_get_chosen_psk(conn, chosen_psk));
+        EXPECT_EQUAL(chosen_psk->identity.size, sizeof(test_identity));
+        EXPECT_BYTEARRAY_EQUAL(chosen_psk->identity.data, test_identity, sizeof(test_identity));  
+        EXPECT_EQUAL(chosen_psk->secret.size, sizeof(test_secret));
+        EXPECT_BYTEARRAY_EQUAL(chosen_psk->secret.data, test_secret, sizeof(test_secret));
+    }
+
+    /* Test s2n_psk_get_type */
+    {
+        struct s2n_psk ext_psk = { .type = S2N_PSK_TYPE_EXTERNAL };
+        struct s2n_psk res_psk = { .type = S2N_PSK_TYPE_RESUMPTION };
+        uint8_t type = 0;
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_psk_get_type(NULL, &type), S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_psk_get_type(&ext_psk, NULL), S2N_ERR_NULL);
+
+        EXPECT_SUCCESS(s2n_psk_get_type(&ext_psk, &type));
+        EXPECT_EQUAL(type, S2N_PSK_TYPE_EXTERNAL);
+
+        EXPECT_SUCCESS(s2n_psk_get_type(&res_psk, &type));
+        EXPECT_EQUAL(type, S2N_PSK_TYPE_RESUMPTION);
+    }
+
+    /* Test s2n_psk_get_identity_length */
+    {
+        const uint8_t test_identity[] = "identity";
+        uint16_t identity_length = 0;
+
+        DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
+        EXPECT_SUCCESS(s2n_psk_set_identity(psk, test_identity, sizeof(test_identity)));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_psk_get_identity_length(NULL, &identity_length), S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_psk_get_identity_length(psk, NULL), S2N_ERR_NULL);
+    
+        EXPECT_SUCCESS(s2n_psk_get_identity_length(psk, &identity_length));
+        EXPECT_EQUAL(identity_length, sizeof(test_identity));
+    }
+
+    /* Test s2n_psk_get_identity */
+    {
+        const uint8_t test_identity[] = "identity";
+        uint8_t identity[sizeof(test_identity)] = { 0 };
+        uint16_t identity_length = 0;
+
+        DEFER_CLEANUP(struct s2n_psk *psk = s2n_external_psk_new(), s2n_psk_free);
+        EXPECT_SUCCESS(s2n_psk_set_identity(psk, test_identity, sizeof(test_identity)));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_psk_get_identity(NULL, identity, &identity_length), S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_psk_get_identity(psk, NULL, &identity_length), S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_psk_get_identity(psk, identity, NULL), S2N_ERR_NULL);
+
+        EXPECT_SUCCESS(s2n_psk_get_identity_length(psk, &identity_length));
+        EXPECT_SUCCESS(s2n_psk_get_identity(psk, identity, &identity_length));
+
+        EXPECT_EQUAL(identity_length, sizeof(test_identity));
+        EXPECT_BYTEARRAY_EQUAL(identity, test_identity, sizeof(test_identity));  
+
+        identity_length -= 1;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_psk_get_identity(psk, identity, &identity_length), S2N_ERR_INSUFFICIENT_MEM_SIZE);
     }
 
     END_TEST();

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -608,3 +608,34 @@ int s2n_connection_get_chosen_psk(struct s2n_connection *conn, struct s2n_psk *c
     POSIX_GUARD_RESULT(s2n_psk_clone(chosen_psk, conn->psk_params.chosen_psk));
     return S2N_SUCCESS;
 }
+
+int s2n_psk_get_type(struct s2n_psk *psk, uint8_t *type)
+{
+    POSIX_ENSURE_REF(psk);
+    POSIX_ENSURE_REF(type);
+
+    *type = psk->type;
+    return S2N_SUCCESS;
+}
+
+int s2n_psk_get_identity_length(struct s2n_psk *psk, uint16_t *identity_length)
+{
+    POSIX_ENSURE_REF(psk);
+    POSIX_ENSURE_REF(identity_length);
+
+    *identity_length = psk->identity.size;
+    return S2N_SUCCESS;
+}
+
+int s2n_psk_get_identity(struct s2n_psk *psk, uint8_t *identity, uint16_t *identity_length)
+{
+    POSIX_ENSURE_REF(psk);
+    POSIX_ENSURE_REF(identity);
+    POSIX_ENSURE_REF(identity_length);
+
+    POSIX_ENSURE(*identity_length >= psk->identity.size, S2N_ERR_INSUFFICIENT_MEM_SIZE);
+    *identity_length = psk->identity.size;
+    POSIX_CHECKED_MEMCPY(identity, psk->identity.data, psk->identity.size);
+
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -605,7 +605,16 @@ int s2n_connection_get_chosen_psk(struct s2n_connection *conn, struct s2n_psk *c
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(chosen_psk);
 
-    POSIX_GUARD_RESULT(s2n_psk_clone(chosen_psk, conn->psk_params.chosen_psk));
+    struct s2n_psk *conn_chosen_psk = conn->psk_params.chosen_psk;
+    if (conn_chosen_psk == NULL) {
+        return S2N_SUCCESS;
+    }
+
+    struct s2n_psk psk = *chosen_psk;
+    *chosen_psk = *conn_chosen_psk;
+    chosen_psk->identity = psk.identity;
+    POSIX_GUARD(s2n_psk_set_identity(chosen_psk, conn_chosen_psk->identity.data, conn_chosen_psk->identity.size));
+
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -599,3 +599,12 @@ int s2n_connection_set_psk_mode(struct s2n_connection *conn, s2n_psk_mode mode)
     conn->psk_mode_overridden = true;
     return S2N_SUCCESS;
 }
+
+int s2n_connection_get_chosen_psk(struct s2n_connection *conn, struct s2n_psk *chosen_psk)
+{
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(chosen_psk);
+
+    POSIX_GUARD_RESULT(s2n_psk_clone(chosen_psk, conn->psk_params.chosen_psk));
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -103,6 +103,7 @@ int s2n_connection_append_psk(struct s2n_connection *conn, struct s2n_psk *psk);
 typedef enum { S2N_PSK_MODE_RESUMPTION, S2N_PSK_MODE_EXTERNAL } s2n_psk_mode;
 int s2n_config_set_psk_mode(struct s2n_config *config, s2n_psk_mode mode);
 int s2n_connection_set_psk_mode(struct s2n_connection *conn, s2n_psk_mode mode);
+int s2n_connection_get_chosen_psk(struct s2n_connection *conn, struct s2n_psk *chosen_psk);
 
 struct s2n_offered_psk;
 struct s2n_offered_psk* s2n_offered_psk_new();

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -98,6 +98,10 @@ int s2n_psk_set_identity(struct s2n_psk *psk, const uint8_t *identity, uint16_t 
 int s2n_psk_set_secret(struct s2n_psk *psk, const uint8_t *secret, uint16_t secret_size);
 int s2n_psk_set_hmac(struct s2n_psk *psk, s2n_psk_hmac hmac);
 
+int s2n_psk_get_type(struct s2n_psk *psk, uint8_t *type);
+int s2n_psk_get_identity_length(struct s2n_psk *psk, uint16_t *identity_length);
+int s2n_psk_get_identity(struct s2n_psk *psk, uint8_t *identity, uint16_t *identity_length);
+
 int s2n_connection_append_psk(struct s2n_connection *conn, struct s2n_psk *psk);
 
 typedef enum { S2N_PSK_MODE_RESUMPTION, S2N_PSK_MODE_EXTERNAL } s2n_psk_mode;


### PR DESCRIPTION
### Description of changes: 

To test external PSKs we need to extend the ability  of s2nd and s2nc to append/set the psk_list supported by the client. This includes inputting the psk_identity, psk_secret and its corresponding psk hmac algorithm and constructing an external psk using `s2n_external_psk_new`, setting the psk identity, psk secret and psk hmac algorithm using `s2n_psk_set_identity`, `s2n_psk_set_secret` and `s2n_psk_set_hmac` and using the `s2n_connection_append_psk`  to append the constructed s2n_external_psk_new psk to the connection. Additionally on the server side, we need to extend the ability of the s2nd server to select a `chosen_psk_wire_index` from a list of `s2n_offered_psks` by setting the `s2n_config_set_psk_selection_callback` function.

```
s2nc --psk psk_identity_1,psk_secret_1,psk_hmac_alg_1  --psk psk_identity_2,psk_secret_2,psk_hmac_alg_2 ... --psk psk_identity_n,psk_secret_n,psk_hmac_alg_n
```

and 

```
s2nd --psk psk_identity_1,psk_secret_1,psk_hmac_alg_1  --psk psk_identity_2,psk_secret_2,psk_hmac_alg_2 ... --psk psk_identity_n,psk_secret_n,psk_hmac_alg_n
 ```

### Call-outs:

- The choice of using command line parameters over using a file to obtain the psk parameters was made for keeping it simple and  easy to use. We can always revert to using a file if the need to expand arises. 
- The PSK_SECRET_SIZE_MAX  value is set to 2048 
 
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? Integration Tests. 

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
