### PR TITLE
Turn on OCSP functionality for AWS-LC

### DIFF
--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -30,7 +30,7 @@
 #include <openssl/asn1.h>
 #include <openssl/x509.h>
 
-#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
+#if !defined(OPENSSL_IS_BORINGSSL)
 #include <openssl/ocsp.h>
 #endif
 

--- a/tls/s2n_x509_validator.h
+++ b/tls/s2n_x509_validator.h
@@ -21,13 +21,13 @@
 
 #include <openssl/x509v3.h>
 
-/* one day, BoringSSL/AWS-LC, may add ocsp stapling support. Let's future proof this a bit by grabbing a definition
+/* one day, BoringSSL may add ocsp stapling support. Let's future proof this a bit by grabbing a definition
  * that would have to be there when they add support */
 #if defined(OPENSSL_IS_BORINGSSL) && !defined(OCSP_RESPONSE_STATUS_SUCCESSFUL)
 #define S2N_OCSP_STAPLING_SUPPORTED 0
 #else
 #define S2N_OCSP_STAPLING_SUPPORTED 1
-#endif /* (defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)) && !defined(OCSP_RESPONSE_STATUS_SUCCESSFUL) */
+#endif /* defined(OPENSSL_IS_BORINGSSL) && !defined(OCSP_RESPONSE_STATUS_SUCCESSFUL) */
 
 typedef enum {
     S2N_CERT_OK = 0,

--- a/tls/s2n_x509_validator.h
+++ b/tls/s2n_x509_validator.h
@@ -23,7 +23,7 @@
 
 /* one day, BoringSSL/AWS-LC, may add ocsp stapling support. Let's future proof this a bit by grabbing a definition
  * that would have to be there when they add support */
-#if (defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)) && !defined(OCSP_RESPONSE_STATUS_SUCCESSFUL)
+#if defined(OPENSSL_IS_BORINGSSL) && !defined(OCSP_RESPONSE_STATUS_SUCCESSFUL)
 #define S2N_OCSP_STAPLING_SUPPORTED 0
 #else
 #define S2N_OCSP_STAPLING_SUPPORTED 1


### PR DESCRIPTION
### Resolved issues:

 Resolves missing OCSP support for s2n from AWS-LC

### Description of changes: 
With https://github.com/awslabs/aws-lc/pull/245 merged, this PR enables `S2N_OCSP_STAPLING_SUPPORTED` when `OPENSSL_IS_AWSLC` is defined.

### Call-outs:

N/A

### Testing:

CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
