### PR TITLE
Add new Security Policies for AWS Common Runtime SDKs

### DIFF
--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -395,6 +395,12 @@ int main(int argc, char **argv)
             "CloudFront-TLS-1-2-2018",
             "CloudFront-TLS-1-2-2019",
             "CloudFront-TLS-1-2-2021",
+            /* AWS Common Runtime SDK */
+            "AWS-CRT-SDK-SSLv3.0",
+            "AWS-CRT-SDK-TLSv1.0",
+            "AWS-CRT-SDK-TLSv1.1",
+            "AWS-CRT-SDK-TLSv1.2",
+            "AWS-CRT-SDK-TLSv1.3",
         };
         for (size_t i = 0; i < s2n_array_len(tls13_security_policy_strings); i++) {
             security_policy = NULL;
@@ -512,6 +518,41 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_kms_pq_tls_1_0_2019_06);
         EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20140601);
         EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_20140601);
+
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "AWS-CRT-SDK-SSLv3.0"));
+        EXPECT_EQUAL(config->security_policy, &security_policy_aws_crt_sdk_ssl_v3);
+        EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_aws_crt_sdk_ssl_v3);
+        EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_null);
+        EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20200207);
+        EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
+
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "AWS-CRT-SDK-TLSv1.0"));
+        EXPECT_EQUAL(config->security_policy, &security_policy_aws_crt_sdk_tls_10);
+        EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_aws_crt_sdk_default);
+        EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_null);
+        EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20200207);
+        EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
+
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "AWS-CRT-SDK-TLSv1.1"));
+        EXPECT_EQUAL(config->security_policy, &security_policy_aws_crt_sdk_tls_11);
+        EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_aws_crt_sdk_default);
+        EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_null);
+        EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20200207);
+        EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
+
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "AWS-CRT-SDK-TLSv1.2"));
+        EXPECT_EQUAL(config->security_policy, &security_policy_aws_crt_sdk_tls_12);
+        EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_aws_crt_sdk_default);
+        EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_null);
+        EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20200207);
+        EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
+
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "AWS-CRT-SDK-TLSv1.3"));
+        EXPECT_EQUAL(config->security_policy, &security_policy_aws_crt_sdk_tls_13);
+        EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_aws_crt_sdk_tls_13);
+        EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_null);
+        EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20200207);
+        EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
 
         EXPECT_FAILURE(s2n_config_set_cipher_preferences(config, NULL));
 

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -1107,29 +1107,30 @@ const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2021 =
     .suites = cipher_suites_cloudfront_tls_1_2_2021,
 };
 
-/* Same as cipher_preferences_cloudfront_tls_1_0_2016, but with AES256-SHA256, DES-CBC3-SHA, and RC4-MD5 added for compatibility. */
+/* Based on cipher_preferences_cloudfront_tls_1_0_2016, but with ordering changed and AES256-SHA256, DES-CBC3-SHA, and
+ * RC4-MD5 added for compatibility. */
 struct s2n_cipher_suite *cipher_suites_aws_crt_sdk_ssl_v3[] = {
     S2N_TLS13_CLOUDFRONT_CIPHER_SUITES_20200716,
     &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
-    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
-    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
-    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
-    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
     &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_ecdsa_with_chacha20_poly1305_sha256,
     &s2n_ecdhe_rsa_with_chacha20_poly1305_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
     &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
     &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
     &s2n_rsa_with_aes_128_gcm_sha256,
     &s2n_rsa_with_aes_256_gcm_sha384,
     &s2n_rsa_with_aes_128_cbc_sha256,
     &s2n_rsa_with_aes_256_cbc_sha256,
-    &s2n_rsa_with_aes_256_cbc_sha,
     &s2n_rsa_with_aes_128_cbc_sha,
+    &s2n_rsa_with_aes_256_cbc_sha,
     &s2n_rsa_with_3des_ede_cbc_sha,
     &s2n_rsa_with_rc4_128_md5
 };
@@ -1139,29 +1140,30 @@ const struct s2n_cipher_preferences cipher_preferences_aws_crt_sdk_ssl_v3 = {
     .suites = cipher_suites_aws_crt_sdk_ssl_v3,
 };
 
-/* Same as cipher_preferences_cloudfront_tls_1_0_2016, but with AES256-SHA256 added for compatibility. */
+/* Based on cipher_preferences_cloudfront_tls_1_0_2016, but with ordering changed and AES256-SHA256 added for
+ * compatibility. */
 struct s2n_cipher_suite *cipher_suites_aws_crt_sdk_default[] = {
     S2N_TLS13_CLOUDFRONT_CIPHER_SUITES_20200716,
     &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
-    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
-    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
-    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
-    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
     &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_ecdsa_with_chacha20_poly1305_sha256,
     &s2n_ecdhe_rsa_with_chacha20_poly1305_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
     &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
     &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
     &s2n_rsa_with_aes_128_gcm_sha256,
     &s2n_rsa_with_aes_256_gcm_sha384,
     &s2n_rsa_with_aes_128_cbc_sha256,
     &s2n_rsa_with_aes_256_cbc_sha256,
-    &s2n_rsa_with_aes_256_cbc_sha,
     &s2n_rsa_with_aes_128_cbc_sha,
+    &s2n_rsa_with_aes_256_cbc_sha,
 };
 
 const struct s2n_cipher_preferences cipher_preferences_aws_crt_sdk_default = {

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -1107,6 +1107,77 @@ const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2021 =
     .suites = cipher_suites_cloudfront_tls_1_2_2021,
 };
 
+/* Same as cipher_preferences_cloudfront_tls_1_0_2016, but with AES256-SHA256, DES-CBC3-SHA, and RC4-MD5 added for compatibility. */
+struct s2n_cipher_suite *cipher_suites_aws_crt_sdk_ssl_v3[] = {
+    S2N_TLS13_CLOUDFRONT_CIPHER_SUITES_20200716,
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_chacha20_poly1305_sha256,
+    &s2n_ecdhe_rsa_with_chacha20_poly1305_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_128_cbc_sha256,
+    &s2n_rsa_with_aes_256_cbc_sha256,
+    &s2n_rsa_with_aes_256_cbc_sha,
+    &s2n_rsa_with_aes_128_cbc_sha,
+    &s2n_rsa_with_3des_ede_cbc_sha,
+    &s2n_rsa_with_rc4_128_md5
+};
+
+const struct s2n_cipher_preferences cipher_preferences_aws_crt_sdk_ssl_v3 = {
+    .count = s2n_array_len(cipher_suites_aws_crt_sdk_ssl_v3),
+    .suites = cipher_suites_aws_crt_sdk_ssl_v3,
+};
+
+/* Same as cipher_preferences_cloudfront_tls_1_0_2016, but with AES256-SHA256 added for compatibility. */
+struct s2n_cipher_suite *cipher_suites_aws_crt_sdk_default[] = {
+    S2N_TLS13_CLOUDFRONT_CIPHER_SUITES_20200716,
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_chacha20_poly1305_sha256,
+    &s2n_ecdhe_rsa_with_chacha20_poly1305_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_128_cbc_sha256,
+    &s2n_rsa_with_aes_256_cbc_sha256,
+    &s2n_rsa_with_aes_256_cbc_sha,
+    &s2n_rsa_with_aes_128_cbc_sha,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_aws_crt_sdk_default = {
+    .count = s2n_array_len(cipher_suites_aws_crt_sdk_default),
+    .suites = cipher_suites_aws_crt_sdk_default,
+};
+
+struct s2n_cipher_suite *cipher_suites_aws_crt_sdk_tls_13[] = {
+    S2N_TLS13_CLOUDFRONT_CIPHER_SUITES_20200716
+};
+
+const struct s2n_cipher_preferences cipher_preferences_aws_crt_sdk_tls_13 = {
+    .count = s2n_array_len(cipher_suites_aws_crt_sdk_tls_13),
+    .suites = cipher_suites_aws_crt_sdk_tls_13,
+};
+
 struct s2n_cipher_suite *cipher_suites_kms_tls_1_0_2018_10[] = {
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -90,8 +90,13 @@ extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_1
 extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2018_legacy;
 extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2019_legacy;
 
-extern const struct s2n_cipher_preferences cipher_preferences_kms_tls_1_0_2018_10;
+/* AWS Common Runtime Cipher Preferences */
+extern const struct s2n_cipher_preferences cipher_preferences_aws_crt_sdk_ssl_v3;
+extern const struct s2n_cipher_preferences cipher_preferences_aws_crt_sdk_default;
+extern const struct s2n_cipher_preferences cipher_preferences_aws_crt_sdk_tls_13;
 
+/* AWS KMS Cipher Preferences */
+extern const struct s2n_cipher_preferences cipher_preferences_kms_tls_1_0_2018_10;
 extern const struct s2n_cipher_preferences cipher_preferences_kms_pq_tls_1_0_2019_06;
 extern const struct s2n_cipher_preferences cipher_preferences_kms_pq_tls_1_0_2020_02;
 extern const struct s2n_cipher_preferences cipher_preferences_kms_pq_tls_1_0_2020_07;

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -289,6 +289,46 @@ const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2019_legacy 
     .ecc_preferences = &s2n_ecc_preferences_20140601,
 };
 
+const struct s2n_security_policy security_policy_aws_crt_sdk_ssl_v3 = {
+    .minimum_protocol_version = S2N_SSLv3,
+    .cipher_preferences = &cipher_preferences_aws_crt_sdk_ssl_v3,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20200310,
+};
+
+const struct s2n_security_policy security_policy_aws_crt_sdk_tls_10 = {
+    .minimum_protocol_version = S2N_TLS10,
+    .cipher_preferences = &cipher_preferences_aws_crt_sdk_default,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20200310,
+};
+
+const struct s2n_security_policy security_policy_aws_crt_sdk_tls_11 = {
+    .minimum_protocol_version = S2N_TLS11,
+    .cipher_preferences = &cipher_preferences_aws_crt_sdk_default,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20200310,
+};
+
+const struct s2n_security_policy security_policy_aws_crt_sdk_tls_12 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_aws_crt_sdk_default,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20200310,
+};
+
+const struct s2n_security_policy security_policy_aws_crt_sdk_tls_13 = {
+    .minimum_protocol_version = S2N_TLS13,
+    .cipher_preferences = &cipher_preferences_aws_crt_sdk_tls_13,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20200310,
+};
+
 const struct s2n_security_policy security_policy_kms_tls_1_0_2018_10 = {
     .minimum_protocol_version = S2N_TLS10,
     .cipher_preferences = &cipher_preferences_kms_tls_1_0_2018_10,
@@ -677,6 +717,11 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version="CloudFront-TLS-1-1-2016-Legacy", .security_policy=&security_policy_cloudfront_tls_1_1_2016_legacy, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="CloudFront-TLS-1-2-2018-Legacy", .security_policy=&security_policy_cloudfront_tls_1_2_2018_legacy, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="CloudFront-TLS-1-2-2019-Legacy", .security_policy=&security_policy_cloudfront_tls_1_2_2019_legacy, .ecc_extension_required=0, .pq_kem_extension_required=0 },
+    { .version="AWS-CRT-SDK-SSLv3.0", .security_policy=&security_policy_aws_crt_sdk_ssl_v3, .ecc_extension_required=0, .pq_kem_extension_required=0 },
+    { .version="AWS-CRT-SDK-TLSv1.0", .security_policy=&security_policy_aws_crt_sdk_tls_10, .ecc_extension_required=0, .pq_kem_extension_required=0 },
+    { .version="AWS-CRT-SDK-TLSv1.1", .security_policy=&security_policy_aws_crt_sdk_tls_11, .ecc_extension_required=0, .pq_kem_extension_required=0 },
+    { .version="AWS-CRT-SDK-TLSv1.2", .security_policy=&security_policy_aws_crt_sdk_tls_12, .ecc_extension_required=0, .pq_kem_extension_required=0 },
+    { .version="AWS-CRT-SDK-TLSv1.3", .security_policy=&security_policy_aws_crt_sdk_tls_13, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="KMS-TLS-1-0-2018-10", .security_policy=&security_policy_kms_tls_1_0_2018_10, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="KMS-PQ-TLS-1-0-2019-06", .security_policy=&security_policy_kms_pq_tls_1_0_2019_06, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="KMS-PQ-TLS-1-0-2020-02", .security_policy=&security_policy_kms_pq_tls_1_0_2020_02, .ecc_extension_required=0, .pq_kem_extension_required=0 },

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -83,6 +83,12 @@ extern const struct s2n_security_policy security_policy_elb_fs_1_2_2019_08;
 extern const struct s2n_security_policy security_policy_elb_fs_1_1_2019_08;
 extern const struct s2n_security_policy security_policy_elb_fs_1_2_res_2019_08;
 
+extern const struct s2n_security_policy security_policy_aws_crt_sdk_ssl_v3;
+extern const struct s2n_security_policy security_policy_aws_crt_sdk_tls_10;
+extern const struct s2n_security_policy security_policy_aws_crt_sdk_tls_11;
+extern const struct s2n_security_policy security_policy_aws_crt_sdk_tls_12;
+extern const struct s2n_security_policy security_policy_aws_crt_sdk_tls_13;
+
 extern const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2019_06;
 extern const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2020_02;
 extern const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2020_07;


### PR DESCRIPTION
### Resolved issues:
N/A

### Description of changes: 
The AWS Common Runtime currently [re-uses a variety of TLS Security policies from ELB and Cloudfront for different minimum TLS versions](https://github.com/awslabs/aws-c-io/blob/main/source/s2n/s2n_tls_channel_handler.c#L962-L983) that have slight differences between them. This PR standardizes new security policies to be used by the AWS Common Runtime SDK clients that is a superset of previous security policies in use, and has a wide range of algorithms for both wide compatibility and high security.

All Common Runtime SDK Security policies now:
 - Support TLS 1.3
 - Support for RSA PSS Signatures
 - Support x25519 Elliptic Curves
 - Support ChaCha-Poly Ciphers
 - Support `AES256-SHA256`, aka `s2n_rsa_with_aes_256_cbc_sha256`. (This cipher was included in ELB security policies, but left out of CloudFront security policies, so it was sometimes used by the CRT. To ensure that no customer is broken by removing it, it is included for backwards compatibility.)

### Call-outs:
Previously, when a CRT user configured the minimum TLS version to be 1.0, the CRT would use `CloudFront-TLS-1-0-2014`, which had support for 3DES. Support for 3DES was removed from `AWS-CRT-SDK-TLSv1.0`, and now 3DES is only supported when a CRT user configures SSLv3.

### Testing:
New unit tests added to confirm properties of new TLS Security Policies.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
