### PR TITLE
Import Kyber512 Round3 AVX2 Implementation - V1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,24 @@ else()
             set(BIKE_R3_X86_64_OPT_SUPPORTED ON)
         endif()
     endif()
+    
+    # Kyber Round-3 code has several different optimizations which require
+    # specific compiler flags to be supported by the compiler.
+    # So for each needed instruction set extension we check if the compiler
+    # supports it and set proper compiler flags to be added later to the
+    # BIKE compilation units.
+    if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(x86_64|amd64|AMD64)$")
+    
+        set(KYBER512R3_AVX2_BMI2_FLAGS "-mavx2 -mbmi2")
+        try_compile(KYBER512R3_AVX2_BMI2_SUPPORTED
+            ${CMAKE_BINARY_DIR}
+            "${CMAKE_CURRENT_LIST_DIR}/tests/features/noop_main.c"
+            COMPILE_DEFINITIONS ${KYBER512R3_AVX2_BMI2_FLAGS})
+            
+        if(KYBER512R3_AVX2_BMI2_SUPPORTED)
+            set(KYBER512R3_AVX2_BMI2_OPT_SUPPORTED ON)
+        endif()
+    endif()
 endif()
 
 # Probe for execinfo.h extensions (not present on some systems, notably android)
@@ -302,6 +320,16 @@ if(BIKE_R3_X86_64_OPT_SUPPORTED)
     endif()
 
     message(STATUS "Enabling BIKE_R3 x86_64 optimizations")
+endif()
+
+if(KYBER512R3_AVX2_BMI2_OPT_SUPPORTED)
+    if(KYBER512R3_AVX2_BMI2_SUPPORTED)
+        FILE(GLOB KYBER512R3_AVX2_BMI2_SRCS "pq-crypto/kyber_r3/*_avx2.c")
+        set_source_files_properties(${KYBER512R3_AVX2_BMI2_SRCS} PROPERTIES COMPILE_FLAGS ${KYBER512R3_AVX2_BMI2_FLAGS})
+        target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_KYBER512R3_AVX2_BMI2)
+    endif()
+
+    message(STATUS "Enabling Kyber_R3 x86_64 optimizations")
 endif()
 
 if(ADX_SUPPORTED)

--- a/pq-crypto/kyber_r3/Makefile
+++ b/pq-crypto/kyber_r3/Makefile
@@ -13,10 +13,41 @@
 # permissions and limitations under the License.
 #
 
-SRCS=$(wildcard *.c)
-OBJS=$(SRCS:.c=.o)
-
-.PHONY : all
-all: $(OBJS)
+.DEFAULT_GOAL := all
 
 include ../../s2n.mk
+include ../s2n_pq_asm.mk
+
+# Kyber Round-3 code has several different optimizations
+# which require specific compiler flags to be supported
+# by the compiler. The flags are set in the s2n_pq_asm.mk
+# file and used here to compile the optimized code files.
+
+SRCS=kyber512r3_cbd.c kyber512r3_fips202.c kyber512r3_indcpa.c kyber512r3_kem.c kyber512r3_ntt.c kyber512r3_poly.c kyber512r3_polyvec.c kyber512r3_reduce.c kyber512r3_symmetric-shake.c
+OBJS=$(SRCS:.c=.o)
+
+AVX2_SRCS=kyber512r3_indcpa_avx2.c
+AVX2_OBJS=$(AVX2_SRCS:.c=.o)
+
+$(AVX2_OBJS): CFLAGS += $(KYBER512R3_AVX2_BMI2_FLAGS)
+
+#WA for GCC 4.8.5 bug.
+CFLAGS += -Wno-missing-braces -Wno-missing-field-initializers -I../../
+
+.PHONY : all
+all: $(OBJS) $(AVX2_OBJS)
+
+CFLAGS_LLVM = -emit-llvm -c -g \
+              -std=c99 -fgnu89-inline -D_POSIX_C_SOURCE=200809L -D_FORTIFY_SOURCE=2 \
+              -I$(LIBCRYPTO_ROOT)/include/ -I../../api/ -I../../
+
+BCS=$(addprefix $(BITCODE_DIR), $(SRCS:.c=.bc))
+AVX2_BCS=$(addprefix $(BITCODE_DIR), $(AVX2_SRCS:.c=.bc))
+
+$(AVX2_BCS): CFLAGS_LLVM += $(KYBER512R3_AVX2_BMI2_FLAGS)
+
+.PHONY : bc
+bc: $(BCS) $(AVX2_BCS)
+
+
+

--- a/pq-crypto/kyber_r3/kyber512r3_indcpa.h
+++ b/pq-crypto/kyber_r3/kyber512r3_indcpa.h
@@ -13,3 +13,26 @@ void indcpa_enc(uint8_t c[S2N_KYBER_512_R3_INDCPA_BYTES], const uint8_t m[S2N_KY
 #define indcpa_dec S2N_KYBER_512_R3_NAMESPACE(indcpa_dec)
 void indcpa_dec(uint8_t m[S2N_KYBER_512_R3_INDCPA_MSGBYTES], const uint8_t c[S2N_KYBER_512_R3_INDCPA_BYTES],
         const uint8_t sk[S2N_KYBER_512_R3_INDCPA_SECRETKEYBYTES]);
+
+
+#ifdef S2N_KYBER512R3_AVX2_BMI2
+
+//#define gen_matrix_avx2 S2N_KYBER_512_R3_NAMESPACE(gen_matrix_avx2)
+//void gen_matrix_avx2(polyvec *a, const uint8_t seed[S2N_KYBER_512_R3_SYMBYTES], int transposed);
+
+#define indcpa_keypair_avx2 S2N_KYBER_512_R3_NAMESPACE(indcpa_keypair_avx2)
+int indcpa_keypair_avx2(uint8_t pk[S2N_KYBER_512_R3_INDCPA_PUBLICKEYBYTES],
+                    uint8_t sk[S2N_KYBER_512_R3_INDCPA_SECRETKEYBYTES]);
+
+#define indcpa_enc_avx2 S2N_KYBER_512_R3_NAMESPACE(indcpa_enc_avx2)
+void indcpa_enc_avx2(uint8_t c[S2N_KYBER_512_R3_INDCPA_BYTES],
+                const uint8_t m[S2N_KYBER_512_R3_INDCPA_MSGBYTES],
+                const uint8_t pk[S2N_KYBER_512_R3_INDCPA_PUBLICKEYBYTES],
+                const uint8_t coins[S2N_KYBER_512_R3_SYMBYTES]);
+
+#define indcpa_dec_avx2 S2N_KYBER_512_R3_NAMESPACE(indcpa_dec_avx2)
+void indcpa_dec_avx2(uint8_t m[S2N_KYBER_512_R3_INDCPA_MSGBYTES],
+                const uint8_t c[S2N_KYBER_512_R3_INDCPA_BYTES],
+                const uint8_t sk[S2N_KYBER_512_R3_INDCPA_SECRETKEYBYTES]);
+
+#endif

--- a/pq-crypto/kyber_r3/kyber512r3_indcpa_avx2.c
+++ b/pq-crypto/kyber_r3/kyber512r3_indcpa_avx2.c
@@ -1,0 +1,417 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include "kyber512r3_indcpa.h"
+#include "kyber512r3_polyvec.h"
+#include "kyber512r3_poly.h"
+#include "kyber512r3_fips202.h"
+#include "kyber512r3_symmetric.h"
+#include "pq-crypto/s2n_pq_random.h"
+#include "utils/s2n_safety.h"
+#include "pq-crypto/s2n_pq.h"
+
+#ifdef S2N_KYBER512R3_AVX2_BMI2
+#include <immintrin.h>
+
+/*************************************************
+* Name:        pack_pk
+*
+* Description: Serialize the public key as concatenation of the
+*              serialized vector of polynomials pk and the
+*              public seed used to generate the matrix A.
+*              The polynomial coefficients in pk are assumed to
+*              lie in the invertal [0,q], i.e. pk must be reduced
+*              by polyvec_reduce().
+*
+* Arguments:   uint8_t *r: pointer to the output serialized public key
+*              polyvec *pk: pointer to the input public-key polyvec
+*              const uint8_t *seed: pointer to the input public seed
+**************************************************/
+static void pack_pk(uint8_t r[S2N_KYBER_512_R3_INDCPA_PUBLICKEYBYTES],
+                    polyvec *pk,
+                    const uint8_t seed[S2N_KYBER_512_R3_SYMBYTES])
+{
+  polyvec_tobytes(r, pk);
+  memcpy(r+S2N_KYBER_512_R3_POLYVECBYTES, seed, S2N_KYBER_512_R3_SYMBYTES);
+}
+
+/*************************************************
+* Name:        unpack_pk
+*
+* Description: De-serialize public key from a byte array;
+*              approximate inverse of pack_pk
+*
+* Arguments:   - polyvec *pk: pointer to output public-key polynomial vector
+*              - uint8_t *seed: pointer to output seed to generate matrix A
+*              - const uint8_t *packedpk: pointer to input serialized public key
+**************************************************/
+static void unpack_pk(polyvec *pk,
+                      uint8_t seed[S2N_KYBER_512_R3_SYMBYTES],
+                      const uint8_t packedpk[S2N_KYBER_512_R3_INDCPA_PUBLICKEYBYTES])
+{
+  polyvec_frombytes(pk, packedpk);
+  memcpy(seed, packedpk+S2N_KYBER_512_R3_POLYVECBYTES, S2N_KYBER_512_R3_SYMBYTES);
+}
+
+/*************************************************
+* Name:        pack_sk
+*
+* Description: Serialize the secret key.
+*              The polynomial coefficients in sk are assumed to
+*              lie in the invertal [0,q], i.e. sk must be reduced
+*              by polyvec_reduce().
+*
+* Arguments:   - uint8_t *r: pointer to output serialized secret key
+*              - polyvec *sk: pointer to input vector of polynomials (secret key)
+**************************************************/
+static void pack_sk(uint8_t r[S2N_KYBER_512_R3_INDCPA_SECRETKEYBYTES], polyvec *sk)
+{
+  polyvec_tobytes(r, sk);
+}
+
+/*************************************************
+* Name:        unpack_sk
+*
+* Description: De-serialize the secret key; inverse of pack_sk
+*
+* Arguments:   - polyvec *sk: pointer to output vector of polynomials (secret key)
+*              - const uint8_t *packedsk: pointer to input serialized secret key
+**************************************************/
+static void unpack_sk(polyvec *sk, const uint8_t packedsk[S2N_KYBER_512_R3_INDCPA_SECRETKEYBYTES])
+{
+  polyvec_frombytes(sk, packedsk);
+}
+
+/*************************************************
+* Name:        pack_ciphertext
+*
+* Description: Serialize the ciphertext as concatenation of the
+*              compressed and serialized vector of polynomials b
+*              and the compressed and serialized polynomial v.
+*              The polynomial coefficients in b and v are assumed to
+*              lie in the invertal [0,q], i.e. b and v must be reduced
+*              by polyvec_reduce() and poly_reduce(), respectively.
+*
+* Arguments:   uint8_t *r: pointer to the output serialized ciphertext
+*              poly *pk: pointer to the input vector of polynomials b
+*              poly *v: pointer to the input polynomial v
+**************************************************/
+static void pack_ciphertext(uint8_t r[S2N_KYBER_512_R3_INDCPA_BYTES], polyvec *b, poly *v)
+{
+  polyvec_compress(r, b);
+  poly_compress(r+S2N_KYBER_512_R3_POLYVECCOMPRESSEDBYTES, v);
+}
+
+/*************************************************
+* Name:        unpack_ciphertext
+*
+* Description: De-serialize and decompress ciphertext from a byte array;
+*              approximate inverse of pack_ciphertext
+*
+* Arguments:   - polyvec *b: pointer to the output vector of polynomials b
+*              - poly *v: pointer to the output polynomial v
+*              - const uint8_t *c: pointer to the input serialized ciphertext
+**************************************************/
+static void unpack_ciphertext(polyvec *b, poly *v, const uint8_t c[S2N_KYBER_512_R3_INDCPA_BYTES])
+{
+  polyvec_decompress(b, c);
+  poly_decompress(v, c+S2N_KYBER_512_R3_POLYVECCOMPRESSEDBYTES);
+}
+
+/*************************************************
+* Name:        rej_uniform
+*
+* Description: Run rejection sampling on uniform random bytes to generate
+*              uniform random integers mod q
+*
+* Arguments:   - int16_t *r: pointer to output array
+*              - unsigned int len: requested number of 16-bit integers (uniform mod q)
+*              - const uint8_t *buf: pointer to input buffer (assumed to be uniformly random bytes)
+*              - unsigned int buflen: length of input buffer in bytes
+*
+* Returns number of sampled 16-bit integers (at most len)
+**************************************************/
+static unsigned int rej_uniform(int16_t *r,
+                                unsigned int len,
+                                const uint8_t *buf,
+                                unsigned int buflen)
+{
+  unsigned int ctr, pos;
+  uint16_t val0, val1;
+
+  ctr = pos = 0;
+  while(ctr < len && pos <= buflen - 3) {  // buflen is always at least 3
+    val0 = ((buf[pos+0] >> 0) | ((uint16_t)buf[pos+1] << 8)) & 0xFFF;
+    val1 = ((buf[pos+1] >> 4) | ((uint16_t)buf[pos+2] << 4)) & 0xFFF;
+    pos += 3;
+
+    if(val0 < S2N_KYBER_512_R3_Q)
+      r[ctr++] = val0;
+    if(ctr < len && val1 < S2N_KYBER_512_R3_Q)
+      r[ctr++] = val1;
+  }
+
+  return ctr;
+}
+
+#define gen_a(A,B)  gen_matrix_avx2(A,B,0)
+#define gen_at(A,B) gen_matrix_avx2(A,B,1)
+
+/*************************************************
+* Name:        gen_matrix_avx2
+*
+* Description: Deterministically generate matrix A (or the transpose of A)
+*              from a seed. Entries of the matrix are polynomials that look
+*              uniformly random. Performs rejection sampling on output of
+*              a XOF
+*
+* Arguments:   - polyvec *a: pointer to ouptput matrix A
+*              - const uint8_t *seed: pointer to input seed
+*              - int transposed: boolean deciding whether A or A^T is generated
+**************************************************/
+/*
+void gen_matrix_avx2(polyvec *a, const uint8_t seed[32], int transposed)
+{
+  unsigned int ctr0, ctr1, ctr2, ctr3;
+  ALIGNED_UINT8(REJ_UNIFORM_AVX_NBLOCKS*S2N_KYBER_512_R3_SHAKE128_RATE) buf[4];
+  __m256i f;
+  keccakx4_state state;
+
+  f = _mm256_loadu_si256((__m256i *)seed);
+  _mm256_store_si256(buf[0].vec, f);
+  _mm256_store_si256(buf[1].vec, f);
+  _mm256_store_si256(buf[2].vec, f);
+  _mm256_store_si256(buf[3].vec, f);
+
+  if(transposed) {
+    buf[0].coeffs[32] = 0;
+    buf[0].coeffs[33] = 0;
+    buf[1].coeffs[32] = 0;
+    buf[1].coeffs[33] = 1;
+    buf[2].coeffs[32] = 1;
+    buf[2].coeffs[33] = 0;
+    buf[3].coeffs[32] = 1;
+    buf[3].coeffs[33] = 1;
+  }
+  else {
+    buf[0].coeffs[32] = 0;
+    buf[0].coeffs[33] = 0;
+    buf[1].coeffs[32] = 1;
+    buf[1].coeffs[33] = 0;
+    buf[2].coeffs[32] = 0;
+    buf[2].coeffs[33] = 1;
+    buf[3].coeffs[32] = 1;
+    buf[3].coeffs[33] = 1;
+  }
+
+  shake128x4_absorb_once(&state, buf[0].coeffs, buf[1].coeffs, buf[2].coeffs, buf[3].coeffs, 34);
+  shake128x4_squeezeblocks(buf[0].coeffs, buf[1].coeffs, buf[2].coeffs, buf[3].coeffs, REJ_UNIFORM_AVX_NBLOCKS, &state);
+
+  ctr0 = rej_uniform_avx2(a[0].vec[0].coeffs, buf[0].coeffs);
+  ctr1 = rej_uniform_avx2(a[0].vec[1].coeffs, buf[1].coeffs);
+  ctr2 = rej_uniform_avx2(a[1].vec[0].coeffs, buf[2].coeffs);
+  ctr3 = rej_uniform_avx2(a[1].vec[1].coeffs, buf[3].coeffs);
+
+  while(ctr0 < S2N_KYBER_512_R3_N || ctr1 < S2N_KYBER_512_R3_N || ctr2 < S2N_KYBER_512_R3_N || ctr3 < S2N_KYBER_512_R3_N) {
+    shake128x4_squeezeblocks(buf[0].coeffs, buf[1].coeffs, buf[2].coeffs, buf[3].coeffs, 1, &state);
+
+    ctr0 += rej_uniform(a[0].vec[0].coeffs + ctr0, S2N_KYBER_512_R3_N - ctr0, buf[0].coeffs, S2N_KYBER_512_R3_SHAKE128_RATE);
+    ctr1 += rej_uniform(a[0].vec[1].coeffs + ctr1, S2N_KYBER_512_R3_N - ctr1, buf[1].coeffs, S2N_KYBER_512_R3_SHAKE128_RATE);
+    ctr2 += rej_uniform(a[1].vec[0].coeffs + ctr2, S2N_KYBER_512_R3_N - ctr2, buf[2].coeffs, S2N_KYBER_512_R3_SHAKE128_RATE);
+    ctr3 += rej_uniform(a[1].vec[1].coeffs + ctr3, S2N_KYBER_512_R3_N - ctr3, buf[3].coeffs, S2N_KYBER_512_R3_SHAKE128_RATE);
+  }
+
+  poly_nttunpack(&a[0].vec[0]);
+  poly_nttunpack(&a[0].vec[1]);
+  poly_nttunpack(&a[1].vec[0]);
+  poly_nttunpack(&a[1].vec[1]);
+}
+*/
+
+#define XOF_BLOCKBYTES 168
+#define GEN_MATRIX_NBLOCKS ((12*S2N_KYBER_512_R3_N/8*(1 << 12)/S2N_KYBER_512_R3_Q + XOF_BLOCKBYTES)/XOF_BLOCKBYTES)
+static void gen_matrix(polyvec *a, const uint8_t seed[S2N_KYBER_512_R3_SYMBYTES], int transposed) {
+    unsigned int ctr, buflen, off;
+    uint8_t buf[GEN_MATRIX_NBLOCKS * XOF_BLOCKBYTES + 2];
+    xof_state state;
+
+    for (unsigned int i = 0; i < S2N_KYBER_512_R3_K; i++) {
+        for (unsigned int j = 0; j < S2N_KYBER_512_R3_K; j++) {
+            if (transposed) {
+                kyber_shake128_absorb(&state, seed, i, j);
+            } else {
+                kyber_shake128_absorb(&state, seed, j, i);
+            }
+
+            shake128_squeezeblocks(buf, GEN_MATRIX_NBLOCKS, &state);
+            buflen = GEN_MATRIX_NBLOCKS * XOF_BLOCKBYTES;
+            ctr = rej_uniform(a[i].vec[j].coeffs, S2N_KYBER_512_R3_N, buf, buflen);
+
+            while (ctr < S2N_KYBER_512_R3_N) {
+                off = buflen % 3;
+                for (unsigned int k = 0; k < off; k++) {
+                    buf[k] = buf[buflen - off + k];
+                }
+                shake128_squeezeblocks(buf + off, 1, &state);
+                buflen = off + XOF_BLOCKBYTES;
+                ctr += rej_uniform(a[i].vec[j].coeffs + ctr, S2N_KYBER_512_R3_N - ctr, buf, buflen);
+            }
+        }
+    }
+}
+
+/*************************************************
+* Name:        indcpa_keypair_avx2
+*
+* Description: Generates public and private key for the CPA-secure
+*              public-key encryption scheme underlying Kyber
+*
+* Arguments:   - uint8_t *pk: pointer to output public key
+*                             (of length S2N_KYBER_512_R3_INDCPA_PUBLICKEYBYTES bytes)
+*              - uint8_t *sk: pointer to output private key
+                              (of length S2N_KYBER_512_R3_INDCPA_SECRETKEYBYTES bytes)
+**************************************************/
+int indcpa_keypair_avx2(uint8_t pk[S2N_KYBER_512_R3_INDCPA_PUBLICKEYBYTES],
+                    uint8_t sk[S2N_KYBER_512_R3_INDCPA_SECRETKEYBYTES])
+{
+  unsigned int i;
+  uint8_t buf[2*S2N_KYBER_512_R3_SYMBYTES];
+  const uint8_t *publicseed = buf;
+  const uint8_t *noiseseed = buf + S2N_KYBER_512_R3_SYMBYTES;
+  polyvec a[S2N_KYBER_512_R3_K], e, pkpv, skpv;
+  uint8_t nonce = 0;
+    
+  POSIX_GUARD_RESULT(s2n_get_random_bytes(buf, S2N_KYBER_512_R3_SYMBYTES));
+  sha3_512(buf, buf, S2N_KYBER_512_R3_SYMBYTES);
+
+  //gen_a(a, publicseed);
+
+  //poly_getnoise_eta1_4x(skpv.vec+0, skpv.vec+1, e.vec+0, e.vec+1, noiseseed, 0, 1, 2, 3);
+
+  gen_matrix(a, publicseed, 0);
+
+  for (i = 0; i < S2N_KYBER_512_R3_K; i++) {
+    poly_getnoise_eta1(&skpv.vec[i], noiseseed, nonce++);
+  }
+  for (i = 0; i < S2N_KYBER_512_R3_K; i++) {
+    poly_getnoise_eta1(&e.vec[i], noiseseed, nonce++);
+  }
+
+  polyvec_ntt(&skpv);
+  polyvec_reduce(&skpv);
+  polyvec_ntt(&e);
+
+  // matrix-vector multiplication
+  for(i=0;i<S2N_KYBER_512_R3_K;i++) {
+    polyvec_pointwise_acc_montgomery(&pkpv.vec[i], &a[i], &skpv);
+    poly_tomont(&pkpv.vec[i]);
+  }
+
+  polyvec_add(&pkpv, &pkpv, &e);
+  polyvec_reduce(&pkpv);
+
+  pack_sk(sk, &skpv);
+  pack_pk(pk, &pkpv, publicseed);
+    
+  return 0;
+}
+
+/*************************************************
+* Name:        indcpa_enc_avx2
+*
+* Description: Encryption function of the CPA-secure
+*              public-key encryption scheme underlying Kyber.
+*
+* Arguments:   - uint8_t *c: pointer to output ciphertext
+*                            (of length S2N_KYBER_512_R3_INDCPA_BYTES bytes)
+*              - const uint8_t *m: pointer to input message
+*                                  (of length S2N_KYBER_512_R3_INDCPA_MSGBYTES bytes)
+*              - const uint8_t *pk: pointer to input public key
+*                                   (of length S2N_KYBER_512_R3_INDCPA_PUBLICKEYBYTES)
+*              - const uint8_t *coins: pointer to input random coins used as seed
+*                                      (of length S2N_KYBER_512_R3_SYMBYTES) to deterministically
+*                                      generate all randomness
+**************************************************/
+void indcpa_enc_avx2(uint8_t c[S2N_KYBER_512_R3_INDCPA_BYTES],
+                const uint8_t m[S2N_KYBER_512_R3_INDCPA_MSGBYTES],
+                const uint8_t pk[S2N_KYBER_512_R3_INDCPA_PUBLICKEYBYTES],
+                const uint8_t coins[S2N_KYBER_512_R3_SYMBYTES])
+{
+  unsigned int i;
+  uint8_t seed[S2N_KYBER_512_R3_SYMBYTES];
+  polyvec sp, pkpv, ep, at[S2N_KYBER_512_R3_K], b;
+  poly v, k, epp;
+    
+  uint8_t nonce = 0;
+
+  unpack_pk(&pkpv, seed, pk);
+  poly_frommsg(&k, m);
+  //gen_at(at, seed);
+
+  //poly_getnoise_eta1122_4x(sp.vec+0, sp.vec+1, ep.vec+0, ep.vec+1, coins, 0, 1, 2, 3);
+  //poly_getnoise_eta2(&epp, coins, 4);
+
+    gen_matrix(at, seed, 1);
+
+  for (i = 0; i < S2N_KYBER_512_R3_K; i++) {
+    poly_getnoise_eta1(sp.vec + i, coins, nonce++);
+  }
+  for (i = 0; i < S2N_KYBER_512_R3_K; i++) {
+    poly_getnoise_eta2(ep.vec + i, coins, nonce++);
+  }
+  poly_getnoise_eta2(&epp, coins, nonce++);
+    
+  polyvec_ntt(&sp);
+
+  // matrix-vector multiplication
+  for(i=0;i<S2N_KYBER_512_R3_K;i++)
+    polyvec_pointwise_acc_montgomery(&b.vec[i], &at[i], &sp);
+  polyvec_pointwise_acc_montgomery(&v, &pkpv, &sp);
+
+  polyvec_invntt_tomont(&b);
+  poly_invntt_tomont(&v);
+
+
+  polyvec_add(&b, &b, &ep);
+  poly_add(&v, &v, &epp);
+  poly_add(&v, &v, &k);
+  polyvec_reduce(&b);
+  poly_reduce(&v);
+
+  pack_ciphertext(c, &b, &v);
+}
+
+/*************************************************
+* Name:        indcpa_dec_avx2
+*
+* Description: Decryption function of the CPA-secure
+*              public-key encryption scheme underlying Kyber.
+*
+* Arguments:   - uint8_t *m: pointer to output decrypted message
+*                            (of length S2N_KYBER_512_R3_INDCPA_MSGBYTES)
+*              - const uint8_t *c: pointer to input ciphertext
+*                                  (of length S2N_KYBER_512_R3_INDCPA_BYTES)
+*              - const uint8_t *sk: pointer to input secret key
+*                                   (of length S2N_KYBER_512_R3_INDCPA_SECRETKEYBYTES)
+**************************************************/
+void indcpa_dec_avx2(uint8_t m[S2N_KYBER_512_R3_INDCPA_MSGBYTES],
+                const uint8_t c[S2N_KYBER_512_R3_INDCPA_BYTES],
+                const uint8_t sk[S2N_KYBER_512_R3_INDCPA_SECRETKEYBYTES])
+{
+  polyvec b, skpv;
+  poly v, mp;
+
+  unpack_ciphertext(&b, &v, c);
+  unpack_sk(&skpv, sk);
+
+  polyvec_ntt(&b);
+  polyvec_pointwise_acc_montgomery(&mp, &skpv, &b);
+  poly_invntt_tomont(&mp);
+
+  poly_sub(&mp, &v, &mp);
+  poly_reduce(&mp);
+
+  poly_tomsg(m, &mp);
+}
+
+#endif

--- a/pq-crypto/kyber_r3/kyber512r3_kem.c
+++ b/pq-crypto/kyber_r3/kyber512r3_kem.c
@@ -24,7 +24,14 @@
 int s2n_kyber_512_r3_crypto_kem_keypair(unsigned char *pk, unsigned char *sk)
 {
     POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
-    POSIX_GUARD(indcpa_keypair(pk, sk));
+#if defined(S2N_KYBER512R3_AVX2_BMI2)
+    if (s2n_kyber512r3_is_avx2_bmi2_enabled()) {
+        POSIX_GUARD(indcpa_keypair_avx2(pk, sk));
+    }else
+#endif
+    {
+        POSIX_GUARD(indcpa_keypair(pk, sk));
+    }
     for(size_t i = 0; i < S2N_KYBER_512_R3_INDCPA_PUBLICKEYBYTES; i++) {
         sk[i + S2N_KYBER_512_R3_INDCPA_SECRETKEYBYTES] = pk[i];
     }
@@ -65,8 +72,15 @@ int s2n_kyber_512_r3_crypto_kem_enc(unsigned char *ct, unsigned char *ss, const 
     sha3_512(kr, buf, 2*S2N_KYBER_512_R3_SYMBYTES);
 
     /* coins are in kr+S2N_KYBER_512_R3_SYMBYTES */
-    indcpa_enc(ct, buf, pk, kr+S2N_KYBER_512_R3_SYMBYTES);
-
+#if defined(S2N_KYBER512R3_AVX2_BMI2)
+    if (s2n_kyber512r3_is_avx2_bmi2_enabled()) {
+        indcpa_enc_avx2(ct, buf, pk, kr+S2N_KYBER_512_R3_SYMBYTES);
+    }else
+#endif
+    {
+        indcpa_enc(ct, buf, pk, kr+S2N_KYBER_512_R3_SYMBYTES);
+    }
+    
     /* overwrite coins in kr with H(c) */
     sha3_256(kr+S2N_KYBER_512_R3_SYMBYTES, ct, S2N_KYBER_512_R3_CIPHERTEXT_BYTES);
     /* hash concatenation of pre-k and H(c) to k */
@@ -100,8 +114,15 @@ int s2n_kyber_512_r3_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, 
     uint8_t cmp[S2N_KYBER_512_R3_CIPHERTEXT_BYTES];
     const uint8_t *pk = sk+S2N_KYBER_512_R3_INDCPA_SECRETKEYBYTES;
 
-    indcpa_dec(buf, ct, sk);
-
+#if defined(S2N_KYBER512R3_AVX2_BMI2)
+    if (s2n_kyber512r3_is_avx2_bmi2_enabled()) {
+        indcpa_dec_avx2(buf, ct, sk);
+    }else
+#endif
+    {
+        indcpa_dec(buf, ct, sk);
+    }
+    
     /* Multitarget countermeasure for coins + contributory KEM */
     for(size_t i = 0; i < S2N_KYBER_512_R3_SYMBYTES; i++) {
         buf[S2N_KYBER_512_R3_SYMBYTES + i] = sk[S2N_KYBER_512_R3_SECRET_KEY_BYTES - 2 * S2N_KYBER_512_R3_SYMBYTES + i];
@@ -109,8 +130,15 @@ int s2n_kyber_512_r3_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, 
     sha3_512(kr, buf, 2*S2N_KYBER_512_R3_SYMBYTES);
 
     /* coins are in kr+S2N_KYBER_512_R3_SYMBYTES */
-    indcpa_enc(cmp, buf, pk, kr+S2N_KYBER_512_R3_SYMBYTES);
-
+#if defined(S2N_KYBER512R3_AVX2_BMI2)
+    if (s2n_kyber512r3_is_avx2_bmi2_enabled()) {
+        indcpa_enc_avx2(cmp, buf, pk, kr+S2N_KYBER_512_R3_SYMBYTES);
+    }else
+#endif
+    {
+        indcpa_enc(cmp, buf, pk, kr+S2N_KYBER_512_R3_SYMBYTES);
+    }
+    
     /* If ct and cmp are equal (dont_copy = 1), decryption has succeeded and we do NOT overwrite pre-k below.
      * If ct and cmp are not equal (dont_copy = 0), decryption fails and we do overwrite pre-k. */
     int dont_copy = s2n_constant_time_equals(ct, cmp, S2N_KYBER_512_R3_CIPHERTEXT_BYTES);

--- a/pq-crypto/s2n_pq.c
+++ b/pq-crypto/s2n_pq.c
@@ -23,6 +23,8 @@ static bool bike_r3_avx512_enabled  = false;
 static bool bike_r3_pclmul_enabled  = false;
 static bool bike_r3_vpclmul_enabled = false;
 
+static bool kyber512r3_avx2_bmi2_enabled = false;
+
 #if defined(S2N_CPUID_AVAILABLE)
 /* https://en.wikipedia.org/wiki/CPUID */
 #include <cpuid.h>
@@ -78,6 +80,15 @@ bool s2n_cpu_supports_adx() {
     }
 
     return (ebx & bit_ADX);
+}
+
+bool s2n_cpu_supports_avx2() {
+    uint32_t eax, ebx, ecx, edx;
+    if (!s2n_get_cpuid_count(EXTENDED_FEATURES_LEAF, EXTENDED_FEATURES_SUBLEAF_ZERO, &eax, &ebx, &ecx, &edx)) {
+        return false;
+    }
+
+    return (ebx & EBX_BIT_AVX2);
 }
 
 bool s2n_cpu_supports_sikep434r3_asm() {
@@ -143,6 +154,14 @@ bool s2n_cpu_supports_bike_r3_vpclmul() {
 #endif
 }
 
+bool s2n_cpu_supports_kyber512r3_avx2_bmi2() {
+#if defined(S2N_KYBER512R3_AVX2_BMI2)
+    return s2n_cpu_supports_bmi2() && s2n_cpu_supports_avx2();
+#else
+    return false;
+#endif
+}
+
 #else /* defined(S2N_CPUID_AVAILABLE) */
 
 /* If CPUID is not available, we cannot perform necessary run-time checks. */
@@ -163,6 +182,10 @@ bool s2n_cpu_supports_bike_r3_pclmul() {
 }
 
 bool s2n_cpu_supports_bike_r3_vpclmul() {
+    return false;
+}
+
+bool s2n_cpu_supports_kyber512r3_avx2_bmi2() {
     return false;
 }
 
@@ -188,6 +211,10 @@ bool s2n_bike_r3_is_vpclmul_enabled() {
     return bike_r3_vpclmul_enabled;
 }
 
+bool s2n_kyber512r3_is_avx2_bmi2_enabled() {
+    return kyber512r3_avx2_bmi2_enabled;
+}
+
 bool s2n_pq_is_enabled() {
 #if defined(S2N_NO_PQ)
     return false;
@@ -206,6 +233,11 @@ S2N_RESULT s2n_disable_bike_r3_opt_all() {
     bike_r3_avx512_enabled  = false;
     bike_r3_pclmul_enabled  = false;
     bike_r3_vpclmul_enabled = false;
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_disable_kyber512r3_opt_avx2_bmi2() {
+    kyber512r3_avx2_bmi2_enabled = false;
     return S2N_RESULT_OK;
 }
 
@@ -250,6 +282,13 @@ S2N_RESULT s2n_try_enable_sikep434r3_asm() {
     return S2N_RESULT_OK;
 }
 
+S2N_RESULT s2n_try_enable_kyber512r3_opt_avx2_bmi2() {
+    if (s2n_pq_is_enabled() && s2n_cpu_supports_kyber512r3_avx2_bmi2()) {
+        kyber512r3_avx2_bmi2_enabled = true;
+    }
+    return S2N_RESULT_OK;
+}
+
 S2N_RESULT s2n_bike_r3_x86_64_opt_init()
 {
     /* try_enable_vpclmul function recursively tries to enable
@@ -262,6 +301,7 @@ S2N_RESULT s2n_bike_r3_x86_64_opt_init()
 S2N_RESULT s2n_pq_init() {
     RESULT_ENSURE_OK(s2n_try_enable_sikep434r3_asm(), S2N_ERR_SAFETY);
     RESULT_ENSURE_OK(s2n_bike_r3_x86_64_opt_init(), S2N_ERR_SAFETY);
-
+    RESULT_ENSURE_OK(s2n_try_enable_kyber512r3_opt_avx2_bmi2(), S2N_ERR_SAFETY);
+    
     return S2N_RESULT_OK;
 }

--- a/pq-crypto/s2n_pq.h
+++ b/pq-crypto/s2n_pq.h
@@ -34,5 +34,9 @@ S2N_RESULT s2n_try_enable_bike_r3_opt_avx2(void);
 S2N_RESULT s2n_try_enable_bike_r3_opt_avx512(void);
 S2N_RESULT s2n_try_enable_bike_r3_opt_vpclmul(void);
 
+bool s2n_kyber512r3_is_avx2_bmi2_enabled(void);
+S2N_RESULT s2n_try_enable_kyber512r3_opt_avx2_bmi2(void);
+S2N_RESULT s2n_disable_kyber512r3_opt_avx2_bmi2(void);
+
 bool s2n_pq_is_enabled(void);
 S2N_RESULT s2n_pq_init(void);

--- a/pq-crypto/s2n_pq_asm.mk
+++ b/pq-crypto/s2n_pq_asm.mk
@@ -66,4 +66,18 @@ ifndef S2N_NO_PQ_ASM
 		CFLAGS_LLVM += -DS2N_BIKE_R3_VPCLMUL
 		BIKE_R3_VPCLMUL_FLAGS := -mvpclmulqdq -mavx512f -mavx512bw -mavx512dq
 	endif
+ 
+    # Kyber Round-3 code has several different optimizations
+    # which require specific compiler flags to be supported
+    # by the compiler. So for each needed instruction set
+    # extension we check if the compiler supports it and
+    # set proper flags to be added in the kyber_r3 Makefile.
+    dummy_file := "$(S2N_ROOT)/tests/features/noop_main.c"
+    dummy_file_out := "test_kyber512r3_avx2_bmi2_support.o"
+    KYBER512R3_AVX2_BMI2_SUPPORTED := $(shell $(CC) -mavx2 -mbmi2 -c -o $(dummy_file_out) $(dummy_file) > /dev/null 2>&1; echo $$?; rm $(dummy_file_out) > /dev/null 2>&1)
+    ifeq ($(KYBER512R3_AVX2_BMI2_SUPPORTED), 0)
+        CFLAGS += -DS2N_KYBER512R3_AVX2_BMI2
+        CFLAGS_LLVM += -DS2N_KYBER512R3_AVX2_BMI2
+        KYBER512R3_AVX2_BMI2_FLAGS := -mavx2 -mbmi2
+    endif
 endif

--- a/tests/unit/s2n_pq_kem_kat_test.c
+++ b/tests/unit/s2n_pq_kem_kat_test.c
@@ -98,6 +98,13 @@ static const struct s2n_kem_test_vector test_vectors[] = {
                 .disable_asm = s2n_pq_noop_asm,
         },
         {
+                .kem = &s2n_kyber_512_r3,
+                .kat_file = "kats/kyber_r3.kat",
+                .asm_is_enabled = s2n_kyber512r3_is_avx2_bmi2_enabled,
+                .enable_asm = s2n_try_enable_kyber512r3_opt_avx2_bmi2,
+                .disable_asm = s2n_disable_kyber512r3_opt_avx2_bmi2,
+        },
+        {
                 .kem = &s2n_sike_p434_r3,
                 .kat_file = "kats/sike_r3.kat",
                 .asm_is_enabled = s2n_sikep434r3_asm_is_enabled,

--- a/tests/unit/s2n_pq_kem_test.c
+++ b/tests/unit/s2n_pq_kem_test.c
@@ -88,6 +88,12 @@ static const struct s2n_kem_test_vector test_vectors[] = {
                 .disable_asm = s2n_pq_noop_asm,
         },
         {
+                .kem = &s2n_kyber_512_r3,
+                .asm_is_enabled = s2n_kyber512r3_is_avx2_bmi2_enabled,
+                .enable_asm = s2n_try_enable_kyber512r3_opt_avx2_bmi2,
+                .disable_asm = s2n_disable_kyber512r3_opt_avx2_bmi2,
+        },
+        {
                 .kem = &s2n_sike_p434_r3,
                 .asm_is_enabled = s2n_sikep434r3_asm_is_enabled,
                 .enable_asm = s2n_try_enable_sikep434r3_asm,


### PR DESCRIPTION
### Resolved issues:

N\A

### Description of changes: 

Imports the "avx2" implementation of the Kyber 512 KEM from R[ound 3 of NIST's PQ crypto standardization effort](https://csrc.nist.gov/Projects/post-quantum-cryptography/round-3-submissions). The crypto code that forms the basis of this change was taken from [Crystals Kyber GitHub repository](https://github.com/pq-crystals/kyber).

### Call-outs:

The crypto specification for kyber512r3 AVX2 optimized implementation is the same as kyber512r3 reference implementation. In other words, the KAT files and PQ extension IDs are the same, and both of the implementations are interoperable. Note that the same namespace macro is used for this imported implementation.

Changes were made to the submission code (by me) to:

- Remove unused/unnecessary code
- Make use of s2n's safety macros
- Integrate with s2n's entropy provider

### Testing:

- The associated KAT and KEM unit test has been added.
- To keep this change a reasonable size (as much as possible), this PR does not exhaustively include all tests necessary for this KEM. There are additional fuzz tests that will be added to future PRs. Moreover, this is a very small and working version of this import process.

- This is not a refactor change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
