### PR TITLE
Adds EMS Serialization/Deserialization

### DIFF
--- a/tests/unit/s2n_extended_master_secret_test.c
+++ b/tests/unit/s2n_extended_master_secret_test.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "utils/s2n_bitmap.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test s2n_conn_set_handshake_type is processing EMS data correctly */    
+    {       
+        struct s2n_config *config;
+        uint64_t current_time = 0;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+
+        EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, 1));
+        EXPECT_SUCCESS(config->wall_clock(config->sys_clock_ctx, &current_time));
+        uint8_t ticket_key_name[16] = "2016.07.26.15\0";
+        S2N_BLOB_FROM_HEX(ticket_key, 
+            "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5");
+        EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(config, ticket_key_name, strlen((char *)ticket_key_name),
+                        ticket_key.data, ticket_key.size, current_time/ONE_SEC_IN_NANOS));
+
+        /**
+         *= https://tools.ietf.org/rfc/rfc7627#section-5.3
+         *= type=test
+         *# If the original session used the "extended_master_secret"
+         *# extension but the new ClientHello does not contain it, the server
+         *# MUST abort the abbreviated handshake.
+         **/
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            conn->actual_protocol_version = S2N_TLS12;
+            conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+            /* Original connection negotiated an EMS */
+            conn->ems_negotiated = true;
+
+            struct s2n_stuffer ticket = { 0 };
+            struct s2n_blob ticket_blob = { 0 };
+            uint8_t ticket_data[S2N_TLS12_TICKET_SIZE_IN_BYTES] = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, ticket_data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
+            EXPECT_SUCCESS(s2n_stuffer_init(&ticket, &ticket_blob));
+
+            /* Encrypt the ticket with EMS data */
+            EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, &ticket));
+
+            EXPECT_SUCCESS(s2n_connection_wipe(conn));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            conn->actual_protocol_version = S2N_TLS12;
+            conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+            conn->session_ticket_status = S2N_DECRYPT_TICKET;
+            EXPECT_SUCCESS(s2n_stuffer_copy(&ticket, &conn->client_ticket_to_decrypt, S2N_TLS12_TICKET_SIZE_IN_BYTES));
+
+            /* Resumed session did not receive the EMS extension */
+            EXPECT_FAILURE_WITH_ERRNO(s2n_conn_set_handshake_type(conn), S2N_ERR_MISSING_EXTENSION);
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /**
+         *= https://tools.ietf.org/rfc/rfc7627#section-5.3
+         *= type=test
+         *# If the original session did not use the "extended_master_secret"
+         *# extension but the new ClientHello contains the extension, then the
+         *# server MUST NOT perform the abbreviated handshake.  Instead, it
+         *# SHOULD continue with a full handshake (as described in
+         *# Section 5.2) to negotiate a new session.
+         **/
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            conn->actual_protocol_version = S2N_TLS12;
+            conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+            /* Original connection did not negotiate an EMS */
+            conn->ems_negotiated = false;
+
+            struct s2n_stuffer ticket = { 0 };
+            struct s2n_blob ticket_blob = { 0 };
+            uint8_t ticket_data[S2N_TLS12_TICKET_SIZE_IN_BYTES] = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, ticket_data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
+            EXPECT_SUCCESS(s2n_stuffer_init(&ticket, &ticket_blob));
+
+            /* Encrypt the ticket without EMS data */
+            EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, &ticket));
+
+            EXPECT_SUCCESS(s2n_connection_wipe(conn));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            conn->actual_protocol_version = S2N_TLS12;
+            conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+            conn->session_ticket_status = S2N_DECRYPT_TICKET;
+            EXPECT_SUCCESS(s2n_stuffer_copy(&ticket, &conn->client_ticket_to_decrypt, S2N_TLS12_TICKET_SIZE_IN_BYTES));
+
+            /* Resumed connection received the EMS extension */
+            conn->ems_negotiated = true;
+
+            EXPECT_SUCCESS(s2n_conn_set_handshake_type(conn));
+
+            /* Fallback to full handshake */
+            EXPECT_TRUE(s2n_handshake_type_check_tls12_flag(conn, FULL_HANDSHAKE));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Session ticket is processed correctly if the previous session and current session both negotiated EMS */
+        {
+            struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            conn->actual_protocol_version = S2N_TLS12;
+            conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+            /* Original connection negotiated an EMS */
+            conn->ems_negotiated = true;
+
+            struct s2n_stuffer ticket = { 0 };
+            struct s2n_blob ticket_blob = { 0 };
+            uint8_t ticket_data[S2N_TLS12_TICKET_SIZE_IN_BYTES] = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, ticket_data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
+            EXPECT_SUCCESS(s2n_stuffer_init(&ticket, &ticket_blob));
+
+            /* Encrypt the ticket with EMS data */
+            EXPECT_SUCCESS(s2n_encrypt_session_ticket(conn, &ticket));
+
+            EXPECT_SUCCESS(s2n_connection_wipe(conn));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            conn->actual_protocol_version = S2N_TLS12;
+            conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+            conn->session_ticket_status = S2N_DECRYPT_TICKET;
+            EXPECT_SUCCESS(s2n_stuffer_copy(&ticket, &conn->client_ticket_to_decrypt, S2N_TLS12_TICKET_SIZE_IN_BYTES));
+
+            /* Resumed connection received the EMS extension */
+            conn->ems_negotiated = true;
+            s2n_extension_type_id ems_ext_id = 0;
+            EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_EMS, &ems_ext_id));
+            S2N_CBIT_SET(conn->extension_requests_received, ems_ext_id);
+
+            EXPECT_SUCCESS(s2n_conn_set_handshake_type(conn));
+
+            EXPECT_FALSE(s2n_handshake_type_check_tls12_flag(conn, FULL_HANDSHAKE));
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));   
+        }
+
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_extended_master_secret_test.c
+++ b/tests/unit/s2n_extended_master_secret_test.c
@@ -31,6 +31,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, 1));
         EXPECT_SUCCESS(config->wall_clock(config->sys_clock_ctx, &current_time));
         uint8_t ticket_key_name[16] = "2016.07.26.15\0";
+        /**
+         *= https://tools.ietf.org/rfc/rfc5869#appendix-A.1
+         *# PRK  = 0x077709362c2e32df0ddc3f0dc47bba63
+         *#        90b6c73bb50f9c3122ec844ad7c2b3e5 (32 octets)
+         **/
         S2N_BLOB_FROM_HEX(ticket_key, 
             "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5");
         EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(config, ticket_key_name, strlen((char *)ticket_key_name),

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -38,6 +38,8 @@
 
 #define SIZE_OF_MAX_EARLY_DATA_SIZE sizeof(uint32_t)
 
+#define S2N_TLS12_STATE_SIZE_IN_BYTES_WITHOUT_EMS S2N_TLS12_STATE_SIZE_IN_BYTES - 1
+
 #define SECONDS_TO_NANOS(seconds) ((seconds) * (uint64_t)ONE_SEC_IN_NANOS)
 
 const uint64_t ticket_issue_time = 283686952306183;
@@ -311,33 +313,43 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
         conn->secure.cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
 
-        uint8_t s_data[S2N_TLS12_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = { 0 };
-        struct s2n_blob state_blob = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
-        struct s2n_stuffer output = { 0 };
+        uint8_t ems_state[] = { false, true };
+        for (size_t i = 0; i < sizeof(ems_state); i++) {
+            /* Test the two different EMS states */
+            conn->ems_negotiated = ems_state[i];
 
-        EXPECT_SUCCESS(s2n_stuffer_init(&output, &state_blob));
-        EXPECT_SUCCESS(s2n_tls12_serialize_resumption_state(conn, &output));
+            uint8_t s_data[S2N_TLS12_STATE_SIZE_IN_BYTES] = { 0 };
+            struct s2n_blob state_blob = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
+            struct s2n_stuffer output = { 0 };
 
-        uint8_t serial_id = 0;
-        EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &serial_id));
-        EXPECT_EQUAL(serial_id, S2N_TLS12_SERIALIZED_FORMAT_VERSION);
+            EXPECT_SUCCESS(s2n_stuffer_init(&output, &state_blob));
+            EXPECT_SUCCESS(s2n_tls12_serialize_resumption_state(conn, &output));
 
-        uint8_t version = 0;
-        EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &version));
-        EXPECT_EQUAL(version, S2N_TLS12);
+            uint8_t serial_id = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &serial_id));
+            EXPECT_EQUAL(serial_id, S2N_TLS12_SERIALIZED_FORMAT_VERSION);
 
-        uint8_t iana_value[2] = { 0 };
-        EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, iana_value, S2N_TLS_CIPHER_SUITE_LEN));
-        EXPECT_BYTEARRAY_EQUAL(conn->secure.cipher_suite->iana_value, &iana_value, S2N_TLS_CIPHER_SUITE_LEN);
+            uint8_t version = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &version));
+            EXPECT_EQUAL(version, S2N_TLS12);
 
-        /* Current time */
-        EXPECT_SUCCESS(s2n_stuffer_skip_read(&output, sizeof(uint64_t)));
+            uint8_t iana_value[2] = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, iana_value, S2N_TLS_CIPHER_SUITE_LEN));
+            EXPECT_BYTEARRAY_EQUAL(conn->secure.cipher_suite->iana_value, &iana_value, S2N_TLS_CIPHER_SUITE_LEN);
 
-        uint8_t master_secret[S2N_TLS_SECRET_LEN] = { 0 };
-        EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, master_secret, S2N_TLS_SECRET_LEN));
-        EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, master_secret, S2N_TLS_SECRET_LEN);
-        
+            /* Current time */
+            EXPECT_SUCCESS(s2n_stuffer_skip_read(&output, sizeof(uint64_t)));
+
+            uint8_t master_secret[S2N_TLS_SECRET_LEN] = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, master_secret, S2N_TLS_SECRET_LEN));
+            EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, master_secret, S2N_TLS_SECRET_LEN);
+
+            uint8_t ems_info = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &ems_info));
+            EXPECT_EQUAL(ems_info, ems_state[i]);
+        }
+
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
     
@@ -564,7 +576,7 @@ int main(int argc, char **argv)
 
     /* s2n_deserialize_resumption_state */
     {
-        uint8_t tls12_ticket[S2N_TLS12_STATE_SIZE_IN_BYTES] = {
+        uint8_t tls12_ticket[S2N_TLS12_STATE_SIZE_IN_BYTES_WITHOUT_EMS] = {
             S2N_TLS12_SERIALIZED_FORMAT_VERSION,
             S2N_TLS12,
             TLS_RSA_WITH_AES_128_GCM_SHA256,
@@ -630,7 +642,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
-        /* Deserialized ticket sets correct connection values for session resumption in TLS1.2 */
+        /* Deserialized ticket sets correct connection values for session resumption in TLS1.2, without EMS data */
         {
             struct s2n_blob ticket_blob = { 0 };
             EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, tls12_ticket, sizeof(tls12_ticket)));
@@ -645,10 +657,103 @@ int main(int argc, char **argv)
 
             EXPECT_OK(s2n_deserialize_resumption_state(conn, NULL, &ticket_stuffer));
 
+            EXPECT_FALSE(conn->ems_negotiated);
             EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS12);
             EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_rsa_with_aes_128_gcm_sha256);
 
             EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, conn->secrets.master_secret, S2N_TLS_SECRET_LEN);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Client processes TLS1.2 ticket with EMS data correctly */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            conn->actual_protocol_version = S2N_TLS12;
+
+            struct s2n_blob blob = { 0 };
+            struct s2n_stuffer stuffer = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secrets.master_secret, S2N_TLS_SECRET_LEN));
+            EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &blob));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
+            conn->secure.cipher_suite = &s2n_rsa_with_aes_128_gcm_sha256;
+            conn->ems_negotiated = true;
+
+            uint8_t s_data[S2N_TLS12_STATE_SIZE_IN_BYTES] = { 0 };
+            struct s2n_blob state_blob = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
+            struct s2n_stuffer output = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_init(&output, &state_blob));
+
+            EXPECT_SUCCESS(s2n_tls12_serialize_resumption_state(conn, &output));
+            EXPECT_OK(s2n_deserialize_resumption_state(conn, NULL, &output));
+
+            EXPECT_TRUE(conn->ems_negotiated);
+            EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS12);
+            EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_rsa_with_aes_128_gcm_sha256);
+
+            EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, conn->secrets.master_secret, S2N_TLS_SECRET_LEN);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Server processes TLS1.2 ticket with EMS data correctly */
+        {
+            struct s2n_connection *conn;
+            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+            conn->actual_protocol_version = S2N_TLS12;
+
+            struct s2n_blob blob = { 0 };
+            struct s2n_stuffer stuffer = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secrets.master_secret, S2N_TLS_SECRET_LEN));
+            EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &blob));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
+            conn->secure.cipher_suite = &s2n_rsa_with_aes_128_gcm_sha256;
+            conn->ems_negotiated = true;
+
+            uint8_t s_data[S2N_TLS12_STATE_SIZE_IN_BYTES] = { 0 };
+            struct s2n_blob state_blob = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
+            struct s2n_stuffer output = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_init(&output, &state_blob));
+
+            EXPECT_SUCCESS(s2n_tls12_serialize_resumption_state(conn, &output));
+
+            /* EMS state in current session matches EMS state in previous session */
+            conn->ems_negotiated = true;
+            EXPECT_OK(s2n_deserialize_resumption_state(conn, NULL, &output));
+            EXPECT_TRUE(conn->ems_negotiated);
+
+            /**
+             *= https://tools.ietf.org/rfc/rfc7627#section-5.3
+             *= type=test
+             *# If the original session used the "extended_master_secret"
+             *# extension but the new ClientHello does not contain it, the server
+             *# MUST abort the abbreviated handshake.
+             **/
+            conn->ems_negotiated = false;
+            EXPECT_SUCCESS(s2n_stuffer_reread(&output));
+            EXPECT_ERROR_WITH_ERRNO(s2n_deserialize_resumption_state(conn, NULL, &output), 
+                        S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
+            EXPECT_TRUE(conn->ems_negotiated);
+
+            /**
+             *= https://tools.ietf.org/rfc/rfc7627#section-5.3
+             *= type=test
+             *# If the original session did not use the "extended_master_secret"
+             *# extension but the new ClientHello contains the extension, then the
+             *# server MUST NOT perform the abbreviated handshake.  Instead, it
+             *# SHOULD continue with a full handshake (as described in
+             *# Section 5.2) to negotiate a new session.
+             **/
+            EXPECT_SUCCESS(s2n_stuffer_wipe_n(&output, 1));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&output, 0));
+            conn->ems_negotiated = true;
+            EXPECT_SUCCESS(s2n_stuffer_reread(&output));
+            EXPECT_ERROR_WITH_ERRNO(s2n_deserialize_resumption_state(conn, NULL, &output), 
+                        S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
+            EXPECT_FALSE(conn->ems_negotiated);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -814,10 +814,10 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
                 return S2N_SUCCESS;
             }
 
-            s2n_extension_type_id ems_ext_id = 0;
-            POSIX_GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_EMS, &ems_ext_id));
             /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
             if (conn->ems_negotiated && S2N_IN_TEST) {
+                s2n_extension_type_id ems_ext_id = 0;
+                POSIX_GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_EMS, &ems_ext_id));
                 /**
                  *= https://tools.ietf.org/rfc/rfc7627#section-5.3
                  *# If the original session used the "extended_master_secret"

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -56,8 +56,8 @@ static int s2n_tls12_serialize_resumption_state(struct s2n_connection *conn, str
     /* Get the time */
     POSIX_GUARD(conn->config->wall_clock(conn->config->sys_clock_ctx, &now));
 
+    /* Write the entry */
     POSIX_GUARD(s2n_stuffer_write_uint8(to, S2N_TLS12_SERIALIZED_FORMAT_VERSION));
-
     POSIX_GUARD(s2n_stuffer_write_uint8(to, conn->actual_protocol_version));
     POSIX_GUARD(s2n_stuffer_write_bytes(to, conn->secure.cipher_suite->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
     POSIX_GUARD(s2n_stuffer_write_uint64(to, now));
@@ -338,7 +338,6 @@ static S2N_RESULT s2n_deserialize_resumption_state(struct s2n_connection *conn, 
     } else {
         RESULT_BAIL(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
     }
-
     return S2N_RESULT_OK;
 }
 

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -174,6 +174,11 @@ static int s2n_tls12_deserialize_resumption_state(struct s2n_connection *conn, s
          *# MUST abort the abbreviated handshake.
          **/
         if (conn->ems_negotiated != ems_negotiated) {
+            /* The session ticket needs to have the same EMS state as the current session. If it doesn't
+             * have the same state, the current session takes the state of the session ticket and errors.
+             * If the deserialization process errors, we will use this state in a few extra checks
+             * to determine if we can fallback to a full handshake.
+             */
             conn->ems_negotiated = ems_negotiated;
             POSIX_BAIL(S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
         }

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -20,8 +20,7 @@
 #include "stuffer/s2n_stuffer.h"
 
 #define S2N_STATE_LIFETIME_IN_NANOS     54000000000000      /* 15 hours */
-#define S2N_TLS12_STATE_SIZE_IN_BYTES   (1 + 8 + 1 + S2N_TLS_CIPHER_SUITE_LEN + S2N_TLS_SECRET_LEN)
-
+#define S2N_TLS12_STATE_SIZE_IN_BYTES   (1 + 8 + 1 + S2N_TLS_CIPHER_SUITE_LEN + S2N_TLS_SECRET_LEN + 1)
 #define S2N_TLS13_FIXED_STATE_SIZE              21
 #define S2N_TLS13_FIXED_EARLY_DATA_STATE_SIZE   3
 
@@ -91,7 +90,8 @@ typedef enum {
 
 typedef enum {
     S2N_TLS12_SERIALIZED_FORMAT_VERSION = 1,
-    S2N_TLS13_SERIALIZED_FORMAT_VERSION
+    S2N_TLS13_SERIALIZED_FORMAT_VERSION,
+    S2N_TLS12_SERIALIZED_FORMAT_VERSION_WITH_EMS,
 } s2n_serial_format_version;
 
 extern int s2n_allowed_to_cache_connection(struct s2n_connection *conn);

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -91,7 +91,6 @@ typedef enum {
 typedef enum {
     S2N_TLS12_SERIALIZED_FORMAT_VERSION = 1,
     S2N_TLS13_SERIALIZED_FORMAT_VERSION,
-    S2N_TLS12_SERIALIZED_FORMAT_VERSION_WITH_EMS,
 } s2n_serial_format_version;
 
 extern int s2n_allowed_to_cache_connection(struct s2n_connection *conn);


### PR DESCRIPTION
### Resolved issues:

 resolves #2950, resolves #2952, resolves #2951

### Description of changes: 

s2n can now serialize and deserialize EMS session tickets.
### Call-outs:
These three individual issues were really small PRs on their own, so I combined them into one PR that encompasses all the changes relating to the new session ticket version.
N/A
### Testing:

Unit tests.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
