### PR TITLE
Allow ecc preferences without secp256r1

### DIFF
--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -240,12 +240,18 @@ static int s2n_parse_client_hello(struct s2n_connection *conn)
     const struct s2n_ecc_preferences *ecc_pref = NULL;
     POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
     POSIX_ENSURE_REF(ecc_pref);
+    POSIX_ENSURE_GT(ecc_pref->count, 0);
 
-    /* This is going to be our fallback if the client has no preference. */
-    /* A TLS-compliant application MUST support key exchange with secp256r1 (NIST P-256) */
-    /* and SHOULD support key exchange with X25519 [RFC7748]. */
-    /* - https://tools.ietf.org/html/rfc8446#section-9.1 */
-    conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
+    if (s2n_ecc_preferences_includes_curve(ecc_pref, TLS_EC_CURVE_SECP_256_R1)) {
+        /* This is going to be our fallback if the client has no preference. */
+        /* A TLS-compliant application MUST support key exchange with secp256r1 (NIST P-256) */
+        /* and SHOULD support key exchange with X25519 [RFC7748]. */
+        /* - https://tools.ietf.org/html/rfc8446#section-9.1 */
+        conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
+    } else {
+        /* P-256 is the preferred fallback option. These prefs don't support it, so choose whatever curve is first. */
+        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+    }
 
     POSIX_GUARD(s2n_extension_list_parse(in, &conn->client_hello.extensions));
 

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -664,8 +664,8 @@ int s2n_security_policies_init()
         }
 
         if (security_policy != &security_policy_null) {
-            /* catch any offending security policy that does not support P-256 */
-            S2N_ERROR_IF(!s2n_ecc_preferences_includes_curve(ecc_preference, TLS_EC_CURVE_SECP_256_R1), S2N_ERR_INVALID_SECURITY_POLICY);
+            /* All policies must have at least one ecc curve configured. */
+            S2N_ERROR_IF(ecc_preference->count == 0, S2N_ERR_INVALID_SECURITY_POLICY);
         }
 
         for (int j = 0; j < cipher_preference->count; j++) {


### PR DESCRIPTION
This change preserves the previous ecc fallback behavior while
allowing for a preference list that does not contain secp256r1.
