### PR TITLE
Ensure that s2n is initialized in `s2n_free_object`

### DIFF
--- a/tests/cbmc/proofs/s2n_free_object/s2n_free_object_harness.c
+++ b/tests/cbmc/proofs/s2n_free_object/s2n_free_object_harness.c
@@ -27,7 +27,6 @@ void s2n_free_object_harness()
 
     /* Assumptions. */
     nondet_s2n_mem_init();
-    uint8_t *old_data = data;
 
     /* Operation under verification. */
     int result = s2n_free_object(&data, size);
@@ -37,10 +36,7 @@ void s2n_free_object_harness()
 
     /* Cleanup after expected error cases, for memory leak check. */
     if (result != S2N_SUCCESS && s2n_errno == S2N_ERR_NOT_INITIALIZED) {
-        /* 1. `s2n_free` failed because s2n was not initialized.
-              Note that `data` is still set to `NULL`, even if the call fails,
-              so we can't use `data` here.
-        */
-        free(old_data);
+        /* `s2n_free` failed because s2n was not initialized. */
+        free(data);
     }
 }

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -219,6 +219,8 @@ int s2n_free_object(uint8_t **p_data, uint32_t size)
     if (*p_data == NULL) {
         return S2N_SUCCESS;
     }
+    
+    POSIX_ENSURE(initialized, S2N_ERR_NOT_INITIALIZED);
     struct s2n_blob b = {.data = *p_data, .allocated = size, .size = size, .growable = 1};
 
     /* s2n_free() will call free() even if it returns error (for a growable blob).


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

`s2n_free_object` used to clear the argument pointer, i.e., used to set it to `NULL` even when it failed to clear the data because s2n was not initialized. This can lead to a **memory leak**: the memory allocation still exists (was not `free`d) but it's no longer accessible using the pointer that was pointing to it!

We fix this behavior by ensuring that s2n is initialized, before clearing out the argument pointer.

### Call-outs:

N/A

### Testing:

The updated CBMC harness should now pass -- we shouldn't need to keep a backup copy of the pointer to `free` it in case of failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
