### PR TITLE
Ignore `munlock` failures

### DIFF
--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -73,9 +73,7 @@ static int s2n_mem_cleanup_impl(void)
 
 static int s2n_mem_free_mlock_impl(void *ptr, uint32_t size)
 {
-    /* We do a best-effort `munlock` and ignore any errors during unlocking.
-     * More details at https://github.com/aws/s2n-tls/issues/2803.
-     */
+    /* Perform a best-effort `munlock`: ignore any errors during unlocking. */
     munlock(ptr, size);
     free(ptr);
     return S2N_SUCCESS;

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -73,10 +73,11 @@ static int s2n_mem_cleanup_impl(void)
 
 static int s2n_mem_free_mlock_impl(void *ptr, uint32_t size)
 {
-    int munlock_rc = munlock(ptr, size);
+    /* We do a best-effort `munlock` and ignore any errors during unlocking.
+     * More details at https://github.com/aws/s2n-tls/issues/2803.
+     */
+    munlock(ptr, size);
     free(ptr);
-    POSIX_ENSURE(munlock_rc == 0, S2N_ERR_MUNLOCK);
-
     return S2N_SUCCESS;
 }
 


### PR DESCRIPTION
### Resolved issues:

None.

Related to: #2803.

### Description of changes: 

Instead of failing on `munlock`, we now do a best-effort `munlock`.

### Call-outs:

We might want to refactor this part later on, and properly handle `munlock` failures. I left #2802 open for discussion.

### Testing:

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
