### PR TITLE
ci: add unit test to s2n_codebuild.sh

### DIFF
--- a/codebuild/bin/install_openssl_1_1_1.sh
+++ b/codebuild/bin/install_openssl_1_1_1.sh
@@ -29,7 +29,7 @@ BUILD_DIR=$1
 INSTALL_DIR=$2
 OS_NAME=$3
 source codebuild/bin/jobs.sh
-RELEASE=1_1_1g
+RELEASE=1_1_1k
 
 cd "$BUILD_DIR"
 curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_${RELEASE}.zip --output OpenSSL_${RELEASE}.zip

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -13,12 +13,9 @@
 # permissions and limitations under the License.
 #
 
-set -ex
+set -e
 
 source codebuild/bin/s2n_setup_env.sh
-# Defer overriding LD_LIBRARY_PATH so that the overriden paths don't interfere with test install scripts.
-# Some Test install scripts use curl commands to download files from S3, but those commands don't work when forced to load OpenSSL 1.1.1
-source codebuild/bin/s2n_override_paths.sh
 
 # Use prlimit to set the memlock limit to unlimited for linux. OSX is unlimited by default
 # Codebuild Containers aren't allowing prlimit changes (and aren't being caught with the usual cgroup check)
@@ -67,6 +64,7 @@ fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMACPlus" ]] && [[ "$OS_NAME" == "linux" ]]; then make -C tests/saw tmp/verify_HMAC.log tmp/verify_drbg.log sike failure-tests; fi
 
 # Run Individual tests
+if [[ "$TESTS" == "ALL" || "$TESTS" == "unit" ]]; then cmake . -Bbuild -DCMAKE_PREFIX_PATH=$LIBCRYPTO_ROOT; cmake --build ./build; make -C build test ARGS=-j$(nproc); fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "asan" ]]; then make clean; S2N_ADDRESS_SANITIZER=1 make -j $JOBS ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integration" ]]; then make clean; make integration ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2" ]]; then make clean; make integrationv2 ; fi
@@ -80,7 +78,7 @@ if [[ "$TESTS" == "sawHMACFailure" ]]; then make -C tests/saw failure-tests ; fi
 if [[ "$TESTS" == "sawSIKE" ]]; then make -C tests/saw sike ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawBIKE" ]]; then make -C tests/saw bike ; fi
 
-# Generate *.gcov files that can be picked up by the CodeCov.io Bash helper script. Don't run lcov or genhtml 
+# Generate *.gcov files that can be picked up by the CodeCov.io Bash helper script. Don't run lcov or genhtml
 # since those will delete .gcov files as they're processed.
 if [[ "$CODECOV_IO_UPLOAD" == "true" && "$FUZZ_COVERAGE" != "true" ]]; then
     make run-gcov;

--- a/codebuild/bin/s2n_setup_env.sh
+++ b/codebuild/bin/s2n_setup_env.sh
@@ -50,28 +50,28 @@
 : "${GB_INSTALL_DIR:=$TEST_DEPS_DIR/gb}"
 : "${FUZZ_TIMEOUT_SEC:=10}"
 
-  # Set some environment vars for OS, Distro and architecture.
-  # Standardized as part of systemd http://0pointer.de/blog/projects/os-release
-  # Samples:
-  #  OS_NAME = "linux"
-  #  DISTRO="ubuntu"
-  #  VERSION_ID = "18.04"
-  #  VERSION_CODENAME = "bionic"
-  if [[ -f "/etc/os-release" ]]; then
-    # AL2 doesn't provide a codename.
-    . /etc/os-release
-    export DISTRO=$(echo "$NAME"|tr "[:upper:]" "[:lower:]")
-    export VERSION_ID=${VERSION_ID:-"unknown"}
-    export VERSION_CODENAME=${VERSION_CODENAME:-"unknown"}
-  elif [[ -x "/usr/bin/sw_vers" ]]; then
-    export DISTRO="apple"
-    export VERSION_ID=$(sw_vers -productVersion|sed 's/:[[:space:]]*/=/g')
-    export VERSION_CODENAME="unknown"  # not queriable via CLI
-  else
-    export DISTRO="unknown"
-    export VERSION_ID="unknown"
-    export VERSION_CODENAME="unknown"
-  fi
+# Set some environment vars for OS, Distro and architecture.
+# Standardized as part of systemd http://0pointer.de/blog/projects/os-release
+# Samples:
+#  OS_NAME = "linux"
+#  DISTRO="ubuntu"
+#  VERSION_ID = "18.04"
+#  VERSION_CODENAME = "bionic"
+if [[ -f "/etc/os-release" ]]; then
+  # AL2 doesn't provide a codename.
+  . /etc/os-release
+  export DISTRO=$(echo "$NAME"|tr "[:upper:]" "[:lower:]")
+  export VERSION_ID=${VERSION_ID:-"unknown"}
+  export VERSION_CODENAME=${VERSION_CODENAME:-"unknown"}
+elif [[ -x "/usr/bin/sw_vers" ]]; then
+  export DISTRO="apple"
+  export VERSION_ID=$(sw_vers -productVersion|sed 's/:[[:space:]]*/=/g')
+  export VERSION_CODENAME="unknown"  # not queriable via CLI
+else
+  export DISTRO="unknown"
+  export VERSION_ID="unknown"
+  export VERSION_CODENAME="unknown"
+fi
 export OS_NAME=$(uname -s|tr "[:upper:]" "[:lower:]")
 export ARCH=$(uname -m)
 
@@ -133,6 +133,34 @@ rm -rf libcrypto-root && ln -s "$LIBCRYPTO_ROOT" libcrypto-root
 
 # Set the libfuzzer to use for fuzz tests
 export LIBFUZZER_ROOT=$LIBFUZZER_INSTALL_DIR
+
+#check if the path contains test dep X, if not and X exists, add to path
+path_overrides="$PYTHON_INSTALL_DIR/bin
+$OPENSSL_1_1_1_INSTALL_DIR/bin
+$GNUTLS_INSTALL_DIR/bin
+$SAW_INSTALL_DIR/bin
+$Z3_INSTALL_DIR/bin
+$SCAN_BUILD_INSTALL_DIR/bin
+$PRLIMIT_INSTALL_DIR/bin
+$LATEST_CLANG_INSTALL_DIR/bin
+`pwd`/codebuild/bin
+~/.local/bin"
+
+testdeps_path(){
+    echo -ne "checking $1 is in the path..."
+    if [[ ! "$PATH" =~ "$1" ]]; then
+        if [[ -d "$1" ]]; then
+            export PATH="$1:$PATH"
+            echo -e "added"
+        else
+            echo -e "doesn't exist"
+        fi
+    else
+        echo -e "already in path"
+    fi
+}
+
+for i in $path_overrides; do testdeps_path "$i" ;done
 
 # Just recording in the output for debugging.
 if [ -f "/etc/lsb-release" ]; then


### PR DESCRIPTION
### Resolved issues:

Call out in #2771 

### Description of changes: 

We only test with S2N_NO_PQ in longer running daily CI, not PRs.  This change adds an explicit unit test to the scripts, using cmake.  Note the environment variable will live in a buildspec, requiring a future commit (with no PR testing).

### Call-outs:

- Bump the OpenSSL 1.1.1 version to `k` from `g`.
- removes problematic s2n_override_paths.sh from CI (breaks LD_LIBRARY_PATH in some cases)
- Buildspec changes will be added separately - with an env var of S2N_NO_PQ=1

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? 
 passing one off [CodeBuild](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nGeneralBatch/build/s2nGeneralBatch%3A21130d10-c50c-4047-881a-2c0bb0df3663/log?region=us-west-2) job

 Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
