### PR TITLE
Relax SIKE Round 3 architecture restrictions

### DIFF
--- a/pq-crypto/sike_r3/sikep434r3.h
+++ b/pq-crypto/sike_r3/sikep434r3.h
@@ -33,7 +33,7 @@ uint64_t bswap64(uint64_t x);
 /* Arch specific definitions */
 #define digit_t S2N_SIKE_P434_R3_NAMESPACE(digit_t)
 #define hdigit_t S2N_SIKE_P434_R3_NAMESPACE(hdigit_t)
-#if defined(_AMD64_) || defined(__x86_64) || defined(__aarch64__) || defined(_S390X_) || defined(_ARM64_) || defined(__powerpc64__) || (defined(__riscv) && (__riscv_xlen == 64))
+#if defined(_AMD64_) || defined(__x86_64) || defined(__x86_64__) || defined(__aarch64__) || defined(_S390X_) || defined(_ARM64_) || defined(__powerpc64__) || (defined(__riscv) && (__riscv_xlen == 64))
     #define S2N_SIKE_P434_R3_NWORDS_FIELD    7 /* Number of words of a 434-bit field element */
     #define S2N_SIKE_P434_R3_ZERO_WORDS      3 /* Number of "0" digits in the least significant part of p434 + 1 */
     #define S2N_SIKE_P434_R3_RADIX           64

--- a/pq-crypto/sike_r3/sikep434r3.h
+++ b/pq-crypto/sike_r3/sikep434r3.h
@@ -41,7 +41,7 @@ uint64_t bswap64(uint64_t x);
     #define S2N_SIKE_P434_R3_BSWAP_DIGIT(i)  bswap64((i))
     typedef uint64_t digit_t;
     typedef uint32_t hdigit_t;
-#else
+#elif defined(_X86_) || defined(_ARM_) || defined(__arm__) || defined(__i386__)
     #define S2N_SIKE_P434_R3_NWORDS_FIELD    14 /* Number of words of a 434-bit field element */
     #define S2N_SIKE_P434_R3_ZERO_WORDS      6  /* Number of "0" digits in the least significant part of p434 + 1 */
     #define S2N_SIKE_P434_R3_RADIX           32
@@ -49,6 +49,8 @@ uint64_t bswap64(uint64_t x);
     #define S2N_SIKE_P434_R3_BSWAP_DIGIT(i)  bswap32((i))
     typedef uint32_t digit_t;
     typedef uint16_t hdigit_t;
+#else
+    #error -- "Unsupported ARCHITECTURE"
 #endif
 
 /* Basic constants */

--- a/pq-crypto/sike_r3/sikep434r3.h
+++ b/pq-crypto/sike_r3/sikep434r3.h
@@ -41,7 +41,7 @@ uint64_t bswap64(uint64_t x);
     #define S2N_SIKE_P434_R3_BSWAP_DIGIT(i)  bswap64((i))
     typedef uint64_t digit_t;
     typedef uint32_t hdigit_t;
-#elif defined(_X86_) || defined(_ARM_)
+#else
     #define S2N_SIKE_P434_R3_NWORDS_FIELD    14 /* Number of words of a 434-bit field element */
     #define S2N_SIKE_P434_R3_ZERO_WORDS      6  /* Number of "0" digits in the least significant part of p434 + 1 */
     #define S2N_SIKE_P434_R3_RADIX           32
@@ -49,8 +49,6 @@ uint64_t bswap64(uint64_t x);
     #define S2N_SIKE_P434_R3_BSWAP_DIGIT(i)  bswap32((i))
     typedef uint32_t digit_t;
     typedef uint16_t hdigit_t;
-#else
-    #error -- "Unsupported ARCHITECTURE"
 #endif
 
 /* Basic constants */


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Updates SIKE architecture-specific headers to fall back to operating on `uint32_t` values on non-64-bit architectures. 

### Call-outs:
Should fix issue seen during build on `manylinux2014-x86`

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
