### PR TITLE
Update Codebuild batch spec with early data integration test

### DIFF
--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -144,6 +144,14 @@ batch:
         variables:
           INTEGV2_TEST: test_well_known_endpoints
 
+    - identifier: s2nIntegrationV2EarlyData
+      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          INTEGV2_TEST: test_early_data
+
     # Individual Integration tests
     - identifier: s2nIntegrationBoringSSLGcc9
       buildspec: codebuild/spec/buildspec_ubuntu.yml


### PR DESCRIPTION
### Description of changes: 

Add integration test merged [here](https://github.com/aws/s2n-tls/pull/2857) to CI.

### Testing:

I manually kicked off the three Codebuild jobs with the new buildspec and the source set to this PR. They are automatically reporting their status. Note that "s2nIntegrationBatch" includes "s2nIntegrationV2EarlyData"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
