### PR TITLE
Optimize aad init

### DIFF
--- a/tests/unit/s2n_tls13_record_aead_test.c
+++ b/tests/unit/s2n_tls13_record_aead_test.c
@@ -102,30 +102,28 @@ int main(int argc, char **argv)
     /* Test s2n_tls13_aead_aad_init() */
     {
         s2n_stack_blob(aad, S2N_TLS13_AAD_LEN, S2N_TLS13_AAD_LEN);
-        struct s2n_stuffer associated_data_stuffer;
-        EXPECT_SUCCESS(s2n_stuffer_init(&associated_data_stuffer, &aad));
-        EXPECT_OK(s2n_tls13_aead_aad_init(662, 12, &associated_data_stuffer));
+        EXPECT_OK(s2n_tls13_aead_aad_init(662, 12, &aad));
         S2N_BLOB_FROM_HEX(expected_aad, "17030302a2");
         S2N_BLOB_EXPECT_EQUAL(expected_aad, aad);
 
         /* record length 16640 should be valid */
-        EXPECT_SUCCESS(s2n_stuffer_rewrite(&associated_data_stuffer));
-        EXPECT_OK(s2n_tls13_aead_aad_init(16628, 12, &associated_data_stuffer));
+        EXPECT_SUCCESS(s2n_blob_zero(&aad));
+        EXPECT_OK(s2n_tls13_aead_aad_init(16628, 12, &aad));
 
         /* record length 16641 should be invalid */
-        EXPECT_SUCCESS(s2n_stuffer_rewrite(&associated_data_stuffer));
-        EXPECT_ERROR_WITH_ERRNO(s2n_tls13_aead_aad_init(16629, 12, &associated_data_stuffer), S2N_ERR_RECORD_LIMIT);
+        EXPECT_SUCCESS(s2n_blob_zero(&aad));
+        EXPECT_ERROR_WITH_ERRNO(s2n_tls13_aead_aad_init(16629, 12, &aad), S2N_ERR_RECORD_LIMIT);
 
         /* Test failure case: No AAD should be invalid */
-        EXPECT_SUCCESS(s2n_stuffer_rewrite(&associated_data_stuffer));
+        EXPECT_SUCCESS(s2n_blob_zero(&aad));
         EXPECT_ERROR(s2n_tls13_aead_aad_init(16629, 12, NULL));
 
         /* Test failure case: 0-length tag should be invalid */
-        EXPECT_SUCCESS(s2n_stuffer_rewrite(&associated_data_stuffer));
-        EXPECT_ERROR(s2n_tls13_aead_aad_init(16628, 0, &associated_data_stuffer));
+        EXPECT_SUCCESS(s2n_blob_zero(&aad));
+        EXPECT_ERROR(s2n_tls13_aead_aad_init(16628, 0, &aad));
 
         /* Test failure case: invalid record length (-1) should be invalid */
-        EXPECT_ERROR(s2n_tls13_aead_aad_init(-1, 0, &associated_data_stuffer));
+        EXPECT_ERROR(s2n_tls13_aead_aad_init(-1, 0, &aad));
     }
 
     /* Test s2n_tls13_aes_128_gcm_sha256 cipher suite with TLS 1.3 test vectors */

--- a/tls/s2n_aead.c
+++ b/tls/s2n_aead.c
@@ -31,6 +31,8 @@ S2N_RESULT s2n_aead_aad_init(const struct s2n_connection *conn, uint8_t * sequen
     uint8_t *data = ad->data;
     RESULT_GUARD_PTR(data);
 
+    /* ad = seq_num || record_type || version || length */
+
     size_t idx = 0;
     for(; idx < S2N_TLS_SEQUENCE_NUM_LEN; idx++) {
         data[idx] = sequence_number[idx];

--- a/tls/s2n_aead.c
+++ b/tls/s2n_aead.c
@@ -23,57 +23,81 @@
 
 /* Derive the AAD for an AEAD mode cipher suite from the connection state, per
  * RFC 5246 section 6.2.3.3 */
-S2N_RESULT s2n_aead_aad_init(const struct s2n_connection *conn, uint8_t * sequence_number, uint8_t content_type, uint16_t record_length, struct s2n_stuffer *ad)
+S2N_RESULT s2n_aead_aad_init(const struct s2n_connection *conn, uint8_t * sequence_number, uint8_t content_type, uint16_t record_length, struct s2n_blob *ad)
 {
-    /* ad = seq_num || record_type || version || length */
-    RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(ad, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
-    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(ad, content_type));
-    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(ad, conn->actual_protocol_version / 10));
-    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(ad, conn->actual_protocol_version % 10));
-    RESULT_GUARD_POSIX(s2n_stuffer_write_uint16(ad, record_length));
+    RESULT_ENSURE_REF(ad);
+    RESULT_ENSURE_GTE(ad->size, S2N_TLS_MAX_AAD_LEN);
 
+    uint8_t *data = ad->data;
+    RESULT_GUARD_PTR(data);
+
+    size_t idx = 0;
+    for(; idx < S2N_TLS_SEQUENCE_NUM_LEN; idx++) {
+        data[idx] = sequence_number[idx];
+    }
+
+    data[idx++] = content_type;
+    data[idx++] = conn->actual_protocol_version / 10;
+    data[idx++] = conn->actual_protocol_version % 10;
+    data[idx++] = record_length >> 8;
+    data[idx++] = record_length & UINT8_MAX;
+
+    /* Double check no overflow */
+    RESULT_ENSURE_LTE(idx, ad->size);
     return S2N_RESULT_OK;
 }
 
 /* Prepares an AAD (additional authentication data) for a TLS 1.3 AEAD record */
-S2N_RESULT s2n_tls13_aead_aad_init(uint16_t record_length, uint8_t tag_length, struct s2n_stuffer *additional_data)
+S2N_RESULT s2n_tls13_aead_aad_init(uint16_t record_length, uint8_t tag_length, struct s2n_blob *additional_data)
 {
     RESULT_ENSURE_GT(tag_length, 0);
     RESULT_ENSURE_REF(additional_data);
+    RESULT_ENSURE_GTE(additional_data->size, S2N_TLS13_AAD_LEN);
 
-    /*
-     * tls1.3 additional_data = opaque_type || legacy_record_version || length
-     *
-     * https://tools.ietf.org/html/rfc8446#section-5.2
-     *
-     *  opaque_type: The outer opaque_type field of a TLSCiphertext record
-     *      is always set to the value 23 (application_data) for outward
-     *      compatibility with middleboxes accustomed to parsing previous
-     *      versions of TLS.  The actual content type of the record is found
-     *      in TLSInnerPlaintext.type after decryption.
-     *  legacy_record_version:  The legacy_record_version field is always
-     *      0x0303.  TLS 1.3 TLSCiphertexts are not generated until after
-     *      TLS 1.3 has been negotiated, so there are no historical
-     *      compatibility concerns where other values might be received.  Note
-     *      that the handshake protocol, including the ClientHello and
-     *      ServerHello messages, authenticates the protocol version, so this
-     *      value is redundant.
-     *  length:  The length (in bytes) of the following
-     *      TLSCiphertext.encrypted_record, which is the sum of the lengths of
-     *      the content and the padding, plus one for the inner content type,
-     *      plus any expansion added by the AEAD algorithm.  The length
-     *      MUST NOT exceed 2^14 + 256 bytes.  An endpoint that receives a
-     *      record that exceeds this length MUST terminate the connection with
-     *      a "record_overflow" alert.
+    uint8_t *data = additional_data->data;
+    RESULT_GUARD_PTR(data);
+
+    size_t idx = 0;
+
+    /**
+     *= https://tools.ietf.org/rfc/rfc8446#section-5.2
+     *# opaque_type:  The outer opaque_type field of a TLSCiphertext record
+     *#    is always set to the value 23 (application_data) for outward
+     *#    compatibility with middleboxes accustomed to parsing previous
+     *#    versions of TLS.  The actual content type of the record is found
+     *#    in TLSInnerPlaintext.type after decryption.
+     **/
+    data[idx++] = TLS_APPLICATION_DATA;
+
+    /**
+     *= https://tools.ietf.org/rfc/rfc8446#section-5.2
+     *# legacy_record_version:  The legacy_record_version field is always
+     *#    0x0303.  TLS 1.3 TLSCiphertexts are not generated until after
+     *#    TLS 1.3 has been negotiated, so there are no historical
+     *#    compatibility concerns where other values might be received.  Note
+     *#    that the handshake protocol, including the ClientHello and
+     *#    ServerHello messages, authenticates the protocol version, so this
+     *#    value is redundant.
      */
+    data[idx++] = 0x03;
+    data[idx++] = 0x03;
 
+    /**
+     *= https://tools.ietf.org/rfc/rfc8446#section-5.2
+     *# length:  The length (in bytes) of the following
+     *#    TLSCiphertext.encrypted_record, which is the sum of the lengths of
+     *#    the content and the padding, plus one for the inner content type,
+     *#    plus any expansion added by the AEAD algorithm.  The length
+     *#    MUST NOT exceed 2^14 + 256 bytes.  An endpoint that receives a
+     *#    record that exceeds this length MUST terminate the connection with
+     *#    a "record_overflow" alert.
+     */
     uint16_t length = record_length + tag_length;
     RESULT_ENSURE(length <= (1 << 14) + 256, S2N_ERR_RECORD_LIMIT);
+    data[idx++] = length >> 8;
+    data[idx++] = length & UINT8_MAX;
 
-    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(additional_data, TLS_APPLICATION_DATA)); /* fixed to 0x17 */
-    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(additional_data, 3)); /* TLS record layer              */
-    RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(additional_data, 3)); /* version fixed at 1.2 (0x0303) */
-    RESULT_GUARD_POSIX(s2n_stuffer_write_uint16(additional_data, length));
-
+    /* Double check no overflow */
+    RESULT_ENSURE_LTE(idx, additional_data->size);
     return S2N_RESULT_OK;
 }

--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -75,5 +75,5 @@ extern int s2n_record_header_parse(struct s2n_connection *conn, uint8_t * conten
 extern int s2n_tls13_parse_record_type(struct s2n_stuffer *stuffer, uint8_t * record_type);
 extern int s2n_sslv2_record_header_parse(struct s2n_connection *conn, uint8_t * record_type, uint8_t * client_protocol_version, uint16_t * fragment_length);
 extern int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, struct s2n_blob *decrypted);
-extern S2N_RESULT s2n_aead_aad_init(const struct s2n_connection *conn, uint8_t * sequence_number, uint8_t content_type, uint16_t record_length, struct s2n_stuffer *ad);
-extern S2N_RESULT s2n_tls13_aead_aad_init(uint16_t record_length, uint8_t tag_length, struct s2n_stuffer *ad);
+extern S2N_RESULT s2n_aead_aad_init(const struct s2n_connection *conn, uint8_t * sequence_number, uint8_t content_type, uint16_t record_length, struct s2n_blob *ad);
+extern S2N_RESULT s2n_tls13_aead_aad_init(uint16_t record_length, uint8_t tag_length, struct s2n_blob *ad);

--- a/tls/s2n_record_read_aead.c
+++ b/tls/s2n_record_read_aead.c
@@ -87,13 +87,10 @@ int s2n_record_parse_aead(
     payload_length -= cipher_suite->record_alg->cipher->io.aead.record_iv_size;
     payload_length -= cipher_suite->record_alg->cipher->io.aead.tag_size;
 
-    struct s2n_stuffer ad_stuffer = {0};
-    POSIX_GUARD(s2n_stuffer_init(&ad_stuffer, &aad));
-
     if (is_tls13_record) {
-        POSIX_GUARD_RESULT(s2n_tls13_aead_aad_init(payload_length, cipher_suite->record_alg->cipher->io.aead.tag_size, &ad_stuffer));
+        POSIX_GUARD_RESULT(s2n_tls13_aead_aad_init(payload_length, cipher_suite->record_alg->cipher->io.aead.tag_size, &aad));
     } else {
-        POSIX_GUARD_RESULT(s2n_aead_aad_init(conn, sequence_number, content_type, payload_length, &ad_stuffer));
+        POSIX_GUARD_RESULT(s2n_aead_aad_init(conn, sequence_number, content_type, payload_length, &aad));
     }
 
     /* Decrypt stuff! */

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -367,13 +367,10 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
 
         /* Set the IV size to the amount of data written */
         iv.size = s2n_stuffer_data_available(&iv_stuffer);
-
-        struct s2n_stuffer ad_stuffer = {0};
-        POSIX_GUARD(s2n_stuffer_init(&ad_stuffer, &aad));
         if (is_tls13_record) {
-            POSIX_GUARD_RESULT(s2n_tls13_aead_aad_init(data_bytes_to_take + S2N_TLS_CONTENT_TYPE_LENGTH, cipher_suite->record_alg->cipher->io.aead.tag_size, &ad_stuffer));
+            POSIX_GUARD_RESULT(s2n_tls13_aead_aad_init(data_bytes_to_take + S2N_TLS_CONTENT_TYPE_LENGTH, cipher_suite->record_alg->cipher->io.aead.tag_size, &aad));
         } else {
-            POSIX_GUARD_RESULT(s2n_aead_aad_init(conn, sequence_number, content_type, data_bytes_to_take, &ad_stuffer));
+            POSIX_GUARD_RESULT(s2n_aead_aad_init(conn, sequence_number, content_type, data_bytes_to_take, &aad));
         }
     } else if (cipher_suite->record_alg->cipher->type == S2N_CBC || cipher_suite->record_alg->cipher->type == S2N_COMPOSITE) {
         s2n_blob_init(&iv, implicit_iv, block_size);


### PR DESCRIPTION
### Description of changes: 

A version of https://github.com/aws/s2n-tls/pull/2942 that passes the sidetrail tests. The issue was that s2n_endian.h / htobe16 in the original PR introduced a new function not modeled by the sidetrail proofs. However, we don't consider the existence of big-endian systems anywhere else ([example](https://github.com/aws/s2n-tls/blob/2c098a6be6e5aa04aff36c5db979f41d6f4f7aff/tls/s2n_record_read_cbc.c#L93-L94)), so not considering it in this case does not introduce any new failure.

I solved the "tainted stuffer" problem by just not using a stuffer. The stuffer wrapped a blob of exactly the right size for the aad, so is really unnecessary without the multiple s2n_stuffer_write_ calls.

I also refactored the existing comments for the compliance tool.

### Testing:
Existing tests. The only one I updated was just to swap the blob/stuffer argument.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
