### PR TITLE
Consolidate hash copies

### DIFF
--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -604,7 +604,6 @@ void cbmc_populate_s2n_crypto_parameters(struct s2n_crypto_parameters *s2n_crypt
     s2n_crypto_parameters->cipher_suite = cbmc_allocate_s2n_cipher_suite();
     cbmc_populate_s2n_session_key(&(s2n_crypto_parameters->client_key));
     cbmc_populate_s2n_session_key(&(s2n_crypto_parameters->server_key));
-    cbmc_populate_s2n_hash_state(&(s2n_crypto_parameters->signature_hash));
     cbmc_populate_s2n_hmac_state(&(s2n_crypto_parameters->client_record_mac));
     cbmc_populate_s2n_hmac_state(&(s2n_crypto_parameters->server_record_mac));
 }
@@ -722,10 +721,6 @@ void cbmc_populate_s2n_handshake(struct s2n_handshake *s2n_handshake)
     cbmc_populate_s2n_hash_state(&(s2n_handshake->sha384));
     cbmc_populate_s2n_hash_state(&(s2n_handshake->sha512));
     cbmc_populate_s2n_hash_state(&(s2n_handshake->md5_sha1));
-    cbmc_populate_s2n_hash_state(&(s2n_handshake->ccv_hash_copy));
-    cbmc_populate_s2n_hash_state(&(s2n_handshake->prf_md5_hash_copy));
-    cbmc_populate_s2n_hash_state(&(s2n_handshake->prf_sha1_hash_copy));
-    cbmc_populate_s2n_hash_state(&(s2n_handshake->prf_tls12_hash_copy));
     cbmc_populate_s2n_hash_state(&(s2n_handshake->server_hello_copy));
     cbmc_populate_s2n_hash_state(&(s2n_handshake->server_finished_copy));
     /* `s2n_handshake->early_data_async_state.conn` is never allocated.
@@ -798,6 +793,7 @@ void cbmc_populate_s2n_connection(struct s2n_connection *s2n_connection)
     cbmc_populate_s2n_blob(&(s2n_connection->application_protocols_overridden));
     cbmc_populate_s2n_stuffer(&(s2n_connection->cookie_stuffer));
     cbmc_populate_s2n_blob(&(s2n_connection->server_early_data_context));
+    cbmc_populate_s2n_hash_state(&(s2n_connection->hash_workspace));
 }
 
 struct s2n_connection *cbmc_allocate_s2n_connection()

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
      */
     {
         /* Carefully consider any increases to this number. */
-        const uint16_t max_connection_size = 15768;
+        const uint16_t max_connection_size = 14568;
         const uint16_t min_connection_size = max_connection_size * 0.75;
 
         size_t connection_size = sizeof(struct s2n_connection);

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -34,7 +34,7 @@
 #define MAX_CONNECTIONS 1000
 
 /* This is roughly the current memory usage per connection */
-#define MEM_PER_CONNECTION (58 * 1024)
+#define MEM_PER_CONNECTION (48 * 1024)
 
 /* This is the maximum memory per connection including 4KB of slack */
 #define MAX_MEM_PER_CONNECTION (MEM_PER_CONNECTION + 4 * 1024)

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -48,10 +48,10 @@ int s2n_client_cert_verify_recv(struct s2n_connection *conn)
     /* Use a copy of the hash state since the verify digest computation may modify the running hash state we need later. */
     struct s2n_hash_state hash_state = {0};
     POSIX_GUARD(s2n_handshake_get_hash_state(conn, chosen_sig_scheme.hash_alg, &hash_state));
-    POSIX_GUARD(s2n_hash_copy(&conn->handshake.ccv_hash_copy, &hash_state));
+    POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &hash_state));
 
     /* Verify the signature */
-    POSIX_GUARD(s2n_pkey_verify(&conn->secure.client_public_key, chosen_sig_scheme.sig_alg, &conn->handshake.ccv_hash_copy, &signature));
+    POSIX_GUARD(s2n_pkey_verify(&conn->secure.client_public_key, chosen_sig_scheme.sig_alg, &conn->hash_workspace, &signature));
 
     /* Client certificate has been verified. Minimize required handshake hash algs */
     POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));
@@ -74,9 +74,9 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
     /* Use a copy of the hash state since the verify digest computation may modify the running hash state we need later. */
     struct s2n_hash_state hash_state = {0};
     POSIX_GUARD(s2n_handshake_get_hash_state(conn, chosen_sig_scheme.hash_alg, &hash_state));
-    POSIX_GUARD(s2n_hash_copy(&conn->handshake.ccv_hash_copy, &hash_state));
+    POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &hash_state));
 
-    S2N_ASYNC_PKEY_SIGN(conn, chosen_sig_scheme.sig_alg, &conn->handshake.ccv_hash_copy, s2n_client_cert_verify_send_complete);
+    S2N_ASYNC_PKEY_SIGN(conn, chosen_sig_scheme.sig_alg, &conn->hash_workspace, s2n_client_cert_verify_send_complete);
 }
 
 static int s2n_client_cert_verify_send_complete(struct s2n_connection *conn, struct s2n_blob *signature)

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -364,6 +364,9 @@ struct s2n_connection {
     uint32_t server_max_early_data_size;
     struct s2n_blob server_early_data_context;
     uint32_t server_keying_material_lifetime;
+
+    /* To avoid allocating memory for hash objects, we reuse one temporary hash object. */
+    struct s2n_hash_state hash_workspace;
 };
 
 int s2n_connection_is_managed_corked(const struct s2n_connection *s2n_connection);

--- a/tls/s2n_connection_evp_digests.c
+++ b/tls/s2n_connection_evp_digests.c
@@ -44,22 +44,13 @@ int s2n_connection_save_hash_state(struct s2n_connection_hash_handles *hash_hand
     hash_handles->sha384 = conn->handshake.sha384.digest.high_level;
     hash_handles->sha512 = conn->handshake.sha512.digest.high_level;
     hash_handles->md5_sha1 = conn->handshake.md5_sha1.digest.high_level;
-    hash_handles->ccv_hash_copy = conn->handshake.ccv_hash_copy.digest.high_level;
-    hash_handles->prf_md5_hash_copy = conn->handshake.prf_md5_hash_copy.digest.high_level;
-    hash_handles->prf_sha1_hash_copy = conn->handshake.prf_sha1_hash_copy.digest.high_level;
-    hash_handles->prf_tls12_hash_copy = conn->handshake.prf_tls12_hash_copy.digest.high_level;
+    hash_handles->hash_workspace = conn->hash_workspace.digest.high_level;
     hash_handles->server_hello_copy = conn->handshake.server_hello_copy.digest.high_level;
     hash_handles->server_finished_copy = conn->handshake.server_finished_copy.digest.high_level;
 
     /* Preserve only the handlers for SSLv3 PRF hash state pointers to avoid re-allocation */
     hash_handles->prf_md5 = conn->prf_space.ssl3.md5.digest.high_level;
     hash_handles->prf_sha1 = conn->prf_space.ssl3.sha1.digest.high_level;
-
-    /* Preserve only the handlers for initial signature hash state pointers to avoid re-allocation */
-    hash_handles->initial_signature_hash = conn->initial.signature_hash.digest.high_level;
-
-    /* Preserve only the handlers for secure signature hash state pointers to avoid re-allocation */
-    hash_handles->secure_signature_hash = conn->secure.signature_hash.digest.high_level;
 
     return 0;
 }
@@ -104,22 +95,13 @@ int s2n_connection_restore_hash_state(struct s2n_connection *conn, struct s2n_co
     conn->handshake.sha384.digest.high_level = hash_handles->sha384;
     conn->handshake.sha512.digest.high_level = hash_handles->sha512;
     conn->handshake.md5_sha1.digest.high_level = hash_handles->md5_sha1;
-    conn->handshake.ccv_hash_copy.digest.high_level = hash_handles->ccv_hash_copy;
-    conn->handshake.prf_md5_hash_copy.digest.high_level = hash_handles->prf_md5_hash_copy;
-    conn->handshake.prf_sha1_hash_copy.digest.high_level = hash_handles->prf_sha1_hash_copy;
-    conn->handshake.prf_tls12_hash_copy.digest.high_level = hash_handles->prf_tls12_hash_copy;
+    conn->hash_workspace.digest.high_level = hash_handles->hash_workspace;
     conn->handshake.server_hello_copy.digest.high_level = hash_handles->server_hello_copy;
     conn->handshake.server_finished_copy.digest.high_level = hash_handles->server_finished_copy;
 
     /* Restore s2n_connection handlers for SSLv3 PRF hash states */
     conn->prf_space.ssl3.md5.digest.high_level = hash_handles->prf_md5;
     conn->prf_space.ssl3.sha1.digest.high_level = hash_handles->prf_sha1;
-
-    /* Restore s2n_connection handlers for initial signature hash states */
-    conn->initial.signature_hash.digest.high_level = hash_handles->initial_signature_hash;
-
-    /* Restore s2n_connection handlers for secure signature hash states */
-    conn->secure.signature_hash.digest.high_level = hash_handles->secure_signature_hash;
 
     return 0;
 }

--- a/tls/s2n_connection_evp_digests.h
+++ b/tls/s2n_connection_evp_digests.h
@@ -37,10 +37,7 @@ struct s2n_connection_hash_handles {
     struct s2n_hash_evp_digest sha384;
     struct s2n_hash_evp_digest sha512;
     struct s2n_hash_evp_digest md5_sha1;
-    struct s2n_hash_evp_digest ccv_hash_copy;
-    struct s2n_hash_evp_digest prf_md5_hash_copy;
-    struct s2n_hash_evp_digest prf_sha1_hash_copy;
-    struct s2n_hash_evp_digest prf_tls12_hash_copy;
+    struct s2n_hash_evp_digest hash_workspace;
     struct s2n_hash_evp_digest server_hello_copy;
     struct s2n_hash_evp_digest server_finished_copy;
     struct s2n_hash_evp_digest prf_md5;

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -67,7 +67,6 @@ struct s2n_crypto_parameters {
     uint8_t server_implicit_iv[S2N_TLS_MAX_IV_LEN];
     uint8_t client_app_secret[S2N_TLS13_SECRET_MAX_LEN];
     uint8_t server_app_secret[S2N_TLS13_SECRET_MAX_LEN];
-    struct s2n_hash_state signature_hash;
     struct s2n_hmac_state client_record_mac;
     struct s2n_hmac_state server_record_mac;
     uint8_t client_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -130,14 +130,9 @@ struct s2n_handshake {
     struct s2n_hash_state sha512;
     struct s2n_hash_state md5_sha1;
 
-    /* A copy of the handshake messages hash used to validate the CertificateVerify message */
-    struct s2n_hash_state ccv_hash_copy;
-
-    /* Used for SSLv3, TLS 1.0, and TLS 1.1 PRFs */
-    struct s2n_hash_state prf_md5_hash_copy;
-    struct s2n_hash_state prf_sha1_hash_copy;
-    /*Used for TLS 1.2 PRF */
-    struct s2n_hash_state prf_tls12_hash_copy;
+    /* TLS1.3 does not always use a hash immediately.
+     * We save copies of some states for later use in the key schedule.
+     */
     struct s2n_hash_state server_hello_copy;
     struct s2n_hash_state server_finished_copy;
 

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -408,7 +408,7 @@ int s2n_hybrid_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *p
     return s2n_prf(conn, premaster_secret, &label, &client_random, &server_random, &conn->kex_params.client_key_exchange_message, &master_secret);
 }
 
-static int s2n_sslv3_finished(struct s2n_connection *conn, uint8_t prefix[4], struct s2n_hash_state *md5, struct s2n_hash_state *sha1, uint8_t * out)
+static int s2n_sslv3_finished(struct s2n_connection *conn, uint8_t prefix[4], struct s2n_hash_state *hash_workspace, uint8_t * out)
 {
     uint8_t xorpad1[48] =
         { 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36, 0x36,
@@ -423,6 +423,8 @@ static int s2n_sslv3_finished(struct s2n_connection *conn, uint8_t prefix[4], st
 
     POSIX_ENSURE_LTE(MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH, sizeof(conn->handshake.client_finished));
 
+    struct s2n_hash_state *md5 = hash_workspace;
+    POSIX_GUARD(s2n_hash_copy(md5, &conn->handshake.md5));
     POSIX_GUARD(s2n_hash_update(md5, prefix, 4));
     POSIX_GUARD(s2n_hash_update(md5, conn->secure.master_secret, sizeof(conn->secure.master_secret)));
     POSIX_GUARD(s2n_hash_update(md5, xorpad1, 48));
@@ -434,6 +436,8 @@ static int s2n_sslv3_finished(struct s2n_connection *conn, uint8_t prefix[4], st
     POSIX_GUARD(s2n_hash_digest(md5, md5_digest, MD5_DIGEST_LENGTH));
     POSIX_GUARD(s2n_hash_reset(md5));
 
+    struct s2n_hash_state *sha1 = hash_workspace;
+    POSIX_GUARD(s2n_hash_copy(sha1, &conn->handshake.sha1));
     POSIX_GUARD(s2n_hash_update(sha1, prefix, 4));
     POSIX_GUARD(s2n_hash_update(sha1, conn->secure.master_secret, sizeof(conn->secure.master_secret)));
     POSIX_GUARD(s2n_hash_update(sha1, xorpad1, 40));
@@ -453,9 +457,7 @@ static int s2n_sslv3_client_finished(struct s2n_connection *conn)
     uint8_t prefix[4] = { 0x43, 0x4c, 0x4e, 0x54 };
 
     POSIX_ENSURE_LTE(MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH, sizeof(conn->handshake.client_finished));
-    POSIX_GUARD(s2n_hash_copy(&conn->handshake.prf_md5_hash_copy, &conn->handshake.md5));
-    POSIX_GUARD(s2n_hash_copy(&conn->handshake.prf_sha1_hash_copy, &conn->handshake.sha1));
-    return s2n_sslv3_finished(conn, prefix, &conn->handshake.prf_md5_hash_copy, &conn->handshake.prf_sha1_hash_copy, conn->handshake.client_finished);
+    return s2n_sslv3_finished(conn, prefix, &conn->hash_workspace, conn->handshake.client_finished);
 }
 
 static int s2n_sslv3_server_finished(struct s2n_connection *conn)
@@ -463,9 +465,7 @@ static int s2n_sslv3_server_finished(struct s2n_connection *conn)
     uint8_t prefix[4] = { 0x53, 0x52, 0x56, 0x52 };
 
     POSIX_ENSURE_LTE(MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH, sizeof(conn->handshake.server_finished));
-    POSIX_GUARD(s2n_hash_copy(&conn->handshake.prf_md5_hash_copy, &conn->handshake.md5));
-    POSIX_GUARD(s2n_hash_copy(&conn->handshake.prf_sha1_hash_copy, &conn->handshake.sha1));
-    return s2n_sslv3_finished(conn, prefix, &conn->handshake.prf_md5_hash_copy, &conn->handshake.prf_sha1_hash_copy, conn->handshake.server_finished);
+    return s2n_sslv3_finished(conn, prefix, &conn->hash_workspace, conn->handshake.server_finished);
 }
 
 int s2n_prf_client_finished(struct s2n_connection *conn)
@@ -491,13 +491,13 @@ int s2n_prf_client_finished(struct s2n_connection *conn)
     if (conn->actual_protocol_version == S2N_TLS12) {
         switch (conn->secure.cipher_suite->prf_alg) {
         case S2N_HMAC_SHA256:
-            POSIX_GUARD(s2n_hash_copy(&conn->handshake.prf_tls12_hash_copy, &conn->handshake.sha256));
-            POSIX_GUARD(s2n_hash_digest(&conn->handshake.prf_tls12_hash_copy, sha_digest, SHA256_DIGEST_LENGTH));
+            POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &conn->handshake.sha256));
+            POSIX_GUARD(s2n_hash_digest(&conn->hash_workspace, sha_digest, SHA256_DIGEST_LENGTH));
             sha.size = SHA256_DIGEST_LENGTH;
             break;
         case S2N_HMAC_SHA384:
-            POSIX_GUARD(s2n_hash_copy(&conn->handshake.prf_tls12_hash_copy, &conn->handshake.sha384));
-            POSIX_GUARD(s2n_hash_digest(&conn->handshake.prf_tls12_hash_copy, sha_digest, SHA384_DIGEST_LENGTH));
+            POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &conn->handshake.sha384));
+            POSIX_GUARD(s2n_hash_digest(&conn->hash_workspace, sha_digest, SHA384_DIGEST_LENGTH));
             sha.size = SHA384_DIGEST_LENGTH;
             break;
         default:
@@ -508,13 +508,13 @@ int s2n_prf_client_finished(struct s2n_connection *conn)
         return s2n_prf(conn, &master_secret, &label, &sha, NULL, NULL, &client_finished);
     }
 
-    POSIX_GUARD(s2n_hash_copy(&conn->handshake.prf_md5_hash_copy, &conn->handshake.md5));
-    POSIX_GUARD(s2n_hash_copy(&conn->handshake.prf_sha1_hash_copy, &conn->handshake.sha1));
-
-    POSIX_GUARD(s2n_hash_digest(&conn->handshake.prf_md5_hash_copy, md5_digest, MD5_DIGEST_LENGTH));
-    POSIX_GUARD(s2n_hash_digest(&conn->handshake.prf_sha1_hash_copy, sha_digest, SHA_DIGEST_LENGTH));
+    POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &conn->handshake.md5));
+    POSIX_GUARD(s2n_hash_digest(&conn->hash_workspace, md5_digest, MD5_DIGEST_LENGTH));
     md5.data = md5_digest;
     md5.size = MD5_DIGEST_LENGTH;
+
+    POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &conn->handshake.sha1));
+    POSIX_GUARD(s2n_hash_digest(&conn->hash_workspace, sha_digest, SHA_DIGEST_LENGTH));
     sha.data = sha_digest;
     sha.size = SHA_DIGEST_LENGTH;
 
@@ -544,13 +544,13 @@ int s2n_prf_server_finished(struct s2n_connection *conn)
     if (conn->actual_protocol_version == S2N_TLS12) {
         switch (conn->secure.cipher_suite->prf_alg) {
         case S2N_HMAC_SHA256:
-            POSIX_GUARD(s2n_hash_copy(&conn->handshake.prf_tls12_hash_copy, &conn->handshake.sha256));
-            POSIX_GUARD(s2n_hash_digest(&conn->handshake.prf_tls12_hash_copy, sha_digest, SHA256_DIGEST_LENGTH));
+            POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &conn->handshake.sha256));
+            POSIX_GUARD(s2n_hash_digest(&conn->hash_workspace, sha_digest, SHA256_DIGEST_LENGTH));
             sha.size = SHA256_DIGEST_LENGTH;
             break;
         case S2N_HMAC_SHA384:
-            POSIX_GUARD(s2n_hash_copy(&conn->handshake.prf_tls12_hash_copy, &conn->handshake.sha384));
-            POSIX_GUARD(s2n_hash_digest(&conn->handshake.prf_tls12_hash_copy, sha_digest, SHA384_DIGEST_LENGTH));
+            POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &conn->handshake.sha384));
+            POSIX_GUARD(s2n_hash_digest(&conn->hash_workspace, sha_digest, SHA384_DIGEST_LENGTH));
             sha.size = SHA384_DIGEST_LENGTH;
             break;
         default:
@@ -561,13 +561,13 @@ int s2n_prf_server_finished(struct s2n_connection *conn)
         return s2n_prf(conn, &master_secret, &label, &sha, NULL, NULL, &server_finished);
     }
 
-    POSIX_GUARD(s2n_hash_copy(&conn->handshake.prf_md5_hash_copy, &conn->handshake.md5));
-    POSIX_GUARD(s2n_hash_copy(&conn->handshake.prf_sha1_hash_copy, &conn->handshake.sha1));
-
-    POSIX_GUARD(s2n_hash_digest(&conn->handshake.prf_md5_hash_copy, md5_digest, MD5_DIGEST_LENGTH));
-    POSIX_GUARD(s2n_hash_digest(&conn->handshake.prf_sha1_hash_copy, sha_digest, SHA_DIGEST_LENGTH));
+    POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &conn->handshake.md5));
+    POSIX_GUARD(s2n_hash_digest(&conn->hash_workspace, md5_digest, MD5_DIGEST_LENGTH));
     md5.data = md5_digest;
     md5.size = MD5_DIGEST_LENGTH;
+
+    POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &conn->handshake.sha1));
+    POSIX_GUARD(s2n_hash_digest(&conn->hash_workspace, sha_digest, SHA_DIGEST_LENGTH));
     sha.data = sha_digest;
     sha.size = SHA_DIGEST_LENGTH;
 

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -41,7 +41,7 @@ int s2n_server_key_recv(struct s2n_connection *conn)
     POSIX_ENSURE_REF(conn->secure.cipher_suite);
     POSIX_ENSURE_REF(conn->secure.cipher_suite->key_exchange_alg);
 
-    struct s2n_hash_state *signature_hash = &conn->secure.signature_hash;
+    struct s2n_hash_state *signature_hash = &conn->hash_workspace;
     const struct s2n_kex *key_exchange = conn->secure.cipher_suite->key_exchange_alg;
     struct s2n_stuffer *in = &conn->handshake.io;
     struct s2n_blob data_to_verify = {0};
@@ -234,7 +234,7 @@ int s2n_server_key_send(struct s2n_connection *conn)
 {
     S2N_ASYNC_PKEY_GUARD(conn);
 
-    struct s2n_hash_state *signature_hash = &conn->secure.signature_hash;
+    struct s2n_hash_state *signature_hash = &conn->hash_workspace;
     const struct s2n_kex *key_exchange = conn->secure.cipher_suite->key_exchange_alg;
     struct s2n_stuffer *out = &conn->handshake.io;
     struct s2n_blob data_to_sign = {0};


### PR DESCRIPTION
### Description of changes: 
This reduces the size of the connection object by ~1k.

We store several s2n_hash_state structures on the connection to perform copy/digest operations. Since we call either s2n_hash_init or s2n_hash_copy every time we interact with these copies, we can instead reuse the same object. We also don't have to worry about contention for the same object, because all uses are during the handshake.

Mostly I just did a straight swap, but I did have to reorder some calculations in the TLS1.2 PRF (s2n_prf.c).

### Testing:
Existing tests continuing to pass. Unfortunately all of the TLS1.2 code I touched relies on functional rather than unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
