### PR TITLE
Formally verify no memory leaks for s2n_array & s2n_set

### DIFF
--- a/tests/cbmc/proofs/s2n_array_free/Makefile
+++ b/tests/cbmc/proofs/s2n_array_free/Makefile
@@ -13,7 +13,7 @@
 
 # Expected runtime is less than 10 seconds.
 
-CBMCFLAGS +=
+CBMCFLAGS += --memory-leak-check
 
 PROOF_UID = s2n_array_free
 HARNESS_ENTRY = $(PROOF_UID)_harness

--- a/tests/cbmc/proofs/s2n_array_free_p/Makefile
+++ b/tests/cbmc/proofs/s2n_array_free_p/Makefile
@@ -13,7 +13,7 @@
 
 # Expected runtime is less than 10 seconds.
 
-CBMCFLAGS +=
+CBMCFLAGS += --memory-leak-check
 
 PROOF_UID = s2n_array_free_p
 HARNESS_ENTRY = $(PROOF_UID)_harness

--- a/tests/cbmc/proofs/s2n_array_free_p/s2n_array_free_p_harness.c
+++ b/tests/cbmc/proofs/s2n_array_free_p/s2n_array_free_p_harness.c
@@ -21,12 +21,26 @@ void s2n_array_free_p_harness()
 {
     /* Non-deterministic inputs. */
     struct s2n_array *array = cbmc_allocate_s2n_array();
+
+    /* Assumptions. */
+    nondet_s2n_mem_init();
     __CPROVER_assume(s2n_result_is_ok(s2n_array_validate(array)));
 
-    nondet_s2n_mem_init();
-
     /* Operation under verification. */
-    if(s2n_result_is_ok(s2n_array_free_p(&array))) {
+    s2n_result result = s2n_array_free_p(&array);
+    if (s2n_result_is_ok(result)) {
         assert(array == NULL);
+    } else {
+        assert(s2n_errno != S2N_ERR_FREE_STATIC_BLOB);
+    }
+
+    /**
+     * Cleanup after expected error cases, for memory leak check.
+     * It's good proof practice not to mix state mutations (below) with property checks (above).
+     */
+    if (s2n_result_is_error(result) && s2n_errno == S2N_ERR_NOT_INITIALIZED) {
+        /* s2n was not initialized, this failure is expected. */
+        free(array->mem.data);
+        free(array);
     }
 }

--- a/tests/cbmc/proofs/s2n_set_free/Makefile
+++ b/tests/cbmc/proofs/s2n_set_free/Makefile
@@ -13,7 +13,7 @@
 
 # Expected runtime is less than 10 seconds.
 
-CBMCFLAGS +=
+CBMCFLAGS += --memory-leak-check
 
 PROOF_UID = s2n_set_free
 HARNESS_ENTRY = $(PROOF_UID)_harness

--- a/tests/cbmc/proofs/s2n_set_free/s2n_set_free_harness.c
+++ b/tests/cbmc/proofs/s2n_set_free/s2n_set_free_harness.c
@@ -21,10 +21,25 @@ void s2n_set_free_harness()
 {
     /* Non-deterministic inputs. */
     struct s2n_set *set = cbmc_allocate_s2n_set();
+
+    /* Assumptions. */
+    nondet_s2n_mem_init();
     __CPROVER_assume(s2n_result_is_ok(s2n_set_validate(set)));
 
-    nondet_s2n_mem_init();
-
     /* Operation under verification. */
-    s2n_set_free(set);
+    s2n_result result = s2n_set_free(set);
+    if (s2n_result_is_error(result)) {
+        assert(s2n_errno != S2N_ERR_FREE_STATIC_BLOB);
+    }
+
+    /**
+     * Cleanup after expected error cases, for memory leak check.
+     * It's good proof practice not to mix state mutations (below) with property checks (above).
+     */
+    if (s2n_result_is_error(result) && s2n_errno == S2N_ERR_NOT_INITIALIZED) {
+        /* s2n was not initialized, this failure is expected. */
+        free(set->data->mem.data);
+        free(set->data);
+        free(set);
+    }
 }

--- a/tests/cbmc/proofs/s2n_set_free_p/Makefile
+++ b/tests/cbmc/proofs/s2n_set_free_p/Makefile
@@ -13,7 +13,7 @@
 
 # Expected runtime is less than 10 seconds.
 
-CBMCFLAGS +=
+CBMCFLAGS += --memory-leak-check
 
 PROOF_UID = s2n_set_free_p
 HARNESS_ENTRY = $(PROOF_UID)_harness

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -28,6 +28,7 @@ S2N_RESULT s2n_array_validate(const struct s2n_array *array)
     RESULT_ENSURE_NE(array->element_size, 0);
     RESULT_GUARD_POSIX(s2n_mul_overflow(array->len, array->element_size, &mem_size));
     RESULT_ENSURE_GTE(array->mem.size, mem_size);
+    RESULT_ENSURE(S2N_IMPLIES(array->mem.size, array->mem.growable), S2N_ERR_SAFETY);
     return S2N_RESULT_OK;
 }
 


### PR DESCRIPTION
### Resolved issues:

None.

Related to #2774.

### Description of changes: 

The harnesses for s2n_array and s2n_set deallocation functions are strengthened with the `--memory-leak-check` flag, and we now explicitly document all error cases where memory might not be `free`d.

### Call-outs:

N/A

### Testing:

The updated CBMC harnesses should still pass after these changes. The --memory-leak-check flag should report any memory leaks within the harnesses that use it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.