### PR TITLE
Fix pre-TLS1.2 ECDSA client certs

### DIFF
--- a/tests/integrationv2/test_client_authentication.py
+++ b/tests/integrationv2/test_client_authentication.py
@@ -46,9 +46,6 @@ def assert_s2n_handshake_complete(results, protocol, provider, is_complete=True)
 def test_client_auth_with_s2n_server(managed_process, cipher, provider, protocol, certificate, client_certificate):
     port = next(available_ports)
 
-    if protocol < Protocols.TLS12 and client_certificate.algorithm == 'EC':
-        pytest.xfail("Client auth with ECDSA certs is currently broken for versions < TLS1.2")
-
     random_bytes = data_bytes(64)
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
@@ -95,9 +92,6 @@ def test_client_auth_with_s2n_server(managed_process, cipher, provider, protocol
 @pytest.mark.parametrize("client_certificate", CERTS_TO_TEST, ids=get_parameter_name)
 def test_client_auth_with_s2n_server_using_nonmatching_certs(managed_process, cipher, provider, protocol, certificate, client_certificate):
     port = next(available_ports)
-
-    if protocol < Protocols.TLS12 and client_certificate.algorithm == 'EC':
-        pytest.xfail("Client auth with ECDSA certs is current broken for versions < TLS1.2")
 
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
@@ -195,9 +189,6 @@ def test_client_auth_with_s2n_client_no_cert(managed_process, cipher, protocol, 
 @pytest.mark.parametrize("client_certificate", CERTS_TO_TEST, ids=get_parameter_name)
 def test_client_auth_with_s2n_client_with_cert(managed_process, cipher, protocol, provider, certificate, client_certificate):
     port = next(available_ports)
-
-    if protocol < Protocols.TLS12 and client_certificate.algorithm == 'EC':
-        pytest.xfail("Client auth with ECDSA certs is currently broken for versions < TLS1.2")
 
     random_bytes = data_bytes(64)
     client_options = ProviderOptions(

--- a/tests/unit/s2n_signature_algorithms_test.c
+++ b/tests/unit/s2n_signature_algorithms_test.c
@@ -49,7 +49,6 @@ const struct s2n_signature_preferences test_preferences = {
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
-    EXPECT_SUCCESS(s2n_disable_tls13());
 
     struct s2n_cert_chain_and_key *rsa_cert_chain;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&rsa_cert_chain,
@@ -189,7 +188,7 @@ int main(int argc, char **argv)
     {
         struct s2n_config *config = s2n_config_new();
 
-        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
         s2n_connection_set_config(conn, config);
 
         const struct s2n_security_policy *security_policy = NULL;
@@ -316,47 +315,165 @@ int main(int argc, char **argv)
 
     /* s2n_choose_default_sig_scheme */
     {
-        struct s2n_config *config = s2n_config_new();
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, rsa_cert_chain));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, ecdsa_cert_chain));
+        /* This method is used by both the client and server to choose default schemes
+         * for both themselves and for their peers, so it needs to behave the same regardless
+         * of the connection mode.
+         */
+        s2n_mode modes[] = { S2N_CLIENT, S2N_SERVER };
+        for (size_t i = 0; i < s2n_array_len(modes); i++) {
+            struct s2n_config *config = s2n_config_new();
+            struct s2n_connection *conn = s2n_connection_new(modes[i]);
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
-        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            const struct s2n_security_policy *security_policy = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
+            EXPECT_NOT_NULL(security_policy);
 
-        const struct s2n_security_policy *security_policy = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
-        EXPECT_NOT_NULL(security_policy);
+            struct s2n_security_policy test_security_policy = {
+                .minimum_protocol_version = security_policy->minimum_protocol_version,
+                .cipher_preferences = security_policy->cipher_preferences,
+                .kem_preferences = security_policy->kem_preferences,
+                .signature_preferences = &test_preferences,
+                .ecc_preferences = security_policy->ecc_preferences,
+            };
 
-        struct s2n_security_policy test_security_policy = {
-            .minimum_protocol_version = security_policy->minimum_protocol_version,
-            .cipher_preferences = security_policy->cipher_preferences,
-            .kem_preferences = security_policy->kem_preferences,
-            .signature_preferences = &test_preferences,
-            .ecc_preferences = security_policy->ecc_preferences,
-        };
+            config->security_policy = &test_security_policy;
 
-        config->security_policy = &test_security_policy;
+            struct s2n_signature_scheme result = { 0 };
 
-        struct s2n_signature_scheme result;
+            /*
+             * For pre-TLS1.2, always choose either RSA or ECDSA depending on the auth method.
+             * Only use RSA-SHA1 if forced to by FIPS.
+             */
+            {
+                conn->actual_protocol_version = S2N_TLS10;
+                struct s2n_signature_scheme s2n_default_rsa = (s2n_is_in_fips_mode()) ? s2n_rsa_pkcs1_sha1 : s2n_rsa_pkcs1_md5_sha1;
 
-        conn->secure.cipher_suite = RSA_CIPHER_SUITE;
-        conn->actual_protocol_version = S2N_TLS10;
-        struct s2n_signature_scheme expected = (s2n_is_in_fips_mode()) ? s2n_rsa_pkcs1_sha1 : s2n_rsa_pkcs1_md5_sha1;
-        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result));
-        EXPECT_EQUAL(result.iana_value, expected.iana_value);
+                /* For the server signature, the auth method must match the cipher suite. */
+                {
+                    /* Choose RSA for an RSA cipher suite. */
+                    {
+                        conn->secure.cipher_suite = RSA_CIPHER_SUITE;
+                        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result, S2N_SERVER));
+                        EXPECT_EQUAL(result.iana_value, s2n_default_rsa.iana_value);
+                    }
 
-        conn->secure.cipher_suite = ECDSA_CIPHER_SUITE;
-        conn->actual_protocol_version = S2N_TLS10;
-        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result));
-        EXPECT_EQUAL(result.iana_value, s2n_ecdsa_sha1.iana_value);
+                    /* Choose ECDSA for a ECDSA cipher suite. */
+                    {
+                        conn->secure.cipher_suite = ECDSA_CIPHER_SUITE;
+                        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result, S2N_SERVER));
+                        EXPECT_EQUAL(result.iana_value, s2n_ecdsa_sha1.iana_value);
+                    }
 
-        conn->secure.cipher_suite = RSA_CIPHER_SUITE;
-        conn->actual_protocol_version = S2N_TLS12;
-        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result));
-        EXPECT_EQUAL(result.iana_value, s2n_rsa_pkcs1_sha1.iana_value);
+                    /* Ignore the type of the client certificate. */
+                    {
+                        conn->secure.cipher_suite = ECDSA_CIPHER_SUITE;
+                        conn->handshake_params.client_cert_pkey_type = S2N_PKEY_TYPE_RSA;
+                        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result, S2N_SERVER));
+                        EXPECT_EQUAL(result.iana_value, s2n_ecdsa_sha1.iana_value);
+                    }
 
-        s2n_connection_free(conn);
-        s2n_config_free(config);
+                    /* When in doubt, choose RSA. */
+                    {
+                        conn->secure.cipher_suite = TLS13_CIPHER_SUITE;
+                        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result, S2N_SERVER));
+                        EXPECT_EQUAL(result.iana_value, s2n_default_rsa.iana_value);
+                    }
+                }
+
+                /* For the client signature, the auth type must match the type of the client certificate */
+                {
+                    /* Choose RSA for an RSA certificate */
+                    {
+                        conn->handshake_params.client_cert_pkey_type = S2N_PKEY_TYPE_RSA;
+                        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result, S2N_CLIENT));
+                        EXPECT_EQUAL(result.iana_value, s2n_default_rsa.iana_value);
+                    }
+
+                    /* Choose ECDSA for a ECDSA certificate */
+                    {
+                        conn->handshake_params.client_cert_pkey_type = S2N_PKEY_TYPE_ECDSA;
+                        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result, S2N_CLIENT));
+                        EXPECT_EQUAL(result.iana_value, s2n_ecdsa_sha1.iana_value);
+                    }
+
+                    /* Ignore the auth type of the cipher suite */
+                    {
+                        conn->secure.cipher_suite = RSA_CIPHER_SUITE;
+                        conn->handshake_params.client_cert_pkey_type = S2N_PKEY_TYPE_ECDSA;
+                        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result, S2N_CLIENT));
+                        EXPECT_EQUAL(result.iana_value, s2n_ecdsa_sha1.iana_value);
+                    }
+                }
+            }
+
+            /*
+             * For TLS1.2, always choose either RSA-SHA1 or ECDSA depending on the auth method.
+             */
+            {
+                conn->actual_protocol_version = S2N_TLS12;
+
+                /* For the server signature, the auth method must match the cipher suite. */
+                {
+                    /* Choose RSA for an RSA cipher suite. */
+                    {
+                        conn->secure.cipher_suite = RSA_CIPHER_SUITE;
+                        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result, S2N_SERVER));
+                        EXPECT_EQUAL(result.iana_value, s2n_rsa_pkcs1_sha1.iana_value);
+                    }
+
+                    /* Choose ECDSA for a ECDSA cipher suite. */
+                    {
+                        conn->secure.cipher_suite = ECDSA_CIPHER_SUITE;
+                        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result, S2N_SERVER));
+                        EXPECT_EQUAL(result.iana_value, s2n_ecdsa_sha1.iana_value);
+                    }
+
+                    /* Ignore the type of the client certificate. */
+                    {
+                        conn->secure.cipher_suite = ECDSA_CIPHER_SUITE;
+                        conn->handshake_params.client_cert_pkey_type = S2N_PKEY_TYPE_RSA;
+                        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result, S2N_SERVER));
+                        EXPECT_EQUAL(result.iana_value, s2n_ecdsa_sha1.iana_value);
+                    }
+
+                    /* When in doubt, choose RSA. */
+                    {
+                        conn->secure.cipher_suite = TLS13_CIPHER_SUITE;
+                        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result, S2N_SERVER));
+                        EXPECT_EQUAL(result.iana_value, s2n_rsa_pkcs1_sha1.iana_value);
+                    }
+                }
+
+                /* For the client signature, the auth type must match the type of the client certificate */
+                {
+                    /* Choose RSA for an RSA certificate */
+                    {
+                        conn->handshake_params.client_cert_pkey_type = S2N_PKEY_TYPE_RSA;
+                        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result, S2N_CLIENT));
+                        EXPECT_EQUAL(result.iana_value, s2n_rsa_pkcs1_sha1.iana_value);
+                    }
+
+                    /* Choose ECDSA for a ECDSA certificate */
+                    {
+                        conn->handshake_params.client_cert_pkey_type = S2N_PKEY_TYPE_ECDSA;
+                        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result, S2N_CLIENT));
+                        EXPECT_EQUAL(result.iana_value, s2n_ecdsa_sha1.iana_value);
+                    }
+
+                    /* Ignore the auth type of the cipher suite */
+                    {
+                        conn->secure.cipher_suite = RSA_CIPHER_SUITE;
+                        conn->handshake_params.client_cert_pkey_type = S2N_PKEY_TYPE_ECDSA;
+                        EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result, S2N_CLIENT));
+                        EXPECT_EQUAL(result.iana_value, s2n_ecdsa_sha1.iana_value);
+                    }
+                }
+            }
+
+            s2n_connection_free(conn);
+            s2n_config_free(config);
+        }
     }
 
     /* s2n_choose_sig_scheme_from_peer_preference_list */
@@ -445,7 +562,7 @@ int main(int argc, char **argv)
              * with the peer, then calling s2n_choose_sig_scheme_from_peer_preference_list
              * is equivalent to calling s2n_choose_default_sig_scheme. */
             struct s2n_signature_scheme default_scheme;
-            EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &default_scheme));
+            EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &default_scheme, S2N_SERVER));
             EXPECT_EQUAL(result.iana_value, default_scheme.iana_value);
         }
 

--- a/tests/unit/s2n_signature_algorithms_test.c
+++ b/tests/unit/s2n_signature_algorithms_test.c
@@ -49,6 +49,7 @@ const struct s2n_signature_preferences test_preferences = {
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
+    EXPECT_SUCCESS(s2n_disable_tls13());
 
     struct s2n_cert_chain_and_key *rsa_cert_chain;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&rsa_cert_chain,
@@ -188,7 +189,7 @@ int main(int argc, char **argv)
     {
         struct s2n_config *config = s2n_config_new();
 
-        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
         s2n_connection_set_config(conn, config);
 
         const struct s2n_security_policy *security_policy = NULL;

--- a/tests/unit/s2n_signature_algorithms_test.c
+++ b/tests/unit/s2n_signature_algorithms_test.c
@@ -387,7 +387,7 @@ int main(int argc, char **argv)
                     {
                         conn->handshake_params.client_cert_pkey_type = S2N_PKEY_TYPE_RSA;
                         EXPECT_SUCCESS(s2n_choose_default_sig_scheme(conn, &result, S2N_CLIENT));
-                        EXPECT_EQUAL(result.iana_value, s2n_default_rsa.iana_value);
+                        EXPECT_EQUAL(result.iana_value, s2n_rsa_pkcs1_md5_sha1.iana_value);
                     }
 
                     /* Choose ECDSA for a ECDSA certificate */

--- a/tls/s2n_auth_selection.c
+++ b/tls/s2n_auth_selection.c
@@ -40,7 +40,7 @@
  * TLS1.2 cipher suites.
  */
 
-static int s2n_get_auth_method_for_cert_type(s2n_pkey_type cert_type, s2n_authentication_method *auth_method)
+int s2n_get_auth_method_for_cert_type(s2n_pkey_type cert_type, s2n_authentication_method *auth_method)
 {
     switch(cert_type) {
         case S2N_PKEY_TYPE_RSA:

--- a/tls/s2n_auth_selection.h
+++ b/tls/s2n_auth_selection.h
@@ -20,6 +20,7 @@
 #include "crypto/s2n_certificate.h"
 #include "crypto/s2n_signature.h"
 
+int s2n_get_auth_method_for_cert_type(s2n_pkey_type cert_type, s2n_authentication_method *auth_method);
 int s2n_is_cipher_suite_valid_for_auth(struct s2n_connection *conn, struct s2n_cipher_suite *cipher_suite);
 int s2n_is_sig_scheme_valid_for_auth(struct s2n_connection *conn, const struct s2n_signature_scheme *sig_scheme);
 int s2n_is_cert_type_valid_for_auth(struct s2n_connection *conn, s2n_pkey_type cert_type);

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -38,7 +38,7 @@ int s2n_client_cert_verify_recv(struct s2n_connection *conn)
     struct s2n_signature_scheme *chosen_sig_scheme = &conn->handshake_params.client_cert_sig_scheme;
 
     if (conn->actual_protocol_version < S2N_TLS12) {
-        *chosen_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
+        POSIX_GUARD(s2n_choose_default_sig_scheme(conn, chosen_sig_scheme, S2N_CLIENT));
     } else {
         /* Verify the SigScheme picked by the Client was in the preference list we sent (or is the default SigScheme) */
         POSIX_GUARD(s2n_get_and_validate_negotiated_signature_scheme(conn, in, chosen_sig_scheme));
@@ -75,7 +75,7 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
 
     struct s2n_signature_scheme *chosen_sig_scheme = &conn->handshake_params.client_cert_sig_scheme;
     if (conn->actual_protocol_version < S2N_TLS12) {
-        *chosen_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
+        POSIX_GUARD(s2n_choose_default_sig_scheme(conn, chosen_sig_scheme, S2N_CLIENT));
     } else {
         POSIX_GUARD(s2n_stuffer_write_uint16(out, conn->handshake_params.client_cert_sig_scheme.iana_value));
     }

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -497,7 +497,7 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
     POSIX_GUARD(s2n_conn_find_name_matching_certs(conn));
 
     POSIX_GUARD(s2n_set_cipher_as_sslv2_server(conn, client_hello->cipher_suites.data, client_hello->cipher_suites.size / S2N_SSLv2_CIPHER_SUITE_LEN));
-    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &conn->handshake_params.conn_sig_scheme));
+    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &conn->handshake_params.conn_sig_scheme, S2N_SERVER));
     POSIX_GUARD(s2n_select_certs_for_server_auth(conn, &conn->handshake_params.our_chain_and_key));
 
     S2N_ERROR_IF(session_id_length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -45,6 +45,8 @@
 
 #define S2N_TLS_PROTOCOL_VERSION_LEN    2
 
+#define S2N_PEER_MODE(our_mode) ((our_mode + 1) % 2)
+
 #define is_handshake_complete(conn) (APPLICATION_DATA == s2n_conn_get_current_message_type(conn))
 
 typedef enum {

--- a/tls/s2n_server_cert_request.c
+++ b/tls/s2n_server_cert_request.c
@@ -60,19 +60,6 @@ static uint8_t s2n_cert_type_preference_list_legacy_dss[] = {
     S2N_CERT_TYPE_ECDSA_SIGN
 };
 
-static int s2n_cert_type_to_pkey_type(s2n_cert_type cert_type_in, s2n_pkey_type *pkey_type_out) {
-    switch(cert_type_in) {
-        case S2N_CERT_TYPE_RSA_SIGN:
-            *pkey_type_out = S2N_PKEY_TYPE_RSA;
-            return 0;
-        case S2N_CERT_TYPE_ECDSA_SIGN:
-            *pkey_type_out = S2N_PKEY_TYPE_ECDSA;
-            return 0;
-        default:
-            POSIX_BAIL(S2N_CERT_ERR_TYPE_UNSUPPORTED);
-    }
-}
-
 static int s2n_recv_client_cert_preferences(struct s2n_stuffer *in, s2n_cert_type *chosen_cert_type_out)
 {
     uint8_t cert_types_len;
@@ -103,6 +90,7 @@ static int s2n_set_cert_chain_as_client(struct s2n_connection *conn)
         struct s2n_cert_chain_and_key *cert = s2n_config_get_single_default_cert(conn->config);
         POSIX_ENSURE_REF(cert);
         conn->handshake_params.our_chain_and_key = cert;
+        conn->handshake_params.client_cert_pkey_type = s2n_cert_chain_and_key_get_pkey_type(cert);
     }
 
     return 0;
@@ -131,7 +119,6 @@ int s2n_cert_req_recv(struct s2n_connection *conn)
 
     s2n_cert_type cert_type = 0;
     POSIX_GUARD(s2n_recv_client_cert_preferences(in, &cert_type));
-    POSIX_GUARD(s2n_cert_type_to_pkey_type(cert_type, &conn->handshake_params.client_cert_pkey_type));
 
     if (conn->actual_protocol_version == S2N_TLS12) {
         POSIX_GUARD(s2n_recv_supported_sig_scheme_list(in, &conn->handshake_params.server_sig_hash_algs));

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -206,7 +206,7 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
     }
 
     /* Choose a default signature scheme */
-    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &conn->handshake_params.conn_sig_scheme));
+    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &conn->handshake_params.conn_sig_scheme, S2N_SERVER));
 
     /* Update the required hashes for this connection */
     POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -149,8 +149,9 @@ int s2n_get_and_validate_negotiated_signature_scheme(struct s2n_connection *conn
     /* We require an exact match in TLS 1.3, but all previous versions can fall back to the default SignatureScheme.
      * This means that an s2n client will accept the default SignatureScheme from a TLS server, even if the client did
      * not send it in it's ClientHello. This pre-TLS1.3 behavior is an intentional choice to maximize support. */
-    struct s2n_signature_scheme default_scheme;
-    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &default_scheme));
+    s2n_mode peer_mode = (conn->mode + 1) % 2;
+    struct s2n_signature_scheme default_scheme = { 0 };
+    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &default_scheme, peer_mode));
 
     if ((conn->actual_protocol_version <= S2N_TLS12)
             && (s2n_signature_scheme_valid_to_accept(conn, &default_scheme) == S2N_SUCCESS)
@@ -163,13 +164,18 @@ int s2n_get_and_validate_negotiated_signature_scheme(struct s2n_connection *conn
     POSIX_BAIL(S2N_ERR_INVALID_SIGNATURE_SCHEME);
 }
 
-int s2n_choose_default_sig_scheme(struct s2n_connection *conn, struct s2n_signature_scheme *sig_scheme_out)
+int s2n_choose_default_sig_scheme(struct s2n_connection *conn, struct s2n_signature_scheme *sig_scheme_out, s2n_mode signer)
 {
     POSIX_ENSURE_REF(conn);
-    POSIX_ENSURE_REF(conn->secure.cipher_suite);
     POSIX_ENSURE_REF(sig_scheme_out);
 
-    s2n_authentication_method cipher_suite_auth_method = conn->secure.cipher_suite->auth_method;
+    s2n_authentication_method auth_method = 0;
+    if (signer == S2N_CLIENT) {
+        POSIX_GUARD(s2n_get_auth_method_for_cert_type(conn->handshake_params.client_cert_pkey_type, &auth_method));
+    } else {
+        POSIX_ENSURE_REF(conn->secure.cipher_suite);
+        auth_method = conn->secure.cipher_suite->auth_method;
+    }
 
     /* Default our signature digest algorithms. For TLS 1.2 this default is different and may be
      * overridden by the signature_algorithms extension. If the server chooses an ECDHE_ECDSA
@@ -177,7 +183,7 @@ int s2n_choose_default_sig_scheme(struct s2n_connection *conn, struct s2n_signat
      */
     *sig_scheme_out = s2n_rsa_pkcs1_md5_sha1;
 
-    if (cipher_suite_auth_method == S2N_AUTHENTICATION_ECDSA) {
+    if (auth_method == S2N_AUTHENTICATION_ECDSA) {
         *sig_scheme_out = s2n_ecdsa_sha1;
     }
 
@@ -196,10 +202,9 @@ int s2n_choose_sig_scheme_from_peer_preference_list(struct s2n_connection *conn,
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(sig_scheme_out);
 
-    struct s2n_signature_scheme chosen_scheme;
-
+    struct s2n_signature_scheme chosen_scheme = { 0 };
     if (conn->actual_protocol_version < S2N_TLS13) {
-        POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &chosen_scheme));
+        POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &chosen_scheme, conn->mode));
     } else {
         /* Pick a default signature algorithm in TLS 1.3 https://tools.ietf.org/html/rfc8446#section-4.4.2.2 */
         POSIX_GUARD(s2n_tls13_default_sig_scheme(conn, &chosen_scheme));
@@ -212,7 +217,6 @@ int s2n_choose_sig_scheme_from_peer_preference_list(struct s2n_connection *conn,
     }
 
     *sig_scheme_out = chosen_scheme;
-
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -149,9 +149,8 @@ int s2n_get_and_validate_negotiated_signature_scheme(struct s2n_connection *conn
     /* We require an exact match in TLS 1.3, but all previous versions can fall back to the default SignatureScheme.
      * This means that an s2n client will accept the default SignatureScheme from a TLS server, even if the client did
      * not send it in it's ClientHello. This pre-TLS1.3 behavior is an intentional choice to maximize support. */
-    s2n_mode peer_mode = (conn->mode + 1) % 2;
     struct s2n_signature_scheme default_scheme = { 0 };
-    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &default_scheme, peer_mode));
+    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &default_scheme, S2N_PEER_MODE(conn->mode)));
 
     if ((conn->actual_protocol_version <= S2N_TLS12)
             && (s2n_signature_scheme_valid_to_accept(conn, &default_scheme) == S2N_SUCCESS)

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -185,11 +185,9 @@ int s2n_choose_default_sig_scheme(struct s2n_connection *conn, struct s2n_signat
 
     if (auth_method == S2N_AUTHENTICATION_ECDSA) {
         *sig_scheme_out = s2n_ecdsa_sha1;
-    }
-
-    /* Default RSA Hash Algorithm is SHA1 (instead of MD5_SHA1) if TLS 1.2 or FIPS mode */
-    if ((conn->actual_protocol_version >= S2N_TLS12 || s2n_is_in_fips_mode())
-            && (sig_scheme_out->sig_alg == S2N_SIGNATURE_RSA)) {
+    } else if (conn->actual_protocol_version >= S2N_TLS12) {
+        *sig_scheme_out = s2n_rsa_pkcs1_sha1;
+    } else if (s2n_is_in_fips_mode() && signer == S2N_SERVER) {
         *sig_scheme_out = s2n_rsa_pkcs1_sha1;
     }
 

--- a/tls/s2n_signature_algorithms.h
+++ b/tls/s2n_signature_algorithms.h
@@ -29,7 +29,7 @@ struct s2n_sig_scheme_list {
     uint8_t len;
 };
 
-int s2n_choose_default_sig_scheme(struct s2n_connection *conn, struct s2n_signature_scheme *sig_scheme_out);
+int s2n_choose_default_sig_scheme(struct s2n_connection *conn, struct s2n_signature_scheme *sig_scheme_out, s2n_mode signer);
 int s2n_choose_sig_scheme_from_peer_preference_list(struct s2n_connection *conn, struct s2n_sig_scheme_list *sig_hash_algs,
                                                             struct s2n_signature_scheme *sig_scheme_out);
 int s2n_get_and_validate_negotiated_signature_scheme(struct s2n_connection *conn, struct s2n_stuffer *in,


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/839, resolves https://github.com/aws/s2n-tls/issues/2780

### Description of changes: 

The only remaining gap in our client auth ECDSA support was for pre-TLS1.2 versions, which always defaulted to s2n_rsa_pkcs1_md5_sha1 regardless of the actual certificate type. I updated it to use s2n_ecdsa_sha1 if using ECDSA certs.

### Call-outs:

**Changes to s2n_server_cert_request.c:** To choose between RSA and ECDSA for the client signature scheme, I also needed to fix how "client_cert_pkey_type" was set when choosing a client certificate. Previously, we recorded the first match between our supported certificate types and the peer's supported certificate types, ignoring the actual client certificate type. I left the validation of supported certificate types as-is: since the S2N client only supports one certificate at a time, even if the peer claims not to support our certificate, we might as well try it anyway. I didn't want to change old existing behavior and start failing to connect to server we could connect to before.

**FIPS behavior:** When choosing default RSA signature schemes pre-TLS1.2 with FIPS, we choose "SHA1" for the server but "MD5_SHA1" for the client. The OpenSSL wiki suggests that client auth isn't allowed at all in FIPS mode: https://wiki.openssl.org/index.php/FIPS_mode_and_TLS#Digital_Signatures_in_TLS I tried updating our code to also prefer SHA1 for the client in FIPS mode, but that broke OpenSSL s_client integration tests because OpenSSL (not in FIPS mode) assumed that the signature was MD5_SHA1. This PR therefore doesn't change any behavior, but maybe we should fail the handshake if someone tries to negotiate client auth when S2N is operating in FIPS mode and has negotiated <TLS1.2.

### Testing:
Previously skipped tests are now passing. No tests are skipped.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
