### PR TITLE
Detect nested s2n_negotiate calls

### DIFF
--- a/tests/unit/s2n_handshake_io_test.c
+++ b/tests/unit/s2n_handshake_io_test.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/s2n.h"
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+#include "utils/s2n_result.h"
+
+bool s2n_custom_send_fn_called = false;
+static int s2n_expect_concurrent_error_send_fn(void *io_context, const uint8_t *buf, uint32_t len)
+{
+    struct s2n_connection *conn = (struct s2n_connection*) io_context;
+    s2n_custom_send_fn_called = true;
+
+    s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+    ssize_t result = s2n_negotiate(conn, &blocked);
+    EXPECT_FAILURE_WITH_ERRNO(result, S2N_ERR_REENTRANCY);
+    return result;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* s2n_negotiate can't be called recursively */
+    {
+        /* Setup connections */
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_OK(s2n_connection_set_secrets(conn));
+
+        /* Setup bad callback */
+        EXPECT_SUCCESS(s2n_connection_set_send_cb(conn, s2n_expect_concurrent_error_send_fn));
+        EXPECT_SUCCESS(s2n_connection_set_send_ctx(conn, (void*) conn));
+
+        /* Negotiate. When we attempt to send the ClientHello, the send callback
+         * should fail due to a reentrancy error.
+         */
+        s2n_custom_send_fn_called = false;
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked), S2N_ERR_IO);
+        EXPECT_TRUE(s2n_custom_send_fn_called);
+
+        /* Cleanup */
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    END_TEST();
+}

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -368,10 +368,11 @@ struct s2n_connection {
     struct s2n_stuffer cookie_stuffer;
 
     /* Flags to prevent users from calling methods recursively.
-     * This can be an easy mistake to make when implementing send/receive callbacks.
+     * This can be an easy mistake to make when implementing callbacks.
      */
     bool send_in_use;
     bool recv_in_use;
+    bool negotiate_in_use;
     
     uint16_t tickets_to_send;
     uint16_t tickets_sent;

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1350,7 +1350,7 @@ static int s2n_handle_retry_state(struct s2n_connection *conn)
     return S2N_SUCCESS;
 }
 
-int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
+int s2n_negotiate_impl(struct s2n_connection *conn, s2n_blocked_status *blocked)
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(blocked);
@@ -1434,4 +1434,14 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
     *blocked = S2N_NOT_BLOCKED;
 
     return S2N_SUCCESS;
+}
+
+int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
+{
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE(!conn->negotiate_in_use, S2N_ERR_REENTRANCY);
+    conn->negotiate_in_use = true;
+    int result = s2n_negotiate_impl(conn, blocked);
+    conn->negotiate_in_use = false;
+    return result;
 }


### PR DESCRIPTION
### Resolved issues:

related to https://github.com/aws/s2n-tls/pull/1969#discussion_r434256141 and https://github.com/aws/s2n-tls/issues/2757. If we prevent reentrancy this way, we can remove the requirement that `s2n_async_pkey_op_apply` is called after the callback completes.

### Description of changes: 

Apply the mechanism from https://github.com/aws/s2n-tls/commit/c8d04e4611bb44e3a09bcf991fec1c6ee4282366 to s2n_negotiate too. s2n_negotiate supports more callbacks than s2n_send/s2n_recv, so has more potential for reentrancy issues.

### Testing:

New unit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
