### PR TITLE
place -Werror behind a flag which is ON by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,9 @@ option(S2N_NO_PQ_ASM "Turns off the ASM for PQ Crypto even if it's available for
 You likely want this on older compilers." OFF)
 option(SEARCH_LIBCRYPTO "Set this if you want to let S2N search libcrypto for you,
 otherwise a crypto target needs to be defined." ON)
-option(UNSAFE_TREAT_WARNINGS_AS_ERRORS "Compiler warning is treated as an error. Warnings may
-indicate danger points where you should check to make sure that your program really does what
-you intend. Try turning this OFF to ignore warnings." ON)
+option(UNSAFE_TREAT_WARNINGS_AS_ERRORS "Compiler warnings are treated as errors. Warnings may
+indicate danger points where you should verify with the S2N-TLS developers that the security of
+the library is not compromised. Turn this OFF to ignore warnings." ON)
 # Turn BUILD_TESTING=ON by default
 include(CTest)
 
@@ -474,4 +474,3 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
 install(FILES "cmake/modules/FindLibCrypto.cmake"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake/modules/"
         COMPONENT Development)
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ option(S2N_NO_PQ_ASM "Turns off the ASM for PQ Crypto even if it's available for
 You likely want this on older compilers." OFF)
 option(SEARCH_LIBCRYPTO "Set this if you want to let S2N search libcrypto for you,
 otherwise a crypto target needs to be defined." ON)
+option(UNSAFE_IGNORE_COMPILER_WARNINGS "Compiler warning is treated as an error. Try turning
+this off when observing errors on a new or unpopular compiler." ON)
 # Turn BUILD_TESTING=ON by default
 include(CTest)
 
@@ -242,10 +244,14 @@ set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE C)
 
 set(CMAKE_C_FLAGS_DEBUGOPT "")
 
-target_compile_options(${PROJECT_NAME} PRIVATE -pedantic -std=gnu99 -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-subscripts
+target_compile_options(${PROJECT_NAME} PRIVATE -pedantic -std=gnu99 -Wall -Wimplicit -Wunused -Wcomment -Wchar-subscripts
         -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security
         -Wno-missing-braces -Wa,--noexecstack
 )
+
+if (UNSAFE_IGNORE_COMPILER_WARNINGS)
+  target_compile_options(${PROJECT_NAME} PRIVATE -Werror )
+endif ()
 
 if(BUILD_TESTING AND BUILD_SHARED_LIBS)
     target_compile_options(${PROJECT_NAME} PRIVATE -fvisibility=default)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ option(SEARCH_LIBCRYPTO "Set this if you want to let S2N search libcrypto for yo
 otherwise a crypto target needs to be defined." ON)
 option(UNSAFE_TREAT_WARNINGS_AS_ERRORS "Compiler warnings are treated as errors. Warnings may
 indicate danger points where you should verify with the S2N-TLS developers that the security of
-the library is not compromised. Turn this OFF to ignore warnings." OFF)
+the library is not compromised. Turn this OFF to ignore warnings." ON)
 # Turn BUILD_TESTING=ON by default
 include(CTest)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,9 @@ option(S2N_NO_PQ_ASM "Turns off the ASM for PQ Crypto even if it's available for
 You likely want this on older compilers." OFF)
 option(SEARCH_LIBCRYPTO "Set this if you want to let S2N search libcrypto for you,
 otherwise a crypto target needs to be defined." ON)
-option(UNSAFE_IGNORE_COMPILER_WARNINGS "Compiler warning is treated as an error. Try turning
-this off when observing errors on a new or unpopular compiler." ON)
+option(UNSAFE_TREAT_WARNINGS_AS_ERRORS "Compiler warning is treated as an error. Warnings may
+indicate danger points where you should check to make sure that your program really does what
+you intend. Try turning this OFF to ignore warnings." ON)
 # Turn BUILD_TESTING=ON by default
 include(CTest)
 
@@ -249,7 +250,7 @@ target_compile_options(${PROJECT_NAME} PRIVATE -pedantic -std=gnu99 -Wall -Wimpl
         -Wno-missing-braces -Wa,--noexecstack
 )
 
-if (UNSAFE_IGNORE_COMPILER_WARNINGS)
+if (UNSAFE_TREAT_WARNINGS_AS_ERRORS)
   target_compile_options(${PROJECT_NAME} PRIVATE -Werror )
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,7 @@ target_compile_options(${PROJECT_NAME} PRIVATE -pedantic -std=gnu99 -Wall -Wimpl
 )
 
 if (UNSAFE_TREAT_WARNINGS_AS_ERRORS)
-  target_compile_options(${PROJECT_NAME} PRIVATE -Werror )
+    target_compile_options(${PROJECT_NAME} PRIVATE -Werror )
 endif ()
 
 if(BUILD_TESTING AND BUILD_SHARED_LIBS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ option(SEARCH_LIBCRYPTO "Set this if you want to let S2N search libcrypto for yo
 otherwise a crypto target needs to be defined." ON)
 option(UNSAFE_TREAT_WARNINGS_AS_ERRORS "Compiler warnings are treated as errors. Warnings may
 indicate danger points where you should verify with the S2N-TLS developers that the security of
-the library is not compromised. Turn this OFF to ignore warnings." ON)
+the library is not compromised. Turn this OFF to ignore warnings." OFF)
 # Turn BUILD_TESTING=ON by default
 include(CTest)
 

--- a/tls/s2n_shutdown.c
+++ b/tls/s2n_shutdown.c
@@ -26,6 +26,8 @@ int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status * more)
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(more);
 
+    int unused_test = 0;
+
     /* Treat this call as a no-op if already wiped */
     if (conn->send == NULL && conn->recv == NULL) {
         return 0;

--- a/tls/s2n_shutdown.c
+++ b/tls/s2n_shutdown.c
@@ -26,8 +26,6 @@ int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status * more)
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(more);
 
-    int unused_test = 0;
-
     /* Treat this call as a no-op if already wiped */
     if (conn->send == NULL && conn->recv == NULL) {
         return 0;


### PR DESCRIPTION
### Resolved issues:


### Description of changes: 
From https://github.com/aws/s2n-tls/pull/2811:

> Currently Werror and extra warnings are force into every type of build.
This is a pain point to package mantainers and cannot be deactivated
easily. Then, when a compiler or package manager that was not explicitly
tested against, for example when new compiler version is launched, the
build fails to users. Release build should not fail to users that
succesfully built after upgrading a dependency or when trying to build
to not yet supported platforms.

This PR allows consumers to turn `-Werror` off when compiling and opt out of treating warnings as errors.

### Call-outs:
From https://gcc.gnu.org/onlinedocs/gcc/Warnings-and-Errors.html:
> Warnings may indicate danger points where you should check to make sure that your program really does what you intend

We maintain `-Werror` by default since it may indicate a danger and users should vet before disabling it.

### Testing:
Used the warning `-Wunused-variable` for testing with CI:
- [unused variable + Flag ON](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nGeneralBatch/build/s2nGeneralBatch%3Adf094c9f-a479-4823-b391-f7a314de7ed5?region=us-west-2)
- [unused variable + Flab OFF](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nGeneralBatch/build/s2nGeneralBatch%3Afb7b1bdb-4e17-4053-b8fe-23d22c1ca24f?region=us-west-2)


 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
