### PR TITLE
bin: add perf impl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ CMakeCache.txt
 CMakeFiles/*
 .project
 ./codebuild/spec/buildspec_*_batch.yml
+/build/
+/target/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,13 +400,13 @@ if (BUILD_TESTING)
 
     endforeach(test_case)
 
-    add_executable(s2nc "bin/s2nc.c" "bin/echo.c" "bin/https.c" "bin/common.c")
+    add_executable(s2nc "bin/s2nc.c" "bin/echo.c" "bin/https.c" "bin/perf.c" "bin/common.c")
     target_link_libraries(s2nc ${PROJECT_NAME})
     target_include_directories(s2nc PRIVATE $<TARGET_PROPERTY:crypto,INTERFACE_INCLUDE_DIRECTORIES>)
     target_include_directories(s2nc PRIVATE api)
     target_compile_options(s2nc PRIVATE -std=gnu99 -D_POSIX_C_SOURCE=200112L)
 
-    add_executable(s2nd "bin/s2nd.c" "bin/echo.c" "bin/https.c" "bin/common.c")
+    add_executable(s2nd "bin/s2nd.c" "bin/echo.c" "bin/https.c" "bin/perf.c" "bin/common.c")
     target_link_libraries(s2nd ${PROJECT_NAME})
     target_include_directories(s2nd PRIVATE $<TARGET_PROPERTY:crypto,INTERFACE_INCLUDE_DIRECTORIES>)
     target_include_directories(s2nd PRIVATE api)

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -20,8 +20,10 @@ include ../s2n.mk
 LDFLAGS += -L../lib/ -L${LIBCRYPTO_ROOT}/lib ../lib/libs2n.a ${CRYPTO_LIBS} ${LIBS}
 CRUFT += s2nc s2nd
 
-s2nc: s2nc.c echo.c
-	${CC} ${CFLAGS} s2nc.c echo.c common.c -o s2nc ${LDFLAGS}
+DEPS = common.c echo.c https.c perf.c
 
-s2nd: s2nd.c echo.c
-	${CC} ${CFLAGS} s2nd.c echo.c https.c common.c -o s2nd ${LDFLAGS}
+s2nc: s2nc.c ${DEPS}
+	${CC} ${CFLAGS} s2nc.c ${DEPS} -o s2nc ${LDFLAGS}
+
+s2nd: s2nd.c ${DEPS}
+	${CC} ${CFLAGS} s2nd.c ${DEPS} -o s2nd ${LDFLAGS}

--- a/bin/common.h
+++ b/bin/common.h
@@ -52,6 +52,9 @@ int early_data_send(struct s2n_connection *conn, uint8_t *data, uint32_t len);
 int https(struct s2n_connection *conn, uint32_t bench);
 int key_log_callback(void *ctx, struct s2n_connection *conn, uint8_t *logline, size_t len);
 
+int perf_server_handler(struct s2n_connection *conn);
+int perf_client_handler(struct s2n_connection *conn, uint64_t send_len, uint64_t recv_len);
+
 char *load_file_to_cstring(const char *path);
 int s2n_str_hex_to_bytes(const unsigned char *hex, uint8_t *out_bytes, uint32_t max_out_bytes_len);
 int s2n_setup_external_psk_list(struct s2n_connection *conn, char *psk_optarg_list[S2N_MAX_PSK_LIST_LENGTH], size_t psk_list_len);

--- a/bin/perf.c
+++ b/bin/perf.c
@@ -17,14 +17,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <time.h>
 
 #include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_endian.h"
 #include "utils/s2n_safety.h"
 #include "common.h"
-
 
 uint64_t read_uint64(uint8_t *data)
 {
@@ -109,7 +107,7 @@ int perf_server_handler(struct s2n_connection *conn)
 
     fprintf(stdout, "Done. Closing connection.\n\n");
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int perf_client_handler(struct s2n_connection *conn, uint64_t send_len, uint64_t recv_len)
@@ -127,8 +125,6 @@ int perf_client_handler(struct s2n_connection *conn, uint64_t send_len, uint64_t
     /* account for the length prefix */
     POSIX_GUARD(send(conn, buffer, 8, &blocked));
 
-    clock_t begin = clock();
-
     while (recv_len) {
         uint32_t buffer_remaining = recv_len < buffer_len ? recv_len : buffer_len;
         POSIX_GUARD(recv(conn, buffer, buffer_remaining, &blocked));
@@ -136,15 +132,9 @@ int perf_client_handler(struct s2n_connection *conn, uint64_t send_len, uint64_t
     }
 
     /* TODO implement send */
-    /* send_len += 8; */
 
-    clock_t end = clock();
-    double time_spent = (double)(end - begin) / CLOCKS_PER_SEC;
-    double recv_mbps = (double)total_recv_len / time_spent / 1000000.0;
-    double send_mbps = (double)total_send_len / time_spent / 1000000.0;
+    fprintf(stdout, "Received %luB.\n", total_recv_len);
+    fprintf(stdout, "    Sent %luB.\n\n", total_send_len);
 
-    fprintf(stdout, "Received %uMiB/s.\n", (uint32_t)recv_mbps);
-    fprintf(stdout, "    Sent %uMiB/s.\n\n", (uint32_t)send_mbps);
-
-    return 0;
+    return S2N_SUCCESS;
 }

--- a/bin/perf.c
+++ b/bin/perf.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <s2n.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <time.h>
+
+#include "error/s2n_errno.h"
+#include "stuffer/s2n_stuffer.h"
+#include "utils/s2n_endian.h"
+#include "utils/s2n_safety.h"
+#include "common.h"
+
+static int send(struct s2n_connection *conn, uint8_t *buffer,  uint32_t left, s2n_blocked_status *blocked_status)
+{
+    uint32_t i = 0;
+    while (i < left) {
+        int out = s2n_send(conn, &buffer[i], left - i, blocked_status);
+        if (out < 0) {
+            fprintf(stderr, "Error writing to connection: '%s'\n", s2n_strerror(s2n_errno, "EN"));
+            s2n_print_stacktrace(stdout);
+            return S2N_FAILURE;
+        }
+        i += out;
+    }
+
+    return S2N_SUCCESS;
+}
+
+static int recv(struct s2n_connection *conn, uint8_t *buffer, uint32_t left, s2n_blocked_status *blocked_status)
+{
+    uint32_t i = 0;
+    while (i < left) {
+        int out = s2n_recv(conn, &buffer[i], left - i, blocked_status);
+        if (out < 0) {
+            fprintf(stderr, "Error writing to connection: '%s'\n", s2n_strerror(s2n_errno, "EN"));
+            s2n_print_stacktrace(stdout);
+            return S2N_FAILURE;
+        }
+        i += out;
+    }
+
+    return S2N_SUCCESS;
+}
+
+int perf_server_handler(struct s2n_connection *conn)
+{
+    printf("handling perf connection\n");
+    uint8_t buffer[UINT16_MAX] = { 0 };
+    uint32_t buffer_len = sizeof(buffer);
+    uint64_t send_len = 0;
+    bool recv_remaining = true;
+
+    s2n_blocked_status blocked = 0;
+
+    /* read the amount the client wants back */
+    POSIX_GUARD(s2n_recv(conn, &buffer, 8, &blocked));
+    send_len = *(uint64_t *) &buffer;
+    send_len = be64toh(send_len);
+
+    while (send_len) {
+        uint32_t buffer_remaining = send_len < buffer_len ? send_len : buffer_len;
+        POSIX_GUARD(send(conn, buffer, buffer_remaining, &blocked));
+        send_len -= buffer_remaining;
+    }
+
+    /* TODO implement recv */
+
+    fprintf(stdout, "Done. Closing connection.\n\n");
+
+    return 0;
+}
+
+int perf_client_handler(struct s2n_connection *conn, uint64_t send_len, uint64_t recv_len)
+{
+    uint8_t buffer[UINT16_MAX] = { 0 };
+    uint32_t buffer_len = sizeof(buffer);
+    uint64_t total_send_len = send_len;
+    uint64_t total_recv_len = recv_len;
+
+    s2n_blocked_status blocked = 0;
+
+    /* write the amount the client wants back */
+    *((uint64_t *) buffer) = htobe64(recv_len);
+
+    /* account for the length prefix */
+    send_len += 8;
+    POSIX_GUARD(send(conn, buffer, 8, &blocked));
+
+    clock_t begin = clock();
+
+    while (recv_len) {
+        uint32_t buffer_remaining = recv_len < buffer_len ? recv_len : buffer_len;
+        POSIX_GUARD(recv(conn, buffer, buffer_remaining, &blocked));
+        recv_len -= buffer_remaining;
+    }
+
+    /* TODO implement send */
+
+    clock_t end = clock();
+    double time_spent = (double)(end - begin) / CLOCKS_PER_SEC;
+    double recv_mbps = (double)total_recv_len / time_spent / 1000000.0;
+    double send_mbps = (double)total_send_len / time_spent / 1000000.0;
+
+    fprintf(stdout, "Received %dMiB/s.\n", (uint32_t)recv_mbps);
+    fprintf(stdout, "    Sent %dMiB/s.\n\n", (uint32_t)send_mbps);
+
+    return 0;
+}

--- a/bin/perf.c
+++ b/bin/perf.c
@@ -27,7 +27,7 @@
 uint64_t read_uint64(uint8_t *data)
 {
     uint64_t u = 0;
-    u |= ((uint64_t) data[0]) << (8);
+    u |= ((uint64_t) data[0]);
     u |= ((uint64_t) data[1]) << (1 * 8);
     u |= ((uint64_t) data[2]) << (2 * 8);
     u |= ((uint64_t) data[3]) << (3 * 8);
@@ -94,7 +94,7 @@ int perf_server_handler(struct s2n_connection *conn)
     s2n_blocked_status blocked = 0;
 
     /* read the amount the client wants back */
-    POSIX_GUARD(s2n_recv(conn, &buffer, 8, &blocked));
+    POSIX_GUARD(s2n_recv(conn, &buffer, sizeof(uint64_t), &blocked));
     send_len = read_uint64(buffer);
 
     while (send_len) {

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -39,6 +39,9 @@
 
 #define S2N_MAX_ECC_CURVE_NAME_LENGTH 10
 
+#define OPT_PERF_SEND_AMOUNT 1000
+#define OPT_PERF_RECEIVE_AMOUNT 1001
+
 void usage()
 {
     fprintf(stderr, "usage: s2nc [options] host [port]\n");
@@ -98,6 +101,10 @@ void usage()
                     "    Ex: --psk psk_id,psk_secret,SHA256 --psk shared_id,shared_secret,SHA384.\n");
     fprintf(stderr, "  -E ,--early-data <file path>\n");
     fprintf(stderr, "    Sends data in file path as early data to the server. Early data will only be sent if s2nc receives a session ticket and resumes a session.");
+    fprintf(stderr, "  --perf-send-amount <bytes>\n");
+    fprintf(stderr, "    Specifies the number of bytes to send to the server in perf mode\n");
+    fprintf(stderr, "  --perf-receive-amount <bytes>\n");
+    fprintf(stderr, "    Specifies the number of bytes to request the server to send in perf mode\n");
     fprintf(stderr, "\n");
     exit(1);
 }
@@ -250,6 +257,7 @@ static void setup_s2n_config(struct s2n_config *config, const char *cipher_prefs
     GUARD_EXIT(s2n_config_send_max_fragment_length(config, mfl_code), "Error setting maximum fragment length");
 }
 
+
 int main(int argc, char *const *argv)
 {
     struct addrinfo hints, *ai_list, *ai;
@@ -288,6 +296,8 @@ int main(int argc, char *const *argv)
     char *psk_optarg_list[S2N_MAX_PSK_LIST_LENGTH];
     size_t psk_list_len = 0;
     char *early_data = NULL;
+    uint64_t perf_send_amount = 0;
+    uint64_t perf_receive_amount = 1000000; /* 1MB */
 
     static struct option long_options[] = {
         {"alpn", required_argument, 0, 'a'},
@@ -313,6 +323,8 @@ int main(int argc, char *const *argv)
         {"key-log", required_argument, 0, 'L'},
         {"psk", required_argument, 0, 'P'},
         {"early-data", required_argument, 0, 'E'},
+        {"perf-send-amount", required_argument, 0, OPT_PERF_SEND_AMOUNT},
+        {"perf-receive-amount", required_argument, 0, OPT_PERF_RECEIVE_AMOUNT},
         { 0 },
     };
 
@@ -410,6 +422,20 @@ int main(int argc, char *const *argv)
         case 'E':
             early_data = load_file_to_cstring(optarg);
             GUARD_EXIT_NULL(early_data);
+            break;
+        case OPT_PERF_SEND_AMOUNT:
+            errno = 0;
+            perf_send_amount = strtoull(optarg, 0, 10);
+            if (errno == ERANGE) {
+                perf_send_amount = 0;
+            }
+            break;
+        case OPT_PERF_RECEIVE_AMOUNT:
+            errno = 0;
+            perf_receive_amount = strtoull(optarg, 0, 10);
+            if (errno == ERANGE) {
+                perf_receive_amount = 0;
+            }
             break;
         case '?':
         default:
@@ -531,7 +557,7 @@ int main(int argc, char *const *argv)
         }
 
         GUARD_EXIT(s2n_connection_set_config(conn, config), "Error setting configuration");
- 
+
         GUARD_EXIT(s2n_set_server_name(conn, server_name), "Error setting server name");
 
         GUARD_EXIT(s2n_connection_set_fd(conn, sockfd) , "Error setting file descriptor");
@@ -605,7 +631,25 @@ int main(int argc, char *const *argv)
 
         GUARD_EXIT(s2n_connection_free_handshake(conn), "Error freeing handshake memory after negotiation");
 
-        if (echo_input == 1) {
+        bool run_perf = false;
+        bool run_echo = false;
+
+        const char * alpn = s2n_get_application_protocol(conn);
+        if (alpn != NULL) {
+            /* determine which protocol the server chose */
+            if (strcmp(alpn, "perf") == 0) {
+                run_perf = true;
+            } else {
+                /* fall back to echo */
+                run_echo = echo_input == 1;
+            }
+        } else {
+            run_echo = echo_input == 1;
+        }
+
+        if (run_perf) {
+            perf_client_handler(conn, perf_send_amount, perf_receive_amount);
+        } else if (run_echo) {
             bool stop_echo = false;
             fflush(stdout);
             fflush(stderr);

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -257,7 +257,6 @@ static void setup_s2n_config(struct s2n_config *config, const char *cipher_prefs
     GUARD_EXIT(s2n_config_send_max_fragment_length(config, mfl_code), "Error setting maximum fragment length");
 }
 
-
 int main(int argc, char *const *argv)
 {
     struct addrinfo hints, *ai_list, *ai;

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,0 +1,18 @@
+# Perf runner
+
+## Requirements
+
+* Linux
+
+## Generating a flamegraph with a 1GB file download, 0B upload
+
+```bash
+./scripts/perf/run
+```
+
+## Generating a flamegraph with a specific downoad and upload size
+
+```bash
+./scripts/perf/run 123 456
+```
+

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,18 +1,24 @@
-# Perf runner
+# Performance Runner
 
 ## Requirements
 
 * Linux
+* Cargo
 
-## Generating a flamegraph with a 1GB file download, 0B upload
+## Generating a Flamegraph
+
 
 ```bash
 ./scripts/perf/run
 ```
 
-## Generating a flamegraph with a specific downoad and upload size
+## Overrides
+
+By default the test will download 1GB worth of data from the server to client, with the `default`
+security policy. This can be changed with the script arguments:
 
 ```bash
-./scripts/perf/run 123 456
+# <download bytes> <upload bytes> <security policy>
+./scripts/perf/run 123 456 default_tls13
 ```
 

--- a/scripts/perf/build
+++ b/scripts/perf/build
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+if ! command -v "inferno-collapse-perf" &> /dev/null; then
+  cargo install inferno
+fi
+

--- a/scripts/perf/run
+++ b/scripts/perf/run
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+./scripts/perf/build
+
+mkdir -p target/perf/results
+sudo env "PATH=$PATH" ./scripts/perf/test $@

--- a/scripts/perf/test
+++ b/scripts/perf/test
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+DOWNLOAD_MB=${1:-1000}
+UPLOAD_MB=${2:-0}
+VERSION=${3:-default}
+
+TMP=$(mktemp -d -t s2n-tls-perf-XXXXXXXXXX)
+FILE="${DOWNLOAD_MB}MB-down-${UPLOAD_MB}MB-up-${VERSION}"
+TITLE="${DOWNLOAD_MB}MB Download, ${UPLOAD_MB}MB Upload ${VERSION}"
+DOWNLOAD_B=$(($DOWNLOAD_MB * 1000000))
+UPLOAD_B=$(($UPLOAD_MB * 1000000))
+OUT=target/perf/results
+
+mkdir -p $OUT
+
+perf record \
+  --output $TMP/$FILE.perf \
+  --call-graph dwarf \
+  --event cycles \
+  -- \
+  timeout --signal INT 15 \
+  ./build/bin/s2nd \
+  --alpn perf \
+  --parallelize \
+  --ciphers $VERSION \
+  localhost 4433 &
+PERF_PID=$!
+
+function stop_server() {
+  echo "shutting down server"
+  kill $PERF_PID
+  echo $1
+  exit 1
+}
+
+echo "waiting for server to boot"
+sleep 1
+
+echo "executing request"
+for i in {1..10}
+do
+  ./build/bin/s2nc \
+    --perf-send-amount $UPLOAD_B \
+    --perf-receive-amount $DOWNLOAD_B \
+    --alpn perf \
+    --insecure \
+    --ciphers $VERSION \
+    localhost 4433 || stop_server "failed to finish the request"
+done
+
+wait $PERF_PID || true
+
+echo "folding events"
+perf script \
+  --input $TMP/$FILE.perf \
+  2>/dev/null \
+  | inferno-collapse-perf \
+  > $OUT/$FILE.folded
+
+echo "generating flamegraph"
+mkdir -p target/perf/results
+inferno-flamegraph $OUT/$FILE.folded \
+  --title "$TITLE" \
+  > $OUT/$FILE.svg
+
+rm -rf $TMP
+
+echo "flamegraph available in $OUT/$FILE.svg"

--- a/scripts/perf/test-all
+++ b/scripts/perf/test-all
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+./scripts/perf/test 1000 0
+./scripts/perf/test 750 250
+./scripts/perf/test 500 500
+./scripts/perf/test 250 750
+./scripts/perf/test 0 1000
+
+cd target/perf/results
+tree -H "." -L 1 -T "Performance Results" --noreport --charset utf-8 -P "*.svg" > index.html

--- a/utils/s2n_endian.h
+++ b/utils/s2n_endian.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef _MSC_VER
+
+#include <stdlib.h>
+#define bswap_16(x) _byteswap_ushort(x)
+#define bswap_32(x) _byteswap_ulong(x)
+#define bswap_64(x) _byteswap_uint64(x)
+
+#elif defined(__APPLE__)
+
+#include <libkern/OSByteOrder.h>
+#define bswap_16(x) OSSwapInt16(x)
+#define bswap_32(x) OSSwapInt32(x)
+#define bswap_64(x) OSSwapInt64(x)
+
+#elif defined(__sun) || defined(sun)
+
+#include <sys/byteorder.h>
+#define bswap_16(x) BSWAP_16(x)
+#define bswap_32(x) BSWAP_32(x)
+#define bswap_64(x) BSWAP_64(x)
+
+#elif defined(__FreeBSD__)
+
+#include <sys/endian.h>
+#define bswap_16(x) bswap16(x)
+#define bswap_32(x) bswap32(x)
+#define bswap_64(x) bswap64(x)
+
+#elif defined(__OpenBSD__)
+
+#include <sys/types.h>
+#define bswap_16(x) swap16(x)
+#define bswap_32(x) swap32(x)
+#define bswap_64(x) swap64(x)
+
+#elif defined(__NetBSD__)
+
+#include <sys/types.h>
+#include <machine/bswap.h>
+#if defined(__BSWAP_RENAME) && !defined(__bswap_32)
+#define bswap_16(x) bswap16(x)
+#define bswap_32(x) bswap32(x)
+#define bswap_64(x) bswap64(x)
+#endif
+
+#else
+
+#include <byteswap.h>
+
+#endif
+
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+#    define htobe16(x) bswap_16(x)
+#    define htole16(x) (x)
+#    define be16toh(x) bswap_16(x)
+#    define le16toh(x) (x)
+
+#    define htobe32(x) bswap_32(x)
+#    define htole32(x) (x)
+#    define be32toh(x) bswap_32(x)
+#    define le32toh(x) (x)
+
+#    define htobe64(x) bswap_64(x)
+#    define htole64(x) (x)
+#    define be64toh(x) bswap_64(x)
+#    define le64toh(x) (x)
+#else
+#    define htobe16(x) (x)
+#    define htole16(x) bswap_16(x)
+#    define be16toh(x) (x)
+#    define le16toh(x) bswap_16(x)
+
+#    define htobe32(x) (x)
+#    define htole32(x) bswap_32(x)
+#    define be32toh(x) (x)
+#    define le32toh(x) bswap_32(x)
+
+#    define htobe64(x) (x)
+#    define htole64(x) bswap_64(x)
+#    define be64toh(x) (x)
+#    define le64toh(x) bswap_64(x)
+#endif


### PR DESCRIPTION
### Description of changes: 

I've added an adaptation of the quic `perf` protocol as defined in [draft-banks-quic-performance-00](https://datatracker.ietf.org/doc/html/draft-banks-quic-performance-00) to s2nd and s2nc. Since TLS doesn't have stream multiplexing, this is simply:

* The client opens a connection with the `perf` ALPN
* The client sends a big endian `uint64_t` to tell the server how many bytes to send
* The server sends and receives on the connection
* The client sends and receives on the connection

NOTE: In the interest of getting this merged, the current implementation is _only_ able to send data on the server and receive data on the client. Future PRs will increase functionality.

I've added a script to make it easy to spin up a client/server pair and generate a flamegraph. The readme for this script can be found in `scripts/perf/README.md`.

### Testing:

The best way to test that it works is to run the perf script itself and verity the flamegraph is produced. Here's the current flamegraph from main:

#### TLS 1.2

[![](https://gist.githubusercontent.com/camshaft/2da7504782062333ef6979b6061827ed/raw/bc5405a7e1e877444f1c877420f311aba385d363/before.svg)](https://gist.githubusercontent.com/camshaft/2da7504782062333ef6979b6061827ed/raw/bc5405a7e1e877444f1c877420f311aba385d363/before.svg)

#### TLS 1.3

[![](https://gist.githubusercontent.com/camshaft/2da7504782062333ef6979b6061827ed/raw/c51ba015bb6844fd5a9ea541c1f12b3e894d4a2f/tls13.svg)](https://gist.githubusercontent.com/camshaft/2da7504782062333ef6979b6061827ed/raw/c51ba015bb6844fd5a9ea541c1f12b3e894d4a2f/tls13.svg)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
