### PR TITLE
Extra EMS Requirements

### DIFF
--- a/tests/unit/s2n_ems_extension_test.c
+++ b/tests/unit/s2n_ems_extension_test.c
@@ -93,14 +93,18 @@ int main(int argc, char **argv)
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
         EXPECT_NOT_NULL(conn);
 
+        /* In the default case we should always be sending this extension */
         EXPECT_TRUE(s2n_client_ems_extension.should_send(conn));
 
         uint8_t test_ticket[] = "test data";
         EXPECT_SUCCESS(s2n_realloc(&conn->client_ticket, sizeof(test_ticket)));
         conn->ems_negotiated = true;
+        /* If we have set a ticket on the connection we only send this extension
+         * if the previous session negotiated EMS. */
         EXPECT_TRUE(s2n_client_ems_extension.should_send(conn));
 
-        /* Don't send this extension if the previous session did not negotiate EMS */
+        /* Don't send this extension if we have set a ticket on the connection
+         * and the previous session did not negotiate EMS */
         conn->ems_negotiated = false;
         EXPECT_FALSE(s2n_client_ems_extension.should_send(conn));
 

--- a/tls/extensions/s2n_client_ems.c
+++ b/tls/extensions/s2n_client_ems.c
@@ -57,7 +57,7 @@ static bool s2n_client_ems_should_send(struct s2n_connection *conn)
     /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
     /* Don't send this extension if the previous session did not negotiate EMS */
     if ((conn->client_ticket.size > 0 && !conn->ems_negotiated) || !s2n_in_unit_test()) {
-            return false;
+        return false;
     } else {
         return true;
     }

--- a/tls/extensions/s2n_client_ems.c
+++ b/tls/extensions/s2n_client_ems.c
@@ -54,8 +54,11 @@ static int s2n_client_ems_recv(struct s2n_connection *conn, struct s2n_stuffer *
 
 static bool s2n_client_ems_should_send(struct s2n_connection *conn)
 {
-    /* TODO: https://github.com/aws/s2n-tls/issues/2990 
-     * We gate on the unit tests because the feature
-     * isn't complete and will mess up our integ tests. */
-    return conn && s2n_in_unit_test();
+    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
+    /* Don't send this extension if the previous session did not negotiate EMS */
+    if ((conn->client_ticket.size > 0 && !conn->ems_negotiated) || !s2n_in_unit_test()) {
+            return false;
+    } else {
+        return true;
+    }
 }

--- a/tls/extensions/s2n_extension_type.c
+++ b/tls/extensions/s2n_extension_type.c
@@ -135,7 +135,20 @@ int s2n_extension_recv(const s2n_extension_type *extension_type, struct s2n_conn
     s2n_extension_type_id extension_id;
     POSIX_GUARD(s2n_extension_supported_iana_value_to_id(extension_type->iana_value, &extension_id));
 
-    /* Do not accept a response if we did not send a request */
+    /**
+     *= https://tools.ietf.org/rfc/rfc8446#section-4.2
+     *
+     *# Implementations MUST NOT send extension responses if the remote
+     *# endpoint did not send the corresponding extension requests, with the
+     *# exception of the "cookie" extension in the HelloRetryRequest.  Upon
+     *# receiving such an extension, an endpoint MUST abort the handshake
+     *# with an "unsupported_extension" alert.
+     *
+     *= https://tools.ietf.org/rfc/rfc7627#section-5.3
+     *# If the original session did not use the "extended_master_secret"
+     *# extension but the new ServerHello contains the extension, the
+     *# client MUST abort the handshake.
+     **/
     if (extension_type->is_response &&
             !S2N_CBIT_TEST(conn->extension_requests_sent, extension_id)) {
         POSIX_BAIL(S2N_ERR_UNSUPPORTED_EXTENSION);

--- a/tls/extensions/s2n_extension_type.c
+++ b/tls/extensions/s2n_extension_type.c
@@ -137,7 +137,6 @@ int s2n_extension_recv(const s2n_extension_type *extension_type, struct s2n_conn
 
     /**
      *= https://tools.ietf.org/rfc/rfc8446#section-4.2
-     *
      *# Implementations MUST NOT send extension responses if the remote
      *# endpoint did not send the corresponding extension requests, with the
      *# exception of the "cookie" extension in the HelloRetryRequest.  Upon


### PR DESCRIPTION
### Resolved issues:

 resolves #2955
### Description of changes: 
The RFC calls out some checks that should be done on the client-side when receiving the EMS extension. This PR implements those.
Specifically:

>   If a client receives a ServerHello that accepts an abbreviated
   handshake, it behaves as follows:

>    If the original session did not use the "extended_master_secret"
      extension but the new ServerHello contains the extension, the
      client MUST abort the handshake.

>    If the original session used the extension but the new ServerHello
      does not contain the extension, the client MUST abort the
      handshake.

Note that the first requirement is handled by our [extension processing code](https://github.com/aws/s2n-tls/blob/main/tls/extensions/s2n_extension_type.c#L139) and therefore doesn't need a compliance comment or testing.
### Testing:

Unit tests

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
