### PR TITLE
Make digest_allow_md5_for_fips proof UID unique

### DIFF
--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/Makefile
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/Makefile
@@ -18,7 +18,7 @@ DEFINES += -DOPENSSL_IS_AWSLC=1
 
 CBMCFLAGS +=
 
-PROOF_UID = s2n_digest_allow_md5_for_fips
+PROOF_UID = s2n_digest_allow_md5_for_fips_boringssl_awslc
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
 

--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/s2n_digest_allow_md5_for_fips_boringssl_awslc_harness.c
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/s2n_digest_allow_md5_for_fips_boringssl_awslc_harness.c
@@ -18,7 +18,7 @@
 #include "api/s2n.h"
 #include "crypto/s2n_evp.h"
 
-void s2n_digest_allow_md5_for_fips_harness()
+void s2n_digest_allow_md5_for_fips_boringssl_awslc_harness()
 {
     /* Non-deterministic inputs. */
     struct s2n_evp_digest *evp_digest = cbmc_allocate_s2n_evp_digest();


### PR DESCRIPTION
This commit fixes the UID for the
s2n_digest_allow_md5_for_fips_boringssl_awslc CBMC proof to be unique.
Previously, the UID was mistakenly set to s2n_digest_allow_md5_for_fips,
which is shared with another proof of that name. This has had the
consequence that all of the proof jobs for both those proofs have been
lumped under the same pipeline.

A check for this sort of error will be posted as a separate PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
