### PR TITLE
Make client respect max frag len extension result

### DIFF
--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -1157,7 +1157,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         EXPECT_EQUAL(server_conn->max_outgoing_fragment_length, mfl_code_to_length[mfl_code]);
-        EXPECT_EQUAL(server_conn->chosen_mfl_code, mfl_code);
+        EXPECT_EQUAL(server_conn->negotiated_mfl_code, mfl_code);
 
         EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 
@@ -1207,7 +1207,7 @@ int main(int argc, char **argv)
 
         /* check that max_fragment_length did not get set due to invalid mfl_code */
         EXPECT_EQUAL(server_conn->max_outgoing_fragment_length, S2N_DEFAULT_FRAGMENT_LENGTH);
-        EXPECT_EQUAL(server_conn->chosen_mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
+        EXPECT_EQUAL(server_conn->negotiated_mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
 
         EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 
@@ -1256,7 +1256,7 @@ int main(int argc, char **argv)
 
         /* check that max_fragment_length did not get set since accept_mfl is not set */
         EXPECT_EQUAL(server_conn->max_outgoing_fragment_length, S2N_DEFAULT_FRAGMENT_LENGTH);
-        EXPECT_EQUAL(server_conn->chosen_mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
+        EXPECT_EQUAL(server_conn->negotiated_mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
 
         EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -1157,7 +1157,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         EXPECT_EQUAL(server_conn->max_outgoing_fragment_length, mfl_code_to_length[mfl_code]);
-        EXPECT_EQUAL(server_conn->mfl_code, mfl_code);
+        EXPECT_EQUAL(server_conn->chosen_mfl_code, mfl_code);
 
         EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 
@@ -1207,7 +1207,7 @@ int main(int argc, char **argv)
 
         /* check that max_fragment_length did not get set due to invalid mfl_code */
         EXPECT_EQUAL(server_conn->max_outgoing_fragment_length, S2N_DEFAULT_FRAGMENT_LENGTH);
-        EXPECT_EQUAL(server_conn->mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
+        EXPECT_EQUAL(server_conn->chosen_mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
 
         EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 
@@ -1256,7 +1256,7 @@ int main(int argc, char **argv)
 
         /* check that max_fragment_length did not get set since accept_mfl is not set */
         EXPECT_EQUAL(server_conn->max_outgoing_fragment_length, S2N_DEFAULT_FRAGMENT_LENGTH);
-        EXPECT_EQUAL(server_conn->mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
+        EXPECT_EQUAL(server_conn->chosen_mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
 
         EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 

--- a/tests/unit/s2n_client_max_frag_len_extension_test.c
+++ b/tests/unit/s2n_client_max_frag_len_extension_test.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
         /* Ignore fragment length if not accepting max fragment length */
         EXPECT_FALSE(config->accept_mfl);
         EXPECT_SUCCESS(s2n_client_max_frag_len_extension.recv(conn, &stuffer));
-        EXPECT_EQUAL(conn->mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
+        EXPECT_EQUAL(conn->chosen_mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
         EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_DEFAULT_FRAGMENT_LENGTH);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
@@ -94,7 +94,14 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(config));
     }
 
-    /* Test receive - invalid mfl code */
+    /* Test receive - invalid mfl code
+     *
+     *= https://tools.ietf.org/rfc/rfc6066#section-4
+     *= type=test
+     *# If a server receives a maximum fragment length negotiation request
+     *# for a value other than the allowed values, it MUST abort the
+     *# handshake with an "illegal_parameter" alert.
+     */
     {
         struct s2n_config *config;
         EXPECT_NOT_NULL(config = s2n_config_new());
@@ -113,7 +120,7 @@ int main(int argc, char **argv)
 
         /* Ignore invalid mfl code */
         EXPECT_SUCCESS(s2n_client_max_frag_len_extension.recv(conn, &stuffer));
-        EXPECT_EQUAL(conn->mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
+        EXPECT_EQUAL(conn->chosen_mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
         EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_DEFAULT_FRAGMENT_LENGTH);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
@@ -139,7 +146,7 @@ int main(int argc, char **argv)
 
         /* Accept valid mfl code */
         EXPECT_SUCCESS(s2n_client_max_frag_len_extension.recv(conn, &stuffer));
-        EXPECT_EQUAL(conn->mfl_code, S2N_TLS_MAX_FRAG_LEN_512);
+        EXPECT_EQUAL(conn->chosen_mfl_code, S2N_TLS_MAX_FRAG_LEN_512);
         EXPECT_EQUAL(conn->max_outgoing_fragment_length, mfl_code_to_length[S2N_TLS_MAX_FRAG_LEN_512]);
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
 

--- a/tests/unit/s2n_client_max_frag_len_extension_test.c
+++ b/tests/unit/s2n_client_max_frag_len_extension_test.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
         /* Ignore fragment length if not accepting max fragment length */
         EXPECT_FALSE(config->accept_mfl);
         EXPECT_SUCCESS(s2n_client_max_frag_len_extension.recv(conn, &stuffer));
-        EXPECT_EQUAL(conn->chosen_mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
+        EXPECT_EQUAL(conn->negotiated_mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
         EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_DEFAULT_FRAGMENT_LENGTH);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
 
         /* Ignore invalid mfl code */
         EXPECT_SUCCESS(s2n_client_max_frag_len_extension.recv(conn, &stuffer));
-        EXPECT_EQUAL(conn->chosen_mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
+        EXPECT_EQUAL(conn->negotiated_mfl_code, S2N_TLS_MAX_FRAG_LEN_EXT_NONE);
         EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_DEFAULT_FRAGMENT_LENGTH);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
@@ -146,7 +146,7 @@ int main(int argc, char **argv)
 
         /* Accept valid mfl code */
         EXPECT_SUCCESS(s2n_client_max_frag_len_extension.recv(conn, &stuffer));
-        EXPECT_EQUAL(conn->chosen_mfl_code, S2N_TLS_MAX_FRAG_LEN_512);
+        EXPECT_EQUAL(conn->negotiated_mfl_code, S2N_TLS_MAX_FRAG_LEN_512);
         EXPECT_EQUAL(conn->max_outgoing_fragment_length, mfl_code_to_length[S2N_TLS_MAX_FRAG_LEN_512]);
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
 

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -265,7 +265,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_prefer_throughput(conn));
         EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_LARGE_FRAGMENT_LENGTH);
 
-        /* After extension - set mfl lower than agreed with peer */
+        /* After extension - don't set mfl higher than agreed with peer */
         conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
         conn->max_outgoing_fragment_length = 1;
         EXPECT_SUCCESS(s2n_connection_prefer_throughput(conn));
@@ -290,16 +290,16 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_SMALL_FRAGMENT_LENGTH);
 
         /* After extension - don't set mfl higher than agreed with peer */
-        conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_4096;
-        conn->max_outgoing_fragment_length = 1;
-        EXPECT_SUCCESS(s2n_connection_prefer_low_latency(conn));
-        EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_SMALL_FRAGMENT_LENGTH);
-
-        /* After extension - set mfl lower than agreed with peer */
         conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
         conn->max_outgoing_fragment_length = 1;
         EXPECT_SUCCESS(s2n_connection_prefer_low_latency(conn));
         EXPECT_EQUAL(conn->max_outgoing_fragment_length, 512);
+
+        /* After extension - set mfl lower than agreed with peer */
+        conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_4096;
+        conn->max_outgoing_fragment_length = 1;
+        EXPECT_SUCCESS(s2n_connection_prefer_low_latency(conn));
+        EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_SMALL_FRAGMENT_LENGTH);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -265,17 +265,17 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_prefer_throughput(conn));
         EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_LARGE_FRAGMENT_LENGTH);
 
-        /* After extension - don't set mfl higher */
-        conn->chosen_mfl_code = 1;
-        conn->max_outgoing_fragment_length = S2N_LARGE_FRAGMENT_LENGTH + 1;
+        /* After extension - set mfl lower than agreed with peer */
+        conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
+        conn->max_outgoing_fragment_length = 1;
         EXPECT_SUCCESS(s2n_connection_prefer_throughput(conn));
-        EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_LARGE_FRAGMENT_LENGTH);
+        EXPECT_EQUAL(conn->max_outgoing_fragment_length, 1024);
 
-        /* After extension - set mfl lower */
-        conn->chosen_mfl_code = 1;
-        conn->max_outgoing_fragment_length = S2N_LARGE_FRAGMENT_LENGTH - 1;
-        EXPECT_SUCCESS(s2n_connection_prefer_throughput(conn));
-        EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_LARGE_FRAGMENT_LENGTH - 1);
+        /* After extension - invalid negotiated mfl */
+        conn->negotiated_mfl_code = UINT8_MAX;
+        conn->max_outgoing_fragment_length = 1;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_prefer_throughput(conn), S2N_ERR_SAFETY);
+        EXPECT_EQUAL(conn->max_outgoing_fragment_length, 1);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
@@ -289,17 +289,17 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_prefer_low_latency(conn));
         EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_SMALL_FRAGMENT_LENGTH);
 
-        /* After extension - don't set mfl higher */
-        conn->chosen_mfl_code = 1;
-        conn->max_outgoing_fragment_length = S2N_SMALL_FRAGMENT_LENGTH + 1;
+        /* After extension - don't set mfl higher than agreed with peer */
+        conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_4096;
+        conn->max_outgoing_fragment_length = 1;
         EXPECT_SUCCESS(s2n_connection_prefer_low_latency(conn));
         EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_SMALL_FRAGMENT_LENGTH);
 
-        /* After extension - set mfl lower */
-        conn->chosen_mfl_code = 1;
-        conn->max_outgoing_fragment_length = S2N_SMALL_FRAGMENT_LENGTH - 1;
+        /* After extension - set mfl lower than agreed with peer */
+        conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
+        conn->max_outgoing_fragment_length = 1;
         EXPECT_SUCCESS(s2n_connection_prefer_low_latency(conn));
-        EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_SMALL_FRAGMENT_LENGTH - 1);
+        EXPECT_EQUAL(conn->max_outgoing_fragment_length, 512);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -256,5 +256,53 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
+    /* s2n_connection_prefer_throughput */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(conn);
+
+        /* Default behavior */
+        EXPECT_SUCCESS(s2n_connection_prefer_throughput(conn));
+        EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_LARGE_FRAGMENT_LENGTH);
+
+        /* After extension - don't set mfl higher */
+        conn->chosen_mfl_code = 1;
+        conn->max_outgoing_fragment_length = S2N_LARGE_FRAGMENT_LENGTH + 1;
+        EXPECT_SUCCESS(s2n_connection_prefer_throughput(conn));
+        EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_LARGE_FRAGMENT_LENGTH);
+
+        /* After extension - set mfl lower */
+        conn->chosen_mfl_code = 1;
+        conn->max_outgoing_fragment_length = S2N_LARGE_FRAGMENT_LENGTH - 1;
+        EXPECT_SUCCESS(s2n_connection_prefer_throughput(conn));
+        EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_LARGE_FRAGMENT_LENGTH - 1);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* s2n_connection_prefer_low_latency */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(conn);
+
+        /* Default behavior */
+        EXPECT_SUCCESS(s2n_connection_prefer_low_latency(conn));
+        EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_SMALL_FRAGMENT_LENGTH);
+
+        /* After extension - don't set mfl higher */
+        conn->chosen_mfl_code = 1;
+        conn->max_outgoing_fragment_length = S2N_SMALL_FRAGMENT_LENGTH + 1;
+        EXPECT_SUCCESS(s2n_connection_prefer_low_latency(conn));
+        EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_SMALL_FRAGMENT_LENGTH);
+
+        /* After extension - set mfl lower */
+        conn->chosen_mfl_code = 1;
+        conn->max_outgoing_fragment_length = S2N_SMALL_FRAGMENT_LENGTH - 1;
+        EXPECT_SUCCESS(s2n_connection_prefer_low_latency(conn));
+        EXPECT_EQUAL(conn->max_outgoing_fragment_length, S2N_SMALL_FRAGMENT_LENGTH - 1);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
     END_TEST();
 }

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -157,12 +157,12 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
 
-            conn->chosen_mfl_code = 0;
+            conn->negotiated_mfl_code = 0;
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, 0);
 
             const uint8_t MFL_EXT_SIZE = 2 + 2 + 1;
-            conn->chosen_mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
+            conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, MFL_EXT_SIZE + EXTENSION_LEN);
 

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -157,12 +157,12 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
 
-            conn->mfl_code = 0;
+            conn->chosen_mfl_code = 0;
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, 0);
 
             const uint8_t MFL_EXT_SIZE = 2 + 2 + 1;
-            conn->mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
+            conn->chosen_mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, MFL_EXT_SIZE + EXTENSION_LEN);
 

--- a/tests/unit/s2n_server_max_frag_len_extension_test.c
+++ b/tests/unit/s2n_server_max_frag_len_extension_test.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_server_max_fragment_length_extension.should_send(conn));
 
         /* Should send if mfl code set. It is set by the client version of this extension. */
-        conn->chosen_mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
+        conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
         EXPECT_TRUE(s2n_server_max_fragment_length_extension.should_send(conn));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
         struct s2n_stuffer stuffer;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        conn->chosen_mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
+        conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
         EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.send(conn, &stuffer));
 
         /* Should have correct fragment length */
@@ -92,7 +92,7 @@ int main(int argc, char **argv)
         struct s2n_stuffer stuffer;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        conn->chosen_mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
+        conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
         EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.send(conn, &stuffer));
 
         EXPECT_FAILURE_WITH_ERRNO(s2n_server_max_fragment_length_extension.recv(conn, &stuffer),
@@ -116,15 +116,15 @@ int main(int argc, char **argv)
         struct s2n_stuffer stuffer;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        conn->chosen_mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
+        conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
         EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.send(conn, &stuffer));
         EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
 
-        conn->chosen_mfl_code = 0;
+        conn->negotiated_mfl_code = 0;
         EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.recv(conn, &stuffer));
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
 
-        EXPECT_EQUAL(conn->chosen_mfl_code, S2N_TLS_MAX_FRAG_LEN_512);
+        EXPECT_EQUAL(conn->negotiated_mfl_code, S2N_TLS_MAX_FRAG_LEN_512);
         EXPECT_EQUAL(conn->max_outgoing_fragment_length, 512);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
@@ -148,32 +148,32 @@ int main(int argc, char **argv)
         /* Existing mfl value lower */
         {
             conn->max_outgoing_fragment_length = mfl_code_to_length[S2N_TLS_MAX_FRAG_LEN_512];
-            conn->chosen_mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
+            conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
 
             EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.send(conn, &stuffer));
             EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
 
-            conn->chosen_mfl_code = 0;
+            conn->negotiated_mfl_code = 0;
             EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.recv(conn, &stuffer));
             EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
 
-            EXPECT_EQUAL(conn->chosen_mfl_code, S2N_TLS_MAX_FRAG_LEN_1024);
+            EXPECT_EQUAL(conn->negotiated_mfl_code, S2N_TLS_MAX_FRAG_LEN_1024);
             EXPECT_EQUAL(conn->max_outgoing_fragment_length, mfl_code_to_length[S2N_TLS_MAX_FRAG_LEN_512]);
         }
 
         /* Existing mfl value higher */
         {
             conn->max_outgoing_fragment_length = mfl_code_to_length[S2N_TLS_MAX_FRAG_LEN_2048];
-            conn->chosen_mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
+            conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
 
             EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.send(conn, &stuffer));
             EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
 
-            conn->chosen_mfl_code = 0;
+            conn->negotiated_mfl_code = 0;
             EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.recv(conn, &stuffer));
             EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
 
-            EXPECT_EQUAL(conn->chosen_mfl_code, S2N_TLS_MAX_FRAG_LEN_1024);
+            EXPECT_EQUAL(conn->negotiated_mfl_code, S2N_TLS_MAX_FRAG_LEN_1024);
             EXPECT_EQUAL(conn->max_outgoing_fragment_length, mfl_code_to_length[S2N_TLS_MAX_FRAG_LEN_1024]);
         }
 

--- a/tests/unit/s2n_server_max_frag_len_extension_test.c
+++ b/tests/unit/s2n_server_max_frag_len_extension_test.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_server_max_fragment_length_extension.should_send(conn));
 
         /* Should send if mfl code set. It is set by the client version of this extension. */
-        conn->mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
+        conn->chosen_mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
         EXPECT_TRUE(s2n_server_max_fragment_length_extension.should_send(conn));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
         struct s2n_stuffer stuffer;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        conn->mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
+        conn->chosen_mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
         EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.send(conn, &stuffer));
 
         /* Should have correct fragment length */
@@ -71,7 +71,15 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(config));
     }
 
-    /* Test receive - does not match requested value */
+    /* Test receive - does not match requested value
+     *
+     *= https://tools.ietf.org/rfc/rfc6066#section-4
+     *= type=test
+     *# Similarly, if a client
+     *# receives a maximum fragment length negotiation response that differs
+     *# from the length it requested, it MUST also abort the handshake with
+     *# an "illegal_parameter" alert.
+     */
     {
         struct s2n_config *config;
         EXPECT_NOT_NULL(config = s2n_config_new());
@@ -84,7 +92,7 @@ int main(int argc, char **argv)
         struct s2n_stuffer stuffer;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        conn->mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
+        conn->chosen_mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
         EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.send(conn, &stuffer));
 
         EXPECT_FAILURE_WITH_ERRNO(s2n_server_max_fragment_length_extension.recv(conn, &stuffer),
@@ -108,11 +116,66 @@ int main(int argc, char **argv)
         struct s2n_stuffer stuffer;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        conn->mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
+        conn->chosen_mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
         EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.send(conn, &stuffer));
         EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+        conn->chosen_mfl_code = 0;
         EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.recv(conn, &stuffer));
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+        EXPECT_EQUAL(conn->chosen_mfl_code, S2N_TLS_MAX_FRAG_LEN_512);
+        EXPECT_EQUAL(conn->max_outgoing_fragment_length, 512);
+
+        EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* Test receive - existing mfl value */
+    {
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_send_max_fragment_length(config, S2N_TLS_MAX_FRAG_LEN_1024));
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        struct s2n_stuffer stuffer;
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        /* Existing mfl value lower */
+        {
+            conn->max_outgoing_fragment_length = mfl_code_to_length[S2N_TLS_MAX_FRAG_LEN_512];
+            conn->chosen_mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
+
+            EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.send(conn, &stuffer));
+            EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+            conn->chosen_mfl_code = 0;
+            EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.recv(conn, &stuffer));
+            EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+            EXPECT_EQUAL(conn->chosen_mfl_code, S2N_TLS_MAX_FRAG_LEN_1024);
+            EXPECT_EQUAL(conn->max_outgoing_fragment_length, mfl_code_to_length[S2N_TLS_MAX_FRAG_LEN_512]);
+        }
+
+        /* Existing mfl value higher */
+        {
+            conn->max_outgoing_fragment_length = mfl_code_to_length[S2N_TLS_MAX_FRAG_LEN_2048];
+            conn->chosen_mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
+
+            EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.send(conn, &stuffer));
+            EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+            conn->chosen_mfl_code = 0;
+            EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.recv(conn, &stuffer));
+            EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+            EXPECT_EQUAL(conn->chosen_mfl_code, S2N_TLS_MAX_FRAG_LEN_1024);
+            EXPECT_EQUAL(conn->max_outgoing_fragment_length, mfl_code_to_length[S2N_TLS_MAX_FRAG_LEN_1024]);
+        }
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
         EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tls/extensions/s2n_client_max_frag_len.c
+++ b/tls/extensions/s2n_client_max_frag_len.c
@@ -56,6 +56,8 @@ static int s2n_client_max_frag_len_recv(struct s2n_connection *conn, struct s2n_
 
     /*
      *= https://tools.ietf.org/rfc/rfc6066#section-4
+     *= type=exception
+     *= reason=For compatibility, we choose to ignore malformed extensions if they are optional
      *# If a server receives a maximum fragment length negotiation request
      *# for a value other than the allowed values, it MUST abort the
      *# handshake with an "illegal_parameter" alert.

--- a/tls/extensions/s2n_client_max_frag_len.c
+++ b/tls/extensions/s2n_client_max_frag_len.c
@@ -71,7 +71,7 @@ static int s2n_client_max_frag_len_recv(struct s2n_connection *conn, struct s2n_
      *# messages (including handshake messages) to ensure that no fragment
      *# larger than the negotiated length is sent.
      */
-    conn->chosen_mfl_code = mfl_code;
+    conn->negotiated_mfl_code = mfl_code;
     conn->max_outgoing_fragment_length = mfl_code_to_length[mfl_code];
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_client_max_frag_len.c
+++ b/tls/extensions/s2n_client_max_frag_len.c
@@ -53,11 +53,25 @@ static int s2n_client_max_frag_len_recv(struct s2n_connection *conn, struct s2n_
 
     uint8_t mfl_code;
     POSIX_GUARD(s2n_stuffer_read_uint8(extension, &mfl_code));
-    if (mfl_code > S2N_TLS_MAX_FRAG_LEN_4096 || mfl_code_to_length[mfl_code] > S2N_TLS_MAXIMUM_FRAGMENT_LENGTH) {
+
+    /*
+     *= https://tools.ietf.org/rfc/rfc6066#section-4
+     *# If a server receives a maximum fragment length negotiation request
+     *# for a value other than the allowed values, it MUST abort the
+     *# handshake with an "illegal_parameter" alert.
+     */
+    if (mfl_code >= s2n_array_len(mfl_code_to_length) || mfl_code_to_length[mfl_code] > S2N_TLS_MAXIMUM_FRAGMENT_LENGTH) {
         return S2N_SUCCESS;
     }
 
-    conn->mfl_code = mfl_code;
+    /*
+     *= https://tools.ietf.org/rfc/rfc6066#section-4
+     *# Once a maximum fragment length other than 2^14 has been successfully
+     *# negotiated, the client and server MUST immediately begin fragmenting
+     *# messages (including handshake messages) to ensure that no fragment
+     *# larger than the negotiated length is sent.
+     */
+    conn->chosen_mfl_code = mfl_code;
     conn->max_outgoing_fragment_length = mfl_code_to_length[mfl_code];
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_server_max_fragment_length.c
+++ b/tls/extensions/s2n_server_max_fragment_length.c
@@ -13,12 +13,15 @@
  * permissions and limitations under the License.
  */
 
+#include <sys/param.h>
+
 #include "error/s2n_errno.h"
 
 #include "stuffer/s2n_stuffer.h"
 
 #include "utils/s2n_safety.h"
 
+#include "tls/s2n_tls.h"
 #include "tls/s2n_tls_parameters.h"
 #include "tls/s2n_connection.h"
 
@@ -39,13 +42,13 @@ const s2n_extension_type s2n_server_max_fragment_length_extension = {
 
 static bool s2n_max_fragment_length_should_send(struct s2n_connection *conn)
 {
-    return conn && conn->mfl_code != S2N_TLS_MAX_FRAG_LEN_EXT_NONE;
+    return conn && conn->chosen_mfl_code != S2N_TLS_MAX_FRAG_LEN_EXT_NONE;
 }
 
 static int s2n_max_fragment_length_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     POSIX_ENSURE_REF(conn);
-    POSIX_GUARD(s2n_stuffer_write_uint8(out, conn->mfl_code));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, conn->chosen_mfl_code));
     return S2N_SUCCESS;
 }
 
@@ -56,6 +59,25 @@ static int s2n_max_fragment_length_recv(struct s2n_connection *conn, struct s2n_
 
     uint8_t mfl_code;
     POSIX_GUARD(s2n_stuffer_read_uint8(extension, &mfl_code));
+
+    /*
+     *= https://tools.ietf.org/rfc/rfc6066#section-4
+     *# Similarly, if a client
+     *# receives a maximum fragment length negotiation response that differs
+     *# from the length it requested, it MUST also abort the handshake with
+     *# an "illegal_parameter" alert.
+     */
     S2N_ERROR_IF(mfl_code != conn->config->mfl_code, S2N_ERR_MAX_FRAG_LEN_MISMATCH);
+
+    /*
+     *= https://tools.ietf.org/rfc/rfc6066#section-4
+     *# Once a maximum fragment length other than 2^14 has been successfully
+     *# negotiated, the client and server MUST immediately begin fragmenting
+     *# messages (including handshake messages) to ensure that no fragment
+     *# larger than the negotiated length is sent.
+     */
+    conn->chosen_mfl_code = mfl_code;
+    conn->max_outgoing_fragment_length = MIN(conn->max_outgoing_fragment_length, mfl_code_to_length[mfl_code]);
+
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_server_max_fragment_length.c
+++ b/tls/extensions/s2n_server_max_fragment_length.c
@@ -42,13 +42,13 @@ const s2n_extension_type s2n_server_max_fragment_length_extension = {
 
 static bool s2n_max_fragment_length_should_send(struct s2n_connection *conn)
 {
-    return conn && conn->chosen_mfl_code != S2N_TLS_MAX_FRAG_LEN_EXT_NONE;
+    return conn && conn->negotiated_mfl_code != S2N_TLS_MAX_FRAG_LEN_EXT_NONE;
 }
 
 static int s2n_max_fragment_length_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     POSIX_ENSURE_REF(conn);
-    POSIX_GUARD(s2n_stuffer_write_uint8(out, conn->chosen_mfl_code));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, conn->negotiated_mfl_code));
     return S2N_SUCCESS;
 }
 
@@ -76,7 +76,7 @@ static int s2n_max_fragment_length_recv(struct s2n_connection *conn, struct s2n_
      *# messages (including handshake messages) to ensure that no fragment
      *# larger than the negotiated length is sent.
      */
-    conn->chosen_mfl_code = mfl_code;
+    conn->negotiated_mfl_code = mfl_code;
     conn->max_outgoing_fragment_length = MIN(conn->max_outgoing_fragment_length, mfl_code_to_length[mfl_code]);
 
     return S2N_SUCCESS;

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -19,6 +19,7 @@
 #include <strings.h>
 #include <time.h>
 #include <unistd.h>
+#include <sys/param.h>
 
 #include <s2n.h>
 #include <stdbool.h>
@@ -1298,22 +1299,26 @@ int s2n_connection_prefer_throughput(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
 
-    if (!conn->mfl_code) {
+    if (conn->chosen_mfl_code) {
+        conn->max_outgoing_fragment_length = MIN(conn->max_outgoing_fragment_length, S2N_LARGE_FRAGMENT_LENGTH);
+    } else {
         conn->max_outgoing_fragment_length = S2N_LARGE_FRAGMENT_LENGTH;
     }
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_connection_prefer_low_latency(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
 
-    if (!conn->mfl_code) {
+    if (conn->chosen_mfl_code) {
+        conn->max_outgoing_fragment_length = MIN(conn->max_outgoing_fragment_length, S2N_SMALL_FRAGMENT_LENGTH);
+    } else {
         conn->max_outgoing_fragment_length = S2N_SMALL_FRAGMENT_LENGTH;
     }
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_connection_set_dynamic_record_threshold(struct s2n_connection *conn, uint32_t resize_threshold, uint16_t timeout_threshold)

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1295,29 +1295,30 @@ const uint8_t *s2n_connection_get_ocsp_response(struct s2n_connection *conn, uin
     return conn->status_response.data;
 }
 
-int s2n_connection_prefer_throughput(struct s2n_connection *conn)
+static S2N_RESULT s2n_connection_set_max_fragment_length(struct s2n_connection *conn, uint16_t max_frag_length)
 {
-    POSIX_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn);
 
-    if (conn->chosen_mfl_code) {
-        conn->max_outgoing_fragment_length = MIN(conn->max_outgoing_fragment_length, S2N_LARGE_FRAGMENT_LENGTH);
+    if (conn->negotiated_mfl_code) {
+        /* Respect the upper limit agreed on with the peer */
+        RESULT_ENSURE_LT(conn->negotiated_mfl_code, s2n_array_len(mfl_code_to_length));
+        conn->max_outgoing_fragment_length = MIN(mfl_code_to_length[conn->negotiated_mfl_code], max_frag_length);
     } else {
-        conn->max_outgoing_fragment_length = S2N_LARGE_FRAGMENT_LENGTH;
+        conn->max_outgoing_fragment_length = max_frag_length;
     }
 
+    return S2N_RESULT_OK;
+}
+
+int s2n_connection_prefer_throughput(struct s2n_connection *conn)
+{
+    POSIX_GUARD_RESULT(s2n_connection_set_max_fragment_length(conn, S2N_LARGE_FRAGMENT_LENGTH));
     return S2N_SUCCESS;
 }
 
 int s2n_connection_prefer_low_latency(struct s2n_connection *conn)
 {
-    POSIX_ENSURE_REF(conn);
-
-    if (conn->chosen_mfl_code) {
-        conn->max_outgoing_fragment_length = MIN(conn->max_outgoing_fragment_length, S2N_SMALL_FRAGMENT_LENGTH);
-    } else {
-        conn->max_outgoing_fragment_length = S2N_SMALL_FRAGMENT_LENGTH;
-    }
-
+    POSIX_GUARD_RESULT(s2n_connection_set_max_fragment_length(conn, S2N_SMALL_FRAGMENT_LENGTH));
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -242,8 +242,9 @@ struct s2n_connection {
     /* number of bytes consumed during application activity */
     uint64_t active_application_bytes_consumed;
 
-    /* Negotiated TLS extension Maximum Fragment Length code */
-    uint8_t mfl_code;
+    /* Negotiated TLS extension Maximum Fragment Length code.
+     * If set, the client and server have both agreed to fragment their records to the given length. */
+    uint8_t chosen_mfl_code;
 
     /* Keep some accounting on each connection */
     uint64_t wire_bytes_in;

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -244,7 +244,7 @@ struct s2n_connection {
 
     /* Negotiated TLS extension Maximum Fragment Length code.
      * If set, the client and server have both agreed to fragment their records to the given length. */
-    uint8_t chosen_mfl_code;
+    uint8_t negotiated_mfl_code;
 
     /* Keep some accounting on each connection */
     uint64_t wire_bytes_in;


### PR DESCRIPTION
### Description of changes: 

RFC for max fragment length extension: https://tools.ietf.org/rfc/rfc6066#section-4 TLDR: If the client and server negotiate a max fragment length, neither can send a fragment larger than that.

Previously, if a customer called `s2n_config_send_max_fragment_length` with a fragment length smaller than the client's max_outgoing_fragment_length, the client would end up using the wrong fragment length. An RFC-compliant server would abort the connection if it received a fragment that was too long. This is a very sharp edge, especially considering it's much less obvious how to configure the max fragment length locally than it is to configure it via `s2n_config_send_max_fragment_length`.

This change ensures that the client respects the chosen max fragment length.

### Call outs

**The current version of this change includes an API behavior change.** Previously, if `s2n_connection_prefer_low_latency` (or theoretically `s2n_connection_prefer_throughput`, if the large record size wasn't the maximum record size) was called for the server after the max_fragment_length extension was received, it silently did nothing. After this change, it may lower the fragment length. I could prevent this behavior change by limiting the "set after extension received" behavior to the client (which previously didn't know whether or not the extension was received), but that's going to codify our existing very un-intuitive behavior. I'm thinking the more consistent / predictable behavior that matches what the API name suggests is worth the edge case behavior change.

### Testing:

Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
