### PR TITLE
bindings: update rust bindings

### DIFF
--- a/bindings/rust/integration/Cargo.toml
+++ b/bindings/rust/integration/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-s2n-tls = { version = "0.1", path = "../s2n-tls", features = ["testing"] }
+s2n-tls = { version = "0.0.2", path = "../s2n-tls", features = ["testing"] }
 s2n-tls-sys = { version = "0.0.2", path = "../s2n-tls-sys" }
 criterion = { version = "0.3", features = ["html_reports"] }
 

--- a/bindings/rust/integration/Cargo.toml
+++ b/bindings/rust/integration/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 s2n-tls = { version = "0.1", path = "../s2n-tls", features = ["testing"] }
-s2n-tls-sys = { version = "0.1", path = "../s2n-tls-sys" }
+s2n-tls-sys = { version = "0.0.2", path = "../s2n-tls-sys" }
 criterion = { version = "0.3", features = ["html_reports"] }
 
 [[bench]]

--- a/bindings/rust/s2n-tls-sys/Cargo.toml
+++ b/bindings/rust/s2n-tls-sys/Cargo.toml
@@ -24,7 +24,9 @@ quic = []
 
 [dependencies]
 libc = "0.2"
-openssl-sys = { version = "<= 0.9.68" } # Pin to this version until s2n-tls supports OpenSSL 3.0
+# NOTE: The version of the `openssl-sys` crate is not the same as OpenSSL itself.
+#       Versions 1.0.1 - 3.0.0 are automatically discovered.
+openssl-sys = { version = "0.9" }
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }

--- a/bindings/rust/s2n-tls-sys/Cargo.toml
+++ b/bindings/rust/s2n-tls-sys/Cargo.toml
@@ -1,10 +1,21 @@
 [package]
 name = "s2n-tls-sys"
-version = "0.1.0"
+description = "A C99 implementation of the TLS/SSL protocols"
+version = "0.0.2"
 authors = ["AWS s2n"]
 edition = "2018"
 links = "s2n-tls"
+repository = "https://github.com/aws/s2n-tls"
 license = "Apache-2.0"
+include = [
+  "build.rs",
+  "Cargo.toml",
+  "files.rs",
+  "lib/**/*.c",
+  "lib/**/*.h",
+  "src/**/*.rs",
+  "tests/**/*.rs",
+]
 
 [features]
 default = []
@@ -13,7 +24,7 @@ quic = []
 
 [dependencies]
 libc = "0.2"
-openssl-sys = { version = "0.9" }
+openssl-sys = { version = "<= 0.9.68" } # Pin to this version until s2n-tls supports OpenSSL 3.0
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }

--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -7,14 +7,15 @@ license = "Apache-2.0"
 
 [features]
 default = []
-quic = []
+quic = ["s2n-tls-sys/quic"]
+pq = ["s2n-tls-sys/pq"]
 testing = ["errno", "bytes"]
 
 [dependencies]
 bytes = { version = "1", optional = true }
 errno = { version = "0.2", optional = true }
 libc = "0.2"
-s2n-tls-sys = { version = "0.1", path = "../s2n-tls-sys" }
+s2n-tls-sys = { version = "0.0.2", path = "../s2n-tls-sys" }
 
 [dev-dependencies]
 bytes = { version = "1" }

--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-tls"
-version = "0.1.0"
+version = "0.0.2"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"

--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "s2n-tls"
+description = "A C99 implementation of the TLS/SSL protocols"
 version = "0.0.2"
 authors = ["AWS s2n"]
 edition = "2018"
+repository = "https://github.com/aws/s2n-tls"
 license = "Apache-2.0"
 
 [features]

--- a/bindings/rust/s2n-tls/src/raw.rs
+++ b/bindings/rust/s2n-tls/src/raw.rs
@@ -9,4 +9,4 @@ pub mod connection;
 pub mod init;
 pub mod security;
 
-pub use s2n_tls_sys as fii;
+pub use s2n_tls_sys as ffi;

--- a/bindings/rust/s2n-tls/src/raw/error.rs
+++ b/bindings/rust/s2n-tls/src/raw/error.rs
@@ -109,6 +109,22 @@ impl Error {
             Self::Code(code) => unsafe { s2n_error_get_type(*code) as _ },
         }
     }
+
+    pub fn alert(&self) -> Option<u8> {
+        match self {
+            Self::InvalidInput => None,
+            Self::Code(_code) => {
+                None
+                // TODO: We should use the new s2n-tls method
+                //       once it's available.
+                // let mut alert = 0;
+                // match call!(s2n_error_get_alert(*code, &mut alert)) {
+                //     Ok(_) => Some(alert),
+                //     Err(_) => None,
+                // }
+            }
+        }
+    }
 }
 
 /// # Safety

--- a/bindings/rust/s2n-tls/src/raw/security.rs
+++ b/bindings/rust/s2n-tls/src/raw/security.rs
@@ -31,4 +31,4 @@ macro_rules! policy {
 policy!(DEFAULT, "default");
 policy!(DEFAULT_TLS13, "default_tls13");
 
-pub const ALL_POLICIES: &'static [Policy] = &[DEFAULT, DEFAULT_TLS13];
+pub const ALL_POLICIES: &[Policy] = &[DEFAULT, DEFAULT_TLS13];


### PR DESCRIPTION
### Description of changes: 

This change includes a few updates for the Rust bindings to prepare for an initial release to crates.io. I've set the version number at `0.0.2` to convey the stability of them at this point in time.

Note than openssl-sys does support loading OpenSSL 3.0, if that's what's in the path. We should probably prioritize #1808 so applications don't have to worry about what version is installed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
