### PR TITLE
Adding EC_KEY_check_key for p521 curve

### DIFF
--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -163,6 +163,8 @@ static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_p
      * From RFC 8422(TLS1.2) Section 5.11: With the NIST curves, each party MUST validate the public key sent by its peer
      * in the ClientKeyExchange and ServerKeyExchange messages. A receiving party MUST check that the x and y parameters from 
      * the peer's public value satisfy the curve equation, y^2 = x^3 + ax + b mod p.
+     * Note that the `EC_KEY_check_key` validation is a MUST for only NIST curves, if a non-NIST curve is added to s2n-tls 
+     * this is an additional validation step that increases security but decreases performance.
      */
     if (iana_id != TLS_EC_CURVE_ECDH_X25519 && iana_id != TLS_EC_CURVE_ECDH_X448) {
         DEFER_CLEANUP(EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(peer_public), EC_KEY_free_pointer);

--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -157,9 +157,12 @@ static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_p
     POSIX_ENSURE_REF(peer_public);
     POSIX_ENSURE_REF(own_key);
 
-    /* From RFC 8446 Section 4.2.8.2: For the curves secp256r1, secp384r1, and secp521r1, peers MUST validate 
+    /* From RFC 8446(TLS1.3) Section 4.2.8.2: For the curves secp256r1, secp384r1, and secp521r1, peers MUST validate 
      * each other's public value Q by ensuring that the point is a valid point on the elliptic curve.
      * For the curve x25519 and x448 the peer public-key validation check doesn't apply.
+     * From RFC 8422(TLS1.2) Section 5.11: With the NIST curves, each party MUST validate the public key sent by its peer
+     * in the ClientKeyExchange and ServerKeyExchange messages. A receiving party MUST check that the x and y parameters from 
+     * the peer's public value satisfy the curve equation, y^2 = x^3 + ax + b mod p.
      */
     if (iana_id != TLS_EC_CURVE_ECDH_X25519 && iana_id != TLS_EC_CURVE_ECDH_X448) {
         DEFER_CLEANUP(EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(peer_public), EC_KEY_free_pointer);

--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -157,11 +157,11 @@ static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_p
     POSIX_ENSURE_REF(peer_public);
     POSIX_ENSURE_REF(own_key);
 
-    /* From RFC 8446 Section 4.2.8.2: For the curves secp256r1 and secp384r1 peers MUST validate each other's
-     * public value Q by ensuring that the point is a valid point on the elliptic curve.
-     * For the curve x25519 the peer public-key validation check doesn't apply.
+    /* From RFC 8446 Section 4.2.8.2: For the curves secp256r1, secp384r1, and secp521r1, peers MUST validate 
+     * each other's public value Q by ensuring that the point is a valid point on the elliptic curve.
+     * For the curve x25519 and x448 the peer public-key validation check doesn't apply.
      */
-    if (iana_id == TLS_EC_CURVE_SECP_256_R1 || iana_id == TLS_EC_CURVE_SECP_384_R1) {
+    if (iana_id != TLS_EC_CURVE_ECDH_X25519 && iana_id != TLS_EC_CURVE_ECDH_X448) {
         DEFER_CLEANUP(EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(peer_public), EC_KEY_free_pointer);
         S2N_ERROR_IF(ec_key == NULL, S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
         POSIX_GUARD_OSSL(EC_KEY_check_key(ec_key), S2N_ERR_ECDHE_SHARED_SECRET);

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -203,6 +203,7 @@
 #define TLS_EC_CURVE_SECP_384_R1           24
 #define TLS_EC_CURVE_SECP_521_R1           25
 #define TLS_EC_CURVE_ECDH_X25519           29
+#define TLS_EC_CURVE_ECDH_X448             30
 
 /* Ethernet maximum transmission unit (MTU)
  * MTU is usually associated with the Ethernet protocol,


### PR DESCRIPTION
### Description of changes: 

This list https://github.com/aws/s2n-tls/blob/main/crypto/s2n_ecc_evp.c#L160-L164 was not updated to perform the EC_KEY_check_key for p521 curve when the curve was added in [pr/2344](https://github.com/aws/s2n-tls/pull/2344).

The fix for it is: !=X25519 and !=x448 (which we currently don't support) instead of the == checks done previously to prevent human error in missing out future curves when added. 

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? Adds an additional validation check.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? No 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
