### PR TITLE
Add Round 3 PQ Hybrid TLS 1.3 Known Answer Tests

### DIFF
--- a/tests/unit/kats/generate_pq_hybrid_tls13_handshake_kats.py
+++ b/tests/unit/kats/generate_pq_hybrid_tls13_handshake_kats.py
@@ -1,0 +1,236 @@
+import hashlib
+import hmac
+
+# The following PEM-encoded ECC private keys were used to generate the ECC shared secrets.
+# These private keys are also used in s2n/tests/unit/s2n_tls13_hybrid_shared_secret_test.c.
+#
+# #define CLIENT_X25519_PRIV_KEY "-----BEGIN PRIVATE KEY-----\n"\
+#                                "MC4CAQAwBQYDK2VuBCIEIIgzBrAp631nCDaoA7ilx/8S/cW1lddVQOw9869sROBF\n"\
+#                                "-----END PRIVATE KEY-----"
+#
+# #define SERVER_X25519_PRIV_KEY "-----BEGIN PRIVATE KEY-----\n"\
+#                                "MC4CAQAwBQYDK2VuBCIEIIBo+KJ2Zs3vRHQ3sYgHL4zTQPlJPl1y7sW8HT9qRE96\n"\
+#                                "-----END PRIVATE KEY-----"
+#
+# #define CLIENT_SECP256R1_PRIV_KEY "-----BEGIN EC PARAMETERS-----\n"\
+#                                   "BggqhkjOPQMBBw==\n"\
+#                                   "-----END EC PARAMETERS-----\n"\
+#                                   "-----BEGIN EC PRIVATE KEY-----\n"\
+#                                   "MHcCAQEEIFCkEmNXACRbWdizfAKP8/Qvx9aplVxLE+Sm2vmCcsY3oAoGCCqGSM49\n"\
+#                                   "AwEHoUQDQgAESk526eZ9lf6xrNOiTF8qkYvJDOfc4qqShcbB7qnT67As4pyeQzVm\n"\
+#                                   "xfMjmXYBOUnPVBL3FKnIk45sDSCfu++gug==\n"\
+#                                   "-----END EC PRIVATE KEY-----"
+#
+# #define SERVER_SECP256R1_PRIV_KEY "-----BEGIN EC PARAMETERS-----\n"\
+#                                   "BggqhkjOPQMBBw==\n"\
+#                                   "-----END EC PARAMETERS-----\n"\
+#                                   "-----BEGIN EC PRIVATE KEY-----\n"\
+#                                   "MHcCAQEEINXLCaZuyYG0HrlSFcHLPFmSnyFm5RqrmyZfgdrxqprXoAoGCCqGSM49\n"\
+#                                   "AwEHoUQDQgAEMDuuxEQ1yaA13ceuJP+RC0sbf5ksW6DPlL+yXJiD7cUeWUPrtxbP\n"\
+#                                   "ViSR6ex8fYV69oCHgnDnElfE3xaiXiQWBw==\n"\
+#                                   "-----END EC PRIVATE KEY-----"
+
+# We aren't really concerned with the actual bytes of the transcript, only the hash.
+# The transcript_hash values were calculated as:
+# hashlib.sha256(b"client_hello || server_hello").hexdigest()
+# hashlib.sha384(b"client_hello || server_hello").hexdigest()
+# The string "client_hello || server_hello" is used in s2n/tests/unit/s2n_tls13_hybrid_shared_secret_test.c.
+
+# The PQ shared secrets come from the first test vector in the corresponding NIST KAT.
+input_vectors = [
+    {
+        "group_name": "x25519_sikep434r2",
+        "cipher_suite": "TLS_AES_128_GCM_SHA256",
+        "ec_shared_secret": "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910",
+        "pq_shared_secret": "35F7F8FF388714DEDC41F139078CEDC9",
+        "transcript_hash": "f5f7f7867668be4b792159d4d194a03ec5cfa238b6409b5ca2ddccfddcc92a2b",
+    },
+    {
+        "group_name": "x25519_sikep434r2",
+        "cipher_suite": "TLS_AES_256_GCM_SHA384",
+        "ec_shared_secret": "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910",
+        "pq_shared_secret": "35F7F8FF388714DEDC41F139078CEDC9",
+        "transcript_hash": "35412cebcf35cb8a7af8f78278a486fc798f8702eaebd067c97acb27bffe13524d8426a4ed57956b4fd0ffdc4c90be52",
+    },
+    {
+        "group_name": "secp256r1_sikep434r2",
+        "cipher_suite": "TLS_AES_128_GCM_SHA256",
+        "ec_shared_secret": "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60",
+        "pq_shared_secret": "35F7F8FF388714DEDC41F139078CEDC9",
+        "transcript_hash": "f5f7f7867668be4b792159d4d194a03ec5cfa238b6409b5ca2ddccfddcc92a2b",
+    },
+    {
+        "group_name": "secp256r1_sikep434r2",
+        "cipher_suite": "TLS_AES_256_GCM_SHA384",
+        "ec_shared_secret": "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60",
+        "pq_shared_secret": "35F7F8FF388714DEDC41F139078CEDC9",
+        "transcript_hash": "35412cebcf35cb8a7af8f78278a486fc798f8702eaebd067c97acb27bffe13524d8426a4ed57956b4fd0ffdc4c90be52",
+    },
+    {
+        "group_name": "x25519_bike1l1r2",
+        "cipher_suite": "TLS_AES_128_GCM_SHA256",
+        "ec_shared_secret": "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910",
+        "pq_shared_secret": "C1C96E2B8B1D23E52F02AD3A766A75ADBEDF7BA1558B94412B4AB534EEDBDE36",
+        "transcript_hash": "f5f7f7867668be4b792159d4d194a03ec5cfa238b6409b5ca2ddccfddcc92a2b",
+    },
+    {
+        "group_name": "x25519_bike1l1r2",
+        "cipher_suite": "TLS_AES_256_GCM_SHA384",
+        "ec_shared_secret": "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910",
+        "pq_shared_secret": "C1C96E2B8B1D23E52F02AD3A766A75ADBEDF7BA1558B94412B4AB534EEDBDE36",
+        "transcript_hash": "35412cebcf35cb8a7af8f78278a486fc798f8702eaebd067c97acb27bffe13524d8426a4ed57956b4fd0ffdc4c90be52",
+    },
+    {
+        "group_name": "secp256r1_bike1l1r2",
+        "cipher_suite": "TLS_AES_128_GCM_SHA256",
+        "ec_shared_secret": "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60",
+        "pq_shared_secret": "C1C96E2B8B1D23E52F02AD3A766A75ADBEDF7BA1558B94412B4AB534EEDBDE36",
+        "transcript_hash": "f5f7f7867668be4b792159d4d194a03ec5cfa238b6409b5ca2ddccfddcc92a2b",
+    },
+    {
+        "group_name": "secp256r1_bike1l1r2",
+        "cipher_suite": "TLS_AES_256_GCM_SHA384",
+        "ec_shared_secret": "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60",
+        "pq_shared_secret": "C1C96E2B8B1D23E52F02AD3A766A75ADBEDF7BA1558B94412B4AB534EEDBDE36",
+        "transcript_hash": "35412cebcf35cb8a7af8f78278a486fc798f8702eaebd067c97acb27bffe13524d8426a4ed57956b4fd0ffdc4c90be52",
+    },
+    {
+        "group_name": "x25519_kyber512r2",
+        "cipher_suite": "TLS_AES_128_GCM_SHA256",
+        "ec_shared_secret": "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910",
+        "pq_shared_secret": "D0FF6083EE6E516C10AECB53DB05426C382A1A75F3E943C9F469A060C634EF4E",
+        "transcript_hash": "f5f7f7867668be4b792159d4d194a03ec5cfa238b6409b5ca2ddccfddcc92a2b",
+    },
+    {
+        "group_name": "x25519_kyber512r2",
+        "cipher_suite": "TLS_AES_256_GCM_SHA384",
+        "ec_shared_secret": "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910",
+        "pq_shared_secret": "D0FF6083EE6E516C10AECB53DB05426C382A1A75F3E943C9F469A060C634EF4E",
+        "transcript_hash": "35412cebcf35cb8a7af8f78278a486fc798f8702eaebd067c97acb27bffe13524d8426a4ed57956b4fd0ffdc4c90be52",
+    },
+    {
+        "group_name": "secp256r1_kyber512r2",
+        "cipher_suite": "TLS_AES_128_GCM_SHA256",
+        "ec_shared_secret": "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60",
+        "pq_shared_secret": "D0FF6083EE6E516C10AECB53DB05426C382A1A75F3E943C9F469A060C634EF4E",
+        "transcript_hash": "f5f7f7867668be4b792159d4d194a03ec5cfa238b6409b5ca2ddccfddcc92a2b",
+    },
+    {
+        "group_name": "secp256r1_kyber512r2",
+        "cipher_suite": "TLS_AES_256_GCM_SHA384",
+        "ec_shared_secret": "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60",
+        "pq_shared_secret": "D0FF6083EE6E516C10AECB53DB05426C382A1A75F3E943C9F469A060C634EF4E",
+        "transcript_hash": "35412cebcf35cb8a7af8f78278a486fc798f8702eaebd067c97acb27bffe13524d8426a4ed57956b4fd0ffdc4c90be52",
+    },
+    {
+        "group_name": "x25519_kyber512r3",
+        "cipher_suite": "TLS_AES_128_GCM_SHA256",
+        "ec_shared_secret": "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910",
+        "pq_shared_secret": "0A6925676F24B22C286F4C81A4224CEC506C9B257D480E02E3B49F44CAA3237F",
+        "transcript_hash": "f5f7f7867668be4b792159d4d194a03ec5cfa238b6409b5ca2ddccfddcc92a2b",
+    },
+    {
+        "group_name": "x25519_kyber512r3",
+        "cipher_suite": "TLS_AES_256_GCM_SHA384",
+        "ec_shared_secret": "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910",
+        "pq_shared_secret": "0A6925676F24B22C286F4C81A4224CEC506C9B257D480E02E3B49F44CAA3237F",
+        "transcript_hash": "35412cebcf35cb8a7af8f78278a486fc798f8702eaebd067c97acb27bffe13524d8426a4ed57956b4fd0ffdc4c90be52",
+    },
+    {
+        "group_name": "secp256r1_kyber512r3",
+        "cipher_suite": "TLS_AES_128_GCM_SHA256",
+        "ec_shared_secret": "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60",
+        "pq_shared_secret": "0A6925676F24B22C286F4C81A4224CEC506C9B257D480E02E3B49F44CAA3237F",
+        "transcript_hash": "f5f7f7867668be4b792159d4d194a03ec5cfa238b6409b5ca2ddccfddcc92a2b",
+    },
+    {
+        "group_name": "secp256r1_kyber512r3",
+        "cipher_suite": "TLS_AES_256_GCM_SHA384",
+        "ec_shared_secret": "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60",
+        "pq_shared_secret": "0A6925676F24B22C286F4C81A4224CEC506C9B257D480E02E3B49F44CAA3237F",
+        "transcript_hash": "35412cebcf35cb8a7af8f78278a486fc798f8702eaebd067c97acb27bffe13524d8426a4ed57956b4fd0ffdc4c90be52",
+    },
+    {
+        "group_name": "x25519_bikel1r3",
+        "cipher_suite": "TLS_AES_128_GCM_SHA256",
+        "ec_shared_secret": "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910",
+        "pq_shared_secret": "1A88B3A458EE42906A5FD423817E043532579C4F79518A81213DC91D0F2FCEA9",
+        "transcript_hash": "f5f7f7867668be4b792159d4d194a03ec5cfa238b6409b5ca2ddccfddcc92a2b",
+    },
+    {
+        "group_name": "x25519_bikel1r3",
+        "cipher_suite": "TLS_AES_256_GCM_SHA384",
+        "ec_shared_secret": "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910",
+        "pq_shared_secret": "1A88B3A458EE42906A5FD423817E043532579C4F79518A81213DC91D0F2FCEA9",
+        "transcript_hash": "35412cebcf35cb8a7af8f78278a486fc798f8702eaebd067c97acb27bffe13524d8426a4ed57956b4fd0ffdc4c90be52",
+    },
+    {
+        "group_name": "secp256r1_bikel1r3",
+        "cipher_suite": "TLS_AES_128_GCM_SHA256",
+        "ec_shared_secret": "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60",
+        "pq_shared_secret": "1A88B3A458EE42906A5FD423817E043532579C4F79518A81213DC91D0F2FCEA9",
+        "transcript_hash": "f5f7f7867668be4b792159d4d194a03ec5cfa238b6409b5ca2ddccfddcc92a2b",
+    },
+    {
+        "group_name": "secp256r1_bikel1r3",
+        "cipher_suite": "TLS_AES_256_GCM_SHA384",
+        "ec_shared_secret": "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60",
+        "pq_shared_secret": "1A88B3A458EE42906A5FD423817E043532579C4F79518A81213DC91D0F2FCEA9",
+        "transcript_hash": "35412cebcf35cb8a7af8f78278a486fc798f8702eaebd067c97acb27bffe13524d8426a4ed57956b4fd0ffdc4c90be52",
+    },
+]
+
+def hdkf_extract(salt: bytes, key: bytes, hash_alg: str):
+    return hmac.new(salt, key, hash_alg).digest()
+
+def hkdf_expand_label(key: bytes, label: str, context: bytes, hash_alg: str):
+    label_arr = [0, hashlib.new(hash_alg).digest_size, len("tls13 ") + len(label)]
+    for c in "tls13 ":
+        label_arr.append(ord(c))
+
+    for c in label:
+        label_arr.append(ord(c))
+
+    label_arr.append(len(context))
+
+    for c in context:
+        label_arr.append(c)
+
+    return hdkf_extract(key, bytearray(label_arr) + bytes([1]), hash_alg)
+
+def compute_secrets(input_vector: dict):
+    shared_secret = bytes.fromhex(input_vector["ec_shared_secret"] + input_vector["pq_shared_secret"])
+    hash_alg = input_vector["cipher_suite"].split("_")[-1].lower()
+    zeros = bytearray([0] * hashlib.new(hash_alg).digest_size)
+    transcript_hash = bytes.fromhex(input_vector["transcript_hash"])
+
+    h = hashlib.new(hash_alg)
+    h.update(b"")
+    empty_hash = h.digest()
+
+    secrets = {"early_secret": hdkf_extract(zeros, zeros, hash_alg)}
+    secrets["derived_secret"] = hkdf_expand_label(secrets["early_secret"], "derived", empty_hash, hash_alg)
+    secrets["handshake_secret"] = hdkf_extract(secrets["derived_secret"], shared_secret, hash_alg)
+    secrets["client_traffic_secret"] = hkdf_expand_label(secrets["handshake_secret"], "c hs traffic", transcript_hash, hash_alg)
+    secrets["server_traffic_secret"] = hkdf_expand_label(secrets["handshake_secret"], "s hs traffic", transcript_hash, hash_alg)
+
+    return secrets
+
+def main():
+    output = ""
+
+    for input_vector in input_vectors:
+        secrets = compute_secrets(input_vector)
+
+        for input_key, input_value in input_vector.items():
+            output += input_key + " = " + input_value + "\n"
+
+        for secret_name, secret_bytes in secrets.items():
+            output += secret_name + " = " + secret_bytes.hex() + "\n"
+
+        output += "\n"
+
+    print(output)
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -88,6 +88,8 @@ struct hybrid_test_vector {
 #define SIKEP434R3_SECRET "35f7f8ff388714dedc41f139078cedc9"
 #define BIKE1L1R2_SECRET "C1C96E2B8B1D23E52F02AD3A766A75ADBEDF7BA1558B94412B4AB534EEDBDE36"
 #define KYBER512R2_SECRET "D0FF6083EE6E516C10AECB53DB05426C382A1A75F3E943C9F469A060C634EF4E"
+#define BIKEL1R3_SECRET "1A88B3A458EE42906A5FD423817E043532579C4F79518A81213DC91D0F2FCEA9"
+#define KYBER512R3_SECRET "0A6925676F24B22C286F4C81A4224CEC506C9B257D480E02E3B49F44CAA3237F"
 
 /* Hybrid shared secrets are the concatenation: ECDHE || PQ */
 #define X25519_SIKEP434R3_HYBRID_SECRET      (X25519_SHARED_SECRET      SIKEP434R3_SECRET)
@@ -96,8 +98,13 @@ struct hybrid_test_vector {
 #define SECP256R1_BIKE1L1R2_HYBRID_SECRET    (SECP256R1_SHARED_SECRET   BIKE1L1R2_SECRET)
 #define X25519_KYBER512R2_HYBRID_SECRET      (X25519_SHARED_SECRET      KYBER512R2_SECRET)
 #define SECP256R1_KYBER512R2_HYBRID_SECRET   (SECP256R1_SHARED_SECRET   KYBER512R2_SECRET)
+#define X25519_BIKEL1R3_HYBRID_SECRET        (X25519_SHARED_SECRET      BIKEL1R3_SECRET)
+#define SECP256R1_BIKEL1R3_HYBRID_SECRET     (SECP256R1_SHARED_SECRET   BIKEL1R3_SECRET)
+#define X25519_KYBER512R3_HYBRID_SECRET      (X25519_SHARED_SECRET      KYBER512R3_SECRET)
+#define SECP256R1_KYBER512R3_HYBRID_SECRET   (SECP256R1_SHARED_SECRET   KYBER512R3_SECRET)
 
-/* The expected traffic secrets were calculated from an independent implementation,
+
+/* The expected traffic secrets were calculated from an independent Python implementation located in the KAT directory,
  * using the ECDHE & PQ secrets defined above. */
 #define AES_128_SECP256R1_SIKEP434R3_CLIENT_TRAFFIC_SECRET "2fa1a075eaf636138170e3b2a84f6baa4ac08f846ffe2d005ae5e66b03352c11"
 #define AES_128_SECP256R1_SIKEP434R3_SERVER_TRAFFIC_SECRET "423dfaf8fd66b17aaf8c919a9318f3a6bd69875aacdf022aa58a953a7b6de806"
@@ -128,6 +135,27 @@ struct hybrid_test_vector {
 #define AES_128_X25519_KYBER512R2_SERVER_TRAFFIC_SECRET "b186dfdb8fcb91f6bb888e55a73f4afa03e86bab7cc81f6a8ae589bffa9926ed"
 #define AES_256_X25519_KYBER512R2_CLIENT_TRAFFIC_SECRET "d30b4e9ab4416e10fa6e3ed2d2bfde3eecaa1e3d9e75b95b035a9d8a3b240c5e483dee0ebd01fd26bec3662b18cd92e2"
 #define AES_256_X25519_KYBER512R2_SERVER_TRAFFIC_SECRET "ad980d9998e7899e214ae30859125283202a27c96eed23f4dba9991b99785cef79ad1e9dacb1e3017262c476b91c82ff"
+
+#define AES_128_X25519_KYBER512R3_CLIENT_TRAFFIC_SECRET "2d95c9e426941b1cc4a0bd81ee8ba091c6b88edba8c5691dc1b43c0604ff7e74"
+#define AES_128_X25519_KYBER512R3_SERVER_TRAFFIC_SECRET "83852c3c0b49f7d260404362eb2d0d91120bc74c149f2224c562d6ac03b29b6e"
+#define AES_256_X25519_KYBER512R3_CLIENT_TRAFFIC_SECRET "b929a21fae51da944f32d55976c3da4a2f612f9594f7f4fadd853cab614b3cc4c141d85b920f665eec44c6fbd47bee6b"
+#define AES_256_X25519_KYBER512R3_SERVER_TRAFFIC_SECRET "e78dbedab82db5c9fe58db87d0d5cdf031ba7e11dd0cb1c9e2bfe3615569e627142737fc31d659b423b7ebdb476d3672"
+
+#define AES_128_SECP256R1_KYBER512R3_CLIENT_TRAFFIC_SECRET "f14d3873f61f422a0b59100e0b6da0a970300103a634ad444cf4ca78d3ef4fe4"
+#define AES_128_SECP256R1_KYBER512R3_SERVER_TRAFFIC_SECRET "04064ddebdbeaa7b51c15d5e919d8a31da94e6fc979fb354ffe453c15abedf3f"
+#define AES_256_SECP256R1_KYBER512R3_CLIENT_TRAFFIC_SECRET "48204afd077b9620c6220fbffa30a6de8867d6b4c96e2194cba1220b603b00850baf9dd041ef5074df86bb241023a0cd"
+#define AES_256_SECP256R1_KYBER512R3_SERVER_TRAFFIC_SECRET "f2939045fbe7b612da2e96959c64760e763f2f4ef9be049742f51061e063f89668b9acec12440e2b794352f43173243c"
+
+#define AES_128_X25519_BIKEL1R3_CLIENT_TRAFFIC_SECRET "5b5b512a330a0abe81f0b99bc9d1ea60f9ae5cf5a860d8a6cb5a3b4ac57be114"
+#define AES_128_X25519_BIKEL1R3_SERVER_TRAFFIC_SECRET "6dbf5e6b0f1aa1455e0372fea3b317cd0933fb73d4dd0bca649611f994ce104b"
+#define AES_256_X25519_BIKEL1R3_CLIENT_TRAFFIC_SECRET "a9bb52629b84104c74f05d523bf9eac5659a018ef35e8aab575c549d63ca1e3ee440379e1b6f99d7f39eb808e608d959"
+#define AES_256_X25519_BIKEL1R3_SERVER_TRAFFIC_SECRET "a315c44d116d8d5516acbc9b9b1d916117fb544d95104ca2107d9235ec535035fa5deb9600ef3af9e4302f5058a7d4a4"
+
+#define AES_128_SECP256R1_BIKEL1R3_CLIENT_TRAFFIC_SECRET "09fd26eb63957676feece8a3d99b683edb44c38c7f8c935e000951db1e6b1982"
+#define AES_128_SECP256R1_BIKEL1R3_SERVER_TRAFFIC_SECRET "8bcaa10935e461c081f432d12462f402c186e0a6dfb48dc4698569b3678ca5c1"
+#define AES_256_SECP256R1_BIKEL1R3_CLIENT_TRAFFIC_SECRET "348dc98ce31aaf1d6d5acd7d9e54188d06c2a2f5a1af6a679721b76385878ef7961c4b9d2b11e84030fd6fd8f2d67dd7"
+#define AES_256_SECP256R1_BIKEL1R3_SERVER_TRAFFIC_SECRET "7bb939e416a53eede29def33e7b0cfe0a28f83bf6c5726137769286ab7ec927f1b591053fe4081ae54305d6927871d5e"
+
 
 /* A fake transcript string to hash when deriving handshake secrets */
 #define FAKE_TRANSCRIPT "client_hello || server_hello"
@@ -235,6 +263,71 @@ int main(int argc, char **argv) {
             .expected_server_traffic_secret = &aes_256_secp256r1_kyber512r2_server_secret,
     };
 
+    S2N_BLOB_FROM_HEX(bikel1r3_secret, BIKEL1R3_SECRET);
+    S2N_BLOB_FROM_HEX(secp256r1_bikel1r3_hybrid_secret, SECP256R1_BIKEL1R3_HYBRID_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_secp256r1_bikel1r3_client_secret, AES_128_SECP256R1_BIKEL1R3_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_secp256r1_bikel1r3_server_secret, AES_128_SECP256R1_BIKEL1R3_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_128_sha_256_secp256r1_bikel1r3_vector = {
+            .cipher_suite = &s2n_tls13_aes_128_gcm_sha256,
+            .transcript = FAKE_TRANSCRIPT,
+            .kem_group = &s2n_secp256r1_bike_l1_r3,
+            .client_ecc_key = CLIENT_SECP256R1_PRIV_KEY,
+            .server_ecc_key = SERVER_SECP256R1_PRIV_KEY,
+            .pq_secret = &bikel1r3_secret,
+            .expected_hybrid_secret = &secp256r1_bikel1r3_hybrid_secret,
+            .expected_client_traffic_secret = &aes_128_secp256r1_bikel1r3_client_secret,
+            .expected_server_traffic_secret = &aes_128_secp256r1_bikel1r3_server_secret,
+    };
+
+    S2N_BLOB_FROM_HEX(aes_256_secp256r1_bikel1r3_client_secret, AES_256_SECP256R1_BIKEL1R3_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_256_secp256r1_bikel1r3_server_secret, AES_256_SECP256R1_BIKEL1R3_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_256_sha_384_secp256r1_bikel1r3_vector = {
+            .cipher_suite = &s2n_tls13_aes_256_gcm_sha384,
+            .transcript = FAKE_TRANSCRIPT,
+            .kem_group = &s2n_secp256r1_bike_l1_r3,
+            .client_ecc_key = CLIENT_SECP256R1_PRIV_KEY,
+            .server_ecc_key = SERVER_SECP256R1_PRIV_KEY,
+            .pq_secret = &bikel1r3_secret,
+            .expected_hybrid_secret = &secp256r1_bikel1r3_hybrid_secret,
+            .expected_client_traffic_secret = &aes_256_secp256r1_bikel1r3_client_secret,
+            .expected_server_traffic_secret = &aes_256_secp256r1_bikel1r3_server_secret,
+    };
+
+    S2N_BLOB_FROM_HEX(kyber512r3_secret, KYBER512R3_SECRET);
+    S2N_BLOB_FROM_HEX(secp256r1_kyber512r3_hybrid_secret, SECP256R1_KYBER512R3_HYBRID_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_secp256r1_kyber512r3_client_secret, AES_128_SECP256R1_KYBER512R3_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_secp256r1_kyber512r3_server_secret, AES_128_SECP256R1_KYBER512R3_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_128_sha_256_secp256r1_kyber512r3_vector = {
+            .cipher_suite = &s2n_tls13_aes_128_gcm_sha256,
+            .transcript = FAKE_TRANSCRIPT,
+            .kem_group = &s2n_secp256r1_kyber_512_r3,
+            .client_ecc_key = CLIENT_SECP256R1_PRIV_KEY,
+            .server_ecc_key = SERVER_SECP256R1_PRIV_KEY,
+            .pq_secret = &kyber512r3_secret,
+            .expected_hybrid_secret = &secp256r1_kyber512r3_hybrid_secret,
+            .expected_client_traffic_secret = &aes_128_secp256r1_kyber512r3_client_secret,
+            .expected_server_traffic_secret = &aes_128_secp256r1_kyber512r3_server_secret,
+    };
+
+    S2N_BLOB_FROM_HEX(aes_256_secp256r1_kyber512r3_client_secret, AES_256_SECP256R1_KYBER512R3_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_256_secp256r1_kyber512r3_server_secret, AES_256_SECP256R1_KYBER512R3_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_256_sha_384_secp256r1_kyber512r3_vector = {
+            .cipher_suite = &s2n_tls13_aes_256_gcm_sha384,
+            .transcript = FAKE_TRANSCRIPT,
+            .kem_group = &s2n_secp256r1_kyber_512_r3,
+            .client_ecc_key = CLIENT_SECP256R1_PRIV_KEY,
+            .server_ecc_key = SERVER_SECP256R1_PRIV_KEY,
+            .pq_secret = &kyber512r3_secret,
+            .expected_hybrid_secret = &secp256r1_kyber512r3_hybrid_secret,
+            .expected_client_traffic_secret = &aes_256_secp256r1_kyber512r3_client_secret,
+            .expected_server_traffic_secret = &aes_256_secp256r1_kyber512r3_server_secret,
+    };
+
+
 #if EVP_APIS_SUPPORTED
     /* All x25519 based tls13_kem_groups require EVP_APIS_SUPPORTED */
     S2N_BLOB_FROM_HEX(x25519_secret, X25519_SHARED_SECRET);
@@ -331,33 +424,97 @@ int main(int argc, char **argv) {
             .expected_client_traffic_secret = &aes_256_x25519_kyber512r2_client_secret,
             .expected_server_traffic_secret = &aes_256_x25519_kyber512r2_server_secret,
     };
+
+    S2N_BLOB_FROM_HEX(x25519_bikel1r3_hybrid_secret, X25519_BIKEL1R3_HYBRID_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_x25519_bikel1r3_client_secret, AES_128_X25519_BIKEL1R3_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_x25519_bikel1r3_server_secret, AES_128_X25519_BIKEL1R3_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_128_sha_256_x25519_bikel1r3_vector = {
+            .cipher_suite = &s2n_tls13_aes_128_gcm_sha256,
+            .transcript = FAKE_TRANSCRIPT,
+            .kem_group = &s2n_x25519_bike_l1_r3,
+            .client_ecc_key = CLIENT_X25519_PRIV_KEY,
+            .server_ecc_key = SERVER_X25519_PRIV_KEY,
+            .pq_secret = &bikel1r3_secret,
+            .expected_hybrid_secret = &x25519_bikel1r3_hybrid_secret,
+            .expected_client_traffic_secret = &aes_128_x25519_bikel1r3_client_secret,
+            .expected_server_traffic_secret = &aes_128_x25519_bikel1r3_server_secret,
+    };
+
+    S2N_BLOB_FROM_HEX(aes_256_x25519_bikel1r3_client_secret, AES_256_X25519_BIKEL1R3_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_256_x25519_bikel1r3_server_secret, AES_256_X25519_BIKEL1R3_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_256_sha_384_x25519_bikel1r3_vector = {
+            .cipher_suite = &s2n_tls13_aes_256_gcm_sha384,
+            .transcript = FAKE_TRANSCRIPT,
+            .kem_group = &s2n_x25519_bike_l1_r3,
+            .client_ecc_key = CLIENT_X25519_PRIV_KEY,
+            .server_ecc_key = SERVER_X25519_PRIV_KEY,
+            .pq_secret = &bikel1r3_secret,
+            .expected_hybrid_secret = &x25519_bikel1r3_hybrid_secret,
+            .expected_client_traffic_secret = &aes_256_x25519_bikel1r3_client_secret,
+            .expected_server_traffic_secret = &aes_256_x25519_bikel1r3_server_secret,
+    };
+
+    S2N_BLOB_FROM_HEX(x25519_kyber512r3_hybrid_secret, X25519_KYBER512R3_HYBRID_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_x25519_kyber512r3_client_secret, AES_128_X25519_KYBER512R3_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_x25519_kyber512r3_server_secret, AES_128_X25519_KYBER512R3_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_128_sha_256_x25519_kyber512r3_vector = {
+            .cipher_suite = &s2n_tls13_aes_128_gcm_sha256,
+            .transcript = FAKE_TRANSCRIPT,
+            .kem_group = &s2n_x25519_kyber_512_r3,
+            .client_ecc_key = CLIENT_X25519_PRIV_KEY,
+            .server_ecc_key = SERVER_X25519_PRIV_KEY,
+            .pq_secret = &kyber512r3_secret,
+            .expected_hybrid_secret = &x25519_kyber512r3_hybrid_secret,
+            .expected_client_traffic_secret = &aes_128_x25519_kyber512r3_client_secret,
+            .expected_server_traffic_secret = &aes_128_x25519_kyber512r3_server_secret,
+    };
+
+    S2N_BLOB_FROM_HEX(aes_256_x25519_kyber512r3_client_secret, AES_256_X25519_KYBER512R3_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_256_x25519_kyber512r3_server_secret, AES_256_X25519_KYBER512R3_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_256_sha_384_x25519_kyber512r3_vector = {
+            .cipher_suite = &s2n_tls13_aes_256_gcm_sha384,
+            .transcript = FAKE_TRANSCRIPT,
+            .kem_group = &s2n_x25519_kyber_512_r3,
+            .client_ecc_key = CLIENT_X25519_PRIV_KEY,
+            .server_ecc_key = SERVER_X25519_PRIV_KEY,
+            .pq_secret = &kyber512r3_secret,
+            .expected_hybrid_secret = &x25519_kyber512r3_hybrid_secret,
+            .expected_client_traffic_secret = &aes_256_x25519_kyber512r3_client_secret,
+            .expected_server_traffic_secret = &aes_256_x25519_kyber512r3_server_secret,
+    };
+
 #endif
 
-#if EVP_APIS_SUPPORTED
     const struct hybrid_test_vector *all_test_vectors[] = {
+            &aes_128_sha_256_secp256r1_bikel1r3_vector,
+            &aes_256_sha_384_secp256r1_bikel1r3_vector,
+            &aes_128_sha_256_secp256r1_kyber512r3_vector,
+            &aes_256_sha_384_secp256r1_kyber512r3_vector,
             &aes_128_sha_256_secp256r1_sikep434r3_vector,
             &aes_256_sha_384_secp256r1_sikep434r3_vector,
+            &aes_128_sha_256_secp256r1_bike1l1r2_vector,
+            &aes_256_sha_384_secp256r1_bike1l1r2_vector,
+            &aes_128_sha_256_secp256r1_kyber512r2_vector,
+            &aes_256_sha_384_secp256r1_kyber512r2_vector,
+#if EVP_APIS_SUPPORTED
+            &aes_128_sha_256_x25519_bikel1r3_vector,
+            &aes_256_sha_384_x25519_bikel1r3_vector,
+            &aes_128_sha_256_x25519_kyber512r3_vector,
+            &aes_256_sha_384_x25519_kyber512r3_vector,
             &aes_128_sha_256_x25519_sikep434r3_vector,
             &aes_256_sha_384_x25519_sikep434r3_vector,
-            &aes_128_sha_256_secp256r1_bike1l1r2_vector,
-            &aes_256_sha_384_secp256r1_bike1l1r2_vector,
             &aes_128_sha_256_x25519_bike1l1r2_vector,
             &aes_256_sha_384_x25519_bike1l1r2_vector,
-            &aes_128_sha_256_secp256r1_kyber512r2_vector,
-            &aes_256_sha_384_secp256r1_kyber512r2_vector,
             &aes_128_sha_256_x25519_kyber512r2_vector,
             &aes_256_sha_384_x25519_kyber512r2_vector,
-    };
-#else
-    const struct hybrid_test_vector *all_test_vectors[] = {
-            &aes_128_sha_256_secp256r1_sikep434r3_vector,
-            &aes_256_sha_384_secp256r1_sikep434r3_vector,
-            &aes_128_sha_256_secp256r1_bike1l1r2_vector,
-            &aes_256_sha_384_secp256r1_bike1l1r2_vector,
-            &aes_128_sha_256_secp256r1_kyber512r2_vector,
-            &aes_256_sha_384_secp256r1_kyber512r2_vector,
-    };
 #endif
+    };
+
+    EXPECT_EQUAL(s2n_array_len(all_test_vectors), (2 * S2N_SUPPORTED_KEM_GROUPS_COUNT));
 
     {
         /* Happy cases for computing the hybrid shared secret and client & server traffic secrets */


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 
Adds missing Round 3 Post Quantum TLS 1.3 Known Answer Tests to protect against regressions in the TLS 1.3 PQ code.

### Call-outs:
Also checks in the Python script used to generate the test vectors. 

### Testing:
Extends an existing unit test to add more test vectors. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
