### PR TITLE
Fix duplicate KEM assignment in pq_kem_test

### DIFF
--- a/tests/unit/s2n_pq_kem_test.c
+++ b/tests/unit/s2n_pq_kem_test.c
@@ -71,7 +71,6 @@ static const struct s2n_kem_test_vector test_vectors[] = {
         },
         {
                 .kem = &s2n_kyber_512_r3,
-                .kem = &s2n_sike_p434_r3,
                 .asm_is_enabled = s2n_pq_no_asm_available,
                 .enable_asm = s2n_pq_noop_asm,
                 .disable_asm = s2n_pq_noop_asm,


### PR DESCRIPTION
### Description of changes: 

Fixes a duplicate KEM assignment in a test vector in `pq_kem_test`.

### Call-outs:

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
