### PR TITLE
Added support for sharing libcrypto (when embedded in another application/language)

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -77,6 +77,14 @@ extern int s2n_error_get_type(int error);
 struct s2n_config;
 struct s2n_connection;
 
+/**
+ * Prevents S2N from calling `OPENSSL_crypto_init`/`OPENSSL_cleanup`/`EVP_cleanup` on OpenSSL versions
+ * prior to 1.1.x. This allows applications or languages that also init OpenSSL to interoperate
+ * with S2N.
+ */
+S2N_API
+extern void s2n_crypto_disable_init(void);
+
 S2N_API
 extern unsigned long s2n_get_openssl_version(void);
 S2N_API

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -474,6 +474,21 @@ int s2n_init();
 before any other s2n-tls functions are called. Failure to call s2n_init() will result
 in errors from other s2n-tls functions.
 
+### s2n\_crypto\_disable\_init
+
+```c
+void s2n_crypto_disable_init();
+```
+
+**s2n_crypto_disable_init** prevents s2n-tls from initializing or tearing down the crypto
+library. This is most useful when s2n-tls is embedded in an application or environment that
+shares usage of the OpenSSL or libcrypto library. Note that if you disable this and are
+using a version of OpenSSL/libcrypto < 1.1.x, you will be responsible for library init
+and cleanup (specifically OPENSSL_add_all_algorithms() or OPENSSL_crypto_init), and
+`EVP_*` APIs will not be usable unless the library is initialized.
+
+This function must be called BEFORE `s2n_init()` to have any effect.
+
 ### s2n\_cleanup
 
 ```c


### PR DESCRIPTION
### Resolved issues:

Resolves a crash on exit experienced in the AWS SDK for PHP and AWS Common Runtime for PHP (aws-crt-php) due to the lack of idempotency on `OPENSSL_cleanup`, `EVP_cleanup` and `OPENSSL_init_crypto` in versions of OpenSSL prior to 1.1.0.

### Description of changes: 

Currently, s2n assumes that it is the only user of libcrypto, and so it initializes libcrypto via `OPENSSL_init_crypto`, and calls `EVP_cleanup`. This results in a crash in `OPENSSL_cleanup` called via `atexit()` handler as installed by libcrypto.

This change adds the `S2N_SHARE_LIBCRYPTO` environment variable, which prevents initialization or cleanup of OpenSSL crypto static state.

### Call-outs:

This does not affect AWS-LC, as AWS-LC's init/cleanup functions are idempotent.

### Testing:

* https://github.com/awslabs/aws-crt-php/pull/41
* https://github.com/awslabs/aws-crt-ffi/pull/35

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
