### PR TITLE
audit memcmp usage

### DIFF
--- a/codebuild/bin/grep_simple_mistakes.sh
+++ b/codebuild/bin/grep_simple_mistakes.sh
@@ -14,9 +14,49 @@
 
 FAILED=0
 
+#############################################
+# Grep for any instances of raw memcmp() function. s2n code should instead be
+# using s2n_constant_time_equals()
+#
+# KNOWN_MEMCMP_USAGE is used to capture all known uses of memcmp and acts as a
+# safeguard against any new uses of memcmp.
+#############################################
+S2N_FILES_ASSERT_NOT_USING_MEMCMP=$(find "$PWD" -type f -name "s2n*.[ch]" -not -path "*/tests/*" -not -path "*/bindings/*")
+declare -A KNOWN_MEMCMP_USAGE
+KNOWN_MEMCMP_USAGE["$PWD/crypto/s2n_rsa.c"]=1
+KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_early_data.c"]=1
+KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_kem.c"]=1
+KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_cipher_suites.c"]=3
+KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_server_hello.c"]=4
+KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_security_policies.c"]=1
+KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_psk.c"]=1
+KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_config.c"]=1
+KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_resume.c"]=2
+KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_connection.c"]=1
+# KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_protocol_preferences.c"]=1
+KNOWN_MEMCMP_USAGE["$PWD/utils/s2n_map.c"]=2 # 3
+KNOWN_MEMCMP_USAGE["$PWD/stuffer/s2n_stuffer_text.c"]=1
+
+for file in $S2N_FILES_ASSERT_NOT_USING_MEMCMP; do
+  # NOTE: this matches on 'memcmp', which will also match comments. However, there
+  # are no uses of 'memcmp' in comments so we opt for this stricter check.
+  RESULT_NUM_LINES=`grep -n 'memcmp' $file | wc -l`
+
+  # set default KNOWN_MEMCMP_USAGE value
+  [ -z "${KNOWN_MEMCMP_USAGE["$file"]}" ] && KNOWN_MEMCMP_USAGE["$file"]="0"
+
+  # check if memcmp usage is 0 or a known value
+  if [ "${RESULT_NUM_LINES}" != "${KNOWN_MEMCMP_USAGE["$file"]}" ]; then
+    echo "Expected: ${KNOWN_MEMCMP_USAGE["$file"]} Found: ${RESULT_NUM_LINES} usage of 'memcmp' in $file"
+    FAILED=1
+  fi
+done
+
+#############################################
 # Assert that functions do not return -1 or S2N_ERR* codes directly.
 # To indicate failure, functions should use the S2N_ERROR* macros defined
 # in s2n_errno.h.
+#############################################
 S2N_FILES_ASSERT_RETURN=$(find "$PWD" -type f -name "s2n*.c" -not -path "*/tests/*")
 for file in $S2N_FILES_ASSERT_RETURN; do
   RESULT_NEGATIVE_ONE=`grep -rn 'return -1;' $file`
@@ -37,7 +77,9 @@ for file in $S2N_FILES_ASSERT_RETURN; do
   fi
 done
 
+#############################################
 # Detect any array size calculations that are not using the s2n_array_len() function.
+#############################################
 S2N_FILES_ARRAY_SIZING_RETURN=$(find "$PWD" -type f -name "s2n*.c" -path "*")
 for file in $S2N_FILES_ARRAY_SIZING_RETURN; do
   RESULT_ARR_DIV=`grep -Ern 'sizeof\((.*)\) \/ sizeof\(\1\[0\]\)' $file`
@@ -48,10 +90,12 @@ for file in $S2N_FILES_ARRAY_SIZING_RETURN; do
   fi
 done
 
+#############################################
 # Assert that all assignments from s2n_stuffer_raw_read() have a
 # notnull_check (or similar manual null check) on the same, or next, line.
 # The assertion is shallow; this doesn't guarantee that we're doing the
 # *correct* null check, just that we are doing *some* null check.
+#############################################
 S2N_FILES_ASSERT_NOTNULL_CHECK=$(find "$PWD" -type f -name "s2n*.[ch]" -not -path "*/tests/*")
 for file in $S2N_FILES_ASSERT_NOTNULL_CHECK; do
   while read -r line_one; do
@@ -77,8 +121,10 @@ for file in $S2N_FILES_ASSERT_NOTNULL_CHECK; do
   done < <(grep -rnE -A 1 "=\ss2n_stuffer_raw_read\(.*\)" $file)
 done
 
+#############################################
 # Assert that "index" is not a variable name. An "index" function exists in strings.h, and older compilers (<GCC 4.8) 
 # warn if any local variables called "index" are used because they are considered to shadow that declaration. 
+#############################################
 S2N_FILES_ASSERT_VARIABLE_NAME_INDEX=$(find "$PWD" -type f -name "s2n*.[ch]")
 for file in $S2N_FILES_ASSERT_VARIABLE_NAME_INDEX; do
   RESULT_VARIABLE_NAME_INDEX=`gcc -fpreprocessed -dD -E -w $file | grep -v '"' | grep '[\*|,|;|[:space:]]index[;|,|\)|[:space:]]'`
@@ -88,8 +134,10 @@ for file in $S2N_FILES_ASSERT_VARIABLE_NAME_INDEX; do
   fi
 done
 
+#############################################
 ## Assert that there are no new uses of S2N_ERROR_IF
 # TODO add crypto, tls (see https://github.com/aws/s2n-tls/issues/2635)
+#############################################
 S2N_ERROR_IF_FREE="bin error pq-crypto scram stuffer utils tests"
 for dir in $S2N_ERROR_IF_FREE; do
   files=$(find "$dir" -type f -name "*.c" -path "*")
@@ -102,6 +150,7 @@ for dir in $S2N_ERROR_IF_FREE; do
   done
 done
 
+#############################################
 if [ $FAILED == 1 ]; then
   printf "\\033[31;1mFAILED Grep For Simple Mistakes check\\033[0m\\n"
   exit -1

--- a/codebuild/bin/grep_simple_mistakes.sh
+++ b/codebuild/bin/grep_simple_mistakes.sh
@@ -33,8 +33,8 @@ KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_psk.c"]=1
 KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_config.c"]=1
 KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_resume.c"]=2
 KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_connection.c"]=1
-# KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_protocol_preferences.c"]=1
-KNOWN_MEMCMP_USAGE["$PWD/utils/s2n_map.c"]=2 # 3
+KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_protocol_preferences.c"]=1
+KNOWN_MEMCMP_USAGE["$PWD/utils/s2n_map.c"]=3
 KNOWN_MEMCMP_USAGE["$PWD/stuffer/s2n_stuffer_text.c"]=1
 
 for file in $S2N_FILES_ASSERT_NOT_USING_MEMCMP; do

--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -142,8 +142,6 @@ static int s2n_rsa_keys_match(const struct s2n_pkey *pub, const struct s2n_pkey 
     plain_out.size = sizeof(plain_outpad);
     POSIX_GUARD(s2n_rsa_decrypt(priv, &enc, &plain_out));
 
-    S2N_ERROR_IF(memcmp(plain_in.data, plain_out.data, plain_in.size), S2N_ERR_KEY_MISMATCH);
-
     return 0;
 }
 

--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -142,6 +142,8 @@ static int s2n_rsa_keys_match(const struct s2n_pkey *pub, const struct s2n_pkey 
     plain_out.size = sizeof(plain_outpad);
     POSIX_GUARD(s2n_rsa_decrypt(priv, &enc, &plain_out));
 
+    S2N_ERROR_IF(memcmp(plain_in.data, plain_out.data, plain_in.size), S2N_ERR_KEY_MISMATCH);
+
     return 0;
 }
 


### PR DESCRIPTION
### Resolved issues:

### Description of changes: 
s2n codes should use `s2n_constant_time_equals` instead of `memcmp`.

This PR adds a check for uses of `memcmp` to `codebuild/bin/grep_simple_mistakes.sh`, which is run as part of CI for each PR. It notes the current uses of 'memcmp' and will flag any future PRs which add or remove uses.

This should give better visibility into new uses of 'memcmp' while reviewing the PR and also help target/replace the current uses.

- failure case: https://github.com/aws/s2n-tls/pull/3059/checks?check_run_id=3655579669
- success case: [commit](https://github.com/aws/s2n-tls/pull/3059/commits/981c73c76c6c4807ddfab30bc04a7ed3d6c42ec2) -  https://github.com/aws/s2n-tls/runs/3655595096


Issue to audit and replace memcmp usage: https://github.com/aws/s2n-tls/issues/3062
### Call-outs:

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
