### PR TITLE
Don't send the client_session_ticket extension when using TLS1.3 tickets

### DIFF
--- a/tests/unit/s2n_client_session_ticket_extension_test.c
+++ b/tests/unit/s2n_client_session_ticket_extension_test.c
@@ -14,6 +14,7 @@
  */
 
 #include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
 
 #include "tls/extensions/s2n_client_session_ticket.h"
 #include "tls/s2n_resume.h"
@@ -53,6 +54,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, true));
         EXPECT_TRUE(s2n_client_session_ticket_extension.should_send(conn));
 
+        /* session ticket should not be sent if TLS1.3 PSKs are being used */
+        DEFER_CLEANUP(struct s2n_psk *test_psk = s2n_test_psk_new(conn), s2n_psk_free);
+        EXPECT_SUCCESS(s2n_connection_append_psk(conn, test_psk));
+        EXPECT_FALSE(s2n_client_session_ticket_extension.should_send(conn));
+
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
@@ -91,6 +97,31 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_conn->session_ticket_status, S2N_DECRYPT_TICKET);
         EXPECT_BYTEARRAY_EQUAL(server_conn->client_ticket_to_decrypt.blob.data,
                 test_ticket, s2n_array_len(test_ticket));
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    /* recv - ignore extension if TLS1.3 */
+    {
+        struct s2n_connection *server_conn;
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        s2n_set_test_ticket(client_conn, test_ticket, S2N_TLS12_TICKET_SIZE_IN_BYTES);
+        EXPECT_SUCCESS(s2n_client_session_ticket_extension.send(client_conn, &stuffer));
+
+        server_conn->actual_protocol_version = S2N_TLS13;
+        EXPECT_SUCCESS(s2n_client_session_ticket_extension.recv(server_conn, &stuffer));
+        EXPECT_EQUAL(server_conn->session_ticket_status, S2N_NO_TICKET);
+        EXPECT_EQUAL(s2n_stuffer_data_available(&server_conn->client_ticket_to_decrypt), 0);
+
+        server_conn->actual_protocol_version = S2N_TLS12;
+        EXPECT_SUCCESS(s2n_client_session_ticket_extension.recv(server_conn, &stuffer));
+        EXPECT_EQUAL(server_conn->session_ticket_status, S2N_DECRYPT_TICKET);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tls/extensions/s2n_client_session_ticket.c
+++ b/tls/extensions/s2n_client_session_ticket.c
@@ -17,6 +17,8 @@
 #include <stdint.h>
 
 #include "tls/extensions/s2n_client_session_ticket.h"
+
+#include "tls/extensions/s2n_client_psk.h"
 #include "tls/s2n_tls.h"
 #include "tls/s2n_tls_parameters.h"
 #include "tls/s2n_resume.h"
@@ -38,7 +40,7 @@ const s2n_extension_type s2n_client_session_ticket_extension = {
 
 static bool s2n_client_session_ticket_should_send(struct s2n_connection *conn)
 {
-    return conn->config->use_tickets;
+    return conn->config->use_tickets && !s2n_client_psk_should_send(conn);
 }
 
 static int s2n_client_session_ticket_send(struct s2n_connection *conn, struct s2n_stuffer *out)
@@ -49,7 +51,7 @@ static int s2n_client_session_ticket_send(struct s2n_connection *conn, struct s2
 
 static int s2n_client_session_ticket_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    if (conn->config->use_tickets != 1) {
+    if (conn->config->use_tickets != 1 || conn->actual_protocol_version > S2N_TLS12) {
         /* Ignore the extension. */
         return S2N_SUCCESS;
     }


### PR DESCRIPTION
### Description of changes: 

Currently, setting TLS1.3 tickets means that we send the TLS1.2 session ticket extension. 

From https://tools.ietf.org/html/rfc5077#section-3.2:
>    If the client possesses a ticket that it wants to use to resume a
>    session, then it includes the ticket in the SessionTicket extension
>    in the ClientHello.  If the client does not have a ticket and is
>    prepared to receive one in the NewSessionTicket handshake message,
>    then it MUST include a zero-length ticket in the SessionTicket
>    extension.  If the client is not prepared to receive a ticket in the
>    NewSessionTicket handshake message, then it MUST NOT include a
>    SessionTicket extension unless it is sending a non-empty ticket it
>    received through some other means from the server.

We can't just check for an empty `conn->client_ticket` to avoid sending the TLS1.2 extension, because the extension is sent even if there is no client ticket. An empty extension indicates that the client is requesting a new ticket. For that same reason, we can't check the actual_protocol_version; we haven't negotiated a version yet, and if the client ticket wasn't set the connection did not inherit the protocol version from the ticket.

What we /can/ do is disable the extension if we are sending the TLS1.3 PSK extension. Setting a TLS1.2 ticket implies that the client knows that it is talking to a TLS1.2 server, and there is no reason to configure PSKs when talking to a TLS1.2 server. Therefore, if a client configures TLS1.3 partial handshakes, we can safely assume that the client does not want to perform a TLS1.2 partial handshake.

### Testing:

Unit and functional tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
