### PR TITLE
Only using extra warning and werror flags on Debug build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,14 +197,21 @@ file(GLOB S2N_SRC
 )
 
 add_library(${PROJECT_NAME} ${S2N_HEADERS} ${S2N_SRC})
-set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE C)
+set_target_properties(${PROJECT_NAME}
+                      PROPERTIES LINKER_LANGUAGE C
+                                 C_STANDARD 99 )
 
-set(CMAKE_C_FLAGS_DEBUGOPT "")
+# Disabling access to execstack
+target_compile_options(${PROJECT_NAME} PRIVATE -Wa,--noexecstack )
 
-target_compile_options(${PROJECT_NAME} PRIVATE -pedantic -std=gnu99 -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts
-        -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security
-        -Wno-missing-braces -Wa,--noexecstack
-)
+#set extra warning flags for debug build
+if (CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
+    target_compile_options(${PROJECT_NAME} PRIVATE -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment )
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wchar-subscripts -Wuninitialized -Wshadow )
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wcast-qual -Wcast-align -Wwrite-strings )
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wno-deprecated-declarations -Wno-unknown-pragmas )
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wformat-security -Wno-missing-braces )
+endif ()
 
 if(BUILD_TESTING AND BUILD_SHARED_LIBS)
     target_compile_options(${PROJECT_NAME} PRIVATE -fvisibility=default)


### PR DESCRIPTION
### Resolved issues:

Didn't create an Issue

### Description of changes: 
  
    Currently Werror and extra warnings are force into every type of build.
    This is a pain point to package mantainers and cannot be deactivated
    easily. Then, when a compiler or package manager that was not explicitly
    tested against, for example when new compiler version is launched, the
    build fails to users. Release build should not fail to users that
    succesfully built after upgrading a dependency or when trying to build
    to not yet supported platforms.

The change makes the werror and other warning related flags only part of the Debug build.
Additionally I moved the declaration of the language dialect to the CMAKE property

### Call-outs:

Remove the line that cleans the CFLAGS, thats unfriendly to packagers, if someone is passing a flag intentionally it should be respected.

### Testing:

It builds