### PR TITLE
Update Max Connection memory usage to support Round 3 KEM Groups

### DIFF
--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
      */
     {
         /* Carefully consider any increases to this number. */
-        const uint16_t max_connection_size = 18700;
+        const uint16_t max_connection_size = 19584;
         const uint16_t min_connection_size = max_connection_size * 0.75;
 
         size_t connection_size = sizeof(struct s2n_connection);


### PR DESCRIPTION
### Resolved issues:
Resolves Unit Test Failures that measure connection memory. This test failure was caused by two different PR's being worked on simultaneously on two different branches that weren't run together until the 2nd was merged into the main branch of s2n.  

Adding Round 3 KEM Groups: https://github.com/aws/s2n-tls/pull/2842
Adding Test to measure s2n Connection Memory: https://github.com/aws/s2n-tls/pull/2913
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
