### PR TITLE
Fix behavior of signature scheme getters in TLS1.2

### DIFF
--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -340,7 +340,7 @@ int main(int argc, char **argv)
      * Check for both the server and client certificates, because they use different negotiation logic.
      */
     {
-        /* TlS1.3 */
+        /* TLS1.3 */
         {
             struct s2n_config *config = s2n_config_new();
             EXPECT_NOT_NULL(config);
@@ -373,7 +373,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_free(config));
         }
 
-        /* TlS1.2 */
+        /* TLS1.2 */
         {
             struct s2n_config *config = s2n_config_new();
             EXPECT_NOT_NULL(config);

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -35,12 +35,15 @@ int s2n_client_cert_verify_recv(struct s2n_connection *conn)
     POSIX_ENSURE_REF(conn->handshake.hashes);
 
     struct s2n_stuffer *in = &conn->handshake.io;
-    struct s2n_signature_scheme chosen_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
+    struct s2n_signature_scheme *chosen_sig_scheme = &conn->handshake_params.client_cert_sig_scheme;
 
-    if(conn->actual_protocol_version >= S2N_TLS12){
+    if (conn->actual_protocol_version < S2N_TLS12) {
+        *chosen_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
+    } else {
         /* Verify the SigScheme picked by the Client was in the preference list we sent (or is the default SigScheme) */
-        POSIX_GUARD(s2n_get_and_validate_negotiated_signature_scheme(conn, in, &chosen_sig_scheme));
+        POSIX_GUARD(s2n_get_and_validate_negotiated_signature_scheme(conn, in, chosen_sig_scheme));
     }
+
     uint16_t signature_size;
     struct s2n_blob signature = {0};
     POSIX_GUARD(s2n_stuffer_read_uint16(in, &signature_size));
@@ -50,11 +53,11 @@ int s2n_client_cert_verify_recv(struct s2n_connection *conn)
 
     /* Use a copy of the hash state since the verify digest computation may modify the running hash state we need later. */
     struct s2n_hash_state hash_state = {0};
-    POSIX_GUARD(s2n_handshake_get_hash_state(conn, chosen_sig_scheme.hash_alg, &hash_state));
+    POSIX_GUARD(s2n_handshake_get_hash_state(conn, chosen_sig_scheme->hash_alg, &hash_state));
     POSIX_GUARD(s2n_hash_copy(&conn->handshake.hashes->hash_workspace, &hash_state));
 
     /* Verify the signature */
-    POSIX_GUARD(s2n_pkey_verify(&conn->handshake_params.client_public_key, chosen_sig_scheme.sig_alg, &conn->handshake.hashes->hash_workspace, &signature));
+    POSIX_GUARD(s2n_pkey_verify(&conn->handshake_params.client_public_key, chosen_sig_scheme->sig_alg, &conn->handshake.hashes->hash_workspace, &signature));
 
     /* Client certificate has been verified. Minimize required handshake hash algs */
     POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));
@@ -70,19 +73,19 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
     S2N_ASYNC_PKEY_GUARD(conn);
     struct s2n_stuffer *out = &conn->handshake.io;
 
-    struct s2n_signature_scheme chosen_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
-
-    if (conn->actual_protocol_version >= S2N_TLS12) {
-        chosen_sig_scheme =  conn->handshake_params.client_cert_sig_scheme;
+    struct s2n_signature_scheme *chosen_sig_scheme = &conn->handshake_params.client_cert_sig_scheme;
+    if (conn->actual_protocol_version < S2N_TLS12) {
+        *chosen_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
+    } else {
         POSIX_GUARD(s2n_stuffer_write_uint16(out, conn->handshake_params.client_cert_sig_scheme.iana_value));
     }
 
     /* Use a copy of the hash state since the verify digest computation may modify the running hash state we need later. */
     struct s2n_hash_state hash_state = {0};
-    POSIX_GUARD(s2n_handshake_get_hash_state(conn, chosen_sig_scheme.hash_alg, &hash_state));
+    POSIX_GUARD(s2n_handshake_get_hash_state(conn, chosen_sig_scheme->hash_alg, &hash_state));
     POSIX_GUARD(s2n_hash_copy(&conn->handshake.hashes->hash_workspace, &hash_state));
 
-    S2N_ASYNC_PKEY_SIGN(conn, chosen_sig_scheme.sig_alg, &conn->handshake.hashes->hash_workspace, s2n_client_cert_verify_send_complete);
+    S2N_ASYNC_PKEY_SIGN(conn, chosen_sig_scheme->sig_alg, &conn->handshake.hashes->hash_workspace, s2n_client_cert_verify_send_complete);
 }
 
 static int s2n_client_cert_verify_send_complete(struct s2n_connection *conn, struct s2n_blob *signature)


### PR DESCRIPTION
### Resolved issues:

Necessary to address in order to unblock https://github.com/aws/s2n-tls/issues/1456

### Description of changes: 

The APIs added to examine the negotiated signature scheme for the asynchronous signing callback don't work for TLS1.2, because TLS1.2 is not consistent about recording the negotiated signature scheme. I updated the TLS1.2 logic to ensure that the signature scheme we end up using is the one recorded in `conn->handshake_params.conn_sig_scheme` / `conn->handshake_params.client_cert_sig_scheme`.

### Testing:

* Added a new functional test.
* I discovered this bug because I tried to use these APIs in s2nc/s2nd to make the signature algorithm integration test cleaner. The APIs printed the wrong hash, so the tests failed. After this fix, the tests passed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
