### PR TITLE
Only keep one copy of kex params

### DIFF
--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -576,24 +576,28 @@ void cbmc_populate_s2n_session_key(struct s2n_session_key *s2n_session_key)
     s2n_session_key->evp_cipher_ctx = malloc(sizeof(*(s2n_session_key->evp_cipher_ctx)));
 }
 
+void cbmc_populate_s2n_kex_parameters(struct s2n_kex_parameters *s2n_kex_paramters)
+{
+	cbmc_populate_s2n_dh_params(&(s2n_kex_paramters->server_dh_params));
+	cbmc_populate_s2n_ecc_evp_params(&(s2n_kex_paramters->server_ecc_evp_params));
+	/* `s2n_crypto_parameters->mutually_supported_curves`
+	 * `s2n_crypto_parameters->client_ecc_evp_params`
+	 * `s2n_crypto_parameters->client_kem_group_params`
+	 * `s2n_crypto_parameters->mutually_supported_kem_groups` are never allocated.
+	 * If required, these initializations should be done in the proof harness.
+	 */
+	cbmc_populate_s2n_kem_group_params(&(s2n_kex_paramters->server_kem_group_params));
+	s2n_kex_paramters->chosen_client_kem_group_params = cbmc_allocate_s2n_kem_group_params();
+	cbmc_populate_s2n_kem_params(&(s2n_kex_paramters->kem_params));
+	cbmc_populate_s2n_blob(&(s2n_kex_paramters->client_key_exchange_message));
+	cbmc_populate_s2n_blob(&(s2n_kex_paramters->client_pq_kem_extension));
+}
+
 void cbmc_populate_s2n_crypto_parameters(struct s2n_crypto_parameters *s2n_crypto_parameters)
 {
     CBMC_ENSURE_REF(s2n_crypto_parameters);
     cbmc_populate_s2n_pkey(&(s2n_crypto_parameters->server_public_key));
     cbmc_populate_s2n_pkey(&(s2n_crypto_parameters->client_public_key));
-    cbmc_populate_s2n_dh_params(&(s2n_crypto_parameters->server_dh_params));
-    cbmc_populate_s2n_ecc_evp_params(&(s2n_crypto_parameters->server_ecc_evp_params));
-    /* `s2n_crypto_parameters->mutually_supported_curves`
-     * `s2n_crypto_parameters->client_ecc_evp_params`
-     * `s2n_crypto_parameters->client_kem_group_params`
-     * `s2n_crypto_parameters->mutually_supported_kem_groups` are never allocated.
-     * If required, these initializations should be done in the proof harness.
-     */
-    cbmc_populate_s2n_kem_group_params(&(s2n_crypto_parameters->server_kem_group_params));
-    s2n_crypto_parameters->chosen_client_kem_group_params = cbmc_allocate_s2n_kem_group_params();
-    cbmc_populate_s2n_kem_params(&(s2n_crypto_parameters->kem_params));
-    cbmc_populate_s2n_blob(&(s2n_crypto_parameters->client_key_exchange_message));
-    cbmc_populate_s2n_blob(&(s2n_crypto_parameters->client_pq_kem_extension));
     cbmc_populate_s2n_signature_scheme(&(s2n_crypto_parameters->conn_sig_scheme));
     cbmc_populate_s2n_blob(&(s2n_crypto_parameters->client_cert_chain));
     cbmc_populate_s2n_signature_scheme(&(s2n_crypto_parameters->client_cert_sig_scheme));
@@ -767,6 +771,7 @@ void cbmc_populate_s2n_connection(struct s2n_connection *s2n_connection)
     s2n_connection->recv_io_context          = malloc(sizeof(*(s2n_connection->secret_cb)));
     cbmc_populate_s2n_crypto_parameters(&(s2n_connection->initial));
     cbmc_populate_s2n_crypto_parameters(&(s2n_connection->secure));
+    cbmc_populate_s2n_kex_parameters(&(s2n_connection->kex_params));
     s2n_connection->client = cbmc_allocate_s2n_crypto_parameters();
     s2n_connection->server = cbmc_allocate_s2n_crypto_parameters();
     cbmc_populate_s2n_handshake_parameters(&(s2n_connection->handshake_params));

--- a/tests/fuzz/s2n_client_key_recv_fuzz_test.c
+++ b/tests/fuzz/s2n_client_key_recv_fuzz_test.c
@@ -122,12 +122,12 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     POSIX_ENSURE_REF(ecc_preferences);
 
     if (server_conn->secure.cipher_suite->key_exchange_alg->client_key_recv == s2n_ecdhe_client_key_recv || server_conn->secure.cipher_suite->key_exchange_alg->client_key_recv == s2n_hybrid_client_key_recv) {
-        server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-        s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params);
+        server_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+        s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.server_ecc_evp_params);
     }
 
     if (server_conn->secure.cipher_suite->key_exchange_alg->client_key_recv == s2n_kem_client_key_recv || server_conn->secure.cipher_suite->key_exchange_alg->client_key_recv == s2n_hybrid_client_key_recv) {
-        server_conn->secure.kem_params.kem = &s2n_sike_p503_r1;
+        server_conn->kex_params.kem_params.kem = &s2n_sike_p503_r1;
     }
 
     /* Run Test

--- a/tests/fuzz/s2n_extensions_server_key_share_recv_test.c
+++ b/tests/fuzz/s2n_extensions_server_key_share_recv_test.c
@@ -66,8 +66,8 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Generate ephemeral keys for all supported curves */
     for (int i = 0; i < ecc_preferences->count; i++) {
-        client_conn->secure.client_ecc_evp_params[i].negotiated_curve = ecc_preferences->ecc_curves[i];
-        POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[i]));
+        client_conn->kex_params.client_ecc_evp_params[i].negotiated_curve = ecc_preferences->ecc_curves[i];
+        POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params[i]));
     }
 
     /* Run Test

--- a/tests/fuzz/s2n_hybrid_ecdhe_bike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_bike_r1_fuzz_test.c
@@ -49,14 +49,14 @@ static int setup_connection(struct s2n_connection *server_conn)
     POSIX_GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
     POSIX_ENSURE_REF(ecc_preferences);
 
-    server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-    server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
-    server_conn->secure.kem_params.kem = &s2n_bike1_l1_r1;
+    server_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+    server_conn->kex_params.server_ecc_evp_params.evp_pkey = NULL;
+    server_conn->kex_params.kem_params.kem = &s2n_bike1_l1_r1;
     server_conn->secure.cipher_suite = &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
-    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->kex_params.kem_params.private_key));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.server_ecc_evp_params));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_hybrid_ecdhe_bike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_bike_r2_fuzz_test.c
@@ -49,14 +49,14 @@ static int setup_connection(struct s2n_connection *server_conn)
     POSIX_GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
     POSIX_ENSURE_REF(ecc_preferences);
 
-    server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-    server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
-    server_conn->secure.kem_params.kem = &s2n_bike1_l1_r2;
+    server_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+    server_conn->kex_params.server_ecc_evp_params.evp_pkey = NULL;
+    server_conn->kex_params.kem_params.kem = &s2n_bike1_l1_r2;
     server_conn->secure.cipher_suite = &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
-    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->kex_params.kem_params.private_key));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.server_ecc_evp_params));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_hybrid_ecdhe_bike_r3_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_bike_r3_fuzz_test.c
@@ -49,14 +49,14 @@ static int setup_connection(struct s2n_connection *server_conn)
     POSIX_GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
     POSIX_ENSURE_REF(ecc_preferences);
 
-    server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-    server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
-    server_conn->secure.kem_params.kem = &s2n_bike_l1_r3;
+    server_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+    server_conn->kex_params.server_ecc_evp_params.evp_pkey = NULL;
+    server_conn->kex_params.kem_params.kem = &s2n_bike_l1_r3;
     server_conn->secure.cipher_suite = &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
-    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->kex_params.kem_params.private_key));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.server_ecc_evp_params));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_hybrid_ecdhe_kyber_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_kyber_r2_fuzz_test.c
@@ -49,14 +49,14 @@ static int setup_connection(struct s2n_connection *server_conn)
     POSIX_GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
     POSIX_ENSURE_REF(ecc_preferences);
 
-    server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-    server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
-    server_conn->secure.kem_params.kem = &s2n_kyber_512_r2;
+    server_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+    server_conn->kex_params.server_ecc_evp_params.evp_pkey = NULL;
+    server_conn->kex_params.kem_params.kem = &s2n_kyber_512_r2;
     server_conn->secure.cipher_suite = &s2n_ecdhe_kyber_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
-    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->kex_params.kem_params.private_key));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.server_ecc_evp_params));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_hybrid_ecdhe_sike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_sike_r1_fuzz_test.c
@@ -49,14 +49,14 @@ static int setup_connection(struct s2n_connection *server_conn)
     POSIX_GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
     POSIX_ENSURE_REF(ecc_preferences);
 
-    server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-    server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
-    server_conn->secure.kem_params.kem = &s2n_sike_p503_r1;
+    server_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+    server_conn->kex_params.server_ecc_evp_params.evp_pkey = NULL;
+    server_conn->kex_params.kem_params.kem = &s2n_sike_p503_r1;
     server_conn->secure.cipher_suite = &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
-    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->kex_params.kem_params.private_key));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.server_ecc_evp_params));
 
     return S2N_SUCCESS;
 }

--- a/tests/fuzz/s2n_hybrid_ecdhe_sike_r3_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_sike_r3_fuzz_test.c
@@ -49,14 +49,14 @@ static int setup_connection(struct s2n_connection *server_conn)
     POSIX_GUARD(s2n_connection_get_ecc_preferences(server_conn, &ecc_preferences));
     POSIX_ENSURE_REF(ecc_preferences);
 
-    server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-    server_conn->secure.server_ecc_evp_params.evp_pkey = NULL;
-    server_conn->secure.kem_params.kem = &s2n_sike_p434_r3;
+    server_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+    server_conn->kex_params.server_ecc_evp_params.evp_pkey = NULL;
+    server_conn->kex_params.kem_params.kem = &s2n_sike_p434_r3;
     server_conn->secure.cipher_suite = &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384;
     server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
-    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->secure.kem_params.private_key));
-    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->kex_params.kem_params.private_key));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.server_ecc_evp_params));
 
     return S2N_SUCCESS;
 }

--- a/tests/testlib/s2n_pq_hybrid_test_utils.c
+++ b/tests/testlib/s2n_pq_hybrid_test_utils.c
@@ -61,8 +61,8 @@ static int setup_connection(struct s2n_connection *conn, const struct s2n_kem *k
     POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
     POSIX_GUARD_PTR(ecc_preferences);
 
-    conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-    conn->secure.kem_params.kem = kem;
+    conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+    conn->kex_params.kem_params.kem = kem;
     conn->secure.cipher_suite = cipher_suite;
     conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
     POSIX_GUARD(s2n_connection_set_cipher_preferences(conn, cipher_pref_version));

--- a/tests/unit/s2n_choose_supported_group_test.c
+++ b/tests/unit/s2n_choose_supported_group_test.c
@@ -46,24 +46,24 @@ int main() {
             EXPECT_EQUAL(kem_pref, &kem_preferences_null);
 
             for (size_t i = 0; i < ecc_pref->count; i++) {
-                EXPECT_NULL(server_conn->secure.mutually_supported_curves[i]);
+                EXPECT_NULL(server_conn->kex_params.mutually_supported_curves[i]);
             }
 
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                EXPECT_NULL(server_conn->secure.mutually_supported_kem_groups[i]);
+                EXPECT_NULL(server_conn->kex_params.mutually_supported_kem_groups[i]);
             }
 
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
 
             EXPECT_SUCCESS(s2n_choose_supported_group(server_conn));
 
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
 
@@ -82,26 +82,26 @@ int main() {
             EXPECT_NOT_NULL(kem_pref);
             EXPECT_EQUAL(kem_pref, &kem_preferences_null);
 
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
 
             for (size_t i = 0; i < ecc_pref->count; i++) {
-                EXPECT_NULL(server_conn->secure.mutually_supported_curves[i]);
+                EXPECT_NULL(server_conn->kex_params.mutually_supported_curves[i]);
             }
 
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                EXPECT_NULL(server_conn->secure.mutually_supported_kem_groups[i]);
+                EXPECT_NULL(server_conn->kex_params.mutually_supported_kem_groups[i]);
             }
 
-            server_conn->secure.mutually_supported_curves[1] = ecc_pref->ecc_curves[1];
+            server_conn->kex_params.mutually_supported_curves[1] = ecc_pref->ecc_curves[1];
             EXPECT_SUCCESS(s2n_choose_supported_group(server_conn));
 
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
-            EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[1]);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
+            EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[1]);
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
 
@@ -121,19 +121,19 @@ int main() {
             EXPECT_EQUAL(kem_pref, &kem_preferences_null);
 
             for (size_t i = 0; i < ecc_pref->count; i++) {
-                server_conn->secure.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
+                server_conn->kex_params.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
             }
 
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                EXPECT_NULL(server_conn->secure.mutually_supported_kem_groups[i]);
+                EXPECT_NULL(server_conn->kex_params.mutually_supported_kem_groups[i]);
             }
 
             EXPECT_SUCCESS(s2n_choose_supported_group(server_conn));
 
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
-            EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
+            EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
     }
@@ -176,25 +176,25 @@ int main() {
             EXPECT_NOT_NULL(kem_pref);
             EXPECT_EQUAL(kem_pref, &test_kem_prefs);
 
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
 
             for (size_t i = 0; i < ecc_pref->count; i++) {
-                server_conn->secure.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
+                server_conn->kex_params.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
             }
 
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                EXPECT_NULL(server_conn->secure.mutually_supported_kem_groups[i]);
+                EXPECT_NULL(server_conn->kex_params.mutually_supported_kem_groups[i]);
             }
 
             EXPECT_SUCCESS(s2n_choose_supported_group(server_conn));
 
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
-            EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
+            EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
 
@@ -214,25 +214,25 @@ int main() {
             EXPECT_NOT_NULL(kem_pref);
             EXPECT_EQUAL(kem_pref, &test_kem_prefs);
 
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
 
             for (size_t i = 0; i < ecc_pref->count; i++) {
-                server_conn->secure.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
+                server_conn->kex_params.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
             }
 
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                server_conn->secure.mutually_supported_kem_groups[i] = kem_pref->tls13_kem_groups[i];
+                server_conn->kex_params.mutually_supported_kem_groups[i] = kem_pref->tls13_kem_groups[i];
             }
 
             EXPECT_SUCCESS(s2n_choose_supported_group(server_conn));
 
-            EXPECT_EQUAL(server_conn->secure.server_kem_group_params.kem_group, kem_pref->tls13_kem_groups[0]);
-            EXPECT_EQUAL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve, kem_pref->tls13_kem_groups[0]->curve);
-            EXPECT_EQUAL(server_conn->secure.server_kem_group_params.kem_params.kem, kem_pref->tls13_kem_groups[0]->kem);
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_EQUAL(server_conn->kex_params.server_kem_group_params.kem_group, kem_pref->tls13_kem_groups[0]);
+            EXPECT_EQUAL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve, kem_pref->tls13_kem_groups[0]->curve);
+            EXPECT_EQUAL(server_conn->kex_params.server_kem_group_params.kem_params.kem, kem_pref->tls13_kem_groups[0]->kem);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
 
@@ -252,26 +252,26 @@ int main() {
             EXPECT_NOT_NULL(kem_pref);
             EXPECT_EQUAL(kem_pref, &test_kem_prefs);
 
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
 
             for (size_t i = 0; i < ecc_pref->count; i++) {
-                server_conn->secure.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
+                server_conn->kex_params.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
             }
 
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                EXPECT_NULL(server_conn->secure.mutually_supported_kem_groups[i]);
+                EXPECT_NULL(server_conn->kex_params.mutually_supported_kem_groups[i]);
             }
 
-            server_conn->secure.mutually_supported_kem_groups[1] = kem_pref->tls13_kem_groups[1];
+            server_conn->kex_params.mutually_supported_kem_groups[1] = kem_pref->tls13_kem_groups[1];
             EXPECT_SUCCESS(s2n_choose_supported_group(server_conn));
 
-            EXPECT_EQUAL(server_conn->secure.server_kem_group_params.kem_group, kem_pref->tls13_kem_groups[1]);
-            EXPECT_EQUAL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve, kem_pref->tls13_kem_groups[1]->curve);
-            EXPECT_EQUAL(server_conn->secure.server_kem_group_params.kem_params.kem, kem_pref->tls13_kem_groups[1]->kem);
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_EQUAL(server_conn->kex_params.server_kem_group_params.kem_group, kem_pref->tls13_kem_groups[1]);
+            EXPECT_EQUAL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve, kem_pref->tls13_kem_groups[1]->curve);
+            EXPECT_EQUAL(server_conn->kex_params.server_kem_group_params.kem_params.kem, kem_pref->tls13_kem_groups[1]->kem);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
 
@@ -291,24 +291,24 @@ int main() {
             EXPECT_EQUAL(kem_pref, &test_kem_prefs);
 
             for (size_t i = 0; i < ecc_pref->count; i++) {
-                EXPECT_NULL(server_conn->secure.mutually_supported_curves[i]);
+                EXPECT_NULL(server_conn->kex_params.mutually_supported_curves[i]);
             }
 
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                EXPECT_NULL(server_conn->secure.mutually_supported_kem_groups[i]);
+                EXPECT_NULL(server_conn->kex_params.mutually_supported_kem_groups[i]);
             }
 
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
 
             EXPECT_SUCCESS(s2n_choose_supported_group(server_conn));
 
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
     }

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -317,7 +317,7 @@ int main(int argc, char **argv)
 
         /* Assume default for negotiated curve. */
         /* Shouldn't be necessary unless the test fails, but we want the failure to be obvious. */
-        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
         conn->actual_protocol_version = conn->server_protocol_version;
         const struct s2n_cipher_suite *expected_rsa_wire_choice = &s2n_ecdhe_rsa_with_aes_128_cbc_sha;
         EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -355,9 +355,9 @@ int main(int argc, char **argv)
             int client_extensions_len = sizeof(client_extensions_data);
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "KMS-PQ-TLS-1-0-2019-06"));
             conn->actual_protocol_version = S2N_TLS12;
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-            conn->secure.client_pq_kem_extension.data = client_extensions_data;
-            conn->secure.client_pq_kem_extension.size = client_extensions_len;
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->kex_params.client_pq_kem_extension.data = client_extensions_data;
+            conn->kex_params.client_pq_kem_extension.size = client_extensions_len;
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers, cipher_count));
             const struct s2n_cipher_suite *bike_cipher = &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;
             const struct s2n_cipher_suite *ecc_cipher = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
@@ -376,9 +376,9 @@ int main(int argc, char **argv)
                 const struct s2n_cipher_suite *expected_classic_wire_choice = &s2n_ecdhe_rsa_with_aes_256_cbc_sha;
                 EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "KMS-PQ-TLS-1-0-2019-06"));
                 conn->actual_protocol_version = i;
-                conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-                conn->secure.client_pq_kem_extension.data = client_extensions_data;
-                conn->secure.client_pq_kem_extension.size = client_extensions_len;
+                conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+                conn->kex_params.client_pq_kem_extension.data = client_extensions_data;
+                conn->kex_params.client_pq_kem_extension.size = client_extensions_len;
                 EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers, cipher_count));
                 EXPECT_EQUAL(conn->secure.cipher_suite, expected_classic_wire_choice);
                 EXPECT_SUCCESS(s2n_connection_wipe(conn));
@@ -400,7 +400,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all_ecdsa"));
         const struct s2n_cipher_suite *expected_ecdsa_wire_choice = &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256;
         /* Assume default for negotiated curve. */
-        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
         conn->actual_protocol_version = conn->server_protocol_version;
         EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
         EXPECT_EQUAL(conn->secure_renegotiation, 0);
@@ -410,7 +410,7 @@ int main(int argc, char **argv)
         /* TEST ECDSA cipher chosen when RSA cipher is at top */
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all"));
         /* Assume default for negotiated curve. */
-        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
         conn->actual_protocol_version = conn->server_protocol_version;
         EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
         EXPECT_EQUAL(conn->secure_renegotiation, 0);
@@ -429,7 +429,7 @@ int main(int argc, char **argv)
         {
             const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_ecdsa_priority"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -442,7 +442,7 @@ int main(int argc, char **argv)
         {
             const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_rsa_with_aes_128_cbc_sha;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -458,7 +458,7 @@ int main(int argc, char **argv)
             const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_rsa_with_aes_128_cbc_sha;
             /* 20170328 only supports RSA ciphers */
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20170328"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -473,7 +473,7 @@ int main(int argc, char **argv)
         {
             const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all_ecdsa"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -488,7 +488,7 @@ int main(int argc, char **argv)
         {
             const struct s2n_cipher_suite *expected_wire_choice = &s2n_rsa_with_rc4_128_md5;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_ecdsa_priority"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers, cipher_count));
@@ -503,7 +503,7 @@ int main(int argc, char **argv)
         {
             const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_ecdsa_priority"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_only_ecdsa, cipher_count_only_ecdsa));
@@ -523,7 +523,7 @@ int main(int argc, char **argv)
             /* Selecting this preference list because it prioritizes ECDHE-ECDSA and ECDHE-RSA over plain RSA kx. */
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "CloudFront-Upstream"));
             /* No shared curve */
-            conn->secure.server_ecc_evp_params.negotiated_curve = NULL;
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = NULL;
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_rsa_fallback, cipher_count_rsa_fallback));
@@ -544,7 +544,7 @@ int main(int argc, char **argv)
         {
             const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_rsa_with_aes_128_cbc_sha;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_ecdsa_priority"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -561,7 +561,7 @@ int main(int argc, char **argv)
         {
             const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -578,7 +578,7 @@ int main(int argc, char **argv)
         {
             const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_ecdsa_priority"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -603,7 +603,7 @@ int main(int argc, char **argv)
         {
             const struct s2n_cipher_suite *expected_wire_choice = &s2n_ecdhe_rsa_with_aes_128_cbc_sha;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all"));
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             conn->actual_protocol_version = conn->server_protocol_version;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, server_config));
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_ecdsa, cipher_count_ecdsa));
@@ -689,7 +689,7 @@ int main(int argc, char **argv)
             const uint8_t count = sizeof(test_wire_ciphers) / S2N_TLS_CIPHER_SUITE_LEN;
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all"));
             conn->actual_protocol_version = S2N_TLS12;
-            conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
 
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, test_wire_ciphers, count));
             EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_ecdhe_rsa_with_aes_128_gcm_sha256);
@@ -703,7 +703,7 @@ int main(int argc, char **argv)
             /* Skip but fall back to cipher suite with protocol version higher than connection */
             {
                 EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all"));
-                conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
+                conn->kex_params.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
 
                 uint8_t test_wire_ciphers[] = {
                     TLS_AES_128_GCM_SHA256, /* tls 1.3 */
@@ -727,7 +727,7 @@ int main(int argc, char **argv)
             /* Skip and do NOT fall back to a TLS1.3 cipher suite if using TLS1.2 */
             {
                 EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all"));
-                conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
+                conn->kex_params.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
 
                 uint8_t test_wire_ciphers[] = {
                         TLS_AES_128_GCM_SHA256, /* tls 1.3 */
@@ -751,7 +751,7 @@ int main(int argc, char **argv)
             /* Skip and do NOT fall back to a TLS1.2 cipher suite if using TLS1.3 */
             {
                 EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all"));
-                conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
+                conn->kex_params.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
 
                 uint8_t test_wire_ciphers[] = {
                         TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, /* tls 1.2 */
@@ -784,7 +784,7 @@ int main(int argc, char **argv)
             /* If chosen PSK is set, a cipher suite with matching HMAC algorithm must be selected */
             {
                 s2n_connection_set_cipher_preferences(conn, "test_all");
-                conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
+                conn->kex_params.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
                 conn->actual_protocol_version = S2N_TLS13;
 
                 EXPECT_OK(s2n_conn_set_chosen_psk(conn));
@@ -803,7 +803,7 @@ int main(int argc, char **argv)
             /* If chosen PSK is set but there is no matching cipher, the server MUST fail to set a cipher */
             {
                 s2n_connection_set_cipher_preferences(conn, "test_all");
-                conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
+                conn->kex_params.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
                 conn->actual_protocol_version = S2N_TLS13;
 
                 /* S2N_HMAC_SHA1 is not a matching HMAC algorithm for any TLS1.3 cipher */

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -114,7 +114,7 @@ static int negotiate_kem(const uint8_t client_extensions[], const size_t client_
     POSIX_GUARD(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
     POSIX_GUARD(s2n_config_set_cipher_preferences(server_config, cipher_pref_version));
     POSIX_GUARD(s2n_connection_set_config(server_conn, server_config));
-    server_conn->secure.kem_params.kem = NULL;
+    server_conn->kex_params.kem_params.kem = NULL;
 
     /* Send the client hello */
     POSIX_ENSURE_EQ(write(io_pair->client, record_header, record_header_len),record_header_len);
@@ -131,8 +131,8 @@ static int negotiate_kem(const uint8_t client_extensions[], const size_t client_
 
     int negotiated_kem_id;
 
-    if (server_conn->secure.kem_params.kem != NULL) {
-        negotiated_kem_id = server_conn->secure.kem_params.kem->kem_extension_id;
+    if (server_conn->kex_params.kem_params.kem != NULL) {
+        negotiated_kem_id = server_conn->kex_params.kem_params.kem->kem_extension_id;
     } else {
         negotiated_kem_id = -1;
     }

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -486,7 +486,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
 
         /* ensure negotiated_curve == secp256r1 for maximum client compatibility */
-        EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, &s2n_ecc_curve_secp256r1);
+        EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve, &s2n_ecc_curve_secp256r1);
 
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);

--- a/tests/unit/s2n_client_key_share_extension_pq_test.c
+++ b/tests/unit/s2n_client_key_share_extension_pq_test.c
@@ -165,7 +165,7 @@ int main() {
 
                         /* First, assert that the client saved its private keys correctly in the connection state
                          * for both hybrid PQ and classic ECC */
-                        struct s2n_kem_group_params *kem_group_params = &conn->secure.client_kem_group_params[0];
+                        struct s2n_kem_group_params *kem_group_params = &conn->kex_params.client_kem_group_params[0];
                         EXPECT_EQUAL(kem_group_params->kem_group, test_kem_group);
                         EXPECT_EQUAL(kem_group_params->kem_params.kem, test_kem_group->kem);
                         EXPECT_NOT_NULL(kem_group_params->kem_params.private_key.data);
@@ -173,23 +173,23 @@ int main() {
                         EXPECT_EQUAL(kem_group_params->ecc_params.negotiated_curve, test_kem_group->curve);
                         EXPECT_NOT_NULL(kem_group_params->ecc_params.evp_pkey);
 
-                        struct s2n_ecc_evp_params *ecc_params = &conn->secure.client_ecc_evp_params[0];
+                        struct s2n_ecc_evp_params *ecc_params = &conn->kex_params.client_ecc_evp_params[0];
                         EXPECT_EQUAL(ecc_params->negotiated_curve, ecc_pref->ecc_curves[0]);
                         EXPECT_NOT_NULL(ecc_params->evp_pkey);
 
                         /* Next, assert that the client didn't generate/save any hybrid or ECC params that it shouldn't have */
                         for (size_t kem_group_index = 1;
                              kem_group_index < S2N_SUPPORTED_KEM_GROUPS_COUNT; kem_group_index++) {
-                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_group);
-                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_params.kem);
-                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].kem_params.private_key.data);
-                            EXPECT_EQUAL(conn->secure.client_kem_group_params[kem_group_index].kem_params.private_key.size,0);
-                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].ecc_params.negotiated_curve);
-                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_index].ecc_params.evp_pkey);
+                            EXPECT_NULL(conn->kex_params.client_kem_group_params[kem_group_index].kem_group);
+                            EXPECT_NULL(conn->kex_params.client_kem_group_params[kem_group_index].kem_params.kem);
+                            EXPECT_NULL(conn->kex_params.client_kem_group_params[kem_group_index].kem_params.private_key.data);
+                            EXPECT_EQUAL(conn->kex_params.client_kem_group_params[kem_group_index].kem_params.private_key.size,0);
+                            EXPECT_NULL(conn->kex_params.client_kem_group_params[kem_group_index].ecc_params.negotiated_curve);
+                            EXPECT_NULL(conn->kex_params.client_kem_group_params[kem_group_index].ecc_params.evp_pkey);
                         }
                         for (size_t ecc_index = 1; ecc_index < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; ecc_index++) {
-                            EXPECT_NULL(conn->secure.client_ecc_evp_params[ecc_index].negotiated_curve);
-                            EXPECT_NULL(conn->secure.client_ecc_evp_params[ecc_index].evp_pkey);
+                            EXPECT_NULL(conn->kex_params.client_ecc_evp_params[ecc_index].negotiated_curve);
+                            EXPECT_NULL(conn->kex_params.client_ecc_evp_params[ecc_index].evp_pkey);
                         }
 
                         /* Now, assert that the client sent the correct bytes over the wire for the key share extension */
@@ -258,8 +258,8 @@ int main() {
                         EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &key_share_extension));
                         EXPECT_SUCCESS(s2n_stuffer_wipe(&key_share_extension));
                         /* Quick sanity check */
-                        EXPECT_NOT_NULL(conn->secure.client_kem_group_params[0].kem_params.private_key.data);
-                        EXPECT_NOT_NULL(conn->secure.client_kem_group_params[0].ecc_params.evp_pkey);
+                        EXPECT_NOT_NULL(conn->kex_params.client_kem_group_params[0].kem_params.private_key.data);
+                        EXPECT_NOT_NULL(conn->kex_params.client_kem_group_params[0].ecc_params.evp_pkey);
 
                         /* Prepare client for HRR. Client would have sent a key share for kem_pref->tls13_kem_groups[0],
                          * but server selects something else for negotiation. */
@@ -269,12 +269,12 @@ int main() {
                         uint8_t chosen_index = kem_pref->tls13_kem_group_count - 1;
                         EXPECT_NOT_EQUAL(chosen_index, 0);
                         const struct s2n_kem_group *negotiated_kem_group = kem_pref->tls13_kem_groups[chosen_index];
-                        conn->secure.server_kem_group_params.kem_group = negotiated_kem_group;
+                        conn->kex_params.server_kem_group_params.kem_group = negotiated_kem_group;
 
                         EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &key_share_extension));
 
                         /* Assert that the client saved its private keys correctly in the connection state for hybrid */
-                        struct s2n_kem_group_params *kem_group_params = &conn->secure.client_kem_group_params[chosen_index];
+                        struct s2n_kem_group_params *kem_group_params = &conn->kex_params.client_kem_group_params[chosen_index];
                         EXPECT_EQUAL(kem_group_params->kem_group, negotiated_kem_group);
                         EXPECT_EQUAL(kem_group_params->kem_params.kem, negotiated_kem_group->kem);
                         EXPECT_NOT_NULL(kem_group_params->kem_params.private_key.data);
@@ -287,16 +287,16 @@ int main() {
                             if (kem_group_i == chosen_index || kem_group_i == 0) {
                                 continue;
                             }
-                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_i].kem_group);
-                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_i].kem_params.kem);
-                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_i].kem_params.private_key.data);
-                            EXPECT_EQUAL(conn->secure.client_kem_group_params[kem_group_i].kem_params.private_key.size,0);
-                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_i].ecc_params.negotiated_curve);
-                            EXPECT_NULL(conn->secure.client_kem_group_params[kem_group_i].ecc_params.evp_pkey);
+                            EXPECT_NULL(conn->kex_params.client_kem_group_params[kem_group_i].kem_group);
+                            EXPECT_NULL(conn->kex_params.client_kem_group_params[kem_group_i].kem_params.kem);
+                            EXPECT_NULL(conn->kex_params.client_kem_group_params[kem_group_i].kem_params.private_key.data);
+                            EXPECT_EQUAL(conn->kex_params.client_kem_group_params[kem_group_i].kem_params.private_key.size,0);
+                            EXPECT_NULL(conn->kex_params.client_kem_group_params[kem_group_i].ecc_params.negotiated_curve);
+                            EXPECT_NULL(conn->kex_params.client_kem_group_params[kem_group_i].ecc_params.evp_pkey);
                         }
                         for (size_t ecc_index = 1; ecc_index < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; ecc_index++) {
-                            EXPECT_NULL(conn->secure.client_ecc_evp_params[ecc_index].negotiated_curve);
-                            EXPECT_NULL(conn->secure.client_ecc_evp_params[ecc_index].evp_pkey);
+                            EXPECT_NULL(conn->kex_params.client_ecc_evp_params[ecc_index].negotiated_curve);
+                            EXPECT_NULL(conn->kex_params.client_ecc_evp_params[ecc_index].evp_pkey);
                         }
 
                         /* Assert that the client sent the correct bytes over the wire for the key share extension */
@@ -356,9 +356,9 @@ int main() {
 
                         EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &first_extension));
 
-                        conn->secure.server_kem_group_params.kem_group = conn->secure.client_kem_group_params[0].kem_group;
-                        conn->secure.server_kem_group_params.ecc_params.negotiated_curve =
-                                conn->secure.client_kem_group_params[0].ecc_params.negotiated_curve;
+                        conn->kex_params.server_kem_group_params.kem_group = conn->kex_params.client_kem_group_params[0].kem_group;
+                        conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve =
+                                conn->kex_params.client_kem_group_params[0].ecc_params.negotiated_curve;
 
                         /* Setup the client to have received a HelloRetryRequest */
                         EXPECT_MEMCPY_SUCCESS(conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
@@ -382,7 +382,7 @@ int main() {
                         uint16_t first_sent_hybrid_iana_id = 0, second_sent_hybrid_iana_id = 0;
                         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&first_extension, &first_sent_hybrid_iana_id));
                         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&second_extension, &second_sent_hybrid_iana_id));
-                        EXPECT_EQUAL(first_sent_hybrid_iana_id, conn->secure.server_kem_group_params.kem_group->iana_id);
+                        EXPECT_EQUAL(first_sent_hybrid_iana_id, conn->kex_params.server_kem_group_params.kem_group->iana_id);
                         EXPECT_EQUAL(first_sent_hybrid_iana_id, second_sent_hybrid_iana_id);
 
                         /* Read the total share size, including both ecc and kem.
@@ -430,7 +430,7 @@ int main() {
                     conn->handshake.message_number = HELLO_RETRY_MSG_NO;
                     conn->actual_protocol_version_established = 1;
 
-                    conn->secure.server_kem_group_params.kem_group = &s2n_secp256r1_bike1_l1_r2;
+                    conn->kex_params.server_kem_group_params.kem_group = &s2n_secp256r1_bike1_l1_r2;
 
                     DEFER_CLEANUP(struct s2n_stuffer key_share_extension = {0}, s2n_stuffer_free);
                     EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, MEM_FOR_EXTENSION));
@@ -483,7 +483,7 @@ int main() {
                 EXPECT_NOT_NULL(ecc_pref);
 
                 for (size_t ec_index = 0; ec_index < ecc_pref->count; ec_index++) {
-                    struct s2n_ecc_evp_params *received_params = &server_conn->secure.client_ecc_evp_params[ec_index];
+                    struct s2n_ecc_evp_params *received_params = &server_conn->kex_params.client_ecc_evp_params[ec_index];
                     EXPECT_NULL(received_params->negotiated_curve);
                     EXPECT_NULL(received_params->evp_pkey);
                 }
@@ -493,7 +493,7 @@ int main() {
                 EXPECT_NOT_NULL(server_kem_pref);
 
                 for (size_t pq_index = 0; pq_index < server_kem_pref->tls13_kem_group_count; pq_index++) {
-                    struct s2n_kem_group_params *received_params = &server_conn->secure.client_kem_group_params[pq_index];
+                    struct s2n_kem_group_params *received_params = &server_conn->kex_params.client_kem_group_params[pq_index];
                     EXPECT_NULL(received_params->kem_group);
                     EXPECT_NULL(received_params->ecc_params.negotiated_curve);
                     EXPECT_NULL(received_params->ecc_params.evp_pkey);
@@ -556,7 +556,7 @@ int main() {
                          * so we make a copy from the wire to ensure that server saved it correctly. */
                         DEFER_CLEANUP(struct s2n_blob pq_key_share_copy = {0}, s2n_free);
                         EXPECT_SUCCESS(s2n_copy_pq_share(&key_share_extension, &pq_key_share_copy,
-                                client_conn->secure.client_kem_group_params[0].kem_group));
+                                client_conn->kex_params.client_kem_group_params[0].kem_group));
 
                         EXPECT_SUCCESS(s2n_client_key_share_extension.recv(server_conn, &key_share_extension));
 
@@ -569,8 +569,8 @@ int main() {
 
                         /* Client should have sent only the first ECC key share, server should have accepted it */
                         for (size_t ec_index = 0; ec_index < ecc_pref->count; ec_index++) {
-                            struct s2n_ecc_evp_params *sent_params = &client_conn->secure.client_ecc_evp_params[ec_index];
-                            struct s2n_ecc_evp_params *received_params = &server_conn->secure.client_ecc_evp_params[ec_index];
+                            struct s2n_ecc_evp_params *sent_params = &client_conn->kex_params.client_ecc_evp_params[ec_index];
+                            struct s2n_ecc_evp_params *received_params = &server_conn->kex_params.client_ecc_evp_params[ec_index];
 
                             if (ec_index == 0) {
                                 EXPECT_NOT_NULL(received_params->negotiated_curve);
@@ -590,9 +590,9 @@ int main() {
                          * the client and server KEM preferences include all the same KEM groups, but may be in
                          * different order. */
                         size_t shares_accepted_by_server = 0;
-                        struct s2n_kem_group_params *sent_params = &client_conn->secure.client_kem_group_params[0];
+                        struct s2n_kem_group_params *sent_params = &client_conn->kex_params.client_kem_group_params[0];
                         for (size_t pq_index = 0; pq_index < server_kem_pref->tls13_kem_group_count; pq_index++) {
-                            struct s2n_kem_group_params *received_params = &server_conn->secure.client_kem_group_params[pq_index];
+                            struct s2n_kem_group_params *received_params = &server_conn->kex_params.client_kem_group_params[pq_index];
 
                             if (sent_params->kem_group == received_params->kem_group) {
                                 EXPECT_EQUAL(received_params->ecc_params.negotiated_curve,sent_params->ecc_params.negotiated_curve);
@@ -661,7 +661,7 @@ int main() {
                     /* Server should have accepted p256 share and no other EC shares */
                     bool p256_accepted = false;
                     for (size_t ec_index = 0; ec_index < ecc_pref->count; ec_index++) {
-                        struct s2n_ecc_evp_params *received_params = &server_conn->secure.client_ecc_evp_params[ec_index];
+                        struct s2n_ecc_evp_params *received_params = &server_conn->kex_params.client_ecc_evp_params[ec_index];
 
                         if (received_params->negotiated_curve == &s2n_ecc_curve_secp256r1) {
                             EXPECT_NOT_NULL(received_params->evp_pkey);
@@ -681,7 +681,7 @@ int main() {
                     bool p256_sike_accepted = false;
                     bool p256_kyber_accepted = false;
                     for (size_t pq_index = 0; pq_index < kem_pref->tls13_kem_group_count; pq_index++) {
-                        struct s2n_kem_group_params *received_params = &server_conn->secure.client_kem_group_params[pq_index];
+                        struct s2n_kem_group_params *received_params = &server_conn->kex_params.client_kem_group_params[pq_index];
 
                         if (received_params->kem_group == &s2n_secp256r1_sike_p434_r3) {
                             EXPECT_EQUAL(received_params->kem_params.kem, &s2n_sike_p434_r3);
@@ -746,7 +746,7 @@ int main() {
                     /* Server should have accepted p256 share and no other EC shares */
                     bool p256_accepted = false;
                     for (size_t ec_index = 0; ec_index < ecc_pref->count; ec_index++) {
-                        struct s2n_ecc_evp_params *received_params = &server_conn->secure.client_ecc_evp_params[ec_index];
+                        struct s2n_ecc_evp_params *received_params = &server_conn->kex_params.client_ecc_evp_params[ec_index];
 
                         if (received_params->negotiated_curve == &s2n_ecc_curve_secp256r1) {
                             EXPECT_NOT_NULL(received_params->evp_pkey);
@@ -765,7 +765,7 @@ int main() {
                     /* Server should have accepted p256_sike, and no other hybrid shares */
                     bool p256_sike_accepted = false;
                     for (size_t pq_index = 0; pq_index < kem_pref->tls13_kem_group_count; pq_index++) {
-                        struct s2n_kem_group_params *received_params = &server_conn->secure.client_kem_group_params[pq_index];
+                        struct s2n_kem_group_params *received_params = &server_conn->kex_params.client_kem_group_params[pq_index];
 
                         if (received_params->kem_group == &s2n_secp256r1_sike_p434_r3) {
                             EXPECT_EQUAL(received_params->kem_params.kem, &s2n_sike_p434_r3);
@@ -821,7 +821,7 @@ int main() {
                     /* Server should have accepted p256 share and no other EC shares */
                     bool p256_accepted = false;
                     for (size_t ec_index = 0; ec_index < ecc_pref->count; ec_index++) {
-                        struct s2n_ecc_evp_params *received_params = &server_conn->secure.client_ecc_evp_params[ec_index];
+                        struct s2n_ecc_evp_params *received_params = &server_conn->kex_params.client_ecc_evp_params[ec_index];
 
                         if (received_params->negotiated_curve == &s2n_ecc_curve_secp256r1) {
                             EXPECT_NOT_NULL(received_params->evp_pkey);
@@ -839,7 +839,7 @@ int main() {
 
                     /* Server should have not have accepted any hybrid shares */
                     for (size_t pq_index = 0; pq_index < kem_pref->tls13_kem_group_count; pq_index++) {
-                        struct s2n_kem_group_params *received_params = &server_conn->secure.client_kem_group_params[pq_index];
+                        struct s2n_kem_group_params *received_params = &server_conn->kex_params.client_kem_group_params[pq_index];
 
                         EXPECT_NULL(received_params->kem_group);
                         EXPECT_NULL(received_params->ecc_params.negotiated_curve);
@@ -884,7 +884,7 @@ int main() {
 
                     /* Server should not have accepted any EC shares */
                     for (size_t ec_index = 0; ec_index < ecc_pref->count; ec_index++) {
-                        struct s2n_ecc_evp_params *received_params = &server_conn->secure.client_ecc_evp_params[ec_index];
+                        struct s2n_ecc_evp_params *received_params = &server_conn->kex_params.client_ecc_evp_params[ec_index];
                         EXPECT_NULL(received_params->negotiated_curve);
                         EXPECT_NULL(received_params->evp_pkey);
                     }
@@ -895,7 +895,7 @@ int main() {
 
                     /* Server should have not have accepted any hybrid shares */
                     for (size_t pq_index = 0; pq_index < kem_pref->tls13_kem_group_count; pq_index++) {
-                        struct s2n_kem_group_params *received_params = &server_conn->secure.client_kem_group_params[pq_index];
+                        struct s2n_kem_group_params *received_params = &server_conn->kex_params.client_kem_group_params[pq_index];
                         EXPECT_NULL(received_params->kem_group);
                         EXPECT_NULL(received_params->ecc_params.negotiated_curve);
                         EXPECT_NULL(received_params->ecc_params.evp_pkey);
@@ -939,7 +939,7 @@ int main() {
 
                     /* Server should not have accepted any EC shares */
                     for (size_t ec_index = 0; ec_index < ecc_pref->count; ec_index++) {
-                        struct s2n_ecc_evp_params *received_params = &server_conn->secure.client_ecc_evp_params[ec_index];
+                        struct s2n_ecc_evp_params *received_params = &server_conn->kex_params.client_ecc_evp_params[ec_index];
                         EXPECT_NULL(received_params->negotiated_curve);
                         EXPECT_NULL(received_params->evp_pkey);
                     }
@@ -950,7 +950,7 @@ int main() {
 
                     /* Server should have not have accepted any hybrid shares */
                     for (size_t pq_index = 0; pq_index < kem_pref->tls13_kem_group_count; pq_index++) {
-                        struct s2n_kem_group_params *received_params = &server_conn->secure.client_kem_group_params[pq_index];
+                        struct s2n_kem_group_params *received_params = &server_conn->kex_params.client_kem_group_params[pq_index];
                         EXPECT_NULL(received_params->kem_group);
                         EXPECT_NULL(received_params->ecc_params.negotiated_curve);
                         EXPECT_NULL(received_params->ecc_params.evp_pkey);
@@ -1000,7 +1000,7 @@ int main() {
 
                     /* Server should not accepted any EC shares */
                     for (size_t ec_index = 0; ec_index < ecc_pref->count; ec_index++) {
-                        struct s2n_ecc_evp_params *received_params = &server_conn->secure.client_ecc_evp_params[ec_index];
+                        struct s2n_ecc_evp_params *received_params = &server_conn->kex_params.client_ecc_evp_params[ec_index];
                         EXPECT_NULL(received_params->negotiated_curve);
                         EXPECT_NULL(received_params->evp_pkey);
                     }
@@ -1012,7 +1012,7 @@ int main() {
                     /* Server should have accepted the first p256_sike share */
                     bool p256_sike_accepted = false;
                     for (size_t pq_index = 0; pq_index < kem_pref->tls13_kem_group_count; pq_index++) {
-                        struct s2n_kem_group_params *received_params = &server_conn->secure.client_kem_group_params[pq_index];
+                        struct s2n_kem_group_params *received_params = &server_conn->kex_params.client_kem_group_params[pq_index];
 
                         if (received_params->kem_group == &s2n_secp256r1_sike_p434_r3) {
                             EXPECT_EQUAL(received_params->kem_params.kem, &s2n_sike_p434_r3);
@@ -1070,7 +1070,7 @@ int main() {
 
                     /* Server should not accepted any EC shares */
                     for (size_t ec_index = 0; ec_index < ecc_pref->count; ec_index++) {
-                        struct s2n_ecc_evp_params *received_params = &server_conn->secure.client_ecc_evp_params[ec_index];
+                        struct s2n_ecc_evp_params *received_params = &server_conn->kex_params.client_ecc_evp_params[ec_index];
                         EXPECT_NULL(received_params->negotiated_curve);
                         EXPECT_NULL(received_params->evp_pkey);
                     }
@@ -1081,7 +1081,7 @@ int main() {
 
                     /* Server should have accepted the first p256_sike share */
                     for (size_t pq_index = 0; pq_index < kem_pref->tls13_kem_group_count; pq_index++) {
-                        struct s2n_kem_group_params *received_params = &server_conn->secure.client_kem_group_params[pq_index];
+                        struct s2n_kem_group_params *received_params = &server_conn->kex_params.client_kem_group_params[pq_index];
                         EXPECT_NULL(received_params->kem_group);
                         EXPECT_NULL(received_params->ecc_params.negotiated_curve);
                         EXPECT_NULL(received_params->ecc_params.evp_pkey);

--- a/tests/unit/s2n_client_pq_kem_extension_test.c
+++ b/tests/unit/s2n_client_pq_kem_extension_test.c
@@ -96,8 +96,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_wipe_n(&stuffer, 1));
 
             EXPECT_SUCCESS(s2n_client_pq_kem_extension.recv(conn, &stuffer));
-            EXPECT_EQUAL(conn->secure.client_pq_kem_extension.size, 0);
-            EXPECT_NULL(conn->secure.client_pq_kem_extension.data);
+            EXPECT_EQUAL(conn->kex_params.client_pq_kem_extension.size, 0);
+            EXPECT_NULL(conn->kex_params.client_pq_kem_extension.data);
 
             EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
             EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -117,13 +117,13 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_pq_kem_extension.recv(conn, &stuffer));
 
             if (s2n_pq_is_enabled()) {
-                EXPECT_EQUAL(conn->secure.client_pq_kem_extension.size,kem_preferences->kem_count * sizeof(kem_extension_size));
-                EXPECT_NOT_NULL(conn->secure.client_pq_kem_extension.data);
+                EXPECT_EQUAL(conn->kex_params.client_pq_kem_extension.size,kem_preferences->kem_count * sizeof(kem_extension_size));
+                EXPECT_NOT_NULL(conn->kex_params.client_pq_kem_extension.data);
                 EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
             } else {
                 /* Server should ignore the extension if PQ is disabled */
-                EXPECT_EQUAL(conn->secure.client_pq_kem_extension.size, 0);
-                EXPECT_NULL(conn->secure.client_pq_kem_extension.data);
+                EXPECT_EQUAL(conn->kex_params.client_pq_kem_extension.size, 0);
+                EXPECT_NULL(conn->kex_params.client_pq_kem_extension.data);
             }
 
             EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));

--- a/tests/unit/s2n_client_supported_groups_extension_test.c
+++ b/tests/unit/s2n_client_supported_groups_extension_test.c
@@ -299,28 +299,28 @@ int main()
 
                 EXPECT_SUCCESS(s2n_client_supported_groups_extension.send(client_conn, &stuffer));
 
-                EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-                EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-                EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-                EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
+                EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+                EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+                EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+                EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
 
                 EXPECT_SUCCESS(s2n_client_supported_groups_extension.recv(server_conn, &stuffer));
 
                 /* If PQ is disabled, s2n_client_supported_groups_extension.send will not have sent PQ IDs */
                 if (!s2n_pq_is_enabled()) {
-                    EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, server_ecc_pref->ecc_curves[0]);
-                    EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-                    EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-                    EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
+                    EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve, server_ecc_pref->ecc_curves[0]);
+                    EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+                    EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+                    EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
 
                     for (size_t j = 0; j < server_kem_pref->tls13_kem_group_count; j++) {
-                        EXPECT_NULL(server_conn->secure.mutually_supported_kem_groups[j]);
+                        EXPECT_NULL(server_conn->kex_params.mutually_supported_kem_groups[j]);
                     }
                 } else {
-                    EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-                    EXPECT_EQUAL(server_conn->secure.server_kem_group_params.kem_group, expected_negotiated_kem_group[i]);
-                    EXPECT_EQUAL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve, expected_negotiated_kem_group[i]->curve);
-                    EXPECT_EQUAL(server_conn->secure.server_kem_group_params.kem_params.kem, expected_negotiated_kem_group[i]->kem);
+                    EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+                    EXPECT_EQUAL(server_conn->kex_params.server_kem_group_params.kem_group, expected_negotiated_kem_group[i]);
+                    EXPECT_EQUAL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve, expected_negotiated_kem_group[i]->curve);
+                    EXPECT_EQUAL(server_conn->kex_params.server_kem_group_params.kem_params.kem, expected_negotiated_kem_group[i]->kem);
                 }
 
                 EXPECT_SUCCESS(s2n_connection_free(client_conn));
@@ -365,17 +365,17 @@ int main()
 
                 EXPECT_SUCCESS(s2n_client_supported_groups_extension.send(client_conn, &stuffer));
 
-                EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-                EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-                EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-                EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
+                EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+                EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+                EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+                EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
 
                 EXPECT_SUCCESS(s2n_client_supported_groups_extension.recv(server_conn, &stuffer));
 
-                EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, server_ecc_pref->ecc_curves[0]);
-                EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-                EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-                EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
+                EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve, server_ecc_pref->ecc_curves[0]);
+                EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+                EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+                EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
 
                 EXPECT_SUCCESS(s2n_connection_free(client_conn));
                 EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -401,17 +401,17 @@ int main()
             EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, 102));
             POSIX_GUARD(s2n_stuffer_write_vector_size(&group_list_len));
 
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
 
             EXPECT_SUCCESS(s2n_client_supported_groups_extension.recv(server_conn, &stuffer));
 
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
             EXPECT_SUCCESS(s2n_disable_tls13());
@@ -447,17 +447,17 @@ int main()
             EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, client_ecc_pref->ecc_curves[0]->iana_id));
             POSIX_GUARD(s2n_stuffer_write_vector_size(&group_list_len));
 
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
 
             EXPECT_SUCCESS(s2n_client_supported_groups_extension.recv(server_conn, &stuffer));
 
-            EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, client_ecc_pref->ecc_curves[0]);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
+            EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve, client_ecc_pref->ecc_curves[0]);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
 
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -493,17 +493,17 @@ int main()
                 EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, client_ecc_pref->ecc_curves[0]->iana_id));
                 POSIX_GUARD(s2n_stuffer_write_vector_size(&group_list_len));
 
-                EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-                EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-                EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-                EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
+                EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+                EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+                EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+                EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
 
                 EXPECT_SUCCESS(s2n_client_supported_groups_extension.recv(server_conn, &stuffer));
 
-                EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve,client_ecc_pref->ecc_curves[0]);
-                EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-                EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-                EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
+                EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve,client_ecc_pref->ecc_curves[0]);
+                EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+                EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+                EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
 
                 EXPECT_SUCCESS(s2n_connection_free(client_conn));
                 EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -526,12 +526,12 @@ int main()
 
         EXPECT_SUCCESS(s2n_client_supported_groups_extension.send(conn, &stuffer));
 
-        EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+        EXPECT_NULL(conn->kex_params.server_ecc_evp_params.negotiated_curve);
         EXPECT_SUCCESS(s2n_client_supported_groups_extension.recv(conn, &stuffer));
-        EXPECT_EQUAL(conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
-        EXPECT_NULL(conn->secure.server_kem_group_params.kem_group);
-        EXPECT_NULL(conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-        EXPECT_NULL(conn->secure.server_kem_group_params.kem_params.kem);
+        EXPECT_EQUAL(conn->kex_params.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
+        EXPECT_NULL(conn->kex_params.server_kem_group_params.kem_group);
+        EXPECT_NULL(conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+        EXPECT_NULL(conn->kex_params.server_kem_group_params.kem_params.kem);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -552,12 +552,12 @@ int main()
         EXPECT_SUCCESS(s2n_client_supported_groups_extension.send(conn, &stuffer));
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "null"));
 
-        EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+        EXPECT_NULL(conn->kex_params.server_ecc_evp_params.negotiated_curve);
         EXPECT_SUCCESS(s2n_client_supported_groups_extension.recv(conn, &stuffer));
-        EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
-        EXPECT_NULL(conn->secure.server_kem_group_params.kem_group);
-        EXPECT_NULL(conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-        EXPECT_NULL(conn->secure.server_kem_group_params.kem_params.kem);
+        EXPECT_NULL(conn->kex_params.server_ecc_evp_params.negotiated_curve);
+        EXPECT_NULL(conn->kex_params.server_kem_group_params.kem_group);
+        EXPECT_NULL(conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+        EXPECT_NULL(conn->kex_params.server_kem_group_params.kem_params.kem);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -578,12 +578,12 @@ int main()
         EXPECT_SUCCESS(s2n_client_supported_groups_extension.send(conn, &stuffer));
         EXPECT_SUCCESS(s2n_stuffer_wipe_n(&stuffer, 1));
 
-        EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+        EXPECT_NULL(conn->kex_params.server_ecc_evp_params.negotiated_curve);
         EXPECT_SUCCESS(s2n_client_supported_groups_extension.recv(conn, &stuffer));
-        EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
-        EXPECT_NULL(conn->secure.server_kem_group_params.kem_group);
-        EXPECT_NULL(conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-        EXPECT_NULL(conn->secure.server_kem_group_params.kem_params.kem);
+        EXPECT_NULL(conn->kex_params.server_ecc_evp_params.negotiated_curve);
+        EXPECT_NULL(conn->kex_params.server_kem_group_params.kem_group);
+        EXPECT_NULL(conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+        EXPECT_NULL(conn->kex_params.server_kem_group_params.kem_params.kem);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -608,12 +608,12 @@ int main()
 
         /* Force a bad value for the negotiated curve so we know extension was parsed and the curve was set to NULL */
         struct s2n_ecc_named_curve invalid_curve = { 0 };
-        conn->secure.server_ecc_evp_params.negotiated_curve = &invalid_curve;
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = &invalid_curve;
         EXPECT_SUCCESS(s2n_client_supported_groups_extension.recv(conn, &supported_groups_extension));
-        EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
-        EXPECT_NULL(conn->secure.server_kem_group_params.kem_group);
-        EXPECT_NULL(conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-        EXPECT_NULL(conn->secure.server_kem_group_params.kem_params.kem);
+        EXPECT_NULL(conn->kex_params.server_ecc_evp_params.negotiated_curve);
+        EXPECT_NULL(conn->kex_params.server_kem_group_params.kem_group);
+        EXPECT_NULL(conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+        EXPECT_NULL(conn->kex_params.server_kem_group_params.kem_params.kem);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&supported_groups_extension));
         EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_connection_preferences_test.c
+++ b/tests/unit/s2n_connection_preferences_test.c
@@ -271,21 +271,21 @@ int main(int argc, char **argv)
 
         /* TLS1.3 always returns a curve */
         conn->actual_protocol_version = S2N_TLS13;
-        conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
         EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));
         EXPECT_BYTEARRAY_EQUAL(curve_name, s2n_ecc_curve_secp256r1.name, strlen(s2n_ecc_curve_secp256r1.name));
 
         /* TLS1.2 returns a curve if ECDHE cipher negotiated */
         conn->actual_protocol_version = S2N_TLS12;
         conn->secure.cipher_suite = &s2n_ecdhe_rsa_with_aes_128_cbc_sha256;
-        conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
         EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));
         EXPECT_BYTEARRAY_EQUAL(curve_name, s2n_ecc_curve_secp256r1.name, strlen(s2n_ecc_curve_secp256r1.name));
 
         /* TLS1.2 does not return a curve if ECDHE cipher was not negotiated */
         conn->actual_protocol_version = S2N_TLS12;
         conn->secure.cipher_suite = &s2n_rsa_with_aes_256_gcm_sha384;
-        conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
         EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));
         EXPECT_BYTEARRAY_EQUAL(curve_name, no_curve, strlen(no_curve));
 

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
      */
     {
         /* Carefully consider any increases to this number. */
-        const uint16_t max_connection_size = 17248;
+        const uint16_t max_connection_size = 15768;
         const uint16_t min_connection_size = max_connection_size * 0.75;
 
         size_t connection_size = sizeof(struct s2n_connection);

--- a/tests/unit/s2n_extensions_server_key_share_select_test.c
+++ b/tests/unit/s2n_extensions_server_key_share_select_test.c
@@ -32,14 +32,14 @@ int main() {
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
 
-        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+        EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+        EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
 
         EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn),
                 S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
-        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+        EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+        EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
         EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -56,16 +56,16 @@ int main() {
         EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
         EXPECT_NOT_NULL(ecc_pref);
 
-        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-        server_conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.client_ecc_evp_params[0]));
+        EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+        EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+        server_conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.client_ecc_evp_params[0]));
 
         EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn),
                 S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
-        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+        EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+        EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
         EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -82,19 +82,19 @@ int main() {
         EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
         EXPECT_NOT_NULL(ecc_pref);
 
-        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-        server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[1];
-        EXPECT_NULL(server_conn->secure.mutually_supported_curves[0]);
-        server_conn->secure.mutually_supported_curves[1] = ecc_pref->ecc_curves[1];
+        EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+        server_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[1];
+        EXPECT_NULL(server_conn->kex_params.mutually_supported_curves[0]);
+        server_conn->kex_params.mutually_supported_curves[1] = ecc_pref->ecc_curves[1];
         for (size_t i = 0; i < ecc_pref->count; i++) {
-            EXPECT_NULL(server_conn->secure.client_ecc_evp_params[i].evp_pkey);
-            EXPECT_NULL(server_conn->secure.client_ecc_evp_params[i].negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.client_ecc_evp_params[i].evp_pkey);
+            EXPECT_NULL(server_conn->kex_params.client_ecc_evp_params[i].negotiated_curve);
         }
 
         EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
-        EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[1]);
-        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+        EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[1]);
+        EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
         EXPECT_TRUE(s2n_is_hello_retry_handshake(server_conn));
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -112,21 +112,21 @@ int main() {
         EXPECT_NOT_NULL(ecc_pref);
 
         /* Server would have initially chosen curve[0] when processing the supported_groups extension */
-        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-        server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-        server_conn->secure.mutually_supported_curves[0] = ecc_pref->ecc_curves[0];
-        server_conn->secure.mutually_supported_curves[1] = ecc_pref->ecc_curves[1];
+        EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+        server_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        server_conn->kex_params.mutually_supported_curves[0] = ecc_pref->ecc_curves[0];
+        server_conn->kex_params.mutually_supported_curves[1] = ecc_pref->ecc_curves[1];
 
-        EXPECT_NULL(server_conn->secure.client_ecc_evp_params[0].evp_pkey);
-        EXPECT_NULL(server_conn->secure.client_ecc_evp_params[0].negotiated_curve);
-        server_conn->secure.client_ecc_evp_params[1].negotiated_curve = ecc_pref->ecc_curves[1];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.client_ecc_evp_params[1]));
+        EXPECT_NULL(server_conn->kex_params.client_ecc_evp_params[0].evp_pkey);
+        EXPECT_NULL(server_conn->kex_params.client_ecc_evp_params[0].negotiated_curve);
+        server_conn->kex_params.client_ecc_evp_params[1].negotiated_curve = ecc_pref->ecc_curves[1];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.client_ecc_evp_params[1]));
 
         EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
         /* Server should have updated it's choice to curve[1] after taking received keyshares into account */
-        EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[1]);
-        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+        EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[1]);
+        EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
         EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
@@ -144,21 +144,21 @@ int main() {
         EXPECT_NOT_NULL(ecc_pref);
 
         /* Server would have initially chosen curve[0] when processing the supported_groups extension */
-        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-        server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-        server_conn->secure.mutually_supported_curves[0] = ecc_pref->ecc_curves[0];
-        server_conn->secure.mutually_supported_curves[1] = ecc_pref->ecc_curves[1];
+        EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+        server_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        server_conn->kex_params.mutually_supported_curves[0] = ecc_pref->ecc_curves[0];
+        server_conn->kex_params.mutually_supported_curves[1] = ecc_pref->ecc_curves[1];
 
-        server_conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.client_ecc_evp_params[0]));
-        server_conn->secure.client_ecc_evp_params[1].negotiated_curve = ecc_pref->ecc_curves[1];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.client_ecc_evp_params[1]));
+        server_conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.client_ecc_evp_params[0]));
+        server_conn->kex_params.client_ecc_evp_params[1].negotiated_curve = ecc_pref->ecc_curves[1];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.client_ecc_evp_params[1]));
 
         EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
         /* Server should still prefer curve[0] after taking received keyshares into account */
-        EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
-        EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+        EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
+        EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
         EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -202,8 +202,8 @@ int main() {
             EXPECT_SUCCESS(s2n_connection_get_kem_preferences(server_conn, &kem_pref));
             EXPECT_NOT_NULL(kem_pref);
 
-            server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-            server_conn->secure.server_kem_group_params.kem_group = kem_pref->tls13_kem_groups[0];
+            server_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            server_conn->kex_params.server_kem_group_params.kem_group = kem_pref->tls13_kem_groups[0];
 
             EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn),
                     S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
@@ -226,11 +226,11 @@ int main() {
             EXPECT_NOT_NULL(kem_pref);
 
             /* Server would have not chosen any group when processing the supported_groups extension */
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
 
             /* Received an erroneous keyshare for kem group 0 */
-            struct s2n_kem_group_params *client_params0 = &server_conn->secure.client_kem_group_params[0];
+            struct s2n_kem_group_params *client_params0 = &server_conn->kex_params.client_kem_group_params[0];
             const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];
             client_params0->kem_group = kem_group0;
             client_params0->kem_params.kem = kem_group0->kem;
@@ -244,11 +244,11 @@ int main() {
                     S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
             /* Nothing selected, no HRR */
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.kem_params.kem);
-            EXPECT_NULL(server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.chosen_client_kem_group_params);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
+            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.chosen_client_kem_group_params);
             EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -267,24 +267,24 @@ int main() {
             EXPECT_NOT_NULL(kem_pref);
 
             /* Server would have initially chosen kem_group[1] when processing the supported_groups extension */
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-            struct s2n_kem_group_params *server_params = &server_conn->secure.server_kem_group_params;
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+            struct s2n_kem_group_params *server_params = &server_conn->kex_params.server_kem_group_params;
             const struct s2n_kem_group *kem_group1 = kem_pref->tls13_kem_groups[1];
             server_params->kem_group = kem_group1;
             server_params->kem_params.kem = kem_group1->kem;
             server_params->ecc_params.negotiated_curve = kem_group1->curve;
 
             /* 0 is not supported, 1 is */
-            EXPECT_NULL(server_conn->secure.mutually_supported_kem_groups[0]);
-            server_conn->secure.mutually_supported_kem_groups[1] = kem_group1;
+            EXPECT_NULL(server_conn->kex_params.mutually_supported_kem_groups[0]);
+            server_conn->kex_params.mutually_supported_kem_groups[1] = kem_group1;
 
             /* No keyshares received */
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_group);
-                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_params.kem);
-                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_params.public_key.data);
-                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve);
-                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].ecc_params.evp_pkey);
+                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_group);
+                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_params.kem);
+                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_params.public_key.data);
+                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].ecc_params.negotiated_curve);
+                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].ecc_params.evp_pkey);
             }
 
             EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
@@ -293,8 +293,8 @@ int main() {
             EXPECT_EQUAL(server_params->kem_group, kem_group1);
             EXPECT_EQUAL(server_params->kem_params.kem, kem_group1->kem);
             EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group1->curve);
-            EXPECT_NULL(server_conn->secure.chosen_client_kem_group_params);
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.chosen_client_kem_group_params);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             EXPECT_TRUE(s2n_is_hello_retry_handshake(server_conn));
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -313,8 +313,8 @@ int main() {
             EXPECT_NOT_NULL(kem_pref);
 
             /* Server would have initially chosen kem_group[0] when processing the supported_groups extension */
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-            struct s2n_kem_group_params *server_params = &server_conn->secure.server_kem_group_params;
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+            struct s2n_kem_group_params *server_params = &server_conn->kex_params.server_kem_group_params;
             const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];
             const struct s2n_kem_group *kem_group1 = kem_pref->tls13_kem_groups[1];
             server_params->kem_group = kem_group0;
@@ -322,12 +322,12 @@ int main() {
             server_params->ecc_params.negotiated_curve = kem_group0->curve;
 
             /* Both 0 and 1 supported */
-            server_conn->secure.mutually_supported_kem_groups[0] = kem_group0;
-            server_conn->secure.mutually_supported_kem_groups[1] = kem_group1;
+            server_conn->kex_params.mutually_supported_kem_groups[0] = kem_group0;
+            server_conn->kex_params.mutually_supported_kem_groups[1] = kem_group1;
 
             /* Received a keyshare for 1 only */
-            EXPECT_NULL(server_conn->secure.client_kem_group_params[0].kem_group);
-            struct s2n_kem_group_params *client_params1 = &server_conn->secure.client_kem_group_params[1];
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params[0].kem_group);
+            struct s2n_kem_group_params *client_params1 = &server_conn->kex_params.client_kem_group_params[1];
             client_params1->kem_group = kem_group1;
             client_params1->kem_params.kem = kem_group1->kem;
             client_params1->ecc_params.negotiated_curve = kem_group1->curve;
@@ -342,8 +342,8 @@ int main() {
             EXPECT_EQUAL(server_params->kem_group, kem_group1);
             EXPECT_EQUAL(server_params->kem_params.kem, kem_group1->kem);
             EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group1->curve);
-            EXPECT_EQUAL(server_conn->secure.chosen_client_kem_group_params, client_params1);
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_EQUAL(server_conn->kex_params.chosen_client_kem_group_params, client_params1);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -362,8 +362,8 @@ int main() {
             EXPECT_NOT_NULL(kem_pref);
 
             /* Server would have initially chosen kem_group[0] when processing the supported_groups extension */
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-            struct s2n_kem_group_params *server_params = &server_conn->secure.server_kem_group_params;
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+            struct s2n_kem_group_params *server_params = &server_conn->kex_params.server_kem_group_params;
             const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];
             server_params->kem_group = kem_group0;
             server_params->kem_params.kem = kem_group0->kem;
@@ -371,10 +371,10 @@ int main() {
 
             /* Support all KEM Groups; received key shares for all KEM groups */
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                struct s2n_kem_group_params *client_params = &server_conn->secure.client_kem_group_params[i];
+                struct s2n_kem_group_params *client_params = &server_conn->kex_params.client_kem_group_params[i];
                 const struct s2n_kem_group *kem_group = kem_pref->tls13_kem_groups[i];
 
-                server_conn->secure.mutually_supported_kem_groups[i] = kem_group;
+                server_conn->kex_params.mutually_supported_kem_groups[i] = kem_group;
 
                 client_params->kem_group = kem_group;
                 client_params->kem_params.kem = kem_group->kem;
@@ -391,8 +391,8 @@ int main() {
             EXPECT_EQUAL(server_params->kem_group, kem_group0);
             EXPECT_EQUAL(server_params->kem_params.kem, kem_group0->kem);
             EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group0->curve);
-            EXPECT_EQUAL(server_conn->secure.chosen_client_kem_group_params, &server_conn->secure.client_kem_group_params[0]);
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_EQUAL(server_conn->kex_params.chosen_client_kem_group_params, &server_conn->kex_params.client_kem_group_params[0]);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -415,8 +415,8 @@ int main() {
             EXPECT_NOT_NULL(kem_pref);
 
             /* Server would have initially chosen kem_group[0] when processing the supported_groups extension */
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-            struct s2n_kem_group_params *server_params = &server_conn->secure.server_kem_group_params;
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+            struct s2n_kem_group_params *server_params = &server_conn->kex_params.server_kem_group_params;
             const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];
             server_params->kem_group = kem_group0;
             server_params->kem_params.kem = kem_group0->kem;
@@ -424,19 +424,19 @@ int main() {
 
             /* Support all KEM groups and all curves */
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                server_conn->secure.mutually_supported_kem_groups[i] = kem_pref->tls13_kem_groups[i];
+                server_conn->kex_params.mutually_supported_kem_groups[i] = kem_pref->tls13_kem_groups[i];
             }
             for (size_t i = 0; i < ecc_pref->count; i++) {
-                server_conn->secure.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
+                server_conn->kex_params.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
             }
 
             /* No keyshares received */
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_group);
-                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_params.kem);
-                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_params.public_key.data);
-                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve);
-                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].ecc_params.evp_pkey);
+                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_group);
+                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_params.kem);
+                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_params.public_key.data);
+                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].ecc_params.negotiated_curve);
+                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].ecc_params.evp_pkey);
             }
 
             EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
@@ -445,8 +445,8 @@ int main() {
             EXPECT_EQUAL(server_params->kem_group, kem_group0);
             EXPECT_EQUAL(server_params->kem_params.kem, kem_group0->kem);
             EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group0->curve);
-            EXPECT_NULL(server_conn->secure.chosen_client_kem_group_params);
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.chosen_client_kem_group_params);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             EXPECT_TRUE(s2n_is_hello_retry_handshake(server_conn));
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -469,8 +469,8 @@ int main() {
             EXPECT_NOT_NULL(kem_pref);
 
             /* Server would have initially chosen kem_group[0] when processing the supported_groups extension */
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-            struct s2n_kem_group_params *server_params = &server_conn->secure.server_kem_group_params;
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+            struct s2n_kem_group_params *server_params = &server_conn->kex_params.server_kem_group_params;
             const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];;
             server_params->kem_group = kem_group0;
             server_params->kem_params.kem = kem_group0->kem;
@@ -478,10 +478,10 @@ int main() {
 
             /* Support all KEM groups and curves; received keyshares for everything */
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                struct s2n_kem_group_params *client_params = &server_conn->secure.client_kem_group_params[i];
+                struct s2n_kem_group_params *client_params = &server_conn->kex_params.client_kem_group_params[i];
                 const struct s2n_kem_group *kem_group = kem_pref->tls13_kem_groups[i];
 
-                server_conn->secure.mutually_supported_kem_groups[i] = kem_pref->tls13_kem_groups[i];
+                server_conn->kex_params.mutually_supported_kem_groups[i] = kem_pref->tls13_kem_groups[i];
 
                 client_params->kem_group = kem_group;
                 client_params->kem_params.kem = kem_group->kem;
@@ -492,10 +492,10 @@ int main() {
                 EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params->ecc_params));
             }
             for (size_t i = 0; i < ecc_pref->count; i++) {
-                struct s2n_ecc_evp_params *client_params = &server_conn->secure.client_ecc_evp_params[i];
+                struct s2n_ecc_evp_params *client_params = &server_conn->kex_params.client_ecc_evp_params[i];
                 const struct s2n_ecc_named_curve *curve = ecc_pref->ecc_curves[i];
 
-                server_conn->secure.mutually_supported_curves[i] = curve;
+                server_conn->kex_params.mutually_supported_curves[i] = curve;
 
                 client_params->negotiated_curve = curve;
                 EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(client_params));
@@ -507,8 +507,8 @@ int main() {
             EXPECT_EQUAL(server_params->kem_group, kem_group0);
             EXPECT_EQUAL(server_params->kem_params.kem, kem_group0->kem);
             EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group0->curve);
-            EXPECT_EQUAL(server_conn->secure.chosen_client_kem_group_params, &server_conn->secure.client_kem_group_params[0]);
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_EQUAL(server_conn->kex_params.chosen_client_kem_group_params, &server_conn->kex_params.client_kem_group_params[0]);
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -531,8 +531,8 @@ int main() {
             EXPECT_NOT_NULL(kem_pref);
 
             /* Server would have initially chosen kem_group[0] when processing the supported_groups extension */
-            EXPECT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-            struct s2n_kem_group_params *server_params = &server_conn->secure.server_kem_group_params;
+            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+            struct s2n_kem_group_params *server_params = &server_conn->kex_params.server_kem_group_params;
             const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];;
             server_params->kem_group = kem_group0;
             server_params->kem_params.kem = kem_group0->kem;
@@ -540,20 +540,20 @@ int main() {
 
             /* Support all KEM groups, but no keyshares received */
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                server_conn->secure.mutually_supported_kem_groups[i] = kem_pref->tls13_kem_groups[i];
+                server_conn->kex_params.mutually_supported_kem_groups[i] = kem_pref->tls13_kem_groups[i];
 
-                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_group);
-                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_params.kem);
-                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].kem_params.public_key.data);
-                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve);
-                EXPECT_NULL(server_conn->secure.client_kem_group_params[i].ecc_params.evp_pkey);
+                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_group);
+                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_params.kem);
+                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_params.public_key.data);
+                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].ecc_params.negotiated_curve);
+                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].ecc_params.evp_pkey);
             }
             /* Support all curves, and all keyshares received */
             for (size_t i = 0; i < ecc_pref->count; i++) {
-                struct s2n_ecc_evp_params *client_params = &server_conn->secure.client_ecc_evp_params[i];
+                struct s2n_ecc_evp_params *client_params = &server_conn->kex_params.client_ecc_evp_params[i];
                 const struct s2n_ecc_named_curve *curve = ecc_pref->ecc_curves[i];
 
-                server_conn->secure.mutually_supported_curves[i] = curve;
+                server_conn->kex_params.mutually_supported_curves[i] = curve;
 
                 client_params->negotiated_curve = curve;
                 EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(client_params));
@@ -562,11 +562,11 @@ int main() {
             EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
             /* Server should update it's choice to curve[0], no HRR */
-            EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
+            EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
             EXPECT_NULL(server_params->kem_group);
             EXPECT_NULL(server_params->kem_params.kem);
             EXPECT_NULL(server_params->ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->secure.chosen_client_kem_group_params);
+            EXPECT_NULL(server_conn->kex_params.chosen_client_kem_group_params);
             EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_kex_with_kem_test.c
+++ b/tests/unit/s2n_kex_with_kem_test.c
@@ -61,11 +61,11 @@ static int do_kex_with_kem(struct s2n_cipher_suite *cipher_suite, const char *se
     POSIX_GUARD(s2n_find_security_policy_from_version(security_policy_version, &security_policy));
     POSIX_GUARD_PTR(security_policy);
 
-    client_conn->secure.kem_params.kem = negotiated_kem;
+    client_conn->kex_params.kem_params.kem = negotiated_kem;
     client_conn->secure.cipher_suite = cipher_suite;
     client_conn->security_policy_override = security_policy;
 
-    server_conn->secure.kem_params.kem = negotiated_kem;
+    server_conn->kex_params.kem_params.kem = negotiated_kem;
     server_conn->secure.cipher_suite = cipher_suite;
     server_conn->security_policy_override = security_policy;
 
@@ -76,15 +76,15 @@ static int do_kex_with_kem(struct s2n_cipher_suite *cipher_suite, const char *se
     const uint32_t KEM_PUBLIC_KEY_MESSAGE_SIZE = (*negotiated_kem).public_key_length + 4;
     POSIX_ENSURE_EQ(data_to_sign.size, KEM_PUBLIC_KEY_MESSAGE_SIZE);
 
-    POSIX_ENSURE_EQ((*negotiated_kem).private_key_length, server_conn->secure.kem_params.private_key.size);
+    POSIX_ENSURE_EQ((*negotiated_kem).private_key_length, server_conn->kex_params.kem_params.private_key.size);
     struct s2n_blob server_key_message = {.size = KEM_PUBLIC_KEY_MESSAGE_SIZE, .data = s2n_stuffer_raw_read(&server_conn->handshake.io,
             KEM_PUBLIC_KEY_MESSAGE_SIZE)};
     POSIX_GUARD_PTR(server_key_message.data);
 
     /* The KEM public key should get written directly to the server's handshake IO; kem_params.public_key
      * should point to NULL */
-    POSIX_ENSURE_EQ(NULL, server_conn->secure.kem_params.public_key.data);
-    POSIX_ENSURE_EQ(0, server_conn->secure.kem_params.public_key.size);
+    POSIX_ENSURE_EQ(NULL, server_conn->kex_params.kem_params.public_key.data);
+    POSIX_ENSURE_EQ(0, server_conn->kex_params.kem_params.public_key.size);
 
     /* Part 1.1: feed that to the client */
     POSIX_GUARD(s2n_stuffer_write(&client_conn->handshake.io, &server_key_message));
@@ -103,11 +103,11 @@ static int do_kex_with_kem(struct s2n_cipher_suite *cipher_suite, const char *se
         S2N_ERROR_PRESERVE_ERRNO();
     }
 
-    POSIX_ENSURE_EQ((*negotiated_kem).public_key_length, client_conn->secure.kem_params.public_key.size);
+    POSIX_ENSURE_EQ((*negotiated_kem).public_key_length, client_conn->kex_params.kem_params.public_key.size);
 
     /* Part 3: Client calls send_key. The additional 2 bytes are for the ciphertext length sent over the wire */
     const uint32_t KEM_CIPHERTEXT_MESSAGE_SIZE = (*negotiated_kem).ciphertext_length + 2;
-    struct s2n_blob *client_shared_key = &(client_conn->secure.kem_params.shared_secret);
+    struct s2n_blob *client_shared_key = &(client_conn->kex_params.kem_params.shared_secret);
     POSIX_GUARD(s2n_kem_client_key_send(client_conn, client_shared_key));
     struct s2n_blob client_key_message = {.size = KEM_CIPHERTEXT_MESSAGE_SIZE, .data = s2n_stuffer_raw_read(&client_conn->handshake.io,
             KEM_CIPHERTEXT_MESSAGE_SIZE)};
@@ -117,7 +117,7 @@ static int do_kex_with_kem(struct s2n_cipher_suite *cipher_suite, const char *se
     POSIX_GUARD(s2n_stuffer_write(&server_conn->handshake.io, &client_key_message));
 
     /* Part 4: Call client key recv */
-    struct s2n_blob *server_shared_key = &(server_conn->secure.kem_params.shared_secret);
+    struct s2n_blob *server_shared_key = &(server_conn->kex_params.kem_params.shared_secret);
     POSIX_GUARD(s2n_kem_client_key_recv(server_conn, server_shared_key));
     POSIX_ENSURE_EQ(memcmp(client_shared_key->data, server_shared_key->data, (*negotiated_kem).shared_secret_key_length), 0);
 
@@ -133,7 +133,7 @@ static int assert_pq_disabled_checks(struct s2n_cipher_suite *cipher_suite, cons
     const struct s2n_security_policy *security_policy = NULL;
     POSIX_GUARD(s2n_find_security_policy_from_version(security_policy_version, &security_policy));
     POSIX_GUARD_PTR(security_policy);
-    server_conn->secure.kem_params.kem = negotiated_kem;
+    server_conn->kex_params.kem_params.kem = negotiated_kem;
     server_conn->secure.cipher_suite = cipher_suite;
     server_conn->security_policy_override = security_policy;
 

--- a/tests/unit/s2n_quic_support_io_test.c
+++ b/tests/unit/s2n_quic_support_io_test.c
@@ -59,13 +59,13 @@ static S2N_RESULT s2n_setup_conn_for_server_hello(struct s2n_connection *conn)
     /* Setup secrets */
     const struct s2n_ecc_preferences *ecc_preferences = NULL;
     RESULT_GUARD_POSIX(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
-    conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-    conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_preferences->ecc_curves[0];
-    if(conn->secure.server_ecc_evp_params.evp_pkey == NULL) {
-        RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.server_ecc_evp_params));
+    conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+    conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_preferences->ecc_curves[0];
+    if(conn->kex_params.server_ecc_evp_params.evp_pkey == NULL) {
+        RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.server_ecc_evp_params));
     }
-    if(conn->secure.client_ecc_evp_params[0].evp_pkey == NULL) {
-        RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+    if(conn->kex_params.client_ecc_evp_params[0].evp_pkey == NULL) {
+        RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
     }
 
     /* Set handshake to write message */

--- a/tests/unit/s2n_server_hello_retry_test.c
+++ b/tests/unit/s2n_server_hello_retry_test.c
@@ -84,9 +84,9 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
         server_conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
-        server_conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
-        server_conn->secure.client_ecc_evp_params[0].negotiated_curve = s2n_all_supported_curves_list[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.client_ecc_evp_params[0]));
+        server_conn->kex_params.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
+        server_conn->kex_params.client_ecc_evp_params[0].negotiated_curve = s2n_all_supported_curves_list[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.client_ecc_evp_params[0]));
 
         EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(server_conn));
 
@@ -100,8 +100,8 @@ int main(int argc, char **argv)
 
         EXPECT_EQUAL(s2n_stuffer_data_available(server_stuffer), total);
 
-        EXPECT_NOT_NULL(server_conn->secure.server_ecc_evp_params.negotiated_curve);
-        EXPECT_NULL(server_conn->secure.server_ecc_evp_params.evp_pkey);
+        EXPECT_NOT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+        EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.evp_pkey);
         EXPECT_TRUE(memcmp(server_conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN) == 0);
 
         EXPECT_SUCCESS(s2n_config_free(server_config));
@@ -119,9 +119,9 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(conn, S2N_TLS13));
         conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
-        conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
-        conn->secure.client_ecc_evp_params[0].negotiated_curve = s2n_all_supported_curves_list[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
+        conn->kex_params.client_ecc_evp_params[0].negotiated_curve = s2n_all_supported_curves_list[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
 
         EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(conn));
 
@@ -221,18 +221,18 @@ int main(int argc, char **argv)
 
         POSIX_CHECKED_MEMCPY(server_conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
         EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
-        server_conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
-        server_conn->secure.client_ecc_evp_params[0].negotiated_curve = s2n_all_supported_curves_list[0];
+        server_conn->kex_params.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
+        server_conn->kex_params.client_ecc_evp_params[0].negotiated_curve = s2n_all_supported_curves_list[0];
         EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(server_conn));
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->secure.client_ecc_evp_params[0]));
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.client_ecc_evp_params[0]));
         EXPECT_SUCCESS(s2n_extensions_server_key_share_send(server_conn, extension_stuffer));
 
         S2N_STUFFER_READ_EXPECT_EQUAL(extension_stuffer, TLS_EXTENSION_KEY_SHARE, uint16);
         /* 4 = S2N_SIZE_OF_EXTENSION_TYPE + S2N_SIZE_OF_EXTENSION_DATA_SIZE */
         S2N_STUFFER_READ_EXPECT_EQUAL(extension_stuffer, s2n_extensions_server_key_share_send_size(server_conn) - 4, uint16);
 
-        client_conn->secure.client_ecc_evp_params[0].negotiated_curve = s2n_all_supported_curves_list[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[0]));
+        client_conn->kex_params.client_ecc_evp_params[0].negotiated_curve = s2n_all_supported_curves_list[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params[0]));
 
         /* Setup the client to receive a HelloRetryRequest */
         POSIX_CHECKED_MEMCPY(client_conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
@@ -247,7 +247,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_stuffer_data_available(extension_stuffer), 0);
 
         /* Server negotiated curve value will be non-null, if the extension succeeded */
-        EXPECT_NOT_NULL(client_conn->secure.server_ecc_evp_params.negotiated_curve);
+        EXPECT_NOT_NULL(client_conn->kex_params.server_ecc_evp_params.negotiated_curve);
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
@@ -265,9 +265,9 @@ int main(int argc, char **argv)
 
         conn->server_protocol_version = S2N_TLS13;
         conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
-        conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
-        conn->secure.client_ecc_evp_params[0].negotiated_curve = s2n_all_supported_curves_list[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
+        conn->kex_params.client_ecc_evp_params[0].negotiated_curve = s2n_all_supported_curves_list[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
 
         /* This blob is taken from the functional test RFC. That RFC does not actually provide hash transcript
          * values, so the expected hashes are taken from what our hash functions generated and the hash
@@ -385,7 +385,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(ecc_pref);
 
         for (int i=0; i<ecc_pref->count; i++) {
-            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&client_conn->secure.client_ecc_evp_params[i]));
+            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&client_conn->kex_params.client_ecc_evp_params[i]));
         }
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&client_conn->handshake.io));
@@ -516,15 +516,15 @@ int main(int argc, char **argv)
             conn->actual_protocol_version = S2N_TLS13;
             conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
 
-            conn->secure.server_ecc_evp_params.negotiated_curve = test_curve;
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = test_curve;
 
             /* Server requested key share is NOT present: allow retry */
             EXPECT_SUCCESS(s2n_server_hello_retry_recv(conn));
 
             /* Server requested key share is present: do NOT allow retry */
-            conn->secure.client_ecc_evp_params[0].negotiated_curve = test_curve;
-            conn->secure.client_ecc_evp_params[0].evp_pkey = EVP_PKEY_new();
-            EXPECT_NOT_NULL(conn->secure.client_ecc_evp_params[0].evp_pkey);
+            conn->kex_params.client_ecc_evp_params[0].negotiated_curve = test_curve;
+            conn->kex_params.client_ecc_evp_params[0].evp_pkey = EVP_PKEY_new();
+            EXPECT_NOT_NULL(conn->kex_params.client_ecc_evp_params[0].evp_pkey);
             EXPECT_FAILURE_WITH_ERRNO(s2n_server_hello_retry_recv(conn),
                     S2N_ERR_INVALID_HELLO_RETRY);
 
@@ -539,10 +539,10 @@ int main(int argc, char **argv)
             conn->actual_protocol_version = S2N_TLS13;
             conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
 
-            conn->secure.server_ecc_evp_params.negotiated_curve = test_curve;
-            conn->secure.client_ecc_evp_params[0].negotiated_curve = test_curve;
-            conn->secure.client_ecc_evp_params[0].evp_pkey = EVP_PKEY_new();
-            EXPECT_NOT_NULL(conn->secure.client_ecc_evp_params[0].evp_pkey);
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = test_curve;
+            conn->kex_params.client_ecc_evp_params[0].negotiated_curve = test_curve;
+            conn->kex_params.client_ecc_evp_params[0].evp_pkey = EVP_PKEY_new();
+            EXPECT_NOT_NULL(conn->kex_params.client_ecc_evp_params[0].evp_pkey);
 
             /* Early data rejected: allow retry */
             conn->early_data_state = S2N_EARLY_DATA_REJECTED;
@@ -564,7 +564,7 @@ int main(int argc, char **argv)
             conn->actual_protocol_version = S2N_TLS13;
             conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
 
-            conn->secure.server_ecc_evp_params.negotiated_curve = test_curve;
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = test_curve;
 
             /* All retry conditions met: allow retry */
             conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
@@ -572,9 +572,9 @@ int main(int argc, char **argv)
 
             /* No retry conditions met: do NOT allow retry */
             conn->early_data_state = S2N_EARLY_DATA_NOT_REQUESTED;
-            conn->secure.client_ecc_evp_params[0].negotiated_curve = test_curve;
-            conn->secure.client_ecc_evp_params[0].evp_pkey = EVP_PKEY_new();
-            EXPECT_NOT_NULL(conn->secure.client_ecc_evp_params[0].evp_pkey);
+            conn->kex_params.client_ecc_evp_params[0].negotiated_curve = test_curve;
+            conn->kex_params.client_ecc_evp_params[0].evp_pkey = EVP_PKEY_new();
+            EXPECT_NOT_NULL(conn->kex_params.client_ecc_evp_params[0].evp_pkey);
             EXPECT_FAILURE_WITH_ERRNO(s2n_server_hello_retry_recv(conn),
                     S2N_ERR_INVALID_HELLO_RETRY);
 

--- a/tests/unit/s2n_server_hello_test.c
+++ b/tests/unit/s2n_server_hello_test.c
@@ -119,9 +119,9 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(ecc_preferences);
         /* configure these parameters so server hello can be sent */
         conn->actual_protocol_version = S2N_TLS13;
-        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-        conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_preferences->ecc_curves[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+        conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_preferences->ecc_curves[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
 
         struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
         EXPECT_SUCCESS(s2n_server_hello_send(conn));
@@ -282,7 +282,7 @@ int main(int argc, char **argv)
         client_conn->client_protocol_version = S2N_TLS13;
 
         /* Set the negotiated curve, otherwise the server might try to respond with a retry */
-        server_conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
+        server_conn->kex_params.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
 
         /* The server will respond with TLS1.1 even though it supports TLS1.3 */
         server_conn->actual_protocol_version = S2N_TLS11;
@@ -326,7 +326,7 @@ int main(int argc, char **argv)
         client_conn->client_protocol_version = S2N_TLS13;
 
         /* Set the negotiated curve, otherwise the server might try to respond with a retry */
-        server_conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
+        server_conn->kex_params.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
 
         /* The server will respond with TLS1.2 even though it supports TLS1.3 */
         server_conn->actual_protocol_version = S2N_TLS12;

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -60,7 +60,7 @@ int main(int argc, char **argv)
         EXPECT_FAILURE(s2n_server_key_share_send_check_ecdhe(conn));
 
         if (s2n_is_evp_apis_supported()) {
-            conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_x25519;
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_x25519;
             EXPECT_FAILURE(s2n_server_key_share_send_check_ecdhe(conn));
         }
 
@@ -68,13 +68,13 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
         EXPECT_NOT_NULL(ecc_pref);
 
-        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
         EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_ecdhe(conn), S2N_ERR_BAD_KEY_SHARE);
 
-        conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+        conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
         EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_ecdhe(conn), S2N_ERR_BAD_KEY_SHARE);
 
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
         EXPECT_SUCCESS(s2n_server_key_share_send_check_ecdhe(conn));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -91,19 +91,19 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
         EXPECT_NOT_NULL(ecc_pref);
 
-        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
         EXPECT_EQUAL(ecc_pref->ecc_curves[0]->share_size + 8, s2n_extensions_server_key_share_send_size(conn));
 
-        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[1];
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[1];
         EXPECT_EQUAL(ecc_pref->ecc_curves[1]->share_size + 8, s2n_extensions_server_key_share_send_size(conn));
 
-        conn->secure.server_ecc_evp_params.negotiated_curve = NULL;
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = NULL;
         EXPECT_EQUAL(0, s2n_extensions_server_key_share_send_size(conn));
 
         /* A HelloRetryRequest only requires a Selected Group, not a key share */
         EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(conn, S2N_TLS13));
         EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(conn));
-        conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
         EXPECT_EQUAL(6, s2n_extensions_server_key_share_send_size(conn));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -118,25 +118,25 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
         EXPECT_NOT_NULL(ecc_pref);
 
-        EXPECT_NULL(conn->secure.server_kem_group_params.kem_group);
+        EXPECT_NULL(conn->kex_params.server_kem_group_params.kem_group);
         DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
 
         for (size_t i = 0; i < ecc_pref->count; i++) {
             const struct s2n_ecc_named_curve *curve = ecc_pref->ecc_curves[i];
-            conn->secure.server_ecc_evp_params.negotiated_curve = curve;
-            conn->secure.client_ecc_evp_params[i].negotiated_curve = curve;
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[i]));
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = curve;
+            conn->kex_params.client_ecc_evp_params[i].negotiated_curve = curve;
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[i]));
 
             EXPECT_SUCCESS(s2n_server_key_share_extension.send(conn, &stuffer));
 
             S2N_STUFFER_READ_EXPECT_EQUAL(&stuffer, curve->iana_id, uint16);
             S2N_STUFFER_READ_EXPECT_EQUAL(&stuffer, curve->share_size, uint16);
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(&stuffer, curve->share_size);
-            EXPECT_NULL(conn->secure.server_kem_group_params.kem_group);
-            EXPECT_EQUAL(conn->secure.server_ecc_evp_params.negotiated_curve, curve);
-            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&conn->secure.server_ecc_evp_params));
-            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&conn->secure.client_ecc_evp_params[i]));
+            EXPECT_NULL(conn->kex_params.server_kem_group_params.kem_group);
+            EXPECT_EQUAL(conn->kex_params.server_ecc_evp_params.negotiated_curve, curve);
+            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&conn->kex_params.server_ecc_evp_params));
+            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&conn->kex_params.client_ecc_evp_params[i]));
         }
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -154,21 +154,21 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
         EXPECT_NOT_NULL(ecc_pref);
 
-        EXPECT_NULL(conn->secure.server_kem_group_params.kem_group);
+        EXPECT_NULL(conn->kex_params.server_kem_group_params.kem_group);
         DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
 
         for (size_t i = 0; i < ecc_pref->count; i++) {
             const struct s2n_ecc_named_curve *curve = ecc_pref->ecc_curves[i];
-            conn->secure.server_ecc_evp_params.negotiated_curve = curve;
-            EXPECT_NULL(conn->secure.server_ecc_evp_params.evp_pkey);
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = curve;
+            EXPECT_NULL(conn->kex_params.server_ecc_evp_params.evp_pkey);
 
             EXPECT_SUCCESS(s2n_server_key_share_extension.send(conn, &stuffer));
 
             S2N_STUFFER_READ_EXPECT_EQUAL(&stuffer, curve->iana_id, uint16);
             EXPECT_EQUAL(0, s2n_stuffer_data_available(&stuffer));
-            EXPECT_EQUAL(conn->secure.server_ecc_evp_params.negotiated_curve, curve);
-            EXPECT_NULL(conn->secure.server_ecc_evp_params.evp_pkey);
+            EXPECT_EQUAL(conn->kex_params.server_ecc_evp_params.negotiated_curve, curve);
+            EXPECT_NULL(conn->kex_params.server_ecc_evp_params.evp_pkey);
         }
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -186,8 +186,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Error if both curve and kem_group are NULL */
-        conn->secure.server_ecc_evp_params.negotiated_curve = NULL;
-        conn->secure.server_kem_group_params.kem_group = NULL;
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = NULL;
+        conn->kex_params.server_kem_group_params.kem_group = NULL;
         EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.send(conn, &stuffer), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -209,20 +209,20 @@ int main(int argc, char **argv)
   
             struct s2n_stuffer* extension_stuffer = &server_send_conn->handshake.io;
 
-            server_send_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[i];
-            server_send_conn->secure.client_ecc_evp_params[i].negotiated_curve = ecc_pref->ecc_curves[i];
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_send_conn->secure.client_ecc_evp_params[i]));
+            server_send_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[i];
+            server_send_conn->kex_params.client_ecc_evp_params[i].negotiated_curve = ecc_pref->ecc_curves[i];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_send_conn->kex_params.client_ecc_evp_params[i]));
             EXPECT_SUCCESS(s2n_server_key_share_extension.send(server_send_conn, extension_stuffer));
 
-            client_recv_conn->secure.client_ecc_evp_params[i].negotiated_curve = ecc_pref->ecc_curves[i];
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_recv_conn->secure.client_ecc_evp_params[i]));
+            client_recv_conn->kex_params.client_ecc_evp_params[i].negotiated_curve = ecc_pref->ecc_curves[i];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_recv_conn->kex_params.client_ecc_evp_params[i]));
 
             /* Parse key share */
             EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_recv_conn, extension_stuffer));
             EXPECT_EQUAL(s2n_stuffer_data_available(extension_stuffer), 0);
 
-            EXPECT_EQUAL(server_send_conn->secure.server_ecc_evp_params.negotiated_curve->iana_id, client_recv_conn->secure.server_ecc_evp_params.negotiated_curve->iana_id);
-            EXPECT_EQUAL(server_send_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[i]);
+            EXPECT_EQUAL(server_send_conn->kex_params.server_ecc_evp_params.negotiated_curve->iana_id, client_recv_conn->kex_params.server_ecc_evp_params.negotiated_curve->iana_id);
+            EXPECT_EQUAL(server_send_conn->kex_params.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[i]);
 
             EXPECT_SUCCESS(s2n_connection_free(server_send_conn));
             EXPECT_SUCCESS(s2n_connection_free(client_recv_conn));
@@ -258,14 +258,14 @@ int main(int argc, char **argv)
 
                 const char *payload = key_share_payloads[i];
 
-                EXPECT_NULL(client_conn->secure.server_ecc_evp_params.negotiated_curve);
+                EXPECT_NULL(client_conn->kex_params.server_ecc_evp_params.negotiated_curve);
                 EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&extension_stuffer, payload));
 
-                client_conn->secure.client_ecc_evp_params[i].negotiated_curve = ecc_pref->ecc_curves[i];
-                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[i]));
+                client_conn->kex_params.client_ecc_evp_params[i].negotiated_curve = ecc_pref->ecc_curves[i];
+                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params[i]));
 
                 EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &extension_stuffer));
-                EXPECT_EQUAL(client_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[i]);
+                EXPECT_EQUAL(client_conn->kex_params.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[i]);
                 EXPECT_EQUAL(s2n_stuffer_data_available(&extension_stuffer), 0);
 
                 EXPECT_SUCCESS(s2n_stuffer_free(&extension_stuffer));
@@ -286,20 +286,20 @@ int main(int argc, char **argv)
 
                 const char *payload = key_share_payloads[0];
 
-                EXPECT_NULL(client_conn->secure.server_ecc_evp_params.negotiated_curve);
+                EXPECT_NULL(client_conn->kex_params.server_ecc_evp_params.negotiated_curve);
                 EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&extension_stuffer, payload));
 
-                client_conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[0]));
+                client_conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params[0]));
 
                 client_conn->actual_protocol_version = S2N_TLS12;
                 EXPECT_SUCCESS(s2n_extension_recv(&s2n_server_key_share_extension, client_conn, &extension_stuffer));
-                EXPECT_NULL(client_conn->secure.server_ecc_evp_params.negotiated_curve);
+                EXPECT_NULL(client_conn->kex_params.server_ecc_evp_params.negotiated_curve);
                 EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&extension_stuffer), 0);
 
                 client_conn->actual_protocol_version = S2N_TLS13;
                 EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &extension_stuffer));
-                EXPECT_EQUAL(client_conn->secure.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
+                EXPECT_EQUAL(client_conn->kex_params.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
                 EXPECT_EQUAL(s2n_stuffer_data_available(&extension_stuffer), 0);
 
                 EXPECT_SUCCESS(s2n_stuffer_free(&extension_stuffer));
@@ -315,7 +315,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             const char *p256 = "001700410474cfd75c0ab7b57247761a277e1c92b5810dacb251bb758f43e9d15aaf292c4a2be43e886425ba55653ebb7a4f32fe368bacce3df00c618645cf1eb6";
 
-            EXPECT_NULL(client_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(client_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&extension_stuffer, p256));
 
             EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &extension_stuffer), S2N_ERR_BAD_KEY_SHARE);
@@ -336,14 +336,14 @@ int main(int argc, char **argv)
 
             const char *p256 = "001700410474cfd75c0ab7b57247761a277e1c92b5810dacb251bb758f43e9d15aaf292c4a2be43e886425ba55653ebb7a4f32fe368bacce3df00c618645cf1eb646f22552";
 
-            EXPECT_NULL(client_conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(client_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&extension_stuffer, p256));
 
             /* If s2n_is_evp_apis_supported is not supported, the ecc_prefs->ecc_curves contains only p-256, p-384 curves. */
             int p_384_index = s2n_is_evp_apis_supported() ? 2 : 1;
 
-            client_conn->secure.client_ecc_evp_params[p_384_index].negotiated_curve = ecc_pref->ecc_curves[p_384_index];
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[p_384_index]));
+            client_conn->kex_params.client_ecc_evp_params[p_384_index].negotiated_curve = ecc_pref->ecc_curves[p_384_index];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params[p_384_index]));
 
             EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &extension_stuffer), S2N_ERR_BAD_KEY_SHARE);
 
@@ -373,33 +373,33 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_stuffer_data_available(&key_share_extension), 0);
 
         /* Server configures the "negotiated_curve" */
-        server_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        server_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
         for (size_t i = 1; i < ecc_pref->count; i++) {
-            server_conn->secure.client_ecc_evp_params[i].negotiated_curve = NULL;
+            server_conn->kex_params.client_ecc_evp_params[i].negotiated_curve = NULL;
         }
 
         EXPECT_SUCCESS(s2n_server_key_share_extension.send(server_conn, &key_share_extension));
         EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &key_share_extension));
         EXPECT_EQUAL(s2n_stuffer_data_available(&key_share_extension), 0);
 
-        EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, client_conn->secure.server_ecc_evp_params.negotiated_curve);
+        EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve, client_conn->kex_params.server_ecc_evp_params.negotiated_curve);
 
         /* Ensure both client and server public key matches */
-        s2n_public_ecc_keys_are_equal(&server_conn->secure.server_ecc_evp_params, &client_conn->secure.server_ecc_evp_params);
-        s2n_public_ecc_keys_are_equal(&server_conn->secure.client_ecc_evp_params[0], &client_conn->secure.client_ecc_evp_params[0]);
+        s2n_public_ecc_keys_are_equal(&server_conn->kex_params.server_ecc_evp_params, &client_conn->kex_params.server_ecc_evp_params);
+        s2n_public_ecc_keys_are_equal(&server_conn->kex_params.client_ecc_evp_params[0], &client_conn->kex_params.client_ecc_evp_params[0]);
 
         /* Server generates shared key based on Server's Key and Client's public key  */
         struct s2n_blob server_shared_secret = { 0 };
         EXPECT_SUCCESS(s2n_ecc_evp_compute_shared_secret_from_params(
-            &server_conn->secure.server_ecc_evp_params,
-            &server_conn->secure.client_ecc_evp_params[0],
+            &server_conn->kex_params.server_ecc_evp_params,
+            &server_conn->kex_params.client_ecc_evp_params[0],
             &server_shared_secret));
 
         /* Clients generates shared key based on Client's Key and Server's public key */
         struct s2n_blob client_shared_secret = { 0 };
         EXPECT_SUCCESS(s2n_ecc_evp_compute_shared_secret_from_params(
-            &client_conn->secure.client_ecc_evp_params[0],
-            &client_conn->secure.server_ecc_evp_params,
+            &client_conn->kex_params.client_ecc_evp_params[0],
+            &client_conn->kex_params.server_ecc_evp_params,
             &client_shared_secret));
 
         /* Test that server shared secret matches client shared secret */
@@ -432,8 +432,8 @@ int main(int argc, char **argv)
         const struct s2n_ecc_named_curve *test_curve = &s2n_ecc_curve_x25519;
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(conn->config, "20140601"));
 
-        conn->secure.server_ecc_evp_params.negotiated_curve = test_curve;
-        conn->secure.client_ecc_evp_params[0].negotiated_curve = test_curve;
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = test_curve;
+        conn->kex_params.client_ecc_evp_params[0].negotiated_curve = test_curve;
         EXPECT_FAILURE(s2n_server_key_share_extension.send(conn, &conn->handshake.io));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -475,7 +475,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
             EXPECT_SUCCESS(s2n_connection_set_keyshare_by_name_for_testing(client_conn, "none"));
 
-            server_conn->secure.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
+            server_conn->kex_params.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
             EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(server_conn));
             EXPECT_MEMCPY_SUCCESS(server_conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
             EXPECT_SUCCESS(s2n_server_key_share_extension.send(server_conn, key_share_extension));
@@ -486,7 +486,7 @@ int main(int argc, char **argv)
 
             /* Verify that no key shares are sent */
             for (size_t i = 0; i < ecc_preferences->count; i++) {
-                struct s2n_ecc_evp_params *ecc_evp_params = &server_conn->secure.client_ecc_evp_params[i];
+                struct s2n_ecc_evp_params *ecc_evp_params = &server_conn->kex_params.client_ecc_evp_params[i];
                 EXPECT_NULL(ecc_evp_params->negotiated_curve);
                 EXPECT_NULL(ecc_evp_params->evp_pkey);
             }
@@ -501,8 +501,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, key_share_extension));
             EXPECT_EQUAL(s2n_stuffer_data_available(key_share_extension), 0);
 
-            EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, client_conn->secure.server_ecc_evp_params.negotiated_curve);
-            EXPECT_NULL(client_conn->secure.server_ecc_evp_params.evp_pkey);
+            EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve, client_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(client_conn->kex_params.server_ecc_evp_params.evp_pkey);
 
             EXPECT_SUCCESS(s2n_stuffer_free(key_share_extension));
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -608,16 +608,16 @@ int main(int argc, char **argv)
 
                         /* Read the test vectors from the KAT file (the PQ key shares are too long to hardcode inline).
                          * pq_private_key is intentionally missing DERFER_CLEANUP; it will get freed during s2n_connection_free. */
-                        struct s2n_blob *pq_private_key = &client_conn->secure.client_kem_group_params[i].kem_params.private_key;
+                        struct s2n_blob *pq_private_key = &client_conn->kex_params.client_kem_group_params[i].kem_params.private_key;
                         DEFER_CLEANUP(struct s2n_stuffer pq_shared_secret = {0}, s2n_stuffer_free);
                         DEFER_CLEANUP(struct s2n_stuffer key_share_payload = {0}, s2n_stuffer_free);
                         EXPECT_SUCCESS(s2n_read_server_key_share_hybrid_test_vectors(kem_group, pq_private_key,
                                 &pq_shared_secret, &key_share_payload));
 
                         /* Assert correct initial state */
-                        EXPECT_NULL(client_conn->secure.server_kem_group_params.kem_group);
-                        EXPECT_NULL(client_conn->secure.chosen_client_kem_group_params);
-                        EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_group);
+                        EXPECT_NULL(client_conn->kex_params.server_kem_group_params.kem_group);
+                        EXPECT_NULL(client_conn->kex_params.chosen_client_kem_group_params);
+                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params[i].kem_group);
 
                         const struct s2n_kem_preferences *kem_prefs = NULL;
                         EXPECT_SUCCESS(s2n_connection_get_kem_preferences(client_conn, &kem_prefs));
@@ -625,28 +625,28 @@ int main(int argc, char **argv)
                         EXPECT_EQUAL(kem_group, kem_prefs->tls13_kem_groups[i]);
 
                         /* This set up would have been done when the client sent its key share(s) */
-                        client_conn->secure.client_kem_group_params[i].kem_group = kem_group;
-                        client_conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve = kem_group->curve;
-                        client_conn->secure.client_kem_group_params[i].kem_params.kem = kem_group->kem;
-                        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_kem_group_params[i].ecc_params));
+                        client_conn->kex_params.client_kem_group_params[i].kem_group = kem_group;
+                        client_conn->kex_params.client_kem_group_params[i].ecc_params.negotiated_curve = kem_group->curve;
+                        client_conn->kex_params.client_kem_group_params[i].kem_params.kem = kem_group->kem;
+                        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_kem_group_params[i].ecc_params));
 
                         /* Call the function and assert correctness */
                         EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &key_share_payload));
 
-                        EXPECT_NOT_NULL(client_conn->secure.server_kem_group_params.kem_group);
-                        EXPECT_EQUAL(client_conn->secure.server_kem_group_params.kem_group, kem_group);
-                        EXPECT_NOT_NULL(client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-                        EXPECT_EQUAL(client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve,kem_group->curve);
-                        EXPECT_NOT_NULL(client_conn->secure.server_kem_group_params.kem_params.kem);
-                        EXPECT_EQUAL(client_conn->secure.server_kem_group_params.kem_params.kem, kem_group->kem);
+                        EXPECT_NOT_NULL(client_conn->kex_params.server_kem_group_params.kem_group);
+                        EXPECT_EQUAL(client_conn->kex_params.server_kem_group_params.kem_group, kem_group);
+                        EXPECT_NOT_NULL(client_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+                        EXPECT_EQUAL(client_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve,kem_group->curve);
+                        EXPECT_NOT_NULL(client_conn->kex_params.server_kem_group_params.kem_params.kem);
+                        EXPECT_EQUAL(client_conn->kex_params.server_kem_group_params.kem_params.kem, kem_group->kem);
 
-                        EXPECT_EQUAL(client_conn->secure.chosen_client_kem_group_params->kem_group, kem_group);
-                        EXPECT_EQUAL(client_conn->secure.chosen_client_kem_group_params->ecc_params.negotiated_curve,kem_group->curve);
-                        EXPECT_EQUAL(client_conn->secure.chosen_client_kem_group_params->kem_params.kem,kem_group->kem);
-                        EXPECT_NOT_NULL(client_conn->secure.chosen_client_kem_group_params->kem_params.shared_secret.data);
-                        EXPECT_EQUAL(client_conn->secure.chosen_client_kem_group_params->kem_params.shared_secret.size,
+                        EXPECT_EQUAL(client_conn->kex_params.chosen_client_kem_group_params->kem_group, kem_group);
+                        EXPECT_EQUAL(client_conn->kex_params.chosen_client_kem_group_params->ecc_params.negotiated_curve,kem_group->curve);
+                        EXPECT_EQUAL(client_conn->kex_params.chosen_client_kem_group_params->kem_params.kem,kem_group->kem);
+                        EXPECT_NOT_NULL(client_conn->kex_params.chosen_client_kem_group_params->kem_params.shared_secret.data);
+                        EXPECT_EQUAL(client_conn->kex_params.chosen_client_kem_group_params->kem_params.shared_secret.size,
                                 kem_group->kem->shared_secret_key_length);
-                        EXPECT_BYTEARRAY_EQUAL(client_conn->secure.chosen_client_kem_group_params->kem_params.shared_secret.data,
+                        EXPECT_BYTEARRAY_EQUAL(client_conn->kex_params.chosen_client_kem_group_params->kem_params.shared_secret.data,
                                 pq_shared_secret.blob.data, kem_group->kem->shared_secret_key_length);
 
                         EXPECT_EQUAL(s2n_stuffer_data_available(&key_share_payload), 0);
@@ -673,29 +673,29 @@ int main(int argc, char **argv)
                     /* Client should successfully parse the indicated group */
                     EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &key_share_payload));
 
-                    EXPECT_NOT_NULL(client_conn->secure.server_kem_group_params.kem_group);
-                    EXPECT_EQUAL(client_conn->secure.server_kem_group_params.kem_group, kem_group);
-                    EXPECT_NOT_NULL(client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-                    EXPECT_EQUAL(client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve,kem_group->curve);
-                    EXPECT_NOT_NULL(client_conn->secure.server_kem_group_params.kem_params.kem);
-                    EXPECT_EQUAL(client_conn->secure.server_kem_group_params.kem_params.kem, kem_group->kem);
+                    EXPECT_NOT_NULL(client_conn->kex_params.server_kem_group_params.kem_group);
+                    EXPECT_EQUAL(client_conn->kex_params.server_kem_group_params.kem_group, kem_group);
+                    EXPECT_NOT_NULL(client_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+                    EXPECT_EQUAL(client_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve,kem_group->curve);
+                    EXPECT_NOT_NULL(client_conn->kex_params.server_kem_group_params.kem_params.kem);
+                    EXPECT_EQUAL(client_conn->kex_params.server_kem_group_params.kem_params.kem, kem_group->kem);
 
                     /* s2n_server_key_share_extension.recv should have exited early after parsing the indicated group,
                      * so everything else should be NULL */
-                    EXPECT_NULL(client_conn->secure.chosen_client_kem_group_params);
+                    EXPECT_NULL(client_conn->kex_params.chosen_client_kem_group_params);
 
                     for (size_t i = 0; i < S2N_SUPPORTED_KEM_GROUPS_COUNT; i++) {
-                        EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_group);
-                        EXPECT_NULL(client_conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve);
-                        EXPECT_NULL(client_conn->secure.client_kem_group_params[i].ecc_params.evp_pkey);
-                        EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_params.kem);
-                        EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_params.private_key.data);
-                        EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_params.public_key.data);
-                        EXPECT_NULL(client_conn->secure.client_kem_group_params[i].kem_params.shared_secret.data);
+                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params[i].kem_group);
+                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params[i].ecc_params.negotiated_curve);
+                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params[i].ecc_params.evp_pkey);
+                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params[i].kem_params.kem);
+                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params[i].kem_params.private_key.data);
+                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params[i].kem_params.public_key.data);
+                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params[i].kem_params.shared_secret.data);
                     }
 
-                    EXPECT_NULL(client_conn->secure.server_kem_group_params.ecc_params.evp_pkey);
-                    EXPECT_NULL(client_conn->secure.server_kem_group_params.kem_params.shared_secret.data);
+                    EXPECT_NULL(client_conn->kex_params.server_kem_group_params.ecc_params.evp_pkey);
+                    EXPECT_NULL(client_conn->kex_params.server_kem_group_params.kem_params.shared_secret.data);
 
                     EXPECT_SUCCESS(s2n_connection_free(client_conn));
                 }
@@ -725,7 +725,7 @@ int main(int argc, char **argv)
                         /* To test the remaining failure cases, we need to read in the test vector from the KAT file, then
                          * manipulate it as necessary. (We do this now, instead of earlier, because we needed
                          * client_kem_group_params[i].kem_params.private_key to be empty to test the previous case.) */
-                        struct s2n_blob *pq_private_key = &client_conn->secure.client_kem_group_params[i].kem_params.private_key;
+                        struct s2n_blob *pq_private_key = &client_conn->kex_params.client_kem_group_params[i].kem_params.private_key;
                         DEFER_CLEANUP(struct s2n_stuffer pq_shared_secret = {0}, s2n_stuffer_free);
                         DEFER_CLEANUP(struct s2n_stuffer key_share_payload = {0}, s2n_stuffer_free);
                         EXPECT_SUCCESS(s2n_read_server_key_share_hybrid_test_vectors(kem_group, pq_private_key,
@@ -734,10 +734,10 @@ int main(int argc, char **argv)
                         /* Server sends the wrong (total) size: data[2] and data[3] are the bytes containing the total size
                          * of the key share; bitflip data[2] to invalidate the sent size */
                         key_share_payload.blob.data[2] = ~key_share_payload.blob.data[2];
-                        client_conn->secure.client_kem_group_params[i].kem_group = kem_group;
-                        client_conn->secure.client_kem_group_params[i].ecc_params.negotiated_curve = kem_group->curve;
-                        client_conn->secure.client_kem_group_params[i].kem_params.kem = kem_group->kem;
-                        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_kem_group_params[i].ecc_params));
+                        client_conn->kex_params.client_kem_group_params[i].kem_group = kem_group;
+                        client_conn->kex_params.client_kem_group_params[i].ecc_params.negotiated_curve = kem_group->curve;
+                        client_conn->kex_params.client_kem_group_params[i].kem_params.kem = kem_group->kem;
+                        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_kem_group_params[i].ecc_params));
                         EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &key_share_payload),
                                 S2N_ERR_BAD_KEY_SHARE);
                         /* Revert key_share_payload back to correct state */
@@ -785,7 +785,7 @@ int main(int argc, char **argv)
                         size_t pq_key_share_first_byte_index = pq_share_size_index + 2;
                         key_share_payload.blob.data[pq_key_share_first_byte_index] = ~key_share_payload.blob.data[pq_key_share_first_byte_index];
                         EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &key_share_payload));
-                        EXPECT_BYTEARRAY_NOT_EQUAL(client_conn->secure.chosen_client_kem_group_params->kem_params.shared_secret.data,
+                        EXPECT_BYTEARRAY_NOT_EQUAL(client_conn->kex_params.chosen_client_kem_group_params->kem_params.shared_secret.data,
                                 pq_shared_secret.blob.data, kem_group->kem->shared_secret_key_length);
 
                         EXPECT_SUCCESS(s2n_connection_free(client_conn));
@@ -810,36 +810,36 @@ int main(int argc, char **argv)
                 conn->security_policy_override = &security_policy_sike_bike;
 
                 EXPECT_FAILURE(s2n_server_key_share_send_check_pq_hybrid(conn));
-                conn->secure.server_kem_group_params.kem_params.kem = &s2n_kyber_512_r2;
+                conn->kex_params.server_kem_group_params.kem_params.kem = &s2n_kyber_512_r2;
 
                 EXPECT_FAILURE(s2n_server_key_share_send_check_pq_hybrid(conn));
-                conn->secure.server_kem_group_params.ecc_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
+                conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
 
-                conn->secure.server_kem_group_params.kem_group = &s2n_secp256r1_kyber_512_r2;
+                conn->kex_params.server_kem_group_params.kem_group = &s2n_secp256r1_kyber_512_r2;
                 EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
 
-                conn->secure.server_kem_group_params.kem_group = &s2n_secp256r1_bike1_l1_r2;
-                conn->secure.server_kem_group_params.kem_params.kem = &s2n_bike1_l1_r2;
+                conn->kex_params.server_kem_group_params.kem_group = &s2n_secp256r1_bike1_l1_r2;
+                conn->kex_params.server_kem_group_params.kem_params.kem = &s2n_bike1_l1_r2;
                 EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_NULL);
 
-                conn->secure.chosen_client_kem_group_params = &conn->secure.client_kem_group_params[1];
+                conn->kex_params.chosen_client_kem_group_params = &conn->kex_params.client_kem_group_params[1];
                 EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_BAD_KEY_SHARE);
 
-                conn->secure.client_kem_group_params[1].kem_group = &s2n_secp256r1_bike1_l1_r2;
+                conn->kex_params.client_kem_group_params[1].kem_group = &s2n_secp256r1_bike1_l1_r2;
                 EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_BAD_KEY_SHARE);
 
-                conn->secure.client_kem_group_params[1].ecc_params.negotiated_curve = s2n_secp256r1_bike1_l1_r2.curve;
+                conn->kex_params.client_kem_group_params[1].ecc_params.negotiated_curve = s2n_secp256r1_bike1_l1_r2.curve;
                 EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_BAD_KEY_SHARE);
 
-                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_kem_group_params[1].ecc_params));
+                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_kem_group_params[1].ecc_params));
                 EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_BAD_KEY_SHARE);
 
-                conn->secure.client_kem_group_params[1].kem_params.kem = s2n_secp256r1_bike1_l1_r2.kem;
+                conn->kex_params.client_kem_group_params[1].kem_params.kem = s2n_secp256r1_bike1_l1_r2.kem;
                 EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_BAD_KEY_SHARE);
 
-                EXPECT_SUCCESS(s2n_alloc(&conn->secure.client_kem_group_params[1].kem_params.public_key,
+                EXPECT_SUCCESS(s2n_alloc(&conn->kex_params.client_kem_group_params[1].kem_params.public_key,
                         s2n_secp256r1_bike1_l1_r2.kem->public_key_length));
-                EXPECT_OK(s2n_kem_generate_keypair(&conn->secure.client_kem_group_params[1].kem_params));
+                EXPECT_OK(s2n_kem_generate_keypair(&conn->kex_params.client_kem_group_params[1].kem_params));
                 EXPECT_SUCCESS(s2n_server_key_share_send_check_pq_hybrid(conn));
             }
 
@@ -862,16 +862,16 @@ int main(int argc, char **argv)
 
                 /* Set up the server so that it's chosen the correct KEM group and received
                  * a correspond keyshare from client */
-                conn->secure.server_ecc_evp_params.negotiated_curve = NULL;
+                conn->kex_params.server_ecc_evp_params.negotiated_curve = NULL;
 
-                struct s2n_kem_group_params *server_params = &conn->secure.server_kem_group_params;
+                struct s2n_kem_group_params *server_params = &conn->kex_params.server_kem_group_params;
                 const struct s2n_kem_group *kem_group = kem_pref->tls13_kem_groups[i];
                 server_params->kem_group = kem_group;
                 server_params->kem_params.kem = kem_group->kem;
                 server_params->ecc_params.negotiated_curve = kem_group->curve;
 
-                struct s2n_kem_group_params *client_params = &conn->secure.client_kem_group_params[i];
-                conn->secure.chosen_client_kem_group_params = client_params;
+                struct s2n_kem_group_params *client_params = &conn->kex_params.client_kem_group_params[i];
+                conn->kex_params.chosen_client_kem_group_params = client_params;
                 client_params->kem_group = kem_group;
                 client_params->kem_params.kem = kem_group->kem;
                 client_params->ecc_params.negotiated_curve = kem_group->curve;
@@ -893,7 +893,7 @@ int main(int argc, char **argv)
                 S2N_STUFFER_READ_EXPECT_EQUAL(&stuffer, kem_group->kem->ciphertext_length, uint16);
                 S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(&stuffer, kem_group->kem->ciphertext_length);
 
-                EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+                EXPECT_NULL(conn->kex_params.server_ecc_evp_params.negotiated_curve);
                 EXPECT_EQUAL(server_params->kem_group, kem_group);
                 EXPECT_EQUAL(server_params->kem_params.kem, kem_group->kem);
                 EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group->curve);
@@ -917,20 +917,20 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_pref));
             EXPECT_NOT_NULL(kem_pref);
 
-            EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+            EXPECT_NULL(conn->kex_params.server_ecc_evp_params.negotiated_curve);
             DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
 
             for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                struct s2n_kem_group_params *server_params = &conn->secure.server_kem_group_params;
+                struct s2n_kem_group_params *server_params = &conn->kex_params.server_kem_group_params;
                 const struct s2n_kem_group *kem_group = kem_pref->tls13_kem_groups[i];
 
                 server_params->kem_group = kem_group;
                 server_params->kem_params.kem = kem_group->kem;
                 server_params->ecc_params.negotiated_curve = kem_group->curve;
-                EXPECT_NULL(conn->secure.chosen_client_kem_group_params);
-                EXPECT_NULL(conn->secure.server_ecc_evp_params.evp_pkey);
-                EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
+                EXPECT_NULL(conn->kex_params.chosen_client_kem_group_params);
+                EXPECT_NULL(conn->kex_params.server_ecc_evp_params.evp_pkey);
+                EXPECT_NULL(conn->kex_params.server_ecc_evp_params.negotiated_curve);
 
                 EXPECT_SUCCESS(s2n_server_key_share_extension.send(conn, &stuffer));
 
@@ -943,10 +943,10 @@ int main(int argc, char **argv)
                 EXPECT_NULL(server_params->kem_params.shared_secret.data);
                 EXPECT_EQUAL(0, server_params->kem_params.shared_secret.size);
                 EXPECT_NULL(server_params->ecc_params.evp_pkey);
-                EXPECT_NULL(conn->secure.chosen_client_kem_group_params);
+                EXPECT_NULL(conn->kex_params.chosen_client_kem_group_params);
 
-                EXPECT_NULL(conn->secure.server_ecc_evp_params.negotiated_curve);
-                EXPECT_NULL(conn->secure.server_ecc_evp_params.evp_pkey);
+                EXPECT_NULL(conn->kex_params.server_ecc_evp_params.negotiated_curve);
+                EXPECT_NULL(conn->kex_params.server_ecc_evp_params.evp_pkey);
             }
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -966,8 +966,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
             EXPECT_NOT_NULL(ecc_pref);
 
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-            conn->secure.server_kem_group_params.kem_group = kem_pref->tls13_kem_groups[0];
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->kex_params.server_kem_group_params.kem_group = kem_pref->tls13_kem_groups[0];
 
             DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));

--- a/tests/unit/s2n_tls13_compute_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_compute_shared_secret_test.c
@@ -54,11 +54,11 @@ int main(int argc, char **argv) {
         EXPECT_NOT_NULL(ecc_pref);
 
         /* Select curve and generate key for client */
-        client_conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[0]));
+        client_conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params[0]));
         /* Recreating conditions where negotiated curve was not set */
         struct s2n_ecc_evp_params missing_params = {NULL,NULL};
-        client_conn->secure.server_ecc_evp_params = missing_params;
+        client_conn->kex_params.server_ecc_evp_params = missing_params;
         DEFER_CLEANUP(struct s2n_blob client_shared_secret = {0}, s2n_free);
         /* Compute fails because server's curve and public key are missing. */
         EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_shared_secret(client_conn, &client_shared_secret), S2N_ERR_NULL);
@@ -79,11 +79,11 @@ int main(int argc, char **argv) {
         EXPECT_NOT_NULL(ecc_pref);
 
         /* Select curve and generate key for client */
-        client_conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[0]));
+        client_conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params[0]));
 
         /* Set curve server sent in server hello */
-        client_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        client_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
 
         DEFER_CLEANUP(struct s2n_blob client_shared_secret = {0}, s2n_free);
         /* Compute fails because server's public key is missing */
@@ -105,14 +105,14 @@ int main(int argc, char **argv) {
         client_conn->actual_protocol_version = S2N_TLS13;
 
         /* Select curve and generate key for client */
-        client_conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.client_ecc_evp_params[0]));
+        client_conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params[0]));
 
         /* Set curve server sent in server hello */
-        client_conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        client_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
 
         /* Generate public key server sent in server hello */
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->secure.server_ecc_evp_params));
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.server_ecc_evp_params));
         DEFER_CLEANUP(struct s2n_blob client_shared_secret = {0}, s2n_free);
         EXPECT_SUCCESS(s2n_tls13_compute_shared_secret(client_conn, &client_shared_secret));
 

--- a/tests/unit/s2n_tls13_handshake_early_data_test.c
+++ b/tests/unit/s2n_tls13_handshake_early_data_test.c
@@ -96,10 +96,10 @@ static S2N_RESULT s2n_setup_tls13_secrets_prereqs(struct s2n_connection *conn)
     RESULT_GUARD_POSIX(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
     RESULT_ENSURE_REF(ecc_pref);
 
-    conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-    conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-    RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.server_ecc_evp_params));
-    RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+    conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+    conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+    RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.server_ecc_evp_params));
+    RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
 
     uint8_t test_value[SHA256_DIGEST_LENGTH] = "test";
     DEFER_CLEANUP(struct s2n_psk *s2n_test_psk = s2n_external_psk_new(), s2n_psk_free);

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -53,10 +53,10 @@ static int s2n_setup_tls13_secrets_prereqs(struct s2n_connection *conn)
     POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
     POSIX_ENSURE_REF(ecc_pref);
 
-    conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-    conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.server_ecc_evp_params));
-    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+    conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+    conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.server_ecc_evp_params));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
 
     return S2N_SUCCESS;
 }
@@ -174,7 +174,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_extensions_client_key_share_recv(server_conn, &client_hello_key_share));
 
         /* Server configures the "negotiated_curve" */
-        server_conn->secure.server_ecc_evp_params.negotiated_curve = server_ecc_preferences->ecc_curves[0];
+        server_conn->kex_params.server_ecc_evp_params.negotiated_curve = server_ecc_preferences->ecc_curves[0];
 
         /* Server sends ServerHello key_share */
         EXPECT_SUCCESS(s2n_extensions_server_key_share_send(server_conn, &server_hello_key_share));
@@ -185,7 +185,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_extensions_server_key_share_recv(client_conn, &server_hello_key_share));
         EXPECT_EQUAL(s2n_stuffer_data_available(&server_hello_key_share), 0);
 
-        EXPECT_EQUAL(server_conn->secure.server_ecc_evp_params.negotiated_curve, client_conn->secure.server_ecc_evp_params.negotiated_curve);
+        EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve, client_conn->kex_params.server_ecc_evp_params.negotiated_curve);
 
         client_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
         server_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
@@ -329,10 +329,10 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(ecc_preferences);
 
             conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.server_ecc_evp_params));
-            conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_preferences->ecc_curves[0];
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.server_ecc_evp_params));
+            conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_preferences->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
 
             const uint8_t psk_data[] = "test identity data";
             const uint8_t secret_data[] = "test secret data";
@@ -376,10 +376,10 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(ecc_preferences);
 
             conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
-            conn->secure.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.server_ecc_evp_params));
-            conn->secure.client_ecc_evp_params[0].negotiated_curve = ecc_preferences->ecc_curves[0];
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.client_ecc_evp_params[0]));
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.server_ecc_evp_params));
+            conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_preferences->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
 
             const uint8_t psk_data[] = "test identity data";
             const uint8_t secret_data[] = "test secret data";

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -435,36 +435,36 @@ int main(int argc, char **argv) {
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(NULL, &calculated_shared_secret), S2N_ERR_NULL);
 
             /* Failures because classic (non-hybrid) parameters were configured */
-            conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_SAFETY);
-            conn->secure.server_ecc_evp_params.negotiated_curve = NULL;
-            EXPECT_SUCCESS(read_priv_ecc(&conn->secure.server_ecc_evp_params.evp_pkey, test_vector->client_ecc_key));
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = NULL;
+            EXPECT_SUCCESS(read_priv_ecc(&conn->kex_params.server_ecc_evp_params.evp_pkey, test_vector->client_ecc_key));
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_SAFETY);
-            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&conn->secure.server_ecc_evp_params));
+            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&conn->kex_params.server_ecc_evp_params));
 
             /* Failure because the chosen_client_kem_group_params is NULL */
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_NULL);
-            conn->secure.chosen_client_kem_group_params = &conn->secure.client_kem_group_params[0];
+            conn->kex_params.chosen_client_kem_group_params = &conn->kex_params.client_kem_group_params[0];
 
             /* Failures because the kem_group_params aren't set */
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_NULL);
-            conn->secure.server_kem_group_params.ecc_params.negotiated_curve = test_vector->kem_group->curve;
+            conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve = test_vector->kem_group->curve;
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_NULL);
-            conn->secure.chosen_client_kem_group_params->ecc_params.negotiated_curve = test_vector->kem_group->curve;
+            conn->kex_params.chosen_client_kem_group_params->ecc_params.negotiated_curve = test_vector->kem_group->curve;
 
             /* Failures because the ECC private keys are NULL */
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_NULL);
-            EXPECT_SUCCESS(read_priv_ecc(&conn->secure.chosen_client_kem_group_params->ecc_params.evp_pkey, test_vector->client_ecc_key));
+            EXPECT_SUCCESS(read_priv_ecc(&conn->kex_params.chosen_client_kem_group_params->ecc_params.evp_pkey, test_vector->client_ecc_key));
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_NULL);
-            EXPECT_SUCCESS(read_priv_ecc(&conn->secure.server_kem_group_params.ecc_params.evp_pkey, test_vector->server_ecc_key));
+            EXPECT_SUCCESS(read_priv_ecc(&conn->kex_params.server_kem_group_params.ecc_params.evp_pkey, test_vector->server_ecc_key));
 
             /* Failure because pq_shared_secret is NULL */
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_NULL);
-            EXPECT_SUCCESS(s2n_dup(test_vector->pq_secret, &conn->secure.chosen_client_kem_group_params->kem_params.shared_secret));
+            EXPECT_SUCCESS(s2n_dup(test_vector->pq_secret, &conn->kex_params.chosen_client_kem_group_params->kem_params.shared_secret));
 
             /* Failure because the kem_group is NULL */
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret), S2N_ERR_NULL);
-            conn->secure.server_kem_group_params.kem_group = test_vector->kem_group;
+            conn->kex_params.server_kem_group_params.kem_group = test_vector->kem_group;
 
             /* Finally, success */
             EXPECT_SUCCESS(s2n_tls13_compute_pq_hybrid_shared_secret(conn, &calculated_shared_secret));
@@ -508,45 +508,45 @@ static int set_up_conns(struct s2n_connection *client_conn, struct s2n_connectio
                         const char *client_priv_ecc, const char *server_priv_ecc, const struct s2n_kem_group *kem_group,
                         struct s2n_blob *pq_shared_secret) {
     /* These parameters would normally be set during the handshake */
-    client_conn->secure.chosen_client_kem_group_params = &client_conn->secure.client_kem_group_params[0];
-    server_conn->secure.chosen_client_kem_group_params = &server_conn->secure.client_kem_group_params[0];
+    client_conn->kex_params.chosen_client_kem_group_params = &client_conn->kex_params.client_kem_group_params[0];
+    server_conn->kex_params.chosen_client_kem_group_params = &server_conn->kex_params.client_kem_group_params[0];
 
-    server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve = kem_group->curve;
-    server_conn->secure.chosen_client_kem_group_params->ecc_params.negotiated_curve = kem_group->curve;
-    client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve = kem_group->curve;
-    client_conn->secure.chosen_client_kem_group_params->ecc_params.negotiated_curve = kem_group->curve;
+    server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve = kem_group->curve;
+    server_conn->kex_params.chosen_client_kem_group_params->ecc_params.negotiated_curve = kem_group->curve;
+    client_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve = kem_group->curve;
+    client_conn->kex_params.chosen_client_kem_group_params->ecc_params.negotiated_curve = kem_group->curve;
 
-    server_conn->secure.server_kem_group_params.kem_group = kem_group;
-    server_conn->secure.chosen_client_kem_group_params->kem_group = kem_group;
-    client_conn->secure.server_kem_group_params.kem_group = kem_group;
-    client_conn->secure.chosen_client_kem_group_params->kem_group = kem_group;
+    server_conn->kex_params.server_kem_group_params.kem_group = kem_group;
+    server_conn->kex_params.chosen_client_kem_group_params->kem_group = kem_group;
+    client_conn->kex_params.server_kem_group_params.kem_group = kem_group;
+    client_conn->kex_params.chosen_client_kem_group_params->kem_group = kem_group;
 
-    server_conn->secure.server_kem_group_params.kem_params.kem = kem_group->kem;
-    server_conn->secure.chosen_client_kem_group_params->kem_params.kem = kem_group->kem;
-    client_conn->secure.server_kem_group_params.kem_params.kem = kem_group->kem;
-    client_conn->secure.chosen_client_kem_group_params->kem_params.kem = kem_group->kem;
+    server_conn->kex_params.server_kem_group_params.kem_params.kem = kem_group->kem;
+    server_conn->kex_params.chosen_client_kem_group_params->kem_params.kem = kem_group->kem;
+    client_conn->kex_params.server_kem_group_params.kem_params.kem = kem_group->kem;
+    client_conn->kex_params.chosen_client_kem_group_params->kem_params.kem = kem_group->kem;
 
     /* During an actual handshake, server will generate the shared secret and store it in chosen_client_kem_group_params,
      * client will decapsulate the ciphertext and store the shared secret in chosen_client_kem_group_params. */
-    POSIX_GUARD(s2n_dup(pq_shared_secret, &server_conn->secure.chosen_client_kem_group_params->kem_params.shared_secret));
-    POSIX_GUARD(s2n_dup(pq_shared_secret, &client_conn->secure.chosen_client_kem_group_params->kem_params.shared_secret));
+    POSIX_GUARD(s2n_dup(pq_shared_secret, &server_conn->kex_params.chosen_client_kem_group_params->kem_params.shared_secret));
+    POSIX_GUARD(s2n_dup(pq_shared_secret, &client_conn->kex_params.chosen_client_kem_group_params->kem_params.shared_secret));
 
     /* Populate the client's PQ private key with something - it doesn't have to be a
      * legitimate private key since it doesn't get used in the shared secret derivation,
      * but we want to make sure its definitely been freed after shared secret calculation */
-    POSIX_GUARD(s2n_alloc(&client_conn->secure.chosen_client_kem_group_params->kem_params.private_key, 2));
+    POSIX_GUARD(s2n_alloc(&client_conn->kex_params.chosen_client_kem_group_params->kem_params.private_key, 2));
     struct s2n_stuffer private_key_stuffer = {0};
     POSIX_GUARD(s2n_stuffer_init(&private_key_stuffer,
-                           &client_conn->secure.chosen_client_kem_group_params->kem_params.private_key));
+                           &client_conn->kex_params.chosen_client_kem_group_params->kem_params.private_key));
     uint8_t fake_private_key[] = {3, 3};
     POSIX_GUARD(s2n_stuffer_write_bytes(&private_key_stuffer, fake_private_key, 2));
 
     /* "Import" the provided private ECC keys */
     POSIX_ENSURE_EQ(sizeof(char) * strlen(client_priv_ecc), sizeof(char) * strlen(server_priv_ecc));
-    POSIX_GUARD(read_priv_ecc(&client_conn->secure.chosen_client_kem_group_params->ecc_params.evp_pkey, client_priv_ecc));
-    POSIX_ENSURE_REF(client_conn->secure.chosen_client_kem_group_params->ecc_params.evp_pkey);
-    POSIX_GUARD(read_priv_ecc(&server_conn->secure.server_kem_group_params.ecc_params.evp_pkey, server_priv_ecc));
-    POSIX_ENSURE_REF(server_conn->secure.server_kem_group_params.ecc_params.evp_pkey);
+    POSIX_GUARD(read_priv_ecc(&client_conn->kex_params.chosen_client_kem_group_params->ecc_params.evp_pkey, client_priv_ecc));
+    POSIX_ENSURE_REF(client_conn->kex_params.chosen_client_kem_group_params->ecc_params.evp_pkey);
+    POSIX_GUARD(read_priv_ecc(&server_conn->kex_params.server_kem_group_params.ecc_params.evp_pkey, server_priv_ecc));
+    POSIX_ENSURE_REF(server_conn->kex_params.server_kem_group_params.ecc_params.evp_pkey);
 
     /* Each peer sends its public ECC key to the other */
     struct s2n_stuffer wire;
@@ -555,13 +555,13 @@ static int set_up_conns(struct s2n_connection *client_conn, struct s2n_connectio
 
     POSIX_GUARD(s2n_stuffer_growable_alloc(&wire, 1024));
 
-    POSIX_GUARD(s2n_ecc_evp_write_params_point(&server_conn->secure.server_kem_group_params.ecc_params, &wire));
+    POSIX_GUARD(s2n_ecc_evp_write_params_point(&server_conn->kex_params.server_kem_group_params.ecc_params, &wire));
     POSIX_GUARD(s2n_ecc_evp_read_params_point(&wire, share_size, &server_point_blob));
-    POSIX_GUARD(s2n_ecc_evp_parse_params_point(&server_point_blob, &client_conn->secure.server_kem_group_params.ecc_params));
+    POSIX_GUARD(s2n_ecc_evp_parse_params_point(&server_point_blob, &client_conn->kex_params.server_kem_group_params.ecc_params));
 
-    POSIX_GUARD(s2n_ecc_evp_write_params_point(&client_conn->secure.chosen_client_kem_group_params->ecc_params, &wire));
+    POSIX_GUARD(s2n_ecc_evp_write_params_point(&client_conn->kex_params.chosen_client_kem_group_params->ecc_params, &wire));
     POSIX_GUARD(s2n_ecc_evp_read_params_point(&wire, share_size, &client_point_blob));
-    POSIX_GUARD(s2n_ecc_evp_parse_params_point(&client_point_blob, &server_conn->secure.chosen_client_kem_group_params->ecc_params));
+    POSIX_GUARD(s2n_ecc_evp_parse_params_point(&client_point_blob, &server_conn->kex_params.chosen_client_kem_group_params->ecc_params));
 
     POSIX_GUARD(s2n_stuffer_free(&wire));
 
@@ -569,21 +569,21 @@ static int set_up_conns(struct s2n_connection *client_conn, struct s2n_connectio
 }
 
 static int assert_kem_group_params_freed(struct s2n_connection *conn) {
-    POSIX_ENSURE_EQ(NULL,conn->secure.server_kem_group_params.ecc_params.evp_pkey);
-    POSIX_ENSURE_EQ(NULL,conn->secure.server_kem_group_params.kem_params.shared_secret.data);
-    POSIX_ENSURE_EQ(0, conn->secure.server_kem_group_params.kem_params.shared_secret.allocated);
-    POSIX_ENSURE_EQ(NULL, conn->secure.server_kem_group_params.kem_params.private_key.data);
-    POSIX_ENSURE_EQ(0, conn->secure.server_kem_group_params.kem_params.private_key.allocated);
-    POSIX_ENSURE_EQ(NULL, conn->secure.server_kem_group_params.kem_params.public_key.data);
-    POSIX_ENSURE_EQ(0, conn->secure.server_kem_group_params.kem_params.public_key.allocated);
+    POSIX_ENSURE_EQ(NULL,conn->kex_params.server_kem_group_params.ecc_params.evp_pkey);
+    POSIX_ENSURE_EQ(NULL,conn->kex_params.server_kem_group_params.kem_params.shared_secret.data);
+    POSIX_ENSURE_EQ(0, conn->kex_params.server_kem_group_params.kem_params.shared_secret.allocated);
+    POSIX_ENSURE_EQ(NULL, conn->kex_params.server_kem_group_params.kem_params.private_key.data);
+    POSIX_ENSURE_EQ(0, conn->kex_params.server_kem_group_params.kem_params.private_key.allocated);
+    POSIX_ENSURE_EQ(NULL, conn->kex_params.server_kem_group_params.kem_params.public_key.data);
+    POSIX_ENSURE_EQ(0, conn->kex_params.server_kem_group_params.kem_params.public_key.allocated);
 
-    POSIX_ENSURE_EQ(NULL, conn->secure.chosen_client_kem_group_params->ecc_params.evp_pkey);
-    POSIX_ENSURE_EQ(NULL, conn->secure.chosen_client_kem_group_params->kem_params.shared_secret.data);
-    POSIX_ENSURE_EQ(0, conn->secure.chosen_client_kem_group_params->kem_params.shared_secret.allocated);
-    POSIX_ENSURE_EQ(NULL, conn->secure.chosen_client_kem_group_params->kem_params.private_key.data);
-    POSIX_ENSURE_EQ(0, conn->secure.chosen_client_kem_group_params->kem_params.private_key.allocated);
-    POSIX_ENSURE_EQ(NULL, conn->secure.chosen_client_kem_group_params->kem_params.public_key.data);
-    POSIX_ENSURE_EQ(0, conn->secure.chosen_client_kem_group_params->kem_params.public_key.allocated);
+    POSIX_ENSURE_EQ(NULL, conn->kex_params.chosen_client_kem_group_params->ecc_params.evp_pkey);
+    POSIX_ENSURE_EQ(NULL, conn->kex_params.chosen_client_kem_group_params->kem_params.shared_secret.data);
+    POSIX_ENSURE_EQ(0, conn->kex_params.chosen_client_kem_group_params->kem_params.shared_secret.allocated);
+    POSIX_ENSURE_EQ(NULL, conn->kex_params.chosen_client_kem_group_params->kem_params.private_key.data);
+    POSIX_ENSURE_EQ(0, conn->kex_params.chosen_client_kem_group_params->kem_params.private_key.allocated);
+    POSIX_ENSURE_EQ(NULL, conn->kex_params.chosen_client_kem_group_params->kem_params.public_key.data);
+    POSIX_ENSURE_EQ(0, conn->kex_params.chosen_client_kem_group_params->kem_params.public_key.allocated);
 
     return S2N_SUCCESS;
 }

--- a/tests/unit/s2n_tls13_pq_handshake_test.c
+++ b/tests/unit/s2n_tls13_pq_handshake_test.c
@@ -83,15 +83,15 @@ int s2n_test_tls13_pq_handshake(const struct s2n_security_policy *client_sec_pol
 
     /* Assert that the server chose the correct group */
     if (expected_kem_group) {
-        POSIX_ENSURE_EQ(expected_kem_group, server_conn->secure.server_kem_group_params.kem_group);
-        POSIX_ENSURE_EQ(expected_kem_group->kem, server_conn->secure.server_kem_group_params.kem_params.kem);
-        POSIX_ENSURE_EQ(expected_kem_group->curve, server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-        POSIX_ENSURE_EQ(NULL, server_conn->secure.server_ecc_evp_params.negotiated_curve);
+        POSIX_ENSURE_EQ(expected_kem_group, server_conn->kex_params.server_kem_group_params.kem_group);
+        POSIX_ENSURE_EQ(expected_kem_group->kem, server_conn->kex_params.server_kem_group_params.kem_params.kem);
+        POSIX_ENSURE_EQ(expected_kem_group->curve, server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+        POSIX_ENSURE_EQ(NULL, server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
     } else {
-        POSIX_ENSURE_EQ(NULL, server_conn->secure.server_kem_group_params.kem_group);
-        POSIX_ENSURE_EQ(NULL, server_conn->secure.server_kem_group_params.kem_params.kem);
-        POSIX_ENSURE_EQ(NULL, server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-        POSIX_ENSURE_EQ(expected_curve, server_conn->secure.server_ecc_evp_params.negotiated_curve);
+        POSIX_ENSURE_EQ(NULL, server_conn->kex_params.server_kem_group_params.kem_group);
+        POSIX_ENSURE_EQ(NULL, server_conn->kex_params.server_kem_group_params.kem_params.kem);
+        POSIX_ENSURE_EQ(NULL, server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+        POSIX_ENSURE_EQ(expected_curve, server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
     }
 
     /* Server sends ServerHello or HRR */
@@ -147,25 +147,25 @@ int s2n_test_tls13_pq_handshake(const struct s2n_security_policy *client_sec_pol
     /* Assert that the correct group was negotiated (we re-check the server group to assert that
      * nothing unexpected changed between then and now while e.g. processing HRR) */
     if (expected_kem_group) {
-        POSIX_ENSURE_EQ(expected_kem_group, client_conn->secure.server_kem_group_params.kem_group);
-        POSIX_ENSURE_EQ(expected_kem_group->kem, client_conn->secure.server_kem_group_params.kem_params.kem);
-        POSIX_ENSURE_EQ(expected_kem_group->curve, client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-        POSIX_ENSURE_EQ(NULL, client_conn->secure.server_ecc_evp_params.negotiated_curve);
+        POSIX_ENSURE_EQ(expected_kem_group, client_conn->kex_params.server_kem_group_params.kem_group);
+        POSIX_ENSURE_EQ(expected_kem_group->kem, client_conn->kex_params.server_kem_group_params.kem_params.kem);
+        POSIX_ENSURE_EQ(expected_kem_group->curve, client_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+        POSIX_ENSURE_EQ(NULL, client_conn->kex_params.server_ecc_evp_params.negotiated_curve);
 
-        POSIX_ENSURE_EQ(expected_kem_group, server_conn->secure.server_kem_group_params.kem_group);
-        POSIX_ENSURE_EQ(expected_kem_group->kem, server_conn->secure.server_kem_group_params.kem_params.kem);
-        POSIX_ENSURE_EQ(expected_kem_group->curve, server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-        POSIX_ENSURE_EQ(NULL, server_conn->secure.server_ecc_evp_params.negotiated_curve);
+        POSIX_ENSURE_EQ(expected_kem_group, server_conn->kex_params.server_kem_group_params.kem_group);
+        POSIX_ENSURE_EQ(expected_kem_group->kem, server_conn->kex_params.server_kem_group_params.kem_params.kem);
+        POSIX_ENSURE_EQ(expected_kem_group->curve, server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+        POSIX_ENSURE_EQ(NULL, server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
     } else {
-        POSIX_ENSURE_EQ(NULL, client_conn->secure.server_kem_group_params.kem_group);
-        POSIX_ENSURE_EQ(NULL, client_conn->secure.server_kem_group_params.kem_params.kem);
-        POSIX_ENSURE_EQ(NULL, client_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-        POSIX_ENSURE_EQ(expected_curve, client_conn->secure.server_ecc_evp_params.negotiated_curve);
+        POSIX_ENSURE_EQ(NULL, client_conn->kex_params.server_kem_group_params.kem_group);
+        POSIX_ENSURE_EQ(NULL, client_conn->kex_params.server_kem_group_params.kem_params.kem);
+        POSIX_ENSURE_EQ(NULL, client_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+        POSIX_ENSURE_EQ(expected_curve, client_conn->kex_params.server_ecc_evp_params.negotiated_curve);
 
-        POSIX_ENSURE_EQ(NULL, server_conn->secure.server_kem_group_params.kem_group);
-        POSIX_ENSURE_EQ(NULL, server_conn->secure.server_kem_group_params.kem_params.kem);
-        POSIX_ENSURE_EQ(NULL, server_conn->secure.server_kem_group_params.ecc_params.negotiated_curve);
-        POSIX_ENSURE_EQ(expected_curve, server_conn->secure.server_ecc_evp_params.negotiated_curve);
+        POSIX_ENSURE_EQ(NULL, server_conn->kex_params.server_kem_group_params.kem_group);
+        POSIX_ENSURE_EQ(NULL, server_conn->kex_params.server_kem_group_params.kem_params.kem);
+        POSIX_ENSURE_EQ(NULL, server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
+        POSIX_ENSURE_EQ(expected_curve, server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
     }
 
     /* Verify basic properties of secrets */

--- a/tests/unit/s2n_tls_hybrid_prf_test.c
+++ b/tests/unit/s2n_tls_hybrid_prf_test.c
@@ -103,13 +103,13 @@ int main(int argc, char **argv)
         EXPECT_MEMCPY_SUCCESS(conn->secure.client_random, client_random, CLIENT_RANDOM_LENGTH);
         EXPECT_MEMCPY_SUCCESS(conn->secure.server_random, server_random, SERVER_RANDOM_LENGTH);
 
-        EXPECT_SUCCESS(s2n_alloc(&conn->secure.client_key_exchange_message, client_key_exchange_message_length));
+        EXPECT_SUCCESS(s2n_alloc(&conn->kex_params.client_key_exchange_message, client_key_exchange_message_length));
 
-        EXPECT_MEMCPY_SUCCESS(conn->secure.client_key_exchange_message.data, client_key_exchange_message, client_key_exchange_message_length);
+        EXPECT_MEMCPY_SUCCESS(conn->kex_params.client_key_exchange_message.data, client_key_exchange_message, client_key_exchange_message_length);
 
         EXPECT_SUCCESS(s2n_hybrid_prf_master_secret(conn, &combined_pms));
         EXPECT_BYTEARRAY_EQUAL(expected_master_secret, conn->secure.master_secret, S2N_TLS_SECRET_LEN);
-        EXPECT_SUCCESS(s2n_free(&conn->secure.client_key_exchange_message));
+        EXPECT_SUCCESS(s2n_free(&conn->kex_params.client_key_exchange_message));
         EXPECT_SUCCESS(s2n_connection_free(conn));
 
         free(premaster_kem_secret);

--- a/tls/extensions/s2n_client_pq_kem.c
+++ b/tls/extensions/s2n_client_pq_kem.c
@@ -63,7 +63,7 @@ static int s2n_client_pq_kem_send(struct s2n_connection *conn, struct s2n_stuffe
 static int s2n_client_pq_kem_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     uint16_t size_of_all;
-    struct s2n_blob *proposed_kems = &conn->secure.client_pq_kem_extension;
+    struct s2n_blob *proposed_kems = &conn->kex_params.client_pq_kem_extension;
 
     /* Ignore extension if PQ is disabled */
     if (!s2n_pq_is_enabled()) {

--- a/tls/extensions/s2n_client_supported_groups.c
+++ b/tls/extensions/s2n_client_supported_groups.c
@@ -92,7 +92,7 @@ static int s2n_client_supported_groups_recv_iana_id(struct s2n_connection *conn,
     for (size_t i = 0; i < ecc_pref->count; i++) {
         const struct s2n_ecc_named_curve *supported_curve = ecc_pref->ecc_curves[i];
         if (iana_id == supported_curve->iana_id) {
-            conn->secure.mutually_supported_curves[i] = supported_curve;
+            conn->kex_params.mutually_supported_curves[i] = supported_curve;
             return S2N_SUCCESS;
         }
     }
@@ -109,7 +109,7 @@ static int s2n_client_supported_groups_recv_iana_id(struct s2n_connection *conn,
     for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
         const struct s2n_kem_group *supported_kem_group = kem_pref->tls13_kem_groups[i];
         if (iana_id == supported_kem_group->iana_id) {
-            conn->secure.mutually_supported_kem_groups[i] = supported_kem_group;
+            conn->kex_params.mutually_supported_kem_groups[i] = supported_kem_group;
             return S2N_SUCCESS;
         }
     }
@@ -130,28 +130,28 @@ static int s2n_choose_supported_group(struct s2n_connection *conn) {
 
     /* Ensure that only the intended group will be non-NULL (if no group is chosen, everything
      * should be NULL). */
-    conn->secure.server_kem_group_params.kem_group = NULL;
-    conn->secure.server_kem_group_params.ecc_params.negotiated_curve = NULL;
-    conn->secure.server_kem_group_params.kem_params.kem = NULL;
-    conn->secure.server_ecc_evp_params.negotiated_curve = NULL;
+    conn->kex_params.server_kem_group_params.kem_group = NULL;
+    conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve = NULL;
+    conn->kex_params.server_kem_group_params.kem_params.kem = NULL;
+    conn->kex_params.server_ecc_evp_params.negotiated_curve = NULL;
 
     /* Prefer to negotiate hybrid PQ over ECC. If PQ is disabled, we will never choose a
      * PQ group because the mutually_supported_kem_groups array will not have been
      * populated with anything. */
     for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-        const struct s2n_kem_group *candidate_kem_group = conn->secure.mutually_supported_kem_groups[i];
+        const struct s2n_kem_group *candidate_kem_group = conn->kex_params.mutually_supported_kem_groups[i];
         if (candidate_kem_group != NULL) {
-            conn->secure.server_kem_group_params.kem_group = candidate_kem_group;
-            conn->secure.server_kem_group_params.ecc_params.negotiated_curve = candidate_kem_group->curve;
-            conn->secure.server_kem_group_params.kem_params.kem = candidate_kem_group->kem;
+            conn->kex_params.server_kem_group_params.kem_group = candidate_kem_group;
+            conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve = candidate_kem_group->curve;
+            conn->kex_params.server_kem_group_params.kem_params.kem = candidate_kem_group->kem;
             return S2N_SUCCESS;
         }
     }
 
     for (size_t i = 0; i < ecc_pref->count; i++) {
-        const struct s2n_ecc_named_curve *candidate_curve = conn->secure.mutually_supported_curves[i];
+        const struct s2n_ecc_named_curve *candidate_curve = conn->kex_params.mutually_supported_curves[i];
         if (candidate_curve != NULL) {
-            conn->secure.server_ecc_evp_params.negotiated_curve = candidate_curve;
+            conn->kex_params.server_ecc_evp_params.negotiated_curve = candidate_curve;
             return S2N_SUCCESS;
         }
     }

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -246,10 +246,10 @@ static int s2n_parse_client_hello(struct s2n_connection *conn)
         /* A TLS-compliant application MUST support key exchange with secp256r1 (NIST P-256) */
         /* and SHOULD support key exchange with X25519 [RFC7748]. */
         /* - https://tools.ietf.org/html/rfc8446#section-9.1 */
-        conn->secure.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
     } else {
         /* P-256 is the preferred fallback option. These prefs don't support it, so choose whatever curve is first. */
-        conn->secure.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
     }
 
     POSIX_GUARD(s2n_extension_list_parse(in, &conn->client_hello.extensions));

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -163,6 +163,9 @@ struct s2n_connection {
     struct s2n_crypto_parameters *client;
     struct s2n_crypto_parameters *server;
 
+    /* Contains parameters needed to negotiate a shared secret */
+    struct s2n_kex_parameters kex_params;
+
     /* Contains parameters needed during the handshake phase */
     struct s2n_handshake_parameters handshake_params;
 

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -30,9 +30,7 @@
 #include "crypto/s2n_dhe.h"
 #include "crypto/s2n_ecc_evp.h"
 
-struct s2n_crypto_parameters {
-    struct s2n_pkey server_public_key;
-    struct s2n_pkey client_public_key;
+struct s2n_kex_parameters {
     struct s2n_dh_params server_dh_params;
     struct s2n_ecc_evp_params server_ecc_evp_params;
     const struct s2n_ecc_named_curve *mutually_supported_curves[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
@@ -44,6 +42,11 @@ struct s2n_crypto_parameters {
     struct s2n_kem_params kem_params;
     struct s2n_blob client_key_exchange_message;
     struct s2n_blob client_pq_kem_extension;
+};
+
+struct s2n_crypto_parameters {
+    struct s2n_pkey server_public_key;
+    struct s2n_pkey client_public_key;
 
     struct s2n_signature_scheme conn_sig_scheme;
 

--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -53,7 +53,7 @@ static S2N_RESULT s2n_check_ecdhe(const struct s2n_cipher_suite *cipher_suite, s
     RESULT_ENSURE_REF(conn);
     RESULT_ENSURE_REF(is_supported);
 
-    *is_supported = conn->secure.server_ecc_evp_params.negotiated_curve != NULL;
+    *is_supported = conn->kex_params.server_ecc_evp_params.negotiated_curve != NULL;
 
     return S2N_RESULT_OK;
 }
@@ -85,7 +85,7 @@ static S2N_RESULT s2n_check_kem(const struct s2n_cipher_suite *cipher_suite, str
         return S2N_RESULT_OK;
     }
 
-    struct s2n_blob *client_kem_pref_list = &(conn->secure.client_pq_kem_extension);
+    struct s2n_blob *client_kem_pref_list = &(conn->kex_params.client_pq_kem_extension);
     const struct s2n_kem *chosen_kem = NULL;
     if (client_kem_pref_list == NULL || client_kem_pref_list->data == NULL) {
         /* If the client did not send a PQ KEM extension, then the server can pick its preferred parameter */
@@ -116,7 +116,7 @@ static S2N_RESULT s2n_configure_kem(const struct s2n_cipher_suite *cipher_suite,
     RESULT_GUARD_POSIX(s2n_connection_get_kem_preferences(conn, &kem_preferences));
     RESULT_ENSURE_REF(kem_preferences);
 
-    struct s2n_blob *proposed_kems = &(conn->secure.client_pq_kem_extension);
+    struct s2n_blob *proposed_kems = &(conn->kex_params.client_pq_kem_extension);
     const struct s2n_kem *chosen_kem = NULL;
     if (proposed_kems == NULL || proposed_kems->data == NULL) {
         /* If the client did not send a PQ KEM extension, then the server can pick its preferred parameter */
@@ -128,7 +128,7 @@ static S2N_RESULT s2n_configure_kem(const struct s2n_cipher_suite *cipher_suite,
                 kem_preferences->kem_count, &chosen_kem));
     }
 
-    conn->secure.kem_params.kem = chosen_kem;
+    conn->kex_params.kem_params.kem = chosen_kem;
     return S2N_RESULT_OK;
 }
 

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -405,7 +405,7 @@ int s2n_hybrid_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *p
     uint8_t master_secret_label[] = "hybrid master secret";
     struct s2n_blob label = {.size = sizeof(master_secret_label) - 1, .data = master_secret_label};
 
-    return s2n_prf(conn, premaster_secret, &label, &client_random, &server_random, &conn->secure.client_key_exchange_message, &master_secret);
+    return s2n_prf(conn, premaster_secret, &label, &client_random, &server_random, &conn->kex_params.client_key_exchange_message, &master_secret);
 }
 
 static int s2n_sslv3_finished(struct s2n_connection *conn, uint8_t prefix[4], struct s2n_hash_state *md5, struct s2n_hash_state *sha1, uint8_t * out)

--- a/tls/s2n_server_hello_retry.c
+++ b/tls/s2n_server_hello_retry.c
@@ -88,8 +88,8 @@ int s2n_server_hello_retry_recv(struct s2n_connection *conn)
      * in the "key_share" extension in the original ClientHello.
      * If either of these checks fails, then the client MUST abort the handshake. */
 
-    const struct s2n_ecc_named_curve *named_curve = conn->secure.server_ecc_evp_params.negotiated_curve;
-    const struct s2n_kem_group *kem_group = conn->secure.server_kem_group_params.kem_group;
+    const struct s2n_ecc_named_curve *named_curve = conn->kex_params.server_ecc_evp_params.negotiated_curve;
+    const struct s2n_kem_group *kem_group = conn->kex_params.server_kem_group_params.kem_group;
 
     /* Boolean XOR check: exactly one of {named_curve, kem_group} should be non-null. */
     POSIX_ENSURE( (named_curve != NULL) != (kem_group != NULL), S2N_ERR_INVALID_HELLO_RETRY);
@@ -101,7 +101,7 @@ int s2n_server_hello_retry_recv(struct s2n_connection *conn)
         for (size_t i = 0; i < ecc_pref->count; i++) {
             if (ecc_pref->ecc_curves[i] == named_curve) {
                 match_found = true;
-                new_key_share_requested = (conn->secure.client_ecc_evp_params[i].evp_pkey == NULL);
+                new_key_share_requested = (conn->kex_params.client_ecc_evp_params[i].evp_pkey == NULL);
                 break;
             }
         }
@@ -116,8 +116,8 @@ int s2n_server_hello_retry_recv(struct s2n_connection *conn)
         for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
             if (kem_pref->tls13_kem_groups[i] == kem_group) {
                 match_found = true;
-                new_key_share_requested = (conn->secure.client_kem_group_params[i].kem_params.private_key.size == 0)
-                        && (conn->secure.client_kem_group_params[i].ecc_params.evp_pkey == NULL);
+                new_key_share_requested = (conn->kex_params.client_kem_group_params[i].kem_params.private_key.size == 0)
+                        && (conn->kex_params.client_kem_group_params[i].ecc_params.evp_pkey == NULL);
                 break;
             }
         }

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -94,7 +94,7 @@ int s2n_ecdhe_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_
 
 int s2n_ecdhe_server_key_recv_parse_data(struct s2n_connection *conn, struct s2n_kex_raw_server_data *raw_server_data)
 {
-    POSIX_GUARD(s2n_ecc_evp_parse_params(&raw_server_data->ecdhe_data, &conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_ecc_evp_parse_params(&raw_server_data->ecdhe_data, &conn->kex_params.server_ecc_evp_params));
 
     return 0;
 }
@@ -138,7 +138,7 @@ int s2n_dhe_server_key_recv_parse_data(struct s2n_connection *conn, struct s2n_k
     struct s2n_dhe_raw_server_points dhe_data = raw_server_data->dhe_data;
 
     /* Copy the DH details */
-    POSIX_GUARD(s2n_dh_p_g_Ys_to_dh_params(&conn->secure.server_dh_params, &dhe_data.p, &dhe_data.g, &dhe_data.Ys));
+    POSIX_GUARD(s2n_dh_p_g_Ys_to_dh_params(&conn->kex_params.server_dh_params, &dhe_data.p, &dhe_data.g, &dhe_data.Ys));
     return 0;
 }
 
@@ -164,11 +164,11 @@ int s2n_kem_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_bl
     POSIX_GUARD(s2n_stuffer_write(&kem_id_stuffer, &(kem_data->kem_name)));
     POSIX_GUARD(s2n_stuffer_read_uint16(&kem_id_stuffer, &kem_id));
 
-    POSIX_GUARD(s2n_get_kem_from_extension_id(kem_id, &(conn->secure.kem_params.kem)));
-    POSIX_GUARD(s2n_kem_recv_public_key(in, &(conn->secure.kem_params)));
+    POSIX_GUARD(s2n_get_kem_from_extension_id(kem_id, &(conn->kex_params.kem_params.kem)));
+    POSIX_GUARD(s2n_kem_recv_public_key(in, &(conn->kex_params.kem_params)));
 
-    kem_data->raw_public_key.data = conn->secure.kem_params.public_key.data;
-    kem_data->raw_public_key.size = conn->secure.kem_params.public_key.size;
+    kem_data->raw_public_key.data = conn->kex_params.kem_params.public_key.data;
+    kem_data->raw_public_key.size = conn->kex_params.kem_params.public_key.size;
 
     data_to_verify->size = sizeof(kem_extension_size) + sizeof(kem_public_key_size) + kem_data->raw_public_key.size;
 
@@ -188,9 +188,9 @@ int s2n_kem_server_key_recv_parse_data(struct s2n_connection *conn, struct s2n_k
     const struct s2n_kem *match = NULL;
     S2N_ERROR_IF(s2n_choose_kem_with_peer_pref_list(cipher_suite->iana_value, &kem_data->kem_name, kem_preferences->kems,
                                                     kem_preferences->kem_count, &match) != 0, S2N_ERR_KEM_UNSUPPORTED_PARAMS);
-    conn->secure.kem_params.kem = match;
+    conn->kex_params.kem_params.kem = match;
 
-    S2N_ERROR_IF(kem_data->raw_public_key.size != conn->secure.kem_params.kem->public_key_length, S2N_ERR_BAD_MESSAGE);
+    S2N_ERROR_IF(kem_data->raw_public_key.size != conn->kex_params.kem_params.kem->public_key_length, S2N_ERR_BAD_MESSAGE);
 
     return 0;
 }
@@ -263,10 +263,10 @@ int s2n_ecdhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data
     struct s2n_stuffer *out = &conn->handshake.io;
 
     /* Generate an ephemeral key and  */
-    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->secure.server_ecc_evp_params));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.server_ecc_evp_params));
 
     /* Write it out and calculate the data to sign later */
-    POSIX_GUARD(s2n_ecc_evp_write_params(&conn->secure.server_ecc_evp_params, out, data_to_sign));
+    POSIX_GUARD(s2n_ecc_evp_write_params(&conn->kex_params.server_ecc_evp_params, out, data_to_sign));
     return 0;
 }
 
@@ -275,26 +275,26 @@ int s2n_dhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_t
     struct s2n_stuffer *out = &conn->handshake.io;
 
     /* Duplicate the DH key from the config */
-    POSIX_GUARD(s2n_dh_params_copy(conn->config->dhparams, &conn->secure.server_dh_params));
+    POSIX_GUARD(s2n_dh_params_copy(conn->config->dhparams, &conn->kex_params.server_dh_params));
 
     /* Generate an ephemeral key */
-    POSIX_GUARD(s2n_dh_generate_ephemeral_key(&conn->secure.server_dh_params));
+    POSIX_GUARD(s2n_dh_generate_ephemeral_key(&conn->kex_params.server_dh_params));
 
     /* Write it out and calculate the data to sign later */
-    POSIX_GUARD(s2n_dh_params_to_p_g_Ys(&conn->secure.server_dh_params, out, data_to_sign));
+    POSIX_GUARD(s2n_dh_params_to_p_g_Ys(&conn->kex_params.server_dh_params, out, data_to_sign));
     return 0;
 }
 
 int s2n_kem_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign)
 {
     struct s2n_stuffer *out = &conn->handshake.io;
-    const struct s2n_kem *kem = conn->secure.kem_params.kem;
+    const struct s2n_kem *kem = conn->kex_params.kem_params.kem;
 
     data_to_sign->data = s2n_stuffer_raw_write(out, 0);
     POSIX_ENSURE_REF(data_to_sign->data);
 
     POSIX_GUARD(s2n_stuffer_write_uint16(out, kem->kem_extension_id));
-    POSIX_GUARD(s2n_kem_send_public_key(out, &(conn->secure.kem_params)));
+    POSIX_GUARD(s2n_kem_send_public_key(out, &(conn->kex_params.kem_params)));
 
     data_to_sign->size = sizeof(kem_extension_size) + sizeof(kem_public_key_size) +  kem->public_key_length;
 

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -72,7 +72,7 @@ int s2n_tls13_compute_ecc_shared_secret(struct s2n_connection *conn, struct s2n_
     POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
     POSIX_ENSURE_REF(ecc_preferences);
 
-    struct s2n_ecc_evp_params *server_key = &conn->secure.server_ecc_evp_params;
+    struct s2n_ecc_evp_params *server_key = &conn->kex_params.server_ecc_evp_params;
     POSIX_ENSURE_REF(server_key);
     POSIX_ENSURE_REF(server_key->negotiated_curve);
     /* for now we do this tedious loop to find the matching client key selection.
@@ -80,7 +80,7 @@ int s2n_tls13_compute_ecc_shared_secret(struct s2n_connection *conn, struct s2n_
     struct s2n_ecc_evp_params *client_key = NULL;
     for (size_t i = 0; i < ecc_preferences->count; i++) {
         if (server_key->negotiated_curve->iana_id == ecc_preferences->ecc_curves[i]->iana_id) {
-            client_key = &conn->secure.client_ecc_evp_params[i];
+            client_key = &conn->kex_params.client_ecc_evp_params[i];
             break;
         }
     }
@@ -102,16 +102,16 @@ int s2n_tls13_compute_pq_hybrid_shared_secret(struct s2n_connection *conn, struc
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(shared_secret);
 
-    /* conn->secure.server_ecc_evp_params should be set only during a classic/non-hybrid handshake */
-    POSIX_ENSURE_EQ(NULL, conn->secure.server_ecc_evp_params.negotiated_curve);
-    POSIX_ENSURE_EQ(NULL, conn->secure.server_ecc_evp_params.evp_pkey);
+    /* conn->kex_params.server_ecc_evp_params should be set only during a classic/non-hybrid handshake */
+    POSIX_ENSURE_EQ(NULL, conn->kex_params.server_ecc_evp_params.negotiated_curve);
+    POSIX_ENSURE_EQ(NULL, conn->kex_params.server_ecc_evp_params.evp_pkey);
 
-    struct s2n_kem_group_params *server_kem_group_params = &conn->secure.server_kem_group_params;
+    struct s2n_kem_group_params *server_kem_group_params = &conn->kex_params.server_kem_group_params;
     POSIX_ENSURE_REF(server_kem_group_params);
     struct s2n_ecc_evp_params *server_ecc_params = &server_kem_group_params->ecc_params;
     POSIX_ENSURE_REF(server_ecc_params);
 
-    struct s2n_kem_group_params *client_kem_group_params = conn->secure.chosen_client_kem_group_params;
+    struct s2n_kem_group_params *client_kem_group_params = conn->kex_params.chosen_client_kem_group_params;
     POSIX_ENSURE_REF(client_kem_group_params);
     struct s2n_ecc_evp_params *client_ecc_params = &client_kem_group_params->ecc_params;
     POSIX_ENSURE_REF(client_ecc_params);
@@ -129,7 +129,7 @@ int s2n_tls13_compute_pq_hybrid_shared_secret(struct s2n_connection *conn, struc
     POSIX_ENSURE_REF(pq_shared_secret);
     POSIX_ENSURE_REF(pq_shared_secret->data);
 
-    const struct s2n_kem_group *negotiated_kem_group = conn->secure.server_kem_group_params.kem_group;
+    const struct s2n_kem_group *negotiated_kem_group = conn->kex_params.server_kem_group_params.kem_group;
     POSIX_ENSURE_REF(negotiated_kem_group);
     POSIX_ENSURE_REF(negotiated_kem_group->kem);
 
@@ -147,7 +147,7 @@ int s2n_tls13_compute_pq_hybrid_shared_secret(struct s2n_connection *conn, struc
 }
 
 static int s2n_tls13_pq_hybrid_supported(struct s2n_connection *conn) {
-    return conn->secure.server_kem_group_params.kem_group != NULL;
+    return conn->kex_params.server_kem_group_params.kem_group != NULL;
 }
 
 int s2n_tls13_compute_shared_secret(struct s2n_connection *conn, struct s2n_blob *shared_secret)


### PR DESCRIPTION
### Description of changes: 

This reduces the size of the connection object by ~1k.

A recent change (https://github.com/aws/s2n-tls/pull/2842 / https://github.com/aws/s2n-tls/pull/2933) increased the size of the pq kex parameters. To compensate, we can avoid unnecessarily storing two copies of each parameter. We only ever use `secure.x`, never `initial.x` or `client->x`.

We should still reduce the amount of memory we waste on empty kex parameters (https://github.com/aws/s2n-tls/issues/2935), but this is a quick fix that ensures we're at least only wasting it once.

### Call-outs:

This looks like a huge PR, but the only real changes are to s2n_connection.h, s2n_crypto.h, and s2n_connection_test.c. The rest are just automated naming updates.

### Testing:
Existing tests pass. This is just a rename / move.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
