### PR TITLE
ci: Add a stale bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,23 @@
+# See Docs at https://github.com/probot/stale
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - ops-backlog
+  - status/needs_team_discussion
+  - status/on_hold
+# Label to use when marking an issue as stale
+staleLabel: status/stale
+# Number of actions per hour
+limitPerRun: 10
+# Limit to only `issues` or `pulls`
+only: pulls
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
### Resolved issues:

n/a

### Description of changes: 

Add a configuration to cleanup stale pulls (only), using labels specific to the s2n-tls project.

### Call-outs:

Stale issues can be added in a later PR, if desired.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Separate project https://github.com/probot/stale/pulls

 Is this a refactor change? No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
