### PR TITLE
Revert "EMS Release (#3053)"

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1624,7 +1624,7 @@ handshake.
 
 **s2n_config_set_session_state_lifetime** sets the lifetime of the cached session state. The default value is 15 hours.
 
-**s2n_connection_set_session** de-serializes the session state and updates the connection accordingly. Note that s2n-tls session tickets are versioned and this function will error if it receives a ticket version it doesn't understand. Therefore users need to handle errors for this function in case the inputted ticket is an unrecognized version, which could occur during a long deployment.
+**s2n_connection_set_session** de-serializes the session state and updates the connection accordingly.
 
 **s2n_connection_get_session** serializes the session state from connection and copies into the **session** buffer and returns the number of copied bytes. The output of this function depends on whether session ids or session tickets are being used for resumption.
 

--- a/tls/extensions/s2n_client_ems.c
+++ b/tls/extensions/s2n_client_ems.c
@@ -54,8 +54,9 @@ static int s2n_client_ems_recv(struct s2n_connection *conn, struct s2n_stuffer *
 
 static bool s2n_client_ems_should_send(struct s2n_connection *conn)
 {
+    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
     /* Don't send this extension if the previous session did not negotiate EMS */
-    if (conn->client_ticket.size > 0 && !conn->ems_negotiated) {
+    if ((conn->client_ticket.size > 0 && !conn->ems_negotiated) || !S2N_IN_TEST) {
         return false;
     } else {
         return true;

--- a/tls/extensions/s2n_server_ems.c
+++ b/tls/extensions/s2n_server_ems.c
@@ -55,7 +55,8 @@ static int s2n_server_ems_recv(struct s2n_connection *conn, struct s2n_stuffer *
 
 static bool s2n_server_ems_should_send(struct s2n_connection *conn)
 {
-    return conn && conn->actual_protocol_version < S2N_TLS13;
+    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
+    return conn && S2N_IN_TEST && conn->actual_protocol_version < S2N_TLS13;
 }
 
 static int s2n_server_ems_if_missing(struct s2n_connection *conn)

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -814,7 +814,8 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
                 return S2N_SUCCESS;
             }
 
-            if (conn->ems_negotiated) {
+            /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
+            if (conn->ems_negotiated && S2N_IN_TEST) {
                 s2n_extension_type_id ems_ext_id = 0;
                 POSIX_GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_EMS, &ems_ext_id));
                 /**

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -452,7 +452,8 @@ int s2n_prf_calculate_master_secret(struct s2n_connection *conn, struct s2n_blob
 
     POSIX_ENSURE_EQ(s2n_conn_get_current_message_type(conn), CLIENT_KEY);
 
-    if(!conn->ems_negotiated) {
+    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
+    if(!conn->ems_negotiated || !S2N_IN_TEST) {
         POSIX_GUARD(s2n_tls_prf_master_secret(conn, premaster_secret));
         return S2N_SUCCESS;
     }

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -156,7 +156,8 @@ static int s2n_tls12_deserialize_resumption_state(struct s2n_connection *conn, s
 
     POSIX_GUARD(s2n_stuffer_read_bytes(from, conn->secrets.master_secret, S2N_TLS_SECRET_LEN));
 
-    if (s2n_stuffer_data_available(from)) {
+    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
+    if (S2N_IN_TEST && s2n_stuffer_data_available(from)) {
         uint8_t ems_negotiated = 0;
         POSIX_GUARD(s2n_stuffer_read_uint8(from, &ems_negotiated));
 
@@ -223,7 +224,8 @@ static S2N_RESULT s2n_tls12_client_deserialize_session_state(struct s2n_connecti
 
     RESULT_GUARD_POSIX(s2n_stuffer_read_bytes(from, conn->secrets.master_secret, S2N_TLS_SECRET_LEN));
 
-    if (s2n_stuffer_data_available(from)) {
+    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
+    if (S2N_IN_TEST && s2n_stuffer_data_available(from)) {
         uint8_t ems_negotiated = 0;
         RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(from, &ems_negotiated));
         conn->ems_negotiated = ems_negotiated;


### PR DESCRIPTION
This reverts commit 1ff0aa8988e98feb6d106e7551c44f1718974d4a.

### Description of changes: 

Our EMS release causes issues when deployed to servers using session tickets. Reverting while we fix (and thoroughly test the fixes for) those issues.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
