### PR TITLE
Add handshake type message for integration tests

### DIFF
--- a/bin/echo.c
+++ b/bin/echo.c
@@ -160,6 +160,7 @@ int negotiate(struct s2n_connection *conn, int fd)
         POSIX_BAIL(S2N_ERR_ACTUAL_PROTOCOL_VERSION);
     }
     printf("CONNECTED:\n");
+    printf("Handshake: %s\n", s2n_connection_get_handshake_type_name(conn));
     printf("Client hello version: %d\n", client_hello_version);
     printf("Client protocol version: %d\n", client_protocol_version);
     printf("Server protocol version: %d\n", server_protocol_version);

--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -18,7 +18,7 @@ from enum import Enum
 
 # Number of lines of output to stdout s2nc or s2nd are expected
 # to produce after a successful handshake
-NUM_EXPECTED_LINES_OUTPUT = 13
+NUM_EXPECTED_LINES_OUTPUT = 14
 
 class OCSP(Enum):
     ENABLED = 1

--- a/tests/integrationv2/test_hello_retry_requests.py
+++ b/tests/integrationv2/test_hello_retry_requests.py
@@ -9,6 +9,7 @@ from fixtures import managed_process
 from providers import Provider, S2N, OpenSSL
 from utils import invalid_test_parameters, get_parameter_name, to_bytes
 
+S2N_HRR_MARKER = to_bytes("HELLO_RETRY_REQUEST")
 
 # List of keyshares for hello retry requests client side test.
 HRR_CLIENT_KEYSHARES = [
@@ -65,6 +66,7 @@ def test_hrr_with_s2n_as_client(managed_process, cipher, provider, curve, protoc
     for results in client.get_results():
         results.assert_success()
         assert to_bytes("Curve: {}".format("x25519")) in results.stdout
+        assert S2N_HRR_MARKER in results.stdout
 
     marker_part1 = b"cf 21 ad 74 e5"
     marker_part2 = b"9a 61 11 be 1d"
@@ -117,6 +119,7 @@ def test_hrr_with_s2n_as_server(managed_process, cipher, provider, curve, protoc
         assert random_bytes in results.stdout
         assert to_bytes("Curve: {}".format(CURVE_NAMES[curve.name])) in results.stdout
         assert random_bytes in results.stdout
+        assert S2N_HRR_MARKER in results.stdout
 
     client_hello_count = 0
     server_hello_count = 0
@@ -172,6 +175,7 @@ def test_hrr_with_default_keyshare(managed_process, cipher, provider, curve, pro
     for results in client.get_results():
         results.assert_success()
         assert to_bytes("Curve: {}".format(CURVE_NAMES[curve.name])) in results.stdout
+        assert S2N_HRR_MARKER in results.stdout
 
     marker_part1 = b"cf 21 ad 74 e5"
     marker_part2 = b"9a 61 11 be 1d"


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/2871

### Description of changes: 

It's currently tricky to get positive confirmation that s2n-tls is attempting specific handshakes, like a HRR. This PR adds a logging line to report the full handshake type, providing more information for both the integration tests and ad-hoc issue debugging.

### Call-outs:

s2n_connection_get_handshake_type_name is public: https://github.com/aws/s2n-tls/blob/main/api/s2n.h#L644-L645

### Testing:

Updated integration tests pass. The early data test will not be run automatically until https://github.com/aws/s2n-tls/pull/2872 is merged, but here's a manual build: [SingleIntegrationV2:test_early_data](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/SingleIntegrationV2/build/SingleIntegrationV2%3Aab2f6efa-f039-4bbb-8d8b-e52116e82c61?region=us-west-2)

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
