### PR TITLE
tests: add s2n_init/s2n_cleanup tests

### DIFF
--- a/tests/unit/s2n_init_test.c
+++ b/tests/unit/s2n_init_test.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+int main(int argc, char **argv)
+{
+    /* disable deferred cleanup */
+    s2n_disable_atexit();
+
+    /* this includes a call to s2n_init */
+    BEGIN_TEST();
+
+    /* clean up and init multiple times */
+    for (size_t i = 0; i < 10; i++) {
+        s2n_cleanup();
+        EXPECT_SUCCESS(s2n_init());
+    }
+
+    END_TEST();
+}

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -249,8 +249,11 @@ int s2n_config_defaults_init(void)
 
 void s2n_wipe_static_configs(void)
 {
-    s2n_config_cleanup(&s2n_default_config);
-    s2n_config_cleanup(&s2n_default_fips_config);
+    if (s2n_is_in_fips_mode()) {
+        s2n_config_cleanup(&s2n_default_fips_config);
+    } else {
+        s2n_config_cleanup(&s2n_default_config);
+    }
     s2n_config_cleanup(&s2n_default_tls13_config);
 }
 

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -249,11 +249,8 @@ int s2n_config_defaults_init(void)
 
 void s2n_wipe_static_configs(void)
 {
-    if (s2n_is_in_fips_mode()) {
-        s2n_config_cleanup(&s2n_default_fips_config);
-    } else {
-        s2n_config_cleanup(&s2n_default_config);
-    }
+    s2n_config_cleanup(&s2n_default_fips_config);
+    s2n_config_cleanup(&s2n_default_config);
     s2n_config_cleanup(&s2n_default_tls13_config);
 }
 

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -162,15 +162,15 @@ static int s2n_tls12_deserialize_resumption_state(struct s2n_connection *conn, s
 
         /**
          *= https://tools.ietf.org/rfc/rfc7627#section-5.3
-         *# If the original session did not use the "extended_master_secret"
-         *# extension but the new ClientHello contains the extension, then the
-         *# server MUST NOT perform the abbreviated handshake.  Instead, it
-         *# SHOULD continue with a full handshake (as described in
-         *# Section 5.2) to negotiate a new session.
+         *# o  If the original session did not use the "extended_master_secret"
+         *#    extension but the new ClientHello contains the extension, then the
+         *#    server MUST NOT perform the abbreviated handshake.  Instead, it
+         *#    SHOULD continue with a full handshake (as described in
+         *#    Section 5.2) to negotiate a new session.
          *#
-         *# If the original session used the "extended_master_secret"
-         *# extension but the new ClientHello does not contain it, the server
-         *# MUST abort the abbreviated handshake.
+         *# o  If the original session used the "extended_master_secret"
+         *#    extension but the new ClientHello does not contain it, the server
+         *#    MUST abort the abbreviated handshake.
          **/
         if (conn->ems_negotiated != ems_negotiated) {
             /* The session ticket needs to have the same EMS state as the current session. If it doesn't

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -77,10 +77,10 @@ static bool s2n_cleanup_atexit_impl(void)
 {
     /* all of these should run, regardless of result, but the
      * values to need to be consumed to prevent warnings */
+    s2n_wipe_static_configs();
     bool a = s2n_result_is_ok(s2n_rand_cleanup_thread());
     bool b = s2n_result_is_ok(s2n_rand_cleanup());
     bool c = s2n_mem_cleanup() == 0;
-    s2n_wipe_static_configs();
 
     return a && b && c;
 }

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -77,7 +77,10 @@ static bool s2n_cleanup_atexit_impl(void)
 {
     /* all of these should run, regardless of result, but the
      * values to need to be consumed to prevent warnings */
+
+    /* the configs need to be wiped before resetting the memory callbacks */
     s2n_wipe_static_configs();
+
     bool a = s2n_result_is_ok(s2n_rand_cleanup_thread());
     bool b = s2n_result_is_ok(s2n_rand_cleanup());
     bool c = s2n_mem_cleanup() == 0;

--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -33,6 +33,7 @@
 
 static S2N_RESULT s2n_map_slot(const struct s2n_map *map, struct s2n_blob *key, uint32_t *slot)
 {
+    RESULT_ENSURE_REF(map);
     union {
         uint8_t u8[32];
         uint32_t u32[8];
@@ -50,6 +51,7 @@ static S2N_RESULT s2n_map_slot(const struct s2n_map *map, struct s2n_blob *key, 
 
 static S2N_RESULT s2n_map_embiggen(struct s2n_map *map, uint32_t capacity)
 {
+    RESULT_ENSURE_REF(map);
     struct s2n_blob mem = {0};
     struct s2n_map tmp = {0};
 
@@ -107,6 +109,7 @@ struct s2n_map *s2n_map_new_with_initial_capacity(uint32_t capacity)
 
 S2N_RESULT s2n_map_add(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value)
 {
+    RESULT_ENSURE_REF(map);
     RESULT_ENSURE(!map->immutable, S2N_ERR_MAP_IMMUTABLE);
 
     if (map->capacity < (map->size * 2)) {
@@ -139,6 +142,7 @@ S2N_RESULT s2n_map_add(struct s2n_map *map, struct s2n_blob *key, struct s2n_blo
 
 S2N_RESULT s2n_map_put(struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value)
 {
+    RESULT_ENSURE_REF(map);
     RESULT_ENSURE(!map->immutable, S2N_ERR_MAP_IMMUTABLE);
 
     if (map->capacity < (map->size * 2)) {
@@ -174,6 +178,7 @@ S2N_RESULT s2n_map_put(struct s2n_map *map, struct s2n_blob *key, struct s2n_blo
 
 S2N_RESULT s2n_map_complete(struct s2n_map *map)
 {
+    RESULT_ENSURE_REF(map);
     map->immutable = 1;
 
     return S2N_RESULT_OK;
@@ -181,6 +186,7 @@ S2N_RESULT s2n_map_complete(struct s2n_map *map)
 
 S2N_RESULT s2n_map_unlock(struct s2n_map *map)
 {
+    RESULT_ENSURE_REF(map);
     map->immutable = 0;
 
     return S2N_RESULT_OK;
@@ -188,6 +194,7 @@ S2N_RESULT s2n_map_unlock(struct s2n_map *map)
 
 S2N_RESULT s2n_map_lookup(const struct s2n_map *map, struct s2n_blob *key, struct s2n_blob *value, bool *key_found)
 {
+    RESULT_ENSURE_REF(map);
     RESULT_ENSURE(map->immutable, S2N_ERR_MAP_MUTABLE);
 
     uint32_t slot = 0;
@@ -222,6 +229,8 @@ S2N_RESULT s2n_map_lookup(const struct s2n_map *map, struct s2n_blob *key, struc
 
 S2N_RESULT s2n_map_free(struct s2n_map *map)
 {
+    /* cppcheck has a false positive warning for checking the pointer here */
+    /* cppcheck-suppress nullPointerRedundantCheck */
     if (map == NULL) {
         return S2N_RESULT_OK;
     }

--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -229,13 +229,13 @@ S2N_RESULT s2n_map_lookup(const struct s2n_map *map, struct s2n_blob *key, struc
 
 S2N_RESULT s2n_map_free(struct s2n_map *map)
 {
-    /* cppcheck has a false positive warning for checking the pointer here */
-    /* cppcheck-suppress nullPointerRedundantCheck */
     if (map == NULL) {
         return S2N_RESULT_OK;
     }
 
     /* Free the keys and values */
+    /* cppcheck has a false positive warning for checking the pointer here */
+    /* cppcheck-suppress nullPointerRedundantCheck */
     for (uint32_t i = 0; i < map->capacity; i++) {
         if (map->table[i].key.size) {
             RESULT_GUARD_POSIX(s2n_free(&map->table[i].key));

--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -222,6 +222,10 @@ S2N_RESULT s2n_map_lookup(const struct s2n_map *map, struct s2n_blob *key, struc
 
 S2N_RESULT s2n_map_free(struct s2n_map *map)
 {
+    if (map == NULL) {
+        return S2N_RESULT_OK;
+    }
+
     /* Free the keys and values */
     for (uint32_t i = 0; i < map->capacity; i++) {
         if (map->table[i].key.size) {


### PR DESCRIPTION
### Description of changes: 

We currently don't have any tests to validate that calling `s2n_init` and `s2n_cleanup` repeatedly work correctly. By adding this simple test, I was able to find a few issues and fix them as part of the change.

### Testing:

The code was executed both under ASAN and Valgrind and no longer report any issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
