### PR TITLE
Make s2n_connection_get_session/session_length work for TLS1.3

### DIFF
--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -96,12 +96,13 @@ static int s2n_setup_ticket_key(struct s2n_config *config)
 
 static S2N_RESULT s2n_setup_encrypted_ticket(struct s2n_connection *conn, struct s2n_stuffer *output)
 {
-    struct s2n_ticket_fields ticket_fields = { 0 };
+    conn->tls13_ticket_fields = (struct s2n_ticket_fields) { 0 };
     uint8_t test_secret_data[] = "test secret";
-    RESULT_GUARD_POSIX(s2n_blob_init(&ticket_fields.session_secret, test_secret_data, sizeof(test_secret_data)));
+    RESULT_GUARD_POSIX(s2n_alloc(&conn->tls13_ticket_fields.session_secret, sizeof(test_secret_data)));
+    RESULT_CHECKED_MEMCPY(conn->tls13_ticket_fields.session_secret.data, test_secret_data, sizeof(test_secret_data));
 
     /* Create a valid resumption psk identity */
-    RESULT_GUARD_POSIX(s2n_encrypt_session_ticket(conn, &ticket_fields, output));
+    RESULT_GUARD_POSIX(s2n_encrypt_session_ticket(conn, output));
     output->blob.size = s2n_stuffer_data_available(output);
 
     return S2N_RESULT_OK;

--- a/tests/unit/s2n_psk_offered_test.c
+++ b/tests/unit/s2n_psk_offered_test.c
@@ -46,12 +46,13 @@ static int s2n_setup_ticket_key(struct s2n_config *config)
 
 static S2N_RESULT s2n_setup_encrypted_ticket(struct s2n_connection *conn, struct s2n_stuffer *output)
 {
-    struct s2n_ticket_fields ticket_fields = { 0 };
+    conn->tls13_ticket_fields = (struct s2n_ticket_fields) { 0 };
     uint8_t test_secret_data[] = "test secret";
-    RESULT_GUARD_POSIX(s2n_blob_init(&ticket_fields.session_secret, test_secret_data, sizeof(test_secret_data)));
+    RESULT_GUARD_POSIX(s2n_alloc(&conn->tls13_ticket_fields.session_secret, sizeof(test_secret_data)));
+    RESULT_CHECKED_MEMCPY(conn->tls13_ticket_fields.session_secret.data, test_secret_data, sizeof(test_secret_data));
 
     /* Create a valid resumption psk identity */
-    RESULT_GUARD_POSIX(s2n_encrypt_session_ticket(conn, &ticket_fields, output));
+    RESULT_GUARD_POSIX(s2n_encrypt_session_ticket(conn, output));
     output->blob.size = s2n_stuffer_data_available(output);
 
     return S2N_RESULT_OK;

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -67,6 +67,225 @@ int main(int argc, char **argv)
     "18df06843d13a08bf2a449844c5f8a"
     "478001bc4d4c627984d5a41da8d0402919");
 
+    /* s2n_connection_get_session_state_size */
+    {
+        /* Safety */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            size_t size = 0;
+            EXPECT_ERROR_WITH_ERRNO(s2n_connection_get_session_state_size(NULL, &size), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_connection_get_session_state_size(conn, NULL), S2N_ERR_NULL);
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* TLS1.2: session state is fixed */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            conn->actual_protocol_version = S2N_TLS12;
+            conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+
+            /* Result matches constant */
+            size_t actual_size = 0;
+            EXPECT_OK(s2n_connection_get_session_state_size(conn, &actual_size));
+            EXPECT_EQUAL(actual_size, S2N_TLS12_STATE_SIZE_IN_BYTES);
+
+            /* Result matches actual size of data */
+            struct s2n_stuffer actual_data = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&actual_data, actual_size));
+            EXPECT_SUCCESS(s2n_tls12_serialize_resumption_state(conn, &actual_data));
+            const uint32_t expected_size = s2n_stuffer_data_available(&actual_data);
+            if (expected_size != actual_size) {
+                fprintf(stderr, "\nS2N_TLS12_STATE_SIZE_IN_BYTES (%i) should be set to %i\n\n",
+                        S2N_TLS12_STATE_SIZE_IN_BYTES, expected_size);
+            }
+            EXPECT_EQUAL(actual_size, s2n_stuffer_data_available(&actual_data));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&actual_data));
+        }
+
+        /* Minimal TLS1.3 state: all variable fields empty, no early data */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            conn->actual_protocol_version = S2N_TLS13;
+
+            /* Result matches constant */
+            size_t actual_size = 0;
+            EXPECT_OK(s2n_connection_get_session_state_size(conn, &actual_size));
+            EXPECT_EQUAL(actual_size, S2N_TLS13_FIXED_STATE_SIZE);
+
+            /* Result matches actual size of data */
+            struct s2n_stuffer actual_data = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&actual_data, actual_size));
+            EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &actual_data));
+            const uint32_t expected_size = s2n_stuffer_data_available(&actual_data);
+            if (actual_size != expected_size) {
+                fprintf(stderr, "\nS2N_TLS13_FIXED_STATE_SIZE (%i) should be set to %i\n\n",
+                        S2N_TLS13_FIXED_STATE_SIZE, expected_size);
+            }
+            EXPECT_EQUAL(actual_size, expected_size);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&actual_data));
+        }
+
+        /* TLS1.3 with secret */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            conn->actual_protocol_version = S2N_TLS13;
+            conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
+
+            /* Set non-zero length secret */
+            uint8_t secret_size = 0;
+            EXPECT_SUCCESS(s2n_hmac_digest_size(conn->secure.cipher_suite->prf_alg, &secret_size));
+            EXPECT_SUCCESS(s2n_realloc(&conn->tls13_ticket_fields.session_secret, secret_size));
+
+            /* Result matches constant */
+            size_t actual_size = 0;
+            EXPECT_OK(s2n_connection_get_session_state_size(conn, &actual_size));
+            EXPECT_EQUAL(actual_size, S2N_TLS13_FIXED_STATE_SIZE + secret_size);
+
+            /* Result matches actual size of data */
+            struct s2n_stuffer actual_data = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&actual_data, actual_size));
+            EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &actual_data));
+            EXPECT_EQUAL(actual_size, s2n_stuffer_data_available(&actual_data));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&actual_data));
+        }
+
+        /* Minimal TLS1.3 with early data: all variable fields empty */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            conn->actual_protocol_version = S2N_TLS13;
+            EXPECT_SUCCESS(s2n_connection_set_server_max_early_data_size(conn, 1));
+
+            /* Result matches constants */
+            size_t actual_size = 0;
+            EXPECT_OK(s2n_connection_get_session_state_size(conn, &actual_size));
+            EXPECT_EQUAL(actual_size, S2N_TLS13_FIXED_STATE_SIZE + S2N_TLS13_FIXED_EARLY_DATA_STATE_SIZE);
+
+            /* Result matches actual size of data */
+            struct s2n_stuffer actual_data = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&actual_data, actual_size));
+            EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &actual_data));
+            const uint32_t expected_size = s2n_stuffer_data_available(&actual_data);
+            if (actual_size != expected_size) {
+                fprintf(stderr, "\nS2N_TLS13_FIXED_EARLY_DATA_STATE_SIZE (%i) should be set to %i\n\n",
+                        S2N_TLS13_FIXED_EARLY_DATA_STATE_SIZE, expected_size - S2N_TLS13_FIXED_STATE_SIZE);
+            }
+            EXPECT_EQUAL(actual_size, expected_size);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&actual_data));
+        }
+
+        /* TLS1.3 with early data: all variable fields set */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            conn->actual_protocol_version = S2N_TLS13;
+
+            /* Set non-zero length secret */
+            uint8_t secret_size = 0;
+            EXPECT_SUCCESS(s2n_hmac_digest_size(conn->secure.cipher_suite->prf_alg, &secret_size));
+            EXPECT_SUCCESS(s2n_alloc(&conn->tls13_ticket_fields.session_secret, secret_size));
+
+            /* Set early data fields */
+            const uint8_t data[] = "test data";
+            EXPECT_SUCCESS(s2n_connection_set_server_max_early_data_size(conn, 1));
+            EXPECT_MEMCPY_SUCCESS(conn->application_protocol, data, sizeof(data));
+            EXPECT_SUCCESS(s2n_connection_set_server_early_data_context(conn, data, sizeof(data)));
+
+            /* Result matches constants */
+            size_t actual_size = 0;
+            EXPECT_OK(s2n_connection_get_session_state_size(conn, &actual_size));
+            EXPECT_NOT_EQUAL(actual_size, 0);
+
+            /* Result matches actual size of data */
+            struct s2n_stuffer actual_data = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&actual_data, actual_size));
+            EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &actual_data));
+            EXPECT_EQUAL(actual_size, s2n_stuffer_data_available(&actual_data));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_stuffer_free(&actual_data));
+        }
+    }
+
+    /* s2n_connection_get_session_length */
+    {
+        /* Safety */
+        EXPECT_EQUAL(s2n_connection_get_session_length(NULL), 0);
+
+        /* Session Ticket */
+        {
+            const uint16_t client_ticket_size = 10;
+
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_NOT_NULL(config);
+            EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, true));
+
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            EXPECT_SUCCESS(s2n_realloc(&conn->client_ticket, client_ticket_size));
+
+            uint8_t versions[] = { S2N_TLS12, S2N_TLS13 };
+            for (size_t i = 0; i < s2n_array_len(versions); i++) {
+                conn->actual_protocol_version = versions[i];
+                int session_length = s2n_connection_get_session_length(conn);
+                EXPECT_NOT_EQUAL(session_length, 0);
+
+                /* Result matches size expected by s2n_connection_get_session */
+                DEFER_CLEANUP(struct s2n_blob session_data = { 0 }, s2n_free);
+                EXPECT_SUCCESS(s2n_alloc(&session_data, session_length));
+                EXPECT_SUCCESS(s2n_connection_get_session(conn, session_data.data, session_data.size));
+            }
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
+        }
+
+        /* Session ID */
+        {
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_NOT_NULL(config);
+            EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, true));
+            EXPECT_SUCCESS(s2n_config_set_session_cache_onoff(config, true));
+
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            conn->session_id_len = 5;
+
+            /* TLS1.3: Always zero. Stateful tickets are not yet supported. */
+            {
+                conn->actual_protocol_version = S2N_TLS13;
+                uint8_t data = 0;
+                EXPECT_EQUAL(s2n_connection_get_session_length(conn), 0);
+                EXPECT_SUCCESS(s2n_connection_get_session(conn, &data, 1));
+                EXPECT_EQUAL(data, 0);
+            }
+
+            /* TLS1.2 */
+            {
+                conn->actual_protocol_version = S2N_TLS12;
+
+                int session_length = s2n_connection_get_session_length(conn);
+                EXPECT_NOT_EQUAL(session_length, 0);
+
+                /* Result matches size expected by s2n_connection_get_session */
+                DEFER_CLEANUP(struct s2n_blob session_id_data = { 0 }, s2n_free);
+                EXPECT_SUCCESS(s2n_alloc(&session_id_data, session_length));
+                EXPECT_SUCCESS(s2n_connection_get_session(conn, session_id_data.data, session_id_data.size));
+            }
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
+        }
+    }
+
     /* s2n_tls12_serialize_resumption_state */
     {
         struct s2n_connection *conn;
@@ -117,11 +336,9 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             struct s2n_stuffer output = { 0 };
-            struct s2n_ticket_fields ticket_fields = { 0 };
 
-            EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(NULL, &ticket_fields, &output), S2N_ERR_NULL);
-            EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(conn, NULL, &output), S2N_ERR_NULL);
-            EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(conn, &ticket_fields, NULL), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(NULL, &output), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(conn, NULL), S2N_ERR_NULL);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
@@ -144,9 +361,10 @@ int main(int argc, char **argv)
             DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
 
-            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 1, .session_secret = test_session_secret };
+            conn->tls13_ticket_fields = (struct s2n_ticket_fields) { .ticket_age_add = 1 };
+            EXPECT_SUCCESS(s2n_dup(&test_session_secret, &conn->tls13_ticket_fields.session_secret));
 
-            EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &ticket_fields, &output));
+            EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &output));
             tls13_client_state_size = s2n_stuffer_data_available(&output);
 
             uint8_t serial_id = 0;
@@ -167,11 +385,11 @@ int main(int argc, char **argv)
 
             uint32_t ticket_age_add = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint32(&output, &ticket_age_add));
-            EXPECT_EQUAL(ticket_age_add, ticket_fields.ticket_age_add);
+            EXPECT_EQUAL(ticket_age_add, conn->tls13_ticket_fields.ticket_age_add);
 
             uint8_t secret_len = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &secret_len));
-            EXPECT_EQUAL(secret_len, ticket_fields.session_secret.size);
+            EXPECT_EQUAL(secret_len, conn->tls13_ticket_fields.session_secret.size);
 
             uint8_t session_secret[S2N_TLS_SECRET_LEN] = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, session_secret, secret_len));
@@ -202,13 +420,14 @@ int main(int argc, char **argv)
             DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
 
-            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 1, .session_secret = test_session_secret };
+            conn->tls13_ticket_fields = (struct s2n_ticket_fields) { .ticket_age_add = 1 };
+            EXPECT_SUCCESS(s2n_dup(&test_session_secret, &conn->tls13_ticket_fields.session_secret));
 
             /* New expiration time */
             {
                 uint64_t expected_expiration_time = ticket_issue_time + ONE_SEC_IN_NANOS;
 
-                EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &ticket_fields, &output));
+                EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &output));
                 tls13_server_state_size = s2n_stuffer_data_available(&output);
                 EXPECT_SUCCESS(s2n_stuffer_skip_read(&output, tls13_client_state_size - SIZE_OF_MAX_EARLY_DATA_SIZE));
 
@@ -230,7 +449,7 @@ int main(int argc, char **argv)
                 uint64_t expected_expiration_time = ticket_issue_time + 1;
                 chosen_psk->keying_material_expiration = expected_expiration_time;
 
-                EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &ticket_fields, &output));
+                EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &output));
                 tls13_server_state_size = s2n_stuffer_data_available(&output);
                 EXPECT_SUCCESS(s2n_stuffer_skip_read(&output, tls13_client_state_size - SIZE_OF_MAX_EARLY_DATA_SIZE));
 
@@ -247,7 +466,7 @@ int main(int argc, char **argv)
                 uint64_t expected_expiration_time = ticket_issue_time + ONE_SEC_IN_NANOS;
                 chosen_psk->keying_material_expiration = UINT64_MAX;
 
-                EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &ticket_fields, &output));
+                EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &output));
                 tls13_server_state_size = s2n_stuffer_data_available(&output);
                 EXPECT_SUCCESS(s2n_stuffer_skip_read(&output, tls13_client_state_size - SIZE_OF_MAX_EARLY_DATA_SIZE));
 
@@ -280,9 +499,10 @@ int main(int argc, char **argv)
             DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
 
-            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 1, .session_secret = test_session_secret };
+            conn->tls13_ticket_fields = (struct s2n_ticket_fields) { .ticket_age_add = 1 };
+            EXPECT_SUCCESS(s2n_dup(&test_session_secret, &conn->tls13_ticket_fields.session_secret));
 
-            EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &ticket_fields, &output));
+            EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &output));
             EXPECT_SUCCESS(s2n_stuffer_skip_read(&output, tls13_server_state_size - SIZE_OF_MAX_EARLY_DATA_SIZE));
 
             uint32_t max_early_data_size = 0;
@@ -320,10 +540,11 @@ int main(int argc, char **argv)
             DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
 
-            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 1, .session_secret = test_session_secret };
+            conn->tls13_ticket_fields = (struct s2n_ticket_fields) { .ticket_age_add = 1 };
+            EXPECT_SUCCESS(s2n_dup(&test_session_secret, &conn->tls13_ticket_fields.session_secret));
 
-            ticket_fields.session_secret.size = UINT8_MAX + 1;
-            EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(conn, &ticket_fields, &output), S2N_ERR_SAFETY);
+            conn->tls13_ticket_fields.session_secret.size = UINT8_MAX + 1;
+            EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(conn, &output), S2N_ERR_SAFETY);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
@@ -661,14 +882,15 @@ int main(int argc, char **argv)
                 DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
                 EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-                struct s2n_ticket_fields ticket_fields = { .ticket_age_add = TICKET_AGE_ADD, .session_secret = test_session_secret };
+                conn->tls13_ticket_fields = (struct s2n_ticket_fields) { .ticket_age_add = TICKET_AGE_ADD };
+                EXPECT_SUCCESS(s2n_dup(&test_session_secret, &conn->tls13_ticket_fields.session_secret));
 
                 /* Initialize client ticket */
                 uint8_t client_ticket[] = { CLIENT_TICKET };
                 EXPECT_SUCCESS(s2n_realloc(&conn->client_ticket, sizeof(client_ticket)));
                 EXPECT_MEMCPY_SUCCESS(conn->client_ticket.data, client_ticket, sizeof(client_ticket));
 
-                EXPECT_OK(s2n_serialize_resumption_state(conn, &ticket_fields, &stuffer));
+                EXPECT_OK(s2n_serialize_resumption_state(conn, &stuffer));
                 EXPECT_OK(s2n_deserialize_resumption_state(conn, &conn->client_ticket, &stuffer));
 
                 /* Check PSK values are correct */
@@ -717,12 +939,13 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
             /* Initialize client ticket */
-            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = TICKET_AGE_ADD, .session_secret = test_session_secret };
+            conn->tls13_ticket_fields = (struct s2n_ticket_fields) { .ticket_age_add = TICKET_AGE_ADD };
+            EXPECT_SUCCESS(s2n_dup(&test_session_secret, &conn->tls13_ticket_fields.session_secret));
             uint8_t client_ticket[] = { CLIENT_TICKET };
             EXPECT_SUCCESS(s2n_realloc(&conn->client_ticket, sizeof(client_ticket)));
             EXPECT_MEMCPY_SUCCESS(conn->client_ticket.data, client_ticket, sizeof(client_ticket));
 
-            EXPECT_OK(s2n_serialize_resumption_state(conn, &ticket_fields, &stuffer));
+            EXPECT_OK(s2n_serialize_resumption_state(conn, &stuffer));
             EXPECT_OK(s2n_deserialize_resumption_state(conn, &conn->client_ticket, &stuffer));
 
             /* Check PSK values are correct */
@@ -761,7 +984,7 @@ int main(int argc, char **argv)
 
                 EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &state_blob));
 
-                EXPECT_OK(s2n_serialize_resumption_state(conn, NULL, &stuffer));
+                EXPECT_OK(s2n_serialize_resumption_state(conn, &stuffer));
                 EXPECT_OK(s2n_deserialize_resumption_state(conn, NULL, &stuffer));
 
                 EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -837,7 +1060,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_blob_init(&blob, data, sizeof(data)));
             EXPECT_SUCCESS(s2n_stuffer_init(&output, &blob));
 
-            EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, NULL, &output));
+            EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, &output));
 
             /* Wiping the master secret to prove that the decryption function actually writes the master secret */
             memset(conn->secure.master_secret, 0, test_master_secret.size);
@@ -875,12 +1098,13 @@ int main(int argc, char **argv)
 
             DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
-            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 1, .session_secret = test_session_secret };
+            conn->tls13_ticket_fields = (struct s2n_ticket_fields) { .ticket_age_add = 1 };
+            EXPECT_SUCCESS(s2n_dup(&test_session_secret, &conn->tls13_ticket_fields.session_secret));
 
             /* This secret is smaller than the maximum secret length */
-            EXPECT_TRUE(ticket_fields.session_secret.size < S2N_TLS_SECRET_LEN);
+            EXPECT_TRUE(conn->tls13_ticket_fields.session_secret.size < S2N_TLS_SECRET_LEN);
 
-            EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, &ticket_fields, &output));
+            EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, &output));
             conn->client_ticket_to_decrypt = output;
             EXPECT_SUCCESS(s2n_decrypt_session_ticket(conn));
 
@@ -917,12 +1141,13 @@ int main(int argc, char **argv)
 
             DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
-            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 1, .session_secret = test_master_secret };
+            conn->tls13_ticket_fields = (struct s2n_ticket_fields) { .ticket_age_add = 1 };
+            EXPECT_SUCCESS(s2n_dup(&test_master_secret, &conn->tls13_ticket_fields.session_secret));
 
             /* This secret is equal to the maximum secret length */
-            EXPECT_EQUAL(ticket_fields.session_secret.size, S2N_TLS_SECRET_LEN);
+            EXPECT_EQUAL(conn->tls13_ticket_fields.session_secret.size, S2N_TLS_SECRET_LEN);
 
-            EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, &ticket_fields, &output));
+            EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, &output));
             conn->client_ticket_to_decrypt = output;
             EXPECT_SUCCESS(s2n_decrypt_session_ticket(conn));
 
@@ -963,9 +1188,10 @@ int main(int argc, char **argv)
 
             DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
-            struct s2n_ticket_fields ticket_fields = { .ticket_age_add = 1, .session_secret = test_master_secret };
+            conn->tls13_ticket_fields = (struct s2n_ticket_fields) { .ticket_age_add = 1 };
+            EXPECT_SUCCESS(s2n_dup(&test_master_secret, &conn->tls13_ticket_fields.session_secret));
 
-            EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, &ticket_fields, &output));
+            EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, &output));
             conn->client_ticket_to_decrypt = output;
             EXPECT_SUCCESS(s2n_decrypt_session_ticket(conn));
 

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -90,7 +90,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(actual_size, S2N_TLS12_STATE_SIZE_IN_BYTES);
 
             /* Result matches actual size of data */
-            struct s2n_stuffer actual_data = { 0 };
+            DEFER_CLEANUP(struct s2n_stuffer actual_data = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&actual_data, actual_size));
             EXPECT_SUCCESS(s2n_tls12_serialize_resumption_state(conn, &actual_data));
             const uint32_t expected_size = s2n_stuffer_data_available(&actual_data);
@@ -101,7 +101,6 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(actual_size, s2n_stuffer_data_available(&actual_data));
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
-            EXPECT_SUCCESS(s2n_stuffer_free(&actual_data));
         }
 
         /* Minimal TLS1.3 state: all variable fields empty, no early data */
@@ -115,7 +114,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(actual_size, S2N_TLS13_FIXED_STATE_SIZE);
 
             /* Result matches actual size of data */
-            struct s2n_stuffer actual_data = { 0 };
+            DEFER_CLEANUP(struct s2n_stuffer actual_data = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&actual_data, actual_size));
             EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &actual_data));
             const uint32_t expected_size = s2n_stuffer_data_available(&actual_data);
@@ -126,7 +125,6 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(actual_size, expected_size);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
-            EXPECT_SUCCESS(s2n_stuffer_free(&actual_data));
         }
 
         /* TLS1.3 with secret */
@@ -146,13 +144,12 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(actual_size, S2N_TLS13_FIXED_STATE_SIZE + secret_size);
 
             /* Result matches actual size of data */
-            struct s2n_stuffer actual_data = { 0 };
+            DEFER_CLEANUP(struct s2n_stuffer actual_data = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&actual_data, actual_size));
             EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &actual_data));
             EXPECT_EQUAL(actual_size, s2n_stuffer_data_available(&actual_data));
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
-            EXPECT_SUCCESS(s2n_stuffer_free(&actual_data));
         }
 
         /* Minimal TLS1.3 with early data: all variable fields empty */
@@ -167,7 +164,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(actual_size, S2N_TLS13_FIXED_STATE_SIZE + S2N_TLS13_FIXED_EARLY_DATA_STATE_SIZE);
 
             /* Result matches actual size of data */
-            struct s2n_stuffer actual_data = { 0 };
+            DEFER_CLEANUP(struct s2n_stuffer actual_data = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&actual_data, actual_size));
             EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &actual_data));
             const uint32_t expected_size = s2n_stuffer_data_available(&actual_data);
@@ -178,7 +175,6 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(actual_size, expected_size);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
-            EXPECT_SUCCESS(s2n_stuffer_free(&actual_data));
         }
 
         /* TLS1.3 with early data: all variable fields set */
@@ -203,13 +199,12 @@ int main(int argc, char **argv)
             EXPECT_NOT_EQUAL(actual_size, 0);
 
             /* Result matches actual size of data */
-            struct s2n_stuffer actual_data = { 0 };
+            DEFER_CLEANUP(struct s2n_stuffer actual_data = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&actual_data, actual_size));
             EXPECT_OK(s2n_tls13_serialize_resumption_state(conn, &actual_data));
             EXPECT_EQUAL(actual_size, s2n_stuffer_data_available(&actual_data));
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
-            EXPECT_SUCCESS(s2n_stuffer_free(&actual_data));
         }
     }
 

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
-        /* Minimal TLS1.3 state: all variable fields empty, no early data */
+        /* Minimal TLS1.3 state: all variable fields empty, zero-length session secret, no early data */
         {
             struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
             conn->actual_protocol_version = S2N_TLS13;
@@ -127,7 +127,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
-        /* TLS1.3 with secret */
+        /* TLS1.3 with non-zero session secret */
         {
             struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
             conn->actual_protocol_version = S2N_TLS13;

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -402,14 +402,10 @@ int main(int argc, char **argv)
         struct s2n_blob nonce = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&nonce, nonce_data, sizeof(nonce_data)));
 
-        uint8_t session_secret_data[S2N_TLS13_SECRET_MAX_LEN] = { 0 };
-        struct s2n_blob output = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&output, session_secret_data, sizeof(session_secret_data)));
-
-        EXPECT_SUCCESS(s2n_generate_session_secret(conn, &nonce, session_secret_data, &output));
-
-        EXPECT_EQUAL(output.size, expected_session_secret.size);
-        EXPECT_BYTEARRAY_EQUAL(output.data, expected_session_secret.data, expected_session_secret.size);
+        struct s2n_blob *output = &conn->tls13_ticket_fields.session_secret;
+        EXPECT_SUCCESS(s2n_generate_session_secret(conn, &nonce, output));
+        EXPECT_EQUAL(output->size, expected_session_secret.size);
+        EXPECT_BYTEARRAY_EQUAL(output->data, expected_session_secret.data, expected_session_secret.size);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
@@ -628,89 +624,6 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
             EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
-            EXPECT_SUCCESS(s2n_config_free(config));
-        }
-
-        /* Test S2N_TLS13_CLIENT_SESSION_TICKET_SIZE(conn) */
-        {
-            struct s2n_config *config = s2n_config_new();
-            EXPECT_NOT_NULL(config);
-            EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, 1));
-            EXPECT_SUCCESS(s2n_config_set_session_ticket_cb(config, s2n_test_session_ticket_cb, NULL));
-            EXPECT_SUCCESS(s2n_setup_test_ticket_key(config));
-
-            struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
-            EXPECT_NOT_NULL(client_conn);
-            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-            client_conn->actual_protocol_version = S2N_TLS13;
-            /* Cipher suite with max key size */
-            client_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-
-            struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
-            EXPECT_NOT_NULL(server_conn);
-            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-            server_conn->actual_protocol_version = S2N_TLS13;
-            /* Cipher suite with max key size */
-            server_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            /* Early data information extends ticket */
-            EXPECT_SUCCESS(s2n_connection_set_server_max_early_data_size(server_conn, 10));
-
-            DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
-            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
-
-            /* Test with no variable fields */
-            {
-                EXPECT_OK(s2n_tls13_server_nst_write(server_conn, &stuffer));
-                EXPECT_SUCCESS(s2n_stuffer_skip_read(&stuffer, sizeof(uint8_t) + SIZEOF_UINT24));
-                EXPECT_OK(s2n_tls13_server_nst_recv(client_conn, &stuffer));
-
-                EXPECT_EQUAL(S2N_TLS13_VARIABLE_SESSION_STATE_SIZE(client_conn), 0);
-                if (cb_session_data_len != S2N_TLS13_CLIENT_SESSION_TICKET_SIZE(client_conn)) {
-                    fprintf(stdout, "\nS2N_TLS13_CLIENT_SESSION_TICKET_SIZE fixed size (%i) should be %i\n",
-                            (int) S2N_TLS13_CLIENT_SESSION_TICKET_SIZE(client_conn) - client_conn->client_ticket.size,
-                            (int) cb_session_data_len - client_conn->client_ticket.size);
-                }
-                EXPECT_EQUAL(cb_session_data_len, S2N_TLS13_CLIENT_SESSION_TICKET_SIZE(client_conn));
-            }
-
-            EXPECT_SUCCESS(s2n_stuffer_wipe(&stuffer));
-
-            /* Test with some variable fields */
-            {
-                const uint8_t app_protocol[] = "https";
-                EXPECT_MEMCPY_SUCCESS(client_conn->application_protocol, app_protocol, sizeof(app_protocol));
-
-                EXPECT_OK(s2n_tls13_server_nst_write(server_conn, &stuffer));
-                EXPECT_SUCCESS(s2n_stuffer_skip_read(&stuffer, sizeof(uint8_t) + SIZEOF_UINT24));
-                EXPECT_OK(s2n_tls13_server_nst_recv(client_conn, &stuffer));
-
-                EXPECT_NOT_EQUAL(S2N_TLS13_VARIABLE_SESSION_STATE_SIZE(client_conn), 0);
-                EXPECT_EQUAL(cb_session_data_len, S2N_TLS13_CLIENT_SESSION_TICKET_SIZE(client_conn));
-            }
-
-            EXPECT_SUCCESS(s2n_stuffer_wipe(&stuffer));
-
-            /* Test with all variable fields */
-            {
-                const uint8_t early_data_context[] = "early data context";
-                EXPECT_SUCCESS(s2n_connection_set_server_early_data_context(server_conn,
-                        early_data_context, sizeof(early_data_context)));
-
-                const uint8_t app_protocol[] = "https";
-                EXPECT_MEMCPY_SUCCESS(client_conn->application_protocol, app_protocol, sizeof(app_protocol));
-                EXPECT_MEMCPY_SUCCESS(server_conn->application_protocol, app_protocol, sizeof(app_protocol));
-
-                EXPECT_OK(s2n_tls13_server_nst_write(server_conn, &stuffer));
-                EXPECT_SUCCESS(s2n_stuffer_skip_read(&stuffer, sizeof(uint8_t) + SIZEOF_UINT24));
-                EXPECT_OK(s2n_tls13_server_nst_recv(client_conn, &stuffer));
-
-                EXPECT_NOT_EQUAL(S2N_TLS13_VARIABLE_SESSION_STATE_SIZE(client_conn), 0);
-                EXPECT_NOT_EQUAL(S2N_TLS13_VARIABLE_SESSION_STATE_SIZE(server_conn), 0);
-                EXPECT_EQUAL(cb_session_data_len, S2N_TLS13_CLIENT_SESSION_TICKET_SIZE(client_conn));
-            }
-
-            EXPECT_SUCCESS(s2n_connection_free(client_conn));
-            EXPECT_SUCCESS(s2n_connection_free(server_conn));
             EXPECT_SUCCESS(s2n_config_free(config));
         }
 
@@ -1026,7 +939,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_free(config));
         }
 
-        /* Test S2N_TLS13_NEW_SESSION_TICKET_SIZE(conn) */
+        /* Test S2N_TLS13_MAX_FIXED_NEW_SESSION_TICKET_SIZE */
         {
             struct s2n_config *config = s2n_config_new();
             EXPECT_NOT_NULL(config);
@@ -1050,20 +963,25 @@ int main(int argc, char **argv)
 
             /* Test with no variable fields */
             {
+                size_t session_state_size = 0;
+                EXPECT_OK(s2n_connection_get_session_state_size(conn, &session_state_size));
+                EXPECT_NOT_EQUAL(session_state_size, 0);
+
                 s2n_blocked_status blocked = 0;
                 EXPECT_OK(s2n_tls13_server_nst_send(conn, &blocked));
                 EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&output), 0);
 
                 uint32_t expected_max_size = s2n_stuffer_data_available(&output) - S2N_TLS_RECORD_HEADER_LENGTH;
-                EXPECT_EQUAL(S2N_TLS13_VARIABLE_SESSION_STATE_SIZE(conn), 0);
-                if (S2N_TLS13_NEW_SESSION_TICKET_SIZE(conn) != expected_max_size) {
-                    fprintf(stdout, "\nS2N_TLS13_NEW_SESSION_TICKET_SIZE (%i) should be %i\n",
-                            (int) S2N_TLS13_NEW_SESSION_TICKET_SIZE(conn), expected_max_size);
+                uint32_t expected_max_fixed_size = expected_max_size - session_state_size;
+                if (S2N_TLS13_MAX_FIXED_NEW_SESSION_TICKET_SIZE != expected_max_fixed_size) {
+                    fprintf(stdout, "\nS2N_TLS13_MAX_FIXED_NEW_SESSION_TICKET_SIZE (%i) should be %i\n",
+                            (int) S2N_TLS13_MAX_FIXED_NEW_SESSION_TICKET_SIZE, expected_max_fixed_size);
                 }
-                EXPECT_EQUAL(S2N_TLS13_NEW_SESSION_TICKET_SIZE(conn), expected_max_size);
+                EXPECT_EQUAL(S2N_TLS13_MAX_FIXED_NEW_SESSION_TICKET_SIZE, expected_max_fixed_size);
             }
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&output));
+            conn->tickets_to_send++;
 
             /* Test with some variable fields */
             {
@@ -1071,17 +989,21 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_connection_set_server_early_data_context(conn,
                         early_data_context, sizeof(early_data_context)));
 
-                conn->tickets_to_send++;
+                size_t session_state_size = 0;
+                EXPECT_OK(s2n_connection_get_session_state_size(conn, &session_state_size));
+                EXPECT_NOT_EQUAL(session_state_size, 0);
+
                 s2n_blocked_status blocked = 0;
                 EXPECT_OK(s2n_tls13_server_nst_send(conn, &blocked));
                 EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&output), 0);
 
                 uint32_t expected_max_size = s2n_stuffer_data_available(&output) - S2N_TLS_RECORD_HEADER_LENGTH;
-                EXPECT_NOT_EQUAL(S2N_TLS13_VARIABLE_SESSION_STATE_SIZE(conn), 0);
-                EXPECT_EQUAL(S2N_TLS13_NEW_SESSION_TICKET_SIZE(conn), expected_max_size);
+                uint32_t expected_max_fixed_size = expected_max_size - session_state_size;
+                EXPECT_EQUAL(S2N_TLS13_MAX_FIXED_NEW_SESSION_TICKET_SIZE, expected_max_fixed_size);
             }
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&output));
+            conn->tickets_to_send++;
 
             /* Test with all variable fields */
             {
@@ -1092,14 +1014,17 @@ int main(int argc, char **argv)
                 const uint8_t app_protocol[] = "https";
                 EXPECT_MEMCPY_SUCCESS(conn->application_protocol, app_protocol, sizeof(app_protocol));
 
-                conn->tickets_to_send++;
+                size_t session_state_size = 0;
+                EXPECT_OK(s2n_connection_get_session_state_size(conn, &session_state_size));
+                EXPECT_NOT_EQUAL(session_state_size, 0);
+
                 s2n_blocked_status blocked = 0;
                 EXPECT_OK(s2n_tls13_server_nst_send(conn, &blocked));
                 EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&output), 0);
 
                 uint32_t expected_max_size = s2n_stuffer_data_available(&output) - S2N_TLS_RECORD_HEADER_LENGTH;
-                EXPECT_NOT_EQUAL(S2N_TLS13_VARIABLE_SESSION_STATE_SIZE(conn), 0);
-                EXPECT_EQUAL(S2N_TLS13_NEW_SESSION_TICKET_SIZE(conn), expected_max_size);
+                uint32_t expected_max_fixed_size = expected_max_size - session_state_size;
+                EXPECT_EQUAL(S2N_TLS13_MAX_FIXED_NEW_SESSION_TICKET_SIZE, expected_max_fixed_size);
             }
 
             EXPECT_SUCCESS(s2n_stuffer_free(&output));

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -1145,9 +1145,8 @@ int main(int argc, char **argv)
 
     EXPECT_SUCCESS(s2n_reset_tls13());
 
-    /* Session resumption APIs and session_ticket_cb return sane values
+    /* Session resumption APIs and session_ticket_cb return the same values
      * when receiving a new ticket in TLS1.3
-     * TODO: https://github.com/aws/s2n-tls/issues/2553
      */
     {
         struct s2n_config *config = s2n_config_new();
@@ -1155,10 +1154,13 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, ecdsa_chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, 1));
-        EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(config, S2N_SESSION_STATE_CONFIGURABLE_LIFETIME_IN_SECS));
         EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(config, ticket_key_name1, strlen((char *)ticket_key_name1),
                 ticket_key1, sizeof(ticket_key1), 0));
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+
+        /* Freeze time */
+        POSIX_GUARD(config->wall_clock(config->sys_clock_ctx, &now));
+        EXPECT_OK(s2n_config_mock_wall_clock(config, &now));
 
         /* Send one NewSessionTicket */
         cb_session_data_len = 0;
@@ -1179,6 +1181,9 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
 
+        /* Old TLS1.2 customer code will likely attempt to read the ticket here -- ensure we indicate no ticket yet */
+        EXPECT_EQUAL(s2n_connection_get_session_length(client_conn), 0);
+
         /* Receive and save the issued session ticket for the next test */
         s2n_blocked_status blocked = S2N_NOT_BLOCKED;
         uint8_t out = 0;
@@ -1188,6 +1193,13 @@ int main(int argc, char **argv)
 
         /* Verify correct session ticket lifetime "hint" */
         EXPECT_EQUAL(s2n_connection_get_session_ticket_lifetime_hint(client_conn), cb_session_lifetime);
+
+        /* Verify the old session ticket APIs produce the same results as the callback */
+        DEFER_CLEANUP(struct s2n_blob legacy_api_ticket = { 0 }, s2n_free);
+        EXPECT_SUCCESS(s2n_realloc(&legacy_api_ticket, cb_session_data_len));
+        EXPECT_EQUAL(s2n_connection_get_session_length(client_conn), cb_session_data_len);
+        EXPECT_SUCCESS(s2n_connection_get_session(client_conn, legacy_api_ticket.data, legacy_api_ticket.size));
+        EXPECT_BYTEARRAY_EQUAL(cb_session_data, legacy_api_ticket.data, legacy_api_ticket.size);
 
         EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -1194,7 +1194,7 @@ int main(int argc, char **argv)
         /* Verify correct session ticket lifetime "hint" */
         EXPECT_EQUAL(s2n_connection_get_session_ticket_lifetime_hint(client_conn), cb_session_lifetime);
 
-        /* Verify the old session ticket APIs produce the same results as the callback */
+        /* Verify the session ticket APIs produce the same results as the callback */
         DEFER_CLEANUP(struct s2n_blob legacy_api_ticket = { 0 }, s2n_free);
         EXPECT_SUCCESS(s2n_realloc(&legacy_api_ticket, cb_session_data_len));
         EXPECT_EQUAL(s2n_connection_get_session_length(client_conn), cb_session_data_len);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -470,6 +470,7 @@ int s2n_connection_free(struct s2n_connection *conn)
     POSIX_GUARD(s2n_free(&conn->our_quic_transport_parameters));
     POSIX_GUARD(s2n_free(&conn->peer_quic_transport_parameters));
     POSIX_GUARD(s2n_free(&conn->server_early_data_context));
+    POSIX_GUARD(s2n_free(&conn->tls13_ticket_fields.session_secret));
     POSIX_GUARD(s2n_stuffer_free(&conn->in));
     POSIX_GUARD(s2n_stuffer_free(&conn->out));
     POSIX_GUARD(s2n_stuffer_free(&conn->handshake.io));
@@ -659,6 +660,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     POSIX_GUARD(s2n_free(&conn->our_quic_transport_parameters));
     POSIX_GUARD(s2n_free(&conn->peer_quic_transport_parameters));
     POSIX_GUARD(s2n_free(&conn->server_early_data_context));
+    POSIX_GUARD(s2n_free(&conn->tls13_ticket_fields.session_secret));
 
     /* Allocate memory for handling handshakes */
     POSIX_GUARD(s2n_stuffer_resize(&conn->handshake.io, S2N_LARGE_RECORD_LENGTH));

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -304,6 +304,7 @@ struct s2n_connection {
     s2n_session_ticket_status session_ticket_status;
     struct s2n_blob client_ticket;
     uint32_t ticket_lifetime_hint;
+    struct s2n_ticket_fields tls13_ticket_fields;
 
     /* Session ticket extension from client to attempt to decrypt as the server. */
     uint8_t ticket_ext_data[S2N_TLS12_TICKET_SIZE_IN_BYTES];

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -159,7 +159,7 @@ static int s2n_tls12_deserialize_resumption_state(struct s2n_connection *conn, s
     return 0;
 }
 
-int s2n_client_serialize_resumption_state(struct s2n_connection *conn, struct s2n_stuffer *to)
+static int s2n_client_serialize_resumption_state(struct s2n_connection *conn, struct s2n_stuffer *to)
 {
     /* Serialize session ticket */
    if (conn->config->use_tickets && conn->client_ticket.size > 0) {

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -87,14 +87,13 @@ static S2N_RESULT s2n_tls13_serialize_keying_material_expiration(struct s2n_conn
     return S2N_RESULT_OK;
 }
 
-static S2N_RESULT s2n_tls13_serialize_resumption_state(struct s2n_connection *conn, struct s2n_ticket_fields *ticket_fields,
-        struct s2n_stuffer *out)
+static S2N_RESULT s2n_tls13_serialize_resumption_state(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     RESULT_ENSURE_REF(conn);
-    RESULT_ENSURE_REF(ticket_fields);
     RESULT_ENSURE_REF(out);
 
     uint64_t current_time = 0;
+    struct s2n_ticket_fields *ticket_fields = &conn->tls13_ticket_fields;
 
     /* Get the time */
     RESULT_GUARD_POSIX(conn->config->wall_clock(conn->config->sys_clock_ctx, &current_time));
@@ -123,13 +122,12 @@ static S2N_RESULT s2n_tls13_serialize_resumption_state(struct s2n_connection *co
     return S2N_RESULT_OK;
 }
 
-static S2N_RESULT s2n_serialize_resumption_state(struct s2n_connection *conn, struct s2n_ticket_fields *ticket_fields,
-        struct s2n_stuffer *out)
+static S2N_RESULT s2n_serialize_resumption_state(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     if(conn->actual_protocol_version < S2N_TLS13) {
         RESULT_GUARD_POSIX(s2n_tls12_serialize_resumption_state(conn, out));
     } else {
-        RESULT_GUARD(s2n_tls13_serialize_resumption_state(conn, ticket_fields, out));
+        RESULT_GUARD(s2n_tls13_serialize_resumption_state(conn, out));
     }
     return S2N_RESULT_OK;
 }
@@ -161,7 +159,7 @@ static int s2n_tls12_deserialize_resumption_state(struct s2n_connection *conn, s
     return 0;
 }
 
-int s2n_client_serialize_resumption_state(struct s2n_connection *conn, struct s2n_ticket_fields *ticket_fields, struct s2n_stuffer *to)
+int s2n_client_serialize_resumption_state(struct s2n_connection *conn, struct s2n_stuffer *to)
 {
     /* Serialize session ticket */
    if (conn->config->use_tickets && conn->client_ticket.size > 0) {
@@ -176,7 +174,7 @@ int s2n_client_serialize_resumption_state(struct s2n_connection *conn, struct s2
    }
 
     /* Serialize session state */
-    POSIX_GUARD_RESULT(s2n_serialize_resumption_state(conn, ticket_fields, to));
+    POSIX_GUARD_RESULT(s2n_serialize_resumption_state(conn, to));
 
     return 0;
 }
@@ -447,7 +445,7 @@ int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, si
 
     struct s2n_stuffer to = {0};
     POSIX_GUARD(s2n_stuffer_init(&to, &serialized_data));
-    POSIX_GUARD(s2n_client_serialize_resumption_state(conn, NULL, &to));
+    POSIX_GUARD(s2n_client_serialize_resumption_state(conn, &to));
 
     return len;
 }
@@ -461,17 +459,58 @@ int s2n_connection_get_session_ticket_lifetime_hint(struct s2n_connection *conn)
     return conn->ticket_lifetime_hint;
 }
 
+S2N_RESULT s2n_connection_get_session_state_size(struct s2n_connection *conn, size_t *state_size)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(state_size);
+
+    if (conn->actual_protocol_version < S2N_TLS13) {
+        *state_size = S2N_TLS12_STATE_SIZE_IN_BYTES;
+        return S2N_RESULT_OK;
+    }
+
+    *state_size = S2N_TLS13_FIXED_STATE_SIZE;
+
+    uint8_t secret_size = 0;
+    RESULT_ENSURE_REF(conn->secure.cipher_suite);
+    RESULT_GUARD_POSIX(s2n_hmac_digest_size(conn->secure.cipher_suite->prf_alg, &secret_size));
+    *state_size += secret_size;
+
+    uint32_t server_max_early_data = 0;
+    RESULT_GUARD(s2n_early_data_get_server_max_size(conn, &server_max_early_data));
+    if (server_max_early_data > 0) {
+        *state_size += S2N_TLS13_FIXED_EARLY_DATA_STATE_SIZE
+                + strlen(conn->application_protocol)
+                + conn->server_early_data_context.size;
+    }
+
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_connection_get_session_length_impl(struct s2n_connection *conn, size_t *length)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn->config);
+    RESULT_ENSURE_REF(length);
+    *length = 0;
+
+    if (conn->config->use_tickets && conn->client_ticket.size > 0) {
+        size_t session_state_size = 0;
+        RESULT_GUARD(s2n_connection_get_session_state_size(conn, &session_state_size));
+        *length = S2N_STATE_FORMAT_LEN + S2N_SESSION_TICKET_SIZE_LEN + conn->client_ticket.size + session_state_size;
+    } else if (conn->session_id_len > 0 && conn->actual_protocol_version < S2N_TLS13) {
+        *length = S2N_STATE_FORMAT_LEN + sizeof(conn->session_id_len) + conn->session_id_len + S2N_TLS12_STATE_SIZE_IN_BYTES;
+    }
+    return S2N_RESULT_OK;
+}
+
 int s2n_connection_get_session_length(struct s2n_connection *conn)
 {
-    /* Session resumption using session ticket "format (1) + session_ticket_len + session_ticket + session state" */
-    if (conn->config->use_tickets && conn->client_ticket.size > 0) {
-        return S2N_STATE_FORMAT_LEN + S2N_SESSION_TICKET_SIZE_LEN + conn->client_ticket.size + S2N_TLS12_STATE_SIZE_IN_BYTES;
-    } else if (conn->session_id_len > 0) {
-        /* Session resumption using session id: "format (0) + session_id_len + session_id + session state" */
-        return S2N_STATE_FORMAT_LEN + 1 + conn->session_id_len + S2N_TLS12_STATE_SIZE_IN_BYTES;
-    } else {
-        return 0;
+    size_t length = 0;
+    if (s2n_result_is_ok(s2n_connection_get_session_length_impl(conn, &length))) {
+        return length;
     }
+    return 0;
 }
 
 int s2n_connection_is_session_resumed(struct s2n_connection *conn)
@@ -645,7 +684,7 @@ struct s2n_ticket_key *s2n_find_ticket_key(struct s2n_config *config, const uint
     return NULL;
 }
 
-int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_ticket_fields *ticket_fields, struct s2n_stuffer *to)
+int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *to)
 {
     struct s2n_ticket_key *key;
     struct s2n_session_key aes_ticket_key = {0};
@@ -680,7 +719,7 @@ int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_ticket_fi
     POSIX_GUARD(s2n_stuffer_write_bytes(&aad, key->key_name, S2N_TICKET_KEY_NAME_LEN));
 
     uint32_t plaintext_header_size = s2n_stuffer_data_available(to);
-    POSIX_GUARD_RESULT(s2n_serialize_resumption_state(conn, ticket_fields, to));
+    POSIX_GUARD_RESULT(s2n_serialize_resumption_state(conn, to));
     POSIX_GUARD(s2n_stuffer_skip_write(to, S2N_TLS_GCM_TAG_LEN));
 
     struct s2n_blob state_blob = { 0 };
@@ -770,7 +809,7 @@ int s2n_decrypt_session_ticket(struct s2n_connection *conn)
 
 int s2n_encrypt_session_cache(struct s2n_connection *conn, struct s2n_stuffer *to)
 {
-    return s2n_encrypt_session_ticket(conn, NULL, to);
+    return s2n_encrypt_session_ticket(conn, to);
 }
 
 int s2n_decrypt_session_cache(struct s2n_connection *conn, struct s2n_stuffer *from)

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -22,6 +22,9 @@
 #define S2N_STATE_LIFETIME_IN_NANOS     54000000000000      /* 15 hours */
 #define S2N_TLS12_STATE_SIZE_IN_BYTES   (1 + 8 + 1 + S2N_TLS_CIPHER_SUITE_LEN + S2N_TLS_SECRET_LEN)
 
+#define S2N_TLS13_FIXED_STATE_SIZE              21
+#define S2N_TLS13_FIXED_EARLY_DATA_STATE_SIZE   3
+
 #define S2N_TLS_SESSION_CACHE_TTL       (6 * 60 * 60)
 #define S2N_TICKET_KEY_NAME_LEN         16
 #define S2N_TICKET_AAD_IMPLICIT_LEN     12
@@ -72,7 +75,7 @@ struct s2n_session_ticket {
 };
 
 extern struct s2n_ticket_key *s2n_find_ticket_key(struct s2n_config *config, const uint8_t *name);
-extern int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_ticket_fields *ticket_fields, struct s2n_stuffer *to);
+extern int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *to);
 extern int s2n_decrypt_session_ticket(struct s2n_connection *conn);
 extern int s2n_encrypt_session_cache(struct s2n_connection *conn, struct s2n_stuffer *to); 
 extern int s2n_decrypt_session_cache(struct s2n_connection *conn, struct s2n_stuffer *from); 
@@ -94,7 +97,7 @@ typedef enum {
 extern int s2n_allowed_to_cache_connection(struct s2n_connection *conn);
 extern int s2n_resume_from_cache(struct s2n_connection *conn);
 extern int s2n_store_to_cache(struct s2n_connection *conn);
-int s2n_client_serialize_resumption_state(struct s2n_connection *conn, struct s2n_ticket_fields *ticket_fields, struct s2n_stuffer *to);
+S2N_RESULT s2n_connection_get_session_state_size(struct s2n_connection *conn, size_t *state_size);
 
 /* These functions will be labeled S2N_API and become a publicly visible api 
  * once we release the session resumption API. */

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -32,6 +32,15 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_random.h"
 
+/*
+ * The maximum size of the NewSessionTicket message, not taking into account the
+ * ticket itself.
+ *
+ * To get the actual maximum size required for the NewSessionTicket message, we'll need
+ * to add the size of the ticket, which is much less predictable.
+ *
+ * This constant is enforced via unit tests.
+ */
 #define S2N_TLS13_MAX_FIXED_NEW_SESSION_TICKET_SIZE 79
 
 int s2n_server_nst_recv(struct s2n_connection *conn) {
@@ -343,7 +352,7 @@ S2N_RESULT s2n_tls13_server_nst_recv(struct s2n_connection *conn, struct s2n_stu
         /* Retrieve serialized session data */
         const uint16_t session_state_size = s2n_connection_get_session_length(conn);
         DEFER_CLEANUP(struct s2n_blob session_state = { 0 }, s2n_free);
-        RESULT_GUARD_POSIX(s2n_alloc(&session_state, session_state_size));
+        RESULT_GUARD_POSIX(s2n_realloc(&session_state, session_state_size));
         RESULT_GUARD_POSIX(s2n_connection_get_session(conn, session_state.data, session_state.size));
 
         struct s2n_session_ticket ticket = {


### PR DESCRIPTION
### Related issues:

https://github.com/aws/s2n-tls/issues/2553

### Description of changes: 

Previously s2n_connection_get_session and s2n_connection_get_session_length did not return correct values for TLS1.3, even if a ticket had been received. Now they do, IF the ticket was received via s2n_recv first.

### Call-outs:

**Other APIs**: Addressing other TLS1.2 APIs will be handled separately (although if there are any you want to make sure I touch, add them to #2553). The changes are clearer if I don't mix them all together.

### Testing:
Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
