### PR TITLE
Duplicate Certificate Error Message

### DIFF
--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -142,9 +142,14 @@ int main(int argc, char **argv) {
         EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
         int err_code = s2n_x509_trust_store_add_pem(&trust_store, cert_chain);
-        free(cert_chain);
         EXPECT_EQUAL(0, err_code);
         EXPECT_TRUE(s2n_x509_trust_store_has_certs(&trust_store));
+
+        /* s2n_x509_trust_store_add_pem returns success when trying to add a
+         * certificate that already exists in the trust store */
+        EXPECT_SUCCESS(s2n_x509_trust_store_add_pem(&trust_store, cert_chain));
+
+        free(cert_chain);
         s2n_x509_trust_store_wipe(&trust_store);
     }
 

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -99,8 +99,7 @@ int s2n_x509_trust_store_add_pem(struct s2n_x509_trust_store *store, const char 
 
         if (!X509_STORE_add_cert(store->trust_store, ca_cert)) {
             unsigned long error = ERR_get_error();
-            POSIX_ENSURE(ERR_GET_REASON(error) == X509_R_CERT_ALREADY_IN_HASH_TABLE,
-                    S2N_ERR_DECODE_CERTIFICATE);
+            POSIX_ENSURE(ERR_GET_REASON(error) == X509_R_CERT_ALREADY_IN_HASH_TABLE, S2N_ERR_DECODE_CERTIFICATE);
         }
     } while (s2n_stuffer_data_available(&pem_in_stuffer));
 

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -97,7 +97,10 @@ int s2n_x509_trust_store_add_pem(struct s2n_x509_trust_store *store, const char 
         DEFER_CLEANUP(X509 *ca_cert = d2i_X509(NULL, &data, next_cert.size), X509_free_pointer);
         S2N_ERROR_IF(ca_cert == NULL, S2N_ERR_DECODE_CERTIFICATE);
 
-        POSIX_GUARD_OSSL(X509_STORE_add_cert(store->trust_store, ca_cert), S2N_ERR_DECODE_CERTIFICATE);
+        int err_code = X509_STORE_add_cert(store->trust_store, ca_cert);
+        POSIX_ENSURE(
+                err_code == X509_R_CERT_ALREADY_IN_HASH_TABLE || err_code == _OSSL_SUCCESS,
+                S2N_ERR_DECODE_CERTIFICATE);
     } while (s2n_stuffer_data_available(&pem_in_stuffer));
 
     return 0;

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -97,10 +97,11 @@ int s2n_x509_trust_store_add_pem(struct s2n_x509_trust_store *store, const char 
         DEFER_CLEANUP(X509 *ca_cert = d2i_X509(NULL, &data, next_cert.size), X509_free_pointer);
         S2N_ERROR_IF(ca_cert == NULL, S2N_ERR_DECODE_CERTIFICATE);
 
-        int err_code = X509_STORE_add_cert(store->trust_store, ca_cert);
-        POSIX_ENSURE(
-                err_code == X509_R_CERT_ALREADY_IN_HASH_TABLE || err_code == _OSSL_SUCCESS,
-                S2N_ERR_DECODE_CERTIFICATE);
+        if (!X509_STORE_add_cert(store->trust_store, ca_cert)) {
+            unsigned long error = ERR_get_error();
+            POSIX_ENSURE(ERR_GET_REASON(error) == X509_R_CERT_ALREADY_IN_HASH_TABLE,
+                    S2N_ERR_DECODE_CERTIFICATE);
+        }
     } while (s2n_stuffer_data_available(&pem_in_stuffer));
 
     return 0;


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Older versions of the Openssl function X509_STORE_add_cert return X509_R_CERT_ALREADY_IN_HASH_TABLE if a user tries to add a certificate that already exists in the cert store. Newer versions of Openssl return successful. This change makes the behavior the same between versions. Essentially now, a duplicate certificate will not cause a S2N_ERR_DECODE_CERTIFICATE error using any Openssl version.
### Call-outs:

N/A
### Testing:

N/A

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
