### PR TITLE
External PSK Integration Tests Part 1 

### DIFF
--- a/bin/common.c
+++ b/bin/common.c
@@ -174,7 +174,7 @@ static int s2n_setup_external_psk(struct s2n_psk **psk, char *params)
                 }
                 break;
             case 2: {
-                    s2n_psk_hmac psk_hmac_alg;
+                    s2n_psk_hmac psk_hmac_alg = 0;
                     GUARD_EXIT(s2n_get_psk_hmac_alg(&psk_hmac_alg, token), "Invalid psk hmac algorithm\n");
                     GUARD_EXIT(s2n_psk_set_hmac(*psk, psk_hmac_alg), "Error setting psk hmac algorithm\n");
                 } 

--- a/bin/common.h
+++ b/bin/common.h
@@ -52,5 +52,5 @@ int https(struct s2n_connection *conn, uint32_t bench);
 int key_log_callback(void *ctx, struct s2n_connection *conn, uint8_t *logline, size_t len);
 
 char *load_file_to_cstring(const char *path);
-int s2n_str_hex_to_bytes(const uint8_t *hex, uint8_t *out_bytes, uint32_t *out_bytes_len);
-int s2n_setup_external_psk(struct s2n_psk **psk, char *params);
+int s2n_str_hex_to_bytes(const unsigned char *hex, uint8_t *out_bytes, uint32_t max_out_bytes_len);
+int s2n_setup_external_psk_list(struct s2n_connection *conn, char *psk_optarg_list[S2N_MAX_PSK_LIST_LENGTH], size_t psk_list_len);

--- a/bin/common.h
+++ b/bin/common.h
@@ -16,6 +16,16 @@
 #pragma once
 
 #include <stdint.h>
+/* Remove once the PSK feature is released */
+#include "tls/s2n_psk.h"
+
+#define GUARD_EXIT_NULL(x)                                 \
+    do {                                                   \
+        if (x == NULL) {                                   \
+            fprintf(stderr, "NULL pointer encountered\n"); \
+            exit(1);                                       \
+        }                                                  \
+    } while (0)
 
 #define GUARD_EXIT(x, msg)  \
   do {                      \
@@ -33,6 +43,8 @@
     }                        \
   } while (0)
 
+#define S2N_MAX_PSK_LIST_LENGTH 10
+
 void print_s2n_error(const char *app_error);
 int echo(struct s2n_connection *conn, int sockfd);
 int negotiate(struct s2n_connection *conn, int sockfd);
@@ -40,3 +52,5 @@ int https(struct s2n_connection *conn, uint32_t bench);
 int key_log_callback(void *ctx, struct s2n_connection *conn, uint8_t *logline, size_t len);
 
 char *load_file_to_cstring(const char *path);
+int s2n_str_hex_to_bytes(const uint8_t *hex, uint8_t *out_bytes, uint32_t *out_bytes_len);
+int s2n_setup_external_psk(struct s2n_psk **psk, char *params);

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -31,6 +31,7 @@
 
 #include "crypto/s2n_rsa.h"
 #include "crypto/s2n_pkey.h"
+#include "common.h"
 
 #define STDIO_BUFSIZE  10240
 
@@ -136,6 +137,16 @@ int negotiate(struct s2n_connection *conn, int fd)
     printf("Cipher negotiated: %s\n", s2n_connection_get_cipher(conn));
     if (s2n_connection_is_session_resumed(conn)) {
         printf("Resumed session\n");
+    }
+
+    uint16_t identity_length = 0;
+    GUARD_EXIT(s2n_connection_get_negotiated_psk_identity_length(conn, &identity_length), "Error getting negotiated psk identity length from the connection\n");
+    if (identity_length != 0) {
+        uint8_t *identity = malloc(identity_length);
+        GUARD_EXIT_NULL(identity);
+        GUARD_EXIT(s2n_connection_get_negotiated_psk_identity(conn, identity, identity_length), "Error getting negotiated psk identity from the connection\n");
+        printf("Negotiated PSK identity: %s\n", identity);
+        free(identity);
     }
 
     return 0;

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -378,15 +378,10 @@ int main(int argc, char *const *argv)
             break;
         case 'P':
             if (psk_list_len >= S2N_MAX_PSK_LIST_LENGTH) {
-                for (size_t i = 0; i < psk_list_len; i++) {
-                    free(psk_optarg_list[i]);
-                }
                 fprintf(stderr, "Error setting psks, maximum number of psks permitted is 10.\n");
                 exit(1);
             }
-            psk_optarg_list[psk_list_len] = malloc(strlen(optarg)+ 1);
-            strcpy(psk_optarg_list[psk_list_len], optarg);
-            psk_list_len += 1;
+            psk_optarg_list[psk_list_len++] = optarg;
             break;
         case '?':
         default:
@@ -585,10 +580,6 @@ int main(int argc, char *const *argv)
 
     if (key_log_file) {
         fclose(key_log_file);
-    }
-
-    for (size_t i = 0; i < psk_list_len; i++) {
-        free(psk_optarg_list[i]);
     }
 
     GUARD_EXIT(s2n_cleanup(), "Error running s2n_cleanup()");

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -94,7 +94,7 @@ void usage()
     fprintf(stderr, "    Enable NSS key logging into the provided path\n");
     fprintf(stderr, "  -P --psk <psk-identity,psk-secret,psk-hmac-alg> \n"
                     "    A comma-separated list of psk parameters in this order: psk_identity, psk_secret and psk_hmac_alg.\n"
-                    "    Note that the maximum number of permitted psks is 10, the psk-secret is hex-encoded and there are no whitespaces allowed before or after the comma.\n"
+                    "    Note that the maximum number of permitted psks is 10, the psk-secret is hex-encoded, and whitespace is not allowed before or after the commas.\n"
                     "    Ex: --psk psk_id,psk_secret,SHA256 --psk shared_id,shared_secret,SHA384.\n");
     fprintf(stderr, "\n");
     exit(1);

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -393,10 +393,6 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
         exit(1);
     }
 
-    for (size_t i = 0; i < settings.psk_list_len; i++) {
-        free(settings.psk_optarg_list[i]);
-    }
-
     GUARD_RETURN(s2n_connection_wipe(conn), "Error wiping connection");
 
     GUARD_RETURN(s2n_connection_free(conn), "Error freeing connection");
@@ -574,15 +570,10 @@ int main(int argc, char *const *argv)
             break;
         case 'P':
             if (conn_settings.psk_list_len >= S2N_MAX_PSK_LIST_LENGTH) {
-                for (size_t i = 0; i < conn_settings.psk_list_len; i++) {
-                    free(conn_settings.psk_optarg_list[i]);
-                }
                 fprintf(stderr, "Error setting psks, maximum number of psks permitted is 10.\n");
                 exit(1);
             }
-            conn_settings.psk_optarg_list[conn_settings.psk_list_len] = malloc(strlen(optarg) + 1);
-            strcpy(conn_settings.psk_optarg_list[conn_settings.psk_list_len], optarg);
-            conn_settings.psk_list_len += 1;
+            conn_settings.psk_optarg_list[conn_settings.psk_list_len++] = optarg;
             break;
         case '?':
         default:

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -292,7 +292,7 @@ void usage()
     fprintf(stderr, "    Enable NSS key logging into the provided path\n");
     fprintf(stderr, "  -P --psk <psk-identity,psk-secret,psk-hmac-alg> \n"
                     "    A comma-separated list of psk parameters in this order: psk_identity, psk_secret and psk_hmac_alg.\n"
-                    "    Note that the maximum number of permitted psks is 10, the psk-secret is hex-encoded and there are no whitespaces allowed before or after the comma.\n"
+                    "    Note that the maximum number of permitted psks is 10, the psk-secret is hex-encoded, and whitespace is not allowed before or after the commas.\n"
                     "    Ex: --psk psk_id,psk_secret,SHA256 --psk shared_id,shared_secret,SHA384.\n");
     fprintf(stderr, "  -h,--help\n");
     fprintf(stderr, "    Display this message and quit.\n");
@@ -361,7 +361,7 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
         GUARD_RETURN(s2n_connection_use_corked_io(conn), "Error setting corked io");
     }
 
-    GUARD_EXIT(
+    GUARD_RETURN(
         s2n_setup_external_psk_list(conn, settings.psk_optarg_list, settings.psk_list_len),
         "Error setting external psk list");
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -290,6 +290,10 @@ void usage()
     fprintf(stderr, "    Send number of bytes in https server mode to test throughput.\n");
     fprintf(stderr, "  -L --key-log <path>\n");
     fprintf(stderr, "    Enable NSS key logging into the provided path\n");
+    fprintf(stderr, "  -P --psk <psk-identity,psk-secret,psk-hmac-alg> \n"
+                    "    A comma-separated list of psk parameters in this order: psk_identity, psk_secret and psk_hmac_alg.\n"
+                    "    Note that the maximum number of permitted psks is 10, the psk-secret is hex-encoded and there are no whitespaces allowed before or after the comma.\n"
+                    "    Ex: --psk psk_id,psk_secret,S2N_PSK_HMAC_SHA256 --psk shared_id,shared_secret,S2N_PSK_HMAC_SHA384.\n");
     fprintf(stderr, "  -h,--help\n");
     fprintf(stderr, "    Display this message and quit.\n");
 
@@ -313,6 +317,8 @@ struct conn_settings {
     int max_conns;
     const char *ca_dir;
     const char *ca_file;
+    char *psk_optarg_list[S2N_MAX_PSK_LIST_LENGTH];
+    size_t psk_list_len;
 };
 
 int handle_connection(int fd, struct s2n_config *config, struct conn_settings settings)
@@ -353,6 +359,15 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
 
     if (settings.use_corked_io) {
         GUARD_RETURN(s2n_connection_use_corked_io(conn), "Error setting corked io");
+    }
+
+    for (size_t i = 0; i < settings.psk_list_len; i++) {
+        struct s2n_psk *psk = s2n_external_psk_new();
+        GUARD_EXIT_NULL(psk);
+        GUARD_EXIT(s2n_setup_external_psk(&psk, settings.psk_optarg_list[i]), "Error setting external PSK parameters\n");
+        GUARD_EXIT(s2n_connection_append_psk(conn, psk), "Error appending psk to the connection\n");
+        GUARD_EXIT(s2n_psk_free(&psk), "Error freeing psk\n");
+        free(settings.psk_optarg_list[i]);
     }
 
     if (negotiate(conn, fd) != S2N_SUCCESS) {
@@ -422,6 +437,7 @@ int main(int argc, char *const *argv)
     conn_settings.session_ticket = 1;
     conn_settings.session_cache = 1;
     conn_settings.max_conns = -1;
+    conn_settings.psk_list_len = 0;
 
     struct option long_options[] = {
         {"ciphers", required_argument, NULL, 'c'},
@@ -450,12 +466,13 @@ int main(int argc, char *const *argv)
         {"alpn", required_argument, 0, 'A'},
         {"non-blocking", no_argument, 0, 'B'},
         {"key-log", required_argument, 0, 'L'},
+        {"psk", required_argument, 0, 'P'},
         /* Per getopt(3) the last element of the array has to be filled with all zeros */
         { 0 },
     };
     while (1) {
         int option_index = 0;
-        int c = getopt_long(argc, argv, "c:hmnst:d:iTCX::wb:A:", long_options, &option_index);
+        int c = getopt_long(argc, argv, "c:hmnst:d:iTCX::wb:A:P:", long_options, &option_index);
         if (c == -1) {
             break;
         }
@@ -555,6 +572,18 @@ int main(int argc, char *const *argv)
             break;
         case 'L':
             key_log_path = optarg;
+            break;
+        case 'P':
+            if (conn_settings.psk_list_len >= S2N_MAX_PSK_LIST_LENGTH) {
+                for (size_t i = 0; i < conn_settings.psk_list_len; i++) {
+                    free(conn_settings.psk_optarg_list[i]);
+                }
+                fprintf(stderr, "Error setting psks, maximum number of psks permitted is 10.\n");
+                exit(1);
+            }
+            conn_settings.psk_optarg_list[conn_settings.psk_list_len] = malloc(strlen(optarg) + 1);
+            strcpy(conn_settings.psk_optarg_list[conn_settings.psk_list_len], optarg);
+            conn_settings.psk_list_len += 1;
             break;
         case '?':
         default:

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -92,7 +92,7 @@ typedef enum {
 } s2n_psk_hmac;
 
 struct s2n_psk;
-struct s2n_psk* s2n_external_psk_new();
+S2N_API struct s2n_psk* s2n_external_psk_new();
 S2N_API int s2n_psk_free(struct s2n_psk **psk);
 S2N_API int s2n_psk_set_identity(struct s2n_psk *psk, const uint8_t *identity, uint16_t identity_size);
 S2N_API int s2n_psk_set_secret(struct s2n_psk *psk, const uint8_t *secret, uint16_t secret_size);
@@ -108,12 +108,12 @@ S2N_API int s2n_connection_get_negotiated_psk_identity_length(struct s2n_connect
 S2N_API int s2n_connection_get_negotiated_psk_identity(struct s2n_connection *conn, uint8_t *identity, uint16_t max_identity_length);
 
 struct s2n_offered_psk;
-struct s2n_offered_psk* s2n_offered_psk_new();
+S2N_API struct s2n_offered_psk* s2n_offered_psk_new();
 S2N_API int s2n_offered_psk_free(struct s2n_offered_psk **psk);
 S2N_API int s2n_offered_psk_get_identity(struct s2n_offered_psk *psk, uint8_t** identity, uint16_t *size);
 
 struct s2n_offered_psk_list;
-bool s2n_offered_psk_list_has_next(struct s2n_offered_psk_list *psk_list);
+S2N_API bool s2n_offered_psk_list_has_next(struct s2n_offered_psk_list *psk_list);
 S2N_API int s2n_offered_psk_list_next(struct s2n_offered_psk_list *psk_list, struct s2n_offered_psk *psk);
 S2N_API int s2n_offered_psk_list_reread(struct s2n_offered_psk_list *psk_list);
 S2N_API int s2n_offered_psk_list_choose_psk(struct s2n_offered_psk_list *psk_list, struct s2n_offered_psk *psk);

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -93,31 +93,31 @@ typedef enum {
 
 struct s2n_psk;
 struct s2n_psk* s2n_external_psk_new();
-int s2n_psk_free(struct s2n_psk **psk);
-int s2n_psk_set_identity(struct s2n_psk *psk, const uint8_t *identity, uint16_t identity_size);
-int s2n_psk_set_secret(struct s2n_psk *psk, const uint8_t *secret, uint16_t secret_size);
-int s2n_psk_set_hmac(struct s2n_psk *psk, s2n_psk_hmac hmac);
+S2N_API int s2n_psk_free(struct s2n_psk **psk);
+S2N_API int s2n_psk_set_identity(struct s2n_psk *psk, const uint8_t *identity, uint16_t identity_size);
+S2N_API int s2n_psk_set_secret(struct s2n_psk *psk, const uint8_t *secret, uint16_t secret_size);
+S2N_API int s2n_psk_set_hmac(struct s2n_psk *psk, s2n_psk_hmac hmac);
 
-int s2n_connection_append_psk(struct s2n_connection *conn, struct s2n_psk *psk);
+S2N_API int s2n_connection_append_psk(struct s2n_connection *conn, struct s2n_psk *psk);
 
 typedef enum { S2N_PSK_MODE_RESUMPTION, S2N_PSK_MODE_EXTERNAL } s2n_psk_mode;
-int s2n_config_set_psk_mode(struct s2n_config *config, s2n_psk_mode mode);
-int s2n_connection_set_psk_mode(struct s2n_connection *conn, s2n_psk_mode mode);
+S2N_API int s2n_config_set_psk_mode(struct s2n_config *config, s2n_psk_mode mode);
+S2N_API int s2n_connection_set_psk_mode(struct s2n_connection *conn, s2n_psk_mode mode);
 
-int s2n_connection_get_negotiated_psk_identity_length(struct s2n_connection *conn, uint16_t *identity_length);
-int s2n_connection_get_negotiated_psk_identity(struct s2n_connection *conn, uint8_t *identity, uint16_t max_identity_length);
+S2N_API int s2n_connection_get_negotiated_psk_identity_length(struct s2n_connection *conn, uint16_t *identity_length);
+S2N_API int s2n_connection_get_negotiated_psk_identity(struct s2n_connection *conn, uint8_t *identity, uint16_t max_identity_length);
 
 struct s2n_offered_psk;
 struct s2n_offered_psk* s2n_offered_psk_new();
-int s2n_offered_psk_free(struct s2n_offered_psk **psk);
-int s2n_offered_psk_get_identity(struct s2n_offered_psk *psk, uint8_t** identity, uint16_t *size);
+S2N_API int s2n_offered_psk_free(struct s2n_offered_psk **psk);
+S2N_API int s2n_offered_psk_get_identity(struct s2n_offered_psk *psk, uint8_t** identity, uint16_t *size);
 
 struct s2n_offered_psk_list;
 bool s2n_offered_psk_list_has_next(struct s2n_offered_psk_list *psk_list);
-int s2n_offered_psk_list_next(struct s2n_offered_psk_list *psk_list, struct s2n_offered_psk *psk);
-int s2n_offered_psk_list_reread(struct s2n_offered_psk_list *psk_list);
-int s2n_offered_psk_list_choose_psk(struct s2n_offered_psk_list *psk_list, struct s2n_offered_psk *psk);
+S2N_API int s2n_offered_psk_list_next(struct s2n_offered_psk_list *psk_list, struct s2n_offered_psk *psk);
+S2N_API int s2n_offered_psk_list_reread(struct s2n_offered_psk_list *psk_list);
+S2N_API int s2n_offered_psk_list_choose_psk(struct s2n_offered_psk_list *psk_list, struct s2n_offered_psk *psk);
 
 typedef int (*s2n_psk_selection_callback)(struct s2n_connection *conn, void *context,
                                           struct s2n_offered_psk_list *psk_list);
-int s2n_config_set_psk_selection_callback(struct s2n_config *config, s2n_psk_selection_callback cb, void *context);
+S2N_API int s2n_config_set_psk_selection_callback(struct s2n_config *config, s2n_psk_selection_callback cb, void *context);


### PR DESCRIPTION
### Description of changes: 

To test external PSKs we need to extend the ability  of s2nd and s2nc to append/set the psk_list supported by the client. This includes inputting the psk_identity, psk_secret and its corresponding psk hmac algorithm and constructing an external psk using `s2n_external_psk_new`, setting the psk identity, psk secret and psk hmac algorithm using `s2n_psk_set_identity`, `s2n_psk_set_secret` and `s2n_psk_set_hmac` and using the `s2n_connection_append_psk`  to append the constructed s2n_external_psk_new psk to the connection. 

```
s2nc --psk psk_identity_1,psk_secret_1,psk_hmac_alg_1  --psk psk_identity_2,psk_secret_2,psk_hmac_alg_2 ... --psk psk_identity_n,psk_secret_n,psk_hmac_alg_10
```

and 

```
s2nd --psk psk_identity_1,psk_secret_1,psk_hmac_alg_1  --psk psk_identity_2,psk_secret_2,psk_hmac_alg_2 ... --psk psk_identity_n,psk_secret_n,psk_hmac_alg_10
 ```

### Call-outs:

- The choice of using command line parameters over using a file to obtain the psk parameters was made for keeping it simple and  easy to use. We can always revert to using a file if the need to expand arises. 
- The S2N_MAX_PSK_LIST_LENGTH  value is set to 10 as practically we don't expect more than 10 psk's to be used with s2nd/s2nc.  
 
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? Integration Tests. 

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
