### PR TITLE
Add API to track session tickets sent

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -498,7 +498,7 @@ extern int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, u
  * Returns the number of session tickets issued by the server.
  *
  * In TLS1.3, this number can be up to the limit configured by s2n_config_set_initial_ticket_count
- * and s2n_connection_add_new_tickets_to_send. In earlier versions, this number will be either 0 or 1.
+ * and s2n_connection_add_new_tickets_to_send. In earlier versions of TLS, this number will be either 0 or 1.
  *
  * @param conn A pointer to the connection object.
  * @param num The number of additional session tickets sent.

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -495,6 +495,18 @@ S2N_API
 extern int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num);
 
 /**
+ * Returns the number of session tickets issued by the server.
+ *
+ * In TLS1.3, this number can be up to the limit configured by s2n_config_set_initial_ticket_count
+ * and s2n_connection_add_new_tickets_to_send. In earlier versions, this number will be either 0 or 1.
+ *
+ * @param conn A pointer to the connection object.
+ * @param num The number of additional session tickets sent.
+ */
+S2N_API
+extern int s2n_connection_get_tickets_sent(struct s2n_connection *conn, uint16_t *num);
+
+/**
  * Sets the keying material lifetime for >=TLS1.3 session tickets so that one session doesn't get re-used ad infinitum.
  * The default value is one week.
  *

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -500,6 +500,8 @@ extern int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, u
  * In TLS1.3, this number can be up to the limit configured by s2n_config_set_initial_ticket_count
  * and s2n_connection_add_new_tickets_to_send. In earlier versions of TLS, this number will be either 0 or 1.
  *
+ * This method only works for server connections.
+ *
  * @param conn A pointer to the connection object.
  * @param num The number of additional session tickets sent.
  */

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1344,7 +1344,7 @@ number actually used by s2n-tls for the connection. **s2n_connection_get_client_
 returns the protocol version used to send the initial client hello message.
 
 Each version number value corresponds to the macros defined as **S2N_SSLv2**,
-**S2N_SSLv3**, **S2N_TLS10**, **S2N_TLS11** and **S2N_TLS12**.
+**S2N_SSLv3**, **S2N_TLS10**, **S2N_TLS11**, **S2N_TLS12**, and **S2N_TLS13**.
 
 ### s2n\_connection\_set\_verify\_host\_callback
 ```c
@@ -1640,7 +1640,7 @@ If the first byte in **session** is 0, then the next byte will contain session i
 
 **s2n_connection_get_session_id** gets the latest session id from the connection, copies it into the **session_id** buffer, and returns the number of copied bytes. The session id may change between s2n receiving the ClientHello and sending the ServerHello, but this function will always describe the latest session id. See **s2n_client_hello_get_session_id** to get the session id as it was sent by the client in the ClientHello message.
 
-**s2n_connection_is_session_resumed** returns 1 if the handshake was abbreviated, otherwise returns 0, for tls versions < TLS1.3.
+**s2n_connection_is_session_resumed** returns 1 if the handshake was abbreviated, otherwise returns 0.
 
 ## TLS1.3 Session Resumption Related Calls
 

--- a/tests/unit/s2n_self_talk_session_resumption_test.c
+++ b/tests/unit/s2n_self_talk_session_resumption_test.c
@@ -26,11 +26,7 @@
     (((client->handshake.handshake_type) & HELLO_RETRY_REQUEST) \
      && ((server->handshake.handshake_type) & HELLO_RETRY_REQUEST))
 
-#define EXPECT_TICKETS_SENT(conn, count) do { \
-    uint16_t _tickets_sent = 0; \
-    EXPECT_SUCCESS(s2n_connection_get_tickets_sent(conn, &_tickets_sent)); \
-    EXPECT_EQUAL(_tickets_sent, count); \
-} while(0);
+#define EXPECT_TICKETS_SENT(conn, count) EXPECT_OK(s2n_assert_tickets_sent(conn, count))
 
 struct s2n_early_data_test_case {
     bool ticket_supported;
@@ -38,6 +34,14 @@ struct s2n_early_data_test_case {
     bool server_supported;
     bool expect_success;
 };
+
+static S2N_RESULT s2n_assert_tickets_sent(struct s2n_connection *conn, uint16_t expected_tickets_sent)
+{
+    uint16_t tickets_sent = 0;
+    RESULT_GUARD_POSIX(s2n_connection_get_tickets_sent(conn, &tickets_sent));
+    RESULT_ENSURE_EQ(tickets_sent, expected_tickets_sent);
+    return S2N_RESULT_OK;
+}
 
 static S2N_RESULT s2n_wipe_connections(struct s2n_connection *client_conn, struct s2n_connection *server_conn,
         struct s2n_test_io_pair *io_pair)

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -839,7 +839,7 @@ int main(int argc, char **argv)
             EXPECT_OK(s2n_tls13_server_nst_send(conn, &blocked));
 
             EXPECT_EQUAL(0, s2n_stuffer_data_available(&stuffer));
-            EXPECT_TICKETS_SENT(conn, 0);
+            EXPECT_ERROR_WITH_ERRNO(s2n_assert_tickets_sent(conn, 0), S2N_ERR_CLIENT_MODE);
 
             EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
             EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -36,11 +36,15 @@
 
 #define MAX_TEST_SESSION_SIZE 300
 
-#define EXPECT_TICKETS_SENT(conn, count) do { \
-    uint16_t _tickets_sent = 0; \
-    EXPECT_SUCCESS(s2n_connection_get_tickets_sent(conn, &_tickets_sent)); \
-    EXPECT_EQUAL(_tickets_sent, count); \
-} while(0);
+#define EXPECT_TICKETS_SENT(conn, count) EXPECT_OK(s2n_assert_tickets_sent(conn, count))
+
+static S2N_RESULT s2n_assert_tickets_sent(struct s2n_connection *conn, uint16_t expected_tickets_sent)
+{
+    uint16_t tickets_sent = 0;
+    RESULT_GUARD_POSIX(s2n_connection_get_tickets_sent(conn, &tickets_sent));
+    RESULT_ENSURE_EQ(tickets_sent, expected_tickets_sent);
+    return S2N_RESULT_OK;
+}
 
 size_t cb_session_data_len = 0;
 uint8_t cb_session_data[MAX_TEST_SESSION_SIZE] = { 0 };

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -973,10 +973,11 @@ int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t 
     return S2N_SUCCESS;
 }
 
-extern int s2n_connection_get_tickets_sent(struct s2n_connection *conn, uint16_t *num)
+int s2n_connection_get_tickets_sent(struct s2n_connection *conn, uint16_t *num)
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(num);
+    POSIX_ENSURE(conn->mode == S2N_SERVER, S2N_ERR_CLIENT_MODE);
     *num = conn->tickets_sent;
     return S2N_SUCCESS;
 }

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -961,7 +961,8 @@ int s2n_config_set_initial_ticket_count(struct s2n_config *config, uint8_t num)
     return S2N_SUCCESS;
 }
 
-int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num) {
+int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t num)
+{
     POSIX_ENSURE_REF(conn);
     POSIX_GUARD_RESULT(s2n_psk_validate_keying_material(conn));
 
@@ -969,6 +970,14 @@ int s2n_connection_add_new_tickets_to_send(struct s2n_connection *conn, uint8_t 
     POSIX_ENSURE(out <= UINT16_MAX, S2N_ERR_INTEGER_OVERFLOW);
     conn->tickets_to_send = out;
 
+    return S2N_SUCCESS;
+}
+
+extern int s2n_connection_get_tickets_sent(struct s2n_connection *conn, uint16_t *num)
+{
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(num);
+    *num = conn->tickets_sent;
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -101,7 +101,11 @@ int s2n_server_nst_send(struct s2n_connection *conn)
     POSIX_GUARD(s2n_encrypt_session_ticket(conn, &to));
     POSIX_GUARD(s2n_stuffer_write(&conn->handshake.io, &to.blob));
 
-    return 0;
+    /* For parity with TLS1.3, track the single ticket sent.
+     * This simplifies s2n_connection_get_tickets_sent.
+     */
+    conn->tickets_sent++;
+    return S2N_SUCCESS;
 }
 
 S2N_RESULT s2n_tls13_server_nst_send(struct s2n_connection *conn, s2n_blocked_status *blocked)


### PR DESCRIPTION
### Description of changes: 

Minor session resumption cleanup:
* Update some documentation
* Add a method to query the number of tickets sent

### Call-outs:

* I removed part of a test in s2n_self_talk_session_resumption_test.c. The test was verifying that TLS1.2 returns a valid ticket 1) when resuming, before a new ticket is issued 2) when resuming, after a new ticket is issued. However, TLS1.2 doesn't support issuing new tickets on resumption handshakes: https://github.com/aws/s2n-tls/blob/main/tls/s2n_handshake_io.c#L811-L841. So the test was actually verifying the same ticket twice.

### Testing:
Added the new getter to a bunch of TLS1.2 and TLS1.3 resumption tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
