### PR TITLE
Added Method to Retrieve Digest for EMS

### DIFF
--- a/tests/unit/s2n_tls_prf_test.c
+++ b/tests/unit/s2n_tls_prf_test.c
@@ -190,14 +190,14 @@ int main(int argc, char **argv)
         /* Get the Client Key transcript */
         EXPECT_SUCCESS(s2n_stuffer_skip_read(&client_to_server, S2N_TLS_RECORD_HEADER_LENGTH));
         uint8_t client_key_message_length = s2n_stuffer_data_available(&client_to_server);
+        uint8_t *client_key_message = s2n_stuffer_raw_read(&client_to_server, client_key_message_length);
         struct s2n_blob message = { 0 };
-        message.data = &client_to_server.blob.data[client_to_server.read_cursor];
-        message.size = client_key_message_length;
+        EXPECT_SUCCESS(s2n_blob_init(&message, client_key_message, client_key_message_length));
 
         EXPECT_OK(s2n_prf_get_digest_for_ems(server_conn, &message, &digest_for_ems));
 
         /* Server reads Client Key Exchange message */
-        EXPECT_SUCCESS(s2n_stuffer_rewind_read(&client_to_server, S2N_TLS_RECORD_HEADER_LENGTH));
+        EXPECT_SUCCESS(s2n_stuffer_rewind_read(&client_to_server, S2N_TLS_RECORD_HEADER_LENGTH + client_key_message_length));
         EXPECT_SUCCESS(s2n_handshake_read_io(server_conn));
 
         /* Calculate the digest message after the Server read the Client Key message */

--- a/tests/unit/s2n_tls_prf_test.c
+++ b/tests/unit/s2n_tls_prf_test.c
@@ -22,7 +22,8 @@
 
 #include "testlib/s2n_testlib.h"
 #include "stuffer/s2n_stuffer.h"
-#include "tls/s2n_prf.h"
+/* To gain access to handshake_read and handshake_write */
+#include "tls/s2n_handshake_io.c"
 
 /*
  * Grabbed from gnutls-cli --insecure -d 9 www.example.com --ciphers AES --macs SHA --protocols TLS1.0
@@ -134,6 +135,87 @@ int main(int argc, char **argv)
         EXPECT_BYTEARRAY_EQUAL(extended_master_secret.data, conn->secrets.master_secret, S2N_TLS_SECRET_LEN);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* s2n_retrieve_digest_for_ems calculates the correct digest to generate an extended master secret.
+     * Here we test that the retrieved digest is the same as the digest after the Client Key Exchange
+     * message is added to the transcript hash.
+     *
+     *= https://tools.ietf.org/rfc/rfc7627#section-3
+     *= type=test
+     *# When a full TLS handshake takes place, we define
+     *#
+     *#       session_hash = Hash(handshake_messages)
+     *#
+     *# where "handshake_messages" refers to all handshake messages sent or
+     *# received, starting at the ClientHello up to and including the
+     *# ClientKeyExchange message, including the type and length fields of
+     *# the handshake messages.
+     */
+    {
+        struct s2n_cert_chain_and_key *tls12_chain_and_key = NULL;
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&tls12_chain_and_key, S2N_DEFAULT_TEST_CERT_CHAIN,
+                S2N_DEFAULT_TEST_PRIVATE_KEY));
+
+        struct s2n_config *config = s2n_config_new();
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, tls12_chain_and_key));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20170210"));
+
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(client_conn);
+
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        DEFER_CLEANUP(struct s2n_stuffer client_to_server = { 0 }, s2n_stuffer_free);
+        DEFER_CLEANUP(struct s2n_stuffer server_to_client = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_to_server, 0));
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_to_client, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_to_client, &client_to_server, client_conn));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&client_to_server, &server_to_client, server_conn));
+
+        EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, CLIENT_KEY));
+
+        /* Client writes Client Key Exchange message */
+        EXPECT_SUCCESS(s2n_handshake_write_io(client_conn));
+
+        uint8_t data[SHA256_DIGEST_LENGTH] = { 0 };
+        struct s2n_blob digest_for_ems = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&digest_for_ems, data, sizeof(data)));
+
+        /* Here we fiddle with the io_stuffers to get the Client Key transcript */
+        DEFER_CLEANUP(struct s2n_stuffer client_key_message = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_key_message, 0));
+        EXPECT_SUCCESS(s2n_stuffer_skip_read(&client_to_server, S2N_TLS_RECORD_HEADER_LENGTH));
+        uint8_t client_key_message_length = s2n_stuffer_data_available(&client_to_server);
+        EXPECT_SUCCESS(s2n_stuffer_copy(&client_to_server, &client_key_message, client_key_message_length));
+        client_key_message.blob.size = client_key_message_length;
+
+        EXPECT_OK(s2n_retrieve_digest_for_ems(server_conn, &client_key_message.blob, &digest_for_ems));
+
+        /* Server reads Client Key Exchange message */
+        EXPECT_SUCCESS(s2n_stuffer_rewind_read(&client_to_server, S2N_TLS_RECORD_HEADER_LENGTH + client_key_message_length));
+        EXPECT_SUCCESS(s2n_handshake_read_io(server_conn));
+
+        /* Calculate the digest message after the Server read the Client Key message */
+        uint8_t server_digest[SHA256_DIGEST_LENGTH] = { 0 };
+        POSIX_GUARD(s2n_hash_copy(&server_conn->hash_workspace, &server_conn->handshake.sha256));
+        POSIX_GUARD(s2n_hash_digest(&server_conn->hash_workspace, server_digest, SHA256_DIGEST_LENGTH));
+
+        /* Digest for generating the EMS and digest after reading the Client Key message
+         * should be the same. */
+        EXPECT_EQUAL(sizeof(server_digest), digest_for_ems.size);
+        EXPECT_BYTEARRAY_EQUAL(server_digest, digest_for_ems.data, digest_for_ems.size);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+
+        EXPECT_SUCCESS(s2n_config_free(config));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(tls12_chain_and_key));
     }
 
     END_TEST();

--- a/tests/unit/s2n_tls_prf_test.c
+++ b/tests/unit/s2n_tls_prf_test.c
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* s2n_retrieve_digest_for_ems calculates the correct digest to generate an extended master secret.
+    /* s2n_prf_get_digest_for_ems calculates the correct digest to generate an extended master secret.
      * Here we test that the retrieved digest is the same as the digest after the Client Key Exchange
      * message is added to the transcript hash.
      *
@@ -183,33 +183,37 @@ int main(int argc, char **argv)
         /* Client writes Client Key Exchange message */
         EXPECT_SUCCESS(s2n_handshake_write_io(client_conn));
 
-        uint8_t data[SHA256_DIGEST_LENGTH] = { 0 };
+        uint8_t data[S2N_MAX_DIGEST_LEN] = { 0 };
         struct s2n_blob digest_for_ems = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&digest_for_ems, data, sizeof(data)));
 
-        /* Here we fiddle with the io_stuffers to get the Client Key transcript */
-        DEFER_CLEANUP(struct s2n_stuffer client_key_message = { 0 }, s2n_stuffer_free);
-        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_key_message, 0));
+        /* Get the Client Key transcript */
         EXPECT_SUCCESS(s2n_stuffer_skip_read(&client_to_server, S2N_TLS_RECORD_HEADER_LENGTH));
         uint8_t client_key_message_length = s2n_stuffer_data_available(&client_to_server);
-        EXPECT_SUCCESS(s2n_stuffer_copy(&client_to_server, &client_key_message, client_key_message_length));
-        client_key_message.blob.size = client_key_message_length;
+        struct s2n_blob message = { 0 };
+        message.data = &client_to_server.blob.data[client_to_server.read_cursor];
+        message.size = client_key_message_length;
 
-        EXPECT_OK(s2n_retrieve_digest_for_ems(server_conn, &client_key_message.blob, &digest_for_ems));
+        EXPECT_OK(s2n_prf_get_digest_for_ems(server_conn, &message, &digest_for_ems));
 
         /* Server reads Client Key Exchange message */
-        EXPECT_SUCCESS(s2n_stuffer_rewind_read(&client_to_server, S2N_TLS_RECORD_HEADER_LENGTH + client_key_message_length));
+        EXPECT_SUCCESS(s2n_stuffer_rewind_read(&client_to_server, S2N_TLS_RECORD_HEADER_LENGTH));
         EXPECT_SUCCESS(s2n_handshake_read_io(server_conn));
 
         /* Calculate the digest message after the Server read the Client Key message */
-        uint8_t server_digest[SHA256_DIGEST_LENGTH] = { 0 };
-        POSIX_GUARD(s2n_hash_copy(&server_conn->hash_workspace, &server_conn->handshake.sha256));
-        POSIX_GUARD(s2n_hash_digest(&server_conn->hash_workspace, server_digest, SHA256_DIGEST_LENGTH));
+        struct s2n_hash_state current_hash_state = { 0 };
+        uint8_t server_digest[S2N_MAX_DIGEST_LEN] = { 0 };
+        s2n_hmac_algorithm prf_alg = server_conn->secure.cipher_suite->prf_alg;
+        s2n_hash_algorithm hash_alg = 0;
+        EXPECT_SUCCESS(s2n_hmac_hash_alg(prf_alg, &hash_alg));
+        uint8_t digest_size = 0;
+        EXPECT_SUCCESS(s2n_hash_digest_size(hash_alg, &digest_size));
+        EXPECT_SUCCESS(s2n_handshake_get_hash_state(server_conn, hash_alg, &current_hash_state));
+        EXPECT_SUCCESS(s2n_hash_digest(&current_hash_state, server_digest, digest_size));
 
         /* Digest for generating the EMS and digest after reading the Client Key message
          * should be the same. */
-        EXPECT_EQUAL(sizeof(server_digest), digest_for_ems.size);
-        EXPECT_BYTEARRAY_EQUAL(server_digest, digest_for_ems.data, digest_for_ems.size);
+        EXPECT_BYTEARRAY_EQUAL(server_digest, digest_for_ems.data, digest_size);
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -436,8 +436,9 @@ S2N_RESULT s2n_retrieve_digest_for_ems(struct s2n_connection *conn, struct s2n_b
     RESULT_ENSURE_REF(output);
 
     struct s2n_hash_state hash_state = { 0 };
+    s2n_hmac_algorithm prf_alg = conn->secure.cipher_suite->prf_alg;
     s2n_hash_algorithm hash_alg = 0;
-    RESULT_GUARD_POSIX(s2n_hmac_hash_alg(conn->secure.cipher_suite->prf_alg, &hash_alg));
+    RESULT_GUARD_POSIX(s2n_hmac_hash_alg(prf_alg, &hash_alg));
     RESULT_GUARD_POSIX(s2n_handshake_get_hash_state(conn, conn->secure.cipher_suite->prf_alg, &hash_state));
     RESULT_GUARD_POSIX(s2n_hash_copy(&conn->hash_workspace, &hash_state));
     RESULT_GUARD_POSIX(s2n_hash_update(&conn->hash_workspace, message->data, message->size));

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -436,6 +436,8 @@ S2N_RESULT s2n_retrieve_digest_for_ems(struct s2n_connection *conn, struct s2n_b
     RESULT_ENSURE_REF(output);
 
     struct s2n_hash_state hash_state = { 0 };
+    s2n_hash_algorithm hash_alg = 0;
+    RESULT_GUARD_POSIX(s2n_hmac_hash_alg(conn->secure.cipher_suite->prf_alg, &hash_alg));
     RESULT_GUARD_POSIX(s2n_handshake_get_hash_state(conn, conn->secure.cipher_suite->prf_alg, &hash_state));
     RESULT_GUARD_POSIX(s2n_hash_copy(&conn->hash_workspace, &hash_state));
     RESULT_GUARD_POSIX(s2n_hash_update(&conn->hash_workspace, message->data, message->size));

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -430,7 +430,7 @@ S2N_RESULT s2n_tls_prf_extended_master_secret(struct s2n_connection *conn, struc
         return S2N_RESULT_OK;
 }
 
-S2N_RESULT s2n_retrieve_digest_for_ems(struct s2n_connection *conn, struct s2n_blob *message, struct s2n_blob *output)
+S2N_RESULT s2n_prf_get_digest_for_ems(struct s2n_connection *conn, struct s2n_blob *message, struct s2n_blob *output)
 {
     RESULT_ENSURE_REF(conn);
     RESULT_ENSURE_REF(output);
@@ -447,7 +447,6 @@ S2N_RESULT s2n_retrieve_digest_for_ems(struct s2n_connection *conn, struct s2n_b
     RESULT_GUARD_POSIX(s2n_hash_digest_size(conn->hash_workspace.alg, &digest_size));
     RESULT_ENSURE_GTE(output->size, digest_size);
     RESULT_GUARD_POSIX(s2n_hash_digest(&conn->hash_workspace, output->data, digest_size));
-
     return S2N_RESULT_OK;
 }
 

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -427,7 +427,7 @@ S2N_RESULT s2n_tls_prf_extended_master_secret(struct s2n_connection *conn, struc
 
     RESULT_GUARD_POSIX(s2n_prf(conn, premaster_secret, &label, session_hash, NULL, NULL, &extended_master_secret));
 
-        return S2N_RESULT_OK;
+    return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_prf_get_digest_for_ems(struct s2n_connection *conn, struct s2n_blob *message, struct s2n_blob *output)
@@ -447,6 +447,7 @@ S2N_RESULT s2n_prf_get_digest_for_ems(struct s2n_connection *conn, struct s2n_bl
     RESULT_GUARD_POSIX(s2n_hash_digest_size(conn->hash_workspace.alg, &digest_size));
     RESULT_ENSURE_GTE(output->size, digest_size);
     RESULT_GUARD_POSIX(s2n_hash_digest(&conn->hash_workspace, output->data, digest_size));
+
     return S2N_RESULT_OK;
 }
 

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -439,7 +439,7 @@ S2N_RESULT s2n_retrieve_digest_for_ems(struct s2n_connection *conn, struct s2n_b
     s2n_hmac_algorithm prf_alg = conn->secure.cipher_suite->prf_alg;
     s2n_hash_algorithm hash_alg = 0;
     RESULT_GUARD_POSIX(s2n_hmac_hash_alg(prf_alg, &hash_alg));
-    RESULT_GUARD_POSIX(s2n_handshake_get_hash_state(conn, conn->secure.cipher_suite->prf_alg, &hash_state));
+    RESULT_GUARD_POSIX(s2n_handshake_get_hash_state(conn, hash_alg, &hash_state));
     RESULT_GUARD_POSIX(s2n_hash_copy(&conn->hash_workspace, &hash_state));
     RESULT_GUARD_POSIX(s2n_hash_update(&conn->hash_workspace, message->data, message->size));
 

--- a/tls/s2n_prf.h
+++ b/tls/s2n_prf.h
@@ -66,7 +66,7 @@ extern int s2n_prf_free(struct s2n_connection *conn);
 extern int s2n_tls_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret);
 extern int s2n_hybrid_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret);
 S2N_RESULT s2n_tls_prf_extended_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret, struct s2n_blob *session_hash);
-S2N_RESULT s2n_retrieve_digest_for_ems(struct s2n_connection *conn, struct s2n_blob *message, struct s2n_blob *output);
+S2N_RESULT s2n_prf_get_digest_for_ems(struct s2n_connection *conn, struct s2n_blob *message, struct s2n_blob *output);
 extern int s2n_prf_key_expansion(struct s2n_connection *conn);
 extern int s2n_prf_server_finished(struct s2n_connection *conn);
 extern int s2n_prf_client_finished(struct s2n_connection *conn);

--- a/tls/s2n_prf.h
+++ b/tls/s2n_prf.h
@@ -66,6 +66,7 @@ extern int s2n_prf_free(struct s2n_connection *conn);
 extern int s2n_tls_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret);
 extern int s2n_hybrid_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret);
 S2N_RESULT s2n_tls_prf_extended_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret, struct s2n_blob *session_hash);
+S2N_RESULT s2n_retrieve_digest_for_ems(struct s2n_connection *conn, struct s2n_blob *message, struct s2n_blob *output);
 extern int s2n_prf_key_expansion(struct s2n_connection *conn);
 extern int s2n_prf_server_finished(struct s2n_connection *conn);
 extern int s2n_prf_client_finished(struct s2n_connection *conn);


### PR DESCRIPTION
### Resolved issues:

 resolves #2948 

### Description of changes: 
Adds ability to get the handshake digest needed for the EMS generation at the same point in the handshake as our master secret calculation.
### Call-outs:
The original idea for this issue was to move the calculation of the master secret to after the handshake hashes are updated. That ended up being a bit of a handful, as then we have to store the premaster secret until the hashes are updated, and the premaster secret size varies, so I figured this way is less of a refactor.
### Testing:
Testing this function is a little weird. There are no handshake traces for TLS1.2, and, since we can't arbitrarily set the hash state, I had to negotiate until the Client Key Exchange message and then prove that the new function generates the same digest as the digest produced after the Client Key Exchange message is actually added to the hash.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
