### PR TITLE
If QUIC, only offer TLS1.3

### DIFF
--- a/tests/unit/s2n_client_supported_versions_extension_test.c
+++ b/tests/unit/s2n_client_supported_versions_extension_test.c
@@ -58,6 +58,58 @@ int main(int argc, char **argv)
     struct s2n_config *config;
     EXPECT_NOT_NULL(config = s2n_config_new());
 
+    const struct s2n_security_policy *security_policy_with_tls13_and_earlier = &security_policy_20190801;
+    EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy_with_tls13_and_earlier));
+    EXPECT_EQUAL(security_policy_with_tls13_and_earlier->minimum_protocol_version, S2N_TLS10);
+
+    /* Client offers all supported versions in version list */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(conn);
+        conn->security_policy_override = security_policy_with_tls13_and_earlier;
+
+        struct s2n_stuffer extension = { 0 };
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extension, 0));
+        EXPECT_SUCCESS(s2n_client_supported_versions_extension.send(conn, &extension));
+
+        /* Check extension contains enough versions */
+        uint8_t version_list_size = 0;
+        size_t supported_versions = latest_version - S2N_TLS10 + 1;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint8(&extension, &version_list_size));
+        EXPECT_EQUAL(version_list_size, S2N_TLS_PROTOCOL_VERSION_LEN * supported_versions);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+    }
+
+    /* Client doesn't offer <TLS1.3 in the version list if QUIC enabled */
+    if (s2n_is_tls13_fully_supported()) {
+        /* For simplicity, we assume TLS1.3 is the latest version. */
+        EXPECT_EQUAL(latest_version, S2N_TLS13);
+
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_NOT_NULL(conn);
+        EXPECT_SUCCESS(s2n_connection_enable_quic(conn));
+        conn->security_policy_override = security_policy_with_tls13_and_earlier;
+
+        struct s2n_stuffer extension = { 0 };
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extension, 0));
+        EXPECT_SUCCESS(s2n_client_supported_versions_extension.send(conn, &extension));
+
+        /* Check extension contains only one version */
+        uint8_t version_list_size = 0;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint8(&extension, &version_list_size));
+        EXPECT_EQUAL(version_list_size, S2N_TLS_PROTOCOL_VERSION_LEN);
+
+        /* Check single version is TLS1.3 */
+        uint16_t version = 0;
+        EXPECT_SUCCESS(s2n_stuffer_read_uint16(&extension, &version));
+        EXPECT_EQUAL(version, 0x0304);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
+    }
+
     /* Client produces a version list that the server can parse */
     {
         struct s2n_connection *client_conn;

--- a/tests/unit/s2n_client_supported_versions_extension_test.c
+++ b/tests/unit/s2n_client_supported_versions_extension_test.c
@@ -72,9 +72,12 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extension, 0));
         EXPECT_SUCCESS(s2n_client_supported_versions_extension.send(conn, &extension));
 
+        /* Total supported versions.
+         * If the "+1" looks wrong, consider what would happen if latest_version == S2N_TLS10. */
+        size_t supported_versions = (latest_version - S2N_TLS10) + 1;
+
         /* Check extension contains enough versions */
         uint8_t version_list_size = 0;
-        size_t supported_versions = latest_version - S2N_TLS10 + 1;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&extension, &version_list_size));
         EXPECT_EQUAL(version_list_size, S2N_TLS_PROTOCOL_VERSION_LEN * supported_versions);
 

--- a/tls/extensions/s2n_client_supported_versions.c
+++ b/tls/extensions/s2n_client_supported_versions.c
@@ -59,7 +59,7 @@ const s2n_extension_type s2n_client_supported_versions_extension = {
 static int s2n_client_supported_versions_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     uint8_t highest_supported_version = conn->client_protocol_version;
-    uint8_t minimum_supported_version;
+    uint8_t minimum_supported_version = s2n_unknown_protocol_version;
     POSIX_GUARD_RESULT(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
     POSIX_ENSURE(highest_supported_version >= minimum_supported_version, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 
@@ -76,7 +76,7 @@ static int s2n_client_supported_versions_send(struct s2n_connection *conn, struc
 
 static int s2n_extensions_client_supported_versions_process(struct s2n_connection *conn, struct s2n_stuffer *extension) {
     uint8_t highest_supported_version = conn->server_protocol_version;
-    uint8_t minimum_supported_version;
+    uint8_t minimum_supported_version = s2n_unknown_protocol_version;
     POSIX_GUARD_RESULT(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
 
     uint8_t size_of_version_list;
@@ -136,7 +136,7 @@ static int s2n_client_supported_versions_recv(struct s2n_connection *conn, struc
 /* Old-style extension functions -- remove after extensions refactor is complete */
 
 int s2n_extensions_client_supported_versions_size(struct s2n_connection *conn) {
-    uint8_t minimum_supported_version;
+    uint8_t minimum_supported_version = s2n_unknown_protocol_version;
     POSIX_GUARD_RESULT(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
     uint8_t highest_supported_version = conn->client_protocol_version;
 

--- a/tls/extensions/s2n_client_supported_versions.c
+++ b/tls/extensions/s2n_client_supported_versions.c
@@ -60,7 +60,7 @@ static int s2n_client_supported_versions_send(struct s2n_connection *conn, struc
 {
     uint8_t highest_supported_version = conn->client_protocol_version;
     uint8_t minimum_supported_version;
-    POSIX_GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
+    POSIX_GUARD_RESULT(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
     POSIX_ENSURE(highest_supported_version >= minimum_supported_version, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 
     uint8_t version_list_length = highest_supported_version - minimum_supported_version + 1;
@@ -77,7 +77,7 @@ static int s2n_client_supported_versions_send(struct s2n_connection *conn, struc
 static int s2n_extensions_client_supported_versions_process(struct s2n_connection *conn, struct s2n_stuffer *extension) {
     uint8_t highest_supported_version = conn->server_protocol_version;
     uint8_t minimum_supported_version;
-    POSIX_GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
+    POSIX_GUARD_RESULT(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
 
     uint8_t size_of_version_list;
     POSIX_GUARD(s2n_stuffer_read_uint8(extension, &size_of_version_list));
@@ -137,7 +137,7 @@ static int s2n_client_supported_versions_recv(struct s2n_connection *conn, struc
 
 int s2n_extensions_client_supported_versions_size(struct s2n_connection *conn) {
     uint8_t minimum_supported_version;
-    POSIX_GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
+    POSIX_GUARD_RESULT(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
     uint8_t highest_supported_version = conn->client_protocol_version;
 
     uint8_t version_list_length = highest_supported_version - minimum_supported_version + 1;

--- a/tls/extensions/s2n_server_supported_versions.c
+++ b/tls/extensions/s2n_server_supported_versions.c
@@ -61,7 +61,7 @@ static int s2n_server_supported_versions_send(struct s2n_connection *conn, struc
 static int s2n_extensions_server_supported_versions_process(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     uint8_t highest_supported_version = conn->client_protocol_version;
-    uint8_t minimum_supported_version;
+    uint8_t minimum_supported_version = s2n_unknown_protocol_version;
     POSIX_GUARD_RESULT(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
     POSIX_ENSURE(highest_supported_version >= minimum_supported_version, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 

--- a/tls/extensions/s2n_server_supported_versions.c
+++ b/tls/extensions/s2n_server_supported_versions.c
@@ -62,7 +62,7 @@ static int s2n_extensions_server_supported_versions_process(struct s2n_connectio
 {
     uint8_t highest_supported_version = conn->client_protocol_version;
     uint8_t minimum_supported_version;
-    POSIX_GUARD(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
+    POSIX_GUARD_RESULT(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
     POSIX_ENSURE(highest_supported_version >= minimum_supported_version, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 
     uint8_t server_version_parts[S2N_TLS_PROTOCOL_VERSION_LEN];

--- a/tls/extensions/s2n_supported_versions.c
+++ b/tls/extensions/s2n_supported_versions.c
@@ -21,11 +21,19 @@
 
 #include "utils/s2n_safety.h"
 
-int s2n_connection_get_minimum_supported_version(struct s2n_connection *conn, uint8_t *min_version)
+S2N_RESULT s2n_connection_get_minimum_supported_version(struct s2n_connection *conn, uint8_t *min_version)
 {
-    const struct s2n_security_policy *security_policy;
-    POSIX_GUARD(s2n_connection_get_security_policy(conn, &security_policy));
+    RESULT_ENSURE_REF(min_version);
+
+    const struct s2n_security_policy *security_policy = NULL;
+    RESULT_GUARD_POSIX(s2n_connection_get_security_policy(conn, &security_policy));
+    RESULT_ENSURE_REF(security_policy);
     *min_version = security_policy->minimum_protocol_version;
 
-    return 0;
+    /* QUIC requires >= TLS1.3 */
+    if (s2n_connection_is_quic_enabled(conn)) {
+        *min_version = MAX(*min_version, S2N_TLS13);
+    }
+
+    return S2N_RESULT_OK;
 }

--- a/tls/extensions/s2n_supported_versions.h
+++ b/tls/extensions/s2n_supported_versions.h
@@ -18,4 +18,4 @@
 #include "tls/s2n_connection.h"
 #include "stuffer/s2n_stuffer.h"
 
-extern int s2n_connection_get_minimum_supported_version(struct s2n_connection *conn, uint8_t *min_version);
+S2N_RESULT s2n_connection_get_minimum_supported_version(struct s2n_connection *conn, uint8_t *min_version);


### PR DESCRIPTION
### Description of changes: 

QUIC doesn't function with versions of TLS < 1.3.

### Testing:
Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
