### PR TITLE
docs: fix a few typos

### DIFF
--- a/docs/DEVELOPMENT-GUIDE.md
+++ b/docs/DEVELOPMENT-GUIDE.md
@@ -159,7 +159,7 @@ As discussed below, s2n-tls rarely allocates resources, and so has nothing to cl
 #define DEFER_CLEANUP(_thealloc, _thecleanup) ...
 ```
 
-`GUARD_GOTO( x , label )` does traditional "goto" style cleanup: if the function `x` returns an error, control is transfered to label `label`.  It is the responsibility of the code at `label` to cleanup any resources, and then return `S2N_RESULT_ERROR`.
+`GUARD_GOTO( x , label )` does traditional "goto" style cleanup: if the function `x` returns an error, control is transferred to label `label`.  It is the responsibility of the code at `label` to cleanup any resources, and then return `S2N_RESULT_ERROR`.
 
 `DEFER_CLEANUP(_thealloc, _thecleanup)` is a more failsafe way of ensuring that resources are cleaned up, using the ` __attribute__((cleanup())` destructor mechanism available in modern C compilers.  When the variable declared in `_thealloc` goes out of scope, the cleanup function `_thecleanup` is automatically called.  This guarantees that resources will be cleaned up, no matter how the function exits.
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1208,9 +1208,9 @@ int s2n_connection_set_dynamic_record_threshold(struct s2n_connection *conn, uin
 
 **s2n_connection_prefer_throughput** and **s2n_connection_prefer_low_latency**
 change the behavior of s2n-tls when sending data to prefer either throughput
-or low latency. Connections prefering low latency will be encrypted using small
+or low latency. Connections preferring low latency will be encrypted using small
 record sizes that can be decrypted sooner by the recipient. Connections
-prefering throughput will use large record sizes that minimize overhead.
+preferring throughput will use large record sizes that minimize overhead.
 
 -Connections default to an 8k outgoing maximum
 


### PR DESCRIPTION
These are merely typo fixes in the `docs/` directory.