### PR TITLE
Integrate sikep434r3 x86_64 assembly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ if(SIKEP434R2_ASM_SUPPORTED)
 endif()
 
 if(SIKEP434R3_ASM_SUPPORTED)
-    target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_SIKEP434R3_ASM)
+    target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_SIKE_P434_R3_ASM)
     message(STATUS "Enabling SIKEP434R3 assembly code")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ endif()
 # If S2N_NO_PQ_ASM is defined, all PQ assembly options will
 # remain turned off by default.
 set(SIKEP434R2_ASM_SUPPORTED false)
+set(SIKEP434R3_ASM_SUPPORTED false)
 set(ADX_SUPPORTED false)
 
 if(S2N_NO_PQ_ASM)
@@ -105,13 +106,12 @@ if(S2N_NO_PQ_ASM)
 else()
     enable_language(ASM)
 
-    # s2n_pq_asm_noop_test.c is just an empty main() function; the
-    # try_compile function in older versions of CMake requires a main()
+    # sikep434r2
     try_compile(
         SIKEP434R2_ASM_SUPPORTED
         ${CMAKE_BINARY_DIR}
         SOURCES
-            "${CMAKE_CURRENT_LIST_DIR}/tests/unit/s2n_pq_asm_noop_test.c"
+            "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
             "${CMAKE_CURRENT_LIST_DIR}/pq-crypto/sike_r2/sikep434r2_fp_x64_asm.S"
     )
 
@@ -124,8 +124,35 @@ else()
             ADX_SUPPORTED
             ${CMAKE_BINARY_DIR}
             SOURCES
-                "${CMAKE_CURRENT_LIST_DIR}/tests/unit/s2n_pq_asm_noop_test.c"
+                "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
                 "${CMAKE_CURRENT_LIST_DIR}/pq-crypto/sike_r2/sikep434r2_fp_x64_asm.S"
+            COMPILE_DEFINITIONS
+                "-DS2N_ADX"
+        )
+    endif()
+
+    # sikep434r3
+    try_compile(
+        SIKEP434R3_ASM_SUPPORTED
+        ${CMAKE_BINARY_DIR}
+        SOURCES
+            "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
+            "${CMAKE_CURRENT_LIST_DIR}/pq-crypto/sike_r3/sikep434r3.c"
+            "${CMAKE_CURRENT_LIST_DIR}/pq-crypto/sike_r3/sikep434r3_fp_x64_asm.S"
+    )
+
+    if(SIKEP434R3_ASM_SUPPORTED)
+        file(GLOB SIKEP434R3_ASM_SRC "pq-crypto/sike_r3/sikep434r3_fp_x64_asm.S")
+        list(APPEND PQ_SRC ${SIKEP434R3_ASM_SRC})
+
+        # The ADX instruction set is preferred for best performance, but not necessary.
+        try_compile(
+            ADX_SUPPORTED
+            ${CMAKE_BINARY_DIR}
+            SOURCES
+                "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
+                "${CMAKE_CURRENT_LIST_DIR}/pq-crypto/sike_r3/sikep434r3.c"
+                "${CMAKE_CURRENT_LIST_DIR}/pq-crypto/sike_r3/sikep434r3_fp_x64_asm.S"
             COMPILE_DEFINITIONS
                 "-DS2N_ADX"
         )
@@ -223,6 +250,11 @@ endif()
 if(SIKEP434R2_ASM_SUPPORTED)
     target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_SIKEP434R2_ASM)
     message(STATUS "Enabling SIKEP434R2 assembly code")
+endif()
+
+if(SIKEP434R3_ASM_SUPPORTED)
+    target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_SIKEP434R3_ASM)
+    message(STATUS "Enabling SIKEP434R3 assembly code")
 endif()
 
 if(ADX_SUPPORTED)

--- a/pq-crypto/Makefile
+++ b/pq-crypto/Makefile
@@ -35,7 +35,7 @@ all: $(OBJS)
 	$(MAKE) -C kyber_r2
 	$(MAKE) -C kyber_90s_r2
 	$(MAKE) -C kyber_r3
-	$(MAKE) -C sike_r3
+	$(MAKE) -C sike_r3 try_include_asm
 endif
 
 .PHONY : sike_r1_bc

--- a/pq-crypto/s2n_pq.c
+++ b/pq-crypto/s2n_pq.c
@@ -84,7 +84,7 @@ bool s2n_cpu_supports_sikep434r2_asm() {
 }
 
 bool s2n_cpu_supports_sikep434r3_asm() {
-#if defined(S2N_SIKEP434R3_ASM)
+#if defined(S2N_SIKE_P434_R3_ASM)
     /* The sikep434r3 assembly code always requires BMI2. If the assembly
      * was compiled with support for ADX, we also require ADX at runtime. */
 #if defined(S2N_ADX)
@@ -95,7 +95,7 @@ bool s2n_cpu_supports_sikep434r3_asm() {
 #else
     /* sikep434r3 assembly was not supported at compile time */
     return false;
-#endif /* defined(S2N_SIKEP434R3_ASM) */
+#endif /* defined(S2N_SIKE_P434_R3_ASM) */
 }
 
 #else /* defined(S2N_CPUID_AVAILABLE) */

--- a/pq-crypto/s2n_pq.h
+++ b/pq-crypto/s2n_pq.h
@@ -21,7 +21,10 @@
 #include "crypto/s2n_fips.h"
 
 bool s2n_sikep434r2_asm_is_enabled(void);
+bool s2n_sikep434r3_asm_is_enabled(void);
 bool s2n_pq_is_enabled(void);
 S2N_RESULT s2n_disable_sikep434r2_asm(void);
+S2N_RESULT s2n_disable_sikep434r3_asm(void);
 S2N_RESULT s2n_try_enable_sikep434r2_asm(void);
+S2N_RESULT s2n_try_enable_sikep434r3_asm(void);
 S2N_RESULT s2n_pq_init(void);

--- a/pq-crypto/s2n_pq_asm.mk
+++ b/pq-crypto/s2n_pq_asm.mk
@@ -15,6 +15,7 @@
 
 # To ensure CPU compatibility, try to compile all ASM code before including it in the build.
 TRY_COMPILE_SIKEP434R2_ASM = -1
+TRY_COMPILE_SIKEP434R3_ASM = -1
 
 ifndef S2N_NO_PQ_ASM
 	# sikep434r2
@@ -34,4 +35,22 @@ ifndef S2N_NO_PQ_ASM
 
 		SIKEP434R2_ASM_OBJ=$(SIKEP434R2_ASM_SRC:.S=.o)
 	endif
+
+	# sikep434r3
+	SIKEP434R3_ASM_SRC := $(shell find . -name "sikep434r3_fp_x64_asm.S")
+	SIKEP434R3_ASM_TEST_OUT := "test_sikep434r3_fp_x64_asm.o"
+	TRY_COMPILE_SIKEP434R3_ASM := $(shell $(CC) -c -o $(SIKEP434R3_ASM_TEST_OUT) $(SIKEP434R3_ASM_SRC) > /dev/null 2>&1; echo $$?; rm $(SIKEP434R3_ASM_TEST_OUT) > /dev/null 2>&1)
+	ifeq ($(TRY_COMPILE_SIKEP434R3_ASM), 0)
+		CFLAGS += -DS2N_SIKEP434R3_ASM
+		CFLAGS_LLVM += -DS2N_SIKEP434R3_ASM
+
+		# The ADX instruction set is preferred for best performance, but not necessary.
+		TRY_COMPILE_SIKEP434R3_ASM_ADX := $(shell $(CC) -DS2N_ADX -c -o $(SIKEP434R3_ASM_TEST_OUT) $(SIKEP434R3_ASM_SRC) > /dev/null 2>&1; echo $$?; rm $(SIKEP434R3_ASM_TEST_OUT) > /dev/null 2>&1)
+		ifeq ($(TRY_COMPILE_SIKEP434R3_ASM_ADX), 0)
+			CFLAGS += -DS2N_ADX
+			ASFLAGS += -DS2N_ADX
+		endif
+
+		SIKEP434R3_ASM_OBJ=$(SIKEP434R3_ASM_SRC:.S=.o)
+		endif
 endif

--- a/pq-crypto/s2n_pq_asm.mk
+++ b/pq-crypto/s2n_pq_asm.mk
@@ -41,8 +41,8 @@ ifndef S2N_NO_PQ_ASM
 	SIKEP434R3_ASM_TEST_OUT := "test_sikep434r3_fp_x64_asm.o"
 	TRY_COMPILE_SIKEP434R3_ASM := $(shell $(CC) -c -o $(SIKEP434R3_ASM_TEST_OUT) $(SIKEP434R3_ASM_SRC) > /dev/null 2>&1; echo $$?; rm $(SIKEP434R3_ASM_TEST_OUT) > /dev/null 2>&1)
 	ifeq ($(TRY_COMPILE_SIKEP434R3_ASM), 0)
-		CFLAGS += -DS2N_SIKEP434R3_ASM
-		CFLAGS_LLVM += -DS2N_SIKEP434R3_ASM
+		CFLAGS += -DS2N_SIKE_P434_R3_ASM
+		CFLAGS_LLVM += -DS2N_SIKE_P434_R3_ASM
 
 		# The ADX instruction set is preferred for best performance, but not necessary.
 		TRY_COMPILE_SIKEP434R3_ASM_ADX := $(shell $(CC) -DS2N_ADX -c -o $(SIKEP434R3_ASM_TEST_OUT) $(SIKEP434R3_ASM_SRC) > /dev/null 2>&1; echo $$?; rm $(SIKEP434R3_ASM_TEST_OUT) > /dev/null 2>&1)

--- a/pq-crypto/sike_r3/Makefile
+++ b/pq-crypto/sike_r3/Makefile
@@ -13,10 +13,22 @@
 # permissions and limitations under the License.
 #
 
-SRCS=$(wildcard *.c)
-OBJS=$(SRCS:.c=.o)
+C_SRCS=$(wildcard *.c)
+C_OBJS=$(C_SRCS:.c=.o)
 
-.PHONY : all
-all: $(OBJS)
+.PHONY : sikep434r3_c
+sikep434r3_c: $(C_OBJS)
 
 include ../../s2n.mk
+include ../s2n_pq_asm.mk
+
+ifeq ($(TRY_COMPILE_SIKEP434R3_ASM), 0)
+.PHONY : sikep434r3_asm
+sikep434r3_asm: $(SIKEP434R3_ASM_OBJ)
+else
+.PHONY : sikep434r3_asm
+sikep434r3_asm: ;
+endif
+
+.PHONY : try_include_asm
+try_include_asm: sikep434r3_c sikep434r3_asm

--- a/pq-crypto/sike_r3/sikep434r3.h
+++ b/pq-crypto/sike_r3/sikep434r3.h
@@ -100,6 +100,9 @@ typedef struct { f2elm_t X; f2elm_t Z; } point_proj;
 #define point_proj_t S2N_SIKE_P434_R3_NAMESPACE(point_proj_t)
 typedef point_proj point_proj_t[1];
 
+/* Macro to avoid compiler warnings when detecting unreferenced parameters */
+#define S2N_SIKE_P434_R3_UNREFERENCED_PARAMETER(PAR) ((void)(PAR))
+
 /********************** Constant-time unsigned comparisons ***********************/
 /* The following functions return 1 (TRUE) if condition is true, 0 (FALSE) otherwise */
 

--- a/pq-crypto/sike_r3/sikep434r3_fp.c
+++ b/pq-crypto/sike_r3/sikep434r3_fp.c
@@ -5,6 +5,7 @@
 *********************************************************************************************/
 
 #include "sikep434r3.h"
+#include "pq-crypto/s2n_pq.h"
 #include "sikep434r3_fp.h"
 #include "sikep434r3_fpx.h"
 #include "sikep434r3_fp_x64_asm.h"
@@ -192,7 +193,7 @@ void mp_mul(const digit_t* a, const digit_t* b, digit_t* c, const unsigned int n
 {
 #if defined(S2N_SIKEP434R3_ASM)
     if (s2n_sikep434r3_asm_is_enabled()) {
-        UNREFERENCED_PARAMETER(nwords);
+        S2N_SIKE_P434_R3_UNREFERENCED_PARAMETER(nwords);
         mul434_asm(a, b, c);
         return;
     }

--- a/pq-crypto/sike_r3/sikep434r3_fp.c
+++ b/pq-crypto/sike_r3/sikep434r3_fp.c
@@ -7,10 +7,18 @@
 #include "sikep434r3.h"
 #include "sikep434r3_fp.h"
 #include "sikep434r3_fpx.h"
+#include "sikep434r3_fp_x64_asm.h"
 
 /* Multiprecision subtraction with correction with 2*p, c = a-b+2p. */
 void mp_sub434_p2(const digit_t* a, const digit_t* b, digit_t* c)
 {
+#if defined(S2N_SIKEP434R3_ASM)
+    if (s2n_sikep434r3_asm_is_enabled()) {
+        mp_sub434_p2_asm(a, b, c);
+        return;
+    }
+#endif
+
     unsigned int i, borrow = 0;
 
     for (i = 0; i < S2N_SIKE_P434_R3_NWORDS_FIELD; i++) {
@@ -26,6 +34,13 @@ void mp_sub434_p2(const digit_t* a, const digit_t* b, digit_t* c)
 /* Multiprecision subtraction with correction with 4*p, c = a-b+4p. */
 void mp_sub434_p4(const digit_t* a, const digit_t* b, digit_t* c)
 {
+#if defined(S2N_SIKEP434R3_ASM)
+    if (s2n_sikep434r3_asm_is_enabled()) {
+        mp_sub434_p4_asm(a, b, c);
+        return;
+    }
+#endif
+
     unsigned int i, borrow = 0;
 
     for (i = 0; i < S2N_SIKE_P434_R3_NWORDS_FIELD; i++) {
@@ -43,6 +58,12 @@ void mp_sub434_p4(const digit_t* a, const digit_t* b, digit_t* c)
  * Output: c in [0, 2*p434-1] */
 void fpadd434(const digit_t* a, const digit_t* b, digit_t* c)
 {
+#if defined(S2N_SIKEP434R3_ASM)
+    if (s2n_sikep434r3_asm_is_enabled()) {
+        fpadd434_asm(a, b, c);
+        return;
+    }
+#endif
     unsigned int i, carry = 0;
     digit_t mask;
 
@@ -67,6 +88,13 @@ void fpadd434(const digit_t* a, const digit_t* b, digit_t* c)
  * Output: c in [0, 2*p434-1] */
 void fpsub434(const digit_t* a, const digit_t* b, digit_t* c)
 {
+#if defined(S2N_SIKEP434R3_ASM)
+    if (s2n_sikep434r3_asm_is_enabled()) {
+        fpsub434_asm(a, b, c);
+        return;
+    }
+#endif
+
     unsigned int i, borrow = 0;
     digit_t mask;
 
@@ -162,6 +190,14 @@ void digit_x_digit(const digit_t a, const digit_t b, digit_t* c)
 /* Multiprecision comba multiply, c = a*b, where lng(a) = lng(b) = nwords. */
 void mp_mul(const digit_t* a, const digit_t* b, digit_t* c, const unsigned int nwords)
 {
+#if defined(S2N_SIKEP434R3_ASM)
+    if (s2n_sikep434r3_asm_is_enabled()) {
+        UNREFERENCED_PARAMETER(nwords);
+        mul434_asm(a, b, c);
+        return;
+    }
+#endif
+
     unsigned int i, j;
     digit_t t = 0, u = 0, v = 0, UV[2];
     unsigned int carry;
@@ -200,6 +236,13 @@ void mp_mul(const digit_t* a, const digit_t* b, digit_t* c, const unsigned int n
  * ma is assumed to be in Montgomery representation. */
 void rdc_mont(digit_t* ma, digit_t* mc)
 {
+#if defined(S2N_SIKEP434R3_ASM)
+    if (s2n_sikep434r3_asm_is_enabled()) {
+        rdc434_asm(ma, mc);
+        return;
+    }
+#endif
+
     unsigned int i, j, carry, count = S2N_SIKE_P434_R3_ZERO_WORDS;
     digit_t UV[2], t = 0, u = 0, v = 0;
 

--- a/pq-crypto/sike_r3/sikep434r3_fp.c
+++ b/pq-crypto/sike_r3/sikep434r3_fp.c
@@ -13,7 +13,7 @@
 /* Multiprecision subtraction with correction with 2*p, c = a-b+2p. */
 void mp_sub434_p2(const digit_t* a, const digit_t* b, digit_t* c)
 {
-#if defined(S2N_SIKEP434R3_ASM)
+#if defined(S2N_SIKE_P434_R3_ASM)
     if (s2n_sikep434r3_asm_is_enabled()) {
         mp_sub434_p2_asm(a, b, c);
         return;
@@ -35,7 +35,7 @@ void mp_sub434_p2(const digit_t* a, const digit_t* b, digit_t* c)
 /* Multiprecision subtraction with correction with 4*p, c = a-b+4p. */
 void mp_sub434_p4(const digit_t* a, const digit_t* b, digit_t* c)
 {
-#if defined(S2N_SIKEP434R3_ASM)
+#if defined(S2N_SIKE_P434_R3_ASM)
     if (s2n_sikep434r3_asm_is_enabled()) {
         mp_sub434_p4_asm(a, b, c);
         return;
@@ -59,7 +59,7 @@ void mp_sub434_p4(const digit_t* a, const digit_t* b, digit_t* c)
  * Output: c in [0, 2*p434-1] */
 void fpadd434(const digit_t* a, const digit_t* b, digit_t* c)
 {
-#if defined(S2N_SIKEP434R3_ASM)
+#if defined(S2N_SIKE_P434_R3_ASM)
     if (s2n_sikep434r3_asm_is_enabled()) {
         fpadd434_asm(a, b, c);
         return;
@@ -89,7 +89,7 @@ void fpadd434(const digit_t* a, const digit_t* b, digit_t* c)
  * Output: c in [0, 2*p434-1] */
 void fpsub434(const digit_t* a, const digit_t* b, digit_t* c)
 {
-#if defined(S2N_SIKEP434R3_ASM)
+#if defined(S2N_SIKE_P434_R3_ASM)
     if (s2n_sikep434r3_asm_is_enabled()) {
         fpsub434_asm(a, b, c);
         return;
@@ -191,7 +191,7 @@ void digit_x_digit(const digit_t a, const digit_t b, digit_t* c)
 /* Multiprecision comba multiply, c = a*b, where lng(a) = lng(b) = nwords. */
 void mp_mul(const digit_t* a, const digit_t* b, digit_t* c, const unsigned int nwords)
 {
-#if defined(S2N_SIKEP434R3_ASM)
+#if defined(S2N_SIKE_P434_R3_ASM)
     if (s2n_sikep434r3_asm_is_enabled()) {
         S2N_SIKE_P434_R3_UNREFERENCED_PARAMETER(nwords);
         mul434_asm(a, b, c);
@@ -237,7 +237,7 @@ void mp_mul(const digit_t* a, const digit_t* b, digit_t* c, const unsigned int n
  * ma is assumed to be in Montgomery representation. */
 void rdc_mont(digit_t* ma, digit_t* mc)
 {
-#if defined(S2N_SIKEP434R3_ASM)
+#if defined(S2N_SIKE_P434_R3_ASM)
     if (s2n_sikep434r3_asm_is_enabled()) {
         rdc434_asm(ma, mc);
         return;

--- a/pq-crypto/sike_r3/sikep434r3_fp_x64_asm.S
+++ b/pq-crypto/sike_r3/sikep434r3_fp_x64_asm.S
@@ -1,0 +1,1008 @@
+//*******************************************************************************************
+// Supersingular Isogeny Key Encapsulation Library
+//
+// Abstract: field arithmetic in x64 assembly for P434 on Linux
+//*******************************************************************************************
+
+/* Requires bmi2 instruction set for mulx. adx instructions are optional, but preferred. */
+.intel_syntax noprefix
+
+#define S2N_SIKE_P434_R3_NAMESPACE(s) s2n_sike_p434_r3_##s
+
+// Registers that are used for parameter passing:
+#define reg_p1  rdi
+#define reg_p2  rsi
+#define reg_p3  rdx
+
+// Define addition instructions
+#ifdef S2N_ADX
+
+#define ADD1    adox
+#define ADC1    adox
+#define ADD2    adcx
+#define ADC2    adcx
+
+#else
+
+#define ADD1    add
+#define ADC1    adc
+#define ADD2    add
+#define ADC2    adc
+
+#endif
+
+// These variables are declared+defined in sikep434r3.{h, c}
+#define p434 S2N_SIKE_P434_R3_NAMESPACE(p434)
+.extern p434
+
+#define p434x2 S2N_SIKE_P434_R3_NAMESPACE(p434x2)
+.extern p434x2
+
+#define p434x4 S2N_SIKE_P434_R3_NAMESPACE(p434x4)
+.extern p434x4
+
+#define p434p1 S2N_SIKE_P434_R3_NAMESPACE(p434p1)
+.extern p434p1
+
+.text
+
+//***********************************************************************
+//  Field addition
+//  Operation: c [reg_p3] = a [reg_p1] + b [reg_p2]
+//***********************************************************************
+#define fpadd434_asm S2N_SIKE_P434_R3_NAMESPACE(fpadd434_asm)
+.global fpadd434_asm
+fpadd434_asm:
+  push   r12
+  push   r13
+  push   r14
+  push   r15
+  push   rbx
+  push   rbp
+  
+  xor    rax, rax
+  mov    r8, [reg_p1]
+  mov    r9, [reg_p1+8]
+  mov    r10, [reg_p1+16]
+  mov    r11, [reg_p1+24]
+  mov    r12, [reg_p1+32]
+  mov    r13, [reg_p1+40]
+  mov    r14, [reg_p1+48]
+  add    r8, [reg_p2] 
+  adc    r9, [reg_p2+8] 
+  adc    r10, [reg_p2+16] 
+  adc    r11, [reg_p2+24] 
+  adc    r12, [reg_p2+32] 
+  adc    r13, [reg_p2+40] 
+  adc    r14, [reg_p2+48]
+
+  mov    rbx, [rip+p434x2]
+  sub    r8, rbx
+  mov    rcx, [rip+p434x2+8]
+  sbb    r9, rcx
+  sbb    r10, rcx
+  mov    rdi, [rip+p434x2+24]
+  sbb    r11, rdi
+  mov    rsi, [rip+p434x2+32]
+  sbb    r12, rsi
+  mov    rbp, [rip+p434x2+40]
+  sbb    r13, rbp
+  mov    r15, [rip+p434x2+48]
+  sbb    r14, r15
+  sbb    rax, 0
+  
+  and    rbx, rax
+  and    rcx, rax
+  and    rdi, rax
+  and    rsi, rax
+  and    rbp, rax
+  and    r15, rax
+  
+  add    r8, rbx  
+  adc    r9, rcx  
+  adc    r10, rcx  
+  adc    r11, rdi 
+  adc    r12, rsi 
+  adc    r13, rbp   
+  adc    r14, r15
+  mov    [reg_p3], r8
+  mov    [reg_p3+8], r9 
+  mov    [reg_p3+16], r10 
+  mov    [reg_p3+24], r11
+  mov    [reg_p3+32], r12 
+  mov    [reg_p3+40], r13 
+  mov    [reg_p3+48], r14
+  
+  pop    rbp
+  pop    rbx
+  pop    r15
+  pop    r14
+  pop    r13
+  pop    r12
+  ret
+
+//***********************************************************************
+//  Field subtraction
+//  Operation: c [reg_p3] = a [reg_p1] - b [reg_p2]
+//***********************************************************************
+#define fpsub434_asm S2N_SIKE_P434_R3_NAMESPACE(fpsub434_asm)
+.global fpsub434_asm
+fpsub434_asm:
+  push   r12
+  push   r13
+  push   r14
+  
+  xor    rax, rax
+  mov    r8, [reg_p1]
+  mov    r9, [reg_p1+8]
+  mov    r10, [reg_p1+16]
+  mov    r11, [reg_p1+24]
+  mov    r12, [reg_p1+32]
+  mov    r13, [reg_p1+40]
+  mov    r14, [reg_p1+48]
+  sub    r8, [reg_p2] 
+  sbb    r9, [reg_p2+8] 
+  sbb    r10, [reg_p2+16] 
+  sbb    r11, [reg_p2+24] 
+  sbb    r12, [reg_p2+32] 
+  sbb    r13, [reg_p2+40] 
+  sbb    r14, [reg_p2+48]
+  sbb    rax, 0
+  
+  mov    rcx, [rip+p434x2]
+  mov    rdi, [rip+p434x2+8]
+  mov    rsi, [rip+p434x2+24]
+  and    rcx, rax
+  and    rdi, rax
+  and    rsi, rax  
+  add    r8, rcx  
+  adc    r9, rdi  
+  adc    r10, rdi  
+  adc    r11, rsi 
+  mov    [reg_p3], r8
+  mov    [reg_p3+8], r9 
+  mov    [reg_p3+16], r10 
+  mov    [reg_p3+24], r11 
+  setc   cl  
+
+  mov    r8, [rip+p434x2+32]
+  mov    rdi, [rip+p434x2+40]
+  mov    rsi, [rip+p434x2+48]
+  and    r8, rax
+  and    rdi, rax
+  and    rsi, rax  
+  bt     rcx, 0  
+  adc    r12, r8 
+  adc    r13, rdi   
+  adc    r14, rsi
+  mov    [reg_p3+32], r12 
+  mov    [reg_p3+40], r13
+  mov    [reg_p3+48], r14
+  
+  pop    r14
+  pop    r13
+  pop    r12
+  ret
+
+///////////////////////////////////////////////////////////////// MACRO
+.macro SUB434_PX  P0
+  push   r12
+  push   r13
+
+  mov    r8, [reg_p1]
+  mov    r9, [reg_p1+8]
+  mov    r10, [reg_p1+16]
+  mov    r11, [reg_p1+24]
+  mov    r12, [reg_p1+32]
+  mov    r13, [reg_p1+40]
+  mov    rcx, [reg_p1+48]
+  sub    r8, [reg_p2]
+  sbb    r9, [reg_p2+8]
+  sbb    r10, [reg_p2+16]
+  sbb    r11, [reg_p2+24]
+  sbb    r12, [reg_p2+32]
+  sbb    r13, [reg_p2+40]
+  sbb    rcx, [reg_p2+48]
+
+  mov    rax, [rip+\P0]
+  mov    rdi, [rip+\P0+8]
+  mov    rsi, [rip+\P0+24]
+  add    r8, rax
+  mov    rax, [rip+\P0+32]
+  adc    r9, rdi
+  adc    r10, rdi
+  adc    r11, rsi
+  mov    rdi, [rip+\P0+40]
+  mov    rsi, [rip+\P0+48]
+  adc    r12, rax
+  adc    r13, rdi
+  adc    rcx, rsi
+  mov    [reg_p3], r8
+  mov    [reg_p3+8], r9
+  mov    [reg_p3+16], r10
+  mov    [reg_p3+24], r11
+  mov    [reg_p3+32], r12
+  mov    [reg_p3+40], r13
+  mov    [reg_p3+48], rcx
+
+  pop    r13
+  pop    r12
+.endm
+
+//***********************************************************************
+//  Multiprecision subtraction with correction with 2*p434
+//  Operation: c [reg_p3] = a [reg_p1] - b [reg_p2] + 2*p434
+//***********************************************************************
+#define mp_sub434_p2_asm S2N_SIKE_P434_R3_NAMESPACE(mp_sub434_p2_asm)
+.global mp_sub434_p2_asm
+mp_sub434_p2_asm:
+  SUB434_PX  p434x2
+  ret
+
+//***********************************************************************
+//  Multiprecision subtraction with correction with 4*p434
+//  Operation: c [reg_p3] = a [reg_p1] - b [reg_p2] + 4*p434
+//***********************************************************************
+#define mp_sub434_p4_asm S2N_SIKE_P434_R3_NAMESPACE(mp_sub434_p4_asm)
+.global mp_sub434_p4_asm
+mp_sub434_p4_asm:
+  SUB434_PX  p434x4
+  ret
+    
+///////////////////////////////////////////////////////////////// MACRO
+// Schoolbook integer multiplication
+// Inputs:  memory pointers M0 and M1
+// Outputs: memory pointer C and regs T1, T3, rax
+// Temps:   regs T0:T6
+/////////////////////////////////////////////////////////////////
+#ifdef S2N_ADX
+
+.macro MUL192_SCHOOL M0, M1, C, T0, T1, T2, T3, T4, T5, T6
+  mov    rdx, \M0
+  mulx   \T0, \T1, \M1     // T0:T1 = A0*B0
+  mov    \C, \T1           // C0_final
+  mulx   \T1, \T2, 8\M1    // T1:T2 = A0*B1
+  xor    rax, rax
+  adox   \T0, \T2
+  mulx   \T2, \T3, 16\M1   // T2:T3 = A0*B2
+  adox   \T1, \T3
+
+  mov    rdx, 8\M0
+  mulx   \T3, \T4, \M1     // T3:T4 = A1*B0
+  adox   \T2, rax
+  xor    rax, rax
+  mulx   \T5, \T6, 8\M1    // T5:T6 = A1*B1
+  adox   \T4, \T0
+  mov    8\C, \T4          // C1_final
+  adcx   \T3, \T6
+  mulx   \T6, \T0, 16\M1   // T6:T0 = A1*B2
+  adox   \T3, \T1
+  adcx   \T5, \T0
+  adcx   \T6, rax
+  adox   \T5, \T2
+
+  mov    rdx, 16\M0
+  mulx   \T1, \T0, \M1     // T1:T0 = A2*B0
+  adox   \T6, rax
+  xor    rax, rax
+  mulx   \T4, \T2, 8\M1    // T4:T2 = A2*B1
+  adox   \T0, \T3
+  mov    16\C, \T0         // C2_final
+  adcx   \T1, \T5
+  mulx   \T0, \T3, 16\M1   // T0:T3 = A2*B2
+  adcx   \T4, \T6
+  adcx   \T0, rax
+  adox   \T1, \T2
+  adox   \T3, \T4
+  adox   rax, \T0
+.endm 
+
+///////////////////////////////////////////////////////////////// MACRO
+// Schoolbook integer multiplication
+// Inputs:  memory pointers M0 and M1
+// Outputs: memory pointer C
+// Temps:   regs T0:T9
+/////////////////////////////////////////////////////////////////
+.macro MUL256_SCHOOL M0, M1, C, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9
+  mov    rdx, \M0
+  mulx   \T0, \T1, \M1     // T0:T1 = A0*B0
+  mov    \C, \T1           // C0_final
+  mulx   \T1, \T2, 8\M1    // T1:T2 = A0*B1
+  xor    rax, rax
+  adox   \T0, \T2
+  mulx   \T2, \T3, 16\M1   // T2:T3 = A0*B2
+  adox   \T1, \T3
+  mulx   \T3, \T4, 24\M1   // T3:T4 = A0*B3
+  adox   \T2, \T4
+
+  mov    rdx, 8\M0
+  mulx   \T5, \T4, \M1     // T5:T4 = A1*B0
+  adox   \T3, rax
+  xor    rax, rax
+  mulx   \T6, \T7, 8\M1    // T6:T7 = A1*B1
+  adox   \T4, \T0
+  mov    8\C, \T4          // C1_final
+  adcx   \T5, \T7
+  mulx   \T7, \T8, 16\M1   // T7:T8 = A1*B2
+  adcx   \T6, \T8
+  adox   \T5, \T1
+  mulx   \T8, \T9, 24\M1   // T8:T9 = A1*B3
+  adcx   \T7, \T9
+  adcx   \T8, rax
+  adox   \T6, \T2
+
+  mov    rdx, 16\M0
+  mulx   \T1, \T0, \M1     // T1:T0 = A2*B0
+  adox   \T7, \T3
+  adox   \T8, rax
+  xor    rax, rax
+  mulx   \T2, \T3, 8\M1    // T2:T3 = A2*B1
+  adox   \T0, \T5
+  mov    16\C, \T0         // C2_final
+  adcx   \T1, \T3
+  mulx   \T3, \T4, 16\M1   // T3:T4 = A2*B2
+  adcx   \T2, \T4
+  adox   \T1, \T6
+  mulx   \T4,\T9, 24\M1    // T3:T4 = A2*B3
+  adcx   \T3, \T9
+  mov    rdx, 24\M0
+  adcx   \T4, rax
+
+  adox   \T2, \T7
+  adox   \T3, \T8
+  adox   \T4, rax
+
+  mulx   \T5, \T0, \M1     // T5:T0 = A3*B0
+  xor    rax, rax
+  mulx   \T6, \T7, 8\M1    // T6:T7 = A3*B1
+  adcx   \T5, \T7
+  adox   \T1, \T0
+  mulx   \T7, \T8, 16\M1   // T7:T8 = A3*B2
+  adcx   \T6, \T8
+  adox   \T2, \T5
+  mulx   \T8, \T9, 24\M1   // T8:T9 = A3*B3
+  adcx   \T7, \T9
+  adcx   \T8, rax
+
+  adox   \T3, \T6
+  adox   \T4, \T7
+  adox   \T8, rax
+  mov    24\C, \T1         // C3_final
+  mov    32\C, \T2         // C4_final
+  mov    40\C, \T3         // C5_final
+  mov    48\C, \T4         // C6_final
+  mov    56\C, \T8         // C7_final
+.endm 
+
+#else // S2N_ADX
+
+.macro MUL192_SCHOOL M0, M1, C, T0, T1, T2, T3, T4, T5, T6
+  mov    rdx, \M0
+  mulx   \T0, \T1, \M1     // T0:T1 = A0*B0
+  mov    \C, \T1           // C0_final
+  mulx   \T1, \T2, 8\M1    // T1:T2 = A0*B1
+  add    \T0, \T2
+  mulx   \T2, \T3, 16\M1   // T2:T3 = A0*B2
+  adc    \T1, \T3
+
+  mov    rdx, 8\M0
+  mulx   \T3, \T4, \M1     // T3:T4 = A1*B0
+  adc    \T2, 0
+  mulx   \T5, \T6, 8\M1    // T5:T6 = A1*B1
+  add    \T4, \T0
+  mov    8\C, \T4          // C1_final
+  adc    \T3, \T1
+  adc    \T5, \T2
+  mulx   \T2, \T1, 16\M1   // T2:T1 = A1*B2
+  adc    \T2, 0
+
+  add    \T3, \T6
+  adc    \T5, \T1
+  adc    \T2, 0
+
+  mov    rdx, 16\M0
+  mulx   \T1, \T0, \M1     // T1:T0 = A2*B0
+  add    \T0, \T3
+  mov    16\C, \T0         // C2_final
+  mulx   \T4, \T6, 8\M1    // T4:T6 = A2*B1
+  adc    \T1, \T5
+  adc    \T2, \T4
+  mulx   rax, \T3, 16\M1   // rax:T3 = A2*B2
+  adc    rax, 0
+  add    \T1, \T6
+  adc    \T3, \T2
+  adc    rax, 0
+.endm 
+
+.macro MUL256_SCHOOL M0, M1, C, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9
+  mov    rdx, \M0
+  mulx   \T0, \T1, \M1     // T0:T1 = A0*B0
+  mov    \C, \T1           // C0_final
+  mulx   \T1, \T2, 8\M1    // T1:T2 = A0*B1
+  add    \T0, \T2
+  mulx   \T2, \T3, 16\M1   // T2:T3 = A0*B2
+  adc    \T1, \T3
+  mulx   \T3, \T4, 24\M1   // T3:T4 = A0*B3
+  adc    \T2, \T4
+  mov    rdx, 8\M0
+  adc    \T3, 0
+
+  mulx   \T5, \T4, \M1     // T5:T4 = A1*B0
+  mulx   \T6, \T7, 8\M1    // T6:T7 = A1*B1
+  add    \T5, \T7
+  mulx   \T7, \T8, 16\M1   // T7:T8 = A1*B2
+  adc    \T6, \T8
+  mulx   \T8, \T9, 24\M1   // T8:T9 = A1*B3
+  adc    \T7, \T9
+  adc    \T8, 0
+
+  add    \T4, \T0
+  mov    8\C, \T4          // C1_final
+  adc    \T5, \T1
+  adc    \T6, \T2
+  adc    \T7, \T3
+  mov    rdx, 16\M0
+  adc    \T8, 0
+
+  mulx   \T1, \T0, \M1     // T1:T0 = A2*B0
+  mulx   \T2, \T3, 8\M1    // T2:T3 = A2*B1
+  add    \T1, \T3
+  mulx   \T3, \T4, 16\M1   // T3:T4 = A2*B2
+  adc    \T2, \T4
+  mulx   \T4,\T9, 24\M1    // T3:T4 = A2*B3
+  adc    \T3, \T9
+  mov    rdx, 24\M0
+  adc    \T4, 0
+
+  add    \T0, \T5
+  mov    16\C, \T0         // C2_final
+  adc    \T1, \T6
+  adc    \T2, \T7
+  adc    \T3, \T8
+  adc    \T4, 0
+
+  mulx   \T5, \T0, \M1     // T5:T0 = A3*B0
+  mulx   \T6, \T7, 8\M1    // T6:T7 = A3*B1
+  add    \T5, \T7
+  mulx   \T7, \T8, 16\M1   // T7:T8 = A3*B2
+  adc    \T6, \T8
+  mulx   \T8, \T9, 24\M1   // T8:T9 = A3*B3
+  adc    \T7, \T9
+  adc    \T8, 0
+
+  add    \T1, \T0
+  mov    24\C, \T1         // C3_final
+  adc    \T2, \T5
+  mov    32\C, \T2         // C4_final
+  adc    \T3, \T6
+  mov    40\C, \T3         // C5_final
+  adc    \T4, \T7
+  mov    48\C, \T4         // C6_final
+  adc    \T8, 0
+  mov    56\C, \T8         // C7_final
+.endm
+
+#endif // S2N_ADX
+
+//*****************************************************************************
+//  434-bit multiplication using Karatsuba (one level), schoolbook (one level)
+//*****************************************************************************
+#define mul434_asm S2N_SIKE_P434_R3_NAMESPACE(mul434_asm)
+.global mul434_asm
+mul434_asm:
+  push   r12
+  push   r13
+  push   r14
+  push   r15
+  mov    rcx, reg_p3
+
+  // r8-r11 <- AH + AL, rax <- mask
+  xor    rax, rax
+  mov    r8, [reg_p1]
+  mov    r9, [reg_p1+8]
+  mov    r10, [reg_p1+16]
+  mov    r11, [reg_p1+24]
+  push   rbx
+  push   rbp
+  sub    rsp, 96
+  add    r8, [reg_p1+32]
+  adc    r9, [reg_p1+40]
+  adc    r10, [reg_p1+48]
+  adc    r11, 0
+  sbb    rax, 0
+  mov    [rsp], r8
+  mov    [rsp+8], r9
+  mov    [rsp+16], r10
+  mov    [rsp+24], r11
+
+  // r12-r15 <- BH + BL, rbx <- mask
+  xor    rbx, rbx
+  mov    r12, [reg_p2]
+  mov    r13, [reg_p2+8]
+  mov    r14, [reg_p2+16]
+  mov    r15, [reg_p2+24]
+  add    r12, [reg_p2+32]
+  adc    r13, [reg_p2+40]
+  adc    r14, [reg_p2+48]
+  adc    r15, 0
+  sbb    rbx, 0
+  mov    [rsp+32], r12
+  mov    [rsp+40], r13
+  mov    [rsp+48], r14
+  mov    [rsp+56], r15
+
+  // r12-r15 <- masked (BH + BL)
+  and    r12, rax
+  and    r13, rax
+  and    r14, rax
+  and    r15, rax
+
+  // r8-r11 <- masked (AH + AL)
+  and    r8, rbx
+  and    r9, rbx
+  and    r10, rbx
+  and    r11, rbx
+
+  // r8-r11 <- masked (AH + AL) + masked (AH + AL)
+  add    r8, r12
+  adc    r9, r13
+  adc    r10, r14
+  adc    r11, r15
+  mov    [rsp+64], r8
+  mov    [rsp+72], r9
+  mov    [rsp+80], r10
+  mov    [rsp+88], r11
+
+  // [rsp] <- (AH+AL) x (BH+BL), low part
+  MUL256_SCHOOL  [rsp], [rsp+32], [rsp], r8, r9, r10, r11, r12, r13, r14, r15, rbx, rbp
+
+  // [rcx] <- AL x BL
+  MUL256_SCHOOL  [reg_p1], [reg_p2], [rcx], r8, r9, r10, r11, r12, r13, r14, r15, rbx, rbp     // Result C0-C3
+
+  // [rcx+64], rbx, rbp, rax <- AH x BH
+  MUL192_SCHOOL  [reg_p1+32], [reg_p2+32], [rcx+64], r8, rbx, r10, rbp, r12, r13, r14
+
+  // r8-r11 <- (AH+AL) x (BH+BL), final step
+  mov    r8, [rsp+64]
+  mov    r9, [rsp+72]
+  mov    r10, [rsp+80]
+  mov    r11, [rsp+88]
+  mov    rdx, [rsp+32]
+  add    r8, rdx
+  mov    rdx, [rsp+40]
+  adc    r9, rdx
+  mov    rdx, [rsp+48]
+  adc    r10, rdx
+  mov    rdx, [rsp+56]
+  adc    r11, rdx
+
+  // r8-r15 <- (AH+AL) x (BH+BL) - ALxBL
+  mov    r12, [rsp]
+  mov    r13, [rsp+8]
+  mov    r14, [rsp+16]
+  mov    r15, [rsp+24]
+  sub    r12, [rcx]
+  sbb    r13, [rcx+8]
+  sbb    r14, [rcx+16]
+  sbb    r15, [rcx+24]
+  sbb    r8, [rcx+32]
+  sbb    r9, [rcx+40]
+  sbb    r10, [rcx+48]
+  sbb    r11, [rcx+56]
+
+  // r8-r15 <- (AH+AL) x (BH+BL) - ALxBL - AHxBH
+  sub    r12, [rcx+64]
+  sbb    r13, [rcx+72]
+  sbb    r14, [rcx+80]
+  sbb    r15, rbx
+  sbb    r8, rbp
+  sbb    r9, rax
+  sbb    r10, 0
+  sbb    r11, 0
+
+  add    r12, [rcx+32]
+  mov    [rcx+32], r12    // Result C4-C7
+  adc    r13, [rcx+40]
+  mov    [rcx+40], r13
+  adc    r14, [rcx+48]
+  mov    [rcx+48], r14
+  adc    r15, [rcx+56]
+  mov    [rcx+56], r15
+  adc    r8, [rcx+64]
+  mov    [rcx+64], r8    // Result C8-C15
+  adc    r9, [rcx+72]
+  mov    [rcx+72], r9
+  adc    r10, [rcx+80]
+  mov    [rcx+80], r10
+  adc    r11, rbx
+  mov    [rcx+88], r11
+  adc    rbp, 0
+  mov    [rcx+96], rbp
+  adc    rax, 0
+  mov    [rcx+104], rax
+
+  add    rsp, 96
+  pop    rbp
+  pop    rbx
+  pop    r15
+  pop    r14
+  pop    r13
+  pop    r12
+  ret
+
+///////////////////////////////////////////////////////////////// MACRO
+// Schoolbook integer multiplication
+// Inputs:  reg I0 and memory pointer M1
+// Outputs: regs T0:T4
+// Temps:   regs T0:T5
+/////////////////////////////////////////////////////////////////
+.macro MUL64x256_SCHOOL I0, M1, T0, T1, T2, T3, T4, T5 
+  mulx   \T2, \T4, 8\M1
+  xor    rax, rax
+  mulx   \T3, \T5, 16\M1
+  ADD1   \T1, \T4            // T1 <- C1_final
+  ADC1   \T2, \T5            // T2 <- C2_final
+  mulx   \T4, \T5, 24\M1
+  ADC1   \T3, \T5            // T3 <- C3_final
+  ADC1   \T4, rax            // T4 <- C4_final
+.endm
+
+///////////////////////////////////////////////////////////////// MACRO
+// Schoolbook integer multiplication
+// Inputs:  regs I0 and I1, and memory pointer M1
+// Outputs: regs T0:T5
+// Temps:   regs T0:T5
+/////////////////////////////////////////////////////////////////
+#ifdef S2N_ADX
+
+.macro MUL128x256_SCHOOL I0, I1, M1, T0, T1, T2, T3, T4, T5
+  mulx   \T2, \T4, 8\M1
+  xor    rax, rax
+  mulx   \T3, \T5, 16\M1
+  ADD1   \T1, \T4
+  ADC1   \T2, \T5
+  mulx   \T4, \T5, 24\M1
+  ADC1   \T3, \T5
+  ADC1   \T4, rax
+
+  xor    rax, rax
+  mov    rdx, \I1
+  mulx   \I1, \T5, \M1
+  ADD2   \T1, \T5            // T1 <- C1_final
+  ADC2   \T2, \I1
+  mulx   \T5, \I1, 8\M1
+  ADC2   \T3, \T5
+  ADD1   \T2, \I1
+  mulx   \T5, \I1, 16\M1
+  ADC2   \T4, \T5
+  ADC1   \T3, \I1
+  mulx   \T5, \I1, 24\M1
+  ADC2   \T5, rax
+  ADC1   \T4, \I1
+  ADC1   \T5, rax
+.endm
+
+#else // S2N_ADX
+
+.macro MUL128x256_SCHOOL I0, I1, M1, T0, T1, T2, T3, T4, T5 
+  mulx   \T2, \T4, 8\M1
+  mulx   \T3, \T5, 16\M1
+  add    \T1, \T4
+  adc    \T2, \T5
+  mulx   \T4, \T5, 24\M1
+  adc    \T3, \T5
+  adc    \T4, 0
+
+  mov    rdx, \I1
+  mulx   \I1, \T5, \M1
+  add    \T1, \T5            // T1 <- C1_final
+  adc    \T2, \I1
+  mulx   \T5, \I1, 8\M1
+  adc    \T3, \T5
+  mulx   \T5, rax, 16\M1
+  adc    \T4, \T5
+  mulx   \T5, rdx, 24\M1
+  adc    \T5, 0
+  add    \T2, \I1
+  adc    \T3, rax
+  adc    \T4, rdx
+  adc    \T5, 0
+.endm
+
+#endif // S2N_ADX
+
+//**************************************************************************************
+//  Montgomery reduction
+//  Based on method described in Faz-Hernandez et al. https://eprint.iacr.org/2017/1015
+//  Operation: c [reg_p2] = a [reg_p1]
+//**************************************************************************************
+#define rdc434_asm S2N_SIKE_P434_R3_NAMESPACE(rdc434_asm)
+.global rdc434_asm
+rdc434_asm:
+  push   r14
+
+  // a[0-1] x p434p1_nz --> result: r8:r13
+  mov    rdx, [reg_p1]
+  mov    r14, [reg_p1+8]
+  mulx   r9, r8, [rip+p434p1+24]   // result r8
+  push   r12
+  push   r13
+  push   r15
+  push   rbp
+  push   rbx
+  MUL128x256_SCHOOL rdx, r14, [rip+p434p1+24], r8, r9, r10, r11, r12, r13
+
+  mov    rdx, [reg_p1+16]
+  mov    rcx, [reg_p1+72]
+  add    r8, [reg_p1+24]
+  adc    r9, [reg_p1+32]
+  adc    r10, [reg_p1+40]
+  adc    r11, [reg_p1+48]
+  adc    r12, [reg_p1+56]
+  adc    r13, [reg_p1+64]
+  adc    rcx, 0
+  mulx   rbp, rbx, [rip+p434p1+24]   // result rbx
+  mov    [reg_p2], r9
+  mov    [reg_p2+8], r10
+  mov    [reg_p2+16], r11
+  mov    [reg_p2+24], r12
+  mov    [reg_p2+32], r13
+  mov    r9, [reg_p1+80]
+  mov    r10, [reg_p1+88]
+  mov    r11, [reg_p1+96]
+  mov    rdi, [reg_p1+104]
+  adc    r9, 0
+  adc    r10, 0
+  adc    r11, 0
+  adc    rdi, 0
+
+  // a[2-3] x p434p1_nz --> result: rbx, rbp, r12:r15
+  MUL128x256_SCHOOL rdx, r8, [rip+p434p1+24], rbx, rbp, r12, r13, r14, r15
+
+  mov    rdx, [reg_p2]
+  add    rbx, [reg_p2+8]
+  adc    rbp, [reg_p2+16]
+  adc    r12, [reg_p2+24]
+  adc    r13, [reg_p2+32]
+  adc    r14, rcx
+  mov    rcx, 0
+  adc    r15, r9
+  adc    rcx, r10
+  mulx   r9, r8, [rip+p434p1+24]   // result r8
+  mov    [reg_p2], rbp
+  mov    [reg_p2+8], r12
+  mov    [reg_p2+16], r13
+  adc    r11, 0
+  adc    rdi, 0
+
+  // a[4-5] x p434p1_nz --> result: r8:r13
+  MUL128x256_SCHOOL rdx, rbx, [rip+p434p1+24], r8, r9, r10, rbp, r12, r13
+
+  mov    rdx, [reg_p2]
+  add    r8, [reg_p2+8]
+  adc    r9, [reg_p2+16]
+  adc    r10, r14
+  adc    rbp, r15
+  adc    r12, rcx
+  adc    r13, r11
+  adc    rdi, 0
+  mulx   r15, r14, [rip+p434p1+24]  // result r14
+  mov    [reg_p2], r8        // Final result c0-c1
+  mov    [reg_p2+8], r9
+
+  // a[6-7] x p434p1_nz --> result: r14:r15, r8:r9, r11
+  MUL64x256_SCHOOL rdx, [rip+p434p1+24], r14, r15, r8, r9, r11, rcx
+
+  // Final result c2:c6
+  add    r14, r10
+  adc    r15, rbp
+  pop    rbx
+  pop    rbp
+  adc    r8, r12
+  adc    r9, r13
+  adc    r11, rdi
+  mov    [reg_p2+16], r14
+  mov    [reg_p2+24], r15
+  pop    r15
+  pop    r13
+  mov    [reg_p2+32], r8
+  mov    [reg_p2+40], r9
+  mov    [reg_p2+48], r11
+
+  pop    r12
+  pop    r14
+  ret
+
+//***********************************************************************
+//  434-bit multiprecision addition
+//  Operation: c [reg_p3] = a [reg_p1] + b [reg_p2]
+//***********************************************************************
+#define mp_add434_asm S2N_SIKE_P434_R3_NAMESPACE(mp_add434_asm)
+.global mp_add434_asm
+mp_add434_asm:
+  mov    r8, [reg_p1]
+  mov    r9, [reg_p1+8]
+  mov    r10, [reg_p1+16]
+  mov    r11, [reg_p1+24]
+  add    r8, [reg_p2] 
+  adc    r9, [reg_p2+8] 
+  adc    r10, [reg_p2+16] 
+  adc    r11, [reg_p2+24] 
+  mov    [reg_p3], r8
+  mov    [reg_p3+8], r9
+  mov    [reg_p3+16], r10
+  mov    [reg_p3+24], r11
+
+  mov    r8, [reg_p1+32]
+  mov    r9, [reg_p1+40]
+  mov    r10, [reg_p1+48]
+  adc    r8, [reg_p2+32] 
+  adc    r9, [reg_p2+40] 
+  adc    r10, [reg_p2+48] 
+  mov    [reg_p3+32], r8
+  mov    [reg_p3+40], r9
+  mov    [reg_p3+48], r10
+  ret
+
+//***************************************************************************
+//  2x434-bit multiprecision subtraction/addition
+//  Operation: c [reg_p3] = a [reg_p1] - b [reg_p2]. If c < 0, add p434*2^448
+//***************************************************************************
+#define mp_subadd434x2_asm S2N_SIKE_P434_R3_NAMESPACE(mp_subadd434x2_asm)
+.global mp_subadd434x2_asm
+mp_subadd434x2_asm:
+  push   r12
+  push   r13 
+  push   r14 
+  push   r15 
+  xor    rax, rax
+  mov    r8, [reg_p1]
+  mov    r9, [reg_p1+8]
+  mov    r10, [reg_p1+16]
+  mov    r11, [reg_p1+24]
+  mov    r12, [reg_p1+32]
+  sub    r8, [reg_p2] 
+  sbb    r9, [reg_p2+8] 
+  sbb    r10, [reg_p2+16] 
+  sbb    r11, [reg_p2+24] 
+  sbb    r12, [reg_p2+32] 
+  mov    [reg_p3], r8
+  mov    [reg_p3+8], r9
+  mov    [reg_p3+16], r10
+  mov    [reg_p3+24], r11
+  mov    [reg_p3+32], r12
+
+  mov    r8, [reg_p1+40]
+  mov    r9, [reg_p1+48]
+  mov    r10, [reg_p1+56] 
+  mov    r11, [reg_p1+64]
+  mov    r12, [reg_p1+72] 
+  sbb    r8, [reg_p2+40] 
+  sbb    r9, [reg_p2+48] 
+  sbb    r10, [reg_p2+56]
+  sbb    r11, [reg_p2+64] 
+  sbb    r12, [reg_p2+72]
+  mov    [reg_p3+40], r8
+  mov    [reg_p3+48], r9
+  mov    [reg_p3+56], r10
+
+  mov    r13, [reg_p1+80]
+  mov    r14, [reg_p1+88] 
+  mov    r15, [reg_p1+96]
+  mov    rcx, [reg_p1+104]
+  sbb    r13, [reg_p2+80]
+  sbb    r14, [reg_p2+88]
+  sbb    r15, [reg_p2+96] 
+  sbb    rcx, [reg_p2+104] 
+  sbb    rax, 0
+
+  // Add p434 anded with the mask in rax 
+  mov    r8, [rip+p434]
+  mov    r9, [rip+p434+24]
+  mov    r10, [rip+p434+32]
+  mov    rdi, [rip+p434+40]
+  mov    rsi, [rip+p434+48]
+  and    r8, rax
+  and    r9, rax
+  and    r10, rax
+  and    rdi, rax
+  and    rsi, rax
+  mov    rax, [reg_p3+56]
+  add    rax, r8
+  adc    r11, r8
+  adc    r12, r8
+  adc    r13, r9
+  adc    r14, r10
+  adc    r15, rdi
+  adc    rcx, rsi
+
+  mov    [reg_p3+56], rax
+  mov    [reg_p3+64], r11
+  mov    [reg_p3+72], r12
+  mov    [reg_p3+80], r13
+  mov    [reg_p3+88], r14
+  mov    [reg_p3+96], r15
+  mov    [reg_p3+104], rcx
+  pop    r15
+  pop    r14
+  pop    r13
+  pop    r12
+  ret
+
+//***********************************************************************
+//  Double 2x434-bit multiprecision subtraction
+//  Operation: c [reg_p3] = c [reg_p3] - a [reg_p1] - b [reg_p2]
+//***********************************************************************
+#define mp_dblsub434x2_asm S2N_SIKE_P434_R3_NAMESPACE(mp_dblsub434x2_asm)
+.global mp_dblsub434x2_asm
+mp_dblsub434x2_asm:
+  push   r12
+  push   r13
+  push   r14
+
+  mov    r8, [reg_p3]
+  mov    r9, [reg_p3+8]
+  mov    r10, [reg_p3+16]
+  mov    r11, [reg_p3+24]
+  mov    r12, [reg_p3+32]
+  mov    r13, [reg_p3+40]
+  mov    r14, [reg_p3+48]
+  sub    r8, [reg_p1]
+  sbb    r9, [reg_p1+8] 
+  sbb    r10, [reg_p1+16] 
+  sbb    r11, [reg_p1+24] 
+  sbb    r12, [reg_p1+32] 
+  sbb    r13, [reg_p1+40] 
+  sbb    r14, [reg_p1+48]
+  setc   al  
+  sub    r8, [reg_p2]
+  sbb    r9, [reg_p2+8] 
+  sbb    r10, [reg_p2+16] 
+  sbb    r11, [reg_p2+24] 
+  sbb    r12, [reg_p2+32] 
+  sbb    r13, [reg_p2+40] 
+  sbb    r14, [reg_p2+48]
+  setc   cl  
+  mov    [reg_p3], r8
+  mov    [reg_p3+8], r9
+  mov    [reg_p3+16], r10
+  mov    [reg_p3+24], r11
+  mov    [reg_p3+32], r12
+  mov    [reg_p3+40], r13
+  mov    [reg_p3+48], r14
+
+  mov    r8, [reg_p3+56]
+  mov    r9, [reg_p3+64]
+  mov    r10, [reg_p3+72]
+  mov    r11, [reg_p3+80]
+  mov    r12, [reg_p3+88]
+  mov    r13, [reg_p3+96]
+  mov    r14, [reg_p3+104]
+  bt     rax, 0  
+  sbb    r8, [reg_p1+56] 
+  sbb    r9, [reg_p1+64] 
+  sbb    r10, [reg_p1+72] 
+  sbb    r11, [reg_p1+80] 
+  sbb    r12, [reg_p1+88] 
+  sbb    r13, [reg_p1+96] 
+  sbb    r14, [reg_p1+104]
+  bt     rcx, 0  
+  sbb    r8, [reg_p2+56] 
+  sbb    r9, [reg_p2+64] 
+  sbb    r10, [reg_p2+72] 
+  sbb    r11, [reg_p2+80] 
+  sbb    r12, [reg_p2+88] 
+  sbb    r13, [reg_p2+96] 
+  sbb    r14, [reg_p2+104] 
+  mov    [reg_p3+56], r8
+  mov    [reg_p3+64], r9
+  mov    [reg_p3+72], r10
+  mov    [reg_p3+80], r11
+  mov    [reg_p3+88], r12
+  mov    [reg_p3+96], r13
+  mov    [reg_p3+104], r14
+
+  pop    r14
+  pop    r13
+  pop    r12
+  ret

--- a/pq-crypto/sike_r3/sikep434r3_fp_x64_asm.S
+++ b/pq-crypto/sike_r3/sikep434r3_fp_x64_asm.S
@@ -31,20 +31,62 @@
 
 #endif
 
-// These variables are declared+defined in sikep434r3.{h, c}
-#define p434 S2N_SIKE_P434_R3_NAMESPACE(p434)
-.extern p434
-
-#define p434x2 S2N_SIKE_P434_R3_NAMESPACE(p434x2)
-.extern p434x2
-
-#define p434x4 S2N_SIKE_P434_R3_NAMESPACE(p434x4)
-.extern p434x4
-
-#define p434p1 S2N_SIKE_P434_R3_NAMESPACE(p434p1)
-.extern p434p1
-
 .text
+
+#define asm_p434 S2N_SIKE_P434_R3_NAMESPACE(asm_p434)
+.align 32
+.type   asm_p434, @object
+.size   asm_p434, 56
+asm_p434:
+.quad   -1
+.quad   -1
+.quad   -1
+.quad   -161717841442111489
+.quad   8918917783347572387
+.quad   7853257225132122198
+.quad   620258357900100
+
+
+#define asm_p434x2 S2N_SIKE_P434_R3_NAMESPACE(asm_p434x2)
+.align 32
+.type   asm_p434x2, @object
+.size   asm_p434x2, 56
+asm_p434x2:
+.quad   -2
+.quad   -1
+.quad   -1
+.quad   -323435682884222977
+.quad   -608908507014406841
+.quad   -2740229623445307220
+.quad   1240516715800200
+
+
+#define asm_p434x4 S2N_SIKE_P434_R3_NAMESPACE(asm_p434x4)
+.align 32
+.type   asm_p434x4, @object
+.size   asm_p434x4, 56
+asm_p434x4:
+.quad   -4
+.quad   -1
+.quad   -1
+.quad   -646871365768445953
+.quad   -1217817014028813681
+.quad   -5480459246890614439
+.quad   2481033431600401
+
+
+#define asm_p434p1 S2N_SIKE_P434_R3_NAMESPACE(asm_p434p1)
+.align 32
+.type   asm_p434p1, @object
+.size   asm_p434p1, 56
+asm_p434p1:
+.quad   0
+.quad   0
+.quad   0
+.quad   -161717841442111488
+.quad   8918917783347572387
+.quad   7853257225132122198
+.quad   620258357900100
 
 //***********************************************************************
 //  Field addition
@@ -76,18 +118,18 @@ fpadd434_asm:
   adc    r13, [reg_p2+40] 
   adc    r14, [reg_p2+48]
 
-  mov    rbx, [rip+p434x2]
+  mov    rbx, [rip+asm_p434x2]
   sub    r8, rbx
-  mov    rcx, [rip+p434x2+8]
+  mov    rcx, [rip+asm_p434x2+8]
   sbb    r9, rcx
   sbb    r10, rcx
-  mov    rdi, [rip+p434x2+24]
+  mov    rdi, [rip+asm_p434x2+24]
   sbb    r11, rdi
-  mov    rsi, [rip+p434x2+32]
+  mov    rsi, [rip+asm_p434x2+32]
   sbb    r12, rsi
-  mov    rbp, [rip+p434x2+40]
+  mov    rbp, [rip+asm_p434x2+40]
   sbb    r13, rbp
-  mov    r15, [rip+p434x2+48]
+  mov    r15, [rip+asm_p434x2+48]
   sbb    r14, r15
   sbb    rax, 0
   
@@ -149,9 +191,9 @@ fpsub434_asm:
   sbb    r14, [reg_p2+48]
   sbb    rax, 0
   
-  mov    rcx, [rip+p434x2]
-  mov    rdi, [rip+p434x2+8]
-  mov    rsi, [rip+p434x2+24]
+  mov    rcx, [rip+asm_p434x2]
+  mov    rdi, [rip+asm_p434x2+8]
+  mov    rsi, [rip+asm_p434x2+24]
   and    rcx, rax
   and    rdi, rax
   and    rsi, rax  
@@ -165,9 +207,9 @@ fpsub434_asm:
   mov    [reg_p3+24], r11 
   setc   cl  
 
-  mov    r8, [rip+p434x2+32]
-  mov    rdi, [rip+p434x2+40]
-  mov    rsi, [rip+p434x2+48]
+  mov    r8, [rip+asm_p434x2+32]
+  mov    rdi, [rip+asm_p434x2+40]
+  mov    rsi, [rip+asm_p434x2+48]
   and    r8, rax
   and    rdi, rax
   and    rsi, rax  
@@ -236,7 +278,7 @@ fpsub434_asm:
 #define mp_sub434_p2_asm S2N_SIKE_P434_R3_NAMESPACE(mp_sub434_p2_asm)
 .global mp_sub434_p2_asm
 mp_sub434_p2_asm:
-  SUB434_PX  p434x2
+  SUB434_PX  asm_p434x2
   ret
 
 //***********************************************************************
@@ -246,7 +288,7 @@ mp_sub434_p2_asm:
 #define mp_sub434_p4_asm S2N_SIKE_P434_R3_NAMESPACE(mp_sub434_p4_asm)
 .global mp_sub434_p4_asm
 mp_sub434_p4_asm:
-  SUB434_PX  p434x4
+  SUB434_PX  asm_p434x4
   ret
     
 ///////////////////////////////////////////////////////////////// MACRO
@@ -724,13 +766,13 @@ rdc434_asm:
   // a[0-1] x p434p1_nz --> result: r8:r13
   mov    rdx, [reg_p1]
   mov    r14, [reg_p1+8]
-  mulx   r9, r8, [rip+p434p1+24]   // result r8
+  mulx   r9, r8, [rip+asm_p434p1+24]   // result r8
   push   r12
   push   r13
   push   r15
   push   rbp
   push   rbx
-  MUL128x256_SCHOOL rdx, r14, [rip+p434p1+24], r8, r9, r10, r11, r12, r13
+  MUL128x256_SCHOOL rdx, r14, [rip+asm_p434p1+24], r8, r9, r10, r11, r12, r13
 
   mov    rdx, [reg_p1+16]
   mov    rcx, [reg_p1+72]
@@ -741,7 +783,7 @@ rdc434_asm:
   adc    r12, [reg_p1+56]
   adc    r13, [reg_p1+64]
   adc    rcx, 0
-  mulx   rbp, rbx, [rip+p434p1+24]   // result rbx
+  mulx   rbp, rbx, [rip+asm_p434p1+24]   // result rbx
   mov    [reg_p2], r9
   mov    [reg_p2+8], r10
   mov    [reg_p2+16], r11
@@ -757,7 +799,7 @@ rdc434_asm:
   adc    rdi, 0
 
   // a[2-3] x p434p1_nz --> result: rbx, rbp, r12:r15
-  MUL128x256_SCHOOL rdx, r8, [rip+p434p1+24], rbx, rbp, r12, r13, r14, r15
+  MUL128x256_SCHOOL rdx, r8, [rip+asm_p434p1+24], rbx, rbp, r12, r13, r14, r15
 
   mov    rdx, [reg_p2]
   add    rbx, [reg_p2+8]
@@ -768,7 +810,7 @@ rdc434_asm:
   mov    rcx, 0
   adc    r15, r9
   adc    rcx, r10
-  mulx   r9, r8, [rip+p434p1+24]   // result r8
+  mulx   r9, r8, [rip+asm_p434p1+24]   // result r8
   mov    [reg_p2], rbp
   mov    [reg_p2+8], r12
   mov    [reg_p2+16], r13
@@ -776,7 +818,7 @@ rdc434_asm:
   adc    rdi, 0
 
   // a[4-5] x p434p1_nz --> result: r8:r13
-  MUL128x256_SCHOOL rdx, rbx, [rip+p434p1+24], r8, r9, r10, rbp, r12, r13
+  MUL128x256_SCHOOL rdx, rbx, [rip+asm_p434p1+24], r8, r9, r10, rbp, r12, r13
 
   mov    rdx, [reg_p2]
   add    r8, [reg_p2+8]
@@ -786,12 +828,12 @@ rdc434_asm:
   adc    r12, rcx
   adc    r13, r11
   adc    rdi, 0
-  mulx   r15, r14, [rip+p434p1+24]  // result r14
+  mulx   r15, r14, [rip+asm_p434p1+24]  // result r14
   mov    [reg_p2], r8        // Final result c0-c1
   mov    [reg_p2+8], r9
 
   // a[6-7] x p434p1_nz --> result: r14:r15, r8:r9, r11
-  MUL64x256_SCHOOL rdx, [rip+p434p1+24], r14, r15, r8, r9, r11, rcx
+  MUL64x256_SCHOOL rdx, [rip+asm_p434p1+24], r14, r15, r8, r9, r11, rcx
 
   // Final result c2:c6
   add    r14, r10
@@ -897,11 +939,11 @@ mp_subadd434x2_asm:
   sbb    rax, 0
 
   // Add p434 anded with the mask in rax 
-  mov    r8, [rip+p434]
-  mov    r9, [rip+p434+24]
-  mov    r10, [rip+p434+32]
-  mov    rdi, [rip+p434+40]
-  mov    rsi, [rip+p434+48]
+  mov    r8, [rip+asm_p434]
+  mov    r9, [rip+asm_p434+24]
+  mov    r10, [rip+asm_p434+32]
+  mov    rdi, [rip+asm_p434+40]
+  mov    rsi, [rip+asm_p434+48]
   and    r8, rax
   and    r9, rax
   and    r10, rax

--- a/pq-crypto/sike_r3/sikep434r3_fp_x64_asm.h
+++ b/pq-crypto/sike_r3/sikep434r3_fp_x64_asm.h
@@ -1,0 +1,38 @@
+/********************************************************************************************
+* Supersingular Isogeny Key Encapsulation Library
+*
+* Abstract: x86_64 assembly optimized modular arithmetic for P434
+*********************************************************************************************/
+
+#pragma once
+
+#if defined(S2N_SIKEP434R3_ASM)
+
+#define fpadd434_asm S2N_SIKE_P434_R3_NAMESPACE(fpadd434_asm)
+void fpadd434_asm(const digit_t* a, const digit_t* b, digit_t* c);
+
+#define fpsub434_asm S2N_SIKE_P434_R3_NAMESPACE(fpsub434_asm)
+void fpsub434_asm(const digit_t* a, const digit_t* b, digit_t* c);
+
+#define mul434_asm S2N_SIKE_P434_R3_NAMESPACE(mul434_asm)
+void mul434_asm(const digit_t* a, const digit_t* b, digit_t* c);
+
+#define rdc434_asm S2N_SIKE_P434_R3_NAMESPACE(rdc434_asm)
+void rdc434_asm(digit_t* ma, digit_t* mc);
+
+#define mp_add434_asm S2N_SIKE_P434_R3_NAMESPACE(mp_add434_asm)
+void mp_add434_asm(const digit_t* a, const digit_t* b, digit_t* c);
+
+#define mp_subadd434x2_asm S2N_SIKE_P434_R3_NAMESPACE(mp_subadd434x2_asm)
+void mp_subadd434x2_asm(const digit_t* a, const digit_t* b, digit_t* c);
+
+#define mp_dblsub434x2_asm S2N_SIKE_P434_R3_NAMESPACE(mp_dblsub434x2_asm)
+void mp_dblsub434x2_asm(const digit_t* a, const digit_t* b, digit_t* c);
+
+#define mp_sub434_p2_asm S2N_SIKE_P434_R3_NAMESPACE(mp_sub434_p2_asm)
+void mp_sub434_p2_asm(const digit_t* a, const digit_t* b, digit_t* c);
+
+#define mp_sub434_p4_asm S2N_SIKE_P434_R3_NAMESPACE(mp_sub434_p4_asm)
+void mp_sub434_p4_asm(const digit_t* a, const digit_t* b, digit_t* c);
+
+#endif

--- a/pq-crypto/sike_r3/sikep434r3_fp_x64_asm.h
+++ b/pq-crypto/sike_r3/sikep434r3_fp_x64_asm.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#if defined(S2N_SIKEP434R3_ASM)
+#if defined(S2N_SIKE_P434_R3_ASM)
 
 #define fpadd434_asm S2N_SIKE_P434_R3_NAMESPACE(fpadd434_asm)
 void fpadd434_asm(const digit_t* a, const digit_t* b, digit_t* c);

--- a/pq-crypto/sike_r3/sikep434r3_fpx.c
+++ b/pq-crypto/sike_r3/sikep434r3_fpx.c
@@ -8,6 +8,8 @@
 #include "sikep434r3.h"
 #include "sikep434r3_fp.h"
 #include "sikep434r3_fpx.h"
+#include "pq-crypto/s2n_pq.h"
+#include "sikep434r3_fp_x64_asm.h"
 
 static void fpmul_mont(const felm_t ma, const felm_t mb, felm_t mc);
 static void to_mont(const felm_t a, felm_t mc);
@@ -162,6 +164,13 @@ static unsigned int mp_sub(const digit_t* a, const digit_t* b, digit_t* c, const
  * c = a-b+(p*2^S2N_SIKE_P434_R3_MAXBITS_FIELD) if a-b < 0, otherwise c=a-b. */
 __inline static void mp_subaddfast(const digit_t* a, const digit_t* b, digit_t* c)
 {
+#if defined(S2N_SIKEP434R3_ASM)
+    if (s2n_sikep434r3_asm_is_enabled()) {
+        mp_subadd434x2_asm(a, b, c);
+        return;
+    }
+#endif
+
     felm_t t1;
 
     digit_t mask = 0 - (digit_t)mp_sub(a, b, c, 2*S2N_SIKE_P434_R3_NWORDS_FIELD);
@@ -174,6 +183,13 @@ __inline static void mp_subaddfast(const digit_t* a, const digit_t* b, digit_t* 
 /* Multiprecision subtraction, c = c-a-b, where lng(a) = lng(b) = 2*S2N_SIKE_P434_R3_NWORDS_FIELD. */
 __inline static void mp_dblsubfast(const digit_t* a, const digit_t* b, digit_t* c)
 {
+#if defined(S2N_SIKEP434R3_ASM)
+    if (s2n_sikep434r3_asm_is_enabled()) {
+        mp_dblsub434x2_asm(a, b, c);
+        return;
+    }
+#endif
+
     mp_sub(c, a, c, 2*S2N_SIKE_P434_R3_NWORDS_FIELD);
     mp_sub(c, b, c, 2*S2N_SIKE_P434_R3_NWORDS_FIELD);
 }
@@ -439,6 +455,13 @@ void fp2sub(const f2elm_t *a, const f2elm_t *b, f2elm_t *c)
 
 void mp_addfast(const digit_t* a, const digit_t* b, digit_t* c)
 {
+#if defined(S2N_SIKEP434R3_ASM)
+    if (s2n_sikep434r3_asm_is_enabled()) {
+        mp_add434_asm(a, b, c);
+        return;
+    }
+#endif
+
     mp_add(a, b, c, S2N_SIKE_P434_R3_NWORDS_FIELD);
 }
 

--- a/pq-crypto/sike_r3/sikep434r3_fpx.c
+++ b/pq-crypto/sike_r3/sikep434r3_fpx.c
@@ -164,7 +164,7 @@ static unsigned int mp_sub(const digit_t* a, const digit_t* b, digit_t* c, const
  * c = a-b+(p*2^S2N_SIKE_P434_R3_MAXBITS_FIELD) if a-b < 0, otherwise c=a-b. */
 __inline static void mp_subaddfast(const digit_t* a, const digit_t* b, digit_t* c)
 {
-#if defined(S2N_SIKEP434R3_ASM)
+#if defined(S2N_SIKE_P434_R3_ASM)
     if (s2n_sikep434r3_asm_is_enabled()) {
         mp_subadd434x2_asm(a, b, c);
         return;
@@ -183,7 +183,7 @@ __inline static void mp_subaddfast(const digit_t* a, const digit_t* b, digit_t* 
 /* Multiprecision subtraction, c = c-a-b, where lng(a) = lng(b) = 2*S2N_SIKE_P434_R3_NWORDS_FIELD. */
 __inline static void mp_dblsubfast(const digit_t* a, const digit_t* b, digit_t* c)
 {
-#if defined(S2N_SIKEP434R3_ASM)
+#if defined(S2N_SIKE_P434_R3_ASM)
     if (s2n_sikep434r3_asm_is_enabled()) {
         mp_dblsub434x2_asm(a, b, c);
         return;
@@ -455,7 +455,7 @@ void fp2sub(const f2elm_t *a, const f2elm_t *b, f2elm_t *c)
 
 void mp_addfast(const digit_t* a, const digit_t* b, digit_t* c)
 {
-#if defined(S2N_SIKEP434R3_ASM)
+#if defined(S2N_SIKE_P434_R3_ASM)
     if (s2n_sikep434r3_asm_is_enabled()) {
         mp_add434_asm(a, b, c);
         return;

--- a/tests/features/noop_main.c
+++ b/tests/features/noop_main.c
@@ -13,14 +13,6 @@
  * permissions and limitations under the License.
  */
 
-int main()
-{
-    /* In CMakeLists.txt, we try_compile the PQ ASM code to determine if the
-     * toolchain is compatible with the assembly instructions. Older versions
-     * of CMake require that we supply a main() function in the sources that
-     * we are passing to try_compile. So, in the try_compile, we use this main()
-     * function as a noop. IMPORTANT NOTE: This file is referenced by name
-     * in CMakeLists.txt (which is unusual for a unit test). If this file is
-     * renamed, then CMakeLists.txt must be updated as well.*/
+int main() {
     return 0;
 }

--- a/tests/unit/s2n_pq_kem_kat_test.c
+++ b/tests/unit/s2n_pq_kem_kat_test.c
@@ -86,9 +86,9 @@ static const struct s2n_kem_test_vector test_vectors[] = {
         {
                 .kem = &s2n_sike_p434_r3,
                 .kat_file = "kats/sike_r3.kat",
-                .asm_is_enabled = s2n_pq_no_asm_available,
-                .enable_asm = s2n_pq_noop_asm,
-                .disable_asm = s2n_pq_noop_asm,
+                .asm_is_enabled = s2n_sikep434r3_asm_is_enabled,
+                .enable_asm = s2n_try_enable_sikep434r3_asm,
+                .disable_asm = s2n_disable_sikep434r3_asm,
         },
 };
 

--- a/tests/unit/s2n_pq_kem_test.c
+++ b/tests/unit/s2n_pq_kem_test.c
@@ -78,9 +78,9 @@ static const struct s2n_kem_test_vector test_vectors[] = {
         },
         {
                 .kem = &s2n_sike_p434_r3,
-                .asm_is_enabled = s2n_pq_no_asm_available,
-                .enable_asm = s2n_pq_noop_asm,
-                .disable_asm = s2n_pq_noop_asm,
+                .asm_is_enabled = s2n_sikep434r3_asm_is_enabled,
+                .enable_asm = s2n_try_enable_sikep434r3_asm,
+                .disable_asm = s2n_disable_sikep434r3_asm,
         },
 };
 


### PR DESCRIPTION
### Description of changes: 

Integrates the x86_64 optimized assembly code for sikep434r3. The integration is very similar to the corresponding code for round 2 (sikep434r2). 

* We're using a `try_compile` strategy to determine CPU compatibility at build time, and `cpuid` checks to determine CPU compatibility at run time. 
* Make and CMake build files have been updated accordingly.

### Call-outs:

* There is some very similar/duplicated code between this PR and the existing sikep434r2 code. sikep434r3 and sikep434r2 are wire-compatible (the KAT files are identical); once we are finished merging all of the round 3 code/tests, we will remove all the round 2 code.
* As part of this PR, I moved `tests/unit/s2n_pq_asm_noop_test.c` to `tests/features/noop_main.c`. It was never really a unit test to begin with, and now we have the `tests/features` directory where we're putting the blobs we use for various `try_compile` checks.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

* Applicable unit tests have been updated to test the assembly code paths.

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

* Not a refactor.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
