### PR TITLE
Make handshake hashes freeable after handshake

### DIFF
--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -713,15 +713,15 @@ void cbmc_populate_s2n_handshake(struct s2n_handshake *s2n_handshake)
 {
     CBMC_ENSURE_REF(s2n_handshake);
     cbmc_populate_s2n_stuffer(&(s2n_handshake->io));
-    cbmc_populate_s2n_hash_state(&(s2n_handshake->md5));
-    cbmc_populate_s2n_hash_state(&(s2n_handshake->sha1));
-    cbmc_populate_s2n_hash_state(&(s2n_handshake->sha224));
-    cbmc_populate_s2n_hash_state(&(s2n_handshake->sha256));
-    cbmc_populate_s2n_hash_state(&(s2n_handshake->sha384));
-    cbmc_populate_s2n_hash_state(&(s2n_handshake->sha512));
-    cbmc_populate_s2n_hash_state(&(s2n_handshake->md5_sha1));
-    cbmc_populate_s2n_hash_state(&(s2n_handshake->server_hello_copy));
-    cbmc_populate_s2n_hash_state(&(s2n_handshake->server_finished_copy));
+    cbmc_populate_s2n_hash_state(&(s2n_handshake->hashes->md5));
+    cbmc_populate_s2n_hash_state(&(s2n_handshake->hashes->sha1));
+    cbmc_populate_s2n_hash_state(&(s2n_handshake->hashes->sha224));
+    cbmc_populate_s2n_hash_state(&(s2n_handshake->hashes->sha256));
+    cbmc_populate_s2n_hash_state(&(s2n_handshake->hashes->sha384));
+    cbmc_populate_s2n_hash_state(&(s2n_handshake->hashes->sha512));
+    cbmc_populate_s2n_hash_state(&(s2n_handshake->hashes->md5_sha1));
+    cbmc_populate_s2n_hash_state(&(s2n_handshake->hashes->server_hello_copy));
+    cbmc_populate_s2n_hash_state(&(s2n_handshake->hashes->server_finished_copy));
     /* `s2n_handshake->early_data_async_state.conn` is never allocated.
      * If required, this initialization should be done in the validation function.
      */

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -722,6 +722,7 @@ void cbmc_populate_s2n_handshake(struct s2n_handshake *s2n_handshake)
     cbmc_populate_s2n_hash_state(&(s2n_handshake->hashes->md5_sha1));
     cbmc_populate_s2n_hash_state(&(s2n_handshake->hashes->server_hello_copy));
     cbmc_populate_s2n_hash_state(&(s2n_handshake->hashes->server_finished_copy));
+    cbmc_populate_s2n_hash_state(&(s2n_handshake->hashes->hash_workspace));
     /* `s2n_handshake->early_data_async_state.conn` is never allocated.
      * If required, this initialization should be done in the validation function.
      */
@@ -792,7 +793,6 @@ void cbmc_populate_s2n_connection(struct s2n_connection *s2n_connection)
     cbmc_populate_s2n_blob(&(s2n_connection->application_protocols_overridden));
     cbmc_populate_s2n_stuffer(&(s2n_connection->cookie_stuffer));
     cbmc_populate_s2n_blob(&(s2n_connection->server_early_data_context));
-    cbmc_populate_s2n_hash_state(&(s2n_connection->hash_workspace));
 }
 
 struct s2n_connection *cbmc_allocate_s2n_connection()

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
      */
     {
         /* Carefully consider any increases to this number. */
-        const uint16_t max_connection_size = 13100;
+        const uint16_t max_connection_size = 11000;
         const uint16_t min_connection_size = max_connection_size * 0.75;
 
         size_t connection_size = sizeof(struct s2n_connection);

--- a/tests/unit/s2n_handshake_hashes_test.c
+++ b/tests/unit/s2n_handshake_hashes_test.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/s2n_handshake_hashes.h"
+
+#include "tls/s2n_connection.h"
+
+/* Needed for s2n_handshake_get_hash_state_ptr */
+#include "tls/s2n_handshake.c"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test s2n_handshake_hashes_new */
+    {
+        /* Safety */
+        EXPECT_ERROR_WITH_ERRNO(s2n_handshake_hashes_new(NULL), S2N_ERR_NULL);
+
+        /* Allocates a new s2n_handshake_hashes struct */
+        {
+            /* Allocates the struct */
+            struct s2n_connection conn = { 0 };
+            EXPECT_NULL(conn.handshake.hashes);
+            EXPECT_OK(s2n_handshake_hashes_new(&conn.handshake.hashes));
+            EXPECT_NOT_NULL(conn.handshake.hashes);
+
+            uint8_t data[100] = { 0 };
+
+            /* Allocates all hashes */
+            for (s2n_hash_algorithm alg = 0; alg < S2N_HASH_SENTINEL; alg++) {
+                if (alg == S2N_HASH_NONE) {
+                    continue;
+                }
+
+                uint8_t size = 0;
+                EXPECT_SUCCESS(s2n_hash_digest_size(alg, &size));
+                EXPECT_TRUE(size < sizeof(data));
+
+                struct s2n_hash_state *hash_state = NULL;
+                EXPECT_SUCCESS(s2n_handshake_get_hash_state_ptr(&conn, alg, &hash_state));
+
+                /* Hash is setup / useable */
+                EXPECT_SUCCESS(s2n_hash_digest(hash_state, data, size));
+            }
+
+            s2n_handshake_hashes_free(&conn.handshake.hashes);
+        }
+    }
+
+    /* Test s2n_handshake_hashes_wipe */
+    {
+        /* Safety */
+        EXPECT_ERROR_WITH_ERRNO(s2n_handshake_hashes_wipe(NULL), S2N_ERR_NULL);
+
+        /* Resets all hashes */
+        {
+            struct s2n_connection conn = { 0 };
+            EXPECT_OK(s2n_handshake_hashes_new(&conn.handshake.hashes));
+            EXPECT_NOT_NULL(conn.handshake.hashes);
+
+            uint8_t data[100] = { 0 };
+
+            for (s2n_hash_algorithm alg = 0; alg < S2N_HASH_SENTINEL; alg++) {
+                if (alg == S2N_HASH_NONE) {
+                    continue;
+                }
+
+                uint8_t size = 0;
+                EXPECT_SUCCESS(s2n_hash_digest_size(alg, &size));
+                EXPECT_TRUE(size < sizeof(data));
+
+                struct s2n_hash_state *hash_state = NULL;
+                EXPECT_SUCCESS(s2n_handshake_get_hash_state_ptr(&conn, alg, &hash_state));
+                EXPECT_SUCCESS(s2n_hash_digest(hash_state, data, size));
+
+                /* Can't calculate the digest again: only one digest allowed per hash */
+                EXPECT_FAILURE_WITH_ERRNO(s2n_hash_digest(hash_state, data, size), S2N_ERR_HASH_NOT_READY);
+
+                /* Wiping the hashes allows them to be successfully reused */
+                EXPECT_OK(s2n_handshake_hashes_wipe(conn.handshake.hashes));
+                EXPECT_SUCCESS(s2n_hash_digest(hash_state, data, size));
+            }
+
+            s2n_handshake_hashes_free(&conn.handshake.hashes);
+        }
+    }
+
+    /* Test s2n_handshake_hashes_free */
+    {
+        /* Safety */
+        EXPECT_ERROR_WITH_ERRNO(s2n_handshake_hashes_free(NULL), S2N_ERR_NULL);
+
+        /* Frees the hashes with no memory leaks */
+        {
+            struct s2n_handshake_hashes *hashes = NULL;
+            EXPECT_OK(s2n_handshake_hashes_new(&hashes));
+            EXPECT_NOT_NULL(hashes);
+
+            EXPECT_OK(s2n_handshake_hashes_free(&hashes));
+            EXPECT_NULL(hashes);
+        }
+    }
+
+    /* Test s2n_handshake_hashes connection lifecycle */
+    {
+        uint8_t digest[SHA256_DIGEST_LENGTH] = { 0 };
+
+        /* A new connection's hashes are properly set up and can be used. */
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(conn);
+
+        struct s2n_hash_state *hash_state = NULL;
+        EXPECT_SUCCESS(s2n_handshake_get_hash_state_ptr(conn, S2N_HASH_SHA256, &hash_state));
+        EXPECT_NOT_NULL(hash_state);
+        EXPECT_SUCCESS(s2n_hash_digest(hash_state, digest, SHA256_DIGEST_LENGTH));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_hash_digest(hash_state, digest, SHA256_DIGEST_LENGTH), S2N_ERR_HASH_NOT_READY);
+
+        /* A wiped connection's hashes can be reused. */
+        EXPECT_SUCCESS(s2n_connection_wipe(conn));
+        EXPECT_SUCCESS(s2n_handshake_get_hash_state_ptr(conn, S2N_HASH_SHA256, &hash_state));
+        EXPECT_NOT_NULL(hash_state);
+        EXPECT_SUCCESS(s2n_hash_digest(hash_state, digest, SHA256_DIGEST_LENGTH));
+
+        /* Freeing the handshake does not free the hashes */
+        EXPECT_SUCCESS(s2n_connection_free_handshake(conn));
+        EXPECT_SUCCESS(s2n_handshake_get_hash_state_ptr(conn, S2N_HASH_SHA256, &hash_state));
+        EXPECT_NOT_NULL(hash_state);
+
+        /* Wiping the connection should restore the freed hashes */
+        EXPECT_SUCCESS(s2n_connection_wipe(conn));
+        EXPECT_SUCCESS(s2n_handshake_get_hash_state_ptr(conn, S2N_HASH_SHA256, &hash_state));
+        EXPECT_NOT_NULL(hash_state);
+        EXPECT_SUCCESS(s2n_hash_digest(hash_state, digest, SHA256_DIGEST_LENGTH));
+
+        /* Freeing the connection should free the hashes */
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_handshake_hashes_test.c
+++ b/tests/unit/s2n_handshake_hashes_test.c
@@ -136,10 +136,10 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(hash_state);
         EXPECT_SUCCESS(s2n_hash_digest(hash_state, digest, SHA256_DIGEST_LENGTH));
 
-        /* Freeing the handshake does not free the hashes */
+        /* Freeing the handshake frees the hashes */
         EXPECT_SUCCESS(s2n_connection_free_handshake(conn));
-        EXPECT_SUCCESS(s2n_handshake_get_hash_state_ptr(conn, S2N_HASH_SHA256, &hash_state));
-        EXPECT_NOT_NULL(hash_state);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_handshake_get_hash_state_ptr(conn, S2N_HASH_SHA256, &hash_state), S2N_ERR_NULL);
+        EXPECT_NULL(conn->handshake.hashes);
 
         /* Wiping the connection should restore the freed hashes */
         EXPECT_SUCCESS(s2n_connection_wipe(conn));

--- a/tests/unit/s2n_tls13_handshake_early_data_test.c
+++ b/tests/unit/s2n_tls13_handshake_early_data_test.c
@@ -89,8 +89,8 @@ static int s2n_check_traffic_secret_order(void* context, struct s2n_connection *
 static S2N_RESULT s2n_setup_tls13_secrets_prereqs(struct s2n_connection *conn)
 {
     conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
-    RESULT_GUARD_POSIX(s2n_tls13_conn_copy_hash(conn, &conn->handshake.server_hello_copy));
-    RESULT_GUARD_POSIX(s2n_tls13_conn_copy_hash(conn, &conn->handshake.server_finished_copy));
+    RESULT_GUARD_POSIX(s2n_tls13_conn_copy_hash(conn, &conn->handshake.hashes->server_hello_copy));
+    RESULT_GUARD_POSIX(s2n_tls13_conn_copy_hash(conn, &conn->handshake.hashes->server_finished_copy));
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
     RESULT_GUARD_POSIX(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
@@ -547,7 +547,7 @@ int main()
             EXPECT_SUCCESS(s2n_dup(&early_secret, &psk->early_secret));
 
             /* Rewrite hashes with known ClientHello */
-            EXPECT_SUCCESS(s2n_hash_update(&client_conn->handshake.sha256,
+            EXPECT_SUCCESS(s2n_hash_update(&client_conn->handshake.hashes->sha256,
                     client_hello_msg.data, client_hello_msg.size));
 
             client_conn->handshake.message_number = 0;

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -46,8 +46,8 @@
 static int s2n_setup_tls13_secrets_prereqs(struct s2n_connection *conn)
 {
     conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
-    POSIX_GUARD(s2n_tls13_conn_copy_hash(conn, &conn->handshake.server_hello_copy));
-    POSIX_GUARD(s2n_tls13_conn_copy_hash(conn, &conn->handshake.server_finished_copy));
+    POSIX_GUARD(s2n_tls13_conn_copy_hash(conn, &conn->handshake.hashes->server_hello_copy));
+    POSIX_GUARD(s2n_tls13_conn_copy_hash(conn, &conn->handshake.hashes->server_finished_copy));
 
     const struct s2n_ecc_preferences *ecc_pref = NULL;
     POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_pref));
@@ -194,8 +194,8 @@ int main(int argc, char **argv)
         server_conn->secure.cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
         /* populating server hello hash is now a requirement for s2n_tls13_handle_handshake_traffic_secret */
-        EXPECT_SUCCESS(s2n_tls13_conn_copy_hash(server_conn, &server_conn->handshake.server_hello_copy));
-        EXPECT_SUCCESS(s2n_tls13_conn_copy_hash(client_conn, &client_conn->handshake.server_hello_copy));
+        EXPECT_SUCCESS(s2n_tls13_conn_copy_hash(server_conn, &server_conn->handshake.hashes->server_hello_copy));
+        EXPECT_SUCCESS(s2n_tls13_conn_copy_hash(client_conn, &client_conn->handshake.hashes->server_hello_copy));
 
         EXPECT_SUCCESS(s2n_tls13_handle_early_secret(server_conn));
         EXPECT_SUCCESS(s2n_tls13_handle_handshake_master_secret(server_conn));
@@ -269,8 +269,8 @@ int main(int argc, char **argv)
         S2N_STUFFER_READ_EXPECT_EQUAL(&server_conn->in, TLS_APPLICATION_DATA, uint8);
 
         /* populating server finished hash is now a requirement for s2n_tls13_handle_application_secrets */
-        EXPECT_SUCCESS(s2n_tls13_conn_copy_hash(server_conn, &server_conn->handshake.server_finished_copy));
-        EXPECT_SUCCESS(s2n_tls13_conn_copy_hash(client_conn, &client_conn->handshake.server_finished_copy));
+        EXPECT_SUCCESS(s2n_tls13_conn_copy_hash(server_conn, &server_conn->handshake.hashes->server_finished_copy));
+        EXPECT_SUCCESS(s2n_tls13_conn_copy_hash(client_conn, &client_conn->handshake.hashes->server_finished_copy));
 
         EXPECT_SUCCESS(s2n_tls13_handle_master_secret(client_conn));
         EXPECT_SUCCESS(s2n_tls13_handle_master_secret(server_conn));

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -31,6 +31,9 @@ static int s2n_client_cert_verify_send_complete(struct s2n_connection *conn, str
 
 int s2n_client_cert_verify_recv(struct s2n_connection *conn)
 {
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->handshake.hashes);
+
     struct s2n_stuffer *in = &conn->handshake.io;
     struct s2n_signature_scheme chosen_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
 
@@ -61,6 +64,9 @@ int s2n_client_cert_verify_recv(struct s2n_connection *conn)
 
 int s2n_client_cert_verify_send(struct s2n_connection *conn)
 {
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->handshake.hashes);
+
     S2N_ASYNC_PKEY_GUARD(conn);
     struct s2n_stuffer *out = &conn->handshake.io;
 

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -48,10 +48,10 @@ int s2n_client_cert_verify_recv(struct s2n_connection *conn)
     /* Use a copy of the hash state since the verify digest computation may modify the running hash state we need later. */
     struct s2n_hash_state hash_state = {0};
     POSIX_GUARD(s2n_handshake_get_hash_state(conn, chosen_sig_scheme.hash_alg, &hash_state));
-    POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &hash_state));
+    POSIX_GUARD(s2n_hash_copy(&conn->handshake.hashes->hash_workspace, &hash_state));
 
     /* Verify the signature */
-    POSIX_GUARD(s2n_pkey_verify(&conn->handshake_params.client_public_key, chosen_sig_scheme.sig_alg, &conn->hash_workspace, &signature));
+    POSIX_GUARD(s2n_pkey_verify(&conn->handshake_params.client_public_key, chosen_sig_scheme.sig_alg, &conn->handshake.hashes->hash_workspace, &signature));
 
     /* Client certificate has been verified. Minimize required handshake hash algs */
     POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));
@@ -74,9 +74,9 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
     /* Use a copy of the hash state since the verify digest computation may modify the running hash state we need later. */
     struct s2n_hash_state hash_state = {0};
     POSIX_GUARD(s2n_handshake_get_hash_state(conn, chosen_sig_scheme.hash_alg, &hash_state));
-    POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &hash_state));
+    POSIX_GUARD(s2n_hash_copy(&conn->handshake.hashes->hash_workspace, &hash_state));
 
-    S2N_ASYNC_PKEY_SIGN(conn, chosen_sig_scheme.sig_alg, &conn->hash_workspace, s2n_client_cert_verify_send_complete);
+    S2N_ASYNC_PKEY_SIGN(conn, chosen_sig_scheme.sig_alg, &conn->handshake.hashes->hash_workspace, s2n_client_cert_verify_send_complete);
 }
 
 static int s2n_client_cert_verify_send_complete(struct s2n_connection *conn, struct s2n_blob *signature)

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -61,7 +61,6 @@
 static int s2n_connection_new_hashes(struct s2n_connection *conn)
 {
     /* Allocate long-term memory for the Connection's hash states */
-    POSIX_GUARD(s2n_hash_new(&conn->hash_workspace));
     POSIX_GUARD(s2n_hash_new(&conn->prf_space.ssl3.md5));
     POSIX_GUARD(s2n_hash_new(&conn->prf_space.ssl3.sha1));
 
@@ -76,8 +75,6 @@ static int s2n_connection_init_hashes(struct s2n_connection *conn)
         /* Only initialize hashes that use MD5 if available. */
         POSIX_GUARD(s2n_hash_init(&conn->prf_space.ssl3.md5, S2N_HASH_MD5));
     }
-
-    POSIX_GUARD(s2n_hash_init(&conn->hash_workspace, S2N_HASH_NONE));
     POSIX_GUARD(s2n_hash_init(&conn->prf_space.ssl3.sha1, S2N_HASH_SHA1));
 
     return 0;
@@ -262,7 +259,6 @@ static int s2n_connection_wipe_keys(struct s2n_connection *conn)
 static int s2n_connection_reset_hashes(struct s2n_connection *conn)
 {
     /* Reset all of the Connection's hash states */
-    POSIX_GUARD(s2n_hash_reset(&conn->hash_workspace));
     POSIX_GUARD(s2n_hash_reset(&conn->prf_space.ssl3.md5));
     POSIX_GUARD(s2n_hash_reset(&conn->prf_space.ssl3.sha1));
 
@@ -314,7 +310,6 @@ static int s2n_connection_wipe_io(struct s2n_connection *conn)
 static int s2n_connection_free_hashes(struct s2n_connection *conn)
 {
     /* Free all of the Connection's hash states */
-    POSIX_GUARD(s2n_hash_free(&conn->hash_workspace));
     POSIX_GUARD(s2n_hash_free(&conn->prf_space.ssl3.md5));
     POSIX_GUARD(s2n_hash_free(&conn->prf_space.ssl3.sha1));
 
@@ -498,7 +493,6 @@ int s2n_connection_release_buffers(struct s2n_connection *conn)
 int s2n_connection_free_handshake(struct s2n_connection *conn)
 {
     /* We are done with the handshake */
-    POSIX_GUARD(s2n_hash_reset(&conn->hash_workspace));
     POSIX_GUARD_RESULT(s2n_handshake_hashes_free(&conn->handshake.hashes));
 
     /* Wipe the buffers we are going to free */

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -61,16 +61,7 @@
 static int s2n_connection_new_hashes(struct s2n_connection *conn)
 {
     /* Allocate long-term memory for the Connection's hash states */
-    POSIX_GUARD(s2n_hash_new(&conn->handshake.md5));
-    POSIX_GUARD(s2n_hash_new(&conn->handshake.sha1));
-    POSIX_GUARD(s2n_hash_new(&conn->handshake.sha224));
-    POSIX_GUARD(s2n_hash_new(&conn->handshake.sha256));
-    POSIX_GUARD(s2n_hash_new(&conn->handshake.sha384));
-    POSIX_GUARD(s2n_hash_new(&conn->handshake.sha512));
-    POSIX_GUARD(s2n_hash_new(&conn->handshake.md5_sha1));
     POSIX_GUARD(s2n_hash_new(&conn->hash_workspace));
-    POSIX_GUARD(s2n_hash_new(&conn->handshake.server_hello_copy));
-    POSIX_GUARD(s2n_hash_new(&conn->handshake.server_finished_copy));
     POSIX_GUARD(s2n_hash_new(&conn->prf_space.ssl3.md5));
     POSIX_GUARD(s2n_hash_new(&conn->prf_space.ssl3.sha1));
 
@@ -86,33 +77,7 @@ static int s2n_connection_init_hashes(struct s2n_connection *conn)
         POSIX_GUARD(s2n_hash_init(&conn->prf_space.ssl3.md5, S2N_HASH_MD5));
     }
 
-
-    /* Allow MD5 for hash states that are used by the PRF. This is required
-     * to comply with the TLS 1.0 and 1.1 RFCs and is approved as per
-     * NIST Special Publication 800-52 Revision 1.
-     */
-    if (s2n_is_in_fips_mode()) {
-        POSIX_GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.md5));
-        POSIX_GUARD(s2n_hash_allow_md5_for_fips(&conn->hash_workspace));
-
-        /* Do not check s2n_hash_is_available before initialization. Allow MD5 and
-         * SHA-1 for both fips and non-fips mode. This is required to perform the
-         * signature checks in the CertificateVerify message in TLS 1.0 and TLS 1.1.
-         * This is approved per Nist SP 800-52r1.*/
-        POSIX_GUARD(s2n_hash_allow_md5_for_fips(&conn->handshake.md5_sha1));
-    }
-
-    POSIX_GUARD(s2n_hash_init(&conn->handshake.md5, S2N_HASH_MD5));
-    POSIX_GUARD(s2n_hash_init(&conn->handshake.md5_sha1, S2N_HASH_MD5_SHA1));
-
-    POSIX_GUARD(s2n_hash_init(&conn->handshake.sha1, S2N_HASH_SHA1));
-    POSIX_GUARD(s2n_hash_init(&conn->handshake.sha224, S2N_HASH_SHA224));
-    POSIX_GUARD(s2n_hash_init(&conn->handshake.sha256, S2N_HASH_SHA256));
-    POSIX_GUARD(s2n_hash_init(&conn->handshake.sha384, S2N_HASH_SHA384));
-    POSIX_GUARD(s2n_hash_init(&conn->handshake.sha512, S2N_HASH_SHA512));
     POSIX_GUARD(s2n_hash_init(&conn->hash_workspace, S2N_HASH_NONE));
-    POSIX_GUARD(s2n_hash_init(&conn->handshake.server_hello_copy, S2N_HASH_NONE));
-    POSIX_GUARD(s2n_hash_init(&conn->handshake.server_finished_copy, S2N_HASH_NONE));
     POSIX_GUARD(s2n_hash_init(&conn->prf_space.ssl3.sha1, S2N_HASH_SHA1));
 
     return 0;
@@ -198,6 +163,7 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
 
     /* Allocate long term hash and HMAC memory */
     PTR_GUARD_POSIX(s2n_prf_new(conn));
+    PTR_GUARD_RESULT(s2n_handshake_hashes_new(&conn->handshake.hashes));
 
     PTR_GUARD_POSIX(s2n_connection_new_hashes(conn));
     PTR_GUARD_POSIX(s2n_connection_init_hashes(conn));
@@ -296,16 +262,7 @@ static int s2n_connection_wipe_keys(struct s2n_connection *conn)
 static int s2n_connection_reset_hashes(struct s2n_connection *conn)
 {
     /* Reset all of the Connection's hash states */
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.md5));
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha1));
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha224));
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha256));
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha384));
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha512));
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.md5_sha1));
     POSIX_GUARD(s2n_hash_reset(&conn->hash_workspace));
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.server_hello_copy));
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.server_finished_copy));
     POSIX_GUARD(s2n_hash_reset(&conn->prf_space.ssl3.md5));
     POSIX_GUARD(s2n_hash_reset(&conn->prf_space.ssl3.sha1));
 
@@ -357,16 +314,7 @@ static int s2n_connection_wipe_io(struct s2n_connection *conn)
 static int s2n_connection_free_hashes(struct s2n_connection *conn)
 {
     /* Free all of the Connection's hash states */
-    POSIX_GUARD(s2n_hash_free(&conn->handshake.md5));
-    POSIX_GUARD(s2n_hash_free(&conn->handshake.sha1));
-    POSIX_GUARD(s2n_hash_free(&conn->handshake.sha224));
-    POSIX_GUARD(s2n_hash_free(&conn->handshake.sha256));
-    POSIX_GUARD(s2n_hash_free(&conn->handshake.sha384));
-    POSIX_GUARD(s2n_hash_free(&conn->handshake.sha512));
-    POSIX_GUARD(s2n_hash_free(&conn->handshake.md5_sha1));
     POSIX_GUARD(s2n_hash_free(&conn->hash_workspace));
-    POSIX_GUARD(s2n_hash_free(&conn->handshake.server_hello_copy));
-    POSIX_GUARD(s2n_hash_free(&conn->handshake.server_finished_copy));
     POSIX_GUARD(s2n_hash_free(&conn->prf_space.ssl3.md5));
     POSIX_GUARD(s2n_hash_free(&conn->prf_space.ssl3.sha1));
 
@@ -425,6 +373,8 @@ int s2n_connection_free(struct s2n_connection *conn)
     POSIX_GUARD_RESULT(s2n_psk_parameters_wipe(&conn->psk_params));
 
     POSIX_GUARD(s2n_prf_free(conn));
+
+    POSIX_GUARD_RESULT(s2n_handshake_hashes_free(&conn->handshake.hashes));
 
     POSIX_GUARD(s2n_connection_reset_hashes(conn));
     POSIX_GUARD(s2n_connection_free_hashes(conn));
@@ -548,16 +498,7 @@ int s2n_connection_release_buffers(struct s2n_connection *conn)
 int s2n_connection_free_handshake(struct s2n_connection *conn)
 {
     /* We are done with the handshake */
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.md5));
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha1));
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha224));
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha256));
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha384));
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.sha512));
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.md5_sha1));
     POSIX_GUARD(s2n_hash_reset(&conn->hash_workspace));
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.server_hello_copy));
-    POSIX_GUARD(s2n_hash_reset(&conn->handshake.server_finished_copy));
 
     /* Wipe the buffers we are going to free */
     POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
@@ -600,11 +541,13 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     struct s2n_connection_prf_handles prf_handles = {0};
     struct s2n_connection_hash_handles hash_handles = {0};
     struct s2n_connection_hmac_handles hmac_handles = {0};
+    struct s2n_handshake_hashes *handshake_hashes = conn->handshake.hashes;
 
     /* Wipe all of the sensitive stuff */
     POSIX_GUARD(s2n_connection_wipe_keys(conn));
     POSIX_GUARD(s2n_connection_reset_hashes(conn));
     POSIX_GUARD(s2n_connection_reset_hmacs(conn));
+    POSIX_GUARD_RESULT(s2n_handshake_hashes_wipe(handshake_hashes));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->alert_in));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->reader_alert_out));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->writer_alert_out));
@@ -687,6 +630,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     POSIX_GUARD(s2n_connection_restore_prf_state(conn, &prf_handles));
     POSIX_GUARD(s2n_connection_restore_hash_state(conn, &hash_handles));
     POSIX_GUARD(s2n_connection_restore_hmac_state(conn, &hmac_handles));
+    conn->handshake.hashes = handshake_hashes;
 
     /* Re-initialize hash and hmac states */
     POSIX_GUARD(s2n_connection_init_hashes(conn));

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -357,9 +357,6 @@ struct s2n_connection {
     uint32_t server_max_early_data_size;
     struct s2n_blob server_early_data_context;
     uint32_t server_keying_material_lifetime;
-
-    /* To avoid allocating memory for hash objects, we reuse one temporary hash object. */
-    struct s2n_hash_state hash_workspace;
 };
 
 int s2n_connection_is_managed_corked(const struct s2n_connection *s2n_connection);

--- a/tls/s2n_connection_evp_digests.c
+++ b/tls/s2n_connection_evp_digests.c
@@ -37,16 +37,7 @@ int s2n_connection_save_prf_state(struct s2n_connection_prf_handles *prf_handles
 int s2n_connection_save_hash_state(struct s2n_connection_hash_handles *hash_handles, struct s2n_connection *conn)
 {
     /* Preserve only the handlers for handshake hash state pointers to avoid re-allocation */
-    hash_handles->md5 = conn->handshake.md5.digest.high_level;
-    hash_handles->sha1 = conn->handshake.sha1.digest.high_level;
-    hash_handles->sha224 = conn->handshake.sha224.digest.high_level;
-    hash_handles->sha256 = conn->handshake.sha256.digest.high_level;
-    hash_handles->sha384 = conn->handshake.sha384.digest.high_level;
-    hash_handles->sha512 = conn->handshake.sha512.digest.high_level;
-    hash_handles->md5_sha1 = conn->handshake.md5_sha1.digest.high_level;
     hash_handles->hash_workspace = conn->hash_workspace.digest.high_level;
-    hash_handles->server_hello_copy = conn->handshake.server_hello_copy.digest.high_level;
-    hash_handles->server_finished_copy = conn->handshake.server_finished_copy.digest.high_level;
 
     /* Preserve only the handlers for SSLv3 PRF hash state pointers to avoid re-allocation */
     hash_handles->prf_md5 = conn->prf_space.ssl3.md5.digest.high_level;
@@ -88,16 +79,7 @@ int s2n_connection_restore_prf_state(struct s2n_connection *conn, struct s2n_con
 int s2n_connection_restore_hash_state(struct s2n_connection *conn, struct s2n_connection_hash_handles *hash_handles)
 {
     /* Restore s2n_connection handlers for handshake hash states */
-    conn->handshake.md5.digest.high_level = hash_handles->md5;
-    conn->handshake.sha1.digest.high_level = hash_handles->sha1;
-    conn->handshake.sha224.digest.high_level = hash_handles->sha224;
-    conn->handshake.sha256.digest.high_level = hash_handles->sha256;
-    conn->handshake.sha384.digest.high_level = hash_handles->sha384;
-    conn->handshake.sha512.digest.high_level = hash_handles->sha512;
-    conn->handshake.md5_sha1.digest.high_level = hash_handles->md5_sha1;
     conn->hash_workspace.digest.high_level = hash_handles->hash_workspace;
-    conn->handshake.server_hello_copy.digest.high_level = hash_handles->server_hello_copy;
-    conn->handshake.server_finished_copy.digest.high_level = hash_handles->server_finished_copy;
 
     /* Restore s2n_connection handlers for SSLv3 PRF hash states */
     conn->prf_space.ssl3.md5.digest.high_level = hash_handles->prf_md5;

--- a/tls/s2n_connection_evp_digests.c
+++ b/tls/s2n_connection_evp_digests.c
@@ -36,9 +36,6 @@ int s2n_connection_save_prf_state(struct s2n_connection_prf_handles *prf_handles
  */
 int s2n_connection_save_hash_state(struct s2n_connection_hash_handles *hash_handles, struct s2n_connection *conn)
 {
-    /* Preserve only the handlers for handshake hash state pointers to avoid re-allocation */
-    hash_handles->hash_workspace = conn->hash_workspace.digest.high_level;
-
     /* Preserve only the handlers for SSLv3 PRF hash state pointers to avoid re-allocation */
     hash_handles->prf_md5 = conn->prf_space.ssl3.md5.digest.high_level;
     hash_handles->prf_sha1 = conn->prf_space.ssl3.sha1.digest.high_level;
@@ -78,9 +75,6 @@ int s2n_connection_restore_prf_state(struct s2n_connection *conn, struct s2n_con
  */
 int s2n_connection_restore_hash_state(struct s2n_connection *conn, struct s2n_connection_hash_handles *hash_handles)
 {
-    /* Restore s2n_connection handlers for handshake hash states */
-    conn->hash_workspace.digest.high_level = hash_handles->hash_workspace;
-
     /* Restore s2n_connection handlers for SSLv3 PRF hash states */
     conn->prf_space.ssl3.md5.digest.high_level = hash_handles->prf_md5;
     conn->prf_space.ssl3.sha1.digest.high_level = hash_handles->prf_sha1;

--- a/tls/s2n_connection_evp_digests.h
+++ b/tls/s2n_connection_evp_digests.h
@@ -30,15 +30,10 @@ struct s2n_connection_prf_handles {
 
 struct s2n_connection_hash_handles {
     /* Handshake hash states */
-    struct s2n_hash_evp_digest hash_workspace;
     struct s2n_hash_evp_digest prf_md5;
 
     /* SSLv3 PRF hash states */
     struct s2n_hash_evp_digest prf_sha1;
-
-    /* Initial signature hash states */
-    struct s2n_hash_evp_digest initial_signature_hash;
-    struct s2n_hash_evp_digest secure_signature_hash;
 };
 
 /* Allocationg new EVP structs is expensive, so we back them up here and reuse them */

--- a/tls/s2n_connection_evp_digests.h
+++ b/tls/s2n_connection_evp_digests.h
@@ -30,16 +30,7 @@ struct s2n_connection_prf_handles {
 
 struct s2n_connection_hash_handles {
     /* Handshake hash states */
-    struct s2n_hash_evp_digest md5;
-    struct s2n_hash_evp_digest sha1;
-    struct s2n_hash_evp_digest sha224;
-    struct s2n_hash_evp_digest sha256;
-    struct s2n_hash_evp_digest sha384;
-    struct s2n_hash_evp_digest sha512;
-    struct s2n_hash_evp_digest md5_sha1;
     struct s2n_hash_evp_digest hash_workspace;
-    struct s2n_hash_evp_digest server_hello_copy;
-    struct s2n_hash_evp_digest server_finished_copy;
     struct s2n_hash_evp_digest prf_md5;
 
     /* SSLv3 PRF hash states */

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -71,28 +71,29 @@ int s2n_handshake_parse_header(struct s2n_connection *conn, uint8_t * message_ty
 static int s2n_handshake_get_hash_state_ptr(struct s2n_connection *conn, s2n_hash_algorithm hash_alg, struct s2n_hash_state **hash_state)
 {
     POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->handshake.hashes);
 
     switch (hash_alg) {
     case S2N_HASH_MD5:
-        *hash_state = &conn->handshake.md5;
+        *hash_state = &conn->handshake.hashes->md5;
         break;
     case S2N_HASH_SHA1:
-        *hash_state = &conn->handshake.sha1;
+        *hash_state = &conn->handshake.hashes->sha1;
         break;
     case S2N_HASH_SHA224:
-        *hash_state = &conn->handshake.sha224;
+        *hash_state = &conn->handshake.hashes->sha224;
         break;
     case S2N_HASH_SHA256:
-        *hash_state = &conn->handshake.sha256;
+        *hash_state = &conn->handshake.hashes->sha256;
         break;
     case S2N_HASH_SHA384:
-        *hash_state = &conn->handshake.sha384;
+        *hash_state = &conn->handshake.hashes->sha384;
         break;
     case S2N_HASH_SHA512:
-        *hash_state = &conn->handshake.sha512;
+        *hash_state = &conn->handshake.hashes->sha512;
         break;
     case S2N_HASH_MD5_SHA1:
-        *hash_state = &conn->handshake.md5_sha1;
+        *hash_state = &conn->handshake.hashes->md5_sha1;
         break;
     default:
         POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -19,6 +19,7 @@
 #include <s2n.h>
 
 #include "tls/s2n_crypto.h"
+#include "tls/s2n_handshake_hashes.h"
 #include "tls/s2n_handshake_type.h"
 #include "tls/s2n_signature_algorithms.h"
 #include "tls/s2n_tls_parameters.h"
@@ -132,19 +133,7 @@ struct s2n_handshake_parameters {
 struct s2n_handshake {
     struct s2n_stuffer io;
 
-    struct s2n_hash_state md5;
-    struct s2n_hash_state sha1;
-    struct s2n_hash_state sha224;
-    struct s2n_hash_state sha256;
-    struct s2n_hash_state sha384;
-    struct s2n_hash_state sha512;
-    struct s2n_hash_state md5_sha1;
-
-    /* TLS1.3 does not always use a hash immediately.
-     * We save copies of some states for later use in the key schedule.
-     */
-    struct s2n_hash_state server_hello_copy;
-    struct s2n_hash_state server_finished_copy;
+    struct s2n_handshake_hashes *hashes;
 
     /* Hash algorithms required for this handshake. The set of required hashes can be reduced as session parameters are
      * negotiated, i.e. cipher suite and protocol version.

--- a/tls/s2n_handshake_hashes.c
+++ b/tls/s2n_handshake_hashes.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tls/s2n_handshake_hashes.h"
+
+#include "crypto/s2n_fips.h"
+#include "tls/s2n_connection.h"
+#include "utils/s2n_blob.h"
+#include "utils/s2n_mem.h"
+#include "utils/s2n_safety.h"
+
+static S2N_RESULT s2n_handshake_hashes_new_hashes(struct s2n_handshake_hashes *hashes)
+{
+    RESULT_ENSURE_REF(hashes);
+    RESULT_GUARD_POSIX(s2n_hash_new(&hashes->md5));
+    RESULT_GUARD_POSIX(s2n_hash_new(&hashes->sha1));
+    RESULT_GUARD_POSIX(s2n_hash_new(&hashes->sha224));
+    RESULT_GUARD_POSIX(s2n_hash_new(&hashes->sha256));
+    RESULT_GUARD_POSIX(s2n_hash_new(&hashes->sha384));
+    RESULT_GUARD_POSIX(s2n_hash_new(&hashes->sha512));
+    RESULT_GUARD_POSIX(s2n_hash_new(&hashes->md5_sha1));
+    RESULT_GUARD_POSIX(s2n_hash_new(&hashes->server_hello_copy));
+    RESULT_GUARD_POSIX(s2n_hash_new(&hashes->server_finished_copy));
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_handshake_hashes_reset_hashes(struct s2n_handshake_hashes *hashes)
+{
+    RESULT_ENSURE_REF(hashes);
+    RESULT_GUARD_POSIX(s2n_hash_reset(&hashes->md5));
+    RESULT_GUARD_POSIX(s2n_hash_reset(&hashes->sha1));
+    RESULT_GUARD_POSIX(s2n_hash_reset(&hashes->sha224));
+    RESULT_GUARD_POSIX(s2n_hash_reset(&hashes->sha256));
+    RESULT_GUARD_POSIX(s2n_hash_reset(&hashes->sha384));
+    RESULT_GUARD_POSIX(s2n_hash_reset(&hashes->sha512));
+    RESULT_GUARD_POSIX(s2n_hash_reset(&hashes->md5_sha1));
+    RESULT_GUARD_POSIX(s2n_hash_reset(&hashes->server_hello_copy));
+    RESULT_GUARD_POSIX(s2n_hash_reset(&hashes->server_finished_copy));
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_handshake_hashes_free_hashes(struct s2n_handshake_hashes *hashes)
+{
+    if (!hashes) {
+        return S2N_RESULT_OK;
+    }
+    RESULT_GUARD_POSIX(s2n_hash_free(&hashes->md5));
+    RESULT_GUARD_POSIX(s2n_hash_free(&hashes->sha1));
+    RESULT_GUARD_POSIX(s2n_hash_free(&hashes->sha224));
+    RESULT_GUARD_POSIX(s2n_hash_free(&hashes->sha256));
+    RESULT_GUARD_POSIX(s2n_hash_free(&hashes->sha384));
+    RESULT_GUARD_POSIX(s2n_hash_free(&hashes->sha512));
+    RESULT_GUARD_POSIX(s2n_hash_free(&hashes->md5_sha1));
+    RESULT_GUARD_POSIX(s2n_hash_free(&hashes->server_hello_copy));
+    RESULT_GUARD_POSIX(s2n_hash_free(&hashes->server_finished_copy));
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_handshake_hashes_init_hashes(struct s2n_handshake_hashes *hashes)
+{
+    /* Allow MD5 for hash states that are used by the PRF. This is required
+     * to comply with the TLS 1.0 and 1.1 RFCs and is approved as per
+     * NIST Special Publication 800-52 Revision 1.
+     */
+    if (s2n_is_in_fips_mode()) {
+        RESULT_GUARD_POSIX(s2n_hash_allow_md5_for_fips(&hashes->md5));
+
+        /* Do not check s2n_hash_is_available before initialization. Allow MD5 and
+         * SHA-1 for both fips and non-fips mode. This is required to perform the
+         * signature checks in the CertificateVerify message in TLS 1.0 and TLS 1.1.
+         * This is approved per Nist SP 800-52r1.*/
+        RESULT_GUARD_POSIX(s2n_hash_allow_md5_for_fips(&hashes->md5_sha1));
+    }
+
+    RESULT_GUARD_POSIX(s2n_hash_init(&hashes->md5, S2N_HASH_MD5));
+    RESULT_GUARD_POSIX(s2n_hash_init(&hashes->sha1, S2N_HASH_SHA1));
+    RESULT_GUARD_POSIX(s2n_hash_init(&hashes->sha224, S2N_HASH_SHA224));
+    RESULT_GUARD_POSIX(s2n_hash_init(&hashes->sha256, S2N_HASH_SHA256));
+    RESULT_GUARD_POSIX(s2n_hash_init(&hashes->sha384, S2N_HASH_SHA384));
+    RESULT_GUARD_POSIX(s2n_hash_init(&hashes->sha512, S2N_HASH_SHA512));
+    RESULT_GUARD_POSIX(s2n_hash_init(&hashes->md5_sha1, S2N_HASH_MD5_SHA1));
+    RESULT_GUARD_POSIX(s2n_hash_init(&hashes->server_hello_copy, S2N_HASH_NONE));
+    RESULT_GUARD_POSIX(s2n_hash_init(&hashes->server_finished_copy, S2N_HASH_NONE));
+
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_handshake_hashes_new(struct s2n_handshake_hashes **hashes)
+{
+    RESULT_ENSURE_REF(hashes);
+    RESULT_ENSURE_EQ(*hashes, NULL);
+
+    DEFER_CLEANUP(struct s2n_blob data = { 0 }, s2n_free);
+    RESULT_GUARD_POSIX(s2n_realloc(&data, sizeof(struct s2n_handshake_hashes)));
+    RESULT_GUARD_POSIX(s2n_blob_zero(&data));
+    *hashes = (struct s2n_handshake_hashes*) data.data;
+    ZERO_TO_DISABLE_DEFER_CLEANUP(data);
+
+    RESULT_GUARD(s2n_handshake_hashes_new_hashes(*hashes));
+    RESULT_GUARD(s2n_handshake_hashes_init_hashes(*hashes));
+
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_handshake_hashes_wipe(struct s2n_handshake_hashes *hashes)
+{
+    RESULT_GUARD(s2n_handshake_hashes_reset_hashes(hashes));
+    return S2N_RESULT_OK;
+}
+
+S2N_CLEANUP_RESULT s2n_handshake_hashes_free(struct s2n_handshake_hashes **hashes)
+{
+    RESULT_ENSURE_REF(hashes);
+    RESULT_GUARD(s2n_handshake_hashes_free_hashes(*hashes));
+    RESULT_GUARD_POSIX(s2n_free_object((uint8_t**) hashes, sizeof(struct s2n_handshake_hashes)));
+    return S2N_RESULT_OK;
+}

--- a/tls/s2n_handshake_hashes.c
+++ b/tls/s2n_handshake_hashes.c
@@ -105,7 +105,7 @@ S2N_RESULT s2n_handshake_hashes_new(struct s2n_handshake_hashes **hashes)
     DEFER_CLEANUP(struct s2n_blob data = { 0 }, s2n_free);
     RESULT_GUARD_POSIX(s2n_realloc(&data, sizeof(struct s2n_handshake_hashes)));
     RESULT_GUARD_POSIX(s2n_blob_zero(&data));
-    *hashes = (struct s2n_handshake_hashes*) data.data;
+    *hashes = (struct s2n_handshake_hashes*)(void*) data.data;
     ZERO_TO_DISABLE_DEFER_CLEANUP(data);
 
     RESULT_GUARD(s2n_handshake_hashes_new_hashes(*hashes));

--- a/tls/s2n_handshake_hashes.c
+++ b/tls/s2n_handshake_hashes.c
@@ -33,6 +33,7 @@ static S2N_RESULT s2n_handshake_hashes_new_hashes(struct s2n_handshake_hashes *h
     RESULT_GUARD_POSIX(s2n_hash_new(&hashes->md5_sha1));
     RESULT_GUARD_POSIX(s2n_hash_new(&hashes->server_hello_copy));
     RESULT_GUARD_POSIX(s2n_hash_new(&hashes->server_finished_copy));
+    RESULT_GUARD_POSIX(s2n_hash_new(&hashes->hash_workspace));
     return S2N_RESULT_OK;
 }
 
@@ -48,6 +49,7 @@ static S2N_RESULT s2n_handshake_hashes_reset_hashes(struct s2n_handshake_hashes 
     RESULT_GUARD_POSIX(s2n_hash_reset(&hashes->md5_sha1));
     RESULT_GUARD_POSIX(s2n_hash_reset(&hashes->server_hello_copy));
     RESULT_GUARD_POSIX(s2n_hash_reset(&hashes->server_finished_copy));
+    RESULT_GUARD_POSIX(s2n_hash_reset(&hashes->hash_workspace));
     return S2N_RESULT_OK;
 }
 
@@ -65,6 +67,7 @@ static S2N_RESULT s2n_handshake_hashes_free_hashes(struct s2n_handshake_hashes *
     RESULT_GUARD_POSIX(s2n_hash_free(&hashes->md5_sha1));
     RESULT_GUARD_POSIX(s2n_hash_free(&hashes->server_hello_copy));
     RESULT_GUARD_POSIX(s2n_hash_free(&hashes->server_finished_copy));
+    RESULT_GUARD_POSIX(s2n_hash_free(&hashes->hash_workspace));
     return S2N_RESULT_OK;
 }
 
@@ -76,6 +79,7 @@ static S2N_RESULT s2n_handshake_hashes_init_hashes(struct s2n_handshake_hashes *
      */
     if (s2n_is_in_fips_mode()) {
         RESULT_GUARD_POSIX(s2n_hash_allow_md5_for_fips(&hashes->md5));
+        RESULT_GUARD_POSIX(s2n_hash_allow_md5_for_fips(&hashes->hash_workspace));
 
         /* Do not check s2n_hash_is_available before initialization. Allow MD5 and
          * SHA-1 for both fips and non-fips mode. This is required to perform the
@@ -93,6 +97,7 @@ static S2N_RESULT s2n_handshake_hashes_init_hashes(struct s2n_handshake_hashes *
     RESULT_GUARD_POSIX(s2n_hash_init(&hashes->md5_sha1, S2N_HASH_MD5_SHA1));
     RESULT_GUARD_POSIX(s2n_hash_init(&hashes->server_hello_copy, S2N_HASH_NONE));
     RESULT_GUARD_POSIX(s2n_hash_init(&hashes->server_finished_copy, S2N_HASH_NONE));
+    RESULT_GUARD_POSIX(s2n_hash_init(&hashes->hash_workspace, S2N_HASH_NONE));
 
     return S2N_RESULT_OK;
 }

--- a/tls/s2n_handshake_hashes.h
+++ b/tls/s2n_handshake_hashes.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <s2n.h>
+
+#include "crypto/s2n_hash.h"
+
+struct s2n_handshake_hashes {
+    struct s2n_hash_state md5;
+    struct s2n_hash_state sha1;
+    struct s2n_hash_state sha224;
+    struct s2n_hash_state sha256;
+    struct s2n_hash_state sha384;
+    struct s2n_hash_state sha512;
+    struct s2n_hash_state md5_sha1;
+
+    /* TLS1.3 does not always use a hash immediately.
+     * We save copies of some states for later use in the key schedule.
+     */
+    struct s2n_hash_state server_hello_copy;
+    struct s2n_hash_state server_finished_copy;
+};
+
+S2N_RESULT s2n_handshake_hashes_new(struct s2n_handshake_hashes **hashes);
+S2N_RESULT s2n_handshake_hashes_wipe(struct s2n_handshake_hashes *hashes);
+S2N_CLEANUP_RESULT s2n_handshake_hashes_free(struct s2n_handshake_hashes **hashes);

--- a/tls/s2n_handshake_hashes.h
+++ b/tls/s2n_handshake_hashes.h
@@ -33,6 +33,11 @@ struct s2n_handshake_hashes {
      */
     struct s2n_hash_state server_hello_copy;
     struct s2n_hash_state server_finished_copy;
+
+    /* To avoid allocating memory for hash objects, we reuse one temporary hash object.
+     * Do NOT rely on this hash state maintaining its value outside of the current context.
+     */
+    struct s2n_hash_state hash_workspace;
 };
 
 S2N_RESULT s2n_handshake_hashes_new(struct s2n_handshake_hashes **hashes);

--- a/tls/s2n_handshake_transcript.c
+++ b/tls/s2n_handshake_transcript.c
@@ -39,6 +39,7 @@ int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct s2n_blo
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(data);
+    POSIX_ENSURE_REF(conn->handshake.hashes);
 
     if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_MD5)) {
         /* The handshake MD5 hash state will fail the s2n_hash_is_available() check
@@ -47,11 +48,11 @@ int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct s2n_blo
          * PRF, which is required to comply with the TLS 1.0 and 1.1 RFCs and is approved
          * as per NIST Special Publication 800-52 Revision 1.
          */
-        POSIX_GUARD(s2n_hash_update(&conn->handshake.md5, data->data, data->size));
+        POSIX_GUARD(s2n_hash_update(&conn->handshake.hashes->md5, data->data, data->size));
     }
 
     if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA1)) {
-        POSIX_GUARD(s2n_hash_update(&conn->handshake.sha1, data->data, data->size));
+        POSIX_GUARD(s2n_hash_update(&conn->handshake.hashes->sha1, data->data, data->size));
     }
 
     const uint8_t md5_sha1_required = (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_MD5) &&
@@ -63,31 +64,31 @@ int s2n_conn_update_handshake_hashes(struct s2n_connection *conn, struct s2n_blo
          * CertificateVerify message and the PRF. NIST SP 800-52r1 approves use
          * of MD5_SHA1 for these use cases (see footnotes 15 and 20, and section
          * 3.3.2) */
-        POSIX_GUARD(s2n_hash_update(&conn->handshake.md5_sha1, data->data, data->size));
+        POSIX_GUARD(s2n_hash_update(&conn->handshake.hashes->md5_sha1, data->data, data->size));
     }
 
     if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA224)) {
-        POSIX_GUARD(s2n_hash_update(&conn->handshake.sha224, data->data, data->size));
+        POSIX_GUARD(s2n_hash_update(&conn->handshake.hashes->sha224, data->data, data->size));
     }
 
     if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA256)) {
-        POSIX_GUARD(s2n_hash_update(&conn->handshake.sha256, data->data, data->size));
+        POSIX_GUARD(s2n_hash_update(&conn->handshake.hashes->sha256, data->data, data->size));
     }
 
     if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA384)) {
-        POSIX_GUARD(s2n_hash_update(&conn->handshake.sha384, data->data, data->size));
+        POSIX_GUARD(s2n_hash_update(&conn->handshake.hashes->sha384, data->data, data->size));
     }
 
     if (s2n_handshake_is_hash_required(&conn->handshake, S2N_HASH_SHA512)) {
-        POSIX_GUARD(s2n_hash_update(&conn->handshake.sha512, data->data, data->size));
+        POSIX_GUARD(s2n_hash_update(&conn->handshake.hashes->sha512, data->data, data->size));
     }
 
     /* Copy hashes that TLS1.3 will need later. */
     if (s2n_connection_get_protocol_version(conn) >= S2N_TLS13) {
         if (s2n_conn_get_current_message_type(conn) == SERVER_HELLO) {
-            POSIX_GUARD(s2n_tls13_conn_copy_hash(conn, &conn->handshake.server_hello_copy));
+            POSIX_GUARD(s2n_tls13_conn_copy_hash(conn, &conn->handshake.hashes->server_hello_copy));
         } else if (s2n_conn_get_current_message_type(conn) == SERVER_FINISHED) {
-            POSIX_GUARD(s2n_tls13_conn_copy_hash(conn, &conn->handshake.server_finished_copy));
+            POSIX_GUARD(s2n_tls13_conn_copy_hash(conn, &conn->handshake.hashes->server_finished_copy));
         }
     }
 

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -433,6 +433,7 @@ S2N_RESULT s2n_tls_prf_extended_master_secret(struct s2n_connection *conn, struc
 S2N_RESULT s2n_prf_get_digest_for_ems(struct s2n_connection *conn, struct s2n_blob *message, struct s2n_blob *output)
 {
     RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn->handshake.hashes);
     RESULT_ENSURE_REF(output);
 
     struct s2n_hash_state hash_state = { 0 };
@@ -500,6 +501,9 @@ static int s2n_sslv3_finished(struct s2n_connection *conn, uint8_t prefix[4], st
 
 static int s2n_sslv3_client_finished(struct s2n_connection *conn)
 {
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->handshake.hashes);
+
     uint8_t prefix[4] = { 0x43, 0x4c, 0x4e, 0x54 };
 
     POSIX_ENSURE_LTE(MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH, sizeof(conn->handshake.client_finished));
@@ -508,6 +512,9 @@ static int s2n_sslv3_client_finished(struct s2n_connection *conn)
 
 static int s2n_sslv3_server_finished(struct s2n_connection *conn)
 {
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->handshake.hashes);
+
     uint8_t prefix[4] = { 0x53, 0x52, 0x56, 0x52 };
 
     POSIX_ENSURE_LTE(MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH, sizeof(conn->handshake.server_finished));

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -440,13 +440,13 @@ S2N_RESULT s2n_prf_get_digest_for_ems(struct s2n_connection *conn, struct s2n_bl
     s2n_hash_algorithm hash_alg = 0;
     RESULT_GUARD_POSIX(s2n_hmac_hash_alg(prf_alg, &hash_alg));
     RESULT_GUARD_POSIX(s2n_handshake_get_hash_state(conn, hash_alg, &hash_state));
-    RESULT_GUARD_POSIX(s2n_hash_copy(&conn->hash_workspace, &hash_state));
-    RESULT_GUARD_POSIX(s2n_hash_update(&conn->hash_workspace, message->data, message->size));
+    RESULT_GUARD_POSIX(s2n_hash_copy(&conn->handshake.hashes->hash_workspace, &hash_state));
+    RESULT_GUARD_POSIX(s2n_hash_update(&conn->handshake.hashes->hash_workspace, message->data, message->size));
 
     uint8_t digest_size = 0;
-    RESULT_GUARD_POSIX(s2n_hash_digest_size(conn->hash_workspace.alg, &digest_size));
+    RESULT_GUARD_POSIX(s2n_hash_digest_size(conn->handshake.hashes->hash_workspace.alg, &digest_size));
     RESULT_ENSURE_GTE(output->size, digest_size);
-    RESULT_GUARD_POSIX(s2n_hash_digest(&conn->hash_workspace, output->data, digest_size));
+    RESULT_GUARD_POSIX(s2n_hash_digest(&conn->handshake.hashes->hash_workspace, output->data, digest_size));
 
     return S2N_RESULT_OK;
 }
@@ -503,7 +503,7 @@ static int s2n_sslv3_client_finished(struct s2n_connection *conn)
     uint8_t prefix[4] = { 0x43, 0x4c, 0x4e, 0x54 };
 
     POSIX_ENSURE_LTE(MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH, sizeof(conn->handshake.client_finished));
-    return s2n_sslv3_finished(conn, prefix, &conn->hash_workspace, conn->handshake.client_finished);
+    return s2n_sslv3_finished(conn, prefix, &conn->handshake.hashes->hash_workspace, conn->handshake.client_finished);
 }
 
 static int s2n_sslv3_server_finished(struct s2n_connection *conn)
@@ -511,7 +511,7 @@ static int s2n_sslv3_server_finished(struct s2n_connection *conn)
     uint8_t prefix[4] = { 0x53, 0x52, 0x56, 0x52 };
 
     POSIX_ENSURE_LTE(MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH, sizeof(conn->handshake.server_finished));
-    return s2n_sslv3_finished(conn, prefix, &conn->hash_workspace, conn->handshake.server_finished);
+    return s2n_sslv3_finished(conn, prefix, &conn->handshake.hashes->hash_workspace, conn->handshake.server_finished);
 }
 
 int s2n_prf_client_finished(struct s2n_connection *conn)
@@ -540,13 +540,13 @@ int s2n_prf_client_finished(struct s2n_connection *conn)
     if (conn->actual_protocol_version == S2N_TLS12) {
         switch (conn->secure.cipher_suite->prf_alg) {
         case S2N_HMAC_SHA256:
-            POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &conn->handshake.hashes->sha256));
-            POSIX_GUARD(s2n_hash_digest(&conn->hash_workspace, sha_digest, SHA256_DIGEST_LENGTH));
+            POSIX_GUARD(s2n_hash_copy(&conn->handshake.hashes->hash_workspace, &conn->handshake.hashes->sha256));
+            POSIX_GUARD(s2n_hash_digest(&conn->handshake.hashes->hash_workspace, sha_digest, SHA256_DIGEST_LENGTH));
             sha.size = SHA256_DIGEST_LENGTH;
             break;
         case S2N_HMAC_SHA384:
-            POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &conn->handshake.hashes->sha384));
-            POSIX_GUARD(s2n_hash_digest(&conn->hash_workspace, sha_digest, SHA384_DIGEST_LENGTH));
+            POSIX_GUARD(s2n_hash_copy(&conn->handshake.hashes->hash_workspace, &conn->handshake.hashes->sha384));
+            POSIX_GUARD(s2n_hash_digest(&conn->handshake.hashes->hash_workspace, sha_digest, SHA384_DIGEST_LENGTH));
             sha.size = SHA384_DIGEST_LENGTH;
             break;
         default:
@@ -557,13 +557,13 @@ int s2n_prf_client_finished(struct s2n_connection *conn)
         return s2n_prf(conn, &master_secret, &label, &sha, NULL, NULL, &client_finished);
     }
 
-    POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &conn->handshake.hashes->md5));
-    POSIX_GUARD(s2n_hash_digest(&conn->hash_workspace, md5_digest, MD5_DIGEST_LENGTH));
+    POSIX_GUARD(s2n_hash_copy(&conn->handshake.hashes->hash_workspace, &conn->handshake.hashes->md5));
+    POSIX_GUARD(s2n_hash_digest(&conn->handshake.hashes->hash_workspace, md5_digest, MD5_DIGEST_LENGTH));
     md5.data = md5_digest;
     md5.size = MD5_DIGEST_LENGTH;
 
-    POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &conn->handshake.hashes->sha1));
-    POSIX_GUARD(s2n_hash_digest(&conn->hash_workspace, sha_digest, SHA_DIGEST_LENGTH));
+    POSIX_GUARD(s2n_hash_copy(&conn->handshake.hashes->hash_workspace, &conn->handshake.hashes->sha1));
+    POSIX_GUARD(s2n_hash_digest(&conn->handshake.hashes->hash_workspace, sha_digest, SHA_DIGEST_LENGTH));
     sha.data = sha_digest;
     sha.size = SHA_DIGEST_LENGTH;
 
@@ -596,13 +596,13 @@ int s2n_prf_server_finished(struct s2n_connection *conn)
     if (conn->actual_protocol_version == S2N_TLS12) {
         switch (conn->secure.cipher_suite->prf_alg) {
         case S2N_HMAC_SHA256:
-            POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &conn->handshake.hashes->sha256));
-            POSIX_GUARD(s2n_hash_digest(&conn->hash_workspace, sha_digest, SHA256_DIGEST_LENGTH));
+            POSIX_GUARD(s2n_hash_copy(&conn->handshake.hashes->hash_workspace, &conn->handshake.hashes->sha256));
+            POSIX_GUARD(s2n_hash_digest(&conn->handshake.hashes->hash_workspace, sha_digest, SHA256_DIGEST_LENGTH));
             sha.size = SHA256_DIGEST_LENGTH;
             break;
         case S2N_HMAC_SHA384:
-            POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &conn->handshake.hashes->sha384));
-            POSIX_GUARD(s2n_hash_digest(&conn->hash_workspace, sha_digest, SHA384_DIGEST_LENGTH));
+            POSIX_GUARD(s2n_hash_copy(&conn->handshake.hashes->hash_workspace, &conn->handshake.hashes->sha384));
+            POSIX_GUARD(s2n_hash_digest(&conn->handshake.hashes->hash_workspace, sha_digest, SHA384_DIGEST_LENGTH));
             sha.size = SHA384_DIGEST_LENGTH;
             break;
         default:
@@ -613,13 +613,13 @@ int s2n_prf_server_finished(struct s2n_connection *conn)
         return s2n_prf(conn, &master_secret, &label, &sha, NULL, NULL, &server_finished);
     }
 
-    POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &conn->handshake.hashes->md5));
-    POSIX_GUARD(s2n_hash_digest(&conn->hash_workspace, md5_digest, MD5_DIGEST_LENGTH));
+    POSIX_GUARD(s2n_hash_copy(&conn->handshake.hashes->hash_workspace, &conn->handshake.hashes->md5));
+    POSIX_GUARD(s2n_hash_digest(&conn->handshake.hashes->hash_workspace, md5_digest, MD5_DIGEST_LENGTH));
     md5.data = md5_digest;
     md5.size = MD5_DIGEST_LENGTH;
 
-    POSIX_GUARD(s2n_hash_copy(&conn->hash_workspace, &conn->handshake.hashes->sha1));
-    POSIX_GUARD(s2n_hash_digest(&conn->hash_workspace, sha_digest, SHA_DIGEST_LENGTH));
+    POSIX_GUARD(s2n_hash_copy(&conn->handshake.hashes->hash_workspace, &conn->handshake.hashes->sha1));
+    POSIX_GUARD(s2n_hash_digest(&conn->handshake.hashes->hash_workspace, sha_digest, SHA_DIGEST_LENGTH));
     sha.data = sha_digest;
     sha.size = SHA_DIGEST_LENGTH;
 

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -41,7 +41,7 @@ int s2n_server_key_recv(struct s2n_connection *conn)
     POSIX_ENSURE_REF(conn->secure.cipher_suite);
     POSIX_ENSURE_REF(conn->secure.cipher_suite->key_exchange_alg);
 
-    struct s2n_hash_state *signature_hash = &conn->hash_workspace;
+    struct s2n_hash_state *signature_hash = &conn->handshake.hashes->hash_workspace;
     const struct s2n_kex *key_exchange = conn->secure.cipher_suite->key_exchange_alg;
     struct s2n_stuffer *in = &conn->handshake.io;
     struct s2n_blob data_to_verify = {0};
@@ -234,7 +234,7 @@ int s2n_server_key_send(struct s2n_connection *conn)
 {
     S2N_ASYNC_PKEY_GUARD(conn);
 
-    struct s2n_hash_state *signature_hash = &conn->hash_workspace;
+    struct s2n_hash_state *signature_hash = &conn->handshake.hashes->hash_workspace;
     const struct s2n_kex *key_exchange = conn->secure.cipher_suite->key_exchange_alg;
     struct s2n_stuffer *out = &conn->handshake.io;
     struct s2n_blob data_to_sign = {0};

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -40,6 +40,7 @@ int s2n_server_key_recv(struct s2n_connection *conn)
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(conn->secure.cipher_suite);
     POSIX_ENSURE_REF(conn->secure.cipher_suite->key_exchange_alg);
+    POSIX_ENSURE_REF(conn->handshake.hashes);
 
     struct s2n_hash_state *signature_hash = &conn->handshake.hashes->hash_workspace;
     const struct s2n_kex *key_exchange = conn->secure.cipher_suite->key_exchange_alg;
@@ -232,6 +233,9 @@ int s2n_hybrid_server_key_recv_parse_data(struct s2n_connection *conn, struct s2
 
 int s2n_server_key_send(struct s2n_connection *conn)
 {
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->handshake.hashes);
+
     S2N_ASYNC_PKEY_GUARD(conn);
 
     struct s2n_hash_state *signature_hash = &conn->handshake.hashes->hash_workspace;

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -293,7 +293,8 @@ int s2n_tls13_handle_handshake_traffic_secret(struct s2n_connection *conn, s2n_m
         conn->server = &conn->secure;
     }
 
-    POSIX_GUARD(s2n_tls13_derive_handshake_traffic_secret(&secrets, &conn->handshake.server_hello_copy, &hs_secret, mode));
+    POSIX_ENSURE_REF(conn->handshake.hashes);
+    POSIX_GUARD(s2n_tls13_derive_handshake_traffic_secret(&secrets, &conn->handshake.hashes->server_hello_copy, &hs_secret, mode));
 
     /* trigger secret callbacks */
     if (conn->secret_cb && conn->config->quic_enabled) {
@@ -352,8 +353,8 @@ static int s2n_tls13_handle_application_secret(struct s2n_connection *conn, s2n_
     }
 
     /* use frozen hashes during the server finished state */
-    struct s2n_hash_state *hash_state;
-    POSIX_GUARD_PTR(hash_state = &conn->handshake.server_finished_copy);
+    POSIX_ENSURE_REF(conn->handshake.hashes);
+    struct s2n_hash_state *hash_state = &conn->handshake.hashes->server_finished_copy;
 
     /* calculate secret */
     struct s2n_blob app_secret = { .data = app_secret_data, .size = keys.size };


### PR DESCRIPTION
### Description of changes: 

I moved the handshake hashes to a separate structure, which is allocated separately from the connection and can be freed after the handshake. Unplanned benefit, it also made keeping the hashes when the connection is wiped much simpler.

Because the handshake hash structure isn't freed on a wipe, this change just introduces one more memory allocation when a connection is first created. If `s2n_connection_free_handshake` is called, it's a little more expensive because the memory must be reallocated for the next handshake.

This saves us ~2.1kb per connection if `s2n_connection_free_handshake` is used. Otherwise, no memory change, the connection structure just _looks_ smaller.

### Testing:

New unit tests.

Did some quick performance testing to ensure no serious impact: https://gist.github.com/lrstewart/4bbe2875f0ea33926ecc1a1e0aa5ac12

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
