### PR TITLE
No optimization when debugging

### DIFF
--- a/s2n.mk
+++ b/s2n.mk
@@ -114,7 +114,7 @@ endif
 
 ifdef S2N_GDB
     S2N_DEBUG = 1
-    CFLAGS += -Og
+    CFLAGS += -O0
 endif
 
 ifdef S2N_DEBUG


### PR DESCRIPTION
### Description of changes: 

Even with -Og, GDB is still sometimes optimizing out values. This can be frustrating and slows down debugging. I'd like to go further and use -O0 when running with gdb.

### Call-outs:

-Og should have worked: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
However, several times the compiler has still optimized out values I care about, and I haven't had that problem when running with -O0.

### Testing:

I often switch to -O0 when debugging and it consistently works.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
