### PR TITLE
Add memory-safety proofs for `s2n_handshake` functions

### DIFF
--- a/tests/cbmc/proofs/s2n_handshake_write_header/Makefile
+++ b/tests/cbmc/proofs/s2n_handshake_write_header/Makefile
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use the default set of CBMC flags.
+CBMCFLAGS +=
+
+PROOF_UID = s2n_handshake_write_header
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/mlock.c
+PROOF_SOURCES += $(PROOF_STUB)/munlock.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/tls/s2n_handshake.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+
+# We abstract these functions because manual inspection demonstrates they are unreachable.
+REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
+REMOVE_FUNCTION_BODY += s2n_blob_slice
+REMOVE_FUNCTION_BODY += s2n_stuffer_wipe
+
+UNWINDSET += s2n_stuffer_write_network_order.4:3 # size of SIZEOF_UINT24
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_handshake_write_header/cbmc-proof.txt
+++ b/tests/cbmc/proofs/s2n_handshake_write_header/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/tests/cbmc/proofs/s2n_handshake_write_header/s2n_handshake_write_header_harness.c
+++ b/tests/cbmc/proofs/s2n_handshake_write_header/s2n_handshake_write_header_harness.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+
+#include <tls/s2n_handshake.h>
+
+void s2n_handshake_write_header_harness()
+{
+    /* Non-deterministic inputs. */
+    struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();
+    uint8_t message_type;
+
+    nondet_s2n_mem_init();
+
+    struct s2n_stuffer old_stuffer = {0};
+    if(stuffer) old_stuffer = *stuffer;
+
+    /* Operation under verification. */
+    if (s2n_handshake_write_header(stuffer, message_type) == S2N_SUCCESS) {
+        /* Post-conditions. */
+        assert(stuffer->blob.data[old_stuffer.read_cursor] == message_type);
+    }
+}

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -29,6 +29,7 @@
 
 int s2n_handshake_write_header(struct s2n_stuffer *out, uint8_t message_type)
 {
+    POSIX_PRECONDITION(s2n_stuffer_validate(out));
     S2N_ERROR_IF(s2n_stuffer_data_available(out), S2N_ERR_HANDSHAKE_STATE);
 
     /* Write the message header */


### PR DESCRIPTION
### Resolved issues:

N/A.

### Description of changes: 

This PR adds CBMC proofs for the following `s2n_handshake` functions:
 - `s2n_handshake_write_header`;

### Call-outs:
N/A.

### Testing:
N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
