### PR TITLE
Fixing wrong file path in makefile for BIKE R3

### DIFF
--- a/pq-crypto/s2n_pq_asm.mk
+++ b/pq-crypto/s2n_pq_asm.mk
@@ -40,7 +40,7 @@ ifndef S2N_NO_PQ_ASM
 	# by the compiler. So for each needed instruction set
 	# extension we check if the compiler supports it and
 	# set proper flags to be added in the BIKE_R3 Makefile.
-	dummy_file := "$(S2N_ROOT)/tests/unit/s2n_pq_asm_noop_test.c"
+	dummy_file := "$(S2N_ROOT)/tests/features/noop_main.c"
 	dummy_file_out := "test_bike_r3_avx_support.o"
 	BIKE_R3_AVX2_SUPPORTED := $(shell $(CC) -mavx2 -c -o $(dummy_file_out) $(dummy_file) > /dev/null 2>&1; echo $$?; rm $(dummy_file_out) > /dev/null 2>&1)
 	ifeq ($(BIKE_R3_AVX2_SUPPORTED), 0)


### PR DESCRIPTION
Signed-off-by: Dusan Kostic <dkostic@amazon.com>

### Resolved issues:

Fixing wrong file path in makefile for BIKE R3. The incorrect path was causing the Makefile to build only the portable version of BIKE R3, while the optimized implementations were left out. The CMake was building everything correctly.

### Description of changes: 
Fixed the file path in s2n_pq_asm.mk file to point to the correct new path of the dummy noop_main.c file.

### Call-outs:

### Testing:
Tested on Ubuntu 20.04 with clang-10.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
