### PR TITLE
Adds TLS1.3 Session Resumption Integration Tests

### DIFF
--- a/bin/common.h
+++ b/bin/common.h
@@ -52,6 +52,7 @@ int early_data_recv(struct s2n_connection *conn);
 int early_data_send(struct s2n_connection *conn, uint8_t *data, uint32_t len);
 int https(struct s2n_connection *conn, uint32_t bench);
 int key_log_callback(void *ctx, struct s2n_connection *conn, uint8_t *logline, size_t len);
+int recv_session_ticket(struct s2n_connection *conn, int fd);
 
 char *load_file_to_cstring(const char *path);
 int s2n_str_hex_to_bytes(const unsigned char *hex, uint8_t *out_bytes, uint32_t max_out_bytes_len);

--- a/bin/common.h
+++ b/bin/common.h
@@ -52,7 +52,6 @@ int early_data_recv(struct s2n_connection *conn);
 int early_data_send(struct s2n_connection *conn, uint8_t *data, uint32_t len);
 int https(struct s2n_connection *conn, uint32_t bench);
 int key_log_callback(void *ctx, struct s2n_connection *conn, uint8_t *logline, size_t len);
-int recv_session_ticket(struct s2n_connection *conn, int fd);
 
 char *load_file_to_cstring(const char *path);
 int s2n_str_hex_to_bytes(const unsigned char *hex, uint8_t *out_bytes, uint32_t max_out_bytes_len);

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -200,7 +200,7 @@ int negotiate(struct s2n_connection *conn, int fd)
         free(identity);
     }
 
-    printf("Ready to send\n");
+    printf("s2n is ready\n");
     return 0;
 }
 

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -200,6 +200,7 @@ int negotiate(struct s2n_connection *conn, int fd)
         free(identity);
     }
 
+    printf("Ready to send\n");
     return 0;
 }
 

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -575,12 +575,11 @@ int main(int argc, char *const *argv)
 
         printf("Connected to %s:%s\n", host, port);
 
-        /* Save session state from connection if reconnect is enabled */
-        if (reconnect > 0) {
+        /* Save session state from connection if reconnect is enabled. */
+        if (reconnect >= 0) {
             if (conn->actual_protocol_version >= S2N_TLS13) {
                 if (!session_ticket) {
-                    print_s2n_error("s2nc can only reconnect in TLS1.3 with session tickets.");
-                    exit(1);
+                    break;
                 }
                 GUARD_EXIT(echo(conn, sockfd, &session_ticket_recv), "Error calling echo");
             } else {

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -576,26 +576,25 @@ int main(int argc, char *const *argv)
         printf("Connected to %s:%s\n", host, port);
 
         /* Save session state from connection if reconnect is enabled. */
-        if (reconnect >= 0) {
-            if (conn->actual_protocol_version >= S2N_TLS13) {
-                if (!session_ticket) {
-                    break;
-                }
-                GUARD_EXIT(echo(conn, sockfd, &session_ticket_recv), "Error calling echo");
-            } else {
-                if (!session_ticket && s2n_connection_get_session_id_length(conn) <= 0) {
-                    print_s2n_error("Endpoint sent empty session id so cannot resume session");
-                    exit(1);
-                }
-                free(session_state);
-                session_state_length = s2n_connection_get_session_length(conn);
-                session_state = calloc(session_state_length, sizeof(uint8_t));
-                GUARD_EXIT_NULL(session_state);
-                if (s2n_connection_get_session(conn, session_state, session_state_length) != session_state_length) {
-                    print_s2n_error("Error getting serialized session state");
-                    exit(1);
-                }
+        if (reconnect > 0 && conn->actual_protocol_version < S2N_TLS13) {
+            if (!session_ticket && s2n_connection_get_session_id_length(conn) <= 0) {
+                print_s2n_error("Endpoint sent empty session id so cannot resume session");
+                exit(1);
             }
+            free(session_state);
+            session_state_length = s2n_connection_get_session_length(conn);
+            session_state = calloc(session_state_length, sizeof(uint8_t));
+            GUARD_EXIT_NULL(session_state);
+            if (s2n_connection_get_session(conn, session_state, session_state_length) != session_state_length) {
+                print_s2n_error("Error getting serialized session state");
+                exit(1);
+            }
+        }
+
+        /* We call echo each reconnect if session tickets are enabled in TLS1.3
+         * to ensure we've read any post-handshake messages sent by the server. */
+        if (conn->actual_protocol_version >= S2N_TLS13 && session_ticket) {
+            GUARD_EXIT(echo(conn, sockfd, &session_ticket_recv), "Error calling echo");
         }
 
         if (dyn_rec_threshold > 0 && dyn_rec_timeout > 0) {

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -394,11 +394,7 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
     /* TODO: However, we should expect to receive a close_notify from the peer and shutdown gracefully. */
     /* Please see tracking issue for more detail: https://github.com/aws/s2n-tls/issues/2692 */
     s2n_blocked_status blocked;
-    int shutdown_rc = s2n_shutdown(conn, &blocked);
-    if (shutdown_rc == -1 && blocked != S2N_BLOCKED_ON_READ) {
-        fprintf(stderr, "Unexpected error during shutdown: '%s'\n", s2n_strerror(s2n_errno, "NULL"));
-        exit(1);
-    }
+    s2n_shutdown(conn, &blocked);
 
     GUARD_RETURN(s2n_connection_wipe(conn), "Error wiping connection");
 

--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -18,7 +18,7 @@ from enum import Enum
 
 # Number of lines of output to stdout s2nc or s2nd are expected
 # to produce after a successful handshake
-NUM_EXPECTED_LINES_OUTPUT = 11
+NUM_EXPECTED_LINES_OUTPUT = 12
 
 class OCSP(Enum):
     ENABLED = 1

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -140,7 +140,7 @@ class S2N(Provider):
             cmd_line.append('-e')
 
         # This is the last thing printed by s2nc before it is ready to send/receive data
-        self.ready_to_send_input_marker = 'Cipher negotiated:'
+        self.ready_to_send_input_marker = 'Ready to send'
 
         if self.options.use_session_ticket is False:
             cmd_line.append('-T')

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -140,7 +140,7 @@ class S2N(Provider):
             cmd_line.append('-e')
 
         # This is the last thing printed by s2nc before it is ready to send/receive data
-        self.ready_to_send_input_marker = 'Ready to send'
+        self.ready_to_send_input_marker = 's2n is ready'
 
         if self.options.use_session_ticket is False:
             cmd_line.append('-T')

--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -3,11 +3,11 @@ import os
 import pytest
 import time
 
-from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS, PROTOCOLS
-from common import ProviderOptions, Protocols
+from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS, PROTOCOLS, TLS13_CIPHERS
+from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process
 from providers import Provider, S2N, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version
+from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, get_expected_openssl_version
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -18,7 +18,6 @@ from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("use_ticket", [True, False])
 def test_session_resumption_s2n_server(managed_process, cipher, curve, protocol, provider, certificate, use_ticket):
-    host = "localhost"
     port = next(available_ports)
 
     client_options = ProviderOptions(
@@ -66,7 +65,6 @@ def test_session_resumption_s2n_server(managed_process, cipher, curve, protocol,
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("use_ticket", [True, False])
 def test_session_resumption_s2n_client(managed_process, cipher, curve, protocol, provider, certificate, use_ticket):
-    host = "localhost"
     port = next(available_ports)
 
     client_options = ProviderOptions(
@@ -102,3 +100,127 @@ def test_session_resumption_s2n_client(managed_process, cipher, curve, protocol,
         assert results.exception is None
         assert results.exit_code == 0
         assert results.stdout.count(bytes("6 server accepts that finished".encode('utf-8')))
+
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
+@pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
+def test_tls13_session_resumption_s2n_server(managed_process, cipher, curve, protocol, provider, certificate):
+    port = str(next(available_ports))
+
+    ticket_filename = 'session_ticket_' + port
+
+    client_options = ProviderOptions(
+        mode=Provider.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=cipher,
+        curve=curve,
+        insecure=True,
+        reconnect=False,
+        extra_flags = ['-sess_out', ticket_filename],
+        data_to_send = data_bytes(4096),
+        protocol=protocol)
+
+    server_options = copy.copy(client_options)
+    server_options.mode = Provider.ServerMode
+    server_options.key = certificate.key
+    server_options.cert = certificate.cert
+    server_options.use_session_ticket = True
+    server_options.extra_flags = None
+
+    server = managed_process(S2N, server_options, timeout=5)
+    client = managed_process(provider, client_options, timeout=5)
+
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+
+    for results in server.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+
+    # Client inputs stored session ticket to resume a session
+    assert os.path.exists(ticket_filename)
+    client_options.extra_flags = ['-sess_in', ticket_filename]
+
+    port = str(next(available_ports))
+    client_options.port = port
+    server_options.port = port
+
+    server = managed_process(S2N, server_options, timeout=5)
+    client = managed_process(provider, client_options, timeout=5)
+
+    openssl_version = get_expected_openssl_version(protocol)
+    s2n_version = get_expected_s2n_version(protocol, OpenSSL)
+
+    # The client should have received a session ticket
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        assert b'Post-Handshake New Session Ticket arrived:' in results.stdout
+        assert bytes("Protocol  : {}".format(openssl_version).encode('utf-8')) in results.stdout
+
+    # The server should indicate a session has been resumed
+    for results in server.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        assert b'Resumed session' in results.stdout
+        assert bytes("Actual protocol version: {}".format(s2n_version).encode('utf-8')) in results.stdout
+
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
+@pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
+def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, protocol, provider, certificate):
+    port = str(next(available_ports))
+
+    random_bytes = data_bytes(64)
+    num_full_connections = 1
+    num_resumed_connections = 5
+
+    server_close_marker = b'Client has finished sending data'
+
+    client_options = ProviderOptions(
+        mode=Provider.ClientMode,
+        host="localhost",
+        port=port,
+        cipher=cipher,
+        curve=curve,
+        insecure=True,
+        use_session_ticket=True,
+        data_to_send=server_close_marker,
+        reconnect=True,
+        protocol=protocol)
+
+    server_options = copy.copy(client_options)
+    server_options.mode = Provider.ServerMode
+    server_options.key = certificate.key
+    server_options.cert = certificate.cert
+    server_options.use_session_ticket = False
+    server_options.reconnects_before_exit = num_resumed_connections + num_full_connections
+    client_send_marker = b"Server has finished sending data"
+    server_options.data_to_send = [random_bytes, random_bytes, random_bytes, random_bytes, client_send_marker]
+
+    send_marker = 'Secure Renegotiation IS supported'
+    server = managed_process(provider, server_options, timeout=5, send_marker=send_marker, close_marker=str(server_close_marker))
+    client = managed_process(S2N, client_options, timeout=5, send_marker=str(client_send_marker))
+
+    s2n_version = get_expected_s2n_version(protocol, OpenSSL)
+
+    for results in client.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        assert results.stdout.count(b'Resumed session') == num_resumed_connections
+        assert bytes("Actual protocol version: {}".format(s2n_version).encode('utf-8')) in results.stdout
+
+    for results in server.get_results():
+        assert results.exception is None
+        assert results.exit_code == 0
+        assert results.stderr.count(b'SSL_accept:SSLv3/TLS write certificate') == num_full_connections

--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -227,8 +227,8 @@ def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, pro
     for results in server.get_results():
         assert results.exception is None
         assert results.exit_code == 0
-        assert not results.stderr
         if provider is S2N:
+            assert not results.stderr
             assert results.stdout.count(b'Resumed session') == num_resumed_connections
             assert bytes("Actual protocol version: {}".format(s2n_version).encode('utf-8')) in results.stdout
         else:

--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -111,9 +111,8 @@ def test_session_resumption_s2n_client(managed_process, cipher, curve, protocol,
 def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, curve, protocol, provider, certificate):
     port = str(next(available_ports))
 
-    ticket_filename = 'session_ticket_' + port + '.pem'
     # Use temp directory to store session tickets
-    p = tmp_path / ticket_filename
+    p = tmp_path / 'ticket.pem'
     path_to_ticket = str(p)
 
     client_options = ProviderOptions(
@@ -224,9 +223,10 @@ def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, pro
         assert results.stdout.count(b'Resumed session') == num_resumed_connections
         assert bytes("Actual protocol version: {}".format(s2n_version).encode('utf-8')) in results.stdout
 
-    # s_server only writes one certificate message in all of the connections
+    server_accepts_str = str(num_resumed_connections + num_full_connections) + " server accepts that finished"
     for results in server.get_results():
         assert results.exception is None
         assert results.exit_code == 0
-        assert bytes("6 server accepts that finished".encode('utf-8')) in results.stdout
+        assert bytes(server_accepts_str.encode('utf-8')) in results.stdout
+        # s_server only writes one certificate message in all of the connections
         assert results.stderr.count(b'SSL_accept:SSLv3/TLS write certificate') == num_full_connections

--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -7,7 +7,7 @@ from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, AL
 from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process
 from providers import Provider, S2N, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, get_expected_openssl_version
+from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -123,6 +123,7 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
         curve=curve,
         insecure=True,
         reconnect=False,
+        data_to_send=data_bytes(4069),
         extra_flags = ['-sess_out', path_to_ticket],
         protocol=protocol)
 
@@ -159,13 +160,11 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
     server = managed_process(S2N, server_options, timeout=5)
     client = managed_process(provider, client_options, timeout=5)
 
-    openssl_version = get_expected_openssl_version(protocol)
     s2n_version = get_expected_s2n_version(protocol, OpenSSL)
 
     for results in client.get_results():
         assert results.exception is None
         assert results.exit_code == 0
-        assert bytes("Protocol  : {}".format(openssl_version).encode('utf-8')) in results.stdout
 
     # The server should indicate a session has been resumed
     for results in server.get_results():

--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -185,7 +185,7 @@ def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, pro
     num_full_connections = 1
     num_resumed_connections = 5
 
-    server_close_marker = b'Client has finished sending data'
+    client_data = b'Client has finished sending data'
 
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
@@ -195,7 +195,7 @@ def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, pro
         curve=curve,
         insecure=True,
         use_session_ticket=True,
-        data_to_send=server_close_marker,
+        data_to_send=client_data,
         reconnect=True,
         protocol=protocol)
 
@@ -205,12 +205,12 @@ def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, pro
     server_options.cert = certificate.cert
     server_options.use_session_ticket = False
     server_options.reconnects_before_exit = num_resumed_connections + num_full_connections
-    client_send_marker = b"Server has finished sending data"
-    server_options.data_to_send = [random_bytes, random_bytes, random_bytes, random_bytes, client_send_marker]
-
+    end_of_server_data = b"Server has finished sending data"
+    server_options.data_to_send = [random_bytes, random_bytes, random_bytes, random_bytes, end_of_server_data]
     send_marker = 'Secure Renegotiation IS supported'
-    server = managed_process(provider, server_options, timeout=5, send_marker=send_marker, close_marker=str(server_close_marker))
-    client = managed_process(S2N, client_options, timeout=5, send_marker=str(client_send_marker))
+
+    server = managed_process(provider, server_options, timeout=5, send_marker=send_marker, close_marker=str(client_data))
+    client = managed_process(S2N, client_options, timeout=5, send_marker=str(end_of_server_data))
 
     s2n_version = get_expected_s2n_version(protocol, OpenSSL)
 

--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -107,8 +107,7 @@ def test_session_resumption_s2n_client(managed_process, cipher, curve, protocol,
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
-@pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
-def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, curve, protocol, provider, certificate):
+def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, curve, protocol, certificate):
     port = str(next(available_ports))
 
     # Use temp directory to store session tickets
@@ -135,7 +134,7 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
     server_options.extra_flags = None
 
     server = managed_process(S2N, server_options, timeout=5)
-    client = managed_process(provider, client_options, timeout=5)
+    client = managed_process(OpenSSL, client_options, timeout=5)
 
     # The client should have received a session ticket
     for results in client.get_results():
@@ -158,11 +157,11 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
     server_options.port = port
 
     server = managed_process(S2N, server_options, timeout=5)
-    client = managed_process(provider, client_options, timeout=5)
+    client = managed_process(OpenSSL, client_options, timeout=5)
 
-    s2n_version = get_expected_s2n_version(protocol, provider)
+    s2n_version = get_expected_s2n_version(protocol, OpenSSL)
 
-    # Client as not read server certificate message as this is a resumed session
+    # Client has not read server certificate message as this is a resumed session
     for results in client.get_results():
         assert results.exception is None
         assert results.exit_code == 0
@@ -241,8 +240,7 @@ def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, pro
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
-@pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
-def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, curve, protocol, provider, certificate):
+def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, curve, protocol, certificate):
     port = str(next(available_ports))
 
     # Use temp directory to store session tickets
@@ -273,8 +271,8 @@ def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, c
     server_options.cert = certificate.cert
     server_options.extra_flags = None
 
-    server = managed_process(provider, server_options, timeout=5)
-    client = managed_process(provider, client_options, timeout=5)
+    server = managed_process(OpenSSL, server_options, timeout=5)
+    client = managed_process(OpenSSL, client_options, timeout=5)
 
     # The client should have received a session ticket
     for results in client.get_results():
@@ -298,7 +296,7 @@ def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, c
 
     # Switch providers so now s2n is the server
     server = managed_process(S2N, server_options, timeout=5)
-    client = managed_process(provider, client_options, timeout=5)
+    client = managed_process(OpenSSL, client_options, timeout=5)
 
     s2n_version = get_expected_s2n_version(protocol, OpenSSL)
 

--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -107,7 +107,8 @@ def test_session_resumption_s2n_client(managed_process, cipher, curve, protocol,
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
-def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, curve, protocol, certificate):
+@pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
+def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, curve, protocol, provider, certificate):
     port = str(next(available_ports))
 
     # Use temp directory to store session tickets
@@ -134,7 +135,7 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
     server_options.extra_flags = None
 
     server = managed_process(S2N, server_options, timeout=5)
-    client = managed_process(OpenSSL, client_options, timeout=5)
+    client = managed_process(provider, client_options, timeout=5)
 
     # The client should have received a session ticket
     for results in client.get_results():
@@ -157,9 +158,9 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
     server_options.port = port
 
     server = managed_process(S2N, server_options, timeout=5)
-    client = managed_process(OpenSSL, client_options, timeout=5)
+    client = managed_process(provider, client_options, timeout=5)
 
-    s2n_version = get_expected_s2n_version(protocol, OpenSSL)
+    s2n_version = get_expected_s2n_version(protocol, provider)
 
     # Client has not read server certificate message as this is a resumed session
     for results in client.get_results():
@@ -211,7 +212,7 @@ def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, pro
     server = managed_process(provider, server_options, timeout=5)
     client = managed_process(S2N, client_options, timeout=5)
 
-    s2n_version = get_expected_s2n_version(protocol, OpenSSL)
+    s2n_version = get_expected_s2n_version(protocol, provider)
 
     # s2nc indicates the number of resumed connections in its output
     for results in client.get_results():
@@ -240,7 +241,8 @@ def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, pro
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
-def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, curve, protocol, certificate):
+@pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
+def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, curve, protocol, provider, certificate):
     port = str(next(available_ports))
 
     # Use temp directory to store session tickets
@@ -271,8 +273,8 @@ def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, c
     server_options.cert = certificate.cert
     server_options.extra_flags = None
 
-    server = managed_process(OpenSSL, server_options, timeout=5)
-    client = managed_process(OpenSSL, client_options, timeout=5)
+    server = managed_process(provider, server_options, timeout=5)
+    client = managed_process(provider, client_options, timeout=5)
 
     # The client should have received a session ticket
     for results in client.get_results():
@@ -296,9 +298,9 @@ def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, c
 
     # Switch providers so now s2n is the server
     server = managed_process(S2N, server_options, timeout=5)
-    client = managed_process(OpenSSL, client_options, timeout=5)
+    client = managed_process(provider, client_options, timeout=5)
 
-    s2n_version = get_expected_s2n_version(protocol, OpenSSL)
+    s2n_version = get_expected_s2n_version(protocol, provider)
 
     # Client has read server certificate because this is a full connection
     for results in client.get_results():


### PR DESCRIPTION
### Resolved issues:

 N/A
### Description of changes: 

Adds tests for TLS1.3 session resumption
### Call-outs:

### Testing:
Integ tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
