### PR TITLE
Release TLS1.3 Session Resumption

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -422,6 +422,24 @@ S2N_API
 extern int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **der_cert_chain_out, uint32_t *cert_chain_len);
 
 S2N_API
+extern int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num);
+S2N_API
+extern int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num);
+S2N_API
+extern int s2n_connection_set_server_keying_material_lifetime(struct s2n_connection *conn, uint32_t lifetime_in_secs);
+
+struct s2n_session_ticket;
+typedef int (*s2n_session_ticket_fn)(struct s2n_connection *conn, void *ctx, struct s2n_session_ticket *ticket);
+S2N_API
+extern int s2n_config_set_session_ticket_cb(struct s2n_config *config, s2n_session_ticket_fn callback, void *ctx);
+S2N_API
+extern int s2n_session_ticket_get_data_len(struct s2n_session_ticket *ticket, size_t *data_len);
+S2N_API
+extern int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, size_t max_data_len, uint8_t *data);
+S2N_API
+extern int s2n_session_ticket_get_lifetime(struct s2n_session_ticket *ticket, uint32_t *session_lifetime);
+
+S2N_API
 extern int s2n_connection_set_session(struct s2n_connection *conn, const uint8_t *session, size_t length);
 S2N_API
 extern int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, size_t max_length);

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -421,21 +421,94 @@ extern int s2n_connection_set_client_auth_type(struct s2n_connection *conn, s2n_
 S2N_API
 extern int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **der_cert_chain_out, uint32_t *cert_chain_len);
 
+/**
+ * Sets the initial number of session tickets to send after a handshake.
+ *
+ * @param config A pointer to the config object.
+ * @param num The number of session tickets that will be sent.
+ */
 S2N_API
 extern int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num);
+
+/**
+ * Increases the amount of session tickets to send after a handshake.
+ *
+ * @param conn A pointer to the s2n_connection object.
+ * @param num The number of additional session tickets to send.
+ */
 S2N_API
 extern int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num);
+
+/**
+ * Sets the keying material lifetime for session tickets so that one session doesn't get re-used ad infinitum.
+ * The default value is one week.
+ *
+ * @param conn A pointer to the s2n_connection object.
+ * @param lifetime_in_secs Lifetime of keying material in seconds.
+ */
 S2N_API
 extern int s2n_connection_set_server_keying_material_lifetime(struct s2n_connection *conn, uint32_t lifetime_in_secs);
 
 struct s2n_session_ticket;
+
+/**
+ * Callback function for receiving a session ticket
+ *
+ * # Safety
+ *
+ * `ctx` MUST be cast into the same type of pointer that was originally created.
+ * `ticket` is an internal pointer that can only be used until this function exits.
+ *
+ * @param conn A pointer to the s2n_connection object.
+ * @param ctx Context for the callback.
+ * @param ticket Pointer to the received session ticket object.
+ */
 typedef int (*s2n_session_ticket_fn)(struct s2n_connection *conn, void *ctx, struct s2n_session_ticket *ticket);
+
+/**
+ * Sets a session ticket callback to be called when a client receives a new session ticket.
+ *
+ * # Safety
+ *
+ * `callback` MUST cast `ctx` into the same type of pointer that was originally created.
+ * `ctx` MUST live for at least as long as it is set on the config.
+ *
+ * @param config A pointer to the config object.
+ * @param callback The function that should be called when the callback is triggered.
+ * @param ctx The context to be passed when the callback is called.
+ */
 S2N_API
 extern int s2n_config_set_session_ticket_cb(struct s2n_config *config, s2n_session_ticket_fn callback, void *ctx);
+
+/**
+ * Gets length of session ticket from a s2n_session_ticket object.
+ *
+ * @param ticket Pointer to session ticket object.
+ * @param data_len Pointer to where the length of the session ticket will be stored.
+ */
 S2N_API
 extern int s2n_session_ticket_get_data_len(struct s2n_session_ticket *ticket, size_t *data_len);
+
+/**
+ * Gets the session ticket data from a s2n_session_ticket object.
+ *
+ * # Safety
+ * `data` must have enough memory to store the session ticket data, as the session ticket will be copied
+ * into `data`, if this function executes successfully.
+ *
+ * @param ticket Pointer to session ticket object.
+ * @param max_data_len Maximum length of data that can be written to the data pointer.
+ * @param data Pointer to where the session ticket data will be stored.
+ */
 S2N_API
 extern int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, size_t max_data_len, uint8_t *data);
+
+/**
+ * Gets lifetime of the session ticket from a s2n_session_ticket object.
+ *
+ * @param ticket Pointer to session ticket object.
+ * @param session_lifetime Pointer to a variable where the lifetime of the session ticket will be stored.
+ */
 S2N_API
 extern int s2n_session_ticket_get_lifetime(struct s2n_session_ticket *ticket, uint32_t *session_lifetime);
 

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -422,16 +422,16 @@ S2N_API
 extern int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **der_cert_chain_out, uint32_t *cert_chain_len);
 
 /**
- * Sets the initial number of session tickets to send after a handshake.
+ * Sets the initial number of session tickets to send after a >=TLS1.3 handshake.
  *
- * @param config A pointer to the config object.
+ * @param config A pointer to the s2n_config object.
  * @param num The number of session tickets that will be sent.
  */
 S2N_API
 extern int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num);
 
 /**
- * Increases the amount of session tickets to send after a handshake.
+ * Increases the number of TLS1.3 session tickets to send after a >=TLS1.3 handshake.
  *
  * @param conn A pointer to the s2n_connection object.
  * @param num The number of additional session tickets to send.
@@ -440,7 +440,7 @@ S2N_API
 extern int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num);
 
 /**
- * Sets the keying material lifetime for session tickets so that one session doesn't get re-used ad infinitum.
+ * Sets the keying material lifetime for >=TLS1.3 session tickets so that one session doesn't get re-used ad infinitum.
  * The default value is one week.
  *
  * @param conn A pointer to the s2n_connection object.
@@ -452,15 +452,15 @@ extern int s2n_connection_set_server_keying_material_lifetime(struct s2n_connect
 struct s2n_session_ticket;
 
 /**
- * Callback function for receiving a session ticket
+ * Callback function for receiving a session ticket.
  *
  * # Safety
  *
- * `ctx` MUST be cast into the same type of pointer that was originally created.
- * `ticket` is an internal pointer that can only be used until this function exits.
+ * `ctx` is a void pointer and the caller is responsible for ensuring it is cast to the correct type.
+ * `ticket` is valid only within the scope of this callback.
  *
  * @param conn A pointer to the s2n_connection object.
- * @param ctx Context for the callback.
+ * @param ctx Context for the session ticket callback function.
  * @param ticket Pointer to the received session ticket object.
  */
 typedef int (*s2n_session_ticket_fn)(struct s2n_connection *conn, void *ctx, struct s2n_session_ticket *ticket);
@@ -471,9 +471,9 @@ typedef int (*s2n_session_ticket_fn)(struct s2n_connection *conn, void *ctx, str
  * # Safety
  *
  * `callback` MUST cast `ctx` into the same type of pointer that was originally created.
- * `ctx` MUST live for at least as long as it is set on the config.
+ * `ctx` MUST be valid for the lifetime of the config, or until a different context is set.
  *
- * @param config A pointer to the config object.
+ * @param config A pointer to the s2n_config object.
  * @param callback The function that should be called when the callback is triggered.
  * @param ctx The context to be passed when the callback is called.
  */
@@ -481,10 +481,10 @@ S2N_API
 extern int s2n_config_set_session_ticket_cb(struct s2n_config *config, s2n_session_ticket_fn callback, void *ctx);
 
 /**
- * Gets length of session ticket from a s2n_session_ticket object.
+ * Gets the length of the session ticket from a s2n_session_ticket object.
  *
- * @param ticket Pointer to session ticket object.
- * @param data_len Pointer to where the length of the session ticket will be stored.
+ * @param ticket Pointer to the s2n_session_ticket object.
+ * @param data_len Pointer to be set to the length of the session ticket on success.
  */
 S2N_API
 extern int s2n_session_ticket_get_data_len(struct s2n_session_ticket *ticket, size_t *data_len);
@@ -493,20 +493,20 @@ extern int s2n_session_ticket_get_data_len(struct s2n_session_ticket *ticket, si
  * Gets the session ticket data from a s2n_session_ticket object.
  *
  * # Safety
- * `data` must have enough memory to store the session ticket data, as the session ticket will be copied
- * into `data`, if this function executes successfully.
+ * The entire session ticket will be copied into `data` on success. Therefore, `data` MUST have enough
+ * memory to store the session ticket data.
  *
- * @param ticket Pointer to session ticket object.
- * @param max_data_len Maximum length of data that can be written to the data pointer.
+ * @param ticket Pointer to the s2n_session_ticket object.
+ * @param max_data_len Maximum length of data that can be written to the 'data' pointer.
  * @param data Pointer to where the session ticket data will be stored.
  */
 S2N_API
 extern int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, size_t max_data_len, uint8_t *data);
 
 /**
- * Gets lifetime of the session ticket from a s2n_session_ticket object.
+ * Gets the lifetime of the session ticket from a s2n_session_ticket object.
  *
- * @param ticket Pointer to session ticket object.
+ * @param ticket Pointer to the s2n_session_ticket object.
  * @param session_lifetime Pointer to a variable where the lifetime of the session ticket will be stored.
  */
 S2N_API

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -422,18 +422,18 @@ S2N_API
 extern int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **der_cert_chain_out, uint32_t *cert_chain_len);
 
 /**
- * Sets the initial number of session tickets to send after a >=TLS1.3 handshake.
+ * Sets the initial number of session tickets to send after a >=TLS1.3 handshake. The default value is one ticket.
  *
- * @param config A pointer to the s2n_config object.
+ * @param config A pointer to the config object.
  * @param num The number of session tickets that will be sent.
  */
 S2N_API
 extern int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num);
 
 /**
- * Increases the number of TLS1.3 session tickets to send after a >=TLS1.3 handshake.
+ * Increases the number of session tickets to send after a >=TLS1.3 handshake.
  *
- * @param conn A pointer to the s2n_connection object.
+ * @param conn A pointer to the connection object.
  * @param num The number of additional session tickets to send.
  */
 S2N_API
@@ -443,7 +443,7 @@ extern int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, u
  * Sets the keying material lifetime for >=TLS1.3 session tickets so that one session doesn't get re-used ad infinitum.
  * The default value is one week.
  *
- * @param conn A pointer to the s2n_connection object.
+ * @param conn A pointer to the connection object.
  * @param lifetime_in_secs Lifetime of keying material in seconds.
  */
 S2N_API
@@ -459,7 +459,7 @@ struct s2n_session_ticket;
  * `ctx` is a void pointer and the caller is responsible for ensuring it is cast to the correct type.
  * `ticket` is valid only within the scope of this callback.
  *
- * @param conn A pointer to the s2n_connection object.
+ * @param conn A pointer to the connection object.
  * @param ctx Context for the session ticket callback function.
  * @param ticket Pointer to the received session ticket object.
  */
@@ -473,7 +473,7 @@ typedef int (*s2n_session_ticket_fn)(struct s2n_connection *conn, void *ctx, str
  * `callback` MUST cast `ctx` into the same type of pointer that was originally created.
  * `ctx` MUST be valid for the lifetime of the config, or until a different context is set.
  *
- * @param config A pointer to the s2n_config object.
+ * @param config A pointer to the config object.
  * @param callback The function that should be called when the callback is triggered.
  * @param ctx The context to be passed when the callback is called.
  */
@@ -481,22 +481,22 @@ S2N_API
 extern int s2n_config_set_session_ticket_cb(struct s2n_config *config, s2n_session_ticket_fn callback, void *ctx);
 
 /**
- * Gets the length of the session ticket from a s2n_session_ticket object.
+ * Gets the length of the session ticket from a session ticket object.
  *
- * @param ticket Pointer to the s2n_session_ticket object.
+ * @param ticket Pointer to the session ticket object.
  * @param data_len Pointer to be set to the length of the session ticket on success.
  */
 S2N_API
 extern int s2n_session_ticket_get_data_len(struct s2n_session_ticket *ticket, size_t *data_len);
 
 /**
- * Gets the session ticket data from a s2n_session_ticket object.
+ * Gets the session ticket data from a session ticket object.
  *
  * # Safety
  * The entire session ticket will be copied into `data` on success. Therefore, `data` MUST have enough
  * memory to store the session ticket data.
  *
- * @param ticket Pointer to the s2n_session_ticket object.
+ * @param ticket Pointer to the session ticket object.
  * @param max_data_len Maximum length of data that can be written to the 'data' pointer.
  * @param data Pointer to where the session ticket data will be stored.
  */
@@ -504,9 +504,9 @@ S2N_API
 extern int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, size_t max_data_len, uint8_t *data);
 
 /**
- * Gets the lifetime of the session ticket from a s2n_session_ticket object.
+ * Gets the lifetime in seconds of the session ticket from a session ticket object.
  *
- * @param ticket Pointer to the s2n_session_ticket object.
+ * @param ticket Pointer to the session ticket object.
  * @param session_lifetime Pointer to a variable where the lifetime of the session ticket will be stored.
  */
 S2N_API

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1590,7 +1590,7 @@ int s2n_session_ticket_get_lifetime(struct s2n_session_ticket *ticket, uint32_t 
 
 **s2n_connection_set_server_keying_material_lifetime** sets the keying material lifetime for session tickets. Use this to ensure session tickets don't get reissued past the lifetime of the certificate used to authenticate the original full handshake.
 
-**s2n_session_ticket_fn** is invoked whenever a client receives a session ticket. Use this callback in conjunction with the **s2n_session_ticket** getters to get the serialized ticket data and related information. A **ctx** pointer is provided to let a user to pass state to the callback, if needed.
+**s2n_session_ticket_fn** is invoked whenever a client receives a session ticket. Use this callback in conjunction with the **s2n_session_ticket** getters to get the serialized ticket data and related information. A **ctx** pointer is provided to let a user pass state to the callback, if needed.
 
 **s2n_config_set_session_ticket_cb** sets the session ticket callback function to be invoked whenever the client receives
 a session ticket from the server.

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -332,7 +332,7 @@ supported status request type is OCSP, **S2N_STATUS_REQUEST_OCSP**.
 ```c
 typedef enum { S2N_CERT_AUTH_NONE, S2N_CERT_AUTH_REQUIRED, S2N_CERT_AUTH_OPTIONAL } s2n_cert_auth_type;
 ```
-**s2n_cert_auth_type** is used to declare what type of client certificiate authentication to use.
+**s2n_cert_auth_type** is used to declare what type of client certificate authentication to use.
 Currently the default for s2n-tls is for neither the server side or the client side to use Client (aka Mutual) authentication.
 
 ## Opaque structures
@@ -750,7 +750,7 @@ int s2n_config_set_wall_clock(struct s2n_config *config, s2n_clock_time_nanoseco
 
 **s2n_config_set_wall_clock** allows the caller to set a
 callback function that will be used to get the system time. The callback function
-takes two arguments; a pointer to abitrary data for use within the callback,
+takes two arguments; a pointer to arbitrary data for use within the callback,
 and a pointer to a 64 bit unsigned integer. The first pointer will be set to
 the value of **data** which supplied by the caller when setting the callback.
 The integer pointed to by the second pointer should be set to the number of
@@ -766,7 +766,7 @@ int s2n_config_set_monotonic_clock(struct s2n_config *config, s2n_clock_time_nan
 
 **s2n_config_set_monotonic_clock** allows the caller to set a
 callback function that will be used to get monotonic time. The callback function
-takes two arguments; a pointer to abitrary data for use within the callback,
+takes two arguments; a pointer to arbitrary data for use within the callback,
 and a pointer to a 64 bit unsigned integer. The first pointer will be set to
 the value of **data** which supplied by the caller when setting the callback.
 The integer pointed to by the second pointer should be an always increasing value. The function
@@ -1020,9 +1020,7 @@ the caller sets (and implements) three callback functions.
 
 ### s2n\_config\_set\_session\_cache\_onoff
 
-**s2n_config_set_session_cache_onoff** enables the session cache. In order to use the session cache feature
-you will need to set a ticket key with **s2n_config_add_ticket_crypto_key** to encrypt session
-state inside the cache.
+**s2n_config_set_session_cache_onoff** enables and disables the session cache. In order to use the session cache feature you will need to set a ticket key with **s2n_config_add_ticket_crypto_key** to encrypt session state inside the cache.
 
 ### s2n\_config\_set\_cache\_store\_callback
 
@@ -1367,7 +1365,7 @@ ssize_t s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tl
 - **max_length** Max number of bytes to copy into the **out** buffer.
 
 **s2n_client_hello_get_extension_length** returns the number of bytes the given extension type takes on the ClientHello message received by the server; it can be used to allocate the **out** buffer.
-**s2n_client_hello_get_extension_by_id** copies into the **out** buffer **max_length** bytes of a given extension type on the ClienthHello and returns the number of bytes that were copied.
+**s2n_client_hello_get_extension_by_id** copies into the **out** buffer **max_length** bytes of a given extension type on the ClientHello and returns the number of bytes that were copied.
 
 ### s2n\_connection\_client\_cert\_used
 
@@ -1554,7 +1552,11 @@ handshake.
 
 **s2n_connection_set_session** de-serializes the session state and updates the connection accordingly.
 
-**s2n_connection_get_session** serializes the session state from connection and copies into the **session** buffer and returns the number of bytes that were copied. If the first byte in **session** is 1, then the next 2 bytes will contain the session ticket length, followed by session ticket and session state. If the first byte in **session** is 0, then the next byte will contain session id length, followed by session id and session state. This function was revamped in TLS1.3 to retrieve the last session ticket received by the client.
+**s2n_connection_get_session** serializes the session state from connection and copies into the **session** buffer and returns the number of bytes that were copied. The output of this function depends on whether session ids or session tickets are being used for resumption.
+
+If the first byte in **session** is 1, then the next 2 bytes will contain the session ticket length, followed by session ticket and session state. In TLS1.3 (which allows multiple session tickets), the most recent session ticket received will be used.
+
+If the first byte in **session** is 0, then the next byte will contain session id length, followed by session id and session state.
 
 **s2n_connection_get_session_ticket_lifetime_hint** returns the session ticket lifetime hint in seconds from the server or -1 when session ticket was not used for resumption.
 
@@ -1566,15 +1568,12 @@ handshake.
 
 **s2n_connection_is_session_resumed** returns 1 if the handshake was abbreviated, otherwise returns 0, for tls versions < TLS1.3.
 
-## Additional TLS1.3 Session Resumption Related calls
+## Additional TLS1.3 Session Resumption Related Calls
 
-Session resumption works differently in versions TLS1.3 and higher. Session ticket messages are now sent after the
-handshake in "post-handshake" messages. While some of the TLS1.2 session resumption APIs are still relevant for TLS1.3
-session resumption, additional APIs are needed to utilize all the capabilities of TLS1.3 session resumption.
+Session resumption works differently in versions TLS1.3 and higher. Session ticket messages are now sent after the handshake in "post-handshake" messages, and multiple session tickets may be issued for the same connection. While some of the TLS1.2 session resumption APIs are still relevant for TLS1.3 session resumption, additional APIs are needed to utilize all the capabilities of TLS1.3 session resumption.
 
 ```c
 int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num);
-
 int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num);
 int s2n_connection_set_server_keying_material_lifetime(struct s2n_connection *conn, uint32_t lifetime_in_secs);
 
@@ -1589,16 +1588,14 @@ int s2n_session_ticket_get_lifetime(struct s2n_session_ticket *ticket, uint32_t 
 
 **s2n_connection_add_new_tickets_to_send** increases the number of session tickets to send by **num**.
 
-**s2n_connection_set_server_keying_material_lifetime** sets the keying material lifetime for session tickets so that one
-session doesn't get re-used ad infinitum.
+**s2n_connection_set_server_keying_material_lifetime** sets the keying material lifetime for session tickets. Use this to ensure session tickets don't get reissued past the lifetime of the certificate used to authenticate the original full handshake.
 
-**s2n_session_ticket_fn** is invoked whenever a client receives a session ticket. Use this callback in conjunction with
-the **s2n_session_ticket** getters to get the serialized ticket data and related information.
+**s2n_session_ticket_fn** is invoked whenever a client receives a session ticket. Use this callback in conjunction with the **s2n_session_ticket** getters to get the serialized ticket data and related information. A **ctx** pointer is provided to let a user to pass state to the callback, if needed.
 
 **s2n_config_set_session_ticket_cb** sets the session ticket callback function to be invoked whenever the client receives
 a session ticket from the server.
 
-**s2n_session_ticket_get_data_len** takes a s2n_session_ticket object and retrieves the number of bytes needed to store the session ticket.
+**s2n_session_ticket_get_data_len** takes a s2n_session_ticket object and retrieves the number of bytes needed to store the session ticket. Use this to allocate enough memory for the session ticket in **s2n_session_ticket_get_data**.
 
 **s2n_session_ticket_get_data** takes a s2n_session_ticket object and copies the serialized session ticket data into the
 **data** buffer. For this reason **max_data_len** should be set to the maximum amount of bytes that can be copied into
@@ -1653,7 +1650,7 @@ applied to the connection through **s2n_async_pkey_op_apply** call.
 
 Note, it is not safe to call multiple functions on the same **conn** or
 **op** objects from 2 different threads at the same time. Doing so will
-produce undefined behaviour. However it is safe to have a call to
+produce undefined behavior. However it is safe to have a call to
 function involving only **conn** at the same time with a call to
 function involving only **op**, as those 2 objects are not coupled with
 each other. It is also safe to free **conn** or **op** at any moment with

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1550,7 +1550,7 @@ handshake.
 
 **s2n_connection_get_session** serializes the session state from connection and copies into the **session** buffer and returns the number of bytes that were copied. The output of this function depends on whether session ids or session tickets are being used for resumption.
 
-If the first byte in **session** is 1, then the next 2 bytes will contain the session ticket length, followed by session ticket and session state. In versions TLS1.3 and greater, (which allows multiple session tickets), the most recent session ticket received will be used. Note that the size of the tickets increased between TLS1.2 and TLS1.3.
+If the first byte in **session** is 1, then the next 2 bytes will contain the session ticket length, followed by session ticket and session state. In versions TLS1.3 and greater, (which allows multiple session tickets), the most recent session ticket received will be used. Note that the size of the session tickets varies.
 
 If the first byte in **session** is 0, then the next byte will contain session id length, followed by session id and session state.
 

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -688,9 +688,8 @@ int s2n_config_set_session_tickets_onoff(struct s2n_config *config, uint8_t enab
     }
 
     config->use_tickets = enabled;
-    /* TODO: The S2N_IN_TEST check is temporary until TLS1.3 session resumption is officially released.
-     * https://github.com/aws/s2n-tls/issues/2808 */
-    if (S2N_IN_TEST && config->initial_tickets_to_send == 0) {
+
+    if (config->initial_tickets_to_send == 0) {
         /* Normally initial_tickets_to_send is set via s2n_config_set_initial_ticket_count.
          * However, s2n_config_set_initial_ticket_count calls this method.
          * So we set initial_tickets_to_send directly to avoid infinite recursion. */

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -98,16 +98,3 @@ extern int s2n_allowed_to_cache_connection(struct s2n_connection *conn);
 extern int s2n_resume_from_cache(struct s2n_connection *conn);
 extern int s2n_store_to_cache(struct s2n_connection *conn);
 S2N_RESULT s2n_connection_get_session_state_size(struct s2n_connection *conn, size_t *state_size);
-
-/* These functions will be labeled S2N_API and become a publicly visible api 
- * once we release the session resumption API. */
-S2N_API int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num);
-S2N_API int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num);
-S2N_API int s2n_connection_set_server_keying_material_lifetime(struct s2n_connection *conn, uint32_t lifetime_in_secs);
-
-struct s2n_session_ticket;
-typedef int (*s2n_session_ticket_fn)(struct s2n_connection *conn, void *ctx, struct s2n_session_ticket *ticket);
-S2N_API int s2n_config_set_session_ticket_cb(struct s2n_config *config, s2n_session_ticket_fn callback, void *ctx);
-S2N_API int s2n_session_ticket_get_data_len(struct s2n_session_ticket *ticket, size_t *data_len);
-S2N_API int s2n_session_ticket_get_data(struct s2n_session_ticket *ticket, size_t max_data_len, uint8_t *data);
-S2N_API int s2n_session_ticket_get_lifetime(struct s2n_session_ticket *ticket, uint32_t *session_lifetime);


### PR DESCRIPTION
### Parent:
#2477
### Resolved issues:

 resolves #2808
### Description of changes: 

- Adds session resumption TLS1.3 APIs to s2n.h so they are now public. 
- Removed S2N_IN_TEST requirement for session tickets so servers should now send TLS1.3 session tickets. 
- Updated the usage guide so that people know how to use these APIs.
- Found some spelling mistakes

### Call-outs:
N/A
### Testing:

N/A

 Is this a refactor change? No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
