### PR TITLE
Clean up after variable-sized ticket conversion

### DIFF
--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -21,8 +21,6 @@
 #include "tls/s2n_resume.c"
 #include "utils/s2n_safety.h"
 
-#define S2N_TLS13_STATE_SIZE_WITHOUT_SECRET S2N_MAX_STATE_SIZE_IN_BYTES - S2N_TLS_SECRET_LEN
-
 #define TICKET_ISSUE_TIME_BYTES 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07
 #define TICKET_AGE_ADD_BYTES 0x01, 0x01, 0x01, 0x01
 #define TICKET_AGE_ADD 16843009
@@ -38,13 +36,6 @@
 #define EARLY_DATA_CONTEXT 0x07, 0x08, 0x09
 
 #define SECONDS_TO_NANOS(seconds) ((seconds) * (uint64_t)ONE_SEC_IN_NANOS)
-
-#define SIZE_OF_MAX_EARLY_DATA_SIZE sizeof(uint32_t)
-#define FIXED_ENCRYPTED_TICKET_SIZE (S2N_TICKET_KEY_NAME_LEN + \
-                                     S2N_TLS_GCM_IV_LEN + \
-                                     S2N_TLS13_STATE_SIZE_WITHOUT_SECRET + \
-                                     S2N_TLS_GCM_TAG_LEN + \
-                                     SIZE_OF_MAX_EARLY_DATA_SIZE)
 
 const uint64_t ticket_issue_time = 283686952306183;
 static int s2n_test_session_ticket_callback(struct s2n_connection *conn, struct s2n_session_ticket *ticket)
@@ -84,7 +75,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
         conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
 
-        uint8_t s_data[S2N_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = { 0 };
+        uint8_t s_data[S2N_TLS12_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = { 0 };
         struct s2n_blob state_blob = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
         struct s2n_stuffer output = { 0 };
@@ -250,7 +241,7 @@ int main(int argc, char **argv)
 
     /* s2n_deserialize_resumption_state */
     {
-        uint8_t tls12_ticket[S2N_STATE_SIZE_IN_BYTES] = {
+        uint8_t tls12_ticket[S2N_TLS12_STATE_SIZE_IN_BYTES] = {
             S2N_TLS12_SERIALIZED_FORMAT_VERSION,
             S2N_TLS12,
             TLS_RSA_WITH_AES_128_GCM_SHA256,
@@ -598,7 +589,7 @@ int main(int argc, char **argv)
                 conn->actual_protocol_version = S2N_TLS12;
                 conn->secure.cipher_suite = &s2n_rsa_with_aes_128_gcm_sha256;
 
-                uint8_t s_data[S2N_STATE_SIZE_IN_BYTES] = { 0 };
+                uint8_t s_data[S2N_TLS12_STATE_SIZE_IN_BYTES] = { 0 };
                 struct s2n_blob state_blob = { 0 };
                 EXPECT_SUCCESS(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
                 struct s2n_stuffer stuffer = { 0 };

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -469,8 +469,8 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_stuffer_read_uint16(&session_stuffer, &ticket_size));
                 EXPECT_EQUAL(ticket_size, sizeof(test_ticket));
 
-                uint8_t ticket[S2N_MAX_TICKET_SIZE_IN_BYTES] = { 0 };
-                EXPECT_SUCCESS(s2n_stuffer_read_bytes(&session_stuffer, ticket, ticket_size));
+                uint8_t *ticket = s2n_stuffer_raw_read(&session_stuffer, ticket_size);
+                EXPECT_NOT_NULL(ticket);
                 EXPECT_BYTEARRAY_EQUAL(ticket, test_ticket, ticket_size);
             }
 

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
 
     size_t serialized_session_state_length = 0;
     uint8_t s2n_state_with_session_id = S2N_STATE_WITH_SESSION_ID;
-    uint8_t serialized_session_state[S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TLS12_TICKET_SIZE_IN_BYTES + S2N_STATE_SIZE_IN_BYTES] = { 0 };
+    uint8_t serialized_session_state[S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES + S2N_TLS12_TICKET_SIZE_IN_BYTES + S2N_TLS12_STATE_SIZE_IN_BYTES] = { 0 };
 
     /* Session ticket keys. Taken from test vectors in https://tools.ietf.org/html/rfc5869 */
     uint8_t ticket_key_name1[16] = "2016.07.26.15\0";
@@ -613,7 +613,7 @@ int main(int argc, char **argv)
         EXPECT_FALSE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
 
         /* Verify that client_ticket is empty */
-        EXPECT_EQUAL(s2n_connection_get_session(client_conn, serialized_session_state, serialized_session_state_length), 1 + 1 + client_conn->session_id_len + S2N_STATE_SIZE_IN_BYTES);
+        EXPECT_EQUAL(s2n_connection_get_session(client_conn, serialized_session_state, serialized_session_state_length), 1 + 1 + client_conn->session_id_len + S2N_TLS12_STATE_SIZE_IN_BYTES);
         EXPECT_EQUAL(memcmp(serialized_session_state, &s2n_state_with_session_id, 1), 0);
         EXPECT_NOT_EQUAL(memcmp(serialized_session_state + S2N_PARTIAL_SESSION_STATE_INFO_IN_BYTES, ticket_key_name2, strlen((char *)ticket_key_name2)), 0);
 
@@ -1003,7 +1003,7 @@ int main(int argc, char **argv)
         uint8_t valid_iv[S2N_TLS_GCM_IV_LEN] = {0};
         POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, valid_iv, sizeof(valid_iv)));
 
-        uint8_t invalid_en_data[S2N_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = {0};
+        uint8_t invalid_en_data[S2N_TLS12_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = {0};
         POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, invalid_en_data, sizeof(invalid_en_data)));
 
         server_conn->session_ticket_status = S2N_DECRYPT_TICKET;
@@ -1029,7 +1029,7 @@ int main(int argc, char **argv)
         uint8_t valid_iv[S2N_TLS_GCM_IV_LEN] = {0};
         POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, valid_iv, sizeof(valid_iv)));
 
-        uint8_t invalid_en_data[S2N_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = {0};
+        uint8_t invalid_en_data[S2N_TLS12_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = {0};
         POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, invalid_en_data, sizeof(invalid_en_data)));
 
         server_conn->session_ticket_status = S2N_DECRYPT_TICKET;

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -20,15 +20,7 @@
 #include "stuffer/s2n_stuffer.h"
 
 #define S2N_STATE_LIFETIME_IN_NANOS     54000000000000      /* 15 hours */
-#define S2N_STATE_SIZE_IN_BYTES         (1 + 8 + 1 + S2N_TLS_CIPHER_SUITE_LEN + S2N_TLS_SECRET_LEN)
-
-#define S2N_MAX_STATE_SIZE_IN_BYTES     sizeof(uint8_t)  +  /* serialization format */  \
-                                        sizeof(uint8_t)  +  /* protocol version */      \
-                                        sizeof(uint16_t) +  /* cipher suite */          \
-                                        sizeof(uint64_t) +  /* ticket issue time */     \
-                                        sizeof(uint32_t) +  /* ticket age add */        \
-                                        sizeof(uint8_t)  +  /* secret size */           \
-                                        S2N_TLS_SECRET_LEN
+#define S2N_TLS12_STATE_SIZE_IN_BYTES   (1 + 8 + 1 + S2N_TLS_CIPHER_SUITE_LEN + S2N_TLS_SECRET_LEN)
 
 #define S2N_TLS_SESSION_CACHE_TTL       (6 * 60 * 60)
 #define S2N_TICKET_KEY_NAME_LEN         16
@@ -39,10 +31,7 @@
 #define ONE_MILLISEC_IN_NANOS           1000000
 #define ONE_WEEK_IN_SEC                 604800
 #define S2N_TLS12_TICKET_SIZE_IN_BYTES  (S2N_TICKET_KEY_NAME_LEN + S2N_TLS_GCM_IV_LEN +     \
-        S2N_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN)
-
-#define S2N_MAX_TICKET_SIZE_IN_BYTES    (S2N_TICKET_KEY_NAME_LEN + S2N_TLS_GCM_IV_LEN +     \
-        S2N_MAX_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN)
+        S2N_TLS12_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN)
 
 #define S2N_TICKET_ENCRYPT_DECRYPT_KEY_LIFETIME_IN_NANOS        7200000000000     /* 2 hours */
 #define S2N_TICKET_DECRYPT_KEY_LIFETIME_IN_NANOS                46800000000000    /* 13 hours */
@@ -55,7 +44,7 @@
 #define S2N_TLS12_SESSION_SIZE          S2N_STATE_FORMAT_LEN + \
                                         S2N_SESSION_TICKET_SIZE_LEN + \
                                         S2N_TLS12_TICKET_SIZE_IN_BYTES + \
-                                        S2N_STATE_SIZE_IN_BYTES
+                                        S2N_TLS12_STATE_SIZE_IN_BYTES
 
 struct s2n_connection;
 struct s2n_config;

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -67,7 +67,7 @@ int s2n_server_nst_recv(struct s2n_connection *conn) {
             /* Alloc some memory for the serialized session ticket */
             DEFER_CLEANUP(struct s2n_blob mem = { 0 }, s2n_free);
             POSIX_GUARD(s2n_alloc(&mem, S2N_STATE_FORMAT_LEN + S2N_SESSION_TICKET_SIZE_LEN + \
-                    conn->client_ticket.size + S2N_STATE_SIZE_IN_BYTES));
+                    conn->client_ticket.size + S2N_TLS12_STATE_SIZE_IN_BYTES));
 
             POSIX_GUARD(s2n_connection_get_session(conn, mem.data, session_len));
             uint32_t session_lifetime = s2n_connection_get_session_ticket_lifetime_hint(conn);


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/2574

### Description of changes: 

Follow-up to https://github.com/aws/s2n-tls/pull/2709. 
As part of this change, none of the TLS1.3 session ticket code should depend on fixed sizes anymore. To enforce that, I removed the TLS1.3 size macros and renamed the original size macros to "TLS12".

### Testing:

Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
