### PR TITLE
build: add option to intern libcrypto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ otherwise a crypto target needs to be defined." ON)
 option(UNSAFE_TREAT_WARNINGS_AS_ERRORS "Compiler warnings are treated as errors. Warnings may
 indicate danger points where you should verify with the S2N-TLS developers that the security of
 the library is not compromised. Turn this OFF to ignore warnings." ON)
+option(S2N_INTERN_LIBCRYPTO "This ensures that s2n-tls is compiled and deployed with a specific
+version of libcrypto by interning the code and hiding symbols. This also enables s2n-tls to be
+loaded in an application with an otherwise conflicting libcrypto version." OFF)
 # Turn BUILD_TESTING=ON by default
 include(CTest)
 
@@ -391,7 +394,67 @@ else()
         message(FATAL_ERROR "Target crypto is not defined, failed to find libcrypto")
     endif()
 endif()
-target_link_libraries(${PROJECT_NAME} PUBLIC crypto ${OS_LIBS} m)
+
+if (S2N_INTERN_LIBCRYPTO)
+    if(NOT LibCrypto_STATIC_LIBRARY)
+        message(FATAL_ERROR "libcrypto interning requires a static build of libcrypto.a to be available")
+    endif()
+
+    add_custom_command(
+        OUTPUT libcrypto.symbols
+        COMMAND
+          # copy the static version of libcrypto
+          cp ${LibCrypto_STATIC_LIBRARY} libcrypto.a &&
+          # dump all of the symbols and prefix them with `s2n$`
+          bash -c "nm libcrypto.a | awk '/ [A-Z] /{print $3\" s2n$\"$3}' | sort | uniq > libcrypto.symbols" &&
+          # redefine the libcrypto libary symbols
+          objcopy --redefine-syms libcrypto.symbols libcrypto.a &&
+          rm -rf libcrypto &&
+          mkdir libcrypto &&
+          cd libcrypto &&
+          # extract libcrypto objects from the archive
+          ar x ../libcrypto.a &&
+          # rename all of the object files so we don't have any object name collisions
+          bash -c "find . -name '*.o' -type f -print0 | xargs -0 -n1 -- basename | xargs -I{} mv {} s2n_crypto__{}"
+        VERBATIM
+    )
+
+    add_custom_target(libcrypto ALL
+      DEPENDS libcrypto.symbols
+    )
+    add_dependencies(${PROJECT_NAME} libcrypto)
+
+    add_custom_command(
+        TARGET ${PROJECT_NAME} PRE_LINK
+        DEPENDS libcrypto.symbols
+        COMMAND
+        find ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${PROJECT_NAME}.dir -name '*.o' -exec objcopy --redefine-syms libcrypto.symbols {} \\\;
+    )
+
+    # copy the static libcrypto into the final artifact
+    if (BUILD_SHARED_LIBS)
+        # if we're building for testing, we export the prefixed symbols so tests can link to them
+        if (BUILD_TESTING)
+          set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS
+              "-Wl,--whole-archive libcrypto.a -Wl,--no-whole-archive")
+        else()
+          set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS
+              "-Wl,--whole-archive libcrypto.a -Wl,--no-whole-archive -Wl,--exclude-libs=ALL")
+        endif()
+    else()
+        add_custom_command(
+            TARGET ${PROJECT_NAME} POST_BUILD
+            DEPENDS libcrypto.symbols
+            COMMAND
+              bash -c "ar -r lib/libs2n.a libcrypto/*.o"
+            VERBATIM
+        )
+    endif()
+else()
+    target_link_libraries(${PROJECT_NAME} PUBLIC crypto)
+endif()
+
+target_link_libraries(${PROJECT_NAME} PUBLIC ${OS_LIBS} m)
 
 target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)
@@ -410,6 +473,15 @@ if (BUILD_TESTING)
     target_link_libraries(testss2n PUBLIC ${PROJECT_NAME})
     target_include_directories(testss2n PUBLIC $<TARGET_PROPERTY:crypto,INTERFACE_INCLUDE_DIRECTORIES>)
 
+    if (S2N_INTERN_LIBCRYPTO)
+        # if libcrypto was interned, rewrite libcrypto symbols so use of internal functions will link correctly
+        add_custom_command(
+            TARGET testss2n POST_BUILD
+            COMMAND
+                objcopy --redefine-syms libcrypto.symbols lib/libtestss2n.a
+        )
+    endif()
+
     #run unit tests
     file (GLOB TEST_LD_PRELOAD "tests/LD_PRELOAD/*.c")
     add_library(allocator_overrides SHARED ${TEST_LD_PRELOAD})
@@ -423,6 +495,14 @@ if (BUILD_TESTING)
         target_include_directories(${test_case_name} PRIVATE ./)
         target_include_directories(${test_case_name} PRIVATE tests)
         target_link_libraries(${test_case_name} PRIVATE testss2n)
+        if (S2N_INTERN_LIBCRYPTO)
+            # if libcrypto was interned, rewrite libcrypto symbols so use of internal functions will link correctly
+            add_custom_command(
+                TARGET ${test_case_name} PRE_LINK
+                COMMAND
+                  find . -name '${test_case_name}.c.o' -exec objcopy --redefine-syms libcrypto.symbols {} \\\;
+            )
+        endif()
         target_compile_options(${test_case_name} PRIVATE -Wno-implicit-function-declaration -Wno-deprecated -D_POSIX_C_SOURCE=200809L -std=gnu99)
         add_test(NAME ${test_case_name} COMMAND $<TARGET_FILE:${test_case_name}> WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit)
 
@@ -451,6 +531,12 @@ if (BUILD_TESTING)
     target_include_directories(s2nd PRIVATE $<TARGET_PROPERTY:crypto,INTERFACE_INCLUDE_DIRECTORIES>)
     target_include_directories(s2nd PRIVATE api)
     target_compile_options(s2nd PRIVATE -std=gnu99 -D_POSIX_C_SOURCE=200112L)
+
+    # if we've interned libcrypto, trying linking to the public version here to ensure we don't get any symbol collisions
+    if (S2N_INTERN_LIBCRYPTO)
+        target_link_libraries(s2nd crypto)
+        target_link_libraries(s2nc crypto)
+    endif()
 
     if(BENCHMARK)
         find_package(benchmark REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,7 +532,7 @@ if (BUILD_TESTING)
     target_include_directories(s2nd PRIVATE api)
     target_compile_options(s2nd PRIVATE -std=gnu99 -D_POSIX_C_SOURCE=200112L)
 
-    # if we've interned libcrypto, trying linking to the public version here to ensure we don't get any symbol collisions
+    # if we've interned libcrypto, try linking to the public version here to ensure we don't get any symbol collisions
     if (S2N_INTERN_LIBCRYPTO)
         target_link_libraries(s2nd crypto)
         target_link_libraries(s2nc crypto)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,7 +396,7 @@ else()
 endif()
 
 if (S2N_INTERN_LIBCRYPTO)
-    if(NOT LibCrypto_STATIC_LIBRARY)
+    if (NOT LibCrypto_STATIC_LIBRARY)
         message(FATAL_ERROR "libcrypto interning requires a static build of libcrypto.a to be available")
     endif()
 


### PR DESCRIPTION
### Description of changes: 

As customers begin to adopt TLS 1.3 they are required to use >libcrypto 1.1. This can be difficult in environments where only libcrypto 1.0 is available or where upgrading to another version will affect other existing application dependencies.

In order to get around this, I've added the option to "intern" libcrypto by copying and prefixing the symbols into s2n-tls's final artifact (i.e. shared/static library). This allows applications to run s2n-tls with a different version of libcrypto from the rest of the code.

### Callouts:

* This option is `off` by default so it won't affect any existing usage
* The symbol prefix is `s2n$`. This should be fine since none of our C code uses `$` in symbol names.
* This requires a static version of libcrypto be available at build time.
* Using this option will increase the final binary size so it should ideally be used only when upgrading to a modern version of libcrypto isn't feasible.

### Testing:

#### Shared lib, testing off
In the symbol dump you can see `s2n$x509_check_cert_time` as a private symbol (`t`). Also note that `libcrypto.so` does not show up in the list of dependencies from `ldd`.
```sh
$ cmake .. -DS2N_INTERN_LIBCRYPTO=on -DBUILD_SHARED_LIBS=on -DBUILD_TESTING=off && cmake --build .
...
$ nm lib/libs2n.so| grep x509
00000000000c04f0 t ct_x509_get_ext
00000000001e6490 t do_x509_check
00000000001d5140 t i2d_x509_aux_internal
00000000001d0330 t int_x509_param_set1
00000000001d0480 t int_x509_param_set_hosts.isra.1
00000000001cc880 t s2n$x509_check_cert_time
00000000001ca580 t s2n$x509_init_sig_info
00000000001ca360 t s2n$x509_set1_time
00000000001f12ef T s2n_cert_get_x509_extension_value
00000000001f11d2 T s2n_cert_get_x509_extension_value_length
000000000032adf0 T s2n_config_disable_x509_verification
...
$ ldd lib/libs2n.so
	linux-vdso.so.1 (0x00007ffd4bbf4000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fc6ed410000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fc6ed208000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fc6ecfe9000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fc6ecbf8000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fc6edca7000)
```

#### Shared lib, testing on

When compiling with testing enabled we need to export the prefixed libcrypto symbols so the tests use the interned library. Note that `s2n$x509_check_cert_time` is now a _public_ symbol (`T`).

```sh
$ cmake .. -DS2N_INTERN_LIBCRYPTO=on -DBUILD_SHARED_LIBS=on -DBUILD_TESTING=on && cmake --build .
...
$ nm lib/libs2n.so| grep x509
00000000001474f0 t ct_x509_get_ext
000000000026d490 t do_x509_check
000000000025c140 t i2d_x509_aux_internal
0000000000257330 t int_x509_param_set1
0000000000257480 t int_x509_param_set_hosts.isra.1
0000000000253880 T s2n$x509_check_cert_time
0000000000251580 T s2n$x509_init_sig_info
0000000000251360 T s2n$x509_set1_time
00000000002782ef T s2n_cert_get_x509_extension_value
00000000002781d2 T s2n_cert_get_x509_extension_value_length
00000000003b1e79 T s2n_config_disable_x509_verification
...
$ ldd lib/libs2n.so
	linux-vdso.so.1 (0x00007ffd4bbf4000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fc6ed410000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fc6ed208000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fc6ecfe9000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fc6ecbf8000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fc6edca7000)
```

#### Static lib
Since static libraries don't hide their symbols, the final results are the same regardless of testing being enabled or not

```sh
$ cmake .. -DS2N_INTERN_LIBCRYPTO=on -DBUILD_SHARED_LIBS=off && cmake --build .
...
$ nm lib/libs2n.a| grep x509
...
s2n_crypto__x509_set.o:
0000000000000300 T s2n$x509_init_sig_info
00000000000000e0 T s2n$x509_set1_time
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
