### PR TITLE
Create 20210816 security policies

### DIFF
--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -1611,4 +1611,28 @@ const struct s2n_cipher_preferences cipher_preferences_kms_fips_tls_1_2_2018_10 
     .suites = cipher_suites_kms_fips_tls_1_2_2018_10,
 };
 
+struct s2n_cipher_suite *cipher_suites_20210816[] = {
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_20210816 = {
+    .count = s2n_array_len(cipher_suites_20210816),
+    .suites = cipher_suites_20210816,
+};
+
+struct s2n_cipher_suite *cipher_suites_20210816_gcm[] = {
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_20210816_gcm = {
+    .count = s2n_array_len(cipher_suites_20210816_gcm),
+    .suites = cipher_suites_20210816_gcm,
+};
+
 /* clang-format on */

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -46,6 +46,8 @@ extern const struct s2n_cipher_preferences cipher_preferences_20190801;
 extern const struct s2n_cipher_preferences cipher_preferences_20190120;
 extern const struct s2n_cipher_preferences cipher_preferences_20190121;
 extern const struct s2n_cipher_preferences cipher_preferences_20190122;
+extern const struct s2n_cipher_preferences cipher_preferences_20210816;
+extern const struct s2n_cipher_preferences cipher_preferences_20210816_gcm;
 extern const struct s2n_cipher_preferences cipher_preferences_test_all;
 
 extern const struct s2n_cipher_preferences cipher_preferences_test_all_tls12;

--- a/tls/s2n_ecc_preferences.c
+++ b/tls/s2n_ecc_preferences.c
@@ -39,6 +39,10 @@ const struct s2n_ecc_named_curve *const s2n_ecc_pref_list_20201021[] = {
     &s2n_ecc_curve_secp521r1,
 };
 
+const struct s2n_ecc_named_curve *const s2n_ecc_pref_list_20210816[] = {
+    &s2n_ecc_curve_secp384r1,
+};
+
 const struct s2n_ecc_named_curve *const s2n_ecc_pref_list_test_all[] = {
 #if EVP_APIS_SUPPORTED
     &s2n_ecc_curve_x25519,
@@ -61,6 +65,11 @@ const struct s2n_ecc_preferences s2n_ecc_preferences_20200310 = {
 const struct s2n_ecc_preferences s2n_ecc_preferences_20201021 = {
         .count = s2n_array_len(s2n_ecc_pref_list_20201021),
         .ecc_curves = s2n_ecc_pref_list_20201021,
+};
+
+const struct s2n_ecc_preferences s2n_ecc_preferences_20210816 = {
+        .count = s2n_array_len(s2n_ecc_pref_list_20210816),
+        .ecc_curves = s2n_ecc_pref_list_20210816,
 };
 
 const struct s2n_ecc_preferences s2n_ecc_preferences_test_all = {

--- a/tls/s2n_ecc_preferences.h
+++ b/tls/s2n_ecc_preferences.h
@@ -28,6 +28,7 @@ struct s2n_ecc_preferences {
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_20140601;
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_20200310;
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_20201021;
+extern const struct s2n_ecc_preferences s2n_ecc_preferences_20210816;
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_test_all;
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_null;
 

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -619,7 +619,7 @@ const struct s2n_security_policy security_policy_20201021 = {
     .ecc_preferences = &s2n_ecc_preferences_20201021,
 };
 
-const struct s2n_security_policy security_policy_minvertls2_2021_08 = {
+const struct s2n_security_policy security_policy_20210816 = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_20210816,
     .kem_preferences = &kem_preferences_null,
@@ -627,7 +627,7 @@ const struct s2n_security_policy security_policy_minvertls2_2021_08 = {
     .ecc_preferences = &s2n_ecc_preferences_20210816,
 };
 
-const struct s2n_security_policy security_policy_minvertls2_2021_08_gcm = {
+const struct s2n_security_policy security_policy_20210816_gcm = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_20210816_gcm,
     .kem_preferences = &kem_preferences_null,
@@ -780,8 +780,8 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version="20190802", .security_policy=&security_policy_20190802, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="20200207", .security_policy=&security_policy_test_all_tls13, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="20201021", .security_policy=&security_policy_20201021, .ecc_extension_required=0, .pq_kem_extension_required=0 },
-    { .version="20210816", .security_policy=&security_policy_minvertls2_2021_08, .ecc_extension_required=0, .pq_kem_extension_required=0 },
-    { .version="20210816_GCM", .security_policy=&security_policy_minvertls2_2021_08_gcm, .ecc_extension_required=0, .pq_kem_extension_required=0 },
+    { .version="20210816", .security_policy=&security_policy_20210816, .ecc_extension_required=0, .pq_kem_extension_required=0 },
+    { .version="20210816_GCM", .security_policy=&security_policy_20210816_gcm, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="test_all", .security_policy=&security_policy_test_all, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="test_all_fips", .security_policy=&security_policy_test_all_fips, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="test_all_ecdsa", .security_policy=&security_policy_test_all_ecdsa, .ecc_extension_required=0, .pq_kem_extension_required=0 },

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -619,6 +619,22 @@ const struct s2n_security_policy security_policy_20201021 = {
     .ecc_preferences = &s2n_ecc_preferences_20201021,
 };
 
+const struct s2n_security_policy security_policy_minvertls2_2021_08 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_20210816,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20210816,
+    .ecc_preferences = &s2n_ecc_preferences_20210816,
+};
+
+const struct s2n_security_policy security_policy_minvertls2_2021_08_gcm = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_20210816_gcm,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20210816,
+    .ecc_preferences = &s2n_ecc_preferences_20210816,
+};
+
 const struct s2n_security_policy security_policy_test_all = {
     .minimum_protocol_version = S2N_SSLv3,
     .cipher_preferences = &cipher_preferences_test_all,
@@ -764,6 +780,8 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version="20190802", .security_policy=&security_policy_20190802, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="20200207", .security_policy=&security_policy_test_all_tls13, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="20201021", .security_policy=&security_policy_20201021, .ecc_extension_required=0, .pq_kem_extension_required=0 },
+    { .version="20210816", .security_policy=&security_policy_minvertls2_2021_08, .ecc_extension_required=0, .pq_kem_extension_required=0 },
+    { .version="20210816_GCM", .security_policy=&security_policy_minvertls2_2021_08_gcm, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="test_all", .security_policy=&security_policy_test_all, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="test_all_fips", .security_policy=&security_policy_test_all_fips, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="test_all_ecdsa", .security_policy=&security_policy_test_all_ecdsa, .ecc_extension_required=0, .pq_kem_extension_required=0 },

--- a/tls/s2n_signature_scheme.c
+++ b/tls/s2n_signature_scheme.c
@@ -348,7 +348,6 @@ const struct s2n_signature_scheme* const s2n_sig_scheme_pref_list_20210816[] = {
 
         /* ECDSA - TLS 1.2 */
         &s2n_ecdsa_sha384, /* same iana value as TLS 1.3 s2n_ecdsa_secp384r1_sha384 */
-        &s2n_ecdsa_secp384r1_sha384,
         &s2n_ecdsa_sha512,
 };
 

--- a/tls/s2n_signature_scheme.c
+++ b/tls/s2n_signature_scheme.c
@@ -339,3 +339,20 @@ const struct s2n_signature_preferences s2n_certificate_signature_preferences_202
     .count = s2n_array_len(s2n_sig_scheme_pref_list_20201110),
     .signature_schemes = s2n_sig_scheme_pref_list_20201110,
 };
+
+/* Based on s2n_sig_scheme_pref_list_20140601 but with all hashes < SHA-384 removed */
+const struct s2n_signature_scheme* const s2n_sig_scheme_pref_list_20210816[] = {
+        /* RSA PKCS1 */
+        &s2n_rsa_pkcs1_sha384,
+        &s2n_rsa_pkcs1_sha512,
+
+        /* ECDSA - TLS 1.2 */
+        &s2n_ecdsa_sha384, /* same iana value as TLS 1.3 s2n_ecdsa_secp384r1_sha384 */
+        &s2n_ecdsa_secp384r1_sha384,
+        &s2n_ecdsa_sha512,
+};
+
+const struct s2n_signature_preferences s2n_signature_preferences_20210816 = {
+    .count = s2n_array_len(s2n_sig_scheme_pref_list_20210816),
+    .signature_schemes = s2n_sig_scheme_pref_list_20210816
+};

--- a/tls/s2n_signature_scheme.h
+++ b/tls/s2n_signature_scheme.h
@@ -76,6 +76,7 @@ extern const struct s2n_signature_scheme s2n_rsa_pss_rsae_sha512;
 extern const struct s2n_signature_preferences s2n_signature_preferences_20140601;
 extern const struct s2n_signature_preferences s2n_signature_preferences_20200207;
 extern const struct s2n_signature_preferences s2n_signature_preferences_20201021;
+extern const struct s2n_signature_preferences s2n_signature_preferences_20210816;
 extern const struct s2n_signature_preferences s2n_signature_preferences_null;
 
 extern const struct s2n_signature_preferences s2n_certificate_signature_preferences_20201110;


### PR DESCRIPTION
### Description of changes: 

Adds new security policies that require a minimum protocol of TLS 1.2 and a minimum cipher of AES-256.

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Existing tests

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
