### PR TITLE
Fix BIKE R3 PQ Assembly detection bug for AMD Zen 3 CPUs

### DIFF
--- a/pq-crypto/s2n_pq.c
+++ b/pq-crypto/s2n_pq.c
@@ -267,9 +267,10 @@ S2N_RESULT s2n_try_enable_bike_r3_opt_avx512() {
 }
 
 S2N_RESULT s2n_try_enable_bike_r3_opt_vpclmul() {
-    /* When VPCLMUL is available, AVX512 is too by default. */
     RESULT_ENSURE_OK(s2n_try_enable_bike_r3_opt_avx512(), S2N_ERR_SAFETY);
-    if (s2n_pq_is_enabled() && s2n_cpu_supports_bike_r3_vpclmul()) {
+    /* Only Enable VPCLMUL if AVX512 is also supported. This is to because the BIKE R3 VPCLMUL requires 512-bit version
+     * of VPCLMUL, and not the 256-bit version that is available on AMD Zen 3 processors. */
+    if (s2n_pq_is_enabled() && s2n_cpu_supports_bike_r3_vpclmul() && s2n_bike_r3_is_avx512_enabled()) {
         bike_r3_vpclmul_enabled = true;
     }
     return S2N_RESULT_OK;


### PR DESCRIPTION
### Resolved issues:
https://github.com/aws/s2n-tls/issues/3046

### Description of changes: 
Only enables BIKE Round 3's VPCLMUL flag if AVX512 is also supported. This is due to VPCLMUL having 512 bit width on Intel with AVX512, and only 256 bit width on AMD Zen 3 CPUs without AVX512.


### Call-outs:
None

### Testing:
Reproduced on AMD Ryzen 5950x, and unit tests confirm this fix works on that CPU.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
