### PR TITLE
Fix SAW TLS1.3 proof build

### DIFF
--- a/tls/Makefile
+++ b/tls/Makefile
@@ -19,7 +19,7 @@ SUB_BUILDS = $(patsubst %/Makefile, %, $(wildcard */Makefile))
 
 BITCODE_DIR?=../tests/saw/bitcode/
 
-BCS_1=s2n_handshake_io.bc s2n_handshake_type.bc s2n_connection.bc s2n_kex.bc
+BCS_1=s2n_handshake_io.bc s2n_handshake_type.bc s2n_connection.bc s2n_kex.bc s2n_quic_support.bc
 BCS=$(addprefix $(BITCODE_DIR), $(BCS_1))
 
 .PHONY : all


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/aws/s2n-tls/pull/3077

### Description of changes: 
Fix the Makefile so that the TLS1.3 proofs play nice with https://github.com/aws/s2n-tls/commit/c096a55ff513de32cc69f6136614177239e76981. Dependencies of the methods we're proving always have to be included as bytecode for SAW.

### Testing:
Existing tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
