### PR TITLE
Suggestion: Prevent randomness callbacks being set to NULL

### DIFF
--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -82,10 +82,10 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_disable_tls13());
 
     /* Verify that randomness callbacks can't be set to NULL */
-    EXPECT_ERROR(s2n_rand_set_callbacks(NULL, cleanup, entropy, entropy));
-    EXPECT_ERROR(s2n_rand_set_callbacks(init, NULL, entropy, entropy));
-    EXPECT_ERROR(s2n_rand_set_callbacks(init, cleanup, NULL, entropy));
-    EXPECT_ERROR(s2n_rand_set_callbacks(init, cleanup, entropy, NULL));
+    EXPECT_FAILURE(s2n_rand_set_callbacks(NULL, cleanup, entropy, entropy));
+    EXPECT_FAILURE(s2n_rand_set_callbacks(init, NULL, entropy, entropy));
+    EXPECT_FAILURE(s2n_rand_set_callbacks(init, cleanup, NULL, entropy));
+    EXPECT_FAILURE(s2n_rand_set_callbacks(init, cleanup, entropy, NULL));
 
     /* Get one byte of data, to make sure the pool is (almost) full */
     blob.size = 1;

--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -54,6 +54,18 @@ void process_safety_tester(int write_fd)
     _exit(0);
 }
 
+static int init(void) {
+    return S2N_SUCCESS;
+}
+
+static int cleanup(void) {
+    return S2N_SUCCESS;
+}
+
+static int entropy(void *ptr, uint32_t size) {
+    return S2N_SUCCESS;
+}
+
 int main(int argc, char **argv)
 {
     uint8_t bits[8] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 };
@@ -68,6 +80,12 @@ int main(int argc, char **argv)
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13());
+
+    /* Verify that randomness callbacks can't be set to NULL */
+    EXPECT_ERROR(s2n_rand_set_callbacks(NULL, cleanup, entropy, entropy));
+    EXPECT_ERROR(s2n_rand_set_callbacks(init, NULL, entropy, entropy));
+    EXPECT_ERROR(s2n_rand_set_callbacks(init, cleanup, NULL, entropy));
+    EXPECT_ERROR(s2n_rand_set_callbacks(init, cleanup, entropy, NULL));
 
     /* Get one byte of data, to make sure the pool is (almost) full */
     blob.size = 1;

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -98,6 +98,10 @@ int s2n_rand_set_callbacks(s2n_rand_init_callback rand_init_callback,
                              s2n_rand_seed_callback rand_seed_callback,
                              s2n_rand_mix_callback rand_mix_callback)
 {
+    RESULT_ENSURE_REF(rand_init_callback);
+    RESULT_ENSURE_REF(rand_cleanup_callback);
+    RESULT_ENSURE_REF(rand_seed_callback);
+    RESULT_ENSURE_REF(rand_mix_callback);
     s2n_rand_init_cb = rand_init_callback;
     s2n_rand_cleanup_cb = rand_cleanup_callback;
     s2n_rand_seed_cb = rand_seed_callback;

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -98,10 +98,10 @@ int s2n_rand_set_callbacks(s2n_rand_init_callback rand_init_callback,
                              s2n_rand_seed_callback rand_seed_callback,
                              s2n_rand_mix_callback rand_mix_callback)
 {
-    RESULT_ENSURE_REF(rand_init_callback);
-    RESULT_ENSURE_REF(rand_cleanup_callback);
-    RESULT_ENSURE_REF(rand_seed_callback);
-    RESULT_ENSURE_REF(rand_mix_callback);
+    POSIX_ENSURE_REF(rand_init_callback);
+    POSIX_ENSURE_REF(rand_cleanup_callback);
+    POSIX_ENSURE_REF(rand_seed_callback);
+    POSIX_ENSURE_REF(rand_mix_callback);
     s2n_rand_init_cb = rand_init_callback;
     s2n_rand_cleanup_cb = rand_cleanup_callback;
     s2n_rand_seed_cb = rand_seed_callback;


### PR DESCRIPTION
### Resolved issues:

### Description of changes: 

Mis-use hardening suggestion below.

The public function `s2n_rand_set_callbacks` can be called with `NULL` arguments, setting randomness function callbacks to `NULL`:
```
int s2n_rand_set_callbacks(s2n_rand_init_callback rand_init_callback,
                             s2n_rand_cleanup_callback rand_cleanup_callback,
                             s2n_rand_seed_callback rand_seed_callback,
                             s2n_rand_mix_callback rand_mix_callback)
{
    s2n_rand_init_cb = rand_init_callback;
    s2n_rand_cleanup_cb = rand_cleanup_callback;
    s2n_rand_seed_cb = rand_seed_callback;
    s2n_rand_mix_cb = rand_mix_callback;

    return S2N_SUCCESS;
}
```

This can result in `NULL`-dereferences later in program execution. For example, when the DRBG code calls either `s2n_get_seed_entropy` or `s2n_get_mix_entropy` (if these have been set to `NULL` of course).

Granted, this is minor issue, but still a somewhat semi-loaded foot-gun.

I can envision defending against it using various levels of paranoia:
1. Prevent callbacks from being set to `NULL` (that's what this PR does).
2. Check for `NULL` in each function dereferencing the callback.
3. Add function documentation with a contract stating `NULL` is not an allowed input.

### Call-outs:

(1) above changes the behaviour of `s2n_rand_set_callbacks`, because it now rejects `NULL` arguments. (2) would maintain the current behaviour. 

### Testing:

 Added unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
