### PR TITLE
Check for < TLS1.3 in s2n_connection_get_session_id/length 

### DIFF
--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1161,6 +1161,8 @@ const char *s2n_get_application_protocol(struct s2n_connection *conn)
 int s2n_connection_get_session_id_length(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
+    /* Stateful session resumption in TLS1.3 using session id is not yet supported. */
+    POSIX_ENSURE(conn->actual_protocol_version < S2N_TLS13, S2N_ERR_UNIMPLEMENTED);
     return conn->session_id_len;
 }
 
@@ -1168,6 +1170,8 @@ int s2n_connection_get_session_id(struct s2n_connection *conn, uint8_t *session_
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(session_id);
+    /* Stateful session resumption in TLS1.3 using session id is not yet supported. */
+    POSIX_ENSURE(conn->actual_protocol_version < S2N_TLS13, S2N_ERR_UNIMPLEMENTED);
 
     int session_id_len = s2n_connection_get_session_id_length(conn);
 


### PR DESCRIPTION
### Resolved issues:

Related to: https://github.com/aws/s2n-tls/issues/2553

### Description of changes: 

s2n_connection_get_session_id and s2n_connection_get_session_id_length APIs updated to check for < TLS1.3 as stateful session resumption in TLS1.3 using session id is not yet supported.

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? Unit Tests 

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? Added check

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
