### PR TITLE
Freebsd ci

### DIFF
--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -16,7 +16,6 @@ jobs:
       id: test
       uses: vmactions/freebsd-vm@v0.1.5
       with:
-        sync: sshfs
         prepare: pkg install -y ninja cmake
         run: |
           setenv CTEST_PARALLEL_LEVEL `sysctl hw.ncpu | awk '{print $2}'`
@@ -25,6 +24,7 @@ jobs:
           cmake . -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug
           cmake --build ./build -j $CTEST_PARALLEL_LEVEL
           ninja -C build test
+          cmake --build ./build --target clean #Saves on copy back rsync time
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@master

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -1,0 +1,32 @@
+name: FreeBSD
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  testfreebsd:
+    runs-on: macos-10.15
+    name: CI FreeBSD
+    env:
+      MYTOKEN : ${{ secrets.MYTOKEN }}
+      MYTOKEN2: "value2"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build and test in FreeBSD
+      id: test
+      uses: vmactions/freebsd-vm@v0.1.5
+      with:
+        copyback: false
+        prepare: pkg install -y ninja cmake
+        run: |
+          pwd
+          ls -lah
+          env
+          freebsd-version
+          cmake . -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug
+          cmake --build ./build -j 4
+          export CTEST_PARALLEL_LEVEL=4
+          ninja -C build test

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -22,11 +22,9 @@ jobs:
         copyback: false
         prepare: pkg install -y ninja cmake
         run: |
-          pwd
-          ls -lah
+          setenv CTEST_PARALLEL_LEVEL `sysctl hw.ncpu | awk '{print $2}'`
           env
           freebsd-version
           cmake . -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug
-          cmake --build ./build -j 4
-          export CTEST_PARALLEL_LEVEL=4
+          cmake --build ./build -j $CTEST_PARALLEL_LEVEL
           ninja -C build test

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -10,16 +10,13 @@ jobs:
   testfreebsd:
     runs-on: macos-10.15
     name: CI FreeBSD
-    env:
-      MYTOKEN : ${{ secrets.MYTOKEN }}
-      MYTOKEN2: "value2"
     steps:
     - uses: actions/checkout@v2
     - name: Build and test in FreeBSD
       id: test
       uses: vmactions/freebsd-vm@v0.1.5
       with:
-        copyback: false
+        sync: sshfs
         prepare: pkg install -y ninja cmake
         run: |
           setenv CTEST_PARALLEL_LEVEL `sysctl hw.ncpu | awk '{print $2}'`
@@ -28,3 +25,9 @@ jobs:
           cmake . -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug
           cmake --build ./build -j $CTEST_PARALLEL_LEVEL
           ninja -C build test
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@master
+      with:
+        name: all_test_output
+        path: build/Testing/Temporary

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -15,7 +15,8 @@
 
 
 #ifdef __FreeBSD__
-/* FreeBSD requires POSIX compatibility off for its syscalls (enables __BSD_VISIBLE)*/
+/* FreeBSD requires POSIX compatibility off for its syscalls (enables __BSD_VISIBLE)
+ * Without the below line, <sys/user.h> cannot be imported (it requires __BSD_VISIBLE) */
 #undef _POSIX_C_SOURCE
 #include <sys/types.h>
 #include <sys/sysctl.h>
@@ -83,8 +84,7 @@ ssize_t get_vm_data_size()
     pidinfo[2] = KERN_PROC_PID;
     pidinfo[3] = (int)ppid;
 
-    struct kinfo_proc procinfo;
-    segsz_t lsize;
+    struct kinfo_proc procinfo = {0};
 
     size_t len = sizeof(procinfo);
 
@@ -92,7 +92,7 @@ ssize_t get_vm_data_size()
 
     /* Taken from linprocfs implementation
      * https://github.com/freebsd/freebsd-src/blob/779fd05344662aeec79c29470258bf657318eab3/sys/compat/linprocfs/linprocfs.c#L1019 */
-    lsize = (procinfo.ki_size >> PAGE_SHIFT) - procinfo.ki_dsize - procinfo.ki_ssize - procinfo.ki_tsize - 1;
+    segsz_t lsize = (procinfo.ki_size >> PAGE_SHIFT) - procinfo.ki_dsize - procinfo.ki_ssize - procinfo.ki_tsize - 1;
 
     return lsize << PAGE_SHIFT;
 #else

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -43,7 +43,6 @@ void mock_client(struct s2n_test_io_pair *io_pair)
     sleep(1);
 
     conn = s2n_connection_new(S2N_CLIENT);
-    TEST_DEBUG_PRINT("Client connected %ld\n", time(0));
     config = s2n_config_new();
     s2n_config_disable_x509_verification(config);
     s2n_connection_set_config(conn, config);
@@ -54,7 +53,6 @@ void mock_client(struct s2n_test_io_pair *io_pair)
     if (result < 0) {
         exit(1);
     }
-    TEST_DEBUG_PRINT("Client handshake complete %ld\n", time(0));
 
     result = s2n_connection_free_handshake(conn);
     if (result < 0) {
@@ -69,11 +67,9 @@ void mock_client(struct s2n_test_io_pair *io_pair)
     s2n_io_pair_shutdown_one_end(io_pair, S2N_CLIENT, SHUT_RD);
 #endif
     /* Give server a chance to send data on broken pipe */
-    TEST_DEBUG_PRINT("Client shut down read %ld\n", time(0));
     sleep(2);
 
     s2n_shutdown(conn, &blocked);
-    TEST_DEBUG_PRINT("Client s2n shut down %ld\n", time(0));
 
     result = s2n_connection_free(conn);
     if (result < 0) {
@@ -89,7 +85,6 @@ void mock_client(struct s2n_test_io_pair *io_pair)
     sleep(1);
 
     s2n_io_pair_shutdown_one_end(io_pair, S2N_CLIENT, SHUT_WR);
-    TEST_DEBUG_PRINT("Client final write shutdown %ld\n", time(0));
 
     _exit(0);
 }
@@ -152,20 +147,17 @@ int main(int argc, char **argv)
         /* Negotiate the handshake. */
         EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
         EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS12);
-        TEST_DEBUG_PRINT("Server negotiate %ld\n", time(0));
 
         /* Give client a chance to close pipe at the receiving end */
         sleep(1);
         char buffer[1];
         /* Fist flush on half closed pipe should get EPIPE */
-        TEST_DEBUG_PRINT("Server send %ld\n", time(0));
         size_t w = s2n_send(conn, buffer, 1, &blocked);
         EXPECT_EQUAL(w, -1);
         EXPECT_EQUAL(s2n_errno, S2N_ERR_IO);
         EXPECT_EQUAL(errno, EPIPE);
 
         /* Second flush on half closed pipe should not get EPIPE as we write is skipped */
-        TEST_DEBUG_PRINT("Server shutdown %ld\n", time(0));
         w = s2n_shutdown(conn, &blocked);
         EXPECT_EQUAL(w, -1);
         EXPECT_EQUAL(s2n_errno, S2N_ERR_IO);

--- a/tests/unit/s2n_self_talk_nonblocking_test.c
+++ b/tests/unit/s2n_self_talk_nonblocking_test.c
@@ -307,8 +307,8 @@ int test_send(int use_tls13, int use_iov, int prefer_throughput)
     while (remaining) {
         int r = !use_iov ? s2n_send(conn, ptr, remaining, &blocked) :
             s2n_sendv_with_offset(conn, iov, iov_size, iov_offs, &blocked);
-        /* We will up to send_at_least_percent bytes, after which the client will block itself.
-         * This allows us to cover the case which s2n_send gets EAGAIN on the very first call
+        /* We will send up to send_at_least_percent bytes, after which the client will block itself.
+         * This allows us to cover the case where s2n_send gets EAGAIN on the very first call
          * which can happen on certain platforms. By making sure we've successfully sent something
          * we can ensure write -> block -> client drain -> write ordering.*/
         if (r < 0 && PERCENT_COMPLETE(remaining, data_size) <= minimum_send_percent) {


### PR DESCRIPTION
### Resolved issues:

 resolves #3109, resolves #3100 

### Description of changes: 
No CI/CD integration currently exists for FreeBSD. This change adds a github actions step which uses https://github.com/vmactions/freebsd-vm to run the build and the unit tests on a FreeBSD VM. This change includes a new github action, and changes to three tests which were failing on FreeBSD (see Testing below).

Detailed test log output is available as a run artifact that is held on to by github actions for 90 days. To view the test logs, first select the github actions run, select "Summary" and then choose the artifact "all_test_output":

<img width="1134" alt="Screen Shot 2022-01-27 at 1 50 45 PM" src="https://user-images.githubusercontent.com/7329298/151450038-3cd4dd96-9eae-4ad2-a418-5c1960269e73.png">

### Call-outs:
See my notes on s2n_self_talk_nonblocking_test below. I'd love to have a maintainer validate my findings and agree with me that it is in fact ok for s2n_send to block on the very first call.

### Testing:

There are no changes to the s2n code, but I did have to make some adjustments to three unit tests to ensure they run properly on FreeBSD:

* s2n_mem_usage_test
This was a specifically Linux only test (I don't think it works on MacOS or Windows either?). I added support for reading allocation sizes from FreeBSD, and adjusted some thresholds based on OS specific allocation behavior

* s2n_self_talk_broken_pipe_test
This test was relying a behavior that is unimplemented in FreeBSD, as far as I can tell. In Linux, when you shutdown() one end of a socketpair(), future writes on the other end of the socket get a EPIPE. FreeBSD requires you to do a full on close() to force the EPIPE.

* s2n_self_talk_nonblocking_test
This one was tricky and took a lot of debugging to understand what was going on. Basically, the flow of this test was as follows:
1. Client and server processes are spawned.
2. The client process is expressly blocked with a SIGSTOP
3. The server calls s2n_send on a blob of data that is large enough to fill the socket given that the client is blocked.
4. The server repeats step 3 until s2n_send hits EAGAIN from the socket. 
5. The server then checks that it was able to send some, but not all of the data blob.
6. The server wakes the client so it can drain the socket
7. The server switches the socket to blocking, and then sends the rest of the data.

It seems that FreeBSD has a particular behavior that was causing issues for this test. It seems that for a socketpair(), FreeBSD will block after receiving only 8K of data. When using s2n_connection_prefer_throughput(), s2n_flush will try to send larger chunks of data at a time (in this case 16K). If an s2n_flush gets blocked halfway through sending a chunk it will surface the EAGAIN and the s2n_send with propagate it back to the calling application. So s2n_send will return -1 and surface a blocked error, giving the impression that 0 bytes were sent (even though 8k was accepted by the socket). This should be fine from the calling application's perspective, because the only thing to do is wait for the socket to drain and call s2n_send again, which will succeed next time and return the total 16K bytes sent. The only reason this broke the tests is that they were assuming that the first s2n_send will always send more than 0 bytes.

I fixed this by only blocking the client application after s2n_send was called successfully at least once. This should allow the test logic to work as is. 
