### PR TITLE
Reduce memory allocated for conn->out

### DIFF
--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -59,6 +59,7 @@ struct s2n_stuffer {
 #define s2n_stuffer_data_available( s )   ((s)->write_cursor - (s)->read_cursor)
 #define s2n_stuffer_space_remaining( s )  ((s)->blob.size - (s)->write_cursor)
 #define s2n_stuffer_is_wiped( s )         ((s)->high_water_mark == 0)
+#define s2n_stuffer_is_empty( s )         ((s)->blob.data == NULL)
 /* Check basic validity constraints on the stuffer: e.g. that cursors point within the blob */
 extern S2N_RESULT s2n_stuffer_validate(const struct s2n_stuffer* stuffer);
 

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -59,7 +59,7 @@ struct s2n_stuffer {
 #define s2n_stuffer_data_available( s )   ((s)->write_cursor - (s)->read_cursor)
 #define s2n_stuffer_space_remaining( s )  ((s)->blob.size - (s)->write_cursor)
 #define s2n_stuffer_is_wiped( s )         ((s)->high_water_mark == 0)
-#define s2n_stuffer_is_empty( s )         ((s)->blob.data == NULL)
+#define s2n_stuffer_is_freed( s )         ((s)->blob.data == NULL)
 /* Check basic validity constraints on the stuffer: e.g. that cursors point within the blob */
 extern S2N_RESULT s2n_stuffer_validate(const struct s2n_stuffer* stuffer);
 

--- a/tests/unit/s2n_record_size_test.c
+++ b/tests/unit/s2n_record_size_test.c
@@ -424,35 +424,35 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
     }
 
-    /* s2n_record_max_write_record_size */
+    /* s2n_record_max_write_size */
     {
         uint16_t result = 0;
         conn = s2n_connection_new(S2N_SERVER);
         EXPECT_NOT_NULL(conn);
 
-        EXPECT_ERROR_WITH_ERRNO(s2n_record_max_write_record_size(NULL, 1, &result), S2N_ERR_NULL);
-        EXPECT_ERROR_WITH_ERRNO(s2n_record_max_write_record_size(conn, 1, NULL), S2N_ERR_NULL);
+        EXPECT_ERROR_WITH_ERRNO(s2n_record_max_write_size(NULL, 1, &result), S2N_ERR_NULL);
+        EXPECT_ERROR_WITH_ERRNO(s2n_record_max_write_size(conn, 1, NULL), S2N_ERR_NULL);
 
         conn->actual_protocol_version = 0;
         conn->handshake.handshake_type = INITIAL;
-        EXPECT_OK(s2n_record_max_write_record_size(conn, S2N_TLS_MAXIMUM_FRAGMENT_LENGTH, &result));
+        EXPECT_OK(s2n_record_max_write_size(conn, S2N_TLS_MAXIMUM_FRAGMENT_LENGTH, &result));
         EXPECT_EQUAL(result, S2N_TLS_MAXIMUM_RECORD_LENGTH);
 
         conn->handshake.handshake_type = NEGOTIATED;
-        EXPECT_OK(s2n_record_max_write_record_size(conn, S2N_TLS_MAXIMUM_FRAGMENT_LENGTH, &result));
+        EXPECT_OK(s2n_record_max_write_size(conn, S2N_TLS_MAXIMUM_FRAGMENT_LENGTH, &result));
         EXPECT_EQUAL(result, S2N_TLS_MAXIMUM_RECORD_LENGTH);
 
         conn->actual_protocol_version = S2N_TLS12;
-        EXPECT_OK(s2n_record_max_write_record_size(conn, S2N_TLS_MAXIMUM_FRAGMENT_LENGTH, &result));
+        EXPECT_OK(s2n_record_max_write_size(conn, S2N_TLS_MAXIMUM_FRAGMENT_LENGTH, &result));
         EXPECT_EQUAL(result, S2N_TLS12_MAXIMUM_RECORD_LENGTH);
 
         conn->actual_protocol_version = S2N_TLS13;
-        EXPECT_OK(s2n_record_max_write_record_size(conn, S2N_TLS_MAXIMUM_FRAGMENT_LENGTH, &result));
+        EXPECT_OK(s2n_record_max_write_size(conn, S2N_TLS_MAXIMUM_FRAGMENT_LENGTH, &result));
         EXPECT_EQUAL(result, S2N_TLS13_MAXIMUM_RECORD_LENGTH);
 
         uint16_t diff = 10;
         conn->actual_protocol_version = S2N_TLS13;
-        EXPECT_OK(s2n_record_max_write_record_size(conn, S2N_TLS_MAXIMUM_FRAGMENT_LENGTH - diff, &result));
+        EXPECT_OK(s2n_record_max_write_size(conn, S2N_TLS_MAXIMUM_FRAGMENT_LENGTH - diff, &result));
         EXPECT_EQUAL(result, S2N_TLS13_MAXIMUM_RECORD_LENGTH - diff);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_record_size_test.c
+++ b/tests/unit/s2n_record_size_test.c
@@ -424,5 +424,39 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
     }
 
+    /* s2n_record_max_write_record_size */
+    {
+        uint16_t result = 0;
+        conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(conn);
+
+        EXPECT_ERROR_WITH_ERRNO(s2n_record_max_write_record_size(NULL, 1, &result), S2N_ERR_NULL);
+        EXPECT_ERROR_WITH_ERRNO(s2n_record_max_write_record_size(conn, 1, NULL), S2N_ERR_NULL);
+
+        conn->actual_protocol_version = 0;
+        conn->handshake.handshake_type = INITIAL;
+        EXPECT_OK(s2n_record_max_write_record_size(conn, S2N_TLS_MAXIMUM_FRAGMENT_LENGTH, &result));
+        EXPECT_EQUAL(result, S2N_TLS_MAXIMUM_RECORD_LENGTH);
+
+        conn->handshake.handshake_type = NEGOTIATED;
+        EXPECT_OK(s2n_record_max_write_record_size(conn, S2N_TLS_MAXIMUM_FRAGMENT_LENGTH, &result));
+        EXPECT_EQUAL(result, S2N_TLS_MAXIMUM_RECORD_LENGTH);
+
+        conn->actual_protocol_version = S2N_TLS12;
+        EXPECT_OK(s2n_record_max_write_record_size(conn, S2N_TLS_MAXIMUM_FRAGMENT_LENGTH, &result));
+        EXPECT_EQUAL(result, S2N_TLS12_MAXIMUM_RECORD_LENGTH);
+
+        conn->actual_protocol_version = S2N_TLS13;
+        EXPECT_OK(s2n_record_max_write_record_size(conn, S2N_TLS_MAXIMUM_FRAGMENT_LENGTH, &result));
+        EXPECT_EQUAL(result, S2N_TLS13_MAXIMUM_RECORD_LENGTH);
+
+        uint16_t diff = 10;
+        conn->actual_protocol_version = S2N_TLS13;
+        EXPECT_OK(s2n_record_max_write_record_size(conn, S2N_TLS_MAXIMUM_FRAGMENT_LENGTH - diff, &result));
+        EXPECT_EQUAL(result, S2N_TLS13_MAXIMUM_RECORD_LENGTH - diff);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
     END_TEST();
 }

--- a/tests/unit/s2n_record_size_test.c
+++ b/tests/unit/s2n_record_size_test.c
@@ -241,7 +241,7 @@ int main(int argc, char **argv)
             r.size = size;
             const uint16_t IV = 0;
             const uint16_t TAG = 16;
-            EXPECT_EQUAL(size, RECORD_SIZE_LESS_OVERHEADS - IV - TAG - TLS13_CONTENT_TYPE_LENGTH);
+            EXPECT_EQUAL(size, RECORD_SIZE_LESS_OVERHEADS - IV - TAG - S2N_TLS_CONTENT_TYPE_LENGTH);
 
             EXPECT_SUCCESS(bytes_written = s2n_record_write(server_conn, TLS_APPLICATION_DATA, &r));
             const uint16_t wire_size = s2n_stuffer_data_available(&server_conn->out);
@@ -292,7 +292,7 @@ int main(int argc, char **argv)
 
             EXPECT_OK(s2n_record_min_write_payload_size(server_conn, &size));
             EXPECT_EQUAL(size, RECORD_SIZE_LESS_OVERHEADS - S2N_TLS_CHACHA20_POLY1305_EXPLICIT_IV_LEN
-                    - S2N_TLS_GCM_TAG_LEN - TLS13_CONTENT_TYPE_LENGTH);
+                    - S2N_TLS_GCM_TAG_LEN - S2N_TLS_CONTENT_TYPE_LENGTH);
             r.size = size;
 
             EXPECT_SUCCESS(bytes_written = s2n_record_write(server_conn, TLS_APPLICATION_DATA, &r));

--- a/tests/unit/s2n_self_talk_io_mem_test.c
+++ b/tests/unit/s2n_self_talk_io_mem_test.c
@@ -1,0 +1,169 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "testlib/s2n_testlib.h"
+
+#include <sys/wait.h>
+#include <unistd.h>
+#include <time.h>
+#include <stdint.h>
+
+#include <s2n.h>
+
+#include "tls/s2n_connection.h"
+#include "tls/s2n_handshake.h"
+#include "tls/s2n_tls13.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    struct s2n_cert_chain_and_key *chain_and_key;
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+            S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+
+    struct s2n_config *config = s2n_config_new();
+    EXPECT_NOT_NULL(config);
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+    EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+
+    /* Default case: use wire record size based on default fragment length */
+    {
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair;
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+
+        /* Do handshake */
+        EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, SERVER_CERT));
+        EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
+
+        /* Output memory allocated according to max fragment length. */
+        EXPECT_EQUAL(client_conn->max_outgoing_fragment_length, S2N_DEFAULT_FRAGMENT_LENGTH);
+        EXPECT_EQUAL(server_conn->max_outgoing_fragment_length, S2N_DEFAULT_FRAGMENT_LENGTH);
+        EXPECT_EQUAL(client_conn->out.blob.size, S2N_TLS_MAX_RECORD_LEN_FOR(S2N_DEFAULT_FRAGMENT_LENGTH));
+        EXPECT_EQUAL(server_conn->out.blob.size, S2N_TLS13_MAX_RECORD_LEN_FOR(S2N_DEFAULT_FRAGMENT_LENGTH));
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    /* Max fragment size set manually */
+    {
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair;
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+
+        /* Set connections to use different fragment sizes */
+        EXPECT_SUCCESS(s2n_connection_prefer_low_latency(client_conn));
+        EXPECT_SUCCESS(s2n_connection_prefer_throughput(server_conn));
+
+        /* Do handshake */
+        EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, SERVER_CERT));
+        EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
+
+        /* Output memory allocated according to max fragment length. */
+        EXPECT_EQUAL(client_conn->max_outgoing_fragment_length, S2N_SMALL_FRAGMENT_LENGTH);
+        EXPECT_EQUAL(server_conn->max_outgoing_fragment_length, S2N_LARGE_FRAGMENT_LENGTH);
+        EXPECT_EQUAL(client_conn->out.blob.size, S2N_TLS_MAX_RECORD_LEN_FOR(S2N_SMALL_FRAGMENT_LENGTH));
+        EXPECT_EQUAL(server_conn->out.blob.size, S2N_TLS13_MAX_RECORD_LEN_FOR(S2N_LARGE_FRAGMENT_LENGTH));
+
+        /* Switch max fragment lengths after handshake */
+        EXPECT_SUCCESS(s2n_connection_prefer_throughput(client_conn));
+        EXPECT_SUCCESS(s2n_connection_prefer_low_latency(server_conn));
+        EXPECT_EQUAL(client_conn->max_outgoing_fragment_length, S2N_LARGE_FRAGMENT_LENGTH);
+        EXPECT_EQUAL(server_conn->max_outgoing_fragment_length, S2N_SMALL_FRAGMENT_LENGTH);
+        EXPECT_EQUAL(client_conn->out.blob.size, S2N_TLS13_MAX_RECORD_LEN_FOR(S2N_LARGE_FRAGMENT_LENGTH));
+        EXPECT_EQUAL(server_conn->out.blob.size, S2N_TLS13_MAX_RECORD_LEN_FOR(S2N_LARGE_FRAGMENT_LENGTH));
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    /* max_fragment_length extension used */
+    {
+        const s2n_max_frag_len mfl_code = S2N_TLS_MAX_FRAG_LEN_2048;
+        const uint16_t expected_mfl = 2048;
+
+        struct s2n_config *config_for_mfl = s2n_config_new();
+        EXPECT_NOT_NULL(config_for_mfl);
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config_for_mfl, "default_tls13"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config_for_mfl));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config_for_mfl, chain_and_key));
+        EXPECT_SUCCESS(s2n_config_send_max_fragment_length(config_for_mfl, mfl_code));
+        EXPECT_SUCCESS(s2n_config_accept_max_fragment_length(config_for_mfl));
+
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config_for_mfl));
+
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config_for_mfl));
+
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair;
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+
+        /* Set connections to use smaller fragment size */
+        EXPECT_SUCCESS(s2n_connection_prefer_low_latency(client_conn));
+        EXPECT_SUCCESS(s2n_connection_prefer_throughput(server_conn));
+
+        /* Do handshake */
+        EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, SERVER_CERT));
+        EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
+
+        /* Output memory allocated according to max fragment length. */
+        EXPECT_EQUAL(client_conn->max_outgoing_fragment_length, S2N_SMALL_FRAGMENT_LENGTH);
+        EXPECT_EQUAL(server_conn->max_outgoing_fragment_length, expected_mfl);
+        EXPECT_EQUAL(client_conn->out.blob.size, S2N_TLS_MAX_RECORD_LEN_FOR(S2N_SMALL_FRAGMENT_LENGTH));
+        EXPECT_EQUAL(server_conn->out.blob.size, S2N_TLS13_MAX_RECORD_LEN_FOR(expected_mfl));
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_config_free(config_for_mfl));
+    }
+
+    EXPECT_SUCCESS(s2n_config_free(config));
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+    END_TEST();
+}

--- a/tests/unit/s2n_self_talk_io_mem_test.c
+++ b/tests/unit/s2n_self_talk_io_mem_test.c
@@ -66,7 +66,11 @@ int main(int argc, char **argv)
         /* Output memory allocated according to max fragment length. */
         EXPECT_EQUAL(client_conn->max_outgoing_fragment_length, S2N_DEFAULT_FRAGMENT_LENGTH);
         EXPECT_EQUAL(server_conn->max_outgoing_fragment_length, S2N_DEFAULT_FRAGMENT_LENGTH);
+        /* The client allocates the protocol-agnostic max record size because when it sends its
+         * first message (ClientHello) the protocol hasn't been negotiated yet. */
         EXPECT_EQUAL(client_conn->out.blob.size, S2N_TLS_MAX_RECORD_LEN_FOR(S2N_DEFAULT_FRAGMENT_LENGTH));
+        /* The server allocates only enough memory for TLS1.3 records because when it sends its
+         * first message (ServerHello) the protocol has already been negotiated. */
         EXPECT_EQUAL(server_conn->out.blob.size, S2N_TLS13_MAX_RECORD_LEN_FOR(S2N_DEFAULT_FRAGMENT_LENGTH));
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
@@ -104,7 +108,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(client_conn->out.blob.size, S2N_TLS_MAX_RECORD_LEN_FOR(S2N_SMALL_FRAGMENT_LENGTH));
         EXPECT_EQUAL(server_conn->out.blob.size, S2N_TLS13_MAX_RECORD_LEN_FOR(S2N_LARGE_FRAGMENT_LENGTH));
 
-        /* Switch max fragment lengths after handshake */
+        /* Switch max fragment lengths after handshake to verify whether buffers are resized */
         EXPECT_SUCCESS(s2n_connection_prefer_throughput(client_conn));
         EXPECT_SUCCESS(s2n_connection_prefer_low_latency(server_conn));
         EXPECT_EQUAL(client_conn->max_outgoing_fragment_length, S2N_LARGE_FRAGMENT_LENGTH);

--- a/tls/extensions/s2n_client_max_frag_len.c
+++ b/tls/extensions/s2n_client_max_frag_len.c
@@ -74,7 +74,7 @@ static int s2n_client_max_frag_len_recv(struct s2n_connection *conn, struct s2n_
      *# larger than the negotiated length is sent.
      */
     conn->negotiated_mfl_code = mfl_code;
-    conn->max_outgoing_fragment_length = mfl_code_to_length[mfl_code];
+    POSIX_GUARD_RESULT(s2n_connection_set_max_fragment_length(conn, mfl_code_to_length[mfl_code]));
     return S2N_SUCCESS;
 }
 

--- a/tls/extensions/s2n_server_max_fragment_length.c
+++ b/tls/extensions/s2n_server_max_fragment_length.c
@@ -77,7 +77,7 @@ static int s2n_max_fragment_length_recv(struct s2n_connection *conn, struct s2n_
      *# larger than the negotiated length is sent.
      */
     conn->negotiated_mfl_code = mfl_code;
-    conn->max_outgoing_fragment_length = MIN(conn->max_outgoing_fragment_length, mfl_code_to_length[mfl_code]);
+    POSIX_GUARD_RESULT(s2n_connection_set_max_fragment_length(conn, conn->max_outgoing_fragment_length));
 
     return S2N_SUCCESS;
 }

--- a/tls/s2n_aead.c
+++ b/tls/s2n_aead.c
@@ -18,6 +18,7 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_mem.h"
 
+#include "tls/s2n_connection.h"
 #include "tls/s2n_record.h"
 
 /* Derive the AAD for an AEAD mode cipher suite from the connection state, per

--- a/tls/s2n_cbc.c
+++ b/tls/s2n_cbc.c
@@ -23,6 +23,7 @@
 
 #include "crypto/s2n_hmac.h"
 
+#include "tls/s2n_connection.h"
 #include "tls/s2n_record.h"
 
 /* A TLS CBC record looks like ..

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1310,7 +1310,7 @@ S2N_RESULT s2n_connection_set_max_fragment_length(struct s2n_connection *conn, u
     /* If no buffer has been initialized yet, no need to resize.
      * The standard I/O logic will handle initializing the buffer.
      */
-    if (s2n_stuffer_is_empty(&conn->out)) {
+    if (s2n_stuffer_is_freed(&conn->out)) {
         return S2N_RESULT_OK;
     }
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1315,7 +1315,7 @@ S2N_RESULT s2n_connection_set_max_fragment_length(struct s2n_connection *conn, u
     }
 
     uint16_t max_wire_record_size = 0;
-    RESULT_GUARD(s2n_record_max_write_record_size(conn, conn->max_outgoing_fragment_length, &max_wire_record_size));
+    RESULT_GUARD(s2n_record_max_write_size(conn, conn->max_outgoing_fragment_length, &max_wire_record_size));
     if ((conn->out.blob.size < max_wire_record_size)) {
         RESULT_GUARD_POSIX(s2n_realloc(&conn->out.blob, max_wire_record_size));
     }

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1295,7 +1295,7 @@ const uint8_t *s2n_connection_get_ocsp_response(struct s2n_connection *conn, uin
     return conn->status_response.data;
 }
 
-static S2N_RESULT s2n_connection_set_max_fragment_length(struct s2n_connection *conn, uint16_t max_frag_length)
+S2N_RESULT s2n_connection_set_max_fragment_length(struct s2n_connection *conn, uint16_t max_frag_length)
 {
     RESULT_ENSURE_REF(conn);
 
@@ -1305,6 +1305,19 @@ static S2N_RESULT s2n_connection_set_max_fragment_length(struct s2n_connection *
         conn->max_outgoing_fragment_length = MIN(mfl_code_to_length[conn->negotiated_mfl_code], max_frag_length);
     } else {
         conn->max_outgoing_fragment_length = max_frag_length;
+    }
+
+    /* If no buffer has been initialized yet, no need to resize.
+     * The standard I/O logic will handle initializing the buffer.
+     */
+    if (s2n_stuffer_is_empty(&conn->out)) {
+        return S2N_RESULT_OK;
+    }
+
+    uint16_t max_wire_record_size = 0;
+    RESULT_GUARD(s2n_record_max_write_record_size(conn, conn->max_outgoing_fragment_length, &max_wire_record_size));
+    if ((conn->out.blob.size < max_wire_record_size)) {
+        RESULT_GUARD_POSIX(s2n_realloc(&conn->out.blob, max_wire_record_size));
     }
 
     return S2N_RESULT_OK;

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -388,3 +388,4 @@ int s2n_connection_get_peer_cert_chain(const struct s2n_connection *conn, struct
 uint8_t s2n_connection_get_protocol_version(const struct s2n_connection *conn);
 /* `none` keyword represents a list of empty keyshares */
 int s2n_connection_set_keyshare_by_name_for_testing(struct s2n_connection *conn, const char* curve_name);
+S2N_RESULT s2n_connection_set_max_fragment_length(struct s2n_connection *conn, uint16_t length);

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -35,6 +35,7 @@
 #include "tls/s2n_kem_preferences.h"
 #include "tls/s2n_ecc_preferences.h"
 #include "tls/s2n_security_policies.h"
+#include "tls/s2n_record.h"
 
 #include "crypto/s2n_hash.h"
 #include "crypto/s2n_hmac.h"

--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -39,11 +39,11 @@
  */
 #define S2N_TLS_MAXIMUM_FRAGMENT_LENGTH         (1 << 14)
 
-/* Maximum TLS record length allows for 2048 bytes of compression expansion and padding */
+/* TLS record length allows for 2048 bytes of compression expansion and padding.
+ * However, S2N does not support compression, so we can ignore the compression overhead.
+ */
 #define S2N_TLS12_ENCRYPTION_OVERHEAD_SIZE      1024
-#define S2N_TLS12_COMPRESSION_OVERHEAD_SIZE     1024
 #define S2N_TLS12_MAX_RECORD_LEN_FOR(frag)      ((frag) + S2N_TLS12_ENCRYPTION_OVERHEAD_SIZE \
-                                                        + S2N_TLS12_COMPRESSION_OVERHEAD_SIZE \
                                                         + S2N_TLS_RECORD_HEADER_LENGTH)
 #define S2N_TLS12_MAXIMUM_RECORD_LENGTH         S2N_TLS12_MAX_RECORD_LEN_FOR(S2N_TLS_MAXIMUM_FRAGMENT_LENGTH)
 

--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -39,8 +39,9 @@
  */
 #define S2N_TLS_MAXIMUM_FRAGMENT_LENGTH         (1 << 14)
 
-/* TLS record length allows for 2048 bytes of compression expansion and padding.
- * However, S2N does not support compression, so we can ignore the compression overhead.
+/* The TLS1.2 record length allows for 1024 bytes of compression expansion and
+ * 1024 bytes of encryption expansion and padding.
+ * Since S2N does not support compression, we can ignore the compression overhead.
  */
 #define S2N_TLS12_ENCRYPTION_OVERHEAD_SIZE      1024
 #define S2N_TLS12_MAX_RECORD_LEN_FOR(frag)      ((frag) + S2N_TLS12_ENCRYPTION_OVERHEAD_SIZE \

--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -64,7 +64,7 @@
 #define S2N_TLS_MAX_RECORD_LEN_FOR(frag)        S2N_TLS12_MAX_RECORD_LEN_FOR(frag)
 #define S2N_TLS_MAXIMUM_RECORD_LENGTH           S2N_TLS_MAX_RECORD_LEN_FOR(S2N_TLS_MAXIMUM_FRAGMENT_LENGTH)
 
-S2N_RESULT s2n_record_max_write_record_size(struct s2n_connection *conn, uint16_t max_fragment_size, uint16_t *max_record_size);
+S2N_RESULT s2n_record_max_write_size(struct s2n_connection *conn, uint16_t max_fragment_size, uint16_t *max_record_size);
 extern S2N_RESULT s2n_record_max_write_payload_size(struct s2n_connection *conn, uint16_t *max_fragment_size);
 extern S2N_RESULT s2n_record_min_write_payload_size(struct s2n_connection *conn, uint16_t *payload_size);
 extern int s2n_record_write(struct s2n_connection *conn, uint8_t content_type, struct s2n_blob *in);

--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -16,10 +16,53 @@
 #pragma once
 
 #include <stdint.h>
+#include "crypto/s2n_hmac.h"
+#include "stuffer/s2n_stuffer.h"
 
-#include "s2n_connection.h"
+#define S2N_TLS_CONTENT_TYPE_LENGTH             1
 
-#define TLS13_CONTENT_TYPE_LENGTH 1
+/* All versions of TLS define the record header the same:
+ * ContentType + ProtocolVersion + length
+ */
+#define S2N_TLS_RECORD_HEADER_LENGTH            (S2N_TLS_CONTENT_TYPE_LENGTH + S2N_TLS_PROTOCOL_VERSION_LEN + 2)
+
+/*
+ * All versions of TLS limit the data fragment to 2^14 bytes.
+ *
+ *= https://tools.ietf.org/rfc/rfc5246#section-6.2.1
+ *# The record layer fragments information blocks into TLSPlaintext
+ *# records carrying data in chunks of 2^14 bytes or less.
+ *
+ *= https://tools.ietf.org/rfc/rfc8446#section-5
+ *# The record layer fragments information blocks into TLSPlaintext
+ *# records carrying data in chunks of 2^14 bytes or less.
+ */
+#define S2N_TLS_MAXIMUM_FRAGMENT_LENGTH         (1 << 14)
+
+/* Maximum TLS record length allows for 2048 bytes of compression expansion and padding */
+#define S2N_TLS12_ENCRYPTION_OVERHEAD_SIZE      1024
+#define S2N_TLS12_COMPRESSION_OVERHEAD_SIZE     1024
+#define S2N_TLS12_MAX_RECORD_LEN_FOR(frag)      ((frag) + S2N_TLS12_ENCRYPTION_OVERHEAD_SIZE \
+                                                        + S2N_TLS12_COMPRESSION_OVERHEAD_SIZE \
+                                                        + S2N_TLS_RECORD_HEADER_LENGTH)
+#define S2N_TLS12_MAXIMUM_RECORD_LENGTH         S2N_TLS12_MAX_RECORD_LEN_FOR(S2N_TLS_MAXIMUM_FRAGMENT_LENGTH)
+
+/*
+ *= https://tools.ietf.org/rfc/rfc8446#section-5
+ *# An AEAD algorithm used in TLS 1.3 MUST NOT produce an expansion
+ *# greater than 255 octets.
+ */
+#define S2N_TLS13_ENCRYPTION_OVERHEAD_SIZE      255
+#define S2N_TLS13_MAX_RECORD_LEN_FOR(frag)      ((frag) + S2N_TLS_CONTENT_TYPE_LENGTH \
+                                                        + S2N_TLS13_ENCRYPTION_OVERHEAD_SIZE \
+                                                        + S2N_TLS_RECORD_HEADER_LENGTH)
+#define S2N_TLS13_MAXIMUM_RECORD_LENGTH         S2N_TLS13_MAX_RECORD_LEN_FOR(S2N_TLS_MAXIMUM_FRAGMENT_LENGTH)
+
+/* Currently, TLS1.2 records may be larger than TLS1.3 records.
+ * If the protocol is unknown, assume TLS1.2.
+ */
+#define S2N_TLS_MAX_RECORD_LEN_FOR(frag)        S2N_TLS12_MAX_RECORD_LEN_FOR(frag)
+#define S2N_TLS_MAXIMUM_RECORD_LENGTH           S2N_TLS_MAX_RECORD_LEN_FOR(S2N_TLS_MAXIMUM_FRAGMENT_LENGTH)
 
 extern S2N_RESULT s2n_record_max_write_payload_size(struct s2n_connection *conn, uint16_t *max_fragment_size);
 extern S2N_RESULT s2n_record_min_write_payload_size(struct s2n_connection *conn, uint16_t *payload_size);

--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -64,6 +64,7 @@
 #define S2N_TLS_MAX_RECORD_LEN_FOR(frag)        S2N_TLS12_MAX_RECORD_LEN_FOR(frag)
 #define S2N_TLS_MAXIMUM_RECORD_LENGTH           S2N_TLS_MAX_RECORD_LEN_FOR(S2N_TLS_MAXIMUM_FRAGMENT_LENGTH)
 
+S2N_RESULT s2n_record_max_write_record_size(struct s2n_connection *conn, uint16_t max_fragment_size, uint16_t *max_record_size);
 extern S2N_RESULT s2n_record_max_write_payload_size(struct s2n_connection *conn, uint16_t *max_fragment_size);
 extern S2N_RESULT s2n_record_min_write_payload_size(struct s2n_connection *conn, uint16_t *payload_size);
 extern int s2n_record_write(struct s2n_connection *conn, uint8_t content_type, struct s2n_blob *in);

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -82,17 +82,17 @@ S2N_RESULT s2n_record_max_write_payload_size(struct s2n_connection *conn, uint16
     return S2N_RESULT_OK;
 }
 
-S2N_RESULT s2n_record_max_write_record_size(struct s2n_connection *conn, uint16_t max_fragment_size, uint16_t *max_size)
+S2N_RESULT s2n_record_max_write_size(struct s2n_connection *conn, uint16_t max_fragment_size, uint16_t *max_record_size)
 {
     RESULT_ENSURE_REF(conn);
-    RESULT_ENSURE_MUT(max_size);
+    RESULT_ENSURE_MUT(max_record_size);
 
     if(!IS_NEGOTIATED(conn)) {
-        *max_size = S2N_TLS_MAX_RECORD_LEN_FOR(max_fragment_size);
+        *max_record_size = S2N_TLS_MAX_RECORD_LEN_FOR(max_fragment_size);
     } else if (conn->actual_protocol_version < S2N_TLS13) {
-        *max_size = S2N_TLS12_MAX_RECORD_LEN_FOR(max_fragment_size);
+        *max_record_size = S2N_TLS12_MAX_RECORD_LEN_FOR(max_fragment_size);
     } else {
-        *max_size = S2N_TLS13_MAX_RECORD_LEN_FOR(max_fragment_size);
+        *max_record_size = S2N_TLS13_MAX_RECORD_LEN_FOR(max_fragment_size);
     }
     return S2N_RESULT_OK;
 }
@@ -280,7 +280,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
 
     if (s2n_stuffer_is_empty(&conn->out)) {
         uint16_t max_wire_record_size = 0;
-        POSIX_GUARD_RESULT(s2n_record_max_write_record_size(conn, max_write_payload_size, &max_wire_record_size));
+        POSIX_GUARD_RESULT(s2n_record_max_write_size(conn, max_write_payload_size, &max_wire_record_size));
         POSIX_GUARD(s2n_stuffer_growable_alloc(&conn->out, max_wire_record_size));
     }
 

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -110,8 +110,8 @@ S2N_RESULT s2n_record_min_write_payload_size(struct s2n_connection *conn, uint16
 
     /* If TLS1.3, remove content type */
     if (conn->actual_protocol_version >= S2N_TLS13) {
-        RESULT_ENSURE(size > TLS13_CONTENT_TYPE_LENGTH, S2N_ERR_FRAGMENT_LENGTH_TOO_SMALL);
-        size -= TLS13_CONTENT_TYPE_LENGTH;
+        RESULT_ENSURE(size > S2N_TLS_CONTENT_TYPE_LENGTH, S2N_ERR_FRAGMENT_LENGTH_TOO_SMALL);
+        size -= S2N_TLS_CONTENT_TYPE_LENGTH;
     }
 
     /* subtract overheads of a TLS record */
@@ -301,7 +301,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
 
     /* TLS 1.3 protected record occupies one extra byte for content type */
     if (is_tls13_record) {
-        extra += TLS13_CONTENT_TYPE_LENGTH;
+        extra += S2N_TLS_CONTENT_TYPE_LENGTH;
     }
 
     /* Rewrite the length to be the actual fragment length */
@@ -341,7 +341,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
         struct s2n_stuffer ad_stuffer = {0};
         POSIX_GUARD(s2n_stuffer_init(&ad_stuffer, &aad));
         if (is_tls13_record) {
-            POSIX_GUARD_RESULT(s2n_tls13_aead_aad_init(data_bytes_to_take + TLS13_CONTENT_TYPE_LENGTH, cipher_suite->record_alg->cipher->io.aead.tag_size, &ad_stuffer));
+            POSIX_GUARD_RESULT(s2n_tls13_aead_aad_init(data_bytes_to_take + S2N_TLS_CONTENT_TYPE_LENGTH, cipher_suite->record_alg->cipher->io.aead.tag_size, &ad_stuffer));
         } else {
             POSIX_GUARD_RESULT(s2n_aead_aad_init(conn, sequence_number, content_type, data_bytes_to_take, &ad_stuffer));
         }
@@ -422,7 +422,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
         encrypted_length += cipher_suite->record_alg->cipher->io.aead.tag_size;
         if (is_tls13_record) {
             /* one extra byte for content type */
-            encrypted_length += TLS13_CONTENT_TYPE_LENGTH;
+            encrypted_length += S2N_TLS_CONTENT_TYPE_LENGTH;
         }
         break;
     case S2N_CBC:

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -278,7 +278,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
     /* Start the MAC with the sequence number */
     POSIX_GUARD(s2n_hmac_update(mac, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
 
-    if (s2n_stuffer_is_empty(&conn->out)) {
+    if (s2n_stuffer_is_freed(&conn->out)) {
         uint16_t max_wire_record_size = 0;
         POSIX_GUARD_RESULT(s2n_record_max_write_size(conn, max_write_payload_size, &max_wire_record_size));
         POSIX_GUARD(s2n_stuffer_growable_alloc(&conn->out, max_wire_record_size));

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -197,20 +197,7 @@
 #define TCP_HEADER_LENGTH 20
 #define TCP_OPTIONS_LENGTH 40
 
-/* The maximum size of a TLS record is 16389 bytes. This is;  1 byte for content
- * type, 2 bytes for the protocol version, 2 bytes for the length field,
- * and then up to 2^14 for the encrypted+compressed payload data.
- */
-#define S2N_TLS_RECORD_HEADER_LENGTH    5
-#define S2N_TLS_MAXIMUM_FRAGMENT_LENGTH 16384
-/* Maximum TLS record length allows for 2048 octets of compression expansion and padding */
-#define S2N_TLS_MAXIMUM_RECORD_LENGTH   (S2N_TLS_MAXIMUM_FRAGMENT_LENGTH + S2N_TLS_RECORD_HEADER_LENGTH + 2048)
 #define S2N_TLS_MAX_FRAG_LEN_EXT_NONE   0
-
-/* TLS1.3 has a max fragment length of 2^14 + 1 byte for the content type */
-#define S2N_TLS13_MAXIMUM_FRAGMENT_LENGTH 16385
-/* Max encryption overhead is 255 for AEAD padding */
-#define S2N_TLS13_MAXIMUM_RECORD_LENGTH   (S2N_TLS13_MAXIMUM_FRAGMENT_LENGTH + S2N_TLS_RECORD_HEADER_LENGTH + 255)
 
 /* The maximum size of an SSL2 message is 2^14 - 1, as neither of the first two
  * bits in the length field are usable. Per;
@@ -241,7 +228,6 @@
  */
 #define S2N_LARGE_RECORD_LENGTH S2N_TLS_MAXIMUM_RECORD_LENGTH
 #define S2N_LARGE_FRAGMENT_LENGTH S2N_TLS_MAXIMUM_FRAGMENT_LENGTH
-#define S2N_TLS13_LARGE_FRAGMENT_LENGTH S2N_TLS13_MAXIMUM_FRAGMENT_LENGTH
 
 /* Cap dynamic record resize threshold to 8M */
 #define S2N_TLS_MAX_RESIZE_THRESHOLD (1024 * 1024 * 8)


### PR DESCRIPTION
### Description of changes: 

We allocate enough space to write records using the maximum fragment length, but by default S2N sets the actual fragment length much lower than the maximum. We can save memory if we only allocate what we need.

We can also save 1K for TLS1.2 by recognizing that S2N doesn't support compression so doesn't need to account for compression overhead.

Before this change, we allocated 16K bytes for conn->out. After this change, we allocate 9K if using TLS1.2 or 8K if using TLS1.3. The client has to allocate 9K regardless of version, because it sends the ClientHello record before it knows what protocol will be used. If `s2n_connection_prefer_low_latency` is called, we only allocate 2.5K bytes for TLS1.2 and 1.5K bytes for TLS1.3.

### Call-outs:

If `s2n_connection_prefer_throughput` is called after the handshake starts, the IO buffer **will** be re-allocated. This is the only case where this change results in a new allocation.

### Testing:

Unit tests + self-talk tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
