### PR TITLE
Adds code contracts macros for CBMC

### DIFF
--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -18,6 +18,8 @@
 #include <s2n.h>
 #include <stdio.h>
 #include <stdbool.h>
+#include <utils/s2n_ensure.h>
+
 /*
  * To easily retrieve error types, we split error values into two parts.
  * The upper 6 bits describe the error type and the lower bits describe the value within the category.
@@ -296,42 +298,6 @@ extern __thread const char *s2n_debug_str;
 #define S2N_ERROR_PTR( x )  do { _S2N_ERROR( ( x ) ); return NULL; } while (0)
 #define S2N_ERROR_IF( cond , x ) do { if ( cond ) { S2N_ERROR( x ); }} while (0)
 #define S2N_ERROR_IS_BLOCKING( x )    ( s2n_error_get_type(x) == S2N_ERR_T_BLOCKED )
-
-/**
- * These macros should not be used in validate functions.
- * All validate functions are also used in assumptions for CBMC proofs,
- * which should not contain __CPROVER_*_ok primitives. The use of these primitives
- * in assumptions may lead to spurious results.
- * Define function contracts.
- * When the code is being verified using CBMC these contracts are formally verified;
- * When the code is built in debug mode, they are checked as much as possible using assertions
- * When the code is built in production mode, non-fatal contracts are not checked.
- * Violations of the function contracts are undefined behaviour.
- */
-#ifdef CBMC
-#    define S2N_MEM_IS_READABLE_CHECK(base, len) (((len) == 0) || __CPROVER_r_ok((base), (len)))
-#    define S2N_MEM_IS_WRITABLE_CHECK(base, len) (((len) == 0) || __CPROVER_w_ok((base), (len)))
-#else
-/* the C runtime does not give a way to check these properties,
- * but we can at least check that the pointer is valid */
-#    define S2N_MEM_IS_READABLE_CHECK(base, len) (((len) == 0) || (base) != NULL)
-#    define S2N_MEM_IS_WRITABLE_CHECK(base, len) (((len) == 0) || (base) != NULL)
-#endif /* CBMC */
-
-/**
- * These macros can safely be used in validate functions.
- */
-#define S2N_MEM_IS_READABLE(base, len) (((len) == 0) || (base) != NULL)
-#define S2N_MEM_IS_WRITABLE(base, len) (((len) == 0) || (base) != NULL)
-#define S2N_OBJECT_PTR_IS_READABLE(ptr) ((ptr) != NULL)
-#define S2N_OBJECT_PTR_IS_WRITABLE(ptr) ((ptr) != NULL)
-
-#define S2N_IMPLIES(a, b) (!(a) || (b))
-/**
- * If and only if (iff) is a biconditional logical connective between statements a and b.
- * Equivalent to (S2N_IMPLIES(a, b) && S2N_IMPLIES(b, a)).
- */
-#define S2N_IFF(a, b) (!!(a) == !!(b))
 
 /** Calculate and print stacktraces */
 struct s2n_stacktrace {

--- a/tests/sidetrail/working/stubs/s2n_ensure.h
+++ b/tests/sidetrail/working/stubs/s2n_ensure.h
@@ -42,3 +42,32 @@ void *s2n_sidetrail_memset(void * ptr, int value, size_t num);
       s2n_sidetrail_memset( __tmp_d, (c), __tmp_n);        \
     }                                                      \
   } while(0)
+
+
+/**
+ * The C runtime does not give a way to check these properties,
+ * but we can at least check for nullness.
+ */
+#define S2N_MEM_IS_READABLE_CHECK(base, len) (((len) == 0) || (base) != NULL)
+#define S2N_MEM_IS_WRITABLE_CHECK(base, len) (((len) == 0) || (base) != NULL)
+
+/**
+ * These macros can safely be used in validate functions.
+ */
+#define S2N_MEM_IS_READABLE(base, len) (((len) == 0) || (base) != NULL)
+#define S2N_MEM_IS_WRITABLE(base, len) (((len) == 0) || (base) != NULL)
+#define S2N_OBJECT_PTR_IS_READABLE(ptr) ((ptr) != NULL)
+#define S2N_OBJECT_PTR_IS_WRITABLE(ptr) ((ptr) != NULL)
+
+#define S2N_IMPLIES(a, b) (!(a) || (b))
+#define S2N_IFF(a, b) (!!(a) == !!(b))
+
+/**
+ * These macros are used to specify code contracts in CBMC proofs.
+ */
+#define CONTRACT_ASSIGNS(...)
+#define CONTRACT_ASSIGNS_ERR(...)
+#define CONTRACT_REQUIRES(...)
+#define CONTRACT_ENSURES(...)
+#define CONTRACT_INVARIANT(...)
+#define CONTRACT_RETURN_VALUE


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

Adds code contracts macros for CBMC and moves proof-related macros to `utils/s2n_ensures.h`.

### Call-outs:
N/A.

### Testing:
N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
