### PR TITLE
Use getpid() instead of syscall() for Emscripten

### DIFF
--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -33,7 +33,7 @@
  */
 pid_t s2n_actual_getpid()
 {
-#if defined(__GNUC__) && defined(SYS_getpid)
+#if defined(__GNUC__) && defined(SYS_getpid) && !defined(__EMSCRIPTEN__)
     /* http://yarchive.net/comp/linux/getpid_caching.html */
     return (pid_t) syscall(SYS_getpid);
 #else


### PR DESCRIPTION
### Resolved issues:

Resolved undefined symbols error when building for Emscripten

### Description of changes: 

Preprocessor directives in s2n_actual_getpid() use syscall() when building for Emscripten which throws undefined symbols error. I have added an extra check to force using getpid() instead.

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 

### Testing:
The only test I did was building s2n and all of the AWS SDK for C++ using vcpkg which proceeded successfully after the attached changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
