### PR TITLE
Check for validity in s2n_stuffer_wipe* operations

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -180,6 +180,7 @@ int s2n_stuffer_reread(struct s2n_stuffer *stuffer)
 
 int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t size)
 {
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
     if (size >= stuffer->write_cursor) {
         return s2n_stuffer_wipe(stuffer);
     }
@@ -189,6 +190,7 @@ int s2n_stuffer_wipe_n(struct s2n_stuffer *stuffer, const uint32_t size)
     POSIX_CHECKED_MEMSET(stuffer->blob.data + stuffer->write_cursor, S2N_WIPE_PATTERN, size);
     stuffer->read_cursor = MIN(stuffer->read_cursor, stuffer->write_cursor);
 
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 
@@ -198,6 +200,7 @@ bool s2n_stuffer_is_consumed(struct s2n_stuffer *stuffer) {
 
 int s2n_stuffer_wipe(struct s2n_stuffer *stuffer)
 {
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
     if (!s2n_stuffer_is_wiped(stuffer)) {
         POSIX_CHECKED_MEMSET(stuffer->blob.data, S2N_WIPE_PATTERN, stuffer->high_water_mark);
     }
@@ -206,6 +209,7 @@ int s2n_stuffer_wipe(struct s2n_stuffer *stuffer)
     stuffer->write_cursor = 0;
     stuffer->read_cursor = 0;
     stuffer->high_water_mark = 0;
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 

--- a/tests/cbmc/proofs/s2n_stuffer_wipe/s2n_stuffer_wipe_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe/s2n_stuffer_wipe_harness.c
@@ -22,9 +22,7 @@
 void s2n_stuffer_wipe_harness()
 {
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
-
     __CPROVER_assume(s2n_result_is_ok(s2n_stuffer_validate(stuffer)));
-    __CPROVER_assume(stuffer->high_water_mark);
 
     if (s2n_stuffer_wipe(stuffer) == S2N_SUCCESS) {
         assert(s2n_result_is_ok(s2n_stuffer_validate(stuffer)));

--- a/tests/cbmc/proofs/s2n_stuffer_wipe_n/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe_n/Makefile
@@ -21,6 +21,7 @@ HARNESS_FILE = $(HARNESS_ENTRY).c
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c

--- a/tests/cbmc/proofs/s2n_stuffer_wipe_n/s2n_stuffer_wipe_n_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_wipe_n/s2n_stuffer_wipe_n_harness.c
@@ -14,6 +14,7 @@
  */
 
 #include <assert.h>
+#include <sys/param.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
 #include "api/s2n.h"
@@ -21,10 +22,34 @@
 
 void s2n_stuffer_wipe_n_harness()
 {
+    /* Non-deterministic inputs. */
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
     uint32_t            n;
 
+    /* Assume preconditions. */
     __CPROVER_assume(s2n_result_is_ok(s2n_stuffer_validate(stuffer)));
 
-    if (s2n_stuffer_wipe_n(stuffer, n) == S2N_SUCCESS) { assert(s2n_result_is_ok(s2n_stuffer_validate(stuffer))); };
+    /* Save previous state. */
+    uint32_t old_n = n;
+    struct s2n_stuffer old_stuffer = *stuffer;
+
+    /* Function under verification. */
+    if (s2n_stuffer_wipe_n(stuffer, n) == S2N_SUCCESS)
+    {
+        assert(s2n_result_is_ok(s2n_stuffer_validate(stuffer)));
+        assert(old_n == n);
+        assert(S2N_IMPLIES(n >= old_stuffer.write_cursor,
+                           stuffer->high_water_mark == 0 &&
+                           stuffer->tainted == 0         &&
+                           stuffer->write_cursor == 0    &&
+                           stuffer->read_cursor == 0));
+        assert(S2N_IMPLIES(n < old_stuffer.write_cursor,
+                           (stuffer->read_cursor == MIN(old_stuffer.read_cursor, (old_stuffer.write_cursor - n)))));
+        assert(S2N_IMPLIES(n < old_stuffer.write_cursor,
+                           (stuffer->write_cursor == old_stuffer.write_cursor - n)));
+        if(n >= old_stuffer.write_cursor)
+            assert_all_bytes_are(stuffer->blob.data, S2N_WIPE_PATTERN, old_stuffer.high_water_mark);
+        else
+            assert_all_bytes_are(stuffer->blob.data+(old_stuffer.write_cursor - n), S2N_WIPE_PATTERN, n);
+    };
 }


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

### Resolved issues:

N/A.

### Description of changes: 

We update CBMC proofs for `s2n_stuffer_wipe*` functions and add pre- and postconditions on them as well. We also update stuffer flags to check for nullness before accessing members of a data structure.

### Call-outs:
N/A.

### Testing:
N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
