### PR TITLE
Adds Options to Output and Input Session Ticket to s2nc

### DIFF
--- a/bin/common.c
+++ b/bin/common.c
@@ -66,12 +66,12 @@ int write_array_to_file(const char *path, uint8_t *data, size_t length) {
        return S2N_FAILURE;
     }
 
-    if(fwrite(data, sizeof(char), length, file) < 0) {
+    if(fwrite(data, sizeof(char), length, file) != length) {
         fclose(file);
         return S2N_FAILURE;
     }
-
     fclose(file);
+
     return S2N_SUCCESS;
 }
 
@@ -90,13 +90,14 @@ int get_file_size(const char* path, size_t *length)
         return S2N_FAILURE;
     }
 
-    size_t file_length = ftell(file);
+    long file_length = ftell(file);
     if (file_length < 0) {
         fclose(file);
         return S2N_FAILURE;
     }
 
     *length = file_length;
+    fclose(file);
     return S2N_SUCCESS;
 }
 

--- a/bin/common.c
+++ b/bin/common.c
@@ -57,6 +57,73 @@ static uint8_t unsafe_verify_host_fn(const char *host_name, size_t host_name_len
     return 1;
 }
 
+int write_array_to_file(const char *path, uint8_t *data, size_t length) {
+    GUARD_EXIT_NULL(path);
+    GUARD_EXIT_NULL(data);
+
+    FILE *file = fopen(path, "wb");
+    if (!file) {
+       return S2N_FAILURE;
+    }
+
+    if(fwrite(data, sizeof(char), length, file) < 0) {
+        fclose(file);
+        return S2N_FAILURE;
+    }
+
+    fclose(file);
+    return S2N_SUCCESS;
+}
+
+int get_file_size(const char* path, size_t *length)
+{
+    GUARD_EXIT_NULL(path);
+    GUARD_EXIT_NULL(length);
+
+    FILE *file = fopen(path, "rb");
+    if (!file) {
+       return S2N_FAILURE;
+    }
+
+    if(fseek(file, 0, SEEK_END) < 0) {
+        fclose(file);
+        return S2N_FAILURE;
+    }
+
+    size_t file_length = ftell(file);
+    if (file_length < 0) {
+        fclose(file);
+        return S2N_FAILURE;
+    }
+
+    *length = file_length;
+    return S2N_SUCCESS;
+}
+
+int load_file_to_array(const char *path, uint8_t *data, size_t max_length)
+{
+    GUARD_EXIT_NULL(path);
+    GUARD_EXIT_NULL(data);
+
+    size_t file_size = 0;
+    if (get_file_size(path, &file_size) < 0 || file_size > max_length) {
+        return S2N_FAILURE;
+    }
+
+    FILE *file = fopen(path, "rb");
+    if (!file) {
+       return S2N_FAILURE;
+    }
+
+    if (fread(data, sizeof(char), file_size, file) < file_size) {
+        fclose(file);
+        return S2N_FAILURE;
+    }
+
+    fclose(file);
+    return S2N_SUCCESS;
+}
+
 char *load_file_to_cstring(const char *path)
 {
     FILE *pem_file = fopen(path, "rb");

--- a/bin/common.c
+++ b/bin/common.c
@@ -85,7 +85,7 @@ int get_file_size(const char* path, size_t *length)
        return S2N_FAILURE;
     }
 
-    if(fseek(file, 0, SEEK_END) < 0) {
+    if(fseek(file, 0, SEEK_END) != 0) {
         fclose(file);
         return S2N_FAILURE;
     }

--- a/bin/common.h
+++ b/bin/common.h
@@ -91,8 +91,34 @@ int cache_store_callback(struct s2n_connection *conn, void *ctx, uint64_t ttl, c
 int cache_retrieve_callback(struct s2n_connection *conn, void *ctx, const void *key, uint64_t key_size, void *value, uint64_t * value_size);
 int cache_delete_callback(struct s2n_connection *conn, void *ctx, const void *key, uint64_t key_size);
 
+/**
+ * Writes array data to the the file specified
+ *
+ * @param path Path to the file where this data will be written
+ * @param data The data to be outputted
+ * @param length Length of the `data` array
+ */
 int write_array_to_file(const char *path, uint8_t *data, size_t length);
+
+/**
+ * Gets size of file
+ *
+ * @param path Path to the file
+ * @param length A pointer which will be set to the size of the file
+ */
 int get_file_size(const char* path, size_t *length);
+
+/**
+ * Reads in data from file into a C array
+ *
+ *  * # Safety
+ *
+ * `data` must have at least `max_length` of memory available
+ *
+ * @param path Path to the file
+ * @param data A pointer which will be set to the data in the file
+ * @param max_length The maximum amount of data that can be written to the `data` pointer
+ */
 int load_file_to_array(const char *path, uint8_t *data, size_t max_length);
 char *load_file_to_cstring(const char *path);
 int s2n_str_hex_to_bytes(const unsigned char *hex, uint8_t *out_bytes, uint32_t max_out_bytes_len);

--- a/bin/common.h
+++ b/bin/common.h
@@ -91,6 +91,9 @@ int cache_store_callback(struct s2n_connection *conn, void *ctx, uint64_t ttl, c
 int cache_retrieve_callback(struct s2n_connection *conn, void *ctx, const void *key, uint64_t key_size, void *value, uint64_t * value_size);
 int cache_delete_callback(struct s2n_connection *conn, void *ctx, const void *key, uint64_t key_size);
 
+int write_array_to_file(const char *path, uint8_t *data, size_t length);
+int get_file_size(const char* path, size_t *length);
+int load_file_to_array(const char *path, uint8_t *data, size_t max_length);
 char *load_file_to_cstring(const char *path);
 int s2n_str_hex_to_bytes(const unsigned char *hex, uint8_t *out_bytes, uint32_t max_out_bytes_len);
 int s2n_setup_external_psk_list(struct s2n_connection *conn, char *psk_optarg_list[S2N_MAX_PSK_LIST_LENGTH], size_t psk_list_len);


### PR DESCRIPTION
### Resolved issues:

related to #3125

### Description of changes: 

This adds the ability for s2nc to store and input session tickets. Currently the only way of testing the resumption logic is through --reconnect, which automatically resumes a set number of times. This option will give us the ability to resume with different servers, it's basically just a lot more flexible.
### Call-outs:

I wrote a couple helper functions to aid in writing/reading to a file. It seems like we don't have a strong error handling story for s2nc/d when the function that is being error handled is NOT an s2n function, so lmk if my functions look weird. 
### Testing:
This set of commands produces a resumption handshake:
`openssl s_server -accept 8888 -cert tests/pems/rsa_2048_sha256_wildcard_cert.pem --key tests/pems/rsa_2048_sha256_wildcard_key.pem -tls1_2 localhost`
`bin/s2nc  --ciphers default --insecure --ticket-out session_ticket -f tests/pems/rsa_2048_sha256_wildcard_cert.pem 127.0.0.1 8888`
`bin/s2nc  --ciphers default --insecure --ticket-in session_ticket -f tests/pems/rsa_2048_sha256_wildcard_cert.pem 127.0.0.1 8888`

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
