### PR TITLE
Adding API s2n_client_hello_has_extension to check if extension exists

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -344,6 +344,8 @@ extern ssize_t s2n_client_hello_get_extension_length(struct s2n_client_hello *ch
 S2N_API
 extern ssize_t s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length);
 S2N_API
+extern int s2n_client_hello_has_extension(struct s2n_client_hello *ch, uint16_t extension_type, bool *contains);
+S2N_API
 extern int s2n_client_hello_get_session_id_length(struct s2n_client_hello *ch, uint32_t *out_length);
 S2N_API
 extern int s2n_client_hello_get_session_id(struct s2n_client_hello *ch, uint8_t *out, uint32_t *out_length, uint32_t max_length);

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -344,7 +344,7 @@ extern ssize_t s2n_client_hello_get_extension_length(struct s2n_client_hello *ch
 S2N_API
 extern ssize_t s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length);
 S2N_API
-extern int s2n_client_hello_has_extension(struct s2n_client_hello *ch, uint16_t extension_type, bool *contains);
+extern int s2n_client_hello_has_extension(struct s2n_client_hello *ch, uint16_t extension_iana, bool *exists);
 S2N_API
 extern int s2n_client_hello_get_session_id_length(struct s2n_client_hello *ch, uint32_t *out_length);
 S2N_API

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -344,6 +344,14 @@ extern ssize_t s2n_client_hello_get_extension_length(struct s2n_client_hello *ch
 S2N_API
 extern ssize_t s2n_client_hello_get_extension_by_id(struct s2n_client_hello *ch, s2n_tls_extension_type extension_type, uint8_t *out, uint32_t max_length);
 S2N_API
+/**
+ * Used to check if a particular extension exists in the client hello.
+ *
+ * @param ch A pointer to the client hello object
+ * @param extension_iana The iana value of the extension
+ * @param exists A pointer that will be set to whether or not the extension exists
+ */
+S2N_API
 extern int s2n_client_hello_has_extension(struct s2n_client_hello *ch, uint16_t extension_iana, bool *exists);
 S2N_API
 extern int s2n_client_hello_get_session_id_length(struct s2n_client_hello *ch, uint32_t *out_length);

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_hello_has_extension(&conn->client_hello, 0x3374, &exists));
         EXPECT_TRUE(exists);
 
-         /* Succeeds on an unsupported extension with payload */
+        /* Succeeds on an unsupported extension with payload */
         exists = false;
         EXPECT_SUCCESS(s2n_client_hello_has_extension(&conn->client_hello, 0xFF00, &exists));
         EXPECT_TRUE(exists);

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -152,14 +152,14 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(extension.data);
 
         /* Succeeds with extension exists with payload */
-        extension = (struct s2n_blob) { .data = NULL, .size = 0 };
+        extension = (struct s2n_blob) { 0 };
         EXPECT_OK(s2n_client_hello_get_raw_extension(0xFF00, &raw_extension, &extension));
         EXPECT_EQUAL(extension.size, 2);
         EXPECT_NOT_NULL(extension.data);
         EXPECT_BYTEARRAY_EQUAL(extension.data, &data[4], 2);
 
         /* Failed with extension not exist */
-        extension = (struct s2n_blob) { .data = NULL, .size = 0 };
+        extension = (struct s2n_blob) { 0 };
         EXPECT_OK(s2n_client_hello_get_raw_extension(0xFFFF, &raw_extension, &extension));
         EXPECT_EQUAL(extension.size, 0);
         EXPECT_NULL(extension.data);

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
         raw_extension->data = data;
         raw_extension->size = sizeof(data);
 
-        /* Succeeds with NPN extension(0 data) */
+        /* Succeeds on an unsupported extension with no payload */
         bool exists = false;
         EXPECT_SUCCESS(s2n_client_hello_has_extension(&conn->client_hello, 0x3374, &exists));
         EXPECT_TRUE(exists);

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -36,6 +36,7 @@
 #include "tls/s2n_tls_parameters.h"
 
 #include "utils/s2n_safety.h"
+#include "tls/s2n_client_hello.c"
 
 #define ZERO_TO_THIRTY_ONE 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, \
                             0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F
@@ -141,25 +142,22 @@ int main(int argc, char **argv)
         };
         struct s2n_blob raw_extension = {
                 .data = data,
-                .size = sizeof(data);
+                .size = sizeof(data),
         };
 
         struct s2n_blob extension = { 0 };
         /* Succeeds with extension exists without payload */
-        EXPECT_SUCCESS(s2n_client_hello_get_raw_extension(0x3374, &raw_extension, &extension));
+        EXPECT_OK(s2n_client_hello_get_raw_extension(0x3374, &raw_extension, &extension));
         EXPECT_EQUAL(extension.size, 0);
 
         /* Succeeds with extension exists with payload */
-        extension = { 0 };
-        EXPECT_SUCCESS(s2n_client_hello_get_raw_extension(0xFF00, &raw_extension, &extension));
+        EXPECT_OK(s2n_client_hello_get_raw_extension(0xFF00, &raw_extension, &extension));
         EXPECT_EQUAL(extension.size, 2);
         EXPECT_BYTEARRAY_EQUAL(extension.data, &data[4], 2);
 
         /* Failed with extension not exist */
-        extension = { 0 };
-        EXPECT_FAIL(s2n_client_hello_get_raw_extension(0xFFFF, &raw_extension, &extension));
+        EXPECT_ERROR_WITH_ERRNO(s2n_client_hello_get_raw_extension(0xFFFF, &raw_extension, &extension), S2N_ERR_INVALID_ARGUMENT);
         EXPECT_EQUAL(extension.size, 0);
-	EXPECT_EQUAL(s2n_errno, S2N_ERR_INVALID_ARGUMENT);
     }
 
     /* Test setting cert chain on recv */

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_hello_has_extension(&conn->client_hello, 0xFF00, &exists));
         EXPECT_TRUE(exists);
 
-        /* Succeeds with extension not exist */
+        /* Succeeds with an invalid extension */
         exists = false;
         EXPECT_SUCCESS(s2n_client_hello_has_extension(&conn->client_hello, 0xFFFF, &exists));
         EXPECT_FALSE(exists);

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -151,11 +151,13 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(extension.size, 0);
 
         /* Succeeds with extension exists with payload */
+	extension = (struct s2n_blob) { .data = NULL, .size = 0 };
         EXPECT_OK(s2n_client_hello_get_raw_extension(0xFF00, &raw_extension, &extension));
         EXPECT_EQUAL(extension.size, 2);
         EXPECT_BYTEARRAY_EQUAL(extension.data, &data[4], 2);
 
         /* Failed with extension not exist */
+	extension = (struct s2n_blob) { .data = NULL, .size = 0 };
         EXPECT_ERROR_WITH_ERRNO(s2n_client_hello_get_raw_extension(0xFFFF, &raw_extension, &extension), S2N_ERR_INVALID_ARGUMENT);
         EXPECT_EQUAL(extension.size, 0);
     }

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_hello_has_extension(&conn->client_hello, 0x3374, &exists));
         EXPECT_TRUE(exists);
 
-        /* Succeeds get extension with payload */
+         /* Succeeds on an unsupported extension with payload */
         exists = false;
         EXPECT_SUCCESS(s2n_client_hello_has_extension(&conn->client_hello, 0xFF00, &exists));
         EXPECT_TRUE(exists);

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -120,9 +120,9 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_hello_has_extension(&conn->client_hello, 0xFF00, &exists));
         EXPECT_TRUE(exists);
 
-        /* Fails with extension not exist */
+        /* Succeeds with extension not exist */
         exists = false;
-        EXPECT_FAILURE(s2n_client_hello_has_extension(&conn->client_hello, 0xFFFF, &exists));
+        EXPECT_SUCCESS(s2n_client_hello_has_extension(&conn->client_hello, 0xFFFF, &exists));
         EXPECT_FALSE(exists);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -984,7 +984,7 @@ int main(int argc, char **argv)
 
         /* Verify expected result for non-existing extension */
         extension_exists = false;
-        EXPECT_FAILURE(s2n_client_hello_has_extension(client_hello, S2N_EXTENSION_CERTIFICATE_TRANSPARENCY, &extension_exists));
+        EXPECT_SUCCESS(s2n_client_hello_has_extension(client_hello, S2N_EXTENSION_CERTIFICATE_TRANSPARENCY, &extension_exists));
         EXPECT_FALSE(extension_exists);
 
         /* Verify s2n_client_hello_get_session_id is what we received in ClientHello */

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -149,17 +149,20 @@ int main(int argc, char **argv)
         /* Succeeds with extension exists without payload */
         EXPECT_OK(s2n_client_hello_get_raw_extension(0x3374, &raw_extension, &extension));
         EXPECT_EQUAL(extension.size, 0);
+        EXPECT_NOT_NULL(extension.data);
 
         /* Succeeds with extension exists with payload */
-	extension = (struct s2n_blob) { .data = NULL, .size = 0 };
+        extension = (struct s2n_blob) { .data = NULL, .size = 0 };
         EXPECT_OK(s2n_client_hello_get_raw_extension(0xFF00, &raw_extension, &extension));
         EXPECT_EQUAL(extension.size, 2);
+        EXPECT_NOT_NULL(extension.data);
         EXPECT_BYTEARRAY_EQUAL(extension.data, &data[4], 2);
 
         /* Failed with extension not exist */
-	extension = (struct s2n_blob) { .data = NULL, .size = 0 };
-        EXPECT_ERROR_WITH_ERRNO(s2n_client_hello_get_raw_extension(0xFFFF, &raw_extension, &extension), S2N_ERR_INVALID_ARGUMENT);
+        extension = (struct s2n_blob) { .data = NULL, .size = 0 };
+        EXPECT_OK(s2n_client_hello_get_raw_extension(0xFFFF, &raw_extension, &extension));
         EXPECT_EQUAL(extension.size, 0);
+        EXPECT_NULL(extension.data);
     }
 
     /* Test setting cert chain on recv */

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -93,41 +93,39 @@ int main(int argc, char **argv)
 
     /* Test s2n_client_hello_has_extension */
     {
-        {
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
-            uint8_t data[] = {
-                    /* arbitrary extension with 2 data */
-                    0xFF, 0x00, /* extension type */
-                    0x00, 0x02, /* extension payload length */
-                    0xAB, 0xCD, /* extension payload */
-                    /* NPN extension without data */
-                    0x33, 0x74,
-                    0x00, 0x00
-            };
+        uint8_t data[] = {
+                /* arbitrary extension with 2 data */
+                0xFF, 0x00, /* extension type */
+                0x00, 0x02, /* extension payload length */
+                0xAB, 0xCD, /* extension payload */
+                /* NPN extension without data */
+                0x33, 0x74,
+                0x00, 0x00
+        };
 
-            struct s2n_blob *raw_extension = &conn->client_hello.extensions.raw;
-            raw_extension->data = data;
-            raw_extension->size = sizeof(data);
+        struct s2n_blob *raw_extension = &conn->client_hello.extensions.raw;
+        raw_extension->data = data;
+        raw_extension->size = sizeof(data);
 
-            /* Succeeds with NPN extension(0 data) */
-            bool exists = false;
-            EXPECT_SUCCESS(s2n_client_hello_has_extension(&conn->client_hello, 0x3374, &exists));
-            EXPECT_TRUE(exists);
+        /* Succeeds with NPN extension(0 data) */
+        bool exists = false;
+        EXPECT_SUCCESS(s2n_client_hello_has_extension(&conn->client_hello, 0x3374, &exists));
+        EXPECT_TRUE(exists);
 
-            /* Succeeds get extension with payload */
-            exists = false;
-            EXPECT_SUCCESS(s2n_client_hello_has_extension(&conn->client_hello, 0xFF00, &exists));
-            EXPECT_TRUE(exists);
+        /* Succeeds get extension with payload */
+        exists = false;
+        EXPECT_SUCCESS(s2n_client_hello_has_extension(&conn->client_hello, 0xFF00, &exists));
+        EXPECT_TRUE(exists);
 
-            /* Fails with extension not exist */
-            exists = false;
-            EXPECT_FAILURE(s2n_client_hello_has_extension(&conn->client_hello, 0xFFFF, &exists));
-            EXPECT_FALSE(exists);
+        /* Fails with extension not exist */
+        exists = false;
+        EXPECT_FAILURE(s2n_client_hello_has_extension(&conn->client_hello, 0xFFFF, &exists));
+        EXPECT_FALSE(exists);
 
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-        }
+        EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
     /* Test setting cert chain on recv */

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -604,16 +604,17 @@ int s2n_client_hello_get_session_id(struct s2n_client_hello *ch, uint8_t *out, u
     return S2N_SUCCESS;
 }
 
-static S2N_RESULT s2n_client_hello_get_raw_extension(uint16_t expected_extension_type,
+static S2N_RESULT s2n_client_hello_get_raw_extension(uint16_t extension_iana,
         struct s2n_blob *raw_extensions, struct s2n_blob *extension)
 {
-    RESULT_GUARD_PTR(raw_extensions);
+    RESULT_ENSURE_REF(raw_extensions);
+    RESULT_ENSURE_REF(extension);
 
     struct s2n_stuffer raw_extensions_stuffer = { 0 };
     RESULT_GUARD_POSIX(s2n_stuffer_init(&raw_extensions_stuffer, raw_extensions));
     RESULT_GUARD_POSIX(s2n_stuffer_skip_write(&raw_extensions_stuffer, raw_extensions->size));
 
-    while(s2n_stuffer_data_available(&raw_extensions_stuffer) > 0) {
+    while (s2n_stuffer_data_available(&raw_extensions_stuffer) > 0) {
         uint16_t extension_type = 0;
         RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&raw_extensions_stuffer, &extension_type));
 
@@ -623,30 +624,30 @@ static S2N_RESULT s2n_client_hello_get_raw_extension(uint16_t expected_extension
         uint8_t *extension_data = s2n_stuffer_raw_read(&raw_extensions_stuffer, extension_size);
         RESULT_ENSURE_REF(extension_data);
 
-        if (expected_extension_type == extension_type) {
+        if (extension_iana == extension_type) {
             RESULT_GUARD_POSIX(s2n_blob_init(extension, extension_data, extension_size));
             return S2N_RESULT_OK;
         }
     }
-    return S2N_RESULT_ERROR;
+    RESULT_BAIL(S2N_ERR_INVALID_ARGUMENT);
 }
 
-int s2n_client_hello_has_extension(struct s2n_client_hello *ch, uint16_t extension_type, bool *exists) {
+int s2n_client_hello_has_extension(struct s2n_client_hello *ch, uint16_t extension_iana, bool *exists) {
     POSIX_ENSURE_REF(ch);
     POSIX_ENSURE_REF(exists);
 
     *exists = false;
 
-    s2n_parsed_extension *parsed_extension = NULL;
-    if (s2n_client_hello_get_parsed_extension(extension_type, &ch->extensions, &parsed_extension) == S2N_SUCCESS) {
+    s2n_extension_type_id extension_type_id = s2n_unsupported_extension;
+    if (s2n_extension_supported_iana_value_to_id(extension_iana, &extension_type_id) == S2N_SUCCESS) {
+        s2n_parsed_extension *parsed_extension = NULL;
+        POSIX_GUARD(s2n_client_hello_get_parsed_extension(extension_iana, &ch->extensions, &parsed_extension));
         *exists = true;
         return S2N_SUCCESS;
     }
 
     struct s2n_blob extension = { 0 };
-    s2n_result result = s2n_client_hello_get_raw_extension(extension_type, &ch->extensions.raw, &extension);
-    POSIX_GUARD_RESULT(result);
-
+    POSIX_GUARD_RESULT(s2n_client_hello_get_raw_extension(extension_iana, &ch->extensions.raw, &extension));
     *exists = true;
     return S2N_SUCCESS;
 }

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -604,7 +604,7 @@ int s2n_client_hello_get_session_id(struct s2n_client_hello *ch, uint8_t *out, u
     return S2N_SUCCESS;
 }
 
-static s2n_result s2n_client_hello_get_raw_extension(uint16_t expected_extension_type,
+static S2N_RESULT s2n_client_hello_get_raw_extension(uint16_t expected_extension_type,
         struct s2n_blob *raw_extensions, struct s2n_blob *extension)
 {
     RESULT_GUARD_PTR(raw_extensions);
@@ -621,7 +621,7 @@ static s2n_result s2n_client_hello_get_raw_extension(uint16_t expected_extension
         RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&raw_extensions_stuffer, &extension_size));
 
         uint8_t *extension_data = s2n_stuffer_raw_read(&raw_extensions_stuffer, extension_size);
-        RESULT_GUARD_PTR(extension_data);
+        RESULT_ENSURE_REF(extension_data);
 
         if (expected_extension_type == extension_type) {
             RESULT_GUARD_POSIX(s2n_blob_init(extension, extension_data, extension_size));

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -653,7 +653,7 @@ int s2n_client_hello_has_extension(struct s2n_client_hello *ch, uint16_t extensi
     struct s2n_blob extension = { 0 };
     POSIX_GUARD_RESULT(s2n_client_hello_get_raw_extension(extension_iana, &ch->extensions.raw, &extension));
     if (extension.data != NULL) {
-	*exists = true;
+        *exists = true;
     }
     return S2N_SUCCESS;
 }

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -610,6 +610,8 @@ static S2N_RESULT s2n_client_hello_get_raw_extension(uint16_t extension_iana,
     RESULT_ENSURE_REF(raw_extensions);
     RESULT_ENSURE_REF(extension);
 
+    *extension = (struct s2n_blob) { .data = NULL, .size = 0 };
+
     struct s2n_stuffer raw_extensions_stuffer = { 0 };
     RESULT_GUARD_POSIX(s2n_stuffer_init(&raw_extensions_stuffer, raw_extensions));
     RESULT_GUARD_POSIX(s2n_stuffer_skip_write(&raw_extensions_stuffer, raw_extensions->size));
@@ -629,7 +631,7 @@ static S2N_RESULT s2n_client_hello_get_raw_extension(uint16_t extension_iana,
             return S2N_RESULT_OK;
         }
     }
-    RESULT_BAIL(S2N_ERR_INVALID_ARGUMENT);
+    return S2N_RESULT_OK;
 }
 
 int s2n_client_hello_has_extension(struct s2n_client_hello *ch, uint16_t extension_iana, bool *exists)
@@ -649,8 +651,9 @@ int s2n_client_hello_has_extension(struct s2n_client_hello *ch, uint16_t extensi
     }
 
     struct s2n_blob extension = { 0 };
-    if (s2n_result_is_ok(s2n_client_hello_get_raw_extension(extension_iana, &ch->extensions.raw, &extension))) {
-        *exists = true;
+    POSIX_GUARD_RESULT(s2n_client_hello_get_raw_extension(extension_iana, &ch->extensions.raw, &extension));
+    if (extension.data != NULL) {
+	*exists = true;
     }
     return S2N_SUCCESS;
 }

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -632,7 +632,8 @@ static S2N_RESULT s2n_client_hello_get_raw_extension(uint16_t extension_iana,
     RESULT_BAIL(S2N_ERR_INVALID_ARGUMENT);
 }
 
-int s2n_client_hello_has_extension(struct s2n_client_hello *ch, uint16_t extension_iana, bool *exists) {
+int s2n_client_hello_has_extension(struct s2n_client_hello *ch, uint16_t extension_iana, bool *exists)
+{
     POSIX_ENSURE_REF(ch);
     POSIX_ENSURE_REF(exists);
 

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -642,13 +642,15 @@ int s2n_client_hello_has_extension(struct s2n_client_hello *ch, uint16_t extensi
     s2n_extension_type_id extension_type_id = s2n_unsupported_extension;
     if (s2n_extension_supported_iana_value_to_id(extension_iana, &extension_type_id) == S2N_SUCCESS) {
         s2n_parsed_extension *parsed_extension = NULL;
-        POSIX_GUARD(s2n_client_hello_get_parsed_extension(extension_iana, &ch->extensions, &parsed_extension));
-        *exists = true;
+        if (s2n_client_hello_get_parsed_extension(extension_iana, &ch->extensions, &parsed_extension) == S2N_SUCCESS) {
+            *exists = true;
+        }
         return S2N_SUCCESS;
     }
 
     struct s2n_blob extension = { 0 };
-    POSIX_GUARD_RESULT(s2n_client_hello_get_raw_extension(extension_iana, &ch->extensions.raw, &extension));
-    *exists = true;
+    if (s2n_result_is_ok(s2n_client_hello_get_raw_extension(extension_iana, &ch->extensions.raw, &extension))) {
+        *exists = true;
+    }
     return S2N_SUCCESS;
 }

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -610,7 +610,7 @@ static S2N_RESULT s2n_client_hello_get_raw_extension(uint16_t extension_iana,
     RESULT_ENSURE_REF(raw_extensions);
     RESULT_ENSURE_REF(extension);
 
-    *extension = (struct s2n_blob) { .data = NULL, .size = 0 };
+    *extension = (struct s2n_blob) { 0 };
 
     struct s2n_stuffer raw_extensions_stuffer = { 0 };
     RESULT_GUARD_POSIX(s2n_stuffer_init(&raw_extensions_stuffer, raw_extensions));


### PR DESCRIPTION
### Resolved issues:

 resolves #3175

### Description of changes: 

At this moment, if extension does not supported by s2n, to get such extension from client hello, we need to call `s2n_client_hello_get_extensions` and then parse and extract given extension from the list.

This change introduces API `s2n_client_hello_has_extension` to check if given extension exists in client hello or not. 

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
```
cmake . -Bbuild -DCMAKE_EXE_LINKER_FLAGS="-lcrypto -lz" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
cmake --build ./build -j $(nproc)
CTEST_PARALLEL_LEVEL=$(nproc) make -C build test
```

 Is this a refactor change? No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
