### PR TITLE
s2n_connection_get_session_id_len returns 0 for >= TLS1.3

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1541,7 +1541,7 @@ handshake.
 
 **s2n_connection_get_session_length** returns number of bytes needed to store serialized session state; it can be used to allocate the **session** buffer.
 
-**s2n_connection_get_session_id_length** returns session id length from the connection.
+**s2n_connection_get_session_id_length** returns session id length from the connection. Session id length will be 0 for TLS versions >= TLS1.3 as stateful session resumption has not yet been implemented in TLS1.3.
 
 **s2n_connection_get_session_id** get the session id from the connection and copies into the **session_id** buffer and returns the number of bytes that were copied.
 

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -281,6 +281,23 @@ int main(int argc, char **argv)
         }
     }
 
+    /* s2n_connection_get_session_id_length */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(conn);
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_session_id_length(NULL), S2N_ERR_NULL);
+
+        conn->session_id_len = 5;
+        conn->actual_protocol_version = S2N_TLS12;
+        EXPECT_EQUAL(s2n_connection_get_session_id_length(conn), 5);
+
+        conn->actual_protocol_version = S2N_TLS13;
+        EXPECT_EQUAL(s2n_connection_get_session_id_length(conn), 0);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
     /* s2n_tls12_serialize_resumption_state */
     {
         struct s2n_connection *conn;

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1161,6 +1161,10 @@ const char *s2n_get_application_protocol(struct s2n_connection *conn)
 int s2n_connection_get_session_id_length(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
+    /* Stateful session resumption in TLS1.3 using session id is not yet supported. */
+    if (conn->actual_protocol_version >= S2N_TLS13) {
+        return 0;
+    }
     return conn->session_id_len;
 }
 


### PR DESCRIPTION
### Resolved issues:

Relevant: #2553

### Description of changes: 

get_session_id_len returns 0 if we have negotiated a protocol version >= TLS1.3. This also affects get_session_id(), which now does not return a session_id in TLS1.3
### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
### Testing:

 Unit tests

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
