### PR TITLE
Check for -1 return code from OCSP_basic_verify()

### DIFF
--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -463,13 +463,15 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_stapled_ocsp_response(
     }
 
     /* Important: this checks that the stapled ocsp response CAN be verified, not that it has been verified. */
-    const int ocsp_verify_err = OCSP_basic_verify(basic_response, cert_chain, validator->trust_store->trust_store, 0);
-    /* do the crypto checks on the response.*/
-    if (!ocsp_verify_err) {
+    const int ocsp_verify_res = OCSP_basic_verify(basic_response, cert_chain, validator->trust_store->trust_store, 0);
+
+    /* OCSP_basic_verify() returns 1 on success, 0 on error, or -1 on fatal error such as malloc failure. */
+    if (ocsp_verify_res != _OSSL_SUCCESS) {
         ret_val = S2N_CERT_ERR_UNTRUSTED;
         goto clean_up;
     }
 
+    /* do the crypto checks on the response.*/
     int status = 0;
     int reason = 0;
 

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -467,7 +467,7 @@ s2n_cert_validation_code s2n_x509_validator_validate_cert_stapled_ocsp_response(
 
     /* OCSP_basic_verify() returns 1 on success, 0 on error, or -1 on fatal error such as malloc failure. */
     if (ocsp_verify_res != _OSSL_SUCCESS) {
-        ret_val = S2N_CERT_ERR_UNTRUSTED;
+        ret_val = ocsp_verify_res == 0 ? S2N_CERT_ERR_UNTRUSTED : S2N_CERT_ERR_INTERNAL_ERROR;
         goto clean_up;
     }
 

--- a/tls/s2n_x509_validator.h
+++ b/tls/s2n_x509_validator.h
@@ -36,7 +36,8 @@ typedef enum {
     S2N_CERT_ERR_EXPIRED = -3,
     S2N_CERT_ERR_TYPE_UNSUPPORTED = -4,
     S2N_CERT_ERR_INVALID = -5,
-    S2N_CERT_ERR_MAX_CHAIN_DEPTH_EXCEEDED = -6
+    S2N_CERT_ERR_MAX_CHAIN_DEPTH_EXCEEDED = -6,
+    S2N_CERT_ERR_INTERNAL_ERROR = -7
 } s2n_cert_validation_code;
 
 typedef enum {


### PR DESCRIPTION
### Description of changes: 

According to [OpenSSL documentation](https://www.openssl.org/docs/man1.1.1/man3/OCSP_basic_verify.html) for the OCSP_basic_verify function:

```
OCSP_basic_verify() returns 1 on success, 0 on error, or -1 on fatal error such as malloc failure.
```

This change ensures we will error on anything other than a 1 returned by OCSP_basic_verify(), rather than just on a 0.
### Call-outs:

Is S2N_CERT_ERR_UNTRUSTED appropriate to return on a fatal error, or should be use a different return value?

### Testing:

I didn't add any additional tests, but if there a way to force a malloc failure in OCSP_basic_verify, then it could be possible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
