### PR TITLE
Handle the Hello Request message

### DIFF
--- a/tests/unit/s2n_post_handshake_test.c
+++ b/tests/unit/s2n_post_handshake_test.c
@@ -124,7 +124,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
-        /* No non-post handshake messages can be received, except HelloRetry during TLS1.2.
+        /* No non-post handshake messages can be received, except HelloRequest during TLS1.2.
          * This means that no handshake message that appears in the handshake state machine
          * should be allowed, except TLS_HELLO_REQUEST.
          */

--- a/tests/unit/s2n_post_handshake_test.c
+++ b/tests/unit/s2n_post_handshake_test.c
@@ -98,18 +98,6 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(conn)); 
         }
 
-        /* post_handshake_recv will error when protocol version is not TLS1.3 */ 
-        {   
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-            conn->actual_protocol_version = S2N_TLS12;
-            conn->secure.cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-
-            EXPECT_FAILURE_WITH_ERRNO(s2n_post_handshake_recv(conn), S2N_ERR_BAD_MESSAGE);
-
-            EXPECT_SUCCESS(s2n_connection_free(conn)); 
-        }
-
         /* Functional test: Multiple post handshake messages can be received in the same record */
         {
             struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
@@ -136,9 +124,9 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
-        /* No non-post handshake messages can be received.
+        /* No non-post handshake messages can be received, except HelloRetry during TLS1.2.
          * This means that no handshake message that appears in the handshake state machine
-         * should be allowed.
+         * should be allowed, except TLS_HELLO_REQUEST.
          */
         {
             /* For TLS1.2 */
@@ -153,7 +141,12 @@ int main(int argc, char **argv)
 
                 EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->in, state_machine[i].message_type));
                 EXPECT_SUCCESS(s2n_stuffer_write_uint24(&conn->in, 0));
-                EXPECT_FAILURE_WITH_ERRNO(s2n_post_handshake_recv(conn), S2N_ERR_BAD_MESSAGE);
+
+                if (state_machine[i].message_type == TLS_HELLO_REQUEST) {
+                    EXPECT_SUCCESS(s2n_post_handshake_recv(conn));
+                } else {
+                    EXPECT_FAILURE_WITH_ERRNO(s2n_post_handshake_recv(conn), S2N_ERR_BAD_MESSAGE);
+                }
 
                 EXPECT_SUCCESS(s2n_connection_free(conn));
             }

--- a/tests/unit/s2n_tls13_handshake_state_machine_test.c
+++ b/tests/unit/s2n_tls13_handshake_state_machine_test.c
@@ -584,6 +584,16 @@ int main(int argc, char **argv)
 
         /* TLS1.3 should error for an expected message from the wrong record type */
         {
+            /* Unfortunately, all our non-handshake record types have a message type of 0,
+             * and the combination of TLS_HANDSHAKE + "0" is actually a message (TLS_HELLO_REQUEST)
+             * which can appear at any point in a TLS1.2 handshake.
+             *
+             * To test, temporarily modify the actions table.
+             * We MUST restore this after this test.
+             */
+            uint8_t old_message_type = state_machine[SERVER_CHANGE_CIPHER_SPEC].message_type;
+            state_machine[SERVER_CHANGE_CIPHER_SPEC].message_type = 1;
+
             struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
             conn->actual_protocol_version = S2N_TLS13;
 
@@ -606,6 +616,7 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_stuffer_free(&input));
             EXPECT_SUCCESS(s2n_connection_free(conn));
+            state_machine[SERVER_CHANGE_CIPHER_SPEC].message_type = old_message_type;
         }
 
         /* Error if a client receives a client cert request in non-FULL_HANDSHAKE mode */

--- a/tls/s2n_client_hello_request.c
+++ b/tls/s2n_client_hello_request.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <s2n.h>
+
+#include "tls/s2n_connection.h"
+#include "utils/s2n_safety.h"
+
+int s2n_client_hello_request_recv(struct s2n_connection *conn)
+{
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE(conn->actual_protocol_version < S2N_TLS13, S2N_ERR_BAD_MESSAGE);
+
+    /*
+     *= https://tools.ietf.org/rfc/rfc5246#section-7.4.1.1
+     *# The HelloRequest message MAY be sent by the server at any time.
+     */
+    POSIX_ENSURE(conn->mode == S2N_CLIENT, S2N_ERR_BAD_MESSAGE);
+
+    /*
+     *= https://tools.ietf.org/rfc/rfc5246#section-7.4.1.1
+     *# This message will be ignored by the client if the client is
+     *# currently negotiating a session.  This message MAY be ignored by
+     *# the client if it does not wish to renegotiate a session, or the
+     *# client may, if it wishes, respond with a no_renegotiation alert.
+     */
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1240,6 +1240,17 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
             POSIX_GUARD_RESULT(s2n_handshake_type_unset_tls12_flag(conn, OCSP_STATUS));
         }
 
+        /*
+         *= https://tools.ietf.org/rfc/rfc5246#section-7.4
+         *# The one message that is not bound by these ordering rules
+         *# is the HelloRequest message, which can be sent at any time, but which
+         *# SHOULD be ignored by the client if it arrives in the middle of a handshake.
+         */
+        if (message_type == TLS_HELLO_REQUEST) {
+            POSIX_GUARD(s2n_client_hello_request_recv(conn));
+            return S2N_SUCCESS;
+        }
+
         POSIX_ENSURE(record_type == EXPECTED_RECORD_TYPE(conn), S2N_ERR_BAD_MESSAGE);
         POSIX_ENSURE(message_type == EXPECTED_MESSAGE_TYPE(conn), S2N_ERR_BAD_MESSAGE);
         POSIX_ENSURE(!CONNECTION_IS_WRITER(conn), S2N_ERR_BAD_MESSAGE);

--- a/tls/s2n_key_update.c
+++ b/tls/s2n_key_update.c
@@ -32,6 +32,7 @@ int s2n_check_record_limit(struct s2n_connection *conn, struct s2n_blob *sequenc
 int s2n_key_update_recv(struct s2n_connection *conn, struct s2n_stuffer *request)
 {
     POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE(conn->actual_protocol_version >= S2N_TLS13, S2N_ERR_BAD_MESSAGE);
     POSIX_ENSURE(!conn->config->quic_enabled, S2N_ERR_BAD_MESSAGE);
 
     uint8_t key_update_request;

--- a/tls/s2n_post_handshake.c
+++ b/tls/s2n_post_handshake.c
@@ -26,7 +26,6 @@ int s2n_post_handshake_recv(struct s2n_connection *conn)
 
     uint8_t post_handshake_id;
     uint32_t message_length;
-    S2N_ERROR_IF(conn->actual_protocol_version != S2N_TLS13, S2N_ERR_BAD_MESSAGE);
 
     while(s2n_stuffer_data_available(&conn->in)) {
         POSIX_GUARD(s2n_stuffer_read_uint8(&conn->in, &post_handshake_id));
@@ -50,6 +49,8 @@ int s2n_post_handshake_recv(struct s2n_connection *conn)
                 POSIX_GUARD_RESULT(s2n_tls13_server_nst_recv(conn, &post_handshake_stuffer));
                 break;
             case TLS_HELLO_REQUEST:
+                POSIX_GUARD(s2n_client_hello_request_recv(conn));
+                break;
             case TLS_CLIENT_HELLO:
             case TLS_SERVER_HELLO:
             case TLS_END_OF_EARLY_DATA:

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -327,6 +327,7 @@ S2N_RESULT s2n_tls13_server_nst_recv(struct s2n_connection *conn, struct s2n_stu
     RESULT_ENSURE_REF(input);
     RESULT_ENSURE_REF(conn->config);
 
+    RESULT_ENSURE(conn->actual_protocol_version >= S2N_TLS13, S2N_ERR_BAD_MESSAGE);
     RESULT_ENSURE(conn->mode == S2N_CLIENT, S2N_ERR_BAD_MESSAGE);
 
     if (!conn->config->use_tickets) {

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -24,6 +24,7 @@ extern uint8_t s2n_unknown_protocol_version;
 extern uint8_t s2n_highest_protocol_version;
 
 extern int s2n_flush(struct s2n_connection *conn, s2n_blocked_status * more);
+int s2n_client_hello_request_recv(struct s2n_connection *conn);
 extern int s2n_client_hello_send(struct s2n_connection *conn);
 extern int s2n_client_hello_recv(struct s2n_connection *conn);
 extern int s2n_establish_session(struct s2n_connection *conn);


### PR DESCRIPTION
### Description of changes: 

S2N previously did not explicitly handle HELLO_REQUEST messages, which means that it considered them an error.

Accept HELLO_REQUEST both during the handshake and afterwards, but ignore it.

https://datatracker.ietf.org/doc/html/rfc5246#section-7.4.1.1

### Testing:
New unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
