### PR TITLE
Separate TLS1.2 and TLS1.3 client ticket memory lifecycles

### DIFF
--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -552,6 +552,8 @@ int main(int argc, char *const *argv)
             s2n_connection_set_dynamic_record_threshold(conn, dyn_rec_threshold, dyn_rec_timeout);
         }
 
+        GUARD_EXIT(s2n_connection_free_handshake(conn), "Error freeing handshake memory after negotiation");
+
         if (echo_input == 1) {
             fflush(stdout);
             fflush(stderr);

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -376,6 +376,8 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
         S2N_ERROR_PRESERVE_ERRNO();
     }
 
+    GUARD_EXIT(s2n_connection_free_handshake(conn), "Error freeing handshake memory after negotiation");
+
     if (settings.https_server) {
         https(conn, settings.https_bench);
     } else if (!settings.only_negotiate) {

--- a/tests/saw/spec/handshake/handshake_io_lowlevel.saw
+++ b/tests/saw/spec/handshake/handshake_io_lowlevel.saw
@@ -358,8 +358,9 @@ let s2n_generate_new_client_session_id_spec = do {
 // a noop function that returns 0 from the perspective of our current proof
 let s2n_decrypt_session_ticket_spec = do {
     pconn <- crucible_alloc_readonly (llvm_struct "struct.s2n_connection");
+    from <- crucible_alloc_readonly (llvm_struct "struct.s2n_stuffer");
 
-    crucible_execute_func [pconn];
+    crucible_execute_func [pconn, from];
     crucible_return (crucible_term {{ 0 : [32] }});
 };
 

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -1049,20 +1049,13 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_write_bytes(&secret_stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
             conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
 
-            uint8_t data[S2N_TLS12_TICKET_SIZE_IN_BYTES] = { 0 };
-            struct s2n_blob blob = { 0 };
-            struct s2n_stuffer output = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&blob, data, sizeof(data)));
-            EXPECT_SUCCESS(s2n_stuffer_init(&output, &blob));
-
-            EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, &output));
+            EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, &conn->client_ticket_to_decrypt));
+            EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&conn->client_ticket_to_decrypt), 0);
 
             /* Wiping the master secret to prove that the decryption function actually writes the master secret */
             memset(conn->secure.master_secret, 0, test_master_secret.size);
 
-            conn->client_ticket_to_decrypt = output;
-            EXPECT_SUCCESS(s2n_decrypt_session_ticket(conn));
-
+            EXPECT_SUCCESS(s2n_decrypt_session_ticket(conn, &conn->client_ticket_to_decrypt));
             EXPECT_EQUAL(s2n_stuffer_data_available(&conn->client_ticket_to_decrypt), 0);
 
             /* Check decryption was successful by comparing master key */
@@ -1100,10 +1093,9 @@ int main(int argc, char **argv)
             EXPECT_TRUE(conn->tls13_ticket_fields.session_secret.size < S2N_TLS_SECRET_LEN);
 
             EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, &output));
-            conn->client_ticket_to_decrypt = output;
-            EXPECT_SUCCESS(s2n_decrypt_session_ticket(conn));
+            EXPECT_SUCCESS(s2n_decrypt_session_ticket(conn, &output));
 
-            EXPECT_EQUAL(s2n_stuffer_data_available(&conn->client_ticket_to_decrypt), 0);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&output), 0);
 
             /* Check decryption was successful */
             struct s2n_psk *psk = NULL;
@@ -1143,10 +1135,9 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(conn->tls13_ticket_fields.session_secret.size, S2N_TLS_SECRET_LEN);
 
             EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, &output));
-            conn->client_ticket_to_decrypt = output;
-            EXPECT_SUCCESS(s2n_decrypt_session_ticket(conn));
+            EXPECT_SUCCESS(s2n_decrypt_session_ticket(conn, &output));
 
-            EXPECT_EQUAL(s2n_stuffer_data_available(&conn->client_ticket_to_decrypt), 0);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&output), 0);
 
             /* Check decryption was successful */
             struct s2n_psk *psk = NULL;
@@ -1187,10 +1178,9 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_dup(&test_master_secret, &conn->tls13_ticket_fields.session_secret));
 
             EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, &output));
-            conn->client_ticket_to_decrypt = output;
-            EXPECT_SUCCESS(s2n_decrypt_session_ticket(conn));
+            EXPECT_SUCCESS(s2n_decrypt_session_ticket(conn, &output));
 
-            EXPECT_EQUAL(s2n_stuffer_data_available(&conn->client_ticket_to_decrypt), 0);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&output), 0);
 
             /* Check decryption was successful */
             struct s2n_psk *psk = NULL;

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -1017,7 +1017,7 @@ int main(int argc, char **argv)
         POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, invalid_en_data, sizeof(invalid_en_data)));
 
         server_conn->session_ticket_status = S2N_DECRYPT_TICKET;
-        EXPECT_FAILURE_WITH_ERRNO(s2n_decrypt_session_ticket(server_conn), S2N_ERR_DECRYPT);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_decrypt_session_ticket(server_conn, &server_conn->client_ticket_to_decrypt), S2N_ERR_DECRYPT);
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_config_free(server_config));
@@ -1043,7 +1043,7 @@ int main(int argc, char **argv)
         POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->client_ticket_to_decrypt, invalid_en_data, sizeof(invalid_en_data)));
 
         server_conn->session_ticket_status = S2N_DECRYPT_TICKET;
-        EXPECT_FAILURE_WITH_ERRNO(s2n_decrypt_session_ticket(server_conn), S2N_ERR_KEY_USED_IN_SESSION_TICKET_NOT_FOUND);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_decrypt_session_ticket(server_conn, &server_conn->client_ticket_to_decrypt), S2N_ERR_KEY_USED_IN_SESSION_TICKET_NOT_FOUND);
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_config_free(server_config));

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -807,7 +807,7 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
 
     if (conn->config->use_tickets) {
         if (conn->session_ticket_status == S2N_DECRYPT_TICKET) {
-            if (!s2n_decrypt_session_ticket(conn)) {
+            if (!s2n_decrypt_session_ticket(conn, &conn->client_ticket_to_decrypt)) {
                 return 0;
             }
 

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -76,7 +76,7 @@ struct s2n_session_ticket {
 
 extern struct s2n_ticket_key *s2n_find_ticket_key(struct s2n_config *config, const uint8_t *name);
 extern int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *to);
-extern int s2n_decrypt_session_ticket(struct s2n_connection *conn);
+extern int s2n_decrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *from);
 extern int s2n_encrypt_session_cache(struct s2n_connection *conn, struct s2n_stuffer *to); 
 extern int s2n_decrypt_session_cache(struct s2n_connection *conn, struct s2n_stuffer *from); 
 extern int s2n_config_is_encrypt_decrypt_key_available(struct s2n_config *config);


### PR DESCRIPTION
### Description of changes: 

How TLS1.2 and TLS1.3 handled client ticket memory were interfering with each other. TLS1.3 doesn't need to store its raw tickets on the connection, so now it doesn't.

### Testing:

Reproduced the memory issues in the self-talk tests. Also added s2n_connection_free_handshake to s2nc/s2nd to avoid similar issues in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
