### PR TITLE
More fixes for BIKE R3 optimized builds

### DIFF
--- a/pq-crypto/bike_r3/sampling_avx512.c
+++ b/pq-crypto/bike_r3/sampling_avx512.c
@@ -66,7 +66,7 @@ void secure_set_bits_avx512(OUT pad_r_t *   r,
     for(size_t w_iter = 0; w_iter < w_size; w_iter++) {
       int32_t w = wlist[w_iter] - first_pos;
       w_pos_qw  = SET1_I64(w >> 6);
-#if (defined(__GNUC__) && ((__GNUC__ == 6) || (__GNUC__ == 5)) && !defined(__clang__)) || (defined(__clang__) && __clang_major__ == 4 && __clang_minor__ == 9)
+#if (defined(__GNUC__) && ((__GNUC__ == 6) || (__GNUC__ == 5)) && !defined(__clang__)) || (defined(__clang__) && __clang_major__ == 3 && __clang_minor__ == 9)
       // Workaround for gcc-6, gcc-5, and clang < 3.9, which do not allowing the second
       // argument of SLLI to be non-immediate value.
       __m512i temp = SET1_I64(w & MASK(6));

--- a/pq-crypto/bike_r3/sampling_avx512.c
+++ b/pq-crypto/bike_r3/sampling_avx512.c
@@ -66,8 +66,8 @@ void secure_set_bits_avx512(OUT pad_r_t *   r,
     for(size_t w_iter = 0; w_iter < w_size; w_iter++) {
       int32_t w = wlist[w_iter] - first_pos;
       w_pos_qw  = SET1_I64(w >> 6);
-#if (defined(__GNUC__) && ((__GNUC__ == 6) || (__GNUC__ == 5)) && !defined(__clang__)) || (defined(__clang__) && __clang_major__ < 4)
-      // Workaround for gcc-6, gcc-5, and clang < 4, which do not allowing the second
+#if (defined(__GNUC__) && ((__GNUC__ == 6) || (__GNUC__ == 5)) && !defined(__clang__)) || (defined(__clang__) && __clang_major__ == 4 && __clang_minor__ == 9)
+      // Workaround for gcc-6, gcc-5, and clang < 3.9, which do not allowing the second
       // argument of SLLI to be non-immediate value.
       __m512i temp = SET1_I64(w & MASK(6));
       w_pos_bit = SLLV_I64(one, temp);

--- a/pq-crypto/bike_r3/sampling_avx512.c
+++ b/pq-crypto/bike_r3/sampling_avx512.c
@@ -66,8 +66,8 @@ void secure_set_bits_avx512(OUT pad_r_t *   r,
     for(size_t w_iter = 0; w_iter < w_size; w_iter++) {
       int32_t w = wlist[w_iter] - first_pos;
       w_pos_qw  = SET1_I64(w >> 6);
-#if defined(__GNUC__) && ((__GNUC__ == 6) || (__GNUC__ == 5)) && !defined(__clang__)
-      // Workaround for gcc-6 and gcc-5 which has a bug not allowing the second
+#if (defined(__GNUC__) && ((__GNUC__ == 6) || (__GNUC__ == 5)) && !defined(__clang__)) || (defined(__clang__) && __clang_major__ < 4)
+      // Workaround for gcc-6, gcc-5, and clang < 4, which do not allowing the second
       // argument of SLLI to be non-immediate value.
       __m512i temp = SET1_I64(w & MASK(6));
       w_pos_bit = SLLV_I64(one, temp);

--- a/pq-crypto/bike_r3/sampling_avx512.c
+++ b/pq-crypto/bike_r3/sampling_avx512.c
@@ -66,8 +66,8 @@ void secure_set_bits_avx512(OUT pad_r_t *   r,
     for(size_t w_iter = 0; w_iter < w_size; w_iter++) {
       int32_t w = wlist[w_iter] - first_pos;
       w_pos_qw  = SET1_I64(w >> 6);
-#if defined(__GNUC__) && (__GNUC__ == 6) && !defined(__clang__)
-      // Workaround for gcc-6 which has a bug not allowing the second
+#if defined(__GNUC__) && ((__GNUC__ == 6) || (__GNUC__ == 5)) && !defined(__clang__)
+      // Workaround for gcc-6 and gcc-5 which has a bug not allowing the second
       // argument of SLLI to be non-immediate value.
       __m512i temp = SET1_I64(w & MASK(6));
       w_pos_bit = SLLV_I64(one, temp);

--- a/pq-crypto/bike_r3/x86_64_intrinsic.h
+++ b/pq-crypto/bike_r3/x86_64_intrinsic.h
@@ -17,6 +17,11 @@
 #  include <immintrin.h>
 #endif
 
+// clang 3.9 doesn't recognize this macro
+#if !defined(_MM_CMPINT_EQ)
+#  define _MM_CMPINT_EQ (0)
+#endif
+
 // For functions in gf2x_mul.c we use exactly the same code for
 // PORTABLE, AVX2, AVX512 implementations. Based on the implementation,
 // we define macros for the different data types (uint64_t, __m256i, __m512i),


### PR DESCRIPTION
### Description of changes: 

This continues fixes for bike_r3 x86_64 optimizations. The current code is causing CI build failures for gcc-5.5 and clang-3.9 in `aws-c-s3`, seen [here](https://github.com/awslabs/aws-c-s3/pull/128/checks?check_run_id=2687388310) and [here](https://github.com/awslabs/aws-c-s3/pull/128/checks?check_run_id=2687389203). This change should fix those errors.

### Call-outs:

None

### Testing:

I tested this change locally on Ubuntu 20.04 with gcc-5.5 and clang-3.9.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
