### PR TITLE
Reapply "Update QUIC parameters IANA (#3029)"

### DIFF
--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -125,12 +125,12 @@
 #define TLS_PSK_DHE_KE_MODE 1
 
 /**
- *= https://tools.ietf.org/id/draft-ietf-quic-tls-32.txt#8.2
+ *= https://tools.ietf.org/rfc/rfc9001.txt#8.2
  *#   enum {
- *#      quic_transport_parameters(0xffa5), (65535)
+ *#      quic_transport_parameters(0x39), (65535)
  *#   } ExtensionType;
  */
-#define TLS_QUIC_TRANSPORT_PARAMETERS      0xffa5
+#define TLS_QUIC_TRANSPORT_PARAMETERS      0x39
 
 /* TLS SignatureScheme (Backwards compatible with SigHash and SigAlg values above) */
 /* Defined here: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-signaturescheme */


### PR DESCRIPTION
### Description of changes: 

In #3069, we reverted QUIC v1 transport parameters. This change reapplies the update made in #3029.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
