### PR TITLE
Remove unnecessary hmac copy from connection

### DIFF
--- a/crypto/s2n_hmac.h
+++ b/crypto/s2n_hmac.h
@@ -44,7 +44,6 @@ struct s2n_hmac_state {
     struct s2n_hash_state outer;
     struct s2n_hash_state outer_just_key;
 
-
     /* key needs to be as large as the biggest block size */
     uint8_t xor_pad[128];
 

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -603,7 +603,6 @@ void cbmc_populate_s2n_crypto_parameters(struct s2n_crypto_parameters *s2n_crypt
     cbmc_populate_s2n_hash_state(&(s2n_crypto_parameters->signature_hash));
     cbmc_populate_s2n_hmac_state(&(s2n_crypto_parameters->client_record_mac));
     cbmc_populate_s2n_hmac_state(&(s2n_crypto_parameters->server_record_mac));
-    cbmc_populate_s2n_hmac_state(&(s2n_crypto_parameters->record_mac_copy_workspace));
 }
 
 struct s2n_crypto_parameters *cbmc_allocate_s2n_crypto_parameters()

--- a/tests/sidetrail/working/patches/cbc.patch
+++ b/tests/sidetrail/working/patches/cbc.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/sidetrail/working/s2n-cbc/tls/s2n_cbc.c b/tests/sidetrail/working/s2n-cbc/tls/s2n_cbc.c
-index b37efb0..077d214 100644
+index 679ba1ba..3a76000c 100644
 --- a/tests/sidetrail/working/s2n-cbc/tls/s2n_cbc.c
 +++ b/tests/sidetrail/working/s2n-cbc/tls/s2n_cbc.c
 @@ -25,6 +25,28 @@
@@ -11,7 +11,7 @@ index b37efb0..077d214 100644
 +#include "ct-verif.h"
 +#include "sidetrail.h"
 +
-+/* Because of a bug in SMACK, when we try to specify the invarients for this loop in the main function, 
++/* Because of a bug in SMACK, when we try to specify the invarients for this loop in the main function,
 + * SMACK crashes. Moving the code (unmodified) to this function sidesteps the bug. Michael Emmi has promissed
 + * a fix soon
 + */
@@ -31,14 +31,14 @@ index b37efb0..077d214 100644
  /* A TLS CBC record looks like ..
   *
   * [ Payload data ] [ HMAC ] [ Padding ] [ Padding length byte ]
-@@ -53,17 +75,20 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
-        copy = &conn->server->record_mac_copy_workspace;
-     }
-     
+@@ -47,17 +69,20 @@
+  */
+ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, struct s2n_blob *decrypted)
+ {
 -    uint8_t mac_digest_size;
 -    POSIX_GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));
-+    uint8_t mac_digest_size = DIGEST_SIZE;;
-+    //GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));
++    uint8_t mac_digest_size = DIGEST_SIZE;
++    //POSIX_GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));
  
      /* The record has to be at least big enough to contain the MAC,
       * plus the padding length byte */
@@ -54,16 +54,16 @@ index b37efb0..077d214 100644
  
      int payload_length = MAX(payload_and_padding_size - padding_length - 1, 0);
  
-@@ -82,20 +107,21 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
-     POSIX_GUARD(s2n_hmac_update(copy, decrypted->data + payload_length + mac_digest_size, decrypted->size - payload_length - mac_digest_size - 1));
+@@ -76,20 +101,21 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
+     POSIX_GUARD(s2n_hmac_update(hmac, decrypted->data + payload_length + mac_digest_size, decrypted->size - payload_length - mac_digest_size - 1));
  
      /* SSLv3 doesn't specify what the padding should actually be */
 -    if (conn->actual_protocol_version == S2N_SSLv3) {
 -        return 0 - mismatches;
 -    }
-+    /* if (conn->actual_protocol_version == S2N_SSLv3) { */
-+    /*     return 0 - mismatches; */
-+    /* } */
++    //if (conn->actual_protocol_version == S2N_SSLv3) {
++    //    return 0 - mismatches;
++    //}
  
      /* Check the maximum amount that could theoretically be padding */
      int check = MIN(255, (payload_and_padding_size - 1));
@@ -74,13 +74,13 @@ index b37efb0..077d214 100644
 -        mismatches |= (decrypted->data[j] ^ padding_length) & mask;
 -    }
 +    mismatches = double_loop(mismatches, decrypted, check, cutoff, padding_length);
-+    /* for (uint32_t i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) { */
-+    /*     uint8_t mask = ~(0xff << ((i >= cutoff) * 8)); */
-+    /*     mismatches |= (decrypted->data[j] ^ padding_length) & mask; */
-+    /* } */
++    //for (uint32_t i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
++    //    uint8_t mask = ~(0xff << ((i >= cutoff) * 8));
++    //    mismatches |= (decrypted->data[j] ^ padding_length) & mask;
++    //}
  
--    POSIX_GUARD(s2n_hmac_reset(copy));
-+    /* POSIX_GUARD(s2n_hmac_reset(copy)); */
+-    POSIX_GUARD(s2n_hmac_reset(hmac));
++    //POSIX_GUARD(s2n_hmac_reset(hmac));
  
-     if (mismatches) {
-         POSIX_BAIL(S2N_ERR_CBC_VERIFY);
+     S2N_ERROR_IF(mismatches, S2N_ERR_CBC_VERIFY);
+ 

--- a/tests/sidetrail/working/patches/cbc.patch
+++ b/tests/sidetrail/working/patches/cbc.patch
@@ -1,9 +1,9 @@
 diff --git a/tests/sidetrail/working/s2n-cbc/tls/s2n_cbc.c b/tests/sidetrail/working/s2n-cbc/tls/s2n_cbc.c
-index 679ba1ba..3a76000c 100644
+index 401ab760..f39cc7e2 100644
 --- a/tests/sidetrail/working/s2n-cbc/tls/s2n_cbc.c
 +++ b/tests/sidetrail/working/s2n-cbc/tls/s2n_cbc.c
-@@ -25,6 +25,28 @@
- 
+@@ -26,6 +26,28 @@
+ #include "tls/s2n_connection.h"
  #include "tls/s2n_record.h"
  
 +#include <smack.h>
@@ -31,7 +31,7 @@ index 679ba1ba..3a76000c 100644
  /* A TLS CBC record looks like ..
   *
   * [ Payload data ] [ HMAC ] [ Padding ] [ Padding length byte ]
-@@ -47,17 +69,20 @@
+@@ -48,23 +70,28 @@
   */
  int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, struct s2n_blob *decrypted)
  {
@@ -54,7 +54,15 @@ index 679ba1ba..3a76000c 100644
  
      int payload_length = MAX(payload_and_padding_size - padding_length - 1, 0);
  
-@@ -76,20 +101,21 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
+     /* Update the MAC */
+     POSIX_GUARD(s2n_hmac_update(hmac, decrypted->data, payload_length));
+     int currently_in_hash_block = hmac->currently_in_hash_block;
++    __VERIFIER_assume(currently_in_hash_block >= 0);
++    __VERIFIER_assume(currently_in_hash_block < BLOCK_SIZE);
+ 
+     /* Check the MAC */
+     uint8_t check_digest[S2N_MAX_DIGEST_LEN];
+@@ -81,18 +108,19 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
      POSIX_GUARD(s2n_hmac_update(hmac, decrypted->data + payload_length + mac_digest_size, decrypted->size - payload_length - mac_digest_size - 1));
  
      /* SSLv3 doesn't specify what the padding should actually be */
@@ -78,9 +86,6 @@ index 679ba1ba..3a76000c 100644
 +    //    uint8_t mask = ~(0xff << ((i >= cutoff) * 8));
 +    //    mismatches |= (decrypted->data[j] ^ padding_length) & mask;
 +    //}
- 
--    POSIX_GUARD(s2n_hmac_reset(hmac));
-+    //POSIX_GUARD(s2n_hmac_reset(hmac));
  
      S2N_ERROR_IF(mismatches, S2N_ERR_CBC_VERIFY);
  

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
      */
     {
         /* Carefully consider any increases to this number. */
-        const uint16_t max_connection_size = 19584;
+        const uint16_t max_connection_size = 17248;
         const uint16_t min_connection_size = max_connection_size * 0.75;
 
         size_t connection_size = sizeof(struct s2n_connection);

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -34,7 +34,7 @@
 #define MAX_CONNECTIONS 1000
 
 /* This is roughly the current memory usage per connection */
-#define MEM_PER_CONNECTION (60 * 1024)
+#define MEM_PER_CONNECTION (58 * 1024)
 
 /* This is the maximum memory per connection including 4KB of slack */
 #define MAX_MEM_PER_CONNECTION (MEM_PER_CONNECTION + 4 * 1024)

--- a/tls/s2n_cbc.c
+++ b/tls/s2n_cbc.c
@@ -64,6 +64,7 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
 
     /* Update the MAC */
     POSIX_GUARD(s2n_hmac_update(hmac, decrypted->data, payload_length));
+    int currently_in_hash_block = hmac->currently_in_hash_block;
 
     /* Check the MAC */
     uint8_t check_digest[S2N_MAX_DIGEST_LEN];
@@ -72,8 +73,11 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
 
     int mismatches = s2n_constant_time_equals(decrypted->data + payload_length, check_digest, mac_digest_size) ^ 1;
 
-    /* Compute a MAC on the rest of the data so that we perform the same number of hash operations */
+    /* Compute a MAC on the rest of the data so that we perform the same number of hash operations.
+     * Include the partial hash block from the first MAC to ensure we use the same number of blocks.
+     */
     POSIX_GUARD(s2n_hmac_reset(hmac));
+    POSIX_GUARD(s2n_hmac_update(hmac, decrypted->data, currently_in_hash_block));
     POSIX_GUARD(s2n_hmac_update(hmac, decrypted->data + payload_length + mac_digest_size, decrypted->size - payload_length - mac_digest_size - 1));
 
     /* SSLv3 doesn't specify what the padding should actually be */
@@ -89,8 +93,6 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
         uint8_t mask = ~(0xff << ((i >= cutoff) * 8));
         mismatches |= (decrypted->data[j] ^ padding_length) & mask;
     }
-
-    POSIX_GUARD(s2n_hmac_reset(hmac));
 
     S2N_ERROR_IF(mismatches, S2N_ERR_CBC_VERIFY);
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -133,10 +133,8 @@ static int s2n_connection_new_hmacs(struct s2n_connection *conn)
     /* Allocate long-term memory for the Connection's HMAC states */
     POSIX_GUARD(s2n_hmac_new(&conn->initial.client_record_mac));
     POSIX_GUARD(s2n_hmac_new(&conn->initial.server_record_mac));
-    POSIX_GUARD(s2n_hmac_new(&conn->initial.record_mac_copy_workspace));
     POSIX_GUARD(s2n_hmac_new(&conn->secure.client_record_mac));
     POSIX_GUARD(s2n_hmac_new(&conn->secure.server_record_mac));
-    POSIX_GUARD(s2n_hmac_new(&conn->secure.record_mac_copy_workspace));
 
     return 0;
 }
@@ -146,10 +144,8 @@ static int s2n_connection_init_hmacs(struct s2n_connection *conn)
     /* Initialize all of the Connection's HMAC states */
     POSIX_GUARD(s2n_hmac_init(&conn->initial.client_record_mac, S2N_HMAC_NONE, NULL, 0));
     POSIX_GUARD(s2n_hmac_init(&conn->initial.server_record_mac, S2N_HMAC_NONE, NULL, 0));
-    POSIX_GUARD(s2n_hmac_init(&conn->initial.record_mac_copy_workspace, S2N_HMAC_NONE, NULL, 0));
     POSIX_GUARD(s2n_hmac_init(&conn->secure.client_record_mac, S2N_HMAC_NONE, NULL, 0));
     POSIX_GUARD(s2n_hmac_init(&conn->secure.server_record_mac, S2N_HMAC_NONE, NULL, 0));
-    POSIX_GUARD(s2n_hmac_init(&conn->secure.record_mac_copy_workspace, S2N_HMAC_NONE, NULL, 0));
 
     return 0;
 }
@@ -340,10 +336,8 @@ static int s2n_connection_reset_hmacs(struct s2n_connection *conn)
     /* Reset all of the Connection's HMAC states */
     POSIX_GUARD(s2n_hmac_reset(&conn->initial.client_record_mac));
     POSIX_GUARD(s2n_hmac_reset(&conn->initial.server_record_mac));
-    POSIX_GUARD(s2n_hmac_reset(&conn->initial.record_mac_copy_workspace));
     POSIX_GUARD(s2n_hmac_reset(&conn->secure.client_record_mac));
     POSIX_GUARD(s2n_hmac_reset(&conn->secure.server_record_mac));
-    POSIX_GUARD(s2n_hmac_reset(&conn->secure.record_mac_copy_workspace));
 
     return 0;
 }
@@ -408,10 +402,8 @@ static int s2n_connection_free_hmacs(struct s2n_connection *conn)
     /* Free all of the Connection's HMAC states */
     POSIX_GUARD(s2n_hmac_free(&conn->initial.client_record_mac));
     POSIX_GUARD(s2n_hmac_free(&conn->initial.server_record_mac));
-    POSIX_GUARD(s2n_hmac_free(&conn->initial.record_mac_copy_workspace));
     POSIX_GUARD(s2n_hmac_free(&conn->secure.client_record_mac));
     POSIX_GUARD(s2n_hmac_free(&conn->secure.server_record_mac));
-    POSIX_GUARD(s2n_hmac_free(&conn->secure.record_mac_copy_workspace));
 
     return 0;
 }

--- a/tls/s2n_connection_evp_digests.c
+++ b/tls/s2n_connection_evp_digests.c
@@ -72,10 +72,8 @@ int s2n_connection_save_hmac_state(struct s2n_connection_hmac_handles *hmac_hand
 {
     POSIX_GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->initial_client, &conn->initial.client_record_mac));
     POSIX_GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->initial_server, &conn->initial.server_record_mac));
-    POSIX_GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->initial_client_copy, &conn->initial.record_mac_copy_workspace));
     POSIX_GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->secure_client, &conn->secure.client_record_mac));
     POSIX_GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->secure_server, &conn->secure.server_record_mac));
-    POSIX_GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->secure_client_copy, &conn->secure.record_mac_copy_workspace));
     return 0;
 }
 
@@ -134,9 +132,7 @@ int s2n_connection_restore_hmac_state(struct s2n_connection *conn, struct s2n_co
 {
     POSIX_GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->initial_client, &conn->initial.client_record_mac));
     POSIX_GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->initial_server, &conn->initial.server_record_mac));
-    POSIX_GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->initial_client_copy, &conn->initial.record_mac_copy_workspace));
     POSIX_GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->secure_client, &conn->secure.client_record_mac));
     POSIX_GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->secure_server, &conn->secure.server_record_mac));
-    POSIX_GUARD(s2n_hmac_restore_evp_hash_state(&hmac_handles->secure_client_copy, &conn->secure.record_mac_copy_workspace));
     return 0;
 }

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -67,7 +67,6 @@ struct s2n_crypto_parameters {
     struct s2n_hash_state signature_hash;
     struct s2n_hmac_state client_record_mac;
     struct s2n_hmac_state server_record_mac;
-    struct s2n_hmac_state record_mac_copy_workspace;
     uint8_t client_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
     uint8_t server_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
 };

--- a/tls/s2n_record_read_cbc.c
+++ b/tls/s2n_record_read_cbc.c
@@ -105,7 +105,7 @@ int s2n_record_parse_cbc(
     struct s2n_blob seq = {.data = sequence_number,.size = S2N_TLS_SEQUENCE_NUM_LEN };
     POSIX_GUARD(s2n_increment_sequence_number(&seq));
 
-    /* Padding */
+    /* Padding. This destroys the mac. */
     if (s2n_verify_cbc(conn, mac, &en) < 0) {
         POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
         POSIX_BAIL(S2N_ERR_BAD_MESSAGE);

--- a/tls/s2n_record_read_cbc.c
+++ b/tls/s2n_record_read_cbc.c
@@ -105,7 +105,7 @@ int s2n_record_parse_cbc(
     struct s2n_blob seq = {.data = sequence_number,.size = S2N_TLS_SEQUENCE_NUM_LEN };
     POSIX_GUARD(s2n_increment_sequence_number(&seq));
 
-    /* Padding. This destroys the mac. */
+    /* Padding. This finalizes the provided HMAC. */
     if (s2n_verify_cbc(conn, mac, &en) < 0) {
         POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
         POSIX_BAIL(S2N_ERR_BAD_MESSAGE);


### PR DESCRIPTION
### Description of changes: 

The record macs aren't used after s2n_record_parse, so there's no need to preserve the original mac structure. `s2n_record_parse_stream` also calculates the HMAC, but doesn't use a copy.

This cuts another 2kb off of the connection object.

### Call-outs:

The main use of the copy previously was to ensure a constant time operation. We should pay particular attention to whether the updated code is constant time.

### Testing:

Existing tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
