### PR TITLE
bindings: import "mid-level" bindings

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "generate",
+    "integration",
     "s2n-tls",
     "s2n-tls-sys",
 ]

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,0 +1,16 @@
+[workspace]
+members = [
+    "generate",
+    "s2n-tls",
+    "s2n-tls-sys",
+]
+
+[profile.release]
+lto = true
+codegen-units = 1
+incremental = false
+
+[profile.bench]
+lto = true
+codegen-units = 1
+incremental = false

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -1,5 +1,8 @@
 # s2n-tls rust bindings
 
+**NOTICE: These bindings are currently subject to change and should not be used without the expectation
+of future breakage.**
+
 ## Installation
 
 In order to generate rust bindings for s2n-tls, you need to have the following installed:

--- a/bindings/rust/s2n-tls-sys/src/lib.rs
+++ b/bindings/rust/s2n-tls-sys/src/lib.rs
@@ -11,5 +11,24 @@ mod quic;
 #[cfg(feature = "quic")]
 pub use quic::*;
 
+// Additional defines that don't get imported with bindgen
+
+pub mod s2n_status_code {
+    pub type Type = libc::c_int;
+    pub const SUCCESS: Type = 0;
+    pub const FAILURE: Type = -1;
+}
+
+pub mod s2n_tls_version {
+    pub type Type = libc::c_int;
+    pub const SSLV2: Type = 20;
+    pub const SSLV3: Type = 30;
+    pub const TLS10: Type = 31;
+    pub const TLS11: Type = 32;
+    pub const TLS12: Type = 33;
+    pub const TLS13: Type = 34;
+    pub const UNKNOWN: Type = 0;
+}
+
 #[cfg(test)]
 mod tests;

--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "s2n-tls"
+version = "0.1.0"
+authors = ["AWS s2n"]
+edition = "2018"
+license = "Apache-2.0"
+
+[features]
+default = []
+quic = []
+
+[dependencies]
+libc = "0.2"
+s2n-tls-sys = { version = "0.1", path = "../s2n-tls-sys" }

--- a/bindings/rust/s2n-tls/src/lib.rs
+++ b/bindings/rust/s2n-tls/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+extern crate alloc;
+
+pub mod raw;

--- a/bindings/rust/s2n-tls/src/raw.rs
+++ b/bindings/rust/s2n-tls/src/raw.rs
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[macro_use]
+pub mod error;
+
+pub mod config;
+pub mod connection;
+pub mod init;
+
+pub use s2n_tls_sys as fii;

--- a/bindings/rust/s2n-tls/src/raw/config.rs
+++ b/bindings/rust/s2n-tls/src/raw/config.rs
@@ -1,0 +1,180 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::raw::error::Error;
+use alloc::rc::Rc;
+use core::convert::TryInto;
+use s2n_tls_sys::*;
+use std::ffi::CString;
+
+struct Owned(*mut s2n_config);
+
+impl Default for Owned {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Owned {
+    fn new() -> Self {
+        crate::raw::init::init();
+        let config = call!(s2n_config_new()).unwrap();
+        Self(config)
+    }
+
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut s2n_config {
+        self.0
+    }
+}
+
+impl Drop for Owned {
+    fn drop(&mut self) {
+        let _ = call!(s2n_config_free(self.0));
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct Config(Rc<Owned>);
+
+impl Config {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn builder() -> Builder {
+        Builder::default()
+    }
+
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut s2n_config {
+        (self.0).0
+    }
+}
+
+#[derive(Default)]
+pub struct Builder(Owned);
+
+impl Builder {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn set_alert_behavior(
+        &mut self,
+        value: s2n_alert_behavior::Type,
+    ) -> Result<&mut Self, Error> {
+        call!(s2n_config_set_alert_behavior(self.as_mut_ptr(), value))?;
+        Ok(self)
+    }
+
+    pub fn set_cipher_preference(&mut self, name: &str) -> Result<&mut Self, Error> {
+        let name = CString::new(name).map_err(|_| Error::InvalidInput)?;
+        call!(s2n_config_set_cipher_preferences(
+            self.as_mut_ptr(),
+            name.as_ptr() as *const _
+        ))?;
+        Ok(self)
+    }
+
+    /// sets the application protocol preferences on an s2n_config object.
+    ///
+    /// protocols is a list in order of preference, with most preferred protocol first,
+    /// and of length protocol_count. When acting as an S2N_CLIENT the protocol list is
+    /// included in the Client Hello message as the ALPN extension. As an S2N_SERVER, the
+    /// list is used to negotiate a mutual application protocol with the client. After
+    /// the negotiation for the connection has completed, the agreed upon protocol can
+    /// be retrieved with s2n_get_application_protocol
+    pub fn set_alpn_preference<P: IntoIterator<Item = I>, I: AsRef<[u8]>>(
+        &mut self,
+        protocols: P,
+    ) -> Result<(), Error> {
+        // reset the list
+        call!(s2n_config_set_protocol_preferences(
+            self.as_mut_ptr(),
+            core::ptr::null(),
+            0
+        ))?;
+
+        for protocol in protocols {
+            self.append_alpn_preference(protocol.as_ref())?;
+        }
+
+        Ok(())
+    }
+
+    pub fn load_pem(&mut self, certificate: &[u8], private_key: &[u8]) -> Result<&mut Self, Error> {
+        let certificate = CString::new(certificate).map_err(|_| Error::InvalidInput)?;
+        let private_key = CString::new(private_key).map_err(|_| Error::InvalidInput)?;
+        call!(s2n_config_add_cert_chain_and_key(
+            self.as_mut_ptr(),
+            certificate.as_ptr(),
+            private_key.as_ptr()
+        ))?;
+        Ok(self)
+    }
+
+    pub fn trust_pem(&mut self, certificate: &[u8]) -> Result<&mut Self, Error> {
+        let certificate = CString::new(certificate).map_err(|_| Error::InvalidInput)?;
+        call!(s2n_config_add_pem_to_trust_store(
+            self.as_mut_ptr(),
+            certificate.as_ptr(),
+        ))?;
+        Ok(self)
+    }
+
+    pub fn append_alpn_preference(&mut self, protocol: &[u8]) -> Result<&mut Self, Error> {
+        call!(s2n_config_append_protocol_preference(
+            self.as_mut_ptr(),
+            protocol.as_ptr(),
+            protocol.len().try_into().map_err(|_| Error::InvalidInput)?,
+        ))?;
+        Ok(self)
+    }
+
+    /// # Safety
+    ///
+    /// The `context` pointer must live at least as long as the config
+    pub unsafe fn set_verify_host_callback(
+        &mut self,
+        callback: s2n_verify_host_fn,
+        context: *mut core::ffi::c_void,
+    ) -> Result<&mut Self, Error> {
+        call!(s2n_config_set_verify_host_callback(
+            self.as_mut_ptr(),
+            callback,
+            context
+        ))?;
+        Ok(self)
+    }
+
+    /// # Safety
+    ///
+    /// The `context` pointer must live at least as long as the config
+    pub unsafe fn set_key_log_callback(
+        &mut self,
+        callback: s2n_key_log_fn,
+        context: *mut core::ffi::c_void,
+    ) -> Result<&mut Self, Error> {
+        call!(s2n_config_set_key_log_cb(
+            self.as_mut_ptr(),
+            callback,
+            context
+        ))?;
+        Ok(self)
+    }
+
+    pub fn build(self) -> Result<Config, Error> {
+        Ok(Config(Rc::new(self.0)))
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut s2n_config {
+        self.0.as_mut_ptr()
+    }
+}
+
+#[cfg(feature = "quic")]
+impl Builder {
+    pub fn enable_quic(&mut self) -> Result<&mut Self, Error> {
+        call!(s2n_tls_sys::s2n_config_enable_quic(self.as_mut_ptr()))?;
+        Ok(self)
+    }
+}

--- a/bindings/rust/s2n-tls/src/raw/connection.rs
+++ b/bindings/rust/s2n-tls/src/raw/connection.rs
@@ -1,0 +1,260 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::missing_safety_doc)] // TODO add safety docs
+
+use crate::raw::{config::Config, error::Error};
+use core::{convert::TryInto, fmt, task::Poll};
+use libc::c_void;
+use s2n_tls_sys::*;
+
+pub use s2n_tls_sys::s2n_mode;
+
+pub struct Connection {
+    connection: *mut s2n_connection,
+    // The config needs to be stored so the reference count is accurate
+    #[allow(dead_code)]
+    config: Option<Config>,
+}
+
+impl fmt::Debug for Connection {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Connection")
+            // TODO add paths
+            .finish()
+    }
+}
+
+impl Connection {
+    pub fn new(mode: s2n_mode::Type) -> Self {
+        crate::raw::init::init();
+        let connection = call!(s2n_connection_new(mode)).unwrap();
+        Self {
+            connection,
+            config: None,
+        }
+    }
+
+    /// can be used to configure s2n to either use built-in blinding (set blinding
+    /// to S2N_BUILT_IN_BLINDING) or self-service blinding (set blinding to
+    /// S2N_SELF_SERVICE_BLINDING).
+    pub fn set_blinding(&mut self, blinding: s2n_blinding::Type) -> Result<(), Error> {
+        call!(s2n_connection_set_blinding(self.connection, blinding))?;
+        Ok(())
+    }
+
+    /// Sets whether or not a Client Certificate should be required to complete the TLS Connection.
+    ///
+    /// If this is set to S2N_CERT_AUTH_OPTIONAL the server will request a client certificate
+    /// but allow the client to not provide one. Rejecting a client certificate when using
+    /// S2N_CERT_AUTH_OPTIONAL will terminate the handshake.
+    pub fn set_client_auth_type(
+        &mut self,
+        client_auth_type: s2n_cert_auth_type::Type,
+    ) -> Result<(), Error> {
+        call!(s2n_connection_set_client_auth_type(
+            self.connection,
+            client_auth_type
+        ))?;
+        Ok(())
+    }
+
+    /// Associates a configuration object with a connection.
+    pub fn set_config(&mut self, mut config: Config) -> Result<(), Error> {
+        call!(s2n_connection_set_config(
+            self.connection,
+            config.as_mut_ptr(),
+        ))?;
+        self.config = Some(config);
+        Ok(())
+    }
+
+    /// provides a smooth transition from s2n_connection_prefer_low_latency to s2n_connection_prefer_throughput.
+    ///
+    /// s2n_send uses small TLS records that fit into a single TCP segment for the resize_threshold
+    /// bytes (cap to 8M) of data and reset record size back to a single segment after timeout_threshold
+    /// seconds of inactivity.
+    pub fn set_dynamic_record_threshold(
+        &mut self,
+        resize_threshold: u32,
+        timeout_threshold: u16,
+    ) -> Result<(), Error> {
+        call!(s2n_connection_set_dynamic_record_threshold(
+            self.connection,
+            resize_threshold,
+            timeout_threshold
+        ))?;
+        Ok(())
+    }
+
+    /// sets the application protocol preferences on an s2n_connection object.
+    ///
+    /// protocols is a list in order of preference, with most preferred protocol first, and of
+    /// length protocol_count. When acting as an S2N_CLIENT the protocol list is included in the
+    /// Client Hello message as the ALPN extension. As an S2N_SERVER, the list is used to negotiate
+    /// a mutual application protocol with the client. After the negotiation for the connection has
+    /// completed, the agreed upon protocol can be retrieved with s2n_get_application_protocol
+    pub fn set_alpn_preference<P: IntoIterator<Item = I>, I: AsRef<[u8]>>(
+        &mut self,
+        protocols: P,
+    ) -> Result<(), Error> {
+        // reset the list
+        call!(s2n_connection_set_protocol_preferences(
+            self.connection,
+            core::ptr::null(),
+            0
+        ))?;
+
+        for protocol in protocols {
+            self.append_alpn_preference(protocol.as_ref())?;
+        }
+
+        Ok(())
+    }
+
+    pub fn append_alpn_preference(&mut self, protocol: &[u8]) -> Result<&mut Self, Error> {
+        call!(s2n_connection_append_protocol_preference(
+            self.connection,
+            protocol.as_ptr(),
+            protocol.len().try_into().map_err(|_| Error::InvalidInput)?,
+        ))?;
+        Ok(self)
+    }
+
+    /// may be used to receive data with callbacks defined by the user.
+    pub fn set_receive_callback(&mut self, callback: s2n_recv_fn) -> Result<(), Error> {
+        call!(s2n_connection_set_recv_cb(self.connection, callback))?;
+        Ok(())
+    }
+
+    /// # Safety
+    ///
+    /// The `context` pointer must live at least as long as the connection
+    pub unsafe fn set_receive_context(&mut self, context: *mut c_void) -> Result<(), Error> {
+        call!(s2n_connection_set_recv_ctx(self.connection, context))?;
+        Ok(())
+    }
+
+    /// may be used to receive data with callbacks defined by the user.
+    pub fn set_send_callback(&mut self, callback: s2n_send_fn) -> Result<(), Error> {
+        call!(s2n_connection_set_send_cb(self.connection, callback))?;
+        Ok(())
+    }
+
+    /// # Safety
+    ///
+    /// The `context` pointer must live at least as long as the connection
+    pub unsafe fn set_send_context(&mut self, context: *mut c_void) -> Result<(), Error> {
+        call!(s2n_connection_set_send_ctx(self.connection, context))?;
+        Ok(())
+    }
+
+    /// Connections prefering low latency will be encrypted using small record sizes that
+    /// can be decrypted sooner by the recipient.
+    pub fn prefer_low_latency(&mut self) -> Result<(), Error> {
+        call!(s2n_connection_prefer_low_latency(self.connection))?;
+        Ok(())
+    }
+
+    /// Connections prefering throughput will use large record sizes that minimize overhead.
+    pub fn prefer_throughput(&mut self) -> Result<(), Error> {
+        call!(s2n_connection_prefer_throughput(self.connection))?;
+        Ok(())
+    }
+
+    /// wipes and free the in and out buffers associated with a connection.
+    ///
+    /// This function may be called when a connection is in keep-alive or idle state to
+    /// reduce memory overhead of long lived connections.
+    pub fn release_buffers(&mut self) -> Result<(), Error> {
+        call!(s2n_connection_release_buffers(self.connection))?;
+        Ok(())
+    }
+
+    pub fn use_corked_io(&mut self) -> Result<(), Error> {
+        call!(s2n_connection_use_corked_io(self.connection))?;
+        Ok(())
+    }
+
+    /// wipes an existing connection and allows it to be reused.
+    ///
+    /// This method erases all data associated with a connection including pending reads.
+    /// This function should be called after all I/O is completed and s2n_shutdown has been
+    /// called. Reusing the same connection handle(s) is more performant than repeatedly
+    /// calling s2n_connection_new and s2n_connection_free
+    pub fn wipe(&mut self) -> Result<(), Error> {
+        call!(s2n_connection_wipe(self.connection))?;
+        Ok(())
+    }
+
+    /// Performs the TLS handshake to completion
+    pub fn negotiate(&mut self) -> Poll<Result<(), Error>> {
+        let mut blocked = s2n_blocked_status::NOT_BLOCKED;
+
+        match call!(s2n_negotiate(self.connection, &mut blocked)) {
+            Ok(_) => Ok(()).into(),
+            Err(err) if err.kind() == s2n_error_type::BLOCKED => Poll::Pending,
+            Err(err) => Err(err).into(),
+        }
+    }
+
+    /// Returns the TLS alert code, if any
+    pub fn alert(&self) -> Option<u8> {
+        let alert = call!(s2n_connection_get_alert(self.connection)).ok()?;
+        Some(alert as u8)
+    }
+
+    /// Sets the SNI value for the connection
+    pub fn set_sni(&mut self, sni: &[u8]) -> Result<(), Error> {
+        let sni = std::ffi::CString::new(sni).map_err(|_| Error::InvalidInput)?;
+        call!(s2n_set_server_name(self.connection, sni.as_ptr()))?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "quic")]
+impl Connection {
+    pub fn set_quic_transport_parameters(&mut self, buffer: &[u8]) -> Result<(), Error> {
+        call!(s2n_connection_set_quic_transport_parameters(
+            self.connection,
+            buffer.as_ptr(),
+            buffer.len().try_into().map_err(|_| Error::InvalidInput)?,
+        ))?;
+        Ok(())
+    }
+
+    pub fn quic_transport_parameters(&mut self) -> Result<&[u8], Error> {
+        let mut ptr = core::ptr::null();
+        let mut len = 0;
+        call!(s2n_connection_get_quic_transport_parameters(
+            self.connection,
+            &mut ptr,
+            &mut len,
+        ))?;
+        let buffer = unsafe { core::slice::from_raw_parts(ptr, len as _) };
+        Ok(buffer)
+    }
+
+    /// # Safety
+    ///
+    /// The `context` pointer must live at least as long as the connection
+    pub unsafe fn set_secret_callback(
+        &mut self,
+        callback: s2n_secret_cb,
+        context: *mut c_void,
+    ) -> Result<(), Error> {
+        call!(s2n_connection_set_secret_callback(
+            self.connection,
+            callback,
+            context
+        ))?;
+        Ok(())
+    }
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        // ignore failures since there's not much we can do about it
+        let _ = call!(s2n_connection_free(self.connection));
+    }
+}

--- a/bindings/rust/s2n-tls/src/raw/connection.rs
+++ b/bindings/rust/s2n-tls/src/raw/connection.rs
@@ -3,7 +3,11 @@
 
 #![allow(clippy::missing_safety_doc)] // TODO add safety docs
 
-use crate::raw::{config::Config, error::Error};
+use crate::raw::{
+    config::Config,
+    error::{Error, Fallible},
+};
+use core::ptr::NonNull;
 use core::{convert::TryInto, fmt, task::Poll};
 use libc::c_void;
 use s2n_tls_sys::*;
@@ -11,7 +15,7 @@ use s2n_tls_sys::*;
 pub use s2n_tls_sys::s2n_mode;
 
 pub struct Connection {
-    connection: *mut s2n_connection,
+    connection: NonNull<s2n_connection>,
     // The config needs to be stored so the reference count is accurate
     #[allow(dead_code)]
     config: Option<Config>,
@@ -25,10 +29,13 @@ impl fmt::Debug for Connection {
     }
 }
 
+/// Safety: s2n_connection objects can be sent across threads
+unsafe impl Send for Connection {}
+
 impl Connection {
     pub fn new(mode: s2n_mode::Type) -> Self {
         crate::raw::init::init();
-        let connection = call!(s2n_connection_new(mode)).unwrap();
+        let connection = unsafe { s2n_connection_new(mode).into_result() }.unwrap();
         Self {
             connection,
             config: None,
@@ -38,9 +45,9 @@ impl Connection {
     /// can be used to configure s2n to either use built-in blinding (set blinding
     /// to S2N_BUILT_IN_BLINDING) or self-service blinding (set blinding to
     /// S2N_SELF_SERVICE_BLINDING).
-    pub fn set_blinding(&mut self, blinding: s2n_blinding::Type) -> Result<(), Error> {
-        call!(s2n_connection_set_blinding(self.connection, blinding))?;
-        Ok(())
+    pub fn set_blinding(&mut self, blinding: s2n_blinding::Type) -> Result<&mut Self, Error> {
+        unsafe { s2n_connection_set_blinding(self.connection.as_ptr(), blinding).into_result() }?;
+        Ok(self)
     }
 
     /// Sets whether or not a Client Certificate should be required to complete the TLS Connection.
@@ -51,22 +58,21 @@ impl Connection {
     pub fn set_client_auth_type(
         &mut self,
         client_auth_type: s2n_cert_auth_type::Type,
-    ) -> Result<(), Error> {
-        call!(s2n_connection_set_client_auth_type(
-            self.connection,
-            client_auth_type
-        ))?;
-        Ok(())
+    ) -> Result<&mut Self, Error> {
+        unsafe {
+            s2n_connection_set_client_auth_type(self.connection.as_ptr(), client_auth_type)
+                .into_result()
+        }?;
+        Ok(self)
     }
 
     /// Associates a configuration object with a connection.
-    pub fn set_config(&mut self, mut config: Config) -> Result<(), Error> {
-        call!(s2n_connection_set_config(
-            self.connection,
-            config.as_mut_ptr(),
-        ))?;
+    pub fn set_config(&mut self, mut config: Config) -> Result<&mut Self, Error> {
+        unsafe {
+            s2n_connection_set_config(self.connection.as_ptr(), config.as_mut_ptr()).into_result()
+        }?;
         self.config = Some(config);
-        Ok(())
+        Ok(self)
     }
 
     /// provides a smooth transition from s2n_connection_prefer_low_latency to s2n_connection_prefer_throughput.
@@ -78,13 +84,16 @@ impl Connection {
         &mut self,
         resize_threshold: u32,
         timeout_threshold: u16,
-    ) -> Result<(), Error> {
-        call!(s2n_connection_set_dynamic_record_threshold(
-            self.connection,
-            resize_threshold,
-            timeout_threshold
-        ))?;
-        Ok(())
+    ) -> Result<&mut Self, Error> {
+        unsafe {
+            s2n_connection_set_dynamic_record_threshold(
+                self.connection.as_ptr(),
+                resize_threshold,
+                timeout_threshold,
+            )
+            .into_result()
+        }?;
+        Ok(self)
     }
 
     /// sets the application protocol preferences on an s2n_connection object.
@@ -97,83 +106,85 @@ impl Connection {
     pub fn set_alpn_preference<P: IntoIterator<Item = I>, I: AsRef<[u8]>>(
         &mut self,
         protocols: P,
-    ) -> Result<(), Error> {
+    ) -> Result<&mut Self, Error> {
         // reset the list
-        call!(s2n_connection_set_protocol_preferences(
-            self.connection,
-            core::ptr::null(),
-            0
-        ))?;
+        unsafe {
+            s2n_connection_set_protocol_preferences(self.connection.as_ptr(), core::ptr::null(), 0)
+                .into_result()
+        }?;
 
         for protocol in protocols {
             self.append_alpn_preference(protocol.as_ref())?;
         }
 
-        Ok(())
+        Ok(self)
     }
 
     pub fn append_alpn_preference(&mut self, protocol: &[u8]) -> Result<&mut Self, Error> {
-        call!(s2n_connection_append_protocol_preference(
-            self.connection,
-            protocol.as_ptr(),
-            protocol.len().try_into().map_err(|_| Error::InvalidInput)?,
-        ))?;
+        unsafe {
+            s2n_connection_append_protocol_preference(
+                self.connection.as_ptr(),
+                protocol.as_ptr(),
+                protocol.len().try_into().map_err(|_| Error::InvalidInput)?,
+            )
+            .into_result()
+        }?;
         Ok(self)
     }
 
     /// may be used to receive data with callbacks defined by the user.
-    pub fn set_receive_callback(&mut self, callback: s2n_recv_fn) -> Result<(), Error> {
-        call!(s2n_connection_set_recv_cb(self.connection, callback))?;
-        Ok(())
+    pub fn set_receive_callback(&mut self, callback: s2n_recv_fn) -> Result<&mut Self, Error> {
+        unsafe { s2n_connection_set_recv_cb(self.connection.as_ptr(), callback).into_result() }?;
+        Ok(self)
     }
 
     /// # Safety
     ///
     /// The `context` pointer must live at least as long as the connection
-    pub unsafe fn set_receive_context(&mut self, context: *mut c_void) -> Result<(), Error> {
-        call!(s2n_connection_set_recv_ctx(self.connection, context))?;
-        Ok(())
+    pub unsafe fn set_receive_context(&mut self, context: *mut c_void) -> Result<&mut Self, Error> {
+        s2n_connection_set_recv_ctx(self.connection.as_ptr(), context).into_result()?;
+        Ok(self)
     }
 
     /// may be used to receive data with callbacks defined by the user.
-    pub fn set_send_callback(&mut self, callback: s2n_send_fn) -> Result<(), Error> {
-        call!(s2n_connection_set_send_cb(self.connection, callback))?;
-        Ok(())
+    pub fn set_send_callback(&mut self, callback: s2n_send_fn) -> Result<&mut Self, Error> {
+        unsafe { s2n_connection_set_send_cb(self.connection.as_ptr(), callback).into_result() }?;
+        Ok(self)
     }
 
     /// # Safety
     ///
     /// The `context` pointer must live at least as long as the connection
-    pub unsafe fn set_send_context(&mut self, context: *mut c_void) -> Result<(), Error> {
-        call!(s2n_connection_set_send_ctx(self.connection, context))?;
-        Ok(())
+    pub unsafe fn set_send_context(&mut self, context: *mut c_void) -> Result<&mut Self, Error> {
+        s2n_connection_set_send_ctx(self.connection.as_ptr(), context).into_result()?;
+        Ok(self)
     }
 
     /// Connections prefering low latency will be encrypted using small record sizes that
     /// can be decrypted sooner by the recipient.
-    pub fn prefer_low_latency(&mut self) -> Result<(), Error> {
-        call!(s2n_connection_prefer_low_latency(self.connection))?;
-        Ok(())
+    pub fn prefer_low_latency(&mut self) -> Result<&mut Self, Error> {
+        unsafe { s2n_connection_prefer_low_latency(self.connection.as_ptr()).into_result() }?;
+        Ok(self)
     }
 
     /// Connections prefering throughput will use large record sizes that minimize overhead.
-    pub fn prefer_throughput(&mut self) -> Result<(), Error> {
-        call!(s2n_connection_prefer_throughput(self.connection))?;
-        Ok(())
+    pub fn prefer_throughput(&mut self) -> Result<&mut Self, Error> {
+        unsafe { s2n_connection_prefer_throughput(self.connection.as_ptr()).into_result() }?;
+        Ok(self)
     }
 
     /// wipes and free the in and out buffers associated with a connection.
     ///
     /// This function may be called when a connection is in keep-alive or idle state to
     /// reduce memory overhead of long lived connections.
-    pub fn release_buffers(&mut self) -> Result<(), Error> {
-        call!(s2n_connection_release_buffers(self.connection))?;
-        Ok(())
+    pub fn release_buffers(&mut self) -> Result<&mut Self, Error> {
+        unsafe { s2n_connection_release_buffers(self.connection.as_ptr()).into_result() }?;
+        Ok(self)
     }
 
-    pub fn use_corked_io(&mut self) -> Result<(), Error> {
-        call!(s2n_connection_use_corked_io(self.connection))?;
-        Ok(())
+    pub fn use_corked_io(&mut self) -> Result<&mut Self, Error> {
+        unsafe { s2n_connection_use_corked_io(self.connection.as_ptr()).into_result() }?;
+        Ok(self)
     }
 
     /// wipes an existing connection and allows it to be reused.
@@ -182,17 +193,17 @@ impl Connection {
     /// This function should be called after all I/O is completed and s2n_shutdown has been
     /// called. Reusing the same connection handle(s) is more performant than repeatedly
     /// calling s2n_connection_new and s2n_connection_free
-    pub fn wipe(&mut self) -> Result<(), Error> {
-        call!(s2n_connection_wipe(self.connection))?;
-        Ok(())
+    pub fn wipe(&mut self) -> Result<&mut Self, Error> {
+        unsafe { s2n_connection_wipe(self.connection.as_ptr()).into_result() }?;
+        Ok(self)
     }
 
     /// Performs the TLS handshake to completion
-    pub fn negotiate(&mut self) -> Poll<Result<(), Error>> {
+    pub fn negotiate(&mut self) -> Poll<Result<&mut Self, Error>> {
         let mut blocked = s2n_blocked_status::NOT_BLOCKED;
 
-        match call!(s2n_negotiate(self.connection, &mut blocked)) {
-            Ok(_) => Ok(()).into(),
+        match unsafe { s2n_negotiate(self.connection.as_ptr(), &mut blocked).into_result() } {
+            Ok(_) => Ok(self).into(),
             Err(err) if err.kind() == s2n_error_type::BLOCKED => Poll::Pending,
             Err(err) => Err(err).into(),
         }
@@ -200,37 +211,44 @@ impl Connection {
 
     /// Returns the TLS alert code, if any
     pub fn alert(&self) -> Option<u8> {
-        let alert = call!(s2n_connection_get_alert(self.connection)).ok()?;
+        let alert =
+            unsafe { s2n_connection_get_alert(self.connection.as_ptr()).into_result() }.ok()?;
         Some(alert as u8)
     }
 
     /// Sets the SNI value for the connection
-    pub fn set_sni(&mut self, sni: &[u8]) -> Result<(), Error> {
+    pub fn set_sni(&mut self, sni: &[u8]) -> Result<&mut Self, Error> {
         let sni = std::ffi::CString::new(sni).map_err(|_| Error::InvalidInput)?;
-        call!(s2n_set_server_name(self.connection, sni.as_ptr()))?;
-        Ok(())
+        unsafe { s2n_set_server_name(self.connection.as_ptr(), sni.as_ptr()).into_result() }?;
+        Ok(self)
     }
 }
 
 #[cfg(feature = "quic")]
 impl Connection {
-    pub fn set_quic_transport_parameters(&mut self, buffer: &[u8]) -> Result<(), Error> {
-        call!(s2n_connection_set_quic_transport_parameters(
-            self.connection,
-            buffer.as_ptr(),
-            buffer.len().try_into().map_err(|_| Error::InvalidInput)?,
-        ))?;
-        Ok(())
+    pub fn set_quic_transport_parameters(&mut self, buffer: &[u8]) -> Result<&mut Self, Error> {
+        unsafe {
+            s2n_connection_set_quic_transport_parameters(
+                self.connection.as_ptr(),
+                buffer.as_ptr(),
+                buffer.len().try_into().map_err(|_| Error::InvalidInput)?,
+            )
+            .into_result()
+        }?;
+        Ok(self)
     }
 
     pub fn quic_transport_parameters(&mut self) -> Result<&[u8], Error> {
         let mut ptr = core::ptr::null();
         let mut len = 0;
-        call!(s2n_connection_get_quic_transport_parameters(
-            self.connection,
-            &mut ptr,
-            &mut len,
-        ))?;
+        unsafe {
+            s2n_connection_get_quic_transport_parameters(
+                self.connection.as_ptr(),
+                &mut ptr,
+                &mut len,
+            )
+            .into_result()
+        }?;
         let buffer = unsafe { core::slice::from_raw_parts(ptr, len as _) };
         Ok(buffer)
     }
@@ -242,19 +260,16 @@ impl Connection {
         &mut self,
         callback: s2n_secret_cb,
         context: *mut c_void,
-    ) -> Result<(), Error> {
-        call!(s2n_connection_set_secret_callback(
-            self.connection,
-            callback,
-            context
-        ))?;
-        Ok(())
+    ) -> Result<&mut Self, Error> {
+        s2n_connection_set_secret_callback(self.connection.as_ptr(), callback, context)
+            .into_result()?;
+        Ok(self)
     }
 }
 
 impl Drop for Connection {
     fn drop(&mut self) {
         // ignore failures since there's not much we can do about it
-        let _ = call!(s2n_connection_free(self.connection));
+        let _ = unsafe { s2n_connection_free(self.connection.as_ptr()).into_result() };
     }
 }

--- a/bindings/rust/s2n-tls/src/raw/error.rs
+++ b/bindings/rust/s2n-tls/src/raw/error.rs
@@ -1,0 +1,143 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::fmt;
+use libc::{c_char, c_int};
+use s2n_tls_sys::*;
+use std::ffi::CStr;
+
+// Ensures errors are converted
+#[macro_export]
+macro_rules! call {
+    ($expr:expr) => {{
+        #[allow(unused_unsafe)]
+        $crate::raw::error::Error::new(unsafe { $expr })
+    }};
+}
+
+pub enum Error {
+    InvalidInput,
+    Code(c_int),
+}
+
+pub trait Fallible {
+    fn is_err(&self) -> bool;
+}
+
+impl Fallible for c_int {
+    fn is_err(&self) -> bool {
+        (*self) < 0
+    }
+}
+
+impl<T> Fallible for *mut T {
+    fn is_err(&self) -> bool {
+        <*mut T>::is_null(*self)
+    }
+}
+
+impl<T> Fallible for *const T {
+    fn is_err(&self) -> bool {
+        <*const T>::is_null(*self)
+    }
+}
+
+impl Error {
+    pub fn new<T: Fallible>(value: T) -> Result<T, Self> {
+        if value.is_err() {
+            Err(Self::capture())
+        } else {
+            Ok(value)
+        }
+    }
+
+    fn capture() -> Self {
+        unsafe {
+            let s2n_errno = s2n_errno_location();
+
+            let code = *s2n_errno;
+
+            // https://github.com/awslabs/s2n/blob/main/docs/USAGE-GUIDE.md#error-handling
+            //# To avoid possible confusion, s2n_errno should be cleared after processing
+            //# an error: s2n_errno = S2N_ERR_T_OK
+            *s2n_errno = s2n_error_type::OK as _;
+
+            Self::Code(code)
+        }
+    }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::InvalidInput => "InvalidInput",
+            Self::Code(code) => unsafe {
+                // Safety: we assume the string has a valid encoding coming from s2n
+                cstr_to_str(s2n_strerror_name(*code))
+            },
+        }
+    }
+
+    pub fn message(&self) -> &'static str {
+        match self {
+            Self::InvalidInput => "A parameter was incorrect.",
+            Self::Code(code) => unsafe {
+                // Safety: we assume the string has a valid encoding coming from s2n
+                cstr_to_str(s2n_strerror(*code, core::ptr::null()))
+            },
+        }
+    }
+
+    pub fn debug(&self) -> &'static str {
+        match self {
+            Self::InvalidInput => "A parameter was incorrect.",
+            Self::Code(code) => unsafe {
+                // Safety: we assume the string has a valid encoding coming from s2n
+                cstr_to_str(s2n_strerror_debug(*code, core::ptr::null()))
+            },
+        }
+    }
+
+    pub fn kind(&self) -> s2n_error_type::Type {
+        match self {
+            Self::InvalidInput => s2n_error_type::USAGE,
+            Self::Code(code) => unsafe { s2n_error_get_type(*code) as _ },
+        }
+    }
+}
+
+/// # Safety
+///
+/// The caller must ensure the char pointer must contain a valid
+/// UTF-8 string from a trusted source
+unsafe fn cstr_to_str(v: *const c_char) -> &'static str {
+    let slice = CStr::from_ptr(v);
+    let bytes = slice.to_bytes();
+    core::str::from_utf8_unchecked(bytes)
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let alternate = f.alternate();
+
+        let mut s = f.debug_struct("Error");
+        if let Self::Code(code) = self {
+            s.field("code", code);
+        }
+        s.field("name", &self.name())
+            .field("message", &self.message())
+            .field("kind", &self.kind());
+
+        if alternate {
+            s.field("debug", &self.debug());
+        }
+
+        s.finish()
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.message())
+    }
+}
+
+impl std::error::Error for Error {}

--- a/bindings/rust/s2n-tls/src/raw/error.rs
+++ b/bindings/rust/s2n-tls/src/raw/error.rs
@@ -3,13 +3,13 @@
 
 use core::fmt;
 use core::ptr::NonNull;
-use libc::{c_char, c_int};
+use libc::c_char;
 use s2n_tls_sys::*;
 use std::ffi::CStr;
 
 pub enum Error {
     InvalidInput,
-    Code(c_int),
+    Code(s2n_status_code::Type),
 }
 
 pub trait Fallible {
@@ -18,11 +18,11 @@ pub trait Fallible {
     fn into_result(self) -> Result<Self::Output, Error>;
 }
 
-impl Fallible for c_int {
-    type Output = c_int;
+impl Fallible for s2n_status_code::Type {
+    type Output = s2n_status_code::Type;
 
     fn into_result(self) -> Result<Self::Output, Error> {
-        if self >= 0 {
+        if self >= s2n_status_code::SUCCESS {
             Ok(self)
         } else {
             Err(Error::capture())

--- a/bindings/rust/s2n-tls/src/raw/init.rs
+++ b/bindings/rust/s2n-tls/src/raw/init.rs
@@ -1,0 +1,115 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::raw::error::Error;
+use s2n_tls_sys::*;
+use std::sync::Once;
+
+static S2N_INIT: Once = Once::new();
+
+/// # Safety
+///
+/// This function should only be called once
+unsafe fn global_init() -> Result<(), Error> {
+    mem::init()?;
+    call!(s2n_init())?;
+    Ok(())
+}
+
+thread_local! {
+    static S2N_THREAD: Thread = {
+        S2N_INIT.call_once(|| unsafe {
+            // Safety: by using `Once` we can ensure the library is initialized once
+            global_init().expect("could not initialize s2n-tls");
+        });
+        Thread
+    };
+}
+
+struct Thread;
+
+impl Drop for Thread {
+    fn drop(&mut self) {
+        // https://doc.rust-lang.org/std/thread/struct.LocalKey.html#platform-specific-behavior
+        // Note that a "best effort" is made to ensure that destructors for types stored in thread local storage are run, but not all platforms can guarantee that destructors will be run for all types in thread local storage.
+        let _ = call!(s2n_cleanup());
+    }
+}
+
+pub fn init() {
+    S2N_THREAD.with(|_| ());
+}
+
+mod mem {
+    use super::*;
+    use alloc::alloc::{alloc, dealloc, Layout};
+    use core::{ffi::c_void, mem::size_of};
+
+    pub unsafe fn init() -> Result<(), Error> {
+        call!(s2n_mem_set_callbacks(
+            Some(mem_init_callback),
+            Some(mem_cleanup_callback),
+            Some(mem_malloc_callback),
+            Some(mem_free_callback),
+        ))?;
+        Ok(())
+    }
+
+    unsafe extern "C" fn mem_init_callback() -> s2n_status_code::Type {
+        // no-op: the global allocator is already initialized
+        0
+    }
+
+    unsafe extern "C" fn mem_cleanup_callback() -> s2n_status_code::Type {
+        // no-op: the global allocator is already initialized
+        0
+    }
+
+    unsafe extern "C" fn mem_malloc_callback(
+        ptr: *mut *mut c_void,
+        requested_len: u32,
+        allocated_len: *mut u32,
+    ) -> s2n_status_code::Type {
+        let layout = if let Some(layout) = layout(requested_len) {
+            layout
+        } else {
+            return -1;
+        };
+        *ptr = alloc(layout) as *mut _;
+
+        if ptr.is_null() {
+            -1
+        } else {
+            *allocated_len = requested_len;
+            0
+        }
+    }
+
+    unsafe extern "C" fn mem_free_callback(ptr: *mut c_void, len: u32) -> s2n_status_code::Type {
+        let layout = if let Some(layout) = layout(len) {
+            layout
+        } else {
+            return -1;
+        };
+
+        dealloc(ptr as *mut _, layout);
+
+        0
+    }
+
+    unsafe fn layout(len: u32) -> Option<Layout> {
+        // https://linux.die.net/man/3/malloc
+        //# The malloc() and calloc() functions return a pointer to the
+        //# allocated memory, which is suitably aligned for any built-in
+        //# type.
+        const ALIGNMENT: usize = size_of::<usize>();
+
+        // * align must not be zero,
+        //
+        // * align must be a power of two,
+        //
+        // * size, when rounded up to the nearest multiple of align, must not overflow (i.e., the rounded value must be less than or equal to usize::MAX).
+
+        Layout::from_size_align(len as usize, ALIGNMENT).ok()
+    }
+}

--- a/bindings/rust/s2n-tls/src/raw/init.rs
+++ b/bindings/rust/s2n-tls/src/raw/init.rs
@@ -58,12 +58,12 @@ mod mem {
 
     unsafe extern "C" fn mem_init_callback() -> s2n_status_code::Type {
         // no-op: the global allocator is already initialized
-        0
+        s2n_status_code::SUCCESS
     }
 
     unsafe extern "C" fn mem_cleanup_callback() -> s2n_status_code::Type {
         // no-op: the global allocator is already initialized
-        0
+        s2n_status_code::SUCCESS
     }
 
     unsafe extern "C" fn mem_malloc_callback(
@@ -74,15 +74,15 @@ mod mem {
         let layout = if let Some(layout) = layout(requested_len) {
             layout
         } else {
-            return -1;
+            return s2n_status_code::SUCCESS;
         };
         *ptr = alloc(layout) as *mut _;
 
         if ptr.is_null() {
-            -1
+            s2n_status_code::FAILURE
         } else {
             *allocated_len = requested_len;
-            0
+            s2n_status_code::SUCCESS
         }
     }
 
@@ -90,12 +90,12 @@ mod mem {
         let layout = if let Some(layout) = layout(len) {
             layout
         } else {
-            return -1;
+            return s2n_status_code::FAILURE;
         };
 
         dealloc(ptr as *mut _, layout);
 
-        0
+        s2n_status_code::SUCCESS
     }
 
     unsafe fn layout(len: u32) -> Option<Layout> {


### PR DESCRIPTION
### Description of changes: 

In the next phase of adding rust bindings, this PR adds "mid-level" bindings which closely resemble the C API, except with a safe interface. These will be used as part of the planned performance tests work.

Eventually high-level bindings will be provided which will integrate with rust's async runtime ecosystem.

### Call-outs:

* These bindings are not exhaustive - there is still quite a bit of remaining work to expose all of the C API's functionality.
* These APIs are subject to change and should not be used without the expectation of breakage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
