### PR TITLE
Add a flag to s2nc to enable FIPS mode in the underlying libcrypto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,11 @@ else()
     set(OS_LIBS Threads::Threads dl rt)
 endif()
 
+# Compiling the unit tests rely on S2N_TEST_IN_FIPS_MODE to be set correctly
+if(S2N_FIPS)
+    add_definitions(-DS2N_TEST_IN_FIPS_MODE)
+endif()
+
 file(GLOB S2N_HEADERS
     ${API_HEADERS}
     ${CRYPTO_HEADERS}


### PR DESCRIPTION
### Description of changes: 

OpenSSL FIPS requires applications to enable libcrypto FIPS mode before using FIPS specific crypto. s2n_init checks the FIPS status of libcrypto at startup. This change adds an option to s2nc to enable libcrypto's FIPS mode before s2n_init is called so the right FIPS code is used. This mimics the way s2nd does this.

With this change some of the integration tests needed to be updated. Some were easy such as reading all of the output of s2nc instead of just the first 15 lines. Other changes involved a slight behavior change: s2nc in FIPS mode does not support the PQ cipher suites and the tests should expect classic cipher suites.

### Call-outs:

This change is needed before https://github.com/aws/s2n-tls/pull/3084 can be merged in because AWS-LC when compiled for FIPS is always in FIPS mode and some cipher suite tests were not getting the right value.

The short parameter -f in s2nd is not supported and users must pass in the full `--enter-fips-mode`. You can see this in the options to `getopt_long`. I kept this the same in s2nc which is the future could be updated to use `-f` for fips, `-t` for the ca-file like s2nd, and a new option for the timeout. Trying to unify the s2nc/d options spiraled a little out of control.

### Testing:

Ran the integration tests locally.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
