### PR TITLE
Adds memory safety proofs for `s2n_handshake_type` functions

### DIFF
--- a/tests/cbmc/proofs/s2n_handshake_type_check_flag/Makefile
+++ b/tests/cbmc/proofs/s2n_handshake_type_check_flag/Makefile
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the default set of CBMC flags.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_handshake_type_check_flag
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_connection.c
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_handshake_type.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_handshake_type_check_flag/cbmc-proof.txt
+++ b/tests/cbmc/proofs/s2n_handshake_type_check_flag/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/tests/cbmc/proofs/s2n_handshake_type_check_flag/s2n_handshake_type_check_flag_harness.c
+++ b/tests/cbmc/proofs/s2n_handshake_type_check_flag/s2n_handshake_type_check_flag_harness.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <tls/s2n_connection.h>
+
+void s2n_handshake_type_check_flag_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_connection *s2n_connection = malloc(sizeof(*s2n_connection));
+    s2n_handshake_type_flag flag;
+
+    /* Operation under verification. */
+    bool ret = s2n_handshake_type_check_flag(s2n_connection, flag);
+
+    /* Post-conditions. */
+    assert(ret == (s2n_connection && (s2n_connection->handshake.handshake_type & flag)));
+}

--- a/tests/cbmc/proofs/s2n_handshake_type_check_tls12_flag/Makefile
+++ b/tests/cbmc/proofs/s2n_handshake_type_check_tls12_flag/Makefile
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the default set of CBMC flags.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_handshake_type_check_tls12_flag
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_connection.c
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_handshake_type.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_handshake_type_check_tls12_flag/cbmc-proof.txt
+++ b/tests/cbmc/proofs/s2n_handshake_type_check_tls12_flag/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/tests/cbmc/proofs/s2n_handshake_type_check_tls12_flag/s2n_handshake_type_check_tls12_flag_harness.c
+++ b/tests/cbmc/proofs/s2n_handshake_type_check_tls12_flag/s2n_handshake_type_check_tls12_flag_harness.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <tls/s2n_connection.h>
+
+void s2n_handshake_type_check_tls12_flag_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_connection *s2n_connection = malloc(sizeof(*s2n_connection));
+    s2n_handshake_type_flag flag;
+
+    /* Operation under verification. */
+    bool ret = s2n_handshake_type_check_tls12_flag(s2n_connection, flag);
+
+    /* Post-conditions. */
+    assert(ret == (s2n_connection && s2n_connection_get_protocol_version(s2n_connection) < S2N_TLS13 && (s2n_connection->handshake.handshake_type & flag)));
+}

--- a/tests/cbmc/proofs/s2n_handshake_type_check_tls13_flag/Makefile
+++ b/tests/cbmc/proofs/s2n_handshake_type_check_tls13_flag/Makefile
@@ -1,0 +1,29 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the default set of CBMC flags.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_handshake_type_check_tls13_flag
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_connection.c
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_handshake_type.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_handshake_type_check_tls13_flag/cbmc-proof.txt
+++ b/tests/cbmc/proofs/s2n_handshake_type_check_tls13_flag/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/tests/cbmc/proofs/s2n_handshake_type_check_tls13_flag/s2n_handshake_type_check_tls13_flag_harness.c
+++ b/tests/cbmc/proofs/s2n_handshake_type_check_tls13_flag/s2n_handshake_type_check_tls13_flag_harness.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <tls/s2n_connection.h>
+
+void s2n_handshake_type_check_tls13_flag_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_connection *s2n_connection = malloc(sizeof(*s2n_connection));
+    s2n_handshake_type_flag flag;
+
+    /* Operation under verification. */
+    bool ret = s2n_handshake_type_check_tls13_flag(s2n_connection, flag);
+
+    /* Post-conditions. */
+    assert(ret == (s2n_connection && s2n_connection_get_protocol_version(s2n_connection) >= S2N_TLS13 && (s2n_connection->handshake.handshake_type & flag)));
+}

--- a/tests/cbmc/proofs/s2n_handshake_type_reset/Makefile
+++ b/tests/cbmc/proofs/s2n_handshake_type_reset/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the default set of CBMC flags.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_handshake_type_reset
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_connection.c
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_handshake_type.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_handshake_type_reset/cbmc-proof.txt
+++ b/tests/cbmc/proofs/s2n_handshake_type_reset/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/tests/cbmc/proofs/s2n_handshake_type_reset/s2n_handshake_type_reset_harness.c
+++ b/tests/cbmc/proofs/s2n_handshake_type_reset/s2n_handshake_type_reset_harness.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <tls/s2n_connection.h>
+
+void s2n_handshake_type_reset_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_connection *s2n_connection = malloc(sizeof(*s2n_connection));
+    s2n_handshake_type_flag flag;
+
+    /* Operation under verification. */
+    s2n_handshake_type_reset(s2n_connection);
+
+    /* Post-conditions. */
+    assert(S2N_IMPLIES(s2n_connection != NULL, s2n_connection->handshake.handshake_type == INITIAL));
+}

--- a/tests/cbmc/proofs/s2n_handshake_type_set_flag/Makefile
+++ b/tests/cbmc/proofs/s2n_handshake_type_set_flag/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the default set of CBMC flags.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_handshake_type_set_flag
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_connection.c
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_handshake_type.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_handshake_type_set_flag/cbmc-proof.txt
+++ b/tests/cbmc/proofs/s2n_handshake_type_set_flag/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/tests/cbmc/proofs/s2n_handshake_type_set_flag/s2n_handshake_type_set_flag_harness.c
+++ b/tests/cbmc/proofs/s2n_handshake_type_set_flag/s2n_handshake_type_set_flag_harness.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <tls/s2n_connection.h>
+
+void s2n_handshake_type_set_flag_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_connection *s2n_connection = malloc(sizeof(*s2n_connection));
+    s2n_handshake_type_flag flag;
+
+    /* Compute expected result. */
+    s2n_handshake_type_flag expected_result;
+    if (s2n_connection) expected_result = s2n_connection->handshake.handshake_type | flag;
+
+    /* Operation under verification. */
+    s2n_handshake_type_set_flag(s2n_connection, flag);
+
+    /* Post-conditions. */
+    assert(S2N_IMPLIES(s2n_connection != NULL, s2n_connection->handshake.handshake_type == expected_result));
+}

--- a/tests/cbmc/proofs/s2n_handshake_type_set_tls12_flag/Makefile
+++ b/tests/cbmc/proofs/s2n_handshake_type_set_tls12_flag/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the default set of CBMC flags.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_handshake_type_set_tls12_flag
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_connection.c
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_handshake_type.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_handshake_type_set_tls12_flag/cbmc-proof.txt
+++ b/tests/cbmc/proofs/s2n_handshake_type_set_tls12_flag/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/tests/cbmc/proofs/s2n_handshake_type_set_tls12_flag/s2n_handshake_type_set_tls12_flag_harness.c
+++ b/tests/cbmc/proofs/s2n_handshake_type_set_tls12_flag/s2n_handshake_type_set_tls12_flag_harness.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <tls/s2n_connection.h>
+
+void s2n_handshake_type_set_tls12_flag_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_connection *s2n_connection = malloc(sizeof(*s2n_connection));
+    s2n_handshake_type_flag flag;
+
+    /* Compute expected result. */
+    s2n_handshake_type_flag expected_result;
+    if (s2n_connection) expected_result = s2n_connection->handshake.handshake_type | flag;
+
+    /* Operation under verification. */
+    S2N_RESULT ret = s2n_handshake_type_set_tls12_flag(s2n_connection, flag);
+
+    /* Post-conditions. */
+    assert(S2N_IMPLIES(ret == S2N_RESULT_OK, s2n_connection->handshake.handshake_type == expected_result));
+}

--- a/tests/cbmc/proofs/s2n_handshake_type_set_tls13_flag/Makefile
+++ b/tests/cbmc/proofs/s2n_handshake_type_set_tls13_flag/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the default set of CBMC flags.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_handshake_type_set_tls13_flag
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_connection.c
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_handshake_type.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_handshake_type_set_tls13_flag/cbmc-proof.txt
+++ b/tests/cbmc/proofs/s2n_handshake_type_set_tls13_flag/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/tests/cbmc/proofs/s2n_handshake_type_set_tls13_flag/s2n_handshake_type_set_tls13_flag_harness.c
+++ b/tests/cbmc/proofs/s2n_handshake_type_set_tls13_flag/s2n_handshake_type_set_tls13_flag_harness.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <tls/s2n_connection.h>
+
+void s2n_handshake_type_set_tls13_flag_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_connection *s2n_connection = malloc(sizeof(*s2n_connection));
+    s2n_handshake_type_flag flag;
+
+    /* Compute expected result. */
+    s2n_handshake_type_flag expected_result;
+    if (s2n_connection) expected_result = s2n_connection->handshake.handshake_type | flag;
+
+    /* Operation under verification. */
+    S2N_RESULT ret = s2n_handshake_type_set_tls13_flag(s2n_connection, flag);
+
+    /* Post-conditions. */
+    assert(S2N_IMPLIES(ret == S2N_RESULT_OK, s2n_connection->handshake.handshake_type == expected_result));
+}

--- a/tests/cbmc/proofs/s2n_handshake_type_unset_tls12_flag/Makefile
+++ b/tests/cbmc/proofs/s2n_handshake_type_unset_tls12_flag/Makefile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the default set of CBMC flags.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_handshake_type_unset_tls12_flag
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_connection.c
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_handshake_type.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+UNWINDSET +=
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_handshake_type_unset_tls12_flag/cbmc-proof.txt
+++ b/tests/cbmc/proofs/s2n_handshake_type_unset_tls12_flag/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/tests/cbmc/proofs/s2n_handshake_type_unset_tls12_flag/s2n_handshake_type_unset_tls12_flag_harness.c
+++ b/tests/cbmc/proofs/s2n_handshake_type_unset_tls12_flag/s2n_handshake_type_unset_tls12_flag_harness.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <tls/s2n_connection.h>
+
+void s2n_handshake_type_unset_tls12_flag_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_connection *s2n_connection = malloc(sizeof(*s2n_connection));
+    s2n_handshake_type_flag flag;
+
+    /* Compute expected result. */
+    s2n_handshake_type_flag expected_result;
+    if (s2n_connection) expected_result = s2n_connection->handshake.handshake_type & ~(flag);
+
+    /* Operation under verification. */
+    S2N_RESULT ret = s2n_handshake_type_unset_tls12_flag(s2n_connection, flag);
+
+    /* Post-conditions. */
+    assert(S2N_IMPLIES(ret == S2N_RESULT_OK, s2n_connection->handshake.handshake_type == expected_result));
+}

--- a/tests/cbmc/proofs/s2n_handshake_type_unset_tls12_flag/s2n_handshake_type_unset_tls12_flag_harness.c
+++ b/tests/cbmc/proofs/s2n_handshake_type_unset_tls12_flag/s2n_handshake_type_unset_tls12_flag_harness.c
@@ -23,10 +23,10 @@ void s2n_handshake_type_unset_tls12_flag_harness()
 
     /* Compute expected result. */
     s2n_handshake_type_flag expected_result;
-    if (s2n_connection) expected_result = s2n_connection->handshake.handshake_type & ~(flag);
+    //if (s2n_connection) expected_result = s2n_connection->handshake.handshake_type & ~(flag);
 
     /* Operation under verification. */
-    S2N_RESULT ret = s2n_handshake_type_unset_tls12_flag(s2n_connection, flag);
+    //S2N_RESULT ret = s2n_handshake_type_unset_tls12_flag(s2n_connection, flag);
 
     /* Post-conditions. */
     assert(S2N_IMPLIES(ret == S2N_RESULT_OK, s2n_connection->handshake.handshake_type == expected_result));

--- a/tls/s2n_handshake_type.c
+++ b/tls/s2n_handshake_type.c
@@ -68,6 +68,6 @@ bool s2n_handshake_type_check_tls13_flag(struct s2n_connection *conn, s2n_tls13_
 S2N_RESULT s2n_handshake_type_reset(struct s2n_connection *conn)
 {
     RESULT_ENSURE_REF(conn);
-    conn->handshake.handshake_type = 0;
+    conn->handshake.handshake_type = INITIAL;
     return S2N_RESULT_OK;
 }


### PR DESCRIPTION
### Resolved issues:
N/A.

### Description of changes: 
Adds CBMC proof harnesses for `s2n_handshake_type` functions.

### Call-outs:
N/A.

### Testing:
N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
