### PR TITLE
Turn On Client OCSP Stapled Test

### DIFF
--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -940,8 +940,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_connection_is_ocsp_stapled(server_conn), 1);
 
         /* Verify that the client received an OCSP response. */
-        /* Currently fails test. Remove when https://github.com/awslabs/s2n/issues/2239 is fixed */
-        /* EXPECT_EQUAL(s2n_connection_is_ocsp_stapled(client_conn), 1); */
+        EXPECT_EQUAL(s2n_connection_is_ocsp_stapled(client_conn), 1);
 
         EXPECT_NOT_NULL(server_ocsp_reply = s2n_connection_get_ocsp_response(client_conn, &length));
         EXPECT_EQUAL(length, sizeof(server_ocsp_status));

--- a/tls/extensions/s2n_server_certificate_status.c
+++ b/tls/extensions/s2n_server_certificate_status.c
@@ -58,7 +58,21 @@ int s2n_server_certificate_status_send(struct s2n_connection *conn, struct s2n_s
 int s2n_server_certificate_status_recv(struct s2n_connection *conn, struct s2n_stuffer *in)
 {
     POSIX_ENSURE_REF(conn);
-
+    /**
+     *= https://tools.ietf.org/rfc/rfc6066#section-8
+     *#   struct {
+     *#       CertificateStatusType status_type;
+     *#       select (status_type) {
+     *#          case ocsp: OCSPResponse;
+     *#       } response;
+     *#   } CertificateStatus;
+     *#
+     *#   opaque OCSPResponse<1..2^24-1>;
+     *#
+     *# An "ocsp_response" contains a complete, DER-encoded OCSP response
+     *# (using the ASN.1 type OCSPResponse defined in [RFC2560]).  Only one
+     *# OCSP response may be sent.
+     **/
     uint8_t type;
     POSIX_GUARD(s2n_stuffer_read_uint8(in, &type));
     if (type != S2N_STATUS_REQUEST_OCSP) {

--- a/tls/extensions/s2n_server_certificate_status.c
+++ b/tls/extensions/s2n_server_certificate_status.c
@@ -65,6 +65,7 @@ int s2n_server_certificate_status_recv(struct s2n_connection *conn, struct s2n_s
         /* We only support OCSP */
         return S2N_SUCCESS;
     }
+    conn->status_type = S2N_STATUS_REQUEST_OCSP;
 
     uint32_t status_size;
     POSIX_GUARD(s2n_stuffer_read_uint24(in, &status_size));


### PR DESCRIPTION
### Resolved issues:

 resolves #2212, resolves #2239

### Description of changes: 
s2n_connection_is_ocsp_stapled() is used by a client to determine whether the server sent an ocsp reponse. This function was failing in tls1.3. This is because OCSP data was moved from the Status Request message in TLS1.2 to extensions on the Certificate message in TLS1.3. During that move we did not set the connection->status_type flag, which tells the client what type of status response they have received. I set the type of the status response so that now  s2n_connection_is_ocsp_stapled works correctly.

Also added a compliance comment.
### Call-outs:
N/A
### Testing:

Turned on unit test.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
