### PR TITLE
Make Async ClientHello Callback and PSK Work Together

### DIFF
--- a/tests/testlib/s2n_test_server_client.c
+++ b/tests/testlib/s2n_test_server_client.c
@@ -28,6 +28,10 @@ static S2N_RESULT s2n_validate_negotiate_result(bool success, bool peer_is_done,
         return S2N_RESULT_ERROR;
     }
 
+    if(s2n_errno == S2N_ERR_ASYNC_BLOCKED) {
+        return S2N_RESULT_ERROR;
+    }
+
     /* If we're blocked but our peer is done writing, propagate the error. */
     if(peer_is_done) {
         return S2N_RESULT_ERROR;

--- a/tests/unit/s2n_self_talk_psk_test.c
+++ b/tests/unit/s2n_self_talk_psk_test.c
@@ -142,7 +142,7 @@ static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn, vo
     return S2N_SUCCESS;
 }
 
-int client_hello_noop_cb(struct s2n_connection *conn, void *ctx)
+int static s2n_client_hello_no_op_cb(struct s2n_connection *conn, void *ctx)
 {
     return S2N_SUCCESS;
 }
@@ -292,7 +292,7 @@ int main(int argc, char **argv)
 
     /* Basic PSK with Client Hello async callback set */
     {
-        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_noop_cb, NULL));
+        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, s2n_client_hello_no_op_cb, NULL));
         EXPECT_SUCCESS(s2n_config_set_client_hello_cb_mode(config, S2N_CLIENT_HELLO_CB_NONBLOCKING));
 
         s2n_set_config_both_connections(client_conn, server_conn, config);
@@ -323,7 +323,7 @@ int main(int argc, char **argv)
 
     /* HRR with PSK and Client Hello async callback set */
     {
-        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config_with_certs, client_hello_noop_cb, NULL));
+        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config_with_certs, s2n_client_hello_no_op_cb, NULL));
         EXPECT_SUCCESS(s2n_config_set_client_hello_cb_mode(config_with_certs, S2N_CLIENT_HELLO_CB_NONBLOCKING));
 
         /* Setup certs */

--- a/tests/unit/s2n_self_talk_psk_test.c
+++ b/tests/unit/s2n_self_talk_psk_test.c
@@ -142,7 +142,7 @@ static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn, vo
     return S2N_SUCCESS;
 }
 
-int static s2n_client_hello_no_op_cb(struct s2n_connection *conn, void *ctx)
+static int s2n_client_hello_no_op_cb(struct s2n_connection *conn, void *ctx)
 {
     return S2N_SUCCESS;
 }

--- a/tests/unit/s2n_self_talk_psk_test.c
+++ b/tests/unit/s2n_self_talk_psk_test.c
@@ -142,6 +142,11 @@ static int s2n_test_select_psk_identity_callback(struct s2n_connection *conn, vo
     return S2N_SUCCESS;
 }
 
+int client_hello_noop_cb(struct s2n_connection *conn, void *ctx)
+{
+    return S2N_SUCCESS;
+}
+
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
@@ -283,6 +288,37 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
         EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+    }
+
+    /* Basic PSK with Client Hello async callback set */
+    {
+        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_noop_cb, NULL));
+        EXPECT_SUCCESS(s2n_config_set_client_hello_cb_mode(config, S2N_CLIENT_HELLO_CB_NONBLOCKING));
+
+        s2n_set_config_both_connections(client_conn, server_conn, config);
+        s2n_set_io_pair_both_connections(client_conn, server_conn, io_pair);
+
+        /* Setup PSKs */
+        EXPECT_OK(setup_client_psks(client_conn));
+        EXPECT_OK(setup_server_psks(server_conn));
+
+        /* Handshake negotiation is successful when the Client Hello callback is marked as done */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_test_server_and_client(server_conn, client_conn), S2N_ERR_ASYNC_BLOCKED);
+        EXPECT_SUCCESS(s2n_client_hello_cb_done(server_conn));
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+        /* Validate handshake type */
+        EXPECT_FALSE(ARE_FULL_HANDSHAKES(client_conn, server_conn));
+
+        /* Validate chosen PSK */
+        EXPECT_OK(validate_chosen_psk(server_conn, test_shared_identity, sizeof(test_shared_identity),
+                                      TEST_SHARED_PSK_WIRE_INDEX_1));
+
+        EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
+
+        EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+        EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, NULL, NULL));
     }
 
     /* HRR with PSK */

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1093,6 +1093,17 @@ static S2N_RESULT s2n_wipe_record(struct s2n_connection *conn)
     return S2N_RESULT_OK;
 }
 
+static S2N_RESULT s2n_finish_read(struct s2n_connection *conn)
+{
+    RESULT_ENSURE_REF(conn);
+
+    RESULT_GUARD_POSIX(s2n_handshake_conn_update_hashes(conn));
+    RESULT_GUARD_POSIX(s2n_stuffer_wipe(&conn->handshake.io));
+    RESULT_GUARD_POSIX(s2n_tls13_handle_secrets(conn));
+    RESULT_GUARD_POSIX(s2n_advance_message(conn));
+    return S2N_RESULT_OK;
+}
+
 /* Reading is a little more complicated than writing as the TLS RFCs allow content
  * types to be interleaved at the record layer. We may get an alert message
  * during the handshake phase, or messages of types that we don't support (e.g.
@@ -1232,29 +1243,12 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
 
         /* Call the relevant handler */
         r = ACTIVE_STATE(conn).handler[conn->mode] (conn);
-        /* At this point we may have already failed.
-         * If the handler fails, we clean up the handshake
-         * and skip processing steps necessary to continue connecting (such as updating the transcript hash.)
-         */
-
-        /* Don't update handshake hashes until after the handler has executed since some handlers need to read the
-         * hash values before they are updated. */
-        if (r >= S2N_SUCCESS || S2N_ERROR_IS_BLOCKING(s2n_errno)) { /* Only do this if we haven't already failed */
-            POSIX_GUARD(s2n_handshake_conn_update_hashes(conn));
-        }
-
-        /* Wipe regardless of whether or not we are successful. */
-        POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
 
         /* Bail with blinding if we have failed. */
         WITH_ERROR_BLINDING(conn, POSIX_GUARD(r));
-        /* At this point we know that we have not failed yet because the prior line would have bailed if we had. */
 
-        /* Update the secrets, if necessary */
-        POSIX_GUARD(s2n_tls13_handle_secrets(conn));
-
-        /* Advance the state machine */
-        POSIX_GUARD(s2n_advance_message(conn));
+        /* If we have not failed, update hashes and wipe the handshake stuffer */
+        POSIX_GUARD_RESULT(s2n_finish_read(conn));
     }
 
     /* We're done with the record, wipe it */
@@ -1302,8 +1296,7 @@ static int s2n_handle_retry_state(struct s2n_connection *conn)
 
         /* The read handler processed the record successfully, we are done with this
          * record. Advance the state machine. */
-        POSIX_GUARD(s2n_tls13_handle_secrets(conn));
-        POSIX_GUARD(s2n_advance_message(conn));
+        POSIX_GUARD_RESULT(s2n_finish_read(conn));
     }
 
     return 0;

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1242,12 +1242,9 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
         POSIX_ENSURE(!CONNECTION_IS_WRITER(conn), S2N_ERR_BAD_MESSAGE);
 
         /* Call the relevant handler */
-        r = ACTIVE_STATE(conn).handler[conn->mode] (conn);
+        WITH_ERROR_BLINDING(conn, POSIX_GUARD(ACTIVE_STATE(conn).handler[conn->mode] (conn)));
 
-        /* Bail with blinding if we have failed. */
-        WITH_ERROR_BLINDING(conn, POSIX_GUARD(r));
-
-        /* If we have not failed, update hashes and wipe the handshake stuffer */
+        /* Advance the state machine */
         POSIX_GUARD_RESULT(s2n_finish_read(conn));
     }
 


### PR DESCRIPTION
### Resolved issues:

 resolves #2967

### Description of changes: 
The ClientHello callback is [called before processing](https://github.com/aws/s2n-tls/blob/main/tls/s2n_client_hello.c#L367) the extensions from the ClientHello. Therefore, if the ClientHello callback is on non-blocking mode and doesn't manage to complete before the function returns, the extensions don't actually get processed yet. This in and of itself isn't a problem, as we have a s2n_handle_retry function which will continue to call the ClientHello handler again and process the extensions whenever the ClientHello callback is marked as done. 

The issue is that currently the _handshake.io stuffer gets wiped_ after the callback executes. The PSK extension needs this stuffer data to calculate PSK binders. So, during non-blocking mode, the handshake.io stuffer is wiped, and whenever the ClientHello callback succeeds and we move on to processing extensions, there is no handshake.io stuffer data for the PSK extension to use, which is an error.

Complicated problem! But the fix is pretty small. Instead of wiping the handshake.io stuffer after the handler executes, we only wipe the stuffer(and update the hashes) after we know the handler has executed successfully.

### Call-outs:

Another solution to this is to use the stored ClientHello to calculate the PSK binders. This ends up being a much larger change, so I went with just moving the stuffer wipe function.
### Testing:
Functional tests. I added a PSK + Async callback + HRR combo test as the HRR matters for calculating the PSK binders and I wanted to make sure this is done correctly.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
