### PR TITLE
Fix build on NetBSD.

### DIFF
--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -14,6 +14,7 @@
  */
 
 #include <sys/param.h>
+#include <sys/socket.h>
 #include <netdb.h>
 
 #include <unistd.h>

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <netdb.h>

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -14,7 +14,7 @@
  */
 
 #define  _DEFAULT_SOURCE 1
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__NetBSD__)
 #include <features.h>
 #endif
 


### PR DESCRIPTION
Signed-off-by: Thomas Klausner <tk@giga.or.at>

This fixes the build of s2n-tls on NetBSD-9.99.92/amd64.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
