### PR TITLE
Update s2n_connection_is_session_resumed for TLS1.3

### DIFF
--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -1067,7 +1067,7 @@ int main(int argc, char **argv)
             conn->psk_params.type = S2N_PSK_TYPE_EXTERNAL;
             EXPECT_TRUE(s2n_connection_is_session_resumed(conn));
 
-            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
         /* TLS1.3 */
@@ -1088,7 +1088,7 @@ int main(int argc, char **argv)
             conn->psk_params.type = S2N_PSK_TYPE_RESUMPTION;
             EXPECT_TRUE(s2n_connection_is_session_resumed(conn));
 
-            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+            EXPECT_SUCCESS(s2n_connection_free(conn));
         }
     }
 

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -1080,11 +1080,11 @@ int main(int argc, char **argv)
             conn->psk_params.type = S2N_PSK_TYPE_EXTERNAL;
             EXPECT_FALSE(s2n_connection_is_session_resumed(conn));
 
-            conn->handshake.handshake_type = NEGOTIATED | WITH_SESSION_TICKET;
+            conn->handshake.handshake_type = NEGOTIATED;
             conn->psk_params.type = S2N_PSK_TYPE_EXTERNAL;
             EXPECT_FALSE(s2n_connection_is_session_resumed(conn));
 
-            conn->handshake.handshake_type = NEGOTIATED | WITH_SESSION_TICKET;
+            conn->handshake.handshake_type = NEGOTIATED;
             conn->psk_params.type = S2N_PSK_TYPE_RESUMPTION;
             EXPECT_TRUE(s2n_connection_is_session_resumed(conn));
 

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -449,8 +449,8 @@ int s2n_connection_get_session_length(struct s2n_connection *conn)
 
 int s2n_connection_is_session_resumed(struct s2n_connection *conn)
 {
-    return conn && (s2n_connection_get_protocol_version(conn) < S2N_TLS13)
-           && IS_RESUMPTION_HANDSHAKE(conn);
+    return conn && IS_RESUMPTION_HANDSHAKE(conn)
+        && (conn->actual_protocol_version < S2N_TLS13 || conn->psk_params.type == S2N_PSK_TYPE_RESUMPTION);
 }
 
 int s2n_connection_is_ocsp_stapled(struct s2n_connection *conn)

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -201,7 +201,7 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
         return 0;
     }
 
-    if (s2n_connection_is_session_resumed(conn)) {
+    if (conn->actual_protocol_version < S2N_TLS13 && s2n_connection_is_session_resumed(conn)) {
         POSIX_GUARD(s2n_prf_key_expansion(conn));
     }
 


### PR DESCRIPTION
### Related issues:

https://github.com/aws/s2n-tls/issues/2553

### Description of changes: 

Currently, s2n_connection_is_session_resumed is always false for TLS1.3. After this change, it is true if we used resumption PSKs on a non-FULL_HANDSHAKE connection.

### Call-outs:

**Other APIs:** Addressing other TLS1.2 APIs will be handled separately (although if there are any you want to make sure I touch, add them to https://github.com/aws/s2n-tls/issues/2553). The changes are clearer if I don't mix them all together.

### Testing:

Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
