### PR TITLE
Make prf_space smaller + freeable after handshake

### DIFF
--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -703,10 +703,15 @@ void cbmc_populate_s2n_prf_working_space(struct s2n_prf_working_space *s2n_prf_w
      * It is always initialized based on the hashing algorithm.
      * If required, this initialization should be done in the validation function.
      */
-    cbmc_populate_s2n_hmac_state(&(s2n_prf_working_space->tls.p_hash.s2n_hmac));
-    cbmc_populate_s2n_evp_hmac_state(&(s2n_prf_working_space->tls.p_hash.s2n_hmac));
-    cbmc_populate_s2n_hash_state(&(s2n_prf_working_space->ssl3.md5));
-    cbmc_populate_s2n_hash_state(&(s2n_prf_working_space->ssl3.sha1));
+    cbmc_populate_s2n_hmac_state(&(s2n_prf_working_space->p_hash.s2n_hmac));
+    cbmc_populate_s2n_evp_hmac_state(&(s2n_prf_working_space->p_hash.s2n_hmac));
+}
+
+struct s2n_prf_working_space* cbmc_allocate_s2n_prf_working_space()
+{
+    struct s2n_prf_working_space *workspace = malloc(sizeof(*workspace));
+    cbmc_populate_s2n_prf_working_space(workspace);
+    return workspace;
 }
 
 void cbmc_populate_s2n_handshake(struct s2n_handshake *s2n_handshake)
@@ -771,7 +776,7 @@ void cbmc_populate_s2n_connection(struct s2n_connection *s2n_connection)
     s2n_connection->server = cbmc_allocate_s2n_crypto_parameters();
     cbmc_populate_s2n_handshake_parameters(&(s2n_connection->handshake_params));
     cbmc_populate_s2n_psk_parameters(&(s2n_connection->psk_params));
-    cbmc_populate_s2n_prf_working_space(&(s2n_connection->prf_space));
+    s2n_connection->prf_space = cbmc_allocate_s2n_prf_working_space();
     cbmc_populate_s2n_stuffer(&(s2n_connection->header_in));
     cbmc_populate_s2n_stuffer(&(s2n_connection->in));
     cbmc_populate_s2n_stuffer(&(s2n_connection->out));

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
      */
     {
         /* Carefully consider any increases to this number. */
-        const uint16_t max_connection_size = 11000;
+        const uint16_t max_connection_size = 9000;
         const uint16_t min_connection_size = max_connection_size * 0.75;
 
         size_t connection_size = sizeof(struct s2n_connection);

--- a/tests/unit/s2n_tls_prf_test.c
+++ b/tests/unit/s2n_tls_prf_test.c
@@ -35,23 +35,19 @@
  */
 int main(int argc, char **argv)
 {
-    uint8_t master_secret_hex_pad[96];
-    char premaster_secret_hex_in[] = "0301bebf2a5707c7bda6bfe5a8971a351a9ebd019de412212da021fd802e03f49f231d4e959c7352679f892f9d7f9748";
-    char client_random_hex_in[] = "537eefc1e720b311ff8483d057ae750a3667af9d5b496cc0d2edfb0dd309a286";
-    char server_random_hex_in[] = "537eefc29f337c5eedacd00a1889b031261701872d666a74fa999dc13bcd8821";
-    char master_secret_hex_in[] = "c8c610686237cd024a2d8e0391f61a8a4464c2c9576ea2b5ccf3af68139ec07c6a1720097063de968f2341f77b837120";
-
-    struct s2n_stuffer client_random_in = {0};
-    struct s2n_stuffer server_random_in = {0};
-    struct s2n_stuffer premaster_secret_in = {0};
-    struct s2n_stuffer master_secret_hex_out = {0};
-    struct s2n_blob master_secret = {.data = master_secret_hex_pad,.size = sizeof(master_secret_hex_pad) };
-    struct s2n_blob pms = {0};
-
-    struct s2n_connection *conn = NULL;
-
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13());
+
+    S2N_BLOB_FROM_HEX(premaster_secret_in,
+            "0301bebf2a5707c7bda6bfe5a8971a351a9ebd019de412212da021fd802e03f49f231d4e959c7352679f892f9d7f9748");
+    S2N_BLOB_FROM_HEX(client_random_in,
+            "537eefc1e720b311ff8483d057ae750a3667af9d5b496cc0d2edfb0dd309a286");
+    S2N_BLOB_FROM_HEX(server_random_in,
+            "537eefc29f337c5eedacd00a1889b031261701872d666a74fa999dc13bcd8821");
+    S2N_BLOB_FROM_HEX(master_secret_in,
+            "c8c610686237cd024a2d8e0391f61a8a4464c2c9576ea2b5ccf3af68139ec07c6a1720097063de968f2341f77b837120");
+
+    struct s2n_connection *conn = NULL;
 
     /* s2n_tls_prf_master_secret */
     {
@@ -60,44 +56,16 @@ int main(int argc, char **argv)
         /* Check the most common PRF */
         conn->actual_protocol_version = S2N_TLS11;
 
-        EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_string(&client_random_in, client_random_hex_in));
-        EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_string(&server_random_in, server_random_hex_in));
-        EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_string(&premaster_secret_in, premaster_secret_hex_in));
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.rsa_premaster_secret, premaster_secret_in.data, premaster_secret_in.size);
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.client_random, client_random_in.data, client_random_in.size);
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.server_random, server_random_in.data, server_random_in.size);
 
-        EXPECT_SUCCESS(s2n_stuffer_init(&master_secret_hex_out, &master_secret));
-
-        /* Parse the hex */
-        for (int i = 0; i < 48; i++) {
-            uint8_t c = 0;
-            EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&premaster_secret_in, &c));
-            conn->secrets.rsa_premaster_secret[i] = c;
-        }
-        for (int i = 0; i < 32; i++) {
-            uint8_t c = 0;
-            EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&client_random_in, &c));
-            conn->secrets.client_random[i] = c;
-        }
-        for (int i = 0; i < 32; i++) {
-            uint8_t c = 0;
-            EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&server_random_in, &c));
-            conn->secrets.server_random[i] = c;
-        }
-
-        pms.data = conn->secrets.rsa_premaster_secret;
-        pms.size = sizeof(conn->secrets.rsa_premaster_secret);
+        struct s2n_blob pms = {0};
+        EXPECT_SUCCESS(s2n_blob_init(&pms, conn->secrets.rsa_premaster_secret, sizeof(conn->secrets.rsa_premaster_secret)));
         EXPECT_SUCCESS(s2n_tls_prf_master_secret(conn, &pms));
-
-        /* Convert the master secret to hex */
-        for (int i = 0; i < 48; i++) {
-            EXPECT_SUCCESS(s2n_stuffer_write_uint8_hex(&master_secret_hex_out, conn->secrets.master_secret[i]));
-        }
-
-        EXPECT_EQUAL(memcmp(master_secret_hex_pad, master_secret_hex_in, sizeof(master_secret_hex_pad)), 0);
+        EXPECT_EQUAL(memcmp(conn->secrets.master_secret, master_secret_in.data, master_secret_in.size), 0);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
-        EXPECT_SUCCESS(s2n_stuffer_free(&client_random_in));
-        EXPECT_SUCCESS(s2n_stuffer_free(&server_random_in));
-        EXPECT_SUCCESS(s2n_stuffer_free(&premaster_secret_in));
     }
 
     /* s2n_tls_prf_extended_master_secret */
@@ -220,6 +188,35 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_config_free(config));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(tls12_chain_and_key));
+    }
+
+    /* Connection lifecyle */
+    {
+        struct s2n_blob pms = {0};
+        EXPECT_SUCCESS(s2n_blob_init(&pms, premaster_secret_in.data, premaster_secret_in.size));
+
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.rsa_premaster_secret, premaster_secret_in.data, premaster_secret_in.size);
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.client_random, client_random_in.data, client_random_in.size);
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.server_random, server_random_in.data, server_random_in.size);
+        EXPECT_SUCCESS(s2n_tls_prf_master_secret(conn, &pms));
+        EXPECT_EQUAL(memcmp(conn->secrets.master_secret, master_secret_in.data, master_secret_in.size), 0);
+
+        EXPECT_SUCCESS(s2n_connection_free_handshake(conn));
+        EXPECT_NULL(conn->prf_space);
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.rsa_premaster_secret, premaster_secret_in.data, premaster_secret_in.size);
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.client_random, client_random_in.data, client_random_in.size);
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.server_random, server_random_in.data, server_random_in.size);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls_prf_master_secret(conn, &pms), S2N_ERR_NULL);
+
+        EXPECT_SUCCESS(s2n_connection_wipe(conn));
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.rsa_premaster_secret, premaster_secret_in.data, premaster_secret_in.size);
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.client_random, client_random_in.data, client_random_in.size);
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.server_random, server_random_in.data, server_random_in.size);
+        EXPECT_SUCCESS(s2n_tls_prf_master_secret(conn, &pms));
+        EXPECT_EQUAL(memcmp(conn->secrets.master_secret, master_secret_in.data, master_secret_in.size), 0);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
     END_TEST();

--- a/tests/unit/s2n_tls_prf_test.c
+++ b/tests/unit/s2n_tls_prf_test.c
@@ -243,7 +243,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
-        /* PRF useable throughout connection lifecycle */
+        /* PRF usable throughout connection lifecycle */
         {
             struct s2n_blob pms = {0};
             EXPECT_SUCCESS(s2n_blob_init(&pms, premaster_secret_in.data, premaster_secret_in.size));

--- a/tests/unit/s2n_tls_prf_test.c
+++ b/tests/unit/s2n_tls_prf_test.c
@@ -207,17 +207,17 @@ int main(int argc, char **argv)
 
         /* Basic lifecyle */
         {
-            struct s2n_connection lconn = { 0 };
-            EXPECT_NULL(lconn.prf_space);
+            struct s2n_connection connection = { 0 };
+            EXPECT_NULL(connection.prf_space);
 
-            EXPECT_OK(s2n_prf_new(&lconn));
-            EXPECT_NOT_NULL(lconn.prf_space);
+            EXPECT_OK(s2n_prf_new(&connection));
+            EXPECT_NOT_NULL(connection.prf_space);
 
-            EXPECT_OK(s2n_prf_wipe(&lconn));
-            EXPECT_NOT_NULL(lconn.prf_space);
+            EXPECT_OK(s2n_prf_wipe(&connection));
+            EXPECT_NOT_NULL(connection.prf_space);
 
-            EXPECT_OK(s2n_prf_free(&lconn));
-            EXPECT_NULL(lconn.prf_space);
+            EXPECT_OK(s2n_prf_free(&connection));
+            EXPECT_NULL(connection.prf_space);
         }
 
         /* PRF freed by s2n_connection_free_handshake */

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -174,7 +174,7 @@ struct s2n_connection {
     struct s2n_psk_parameters psk_params;
 
     /* The PRF needs some storage elements to work with */
-    struct s2n_prf_working_space prf_space;
+    struct s2n_prf_working_space *prf_space;
 
     /* Whether to use client_cert_auth_type stored in s2n_config or in this s2n_connection.
      *

--- a/tls/s2n_connection_evp_digests.c
+++ b/tls/s2n_connection_evp_digests.c
@@ -31,19 +31,6 @@ int s2n_connection_save_prf_state(struct s2n_connection_prf_handles *prf_handles
 }
 
 /* On s2n_connection_wipe, save all pointers to OpenSSL EVP digest structs in a temporary
- * s2n_connection_hash_handles struct to avoid re-allocation after zeroing the connection struct.
- * Do not store any additional hash state as it is unnecessary and excessive copying would impact performance.
- */
-int s2n_connection_save_hash_state(struct s2n_connection_hash_handles *hash_handles, struct s2n_connection *conn)
-{
-    /* Preserve only the handlers for SSLv3 PRF hash state pointers to avoid re-allocation */
-    hash_handles->prf_md5 = conn->prf_space.ssl3.md5.digest.high_level;
-    hash_handles->prf_sha1 = conn->prf_space.ssl3.sha1.digest.high_level;
-
-    return 0;
-}
-
-/* On s2n_connection_wipe, save all pointers to OpenSSL EVP digest structs in a temporary
  * s2n_connection_hmac_handles struct to avoid re-allocation after zeroing the connection struct.
  * Do not store any additional HMAC state as it is unnecessary and excessive copying would impact performance.
  */
@@ -65,19 +52,6 @@ int s2n_connection_restore_prf_state(struct s2n_connection *conn, struct s2n_con
     /* Restore s2n_connection handlers for TLS PRF p_hash */
     POSIX_GUARD(s2n_hmac_restore_evp_hash_state(&prf_handles->p_hash_s2n_hmac, &conn->prf_space.tls.p_hash.s2n_hmac));
     conn->prf_space.tls.p_hash.evp_hmac = prf_handles->p_hash_evp_hmac;
-
-    return 0;
-}
-
-/* On s2n_connection_wipe, restore all pointers to OpenSSL EVP digest structs after zeroing the connection struct
- * to avoid re-allocation. Do not store any additional hash state as it is unnecessary and excessive copying
- * would impact performance.
- */
-int s2n_connection_restore_hash_state(struct s2n_connection *conn, struct s2n_connection_hash_handles *hash_handles)
-{
-    /* Restore s2n_connection handlers for SSLv3 PRF hash states */
-    conn->prf_space.ssl3.md5.digest.high_level = hash_handles->prf_md5;
-    conn->prf_space.ssl3.sha1.digest.high_level = hash_handles->prf_sha1;
 
     return 0;
 }

--- a/tls/s2n_connection_evp_digests.c
+++ b/tls/s2n_connection_evp_digests.c
@@ -18,19 +18,6 @@
 #include "utils/s2n_safety.h"
 
 /* On s2n_connection_wipe, save all pointers to OpenSSL EVP digest structs in a temporary
- * s2n_connection_prf_handles struct to avoid re-allocation after zeroing the connection struct.
- * Do not store any additional hash/HMAC state as it is unnecessary and excessive copying would impact performance.
- */
-int s2n_connection_save_prf_state(struct s2n_connection_prf_handles *prf_handles, struct s2n_connection *conn)
-{
-    /* Preserve only the handlers for TLS PRF p_hash pointers to avoid re-allocation */
-    POSIX_GUARD(s2n_hmac_save_evp_hash_state(&prf_handles->p_hash_s2n_hmac, &conn->prf_space.tls.p_hash.s2n_hmac));
-    prf_handles->p_hash_evp_hmac = conn->prf_space.tls.p_hash.evp_hmac;
-
-    return 0;
-}
-
-/* On s2n_connection_wipe, save all pointers to OpenSSL EVP digest structs in a temporary
  * s2n_connection_hmac_handles struct to avoid re-allocation after zeroing the connection struct.
  * Do not store any additional HMAC state as it is unnecessary and excessive copying would impact performance.
  */
@@ -40,19 +27,6 @@ int s2n_connection_save_hmac_state(struct s2n_connection_hmac_handles *hmac_hand
     POSIX_GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->initial_server, &conn->initial.server_record_mac));
     POSIX_GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->secure_client, &conn->secure.client_record_mac));
     POSIX_GUARD(s2n_hmac_save_evp_hash_state(&hmac_handles->secure_server, &conn->secure.server_record_mac));
-    return 0;
-}
-
-/* On s2n_connection_wipe, restore all pointers to OpenSSL EVP digest structs after zeroing the connection struct
- * to avoid re-allocation. Do not store any additional hash/HMAC state as it is unnecessary and excessive copying
- * would impact performance.
- */
-int s2n_connection_restore_prf_state(struct s2n_connection *conn, struct s2n_connection_prf_handles *prf_handles)
-{
-    /* Restore s2n_connection handlers for TLS PRF p_hash */
-    POSIX_GUARD(s2n_hmac_restore_evp_hash_state(&prf_handles->p_hash_s2n_hmac, &conn->prf_space.tls.p_hash.s2n_hmac));
-    conn->prf_space.tls.p_hash.evp_hmac = prf_handles->p_hash_evp_hmac;
-
     return 0;
 }
 

--- a/tls/s2n_connection_evp_digests.h
+++ b/tls/s2n_connection_evp_digests.h
@@ -20,14 +20,6 @@
 
 #include "crypto/s2n_hash.h"
 
-struct s2n_connection_prf_handles {
-    /* TLS PRF HMAC p_hash */
-    struct s2n_hmac_evp_backup p_hash_s2n_hmac;
-
-    /* TLS PRF EVP p_hash */
-    struct s2n_evp_hmac_state p_hash_evp_hmac;
-};
-
 /* Allocationg new EVP structs is expensive, so we back them up here and reuse them */
 struct s2n_connection_hmac_handles {
     struct s2n_hmac_evp_backup initial_client;
@@ -38,7 +30,5 @@ struct s2n_connection_hmac_handles {
     struct s2n_hmac_evp_backup secure_server;
 };
 
-extern int s2n_connection_save_prf_state(struct s2n_connection_prf_handles *prf_handles, struct s2n_connection *conn);
 extern int s2n_connection_save_hmac_state(struct s2n_connection_hmac_handles *hmac_handles, struct s2n_connection *conn);
-extern int s2n_connection_restore_prf_state(struct s2n_connection *conn, struct s2n_connection_prf_handles *prf_handles);
 extern int s2n_connection_restore_hmac_state(struct s2n_connection *conn, struct s2n_connection_hmac_handles *hmac_handles);

--- a/tls/s2n_connection_evp_digests.h
+++ b/tls/s2n_connection_evp_digests.h
@@ -28,14 +28,6 @@ struct s2n_connection_prf_handles {
     struct s2n_evp_hmac_state p_hash_evp_hmac;
 };
 
-struct s2n_connection_hash_handles {
-    /* Handshake hash states */
-    struct s2n_hash_evp_digest prf_md5;
-
-    /* SSLv3 PRF hash states */
-    struct s2n_hash_evp_digest prf_sha1;
-};
-
 /* Allocationg new EVP structs is expensive, so we back them up here and reuse them */
 struct s2n_connection_hmac_handles {
     struct s2n_hmac_evp_backup initial_client;
@@ -47,8 +39,6 @@ struct s2n_connection_hmac_handles {
 };
 
 extern int s2n_connection_save_prf_state(struct s2n_connection_prf_handles *prf_handles, struct s2n_connection *conn);
-extern int s2n_connection_save_hash_state(struct s2n_connection_hash_handles *hash_handles, struct s2n_connection *conn);
 extern int s2n_connection_save_hmac_state(struct s2n_connection_hmac_handles *hmac_handles, struct s2n_connection *conn);
 extern int s2n_connection_restore_prf_state(struct s2n_connection *conn, struct s2n_connection_prf_handles *prf_handles);
-extern int s2n_connection_restore_hash_state(struct s2n_connection *conn, struct s2n_connection_hash_handles *hash_handles);
 extern int s2n_connection_restore_hmac_state(struct s2n_connection *conn, struct s2n_connection_hmac_handles *hmac_handles);

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -364,10 +364,13 @@ S2N_RESULT s2n_prf_wipe(struct s2n_connection *conn)
 S2N_RESULT s2n_prf_free(struct s2n_connection *conn)
 {
     RESULT_ENSURE_REF(conn);
-    if (!conn->prf_space) {
+    if (conn->prf_space == NULL) {
         return S2N_RESULT_OK;
     }
 
+    /* cppcheck-suppress nullPointerRedundantCheck
+     * cppcheck doesn't recognize the early exit if conn->prf_space == NULL.
+     */
     conn->prf_space->p_hash_hmac_impl = s2n_get_hmac_implementation();
     RESULT_GUARD_POSIX(conn->prf_space->p_hash_hmac_impl->free(conn->prf_space));
 

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -350,7 +350,14 @@ S2N_RESULT s2n_prf_wipe(struct s2n_connection *conn)
 {
     RESULT_ENSURE_REF(conn);
     RESULT_ENSURE_REF(conn->prf_space);
-    RESULT_GUARD_POSIX(s2n_hmac_reset(&conn->prf_space->p_hash.s2n_hmac));
+
+    /* If we actually initialized s2n_hmac, wipe it.
+     * A valid, initialized s2n_hmac_state will have a valid block size.
+     */
+    if (conn->prf_space->p_hash.s2n_hmac.hash_block_size != 0) {
+        RESULT_GUARD_POSIX(s2n_hmac_reset(&conn->prf_space->p_hash.s2n_hmac));
+    }
+
     return S2N_RESULT_OK;
 }
 

--- a/tls/s2n_prf.h
+++ b/tls/s2n_prf.h
@@ -32,12 +32,10 @@ struct p_hash_state {
 };
 
 struct s2n_prf_working_space {
-    struct {
-        const struct s2n_p_hash_hmac *p_hash_hmac_impl;
-        struct p_hash_state p_hash;
-        uint8_t digest0[S2N_MAX_DIGEST_LEN];
-        uint8_t digest1[S2N_MAX_DIGEST_LEN];
-    } tls;
+    const struct s2n_p_hash_hmac *p_hash_hmac_impl;
+    struct p_hash_state p_hash;
+    uint8_t digest0[S2N_MAX_DIGEST_LEN];
+    uint8_t digest1[S2N_MAX_DIGEST_LEN];
 };
 
 /* The s2n p_hash implementation is abstracted to allow for separate implementations, using
@@ -54,8 +52,10 @@ struct s2n_p_hash_hmac {
 
 #include "tls/s2n_connection.h"
 
-extern int s2n_prf_new(struct s2n_connection *conn);
-extern int s2n_prf_free(struct s2n_connection *conn);
+S2N_RESULT s2n_prf_new(struct s2n_connection *conn);
+S2N_RESULT s2n_prf_wipe(struct s2n_connection *conn);
+S2N_RESULT s2n_prf_free(struct s2n_connection *conn);
+
 extern int s2n_tls_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret);
 extern int s2n_hybrid_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret);
 S2N_RESULT s2n_tls_prf_extended_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret, struct s2n_blob *session_hash);

--- a/tls/s2n_prf.h
+++ b/tls/s2n_prf.h
@@ -38,13 +38,6 @@ struct s2n_prf_working_space {
         uint8_t digest0[S2N_MAX_DIGEST_LEN];
         uint8_t digest1[S2N_MAX_DIGEST_LEN];
     } tls;
-
-    struct {
-        struct s2n_hash_state md5;
-        struct s2n_hash_state sha1;
-        uint8_t md5_digest[MD5_DIGEST_LENGTH];
-        uint8_t sha1_digest[SHA_DIGEST_LENGTH];
-    } ssl3;
 };
 
 /* The s2n p_hash implementation is abstracted to allow for separate implementations, using


### PR DESCRIPTION
### Description of changes: 

The connection is now <10kb! 🎉

This time I went after the memory in "prf_workspace", a structure that exists just to avoid allocating hashes / hmacs during the handshake. There are two parts to the structure, one only used by sslv3 and using hashes and one used by later tls versions using a custom hmac.

I removed the sslv3 part and substituted the shared temporary `hash_workspace` hash.

I moved the rest of the structure out of s2n_connection so that it could be freed after the handshake, like I did to the handshake hashes in https://github.com/aws/s2n-tls/pull/2987. Like in that PR, this also allowed me to simplify the s2n_connection_wipe logic to skip the save/restore logic for the prf.

### Call-outs:
**Why don't we reset p_hash on wipe?** We didn't in the previous save/restore logic, so I didn't add it there. `reset` is called on p_hash when the prf is used.

### Testing:
Unit tests pass. I rewrote s2n_tls_prf_test to use S2N_BLOB_FROM_HEX to avoid a manual hex conversion every time we interact with the test vectors, but I verified that the old test passes on the next code too.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
