### PR TITLE
Test Codebuild

### DIFF
--- a/bin/common.c
+++ b/bin/common.c
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+#include "common.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -20,6 +21,7 @@
 #include <errno.h>
 #include <s2n.h>
 
+#define PSK_SECRET_SIZE_MAX 2048
 char *load_file_to_cstring(const char *path)
 {
     FILE *pem_file = fopen(path, "rb");
@@ -64,7 +66,8 @@ char *load_file_to_cstring(const char *path)
     return pem_out;
 }
 
-int key_log_callback(void *file, struct s2n_connection *conn, uint8_t *logline, size_t len) {
+int key_log_callback(void *file, struct s2n_connection *conn, uint8_t *logline, size_t len)
+{
     if (fwrite(logline, 1, len, (FILE *)file) != len) {
         return S2N_FAILURE;
     }
@@ -74,4 +77,58 @@ int key_log_callback(void *file, struct s2n_connection *conn, uint8_t *logline, 
     }
 
     return fflush((FILE *)file);
+}
+
+static int s2n_get_psk_hmac_alg(s2n_psk_hmac *psk_hmac, char *hmac_str)
+{
+    POSIX_ENSURE_REF(psk_hmac);
+    POSIX_ENSURE_REF(hmac_str);
+
+    if (strcmp(hmac_str, "S2N_PSK_HMAC_SHA256") == 0) {
+        *psk_hmac = S2N_PSK_HMAC_SHA256;
+    } else if (strcmp(hmac_str, "S2N_PSK_HMAC_SHA384") == 0) {
+        *psk_hmac = S2N_PSK_HMAC_SHA384;
+    } else {
+        return S2N_FAILURE;
+    }
+    return S2N_SUCCESS;
+}
+
+int s2n_setup_external_psk(struct s2n_psk *psk_list[S2N_MAX_PSK_LIST_LENGTH], size_t *psk_idx, char *params)
+{
+    POSIX_ENSURE_REF(psk_list);
+    POSIX_ENSURE_REF(psk_idx);
+    POSIX_ENSURE_REF(params);
+
+    struct s2n_psk *psk = s2n_external_psk_new();
+    POSIX_ENSURE_REF(psk);
+    POSIX_GUARD_RESULT(s2n_psk_init(psk, S2N_PSK_TYPE_EXTERNAL));
+    /* Default HMAC algorithm is S2N_PSK_HMAC_SHA256 */
+    s2n_psk_hmac psk_hmac_alg = S2N_PSK_HMAC_SHA256;
+    size_t idx = 0;
+    for (char *token = strtok(params, ","); token != NULL; token = strtok(NULL, ","), idx++) {
+        struct s2n_blob secret = { 0 };
+        uint8_t secret_buf[PSK_SECRET_SIZE_MAX] = { 0 };
+        switch (idx) {
+            case 0:
+                GUARD_EXIT(s2n_psk_set_identity(psk, (const uint8_t *)token, strlen(token)),
+                             "Error setting psk identity");
+                break;
+            case 1:
+                POSIX_GUARD(s2n_blob_init(&secret, secret_buf, sizeof(secret_buf)));
+                POSIX_GUARD(s2n_hex_string_to_bytes((const uint8_t *)token, &secret));
+                GUARD_EXIT(s2n_psk_set_secret(psk, secret.data, secret.size),
+                             "Error setting psk secret");
+                break;
+            case 2:
+                GUARD_EXIT(s2n_get_psk_hmac_alg(&psk_hmac_alg, token), "Invalid psk hmac algorithm");
+                GUARD_EXIT(s2n_psk_set_hmac(psk, psk_hmac_alg), "Error setting psk hmac algorithm");
+                break;
+            default:
+                break;
+        }
+    }
+
+    psk_list[(*psk_idx)++] = psk;
+    return S2N_SUCCESS;
 }

--- a/bin/common.h
+++ b/bin/common.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <stdint.h>
+#include "tls/s2n_psk.h"
+#include "utils/s2n_safety.h"
 
 #define GUARD_EXIT(x, msg)  \
   do {                      \
@@ -33,6 +35,8 @@
     }                        \
   } while (0)
 
+#define S2N_MAX_PSK_LIST_LENGTH 10
+
 void print_s2n_error(const char *app_error);
 int echo(struct s2n_connection *conn, int sockfd);
 int negotiate(struct s2n_connection *conn, int sockfd);
@@ -40,3 +44,4 @@ int https(struct s2n_connection *conn, uint32_t bench);
 int key_log_callback(void *ctx, struct s2n_connection *conn, uint8_t *logline, size_t len);
 
 char *load_file_to_cstring(const char *path);
+int s2n_setup_external_psk(struct s2n_psk *psk_list[S2N_MAX_PSK_LIST_LENGTH], size_t *psk_idx, char *params);

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -31,6 +31,7 @@
 
 #include "crypto/s2n_rsa.h"
 #include "crypto/s2n_pkey.h"
+#include "tls/s2n_connection.h"
 
 #define STDIO_BUFSIZE  10240
 
@@ -71,6 +72,8 @@ static int wait_for_event(int fd, s2n_blocked_status blocked)
 
 int negotiate(struct s2n_connection *conn, int fd)
 {
+    POSIX_ENSURE_REF(conn);
+
     s2n_blocked_status blocked;
     while (s2n_negotiate(conn, &blocked) != S2N_SUCCESS) {
         if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
@@ -136,6 +139,11 @@ int negotiate(struct s2n_connection *conn, int fd)
     printf("Cipher negotiated: %s\n", s2n_connection_get_cipher(conn));
     if (s2n_connection_is_session_resumed(conn)) {
         printf("Resumed session\n");
+    }
+
+    if (conn->psk_params.chosen_psk) {
+        printf("Chosen PSK type: %s\n", (conn->psk_params.chosen_psk->type) ? "S2N_PSK_TYPE_EXTERNAL" : "S2N_PSK_TYPE_RESUMPTION");
+        printf("Chosen PSK identity: %s\n", conn->psk_params.chosen_psk->identity.data);
     }
 
     return 0;

--- a/tests/integrationv2/test_external_psk.py
+++ b/tests/integrationv2/test_external_psk.py
@@ -1,0 +1,213 @@
+import copy
+import os
+import pytest
+import time
+
+from configuration import available_ports
+from common import ProviderOptions, Protocols, data_bytes, Ciphers, Certificates
+from fixtures import managed_process
+from providers import S2N, OpenSSL
+from utils import invalid_test_parameters, get_parameter_name
+
+# Test Vectors from https://tools.ietf.org/html/rfc8448#section-4 
+shared_psk_identity = '2c035d829359ee5ff7af4ec900000000262a6494dc486d2c8a34cb33fa90bf1b00'\
+                      '70ad3c498883c9367c09a2be785abc55cd226097a3a982117283f82a03a143efd3'\
+                      'ff5dd36d64e861be7fd61d2827db279cce145077d454a3664d4e6da4d29ee03725'\
+                      'a6a4dafcd0fc67d2aea70529513e3da2677fa5906c5b3f7d8f92f228bda40dda72'\
+                      '1470f9fbf297b5aea617646fac5c03272e970727c621a79141ef5f7de6505e5bfb'\
+                      'c388e93343694093934ae4d357'
+
+shared_psk_secret = '4ecd0eb6ec3b4d87f5d6028f922ca4c5851a277fd41311c9e62d2c9492e1c4f3'
+
+s2n_known_value_psk = '2c035d829359ee5ff7af4ec900000000262a6494dc486d2c8a34cb33fa90bf1b00'\
+                      '70ad3c498883c9367c09a2be785abc55cd226097a3a982117283f82a03a143efd3'\
+                      'ff5dd36d64e861be7fd61d2827db279cce145077d454a3664d4e6da4d29ee03725'\
+                      'a6a4dafcd0fc67d2aea70529513e3da2677fa5906c5b3f7d8f92f228bda40dda72'\
+                      '1470f9fbf297b5aea617646fac5c03272e970727c621a79141ef5f7de6505e5bfb'\
+                      'c388e93343694093934ae4d357,'\
+                      '4ecd0eb6ec3b4d87f5d6028f922ca4c5851a277fd41311c9e62d2c9492e1c4f3,'\
+                      'S2N_PSK_HMAC_SHA256'
+
+# Arbitrary Test vectors
+s2n_client_only_psk = 's2n_client_psk_identity,'\
+                      'a6dadae4567876,'\
+                      'S2N_PSK_HMAC_SHA384'\
+
+s2n_server_only_psk = 's2n_server_psk_identity,'\
+                      'a64dafcd0fc67d2a,'\
+                      'S2N_PSK_HMAC_SHA256'\
+
+s2n_shared_psk = 's2n_psk_identity,'\
+                 'f9bf29b5aea6aea7,'\
+                 'S2N_PSK_HMAC_SHA256'\
+
+s2n_invalid_hmac_psk = 'psk_identity,'\
+                       'f9bf29b5aea6aea7,'\
+                       'S2N_PSK_HMAC_SHA512'\
+
+S2N_CLIENT_PSK_PARAMETERS = [ 
+    [ '--psk', s2n_client_only_psk ],
+    [ '--psk', s2n_known_value_psk ], 
+    [ '--psk', s2n_invalid_hmac_psk ],
+    [ '--psk', s2n_client_only_psk, '--psk', s2n_shared_psk ], 
+]
+
+S2N_SERVER_PSK_PARAMETERS = [
+    [ '--psk', s2n_server_only_psk ],
+    [ '--psk', s2n_known_value_psk ],
+    [ '--psk', s2n_invalid_hmac_psk ],
+    [ '--psk', s2n_server_only_psk, '--psk', s2n_shared_psk ], 
+]
+
+OPENSSL_PSK_PARAMETER = [ '-psk_identity', shared_psk_identity, '--psk', shared_psk_secret ]
+
+def s2n_assert_chosen_psk(idx, results, random_bytes, is_s2nd=False, is_peer_openssl_server=False):
+    if idx == 0:
+        assert b"Chosen PSK type: S2N_PSK_TYPE_EXTERNAL" not in results.stdout
+        assert b"Chosen PSK identity" not in results.stdout
+        if is_s2nd:
+            assert random_bytes in results.stdout
+            assert results.exit_code == 0
+        if is_peer_openssl_server:
+            assert b"Failed to negotiate: 'TLS alert received'. Error encountered in s2n_alerts.c line 122" in results.stderr
+            assert results.exit_code != 0
+        else:
+            assert results.exit_code == 0
+    elif idx == 1:
+        assert b"Chosen PSK type: S2N_PSK_TYPE_EXTERNAL" in results.stdout
+        assert bytes("Chosen PSK identity: {}".format(shared_psk_identity).encode('utf-8')) in results.stdout
+        if is_s2nd:
+            assert random_bytes in results.stdout
+        assert results.exit_code == 0   
+    elif idx == 2:
+        assert b"Invalid psk hmac algorithm" in results.stderr
+        assert results.exit_code != 0
+    elif idx == 3: 
+        assert b"Chosen PSK type: S2N_PSK_TYPE_EXTERNAL" in results.stdout
+        assert b"Chosen PSK identity: s2n_psk_identity" in results.stdout
+        if is_s2nd:
+            assert random_bytes in results.stdout
+        assert results.exit_code == 0
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("client_psk_params", S2N_CLIENT_PSK_PARAMETERS, ids=get_parameter_name)
+def test_external_psk_s2nc_with_s2nd(managed_process, client_psk_params):
+    port = next(available_ports)
+
+    random_bytes = data_bytes(64)
+    client_options = ProviderOptions(
+        mode=S2N.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=Ciphers.CHACHA20_POLY1305_SHA256,
+        data_to_send=random_bytes,
+        key=Certificates.ECDSA_256.key,
+        cert=Certificates.ECDSA_256.cert,
+        trust_store=Certificates.ECDSA_256.cert,
+        insecure=False,
+        extra_flags=client_psk_params,
+        protocol=Protocols.TLS13)
+    
+    idx = S2N_CLIENT_PSK_PARAMETERS.index(client_psk_params)
+    server_psk_params = S2N_SERVER_PSK_PARAMETERS[idx]
+    server_options = copy.copy(client_options)
+    server_options.data_to_send = None
+    server_options.mode = S2N.ServerMode
+    server_options.extra_flags = server_psk_params
+
+    server = managed_process(S2N, server_options, timeout=20)
+    client = managed_process(S2N, client_options, timeout=20)
+
+    for results in client.get_results():
+        s2n_assert_chosen_psk(idx, results, random_bytes)
+        assert results.exception is None
+
+    for results in server.get_results():
+        s2n_assert_chosen_psk(idx, results, random_bytes, True)
+        assert results.exception is None
+
+pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("s2n_client_psk_params", S2N_CLIENT_PSK_PARAMETERS[:3], ids=get_parameter_name)
+def test_external_psk_s2nc_with_openssl_server(managed_process, s2n_client_psk_params):
+    port = next(available_ports)
+
+    random_bytes = data_bytes(64)
+    client_options = ProviderOptions(
+        mode=S2N.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=Ciphers.CHACHA20_POLY1305_SHA256,
+        data_to_send=random_bytes,
+        insecure=False,
+        key=Certificates.ECDSA_256.key,
+        cert=Certificates.ECDSA_256.cert,
+        trust_store=Certificates.ECDSA_256.cert,
+        extra_flags=s2n_client_psk_params,
+        protocol=Protocols.TLS13)
+
+    server_options = copy.copy(client_options)
+    server_options.data_to_send = None
+    server_options.mode = OpenSSL.ServerMode
+    server_options.extra_flags = OPENSSL_PSK_PARAMETER
+    idx = S2N_CLIENT_PSK_PARAMETERS.index(s2n_client_psk_params)
+    server = managed_process(OpenSSL, server_options, timeout=20)
+    client = managed_process(S2N, client_options, timeout=20)
+
+    for results in client.get_results():
+        s2n_assert_chosen_psk(idx, results, random_bytes, False, True)
+        assert results.exception is None
+
+    for results in server.get_results():
+        if idx == 0:
+            assert b"PSK warning: client identity not what we expected" in results.stdout
+            assert b"error:141F906E:SSL routines:tls_parse_ctos_psk:bad extension:ssl/statem/extensions_srvr.c:1272" in results.stderr
+            assert results.exception is None
+            assert results.exit_code == 0
+        elif idx % 2 == 1:
+            assert b"PSK key given, setting server callback" in results.stdout
+            assert results.exception is None
+            assert results.exit_code == 0
+        else:
+            assert results.exit_code != 0
+
+pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("s2n_server_psk_params", S2N_SERVER_PSK_PARAMETERS[:3], ids=get_parameter_name)
+def test_external_psk_s2nd_with_openssl_client(managed_process, s2n_server_psk_params):
+    port = next(available_ports)
+
+    random_bytes = data_bytes(64)
+    client_options = ProviderOptions(
+        mode=OpenSSL.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=Ciphers.CHACHA20_POLY1305_SHA256,
+        data_to_send=random_bytes,
+        key=Certificates.ECDSA_256.key,
+        cert=Certificates.ECDSA_256.cert,
+        trust_store=Certificates.ECDSA_256.cert,
+        insecure=False,
+        extra_flags=OPENSSL_PSK_PARAMETER,
+        protocol=Protocols.TLS13)
+
+    server_options = copy.copy(client_options)
+    server_options.data_to_send = None
+    server_options.mode = S2N.ServerMode
+    server_options.extra_flags = s2n_server_psk_params
+    idx = S2N_SERVER_PSK_PARAMETERS.index(s2n_server_psk_params)
+    server = managed_process(S2N, server_options, timeout=20)
+    client = managed_process(OpenSSL, client_options, timeout=20)
+
+    for results in server.get_results():
+        s2n_assert_chosen_psk(idx, results, random_bytes, True)
+        assert results.exception is None
+
+    for results in client.get_results():
+        if idx == 0:
+            assert results.exception is None
+            assert results.exit_code == 0
+        elif idx % 2 == 1:
+            assert b"PSK key given, setting client callback" in results.stdout
+            assert results.exception is None
+            assert results.exit_code == 0
+        else:
+            assert results.exit_code != 0

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -434,7 +434,7 @@ int main(int argc, char **argv)
             "ff5dd36d64e861be7fd61d2827db279cce145077d454a3664d4e6da4d29ee03725"
             "a6a4dafcd0fc67d2aea70529513e3da2677fa5906c5b3f7d8f92f228bda40dda72"
             "1470f9fbf297b5aea617646fac5c03272e970727c621a79141ef5f7de6505e5bfb"
-            "c388e93343694093934ae4d357fad6aacb");
+            "c388e93343694093934ae4d357");
         S2N_BLOB_FROM_HEX(client_hello_prefix,
             "010001fc03031bc3ceb6bbe39cff938355b5a50adb6db21b7a6af649d7b4bc419d"
             "7876487d95000006130113031302010001cd0000000b0009000006736572766572"


### PR DESCRIPTION
### Description of changes: 

To test external PSKs we need to extend the ability  of s2nd and s2nc to append/set the psk_list supported by the client. This includes inputting the psk_identity, psk_secret and its corresponding psk hmac algorithm and constructing an external psk using `s2n_external_psk_new`, setting the psk identity, psk secret and psk hmac algorithm using `s2n_psk_set_identity`, `s2n_psk_set_secret` and `s2n_psk_set_hmac` and using the `s2n_connection_append_psk`  to append the constructed s2n_external_psk_new psk to the connection. Additionally on the server side, we need to extend the ability of the s2nd server to select a `chosen_psk_wire_index` from a list of `s2n_offered_psks` by setting the `s2n_config_set_psk_selection_callback` function.

```
s2nc --psk psk_identity_1,psk_secret_1,psk_hmac_alg_1  --psk psk_identity_2,psk_secret_2,psk_hmac_alg_2 ... --psk psk_identity_n,psk_secret_n,psk_hmac_alg_n
```

and 

```
s2nd --psk psk_identity_1,psk_secret_1,psk_hmac_alg_1  --psk psk_identity_2,psk_secret_2,psk_hmac_alg_2 ... --psk psk_identity_n,psk_secret_n,psk_hmac_alg_n
 ```

### Call-outs:

- The choice of using command line parameters over using a file to obtain the psk parameters was made for keeping it simple and  easy to use. We can always revert to using a file if the need to expand arises. 
- The PSK_SECRET_SIZE_MAX  value is set to 2048 
 
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? Integration Tests. 

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
