### PR TITLE
Formally verify no memory leaks in hash functions

### DIFF
--- a/tests/cbmc/include/cbmc_proof/cbmc_utils.h
+++ b/tests/cbmc/include/cbmc_proof/cbmc_utils.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <cbmc_proof/nondet.h>
+#include <crypto/s2n_hash.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stuffer/s2n_stuffer.h>
@@ -26,6 +27,29 @@
 struct store_byte_from_buffer {
     size_t  idx;
     uint8_t byte;
+};
+
+/**
+ * Reference counted keys (EVP_PKEY and EC_KEY) store the reference counts
+ * within the key itself, thus making them potentially unavailable after the
+ * keys get deallocated.
+ * In the `rc_keys_from_evp_pkey_ctx`, we store the reference counts outside of the keys,
+ * so we can assert properties on them regardless of whether keys was deallocated or not.
+ */
+struct rc_keys_from_evp_pkey_ctx {
+    EVP_PKEY *pkey;
+    int pkey_refs;
+    EC_KEY *pkey_eckey;
+    int pkey_eckey_refs;
+};
+
+/**
+ * In the `rc_keys_from_hash_state`, we store two `rc_keys_from_evp_pkey_ctx` objects:
+ * one for the `evp` field and another for `evp_md5_secondary` field.
+ */
+struct rc_keys_from_hash_state {
+    struct rc_keys_from_evp_pkey_ctx evp;
+    struct rc_keys_from_evp_pkey_ctx evp_md5;
 };
 
 /**
@@ -86,6 +110,46 @@ void assert_byte_from_buffer_matches(const uint8_t *const buffer, const struct s
 void assert_byte_from_blob_matches(const struct s2n_blob *blob, const struct store_byte_from_buffer *const b);
 
 /**
+ * Assert that the reference counts in `storage` have decremented by 1 (if they were > 1).
+ * We cannot check anything if the previous reference count was 1, because the key is deallocated in that case.
+ */
+void assert_rc_decrement_on_evp_pkey_ctx(struct rc_keys_from_evp_pkey_ctx *storage);
+
+/**
+ * Assert that the reference counts in `storage` have decremented by 1 (if they were > 1).
+ * We cannot check anything if the previous reference count was 1, because the key is deallocated in that case.
+ */
+void assert_rc_unchanged_on_evp_pkey_ctx(struct rc_keys_from_evp_pkey_ctx *storage);
+
+/**
+ * Assert that the reference counts in `storage` are unchanged.
+ */
+void assert_rc_decrement_on_hash_state(struct rc_keys_from_hash_state *storage);
+
+/**
+ * Assert that the reference counts in `storage` are unchanged.
+ */
+void assert_rc_unchanged_on_hash_state(struct rc_keys_from_hash_state *storage);
+
+/**
+ * Saves reference-counted keys from an `EVP_PKEY_CTX`.
+ * Afterwards, one can assert that keys have changed as expected (e.g. after `s2n_hash_free`), i.e.,
+ * reference counts have either decreased by 1: see `assert_rc_decrement_on_evp_pkey_ctx`.
+ * Additionally, one can also `free` the keys that are left with non-zero reference counts,
+ * if that's expected, using `free_rc_keys_from_evp_pkey_ctx` for memory leak check to go through.
+ */
+void save_rc_keys_from_evp_pkey_ctx(const EVP_PKEY_CTX *pctx, struct rc_keys_from_evp_pkey_ctx *storage);
+
+/**
+ * Saves reference-counted keys from an `s2n_hash_state`.
+ * Afterwards, one can assert that keys have changed as expected (e.g. after `s2n_hash_free`), i.e.,
+ * reference counts have either decreased by 1: see `assert_rc_decrement_on_hash_state`.
+ * Additionally, one can also `free` the keys that are left with non-zero reference counts,
+ * if that's expected, using `free_rc_keys_from_hash_state` for memory leak check to go through.
+ */
+void save_rc_keys_from_hash_state(const struct s2n_hash_state *state, struct rc_keys_from_hash_state *storage);
+
+/**
  * Nondeterministically selects a byte from array and stores it into a store_array_list_byte
  * structure. Afterwards, one can prove using the assert_byte_from_buffer_matches function
  * whether no byte in the array has changed.
@@ -98,6 +162,16 @@ void save_byte_from_array(const uint8_t *const array, const size_t size, struct 
  * whether no byte in the blob has changed.
  */
 void save_byte_from_blob(const struct s2n_blob *blob, struct store_byte_from_buffer *storage);
+
+/**
+ * Free all ref-counted keys in `storage` that earlier had a reference count != 1.
+ */
+void free_rc_keys_from_evp_pkey_ctx(struct rc_keys_from_evp_pkey_ctx *pctx);
+
+/**
+ * Free all ref-counted keys in `storage` that earlier had a reference count != 1.
+ */
+void free_rc_keys_from_hash_state(struct rc_keys_from_hash_state *storage);
 
 /**
  * Standard stub function to compare two items.

--- a/tests/cbmc/include/cbmc_proof/cbmc_utils.h
+++ b/tests/cbmc/include/cbmc_proof/cbmc_utils.h
@@ -30,10 +30,10 @@ struct store_byte_from_buffer {
 };
 
 /**
- * Reference counted keys (EVP_PKEY and EC_KEY) store the reference counts
- * within the key itself, thus making them potentially unavailable after the
- * keys get deallocated.
- * In the `rc_keys_from_evp_pkey_ctx`, we store the reference counts outside of the keys,
+ * Reference counted keys (EVP_PKEY and EC_KEY) store the reference count
+ * within the key itself, thus making it potentially unavailable after the
+ * key get deallocated.
+ * In the `rc_keys_from_evp_pkey_ctx`, we store the reference count outside of the key,
  * so we can assert properties on them regardless of whether keys was deallocated or not.
  */
 struct rc_keys_from_evp_pkey_ctx {
@@ -132,7 +132,7 @@ void assert_rc_decrement_on_hash_state(struct rc_keys_from_hash_state *storage);
 void assert_rc_unchanged_on_hash_state(struct rc_keys_from_hash_state *storage);
 
 /**
- * Saves reference-counted keys from an `EVP_PKEY_CTX`.
+ * Save reference-counted keys from an `EVP_PKEY_CTX`.
  * Afterwards, one can assert that keys have changed as expected (e.g. after `s2n_hash_free`), i.e.,
  * reference counts have either decreased by 1: see `assert_rc_decrement_on_evp_pkey_ctx`.
  * Additionally, one can also `free` the keys that are left with non-zero reference counts,
@@ -141,7 +141,7 @@ void assert_rc_unchanged_on_hash_state(struct rc_keys_from_hash_state *storage);
 void save_rc_keys_from_evp_pkey_ctx(const EVP_PKEY_CTX *pctx, struct rc_keys_from_evp_pkey_ctx *storage);
 
 /**
- * Saves reference-counted keys from an `s2n_hash_state`.
+ * Save reference-counted keys from an `s2n_hash_state`.
  * Afterwards, one can assert that keys have changed as expected (e.g. after `s2n_hash_free`), i.e.,
  * reference counts have either decreased by 1: see `assert_rc_decrement_on_hash_state`.
  * Additionally, one can also `free` the keys that are left with non-zero reference counts,

--- a/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
+++ b/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
@@ -123,3 +123,13 @@ struct s2n_hmac_state* cbmc_allocate_s2n_hmac_state();
  * Properly allocates s2n_hmac_state for CBMC proofs.
  */
 struct s2n_hmac_evp_backup* cbmc_allocate_s2n_hmac_evp_backup();
+
+/*
+ * Populates the fields of a pre-allocated s2n_evp_digest for CBMC proofs.
+ */
+void cbmc_populate_s2n_evp_digest(struct s2n_evp_digest *evp_digest);
+
+/*
+ * Populates the fields of a pre-allocated s2n_hash_state for CBMC proofs.
+ */
+void cbmc_populate_s2n_hash_state(struct s2n_hash_state *state);

--- a/tests/cbmc/proofs/s2n_dh_params_free/Makefile
+++ b/tests/cbmc/proofs/s2n_dh_params_free/Makefile
@@ -13,13 +13,14 @@
 
 # Expected runtime is 10 seconds.
 
-CHECKFLAGS +=
+CHECKFLAGS += --memory-leak-check
 
 PROOF_UID = s2n_dh_params_free
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/dh_override.c
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c

--- a/tests/cbmc/proofs/s2n_dh_params_free/s2n_dh_params_free_harness.c
+++ b/tests/cbmc/proofs/s2n_dh_params_free/s2n_dh_params_free_harness.c
@@ -32,8 +32,6 @@ void s2n_dh_params_free_harness()
     /* Operation under verification. */
     if (s2n_dh_params_free(dh_params) == S2N_SUCCESS) {
         assert(dh_params->dh == NULL);
-    } else {
-        assert(dh_params == NULL && s2n_errno == S2N_ERR_NULL);
     }
     
     /* Cleanup before memory leak check.

--- a/tests/cbmc/proofs/s2n_dh_params_free/s2n_dh_params_free_harness.c
+++ b/tests/cbmc/proofs/s2n_dh_params_free/s2n_dh_params_free_harness.c
@@ -30,17 +30,15 @@ void s2n_dh_params_free_harness()
     nondet_s2n_mem_init();
 
     /* Operation under verification. */
-    int result = s2n_dh_params_free(dh_params);
-
-    /* Postconditions. */
-    if (result == S2N_SUCCESS) {
+    if (s2n_dh_params_free(dh_params) == S2N_SUCCESS) {
         assert(dh_params->dh == NULL);
     } else {
         assert(dh_params == NULL && s2n_errno == S2N_ERR_NULL);
     }
     
     /* Cleanup before memory leak check.
-     * 1. free our heap-allocated `dh_params`, since `s2n_dh_params_free` only `free`s the contents.
+     * `free` our heap-allocated `dh_params` object,
+     * since `s2n_dh_params_free` only `free`s the contents.
      */
     free(dh_params);
 }

--- a/tests/cbmc/proofs/s2n_dh_params_free/s2n_dh_params_free_harness.c
+++ b/tests/cbmc/proofs/s2n_dh_params_free/s2n_dh_params_free_harness.c
@@ -30,8 +30,17 @@ void s2n_dh_params_free_harness()
     nondet_s2n_mem_init();
 
     /* Operation under verification. */
-    if (s2n_dh_params_free(dh_params) == S2N_SUCCESS) {
-        /* Postconditions. */
+    int result = s2n_dh_params_free(dh_params);
+
+    /* Postconditions. */
+    if (result == S2N_SUCCESS) {
         assert(dh_params->dh == NULL);
+    } else {
+        assert(dh_params == NULL && s2n_errno == S2N_ERR_NULL);
     }
+    
+    /* Cleanup before memory leak check.
+       1. free our heap-allocated `dh_params`, since `s2n_dh_params_free` only `free`s the contents.
+    */
+    free(dh_params);
 }

--- a/tests/cbmc/proofs/s2n_dh_params_free/s2n_dh_params_free_harness.c
+++ b/tests/cbmc/proofs/s2n_dh_params_free/s2n_dh_params_free_harness.c
@@ -40,7 +40,7 @@ void s2n_dh_params_free_harness()
     }
     
     /* Cleanup before memory leak check.
-       1. free our heap-allocated `dh_params`, since `s2n_dh_params_free` only `free`s the contents.
-    */
+     * 1. free our heap-allocated `dh_params`, since `s2n_dh_params_free` only `free`s the contents.
+     */
     free(dh_params);
 }

--- a/tests/cbmc/proofs/s2n_hash_free/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_free/Makefile
@@ -13,18 +13,22 @@
 
 # Expected runtime is less than a minute.
 
-CBMCFLAGS +=
+CBMCFLAGS += --memory-leak-check
 
 PROOF_UID = s2n_hash_free
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_init

--- a/tests/cbmc/proofs/s2n_hash_free/s2n_hash_free_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_free/s2n_hash_free_harness.c
@@ -23,15 +23,42 @@ void s2n_hash_free_harness()
     /* Non-deterministic inputs. */
     struct s2n_hash_state *state = cbmc_allocate_s2n_hash_state();
 
+    /* Assumptions. */
+    __CPROVER_assume(s2n_result_is_ok(s2n_hash_state_validate(state)));
+
+    struct rc_keys_from_hash_state saved_hash_state;
+    save_rc_keys_from_hash_state(state, &saved_hash_state);
+
     /* Operation under verification. */
-    if (s2n_hash_free(state) == S2N_SUCCESS)
-    {
-        /* Post-conditions. */
-        if (state != NULL) {
-            assert(state->hash_impl->free != NULL);
-            assert(IMPLIES(s2n_is_in_fips_mode(), state->digest.high_level.evp.ctx == NULL));
-            assert(IMPLIES(s2n_is_in_fips_mode(), state->digest.high_level.evp_md5_secondary.ctx == NULL));
-            assert(state->is_ready_for_input == 0);
+    int result = s2n_hash_free(state);
+
+    /* Post-conditions. */
+    assert(result == S2N_SUCCESS);
+    if (state != NULL) {
+        assert(state->hash_impl->free != NULL);
+        if(s2n_is_in_fips_mode()) {
+            assert(state->digest.high_level.evp.ctx == NULL);
+            assert(state->digest.high_level.evp_md5_secondary.ctx == NULL);
+            assert_rc_decrement_on_hash_state(&saved_hash_state);
+        } else {
+            assert_rc_unchanged_on_hash_state(&saved_hash_state);
         }
+        assert(state->is_ready_for_input == 0);
     }
+
+    /* Cleanup after expected error cases, for memory leak check. */
+    if (state != NULL) {
+        /* 1. `free` leftover EVP_MD_CTX objects if `s2n_is_in_fips_mode`,
+              since `s2n_hash_free` is a NO-OP in that case. */
+        if (!s2n_is_in_fips_mode()) {
+            S2N_EVP_MD_CTX_FREE(state->digest.high_level.evp.ctx);
+            S2N_EVP_MD_CTX_FREE(state->digest.high_level.evp_md5_secondary.ctx);
+        }
+
+        /* 2. `free` leftover reference-counted keys (i.e. those with non-zero ref-count),
+              since they are not automatically `free`d until their ref count reaches 0. */
+        free_rc_keys_from_hash_state(&saved_hash_state);
+    }
+    /* 3. free our heap-allocated `state` since `s2n_hash_free` only `free`s the contents. */
+    free(state);
 }

--- a/tests/cbmc/proofs/s2n_hash_free/s2n_hash_free_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_free/s2n_hash_free_harness.c
@@ -30,10 +30,7 @@ void s2n_hash_free_harness()
     save_rc_keys_from_hash_state(state, &saved_hash_state);
 
     /* Operation under verification. */
-    int result = s2n_hash_free(state);
-
-    /* Post-conditions. */
-    assert(result == S2N_SUCCESS);
+    assert(s2n_hash_free(state) == S2N_SUCCESS);
     if (state != NULL) {
         assert(state->hash_impl->free != NULL);
         if (s2n_is_in_fips_mode()) {

--- a/tests/cbmc/proofs/s2n_hash_free/s2n_hash_free_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_free/s2n_hash_free_harness.c
@@ -36,7 +36,7 @@ void s2n_hash_free_harness()
     assert(result == S2N_SUCCESS);
     if (state != NULL) {
         assert(state->hash_impl->free != NULL);
-        if(s2n_is_in_fips_mode()) {
+        if (s2n_is_in_fips_mode()) {
             assert(state->digest.high_level.evp.ctx == NULL);
             assert(state->digest.high_level.evp_md5_secondary.ctx == NULL);
             assert_rc_decrement_on_hash_state(&saved_hash_state);

--- a/tests/cbmc/proofs/s2n_hmac_free/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_free/Makefile
@@ -19,6 +19,8 @@ PROOF_UID = s2n_hmac_free
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 
+PROOF_SOURCES += $(OPENSSL_SOURCE)/bn_override.c
+PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
@@ -26,6 +28,7 @@ PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
 
 # We abstract these functions because manual inspection demonstrates they are unreachable.
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_hash_c_s2n_evp_hash_init

--- a/tests/cbmc/proofs/s2n_hmac_free/s2n_hmac_free_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_free/s2n_hmac_free_harness.c
@@ -35,10 +35,7 @@ void s2n_hmac_free_harness()
     save_rc_keys_from_hash_state(&state->outer_just_key, &saved_outer_just_key_hash_state);
 
     /* Operation under verification. */
-    int result = s2n_hmac_free(state);
-
-    /* Post-conditions. */
-    assert(result == S2N_SUCCESS);
+    assert(s2n_hmac_free(state) == S2N_SUCCESS);
     if (state != NULL) {
         assert(state->inner.hash_impl->free != NULL);
         assert(state->inner_just_key.hash_impl->free != NULL);
@@ -90,7 +87,8 @@ void s2n_hmac_free_harness()
         }
 
         /* 2. `free` leftover reference-counted keys (i.e. those with non-zero ref-count),
-              since they are not automatically `free`d until their ref count reaches 0. */
+         *    since they are not automatically `free`d until their ref count reaches 0.
+         */
         free_rc_keys_from_hash_state(&saved_inner_hash_state);
         free_rc_keys_from_hash_state(&saved_inner_just_key_hash_state);
         free_rc_keys_from_hash_state(&saved_inner_hash_state);

--- a/tests/cbmc/proofs/s2n_hmac_free/s2n_hmac_free_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_free/s2n_hmac_free_harness.c
@@ -23,27 +23,79 @@ void s2n_hmac_free_harness()
     /* Non-deterministic inputs. */
     struct s2n_hmac_state *state = cbmc_allocate_s2n_hmac_state();
 
+    /* Assumptions. */
+    __CPROVER_assume(s2n_result_is_ok(s2n_hmac_state_validate(state)));
+
+    struct rc_keys_from_hash_state saved_inner_hash_state, saved_inner_just_key_hash_state,
+                                   saved_outer_hash_state, saved_outer_just_key_hash_state;
+
+    save_rc_keys_from_hash_state(&state->inner, &saved_inner_hash_state);
+    save_rc_keys_from_hash_state(&state->inner_just_key, &saved_inner_just_key_hash_state);
+    save_rc_keys_from_hash_state(&state->outer, &saved_outer_hash_state);
+    save_rc_keys_from_hash_state(&state->outer_just_key, &saved_outer_just_key_hash_state);
+
     /* Operation under verification. */
-    if (s2n_hmac_free(state) == S2N_SUCCESS)
-    {
-        /* Post-conditions. */
-        if (state != NULL) {
-            assert(state->inner.hash_impl->free != NULL);
-            assert(IMPLIES(s2n_is_in_fips_mode(), state->inner.digest.high_level.evp.ctx == NULL));
-            assert(IMPLIES(s2n_is_in_fips_mode(), state->inner.digest.high_level.evp_md5_secondary.ctx == NULL));
-            assert(state->inner.is_ready_for_input == 0);
-            assert(state->inner_just_key.hash_impl->free != NULL);
-            assert(IMPLIES(s2n_is_in_fips_mode(), state->inner_just_key.digest.high_level.evp.ctx == NULL));
-            assert(IMPLIES(s2n_is_in_fips_mode(), state->inner_just_key.digest.high_level.evp_md5_secondary.ctx == NULL));
-            assert(state->inner_just_key.is_ready_for_input == 0);
-            assert(state->outer.hash_impl->free != NULL);
-            assert(IMPLIES(s2n_is_in_fips_mode(), state->outer.digest.high_level.evp.ctx == NULL));
-            assert(IMPLIES(s2n_is_in_fips_mode(), state->outer.digest.high_level.evp_md5_secondary.ctx == NULL));
-            assert(state->outer.is_ready_for_input == 0);
-            assert(state->outer_just_key.hash_impl->free != NULL);
-            assert(IMPLIES(s2n_is_in_fips_mode(), state->outer_just_key.digest.high_level.evp.ctx == NULL));
-            assert(IMPLIES(s2n_is_in_fips_mode(), state->outer_just_key.digest.high_level.evp_md5_secondary.ctx == NULL));
-            assert(state->outer_just_key.is_ready_for_input == 0);
+    int result = s2n_hmac_free(state);
+
+    /* Post-conditions. */
+    assert (result == S2N_SUCCESS);
+    if (state != NULL) {
+        assert(state->inner.hash_impl->free != NULL);
+        assert(state->inner_just_key.hash_impl->free != NULL);
+        assert(state->outer.hash_impl->free != NULL);
+        assert(state->outer_just_key.hash_impl->free != NULL);
+        
+        if (s2n_is_in_fips_mode()) {
+            assert(state->inner.digest.high_level.evp.ctx == NULL);
+            assert(state->inner.digest.high_level.evp_md5_secondary.ctx == NULL);
+            assert_rc_decrement_on_hash_state(&saved_inner_hash_state);
+
+            assert(state->inner_just_key.digest.high_level.evp.ctx == NULL);
+            assert(state->inner_just_key.digest.high_level.evp_md5_secondary.ctx == NULL);
+            assert_rc_decrement_on_hash_state(&saved_inner_just_key_hash_state);
+
+            assert(state->outer.digest.high_level.evp.ctx == NULL);
+            assert(state->outer.digest.high_level.evp_md5_secondary.ctx == NULL);
+            assert_rc_decrement_on_hash_state(&saved_outer_hash_state);
+
+            assert(state->outer_just_key.digest.high_level.evp.ctx == NULL);
+            assert(state->outer_just_key.digest.high_level.evp_md5_secondary.ctx == NULL);
+            assert_rc_decrement_on_hash_state(&saved_outer_just_key_hash_state);
+        } else {
+            assert_rc_unchanged_on_hash_state(&saved_inner_hash_state);
+            assert_rc_unchanged_on_hash_state(&saved_outer_just_key_hash_state);
+            assert_rc_unchanged_on_hash_state(&saved_outer_hash_state);
+            assert_rc_unchanged_on_hash_state(&saved_outer_just_key_hash_state);
         }
+
+        assert(state->inner.is_ready_for_input == 0);
+        assert(state->inner_just_key.is_ready_for_input == 0);
+        assert(state->outer.is_ready_for_input == 0);
+        assert(state->outer_just_key.is_ready_for_input == 0);
     }
+
+    /* Cleanup after expected error cases, for memory leak check. */
+    if (state != NULL) {
+        /* 1. `free` leftover EVP_MD_CTX objects if `s2n_is_in_fips_mode`,
+              since `s2n_hash_free` is a NO-OP in that case. */
+        if (!s2n_is_in_fips_mode()) {
+            S2N_EVP_MD_CTX_FREE(state->inner.digest.high_level.evp.ctx);
+            S2N_EVP_MD_CTX_FREE(state->inner.digest.high_level.evp_md5_secondary.ctx);
+            S2N_EVP_MD_CTX_FREE(state->inner_just_key.digest.high_level.evp.ctx);
+            S2N_EVP_MD_CTX_FREE(state->inner_just_key.digest.high_level.evp_md5_secondary.ctx);
+            S2N_EVP_MD_CTX_FREE(state->outer.digest.high_level.evp.ctx);
+            S2N_EVP_MD_CTX_FREE(state->outer.digest.high_level.evp_md5_secondary.ctx);
+            S2N_EVP_MD_CTX_FREE(state->outer_just_key.digest.high_level.evp.ctx);
+            S2N_EVP_MD_CTX_FREE(state->outer_just_key.digest.high_level.evp_md5_secondary.ctx);
+        }
+
+        /* 2. `free` leftover reference-counted keys (i.e. those with non-zero ref-count),
+              since they are not automatically `free`d until their ref count reaches 0. */
+        free_rc_keys_from_hash_state(&saved_inner_hash_state);
+        free_rc_keys_from_hash_state(&saved_inner_just_key_hash_state);
+        free_rc_keys_from_hash_state(&saved_inner_hash_state);
+        free_rc_keys_from_hash_state(&saved_outer_just_key_hash_state);
+    }
+    /* 3. free our heap-allocated `state` since `s2n_hash_free` only `free`s the contents. */
+    free(state);
 }

--- a/tests/cbmc/proofs/s2n_hmac_free/s2n_hmac_free_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_free/s2n_hmac_free_harness.c
@@ -38,7 +38,7 @@ void s2n_hmac_free_harness()
     int result = s2n_hmac_free(state);
 
     /* Post-conditions. */
-    assert (result == S2N_SUCCESS);
+    assert(result == S2N_SUCCESS);
     if (state != NULL) {
         assert(state->inner.hash_impl->free != NULL);
         assert(state->inner_just_key.hash_impl->free != NULL);

--- a/tests/cbmc/sources/cbmc_utils.c
+++ b/tests/cbmc/sources/cbmc_utils.c
@@ -14,6 +14,7 @@
  */
 
 #include <assert.h>
+#include <crypto/s2n_hash.h>
 #include <cbmc_proof/cbmc_utils.h>
 
 /**
@@ -193,4 +194,77 @@ bool uninterpreted_predicate_fn(uint8_t value);
 void nondet_s2n_mem_init()
 {
     if (nondet_bool()) { s2n_mem_init(); }
+}
+
+void assert_rc_decrement_on_evp_pkey_ctx(struct rc_keys_from_evp_pkey_ctx *storage)
+{
+    if (storage->pkey_refs > 1)
+        assert(storage->pkey->references == storage->pkey_refs - 1);
+    else if (storage->pkey_refs == 1 && storage->pkey_eckey_refs > 1)
+        assert(storage->pkey_eckey->references == storage->pkey_eckey_refs - 1);
+}
+
+void assert_rc_unchanged_on_evp_pkey_ctx(struct rc_keys_from_evp_pkey_ctx *storage)
+{
+    if (storage->pkey)
+        assert(storage->pkey->references == storage->pkey_refs);
+    if (storage->pkey_eckey)
+        assert(storage->pkey_eckey->references == storage->pkey_eckey_refs);
+}
+
+void assert_rc_decrement_on_hash_state(struct rc_keys_from_hash_state *storage)
+{
+    assert_rc_decrement_on_evp_pkey_ctx(&storage->evp);
+    assert_rc_decrement_on_evp_pkey_ctx(&storage->evp_md5);
+}
+
+void assert_rc_unchanged_on_hash_state(struct rc_keys_from_hash_state *storage)
+{
+    assert_rc_unchanged_on_evp_pkey_ctx(&storage->evp);
+    assert_rc_unchanged_on_evp_pkey_ctx(&storage->evp_md5);
+}
+
+void save_abstract_evp_ctx(const EVP_PKEY_CTX *pctx, struct rc_keys_from_evp_pkey_ctx *storage)
+{
+    storage->pkey = pctx->pkey;
+    if (storage->pkey) {
+        storage->pkey_refs = storage->pkey->references;
+        storage->pkey_eckey = storage->pkey->ec_key;
+        if (storage->pkey_eckey)
+            storage->pkey_eckey_refs = storage->pkey_eckey->references;
+    }
+}
+
+void save_rc_keys_from_hash_state(const struct s2n_hash_state *state, struct rc_keys_from_hash_state *storage)
+{
+    storage->evp.pkey = storage->evp.pkey_eckey = storage->evp_md5.pkey = storage->evp_md5.pkey_eckey = NULL;
+    storage->evp.pkey_refs = storage->evp.pkey_eckey_refs = storage->evp_md5.pkey_refs = storage->evp_md5.pkey_eckey_refs = 0;
+
+    if (state) {
+        if (state->digest.high_level.evp.ctx)
+            if (state->digest.high_level.evp.ctx->pctx)
+                save_abstract_evp_ctx(state->digest.high_level.evp.ctx->pctx, &storage->evp);
+
+        if (state->digest.high_level.evp_md5_secondary.ctx)
+            if (state->digest.high_level.evp_md5_secondary.ctx->pctx)
+                save_abstract_evp_ctx(state->digest.high_level.evp_md5_secondary.ctx->pctx, &storage->evp_md5);
+    }
+}
+
+void free_rc_keys_from_evp_pkey_ctx(struct rc_keys_from_evp_pkey_ctx *pctx)
+{
+    if (pctx->pkey && pctx->pkey_refs != 1) {
+        pctx->pkey->references = 1;
+        EVP_PKEY_free(pctx->pkey);
+    }
+    if (pctx->pkey_eckey && pctx->pkey_eckey_refs != 1) {
+        pctx->pkey_eckey->references = 1;
+        EC_KEY_free(pctx->pkey_eckey);
+    }
+}
+
+void free_rc_keys_from_hash_state(struct rc_keys_from_hash_state *storage)
+{
+    free_rc_keys_from_evp_pkey_ctx(&storage->evp);
+    free_rc_keys_from_evp_pkey_ctx(&storage->evp_md5);
 }

--- a/tests/cbmc/sources/cbmc_utils.c
+++ b/tests/cbmc/sources/cbmc_utils.c
@@ -198,18 +198,21 @@ void nondet_s2n_mem_init()
 
 void assert_rc_decrement_on_evp_pkey_ctx(struct rc_keys_from_evp_pkey_ctx *storage)
 {
-    if (storage->pkey_refs > 1)
+    if (storage->pkey_refs > 1) {
         assert(storage->pkey->references == storage->pkey_refs - 1);
-    else if (storage->pkey_refs == 1 && storage->pkey_eckey_refs > 1)
+    } else if (storage->pkey_refs == 1 && storage->pkey_eckey_refs > 1) {
         assert(storage->pkey_eckey->references == storage->pkey_eckey_refs - 1);
+    }
 }
 
 void assert_rc_unchanged_on_evp_pkey_ctx(struct rc_keys_from_evp_pkey_ctx *storage)
 {
-    if (storage->pkey)
+    if (storage->pkey) {
         assert(storage->pkey->references == storage->pkey_refs);
-    if (storage->pkey_eckey)
+    }
+    if (storage->pkey_eckey) {
         assert(storage->pkey_eckey->references == storage->pkey_eckey_refs);
+    }
 }
 
 void assert_rc_decrement_on_hash_state(struct rc_keys_from_hash_state *storage)
@@ -230,8 +233,9 @@ void save_abstract_evp_ctx(const EVP_PKEY_CTX *pctx, struct rc_keys_from_evp_pke
     if (storage->pkey) {
         storage->pkey_refs = storage->pkey->references;
         storage->pkey_eckey = storage->pkey->ec_key;
-        if (storage->pkey_eckey)
+        if (storage->pkey_eckey) {
             storage->pkey_eckey_refs = storage->pkey_eckey->references;
+        }
     }
 }
 
@@ -241,13 +245,17 @@ void save_rc_keys_from_hash_state(const struct s2n_hash_state *state, struct rc_
     storage->evp.pkey_refs = storage->evp.pkey_eckey_refs = storage->evp_md5.pkey_refs = storage->evp_md5.pkey_eckey_refs = 0;
 
     if (state) {
-        if (state->digest.high_level.evp.ctx)
-            if (state->digest.high_level.evp.ctx->pctx)
+        if (state->digest.high_level.evp.ctx) {
+            if (state->digest.high_level.evp.ctx->pctx) {
                 save_abstract_evp_ctx(state->digest.high_level.evp.ctx->pctx, &storage->evp);
+            }
+        }
 
-        if (state->digest.high_level.evp_md5_secondary.ctx)
-            if (state->digest.high_level.evp_md5_secondary.ctx->pctx)
+        if (state->digest.high_level.evp_md5_secondary.ctx) {
+            if (state->digest.high_level.evp_md5_secondary.ctx->pctx) {
                 save_abstract_evp_ctx(state->digest.high_level.evp_md5_secondary.ctx->pctx, &storage->evp_md5);
+            }
+        }
     }
 }
 

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -156,9 +156,9 @@ EVP_MD_CTX* cbmc_allocate_EVP_MD_CTX() {
 void cbmc_populate_s2n_evp_digest(struct s2n_evp_digest *evp_digest) {
     if (evp_digest != NULL) {
         /* `evp_digest->md` is never allocated.
-           It is always initialized based on the hashing algorithm.
-           If required, this initialization should be done in the validation function.
-        */
+         * It is always initialized based on the hashing algorithm.
+         * If required, this initialization should be done in the validation function.
+         */
         evp_digest->ctx = cbmc_allocate_EVP_MD_CTX();
     }
 }
@@ -174,9 +174,9 @@ void cbmc_populate_s2n_hash_state(struct s2n_hash_state* state)
 {
     if (state != NULL) {
         /* `state->hash_impl` is never allocated.
-           It is always initialized based on the hashing algorithm.
-           If required, this initialization should be done in the validation function.
-        */
+         * It is always initialized based on the hashing algorithm.
+         * If required, this initialization should be done in the validation function.
+         */
         cbmc_populate_s2n_evp_digest(&state->digest.high_level.evp);
         cbmc_populate_s2n_evp_digest(&state->digest.high_level.evp_md5_secondary);
     }


### PR DESCRIPTION
### Resolved issues:

Related to aws/s2n-tls#2774.

### Description of changes: 

The harnesses for deallocation functions within crypto are strengthened with the `--memory-leak-check` flag (added to `CHECKFLAGS` in the `Makefile`s). In the harness that use this flag, we are forced to explicitly document all error cases where memory might not be `free`d.

### Call-outs:

N/A

### Testing:

The CBMC harnesses should still pass after these changes. The `--memory-leak-check` flag should report any memory leaks within the harnesses that use it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
