### PR TITLE
ci: Use stable for openssl1.1.1

### DIFF
--- a/codebuild/bin/install_openssl_1_1_1.sh
+++ b/codebuild/bin/install_openssl_1_1_1.sh
@@ -29,7 +29,7 @@ BUILD_DIR=$1
 INSTALL_DIR=$2
 OS_NAME=$3
 source codebuild/bin/jobs.sh
-RELEASE=1_1_1k
+RELEASE=1_1_1-stable
 
 mkdir -p $BUILD_DIR
 cd "$BUILD_DIR"


### PR DESCRIPTION
### Resolved issues:

n/a

### Description of changes: 

We were pinned to openssl 1.1.1k or ci, updating to make it match the openssl1.0.2 setup.

### Call-outs:

None.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? locally in addition to regulate tests

 Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
