### PR TITLE
Fix TLS1.3 dynamic record min calculation

### DIFF
--- a/tests/unit/s2n_record_size_test.c
+++ b/tests/unit/s2n_record_size_test.c
@@ -227,6 +227,30 @@ int main(int argc, char **argv)
             EXPECT_LESS_THAN_EQUAL(bytes_written, RECORD_SIZE_LESS_OVERHEADS);
         }
 
+        /* TLS1.3 AEAD */
+        {
+            EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+            EXPECT_SUCCESS(s2n_stuffer_wipe(&server_conn->out));
+
+            server_conn->actual_protocol_version = S2N_TLS13;
+            server_conn->initial.cipher_suite->record_alg = &s2n_tls13_record_alg_aes128_gcm;
+            EXPECT_SUCCESS(setup_server_keys(server_conn, &aes128));
+
+            EXPECT_OK(s2n_record_min_write_payload_size(server_conn, &size));
+            r.size = size;
+            const uint16_t IV = 0;
+            const uint16_t TAG = 16;
+            EXPECT_EQUAL(size, RECORD_SIZE_LESS_OVERHEADS - IV - TAG - TLS13_CONTENT_TYPE_LENGTH);
+
+            EXPECT_SUCCESS(bytes_written = s2n_record_write(server_conn, TLS_APPLICATION_DATA, &r));
+            const uint16_t wire_size = s2n_stuffer_data_available(&server_conn->out);
+            EXPECT_LESS_THAN_EQUAL(wire_size, MIN_SIZE);
+            EXPECT_EQUAL(bytes_written, size);
+            EXPECT_EQUAL(RECORD_SIZE(server_conn->out.blob.data), wire_size - S2N_TLS_RECORD_HEADER_LENGTH);
+            EXPECT_LESS_THAN_EQUAL(bytes_written, RECORD_SIZE_LESS_OVERHEADS);
+        }
+
+        /* chacha20 */
         if (s2n_chacha20_poly1305.is_available()) {
             EXPECT_SUCCESS(destroy_server_keys(server_conn));
             EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
@@ -241,6 +265,33 @@ int main(int argc, char **argv)
 
             EXPECT_OK(s2n_record_min_write_payload_size(server_conn, &size));
             EXPECT_EQUAL(size, RECORD_SIZE_LESS_OVERHEADS - S2N_TLS_CHACHA20_POLY1305_EXPLICIT_IV_LEN - S2N_TLS_GCM_TAG_LEN);
+            r.size = size;
+
+            EXPECT_SUCCESS(bytes_written = s2n_record_write(server_conn, TLS_APPLICATION_DATA, &r));
+            const uint16_t wire_size = s2n_stuffer_data_available(&server_conn->out);
+            EXPECT_LESS_THAN_EQUAL(wire_size, MIN_SIZE);
+            EXPECT_EQUAL(bytes_written, size);
+            EXPECT_EQUAL(RECORD_SIZE(server_conn->out.blob.data), wire_size - S2N_TLS_RECORD_HEADER_LENGTH);
+            EXPECT_LESS_THAN_EQUAL(bytes_written, RECORD_SIZE_LESS_OVERHEADS);
+        }
+
+        /* TLS1.3 chacha20 */
+        if (s2n_chacha20_poly1305.is_available()) {
+            EXPECT_SUCCESS(destroy_server_keys(server_conn));
+            EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+
+            server_conn->actual_protocol_version = S2N_TLS13;
+            server_conn->initial.cipher_suite->record_alg = &s2n_tls13_record_alg_chacha20_poly1305;
+            uint8_t chacha20_poly1305_key_data[] = "1234567890123456789012345678901";
+            struct s2n_blob chacha20_poly1305_key = {0};
+            EXPECT_SUCCESS(s2n_blob_init(&chacha20_poly1305_key, chacha20_poly1305_key_data, sizeof(chacha20_poly1305_key_data)));
+
+            EXPECT_SUCCESS(setup_server_keys(server_conn, &chacha20_poly1305_key));
+            EXPECT_SUCCESS(s2n_stuffer_wipe(&server_conn->out));
+
+            EXPECT_OK(s2n_record_min_write_payload_size(server_conn, &size));
+            EXPECT_EQUAL(size, RECORD_SIZE_LESS_OVERHEADS - S2N_TLS_CHACHA20_POLY1305_EXPLICIT_IV_LEN
+                    - S2N_TLS_GCM_TAG_LEN - TLS13_CONTENT_TYPE_LENGTH);
             r.size = size;
 
             EXPECT_SUCCESS(bytes_written = s2n_record_write(server_conn, TLS_APPLICATION_DATA, &r));

--- a/tests/unit/s2n_record_size_test.c
+++ b/tests/unit/s2n_record_size_test.c
@@ -229,6 +229,7 @@ int main(int argc, char **argv)
 
         /* TLS1.3 AEAD */
         {
+            EXPECT_SUCCESS(destroy_server_keys(server_conn));
             EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&server_conn->out));
 

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -83,6 +83,8 @@ extern const struct s2n_record_algorithm s2n_record_alg_aes256_sha384;
 extern const struct s2n_record_algorithm s2n_record_alg_aes128_gcm;
 extern const struct s2n_record_algorithm s2n_record_alg_aes256_gcm;
 extern const struct s2n_record_algorithm s2n_record_alg_chacha20_poly1305;
+extern const struct s2n_record_algorithm s2n_tls13_record_alg_aes128_gcm;
+extern const struct s2n_record_algorithm s2n_tls13_record_alg_chacha20_poly1305;
 
 struct s2n_cipher_suite {
     /* Is there an implementation available? Set in s2n_cipher_suites_init() */


### PR DESCRIPTION
### Description of changes: 

I noticed a bug in how the minimum payload size is calculated when using dynamic records sizes. The logic works for TLS1.2, but in TLS1.3 encrypted records include an extra byte for the inner plaintext content type. This would lead to records being one byte longer than the MTU.

### Call-outs:

It's possible this is contributing to the flakiness of our dynamic record size tests, but I didn't attempt to confirm. 

### Testing:

New unit tests failed before fix, succeeded after.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
