### PR TITLE
Formally verify no memory leaks for s2n_blob

### DIFF
--- a/tests/cbmc/proofs/s2n_blob_zeroize_free/Makefile
+++ b/tests/cbmc/proofs/s2n_blob_zeroize_free/Makefile
@@ -13,7 +13,7 @@
 #
 # Expected runtime is around 5 seconds.
 
-CHECKFLAGS +=
+CHECKFLAGS += --memory-leak-check
 
 PROOF_UID = s2n_blob_zeroize_free
 HARNESS_ENTRY = $(PROOF_UID)_harness

--- a/tests/cbmc/proofs/s2n_free/Makefile
+++ b/tests/cbmc/proofs/s2n_free/Makefile
@@ -11,7 +11,7 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-CHECKFLAGS +=
+CHECKFLAGS += --memory-leak-check
 
 PROOF_UID = s2n_free
 HARNESS_ENTRY = $(PROOF_UID)_harness

--- a/tests/cbmc/proofs/s2n_free/s2n_free_harness.c
+++ b/tests/cbmc/proofs/s2n_free/s2n_free_harness.c
@@ -22,14 +22,34 @@
 
 void s2n_free_harness()
 {
+    /* Non-deterministic inputs. */
     struct s2n_blob *blob = cbmc_allocate_s2n_blob();
-    __CPROVER_assume(s2n_result_is_ok(s2n_blob_validate(blob)));
 
+    /* Assumptions. */
     nondet_s2n_mem_init();
+    __CPROVER_assume(s2n_result_is_ok(s2n_blob_validate(blob)));
+    const struct s2n_blob old_blob = *blob;
 
-    if (s2n_free(blob) == S2N_SUCCESS) {
-        /* If the call worked, assert all bytes in the blob struct
-           are zero */
+    /* Operation under verification. */
+    int result = s2n_free(blob);
+    if (result == S2N_SUCCESS) {
+        /* Postconditions. */
+        assert(S2N_IMPLIES(old_blob.allocated, blob->data == NULL));
         assert_all_zeroes(blob, sizeof(*blob));
+        if (old_blob.size != 0 && s2n_blob_is_growable(&old_blob)) {
+            assert(!S2N_MEM_IS_READABLE(blob->data, old_blob.size));
+        }
     }
+
+    /* Cleanup after expected error cases, for memory leak check. */
+    bool failed_before_free = (s2n_errno == S2N_ERR_NOT_INITIALIZED) || (s2n_errno == S2N_ERR_FREE_STATIC_BLOB);
+    if ((result != S2N_SUCCESS && failed_before_free) || !s2n_blob_is_growable(blob)) {
+        /* 1. `s2n_free` failed _before_ calling `free`, either because:
+              (a) s2n was not initialized, or (b) the blob was a static blob.
+           2. `blob` is not growable, then `s2n_free` is not supposed to `free` even if successful.
+        */
+        free(blob->data);
+    }
+    /* 3. free our heap-allocated `blob` since `s2n_free` only `free`s the contents. */
+    free(blob);
 }

--- a/tests/cbmc/proofs/s2n_free_object/Makefile
+++ b/tests/cbmc/proofs/s2n_free_object/Makefile
@@ -11,7 +11,7 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-CHECKFLAGS +=
+CHECKFLAGS += --memory-leak-check
 
 PROOF_UID = s2n_free_object
 HARNESS_ENTRY = $(PROOF_UID)_harness

--- a/tests/cbmc/proofs/s2n_free_object/s2n_free_object_harness.c
+++ b/tests/cbmc/proofs/s2n_free_object/s2n_free_object_harness.c
@@ -25,10 +25,22 @@ void s2n_free_object_harness()
     uint32_t size;
     uint8_t *data = malloc(size);
 
+    /* Assumptions. */
     nondet_s2n_mem_init();
+    uint8_t *old_data = data;
 
     /* Operation under verification. */
-    if (s2n_free_object(&data, size) == S2N_SUCCESS) {
+    int result = s2n_free_object(&data, size);
+    if (result == S2N_SUCCESS) {
         assert(data == NULL);
+    }
+
+    /* Cleanup after expected error cases, for memory leak check. */
+    if (result != S2N_SUCCESS && s2n_errno == S2N_ERR_NOT_INITIALIZED) {
+        /* 1. `s2n_free` failed because s2n was not initialized.
+              Note that `data` is still set to `NULL`, even if the call fails,
+              so we can't use `data` here.
+        */
+        free(old_data);
     }
 }

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -75,7 +75,7 @@ static int s2n_mem_free_mlock_impl(void *ptr, uint32_t size)
 {
     int munlock_rc = munlock(ptr, size);
     free(ptr);
-    POSIX_GUARD(munlock_rc);
+    POSIX_ENSURE(munlock_rc == 0, S2N_ERR_MUNLOCK);
 
     return S2N_SUCCESS;
 }


### PR DESCRIPTION
### Resolved issues:

N/A

Related to #2774.

### Description of changes: 

The harnesses that `free` s2n_blob are strengthened with the `--memory-leak-check` flag (added to `CHECKFLAGS` in the `Makefile`s). In the harness that use this flag, we are forced to explicitly document all error cases where memory might not be `free`d.

### Call-outs:

N/A

### Testing:

The CBMC harnesses should still pass after these changes. The `--memory-leak-check` flag should report any memory leaks within the harnesses that use it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
