### PR TITLE
Added try_compile for features.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,13 @@ try_compile(
         SOURCES "${CMAKE_CURRENT_LIST_DIR}/tests/features/cpuid.c"
 )
 
+# Determine if features.h is available
+try_compile(
+        S2N_FEATURES_AVAILABLE
+        ${CMAKE_BINARY_DIR}
+        SOURCES "${CMAKE_CURRENT_LIST_DIR}/tests/features/features.c"
+)
+
 # Determine if __attribute__((fallthrough)) is available
 try_compile(
         FALL_THROUGH_SUPPORTED
@@ -374,6 +381,10 @@ endif()
 
 if(S2N_CPUID_AVAILABLE)
     target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_CPUID_AVAILABLE)
+endif()
+
+if(S2N_FEATURES_AVAILABLE)
+    target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_FEATURES_AVAILABLE)
 endif()
 
 target_compile_options(${PROJECT_NAME} PUBLIC -fPIC)

--- a/s2n.mk
+++ b/s2n.mk
@@ -181,6 +181,12 @@ ifeq ($(TRY_COMPILE_CPUID), 0)
 	DEFAULT_CFLAGS += -DS2N_CPUID_AVAILABLE
 endif
 
+# Determine if features.h is availabe
+TRY_COMPILE_FEATURES := $(call try_compile,$(S2N_ROOT)/tests/features/features.c)
+ifeq ($(TRY_COMPILE_FEATURES), 0)
+	DEFAULT_CFLAGS += -DS2N_FEATURES_AVAILABLE
+endif
+
 # Determine if __attribute__((fallthrough)) is available
 TRY_COMPILE_FALL_THROUGH := $(call try_compile,$(S2N_ROOT)/tests/features/fallthrough.c)
 ifeq ($(TRY_COMPILE_FALL_THROUGH), 0)

--- a/tests/features/features.c
+++ b/tests/features/features.c
@@ -14,4 +14,6 @@
  */
 
 #include <features.h>
-int main() { return 0; }
+int main() {
+    return 0;
+}

--- a/tests/features/features.c
+++ b/tests/features/features.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <features.h>
+int main() { return 0; }

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -14,8 +14,8 @@
  */
 
 #define  _DEFAULT_SOURCE 1
-#if defined(DS2N_FEATURES_AVAILABLE)
-    #include <features.h>
+#if defined(S2N_FEATURES_AVAILABLE)
+#include <features.h>
 #endif
 
 #include <stdint.h>

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -14,8 +14,8 @@
  */
 
 #define  _DEFAULT_SOURCE 1
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__NetBSD__)
-#include <features.h>
+#if defined(DS2N_FEATURES_AVAILABLE)
+    #include <features.h>
 #endif
 
 #include <stdint.h>


### PR DESCRIPTION
### Resolved issues:

 resolves #3132

### Description of changes: 

Removes all of the checks for specific operating systems and creates a try compile in both make and cmake to test that this header file can be included.
### Call-outs:

### Testing:

Wasn't exactly sure how to test this besides just compiling with make and cmake? Can confirm that I was able to run s2n_mem_usage_test which uses the file with this include statement (ran test on linux operating system). I guess since our CI now has a FreeBSD build that should suffice?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
