### PR TITLE
Make TLS1.3 ticket processing less strict to handle future changes

### DIFF
--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -801,6 +801,40 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_free(config));
         }
 
+        /* Deserializing state ignores extra data.
+         * This will make it possible to easily add new fields in the future, without needing
+         * to worry about versioning. */
+        {
+            uint8_t extra_data[] = "more ticket data, maybe from the future";
+
+            struct s2n_stuffer ticket_stuffer = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&ticket_stuffer, 0));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&ticket_stuffer, tls13_ticket_with_early_data,
+                    sizeof(tls13_ticket_with_early_data)));
+            /* Add some unexpected data */
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&ticket_stuffer, extra_data, sizeof(extra_data)));
+
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_NOT_NULL(config);
+            EXPECT_SUCCESS(s2n_config_set_wall_clock(config, mock_time, NULL));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+            /* Initialize client ticket */
+            const uint8_t client_ticket[] = { CLIENT_TICKET };
+            EXPECT_SUCCESS(s2n_realloc(&conn->client_ticket, sizeof(client_ticket)));
+            EXPECT_MEMCPY_SUCCESS(conn->client_ticket.data, client_ticket, sizeof(client_ticket));
+
+            EXPECT_OK(s2n_deserialize_resumption_state(conn, &conn->client_ticket, &ticket_stuffer));
+            EXPECT_EQUAL(conn->psk_params.psk_list.len, 1);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&ticket_stuffer), sizeof(extra_data));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
+        }
+
         /* Any existing psks are removed when creating a new resumption psk */
         {
             struct s2n_blob ticket_blob = { 0 };

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -285,7 +285,6 @@ static S2N_RESULT s2n_tls13_deserialize_session_state(struct s2n_connection *con
     RESULT_GUARD(s2n_psk_parameters_wipe(&conn->psk_params));
     RESULT_GUARD_POSIX(s2n_connection_append_psk(conn, &psk));
 
-    RESULT_ENSURE(s2n_stuffer_data_available(from) == 0, S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
     return S2N_RESULT_OK;
 }
 


### PR DESCRIPTION
### Description of changes: 

If we need to add fields to the ticket in the future, we COULD add a new format version. However, that's a pretty heavy-weight option: older versions of the library potentially won't be able to use tickets written by newer versions, which could complicated deployments / rollbacks. We'd probably need to bump the library version and warn about the impact, or add an API to configure what version of tickets a server writes, or something else.

However, if we just need to add fields to the ticket in the future, we could make that easy by ignoring any part of the ticket we don't recognize. So if an older client tries to use a ticket created by a newer client, it just ignores the unknown fields.

The downside is that we'd be less strict in our verification. We'd be accepting arguably malformed tickets. 

### Call-outs:

This is a one line change. The real question is whether or not we should do it.

### Testing:

Unit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
