### PR TITLE
BIKE R3 fix for gcc-4.8.2

### DIFF
--- a/pq-crypto/bike_r3/gf2x_mul_base_pclmul.c
+++ b/pq-crypto/bike_r3/gf2x_mul_base_pclmul.c
@@ -16,8 +16,8 @@
 #define UNPACKLO(x, y)     _mm_unpacklo_epi64((x), (y))
 #define UNPACKHI(x, y)     _mm_unpackhi_epi64((x), (y))
 #define CLMUL(x, y, imm)   _mm_clmulepi64_si128((x), (y), (imm))
-#define BSRLI(x, imm)      _mm_bsrli_si128((x), (imm))
-#define BSLLI(x, imm)      _mm_bslli_si128((x), (imm))
+#define BSRLI(x, imm)      _mm_srli_si128((x), (imm))
+#define BSLLI(x, imm)      _mm_slli_si128((x), (imm))
 
 // 4x4 Karatsuba multiplication
 _INLINE_ void gf2x_mul4_int(OUT __m128i      c[4],


### PR DESCRIPTION
### Resolved issues:

Fixes BIKE R3 when compiled with gcc-4.8.2 (as in S3's CI).

### Description of changes: 

The version of gcc used in S2N's CI is gcc-4.8.5 which correctly recognizes x86 intrinsic functions `_mm_bsrli_si128` and `_mm_bslli_si128`. However, the patch that added the functions to gcc-4.8.5 wasn't back-ported to gcc-4.8.2 that is used in S3's CI, so that older version of gcc doesn't recognize the functions. This change replaces the functions with their older counterparts that are recognized by gcc-4.8.2, `_mm_srli_si128` and `_mm_slli_si128`.

### Call-outs:

None.

### Testing:
Unit tests on Ubuntu EC2 instance with gcc-9 and gcc-4.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
