### PR TITLE
Update codebuild script for NO_PQ when building unit tests with cmake

### DIFF
--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -60,11 +60,16 @@ if [[ "$OS_NAME" == "osx" && "$TESTS" == "integration" ]]; then
     scan-build --status-bugs -o /tmp/scan-build make -j$JOBS; STATUS=$?; test $STATUS -ne 0 && cat /tmp/scan-build/*/* ; [ "$STATUS" -eq "0" ];
 fi
 
+CMAKE_PQ_OPTION="S2N_NO_PQ=False"
+if [[ -n "$S2N_NO_PQ" ]]; then
+    CMAKE_PQ_OPTION="S2N_NO_PQ=True"
+fi
+
 # Run Multiple tests on one flag.
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMACPlus" ]] && [[ "$OS_NAME" == "linux" ]]; then make -C tests/saw tmp/verify_HMAC.log tmp/verify_drbg.log sike failure-tests; fi
 
 # Run Individual tests
-if [[ "$TESTS" == "ALL" || "$TESTS" == "unit" ]]; then cmake . -Bbuild -DCMAKE_PREFIX_PATH=$LIBCRYPTO_ROOT; cmake --build ./build; make -C build test ARGS=-j$(nproc); fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "unit" ]]; then cmake . -Bbuild -DCMAKE_PREFIX_PATH=$LIBCRYPTO_ROOT -D${CMAKE_PQ_OPTION}; cmake --build ./build; make -C build test ARGS=-j$(nproc); fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "asan" ]]; then make clean; S2N_ADDRESS_SANITIZER=1 make -j $JOBS ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integration" ]]; then make clean; make integration ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2" ]]; then make clean; make integrationv2 ; fi

--- a/codebuild/bin/s2n_codebuild_al2.sh
+++ b/codebuild/bin/s2n_codebuild_al2.sh
@@ -23,9 +23,14 @@ if [[ "$OS_NAME" == "linux" && -n "$CODEBUILD_BUILD_ARN" ]]; then
     sudo -E ${PRLIMIT_LOCATION} --pid "$$" --memlock=unlimited:unlimited;
 fi
 
+CMAKE_PQ_OPTION="S2N_NO_PQ=False"
+if [[ -n "$S2N_NO_PQ" ]]; then
+    CMAKE_PQ_OPTION="S2N_NO_PQ=True"
+fi
+
 # Linker flags are a workaround for openssl
 case "$TESTS" in
-  "unit") cmake . -Bbuild -DCMAKE_EXE_LINKER_FLAGS="-lcrypto -lz" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+  "unit") cmake . -Bbuild -DCMAKE_EXE_LINKER_FLAGS="-lcrypto -lz" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -D${CMAKE_PQ_OPTION}
           cmake --build ./build -j $(nproc)
           CTEST_PARALLEL_LEVEL=$(nproc) make -C build test;;
   *) echo "Unknown test"

--- a/codebuild/bin/s2n_setup_env.sh
+++ b/codebuild/bin/s2n_setup_env.sh
@@ -106,6 +106,7 @@ export FUZZ_TIMEOUT_SEC
 export GB_INSTALL_DIR
 export OS_NAME
 export S2N_CORKED_IO
+export S2N_NO_PQ
 
 # S2N_COVERAGE should not be used with fuzz tests, use FUZZ_COVERAGE instead
 if [[ "$S2N_COVERAGE" == "true" && "$TESTS" == "fuzz" ]]; then


### PR DESCRIPTION
### Description of changes: 

A `NO_PQ` codebuild job [was added recently](https://github.com/aws/s2n-tls/pull/2451), but it looks like the `unit` build uses CMake, which wasn't respecting the `S2N_NO_PQ` env variable. We can see from [this](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nGeneralBatch/build/s2nGeneralBatch%3Af1b15997-b4cb-4609-b788-237358a2b9b1/?region=us-west-2) `NO_PQ` build on a recent PR that CMake is still compiling and testing PQ:

```
Using 8 jobs for make..
-- The ASM compiler identification is GNU
   ...
-- Found assembler: /usr/bin/cc
-- Enabling SIKEP434R2 assembly code
-- Support for ADX assembly instructions detected
   ...
[ 15%] Building C object CMakeFiles/s2n.dir/pq-crypto/sike_r3/sikep434r3.c.o
[ 16%] Building C object CMakeFiles/s2n.dir/pq-crypto/sike_r3/sikep434r3_ec_isogeny.c.o
[ 16%] Building C object CMakeFiles/s2n.dir/pq-crypto/sike_r3/sikep434r3_fips202.c.o
[ 16%] Building C object CMakeFiles/s2n.dir/pq-crypto/sike_r3/sikep434r3_fp.c.o
[ 16%] Building C object CMakeFiles/s2n.dir/pq-crypto/sike_r3/sikep434r3_fpx.c.o
[ 16%] Building C object CMakeFiles/s2n.dir/pq-crypto/sike_r3/sikep434r3_kem.c.o
[ 16%] Building C object CMakeFiles/s2n.dir/pq-crypto/sike_r3/sikep434r3_sidh.c.o
   ...
Start 101: s2n_pq_kem_kat_test
   ...
201/201 Test #101: s2n_pq_kem_kat_test ..............................   Passed  208.89 sec
```

The same issue existed for the AL2 CodeBuild job.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)?
* Existing tests pass
* Manually verify that `NO_PQ` codebuild job is correctly excluding PQ

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
