### PR TITLE
ci: Codebuild al2 scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,23 +36,32 @@ An example of building on OSX:
 
 ```sh
 # Install required dependencies using homebrew
-brew install ninja cmake
+brew install ninja cmake coreutils openssl@1.1
 
 # Clone the s2n-tls source repository into the `s2n-tls` directory
 git clone https://github.com/${YOUR_GITHUB_ACCOUNT_NAME}/s2n-tls.git
+cd s2n-tls
 
-# Create a build directory parallel to the source directory
-mkdir s2n_tls_build
-
-# From the build directory, build s2n-tls with debug symbols and a specific OpenSSL version
-cd s2n_tls_build
-cmake -GNinja \
+# Create a build directory, and build s2n-tls with debug symbols and a specific OpenSSL version.
+cmake . -Bbuild -GNinja \
     -DCMAKE_BUILD_TYPE=Debug \
-    -DCMAKE_PREFIX_PATH=$(dirname $(dirname $(brew list openssl@1.1|grep libcrypto.dylib))) \
-    ../s2n-tls
-ninja -j6
-CTEST_PARALLEL_LEVEL=5 ninja test
+    -DCMAKE_PREFIX_PATH=$(dirname $(dirname $(brew list openssl@1.1|grep libcrypto.dylib)))
+cmake --build ./build -j $(nproc)
+CTEST_PARALLEL_LEVEL=$(nproc) ninja -C build test
 ```
+
+### Amazonlinux2
+
+Install dependancies with `./codebuild/bin/install_al2_dependencies.sh` after cloning.
+
+```sh
+git clone https://github.com/${YOUR_GITHUB_ACCOUNT_NAME}/s2n-tls.git
+cd s2n-tls
+cmake . -Bbuild -DCMAKE_EXE_LINKER_FLAGS="-lcrypto -lz" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+cmake --build ./build -j $(nproc)
+CTEST_PARALLEL_LEVEL=$(nproc) make -C build test
+```
+
 
 ## Have a Question?
 If you have any questions about Submitting PR's, Opening Issues, s2n-tls API usage, or something similar, we have a public chatroom available here to answer your questions: https://gitter.im/aws/s2n-tls

--- a/codebuild/bin/install_al2_dependencies.sh
+++ b/codebuild/bin/install_al2_dependencies.sh
@@ -16,6 +16,11 @@
 set -eu
 source ./codebuild/bin/s2n_setup_env.sh
 
+if [[ ${DISTRO} != "amazon linux" ]]; then
+    echo "Target AL2, but running on $DISTRO: Nothing to do."
+    exit 0
+fi
+
 base_packages() {
     yum update -y
     yum erase -y openssl-devel || true
@@ -49,5 +54,5 @@ symlink_all_the_things() {
 base_packages
 mono
 yum groupinstall -y "Development tools"
-yum install -y which nettle-devel openssl11-devel which sudo python3-pip cmake3 tcpdump unzip zlib-devel libtool ninja-build wget
+yum install -y clang cmake3 iproute net-tools nettle-devel nettle openssl11-static openssl11-libs openssl11-devel which sudo psmisc python3-pip  tcpdump unzip zlib-devel libtool ninja-build valgrind  wget which
 symlink_all_the_things

--- a/codebuild/bin/s2n_codebuild_al2.sh
+++ b/codebuild/bin/s2n_codebuild_al2.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -e
+
+source codebuild/bin/s2n_setup_env.sh
+# Use prlimit to set the memlock limit to unlimited for linux. OSX is unlimited by default
+# Codebuild Containers aren't allowing prlimit changes (and aren't being caught with the usual cgroup check)
+if [[ "$OS_NAME" == "linux" && -n "$CODEBUILD_BUILD_ARN" ]]; then
+    PRLIMIT_LOCATION=`which prlimit`
+    sudo -E ${PRLIMIT_LOCATION} --pid "$$" --memlock=unlimited:unlimited;
+fi
+
+# Linker flags are a workaround for openssl
+case "$TESTS" in
+  "unit") cmake . -Bbuild -DCMAKE_EXE_LINKER_FLAGS="-lcrypto -lz" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          cmake --build ./build -j $(nproc)
+          CTEST_PARALLEL_LEVEL=$(nproc) make -C build test
+  *) echo "Unknown test"
+     exit 1;;
+esac
+

--- a/codebuild/spec/buildspec_amazonlinux2.in
+++ b/codebuild/spec/buildspec_amazonlinux2.in
@@ -16,11 +16,7 @@ phases:
           cd third-party-src;
         fi
       - ./codebuild/bin/install_al2_dependencies.sh
-      - ./codebuild/bin/install_default_dependencies.sh
   build:
     commands:
       - printenv
-      - $CB_BIN_DIR/s2n_codebuild.sh
-  post_build:
-    commands:
-      - echo Build completed on `date`
+      - $CB_BIN_DIR/s2n_codebuild_al2.sh


### PR DESCRIPTION
### Resolved issues:

Incremental steps for AL2 (tangentially #387  )

### Description of changes: 

Minimal scripting to get to AL2 unit testing in CI without touching the existing Ubuntu specific bits.

The README updates are not required, willing to move those out if needed.

### Call-outs:

The buildspec file is an example template- naming it .in prevents this from being blocked by the buildspec filter in CI.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? local AL2 instance.

 Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
