### PR TITLE
Change debug line to the format gdb expects

### DIFF
--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -291,7 +291,7 @@ extern __thread const char *s2n_debug_str;
 #define STRING_(s) TO_STRING(s)
 #define STRING__LINE__ STRING_(__LINE__)
 
-#define _S2N_DEBUG_LINE     "Error encountered in " __FILE__ " line " STRING__LINE__
+#define _S2N_DEBUG_LINE     "Error encountered in " __FILE__ ":" STRING__LINE__
 #define _S2N_ERROR( x )     do { s2n_debug_str = _S2N_DEBUG_LINE; s2n_errno = ( x ); s2n_calculate_stacktrace(); } while (0)
 #define S2N_ERROR( x )      do { _S2N_ERROR( ( x ) ); return -1; } while (0)
 #define S2N_ERROR_PRESERVE_ERRNO() do { return -1; } while (0)

--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -86,11 +86,11 @@ int test_count;
                           int real_errno = errno; \
                           if (isatty(fileno(stderr))) { \
                             errno = real_errno; \
-                            fprintf(stderr, "\033[31;1mFAILED test %d\033[0m\n%s (%s line %d)\nError Message: '%s'\n Debug String: '%s'\n System Error: %s (%d)\n", test_count, (msg), __FILE__, __LINE__, s2n_strerror(s2n_errno, "EN"), s2n_debug_str, strerror(errno), errno); \
+                            fprintf(stderr, "\033[31;1mFAILED test %d\033[0m\n%s (%s:%d)\nError Message: '%s'\n Debug String: '%s'\n System Error: %s (%d)\n", test_count, (msg), __FILE__, __LINE__, s2n_strerror(s2n_errno, "EN"), s2n_debug_str, strerror(errno), errno); \
                           } \
                           else { \
                             errno = real_errno; \
-                            fprintf(stderr, "FAILED test %d\n%s (%s line %d)\nError Message: '%s'\n Debug String: '%s'\n System Error: %s (%d)\n", test_count, (msg), __FILE__, __LINE__, s2n_strerror(s2n_errno, "EN"), s2n_debug_str, strerror(errno), errno); \
+                            fprintf(stderr, "FAILED test %d\n%s (%s:%d)\nError Message: '%s'\n Debug String: '%s'\n System Error: %s (%d)\n", test_count, (msg), __FILE__, __LINE__, s2n_strerror(s2n_errno, "EN"), s2n_debug_str, strerror(errno), errno); \
                           } \
                         } while(0)
 


### PR DESCRIPTION
### Description of changes: 

When debugging with gdb, it's mildly annoying to be unable to copy the debug line into a breakpoint without replacing "line" with ":", which is what gdb expects. ":" isn't any less readable and is the standard in stacktraces, so let's just use it.

Example output:
```
!(((s2n_disable_tls13())) == (-1)) is not true  (s2n_handshake_test.c:239)
Error Message: 'a safety check failed'
 Debug String: 'Error encountered in s2n_tls13.c:49'
 System Error: No such file or directory (2)
```

Previous output:
```
!(((s2n_disable_tls13())) == (-1)) is not true  (s2n_handshake_test.c line 239)
Error Message: 'a safety check failed'
 Debug String: 'Error encountered in s2n_tls13.c line 49'
 System Error: No such file or directory (2)
```

### Testing
I broke a test and checked the output.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
