### PR TITLE
Conflicting ports in integration test

### DIFF
--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -13,7 +13,7 @@
 # permissions and limitations under the License.
 #
 
-S2ND_PORT=8888
+S2ND_PORT=18888
 S2ND_HOST=127.0.0.1
 
 # If the libcrypto that s2n was built with is not specified, assume latest(1.1.1).

--- a/tests/integration/common/s2n_test_common.py
+++ b/tests/integration/common/s2n_test_common.py
@@ -122,7 +122,7 @@ def run_connection_test(get_peer, scenarios, test_func=basic_write_test):
                 result = Result("Server process crashed")
 
         except AssertionError as error:
-            result = Result(error)
+            result = Result(str(error))
         finally:
             cleanup_processes(server, client)
             if client:


### PR DESCRIPTION
### Resolved issues:

### Description of changes: 

In s2n_test_common, run_connection_test, __test, AssertionErrors are caught from performing a handshake and running test_func. If an AssertionError is caught, it is used directly in the constructor of a Result. However, only the exception's error message should be passed to the Result, since it expects a string in the to string function (__str__ in s2n_test_reporting.py:60). This change calls the exception's to string function and passes that to the Result instead.

This type error was found when an assertion error was caught after a port was used in a handshake test that was already in use. To try and avoid conflicting ports when running integration tests, the S2ND_PORT field in the Makefile was increased.

### Call-outs:


### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
