### PR TITLE
Move/Modify methods from s2nd to common.h/common.c

### DIFF
--- a/bin/common.c
+++ b/bin/common.c
@@ -27,9 +27,6 @@
 #include "utils/s2n_safety.h"
 #include <sys/stat.h>
 #include <sys/mman.h>
-
-
-
 uint8_t ticket_key_name[16] = "2016.07.26.15\0";
 
 uint8_t default_ticket_key[32] = {0x07, 0x77, 0x09, 0x36, 0x2c, 0x2e, 0x32, 0xdf, 0x0d, 0xdc,

--- a/bin/common.c
+++ b/bin/common.c
@@ -25,7 +25,6 @@
 #include <s2n.h>
 #include <error/s2n_errno.h>
 #include "utils/s2n_safety.h"
-
 #include <sys/stat.h>
 #include <sys/mman.h>
 

--- a/bin/common.c
+++ b/bin/common.c
@@ -17,12 +17,48 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <unistd.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <getopt.h>
 #include <errno.h>
 #include <s2n.h>
 #include <error/s2n_errno.h>
 #include "utils/s2n_safety.h"
+
+#include <sys/stat.h>
+#include <sys/mman.h>
+
+
+
+uint8_t ticket_key_name[16] = "2016.07.26.15\0";
+
+uint8_t default_ticket_key[32] = {0x07, 0x77, 0x09, 0x36, 0x2c, 0x2e, 0x32, 0xdf, 0x0d, 0xdc,
+                                  0x3f, 0x0d, 0xc4, 0x7b, 0xba, 0x63, 0x90, 0xb6, 0xc7, 0x3b,
+                                  0xb5, 0x0f, 0x9c, 0x31, 0x22, 0xec, 0x84, 0x4a, 0xd7, 0xc2,
+                                  0xb3, 0xe5 };
+
+struct session_cache_entry session_cache[256];
+
+static char dhparams[] =
+        "-----BEGIN DH PARAMETERS-----\n"
+        "MIIBCAKCAQEAy1+hVWCfNQoPB+NA733IVOONl8fCumiz9zdRRu1hzVa2yvGseUSq\n"
+        "Bbn6k0FQ7yMED6w5XWQKDC0z2m0FI/BPE3AjUfuPzEYGqTDf9zQZ2Lz4oAN90Sud\n"
+        "luOoEhYR99cEbCn0T4eBvEf9IUtczXUZ/wj7gzGbGG07dLfT+CmCRJxCjhrosenJ\n"
+        "gzucyS7jt1bobgU66JKkgMNm7hJY4/nhR5LWTCzZyzYQh2HM2Vk4K5ZqILpj/n0S\n"
+        "5JYTQ2PVhxP+Uu8+hICs/8VvM72DznjPZzufADipjC7CsQ4S6x/ecZluFtbb+ZTv\n"
+        "HI5CnYmkAwJ6+FSWGaZQDi8bgerFk9RWwwIBAg==\n"
+        "-----END DH PARAMETERS-----\n";
+
+/*
+ * Since this is a server, and the mechanism for hostname verification is not defined for this use-case,
+ * allow any hostname through. If you are writing something with mutual auth and you have a scheme for verifying
+ * the client (e.g. a reverse DNS lookup), you would plug that in here.
+ */
+static uint8_t unsafe_verify_host_fn(const char *host_name, size_t host_name_len, void *data)
+{
+    return 1;
+}
 
 char *load_file_to_cstring(const char *path)
 {
@@ -205,6 +241,107 @@ int s2n_setup_external_psk_list(struct s2n_connection *conn, char *psk_optarg_li
     return S2N_SUCCESS;
 }
 
+int s2n_config_settings(int max_early_data, struct s2n_config *config, struct conn_settings conn_settings, const char *cipher_prefs, const char *session_ticket_key_file_path) {
+    GUARD_EXIT(s2n_config_set_server_max_early_data_size(config, max_early_data), "Error setting max early data");
+
+    GUARD_EXIT(s2n_config_add_dhparams(config, dhparams), "Error adding DH parameters");
+
+    GUARD_EXIT(s2n_config_set_cipher_preferences(config, cipher_prefs),"Error setting cipher prefs");
+
+    GUARD_EXIT(s2n_config_set_cache_store_callback(config, cache_store_callback, session_cache), "Error setting cache store callback");
+
+    GUARD_EXIT(s2n_config_set_cache_retrieve_callback(config, cache_retrieve_callback, session_cache), "Error setting cache retrieve callback");
+
+    GUARD_EXIT(s2n_config_set_cache_delete_callback(config, cache_delete_callback, session_cache), "Error setting cache retrieve callback");
+
+    if (conn_settings.enable_mfl) {
+        GUARD_EXIT(s2n_config_accept_max_fragment_length(config), "Error enabling TLS maximum fragment length extension in server");
+    }
+
+    if (s2n_config_set_verify_host_callback(config, unsafe_verify_host_fn, NULL)) {
+        print_s2n_error("Failure to set hostname verification callback");
+        exit(1);
+    }
+
+    if (conn_settings.session_ticket) {
+        GUARD_EXIT(s2n_config_set_session_tickets_onoff(config, 1), "Error enabling session tickets");
+    }
+
+    if (conn_settings.session_cache) {
+        GUARD_EXIT(s2n_config_set_session_cache_onoff(config, 1), "Error enabling session cache using id");
+    }
+
+    if (conn_settings.session_ticket || conn_settings.session_cache) {
+        /* Key initialization */
+        uint8_t *st_key;
+        uint32_t st_key_length;
+
+        if (session_ticket_key_file_path) {
+            int fd = open(session_ticket_key_file_path, O_RDONLY);
+            GUARD_EXIT(fd, "Error opening session ticket key file");
+
+            struct stat st;
+            GUARD_EXIT(fstat(fd, &st), "Error fstat-ing session ticket key file");
+
+            st_key = mmap(0, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+            POSIX_ENSURE(st_key != MAP_FAILED, S2N_ERR_MMAP);
+
+            st_key_length = st.st_size;
+
+            close(fd);
+        } else {
+            st_key = default_ticket_key;
+            st_key_length = sizeof(default_ticket_key);
+        }
+
+        if (s2n_config_add_ticket_crypto_key(config, ticket_key_name, strlen((char*)ticket_key_name), st_key, st_key_length, 0) != 0) {
+            fprintf(stderr, "Error adding ticket key: '%s'\n", s2n_strerror(s2n_errno, "EN"));
+            exit(1);
+        }
+    }
+    return 0;
+}
+
+int setup_s2n_connection(struct s2n_connection *conn, int fd, struct s2n_config *config, struct conn_settings settings) {
+    if (settings.self_service_blinding) {
+        s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING);
+    }
+
+    if (settings.mutual_auth) {
+        GUARD_RETURN(s2n_config_set_client_auth_type(config, S2N_CERT_AUTH_REQUIRED), "Error setting client auth type");
+
+        if (settings.ca_dir || settings.ca_file) {
+            GUARD_RETURN(s2n_config_set_verification_ca_location(config, settings.ca_file, settings.ca_dir), "Error adding verify location");
+        }
+
+        if (settings.insecure) {
+            GUARD_RETURN(s2n_config_disable_x509_verification(config), "Error disabling X.509 validation");
+        }
+    }
+
+    GUARD_RETURN(s2n_connection_set_config(conn, config), "Error setting configuration");
+
+    if (settings.prefer_throughput) {
+        GUARD_RETURN(s2n_connection_prefer_throughput(conn), "Error setting prefer throughput");
+    }
+
+    if (settings.prefer_low_latency) {
+        GUARD_RETURN(s2n_connection_prefer_low_latency(conn), "Error setting prefer low latency");
+    }
+
+    GUARD_RETURN(s2n_connection_set_fd(conn, fd), "Error setting file descriptor");
+
+    if (settings.use_corked_io) {
+        GUARD_RETURN(s2n_connection_use_corked_io(conn), "Error setting corked io");
+    }
+
+    GUARD_RETURN(
+            s2n_setup_external_psk_list(conn, settings.psk_optarg_list, settings.psk_list_len),
+            "Error setting external psk list");
+
+    GUARD_RETURN(early_data_recv(conn), "Error receiving early data");
+    return 0;
+}
 
 int cache_store_callback(struct s2n_connection *conn, void *ctx, uint64_t ttl, const void *key, uint64_t key_size, const void *value, uint64_t value_size)
 {

--- a/bin/common.c
+++ b/bin/common.c
@@ -240,7 +240,7 @@ int s2n_setup_external_psk_list(struct s2n_connection *conn, char *psk_optarg_li
     return S2N_SUCCESS;
 }
 
-int s2n_config_settings(int max_early_data, struct s2n_config *config, struct conn_settings conn_settings, const char *cipher_prefs, const char *session_ticket_key_file_path) {
+int s2n_set_common_server_config(int max_early_data, struct s2n_config *config, struct conn_settings conn_settings, const char *cipher_prefs, const char *session_ticket_key_file_path) {
     GUARD_EXIT(s2n_config_set_server_max_early_data_size(config, max_early_data), "Error setting max early data");
 
     GUARD_EXIT(s2n_config_add_dhparams(config, dhparams), "Error adding DH parameters");
@@ -301,7 +301,7 @@ int s2n_config_settings(int max_early_data, struct s2n_config *config, struct co
     return 0;
 }
 
-int setup_s2n_connection(struct s2n_connection *conn, int fd, struct s2n_config *config, struct conn_settings settings) {
+int s2n_setup_server_connection(struct s2n_connection *conn, int fd, struct s2n_config *config, struct conn_settings settings) {
     if (settings.self_service_blinding) {
         s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING);
     }

--- a/bin/common.h
+++ b/bin/common.h
@@ -95,5 +95,5 @@ char *load_file_to_cstring(const char *path);
 int s2n_str_hex_to_bytes(const unsigned char *hex, uint8_t *out_bytes, uint32_t max_out_bytes_len);
 int s2n_setup_external_psk_list(struct s2n_connection *conn, char *psk_optarg_list[S2N_MAX_PSK_LIST_LENGTH], size_t psk_list_len);
 uint8_t unsafe_verify_host(const char *host_name, size_t host_name_len, void *data);
-int setup_s2n_connection(struct s2n_connection *conn, int fd, struct s2n_config *config, struct conn_settings settings);
-int s2n_config_settings(int max_early_data, struct s2n_config *config, struct conn_settings conn_settings, const char *cipher_prefs, const char *session_ticket_key_file_path);
+int s2n_setup_server_connection(struct s2n_connection *conn, int fd, struct s2n_config *config, struct conn_settings settings);
+int s2n_set_common_server_config(int max_early_data, struct s2n_config *config, struct conn_settings conn_settings, const char *cipher_prefs, const char *session_ticket_key_file_path);

--- a/bin/common.h
+++ b/bin/common.h
@@ -57,6 +57,26 @@ struct verify_data {
     const char *trusted_host;
 };
 
+struct conn_settings {
+    unsigned mutual_auth:1;
+    unsigned self_service_blinding:1;
+    unsigned only_negotiate:1;
+    unsigned prefer_throughput:1;
+    unsigned prefer_low_latency:1;
+    unsigned enable_mfl:1;
+    unsigned session_ticket:1;
+    unsigned session_cache:1;
+    unsigned insecure:1;
+    unsigned use_corked_io:1;
+    unsigned https_server:1;
+    uint32_t https_bench;
+    int max_conns;
+    const char *ca_dir;
+    const char *ca_file;
+    char *psk_optarg_list[S2N_MAX_PSK_LIST_LENGTH];
+    size_t psk_list_len;
+};
+
 void print_s2n_error(const char *app_error);
 int echo(struct s2n_connection *conn, int sockfd, bool *stop_echo);
 int wait_for_event(int fd, s2n_blocked_status blocked);
@@ -75,3 +95,5 @@ char *load_file_to_cstring(const char *path);
 int s2n_str_hex_to_bytes(const unsigned char *hex, uint8_t *out_bytes, uint32_t max_out_bytes_len);
 int s2n_setup_external_psk_list(struct s2n_connection *conn, char *psk_optarg_list[S2N_MAX_PSK_LIST_LENGTH], size_t psk_list_len);
 uint8_t unsafe_verify_host(const char *host_name, size_t host_name_len, void *data);
+int setup_s2n_connection(struct s2n_connection *conn, int fd, struct s2n_config *config, struct conn_settings settings);
+int s2n_config_settings(int max_early_data, struct s2n_config *config, struct conn_settings conn_settings, const char *cipher_prefs, const char *session_ticket_key_file_path);

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -120,34 +120,7 @@ static char default_private_key[] =
     "ggF9KQ0xWz7Km3GXv5+bwM5bcgt1A/s6sZCimXuj3Fle3RqOTF0="
     "-----END RSA PRIVATE KEY-----";
 
-static char dhparams[] =
-    "-----BEGIN DH PARAMETERS-----\n"
-    "MIIBCAKCAQEAy1+hVWCfNQoPB+NA733IVOONl8fCumiz9zdRRu1hzVa2yvGseUSq\n"
-    "Bbn6k0FQ7yMED6w5XWQKDC0z2m0FI/BPE3AjUfuPzEYGqTDf9zQZ2Lz4oAN90Sud\n"
-    "luOoEhYR99cEbCn0T4eBvEf9IUtczXUZ/wj7gzGbGG07dLfT+CmCRJxCjhrosenJ\n"
-    "gzucyS7jt1bobgU66JKkgMNm7hJY4/nhR5LWTCzZyzYQh2HM2Vk4K5ZqILpj/n0S\n"
-    "5JYTQ2PVhxP+Uu8+hICs/8VvM72DznjPZzufADipjC7CsQ4S6x/ecZluFtbb+ZTv\n"
-    "HI5CnYmkAwJ6+FSWGaZQDi8bgerFk9RWwwIBAg==\n"
-    "-----END DH PARAMETERS-----\n";
 
-uint8_t ticket_key_name[16] = "2016.07.26.15\0";
-
-uint8_t default_ticket_key[32] = {0x07, 0x77, 0x09, 0x36, 0x2c, 0x2e, 0x32, 0xdf, 0x0d, 0xdc,
-                                  0x3f, 0x0d, 0xc4, 0x7b, 0xba, 0x63, 0x90, 0xb6, 0xc7, 0x3b,
-                                  0xb5, 0x0f, 0x9c, 0x31, 0x22, 0xec, 0x84, 0x4a, 0xd7, 0xc2,
-                                  0xb3, 0xe5 };
-
-struct session_cache_entry session_cache[256];
-
-/*
- * Since this is a server, and the mechanism for hostname verification is not defined for this use-case,
- * allow any hostname through. If you are writing something with mutual auth and you have a scheme for verifying
- * the client (e.g. a reverse DNS lookup), you would plug that in here.
- */
-static uint8_t unsafe_verify_host_fn(const char *host_name, size_t host_name_len, void *data)
-{
-    return 1;
-}
 
 void usage()
 {
@@ -219,27 +192,6 @@ void usage()
     exit(1);
 }
 
-
-struct conn_settings {
-    unsigned mutual_auth:1;
-    unsigned self_service_blinding:1;
-    unsigned only_negotiate:1;
-    unsigned prefer_throughput:1;
-    unsigned prefer_low_latency:1;
-    unsigned enable_mfl:1;
-    unsigned session_ticket:1;
-    unsigned session_cache:1;
-    unsigned insecure:1;
-    unsigned use_corked_io:1;
-    unsigned https_server:1;
-    uint32_t https_bench;
-    int max_conns;
-    const char *ca_dir;
-    const char *ca_file;
-    char *psk_optarg_list[S2N_MAX_PSK_LIST_LENGTH];
-    size_t psk_list_len;
-};
-
 int handle_connection(int fd, struct s2n_config *config, struct conn_settings settings)
 {
     struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
@@ -248,43 +200,7 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
         S2N_ERROR_PRESERVE_ERRNO();
     }
 
-    if (settings.self_service_blinding) {
-        s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING);
-    }
-
-    if (settings.mutual_auth) {
-        GUARD_RETURN(s2n_config_set_client_auth_type(config, S2N_CERT_AUTH_REQUIRED), "Error setting client auth type");
-
-        if (settings.ca_dir || settings.ca_file) {
-            GUARD_RETURN(s2n_config_set_verification_ca_location(config, settings.ca_file, settings.ca_dir), "Error adding verify location");
-        }
-
-        if (settings.insecure) {
-            GUARD_RETURN(s2n_config_disable_x509_verification(config), "Error disabling X.509 validation");
-        }
-    }
-
-    GUARD_RETURN(s2n_connection_set_config(conn, config), "Error setting configuration");
-
-    if (settings.prefer_throughput) {
-        GUARD_RETURN(s2n_connection_prefer_throughput(conn), "Error setting prefer throughput");
-    }
-
-    if (settings.prefer_low_latency) {
-        GUARD_RETURN(s2n_connection_prefer_low_latency(conn), "Error setting prefer low latency");
-    }
-
-    GUARD_RETURN(s2n_connection_set_fd(conn, fd), "Error setting file descriptor");
-
-    if (settings.use_corked_io) {
-        GUARD_RETURN(s2n_connection_use_corked_io(conn), "Error setting corked io");
-    }
-
-    GUARD_RETURN(
-        s2n_setup_external_psk_list(conn, settings.psk_optarg_list, settings.psk_list_len),
-        "Error setting external psk list");
-
-    GUARD_RETURN(early_data_recv(conn), "Error receiving early data");
+    setup_s2n_connection(conn, fd, config, settings);
 
     if (negotiate(conn, fd) != S2N_SUCCESS) {
         if (settings.mutual_auth) {
@@ -640,63 +556,7 @@ int main(int argc, char *const *argv)
         close(fd);
     }
 
-    GUARD_EXIT(s2n_config_set_server_max_early_data_size(config, max_early_data), "Error setting max early data");
-
-    GUARD_EXIT(s2n_config_add_dhparams(config, dhparams), "Error adding DH parameters");
-
-    GUARD_EXIT(s2n_config_set_cipher_preferences(config, cipher_prefs),"Error setting cipher prefs");
-
-    GUARD_EXIT(s2n_config_set_cache_store_callback(config, cache_store_callback, session_cache), "Error setting cache store callback");
-
-    GUARD_EXIT(s2n_config_set_cache_retrieve_callback(config, cache_retrieve_callback, session_cache), "Error setting cache retrieve callback");
-
-    GUARD_EXIT(s2n_config_set_cache_delete_callback(config, cache_delete_callback, session_cache), "Error setting cache retrieve callback");
-
-    if (conn_settings.enable_mfl) {
-        GUARD_EXIT(s2n_config_accept_max_fragment_length(config), "Error enabling TLS maximum fragment length extension in server");
-    }
-
-    if (s2n_config_set_verify_host_callback(config, unsafe_verify_host_fn, NULL)) {
-        print_s2n_error("Failure to set hostname verification callback");
-        exit(1);
-    }
-
-    if (conn_settings.session_ticket) {
-        GUARD_EXIT(s2n_config_set_session_tickets_onoff(config, 1), "Error enabling session tickets");
-    }
-
-    if (conn_settings.session_cache) {
-        GUARD_EXIT(s2n_config_set_session_cache_onoff(config, 1), "Error enabling session cache using id");
-    }
-
-    if (conn_settings.session_ticket || conn_settings.session_cache) {
-        /* Key initialization */
-        uint8_t *st_key;
-        uint32_t st_key_length;
-
-        if (session_ticket_key_file_path) {
-            int fd = open(session_ticket_key_file_path, O_RDONLY);
-            GUARD_EXIT(fd, "Error opening session ticket key file");
-
-            struct stat st;
-            GUARD_EXIT(fstat(fd, &st), "Error fstat-ing session ticket key file");
-
-            st_key = mmap(0, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
-            POSIX_ENSURE(st_key != MAP_FAILED, S2N_ERR_MMAP);
-
-            st_key_length = st.st_size;
-
-            close(fd);
-        } else {
-            st_key = default_ticket_key;
-            st_key_length = sizeof(default_ticket_key);
-        }
-
-        if (s2n_config_add_ticket_crypto_key(config, ticket_key_name, strlen((char*)ticket_key_name), st_key, st_key_length, 0) != 0) {
-            fprintf(stderr, "Error adding ticket key: '%s'\n", s2n_strerror(s2n_errno, "EN"));
-            exit(1);
-        }
-    }
+    s2n_config_settings(max_early_data, config, conn_settings, cipher_prefs, session_ticket_key_file_path);
 
     if (parallelize) {
         struct sigaction sa;

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -200,7 +200,7 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
         S2N_ERROR_PRESERVE_ERRNO();
     }
 
-    setup_s2n_connection(conn, fd, config, settings);
+    s2n_setup_server_connection(conn, fd, config, settings);
 
     if (negotiate(conn, fd) != S2N_SUCCESS) {
         if (settings.mutual_auth) {
@@ -556,7 +556,7 @@ int main(int argc, char *const *argv)
         close(fd);
     }
 
-    s2n_config_settings(max_early_data, config, conn_settings, cipher_prefs, session_ticket_key_file_path);
+    s2n_set_common_server_config(max_early_data, config, conn_settings, cipher_prefs, session_ticket_key_file_path);
 
     if (parallelize) {
         struct sigaction sa;


### PR DESCRIPTION
### Resolved issues:

### Description of changes: 

Split up handle_connections and main to be used by others (split up into 2 methods: s2n_set_common_server_config() and s2n_setup_server_connection()

Moved shared variables to broader files

### Call-outs:

Methods in echo.c and common.c will be used in future benchmarks.

### Testing:

Manually tested by running the tools (s2nc/s2nd) and covered by integration tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
