### PR TITLE
Use S2N_HMAC_SHA256 in psk PRF match test case

### DIFF
--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -132,8 +132,8 @@ int main(int argc, char **argv)
                     TLS_AES_128_GCM_SHA256,
                 };
 
-                /* S2N_HASH_SHA256 is a matching hash algorithm for the cipher suite present in valid_tls13_wire_ciphers */
-                conn->psk_params.chosen_psk->hmac_alg = S2N_HASH_SHA256;
+                /* S2N_HMAC_SHA256 is a matching hmac algorithm for the cipher suite present in valid_tls13_wire_ciphers */
+                conn->psk_params.chosen_psk->hmac_alg = S2N_HMAC_SHA256;
                 EXPECT_SUCCESS(s2n_set_cipher_as_client(conn, valid_tls13_wire_ciphers));
                 EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_tls13_aes_128_gcm_sha256);
 


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

This was previously assigning an s2n_hash_algorithm value to a field
that expects an s2n_hmac_algorithm

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.