### PR TITLE
Error blinding updates / fixes

### DIFF
--- a/tests/unit/s2n_handshake_io_errors_test.c
+++ b/tests/unit/s2n_handshake_io_errors_test.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <s2n.h>
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+#include "utils/s2n_result.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* IO blocking on read does not close connection or invoke blinding */
+    {
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
+
+        DEFER_CLEANUP(struct s2n_stuffer io_stuffer = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&io_stuffer, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&io_stuffer, &io_stuffer, server_conn));
+
+        /* Try to read the ClientHello, which hasn't been written yet */
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(server_conn, &blocked), S2N_ERR_IO_BLOCKED);
+
+        /* Error did not close connection */
+        EXPECT_FALSE(server_conn->closed);
+
+        /* Error did not trigger blinding */
+        EXPECT_EQUAL(s2n_connection_get_delay(server_conn), 0);
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    /* Failure in read handler closes connection and invokes blinding */
+    {
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
+
+        DEFER_CLEANUP(struct s2n_stuffer io_stuffer = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&io_stuffer, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&io_stuffer, &io_stuffer, client_conn));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&io_stuffer, &io_stuffer, server_conn));
+
+        /* Write the ClientHello */
+        EXPECT_OK(s2n_negotiate_until_message(client_conn, &blocked, SERVER_HELLO));
+
+        /* Overwrite everything except the headers */
+        uint32_t content_size = s2n_stuffer_data_available(&io_stuffer)
+                - S2N_TLS_RECORD_HEADER_LENGTH - TLS_HANDSHAKE_HEADER_LENGTH;
+        EXPECT_SUCCESS(s2n_stuffer_wipe_n(&io_stuffer, content_size));
+        EXPECT_SUCCESS(s2n_stuffer_skip_write(&io_stuffer, content_size));
+
+        /* Read the ClientHello */
+        EXPECT_ERROR_WITH_ERRNO(s2n_negotiate_until_message(server_conn, &blocked, SERVER_HELLO),
+                S2N_ERR_BAD_MESSAGE);
+
+        /* Error closes connection */
+        EXPECT_TRUE(server_conn->closed);
+
+        /* Error triggers blinding */
+        EXPECT_NOT_EQUAL(s2n_connection_get_delay(server_conn), 0);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+
+    }
+
+    /* Decrypt failure closes connection and invokes blinding */
+    {
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
+
+        DEFER_CLEANUP(struct s2n_stuffer io_stuffer = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&io_stuffer, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&io_stuffer, &io_stuffer, client_conn));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&io_stuffer, &io_stuffer, server_conn));
+
+        /* Write the ClientHello */
+        EXPECT_OK(s2n_negotiate_until_message(client_conn, &blocked, SERVER_HELLO));
+
+        /* Set up encryption on the server */
+        EXPECT_OK(s2n_connection_set_secrets(server_conn));
+
+        /* Read the ClientHello */
+        EXPECT_ERROR_WITH_ERRNO(s2n_negotiate_until_message(server_conn, &blocked, SERVER_HELLO),
+                S2N_ERR_DECRYPT);
+
+        /* Error closes connection */
+        EXPECT_TRUE(server_conn->closed);
+
+        /* Error triggers blinding */
+        EXPECT_NOT_EQUAL(s2n_connection_get_delay(server_conn), 0);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_safety_blinding_test.c
+++ b/tests/unit/s2n_safety_blinding_test.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/s2n_connection.h"
+#include "utils/s2n_safety.h"
+
+#define TEST_ERRNO S2N_ERR_T_INTERNAL_END
+
+#define SETUP_TEST(conn) \
+    EXPECT_SUCCESS(s2n_connection_wipe(conn)); \
+    EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING)); \
+
+#define EXPECT_BLINDING(conn) \
+    EXPECT_NOT_EQUAL(s2n_connection_get_delay(conn), 0); \
+    EXPECT_TRUE(conn->closed); \
+
+#define EXPECT_NO_BLINDING(conn) \
+    EXPECT_EQUAL(s2n_connection_get_delay(conn), 0); \
+    EXPECT_FALSE(conn->closed); \
+
+S2N_RESULT s2n_result_func(bool success)
+{
+    RESULT_ENSURE(success, TEST_ERRNO);
+    return S2N_RESULT_OK;
+}
+
+int s2n_posix_func(bool success)
+{
+    POSIX_ENSURE(success, TEST_ERRNO);
+    return S2N_SUCCESS;
+}
+
+int ptr_value = 0;
+int* s2n_ptr_func(bool success)
+{
+    PTR_ENSURE(success, TEST_ERRNO);
+    return &ptr_value;
+}
+
+S2N_RESULT s2n_result_test(struct s2n_connection *conn)
+{
+    WITH_ERROR_BLINDING(conn, RESULT_GUARD(s2n_result_func(true)));
+    EXPECT_NO_BLINDING(conn);
+
+    WITH_ERROR_BLINDING(conn, RESULT_ENSURE(true, S2N_ERR_UNIMPLEMENTED));
+    EXPECT_NO_BLINDING(conn);
+
+    WITH_ERROR_BLINDING(conn, RESULT_GUARD_POSIX(s2n_posix_func(true)));
+    EXPECT_NO_BLINDING(conn);
+
+    WITH_ERROR_BLINDING(conn, RESULT_GUARD_PTR(s2n_ptr_func(true)));
+    EXPECT_NO_BLINDING(conn);
+
+    WITH_ERROR_BLINDING(conn, RESULT_GUARD(s2n_result_func(false)));
+    return S2N_RESULT_OK;
+}
+
+int s2n_posix_test(struct s2n_connection *conn)
+{
+    WITH_ERROR_BLINDING(conn, POSIX_GUARD_RESULT(s2n_result_func(true)));
+    EXPECT_NO_BLINDING(conn);
+
+    WITH_ERROR_BLINDING(conn, POSIX_ENSURE(true, S2N_ERR_UNIMPLEMENTED));
+    EXPECT_NO_BLINDING(conn);
+
+    WITH_ERROR_BLINDING(conn, POSIX_GUARD(s2n_posix_func(true)));
+    EXPECT_NO_BLINDING(conn);
+
+    WITH_ERROR_BLINDING(conn, POSIX_GUARD_PTR(s2n_ptr_func(true)));
+    EXPECT_NO_BLINDING(conn);
+
+    WITH_ERROR_BLINDING(conn, POSIX_GUARD(s2n_posix_func(false)));
+    return S2N_SUCCESS;
+}
+
+int* s2n_ptr_test(struct s2n_connection *conn)
+{
+    WITH_ERROR_BLINDING(conn, PTR_GUARD_RESULT(s2n_result_func(true)));
+    EXPECT_NO_BLINDING(conn);
+
+    WITH_ERROR_BLINDING(conn, PTR_ENSURE(true, S2N_ERR_UNIMPLEMENTED));
+    EXPECT_NO_BLINDING(conn);
+
+    WITH_ERROR_BLINDING(conn, PTR_GUARD_POSIX(s2n_posix_func(true)));
+    EXPECT_NO_BLINDING(conn);
+
+    WITH_ERROR_BLINDING(conn, PTR_GUARD(s2n_ptr_func(true)));
+    EXPECT_NO_BLINDING(conn);
+
+    WITH_ERROR_BLINDING(conn, PTR_GUARD(s2n_ptr_func(false)));
+    return S2N_SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test: s2n_connection_apply_error_blinding */
+    {
+        /* Safety check */
+        struct s2n_connection *conn = NULL;
+        EXPECT_ERROR_WITH_ERRNO(s2n_connection_apply_error_blinding(NULL), S2N_ERR_NULL);
+        EXPECT_OK(s2n_connection_apply_error_blinding(&conn));
+
+        conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(conn);
+
+        /* No-op for no error */
+        {
+            SETUP_TEST(conn);
+            s2n_errno = S2N_ERR_OK;
+            EXPECT_OK(s2n_connection_apply_error_blinding(&conn));
+            EXPECT_NO_BLINDING(conn);
+        }
+
+        /* No-op for retriable errors */
+        {
+            SETUP_TEST(conn);
+            s2n_errno = S2N_ERR_IO_BLOCKED;
+            EXPECT_OK(s2n_connection_apply_error_blinding(&conn));
+            EXPECT_NO_BLINDING(conn);
+        }
+
+        /* Closes connection but does not blind for non-blinding errors */
+        {
+            SETUP_TEST(conn);
+            s2n_errno = S2N_ERR_CIPHER_NOT_SUPPORTED;
+            EXPECT_OK(s2n_connection_apply_error_blinding(&conn));
+            EXPECT_EQUAL(s2n_connection_get_delay(conn), 0);
+            EXPECT_TRUE(conn->closed);
+        }
+
+        /* Blinds for an average error */
+        {
+            SETUP_TEST(conn);
+            s2n_errno = S2N_ERR_UNIMPLEMENTED;
+            EXPECT_OK(s2n_connection_apply_error_blinding(&conn));
+            EXPECT_BLINDING(conn);
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test: WITH_ERROR_BLINDING macro */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(conn);
+
+        SETUP_TEST(conn);
+        EXPECT_ERROR_WITH_ERRNO(s2n_result_test(conn), TEST_ERRNO);
+        EXPECT_BLINDING(conn);
+
+        SETUP_TEST(conn);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_posix_test(conn), TEST_ERRNO);
+        EXPECT_BLINDING(conn);
+
+        SETUP_TEST(conn);
+        EXPECT_NULL(s2n_ptr_test(conn));
+        EXPECT_NOT_EQUAL(s2n_connection_get_delay(conn), 0);
+        EXPECT_BLINDING(conn);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_safety_blinding_test.c
+++ b/tests/unit/s2n_safety_blinding_test.c
@@ -155,7 +155,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test: WITH_ERROR_BLINDING macro */
+    /* Test: WITH_ERROR_BLINDING macro
+     * The WITH_ERROR_BLINDING macro relies on the current method exiting early.
+     * We can't trigger that behavior in main, so we call separate test methods.
+     * Each test method verifies that some success cases don't lead to blinding, then
+     * triggers blinding. Back in main, we verify that the blinding occurred. */
     {
         struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
         EXPECT_NOT_NULL(conn);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1244,13 +1244,13 @@ S2N_CLEANUP_RESULT s2n_connection_apply_error_blinding(struct s2n_connection **c
         case S2N_ERR_CIPHER_NOT_SUPPORTED:
         case S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED:
             (*conn)->closed = 1;
-            return S2N_RESULT_OK;
+            break;
         default:
+            /* Apply blinding to all other errors */
+            RESULT_GUARD_POSIX(s2n_connection_kill(*conn));
             break;
     }
 
-    /* Apply blinding to all other errors */
-    RESULT_GUARD_POSIX(s2n_connection_kill(*conn));
     return S2N_RESULT_OK;
 }
 

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -82,15 +82,10 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
         conn->header_in.blob.data[0] &= 0x7f;
         *isSSLv2 = 1;
 
-        if (s2n_sslv2_record_header_parse(conn, record_type, &conn->client_protocol_version, &fragment_length) < 0) {
-            POSIX_GUARD(s2n_connection_kill(conn));
-            S2N_ERROR_PRESERVE_ERRNO();
-        }
+        WITH_ERROR_BLINDING(conn, POSIX_GUARD(s2n_sslv2_record_header_parse(conn, record_type,
+                &conn->client_protocol_version, &fragment_length)));
     } else {
-        if (s2n_record_header_parse(conn, record_type, &fragment_length) < 0) {
-            POSIX_GUARD(s2n_connection_kill(conn));
-            S2N_ERROR_PRESERVE_ERRNO();
-        }
+        WITH_ERROR_BLINDING(conn, POSIX_GUARD(s2n_record_header_parse(conn, record_type, &fragment_length)));
     }
 
     /* Read enough to have the whole record */
@@ -101,10 +96,10 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
     }
 
     /* Decrypt and parse the record */
-    if (s2n_record_parse(conn) < 0) {
-        POSIX_ENSURE(!s2n_early_data_is_trial_decryption_allowed(conn, *record_type), S2N_ERR_EARLY_DATA_TRIAL_DECRYPT);
-        POSIX_GUARD(s2n_connection_kill(conn));
-        S2N_ERROR_PRESERVE_ERRNO();
+    if (s2n_early_data_is_trial_decryption_allowed(conn, *record_type)) {
+        POSIX_ENSURE(s2n_record_parse(conn) >= S2N_SUCCESS, S2N_ERR_EARLY_DATA_TRIAL_DECRYPT);
+    } else {
+        WITH_ERROR_BLINDING(conn, POSIX_GUARD(s2n_record_parse(conn)));
     }
 
     /* In TLS 1.3, encrypted handshake records would appear to be of record type
@@ -169,7 +164,7 @@ ssize_t s2n_recv_impl(struct s2n_connection * conn, void *buf, ssize_t size, s2n
                     POSIX_GUARD(s2n_flush(conn, blocked));
                     break;
                 case TLS_HANDSHAKE:
-                    POSIX_GUARD(s2n_post_handshake_recv(conn));
+                    WITH_ERROR_BLINDING(conn, POSIX_GUARD(s2n_post_handshake_recv(conn)));
                     break;
             }
             POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -82,10 +82,11 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int
         conn->header_in.blob.data[0] &= 0x7f;
         *isSSLv2 = 1;
 
-        WITH_ERROR_BLINDING(conn, POSIX_GUARD(s2n_sslv2_record_header_parse(conn, record_type,
-                &conn->client_protocol_version, &fragment_length)));
+        WITH_ERROR_BLINDING(conn, POSIX_GUARD(
+                s2n_sslv2_record_header_parse(conn, record_type, &conn->client_protocol_version, &fragment_length)));
     } else {
-        WITH_ERROR_BLINDING(conn, POSIX_GUARD(s2n_record_header_parse(conn, record_type, &fragment_length)));
+        WITH_ERROR_BLINDING(conn, POSIX_GUARD(
+                s2n_record_header_parse(conn, record_type, &fragment_length)));
     }
 
     /* Read enough to have the whole record */


### PR DESCRIPTION
### Description of changes: 

While investigating an issue with blinding in 0RTT, I noticed that we don't blind post-handshake message processing and we blind write errors when retrying a state.

This change:
- Adds a macro to make error blinding easier to apply
- Adds error blinding to post-handshake message parsing
- Cleans up retry error handling to make it match the non-retry version

### Call-outs:

In this PR, I'm trying to avoid blinding errors that weren't blinded before (with the exception of post-handshake processing). However, I think we should consider expanding blinding to avoid missing anything / confusion about what's secret: https://github.com/aws/s2n-tls/issues/2851

### Testing:

New unit and functional tests.

 Is this a refactor change? Yes. I wrote some new functional tests to validate important existing blinding behavior, and verified that this change did not break them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
