### PR TITLE
Update a pair of parameterless function declarations to remove strict prototype warning

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -704,7 +704,7 @@ struct s2n_psk;
  * @return struct s2n_psk* Returns a pointer to the newly created external PSK object.
  */
 S2N_API
-struct s2n_psk* s2n_external_psk_new();
+struct s2n_psk* s2n_external_psk_new(void);
 
 /**
  * Frees the memory associated with the external PSK object.
@@ -853,7 +853,7 @@ struct s2n_offered_psk;
  * @return struct s2n_offered_psk* Returns a pointer to the newly created offered PSK object.
  */
 S2N_API 
-struct s2n_offered_psk* s2n_offered_psk_new();
+struct s2n_offered_psk* s2n_offered_psk_new(void);
 
 /**
  * Frees the memory associated with the `s2n_offered_psk` object.


### PR DESCRIPTION

### Description of changes: 

A new pair of public APIs are declared with an empty parameter list rather than void.  This is flagged as a warning on certain compilers.

### Testing:

Build only

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
