### PR TITLE
Fix TLS1.3 ticket lifetime math

### DIFF
--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -184,7 +184,8 @@ static S2N_RESULT s2n_generate_ticket_lifetime(struct s2n_connection *conn, uint
     RESULT_ENSURE_REF(conn);
     RESULT_ENSURE_MUT(ticket_lifetime);
 
-    uint32_t key_lifetime_in_secs = conn->config->decrypt_key_lifetime_in_nanos / ONE_SEC_IN_NANOS;
+    uint32_t key_lifetime_in_secs =
+            (conn->config->encrypt_decrypt_key_lifetime_in_nanos + conn->config->decrypt_key_lifetime_in_nanos) / ONE_SEC_IN_NANOS;
     uint32_t session_lifetime_in_secs = conn->config->session_state_lifetime_in_nanos / ONE_SEC_IN_NANOS;
     uint32_t key_and_session_min_lifetime = MIN(key_lifetime_in_secs, session_lifetime_in_secs);
     /** 


### PR DESCRIPTION
### Description of changes: 

When calculating the TLS1.3 ticket lifetime, we consider the decrypt lifetime but not the encrypt_decrypt lifetime. The total lifetime is (decrypt + encrypt_decrypt). So for the [default case](https://github.com/aws/s2n-tls/blob/main/tls/s2n_resume.h#L38-L39), the decrypt time is 13 hours, the encrypt_decrypt time is 2 hours, and the total lifetime is 15 hours.

### Testing:

Fixed unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
