### PR TITLE
Feature probe for EVP_md5_sha1()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,6 +409,19 @@ else()
     endif()
 endif()
 
+# Determine if EVP_md5_sha1 is available in libcrypto
+try_compile(
+        LIBCRYPTO_SUPPORTS_EVP_MD5_SHA1_HASH
+        ${CMAKE_BINARY_DIR}
+        SOURCES "${CMAKE_CURRENT_LIST_DIR}/tests/features/evp_md5_sha1.c"
+        LINK_LIBRARIES crypto ${OS_LIBS}
+        CMAKE_FLAGS
+            "-DINCLUDE_DIRECTORIES=$<TARGET_PROPERTY:crypto,INTERFACE_INCLUDE_DIRECTORIES>"
+)
+if (LIBCRYPTO_SUPPORTS_EVP_MD5_SHA1_HASH)
+    target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_LIBCRYPTO_SUPPORTS_EVP_MD5_SHA1_HASH)
+endif()
+
 if (S2N_INTERN_LIBCRYPTO)
     if (NOT LibCrypto_STATIC_LIBRARY)
         message(FATAL_ERROR "libcrypto interning requires a static build of libcrypto.a to be available")

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -22,18 +22,12 @@
 
 #include "utils/s2n_safety.h"
 
-#if S2N_OPENSSL_VERSION_AT_LEAST(1,1,1) || defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
-#define S2N_EVP_SUPPORTS_SHA1_MD5_HASH true
-#else
-#define S2N_EVP_SUPPORTS_SHA1_MD5_HASH false
-#endif
-
 static bool s2n_use_custom_md5_sha1()
 {
-#if S2N_EVP_SUPPORTS_SHA1_MD5_HASH
-        return false;
+#if defined(S2N_LIBCRYPTO_SUPPORTS_EVP_MD5_SHA1_HASH)
+    return false;
 #else
-        return true;
+    return true;
 #endif
 }
 
@@ -52,7 +46,7 @@ const EVP_MD* s2n_hash_alg_to_evp_md(s2n_hash_algorithm alg)
             return EVP_sha384();
         case S2N_HASH_SHA512:
             return EVP_sha512();
-#if S2N_EVP_SUPPORTS_SHA1_MD5_HASH
+#if defined(S2N_LIBCRYPTO_SUPPORTS_EVP_MD5_SHA1_HASH)
         case S2N_HASH_MD5_SHA1:
             return EVP_md5_sha1();
 #endif

--- a/s2n.mk
+++ b/s2n.mk
@@ -167,7 +167,7 @@ ifndef COV_TOOL
 	endif
 endif
 
-try_compile = $(shell cat $(1) | $(CC) -Werror -o tmp.o -xc - > /dev/null 2>&1; echo $$?; rm tmp.o > /dev/null 2>&1)
+try_compile = $(shell $(CC) $(CFLAGS) -c -o tmp.o $(1) > /dev/null 2>&1; echo $$?; rm tmp.o > /dev/null 2>&1)
 
 # Determine if execinfo.h is available
 TRY_COMPILE_EXECINFO := $(call try_compile,$(S2N_ROOT)/tests/features/execinfo.c)
@@ -191,6 +191,12 @@ endif
 TRY_COMPILE__RESTRICT__ := $(call try_compile,$(S2N_ROOT)/tests/features/__restrict__.c)
 ifeq ($(TRY_COMPILE__RESTRICT__), 0)
 	DEFAULT_CFLAGS += -DS2N___RESTRICT__SUPPORTED
+endif
+
+# Determine if EVP_md5_sha1 is available
+TRY_EVP_MD5_SHA1_HASH := $(call try_compile,$(S2N_ROOT)/tests/features/evp_md5_sha1.c)
+ifeq ($(TRY_EVP_MD5_SHA1_HASH), 0)
+	DEFAULT_CFLAGS += -DS2N_LIBCRYPTO_SUPPORTS_EVP_MD5_SHA1_HASH
 endif
 
 CFLAGS_LLVM = ${DEFAULT_CFLAGS} -emit-llvm -c -g -O1

--- a/tests/features/evp_md5_sha1.c
+++ b/tests/features/evp_md5_sha1.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <openssl/evp.h>
+int main() {
+    EVP_md5_sha1();
+    return 0;
+}

--- a/tests/saw/Makefile
+++ b/tests/saw/Makefile
@@ -25,7 +25,6 @@ LOGS=$(patsubst %.saw,tmp/%.log,$(SCRIPTS))
 SHELL:=/bin/bash
 YICES_VERSION=$(shell yices-smt2 --version)
 export LIBCRYPTO_ROOT:=$(shell pwd)/../../libcrypto-root
-export S2N_ROOT=$(shell pwd)/s2n
 
 .PHONY : all
 all:

--- a/tests/unit/s2n_hash_test.c
+++ b/tests/unit/s2n_hash_test.c
@@ -39,6 +39,14 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
+#if defined(OPENSSL_IS_AWSLC)
+    /* Sanity check that we're setting S2N_LIBCRYPTO_SUPPORTS_EVP_MD5_SHA1_HASH properly.
+     * AWS-LC is known to support EVP_md5_sha1(). If this fails, something is wrong with our
+     * S2N_LIBCRYPTO_SUPPORTS_EVP_MD5_SHA1_HASH feature testing.
+     */
+    EXPECT_NOT_NULL(s2n_hash_alg_to_evp_md(S2N_HASH_MD5_SHA1));
+#endif
+
     POSIX_GUARD(s2n_hash_new(&hash));
     EXPECT_FALSE(s2n_hash_is_ready_for_input(&hash));
     EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));


### PR DESCRIPTION
### Resolved issues:
https://github.com/aws/s2n-tls/pull/3126#discussion_r751824884

### Description of changes: 
Instead of checking libcrypto versions to determine if EVP_md5_sha1() is supported, we can attempt to compile a small example using it. We already do this for other features, but none based on libcrypto.

cmake:
The built-in try_compile in cmake both builds and links, so I had to add the "-I" argument and the link libraries. I also needed to put this feature probe later in the file than the others, so that the crypto target would be configured.

make:
Our custom try_compile in make only builds the *.o file. Previously it didn't match our [actual build targets](https://www.gnu.org/software/make/manual/html_node/Catalogue-of-Rules.html#Catalogue-of-Rules). Minimally I needed the "-I" argument from our CLAGS, but I decided to just add all of our CFLAGS for completeness.

### Testing:

I added a sanity check to make sure at least awslc sets the feature flag to true. We don't need a corresponding negative test: if the flag is incorrectly set to true when the feature isn't actually supported, the build will just fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
