### PR TITLE
Make s2n_connection_get_session_ticket_lifetime_hint work with TLS1.3

### DIFF
--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -1164,6 +1164,9 @@ int main(int argc, char **argv)
         EXPECT_NOT_EQUAL(cb_session_data_len, 0);
         EXPECT_SUCCESS(s2n_stuffer_write_bytes(&tls13_serialized_session_state, cb_session_data, cb_session_data_len));
 
+        /* Verify correct session ticket lifetime "hint" */
+        EXPECT_EQUAL(s2n_connection_get_session_ticket_lifetime_hint(client_conn), cb_session_lifetime);
+
         EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -324,6 +324,8 @@ S2N_RESULT s2n_tls13_server_nst_recv(struct s2n_connection *conn, struct s2n_stu
         if (ticket_lifetime == 0) {
             return S2N_RESULT_OK;
         }
+        conn->ticket_lifetime_hint = ticket_lifetime;
+
         struct s2n_ticket_fields ticket_fields = { 0 };
         RESULT_GUARD_POSIX(s2n_stuffer_read_uint32(input, &ticket_fields.ticket_age_add));
 


### PR DESCRIPTION
### Related issues:

https://github.com/aws/s2n-tls/issues/2553

### Description of changes: 

The easiest of the backwards compatibility PRs ;) Previously, s2n_connection_get_session_ticket_lifetime_hint returned nothing for TLS1.3. Now, if a ticket was received, it will return the ticket lifetime.

### Call-outs:

**Other APIs**: Addressing other TLS1.2 APIs will be handled separately (although if there are any you want to make sure I touch, add them to #2553). The changes are clearer if I don't mix them all together.

### Testing:
Unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
