### PR TITLE
Refactor s2n_client_key_share_extension for scaleability

### DIFF
--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -576,21 +576,20 @@ void cbmc_populate_s2n_session_key(struct s2n_session_key *s2n_session_key)
     s2n_session_key->evp_cipher_ctx = malloc(sizeof(*(s2n_session_key->evp_cipher_ctx)));
 }
 
-void cbmc_populate_s2n_kex_parameters(struct s2n_kex_parameters *s2n_kex_paramters)
+void cbmc_populate_s2n_kex_parameters(struct s2n_kex_parameters *s2n_kex_parameters)
 {
-	cbmc_populate_s2n_dh_params(&(s2n_kex_paramters->server_dh_params));
-	cbmc_populate_s2n_ecc_evp_params(&(s2n_kex_paramters->server_ecc_evp_params));
+	cbmc_populate_s2n_dh_params(&(s2n_kex_parameters->server_dh_params));
+	cbmc_populate_s2n_ecc_evp_params(&(s2n_kex_parameters->server_ecc_evp_params));
 	/* `s2n_crypto_parameters->mutually_supported_curves`
 	 * `s2n_crypto_parameters->client_ecc_evp_params`
 	 * `s2n_crypto_parameters->client_kem_group_params`
 	 * `s2n_crypto_parameters->mutually_supported_kem_groups` are never allocated.
 	 * If required, these initializations should be done in the proof harness.
 	 */
-	cbmc_populate_s2n_kem_group_params(&(s2n_kex_paramters->server_kem_group_params));
-	s2n_kex_paramters->chosen_client_kem_group_params = cbmc_allocate_s2n_kem_group_params();
-	cbmc_populate_s2n_kem_params(&(s2n_kex_paramters->kem_params));
-	cbmc_populate_s2n_blob(&(s2n_kex_paramters->client_key_exchange_message));
-	cbmc_populate_s2n_blob(&(s2n_kex_paramters->client_pq_kem_extension));
+	cbmc_populate_s2n_kem_group_params(&(s2n_kex_parameters->server_kem_group_params));
+	cbmc_populate_s2n_kem_params(&(s2n_kex_parameters->kem_params));
+	cbmc_populate_s2n_blob(&(s2n_kex_parameters->client_key_exchange_message));
+	cbmc_populate_s2n_blob(&(s2n_kex_parameters->client_pq_kem_extension));
 }
 
 void cbmc_populate_s2n_crypto_parameters(struct s2n_crypto_parameters *s2n_crypto_parameters)

--- a/tests/fuzz/s2n_extensions_server_key_share_recv_test.c
+++ b/tests/fuzz/s2n_extensions_server_key_share_recv_test.c
@@ -64,11 +64,8 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     POSIX_GUARD(s2n_connection_get_ecc_preferences(client_conn, &ecc_preferences));
     POSIX_ENSURE_REF(ecc_preferences);
 
-    /* Generate ephemeral keys for all supported curves */
-    for (int i = 0; i < ecc_preferences->count; i++) {
-        client_conn->kex_params.client_ecc_evp_params[i].negotiated_curve = ecc_preferences->ecc_curves[i];
-        POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params[i]));
-    }
+    client_conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[randval % ecc_preferences->count];
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params));
 
     /* Run Test
      * Do not use GUARD macro here since the connection memory hasn't been freed.

--- a/tests/testlib/s2n_connection_test_utils.c
+++ b/tests/testlib/s2n_connection_test_utils.c
@@ -273,3 +273,26 @@ S2N_RESULT s2n_connection_set_secrets(struct s2n_connection *conn)
 
     return S2N_RESULT_OK;
 }
+
+S2N_RESULT s2n_set_all_mutually_supported_groups(struct s2n_connection *conn)
+{
+    RESULT_ENSURE_REF(conn);
+
+    const struct s2n_ecc_preferences *ecc_pref = NULL;
+    RESULT_GUARD_POSIX(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
+    RESULT_ENSURE_REF(ecc_pref);
+
+    for(size_t i = 0; i < ecc_pref->count; i++) {
+        conn->kex_params.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
+    }
+
+    const struct s2n_kem_preferences *kem_pref = NULL;
+    RESULT_GUARD_POSIX(s2n_connection_get_kem_preferences(conn, &kem_pref));
+    RESULT_ENSURE_REF(kem_pref);
+
+    for(size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
+        conn->kex_params.mutually_supported_kem_groups[i] = kem_pref->tls13_kem_groups[i];
+    }
+
+    return S2N_RESULT_OK;
+}

--- a/tests/testlib/s2n_testlib.h
+++ b/tests/testlib/s2n_testlib.h
@@ -60,6 +60,7 @@ int s2n_fd_set_non_blocking(int fd);
 int s2n_set_connection_hello_retry_flags(struct s2n_connection *conn);
 int s2n_connection_allow_all_response_extensions(struct s2n_connection *conn);
 int s2n_connection_set_all_protocol_versions(struct s2n_connection *conn, uint8_t version);
+S2N_RESULT s2n_set_all_mutually_supported_groups(struct s2n_connection *conn);
 
 S2N_RESULT s2n_connection_set_secrets(struct s2n_connection *conn);
 

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
      */
     {
         /* Carefully consider any increases to this number. */
-        const uint16_t max_connection_size = 14100;
+        const uint16_t max_connection_size = 13100;
         const uint16_t min_connection_size = max_connection_size * 0.75;
 
         size_t connection_size = sizeof(struct s2n_connection);

--- a/tests/unit/s2n_extensions_server_key_share_select_test.c
+++ b/tests/unit/s2n_extensions_server_key_share_select_test.c
@@ -45,33 +45,7 @@ int main() {
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
     }
 
-    /* If client and server have no mutually supported groups but server received an ECC key share,
-     * a Hello Retry Request flag is not set and the server ignores the mutually supported keyshare. */
-    {
-        struct s2n_connection *server_conn = NULL;
-        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
-
-        const struct s2n_ecc_preferences *ecc_pref = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
-        EXPECT_NOT_NULL(ecc_pref);
-
-        EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
-        EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
-        server_conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.client_ecc_evp_params[0]));
-
-        EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn),
-                S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
-
-        EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
-        EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
-        EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
-
-        EXPECT_SUCCESS(s2n_connection_free(server_conn));
-    }
-
-    /* If client has sent no keyshares, but server and client have a mutually supported EC curve,
+    /* If client has sent no valid keyshares, but server and client have a mutually supported EC curve,
      * send Hello Retry Request. */
     {
         struct s2n_connection *server_conn = NULL;
@@ -86,10 +60,8 @@ int main() {
         server_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[1];
         EXPECT_NULL(server_conn->kex_params.mutually_supported_curves[0]);
         server_conn->kex_params.mutually_supported_curves[1] = ecc_pref->ecc_curves[1];
-        for (size_t i = 0; i < ecc_pref->count; i++) {
-            EXPECT_NULL(server_conn->kex_params.client_ecc_evp_params[i].evp_pkey);
-            EXPECT_NULL(server_conn->kex_params.client_ecc_evp_params[i].negotiated_curve);
-        }
+        EXPECT_NULL(server_conn->kex_params.client_ecc_evp_params.evp_pkey);
+        EXPECT_NULL(server_conn->kex_params.client_ecc_evp_params.negotiated_curve);
 
         EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
@@ -100,7 +72,7 @@ int main() {
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
     }
 
-    /* When client and server mutually support curve 0 and curve 1, but client has only sent a keyshare for
+    /* When client has only sent a valid keyshare for
      * curve 1, Hello Retry Request is not sent and server chooses curve 1. */
     {
         struct s2n_connection *server_conn = NULL;
@@ -117,10 +89,10 @@ int main() {
         server_conn->kex_params.mutually_supported_curves[0] = ecc_pref->ecc_curves[0];
         server_conn->kex_params.mutually_supported_curves[1] = ecc_pref->ecc_curves[1];
 
-        EXPECT_NULL(server_conn->kex_params.client_ecc_evp_params[0].evp_pkey);
-        EXPECT_NULL(server_conn->kex_params.client_ecc_evp_params[0].negotiated_curve);
-        server_conn->kex_params.client_ecc_evp_params[1].negotiated_curve = ecc_pref->ecc_curves[1];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.client_ecc_evp_params[1]));
+        EXPECT_NULL(server_conn->kex_params.client_ecc_evp_params.evp_pkey);
+        EXPECT_NULL(server_conn->kex_params.client_ecc_evp_params.negotiated_curve);
+        server_conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[1];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.client_ecc_evp_params));
 
         EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
@@ -130,38 +102,6 @@ int main() {
         EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn)); 
-    }
-
-    /* When client and server mutually support curve 0 and curve 1 and client has sent keyshares for both,
-     * Hello Retry Request is not sent and server chooses curve 0. */
-    {
-        struct s2n_connection *server_conn = NULL;
-        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
-
-        const struct s2n_ecc_preferences *ecc_pref = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
-        EXPECT_NOT_NULL(ecc_pref);
-
-        /* Server would have initially chosen curve[0] when processing the supported_groups extension */
-        EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
-        server_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-        server_conn->kex_params.mutually_supported_curves[0] = ecc_pref->ecc_curves[0];
-        server_conn->kex_params.mutually_supported_curves[1] = ecc_pref->ecc_curves[1];
-
-        server_conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.client_ecc_evp_params[0]));
-        server_conn->kex_params.client_ecc_evp_params[1].negotiated_curve = ecc_pref->ecc_curves[1];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.client_ecc_evp_params[1]));
-
-        EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
-
-        /* Server should still prefer curve[0] after taking received keyshares into account */
-        EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
-        EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
-        EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
-
-        EXPECT_SUCCESS(s2n_connection_free(server_conn));
     }
 
     {
@@ -213,48 +153,7 @@ int main() {
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
 
-        /* If client and server have no mutually supported groups but server received a KEM group key share,
-         * a Hello Retry Request flag is not set and the server ignores the keyshare. */
-        {
-            struct s2n_connection *server_conn = NULL;
-            EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-            server_conn->security_policy_override = &test_security_policy;
-            EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
-
-            const struct s2n_kem_preferences *kem_pref = NULL;
-            EXPECT_SUCCESS(s2n_connection_get_kem_preferences(server_conn, &kem_pref));
-            EXPECT_NOT_NULL(kem_pref);
-
-            /* Server would have not chosen any group when processing the supported_groups extension */
-            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
-            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
-
-            /* Received an erroneous keyshare for kem group 0 */
-            struct s2n_kem_group_params *client_params0 = &server_conn->kex_params.client_kem_group_params[0];
-            const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];
-            client_params0->kem_group = kem_group0;
-            client_params0->kem_params.kem = kem_group0->kem;
-            client_params0->ecc_params.negotiated_curve = kem_group0->curve;
-            /* The PQ public key is fake; that's good enough for this test */
-            EXPECT_SUCCESS(s2n_alloc(&client_params0->kem_params.public_key, kem_group0->kem->public_key_length));
-            POSIX_CHECKED_MEMSET(client_params0->kem_params.public_key.data, 1, kem_group0->kem->public_key_length);
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params0->ecc_params));
-
-            EXPECT_FAILURE_WITH_ERRNO(s2n_extensions_server_key_share_select(server_conn),
-                    S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
-
-            /* Nothing selected, no HRR */
-            EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
-            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_group);
-            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.kem_params.kem);
-            EXPECT_NULL(server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->kex_params.chosen_client_kem_group_params);
-            EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
-
-            EXPECT_SUCCESS(s2n_connection_free(server_conn));
-        }
-
-        /* If client has sent no keyshares but server and client mutually support KEM group 1,
+        /* If client has sent no valid keyshares but server and client mutually support KEM group 1,
          * select KEM group 1 and send Hello Retry Request. */
         {
             struct s2n_connection *server_conn = NULL;
@@ -279,13 +178,11 @@ int main() {
             server_conn->kex_params.mutually_supported_kem_groups[1] = kem_group1;
 
             /* No keyshares received */
-            for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_group);
-                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_params.kem);
-                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_params.public_key.data);
-                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].ecc_params.negotiated_curve);
-                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].ecc_params.evp_pkey);
-            }
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.kem_params.kem);
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.kem_params.public_key.data);
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.ecc_params.evp_pkey);
 
             EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
@@ -293,20 +190,21 @@ int main() {
             EXPECT_EQUAL(server_params->kem_group, kem_group1);
             EXPECT_EQUAL(server_params->kem_params.kem, kem_group1->kem);
             EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group1->curve);
-            EXPECT_NULL(server_conn->kex_params.chosen_client_kem_group_params);
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.kem_group);
             EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             EXPECT_TRUE(s2n_is_hello_retry_handshake(server_conn));
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
 
-        /* When client and server mutually support KEM groups 0 and 1, but client has only sent a keyshare for
+        /* When client has only sent a valid keyshare for
          * KEM group 1, Hello Retry Request is not sent and server chooses group 1. */
         {
             struct s2n_connection *server_conn = NULL;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             server_conn->security_policy_override = &test_security_policy;
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
+            EXPECT_OK(s2n_set_all_mutually_supported_groups(server_conn));
 
             const struct s2n_kem_preferences *kem_pref = NULL;
             EXPECT_SUCCESS(s2n_connection_get_kem_preferences(server_conn, &kem_pref));
@@ -321,20 +219,16 @@ int main() {
             server_params->kem_params.kem = kem_group0->kem;
             server_params->ecc_params.negotiated_curve = kem_group0->curve;
 
-            /* Both 0 and 1 supported */
-            server_conn->kex_params.mutually_supported_kem_groups[0] = kem_group0;
-            server_conn->kex_params.mutually_supported_kem_groups[1] = kem_group1;
-
             /* Received a keyshare for 1 only */
-            EXPECT_NULL(server_conn->kex_params.client_kem_group_params[0].kem_group);
-            struct s2n_kem_group_params *client_params1 = &server_conn->kex_params.client_kem_group_params[1];
-            client_params1->kem_group = kem_group1;
-            client_params1->kem_params.kem = kem_group1->kem;
-            client_params1->ecc_params.negotiated_curve = kem_group1->curve;
-            EXPECT_SUCCESS(s2n_alloc(&client_params1->kem_params.public_key, kem_group1->kem->public_key_length));
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.kem_group);
+            struct s2n_kem_group_params *client_params = &server_conn->kex_params.client_kem_group_params;
+            client_params->kem_group = kem_group1;
+            client_params->kem_params.kem = kem_group1->kem;
+            client_params->ecc_params.negotiated_curve = kem_group1->curve;
+            EXPECT_SUCCESS(s2n_alloc(&client_params->kem_params.public_key, kem_group1->kem->public_key_length));
             /* The PQ public key is fake; that's good enough for this test */
-            POSIX_CHECKED_MEMSET(client_params1->kem_params.public_key.data, 1, kem_group1->kem->public_key_length);
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params1->ecc_params));
+            POSIX_CHECKED_MEMSET(client_params->kem_params.public_key.data, 1, kem_group1->kem->public_key_length);
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params->ecc_params));
 
             EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
@@ -342,20 +236,21 @@ int main() {
             EXPECT_EQUAL(server_params->kem_group, kem_group1);
             EXPECT_EQUAL(server_params->kem_params.kem, kem_group1->kem);
             EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group1->curve);
-            EXPECT_EQUAL(server_conn->kex_params.chosen_client_kem_group_params, client_params1);
+            EXPECT_EQUAL(server_conn->kex_params.client_kem_group_params.kem_group, kem_group1);
             EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
 
-        /* When client and server mutually support KEM groups 0,1,2 and client has sent keyshares for all,
+        /* When client has sent a valid keyshares for group 0,
          * Hello Retry Request is not sent and server chooses group 0. */
         {
             struct s2n_connection *server_conn = NULL;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             server_conn->security_policy_override = &test_security_policy;
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
+            EXPECT_OK(s2n_set_all_mutually_supported_groups(server_conn));
 
             const struct s2n_kem_preferences *kem_pref = NULL;
             EXPECT_SUCCESS(s2n_connection_get_kem_preferences(server_conn, &kem_pref));
@@ -369,21 +264,16 @@ int main() {
             server_params->kem_params.kem = kem_group0->kem;
             server_params->ecc_params.negotiated_curve = kem_group0->curve;
 
-            /* Support all KEM Groups; received key shares for all KEM groups */
-            for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                struct s2n_kem_group_params *client_params = &server_conn->kex_params.client_kem_group_params[i];
-                const struct s2n_kem_group *kem_group = kem_pref->tls13_kem_groups[i];
-
-                server_conn->kex_params.mutually_supported_kem_groups[i] = kem_group;
-
-                client_params->kem_group = kem_group;
-                client_params->kem_params.kem = kem_group->kem;
-                client_params->ecc_params.negotiated_curve = kem_group->curve;
-                EXPECT_SUCCESS(s2n_alloc(&client_params->kem_params.public_key, kem_group->kem->public_key_length));
-                /* The PQ public key is fake; that's good enough for this test */
-                POSIX_CHECKED_MEMSET(client_params->kem_params.public_key.data, 1, kem_group->kem->public_key_length);
-                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params->ecc_params));
-            }
+            /* Received key shares for all KEM groups */
+            struct s2n_kem_group_params *client_params = &server_conn->kex_params.client_kem_group_params;
+            const struct s2n_kem_group *kem_group = kem_pref->tls13_kem_groups[0];
+            client_params->kem_group = kem_group;
+            client_params->kem_params.kem = kem_group->kem;
+            client_params->ecc_params.negotiated_curve = kem_group->curve;
+            EXPECT_SUCCESS(s2n_alloc(&client_params->kem_params.public_key, kem_group->kem->public_key_length));
+            /* The PQ public key is fake; that's good enough for this test */
+            POSIX_CHECKED_MEMSET(client_params->kem_params.public_key.data, 1, kem_group->kem->public_key_length);
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params->ecc_params));
 
             EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
@@ -391,20 +281,21 @@ int main() {
             EXPECT_EQUAL(server_params->kem_group, kem_group0);
             EXPECT_EQUAL(server_params->kem_params.kem, kem_group0->kem);
             EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group0->curve);
-            EXPECT_EQUAL(server_conn->kex_params.chosen_client_kem_group_params, &server_conn->kex_params.client_kem_group_params[0]);
+            EXPECT_EQUAL(server_conn->kex_params.client_kem_group_params.kem_group, kem_group0);
             EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
 
-        /* When client and server mutually support all KEM groups and all curves, but client sent no keyshares,
+        /* When client sent no valid keyshares,
          * server should choose kem_group[0] and send HRR. */
         {
             struct s2n_connection *server_conn = NULL;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             server_conn->security_policy_override = &test_security_policy;
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
+            EXPECT_OK(s2n_set_all_mutually_supported_groups(server_conn));
 
             const struct s2n_ecc_preferences *ecc_pref = NULL;
             EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
@@ -422,22 +313,12 @@ int main() {
             server_params->kem_params.kem = kem_group0->kem;
             server_params->ecc_params.negotiated_curve = kem_group0->curve;
 
-            /* Support all KEM groups and all curves */
-            for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                server_conn->kex_params.mutually_supported_kem_groups[i] = kem_pref->tls13_kem_groups[i];
-            }
-            for (size_t i = 0; i < ecc_pref->count; i++) {
-                server_conn->kex_params.mutually_supported_curves[i] = ecc_pref->ecc_curves[i];
-            }
-
             /* No keyshares received */
-            for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_group);
-                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_params.kem);
-                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_params.public_key.data);
-                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].ecc_params.negotiated_curve);
-                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].ecc_params.evp_pkey);
-            }
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.kem_params.kem);
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.kem_params.public_key.data);
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.ecc_params.evp_pkey);
 
             EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
@@ -445,20 +326,21 @@ int main() {
             EXPECT_EQUAL(server_params->kem_group, kem_group0);
             EXPECT_EQUAL(server_params->kem_params.kem, kem_group0->kem);
             EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group0->curve);
-            EXPECT_NULL(server_conn->kex_params.chosen_client_kem_group_params);
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.kem_group);
             EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             EXPECT_TRUE(s2n_is_hello_retry_handshake(server_conn));
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
 
-        /* When client and server mutually support all KEM groups and all curves, and client sent keyshares
+        /* When client sent valid keyshares
          * for everything, server should choose kem_group[0] and not send HRR. */
         {
             struct s2n_connection *server_conn = NULL;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             server_conn->security_policy_override = &test_security_policy;
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
+            EXPECT_OK(s2n_set_all_mutually_supported_groups(server_conn));
 
             const struct s2n_ecc_preferences *ecc_pref = NULL;
             EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
@@ -476,30 +358,21 @@ int main() {
             server_params->kem_params.kem = kem_group0->kem;
             server_params->ecc_params.negotiated_curve = kem_group0->curve;
 
-            /* Support all KEM groups and curves; received keyshares for everything */
-            for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                struct s2n_kem_group_params *client_params = &server_conn->kex_params.client_kem_group_params[i];
-                const struct s2n_kem_group *kem_group = kem_pref->tls13_kem_groups[i];
+            /* Receive highest priority KEM share */
+            struct s2n_kem_group_params *client_kem_params = &server_conn->kex_params.client_kem_group_params;
+            const struct s2n_kem_group *kem_group = kem_pref->tls13_kem_groups[0];
+            client_kem_params->kem_group = kem_group;
+            client_kem_params->kem_params.kem = kem_group->kem;
+            client_kem_params->ecc_params.negotiated_curve = kem_group->curve;
+            EXPECT_SUCCESS(s2n_alloc(&client_kem_params->kem_params.public_key, kem_group->kem->public_key_length));
+            /* The PQ public key is fake; that's good enough for this test */
+            POSIX_CHECKED_MEMSET(client_kem_params->kem_params.public_key.data, 1, kem_group->kem->public_key_length);
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_kem_params->ecc_params));
 
-                server_conn->kex_params.mutually_supported_kem_groups[i] = kem_pref->tls13_kem_groups[i];
-
-                client_params->kem_group = kem_group;
-                client_params->kem_params.kem = kem_group->kem;
-                client_params->ecc_params.negotiated_curve = kem_group->curve;
-                EXPECT_SUCCESS(s2n_alloc(&client_params->kem_params.public_key, kem_group->kem->public_key_length));
-                /* The PQ public key is fake; that's good enough for this test */
-                POSIX_CHECKED_MEMSET(client_params->kem_params.public_key.data, 1, kem_group->kem->public_key_length);
-                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_params->ecc_params));
-            }
-            for (size_t i = 0; i < ecc_pref->count; i++) {
-                struct s2n_ecc_evp_params *client_params = &server_conn->kex_params.client_ecc_evp_params[i];
-                const struct s2n_ecc_named_curve *curve = ecc_pref->ecc_curves[i];
-
-                server_conn->kex_params.mutually_supported_curves[i] = curve;
-
-                client_params->negotiated_curve = curve;
-                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(client_params));
-            }
+            /* Receive highest priority ECC share */
+            struct s2n_ecc_evp_params *client_params = &server_conn->kex_params.client_ecc_evp_params;
+            client_params->negotiated_curve = ecc_pref->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(client_params));
 
             EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
@@ -507,20 +380,21 @@ int main() {
             EXPECT_EQUAL(server_params->kem_group, kem_group0);
             EXPECT_EQUAL(server_params->kem_params.kem, kem_group0->kem);
             EXPECT_EQUAL(server_params->ecc_params.negotiated_curve, kem_group0->curve);
-            EXPECT_EQUAL(server_conn->kex_params.chosen_client_kem_group_params, &server_conn->kex_params.client_kem_group_params[0]);
+            EXPECT_EQUAL(server_conn->kex_params.client_kem_group_params.kem_group, kem_group0);
             EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
 
-        /* When client and server mutually support all KEM groups and all curves, but client sent keyshares
+        /* When client sent valid keyshares
          * only for ECC, server should choose curves[0] and not send HRR. */
         {
             struct s2n_connection *server_conn = NULL;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             server_conn->security_policy_override = &test_security_policy;
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
+            EXPECT_OK(s2n_set_all_mutually_supported_groups(server_conn));
 
             const struct s2n_ecc_preferences *ecc_pref = NULL;
             EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(server_conn, &ecc_pref));
@@ -538,35 +412,26 @@ int main() {
             server_params->kem_params.kem = kem_group0->kem;
             server_params->ecc_params.negotiated_curve = kem_group0->curve;
 
-            /* Support all KEM groups, but no keyshares received */
-            for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-                server_conn->kex_params.mutually_supported_kem_groups[i] = kem_pref->tls13_kem_groups[i];
+            /* No keyshares received */
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.kem_group);
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.kem_params.kem);
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.kem_params.public_key.data);
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.ecc_params.negotiated_curve);
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.ecc_params.evp_pkey);
 
-                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_group);
-                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_params.kem);
-                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].kem_params.public_key.data);
-                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].ecc_params.negotiated_curve);
-                EXPECT_NULL(server_conn->kex_params.client_kem_group_params[i].ecc_params.evp_pkey);
-            }
-            /* Support all curves, and all keyshares received */
-            for (size_t i = 0; i < ecc_pref->count; i++) {
-                struct s2n_ecc_evp_params *client_params = &server_conn->kex_params.client_ecc_evp_params[i];
-                const struct s2n_ecc_named_curve *curve = ecc_pref->ecc_curves[i];
-
-                server_conn->kex_params.mutually_supported_curves[i] = curve;
-
-                client_params->negotiated_curve = curve;
-                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(client_params));
-            }
+            /* Highest priority keyshare chosen */
+            struct s2n_ecc_evp_params *client_params = &server_conn->kex_params.client_ecc_evp_params;
+            client_params->negotiated_curve = ecc_pref->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(client_params));
 
             EXPECT_SUCCESS(s2n_extensions_server_key_share_select(server_conn));
 
-            /* Server should update it's choice to curve[0], no HRR */
+            /* Server should update its choice to curve[0], no HRR */
             EXPECT_EQUAL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[0]);
             EXPECT_NULL(server_params->kem_group);
             EXPECT_NULL(server_params->kem_params.kem);
             EXPECT_NULL(server_params->ecc_params.negotiated_curve);
-            EXPECT_NULL(server_conn->kex_params.chosen_client_kem_group_params);
+            EXPECT_NULL(server_conn->kex_params.client_kem_group_params.kem_group);
             EXPECT_FALSE(s2n_is_hello_retry_handshake(server_conn));
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_quic_support_io_test.c
+++ b/tests/unit/s2n_quic_support_io_test.c
@@ -60,12 +60,12 @@ static S2N_RESULT s2n_setup_conn_for_server_hello(struct s2n_connection *conn)
     const struct s2n_ecc_preferences *ecc_preferences = NULL;
     RESULT_GUARD_POSIX(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
     conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-    conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_preferences->ecc_curves[0];
+    conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
     if(conn->kex_params.server_ecc_evp_params.evp_pkey == NULL) {
         RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.server_ecc_evp_params));
     }
-    if(conn->kex_params.client_ecc_evp_params[0].evp_pkey == NULL) {
-        RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
+    if(conn->kex_params.client_ecc_evp_params.evp_pkey == NULL) {
+        RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params));
     }
 
     /* Set handshake to write message */

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -52,8 +52,8 @@ static int configure_tls13_connection(struct s2n_connection *conn)
     EXPECT_NOT_NULL(ecc_pref);
 
     conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-    conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
+    conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
     POSIX_GUARD(s2n_connection_allow_all_response_extensions(conn));
 
@@ -288,7 +288,7 @@ int main(int argc, char **argv)
             conn->actual_protocol_version = S2N_TLS13;
 
             /* key_share_send() requires a negotiated_curve */
-            conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
 
             const uint8_t size = P256_KEYSHARE_SIZE + SUPPORTED_VERSION_SIZE;
 
@@ -298,7 +298,7 @@ int main(int argc, char **argv)
             EXPECT_FAILURE(s2n_server_extensions_send(conn, hello_stuffer));
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(hello_stuffer));
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params));
 
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
             S2N_STUFFER_LENGTH_WRITTEN_EXPECT_EQUAL(hello_stuffer, size + EXTENSION_LEN);
@@ -333,14 +333,14 @@ int main(int argc, char **argv)
             conn->actual_protocol_version = S2N_TLS13;
 
             /* key_share_send() requires a negotiated_curve */
-            conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
             /* secure_renegotiation extension not send >=TLS13*/
             uint8_t size = s2n_extensions_server_key_share_send_size(conn)
                 + s2n_extensions_server_supported_versions_size(conn);
 
             EXPECT_FAILURE(s2n_server_extensions_send(conn, hello_stuffer));
 
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params));
 
             EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, s2n_stuffer_data_available(hello_stuffer)));
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
@@ -379,7 +379,7 @@ int main(int argc, char **argv)
             conn->actual_protocol_version = S2N_TLS13;
 
             /* key_share_send() requires a negotiated_curve */
-            conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
 
             /* nst extension not send >=TLS13*/
             uint8_t size = s2n_extensions_server_key_share_send_size(conn)
@@ -387,7 +387,7 @@ int main(int argc, char **argv)
 
             EXPECT_FAILURE(s2n_server_extensions_send(conn, hello_stuffer));
 
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params));
 
             EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, s2n_stuffer_data_available(hello_stuffer)));
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
@@ -435,14 +435,14 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_set_cipher_as_tls_server(conn, wire_ciphers_with_tls13, cipher_count_tls13));
 
             /* key_share_send() requires a negotiated_curve */
-            conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+            conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
 
             uint8_t size = s2n_extensions_server_key_share_send_size(conn)
                 + s2n_extensions_server_supported_versions_size(conn);
 
             EXPECT_FAILURE(s2n_server_extensions_send(conn, hello_stuffer));
 
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params));
 
             EXPECT_SUCCESS(s2n_stuffer_skip_read(hello_stuffer, s2n_stuffer_data_available(hello_stuffer)));
             EXPECT_SUCCESS(s2n_server_extensions_send(conn, hello_stuffer));
@@ -480,8 +480,8 @@ int main(int argc, char **argv)
                 /* Setup required for other server extensions */
                 conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
                 conn->kex_params.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
-                conn->kex_params.client_ecc_evp_params[0].negotiated_curve = &s2n_ecc_curve_secp256r1;
-                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
+                conn->kex_params.client_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
+                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params));
 
                 if (is_hrr) {
                     EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(conn));

--- a/tests/unit/s2n_server_hello_test.c
+++ b/tests/unit/s2n_server_hello_test.c
@@ -120,8 +120,8 @@ int main(int argc, char **argv)
         /* configure these parameters so server hello can be sent */
         conn->actual_protocol_version = S2N_TLS13;
         conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
-        conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_preferences->ecc_curves[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
+        conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params));
 
         struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
         EXPECT_SUCCESS(s2n_server_hello_send(conn));

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -71,10 +71,10 @@ int main(int argc, char **argv)
         conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
         EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_ecdhe(conn), S2N_ERR_BAD_KEY_SHARE);
 
-        conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+        conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
         EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_ecdhe(conn), S2N_ERR_BAD_KEY_SHARE);
 
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params));
         EXPECT_SUCCESS(s2n_server_key_share_send_check_ecdhe(conn));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -125,8 +125,8 @@ int main(int argc, char **argv)
         for (size_t i = 0; i < ecc_pref->count; i++) {
             const struct s2n_ecc_named_curve *curve = ecc_pref->ecc_curves[i];
             conn->kex_params.server_ecc_evp_params.negotiated_curve = curve;
-            conn->kex_params.client_ecc_evp_params[i].negotiated_curve = curve;
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[i]));
+            conn->kex_params.client_ecc_evp_params.negotiated_curve = curve;
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params));
 
             EXPECT_SUCCESS(s2n_server_key_share_extension.send(conn, &stuffer));
 
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
             EXPECT_NULL(conn->kex_params.server_kem_group_params.kem_group);
             EXPECT_EQUAL(conn->kex_params.server_ecc_evp_params.negotiated_curve, curve);
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&conn->kex_params.server_ecc_evp_params));
-            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&conn->kex_params.client_ecc_evp_params[i]));
+            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&conn->kex_params.client_ecc_evp_params));
         }
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -210,12 +210,12 @@ int main(int argc, char **argv)
             struct s2n_stuffer* extension_stuffer = &server_send_conn->handshake.io;
 
             server_send_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[i];
-            server_send_conn->kex_params.client_ecc_evp_params[i].negotiated_curve = ecc_pref->ecc_curves[i];
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_send_conn->kex_params.client_ecc_evp_params[i]));
+            server_send_conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[i];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_send_conn->kex_params.client_ecc_evp_params));
             EXPECT_SUCCESS(s2n_server_key_share_extension.send(server_send_conn, extension_stuffer));
 
-            client_recv_conn->kex_params.client_ecc_evp_params[i].negotiated_curve = ecc_pref->ecc_curves[i];
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_recv_conn->kex_params.client_ecc_evp_params[i]));
+            client_recv_conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[i];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_recv_conn->kex_params.client_ecc_evp_params));
 
             /* Parse key share */
             EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_recv_conn, extension_stuffer));
@@ -261,8 +261,8 @@ int main(int argc, char **argv)
                 EXPECT_NULL(client_conn->kex_params.server_ecc_evp_params.negotiated_curve);
                 EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&extension_stuffer, payload));
 
-                client_conn->kex_params.client_ecc_evp_params[i].negotiated_curve = ecc_pref->ecc_curves[i];
-                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params[i]));
+                client_conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[i];
+                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params));
 
                 EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &extension_stuffer));
                 EXPECT_EQUAL(client_conn->kex_params.server_ecc_evp_params.negotiated_curve, ecc_pref->ecc_curves[i]);
@@ -289,8 +289,8 @@ int main(int argc, char **argv)
                 EXPECT_NULL(client_conn->kex_params.server_ecc_evp_params.negotiated_curve);
                 EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&extension_stuffer, payload));
 
-                client_conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params[0]));
+                client_conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params));
 
                 client_conn->actual_protocol_version = S2N_TLS12;
                 EXPECT_SUCCESS(s2n_extension_recv(&s2n_server_key_share_extension, client_conn, &extension_stuffer));
@@ -342,8 +342,8 @@ int main(int argc, char **argv)
             /* If s2n_is_evp_apis_supported is not supported, the ecc_prefs->ecc_curves contains only p-256, p-384 curves. */
             int p_384_index = s2n_is_evp_apis_supported() ? 2 : 1;
 
-            client_conn->kex_params.client_ecc_evp_params[p_384_index].negotiated_curve = ecc_pref->ecc_curves[p_384_index];
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params[p_384_index]));
+            client_conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[p_384_index];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params));
 
             EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &extension_stuffer), S2N_ERR_BAD_KEY_SHARE);
 
@@ -360,6 +360,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         server_conn->actual_protocol_version = S2N_TLS13;
+        EXPECT_OK(s2n_set_all_mutually_supported_groups(server_conn));
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 0));
 
         const struct s2n_ecc_preferences *ecc_pref = NULL;
@@ -374,9 +375,6 @@ int main(int argc, char **argv)
 
         /* Server configures the "negotiated_curve" */
         server_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-        for (size_t i = 1; i < ecc_pref->count; i++) {
-            server_conn->kex_params.client_ecc_evp_params[i].negotiated_curve = NULL;
-        }
 
         EXPECT_SUCCESS(s2n_server_key_share_extension.send(server_conn, &key_share_extension));
         EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &key_share_extension));
@@ -386,19 +384,19 @@ int main(int argc, char **argv)
 
         /* Ensure both client and server public key matches */
         s2n_public_ecc_keys_are_equal(&server_conn->kex_params.server_ecc_evp_params, &client_conn->kex_params.server_ecc_evp_params);
-        s2n_public_ecc_keys_are_equal(&server_conn->kex_params.client_ecc_evp_params[0], &client_conn->kex_params.client_ecc_evp_params[0]);
+        s2n_public_ecc_keys_are_equal(&server_conn->kex_params.client_ecc_evp_params, &client_conn->kex_params.client_ecc_evp_params);
 
         /* Server generates shared key based on Server's Key and Client's public key  */
         struct s2n_blob server_shared_secret = { 0 };
         EXPECT_SUCCESS(s2n_ecc_evp_compute_shared_secret_from_params(
             &server_conn->kex_params.server_ecc_evp_params,
-            &server_conn->kex_params.client_ecc_evp_params[0],
+            &server_conn->kex_params.client_ecc_evp_params,
             &server_shared_secret));
 
         /* Clients generates shared key based on Client's Key and Server's public key */
         struct s2n_blob client_shared_secret = { 0 };
         EXPECT_SUCCESS(s2n_ecc_evp_compute_shared_secret_from_params(
-            &client_conn->kex_params.client_ecc_evp_params[0],
+            &client_conn->kex_params.client_ecc_evp_params,
             &client_conn->kex_params.server_ecc_evp_params,
             &client_shared_secret));
 
@@ -433,7 +431,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(conn->config, "20140601"));
 
         conn->kex_params.server_ecc_evp_params.negotiated_curve = test_curve;
-        conn->kex_params.client_ecc_evp_params[0].negotiated_curve = test_curve;
+        conn->kex_params.client_ecc_evp_params.negotiated_curve = test_curve;
         EXPECT_FAILURE(s2n_server_key_share_extension.send(conn, &conn->handshake.io));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -485,11 +483,9 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(ecc_preferences);
 
             /* Verify that no key shares are sent */
-            for (size_t i = 0; i < ecc_preferences->count; i++) {
-                struct s2n_ecc_evp_params *ecc_evp_params = &server_conn->kex_params.client_ecc_evp_params[i];
-                EXPECT_NULL(ecc_evp_params->negotiated_curve);
-                EXPECT_NULL(ecc_evp_params->evp_pkey);
-            }
+            struct s2n_ecc_evp_params *ecc_evp_params = &server_conn->kex_params.client_ecc_evp_params;
+            EXPECT_NULL(ecc_evp_params->negotiated_curve);
+            EXPECT_NULL(ecc_evp_params->evp_pkey);
 
             /* Setup the client to have received a HelloRetryRequest */
             EXPECT_MEMCPY_SUCCESS(client_conn->secrets.server_random, hello_retry_req_random, S2N_TLS_RANDOM_DATA_LEN);
@@ -608,7 +604,7 @@ int main(int argc, char **argv)
 
                         /* Read the test vectors from the KAT file (the PQ key shares are too long to hardcode inline).
                          * pq_private_key is intentionally missing DERFER_CLEANUP; it will get freed during s2n_connection_free. */
-                        struct s2n_blob *pq_private_key = &client_conn->kex_params.client_kem_group_params[i].kem_params.private_key;
+                        struct s2n_blob *pq_private_key = &client_conn->kex_params.client_kem_group_params.kem_params.private_key;
                         DEFER_CLEANUP(struct s2n_stuffer pq_shared_secret = {0}, s2n_stuffer_free);
                         DEFER_CLEANUP(struct s2n_stuffer key_share_payload = {0}, s2n_stuffer_free);
                         EXPECT_SUCCESS(s2n_read_server_key_share_hybrid_test_vectors(kem_group, pq_private_key,
@@ -616,8 +612,7 @@ int main(int argc, char **argv)
 
                         /* Assert correct initial state */
                         EXPECT_NULL(client_conn->kex_params.server_kem_group_params.kem_group);
-                        EXPECT_NULL(client_conn->kex_params.chosen_client_kem_group_params);
-                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params[i].kem_group);
+                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params.kem_group);
 
                         const struct s2n_kem_preferences *kem_prefs = NULL;
                         EXPECT_SUCCESS(s2n_connection_get_kem_preferences(client_conn, &kem_prefs));
@@ -625,10 +620,10 @@ int main(int argc, char **argv)
                         EXPECT_EQUAL(kem_group, kem_prefs->tls13_kem_groups[i]);
 
                         /* This set up would have been done when the client sent its key share(s) */
-                        client_conn->kex_params.client_kem_group_params[i].kem_group = kem_group;
-                        client_conn->kex_params.client_kem_group_params[i].ecc_params.negotiated_curve = kem_group->curve;
-                        client_conn->kex_params.client_kem_group_params[i].kem_params.kem = kem_group->kem;
-                        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_kem_group_params[i].ecc_params));
+                        client_conn->kex_params.client_kem_group_params.kem_group = kem_group;
+                        client_conn->kex_params.client_kem_group_params.ecc_params.negotiated_curve = kem_group->curve;
+                        client_conn->kex_params.client_kem_group_params.kem_params.kem = kem_group->kem;
+                        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_kem_group_params.ecc_params));
 
                         /* Call the function and assert correctness */
                         EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &key_share_payload));
@@ -640,13 +635,13 @@ int main(int argc, char **argv)
                         EXPECT_NOT_NULL(client_conn->kex_params.server_kem_group_params.kem_params.kem);
                         EXPECT_EQUAL(client_conn->kex_params.server_kem_group_params.kem_params.kem, kem_group->kem);
 
-                        EXPECT_EQUAL(client_conn->kex_params.chosen_client_kem_group_params->kem_group, kem_group);
-                        EXPECT_EQUAL(client_conn->kex_params.chosen_client_kem_group_params->ecc_params.negotiated_curve,kem_group->curve);
-                        EXPECT_EQUAL(client_conn->kex_params.chosen_client_kem_group_params->kem_params.kem,kem_group->kem);
-                        EXPECT_NOT_NULL(client_conn->kex_params.chosen_client_kem_group_params->kem_params.shared_secret.data);
-                        EXPECT_EQUAL(client_conn->kex_params.chosen_client_kem_group_params->kem_params.shared_secret.size,
+                        EXPECT_EQUAL(client_conn->kex_params.client_kem_group_params.kem_group, kem_group);
+                        EXPECT_EQUAL(client_conn->kex_params.client_kem_group_params.ecc_params.negotiated_curve,kem_group->curve);
+                        EXPECT_EQUAL(client_conn->kex_params.client_kem_group_params.kem_params.kem,kem_group->kem);
+                        EXPECT_NOT_NULL(client_conn->kex_params.client_kem_group_params.kem_params.shared_secret.data);
+                        EXPECT_EQUAL(client_conn->kex_params.client_kem_group_params.kem_params.shared_secret.size,
                                 kem_group->kem->shared_secret_key_length);
-                        EXPECT_BYTEARRAY_EQUAL(client_conn->kex_params.chosen_client_kem_group_params->kem_params.shared_secret.data,
+                        EXPECT_BYTEARRAY_EQUAL(client_conn->kex_params.client_kem_group_params.kem_params.shared_secret.data,
                                 pq_shared_secret.blob.data, kem_group->kem->shared_secret_key_length);
 
                         EXPECT_EQUAL(s2n_stuffer_data_available(&key_share_payload), 0);
@@ -682,17 +677,13 @@ int main(int argc, char **argv)
 
                     /* s2n_server_key_share_extension.recv should have exited early after parsing the indicated group,
                      * so everything else should be NULL */
-                    EXPECT_NULL(client_conn->kex_params.chosen_client_kem_group_params);
-
-                    for (size_t i = 0; i < S2N_SUPPORTED_KEM_GROUPS_COUNT; i++) {
-                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params[i].kem_group);
-                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params[i].ecc_params.negotiated_curve);
-                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params[i].ecc_params.evp_pkey);
-                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params[i].kem_params.kem);
-                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params[i].kem_params.private_key.data);
-                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params[i].kem_params.public_key.data);
-                        EXPECT_NULL(client_conn->kex_params.client_kem_group_params[i].kem_params.shared_secret.data);
-                    }
+                    EXPECT_NULL(client_conn->kex_params.client_kem_group_params.kem_group);
+                    EXPECT_NULL(client_conn->kex_params.client_kem_group_params.ecc_params.negotiated_curve);
+                    EXPECT_NULL(client_conn->kex_params.client_kem_group_params.ecc_params.evp_pkey);
+                    EXPECT_NULL(client_conn->kex_params.client_kem_group_params.kem_params.kem);
+                    EXPECT_NULL(client_conn->kex_params.client_kem_group_params.kem_params.private_key.data);
+                    EXPECT_NULL(client_conn->kex_params.client_kem_group_params.kem_params.public_key.data);
+                    EXPECT_NULL(client_conn->kex_params.client_kem_group_params.kem_params.shared_secret.data);
 
                     EXPECT_NULL(client_conn->kex_params.server_kem_group_params.ecc_params.evp_pkey);
                     EXPECT_NULL(client_conn->kex_params.server_kem_group_params.kem_params.shared_secret.data);
@@ -725,7 +716,7 @@ int main(int argc, char **argv)
                         /* To test the remaining failure cases, we need to read in the test vector from the KAT file, then
                          * manipulate it as necessary. (We do this now, instead of earlier, because we needed
                          * client_kem_group_params[i].kem_params.private_key to be empty to test the previous case.) */
-                        struct s2n_blob *pq_private_key = &client_conn->kex_params.client_kem_group_params[i].kem_params.private_key;
+                        struct s2n_blob *pq_private_key = &client_conn->kex_params.client_kem_group_params.kem_params.private_key;
                         DEFER_CLEANUP(struct s2n_stuffer pq_shared_secret = {0}, s2n_stuffer_free);
                         DEFER_CLEANUP(struct s2n_stuffer key_share_payload = {0}, s2n_stuffer_free);
                         EXPECT_SUCCESS(s2n_read_server_key_share_hybrid_test_vectors(kem_group, pq_private_key,
@@ -734,10 +725,10 @@ int main(int argc, char **argv)
                         /* Server sends the wrong (total) size: data[2] and data[3] are the bytes containing the total size
                          * of the key share; bitflip data[2] to invalidate the sent size */
                         key_share_payload.blob.data[2] = ~key_share_payload.blob.data[2];
-                        client_conn->kex_params.client_kem_group_params[i].kem_group = kem_group;
-                        client_conn->kex_params.client_kem_group_params[i].ecc_params.negotiated_curve = kem_group->curve;
-                        client_conn->kex_params.client_kem_group_params[i].kem_params.kem = kem_group->kem;
-                        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_kem_group_params[i].ecc_params));
+                        client_conn->kex_params.client_kem_group_params.kem_group = kem_group;
+                        client_conn->kex_params.client_kem_group_params.ecc_params.negotiated_curve = kem_group->curve;
+                        client_conn->kex_params.client_kem_group_params.kem_params.kem = kem_group->kem;
+                        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_kem_group_params.ecc_params));
                         EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &key_share_payload),
                                 S2N_ERR_BAD_KEY_SHARE);
                         /* Revert key_share_payload back to correct state */
@@ -785,7 +776,7 @@ int main(int argc, char **argv)
                         size_t pq_key_share_first_byte_index = pq_share_size_index + 2;
                         key_share_payload.blob.data[pq_key_share_first_byte_index] = ~key_share_payload.blob.data[pq_key_share_first_byte_index];
                         EXPECT_SUCCESS(s2n_server_key_share_extension.recv(client_conn, &key_share_payload));
-                        EXPECT_BYTEARRAY_NOT_EQUAL(client_conn->kex_params.chosen_client_kem_group_params->kem_params.shared_secret.data,
+                        EXPECT_BYTEARRAY_NOT_EQUAL(client_conn->kex_params.client_kem_group_params.kem_params.shared_secret.data,
                                 pq_shared_secret.blob.data, kem_group->kem->shared_secret_key_length);
 
                         EXPECT_SUCCESS(s2n_connection_free(client_conn));
@@ -820,26 +811,23 @@ int main(int argc, char **argv)
 
                 conn->kex_params.server_kem_group_params.kem_group = &s2n_secp256r1_bike1_l1_r2;
                 conn->kex_params.server_kem_group_params.kem_params.kem = &s2n_bike1_l1_r2;
-                EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_NULL);
-
-                conn->kex_params.chosen_client_kem_group_params = &conn->kex_params.client_kem_group_params[1];
                 EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_BAD_KEY_SHARE);
 
-                conn->kex_params.client_kem_group_params[1].kem_group = &s2n_secp256r1_bike1_l1_r2;
+                conn->kex_params.client_kem_group_params.kem_group = &s2n_secp256r1_bike1_l1_r2;
                 EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_BAD_KEY_SHARE);
 
-                conn->kex_params.client_kem_group_params[1].ecc_params.negotiated_curve = s2n_secp256r1_bike1_l1_r2.curve;
+                conn->kex_params.client_kem_group_params.ecc_params.negotiated_curve = s2n_secp256r1_bike1_l1_r2.curve;
                 EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_BAD_KEY_SHARE);
 
-                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_kem_group_params[1].ecc_params));
+                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_kem_group_params.ecc_params));
                 EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_BAD_KEY_SHARE);
 
-                conn->kex_params.client_kem_group_params[1].kem_params.kem = s2n_secp256r1_bike1_l1_r2.kem;
+                conn->kex_params.client_kem_group_params.kem_params.kem = s2n_secp256r1_bike1_l1_r2.kem;
                 EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_send_check_pq_hybrid(conn), S2N_ERR_BAD_KEY_SHARE);
 
-                EXPECT_SUCCESS(s2n_alloc(&conn->kex_params.client_kem_group_params[1].kem_params.public_key,
+                EXPECT_SUCCESS(s2n_alloc(&conn->kex_params.client_kem_group_params.kem_params.public_key,
                         s2n_secp256r1_bike1_l1_r2.kem->public_key_length));
-                EXPECT_OK(s2n_kem_generate_keypair(&conn->kex_params.client_kem_group_params[1].kem_params));
+                EXPECT_OK(s2n_kem_generate_keypair(&conn->kex_params.client_kem_group_params.kem_params));
                 EXPECT_SUCCESS(s2n_server_key_share_send_check_pq_hybrid(conn));
             }
 
@@ -870,8 +858,7 @@ int main(int argc, char **argv)
                 server_params->kem_params.kem = kem_group->kem;
                 server_params->ecc_params.negotiated_curve = kem_group->curve;
 
-                struct s2n_kem_group_params *client_params = &conn->kex_params.client_kem_group_params[i];
-                conn->kex_params.chosen_client_kem_group_params = client_params;
+                struct s2n_kem_group_params *client_params = &conn->kex_params.client_kem_group_params;
                 client_params->kem_group = kem_group;
                 client_params->kem_params.kem = kem_group->kem;
                 client_params->ecc_params.negotiated_curve = kem_group->curve;
@@ -928,7 +915,6 @@ int main(int argc, char **argv)
                 server_params->kem_group = kem_group;
                 server_params->kem_params.kem = kem_group->kem;
                 server_params->ecc_params.negotiated_curve = kem_group->curve;
-                EXPECT_NULL(conn->kex_params.chosen_client_kem_group_params);
                 EXPECT_NULL(conn->kex_params.server_ecc_evp_params.evp_pkey);
                 EXPECT_NULL(conn->kex_params.server_ecc_evp_params.negotiated_curve);
 
@@ -943,7 +929,6 @@ int main(int argc, char **argv)
                 EXPECT_NULL(server_params->kem_params.shared_secret.data);
                 EXPECT_EQUAL(0, server_params->kem_params.shared_secret.size);
                 EXPECT_NULL(server_params->ecc_params.evp_pkey);
-                EXPECT_NULL(conn->kex_params.chosen_client_kem_group_params);
 
                 EXPECT_NULL(conn->kex_params.server_ecc_evp_params.negotiated_curve);
                 EXPECT_NULL(conn->kex_params.server_ecc_evp_params.evp_pkey);

--- a/tests/unit/s2n_tls13_compute_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_compute_shared_secret_test.c
@@ -54,8 +54,8 @@ int main(int argc, char **argv) {
         EXPECT_NOT_NULL(ecc_pref);
 
         /* Select curve and generate key for client */
-        client_conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params[0]));
+        client_conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params));
         /* Recreating conditions where negotiated curve was not set */
         struct s2n_ecc_evp_params missing_params = {NULL,NULL};
         client_conn->kex_params.server_ecc_evp_params = missing_params;
@@ -79,8 +79,8 @@ int main(int argc, char **argv) {
         EXPECT_NOT_NULL(ecc_pref);
 
         /* Select curve and generate key for client */
-        client_conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params[0]));
+        client_conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params));
 
         /* Set curve server sent in server hello */
         client_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
@@ -105,8 +105,8 @@ int main(int argc, char **argv) {
         client_conn->actual_protocol_version = S2N_TLS13;
 
         /* Select curve and generate key for client */
-        client_conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
-        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params[0]));
+        client_conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
+        EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&client_conn->kex_params.client_ecc_evp_params));
 
         /* Set curve server sent in server hello */
         client_conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];

--- a/tests/unit/s2n_tls13_handshake_early_data_test.c
+++ b/tests/unit/s2n_tls13_handshake_early_data_test.c
@@ -97,9 +97,9 @@ static S2N_RESULT s2n_setup_tls13_secrets_prereqs(struct s2n_connection *conn)
     RESULT_ENSURE_REF(ecc_pref);
 
     conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-    conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+    conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
     RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.server_ecc_evp_params));
-    RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
+    RESULT_GUARD_POSIX(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params));
 
     uint8_t test_value[SHA256_DIGEST_LENGTH] = "test";
     DEFER_CLEANUP(struct s2n_psk *s2n_test_psk = s2n_external_psk_new(), s2n_psk_free);

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -54,9 +54,9 @@ static int s2n_setup_tls13_secrets_prereqs(struct s2n_connection *conn)
     POSIX_ENSURE_REF(ecc_pref);
 
     conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
-    conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_pref->ecc_curves[0];
+    conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_pref->ecc_curves[0];
     POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.server_ecc_evp_params));
-    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
+    POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params));
 
     return S2N_SUCCESS;
 }
@@ -170,6 +170,9 @@ int main(int argc, char **argv)
         S2N_STUFFER_READ_EXPECT_EQUAL(&client_hello_key_share, TLS_EXTENSION_KEY_SHARE, uint16);
         S2N_STUFFER_READ_EXPECT_EQUAL(&client_hello_key_share, s2n_extensions_client_key_share_size(server_conn)
             - (S2N_SIZE_OF_EXTENSION_TYPE + S2N_SIZE_OF_EXTENSION_DATA_SIZE), uint16);
+
+        /* Server configures the "supported_groups" shared with the client */
+        server_conn->kex_params.mutually_supported_curves[0] = server_ecc_preferences->ecc_curves[0];
 
         EXPECT_SUCCESS(s2n_extensions_client_key_share_recv(server_conn, &client_hello_key_share));
 
@@ -331,8 +334,8 @@ int main(int argc, char **argv)
             conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
             conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.server_ecc_evp_params));
-            conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_preferences->ecc_curves[0];
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
+            conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params));
 
             const uint8_t psk_data[] = "test identity data";
             const uint8_t secret_data[] = "test secret data";
@@ -378,8 +381,8 @@ int main(int argc, char **argv)
             conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
             conn->kex_params.server_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
             EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.server_ecc_evp_params));
-            conn->kex_params.client_ecc_evp_params[0].negotiated_curve = ecc_preferences->ecc_curves[0];
-            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params[0]));
+            conn->kex_params.client_ecc_evp_params.negotiated_curve = ecc_preferences->ecc_curves[0];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&conn->kex_params.client_ecc_evp_params));
 
             const uint8_t psk_data[] = "test identity data";
             const uint8_t secret_data[] = "test secret data";

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -118,7 +118,7 @@ static int s2n_generate_pq_hybrid_key_share(struct s2n_stuffer *out, struct s2n_
 
     struct s2n_ecc_evp_params *ecc_params = &kem_group_params->ecc_params;
     ecc_params->negotiated_curve = kem_group->curve;
-    POSIX_GUARD_RESULT(s2n_ecdhe_send_public_key(out, ecc_params));
+    POSIX_GUARD_RESULT(s2n_ecdhe_send_public_key(ecc_params, out));
 
     struct s2n_kem_params *kem_params = &kem_group_params->kem_params;
     kem_params->kem = kem_group->kem;

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -67,15 +67,34 @@ static int s2n_generate_default_ecc_key_share(struct s2n_connection *conn, struc
     POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
     POSIX_ENSURE_REF(ecc_pref);
 
-    struct s2n_ecc_evp_params *ecc_evp_params = NULL;
-    ecc_evp_params = &conn->kex_params.client_ecc_evp_params[0];
-    ecc_evp_params->negotiated_curve = ecc_pref->ecc_curves[0];
-    POSIX_GUARD(s2n_ecdhe_parameters_send(ecc_evp_params, out));
+    /* We only ever send a single EC key share: either the share requested by the server
+     * during a retry, or the most preferred share according to local preferences.
+     */
+    struct s2n_ecc_evp_params *client_params = &conn->kex_params.client_ecc_evp_params;
+    if (s2n_is_hello_retry_handshake(conn)) {
+        const struct s2n_ecc_named_curve *server_curve = conn->kex_params.server_ecc_evp_params.negotiated_curve;
+
+        /* If the server did not request a specific ECC keyshare, don't send one */
+        if (!server_curve) {
+            return S2N_SUCCESS;
+        }
+
+        /* If the server requested a new ECC keyshare, free the old one */
+        if (server_curve != client_params->negotiated_curve) {
+            POSIX_GUARD(s2n_ecc_evp_params_free(client_params));
+        }
+
+        client_params->negotiated_curve = server_curve;
+    } else {
+        client_params->negotiated_curve = ecc_pref->ecc_curves[0];
+    }
+    POSIX_GUARD(s2n_ecdhe_parameters_send(client_params, out));
 
     return S2N_SUCCESS;
 }
 
-static int s2n_generate_pq_hybrid_key_share(struct s2n_stuffer *out, struct s2n_kem_group_params *kem_group_params) {
+static int s2n_generate_pq_hybrid_key_share(struct s2n_stuffer *out, struct s2n_kem_group_params *kem_group_params)
+{
     POSIX_ENSURE_REF(out);
     POSIX_ENSURE_REF(kem_group_params);
 
@@ -99,14 +118,7 @@ static int s2n_generate_pq_hybrid_key_share(struct s2n_stuffer *out, struct s2n_
 
     struct s2n_ecc_evp_params *ecc_params = &kem_group_params->ecc_params;
     ecc_params->negotiated_curve = kem_group->curve;
-    POSIX_GUARD(s2n_stuffer_write_uint16(out, ecc_params->negotiated_curve->share_size));
-
-    /* If we received a HRR for any reason other than to request a different key share,
-     * we might have already generated the key. */
-    if (ecc_params->evp_pkey == NULL) {
-        POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(ecc_params));
-    }
-    POSIX_GUARD(s2n_ecc_evp_write_params_point(ecc_params, out));
+    POSIX_GUARD_RESULT(s2n_ecdhe_send_public_key(out, ecc_params));
 
     struct s2n_kem_params *kem_params = &kem_group_params->kem_params;
     kem_params->kem = kem_group->kem;
@@ -117,7 +129,8 @@ static int s2n_generate_pq_hybrid_key_share(struct s2n_stuffer *out, struct s2n_
     return S2N_SUCCESS;
 }
 
-static int s2n_generate_default_pq_hybrid_key_share(struct s2n_connection *conn, struct s2n_stuffer *out) {
+static int s2n_generate_default_pq_hybrid_key_share(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(out);
 
@@ -134,90 +147,28 @@ static int s2n_generate_default_pq_hybrid_key_share(struct s2n_connection *conn,
         return S2N_SUCCESS;
     }
 
-    /* We only send a single PQ key share - the highest preferred one */
-    struct s2n_kem_group_params *kem_group_params = &conn->kex_params.client_kem_group_params[0];
-    kem_group_params->kem_group = kem_pref->tls13_kem_groups[0];
+    /* We only ever send a single PQ key share: either the share requested by the server
+     * during a retry, or the most preferred share according to local preferences.
+     */
+    struct s2n_kem_group_params *client_params = &conn->kex_params.client_kem_group_params;
+    if (s2n_is_hello_retry_handshake(conn)) {
+        const struct s2n_kem_group *server_group = conn->kex_params.server_kem_group_params.kem_group;
 
-    POSIX_GUARD(s2n_generate_pq_hybrid_key_share(out, kem_group_params));
-
-    return S2N_SUCCESS;
-}
-
-static int s2n_send_hrr_ecc_keyshare(struct s2n_connection *conn, struct s2n_stuffer *out)
-{
-    POSIX_ENSURE_REF(conn);
-
-    const struct s2n_ecc_preferences *ecc_pref = NULL;
-    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    POSIX_ENSURE_REF(ecc_pref);
-
-    const struct s2n_ecc_named_curve *server_negotiated_curve = conn->kex_params.server_ecc_evp_params.negotiated_curve;
-    POSIX_ENSURE(server_negotiated_curve != NULL, S2N_ERR_BAD_KEY_SHARE);
-    POSIX_ENSURE(s2n_ecc_preferences_includes_curve(ecc_pref, server_negotiated_curve->iana_id),
-            S2N_ERR_INVALID_HELLO_RETRY);
-
-    struct s2n_ecc_evp_params *ecc_evp_params = NULL;
-    for (size_t i = 0; i < ecc_pref->count; i++) {
-        if (ecc_pref->ecc_curves[i]->iana_id == server_negotiated_curve->iana_id) {
-            ecc_evp_params = &conn->kex_params.client_ecc_evp_params[i];
-            break;
+        /* If the server did not request a specific PQ keyshare, don't send one */
+        if (!server_group) {
+            return S2N_SUCCESS;
         }
-    }
-    POSIX_ENSURE_REF(ecc_evp_params);
 
-    /* Generate the keyshare for the server negotiated curve */
-    ecc_evp_params->negotiated_curve = server_negotiated_curve;
-    POSIX_GUARD(s2n_ecdhe_parameters_send(ecc_evp_params, out));
-
-    return S2N_SUCCESS;
-}
-
-static int s2n_send_hrr_pq_hybrid_keyshare(struct s2n_connection *conn, struct s2n_stuffer *out) {
-    POSIX_ENSURE_REF(conn);
-    POSIX_ENSURE_REF(out);
-
-    /* If PQ is disabled, the client should not have sent any PQ IDs
-     * in the supported_groups list of the initial ClientHello */
-    POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
-
-    const struct s2n_kem_preferences *kem_pref = NULL;
-    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
-    POSIX_ENSURE_REF(kem_pref);
-
-    const struct s2n_kem_group *server_negotiated_kem_group = conn->kex_params.server_kem_group_params.kem_group;
-    POSIX_ENSURE(server_negotiated_kem_group != NULL, S2N_ERR_INVALID_HELLO_RETRY);
-    POSIX_ENSURE(s2n_kem_preferences_includes_tls13_kem_group(kem_pref, server_negotiated_kem_group->iana_id),
-            S2N_ERR_INVALID_HELLO_RETRY);
-    struct s2n_kem_group_params *kem_group_params = NULL;
-
-    for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-        if (kem_pref->tls13_kem_groups[i]->iana_id == server_negotiated_kem_group->iana_id) {
-            kem_group_params = &conn->kex_params.client_kem_group_params[i];
-            break;
+        /* If the server requested a new PQ keyshare, free the old one */
+        if (client_params->kem_group != server_group) {
+            POSIX_GUARD(s2n_kem_group_free(client_params));
         }
-    }
-    POSIX_ENSURE_REF(kem_group_params);
 
-    /* Generate the keyshare for the server negotiated KEM group */
-    kem_group_params->kem_group = server_negotiated_kem_group;
-    POSIX_GUARD(s2n_generate_pq_hybrid_key_share(out, kem_group_params));
-
-    return S2N_SUCCESS;
-}
-
-/* From https://tools.ietf.org/html/rfc8446#section-4.1.2
- * If a "key_share" extension was supplied in the HelloRetryRequest,
- * replace the list of shares with a list containing a single
- * KeyShareEntry from the indicated group.*/
-static int s2n_send_hrr_keyshare(struct s2n_connection *conn, struct s2n_stuffer *out) {
-    POSIX_ENSURE_REF(conn);
-    POSIX_ENSURE_REF(out);
-
-    if (conn->kex_params.server_kem_group_params.kem_group != NULL) {
-        POSIX_GUARD(s2n_send_hrr_pq_hybrid_keyshare(conn, out));
+        client_params->kem_group = server_group;
     } else {
-        POSIX_GUARD(s2n_send_hrr_ecc_keyshare(conn, out));
+        client_params->kem_group = kem_pref->tls13_kem_groups[0];
     }
+    POSIX_GUARD(s2n_generate_pq_hybrid_key_share(out, client_params));
 
     return S2N_SUCCESS;
 }
@@ -226,21 +177,19 @@ static int s2n_client_key_share_send(struct s2n_connection *conn, struct s2n_stu
 {
     struct s2n_stuffer_reservation shares_size = {0};
     POSIX_GUARD(s2n_stuffer_reserve_uint16(out, &shares_size));
-
-    if (s2n_is_hello_retry_handshake(conn)) {
-        POSIX_GUARD(s2n_send_hrr_keyshare(conn, out));
-    } else {
-        POSIX_GUARD(s2n_generate_default_pq_hybrid_key_share(conn, out));
-        POSIX_GUARD(s2n_generate_default_ecc_key_share(conn, out));
-    }
-
+    POSIX_GUARD(s2n_generate_default_pq_hybrid_key_share(conn, out));
+    POSIX_GUARD(s2n_generate_default_ecc_key_share(conn, out));
     POSIX_GUARD(s2n_stuffer_write_vector_size(&shares_size));
+
+    /* We must have written at least one share */
+    POSIX_ENSURE(s2n_stuffer_data_available(out) > shares_size.length, S2N_ERR_BAD_KEY_SHARE);
 
     return S2N_SUCCESS;
 }
 
 static int s2n_client_key_share_parse_ecc(struct s2n_stuffer *key_share, const struct s2n_ecc_named_curve *curve,
-        struct s2n_ecc_evp_params *ecc_params) {
+        struct s2n_ecc_evp_params *ecc_params)
+{
     POSIX_ENSURE_REF(key_share);
     POSIX_ENSURE_REF(curve);
     POSIX_ENSURE_REF(ecc_params);
@@ -258,33 +207,46 @@ static int s2n_client_key_share_parse_ecc(struct s2n_stuffer *key_share, const s
     return S2N_SUCCESS;
 }
 
-static int s2n_client_key_share_recv_ecc(struct s2n_connection *conn, struct s2n_stuffer *key_share,
-        uint16_t curve_iana_id, bool *match) {
+static int s2n_client_key_share_recv_ecc(struct s2n_connection *conn, struct s2n_stuffer *key_share, uint16_t curve_iana_id)
+{
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(key_share);
-    POSIX_ENSURE_REF(match);
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
     POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
     POSIX_ENSURE_REF(ecc_pref);
 
+    struct s2n_ecc_evp_params *client_params = &conn->kex_params.client_ecc_evp_params;
+
     const struct s2n_ecc_named_curve *curve = NULL;
-    struct s2n_ecc_evp_params *client_ecc_params = NULL;
     for (size_t i = 0; i < ecc_pref->count; i++) {
-        if (curve_iana_id == ecc_pref->ecc_curves[i]->iana_id) {
-            curve = ecc_pref->ecc_curves[i];
-            client_ecc_params = &conn->kex_params.client_ecc_evp_params[i];
+        const struct s2n_ecc_named_curve *supported_curve = ecc_pref->ecc_curves[i];
+        POSIX_ENSURE_REF(supported_curve);
+
+        /* Stop if we reach the current highest priority share.
+         * Any share of lower priority is discarded.
+         */
+        if (client_params->negotiated_curve == supported_curve) {
+            break;
+        }
+
+        /* Skip if not supported by the client.
+         * The client must not send shares it doesn't support, but the server
+         * is not required to error if they are encountered.
+         */
+        if (!conn->kex_params.mutually_supported_curves[i]) {
+            continue;
+        }
+
+        /* Stop if we find a match */
+        if (curve_iana_id == supported_curve->iana_id) {
+            curve = supported_curve;
             break;
         }
     }
 
     /* Ignore unsupported curves */
-    if (!curve || !client_ecc_params) {
-        return S2N_SUCCESS;
-    }
-
-    /* Ignore curves that we've already received material for */
-    if (client_ecc_params->negotiated_curve) {
+    if (!curve) {
         return S2N_SUCCESS;
     }
 
@@ -293,20 +255,25 @@ static int s2n_client_key_share_recv_ecc(struct s2n_connection *conn, struct s2n
         return S2N_SUCCESS;
     }
 
-    POSIX_GUARD(s2n_client_key_share_parse_ecc(key_share, curve, client_ecc_params));
-    /* negotiated_curve will be non-NULL if the key share was parsed successfully */
-    if (client_ecc_params->negotiated_curve) {
-        *match = true;
+    DEFER_CLEANUP(struct s2n_ecc_evp_params new_client_params = { 0 }, s2n_ecc_evp_params_free);
+
+    POSIX_GUARD(s2n_client_key_share_parse_ecc(key_share, curve, &new_client_params));
+    /* negotiated_curve will be NULL if the key share was not parsed successfully */
+    if (!new_client_params.negotiated_curve) {
+        return S2N_SUCCESS;
     }
 
+    POSIX_GUARD(s2n_ecc_evp_params_free(client_params));
+    *client_params = new_client_params;
+
+    ZERO_TO_DISABLE_DEFER_CLEANUP(new_client_params);
     return S2N_SUCCESS;
 }
 
-static int s2n_client_key_share_recv_pq_hybrid(struct s2n_connection *conn, struct s2n_stuffer *key_share,
-        uint16_t kem_group_iana_id, bool *match) {
+static int s2n_client_key_share_recv_pq_hybrid(struct s2n_connection *conn, struct s2n_stuffer *key_share, uint16_t kem_group_iana_id)
+{
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(key_share);
-    POSIX_ENSURE_REF(match);
 
     const struct s2n_kem_preferences *kem_pref = NULL;
     POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
@@ -317,23 +284,37 @@ static int s2n_client_key_share_recv_pq_hybrid(struct s2n_connection *conn, stru
         return S2N_SUCCESS;
     }
 
+    struct s2n_kem_group_params *client_params = &conn->kex_params.client_kem_group_params;
+
     const struct s2n_kem_group *kem_group = NULL;
-    struct s2n_kem_group_params *client_kem_group_params = NULL;
     for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
-        if (kem_group_iana_id == kem_pref->tls13_kem_groups[i]->iana_id) {
-            kem_group = kem_pref->tls13_kem_groups[i];
-            client_kem_group_params = &conn->kex_params.client_kem_group_params[i];
+        const struct s2n_kem_group *supported_group = kem_pref->tls13_kem_groups[i];
+        POSIX_ENSURE_REF(supported_group);
+
+        /* Stop if we reach the current highest priority share.
+         * Any share of lower priority is discarded.
+         */
+        if (client_params->kem_group == supported_group) {
+            break;
+        }
+
+        /* Skip if not supported by the client.
+         * The client must not send shares it doesn't support, but the server
+         * is not required to error if they are encountered.
+         */
+        if (!conn->kex_params.mutually_supported_kem_groups[i]) {
+            continue;
+        }
+
+        /* Stop if we find a match */
+        if (kem_group_iana_id == supported_group->iana_id) {
+            kem_group = supported_group;
             break;
         }
     }
 
     /* Ignore unsupported KEM groups */
-    if (!kem_group || !client_kem_group_params) {
-        return S2N_SUCCESS;
-    }
-
-    /* Ignore KEM groups that we've already received material for */
-    if (client_kem_group_params->kem_group) {
+    if (!kem_group) {
         return S2N_SUCCESS;
     }
 
@@ -342,80 +323,85 @@ static int s2n_client_key_share_recv_pq_hybrid(struct s2n_connection *conn, stru
         return S2N_SUCCESS;
     }
 
+    /* Ignore KEM groups with unexpected ECC share sizes */
     uint16_t ec_share_size = 0;
     POSIX_GUARD(s2n_stuffer_read_uint16(key_share, &ec_share_size));
-    /* Ignore KEM groups with unexpected ECC share sizes */
     if (ec_share_size != kem_group->curve->share_size) {
         return S2N_SUCCESS;
     }
 
-    POSIX_GUARD(s2n_client_key_share_parse_ecc(key_share, kem_group->curve, &client_kem_group_params->ecc_params));
+    DEFER_CLEANUP(struct s2n_kem_group_params new_client_params = { 0 }, s2n_kem_group_free);
+    new_client_params.kem_group = kem_group;
+
+    POSIX_GUARD(s2n_client_key_share_parse_ecc(key_share, kem_group->curve, &new_client_params.ecc_params));
     /* If we were unable to parse the EC portion of the share, negotiated_curve
      * will be NULL, and we should ignore the entire key share. */
-    if (!client_kem_group_params->ecc_params.negotiated_curve) {
+    if (!new_client_params.ecc_params.negotiated_curve) {
         return S2N_SUCCESS;
     }
 
     /* Note: the PQ share size is validated in s2n_kem_recv_public_key() */
     /* Ignore groups with PQ public keys we can't parse */
-    client_kem_group_params->kem_params.kem = kem_group->kem;
-    if (s2n_kem_recv_public_key(key_share, &client_kem_group_params->kem_params) != S2N_SUCCESS) {
-        client_kem_group_params->kem_group = NULL;
-        client_kem_group_params->kem_params.kem = NULL;
-        client_kem_group_params->ecc_params.negotiated_curve = NULL;
-        /* s2n_kem_group_free() will free both the ECC and KEM params */
-        POSIX_GUARD(s2n_kem_group_free(client_kem_group_params));
+    new_client_params.kem_params.kem = kem_group->kem;
+    if (s2n_kem_recv_public_key(key_share, &new_client_params.kem_params) != S2N_SUCCESS) {
         return S2N_SUCCESS;
     }
 
-    client_kem_group_params->kem_group = kem_group;
-    *match = true;
+    POSIX_GUARD(s2n_kem_group_free(client_params));
+    *client_params = new_client_params;
+
+    ZERO_TO_DISABLE_DEFER_CLEANUP(new_client_params);
     return S2N_SUCCESS;
 }
 
-static int s2n_client_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension) {
+/*
+ * We chose our most preferred group of the mutually supported groups while processing the
+ * supported_groups extension. However, our true most preferred group is always the
+ * group that we already have a key share for, since retries are expensive.
+ *
+ * This method modifies our group selection based on what keyshares are available.
+ * It then stores the client keyshare for the selected group, or initiates a retry
+ * if no valid keyshares are available.
+ */
+static int s2n_client_key_share_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(extension);
 
-    const struct s2n_ecc_preferences *ecc_pref = NULL;
-    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
-    POSIX_ENSURE_REF(ecc_pref);
-
-    const struct s2n_kem_preferences *kem_pref = NULL;
-    POSIX_GUARD(s2n_connection_get_kem_preferences(conn, &kem_pref));
-    POSIX_ENSURE_REF(kem_pref);
-
     uint16_t key_shares_size;
     POSIX_GUARD(s2n_stuffer_read_uint16(extension, &key_shares_size));
-    POSIX_ENSURE(s2n_stuffer_data_available(extension) >= key_shares_size, S2N_ERR_BAD_MESSAGE);
+    POSIX_ENSURE(s2n_stuffer_data_available(extension) == key_shares_size, S2N_ERR_BAD_MESSAGE);
 
-    uint16_t named_group, share_size;
-    bool match_found = false;
-    /* bytes_processed is declared as a uint32_t to avoid integer overflow in later calculations */
-    uint32_t bytes_processed = 0;
+    uint16_t named_group = 0, share_size = 0;
+    struct s2n_blob key_share_blob = { 0 };
+    struct s2n_stuffer key_share = { 0 };
 
-    while (bytes_processed < key_shares_size) {
+    uint16_t keyshare_count = 0;
+    while(s2n_stuffer_data_available(extension) > 0) {
         POSIX_GUARD(s2n_stuffer_read_uint16(extension, &named_group));
         POSIX_GUARD(s2n_stuffer_read_uint16(extension, &share_size));
-
         POSIX_ENSURE(s2n_stuffer_data_available(extension) >= share_size, S2N_ERR_BAD_MESSAGE);
-        bytes_processed += share_size + S2N_SIZE_OF_NAMED_GROUP + S2N_SIZE_OF_KEY_SHARE_SIZE;
 
-        struct s2n_blob key_share_blob = { .size = share_size, .data = s2n_stuffer_raw_read(extension, share_size) };
-        POSIX_ENSURE_REF(key_share_blob.data);
-        struct s2n_stuffer key_share = { 0 };
+        POSIX_GUARD(s2n_blob_init(&key_share_blob,
+            s2n_stuffer_raw_read(extension, share_size), share_size));
         POSIX_GUARD(s2n_stuffer_init(&key_share, &key_share_blob));
         POSIX_GUARD(s2n_stuffer_skip_write(&key_share, share_size));
+        keyshare_count++;
 
         /* Try to parse the share as ECC, then as PQ/hybrid; will ignore
          * shares for unrecognized groups. */
-        POSIX_GUARD(s2n_client_key_share_recv_ecc(conn, &key_share, named_group, &match_found));
-        POSIX_GUARD(s2n_client_key_share_recv_pq_hybrid(conn, &key_share, named_group, &match_found));
+        POSIX_GUARD(s2n_client_key_share_recv_ecc(conn, &key_share, named_group));
+        POSIX_GUARD(s2n_client_key_share_recv_pq_hybrid(conn, &key_share, named_group));
     }
+
+    /* During a retry, the client should only have sent one keyshare */
+    POSIX_ENSURE(!s2n_is_hello_retry_handshake(conn) || keyshare_count == 1, S2N_ERR_BAD_MESSAGE);
 
     /* If there were no matching key shares, then we received an empty key share extension
      * or we didn't match a key share with a supported group. We should send a retry. */
-    if (!match_found) {
+    struct s2n_ecc_evp_params *client_ecc_params = &conn->kex_params.client_ecc_evp_params;
+    struct s2n_kem_group_params *client_pq_params = &conn->kex_params.client_kem_group_params;
+    if (!client_pq_params->kem_group && !client_ecc_params->negotiated_curve) {
         POSIX_GUARD(s2n_set_hello_retry_required(conn));
     }
 

--- a/tls/extensions/s2n_extension_type_lists.c
+++ b/tls/extensions/s2n_extension_type_lists.c
@@ -51,7 +51,13 @@
 
 static const s2n_extension_type *const client_hello_extensions[] = {
         &s2n_client_supported_versions_extension,
+
+        /* We MUST process key_share after supported_groups,
+         * because we need to choose the keyshare based on the
+         * mutually supported groups. */
+        &s2n_client_supported_groups_extension,
         &s2n_client_key_share_extension,
+
         &s2n_client_signature_algorithms_extension,
         &s2n_client_server_name_extension,
         &s2n_client_alpn_extension,
@@ -59,7 +65,6 @@ static const s2n_extension_type *const client_hello_extensions[] = {
         &s2n_client_sct_list_extension,
         &s2n_client_max_frag_len_extension,
         &s2n_client_session_ticket_extension,
-        &s2n_client_supported_groups_extension,
         &s2n_client_ec_point_format_extension,
         &s2n_client_pq_kem_extension,
         &s2n_client_renegotiation_info_extension,

--- a/tls/extensions/s2n_key_share.c
+++ b/tls/extensions/s2n_key_share.c
@@ -17,7 +17,10 @@
 #include "tls/s2n_tls.h"
 #include "utils/s2n_safety.h"
 
-S2N_RESULT s2n_ecdhe_send_public_key(struct s2n_stuffer *out, struct s2n_ecc_evp_params *ecc_evp_params)
+/* Generate and write an ecc point.
+ * This is used to write the ecc portion of PQ hybrid keyshares, which does NOT include the curve id.
+ */
+S2N_RESULT s2n_ecdhe_send_public_key(struct s2n_ecc_evp_params *ecc_evp_params, struct s2n_stuffer *out)
 {
     RESULT_ENSURE_REF(ecc_evp_params);
     RESULT_ENSURE_REF(ecc_evp_params->negotiated_curve);
@@ -31,13 +34,16 @@ S2N_RESULT s2n_ecdhe_send_public_key(struct s2n_stuffer *out, struct s2n_ecc_evp
     return S2N_RESULT_OK;
 }
 
+/* Generate and write an ecc point and its corresponding curve id.
+ * This is used to write ecc keyshares for the client and server key_share extensions.
+ */
 int s2n_ecdhe_parameters_send(struct s2n_ecc_evp_params *ecc_evp_params, struct s2n_stuffer *out)
 {
     POSIX_ENSURE_REF(ecc_evp_params);
     POSIX_ENSURE_REF(ecc_evp_params->negotiated_curve);
 
     POSIX_GUARD(s2n_stuffer_write_uint16(out, ecc_evp_params->negotiated_curve->iana_id));
-    POSIX_GUARD_RESULT(s2n_ecdhe_send_public_key(out, ecc_evp_params));
+    POSIX_GUARD_RESULT(s2n_ecdhe_send_public_key(ecc_evp_params, out));
 
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_key_share.h
+++ b/tls/extensions/s2n_key_share.h
@@ -25,4 +25,5 @@
 #define S2N_SIZE_OF_NAMED_GROUP             2
 #define S2N_SIZE_OF_KEY_SHARE_SIZE          2
 
-extern int s2n_ecdhe_parameters_send(struct s2n_ecc_evp_params *ecc_evp_params, struct s2n_stuffer *out);
+S2N_RESULT s2n_ecdhe_send_public_key(struct s2n_stuffer *out, struct s2n_ecc_evp_params *ecc_evp_params);
+int s2n_ecdhe_parameters_send(struct s2n_ecc_evp_params *ecc_evp_params, struct s2n_stuffer *out);

--- a/tls/extensions/s2n_key_share.h
+++ b/tls/extensions/s2n_key_share.h
@@ -25,5 +25,5 @@
 #define S2N_SIZE_OF_NAMED_GROUP             2
 #define S2N_SIZE_OF_KEY_SHARE_SIZE          2
 
-S2N_RESULT s2n_ecdhe_send_public_key(struct s2n_stuffer *out, struct s2n_ecc_evp_params *ecc_evp_params);
+S2N_RESULT s2n_ecdhe_send_public_key(struct s2n_ecc_evp_params *ecc_evp_params, struct s2n_stuffer *out);
 int s2n_ecdhe_parameters_send(struct s2n_ecc_evp_params *ecc_evp_params, struct s2n_stuffer *out);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1023,7 +1023,7 @@ const char *s2n_connection_get_kem_group_name(struct s2n_connection *conn)
 {
     PTR_ENSURE_REF(conn);
 
-    if (!conn->kex_params.client_kem_group_params.kem_group) {
+    if (conn->actual_protocol_version < S2N_TLS13 || !conn->kex_params.client_kem_group_params.kem_group) {
         return "NONE";
     }
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -257,14 +257,10 @@ S2N_RESULT s2n_connection_wipe_all_keyshares(struct s2n_connection *conn)
     RESULT_ENSURE_REF(conn);
 
     RESULT_GUARD_POSIX(s2n_ecc_evp_params_free(&conn->kex_params.server_ecc_evp_params));
-    for (size_t i = 0; i < S2N_ECC_EVP_SUPPORTED_CURVES_COUNT; i++) {
-        RESULT_GUARD_POSIX(s2n_ecc_evp_params_free(&conn->kex_params.client_ecc_evp_params[i]));
-    }
+    RESULT_GUARD_POSIX(s2n_ecc_evp_params_free(&conn->kex_params.client_ecc_evp_params));
 
     RESULT_GUARD_POSIX(s2n_kem_group_free(&conn->kex_params.server_kem_group_params));
-    for (size_t i = 0; i < S2N_SUPPORTED_KEM_GROUPS_COUNT; i++) {
-        RESULT_GUARD_POSIX(s2n_kem_group_free(&conn->kex_params.client_kem_group_params[i]));
-    }
+    RESULT_GUARD_POSIX(s2n_kem_group_free(&conn->kex_params.client_kem_group_params));
 
     return S2N_RESULT_OK;
 }
@@ -1027,11 +1023,11 @@ const char *s2n_connection_get_kem_group_name(struct s2n_connection *conn)
 {
     PTR_ENSURE_REF(conn);
 
-    if (!conn->kex_params.chosen_client_kem_group_params || !conn->kex_params.chosen_client_kem_group_params->kem_group) {
+    if (!conn->kex_params.client_kem_group_params.kem_group) {
         return "NONE";
     }
 
-    return conn->kex_params.chosen_client_kem_group_params->kem_group->name;
+    return conn->kex_params.client_kem_group_params.kem_group->name;
 }
 
 int s2n_connection_get_client_protocol_version(struct s2n_connection *conn)

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -34,10 +34,9 @@ struct s2n_kex_parameters {
     struct s2n_dh_params server_dh_params;
     struct s2n_ecc_evp_params server_ecc_evp_params;
     const struct s2n_ecc_named_curve *mutually_supported_curves[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
-    struct s2n_ecc_evp_params client_ecc_evp_params[S2N_ECC_EVP_SUPPORTED_CURVES_COUNT];
+    struct s2n_ecc_evp_params client_ecc_evp_params;
     struct s2n_kem_group_params server_kem_group_params;
-    struct s2n_kem_group_params *chosen_client_kem_group_params;
-    struct s2n_kem_group_params client_kem_group_params[S2N_SUPPORTED_KEM_GROUPS_COUNT];
+    struct s2n_kem_group_params client_kem_group_params;
     const struct s2n_kem_group *mutually_supported_kem_groups[S2N_SUPPORTED_KEM_GROUPS_COUNT];
     struct s2n_kem_params kem_params;
     struct s2n_blob client_key_exchange_message;

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -80,6 +80,8 @@ int s2n_tls13_compute_ecc_shared_secret(struct s2n_connection *conn, struct s2n_
     POSIX_ENSURE_REF(client_key);
     POSIX_ENSURE_REF(client_key->negotiated_curve);
 
+    POSIX_ENSURE_EQ(server_key->negotiated_curve, client_key->negotiated_curve);
+
     if (conn->mode == S2N_CLIENT) {
         POSIX_GUARD(s2n_ecc_evp_compute_shared_secret_from_params(client_key, server_key, shared_secret));
     } else {

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -75,17 +75,10 @@ int s2n_tls13_compute_ecc_shared_secret(struct s2n_connection *conn, struct s2n_
     struct s2n_ecc_evp_params *server_key = &conn->kex_params.server_ecc_evp_params;
     POSIX_ENSURE_REF(server_key);
     POSIX_ENSURE_REF(server_key->negotiated_curve);
-    /* for now we do this tedious loop to find the matching client key selection.
-     * this can be simplified if we get an index or a pointer to a specific key */
-    struct s2n_ecc_evp_params *client_key = NULL;
-    for (size_t i = 0; i < ecc_preferences->count; i++) {
-        if (server_key->negotiated_curve->iana_id == ecc_preferences->ecc_curves[i]->iana_id) {
-            client_key = &conn->kex_params.client_ecc_evp_params[i];
-            break;
-        }
-    }
 
-    POSIX_ENSURE(client_key != NULL, S2N_ERR_BAD_KEY_SHARE);
+    struct s2n_ecc_evp_params *client_key  = &conn->kex_params.client_ecc_evp_params;
+    POSIX_ENSURE_REF(client_key);
+    POSIX_ENSURE_REF(client_key->negotiated_curve);
 
     if (conn->mode == S2N_CLIENT) {
         POSIX_GUARD(s2n_ecc_evp_compute_shared_secret_from_params(client_key, server_key, shared_secret));
@@ -111,7 +104,7 @@ int s2n_tls13_compute_pq_hybrid_shared_secret(struct s2n_connection *conn, struc
     struct s2n_ecc_evp_params *server_ecc_params = &server_kem_group_params->ecc_params;
     POSIX_ENSURE_REF(server_ecc_params);
 
-    struct s2n_kem_group_params *client_kem_group_params = conn->kex_params.chosen_client_kem_group_params;
+    struct s2n_kem_group_params *client_kem_group_params = &conn->kex_params.client_kem_group_params;
     POSIX_ENSURE_REF(client_kem_group_params);
     struct s2n_ecc_evp_params *client_ecc_params = &client_kem_group_params->ecc_params;
     POSIX_ENSURE_REF(client_ecc_params);


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/2935

### Description of changes: 

Follow up to https://github.com/aws/s2n-tls/commit/bba31e9a113c6aa12706d19bee906a1859a198ff.

Now that no code path involves S2N sending multiple keyshares, we can stop maintaining memory for multiple keyshares. Instead of an array of keyshares indexed according to the ECC preferences, we have a single keyshare:
* When sending, that keyshare is either for our most preferred group, or for the group chosen by the server on a retry. If we generate a new share during a retry, we wipe the old share and reuse the structure.
* When receiving, we keep track of the most preferred keyshare as we iterate over the client's offered list. If we encounter a keyshare we prefer to the currently stored one, we wipe and replace.
  * Previously we didn't consider the "mutually supported curves" when processing the client keyshares. We didn't reject shares for groups not offered by the peer until later in the handshake. But because we now only keep one keyshare, we have to consider the "mutually supported curves" earlier to ensure the single key share we keep is valid.

### Testing:

I touched the existing tests as little as possible to verify no unexpected behavior changes. The changes I made to the tests generally fall into three categories:
* A straight swap of client_ecc_evp_params[0] or chosen_client_ecc_evp_params for client_ecc_evp_params.
* Converting a for loop over all ecc preferences to just client_ecc_evp_params. In many places in the tests, we verify one entry of client_ecc_evp_params[] is set as expected and the rest are empty. Now, we just need to verify that client_ecc_evp_params is set as expected.
* Delete some tests that verify some curve is within our ecc preferences. We got this check "for free" when we had to iterate over client_ecc_evp_params[], but now it would be unnecessary work. All curves are verified to be within our ecc preferences before they are set on client_ecc_evp_params/server_ecc_evp_params, so we don't need to keep checking in every method.
* Move the tests of "mutually supported curves" / keyshare interaction from s2n_extensions_server_key_share_select_test.c  to s2n_client_key_share_extension_(pq_)test, because I moved the check for client support from the server to the client extension.

I also added some new tests around share parsing failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
