### PR TITLE
Fixing Flakiness in Cross-Compat Test

### DIFF
--- a/tests/integrationv2/test_cross_compatibility.py
+++ b/tests/integrationv2/test_cross_compatibility.py
@@ -3,12 +3,13 @@ import copy
 import os
 
 from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS, PROTOCOLS
-from common import ProviderOptions, Protocols
+from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process
 from providers import Provider, S2N, OpenSSL
 from utils import invalid_test_parameters, get_parameter_name, to_bytes
 
 S2N_RESUMPTION_MARKER = to_bytes("Resumed session")
+CLOSE_MARKER_BYTES = data_bytes(10)
 
 TICKET_FILE = 'ticket'
 RESUMPTION_PROTOCOLS = [Protocols.TLS12, Protocols.TLS13]
@@ -45,9 +46,10 @@ def test_s2n_old_server_new_ticket(managed_process, tmp_path, cipher, curve, pro
     server_options.mode = Provider.ServerMode
     server_options.key = certificate.key
     server_options.cert = certificate.cert
+    server_options.data_to_send = CLOSE_MARKER_BYTES
 
-    s2n_server = managed_process(S2N, server_options)
-    client = managed_process(provider, client_options)
+    s2n_server = managed_process(S2N, server_options, send_marker=S2N.get_send_marker())
+    client = managed_process(provider, client_options, close_marker=str(CLOSE_MARKER_BYTES))
 
     for results in client.get_results():
         results.assert_success()
@@ -102,9 +104,10 @@ def test_s2n_new_server_old_ticket(managed_process, tmp_path, cipher, curve, pro
     server_options.use_mainline_version = True
     server_options.key = certificate.key
     server_options.cert = certificate.cert
+    server_options.data_to_send = CLOSE_MARKER_BYTES
 
-    s2n_server = managed_process(S2N, server_options)
-    client = managed_process(provider, client_options)
+    s2n_server = managed_process(S2N, server_options, send_marker=S2N.get_send_marker())
+    client = managed_process(provider, client_options, close_marker=str(CLOSE_MARKER_BYTES))
 
     for results in client.get_results():
         results.assert_success()

--- a/tests/integrationv2/test_cross_compatibility.py
+++ b/tests/integrationv2/test_cross_compatibility.py
@@ -61,8 +61,8 @@ def test_s2n_old_server_new_ticket(managed_process, tmp_path, cipher, curve, pro
     client_options.extra_flags = ['-sess_in', ticket_file]
     server_options.use_mainline_version = True
 
-    s2n_server = managed_process(S2N, server_options)
-    client = managed_process(provider, client_options)
+    s2n_server = managed_process(S2N, server_options, send_marker=S2N.get_send_marker())
+    client = managed_process(provider, client_options, close_marker=str(CLOSE_MARKER_BYTES))
 
     for results in client.get_results():
         results.assert_success()
@@ -119,8 +119,8 @@ def test_s2n_new_server_old_ticket(managed_process, tmp_path, cipher, curve, pro
     client_options.extra_flags = ['-sess_in', ticket_file]
     server_options.use_mainline_version = False
 
-    s2n_server = managed_process(S2N, server_options)
-    client = managed_process(provider, client_options)
+    s2n_server = managed_process(S2N, server_options, send_marker=S2N.get_send_marker())
+    client = managed_process(provider, client_options, close_marker=str(CLOSE_MARKER_BYTES))
 
     for results in client.get_results():
         results.assert_success()


### PR DESCRIPTION
### Resolved issues:

 N/A
### Description of changes: 
The new Cross-Compat integ test has been quite flaky. This change has the server send some data after the handshake to make sure that the client receives the session resumption ticket after the handshake.
### Call-outs:
N/A
### Testing:
So far, the Cross-Compat test has been really flaky, so I think if this gets through CI we should feel assured that this change at least improves the flakiness. Also this passed the CI without retries, I swear!

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
