### PR TITLE
Formally verify no memory leaks in s2n_stuffer

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -25,15 +25,13 @@
 
 S2N_RESULT s2n_stuffer_validate(const struct s2n_stuffer* stuffer)
 {
-    RESULT_ENSURE_REF(stuffer);
-    RESULT_GUARD(s2n_blob_validate(&stuffer->blob));
-
     /**
      * Note that we do not assert any properties on the tainted field,
      * as any boolean value in that field is valid.
      */
+    RESULT_ENSURE_REF(stuffer);
+    RESULT_GUARD(s2n_blob_validate(&stuffer->blob));
     RESULT_ENSURE(S2N_IMPLIES(stuffer->growable, stuffer->alloced), S2N_ERR_SAFETY);
-    RESULT_ENSURE(S2N_IMPLIES(stuffer->alloced, stuffer->blob.growable), S2N_ERR_SAFETY);
 
     /* <= is valid because we can have a fully written/read stuffer */
     RESULT_DEBUG_ENSURE(stuffer->high_water_mark <= stuffer->blob.size, S2N_ERR_SAFETY);

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -25,12 +25,15 @@
 
 S2N_RESULT s2n_stuffer_validate(const struct s2n_stuffer* stuffer)
 {
-    /**
-     * Note that we do not assert any properties on the alloced, growable, and tainted fields,
-     * as all possible combinations of boolean values in those fields are valid.
-     */
     RESULT_ENSURE_REF(stuffer);
     RESULT_GUARD(s2n_blob_validate(&stuffer->blob));
+
+    /**
+     * Note that we do not assert any properties on the tainted field,
+     * as any boolean value in that field is valid.
+     */
+    RESULT_ENSURE(S2N_IMPLIES(stuffer->growable, stuffer->alloced), S2N_ERR_SAFETY);
+    RESULT_ENSURE(S2N_IMPLIES(stuffer->alloced, stuffer->blob.growable), S2N_ERR_SAFETY);
 
     /* <= is valid because we can have a fully written/read stuffer */
     RESULT_DEBUG_ENSURE(stuffer->high_water_mark <= stuffer->blob.size, S2N_ERR_SAFETY);
@@ -74,6 +77,7 @@ int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)
     stuffer->alloced = 0;
     stuffer->growable = 0;
     stuffer->tainted = 0;
+    POSIX_POSTCONDITION(s2n_stuffer_validate(stuffer));
     return S2N_SUCCESS;
 }
 
@@ -102,6 +106,7 @@ int s2n_stuffer_growable_alloc(struct s2n_stuffer *stuffer, const uint32_t size)
 
 int s2n_stuffer_free(struct s2n_stuffer *stuffer)
 {
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
     if (stuffer != NULL) {
         if (stuffer->alloced) {
             POSIX_GUARD(s2n_free(&stuffer->blob));

--- a/tests/cbmc/proofs/s2n_stuffer_free/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_free/Makefile
@@ -13,7 +13,7 @@
 
 # Expected runtime is 10 seconds.
 
-CHECKFLAGS +=
+CHECKFLAGS += --memory-leak-check
 
 PROOF_UID = s2n_stuffer_free
 HARNESS_ENTRY = $(PROOF_UID)_harness


### PR DESCRIPTION
### Resolved issues:

None.

Related to #2774.

### Description of changes: 

The harness for s2n_stuffer deallocator (s2n_stuffer_free) is strengthened with the `--memory-leak-check` flag, and we now explicitly document all error cases where memory might not be `free`d.

### Call-outs:

N/A

### Testing:

The updated CBMC harnesses should still pass after these changes. The `--memory-leak-check` flag should report any memory leaks within the harnesses that use it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.