### PR TITLE
Fix build issue with AWS Common Runtime SDK CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,15 @@ file(GLOB UTILS_SRC "utils/*.c")
 file(GLOB PQ_HEADERS "pq-crypto/*.h")
 file(GLOB PQ_SRC "pq-crypto/*.c")
 
+message(STATUS "Detected CMAKE_SYSTEM_PROCESSOR as ${CMAKE_SYSTEM_PROCESSOR}")
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+  message(STATUS "Detected 32-Bit system - disabling PQ crypto assembly optimizations")
+  set(S2N_NO_PQ_ASM ON)
+else()
+    message(STATUS "Detected 64-Bit system")
+endif()
+
 if(S2N_NO_PQ)
     # PQ is disabled, so we do not include any PQ crypto code
     message(STATUS "S2N_NO_PQ flag was detected - disabling PQ crypto")
@@ -328,7 +337,7 @@ if(BIKE_R3_X86_64_OPT_SUPPORTED)
 endif()
 
 if(KYBER512R3_AVX2_BMI2_OPT_SUPPORTED)
-    FILE(GLOB KYBER512R3_AVX2_BMI2_SRCS "pq-crypto/kyber_r3/*_avx2.c")
+    FILE(GLOB KYBER512R3_AVX2_BMI2_SRCS "pq-crypto/kyber_r3/*.c")
     set_source_files_properties(${KYBER512R3_AVX2_BMI2_SRCS} PROPERTIES COMPILE_FLAGS ${KYBER512R3_AVX2_BMI2_FLAGS})
     target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_KYBER512R3_AVX2_BMI2)
 


### PR DESCRIPTION
### Resolved issues:
Fixes two seperate issues uncovered by the AWS Common Runtime continuous integration tests: 
  - https://github.com/awslabs/aws-c-io/pull/413/checks?check_run_id=3302617117

## 1. Issue when compiling 32-bit x86 binaries
Kyber's Round 3 assembly optimizations are not able to access 64-bit only registers when compiled on 32 bit x86 CPU's. The fix for this issue is to disable PQ Assembly optimizations if being compiled for a 32-bit system. I believe `CMAKE_SIZEOF_VOID_P` is the correct mechanism to check, but I'm open to other suggestions for those with more CMake experience if it will not work when cross-compiling on 64-bit systems.

Build Error:
```
[ 37%] Building C object CMakeFiles/s2n.dir/pq-crypto/kyber_r2/verify.c.o
[ 37%] Building C object CMakeFiles/s2n.dir/pq-crypto/kyber_r3/KeccakP-1600-times4-SIMD256_avx2.c.o
[ 38%] Building ASM object CMakeFiles/s2n.dir/pq-crypto/kyber_r3/kyber512r3_basemul_avx2.S.o
/root/aws-c-io/build/deps/s2n/pq-crypto/kyber_r3/kyber512r3_basemul_avx2.S: Assembler messages:
/root/aws-c-io/build/deps/s2n/pq-crypto/kyber_r3/kyber512r3_basemul_avx2.S:88: Error: bad register name `%rsp'
/root/aws-c-io/build/deps/s2n/pq-crypto/kyber_r3/kyber512r3_basemul_avx2.S:89: Error: bad register name `%rsp'
/root/aws-c-io/build/deps/s2n/pq-crypto/kyber_r3/kyber512r3_basemul_avx2.S:90: Error: bad register name `%rsp'
/root/aws-c-io/build/deps/s2n/pq-crypto/kyber_r3/kyber512r3_basemul_avx2.S:92: Error: bad register name `%rcx)'
```

## 2. Unknown type name __m256i on systems known to support AVX2
Kyber makes a CMake `try_compile()` call [here](https://github.com/aws/s2n-tls/blob/40350a35d7333b8d3006dad0a5cfd41d3d0a7e78/CMakeLists.txt#L185-L189) to confirm that AVX2 is supported before turning this feature on, but later finds that one of the AVX2 types is missing in a header file. I believe the issue is that the AVX flags are only enabled for files that match  `/pq-crypto/kyber_r3/*_avx.c` and not all files in that directory since the failure seems to be for the file `/pq-crypto/kyber_r3/kyber512r3_kem.c` which doesn't have the `-mavx2` flag needed to enable the type in the `#include <immintrin.h>` call in `kyber512r3_align_avx2.h`. The fix for this issue to enable the AVX2 flags for all files in the Kyber Round 3 directory if AVX2 is supported instead of just a subset.

Build Error:
```
[ 41%] Building C object CMakeFiles/s2n.dir/pq-crypto/kyber_r3/kyber512r3_indcpa_avx2.c.o
[ 41%] Building ASM object CMakeFiles/s2n.dir/pq-crypto/kyber_r3/kyber512r3_invntt_avx2.S.o
[ 41%] Building C object CMakeFiles/s2n.dir/pq-crypto/kyber_r3/kyber512r3_kem.c.o
In file included from /root/aws-c-io/build/deps/s2n/pq-crypto/kyber_r3/kyber512r3_poly_avx2.h:4:0,
                 from /root/aws-c-io/build/deps/s2n/pq-crypto/kyber_r3/kyber512r3_polyvec_avx2.h:5,
                 from /root/aws-c-io/build/deps/s2n/pq-crypto/kyber_r3/kyber512r3_indcpa_avx2.h:5,
                 from /root/aws-c-io/build/deps/s2n/pq-crypto/kyber_r3/kyber512r3_kem.c:6:
/root/aws-c-io/build/deps/s2n/pq-crypto/kyber_r3/kyber512r3_align_avx2.h:15:11: error: unknown type name __m256i
     union {                     \
```

### Description of changes: 
Minor tweaks to s2n's CMake build to offer wider compatibility. 

### Call-outs:
~~I have only run these tests locally and am not 100% sure that it will fix the issue seen by the AWS CRT team.~~

The AWS Common Runtime has built this branch into [this commit](https://github.com/awslabs/aws-c-io/commit/4f9035e3cb3940c14e2f599058f136e54c9d05d2) and has [confirmed that these changes fix the issue that they are seeing](https://github.com/awslabs/aws-c-io/runs/3306172487)

### Testing:
Ran the CMake build locally on my 64-bit Ubuntu system. 
Test this commit in AWS Common Runtime's CI: https://github.com/awslabs/aws-c-io/runs/3306172487

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
