### PR TITLE
Workaround AL2 nodejs package issue

### DIFF
--- a/codebuild/bin/install_al2_dependencies.sh
+++ b/codebuild/bin/install_al2_dependencies.sh
@@ -22,6 +22,7 @@ if [[ ${DISTRO} != "amazon linux" ]]; then
 fi
 
 base_packages() {
+    yum erase -y nodejs
     yum update -y
     yum erase -y openssl-devel || true
     yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm || true


### PR DESCRIPTION
### Resolved issues:

All CodeBuild AL2 jobs failing.

### Description of changes: 

The libuv package's latest version is missing from a repository. We don't need nodejs, so remove it as a workaround.

### Call-outs:

none

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? CI will test this

 Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
