### PR TITLE
Fixes Potential IO Memory Leak

### DIFF
--- a/tests/cbmc/proofs/s2n_socket_quickack/s2n_socket_quickack_harness.c
+++ b/tests/cbmc/proofs/s2n_socket_quickack/s2n_socket_quickack_harness.c
@@ -21,5 +21,5 @@ void s2n_socket_quickack_harness()
   int result = s2n_socket_quickack(s2n_connection);
 
   /* Post-condition. */
-  assert(S2N_IMPLIES(result == S2N_SUCCESS, (!s2n_connection->managed_io) || (s2n_connection->recv_io_context) != NULL));
+  assert(S2N_IMPLIES(result == S2N_SUCCESS, (!s2n_connection->managed_recv_io) || (s2n_connection->recv_io_context) != NULL));
 }

--- a/tests/cbmc/proofs/s2n_socket_was_corked/s2n_socket_was_corked_harness.c
+++ b/tests/cbmc/proofs/s2n_socket_was_corked/s2n_socket_was_corked_harness.c
@@ -21,6 +21,6 @@ void s2n_socket_was_corked_harness()
   int result = s2n_socket_was_corked(s2n_connection);
 
   /* Post-condition. */
-  assert(S2N_IMPLIES(s2n_connection != NULL && (!s2n_connection->managed_io || !s2n_connection->send), result == 0)); /* false */
+  assert(S2N_IMPLIES(s2n_connection != NULL && (!s2n_connection->managed_send_io || !s2n_connection->send), result == 0)); /* false */
   assert(S2N_IMPLIES(s2n_connection == NULL, result != 0));
 }

--- a/tests/testlib/s2n_connection_test_utils.c
+++ b/tests/testlib/s2n_connection_test_utils.c
@@ -87,15 +87,26 @@ static int buffer_write(void *io_context, const uint8_t *buf, uint32_t len)
 /* The connection will read/write to/from a stuffer, instead of sockets */
 int s2n_connection_set_io_stuffers(struct s2n_stuffer *input, struct s2n_stuffer *output, struct s2n_connection *conn)
 {
-    /* Set Up Callbacks*/
-    POSIX_GUARD(s2n_connection_set_recv_cb(conn, &buffer_read));
-    POSIX_GUARD(s2n_connection_set_send_cb(conn, &buffer_write));
+    POSIX_GUARD(s2n_connection_set_recv_io_stuffer(input, conn));
+    POSIX_GUARD(s2n_connection_set_send_io_stuffer(output, conn));
 
-    /* Set up Callback Contexts to use stuffers */
+    return S2N_SUCCESS;
+}
+
+int s2n_connection_set_recv_io_stuffer(struct s2n_stuffer *input, struct s2n_connection *conn)
+{
+    POSIX_GUARD(s2n_connection_set_recv_cb(conn, &buffer_read));
     POSIX_GUARD(s2n_connection_set_recv_ctx(conn, input));
+
+    return S2N_SUCCESS;
+}
+
+int s2n_connection_set_send_io_stuffer(struct s2n_stuffer *output, struct s2n_connection *conn)
+{
+    POSIX_GUARD(s2n_connection_set_send_cb(conn, &buffer_write));
     POSIX_GUARD(s2n_connection_set_send_ctx(conn, output));
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_io_pair_init(struct s2n_test_io_pair *io_pair)

--- a/tests/testlib/s2n_testlib.h
+++ b/tests/testlib/s2n_testlib.h
@@ -39,6 +39,8 @@ extern int s2n_stuffer_alloc_ro_from_hex_string(struct s2n_stuffer *stuffer, con
 void s2n_print_connection(struct s2n_connection *conn, const char *marker);
 
 int s2n_connection_set_io_stuffers(struct s2n_stuffer *input, struct s2n_stuffer *output, struct s2n_connection *conn);
+int s2n_connection_set_recv_io_stuffer(struct s2n_stuffer *input, struct s2n_connection *conn);
+int s2n_connection_set_send_io_stuffer(struct s2n_stuffer *output, struct s2n_connection *conn);
 
 struct s2n_test_io_pair {
     int client;

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -16,12 +16,14 @@
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 
-#include "tls/s2n_connection.h"
-
 #include "tls/extensions/s2n_extension_list.h"
 #include "tls/extensions/s2n_client_server_name.h"
-#include "crypto/s2n_hash.h"
+#include "tls/s2n_connection.h"
 #include "tls/s2n_tls.h"
+
+#include "crypto/s2n_hash.h"
+
+#include "utils/s2n_socket.h"
 
 const uint8_t actual_version = 1, client_version = 2, server_version = 3;
 static int s2n_set_test_protocol_versions(struct s2n_connection *conn)
@@ -518,6 +520,68 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_get_write_fd(conn, &getWriteFd));
         EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_read_fd(conn, &getReadFd), S2N_ERR_INVALID_STATE);
         EXPECT_EQUAL(getWriteFd, WRITEFD);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* s2n_connection_set_fd can be called twice in a row */
+    {
+        static const int OLDFD = 1;
+        static const int NEWFD = 2;
+        static int getReadFd, getWriteFd;
+
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(conn);
+
+        EXPECT_SUCCESS(s2n_connection_set_fd(conn, OLDFD));
+        EXPECT_SUCCESS(s2n_connection_set_fd(conn, NEWFD));
+
+        EXPECT_SUCCESS(s2n_connection_get_write_fd(conn, &getWriteFd));
+        EXPECT_SUCCESS(s2n_connection_get_read_fd(conn, &getReadFd));
+        EXPECT_EQUAL(getReadFd, NEWFD);
+        EXPECT_EQUAL(getWriteFd, NEWFD);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* s2n_connection_set_read_fd and s2n_connection_set_write_fd can be called 
+     * after s2n_connection_set_fd */
+    {
+        static const int OLDFD = 1;
+        static const int NEWFD = 2;
+        static int getReadFd, getWriteFd;
+
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(conn);
+
+        EXPECT_SUCCESS(s2n_connection_set_fd(conn, OLDFD));
+        EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, NEWFD));
+        EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, NEWFD));
+
+        EXPECT_SUCCESS(s2n_connection_get_write_fd(conn, &getWriteFd));
+        EXPECT_SUCCESS(s2n_connection_get_read_fd(conn, &getReadFd));
+        EXPECT_EQUAL(getReadFd, NEWFD);
+        EXPECT_EQUAL(getWriteFd, NEWFD);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* The default s2n socket read/write setup can be used with a user-defined send/recv context */
+    {
+        static const int READFD = 1;
+        static const int WRITEFD = 2;
+        uint8_t socket_ctx[] = { "Some test context" };
+
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(conn);
+
+        EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, READFD));
+        s2n_connection_set_send_ctx(conn, socket_ctx);
+
+        EXPECT_SUCCESS(s2n_connection_wipe(conn));
+
+        EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, WRITEFD));
+        s2n_connection_set_recv_ctx(conn, socket_ctx);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -576,12 +576,27 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn);
 
         EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, READFD));
-        s2n_connection_set_send_ctx(conn, socket_ctx);
+        EXPECT_SUCCESS(s2n_connection_set_send_ctx(conn, socket_ctx));
 
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
         EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, WRITEFD));
-        s2n_connection_set_recv_ctx(conn, socket_ctx);
+        EXPECT_SUCCESS(s2n_connection_set_recv_ctx(conn, socket_ctx));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* The default s2n socket read/write setup can be overwritten by custom socket setup */
+    {
+        static const int READFD = 1;
+        uint8_t socket_ctx[] = { "Some test context" };
+
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(conn);
+
+        EXPECT_SUCCESS(s2n_connection_set_fd(conn, READFD));
+        EXPECT_SUCCESS(s2n_connection_set_send_ctx(conn, socket_ctx));
+        EXPECT_SUCCESS(s2n_connection_set_recv_ctx(conn, socket_ctx));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }

--- a/tests/unit/s2n_self_talk_custom_io_test.c
+++ b/tests/unit/s2n_self_talk_custom_io_test.c
@@ -62,127 +62,171 @@ int mock_client(struct s2n_test_io_pair *io_pair)
     _exit(0);
 }
 
-/**
- * This test creates a server, client, and a pair of pipes. The client uses the
- * pipes directly for I/O in s2n. The server copies data from the pipes into
- * stuffers and manages s2n I/O with a set of I/O callbacks that read and write
- * from the stuffers.
- */
+
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
-    struct s2n_config *config;
-    s2n_blocked_status blocked;
-    int status;
-    pid_t pid;
-    char *cert_chain_pem;
-    char *private_key_pem;
-    char *dhparams_pem;
-    struct s2n_cert_chain_and_key *chain_and_key;
-    struct s2n_stuffer in, out;
-
     BEGIN_TEST();
-
-    EXPECT_NOT_NULL(config = s2n_config_new());
-    EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_NOT_NULL(dhparams_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_DHPARAMS, dhparams_pem, S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
-    EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
-    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-    EXPECT_SUCCESS(s2n_config_add_dhparams(config, dhparams_pem));
-
-    /* For convenience, this test will intentionally try to write to closed pipes during shutdown. Ignore the signal to
-     * avoid exiting the process on SIGPIPE.
+    /**
+     * This test creates a server, client, and a pair of pipes. The client uses the
+     * pipes directly for I/O in s2n. The server copies data from the pipes into
+     * stuffers and manages s2n I/O with a set of I/O callbacks that read and write
+     * from the stuffers.
      */
-    signal(SIGPIPE, SIG_IGN);
+    {
+        struct s2n_connection *conn;
+        struct s2n_config *config;
+        s2n_blocked_status blocked;
+        int status;
+        pid_t pid;
+        char *cert_chain_pem;
+        char *private_key_pem;
+        char *dhparams_pem;
+        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_stuffer in, out;
 
-    /* Create a pipe */
-    struct s2n_test_io_pair io_pair;
-    EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(dhparams_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_DHPARAMS, dhparams_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+        EXPECT_SUCCESS(s2n_config_add_dhparams(config, dhparams_pem));
 
-    /* Create a child process */
-    pid = fork();
-    if (pid == 0) {
-        /* This is the client process, close the server end of the pipe */
+        /* For convenience, this test will intentionally try to write to closed pipes during shutdown. Ignore the signal to
+        * avoid exiting the process on SIGPIPE.
+        */
+        signal(SIGPIPE, SIG_IGN);
+
+        /* Create a pipe */
+        struct s2n_test_io_pair io_pair;
+        EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
+
+        /* Create a child process */
+        pid = fork();
+        if (pid == 0) {
+            /* This is the client process, close the server end of the pipe */
+            EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
+
+            /* Free the config */
+            EXPECT_SUCCESS(s2n_config_free(config));
+            free(cert_chain_pem);
+            free(private_key_pem);
+            free(dhparams_pem);
+
+            /* Run the client */
+            mock_client(&io_pair);
+        }
+
+        /* This is the server process, close the client end of the pipe */
+        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));
+
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        EXPECT_FAILURE(s2n_connection_use_corked_io(conn));
+
+        /* Set up our I/O callbacks. Use stuffers for the "I/O context" */
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&in, &out, conn));
+
+        /* Make our pipes non-blocking */
+        EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server));
+        EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server));
+
+        /* Negotiate the handshake. */
+        do {
+            int ret;
+
+            ret = s2n_negotiate(conn, &blocked);
+            EXPECT_TRUE(ret == 0 || (blocked && (errno == EAGAIN || errno == EWOULDBLOCK)));
+
+            /* check to see if we need to copy more over from the pipes to the buffers
+            * to continue the handshake
+            */
+            s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE, NULL);
+            s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out), NULL);
+        } while (blocked);
+
+        /* Shutdown after negotiating */
+        uint8_t server_shutdown=0;
+        do {
+            int ret;
+
+            ret = s2n_shutdown(conn, &blocked);
+            EXPECT_TRUE(ret == 0 || (blocked && (errno == EAGAIN || errno == EWOULDBLOCK)));
+            if (ret == 0) {
+                server_shutdown = 1;
+            }
+
+            s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE, NULL);
+            s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out), NULL);
+        } while (!server_shutdown);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+
+        /* Clean up */
+        EXPECT_SUCCESS(s2n_stuffer_free(&in));
+        EXPECT_SUCCESS(s2n_stuffer_free(&out));
+        EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
+        EXPECT_EQUAL(status, 0);
         EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
-
-        /* Free the config */
         EXPECT_SUCCESS(s2n_config_free(config));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
         free(cert_chain_pem);
         free(private_key_pem);
         free(dhparams_pem);
-
-        /* Run the client */
-        mock_client(&io_pair);
     }
 
-    /* This is the server process, close the client end of the pipe */
-    EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));
+    /* Clients and servers can utilize both custom IO and default IO for their sending and receiving */
+    {
+        /* Setup connections */
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
+        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
-    EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-    EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+        /* Setup config */
+        struct s2n_config *config_with_certs = NULL;
+        EXPECT_NOT_NULL(config_with_certs = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config_with_certs, "default_tls13"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config_with_certs));
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key, S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN,
+                                                    S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config_with_certs, chain_and_key));
 
-    EXPECT_FAILURE(s2n_connection_use_corked_io(conn));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config_with_certs));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config_with_certs));
 
-    /* Set up our I/O callbacks. Use stuffers for the "I/O context" */
-    EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
-    EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
-    EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&in, &out, conn));
+        /* Create nonblocking pipes */
+        struct s2n_test_io_pair io_pair = { 0 };
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
 
-    /* Make our pipes non-blocking */
-    EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server));
-    EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server));
+        /* Server writes to fd and client reads from fd */
+        EXPECT_SUCCESS(s2n_connection_set_write_fd(server_conn, io_pair.server));
+        EXPECT_SUCCESS(s2n_connection_set_read_fd(client_conn, io_pair.client));
 
-    /* Negotiate the handshake. */
-    do {
-        int ret;
+        DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, S2N_DEFAULT_RECORD_LENGTH));
 
-        ret = s2n_negotiate(conn, &blocked);
-        EXPECT_TRUE(ret == 0 || (blocked && (errno == EAGAIN || errno == EWOULDBLOCK)));
+        /* Client writes to stuffer and server reads from stuffer */
+        EXPECT_SUCCESS(s2n_connection_set_send_io_stuffer(&stuffer, client_conn));
+        EXPECT_SUCCESS(s2n_connection_set_recv_io_stuffer(&stuffer, server_conn));
 
-        /* check to see if we need to copy more over from the pipes to the buffers
-         * to continue the handshake
-         */
-        s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE, NULL);
-        s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out), NULL);
-    } while (blocked);
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
-    /* Shutdown after negotiating */
-    uint8_t server_shutdown=0;
-    do {
-        int ret;
-
-        ret = s2n_shutdown(conn, &blocked);
-        EXPECT_TRUE(ret == 0 || (blocked && (errno == EAGAIN || errno == EWOULDBLOCK)));
-        if (ret == 0) {
-            server_shutdown = 1;
-        }
-
-        s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE, NULL);
-        s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out), NULL);
-    } while (!server_shutdown);
-
-    EXPECT_SUCCESS(s2n_connection_free(conn));
-
-    /* Clean up */
-    EXPECT_SUCCESS(s2n_stuffer_free(&in));
-    EXPECT_SUCCESS(s2n_stuffer_free(&out));
-    EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
-    EXPECT_EQUAL(status, 0);
-    EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
-    EXPECT_SUCCESS(s2n_config_free(config));
-    EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
-    free(cert_chain_pem);
-    free(private_key_pem);
-    free(dhparams_pem);
-
-    s2n_cleanup();
+        /* Clean-up */
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_config_free(config_with_certs));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+    }
 
     END_TEST();
-
-    return 0;
 }

--- a/tests/unit/s2n_self_talk_custom_io_test.c
+++ b/tests/unit/s2n_self_talk_custom_io_test.c
@@ -62,7 +62,6 @@ int mock_client(struct s2n_test_io_pair *io_pair)
     _exit(0);
 }
 
-
 int main(int argc, char **argv)
 {
     BEGIN_TEST();

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -643,7 +643,7 @@ int s2n_connection_set_send_ctx(struct s2n_connection *conn, void *ctx)
     POSIX_ENSURE_REF(conn);
     POSIX_GUARD(s2n_connection_free_managed_send_io(conn));
     conn->send_io_context = ctx;
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_connection_set_recv_cb(struct s2n_connection *conn, s2n_recv_fn recv)

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -79,11 +79,11 @@ struct s2n_connection {
 
     /* Has the user set their own I/O callbacks or is this connection using the
      * default socket-based I/O set by s2n */
-    uint8_t managed_send_io;
-    uint8_t managed_recv_io;
+    unsigned managed_send_io:1;
+    unsigned managed_recv_io:1;
 
     /* Is this connection using CORK/SO_RCVLOWAT optimizations? Only valid when the connection is using
-     * managed_send/recv_io
+     * managed_send_io
      */
     unsigned corked_io:1;
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -77,11 +77,6 @@ struct s2n_connection {
     void *send_io_context;
     void *recv_io_context;
 
-    /* Has the user set their own I/O callbacks or is this connection using the
-     * default socket-based I/O set by s2n */
-    unsigned managed_send_io:1;
-    unsigned managed_recv_io:1;
-
     /* Is this connection using CORK/SO_RCVLOWAT optimizations? Only valid when the connection is using
      * managed_send_io
      */
@@ -326,6 +321,11 @@ struct s2n_connection {
 
     /* Cookie extension data */
     struct s2n_stuffer cookie_stuffer;
+
+    /* Has the user set their own I/O callbacks or is this connection using the
+     * default socket-based I/O set by s2n */
+    unsigned managed_send_io:1;
+    unsigned managed_recv_io:1;
 
     /* Key update data */
     unsigned key_update_pending:1;

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -79,10 +79,11 @@ struct s2n_connection {
 
     /* Has the user set their own I/O callbacks or is this connection using the
      * default socket-based I/O set by s2n */
-    uint8_t managed_io;
+    uint8_t managed_send_io;
+    uint8_t managed_recv_io;
 
     /* Is this connection using CORK/SO_RCVLOWAT optimizations? Only valid when the connection is using
-     * managed_io
+     * managed_send/recv_io
      */
     unsigned corked_io:1;
 

--- a/utils/s2n_socket.c
+++ b/utils/s2n_socket.c
@@ -41,7 +41,7 @@ int s2n_socket_quickack(struct s2n_connection *conn)
 {
 #ifdef TCP_QUICKACK
     POSIX_ENSURE_REF(conn);
-    if (!conn->managed_io) {
+    if (!conn->managed_recv_io) {
         return 0;
     }
 
@@ -131,7 +131,7 @@ int s2n_socket_was_corked(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
     /* If we're not using custom I/O and a send fd has not been set yet, return false*/
-    if (!conn->managed_io || !conn->send) {
+    if (!conn->managed_send_io || !conn->send) {
         return 0;
     }
 


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 
Separated the managed_io bitflag into the managed_send/recv_io bitflag so that its possible to use a custom  send operation and use the default recv, or a custom recv operation and use the default send (without leaking the socket_ctx or erroring when the memory is freed.)
### Call-outs:
N/A
### Testing:
Unit tests of the specific scenarios that were causing leaks and erroring. Also added a self-talk test where I proved that clients and servers could use custom and default sends and recvs.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
