### PR TITLE
Document which macros should not be used for new code

### DIFF
--- a/docs/SAFETY-MACROS.md
+++ b/docs/SAFETY-MACROS.md
@@ -158,6 +158,8 @@ Ensures `(result) >= S2N_SUCCESS`, otherwise the function will return `S2N_RESUL
 
 Ensures `(result) != NULL`, otherwise the function will return `S2N_RESULT_ERROR`
 
+Does not set s2n_errno to S2N_ERR_NULL, so is NOT a direct replacement for RESULT_ENSURE_REF.
+
 
 ## Macros for functions that return `int` (POSIX error signal)
 
@@ -352,6 +354,8 @@ Ensures `(result) >= S2N_SUCCESS`, otherwise the function will return `S2N_FAILU
 
 Ensures `(result) != NULL`, otherwise the function will return `S2N_FAILURE`
 
+Does not set s2n_errno to S2N_ERR_NULL, so is NOT a direct replacement for POSIX_ENSURE_REF.
+
 
 ## Macros for functions that return a pointer
 
@@ -545,4 +549,6 @@ Ensures `(result) >= S2N_SUCCESS`, otherwise the function will return `NULL`
 ### PTR_GUARD_PTR(result)
 
 Ensures `(result) != NULL`, otherwise the function will return `NULL`
+
+Does not set s2n_errno to S2N_ERR_NULL, so is NOT a direct replacement for PTR_ENSURE_REF.
 

--- a/docs/SAFETY-MACROS.md
+++ b/docs/SAFETY-MACROS.md
@@ -164,15 +164,21 @@ Ensures `(result) != NULL`, otherwise the function will return `S2N_RESULT_ERROR
 
 ### POSIX_BAIL(error)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Sets the global `s2n_errno` to `error` and returns with an `S2N_FAILURE`
 
 
 ### POSIX_ENSURE(condition, error)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures the `condition` is `true`, otherwise the function will `POSIX_BAIL` with `error`
 
 
 ### POSIX_DEBUG_ENSURE(condition, error)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures the `condition` is `true`, otherwise the function will `POSIX_BAIL` with `error`
 
@@ -182,6 +188,8 @@ NOTE: The condition will _only_ be checked when the code is compiled in debug mo
 
 ### POSIX_ENSURE_OK(result, error)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `(result) >= S2N_SUCCESS`, otherwise the function will `POSIX_BAIL` with `error`
 
 This can be useful for overriding the global `s2n_errno`
@@ -189,55 +197,77 @@ This can be useful for overriding the global `s2n_errno`
 
 ### POSIX_ENSURE_GTE(a, b)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `a` is greater than or equal to `b`, otherwise the function will `POSIX_BAIL` with a `S2N_ERR_SAFETY` error
 
 
 ### POSIX_ENSURE_LTE(a, b)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures `a` is less than or equal to `b`, otherwise the function will `POSIX_BAIL` with a `S2N_ERR_SAFETY` error
 
 
 ### POSIX_ENSURE_GT(a, b)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `a` is greater than `b`, otherwise the function will `POSIX_BAIL` with a `S2N_ERR_SAFETY` error
 
 
 ### POSIX_ENSURE_LT(a, b)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures `a` is less than `b`, otherwise the function will `POSIX_BAIL` with a `S2N_ERR_SAFETY` error
 
 
 ### POSIX_ENSURE_EQ(a, b)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `a` is equal to `b`, otherwise the function will `POSIX_BAIL` with a `S2N_ERR_SAFETY` error
 
 
 ### POSIX_ENSURE_NE(a, b)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures `a` is not equal to `b`, otherwise the function will `POSIX_BAIL` with a `S2N_ERR_SAFETY` error
 
 
 ### POSIX_ENSURE_INCLUSIVE_RANGE(min, n, max)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `min <= n <= max`, otherwise the function will `POSIX_BAIL` with `S2N_ERR_SAFETY`
 
 
 ### POSIX_ENSURE_EXCLUSIVE_RANGE(min, n, max)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures `min < n < max`, otherwise the function will `POSIX_BAIL` with `S2N_ERR_SAFETY`
 
 
 ### POSIX_ENSURE_REF(x)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `x` is a readable reference, otherwise the function will `POSIX_BAIL` with `S2N_ERR_NULL`
 
 
 ### POSIX_ENSURE_MUT(x)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `x` is a mutable reference, otherwise the function will `POSIX_BAIL` with `S2N_ERR_NULL`
 
 
 ### POSIX_PRECONDITION(result)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures the `result` is `S2N_RESULT_OK`, otherwise the function will return an error signal
 
@@ -247,6 +277,8 @@ but can be altered by a testing environment to provide additional guarantees.
 
 
 ### POSIX_POSTCONDITION(result)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures the `result` is `S2N_RESULT_OK`, otherwise the function will return an error signal
 
@@ -260,6 +292,8 @@ to provide additional guarantees.
 
 
 ### POSIX_CHECKED_MEMCPY(destination, source, len)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Performs a safer memcpy.
 
@@ -276,6 +310,8 @@ Callers will still need to ensure the following:
 
 ### POSIX_CHECKED_MEMSET(destination, value, len)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Performs a safer memset
 
 The following checks are performed:
@@ -290,10 +326,14 @@ Callers will still need to ensure the following:
 
 ### POSIX_GUARD(result)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `(result) >= S2N_SUCCESS`, otherwise the function will return `S2N_FAILURE`
 
 
 ### POSIX_GUARD_OSSL(result, error)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures `result == _OSSL_SUCCESS`, otherwise the function will `POSIX_BAIL` with `error`
 
@@ -318,15 +358,21 @@ Ensures `(result) != NULL`, otherwise the function will return `S2N_FAILURE`
 
 ### PTR_BAIL(error)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Sets the global `s2n_errno` to `error` and returns with an `NULL`
 
 
 ### PTR_ENSURE(condition, error)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures the `condition` is `true`, otherwise the function will `PTR_BAIL` with `error`
 
 
 ### PTR_DEBUG_ENSURE(condition, error)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures the `condition` is `true`, otherwise the function will `PTR_BAIL` with `error`
 
@@ -336,6 +382,8 @@ NOTE: The condition will _only_ be checked when the code is compiled in debug mo
 
 ### PTR_ENSURE_OK(result, error)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `(result) != NULL`, otherwise the function will `PTR_BAIL` with `error`
 
 This can be useful for overriding the global `s2n_errno`
@@ -343,55 +391,77 @@ This can be useful for overriding the global `s2n_errno`
 
 ### PTR_ENSURE_GTE(a, b)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `a` is greater than or equal to `b`, otherwise the function will `PTR_BAIL` with a `S2N_ERR_SAFETY` error
 
 
 ### PTR_ENSURE_LTE(a, b)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures `a` is less than or equal to `b`, otherwise the function will `PTR_BAIL` with a `S2N_ERR_SAFETY` error
 
 
 ### PTR_ENSURE_GT(a, b)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `a` is greater than `b`, otherwise the function will `PTR_BAIL` with a `S2N_ERR_SAFETY` error
 
 
 ### PTR_ENSURE_LT(a, b)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures `a` is less than `b`, otherwise the function will `PTR_BAIL` with a `S2N_ERR_SAFETY` error
 
 
 ### PTR_ENSURE_EQ(a, b)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `a` is equal to `b`, otherwise the function will `PTR_BAIL` with a `S2N_ERR_SAFETY` error
 
 
 ### PTR_ENSURE_NE(a, b)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures `a` is not equal to `b`, otherwise the function will `PTR_BAIL` with a `S2N_ERR_SAFETY` error
 
 
 ### PTR_ENSURE_INCLUSIVE_RANGE(min, n, max)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `min <= n <= max`, otherwise the function will `PTR_BAIL` with `S2N_ERR_SAFETY`
 
 
 ### PTR_ENSURE_EXCLUSIVE_RANGE(min, n, max)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures `min < n < max`, otherwise the function will `PTR_BAIL` with `S2N_ERR_SAFETY`
 
 
 ### PTR_ENSURE_REF(x)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `x` is a readable reference, otherwise the function will `PTR_BAIL` with `S2N_ERR_NULL`
 
 
 ### PTR_ENSURE_MUT(x)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `x` is a mutable reference, otherwise the function will `PTR_BAIL` with `S2N_ERR_NULL`
 
 
 ### PTR_PRECONDITION(result)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures the `result` is `S2N_RESULT_OK`, otherwise the function will return an error signal
 
@@ -401,6 +471,8 @@ but can be altered by a testing environment to provide additional guarantees.
 
 
 ### PTR_POSTCONDITION(result)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures the `result` is `S2N_RESULT_OK`, otherwise the function will return an error signal
 
@@ -414,6 +486,8 @@ to provide additional guarantees.
 
 
 ### PTR_CHECKED_MEMCPY(destination, source, len)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Performs a safer memcpy.
 
@@ -430,6 +504,8 @@ Callers will still need to ensure the following:
 
 ### PTR_CHECKED_MEMSET(destination, value, len)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Performs a safer memset
 
 The following checks are performed:
@@ -444,10 +520,14 @@ Callers will still need to ensure the following:
 
 ### PTR_GUARD(result)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `(result) != NULL`, otherwise the function will return `NULL`
 
 
 ### PTR_GUARD_OSSL(result, error)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures `result == _OSSL_SUCCESS`, otherwise the function will `PTR_BAIL` with `error`
 

--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -294,11 +294,17 @@ extern __thread const char *s2n_debug_str;
 
 #define _S2N_DEBUG_LINE     "Error encountered in " __FILE__ ":" STRING__LINE__
 #define _S2N_ERROR( x )     do { s2n_debug_str = _S2N_DEBUG_LINE; s2n_errno = ( x ); s2n_calculate_stacktrace(); } while (0)
-#define S2N_ERROR( x )      do { _S2N_ERROR( ( x ) ); return -1; } while (0)
 #define S2N_ERROR_PRESERVE_ERRNO() do { return -1; } while (0)
-#define S2N_ERROR_PTR( x )  do { _S2N_ERROR( ( x ) ); return NULL; } while (0)
-#define S2N_ERROR_IF( cond , x ) do { if ( cond ) { S2N_ERROR( x ); }} while (0)
 #define S2N_ERROR_IS_BLOCKING( x )    ( s2n_error_get_type(x) == S2N_ERR_T_BLOCKED )
+
+/* DEPRECATED: use POSIX_BAIL instead */
+#define S2N_ERROR( x )      do { _S2N_ERROR( ( x ) ); return -1; } while (0)
+
+/* DEPRECATED: use PTR_BAIL instead */
+#define S2N_ERROR_PTR( x )  do { _S2N_ERROR( ( x ) ); return NULL; } while (0)
+
+/* DEPRECATED: use POSIX_ENSURE instead */
+#define S2N_ERROR_IF( cond , x ) do { if ( cond ) { S2N_ERROR( x ); }} while (0)
 
 /** Calculate and print stacktraces */
 struct s2n_stacktrace {

--- a/scripts/s2n_safety_macros.py
+++ b/scripts/s2n_safety_macros.py
@@ -662,6 +662,7 @@ docs = """
 # S2N Safety Macros
 """
 checks = []
+deprecation_message = "DEPRECATED: all methods (except those in s2n.h) should return s2n_result."
 
 def push_doc(args):
     args['doc'] = textwrap.dedent(args['doc']).format_map(args).strip()
@@ -683,6 +684,10 @@ for context in CONTEXTS:
         args = {'macro': name}
         args.update(context)
         args.update(value)
+
+        args['doc'] = textwrap.dedent(args['doc']).strip()
+        if context['ret'] != DEFAULT['ret']:
+            args['doc'] = (deprecation_message + "\n\n" + args['doc'])
 
         docs += push_doc(args)
         header += push_macro(args)

--- a/scripts/s2n_safety_macros.py
+++ b/scripts/s2n_safety_macros.py
@@ -704,6 +704,9 @@ for context in CONTEXTS:
     for other in CONTEXTS:
         if len(other['suffix']) > 0:
             doc = 'Ensures `{is_ok}`, otherwise the function will return `{error}`'
+            if other == PTR:
+                doc += '\n\nDoes not set s2n_errno to S2N_ERR_NULL, so is NOT a direct replacement for {prefix}ENSURE_REF.'
+
             impl = '__S2N_ENSURE({is_ok}, return {error})'
             args = {
                 'prefix': context['prefix'],

--- a/utils/s2n_safety_macros.h
+++ b/utils/s2n_safety_macros.h
@@ -201,16 +201,22 @@
 #define RESULT_GUARD_PTR(result)                               __S2N_ENSURE((result) != NULL, return S2N_RESULT_ERROR)
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Sets the global `s2n_errno` to `error` and returns with an `S2N_FAILURE`
  */
 #define POSIX_BAIL(error)                                     do { _S2N_ERROR((error)); return S2N_FAILURE; } while (0)
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures the `condition` is `true`, otherwise the function will `POSIX_BAIL` with `error`
  */
 #define POSIX_ENSURE(condition, error)                        __S2N_ENSURE((condition), POSIX_BAIL(error))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures the `condition` is `true`, otherwise the function will `POSIX_BAIL` with `error`
  *
  * NOTE: The condition will _only_ be checked when the code is compiled in debug mode.
@@ -219,6 +225,8 @@
 #define POSIX_DEBUG_ENSURE(condition, error)                  __S2N_ENSURE_DEBUG((condition), POSIX_BAIL(error))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `(result) >= S2N_SUCCESS`, otherwise the function will `POSIX_BAIL` with `error`
  *
  * This can be useful for overriding the global `s2n_errno`
@@ -226,36 +234,50 @@
 #define POSIX_ENSURE_OK(result, error)                        __S2N_ENSURE((result) >= S2N_SUCCESS, POSIX_BAIL(error))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `a` is greater than or equal to `b`, otherwise the function will `POSIX_BAIL` with a `S2N_ERR_SAFETY` error
  */
 #define POSIX_ENSURE_GTE(a, b)                                __S2N_ENSURE((a) >= (b), POSIX_BAIL(S2N_ERR_SAFETY))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `a` is less than or equal to `b`, otherwise the function will `POSIX_BAIL` with a `S2N_ERR_SAFETY` error
  */
 #define POSIX_ENSURE_LTE(a, b)                                __S2N_ENSURE((a) <= (b), POSIX_BAIL(S2N_ERR_SAFETY))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `a` is greater than `b`, otherwise the function will `POSIX_BAIL` with a `S2N_ERR_SAFETY` error
  */
 #define POSIX_ENSURE_GT(a, b)                                 __S2N_ENSURE((a) > (b), POSIX_BAIL(S2N_ERR_SAFETY))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `a` is less than `b`, otherwise the function will `POSIX_BAIL` with a `S2N_ERR_SAFETY` error
  */
 #define POSIX_ENSURE_LT(a, b)                                 __S2N_ENSURE((a) < (b), POSIX_BAIL(S2N_ERR_SAFETY))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `a` is equal to `b`, otherwise the function will `POSIX_BAIL` with a `S2N_ERR_SAFETY` error
  */
 #define POSIX_ENSURE_EQ(a, b)                                 __S2N_ENSURE((a) == (b), POSIX_BAIL(S2N_ERR_SAFETY))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `a` is not equal to `b`, otherwise the function will `POSIX_BAIL` with a `S2N_ERR_SAFETY` error
  */
 #define POSIX_ENSURE_NE(a, b)                                 __S2N_ENSURE((a) != (b), POSIX_BAIL(S2N_ERR_SAFETY))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `min <= n <= max`, otherwise the function will `POSIX_BAIL` with `S2N_ERR_SAFETY`
  */
 #define POSIX_ENSURE_INCLUSIVE_RANGE(min, n, max)              \
@@ -268,6 +290,8 @@
         } while(0)
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `min < n < max`, otherwise the function will `POSIX_BAIL` with `S2N_ERR_SAFETY`
  */
 #define POSIX_ENSURE_EXCLUSIVE_RANGE(min, n, max)              \
@@ -280,16 +304,22 @@
         } while(0)
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `x` is a readable reference, otherwise the function will `POSIX_BAIL` with `S2N_ERR_NULL`
  */
 #define POSIX_ENSURE_REF(x)                                   __S2N_ENSURE(S2N_OBJECT_PTR_IS_READABLE(x), POSIX_BAIL(S2N_ERR_NULL))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `x` is a mutable reference, otherwise the function will `POSIX_BAIL` with `S2N_ERR_NULL`
  */
 #define POSIX_ENSURE_MUT(x)                                   __S2N_ENSURE(S2N_OBJECT_PTR_IS_WRITABLE(x), POSIX_BAIL(S2N_ERR_NULL))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures the `result` is `S2N_RESULT_OK`, otherwise the function will return an error signal
  *
  * `POSIX_PRECONDITION` should be used at the beginning of a function to make assertions about
@@ -299,6 +329,8 @@
 #define POSIX_PRECONDITION(result)                            POSIX_GUARD_RESULT(__S2N_ENSURE_PRECONDITION((result)))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures the `result` is `S2N_RESULT_OK`, otherwise the function will return an error signal
  *
  * NOTE: The condition will _only_ be checked when the code is compiled in debug mode.
@@ -312,6 +344,8 @@
 #define POSIX_POSTCONDITION(result)                           POSIX_GUARD_RESULT(__S2N_ENSURE_POSTCONDITION((result)))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Performs a safer memcpy.
  *
  * The following checks are performed:
@@ -327,6 +361,8 @@
 #define POSIX_CHECKED_MEMCPY(destination, source, len)        __S2N_ENSURE_SAFE_MEMCPY((destination), (source), (len), POSIX_GUARD_PTR)
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Performs a safer memset
  *
  * The following checks are performed:
@@ -341,11 +377,15 @@
 #define POSIX_CHECKED_MEMSET(destination, value, len)         __S2N_ENSURE_SAFE_MEMSET((destination), (value), (len), POSIX_ENSURE_REF)
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `(result) >= S2N_SUCCESS`, otherwise the function will return `S2N_FAILURE`
  */
 #define POSIX_GUARD(result)                                   __S2N_ENSURE((result) >= S2N_SUCCESS, return S2N_FAILURE)
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `result == _OSSL_SUCCESS`, otherwise the function will `POSIX_BAIL` with `error`
  */
 #define POSIX_GUARD_OSSL(result, error)                       __S2N_ENSURE((result) == _OSSL_SUCCESS, POSIX_BAIL(error))
@@ -366,16 +406,22 @@
 #define POSIX_GUARD_PTR(result)                               __S2N_ENSURE((result) != NULL, return S2N_FAILURE)
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Sets the global `s2n_errno` to `error` and returns with an `NULL`
  */
 #define PTR_BAIL(error)                                       do { _S2N_ERROR((error)); return NULL; } while (0)
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures the `condition` is `true`, otherwise the function will `PTR_BAIL` with `error`
  */
 #define PTR_ENSURE(condition, error)                          __S2N_ENSURE((condition), PTR_BAIL(error))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures the `condition` is `true`, otherwise the function will `PTR_BAIL` with `error`
  *
  * NOTE: The condition will _only_ be checked when the code is compiled in debug mode.
@@ -384,6 +430,8 @@
 #define PTR_DEBUG_ENSURE(condition, error)                    __S2N_ENSURE_DEBUG((condition), PTR_BAIL(error))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `(result) != NULL`, otherwise the function will `PTR_BAIL` with `error`
  *
  * This can be useful for overriding the global `s2n_errno`
@@ -391,36 +439,50 @@
 #define PTR_ENSURE_OK(result, error)                          __S2N_ENSURE((result) != NULL, PTR_BAIL(error))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `a` is greater than or equal to `b`, otherwise the function will `PTR_BAIL` with a `S2N_ERR_SAFETY` error
  */
 #define PTR_ENSURE_GTE(a, b)                                  __S2N_ENSURE((a) >= (b), PTR_BAIL(S2N_ERR_SAFETY))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `a` is less than or equal to `b`, otherwise the function will `PTR_BAIL` with a `S2N_ERR_SAFETY` error
  */
 #define PTR_ENSURE_LTE(a, b)                                  __S2N_ENSURE((a) <= (b), PTR_BAIL(S2N_ERR_SAFETY))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `a` is greater than `b`, otherwise the function will `PTR_BAIL` with a `S2N_ERR_SAFETY` error
  */
 #define PTR_ENSURE_GT(a, b)                                   __S2N_ENSURE((a) > (b), PTR_BAIL(S2N_ERR_SAFETY))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `a` is less than `b`, otherwise the function will `PTR_BAIL` with a `S2N_ERR_SAFETY` error
  */
 #define PTR_ENSURE_LT(a, b)                                   __S2N_ENSURE((a) < (b), PTR_BAIL(S2N_ERR_SAFETY))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `a` is equal to `b`, otherwise the function will `PTR_BAIL` with a `S2N_ERR_SAFETY` error
  */
 #define PTR_ENSURE_EQ(a, b)                                   __S2N_ENSURE((a) == (b), PTR_BAIL(S2N_ERR_SAFETY))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `a` is not equal to `b`, otherwise the function will `PTR_BAIL` with a `S2N_ERR_SAFETY` error
  */
 #define PTR_ENSURE_NE(a, b)                                   __S2N_ENSURE((a) != (b), PTR_BAIL(S2N_ERR_SAFETY))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `min <= n <= max`, otherwise the function will `PTR_BAIL` with `S2N_ERR_SAFETY`
  */
 #define PTR_ENSURE_INCLUSIVE_RANGE(min, n, max)                \
@@ -433,6 +495,8 @@
         } while(0)
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `min < n < max`, otherwise the function will `PTR_BAIL` with `S2N_ERR_SAFETY`
  */
 #define PTR_ENSURE_EXCLUSIVE_RANGE(min, n, max)                \
@@ -445,16 +509,22 @@
         } while(0)
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `x` is a readable reference, otherwise the function will `PTR_BAIL` with `S2N_ERR_NULL`
  */
 #define PTR_ENSURE_REF(x)                                     __S2N_ENSURE(S2N_OBJECT_PTR_IS_READABLE(x), PTR_BAIL(S2N_ERR_NULL))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `x` is a mutable reference, otherwise the function will `PTR_BAIL` with `S2N_ERR_NULL`
  */
 #define PTR_ENSURE_MUT(x)                                     __S2N_ENSURE(S2N_OBJECT_PTR_IS_WRITABLE(x), PTR_BAIL(S2N_ERR_NULL))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures the `result` is `S2N_RESULT_OK`, otherwise the function will return an error signal
  *
  * `PTR_PRECONDITION` should be used at the beginning of a function to make assertions about
@@ -464,6 +534,8 @@
 #define PTR_PRECONDITION(result)                              PTR_GUARD_RESULT(__S2N_ENSURE_PRECONDITION((result)))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures the `result` is `S2N_RESULT_OK`, otherwise the function will return an error signal
  *
  * NOTE: The condition will _only_ be checked when the code is compiled in debug mode.
@@ -477,6 +549,8 @@
 #define PTR_POSTCONDITION(result)                             PTR_GUARD_RESULT(__S2N_ENSURE_POSTCONDITION((result)))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Performs a safer memcpy.
  *
  * The following checks are performed:
@@ -492,6 +566,8 @@
 #define PTR_CHECKED_MEMCPY(destination, source, len)          __S2N_ENSURE_SAFE_MEMCPY((destination), (source), (len), PTR_GUARD_PTR)
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Performs a safer memset
  *
  * The following checks are performed:
@@ -506,11 +582,15 @@
 #define PTR_CHECKED_MEMSET(destination, value, len)           __S2N_ENSURE_SAFE_MEMSET((destination), (value), (len), PTR_ENSURE_REF)
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `(result) != NULL`, otherwise the function will return `NULL`
  */
 #define PTR_GUARD(result)                                     __S2N_ENSURE((result) != NULL, return NULL)
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `result == _OSSL_SUCCESS`, otherwise the function will `PTR_BAIL` with `error`
  */
 #define PTR_GUARD_OSSL(result, error)                         __S2N_ENSURE((result) == _OSSL_SUCCESS, PTR_BAIL(error))

--- a/utils/s2n_safety_macros.h
+++ b/utils/s2n_safety_macros.h
@@ -197,6 +197,8 @@
 
 /**
  * Ensures `(result) != NULL`, otherwise the function will return `S2N_RESULT_ERROR`
+ *
+ * Does not set s2n_errno to S2N_ERR_NULL, so is NOT a direct replacement for RESULT_ENSURE_REF.
  */
 #define RESULT_GUARD_PTR(result)                               __S2N_ENSURE((result) != NULL, return S2N_RESULT_ERROR)
 
@@ -402,6 +404,8 @@
 
 /**
  * Ensures `(result) != NULL`, otherwise the function will return `S2N_FAILURE`
+ *
+ * Does not set s2n_errno to S2N_ERR_NULL, so is NOT a direct replacement for POSIX_ENSURE_REF.
  */
 #define POSIX_GUARD_PTR(result)                               __S2N_ENSURE((result) != NULL, return S2N_FAILURE)
 
@@ -607,6 +611,8 @@
 
 /**
  * Ensures `(result) != NULL`, otherwise the function will return `NULL`
+ *
+ * Does not set s2n_errno to S2N_ERR_NULL, so is NOT a direct replacement for PTR_ENSURE_REF.
  */
 #define PTR_GUARD_PTR(result)                                 __S2N_ENSURE((result) != NULL, return NULL)
 


### PR DESCRIPTION
### Description of changes: 

New developers aren't aware of our preferences for s2n_result and ENSURE. This adds deprecation warnings. They're not enforced, but hopefully they'll provide some guidance.

### Callouts
How does the spacing look? Are the warnings obvious enough?

### Testing:
No functional change, just comments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
