### PR TITLE
tls: optimize aad init

### DIFF
--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -59,6 +59,8 @@ int s2n_stuffer_read_uint8(struct s2n_stuffer *stuffer, uint8_t * u)
 
 int s2n_stuffer_write_uint8(struct s2n_stuffer *stuffer, const uint8_t u)
 {
+    POSIX_ENSURE_REF(stuffer);
+
     bool was_tainted = stuffer->tainted;
     uint8_t *data = s2n_stuffer_raw_write(stuffer, sizeof(u));
     POSIX_GUARD_PTR(data);
@@ -83,6 +85,8 @@ int s2n_stuffer_read_uint16(struct s2n_stuffer *stuffer, uint16_t * u)
 
 int s2n_stuffer_write_uint16(struct s2n_stuffer *stuffer, uint16_t u)
 {
+    POSIX_ENSURE_REF(stuffer);
+
     bool was_tainted = stuffer->tainted;
     uint8_t *data = s2n_stuffer_raw_write(stuffer, sizeof(u));
     POSIX_GUARD_PTR(data);
@@ -116,6 +120,8 @@ int s2n_stuffer_read_uint24(struct s2n_stuffer *stuffer, uint32_t * u)
 
 int s2n_stuffer_write_uint24(struct s2n_stuffer *stuffer, uint32_t u)
 {
+    POSIX_ENSURE_REF(stuffer);
+
     bool was_tainted = stuffer->tainted;
     uint8_t *data = s2n_stuffer_raw_write(stuffer, SIZEOF_UINT24);
     POSIX_GUARD_PTR(data);
@@ -151,6 +157,8 @@ int s2n_stuffer_read_uint32(struct s2n_stuffer *stuffer, uint32_t * u)
 
 int s2n_stuffer_write_uint32(struct s2n_stuffer *stuffer, uint32_t u)
 {
+    POSIX_ENSURE_REF(stuffer);
+
     bool was_tainted = stuffer->tainted;
     uint8_t *data = s2n_stuffer_raw_write(stuffer, sizeof(u));
     POSIX_GUARD_PTR(data);
@@ -186,6 +194,8 @@ int s2n_stuffer_read_uint64(struct s2n_stuffer *stuffer, uint64_t * u)
 
 int s2n_stuffer_write_uint64(struct s2n_stuffer *stuffer, uint64_t u)
 {
+    POSIX_ENSURE_REF(stuffer);
+
     bool was_tainted = stuffer->tainted;
     uint8_t *data = s2n_stuffer_raw_write(stuffer, sizeof(u));
     POSIX_GUARD_PTR(data);

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -17,7 +17,6 @@
 
 #include "stuffer/s2n_stuffer.h"
 
-#include "utils/s2n_endian.h"
 #include "utils/s2n_annotations.h"
 #include "utils/s2n_safety.h"
 
@@ -59,13 +58,7 @@ int s2n_stuffer_read_uint8(struct s2n_stuffer *stuffer, uint8_t * u)
 
 int s2n_stuffer_write_uint8(struct s2n_stuffer *stuffer, const uint8_t u)
 {
-    POSIX_ENSURE_REF(stuffer);
-
-    bool was_tainted = stuffer->tainted;
-    uint8_t *data = s2n_stuffer_raw_write(stuffer, sizeof(u));
-    POSIX_GUARD_PTR(data);
-    data[0] = u;
-    stuffer->tainted = was_tainted;
+    POSIX_GUARD(s2n_stuffer_write_bytes(stuffer, &u, sizeof(u)));
 
     return S2N_SUCCESS;
 }
@@ -83,20 +76,9 @@ int s2n_stuffer_read_uint16(struct s2n_stuffer *stuffer, uint16_t * u)
     return S2N_SUCCESS;
 }
 
-int s2n_stuffer_write_uint16(struct s2n_stuffer *stuffer, uint16_t u)
+int s2n_stuffer_write_uint16(struct s2n_stuffer *stuffer, const uint16_t u)
 {
-    POSIX_ENSURE_REF(stuffer);
-
-    bool was_tainted = stuffer->tainted;
-    uint8_t *data = s2n_stuffer_raw_write(stuffer, sizeof(u));
-    POSIX_GUARD_PTR(data);
-
-    u = htobe16(u);
-    data[0] = (u) & UINT8_MAX;
-    data[1] = (u >> (1 * 8)) & UINT8_MAX;
-    stuffer->tainted = was_tainted;
-
-    return S2N_SUCCESS;
+    return s2n_stuffer_write_network_order(stuffer, u, sizeof(u));
 }
 
 int s2n_stuffer_reserve_uint16(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservation *reservation)
@@ -118,21 +100,9 @@ int s2n_stuffer_read_uint24(struct s2n_stuffer *stuffer, uint32_t * u)
     return S2N_SUCCESS;
 }
 
-int s2n_stuffer_write_uint24(struct s2n_stuffer *stuffer, uint32_t u)
+int s2n_stuffer_write_uint24(struct s2n_stuffer *stuffer, const uint32_t u)
 {
-    POSIX_ENSURE_REF(stuffer);
-
-    bool was_tainted = stuffer->tainted;
-    uint8_t *data = s2n_stuffer_raw_write(stuffer, SIZEOF_UINT24);
-    POSIX_GUARD_PTR(data);
-
-    u = htobe32(u);
-    data[0] = (u >> (1 * 8)) & UINT8_MAX;
-    data[1] = (u >> (2 * 8)) & UINT8_MAX;
-    data[2] = (u >> (3 * 8)) & UINT8_MAX;
-    stuffer->tainted = was_tainted;
-
-    return S2N_SUCCESS;
+    return s2n_stuffer_write_network_order(stuffer, u, SIZEOF_UINT24);
 }
 
 int s2n_stuffer_reserve_uint24(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservation *reservation)
@@ -155,22 +125,9 @@ int s2n_stuffer_read_uint32(struct s2n_stuffer *stuffer, uint32_t * u)
     return S2N_SUCCESS;
 }
 
-int s2n_stuffer_write_uint32(struct s2n_stuffer *stuffer, uint32_t u)
+int s2n_stuffer_write_uint32(struct s2n_stuffer *stuffer, const uint32_t u)
 {
-    POSIX_ENSURE_REF(stuffer);
-
-    bool was_tainted = stuffer->tainted;
-    uint8_t *data = s2n_stuffer_raw_write(stuffer, sizeof(u));
-    POSIX_GUARD_PTR(data);
-
-    u = htobe32(u);
-    data[0] = (u) & UINT8_MAX;
-    data[1] = (u >> (1 * 8)) & UINT8_MAX;
-    data[2] = (u >> (2 * 8)) & UINT8_MAX;
-    data[3] = (u >> (3 * 8)) & UINT8_MAX;
-    stuffer->tainted = was_tainted;
-
-    return S2N_SUCCESS;
+    return s2n_stuffer_write_network_order(stuffer, u, sizeof(u));
 }
 
 int s2n_stuffer_read_uint64(struct s2n_stuffer *stuffer, uint64_t * u)
@@ -192,26 +149,9 @@ int s2n_stuffer_read_uint64(struct s2n_stuffer *stuffer, uint64_t * u)
     return S2N_SUCCESS;
 }
 
-int s2n_stuffer_write_uint64(struct s2n_stuffer *stuffer, uint64_t u)
+int s2n_stuffer_write_uint64(struct s2n_stuffer *stuffer, const uint64_t u)
 {
-    POSIX_ENSURE_REF(stuffer);
-
-    bool was_tainted = stuffer->tainted;
-    uint8_t *data = s2n_stuffer_raw_write(stuffer, sizeof(u));
-    POSIX_GUARD_PTR(data);
-
-    u = htobe64(u);
-    data[0] = (u) & UINT8_MAX;
-    data[1] = (u >> (1 * 8)) & UINT8_MAX;
-    data[2] = (u >> (2 * 8)) & UINT8_MAX;
-    data[3] = (u >> (3 * 8)) & UINT8_MAX;
-    data[4] = (u >> (4 * 8)) & UINT8_MAX;
-    data[5] = (u >> (5 * 8)) & UINT8_MAX;
-    data[6] = (u >> (6 * 8)) & UINT8_MAX;
-    data[7] = (u >> (7 * 8)) & UINT8_MAX;
-    stuffer->tainted = was_tainted;
-
-    return S2N_SUCCESS;
+    return s2n_stuffer_write_network_order(stuffer, u, sizeof(u));
 }
 
 static int length_matches_value_check(uint32_t value, uint8_t length)

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -92,8 +92,8 @@ int s2n_stuffer_write_uint16(struct s2n_stuffer *stuffer, uint16_t u)
     POSIX_GUARD_PTR(data);
 
     u = htobe16(u);
-    data[0] = u;
-    data[1] = u >> (1 * 8);
+    data[0] = (u) & UINT8_MAX;
+    data[1] = (u >> (1 * 8)) & UINT8_MAX;
     stuffer->tainted = was_tainted;
 
     return S2N_SUCCESS;
@@ -127,9 +127,9 @@ int s2n_stuffer_write_uint24(struct s2n_stuffer *stuffer, uint32_t u)
     POSIX_GUARD_PTR(data);
 
     u = htobe32(u);
-    data[0] = u >> (1 * 8);
-    data[1] = u >> (2 * 8);
-    data[2] = u >> (3 * 8);
+    data[0] = (u >> (1 * 8)) & UINT8_MAX;
+    data[1] = (u >> (2 * 8)) & UINT8_MAX;
+    data[2] = (u >> (3 * 8)) & UINT8_MAX;
     stuffer->tainted = was_tainted;
 
     return S2N_SUCCESS;
@@ -164,10 +164,10 @@ int s2n_stuffer_write_uint32(struct s2n_stuffer *stuffer, uint32_t u)
     POSIX_GUARD_PTR(data);
 
     u = htobe32(u);
-    data[0] = u;
-    data[1] = u >> (1 * 8);
-    data[2] = u >> (2 * 8);
-    data[3] = u >> (3 * 8);
+    data[0] = (u) & UINT8_MAX;
+    data[1] = (u >> (1 * 8)) & UINT8_MAX;
+    data[2] = (u >> (2 * 8)) & UINT8_MAX;
+    data[3] = (u >> (3 * 8)) & UINT8_MAX;
     stuffer->tainted = was_tainted;
 
     return S2N_SUCCESS;
@@ -201,14 +201,14 @@ int s2n_stuffer_write_uint64(struct s2n_stuffer *stuffer, uint64_t u)
     POSIX_GUARD_PTR(data);
 
     u = htobe64(u);
-    data[0] = u;
-    data[1] = u >> (1 * 8);
-    data[2] = u >> (2 * 8);
-    data[3] = u >> (3 * 8);
-    data[4] = u >> (4 * 8);
-    data[5] = u >> (5 * 8);
-    data[6] = u >> (6 * 8);
-    data[7] = u >> (7 * 8);
+    data[0] = (u) & UINT8_MAX;
+    data[1] = (u >> (1 * 8)) & UINT8_MAX;
+    data[2] = (u >> (2 * 8)) & UINT8_MAX;
+    data[3] = (u >> (3 * 8)) & UINT8_MAX;
+    data[4] = (u >> (4 * 8)) & UINT8_MAX;
+    data[5] = (u >> (5 * 8)) & UINT8_MAX;
+    data[6] = (u >> (6 * 8)) & UINT8_MAX;
+    data[7] = (u >> (7 * 8)) & UINT8_MAX;
     stuffer->tainted = was_tainted;
 
     return S2N_SUCCESS;

--- a/tests/unit/s2n_stuffer_network_order_test.c
+++ b/tests/unit/s2n_stuffer_network_order_test.c
@@ -42,15 +42,12 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, 0x00, 0));
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
 
-        uint8_t byte_length;
-
         /* uint8_t */
         {
-            byte_length = sizeof(uint8_t);
             uint8_t actual_value;
 
             for (int i = 0; i <= UINT8_MAX; i++) {
-                EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, i, byte_length));
+                EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, i));
                 EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &actual_value));
                 EXPECT_EQUAL(i, actual_value);
             }
@@ -58,11 +55,10 @@ int main(int argc, char **argv)
 
         /* uint16_t */
         {
-            byte_length = sizeof(uint16_t);
             uint16_t actual_value;
 
             for (int i = 0; i < UINT16_MAX; i++) {
-                EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, i, byte_length));
+                EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, i));
                 EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &actual_value));
                 EXPECT_EQUAL(i, actual_value);
             }
@@ -70,19 +66,18 @@ int main(int argc, char **argv)
 
         /* uint24 */
         {
-            byte_length = 3;
             uint32_t actual_value;
             uint32_t test_values[] = { 0x000001, 0x0000FF, 0xABCDEF, 0xFFFFFF };
 
             for (int i = 0; i < s2n_array_len(test_values); i++) {
-                EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, test_values[i], byte_length));
+                EXPECT_SUCCESS(s2n_stuffer_write_uint24(&stuffer, test_values[i]));
                 EXPECT_SUCCESS(s2n_stuffer_read_uint24(&stuffer, &actual_value));
                 EXPECT_EQUAL(test_values[i], actual_value);
             }
 
             uint16_t prime = 257;
             for (uint32_t i = 0; i < 0xFFFFFF - prime; i += prime) {
-                EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, i, byte_length));
+                EXPECT_SUCCESS(s2n_stuffer_write_uint24(&stuffer, i));
                 EXPECT_SUCCESS(s2n_stuffer_read_uint24(&stuffer, &actual_value));
                 EXPECT_EQUAL(i, actual_value);
             }
@@ -90,20 +85,38 @@ int main(int argc, char **argv)
 
         /* uint32_t */
         {
-            byte_length = sizeof(uint32_t);
             uint32_t actual_value;
             uint32_t test_values[] = { 0x00000001, 0x000000FF, 0xABCDEF12, UINT32_MAX };
 
             for (int i = 0; i < s2n_array_len(test_values); i++) {
-                EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, test_values[i], byte_length));
+                EXPECT_SUCCESS(s2n_stuffer_write_uint32(&stuffer, test_values[i]));
                 EXPECT_SUCCESS(s2n_stuffer_read_uint32(&stuffer, &actual_value));
                 EXPECT_EQUAL(test_values[i], actual_value);
             }
 
             uint32_t prime = 65537;
             for (uint32_t i = 0; i < UINT32_MAX - prime; i += prime) {
-                EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, i, byte_length));
+                EXPECT_SUCCESS(s2n_stuffer_write_uint32(&stuffer, i));
                 EXPECT_SUCCESS(s2n_stuffer_read_uint32(&stuffer, &actual_value));
+                EXPECT_EQUAL(i, actual_value);
+            }
+        }
+
+        /* uint64_t */
+        {
+            uint64_t actual_value;
+            uint64_t test_values[] = { 0x00000001, 0x000000FF, (uint64_t)UINT32_MAX + 1, UINT64_MAX };
+
+            for (int i = 0; i < s2n_array_len(test_values); i++) {
+                EXPECT_SUCCESS(s2n_stuffer_write_uint64(&stuffer, test_values[i]));
+                EXPECT_SUCCESS(s2n_stuffer_read_uint64(&stuffer, &actual_value));
+                EXPECT_EQUAL(test_values[i], actual_value);
+            }
+
+            uint64_t prime = 65537;
+            for (uint64_t i = 0; i < UINT32_MAX - prime; i += prime) {
+                EXPECT_SUCCESS(s2n_stuffer_write_uint64(&stuffer, i));
+                EXPECT_SUCCESS(s2n_stuffer_read_uint64(&stuffer, &actual_value));
                 EXPECT_EQUAL(i, actual_value);
             }
         }

--- a/tls/s2n_aead.c
+++ b/tls/s2n_aead.c
@@ -46,8 +46,8 @@ S2N_RESULT s2n_aead_aad_init(const struct s2n_connection *conn, uint8_t * sequen
     bytes[idx++] = conn->actual_protocol_version % 10;
 
     record_length = htobe16(record_length);
-    bytes[idx++] = record_length >> 8;
     bytes[idx++] = record_length;
+    bytes[idx++] = record_length >> 8;
     ad->tainted = was_tainted;
 
     return S2N_RESULT_OK;

--- a/utils/s2n_endian.h
+++ b/utils/s2n_endian.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef _MSC_VER
+
+#include <stdlib.h>
+#define bswap_16(x) _byteswap_ushort(x)
+#define bswap_32(x) _byteswap_ulong(x)
+#define bswap_64(x) _byteswap_uint64(x)
+
+#elif defined(__APPLE__)
+
+#include <libkern/OSByteOrder.h>
+#define bswap_16(x) OSSwapInt16(x)
+#define bswap_32(x) OSSwapInt32(x)
+#define bswap_64(x) OSSwapInt64(x)
+
+#elif defined(__sun) || defined(sun)
+
+#include <sys/byteorder.h>
+#define bswap_16(x) BSWAP_16(x)
+#define bswap_32(x) BSWAP_32(x)
+#define bswap_64(x) BSWAP_64(x)
+
+#elif defined(__FreeBSD__)
+
+#include <sys/endian.h>
+#define bswap_16(x) bswap16(x)
+#define bswap_32(x) bswap32(x)
+#define bswap_64(x) bswap64(x)
+
+#elif defined(__OpenBSD__)
+
+#include <sys/types.h>
+#define bswap_16(x) swap16(x)
+#define bswap_32(x) swap32(x)
+#define bswap_64(x) swap64(x)
+
+#elif defined(__NetBSD__)
+
+#include <sys/types.h>
+#include <machine/bswap.h>
+#if defined(__BSWAP_RENAME) && !defined(__bswap_32)
+#define bswap_16(x) bswap16(x)
+#define bswap_32(x) bswap32(x)
+#define bswap_64(x) bswap64(x)
+#endif
+
+#else
+
+#include <byteswap.h>
+
+#endif
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#    define htobe16(x) bswap_16(x)
+#    define htole16(x) (x)
+#    define be16toh(x) bswap_16(x)
+#    define le16toh(x) (x)
+
+#    define htobe32(x) bswap_32(x)
+#    define htole32(x) (x)
+#    define be32toh(x) bswap_32(x)
+#    define le32toh(x) (x)
+
+#    define htobe64(x) bswap_64(x)
+#    define htole64(x) (x)
+#    define be64toh(x) bswap_64(x)
+#    define le64toh(x) (x)
+#else
+#    define htobe16(x) (x)
+#    define htole16(x) bswap_16(x)
+#    define be16toh(x) (x)
+#    define le16toh(x) bswap_16(x)
+
+#    define htobe32(x) (x)
+#    define htole32(x) bswap_32(x)
+#    define be32toh(x) (x)
+#    define le32toh(x) bswap_32(x)
+
+#    define htobe64(x) (x)
+#    define htole64(x) bswap_64(x)
+#    define be64toh(x) (x)
+#    define le64toh(x) bswap_64(x)
+#endif


### PR DESCRIPTION
### Description of changes: 

I've been performance testing s2n-tls and noticed that there was a lot of time spent in the `aad_init` functions due to the stuffer checks. By swapping it would with `raw_write`, I was able to increase throughput by 10%.

### Before

[![](https://gist.githubusercontent.com/camshaft/2da7504782062333ef6979b6061827ed/raw/bc5405a7e1e877444f1c877420f311aba385d363/before.svg)](https://gist.githubusercontent.com/camshaft/2da7504782062333ef6979b6061827ed/raw/bc5405a7e1e877444f1c877420f311aba385d363/before.svg)

### After

[![](https://gist.githubusercontent.com/camshaft/2da7504782062333ef6979b6061827ed/raw/bc5405a7e1e877444f1c877420f311aba385d363/after.svg)](https://gist.githubusercontent.com/camshaft/2da7504782062333ef6979b6061827ed/raw/bc5405a7e1e877444f1c877420f311aba385d363/after.svg)

### Testing:

The existing tests should be sufficient to catch any regressions.

### TODO

- [ ] figure out side trail failure

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
