### PR TITLE
Add gcov and lcov targets for pq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ run-lcov:
 	$(MAKE) -C tests lcov
 	$(MAKE) -C tls run-lcov
 	$(MAKE) -C utils lcov
-	lcov -a crypto/coverage.info -a error/coverage.info -a pq-crypto/coverage.info -a pq-crypto/sike_r1/coverage.info -a stuffer/coverage.info -a tls/coverage.info -a $(wildcard tls/*/coverage.info) -a utils/coverage.info --output ${COVERAGE_DIR}/all_coverage.info
+	lcov -a crypto/coverage.info -a error/coverage.info -a pq-crypto/coverage.info -a pq-crypto/sike_r1/coverage.info -a pq-crypto/sike_r3/coverage.info -a pq-crypto/bike_r1/coverage.info -a pq-crypto/bike_r2/coverage.info -a pq-crypto/bike_r3/coverage.info -a pq-crypto/kyber_r2/coverage.info -a pq-crypto/kyber_r3/coverage.info -a stuffer/coverage.info -a tls/coverage.info -a $(wildcard tls/*/coverage.info) -a utils/coverage.info --output ${COVERAGE_DIR}/all_coverage.info
 
 .PHONY : run-genhtml
 run-genhtml:

--- a/pq-crypto/Makefile
+++ b/pq-crypto/Makefile
@@ -52,10 +52,22 @@ bike_r2_bc: $(BCS1)
 .PHONY : run-gcov
 run-gcov: gcov
 	$(MAKE) -C sike_r1 gcov
+	$(MAKE) -C sike_r3 gcov
+	$(MAKE) -C bike_r1 gcov
+	$(MAKE) -C bike_r2 gcov
+	$(MAKE) -C bike_r3 gcov
+	$(MAKE) -C kyber_r2 gcov
+	$(MAKE) -C kyber_r3 gcov
 
 .PHONY : run-lcov
 run-lcov: lcov
 	$(MAKE) -C sike_r1 lcov
+	$(MAKE) -C sike_r3 lcov
+	$(MAKE) -C bike_r1 lcov
+	$(MAKE) -C bike_r2 lcov
+	$(MAKE) -C bike_r3 lcov
+	$(MAKE) -C kyber_r2 lcov
+	$(MAKE) -C kyber_r3 lcov
 
 .PHONY : clean
 clean: decruft


### PR DESCRIPTION
### Description of changes: 

Adds `gcov` and `lcov` `make` targets that were missing from `pq-crypto` (prompted by [this](https://github.com/aws/s2n-tls/pull/2864#discussion_r649361535)).

### Call-outs:

None

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)?
* Existing tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
