### PR TITLE
Adds session-resumption self-talk tests

### DIFF
--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -43,7 +43,7 @@
 const uint64_t ticket_issue_time = 283686952306183;
 const uint64_t keying_material_expiration = 283686952306184;
 
-static int s2n_test_session_ticket_callback(void *ctx, struct s2n_connection *conn, struct s2n_session_ticket *ticket)
+static int s2n_test_session_ticket_callback(struct s2n_connection *conn, void *ctx, struct s2n_session_ticket *ticket)
 {
     return S2N_SUCCESS;
 }

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -43,7 +43,7 @@
 const uint64_t ticket_issue_time = 283686952306183;
 const uint64_t keying_material_expiration = 283686952306184;
 
-static int s2n_test_session_ticket_callback(struct s2n_connection *conn, struct s2n_session_ticket *ticket)
+static int s2n_test_session_ticket_callback(void *ctx, struct s2n_connection *conn, struct s2n_session_ticket *ticket)
 {
     return S2N_SUCCESS;
 }

--- a/tests/unit/s2n_self_talk_session_resumption_test.c
+++ b/tests/unit/s2n_self_talk_session_resumption_test.c
@@ -1,0 +1,360 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#define ARE_FULL_HANDSHAKES(client, server) \
+    (IS_FULL_HANDSHAKE(client) && IS_FULL_HANDSHAKE(server))
+
+#define IS_HELLO_RETRY(client, server)                          \
+    (((client->handshake.handshake_type) & HELLO_RETRY_REQUEST) \
+     && ((server->handshake.handshake_type) & HELLO_RETRY_REQUEST))
+
+static int s2n_test_session_ticket_cb(void *ctx, struct s2n_connection *conn, struct s2n_session_ticket *ticket)
+{
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(ticket);
+
+    size_t data_len = 0;
+    EXPECT_SUCCESS(s2n_session_ticket_get_data_len(ticket, &data_len));
+
+    struct s2n_stuffer *stuffer = (struct s2n_stuffer *) ctx;
+    EXPECT_SUCCESS(s2n_stuffer_resize(stuffer, data_len));
+    EXPECT_SUCCESS(s2n_session_ticket_get_data(ticket, data_len, stuffer->blob.data));
+    EXPECT_SUCCESS(s2n_stuffer_skip_write(stuffer, data_len));
+
+    return S2N_SUCCESS;
+}
+
+static int s2n_setup_test_ticket_key(struct s2n_config *config)
+{
+    POSIX_ENSURE_REF(config);
+
+    /**
+     *= https://tools.ietf.org/rfc/rfc5869#appendix-A.1
+     *# PRK  = 0x077709362c2e32df0ddc3f0dc47bba63
+     *#        90b6c73bb50f9c3122ec844ad7c2b3e5 (32 octets)
+     **/
+    S2N_BLOB_FROM_HEX(ticket_key,
+    "077709362c2e32df0ddc3f0dc47bba63"
+    "90b6c73bb50f9c3122ec844ad7c2b3e5");
+
+    /* Set up encryption key */
+    uint64_t current_time = 0;
+    uint8_t ticket_key_name[16] = "2016.07.26.15\0";
+    EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, 1));
+    EXPECT_SUCCESS(config->wall_clock(config->sys_clock_ctx, &current_time));
+    EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(config, ticket_key_name, strlen((char *)ticket_key_name),
+                    ticket_key.data, ticket_key.size, current_time/ONE_SEC_IN_NANOS));
+
+    return S2N_SUCCESS;
+}
+
+static S2N_RESULT s2n_test_recv_new_session_ticket(struct s2n_connection *conn)
+{
+    RESULT_ENSURE_REF(conn);
+
+    s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+    uint8_t out = 0;
+    EXPECT_FAILURE_WITH_ERRNO(s2n_recv(conn, &out, 1, &blocked), S2N_ERR_IO_BLOCKED);
+    
+    return S2N_RESULT_OK;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Setup server config */
+    struct s2n_config *server_config = s2n_config_new();
+    EXPECT_NOT_NULL(server_config);
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "default_tls13"));
+    EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(server_config));
+    struct s2n_cert_chain_and_key *tls13_chain_and_key = NULL;
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&tls13_chain_and_key, S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN,
+                                                   S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, tls13_chain_and_key));
+    struct s2n_cert_chain_and_key *tls12_chain_and_key = NULL;
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&tls12_chain_and_key, S2N_DEFAULT_TEST_CERT_CHAIN, 
+                                                   S2N_DEFAULT_TEST_PRIVATE_KEY));
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, tls12_chain_and_key));
+    EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, true));
+    EXPECT_SUCCESS(s2n_setup_test_ticket_key(server_config));
+
+    /* Setup TLS1.3 client config */
+    struct s2n_config *tls13_client_config = s2n_config_new();
+    EXPECT_NOT_NULL(tls13_client_config);
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(tls13_client_config, "default_tls13"));
+    EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(tls13_client_config));
+    EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(tls13_client_config, true));
+    DEFER_CLEANUP(struct s2n_stuffer cb_session_data = { 0 }, s2n_stuffer_free);
+    EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&cb_session_data, 0));
+    EXPECT_SUCCESS(s2n_config_set_session_ticket_cb(tls13_client_config, s2n_test_session_ticket_cb, &cb_session_data));
+
+    /* Setup TLS1.2 client config */
+    struct s2n_config *tls12_client_config = s2n_config_new();
+    EXPECT_NOT_NULL(tls12_client_config);
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(tls12_client_config, "20170210"));
+    EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(tls12_client_config));
+    EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(tls12_client_config, true));
+
+    /* Test: Server and client resume a session multiple times */
+    {
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_NOT_NULL(server_conn);
+
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls13_client_config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair = { 0 };
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        /* Negotiate initial handshake to get session ticket */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_TRUE(ARE_FULL_HANDSHAKES(client_conn, server_conn));
+
+        /* Receive and save the issued session ticket for the next connection */
+        EXPECT_OK(s2n_test_recv_new_session_ticket(client_conn));
+
+        for (size_t i = 0; i < 10; i++) {
+            /* Prepare client and server for new connection */
+            EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+            EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+            EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+            /* Client sets up a resumption connection with the received session ticket data */
+            size_t cb_session_data_len = s2n_stuffer_data_available(&cb_session_data);
+            EXPECT_SUCCESS(s2n_connection_set_session(client_conn, cb_session_data.blob.data, cb_session_data_len));
+            EXPECT_SUCCESS(s2n_stuffer_rewrite(&cb_session_data));
+
+            /* Negotiate new connection */
+            EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+            EXPECT_FALSE(ARE_FULL_HANDSHAKES(client_conn, server_conn));
+
+            /* Receive and save the issued session ticket for the next connection */
+            EXPECT_OK(s2n_test_recv_new_session_ticket(client_conn));
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+        EXPECT_SUCCESS(s2n_stuffer_rewrite(&cb_session_data));
+    }
+
+    /* Test: Server does not accept an expired ticket and instead does a full handshake */
+    {
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_NOT_NULL(server_conn);
+
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls13_client_config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair = { 0 };
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        /* Negotiate initial handshake to get session ticket */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_TRUE(ARE_FULL_HANDSHAKES(client_conn, server_conn));
+
+        /* Receive and save the issued session ticket for the next connection */
+        EXPECT_OK(s2n_test_recv_new_session_ticket(client_conn));
+
+        /* Prepare client and server for new connection */
+        EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+        EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        /* Client sets up a resumption connection with the received session ticket data */
+        size_t cb_session_data_len = s2n_stuffer_data_available(&cb_session_data);
+        EXPECT_SUCCESS(s2n_connection_set_session(client_conn, cb_session_data.blob.data, cb_session_data_len));
+        EXPECT_SUCCESS(s2n_stuffer_rewrite(&cb_session_data));
+
+        /* Setup conditions to make the server think the ticket has expired */
+        EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(server_config, 0));
+
+        /* Negotiate new connection */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_TRUE(ARE_FULL_HANDSHAKES(client_conn, server_conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+        EXPECT_SUCCESS(s2n_stuffer_rewrite(&cb_session_data));
+        EXPECT_SUCCESS(s2n_config_set_session_state_lifetime(server_config, S2N_STATE_LIFETIME_IN_NANOS));
+    }
+
+    /* Test: A TLS1.2 client with a valid TLS1.3 ticket falls back to a TLS1.2 connection */
+    {
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_NOT_NULL(server_conn);
+
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls13_client_config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair = { 0 };
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        /* Negotiate initial handshake to produce TLS1.3 session ticket */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_TRUE(ARE_FULL_HANDSHAKES(client_conn, server_conn));
+
+        /* Receive and save the issued session ticket for the next connection */
+        EXPECT_OK(s2n_test_recv_new_session_ticket(client_conn));
+
+        /* Prepare client and server for a second connection */
+        EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+        EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        /* Client sets up a resumption connection with the received session ticket data */
+        size_t cb_session_data_len = s2n_stuffer_data_available(&cb_session_data);
+        EXPECT_SUCCESS(s2n_connection_set_session(client_conn, cb_session_data.blob.data, cb_session_data_len));
+        EXPECT_SUCCESS(s2n_stuffer_rewrite(&cb_session_data));
+
+        /* Set client config to TLS1.2 cipher preferences */
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls12_client_config));
+
+        /* Negotiate second connection */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+        /* Falls back to TLS1.2 handshake */
+        EXPECT_TRUE(ARE_FULL_HANDSHAKES(client_conn, server_conn));
+        EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+    }
+
+    /* HRR with session resumption */
+    {
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_NOT_NULL(server_conn);
+
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls13_client_config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair = { 0 };
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(client_conn, "none"));
+
+        /* Negotiate handshake */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+        /* Validate handshake type */
+        EXPECT_TRUE(IS_HELLO_RETRY(client_conn, server_conn));
+        EXPECT_TRUE(ARE_FULL_HANDSHAKES(client_conn, server_conn));
+
+        /* Receive and save the issued session ticket for the next connection */
+        EXPECT_OK(s2n_test_recv_new_session_ticket(client_conn));
+
+        /* Prepare client and server for new connection */
+        EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+        EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        /* Client sets up a resumption connection with the received session ticket data */
+        size_t cb_session_data_len = s2n_stuffer_data_available(&cb_session_data);
+        EXPECT_SUCCESS(s2n_connection_set_session(client_conn, cb_session_data.blob.data, cb_session_data_len));
+        EXPECT_SUCCESS(s2n_stuffer_rewrite(&cb_session_data));
+
+        /* Negotiate new connection */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_FALSE(ARE_FULL_HANDSHAKES(client_conn, server_conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+    }
+
+    /* Test: A client with a valid TLS1.2 session ticket and TLS1.3 cipher preferences
+     * will fail connecting to a TLS1.3 server. This is because the server
+     * interprets the client as a TLS1.2 client and sends the client a TLS1.2 Server Hello.
+     * The client receives this TLS1.2 Server Hello and errors, because the client 
+     * views the TLS1.2 Server Hello as a downgrade attack, given that the client advertised
+     * its TLS1.3 ability in the Client Hello.
+     */
+    {
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_NOT_NULL(server_conn);
+
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls12_client_config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair = { 0 };
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        /* Negotiate initial handshake to produce TLS1.2 session ticket */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_TRUE(ARE_FULL_HANDSHAKES(client_conn, server_conn));
+        EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
+
+        /* Store the TLS1.2 session ticket */
+        size_t tls12_session_ticket_len = s2n_connection_get_session_length(client_conn);
+        uint8_t tls12_session_ticket[S2N_TLS12_SESSION_SIZE] = { 0 };
+        EXPECT_SUCCESS(s2n_connection_get_session(client_conn, tls12_session_ticket, tls12_session_ticket_len));
+
+        /* Prepare client and server for a second connection */
+        EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+        EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
+
+        /* Client sets up a resumption connection with the received TLS1.2 session ticket data */
+        EXPECT_SUCCESS(s2n_connection_set_session(client_conn, tls12_session_ticket, tls12_session_ticket_len));
+
+        /* Set client config to TLS1.3 cipher preferences */
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls13_client_config));
+
+        /* Negotiate second connection */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_test_server_and_client(server_conn, client_conn), S2N_ERR_PROTOCOL_DOWNGRADE_DETECTED);
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+    }
+
+    /* Clean-up */
+    EXPECT_SUCCESS(s2n_config_free(server_config));
+    EXPECT_SUCCESS(s2n_config_free(tls13_client_config));
+    EXPECT_SUCCESS(s2n_config_free(tls12_client_config));
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_free(tls13_chain_and_key));
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_free(tls12_chain_and_key));
+
+    END_TEST();
+}

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -39,7 +39,7 @@
 size_t cb_session_data_len = 0;
 uint8_t cb_session_data[MAX_TEST_SESSION_SIZE] = { 0 };
 uint32_t cb_session_lifetime = 0;
-static int s2n_test_session_ticket_cb(void *ctx, struct s2n_connection *conn, struct s2n_session_ticket *ticket)
+static int s2n_test_session_ticket_cb(struct s2n_connection *conn, void *ctx, struct s2n_session_ticket *ticket)
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(ticket);
@@ -408,36 +408,6 @@ int main(int argc, char **argv)
         EXPECT_BYTEARRAY_EQUAL(output->data, expected_session_secret.data, expected_session_secret.size);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
-    }
-
-    /* s2n_server_nst_recv */
-    { 
-         /* Does not read ticket message if config->use_tickets is not set */  
-        {
-            struct s2n_config *config = s2n_config_new();
-            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
-            EXPECT_NOT_NULL(conn);
-            EXPECT_NOT_NULL(config);
-
-            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
-
-            /* Set up input stuffer */
-            DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
-            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
-
-            uint8_t test_ticket[] = { TEST_TICKET };
-            struct s2n_blob nst_message = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&nst_message, test_ticket, sizeof(test_ticket)));
-            EXPECT_SUCCESS(s2n_stuffer_write(&conn->handshake.io, &nst_message));
-
-            EXPECT_SUCCESS(s2n_server_nst_recv(conn));
-
-            EXPECT_EQUAL(conn->client_ticket.size, 0);
-            EXPECT_TRUE(s2n_stuffer_data_available(&conn->handshake.io) > 0);
-
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-            EXPECT_SUCCESS(s2n_config_free(config));
-        }
     }
 
     /* s2n_tls13_server_nst_recv */

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -39,7 +39,7 @@
 size_t cb_session_data_len = 0;
 uint8_t cb_session_data[MAX_TEST_SESSION_SIZE] = { 0 };
 uint32_t cb_session_lifetime = 0;
-static int s2n_test_session_ticket_cb(struct s2n_connection *conn, struct s2n_session_ticket *ticket)
+static int s2n_test_session_ticket_cb(void *ctx, struct s2n_connection *conn, struct s2n_session_ticket *ticket)
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(ticket);
@@ -410,6 +410,36 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
+    /* s2n_server_nst_recv */
+    { 
+         /* Does not read ticket message if config->use_tickets is not set */  
+        {
+            struct s2n_config *config = s2n_config_new();
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_NOT_NULL(config);
+
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+            /* Set up input stuffer */
+            DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+
+            uint8_t test_ticket[] = { TEST_TICKET };
+            struct s2n_blob nst_message = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&nst_message, test_ticket, sizeof(test_ticket)));
+            EXPECT_SUCCESS(s2n_stuffer_write(&conn->handshake.io, &nst_message));
+
+            EXPECT_SUCCESS(s2n_server_nst_recv(conn));
+
+            EXPECT_EQUAL(conn->client_ticket.size, 0);
+            EXPECT_TRUE(s2n_stuffer_data_available(&conn->handshake.io) > 0);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
+        }
+    }
+
     /* s2n_tls13_server_nst_recv */
     {
         uint8_t test_ticket[] = { TEST_TICKET };
@@ -422,6 +452,32 @@ int main(int argc, char **argv)
             TEST_TICKET,         /* ticket */
             0x00, 0x00,          /* extensions len */
         };
+
+        /* Does not read ticket message if config->use_tickets is not set */
+        {
+            struct s2n_config *config = s2n_config_new();
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_NOT_NULL(config);
+
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+            /* Set up input stuffer */
+            DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+
+            struct s2n_blob nst_message = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&nst_message, nst_data, sizeof(nst_data)));
+            EXPECT_SUCCESS(s2n_stuffer_write(&input, &nst_message));
+
+            EXPECT_OK(s2n_tls13_server_nst_recv(conn, &input));
+
+            EXPECT_EQUAL(conn->client_ticket.size, 0);
+            EXPECT_TRUE(s2n_stuffer_data_available(&input) > 0);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
+        }
 
         /* Tests session_ticket_cb correctly serializes session data from an arbitrary new session ticket message */
         {

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -53,7 +53,7 @@ static int mock_time(void *data, uint64_t *nanoseconds)
 uint8_t cb_session_data[S2N_TLS12_SESSION_SIZE * 2] = { 0 };
 size_t cb_session_data_len = 0;
 uint32_t cb_session_lifetime = 0;
-static int s2n_test_session_ticket_callback(struct s2n_connection *conn, struct s2n_session_ticket *ticket)
+static int s2n_test_session_ticket_callback(void *ctx, struct s2n_connection *conn, struct s2n_session_ticket *ticket)
 {
     EXPECT_NOT_NULL(conn);
     EXPECT_NOT_NULL(ticket);

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -53,7 +53,7 @@ static int mock_time(void *data, uint64_t *nanoseconds)
 uint8_t cb_session_data[S2N_TLS12_SESSION_SIZE * 2] = { 0 };
 size_t cb_session_data_len = 0;
 uint32_t cb_session_lifetime = 0;
-static int s2n_test_session_ticket_callback(void *ctx, struct s2n_connection *conn, struct s2n_session_ticket *ticket)
+static int s2n_test_session_ticket_callback(struct s2n_connection *conn, void *ctx, struct s2n_session_ticket *ticket)
 {
     EXPECT_NOT_NULL(conn);
     EXPECT_NOT_NULL(ticket);

--- a/tests/unit/s2n_tls13_new_session_ticket_test.c
+++ b/tests/unit/s2n_tls13_new_session_ticket_test.c
@@ -28,7 +28,7 @@
 #define MAX_TEST_SESSION_SIZE 300
 
 uint8_t session_ticket_counter = 0;
-static int s2n_test_session_ticket_cb(struct s2n_connection *conn, struct s2n_session_ticket *ticket)
+static int s2n_test_session_ticket_cb(void *ctx, struct s2n_connection *conn, struct s2n_session_ticket *ticket)
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(ticket);

--- a/tests/unit/s2n_tls13_new_session_ticket_test.c
+++ b/tests/unit/s2n_tls13_new_session_ticket_test.c
@@ -28,7 +28,7 @@
 #define MAX_TEST_SESSION_SIZE 300
 
 uint8_t session_ticket_counter = 0;
-static int s2n_test_session_ticket_cb(void *ctx, struct s2n_connection *conn, struct s2n_session_ticket *ticket)
+static int s2n_test_session_ticket_cb(struct s2n_connection *conn, void *ctx, struct s2n_session_ticket *ticket)
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(ticket);

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -305,7 +305,7 @@ static S2N_RESULT s2n_validate_ticket_lifetime(struct s2n_connection *conn, uint
      * may wrap, resulting in the modulo 2^32 operation. */
     uint32_t ticket_age_in_millis = obfuscated_ticket_age - ticket_age_add;
     uint32_t session_lifetime_in_millis = conn->config->session_state_lifetime_in_nanos / ONE_MILLISEC_IN_NANOS;
-    RESULT_ENSURE(ticket_age_in_millis <= session_lifetime_in_millis, S2N_ERR_INVALID_SESSION_TICKET);
+    RESULT_ENSURE(ticket_age_in_millis < session_lifetime_in_millis, S2N_ERR_INVALID_SESSION_TICKET);
 
     return S2N_RESULT_OK;
 }

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -322,7 +322,7 @@ int s2n_offered_psk_list_choose_psk(struct s2n_offered_psk_list *psk_list, struc
         return S2N_SUCCESS;
     }
     
-    if (psk_params->type == S2N_PSK_TYPE_RESUMPTION) {
+    if (psk_params->type == S2N_PSK_TYPE_RESUMPTION && psk_list->conn->config->use_tickets) {
         POSIX_GUARD(s2n_stuffer_init(&psk_list->conn->client_ticket_to_decrypt, &psk->identity));
         POSIX_GUARD(s2n_stuffer_skip_write(&psk_list->conn->client_ticket_to_decrypt, psk->identity.size));
 

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -168,6 +168,7 @@ static int s2n_client_serialize_resumption_state(struct s2n_connection *conn, st
        POSIX_GUARD(s2n_stuffer_write(to, &conn->client_ticket));
    } else {
        /* Serialize session id */
+       POSIX_ENSURE_LT(conn->actual_protocol_version, S2N_TLS13);
        POSIX_GUARD(s2n_stuffer_write_uint8(to, S2N_STATE_WITH_SESSION_ID));
        POSIX_GUARD(s2n_stuffer_write_uint8(to, conn->session_id_len));
        POSIX_GUARD(s2n_stuffer_write_bytes(to, conn->session_id, conn->session_id_len));

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -106,7 +106,7 @@ int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t 
 int s2n_connection_set_server_keying_material_lifetime(struct s2n_connection *conn, uint32_t lifetime_in_secs);
 
 struct s2n_session_ticket;
-typedef int (*s2n_session_ticket_fn)(void *ctx, struct s2n_connection *conn, struct s2n_session_ticket *ticket);
+typedef int (*s2n_session_ticket_fn)(struct s2n_connection *conn, void *ctx, struct s2n_session_ticket *ticket);
 int s2n_config_set_session_ticket_cb(struct s2n_config *config, s2n_session_ticket_fn callback, void *ctx);
 int s2n_session_ticket_get_data_len(struct s2n_session_ticket *ticket, size_t *data_len);
 int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, size_t max_data_len, uint8_t *data);

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -106,7 +106,7 @@ int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t 
 int s2n_connection_set_server_keying_material_lifetime(struct s2n_connection *conn, uint32_t lifetime_in_secs);
 
 struct s2n_session_ticket;
-typedef int (*s2n_session_ticket_fn)(struct s2n_connection *conn, struct s2n_session_ticket *ticket);
+typedef int (*s2n_session_ticket_fn)(void *ctx, struct s2n_connection *conn, struct s2n_session_ticket *ticket);
 int s2n_config_set_session_ticket_cb(struct s2n_config *config, s2n_session_ticket_fn callback, void *ctx);
 int s2n_session_ticket_get_data_len(struct s2n_session_ticket *ticket, size_t *data_len);
 int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, size_t max_data_len, uint8_t *data);

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -44,9 +44,6 @@
 #define S2N_TLS13_MAX_FIXED_NEW_SESSION_TICKET_SIZE 79
 
 int s2n_server_nst_recv(struct s2n_connection *conn) {
-    if (!conn->config->use_tickets) {
-        return S2N_SUCCESS;
-    }
 
     POSIX_GUARD(s2n_stuffer_read_uint32(&conn->handshake.io, &conn->ticket_lifetime_hint));
 
@@ -72,7 +69,7 @@ int s2n_server_nst_recv(struct s2n_connection *conn) {
 
             struct s2n_session_ticket ticket = { .ticket_data = mem, .session_lifetime = session_lifetime };
 
-            POSIX_GUARD(conn->config->session_ticket_cb(conn->config->session_ticket_ctx, conn, &ticket));
+            POSIX_GUARD(conn->config->session_ticket_cb(conn, conn->config->session_ticket_ctx, &ticket));
         }
     }
 
@@ -366,7 +363,7 @@ S2N_RESULT s2n_tls13_server_nst_recv(struct s2n_connection *conn, struct s2n_stu
                 .ticket_data = session_state,
                 .session_lifetime = session_lifetime
         };
-        RESULT_GUARD_POSIX(conn->config->session_ticket_cb(conn->config->session_ticket_ctx, conn, &ticket));
+        RESULT_GUARD_POSIX(conn->config->session_ticket_cb(conn, conn->config->session_ticket_ctx, &ticket));
     }
 
     return S2N_RESULT_OK;

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -44,7 +44,6 @@
 #define S2N_TLS13_MAX_FIXED_NEW_SESSION_TICKET_SIZE 79
 
 int s2n_server_nst_recv(struct s2n_connection *conn) {
-
     POSIX_GUARD(s2n_stuffer_read_uint32(&conn->handshake.io, &conn->ticket_lifetime_hint));
 
     uint16_t session_ticket_len;


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Adds several tls13 session resumption self-talk tests.
### Call-outs:
Couple of small fixes with this pr:
1. The session resumption callback did not have a way of accessing the context stored on the connection.
2. Session ticket message will now not be read unless use_tickets is on.
### Testing:

Functional tests

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
