### PR TITLE
Flush stdout in initial BEGIN_TEST message

### DIFF
--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -50,6 +50,7 @@ int test_count;
     S2N_TEST_OPTIONALLY_ENABLE_FIPS_MODE();                    \
     EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init());                  \
     fprintf(stdout, "Running %-50s ... ", __FILE__);           \
+    fflush(stdout);                                            \
   } while(0)
 
 #define END_TEST()   do { \


### PR DESCRIPTION
### Description of changes: 

Each unit test suite is encapsulated in `BEGIN_TEST` and `END_TEST` macro's. An initial message is printed to `stdout` by the former macro:
```
fprintf(stdout, "Running %-50s ... ", __FILE__);
```
When writing a test suite that initially forks a number of child processes, the kernel sometimes still have the data buffered for the `stdout` fd, before the fork is executed. In a 3-fork test suite this creates the following output:
```
$ ./bin/s2n_foo_test 
Running ../tests/unit/s2n_foo_test.c    ... In child 0
Running ../tests/unit/s2n_foo_test.c    ... In child 1
Running ../tests/unit/s2n_foo_test.c    ... In child 2
Running ../tests/unit/s2n_foo_test.c    ... PASSED          3 tests
```
which is not the intention. To prevent this, simply flush `stdout`.

### Testing:

**Before change:**
```
$ ./bin/s2n_foo_test 
Running ../tests/unit/s2n_foo_test.c    ... In child 0
Running ../tests/unit/s2n_foo_test.c    ... In child 1
Running ../tests/unit/s2n_foo_test.c    ... In child 2
Running ../tests/unit/s2n_foo_test.c    ... PASSED          3 tests
```

**After change:**
```
$ ./bin/s2n_foo_test 
Running ../tests/unit/s2n_foo_test.c    ... In child 0
In child 1
In child 2
PASSED          3 tests
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
