### PR TITLE
Adding APIs s2n_str_hex_to_bytes_length and s2n_str_hex_to_bytes

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -613,6 +613,27 @@ S2N_API
 extern int s2n_async_pkey_op_free(struct s2n_async_pkey_op *op);
 
 /**
+ * Returns the length of the bytes representation of the hex-encoded string.
+ * 
+ * @param hex A pointer to the hex-encoded string being read.
+ * @param out_bytes_len represents the length of the output bytes buffer.
+ */
+S2N_API
+extern int s2n_str_hex_to_bytes_length(const uint8_t *hex, uint32_t *out_bytes_len);
+
+/**
+ * Returns the bytes representation of the hex-encoded string.
+ * 
+ * @param hex A pointer to the hex-encoded string being read.
+ * @param out_bytes A pointer to the output buffer which will hold the bytes representation of the hex encoded string. 
+ * @param out_bytes_len This value is both an input and output parameter and represents the length of the output buffer `out_bytes`.
+ * When used as an input parameter, the caller must use this parameter to convey the maximum length of `out_bytes`. 
+ * When used as an output parameter, `out_bytes_len` holds the actual length of bytes representation of the hex-encoded string.
+ */
+S2N_API
+extern int s2n_str_hex_to_bytes(const uint8_t *hex, uint8_t *out_bytes, uint32_t *out_bytes_len);
+
+/**
  * Callback function for handling key log events
  *
  * THIS SHOULD BE USED FOR DEBUGGING PURPOSES ONLY!

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1492,6 +1492,22 @@ int s2n_cert_get_utf8_string_from_extension_data(const uint8_t *extension_data, 
 
 **s2n_cert_get_utf8_string_from_extension_data** gets the UTF8 String representation of the DER encoded ASN.1 X.509 certificate extension data.
 
+### s2n\_str\_hex\_to\_bytes\_length
+
+```c
+int s2n_str_hex_to_bytes_length(const uint8_t *hex, uint32_t *out_bytes_len);
+```
+
+**s2n_str_hex_to_bytes_length** returns the length of the bytes representation of the hex-encoded string.
+
+### s2n\_str\_hex\_to\_bytes
+
+```c
+int s2n_str_hex_to_bytes(const uint8_t *hex, uint8_t *out_bytes, uint32_t *out_bytes_len);
+```
+
+**s2n_str_hex_to_bytes** returns the bytes representation of the hex-encoded string.
+
 ### Session Resumption Related calls
 
 ```c

--- a/tests/unit/s2n_str_test.c
+++ b/tests/unit/s2n_str_test.c
@@ -15,59 +15,122 @@
 
 #include "s2n_test.h"
 #include "utils/s2n_str.h"
+#include "utils/s2n_blob.h"
+#include "utils/s2n_safety.h"
 
 #define BUF_SIZE 10
 
 int main(int argc, char **argv)
 {
-    char buf[BUF_SIZE];
-
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13());
 
-    char *p = buf;
-    char *last = buf + BUF_SIZE;
-    const char *hello = "Hello";
-    const char *world = " World!";
-    const char *expect_result = "Hello Wor";
-    const char *hi = " Hi!";
-    const char *hello_hi = "Hello Hi!";
+    /* Test s2n_strcpy */
+    {
+        char buf[BUF_SIZE];
+        char *p = buf;
+        char *last = buf + BUF_SIZE;
+        const char *hello = "Hello";
+        const char *world = " World!";
+        const char *expect_result = "Hello Wor";
+        const char *hi = " Hi!";
+        const char *hello_hi = "Hello Hi!";
 
-    p = s2n_strcpy(p, last, hello);
-    EXPECT_TRUE(0 == strcmp(buf, hello));
+        p = s2n_strcpy(p, last, hello);
+        EXPECT_TRUE(0 == strcmp(buf, hello));
 
-    /* buf = last, string does not change */
-    p = s2n_strcpy(p, p, hello);
-    EXPECT_TRUE(0 == strcmp(buf, hello));
+        /* buf = last, string does not change */
+        p = s2n_strcpy(p, p, hello);
+        EXPECT_TRUE(0 == strcmp(buf, hello));
 
-    /* buf > last, string does not change */
-    p = s2n_strcpy(p, buf, hello);
-    EXPECT_TRUE(0 == strcmp(buf, hello));
+        /* buf > last, string does not change */
+        p = s2n_strcpy(p, buf, hello);
+        EXPECT_TRUE(0 == strcmp(buf, hello));
 
-    /* last - buf - 1 <= length of src string, output string length is truncated to buf size - 1 */
-    p = s2n_strcpy(p, last, world);
-    EXPECT_TRUE(0 == strcmp(buf, expect_result));
+        /* last - buf - 1 <= length of src string, output string length is truncated to buf size - 1 */
+        p = s2n_strcpy(p, last, world);
+        EXPECT_TRUE(0 == strcmp(buf, expect_result));
 
-    /* NULL src, a NULL terminator should be added */
-    p = buf;
-    p = s2n_strcpy(p, last, NULL);
-    EXPECT_EQUAL(*p, '\0');
+        /* NULL src, a NULL terminator should be added */
+        p = buf;
+        p = s2n_strcpy(p, last, NULL);
+        EXPECT_EQUAL(*p, '\0');
 
-    p = s2n_strcpy(p, last, hello);
-    EXPECT_TRUE(0 == strcmp(buf, hello));
+        p = s2n_strcpy(p, last, hello);
+        EXPECT_TRUE(0 == strcmp(buf, hello));
 
-    /* buf + 1 = last, a NULL terminator should be added */
-    *p = 'a';
-    p = s2n_strcpy(p, p + 1, hello);
-    EXPECT_TRUE(0 == strcmp(buf, hello));
+        /* buf + 1 = last, a NULL terminator should be added */
+        *p = 'a';
+        p = s2n_strcpy(p, p + 1, hello);
+        EXPECT_TRUE(0 == strcmp(buf, hello));
 
-    /* Normal case, string just fit buf size */
-    p = s2n_strcpy(p, last, hi);
-    EXPECT_TRUE(0 == strcmp(buf, hello_hi));
+        /* Normal case, string just fit buf size */
+        p = s2n_strcpy(p, last, hi);
+        EXPECT_TRUE(0 == strcmp(buf, hello_hi));
 
-    /* Writing to the end buf does not change the string */
-    s2n_strcpy(p, last, "s2n");
-    EXPECT_TRUE(0 == strcmp(buf, hello_hi));
+        /* Writing to the end buf does not change the string */
+        s2n_strcpy(p, last, "s2n");
+        EXPECT_TRUE(0 == strcmp(buf, hello_hi));
+    }
+
+    /* Test s2n_str_hex_to_bytes_length and s2n_str_hex_to_bytes */
+    {
+        uint8_t test_mem[10] = { 0 };
+        uint32_t test_len = 0;
+
+        /* Test with output buffer too small */
+        {
+            const uint8_t long_input_str[] = "abcdef123456";
+
+            EXPECT_SUCCESS(s2n_str_hex_to_bytes_length(long_input_str, &test_len));
+            EXPECT_EQUAL(test_len, sizeof(long_input_str)/2); 
+
+            /* Succeeds with output blob of the right size */
+            EXPECT_SUCCESS(s2n_str_hex_to_bytes(long_input_str, test_mem, &test_len));
+            test_len -= 1;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_str_hex_to_bytes(long_input_str, test_mem, &test_len),
+                    S2N_ERR_INSUFFICIENT_MEM_SIZE);
+        }
+
+        /* Test with invalid characters */
+        {
+            EXPECT_SUCCESS(s2n_str_hex_to_bytes_length((const uint8_t*) "12", &test_len));
+            EXPECT_SUCCESS(s2n_str_hex_to_bytes((const uint8_t*) "12", test_mem, &test_len));
+    
+            EXPECT_FAILURE_WITH_ERRNO(s2n_str_hex_to_bytes_length((const uint8_t*) "#2", &test_len),
+                    S2N_ERR_INVALID_HEX);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_str_hex_to_bytes((const uint8_t*) "#2", test_mem, &test_len),
+                    S2N_ERR_INVALID_HEX);
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_str_hex_to_bytes_length((const uint8_t*) "1#", &test_len),
+                    S2N_ERR_INVALID_HEX);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_str_hex_to_bytes((const uint8_t*) "1#", test_mem, &test_len),
+                    S2N_ERR_INVALID_HEX);
+        }
+
+        /* Test with valid characters */
+        struct {
+            const char *input;
+            uint32_t expected_output_size;
+            uint8_t expected_output[sizeof(test_mem)];
+        } test_cases[] = {
+                { .input = "abcd", .expected_output = { 171, 205 }, .expected_output_size = 2 },
+                { .input = "ab cd", .expected_output = { 171, 205 }, .expected_output_size = 2 },
+                { .input = " abcd", .expected_output = { 171, 205 }, .expected_output_size = 2 },
+                { .input = "abcd ", .expected_output = { 171, 205 }, .expected_output_size = 2 },
+                { .input = "  ab     cd  ", .expected_output = { 171, 205 }, .expected_output_size = 2 },
+                { .input = "", .expected_output = { 0 }, .expected_output_size = 0 },
+                { .input = " ", .expected_output = { 0 }, .expected_output_size = 0 },
+                { .input = "12 34 56 78 90", .expected_output = { 18, 52, 86, 120, 144 }, .expected_output_size = 5 },
+                { .input = "1234567890", .expected_output = { 18, 52, 86, 120, 144 }, .expected_output_size = 5 },
+        };
+        for (size_t i = 0; i < s2n_array_len(test_cases); i++) {
+            test_len = 0;
+            EXPECT_SUCCESS(s2n_str_hex_to_bytes_length((const uint8_t *) test_cases[i].input, &test_len));
+            EXPECT_SUCCESS(s2n_str_hex_to_bytes((const uint8_t *) test_cases[i].input, test_mem, &test_len));
+            EXPECT_BYTEARRAY_EQUAL(test_mem, test_cases[i].expected_output, test_cases[i].expected_output_size);
+        }
+    }
 
     END_TEST();
 }

--- a/utils/s2n_str.h
+++ b/utils/s2n_str.h
@@ -14,4 +14,8 @@
  */
 #pragma once
 
+#include <stdint.h>
+
 extern char *s2n_strcpy(char *buf, char *last, const char *str);
+int s2n_str_hex_to_bytes_length(const uint8_t *hex, uint32_t *out_bytes_len);
+int s2n_str_hex_to_bytes(const uint8_t *hex, uint8_t *out_bytes, uint32_t *out_bytes_len);


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/2740

### Description of changes: 

Add s2n APIs to convert hex string to bytes without using internal blob structure.

```c
S2N_API int s2n_str_hex_to_bytes_length(const char *str, uint32_t *out_bytes_len);
S2N_API int s2n_str_hex_to_bytes(const char *str, uint8_t *out_bytes, uint32_t *out_bytes_len);
```

### Callout: 

The API is not being released in s2n.h, adding to the utility functions in bin/common.h instead as s2n's scope does not include providing hex encoder and decoder APIs.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Unit Testing 

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
