### PR TITLE
Enable Client-side TLS 1.2 Self Downgrade

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -564,7 +564,7 @@ The following chart maps the security policy version to protocol version and cip
 |   "20190120"   |       |   X    |    X   |    X   |         |    X    |                   |       |    X    |  X   |     |     |   X   |
 |   "20190121"   |       |   X    |    X   |    X   |         |    X    |                   |       |    X    |  X   |     |     |   X   |
 |   "20190122"   |       |   X    |    X   |    X   |         |    X    |                   |   X   |    X    |  X   |     |  X  |   X   |
-| "default_tls13"|       |   X    |    X   |    X   |    X    |    X    |          X        |       |    X    |      |     |     |   X   |
+| "default_tls13"|       |   X    |    X   |    X   |    X    |    X    |          X        |   X   |    X    |      |     |     |   X   |
 |   "20190801"   |       |   X    |    X   |    X   |    X    |    X    |          X        |       |    X    |      |     |     |   X   |
 |   "20190802"   |       |   X    |    X   |    X   |    X    |    X    |          X        |       |    X    |      |     |     |   X   |
 |   "20200207"   |       |   X    |    X   |    X   |    X    |    X    |          X        |       |    X    |      |     |     |       |

--- a/tests/integration/common/s2n_test_scenario.py
+++ b/tests/integration/common/s2n_test_scenario.py
@@ -108,23 +108,25 @@ def get_libcrypto():
     return str(os.getenv("S2N_LIBCRYPTO")).strip('"')
 
 
-ALL_CIPHERS = [
+ALL_TLS13_CIPHERS = [
     Cipher("TLS_AES_256_GCM_SHA384", Version.TLS13),
     Cipher("TLS_CHACHA20_POLY1305_SHA256", Version.TLS13),
     Cipher("TLS_AES_128_GCM_SHA256", Version.TLS13)
 ]
 
+NO_TLS13_CIPHERS = [ ]
+
 # Older versions of Openssl do not support CHACHA20. Current versions of LibreSSL and BoringSSL use a different API
 # that is unsupported by s2n.
-LEGACY_COMPATIBLE_CIPHERS = list(filter(lambda x: "CHACHA20" not in x.name, ALL_CIPHERS))
+LEGACY_COMPATIBLE_CIPHERS = list(filter(lambda x: "CHACHA20" not in x.name, ALL_TLS13_CIPHERS))
 
 ALL_CIPHERS_PER_LIBCRYPTO_VERSION = {
-    "openssl-1.1.1"         : ALL_CIPHERS,
-    "openssl-1.0.2"         : LEGACY_COMPATIBLE_CIPHERS,
-    "openssl-1.0.2-fips"    : LEGACY_COMPATIBLE_CIPHERS,
-    "libressl"              : LEGACY_COMPATIBLE_CIPHERS,
-    "boringssl"             : LEGACY_COMPATIBLE_CIPHERS,
-    "awslc"                 : LEGACY_COMPATIBLE_CIPHERS,
+    "openssl-1.1.1"         : ALL_TLS13_CIPHERS,
+    "openssl-1.0.2"         : NO_TLS13_CIPHERS,
+    "openssl-1.0.2-fips"    : NO_TLS13_CIPHERS,
+    "libressl"              : NO_TLS13_CIPHERS,
+    "boringssl"             : NO_TLS13_CIPHERS,
+    "awslc"                 : NO_TLS13_CIPHERS,
 }
 
 class Curve():

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -632,14 +632,14 @@ int main(int argc, char **argv)
         }
 
         /* Client sends TLS1.3 cipher suites, server selects correct TLS1.3 ciphersuite */
-        {
+        if (s2n_is_tls13_fully_supported()) {
             struct test_case {
                 const char *cipher_pref;
                 const struct s2n_cipher_suite *expected_cipher_wire;
             };
 
             struct test_case test_cases[] = {
-                { .cipher_pref = "default_tls13", .expected_cipher_wire = &s2n_tls13_aes_256_gcm_sha384 },
+                { .cipher_pref = "default_tls13", .expected_cipher_wire = &s2n_tls13_aes_128_gcm_sha256 },
                 { .cipher_pref = "test_all", .expected_cipher_wire = &s2n_tls13_aes_128_gcm_sha256 },
                 { .cipher_pref = "test_all_tls13", .expected_cipher_wire = &s2n_tls13_aes_128_gcm_sha256 },
             };

--- a/tests/unit/s2n_client_auth_handshake_test.c
+++ b/tests/unit/s2n_client_auth_handshake_test.c
@@ -308,6 +308,10 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
+    if (!s2n_is_tls13_fully_supported()) {
+        END_TEST();
+    }
+
     EXPECT_SUCCESS(s2n_enable_tls13());
 
     /* client_auth handshake negotiation */

--- a/tests/unit/s2n_client_early_data_indication_test.c
+++ b/tests/unit/s2n_client_early_data_indication_test.c
@@ -36,6 +36,10 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
+    if (!s2n_is_tls13_fully_supported()) {
+        END_TEST();
+    }
+
     /* Test s2n_client_early_data_indication_should_send */
     {
         /* Safety check */

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -897,7 +897,7 @@ int main(int argc, char **argv)
     }
 
     /* Server and client support the OCSP extension. Test Behavior for TLS 1.3 */
-    if(s2n_x509_ocsp_stapling_supported()) {
+    if(s2n_x509_ocsp_stapling_supported() && s2n_is_tls13_fully_supported()) {
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
         struct s2n_config *server_config;

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -403,9 +403,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
                     s2n_stuffer_data_available(&client_conn->handshake.io)));
-
             EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
-
 
             s2n_connection_free(client_conn);
             s2n_connection_free(server_conn);

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -381,7 +381,7 @@ int main(int argc, char **argv)
     /* Test that S2N will accept a ClientHello with legacy_session_id set when running with QUIC.
      * Since this requirement is a SHOULD, we're accepting it for non-compliant endpoints.
      * https://tools.ietf.org/html/draft-ietf-quic-tls-32#section-8.4*/
-    {
+    if (s2n_is_tls13_fully_supported()) {
         EXPECT_SUCCESS(s2n_reset_tls13());
 
         const size_t test_session_id_len = 10;
@@ -403,11 +403,9 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
                     s2n_stuffer_data_available(&client_conn->handshake.io)));
-            if (s2n_is_tls_12_self_downgrade_required(client_conn)) {
-                EXPECT_FAILURE_WITH_ERRNO(s2n_client_hello_recv(server_conn), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
-            } else {
-                EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
-            }
+
+            EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
+
 
             s2n_connection_free(client_conn);
             s2n_connection_free(server_conn);
@@ -427,12 +425,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
                     s2n_stuffer_data_available(&client_conn->handshake.io)));
-
-            if (s2n_is_tls_12_self_downgrade_required(client_conn)) {
-                EXPECT_FAILURE_WITH_ERRNO(s2n_client_hello_recv(server_conn), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
-            } else {
-                EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
-            }
+            EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
 
             s2n_connection_free(client_conn);
             s2n_connection_free(server_conn);

--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -39,6 +39,10 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
+    if (!s2n_is_tls13_fully_supported()) {
+        END_TEST();
+    }
+
     EXPECT_SUCCESS(s2n_enable_tls13());
 
     /* Test s2n_server_hello_retry_recv */

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -166,7 +166,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_disable_tls13());
 
         /* With TLS1.3 */
-        {
+        if (s2n_is_tls13_fully_supported()) {
             EXPECT_SUCCESS(s2n_enable_tls13());
 
             /* Generate a session id by default */
@@ -311,7 +311,7 @@ int main(int argc, char **argv)
         }
 
         /* When TLS 1.3 supported */
-        {
+        if (s2n_is_tls13_fully_supported()) {
             EXPECT_SUCCESS(s2n_enable_tls13());
 
             struct s2n_config *config;
@@ -364,7 +364,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, ecdsa_chain_and_key));
 
         /* Succeeds when negotiating TLS1.3 */
-        {
+        if (s2n_is_tls13_fully_supported()) {
             struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
             EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -427,8 +427,8 @@ int main(int argc, char **argv)
             EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
 
             EXPECT_SUCCESS(s2n_client_hello_send(conn));
-            EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS13);
-            EXPECT_EQUAL(conn->client_protocol_version, S2N_TLS13);
+            EXPECT_EQUAL(conn->actual_protocol_version, s2n_get_highest_fully_supported_tls_version());
+            EXPECT_EQUAL(conn->client_protocol_version, s2n_get_highest_fully_supported_tls_version());
             EXPECT_EQUAL(conn->client_hello_version, S2N_TLS12);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -467,9 +467,8 @@ int main(int argc, char **argv)
             EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
 
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
-
-            EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
-            EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS13);
+            EXPECT_EQUAL(client_conn->actual_protocol_version, s2n_get_highest_fully_supported_tls_version());
+            EXPECT_EQUAL(client_conn->client_protocol_version, s2n_get_highest_fully_supported_tls_version());
             EXPECT_EQUAL(client_conn->client_hello_version, S2N_TLS12);
 
             /* Server configured with TLS 1.2 negotiates TLS12 version */

--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -1422,7 +1422,7 @@ int main(int argc, char **argv)
     }
 
     /* Functional test */
-    {
+    if (s2n_is_tls13_fully_supported()) {
         /* Setup connections */
         struct s2n_connection *client_conn, *server_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -127,7 +127,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_enable_tls13());
             EXPECT_NOT_NULL(config = s2n_config_new());
             EXPECT_EQUAL(config->security_policy, tls13_security_policy);
-            EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_20190801);
+            EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_20210831);
             EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_null);
             EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20200207);
             EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -353,7 +353,7 @@ int main(int argc, char **argv)
      */
     {
         /* TLS1.3 */
-        {
+        if (s2n_is_tls13_fully_supported()) {
             struct s2n_config *config = s2n_config_new();
             EXPECT_NOT_NULL(config);
             EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));

--- a/tests/unit/s2n_early_data_io_api_test.c
+++ b/tests/unit/s2n_early_data_io_api_test.c
@@ -81,6 +81,10 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
+    if (!s2n_is_tls13_fully_supported()) {
+        END_TEST();
+    }
+
     const uint8_t test_data[] = "hello world";
 
     /* Malformed record: empty handshake record */
@@ -109,6 +113,7 @@ int main(int argc, char **argv)
         /* Safety checks */
         {
             struct s2n_connection conn = { 0 };
+            conn.mode = S2N_CLIENT;
             s2n_blocked_status blocked = S2N_NOT_BLOCKED;
             ssize_t data_size = 0;
             uint8_t data = 0;

--- a/tests/unit/s2n_early_data_io_test.c
+++ b/tests/unit/s2n_early_data_io_test.c
@@ -56,6 +56,10 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
+    if (!s2n_is_tls13_fully_supported()) {
+        END_TEST();
+    }
+
     const uint8_t test_data[] = "hello world";
 
     DEFER_CLEANUP(struct s2n_psk *test_psk = s2n_external_psk_new(), s2n_psk_free);

--- a/tests/unit/s2n_encrypted_extensions_test.c
+++ b/tests/unit/s2n_encrypted_extensions_test.c
@@ -16,6 +16,8 @@
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 
+#include "crypto/s2n_rsa_signing.h"
+
 #include "tls/s2n_tls.h"
 #include "tls/s2n_tls13.h"
 
@@ -173,7 +175,7 @@ int main(int argc, char **argv)
     }
 
     /* Functional: Unencrypted EncryptedExtensions rejected */
-    {
+    if (s2n_is_tls13_fully_supported()) {
         s2n_blocked_status blocked = S2N_NOT_BLOCKED;
 
         struct s2n_cert_chain_and_key *chain_and_key;

--- a/tests/unit/s2n_extension_type_test.c
+++ b/tests/unit/s2n_extension_type_test.c
@@ -444,7 +444,7 @@ int main()
             uint16_t key_shares_id = s2n_extension_iana_value_to_id(TLS_EXTENSION_KEY_SHARE);
 
             /* Both TLS1.3 */
-            {
+            if (s2n_is_tls13_fully_supported()) {
                 struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
                 EXPECT_NOT_NULL(client_conn);
                 EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
@@ -517,7 +517,12 @@ int main()
 
                 /* Expected CLIENT_HELLO extensions sent, but not received */
                 EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, SERVER_HELLO));
-                EXPECT_TRUE(S2N_CBIT_TEST(client_conn->extension_requests_sent, key_shares_id));
+                if (s2n_is_tls13_fully_supported()) {
+                    EXPECT_TRUE(S2N_CBIT_TEST(client_conn->extension_requests_sent, key_shares_id));
+                } else {
+                    EXPECT_FALSE(S2N_CBIT_TEST(client_conn->extension_requests_sent, key_shares_id));
+                }
+
                 EXPECT_FALSE(S2N_CBIT_TEST(server_conn->extension_requests_received, key_shares_id));
 
                 /* No expected SERVER_HELLO extensions sent and received */

--- a/tests/unit/s2n_extension_type_test.c
+++ b/tests/unit/s2n_extension_type_test.c
@@ -436,10 +436,10 @@ int main()
             EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&cert_chain,
                     S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
 
-            struct s2n_config *config = s2n_config_new();
-            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
-            EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all"));
+            struct s2n_config *test_all_config = s2n_config_new();
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(test_all_config, cert_chain));
+            EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(test_all_config));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(test_all_config, "test_all"));
 
             uint16_t key_shares_id = s2n_extension_iana_value_to_id(TLS_EXTENSION_KEY_SHARE);
 
@@ -447,11 +447,11 @@ int main()
             if (s2n_is_tls13_fully_supported()) {
                 struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
                 EXPECT_NOT_NULL(client_conn);
-                EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+                EXPECT_SUCCESS(s2n_connection_set_config(client_conn, test_all_config));
 
                 struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
                 EXPECT_NOT_NULL(server_conn);
-                EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+                EXPECT_SUCCESS(s2n_connection_set_config(server_conn, test_all_config));
 
                 struct s2n_test_io_pair io_pair = { 0 };
                 EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
@@ -475,12 +475,12 @@ int main()
             {
                 struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
                 EXPECT_NOT_NULL(client_conn);
-                EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+                EXPECT_SUCCESS(s2n_connection_set_config(client_conn, test_all_config));
                 EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "test_all_tls12"));
 
                 struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
                 EXPECT_NOT_NULL(server_conn);
-                EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+                EXPECT_SUCCESS(s2n_connection_set_config(server_conn, test_all_config));
 
                 struct s2n_test_io_pair io_pair = { 0 };
                 EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
@@ -500,15 +500,15 @@ int main()
                 EXPECT_SUCCESS(s2n_connection_free(server_conn));
             }
 
-            /* Server TLS1.2 */
-            {
+            /* Client TLS 1.3 with Server TLS1.2 */
+            if (s2n_is_tls13_fully_supported()) {
                 struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
                 EXPECT_NOT_NULL(client_conn);
-                EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+                EXPECT_SUCCESS(s2n_connection_set_config(client_conn, test_all_config));
 
                 struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
                 EXPECT_NOT_NULL(server_conn);
-                EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+                EXPECT_SUCCESS(s2n_connection_set_config(server_conn, test_all_config));
                 EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "test_all_tls12"));
 
                 struct s2n_test_io_pair io_pair = { 0 };
@@ -517,11 +517,7 @@ int main()
 
                 /* Expected CLIENT_HELLO extensions sent, but not received */
                 EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, SERVER_HELLO));
-                if (s2n_is_tls13_fully_supported()) {
-                    EXPECT_TRUE(S2N_CBIT_TEST(client_conn->extension_requests_sent, key_shares_id));
-                } else {
-                    EXPECT_FALSE(S2N_CBIT_TEST(client_conn->extension_requests_sent, key_shares_id));
-                }
+                EXPECT_TRUE(S2N_CBIT_TEST(client_conn->extension_requests_sent, key_shares_id));
 
                 EXPECT_FALSE(S2N_CBIT_TEST(server_conn->extension_requests_received, key_shares_id));
 
@@ -534,7 +530,7 @@ int main()
                 EXPECT_SUCCESS(s2n_connection_free(server_conn));
             }
 
-            EXPECT_SUCCESS(s2n_config_free(config));
+            EXPECT_SUCCESS(s2n_config_free(test_all_config));
             EXPECT_SUCCESS(s2n_cert_chain_and_key_free(cert_chain));
         }
     }

--- a/tests/unit/s2n_extension_type_test.c
+++ b/tests/unit/s2n_extension_type_test.c
@@ -518,7 +518,6 @@ int main()
                 /* Expected CLIENT_HELLO extensions sent, but not received */
                 EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, SERVER_HELLO));
                 EXPECT_TRUE(S2N_CBIT_TEST(client_conn->extension_requests_sent, key_shares_id));
-
                 EXPECT_FALSE(S2N_CBIT_TEST(server_conn->extension_requests_received, key_shares_id));
 
                 /* No expected SERVER_HELLO extensions sent and received */

--- a/tests/unit/s2n_handshake_partial_test.c
+++ b/tests/unit/s2n_handshake_partial_test.c
@@ -45,6 +45,10 @@ int main()
 {
     BEGIN_TEST();
 
+    if (!s2n_is_tls13_fully_supported()) {
+        END_TEST();
+    }
+
     const uint8_t test_psk_data[] = "very secret";
     DEFER_CLEANUP(struct s2n_psk *test_psk = s2n_external_psk_new(), s2n_psk_free);
     EXPECT_SUCCESS(s2n_psk_set_identity(test_psk, test_psk_data, sizeof(test_psk_data)));

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -344,8 +344,7 @@ int main(int argc, char **argv)
         }
 
         /*  Test: RSA cert with RSA PSS signatures */
-        if (s2n_is_rsa_pss_signing_supported())
-        {
+        if (s2n_is_rsa_pss_signing_supported()) {
             const struct s2n_signature_scheme* const rsa_pss_rsae_sig_schemes[] = {
                     /* RSA PSS */
                     &s2n_rsa_pss_rsae_sha256,

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -83,29 +83,38 @@ int main(int argc, char **argv)
                     struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
                     EXPECT_NOT_NULL(client_conn);
                     EXPECT_NOT_NULL(server_conn);
-                    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, security_policy_selection[policy_index].version));
-                    EXPECT_SUCCESS(s2n_config_set_verification_ca_location(config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
-                    EXPECT_NOT_NULL(config->default_certs_by_type.certs[S2N_PKEY_TYPE_RSA]);
-                    EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-                    EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
-                    client_conn->actual_protocol_version = S2N_TLS13;
-                    server_conn->actual_protocol_version = S2N_TLS13;
-                    client_conn->secure.cipher_suite = &tls_13_ciphers[i];
-                    server_conn->secure.cipher_suite = &tls_13_ciphers[i];
-
-                    struct s2n_signature_scheme chosen_scheme = {0};
-
-                    if (s2n_is_rsa_pss_signing_supported()) {
-                        /* If RSA PSS signing is supported, then we should always be able to select a default Signature
-                         * Scheme for RSA Certs for TLS 1.3 */
-                        EXPECT_SUCCESS(s2n_tls13_default_sig_scheme(client_conn, &chosen_scheme));
-                        EXPECT_SUCCESS(s2n_tls13_default_sig_scheme(server_conn, &chosen_scheme));
+                    if (security_policy_selection[policy_index].security_policy->minimum_protocol_version == S2N_TLS13
+                            && !s2n_is_tls13_fully_supported()) {
+                        /* We purposefully do not allow users to configure Security Policies with a minimum allowed TLS
+                         * Version of TLS 1.3, if TLS 1.3 algorithms aren't fully supported by the libcrypto we're using */
+                        EXPECT_FAILURE(s2n_config_set_cipher_preferences(config, security_policy_selection[policy_index].version));
                     } else {
-                        /* We can't pick a default TLS 1.3 signature scheme when configured with an RSA Cert when we
-                         * do not support RSA PSS signing since RSA PSS signing is required for TLS 1.3 */
-                        EXPECT_FAILURE(s2n_tls13_default_sig_scheme(client_conn, &chosen_scheme));
-                        EXPECT_FAILURE(s2n_tls13_default_sig_scheme(server_conn, &chosen_scheme));
+
+                        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, security_policy_selection[policy_index].version));
+                        EXPECT_SUCCESS(s2n_config_set_verification_ca_location(config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
+                        EXPECT_NOT_NULL(config->default_certs_by_type.certs[S2N_PKEY_TYPE_RSA]);
+                        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+                        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+                        client_conn->actual_protocol_version = S2N_TLS13;
+                        server_conn->actual_protocol_version = S2N_TLS13;
+                        client_conn->secure.cipher_suite = &tls_13_ciphers[i];
+                        server_conn->secure.cipher_suite = &tls_13_ciphers[i];
+
+                        struct s2n_signature_scheme chosen_scheme = {0};
+
+                        if (s2n_is_rsa_pss_signing_supported()) {
+                            /* If RSA PSS signing is supported, then we should always be able to select a default Signature
+                             * Scheme for RSA Certs for TLS 1.3 */
+                            EXPECT_SUCCESS(s2n_tls13_default_sig_scheme(client_conn, &chosen_scheme));
+                            EXPECT_SUCCESS(s2n_tls13_default_sig_scheme(server_conn, &chosen_scheme));
+                        } else {
+                            /* We can't pick a default TLS 1.3 signature scheme when configured with an RSA Cert when we
+                             * do not support RSA PSS signing since RSA PSS signing is required for TLS 1.3 */
+                            EXPECT_FAILURE(s2n_tls13_default_sig_scheme(client_conn, &chosen_scheme));
+                            EXPECT_FAILURE(s2n_tls13_default_sig_scheme(server_conn, &chosen_scheme));
+                        }
                     }
 
                     EXPECT_SUCCESS(s2n_connection_free(client_conn));
@@ -134,23 +143,32 @@ int main(int argc, char **argv)
                     struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
                     EXPECT_NOT_NULL(client_conn);
                     EXPECT_NOT_NULL(server_conn);
-                    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, security_policy_selection[policy_index].version));
-                    EXPECT_SUCCESS(s2n_config_set_verification_ca_location(config, S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, NULL));
-                    EXPECT_NOT_NULL(config->default_certs_by_type.certs[S2N_PKEY_TYPE_ECDSA]);
-                    EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-                    EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
-                    client_conn->actual_protocol_version = S2N_TLS13;
-                    server_conn->actual_protocol_version = S2N_TLS13;
-                    client_conn->secure.cipher_suite = &tls_13_ciphers[i];
-                    server_conn->secure.cipher_suite = &tls_13_ciphers[i];
+                    if (security_policy_selection[policy_index].security_policy->minimum_protocol_version == S2N_TLS13
+                            && !s2n_is_tls13_fully_supported()) {
+                        /* We purposefully do not allow users to configure Security Policies with a minimum allowed TLS
+                         * Version of TLS 1.3, if TLS 1.3 algorithms aren't fully supported by the libcrypto we're using */
+                        EXPECT_FAILURE(s2n_config_set_cipher_preferences(config, security_policy_selection[policy_index].version));
+                    } else {
 
-                    struct s2n_signature_scheme chosen_scheme = {0};
+                        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, security_policy_selection[policy_index].version));
+                        EXPECT_SUCCESS(s2n_config_set_verification_ca_location(config, S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, NULL));
+                        EXPECT_NOT_NULL(config->default_certs_by_type.certs[S2N_PKEY_TYPE_ECDSA]);
+                        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+                        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
-                    /* If an ECDSA Certificate is configured, then we should always be able to pick a default Signature
-                     * Scheme (even if RSA PSS is not supported by the libcrypto) */
-                    EXPECT_SUCCESS(s2n_tls13_default_sig_scheme(client_conn, &chosen_scheme));
-                    EXPECT_SUCCESS(s2n_tls13_default_sig_scheme(server_conn, &chosen_scheme));
+                        client_conn->actual_protocol_version = S2N_TLS13;
+                        server_conn->actual_protocol_version = S2N_TLS13;
+                        client_conn->secure.cipher_suite = &tls_13_ciphers[i];
+                        server_conn->secure.cipher_suite = &tls_13_ciphers[i];
+
+                        struct s2n_signature_scheme chosen_scheme = {0};
+
+                        /* If an ECDSA Certificate is configured, then we should always be able to pick a default Signature
+                         * Scheme (even if RSA PSS is not supported by the libcrypto) */
+                        EXPECT_SUCCESS(s2n_tls13_default_sig_scheme(client_conn, &chosen_scheme));
+                        EXPECT_SUCCESS(s2n_tls13_default_sig_scheme(server_conn, &chosen_scheme));
+                    }
 
                     EXPECT_SUCCESS(s2n_connection_free(client_conn));
                     EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -560,8 +578,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_20140601);
 
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
-        EXPECT_EQUAL(config->security_policy, &security_policy_20201110);
-        EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_20190801);
+        EXPECT_EQUAL(config->security_policy, &security_policy_default_tls13);
+        EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_20210831);
         EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_null);
         EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20200207);
         EXPECT_EQUAL(config->security_policy->certificate_signature_preferences, &s2n_certificate_signature_preferences_20201110);
@@ -644,12 +662,16 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20200207);
         EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
 
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "AWS-CRT-SDK-TLSv1.3"));
-        EXPECT_EQUAL(config->security_policy, &security_policy_aws_crt_sdk_tls_13);
-        EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_aws_crt_sdk_tls_13);
-        EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_null);
-        EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20200207);
-        EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
+        if (s2n_is_tls13_fully_supported()) {
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "AWS-CRT-SDK-TLSv1.3"));
+            EXPECT_EQUAL(config->security_policy, &security_policy_aws_crt_sdk_tls_13);
+            EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_aws_crt_sdk_tls_13);
+            EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_null);
+            EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20200207);
+            EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
+        } else {
+            EXPECT_FAILURE(s2n_config_set_cipher_preferences(config, "AWS-CRT-SDK-TLSv1.3"));
+        }
 
         EXPECT_FAILURE(s2n_config_set_cipher_preferences(config, NULL));
 
@@ -682,8 +704,8 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
         EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
-        EXPECT_EQUAL(security_policy, &security_policy_20201110);
-        EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_20190801);
+        EXPECT_EQUAL(security_policy, &security_policy_default_tls13);
+        EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_20210831);
         EXPECT_EQUAL(security_policy->kem_preferences, &kem_preferences_null);
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20200207);
         EXPECT_EQUAL(security_policy->certificate_signature_preferences, &s2n_certificate_signature_preferences_20201110);

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -84,13 +84,11 @@ int main(int argc, char **argv)
                     EXPECT_NOT_NULL(client_conn);
                     EXPECT_NOT_NULL(server_conn);
 
-                    if (security_policy_selection[policy_index].security_policy->minimum_protocol_version == S2N_TLS13
-                            && !s2n_is_tls13_fully_supported()) {
+                    if (security_policy_selection[policy_index].security_policy->minimum_protocol_version > s2n_get_highest_fully_supported_tls_version()) {
                         /* We purposefully do not allow users to configure Security Policies with a minimum allowed TLS
-                         * Version of TLS 1.3, if TLS 1.3 algorithms aren't fully supported by the libcrypto we're using */
+                         * versions that are greater than what libcrypto supports. */
                         EXPECT_FAILURE(s2n_config_set_cipher_preferences(config, security_policy_selection[policy_index].version));
                     } else {
-
                         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, security_policy_selection[policy_index].version));
                         EXPECT_SUCCESS(s2n_config_set_verification_ca_location(config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
                         EXPECT_NOT_NULL(config->default_certs_by_type.certs[S2N_PKEY_TYPE_RSA]);

--- a/tests/unit/s2n_self_talk_key_log_test.c
+++ b/tests/unit/s2n_self_talk_key_log_test.c
@@ -16,6 +16,7 @@
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 
+#include "crypto/s2n_rsa_signing.h"
 #include "tls/s2n_key_log.h"
 
 static int s2n_test_key_log_cb(void* context, struct s2n_connection *conn,
@@ -115,7 +116,7 @@ int main(int argc, char **argv)
     }
 
     /* TLS 1.3 */
-    {
+    if (s2n_is_tls13_fully_supported()) {
         /* Setup connections */
         struct s2n_connection *client_conn, *server_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));

--- a/tests/unit/s2n_self_talk_nonblocking_test.c
+++ b/tests/unit/s2n_self_talk_nonblocking_test.c
@@ -267,7 +267,8 @@ int test_send(int use_tls13, int use_iov, int prefer_throughput)
 
     /* Make sure we negotiated the expected version */
     if (use_tls13) {
-        EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS13);
+        int expected_protocol_version = (s2n_is_tls13_fully_supported() ? S2N_TLS13 : S2N_TLS12);
+        EXPECT_EQUAL(conn->actual_protocol_version, expected_protocol_version);
     } else {
         EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS12);
     }

--- a/tests/unit/s2n_self_talk_nonblocking_test.c
+++ b/tests/unit/s2n_self_talk_nonblocking_test.c
@@ -267,8 +267,7 @@ int test_send(int use_tls13, int use_iov, int prefer_throughput)
 
     /* Make sure we negotiated the expected version */
     if (use_tls13) {
-        int expected_protocol_version = (s2n_is_tls13_fully_supported() ? S2N_TLS13 : S2N_TLS12);
-        EXPECT_EQUAL(conn->actual_protocol_version, expected_protocol_version);
+        EXPECT_EQUAL(conn->actual_protocol_version, s2n_get_highest_fully_supported_tls_version());
     } else {
         EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS12);
     }

--- a/tests/unit/s2n_self_talk_psk_test.c
+++ b/tests/unit/s2n_self_talk_psk_test.c
@@ -151,6 +151,10 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
+    if (!s2n_is_tls13_fully_supported()) {
+        END_TEST();
+    }
+
     /* Setup connections */
     struct s2n_connection *client_conn = NULL;
     struct s2n_connection *server_conn = NULL;

--- a/tests/unit/s2n_self_talk_quic_support_test.c
+++ b/tests/unit/s2n_self_talk_quic_support_test.c
@@ -43,6 +43,10 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
+    if (!s2n_is_tls13_fully_supported()) {
+        END_TEST();
+    }
+
     const uint8_t *transport_params = NULL;
     uint16_t transport_params_len = 0;
 

--- a/tests/unit/s2n_self_talk_session_resumption_test.c
+++ b/tests/unit/s2n_self_talk_session_resumption_test.c
@@ -142,6 +142,10 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
+    if (!s2n_is_tls13_fully_supported()) {
+        END_TEST();
+    }
+
     /* For some session resumption test cases, we want to test all possible configurations of 0-RTT support. */
     size_t test_case_i = 0;
     struct s2n_early_data_test_case early_data_test_cases[ 2 * 2 * 2 ] = { 0 };

--- a/tests/unit/s2n_self_talk_tls13_test.c
+++ b/tests/unit/s2n_self_talk_tls13_test.c
@@ -141,8 +141,7 @@ int main(int argc, char **argv)
 
     /* Negotiate the handshake. */
     EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
-    int expected_protocol_version = s2n_is_tls13_fully_supported() ? S2N_TLS13 : S2N_TLS12;
-    EXPECT_EQUAL(conn->actual_protocol_version, expected_protocol_version);
+    EXPECT_EQUAL(conn->actual_protocol_version, s2n_get_highest_fully_supported_tls_version());
 
     char buffer[0xffff];
     for (int i = 1; i < 0xffff; i += 100) {

--- a/tests/unit/s2n_self_talk_tls13_test.c
+++ b/tests/unit/s2n_self_talk_tls13_test.c
@@ -141,7 +141,8 @@ int main(int argc, char **argv)
 
     /* Negotiate the handshake. */
     EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
-    EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS13);
+    int expected_protocol_version = s2n_is_tls13_fully_supported() ? S2N_TLS13 : S2N_TLS12;
+    EXPECT_EQUAL(conn->actual_protocol_version, expected_protocol_version);
 
     char buffer[0xffff];
     for (int i = 1; i < 0xffff; i += 100) {

--- a/tests/unit/s2n_server_early_data_indication_test.c
+++ b/tests/unit/s2n_server_early_data_indication_test.c
@@ -40,6 +40,11 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
+    if (!s2n_is_tls13_fully_supported()) {
+        END_TEST();
+    }
+
+
     const uint32_t nonzero_max_early_data = 10;
 
     /* Test s2n_server_early_data_indication_should_send */

--- a/tests/unit/s2n_server_early_data_indication_test.c
+++ b/tests/unit/s2n_server_early_data_indication_test.c
@@ -44,7 +44,6 @@ int main(int argc, char **argv)
         END_TEST();
     }
 
-
     const uint32_t nonzero_max_early_data = 10;
 
     /* Test s2n_server_early_data_indication_should_send */

--- a/tests/unit/s2n_server_hello_retry_test.c
+++ b/tests/unit/s2n_server_hello_retry_test.c
@@ -61,6 +61,10 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
+    if (!s2n_is_tls13_fully_supported()) {
+        END_TEST();
+    }
+
     EXPECT_SUCCESS(s2n_enable_tls13());
 
     /* Send Hello Retry Request messages */

--- a/tests/unit/s2n_server_hello_test.c
+++ b/tests/unit/s2n_server_hello_test.c
@@ -522,7 +522,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(non_quic_config, chain_and_key));
 
         /* Succeeds when negotiating TLS1.3 */
-        {
+        if (s2n_is_tls13_fully_supported()) {
             struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, non_quic_config));
 
@@ -585,7 +585,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
 
         /* Succeeds when negotiating TLS1.3 */
-        {
+        if (s2n_is_tls13_fully_supported()) {
             struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "test_all"));
@@ -613,8 +613,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
         }
 
-        /* Fails when negotiating TLS1.2 */
-        {
+        /* TLS 1.3 Client Early Data is rejected when server only supports TLS1.2 */
+        if (s2n_is_tls13_fully_supported()) {
             struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "test_all"));

--- a/tests/unit/s2n_server_hello_test.c
+++ b/tests/unit/s2n_server_hello_test.c
@@ -578,14 +578,14 @@ int main(int argc, char **argv)
      *# A client that attempts to send 0-RTT data MUST fail a connection if
      *# it receives a ServerHello with TLS 1.2 or older.
      */
-    {
+    if (s2n_is_tls13_fully_supported()) {
         EXPECT_SUCCESS(s2n_reset_tls13());
 
         struct s2n_config *config = s2n_config_new();
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
 
         /* Succeeds when negotiating TLS1.3 */
-        if (s2n_is_tls13_fully_supported()) {
+        {
             struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "test_all"));
@@ -614,7 +614,7 @@ int main(int argc, char **argv)
         }
 
         /* TLS 1.3 Client Early Data is rejected when server only supports TLS1.2 */
-        if (s2n_is_tls13_fully_supported()) {
+        {
             struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "test_all"));

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -1204,7 +1204,7 @@ int main(int argc, char **argv)
     }
 
     /* Functional test: s2n_negotiate sends new session tickets after the handshake is complete */
-    {
+    if (s2n_is_tls13_fully_supported()) {
         /* Setup connections */
         struct s2n_connection *client_conn, *server_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));

--- a/tests/unit/s2n_server_psk_extension_test.c
+++ b/tests/unit/s2n_server_psk_extension_test.c
@@ -258,7 +258,7 @@ int main(int argc, char **argv)
     }
 
     /* Functional test */
-    {
+    if (s2n_is_tls13_fully_supported()) {
         /* Setup connections */
         EXPECT_SUCCESS(s2n_enable_tls13());
         struct s2n_connection *client_conn, *server_conn;

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -1148,7 +1148,7 @@ int main(int argc, char **argv)
     /* Session resumption APIs and session_ticket_cb return the same values
      * when receiving a new ticket in TLS1.3
      */
-    {
+    if (s2n_is_tls13_fully_supported()) {
         struct s2n_config *config = s2n_config_new();
         EXPECT_NOT_NULL(config);
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, ecdsa_chain_and_key));
@@ -1208,7 +1208,7 @@ int main(int argc, char **argv)
     }
 
     /* Client has TLS1.3 ticket but negotiates TLS1.2 */
-    {
+    if (s2n_is_tls13_fully_supported()) {
         s2n_extension_type_id client_session_ticket_ext_id = 0, psk_ext_id = 0;
         EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_PRE_SHARED_KEY, &psk_ext_id));
         EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_SESSION_TICKET, &client_session_ticket_ext_id));

--- a/tests/unit/s2n_tls13_compute_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_compute_shared_secret_test.c
@@ -29,6 +29,10 @@ int main(int argc, char **argv) {
 
     BEGIN_TEST();
 
+    if (!s2n_is_tls13_fully_supported()) {
+        END_TEST();
+    }
+
     struct s2n_cert_chain_and_key *cert_chain = NULL;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&cert_chain,
             S2N_ECDSA_P384_PKCS1_CERT_CHAIN, S2N_ECDSA_P384_PKCS1_KEY));

--- a/tests/unit/s2n_tls13_new_session_ticket_test.c
+++ b/tests/unit/s2n_tls13_new_session_ticket_test.c
@@ -76,6 +76,10 @@ int main(int argc, char **argv)
 {   
     BEGIN_TEST();
     
+    if (!s2n_is_tls13_fully_supported()) {
+        END_TEST();
+    }
+
     /* s2n_send sends NewSessionTicket message and s2n_recv receives it */
     {
         struct s2n_connection *server_conn= s2n_connection_new(S2N_SERVER);

--- a/tests/unit/s2n_tls13_pq_handshake_test.c
+++ b/tests/unit/s2n_tls13_pq_handshake_test.c
@@ -15,6 +15,7 @@
 
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
+#include "crypto/s2n_rsa_signing.h"
 #include "tls/s2n_kem_preferences.h"
 #include "tls/s2n_security_policies.h"
 #include "tls/s2n_ecc_preferences.h"
@@ -209,6 +210,10 @@ int s2n_test_tls13_pq_handshake(const struct s2n_security_policy *client_sec_pol
 
 int main() {
     BEGIN_TEST();
+
+    if (!s2n_is_tls13_fully_supported()) {
+        END_TEST();
+    }
 
     /* Additional KEM preferences/security policies to test against. These policies can only be used
      * as the server's policy in this test: when generating the ClientHello, the client relies on

--- a/tls/extensions/s2n_client_supported_versions.c
+++ b/tls/extensions/s2n_client_supported_versions.c
@@ -61,6 +61,7 @@ static int s2n_client_supported_versions_send(struct s2n_connection *conn, struc
     uint8_t highest_supported_version = conn->client_protocol_version;
     uint8_t minimum_supported_version;
     POSIX_GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
+    POSIX_ENSURE(highest_supported_version >= minimum_supported_version, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 
     uint8_t version_list_length = highest_supported_version - minimum_supported_version + 1;
     POSIX_GUARD(s2n_stuffer_write_uint8(out, version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN));

--- a/tls/extensions/s2n_server_supported_versions.c
+++ b/tls/extensions/s2n_server_supported_versions.c
@@ -63,6 +63,7 @@ static int s2n_extensions_server_supported_versions_process(struct s2n_connectio
     uint8_t highest_supported_version = conn->client_protocol_version;
     uint8_t minimum_supported_version;
     POSIX_GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
+    POSIX_ENSURE(highest_supported_version >= minimum_supported_version, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 
     uint8_t server_version_parts[S2N_TLS_PROTOCOL_VERSION_LEN];
     POSIX_GUARD(s2n_stuffer_read_bytes(extension, server_version_parts, S2N_TLS_PROTOCOL_VERSION_LEN));

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -57,6 +57,31 @@ const struct s2n_cipher_preferences cipher_preferences_20190801 = {
     .suites = cipher_suites_20190801,
 };
 
+/* Same as 20190801, but with ECDSA for TLS 1.2 added */
+struct s2n_cipher_suite *cipher_suites_20210831[] = {
+    S2N_TLS13_CLOUDFRONT_CIPHER_SUITES_20200716,
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_chacha20_poly1305_sha256,
+    &s2n_ecdhe_rsa_with_chacha20_poly1305_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_128_cbc_sha256,
+    &s2n_rsa_with_aes_128_cbc_sha
+};
+
+const struct s2n_cipher_preferences cipher_preferences_20210831 = {
+    .count = s2n_array_len(cipher_suites_20210831),
+    .suites = cipher_suites_20210831,
+};
+
 /* s2n's list of cipher suites, in order of preference, as of 2014-06-01 */
 struct s2n_cipher_suite *cipher_suites_20140601[] = {
     &s2n_dhe_rsa_with_aes_128_cbc_sha256,

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -50,6 +50,7 @@ extern const struct s2n_cipher_preferences cipher_preferences_20210816;
 extern const struct s2n_cipher_preferences cipher_preferences_20210816_gcm;
 extern const struct s2n_cipher_preferences cipher_preferences_20210825;
 extern const struct s2n_cipher_preferences cipher_preferences_20210825_gcm;
+extern const struct s2n_cipher_preferences cipher_preferences_20210831;
 
 extern const struct s2n_cipher_preferences cipher_preferences_test_all;
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -800,6 +800,7 @@ int s2n_connection_get_client_auth_type(struct s2n_connection *conn, s2n_cert_au
     if (conn->client_cert_auth_type_overridden) {
         *client_cert_auth_type = conn->client_cert_auth_type;
     } else {
+        POSIX_ENSURE_REF(conn->config);
         *client_cert_auth_type = conn->config->client_cert_auth_type;
     }
 

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -872,7 +872,7 @@ int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const cha
     POSIX_ENSURE_REF(security_policy->signature_preferences);
     POSIX_ENSURE_REF(security_policy->ecc_preferences);
 
-    /* If the Security Policies Minimum version is higher than what libcrypto supports, return an error. */
+    /* If the security policy's minimum version is higher than what libcrypto supports, return an error. */
     POSIX_ENSURE((security_policy->minimum_protocol_version <= s2n_get_highest_fully_supported_tls_version()), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 
     conn->security_policy_override = security_policy;

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -855,7 +855,7 @@ int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *ver
     POSIX_ENSURE_REF(security_policy->signature_preferences);
     POSIX_ENSURE_REF(security_policy->ecc_preferences);
 
-    /* If the Security Policies Minimum version is higher than what libcrypto supports, return an error. */
+    /* If the security policy's minimum version is higher than what libcrypto supports, return an error. */
     POSIX_ENSURE((security_policy->minimum_protocol_version <= s2n_get_highest_fully_supported_tls_version()), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 
     config->security_policy = security_policy;

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -27,9 +27,9 @@ const struct s2n_security_policy security_policy_20170210 = {
     .ecc_preferences = &s2n_ecc_preferences_20140601,
 };
 
-const struct s2n_security_policy security_policy_20201110 = {
+const struct s2n_security_policy security_policy_default_tls13 = {
     .minimum_protocol_version = S2N_TLS10,
-    .cipher_preferences = &cipher_preferences_20190801,
+    .cipher_preferences = &cipher_preferences_20210831,
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .certificate_signature_preferences = &s2n_certificate_signature_preferences_20201110,
@@ -733,7 +733,7 @@ const struct s2n_security_policy security_policy_null = {
 
 struct s2n_security_policy_selection security_policy_selection[] = {
     { .version="default", .security_policy=&security_policy_20170210, .ecc_extension_required=0, .pq_kem_extension_required=0 },
-    { .version="default_tls13", .security_policy=&security_policy_20201110, .ecc_extension_required=0, .pq_kem_extension_required=0 },
+    { .version="default_tls13", .security_policy=&security_policy_default_tls13, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="default_fips", .security_policy=&security_policy_20170405, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     { .version="ELBSecurityPolicy-TLS-1-0-2015-04", .security_policy=&security_policy_elb_2015_04, .ecc_extension_required=0, .pq_kem_extension_required=0 },
     /* Not a mistake. TLS-1-0-2015-05 and 2016-08 are equivalent */
@@ -855,6 +855,9 @@ int s2n_config_set_cipher_preferences(struct s2n_config *config, const char *ver
     POSIX_ENSURE_REF(security_policy->signature_preferences);
     POSIX_ENSURE_REF(security_policy->ecc_preferences);
 
+    /* If the Security Policies Minimum version is higher than what libcrypto supports, return an error. */
+    POSIX_ENSURE((security_policy->minimum_protocol_version <= s2n_get_highest_fully_supported_tls_version()), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+
     config->security_policy = security_policy;
     return 0;
 }
@@ -868,6 +871,9 @@ int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const cha
     POSIX_ENSURE_REF(security_policy->kem_preferences);
     POSIX_ENSURE_REF(security_policy->signature_preferences);
     POSIX_ENSURE_REF(security_policy->ecc_preferences);
+
+    /* If the Security Policies Minimum version is higher than what libcrypto supports, return an error. */
+    POSIX_ENSURE((security_policy->minimum_protocol_version <= s2n_get_highest_fully_supported_tls_version()), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 
     conn->security_policy_override = security_policy;
     return 0;

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -62,7 +62,7 @@ extern const struct s2n_security_policy security_policy_20190214;
 extern const struct s2n_security_policy security_policy_20190214_gcm;
 extern const struct s2n_security_policy security_policy_20190801;
 extern const struct s2n_security_policy security_policy_20190802;
-extern const struct s2n_security_policy security_policy_20201110;
+extern const struct s2n_security_policy security_policy_default_tls13;
 extern const struct s2n_security_policy security_policy_test_all;
 
 extern const struct s2n_security_policy security_policy_test_all_tls12;

--- a/tls/s2n_tls13.c
+++ b/tls/s2n_tls13.c
@@ -16,6 +16,7 @@
 #include "api/s2n.h"
 #include "tls/s2n_tls.h"
 #include "tls/s2n_tls13.h"
+#include "crypto/s2n_rsa_pss.h"
 #include "crypto/s2n_rsa_signing.h"
 
 bool s2n_use_default_tls13_config_flag = false;
@@ -23,6 +24,15 @@ bool s2n_use_default_tls13_config_flag = false;
 bool s2n_use_default_tls13_config()
 {
     return s2n_use_default_tls13_config_flag;
+}
+
+bool s2n_is_tls13_fully_supported() {
+    /* Older versions of Openssl (eg 1.0.2) do not support RSA PSS, which is required for TLS 1.3. */
+    return s2n_is_rsa_pss_signing_supported() && s2n_is_rsa_pss_certs_supported();
+}
+
+int s2n_get_highest_fully_supported_tls_version() {
+    return s2n_is_tls13_fully_supported() ? S2N_TLS13 : S2N_TLS12;
 }
 
 /* Allow TLS1.3 to be negotiated, and use the default TLS1.3 security policy.

--- a/tls/s2n_tls13.h
+++ b/tls/s2n_tls13.h
@@ -42,6 +42,8 @@ extern "C" {
 extern uint8_t hello_retry_req_random[S2N_TLS_RANDOM_DATA_LEN];
 
 bool s2n_use_default_tls13_config();
+bool s2n_is_tls13_fully_supported();
+int s2n_get_highest_fully_supported_tls_version();
 int s2n_disable_tls13();
 int s2n_reset_tls13();
 bool s2n_is_valid_tls13_cipher(const uint8_t version[2]);


### PR DESCRIPTION
### Resolved issues:
Continuation of https://github.com/aws/s2n-tls/pull/3009 since there are TLS Servers in the wild that will pick RSA PSS no matter what if a client offers support for TLS 1.3, even if RSA PSS is not offered in the Signatures Schems extension. 

This behavior seems to be allowed due to the TLS 1.3 RFC stating servers are allowed to assume clients support RSA PSS if TLS 1.3 is offered. 

[This paragraph from Page 44](https://datatracker.ietf.org/doc/html/rfc8446#page-44):

```
Implementations that advertise support for RSASSA-PSS (which is
mandatory in TLS 1.3) MUST be prepared to accept a signature using
that scheme even when TLS 1.2 is negotiated.  In TLS 1.2,
RSASSA-PSS is used with RSA cipher suites.
```
[... and this paragraph from Page 70](https://datatracker.ietf.org/doc/html/rfc8446#page-70):
```
  RSA signatures MUST use an
   RSASSA-PSS algorithm, regardless of whether RSASSA-PKCS1-v1_5
   algorithms appear in "signature_algorithms".  The SHA-1 algorithm
   MUST NOT be used in any signatures of CertificateVerify messages.
```

### Description of changes: 
s2n client will now self-downgrade itself to TLS 1.2 if the libcrypto it was compiled against does not support RSA PSS signature algorithms with RSA Certificates (eg Openssl 1.0.2). Previously, s2n unit tests used ECDSA Certificates to test TLS 1.3 functionality when compiled against Openssl 1.0.2. With this change, many unit tests that were previously using and assuming TLS 1.3 + ECDSA with Openssl 1.0.2, were downgraded to use TLS 1.2 + ECDSA with Openssl 1.0.2 and needed to be updated if the feature they were testing was TLS 1.3 only. 

##### The following are all of the major changes in this PR:
 - s2n client will self-downgrade to TLS 1.2 if the libcrypto it was compiled against does not support RSA PSS (Eg Openssl 1.0.2). 
 - `default_tls13` Security Policy was updated to add support for ECDSA ciphers when TLS 1.2 was negotiated. This is so that any tests that get downgraded from "ECDSA + TLS 1.3" to "ECDSA + TLS 1.2" can still complete a TLS handshake if the feature they are using does not depend on TLS 1.3.
 - `default_tls13` now prefers AES-128 over AES-256 for both TLS 1.2 and TLS 1.3. This is to make the priority order consistent between TLS versions, since previously AES-256 was higher priority only for TLS 1.3. 
 - New logic was added to reject users attempting to configure Security Policies that have a higher minimum TLS version than what the libcrypto supports. This is to improve the customer experience so that customers will get a clear error message when setting these Security Policies, rather than encounter hard to debug TLS negotiation failures when attempting to connect to various sites. At the moment, the only Security Policy that matches this criteria is `AWS-CRT-SDK-TLSv1.3` when s2n is compiled with older versions of libcrypto.
 - New internal API's `s2n_get_highest_fully_supported_tls_version()` and `s2n_is_tls13_fully_supported()` were added. These are used throughout the unit tests where TLS 1.3 was previously hard-coded so that we still run as many tests as possible when downgrading to TLS 1.2. 
 - Updates to Unit/Integration tests to allow for TLS 1.2 downgrades. These changes will vary from test to test, but I attempted to keep as many tests as possible, but sometimes was forced to disable certain tests if the feature under test required TLS 1.3, or if a significant number of tests in a file used TLS 1.3 features.
 

### Call-outs:
None.

### Testing:
Modified a large number of tests, since many previously had the assumption that if `default_tls13` security policy was used by both Client and Server, then it would guarantee that TLS 1.3 is negotiated. This is no longer the case since if s2n is compiled against Openssl 1.0.2 (which is missing support for RSA PSS), then the s2n client will downgrade itself to TLS 1.2 (even though TLS 1.3 could be used if ECDSA is used). 

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
