### PR TITLE
Fix loop counter overflows due to inconsistent type

### DIFF
--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -195,7 +195,7 @@ int cache_retrieve_callback(struct s2n_connection *conn, void *ctx, const void *
     *value_size = cache[idx].value_len;
     memcpy(value, cache[idx].value, cache[idx].value_len);
 
-    for (int i = 0; i < key_size; i++) {
+    for (uint64_t i = 0; i < key_size; i++) {
         printf("%02x", ((const uint8_t *)key)[i]);
     }
     printf("\n");

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -31,9 +31,9 @@
     acceptable in DRBG */
 int s2n_increment_drbg_counter(struct s2n_blob *counter)
 {
-    for (int i = counter->size - 1; i >= 0; i--) {
-        counter->data[i] += 1;
-        if (counter->data[i]) {
+    for (uint32_t i = counter->size; i > 0; i--) {
+        counter->data[i-1] += 1;
+        if (counter->data[i-1]) {
             break;
         }
 
@@ -95,7 +95,7 @@ static int s2n_drbg_update(struct s2n_drbg *drbg, struct s2n_blob *provided_data
     POSIX_GUARD(s2n_drbg_bits(drbg, &temp_blob));
 
     /* XOR in the provided data */
-    for (int i = 0; i < provided_data->size; i++) {
+    for (uint32_t i = 0; i < provided_data->size; i++) {
         temp_blob.data[i] ^= provided_data->data[i];
     }
 
@@ -115,7 +115,7 @@ static int s2n_drbg_mix_in_entropy(struct s2n_drbg *drbg, struct s2n_blob *entro
 
     POSIX_ENSURE_GTE(entropy->size, ps->size);
 
-    for (int i = 0; i < ps->size; i++) {
+    for (uint32_t i = 0; i < ps->size; i++) {
         entropy->data[i] ^= ps->data[i];
     }
 

--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -476,9 +476,9 @@ int s2n_ecc_evp_find_supported_curve(struct s2n_blob *iana_ids, const struct s2n
 
     POSIX_GUARD(s2n_stuffer_init(&iana_ids_in, iana_ids));
     POSIX_GUARD(s2n_stuffer_write(&iana_ids_in, iana_ids));
-    for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
+    for (size_t i = 0; i < s2n_all_supported_curves_list_len; i++) {
         const struct s2n_ecc_named_curve *supported_curve = s2n_all_supported_curves_list[i];
-        for (int j = 0; j < iana_ids->size / 2; j++) {
+        for (uint32_t j = 0; j < iana_ids->size / 2; j++) {
             uint16_t iana_id;
             POSIX_GUARD(s2n_stuffer_read_uint16(&iana_ids_in, &iana_id));
             if (supported_curve->iana_id == iana_id) {

--- a/crypto/s2n_sequence.c
+++ b/crypto/s2n_sequence.c
@@ -25,7 +25,8 @@
 
 int s2n_increment_sequence_number(struct s2n_blob *sequence_number)
 {
-    for (int i = sequence_number->size - 1; i >= 0; i--) {
+    for (uint32_t j = sequence_number->size; j > 0; j--) {
+        uint32_t i = j - 1;
         sequence_number->data[i] += 1;
         if (sequence_number->data[i]) {
             break;
@@ -50,8 +51,8 @@ int s2n_sequence_number_to_uint64(struct s2n_blob *sequence_number, uint64_t *ou
     uint8_t shift = 0;
     *output = 0;
 
-    for (int i = sequence_number->size - 1; i >= 0; i--) {
-        *output += ((uint64_t) sequence_number->data[i]) << shift;
+    for (uint32_t i = sequence_number->size; i > 0; i--) {
+        *output += ((uint64_t) sequence_number->data[i-1]) << shift;
         shift += SEQUENCE_NUMBER_POWER;
     }
     return S2N_SUCCESS;

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -326,7 +326,7 @@ int s2n_stuffer_writev_bytes(struct s2n_stuffer *stuffer, const struct iovec* io
     POSIX_ENSURE(S2N_MEM_IS_READABLE(ptr, size), S2N_ERR_NULL);
 
     size_t size_left = size, to_skip = offs;
-    for (int i = 0; i < iov_count; i++) {
+    for (size_t i = 0; i < iov_count; i++) {
         if (to_skip >= iov[i].iov_len) {
             to_skip -= iov[i].iov_len;
             continue;

--- a/tests/sidetrail/DEBUGGING.md
+++ b/tests/sidetrail/DEBUGGING.md
@@ -89,7 +89,7 @@ A good example of this is in `s2n_constant_time_equals`.
 
 ```C
     uint8_t xor = 0;
-    for (int i = 0; i < len; i++) {
+    for (uint32_t i = 0; i < len; i++) {
         /* Invariants must hold for each execution of the loop
 	 * and at loop exit, hence the <= */
         S2N_INVARIANT(i <= len);

--- a/tests/sidetrail/working/patches/cbc.patch
+++ b/tests/sidetrail/working/patches/cbc.patch
@@ -19,7 +19,7 @@ index b37efb0..077d214 100644
 +  __VERIFIER_assert(decrypted->size >= 0);
 +  __VERIFIER_assert(decrypted->size <= MAX_SIZE);
 +  int mismatches = old_mismatches;
-+  for (int i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
++  for (uint32_t i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
 +    invariant(i <= check);
 +    invariant(j == i + decrypted->size - check - 1);
 +    uint8_t mask = ~(0xff << ((i >= cutoff) * 8));
@@ -69,12 +69,12 @@ index b37efb0..077d214 100644
      int check = MIN(255, (payload_and_padding_size - 1));
  
      int cutoff = check - padding_length;
--    for (int i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
+-    for (uint32_t i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
 -        uint8_t mask = ~(0xff << ((i >= cutoff) * 8));
 -        mismatches |= (decrypted->data[j] ^ padding_length) & mask;
 -    }
 +    mismatches = double_loop(mismatches, decrypted, check, cutoff, padding_length);
-+    /* for (int i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) { */
++    /* for (uint32_t i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) { */
 +    /*     uint8_t mask = ~(0xff << ((i >= cutoff) * 8)); */
 +    /*     mismatches |= (decrypted->data[j] ^ padding_length) & mask; */
 +    /* } */

--- a/tests/sidetrail/working/stubs/s2n_ensure.c
+++ b/tests/sidetrail/working/stubs/s2n_ensure.c
@@ -21,7 +21,7 @@ void* s2n_sidetrail_memset(void* ptr, int value, size_t num)
 {
     uint8_t* p = (uint8_t*)(ptr);
     __VERIFIER_assert(num >= 0);
-    for (int i = 0; i < num; ++i) {
+    for (size_t i = 0; i < num; ++i) {
         S2N_INVARIANT(i <= num);
         p[i] = value;
     }

--- a/tls/s2n_cbc.c
+++ b/tls/s2n_cbc.c
@@ -90,7 +90,7 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
     int check = MIN(255, (payload_and_padding_size - 1));
 
     int cutoff = check - padding_length;
-    for (int i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
+    for (uint32_t i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
         uint8_t mask = ~(0xff << ((i >= cutoff) * 8));
         mismatches |= (decrypted->data[j] ^ padding_length) & mask;
     }

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1150,7 +1150,7 @@ int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_C
 
 static int s2n_wire_ciphers_contain(const uint8_t *match, const uint8_t *wire, uint32_t count, uint32_t cipher_suite_len)
 {
-    for (int i = 0; i < count; i++) {
+    for (uint32_t i = 0; i < count; i++) {
         const uint8_t *theirs = wire + (i * cipher_suite_len) + (cipher_suite_len - S2N_TLS_CIPHER_SUITE_LEN);
 
         if (!memcmp(match, theirs, S2N_TLS_CIPHER_SUITE_LEN)) {

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -505,7 +505,7 @@ int s2n_config_set_cert_chain_and_key_defaults(struct s2n_config *config,
 
     /* Validate certs being set before clearing auto-chosen defaults or previously set defaults */
     struct certs_by_type new_defaults = {{ 0 }};
-    for (int i = 0; i < num_cert_key_pairs; i++) {
+    for (uint32_t i = 0; i < num_cert_key_pairs; i++) {
         POSIX_ENSURE_REF(cert_key_pairs[i]);
         s2n_pkey_type cert_type = s2n_cert_chain_and_key_get_pkey_type(cert_key_pairs[i]);
         S2N_ERROR_IF(new_defaults.certs[cert_type] != NULL, S2N_ERR_MULTIPLE_DEFAULT_CERTIFICATES_PER_AUTH_TYPE);
@@ -513,7 +513,7 @@ int s2n_config_set_cert_chain_and_key_defaults(struct s2n_config *config,
     }
 
     POSIX_GUARD(s2n_config_clear_default_certificates(config));
-    for (int i = 0; i < num_cert_key_pairs; i++) {
+    for (uint32_t i = 0; i < num_cert_key_pairs; i++) {
         s2n_pkey_type cert_type = s2n_cert_chain_and_key_get_pkey_type(cert_key_pairs[i]);
         config->default_certs_by_type.certs[cert_type] = cert_key_pairs[i];
     }

--- a/tls/s2n_ecc_preferences.c
+++ b/tls/s2n_ecc_preferences.c
@@ -80,7 +80,7 @@ int s2n_check_ecc_preferences_curves_list(const struct s2n_ecc_preferences *ecc_
     for (int i = 0; i < ecc_preferences->count; i++) {
         const struct s2n_ecc_named_curve *named_curve = ecc_preferences->ecc_curves[i];
         int curve_found = 0;
-        for (int j = 0; j < s2n_all_supported_curves_list_len; j++) {
+        for (size_t j = 0; j < s2n_all_supported_curves_list_len; j++) {
             if (named_curve->iana_id == s2n_all_supported_curves_list[j]->iana_id) {
                 curve_found = 1;
                 break; 

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -301,7 +301,7 @@ static int s2n_p_hash(struct s2n_prf_working_space *ws, s2n_hmac_algorithm alg, 
 
         uint32_t bytes_to_xor = MIN(outputlen, digest_size);
 
-        for (int i = 0; i < bytes_to_xor; i++) {
+        for (uint32_t i = 0; i < bytes_to_xor; i++) {
             *output ^= ws->tls.digest1[i];
             output++;
             outputlen--;

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -129,7 +129,7 @@ ssize_t s2n_sendv_with_offset_impl(struct s2n_connection *conn, const struct iov
         bufs = _bufs;
         count = _count;
     }
-    for (int i = 0; i < count; i++) {
+    for (ssize_t i = 0; i < count; i++) {
         total_size += bufs[i].iov_len;
     }
     total_size -= offs;

--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -63,7 +63,7 @@ static S2N_RESULT s2n_map_embiggen(struct s2n_map *map, uint32_t capacity)
     tmp.table = (void *) mem.data;
     tmp.immutable = 0;
 
-    for (int i = 0; i < map->capacity; i++) {
+    for (uint32_t i = 0; i < map->capacity; i++) {
         if (map->table[i].key.size) {
             RESULT_GUARD(s2n_map_add(&tmp, &map->table[i].key, &map->table[i].value));
             RESULT_GUARD_POSIX(s2n_free(&map->table[i].key));
@@ -223,7 +223,7 @@ S2N_RESULT s2n_map_lookup(const struct s2n_map *map, struct s2n_blob *key, struc
 S2N_RESULT s2n_map_free(struct s2n_map *map)
 {
     /* Free the keys and values */
-    for (int i = 0; i < map->capacity; i++) {
+    for (uint32_t i = 0; i < map->capacity; i++) {
         if (map->table[i].key.size) {
             RESULT_GUARD_POSIX(s2n_free(&map->table[i].key));
             RESULT_GUARD_POSIX(s2n_free(&map->table[i].value));

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -68,7 +68,7 @@ bool s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, const uint32
     }
 
     uint8_t xor = 0;
-    for (int i = 0; i < len; i++) {
+    for (uint32_t i = 0; i < len; i++) {
         /* Invariants must hold for each execution of the loop
 	 * and at loop exit, hence the <= */
         S2N_INVARIANT(i <= len);


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

The modified loops used `int` counters but `uint32_t`, `size_t`, or `uint64_t` upper bounds. This could have led to potential overflows during loop counter increment when the upper bound exceeds (2^31)-1.

Additionally, since signed overflows are undefined as per the ISO C standard, the overflowed loop counters could have subsequently triggered a buffer overflow when used as array indices.

We fix these issues by using consistent types for both the loop counter and the upper bound.

### Call-outs:

N/A

### Testing:

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
