### PR TITLE
Do not overwrite LibCrypto_LIBRARY if it's already specified

### DIFF
--- a/cmake/modules/FindLibCrypto.cmake
+++ b/cmake/modules/FindLibCrypto.cmake
@@ -59,12 +59,13 @@ else()
         ${CMAKE_INSTALL_PREFIX}/lib
         )
 
-    if (BUILD_SHARED_LIBS)
-        set(LibCrypto_LIBRARY ${LibCrypto_SHARED_LIBRARY})
-    else()
-        set(LibCrypto_LIBRARY ${LibCrypto_STATIC_LIBRARY})
+    if (NOT LibCrypto_LIBRARY)
+        if (BUILD_SHARED_LIBS)
+            set(LibCrypto_LIBRARY ${LibCrypto_SHARED_LIBRARY})
+        else()
+            set(LibCrypto_LIBRARY ${LibCrypto_STATIC_LIBRARY})
+        endif()
     endif()
-
 
     include(FindPackageHandleStandardArgs)
     find_package_handle_standard_args(LibCrypto DEFAULT_MSG


### PR DESCRIPTION
### Resolved issues:

Resolves ongoing issues in AWS Common Runtime packages trying to use system libcrypto from the openssl-devel or similar package.

### Description of changes: 

During builds, the FindLibCrypto.cmake script was indiscriminately re-writing `LibCrypto_LIBRARY`, while the default cmake behavior was leaving `LibCrypto_STATIC_LIBRARY` and `LibCrypto_SHARED_LIBRARY` untouched. This would result in the configure step declaring that it was unable to find libcrypto after logging that it did, in fact, find libcrypto.

### Testing:

 Tested by building a series of downstream AWS CRT libraries with and without OpenSSL/libcrypto support via `SEARCH_LIBCRYPTO` and by specifying `LibCrypto_*` variables

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
