### PR TITLE
ci: Set CC with GCC_VERSION

### DIFF
--- a/codebuild/bin/s2n_setup_env.sh
+++ b/codebuild/bin/s2n_setup_env.sh
@@ -152,6 +152,16 @@ $LATEST_CLANG_INSTALL_DIR/bin
 `pwd`/codebuild/bin
 ~/.local/bin"
 
+# Translate GCC_VERSION into something understood by other build tools.
+if [[ -n "$GCC_VERSION" ]] && [[ "$GCC_VERSION" != "NONE" ]]; then
+    if [[ -x "$(which gcc-$GCC_VERSION)" ]]; then
+            export CC="$(which gcc-$GCC_VERSION)"
+           echo "Set CC to $CC"
+    else
+            echo -e "WARNING: gcc executable not found, using system defaults"
+    fi
+fi
+
 testdeps_path(){
     echo -ne "checking $1 is in the path..."
     if [[ ! "$PATH" =~ "$1" ]]; then
@@ -182,4 +192,4 @@ echo "LATEST_CLANG=$LATEST_CLANG"
 echo "TESTS=$TESTS"
 echo "PATH=$PATH"
 echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
-
+echo "CC=$CC"


### PR DESCRIPTION
### Resolved issues:

none

### Description of changes: 

Setting GCC_VERSION or aliasing gcc is not enough for CMake.

### Call-outs:

Throw a warning when we were unable to find the GCC_VERSION set.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? locally

 Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
