### PR TITLE
integration: enforce timeout, allow for the process to shutdown gracefully, run in non-blocking mode

### DIFF
--- a/bin/echo.c
+++ b/bin/echo.c
@@ -177,7 +177,7 @@ int print_connection_info(struct s2n_connection *conn)
     uint32_t length;
     const uint8_t *status = s2n_connection_get_ocsp_response(conn, &length);
     if (status && length > 0) {
-        fprintf(stderr, "OCSP response received, length %u\n", length);
+        printf("OCSP response received, length %u\n", length);
     }
 
     printf("Cipher negotiated: %s\n", s2n_connection_get_cipher(conn));

--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -116,7 +116,7 @@ def try_client_handshake(endpoint, arguments, expected_cipher):
     TODO: warn if there is drift between the OS CA certs and our own.
     see https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/
     """
-    s2nc_cmd = ["../../bin/s2nc", "-f", "./trust-store/ca-bundle.crt", "-a", "http/1.1"] + arguments + [str(endpoint)]
+    s2nc_cmd = ["../../bin/s2nc", "-f", "./trust-store/ca-bundle.crt", "-a", "http/1.1", "-B"] + arguments + [str(endpoint)]
     currentDir = os.path.dirname(os.path.realpath(__file__))
     s2nc = subprocess.Popen(s2nc_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=currentDir, universal_newlines=True)
 

--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -118,7 +118,7 @@ def try_client_handshake(endpoint, arguments, expected_cipher):
     """
     s2nc_cmd = ["../../bin/s2nc", "-f", "./trust-store/ca-bundle.crt", "-a", "http/1.1"] + arguments + [str(endpoint)]
     currentDir = os.path.dirname(os.path.realpath(__file__))
-    s2nc = subprocess.Popen(s2nc_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=currentDir, universal_newlines=True)
+    s2nc = subprocess.Popen(s2nc_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=currentDir)
 
     try:
         outs, errs = s2nc.communicate(timeout=5)

--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -118,7 +118,7 @@ def try_client_handshake(endpoint, arguments, expected_cipher):
     """
     s2nc_cmd = ["../../bin/s2nc", "-f", "./trust-store/ca-bundle.crt", "-a", "http/1.1"] + arguments + [str(endpoint)]
     currentDir = os.path.dirname(os.path.realpath(__file__))
-    s2nc = subprocess.Popen(s2nc_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=currentDir)
+    s2nc = subprocess.Popen(s2nc_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=currentDir, universal_newlines=True)
 
     try:
         outs, errs = s2nc.communicate(timeout=5)
@@ -134,7 +134,6 @@ def try_client_handshake(endpoint, arguments, expected_cipher):
                 found = 1
                 break
 
-        s2nc.kill()
         s2nc.wait()
 
         if found == 0:

--- a/tests/integration/s2n_client_endpoint_handshake_test.py
+++ b/tests/integration/s2n_client_endpoint_handshake_test.py
@@ -130,7 +130,6 @@ def try_client_handshake(endpoint, arguments, expected_cipher):
 
         for line in range(0, NUM_EXPECTED_LINES_OUTPUT):
             output = str(outs)
-            print(output, end='')
             if expected_output in output:
                 found = 1
                 break
@@ -144,7 +143,6 @@ def try_client_handshake(endpoint, arguments, expected_cipher):
         return 0
 
     except subprocess.TimeoutExpired:
-        print("Caught exception: subprocess.TimeoutExpired")
         s2nc.kill()
         return -1
 
@@ -188,7 +186,6 @@ def well_known_endpoints_test(use_corked_io, tls13_enabled, fips_mode):
             print("Connecting to: %-35sAttempt: %-10s... " % (endpoint, i))
             ret = try_client_handshake(endpoint, arguments, expected_cipher)
 
-            print("return code: %s" % ret)
             if ret == 0:
                 break
             else:

--- a/tests/integration/s2n_pq_handshake_test.py
+++ b/tests/integration/s2n_pq_handshake_test.py
@@ -81,8 +81,8 @@ def do_pq_handshake(client_ciphers, server_ciphers, expected_cipher, expected_ke
     expected_cipher_output = "Cipher negotiated: " + expected_cipher
     expected_kem_output = "KEM: " + expected_kem
 
-    s2nd = subprocess.Popen(s2nd_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=current_dir)
-    s2nc = subprocess.Popen(s2nc_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=current_dir)
+    s2nd = subprocess.Popen(s2nd_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=current_dir, universal_newlines=True)
+    s2nc = subprocess.Popen(s2nc_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=current_dir, universal_newlines=True)
 
     client_kem_found = False
     client_cipher_found = False
@@ -92,7 +92,9 @@ def do_pq_handshake(client_ciphers, server_ciphers, expected_cipher, expected_ke
     server_version_correct = False
 
     for i in range(0, NUM_EXPECTED_LINES_OUTPUT):
-        client_line = str(s2nc.stdout.readline().decode("utf-8"))
+        client_outs, errs = s2nc.communicate(timeout=5)
+        client_line = str(client_outs)
+
         if expected_kem_output in client_line:
             client_kem_found = True
         if expected_cipher_output in client_line:
@@ -100,7 +102,8 @@ def do_pq_handshake(client_ciphers, server_ciphers, expected_cipher, expected_ke
         if validate_version(S2N_TLS12, client_line):
             client_version_correct = True
 
-        server_line = str(s2nd.stdout.readline().decode("utf-8"))
+        server_outs, errs = s2nc.communicate(timeout=5)
+        server_line = str(server_outs)
         if expected_kem_output in server_line:
             server_kem_found = True
         if expected_cipher_output in server_line:

--- a/tests/integration/s2n_pq_handshake_test.py
+++ b/tests/integration/s2n_pq_handshake_test.py
@@ -111,7 +111,6 @@ def do_pq_handshake(client_ciphers, server_ciphers, expected_cipher, expected_ke
         if validate_version(S2N_TLS12, server_line):
             server_version_correct = True
 
-    s2nc.kill()
     s2nc.wait()
 
     s2nd.kill()

--- a/tests/integration/s2n_test_constants.py
+++ b/tests/integration/s2n_test_constants.py
@@ -18,7 +18,7 @@ from enum import Enum
 
 # Number of lines of output to stdout s2nc or s2nd are expected
 # to produce after a successful handshake
-NUM_EXPECTED_LINES_OUTPUT = 15
+NUM_EXPECTED_LINES_OUTPUT = 16
 
 class OCSP(Enum):
     ENABLED = 1


### PR DESCRIPTION
### Resolved issues:

 resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.

### Description of changes: 

Currently its possible for s2nc to hangup and not make any progress. After doing some local testing it seem this happens afterhttps://github.com/aws/s2n-tls/pull/3148/files multiple calls to `python3 ./tests/integration/s2n_client_endpoint_handshake_test.py`.

This PR introduces the following changes:
- add a timeout to the subprocess so that we dont hang forever
- remove the `subprocess.kill()` and instead let the subprocess gracefully shutdown.
- handle TimeoutException to ensure retries work
- run s2nc in non-blocking mode
 
### Call-outs:

**Why add a timeout?**
So we dont hang forever, and either succeed or fail.

**Why remove `kill()`?**
Since multiple tests are run, and they all share an in-memory buffer, a kill() signal could be leaving corrupted memory in the buffer. Therefore instead of a kill signal let the client shutdown gracefully.

**Why handle TimeoutExcpetion?**
Since we added a timeout, we also need to handle the TimeoutException to maintain previous behavior.

**Why non-blocking mode**
Based on local testing(strace), the process gets stuck on a `read` syscall.



**Output of local testing which shows how the `read` syscall blocks**
```
❯ strace -p 887250                                                                                        ~/projects/s2n-tls
strace: Process 887250 attached
read(4, "\25\3\3\0\32", 5)              = 5
read(4, "\320U\4\177;\304t\35c\257\\\23\312\240\231/%g\273\201\361\333\233\303\230\267", 26) = 26
munlock(NULL, 0)                        = 0
munlock(NULL, 0)                        = 0
munlock(NULL, 0)                        = 0
munlock(0x1f58000, 12)                  = 0
munlock(0x1f5a000, 12)                  = 0
munlock(NULL, 0)                        = 0
munlock(NULL, 0)                        = 0
munlock(NULL, 0)                        = 0
munlock(NULL, 0)                        = 0
munlock(NULL, 0)                        = 0
munlock(NULL, 0)                        = 0
munlock(0x1f60000, 16384)               = 0
munlock(0x1f5c000, 12288)               = 0
munlock(NULL, 0)                        = 0
munlock(NULL, 0)                        = 0
munlock(NULL, 0)                        = 0
munlock(0x1f4a000, 8896)                = 0
munlock(0x1f42000, 4096)                = 0
munlock(0x1f40000, 32)                  = 0
munlock(0x1f3e000, 16)                  = 0
munlock(0x1f48000, 4096)                = 0
munlock(0x1f46000, 32)                  = 0
munlock(0x1f44000, 16)                  = 0
munlock(0x1ef4000, 4096)                = 0
munlock(0x1e45000, 48)                  = 0
munlock(0x1e43000, 24)                  = 0
munlock(0x1e41000, 376)                 = 0
close(4)                                = 0
close(3)                                = 0
write(1, "CONNECTED:\nHandshake: NEGOTIATED"..., 521) = 521
exit_group(0)                           = ?

```

```
❯ lsof -p 887250 | grep 4                                                                                                 ~/projects/s2n-tls
s2nc    887250 toidiu  cwd    DIR   259,2     4096 23343002 /home/toidiu/projects/s2n-tls/tests/integration
s2nc    887250 toidiu  rtd    DIR   259,2     4096        2 /
s2nc    887250 toidiu  txt    REG   259,2   164192 29624046 /home/toidiu/projects/s2n-tls/build/bin/s2nc
s2nc    887250 toidiu  mem    REG   259,2  2076736  3939149 /nix/store/jsp3h3wpzc842j0rz61m5ly71ak6qgdn-glibc-2.32-54/lib/libc-2.32.so
s2nc    887250 toidiu  mem    REG   259,2   143608  3939186 /nix/store/jsp3h3wpzc842j0rz61m5ly71ak6qgdn-glibc-2.32-54/lib/libpthread-2.32.so
s2nc    887250 toidiu  mem    REG   259,2  1422328  3939161 /nix/store/jsp3h3wpzc842j0rz61m5ly71ak6qgdn-glibc-2.32-54/lib/libm-2.32.so
s2nc    887250 toidiu  mem    REG   259,2    49464  3939192 /nix/store/jsp3h3wpzc842j0rz61m5ly71ak6qgdn-glibc-2.32-54/lib/librt-2.32.so
s2nc    887250 toidiu  mem    REG   259,2    18432  3939156 /nix/store/jsp3h3wpzc842j0rz61m5ly71ak6qgdn-glibc-2.32-54/lib/libdl-2.32.so
s2nc    887250 toidiu  mem    REG   259,2  3374336  3813534 /nix/store/rdkqa0va7fv9qd20sphn2w35kmxr7jbx-openssl-1.1.1l/lib/libcrypto.so.1.1
s2nc    887250 toidiu  mem    REG   259,2  6876440 29623842 /home/toidiu/projects/s2n-tls/build/lib/libs2n.so
s2nc    887250 toidiu  mem    REG   259,2   196896  3939140 /nix/store/jsp3h3wpzc842j0rz61m5ly71ak6qgdn-glibc-2.32-54/lib/ld-2.32.so
s2nc    887250 toidiu    1w  FIFO    0,12      0t0  2360894 pipe
s2nc    887250 toidiu    2u   CHR  136,14      0t0       17 /dev/pts/14
s2nc    887250 toidiu    4u  IPv4 2365643      0t0      TCP nixos.hsd1.wa.comcast.net:36498->162.219.225.118:https (ESTABLISHED)
```

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
