### PR TITLE
Allow QUIC to be enabled per-connection

### DIFF
--- a/tests/unit/s2n_quic_support_test.c
+++ b/tests/unit/s2n_quic_support_test.c
@@ -64,6 +64,43 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(config));
     }
 
+    /* Test s2n_connection_enable_quic */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_FALSE(s2n_connection_is_quic_enabled(conn));
+
+        /* Check error handling */
+        {
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_enable_quic(NULL), S2N_ERR_NULL);
+            EXPECT_FALSE(s2n_connection_is_quic_enabled(conn));
+        }
+
+        /* Check success */
+        {
+            EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
+            EXPECT_TRUE(s2n_connection_is_quic_enabled(conn));
+
+            /* Enabling QUIC again still succeeds */
+            EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
+            EXPECT_TRUE(s2n_connection_is_quic_enabled(conn));
+        }
+
+        /* Check with config enabled too */
+        {
+            struct s2n_config *config = s2n_config_new();
+            EXPECT_NOT_NULL(config);
+            EXPECT_FALSE(config->quic_enabled);
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+            EXPECT_SUCCESS(s2n_config_enable_quic(config));
+            EXPECT_TRUE(s2n_connection_is_quic_enabled(conn));
+
+            EXPECT_SUCCESS(s2n_config_free(config));
+        }
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
     /* Test s2n_connection_set_quic_transport_parameters */
     {
         /* Safety checks */

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -350,6 +350,9 @@ struct s2n_connection {
     /* Connection negotiated an EMS */
     unsigned ems_negotiated:1;
 
+    /* Connection can be used by a QUIC implementation */
+    unsigned quic_enabled:1;
+
     /* Flags to prevent users from calling methods recursively.
      * This can be an easy mistake to make when implementing send/receive callbacks.
      */

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -42,9 +42,17 @@ int s2n_config_enable_quic(struct s2n_config *config)
     return S2N_SUCCESS;
 }
 
+int s2n_connection_enable_quic(struct s2n_connection *conn)
+{
+    POSIX_ENSURE_REF(conn);
+    conn->quic_enabled = true;
+    return S2N_SUCCESS;
+}
+
 bool s2n_connection_is_quic_enabled(struct s2n_connection *conn)
 {
-    return conn && conn->config && conn->config->quic_enabled;
+    return (conn && conn->quic_enabled) ||
+           (conn && conn->config && conn->config->quic_enabled);
 }
 
 int s2n_connection_set_quic_transport_parameters(struct s2n_connection *conn,

--- a/tls/s2n_quic_support.h
+++ b/tls/s2n_quic_support.h
@@ -30,6 +30,7 @@
  */
 
 S2N_API int s2n_config_enable_quic(struct s2n_config *config);
+S2N_API int s2n_connection_enable_quic(struct s2n_connection *conn);
 bool s2n_connection_is_quic_enabled(struct s2n_connection *conn);
 
 /*


### PR DESCRIPTION
### Description of changes: 

Add a connection API to enable QUIC. QUIC implementations may not be responsible for managing S2N-TLS configurations, so setting the flag on the connection instead should be an option.

### Testing:

Unit tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
