### PR TITLE
Add unit test to monitor s2n_connection size changes

### DIFF
--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -50,6 +50,26 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13());
 
+    /* Test s2n_connection does not grow too much.
+     * s2n_connection is a very large structure. We should be working to reduce its
+     * size, not increasing it.
+     * This test documents changes to its size for reviewers so that we can
+     * make very deliberate choices about increasing memory usage.
+     */
+    {
+        /* Carefully consider any increases to this number. */
+        const size_t connection_size = 17936;
+
+        if (sizeof(struct s2n_connection) != connection_size) {
+            const char message[] = "s2n_connection size changed from %lu to %lu. "
+                    "Please verify that this change was intentional and then update this test.";
+            char message_buffer[sizeof(message) + 50] = { 0 };
+            EXPECT_TRUE(snprintf(message_buffer, sizeof(message_buffer), message, connection_size, sizeof(struct s2n_connection))
+                    < sizeof(message_buffer));
+            FAIL_MSG(message_buffer);
+        }
+    }
+
     /* s2n_get_server_name */
     {
         const char* test_server_name = "A server name";

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -55,16 +55,19 @@ int main(int argc, char **argv)
      * size, not increasing it.
      * This test documents changes to its size for reviewers so that we can
      * make very deliberate choices about increasing memory usage.
+     *
+     * We can't easily enforce an exact size for s2n_connection because it varies
+     * based on some settings (like how many KEM groups are supported).
      */
     {
         /* Carefully consider any increases to this number. */
-        const size_t connection_size = 17936;
+        const size_t connection_size = 18656;
 
-        if (sizeof(struct s2n_connection) != connection_size) {
-            const char message[] = "s2n_connection size changed from %lu to %lu. "
+        if (sizeof(struct s2n_connection) > connection_size) {
+            const char message[] = "s2n_connection size (%lu) increased above %lu. "
                     "Please verify that this change was intentional and then update this test.";
             char message_buffer[sizeof(message) + 50] = { 0 };
-            EXPECT_TRUE(snprintf(message_buffer, sizeof(message_buffer), message, connection_size, sizeof(struct s2n_connection))
+            EXPECT_TRUE(snprintf(message_buffer, sizeof(message_buffer), message, sizeof(struct s2n_connection), connection_size)
                     < sizeof(message_buffer));
             FAIL_MSG(message_buffer);
         }

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
      */
     {
         /* Carefully consider any increases to this number. */
-        const size_t connection_size = 18656;
+        const size_t connection_size = 18700;
 
         if (sizeof(struct s2n_connection) > connection_size) {
             const char message[] = "s2n_connection size (%lu) increased above %lu. "

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -61,14 +61,15 @@ int main(int argc, char **argv)
      */
     {
         /* Carefully consider any increases to this number. */
-        const size_t connection_size = 18700;
+        const uint16_t connection_size = 18700;
 
         if (sizeof(struct s2n_connection) > connection_size) {
-            const char message[] = "s2n_connection size (%lu) increased above %lu. "
+            const char message[] = "s2n_connection size (%lu) increased above %i. "
                     "Please verify that this change was intentional and then update this test.";
             char message_buffer[sizeof(message) + 50] = { 0 };
-            EXPECT_TRUE(snprintf(message_buffer, sizeof(message_buffer), message, sizeof(struct s2n_connection), connection_size)
-                    < sizeof(message_buffer));
+            int r = snprintf(message_buffer, sizeof(message_buffer), message,
+                    (unsigned long) sizeof(struct s2n_connection), connection_size);
+            EXPECT_TRUE(r < sizeof(message_buffer));
             FAIL_MSG(message_buffer);
         }
     }

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -61,14 +61,17 @@ int main(int argc, char **argv)
      */
     {
         /* Carefully consider any increases to this number. */
-        const uint16_t connection_size = 18700;
+        const uint16_t max_connection_size = 18700;
+        const uint16_t min_connection_size = max_connection_size * 0.75;
 
-        if (sizeof(struct s2n_connection) > connection_size) {
-            const char message[] = "s2n_connection size (%lu) increased above %i. "
+        size_t connection_size = sizeof(struct s2n_connection);
+
+        if (connection_size > max_connection_size || connection_size < min_connection_size) {
+            const char message[] = "s2n_connection size (%zu) no longer in (%i, %i). "
                     "Please verify that this change was intentional and then update this test.";
-            char message_buffer[sizeof(message) + 50] = { 0 };
+            char message_buffer[sizeof(message) + 100] = { 0 };
             int r = snprintf(message_buffer, sizeof(message_buffer), message,
-                    (unsigned long) sizeof(struct s2n_connection), connection_size);
+                    connection_size, min_connection_size, max_connection_size);
             EXPECT_TRUE(r < sizeof(message_buffer));
             FAIL_MSG(message_buffer);
         }

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -34,7 +34,7 @@
 #define MAX_CONNECTIONS 1000
 
 /* This is roughly the current memory usage per connection */
-#define MEM_PER_CONNECTION (106 * 1024)
+#define MEM_PER_CONNECTION (60 * 1024)
 
 /* This is the maximum memory per connection including 4KB of slack */
 #define MAX_MEM_PER_CONNECTION (MEM_PER_CONNECTION + 4 * 1024)
@@ -92,6 +92,7 @@ int main(int argc, char **argv)
     }
 
     const ssize_t maxAllowedMemDiff = 2 * connectionsToUse * MAX_MEM_PER_CONNECTION;
+    const ssize_t minAllowedMemDiff = maxAllowedMemDiff * 0.75;
 
     struct s2n_connection **clients = calloc(connectionsToUse, sizeof(struct s2n_connection *));
     struct s2n_connection **servers = calloc(connectionsToUse, sizeof(struct s2n_connection *));
@@ -186,6 +187,9 @@ int main(int argc, char **argv)
     EXPECT_TRUE(vm_data_after_handshakes - vm_data_initial < maxAllowedMemDiff);
     EXPECT_TRUE(vm_data_after_free_handshake <= vm_data_after_handshakes);
     EXPECT_TRUE(vm_data_after_release_buffers <= vm_data_after_free_handshake);
+
+    /* If the maximum memory drops too much, we should tighten up the limits in this test. */
+    EXPECT_TRUE(vm_data_after_handshakes - vm_data_initial > minAllowedMemDiff);
 
     END_TEST();
 


### PR DESCRIPTION
### Description of changes: 

I want to ensure future changes don't increase the size of s2n_connection more than their author expects / reviewers are comfortable with. To do this, I add a test to monitor sizeof(struct s2n_connection). Any future change that modifies s2n_connection's size will need to update this test, which will document the memory effect of that change.

To help update the test, the error message reports the correct size:
```
s2n_connection size changed from 17935 to 17936. Please verify that this change was intentional and then update this test. (s2n_connection_test.c line 68)
Error Message: 'no error'
 Debug String: '(null)'
 System Error: No such file or directory (2)
```

I also updated the old memory test. This is the new output:
```
VmData initial:                  532480
VmData after allocations:      19509248
VmData after handshakes:       31494144
VmData after free handshake:   31494144
VmData after release:          31494144
Max VmData diff allowed:       33030144
Number of connections used:         252
```
### Testing:

New unit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
