### PR TITLE
Adds Error Checking Around Fragment Length

### DIFF
--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -409,11 +409,14 @@ int main(int argc, char **argv)
         uint8_t protocol_version = 0;
         uint16_t fragment_length = 0;
 
-        /* First two bytes to parse are the fragment length */
+        /* First two bytes are the fragment length */
         uint8_t header_bytes[] = { 0x00, 0x00, 0x00, 0x00, 0x00 };
         EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->header_in, header_bytes, sizeof(header_bytes)));
 
         EXPECT_FAILURE_WITH_ERRNO(s2n_sslv2_record_header_parse(conn, &record_type, &protocol_version, &fragment_length), S2N_ERR_SAFETY);
+
+        /* Check the rest of the stuffer has not been read yet */
+        EXPECT_EQUAL(s2n_stuffer_data_available(&conn->header_in), 3);
     }
 
     EXPECT_SUCCESS(s2n_hmac_free(&check_mac));

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -401,6 +401,21 @@ int main(int argc, char **argv)
         EXPECT_FAILURE_WITH_ERRNO(s2n_record_parse(conn), S2N_ERR_DECRYPT);
     }
 
+    /* Test s2n_sslv2_record_header_parse fails when fragment_length < 3 */
+    {
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
+
+        uint8_t record_type = 0;
+        uint8_t protocol_version = 0;
+        uint16_t fragment_length = 0;
+
+        /* First two bytes to parse are the fragment length */
+        uint8_t header_bytes[] = { 0x00, 0x00, 0x00, 0x00, 0x00 };
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->header_in, header_bytes, sizeof(header_bytes)));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_sslv2_record_header_parse(conn, &record_type, &protocol_version, &fragment_length), S2N_ERR_SAFETY);
+    }
+
     EXPECT_SUCCESS(s2n_hmac_free(&check_mac));
 
     EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -44,6 +44,7 @@ int s2n_sslv2_record_header_parse(
     POSIX_GUARD(s2n_stuffer_read_uint16(in, fragment_length));
 
     /* Adjust to account for the 3 bytes of payload data we consumed in the header */
+    POSIX_ENSURE_GTE(*fragment_length, 3);
     *fragment_length -= 3;
 
     POSIX_GUARD(s2n_stuffer_read_uint8(in, record_type));


### PR DESCRIPTION
### Resolved issues:

 N/A

### Description of changes: 

Adds a guard around a potential overflow error.
### Call-outs:
N/A
### Testing:

Unit test

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
