### PR TITLE
bindings: export include dir in rust build

### DIFF
--- a/bindings/rust/generate.sh
+++ b/bindings/rust/generate.sh
@@ -33,3 +33,7 @@ cd s2n-tls-sys \
   && cargo test --release \
   && cargo test --features quic \
   && cd ..
+
+cd integration \
+  && cargo run \
+  && cd ..

--- a/bindings/rust/generate/Cargo.toml
+++ b/bindings/rust/generate/Cargo.toml
@@ -10,4 +10,3 @@ publish = false
 [dependencies]
 bindgen = "0.58"
 glob = "0.3"
-heck = "0.3"

--- a/bindings/rust/generate/src/main.rs
+++ b/bindings/rust/generate/src/main.rs
@@ -64,9 +64,7 @@ fn gen_bindings(entry: &str, s2n_dir: &Path) -> bindgen::Builder {
         .rustfmt_bindings(true)
         .header_contents("s2n-sys.h", entry)
         .enable_function_attribute_detection()
-        .default_enum_style(bindgen::EnumVariation::Rust {
-            non_exhaustive: true,
-        })
+        .default_enum_style(bindgen::EnumVariation::ModuleConsts)
         .rust_target(bindgen::RustTarget::Stable_1_40)
         // only export s2n-related stuff
         .blocklist_type("iovec")
@@ -77,7 +75,6 @@ fn gen_bindings(entry: &str, s2n_dir: &Path) -> bindgen::Builder {
         // rust can't access thread-local variables
         // https://github.com/rust-lang/rust/issues/29594
         .blocklist_item("s2n_errno")
-        .rustified_enum("s2n_.*")
         .raw_line(COPYRIGHT)
         .raw_line(PRELUDE)
         .ctypes_prefix("::libc")
@@ -120,8 +117,6 @@ impl bindgen::callbacks::ParseCallbacks for S2nCallbacks {
         variant_name: &str,
         _variant_value: bindgen::callbacks::EnumVariantValue,
     ) -> Option<String> {
-        use heck::CamelCase;
-
         if !variant_name.starts_with("S2N_") {
             return None;
         }
@@ -135,10 +130,18 @@ impl bindgen::callbacks::ParseCallbacks for S2nCallbacks {
             .trim_start_matches("S2N_CT_SUPPORT_")
             .trim_start_matches("S2N_STATUS_REQUEST_")
             .trim_start_matches("S2N_CERT_AUTH_")
+            .trim_start_matches("S2N_CLIENT_HELLO_CB_")
+            .trim_start_matches("S2N_TLS_SIGNATURE_")
+            .trim_start_matches("S2N_TLS_HASH_")
+            .trim_start_matches("S2N_PSK_HMAC_")
+            .trim_start_matches("S2N_PSK_MODE_")
+            .trim_start_matches("S2N_ASYNC_PKEY_VALIDATION_")
+            .trim_start_matches("S2N_ASYNC_")
+            .trim_start_matches("S2N_EARLY_DATA_STATUS_")
             // match everything else
             .trim_start_matches("S2N_");
 
-        Some(variant_name.to_camel_case())
+        Some(variant_name.to_owned())
     }
 }
 

--- a/bindings/rust/integration/Cargo.toml
+++ b/bindings/rust/integration/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "integration"
+version = "0.1.0"
+authors = ["AWS s2n"]
+edition = "2018"
+publish = false
+
+[dependencies]
+s2n-tls-sys = { version = "0.1", path = "../s2n-tls-sys" }

--- a/bindings/rust/integration/build.rs
+++ b/bindings/rust/integration/build.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+
+fn main() {
+    // ensure the build script exports the include directory
+    let include_dir = std::env::var("DEP_S2N_TLS_INCLUDE").expect("missing DEP_S2N_TLS_INCLUDE");
+    let include_dir = PathBuf::from(include_dir);
+
+    // make sure that `s2n.h` is available
+    let api = std::fs::read_to_string(include_dir.join("s2n.h")).unwrap();
+    assert!(api.contains("s2n_negotiate"));
+}

--- a/bindings/rust/integration/src/main.rs
+++ b/bindings/rust/integration/src/main.rs
@@ -1,0 +1,12 @@
+use s2n_tls_sys::*;
+
+fn main() {
+    unsafe {
+        s2n_init();
+        let conn = s2n_connection_new(s2n_mode::SERVER);
+
+        if !conn.is_null() {
+            s2n_connection_free(conn);
+        }
+    }
+}


### PR DESCRIPTION
### Description of changes: 

Consumers of the rust `s2n-tls-sys` crate may need to include the C header as part of their build. This PR
* Exports the include dir and copies the `api/s2n.h` header into it
* Adds an integration test to ensure the include dir is exported

### Testing:
The integration test is sufficient in ensuring the expected outcome. This will automatically be executed as part of the generate script.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
