### PR TITLE
Move more fields off s2n_crypto_parameters to avoid duplicates

### DIFF
--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -596,11 +596,6 @@ void cbmc_populate_s2n_kex_parameters(struct s2n_kex_parameters *s2n_kex_paramte
 void cbmc_populate_s2n_crypto_parameters(struct s2n_crypto_parameters *s2n_crypto_parameters)
 {
     CBMC_ENSURE_REF(s2n_crypto_parameters);
-    cbmc_populate_s2n_pkey(&(s2n_crypto_parameters->server_public_key));
-    cbmc_populate_s2n_pkey(&(s2n_crypto_parameters->client_public_key));
-    cbmc_populate_s2n_signature_scheme(&(s2n_crypto_parameters->conn_sig_scheme));
-    cbmc_populate_s2n_blob(&(s2n_crypto_parameters->client_cert_chain));
-    cbmc_populate_s2n_signature_scheme(&(s2n_crypto_parameters->client_cert_sig_scheme));
     s2n_crypto_parameters->cipher_suite = cbmc_allocate_s2n_cipher_suite();
     cbmc_populate_s2n_session_key(&(s2n_crypto_parameters->client_key));
     cbmc_populate_s2n_session_key(&(s2n_crypto_parameters->server_key));
@@ -659,6 +654,11 @@ void cbmc_populate_s2n_cert_chain_and_key(struct s2n_cert_chain_and_key *s2n_cer
 void cbmc_populate_s2n_handshake_parameters(struct s2n_handshake_parameters *s2n_handshake_parameters)
 {
     CBMC_ENSURE_REF(s2n_handshake_parameters);
+    cbmc_populate_s2n_pkey(&(s2n_handshake_parameters->server_public_key));
+    cbmc_populate_s2n_pkey(&(s2n_handshake_parameters->client_public_key));
+    cbmc_populate_s2n_signature_scheme(&(s2n_handshake_parameters->conn_sig_scheme));
+    cbmc_populate_s2n_blob(&(s2n_handshake_parameters->client_cert_chain));
+    cbmc_populate_s2n_signature_scheme(&(s2n_handshake_parameters->client_cert_sig_scheme));
     cbmc_populate_s2n_cert_chain_and_key(&(s2n_handshake_parameters->our_chain_and_key));
     /* `s2n_handshake_parameters->exact_sni_matches`
      * `s2n_handshake_parameters->wc_sni_matches` are never allocated.

--- a/tests/fuzz/s2n_client_cert_verify_recv_test.c
+++ b/tests/fuzz/s2n_client_cert_verify_recv_test.c
@@ -146,7 +146,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
     POSIX_ENSURE_REF(server_conn);
     POSIX_GUARD(s2n_stuffer_write_bytes(&server_conn->handshake.io, buf, len));
-    server_conn->secure.client_public_key.key.rsa_key.rsa = public_key.key.rsa_key.rsa;
+    server_conn->handshake_params.client_public_key.key.rsa_key.rsa = public_key.key.rsa_key.rsa;
 
     /* Pull a byte off the libfuzzer input and use it to set parameters */
     uint8_t randval = 0;
@@ -160,7 +160,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     /* Set the client_rsa_public_key so that it is not free'd during s2n_connection_free since it will be reused in
      * later fuzz tests  */
-    server_conn->secure.client_public_key.key.rsa_key.rsa = NULL;
+    server_conn->handshake_params.client_public_key.key.rsa_key.rsa = NULL;
 
     /* Cleanup */
     POSIX_GUARD(s2n_connection_free(server_conn));

--- a/tests/fuzz/s2n_hybrid_ecdhe_bike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_bike_r1_fuzz_test.c
@@ -53,7 +53,7 @@ static int setup_connection(struct s2n_connection *server_conn)
     server_conn->kex_params.server_ecc_evp_params.evp_pkey = NULL;
     server_conn->kex_params.kem_params.kem = &s2n_bike1_l1_r1;
     server_conn->secure.cipher_suite = &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;
-    server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
+    server_conn->handshake_params.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
     POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->kex_params.kem_params.private_key));
     POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.server_ecc_evp_params));

--- a/tests/fuzz/s2n_hybrid_ecdhe_bike_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_bike_r2_fuzz_test.c
@@ -53,7 +53,7 @@ static int setup_connection(struct s2n_connection *server_conn)
     server_conn->kex_params.server_ecc_evp_params.evp_pkey = NULL;
     server_conn->kex_params.kem_params.kem = &s2n_bike1_l1_r2;
     server_conn->secure.cipher_suite = &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;
-    server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
+    server_conn->handshake_params.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
     POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->kex_params.kem_params.private_key));
     POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.server_ecc_evp_params));

--- a/tests/fuzz/s2n_hybrid_ecdhe_bike_r3_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_bike_r3_fuzz_test.c
@@ -53,7 +53,7 @@ static int setup_connection(struct s2n_connection *server_conn)
     server_conn->kex_params.server_ecc_evp_params.evp_pkey = NULL;
     server_conn->kex_params.kem_params.kem = &s2n_bike_l1_r3;
     server_conn->secure.cipher_suite = &s2n_ecdhe_bike_rsa_with_aes_256_gcm_sha384;
-    server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
+    server_conn->handshake_params.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
     POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->kex_params.kem_params.private_key));
     POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.server_ecc_evp_params));

--- a/tests/fuzz/s2n_hybrid_ecdhe_kyber_r2_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_kyber_r2_fuzz_test.c
@@ -53,7 +53,7 @@ static int setup_connection(struct s2n_connection *server_conn)
     server_conn->kex_params.server_ecc_evp_params.evp_pkey = NULL;
     server_conn->kex_params.kem_params.kem = &s2n_kyber_512_r2;
     server_conn->secure.cipher_suite = &s2n_ecdhe_kyber_rsa_with_aes_256_gcm_sha384;
-    server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
+    server_conn->handshake_params.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
     POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->kex_params.kem_params.private_key));
     POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.server_ecc_evp_params));

--- a/tests/fuzz/s2n_hybrid_ecdhe_sike_r1_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_sike_r1_fuzz_test.c
@@ -53,7 +53,7 @@ static int setup_connection(struct s2n_connection *server_conn)
     server_conn->kex_params.server_ecc_evp_params.evp_pkey = NULL;
     server_conn->kex_params.kem_params.kem = &s2n_sike_p503_r1;
     server_conn->secure.cipher_suite = &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384;
-    server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
+    server_conn->handshake_params.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
     POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->kex_params.kem_params.private_key));
     POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.server_ecc_evp_params));

--- a/tests/fuzz/s2n_hybrid_ecdhe_sike_r3_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_sike_r3_fuzz_test.c
@@ -53,7 +53,7 @@ static int setup_connection(struct s2n_connection *server_conn)
     server_conn->kex_params.server_ecc_evp_params.evp_pkey = NULL;
     server_conn->kex_params.kem_params.kem = &s2n_sike_p434_r3;
     server_conn->secure.cipher_suite = &s2n_ecdhe_sike_rsa_with_aes_256_gcm_sha384;
-    server_conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
+    server_conn->handshake_params.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
 
     POSIX_GUARD(s2n_dup(&server_kem_params.private_key, &server_conn->kex_params.kem_params.private_key));
     POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.server_ecc_evp_params));

--- a/tests/testlib/s2n_pq_hybrid_test_utils.c
+++ b/tests/testlib/s2n_pq_hybrid_test_utils.c
@@ -64,7 +64,7 @@ static int setup_connection(struct s2n_connection *conn, const struct s2n_kem *k
     conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     conn->kex_params.kem_params.kem = kem;
     conn->secure.cipher_suite = cipher_suite;
-    conn->secure.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
+    conn->handshake_params.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
     POSIX_GUARD(s2n_connection_set_cipher_preferences(conn, cipher_pref_version));
     return S2N_SUCCESS;
 }
@@ -104,7 +104,7 @@ int s2n_test_hybrid_ecdhe_kem_with_kat(const struct s2n_kem *kem, struct s2n_cip
     POSIX_GUARD(s2n_connection_set_config(server_conn, server_config));
 
     POSIX_GUARD(s2n_choose_sig_scheme_from_peer_preference_list(server_conn, &server_conn->handshake_params.client_sig_hash_algs,
-            &server_conn->secure.conn_sig_scheme));
+            &server_conn->handshake_params.conn_sig_scheme));
 
     DEFER_CLEANUP(struct s2n_stuffer certificate_in = {0}, s2n_stuffer_free);
     POSIX_GUARD(s2n_stuffer_alloc(&certificate_in, S2N_MAX_TEST_PEM_SIZE));
@@ -119,7 +119,7 @@ int s2n_test_hybrid_ecdhe_kem_with_kat(const struct s2n_kem *kem, struct s2n_cip
     temp_blob.size = s2n_stuffer_data_available(&certificate_out);
     temp_blob.data = s2n_stuffer_raw_read(&certificate_out, temp_blob.size);
     s2n_pkey_type pkey_type = {0};
-    POSIX_GUARD(s2n_asn1der_to_public_key_and_type(&client_conn->secure.server_public_key, &pkey_type, &temp_blob));
+    POSIX_GUARD(s2n_asn1der_to_public_key_and_type(&client_conn->handshake_params.server_public_key, &pkey_type, &temp_blob));
 
     server_conn->handshake_params.our_chain_and_key = chain_and_key;
 

--- a/tests/testlib/s2n_pq_hybrid_test_utils.c
+++ b/tests/testlib/s2n_pq_hybrid_test_utils.c
@@ -185,7 +185,7 @@ int s2n_test_hybrid_ecdhe_kem_with_kat(const struct s2n_kem *kem, struct s2n_cip
 
     /* Part 4.1 verify results as best we can, the client and server should at least have the same master secret */
     /* Compare byte arrays for equality */
-    POSIX_ENSURE_EQ(memcmp(server_conn->secure.master_secret, client_conn->secure.master_secret, S2N_TLS_SECRET_LEN), 0);
+    POSIX_ENSURE_EQ(memcmp(server_conn->secrets.master_secret, client_conn->secrets.master_secret, S2N_TLS_SECRET_LEN), 0);
 
 #if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
     /* Part 4.1.1 if we're running in known answer mode check that both the client and server got the expected master secret
@@ -193,8 +193,8 @@ int s2n_test_hybrid_ecdhe_kem_with_kat(const struct s2n_kem *kem, struct s2n_cip
     uint8_t expected_master_secret[S2N_TLS_SECRET_LEN];
     POSIX_GUARD(ReadHex(kat_file, expected_master_secret, S2N_TLS_SECRET_LEN, "expected_master_secret = "));
     /* Compare byte arrays for equality */
-    POSIX_ENSURE_EQ(memcmp(expected_master_secret, client_conn->secure.master_secret, S2N_TLS_SECRET_LEN), 0);
-    POSIX_ENSURE_EQ(memcmp(expected_master_secret, server_conn->secure.master_secret, S2N_TLS_SECRET_LEN), 0);
+    POSIX_ENSURE_EQ(memcmp(expected_master_secret, client_conn->secrets.master_secret, S2N_TLS_SECRET_LEN), 0);
+    POSIX_ENSURE_EQ(memcmp(expected_master_secret, server_conn->secrets.master_secret, S2N_TLS_SECRET_LEN), 0);
 #endif
 
     POSIX_GUARD(s2n_cert_chain_and_key_free(chain_and_key));

--- a/tests/unit/s2n_auth_selection_test.c
+++ b/tests/unit/s2n_auth_selection_test.c
@@ -55,7 +55,7 @@ static int s2n_test_auth_combo(struct s2n_connection *conn,
     conn->secure.cipher_suite = cipher_suite;
 
     POSIX_GUARD(s2n_is_sig_scheme_valid_for_auth(conn, sig_scheme));
-    conn->secure.conn_sig_scheme.sig_alg = sig_scheme->sig_alg;
+    conn->handshake_params.conn_sig_scheme.sig_alg = sig_scheme->sig_alg;
 
     POSIX_GUARD(s2n_select_certs_for_server_auth(conn, &actual_cert_chain));
     POSIX_ENSURE_EQ(actual_cert_chain, expected_cert_chain);
@@ -305,38 +305,38 @@ int main(int argc, char **argv)
         /* Requested cert chain exists */
         s2n_connection_set_config(conn, all_certs_config);
 
-        conn->secure.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA;
+        conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA;
         EXPECT_SUCCESS(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_EQUAL(chosen_certs, rsa_cert_chain);
 
-        conn->secure.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_PSS;
+        conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_PSS;
         EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_EQUAL(chosen_certs, rsa_pss_cert_chain);
 
-        conn->secure.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_RSAE;
+        conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_RSAE;
         EXPECT_SUCCESS(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_EQUAL(chosen_certs, rsa_cert_chain);
 
-        conn->secure.conn_sig_scheme.sig_alg = S2N_SIGNATURE_ECDSA;
+        conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_ECDSA;
         EXPECT_SUCCESS(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_EQUAL(chosen_certs, ecdsa_cert_chain);
 
         /* Requested cert chain does NOT exist */
         s2n_connection_set_config(conn, no_certs_config);
 
-        conn->secure.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA;
+        conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA;
         EXPECT_FAILURE(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_NULL(chosen_certs);
 
-        conn->secure.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_PSS;
+        conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_PSS;
         EXPECT_FAILURE(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_NULL(chosen_certs);
 
-        conn->secure.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_RSAE;
+        conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_RSAE;
         EXPECT_FAILURE(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_NULL(chosen_certs);
 
-        conn->secure.conn_sig_scheme.sig_alg = S2N_SIGNATURE_ECDSA;
+        conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_ECDSA;
         EXPECT_FAILURE(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_NULL(chosen_certs);
 

--- a/tests/unit/s2n_client_auth_handshake_test.c
+++ b/tests/unit/s2n_client_auth_handshake_test.c
@@ -52,8 +52,8 @@ int s2n_test_client_auth_negotiation(struct s2n_config *server_config, struct s2
     client_conn->server_protocol_version = S2N_TLS13;
     client_conn->client_protocol_version = S2N_TLS13;
     client_conn->actual_protocol_version = S2N_TLS13;
-    client_conn->secure.conn_sig_scheme = s2n_ecdsa_secp256r1_sha256;
-    client_conn->secure.client_cert_sig_scheme = s2n_ecdsa_secp256r1_sha256;
+    client_conn->handshake_params.conn_sig_scheme = s2n_ecdsa_secp256r1_sha256;
+    client_conn->handshake_params.client_cert_sig_scheme = s2n_ecdsa_secp256r1_sha256;
     client_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
     if (!no_cert) {
         client_conn->handshake_params.our_chain_and_key = ecdsa_cert;
@@ -63,7 +63,7 @@ int s2n_test_client_auth_negotiation(struct s2n_config *server_config, struct s2
     server_conn->server_protocol_version = S2N_TLS13;
     server_conn->client_protocol_version = S2N_TLS13;
     server_conn->actual_protocol_version = S2N_TLS13;
-    server_conn->secure.conn_sig_scheme = s2n_ecdsa_secp256r1_sha256;
+    server_conn->handshake_params.conn_sig_scheme = s2n_ecdsa_secp256r1_sha256;
     server_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
     if (no_cert) {

--- a/tests/unit/s2n_client_cert_verify_test.c
+++ b/tests/unit/s2n_client_cert_verify_test.c
@@ -170,7 +170,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn);
 
         /* Set any signature scheme. Our test pkey methods ignore it. */
-        conn->secure.client_cert_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
+        conn->handshake_params.client_cert_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
 
         struct s2n_cert_chain_and_key *chain_and_key;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -448,7 +448,7 @@ int main(int argc, char **argv)
         server_conn->psk_params.chosen_psk = &chosen_psk;
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
 
-        EXPECT_EQUAL(server_conn->secure.conn_sig_scheme.iana_value, 0);
+        EXPECT_EQUAL(server_conn->handshake_params.conn_sig_scheme.iana_value, 0);
         EXPECT_NULL(server_conn->handshake_params.our_chain_and_key);
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));

--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -623,14 +623,14 @@ int main(int argc, char **argv)
     }
 
     /* Test s2n_hello_retry_validate raises a S2N_ERR_INVALID_HELLO_RETRY error when
-     * when conn->secure.server_random is not set to the correct hello retry random value
+     * when conn->secrets.server_random is not set to the correct hello retry random value
      * specified in the RFC: https://tools.ietf.org/html/rfc8446#section-4.1.3 */
     {
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         /* From RFC: https://tools.ietf.org/html/rfc8446#section-4.1.3 */
         const uint8_t not_hello_retry_request_random[S2N_TLS_RANDOM_DATA_LEN] = { 0 };
-        EXPECT_MEMCPY_SUCCESS(conn->secure.server_random, not_hello_retry_request_random,
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.server_random, not_hello_retry_request_random,
                               S2N_TLS_RANDOM_DATA_LEN);
 
         EXPECT_FAILURE_WITH_ERRNO(s2n_hello_retry_validate(conn), S2N_ERR_INVALID_HELLO_RETRY);

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -1111,10 +1111,10 @@ int main(int argc, char **argv)
 
         EXPECT_EQUAL(server_conn->secure.cipher_suite, &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha);
         EXPECT_EQUAL(client_conn->secure.cipher_suite, &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha);
-        EXPECT_EQUAL(server_conn->secure.conn_sig_scheme.sig_alg, S2N_SIGNATURE_ECDSA);
-        EXPECT_EQUAL(server_conn->secure.conn_sig_scheme.hash_alg, S2N_HASH_SHA1);
-        EXPECT_EQUAL(client_conn->secure.conn_sig_scheme.sig_alg, S2N_SIGNATURE_ECDSA);
-        EXPECT_EQUAL(client_conn->secure.conn_sig_scheme.hash_alg, S2N_HASH_SHA1);
+        EXPECT_EQUAL(server_conn->handshake_params.conn_sig_scheme.sig_alg, S2N_SIGNATURE_ECDSA);
+        EXPECT_EQUAL(server_conn->handshake_params.conn_sig_scheme.hash_alg, S2N_HASH_SHA1);
+        EXPECT_EQUAL(client_conn->handshake_params.conn_sig_scheme.sig_alg, S2N_SIGNATURE_ECDSA);
+        EXPECT_EQUAL(client_conn->handshake_params.conn_sig_scheme.hash_alg, S2N_HASH_SHA1);
 
         /* Free the data */
         EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_client_key_share_extension_pq_test.c
+++ b/tests/unit/s2n_client_key_share_extension_pq_test.c
@@ -361,7 +361,7 @@ int main() {
                                 conn->kex_params.client_kem_group_params[0].ecc_params.negotiated_curve;
 
                         /* Setup the client to have received a HelloRetryRequest */
-                        EXPECT_MEMCPY_SUCCESS(conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
+                        EXPECT_MEMCPY_SUCCESS(conn->secrets.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
                         EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(conn, S2N_TLS13));
                         EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(conn));
                         conn->early_data_state = S2N_EARLY_DATA_REJECTED;

--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -303,7 +303,7 @@ int main(int argc, char **argv)
             }
 
             /* Setup the client to have received a HelloRetryRequest */
-            EXPECT_MEMCPY_SUCCESS(conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
+            EXPECT_MEMCPY_SUCCESS(conn->secrets.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(conn, S2N_TLS13));
             EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(conn));
             conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
@@ -384,7 +384,7 @@ int main(int argc, char **argv)
             }
 
             /* Setup the client to have received a HelloRetryRequest with server negotiated curve as x25519 */
-            EXPECT_MEMCPY_SUCCESS(conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
+            EXPECT_MEMCPY_SUCCESS(conn->secrets.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(conn, S2N_TLS13));
             EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(conn));
             conn->kex_params.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_x25519;
@@ -436,7 +436,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(ecc_preferences);
 
             /* Setup the client to have received a HelloRetryRequest */
-            POSIX_CHECKED_MEMCPY(client_conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
+            POSIX_CHECKED_MEMCPY(client_conn->secrets.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(client_conn, S2N_TLS13));
             EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(client_conn));
             client_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
@@ -493,7 +493,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 0));
 
             /* Setup the client to have received a HelloRetryRequest */
-            EXPECT_MEMCPY_SUCCESS(conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
+            EXPECT_MEMCPY_SUCCESS(conn->secrets.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(conn, S2N_TLS13));
             EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(conn));
             conn->kex_params.server_ecc_evp_params.negotiated_curve = NULL;
@@ -538,7 +538,7 @@ int main(int argc, char **argv)
             }
 
             /* Setup the client to have received a HelloRetryRequest */
-            EXPECT_MEMCPY_SUCCESS(conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
+            EXPECT_MEMCPY_SUCCESS(conn->secrets.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(conn, S2N_TLS13));
             EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(conn));
             conn->early_data_state = S2N_EARLY_DATA_REJECTED;

--- a/tests/unit/s2n_client_signature_algorithms_extension_test.c
+++ b/tests/unit/s2n_client_signature_algorithms_extension_test.c
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_signature_algorithms_extension.recv(conn, &signature_algorithms_extension));
         EXPECT_EQUAL(conn->handshake_params.client_sig_hash_algs.len, sig_hash_algs.len);
         EXPECT_FAILURE(s2n_choose_sig_scheme_from_peer_preference_list(conn, &conn->handshake_params.client_sig_hash_algs,
-                                &conn->secure.conn_sig_scheme));
+                                &conn->handshake_params.conn_sig_scheme));
 
         EXPECT_SUCCESS(s2n_stuffer_free(&signature_algorithms_extension));
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -122,8 +122,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_signature_algorithms_extension.recv(conn, &signature_algorithms_extension));
         EXPECT_EQUAL(conn->handshake_params.client_sig_hash_algs.len, sig_hash_algs.len);
         EXPECT_SUCCESS(s2n_choose_sig_scheme_from_peer_preference_list(conn, &conn->handshake_params.client_sig_hash_algs,
-                                &conn->secure.conn_sig_scheme));
-        EXPECT_EQUAL(conn->secure.conn_sig_scheme.iana_value, TLS_SIGNATURE_SCHEME_RSA_PKCS1_SHA384);
+                                &conn->handshake_params.conn_sig_scheme));
+        EXPECT_EQUAL(conn->handshake_params.conn_sig_scheme.iana_value, TLS_SIGNATURE_SCHEME_RSA_PKCS1_SHA384);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&signature_algorithms_extension));
         EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
      */
     {
         /* Carefully consider any increases to this number. */
-        const uint16_t max_connection_size = 14328;
+        const uint16_t max_connection_size = 14100;
         const uint16_t min_connection_size = max_connection_size * 0.75;
 
         size_t connection_size = sizeof(struct s2n_connection);

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
      */
     {
         /* Carefully consider any increases to this number. */
-        const uint16_t max_connection_size = 14568;
+        const uint16_t max_connection_size = 14328;
         const uint16_t min_connection_size = max_connection_size * 0.75;
 
         size_t connection_size = sizeof(struct s2n_connection);
@@ -215,8 +215,8 @@ int main(int argc, char **argv)
                                                      S2N_TLS_HASH_NONE };
 
         for (size_t i = S2N_TLS_HASH_NONE; i <= UINT16_MAX; i++) {
-            conn->secure.client_cert_sig_scheme.hash_alg = i;
-            conn->secure.conn_sig_scheme.hash_alg = i;
+            conn->handshake_params.client_cert_sig_scheme.hash_alg = i;
+            conn->handshake_params.conn_sig_scheme.hash_alg = i;
             if (i <= S2N_HASH_SENTINEL) {
                 EXPECT_SUCCESS(s2n_connection_get_selected_client_cert_digest_algorithm(conn, &output));
                 EXPECT_EQUAL(expected_output[i], output);
@@ -262,8 +262,8 @@ int main(int argc, char **argv)
         };
 
         for (size_t i = 0; i <= UINT16_MAX; i++) {
-            conn->secure.client_cert_sig_scheme.sig_alg = i;
-            conn->secure.conn_sig_scheme.sig_alg = i;
+            conn->handshake_params.client_cert_sig_scheme.sig_alg = i;
+            conn->handshake_params.conn_sig_scheme.sig_alg = i;
 
             if (i < s2n_array_len(expected_output)) {
                 EXPECT_SUCCESS(s2n_connection_get_selected_client_cert_signature_algorithm(conn, &output));

--- a/tests/unit/s2n_fragmentation_coalescing_test.c
+++ b/tests/unit/s2n_fragmentation_coalescing_test.c
@@ -447,7 +447,7 @@ int main(int argc, char **argv)
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->secure.server_random, zero_to_thirty_one, 32), 0);
+    EXPECT_EQUAL(memcmp(conn->secrets.server_random, zero_to_thirty_one, 32), 0);
 
     /* Check that the server hello message was processed */
     EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
@@ -493,7 +493,7 @@ int main(int argc, char **argv)
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->secure.server_random, zero_to_thirty_one, 32), 0);
+    EXPECT_EQUAL(memcmp(conn->secrets.server_random, zero_to_thirty_one, 32), 0);
 
     /* Check that the server done message was processed */
     EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_HELLO_DONE);
@@ -539,7 +539,7 @@ int main(int argc, char **argv)
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->secure.server_random, zero_to_thirty_one, 32), 0);
+    EXPECT_EQUAL(memcmp(conn->secrets.server_random, zero_to_thirty_one, 32), 0);
 
     /* Check that the server hello message was processed */
     EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
@@ -585,7 +585,7 @@ int main(int argc, char **argv)
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
-    EXPECT_NOT_EQUAL(memcmp(conn->secure.server_random, zero_to_thirty_one, 32), 0);
+    EXPECT_NOT_EQUAL(memcmp(conn->secrets.server_random, zero_to_thirty_one, 32), 0);
 
     /* Check that the server hello message was not processed */
     EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_HELLO);
@@ -631,7 +631,7 @@ int main(int argc, char **argv)
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data failed */
-    EXPECT_NOT_EQUAL(memcmp(conn->secure.server_random, zero_to_thirty_one, 32), 0);
+    EXPECT_NOT_EQUAL(memcmp(conn->secrets.server_random, zero_to_thirty_one, 32), 0);
 
     /* Check that the server hello message was not processed */
     EXPECT_NOT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -190,7 +190,7 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
             EXPECT_STRING_EQUAL(s2n_connection_get_cipher(server_conn), expected_cipher->name);
 
             EXPECT_EQUAL(server_conn->handshake_params.our_chain_and_key, expected_cert_chain);
-            EXPECT_EQUAL(server_conn->secure.conn_sig_scheme.sig_alg, expected_sig_alg);
+            EXPECT_EQUAL(server_conn->handshake_params.conn_sig_scheme.sig_alg, expected_sig_alg);
 
             EXPECT_TRUE(IS_NEGOTIATED(server_conn));
             EXPECT_TRUE(IS_NEGOTIATED(client_conn));

--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -121,7 +121,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             server_conn->actual_protocol_version = S2N_TLS13;
             server_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            POSIX_CHECKED_MEMCPY(server_conn->secure.client_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(server_conn->secrets.client_app_secret, application_secret.data, application_secret.size);
 
             server_conn->secure.client_sequence_number[0] = 1; 
             /* Write the key update request to the correct stuffer */
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            POSIX_CHECKED_MEMCPY(client_conn->secure.server_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(client_conn->secrets.server_app_secret, application_secret.data, application_secret.size);
 
             client_conn->secure.server_sequence_number[0] = 1; 
             /* Write the key update request to the correct stuffer */
@@ -165,7 +165,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            POSIX_CHECKED_MEMCPY(client_conn->secure.client_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(client_conn->secrets.client_app_secret, application_secret.data, application_secret.size);
             uint8_t zeroed_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN] = {0};
 
             /* Setup io */
@@ -192,7 +192,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            POSIX_CHECKED_MEMCPY(client_conn->secure.client_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(client_conn->secrets.client_app_secret, application_secret.data, application_secret.size);
             uint8_t zeroed_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN] = {0};
 
             /* Setup io */
@@ -222,7 +222,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            POSIX_CHECKED_MEMCPY(client_conn->secure.client_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(client_conn->secrets.client_app_secret, application_secret.data, application_secret.size);
             uint8_t expected_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN] = {0};
 
             /* Setup io */

--- a/tests/unit/s2n_malformed_handshake_test.c
+++ b/tests/unit/s2n_malformed_handshake_test.c
@@ -284,7 +284,7 @@ int main(int argc, char **argv)
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->secure.server_random, zero_to_thirty_one, 32), 0);
+    EXPECT_EQUAL(memcmp(conn->secrets.server_random, zero_to_thirty_one, 32), 0);
 
     /* Check that the server hello message was processed .. we should be HELLO DONE */
     EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_HELLO_DONE);
@@ -333,7 +333,7 @@ int main(int argc, char **argv)
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->secure.server_random, zero_to_thirty_one, 32), 0);
+    EXPECT_EQUAL(memcmp(conn->secrets.server_random, zero_to_thirty_one, 32), 0);
 
     /* Check that the server hello message was not processed, we're stuck in SERVER_CERT */
     EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
@@ -382,7 +382,7 @@ int main(int argc, char **argv)
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->secure.server_random, zero_to_thirty_one, 32), 0);
+    EXPECT_EQUAL(memcmp(conn->secrets.server_random, zero_to_thirty_one, 32), 0);
 
     /* Check that the server hello message was not processed, we're stuck in SERVER_CERT */
     EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
@@ -431,7 +431,7 @@ int main(int argc, char **argv)
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->secure.server_random, zero_to_thirty_one, 32), 0);
+    EXPECT_EQUAL(memcmp(conn->secrets.server_random, zero_to_thirty_one, 32), 0);
 
     /* Check that the server hello message was not processed, we're stuck in SERVER_CERT */
     EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
@@ -480,7 +480,7 @@ int main(int argc, char **argv)
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->secure.server_random, zero_to_thirty_one, 32), 0);
+    EXPECT_EQUAL(memcmp(conn->secrets.server_random, zero_to_thirty_one, 32), 0);
 
     /* Check that the server hello message was not processed, we're stuck in SERVER_CERT */
     EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
@@ -529,7 +529,7 @@ int main(int argc, char **argv)
     EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
     /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->secure.server_random, zero_to_thirty_one, 32), 0);
+    EXPECT_EQUAL(memcmp(conn->secrets.server_random, zero_to_thirty_one, 32), 0);
 
     /* Check that the server hello message was not processed, we're stuck in SERVER_CERT */
     EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -306,7 +306,7 @@ int main(int argc, char **argv)
 
         struct s2n_blob blob = { 0 };
         struct s2n_stuffer stuffer = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
+        EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secrets.master_secret, S2N_TLS_SECRET_LEN));
         EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &blob));
         EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
         conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
@@ -648,7 +648,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS12);
             EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_rsa_with_aes_128_gcm_sha256);
 
-            EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, conn->secure.master_secret, S2N_TLS_SECRET_LEN);
+            EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, conn->secrets.master_secret, S2N_TLS_SECRET_LEN);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
@@ -1095,7 +1095,7 @@ int main(int argc, char **argv)
 
             struct s2n_blob secret = { 0 };
             struct s2n_stuffer secret_stuffer = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&secret, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
+            EXPECT_SUCCESS(s2n_blob_init(&secret, conn->secrets.master_secret, S2N_TLS_SECRET_LEN));
             EXPECT_SUCCESS(s2n_stuffer_init(&secret_stuffer, &secret));
             EXPECT_SUCCESS(s2n_stuffer_write_bytes(&secret_stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
             conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
@@ -1104,13 +1104,13 @@ int main(int argc, char **argv)
             EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&conn->client_ticket_to_decrypt), 0);
 
             /* Wiping the master secret to prove that the decryption function actually writes the master secret */
-            memset(conn->secure.master_secret, 0, test_master_secret.size);
+            memset(conn->secrets.master_secret, 0, test_master_secret.size);
 
             EXPECT_SUCCESS(s2n_decrypt_session_ticket(conn, &conn->client_ticket_to_decrypt));
             EXPECT_EQUAL(s2n_stuffer_data_available(&conn->client_ticket_to_decrypt), 0);
 
             /* Check decryption was successful by comparing master key */
-            EXPECT_BYTEARRAY_EQUAL(conn->secure.master_secret, test_master_secret.data, test_master_secret.size);
+            EXPECT_BYTEARRAY_EQUAL(conn->secrets.master_secret, test_master_secret.data, test_master_secret.size);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
             EXPECT_SUCCESS(s2n_config_free(config));

--- a/tests/unit/s2n_send_key_update_test.c
+++ b/tests/unit/s2n_send_key_update_test.c
@@ -58,8 +58,8 @@ static int s2n_test_init_encryption(struct s2n_connection *conn)
     POSIX_GUARD(cipher_suite->record_alg->cipher->set_decryption_key(client_session_key, &key));
 
     /* Initialized secrets */
-    POSIX_CHECKED_MEMCPY(conn->secure.server_app_secret, application_secret.data, application_secret.size);
-    POSIX_CHECKED_MEMCPY(conn->secure.client_app_secret, application_secret.data, application_secret.size);
+    POSIX_CHECKED_MEMCPY(conn->secrets.server_app_secret, application_secret.data, application_secret.size);
+    POSIX_CHECKED_MEMCPY(conn->secrets.client_app_secret, application_secret.data, application_secret.size);
  
     /* Copy iv bytes from input data */
     POSIX_CHECKED_MEMCPY(server_implicit_iv, iv.data, iv.size);
@@ -109,14 +109,14 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_send(server_conn, message, sizeof(message), &blocked));
         
         /* Verify key update happened */
-        EXPECT_BYTEARRAY_NOT_EQUAL(server_conn->secure.server_app_secret, client_conn->secure.server_app_secret, S2N_TLS13_SECRET_MAX_LEN);
+        EXPECT_BYTEARRAY_NOT_EQUAL(server_conn->secrets.server_app_secret, client_conn->secrets.server_app_secret, S2N_TLS13_SECRET_MAX_LEN);
         EXPECT_BYTEARRAY_EQUAL(server_conn->secure.server_sequence_number, zero_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN);
         
         /* Receive keyupdate message */
         uint8_t data[100];
         EXPECT_SUCCESS(s2n_recv(client_conn, data, sizeof(message), &blocked));
         EXPECT_BYTEARRAY_EQUAL(data, message, sizeof(message));
-        EXPECT_BYTEARRAY_EQUAL(client_conn->secure.server_app_secret, server_conn->secure.server_app_secret, S2N_TLS13_SECRET_MAX_LEN);
+        EXPECT_BYTEARRAY_EQUAL(client_conn->secrets.server_app_secret, server_conn->secrets.server_app_secret, S2N_TLS13_SECRET_MAX_LEN);
         EXPECT_BYTEARRAY_EQUAL(client_conn->secure.server_sequence_number, zero_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN);
         
         EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_server_hello_retry_test.c
+++ b/tests/unit/s2n_server_hello_retry_test.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
 
         EXPECT_NOT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
         EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.evp_pkey);
-        EXPECT_TRUE(memcmp(server_conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN) == 0);
+        EXPECT_TRUE(memcmp(server_conn->secrets.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN) == 0);
 
         EXPECT_SUCCESS(s2n_config_free(server_config));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -219,7 +219,7 @@ int main(int argc, char **argv)
 
         struct s2n_stuffer* extension_stuffer = &server_conn->handshake.io;
 
-        POSIX_CHECKED_MEMCPY(server_conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
+        POSIX_CHECKED_MEMCPY(server_conn->secrets.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
         EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
         server_conn->kex_params.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
         server_conn->kex_params.client_ecc_evp_params[0].negotiated_curve = s2n_all_supported_curves_list[0];
@@ -235,7 +235,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params[0]));
 
         /* Setup the client to receive a HelloRetryRequest */
-        POSIX_CHECKED_MEMCPY(client_conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
+        POSIX_CHECKED_MEMCPY(client_conn->secrets.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
         EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(client_conn, S2N_TLS13));
 
         /* Setup the handshake type and message number to simulate a condition where a HelloRetry should be sent */

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -477,7 +477,7 @@ int main(int argc, char **argv)
 
             server_conn->kex_params.server_ecc_evp_params.negotiated_curve = s2n_all_supported_curves_list[0];
             EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(server_conn));
-            EXPECT_MEMCPY_SUCCESS(server_conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
+            EXPECT_MEMCPY_SUCCESS(server_conn->secrets.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
             EXPECT_SUCCESS(s2n_server_key_share_extension.send(server_conn, key_share_extension));
 
             const struct s2n_ecc_preferences *ecc_preferences = NULL;
@@ -492,7 +492,7 @@ int main(int argc, char **argv)
             }
 
             /* Setup the client to have received a HelloRetryRequest */
-            EXPECT_MEMCPY_SUCCESS(client_conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
+            EXPECT_MEMCPY_SUCCESS(client_conn->secrets.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(client_conn, S2N_TLS13));
             EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(client_conn));
             EXPECT_SUCCESS(s2n_set_hello_retry_required(client_conn));

--- a/tests/unit/s2n_ssl_prf_test.c
+++ b/tests/unit/s2n_ssl_prf_test.c
@@ -69,28 +69,28 @@ int main(int argc, char **argv)
     for (int i = 0; i < 48; i++) {
         uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&premaster_secret_in, &c));
-        conn->secure.rsa_premaster_secret[i] = c;
+        conn->secrets.rsa_premaster_secret[i] = c;
     }
     for (int i = 0; i < 32; i++) {
         uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&client_random_in, &c));
-        conn->secure.client_random[i] = c;
+        conn->secrets.client_random[i] = c;
     }
     for (int i = 0; i < 32; i++) {
         uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&server_random_in, &c));
-        conn->secure.server_random[i] = c;
+        conn->secrets.server_random[i] = c;
     }
 
     /* Set the protocol version to sslv3 */
     conn->actual_protocol_version = S2N_SSLv3;
-    pms.data = conn->secure.rsa_premaster_secret;
-    pms.size = sizeof(conn->secure.rsa_premaster_secret);
+    pms.data = conn->secrets.rsa_premaster_secret;
+    pms.size = sizeof(conn->secrets.rsa_premaster_secret);
     EXPECT_SUCCESS(s2n_tls_prf_master_secret(conn, &pms));
 
     /* Convert the master secret to hex */
     for (int i = 0; i < 48; i++) {
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8_hex(&master_secret_hex_out, conn->secure.master_secret[i]));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8_hex(&master_secret_hex_out, conn->secrets.master_secret[i]));
     }
 
     EXPECT_EQUAL(memcmp(master_secret_hex_pad, master_secret_hex_in, sizeof(master_secret_hex_pad)), 0);

--- a/tests/unit/s2n_tls13_cert_verify_test.c
+++ b/tests/unit/s2n_tls13_cert_verify_test.c
@@ -79,8 +79,8 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
         EXPECT_SUCCESS(s2n_connection_set_config(sending_conn, config));
         sending_conn->handshake_params.our_chain_and_key = cert_chain;
-        sending_conn->secure.conn_sig_scheme = sig_scheme;
-        sending_conn->secure.client_cert_sig_scheme = sig_scheme;
+        sending_conn->handshake_params.conn_sig_scheme = sig_scheme;
+        sending_conn->handshake_params.client_cert_sig_scheme = sig_scheme;
         sending_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
         EXPECT_SUCCESS(s2n_connection_set_config(verifying_conn, config));
@@ -94,11 +94,11 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         uint32_t available_size = s2n_stuffer_data_available(&certificate_out);
         EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
         if (verifying_conn->mode == S2N_CLIENT) {
-            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->secure.server_public_key, &pkey_type, &b));
-            EXPECT_SUCCESS(s2n_pkey_match(&verifying_conn->secure.server_public_key, sending_conn->handshake_params.our_chain_and_key->private_key));
+            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->handshake_params.server_public_key, &pkey_type, &b));
+            EXPECT_SUCCESS(s2n_pkey_match(&verifying_conn->handshake_params.server_public_key, sending_conn->handshake_params.our_chain_and_key->private_key));
         } else {
-            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->secure.client_public_key, &pkey_type, &b));
-            EXPECT_SUCCESS(s2n_pkey_match(&verifying_conn->secure.client_public_key, sending_conn->handshake_params.our_chain_and_key->private_key));
+            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->handshake_params.client_public_key, &pkey_type, &b));
+            EXPECT_SUCCESS(s2n_pkey_match(&verifying_conn->handshake_params.client_public_key, sending_conn->handshake_params.our_chain_and_key->private_key));
         }
 
         /* Hash initialization */
@@ -160,8 +160,8 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
         EXPECT_SUCCESS(s2n_connection_set_config(verifying_conn, config));
         verifying_conn->handshake_params.our_chain_and_key = cert_chain;
-        verifying_conn->secure.conn_sig_scheme = sig_scheme;
-        verifying_conn->secure.client_cert_sig_scheme = sig_scheme;
+        verifying_conn->handshake_params.conn_sig_scheme = sig_scheme;
+        verifying_conn->handshake_params.client_cert_sig_scheme = sig_scheme;
         verifying_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
         EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
@@ -171,11 +171,11 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         uint32_t available_size = s2n_stuffer_data_available(&certificate_out);
         EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
         if (verifying_conn->mode == S2N_CLIENT) {
-            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->secure.server_public_key, &pkey_type, &b));
-            EXPECT_SUCCESS(s2n_pkey_match(&verifying_conn->secure.server_public_key, verifying_conn->handshake_params.our_chain_and_key->private_key));
+            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->handshake_params.server_public_key, &pkey_type, &b));
+            EXPECT_SUCCESS(s2n_pkey_match(&verifying_conn->handshake_params.server_public_key, verifying_conn->handshake_params.our_chain_and_key->private_key));
         } else {
-            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->secure.client_public_key, &pkey_type, &b));
-            EXPECT_SUCCESS(s2n_pkey_match(&verifying_conn->secure.client_public_key, verifying_conn->handshake_params.our_chain_and_key->private_key));
+            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->handshake_params.client_public_key, &pkey_type, &b));
+            EXPECT_SUCCESS(s2n_pkey_match(&verifying_conn->handshake_params.client_public_key, verifying_conn->handshake_params.our_chain_and_key->private_key));
         }
         /* Initialize send hash with hello */
         EXPECT_SUCCESS(s2n_hash_init(&verifying_conn->handshake.sha256, S2N_HASH_SHA256));
@@ -194,7 +194,7 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
 
         EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_cert_verify_recv(verifying_conn), S2N_ERR_VERIFY_SIGNATURE);
 
-        EXPECT_SUCCESS(s2n_pkey_free(&verifying_conn->secure.client_public_key));
+        EXPECT_SUCCESS(s2n_pkey_free(&verifying_conn->handshake_params.client_public_key));
 
         /* Clean up */
         free(cert_chain_pem);
@@ -228,8 +228,8 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
         EXPECT_SUCCESS(s2n_connection_set_config(verifying_conn, config));
         verifying_conn->handshake_params.our_chain_and_key = cert_chain;
-        verifying_conn->secure.conn_sig_scheme = sig_scheme;
-        verifying_conn->secure.client_cert_sig_scheme = sig_scheme;
+        verifying_conn->handshake_params.conn_sig_scheme = sig_scheme;
+        verifying_conn->handshake_params.client_cert_sig_scheme = sig_scheme;
         verifying_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
         EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
@@ -239,9 +239,9 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         uint32_t available_size = s2n_stuffer_data_available(&certificate_out);
         EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
         if (verifying_conn->mode == S2N_CLIENT) {
-            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->secure.server_public_key, &pkey_type, &b));
+            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->handshake_params.server_public_key, &pkey_type, &b));
         } else {
-            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->secure.client_public_key, &pkey_type, &b));
+            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->handshake_params.client_public_key, &pkey_type, &b));
         }
 
         /* Initialize send hash with hello */
@@ -261,9 +261,9 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
 
         /* Clean up */
         if (verifying_conn->mode == S2N_CLIENT) {
-            EXPECT_SUCCESS(s2n_pkey_free(&verifying_conn->secure.server_public_key));
+            EXPECT_SUCCESS(s2n_pkey_free(&verifying_conn->handshake_params.server_public_key));
         } else {
-            EXPECT_SUCCESS(s2n_pkey_free(&verifying_conn->secure.client_public_key));
+            EXPECT_SUCCESS(s2n_pkey_free(&verifying_conn->handshake_params.client_public_key));
         }
 
         free(cert_chain_pem);
@@ -298,8 +298,8 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
         EXPECT_SUCCESS(s2n_connection_set_config(verifying_conn, config));
         verifying_conn->handshake_params.our_chain_and_key = cert_chain;
-        verifying_conn->secure.conn_sig_scheme = sig_scheme;
-        verifying_conn->secure.client_cert_sig_scheme = sig_scheme;
+        verifying_conn->handshake_params.conn_sig_scheme = sig_scheme;
+        verifying_conn->handshake_params.client_cert_sig_scheme = sig_scheme;
         verifying_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
         EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
@@ -310,9 +310,9 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         uint32_t available_size = s2n_stuffer_data_available(&certificate_out);
         EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
         if (verifying_conn->mode == S2N_CLIENT) {
-            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->secure.server_public_key, &pkey_type, &b));
+            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->handshake_params.server_public_key, &pkey_type, &b));
         } else {
-            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->secure.client_public_key, &pkey_type, &b));
+            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&verifying_conn->handshake_params.client_public_key, &pkey_type, &b));
         }
 
         /* Hash initialization */
@@ -327,16 +327,16 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         EXPECT_SUCCESS(s2n_hash_update(&verifying_conn->handshake.sha256, hello, strlen((char *)hello)));
 
         /* In this case it doesn't matter if we use conn_sig_scheme or client_cert_sig_scheme as they are currently equal */
-        verifying_conn->secure.conn_sig_scheme.hash_alg = S2N_HASH_SHA1;
-        EXPECT_FAILURE(s2n_tls13_cert_read_and_verify_signature(verifying_conn, &verifying_conn->secure.conn_sig_scheme));
+        verifying_conn->handshake_params.conn_sig_scheme.hash_alg = S2N_HASH_SHA1;
+        EXPECT_FAILURE(s2n_tls13_cert_read_and_verify_signature(verifying_conn, &verifying_conn->handshake_params.conn_sig_scheme));
 
         /* send and receive with mismatched signature algs */
-        verifying_conn->secure.conn_sig_scheme.hash_alg = S2N_HASH_SHA256;
-        verifying_conn->secure.conn_sig_scheme.sig_alg = S2N_SIGNATURE_ECDSA;
-        verifying_conn->secure.conn_sig_scheme.iana_value = 0xFFFF;
-        verifying_conn->secure.client_cert_sig_scheme.hash_alg = S2N_HASH_SHA256;
-        verifying_conn->secure.client_cert_sig_scheme.sig_alg = S2N_SIGNATURE_ECDSA;
-        verifying_conn->secure.client_cert_sig_scheme.iana_value = 0xFFFF;
+        verifying_conn->handshake_params.conn_sig_scheme.hash_alg = S2N_HASH_SHA256;
+        verifying_conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_ECDSA;
+        verifying_conn->handshake_params.conn_sig_scheme.iana_value = 0xFFFF;
+        verifying_conn->handshake_params.client_cert_sig_scheme.hash_alg = S2N_HASH_SHA256;
+        verifying_conn->handshake_params.client_cert_sig_scheme.sig_alg = S2N_SIGNATURE_ECDSA;
+        verifying_conn->handshake_params.client_cert_sig_scheme.iana_value = 0xFFFF;
 
         EXPECT_SUCCESS(s2n_hash_init(&verifying_conn->handshake.sha256, S2N_HASH_SHA256));
         EXPECT_SUCCESS(s2n_hash_update(&verifying_conn->handshake.sha256, hello, strlen((char *)hello)));
@@ -350,9 +350,9 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
 
         /* Clean up */
         if (verifying_conn->mode == S2N_CLIENT) {
-            EXPECT_SUCCESS(s2n_pkey_free(&verifying_conn->secure.server_public_key));
+            EXPECT_SUCCESS(s2n_pkey_free(&verifying_conn->handshake_params.server_public_key));
         } else {
-            EXPECT_SUCCESS(s2n_pkey_free(&verifying_conn->secure.client_public_key));
+            EXPECT_SUCCESS(s2n_pkey_free(&verifying_conn->handshake_params.client_public_key));
         }
 
         free(cert_chain_pem);

--- a/tests/unit/s2n_tls13_handshake_early_data_test.c
+++ b/tests/unit/s2n_tls13_handshake_early_data_test.c
@@ -555,7 +555,7 @@ int main()
             EXPECT_SUCCESS(s2n_tls13_handle_secrets(client_conn));
 
             /* Check early secret secret set correctly */
-            EXPECT_BYTEARRAY_EQUAL(client_conn->secure.rsa_premaster_secret, early_secret.data, early_secret.size);
+            EXPECT_BYTEARRAY_EQUAL(client_conn->secrets.rsa_premaster_secret, early_secret.data, early_secret.size);
 
             /* Check IV calculated correctly */
             EXPECT_BYTEARRAY_EQUAL(client_conn->secure.client_implicit_iv, iv.data, iv.size);

--- a/tests/unit/s2n_tls_hybrid_prf_test.c
+++ b/tests/unit/s2n_tls_hybrid_prf_test.c
@@ -100,15 +100,15 @@ int main(int argc, char **argv)
         s2n_stuffer_write(&combined_stuffer, &classic_pms);
         s2n_stuffer_write(&combined_stuffer, &kem_pms);
 
-        EXPECT_MEMCPY_SUCCESS(conn->secure.client_random, client_random, CLIENT_RANDOM_LENGTH);
-        EXPECT_MEMCPY_SUCCESS(conn->secure.server_random, server_random, SERVER_RANDOM_LENGTH);
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.client_random, client_random, CLIENT_RANDOM_LENGTH);
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.server_random, server_random, SERVER_RANDOM_LENGTH);
 
         EXPECT_SUCCESS(s2n_alloc(&conn->kex_params.client_key_exchange_message, client_key_exchange_message_length));
 
         EXPECT_MEMCPY_SUCCESS(conn->kex_params.client_key_exchange_message.data, client_key_exchange_message, client_key_exchange_message_length);
 
         EXPECT_SUCCESS(s2n_hybrid_prf_master_secret(conn, &combined_pms));
-        EXPECT_BYTEARRAY_EQUAL(expected_master_secret, conn->secure.master_secret, S2N_TLS_SECRET_LEN);
+        EXPECT_BYTEARRAY_EQUAL(expected_master_secret, conn->secrets.master_secret, S2N_TLS_SECRET_LEN);
         EXPECT_SUCCESS(s2n_free(&conn->kex_params.client_key_exchange_message));
         EXPECT_SUCCESS(s2n_connection_free(conn));
 

--- a/tests/unit/s2n_tls_prf_test.c
+++ b/tests/unit/s2n_tls_prf_test.c
@@ -67,26 +67,26 @@ int main(int argc, char **argv)
     for (int i = 0; i < 48; i++) {
         uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&premaster_secret_in, &c));
-        conn->secure.rsa_premaster_secret[i] = c;
+        conn->secrets.rsa_premaster_secret[i] = c;
     }
     for (int i = 0; i < 32; i++) {
         uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&client_random_in, &c));
-        conn->secure.client_random[i] = c;
+        conn->secrets.client_random[i] = c;
     }
     for (int i = 0; i < 32; i++) {
         uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&server_random_in, &c));
-        conn->secure.server_random[i] = c;
+        conn->secrets.server_random[i] = c;
     }
 
-    pms.data = conn->secure.rsa_premaster_secret;
-    pms.size = sizeof(conn->secure.rsa_premaster_secret);
+    pms.data = conn->secrets.rsa_premaster_secret;
+    pms.size = sizeof(conn->secrets.rsa_premaster_secret);
     EXPECT_SUCCESS(s2n_tls_prf_master_secret(conn, &pms));
 
     /* Convert the master secret to hex */
     for (int i = 0; i < 48; i++) {
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8_hex(&master_secret_hex_out, conn->secure.master_secret[i]));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8_hex(&master_secret_hex_out, conn->secrets.master_secret[i]));
     }
 
     EXPECT_EQUAL(memcmp(master_secret_hex_pad, master_secret_hex_in, sizeof(master_secret_hex_pad)), 0);

--- a/tls/s2n_auth_selection.c
+++ b/tls/s2n_auth_selection.c
@@ -222,7 +222,7 @@ int s2n_select_certs_for_server_auth(struct s2n_connection *conn, struct s2n_cer
     POSIX_ENSURE_REF(conn);
 
     s2n_pkey_type cert_type;
-    POSIX_GUARD(s2n_get_cert_type_for_sig_alg(conn->secure.conn_sig_scheme.sig_alg, &cert_type));
+    POSIX_GUARD(s2n_get_cert_type_for_sig_alg(conn->handshake_params.conn_sig_scheme.sig_alg, &cert_type));
 
     *chosen_certs = s2n_get_compatible_cert_chain_and_key(conn, cert_type);
     S2N_ERROR_IF(*chosen_certs == NULL, S2N_ERR_CERT_TYPE_UNSUPPORTED);

--- a/tls/s2n_client_cert.c
+++ b/tls/s2n_client_cert.c
@@ -61,12 +61,12 @@ int s2n_client_cert_recv(struct s2n_connection *conn)
                                                  client_cert_chain.data, client_cert_chain.size,
                                                         &pkey_type, &public_key) != S2N_CERT_OK, S2N_ERR_CERT_UNTRUSTED);
 
-    conn->secure.client_cert_pkey_type = pkey_type;
+    conn->handshake_params.client_cert_pkey_type = pkey_type;
     POSIX_GUARD(s2n_pkey_setup_for_type(&public_key, pkey_type));
     
     POSIX_GUARD(s2n_pkey_check_key_exists(&public_key));
-    POSIX_GUARD(s2n_dup(&client_cert_chain, &conn->secure.client_cert_chain));
-    conn->secure.client_public_key = public_key;
+    POSIX_GUARD(s2n_dup(&client_cert_chain, &conn->handshake_params.client_cert_chain));
+    conn->handshake_params.client_public_key = public_key;
     
     return 0;
 }

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -51,7 +51,7 @@ int s2n_client_cert_verify_recv(struct s2n_connection *conn)
     POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &hash_state));
 
     /* Verify the signature */
-    POSIX_GUARD(s2n_pkey_verify(&conn->secure.client_public_key, chosen_sig_scheme.sig_alg, &conn->hash_workspace, &signature));
+    POSIX_GUARD(s2n_pkey_verify(&conn->handshake_params.client_public_key, chosen_sig_scheme.sig_alg, &conn->hash_workspace, &signature));
 
     /* Client certificate has been verified. Minimize required handshake hash algs */
     POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));
@@ -67,8 +67,8 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
     struct s2n_signature_scheme chosen_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
 
     if (conn->actual_protocol_version >= S2N_TLS12) {
-        chosen_sig_scheme =  conn->secure.client_cert_sig_scheme;
-        POSIX_GUARD(s2n_stuffer_write_uint16(out, conn->secure.client_cert_sig_scheme.iana_value));
+        chosen_sig_scheme =  conn->handshake_params.client_cert_sig_scheme;
+        POSIX_GUARD(s2n_stuffer_write_uint16(out, conn->handshake_params.client_cert_sig_scheme.iana_value));
     }
 
     /* Use a copy of the hash state since the verify digest computation may modify the running hash state we need later. */

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -208,7 +208,7 @@ static int s2n_parse_client_hello(struct s2n_connection *conn)
     uint8_t client_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
 
     POSIX_GUARD(s2n_stuffer_read_bytes(in, client_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
-    POSIX_GUARD(s2n_stuffer_erase_and_read_bytes(in, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_stuffer_erase_and_read_bytes(in, conn->secrets.client_random, S2N_TLS_RANDOM_DATA_LEN));
 
     /* Protocol version in the ClientHello is fixed at 0x0303(TLS 1.2) for
      * future versions of TLS. Therefore, we will negotiate down if a client sends
@@ -396,7 +396,7 @@ int s2n_client_hello_send(struct s2n_connection *conn)
     uint8_t client_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN] = {0};
 
     struct s2n_blob b = {0};
-    POSIX_GUARD(s2n_blob_init(&b, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_blob_init(&b, conn->secrets.client_random, S2N_TLS_RANDOM_DATA_LEN));
     /* Create the client random data */
     POSIX_GUARD(s2n_stuffer_init(&client_random, &b));
 
@@ -509,7 +509,7 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
     }
 
     struct s2n_blob b = {0};
-    POSIX_GUARD(s2n_blob_init(&b, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_blob_init(&b, conn->secrets.client_random, S2N_TLS_RANDOM_DATA_LEN));
 
     b.data += S2N_TLS_RANDOM_DATA_LEN - challenge_length;
     b.size -= S2N_TLS_RANDOM_DATA_LEN - challenge_length;

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -312,7 +312,7 @@ int s2n_process_client_hello(struct s2n_connection *conn)
     /* And set the signature and hash algorithm used for key exchange signatures */
     POSIX_GUARD(s2n_choose_sig_scheme_from_peer_preference_list(conn,
         &conn->handshake_params.client_sig_hash_algs,
-        &conn->secure.conn_sig_scheme));
+        &conn->handshake_params.conn_sig_scheme));
 
     /* And finally, set the certs specified by the final auth + sig_alg combo. */
     POSIX_GUARD(s2n_select_certs_for_server_auth(conn, &conn->handshake_params.our_chain_and_key));
@@ -497,7 +497,7 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
     POSIX_GUARD(s2n_conn_find_name_matching_certs(conn));
 
     POSIX_GUARD(s2n_set_cipher_as_sslv2_server(conn, client_hello->cipher_suites.data, client_hello->cipher_suites.size / S2N_SSLv2_CIPHER_SUITE_LEN));
-    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &conn->secure.conn_sig_scheme));
+    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &conn->handshake_params.conn_sig_scheme));
     POSIX_GUARD(s2n_select_certs_for_server_auth(conn, &conn->handshake_params.our_chain_and_key));
 
     S2N_ERROR_IF(session_id_length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -264,7 +264,7 @@ int s2n_rsa_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared
     POSIX_CHECKED_MEMCPY(conn->secure.rsa_premaster_secret, client_hello_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN);
 
     uint32_t encrypted_size = 0;
-    POSIX_GUARD_RESULT(s2n_pkey_size(&conn->secure.server_public_key, &encrypted_size));
+    POSIX_GUARD_RESULT(s2n_pkey_size(&conn->handshake_params.server_public_key, &encrypted_size));
     S2N_ERROR_IF(encrypted_size > 0xffff, S2N_ERR_SIZE_MISMATCH);
 
     if (conn->actual_protocol_version > S2N_SSLv3) {
@@ -277,10 +277,10 @@ int s2n_rsa_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared
     POSIX_ENSURE_REF(encrypted.data);
 
     /* Encrypt the secret and send it on */
-    POSIX_GUARD(s2n_pkey_encrypt(&conn->secure.server_public_key, shared_key, &encrypted));
+    POSIX_GUARD(s2n_pkey_encrypt(&conn->handshake_params.server_public_key, shared_key, &encrypted));
 
     /* We don't need the key any more, so free it */
-    POSIX_GUARD(s2n_pkey_free(&conn->secure.server_public_key));
+    POSIX_GUARD(s2n_pkey_free(&conn->handshake_params.server_public_key));
     return 0;
 }
 

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -103,7 +103,7 @@ int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared
 {
     /* Set shared_key before async guard to pass the proper shared_key to the caller upon async completion */
     POSIX_ENSURE_REF(shared_key);
-    shared_key->data = conn->secure.rsa_premaster_secret;
+    shared_key->data = conn->secrets.rsa_premaster_secret;
     shared_key->size = S2N_TLS_SECRET_LEN;
 
     S2N_ASYNC_PKEY_GUARD(conn);
@@ -135,8 +135,8 @@ int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared
 
     /* First: use a random pre-master secret */
     POSIX_GUARD_RESULT(s2n_get_private_random_data(shared_key));
-    conn->secure.rsa_premaster_secret[0] = client_hello_protocol_version[0];
-    conn->secure.rsa_premaster_secret[1] = client_hello_protocol_version[1];
+    conn->secrets.rsa_premaster_secret[0] = client_hello_protocol_version[0];
+    conn->secrets.rsa_premaster_secret[1] = client_hello_protocol_version[1];
 
     S2N_ASYNC_PKEY_DECRYPT(conn, &encrypted, shared_key, s2n_rsa_client_key_recv_complete);
 }
@@ -146,9 +146,9 @@ int s2n_rsa_client_key_recv_complete(struct s2n_connection *conn, bool rsa_faile
     S2N_ERROR_IF(decrypted->size != S2N_TLS_SECRET_LEN, S2N_ERR_SIZE_MISMATCH);
 
     /* Avoid copying the same buffer for the case where async pkey is not used */
-    if (conn->secure.rsa_premaster_secret != decrypted->data) {
+    if (conn->secrets.rsa_premaster_secret != decrypted->data) {
         /* Copy (maybe) decrypted data into shared key */
-        POSIX_CHECKED_MEMCPY(conn->secure.rsa_premaster_secret, decrypted->data, S2N_TLS_SECRET_LEN);
+        POSIX_CHECKED_MEMCPY(conn->secrets.rsa_premaster_secret, decrypted->data, S2N_TLS_SECRET_LEN);
     }
 
     /* Get client hello protocol version for comparison with decrypted data */
@@ -161,7 +161,7 @@ int s2n_rsa_client_key_recv_complete(struct s2n_connection *conn, bool rsa_faile
 
     /* Set rsa_failed to true, if it isn't already, if the protocol version isn't what we expect */
     conn->handshake.rsa_failed |= !s2n_constant_time_equals(client_hello_protocol_version,
-            conn->secure.rsa_premaster_secret, S2N_TLS_PROTOCOL_VERSION_LEN);
+            conn->secrets.rsa_premaster_secret, S2N_TLS_PROTOCOL_VERSION_LEN);
 
     return 0;
 }
@@ -252,7 +252,7 @@ int s2n_rsa_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared
     client_hello_protocol_version[0] = legacy_client_hello_protocol_version / 10;
     client_hello_protocol_version[1] = legacy_client_hello_protocol_version % 10;
 
-    shared_key->data = conn->secure.rsa_premaster_secret;
+    shared_key->data = conn->secrets.rsa_premaster_secret;
     shared_key->size = S2N_TLS_SECRET_LEN;
 
     POSIX_GUARD_RESULT(s2n_get_private_random_data(shared_key));
@@ -261,7 +261,7 @@ int s2n_rsa_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared
      * The latest version supported by client (as seen from the the client hello version) are <= TLS1.2
      * for all clients, because TLS 1.3 clients freezes the TLS1.2 legacy version in client hello.
      */
-    POSIX_CHECKED_MEMCPY(conn->secure.rsa_premaster_secret, client_hello_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN);
+    POSIX_CHECKED_MEMCPY(conn->secrets.rsa_premaster_secret, client_hello_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN);
 
     uint32_t encrypted_size = 0;
     POSIX_GUARD_RESULT(s2n_pkey_size(&conn->handshake_params.server_public_key, &encrypted_size));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -283,15 +283,15 @@ static int s2n_connection_wipe_keys(struct s2n_connection *conn)
 
     /* Free any server key received (we may not have completed a
      * handshake, so this may not have been free'd yet) */
-    POSIX_GUARD(s2n_pkey_free(&conn->secure.server_public_key));
-    POSIX_GUARD(s2n_pkey_zero_init(&conn->secure.server_public_key));
-    POSIX_GUARD(s2n_pkey_free(&conn->secure.client_public_key));
-    POSIX_GUARD(s2n_pkey_zero_init(&conn->secure.client_public_key));
+    POSIX_GUARD(s2n_pkey_free(&conn->handshake_params.server_public_key));
+    POSIX_GUARD(s2n_pkey_zero_init(&conn->handshake_params.server_public_key));
+    POSIX_GUARD(s2n_pkey_free(&conn->handshake_params.client_public_key));
+    POSIX_GUARD(s2n_pkey_zero_init(&conn->handshake_params.client_public_key));
     s2n_x509_validator_wipe(&conn->x509_validator);
     POSIX_GUARD(s2n_dh_params_free(&conn->kex_params.server_dh_params));
     POSIX_GUARD_RESULT(s2n_connection_wipe_all_keyshares(conn));
     POSIX_GUARD(s2n_kem_free(&conn->kex_params.kem_params));
-    POSIX_GUARD(s2n_free(&conn->secure.client_cert_chain));
+    POSIX_GUARD(s2n_free(&conn->handshake_params.client_cert_chain));
     POSIX_GUARD(s2n_free(&conn->ct_response));
 
     return 0;
@@ -749,10 +749,10 @@ int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(der_cert_chain_out);
     POSIX_ENSURE_REF(cert_chain_len);
-    POSIX_ENSURE_REF(conn->secure.client_cert_chain.data);
+    POSIX_ENSURE_REF(conn->handshake_params.client_cert_chain.data);
 
-    *der_cert_chain_out = conn->secure.client_cert_chain.data;
-    *cert_chain_len = conn->secure.client_cert_chain.size;
+    *der_cert_chain_out = conn->handshake_params.client_cert_chain.data;
+    *cert_chain_len = conn->handshake_params.client_cert_chain.size;
 
     return 0;
 }
@@ -1530,7 +1530,7 @@ int s2n_connection_get_selected_digest_algorithm(struct s2n_connection *conn, s2
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(converted_scheme);
 
-    POSIX_GUARD_RESULT(s2n_signature_scheme_to_tls_iana(&conn->secure.conn_sig_scheme, converted_scheme));
+    POSIX_GUARD_RESULT(s2n_signature_scheme_to_tls_iana(&conn->handshake_params.conn_sig_scheme, converted_scheme));
 
     return S2N_SUCCESS;
 }
@@ -1540,7 +1540,7 @@ int s2n_connection_get_selected_client_cert_digest_algorithm(struct s2n_connecti
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(converted_scheme);
 
-    POSIX_GUARD_RESULT(s2n_signature_scheme_to_tls_iana(&conn->secure.client_cert_sig_scheme, converted_scheme));
+    POSIX_GUARD_RESULT(s2n_signature_scheme_to_tls_iana(&conn->handshake_params.client_cert_sig_scheme, converted_scheme));
     return S2N_SUCCESS;
 }
 
@@ -1575,7 +1575,7 @@ int s2n_connection_get_selected_signature_algorithm(struct s2n_connection *conn,
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(converted_scheme);
 
-    POSIX_GUARD_RESULT(s2n_signature_scheme_to_signature_algorithm(&conn->secure.conn_sig_scheme, converted_scheme));
+    POSIX_GUARD_RESULT(s2n_signature_scheme_to_signature_algorithm(&conn->handshake_params.conn_sig_scheme, converted_scheme));
 
     return S2N_SUCCESS;
 }
@@ -1585,7 +1585,7 @@ int s2n_connection_get_selected_client_cert_signature_algorithm(struct s2n_conne
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(converted_scheme);
 
-    POSIX_GUARD_RESULT(s2n_signature_scheme_to_signature_algorithm(&conn->secure.client_cert_sig_scheme, converted_scheme));
+    POSIX_GUARD_RESULT(s2n_signature_scheme_to_signature_algorithm(&conn->handshake_params.client_cert_sig_scheme, converted_scheme));
 
     return S2N_SUCCESS;
 }

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -158,6 +158,7 @@ struct s2n_connection {
     /* Our crypto parameters */
     struct s2n_crypto_parameters initial;
     struct s2n_crypto_parameters secure;
+    struct s2n_secrets secrets;
 
     /* Which set is the client/server actually using? */
     struct s2n_crypto_parameters *client;

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -44,21 +44,23 @@ struct s2n_kex_parameters {
     struct s2n_blob client_pq_kem_extension;
 };
 
-struct s2n_crypto_parameters {
-    struct s2n_cipher_suite *cipher_suite;
-    struct s2n_session_key client_key;
-    struct s2n_session_key server_key;
-
+struct s2n_secrets {
     uint8_t rsa_premaster_secret[S2N_TLS_SECRET_LEN];
     uint8_t master_secret[S2N_TLS_SECRET_LEN];
     uint8_t client_random[S2N_TLS_RANDOM_DATA_LEN];
     uint8_t server_random[S2N_TLS_RANDOM_DATA_LEN];
-    uint8_t client_implicit_iv[S2N_TLS_MAX_IV_LEN];
-    uint8_t server_implicit_iv[S2N_TLS_MAX_IV_LEN];
     uint8_t client_app_secret[S2N_TLS13_SECRET_MAX_LEN];
     uint8_t server_app_secret[S2N_TLS13_SECRET_MAX_LEN];
+};
+
+struct s2n_crypto_parameters {
+    struct s2n_cipher_suite *cipher_suite;
+    struct s2n_session_key client_key;
+    struct s2n_session_key server_key;
     struct s2n_hmac_state client_record_mac;
     struct s2n_hmac_state server_record_mac;
+    uint8_t client_implicit_iv[S2N_TLS_MAX_IV_LEN];
+    uint8_t server_implicit_iv[S2N_TLS_MAX_IV_LEN];
     uint8_t client_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
     uint8_t server_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
 };

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -45,16 +45,6 @@ struct s2n_kex_parameters {
 };
 
 struct s2n_crypto_parameters {
-    struct s2n_pkey server_public_key;
-    struct s2n_pkey client_public_key;
-
-    struct s2n_signature_scheme conn_sig_scheme;
-
-    struct s2n_blob client_cert_chain;
-    s2n_pkey_type client_cert_pkey_type;
-
-    struct s2n_signature_scheme client_cert_sig_scheme;
-
     struct s2n_cipher_suite *cipher_suite;
     struct s2n_session_key client_key;
     struct s2n_session_key server_key;

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -82,11 +82,21 @@ typedef enum {
 } s2n_async_state;
 
 struct s2n_handshake_parameters {
+    /* Public keys for server / client */
+    struct s2n_pkey server_public_key;
+    struct s2n_pkey client_public_key;
+    struct s2n_blob client_cert_chain;
+    s2n_pkey_type client_cert_pkey_type;
+
     /* Signature/hash algorithm pairs offered by the client in the signature_algorithms extension */
     struct s2n_sig_scheme_list client_sig_hash_algs;
+    /* Signature scheme chosen by the server */
+    struct s2n_signature_scheme conn_sig_scheme;
 
     /* Signature/hash algorithm pairs offered by the server in the certificate request */
     struct s2n_sig_scheme_list server_sig_hash_algs;
+    /* Signature scheme chosen by the client */
+    struct s2n_signature_scheme client_cert_sig_scheme;
 
     /* The cert chain we will send the peer. */
     struct s2n_cert_chain_and_key *our_chain_and_key;

--- a/tls/s2n_key_log.c
+++ b/tls/s2n_key_log.c
@@ -124,7 +124,7 @@ S2N_RESULT s2n_key_log_tls13_secret(struct s2n_connection *conn, struct s2n_blob
     RESULT_GUARD_POSIX(s2n_stuffer_alloc(&output, len));
 
     RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(&output, label, label_size));
-    RESULT_GUARD(s2n_key_log_hex_encode(&output, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    RESULT_GUARD(s2n_key_log_hex_encode(&output, conn->secrets.client_random, S2N_TLS_RANDOM_DATA_LEN));
     RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(&output, ' '));
     RESULT_GUARD(s2n_key_log_hex_encode(&output, secret->data, secret->size));
 
@@ -160,9 +160,9 @@ S2N_RESULT s2n_key_log_tls12_secret(struct s2n_connection *conn)
     RESULT_GUARD_POSIX(s2n_stuffer_alloc(&output, len));
 
     RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(&output, label, label_size));
-    RESULT_GUARD(s2n_key_log_hex_encode(&output, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    RESULT_GUARD(s2n_key_log_hex_encode(&output, conn->secrets.client_random, S2N_TLS_RANDOM_DATA_LEN));
     RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(&output, ' '));
-    RESULT_GUARD(s2n_key_log_hex_encode(&output, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
+    RESULT_GUARD(s2n_key_log_hex_encode(&output, conn->secrets.master_secret, S2N_TLS_SECRET_LEN));
 
     uint8_t *data = s2n_stuffer_raw_read(&output, len);
     RESULT_ENSURE_REF(data);

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -386,9 +386,9 @@ static int s2n_prf(struct s2n_connection *conn, struct s2n_blob *secret, struct 
 
 int s2n_tls_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret)
 {
-    struct s2n_blob client_random = {.size = sizeof(conn->secure.client_random), .data = conn->secure.client_random};
-    struct s2n_blob server_random = {.size = sizeof(conn->secure.server_random), .data = conn->secure.server_random};
-    struct s2n_blob master_secret = {.size = sizeof(conn->secure.master_secret), .data = conn->secure.master_secret};
+    struct s2n_blob client_random = {.size = sizeof(conn->secrets.client_random), .data = conn->secrets.client_random};
+    struct s2n_blob server_random = {.size = sizeof(conn->secrets.server_random), .data = conn->secrets.server_random};
+    struct s2n_blob master_secret = {.size = sizeof(conn->secrets.master_secret), .data = conn->secrets.master_secret};
 
     uint8_t master_secret_label[] = "master secret";
     struct s2n_blob label = {.size = sizeof(master_secret_label) - 1, .data = master_secret_label};
@@ -398,9 +398,9 @@ int s2n_tls_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *prem
 
 int s2n_hybrid_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret)
 {
-    struct s2n_blob client_random = {.size = sizeof(conn->secure.client_random), .data = conn->secure.client_random};
-    struct s2n_blob server_random = {.size = sizeof(conn->secure.server_random), .data = conn->secure.server_random};
-    struct s2n_blob master_secret = {.size = sizeof(conn->secure.master_secret), .data = conn->secure.master_secret};
+    struct s2n_blob client_random = {.size = sizeof(conn->secrets.client_random), .data = conn->secrets.client_random};
+    struct s2n_blob server_random = {.size = sizeof(conn->secrets.server_random), .data = conn->secrets.server_random};
+    struct s2n_blob master_secret = {.size = sizeof(conn->secrets.master_secret), .data = conn->secrets.master_secret};
 
     uint8_t master_secret_label[] = "hybrid master secret";
     struct s2n_blob label = {.size = sizeof(master_secret_label) - 1, .data = master_secret_label};
@@ -426,11 +426,11 @@ static int s2n_sslv3_finished(struct s2n_connection *conn, uint8_t prefix[4], st
     struct s2n_hash_state *md5 = hash_workspace;
     POSIX_GUARD(s2n_hash_copy(md5, &conn->handshake.md5));
     POSIX_GUARD(s2n_hash_update(md5, prefix, 4));
-    POSIX_GUARD(s2n_hash_update(md5, conn->secure.master_secret, sizeof(conn->secure.master_secret)));
+    POSIX_GUARD(s2n_hash_update(md5, conn->secrets.master_secret, sizeof(conn->secrets.master_secret)));
     POSIX_GUARD(s2n_hash_update(md5, xorpad1, 48));
     POSIX_GUARD(s2n_hash_digest(md5, md5_digest, MD5_DIGEST_LENGTH));
     POSIX_GUARD(s2n_hash_reset(md5));
-    POSIX_GUARD(s2n_hash_update(md5, conn->secure.master_secret, sizeof(conn->secure.master_secret)));
+    POSIX_GUARD(s2n_hash_update(md5, conn->secrets.master_secret, sizeof(conn->secrets.master_secret)));
     POSIX_GUARD(s2n_hash_update(md5, xorpad2, 48));
     POSIX_GUARD(s2n_hash_update(md5, md5_digest, MD5_DIGEST_LENGTH));
     POSIX_GUARD(s2n_hash_digest(md5, md5_digest, MD5_DIGEST_LENGTH));
@@ -439,11 +439,11 @@ static int s2n_sslv3_finished(struct s2n_connection *conn, uint8_t prefix[4], st
     struct s2n_hash_state *sha1 = hash_workspace;
     POSIX_GUARD(s2n_hash_copy(sha1, &conn->handshake.sha1));
     POSIX_GUARD(s2n_hash_update(sha1, prefix, 4));
-    POSIX_GUARD(s2n_hash_update(sha1, conn->secure.master_secret, sizeof(conn->secure.master_secret)));
+    POSIX_GUARD(s2n_hash_update(sha1, conn->secrets.master_secret, sizeof(conn->secrets.master_secret)));
     POSIX_GUARD(s2n_hash_update(sha1, xorpad1, 40));
     POSIX_GUARD(s2n_hash_digest(sha1, sha_digest, SHA_DIGEST_LENGTH));
     POSIX_GUARD(s2n_hash_reset(sha1));
-    POSIX_GUARD(s2n_hash_update(sha1, conn->secure.master_secret, sizeof(conn->secure.master_secret)));
+    POSIX_GUARD(s2n_hash_update(sha1, conn->secrets.master_secret, sizeof(conn->secrets.master_secret)));
     POSIX_GUARD(s2n_hash_update(sha1, xorpad2, 40));
     POSIX_GUARD(s2n_hash_update(sha1, sha_digest, SHA_DIGEST_LENGTH));
     POSIX_GUARD(s2n_hash_digest(sha1, sha_digest, SHA_DIGEST_LENGTH));
@@ -486,8 +486,8 @@ int s2n_prf_client_finished(struct s2n_connection *conn)
     label.data = client_finished_label;
     label.size = sizeof(client_finished_label) - 1;
 
-    master_secret.data = conn->secure.master_secret;
-    master_secret.size = sizeof(conn->secure.master_secret);
+    master_secret.data = conn->secrets.master_secret;
+    master_secret.size = sizeof(conn->secrets.master_secret);
     if (conn->actual_protocol_version == S2N_TLS12) {
         switch (conn->secure.cipher_suite->prf_alg) {
         case S2N_HMAC_SHA256:
@@ -539,8 +539,8 @@ int s2n_prf_server_finished(struct s2n_connection *conn)
     label.data = server_finished_label;
     label.size = sizeof(server_finished_label) - 1;
 
-    master_secret.data = conn->secure.master_secret;
-    master_secret.size = sizeof(conn->secure.master_secret);
+    master_secret.data = conn->secrets.master_secret;
+    master_secret.size = sizeof(conn->secrets.master_secret);
     if (conn->actual_protocol_version == S2N_TLS12) {
         switch (conn->secure.cipher_suite->prf_alg) {
         case S2N_HMAC_SHA256:
@@ -608,9 +608,9 @@ static int s2n_prf_make_server_key(struct s2n_connection *conn, struct s2n_stuff
 
 int s2n_prf_key_expansion(struct s2n_connection *conn)
 {
-    struct s2n_blob client_random = {.data = conn->secure.client_random,.size = sizeof(conn->secure.client_random) };
-    struct s2n_blob server_random = {.data = conn->secure.server_random,.size = sizeof(conn->secure.server_random) };
-    struct s2n_blob master_secret = {.data = conn->secure.master_secret,.size = sizeof(conn->secure.master_secret) };
+    struct s2n_blob client_random = {.data = conn->secrets.client_random,.size = sizeof(conn->secrets.client_random) };
+    struct s2n_blob server_random = {.data = conn->secrets.server_random,.size = sizeof(conn->secrets.server_random) };
+    struct s2n_blob master_secret = {.data = conn->secrets.master_secret,.size = sizeof(conn->secrets.master_secret) };
     struct s2n_blob label, out;
     uint8_t key_expansion_label[] = "key expansion";
     uint8_t key_block[S2N_MAX_KEY_BLOCK_LEN];

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -61,7 +61,7 @@ static int s2n_tls12_serialize_resumption_state(struct s2n_connection *conn, str
     POSIX_GUARD(s2n_stuffer_write_uint8(to, conn->actual_protocol_version));
     POSIX_GUARD(s2n_stuffer_write_bytes(to, conn->secure.cipher_suite->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
     POSIX_GUARD(s2n_stuffer_write_uint64(to, now));
-    POSIX_GUARD(s2n_stuffer_write_bytes(to, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
+    POSIX_GUARD(s2n_stuffer_write_bytes(to, conn->secrets.master_secret, S2N_TLS_SECRET_LEN));
 
     return 0;
 }
@@ -154,7 +154,7 @@ static int s2n_tls12_deserialize_resumption_state(struct s2n_connection *conn, s
     S2N_ERROR_IF(now - then > conn->config->session_state_lifetime_in_nanos, S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
 
     /* Last but not least, put the master secret in place */
-    POSIX_GUARD(s2n_stuffer_read_bytes(from, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
+    POSIX_GUARD(s2n_stuffer_read_bytes(from, conn->secrets.master_secret, S2N_TLS_SECRET_LEN));
 
     return 0;
 }
@@ -198,7 +198,7 @@ static S2N_RESULT s2n_tls12_client_deserialize_session_state(struct s2n_connecti
     RESULT_GUARD_POSIX(s2n_stuffer_read_uint64(from, &then));
 
     /* Last but not least, put the master secret in place */
-    RESULT_GUARD_POSIX(s2n_stuffer_read_bytes(from, conn->secure.master_secret, S2N_TLS_SECRET_LEN));
+    RESULT_GUARD_POSIX(s2n_stuffer_read_bytes(from, conn->secrets.master_secret, S2N_TLS_SECRET_LEN));
 
     return S2N_RESULT_OK;
 }

--- a/tls/s2n_server_cert.c
+++ b/tls/s2n_server_cert.c
@@ -50,7 +50,7 @@ int s2n_server_cert_recv(struct s2n_connection *conn)
 
     POSIX_GUARD(s2n_is_cert_type_valid_for_auth(conn, actual_cert_pkey_type));
     POSIX_GUARD(s2n_pkey_setup_for_type(&public_key, actual_cert_pkey_type));
-    conn->secure.server_public_key = public_key;
+    conn->handshake_params.server_public_key = public_key;
 
     return 0;
 }

--- a/tls/s2n_server_cert_request.c
+++ b/tls/s2n_server_cert_request.c
@@ -98,7 +98,7 @@ static int s2n_set_cert_chain_as_client(struct s2n_connection *conn)
 {
     if (s2n_config_get_num_default_certs(conn->config) > 0) {
         POSIX_GUARD(s2n_choose_sig_scheme_from_peer_preference_list(conn, &conn->handshake_params.server_sig_hash_algs,
-                                                               &conn->secure.client_cert_sig_scheme));
+                                                               &conn->handshake_params.client_cert_sig_scheme));
 
         struct s2n_cert_chain_and_key *cert = s2n_config_get_single_default_cert(conn->config);
         POSIX_ENSURE_REF(cert);
@@ -131,7 +131,7 @@ int s2n_cert_req_recv(struct s2n_connection *conn)
 
     s2n_cert_type cert_type = 0;
     POSIX_GUARD(s2n_recv_client_cert_preferences(in, &cert_type));
-    POSIX_GUARD(s2n_cert_type_to_pkey_type(cert_type, &conn->secure.client_cert_pkey_type));
+    POSIX_GUARD(s2n_cert_type_to_pkey_type(cert_type, &conn->handshake_params.client_cert_pkey_type));
 
     if (conn->actual_protocol_version == S2N_TLS12) {
         POSIX_GUARD(s2n_recv_supported_sig_scheme_list(in, &conn->handshake_params.server_sig_hash_algs));

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -206,7 +206,7 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
     }
 
     /* Choose a default signature scheme */
-    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &conn->secure.conn_sig_scheme));
+    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &conn->handshake_params.conn_sig_scheme));
 
     /* Update the required hashes for this connection */
     POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -53,7 +53,7 @@ const uint8_t tls11_downgrade_protection_bytes[] = {
 static int s2n_hello_retry_validate(struct s2n_connection *conn) {
     POSIX_ENSURE_REF(conn);
 
-    POSIX_ENSURE(memcmp(hello_retry_req_random, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN) == 0,
+    POSIX_ENSURE(memcmp(hello_retry_req_random, conn->secrets.server_random, S2N_TLS_RANDOM_DATA_LEN) == 0,
                  S2N_ERR_INVALID_HELLO_RETRY);
 
     return S2N_SUCCESS;
@@ -61,7 +61,7 @@ static int s2n_hello_retry_validate(struct s2n_connection *conn) {
 
 static int s2n_client_detect_downgrade_mechanism(struct s2n_connection *conn) {
     POSIX_ENSURE_REF(conn);
-    uint8_t *downgrade_bytes = &conn->secure.server_random[S2N_TLS_RANDOM_DATA_LEN - S2N_DOWNGRADE_PROTECTION_SIZE];
+    uint8_t *downgrade_bytes = &conn->secrets.server_random[S2N_TLS_RANDOM_DATA_LEN - S2N_DOWNGRADE_PROTECTION_SIZE];
 
     /* Detect downgrade attacks according to RFC 8446 section 4.1.3 */
     if (conn->client_protocol_version == S2N_TLS13 && conn->server_protocol_version == S2N_TLS12) {
@@ -79,7 +79,7 @@ static int s2n_client_detect_downgrade_mechanism(struct s2n_connection *conn) {
 
 static int s2n_server_add_downgrade_mechanism(struct s2n_connection *conn) {
     POSIX_ENSURE_REF(conn);
-    uint8_t *downgrade_bytes = &conn->secure.server_random[S2N_TLS_RANDOM_DATA_LEN - S2N_DOWNGRADE_PROTECTION_SIZE];
+    uint8_t *downgrade_bytes = &conn->secrets.server_random[S2N_TLS_RANDOM_DATA_LEN - S2N_DOWNGRADE_PROTECTION_SIZE];
 
     /* Protect against downgrade attacks according to RFC 8446 section 4.1.3 */
     if (conn->server_protocol_version >= S2N_TLS13 && conn->actual_protocol_version == S2N_TLS12) {
@@ -104,7 +104,7 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
     uint8_t session_id[S2N_TLS_SESSION_ID_MAX_LEN];
 
     POSIX_GUARD(s2n_stuffer_read_bytes(in, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
-    POSIX_GUARD(s2n_stuffer_read_bytes(in, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_stuffer_read_bytes(in, conn->secrets.server_random, S2N_TLS_RANDOM_DATA_LEN));
 
     /* If the client receives a second HelloRetryRequest in the same connection, it MUST send an error. */
     if (s2n_hello_retry_validate(conn) == S2N_SUCCESS) {
@@ -166,7 +166,7 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
             conn->actual_protocol_version = actual_protocol_version;
             POSIX_GUARD(s2n_set_cipher_as_client(conn, cipher_suite_wire));
             /* Erase master secret which might have been set for session resumption */
-            POSIX_CHECKED_MEMSET((uint8_t *)conn->secure.master_secret, 0, S2N_TLS_SECRET_LEN);
+            POSIX_CHECKED_MEMSET((uint8_t *)conn->secrets.master_secret, 0, S2N_TLS_SECRET_LEN);
 
             /* Erase client session ticket which might have been set for session resumption */
             POSIX_GUARD(s2n_free(&conn->client_ticket));
@@ -227,7 +227,7 @@ int s2n_server_hello_write_message(struct s2n_connection *conn)
     protocol_version[1] = (uint8_t)(legacy_protocol_version % 10);
 
     POSIX_GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
-    POSIX_GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, conn->secrets.server_random, S2N_TLS_RANDOM_DATA_LEN));
     POSIX_GUARD(s2n_stuffer_write_uint8(&conn->handshake.io, conn->session_id_len));
     POSIX_GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, conn->session_id, conn->session_id_len));
     POSIX_GUARD(s2n_stuffer_write_bytes(&conn->handshake.io, conn->secure.cipher_suite->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
@@ -242,7 +242,7 @@ int s2n_server_hello_send(struct s2n_connection *conn)
 
     struct s2n_stuffer server_random = {0};
     struct s2n_blob b = {0};
-    POSIX_GUARD(s2n_blob_init(&b, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_blob_init(&b, conn->secrets.server_random, S2N_TLS_RANDOM_DATA_LEN));
 
     /* Create the server random data */
     POSIX_GUARD(s2n_stuffer_init(&server_random, &b));

--- a/tls/s2n_server_hello_retry.c
+++ b/tls/s2n_server_hello_retry.c
@@ -53,7 +53,7 @@ int s2n_server_hello_retry_send(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
 
-    POSIX_CHECKED_MEMCPY(conn->secure.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
+    POSIX_CHECKED_MEMCPY(conn->secrets.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
 
     POSIX_GUARD(s2n_server_hello_write_message(conn));
 

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -56,7 +56,7 @@ int s2n_server_key_recv(struct s2n_connection *conn)
         /* Verify the SigScheme picked by the Server was in the preference list we sent (or is the default SigScheme) */
         POSIX_GUARD(s2n_get_and_validate_negotiated_signature_scheme(conn, in, &active_sig_scheme));
     } else {
-        active_sig_scheme = conn->secure.conn_sig_scheme;
+        active_sig_scheme = conn->handshake_params.conn_sig_scheme;
     }
     POSIX_GUARD(s2n_hash_init(signature_hash, active_sig_scheme.hash_alg));
     POSIX_GUARD(s2n_hash_update(signature_hash, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
@@ -73,11 +73,11 @@ int s2n_server_key_recv(struct s2n_connection *conn)
     POSIX_ENSURE_REF(signature.data);
     POSIX_ENSURE_GT(signature_length, 0);
 
-    S2N_ERROR_IF(s2n_pkey_verify(&conn->secure.server_public_key, active_sig_scheme.sig_alg,signature_hash, &signature) < 0,
+    S2N_ERROR_IF(s2n_pkey_verify(&conn->handshake_params.server_public_key, active_sig_scheme.sig_alg,signature_hash, &signature) < 0,
             S2N_ERR_BAD_MESSAGE);
 
     /* We don't need the key any more, so free it */
-    POSIX_GUARD(s2n_pkey_free(&conn->secure.server_public_key));
+    POSIX_GUARD(s2n_pkey_free(&conn->handshake_params.server_public_key));
 
     /* Parse the KEX data into whatever form needed and save it to the connection object */
     POSIX_GUARD_RESULT(s2n_kex_server_key_recv_parse_data(key_exchange, conn, &kex_data));
@@ -244,18 +244,18 @@ int s2n_server_key_send(struct s2n_connection *conn)
 
     /* Add common signature data */
     if (conn->actual_protocol_version == S2N_TLS12) {
-        POSIX_GUARD(s2n_stuffer_write_uint16(out, conn->secure.conn_sig_scheme.iana_value));
+        POSIX_GUARD(s2n_stuffer_write_uint16(out, conn->handshake_params.conn_sig_scheme.iana_value));
     }
 
     /* Add the random data to the hash */
-    POSIX_GUARD(s2n_hash_init(signature_hash, conn->secure.conn_sig_scheme.hash_alg));
+    POSIX_GUARD(s2n_hash_init(signature_hash, conn->handshake_params.conn_sig_scheme.hash_alg));
     POSIX_GUARD(s2n_hash_update(signature_hash, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
     POSIX_GUARD(s2n_hash_update(signature_hash, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
 
     /* Add KEX specific data to the hash */
     POSIX_GUARD(s2n_hash_update(signature_hash, data_to_sign.data, data_to_sign.size));
 
-    S2N_ASYNC_PKEY_SIGN(conn, conn->secure.conn_sig_scheme.sig_alg, signature_hash, s2n_server_key_send_write_signature);
+    S2N_ASYNC_PKEY_SIGN(conn, conn->handshake_params.conn_sig_scheme.sig_alg, signature_hash, s2n_server_key_send_write_signature);
 }
 
 int s2n_ecdhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_to_sign)

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -59,8 +59,8 @@ int s2n_server_key_recv(struct s2n_connection *conn)
         active_sig_scheme = conn->handshake_params.conn_sig_scheme;
     }
     POSIX_GUARD(s2n_hash_init(signature_hash, active_sig_scheme.hash_alg));
-    POSIX_GUARD(s2n_hash_update(signature_hash, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
-    POSIX_GUARD(s2n_hash_update(signature_hash, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_hash_update(signature_hash, conn->secrets.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_hash_update(signature_hash, conn->secrets.server_random, S2N_TLS_RANDOM_DATA_LEN));
 
     /* Add KEX specific data */
     POSIX_GUARD(s2n_hash_update(signature_hash, data_to_verify.data, data_to_verify.size));
@@ -249,8 +249,8 @@ int s2n_server_key_send(struct s2n_connection *conn)
 
     /* Add the random data to the hash */
     POSIX_GUARD(s2n_hash_init(signature_hash, conn->handshake_params.conn_sig_scheme.hash_alg));
-    POSIX_GUARD(s2n_hash_update(signature_hash, conn->secure.client_random, S2N_TLS_RANDOM_DATA_LEN));
-    POSIX_GUARD(s2n_hash_update(signature_hash, conn->secure.server_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_hash_update(signature_hash, conn->secrets.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD(s2n_hash_update(signature_hash, conn->secrets.server_random, S2N_TLS_RANDOM_DATA_LEN));
 
     /* Add KEX specific data to the hash */
     POSIX_GUARD(s2n_hash_update(signature_hash, data_to_sign.data, data_to_sign.size));

--- a/tls/s2n_tls13_certificate_verify.c
+++ b/tls/s2n_tls13_certificate_verify.c
@@ -60,10 +60,10 @@ int s2n_tls13_cert_verify_send(struct s2n_connection *conn)
 
     if (conn->mode == S2N_SERVER) {
         /* Write digital signature */
-        POSIX_GUARD(s2n_tls13_write_cert_verify_signature(conn, &conn->secure.conn_sig_scheme));
+        POSIX_GUARD(s2n_tls13_write_cert_verify_signature(conn, &conn->handshake_params.conn_sig_scheme));
     } else {
         /* Write digital signature */
-        POSIX_GUARD(s2n_tls13_write_cert_verify_signature(conn, &conn->secure.client_cert_sig_scheme));
+        POSIX_GUARD(s2n_tls13_write_cert_verify_signature(conn, &conn->handshake_params.client_cert_sig_scheme));
     }
 
 
@@ -144,16 +144,16 @@ int s2n_tls13_cert_verify_recv(struct s2n_connection *conn)
 {
     if (conn->mode == S2N_SERVER) {
         /* Read the algorithm and update sig_scheme */
-        POSIX_GUARD(s2n_get_and_validate_negotiated_signature_scheme(conn, &conn->handshake.io, &conn->secure.client_cert_sig_scheme));
+        POSIX_GUARD(s2n_get_and_validate_negotiated_signature_scheme(conn, &conn->handshake.io, &conn->handshake_params.client_cert_sig_scheme));
 
         /* Read the rest of the signature and verify */
-        POSIX_GUARD(s2n_tls13_cert_read_and_verify_signature(conn, &conn->secure.client_cert_sig_scheme));
+        POSIX_GUARD(s2n_tls13_cert_read_and_verify_signature(conn, &conn->handshake_params.client_cert_sig_scheme));
     } else {
         /* Read the algorithm and update sig_scheme */
-        POSIX_GUARD(s2n_get_and_validate_negotiated_signature_scheme(conn, &conn->handshake.io, &conn->secure.conn_sig_scheme));
+        POSIX_GUARD(s2n_get_and_validate_negotiated_signature_scheme(conn, &conn->handshake.io, &conn->handshake_params.conn_sig_scheme));
 
         /* Read the rest of the signature and verify */
-        POSIX_GUARD(s2n_tls13_cert_read_and_verify_signature(conn, &conn->secure.conn_sig_scheme));
+        POSIX_GUARD(s2n_tls13_cert_read_and_verify_signature(conn, &conn->handshake_params.conn_sig_scheme));
     }
 
     return 0;
@@ -188,9 +188,9 @@ int s2n_tls13_cert_read_and_verify_signature(struct s2n_connection *conn, struct
     POSIX_GUARD(s2n_hash_update(&message_hash, unsigned_content.blob.data, s2n_stuffer_data_available(&unsigned_content)));
 
     if (conn->mode == S2N_CLIENT) {
-        POSIX_GUARD(s2n_pkey_verify(&conn->secure.server_public_key, chosen_sig_scheme->sig_alg, &message_hash, &signed_content));
+        POSIX_GUARD(s2n_pkey_verify(&conn->handshake_params.server_public_key, chosen_sig_scheme->sig_alg, &message_hash, &signed_content));
     } else {
-        POSIX_GUARD(s2n_pkey_verify(&conn->secure.client_public_key, chosen_sig_scheme->sig_alg, &message_hash, &signed_content));
+        POSIX_GUARD(s2n_pkey_verify(&conn->handshake_params.client_public_key, chosen_sig_scheme->sig_alg, &message_hash, &signed_content));
     }
 
     return 0;

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -60,7 +60,7 @@ static int s2n_tls13_keys_init_with_ref(struct s2n_tls13_keys *handshake, s2n_hm
 
 int s2n_tls13_keys_from_conn(struct s2n_tls13_keys *keys, struct s2n_connection *conn)
 {
-    POSIX_GUARD(s2n_tls13_keys_init_with_ref(keys, conn->secure.cipher_suite->prf_alg, conn->secure.rsa_premaster_secret, conn->secure.master_secret));
+    POSIX_GUARD(s2n_tls13_keys_init_with_ref(keys, conn->secure.cipher_suite->prf_alg, conn->secrets.rsa_premaster_secret, conn->secrets.master_secret));
 
     return 0;
 }
@@ -346,12 +346,12 @@ static int s2n_tls13_handle_application_secret(struct s2n_connection *conn, s2n_
     struct s2n_session_key *session_key;
     s2n_secret_type_t secret_type;
     if (mode == S2N_CLIENT) {
-        app_secret_data = conn->secure.client_app_secret;
+        app_secret_data = conn->secrets.client_app_secret;
         implicit_iv_data = conn->secure.client_implicit_iv;
         session_key = &conn->secure.client_key;
         secret_type = S2N_CLIENT_APPLICATION_TRAFFIC_SECRET;
     } else {
-        app_secret_data = conn->secure.server_app_secret;
+        app_secret_data = conn->secrets.server_app_secret;
         implicit_iv_data = conn->secure.server_implicit_iv;
         session_key = &conn->secure.server_key;
         secret_type = S2N_SERVER_APPLICATION_TRAFFIC_SECRET;
@@ -527,11 +527,11 @@ int s2n_update_application_traffic_keys(struct s2n_connection *conn, s2n_mode mo
 
     if (mode == S2N_CLIENT) {
         old_key = &conn->secure.client_key;
-        POSIX_GUARD(s2n_blob_init(&old_app_secret, conn->secure.client_app_secret, keys.size));
+        POSIX_GUARD(s2n_blob_init(&old_app_secret, conn->secrets.client_app_secret, keys.size));
         POSIX_GUARD(s2n_blob_init(&app_iv, conn->secure.client_implicit_iv, S2N_TLS13_FIXED_IV_LEN));
     } else {
         old_key = &conn->secure.server_key;
-        POSIX_GUARD(s2n_blob_init(&old_app_secret, conn->secure.server_app_secret, keys.size));
+        POSIX_GUARD(s2n_blob_init(&old_app_secret, conn->secrets.server_app_secret, keys.size));
         POSIX_GUARD(s2n_blob_init(&app_iv, conn->secure.server_implicit_iv, S2N_TLS13_FIXED_IV_LEN));  
     }
 


### PR DESCRIPTION
### Description of changes: 

Really just a continuation of https://github.com/aws/s2n-tls/pull/2940. A connection has both an initial and secure version of the s2n_crypto_parameters structure. So if only the secure copy of a field is ever referenced, the field does not need to be on the s2n_crypto_parameters structure. In this PR, I move the rest of the secure-only fields off the structure.

This only saves about ~.5kb (out of 14.5kb atm), but I think it'll set the right precedent and discourage placing more fields we don't need two copies of on the crypto_parameters in the future.

### Call-outs:
Although this technically includes a lot of files, basically all of them are just renames automatically handled by my IDE. The actually relevant changes are [tls/s2n_crypto.h](https://github.com/aws/s2n-tls/pull/2964/files#diff-c1edfd72d4badbe6da8da1ac8d625ab08947e2ec0f3e5015b5e5cb1efbdb656b), [tls/s2n_connection.h](https://github.com/aws/s2n-tls/pull/2964/files#diff-f3d04f614a18b2729ca819a7461acb90f6e27556e192b5d87abad099cb8c3fbc), and [tls/s2n_handshake.h](https://github.com/aws/s2n-tls/pull/2964/files#diff-9ef339ddd8d33a1e5a47649af2a2370b5698d0ca4066e845a3afeab927ef6d3c). The only test files updated by hand were [tests/cbmc/sources/make_common_datastructures.c](https://github.com/aws/s2n-tls/pull/2964/files#diff-51d56b51e7226a9b64725d0f69afa91ee43c3f8a4773467a2c6c90cd21b51159) and [tests/unit/s2n_connection_test.c](https://github.com/aws/s2n-tls/pull/2964/files#diff-be91130136d757d0bdfe49e6005baf7693bb5d63c2e4e5cee4553a656b05ef63).

### Testing:
Existing tests pass. No behavior changes, just moving/renaming variables.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
