### PR TITLE
ci:Diff spec changes against the live CodeBuild Jobs.

### DIFF
--- a/codebuild/create_batch.sh
+++ b/codebuild/create_batch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not use
@@ -19,6 +19,11 @@ BUILDSPEC_FUZZ=./spec/buildspec_fuzz_batch.yml
 BUILDSPEC_INTEG=./spec/buildspec_integ_batch.yml
 BUILDSPEC_GENERAL=./spec/buildspec_general_batch.yml
 
+OMNIBUSCHANGED=0
+FUZZCHANGED=0
+INTEGCHANGED=0
+GENERALCHANGED=0
+
 synth_subjobs () {
   yq -S -Y -r '{batch:{"build-list":[.batch."build-list"[]| select(.identifier|contains("Fuzz")) ]}}' $BUILDSPEC_OMNIBUS > $BUILDSPEC_FUZZ
   yq -S -Y -r '{batch:{"build-list":[.batch."build-list"[]| select(.identifier|contains("Integ")) ]}}' $BUILDSPEC_OMNIBUS > $BUILDSPEC_INTEG
@@ -37,6 +42,34 @@ check_buildspec () {
     fi
 }
 
+download_cb_source () {
+  for job in s2nFuzzBatch s2nGeneralBatch s2nIntegrationBatch s2nOmnibus; do
+    echo "Downloading spec files for $job"
+    aws codebuild batch-get-projects --name $job|jq -r '.projects[].source' > "$job"_source.json
+    jq -r '.buildspec' "$job"_source.json > buildspec_"$job"_current.yml
+  done
+}
+
+upload_cb_source () {
+    local NEWBUILDSPEC=$1
+    local jobname=$2
+    local jobsource="$jobname"_source.json
+    echo "Merging buildspec into .source json"
+    jq -r --arg NEWBUILDSPEC "$(cat $NEWBUILDSPEC)" '.buildspec=$NEWBUILDSPEC' "$jobsource" > "$jobname"_new.json
+    echo "Not updating live buildspecs...yet"
+    #echo "Uploading new CodeBuild buildspec for $jobname"
+    #aws codebuild update-project --name "$jobname" --source="$(cat "$jobname"_new.json)"
+}
+
+check_drift(){
+  local current=$1
+  local new=$2
+  echo -e "\n====\nChanges for $new\n===="
+  set +e
+  diff -B "$current" "$new"
+  return "$?"
+}
+
 PREREQS="jq yq"
 for i in $PREREQS; do
   if ! command -v $i &> /dev/null; then
@@ -45,4 +78,27 @@ for i in $PREREQS; do
 done
 synth_subjobs
 check_buildspec
-echo "Note the buildspec_*_batch.yml files that were just created should only be used in-line with CodeBuild and not be commited to the repository."
+download_cb_source
+
+check_drift "buildspec_s2nOmnibus_current.yml" "$BUILDSPEC_OMNIBUS"
+OMNIBUSCHANGED="$?"
+check_drift "buildspec_s2nFuzzBatch_current.yml" "$BUILDSPEC_FUZZ"
+FUZZCHANGED="$?"
+check_drift "buildspec_s2nIntegrationBatch_current.yml" $BUILDSPEC_INTEG
+INTEGCHANGED="$?"
+check_drift "buildspec_s2nGeneralBatch_current.yml" $BUILDSPEC_GENERAL
+GENERALCHANGED="$?"
+
+echo -e "Status of drift\nOmnibus: $OMNIBUSCHANGED\nFuzz: $FUZZCHANGED\nInteg:$INTEGCHANGED\nGeneral:$GENERALCHANGED\n"
+set -e
+
+if [[ "$OMNIBUSCHANGED" == "0" ]]; then
+  echo "No changes, exiting"
+  exit 0
+fi
+
+echo "Proceed with update? (enter)"
+read
+#upload_cb_source $BUILDSPEC_OMNIBUS s2nOmnibus
+rm *_current.yml *_source.json *_new.json
+echo "Done."

--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -324,7 +324,7 @@ batch:
       buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         privileged-mode: true
-        compute-type: BUILD_GENERAL1_SMALL
+        compute-type: BUILD_GENERAL1_MEDIUM
         variables:
           TESTS: unit
           GCC_VERSION: '9'
@@ -367,18 +367,6 @@ batch:
           FUZZ_TIMEOUT_SEC: 60
           FUZZ_COVERAGE: true
           CODECOV_IO_UPLOAD: true
-
-    - identifier: s2nFuzzerOpenSSL102
-      buildspec: codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        image: aws/codebuild/standard:5.0
-        variables:
-          S2N_LIBCRYPTO: openssl-1.0.2
-          LATEST_CLANG: true
-          TESTS: fuzz
-          FUZZ_TIMEOUT_SEC: 60
 
     - identifier: s2nFuzzerOpenSSL102FIPS
       buildspec: codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml


### PR DESCRIPTION
### Resolved issues:

none

### Description of changes: 

Inline CodeBuild buildspecs can get out of sync with version control.  Provide a mechanism to diff/update.

### Call-outs:

Being cautious, this could bork CI pretty easily.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Private account testing.

 Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
