### PR TITLE
Remove unused macro and safeguard against removing prediction resistance

### DIFF
--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -197,7 +197,9 @@ int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob)
 
     S2N_ERROR_IF(blob->size > S2N_DRBG_GENERATE_LIMIT, S2N_ERR_DRBG_REQUEST_SIZE);
 
-    /* Always mix in additional entropy, for prediction resistance */
+    /* Always mix in additional entropy, for prediction resistance.
+        If s2n_drbg_mix is removed: must implement reseeding according to limit
+        specified in NIST SP800-90A 10.2.1 Table 3 */
     POSIX_GUARD(s2n_drbg_mix(drbg, &zeros));
     POSIX_GUARD(s2n_drbg_bits(drbg, blob));
     POSIX_GUARD(s2n_drbg_update(drbg, &zeros));

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -199,7 +199,7 @@ int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob)
 
     /* Always mix in additional entropy, for prediction resistance.
         If s2n_drbg_mix is removed: must implement reseeding according to limit
-        specified in NIST SP800-90A 10.2.1 Table 3 */
+        specified in NIST SP800-90A 10.2.1 Table 3. */
     POSIX_GUARD(s2n_drbg_mix(drbg, &zeros));
     POSIX_GUARD(s2n_drbg_bits(drbg, blob));
     POSIX_GUARD(s2n_drbg_update(drbg, &zeros));

--- a/crypto/s2n_drbg.h
+++ b/crypto/s2n_drbg.h
@@ -28,9 +28,6 @@
 /* The maximum size of any one request: from NIST SP800-90A 10.2.1 Table 3 */
 #define S2N_DRBG_GENERATE_LIMIT 8192
 
-/* We reseed after 2^35 bytes have been generated: from NIST SP800-90A 10.2.1 Table 3 */
-#define S2N_DRBG_RESEED_LIMIT   34359738368
-
 struct s2n_drbg {
     /* Track how many bytes have been used */
     uint64_t bytes_used;


### PR DESCRIPTION

### Description of changes: 

The macro `S2N_DRBG_RESEED_LIMIT` appears to be unused. At least, grepping gives nothing:

```
htorben in ~/s2n on main !                                                                                     
± grep -r "S2N_DRBG_RESEED_LIMIT" ./                                                                            
.//crypto/s2n_drbg.h:#define S2N_DRBG_RESEED_LIMIT   34359738368
```

### Call-outs:

The `CTR-DRBG` is typically reseeded after a certain number of requests. Per NIST SP800-90A 10.2.1 Table 3 the reseed limit for the AES-based `CTR-DRBG` is `2^48`. Prediction resistance is always enabled though:
https://github.com/aws/s2n-tls/blob/main/crypto/s2n_drbg.c#L201
which performs reseeding on every request.

But, expanded comment to highlight that a reseeding limit should probably be added if prediction resistance is ever relaxed.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
