### PR TITLE
Add selection logic for resumption psks

### DIFF
--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -84,7 +84,7 @@ static int s2n_setup_ticket_key(struct s2n_config *config)
     "90b6c73bb50f9c3122ec844ad7c2b3e5");
 
     /* Set up encryption key */
-    uint64_t current_time;
+    uint64_t current_time = 0;
     uint8_t ticket_key_name[16] = "2016.07.26.15\0";
 
     POSIX_GUARD(s2n_config_set_session_tickets_onoff(config, 1));
@@ -692,8 +692,8 @@ int main(int argc, char **argv)
                 struct s2n_blob bad_identity = { 0 };
                 EXPECT_SUCCESS(s2n_blob_init(&bad_identity, bad_identity_data, sizeof(bad_identity_data)));
 
-                uint8_t invalid_psk_idx = 5;
-                for (size_t i = 0; i < invalid_psk_idx; i++) {
+                uint8_t psk_idx = 5;
+                for (size_t i = 0; i < psk_idx; i++) {
                     EXPECT_OK(s2n_write_test_identity(&identity_list.wire_data, &bad_identity));
                 }
 
@@ -705,7 +705,7 @@ int main(int argc, char **argv)
 
                 EXPECT_OK(s2n_select_resumption_psk(conn, &identity_list));
 
-                EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, invalid_psk_idx);
+                EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, psk_idx);
                 EXPECT_NOT_NULL(conn->psk_params.chosen_psk);
 
                 /* Sanity check psk creation is correct */
@@ -724,7 +724,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_blob_init(&bad_identity, bad_identity_data, sizeof(bad_identity_data)));
                 EXPECT_OK(s2n_write_test_identity(&identity_list.wire_data, &bad_identity));
 
-                EXPECT_ERROR_WITH_ERRNO(s2n_select_resumption_psk(conn, &identity_list), S2N_ERR_BAD_MESSAGE);
+                EXPECT_ERROR_WITH_ERRNO(s2n_select_resumption_psk(conn, &identity_list), S2N_ERR_INVALID_SESSION_TICKET);
                 EXPECT_NULL(conn->psk_params.chosen_psk);
             }
 

--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -652,6 +652,8 @@ int main(int argc, char **argv)
         ticket_age_add = 1000;
         conn->config->session_state_lifetime_in_nanos = MILLIS_TO_NANOS(UINT32_MAX);
         EXPECT_OK(s2n_validate_ticket_lifetime(conn, obfuscated_ticket_age, ticket_age_add));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
     /* Test: s2n_select_resumption_psk */

--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -705,6 +705,7 @@ int main(int argc, char **argv)
 
             /* First valid resumption psk is chosen */
             {
+                conn->psk_params.chosen_psk_wire_index = 0;
                 conn->psk_params.chosen_psk = NULL;
                 EXPECT_SUCCESS(s2n_stuffer_rewrite(&wire_identities_in));
 
@@ -713,17 +714,20 @@ int main(int argc, char **argv)
                 struct s2n_blob bad_identity = { 0 };
                 EXPECT_SUCCESS(s2n_blob_init(&bad_identity, bad_identity_data, sizeof(bad_identity_data)));
 
-                uint8_t valid_psk_idx = 5;
-                for (size_t i = 0; i < valid_psk_idx; i++) {
+                uint8_t invalid_psk_idx = 5;
+                for (size_t i = 0; i < invalid_psk_idx; i++) {
                     EXPECT_OK(s2n_write_test_identity(&wire_identities_in, &bad_identity));
                 }
 
                 /* Write valid resumption psk */
                 EXPECT_OK(s2n_write_test_identity(&wire_identities_in, &psk_identity.blob));
 
+                /* Write second valid resumption psk */
+                EXPECT_OK(s2n_write_test_identity(&wire_identities_in, &psk_identity.blob));
+
                 EXPECT_OK(s2n_select_resumption_psk(conn, &wire_identities_in));
 
-                EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, valid_psk_idx);
+                EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, invalid_psk_idx);
                 EXPECT_NOT_NULL(conn->psk_params.chosen_psk);
 
                 /* Sanity check psk creation is correct */
@@ -732,6 +736,7 @@ int main(int argc, char **argv)
 
             /* No valid resumption psks */
             {
+                conn->psk_params.chosen_psk_wire_index = 0;
                 conn->psk_params.chosen_psk = NULL;
                 EXPECT_SUCCESS(s2n_stuffer_rewrite(&wire_identities_in));
 
@@ -747,6 +752,7 @@ int main(int argc, char **argv)
 
             /* Ticket has expired */
             {
+                conn->psk_params.chosen_psk_wire_index = 0;
                 conn->psk_params.chosen_psk = NULL;
                 EXPECT_SUCCESS(s2n_stuffer_rewrite(&wire_identities_in));
 

--- a/tests/unit/s2n_early_data_io_api_test.c
+++ b/tests/unit/s2n_early_data_io_api_test.c
@@ -796,6 +796,10 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, known_psk));
             EXPECT_SUCCESS(s2n_connection_set_server_max_early_data_size(server_conn, max_early_data));
+            /* We need to explicitly set the psk_params type to skip our stateless session resumption recv 
+             * code because the handshake traces we're using are meant for stateful session resumption.
+             * TODO: https://github.com/aws/s2n-tls/issues/2742 */
+            server_conn->psk_params.type = S2N_PSK_TYPE_EXTERNAL;
 
             DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
             DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
@@ -836,6 +840,10 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, known_psk));
             EXPECT_SUCCESS(s2n_connection_set_server_max_early_data_size(server_conn, max_early_data));
+            /* We need to explicitly set the psk_params type to skip our stateless session resumption recv 
+             * code because the handshake traces we're using are meant for stateful session resumption.
+             * TODO: https://github.com/aws/s2n-tls/issues/2742 */
+            server_conn->psk_params.type = S2N_PSK_TYPE_EXTERNAL;
 
             DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
             DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
@@ -914,6 +922,10 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, known_psk_without_early_data));
             EXPECT_SUCCESS(s2n_connection_set_server_max_early_data_size(server_conn, max_early_data));
+            /* We need to explicitly set the psk_params type to skip our stateless session resumption recv 
+             * code because the handshake traces we're using are meant for stateful session resumption.
+             * TODO: https://github.com/aws/s2n-tls/issues/2742 */
+            server_conn->psk_params.type = S2N_PSK_TYPE_EXTERNAL;
 
             DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
             DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
@@ -955,6 +967,10 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, known_psk_with_wrong_cipher_suite));
             EXPECT_SUCCESS(s2n_connection_set_server_max_early_data_size(server_conn, max_early_data));
+            /* We need to explicitly set the psk_params type to skip our stateless session resumption recv 
+             * code because the handshake traces we're using are meant for stateful session resumption.
+             * TODO: https://github.com/aws/s2n-tls/issues/2742 */
+            server_conn->psk_params.type = S2N_PSK_TYPE_EXTERNAL;
 
             DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
             DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);

--- a/tests/unit/s2n_psk_offered_test.c
+++ b/tests/unit/s2n_psk_offered_test.c
@@ -455,15 +455,20 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(conn->psk_params.chosen_psk, expected_match);
             EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, wire_index);
         }
+        
+        EXPECT_SUCCESS(s2n_connection_free(conn));
 
-        /* Setup for creating a test resumption psk */
+        /* Test: Valid resumption psk is received */
         {
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+
             struct s2n_config *config = s2n_config_new();
             EXPECT_NOT_NULL(config);
             EXPECT_SUCCESS(s2n_setup_ticket_key(config));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
-            conn->psk_params.type = S2N_PSK_TYPE_RESUMPTION;
 
+            conn->psk_params.type = S2N_PSK_TYPE_RESUMPTION;
             conn->actual_protocol_version = S2N_TLS13;
             conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
@@ -473,59 +478,82 @@ int main(int argc, char **argv)
 
             struct s2n_offered_psk_list identity_list = { .conn = conn };
 
-            /* Valid resumption psk is received */
-            {
-                DEFER_CLEANUP(struct s2n_stuffer test_stuffer = { 0 }, s2n_stuffer_free);
-                EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&test_stuffer, 0));
-                EXPECT_SUCCESS(s2n_stuffer_write_bytes(&test_stuffer, psk_identity.blob.data, psk_identity.blob.size));
-                test_stuffer.blob.size = s2n_stuffer_data_available(&psk_identity);
-                struct s2n_offered_psk client_psk = { .identity = test_stuffer.blob, .wire_index = wire_index };
+            DEFER_CLEANUP(struct s2n_stuffer test_stuffer = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&test_stuffer, 0));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&test_stuffer, psk_identity.blob.data, psk_identity.blob.size));
+            test_stuffer.blob.size = s2n_stuffer_data_available(&psk_identity);
+            
+            struct s2n_offered_psk client_psk = { .identity = test_stuffer.blob, .wire_index = wire_index };
 
-                EXPECT_SUCCESS(s2n_offered_psk_list_choose_psk(&identity_list, &client_psk));
+            EXPECT_SUCCESS(s2n_offered_psk_list_choose_psk(&identity_list, &client_psk));
 
-                EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, wire_index);
-                EXPECT_NOT_NULL(conn->psk_params.chosen_psk);
+            EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, wire_index);
+            EXPECT_NOT_NULL(conn->psk_params.chosen_psk);
 
-                /* Sanity check psk creation is correct */
-                EXPECT_EQUAL(conn->psk_params.chosen_psk->hmac_alg, s2n_tls13_aes_128_gcm_sha256.prf_alg);
-            }
-
-            /* Invalid resumption psk is received */
-            {
-                conn->psk_params.chosen_psk_wire_index = 0;
-                conn->psk_params.chosen_psk = NULL;
-
-                struct s2n_offered_psk client_psk = { .identity = wire_identity, .wire_index = wire_index };
-
-                EXPECT_FAILURE(s2n_offered_psk_list_choose_psk(&identity_list, &client_psk));
-
-                EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, 0);
-                EXPECT_NULL(conn->psk_params.chosen_psk);
-            }
-
-            /* Resumption psk has expired */
-            {
-                conn->psk_params.chosen_psk_wire_index = 0;
-                conn->psk_params.chosen_psk = NULL;
-
-                DEFER_CLEANUP(struct s2n_stuffer test_stuffer = { 0 }, s2n_stuffer_free);
-                EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&test_stuffer, 0));
-                EXPECT_SUCCESS(s2n_stuffer_write_bytes(&test_stuffer, psk_identity.blob.data, psk_identity.blob.size));
-                test_stuffer.blob.size = s2n_stuffer_data_available(&psk_identity);
-    
-                /* Obfuscated ticket age is larger than the session lifetime */
-                struct s2n_offered_psk client_psk = { .identity = psk_identity.blob, .wire_index = wire_index, .obfuscated_ticket_age = 100 };
-                conn->config->session_state_lifetime_in_nanos = 0;
-
-                EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_choose_psk(&identity_list, &client_psk), S2N_ERR_INVALID_SESSION_TICKET);
-
-                EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, 0);
-                EXPECT_NULL(conn->psk_params.chosen_psk);
-            }
+            /* Sanity check psk creation is correct */
+            EXPECT_EQUAL(conn->psk_params.chosen_psk->hmac_alg, s2n_tls13_aes_128_gcm_sha256.prf_alg);
 
             EXPECT_SUCCESS(s2n_config_free(config));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
         }
-        EXPECT_SUCCESS(s2n_connection_free(conn));
+
+        /* Resumption psk has expired */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_NOT_NULL(config);
+            EXPECT_SUCCESS(s2n_setup_ticket_key(config));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+            conn->psk_params.type = S2N_PSK_TYPE_RESUMPTION;
+            conn->actual_protocol_version = S2N_TLS13;
+            conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
+
+            DEFER_CLEANUP(struct s2n_stuffer psk_identity = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_identity, 0));
+            EXPECT_OK(s2n_setup_encrypted_ticket(conn, &psk_identity));
+
+            struct s2n_offered_psk_list identity_list = { .conn = conn };
+
+            DEFER_CLEANUP(struct s2n_stuffer test_stuffer = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&test_stuffer, 0));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&test_stuffer, psk_identity.blob.data, psk_identity.blob.size));
+            test_stuffer.blob.size = s2n_stuffer_data_available(&psk_identity);
+
+            /* Obfuscated ticket age is larger than the session lifetime */
+            struct s2n_offered_psk client_psk = { .identity = psk_identity.blob, .wire_index = wire_index, .obfuscated_ticket_age = 100 };
+            conn->config->session_state_lifetime_in_nanos = 0;
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_choose_psk(&identity_list, &client_psk), S2N_ERR_INVALID_SESSION_TICKET);
+
+            EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, 0);
+            EXPECT_NULL(conn->psk_params.chosen_psk);
+
+            EXPECT_SUCCESS(s2n_config_free(config));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Invalid resumption psk is received */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+
+            conn->psk_params.type = S2N_PSK_TYPE_RESUMPTION;
+            conn->actual_protocol_version = S2N_TLS13;
+            conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
+
+            struct s2n_offered_psk_list identity_list = { .conn = conn };
+            struct s2n_offered_psk client_psk = { .identity = wire_identity, .wire_index = wire_index };
+
+            EXPECT_FAILURE(s2n_offered_psk_list_choose_psk(&identity_list, &client_psk));
+
+            EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, 0);
+            EXPECT_NULL(conn->psk_params.chosen_psk);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
     }
 
     /* Functional test: Process the output of sending the psk extension */

--- a/tests/unit/s2n_psk_offered_test.c
+++ b/tests/unit/s2n_psk_offered_test.c
@@ -34,7 +34,7 @@ static int s2n_setup_ticket_key(struct s2n_config *config)
     "90b6c73bb50f9c3122ec844ad7c2b3e5");
 
     /* Set up encryption key */
-    uint64_t current_time;
+    uint64_t current_time = 0;
     uint8_t ticket_key_name[16] = "2016.07.26.15\0";
 
     POSIX_GUARD(s2n_config_set_session_tickets_onoff(config, 1));
@@ -415,7 +415,7 @@ int main(int argc, char **argv)
 
         /* Test: No known PSKs */
         {
-            EXPECT_SUCCESS(s2n_offered_psk_list_choose_psk(&offered_psk_list, &offered_psk));
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_choose_psk(&offered_psk_list, &offered_psk), S2N_ERR_NULL);
             EXPECT_NULL(conn->psk_params.chosen_psk);
         }
 
@@ -426,7 +426,7 @@ int main(int argc, char **argv)
             EXPECT_OK(s2n_psk_init(different_identity, S2N_PSK_TYPE_EXTERNAL));
             EXPECT_SUCCESS(s2n_psk_set_identity(different_identity, wire_identity_2, sizeof(wire_identity_2)));
 
-            EXPECT_SUCCESS(s2n_offered_psk_list_choose_psk(&offered_psk_list, &offered_psk));
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_choose_psk(&offered_psk_list, &offered_psk), S2N_ERR_NULL);
             EXPECT_NULL(conn->psk_params.chosen_psk);
         }
 

--- a/tests/unit/s2n_psk_offered_test.c
+++ b/tests/unit/s2n_psk_offered_test.c
@@ -17,6 +17,46 @@
 #include "testlib/s2n_testlib.h"
 #include "tls/extensions/s2n_client_psk.h"
 
+/* Include source to test static methods. */
+#include "tls/s2n_psk.c"
+
+#define MILLIS_TO_NANOS(millis) (millis * (uint64_t)ONE_MILLISEC_IN_NANOS)
+
+static int s2n_setup_ticket_key(struct s2n_config *config)
+{
+    /**
+     *= https://tools.ietf.org/rfc/rfc5869#appendix-A.1
+     *# PRK  = 0x077709362c2e32df0ddc3f0dc47bba63
+     *#        90b6c73bb50f9c3122ec844ad7c2b3e5 (32 octets)
+     **/
+    S2N_BLOB_FROM_HEX(ticket_key,
+    "077709362c2e32df0ddc3f0dc47bba63"
+    "90b6c73bb50f9c3122ec844ad7c2b3e5");
+
+    /* Set up encryption key */
+    uint64_t current_time;
+    uint8_t ticket_key_name[16] = "2016.07.26.15\0";
+
+    POSIX_GUARD(s2n_config_set_session_tickets_onoff(config, 1));
+    POSIX_GUARD(config->wall_clock(config->sys_clock_ctx, &current_time));
+    POSIX_GUARD(s2n_config_add_ticket_crypto_key(config, ticket_key_name, strlen((char *)ticket_key_name),
+                ticket_key.data, ticket_key.size, current_time/ONE_SEC_IN_NANOS));
+    return S2N_SUCCESS;
+}
+
+static S2N_RESULT s2n_setup_encrypted_ticket(struct s2n_connection *conn, struct s2n_stuffer *output)
+{
+    struct s2n_ticket_fields ticket_fields = { 0 };
+    uint8_t test_secret_data[] = "test secret";
+    RESULT_GUARD_POSIX(s2n_blob_init(&ticket_fields.session_secret, test_secret_data, sizeof(test_secret_data)));
+
+    /* Create a valid resumption psk identity */
+    RESULT_GUARD_POSIX(s2n_encrypt_session_ticket(conn, &ticket_fields, output));
+    output->blob.size = s2n_stuffer_data_available(output);
+
+    return S2N_RESULT_OK;
+}
+
 static S2N_RESULT s2n_write_test_identity(struct s2n_stuffer *out, const uint8_t *identity, uint16_t identity_size)
 {
     RESULT_GUARD_POSIX(s2n_stuffer_write_uint16(out, identity_size));
@@ -83,6 +123,9 @@ int main(int argc, char **argv)
         {
             struct s2n_offered_psk psk = { 0 };
             struct s2n_offered_psk_list psk_list = { 0 };
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+            psk_list.conn = conn;
 
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_list.wire_data, 0));
             EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_1, sizeof(wire_identity_1)));
@@ -97,6 +140,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(psk.identity.data, NULL);
 
             EXPECT_SUCCESS(s2n_stuffer_free(&psk_list.wire_data));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
         /* Fails to parse zero-length identities */
@@ -134,6 +178,9 @@ int main(int argc, char **argv)
         {
             struct s2n_offered_psk psk = { 0 };
             struct s2n_offered_psk_list psk_list = { 0 };
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+            psk_list.conn = conn;
 
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_list.wire_data, 0));
             EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_1, sizeof(wire_identity_1)));
@@ -152,6 +199,65 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(psk.identity.data, NULL);
 
             EXPECT_SUCCESS(s2n_stuffer_free(&psk_list.wire_data));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+    }
+
+    /* Test s2n_offered_psk_list_read_next */
+    {
+        /* Safety check */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            struct s2n_offered_psk_list psk_list = { 0 };
+            EXPECT_ERROR_WITH_ERRNO(s2n_offered_psk_list_read_next(&psk_list, NULL), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_offered_psk_list_read_next(NULL, &psk), S2N_ERR_NULL);
+        }
+
+        /* External PSKs skip obfuscated ticket age parsing */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            struct s2n_offered_psk_list psk_list = { 0 };
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+            conn->psk_params.type = S2N_PSK_TYPE_EXTERNAL;
+            psk_list.conn = conn;
+            uint32_t obfuscated_ticket_age = 100;
+
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_list.wire_data, 0));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint16(&psk_list.wire_data, sizeof(wire_identity_1)));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&psk_list.wire_data, wire_identity_1, sizeof(wire_identity_1)));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint32(&psk_list.wire_data, obfuscated_ticket_age));
+
+            EXPECT_OK(s2n_offered_psk_list_read_next(&psk_list, &psk));
+
+            EXPECT_EQUAL(psk.obfuscated_ticket_age, 0);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&psk_list.wire_data));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Resumption PSKs do not skip obfuscated ticket age parsing */
+        {
+            struct s2n_offered_psk psk = { 0 };
+            struct s2n_offered_psk_list psk_list = { 0 };
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+            conn->psk_params.type = S2N_PSK_TYPE_RESUMPTION;
+            psk_list.conn = conn;
+            uint32_t obfuscated_ticket_age = 100;
+
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_list.wire_data, 0));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint16(&psk_list.wire_data, sizeof(wire_identity_1)));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&psk_list.wire_data, wire_identity_1, sizeof(wire_identity_1)));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint32(&psk_list.wire_data, obfuscated_ticket_age));
+
+            EXPECT_OK(s2n_offered_psk_list_read_next(&psk_list, &psk));
+
+            EXPECT_EQUAL(psk.obfuscated_ticket_age, obfuscated_ticket_age);
+
+            EXPECT_SUCCESS(s2n_stuffer_free(&psk_list.wire_data));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+
         }
     }
 
@@ -175,6 +281,9 @@ int main(int argc, char **argv)
         {
             struct s2n_offered_psk psk = { 0 };
             struct s2n_offered_psk_list psk_list = { 0 };
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+            psk_list.conn = conn;
 
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_list.wire_data, 0));
             EXPECT_OK(s2n_write_test_identity(&psk_list.wire_data, wire_identity_1, sizeof(wire_identity_1)));
@@ -192,6 +301,7 @@ int main(int argc, char **argv)
             EXPECT_BYTEARRAY_EQUAL(psk.identity.data, wire_identity_1, sizeof(wire_identity_1));
 
             EXPECT_SUCCESS(s2n_stuffer_free(&psk_list.wire_data));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
         }
     }
 
@@ -253,6 +363,32 @@ int main(int argc, char **argv)
         }
     }
 
+    /* Test: s2n_validate_ticket_lifetime */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(conn);
+        uint32_t ticket_age_add = 0;
+        uint32_t obfuscated_ticket_age = 0;
+
+        /* Ticket age is smaller than session lifetime */
+        conn->config->session_state_lifetime_in_nanos = MILLIS_TO_NANOS(100);
+        EXPECT_OK(s2n_validate_ticket_lifetime(conn, obfuscated_ticket_age, ticket_age_add));
+
+        /* Ticket age is greater than session lifetime */
+        obfuscated_ticket_age = 101;
+        conn->config->session_state_lifetime_in_nanos = MILLIS_TO_NANOS(100);
+        EXPECT_ERROR_WITH_ERRNO(s2n_validate_ticket_lifetime(conn, obfuscated_ticket_age, ticket_age_add), S2N_ERR_INVALID_SESSION_TICKET);
+
+        /* ticket_age_add is greater than obfuscated ticket age and ticket age
+         * is smaller than session lifetime */
+        obfuscated_ticket_age = 100;
+        ticket_age_add = 1000;
+        conn->config->session_state_lifetime_in_nanos = MILLIS_TO_NANOS(UINT32_MAX);
+        EXPECT_OK(s2n_validate_ticket_lifetime(conn, obfuscated_ticket_age, ticket_age_add));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
     /* Test: s2n_offered_psk_list_choose_psk */
     {
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
@@ -267,6 +403,7 @@ int main(int argc, char **argv)
         struct s2n_offered_psk offered_psk = { .identity = wire_identity, .wire_index = wire_index };
 
         struct s2n_offered_psk_list offered_psk_list = { .conn = conn };
+        conn->psk_params.type = S2N_PSK_TYPE_EXTERNAL;
 
         /* Safety */
         EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_choose_psk(NULL, &offered_psk), S2N_ERR_NULL);
@@ -319,6 +456,75 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, wire_index);
         }
 
+        /* Setup for creating a test resumption psk */
+        {
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_NOT_NULL(config);
+            EXPECT_SUCCESS(s2n_setup_ticket_key(config));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            conn->psk_params.type = S2N_PSK_TYPE_RESUMPTION;
+
+            conn->actual_protocol_version = S2N_TLS13;
+            conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
+
+            DEFER_CLEANUP(struct s2n_stuffer psk_identity = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&psk_identity, 0));
+            EXPECT_OK(s2n_setup_encrypted_ticket(conn, &psk_identity));
+
+            struct s2n_offered_psk_list identity_list = { .conn = conn };
+
+            /* Valid resumption psk is received */
+            {
+                DEFER_CLEANUP(struct s2n_stuffer test_stuffer = { 0 }, s2n_stuffer_free);
+                EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&test_stuffer, 0));
+                EXPECT_SUCCESS(s2n_stuffer_write_bytes(&test_stuffer, psk_identity.blob.data, psk_identity.blob.size));
+                test_stuffer.blob.size = s2n_stuffer_data_available(&psk_identity);
+                struct s2n_offered_psk client_psk = { .identity = test_stuffer.blob, .wire_index = wire_index };
+
+                EXPECT_SUCCESS(s2n_offered_psk_list_choose_psk(&identity_list, &client_psk));
+
+                EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, wire_index);
+                EXPECT_NOT_NULL(conn->psk_params.chosen_psk);
+
+                /* Sanity check psk creation is correct */
+                EXPECT_EQUAL(conn->psk_params.chosen_psk->hmac_alg, s2n_tls13_aes_128_gcm_sha256.prf_alg);
+            }
+
+            /* Invalid resumption psk is received */
+            {
+                conn->psk_params.chosen_psk_wire_index = 0;
+                conn->psk_params.chosen_psk = NULL;
+
+                struct s2n_offered_psk client_psk = { .identity = wire_identity, .wire_index = wire_index };
+
+                EXPECT_FAILURE(s2n_offered_psk_list_choose_psk(&identity_list, &client_psk));
+
+                EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, 0);
+                EXPECT_NULL(conn->psk_params.chosen_psk);
+            }
+
+            /* Resumption psk has expired */
+            {
+                conn->psk_params.chosen_psk_wire_index = 0;
+                conn->psk_params.chosen_psk = NULL;
+
+                DEFER_CLEANUP(struct s2n_stuffer test_stuffer = { 0 }, s2n_stuffer_free);
+                EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&test_stuffer, 0));
+                EXPECT_SUCCESS(s2n_stuffer_write_bytes(&test_stuffer, psk_identity.blob.data, psk_identity.blob.size));
+                test_stuffer.blob.size = s2n_stuffer_data_available(&psk_identity);
+    
+                /* Obfuscated ticket age is larger than the session lifetime */
+                struct s2n_offered_psk client_psk = { .identity = psk_identity.blob, .wire_index = wire_index, .obfuscated_ticket_age = 100 };
+                conn->config->session_state_lifetime_in_nanos = 0;
+
+                EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_choose_psk(&identity_list, &client_psk), S2N_ERR_INVALID_SESSION_TICKET);
+
+                EXPECT_EQUAL(conn->psk_params.chosen_psk_wire_index, 0);
+                EXPECT_NULL(conn->psk_params.chosen_psk);
+            }
+
+            EXPECT_SUCCESS(s2n_config_free(config));
+        }
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
@@ -326,6 +532,7 @@ int main(int argc, char **argv)
     {
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
         EXPECT_NOT_NULL(conn);
+        conn->psk_params.type = S2N_PSK_TYPE_EXTERNAL;
 
         const uint8_t test_secret[] = "secret";
 

--- a/tests/unit/s2n_psk_offered_test.c
+++ b/tests/unit/s2n_psk_offered_test.c
@@ -213,7 +213,12 @@ int main(int argc, char **argv)
             EXPECT_ERROR_WITH_ERRNO(s2n_offered_psk_list_read_next(NULL, &psk), S2N_ERR_NULL);
         }
 
-        /* External PSKs skip obfuscated ticket age parsing */
+        /**
+         *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
+         *= type=test
+         *# For identities established externally, an obfuscated_ticket_age of 0 SHOULD be
+         *# used, and servers MUST ignore the value.
+         */
         {
             struct s2n_offered_psk psk = { 0 };
             struct s2n_offered_psk_list psk_list = { 0 };

--- a/tests/unit/s2n_server_psk_extension_test.c
+++ b/tests/unit/s2n_server_psk_extension_test.c
@@ -55,6 +55,8 @@ static s2n_result setup_server_psks(struct s2n_connection *server_conn)
 {
     RESULT_ENSURE_REF(server_conn);
 
+    EXPECT_OK(s2n_connection_set_psk_type(server_conn, S2N_PSK_TYPE_EXTERNAL));
+
     /* Setup shared PSK for server */
     struct s2n_psk *shared_psk = NULL;
     RESULT_GUARD(s2n_array_pushback(&server_conn->psk_params.psk_list, (void**) &shared_psk));

--- a/tests/unit/s2n_tls13_handshake_early_data_test.c
+++ b/tests/unit/s2n_tls13_handshake_early_data_test.c
@@ -586,6 +586,10 @@ int main()
             EXPECT_SUCCESS(s2n_psk_set_secret(psk, psk_secret.data, psk_secret.size));
             EXPECT_SUCCESS(s2n_psk_configure_early_data(psk, max_early_data, 0x13, 0x01));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, psk));
+            /* We need to explicitly set the psk_params type to skip our stateless session resumption recv 
+             * code because the handshake traces we're using are meant for stateful session resumption.
+             * TODO: https://github.com/aws/s2n-tls/issues/2742 */
+            server_conn->psk_params.type = S2N_PSK_TYPE_EXTERNAL;
 
             DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
             DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -232,6 +232,7 @@ static S2N_RESULT s2n_select_resumption_psk(struct s2n_connection *conn, struct 
     RESULT_ENSURE_REF(client_identity_list);
 
     struct s2n_offered_psk client_psk = { 0 };
+    conn->psk_params.chosen_psk = NULL;
 
     while(s2n_offered_psk_list_has_next(client_identity_list)) {
         RESULT_GUARD_POSIX(s2n_offered_psk_list_next(client_identity_list, &client_psk));
@@ -243,7 +244,7 @@ static S2N_RESULT s2n_select_resumption_psk(struct s2n_connection *conn, struct 
         return S2N_RESULT_OK;
     }
 
-    RESULT_BAIL(S2N_ERR_BAD_MESSAGE);
+    RESULT_BAIL(S2N_ERR_INVALID_SESSION_TICKET);
 }
 
 static S2N_RESULT s2n_client_psk_recv_identity_list(struct s2n_connection *conn, struct s2n_stuffer *wire_identities_in)

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -234,10 +234,10 @@ static S2N_RESULT s2n_select_resumption_psk(struct s2n_connection *conn, struct 
     struct s2n_offered_psk client_psk = { 0 };
     conn->psk_params.chosen_psk = NULL;
 
-    while(s2n_offered_psk_list_has_next(client_identity_list)) {
+    while (s2n_offered_psk_list_has_next(client_identity_list)) {
         RESULT_GUARD_POSIX(s2n_offered_psk_list_next(client_identity_list, &client_psk));
         /* Select the first resumption PSK that can be decrypted */
-        if(s2n_offered_psk_list_choose_psk(client_identity_list, &client_psk) != S2N_SUCCESS) {
+        if (s2n_offered_psk_list_choose_psk(client_identity_list, &client_psk) != S2N_SUCCESS) {
             continue;
         }
 

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -277,6 +277,9 @@ static S2N_RESULT s2n_select_resumption_psk(struct s2n_connection *conn, struct 
             continue;
         }
 
+        /* If the decrypt_session_ticket method succeeds, all previously-set PSKs have been wiped
+         * and a new PSK has been added. Therefore we can be assured that the first PSK in our list
+         * is the one we just read. */
         struct s2n_psk *psk = NULL;
         RESULT_GUARD(s2n_array_get(&conn->psk_params.psk_list, 0, (void**)&psk));
         RESULT_ENSURE_REF(psk);
@@ -284,6 +287,9 @@ static S2N_RESULT s2n_select_resumption_psk(struct s2n_connection *conn, struct 
 
         conn->psk_params.chosen_psk = psk;
         conn->psk_params.chosen_psk_wire_index = wire_index;
+
+        /* Select the first resumption PSK that can be decrypted */
+        break;
     }
 
     RESULT_ENSURE_REF(conn->psk_params.chosen_psk);

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -237,11 +237,9 @@ static S2N_RESULT s2n_select_resumption_psk(struct s2n_connection *conn, struct 
     while (s2n_offered_psk_list_has_next(client_identity_list)) {
         RESULT_GUARD_POSIX(s2n_offered_psk_list_next(client_identity_list, &client_psk));
         /* Select the first resumption PSK that can be decrypted */
-        if (s2n_offered_psk_list_choose_psk(client_identity_list, &client_psk) != S2N_SUCCESS) {
-            continue;
+        if (s2n_offered_psk_list_choose_psk(client_identity_list, &client_psk) == S2N_SUCCESS) {
+            return S2N_RESULT_OK;
         }
-
-        return S2N_RESULT_OK;
     }
 
     RESULT_BAIL(S2N_ERR_INVALID_SESSION_TICKET);

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -215,12 +215,12 @@ S2N_RESULT s2n_offered_psk_list_read_next(struct s2n_offered_psk_list *psk_list,
     identity_data = s2n_stuffer_raw_read(&psk_list->wire_data, identity_size);
     RESULT_ENSURE_REF(identity_data);
 
-    /**
+    /** This value will only be used for servers parsing resumption PSKs. 
      *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
      *# For identities established externally, an obfuscated_ticket_age of 0 SHOULD be
      *# used, and servers MUST ignore the value.
      */
-    RESULT_GUARD_POSIX(s2n_stuffer_skip_read(&psk_list->wire_data, sizeof(uint32_t)));
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint32(&psk_list->wire_data, &psk->obfuscated_ticket_age));
 
     RESULT_GUARD_POSIX(s2n_blob_init(&psk->identity, identity_data, identity_size));
     psk->wire_index = psk_list->wire_index;

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -318,9 +318,8 @@ int s2n_offered_psk_list_choose_psk(struct s2n_offered_psk_list *psk_list, struc
         return S2N_SUCCESS;
     }
     
-    if(psk_params->type == S2N_PSK_TYPE_EXTERNAL) {
+    if (psk_params->type == S2N_PSK_TYPE_EXTERNAL) {
         POSIX_GUARD_RESULT(s2n_match_psk_identity(&psk_params->psk_list, &psk->identity, &psk_params->chosen_psk));
-        psk_params->chosen_psk_wire_index = psk->wire_index;
     } else {
         struct s2n_stuffer ticket_stuffer = { 0 };
         POSIX_GUARD(s2n_stuffer_init(&ticket_stuffer, &psk->identity));
@@ -329,18 +328,14 @@ int s2n_offered_psk_list_choose_psk(struct s2n_offered_psk_list *psk_list, struc
 
         POSIX_GUARD(s2n_decrypt_session_ticket(psk_list->conn));
 
-        /* If the decrypt_session_ticket method succeeds, all previously-set PSKs have been wiped
-         * and a new PSK has been added. Therefore we can be assured that the first PSK in our list
-         * is the one we just read. */
-        POSIX_ENSURE_EQ(psk_params->psk_list.len, 1);
+        /* If the decrypt_session_ticket method succeeds, a new PSK has been added. */
         struct s2n_psk *decrypted_psk = NULL;
-        POSIX_GUARD_RESULT(s2n_array_get(&psk_params->psk_list, 0, (void**)&decrypted_psk));
+        POSIX_GUARD_RESULT(s2n_match_psk_identity(&psk_params->psk_list, &psk->identity, &decrypted_psk));
         POSIX_ENSURE_REF(decrypted_psk);
         POSIX_GUARD_RESULT(s2n_validate_ticket_lifetime(psk_list->conn, psk->obfuscated_ticket_age, decrypted_psk->ticket_age_add));
-
-        psk_params->chosen_psk_wire_index = psk->wire_index;
         psk_params->chosen_psk = decrypted_psk;
     }
+    psk_params->chosen_psk_wire_index = psk->wire_index;
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -205,6 +205,7 @@ bool s2n_offered_psk_list_has_next(struct s2n_offered_psk_list *psk_list)
 S2N_RESULT s2n_offered_psk_list_read_next(struct s2n_offered_psk_list *psk_list, struct s2n_offered_psk *psk)
 {
     RESULT_ENSURE_REF(psk_list);
+    RESULT_ENSURE_REF(psk_list->conn);
     RESULT_ENSURE_MUT(psk);
 
     uint16_t identity_size = 0;
@@ -215,12 +216,16 @@ S2N_RESULT s2n_offered_psk_list_read_next(struct s2n_offered_psk_list *psk_list,
     identity_data = s2n_stuffer_raw_read(&psk_list->wire_data, identity_size);
     RESULT_ENSURE_REF(identity_data);
 
-    /** This value will only be used for servers parsing resumption PSKs. 
+    /**
      *= https://tools.ietf.org/rfc/rfc8446#section-4.2.11
      *# For identities established externally, an obfuscated_ticket_age of 0 SHOULD be
      *# used, and servers MUST ignore the value.
      */
-    RESULT_GUARD_POSIX(s2n_stuffer_read_uint32(&psk_list->wire_data, &psk->obfuscated_ticket_age));
+    if (psk_list->conn->psk_params.type == S2N_PSK_TYPE_EXTERNAL) {
+        RESULT_GUARD_POSIX(s2n_stuffer_skip_read(&psk_list->wire_data, sizeof(uint32_t)));
+    } else {
+        RESULT_GUARD_POSIX(s2n_stuffer_read_uint32(&psk_list->wire_data, &psk->obfuscated_ticket_age));
+    }
 
     RESULT_GUARD_POSIX(s2n_blob_init(&psk->identity, identity_data, identity_size));
     psk->wire_index = psk_list->wire_index;
@@ -280,6 +285,27 @@ static S2N_RESULT s2n_match_psk_identity(struct s2n_array *known_psks, const str
     return S2N_RESULT_OK;
 }
 
+/**
+ *= https://tools.ietf.org/html/rfc8446#section-4.2.10  
+ *# For PSKs provisioned via NewSessionTicket, a server MUST validate
+ *#  that the ticket age for the selected PSK identity (computed by
+ *#  subtracting ticket_age_add from PskIdentity.obfuscated_ticket_age
+ *#  modulo 2^32) is within a small tolerance of the time since the ticket
+ *#  was issued (see Section 8).
+ **/
+static S2N_RESULT s2n_validate_ticket_lifetime(struct s2n_connection *conn, uint32_t obfuscated_ticket_age, uint32_t ticket_age_add) 
+{
+    RESULT_ENSURE_REF(conn);
+
+    /* Subtract the ticket_age_add value from the ticket age in milliseconds. The resulting uint32_t value
+     * may wrap, resulting in the modulo 2^32 operation. */
+    uint32_t ticket_age_in_millis = obfuscated_ticket_age - ticket_age_add;
+    uint32_t session_lifetime_in_millis = conn->config->session_state_lifetime_in_nanos / ONE_MILLISEC_IN_NANOS;
+    RESULT_ENSURE(ticket_age_in_millis <= session_lifetime_in_millis, S2N_ERR_INVALID_SESSION_TICKET);
+
+    return S2N_RESULT_OK;
+}
+
 int s2n_offered_psk_list_choose_psk(struct s2n_offered_psk_list *psk_list, struct s2n_offered_psk *psk)
 {
     POSIX_ENSURE_REF(psk_list);
@@ -291,9 +317,30 @@ int s2n_offered_psk_list_choose_psk(struct s2n_offered_psk_list *psk_list, struc
         psk_params->chosen_psk = NULL;
         return S2N_SUCCESS;
     }
+    
+    if(psk_params->type == S2N_PSK_TYPE_EXTERNAL) {
+        POSIX_GUARD_RESULT(s2n_match_psk_identity(&psk_params->psk_list, &psk->identity, &psk_params->chosen_psk));
+        psk_params->chosen_psk_wire_index = psk->wire_index;
+    } else {
+        struct s2n_stuffer ticket_stuffer = { 0 };
+        POSIX_GUARD(s2n_stuffer_init(&ticket_stuffer, &psk->identity));
+        POSIX_GUARD(s2n_stuffer_skip_write(&ticket_stuffer, psk->identity.size));
+        psk_list->conn->client_ticket_to_decrypt = ticket_stuffer;
 
-    POSIX_GUARD_RESULT(s2n_match_psk_identity(&psk_params->psk_list, &psk->identity, &psk_params->chosen_psk));
-    psk_params->chosen_psk_wire_index = psk->wire_index;
+        POSIX_GUARD(s2n_decrypt_session_ticket(psk_list->conn));
+
+        /* If the decrypt_session_ticket method succeeds, all previously-set PSKs have been wiped
+         * and a new PSK has been added. Therefore we can be assured that the first PSK in our list
+         * is the one we just read. */
+        POSIX_ENSURE_EQ(psk_params->psk_list.len, 1);
+        struct s2n_psk *decrypted_psk = NULL;
+        POSIX_GUARD_RESULT(s2n_array_get(&psk_params->psk_list, 0, (void**)&decrypted_psk));
+        POSIX_ENSURE_REF(decrypted_psk);
+        POSIX_GUARD_RESULT(s2n_validate_ticket_lifetime(psk_list->conn, psk->obfuscated_ticket_age, decrypted_psk->ticket_age_add));
+
+        psk_params->chosen_psk_wire_index = psk->wire_index;
+        psk_params->chosen_psk = decrypted_psk;
+    }
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -65,6 +65,7 @@ S2N_CLEANUP_RESULT s2n_psk_parameters_wipe_secrets(struct s2n_psk_parameters *pa
 struct s2n_offered_psk {
     struct s2n_blob identity;
     uint16_t wire_index;
+    uint32_t obfuscated_ticket_age;
 };
 
 struct s2n_offered_psk_list {


### PR DESCRIPTION
### Resolved issues:

 resolves #2505 
### Description of changes: 

Added option to decrypt and deserialize resumption psks.
### Call-outs:

I had to set the psk_param type in a couple tests because we now have the option to recv resumption psks.
### Testing:

Unit tests/Functional tests.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
