### PR TITLE
Removes redundant safety macro

### DIFF
--- a/docs/SAFETY-MACROS.md
+++ b/docs/SAFETY-MACROS.md
@@ -460,9 +460,3 @@ Ensures `s2n_result_is_ok(result)`, otherwise the function will return `NULL`
 ### PTR_GUARD_POSIX(result)
 
 Ensures `(result) >= S2N_SUCCESS`, otherwise the function will return `NULL`
-
-
-### PTR_GUARD_PTR(result)
-
-Ensures `(result) != NULL`, otherwise the function will return `NULL`
-

--- a/utils/s2n_safety_macros.h
+++ b/utils/s2n_safety_macros.h
@@ -524,9 +524,3 @@
  * Ensures `(result) >= S2N_SUCCESS`, otherwise the function will return `NULL`
  */
 #define PTR_GUARD_POSIX(result)                               __S2N_ENSURE((result) >= S2N_SUCCESS, return NULL)
-
-/**
- * Ensures `(result) != NULL`, otherwise the function will return `NULL`
- */
-#define PTR_GUARD_PTR(result)                                 __S2N_ENSURE((result) != NULL, return NULL)
-


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

### Resolved issues:
N/A.

### Description of changes: 
Removes redundant safety macro. `PRT_GUARD` is equivalent to `PTR_GUARD_PTR`.

### Call-outs:
N/A.

### Testing:
N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
