### PR TITLE
Disable mlock during unit tests

### DIFF
--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -56,7 +56,7 @@ static int s2n_mem_init_impl(void)
 
     page_size = (uint32_t) sysconf_rc;
 
-    if (getenv("S2N_DONT_MLOCK")) {
+    if (getenv("S2N_DONT_MLOCK") || s2n_in_unit_test()) {
         s2n_mem_malloc_cb = s2n_mem_malloc_no_mlock_impl;
         s2n_mem_free_cb = s2n_mem_free_no_mlock_impl;
     }


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 
Disables `mlock` during unit tests. If unit tests need alternate behavior that tests the `mlock` feature they can use the `s2n_mem_set_callbacks()` API immediately before `BEGIN_TEST()`.

Right now, the unit testing scripts set the environment flag `S2N_DONT_MLOCK` before running the unit tests since memory locking during testing can result in unrealted test failures. However, manually running unit tests without the test scripts (such as during debugging sessions, or by automated build tools not controlled by s2n) can cause the unit tests to fail due to most Linux OS's enforcing a low default limit to the amount of memory that can be locked at once. 

So to fix this issue, we can update `s2n_mem_init_impl()` to check if s2n is being initialized during a unit test, and disable `mlock` by default as is usually intended.

See: 
  - https://github.com/aws/s2n-tls/issues/108
  - https://github.com/aws/s2n-tls/issues/676
  - https://github.com/aws/s2n-tls/issues/677
  - https://github.com/aws/s2n-tls/pull/2793

### Call-outs:
N/A

### Testing:
Ran unit tests before/after this one line change, and both passed. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
