### PR TITLE
EMS and Session Caching Interaction

### DIFF
--- a/tests/unit/s2n_ems_extension_test.c
+++ b/tests/unit/s2n_ems_extension_test.c
@@ -96,8 +96,7 @@ int main(int argc, char **argv)
         /* In the default case we should always be sending this extension */
         EXPECT_TRUE(s2n_client_ems_extension.should_send(conn));
 
-        uint8_t test_ticket[] = "test data";
-        EXPECT_SUCCESS(s2n_realloc(&conn->client_ticket, sizeof(test_ticket)));
+        conn->set_session = true;
         conn->ems_negotiated = true;
         /* If we have set a ticket on the connection we only send this extension
          * if the previous session negotiated EMS. */

--- a/tests/unit/s2n_extended_master_secret_test.c
+++ b/tests/unit/s2n_extended_master_secret_test.c
@@ -246,9 +246,7 @@ int main(int argc, char **argv)
          * resumption ticket to the connection, which indicates the previous session did not negotiate
          * EMS and therefore this session shouldn't either. The resumption ticket does not have to be valid
          * as this test is only interested in EMS. */
-        const uint8_t client_ticket[] = { "some ticket" };
-        EXPECT_SUCCESS(s2n_realloc(&client_conn->client_ticket, sizeof(client_ticket)));
-        EXPECT_MEMCPY_SUCCESS(client_conn->client_ticket.data, client_ticket, sizeof(client_ticket));
+        client_conn->set_session = true;
 
         /* Connection is successful and EMS is not negotiated */
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));

--- a/tests/unit/s2n_self_talk_session_id_test.c
+++ b/tests/unit/s2n_self_talk_session_id_test.c
@@ -27,6 +27,8 @@
 #include "tls/s2n_connection.h"
 #include "tls/s2n_handshake.h"
 
+#include "utils/s2n_bitmap.h"
+
 #define MAX_KEY_LEN 32
 #define MAX_VAL_LEN 255
 
@@ -460,6 +462,199 @@ int main(int argc, char **argv)
 
     /* Close the pipes */
     EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
+
+    /* Session caching with a server that does not support EMS */
+    {
+        initialize_cache();
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(client_conn);
+        s2n_config_disable_x509_verification(config);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        /* Negotiate until server has read the Client Hello message but hasn't written the server hello message */
+        EXPECT_OK(s2n_negotiate_until_message(client_conn, &blocked, SERVER_HELLO));
+        EXPECT_OK(s2n_negotiate_until_message(server_conn, &blocked, SERVER_HELLO));
+
+        /* s2n servers by default support EMS. We turn it off by manually setting ems_negotiated to false
+        * and removing the EMS extension from our received extensions. */
+        server_conn->ems_negotiated = false;
+        s2n_extension_type_id ems_ext_id = 0;
+        EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_EMS, &ems_ext_id));
+        S2N_CBIT_CLR(server_conn->extension_requests_received, ems_ext_id);
+
+        /* Connection is successful and EMS is not negotiated */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS12);
+        EXPECT_FALSE(server_conn->ems_negotiated);
+        EXPECT_FALSE(client_conn->ems_negotiated);
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(client_conn));
+
+        size_t tls12_session_ticket_len = s2n_connection_get_session_length(client_conn);
+        uint8_t tls12_session_ticket[S2N_TLS12_SESSION_SIZE] = { 0 };
+        EXPECT_SUCCESS(s2n_connection_get_session(client_conn, tls12_session_ticket, tls12_session_ticket_len));
+
+        /* Wipe connections and set up new handshake */
+        EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+        EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_session(client_conn, tls12_session_ticket, tls12_session_ticket_len));
+
+        /* Server will block the first time cache is accessed */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_test_server_and_client(server_conn, client_conn), S2N_ERR_ASYNC_BLOCKED);
+
+        /* Resumed connection is successful and EMS is not negotiated */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_EQUAL(S2N_CBIT_TEST(server_conn->extension_requests_received, ems_ext_id), 0);
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS12);
+        EXPECT_FALSE(server_conn->ems_negotiated);
+        EXPECT_FALSE(client_conn->ems_negotiated);
+        EXPECT_FALSE(IS_FULL_HANDSHAKE(server_conn));
+        EXPECT_FALSE(IS_FULL_HANDSHAKE(client_conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+    }
+
+    /**
+     *= https://tools.ietf.org/rfc/rfc7627#section-5.3
+     *= type=test
+     *# If the original session used the "extended_master_secret"
+     *# extension but the new ClientHello does not contain it, the server
+     *# MUST abort the abbreviated handshake.
+     **/
+    {
+        initialize_cache();
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(client_conn);
+        s2n_config_disable_x509_verification(config);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        /* Connection is successful and EMS is negotiated */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_TRUE(server_conn->ems_negotiated);
+        EXPECT_TRUE(client_conn->ems_negotiated);
+
+        size_t tls12_session_ticket_len = s2n_connection_get_session_length(client_conn);
+        uint8_t tls12_session_ticket[S2N_TLS12_SESSION_SIZE] = { 0 };
+        EXPECT_SUCCESS(s2n_connection_get_session(client_conn, tls12_session_ticket, tls12_session_ticket_len));
+
+        /* Wipe connections and set up new handshake */
+        EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+        EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        /* Force the client to not send the EMS extension */
+        EXPECT_SUCCESS(s2n_connection_set_session(client_conn, tls12_session_ticket, tls12_session_ticket_len));
+        client_conn->ems_negotiated = false;
+
+        /* Server will block the first time cache is accessed */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_test_server_and_client(server_conn, client_conn), S2N_ERR_ASYNC_BLOCKED);
+
+        /* Server did not receive the EMS extension from client */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_test_server_and_client(server_conn, client_conn), S2N_ERR_MISSING_EXTENSION);
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    /**
+     *= https://tools.ietf.org/rfc/rfc7627#section-5.3
+     *= type=test
+     *# If the original session did not use the "extended_master_secret"
+     *# extension but the new ClientHello contains the extension, then the
+     *# server MUST NOT perform the abbreviated handshake.  Instead, it
+     *# SHOULD continue with a full handshake (as described in
+     *# Section 5.2) to negotiate a new session.
+     **/
+    {
+        initialize_cache();
+        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(client_conn);
+        s2n_config_disable_x509_verification(config);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        /* Create nonblocking pipes */
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        /* Negotiate until server has read the Client Hello message but hasn't written the Server Hello message */
+        EXPECT_OK(s2n_negotiate_until_message(client_conn, &blocked, SERVER_HELLO));
+        EXPECT_OK(s2n_negotiate_until_message(server_conn, &blocked, SERVER_HELLO));
+
+        /* s2n servers by default support EMS. We turn it off by manually setting ems_negotiated to false
+        * and removing the EMS extension from our received extensions. */
+        server_conn->ems_negotiated = false;
+        s2n_extension_type_id ems_ext_id = 0;
+        EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_EMS, &ems_ext_id));
+        S2N_CBIT_CLR(server_conn->extension_requests_received, ems_ext_id);
+
+        /* Connection is successful and EMS is not negotiated */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS12);
+        EXPECT_FALSE(server_conn->ems_negotiated);
+        EXPECT_FALSE(client_conn->ems_negotiated);
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(client_conn));
+
+        size_t tls12_session_ticket_len = s2n_connection_get_session_length(client_conn);
+        uint8_t tls12_session_ticket[S2N_TLS12_SESSION_SIZE] = { 0 };
+        EXPECT_SUCCESS(s2n_connection_get_session(client_conn, tls12_session_ticket, tls12_session_ticket_len));
+
+        /* Wipe connections and set up new handshake */
+        EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+        EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        /* Force the client to send the EMS extension even though the original session did not negotiate EMS */
+        EXPECT_SUCCESS(s2n_connection_set_session(client_conn, tls12_session_ticket, tls12_session_ticket_len));
+        client_conn->ems_negotiated = true;
+
+        /* Server will block the first time cache is accessed */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_test_server_and_client(server_conn, client_conn), S2N_ERR_ASYNC_BLOCKED);
+
+        /* Fallback to full handshake */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_EQUAL(S2N_CBIT_TEST(server_conn->extension_requests_received, ems_ext_id), 1);
+        EXPECT_TRUE(server_conn->ems_negotiated);
+        EXPECT_TRUE(client_conn->ems_negotiated);
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(server_conn));
+        EXPECT_TRUE(IS_FULL_HANDSHAKE(client_conn));
+
+        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
+    }
 
     /* Clean up */
     EXPECT_SUCCESS(s2n_config_free(config));

--- a/tls/extensions/s2n_client_ems.c
+++ b/tls/extensions/s2n_client_ems.c
@@ -56,7 +56,7 @@ static bool s2n_client_ems_should_send(struct s2n_connection *conn)
 {
     /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
     /* Don't send this extension if the previous session did not negotiate EMS */
-    if ((conn->client_ticket.size > 0 && !conn->ems_negotiated) || !S2N_IN_TEST) {
+    if ((conn->set_session && !conn->ems_negotiated) || !S2N_IN_TEST) {
         return false;
     } else {
         return true;

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -131,6 +131,9 @@ struct s2n_connection {
     /* Connection negotiated an EMS */
     unsigned ems_negotiated:1;
 
+    /* Connection successfully set a ticket on the connection */
+    unsigned set_session:1;
+
     /* The configuration (cert, key .. etc ) */
     struct s2n_config *config;
 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -784,6 +784,31 @@ static S2N_RESULT s2n_conn_set_tls13_handshake_type(struct s2n_connection *conn)
     return S2N_RESULT_OK;
 }
 
+static S2N_RESULT s2n_validate_ems_status(struct s2n_connection *conn)
+{
+    RESULT_ENSURE_REF(conn);
+
+    s2n_extension_type_id ems_ext_id = 0;
+    RESULT_GUARD_POSIX(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_EMS, &ems_ext_id));
+    bool ems_extension_recv = S2N_CBIT_TEST(conn->extension_requests_received, ems_ext_id);
+
+    /**
+     *= https://tools.ietf.org/rfc/rfc7627#section-5.3
+     *# If the original session used the "extended_master_secret"
+     *# extension but the new ClientHello does not contain it, the server
+     *# MUST abort the abbreviated handshake.
+     **/
+    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
+    if (conn->ems_negotiated && S2N_IN_TEST) {
+        RESULT_ENSURE(ems_extension_recv, S2N_ERR_MISSING_EXTENSION);
+    }
+
+    /* Since we're discarding the resumption ticket, ignore EMS value from the ticket */
+    conn->ems_negotiated = ems_extension_recv;
+
+    return S2N_RESULT_OK;
+}
+
 int s2n_conn_set_handshake_type(struct s2n_connection *conn)
 {
     if (IS_TLS13_HANDSHAKE(conn)) {
@@ -813,18 +838,7 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
                 return S2N_SUCCESS;
             }
 
-            /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
-            if (conn->ems_negotiated && S2N_IN_TEST) {
-                s2n_extension_type_id ems_ext_id = 0;
-                POSIX_GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_EMS, &ems_ext_id));
-                /**
-                 *= https://tools.ietf.org/rfc/rfc7627#section-5.3
-                 *# If the original session used the "extended_master_secret"
-                 *# extension but the new ClientHello does not contain it, the server
-                 *# MUST abort the abbreviated handshake.
-                 **/
-                POSIX_ENSURE(S2N_CBIT_TEST(conn->extension_requests_received, ems_ext_id), S2N_ERR_MISSING_EXTENSION);
-            }
+            POSIX_GUARD_RESULT(s2n_validate_ems_status(conn));
 
             if (s2n_config_is_encrypt_decrypt_key_available(conn->config) == 1) {
                 conn->session_ticket_status = S2N_NEW_TICKET;
@@ -847,6 +861,7 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
         if (r == S2N_SUCCESS || (r < S2N_SUCCESS && S2N_ERROR_IS_BLOCKING(s2n_errno))) {
             return r;
         }
+        POSIX_GUARD_RESULT(s2n_validate_ems_status(conn));
     }
 
 skip_cache_lookup:


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Bug fix where client would incorrectly send an ems extension when resuming with a non-ems session using session IDs.
The correct behavior is for the client to not send the ems extension in the client hello because the previous session did not negotiate EMS. This worked with session tickets but not with session caching. 

Note that the situation where both client and server support ems is already tested in the self_talk_session_id_test file, given that this is default behavior.
### Call-outs:

Why was this missed? We don't know anyone who is using session caching, also it mostly works the same way as ticket resumption, so easy to miss.
### Testing:

Added a new self talk test to mimic this situation.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
