### PR TITLE
pq: enable pq in fips mode

### DIFF
--- a/pq-crypto/s2n_pq.c
+++ b/pq-crypto/s2n_pq.c
@@ -219,7 +219,7 @@ bool s2n_pq_is_enabled() {
 #if defined(S2N_NO_PQ)
     return false;
 #else
-    return !s2n_is_in_fips_mode();
+    return true;
 #endif
 }
 


### PR DESCRIPTION
### Resolved issues:

### Description of changes: 
NIST has [approved](https://csrc.nist.gov/Projects/Post-Quantum-Cryptography/faqs) hybrid key exchange for FIPS mode. This PR therefore enables PQ in FIPS mode.

### Testing:
How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
