### PR TITLE
tests: fix fuzz count formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ libcrypto-root
 libcrypto-root/*
 tests/integration/__pycache__
 tests/unit/*_test
+tests/fuzz/*_test
+tests/fuzz/*.txt
 tests/fuzz/fuzz-*.log
 tests/benchmark/*_benchmark
 bin/s2nc

--- a/tests/fuzz/runFuzzTest.sh
+++ b/tests/fuzz/runFuzzTest.sh
@@ -205,6 +205,6 @@ then
 
 else
     cat ${TEST_NAME}_output.txt
-    printf "\033[31;1mFAILED\033[0m %s, %6d features covered\n" $TEST_INFO $FEATURE_COVERAGE
+    printf "\033[31;1mFAILED\033[0m %s, %6d features covered\n" "$TEST_INFO" $FEATURE_COVERAGE
     exit -1
 fi


### PR DESCRIPTION
### Description of changes: 

When fuzz tests are executed for a long time the test count can get quite high and awk will format the number in scientific notation. The value will be exported into a bash variable and a divide operation will be performed, which results in an error.

This change, instead, performs the formatting and division in awk instead to avoid crossing language boundaries.

### Testing:

I executed the code outside of the script with a very large number and the formatting was correct:

```sh
TEST_NAME=test
FUZZ_TIMEOUT_SEC=27400
echo "stat::number_of_executed_units: 999999999999999" > ${TEST_NAME}_output.txt
TEST_INFO=$(
    grep -o "stat::number_of_executed_units: [0-9]*" ${TEST_NAME}_output.txt | \
    awk -v timeout=$FUZZ_TIMEOUT_SEC '{count += int($2); rate = int(count / timeout)} END {print count, "tests, " rate " test/sec"}' \
)
TESTS_PER_SEC=$(echo "$TEST_INFO" | cut -d ' ' -f 3)
printf "\033[32;1mPASSED\033[0m %s\n" "$TEST_INFO"
# PASSED 999999999999999 tests, 36496350364 test/sec
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
