### PR TITLE
Fix incorrect blob resize

### DIFF
--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -538,7 +538,7 @@ int main(int argc, char **argv)
             conn->tls13_ticket_fields = (struct s2n_ticket_fields) { .ticket_age_add = 1 };
             EXPECT_SUCCESS(s2n_dup(&test_session_secret, &conn->tls13_ticket_fields.session_secret));
 
-            conn->tls13_ticket_fields.session_secret.size = UINT8_MAX + 1;
+            EXPECT_SUCCESS(s2n_realloc(&conn->tls13_ticket_fields.session_secret, UINT8_MAX + 1));
             EXPECT_ERROR_WITH_ERRNO(s2n_tls13_serialize_resumption_state(conn, &output), S2N_ERR_SAFETY);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));


### PR DESCRIPTION
### Description of changes: 

In order to test an incorrect secret size, we were setting the size of the secret blob to larger than the size of the memory actually allocated for the blob. This was leading to issues freeing the blob.

### Call-outs:

I did a quick search for other places in the code where we do "x.size = y" instead of "s2n_realloc(x, y)" and there are a lot. Although they should (probably, some might be avoiding freeing the memory if y==0) be calling s2n_realloc, fixing them all looks like a major refactor.

### Testing:

Existing tests pass with S2N_DONT_MLOCK set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
