### PR TITLE
Fix TLS1.2 session cache + missing ticket key

### DIFF
--- a/tests/unit/s2n_self_talk_session_resumption_test.c
+++ b/tests/unit/s2n_self_talk_session_resumption_test.c
@@ -694,14 +694,14 @@ int main(int argc, char **argv)
         /* Setup config without session ticket key */
         struct s2n_config *no_key_config = s2n_config_new();
         EXPECT_NOT_NULL(no_key_config);
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(no_key_config, "AWS-CRT-SDK-TLSv1.0"));
+        no_key_config->security_policy = server_config->security_policy;
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(no_key_config));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(no_key_config, tls13_chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(no_key_config, true));
 
         struct s2n_config *no_key_config_with_cache = s2n_config_new();
         EXPECT_NOT_NULL(no_key_config_with_cache);
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(no_key_config_with_cache, "AWS-CRT-SDK-TLSv1.0"));
+        no_key_config_with_cache->security_policy = server_config->security_policy;
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(no_key_config_with_cache));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(no_key_config_with_cache, tls13_chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(no_key_config_with_cache, true));

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -86,7 +86,9 @@ static int s2n_calculate_keys(struct s2n_connection *conn, struct s2n_blob *shar
 
     /* Expand the keys */
     POSIX_GUARD(s2n_prf_key_expansion(conn));
-    /* Save the master secret in the cache */
+    /* Save the master secret in the cache.
+     * Failing to cache the session should not affect the current handshake.
+     */
     if (s2n_allowed_to_cache_connection(conn)) {
         s2n_result_ignore(s2n_store_to_cache(conn));
     }

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -88,7 +88,7 @@ static int s2n_calculate_keys(struct s2n_connection *conn, struct s2n_blob *shar
     POSIX_GUARD(s2n_prf_key_expansion(conn));
     /* Save the master secret in the cache */
     if (s2n_allowed_to_cache_connection(conn)) {
-        POSIX_GUARD(s2n_store_to_cache(conn));
+        s2n_result_ignore(s2n_store_to_cache(conn));
     }
     /* log the secret, if needed */
     s2n_result_ignore(s2n_key_log_tls12_secret(conn));

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -95,5 +95,5 @@ typedef enum {
 
 extern int s2n_allowed_to_cache_connection(struct s2n_connection *conn);
 extern int s2n_resume_from_cache(struct s2n_connection *conn);
-extern int s2n_store_to_cache(struct s2n_connection *conn);
+S2N_RESULT s2n_store_to_cache(struct s2n_connection *conn);
 S2N_RESULT s2n_connection_get_session_state_size(struct s2n_connection *conn, size_t *state_size);


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/3040

### Description of changes: 

If there are no valid keys to encrypt session tickets but session caching is enabled, the handshake fails on the ClientKeyExchange message when we try to encrypt and cache the session.

Caching a session should never cause the actual original connection to fail, so I made the caching call optional. I also switched it to an S2N_RESULT return type, because intentionally ignoring an S2N_RESULT return type is nicely self-documenting.

### Testing:

I extended the existing "TLS1.3 with no ticket keys doesn't issue new session tickets" self-talk test to also include:
* Both TLS1.2 and TLS1.3
* Both issuing new session tickets and using existing session tickets
* Both session tickets and session caching

That _should_ cover all the cases where a ticket key could be used?

(Integration tests failing bc of https://github.com/aws/s2n-tls/pull/3038)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
