### PR TITLE
Offer only TLS1.3 handshake options if QUIC enabled

### DIFF
--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -44,6 +44,8 @@
 #define TLS12_LENGTH_TO_CIPHER_LIST (LENGTH_TO_SESSION_ID + 1)
 #define TLS13_LENGTH_TO_CIPHER_LIST (TLS12_LENGTH_TO_CIPHER_LIST + S2N_TLS_SESSION_ID_MAX_LEN)
 
+int s2n_parse_client_hello(struct s2n_connection *conn);
+
 int main(int argc, char **argv)
 {
     struct s2n_cert_chain_and_key *chain_and_key, *ecdsa_chain_and_key;
@@ -352,6 +354,87 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_free(config));
             EXPECT_SUCCESS(s2n_disable_tls13());
         }
+
+        /* TLS_EMPTY_RENEGOTIATION_INFO_SCSV only included if TLS1.2 ciphers included */
+        {
+            EXPECT_SUCCESS(s2n_reset_tls13());
+            const uint8_t empty_renegotiation_info_scsv[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_EMPTY_RENEGOTIATION_INFO_SCSV };
+
+            struct {
+                const char* security_policy;
+                bool expect_renegotiation_info;
+            } test_cases[] = {
+                { .security_policy = "test_all_tls13",  .expect_renegotiation_info = false },
+                { .security_policy = "default_tls13",   .expect_renegotiation_info = true },
+                { .security_policy = "default",         .expect_renegotiation_info = true },
+            };
+
+            for (size_t i = 0; i < s2n_array_len(test_cases); i++) {
+                struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+                EXPECT_NOT_NULL(conn);
+                EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, test_cases[i].security_policy));
+
+                EXPECT_SUCCESS(s2n_client_hello_send(conn));
+                EXPECT_SUCCESS(s2n_parse_client_hello(conn));
+
+                struct s2n_blob *cipher_suites = &conn->client_hello.cipher_suites;
+                EXPECT_TRUE(cipher_suites->size > 0);
+
+                uint8_t *iana = cipher_suites->data;
+                bool found_renegotiation_info = false;
+                for (size_t j = 0; j < cipher_suites->size; j+=S2N_TLS_CIPHER_SUITE_LEN) {
+                    if (memcmp(iana + j, empty_renegotiation_info_scsv, S2N_TLS_CIPHER_SUITE_LEN) == 0) {
+                        found_renegotiation_info = true;
+                    }
+                }
+
+                EXPECT_EQUAL(found_renegotiation_info, test_cases[i].expect_renegotiation_info);
+
+                EXPECT_SUCCESS(s2n_connection_free(conn));
+            }
+        }
+
+        /* TLS1.2 cipher suites not written if QUIC enabled */
+        {
+            EXPECT_SUCCESS(s2n_reset_tls13());
+
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_NOT_NULL(config);
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+
+            bool quic_enabled[] = { false, true };
+
+            /* TLS 1.2 cipher suites only written if QUIC not enabled */
+            for (size_t i = 0; i < s2n_array_len(quic_enabled); i++) {
+                config->quic_enabled = quic_enabled[i];
+
+                struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+                EXPECT_NOT_NULL(conn);
+                EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+                EXPECT_SUCCESS(s2n_client_hello_send(conn));
+                EXPECT_SUCCESS(s2n_parse_client_hello(conn));
+
+                struct s2n_blob *cipher_suites = &conn->client_hello.cipher_suites;
+                EXPECT_TRUE(cipher_suites->size > 0);
+
+                bool tls12_cipher_found = false;
+                uint8_t *iana = cipher_suites->data;
+                for (size_t j = 0; j < cipher_suites->size; j+=S2N_TLS_CIPHER_SUITE_LEN) {
+                    /* All TLS1.3 cipher suites have IANAs starting with 0x13 */
+                    if (iana[j] != 0x13) {
+                        tls12_cipher_found = true;
+                    }
+                }
+
+                /* TLS1.2 and QUIC are mutually exclusive */
+                EXPECT_TRUE(tls12_cipher_found != quic_enabled[i]);
+
+                EXPECT_SUCCESS(s2n_connection_free(conn));
+            }
+
+            EXPECT_SUCCESS(s2n_config_free(config));
+        }
     }
 
     /* Test that negotiating TLS1.2 with QUIC-enabled server fails */
@@ -386,7 +469,6 @@ int main(int argc, char **argv)
         /* Fails when negotiating TLS1.2 */
         {
             struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
-            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "test_all_tls12"));
 
             struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);

--- a/tests/unit/s2n_signature_algorithms_test.c
+++ b/tests/unit/s2n_signature_algorithms_test.c
@@ -180,6 +180,25 @@ int main(int argc, char **argv)
             }
         }
 
+        /* Test: do not send TLS1.2 signature schemes if QUIC enabled */
+        {
+            s2n_stuffer_wipe(&result);
+            config->quic_enabled = true;
+
+            conn->actual_protocol_version = S2N_TLS13;
+            EXPECT_SUCCESS(s2n_send_supported_sig_scheme_list(conn, &result));
+
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&result, &size));
+            EXPECT_TRUE(size > 0);
+            EXPECT_EQUAL(size, s2n_supported_sig_scheme_list_size(conn));
+
+            EXPECT_SUCCESS(s2n_stuffer_read_uint16(&result, &iana_value));
+            EXPECT_EQUAL(iana_value, s2n_ecdsa_secp384r1_sha384.iana_value);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&result), 0);
+
+            config->quic_enabled = false;
+        }
+
         s2n_connection_free(conn);
         s2n_config_free(config);
         s2n_stuffer_free(&result);

--- a/tests/unit/s2n_signature_algorithms_test.c
+++ b/tests/unit/s2n_signature_algorithms_test.c
@@ -49,7 +49,6 @@ const struct s2n_signature_preferences test_preferences = {
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
-    EXPECT_SUCCESS(s2n_disable_tls13());
 
     struct s2n_cert_chain_and_key *rsa_cert_chain;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&rsa_cert_chain,
@@ -235,6 +234,7 @@ int main(int argc, char **argv)
             s2n_stuffer_wipe(&choice);
             s2n_stuffer_write_uint16(&choice, s2n_rsa_pkcs1_sha256.iana_value);
 
+            conn->actual_protocol_version = S2N_TLS12;
             EXPECT_SUCCESS(s2n_get_and_validate_negotiated_signature_scheme(conn, &choice, &result));
             EXPECT_EQUAL(result.iana_value, s2n_rsa_pkcs1_sha256.iana_value);
             EXPECT_BYTEARRAY_EQUAL(&result, &s2n_rsa_pkcs1_sha256, sizeof(struct s2n_signature_scheme));

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -191,7 +191,7 @@ int s2n_collect_client_hello(struct s2n_connection *conn, struct s2n_stuffer *so
     return 0;
 }
 
-static int s2n_parse_client_hello(struct s2n_connection *conn)
+int s2n_parse_client_hello(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
     POSIX_GUARD(s2n_collect_client_hello(conn, &conn->handshake.io));
@@ -386,6 +386,28 @@ int s2n_client_hello_recv(struct s2n_connection *conn)
     return 0;
 }
 
+
+static bool s2n_cipher_suite_available(struct s2n_connection *conn, struct s2n_cipher_suite *cipher)
+{
+    if (!conn || !cipher || !conn->config) {
+        return false;
+    }
+
+    if (!cipher->available) {
+        return false;
+    }
+
+    if (cipher->minimum_required_tls_version > conn->client_protocol_version) {
+        return false;
+    }
+
+    if (conn->config->quic_enabled && cipher->minimum_required_tls_version < S2N_TLS13) {
+        return false;
+    }
+
+    return true;
+}
+
 int s2n_client_hello_send(struct s2n_connection *conn)
 {
     const struct s2n_security_policy *security_policy;
@@ -434,16 +456,24 @@ int s2n_client_hello_send(struct s2n_connection *conn)
     POSIX_GUARD(s2n_stuffer_reserve_uint16(out, &available_cipher_suites_size));
 
     /* Now, write the IANA values of every available cipher suite in our list */
+    struct s2n_cipher_suite *cipher = NULL;
+    bool legacy_renegotiation_signal_required = false;
     for (int i = 0; i < security_policy->cipher_preferences->count; i++ ) {
-        if (cipher_preferences->suites[i]->available &&
-                cipher_preferences->suites[i]->minimum_required_tls_version <= conn->client_protocol_version) {
-            POSIX_GUARD(s2n_stuffer_write_bytes(out, security_policy->cipher_preferences->suites[i]->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
+        cipher = cipher_preferences->suites[i];
+        if (!s2n_cipher_suite_available(conn, cipher)) {
+            continue;
         }
+        if (cipher->minimum_required_tls_version < S2N_TLS13) {
+            legacy_renegotiation_signal_required = true;
+        }
+        POSIX_GUARD(s2n_stuffer_write_bytes(out, cipher->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
     }
 
-    /* Lastly, write TLS_EMPTY_RENEGOTIATION_INFO_SCSV so that server knows it's an initial handshake (RFC5746 Section 3.4) */
-    uint8_t renegotiation_info_scsv[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_EMPTY_RENEGOTIATION_INFO_SCSV };
-    POSIX_GUARD(s2n_stuffer_write_bytes(out, renegotiation_info_scsv, S2N_TLS_CIPHER_SUITE_LEN));
+    if (legacy_renegotiation_signal_required) {
+        /* Lastly, write TLS_EMPTY_RENEGOTIATION_INFO_SCSV so that server knows it's an initial handshake (RFC5746 Section 3.4) */
+        uint8_t renegotiation_info_scsv[S2N_TLS_CIPHER_SUITE_LEN] = { TLS_EMPTY_RENEGOTIATION_INFO_SCSV };
+        POSIX_GUARD(s2n_stuffer_write_bytes(out, renegotiation_info_scsv, S2N_TLS_CIPHER_SUITE_LEN));
+    }
 
     /* Write size of the list of available ciphers */
     POSIX_GUARD(s2n_stuffer_write_vector_size(&available_cipher_suites_size));

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -32,6 +32,13 @@ static int s2n_signature_scheme_valid_to_offer(struct s2n_connection *conn, cons
     /* We don't know what protocol version we will eventually negotiate, but we know that it won't be any higher. */
     POSIX_ENSURE_GTE(conn->actual_protocol_version, scheme->minimum_protocol_version);
 
+    /* QUIC only supports TLS1.3 */
+    POSIX_ENSURE_REF(conn->config);
+    if (conn->config->quic_enabled
+            && scheme->maximum_protocol_version != S2N_UNKNOWN_PROTOCOL_VERSION) {
+        POSIX_ENSURE_GTE(scheme->maximum_protocol_version, S2N_TLS13);
+    }
+
     if (!s2n_is_rsa_pss_signing_supported()) {
         POSIX_ENSURE_NE(scheme->sig_alg, S2N_SIGNATURE_RSA_PSS_RSAE);
     }

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -24,6 +24,7 @@
 #include "tls/s2n_signature_algorithms.h"
 #include "tls/s2n_signature_scheme.h"
 #include "tls/s2n_security_policies.h"
+#include "tls/s2n_tls.h"
 
 #include "utils/s2n_safety.h"
 
@@ -32,11 +33,8 @@ static int s2n_signature_scheme_valid_to_offer(struct s2n_connection *conn, cons
     /* We don't know what protocol version we will eventually negotiate, but we know that it won't be any higher. */
     POSIX_ENSURE_GTE(conn->actual_protocol_version, scheme->minimum_protocol_version);
 
-    /* QUIC only supports TLS1.3 */
-    POSIX_ENSURE_REF(conn->config);
-    if (conn->config->quic_enabled
-            && scheme->maximum_protocol_version != S2N_UNKNOWN_PROTOCOL_VERSION) {
-        POSIX_ENSURE_GTE(scheme->maximum_protocol_version, S2N_TLS13);
+    if (s2n_is_version_fallback_disabled(conn) && scheme->maximum_protocol_version) {
+        POSIX_ENSURE_GTE(scheme->maximum_protocol_version, s2n_highest_protocol_version);
     }
 
     if (!s2n_is_rsa_pss_signing_supported()) {

--- a/tls/s2n_tls13.c
+++ b/tls/s2n_tls13.c
@@ -82,3 +82,8 @@ bool s2n_is_middlebox_compat_enabled(struct s2n_connection *conn)
     return s2n_connection_get_protocol_version(conn) >= S2N_TLS13
             && conn && conn->config && !conn->config->quic_enabled;
 }
+
+bool s2n_is_version_fallback_disabled(struct s2n_connection *conn)
+{
+    return conn && conn->config && conn->config->quic_enabled;
+}

--- a/tls/s2n_tls13.h
+++ b/tls/s2n_tls13.h
@@ -47,6 +47,7 @@ int s2n_reset_tls13();
 bool s2n_is_valid_tls13_cipher(const uint8_t version[2]);
 
 bool s2n_is_middlebox_compat_enabled(struct s2n_connection *conn);
+bool s2n_is_version_fallback_disabled(struct s2n_connection *conn);
 
 bool s2n_is_hello_retry_handshake(struct s2n_connection *conn);
 bool s2n_is_hello_retry_message(struct s2n_connection *conn);


### PR DESCRIPTION
### Description of changes: 

Rather than always adding separate "TLS1.3-only" security policies for QUIC implementations to use, it might be cleaner to let it use any security policy but disable all non-TLS1.3 options.

### Call-outs:

Thoughts: Is this a good idea? Or should we just add separate TLS1.3-only policies for QUIC implementations?

### Testing:

Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
