### PR TITLE
Workaround gcc-11 errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,9 @@ set(CMAKE_C_FLAGS_DEBUGOPT "")
 
 target_compile_options(${PROJECT_NAME} PRIVATE -pedantic -std=gnu99 -Wall -Wimplicit -Wunused -Wcomment -Wchar-subscripts
         -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security
+        -Wno-error=array-parameter -Wno-error=discarded-qualifiers -Wno-error=analyzer-null-dereference
+        -Wno-error=analyzer-file-leak -Wno-error=analyzer-malloc-leak -Wno-error=analyzer-possible-null-dereference
+        -Wno-error=stringop-overflow -Wno-error=stringop-overread
         -Wno-missing-braces -Wa,--noexecstack
 )
 

--- a/s2n.mk
+++ b/s2n.mk
@@ -49,6 +49,9 @@ DEFAULT_CFLAGS += -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-s
                  -Wshadow  -Wcast-align -Wwrite-strings -fPIC -Wno-missing-braces\
                  -D_POSIX_C_SOURCE=200809L -O2 -I$(LIBCRYPTO_ROOT)/include/ \
                  -I$(S2N_ROOT)/api/ -I$(S2N_ROOT) -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security \
+                 -Wno-error=array-parameter -Wno-error=discarded-qualifiers -Wno-error=analyzer-null-dereference \
+                 -Wno-error=analyzer-file-leak -Wno-error=analyzer-malloc-leak -Wno-error=analyzer-possible-null-dereference \
+                 -Wno-error=stringop-overflow -Wno-error=stringop-overread \
                  -D_FORTIFY_SOURCE=2 -fgnu89-inline -fvisibility=hidden -DS2N_EXPORTS
 
 COVERAGE_CFLAGS = -fprofile-arcs -ftest-coverage


### PR DESCRIPTION
On ubuntu 20.04, install gcc-11
$ sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
$ sudo apt install -y gcc-11

1) make
$ S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=11
$ source codebuild/bin/s2n_setup_env.sh
$ codebuild/bin/s2n_install_test_dependencies.sh
$ codebuild/bin/s2n_codebuild.sh

2) cmake
$ export CC="gcc-11"
$ cmake . -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug
$ cmake --build ./build -j $(nproc)

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>

### Resolved issues:

 resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.

### Description of changes: 

Describe s2n’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.
### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
