### PR TITLE
Fixing naming error of cipher suite

### DIFF
--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -263,7 +263,7 @@ struct s2n_cipher_suite s2n_rsa_with_3des_ede_cbc_sha = /* 0x00,0x0A */ {
 
 struct s2n_cipher_suite s2n_dhe_rsa_with_3des_ede_cbc_sha = /* 0x00,0x16 */ {
     .available = 0,
-    .name = "EDH-RSA-DES-CBC3-SHA",
+    .name = "DHE-RSA-DES-CBC3-SHA",
     .iana_value = { TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA },
     .key_exchange_alg = &s2n_dhe,
     .auth_method = S2N_AUTHENTICATION_RSA,


### PR DESCRIPTION
### Resolved issues:

s2n_dhe_rsa_with_3des_ede_cbc_sha has a .name attribute that says EDH-RSA-DES-CBC3-SHA. It has been renamed it to say DHE-RSA-DES-CBC3-SHA.

### Description of changes: 

.name of cipher suite has been changed.

### Testing:

Covered by integration testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
