### PR TITLE
Generate EMS when Negotiated

### DIFF
--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -173,7 +173,7 @@ const struct s2n_kex s2n_rsa = {
     .server_key_send = NULL,
     .client_key_recv = &s2n_rsa_client_key_recv,
     .client_key_send = &s2n_rsa_client_key_send,
-    .prf = &s2n_tls_prf_master_secret,
+    .prf = &s2n_prf_calculate_master_secret,
 };
 
 const struct s2n_kex s2n_dhe = {
@@ -185,7 +185,7 @@ const struct s2n_kex s2n_dhe = {
     .server_key_send = &s2n_dhe_server_key_send,
     .client_key_recv = &s2n_dhe_client_key_recv,
     .client_key_send = &s2n_dhe_client_key_send,
-    .prf = &s2n_tls_prf_master_secret,
+    .prf = &s2n_prf_calculate_master_secret,
 };
 
 const struct s2n_kex s2n_ecdhe = {
@@ -197,7 +197,7 @@ const struct s2n_kex s2n_ecdhe = {
     .server_key_send = &s2n_ecdhe_server_key_send,
     .client_key_recv = &s2n_ecdhe_client_key_recv,
     .client_key_send = &s2n_ecdhe_client_key_send,
-    .prf = &s2n_tls_prf_master_secret,
+    .prf = &s2n_prf_calculate_master_secret,
 };
 
 const struct s2n_kex s2n_hybrid_ecdhe_kem = {

--- a/tls/s2n_prf.h
+++ b/tls/s2n_prf.h
@@ -56,6 +56,7 @@ S2N_RESULT s2n_prf_new(struct s2n_connection *conn);
 S2N_RESULT s2n_prf_wipe(struct s2n_connection *conn);
 S2N_RESULT s2n_prf_free(struct s2n_connection *conn);
 
+int s2n_prf_calculate_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret);
 extern int s2n_tls_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret);
 extern int s2n_hybrid_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret);
 S2N_RESULT s2n_tls_prf_extended_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret, struct s2n_blob *session_hash);


### PR DESCRIPTION
### Resolved issues:

 resolves #2949

### Description of changes: 

Added some branching logic so that we call the correct generate function when an EMS handshake is negotiated.
### Call-outs:

N/A
### Testing:

Testing this is slightly weird. I added a test for whether we produced a master secret or an extended master secret. Testing that we've produced the correct secret will have to be for the integration tests.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
