### PR TITLE
And test to verify unencrypted EncryptedExtensions rejected

### DIFF
--- a/tests/unit/s2n_encrypted_extensions_test.c
+++ b/tests/unit/s2n_encrypted_extensions_test.c
@@ -172,5 +172,74 @@ int main(int argc, char **argv)
         }
     }
 
+    /* Functional: Unencrypted EncryptedExtensions rejected */
+    {
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+
+        struct s2n_cert_chain_and_key *chain_and_key;
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+
+        struct s2n_config *config;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
+
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
+
+        /* Create IO stuffers */
+        DEFER_CLEANUP(struct s2n_stuffer client_to_server = { 0 }, s2n_stuffer_free);
+        DEFER_CLEANUP(struct s2n_stuffer server_to_client = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_to_server, 0));
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_to_client, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_to_client, &client_to_server, client_conn));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&client_to_server, &server_to_client, server_conn));
+
+        /* Do handshake up until EncryptedExtensions */
+        EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, ENCRYPTED_EXTENSIONS));
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), ENCRYPTED_EXTENSIONS);
+
+        /* Verify that the EncryptedExtension message would normally be encrypted */
+        EXPECT_EQUAL(server_conn->server, &server_conn->secure);
+
+        /* Force the server to disable encryption for the EncryptedExtensions message */
+        server_conn->server = &server_conn->initial;
+
+        /* Enable an extension to ensure the message is long enough to resemble an encrypted record.
+         * If the message is too short, we fail without even attempting decryption and this error
+         * is difficult to distinguish from other S2N_ERR_BAD_MESSAGE cases.
+         */
+        uint8_t long_alpn[] = "httttttttttttttttttttps";
+        EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(server_conn));
+        EXPECT_MEMCPY_SUCCESS(server_conn->application_protocol, long_alpn, sizeof(long_alpn));
+
+        /* Wipe any pending CCS messages. We don't need the complication. */
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&server_to_client));
+
+        /* Write unencrypted EncryptedExtensions message */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(server_conn), ENCRYPTED_EXTENSIONS);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(server_conn, &blocked), S2N_ERR_IO_BLOCKED);
+        EXPECT_NOT_EQUAL(s2n_conn_get_current_message_type(server_conn), ENCRYPTED_EXTENSIONS);
+
+        /* Client fails to parse the EncryptedExtensions */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), ENCRYPTED_EXTENSIONS);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(client_conn, &blocked), S2N_ERR_DECRYPT);
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(client_conn), ENCRYPTED_EXTENSIONS);
+
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
     END_TEST();
 }


### PR DESCRIPTION
### Resolved issues:

 https://github.com/aws/s2n-tls/issues/1685

### Description of changes: 

Add a test to ensure unencrypted EncryptedExtensions are not accepted by the client.

### Testing:

This is a test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
