### PR TITLE
Allow EVP hash implementation to use EVP_md5_sha1 if available

### DIFF
--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -327,6 +327,7 @@ static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm al
         return S2N_SUCCESS;
     }
 
+    POSIX_ENSURE_REF(s2n_hash_alg_to_evp_md(alg));
     POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, s2n_hash_alg_to_evp_md(alg), NULL), S2N_ERR_HASH_INIT_FAILED);
     return S2N_SUCCESS;
 }
@@ -368,7 +369,11 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
         return S2N_SUCCESS;
     }
 
+    POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
+
     if (state->alg == S2N_HASH_MD5_SHA1 && s2n_use_custom_md5_sha1()) {
+        POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp_md5_secondary.ctx));
+
         uint8_t sha1_digest_size = 0;
         POSIX_GUARD(s2n_hash_digest_size(S2N_HASH_SHA1, &sha1_digest_size));
 
@@ -383,7 +388,6 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
         return S2N_SUCCESS;
     }
 
-    POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
     POSIX_ENSURE(EVP_MD_CTX_size(state->digest.high_level.evp.ctx) <= digest_size, S2N_ERR_HASH_DIGEST_FAILED);
     POSIX_GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, out, &digest_size), S2N_ERR_HASH_DIGEST_FAILED);
     return S2N_SUCCESS;

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -22,6 +22,36 @@
 
 #include "utils/s2n_safety.h"
 
+#if S2N_OPENSSL_VERSION_AT_LEAST(1,1,1) || defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+#define S2N_EVP_SUPPORTS_SHA1_MD5_HASH true
+#else
+#define S2N_EVP_SUPPORTS_SHA1_MD5_HASH false
+#endif
+
+const EVP_MD* s2n_hash_alg_to_evp_md(s2n_hash_algorithm alg)
+{
+    switch (alg) {
+        case S2N_HASH_MD5:
+            return EVP_md5();
+        case S2N_HASH_SHA1:
+            return EVP_sha1();
+        case S2N_HASH_SHA224:
+            return EVP_sha224();
+        case S2N_HASH_SHA256:
+            return EVP_sha256();
+        case S2N_HASH_SHA384:
+            return EVP_sha384();
+        case S2N_HASH_SHA512:
+            return EVP_sha512();
+#if S2N_EVP_SUPPORTS_SHA1_MD5_HASH
+        case S2N_HASH_MD5_SHA1:
+            return EVP_md5_sha1();
+#endif
+        default:
+            return NULL;
+    }
+}
+
 int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out)
 {
     POSIX_ENSURE(S2N_MEM_IS_WRITABLE_CHECK(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
@@ -245,10 +275,15 @@ static int s2n_low_level_hash_free(struct s2n_hash_state *state)
 static int s2n_evp_hash_new(struct s2n_hash_state *state)
 {
     POSIX_ENSURE_REF(state->digest.high_level.evp.ctx = S2N_EVP_MD_CTX_NEW());
-    POSIX_ENSURE_REF(state->digest.high_level.evp_md5_secondary.ctx = S2N_EVP_MD_CTX_NEW());
     state->is_ready_for_input = 0;
     state->currently_in_hash = 0;
+    return S2N_SUCCESS;
+}
 
+static int s2n_evp_hash_with_custom_sha1_md5_new(struct s2n_hash_state *state)
+{
+    POSIX_GUARD(s2n_evp_hash_new(state));
+    POSIX_ENSURE_REF(state->digest.high_level.evp_md5_secondary.ctx = S2N_EVP_MD_CTX_NEW());
     return S2N_SUCCESS;
 }
 
@@ -259,79 +294,78 @@ static int s2n_evp_hash_allow_md5_for_fips(struct s2n_hash_state *state)
      * outside of the TLS 1.0 and 1.1 PRF when in FIPS mode. When needed, this must
      * be called prior to s2n_hash_init().
      */
-    POSIX_GUARD(s2n_digest_allow_md5_for_fips(&state->digest.high_level.evp_md5_secondary));
     return s2n_digest_allow_md5_for_fips(&state->digest.high_level.evp);
+}
+
+static int s2n_evp_hash_with_custom_sha1_md5_allow_md5_for_fips(struct s2n_hash_state *state)
+{
+    /* This is only to be used for s2n_hash_states that will require MD5 to be used
+     * to comply with the TLS 1.0 and 1.1 RFC's for the PRF. MD5 cannot be used
+     * outside of the TLS 1.0 and 1.1 PRF when in FIPS mode. When needed, this must
+     * be called prior to s2n_hash_init().
+     */
+    POSIX_GUARD(s2n_evp_hash_allow_md5_for_fips(state));
+    POSIX_GUARD(s2n_digest_allow_md5_for_fips(&state->digest.high_level.evp_md5_secondary));
+    return S2N_SUCCESS;
 }
 
 static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 {
     POSIX_ENSURE_REF(state->digest.high_level.evp.ctx);
-    POSIX_ENSURE_REF(state->digest.high_level.evp_md5_secondary.ctx);
-    switch (alg) {
-    case S2N_HASH_NONE:
-        break;
-    case S2N_HASH_MD5:
-        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_md5(), NULL), S2N_ERR_HASH_INIT_FAILED);
-        break;
-    case S2N_HASH_SHA1:
-      POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha1(), NULL), S2N_ERR_HASH_INIT_FAILED);
-        break;
-    case S2N_HASH_SHA224:
-        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha224(), NULL), S2N_ERR_HASH_INIT_FAILED);
-        break;
-    case S2N_HASH_SHA256:
-        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha256(), NULL), S2N_ERR_HASH_INIT_FAILED);
-        break;
-    case S2N_HASH_SHA384:
-        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha384(), NULL), S2N_ERR_HASH_INIT_FAILED);
-        break;
-    case S2N_HASH_SHA512:
-        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha512(), NULL), S2N_ERR_HASH_INIT_FAILED);
-        break;
-    case S2N_HASH_MD5_SHA1:
-        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha1(), NULL), S2N_ERR_HASH_INIT_FAILED);
-        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp_md5_secondary.ctx, EVP_md5(), NULL), S2N_ERR_HASH_INIT_FAILED);
-        break;
-    default:
-        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
-    }
 
     state->alg = alg;
     state->is_ready_for_input = 1;
     state->currently_in_hash = 0;
 
+    if (alg == S2N_HASH_NONE) {
+        return S2N_SUCCESS;
+    }
+
+    POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx,
+            s2n_hash_alg_to_evp_md(alg), NULL), S2N_ERR_HASH_INIT_FAILED);
+    return S2N_SUCCESS;
+}
+
+static int s2n_evp_hash_with_custom_sha1_md5_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
+{
+    if (alg != S2N_HASH_MD5_SHA1) {
+        return s2n_evp_hash_init(state, alg);
+    }
+
+    POSIX_GUARD(s2n_evp_hash_init(state, S2N_HASH_SHA1));
+    state->alg = S2N_HASH_MD5_SHA1;
+
+    POSIX_ENSURE_REF(state->digest.high_level.evp_md5_secondary.ctx);
+    POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp_md5_secondary.ctx, EVP_md5(), NULL),
+            S2N_ERR_HASH_INIT_FAILED);
     return S2N_SUCCESS;
 }
 
 static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
     POSIX_ENSURE(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
-
-    switch (state->alg) {
-    case S2N_HASH_NONE:
-        break;
-    case S2N_HASH_MD5:
-    case S2N_HASH_SHA1:
-    case S2N_HASH_SHA224:
-    case S2N_HASH_SHA256:
-    case S2N_HASH_SHA384:
-    case S2N_HASH_SHA512:
-        POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
-        POSIX_GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp.ctx, data, size), S2N_ERR_HASH_UPDATE_FAILED);
-        break;
-    case S2N_HASH_MD5_SHA1:
-        POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
-        POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp_md5_secondary.ctx));
-        POSIX_GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp.ctx, data, size), S2N_ERR_HASH_UPDATE_FAILED);
-        POSIX_GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp_md5_secondary.ctx, data, size), S2N_ERR_HASH_UPDATE_FAILED);
-        break;
-    default:
-        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
-    }
-
     POSIX_ENSURE(size <= (UINT64_MAX - state->currently_in_hash), S2N_ERR_INTEGER_OVERFLOW);
     state->currently_in_hash += size;
 
+    if (state->alg == S2N_HASH_NONE) {
+        return S2N_SUCCESS;
+    }
+
+    POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
+    POSIX_GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp.ctx, data, size), S2N_ERR_HASH_UPDATE_FAILED);
+    return S2N_SUCCESS;
+}
+
+static int s2n_evp_hash_with_custom_sha1_md5_update(struct s2n_hash_state *state, const void *data, uint32_t size)
+{
+    POSIX_GUARD(s2n_evp_hash_update(state, data, size));
+    if (state->alg != S2N_HASH_MD5_SHA1) {
+        return S2N_SUCCESS;
+    }
+
+    POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp_md5_secondary.ctx));
+    POSIX_GUARD_OSSL(EVP_DigestUpdate(state->digest.high_level.evp_md5_secondary.ctx, data, size),
+            S2N_ERR_HASH_UPDATE_FAILED);
     return S2N_SUCCESS;
 }
 
@@ -339,44 +373,53 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
 {
     POSIX_ENSURE(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
+    state->currently_in_hash = 0;
+    state->is_ready_for_input = 0;
+
+    unsigned int digest_size = size;
+    uint8_t expected_digest_size = 0;
+    POSIX_GUARD(s2n_hash_digest_size(state->alg, &expected_digest_size));
+    POSIX_ENSURE_EQ(digest_size, expected_digest_size);
+
+    if (state->alg == S2N_HASH_NONE) {
+        return S2N_SUCCESS;
+    }
+
+    POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
+    POSIX_ENSURE(EVP_MD_CTX_size(state->digest.high_level.evp.ctx) <= digest_size, S2N_ERR_HASH_DIGEST_FAILED);
+    POSIX_GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, out, &digest_size), S2N_ERR_HASH_DIGEST_FAILED);
+    return S2N_SUCCESS;
+}
+
+static int s2n_evp_hash_with_custom_sha1_md5_digest(struct s2n_hash_state *state, void *out, uint32_t size)
+{
+    if (state->alg != S2N_HASH_MD5_SHA1) {
+        return s2n_evp_hash_digest(state, out, size);
+    }
+
+    POSIX_ENSURE(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
+    POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
+    POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp_md5_secondary.ctx));
+
     unsigned int digest_size = size;
     uint8_t expected_digest_size;
     POSIX_GUARD(s2n_hash_digest_size(state->alg, &expected_digest_size));
     POSIX_ENSURE_EQ(digest_size, expected_digest_size);
 
     /* Used for S2N_HASH_MD5_SHA1 case to specify the exact size of each digest. */
-    uint8_t sha1_digest_size;
-    unsigned int sha1_primary_digest_size;
-    unsigned int md5_secondary_digest_size;
+    uint8_t sha1_digest_size = 0;
+    POSIX_GUARD(s2n_hash_digest_size(S2N_HASH_SHA1, &sha1_digest_size));
+    unsigned int sha1_primary_digest_size = sha1_digest_size;
+    unsigned int md5_secondary_digest_size = digest_size - sha1_primary_digest_size;
 
-    switch (state->alg) {
-    case S2N_HASH_NONE:
-        break;
-    case S2N_HASH_MD5:
-    case S2N_HASH_SHA1:
-    case S2N_HASH_SHA224:
-    case S2N_HASH_SHA256:
-    case S2N_HASH_SHA384:
-    case S2N_HASH_SHA512:
-        POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
-        POSIX_ENSURE(EVP_MD_CTX_size(state->digest.high_level.evp.ctx) <= digest_size, S2N_ERR_HASH_DIGEST_FAILED);
-        POSIX_GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, out, &digest_size), S2N_ERR_HASH_DIGEST_FAILED);
-        break;
-    case S2N_HASH_MD5_SHA1:
-        POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp.ctx));
-        POSIX_ENSURE_REF(EVP_MD_CTX_md(state->digest.high_level.evp_md5_secondary.ctx));
-        POSIX_GUARD(s2n_hash_digest_size(S2N_HASH_SHA1, &sha1_digest_size));
-        sha1_primary_digest_size = sha1_digest_size;
-        md5_secondary_digest_size = digest_size - sha1_primary_digest_size;
-        POSIX_ENSURE(EVP_MD_CTX_size(state->digest.high_level.evp.ctx) <= sha1_digest_size, S2N_ERR_HASH_DIGEST_FAILED);
-        POSIX_ENSURE(EVP_MD_CTX_size(state->digest.high_level.evp_md5_secondary.ctx) <= md5_secondary_digest_size, S2N_ERR_HASH_DIGEST_FAILED);
-
-        POSIX_GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp.ctx, ((uint8_t *) out) + MD5_DIGEST_LENGTH, &sha1_primary_digest_size), S2N_ERR_HASH_DIGEST_FAILED);
-        POSIX_GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp_md5_secondary.ctx, out, &md5_secondary_digest_size), S2N_ERR_HASH_DIGEST_FAILED);
-        break;
-    default:
-        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
-    }
+    POSIX_ENSURE(EVP_MD_CTX_size(state->digest.high_level.evp.ctx) <= sha1_digest_size,
+            S2N_ERR_HASH_DIGEST_FAILED);
+    POSIX_ENSURE(EVP_MD_CTX_size(state->digest.high_level.evp_md5_secondary.ctx) <= md5_secondary_digest_size,
+            S2N_ERR_HASH_DIGEST_FAILED);
+    POSIX_GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp.ctx,
+            ((uint8_t *) out) + MD5_DIGEST_LENGTH, &sha1_primary_digest_size), S2N_ERR_HASH_DIGEST_FAILED);
+    POSIX_GUARD_OSSL(EVP_DigestFinal_ex(state->digest.high_level.evp_md5_secondary.ctx,
+            out, &md5_secondary_digest_size), S2N_ERR_HASH_DIGEST_FAILED);
 
     state->currently_in_hash = 0;
     state->is_ready_for_input = 0;
@@ -385,42 +428,38 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
 
 static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
 {
-    bool is_md5_allowed_for_fips = false;
-    switch (from->alg) {
-    case S2N_HASH_NONE:
-        break;
-    case S2N_HASH_MD5:
-        POSIX_GUARD_RESULT(s2n_digest_is_md5_allowed_for_fips(&from->digest.high_level.evp, &is_md5_allowed_for_fips));
-        if (is_md5_allowed_for_fips) {
-            POSIX_GUARD(s2n_hash_allow_md5_for_fips(to));
-        }
-        FALL_THROUGH;
-    case S2N_HASH_SHA1:
-    case S2N_HASH_SHA224:
-    case S2N_HASH_SHA256:
-    case S2N_HASH_SHA384:
-    case S2N_HASH_SHA512:
-        POSIX_ENSURE_REF(to->digest.high_level.evp.ctx);
-        POSIX_GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp.ctx, from->digest.high_level.evp.ctx), S2N_ERR_HASH_COPY_FAILED);
-        break;
-    case S2N_HASH_MD5_SHA1:
-        POSIX_ENSURE_REF(to->digest.high_level.evp.ctx);
-        POSIX_ENSURE_REF(to->digest.high_level.evp_md5_secondary.ctx);
-        POSIX_GUARD_RESULT(s2n_digest_is_md5_allowed_for_fips(&from->digest.high_level.evp, &is_md5_allowed_for_fips));
-        if (is_md5_allowed_for_fips) {
-            POSIX_GUARD(s2n_hash_allow_md5_for_fips(to));
-        }
-        POSIX_GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp.ctx, from->digest.high_level.evp.ctx), S2N_ERR_HASH_COPY_FAILED);
-        POSIX_GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp_md5_secondary.ctx, from->digest.high_level.evp_md5_secondary.ctx), S2N_ERR_HASH_COPY_FAILED);
-        break;
-    default:
-        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
-    }
-
     to->hash_impl = from->hash_impl;
     to->alg = from->alg;
     to->is_ready_for_input = from->is_ready_for_input;
     to->currently_in_hash = from->currently_in_hash;
+
+    if (from->alg == S2N_HASH_NONE) {
+        return S2N_SUCCESS;
+    }
+
+    POSIX_ENSURE_REF(to->digest.high_level.evp.ctx);
+    POSIX_GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp.ctx, from->digest.high_level.evp.ctx),
+            S2N_ERR_HASH_COPY_FAILED);
+
+    bool is_md5_allowed_for_fips = false;
+    POSIX_GUARD_RESULT(s2n_digest_is_md5_allowed_for_fips(&from->digest.high_level.evp, &is_md5_allowed_for_fips));
+    if (is_md5_allowed_for_fips && (from->alg == S2N_HASH_MD5 || from->alg == S2N_HASH_MD5_SHA1)) {
+        POSIX_GUARD(s2n_hash_allow_md5_for_fips(to));
+    }
+
+    return S2N_SUCCESS;
+}
+
+static int s2n_evp_hash_with_custom_sha1_md5_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
+{
+    POSIX_GUARD(s2n_evp_hash_copy(to, from));
+    if (from->alg != S2N_HASH_MD5_SHA1) {
+        return S2N_SUCCESS;
+    }
+
+    POSIX_ENSURE_REF(to->digest.high_level.evp_md5_secondary.ctx);
+    POSIX_GUARD_OSSL(EVP_MD_CTX_copy_ex(to->digest.high_level.evp_md5_secondary.ctx,
+            from->digest.high_level.evp_md5_secondary.ctx), S2N_ERR_HASH_COPY_FAILED);
 
     return S2N_SUCCESS;
 }
@@ -435,26 +474,33 @@ static int s2n_evp_hash_reset(struct s2n_hash_state *state)
     }
 
     POSIX_GUARD_OSSL(S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp.ctx), S2N_ERR_HASH_WIPE_FAILED);
-
-    if (state->alg == S2N_HASH_MD5_SHA1) {
-        POSIX_GUARD_OSSL(S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp_md5_secondary.ctx), S2N_ERR_HASH_WIPE_FAILED);
-    }
-
     if (reset_md5_for_fips) {
         POSIX_GUARD(s2n_hash_allow_md5_for_fips(state));
     }
+    return s2n_hash_init(state, state->alg);
+}
 
-    /* hash_init resets the ready_for_input and currently_in_hash fields. */
-    return s2n_evp_hash_init(state, state->alg);
+static int s2n_evp_hash_with_custom_sha1_md5_reset(struct s2n_hash_state *state)
+{
+    if (state->alg == S2N_HASH_MD5_SHA1) {
+        POSIX_GUARD_OSSL(S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp_md5_secondary.ctx), S2N_ERR_HASH_WIPE_FAILED);
+    }
+    return s2n_evp_hash_reset(state);
 }
 
 static int s2n_evp_hash_free(struct s2n_hash_state *state)
 {
     S2N_EVP_MD_CTX_FREE(state->digest.high_level.evp.ctx);
-    S2N_EVP_MD_CTX_FREE(state->digest.high_level.evp_md5_secondary.ctx);
     state->digest.high_level.evp.ctx = NULL;
-    state->digest.high_level.evp_md5_secondary.ctx = NULL;
     state->is_ready_for_input = 0;
+    return S2N_SUCCESS;
+}
+
+static int s2n_evp_hash_with_custom_sha1_md5_free(struct s2n_hash_state *state)
+{
+    POSIX_GUARD(s2n_evp_hash_free(state));
+    S2N_EVP_MD_CTX_FREE(state->digest.high_level.evp_md5_secondary.ctx);
+    state->digest.high_level.evp_md5_secondary.ctx = NULL;
     return S2N_SUCCESS;
 }
 
@@ -469,7 +515,18 @@ static const struct s2n_hash s2n_low_level_hash = {
     .free = &s2n_low_level_hash_free,
 };
 
-static const struct s2n_hash s2n_evp_hash = {
+const struct s2n_hash s2n_evp_hash_with_custom_sha1_md5 = {
+    .alloc = &s2n_evp_hash_with_custom_sha1_md5_new,
+    .allow_md5_for_fips = &s2n_evp_hash_with_custom_sha1_md5_allow_md5_for_fips,
+    .init = &s2n_evp_hash_with_custom_sha1_md5_init,
+    .update = &s2n_evp_hash_with_custom_sha1_md5_update,
+    .digest = &s2n_evp_hash_with_custom_sha1_md5_digest,
+    .copy = &s2n_evp_hash_with_custom_sha1_md5_copy,
+    .reset = &s2n_evp_hash_with_custom_sha1_md5_reset,
+    .free = &s2n_evp_hash_with_custom_sha1_md5_free,
+};
+
+const struct s2n_hash s2n_evp_hash = {
     .alloc = &s2n_evp_hash_new,
     .allow_md5_for_fips = &s2n_evp_hash_allow_md5_for_fips,
     .init = &s2n_evp_hash_init,
@@ -482,8 +539,14 @@ static const struct s2n_hash s2n_evp_hash = {
 
 static int s2n_hash_set_impl(struct s2n_hash_state *state)
 {
-    state->hash_impl = s2n_is_in_fips_mode() ? &s2n_evp_hash : &s2n_low_level_hash;
-
+    state->hash_impl = &s2n_low_level_hash;
+    if (s2n_is_in_fips_mode()) {
+#if S2N_EVP_SUPPORTS_SHA1_MD5_HASH
+        state->hash_impl = &s2n_evp_hash;
+#else
+        state->hash_impl = &s2n_evp_hash_with_custom_sha1_md5;
+#endif
+    }
     return S2N_SUCCESS;
 }
 
@@ -609,7 +672,6 @@ int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t 
     *out = state->currently_in_hash;
     return S2N_SUCCESS;
 }
-
 
 /* Calculate, in constant time, the number of bytes currently in the hash_block */
 int s2n_hash_const_time_get_currently_in_hash_block(struct s2n_hash_state *state, uint64_t *out)

--- a/crypto/s2n_hash.h
+++ b/crypto/s2n_hash.h
@@ -87,6 +87,7 @@ struct s2n_hash {
     int (*free) (struct s2n_hash_state *state);
 };
 
+const EVP_MD* s2n_hash_alg_to_evp_md(s2n_hash_algorithm alg);
 extern int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out);
 extern int s2n_hash_block_size(s2n_hash_algorithm alg, uint64_t *block_size);
 extern bool s2n_hash_is_available(s2n_hash_algorithm alg);

--- a/crypto/s2n_rsa_signing.c
+++ b/crypto/s2n_rsa_signing.c
@@ -159,7 +159,7 @@ int s2n_rsa_pss_sign_digest(const struct s2n_pkey *priv, s2n_hash_algorithm hash
     POSIX_ENSURE_REF(digest_in);
     POSIX_ENSURE_REF(signature_out);
 
-    const EVP_MD* digest_alg = s2n_hash_alg_to_evp_alg(hash_alg);
+    const EVP_MD* digest_alg = s2n_hash_alg_to_evp_md(hash_alg);
     POSIX_ENSURE_REF(digest_alg);
 
     /* For more info see: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_sign.html */
@@ -207,7 +207,7 @@ int s2n_rsa_pss_verify(const struct s2n_pkey *pub, struct s2n_hash_state *digest
     uint8_t digest_data[S2N_MAX_DIGEST_LEN];
     POSIX_GUARD(s2n_hash_digest_size(digest->alg, &digest_length));
     POSIX_GUARD(s2n_hash_digest(digest, digest_data, digest_length));
-    const EVP_MD* digest_alg = s2n_hash_alg_to_evp_alg(digest->alg);
+    const EVP_MD* digest_alg = s2n_hash_alg_to_evp_md(digest->alg);
     POSIX_ENSURE_REF(digest_alg);
 
     /* For more info see: https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_verify.html */

--- a/tests/unit/s2n_hash_all_algs_test.c
+++ b/tests/unit/s2n_hash_all_algs_test.c
@@ -30,6 +30,7 @@ const uint8_t input_data[INPUT_DATA_SIZE] = "hello hash";
  * never change and match the results of the EVP implementation.
  */
 const char* expected_result_hex[S2N_HASH_SENTINEL] = {
+        [S2N_HASH_NONE]     = "",
         [S2N_HASH_MD5]      = "f5d589043253ca6ae54124c31be43701",
         [S2N_HASH_SHA1]     = "ccf8abd6b03ef5054a4f257e7c712e17f965272d",
         [S2N_HASH_SHA224]   = "dae80554ab74bf098b1a39e48c85c58e4af4628d2a357ee5cf6b1b85",
@@ -140,7 +141,7 @@ int main(int argc, char **argv)
     BEGIN_TEST();
 
     /* Calculate digests when not in FIPS mode. They must match. */
-    for (s2n_hash_algorithm hash_alg = 1; hash_alg < S2N_HASH_SENTINEL; hash_alg++) {
+    for (s2n_hash_algorithm hash_alg = 0; hash_alg < S2N_HASH_SENTINEL; hash_alg++) {
         struct s2n_blob actual_result = { 0 };
         uint8_t actual_result_data[OUTPUT_DATA_SIZE] = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&actual_result, actual_result_data, OUTPUT_DATA_SIZE));

--- a/tests/unit/s2n_hash_all_algs_test.c
+++ b/tests/unit/s2n_hash_all_algs_test.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "crypto/s2n_evp.h"
+#include "crypto/s2n_fips.h"
+#include "crypto/s2n_hash.h"
+
+#define INPUT_DATA_SIZE 100
+#define OUTPUT_DATA_SIZE 100
+
+const uint8_t input_data[INPUT_DATA_SIZE] = "hello hash";
+
+const char* expected_result_hex[S2N_HASH_SENTINEL] = {
+        [S2N_HASH_MD5]      = "f5d589043253ca6ae54124c31be43701",
+        [S2N_HASH_SHA1]     = "ccf8abd6b03ef5054a4f257e7c712e17f965272d",
+        [S2N_HASH_SHA224]   = "dae80554ab74bf098b1a39e48c85c58e4af4628d2a357ee5cf6b1b85",
+        [S2N_HASH_SHA256]   = "a8a7fb9d2d3ff62eee5bed1bfcc7b2e17ffebf00c3c77fdf43259d690022041f",
+        [S2N_HASH_SHA384]   = "d7131b24ea0985fc9f6462139969decff21f24967f6df17e31ce2410fda6534a5c"
+                              "f85cb4be737961eddce0c201c0dac0",
+        [S2N_HASH_SHA512]   = "b11305336d6071d8cbab6709fc1019f874961e13a04611f8e7d4c1f9164a2c923f"
+                              "7b3da0a37001cef5fdb71584a0f92020a45f23a6fc06cc3ab42ceaa0467a34",
+        [S2N_HASH_MD5_SHA1] = "f5d589043253ca6ae54124c31be43701ccf8abd6b03ef5054a4f257e7c712e17f965272d",
+};
+
+S2N_RESULT s2n_hash_test_state(struct s2n_hash_state *hash_state, s2n_hash_algorithm hash_alg, struct s2n_blob *digest)
+{
+    /* Test s2n_hash_update */
+    {
+        /* Break the test data into some arbitrarily sized chunks. */
+        size_t chunk_sizes[] = { 1, 0, 10, 17, 31 };
+
+        size_t offset = 0;
+        for (size_t i = 0; i < s2n_array_len(chunk_sizes); i++) {
+            RESULT_GUARD_POSIX(s2n_hash_update(hash_state, input_data + offset, chunk_sizes[i]));
+            offset += chunk_sizes[i];
+            RESULT_ENSURE_EQ(hash_state->currently_in_hash, offset);
+        }
+
+        /* Add the rest */
+        RESULT_GUARD_POSIX(s2n_hash_update(hash_state, input_data + offset, (INPUT_DATA_SIZE - offset)));
+        RESULT_ENSURE_EQ(hash_state->currently_in_hash, INPUT_DATA_SIZE);
+    }
+
+    /* Test s2n_hash_copy */
+    struct s2n_hash_state hash_copy = { 0 };
+    {
+        struct s2n_blob result = { 0 };
+        uint8_t result_data[OUTPUT_DATA_SIZE] = { 0 };
+        RESULT_GUARD_POSIX(s2n_blob_init(&result, result_data, OUTPUT_DATA_SIZE));
+
+        RESULT_GUARD_POSIX(s2n_hash_new(&hash_copy));
+        RESULT_GUARD_POSIX(s2n_hash_copy(&hash_copy, hash_state));
+        RESULT_ENSURE_EQ(hash_copy.currently_in_hash, hash_state->currently_in_hash);
+        RESULT_ENSURE_EQ(hash_copy.is_ready_for_input, hash_state->is_ready_for_input);
+    }
+
+    /* Test s2n_hash_digest */
+    {
+        uint8_t digest_size = 0;
+        RESULT_GUARD_POSIX(s2n_hash_digest_size(hash_alg, &digest_size));
+        digest->size = digest_size;
+
+        RESULT_GUARD_POSIX(s2n_hash_digest(hash_state, digest->data, digest_size));
+        RESULT_ENSURE_EQ(hash_state->currently_in_hash, 0);
+        RESULT_ENSURE_EQ(hash_state->is_ready_for_input, false);
+
+        uint8_t copy_result[OUTPUT_DATA_SIZE] = { 0 };
+        RESULT_GUARD_POSIX(s2n_hash_digest(&hash_copy, copy_result, digest_size));
+        RESULT_ENSURE_EQ(hash_state->currently_in_hash, 0);
+        RESULT_ENSURE_EQ(hash_state->is_ready_for_input, false);
+        RESULT_ENSURE_EQ(memcmp(digest->data, copy_result, digest_size), 0);
+    }
+
+    RESULT_GUARD_POSIX(s2n_hash_free(&hash_copy));
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_hash_test(s2n_hash_algorithm hash_alg, struct s2n_blob *digest)
+{
+    struct s2n_hash_state hash_state = { 0 };
+
+    /* Test s2n_hash_new + s2n_hash_init */
+    {
+        RESULT_GUARD_POSIX(s2n_hash_new(&hash_state));
+        RESULT_ENSURE_EQ(hash_state.currently_in_hash, 0);
+        RESULT_ENSURE_EQ(hash_state.is_ready_for_input, false);
+
+        /* Allow MD5 when necessary */
+        if (s2n_is_in_fips_mode() && (hash_alg == S2N_HASH_MD5 || hash_alg == S2N_HASH_MD5_SHA1)) {
+            RESULT_GUARD_POSIX(s2n_hash_allow_md5_for_fips(&hash_state));
+        }
+
+        RESULT_GUARD_POSIX(s2n_hash_init(&hash_state, hash_alg));
+        RESULT_ENSURE_EQ(hash_state.currently_in_hash, 0);
+        RESULT_ENSURE_EQ(hash_state.is_ready_for_input, true);
+
+        RESULT_GUARD(s2n_hash_test_state(&hash_state, hash_alg, digest));
+    }
+
+    /* Test s2n_hash_reset */
+    {
+        struct s2n_blob result = { 0 };
+        uint8_t result_data[OUTPUT_DATA_SIZE] = { 0 };
+        RESULT_GUARD_POSIX(s2n_blob_init(&result, result_data, OUTPUT_DATA_SIZE));
+
+        RESULT_GUARD_POSIX(s2n_hash_reset(&hash_state));
+        RESULT_ENSURE_EQ(hash_state.currently_in_hash, 0);
+        RESULT_ENSURE_EQ(hash_state.is_ready_for_input, true);
+
+        RESULT_GUARD(s2n_hash_test_state(&hash_state, hash_alg, &result));
+        RESULT_ENSURE_EQ(digest->size, result.size);
+        RESULT_ENSURE_EQ(memcmp(digest->data, result.data, result.size), 0);
+    }
+
+    RESULT_GUARD_POSIX(s2n_hash_free(&hash_state));
+    return S2N_RESULT_OK;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Calculate digests when not in FIPS mode. They must match. */
+    for (s2n_hash_algorithm hash_alg = 1; hash_alg < S2N_HASH_SENTINEL; hash_alg++) {
+        struct s2n_blob actual_result = { 0 };
+        uint8_t actual_result_data[OUTPUT_DATA_SIZE] = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&actual_result, actual_result_data, OUTPUT_DATA_SIZE));
+
+        struct s2n_blob expected_result = { 0 };
+        uint8_t expected_result_data[OUTPUT_DATA_SIZE] = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&expected_result, expected_result_data, OUTPUT_DATA_SIZE));
+        EXPECT_SUCCESS(s2n_hex_string_to_bytes((const uint8_t*) expected_result_hex[hash_alg], &expected_result));
+
+        EXPECT_OK(s2n_hash_test(hash_alg, &actual_result));
+        EXPECT_EQUAL(expected_result.size, actual_result.size);
+        EXPECT_BYTEARRAY_EQUAL(expected_result.data, actual_result.data, actual_result.size);
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_hash_all_algs_test.c
+++ b/tests/unit/s2n_hash_all_algs_test.c
@@ -25,6 +25,10 @@
 
 const uint8_t input_data[INPUT_DATA_SIZE] = "hello hash";
 
+/* These values were generated using the low level s2n_hash implementation.
+ * They are useful to validate that the results of the low level implementation
+ * never change and match the results of the EVP implementation.
+ */
 const char* expected_result_hex[S2N_HASH_SENTINEL] = {
         [S2N_HASH_MD5]      = "f5d589043253ca6ae54124c31be43701",
         [S2N_HASH_SHA1]     = "ccf8abd6b03ef5054a4f257e7c712e17f965272d",


### PR DESCRIPTION
### Description of changes: 

Currently, we only use the EVP hash implementation with FIPS. Our original FIPS libcrypto, Openssl-1.0.2, doesn't support EVP_md5_sha1(), so we calculated md5+sha1 by separately tracking a md5 hash and a sha1 hash and then combining the results.

As part of the work to make s2n-tls use AwsLC+FIPS in compliance with the latest FIPS standards, we will need to avoid passing raw bytes to our signing methods. To avoid handling raw bytes, we need to be able to actually use the EVP implementation of md5+sha1, rather than our custom concatenation. This change modifies the EVP implementation to do so.

### Call-outs:

* The primary difference here is how we handle md5+sha1. I tried to reuse as much of the code between the two EVP versions as possible, only special casing md5+sha1.
* I initially tried adding a new implementation of s2n_hash, but that turned out messier than I expected. I believe this version is cleaner, but you can see the original in my first commit: https://github.com/aws/s2n-tls/commit/180f852a1c7592f6bc764a3945a8b235461c4c77

### Testing:

This is a refactor change. A bug could affect any customer using FIPS, although it'd be most likely to break legacy 1.0 or 1.1 connections that rely on the MD5+SHA1 hash.

We had some existing hash tests in [s2n_hash_test.c](https://github.com/aws/s2n-tls/blob/main/tests/unit/s2n_hash_test.c), but they didn't cover all hashes so I added a test that iterates over all hashes for testing. That test uses values I got from the low-level hash implementation, which I didn't touch in this refactor.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
