### PR TITLE
Use DEFER_CLEANUP with s2n_crypto_free 

### DIFF
--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -280,6 +280,7 @@ int s2n_cert_chain_and_key_load_cns(struct s2n_cert_chain_and_key *chain_and_key
             continue;
         } else if (utf8_out_len == 0) {
             /* We still need to free memory here see https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7521 */
+            OPENSSL_free(utf8_str);
         } else {
             struct s2n_blob *cn_name = NULL;
             POSIX_GUARD_RESULT(s2n_array_pushback(chain_and_key->cn_names, (void **)&cn_name));


### PR DESCRIPTION
### Resolved issues:

https://github.com/aws/s2n-tls/issues/2673

### Description of changes: 

Use DEFER_CLEANUP with s2n_crypto_free function to free/cleanup memory instead of OpenSSL_free when a failure occurs.

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
