### PR TITLE
Add early-data session resumption self-talk tests

### DIFF
--- a/tests/testlib/s2n_test_server_client.c
+++ b/tests/testlib/s2n_test_server_client.c
@@ -62,6 +62,14 @@ S2N_RESULT s2n_negotiate_test_server_and_client_with_early_data(struct s2n_conne
     ssize_t total_data_sent = 0, total_data_recv = 0;
     ssize_t data_sent = 0, data_recv = 0;
 
+    /* We call s2n_send_early_data and s2n_recv_early_data to handle the early data before
+     * calling s2n_negotiate to complete the handshake.
+     *
+     * s2n_recv_early_data does not indicate success until it receives the EndOfEarlyData message,
+     * indicating that the client is done sending early data. However, the client does not send the
+     * EndOfEarlyData message until s2n_negotiate is called. So we need to exit the early data loop
+     * once the client is done, ignoring whether or not the server is done.
+     */
     do {
         bool client_success = (s2n_send_early_data(client_conn, early_data_to_send->data + total_data_sent,
                 early_data_to_send->size - total_data_sent, &data_sent, &blocked) >= S2N_SUCCESS);
@@ -71,10 +79,14 @@ S2N_RESULT s2n_negotiate_test_server_and_client_with_early_data(struct s2n_conne
         bool server_success = (s2n_recv_early_data(server_conn, early_data_received->data + total_data_recv,
                 early_data_received->size - total_data_recv, &data_recv, &blocked) >= S2N_SUCCESS);
         total_data_recv += data_recv;
-        RESULT_GUARD(s2n_validate_negotiate_result(server_success, server_done, &server_done));
-    } while (!(client_done && data_recv == 0));
+        /* We pass in client_done==false to avoid the server erroring on blocked IO.
+         * The s2n_negotiate calls later will resolve that blocked condition. */
+        RESULT_GUARD(s2n_validate_negotiate_result(server_success, false, &server_done));
+    } while (total_data_sent < early_data_to_send->size && !client_done);
 
+    /* Finish the handshake */
     RESULT_GUARD_POSIX(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
     return S2N_RESULT_OK;
 }
 

--- a/tests/testlib/s2n_testlib.h
+++ b/tests/testlib/s2n_testlib.h
@@ -159,6 +159,8 @@ int s2n_negotiate_test_server_and_client(struct s2n_connection *server_conn, str
 S2N_RESULT s2n_negotiate_test_server_and_client_until_message(struct s2n_connection *server_conn,
         struct s2n_connection *client_conn, message_type_t message_type);
 int s2n_shutdown_test_server_and_client(struct s2n_connection *server_conn, struct s2n_connection *client_conn);
+S2N_RESULT s2n_negotiate_test_server_and_client_with_early_data(struct s2n_connection *server_conn,
+        struct s2n_connection *client_conn, struct s2n_blob *early_data_to_send, struct s2n_blob *early_data_received);
 
 int s2n_test_kem_with_kat(const struct s2n_kem *kem, const char *kat_file);
 int s2n_test_hybrid_ecdhe_kem_with_kat(const struct s2n_kem *kem, struct s2n_cipher_suite *cipher_suite,

--- a/tests/unit/s2n_self_talk_session_resumption_test.c
+++ b/tests/unit/s2n_self_talk_session_resumption_test.c
@@ -23,6 +23,13 @@
     (((client->handshake.handshake_type) & HELLO_RETRY_REQUEST) \
      && ((server->handshake.handshake_type) & HELLO_RETRY_REQUEST))
 
+struct s2n_early_data_test_case {
+    bool ticket_supported;
+    bool client_supported;
+    bool server_supported;
+    bool expect_success;
+};
+
 static int s2n_test_session_ticket_cb(struct s2n_connection *conn, void *ctx, struct s2n_session_ticket *ticket)
 {
     POSIX_ENSURE_REF(conn);
@@ -32,6 +39,7 @@ static int s2n_test_session_ticket_cb(struct s2n_connection *conn, void *ctx, st
     EXPECT_SUCCESS(s2n_session_ticket_get_data_len(ticket, &data_len));
 
     struct s2n_stuffer *stuffer = (struct s2n_stuffer *) ctx;
+    EXPECT_SUCCESS(s2n_stuffer_wipe(stuffer));
     EXPECT_SUCCESS(s2n_stuffer_resize(stuffer, data_len));
     EXPECT_SUCCESS(s2n_session_ticket_get_data(ticket, data_len, stuffer->blob.data));
     EXPECT_SUCCESS(s2n_stuffer_skip_write(stuffer, data_len));
@@ -63,20 +71,91 @@ static int s2n_setup_test_ticket_key(struct s2n_config *config)
     return S2N_SUCCESS;
 }
 
-static S2N_RESULT s2n_test_recv_new_session_ticket(struct s2n_connection *conn)
+static S2N_RESULT s2n_test_issue_new_session_ticket(struct s2n_connection *server_conn, struct s2n_connection *client_conn,
+        const struct s2n_early_data_test_case *early_data_case)
 {
-    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(server_conn);
+    RESULT_ENSURE_REF(client_conn);
+    RESULT_ENSURE_REF(early_data_case);
 
+    uint8_t data = 1;
     s2n_blocked_status blocked = S2N_NOT_BLOCKED;
-    uint8_t out = 0;
-    EXPECT_FAILURE_WITH_ERRNO(s2n_recv(conn, &out, 1, &blocked), S2N_ERR_IO_BLOCKED);
-    
+    RESULT_GUARD_POSIX(s2n_connection_add_new_tickets_to_send(server_conn, 1));
+
+    if (early_data_case->ticket_supported) {
+        RESULT_GUARD_POSIX(s2n_connection_set_server_max_early_data_size(server_conn, UINT16_MAX));
+    } else {
+        RESULT_GUARD_POSIX(s2n_connection_set_server_max_early_data_size(server_conn, 0));
+    }
+
+    RESULT_ENSURE_NE(server_conn->tickets_to_send, server_conn->tickets_sent);
+    RESULT_GUARD_POSIX(s2n_send(server_conn, &data, 1, &blocked));
+    RESULT_GUARD_POSIX(s2n_recv(client_conn, &data, 1, &blocked));
+    RESULT_ENSURE_EQ(server_conn->tickets_to_send, server_conn->tickets_sent);
+
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_test_negotiate(struct s2n_connection *server_conn, struct s2n_connection *client_conn,
+        const struct s2n_early_data_test_case *early_data_case)
+{
+    RESULT_ENSURE_REF(server_conn);
+    RESULT_ENSURE_REF(client_conn);
+    RESULT_ENSURE_REF(early_data_case);
+
+    uint8_t early_data[] = "very early hello world";
+    uint8_t empty_data[sizeof(early_data)] = { 0 };
+
+    uint8_t early_data_recv_data[sizeof(early_data)] = { 0 };
+    struct s2n_blob early_data_recv = { 0 };
+    RESULT_GUARD_POSIX(s2n_blob_init(&early_data_recv, early_data_recv_data, sizeof(early_data_recv_data)));
+
+    if (early_data_case->server_supported) {
+        RESULT_GUARD_POSIX(s2n_connection_set_server_max_early_data_size(server_conn, UINT16_MAX));
+    } else {
+        RESULT_GUARD_POSIX(s2n_connection_set_server_max_early_data_size(server_conn, 0));
+    }
+
+    struct s2n_blob early_data_send = { 0 };
+    if (early_data_case->client_supported) {
+        RESULT_GUARD_POSIX(s2n_blob_init(&early_data_send, early_data, sizeof(early_data)));
+    }
+
+    RESULT_GUARD(s2n_negotiate_test_server_and_client_with_early_data(server_conn, client_conn,
+            &early_data_send, &early_data_recv));
+
+    if (early_data_case->expect_success) {
+        RESULT_ENSURE_EQ(early_data_recv.size, sizeof(early_data));
+        EXPECT_BYTEARRAY_EQUAL(early_data_recv.data, early_data, sizeof(early_data));
+    } else {
+        RESULT_ENSURE_EQ(early_data_recv.size, sizeof(empty_data));
+        EXPECT_BYTEARRAY_EQUAL(early_data_recv.data, empty_data, sizeof(empty_data));
+    }
+
     return S2N_RESULT_OK;
 }
 
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
+
+    /* For some session resumption test cases, we want to test all possible configurations of 0-RTT support. */
+    size_t test_case_i = 0;
+    struct s2n_early_data_test_case early_data_test_cases[ 2 * 2 * 2 ] = { 0 };
+    for (size_t ticket_supported = 0; ticket_supported < 2; ticket_supported++) {
+        early_data_test_cases[test_case_i].ticket_supported = ticket_supported;
+        for (size_t client_supported = 0; client_supported < 2; client_supported++) {
+            early_data_test_cases[test_case_i].client_supported = client_supported;
+            for (size_t server_supported = 0; server_supported < 2; server_supported++) {
+                early_data_test_cases[test_case_i].server_supported = server_supported;
+                early_data_test_cases[test_case_i].expect_success = client_supported && server_supported && ticket_supported;
+            }
+        }
+        test_case_i++;
+    }
+    /* For some session resumption test cases, we don't want to test or don't care about 0-RTT */
+    const struct s2n_early_data_test_case no_early_data = { .client_supported = false, .server_supported = false,
+            .expect_success = false };
 
     /* Setup server config */
     struct s2n_config *server_config = s2n_config_new();
@@ -112,7 +191,9 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(tls12_client_config, true));
 
     /* Test: Server and client resume a session multiple times */
-    {
+    for (size_t early_data_i = 0; early_data_i < s2n_array_len(early_data_test_cases); early_data_i++) {
+        const struct s2n_early_data_test_case early_data_case = early_data_test_cases[early_data_i];
+
         struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
         struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
         EXPECT_NOT_NULL(client_conn);
@@ -126,12 +207,12 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
-        /* Negotiate initial handshake to get session ticket */
+        /* Negotiate initial handshake */
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
         EXPECT_TRUE(ARE_FULL_HANDSHAKES(client_conn, server_conn));
 
         /* Receive and save the issued session ticket for the next connection */
-        EXPECT_OK(s2n_test_recv_new_session_ticket(client_conn));
+        EXPECT_OK(s2n_test_issue_new_session_ticket(server_conn, client_conn, &early_data_case));
 
         for (size_t i = 0; i < 10; i++) {
             /* Prepare client and server for new connection */
@@ -145,11 +226,11 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_rewrite(&cb_session_data));
 
             /* Negotiate new connection */
-            EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+            EXPECT_OK(s2n_test_negotiate(server_conn, client_conn, &early_data_case));
             EXPECT_FALSE(ARE_FULL_HANDSHAKES(client_conn, server_conn));
 
             /* Receive and save the issued session ticket for the next connection */
-            EXPECT_OK(s2n_test_recv_new_session_ticket(client_conn));
+            EXPECT_OK(s2n_test_issue_new_session_ticket(server_conn, client_conn, &early_data_case));
         }
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -173,12 +254,12 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
-        /* Negotiate initial handshake to get session ticket */
+        /* Negotiate initial handshake */
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
         EXPECT_TRUE(ARE_FULL_HANDSHAKES(client_conn, server_conn));
 
         /* Receive and save the issued session ticket for the next connection */
-        EXPECT_OK(s2n_test_recv_new_session_ticket(client_conn));
+        EXPECT_OK(s2n_test_issue_new_session_ticket(server_conn, client_conn, &no_early_data));
 
         /* Prepare client and server for new connection */
         EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
@@ -205,7 +286,11 @@ int main(int argc, char **argv)
     }
 
     /* Test: A TLS1.2 client with a valid TLS1.3 ticket falls back to a TLS1.2 connection */
-    {
+    for (size_t early_data_i = 0; early_data_i < s2n_array_len(early_data_test_cases); early_data_i++) {
+        struct s2n_early_data_test_case early_data_case = early_data_test_cases[early_data_i];
+        /* Early data is never sent in TLS1.2 (or in a full handshake) */
+        early_data_case.expect_success = false;
+
         struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
         struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
         EXPECT_NOT_NULL(client_conn);
@@ -219,12 +304,12 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
-        /* Negotiate initial handshake to produce TLS1.3 session ticket */
+        /* Negotiate initial handshake */
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
         EXPECT_TRUE(ARE_FULL_HANDSHAKES(client_conn, server_conn));
 
         /* Receive and save the issued session ticket for the next connection */
-        EXPECT_OK(s2n_test_recv_new_session_ticket(client_conn));
+        EXPECT_OK(s2n_test_issue_new_session_ticket(server_conn, client_conn, &early_data_case));
 
         /* Prepare client and server for a second connection */
         EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
@@ -240,7 +325,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls12_client_config));
 
         /* Negotiate second connection */
-        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_OK(s2n_test_negotiate(server_conn, client_conn, &early_data_case));
 
         /* Falls back to TLS1.2 handshake */
         EXPECT_TRUE(ARE_FULL_HANDSHAKES(client_conn, server_conn));
@@ -304,7 +389,11 @@ int main(int argc, char **argv)
     }
 
     /* HRR when issuing a session resumption ticket and when resuming a session */
-    {
+    for (size_t early_data_i = 0; early_data_i < s2n_array_len(early_data_test_cases); early_data_i++) {
+        struct s2n_early_data_test_case early_data_case = early_data_test_cases[early_data_i];
+        /* Never use early data on a HRR */
+        early_data_case.expect_success = false;
+
         struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
         struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
         EXPECT_NOT_NULL(client_conn);
@@ -328,7 +417,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(IS_HELLO_RETRY(client_conn, server_conn));
 
         /* Receive and save the issued session ticket for the next connection */
-        EXPECT_OK(s2n_test_recv_new_session_ticket(client_conn));
+        EXPECT_OK(s2n_test_issue_new_session_ticket(server_conn, client_conn, &early_data_case));
 
         /* Prepare client and server for new connection */
         EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
@@ -343,7 +432,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_rewrite(&cb_session_data));
 
         /* Negotiate new connection */
-        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_OK(s2n_test_negotiate(server_conn, client_conn, &early_data_case));
         EXPECT_FALSE(ARE_FULL_HANDSHAKES(client_conn, server_conn));
         EXPECT_TRUE(IS_HELLO_RETRY(client_conn, server_conn));
 

--- a/tls/extensions/s2n_nst_early_data_indication.c
+++ b/tls/extensions/s2n_nst_early_data_indication.c
@@ -64,11 +64,17 @@ static int s2n_nst_early_data_indiction_recv(struct s2n_connection *conn, struct
     return S2N_SUCCESS;
 }
 
+static int s2n_nst_early_data_indication_missing(struct s2n_connection *conn)
+{
+    POSIX_GUARD(s2n_connection_set_server_max_early_data_size(conn, 0));
+    return S2N_SUCCESS;
+}
+
 const s2n_extension_type s2n_nst_early_data_indication_extension = {
     .iana_value = TLS_EXTENSION_EARLY_DATA,
     .is_response = false,
     .send = s2n_nst_early_data_indication_send,
     .recv = s2n_nst_early_data_indiction_recv,
     .should_send = s2n_nst_early_data_indication_should_send,
-    .if_missing = s2n_extension_noop_if_missing,
+    .if_missing = s2n_nst_early_data_indication_missing,
 };

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -339,7 +339,20 @@ int s2n_connection_get_max_early_data_size(struct s2n_connection *conn, uint32_t
     POSIX_ENSURE_REF(max_early_data_size);
     *max_early_data_size = 0;
 
+    uint32_t server_max_early_data_size = 0;
+    POSIX_GUARD_RESULT(s2n_early_data_get_server_max_size(conn, &server_max_early_data_size));
+
     if (conn->psk_params.psk_list.len == 0) {
+        /* The server can load its PSKs during the handshake, either via the PSK selection callback
+         * or by receiving a stateless session ticket.
+         *
+         * Before that happens, we should make an optimistic assumption of the early data size.
+         * That way, the max early data size always decreases (for example, it won't go from 0 -> UINT32_MAX
+         * after receiving a PSK in the ClientHello).
+         */
+        if (conn->mode == S2N_SERVER && !IS_NEGOTIATED(conn)) {
+            *max_early_data_size = server_max_early_data_size;
+        }
         return S2N_SUCCESS;
     }
 
@@ -358,8 +371,6 @@ int s2n_connection_get_max_early_data_size(struct s2n_connection *conn, uint32_t
      * while setting up this connection, not during a previous connection.
      */
     if (conn->mode == S2N_SERVER && first_psk->type == S2N_PSK_TYPE_RESUMPTION) {
-        uint32_t server_max_early_data_size = 0;
-        POSIX_GUARD_RESULT(s2n_early_data_get_server_max_size(conn, &server_max_early_data_size));
         *max_early_data_size = MIN(*max_early_data_size, server_max_early_data_size);
     }
 

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -343,7 +343,8 @@ int s2n_connection_get_max_early_data_size(struct s2n_connection *conn, uint32_t
     POSIX_GUARD_RESULT(s2n_early_data_get_server_max_size(conn, &server_max_early_data_size));
 
     if (conn->psk_params.psk_list.len == 0) {
-        /* The server can load its PSKs during the handshake, either via the PSK selection callback
+        /* This method may be called by the server before loading its PSKs.
+         * The server can load its PSKs during the handshake, either via the PSK selection callback
          * or by receiving a stateless session ticket.
          *
          * Before that happens, we should make an optimistic assumption of the early data size.


### PR DESCRIPTION
### Description of changes: 

I modified the TLS1.3 session ticket self-talk tests to sometimes use early data, testing the combination of early data and session tickets. In the process I found two early data bugs:
* s2n_connection_get_max_early_data_size reported 0 when a server had not received a ticket yet, which led calls to s2n_recv_early_data to initially indicate no-op.
* If a client received one NewSessionTicket message with the early data extension and then one without, it would use the non-zero max_early_data_size set by the first for the second.

### Testing:

This is a PR to add more tests! I also added unit tests for the two fixes the new self-talk tests found.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
