### PR TITLE
Disable EndOfEarlyData message for QUIC + clean up QUIC special casing

### DIFF
--- a/tests/unit/s2n_quic_support_test.c
+++ b/tests/unit/s2n_quic_support_test.c
@@ -36,22 +36,31 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(config);
         EXPECT_FALSE(config->quic_enabled);
 
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_FALSE(s2n_connection_is_quic_enabled(conn));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+        EXPECT_FALSE(s2n_connection_is_quic_enabled(conn));
+
         /* Check error handling */
         {
             EXPECT_FAILURE_WITH_ERRNO(s2n_config_enable_quic(NULL), S2N_ERR_NULL);
             EXPECT_FALSE(config->quic_enabled);
+            EXPECT_FALSE(s2n_connection_is_quic_enabled(conn));
         }
 
         /* Check success */
         {
             EXPECT_SUCCESS(s2n_config_enable_quic(config));
             EXPECT_TRUE(config->quic_enabled);
+            EXPECT_TRUE(s2n_connection_is_quic_enabled(conn));
 
             /* Enabling QUIC again still succeeds */
             EXPECT_SUCCESS(s2n_config_enable_quic(config));
             EXPECT_TRUE(config->quic_enabled);
+            EXPECT_TRUE(s2n_connection_is_quic_enabled(conn));
         }
 
+        EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
     }
 

--- a/tls/extensions/s2n_quic_transport_params.c
+++ b/tls/extensions/s2n_quic_transport_params.c
@@ -31,14 +31,14 @@
 
 static bool s2n_quic_transport_params_should_send(struct s2n_connection *conn)
 {
-    return conn && conn->config && conn->config->quic_enabled;
+    return s2n_connection_is_quic_enabled(conn);
 }
 
 static int s2n_quic_transport_params_if_missing(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(conn->config);
-    POSIX_ENSURE(!conn->config->quic_enabled, S2N_ERR_MISSING_EXTENSION);
+    POSIX_ENSURE(!s2n_connection_is_quic_enabled(conn), S2N_ERR_MISSING_EXTENSION);
     return S2N_SUCCESS;
 }
 
@@ -58,7 +58,7 @@ static int s2n_quic_transport_params_recv(struct s2n_connection *conn, struct s2
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(extension);
     POSIX_ENSURE_REF(conn->config);
-    POSIX_ENSURE(conn->config->quic_enabled, S2N_ERR_UNSUPPORTED_EXTENSION);
+    POSIX_ENSURE(s2n_connection_is_quic_enabled(conn), S2N_ERR_UNSUPPORTED_EXTENSION);
 
     if (s2n_stuffer_data_available(extension)) {
         POSIX_GUARD(s2n_alloc(&conn->peer_quic_transport_parameters, s2n_stuffer_data_available(extension)));

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -60,7 +60,7 @@ static bool s2n_alerts_supported(struct s2n_connection *conn)
 {
     /* If running in QUIC mode, QUIC handles alerting.
      * S2N should not send or receive alerts. */
-    return conn && conn->config && !conn->config->quic_enabled;
+    return !s2n_connection_is_quic_enabled(conn);
 }
 
 static bool s2n_handle_as_warning(struct s2n_connection *conn, uint8_t level, uint8_t type)

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -70,9 +70,8 @@ static S2N_RESULT s2n_generate_client_session_id(struct s2n_connection *conn)
         return S2N_RESULT_OK;
     }
 
-    /* Generate the session id for TLS1.3 if in middlebox compatibility mode.
-     * For now, we default to middlebox compatibility mode unless using QUIC. */
-    if (conn->config->quic_enabled) {
+    /* Only generate the session id for TLS1.3 if in middlebox compatibility mode */
+    if (conn->client_protocol_version >= S2N_TLS13 && !s2n_is_middlebox_compat_enabled(conn)) {
         return S2N_RESULT_OK;
     }
 
@@ -303,7 +302,7 @@ int s2n_process_client_hello(struct s2n_connection *conn)
         POSIX_BAIL(S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
     }
 
-    if (conn->config->quic_enabled) {
+    if (s2n_connection_is_quic_enabled(conn)) {
         POSIX_ENSURE(conn->actual_protocol_version >= S2N_TLS13, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
     }
 

--- a/tls/s2n_early_data_io.c
+++ b/tls/s2n_early_data_io.c
@@ -34,6 +34,7 @@ int s2n_end_of_early_data_send(struct s2n_connection *conn)
 
 int s2n_end_of_early_data_recv(struct s2n_connection *conn)
 {
+    POSIX_ENSURE(!s2n_connection_is_quic_enabled(conn), S2N_ERR_BAD_MESSAGE);
     POSIX_GUARD_RESULT(s2n_connection_set_early_data_state(conn, S2N_END_OF_EARLY_DATA));
     return S2N_SUCCESS;
 }

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -965,7 +965,7 @@ static int s2n_handshake_write_io(struct s2n_connection *conn)
         out.data = s2n_stuffer_raw_read(&conn->handshake.io, out.size);
         POSIX_ENSURE_REF(out.data);
 
-        if (conn->config->quic_enabled) {
+        if (s2n_connection_is_quic_enabled(conn)) {
             POSIX_GUARD_RESULT(s2n_quic_write_handshake_message(conn, &out));
         } else {
             POSIX_GUARD(s2n_record_write(conn, record_type, &out));
@@ -1136,7 +1136,7 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
 
     /* Fill conn->in stuffer necessary for the handshake.
      * If using TCP, read a record. If using QUIC, read a message. */
-    if (conn->config->quic_enabled) {
+    if (s2n_connection_is_quic_enabled(conn)) {
         record_type = TLS_HANDSHAKE;
         POSIX_GUARD_RESULT(s2n_quic_read_handshake_message(conn, &message_type));
     } else {
@@ -1184,7 +1184,7 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
          * due to a peer operating in middlebox compatibility mode.
          * However, when operating in QUIC mode, S2N should not accept ANY CCS messages,
          * including these unexpected ones.*/
-        if (!IS_TLS13_HANDSHAKE(conn) || conn->config->quic_enabled) {
+        if (!IS_TLS13_HANDSHAKE(conn) || s2n_connection_is_quic_enabled(conn)) {
             POSIX_ENSURE(EXPECTED_RECORD_TYPE(conn) == TLS_CHANGE_CIPHER_SPEC, S2N_ERR_BAD_MESSAGE);
             POSIX_ENSURE(!CONNECTION_IS_WRITER(conn), S2N_ERR_BAD_MESSAGE);
         }

--- a/tls/s2n_key_update.c
+++ b/tls/s2n_key_update.c
@@ -33,7 +33,7 @@ int s2n_key_update_recv(struct s2n_connection *conn, struct s2n_stuffer *request
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE(conn->actual_protocol_version >= S2N_TLS13, S2N_ERR_BAD_MESSAGE);
-    POSIX_ENSURE(!conn->config->quic_enabled, S2N_ERR_BAD_MESSAGE);
+    POSIX_ENSURE(!s2n_connection_is_quic_enabled(conn), S2N_ERR_BAD_MESSAGE);
 
     uint8_t key_update_request;
     POSIX_GUARD(s2n_stuffer_read_uint8(request, &key_update_request));

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -42,6 +42,11 @@ int s2n_config_enable_quic(struct s2n_config *config)
     return S2N_SUCCESS;
 }
 
+bool s2n_connection_is_quic_enabled(struct s2n_connection *conn)
+{
+    return conn && conn->config && conn->config->quic_enabled;
+}
+
 int s2n_connection_set_quic_transport_parameters(struct s2n_connection *conn,
         const uint8_t *data_buffer, uint16_t data_len)
 {

--- a/tls/s2n_quic_support.h
+++ b/tls/s2n_quic_support.h
@@ -30,6 +30,7 @@
  */
 
 S2N_API int s2n_config_enable_quic(struct s2n_config *config);
+bool s2n_connection_is_quic_enabled(struct s2n_connection *conn);
 
 /*
  * Set the data to be sent in the quic_transport_parameters extension.

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -124,7 +124,7 @@ ssize_t s2n_recv_impl(struct s2n_connection * conn, void *buf, ssize_t size, s2n
     }
     *blocked = S2N_BLOCKED_ON_READ;
 
-    S2N_ERROR_IF(conn->config->quic_enabled, S2N_ERR_UNSUPPORTED_WITH_QUIC);
+    POSIX_ENSURE(!s2n_connection_is_quic_enabled(conn), S2N_ERR_UNSUPPORTED_WITH_QUIC);
     POSIX_GUARD_RESULT(s2n_early_data_validate_recv(conn));
 
     while (size && !conn->closed) {

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -92,8 +92,8 @@ ssize_t s2n_sendv_with_offset_impl(struct s2n_connection *conn, const struct iov
 {
     ssize_t user_data_sent, total_size = 0;
 
-    S2N_ERROR_IF(conn->closed, S2N_ERR_CLOSED);
-    S2N_ERROR_IF(conn->config->quic_enabled, S2N_ERR_UNSUPPORTED_WITH_QUIC);
+    POSIX_ENSURE(!conn->closed, S2N_ERR_CLOSED);
+    POSIX_ENSURE(!s2n_connection_is_quic_enabled(conn), S2N_ERR_UNSUPPORTED_WITH_QUIC);
 
     /* Flush any pending I/O */
     POSIX_GUARD(s2n_flush(conn, blocked));

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -131,8 +131,8 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
     } else {
         conn->server_protocol_version = (uint8_t)(protocol_version[0] * 10) + protocol_version[1];
 
-        S2N_ERROR_IF(s2n_client_detect_downgrade_mechanism(conn), S2N_ERR_PROTOCOL_DOWNGRADE_DETECTED);
-        POSIX_ENSURE(!conn->config->quic_enabled, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+        POSIX_ENSURE(!s2n_client_detect_downgrade_mechanism(conn), S2N_ERR_PROTOCOL_DOWNGRADE_DETECTED);
+        POSIX_ENSURE(!s2n_connection_is_quic_enabled(conn), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 
         /*
          *= https://tools.ietf.org/rfc/rfc8446#appendix-D.3

--- a/tls/s2n_tls13.c
+++ b/tls/s2n_tls13.c
@@ -80,5 +80,5 @@ bool s2n_is_valid_tls13_cipher(const uint8_t version[2]) {
 bool s2n_is_middlebox_compat_enabled(struct s2n_connection *conn)
 {
     return s2n_connection_get_protocol_version(conn) >= S2N_TLS13
-            && conn && conn->config && !conn->config->quic_enabled;
+            && !s2n_connection_is_quic_enabled(conn);
 }

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -209,7 +209,7 @@ int s2n_tls13_handle_early_traffic_secret(struct s2n_connection *conn)
     POSIX_GUARD(s2n_tls13_derive_early_traffic_secret(&secrets, &hash_state, &early_traffic_secret));
 
     /* trigger callbacks */
-    if (conn->secret_cb && conn->config->quic_enabled) {
+    if (conn->secret_cb && s2n_connection_is_quic_enabled(conn)) {
         POSIX_GUARD(conn->secret_cb(conn->secret_cb_context, conn, S2N_CLIENT_EARLY_TRAFFIC_SECRET,
                 early_traffic_secret.data, early_traffic_secret.size));
     }
@@ -297,7 +297,7 @@ int s2n_tls13_handle_handshake_traffic_secret(struct s2n_connection *conn, s2n_m
     POSIX_GUARD(s2n_tls13_derive_handshake_traffic_secret(&secrets, &conn->handshake.hashes->server_hello_copy, &hs_secret, mode));
 
     /* trigger secret callbacks */
-    if (conn->secret_cb && conn->config->quic_enabled) {
+    if (conn->secret_cb && s2n_connection_is_quic_enabled(conn)) {
         POSIX_GUARD(conn->secret_cb(conn->secret_cb_context, conn, secret_type, hs_secret.data, hs_secret.size));
     }
     s2n_result_ignore(s2n_key_log_tls13_secret(conn, &hs_secret, secret_type));
@@ -361,7 +361,7 @@ static int s2n_tls13_handle_application_secret(struct s2n_connection *conn, s2n_
     POSIX_GUARD(s2n_tls13_derive_application_secret(&keys, hash_state, &app_secret, mode));
 
     /* trigger secret callback */
-    if (conn->secret_cb && conn->config->quic_enabled) {
+    if (conn->secret_cb && s2n_connection_is_quic_enabled(conn)) {
         POSIX_GUARD(conn->secret_cb(conn->secret_cb_context, conn, secret_type,
                 app_secret.data, app_secret.size));
     }


### PR DESCRIPTION
### Description of changes: 

Add a new check to make sure we don't receive EndOfEarlyData if using QUIC. S2N doesn't actually support early data + QUIC yet, but we can at least fail if the unexpected message is received.

Also clean up existing "is QUIC enabled" checks.

### Testing:
Unit tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
