### PR TITLE
Various small integration framework fixes

### DIFF
--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -378,7 +378,7 @@ class Results(object):
     def __str__(self):
         return "Stdout: {}\nStderr: {}\nExit code: {}\nException: {}".format(self.stdout, self.stderr, self.exit_code, self.exception)
 
-    def is_success(self):
+    def assert_success(self):
         assert self.exception is None
         assert self.exit_code == 0
         if not self.expect_stderr:

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -368,14 +368,21 @@ class Results(object):
     # Any exception thrown while running the process
     exception = None
 
-    def __init__(self, stdout, stderr, exit_code, exception):
+    def __init__(self, stdout, stderr, exit_code, exception, expect_stderr=False):
         self.stdout = stdout
         self.stderr = stderr
         self.exit_code = exit_code
         self.exception = exception
+        self.expect_stderr = expect_stderr
 
     def __str__(self):
         return "Stdout: {}\nStderr: {}\nExit code: {}\nException: {}".format(self.stdout, self.stderr, self.exit_code, self.exception)
+
+    def is_success(self):
+        assert self.exception is None
+        assert self.exit_code == 0
+        if not self.expect_stderr:
+            assert not self.stderr
 
 
 class ProviderOptions(object):

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -405,6 +405,8 @@ class ProviderOptions(object):
 
         # Hostname
         self.host = host
+        if not self.host:
+            self.host = "localhost"
 
         # Port (string because this will be converted to a command line
         self.port = str(port)

--- a/tests/integrationv2/fixtures.py
+++ b/tests/integrationv2/fixtures.py
@@ -21,13 +21,15 @@ def managed_process():
     """
     processes = []
 
-    def _fn(provider_class: Provider, options: ProviderOptions, timeout=5, send_marker=None, close_marker=None):
+    def _fn(provider_class: Provider, options: ProviderOptions, timeout=5, send_marker=None, close_marker=None, expect_stderr=None):
         provider = provider_class(options)
         cmd_line = provider.get_cmd_line()
         # The process will default to send markers in the providers.py file
         # if not specified by a test.
         if send_marker is not None:
             provider.ready_to_send_input_marker = send_marker
+        if expect_stderr is None:
+            expect_stderr = provider.expect_stderr
         p = ManagedProcess(cmd_line,
                 provider.set_provider_ready,
                 wait_for_marker=provider.ready_to_test_marker,
@@ -35,7 +37,8 @@ def managed_process():
                 close_marker=close_marker,
                 data_source=options.data_to_send,
                 timeout=timeout,
-                env_overrides=options.env_overrides)
+                env_overrides=options.env_overrides,
+                expect_stderr=expect_stderr)
 
         processes.append(p)
         with p.ready_condition:

--- a/tests/integrationv2/processes.py
+++ b/tests/integrationv2/processes.py
@@ -247,7 +247,7 @@ class ManagedProcess(threading.Thread):
         self.proc_env = proc_env
 
         # Command line to execute in the subprocess
-        self.cmd_line = cmd_line
+        self.cmd_line = list(map(str, cmd_line))
 
         # Total time to wait until killing the subprocess
         self.timeout = timeout

--- a/tests/integrationv2/processes.py
+++ b/tests/integrationv2/processes.py
@@ -236,7 +236,8 @@ class ManagedProcess(threading.Thread):
     The stdin/stdout/stderr and exist code a monitored and results
     are made available to the caller.
     """
-    def __init__(self, cmd_line, provider_set_ready_condition, wait_for_marker=None, send_marker_list=None, close_marker=None, timeout=5, data_source=None, env_overrides=dict()):
+    def __init__(self, cmd_line, provider_set_ready_condition, wait_for_marker=None, send_marker_list=None, close_marker=None,
+                 timeout=5, data_source=None, env_overrides=dict(), expect_stderr=False):
         threading.Thread.__init__(self)
 
         proc_env = os.environ.copy()
@@ -267,6 +268,7 @@ class ManagedProcess(threading.Thread):
         self.close_marker = close_marker
         self.data_source = data_source
         self.send_marker_list = send_marker_list
+        self.expect_stderr = expect_stderr
 
         if data_source is not None:
             if type(data_source) is not list:
@@ -282,7 +284,7 @@ class ManagedProcess(threading.Thread):
                 proc = subprocess.Popen(self.cmd_line, env=self.proc_env, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
                 self.proc = proc
             except Exception as ex:
-                self.results = Results(None, None, None, ex)
+                self.results = Results(None, None, None, ex, self.expect_stderr)
                 raise ex
 
             communicator = _processCommunicator(proc)
@@ -297,16 +299,16 @@ class ManagedProcess(threading.Thread):
             proc_results = None
             try:
                 proc_results = communicator.communicate(input_data=self.data_source, send_marker_list=self.send_marker_list, close_marker=self.close_marker, timeout=self.timeout)
-                self.results = Results(proc_results[0], proc_results[1], proc.returncode, None)
+                self.results = Results(proc_results[0], proc_results[1], proc.returncode, None, self.expect_stderr)
             except subprocess.TimeoutExpired as ex:
                 proc.kill()
                 wrapped_ex = TimeoutException(ex)
 
                 # Read any remaining output
                 proc_results = communicator.communicate()
-                self.results = Results(proc_results[0], proc_results[1], proc.returncode, wrapped_ex)
+                self.results = Results(proc_results[0], proc_results[1], proc.returncode, wrapped_ex, self.expect_stderr)
             except Exception as ex:
-                self.results = Results(proc_results[0], proc_results[1], proc.returncode, ex)
+                self.results = Results(proc_results[0], proc_results[1], proc.returncode, ex, self.expect_stderr)
                 raise ex
             finally:
                 # This data is dumped to stdout so we capture this

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -182,6 +182,9 @@ class S2N(Provider):
         return cmd_line
 
     def setup_server(self):
+        # s2nd prints this message after it begins listening for connections
+        self.ready_to_test_marker = 'Listening on'
+
         """
         Using the passed ProviderOptions, create a command line.
         """

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -15,6 +15,9 @@ class Provider(object):
     ServerMode = "server"
 
     def __init__(self, options: ProviderOptions):
+        # If the provider includes stderr output on a success, set this to True.
+        self.expect_stderr = False
+
         # If the test should wait for a specific output message before beginning,
         # put that message in ready_to_test_marker
         self.ready_to_test_marker = None
@@ -243,6 +246,8 @@ class OpenSSL(Provider):
 
     def __init__(self, options: ProviderOptions):
         Provider.__init__(self, options)
+        # We print some OpenSSL logging that includes stderr
+        self.expect_stderr = True
 
     @classmethod
     def get_send_marker(cls):

--- a/tests/integrationv2/test_client_authentication.py
+++ b/tests/integrationv2/test_client_authentication.py
@@ -8,7 +8,7 @@ from configuration import (available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES,
 from common import Certificates, ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process
 from providers import Provider, S2N, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version
+from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
 
 
 # If we test every available cert, the test takes too long.
@@ -32,9 +32,9 @@ def assert_openssl_handshake_complete(results, is_complete=True):
 def assert_s2n_handshake_complete(results, protocol, provider, is_complete=True):
     expected_version = get_expected_s2n_version(protocol, provider)
     if is_complete:
-        assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
+        assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
     else:
-        assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) not in results.stdout
+        assert to_bytes("Actual protocol version: {}".format(expected_version)) not in results.stdout
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -52,7 +52,6 @@ def test_client_auth_with_s2n_server(managed_process, cipher, provider, protocol
     random_bytes = data_bytes(64)
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=cipher,
         data_to_send=random_bytes,
@@ -75,8 +74,7 @@ def test_client_auth_with_s2n_server(managed_process, cipher, provider, protocol
 
     # Openssl should send a client certificate and complete the handshake
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         assert b'write client certificate' in results.stderr
         assert b'write certificate verify' in results.stderr
         assert_openssl_handshake_complete(results)
@@ -84,8 +82,7 @@ def test_client_auth_with_s2n_server(managed_process, cipher, provider, protocol
 
     # S2N should successfully connect
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         assert_s2n_handshake_complete(results, protocol, provider)
         assert random_bytes in results.stdout
 
@@ -104,7 +101,6 @@ def test_client_auth_with_s2n_server_using_nonmatching_certs(managed_process, ci
 
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=cipher,
         data_to_send=b'',
@@ -157,7 +153,6 @@ def test_client_auth_with_s2n_client_no_cert(managed_process, cipher, protocol, 
     random_bytes = data_bytes(64)
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=cipher,
         data_to_send=random_bytes,
@@ -177,8 +172,7 @@ def test_client_auth_with_s2n_client_no_cert(managed_process, cipher, protocol, 
 
     # Openssl should tell us that a cert was requested but not received
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         assert b'write certificate request' in results.stderr
         assert b'read client certificate' not in results.stderr
         assert b"peer did not return a certificate" in results.stderr
@@ -208,7 +202,6 @@ def test_client_auth_with_s2n_client_with_cert(managed_process, cipher, protocol
     random_bytes = data_bytes(64)
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=cipher,
         data_to_send=random_bytes,
@@ -231,14 +224,12 @@ def test_client_auth_with_s2n_client_with_cert(managed_process, cipher, protocol
 
     # The client should connect and return without error
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         assert_s2n_handshake_complete(results, protocol, provider)
 
     # Openssl should indicate the certificate was successfully received.
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         assert random_bytes[1:] in results.stdout
         assert b'read client certificate' in results.stderr
         assert b'read certificate verify' in results.stderr

--- a/tests/integrationv2/test_client_authentication.py
+++ b/tests/integrationv2/test_client_authentication.py
@@ -74,7 +74,7 @@ def test_client_auth_with_s2n_server(managed_process, cipher, provider, protocol
 
     # Openssl should send a client certificate and complete the handshake
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert b'write client certificate' in results.stderr
         assert b'write certificate verify' in results.stderr
         assert_openssl_handshake_complete(results)
@@ -82,7 +82,7 @@ def test_client_auth_with_s2n_server(managed_process, cipher, provider, protocol
 
     # S2N should successfully connect
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert_s2n_handshake_complete(results, protocol, provider)
         assert random_bytes in results.stdout
 
@@ -172,7 +172,7 @@ def test_client_auth_with_s2n_client_no_cert(managed_process, cipher, protocol, 
 
     # Openssl should tell us that a cert was requested but not received
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert b'write certificate request' in results.stderr
         assert b'read client certificate' not in results.stderr
         assert b"peer did not return a certificate" in results.stderr
@@ -224,12 +224,12 @@ def test_client_auth_with_s2n_client_with_cert(managed_process, cipher, protocol
 
     # The client should connect and return without error
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert_s2n_handshake_complete(results, protocol, provider)
 
     # Openssl should indicate the certificate was successfully received.
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert random_bytes[1:] in results.stdout
         assert b'read client certificate' in results.stderr
         assert b'read certificate verify' in results.stderr

--- a/tests/integrationv2/test_dynamic_record_sizes.py
+++ b/tests/integrationv2/test_dynamic_record_sizes.py
@@ -8,7 +8,7 @@ from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, AL
 from common import ProviderOptions, data_bytes, Protocols
 from fixtures import managed_process, custom_mtu
 from providers import Provider, S2N, OpenSSL, Tcpdump
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version
+from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
 
 
 def find_fragmented_packet(results):
@@ -45,14 +45,12 @@ def find_fragmented_packet(results):
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 def test_s2n_client_dynamic_record(custom_mtu, managed_process, cipher, curve, provider, protocol, certificate):
-    host = "localhost"
     port = next(available_ports)
 
     # 16384 bytes is enough to reliably get a packet that will exceed the MTU
     bytes_to_send = data_bytes(16384)
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=cipher,
         data_to_send=bytes_to_send,
@@ -74,13 +72,11 @@ def test_s2n_client_dynamic_record(custom_mtu, managed_process, cipher, curve, p
     client = managed_process(S2N, client_options, timeout=5)
 
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
+        results.is_success()
+        assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
 
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
 
     # The Tcpdump provider only captures 12 packets. This is enough
     # to detect a packet larger than the MTU, but less than the

--- a/tests/integrationv2/test_dynamic_record_sizes.py
+++ b/tests/integrationv2/test_dynamic_record_sizes.py
@@ -72,11 +72,11 @@ def test_s2n_client_dynamic_record(custom_mtu, managed_process, cipher, curve, p
     client = managed_process(S2N, client_options, timeout=5)
 
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
 
     # The Tcpdump provider only captures 12 packets. This is enough
     # to detect a packet larger than the MTU, but less than the

--- a/tests/integrationv2/test_fragmentation.py
+++ b/tests/integrationv2/test_fragmentation.py
@@ -45,12 +45,12 @@ def test_s2n_server_low_latency(managed_process, multi_cipher, provider, protoco
     client = managed_process(provider, client_options, timeout=5)
 
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
         assert random_bytes in results.stdout
 
@@ -89,11 +89,11 @@ def test_s2n_server_framented_data(managed_process, multi_cipher, provider, prot
     client = managed_process(provider, client_options, timeout=5)
 
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
         assert random_bytes in results.stdout

--- a/tests/integrationv2/test_fragmentation.py
+++ b/tests/integrationv2/test_fragmentation.py
@@ -5,7 +5,7 @@ from configuration import available_ports, PROTOCOLS
 from common import ProviderOptions, Ciphers, Certificates, data_bytes
 from fixtures import managed_process
 from providers import Provider, S2N, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version
+from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
 
 
 def multi_cipher_name(c):
@@ -27,7 +27,6 @@ def test_s2n_server_low_latency(managed_process, multi_cipher, provider, protoco
     random_bytes = data_bytes(65519)
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=multi_cipher,
         data_to_send=random_bytes,
@@ -46,15 +45,13 @@ def test_s2n_server_low_latency(managed_process, multi_cipher, provider, protoco
     client = managed_process(provider, client_options, timeout=5)
 
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
+        results.is_success()
+        assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
         assert random_bytes in results.stdout
 
 
@@ -73,7 +70,6 @@ def test_s2n_server_framented_data(managed_process, multi_cipher, provider, prot
     random_bytes = data_bytes(65519)
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=multi_cipher,
         data_to_send=random_bytes,
@@ -93,13 +89,11 @@ def test_s2n_server_framented_data(managed_process, multi_cipher, provider, prot
     client = managed_process(provider, client_options, timeout=5)
 
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
+        results.is_success()
+        assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
         assert random_bytes in results.stdout

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -5,7 +5,7 @@ from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, AL
 from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process
 from providers import Provider, S2N, OpenSSL, JavaSSL
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version
+from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -25,7 +25,6 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
     random_bytes = data_bytes(65519)
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=cipher,
         cert=certificate.cert,
@@ -49,21 +48,19 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
     # just want to make sure there was no exception and that
     # the client exited cleanly.
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
     # The server is always S2N in this test, so we can examine
     # the stdout reliably.
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
+        results.is_success()
+        assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
         assert random_bytes in results.stdout
 
         if provider is not S2N:
-            assert bytes("Cipher negotiated: {}".format(cipher.name).encode('utf-8')) in results.stdout
+            assert to_bytes("Cipher negotiated: {}".format(cipher.name)) in results.stdout
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -83,7 +80,6 @@ def test_s2n_client_happy_path(managed_process, cipher, provider, curve, protoco
     random_bytes = data_bytes(4096)
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=cipher,
         curve=curve,
@@ -107,15 +103,13 @@ def test_s2n_client_happy_path(managed_process, cipher, provider, curve, protoco
     # The client is always S2N in this test, so we can examine
     # the stdout reliably.
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
+        results.is_success()
+        assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
 
     # The server will be one of all supported providers. We
     # just want to make sure there was no exception and that
     # the client exited cleanly.
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         # Avoid debugging information that sometimes gets inserted after the first character
         assert random_bytes[1:] in results.stdout

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -48,14 +48,14 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
     # just want to make sure there was no exception and that
     # the client exited cleanly.
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
     # The server is always S2N in this test, so we can examine
     # the stdout reliably.
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
         assert random_bytes in results.stdout
 
@@ -103,13 +103,13 @@ def test_s2n_client_happy_path(managed_process, cipher, provider, curve, protoco
     # The client is always S2N in this test, so we can examine
     # the stdout reliably.
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
 
     # The server will be one of all supported providers. We
     # just want to make sure there was no exception and that
     # the client exited cleanly.
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         # Avoid debugging information that sometimes gets inserted after the first character
         assert random_bytes[1:] in results.stdout

--- a/tests/integrationv2/test_hello_retry_requests.py
+++ b/tests/integrationv2/test_hello_retry_requests.py
@@ -63,14 +63,14 @@ def test_hrr_with_s2n_as_client(managed_process, cipher, provider, curve, protoc
 
     # The client should connect and return without error
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert to_bytes("Curve: {}".format("x25519")) in results.stdout
 
     marker_part1 = b"cf 21 ad 74 e5"
     marker_part2 = b"9a 61 11 be 1d"
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert marker_part1 in results.stdout and marker_part2 in results.stdout
         if 'none' in keyshare:
             assert b'"key share" (id=51), len=2\n0000 - 00 00' in results.stdout
@@ -113,7 +113,7 @@ def test_hrr_with_s2n_as_server(managed_process, cipher, provider, curve, protoc
 
     # The client should connect and return without error
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert random_bytes in results.stdout
         assert to_bytes("Curve: {}".format(CURVE_NAMES[curve.name])) in results.stdout
         assert random_bytes in results.stdout
@@ -125,7 +125,7 @@ def test_hrr_with_s2n_as_server(managed_process, cipher, provider, curve, protoc
     marker = b"cf 21 ad 74 e5 9a 61 11 be 1d"
 
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert marker in results.stdout
         client_hello_count = results.stdout.count(b'ClientHello')
         server_hello_count = results.stdout.count(b'ServerHello')
@@ -170,14 +170,14 @@ def test_hrr_with_default_keyshare(managed_process, cipher, provider, curve, pro
 
     # The client should connect and return without error
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert to_bytes("Curve: {}".format(CURVE_NAMES[curve.name])) in results.stdout
 
     marker_part1 = b"cf 21 ad 74 e5"
     marker_part2 = b"9a 61 11 be 1d"
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert marker_part1 in results.stdout and marker_part2 in results.stdout
         assert b'Supported Elliptic Groups: X25519:P-256:P-384' in results.stdout
         assert to_bytes("Shared Elliptic groups: {}".format(server_options.curve)) in results.stdout

--- a/tests/integrationv2/test_key_update.py
+++ b/tests/integrationv2/test_key_update.py
@@ -51,12 +51,12 @@ def test_s2n_server_key_update(managed_process, cipher):
     )
 
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert key_update_marker in str(results.stderr)
         assert server_data in results.stdout
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert client_data in results.stdout
 
 
@@ -109,10 +109,10 @@ def test_s2n_client_key_update(managed_process, cipher):
     )
 
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert server_data in results.stdout
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert read_key_update_marker in results.stderr
         assert client_data in results.stdout

--- a/tests/integrationv2/test_key_update.py
+++ b/tests/integrationv2/test_key_update.py
@@ -51,14 +51,12 @@ def test_s2n_server_key_update(managed_process, cipher):
     )
 
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         assert key_update_marker in str(results.stderr)
         assert server_data in results.stdout
 
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         assert client_data in results.stdout
 
 
@@ -111,12 +109,10 @@ def test_s2n_client_key_update(managed_process, cipher):
     )
 
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         assert server_data in results.stdout
 
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         assert read_key_update_marker in results.stderr
         assert client_data in results.stdout

--- a/tests/integrationv2/test_pq_handshake.py
+++ b/tests/integrationv2/test_pq_handshake.py
@@ -5,7 +5,7 @@ from configuration import available_ports, PROVIDERS, PROTOCOLS
 from common import Ciphers, ProviderOptions, Protocols, data_bytes, KemGroups, Certificates, pq_enabled
 from fixtures import managed_process
 from providers import Provider, S2N, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name
+from utils import invalid_test_parameters, get_parameter_name, to_bytes
 
 CIPHERS = [
     None,  # `None` will default to the appropriate `test_all` cipher preference in the S2N client provider
@@ -128,11 +128,11 @@ def get_oqs_openssl_override_env_vars():
 
 def assert_s2n_negotiation_parameters(s2n_results, expected_result):
     if expected_result is not None:
-        assert bytes(("Cipher negotiated: " + expected_result['cipher']).encode('utf-8')) in s2n_results.stdout
-        assert bytes(("KEM: " + expected_result['kem']).encode('utf-8')) in s2n_results.stdout
+        assert to_bytes(("Cipher negotiated: " + expected_result['cipher'])) in s2n_results.stdout
+        assert to_bytes(("KEM: " + expected_result['kem'])) in s2n_results.stdout
         # Purposefully leave off the "KEM Group: " prefix in order to perform partial matches
         # without specifying the curve.
-        assert bytes(expected_result['kem_group'].encode('utf-8')) in s2n_results.stdout
+        assert to_bytes(expected_result['kem_group']) in s2n_results.stdout
 
 
 @pytest.mark.uncollect_if(func=invalid_pq_handshake_test_parameters)
@@ -140,12 +140,10 @@ def assert_s2n_negotiation_parameters(s2n_results, expected_result):
 @pytest.mark.parametrize("client_cipher", CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("server_cipher", CIPHERS, ids=get_parameter_name)
 def test_s2nc_to_s2nd_pq_handshake(managed_process, protocol, client_cipher, server_cipher):
-    host = "localhost"
     port = next(available_ports)
 
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host=host,
         port=port,
         insecure=True,
         cipher=client_cipher,
@@ -153,7 +151,6 @@ def test_s2nc_to_s2nd_pq_handshake(managed_process, protocol, client_cipher, ser
 
     server_options = ProviderOptions(
         mode=Provider.ServerMode,
-        host=host,
         port=port,
         protocol=protocol,
         cipher=server_cipher,
@@ -173,13 +170,11 @@ def test_s2nc_to_s2nd_pq_handshake(managed_process, protocol, client_cipher, ser
 
     # Client and server are both s2n; can make meaningful assertions about negotiation for both
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         assert_s2n_negotiation_parameters(results, expected_result)
 
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         assert_s2n_negotiation_parameters(results, expected_result)
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -191,12 +186,10 @@ def test_s2nc_to_oqs_openssl_pq_handshake(managed_process, protocol, cipher, kem
     if not pq_enabled():
         return
 
-    host = "localhost"
     port = next(available_ports)
 
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host=host,
         port=port,
         insecure=True,
         cipher=cipher,
@@ -204,7 +197,6 @@ def test_s2nc_to_oqs_openssl_pq_handshake(managed_process, protocol, cipher, kem
 
     server_options = ProviderOptions(
         mode=Provider.ServerMode,
-        host=host,
         port=port,
         protocol=protocol,
         cert=Certificates.RSA_4096_SHA512.cert,
@@ -219,14 +211,12 @@ def test_s2nc_to_oqs_openssl_pq_handshake(managed_process, protocol, cipher, kem
 
     for results in client.get_results():
         # Client is s2n; can make meaningful assertions about negotiation
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         assert_s2n_negotiation_parameters(results, expected_result)
 
     for results in server.get_results():
         # Server is OQS OpenSSL; just ensure the process exited successfully
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
@@ -237,12 +227,10 @@ def test_oqs_openssl_to_s2nd_pq_handshake(managed_process, protocol, cipher, kem
     if not pq_enabled():
         return
 
-    host = "localhost"
     port = next(available_ports)
 
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host=host,
         port=port,
         protocol=protocol,
         env_overrides=get_oqs_openssl_override_env_vars(),
@@ -250,7 +238,6 @@ def test_oqs_openssl_to_s2nd_pq_handshake(managed_process, protocol, cipher, kem
 
     server_options = ProviderOptions(
         mode=Provider.ServerMode,
-        host=host,
         port=port,
         protocol=protocol,
         cipher=cipher,
@@ -264,11 +251,9 @@ def test_oqs_openssl_to_s2nd_pq_handshake(managed_process, protocol, cipher, kem
 
     for results in client.get_results():
         # Client is OQS OpenSSL; just ensure the process exited successfully
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
 
     for results in server.get_results():
         # Server is s2n; can make meaningful assertions about negotiation
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         assert_s2n_negotiation_parameters(results, expected_result)

--- a/tests/integrationv2/test_pq_handshake.py
+++ b/tests/integrationv2/test_pq_handshake.py
@@ -170,11 +170,11 @@ def test_s2nc_to_s2nd_pq_handshake(managed_process, protocol, client_cipher, ser
 
     # Client and server are both s2n; can make meaningful assertions about negotiation for both
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert_s2n_negotiation_parameters(results, expected_result)
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert_s2n_negotiation_parameters(results, expected_result)
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -211,12 +211,12 @@ def test_s2nc_to_oqs_openssl_pq_handshake(managed_process, protocol, cipher, kem
 
     for results in client.get_results():
         # Client is s2n; can make meaningful assertions about negotiation
-        results.is_success()
+        results.assert_success()
         assert_s2n_negotiation_parameters(results, expected_result)
 
     for results in server.get_results():
         # Server is OQS OpenSSL; just ensure the process exited successfully
-        results.is_success()
+        results.assert_success()
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
@@ -251,9 +251,9 @@ def test_oqs_openssl_to_s2nd_pq_handshake(managed_process, protocol, cipher, kem
 
     for results in client.get_results():
         # Client is OQS OpenSSL; just ensure the process exited successfully
-        results.is_success()
+        results.assert_success()
 
     for results in server.get_results():
         # Server is s2n; can make meaningful assertions about negotiation
-        results.is_success()
+        results.assert_success()
         assert_s2n_negotiation_parameters(results, expected_result)

--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -43,14 +43,14 @@ def test_session_resumption_s2n_server(managed_process, cipher, curve, protocol,
 
     # The client should connect and return without error
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert results.stdout.count(to_bytes("Session-ID:")) == 6
 
     expected_version = get_expected_s2n_version(protocol, OpenSSL)
 
     # S2N should indicate the procotol version in a successful connection.
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert results.stdout.count(to_bytes("Actual protocol version: {}".format(expected_version))) == 6
 
 
@@ -88,11 +88,11 @@ def test_session_resumption_s2n_client(managed_process, cipher, curve, protocol,
 
     expected_version = get_expected_s2n_version(protocol, OpenSSL)
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert results.stdout.count(to_bytes("Actual protocol version: {}".format(expected_version))) == 6
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert results.stdout.count(to_bytes("6 server accepts that finished"))
 
 
@@ -132,11 +132,11 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
 
     # The client should have received a session ticket
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert b'Post-Handshake New Session Ticket arrived:' in results.stdout
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         # The first connection is a full handshake
         assert b'Resumed session' not in results.stdout
 
@@ -155,12 +155,12 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
 
     # Client has not read server certificate message as this is a resumed session
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert to_bytes("SSL_connect:SSLv3/TLS read server certificate") not in results.stderr
 
     # The server should indicate a session has been resumed
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert b'Resumed session' in results.stdout
         assert to_bytes("Actual protocol version: {}".format(s2n_version)) in results.stdout
 
@@ -203,14 +203,14 @@ def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, pro
 
     # s2nc indicates the number of resumed connections in its output
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert results.stdout.count(b'Resumed session') == num_resumed_connections
         assert to_bytes("Actual protocol version: {}".format(s2n_version)) in results.stdout
 
     server_accepts_str = str(num_resumed_connections + num_full_connections) + " server accepts that finished"
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         if provider is S2N:
             assert results.stdout.count(b'Resumed session') == num_resumed_connections
             assert to_bytes("Actual protocol version: {}".format(s2n_version)) in results.stdout
@@ -260,11 +260,11 @@ def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, c
 
     # The client should have received a session ticket
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert b'Post-Handshake New Session Ticket arrived:' in results.stdout
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         # Server should have sent certificate message as this is a full connection
         assert b'SSL_accept:SSLv3/TLS write certificate' in results.stderr
 
@@ -284,11 +284,11 @@ def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, c
 
     # Client has read server certificate because this is a full connection
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert to_bytes("SSL_connect:SSLv3/TLS read server certificate") in results.stderr
 
     # The server should indicate a session has not been resumed
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert b'Resumed session' not in results.stdout
         assert to_bytes("Actual protocol version: {}".format(s2n_version)) in results.stdout

--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -7,7 +7,7 @@ from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, AL
 from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process
 from providers import Provider, S2N, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version
+from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -22,7 +22,6 @@ def test_session_resumption_s2n_server(managed_process, cipher, curve, protocol,
 
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=cipher,
         curve=curve,
@@ -44,17 +43,15 @@ def test_session_resumption_s2n_server(managed_process, cipher, curve, protocol,
 
     # The client should connect and return without error
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert results.stdout.count(bytes("Session-ID:".encode('utf-8'))) == 6
+        results.is_success()
+        assert results.stdout.count(to_bytes("Session-ID:")) == 6
 
     expected_version = get_expected_s2n_version(protocol, OpenSSL)
 
     # S2N should indicate the procotol version in a successful connection.
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert results.stdout.count(bytes("Actual protocol version: {}".format(expected_version).encode('utf-8'))) == 6
+        results.is_success()
+        assert results.stdout.count(to_bytes("Actual protocol version: {}".format(expected_version))) == 6
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -69,7 +66,6 @@ def test_session_resumption_s2n_client(managed_process, cipher, curve, protocol,
 
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=cipher,
         curve=curve,
@@ -92,14 +88,12 @@ def test_session_resumption_s2n_client(managed_process, cipher, curve, protocol,
 
     expected_version = get_expected_s2n_version(protocol, OpenSSL)
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert results.stdout.count(bytes("Actual protocol version: {}".format(expected_version).encode('utf-8'))) == 6
+        results.is_success()
+        assert results.stdout.count(to_bytes("Actual protocol version: {}".format(expected_version))) == 6
 
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert results.stdout.count(bytes("6 server accepts that finished".encode('utf-8')))
+        results.is_success()
+        assert results.stdout.count(to_bytes("6 server accepts that finished"))
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -117,7 +111,6 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
 
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=cipher,
         curve=curve,
@@ -139,13 +132,11 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
 
     # The client should have received a session ticket
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         assert b'Post-Handshake New Session Ticket arrived:' in results.stdout
 
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         # The first connection is a full handshake
         assert b'Resumed session' not in results.stdout
 
@@ -164,17 +155,14 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
 
     # Client has not read server certificate message as this is a resumed session
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert bytes("SSL_connect:SSLv3/TLS read server certificate".encode('utf-8')) not in results.stderr
+        results.is_success()
+        assert to_bytes("SSL_connect:SSLv3/TLS read server certificate") not in results.stderr
 
     # The server should indicate a session has been resumed
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert not results.stderr
+        results.is_success()
         assert b'Resumed session' in results.stdout
-        assert bytes("Actual protocol version: {}".format(s2n_version).encode('utf-8')) in results.stdout
+        assert to_bytes("Actual protocol version: {}".format(s2n_version)) in results.stdout
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -194,7 +182,6 @@ def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, pro
 
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=cipher,
         curve=curve,
@@ -216,23 +203,19 @@ def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, pro
 
     # s2nc indicates the number of resumed connections in its output
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert not results.stderr
+        results.is_success()
         assert results.stdout.count(b'Resumed session') == num_resumed_connections
-        assert bytes("Actual protocol version: {}".format(s2n_version).encode('utf-8')) in results.stdout
+        assert to_bytes("Actual protocol version: {}".format(s2n_version)) in results.stdout
 
     server_accepts_str = str(num_resumed_connections + num_full_connections) + " server accepts that finished"
 
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         if provider is S2N:
-            assert not results.stderr
             assert results.stdout.count(b'Resumed session') == num_resumed_connections
-            assert bytes("Actual protocol version: {}".format(s2n_version).encode('utf-8')) in results.stdout
+            assert to_bytes("Actual protocol version: {}".format(s2n_version)) in results.stdout
         else:
-            assert bytes(server_accepts_str.encode('utf-8')) in results.stdout
+            assert to_bytes(server_accepts_str) in results.stdout
             # s_server only writes one certificate message in all of the connections
             assert results.stderr.count(b'SSL_accept:SSLv3/TLS write certificate') == num_full_connections
 
@@ -257,7 +240,6 @@ def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, c
     """
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=cipher,
         curve=curve,
@@ -278,13 +260,11 @@ def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, c
 
     # The client should have received a session ticket
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         assert b'Post-Handshake New Session Ticket arrived:' in results.stdout
 
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         # Server should have sent certificate message as this is a full connection
         assert b'SSL_accept:SSLv3/TLS write certificate' in results.stderr
 
@@ -304,14 +284,11 @@ def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, c
 
     # Client has read server certificate because this is a full connection
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert bytes("SSL_connect:SSLv3/TLS read server certificate".encode('utf-8')) in results.stderr
+        results.is_success()
+        assert to_bytes("SSL_connect:SSLv3/TLS read server certificate") in results.stderr
 
     # The server should indicate a session has not been resumed
     for results in server.get_results():
-        assert results.exception is None
-        assert not results.stderr
-        assert results.exit_code == 0
+        results.is_success()
         assert b'Resumed session' not in results.stdout
-        assert bytes("Actual protocol version: {}".format(s2n_version).encode('utf-8')) in results.stdout
+        assert to_bytes("Actual protocol version: {}".format(s2n_version)) in results.stdout

--- a/tests/integrationv2/test_signature_algorithms.py
+++ b/tests/integrationv2/test_signature_algorithms.py
@@ -97,14 +97,14 @@ def test_s2n_server_signature_algorithms(managed_process, cipher, provider, prot
     client = managed_process(provider, client_options, timeout=5)
 
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert to_bytes('Peer signing digest: {}'.format(signature.sig_digest)) in results.stdout
         assert to_bytes('Peer signature type: {}'.format(signature.sig_type)) in results.stdout
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
         assert random_bytes in results.stdout
 
@@ -157,12 +157,12 @@ def test_s2n_client_signature_algorithms(managed_process, cipher, provider, prot
     client = managed_process(S2N, client_options, timeout=5)
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert to_bytes('Shared Signature Algorithms: {}+{}'.format(signature.sig_type, signature.sig_digest)) in results.stdout
         assert random_bytes in results.stdout
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout

--- a/tests/integrationv2/test_signature_algorithms.py
+++ b/tests/integrationv2/test_signature_algorithms.py
@@ -5,7 +5,7 @@ from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, AL
 from common import ProviderOptions, Protocols, Ciphers, Certificates, Signatures, data_bytes
 from fixtures import managed_process
 from providers import Provider, S2N, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version
+from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
 
 
 certs = [
@@ -76,7 +76,6 @@ def test_s2n_server_signature_algorithms(managed_process, cipher, provider, prot
     random_bytes = data_bytes(64)
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=cipher,
         data_to_send=random_bytes,
@@ -98,17 +97,15 @@ def test_s2n_server_signature_algorithms(managed_process, cipher, provider, prot
     client = managed_process(provider, client_options, timeout=5)
 
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert bytes('Peer signing digest: {}'.format(signature.sig_digest).encode('utf-8')) in results.stdout
-        assert bytes('Peer signature type: {}'.format(signature.sig_type).encode('utf-8')) in results.stdout
+        results.is_success()
+        assert to_bytes('Peer signing digest: {}'.format(signature.sig_digest)) in results.stdout
+        assert to_bytes('Peer signature type: {}'.format(signature.sig_type)) in results.stdout
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
+        results.is_success()
+        assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
         assert random_bytes in results.stdout
 
 
@@ -125,7 +122,6 @@ def test_s2n_client_signature_algorithms(managed_process, cipher, provider, prot
     random_bytes = data_bytes(64)
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=cipher,
         data_to_send=random_bytes,
@@ -161,14 +157,12 @@ def test_s2n_client_signature_algorithms(managed_process, cipher, provider, prot
     client = managed_process(S2N, client_options, timeout=5)
 
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert bytes('Shared Signature Algorithms: {}+{}'.format(signature.sig_type, signature.sig_digest).encode('utf-8')) in results.stdout
+        results.is_success()
+        assert to_bytes('Shared Signature Algorithms: {}+{}'.format(signature.sig_type, signature.sig_digest)) in results.stdout
         assert random_bytes in results.stdout
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
+        results.is_success()
+        assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout

--- a/tests/integrationv2/test_sni_match.py
+++ b/tests/integrationv2/test_sni_match.py
@@ -58,12 +58,12 @@ def test_sni_match(managed_process, provider, protocol, cert_test_case):
     client = managed_process(provider, client_options, timeout=5)
 
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
         if cert_test_case.client_sni is not None:
             assert to_bytes("Server name: {}".format(cert_test_case.client_sni)) in results.stdout

--- a/tests/integrationv2/test_sni_match.py
+++ b/tests/integrationv2/test_sni_match.py
@@ -5,7 +5,7 @@ from configuration import available_ports, MULTI_CERT_TEST_CASES, PROVIDERS, PRO
 from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process
 from providers import Provider, S2N, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version
+from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
 
 
 def filter_cipher_list(*args, **kwargs):
@@ -31,12 +31,10 @@ def filter_cipher_list(*args, **kwargs):
 @pytest.mark.parametrize("protocol", [Protocols.TLS13, Protocols.TLS12], ids=get_parameter_name)
 @pytest.mark.parametrize("cert_test_case", MULTI_CERT_TEST_CASES)
 def test_sni_match(managed_process, provider, protocol, cert_test_case):
-    host = "localhost"
     port = next(available_ports)
 
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host=host,
         port=port,
         insecure=False,
         verify_hostname=True,
@@ -46,7 +44,6 @@ def test_sni_match(managed_process, provider, protocol, cert_test_case):
 
     server_options = ProviderOptions(
         mode = Provider.ServerMode,
-        host=host,
         port=port,
         extra_flags=[],
         protocol=protocol)
@@ -61,15 +58,13 @@ def test_sni_match(managed_process, provider, protocol, cert_test_case):
     client = managed_process(provider, client_options, timeout=5)
 
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
+        results.is_success()
+        assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
         if cert_test_case.client_sni is not None:
-            assert bytes("Server name: {}".format(cert_test_case.client_sni).encode('utf-8')) in results.stdout
+            assert to_bytes("Server name: {}".format(cert_test_case.client_sni)) in results.stdout
 

--- a/tests/integrationv2/test_version_negotiation.py
+++ b/tests/integrationv2/test_version_negotiation.py
@@ -41,12 +41,12 @@ def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, protocol, p
     actual_version = get_expected_s2n_version(protocol, provider)
 
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         assert to_bytes("Client protocol version: {}".format(client_version)) in results.stdout
         assert to_bytes("Actual protocol version: {}".format(actual_version)) in results.stdout
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         if provider is S2N:
             # The server is only TLS12, so it reads the version from the CLIENT_HELLO, which is never above TLS12
             # This check only cares about S2N. Trying to maintain expected output of other providers doesn't
@@ -92,7 +92,7 @@ def test_s2nd_tls13_negotiates_tls12(managed_process, cipher, curve, protocol, p
     actual_version = get_expected_s2n_version(protocol, provider)
 
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
         if provider is S2N:
             # The client will get the server version from the SERVER HELLO, which will be the negotiated version
             assert to_bytes("Server protocol version: {}".format(actual_version)) in results.stdout
@@ -104,7 +104,7 @@ def test_s2nd_tls13_negotiates_tls12(managed_process, cipher, curve, protocol, p
             assert to_bytes("Protocol  : {}".format(openssl_version)) in results.stdout
 
     for results in server.get_results():
-        results.is_success()
+        results.assert_success()
         assert to_bytes("Server protocol version: {}".format(server_version)) in results.stdout
         assert to_bytes("Actual protocol version: {}".format(actual_version)) in results.stdout
         assert random_bytes in results.stdout

--- a/tests/integrationv2/test_version_negotiation.py
+++ b/tests/integrationv2/test_version_negotiation.py
@@ -5,7 +5,7 @@ from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, AL
 from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process
 from providers import Provider, S2N, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, get_expected_openssl_version
+from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, get_expected_openssl_version, to_bytes
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -20,7 +20,6 @@ def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, protocol, p
     random_bytes = data_bytes(24)
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=cipher,
         curve=curve,
@@ -42,20 +41,18 @@ def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, protocol, p
     actual_version = get_expected_s2n_version(protocol, provider)
 
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert bytes("Client protocol version: {}".format(client_version).encode('utf-8')) in results.stdout
-        assert bytes("Actual protocol version: {}".format(actual_version).encode('utf-8')) in results.stdout
+        results.is_success()
+        assert to_bytes("Client protocol version: {}".format(client_version)) in results.stdout
+        assert to_bytes("Actual protocol version: {}".format(actual_version)) in results.stdout
 
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         if provider is S2N:
             # The server is only TLS12, so it reads the version from the CLIENT_HELLO, which is never above TLS12
             # This check only cares about S2N. Trying to maintain expected output of other providers doesn't
             # add benefit to whether the S2N client was able to negotiate a lower TLS version.
-            assert bytes("Client protocol version: {}".format(actual_version).encode('utf-8')) in results.stdout
-            assert bytes("Actual protocol version: {}".format(actual_version).encode('utf-8')) in results.stdout
+            assert to_bytes("Client protocol version: {}".format(actual_version)) in results.stdout
+            assert to_bytes("Actual protocol version: {}".format(actual_version)) in results.stdout
 
         assert random_bytes in results.stdout
 
@@ -72,7 +69,6 @@ def test_s2nd_tls13_negotiates_tls12(managed_process, cipher, curve, protocol, p
     random_bytes = data_bytes(24)
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
-        host="localhost",
         port=port,
         cipher=cipher,
         curve=curve,
@@ -96,21 +92,19 @@ def test_s2nd_tls13_negotiates_tls12(managed_process, cipher, curve, protocol, p
     actual_version = get_expected_s2n_version(protocol, provider)
 
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
         if provider is S2N:
             # The client will get the server version from the SERVER HELLO, which will be the negotiated version
-            assert bytes("Server protocol version: {}".format(actual_version).encode('utf-8')) in results.stdout
-            assert bytes("Actual protocol version: {}".format(actual_version).encode('utf-8')) in results.stdout
+            assert to_bytes("Server protocol version: {}".format(actual_version)) in results.stdout
+            assert to_bytes("Actual protocol version: {}".format(actual_version)) in results.stdout
         elif provider is OpenSSL:
             # This check cares about other providers because we want to know that they did negotiate the version
             # that our S2N server intended to negotiate.
             openssl_version = get_expected_openssl_version(protocol)
-            assert bytes("Protocol  : {}".format(openssl_version).encode('utf-8')) in results.stdout
+            assert to_bytes("Protocol  : {}".format(openssl_version)) in results.stdout
 
     for results in server.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
-        assert bytes("Server protocol version: {}".format(server_version).encode('utf-8')) in results.stdout
-        assert bytes("Actual protocol version: {}".format(actual_version).encode('utf-8')) in results.stdout
+        results.is_success()
+        assert to_bytes("Server protocol version: {}".format(server_version)) in results.stdout
+        assert to_bytes("Actual protocol version: {}".format(actual_version)) in results.stdout
         assert random_bytes in results.stdout

--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -81,6 +81,8 @@ def test_well_known_endpoints(managed_process, protocol, endpoint, provider, cip
     else:
         client_options.trust_store = "../integration/trust-store/ca-bundle.crt"
 
+    # expect_stderr=True because S2N sometimes receives OCSP responses:
+    # https://github.com/aws/s2n-tls/blob/14ed186a13c1ffae7fbb036ed5d2849ce7c17403/bin/echo.c#L180-L184
     client = managed_process(provider, client_options, timeout=5, expect_stderr=True)
 
     expected_result = EXPECTED_RESULTS.get((endpoint, cipher), None)

--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -6,7 +6,7 @@ from common import ProviderOptions, Protocols, Ciphers, pq_enabled
 from fixtures import managed_process
 from global_flags import get_flag, S2N_FIPS_MODE
 from providers import Provider, S2N
-from utils import invalid_test_parameters, get_parameter_name
+from utils import invalid_test_parameters, get_parameter_name, to_bytes
 
 
 ENDPOINTS = [
@@ -81,14 +81,13 @@ def test_well_known_endpoints(managed_process, protocol, endpoint, provider, cip
     else:
         client_options.trust_store = "../integration/trust-store/ca-bundle.crt"
 
-    client = managed_process(provider, client_options, timeout=5)
+    client = managed_process(provider, client_options, timeout=5, expect_stderr=True)
 
     expected_result = EXPECTED_RESULTS.get((endpoint, cipher), None)
 
     for results in client.get_results():
-        assert results.exception is None
-        assert results.exit_code == 0
+        results.is_success()
 
         if expected_result is not None:
-            assert bytes(expected_result['cipher'].encode('utf-8')) in results.stdout
-            assert bytes(expected_result['kem'].encode('utf-8')) in results.stdout
+            assert to_bytes(expected_result['cipher']) in results.stdout
+            assert to_bytes(expected_result['kem']) in results.stdout

--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -86,7 +86,7 @@ def test_well_known_endpoints(managed_process, protocol, endpoint, provider, cip
     expected_result = EXPECTED_RESULTS.get((endpoint, cipher), None)
 
     for results in client.get_results():
-        results.is_success()
+        results.assert_success()
 
         if expected_result is not None:
             assert to_bytes(expected_result['cipher']) in results.stdout

--- a/tests/integrationv2/utils.py
+++ b/tests/integrationv2/utils.py
@@ -2,6 +2,10 @@ from common import Protocols, Curves, Ciphers
 from providers import S2N, OpenSSL
 
 
+def to_bytes(val):
+    return bytes(str(val).encode('utf-8'))
+
+
 def get_expected_s2n_version(protocol, provider):
     """
     s2nd and s2nc print a number for the negotiated TLS version.


### PR DESCRIPTION
### Description of changes: 

While writing the early data integration tests, I made some quality of life tweaks to the framework to avoid repeatedly implementing the same common behaviors:

* I made the current behavior of only the client sending data by default more explicit / obvious, and added a getter to retrieve the send marker and make enabling sending for servers easier.
* I added an is_success method for Results, and made its stderr behavior configurable via providers.
* I added a method to encode utf strings into bytes automatically, instead of specifying the same encoding every time
* I modified ManagedProcess to call str() on all cmd_line arguments automatically, instead of forcing each test to ensure all arguments are strings
* I made the options default to localhost, instead of specifying it every time

### Testing:

Existing tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
