### PR TITLE
OpenSSL rand-engine requires engine support

### DIFF
--- a/crypto/s2n_openssl.h
+++ b/crypto/s2n_openssl.h
@@ -42,7 +42,7 @@
 #define s2n_evp_ctx_init(ctx) EVP_CIPHER_CTX_init(ctx)
 #endif
 
-#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_FIPS) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_AWSLC)
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_FIPS) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_AWSLC) && !defined(OPENSSL_NO_ENGINE)
 #define S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND 1
 #else
 #define S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND 0


### PR DESCRIPTION
We link against a custom-built OpenSSL where engine-support has been omitted. This is signaled via the following `openssl/opensslconf.h` defines:

```
#ifndef OPENSSL_NO_ENGINE
# define OPENSSL_NO_ENGINE
#endif
```

The s2n custom random engine check must be tightened to also check for OpenSSL random engine omission.