### PR TITLE
Add AWS-LC FIPS integration target

### DIFF
--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -20,6 +20,7 @@
 #include <getopt.h>
 #include <fcntl.h>
 
+#include <openssl/crypto.h>
 #include <openssl/err.h>
 
 #include "api/s2n.h"
@@ -403,7 +404,7 @@ int main(int argc, char *const *argv)
     }
 
     if (fips_mode) {
-#ifdef OPENSSL_FIPS
+#if defined(OPENSSL_FIPS) || defined(OPENSSL_IS_AWSLC)
         if (FIPS_mode_set(1) == 0) {
             unsigned long fips_rc = ERR_get_error();
             char ssl_error_buf[256]; /* Openssl claims you need no more than 120 bytes for error strings */

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -489,6 +489,7 @@ int main(int argc, char *const *argv)
     }
 
     if (fips_mode) {
+#if defined(OPENSSL_FIPS) || defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_AWSLC)
         if (FIPS_mode_set(1) == 0) {
             unsigned long fips_rc = ERR_get_error();
             char ssl_error_buf[256]; /* Openssl claims you need no more than 120 bytes for error strings */
@@ -496,6 +497,10 @@ int main(int argc, char *const *argv)
             exit(1);
         }
         printf("s2nd entered FIPS mode\n");
+#else
+        fprintf(stderr, "Error entering FIPS mode. s2nd is not linked with a FIPS-capable libcrypto.\n");
+        exit(1);
+#endif
     }
 
     GUARD_EXIT(s2n_init(), "Error running s2n_init()");

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -489,7 +489,6 @@ int main(int argc, char *const *argv)
     }
 
     if (fips_mode) {
-#ifdef OPENSSL_FIPS
         if (FIPS_mode_set(1) == 0) {
             unsigned long fips_rc = ERR_get_error();
             char ssl_error_buf[256]; /* Openssl claims you need no more than 120 bytes for error strings */
@@ -497,10 +496,6 @@ int main(int argc, char *const *argv)
             exit(1);
         }
         printf("s2nd entered FIPS mode\n");
-#else
-        fprintf(stderr, "Error entering FIPS mode. s2nd is not linked with a FIPS-capable libcrypto.\n");
-        exit(1);
-#endif
     }
 
     GUARD_EXIT(s2n_init(), "Error running s2n_init()");

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -489,7 +489,7 @@ int main(int argc, char *const *argv)
     }
 
     if (fips_mode) {
-#if defined(OPENSSL_FIPS) || defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_AWSLC)
+#if defined(OPENSSL_FIPS) || defined(OPENSSL_IS_AWSLC)
         if (FIPS_mode_set(1) == 0) {
             unsigned long fips_rc = ERR_get_error();
             char ssl_error_buf[256]; /* Openssl claims you need no more than 120 bytes for error strings */

--- a/codebuild/bin/install_awslc.sh
+++ b/codebuild/bin/install_awslc.sh
@@ -16,16 +16,17 @@ set -ex
 pushd "$(pwd)"
 
 usage() {
-    echo "install_awslc.sh build_dir install_dir"
+    echo "install_awslc.sh build_dir install_dir is_fips"
     exit 1
 }
 
-if [ "$#" -ne "2" ]; then
+if [ "$#" -ne "3" ]; then
     usage
 fi
 
 BUILD_DIR=$1
 INSTALL_DIR=$2
+IS_FIPS=$3
 source codebuild/bin/jobs.sh
 
 cd "$BUILD_DIR"
@@ -33,7 +34,7 @@ git clone https://github.com/awslabs/aws-lc.git
 mkdir build
 cd build
 
-cmake ../aws-lc -GNinja -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
+cmake ../aws-lc -GNinja -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" -DFIPS="${IS_FIPS}"
 ninja -j "${JOBS}" install
 
 popd

--- a/codebuild/bin/install_default_dependencies.sh
+++ b/codebuild/bin/install_default_dependencies.sh
@@ -60,7 +60,10 @@ fi
 
 # Download and Install AWS-LC
 if [[ "$S2N_LIBCRYPTO" == "awslc" && ! -d "$AWSLC_INSTALL_DIR" ]]; then
-    codebuild/bin/install_awslc.sh "$(mktemp -d)" "$AWSLC_INSTALL_DIR" > /dev/null ;
+    codebuild/bin/install_awslc.sh "$(mktemp -d)" "$AWSLC_INSTALL_DIR" "0" > /dev/null ;
+fi
+if [[ "$S2N_LIBCRYPTO" == "awslc-fips" && ! -d "$AWSLC_FIPS_INSTALL_DIR" ]]; then
+    codebuild/bin/install_awslc.sh "$(mktemp -d)" "$AWSLC_FIPS_INSTALL_DIR" "1" > /dev/null ;
 fi
 
 if [[ "$TESTS" == "integration" || "$TESTS" == "integrationv2" || "$TESTS" == "ALL" ]]; then

--- a/codebuild/bin/s2n_setup_env.sh
+++ b/codebuild/bin/s2n_setup_env.sh
@@ -43,6 +43,7 @@
 : "${OPENSSL_1_0_2_FIPS_INSTALL_DIR:=$TEST_DEPS_DIR/openssl-1.0.2-fips}"
 : "${BORINGSSL_INSTALL_DIR:=$TEST_DEPS_DIR/boringssl}"
 : "${AWSLC_INSTALL_DIR:=$TEST_DEPS_DIR/awslc}"
+: "${AWSLC_FIPS_INSTALL_DIR:=$TEST_DEPS_DIR/awslc-fips}"
 : "${LIBRESSL_INSTALL_DIR:=$TEST_DEPS_DIR/libressl-2.6.4}"
 : "${CPPCHECK_INSTALL_DIR:=$TEST_DEPS_DIR/cppcheck}"
 : "${CTVERIF_INSTALL_DIR:=$TEST_DEPS_DIR/ctverif}"
@@ -125,6 +126,10 @@ fi
 if [[ "$S2N_LIBCRYPTO" == "boringssl" ]]; then export LIBCRYPTO_ROOT=$BORINGSSL_INSTALL_DIR ; fi
 
 if [[ "$S2N_LIBCRYPTO" == "awslc" ]]; then export LIBCRYPTO_ROOT=$AWSLC_INSTALL_DIR ; fi
+if [[ "$S2N_LIBCRYPTO" == "awslc-fips" ]]; then
+  export LIBCRYPTO_ROOT=$AWSLC_FIPS_INSTALL_DIR ;
+  export S2N_TEST_IN_FIPS_MODE=1 ;
+fi
 
 if [[ "$S2N_LIBCRYPTO" == "libressl" ]]; then export LIBCRYPTO_ROOT=$LIBRESSL_INSTALL_DIR ; fi
 

--- a/codebuild/spec/buildspec_ubuntu_integ_awslc.yml
+++ b/codebuild/spec/buildspec_ubuntu_integ_awslc.yml
@@ -17,7 +17,6 @@ env:
   variables:
     # CODEBUILD_ is a reserved namespace.
     CB_BIN_DIR: "./codebuild/bin"
-    S2N_LIBCRYPTO: "awslc"
     TESTS: "integration"
     BUILD_S2N: true
 
@@ -37,7 +36,7 @@ phases:
       - add-apt-repository ppa:longsleep/golang-backports -y
       - apt-get update -o Acquire::CompressionTypes::Order::=gz
       - apt-get update -y
-      - apt-get install -y --no-install-recommends gcc g++ gcc-4.8 g++-4.8 gcc-6 g++-6 gcc-9 g++-9
+      - apt-get install -y --no-install-recommends gcc g++ gcc-4.8 g++-4.8 gcc-9 g++-9
       # Don't install old clang and llvm if LATEST_CLANG is enabled, handle it in install_clang.sh instead
       - |
         if expr "${LATEST_CLANG}" != "true" >/dev/null; then
@@ -50,13 +49,15 @@ phases:
         if [ -d "third-party-src" ]; then
           cd third-party-src;
         fi
-      - GCC_VERSION=6 $CB_BIN_DIR/install_default_dependencies.sh
+      - S2N_LIBCRYPTO=awslc $CB_BIN_DIR/install_default_dependencies.sh
+      - S2N_LIBCRYPTO=awslc-fips $CB_BIN_DIR/install_default_dependencies.sh
   build:
     commands:
       - printenv
-      - GCC_VERSION=4.8 $CB_BIN_DIR/s2n_codebuild.sh
-      - GCC_VERSION=6 $CB_BIN_DIR/s2n_codebuild.sh
-      - GCC_VERSION=9 $CB_BIN_DIR/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=awslc GCC_VERSION=4.8 $CB_BIN_DIR/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=awslc GCC_VERSION=9 $CB_BIN_DIR/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=awslc-fips GCC_VERSION=4.8 $CB_BIN_DIR/s2n_codebuild.sh
+      - S2N_LIBCRYPTO=awslc-fips GCC_VERSION=9 $CB_BIN_DIR/s2n_codebuild.sh
   post_build:
     commands:
       - echo Build completed on `date`

--- a/crypto/s2n_evp.c
+++ b/crypto/s2n_evp.c
@@ -44,7 +44,7 @@ S2N_RESULT s2n_digest_is_md5_allowed_for_fips(struct s2n_evp_digest *evp_digest,
     }
 #else
     if (s2n_is_in_fips_mode()) {
-        /* s2n is in FIPS mode and built with AWS-LC or BoringSSL, there are no flags to check in the EVP digest to allows MD5. */
+        /* If s2n is in FIPS mode and built with AWS-LC or BoringSSL, there are no flags to check in the EVP digest to allow MD5. */
         *out = true;
     }
 #endif

--- a/crypto/s2n_evp.c
+++ b/crypto/s2n_evp.c
@@ -42,6 +42,11 @@ S2N_RESULT s2n_digest_is_md5_allowed_for_fips(struct s2n_evp_digest *evp_digest,
         /* s2n is in FIPS mode and the EVP digest allows MD5. */
         *out = true;
     }
+#else
+    if (s2n_is_in_fips_mode()) {
+        /* s2n is in FIPS mode and built with AWS-LC or BoringSSL, there are no flags to check in the EVP digest to allows MD5. */
+        *out = true;
+    }
 #endif
     return S2N_RESULT_OK;
 }

--- a/crypto/s2n_evp.h
+++ b/crypto/s2n_evp.h
@@ -16,10 +16,7 @@
 #pragma once
 
 #include <openssl/evp.h>
-
-#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
 #include <openssl/hmac.h>
-#endif
 
 #include "crypto/s2n_openssl.h"
 #include "utils/s2n_result.h"
@@ -31,11 +28,10 @@ struct s2n_evp_digest {
 
 struct s2n_evp_hmac_state {
     struct s2n_evp_digest evp_digest;
-#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
-    HMAC_CTX *hmac_ctx;
-#else
-    EVP_PKEY *evp_pkey;
-#endif
+    union {
+        HMAC_CTX *hmac_ctx;
+        EVP_PKEY *evp_pkey;
+    } ctx;
 };
 
 /* Define API's that change based on the OpenSSL Major Version. */

--- a/crypto/s2n_evp.h
+++ b/crypto/s2n_evp.h
@@ -17,6 +17,10 @@
 
 #include <openssl/evp.h>
 
+#ifdef OPENSSL_IS_AWSLC
+#include <openssl/hmac.h>
+#endif
+
 #include "crypto/s2n_openssl.h"
 #include "utils/s2n_result.h"
 
@@ -27,7 +31,11 @@ struct s2n_evp_digest {
 
 struct s2n_evp_hmac_state {
     struct s2n_evp_digest evp_digest;
+#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
+    HMAC_CTX *hmac_key;
+#else
     EVP_PKEY *mac_key;
+#endif
 };
 
 /* Define API's that change based on the OpenSSL Major Version. */

--- a/crypto/s2n_evp.h
+++ b/crypto/s2n_evp.h
@@ -17,7 +17,7 @@
 
 #include <openssl/evp.h>
 
-#ifdef OPENSSL_IS_AWSLC
+#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
 #include <openssl/hmac.h>
 #endif
 

--- a/crypto/s2n_evp.h
+++ b/crypto/s2n_evp.h
@@ -32,9 +32,9 @@ struct s2n_evp_digest {
 struct s2n_evp_hmac_state {
     struct s2n_evp_digest evp_digest;
 #if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
-    HMAC_CTX *hmac_key;
+    HMAC_CTX *hmac_ctx;
 #else
-    EVP_PKEY *mac_key;
+    EVP_PKEY *evp_pkey;
 #endif
 };
 

--- a/crypto/s2n_fips.c
+++ b/crypto/s2n_fips.c
@@ -27,7 +27,7 @@ int s2n_fips_init(void)
      *
      * AWS-LC always define FIPS_mode() that you can call and check what the library was built with. It does not define
      * a public OPENSSL_FIPS/AWSLC_FIPS macro that we can (or need to) check here */
-#if defined(OPENSSL_FIPS)
+#if defined(OPENSSL_FIPS) || defined(OPENSSL_IS_AWSLC)
     if (FIPS_mode()) {
         s2n_fips_mode = 1;
     }

--- a/crypto/s2n_fips.c
+++ b/crypto/s2n_fips.c
@@ -23,12 +23,10 @@ int s2n_fips_init(void)
 {
     s2n_fips_mode = 0;
 
-#ifdef OPENSSL_FIPS
-    /* FIPS mode can be entered only if OPENSSL_FIPS is defined */
+    /* You can always call FIPS_mode to check if the underlying libcrypto was compiled for FIPS or not*/
     if (FIPS_mode()) {
         s2n_fips_mode = 1;
     }
-#endif
 
     return 0;
 }

--- a/crypto/s2n_fips.c
+++ b/crypto/s2n_fips.c
@@ -23,8 +23,11 @@ int s2n_fips_init(void)
 {
     s2n_fips_mode = 0;
 
-    /* AWS-LC, OpenSSL, and BoringSSL, but not LibreSSL always define a FIPS_mode that you can call and check */
-#ifndef LIBRESSL_VERSION_NUMBER
+    /* FIPS mode can be checked if OpenSSL was configured and built for FIPS which then defines OPENSSL_FIPS.
+     *
+     * AWS-LC and BoringSSL always define FIPS_mode() that you can call and check what the library was built with.
+     * Neither library define a public *_FIPS macro that we can (or should) check here */
+#if defined(OPENSSL_FIPS) || defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_AWSLC)
     if (FIPS_mode()) {
         s2n_fips_mode = 1;
     }

--- a/crypto/s2n_fips.c
+++ b/crypto/s2n_fips.c
@@ -26,7 +26,11 @@ int s2n_fips_init(void)
     /* FIPS mode can be checked if OpenSSL was configured and built for FIPS which then defines OPENSSL_FIPS.
      *
      * AWS-LC always define FIPS_mode() that you can call and check what the library was built with. It does not define
-     * a public OPENSSL_FIPS/AWSLC_FIPS macro that we can (or need to) check here */
+     * a public OPENSSL_FIPS/AWSLC_FIPS macro that we can (or need to) check here
+     *
+     * Note: FIPS_mode() does not change the FIPS state of libcrypto. This only returns the current state. Applications
+     * using s2n must call FIPS_mode_set(1) prior to s2n_init.
+     * */
 #if defined(OPENSSL_FIPS) || defined(OPENSSL_IS_AWSLC)
     if (FIPS_mode()) {
         s2n_fips_mode = 1;

--- a/crypto/s2n_fips.c
+++ b/crypto/s2n_fips.c
@@ -23,11 +23,12 @@ int s2n_fips_init(void)
 {
     s2n_fips_mode = 0;
 
-    /* You can always call FIPS_mode to check if the underlying libcrypto was compiled for FIPS or not*/
+    /* AWS-LC, OpenSSL, and BoringSSL, but not LibreSSL always define a FIPS_mode that you can call and check */
+#ifndef LIBRESSL_VERSION_NUMBER
     if (FIPS_mode()) {
         s2n_fips_mode = 1;
     }
-
+#endif
     return 0;
 }
 

--- a/crypto/s2n_fips.c
+++ b/crypto/s2n_fips.c
@@ -25,7 +25,7 @@ int s2n_fips_init(void)
 
     /* FIPS mode can be checked if OpenSSL was configured and built for FIPS which then defines OPENSSL_FIPS.
      *
-     * AWS-LC always define FIPS_mode() that you can call and check what the library was built with. It does not define
+     * AWS-LC always defines FIPS_mode() that you can call and check what the library was built with. It does not define
      * a public OPENSSL_FIPS/AWSLC_FIPS macro that we can (or need to) check here
      *
      * Note: FIPS_mode() does not change the FIPS state of libcrypto. This only returns the current state. Applications

--- a/crypto/s2n_fips.c
+++ b/crypto/s2n_fips.c
@@ -26,9 +26,8 @@ int s2n_fips_init(void)
     /* FIPS mode can be checked if OpenSSL was configured and built for FIPS which then defines OPENSSL_FIPS.
      *
      * AWS-LC always define FIPS_mode() that you can call and check what the library was built with. It does not define
-     * a public OPENSSL_FIPS/AWSLC_FIPS macro that we can (or should) check here */
-#if defined(OPENSSL_FIPS) || defined(OPENSSL_IS_AWSLC)
-    FIPS_mode_set(1);
+     * a public OPENSSL_FIPS/AWSLC_FIPS macro that we can (or need to) check here */
+#if defined(OPENSSL_FIPS)
     if (FIPS_mode()) {
         s2n_fips_mode = 1;
     }

--- a/crypto/s2n_fips.c
+++ b/crypto/s2n_fips.c
@@ -25,9 +25,10 @@ int s2n_fips_init(void)
 
     /* FIPS mode can be checked if OpenSSL was configured and built for FIPS which then defines OPENSSL_FIPS.
      *
-     * AWS-LC and BoringSSL always define FIPS_mode() that you can call and check what the library was built with.
-     * Neither library define a public *_FIPS macro that we can (or should) check here */
-#if defined(OPENSSL_FIPS) || defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_AWSLC)
+     * AWS-LC always define FIPS_mode() that you can call and check what the library was built with. It does not define
+     * a public OPENSSL_FIPS/AWSLC_FIPS macro that we can (or should) check here */
+#if defined(OPENSSL_FIPS) || defined(OPENSSL_IS_AWSLC)
+    FIPS_mode_set(1);
     if (FIPS_mode()) {
         s2n_fips_mode = 1;
     }

--- a/s2n.mk
+++ b/s2n.mk
@@ -36,8 +36,11 @@ INDENT  = $(shell (if indent --version 2>&1 | grep GNU > /dev/null; then echo in
 ifeq ($(S2N_LIBCRYPTO), boringssl)
 	DEFAULT_CFLAGS = -std=c11
 else ifeq ($(S2N_LIBCRYPTO), awslc)
-	# AWS-LC is a BoringSSL derivative.
-	DEFAULT_CFLAGS = -std=c11
+	# AWS-LC is a BoringSSL derivative and has fixed the c11 issues but not all -Wcast-qual warnings
+	DEFAULT_CFLAGS = -std=c99
+else ifeq ($(S2N_LIBCRYPTO), awslc-fips)
+	# AWS-LC is a BoringSSL derivative and has fixed the c11 issues but not all -Wcast-qual warnings
+	DEFAULT_CFLAGS = -std=c99
 else
 	DEFAULT_CFLAGS = -std=c99 -Wcast-qual
 endif

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -247,7 +247,11 @@ void cbmc_populate_s2n_evp_hmac_state(struct s2n_evp_hmac_state *evp_hmac_state)
 {
     CBMC_ENSURE_REF(evp_hmac_state);
     cbmc_populate_s2n_evp_digest(&(evp_hmac_state->evp_digest));
+#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
+    evp_hmac_state->hmac_key = malloc(sizeof(*(evp_hmac_state->hmac_key)));
+#else
     evp_hmac_state->mac_key = malloc(sizeof(*(evp_hmac_state->mac_key)));
+#endif
 }
 
 struct s2n_evp_hmac_state *cbmc_allocate_s2n_evp_hmac_state()

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -248,9 +248,9 @@ void cbmc_populate_s2n_evp_hmac_state(struct s2n_evp_hmac_state *evp_hmac_state)
     CBMC_ENSURE_REF(evp_hmac_state);
     cbmc_populate_s2n_evp_digest(&(evp_hmac_state->evp_digest));
 #if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
-    evp_hmac_state->hmac_key = malloc(sizeof(*(evp_hmac_state->hmac_key)));
+    evp_hmac_state->hmac_ctx = malloc(sizeof(*(evp_hmac_state->hmac_ctx)));
 #else
-    evp_hmac_state->mac_key = malloc(sizeof(*(evp_hmac_state->mac_key)));
+    evp_hmac_state->evp_pkey = malloc(sizeof(*(evp_hmac_state->evp_pkey)));
 #endif
 }
 

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -248,9 +248,9 @@ void cbmc_populate_s2n_evp_hmac_state(struct s2n_evp_hmac_state *evp_hmac_state)
     CBMC_ENSURE_REF(evp_hmac_state);
     cbmc_populate_s2n_evp_digest(&(evp_hmac_state->evp_digest));
 #if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
-    evp_hmac_state->hmac_ctx = malloc(sizeof(*(evp_hmac_state->hmac_ctx)));
+    evp_hmac_state->ctx.hmac_ctx = malloc(sizeof(*(evp_hmac_state->ctx.hmac_ctx)));
 #else
-    evp_hmac_state->evp_pkey = malloc(sizeof(*(evp_hmac_state->evp_pkey)));
+    evp_hmac_state->ctx.evp_pkey = malloc(sizeof(*(evp_hmac_state->ctx.evp_pkey)));
 #endif
 }
 

--- a/tests/integration/common/s2n_test_scenario.py
+++ b/tests/integration/common/s2n_test_scenario.py
@@ -126,7 +126,8 @@ ALL_CIPHERS_PER_LIBCRYPTO_VERSION = {
     "openssl-1.0.2-fips"    : NO_TLS13_CIPHERS,
     "libressl"              : NO_TLS13_CIPHERS,
     "boringssl"             : NO_TLS13_CIPHERS,
-    "awslc"                 : NO_TLS13_CIPHERS,
+    "awslc"                 : ALL_TLS13_CIPHERS,
+    "awslc-fips"            : NO_TLS13_CIPHERS,
 }
 
 class Curve():
@@ -167,7 +168,8 @@ ALL_CURVES_PER_LIBCRYPTO_VERSION = {
     "openssl-1.0.2-fips"    : LEGACY_COMPATIBLE_CURVES,
     "libressl"              : LEGACY_COMPATIBLE_CURVES,
     "boringssl"             : LEGACY_COMPATIBLE_CURVES,
-    "awslc"                 : LEGACY_COMPATIBLE_CURVES,
+    "awslc"                 : ALL_CURVES,
+    "awslc-fips"            : LEGACY_COMPATIBLE_CURVES,
 }
 
 

--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -107,10 +107,10 @@ OPENSSL_1_0_2_TEST_CIPHERS = list(filter(lambda x: "CHACHA20" not in x.openssl_n
 # Test ciphers to use when s2n is built with Openssl 1.0.2 libcrypto that is linked with a FIPS module.
 OPENSSL_1_0_2_FIPS_TEST_CIPHERS = list(filter(lambda x: x.openssl_fips_compatible == True, ALL_TEST_CIPHERS))
 
-# Test ciphers to use when s2n is built with BoringSSL. All ciphers should be avilable.
+# Test ciphers to use when s2n is built with BoringSSL. All ciphers should be available.
 BORINGSSL_TEST_CIPHERS = ALL_TEST_CIPHERS
 
-# Test ciphers to use when s2n is built with AWS-LC. All ciphers should be avilable.
+# Test ciphers to use when s2n is built with AWS-LC. All ciphers should be available.
 AWSLC_TEST_CIPHERS = ALL_TEST_CIPHERS
 
 # Test ciphers to use when s2n is built with LibreSSL. LibreSSL does not have the
@@ -126,6 +126,7 @@ S2N_LIBCRYPTO_TO_TEST_CIPHERS = {
     "libressl"              : LIBRESSL_TEST_CIPHERS,
     "boringssl"             : BORINGSSL_TEST_CIPHERS,
     "awslc"                 : AWSLC_TEST_CIPHERS,
+    "awslc-fips"            : OPENSSL_1_0_2_FIPS_TEST_CIPHERS,
 }
 
 S2N_LIBCRYPTO_TO_OCSP = {
@@ -134,10 +135,11 @@ S2N_LIBCRYPTO_TO_OCSP = {
     "openssl-1.0.2-fips"    : [OCSP.ENABLED, OCSP.DISABLED, OCSP.MALFORMED],
     "libressl"              : [OCSP.ENABLED, OCSP.DISABLED, OCSP.MALFORMED],
     "boringssl"             : [OCSP.DISABLED],
-    "awslc"                 : [OCSP.DISABLED],
+    "awslc"                 : [OCSP.ENABLED, OCSP.DISABLED, OCSP.MALFORMED],
+    "awslc-fips"            : [OCSP.ENABLED, OCSP.DISABLED, OCSP.MALFORMED],
 }
 
-S2N_LIBCRYPTO_CHOICES = ['openssl-1.0.2', 'openssl-1.0.2-fips', 'openssl-1.1.1', 'libressl', 'boringssl', 'awslc']
+S2N_LIBCRYPTO_CHOICES = ['openssl-1.0.2', 'openssl-1.0.2-fips', 'openssl-1.1.1', 'libressl', 'boringssl', 'awslc', "awslc-fips"]
 
 S2N_PROTO_VERS_TO_STR = {
     S2N_SSLv3 : "SSLv3",

--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -187,7 +187,7 @@ int test_count;
             fprintf(stderr, "s2nd failed to enter FIPS mode with RC: %lu; String: %s\n", fips_rc, ERR_error_string(fips_rc, ssl_error_buf)); \
             return 1; \
         } \
-        printf("s2nd entered FIPS mode\n"); \
+        printf("s2n entered FIPS mode\n"); \
     } while (0)
 
 #else

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -34,7 +34,7 @@
 #define MAX_CONNECTIONS 1000
 
 /* This is roughly the current memory usage per connection */
-#define MEM_PER_CONNECTION (43 * 1024)
+#define MEM_PER_CONNECTION (47 * 1024)
 /* This is the maximum memory per connection including 4KB of slack */
 #define MAX_MEM_PER_CONNECTION (MEM_PER_CONNECTION + 4 * 1024)
 

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -33,6 +33,7 @@
  * usage. The greater the value, the more accurate the end result. */
 #define MAX_CONNECTIONS 1000
 
+/* This is roughly the current memory usage per connection */
 #define MEM_PER_CONNECTION (43 * 1024)
 /* This is the maximum memory per connection including 4KB of slack */
 #define MAX_MEM_PER_CONNECTION (MEM_PER_CONNECTION + 4 * 1024)

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -33,16 +33,7 @@
  * usage. The greater the value, the more accurate the end result. */
 #define MAX_CONNECTIONS 1000
 
-/* This is roughly the current memory usage per connection and is the maximum across all supported libcryptos.
- *
-* The current biggest offender is s2n + AWS-LC due to:
-    * AWS-LC uses EVP_CIPHER_CTX contexts as well as EVP_AEAD_CTX in s2n_session_key (this could be a union in the future)
-    * AWS-LC uses an HMAC_CTX which is larger than OpenSSL EVP_PKEY in s2n_evp_hmac_state without being able to get rid
-        * of the EVP_MD_CTX in s2n_evp_digest because s2n_hash uses that type
-    * AWS-LC FIPS uses Jitter for entropy which requires additional state per thread
-* https://github.com/aws/s2n-tls/issues/3114
-*/
-#define MEM_PER_CONNECTION (49 * 1024)
+#define MEM_PER_CONNECTION (43 * 1024)
 /* This is the maximum memory per connection including 4KB of slack */
 #define MAX_MEM_PER_CONNECTION (MEM_PER_CONNECTION + 4 * 1024)
 

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -39,6 +39,7 @@
     * AWS-LC uses an HMAC_CTX which is larger than OpenSSL EVP_PKEY in s2n_evp_hmac_state without being able to get rid
         * of the EVP_MD_CTX in s2n_evp_digest because s2n_hash uses that type
     * AWS-LC FIPS uses Jitter for entropy which requires additional state per thread
+* https://github.com/aws/s2n-tls/issues/3114
 */
 #define MEM_PER_CONNECTION (49 * 1024)
 #else

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -34,7 +34,7 @@
 #define MAX_CONNECTIONS 1000
 
 /* This is roughly the current memory usage per connection */
-#define MEM_PER_CONNECTION (47 * 1024)
+#define MEM_PER_CONNECTION (43 * 1024)
 /* This is the maximum memory per connection including 4KB of slack */
 #define MAX_MEM_PER_CONNECTION (MEM_PER_CONNECTION + 4 * 1024)
 

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -33,9 +33,18 @@
  * usage. The greater the value, the more accurate the end result. */
 #define MAX_CONNECTIONS 1000
 
+#ifdef OPENSSL_IS_AWSLC
+/* s2n + AWS-LC memory usage is currently a little higher than s2n + OpenSSL due to:
+    * AWS-LC uses EVP_CIPHER_CTX contexts as well as EVP_AEAD_CTX in s2n_session_key (this could be a union in the future)
+    * AWS-LC uses an HMAC_CTX which is larger than OpenSSL EVP_PKEY in s2n_evp_hmac_state without being able to get rid
+        * of the EVP_MD_CTX in s2n_evp_digest because s2n_hash uses that type
+    * AWS-LC FIPS uses Jitter for entropy which requires additional state per thread
+*/
+#define MEM_PER_CONNECTION (49 * 1024)
+#else
 /* This is roughly the current memory usage per connection */
 #define MEM_PER_CONNECTION (48 * 1024)
-
+#endif
 /* This is the maximum memory per connection including 4KB of slack */
 #define MAX_MEM_PER_CONNECTION (MEM_PER_CONNECTION + 4 * 1024)
 

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -33,8 +33,9 @@
  * usage. The greater the value, the more accurate the end result. */
 #define MAX_CONNECTIONS 1000
 
-#ifdef OPENSSL_IS_AWSLC
-/* s2n + AWS-LC memory usage is currently a little higher than s2n + OpenSSL due to:
+/* This is roughly the current memory usage per connection and is the maximum across all supported libcryptos.
+ *
+* The current biggest offender is s2n + AWS-LC due to:
     * AWS-LC uses EVP_CIPHER_CTX contexts as well as EVP_AEAD_CTX in s2n_session_key (this could be a union in the future)
     * AWS-LC uses an HMAC_CTX which is larger than OpenSSL EVP_PKEY in s2n_evp_hmac_state without being able to get rid
         * of the EVP_MD_CTX in s2n_evp_digest because s2n_hash uses that type
@@ -42,10 +43,6 @@
 * https://github.com/aws/s2n-tls/issues/3114
 */
 #define MEM_PER_CONNECTION (49 * 1024)
-#else
-/* This is roughly the current memory usage per connection */
-#define MEM_PER_CONNECTION (48 * 1024)
-#endif
 /* This is the maximum memory per connection including 4KB of slack */
 #define MAX_MEM_PER_CONNECTION (MEM_PER_CONNECTION + 4 * 1024)
 

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -34,7 +34,7 @@
 #define MAX_CONNECTIONS 1000
 
 /* This is roughly the current memory usage per connection */
-#define MEM_PER_CONNECTION (43 * 1024)
+#define MEM_PER_CONNECTION (49 * 1024)
 /* This is the maximum memory per connection including 4KB of slack */
 #define MAX_MEM_PER_CONNECTION (MEM_PER_CONNECTION + 4 * 1024)
 

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -16,7 +16,7 @@
 #include <sys/param.h>
 #include <openssl/md5.h>
 #include <openssl/sha.h>
-#ifdef OPENSSL_IS_AWSLC
+#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
 #include <openssl/hmac.h>
 #endif
 #include <string.h>

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -14,11 +14,9 @@
  */
 
 #include <sys/param.h>
+#include <openssl/hmac.h>
 #include <openssl/md5.h>
 #include <openssl/sha.h>
-#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
-#include <openssl/hmac.h>
-#endif
 #include <string.h>
 
 #include "error/s2n_errno.h"

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -135,14 +135,14 @@ static int s2n_evp_pkey_p_hash_digest_init(struct s2n_prf_working_space *ws)
 {
     POSIX_ENSURE_REF(ws->p_hash.evp_hmac.evp_digest.md);
     POSIX_ENSURE_REF(ws->p_hash.evp_hmac.evp_digest.ctx);
-    POSIX_ENSURE_REF(ws->p_hash.evp_hmac.evp_pkey);
+    POSIX_ENSURE_REF(ws->p_hash.evp_hmac.ctx.evp_pkey);
  
     /* Ignore the MD5 check when in FIPS mode to comply with the TLS 1.0 RFC */
     if (s2n_is_in_fips_mode()) {
         POSIX_GUARD(s2n_digest_allow_md5_for_fips(&ws->p_hash.evp_hmac.evp_digest));
     }
 
-    POSIX_GUARD_OSSL(EVP_DigestSignInit(ws->p_hash.evp_hmac.evp_digest.ctx, NULL, ws->p_hash.evp_hmac.evp_digest.md, NULL, ws->p_hash.evp_hmac.evp_pkey),
+    POSIX_GUARD_OSSL(EVP_DigestSignInit(ws->p_hash.evp_hmac.evp_digest.ctx, NULL, ws->p_hash.evp_hmac.evp_digest.md, NULL, ws->p_hash.evp_hmac.ctx.evp_pkey),
            S2N_ERR_P_HASH_INIT_FAILED);
 
     return 0;
@@ -154,7 +154,7 @@ static int s2n_evp_pkey_p_hash_init(struct s2n_prf_working_space *ws, s2n_hmac_a
     POSIX_GUARD(s2n_init_md_from_hmac_alg(ws, alg));
 
     /* Initialize the mac key using the provided secret */
-    POSIX_ENSURE_REF(ws->p_hash.evp_hmac.evp_pkey = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL, secret->data, secret->size));
+    POSIX_ENSURE_REF(ws->p_hash.evp_hmac.ctx.evp_pkey = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL, secret->data, secret->size));
 
     /* Initialize the message digest context with the above message digest and mac key */
     return s2n_evp_pkey_p_hash_digest_init(ws);
@@ -179,7 +179,7 @@ static int s2n_evp_pkey_p_hash_final(struct s2n_prf_working_space *ws, void *dig
 
 static int s2n_evp_pkey_p_hash_wipe(struct s2n_prf_working_space *ws)
 {
-  POSIX_GUARD_OSSL(S2N_EVP_MD_CTX_RESET(ws->p_hash.evp_hmac.evp_digest.ctx), S2N_ERR_P_HASH_WIPE_FAILED);
+    POSIX_GUARD_OSSL(S2N_EVP_MD_CTX_RESET(ws->p_hash.evp_hmac.evp_digest.ctx), S2N_ERR_P_HASH_WIPE_FAILED);
 
     return 0;
 }
@@ -188,6 +188,9 @@ static int s2n_evp_pkey_p_hash_reset(struct s2n_prf_working_space *ws)
 {
     POSIX_GUARD(s2n_evp_pkey_p_hash_wipe(ws));
 
+    if (ws->p_hash.evp_hmac.evp_digest.md == NULL) {
+        return S2N_SUCCESS;
+    }
     return s2n_evp_pkey_p_hash_digest_init(ws);
 }
 
@@ -197,9 +200,9 @@ static int s2n_evp_pkey_p_hash_cleanup(struct s2n_prf_working_space *ws)
     POSIX_GUARD(s2n_evp_pkey_p_hash_wipe(ws));
 
     /* Free mac key - PKEYs cannot be reused */
-    POSIX_ENSURE_REF(ws->p_hash.evp_hmac.evp_pkey);
-    EVP_PKEY_free(ws->p_hash.evp_hmac.evp_pkey);
-    ws->p_hash.evp_hmac.evp_pkey = NULL;
+    POSIX_ENSURE_REF(ws->p_hash.evp_hmac.ctx.evp_pkey);
+    EVP_PKEY_free(ws->p_hash.evp_hmac.ctx.evp_pkey);
+    ws->p_hash.evp_hmac.ctx.evp_pkey = NULL;
 
     return 0;
 }
@@ -225,7 +228,7 @@ static const struct s2n_p_hash_hmac s2n_evp_pkey_p_hash_hmac = {
 #else
 static int s2n_evp_hmac_p_hash_alloc(struct s2n_prf_working_space *ws)
 {
-    POSIX_ENSURE_REF(ws->p_hash.evp_hmac.hmac_ctx = HMAC_CTX_new());
+    POSIX_ENSURE_REF(ws->p_hash.evp_hmac.ctx.hmac_ctx = HMAC_CTX_new());
     return S2N_SUCCESS;
 }
 
@@ -235,13 +238,13 @@ static int s2n_evp_hmac_p_hash_init(struct s2n_prf_working_space *ws, s2n_hmac_a
     POSIX_GUARD(s2n_init_md_from_hmac_alg(ws, alg));
 
     /* Initialize the mac and digest */
-    POSIX_GUARD_OSSL(HMAC_Init_ex(ws->p_hash.evp_hmac.hmac_ctx, secret->data, secret->size, ws->p_hash.evp_hmac.evp_digest.md, NULL), S2N_ERR_P_HASH_INIT_FAILED);
+    POSIX_GUARD_OSSL(HMAC_Init_ex(ws->p_hash.evp_hmac.ctx.hmac_ctx, secret->data, secret->size, ws->p_hash.evp_hmac.evp_digest.md, NULL), S2N_ERR_P_HASH_INIT_FAILED);
     return S2N_SUCCESS;
 }
 
 static int s2n_evp_hmac_p_hash_update(struct s2n_prf_working_space *ws, const void *data, uint32_t size)
 {
-    POSIX_GUARD_OSSL(HMAC_Update(ws->p_hash.evp_hmac.hmac_ctx, data, (size_t)size), S2N_ERR_P_HASH_UPDATE_FAILED);
+    POSIX_GUARD_OSSL(HMAC_Update(ws->p_hash.evp_hmac.ctx.hmac_ctx, data, (size_t)size), S2N_ERR_P_HASH_UPDATE_FAILED);
     return S2N_SUCCESS;
 }
 
@@ -249,26 +252,30 @@ static int s2n_evp_hmac_p_hash_final(struct s2n_prf_working_space *ws, void *dig
 {
     /* HMAC_Final API's require size_t data structures */
     unsigned int digest_size = size;
-    POSIX_GUARD_OSSL(HMAC_Final(ws->p_hash.evp_hmac.hmac_ctx, (unsigned char *)digest, &digest_size), S2N_ERR_P_HASH_FINAL_FAILED);
+    POSIX_GUARD_OSSL(HMAC_Final(ws->p_hash.evp_hmac.ctx.hmac_ctx, (unsigned char *)digest, &digest_size), S2N_ERR_P_HASH_FINAL_FAILED);
     return S2N_SUCCESS;
 }
 
 static int s2n_evp_hmac_p_hash_reset(struct s2n_prf_working_space *ws)
 {
-    POSIX_GUARD_OSSL(HMAC_Init_ex(ws->p_hash.evp_hmac.hmac_ctx, NULL, 0, ws->p_hash.evp_hmac.evp_digest.md, NULL), S2N_ERR_P_HASH_INIT_FAILED);
+    POSIX_ENSURE_REF(ws);
+    if (ws->p_hash.evp_hmac.evp_digest.md == NULL) {
+        return S2N_SUCCESS;
+    }
+    POSIX_GUARD_OSSL(HMAC_Init_ex(ws->p_hash.evp_hmac.ctx.hmac_ctx, NULL, 0, ws->p_hash.evp_hmac.evp_digest.md, NULL), S2N_ERR_P_HASH_INIT_FAILED);
     return S2N_SUCCESS;
 }
 
 static int s2n_evp_hmac_p_hash_cleanup(struct s2n_prf_working_space *ws)
 {
     /* Prepare the workspace md_ctx for the next p_hash */
-    HMAC_CTX_reset(ws->p_hash.evp_hmac.hmac_ctx);
+    HMAC_CTX_reset(ws->p_hash.evp_hmac.ctx.hmac_ctx);
     return S2N_SUCCESS;
 }
 
 static int s2n_evp_hmac_p_hash_free(struct s2n_prf_working_space *ws)
 {
-    HMAC_CTX_free(ws->p_hash.evp_hmac.hmac_ctx);
+    HMAC_CTX_free(ws->p_hash.evp_hmac.ctx.hmac_ctx);
     return S2N_SUCCESS;
 }
 
@@ -307,7 +314,13 @@ static int s2n_hmac_p_hash_digest(struct s2n_prf_working_space *ws, void *digest
 
 static int s2n_hmac_p_hash_reset(struct s2n_prf_working_space *ws)
 {
-    return s2n_hmac_reset(&ws->p_hash.s2n_hmac);
+    /* If we actually initialized s2n_hmac, wipe it.
+     * A valid, initialized s2n_hmac_state will have a valid block size.
+     */
+    if (ws->p_hash.s2n_hmac.hash_block_size != 0) {
+        return s2n_hmac_reset(&ws->p_hash.s2n_hmac);
+    }
+    return S2N_SUCCESS;
 }
 
 static int s2n_hmac_p_hash_cleanup(struct s2n_prf_working_space *ws)
@@ -330,13 +343,21 @@ static const struct s2n_p_hash_hmac s2n_internal_p_hash_hmac = {
     .free = &s2n_hmac_p_hash_free,
 };
 
+const struct s2n_p_hash_hmac *s2n_get_hmac_implementation() {
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+    return s2n_is_in_fips_mode() ? &s2n_evp_hmac_p_hash_hmac : &s2n_internal_p_hash_hmac;
+#else
+    return s2n_is_in_fips_mode() ? &s2n_evp_pkey_p_hash_hmac : &s2n_internal_p_hash_hmac;
+#endif
+}
+
 static int s2n_p_hash(struct s2n_prf_working_space *ws, s2n_hmac_algorithm alg, struct s2n_blob *secret, struct s2n_blob *label,
                       struct s2n_blob *seed_a, struct s2n_blob *seed_b, struct s2n_blob *seed_c, struct s2n_blob *out)
 {
     uint8_t digest_size;
     POSIX_GUARD(s2n_hmac_digest_size(alg, &digest_size));
 
-    const struct s2n_p_hash_hmac *hmac = ws->p_hash_hmac_impl;
+    const struct s2n_p_hash_hmac *hmac = s2n_get_hmac_implementation();
 
     /* First compute hmac(secret + A(0)) */
     POSIX_GUARD(hmac->init(ws, alg, secret));
@@ -389,13 +410,6 @@ static int s2n_p_hash(struct s2n_prf_working_space *ws, s2n_hmac_algorithm alg, 
 
     return 0;
 }
-const struct s2n_p_hash_hmac *s2n_get_hmac_implementation() {
-#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
-  return s2n_is_in_fips_mode() ? &s2n_evp_hmac_p_hash_hmac : &s2n_internal_p_hash_hmac;
-#else
-  return s2n_is_in_fips_mode() ? &s2n_evp_pkey_p_hash_hmac : &s2n_internal_p_hash_hmac;
-#endif
-}
 
 S2N_RESULT s2n_prf_new(struct s2n_connection *conn)
 {
@@ -409,8 +423,8 @@ S2N_RESULT s2n_prf_new(struct s2n_connection *conn)
     ZERO_TO_DISABLE_DEFER_CLEANUP(mem);
 
     /* Allocate the hmac state */
-    conn->prf_space->p_hash_hmac_impl = s2n_get_hmac_implementation();
-    RESULT_GUARD_POSIX(conn->prf_space->p_hash_hmac_impl->alloc(conn->prf_space));
+    const struct s2n_p_hash_hmac *hmac_impl = s2n_get_hmac_implementation();
+    RESULT_GUARD_POSIX(hmac_impl->alloc(conn->prf_space));
     return S2N_RESULT_OK;
 }
 
@@ -419,12 +433,8 @@ S2N_RESULT s2n_prf_wipe(struct s2n_connection *conn)
     RESULT_ENSURE_REF(conn);
     RESULT_ENSURE_REF(conn->prf_space);
 
-    /* If we actually initialized s2n_hmac, wipe it.
-     * A valid, initialized s2n_hmac_state will have a valid block size.
-     */
-    if (conn->prf_space->p_hash.s2n_hmac.hash_block_size != 0) {
-        RESULT_GUARD_POSIX(s2n_hmac_reset(&conn->prf_space->p_hash.s2n_hmac));
-    }
+    const struct s2n_p_hash_hmac *hmac_impl = s2n_get_hmac_implementation();
+    RESULT_GUARD_POSIX(hmac_impl->reset(conn->prf_space));
 
     return S2N_RESULT_OK;
 }
@@ -436,11 +446,8 @@ S2N_RESULT s2n_prf_free(struct s2n_connection *conn)
         return S2N_RESULT_OK;
     }
 
-    /* cppcheck-suppress nullPointerRedundantCheck
-     * cppcheck doesn't recognize the early exit if conn->prf_space == NULL.
-     */
-    conn->prf_space->p_hash_hmac_impl = s2n_get_hmac_implementation();
-    RESULT_GUARD_POSIX(conn->prf_space->p_hash_hmac_impl->free(conn->prf_space));
+    const struct s2n_p_hash_hmac *hmac_impl = s2n_get_hmac_implementation();
+    RESULT_GUARD_POSIX(hmac_impl->free(conn->prf_space));
 
     RESULT_GUARD_POSIX(s2n_free_object((uint8_t **) &conn->prf_space, sizeof(struct s2n_prf_working_space)));
     return S2N_RESULT_OK;
@@ -468,12 +475,7 @@ static int s2n_prf(struct s2n_connection *conn, struct s2n_blob *secret, struct 
      * outputs will be XORd just ass the TLS 1.0 and 1.1 RFCs require.
      */
     POSIX_GUARD(s2n_blob_zero(out));
-
-    /* Ensure that p_hash_hmac_impl is set, as it may have been reset for prf_space on s2n_connection_wipe.
-     * When in FIPS mode, the EVP API's must be used for the p_hash HMAC.
-     */
-    conn->prf_space->p_hash_hmac_impl = s2n_get_hmac_implementation();
-
+    
     if (conn->actual_protocol_version == S2N_TLS12) {
         return s2n_p_hash(conn->prf_space, conn->secure.cipher_suite->prf_alg, secret, label, seed_a, seed_b,
                           seed_c, out);

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -186,12 +186,7 @@ static int s2n_evp_pkey_p_hash_reset(struct s2n_prf_working_space *ws)
 {
     POSIX_GUARD(s2n_evp_pkey_p_hash_wipe(ws));
 
-    /*
-     * On some cleanup paths s2n_evp_pkey_p_hash_reset can be called before s2n_evp_pkey_p_hash_init so there is nothing
-     * to reset.
-     * ws->p_hash.evp_hmac.evp_digest.md == NULL || ws
-     */
-    if (ws->p_hash.evp_hmac.ctx.evp_pkey == NULL) {
+    if (ws->p_hash.evp_hmac.evp_digest.md == NULL) {
         return S2N_SUCCESS;
     }
     return s2n_evp_pkey_p_hash_digest_init(ws);
@@ -293,32 +288,26 @@ static const struct s2n_p_hash_hmac s2n_evp_hmac_p_hash_hmac = {
 };
 #endif /* !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC) */
 
-static int s2n_hmac_p_hash_alloc(struct s2n_prf_working_space *ws)
+static int s2n_hmac_p_hash_new(struct s2n_prf_working_space *ws)
 {
-    DEFER_CLEANUP(struct s2n_blob mem = { 0 }, s2n_free);
-    POSIX_GUARD_POSIX(s2n_realloc(&mem, sizeof(struct s2n_hmac_state)));
-    POSIX_GUARD_POSIX(s2n_blob_zero(&mem));
-    ws->p_hash.s2n_hmac = (struct s2n_hmac_state*)(void*) mem.data;
-    ZERO_TO_DISABLE_DEFER_CLEANUP(mem);
+    POSIX_GUARD(s2n_hmac_new(&ws->p_hash.s2n_hmac));
 
-    POSIX_GUARD(s2n_hmac_new(ws->p_hash.s2n_hmac));
-
-    return s2n_hmac_init(ws->p_hash.s2n_hmac, S2N_HMAC_NONE, NULL, 0);
+    return s2n_hmac_init(&ws->p_hash.s2n_hmac, S2N_HMAC_NONE, NULL, 0);
 }
 
 static int s2n_hmac_p_hash_init(struct s2n_prf_working_space *ws, s2n_hmac_algorithm alg, struct s2n_blob *secret)
 {
-    return s2n_hmac_init(ws->p_hash.s2n_hmac, alg, secret->data, secret->size);
+    return s2n_hmac_init(&ws->p_hash.s2n_hmac, alg, secret->data, secret->size);
 }
 
 static int s2n_hmac_p_hash_update(struct s2n_prf_working_space *ws, const void *data, uint32_t size)
 {
-    return s2n_hmac_update(ws->p_hash.s2n_hmac, data, size);
+    return s2n_hmac_update(&ws->p_hash.s2n_hmac, data, size);
 }
 
-static int s2n_hmac_p_hash_final(struct s2n_prf_working_space *ws, void *digest, uint32_t size)
+static int s2n_hmac_p_hash_digest(struct s2n_prf_working_space *ws, void *digest, uint32_t size)
 {
-    return s2n_hmac_digest(ws->p_hash.s2n_hmac, digest, size);
+    return s2n_hmac_digest(&ws->p_hash.s2n_hmac, digest, size);
 }
 
 static int s2n_hmac_p_hash_reset(struct s2n_prf_working_space *ws)
@@ -326,8 +315,8 @@ static int s2n_hmac_p_hash_reset(struct s2n_prf_working_space *ws)
     /* If we actually initialized s2n_hmac, wipe it.
      * A valid, initialized s2n_hmac_state will have a valid block size.
      */
-    if (ws->p_hash.s2n_hmac->hash_block_size != 0) {
-        return s2n_hmac_reset(ws->p_hash.s2n_hmac);
+    if (ws->p_hash.s2n_hmac.hash_block_size != 0) {
+        return s2n_hmac_reset(&ws->p_hash.s2n_hmac);
     }
     return S2N_SUCCESS;
 }
@@ -339,16 +328,14 @@ static int s2n_hmac_p_hash_cleanup(struct s2n_prf_working_space *ws)
 
 static int s2n_hmac_p_hash_free(struct s2n_prf_working_space *ws)
 {
-    int result = s2n_hmac_free(ws->p_hash.s2n_hmac);
-    POSIX_GUARD_POSIX(s2n_free_object((uint8_t **) ws->p_hash.s2n_hmac, sizeof(struct s2n_hmac_state)));
-    return result;
+    return s2n_hmac_free(&ws->p_hash.s2n_hmac);
 }
 
 static const struct s2n_p_hash_hmac s2n_internal_p_hash_hmac = {
-    .alloc = &s2n_hmac_p_hash_alloc,
+    .alloc = &s2n_hmac_p_hash_new,
     .init = &s2n_hmac_p_hash_init,
     .update = &s2n_hmac_p_hash_update,
-    .final = &s2n_hmac_p_hash_final,
+    .final = &s2n_hmac_p_hash_digest,
     .reset = &s2n_hmac_p_hash_reset,
     .cleanup = &s2n_hmac_p_hash_cleanup,
     .free = &s2n_hmac_p_hash_free,

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -186,7 +186,11 @@ static int s2n_evp_pkey_p_hash_reset(struct s2n_prf_working_space *ws)
 {
     POSIX_GUARD(s2n_evp_pkey_p_hash_wipe(ws));
 
-    if (ws->p_hash.evp_hmac.evp_digest.md == NULL) {
+    /*
+     * On some cleanup paths s2n_evp_pkey_p_hash_reset can be called before s2n_evp_pkey_p_hash_init so there is nothing
+     * to reset.
+     */
+    if (ws->p_hash.evp_hmac.ctx.evp_pkey == NULL) {
         return S2N_SUCCESS;
     }
     return s2n_evp_pkey_p_hash_digest_init(ws);

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -131,7 +131,7 @@ static int s2n_evp_pkey_p_hash_alloc(struct s2n_prf_working_space *ws)
     return 0;
 }
 
-static int s2n_evp_pkey_hmac_p_hash_digest_init(struct s2n_prf_working_space *ws)
+static int s2n_evp_pkey_p_hash_digest_init(struct s2n_prf_working_space *ws)
 {
     POSIX_ENSURE_REF(ws->p_hash.evp_hmac.evp_digest.md);
     POSIX_ENSURE_REF(ws->p_hash.evp_hmac.evp_digest.ctx);
@@ -157,7 +157,7 @@ static int s2n_evp_pkey_p_hash_init(struct s2n_prf_working_space *ws, s2n_hmac_a
     POSIX_ENSURE_REF(ws->p_hash.evp_hmac.mac_key = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL, secret->data, secret->size));
 
     /* Initialize the message digest context with the above message digest and mac key */
-    return s2n_evp_pkey_hmac_p_hash_digest_init(ws);
+    return s2n_evp_pkey_p_hash_digest_init(ws);
 }
 
 static int s2n_evp_pkey_p_hash_update(struct s2n_prf_working_space *ws, const void *data, uint32_t size)
@@ -167,7 +167,8 @@ static int s2n_evp_pkey_p_hash_update(struct s2n_prf_working_space *ws, const vo
     return 0;
 }
 
-static int s2n_evp_pkey_p_hash_final(struct s2n_prf_working_space *ws, void *digest, uint32_t size){
+static int s2n_evp_pkey_p_hash_final(struct s2n_prf_working_space *ws, void *digest, uint32_t size)
+{
     /* EVP_DigestSign API's require size_t data structures */
     size_t digest_size = size;
 
@@ -176,7 +177,7 @@ static int s2n_evp_pkey_p_hash_final(struct s2n_prf_working_space *ws, void *dig
     return 0;
 }
 
-static int s2n_evp_pkey_hmac_p_hash_wipe(struct s2n_prf_working_space *ws)
+static int s2n_evp_pkey_p_hash_wipe(struct s2n_prf_working_space *ws)
 {
   POSIX_GUARD_OSSL(S2N_EVP_MD_CTX_RESET(ws->p_hash.evp_hmac.evp_digest.ctx), S2N_ERR_P_HASH_WIPE_FAILED);
 
@@ -185,15 +186,15 @@ static int s2n_evp_pkey_hmac_p_hash_wipe(struct s2n_prf_working_space *ws)
 
 static int s2n_evp_pkey_p_hash_reset(struct s2n_prf_working_space *ws)
 {
-    POSIX_GUARD(s2n_evp_pkey_hmac_p_hash_wipe(ws));
+    POSIX_GUARD(s2n_evp_pkey_p_hash_wipe(ws));
 
-    return s2n_evp_pkey_hmac_p_hash_digest_init(ws);
+    return s2n_evp_pkey_p_hash_digest_init(ws);
 }
 
 static int s2n_evp_pkey_p_hash_cleanup(struct s2n_prf_working_space *ws)
 {
     /* Prepare the workspace md_ctx for the next p_hash */
-    POSIX_GUARD(s2n_evp_pkey_hmac_p_hash_wipe(ws));
+    POSIX_GUARD(s2n_evp_pkey_p_hash_wipe(ws));
 
     /* Free mac key - PKEYs cannot be reused */
     POSIX_ENSURE_REF(ws->p_hash.evp_hmac.mac_key);

--- a/tls/s2n_prf.h
+++ b/tls/s2n_prf.h
@@ -26,16 +26,13 @@
 /* Enough to support TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, 2*SHA384_DIGEST_LEN + 2*AES256_KEY_SIZE */
 #define S2N_MAX_KEY_BLOCK_LEN 160
 
-/* TODO: make this a union. If s2n is in FIPS mode it's always going to use evp_hmac, and outside of FIPS it should
- * always use s2n_hmac, https://github.com/aws/s2n-tls/issues/3111 */
-struct p_hash_state {
+union p_hash_state {
     struct s2n_hmac_state s2n_hmac;
     struct s2n_evp_hmac_state evp_hmac;
 };
 
 struct s2n_prf_working_space {
-    const struct s2n_p_hash_hmac *p_hash_hmac_impl;
-    struct p_hash_state p_hash;
+    union p_hash_state p_hash;
     uint8_t digest0[S2N_MAX_DIGEST_LEN];
     uint8_t digest1[S2N_MAX_DIGEST_LEN];
 };

--- a/tls/s2n_prf.h
+++ b/tls/s2n_prf.h
@@ -27,7 +27,7 @@
 #define S2N_MAX_KEY_BLOCK_LEN 160
 
 union p_hash_state {
-    struct s2n_hmac_state *s2n_hmac;
+    struct s2n_hmac_state s2n_hmac;
     struct s2n_evp_hmac_state evp_hmac;
 };
 

--- a/tls/s2n_prf.h
+++ b/tls/s2n_prf.h
@@ -27,7 +27,7 @@
 #define S2N_MAX_KEY_BLOCK_LEN 160
 
 union p_hash_state {
-    struct s2n_hmac_state s2n_hmac;
+    struct s2n_hmac_state *s2n_hmac;
     struct s2n_evp_hmac_state evp_hmac;
 };
 


### PR DESCRIPTION
### Resolved issues:

Resolves CryptoAlg-801 and replaces #2965 because Dusan is out. 

### Description of changes: 
Adding AWS-LC FIPS integration test to the CI. I also dropped the GCC 6 build to add 2 builds with AWS-LC FIPS using GC 4.8 and 9. I figure it's a good balance of still having coverage without making the build too slow.

### Call-outs:
This installs AWS-LC FIPS into a separate folder and runs it after the main AWS-LC integration tests. This follows the pattern as I understand it from https://github.com/aws/s2n-tls/blob/main/codebuild/spec/buildspec_ubuntu_integ_openssl102.yml#L49-L55

### Testing:

This is a CI change and will be checked there.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
