### PR TITLE
Fix s2n_connection_get_client_cert_chain for TLS1.3

### DIFF
--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -420,6 +420,14 @@ int s2n_cert_chain_and_key_load_pem_bytes(struct s2n_cert_chain_and_key *chain_a
     return S2N_SUCCESS;
 }
 
+S2N_CLEANUP_RESULT s2n_cert_chain_and_key_ptr_free(struct s2n_cert_chain_and_key **cert_and_key)
+{
+    RESULT_ENSURE_REF(cert_and_key);
+    RESULT_GUARD_POSIX(s2n_cert_chain_and_key_free(*cert_and_key));
+    *cert_and_key = NULL;
+    return S2N_RESULT_OK;
+}
+
 int s2n_cert_chain_and_key_free(struct s2n_cert_chain_and_key *cert_and_key)
 {
     if (cert_and_key == NULL) {

--- a/crypto/s2n_certificate.h
+++ b/crypto/s2n_certificate.h
@@ -67,6 +67,7 @@ int s2n_cert_chain_and_key_load_cns(struct s2n_cert_chain_and_key *chain_and_key
 int s2n_cert_chain_and_key_load_sans(struct s2n_cert_chain_and_key *chain_and_key, X509 *x509_cert);
 int s2n_cert_chain_and_key_matches_dns_name(const struct s2n_cert_chain_and_key *chain_and_key, const struct s2n_blob *dns_name);
 
+S2N_CLEANUP_RESULT s2n_cert_chain_and_key_ptr_free(struct s2n_cert_chain_and_key **cert_and_key);
 int s2n_cert_set_cert_type(struct s2n_cert *cert, s2n_pkey_type pkey_type);
 int s2n_send_cert_chain(struct s2n_connection *conn, struct s2n_stuffer *out, struct s2n_cert_chain_and_key *chain_and_key);
 int s2n_send_empty_cert_chain(struct s2n_stuffer *out);

--- a/tests/unit/s2n_certificate_test.c
+++ b/tests/unit/s2n_certificate_test.c
@@ -678,8 +678,12 @@ int main(int argc, char **argv)
             EXPECT_NOT_EQUAL(tls12_server_conn->handshake_params.client_cert_chain.size, 0);
         }
 
-        /* Perform TLS1.3 handshake and verify cert chain is NOT available */
-        {
+        /* Perform TLS1.3 handshake and verify cert chain is NOT available.
+         *
+         * The TLS1.3 handshake is only possible if TLS1.3 is fully supported because of client auth:
+         * the server doesn't know whether the client will offer a RSA-PSS certificate or not.
+         */
+        if (s2n_is_tls13_fully_supported()) {
             EXPECT_SUCCESS(s2n_connection_set_config(tls13_client_conn, config));
             EXPECT_SUCCESS(s2n_connection_set_config(tls13_server_conn, config));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(tls13_client_conn, "default_tls13"));
@@ -710,7 +714,7 @@ int main(int argc, char **argv)
         /* Should produce same result for TLS1.2 and TLS1.3
          * (Both connections used the same certificate chain for the handshake)
          */
-        {
+        if (s2n_is_tls13_fully_supported()) {
             uint8_t *tls12_output = NULL;
             uint32_t tls12_output_len = 0;
             EXPECT_SUCCESS(s2n_connection_get_client_cert_chain(tls12_server_conn, &tls12_output, &tls12_output_len));

--- a/tests/unit/s2n_certificate_test.c
+++ b/tests/unit/s2n_certificate_test.c
@@ -646,7 +646,7 @@ int main(int argc, char **argv)
         DEFER_CLEANUP(struct s2n_connection *tls13_client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
         DEFER_CLEANUP(struct s2n_connection *tls13_server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
 
-        /* Should error before handshakes performed.
+        /* Should error before the handshake is performed.
          * This method is intended to be called after the handshake is complete and requires
          * state set during the handshake.
          */

--- a/tls/s2n_client_cert.c
+++ b/tls/s2n_client_cert.c
@@ -27,6 +27,71 @@
 #include "utils/s2n_blob.h"
 #include "utils/s2n_safety.h"
 
+/* In TLS1.2, the certificate list is just an opaque vector of certificates:
+ *
+ *      opaque ASN.1Cert<1..2^24-1>;
+ *
+ *      struct {
+ *          ASN.1Cert certificate_list<0..2^24-1>;
+ *      } Certificate;
+ *
+ * This construction allowed us to store the entire certificate_list blob
+ * and return it from the s2n_connection_get_client_cert_chain method for
+ * customers to examine.
+ *
+ * However, TLS1.3 introduced per-certificate extensions:
+ *
+ *      struct {
+ *          opaque cert_data<1..2^24-1>;
+ * ---->    Extension extensions<0..2^16-1>;    <----
+ *      } CertificateEntry;
+ *
+ *      struct {
+ *          opaque certificate_request_context<0..2^8-1>;
+ *          CertificateEntry certificate_list<0..2^24-1>;
+ *      } Certificate;
+ *
+ * So in order to store / return the certificates in the same format as in TLS1.2,
+ * we need to first strip out the extensions.
+ */
+static S2N_RESULT s2n_client_cert_chain_store(struct s2n_connection *conn, struct s2n_blob *client_cert_chain)
+{
+    RESULT_ENSURE_REF(conn);
+
+    /* Earlier versions are a basic copy */
+    if (conn->actual_protocol_version < S2N_TLS13) {
+        RESULT_GUARD_POSIX(s2n_dup(client_cert_chain, &conn->handshake_params.client_cert_chain));
+        return S2N_RESULT_OK;
+    }
+
+    struct s2n_stuffer cert_chain_in = { 0 };
+    RESULT_GUARD_POSIX(s2n_stuffer_init(&cert_chain_in, client_cert_chain));
+    RESULT_GUARD_POSIX(s2n_stuffer_skip_write(&cert_chain_in, client_cert_chain->size));
+
+    struct s2n_stuffer cert_chain_out = { 0 };
+    RESULT_GUARD_POSIX(s2n_realloc(&conn->handshake_params.client_cert_chain, client_cert_chain->size));
+    RESULT_GUARD_POSIX(s2n_stuffer_init(&cert_chain_out, &conn->handshake_params.client_cert_chain));
+
+    uint32_t cert_size = 0;
+    uint16_t extensions_size = 0;
+    while(s2n_stuffer_data_available(&cert_chain_in)) {
+        RESULT_GUARD_POSIX(s2n_stuffer_read_uint24(&cert_chain_in, &cert_size));
+        RESULT_GUARD_POSIX(s2n_stuffer_write_uint24(&cert_chain_out, cert_size));
+        RESULT_GUARD_POSIX(s2n_stuffer_copy(&cert_chain_in, &cert_chain_out, cert_size));
+
+        /* The new TLS1.3 format includes extensions, which we must skip.
+         * Customers will not expect TLS extensions in a DER-encoded certificate.
+         */
+        RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&cert_chain_in, &extensions_size));
+        RESULT_GUARD_POSIX(s2n_stuffer_skip_read(&cert_chain_in, extensions_size));
+    }
+
+    /* We will have allocated more memory than actually necessary.
+     * If this becomes a problem, we should consider reallocing the correct amount of memory here.
+     */
+    conn->handshake_params.client_cert_chain.size = s2n_stuffer_data_available(&cert_chain_out);
+    return S2N_RESULT_OK;
+}
 
 int s2n_client_cert_recv(struct s2n_connection *conn)
 {
@@ -65,10 +130,10 @@ int s2n_client_cert_recv(struct s2n_connection *conn)
     POSIX_GUARD(s2n_pkey_setup_for_type(&public_key, pkey_type));
     
     POSIX_GUARD(s2n_pkey_check_key_exists(&public_key));
-    POSIX_GUARD(s2n_dup(&client_cert_chain, &conn->handshake_params.client_cert_chain));
+    POSIX_GUARD_RESULT(s2n_client_cert_chain_store(conn, &client_cert_chain));
     conn->handshake_params.client_public_key = public_key;
-    
-    return 0;
+
+    return S2N_SUCCESS;
 }
 
 
@@ -76,7 +141,7 @@ int s2n_client_cert_send(struct s2n_connection *conn)
 {
     struct s2n_cert_chain_and_key *chain_and_key = conn->handshake_params.our_chain_and_key;
 
-    if (conn->actual_protocol_version == S2N_TLS13) {
+    if (conn->actual_protocol_version >= S2N_TLS13) {
         /* If this message is in response to a CertificateRequest, the value of
          * certificate_request_context in that message.
          * https://tools.ietf.org/html/rfc8446#section-4.4.2
@@ -95,5 +160,5 @@ int s2n_client_cert_send(struct s2n_connection *conn)
     }
 
     POSIX_GUARD(s2n_send_cert_chain(conn, &conn->handshake.io, chain_and_key));
-    return 0;
+    return S2N_SUCCESS;
 }

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -334,6 +334,14 @@ int s2n_config_free_dhparams(struct s2n_config *config)
     return 0;
 }
 
+S2N_CLEANUP_RESULT s2n_config_ptr_free(struct s2n_config **config)
+{
+    RESULT_ENSURE_REF(config);
+    RESULT_GUARD_POSIX(s2n_config_free(*config));
+    *config = NULL;
+    return S2N_RESULT_OK;
+}
+
 int s2n_config_free(struct s2n_config *config)
 {
     s2n_config_cleanup(config);

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -146,6 +146,8 @@ struct s2n_config {
     s2n_async_pkey_validation_mode async_pkey_validation_mode;
 };
 
+S2N_CLEANUP_RESULT s2n_config_ptr_free(struct s2n_config **config);
+
 int s2n_config_defaults_init(void);
 extern struct s2n_config *s2n_fetch_default_config(void);
 int s2n_config_set_unsafe_for_testing(struct s2n_config *config);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -332,6 +332,14 @@ static uint8_t s2n_default_verify_host(const char *host_name, size_t len, void *
     return 0;
 }
 
+S2N_CLEANUP_RESULT s2n_connection_ptr_free(struct s2n_connection **conn)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_GUARD_POSIX(s2n_connection_free(*conn));
+    *conn = NULL;
+    return S2N_RESULT_OK;
+}
+
 int s2n_connection_free(struct s2n_connection *conn)
 {
     POSIX_GUARD(s2n_connection_wipe_keys(conn));

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -381,6 +381,8 @@ struct s2n_connection {
     uint32_t server_keying_material_lifetime;
 };
 
+S2N_CLEANUP_RESULT s2n_connection_ptr_free(struct s2n_connection **s2n_connection);
+
 int s2n_connection_is_managed_corked(const struct s2n_connection *s2n_connection);
 int s2n_connection_is_client_auth_enabled(struct s2n_connection *s2n_connection);
 


### PR DESCRIPTION
### Description of changes: 

A customer noticed that s2n_connection_get_client_cert_chain was reporting that the client cert chain was 2 bytes longer than it actually was, resulting in errors parsing the chain. The issue is that TLS1.3 added extensions to each certificate entry, which add at least two "nonsense" bytes to each entry that we should not be passing on to customers. We therefore can't save the client certificate chain by just copying a big block of memory like we do for TLS1.2; the extensions need to be removed first.

Also: **why did I add the ptr_free methods?** Initially, because I needed s2n_cert_chain_and_key_ptr_free for my original fix for this bug. Then I added the others, because the lack of them has made writing tests more difficult for years. Although my final solution doesn't need s2n_cert_chain_and_key_ptr_free, I'm keeping it because it really improves the test writing experience. But if we end up mostly discussing these additions, I can rewrite my tests without them and move them to a separate PR.

### Call-outs:

I considered three options:

1. Build the cert chain while parsing the "certificate_list" field. Unfortunately the parsing logic is part of "s2n_x509_validator_validate_cert_chain", which also handles validation and processing the extensions: https://github.com/aws/s2n-tls/blob/main/tls/s2n_x509_validator.c#L305-L347 It's a very complicated method that probably needs to be refactored into smaller, more focused methods (and to match the rest of our codebase: it doesn't return int OR s2n_result). I don't want to further complicate it / give it more jobs, and I don't think it's worth trying to refactor it just to fix this bug. I did not attempt to implement this solution.
2. Turn s2n_connection_get_client_cert_chain into a wrapper around the newer s2n_connection_get_peer_cert_chain method. I implemented this solution: https://github.com/lrstewart/s2n/commit/36f80e0cd092baf3a839b8bfa5dce0a9ed55a526 Unfortunately, it's slower than the original, which makes sense since it performs multiple allocations and basically re-parses every certificate. It's not prohibitively slow though, so it's still a valid alternative to this PR. Here's the flamegraph for a test of the handshake + s2n_connection_get_client_cert_chain: https://gist.github.com/lrstewart/95646f887677b3483ded43e2b42f5547 The existing s2n_connection_get_client_cert_chain doesn't even appear on flamegraphs, but the new s2n_connection_get_client_cert_chain is 0.17% of the test.
3. The solution I implemented here. It's hacky, but it solves the problem and had no impact on performance that I could measure. I also like that it's very readable and can't possibly impact the actual certificate validation. I would argue it's sufficient until we get around to cleaning up the x509_validator methods.

### Testing:

New unit tests (there were none before). I also confirmed that the new tests fail without this fix, and specifically they fail because the TLS1.3 chain is two bytes longer than the TLS1.2 chain.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
