### PR TITLE
Avoid allocations in new_session_ticket

### DIFF
--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -835,9 +835,16 @@ int main(int argc, char **argv)
 
         /* 0 tickets are requested */
         {
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_NOT_NULL(config);
+            EXPECT_SUCCESS(s2n_setup_test_ticket_key(config));
+
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             conn->actual_protocol_version = S2N_TLS13;
+            conn->tickets_to_send = 0;
+            EXPECT_NOT_EQUAL(0, s2n_stuffer_space_remaining(&conn->handshake.io));
 
             /* Setup io */
             struct s2n_stuffer stuffer;
@@ -847,10 +854,15 @@ int main(int argc, char **argv)
             s2n_blocked_status blocked = 0;
             EXPECT_OK(s2n_tls13_server_nst_send(conn, &blocked));
 
+            /* Check no tickets are written */
             EXPECT_EQUAL(0, s2n_stuffer_data_available(&stuffer));
+
+            /* Check handshake.io is cleaned up */
+            EXPECT_EQUAL(0, s2n_stuffer_space_remaining(&conn->handshake.io));
 
             EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
             EXPECT_SUCCESS(s2n_connection_free(conn));
+            EXPECT_SUCCESS(s2n_config_free(config));
         }
 
         /* Sends one new session ticket */
@@ -865,6 +877,7 @@ int main(int argc, char **argv)
             conn->actual_protocol_version = S2N_TLS13;
             conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
             conn->tickets_to_send = 1;
+            EXPECT_NOT_EQUAL(s2n_stuffer_space_remaining(&conn->handshake.io), 0);
 
             /* Setup io */
             struct s2n_stuffer stuffer;
@@ -880,7 +893,10 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &record_len));
             EXPECT_TRUE(record_len > 0);
             EXPECT_SUCCESS(s2n_stuffer_skip_read(&stuffer, record_len));
-            EXPECT_TRUE(s2n_stuffer_data_available(&stuffer) == 0);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
+
+            /* Check handshake.io is cleaned up */
+            EXPECT_EQUAL(s2n_stuffer_space_remaining(&conn->handshake.io), 0);
 
             EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
             EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -1201,6 +1217,11 @@ int main(int argc, char **argv)
 
         /* Do handshake */
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+        /* Check handshake.io was cleaned up.
+         * If a ticket was written, this happens afterwards. */
+        EXPECT_EQUAL(s2n_stuffer_space_remaining(&server_conn->handshake.io), 0);
+        EXPECT_EQUAL(s2n_stuffer_space_remaining(&client_conn->handshake.io), 0);
 
         /* Check there are five records corresponding to five new session tickets
          * not read as part of the handshake */

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1381,12 +1381,12 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
             }
         }
 
-        /* If the handshake has just ended, free up memory */
         if (ACTIVE_STATE(conn).writer == 'B') {
-            POSIX_GUARD(s2n_stuffer_resize(&conn->handshake.io, 0));
-
             /* Send any pending post-handshake messages */
             POSIX_GUARD(s2n_post_handshake_send(conn, blocked));
+
+            /* If the handshake has just ended, free up memory */
+            POSIX_GUARD(s2n_stuffer_resize(&conn->handshake.io, 0));
         }
     }
 

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -108,7 +108,23 @@ S2N_RESULT s2n_tls13_server_nst_send(struct s2n_connection *conn, s2n_blocked_st
 {
     RESULT_ENSURE_REF(conn);
 
+    /* Usually tickets are sent immediately after the handshake.
+     * If possible, reuse the handshake IO stuffer before it's wiped.
+     *
+     * Note: handshake.io isn't explicitly dedicated to only reading or only writing,
+     * so we have to be careful using it outside of s2n_negotiate.
+     * If we use it for writing here, we CAN'T use it for reading any post-handshake messages.
+     */
+    struct s2n_stuffer *nst_stuffer = &conn->handshake.io;
+
     if (conn->mode != S2N_SERVER || conn->actual_protocol_version < S2N_TLS13 || !conn->config->use_tickets) {
+        return S2N_RESULT_OK;
+    }
+
+    /* No-op if all tickets already sent.
+     * Clean up the stuffer used for the ticket to conserve memory. */
+    if (conn->tickets_to_send == conn->tickets_sent) {
+        RESULT_GUARD_POSIX(s2n_stuffer_resize(nst_stuffer, 0));
         return S2N_RESULT_OK;
     }
 
@@ -133,26 +149,27 @@ S2N_RESULT s2n_tls13_server_nst_send(struct s2n_connection *conn, s2n_blocked_st
     size_t session_state_size = 0;
     RESULT_GUARD(s2n_connection_get_session_state_size(conn, &session_state_size));
     const size_t maximum_nst_size = session_state_size + S2N_TLS13_MAX_FIXED_NEW_SESSION_TICKET_SIZE;
-
-    DEFER_CLEANUP(struct s2n_stuffer nst_stuffer = { 0 }, s2n_stuffer_free);
-    RESULT_GUARD_POSIX(s2n_stuffer_growable_alloc(&nst_stuffer, maximum_nst_size));
+    if (s2n_stuffer_space_remaining(nst_stuffer) < maximum_nst_size) {
+        RESULT_GUARD_POSIX(s2n_stuffer_resize(nst_stuffer, maximum_nst_size));
+    }
 
     while (conn->tickets_to_send - conn->tickets_sent > 0) {
-        if (s2n_result_is_error(s2n_tls13_server_nst_write(conn, &nst_stuffer))) {
+        if (s2n_result_is_error(s2n_tls13_server_nst_write(conn, nst_stuffer))) {
             return S2N_RESULT_OK;
         }
 
         struct s2n_blob nst_blob = { 0 };
-        uint16_t nst_size = s2n_stuffer_data_available(&nst_stuffer);
-        uint8_t *nst_data = s2n_stuffer_raw_read(&nst_stuffer, nst_size);
+        uint16_t nst_size = s2n_stuffer_data_available(nst_stuffer);
+        uint8_t *nst_data = s2n_stuffer_raw_read(nst_stuffer, nst_size);
         RESULT_ENSURE_REF(nst_data);
         RESULT_GUARD_POSIX(s2n_blob_init(&nst_blob, nst_data, nst_size));
 
         RESULT_GUARD_POSIX(s2n_record_write(conn, TLS_HANDSHAKE, &nst_blob));
         RESULT_GUARD_POSIX(s2n_flush(conn, blocked));
-        RESULT_GUARD_POSIX(s2n_stuffer_wipe(&nst_stuffer));
+        RESULT_GUARD_POSIX(s2n_stuffer_wipe(nst_stuffer));
     }
 
+    RESULT_GUARD_POSIX(s2n_stuffer_resize(nst_stuffer, 0));
     return S2N_RESULT_OK;
 }
 


### PR DESCRIPTION
### Description of changes: 

camshaft's perf tests noted a big slow down in s2n_tls13_server_nst_send caused by allocating a stuffer whether or not we actually sent a ticket.

I fixed that for the "send no tickets" case by adding an earlier check to bail out of the method without any allocation. I also fixed it for the most common "send tickets immediately after handshake" case by reusing the handshake.io memory instead of allocating new memory. A big allocation is still possible, but only if tickets are sent later in the connection.

### Call outs
There is still one memory allocation involved in new_session_ticket (https://github.com/aws/s2n-tls/blob/main/tls/s2n_server_new_session_ticket.c#L234), but it only occurs when a ticket is generated and only once per connection. We could remove that allocation by storing the <50 bytes on the connection, but that would be a separate optimization.

### Testing:

Before:
[![](https://gist.githubusercontent.com/lrstewart/e5c282168fd9fa6d778c39dc768cb503/raw/f4b620629adce4e1a76f0d08ae23b0b114a1d76b/1000MB-down-0MB-up-default_tls13.svg)](https://gist.githubusercontent.com/lrstewart/e5c282168fd9fa6d778c39dc768cb503/raw/f4b620629adce4e1a76f0d08ae23b0b114a1d76b/1000MB-down-0MB-up-default_tls13.svg)

After:
[![](https://gist.githubusercontent.com/lrstewart/a080df8a6017dbc0132dac771ed24e4f/raw/94aa0314f2390c5584ffb3e28808fd31ec278a6d/1000MB-down-0MB-up-default_tls13%2520(1).svg)](https://gist.githubusercontent.com/lrstewart/a080df8a6017dbc0132dac771ed24e4f/raw/94aa0314f2390c5584ffb3e28808fd31ec278a6d/1000MB-down-0MB-up-default_tls13%2520(1).svg)




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
