### PR TITLE
Micro-optimization: Make S2N_IMPLIES in s2n_validate_stuffer a debug assertion

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -31,7 +31,7 @@ S2N_RESULT s2n_stuffer_validate(const struct s2n_stuffer* stuffer)
      */
     RESULT_ENSURE_REF(stuffer);
     RESULT_GUARD(s2n_blob_validate(&stuffer->blob));
-    RESULT_ENSURE(S2N_IMPLIES(stuffer->growable, stuffer->alloced), S2N_ERR_SAFETY);
+    RESULT_DEBUG_ENSURE(S2N_IMPLIES(stuffer->growable, stuffer->alloced), S2N_ERR_SAFETY);
 
     /* <= is valid because we can have a fully written/read stuffer */
     RESULT_DEBUG_ENSURE(stuffer->high_water_mark <= stuffer->blob.size, S2N_ERR_SAFETY);


### PR DESCRIPTION
Make S2N_IMPLIES in s2n_validate_stuffer a debug assertion

### Description of changes: 

Simply changing `RESULT_ENSURE` to `RESULT_DEBUG_ENSURE` around the `S2N_IMPLIES` macro will result in this being compiled out in release builds and makes this function extremely lightweight, and removes an additional call to `s2n_calculate_stacktrace`

### Testing:

Existing tests and proofs cover this function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
