### PR TITLE
s2n_deserialize_resumption_state for TLS1.3 stateful session resumption

### DIFF
--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -931,12 +931,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_set_wall_clock(config, mock_time, NULL));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-            uint8_t session_id[] = { SESSION_ID_DATA };
-            struct s2n_blob psk_identity = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&psk_identity, session_id, sizeof(session_id)));
-
-            EXPECT_ERROR_WITH_ERRNO(s2n_deserialize_resumption_state(conn, &psk_identity, &session_id_stuffer),
-                                      S2N_ERR_SAFETY);
+            EXPECT_ERROR_WITH_ERRNO(s2n_deserialize_resumption_state(conn, NULL, &session_id_stuffer),
+                                      S2N_ERR_NULL);
             EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_null_cipher_suite);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -66,7 +66,7 @@ static S2N_RESULT s2n_generate_client_session_id(struct s2n_connection *conn)
         return S2N_RESULT_OK;
     }
 
-    /* Only generate the session id for pre-TLS1.3 if using tickets */
+    /* Only generate the session id for pre-TLS1.3 if not using tickets */
     if (conn->client_protocol_version < S2N_TLS13 && !conn->config->use_tickets) {
         return S2N_RESULT_OK;
     }

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -304,6 +304,8 @@ static S2N_RESULT s2n_deserialize_resumption_state(struct s2n_connection *conn, 
             RESULT_GUARD(s2n_tls12_client_deserialize_session_state(conn, from));
         }  
     } else if (format == S2N_TLS13_SERIALIZED_FORMAT_VERSION) {
+        /* Stateful session resumption is not yet implemented in TLS1.3 */
+        RESULT_ENSURE_EQ(conn->config->use_tickets, 1);
         RESULT_GUARD(s2n_tls13_deserialize_session_state(conn, psk_identity, from));
     } else {
         RESULT_BAIL(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -304,8 +304,6 @@ static S2N_RESULT s2n_deserialize_resumption_state(struct s2n_connection *conn, 
             RESULT_GUARD(s2n_tls12_client_deserialize_session_state(conn, from));
         }  
     } else if (format == S2N_TLS13_SERIALIZED_FORMAT_VERSION) {
-        /* Stateful session resumption is not yet implemented in TLS1.3 */
-        RESULT_ENSURE_EQ(conn->config->use_tickets, 1);
         RESULT_GUARD(s2n_tls13_deserialize_session_state(conn, psk_identity, from));
     } else {
         RESULT_BAIL(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);


### PR DESCRIPTION
### Resolved issues:

Related to https://github.com/aws/s2n-tls/issues/2553

### Description of changes: 

`s2n_deserialize_resumption_state` will fail for the unimplemented stateful session resumption in TLS1.3. Adding a check  to prevent abrupt failures when `s2n_tls13_deserialize_session_state` is called. 

The following function calls within `s2n_client_deserialize_with_session_id ` and `s2n_decrypt_session_cache ` will fail in TLS1.3:

https://github.com/aws/s2n-tls/blob/3d522c4b8f2071c2983d3a00269e3ffbb41ea4d5/tls/s2n_resume.c#L327

https://github.com/aws/s2n-tls/blob/3d522c4b8f2071c2983d3a00269e3ffbb41ea4d5/tls/s2n_resume.c#L865

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? Unit Tests

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
