### PR TITLE
Improved support for using s2n-tls from within an unloadable shared lib

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -85,6 +85,13 @@ struct s2n_connection;
 S2N_API
 extern void s2n_crypto_disable_init(void);
 
+/**
+ * Prevents S2N from installing an atexit handler, which allows safe shutdown of S2N from within a
+ * re-entrant shared library
+ */
+S2N_API
+extern void s2n_disable_atexit(void);
+
 S2N_API
 extern unsigned long s2n_get_openssl_version(void);
 S2N_API

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -83,14 +83,14 @@ struct s2n_connection;
  * with S2N.
  */
 S2N_API
-extern void s2n_crypto_disable_init(void);
+extern int s2n_crypto_disable_init(void);
 
 /**
  * Prevents S2N from installing an atexit handler, which allows safe shutdown of S2N from within a
  * re-entrant shared library
  */
 S2N_API
-extern void s2n_disable_atexit(void);
+extern int s2n_disable_atexit(void);
 
 S2N_API
 extern unsigned long s2n_get_openssl_version(void);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -477,7 +477,7 @@ in errors from other s2n-tls functions.
 ### s2n\_crypto\_disable\_init
 
 ```c
-void s2n_crypto_disable_init();
+int s2n_crypto_disable_init();
 ```
 
 **s2n_crypto_disable_init** prevents s2n-tls from initializing or tearing down the crypto
@@ -487,12 +487,13 @@ using a version of OpenSSL/libcrypto < 1.1.x, you will be responsible for librar
 and cleanup (specifically OPENSSL_add_all_algorithms() or OPENSSL_crypto_init), and
 `EVP_*` APIs will not be usable unless the library is initialized.
 
-This function must be called BEFORE `s2n_init()` to have any effect.
+This function must be called BEFORE `s2n_init()` to have any effect. It will return an error
+if s2n is already initialized.
 
 ### s2n\_disable\_atexit
 
 ```c
-void s2n_disable_atexit();
+int s2n_disable_atexit();
 ```
 
 **s2n_disable_atexit** prevents s2n-tls from installing an atexit() handler to clean itself
@@ -501,7 +502,8 @@ shares usage of the OpenSSL or libcrypto library. Note that this will cause `s2n
 do complete cleanup of s2n-tls when called from the main thread (the thread `s2n_init` was
 called from).
 
-This function must be called BEFORE `s2n_init()` to have any effect.
+This function must be called BEFORE `s2n_init()` to have any effect. It will return an error
+if s2n is already initialized.
 
 ### s2n\_cleanup
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -489,6 +489,20 @@ and cleanup (specifically OPENSSL_add_all_algorithms() or OPENSSL_crypto_init), 
 
 This function must be called BEFORE `s2n_init()` to have any effect.
 
+### s2n\_disable\_atexit
+
+```c
+void s2n_disable_atexit();
+```
+
+**s2n_disable_atexit** prevents s2n-tls from installing an atexit() handler to clean itself
+up. This is most useful when s2n-tls is embedded in an application or environment that
+shares usage of the OpenSSL or libcrypto library. Note that this will cause `s2n_cleanup` to
+do complete cleanup of s2n-tls when called from the main thread (the thread `s2n_init` was
+called from).
+
+This function must be called BEFORE `s2n_init()` to have any effect.
+
 ### s2n\_cleanup
 
 ```c

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -995,8 +995,11 @@ const struct s2n_cipher_preferences cipher_preferences_test_all_tls13 = {
 };
 
 static bool should_init_crypto = true;
-void s2n_crypto_disable_init(void) {
+static bool crypto_initialized = false;
+int s2n_crypto_disable_init(void) {
+    POSIX_ENSURE(!crypto_initialized, S2N_ERR_INITIALIZED);
     should_init_crypto = false;
+    return S2N_SUCCESS;
 }
 
 /* Determines cipher suite availability and selects record algorithms */
@@ -1051,7 +1054,9 @@ int s2n_cipher_suites_init(void)
 #endif
     }
 
-    return 0;
+    crypto_initialized = true;
+
+    return S2N_SUCCESS;
 }
 
 /* Reset any selected record algorithms */

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -24,6 +24,7 @@
 #include "utils/s2n_mem.h"
 #include "utils/s2n_random.h"
 #include "utils/s2n_safety.h"
+#include "utils/s2n_safety_macros.h"
 
 #include "openssl/opensslv.h"
 
@@ -38,12 +39,15 @@ unsigned long s2n_get_openssl_version(void)
     return OPENSSL_VERSION_NUMBER;
 }
 
-static bool atexit_cleanup = true;
-void s2n_disable_atexit(void) {
-    atexit_cleanup = false;
-}
-
 static pthread_t main_thread = 0;
+
+static bool atexit_cleanup = true;
+int s2n_disable_atexit(void) {
+    const bool already_initialized = (main_thread != 0);
+    POSIX_ENSURE(!already_initialized, S2N_ERR_INITIALIZED);
+    atexit_cleanup = false;
+    return S2N_SUCCESS;
+}
 
 int s2n_init(void)
 {
@@ -65,7 +69,7 @@ int s2n_init(void)
         s2n_stack_traces_enabled_set(true);
     }
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static bool s2n_cleanup_atexit_impl(void)

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -86,7 +86,7 @@ int s2n_cleanup(void)
      * so ensure that whatever clean ups we have here are thread safe */
     POSIX_GUARD_RESULT(s2n_rand_cleanup_thread());
 
-    /* If this is the main thread and atexit cleanup is unavailable,
+    /* If this is the main thread and atexit cleanup is disabled,
      * perform final cleanup now */
     if (pthread_self() == main_thread && !atexit_cleanup) {
         POSIX_ENSURE(s2n_cleanup_atexit_impl(), S2N_ERR_ATEXIT);

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -29,6 +29,8 @@
 
 #include "pq-crypto/s2n_pq.h"
 
+#include <pthread.h>
+
 static void s2n_cleanup_atexit(void);
 
 unsigned long s2n_get_openssl_version(void)
@@ -36,8 +38,16 @@ unsigned long s2n_get_openssl_version(void)
     return OPENSSL_VERSION_NUMBER;
 }
 
+static bool atexit_cleanup = true;
+void s2n_disable_atexit(void) {
+    atexit_cleanup = false;
+}
+
+static pthread_t main_thread = 0;
+
 int s2n_init(void)
 {
+    main_thread = pthread_self();
     POSIX_GUARD(s2n_fips_init());
     POSIX_GUARD(s2n_mem_init());
     POSIX_GUARD_RESULT(s2n_rand_init());
@@ -47,20 +57,14 @@ int s2n_init(void)
     POSIX_GUARD(s2n_extension_type_init());
     POSIX_GUARD_RESULT(s2n_pq_init());
 
-    POSIX_ENSURE_OK(atexit(s2n_cleanup_atexit), S2N_ERR_ATEXIT);
+    if (atexit_cleanup) {
+        POSIX_ENSURE_OK(atexit(s2n_cleanup_atexit), S2N_ERR_ATEXIT);
+    }
 
     if (getenv("S2N_PRINT_STACKTRACE")) {
         s2n_stack_traces_enabled_set(true);
     }
 
-    return 0;
-}
-
-int s2n_cleanup(void)
-{
-    /* s2n_cleanup is supposed to be called from each thread before exiting,
-     * so ensure that whatever clean ups we have here are thread safe */
-    POSIX_GUARD_RESULT(s2n_rand_cleanup_thread());
     return 0;
 }
 
@@ -76,8 +80,21 @@ static bool s2n_cleanup_atexit_impl(void)
     return a && b && c;
 }
 
+int s2n_cleanup(void)
+{
+    /* s2n_cleanup is supposed to be called from each thread before exiting,
+     * so ensure that whatever clean ups we have here are thread safe */
+    POSIX_GUARD_RESULT(s2n_rand_cleanup_thread());
+
+    /* If this is the main thread and atexit cleanup is unavailable,
+     * perform final cleanup now */
+    if (pthread_self() == main_thread && !atexit_cleanup) {
+        POSIX_ENSURE(s2n_cleanup_atexit_impl(), S2N_ERR_ATEXIT);
+    }
+    return 0;
+}
+
 static void s2n_cleanup_atexit(void)
 {
     s2n_cleanup_atexit_impl();
 }
-

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -415,6 +415,8 @@ S2N_RESULT s2n_rand_cleanup(void)
         ENGINE_finish(rand_engine);
         ENGINE_free(rand_engine);
         ENGINE_cleanup();
+        RAND_set_rand_engine(NULL);
+        RAND_set_rand_method(NULL);
     }
 #endif
 


### PR DESCRIPTION
### Resolved issues:

Resolves crash on exit in Java and PHP when using s2n-tls via the AWS CRT.

### Description of changes: 

Currently, s2n uses an `atexit()` handler to clean itself up. This is a guaranteed crash when s2n-tls is embedded in a shared library that can be unloaded.

A call to `s2n_disable_atexit()` prevents s2n from installing the `atexit()` handler, and adjusts `s2n_cleanup()` so that it will perform final cleanup when called from the main thread (defined as the thread `s2n_init()` was called from).

Additionally, after cleaning up its ENGINE/rand implementation, s2n now sets the libcrypto RAND engine and method to NULL, preventing a crash on shutdown as libcrypto tries to free the already freed (and in the case of a shared library, unloaded) ENGINE implementation.

### Call-outs:

It may be advantageous to create a single API call to prepare s2n for use in an embedded/modular/plugin environment. That is something we could address in a follow-up, once this is working in target environments. The original draft of the prior change proposed an `s2n_share_libcrypto()` API, something singular feels like a good move for users.

### Testing:

* https://github.com/awslabs/aws-crt-ffi/pull/35
* https://github.com/awslabs/aws-crt-php/pull/41

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
