### PR TITLE
Update s2n_config_set_session_tickets_onoff for TLS1.3

### DIFF
--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -226,5 +226,30 @@ int main(int argc, char **argv)
         }
     }
 
+    /* s2n_config_set_session_tickets_onoff */
+    {
+        /* Safety */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_session_tickets_onoff(NULL, true), S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_session_tickets_onoff(NULL, false), S2N_ERR_NULL);
+
+        struct s2n_config *config = s2n_config_new();
+        EXPECT_NOT_NULL(config);
+
+        EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, true));
+        EXPECT_TRUE(config->use_tickets);
+        EXPECT_EQUAL(config->initial_tickets_to_send, 1);
+
+        EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, false));
+        EXPECT_FALSE(config->use_tickets);
+        EXPECT_EQUAL(config->initial_tickets_to_send, 1);
+
+        config->initial_tickets_to_send = 10;
+        EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, true));
+        EXPECT_TRUE(config->use_tickets);
+        EXPECT_EQUAL(config->initial_tickets_to_send, 10);
+
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
     END_TEST();
 }

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -991,8 +991,13 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_EQUAL(conn->tickets_to_send, 0);
+        EXPECT_FALSE(config->use_tickets);
+
+        EXPECT_SUCCESS(s2n_config_set_initial_ticket_count(config, 0));
+        EXPECT_TRUE(config->use_tickets);
 
         EXPECT_SUCCESS(s2n_config_set_initial_ticket_count(config, num_tickets));
+        EXPECT_TRUE(config->use_tickets);
 
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
         EXPECT_EQUAL(conn->tickets_to_send, num_tickets);

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -687,6 +687,9 @@ int s2n_config_set_session_tickets_onoff(struct s2n_config *config, uint8_t enab
     }
 
     config->use_tickets = enabled;
+    if (config->initial_tickets_to_send == 0) {
+        config->initial_tickets_to_send = 1;
+    }
 
     /* session ticket || session id is enabled */
     if (enabled) {

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -688,6 +688,9 @@ int s2n_config_set_session_tickets_onoff(struct s2n_config *config, uint8_t enab
 
     config->use_tickets = enabled;
     if (config->initial_tickets_to_send == 0) {
+        /* Normally initial_tickets_to_send is set via s2n_config_set_initial_ticket_count.
+         * However, s2n_config_set_initial_ticket_count calls this method.
+         * So we set initial_tickets_to_send directly to avoid infinite recursion. */
         config->initial_tickets_to_send = 1;
     }
 

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -883,6 +883,7 @@ int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num)
     POSIX_ENSURE_REF(config);
 
     config->initial_tickets_to_send = num;
+    POSIX_GUARD(s2n_config_set_session_tickets_onoff(config, true));
 
     return S2N_SUCCESS;
 }

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -115,7 +115,7 @@ S2N_RESULT s2n_tls13_server_nst_send(struct s2n_connection *conn, s2n_blocked_st
 {
     RESULT_ENSURE_REF(conn);
 
-    if (conn->mode != S2N_SERVER || conn->actual_protocol_version < S2N_TLS13) {
+    if (conn->mode != S2N_SERVER || conn->actual_protocol_version < S2N_TLS13 || !conn->config->use_tickets) {
         return S2N_RESULT_OK;
     }
 


### PR DESCRIPTION
### Related issues:

https://github.com/aws/s2n-tls/issues/2553

### Description of changes: 

Currently, to use tickets with TLS1.3, you have to call both s2n_config_set_session_tickets_onoff (to set up ticket keys) and either s2n_config_set_initial_ticket_count or s2n_connection_add_new_tickets_to_send to change the number of new TLS1.3 tickets from 0 to at least 1.

After this change, you can either call s2n_config_set_session_tickets_onoff (to get a default 1 ticket) or s2n_config_set_initial_ticket_count, but it is not necessary to call both.

### Call-outs:

**Other APIs:** Addressing other TLS1.2 APIs will be handled separately (although if there are any you want to make sure I touch, add them to https://github.com/aws/s2n-tls/issues/2553). The changes are clearer if I don't mix them all together.

### Testing:

 Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
