### PR TITLE
Pinned bash script to previous commit

### DIFF
--- a/codebuild/bin/install_libFuzzer.sh
+++ b/codebuild/bin/install_libFuzzer.sh
@@ -44,6 +44,9 @@ mkdir -p "$LIBFUZZER_INSTALL_DIR"/lib && cp libFuzzer.a "$LIBFUZZER_INSTALL_DIR"
 
 # Run AFL instead of libfuzzer if AFL_FUZZ is set. Not compatible with fuzz coverage.
 if [[ "$AFL_FUZZ" == "true" && "$FUZZ_COVERAGE" != "true" ]]; then
+	# Clusterfuzz's bash script changed from AFL to AFL++ on April 1, 2021; this
+	# commit (ac5ac9e4604ea03cfd643185ad1e3800e952ea44) pins the script to an older version
+	# of Clusterfuzz until we support AFL++.
 	mkdir -p "$LIBFUZZER_INSTALL_DIR" && curl https://raw.githubusercontent.com/google/clusterfuzz/ac5ac9e4604ea03cfd643185ad1e3800e952ea44/docs/setting-up-fuzzing/build_afl.bash > "$LIBFUZZER_INSTALL_DIR"/build_afl.bash
 	chmod +x "$LIBFUZZER_INSTALL_DIR"/build_afl.bash
 	cd "$LIBFUZZER_INSTALL_DIR"

--- a/codebuild/bin/install_libFuzzer.sh
+++ b/codebuild/bin/install_libFuzzer.sh
@@ -44,7 +44,7 @@ mkdir -p "$LIBFUZZER_INSTALL_DIR"/lib && cp libFuzzer.a "$LIBFUZZER_INSTALL_DIR"
 
 # Run AFL instead of libfuzzer if AFL_FUZZ is set. Not compatible with fuzz coverage.
 if [[ "$AFL_FUZZ" == "true" && "$FUZZ_COVERAGE" != "true" ]]; then
-	mkdir -p "$LIBFUZZER_INSTALL_DIR" && curl https://raw.githubusercontent.com/google/clusterfuzz/master/docs/setting-up-fuzzing/build_afl.bash > "$LIBFUZZER_INSTALL_DIR"/build_afl.bash
+	mkdir -p "$LIBFUZZER_INSTALL_DIR" && curl https://raw.githubusercontent.com/google/clusterfuzz/ac5ac9e4604ea03cfd643185ad1e3800e952ea44/docs/setting-up-fuzzing/build_afl.bash > "$LIBFUZZER_INSTALL_DIR"/build_afl.bash
 	chmod +x "$LIBFUZZER_INSTALL_DIR"/build_afl.bash
 	cd "$LIBFUZZER_INSTALL_DIR"
 	"$LIBFUZZER_INSTALL_DIR"/build_afl.bash


### PR DESCRIPTION
### Resolved issues:

 N/A

### Description of changes: 

Clusterfuzz's bash script recently changed from AFL to AFL++, this will pin the script to an older version until we can support AFL++.
### Call-outs:
Note: I anticipate us still having timeout issues with the fuzz tests but at least this commit will get them to pass.
### Testing:

Fuzz tests pass.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
