### PR TITLE
Re-enable Twitter.com client integration test

### DIFF
--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -30,12 +30,7 @@ well_known_endpoints = [
     {"endpoint": "facebook.com"},
     {"endpoint": "google.com"},
     {"endpoint": "s3.amazonaws.com"},
-    # twitter.com offers RSA certificates even when the client does not include RSA PSS
-    # in the the Signature Schemes extension. Disabling twitter for now since this prevents
-    # s2n from negotiating a handshake if the libcrypto does not support RSA PSS signature
-    # algorithms with RSA Certificates
-    # See https://github.com/aws/s2n-tls/pull/3030
-    # {"endpoint": "twitter.com"},
+    {"endpoint": "twitter.com"},
     {"endpoint": "wikipedia.org"},
     {"endpoint": "yahoo.com"},
 ]


### PR DESCRIPTION
### Resolved issues:
Now that https://github.com/aws/s2n-tls/pull/3030 has been merged, we can re-enable this integration test


### Description of changes: 
Re-enables integration test that ensure's that s2n client can complete a TLS handshake with Twitter.

### Call-outs:
None.

### Testing:
Integration Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
