### PR TITLE
Updates Codebuild CI buildspec to include PSK integration tests

### DIFF
--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -152,6 +152,14 @@ batch:
         variables:
           INTEGV2_TEST: test_early_data
 
+    - identifier: s2nIntegrationV2ExternalPSK
+      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          INTEGV2_TEST: test_external_psk
+
     # Individual Integration tests
     - identifier: s2nIntegrationBoringSSLGcc9
       buildspec: codebuild/spec/buildspec_ubuntu.yml


### PR DESCRIPTION
### Resolved issues:

Add integration tests to the CI build spec for PR https://github.com/aws/s2n-tls/pull/2821

### Description of changes: 

The CI batch job for "s2nIntegrationBatch" includes "s2nIntegrationV2ExternalPSK" 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
