### PR TITLE
Avoid arithmetic operations on NULL pointers

### DIFF
--- a/crypto/s2n_dhe.c
+++ b/crypto/s2n_dhe.c
@@ -142,7 +142,7 @@ int s2n_pkcs3_to_dh_params(struct s2n_dh_params *dh_params, struct s2n_blob *pkc
     uint8_t *original_ptr = pkcs3->data;
     dh_params->dh         = d2i_DHparams(NULL, ( const unsigned char ** )( void * )&pkcs3->data, pkcs3->size);
     POSIX_GUARD(s2n_check_p_g_dh_params(dh_params));
-    if (pkcs3->data - original_ptr != pkcs3->size) {
+    if (pkcs3->data && (pkcs3->data - original_ptr != pkcs3->size)) {
         DH_free(dh_params->dh);
         POSIX_BAIL(S2N_ERR_INVALID_PKCS3);
     }

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -228,7 +228,7 @@ void *s2n_stuffer_raw_read(struct s2n_stuffer *stuffer, uint32_t data_len)
 
     stuffer->tainted = 1;
 
-    return stuffer->blob.data + stuffer->read_cursor - data_len;
+    return (stuffer->blob.data) ? (stuffer->blob.data + stuffer->read_cursor - data_len) : NULL;
 }
 
 int s2n_stuffer_read(struct s2n_stuffer *stuffer, struct s2n_blob *out)
@@ -242,7 +242,7 @@ int s2n_stuffer_erase_and_read(struct s2n_stuffer *stuffer, struct s2n_blob *out
 {
     POSIX_GUARD(s2n_stuffer_skip_read(stuffer, out->size));
 
-    void *ptr = stuffer->blob.data + stuffer->read_cursor - out->size;
+    void *ptr = (stuffer->blob.data) ? (stuffer->blob.data + stuffer->read_cursor - out->size) : NULL;
     POSIX_ENSURE(S2N_MEM_IS_READABLE(ptr, out->size), S2N_ERR_NULL);
 
     POSIX_CHECKED_MEMCPY(out->data, ptr, out->size);
@@ -292,7 +292,7 @@ void *s2n_stuffer_raw_write(struct s2n_stuffer *stuffer, const uint32_t data_len
 
     stuffer->tainted = 1;
 
-    return stuffer->blob.data + stuffer->write_cursor - data_len;
+    return (stuffer->blob.data) ? (stuffer->blob.data + stuffer->write_cursor - data_len) : NULL;
 }
 
 int s2n_stuffer_write(struct s2n_stuffer *stuffer, const struct s2n_blob *in)
@@ -358,8 +358,8 @@ static int s2n_stuffer_copy_impl(struct s2n_stuffer *from, struct s2n_stuffer *t
     POSIX_GUARD(s2n_stuffer_skip_read(from, len));
     POSIX_GUARD(s2n_stuffer_skip_write(to, len));
 
-    uint8_t *from_ptr = from->blob.data + from->read_cursor - len;
-    uint8_t *to_ptr = to->blob.data + to->write_cursor - len;
+    uint8_t *from_ptr = (from->blob.data) ? (from->blob.data + from->read_cursor - len) : NULL;
+    uint8_t *to_ptr = (to->blob.data) ? (to->blob.data + to->write_cursor - len) : NULL;
 
     POSIX_CHECKED_MEMCPY(to_ptr, from_ptr, len);
 

--- a/stuffer/s2n_stuffer_file.c
+++ b/stuffer/s2n_stuffer_file.c
@@ -29,6 +29,7 @@
 int s2n_stuffer_recv_from_fd(struct s2n_stuffer *stuffer, const int rfd, const uint32_t len, uint32_t *bytes_written)
 {
     POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+
     /* Make sure we have enough space to write */
     POSIX_GUARD(s2n_stuffer_skip_write(stuffer, len));
 
@@ -37,8 +38,8 @@ int s2n_stuffer_recv_from_fd(struct s2n_stuffer *stuffer, const int rfd, const u
 
     ssize_t r = 0;
     do {
+        POSIX_ENSURE(stuffer->blob.data && (r >= 0 || errno == EINTR), S2N_ERR_READ);
         r = read(rfd, stuffer->blob.data + stuffer->write_cursor, len);
-        POSIX_ENSURE(r >= 0 || errno == EINTR, S2N_ERR_READ);
     } while (r < 0);
 
     /* Record just how many bytes we have written */
@@ -60,8 +61,8 @@ int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, const int wfd, const uin
 
     ssize_t w = 0;
     do {
+        POSIX_ENSURE(stuffer->blob.data && (w >= 0 || errno == EINTR), S2N_ERR_WRITE);
         w = write(wfd, stuffer->blob.data + stuffer->read_cursor, len);
-        POSIX_ENSURE(w >= 0 || errno == EINTR, S2N_ERR_WRITE);
     } while (w < 0);
 
     POSIX_ENSURE(w <= UINT32_MAX - stuffer->read_cursor, S2N_ERR_INTEGER_OVERFLOW);

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -25,7 +25,7 @@ int s2n_stuffer_write_network_order(struct s2n_stuffer *stuffer, const uint64_t 
 {
     POSIX_ENSURE(length <= sizeof(input), S2N_ERR_SAFETY);
     POSIX_GUARD(s2n_stuffer_skip_write(stuffer, length));
-    uint8_t *data = stuffer->blob.data + stuffer->write_cursor - length;
+    uint8_t *data = (stuffer->blob.data) ? (stuffer->blob.data + stuffer->write_cursor - length) : NULL;
 
     for (int i = 0; i < length; i++) {
         S2N_INVARIANT(i <= length);

--- a/tests/cbmc/proofs/s2n_blob_slice/s2n_blob_slice_harness.c
+++ b/tests/cbmc/proofs/s2n_blob_slice/s2n_blob_slice_harness.c
@@ -44,7 +44,9 @@ void s2n_blob_slice_harness()
         assert(slice->size == size);
         assert(slice->growable == 0);
         assert(slice->allocated == 0);
-        assert_bytes_match(blob->data + offset, slice->data, slice->size);
+        if (blob->data) {
+            assert_bytes_match(blob->data + offset, slice->data, slice->size);
+        }
     } else {
         assert_blob_equivalence(slice, &old_slice, &old_byte_from_slice);
     }

--- a/tests/cbmc/proofs/s2n_dh_params_to_p_g_Ys/Makefile
+++ b/tests/cbmc/proofs/s2n_dh_params_to_p_g_Ys/Makefile
@@ -37,7 +37,10 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
 
-UNWINDSET +=
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_free
+REMOVE_FUNCTION_BODY += s2n_realloc
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 
 UNWINDSET += s2n_stuffer_write_network_order.4:9
 

--- a/tests/cbmc/proofs/s2n_realloc/s2n_realloc_harness.c
+++ b/tests/cbmc/proofs/s2n_realloc/s2n_realloc_harness.c
@@ -53,7 +53,9 @@ void s2n_realloc_harness()
             }
 #pragma CPROVER check pop
         } else {
-            assert_all_zeroes(blob->data + blob->size, old_blob.size - blob->size);
+            if(blob->data) {
+                assert_all_zeroes(blob->data + blob->size, old_blob.size - blob->size);
+            }
         }
     }
 }

--- a/tests/cbmc/proofs/s2n_stuffer_erase_and_read/s2n_stuffer_erase_and_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_erase_and_read/s2n_stuffer_erase_and_read_harness.c
@@ -38,13 +38,13 @@ void s2n_stuffer_erase_and_read_harness()
 
     /* Store a byte from the stuffer to compare if the copy succeeds */
     struct store_byte_from_buffer copied_byte;
-    if (s2n_stuffer_data_available(stuffer) >= blob->size) {
+    if (stuffer->blob.data && s2n_stuffer_data_available(stuffer) >= blob->size) {
         save_byte_from_array(&stuffer->blob.data[ old_stuffer.read_cursor ], blob->size, &copied_byte);
     }
 
     if (s2n_stuffer_erase_and_read(stuffer, blob) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + old_blob.size);
-        assert_all_zeroes(&(old_stuffer.blob.data[ old_stuffer.read_cursor ]), old_blob.size);
+        if (old_stuffer.blob.data) assert_all_zeroes(&(old_stuffer.blob.data[ old_stuffer.read_cursor ]), old_blob.size);
         assert_byte_from_blob_matches(blob, &copied_byte);
     } else {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);

--- a/tests/cbmc/proofs/s2n_stuffer_erase_and_read_bytes/s2n_stuffer_erase_and_read_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_erase_and_read_bytes/s2n_stuffer_erase_and_read_bytes_harness.c
@@ -32,13 +32,13 @@ void s2n_stuffer_erase_and_read_bytes_harness()
     save_byte_from_blob(&stuffer->blob, &old_byte);
 
     struct store_byte_from_buffer copied_byte;
-    if (s2n_stuffer_data_available(stuffer) >= blob->size) {
+    if (stuffer->blob.data && s2n_stuffer_data_available(stuffer) >= blob->size) {
         save_byte_from_array(&stuffer->blob.data[ old_stuffer.read_cursor ], blob->size, &copied_byte);
     }
 
     if (s2n_stuffer_erase_and_read_bytes(stuffer, blob->data, blob->size) == S2N_SUCCESS) {
         assert(stuffer->read_cursor == old_stuffer.read_cursor + old_blob.size);
-        assert_all_zeroes(&(stuffer->blob.data[ old_stuffer.read_cursor ]), old_blob.size);
+        if (stuffer->blob.data) assert_all_zeroes(&(stuffer->blob.data[ old_stuffer.read_cursor ]), old_blob.size);
         assert_byte_from_blob_matches(blob, &copied_byte);
     } else {
         assert(stuffer->read_cursor == old_stuffer.read_cursor);

--- a/tests/cbmc/proofs/s2n_stuffer_read_bytes/s2n_stuffer_read_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_bytes/s2n_stuffer_read_bytes_harness.c
@@ -38,7 +38,7 @@ void s2n_stuffer_read_bytes_harness()
 
     /* Store a byte from the stuffer to compare if the copy succeeds */
     struct store_byte_from_buffer copied_byte;
-    if (s2n_stuffer_data_available(stuffer) >= blob->size) {
+    if (stuffer->blob.data && s2n_stuffer_data_available(stuffer) >= blob->size) {
         save_byte_from_array(&stuffer->blob.data[ old_stuffer.read_cursor ], blob->size, &copied_byte);
     }
 

--- a/tests/cbmc/proofs/s2n_stuffer_send_to_fd/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_send_to_fd/Makefile
@@ -35,6 +35,8 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
 
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+
 UNWINDSET += s2n_stuffer_send_to_fd.5:3
 
 include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_write_network_order/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_write_network_order/Makefile
@@ -34,6 +34,7 @@ PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_blob_slice
 REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
 

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -61,7 +61,7 @@ int s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint32_t of
     uint32_t slice_size = 0;
     POSIX_GUARD(s2n_add_overflow(offset, size, &slice_size));
     POSIX_ENSURE(b->size >= slice_size, S2N_ERR_SIZE_MISMATCH);
-    slice->data = b->data + offset;
+    slice->data = (b->data) ? (b->data + offset) : NULL;
     slice->size = size;
     slice->growable = 0;
     slice->allocated = 0;


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

### Resolved issues:

N/A.

### Description of changes: 

Arithmetic operations on NULL pointers are undefined behavior.
https://stackoverflow.com/questions/22103758/pointer-arithmetic-with-nulls/22103835
https://stackoverflow.com/questions/54232894/c-null-pointer-arithmetic


### Call-outs:
N/A.

### Testing:
N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
