### PR TITLE
Updating the ready_to_send_input_marker for s2n 

### DIFF
--- a/bin/echo.c
+++ b/bin/echo.c
@@ -149,6 +149,7 @@ int negotiate(struct s2n_connection *conn, int fd)
         free(identity);
     }
 
+    printf("s2n is ready\n");  
     return 0;
 }
 

--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -18,7 +18,7 @@ from enum import Enum
 
 # Number of lines of output to stdout s2nc or s2nd are expected
 # to produce after a successful handshake
-NUM_EXPECTED_LINES_OUTPUT = 11
+NUM_EXPECTED_LINES_OUTPUT = 12
 
 class OCSP(Enum):
     ENABLED = 1

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -187,6 +187,9 @@ class S2N(Provider):
         """
         cmd_line = ['s2nd', '-X', '--self-service-blinding', '--non-blocking']
 
+        # This is the last thing printed by s2nd before it is ready to begin
+        self.ready_to_test_marker = 's2n is ready'
+
         if self.options.key is not None:
             cmd_line.extend(['--key', self.options.key])
         if self.options.cert is not None:

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -140,7 +140,7 @@ class S2N(Provider):
             cmd_line.append('-e')
 
         # This is the last thing printed by s2nc before it is ready to send/receive data
-        self.ready_to_send_input_marker = 'Cipher negotiated:'
+        self.ready_to_send_input_marker = 's2n is ready'
 
         if self.options.use_session_ticket is False:
             cmd_line.append('-T')


### PR DESCRIPTION
### Description of changes: 

With the psk print message addition to s2nc, the last message is no longer `Cipher negotiated:`, updating to a more generic marker. 

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
