### PR TITLE
Bring __ANDROID__ and ANDROID back for tm_gmtoff

### DIFF
--- a/utils/s2n_asn1_time.c
+++ b/utils/s2n_asn1_time.c
@@ -47,7 +47,7 @@ typedef enum parser_state {
 
 static inline long get_gmt_offset(struct tm *t) {
     /* See: https://sourceware.org/git/?p=glibc.git;a=blob;f=include/features.h;h=ba272078cf2263ec88e039fda7524c136a4a7953;hb=HEAD */
-#if defined(__USE_MISC) || defined(ANDROID) || (defined(__APPLE__) && defined(__MACH__))
+#if defined(__USE_MISC) || defined(__ANDROID__) || defined(ANDROID) || (defined(__APPLE__) && defined(__MACH__))
     return t->tm_gmtoff;
 #else
     return t->__tm_gmtoff;

--- a/utils/s2n_asn1_time.c
+++ b/utils/s2n_asn1_time.c
@@ -47,7 +47,7 @@ typedef enum parser_state {
 
 static inline long get_gmt_offset(struct tm *t) {
     /* See: https://sourceware.org/git/?p=glibc.git;a=blob;f=include/features.h;h=ba272078cf2263ec88e039fda7524c136a4a7953;hb=HEAD */
-#if defined(__USE_MISC) || (defined(__APPLE__) && defined(__MACH__))
+#if defined(__USE_MISC) || defined(ANDROID) || (defined(__APPLE__) && defined(__MACH__))
     return t->tm_gmtoff;
 #else
     return t->__tm_gmtoff;


### PR DESCRIPTION
### Resolved issues:
Commit https://github.com/aws/s2n-tls/commit/aa581bf2ca189e69a35077c016726b74c2408f67 breaks Android build for aws-crt-cpp and some other consumers.

### Description of changes: 
Bring `defined(__ANDROID__) || defined(ANDROID)` back to use `t->tm_gmtoff`.

### Call-outs:
Do you have Android Arm build in your CI?

### Testing:
aws-crt-cpp has CI for Android build. It passed after I made this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
