### PR TITLE
Remove twitter.com from endpoint handshake test for OpenSSL 1.0.2

### DIFF
--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -19,7 +19,6 @@ import subprocess
 import sys
 import time
 
-from common.s2n_test_scenario import get_libcrypto
 from s2n_test_constants import *
 
 # If a cipher_preference_version is specified, we will use it while attempting the handshake;
@@ -31,18 +30,15 @@ well_known_endpoints = [
     {"endpoint": "facebook.com"},
     {"endpoint": "google.com"},
     {"endpoint": "s3.amazonaws.com"},
-    {"endpoint": "twitter.com"},
+    # twitter.com offers RSA certificates even when the client does not include RSA PSS
+    # in the the Signature Schemes extension. Disabling twitter for now since this prevents
+    # s2n from negotiating a handshake if the libcrypto does not support RSA PSS signature
+    # algorithms with RSA Certificates
+    # See https://github.com/aws/s2n-tls/pull/3030
+    # {"endpoint": "twitter.com"},
     {"endpoint": "wikipedia.org"},
     {"endpoint": "yahoo.com"},
 ]
-
-# twitter.com offers RSA certificates even when the client does not include RSA PSS
-# in the the Signature Schemes extension. Since OpenSSL 1.0.2 does not support
-# RSA PSS signature algorithms with RSA Certificates, we are unable to negotiate a
-# handshake with twitter.com in this case.
-# See https://github.com/aws/s2n-tls/pull/3030
-if get_libcrypto() in ["openssl-1.0.2", "openssl-1.0.2-fips"]:
-    well_known_endpoints.remove({"endpoint": "twitter.com"})
 
 if os.getenv("S2N_NO_PQ") is None:
     # If PQ was compiled into S2N, test the PQ preferences against KMS

--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 import time
 
+from common.s2n_test_scenario import get_libcrypto
 from s2n_test_constants import *
 
 # If a cipher_preference_version is specified, we will use it while attempting the handshake;
@@ -30,9 +31,18 @@ well_known_endpoints = [
     {"endpoint": "facebook.com"},
     {"endpoint": "google.com"},
     {"endpoint": "s3.amazonaws.com"},
+    {"endpoint": "twitter.com"},
     {"endpoint": "wikipedia.org"},
     {"endpoint": "yahoo.com"},
 ]
+
+# twitter.com offers RSA certificates even when the client does not include RSA PSS
+# in the the Signature Schemes extension. Since OpenSSL 1.0.2 does not support
+# RSA PSS signature algorithms with RSA Certificates, we are unable to negotiate a
+# handshake with twitter.com in this case.
+# See https://github.com/aws/s2n-tls/pull/3030
+if get_libcrypto() in ["openssl-1.0.2", "openssl-1.0.2-fips"]:
+    well_known_endpoints.remove({"endpoint": "twitter.com"})
 
 if os.getenv("S2N_NO_PQ") is None:
     # If PQ was compiled into S2N, test the PQ preferences against KMS

--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -13,15 +13,13 @@
 # permissions and limitations under the License.
 #
 
+import argparse
 import os
+import subprocess
 import sys
 import time
-import socket
-import subprocess
-import itertools
-import argparse
-from s2n_test_constants import *
 
+from s2n_test_constants import *
 
 # If a cipher_preference_version is specified, we will use it while attempting the handshake;
 # otherwise, s2n will use the default. If an expected_cipher is specified, the test will pass
@@ -32,7 +30,6 @@ well_known_endpoints = [
     {"endpoint": "facebook.com"},
     {"endpoint": "google.com"},
     {"endpoint": "s3.amazonaws.com"},
-    {"endpoint": "twitter.com"},
     {"endpoint": "wikipedia.org"},
     {"endpoint": "yahoo.com"},
 ]


### PR DESCRIPTION
### Description of changes: 

twitter.com offers RSA certificates even when the client does not include RSA PSS
in the the Signature Schemes extension. Since OpenSSL 1.0.2 does not support
RSA PSS signature algorithms with RSA Certificates, we are unable to negotiate a
handshake with twitter.com in this case.

See https://github.com/aws/s2n-tls/pull/3030

### Call-outs:

N/A

### Testing:

N/A

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
