### PR TITLE
async_pkey support for s2n_client_verify

### DIFF
--- a/tests/unit/s2n_async_pkey_test.c
+++ b/tests/unit/s2n_async_pkey_test.c
@@ -25,6 +25,8 @@
 #include "tls/s2n_cipher_suites.h"
 #include "utils/s2n_safety.h"
 
+#include <pthread.h>
+
 struct s2n_async_pkey_op *pkey_op = NULL;
 
 typedef int (async_handler)(struct s2n_connection *conn);
@@ -139,6 +141,43 @@ int async_pkey_apply_in_callback(struct s2n_connection *conn, struct s2n_async_p
 int async_pkey_store_callback(struct s2n_connection *conn, struct s2n_async_pkey_op *op)
 {
     pkey_op = op;
+    return S2N_SUCCESS;
+}
+
+struct task_params {
+    struct s2n_connection *conn;
+    struct s2n_async_pkey_op *op;
+};
+
+void *pkey_task(void *param)
+{
+    struct task_params *params = (struct task_params*)param;
+
+    struct s2n_cert_chain_and_key *chain_and_key = s2n_connection_get_selected_cert(params->conn);
+    EXPECT_NOT_NULL(chain_and_key);
+
+    s2n_cert_private_key *pkey = s2n_cert_chain_and_key_get_private_key(chain_and_key);
+    EXPECT_NOT_NULL(pkey);
+
+    EXPECT_SUCCESS(s2n_async_pkey_op_perform(params->op, pkey));
+    EXPECT_SUCCESS(s2n_async_pkey_op_apply(params->op, params->conn));
+
+    free(params);
+    pthread_exit(NULL);
+}
+
+int async_pkey_perform_op(struct s2n_connection *conn, struct s2n_async_pkey_op *op)
+{
+    EXPECT_NOT_NULL(conn);
+    EXPECT_NOT_NULL(op);
+
+    struct task_params *params = malloc(sizeof(struct task_params));
+    params->conn = conn; 
+    params->op = op; 
+
+    pthread_t worker;
+    POSIX_GUARD(pthread_create(&worker, NULL, &pkey_task, params));
+
     return S2N_SUCCESS;
 }
 
@@ -288,6 +327,52 @@ int main(int argc, char **argv)
 
             EXPECT_FAILURE_WITH_ERRNO(
                     try_handshake(server_conn, client_conn, async_handler_free_pkey_op), S2N_ERR_ASYNC_BLOCKED);
+
+            /* Free the data */
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+            EXPECT_SUCCESS(s2n_config_free(server_config));
+            EXPECT_SUCCESS(s2n_config_free(client_config));
+        }
+
+        /*  Test: client certificate verify */
+        {
+            struct s2n_config *server_config, *client_config;
+            EXPECT_NOT_NULL(server_config = s2n_config_new());
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+            EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
+            EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_perform_op));
+            EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(server_config));
+            server_config->security_policy = &server_security_policy;
+
+            EXPECT_NOT_NULL(client_config = s2n_config_new());
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(client_config, chain_and_key));
+            EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(client_config, async_pkey_perform_op));
+            EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(client_config));
+
+            /* Create connection */
+            struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(client_conn);
+            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
+            EXPECT_SUCCESS(s2n_connection_set_client_auth_type(client_conn, S2N_CERT_AUTH_REQUIRED));
+
+            struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(server_conn);
+            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+            EXPECT_SUCCESS(s2n_connection_set_client_auth_type(server_conn, S2N_CERT_AUTH_REQUIRED));
+
+            /* Create nonblocking pipes */
+            struct s2n_test_io_pair io_pair;
+            EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+            EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+            EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+
+            EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+            /* Verify that both connections negotiated Mutual Auth */
+            EXPECT_TRUE(s2n_connection_client_cert_used(server_conn));
+            EXPECT_TRUE(s2n_connection_client_cert_used(client_conn));
 
             /* Free the data */
             EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_async_pkey_test.c
+++ b/tests/unit/s2n_async_pkey_test.c
@@ -172,6 +172,8 @@ int async_pkey_perform_op(struct s2n_connection *conn, struct s2n_async_pkey_op 
     EXPECT_NOT_NULL(op);
 
     struct task_params *params = malloc(sizeof(struct task_params));
+    EXPECT_NOT_NULL(params);
+    
     params->conn = conn; 
     params->op = op; 
 

--- a/tests/unit/s2n_client_cert_verify_test.c
+++ b/tests/unit/s2n_client_cert_verify_test.c
@@ -45,18 +45,6 @@ static int test_sign(const struct s2n_pkey *priv_key, s2n_signature_algorithm si
     return S2N_SUCCESS;
 }
 
-int s2n_async_pkey_perform_stored_op(void)
-{
-    struct s2n_cert_chain_and_key *chain_and_key = s2n_connection_get_selected_cert(pkey_conn);
-    EXPECT_NOT_NULL(chain_and_key);
-
-    s2n_cert_private_key *pkey = s2n_cert_chain_and_key_get_private_key(chain_and_key);
-    EXPECT_NOT_NULL(pkey);
-
-    EXPECT_SUCCESS(s2n_async_pkey_op_perform(pkey_op, pkey));
-    return S2N_SUCCESS;
-}
-
 int s2n_async_pkey_store_op(struct s2n_connection *conn, struct s2n_async_pkey_op *op)
 {
     EXPECT_NOT_NULL(conn);
@@ -76,7 +64,13 @@ static int s2n_test_negotiate_with_async_pkey_op(struct s2n_connection *conn, s2
     }
 
     if (*block == S2N_BLOCKED_ON_APPLICATION_INPUT && pkey_op != NULL) {
-        EXPECT_SUCCESS(s2n_async_pkey_perform_stored_op());
+        struct s2n_cert_chain_and_key *chain_and_key = s2n_connection_get_selected_cert(pkey_conn);
+        EXPECT_NOT_NULL(chain_and_key);
+
+        s2n_cert_private_key *pkey = s2n_cert_chain_and_key_get_private_key(chain_and_key);
+        EXPECT_NOT_NULL(pkey);
+
+        EXPECT_SUCCESS(s2n_async_pkey_op_perform(pkey_op, pkey));
         EXPECT_SUCCESS(s2n_async_pkey_op_apply(pkey_op, conn));
         EXPECT_SUCCESS(s2n_async_pkey_op_free(pkey_op));
         pkey_op = NULL;

--- a/tests/unit/s2n_client_cert_verify_test.c
+++ b/tests/unit/s2n_client_cert_verify_test.c
@@ -74,20 +74,20 @@ int async_pkey_perform_op(struct s2n_connection *conn, struct s2n_async_pkey_op 
 
 static int negotiate(struct s2n_connection *conn, s2n_blocked_status *block) 
 {
-        int rc = s2n_negotiate(conn, block);
-        if (!(rc == 0 || (*block && s2n_error_get_type(s2n_errno) == S2N_ERR_T_BLOCKED))) {
-            return S2N_FAILURE;
-        }
+    int rc = s2n_negotiate(conn, block);
+    if (!(rc == 0 || (*block && s2n_error_get_type(s2n_errno) == S2N_ERR_T_BLOCKED))) {
+        return S2N_FAILURE;
+    }
 
-        if (*block == S2N_BLOCKED_ON_APPLICATION_INPUT && pkey_op != NULL) {
-            if (s2n_async_pkey_op_apply(pkey_op, conn) == S2N_SUCCESS) {
-                EXPECT_SUCCESS(s2n_async_pkey_op_free(pkey_op));
-                pkey_op = NULL;
-                pkey_conn = NULL;
-            }
+    if (*block == S2N_BLOCKED_ON_APPLICATION_INPUT && pkey_op != NULL) {
+        if (s2n_async_pkey_op_apply(pkey_op, conn) == S2N_SUCCESS) {
+            EXPECT_SUCCESS(s2n_async_pkey_op_free(pkey_op));
+            pkey_op = NULL;
+            pkey_conn = NULL;
         }
+    }
 
-        return S2N_SUCCESS;
+    return S2N_SUCCESS;
 }
 
 static int try_handshake(struct s2n_connection *server_conn, struct s2n_connection *client_conn)

--- a/tests/unit/s2n_client_cert_verify_test.c
+++ b/tests/unit/s2n_client_cert_verify_test.c
@@ -14,6 +14,7 @@
  */
 
 #include <stdint.h>
+#include <pthread.h>
 #include <s2n.h>
 
 #include "s2n_test.h"
@@ -23,6 +24,8 @@
 #include "tls/s2n_connection.h"
 #include "utils/s2n_result.h"
 #include "utils/s2n_safety.h"
+
+struct s2n_async_pkey_op *pkey_op = NULL;
 
 const uint8_t test_signature_data[] = "I signed this";
 const uint32_t test_signature_size = sizeof(test_signature_data);
@@ -39,6 +42,86 @@ static int test_sign(const struct s2n_pkey *priv_key, s2n_signature_algorithm si
 {
     POSIX_CHECKED_MEMCPY(signature->data, test_signature_data, test_signature_size);
     signature->size = test_signature_size;
+    return S2N_SUCCESS;
+}
+
+struct task_params {
+    struct s2n_connection *conn;
+    struct s2n_async_pkey_op *op;
+};
+
+void *pkey_task(void *param)
+{
+    struct task_params *params = (struct task_params*)param;
+
+    struct s2n_cert_chain_and_key *chain_and_key = s2n_connection_get_selected_cert(params->conn);
+    EXPECT_NOT_NULL(chain_and_key);
+
+    s2n_cert_private_key *pkey = s2n_cert_chain_and_key_get_private_key(chain_and_key);
+    EXPECT_NOT_NULL(pkey);
+
+    EXPECT_SUCCESS(s2n_async_pkey_op_perform(params->op, pkey));
+
+    free(params);
+    pthread_exit(NULL);
+}
+
+int async_pkey_perform_op(struct s2n_connection *conn, struct s2n_async_pkey_op *op)
+{
+    EXPECT_NOT_NULL(conn);
+    EXPECT_NOT_NULL(op);
+
+    pkey_op = op;
+
+    struct task_params *params = malloc(sizeof(struct task_params));
+    EXPECT_NOT_NULL(params);
+    
+    params->conn = conn; 
+    params->op = op; 
+
+    pthread_t worker = {0};
+    POSIX_GUARD(pthread_create(&worker, NULL, &pkey_task, params));
+    POSIX_GUARD(pthread_detach(worker));
+
+    return S2N_SUCCESS;
+}
+
+static int try_handshake(struct s2n_connection *server_conn, struct s2n_connection *client_conn)
+{
+    s2n_blocked_status server_blocked = {0};
+    s2n_blocked_status client_blocked = {0};
+
+    int server_rc = 0;
+    int client_rc= 0;
+
+    do {
+        client_rc = s2n_negotiate(client_conn, &client_blocked);
+        if (!(client_rc == 0 || (client_blocked && s2n_error_get_type(s2n_errno) == S2N_ERR_T_BLOCKED))) {
+            return S2N_FAILURE;
+        }
+
+        if(client_blocked == S2N_BLOCKED_ON_APPLICATION_INPUT && pkey_op != NULL) {
+            if(s2n_async_pkey_op_apply(pkey_op, client_conn) == S2N_SUCCESS) {
+                EXPECT_SUCCESS(s2n_async_pkey_op_free(pkey_op));
+                pkey_op = NULL;
+            }
+        }
+
+        server_rc = s2n_negotiate(server_conn, &server_blocked);
+        if (!(server_rc == 0 || (server_blocked && s2n_error_get_type(s2n_errno) == S2N_ERR_T_BLOCKED))) {
+            return S2N_FAILURE;
+        }
+
+        if(server_blocked == S2N_BLOCKED_ON_APPLICATION_INPUT && pkey_op != NULL) {
+            if(s2n_async_pkey_op_apply(pkey_op, server_conn) == S2N_SUCCESS) {
+                EXPECT_SUCCESS(s2n_async_pkey_op_free(pkey_op));
+                pkey_op = NULL;
+            }
+        } 
+    } while (client_blocked || server_blocked);
+
+    POSIX_GUARD(s2n_shutdown_test_server_and_client(server_conn, client_conn));
+
     return S2N_SUCCESS;
 }
 
@@ -78,6 +161,57 @@ int main(int argc, char **argv)
         EXPECT_BYTEARRAY_EQUAL(signature_data, test_signature_data, test_signature_size);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+    }
+
+    /*  Test: client certificate verify. */
+    {
+        struct s2n_cert_chain_and_key *chain_and_key;
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+                S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+
+        struct s2n_config *server_config, *client_config;
+        EXPECT_NOT_NULL(server_config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+        EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_perform_op));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(server_config));
+
+        EXPECT_NOT_NULL(client_config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(client_config, chain_and_key));
+        EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(client_config, async_pkey_perform_op));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(client_config));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "20170210"));
+
+        /* Create connection */
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
+        EXPECT_SUCCESS(s2n_connection_set_client_auth_type(client_conn, S2N_CERT_AUTH_REQUIRED));
+
+
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+        EXPECT_SUCCESS(s2n_connection_set_client_auth_type(server_conn, S2N_CERT_AUTH_REQUIRED));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair = {0};
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+
+        EXPECT_SUCCESS(try_handshake(server_conn, client_conn));
+
+        /* Verify that both connections negotiated Mutual Auth */
+        EXPECT_TRUE(s2n_connection_client_cert_used(server_conn));
+        EXPECT_TRUE(s2n_connection_client_cert_used(client_conn));
+
+        /* Free the data */
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+        EXPECT_SUCCESS(s2n_config_free(server_config));
+        EXPECT_SUCCESS(s2n_config_free(client_config));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
     }
 

--- a/tests/unit/s2n_client_cert_verify_test.c
+++ b/tests/unit/s2n_client_cert_verify_test.c
@@ -14,7 +14,6 @@
  */
 
 #include <stdint.h>
-#include <pthread.h>
 #include <s2n.h>
 
 #include "s2n_test.h"

--- a/tests/unit/s2n_client_cert_verify_test.c
+++ b/tests/unit/s2n_client_cert_verify_test.c
@@ -24,6 +24,7 @@
 #include "utils/s2n_result.h"
 #include "utils/s2n_safety.h"
 
+static bool async_callback_invoked = false;
 static struct s2n_async_pkey_op *pkey_op = NULL;
 static struct s2n_connection *pkey_conn = NULL;
 
@@ -50,6 +51,7 @@ int s2n_async_pkey_store_op(struct s2n_connection *conn, struct s2n_async_pkey_o
     EXPECT_NOT_NULL(conn);
     EXPECT_NOT_NULL(op);
 
+    async_callback_invoked = true;
     pkey_op = op;
     pkey_conn = conn;
 
@@ -166,6 +168,9 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
 
         EXPECT_SUCCESS(s2n_try_handshake_with_async_pkey_op(server_conn, client_conn));
+
+        /* Make sure async callback was used during the handshake. */
+        EXPECT_TRUE(async_callback_invoked);
 
         /* Verify that both connections negotiated Mutual Auth */
         EXPECT_TRUE(s2n_connection_client_cert_used(server_conn));

--- a/tests/unit/s2n_client_cert_verify_test.c
+++ b/tests/unit/s2n_client_cert_verify_test.c
@@ -45,7 +45,7 @@ static int test_sign(const struct s2n_pkey *priv_key, s2n_signature_algorithm si
     return S2N_SUCCESS;
 }
 
-int s2n_async_pkey_store_perform(void)
+int s2n_async_pkey_perform_stored_op(void)
 {
     struct s2n_cert_chain_and_key *chain_and_key = s2n_connection_get_selected_cert(pkey_conn);
     EXPECT_NOT_NULL(chain_and_key);
@@ -76,7 +76,7 @@ static int s2n_test_negotiate_with_async_pkey_op(struct s2n_connection *conn, s2
     }
 
     if (*block == S2N_BLOCKED_ON_APPLICATION_INPUT && pkey_op != NULL) {
-        EXPECT_SUCCESS(s2n_async_pkey_store_perform());
+        EXPECT_SUCCESS(s2n_async_pkey_perform_stored_op());
         EXPECT_SUCCESS(s2n_async_pkey_op_apply(pkey_op, conn));
         EXPECT_SUCCESS(s2n_async_pkey_op_free(pkey_op));
         pkey_op = NULL;

--- a/tests/unit/s2n_client_cert_verify_test.c
+++ b/tests/unit/s2n_client_cert_verify_test.c
@@ -80,6 +80,7 @@ static int s2n_test_negotiate_with_async_pkey_op(struct s2n_connection *conn, s2
     }
 
     if (*block == S2N_BLOCKED_ON_APPLICATION_INPUT && pkey_op != NULL) {
+        POSIX_GUARD(pthread_join(worker, NULL));
         if (s2n_async_pkey_op_apply(pkey_op, conn) == S2N_SUCCESS) {
             EXPECT_SUCCESS(s2n_async_pkey_op_free(pkey_op));
             pkey_op = NULL;
@@ -98,8 +99,6 @@ static int s2n_try_handshake_with_async_pkey_op(struct s2n_connection *server_co
     do {
         EXPECT_SUCCESS(s2n_test_negotiate_with_async_pkey_op(client_conn, &client_blocked));
         EXPECT_SUCCESS(s2n_test_negotiate_with_async_pkey_op(server_conn, &server_blocked));
-
-        POSIX_GUARD(pthread_join(worker, NULL));
     } while (client_blocked || server_blocked);
 
     POSIX_GUARD(s2n_shutdown_test_server_and_client(server_conn, client_conn));

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -81,7 +81,7 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
     return S2N_SUCCESS;
 }
 
-int s2n_client_cert_verify_send_complete(struct s2n_connection *conn, struct s2n_blob *signature)
+static int s2n_client_cert_verify_send_complete(struct s2n_connection *conn, struct s2n_blob *signature)
 {
     struct s2n_stuffer *out = &conn->handshake.io;
 

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -25,7 +25,9 @@
 #include "stuffer/s2n_stuffer.h"
 
 #include "utils/s2n_safety.h"
+#include "tls/s2n_async_pkey.h"
 
+static int s2n_client_cert_verify_send_complete(struct s2n_connection *conn, struct s2n_blob *signature);
 
 int s2n_client_cert_verify_recv(struct s2n_connection *conn)
 {
@@ -54,11 +56,12 @@ int s2n_client_cert_verify_recv(struct s2n_connection *conn)
     /* Client certificate has been verified. Minimize required handshake hash algs */
     POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_client_cert_verify_send(struct s2n_connection *conn)
 {
+    S2N_ASYNC_PKEY_GUARD(conn);
     struct s2n_stuffer *out = &conn->handshake.io;
 
     struct s2n_signature_scheme chosen_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
@@ -73,20 +76,20 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
     POSIX_GUARD(s2n_handshake_get_hash_state(conn, chosen_sig_scheme.hash_alg, &hash_state));
     POSIX_GUARD(s2n_hash_copy(&conn->handshake.ccv_hash_copy, &hash_state));
 
-    struct s2n_cert_chain_and_key *cert_chain_and_key = conn->handshake_params.our_chain_and_key;
+    S2N_ASYNC_PKEY_SIGN(conn, conn->secure.client_cert_sig_scheme.sig_alg, &conn->handshake.ccv_hash_copy, s2n_client_cert_verify_send_complete);
 
-    DEFER_CLEANUP(struct s2n_blob signature = {0}, s2n_free);
-    uint32_t max_signature_size = 0;
-    POSIX_GUARD_RESULT(s2n_pkey_size(cert_chain_and_key->private_key, &max_signature_size));
-    POSIX_GUARD(s2n_alloc(&signature, max_signature_size));
+    return S2N_SUCCESS;
+}
 
-    POSIX_GUARD(s2n_pkey_sign(cert_chain_and_key->private_key, chosen_sig_scheme.sig_alg, &conn->handshake.ccv_hash_copy, &signature));
+int s2n_client_cert_verify_send_complete(struct s2n_connection *conn, struct s2n_blob *signature)
+{
+    struct s2n_stuffer *out = &conn->handshake.io;
 
-    POSIX_GUARD(s2n_stuffer_write_uint16(out, signature.size));
-    POSIX_GUARD(s2n_stuffer_write(out, &signature));
+    POSIX_GUARD(s2n_stuffer_write_uint16(out, signature->size));
+    POSIX_GUARD(s2n_stuffer_write(out, signature));
 
     /* Client certificate has been verified. Minimize required handshake hash algs */
     POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));
 
-    return 0;
+    return S2N_SUCCESS;
 }

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -77,8 +77,6 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
     POSIX_GUARD(s2n_hash_copy(&conn->handshake.ccv_hash_copy, &hash_state));
 
     S2N_ASYNC_PKEY_SIGN(conn, chosen_sig_scheme.sig_alg, &conn->handshake.ccv_hash_copy, s2n_client_cert_verify_send_complete);
-
-    return S2N_SUCCESS;
 }
 
 static int s2n_client_cert_verify_send_complete(struct s2n_connection *conn, struct s2n_blob *signature)

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -87,6 +87,7 @@ int s2n_client_cert_verify_send_complete(struct s2n_connection *conn, struct s2n
 
     POSIX_GUARD(s2n_stuffer_write_uint16(out, signature->size));
     POSIX_GUARD(s2n_stuffer_write(out, signature));
+    POSIX_GUARD(s2n_free(signature));
 
     /* Client certificate has been verified. Minimize required handshake hash algs */
     POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -76,7 +76,7 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
     POSIX_GUARD(s2n_handshake_get_hash_state(conn, chosen_sig_scheme.hash_alg, &hash_state));
     POSIX_GUARD(s2n_hash_copy(&conn->handshake.ccv_hash_copy, &hash_state));
 
-    S2N_ASYNC_PKEY_SIGN(conn, conn->secure.client_cert_sig_scheme.sig_alg, &conn->handshake.ccv_hash_copy, s2n_client_cert_verify_send_complete);
+    S2N_ASYNC_PKEY_SIGN(conn, chosen_sig_scheme.sig_alg, &conn->handshake.ccv_hash_copy, s2n_client_cert_verify_send_complete);
 
     return S2N_SUCCESS;
 }
@@ -87,7 +87,6 @@ int s2n_client_cert_verify_send_complete(struct s2n_connection *conn, struct s2n
 
     POSIX_GUARD(s2n_stuffer_write_uint16(out, signature->size));
     POSIX_GUARD(s2n_stuffer_write(out, signature));
-    POSIX_GUARD(s2n_free(signature));
 
     /* Client certificate has been verified. Minimize required handshake hash algs */
     POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 
Added async wrapper for private key operations during s2n_client_verify calls. Original logic allowed for only synchronous client private key operations.

Expanded the s2n_async_pkey_test.c test case to test async support for client side private key operations.

### Call-outs:
I added a dependency for pthread in the existing tests, as this test case must be on the happy path, and that requires some background processing.

### Testing:

 Added a test with my changes.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

Not a refactor.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
