### PR TITLE
Minor updates to async pkey operation documentation

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1726,7 +1726,9 @@ and will keep giving the same error until the **op** is performed and applied.
 The **op** can be performed either by calling **s2n_async_pkey_op_perform** to trigger
 s2n-tls to perform the operation using the currently configured private key, or by manually performing
 the private key operation and then calling **s2n_async_pkey_op_set_output** to pass the result to s2n-tls (see [Offloading asynchronous private key operations](#Offloading-asynchronous-private-key-operations)). Whichever method is used, **s2n_async_pkey_op_apply**
-should then be called to mark the **op** as completed and allow the handshake to continue.
+should then be called to mark the **op** as completed and allow the handshake to continue. **s2n_async_pkey_op_perform**, **s2n_async_pkey_op_set_output**, and the other asynchronous pkey functions
+mentioned here may be called from within the **s2n_async_pkey_fn** callback method, but **s2n_async_pkey_op_apply**
+MUST only be called after the callback has completed.
 
 Note, it is not safe to call multiple functions on the same **conn** or
 **op** objects from 2 different threads at the same time. Doing so will


### PR DESCRIPTION
### Description of changes: 

I'm trying to clarify the documentation a little in response to a customer question about whether `s2n_async_pkey_op_perform` still has to be called if offloading pkey operations and which methods can be called from the callback. My goal is to make it clear that:
* either  `s2n_async_pkey_op_perform` or  `s2n_async_pkey_op_set_output` needs to be called, but not both.
* only `s2n_async_pkey_op_apply` can't be called from the callback

### Call-outs:
* Should I somehow mention that while  `s2n_async_pkey_op_perform` can technically be called from inside the callback, that defeats the purpose of asynchronous pkey operations since it wouldn't actually be asynchronous?
* Don't forget Github will let you view the diff as a markdown preview. It makes it easier to review. Click the little file icon / "Display the rich diff" in the upper right corner of the file.

### Testing:
No tests, just documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
