### PR TITLE
Fix HRR + 0RTT bug

### DIFF
--- a/tests/testlib/s2n_connection_test_utils.c
+++ b/tests/testlib/s2n_connection_test_utils.c
@@ -245,3 +245,27 @@ S2N_RESULT s2n_config_mock_wall_clock(struct s2n_config *config, uint64_t *test_
     RESULT_GUARD_POSIX(s2n_config_set_wall_clock(config, mock_time, test_time_in_ns));
     return S2N_RESULT_OK;
 }
+
+S2N_RESULT s2n_connection_set_secrets(struct s2n_connection *conn)
+{
+    RESULT_ENSURE_REF(conn);
+    conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
+    const struct s2n_cipher *cipher = conn->secure.cipher_suite->record_alg->cipher;
+
+    uint8_t client_key_bytes[S2N_TLS13_SECRET_MAX_LEN] = "client key";
+    struct s2n_blob client_key = { 0 };
+    RESULT_GUARD_POSIX(s2n_blob_init(&client_key, client_key_bytes, cipher->key_material_size));
+    RESULT_GUARD_POSIX(cipher->init(&conn->secure.client_key));
+    RESULT_GUARD_POSIX(cipher->set_encryption_key(&conn->secure.client_key, &client_key));
+
+    uint8_t server_key_bytes[S2N_TLS13_SECRET_MAX_LEN] = "server key";
+    struct s2n_blob server_key = { 0 };
+    RESULT_GUARD_POSIX(s2n_blob_init(&server_key, server_key_bytes, cipher->key_material_size));
+    RESULT_GUARD_POSIX(cipher->init(&conn->secure.server_key));
+    RESULT_GUARD_POSIX(cipher->set_encryption_key(&conn->secure.server_key, &server_key));
+
+    conn->client = &conn->secure;
+    conn->server = &conn->secure;
+
+    return S2N_RESULT_OK;
+}

--- a/tests/testlib/s2n_connection_test_utils.c
+++ b/tests/testlib/s2n_connection_test_utils.c
@@ -246,6 +246,10 @@ S2N_RESULT s2n_config_mock_wall_clock(struct s2n_config *config, uint64_t *test_
     return S2N_RESULT_OK;
 }
 
+/* Sets the encryption and decryption keys to enable sending and receiving encrypted data.
+ * Basically, it bypasses the usual key exchange -> shared secret -> derive keys process
+ * and just uses static mock keys.
+ */
 S2N_RESULT s2n_connection_set_secrets(struct s2n_connection *conn)
 {
     RESULT_ENSURE_REF(conn);

--- a/tests/testlib/s2n_testlib.h
+++ b/tests/testlib/s2n_testlib.h
@@ -59,6 +59,8 @@ int s2n_set_connection_hello_retry_flags(struct s2n_connection *conn);
 int s2n_connection_allow_all_response_extensions(struct s2n_connection *conn);
 int s2n_connection_set_all_protocol_versions(struct s2n_connection *conn, uint8_t version);
 
+S2N_RESULT s2n_connection_set_secrets(struct s2n_connection *conn);
+
 S2N_RESULT s2n_config_mock_wall_clock(struct s2n_config *config, uint64_t *test_time_in_ns);
 
 struct s2n_psk* s2n_test_psk_new(struct s2n_connection *conn);

--- a/tests/unit/s2n_early_data_io_test.c
+++ b/tests/unit/s2n_early_data_io_test.c
@@ -445,12 +445,14 @@ int main(int argc, char **argv)
              * An error will only occur if the encryption happens to produce a known record type as the
              * last non-padding byte.
              *
-             * The chance this test produces a false negative:
-             * Ignoring the more complicated case where we strip "padding" off the end of the encrypted record,
-             * we handle 4 record types (HANDSHAKE, APPLICATION_DATA, ALERT, and CHANGE_CIPHER_SPEC).
-             * (((256 - 4) / 256) ^ 300) = 0.009, < 1%
+             * We handle 4 record types (HANDSHAKE, APPLICATION_DATA, ALERT, and CHANGE_CIPHER_SPEC).
+             * So the chance this test produces a false negative (succeeds when it should fail):
+             * (((256 - 4) / 256) ^ 450) = 0.0008, < 0.1%
+             *
+             * (This calculation ignores the case where the encryption produces an apparently padded record.
+             *  That would increase the number of records not ignored, making a false negative even less likely)
              */
-            const size_t repetitions = 300;
+            const size_t repetitions = 450;
             for(size_t i = 0; i < repetitions; i++) {
                 EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
                 EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));

--- a/tests/unit/s2n_early_data_io_test.c
+++ b/tests/unit/s2n_early_data_io_test.c
@@ -430,6 +430,65 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
 
+        /* Early data rejected due to HRR, but received anyway and ignored.  */
+        {
+            struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(client_conn);
+            struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(server_conn);
+
+            struct s2n_test_io_pair io_pair = { 0 };
+            EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+
+            /* We run this multiple times because if the early data is incorrectly processed as a normal,
+             * unencrypted record, it is usually just ignored anyway because the record type is unknown.
+             * An error will only occur if the encryption happens to produce a known record type as the
+             * last non-padding byte.
+             *
+             * The chance this test produces a false negative:
+             * Ignoring the more complicated case where we strip "padding" off the end of the encrypted record,
+             * we handle 4 record types (HANDSHAKE, APPLICATION_DATA, ALERT, and CHANGE_CIPHER_SPEC).
+             * (((256 - 4) / 256) ^ 300) = 0.009, < 1%
+             */
+            const size_t repetitions = 300;
+            for(size_t i = 0; i < repetitions; i++) {
+                EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+                EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
+                EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
+                EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+                EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
+                EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
+                EXPECT_SUCCESS(s2n_connection_set_early_data_expected(client_conn));
+                EXPECT_SUCCESS(s2n_connection_set_early_data_expected(server_conn));
+                client_conn->security_policy_override = &retry_policy;
+
+                s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+                EXPECT_OK(s2n_negotiate_until_message(client_conn, &blocked, SERVER_HELLO));
+                EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), SERVER_HELLO);
+                EXPECT_EQUAL(client_conn->early_data_state, S2N_EARLY_DATA_REQUESTED);
+
+                EXPECT_SUCCESS_S2N_SEND(client_conn, test_data, sizeof(test_data), &blocked);
+
+                EXPECT_SUCCESS(s2n_connection_set_end_of_early_data(client_conn));
+                EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+                EXPECT_FALSE(WITH_EARLY_DATA(client_conn));
+                EXPECT_FALSE(WITH_EARLY_DATA(server_conn));
+                EXPECT_TRUE(WITH_EARLY_CLIENT_CCS(client_conn));
+                EXPECT_TRUE(WITH_EARLY_CLIENT_CCS(server_conn));
+                EXPECT_TRUE(IS_HELLO_RETRY_HANDSHAKE(client_conn));
+                EXPECT_TRUE(IS_HELLO_RETRY_HANDSHAKE(server_conn));
+
+                EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+                EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+            }
+
+            EXPECT_SUCCESS(s2n_connection_free(client_conn));
+            EXPECT_SUCCESS(s2n_connection_free(server_conn));
+            EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+        }
+
         /* PSK rejected altogether */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
-        EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
+        EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_ALERT, &in));
 
         if (i < S2N_DEFAULT_FRAGMENT_LENGTH) {
             EXPECT_EQUAL(bytes_written, i);
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(bytes_written, S2N_DEFAULT_FRAGMENT_LENGTH);
         }
 
-        EXPECT_EQUAL(conn->out.blob.data[0], TLS_APPLICATION_DATA);
+        EXPECT_EQUAL(conn->out.blob.data[0], TLS_ALERT);
         EXPECT_EQUAL(conn->out.blob.data[1], 3);
         EXPECT_EQUAL(conn->out.blob.data[2], 2);
         EXPECT_EQUAL(conn->out.blob.data[3], (bytes_written >> 8) & 0xff);
@@ -125,7 +125,7 @@ int main(int argc, char **argv)
         uint16_t fragment_length;
         EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
         EXPECT_SUCCESS(s2n_record_parse(conn));
-        EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
+        EXPECT_EQUAL(content_type, TLS_ALERT);
         EXPECT_EQUAL(fragment_length, bytes_written);
     }
 
@@ -144,7 +144,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_hmac_update(&check_mac, conn->initial.server_sequence_number, 8));
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
-        EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
+        EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_ALERT, &in));
 
         if (i <= S2N_DEFAULT_FRAGMENT_LENGTH) {
             EXPECT_EQUAL(bytes_written, i);
@@ -154,7 +154,7 @@ int main(int argc, char **argv)
         }
 
         uint16_t predicted_length = bytes_written + 20;
-        EXPECT_EQUAL(conn->out.blob.data[0], TLS_APPLICATION_DATA);
+        EXPECT_EQUAL(conn->out.blob.data[0], TLS_ALERT);
         EXPECT_EQUAL(conn->out.blob.data[1], 3);
         EXPECT_EQUAL(conn->out.blob.data[2], 2);
         EXPECT_EQUAL(conn->out.blob.data[3], (predicted_length >> 8) & 0xff);
@@ -184,7 +184,7 @@ int main(int argc, char **argv)
         uint16_t fragment_length;
         EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
         EXPECT_SUCCESS(s2n_record_parse(conn));
-        EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
+        EXPECT_EQUAL(content_type, TLS_ALERT);
         EXPECT_EQUAL(fragment_length, predicted_length);
 
         /* Simulate a replay attack and verify that replaying the same record
@@ -209,7 +209,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         conn->in.blob.data[byte_to_corrupt] += 1;
-        EXPECT_FAILURE(s2n_record_parse(conn));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_record_parse(conn), S2N_ERR_BAD_MESSAGE);
     }
 
     /* Test a mock block cipher with a mac - in TLS1.0 mode */
@@ -354,14 +354,14 @@ int main(int argc, char **argv)
     EXPECT_MEMCPY_SUCCESS(conn->initial.server_sequence_number, max_num_records, sizeof(max_num_records));
     EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
     /* Sequence number should wrap around */
-    EXPECT_FAILURE(s2n_record_write(conn, TLS_APPLICATION_DATA, &empty_blob));
+    EXPECT_FAILURE_WITH_ERRNO(s2n_record_write(conn, TLS_ALERT, &empty_blob), S2N_ERR_RECORD_LIMIT);
 
     /* Test TLS 1.3 Record should reflect as TLS 1.2 version on the wire */
     {
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
 
         conn->actual_protocol_version = S2N_TLS13;
-        EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &empty_blob));
+        EXPECT_SUCCESS(s2n_record_write(conn, TLS_ALERT, &empty_blob));
 
         /* Make sure that TLS 1.3 records appear as TLS 1.2 version */
         EXPECT_EQUAL(conn->out.blob.data[1], 3);
@@ -384,7 +384,21 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_reread(&conn->header_in));
         conn->header_in.blob.data[1] = 3;
         conn->header_in.blob.data[2] = 4;
-        EXPECT_FAILURE(s2n_record_header_parse(conn, &content_type, &fragment_length));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_record_header_parse(conn, &content_type, &fragment_length), S2N_ERR_BAD_MESSAGE);
+    }
+
+    /* Test: ApplicationData MUST be encrypted */
+    {
+        EXPECT_SUCCESS(s2n_connection_wipe(conn));
+        conn->actual_protocol_version = S2N_TLS13;
+
+        /* Write fails with no secrets / cipher set */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_record_write(conn, TLS_APPLICATION_DATA, &empty_blob), S2N_ERR_ENCRYPT);
+
+        /* Read fails with no secrets / cipher set */
+        uint8_t header_bytes[] = { TLS_APPLICATION_DATA, 0x03, 0x04, 0x00, 0x00 };
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->header_in, header_bytes, sizeof(header_bytes)));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_record_parse(conn), S2N_ERR_DECRYPT);
     }
 
     EXPECT_SUCCESS(s2n_hmac_free(&check_mac));

--- a/tests/unit/s2n_send_test.c
+++ b/tests/unit/s2n_send_test.c
@@ -40,6 +40,7 @@ int main(int argc, char **argv)
         /* Setup connections */
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_OK(s2n_connection_set_secrets(conn));
 
         /* Setup bad send callback */
         EXPECT_SUCCESS(s2n_connection_set_send_cb(conn, s2n_expect_concurrent_error_send_fn));

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -223,7 +223,7 @@ int main(int argc, char **argv)
         server_conn->server = &server_conn->initial;
         S2N_BLOB_FROM_HEX(deadbeef_from_server, "DEADBEEF");
 
-        EXPECT_SUCCESS(s2n_record_write(server_conn, TLS_APPLICATION_DATA, &deadbeef_from_server));
+        EXPECT_SUCCESS(s2n_record_write(server_conn, TLS_HANDSHAKE, &deadbeef_from_server));
         EXPECT_EQUAL(s2n_stuffer_data_available(&server_conn->out), 9);
         EXPECT_SUCCESS(s2n_stuffer_wipe(&server_conn->out));
 
@@ -245,7 +245,7 @@ int main(int argc, char **argv)
         /* client writes message to server in plaintext */
         client_conn->client = &client_conn->initial;
         S2N_BLOB_FROM_HEX(cafefood_from_client, "CAFED00D");
-        EXPECT_SUCCESS(s2n_record_write(client_conn, TLS_APPLICATION_DATA, &cafefood_from_client));
+        EXPECT_SUCCESS(s2n_record_write(client_conn, TLS_HANDSHAKE, &cafefood_from_client));
 
         /* unencrypted length */
         EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->out), 9);
@@ -255,16 +255,6 @@ int main(int argc, char **argv)
         client_conn->client = &client_conn->secure;
         EXPECT_SUCCESS(s2n_record_write(client_conn, TLS_APPLICATION_DATA, &cafefood_from_client));
         EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->out), 26);
-        EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->out, &server_conn->header_in, 5));
-        EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->out, &server_conn->in, s2n_stuffer_data_available(&client_conn->out)));
-
-        /* if aead payload is parsed as plaintext, it would be of length 21 */
-        server_conn->client = &server_conn->initial;
-        EXPECT_SUCCESS(s2n_record_parse(server_conn));
-        EXPECT_EQUAL(s2n_stuffer_data_available(&server_conn->in), 21);
-        EXPECT_SUCCESS(s2n_stuffer_reread(&client_conn->out));
-        EXPECT_SUCCESS(s2n_stuffer_wipe(&server_conn->header_in));
-        EXPECT_SUCCESS(s2n_stuffer_wipe(&server_conn->in));
         EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->out, &server_conn->header_in, 5));
         EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->out, &server_conn->in, s2n_stuffer_data_available(&client_conn->out)));
 

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -143,6 +143,12 @@ int s2n_record_parse(struct s2n_connection *conn)
         conn->server = current_server_crypto;
     }
 
+    /* The NULL stream cipher MUST NEVER be used for ApplicationData.
+     * If ApplicationData is unencrypted, we can't trust it. */
+    if (cipher_suite->record_alg->cipher == &s2n_null_cipher) {
+        POSIX_ENSURE(content_type != TLS_APPLICATION_DATA, S2N_ERR_DECRYPT);
+    }
+
     switch (cipher_suite->record_alg->cipher->type) {
     case S2N_AEAD:
         POSIX_GUARD(s2n_record_parse_aead(cipher_suite, conn, content_type, encrypted_length, implicit_iv, mac, sequence_number, session_key));

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -219,6 +219,12 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
         implicit_iv = conn->client->client_implicit_iv;
     }
 
+    /* The NULL stream cipher MUST NEVER be used for ApplicationData.
+     * Writing ApplicationData unencrypted defeats the purpose of TLS. */
+    if (cipher_suite->record_alg->cipher == &s2n_null_cipher) {
+        POSIX_ENSURE(content_type != TLS_APPLICATION_DATA, S2N_ERR_ENCRYPT);
+    }
+
     const int is_tls13_record = cipher_suite->record_alg->flags & S2N_TLS13_RECORD_AEAD_NONCE;
     s2n_stack_blob(aad, is_tls13_record ? S2N_TLS13_AAD_LEN : S2N_TLS_MAX_AAD_LEN, S2N_TLS_MAX_AAD_LEN);
 


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/2817

### Description of changes: 

After a retry, we can receive early data before we receive the new ClientHello. During that time, there is no encryption
expected, so encrypted early data is treated as plaintext records. Usually that leads to unknown record types, which we ignore, but rarely it produces a malformed record of a known type.

To fix this, we should never allow decryption (or encryption) of ApplicationData with the null cipher. Even outside of early
data, it's a nice sanity check.

### Testing:

Switched or deleted unit tests testing unencrypted ApplicationData. Added a helper method to make testing encrypted ApplicationData almost as convenient. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
