### PR TITLE
Move error handling/blinding higher in the call stack

### DIFF
--- a/tests/unit/s2n_early_data_io_api_test.c
+++ b/tests/unit/s2n_early_data_io_api_test.c
@@ -196,6 +196,7 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
             EXPECT_NOT_NULL(server_conn);
+            EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
 
@@ -346,8 +347,12 @@ int main(int argc, char **argv)
             EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_test_server_and_client(server_conn, client_conn),
                                 S2N_ERR_BAD_MESSAGE);
 
+            /* Read the remaining early data properly */
+            server_conn->closed = false;
+            client_conn->closed = false;
             EXPECT_SUCCESS(s2n_recv_early_data(server_conn, actual_payload, sizeof(actual_payload),
                     &data_size, &blocked));
+
             EXPECT_NOT_BLOCKED(server_conn, blocked, APPLICATION_DATA);
             EXPECT_EQUAL(data_size, sizeof(test_data) - 1);
             EXPECT_BYTEARRAY_EQUAL(actual_payload, test_data + 1, sizeof(test_data) - 1);

--- a/tests/unit/s2n_early_data_io_test.c
+++ b/tests/unit/s2n_early_data_io_test.c
@@ -116,6 +116,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
             EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
 
+            EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
@@ -142,6 +143,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
             EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
 
+            EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
@@ -205,6 +207,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
             EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
 
+            EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
@@ -252,6 +255,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
             EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
 
+            EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
             EXPECT_SUCCESS(s2n_config_free(config));
@@ -280,6 +284,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
             EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
 
+            EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
@@ -322,6 +327,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
             EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
 
+            EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
             EXPECT_SUCCESS(s2n_config_free(config));
@@ -358,7 +364,10 @@ int main(int argc, char **argv)
             EXPECT_FALSE(IS_HELLO_RETRY_HANDSHAKE(server_conn));
             EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
             EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
+            EXPECT_FALSE(client_conn->closed);
+            EXPECT_FALSE(server_conn->closed);
 
+            EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
@@ -426,6 +435,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
             EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
 
+            EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
@@ -481,7 +491,10 @@ int main(int argc, char **argv)
                 EXPECT_TRUE(WITH_EARLY_CLIENT_CCS(server_conn));
                 EXPECT_TRUE(IS_HELLO_RETRY_HANDSHAKE(client_conn));
                 EXPECT_TRUE(IS_HELLO_RETRY_HANDSHAKE(server_conn));
+                EXPECT_FALSE(client_conn->closed);
+                EXPECT_FALSE(server_conn->closed);
 
+                EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
                 EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
                 EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
             }
@@ -515,6 +528,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), APPLICATION_DATA);
             EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), APPLICATION_DATA);
 
+            EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }

--- a/tests/unit/s2n_handshake_io_errors_test.c
+++ b/tests/unit/s2n_handshake_io_errors_test.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <s2n.h>
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+#include "utils/s2n_result.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* IO blocking on read does not close connection */
+    {
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
+
+        DEFER_CLEANUP(struct s2n_stuffer io_stuffer = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&io_stuffer, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&io_stuffer, &io_stuffer, server_conn));
+
+        /* Try to read the ClientHello, which hasn't been written yet */
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(server_conn, &blocked), S2N_ERR_IO_BLOCKED);
+
+        /* Error did not close connection */
+        EXPECT_FALSE(server_conn->closed);
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    /* Failure in read handler closes connection */
+    {
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
+
+        DEFER_CLEANUP(struct s2n_stuffer io_stuffer = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&io_stuffer, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&io_stuffer, &io_stuffer, client_conn));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&io_stuffer, &io_stuffer, server_conn));
+
+        /* Write the ClientHello */
+        EXPECT_OK(s2n_negotiate_until_message(client_conn, &blocked, SERVER_HELLO));
+
+        /* Overwrite everything except the headers */
+        uint32_t content_size = s2n_stuffer_data_available(&io_stuffer)
+                - S2N_TLS_RECORD_HEADER_LENGTH - TLS_HANDSHAKE_HEADER_LENGTH;
+        EXPECT_SUCCESS(s2n_stuffer_wipe_n(&io_stuffer, content_size));
+        EXPECT_SUCCESS(s2n_stuffer_skip_write(&io_stuffer, content_size));
+
+        /* Read the ClientHello */
+        EXPECT_ERROR_WITH_ERRNO(s2n_negotiate_until_message(server_conn, &blocked, SERVER_HELLO),
+                S2N_ERR_BAD_MESSAGE);
+
+        /* Error closes connection */
+        EXPECT_TRUE(server_conn->closed);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+
+    }
+
+    /* Decrypt failure closes connection */
+    {
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
+
+        DEFER_CLEANUP(struct s2n_stuffer io_stuffer = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&io_stuffer, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&io_stuffer, &io_stuffer, client_conn));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&io_stuffer, &io_stuffer, server_conn));
+
+        /* Write the ClientHello */
+        EXPECT_OK(s2n_negotiate_until_message(client_conn, &blocked, SERVER_HELLO));
+
+        /* Set up encryption on the server */
+        EXPECT_OK(s2n_connection_set_secrets(server_conn));
+
+        /* Read the ClientHello */
+        EXPECT_ERROR_WITH_ERRNO(s2n_negotiate_until_message(server_conn, &blocked, SERVER_HELLO),
+                S2N_ERR_DECRYPT);
+
+        /* Error closes connection */
+        EXPECT_TRUE(server_conn->closed);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_post_handshake_test.c
+++ b/tests/unit/s2n_post_handshake_test.c
@@ -38,9 +38,8 @@ int s2n_key_update_write(struct s2n_blob *out);
 
 int main(int argc, char **argv)
 {
-
     BEGIN_TEST();
-    EXPECT_SUCCESS(s2n_disable_tls13());
+
     /* s2n_post_handshake_recv */
     {   
         /* post_handshake_recv processes a key update requested message */
@@ -195,7 +194,37 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(conn)); 
         }
     }
+
+    /* Errors while processing post-handshake messages close the connection */
+    {
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
+
+        DEFER_CLEANUP(struct s2n_stuffer io_stuffer = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&io_stuffer, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&io_stuffer, &io_stuffer, client_conn));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&io_stuffer, &io_stuffer, server_conn));
+
+        /* Send just the ClientHello */
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+        EXPECT_OK(s2n_negotiate_until_message(client_conn, &blocked, SERVER_HELLO));
+
+        /* Try to read the ClientHello as a post-handshake message */
+        uint8_t output_buffer[10] = { 0 };
+        EXPECT_FAILURE_WITH_ERRNO(s2n_recv(server_conn, output_buffer, sizeof(output_buffer), &blocked), S2N_ERR_BAD_MESSAGE);
+
+        /* Error closed connection */
+        EXPECT_TRUE(server_conn->closed);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
     END_TEST();
 }
-
-

--- a/tests/unit/s2n_recv_test.c
+++ b/tests/unit/s2n_recv_test.c
@@ -28,6 +28,10 @@ int s2n_expect_concurrent_error_recv_fn(void *io_context, uint8_t *buf, uint32_t
     s2n_blocked_status blocked = 0;
     ssize_t result = s2n_recv(conn, buf, len, &blocked);
     EXPECT_FAILURE_WITH_ERRNO(result, S2N_ERR_REENTRANCY);
+
+    /* Usage error does not close the connection */
+    EXPECT_FALSE(conn->closed);
+
     return result;
 }
 

--- a/tests/unit/s2n_self_talk_session_resumption_test.c
+++ b/tests/unit/s2n_self_talk_session_resumption_test.c
@@ -216,6 +216,7 @@ int main(int argc, char **argv)
 
         for (size_t i = 0; i < 10; i++) {
             /* Prepare client and server for new connection */
+            EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
             EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
             EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
@@ -237,6 +238,7 @@ int main(int argc, char **argv)
             EXPECT_OK(s2n_test_issue_new_session_ticket(server_conn, client_conn, &early_data_case));
         }
 
+        EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
@@ -266,6 +268,7 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_test_issue_new_session_ticket(server_conn, client_conn, &no_early_data));
 
         /* Prepare client and server for new connection */
+        EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
         EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
         EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
@@ -316,6 +319,7 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_test_issue_new_session_ticket(server_conn, client_conn, &early_data_case));
 
         /* Prepare client and server for a second connection */
+        EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
         EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
         EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
@@ -336,6 +340,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
 
+        EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
@@ -373,6 +378,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_get_session(client_conn, tls12_session_ticket, tls12_session_ticket_len));
 
         /* Prepare client and server for a second connection */
+        EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
         EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
         EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
@@ -424,6 +430,7 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_test_issue_new_session_ticket(server_conn, client_conn, &early_data_case));
 
         /* Prepare client and server for new connection */
+        EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
         EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
         EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
@@ -476,6 +483,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&cb_session_data, &tls13_ticket, s2n_stuffer_data_available(&cb_session_data)));
 
         /* Prepare client and server for a second connection */
+        EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
         EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
         EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
@@ -490,6 +498,7 @@ int main(int argc, char **argv)
 
         /* Switch between TLS1.2 and TLS1.3 resumption */
         for (size_t i = 0; i < 10; i++) {
+            EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
             EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
             EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1206,6 +1206,38 @@ uint64_t s2n_connection_get_delay(struct s2n_connection *conn)
     return conn->delay - elapsed;
 }
 
+S2N_RESULT s2n_connection_handle_read_error(struct s2n_connection *conn, int error)
+{
+    RESULT_ENSURE_REF(conn);
+
+    /* All blocking errors are retriable and should trigger no further action. */
+    if (s2n_error_get_type(error) == S2N_ERR_T_BLOCKED) {
+        return S2N_RESULT_OK;
+    }
+
+    /* Most errors trigger blinding */
+    switch(error) {
+        /* Don't invoke blinding on some of the common errors.
+         *
+         * Be careful adding new errors here. Disabling blinding for an
+         * error that can be triggered by secret / encrypted values can
+         * potentially lead to a side channel attack.
+         *
+         * We may want to someday add an explicit error type for these errors.
+         */
+        case S2N_ERR_CANCELLED:
+        case S2N_ERR_CIPHER_NOT_SUPPORTED:
+        case S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED:
+            conn->closed = 1;
+            return S2N_RESULT_OK;
+        default:
+            /* Apply blinding to all other errors */
+            RESULT_GUARD_POSIX(s2n_connection_kill(conn));
+    }
+
+    return S2N_RESULT_OK;
+}
+
 int s2n_connection_kill(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1062,25 +1062,8 @@ static int s2n_handshake_handle_sslv2(struct s2n_connection *conn)
     /* We're done with the record, wipe it */
     POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
-    if (r < 0) {
-        /* Don't invoke blinding on some of the common errors */
-        switch (s2n_errno) {
-            case S2N_ERR_CANCELLED:
-            case S2N_ERR_CIPHER_NOT_SUPPORTED:
-            case S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED:
-                conn->closed = 1;
-                break;
-            case S2N_ERR_IO_BLOCKED:
-            case S2N_ERR_ASYNC_BLOCKED:
-                /* A blocking condition is retryable, so we should return without killing the connection. */
-                S2N_ERROR_PRESERVE_ERRNO();
-                break;
-            default:
-                POSIX_GUARD(s2n_connection_kill(conn));
-        }
 
-        return r;
-    }
+    POSIX_GUARD(r);
 
     conn->in_status = ENCRYPTED;
 
@@ -1258,25 +1241,7 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
 
         POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
 
-        if (r < 0) {
-            /* Don't invoke blinding on some of the common errors */
-            switch (s2n_errno) {
-                case S2N_ERR_CANCELLED:
-                case S2N_ERR_CIPHER_NOT_SUPPORTED:
-                case S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED:
-                    conn->closed = 1;
-                    break;
-                case S2N_ERR_IO_BLOCKED:
-                case S2N_ERR_ASYNC_BLOCKED:
-                    /* A blocking condition is retryable, so we should return without killing the connection. */
-                    S2N_ERROR_PRESERVE_ERRNO();
-                    break;
-                default:
-                    POSIX_GUARD(s2n_connection_kill(conn));
-            }
-
-            return r;
-        }
+        POSIX_GUARD(r);
 
         /* Update the secrets, if necessary */
         POSIX_GUARD(s2n_tls13_handle_secrets(conn));
@@ -1307,30 +1272,30 @@ static int s2n_handle_retry_state(struct s2n_connection *conn)
     /* Resume the handshake */
     conn->handshake.paused = false;
 
-    if (!CONNECTION_IS_WRITER(conn)) {
-        /* We're done parsing the record, reset everything */
-        POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
-        POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
-        conn->in_status = ENCRYPTED;
-    }
-
-    if (r < 0) {
-        /* There is some other problem and we should kill the connection. */
-        if (conn->session_id_len) {
-            s2n_try_delete_session_cache(conn);
-        }
-
-        POSIX_GUARD(s2n_connection_kill(conn));
-        S2N_ERROR_PRESERVE_ERRNO();
-    }
-
     if (CONNECTION_IS_WRITER(conn)) {
-        /* If we're the writer and handler just finished, update the record header if
+        POSIX_GUARD(r);
+
+        /* If we're the writer and the handler just finished, update the record header if
          * needed and let the s2n_handshake_write_io write the data to the socket */
         if (EXPECTED_RECORD_TYPE(conn) == TLS_HANDSHAKE) {
             POSIX_GUARD(s2n_handshake_finish_header(&conn->handshake.io));
         }
     } else {
+        /* We're done parsing the record, reset everything */
+        POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
+        POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
+        conn->in_status = ENCRYPTED;
+
+        if (r < 0) {
+            /* There is some other problem and we should kill the connection. */
+            if (conn->session_id_len) {
+                s2n_try_delete_session_cache(conn);
+            }
+
+            POSIX_GUARD_RESULT(s2n_connection_handle_read_error(conn, s2n_errno));
+            S2N_ERROR_PRESERVE_ERRNO();
+        }
+
         /* The read handler processed the record successfully, we are done with this
          * record. Advance the state machine. */
         POSIX_GUARD(s2n_tls13_handle_secrets(conn));
@@ -1408,6 +1373,7 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
                     *blocked = S2N_BLOCKED_ON_EARLY_DATA;
                 }
 
+                POSIX_GUARD_RESULT(s2n_connection_handle_read_error(conn, s2n_errno));
                 S2N_ERROR_PRESERVE_ERRNO();
             }
         }

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -80,6 +80,7 @@ extern int s2n_handshake_finish_header(struct s2n_stuffer *out);
 extern int s2n_handshake_parse_header(struct s2n_connection *conn, uint8_t * message_type, uint32_t * length);
 extern int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int *isSSLv2);
 extern int s2n_recv_close_notify(struct s2n_connection *conn, s2n_blocked_status * blocked);
+S2N_RESULT s2n_connection_handle_read_error(struct s2n_connection *conn, int error);
 
 extern uint16_t mfl_code_to_length[5];
 


### PR DESCRIPTION


### Description of changes: 

Calls to s2n_shutdown after processing rejected 0RTT data were failing because although the rejected 0RTT data was eventually ignored, it still triggered a call to s2n_connection_kill, closing the connection.

While investigating, I realized we also wouldn't trigger error blinding in some newer cases we probably should, like post-handshake message processing.

I've consolidated the read error handling logic and moved it up as high in the call stack as I can so it applies to new read features. I also cleaned up the retry error handling, which didn't match the non-retry version.

### Call-outs:

Please keep an eye out for behavior changes I missed and potential other tests I can write. I think one of the benefits of moving the logic higher in the stack is that I'm less worried about strange edge cases, but I need to make sure we weren't relying on any strange edge cases ;)

### Testing:

Unit tests + integration tests

 Is this a refactor change? Yes. I wrote new unit tests to verify the expected previous behavior where there didn't seem to be enough coverage, and verified those tests still passed after my change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
