### PR TITLE
build: add S2N_DEBUG_INFO option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,17 @@ set(VERSION_MAJOR 1)
 set(VERSION_MINOR 0)
 set(VERSION_PATCH 0)
 
+string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
+# minimize the artifact size of we've been configured with MinSizeRel
+if(uppercase_CMAKE_BUILD_TYPE STREQUAL "MINSIZEREL")
+    message(STATUS "Configuring for minimal artifact size")
+    set(S2N_DEBUG_INFO_DEFAULT OFF)
+    set(S2N_STACKTRACE_DEFAULT OFF)
+else()
+    set(S2N_DEBUG_INFO_DEFAULT ON)
+    set(S2N_STACKTRACE_DEFAULT ON)
+endif()
+
 option(S2N_NO_PQ "Disables all Post Quantum Crypto code. You likely want this
 for older compilers or uncommon platforms." OFF)
 option(S2N_NO_PQ_ASM "Turns off the ASM for PQ Crypto even if it's available for the toolchain.
@@ -33,13 +44,14 @@ version of libcrypto by interning the code and hiding symbols. This also enables
 loaded in an application with an otherwise conflicting libcrypto version." OFF)
 option(S2N_LTO, "Enables link time optimizations when building s2n-tls." OFF)
 option(S2N_STACKTRACE "Enables stacktrace functionality in s2n-tls. Note that this functionality is
-only available on platforms that support execinfo." ON)
+only available on platforms that support execinfo." ${S2N_STACKTRACE_DEFAULT})
 option(COVERAGE "Enable profiling collection for code coverage calculation" OFF)
 option(S2N_INTEG_TESTS "Enable the integrationv2 tests" OFF)
 option(S2N_FAST_INTEG_TESTS "Enable the integrationv2 with more parallelism, only has effect if S2N_INTEG_TESTS=ON" OFF)
 option(S2N_INSTALL_S2NC_S2ND "Install the binaries s2nc and s2nd" OFF)
 option(TSAN "Enable ThreadSanitizer to test thread safety" OFF)
 option(ASAN "Enable AddressSanitizer to test memory safety" OFF)
+option(S2N_DEBUG_INFO "Enables debugging information" ${S2N_DEBUG_INFO_DEFAULT})
 
 # Turn BUILD_TESTING=ON by default
 include(CTest)
@@ -128,6 +140,11 @@ endif()
 # Compiling the unit tests rely on S2N_TEST_IN_FIPS_MODE to be set correctly
 if(S2N_FIPS)
     add_definitions(-DS2N_TEST_IN_FIPS_MODE)
+endif()
+
+if(S2N_DEBUG_INFO)
+    message(STATUS "Enabling debug info")
+    add_definitions(-DS2N_DEBUG_INFO)
 endif()
 
 file(GLOB S2N_HEADERS

--- a/bindings/rust/s2n-tls-sys/build.rs
+++ b/bindings/rust/s2n-tls-sys/build.rs
@@ -123,6 +123,11 @@ fn build_vendored() {
         }
     }
 
+    // only enable debug info if we're not optimizing for size
+    if !["s", "z"].contains(&env("OPT_LEVEL").as_str()) {
+        build.define("S2N_DEBUG_INFO", "1");
+    }
+
     if !pq {
         build.define("S2N_NO_PQ", "1");
     }

--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -304,12 +304,17 @@ static const char *no_such_error = "Internal s2n error";
     ERR_ENTRY(S2N_ERR_KTLS_RENEG, "kTLS does not support secure renegotiation") \
     /* clang-format on */
 
-#define ERR_STR_CASE(ERR, str) \
-    case ERR:                  \
-        return str;
 #define ERR_NAME_CASE(ERR, str) \
     case ERR:                   \
         return #ERR;
+
+#ifdef S2N_DEBUG_INFO
+    #define ERR_STR_CASE(ERR, str) \
+        case ERR:                  \
+            return str;
+#else
+    #define ERR_STR_CASE(ERR, str) ERR_NAME_CASE(ERR, str)
+#endif
 
 const char *s2n_strerror(int error, const char *lang)
 {

--- a/s2n.mk
+++ b/s2n.mk
@@ -51,7 +51,7 @@ DEFAULT_CFLAGS += -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-s
                  -Wshadow  -Wcast-align -Wwrite-strings -fPIC -Wno-missing-braces\
                  -D_POSIX_C_SOURCE=200809L -O2 -I$(LIBCRYPTO_ROOT)/include/ \
                  -I$(S2N_ROOT)/api/ -I$(S2N_ROOT) -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security \
-                 -D_FORTIFY_SOURCE=2 -fgnu89-inline -fvisibility=hidden -DS2N_EXPORTS
+                 -D_FORTIFY_SOURCE=2 -fgnu89-inline -fvisibility=hidden -DS2N_EXPORTS -DS2N_DEBUG_INFO
 
 COVERAGE_CFLAGS = -fprofile-arcs -ftest-coverage
 COVERAGE_LDFLAGS = --coverage

--- a/tests/benchmark/utils/shared_info.cc
+++ b/tests/benchmark/utils/shared_info.cc
@@ -157,7 +157,7 @@ int benchmark_negotiate(struct s2n_connection *conn, int fd, benchmark::State& s
     if (s2n_ret != S2N_SUCCESS) {
         if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
             fprintf(stderr, "Failed to negotiate: '%s'. %s\n",
-                    s2n_strerror(s2n_errno, "EN"),
+                    s2n_strerror_name(s2n_errno),
                     s2n_strerror_debug(s2n_errno, "EN"));
             fprintf(stderr, "Alert: %d\n",
                     s2n_connection_get_alert(conn));

--- a/tests/integrationv2/test_client_authentication.py
+++ b/tests/integrationv2/test_client_authentication.py
@@ -135,7 +135,7 @@ def test_client_auth_with_s2n_server_using_nonmatching_certs(managed_process, pr
     for results in server.get_results():
         assert results.exception is None
         assert results.exit_code != 0
-        assert b'Certificate is untrusted' in results.stderr
+        assert b'S2N_ERR_CERT_UNTRUSTED' in results.stderr
         assert b'Error: Mutual Auth was required, but not negotiated' in results.stderr
         assert_s2n_handshake_complete(results, protocol, provider, False)
 

--- a/tests/unit/s2n_error_lookup_test.c
+++ b/tests/unit/s2n_error_lookup_test.c
@@ -99,7 +99,11 @@ int main(void)
 
     /* Ensure the file/line information is returned as expected */
     s2n_result_ignore(test_function(false));
+#ifdef S2N_DEBUG_INFO
     EXPECT_EQUAL(strcmp(s2n_strerror_source(S2N_ERR_SAFETY), "s2n_error_lookup_test.c:28"), 0);
+#else
+    EXPECT_EQUAL(strcmp(s2n_strerror_source(S2N_ERR_SAFETY), "s2n_error_lookup_test.c"), 0);
+#endif
 
     EXPECT_EQUAL(strcmp(EXAMPLE_DEBUG_STR("/absolute/path/to/file.c"), "file.c"), 0);
     EXPECT_EQUAL(strcmp(EXAMPLE_DEBUG_STR("relative/path/to/file.c"), "file.c"), 0);
@@ -110,7 +114,11 @@ int main(void)
     EXPECT_SUCCESS(s2n_cleanup());
 
     EXPECT_EQUAL(strcmp(s2n_strerror_name(S2N_ERR_OK), "S2N_ERR_OK"), 0);
+#ifdef S2N_DEBUG_INFO
     EXPECT_EQUAL(strcmp(s2n_strerror(S2N_ERR_OK, "EN"), "no error"), 0);
+#else
+    EXPECT_EQUAL(strcmp(s2n_strerror(S2N_ERR_OK, "EN"), "S2N_ERR_OK"), 0);
+#endif
 
     END_TEST();
 }


### PR DESCRIPTION
### Description of changes: 

s2n-tls is built with debugging information in all build modes. This can, unfortunately, add bloat to the final artifact. A lot of the size comes from the `_S2N_DEBUG_LINE` where we create a static string for each location that an error could possibly occur:

https://github.com/aws/s2n-tls/blob/b0725af8e9900da37c2ec32bb40bf5a92e6bc896/error/s2n_errno.h#L295

You can see this in effect by calling `strings build/lib/libs2n.so`:

```
...
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:56
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:61
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:62
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:69
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:70
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:71
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:81
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:89
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:90
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:97
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:104
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:111
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:113
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:139
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:144
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:174
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:190
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:198
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:201
Error encountered in /home/s2n-dev/s2n/crypto/s2n_pkey.c:233
...
```

This change adds an option to disable debug information. This means the following:

* Error locations only contain file names without the line number.
* Error descriptions only return their name when reading the error description. This _shouldn't_ be an issue since users can look up more information in the header file about an error with the error name.

With these changes, the final artifact size is reduced by ~35%.

### Call-outs:

With `CMAKE_BUILD_TYPE` set to `MinSizeRel`, debug information and stacktraces are disabled by default. Each option can be enabled with `-DS2N_DEBUG_INFO=on` and `-DS2N_STACKTRACE=on` respectively. All other build types enable both options by default.

### Testing:

| CMAKE_BUILD_TYPE | BUILD_SHARED_LIBS | Artifact Size |
|------------------|-------------------|---------------|
| Release          | OFF               | 2.3Mi         |
| MinSizeRel       | OFF               | 1.5Mi         |
| Release          | ON                | 1.2Mi         |
| MinSizeRel       | ON                | 739Ki         |

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
