### PR TITLE
Added a Test for Mutal Auth + Caching

### DIFF
--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -1543,5 +1543,30 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(conn.server_keying_material_lifetime, UINT32_MAX);
     }
 
+    /* s2n_allowed_to_cache_connection */
+    {
+        struct s2n_connection *conn = NULL;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        struct s2n_config *config = NULL;
+        EXPECT_NOT_NULL(config = s2n_config_new());
+        EXPECT_SUCCESS(s2n_config_set_client_auth_type(config, S2N_CERT_AUTH_REQUIRED));
+
+        /* Turn session caching on */
+        config->use_session_cache = 1;
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        /* Cannot cache connection if client auth is required */
+        EXPECT_FALSE(s2n_allowed_to_cache_connection(conn));
+
+        EXPECT_SUCCESS(s2n_config_set_client_auth_type(config, S2N_CERT_AUTH_NONE));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        /* Allowed to cache connection if client auth is not required */
+        EXPECT_TRUE(s2n_allowed_to_cache_connection(conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
     END_TEST();
 }

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -34,7 +34,7 @@ int s2n_allowed_to_cache_connection(struct s2n_connection *conn)
 {
     /* We're unable to cache connections with a Client Cert since we currently don't serialize the Client Cert,
      * which means that callers won't have access to the Client's Cert if the connection is resumed. */
-    if (s2n_connection_is_client_auth_enabled(conn) > 0) {
+    if (s2n_connection_is_client_auth_enabled(conn)) {
         return 0;
     }
 


### PR DESCRIPTION
### Resolved issues:

 resolves #563
### Description of changes: 

Cleaning up a very old issue. This pr adds the test for s2n_allowed_to_cache_connection.
### Call-outs:

N/A
### Testing:

Unit test

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
