### PR TITLE
Adds TLS1.3 Session Resumption and Early Data Functionality to s2nd/s2nd

### DIFF
--- a/bin/common.h
+++ b/bin/common.h
@@ -46,9 +46,8 @@
 #define S2N_MAX_PSK_LIST_LENGTH 10
 
 void print_s2n_error(const char *app_error);
-int echo(struct s2n_connection *conn, int sockfd);
+int echo(struct s2n_connection *conn, int sockfd, bool *stop_echo);
 int negotiate(struct s2n_connection *conn, int sockfd);
-int recv_session_ticket(struct s2n_connection *conn, int fd);
 int early_data_recv(struct s2n_connection *conn);
 int early_data_send(struct s2n_connection *conn, uint8_t *data, uint32_t len);
 int https(struct s2n_connection *conn, uint32_t bench);

--- a/bin/common.h
+++ b/bin/common.h
@@ -48,6 +48,9 @@
 void print_s2n_error(const char *app_error);
 int echo(struct s2n_connection *conn, int sockfd);
 int negotiate(struct s2n_connection *conn, int sockfd);
+int recv_session_ticket(struct s2n_connection *conn, int fd);
+int early_data_recv(struct s2n_connection *conn);
+int early_data_send(struct s2n_connection *conn, uint8_t *data, uint32_t len);
 int https(struct s2n_connection *conn, uint32_t bench);
 int key_log_callback(void *ctx, struct s2n_connection *conn, uint8_t *logline, size_t len);
 

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -96,6 +96,7 @@ int early_data_recv(struct s2n_connection *conn)
         for (size_t i = 0; i < total_data_recv; i++) {
             fprintf(stdout, "%c", early_data_received[i]);
         }
+        fprintf(stdout, "\n");
     }
 
     free(early_data_received);
@@ -220,10 +221,7 @@ int echo(struct s2n_connection *conn, int sockfd, bool *stop_echo)
     do {
         /* echo will send and receive Application Data back and forth between
          * client and server, until stop_echo is true. */
-        while (!(*stop_echo)) {
-            if ((p = poll(readers, 2, -1)) < 0) {
-                return 0;
-            }
+        while (!(*stop_echo) && (p = poll(readers, 2, -1)) > 0) {
             char buffer[STDIO_BUFSIZE];
             ssize_t bytes_read = 0;
             ssize_t bytes_written = 0;

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -555,10 +555,16 @@ int main(int argc, char *const *argv)
 
         GUARD_EXIT(s2n_setup_external_psk_list(conn, psk_optarg_list, psk_list_len), "Error setting external psk list");
 
-        /* Send early data if we have a session ticket in our possession */
-        if (early_data && session_state_length) {
-            uint32_t early_data_length = strlen(early_data);
-            GUARD_EXIT(early_data_send(conn, (uint8_t *)early_data, early_data_length), "Error sending early data");
+        if (early_data) {
+            if (!session_ticket) {
+                print_s2n_error("Early data can only be used with session tickets.");
+                exit(1);
+            }
+            /* Send early data if we have a received a session ticket from the server */
+            if (session_state_length) {
+                uint32_t early_data_length = strlen(early_data);
+                GUARD_EXIT(early_data_send(conn, (uint8_t *)early_data, early_data_length), "Error sending early data");
+            }
         }
 
         /* See echo.c */
@@ -571,9 +577,24 @@ int main(int argc, char *const *argv)
 
         /* Save session state from connection if reconnect is enabled */
         if (reconnect > 0) {
-            /* Only need to wait to receive the session ticket in TLS1.3 */
-            if ((conn->actual_protocol_version >= S2N_TLS13 ) && session_ticket) {
+            if (conn->actual_protocol_version >= S2N_TLS13) {
+                if (!session_ticket) {
+                    print_s2n_error("s2nc can only reconnect in TLS1.3 with session tickets.");
+                    exit(1);
+                }
                 GUARD_EXIT(echo(conn, sockfd, &session_ticket_recv), "Error calling echo");
+            } else {
+                if (!session_ticket && s2n_connection_get_session_id_length(conn) <= 0) {
+                    printf("Endpoint sent empty session id so cannot resume session\n");
+                    exit(1);
+                }
+                free(session_state);
+                session_state_length = s2n_connection_get_session_length(conn);
+                session_state = calloc(session_state_length, sizeof(uint8_t));
+                if (s2n_connection_get_session(conn, session_state, session_state_length) != session_state_length) {
+                    print_s2n_error("Error getting serialized session state");
+                    exit(1);
+                }
             }
         }
 

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -585,12 +585,13 @@ int main(int argc, char *const *argv)
                 GUARD_EXIT(echo(conn, sockfd, &session_ticket_recv), "Error calling echo");
             } else {
                 if (!session_ticket && s2n_connection_get_session_id_length(conn) <= 0) {
-                    printf("Endpoint sent empty session id so cannot resume session\n");
+                    print_s2n_error("Endpoint sent empty session id so cannot resume session");
                     exit(1);
                 }
                 free(session_state);
                 session_state_length = s2n_connection_get_session_length(conn);
                 session_state = calloc(session_state_length, sizeof(uint8_t));
+                GUARD_EXIT_NULL(session_state);
                 if (s2n_connection_get_session(conn, session_state, session_state_length) != session_state_length) {
                     print_s2n_error("Error getting serialized session state");
                     exit(1);

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -294,7 +294,7 @@ void usage()
                     "    A comma-separated list of psk parameters in this order: psk_identity, psk_secret and psk_hmac_alg.\n"
                     "    Note that the maximum number of permitted psks is 10, the psk-secret is hex-encoded, and whitespace is not allowed before or after the commas.\n"
                     "    Ex: --psk psk_id,psk_secret,SHA256 --psk shared_id,shared_secret,SHA384.\n");
-    fprintf(stderr, "  -E, --max_early_data \n");
+    fprintf(stderr, "  -E, --max-early-data \n");
     fprintf(stderr, "    Sets maximum early data allowed in session tickets. \n");
     fprintf(stderr, "  -h,--help\n");
     fprintf(stderr, "    Display this message and quit.\n");
@@ -385,7 +385,8 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
     if (settings.https_server) {
         https(conn, settings.https_bench);
     } else if (!settings.only_negotiate) {
-        echo(conn, fd);
+        bool stop_echo = false;
+        echo(conn, fd, &stop_echo);
     }
 
     /* The following call can block on receiving a close_notify if we initiate the shutdown or if the */
@@ -469,7 +470,7 @@ int main(int argc, char *const *argv)
         {"non-blocking", no_argument, 0, 'B'},
         {"key-log", required_argument, 0, 'L'},
         {"psk", required_argument, 0, 'P'},
-        {"max_early_data", required_argument, 0, 'E'},
+        {"max-early-data", required_argument, 0, 'E'},
         /* Per getopt(3) the last element of the array has to be filled with all zeros */
         { 0 },
     };

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -294,6 +294,8 @@ void usage()
                     "    A comma-separated list of psk parameters in this order: psk_identity, psk_secret and psk_hmac_alg.\n"
                     "    Note that the maximum number of permitted psks is 10, the psk-secret is hex-encoded, and whitespace is not allowed before or after the commas.\n"
                     "    Ex: --psk psk_id,psk_secret,SHA256 --psk shared_id,shared_secret,SHA384.\n");
+    fprintf(stderr, "  -E, --max_early_data \n");
+    fprintf(stderr, "    Sets maximum early data allowed in session tickets. \n");
     fprintf(stderr, "  -h,--help\n");
     fprintf(stderr, "    Display this message and quit.\n");
 
@@ -365,6 +367,8 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
         s2n_setup_external_psk_list(conn, settings.psk_optarg_list, settings.psk_list_len),
         "Error setting external psk list");
 
+    GUARD_RETURN(early_data_recv(conn), "Error receiving early data");
+
     if (negotiate(conn, fd) != S2N_SUCCESS) {
         if (settings.mutual_auth) {
             if (!s2n_connection_client_cert_used(conn)) {
@@ -435,6 +439,7 @@ int main(int argc, char *const *argv)
     conn_settings.session_cache = 1;
     conn_settings.max_conns = -1;
     conn_settings.psk_list_len = 0;
+    int max_early_data = 0;
 
     struct option long_options[] = {
         {"ciphers", required_argument, NULL, 'c'},
@@ -464,12 +469,13 @@ int main(int argc, char *const *argv)
         {"non-blocking", no_argument, 0, 'B'},
         {"key-log", required_argument, 0, 'L'},
         {"psk", required_argument, 0, 'P'},
+        {"max_early_data", required_argument, 0, 'E'},
         /* Per getopt(3) the last element of the array has to be filled with all zeros */
         { 0 },
     };
     while (1) {
         int option_index = 0;
-        int c = getopt_long(argc, argv, "c:hmnst:d:iTCX::wb:A:P:", long_options, &option_index);
+        int c = getopt_long(argc, argv, "c:hmnst:d:iTCX::wb:A:P:E:", long_options, &option_index);
         if (c == -1) {
             break;
         }
@@ -576,6 +582,9 @@ int main(int argc, char *const *argv)
                 exit(1);
             }
             conn_settings.psk_optarg_list[conn_settings.psk_list_len++] = optarg;
+            break;
+        case 'E':
+            max_early_data = atoi(optarg);
             break;
         case '?':
         default:
@@ -716,6 +725,8 @@ int main(int argc, char *const *argv)
 
         close(fd);
     }
+
+    GUARD_EXIT(s2n_config_set_server_max_early_data_size(config, max_early_data), "Error setting max early data");
 
     GUARD_EXIT(s2n_config_add_dhparams(config, dhparams), "Error adding DH parameters");
 

--- a/tls/s2n_early_data.h
+++ b/tls/s2n_early_data.h
@@ -60,17 +60,17 @@ S2N_RESULT s2n_early_data_validate_recv(struct s2n_connection *conn);
 
 /* Public Interface -- will be made visible and moved to s2n.h when the 0RTT feature is released */
 
-int s2n_config_set_server_max_early_data_size(struct s2n_config *config, uint32_t max_early_data_size);
-int s2n_connection_set_server_max_early_data_size(struct s2n_connection *conn, uint32_t max_early_data_size);
-int s2n_connection_set_server_early_data_context(struct s2n_connection *conn, const uint8_t *context, uint16_t context_size);
+S2N_API int s2n_config_set_server_max_early_data_size(struct s2n_config *config, uint32_t max_early_data_size);
+S2N_API int s2n_connection_set_server_max_early_data_size(struct s2n_connection *conn, uint32_t max_early_data_size);
+S2N_API int s2n_connection_set_server_early_data_context(struct s2n_connection *conn, const uint8_t *context, uint16_t context_size);
 
-int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data_size,
+S2N_API int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data_size,
         uint8_t cipher_suite_first_byte, uint8_t cipher_suite_second_byte);
-int s2n_psk_set_application_protocol(struct s2n_psk *psk, const uint8_t *application_protocol, uint8_t size);
-int s2n_psk_set_context(struct s2n_psk *psk, const uint8_t *context, uint16_t size);
+S2N_API int s2n_psk_set_application_protocol(struct s2n_psk *psk, const uint8_t *application_protocol, uint8_t size);
+S2N_API int s2n_psk_set_context(struct s2n_psk *psk, const uint8_t *context, uint16_t size);
 
-int s2n_connection_set_early_data_expected(struct s2n_connection *conn);
-int s2n_connection_set_end_of_early_data(struct s2n_connection *conn);
+S2N_API int s2n_connection_set_early_data_expected(struct s2n_connection *conn);
+S2N_API int s2n_connection_set_end_of_early_data(struct s2n_connection *conn);
 
 typedef enum {
     S2N_EARLY_DATA_STATUS_OK,
@@ -78,20 +78,20 @@ typedef enum {
     S2N_EARLY_DATA_STATUS_REJECTED,
     S2N_EARLY_DATA_STATUS_END,
 } s2n_early_data_status_t;
-int s2n_connection_get_early_data_status(struct s2n_connection *conn, s2n_early_data_status_t *status);
+S2N_API int s2n_connection_get_early_data_status(struct s2n_connection *conn, s2n_early_data_status_t *status);
 
-int s2n_connection_get_remaining_early_data_size(struct s2n_connection *conn, uint32_t *allowed_early_data_size);
-int s2n_connection_get_max_early_data_size(struct s2n_connection *conn, uint32_t *max_early_data_size);
+S2N_API int s2n_connection_get_remaining_early_data_size(struct s2n_connection *conn, uint32_t *allowed_early_data_size);
+S2N_API int s2n_connection_get_max_early_data_size(struct s2n_connection *conn, uint32_t *max_early_data_size);
 
-int s2n_send_early_data(struct s2n_connection *conn, const uint8_t *data, ssize_t data_len,
+S2N_API int s2n_send_early_data(struct s2n_connection *conn, const uint8_t *data, ssize_t data_len,
         ssize_t *data_sent, s2n_blocked_status *blocked);
-int s2n_recv_early_data(struct s2n_connection *conn, uint8_t *data, ssize_t max_data_len,
+S2N_API int s2n_recv_early_data(struct s2n_connection *conn, uint8_t *data, ssize_t max_data_len,
         ssize_t *data_received, s2n_blocked_status *blocked);
 
 struct s2n_offered_early_data;
 typedef int (*s2n_early_data_cb)(struct s2n_connection *conn, struct s2n_offered_early_data *early_data);
-int s2n_config_set_early_data_cb(struct s2n_config *config, s2n_early_data_cb cb);
-int s2n_offered_early_data_get_context_length(struct s2n_offered_early_data *early_data, uint16_t *context_len);
-int s2n_offered_early_data_get_context(struct s2n_offered_early_data *early_data, uint8_t *context, uint16_t max_len);
-int s2n_offered_early_data_reject(struct s2n_offered_early_data *early_data);
-int s2n_offered_early_data_accept(struct s2n_offered_early_data *early_data);
+S2N_API int s2n_config_set_early_data_cb(struct s2n_config *config, s2n_early_data_cb cb);
+S2N_API int s2n_offered_early_data_get_context_length(struct s2n_offered_early_data *early_data, uint16_t *context_len);
+S2N_API int s2n_offered_early_data_get_context(struct s2n_offered_early_data *early_data, uint8_t *context, uint16_t max_len);
+S2N_API int s2n_offered_early_data_reject(struct s2n_offered_early_data *early_data);
+S2N_API int s2n_offered_early_data_accept(struct s2n_offered_early_data *early_data);

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -101,13 +101,13 @@ S2N_RESULT s2n_connection_get_session_state_size(struct s2n_connection *conn, si
 
 /* These functions will be labeled S2N_API and become a publicly visible api 
  * once we release the session resumption API. */
-int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num);
-int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num);
-int s2n_connection_set_server_keying_material_lifetime(struct s2n_connection *conn, uint32_t lifetime_in_secs);
+S2N_API int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num);
+S2N_API int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num);
+S2N_API int s2n_connection_set_server_keying_material_lifetime(struct s2n_connection *conn, uint32_t lifetime_in_secs);
 
 struct s2n_session_ticket;
 typedef int (*s2n_session_ticket_fn)(struct s2n_connection *conn, void *ctx, struct s2n_session_ticket *ticket);
-int s2n_config_set_session_ticket_cb(struct s2n_config *config, s2n_session_ticket_fn callback, void *ctx);
-int s2n_session_ticket_get_data_len(struct s2n_session_ticket *ticket, size_t *data_len);
-int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, size_t max_data_len, uint8_t *data);
-int s2n_session_ticket_get_lifetime(struct s2n_session_ticket *ticket, uint32_t *session_lifetime);
+S2N_API int s2n_config_set_session_ticket_cb(struct s2n_config *config, s2n_session_ticket_fn callback, void *ctx);
+S2N_API int s2n_session_ticket_get_data_len(struct s2n_session_ticket *ticket, size_t *data_len);
+S2N_API int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, size_t max_data_len, uint8_t *data);
+S2N_API int s2n_session_ticket_get_lifetime(struct s2n_session_ticket *ticket, uint32_t *session_lifetime);

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -56,7 +56,6 @@ int s2n_server_nst_recv(struct s2n_connection *conn) {
 
         if (conn->config->session_ticket_cb != NULL) {
             size_t session_len = s2n_connection_get_session_length(conn);
-            POSIX_ENSURE_GTE(S2N_TLS12_SESSION_SIZE, session_len);
 
             /* Alloc some memory for the serialized session ticket */
             DEFER_CLEANUP(struct s2n_blob mem = { 0 }, s2n_free);


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

This PR enables TLS1.3 session resumption in s2nc and s2nd and adds functionality for sending early data with that session resumption.  Specifically:
1. It gives s2nc the ability to resume a TLS1.3 session with s_server, and send early data along with that resumed session
2. It gives s2nd the ability to resume a TLS1.3 session with s_client, and read the early data sent in that resumed session

### Call-outs:

With this change s2nc/s2nd only can send/recv early data with session resumption(not with external psks.) This is because s_client/s_server don't accept early data on their external psks so we can't test that feature with them. 
### Testing:
Manual testing:
s2nd can successfully read early data from a resumed session with s_client
s2nc can successfully reconnect 5 times with s_server and send early data with each reconnect (and s_server reads the early data correctly).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
