### PR TITLE
Fixes hard-coded default client cert signature algorithm  

### DIFF
--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -369,6 +369,8 @@ class OpenSSL(Provider):
                 cmd_line.extend(['-key', self.options.key])
             if self.options.cert:
                 cmd_line.extend(['-cert', self.options.cert])
+            if self.options.trust_store:
+                cmd_line.extend(['-CAfile', self.options.trust_store])
 
         if self.options.reconnect is True:
             cmd_line.append('-reconnect')
@@ -407,6 +409,8 @@ class OpenSSL(Provider):
             cmd_line.extend(['-cert', self.options.cert])
         if self.options.key is not None:
             cmd_line.extend(['-key', self.options.key])
+        if self.options.trust_store:
+            cmd_line.extend(['-CAfile', self.options.trust_store])
 
         # Unlike s2n, OpenSSL allows us to be much more specific about which TLS
         # protocol to use.

--- a/tests/integrationv2/test_client_authentication.py
+++ b/tests/integrationv2/test_client_authentication.py
@@ -46,9 +46,6 @@ def assert_s2n_handshake_complete(results, protocol, provider, is_complete=True)
 def test_client_auth_with_s2n_server(managed_process, cipher, provider, protocol, certificate, client_certificate):
     port = next(available_ports)
 
-    if protocol < Protocols.TLS12 and client_certificate.algorithm == 'EC':
-        pytest.xfail("Client auth with ECDSA certs is currently broken for versions < TLS1.2")
-
     random_bytes = data_bytes(64)
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
@@ -95,9 +92,6 @@ def test_client_auth_with_s2n_server(managed_process, cipher, provider, protocol
 @pytest.mark.parametrize("client_certificate", CERTS_TO_TEST, ids=get_parameter_name)
 def test_client_auth_with_s2n_server_using_nonmatching_certs(managed_process, cipher, provider, protocol, certificate, client_certificate):
     port = next(available_ports)
-
-    if protocol < Protocols.TLS12 and client_certificate.algorithm == 'EC':
-        pytest.xfail("Client auth with ECDSA certs is current broken for versions < TLS1.2")
 
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
@@ -195,9 +189,6 @@ def test_client_auth_with_s2n_client_no_cert(managed_process, cipher, protocol, 
 @pytest.mark.parametrize("client_certificate", CERTS_TO_TEST, ids=get_parameter_name)
 def test_client_auth_with_s2n_client_with_cert(managed_process, cipher, protocol, provider, certificate, client_certificate):
     port = next(available_ports)
-
-    if protocol < Protocols.TLS12 and client_certificate.algorithm == 'EC':
-        pytest.xfail("Client auth with ECDSA certs is currently broken for versions < TLS1.2")
 
     random_bytes = data_bytes(64)
     client_options = ProviderOptions(

--- a/tests/unit/s2n_client_cert_verify_test.c
+++ b/tests/unit/s2n_client_cert_verify_test.c
@@ -19,7 +19,6 @@
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 
-#include "crypto/s2n_fips.h"
 #include "tls/s2n_tls.h"
 #include "tls/s2n_connection.h"
 #include "utils/s2n_result.h"
@@ -320,61 +319,83 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
     }
 
-    /* Test s2n_choose_default_sig_scheme usage within s2n_client_cert_verify_send */
+    /* Test default client signature algorithm (RSA) within s2n_client_cert_verify_send and  s2n_client_cert_verify_recv */
     {
-        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
-        EXPECT_NOT_NULL(conn);
+        const char *cert_file = S2N_DEFAULT_TEST_CERT_CHAIN;
+        const char *key_file = S2N_DEFAULT_TEST_PRIVATE_KEY;
 
-        struct s2n_cert_chain_and_key *chain_and_key = NULL;
-        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
-                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
-        chain_and_key->private_key->size = test_size;
-        chain_and_key->private_key->sign = test_sign;
-        conn->handshake_params.our_chain_and_key = chain_and_key;
-        conn->actual_protocol_version = S2N_TLS11;
-        conn->secure.cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
+        struct s2n_config *config = NULL;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
 
-        /* Send cert verify */
-        EXPECT_SUCCESS(s2n_client_cert_verify_send(conn));
+        /* Derive private/public keys and set connection variables */
+        struct s2n_stuffer certificate_in = { 0 }, certificate_out = { 0 };
+        struct s2n_blob b = { 0 };
+        struct s2n_cert_chain_and_key *cert_chain = NULL;
+        char *cert_chain_pem = NULL;
+        char *private_key_pem = NULL;
+        s2n_pkey_type pkey_type = { 0 };
 
-        /* Assert signature_size written to handshake_io */
-        uint16_t signature_size = 0;
-        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&conn->handshake.io, &signature_size));
-        EXPECT_EQUAL(signature_size, test_signature_size);
-        EXPECT_EQUAL(signature_size, s2n_stuffer_data_available(&conn->handshake.io));
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(client_conn);
 
-        /* Assert signature_data written to handshake_io */
-        uint8_t *signature_data = s2n_stuffer_raw_read(&conn->handshake.io, test_signature_size);
-        EXPECT_NOT_NULL(signature_data);
-        EXPECT_BYTEARRAY_EQUAL(signature_data, test_signature_data, test_signature_size);
+        EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_in, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_out, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(cert_chain = s2n_cert_chain_and_key_new());
+        EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(cert_file, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(key_file, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(cert_chain, cert_chain_pem, private_key_pem));
 
-        /* Obtain the chosen_sig_scheme for the connection */
-        s2n_authentication_method cipher_suite_auth_method = conn->secure.cipher_suite->auth_method;
-        EXPECT_EQUAL(cipher_suite_auth_method, S2N_AUTHENTICATION_RSA);
-        struct s2n_signature_scheme chosen_sig_scheme = { 0 };
-        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &chosen_sig_scheme));
-        if (s2n_is_in_fips_mode()) {
-            EXPECT_EQUAL(chosen_sig_scheme.iana_value, s2n_rsa_pkcs1_sha1.iana_value);
-        } else {
-            EXPECT_EQUAL(chosen_sig_scheme.iana_value, s2n_rsa_pkcs1_md5_sha1.iana_value);
-        }
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        client_conn->handshake_params.our_chain_and_key = cert_chain;
+        client_conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha;
+        client_conn->actual_protocol_version = S2N_TLS11;
 
-        /* Verify the hash_state of the chosen_sig_scheme is set correctly on the conn->handshake */
-        struct s2n_hash_state hash_state = { 0 };
-        EXPECT_SUCCESS(s2n_handshake_get_hash_state(conn, chosen_sig_scheme.hash_alg, &hash_state));
-        EXPECT_EQUAL(conn->handshake.ccv_hash_copy.alg, hash_state.alg);
-        if (s2n_is_in_fips_mode()) {
-            EXPECT_EQUAL(conn->handshake.ccv_hash_copy.alg, S2N_HASH_SHA1);
-        } else {
-            EXPECT_EQUAL(conn->handshake.ccv_hash_copy.alg, S2N_HASH_MD5_SHA1);
-        }
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        server_conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha;
+        server_conn->actual_protocol_version = S2N_TLS11;
+
+        EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
+        EXPECT_SUCCESS(s2n_stuffer_write(&certificate_in, &b));
+        EXPECT_SUCCESS(s2n_stuffer_certificate_from_pem(&certificate_in, &certificate_out));
+
+        /* Extract public key from certificate and set it for verifying connection */
+        uint32_t available_size = s2n_stuffer_data_available(&certificate_out);
+        EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
+        EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&server_conn->secure.client_public_key, &pkey_type, &b));
+        EXPECT_SUCCESS(s2n_pkey_match(&server_conn->secure.client_public_key, client_conn->handshake_params.our_chain_and_key->private_key));
+
+       /* Send cert verify */
+        EXPECT_SUCCESS(s2n_client_cert_verify_send(client_conn));
+        EXPECT_EQUAL(client_conn->handshake.ccv_hash_copy.alg, S2N_HASH_MD5_SHA1);
+
+        EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io, s2n_stuffer_data_available(&client_conn->handshake.io)));
+
+        /* In the handshake this value would be set when the server obtains the s2n_client_cert_recv message */ 
+        server_conn->secure.client_cert_pkey_type = S2N_PKEY_TYPE_RSA;
+        /* Receive and verify cert */
+        EXPECT_SUCCESS(s2n_client_cert_verify_recv(server_conn));
+
+        EXPECT_EQUAL(server_conn->handshake.ccv_hash_copy.alg, S2N_HASH_MD5_SHA1);
 
         /* Clean up */
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        free(cert_chain_pem);
+        free(private_key_pem);
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(cert_chain));
+        EXPECT_SUCCESS(s2n_stuffer_free(&certificate_in));
+        EXPECT_SUCCESS(s2n_stuffer_free(&certificate_out));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
     }
 
-    /* Test s2n_choose_default_sig_scheme usage within s2n_client_cert_verify_recv */
+    /* Test default client signature algorithm (ECDSA) within s2n_client_cert_verify_send and  s2n_client_cert_verify_recv */
     {
         const char *cert_file = S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN;
         const char *key_file = S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY;
@@ -428,22 +449,15 @@ int main(int argc, char **argv)
 
        /* Send cert verify */
         EXPECT_SUCCESS(s2n_client_cert_verify_send(client_conn));
+        EXPECT_EQUAL(client_conn->handshake.ccv_hash_copy.alg, S2N_HASH_SHA1);
+
         EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io, s2n_stuffer_data_available(&client_conn->handshake.io)));
 
+        /* In the handshake this value would be set when the server obtains the s2n_client_cert_recv message */ 
+        server_conn->secure.client_cert_pkey_type = S2N_PKEY_TYPE_ECDSA;
         /* Receive and verify cert */
         EXPECT_SUCCESS(s2n_client_cert_verify_recv(server_conn));
 
-        /* Obtain the chosen_sig_scheme for the connection */
-        s2n_authentication_method cipher_suite_auth_method = server_conn->secure.cipher_suite->auth_method;
-        EXPECT_EQUAL(cipher_suite_auth_method, S2N_AUTHENTICATION_ECDSA);
-        struct s2n_signature_scheme chosen_sig_scheme = { 0 };
-        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(server_conn, &chosen_sig_scheme));
-        EXPECT_EQUAL(chosen_sig_scheme.iana_value, s2n_ecdsa_sha1.iana_value);
-
-        /* Verify the hash_state of the chosen_sig_scheme is set correctly on the conn->handshake */
-        struct s2n_hash_state hash_state = { 0 };
-        EXPECT_SUCCESS(s2n_handshake_get_hash_state(server_conn, chosen_sig_scheme.hash_alg, &hash_state));
-        EXPECT_EQUAL(server_conn->handshake.ccv_hash_copy.alg, hash_state.alg);
         EXPECT_EQUAL(server_conn->handshake.ccv_hash_copy.alg, S2N_HASH_SHA1);
 
         /* Clean up */

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -32,7 +32,8 @@ static int s2n_client_cert_verify_send_complete(struct s2n_connection *conn, str
 int s2n_client_cert_verify_recv(struct s2n_connection *conn)
 {
     struct s2n_stuffer *in = &conn->handshake.io;
-    struct s2n_signature_scheme chosen_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
+    struct s2n_signature_scheme chosen_sig_scheme = { 0 };
+    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &chosen_sig_scheme));
 
     if(conn->actual_protocol_version >= S2N_TLS12){
         /* Verify the SigScheme picked by the Client was in the preference list we sent (or is the default SigScheme) */
@@ -64,7 +65,8 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
     S2N_ASYNC_PKEY_GUARD(conn);
     struct s2n_stuffer *out = &conn->handshake.io;
 
-    struct s2n_signature_scheme chosen_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
+    struct s2n_signature_scheme chosen_sig_scheme = { 0 };
+    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &chosen_sig_scheme));
 
     if (conn->actual_protocol_version >= S2N_TLS12) {
         chosen_sig_scheme =  conn->secure.client_cert_sig_scheme;

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -33,7 +33,12 @@ int s2n_client_cert_verify_recv(struct s2n_connection *conn)
 {
     struct s2n_stuffer *in = &conn->handshake.io;
     struct s2n_signature_scheme chosen_sig_scheme = { 0 };
-    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &chosen_sig_scheme));
+
+    if (conn->secure.client_cert_pkey_type == S2N_PKEY_TYPE_RSA) {
+        chosen_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
+    } else {
+        chosen_sig_scheme = s2n_ecdsa_sha1;
+    }
 
     if(conn->actual_protocol_version >= S2N_TLS12){
         /* Verify the SigScheme picked by the Client was in the preference list we sent (or is the default SigScheme) */
@@ -64,9 +69,14 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
 {
     S2N_ASYNC_PKEY_GUARD(conn);
     struct s2n_stuffer *out = &conn->handshake.io;
-
     struct s2n_signature_scheme chosen_sig_scheme = { 0 };
-    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &chosen_sig_scheme));
+
+    s2n_pkey_type cert_type = s2n_cert_chain_and_key_get_pkey_type(conn->handshake_params.our_chain_and_key);
+    if (cert_type == S2N_PKEY_TYPE_RSA) {
+        chosen_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
+    } else {
+        chosen_sig_scheme = s2n_ecdsa_sha1;
+    }
 
     if (conn->actual_protocol_version >= S2N_TLS12) {
         chosen_sig_scheme =  conn->secure.client_cert_sig_scheme;


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/2780

### Description of changes: 

We use hardcoded values hard coded default RSA signature algorithm even if our client cert is ECDSA within `s2n_client_cert_verify_send` and `s2n_client_cert_verify_recv` functions for versions < TLS1.2.  Reference:

https://github.com/aws/s2n-tls/blob/c4d90e34fbd2ba64bb17a95628622ccc1d0c6807/tls/s2n_client_cert_verify.c#L32-L35

https://github.com/aws/s2n-tls/blob/c4d90e34fbd2ba64bb17a95628622ccc1d0c6807/tls/s2n_client_cert_verify.c#L62-L67

In this change, we fix this issue and replace the hardcoded value of `s2n_rsa_pkcs1_md5_sha1` chooses the default signature scheme based on whether RSA or ECDSA certificates are used for the authentication by using the `conn->secure.client_cert_pkey_type` value that is set on https://github.com/aws/s2n-tls/blob/main/tls/s2n_client_cert.c#L59-L65 for the server side and determining the  `client_cert_pkey_type` from `handshake_params.our_chain_and_key` by `s2n_pkey_type cert_type = s2n_cert_chain_and_key_get_pkey_type(conn->handshake_params.our_chain_and_key);` on the client side. 

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? Added unit tests. 

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? yes, we replace hardcoded value. To provide the intended behavior we expect all unit and integration tests to pass without any failures. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
