### PR TITLE
Remove ChaCha TLS 1.3 Cipher from KMS FIPS Cipher Pref List

### DIFF
--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -1727,7 +1727,8 @@ const struct s2n_cipher_preferences cipher_preferences_kms_fips_tls_1_2_2018_10 
 };
 
 struct s2n_cipher_suite *cipher_suites_kms_fips_tls_1_2_2021_08[] = {
-    S2N_TLS13_CLOUDFRONT_CIPHER_SUITES_20200716,
+    &s2n_tls13_aes_128_gcm_sha256,
+    &s2n_tls13_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,


### PR DESCRIPTION
### Resolved issues:
N/A


### Description of changes: 
Removes ChaCha Cipher from recently added KMS FIPS Cipher Policy. No impact since this policy was just added a few days ago and is not actually used anywhere yet.

### Call-outs:
None

### Testing:
Existing Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
