### PR TITLE
Check Cipher Suite is ECC Before Returning Curve

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1439,7 +1439,7 @@ negotiated by s2n-tls for a connection in Openssl format, e.g. "ECDHE-RSA-AES128
 const char * s2n_connection_get_curve(struct s2n_connection *conn);
 ```
 
-**s2n_connection_get_curve** returns a string indicating the elliptic curve used during ECDHE key exchange. The string "NONE" is returned if no curve has was used.
+**s2n_connection_get_curve** returns a string indicating the elliptic curve used during ECDHE key exchange. The string "NONE" is returned if no curve was used.
 
 ### s2n\_connection\_get\_selected\_cert
 

--- a/tests/unit/s2n_connection_preferences_test.c
+++ b/tests/unit/s2n_connection_preferences_test.c
@@ -267,27 +267,27 @@ int main(int argc, char **argv)
 
         /* No curve negotiated yet */
         EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));
-        EXPECT_BYTEARRAY_EQUAL(curve_name, no_curve, sizeof(no_curve));
+        EXPECT_BYTEARRAY_EQUAL(curve_name, no_curve, strlen(no_curve));
 
         /* TLS1.3 always returns a curve */
         conn->actual_protocol_version = S2N_TLS13;
         conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
         EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));
-        EXPECT_BYTEARRAY_EQUAL(curve_name, s2n_ecc_curve_secp256r1.name, sizeof(s2n_ecc_curve_secp256r1.name));
+        EXPECT_BYTEARRAY_EQUAL(curve_name, s2n_ecc_curve_secp256r1.name, strlen(s2n_ecc_curve_secp256r1.name));
 
         /* TLS1.2 returns a curve if ECDHE cipher negotiated */
         conn->actual_protocol_version = S2N_TLS12;
         conn->secure.cipher_suite = &s2n_ecdhe_rsa_with_aes_128_cbc_sha256;
         conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
         EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));
-        EXPECT_BYTEARRAY_EQUAL(curve_name, s2n_ecc_curve_secp256r1.name, sizeof(s2n_ecc_curve_secp256r1.name));
+        EXPECT_BYTEARRAY_EQUAL(curve_name, s2n_ecc_curve_secp256r1.name, strlen(s2n_ecc_curve_secp256r1.name));
 
         /* TLS1.2 does not return a curve if ECDHE cipher was not negotiated */
         conn->actual_protocol_version = S2N_TLS12;
         conn->secure.cipher_suite = &s2n_rsa_with_aes_256_gcm_sha384;
         conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
         EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));
-        EXPECT_BYTEARRAY_EQUAL(curve_name, no_curve, sizeof(no_curve));
+        EXPECT_BYTEARRAY_EQUAL(curve_name, no_curve, strlen(no_curve));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }

--- a/tests/unit/s2n_connection_preferences_test.c
+++ b/tests/unit/s2n_connection_preferences_test.c
@@ -287,7 +287,6 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));
         EXPECT_BYTEARRAY_EQUAL(curve_name, no_curve, sizeof(no_curve));
 
-
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 

--- a/tests/unit/s2n_connection_preferences_test.c
+++ b/tests/unit/s2n_connection_preferences_test.c
@@ -269,19 +269,21 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));
         EXPECT_BYTEARRAY_EQUAL(curve_name, no_curve, sizeof(no_curve));
 
-        /* ECDHE cipher negotiated and curve chosen */
+        /* TLS1.3 always returns a curve */
+        conn->actual_protocol_version = S2N_TLS13;
+        conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
+        EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));
+        EXPECT_BYTEARRAY_EQUAL(curve_name, s2n_ecc_curve_secp256r1.name, sizeof(s2n_ecc_curve_secp256r1.name));
+
+        /* TLS1.2 returns a curve if ECDHE cipher negotiated */
+        conn->actual_protocol_version = S2N_TLS12;
         conn->secure.cipher_suite = &s2n_ecdhe_rsa_with_aes_128_cbc_sha256;
         conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
         EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));
         EXPECT_BYTEARRAY_EQUAL(curve_name, s2n_ecc_curve_secp256r1.name, sizeof(s2n_ecc_curve_secp256r1.name));
 
-        /* Hybrid ECDHE cipher negotiated and curve chosen */
-        conn->secure.cipher_suite = &s2n_ecdhe_kyber_rsa_with_aes_256_gcm_sha384;
-        conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
-        EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));
-        EXPECT_BYTEARRAY_EQUAL(curve_name, s2n_ecc_curve_secp256r1.name, sizeof(s2n_ecc_curve_secp256r1.name));
-
-        /* ECDHE cipher was not negotiated but curve is set */
+        /* TLS1.2 does not return a curve if ECDHE cipher was not negotiated */
+        conn->actual_protocol_version = S2N_TLS12;
         conn->secure.cipher_suite = &s2n_rsa_with_aes_256_gcm_sha384;
         conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
         EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1033,11 +1033,13 @@ const char *s2n_connection_get_curve(struct s2n_connection *conn)
 {
     PTR_ENSURE_REF(conn);
 
-    if (!conn->secure.server_ecc_evp_params.negotiated_curve) {
-        return "NONE";
+    if (conn->secure.server_ecc_evp_params.negotiated_curve && 
+        (s2n_kex_includes(conn->secure.cipher_suite->key_exchange_alg, &s2n_ecdhe) ||
+         s2n_kex_includes(conn->secure.cipher_suite->key_exchange_alg, &s2n_hybrid_ecdhe_kem))) {
+        return conn->secure.server_ecc_evp_params.negotiated_curve->name;
     }
 
-    return conn->secure.server_ecc_evp_params.negotiated_curve->name;
+    return "NONE";
 }
 
 const char *s2n_connection_get_kem_name(struct s2n_connection *conn)

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1034,7 +1034,7 @@ const char *s2n_connection_get_curve(struct s2n_connection *conn)
     PTR_ENSURE_REF(conn);
 
     if (conn->secure.server_ecc_evp_params.negotiated_curve) {
-        /* s2n-tls currently only supports ECC groups for TLS1.3. */
+        /* TLS1.3 currently only uses ECC groups. */
         if (conn->actual_protocol_version >= S2N_TLS13 || s2n_kex_includes(conn->secure.cipher_suite->key_exchange_alg, &s2n_ecdhe)) {
             return conn->secure.server_ecc_evp_params.negotiated_curve->name;
         }

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1034,6 +1034,7 @@ const char *s2n_connection_get_curve(struct s2n_connection *conn)
     PTR_ENSURE_REF(conn);
 
     if (conn->secure.server_ecc_evp_params.negotiated_curve) {
+        /* s2n-tls currently only supports ECC groups for TLS1.3. */
         if (conn->actual_protocol_version >= S2N_TLS13 || s2n_kex_includes(conn->secure.cipher_suite->key_exchange_alg, &s2n_ecdhe)) {
             return conn->secure.server_ecc_evp_params.negotiated_curve->name;
         }

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1033,10 +1033,10 @@ const char *s2n_connection_get_curve(struct s2n_connection *conn)
 {
     PTR_ENSURE_REF(conn);
 
-    if (conn->secure.server_ecc_evp_params.negotiated_curve && 
-        (s2n_kex_includes(conn->secure.cipher_suite->key_exchange_alg, &s2n_ecdhe) ||
-         s2n_kex_includes(conn->secure.cipher_suite->key_exchange_alg, &s2n_hybrid_ecdhe_kem))) {
-        return conn->secure.server_ecc_evp_params.negotiated_curve->name;
+    if (conn->secure.server_ecc_evp_params.negotiated_curve) {
+        if (conn->actual_protocol_version >= S2N_TLS13 || s2n_kex_includes(conn->secure.cipher_suite->key_exchange_alg, &s2n_ecdhe)) {
+            return conn->secure.server_ecc_evp_params.negotiated_curve->name;
+        }
     }
 
     return "NONE";


### PR DESCRIPTION
### Resolved issues:

 resolves #2901

### Description of changes: 

s2n sets a curve by default on the server-side, which was causing the s2n_connection_get_curve() to return a curve, even when not using curves. s2n_connection_get_curve now checks that a cipher suite was selected that uses curves before returning the curve used.

### Call-outs:

N/A
### Testing:

Unit tests.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
