### PR TITLE
EMS Re-Release

### DIFF
--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -655,13 +655,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
             EXPECT_NOT_NULL(conn);
 
-            EXPECT_OK(s2n_deserialize_resumption_state(conn, NULL, &ticket_stuffer));
-
-            EXPECT_FALSE(conn->ems_negotiated);
-            EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS12);
-            EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_rsa_with_aes_128_gcm_sha256);
-
-            EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, conn->secrets.master_secret, S2N_TLS_SECRET_LEN);
+            EXPECT_ERROR_WITH_ERRNO(s2n_deserialize_resumption_state(conn, NULL, &ticket_stuffer), S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -328,7 +328,7 @@ int main(int argc, char **argv)
 
             uint8_t serial_id = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &serial_id));
-            EXPECT_EQUAL(serial_id, S2N_SERIALIZED_FORMAT_TLS12_V2);
+            EXPECT_EQUAL(serial_id, S2N_SERIALIZED_FORMAT_TLS12_V3);
 
             uint8_t version = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output, &version));

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -642,7 +642,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
 
-        /* Deserialized ticket sets correct connection values for session resumption in TLS1.2, without EMS data */
+        /* Deserialized ticket without EMS data errors */
         {
             struct s2n_blob ticket_blob = { 0 };
             EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, tls12_ticket, sizeof(tls12_ticket)));

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -583,6 +583,13 @@ int main(int argc, char **argv)
             TICKET_ISSUE_TIME_BYTES,
         };
 
+        uint8_t tls12_ticket_with_ems[S2N_TLS12_STATE_SIZE_IN_BYTES] = {
+            S2N_SERIALIZED_FORMAT_TLS12_V3,
+            S2N_TLS12,
+            TLS_RSA_WITH_AES_128_GCM_SHA256,
+            TICKET_ISSUE_TIME_BYTES,
+        };
+
         uint8_t tls13_ticket[] = {
             S2N_SERIALIZED_FORMAT_TLS13_V1,
             S2N_TLS13,
@@ -656,6 +663,33 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn);
 
             EXPECT_ERROR_WITH_ERRNO(s2n_deserialize_resumption_state(conn, NULL, &ticket_stuffer), S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
+
+            EXPECT_SUCCESS(s2n_connection_free(conn));
+        }
+
+        /* Client processes hardcoded TLS1.2 ticket with EMS data correctly */
+        {
+            struct s2n_blob ticket_blob = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, tls12_ticket_with_ems, sizeof(tls12_ticket_with_ems)));
+            struct s2n_stuffer ticket_stuffer = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_init(&ticket_stuffer, &ticket_blob));
+            EXPECT_SUCCESS(s2n_stuffer_skip_write(&ticket_stuffer, sizeof(tls12_ticket_with_ems) - S2N_TLS_SECRET_LEN - 1));
+            /* The secret needs to be written to the ticket separately as it has a fixed length */
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&ticket_stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
+
+            /* Write EMS data */
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&ticket_stuffer, 1));
+
+            struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+            EXPECT_NOT_NULL(conn);
+
+            EXPECT_OK(s2n_deserialize_resumption_state(conn, NULL, &ticket_stuffer));
+            
+            EXPECT_TRUE(conn->ems_negotiated);
+            EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS12);
+            EXPECT_EQUAL(conn->secure.cipher_suite, &s2n_rsa_with_aes_128_gcm_sha256);
+
+            EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, conn->secrets.master_secret, S2N_TLS_SECRET_LEN);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }

--- a/tls/extensions/s2n_client_ems.c
+++ b/tls/extensions/s2n_client_ems.c
@@ -47,19 +47,15 @@ static int s2n_client_ems_recv(struct s2n_connection *conn, struct s2n_stuffer *
     POSIX_ENSURE_REF(conn);
 
     /* Read nothing. The extension just needs to exist. */
-    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
-    if (S2N_IN_TEST) {
-        conn->ems_negotiated = true;
-    }
+    conn->ems_negotiated = true;
 
     return S2N_SUCCESS;
 }
 
 static bool s2n_client_ems_should_send(struct s2n_connection *conn)
 {
-    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
     /* Don't send this extension if the previous session did not negotiate EMS */
-    if ((conn->set_session && !conn->ems_negotiated) || !S2N_IN_TEST) {
+    if (conn->set_session && !conn->ems_negotiated) {
         return false;
     } else {
         return true;

--- a/tls/extensions/s2n_client_ems.c
+++ b/tls/extensions/s2n_client_ems.c
@@ -47,7 +47,10 @@ static int s2n_client_ems_recv(struct s2n_connection *conn, struct s2n_stuffer *
     POSIX_ENSURE_REF(conn);
 
     /* Read nothing. The extension just needs to exist. */
-    conn->ems_negotiated = true;
+    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
+    if (S2N_IN_TEST) {
+        conn->ems_negotiated = true;
+    }
 
     return S2N_SUCCESS;
 }

--- a/tls/extensions/s2n_server_ems.c
+++ b/tls/extensions/s2n_server_ems.c
@@ -55,8 +55,7 @@ static int s2n_server_ems_recv(struct s2n_connection *conn, struct s2n_stuffer *
 
 static bool s2n_server_ems_should_send(struct s2n_connection *conn)
 {
-    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
-    return conn && S2N_IN_TEST && conn->actual_protocol_version < S2N_TLS13;
+    return conn && conn->actual_protocol_version < S2N_TLS13;
 }
 
 static int s2n_server_ems_if_missing(struct s2n_connection *conn)

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -804,7 +804,10 @@ static S2N_RESULT s2n_validate_ems_status(struct s2n_connection *conn)
     }
 
     /* Since we're discarding the resumption ticket, ignore EMS value from the ticket */
-    conn->ems_negotiated = ems_extension_recv;
+    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
+    if (S2N_IN_TEST) {
+        conn->ems_negotiated = ems_extension_recv;
+    }
 
     return S2N_RESULT_OK;
 }

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -798,16 +798,12 @@ static S2N_RESULT s2n_validate_ems_status(struct s2n_connection *conn)
      *# extension but the new ClientHello does not contain it, the server
      *# MUST abort the abbreviated handshake.
      **/
-    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
-    if (conn->ems_negotiated && S2N_IN_TEST) {
+    if (conn->ems_negotiated) {
         RESULT_ENSURE(ems_extension_recv, S2N_ERR_MISSING_EXTENSION);
     }
 
     /* Since we're discarding the resumption ticket, ignore EMS value from the ticket */
-    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
-    if (S2N_IN_TEST) {
-        conn->ems_negotiated = ems_extension_recv;
-    }
+    conn->ems_negotiated = ems_extension_recv;
 
     return S2N_RESULT_OK;
 }

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -522,8 +522,7 @@ int s2n_prf_calculate_master_secret(struct s2n_connection *conn, struct s2n_blob
 
     POSIX_ENSURE_EQ(s2n_conn_get_current_message_type(conn), CLIENT_KEY);
 
-    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
-    if(!conn->ems_negotiated || !S2N_IN_TEST) {
+    if(!conn->ems_negotiated) {
         POSIX_GUARD(s2n_tls_prf_master_secret(conn, premaster_secret));
         return S2N_SUCCESS;
     }

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -156,8 +156,7 @@ static int s2n_tls12_deserialize_resumption_state(struct s2n_connection *conn, s
 
     POSIX_GUARD(s2n_stuffer_read_bytes(from, conn->secrets.master_secret, S2N_TLS_SECRET_LEN));
 
-    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
-    if (S2N_IN_TEST && s2n_stuffer_data_available(from)) {
+    if (s2n_stuffer_data_available(from)) {
         uint8_t ems_negotiated = 0;
         POSIX_GUARD(s2n_stuffer_read_uint8(from, &ems_negotiated));
 
@@ -224,8 +223,7 @@ static S2N_RESULT s2n_tls12_client_deserialize_session_state(struct s2n_connecti
 
     RESULT_GUARD_POSIX(s2n_stuffer_read_bytes(from, conn->secrets.master_secret, S2N_TLS_SECRET_LEN));
 
-    /* TODO: https://github.com/aws/s2n-tls/issues/2990 */
-    if (S2N_IN_TEST && s2n_stuffer_data_available(from)) {
+    if (s2n_stuffer_data_available(from)) {
         uint8_t ems_negotiated = 0;
         RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(from, &ems_negotiated));
         conn->ems_negotiated = ems_negotiated;

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -57,7 +57,7 @@ static int s2n_tls12_serialize_resumption_state(struct s2n_connection *conn, str
     POSIX_GUARD(conn->config->wall_clock(conn->config->sys_clock_ctx, &now));
 
     /* Write the entry */
-    POSIX_GUARD(s2n_stuffer_write_uint8(to, S2N_SERIALIZED_FORMAT_TLS12_V2));
+    POSIX_GUARD(s2n_stuffer_write_uint8(to, S2N_SERIALIZED_FORMAT_TLS12_V3));
     POSIX_GUARD(s2n_stuffer_write_uint8(to, conn->actual_protocol_version));
     POSIX_GUARD(s2n_stuffer_write_bytes(to, conn->secure.cipher_suite->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
     POSIX_GUARD(s2n_stuffer_write_uint64(to, now));
@@ -326,7 +326,7 @@ static S2N_RESULT s2n_deserialize_resumption_state(struct s2n_connection *conn, 
     uint8_t format = 0;
     RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(from, &format));
 
-    if (format == S2N_SERIALIZED_FORMAT_TLS12_V1 || format == S2N_SERIALIZED_FORMAT_TLS12_V2) {
+    if (format == S2N_SERIALIZED_FORMAT_TLS12_V3) {
         if (conn->mode == S2N_SERVER) {
             RESULT_GUARD_POSIX(s2n_tls12_deserialize_resumption_state(conn, from));
         } else {

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -92,6 +92,7 @@ typedef enum {
     S2N_SERIALIZED_FORMAT_TLS12_V1 = 1,
     S2N_SERIALIZED_FORMAT_TLS13_V1,
     S2N_SERIALIZED_FORMAT_TLS12_V2,
+    S2N_SERIALIZED_FORMAT_TLS12_V3,
 } s2n_serial_format_version;
 
 extern int s2n_allowed_to_cache_connection(struct s2n_connection *conn);


### PR DESCRIPTION
### Resolved issues:

 resolves #3112

### Description of changes: 
Previous issue is that ems was being marked as true on session tickets when it was actually not being negotiated, due to incorrect gating code. This change invalidates all previous TLS1.2 tickets by upping the TLS1.2 ticket version, so if a client tries to use a previous ticket the server will just fall back to a full handshake. Also re-releases EMS code.
### Call-outs:
N/A
### Testing:
I tested this code manually against the main branch of s2n. I verified:
- Old servers fall back to a full handshake when reading new tickets.
- New servers fall back to a full handshake when reading old tickets.
- New servers successfully resume when reading new tickets. (EMS is negotiated on both these connections)
- Old clients fail when reading a new ticket.
- New clients fail when reading an old ticket.
- New clients succeed when reading a new ticket.

whew 😅 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
