### PR TITLE
remove unused function s2n_actual_getpid

### DIFF
--- a/codebuild/bin/cppcheck_suppressions.txt
+++ b/codebuild/bin/cppcheck_suppressions.txt
@@ -6,7 +6,6 @@ variableScope:tests/unit/*
 // Reason: There are many Config options that aren't checked by Cppcheck, and it warns for each. Ignore these so that they don't clutter the output.
 ConfigurationNotChecked:bin/s2nd.c
 ConfigurationNotChecked:tls/s2n_x509_validator.c
-ConfigurationNotChecked:utils/s2n_safety.c
 ConfigurationNotChecked:utils/s2n_socket.c
 
 // cppcheck Message: (style:redundantAssignment) Variable 'mock_time' is reassigned a value before the old one has been used.

--- a/tests/sidetrail/working/patches/safety.patch
+++ b/tests/sidetrail/working/patches/safety.patch
@@ -2,7 +2,7 @@ diff --git a/utils/s2n_safety.c b/utils/s2n_safety.c
 index ae8e5783..cc06a2d0 100644
 --- a/utils/s2n_safety.c
 +++ b/utils/s2n_safety.c
-@@ -57,9 +57,6 @@ pid_t s2n_actual_getpid()
+@@ -57,9 +57,6 @@ s2n_constant_time_equals
   */
  bool s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, const uint32_t len)
  {
@@ -14,7 +14,7 @@ index ae8e5783..cc06a2d0 100644
      if (len == 0) {
          return true;
      }
-@@ -90,10 +87,6 @@ bool s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, const uint32
+@@ -90,10 +87,6 @@ s2n_constant_time_copy_or_dont
   */
  int s2n_constant_time_copy_or_dont(uint8_t * dest, const uint8_t * src, uint32_t len, uint8_t dont)
  {

--- a/utils/s2n_safety.c
+++ b/utils/s2n_safety.c
@@ -13,33 +13,11 @@
  * permissions and limitations under the License.
  */
 
-#define _GNU_SOURCE             /* For syscall on Linux */
-#undef _POSIX_C_SOURCE          /* For syscall() on Mac OS X */
-
-#include <unistd.h>
-#include <sys/syscall.h>
-#include <sys/types.h>
 #include <stdint.h>
 #include <stdio.h>
 
 #include "utils/s2n_annotations.h"
 #include "utils/s2n_safety.h"
-
-/**
- * Get the process id
- *
- * Returns:
- *  The process ID of the current process
- */
-pid_t s2n_actual_getpid()
-{
-#if defined(__GNUC__) && defined(SYS_getpid)
-    /* http://yarchive.net/comp/linux/getpid_caching.html */
-    return (pid_t) syscall(SYS_getpid);
-#else
-    return getpid();
-#endif
-}
 
 /**
  * Given arrays "a" and "b" of length "len", determine whether they

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <string.h>
-#include <sys/types.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -48,14 +47,6 @@ int s2n_in_unit_test_set(bool newval);
 
 #define S2N_IN_INTEG_TEST ( getenv("S2N_INTEG_TEST") != NULL )
 #define S2N_IN_TEST ( s2n_in_unit_test() || S2N_IN_INTEG_TEST )
-
-/**
- * Get the process id
- *
- * Returns:
- *  The process ID of the current process
- */
-extern pid_t s2n_actual_getpid();
 
 /* Returns 1 if a and b are equal, in constant time */
 extern bool s2n_constant_time_equals(const uint8_t * a, const uint8_t * b, const uint32_t len);


### PR DESCRIPTION
### Resolved issues:

 resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.

### Description of changes: 
The function `s2n_actual_getpid` is no longer used.

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
### Testing:
Existing unit tests should pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
