### PR TITLE
Switch sigalg integ test to use s2n output instead of Openssl output

### DIFF
--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -18,7 +18,7 @@ from enum import Enum
 
 # Number of lines of output to stdout s2nc or s2nd are expected
 # to produce after a successful handshake
-NUM_EXPECTED_LINES_OUTPUT = 14
+NUM_EXPECTED_LINES_OUTPUT = 16
 
 class OCSP(Enum):
     ENABLED = 1

--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -18,7 +18,7 @@ from enum import Enum
 
 # Number of lines of output to stdout s2nc or s2nd are expected
 # to produce after a successful handshake
-NUM_EXPECTED_LINES_OUTPUT = 16
+NUM_EXPECTED_LINES_OUTPUT = 15
 
 class OCSP(Enum):
     ENABLED = 1

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -300,17 +300,16 @@ class KemGroups(object):
 
 
 class Signature(object):
-    def __init__(self, name, min_protocol=Protocols.SSLv3, sig_type=None, sig_digest=None):
+    def __init__(self, name, min_protocol=Protocols.SSLv3, max_protocol=Protocols.TLS13, sig_type=None, sig_digest=None):
         self.min_protocol = min_protocol
+        self.max_protocol = max_protocol
 
         if 'RSA' in name.upper():
             self.algorithm = 'RSA'
-        if 'PSS' in name.upper():
-            self.algorithm = 'RSAPSS'
         if 'EC' in name.upper() or 'ED' in name.upper():
             self.algorithm = 'EC'
 
-        if '+' in name:
+        if not (sig_type or sig_digest) and '+' in name:
             sig_type, sig_digest = name.split('+')
 
         self.name = name
@@ -323,28 +322,19 @@ class Signature(object):
 
 
 class Signatures(object):
-    RSA_SHA1 = Signature('RSA+SHA1')
-    RSA_SHA224 = Signature('RSA+SHA224')
-    RSA_SHA256 = Signature('RSA+SHA256')
-    RSA_SHA384 = Signature('RSA+SHA384')
-    RSA_SHA512 = Signature('RSA+SHA512')
+    RSA_SHA1   = Signature('RSA+SHA1',   max_protocol=Protocols.TLS12)
+    RSA_SHA224 = Signature('RSA+SHA224', max_protocol=Protocols.TLS12)
+    RSA_SHA256 = Signature('RSA+SHA256', max_protocol=Protocols.TLS12)
+    RSA_SHA384 = Signature('RSA+SHA384', max_protocol=Protocols.TLS12)
+    RSA_SHA512 = Signature('RSA+SHA512', max_protocol=Protocols.TLS12)
 
-    # Using rss_pss_pss_sha256 results in a signature not found error, but using
-    # this naming scheme seems to work.
-    RSA_PSS_SHA256 = Signature(
+    RSA_PSS_RSAE_SHA256 = Signature(
         'RSA-PSS+SHA256',
-        min_protocol=Protocols.TLS13,
-        sig_type='RSA-PSS',
+        sig_type='RSA-PSS-RSAE',
         sig_digest='SHA256')
 
     ECDSA_SECP256r1_SHA256 = Signature(
         'ecdsa_secp256r1_sha256',
-        min_protocol=Protocols.TLS13,
-        sig_type='ECDSA',
-        sig_digest='SHA256')
-
-    ED25519 = Signature(
-        'ed25519',
         min_protocol=Protocols.TLS13,
         sig_type='ECDSA',
         sig_digest='SHA256')

--- a/tests/integrationv2/test_signature_algorithms.py
+++ b/tests/integrationv2/test_signature_algorithms.py
@@ -26,16 +26,6 @@ all_sigs = [
     Signatures.RSA_PSS_RSAE_SHA256,
 ]
 
-# These ciphers don't print out the proper debugging information from s_client,
-# so we can't verify the signature algorithm used. When s2n provides the signature
-# algorithm to the client, we can enable these.
-unsupported_ciphers = [
-    Ciphers.AES128_SHA,
-    Ciphers.AES256_SHA,
-    Ciphers.AES128_SHA256,
-    Ciphers.AES256_SHA256,
-]
-
 
 def signature_marker(mode, signature):
     return to_bytes("{mode} signature negotiated: {type}+{digest}" \
@@ -58,9 +48,6 @@ def skip_ciphers(*args, **kwargs):
         return True
 
     if protocol < sigalg.min_protocol:
-        return True
-
-    if cipher in unsupported_ciphers:
         return True
 
     return invalid_test_parameters(*args, **kwargs)
@@ -151,8 +138,18 @@ def test_s2n_client_signature_algorithms(managed_process, cipher, provider, prot
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
+    # In versions before TLS1.3, the server uses the negotiated signature scheme for the
+    # ServerKeyExchange message. The server only sends the ServerKeyExchange message when using
+    # a key exchange method that provides forward secrecy, ie, NOT static RSA.
+    # So if using RSA key exchange, there is no actual "negotiated" signature scheme, because
+    # the server never sends the client a signature scheme.
+    #
+    # This mostly has to be inferred from the RFCs, but this blog post is a pretty good summary
+    # of the situation: https://timtaubert.de/blog/2016/07/the-evolution-of-signatures-in-tls/
+    server_sigalg_used = not cipher.iana_standard_name.startswith("TLS_RSA_WITH_")
+
     for results in client.get_results():
         results.assert_success()
         assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
-        assert signature_marker(Provider.ServerMode, signature) in results.stdout
+        assert signature_marker(Provider.ServerMode, signature) in results.stdout or not server_sigalg_used
         assert (signature_marker(Provider.ClientMode, signature) in results.stdout) == client_auth


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/1456

### Description of changes: 

Currently, S2N relies on debugging messages from OpenSSL to test signature negotiation. Those debugging messages aren't necessarily reliable, and using them limits us to only testing against OpenSSL.

Instead, we should log the relevant information from s2nc/s2nd and use that information in the tests.

I fixed a few other things:
* I updated the "RSA-PSS" signature in the tests to make it clear it is RSA-PSS-RSAE, not RSA-PSS-PSS, because I think that distinction was causing confusion. I also removed its minimum version, so it's now being used with TLS1.2 too.
* I removed the unsupported_ciphers list. Most of the ciphers on that list technically don't have negotiated signature schemes; see the very strange comment I added.
* I removed ED25519, since it wasn't used anywhere.
* I made `test_s2n_client_signature_algorithms` use the parameterized certificate. Not sure why it wasn't before, since the s2n_server version does.

### Testing:
Tests pass.

I also sanity checked what tests are actually run by grepping the output:
```
RSA-PSS used in TLS1.2 (previously not allowed by min version):
grep RSA-PSS out | grep TLS1.2 | wc -l
864

RSA-PSS used in TLS1.3:
grep RSA-PSS out | grep TLS1.3 | wc -l
144

ecdsa_secp256r1 used in TLS1.3 (previously "unsupported"):
grep ecdsa_secp256r1_sha256 out | grep TLS1.3 | wc -l
12

ecdsa_secp256r1 curve NOT used in TLS1.2 (TLS1.3-only scheme):
grep ecdsa_secp256r1_sha256 out | grep TLS1.2 | wc -l
0

AES128-SHA used (previously "unsupported"):
grep AES128-SHA out | wc -l
1728

PCKS1 RSA used in TLS1.2:
grep RSA+SHA256 out | grep TLS1.2 | wc -l
864

PCKS1 RSA NOT used in TLS1.3 (only RSA-PSS allowed):
grep RSA+SHA256 out | grep TLS1.3 | wc -l
0

RSA-PSS certificate not used yet (requires RSA-PSS-PSS):
grep RSA_PSS_2048_SHA256 out | wc -l
0
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
