### PR TITLE
Remove all occurrences of `#pragma check disable`

### DIFF
--- a/tests/sidetrail/working/patches/safety.patch
+++ b/tests/sidetrail/working/patches/safety.patch
@@ -20,6 +20,7 @@ index ae8e5783..cc06a2d0 100644
 -    S2N_PUBLIC_INPUT(src);
 -    S2N_PUBLIC_INPUT(len);
 -
- /* This underflows a value of 0 to the maximum value via arithmetic underflow,
-  * so the check for arithmetic overflow/underflow needs to be disabled for CBMC.
-  * Additionally, uint_fast16_t is defined as the fastest available unsigned
+     uint8_t mask = (((0xFFFF & dont) - 1) >> 8) & 0xFF;
+
+     /* dont = 0 : mask = 0xff */
+     /* dont > 0 : mask = 0x00 */

--- a/utils/s2n_str.c
+++ b/utils/s2n_str.c
@@ -17,17 +17,9 @@
 #include "utils/s2n_str.h"
 
 char *s2n_strcpy(char *buf, char *last, const char *str) {
-
-/* CBMC pointer checks need to be disabled to compare buf and last for
- * the case where they are the same. */
-#pragma CPROVER check push
-#pragma CPROVER check disable "pointer"
-
     if (buf >= last) {
         return buf;
     }
-
-#pragma CPROVER check pop
 
     if (NULL == str) {
         *buf = '\0';


### PR DESCRIPTION
[Inspired by #2774]

### Resolved issues:

N/A

### Description of changes: 

These `#pragma` directives turn off CBMC's safety checks, so should be avoided as much as possible.

### Call-outs:

N/A

### Testing:

The CBMC harnesses should still pass after these changes (and should run more checks that were previously disabled).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.