### PR TITLE
Adds close markers to flaky test

### DIFF
--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -150,8 +150,8 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
     client_options.port = port
     server_options.port = port
 
-    server = managed_process(S2N, server_options, timeout=5)
-    client = managed_process(provider, client_options, timeout=5)
+    server = managed_process(S2N, server_options, timeout=5, send_marker=S2N.get_send_marker())
+    client = managed_process(provider, client_options, timeout=5, close_marker=str(close_marker_bytes))
 
     s2n_version = get_expected_s2n_version(protocol, provider)
 

--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -109,6 +109,9 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
     p = tmp_path / 'ticket.pem'
     path_to_ticket = str(p)
 
+    server_send_marker = 's2n is ready'
+    data = data_bytes(10)
+
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
         port=port,
@@ -116,7 +119,7 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
         curve=curve,
         insecure=True,
         reconnect=False,
-        data_to_send=data_bytes(4069),
+        data_to_send=data,
         extra_flags = ['-sess_out', path_to_ticket],
         protocol=protocol)
 
@@ -126,9 +129,10 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
     server_options.cert = certificate.cert
     server_options.use_session_ticket = True
     server_options.extra_flags = None
+    server_options.data_to_send = data
 
-    server = managed_process(S2N, server_options, timeout=5)
-    client = managed_process(provider, client_options, timeout=5)
+    server = managed_process(S2N, server_options, timeout=5, send_marker=server_send_marker, close_marker=str(data))
+    client = managed_process(provider, client_options, timeout=5, close_marker=str(data))
 
     # The client should have received a session ticket
     for results in client.get_results():


### PR DESCRIPTION
### Resolved issues:

N/A
### Description of changes: 
Someone noticed some flaky behavior with the session resumption integ tests, so I changed the failing test to rely on close markers. 
### Call-outs:

N/A
### Testing:

I ran the test in a loop 20 times. The tests all pass, with no flaky behavior observed. That being said, I couldn't actually recreate the flaky behavior so this solution may need to be revisited.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
