### PR TITLE
Revert "Flush stdout with initial BEGIN_TEST message (#3185)"

### DIFF
--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -50,7 +50,6 @@ int test_count;
     S2N_TEST_OPTIONALLY_ENABLE_FIPS_MODE();                    \
     EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init());                  \
     fprintf(stdout, "Running %-50s ... ", __FILE__);           \
-    fflush(stdout);                                            \
   } while(0)
 
 #define END_TEST()   do { \


### PR DESCRIPTION
This reverts commit 1f2adbe0c45d3d24ede5f5ea7f9fef5c38888054.

### Description of changes: 
Some of our CI jobs run unit tests in parallel. Unfortunately, after [this change](https://github.com/aws/s2n-tls/pull/3185), that led to jumbled output like:
```
Running s2n_pq_kem_hybrid_kat_test.c                       ... Running s2n_auth_selection_test.c                          ... PASSED        353 tests
Running s2n_hash_test.c                                    ... Running s2n_tls13_zero_length_payload_test.c               ... PASSED        459 tests
PASSED         57 tests
Running s2n_client_auth_handshake_test.c                   ... SKIPPED       ALL tests
Running s2n_cipher_suites_test.c                           ... Running s2n_mutual_auth_test.c                             ... PASSED     266490 tests
Running s2n_tls_prf_test.c                                 ... PASSED         12 tests
```
(See [here](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoidUpNb2QzNjZzQ3lrWm1UQ2xzdFZMN1ZGYWE5dVlSQ1ZKd1BnZzZ6aXN1dlZXTmFuZWdvNnR0SitPaFlIcUdjaDZ6RU9KemY2Mi9ybXVBajF0RXo4NmZ1Rnl4dkZrT241UUY4MTVQMkRuNTQ9IiwiaXZQYXJhbWV0ZXJTcGVjIjoiemFRUDgvZUMreVhER0RKaiIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D/build/4fc1a813-aa00-4c03-b066-7e2bff2a9c05) for the full output)

I prefer the repeated "Running" messages present without the flush. Maybe the repetition is a feature: it's /very/ clear what test each message is associated with :)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
