### PR TITLE
Nitpick usage guide links

### DIFF
--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -402,7 +402,7 @@ int s2n_print_stacktrace(FILE *fptr)
     if (!s_s2n_stack_traces_enabled) {
       fprintf(fptr, "%s\n%s\n",
 	      "NOTE: Some details are omitted, run with S2N_PRINT_STACKTRACE=1 for a verbose backtrace.",
-	      "See https://github.com/awslabs/s2n/blob/main/docs/USAGE-GUIDE.md");
+	      "See https://github.com/aws/s2n-tls/blob/main/docs/USAGE-GUIDE.md");
         return S2N_SUCCESS;
     }
 

--- a/libcrypto-build/README.md
+++ b/libcrypto-build/README.md
@@ -1,4 +1,4 @@
 This directory is used to store build artifacts (tarballs and source) for a locally
 built copy of libcrypto, either from OpenSSL, LibreSSL or BoringSSL.
 
-See the s2n [Usage Guide](https://github.com/awslabs/s2n/blob/main/docs/USAGE-GUIDE.md) for more details.
+See the s2n [Usage Guide](https://github.com/aws/s2n-tls/blob/main/docs/USAGE-GUIDE.md) for more details.

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -56,7 +56,7 @@ struct s2n_config {
     unsigned disable_x509_validation:1;
     unsigned max_verify_cert_chain_depth_set:1;
     /* Whether to add dss cert type during a server certificate request.
-     * See https://github.com/awslabs/s2n/blob/main/docs/USAGE-GUIDE.md */
+     * See https://github.com/aws/s2n-tls/blob/main/docs/USAGE-GUIDE.md */
     unsigned cert_req_dss_legacy_compat_enabled:1;
     /* Whether any RSA certificates have been configured server-side to send to clients. This is needed so that the
      * server knows whether or not to self-downgrade to TLS 1.2 if the server is compiled with Openssl 1.0.2 and does


### PR DESCRIPTION
### Description of changes: 

Reference `aws/s2n-tls` instead of `awslabs/s2n` even though they map to the same.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
