### PR TITLE
Stops TLS13 From Erroring if Session Ticket Write Fails

### DIFF
--- a/tls/s2n_post_handshake.c
+++ b/tls/s2n_post_handshake.c
@@ -79,7 +79,9 @@ int s2n_post_handshake_send(struct s2n_connection *conn, s2n_blocked_status *blo
     POSIX_ENSURE_REF(conn);
 
     POSIX_GUARD(s2n_key_update_send(conn, blocked));
-    POSIX_GUARD_RESULT(s2n_tls13_server_nst_send(conn, blocked));
+    if(s2n_result_is_error(s2n_tls13_server_nst_send(conn, blocked))) {
+        return S2N_SUCCESS;
+    }
 
     return S2N_SUCCESS;
 }

--- a/tls/s2n_post_handshake.c
+++ b/tls/s2n_post_handshake.c
@@ -79,9 +79,7 @@ int s2n_post_handshake_send(struct s2n_connection *conn, s2n_blocked_status *blo
     POSIX_ENSURE_REF(conn);
 
     POSIX_GUARD(s2n_key_update_send(conn, blocked));
-    if(s2n_result_is_error(s2n_tls13_server_nst_send(conn, blocked))) {
-        return S2N_SUCCESS;
-    }
+    POSIX_GUARD_RESULT(s2n_tls13_server_nst_send(conn, blocked));
 
     return S2N_SUCCESS;
 }

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -138,7 +138,9 @@ S2N_RESULT s2n_tls13_server_nst_send(struct s2n_connection *conn, s2n_blocked_st
     RESULT_GUARD_POSIX(s2n_stuffer_growable_alloc(&nst_stuffer, maximum_nst_size));
 
     while (conn->tickets_to_send - conn->tickets_sent > 0) {
-        RESULT_GUARD(s2n_tls13_server_nst_write(conn, &nst_stuffer));
+        if (s2n_result_is_error(s2n_tls13_server_nst_write(conn, &nst_stuffer))) {
+            return S2N_RESULT_OK;
+        }
 
         struct s2n_blob nst_blob = { 0 };
         uint16_t nst_size = s2n_stuffer_data_available(&nst_stuffer);


### PR DESCRIPTION
### Resolved issues:

 resolves #2912

### Description of changes: 
TLS13 session ticket handling happens after the handshake, as opposed to TLS12, which happens during the handshake. When we implemented the TLS13 handling we lost the TLS1.2 behavior that the server shouldn't error if it was unable to create a session ticket because there is no ticket key. This PR adds that behavior in to TLS1.3. Now, a server will not error something goes wrong writing the session ticket message.
### Call-outs:

I waffled 🧇 a bit on where to put the error handling. In order to make TLS1.3 behave more like TLS1.2, the error handling surrounds the entire session ticket write message, rather than just the encrypt/decrypt key. So any error during session ticket write will just stop the server from issuing a session ticket but not abort the handshake.
### Testing:

 Functional test.
 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
