### PR TITLE
Fix BIKE Round-3 build issue when S2N is compiled in S3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,10 +178,11 @@ else()
             "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
             COMPILE_DEFINITIONS ${BIKE_R3_AVX512_FLAGS})
 
+        set(BIKE_R3_PCLMUL_FLAGS "-mpclmul -msse2")
         try_compile(BIKE_R3_PCLMUL_SUPPORTED
             ${CMAKE_BINARY_DIR}
             "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
-            COMPILE_DEFINITIONS "-mpclmul")
+            COMPILE_DEFINITIONS ${BIKE_R3_PCLMUL_FLAGS})
 
         set(BIKE_R3_VPCLMUL_FLAGS "-mvpclmulqdq -mavx512f -mavx512bw -mavx512dq")
         try_compile(BIKE_R3_VPCLMUL_SUPPORTED
@@ -311,7 +312,7 @@ if(BIKE_R3_X86_64_OPT_SUPPORTED)
 
     if(BIKE_R3_PCLMUL_SUPPORTED)
         FILE(GLOB BIKE_R3_PCLMUL_SRCS "pq-crypto/bike_r3/*_pclmul.c")
-        set_source_files_properties(${BIKE_R3_PCLMUL_SRCS} PROPERTIES COMPILE_FLAGS -mpclmul)
+        set_source_files_properties(${BIKE_R3_PCLMUL_SRCS} PROPERTIES COMPILE_FLAGS ${BIKE_R3_PCLMUL_FLAGS})
         target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_BIKE_R3_PCLMUL)
     endif()
 

--- a/pq-crypto/s2n_pq_asm.mk
+++ b/pq-crypto/s2n_pq_asm.mk
@@ -73,16 +73,16 @@ ifndef S2N_NO_PQ_ASM
 		CFLAGS_LLVM += -DS2N_BIKE_R3_AVX512
 		BIKE_R3_AVX512_FLAGS := -mavx512f -mavx512bw -mavx512dq
 	endif
-	BIKE_R3_PCLMUL_SUPPORTED := $(shell $(CC) -mpclmul -c -o $(dummy_file_out) $(dummy_file) > /dev/null 2>&1; echo $$?; rm $(dummy_file_out) > /dev/null 2>&1)
+	BIKE_R3_PCLMUL_SUPPORTED := $(shell $(CC) -mpclmul -msse2 -c -o $(dummy_file_out) $(dummy_file) > /dev/null 2>&1; echo $$?; rm $(dummy_file_out) > /dev/null 2>&1)
 	ifeq ($(BIKE_R3_PCLMUL_SUPPORTED), 0)
 		CFLAGS += -DS2N_BIKE_R3_PCLMUL
 		CFLAGS_LLVM += -DS2N_BIKE_R3_PCLMUL
-		BIKE_R3_PCLMUL_FLAGS := -mpclmul
+		BIKE_R3_PCLMUL_FLAGS := -mpclmul -msse2
 	endif
 	BIKE_R3_PCLMUL_SUPPORTED := $(shell $(CC) -mvpclmulqdq -c -o $(dummy_file_out) $(dummy_file) > /dev/null 2>&1; echo $$?; rm $(dummy_file_out) > /dev/null 2>&1)
 	ifeq ($(BIKE_R3_VPCLMUL_SUPPORTED), 0)
 		CFLAGS += -DS2N_BIKE_R3_VPCLMUL
 		CFLAGS_LLVM += -DS2N_BIKE_R3_VPCLMUL
-		BIKE_R3_PCLMUL_FLAGS := -mvpclmulqdq -mavx512f -mavx512bw -mavx512dq
+		BIKE_R3_VPCLMUL_FLAGS := -mvpclmulqdq -mavx512f -mavx512bw -mavx512dq
 	endif
 endif


### PR DESCRIPTION
Signed-off-by: Dusan Kostic <dkostic@amazon.com>

### Resolved issues:

Addressing the issue when S3 is building with S2N by adding "-msse2" compile flag to the BIKE build.

### Description of changes: 

Adding "-msse2" compile flag to the BIKE build.

### Call-outs:

### Testing:

Tested on an EC2 instance with Ubuntu 20.04 and gcc-9.3.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
