### PR TITLE
Criterion subprocess wellknownendpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,16 @@ DEV_VERSION ?= ubuntu_18.04_$(DEV_OPENSSL_VERSION)_gcc9
 dev:
 	@docker run -it --rm --ulimit memlock=-1 -v `pwd`:/home/s2n-dev/s2n $(DEV_IMAGE):$(DEV_VERSION)
 
+.PHONY : install
+install: bin libs
+	$(MAKE) -C bin install
+	$(MAKE) -C lib install
+
+.PHONY: uninstall
+uninstall:
+	$(MAKE) -C bin uninstall
+	$(MAKE) -C lib uninstall
+
 .PHONY : clean
 clean:
 	$(MAKE) -C pq-crypto clean

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -25,3 +25,12 @@ s2nc: s2nc.c echo.c
 
 s2nd: s2nd.c echo.c
 	${CC} ${CFLAGS} s2nd.c echo.c https.c common.c -o s2nd ${LDFLAGS}
+
+$(bindir):
+	@mkdir -p $(bindir)
+
+install: s2nc s2nd $(bindir)
+	@cp s2n? $(bindir)
+
+uninstall:
+	@rm $(bindir)/s2n?

--- a/bindings/rust/Makefile
+++ b/bindings/rust/Makefile
@@ -1,0 +1,17 @@
+SHELL := /bin/bash
+
+bench: target/release/deps/s2nc-%
+
+bindings: RUSTBINDINGS
+
+.EXPORT_ALL_VARIABLES:
+OPENSSL_DIR = $(value LIBCRYPTO_ROOT)
+
+RUSTBINDINGS = ./s2n-tls-sys/src/api.rs
+
+RUSTBINDINGS: generate/src/main.rs
+	@OPENSSL_DIR=$(OPENSSL_DIR) ./generate.sh
+
+target/release/deps/s2nc-%:
+	@OPENSSL_DIR=$(OPENSSL_DIR) cargo bench --no-run
+

--- a/bindings/rust/Makefile
+++ b/bindings/rust/Makefile
@@ -1,17 +1,14 @@
 SHELL := /bin/bash
 
-bench: target/release/deps/s2nc-%
-
-bindings: RUSTBINDINGS
-
-.EXPORT_ALL_VARIABLES:
-OPENSSL_DIR = $(value LIBCRYPTO_ROOT)
-
-RUSTBINDINGS = ./s2n-tls-sys/src/api.rs
-
-RUSTBINDINGS: generate/src/main.rs
-	@OPENSSL_DIR=$(OPENSSL_DIR) ./generate.sh
+all: s2n-tls-sys/src/api.rs target/release/deps/s2nc-%
 
 target/release/deps/s2nc-%:
-	@OPENSSL_DIR=$(OPENSSL_DIR) cargo bench --no-run
+	cargo bench --no-run
 
+s2n-tls-sys/src/api.rs:
+	./generate.sh
+
+.PHONY: clean
+clean:
+	@cargo clean
+	@rm -f s2n-tls-sys/src/api.rs target/release/deps/s2nc-* target/release/deps/s2nd-*

--- a/bindings/rust/integration/Cargo.toml
+++ b/bindings/rust/integration/Cargo.toml
@@ -9,7 +9,16 @@ publish = false
 s2n-tls = { version = "0.0.2", path = "../s2n-tls", features = ["testing"] }
 s2n-tls-sys = { version = "0.0.2", path = "../s2n-tls-sys" }
 criterion = { version = "0.3", features = ["html_reports"] }
+subprocess = "0.2.8"
 
 [[bench]]
 name = "handshake"
+harness = false
+
+[[bench]]
+name = "s2nc"
+harness = false
+
+[[bench]]
+name = "s2nd"
 harness = false

--- a/bindings/rust/integration/benches/s2nc.rs
+++ b/bindings/rust/integration/benches/s2nc.rs
@@ -6,6 +6,7 @@ use std::{
     dbg, env,
     io::{self, Write},
     process::Command,
+    time::Duration,
 };
 mod utils;
 
@@ -34,5 +35,7 @@ pub fn s2nc(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, s2nc);
+criterion_group!(name = benches;
+                 config = Criterion::default().sample_size(10).measurement_time(Duration::from_secs(1));
+                 targets = s2nc);
 criterion_main!(benches);

--- a/bindings/rust/integration/benches/s2nc.rs
+++ b/bindings/rust/integration/benches/s2nc.rs
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::{
+    dbg, env,
+    io::{self, Write},
+    process::Command,
+};
+
+pub fn s2nc(c: &mut Criterion) {
+    let mut group = c.benchmark_group("s2nc");
+    let test_name = format!("s2nc");
+    group.bench_function(test_name, move |b| {
+        b.iter(|| {
+            let s2nc_args = env::var("S2NC_ARGS").unwrap();
+            let s2nc_args_split = s2nc_args.split(' ');
+            let s2nc_args_vec = s2nc_args_split.collect::<Vec<&str>>();
+            dbg!("DEBUG: S2NC_ARGS {:?}", &s2nc_args_vec);
+            assert_ne!(s2nc_args.len(), 0);
+            let output = Command::new("/opt/s2n/bin/s2nc")
+                .args(s2nc_args_vec)
+                .output()
+                .expect("failed to execute process");
+
+            io::stdout().write_all(&output.stdout).unwrap();
+            io::stderr().write_all(&output.stderr).unwrap();
+            dbg!("DEBUG: return code {:?}", &output.status);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, s2nc);
+criterion_main!(benches);

--- a/bindings/rust/integration/benches/s2nc.rs
+++ b/bindings/rust/integration/benches/s2nc.rs
@@ -25,7 +25,6 @@ pub fn s2nc(c: &mut Criterion) {
                 .args(s2nc_args.get_vec())
                 .output()
                 .expect("failed to execute process");
-
             io::stdout().write_all(&output.stdout).unwrap();
             io::stderr().write_all(&output.stderr).unwrap();
             dbg!("DEBUG: return code {:?}", &output.status);

--- a/bindings/rust/integration/benches/s2nc.rs
+++ b/bindings/rust/integration/benches/s2nc.rs
@@ -7,19 +7,21 @@ use std::{
     io::{self, Write},
     process::Command,
 };
+mod utils;
 
 pub fn s2nc(c: &mut Criterion) {
     let mut group = c.benchmark_group("s2nc");
-    let test_name = format!("s2nc");
+    let s2nc_env: &str = &env::var("S2NC_ARGS").unwrap();
+    let s2nc_args: utils::Arguments = s2nc_env.into();
+    let test_name = format!("s2nc{:?}", s2nc_args.get_endpoint().unwrap());
+
     group.bench_function(test_name, move |b| {
         b.iter(|| {
-            let s2nc_args = env::var("S2NC_ARGS").unwrap();
-            let s2nc_args_split = s2nc_args.split(' ');
-            let s2nc_args_vec = s2nc_args_split.collect::<Vec<&str>>();
-            dbg!("DEBUG: S2NC_ARGS {:?}", &s2nc_args_vec);
-            assert_ne!(s2nc_args.len(), 0);
-            let output = Command::new("/opt/s2n/bin/s2nc")
-                .args(s2nc_args_vec)
+            let s2nc_env: &str = &env::var("S2NC_ARGS").unwrap();
+            let s2nc_args: utils::Arguments = s2nc_env.into();
+            dbg!("s2nc harness: {:?}", &s2nc_args);
+            let output = Command::new("/usr/local/bin/s2nc")
+                .args(s2nc_args.get_vec())
                 .output()
                 .expect("failed to execute process");
 

--- a/bindings/rust/integration/benches/s2nc.rs
+++ b/bindings/rust/integration/benches/s2nc.rs
@@ -14,8 +14,8 @@ pub fn s2nc(c: &mut Criterion) {
     let mut group = c.benchmark_group("s2nc");
     let s2nc_env: &str = &env::var("S2NC_ARGS").unwrap();
     let s2nc_args: utils::Arguments = s2nc_env.into();
-    let test_name = format!("s2nc{:?}", s2nc_args.get_endpoint().unwrap());
-
+    let test_name = format!("s2nc_{}", s2nc_args.get_endpoint().unwrap());
+    dbg!("Parsed test_name as: {:?}", &test_name);
     group.bench_function(test_name, move |b| {
         b.iter(|| {
             let s2nc_env: &str = &env::var("S2NC_ARGS").unwrap();

--- a/bindings/rust/integration/benches/s2nd.rs
+++ b/bindings/rust/integration/benches/s2nd.rs
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::{
+    env,
+    io::{self, Write},
+    process::Command,
+};
+
+pub fn s2nd(c: &mut Criterion) {
+    let mut group = c.benchmark_group("s2n_server");
+    group.bench_function(
+        format!("{:?}_s2nd", env::var("TOX_TEST_NAME").unwrap()),
+        move |b| {
+            b.iter(|| {
+                let s2nd_args = env::var("S2ND_ARGS").unwrap();
+                assert_ne!(s2nd_args.len(), 0);
+                let output = Command::new("/opt/s2n/bin/s2nd")
+                    .arg(s2nd_args)
+                    .output()
+                    .expect("failed to execute process");
+
+                io::stdout().write_all(&output.stdout).unwrap();
+                io::stderr().write_all(&output.stderr).unwrap();
+            });
+        },
+    );
+
+    group.finish();
+}
+
+criterion_group!(benches, s2nd);
+criterion_main!(benches);

--- a/bindings/rust/integration/benches/s2nd.rs
+++ b/bindings/rust/integration/benches/s2nd.rs
@@ -16,7 +16,7 @@ pub fn s2nd(c: &mut Criterion) {
             b.iter(|| {
                 let s2nd_args = env::var("S2ND_ARGS").unwrap();
                 assert_ne!(s2nd_args.len(), 0);
-                let output = Command::new("/opt/s2n/bin/s2nd")
+                let output = Command::new("/usr/local/bin/s2nd")
                     .arg(s2nd_args)
                     .output()
                     .expect("failed to execute process");

--- a/bindings/rust/integration/benches/utils.rs
+++ b/bindings/rust/integration/benches/utils.rs
@@ -1,0 +1,58 @@
+#[derive(Debug, Clone)]
+pub struct Arguments<'a> {
+    argument: Vec<&'a str>,
+}
+
+impl<'a> From<&'a str> for Arguments<'a> {
+    fn from(s: &'a str) -> Arguments<'a> {
+        assert_ne!(s.len(), 0, "Arguments string can not be empty");
+        let s_split = s.split(' ');
+        Arguments {
+            argument: s_split.collect::<Vec<&str>>(),
+        }
+    }
+}
+
+impl<'a> Arguments<'a> {
+    pub fn get_dash_c(self) -> Result<&'a str, ()> {
+        let mut counter = 0;
+        for element in &self.argument {
+            counter += 1;
+            if element.eq(&"-c") {
+                return Ok(self.argument[counter]);
+            }
+        }
+        Err(())
+    }
+
+    pub fn get_endpoint(self) -> Result<&'a str, ()> {
+        let mut counter = 0;
+        for element in &self.argument {
+            counter += 1;
+            if element.eq(&"-c") {
+                return Ok(self.argument[counter + 1]);
+            }
+        }
+        Err(())
+    }
+
+    pub fn get_vec(self) -> Vec<&'a str> {
+        self.argument
+    }
+}
+
+#[test]
+fn argument_get_dash_c_test() {
+    let args: Arguments = "reset --hard --force -c foo.pem".into();
+    assert_eq!(
+        args.get_dash_c().unwrap(),
+        "foo.pem",
+        "Failed to fetch the correct argument"
+    );
+}
+
+#[test]
+#[should_panic]
+fn argument_empty_test() {
+    let _a: Arguments = "".into();
+}

--- a/bindings/rust/integration/benches/utils.rs
+++ b/bindings/rust/integration/benches/utils.rs
@@ -14,6 +14,7 @@ impl<'a> From<&'a str> for Arguments<'a> {
 }
 
 impl<'a> Arguments<'a> {
+    #[allow(dead_code)]
     pub fn get_dash_c(self) -> Result<&'a str, ()> {
         let mut counter = 0;
         for element in &self.argument {

--- a/bindings/rust/integration/benches/utils.rs
+++ b/bindings/rust/integration/benches/utils.rs
@@ -31,7 +31,8 @@ impl<'a> Arguments<'a> {
         for element in &self.argument {
             counter += 1;
             if element.eq(&"-c") {
-                return Ok(self.argument[counter + 1]);
+                let result = self.argument[counter + 1].trim_end_matches("_").trim_start_matches("_");
+                return Ok(result);
             }
         }
         Err(())

--- a/codebuild/bin/criterion_baseline.sh
+++ b/codebuild/bin/criterion_baseline.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
 set -eu
 source codebuild/bin/utils.sh
 

--- a/codebuild/bin/criterion_baseline.sh
+++ b/codebuild/bin/criterion_baseline.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#!/bin/bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").

--- a/codebuild/bin/criterion_baseline.sh
+++ b/codebuild/bin/criterion_baseline.sh
@@ -1,25 +1,42 @@
 #!/usr/bin/env bash
-set -eux
-AWS_S3_URL="s3://s2n-tls-logs/main"
+set -eu
 source codebuild/bin/utils.sh
+
+AWS_S3_URL="s3://s2n-tls-logs/release/"
 
 install_deps(){
     make install
-    . $HOME/.cargo/env
+    source "$HOME"/.cargo/env
     make -C bindings/rust
 }
 
+
+# There can be only one artifact config per batch job,
+# so we're scipting the baseline upload steps here.
+upload_artifacts(){
+  cd tests/integrationv2/target/criterion
+  echo "Creating zip ${AWS_S3_PATH}"
+  zip -r "${AWS_S3_PATH}" ./*
+  aws s3 cp "${AWS_S3_PATH}" "${AWS_S3_URL}"
+  echo "S3 upload complete"
+}
 
 if [ -d "third-party-src" ]; then
   # Don't run against c.a.c.
   return 0
 fi
+
+# Fetch creds and the latest release number.
 gh_login s2n_codebuild_PRs
 get_latest_release
-zip_count=$(aws s3 ls ${S3_FULLPATH}|wc -l||true)
+AWS_S3_PATH="integv2criterion_${INTEGV2_TEST}_${LATEST_RELEASE_VER}.zip"
+
+zip_count=$(aws s3 ls "${AWS_S3_URL}${AWS_S3_PATH}"|wc -l||true)
 if [ "$zip_count" -eq 0 ]; then
+  echo "File ${AWS_S3_URL}${AWS_S3_PATH} not found"
   install_deps
-  TOX_TEST_NAME=$INTEGV2_TEST.py make integrationv2
+  TOX_TEST_NAME=${INTEGV2_TEST}.py make integrationv2
+  upload_artifacts
 else
-  echo "Found existing artifact for $RELEASE_VER, not rebuilding."
+  echo "Found existing artifact for ${LATEST_RELEASE_VER}, not rebuilding."
 fi

--- a/codebuild/bin/criterion_baseline.sh
+++ b/codebuild/bin/criterion_baseline.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -eux
+AWS_S3_URL="s3://s2n-tls-logs/main"
+source codebuild/bin/utils.sh
+
+install_deps(){
+    make install
+    . $HOME/.cargo/env
+    make -C bindings/rust
+}
+
+
+if [ -d "third-party-src" ]; then
+  # Don't run against c.a.c.
+  return 0
+fi
+gh_login s2n_codebuild_PRs
+get_latest_release
+zip_count=$(aws s3 ls ${S3_FULLPATH}|wc -l||true)
+if [ "$zip_count" -eq 0 ]; then
+  install_deps
+  TOX_TEST_NAME=$INTEGV2_TEST.py make integrationv2
+else
+  echo "Found existing artifact for $RELEASE_VER, not rebuilding."
+fi

--- a/codebuild/bin/criterion_delta.sh
+++ b/codebuild/bin/criterion_delta.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -eu
+source ./codebuild/bin/utils.sh
+
+make install
+source $HOME/.cargo/env
+make -C bindings/rust
+TOX_TEST_NAME="$INTEGV2_TEST".py make integrationv2

--- a/codebuild/bin/criterion_delta.sh
+++ b/codebuild/bin/criterion_delta.sh
@@ -18,4 +18,5 @@ source ./codebuild/bin/utils.sh
 make install
 source $HOME/.cargo/env
 make -C bindings/rust
-TOX_TEST_NAME="$INTEGV2_TEST".py make integrationv2
+S2N_USECRITERION=1 TOX_TEST_NAME="$INTEGV2_TEST".py make integrationv2
+S2N_USECRITERION=3 TOX_TEST_NAME="$INTEGV2_TEST".py make integrationv2

--- a/codebuild/bin/install_ubuntu_dependencies.sh
+++ b/codebuild/bin/install_ubuntu_dependencies.sh
@@ -16,20 +16,33 @@
 # Shim code to get local docker/ec2 instances bootstraped like a CodeBuild instance.
 # Not actually used by CodeBuild.
 
-set -ex
+set -e
 
-add-apt-repository ppa:ubuntu-toolchain-r/test -y
-add-apt-repository ppa:longsleep/golang-backports -y
-apt-get update -o Acquire::CompressionTypes::Order::=gz
+get_rust() {
+  apt install -y clang-10 sudo
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+  source $HOME/.cargo/env
+  rustup default nightly
+}
 
-DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python3-pip python3-testresources llvm curl git tox cmake libtool ninja-build golang-go quilt"
+base_packages() {
+  echo "Installing repositories and base packages"
+  apt update -y
+  apt install -y software-properties-common
+  add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  add-apt-repository ppa:longsleep/golang-backports -y
+  apt-get update -o Acquire::CompressionTypes::Order::=gz
 
-
-if [[ -n "$GCC_VERSION" ]] && [[ "$GCC_VERSION" != "NONE" ]]; then
+  DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python3-pip python3-testresources llvm curl git tox cmake libtool ninja-build golang-go quilt"
+  if [[ -n "${GCC_VERSION:-}" ]] && [[ "${GCC_VERSION:-}" != "NONE" ]]; then
     DEPENDENCIES+=" gcc-$GCC_VERSION g++-$GCC_VERSION";
-fi
+  fi
 
-apt-get -y install --no-install-recommends ${DEPENDENCIES}
+  apt-get -y install --no-install-recommends ${DEPENDENCIES}
+}
+
+base_packages
+get_rust
 
 # If prlimit is not on our current PATH, download and compile prlimit manually. s2n needs prlimit to memlock pages
 if ! type prlimit > /dev/null && [[ ! -d "$PRLIMIT_INSTALL_DIR" ]]; then

--- a/codebuild/bin/install_ubuntu_dependencies.sh
+++ b/codebuild/bin/install_ubuntu_dependencies.sh
@@ -18,6 +18,10 @@
 
 set -e
 
+github_apt(){
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list
+}
 get_rust() {
   apt install -y clang-10 sudo
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -33,7 +37,7 @@ base_packages() {
   add-apt-repository ppa:longsleep/golang-backports -y
   apt-get update -o Acquire::CompressionTypes::Order::=gz
 
-  DEPENDENCIES="unzip make indent kwstyle libssl-dev tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config gcc g++ zlibc zlib1g-dev python3-pip python3-testresources llvm curl git tox cmake libtool ninja-build golang-go quilt"
+  DEPENDENCIES="unzip make indent iproute2 kwstyle libssl-dev net-tools  tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config psmisc gcc g++ zlibc zlib1g-dev python3-pip python3-testresources llvm curl shellcheck git tox cmake libtool ninja-build golang-go quilt gh netbase"
   if [[ -n "${GCC_VERSION:-}" ]] && [[ "${GCC_VERSION:-}" != "NONE" ]]; then
     DEPENDENCIES+=" gcc-$GCC_VERSION g++-$GCC_VERSION";
   fi
@@ -41,6 +45,8 @@ base_packages() {
   apt-get -y install --no-install-recommends ${DEPENDENCIES}
 }
 
+
+github_apt
 base_packages
 get_rust
 

--- a/codebuild/bin/install_ubuntu_dependencies.sh
+++ b/codebuild/bin/install_ubuntu_dependencies.sh
@@ -21,6 +21,8 @@ set -e
 github_apt(){
   curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list
+  apt update -y
+  apt install -y gh
 }
 get_rust() {
   apt install -y clang-10 sudo
@@ -37,7 +39,7 @@ base_packages() {
   add-apt-repository ppa:longsleep/golang-backports -y
   apt-get update -o Acquire::CompressionTypes::Order::=gz
 
-  DEPENDENCIES="unzip make indent iproute2 kwstyle libssl-dev net-tools  tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config psmisc gcc g++ zlibc zlib1g-dev python3-pip python3-testresources llvm curl shellcheck git tox cmake libtool ninja-build golang-go quilt gh netbase"
+  DEPENDENCIES="unzip make indent iproute2 kwstyle libssl-dev net-tools  tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config psmisc gcc g++ zlibc zlib1g-dev python3-pip python3-testresources llvm curl shellcheck git tox cmake libtool ninja-build golang-go quilt jq"
   if [[ -n "${GCC_VERSION:-}" ]] && [[ "${GCC_VERSION:-}" != "NONE" ]]; then
     DEPENDENCIES+=" gcc-$GCC_VERSION g++-$GCC_VERSION";
   fi
@@ -46,8 +48,8 @@ base_packages() {
 }
 
 
-github_apt
 base_packages
+github_apt
 get_rust
 
 # If prlimit is not on our current PATH, download and compile prlimit manually. s2n needs prlimit to memlock pages

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -75,7 +75,7 @@ if [[ "$TESTS" == "ALL" || "$TESTS" == "asan" ]]; then make clean; S2N_ADDRESS_S
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integration" ]]; then make clean; S2N_NO_SSLYZE=1 make integration ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2" ]]; then make clean; make integrationv2 ; fi
 # Env must have S2N_USECRITERION set for the following to work
-if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2crit" ]]; then make install; make -C bindings/rust bench; make -C tests/integrationv2 ${INTEGV2_TEST}; fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2crit" ]]; then make install; make -C bindings/rust ; make -C tests/integrationv2 "${INTEGV2_TEST}"; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "fuzz" ]]; then (make clean && make fuzz) ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "benchmark" ]]; then (make clean && make benchmark) ; fi
 if [[ "$TESTS" == "sawHMAC" ]] && [[ "$OS_NAME" == "linux" ]]; then make -C tests/saw/ tmp/verify_HMAC.log ; fi

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -74,7 +74,8 @@ if [[ "$TESTS" == "ALL" || "$TESTS" == "interning" ]]; then ./codebuild/bin/test
 if [[ "$TESTS" == "ALL" || "$TESTS" == "asan" ]]; then make clean; S2N_ADDRESS_SANITIZER=1 make -j $JOBS ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integration" ]]; then make clean; S2N_NO_SSLYZE=1 make integration ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2" ]]; then make clean; make integrationv2 ; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2crit" ]]; then make clean; make install; make -C bindings/rust bench; export S2N_USECRITERION=1; export XDIST_WORKERS=1; make integrationv2 ; fi
+# Env must have S2N_USECRITERION set for the following to work
+if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2crit" ]]; then make install; make -C bindings/rust bench; export XDIST_WORKERS=1; make -C tests/integrationv2 ${INTEGV2_TEST}; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "fuzz" ]]; then (make clean && make fuzz) ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "benchmark" ]]; then (make clean && make benchmark) ; fi
 if [[ "$TESTS" == "sawHMAC" ]] && [[ "$OS_NAME" == "linux" ]]; then make -C tests/saw/ tmp/verify_HMAC.log ; fi

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -75,7 +75,7 @@ if [[ "$TESTS" == "ALL" || "$TESTS" == "asan" ]]; then make clean; S2N_ADDRESS_S
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integration" ]]; then make clean; S2N_NO_SSLYZE=1 make integration ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2" ]]; then make clean; make integrationv2 ; fi
 # Env must have S2N_USECRITERION set for the following to work
-if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2crit" ]]; then make install; make -C bindings/rust bench; export XDIST_WORKERS=1; make -C tests/integrationv2 ${INTEGV2_TEST}; fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2crit" ]]; then make install; make -C bindings/rust bench; make -C tests/integrationv2 ${INTEGV2_TEST}; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "fuzz" ]]; then (make clean && make fuzz) ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "benchmark" ]]; then (make clean && make benchmark) ; fi
 if [[ "$TESTS" == "sawHMAC" ]] && [[ "$OS_NAME" == "linux" ]]; then make -C tests/saw/ tmp/verify_HMAC.log ; fi

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -74,6 +74,7 @@ if [[ "$TESTS" == "ALL" || "$TESTS" == "interning" ]]; then ./codebuild/bin/test
 if [[ "$TESTS" == "ALL" || "$TESTS" == "asan" ]]; then make clean; S2N_ADDRESS_SANITIZER=1 make -j $JOBS ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integration" ]]; then make clean; S2N_NO_SSLYZE=1 make integration ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2" ]]; then make clean; make integrationv2 ; fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2crit" ]]; then make clean; make install; make -C bindings/rust bench; export S2N_USECRITERION=1; export XDIST_WORKERS=1; make integrationv2 ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "fuzz" ]]; then (make clean && make fuzz) ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "benchmark" ]]; then (make clean && make benchmark) ; fi
 if [[ "$TESTS" == "sawHMAC" ]] && [[ "$OS_NAME" == "linux" ]]; then make -C tests/saw/ tmp/verify_HMAC.log ; fi

--- a/codebuild/bin/utils.sh
+++ b/codebuild/bin/utils.sh
@@ -1,7 +1,7 @@
 # Utility functions
 get_latest_release(){
     export LATEST_RELEASE_URL=$(gh api /repos/aws/s2n-tls/releases/latest|jq -r '.tarball_url')
-    export LATEST_RELEASE_VER=$(echo $RELEASE_URL | sed 's|.*/||')
+    export LATEST_RELEASE_VER=$(echo $LATEST_RELEASE_URL | sed 's|.*/||')
 }
 
 gh_login(){

--- a/codebuild/bin/utils.sh
+++ b/codebuild/bin/utils.sh
@@ -6,7 +6,6 @@ get_latest_release(){
 
 gh_login(){
   # Takes secrets manager key as an argument
-  TOKEN=$(aws secretsmanager get-secret-value --secret-id "$1" --query 'SecretString' --output text |jq -r '.secret_key')
-  echo "$TOKEN"|gh auth login --with-token
+  aws secretsmanager get-secret-value --secret-id "$1" --query 'SecretString' --output text |jq -r '.secret_key'| gh auth login --with-token
   gh auth status
 }

--- a/codebuild/bin/utils.sh
+++ b/codebuild/bin/utils.sh
@@ -1,11 +1,47 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+set -e
+
 # Utility functions
 get_latest_release(){
-    export LATEST_RELEASE_URL=$(gh api /repos/aws/s2n-tls/releases/latest|jq -r '.tarball_url')
-    export LATEST_RELEASE_VER=$(echo $LATEST_RELEASE_URL | sed 's|.*/||')
+    LATEST_RELEASE_URL=$(gh api /repos/aws/s2n-tls/releases/latest|jq -r '.tarball_url')
+    LATEST_RELEASE_VER=$(echo "${LATEST_RELEASE_URL}" | sed 's|.*/||')
+    export LATEST_RELEASE_URL
+    export LATEST_RELEASE_VER
 }
 
 gh_login(){
-  # Takes secrets manager key as an argument
-  aws secretsmanager get-secret-value --secret-id "$1" --query 'SecretString' --output text |jq -r '.secret_key'| gh auth login --with-token
-  gh auth status
+    # Takes secrets manager key as an argument
+    aws secretsmanager get-secret-value --secret-id "$1" --query 'SecretString' --output text |jq -r '.secret_key'| gh auth login --with-token
+    #gh auth status
 }
+
+usage(){
+    echo -e "Usage:\n\tget_latest_release: returns just the latest v.N.N.N version"
+    echo -e "\tgh_login <Secret Name> : retrieves a GitHub PAT from secrest manager and logs into GitHub.\n"
+}
+
+if [[ "${BASH_SOURCE[0]}" != "${0}"  ]]; then
+    echo "Sourced utils.sh"
+else
+    case "${1:-}" in
+        "gh_login")
+            gh_login "${2:-}";;
+        "get_latest_release")
+            get_latest_release
+            echo "$LATEST_RELEASE_VER";;
+        *)  usage;
+    esac
+fi

--- a/codebuild/bin/utils.sh
+++ b/codebuild/bin/utils.sh
@@ -1,0 +1,12 @@
+# Utility functions
+get_latest_release(){
+    export LATEST_RELEASE_URL=$(gh api /repos/aws/s2n-tls/releases/latest|jq -r '.tarball_url')
+    export LATEST_RELEASE_VER=$(echo $RELEASE_URL | sed 's|.*/||')
+}
+
+gh_login(){
+  # Takes secrets manager key as an argument
+  TOKEN=$(aws secretsmanager get-secret-value --secret-id "$1" --query 'SecretString' --output text |jq -r '.secret_key')
+  echo "$TOKEN"|gh auth login --with-token
+  gh auth status
+}

--- a/codebuild/spec/README.md
+++ b/codebuild/spec/README.md
@@ -1,0 +1,9 @@
+### CodeBuild Buildspec files
+
+CodeBuild supports two ways of getting a jobs configuration: as part of the git repository, or inline.
+
+Due to security issues around running CodeBuild jobs
+with external contributors spec files, many of our CodeBuild spec files are being inlined.
+
+The inline directory has buildspecs that are just for reference/backup and do not actually affect running jobs.
+

--- a/codebuild/spec/buildspec_ubuntu_integv2criterion_baseline.yml
+++ b/codebuild/spec/buildspec_ubuntu_integv2criterion_baseline.yml
@@ -1,0 +1,28 @@
+---
+version: 0.2
+env:
+  variables:
+    # CODEBUILD_ is a reserved namespace.
+    CB_BIN_DIR: "./codebuild/bin"
+phases:
+  install:
+    runtime-versions:
+      python: 3.x
+    commands:
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - $CB_BIN_DIR/install_ubuntu_dependencies.sh
+  build:
+    commands:
+      - $CB_BIN_DIR/criterion_baseline.sh
+
+artifacts:
+  files:
+    - "**/index.html"
+    - "**/*.svg"
+    - "**/*.json"
+  base-directory: "bindings/rust/target/criterion"
+  name: integv2criterion_${INTEGV2_TEST}_${RELEASE_VER}.zip
+  discard-paths: no

--- a/codebuild/spec/buildspec_ubuntu_integv2criterion_baseline.yml
+++ b/codebuild/spec/buildspec_ubuntu_integv2criterion_baseline.yml
@@ -17,4 +17,14 @@ phases:
   build:
     commands:
       - $CB_BIN_DIR/criterion_baseline.sh
+      - mkdir -p bindings/rust/target/criterion
+      - echo "{id:$CODEBUILD_BUILD_ID}" >> bindings/rust/target/criterion/artifact.json
+
+artifacts:
+  files:
+    - "**/index.html"
+    - "**/*.svg"
+    - "**/*.json"
+  base-directory: "bindings/rust/target/criterion"
+  discard-paths: no
 

--- a/codebuild/spec/buildspec_ubuntu_integv2criterion_baseline.yml
+++ b/codebuild/spec/buildspec_ubuntu_integv2criterion_baseline.yml
@@ -18,11 +18,3 @@ phases:
     commands:
       - $CB_BIN_DIR/criterion_baseline.sh
 
-artifacts:
-  files:
-    - "**/index.html"
-    - "**/*.svg"
-    - "**/*.json"
-  base-directory: "bindings/rust/target/criterion"
-  name: integv2criterion_${INTEGV2_TEST}_${RELEASE_VER}.zip
-  discard-paths: no

--- a/codebuild/spec/buildspec_ubuntu_integv2criterion_baseline.yml
+++ b/codebuild/spec/buildspec_ubuntu_integv2criterion_baseline.yml
@@ -17,14 +17,14 @@ phases:
   build:
     commands:
       - $CB_BIN_DIR/criterion_baseline.sh
-      - mkdir -p bindings/rust/target/criterion
-      - echo "{id:$CODEBUILD_BUILD_ID}" >> bindings/rust/target/criterion/artifact.json
+      - mkdir -p tests/integrationv2/target/criterion
+      - echo "{id:$CODEBUILD_BUILD_ID}" >> tests/integrationv2/target/criterion/artifact.json
 
 artifacts:
   files:
     - "**/index.html"
     - "**/*.svg"
     - "**/*.json"
-  base-directory: "bindings/rust/target/criterion"
+  base-directory: "tests/integrationv2/target/criterion"
   discard-paths: no
 

--- a/codebuild/spec/inline/buildspec_benchmark.yml
+++ b/codebuild/spec/inline/buildspec_benchmark.yml
@@ -1,0 +1,59 @@
+---
+version: 0.2
+env:
+  variables:
+    ARTIFACT_BUCKET: s3://s2n-tls-logs/main
+    ARTIFACT_FILE: benchmark
+batch:
+  build-list:
+    - identifier: handshake
+      compute-type: BUILD_GENERAL1_SMALL
+      env:
+        LATEST_CLANG: true
+        S2N_LIBCRYPTO: openssl-1.1.1
+phases:
+  install:
+    runtime-versions:
+      python: 3.9
+    commands:
+      - curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+      - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list
+      - ./codebuild/bin/install_ubuntu_dependencies.sh
+      - apt install -y clang-10 sudo gh
+      - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - . $HOME/.cargo/env
+      - rustup default nightly
+      - ./codebuild/bin/install_openssl_1_1_1.sh $(mktemp -d) $(pwd)/test-deps/openssl-1.1.1 linux
+      - cd ./bindings/rust
+      - OPENSSL_DIR=$(pwd)/../../test-deps/openssl-1.1.1 ./generate.sh
+  pre_build:
+    commands:
+      - mkdir -p target/criterion || true
+      - aws s3 cp ${ARTIFACT_BUCKET}/${ARTIFACT_FILE}_$(date +%Y-%m-%d).zip .
+      - unzip -o ${ARTIFACT_FILE}_$(date +%Y-%m-%d).zip -d ./target/criterion
+  build:
+    commands:
+      - cargo bench --bench $CODEBUILD_BATCH_BUILD_IDENTIFIER -- --load-baseline new --baseline main | tee bench.log
+  post_build:
+    commands:
+      - echo "Checking for negative results..."
+      - test $(grep -c 'Performance has regressed' ./bench.log ) -eq 0
+      - echo "Checking for positive/netrual results (must be > 0)"
+      - test $(grep -ce 'No change' -e 'Change within noise' -e 'Performance has improved' ./bench.log) -gt 0
+      - echo "Updating PR with a comment"
+      - TOKEN=$(aws secretsmanager get-secret-value --secret-id s2n_codebuild_PRs --query 'SecretString' --output text |jq -r '.secret_key')
+      - echo "$TOKEN"|gh auth login --with-token
+      - GITHUB_PR=$(echo $CODEBUILD_WEBHOOK_TRIGGER|sed 's|pr/||')
+      - JOB_ID=$(echo $CODEBUILD_BUILD_ID|cut -d ":" -f 2)
+      - BASE_URL=https://d17xuyslvs6yyp.cloudfront.net/reports
+      - REPORT_URL="$BASE_URL/$JOB_ID/handshake-s2nBenchmarkBatch/report/index.html"
+      - echo "[Benchmark report]($REPORT_URL)" > pr_comment
+      - grep -ie 'Change ' -ie 'Performance ' bench.log |sort|uniq >> pr_comment
+      - gh pr comment $GITHUB_PR --repo aws/s2n-tls --body-file pr_comment || true
+artifacts:
+  files:
+    - "**/index.html"
+    - "**/*.svg"
+    - "**/*.json"
+  base-directory: "bindings/rust/target/criterion"
+  discard-paths: no

--- a/codebuild/spec/inline/buildspec_benchmark_scheduled.yml
+++ b/codebuild/spec/inline/buildspec_benchmark_scheduled.yml
@@ -1,0 +1,46 @@
+---
+version: 0.2
+batch:
+  build-list:
+    - identifier: handshake
+      compute-type: BUILD_GENERAL1_SMALL
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        LATEST_CLANG: true
+        S2N_LIBCRYPTO: openssl-1.1.1
+phases:
+  install:
+    runtime-versions:
+      python: 3.9
+  pre_build:
+    commands:
+      - ./codebuild/bin/install_ubuntu_dependencies.sh
+      - apt install -y clang-10 sudo
+      - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - . $HOME/.cargo/env
+      - rustup default nightly
+      - ./codebuild/bin/install_openssl_1_1_1.sh $(mktemp -d) $(pwd)/test-deps/openssl-1.1.1 linux
+      - cd ./bindings/rust
+      - OPENSSL_DIR=$(pwd)/../../test-deps/openssl-1.1.1 ./generate.sh
+  build:
+    commands:
+      - cd integration
+      - cargo bench --bench handshake -- --save-baseline main
+      - cd ..
+  post_build:
+    commands:
+      - |
+        if [ -z "${CODEBUILD_WEBHOOK_EVENT}" ]; then
+          export BASELINE_DATE=$(date -d tomorrow +%Y-%m-%d);
+        else
+          export BASELINE_DATE=$(date +%Y-%m-%d);
+        fi
+artifacts:
+  files:
+    - "**/index.html"
+    - "**/*.svg"
+    - "**/*.json"
+  base-directory: "bindings/rust/target/criterion"
+  name: benchmark_${BASELINE_DATE}.zip
+  discard-paths: no
+

--- a/codebuild/spec/inline/buildspec_fuzz_batch.yml
+++ b/codebuild/spec/inline/buildspec_fuzz_batch.yml
@@ -1,0 +1,37 @@
+batch:
+  build-list:
+    - buildspec: codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/standard:5.0
+        privileged-mode: true
+        variables:
+          CODECOV_IO_UPLOAD: true
+          FUZZ_COVERAGE: true
+          FUZZ_TIMEOUT_SEC: 60
+          LATEST_CLANG: true
+          S2N_LIBCRYPTO: openssl-1.1.1
+          TESTS: fuzz
+      identifier: s2nFuzzerOpenSSL111Coverage
+    - buildspec: codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/standard:5.0
+        privileged-mode: true
+        variables:
+          FUZZ_TIMEOUT_SEC: 60
+          LATEST_CLANG: true
+          S2N_LIBCRYPTO: openssl-1.0.2
+          TESTS: fuzz
+      identifier: s2nFuzzerOpenSSL102
+    - buildspec: codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/standard:5.0
+        privileged-mode: true
+        variables:
+          FUZZ_TIMEOUT_SEC: 60
+          LATEST_CLANG: true
+          S2N_LIBCRYPTO: openssl-1.0.2-fips
+          TESTS: fuzz
+      identifier: s2nFuzzerOpenSSL102FIPS

--- a/codebuild/spec/inline/buildspec_general_batch.yml
+++ b/codebuild/spec/inline/buildspec_general_batch.yml
@@ -1,0 +1,129 @@
+batch:
+  build-list:
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_2XLARGE
+        privileged-mode: true
+        variables:
+          GCC_VERSION: NONE
+          S2N_LIBCRYPTO: openssl-1.0.2
+          SAW: true
+          TESTS: sawBIKE
+      identifier: s2nSawBike
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          GCC_VERSION: NONE
+          SAW: true
+          TESTS: sawHMACPlus
+      identifier: sawHMACPlus
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          GCC_VERSION: NONE
+          SAW: true
+          TESTS: tls
+      identifier: s2nSawTls
+    - buildspec: codebuild/spec/buildspec_sidetrail.yml
+      env:
+        compute-type: BUILD_GENERAL1_2XLARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/linux-docker-images:sidetrail
+        privileged-mode: true
+        variables:
+          TESTS: sidetrail
+      identifier: s2nSidetrail
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          BUILD_S2N: true
+          GCC_VERSION: 6
+          S2N_LIBCRYPTO: openssl-1.0.2-fips
+          TESTS: valgrind
+      identifier: s2nValgrindOpenSSL102Gcc6Fips
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          BUILD_S2N: true
+          GCC_VERSION: 9
+          S2N_LIBCRYPTO: openssl-1.1.1
+          TESTS: valgrind
+      identifier: s2nValgrindOpenSSL111Gcc9
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          BUILD_S2N: 'true'
+          GCC_VERSION: '6'
+          S2N_LIBCRYPTO: 'openssl-1.0.2'
+          TESTS: valgrind
+      identifier: s2nValgrindOpenssl102
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          BUILD_S2N: 'true'
+          CODECOV_IO_UPLOAD: 'true'
+          CODECOV_TOKEN: 'e460b7c1-6019-4a50-b65d-555c4a8fbc22'
+          GCC_VERSION: '6'
+          S2N_COVERAGE: 'true'
+          S2N_LIBCRYPTO: 'openssl-1.1.1'
+          TESTS: asan
+      identifier: s2nAsanOpenSSL111Coverage
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          BUILD_S2N: 'true'
+          GCC_VERSION: '6'
+          S2N_LIBCRYPTO: 'openssl-1.0.2'
+          TESTS: asan
+      identifier: s2nAsanOpenssl102
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        privileged-mode: true
+        variables:
+          BUILD_S2N: 'true'
+          GCC_VERSION: '9'
+          S2N_LIBCRYPTO: 'openssl-1.1.1'
+          S2N_NO_PQ: 1
+          TESTS: unit
+      identifier: s2nUnitNoPQ
+    - buildspec: codebuild/spec/buildspec_amazonlinux2.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/amazonlinux2-aarch64-standard:2.0
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          S2N_NO_PQ: 1
+          TESTS: unit
+      identifier: s2nUnitAl2Arm
+    - buildspec: codebuild/spec/buildspec_amazonlinux2.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        privileged-mode: true
+        variables:
+          S2N_NO_PQ: 1
+          TESTS: unit
+      identifier: s2nUnitAl2
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          BUILD_S2N: 'true'
+          TESTS: interning
+      identifier: s2nLibcryptoInterning

--- a/codebuild/spec/inline/buildspec_integ_batch.yml
+++ b/codebuild/spec/inline/buildspec_integ_batch.yml
@@ -1,0 +1,185 @@
+batch:
+  build-list:
+    - buildspec: codebuild/spec/buildspec_ubuntu_integ_boringlibre.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+      identifier: s2nIntegrationBoringLibre
+    - buildspec: codebuild/spec/buildspec_ubuntu_integ_awslc.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+      identifier: s2nIntegrationAwsLc
+    - buildspec: codebuild/spec/buildspec_ubuntu_integ_openssl111.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+      identifier: s2nIntegrationOpenSSL111PlusCoverage
+    - buildspec: codebuild/spec/buildspec_ubuntu_integ_openssl102.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+      identifier: s2nIntegrationOpenSSL102Plus
+    - buildspec: codebuild/spec/buildspec_ubuntu_integ_openssl102_asanvalgrind.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+      identifier: s2nIntegrationOpenSSL102AsanValgrind
+    - buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          INTEGV2_TEST: test_client_authentication
+      identifier: s2nIntegrationV2ClientAuthentication
+    - buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          INTEGV2_TEST: test_dynamic_record_sizes
+      identifier: s2nIntegrationV2DynamicRecordSizes
+    - buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          INTEGV2_TEST: test_key_update
+      identifier: s2nIntegrationV2KeyUpdate
+    - buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          INTEGV2_TEST: test_happy_path
+      identifier: s2nIntegrationV2HappyPath
+    - buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          INTEGV2_TEST: test_session_resumption
+      identifier: s2nIntegrationV2SessionResumption
+    - buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          INTEGV2_TEST: test_sni_match
+      identifier: s2nIntegrationV2SniMatch
+    - buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          INTEGV2_TEST: test_fragmentation
+      identifier: s2nIntegrationV2Fragmentation
+    - buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          INTEGV2_TEST: test_hello_retry_requests
+      identifier: s2nIntegrationV2HelloRetryRequests
+    - buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          INTEGV2_TEST: test_pq_handshake
+      identifier: s2nIntegrationV2PqHandshake
+    - buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          INTEGV2_TEST: test_signature_algorithms
+      identifier: s2nIntegrationV2SignatureAlgorithms
+    - buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          INTEGV2_TEST: test_version_negotiation
+      identifier: s2nIntegrationV2VersionNegotiation
+    - buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          INTEGV2_TEST: test_well_known_endpoints
+      identifier: s2nIntegrationV2WellKnownEndpoints
+    - buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          INTEGV2_TEST: test_early_data
+      identifier: s2nIntegrationV2EarlyData
+    - buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          INTEGV2_TEST: test_external_psk
+      identifier: s2nIntegrationV2ExternalPSK
+    - buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          INTEGV2_TEST: test_cross_compatibility
+      identifier: s2nIntegrationV2CrossCompatibility
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          BUILD_S2N: true
+          GCC_VERSION: 9
+          S2N_LIBCRYPTO: boringssl
+          TESTS: integration
+      identifier: s2nIntegrationBoringSSLGcc9
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          BUILD_S2N: true
+          GCC_VERSION: 6
+          OPENSSL_ia32cap: "~0x200000200000000"
+          S2N_LIBCRYPTO: openssl-1.1.1
+          TESTS: integration
+      identifier: s2nIntegrationOpenSSL111Gcc6SoftCrypto
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          BUILD_S2N: true
+          GCC_VERSION: 9
+          S2N_LIBCRYPTO: openssl-1.1.1
+          TESTS: integration
+      identifier: s2nIntegrationOpenSSL111Gcc9
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          BUILD_S2N: true
+          GCC_VERSION: 9
+          S2N_LIBCRYPTO: libressl
+          TESTS: integration
+      identifier: s2nIntegrationLibreSSLGcc9
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          BUILD_S2N: true
+          CODECOV_IO_UPLOAD: true
+          GCC_VERSION: 6
+          S2N_COVERAGE: true
+          S2N_LIBCRYPTO: openssl-1.1.1
+          TESTS: integration
+      identifier: s2nIntegrationOpenSSL111Gcc6Coverage

--- a/codebuild/spec/inline/buildspec_ubuntu_integv2criterion.yml
+++ b/codebuild/spec/inline/buildspec_ubuntu_integv2criterion.yml
@@ -5,12 +5,6 @@ env:
   variables:
     # CODEBUILD_ is a reserved namespace.
     CB_BIN_DIR: "./codebuild/bin"
-    TESTS: integrationv2crit
-    GCC_VERSION: 6
-    XDIST_WORKERS: 1
-    ARTIFACT_BUCKET: s3://s2n-tls-logs/main
-    ARTIFACT_FILE: integv2criterion
-
 
 # Doc for batch https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html#build-spec.batch.build-list
 batch:
@@ -23,13 +17,25 @@ batch:
         variables:
           INTEGV2_TEST: test_well_known_endpoints
           S2N_USECRITERION: 2
+          S2N_NO_PQ: 1
+          TESTS: integrationv2crit
+          GCC_VERSION: 6
+          XDIST_WORKERS: 2
+          RUST_BACKTRACE: 1
     - identifier: s2nIntegrationv2WellKnownEndpoints
+      debug-session: true
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           INTEGV2_TEST: test_well_known_endpoints
           S2N_USECRITERION: 1
+          S2N_NO_PQ: 1
+          TESTS: integrationv2crit
+          GCC_VERSION: 6
+          XDIST_WORKERS: 2
+          ARTIFACT_BUCKET: s3://s2n-tls-logs/release
+          ARTIFACT_FILE: integv2criterion
       depend-on:
         - s2nIntegrationv2WellKnownEndpointsBaseline
 
@@ -38,58 +44,20 @@ phases:
     runtime-versions:
       python: 3.x
     commands:
-      - . $CB_BIN_DIR/utils.sh
-      - gh_login s2n_codebuild_PRs
-      - get_latest_release
-      - mkdir -p target/criterion || true
-      - aws s3 cp ${ARTIFACT_BUCKET}/${ARTIFACT_FILE}_${INTEGV2_TEST}_${LATEST_RELEASE_VER}.zip .
-      - unzip -o ${ARTIFACT_FILE}_${INTEGV2_TEST}_${LATEST_RELEASE_VER}.zip -d ./target/criterion
-  pre_build:
-    commands:
-      - echo Entered the install phase...
-      - |
-        if [ -d "third-party-src" ]; then
-          cd third-party-src;
-        fi
       - $CB_BIN_DIR/install_ubuntu_dependencies.sh
-      - |
-        if expr "${GCC_VERSION}" : "9" >/dev/null; then
-          apt-get install -y --no-install-recommends g++ g++-9 gcc gcc-9;
-        fi
-      - |
-        if expr "${GCC_VERSION}" : "6" >/dev/null; then
-          apt-get install -y --no-install-recommends g++ g++-6 gcc gcc-6;
-        fi
-      # Don't install old clang and llvm if LATEST_CLANG is enabled, handle it in install_clang.sh instead
-      - |
-        if expr "${LATEST_CLANG}" != "true" >/dev/null; then
-          apt-get install -y --no-install-recommends clang-3.9 llvm-3.9;
-        fi
-      - apt-get install -y --no-install-recommends indent iproute2 kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc cmake tox libtool ninja-build
-      - |
-        if [ -d "third-party-src" ]; then
-          cd third-party-src;
-        fi
-      - $CB_BIN_DIR/install_default_dependencies.sh
+      - $CB_BIN_DIR/utils.sh gh_login s2n_codebuild_PRs
+      - export LATEST_RELEASE_VER=$($CB_BIN_DIR/utils.sh get_latest_release)
+      - mkdir -p tests/integrationv2/target/criterion || true
+      - aws s3 cp ${ARTIFACT_BUCKET}/${ARTIFACT_FILE}_${INTEGV2_TEST}_${LATEST_RELEASE_VER}.zip .
+      - unzip -o ${ARTIFACT_FILE}_${INTEGV2_TEST}_${LATEST_RELEASE_VER}.zip -d ./tests/integrationv2/target/criterion
   build:
     commands:
-      - make install
-      - . $HOME/.cargo/env
-      - make -C bindings/rust
       - codebuild-breakpoint
-      - TOX_TEST_NAME=$INTEGV2_TEST.py make integrationv2
-  post_build:
-    commands:
-      - |
-        if [ -z "${CODEBUILD_WEBHOOK_EVENT}" ]; then
-          export BASELINE_DATE=$(date -d tomorrow +%Y-%m-%d);
-        else
-          export BASELINE_DATE=$(date +%Y-%m-%d);
-        fi
+      - $CB_BIN_DIR/criterion_delta.sh
 artifacts:
   files:
     - "**/index.html"
     - "**/*.svg"
     - "**/*.json"
-  base-directory: "bindings/rust/target/criterion"
+  base-directory: "tests/integrationv2/target/criterion"
   discard-paths: no

--- a/codebuild/spec/inline/buildspec_ubuntu_integv2criterion.yml
+++ b/codebuild/spec/inline/buildspec_ubuntu_integv2criterion.yml
@@ -1,0 +1,95 @@
+---
+version: 0.2
+
+env:
+  variables:
+    # CODEBUILD_ is a reserved namespace.
+    CB_BIN_DIR: "./codebuild/bin"
+    TESTS: integrationv2crit
+    GCC_VERSION: 6
+    XDIST_WORKERS: 1
+    ARTIFACT_BUCKET: s3://s2n-tls-logs/main
+    ARTIFACT_FILE: integv2criterion
+
+
+# Doc for batch https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html#build-spec.batch.build-list
+batch:
+  build-graph:
+    - identifier: s2nIntegrationv2WellKnownEndpointsBaseline
+      buildspec: codebuild/spec/buildspec_ubuntu_integv2criterion_baseline.yml
+      env:
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          INTEGV2_TEST: test_well_known_endpoints
+          S2N_USECRITERION: 2
+    - identifier: s2nIntegrationv2WellKnownEndpoints
+      env:
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          INTEGV2_TEST: test_well_known_endpoints
+          S2N_USECRITERION: 1
+      depend-on:
+        - s2nIntegrationv2WellKnownEndpointsBaseline
+
+phases:
+  install:
+    runtime-versions:
+      python: 3.x
+    commands:
+      - . $CB_BIN_DIR/utils.sh
+      - gh_login s2n_codebuild_PRs
+      - get_latest_release
+      - mkdir -p target/criterion || true
+      - aws s3 cp ${ARTIFACT_BUCKET}/${ARTIFACT_FILE}_${INTEGV2_TEST}_${LATEST_RELEASE_VER}.zip .
+      - unzip -o ${ARTIFACT_FILE}_${INTEGV2_TEST}_${LATEST_RELEASE_VER}.zip -d ./target/criterion
+  pre_build:
+    commands:
+      - echo Entered the install phase...
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - $CB_BIN_DIR/install_ubuntu_dependencies.sh
+      - |
+        if expr "${GCC_VERSION}" : "9" >/dev/null; then
+          apt-get install -y --no-install-recommends g++ g++-9 gcc gcc-9;
+        fi
+      - |
+        if expr "${GCC_VERSION}" : "6" >/dev/null; then
+          apt-get install -y --no-install-recommends g++ g++-6 gcc gcc-6;
+        fi
+      # Don't install old clang and llvm if LATEST_CLANG is enabled, handle it in install_clang.sh instead
+      - |
+        if expr "${LATEST_CLANG}" != "true" >/dev/null; then
+          apt-get install -y --no-install-recommends clang-3.9 llvm-3.9;
+        fi
+      - apt-get install -y --no-install-recommends indent iproute2 kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc cmake tox libtool ninja-build
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
+      - $CB_BIN_DIR/install_default_dependencies.sh
+  build:
+    commands:
+      - make install
+      - . $HOME/.cargo/env
+      - make -C bindings/rust
+      - codebuild-breakpoint
+      - TOX_TEST_NAME=$INTEGV2_TEST.py make integrationv2
+  post_build:
+    commands:
+      - |
+        if [ -z "${CODEBUILD_WEBHOOK_EVENT}" ]; then
+          export BASELINE_DATE=$(date -d tomorrow +%Y-%m-%d);
+        else
+          export BASELINE_DATE=$(date +%Y-%m-%d);
+        fi
+artifacts:
+  files:
+    - "**/index.html"
+    - "**/*.svg"
+    - "**/*.json"
+  base-directory: "bindings/rust/target/criterion"
+  discard-paths: no

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -33,3 +33,14 @@ libs2n.so: ${OBJS}
 
 libs2n.dylib: ${OBJS}
 	test ! -f /usr/lib/libSystem.dylib || libtool -dynamic  ${LIBS} -L${LIBCRYPTO_ROOT}/lib ${CRYPTO_LIBS} -o libs2n.dylib ${OBJS}
+
+$(libdir):
+	@mkdir -p $(libdir)
+
+install: libs2n.a libs2n.so $(libdir)
+	@cp libs2n.*  $(libdir)
+	@cp ../api/s2n.h  $(includedir)
+
+uninstall:
+	@rm $(libdir)/libs2n.*
+	@rm $(includedir)/s2n.h

--- a/s2n.mk
+++ b/s2n.mk
@@ -167,6 +167,13 @@ ifndef COV_TOOL
 	endif
 endif
 
+# Used for testing.
+prefix ?= /usr/local
+exec_prefix ?= $(prefix)
+bindir ?= $(exec_prefix)/bin
+libdir ?= $(exec_prefix)/lib64
+includedir ?= $(exec_prefix)/include
+
 try_compile = $(shell $(CC) $(CFLAGS) -c -o tmp.o $(1) > /dev/null 2>&1; echo $$?; rm tmp.o > /dev/null 2>&1)
 
 # Determine if execinfo.h is available

--- a/tests/integrationv2/README.md
+++ b/tests/integrationv2/README.md
@@ -152,3 +152,23 @@ An example of how to test that the server and the client can send and receive ap
 An error similar to this is caused by a runtime error in a test. In `tox.ini` change `-n8` to `-n0` to
 see the actual error causing the OSError.
 
+
+# Criterion
+
+### What is the basic flow of running crition in between pyest and s2nc/d?
+
+Normally, you'd run criterion with `cargo bench --bench <name>`, but cargo does some checks to see if it needs to rebuild
+the benchmark and other housekeeping that slows things down a bit.  Running `cargo bench --no-run` is the benchmark equivilent to `cargo build` and will produce a binary executable.
+
+The binary created by no-run has a uniqe name and must be searched for, which the CriterionS2N provider finds and replaces in the final command.
+The arguments to s2nc/d are moved to `S2NC_ARS` or `S2ND_ARGS`, which is read by the rust benchmark when spawning s2nc/d as subprocesses.
+
+Criterion needs 3 passes to generate a report showing changes between two runs. The first pass estabalishes a base line, the second run a delta dataset, and the final a report.
+These modes have slightly different command line arguments to criterion and are controlled with the environment variable S2N_USECRITERION in the provider.
+
+## Troubleshooting CriterionS2N
+
+The most direct trouble-shooting is done using the [interactive troubleshooting CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/session-manager.html#ssm-pause-build) `codebuild-break` line in the buildspec. Put the break right before the main build step and run interactivly.
+
+As mentioned above, in order to get more output from the tests, set the -n/XDIST_WORKER environment variable to 0 and add a -v to the pytest command line in tox.ini.
+

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -7,7 +7,7 @@ import itertools
 
 
 from constants import TEST_CERT_DIRECTORY
-from global_flags import get_flag, S2N_NO_PQ, S2N_FIPS_MODE
+from global_flags import get_flag, S2N_NO_PQ, S2N_FIPS_MODE, S2N_USECRITERION
 
 
 def data_bytes(n_bytes):

--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -2,7 +2,7 @@ import collections
 
 from common import Certificates, Ciphers, Curves, Protocols, AvailablePorts
 from constants import TEST_SNI_CERT_DIRECTORY
-from providers import S2N, OpenSSL, BoringSSL, JavaSSL
+from providers import CriterionS2N, S2N, OpenSSL, BoringSSL, JavaSSL
 
 
 # The boolean configuration will let a test run for True and False
@@ -20,7 +20,7 @@ PROTOCOLS = [
 
 
 # List of providers that will be tested.
-PROVIDERS = [S2N, OpenSSL, JavaSSL]
+PROVIDERS = [CriterionS2N, OpenSSL, JavaSSL]
 
 
 # List of binary TLS13 settings

--- a/tests/integrationv2/conftest.py
+++ b/tests/integrationv2/conftest.py
@@ -1,12 +1,12 @@
 import pytest
-from global_flags import set_flag, S2N_PROVIDER_VERSION, S2N_FIPS_MODE, S2N_NO_PQ
+from global_flags import set_flag, S2N_PROVIDER_VERSION, S2N_FIPS_MODE, S2N_NO_PQ, S2N_USECRITERION
 
 
 def pytest_addoption(parser):
     parser.addoption("--provider-version", action="store", dest="provider-version", default=None, type=str, help="Set the version of the TLS provider")
     parser.addoption("--fips-mode", action="store", dest="fips-mode", default=False, type=int, help="S2N is running in FIPS mode")
     parser.addoption("--no-pq", action="store", dest="no-pq", default=False, type=int, help="Turn off PQ support")
-
+    parser.addoption("--provider-criterion", action="store", dest="provider-criterion", default=False, type=int, help="Run the test under a Criterion provider, if available.")
 
 def pytest_configure(config):
     """
@@ -19,12 +19,14 @@ def pytest_configure(config):
 
     no_pq = config.getoption('no-pq', 0)
     fips_mode = config.getoption('fips-mode', 0)
+    use_criterion = config.getoption('proivder-criterion', 0)
     if no_pq is 1:
         set_flag(S2N_NO_PQ, True)
     if fips_mode is 1:
         set_flag(S2N_FIPS_MODE, True)
 
     set_flag(S2N_PROVIDER_VERSION, config.getoption('provider-version', None))
+    set_flag(S2N_USECRITERION, config.getoption('provider-criterion', None))
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/integrationv2/conftest.py
+++ b/tests/integrationv2/conftest.py
@@ -6,7 +6,8 @@ def pytest_addoption(parser):
     parser.addoption("--provider-version", action="store", dest="provider-version", default=None, type=str, help="Set the version of the TLS provider")
     parser.addoption("--fips-mode", action="store", dest="fips-mode", default=False, type=int, help="S2N is running in FIPS mode")
     parser.addoption("--no-pq", action="store", dest="no-pq", default=False, type=int, help="Turn off PQ support")
-    parser.addoption("--provider-criterion", action="store", dest="provider-criterion", default=False, type=int, help="Run the test under a Criterion provider, if available.")
+    parser.addoption("--provider-criterion", action="store", dest="provider-criterion",
+      default=False, type=int, help="0=off(default, 1=Run the test under a Criterion provider in delta mode, 2=Run in baseline mode.")
 
 def pytest_configure(config):
     """

--- a/tests/integrationv2/fixtures.py
+++ b/tests/integrationv2/fixtures.py
@@ -7,7 +7,9 @@ import time
 from processes import ManagedProcess
 from providers import Provider
 from common import ProviderOptions, Protocols
+import logging
 
+LOGGER = logging.getLogger(__name__)
 
 @pytest.fixture
 def managed_process():
@@ -24,12 +26,14 @@ def managed_process():
     def _fn(provider_class: Provider, options: ProviderOptions, timeout=5, send_marker=None, close_marker=None, expect_stderr=None):
         provider = provider_class(options)
         cmd_line = provider.get_cmd_line()
+        cwd = provider.get_cwd()
         # The process will default to send markers in the providers.py file
         # if not specified by a test.
         if send_marker is not None:
             provider.ready_to_send_input_marker = send_marker
         if expect_stderr is None:
             expect_stderr = provider.expect_stderr
+
         p = ManagedProcess(cmd_line,
                 provider.set_provider_ready,
                 wait_for_marker=provider.ready_to_test_marker,
@@ -38,7 +42,8 @@ def managed_process():
                 data_source=options.data_to_send,
                 timeout=timeout,
                 env_overrides=options.env_overrides,
-                expect_stderr=expect_stderr)
+                expect_stderr=expect_stderr,
+                cwd=cwd)
 
         processes.append(p)
         with p.ready_condition:

--- a/tests/integrationv2/fixtures.py
+++ b/tests/integrationv2/fixtures.py
@@ -7,9 +7,7 @@ import time
 from processes import ManagedProcess
 from providers import Provider
 from common import ProviderOptions, Protocols
-import logging
 
-LOGGER = logging.getLogger(__name__)
 
 @pytest.fixture
 def managed_process():
@@ -33,7 +31,6 @@ def managed_process():
             provider.ready_to_send_input_marker = send_marker
         if expect_stderr is None:
             expect_stderr = provider.expect_stderr
-
         p = ManagedProcess(cmd_line,
                 provider.set_provider_ready,
                 wait_for_marker=provider.ready_to_test_marker,

--- a/tests/integrationv2/global_flags.py
+++ b/tests/integrationv2/global_flags.py
@@ -12,6 +12,9 @@ S2N_FIPS_MODE = 's2n_fips_mode'
 # (set from the S2N_LIBCRYPTO env var, which is how the original integration test works)
 S2N_PROVIDER_VERSION = 's2n_provider_version'
 
+# From S2N_USECRITERION env var.
+S2N_USECRITERION = 's2n_usecriterion'
+
 _flags = {}
 
 def get_flag(name, default=None):

--- a/tests/integrationv2/processes.py
+++ b/tests/integrationv2/processes.py
@@ -237,7 +237,7 @@ class ManagedProcess(threading.Thread):
     are made available to the caller.
     """
     def __init__(self, cmd_line, provider_set_ready_condition, wait_for_marker=None, send_marker_list=None, close_marker=None,
-                 timeout=5, data_source=None, env_overrides=dict(), expect_stderr=False):
+                 timeout=5, data_source=None, env_overrides=dict(), expect_stderr=False, cwd=None):
         threading.Thread.__init__(self)
 
         proc_env = os.environ.copy()
@@ -256,6 +256,9 @@ class ManagedProcess(threading.Thread):
         # Condition variable indicating when results are ready to be collected
         self.results_condition = threading.Condition()
         self.results = None
+
+        # Set current working dir
+        self.cwd = cwd
 
         # Condition variable indicating when this subprocess has been launched successfully
         self.ready_condition = threading.Condition()
@@ -281,7 +284,7 @@ class ManagedProcess(threading.Thread):
     def run(self):
         with self.results_condition:
             try:
-                proc = subprocess.Popen(self.cmd_line, env=self.proc_env, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+                proc = subprocess.Popen(self.cmd_line, env=self.proc_env, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True, cwd=self.cwd)
                 self.proc = proc
             except Exception as ex:
                 self.results = Results(None, None, None, ex, self.expect_stderr)

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -298,8 +298,10 @@ class CriterionS2N(S2N):
 
     def __init__(self, options: ProviderOptions):
         super().__init__(options)
-        # Set cwd for the benchmark
+        # Set cargo root
         self.cargo_root = self._find_cargo()
+        # Set cwd for the benchmark
+        self.cwd = self.cargo_root
         # Find the criterion binaries
         self._cargo_bench()
 

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -303,8 +303,7 @@ class CriterionS2N(S2N):
         super().__init__(options)
         # Set cargo root
         self.cargo_root = self._find_cargo()
-        # Set cwd for the benchmark
-        self.cwd = self.cargo_root
+
         # Find the criterion binaries
         self._cargo_bench()
 

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -270,6 +270,8 @@ class CriterionS2N(S2N):
     criterion_delta = 1
     criterion_baseline = 2
     criterion_report = 3
+    # Figure out what mode to run in: baseline, delta or report
+    criterion_mode = get_flag(S2N_USECRITERION)
 
     def _find_s2n_benchmark(self, pattern):
         result = find_files(pattern, root_dir=self.cargo_root, mode=EXECUTABLE)
@@ -306,10 +308,6 @@ class CriterionS2N(S2N):
         # Find the criterion binaries
         self._cargo_bench()
 
-        #Figure out what mode to run in: baseline or delta
-        self.criterion_mode = get_flag(S2N_USECRITERION)
-        assert self.criterion_mode
-
         #strip off the s2nc/d at the front because criterion
         if 's2nc' in self.cmd_line[0] or 's2nd' in self.cmd_line[0]:
             self.cmd_line = self.cmd_line[1:]
@@ -341,6 +339,7 @@ class CriterionS2N(S2N):
 
     def capture_client_args_report(self):
         self.cmd_line = [self.s2nc_bench, "--bench", "s2nc", "--load-baseline", "new", "--baseline", "main"]
+
 
 class OpenSSL(Provider):
     _version = get_flag(S2N_PROVIDER_VERSION)

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -316,11 +316,6 @@ class CriterionS2N(S2N):
             self.options.env_overrides.update({'S2ND_ARGS': ' '.join(self.cmd_line)})
             self.capture_server_args()
         elif self.options.mode == Provider.ClientMode:
-            # echo is causing s2nc to wait too long.
-            try:
-                self.cmd_line.remove('-e')
-            except ValueError:
-                pass
             self.options.env_overrides.update({'S2NC_ARGS': ' '.join(self.cmd_line)})
             if self.criterion_mode == CriterionS2N.criterion_baseline:
               self.capture_client_args_baseline()

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -305,7 +305,11 @@ class CriterionS2N(S2N):
 
         #Figure out what mode to run in: baseline or delta
         self.criterion_mode = get_flag(S2N_USECRITERION)
-        assert self.criterion_mode  == 2
+        assert self.criterion_mode
+
+        #strip off the s2nc/d at the front because criterion
+        if 's2nc' in self.cmd_line[0] or 's2nd' in self.cmd_line[0]:
+            self.cmd_line = self.cmd_line[1:]
 
         # Copy the command arguments to an environment variable for the harness to read.
         if self.options.mode == Provider.ServerMode:

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -269,6 +269,7 @@ class CriterionS2N(S2N):
     criterion_off = 0
     criterion_delta = 1
     criterion_baseline = 2
+    criterion_report = 3
 
     def _find_s2n_benchmark(self, pattern):
         result = find_files(pattern, root_dir=self.cargo_root, mode=EXECUTABLE)
@@ -320,9 +321,11 @@ class CriterionS2N(S2N):
         elif self.options.mode == Provider.ClientMode:
             self.options.env_overrides.update({'S2NC_ARGS': ' '.join(self.cmd_line)})
             if self.criterion_mode == CriterionS2N.criterion_baseline:
-              self.capture_client_args_baseline()
+                self.capture_client_args_baseline()
             if self.criterion_mode == CriterionS2N.criterion_delta:
-              self.capture_client_args_delta()
+                self.capture_client_args_delta()
+            if self.criterion_mode == CriterionS2N.criterion_report:
+                self.capture_client_args_report()
 
     def capture_server_args(self, cmd_line):
         # Without this flag, criterion won't run
@@ -330,12 +333,14 @@ class CriterionS2N(S2N):
 
     def capture_client_args_baseline(self):
         # Without this flag, criterion won't run
-        self.cmd_line = [self.s2nc_bench, "--bench", "s2nc", "--save-baseline","main"]
+        self.cmd_line = [self.s2nc_bench, "--bench", "s2nc", "--save-baseline", "main"]
 
     def capture_client_args_delta(self):
         # Without this flag, criterion won't run
-        self.cmd_line = [self.s2nc_bench, "--bench","s2nc", "--load-baseline","new","--baseline","main"]
+        self.cmd_line = [self.s2nc_bench, "--bench", "s2nc"]
 
+    def capture_client_args_report(self):
+        self.cmd_line = [self.s2nc_bench, "--bench", "s2nc", "--load-baseline", "new", "--baseline", "main"]
 
 class OpenSSL(Provider):
     _version = get_flag(S2N_PROVIDER_VERSION)

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -316,6 +316,11 @@ class CriterionS2N(S2N):
             self.options.env_overrides.update({'S2ND_ARGS': ' '.join(self.cmd_line)})
             self.capture_server_args()
         elif self.options.mode == Provider.ClientMode:
+            # echo is causing s2nc to wait too long.
+            try:
+                self.cmd_line.remove('-e')
+            except ValueError:
+                pass
             self.options.env_overrides.update({'S2NC_ARGS': ' '.join(self.cmd_line)})
             if self.criterion_mode == CriterionS2N.criterion_baseline:
               self.capture_client_args_baseline()

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -42,7 +42,7 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
     # Passing the type of client and server as a parameter will
     # allow us to use a fixture to enumerate all possibilities.
     server = managed_process(S2N, server_options, timeout=5)
-    client = managed_process(provider, client_options, timeout=5)
+    client = managed_process(provider, client_options, timeout=300)
 
     # The client will be one of all supported providers. We
     # just want to make sure there was no exception and that

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -42,7 +42,7 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
     # Passing the type of client and server as a parameter will
     # allow us to use a fixture to enumerate all possibilities.
     server = managed_process(S2N, server_options, timeout=5)
-    client = managed_process(provider, client_options, timeout=300)
+    client = managed_process(provider, client_options, timeout=5)
 
     # The client will be one of all supported providers. We
     # just want to make sure there was no exception and that

--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -120,6 +120,10 @@ def test_well_known_endpoints(managed_process, protocol, endpoint, provider, cip
     for results in client.get_results():
         results.assert_success()
 
+    if provider is CriterionS2N and provider.criterion_mode is CriterionS2N.criterion_report:
+        # In report mode, criterion doesn't actually run the test, so no output to check.
+        return
+    else:
         if expected_result is not None:
             assert to_bytes(expected_result['cipher']) in results.stdout
             assert to_bytes(expected_result['kem']) in results.stdout

--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -5,9 +5,8 @@ from configuration import available_ports, PROTOCOLS
 from common import ProviderOptions, Protocols, Ciphers, pq_enabled
 from fixtures import managed_process
 from global_flags import get_flag, S2N_FIPS_MODE
-from providers import Provider, S2N
+from providers import Provider, CriterionS2N
 from utils import invalid_test_parameters, get_parameter_name, to_bytes
-
 
 ENDPOINTS = [
     "www.akamai.com",
@@ -88,7 +87,7 @@ else:
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("endpoint", ENDPOINTS, ids=get_parameter_name)
-@pytest.mark.parametrize("provider", [S2N], ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [CriterionS2N], ids=get_parameter_name)
 @pytest.mark.parametrize("cipher", CIPHERS, ids=get_parameter_name)
 def test_well_known_endpoints(managed_process, protocol, endpoint, provider, cipher):
     port = "443"
@@ -109,7 +108,7 @@ def test_well_known_endpoints(managed_process, protocol, endpoint, provider, cip
 
     # expect_stderr=True because S2N sometimes receives OCSP responses:
     # https://github.com/aws/s2n-tls/blob/14ed186a13c1ffae7fbb036ed5d2849ce7c17403/bin/echo.c#L180-L184
-    client = managed_process(provider, client_options, timeout=5, expect_stderr=True)
+    client = managed_process(provider, client_options, timeout=300, expect_stderr=True)
 
     expected_result = EXPECTED_RESULTS.get((endpoint, cipher), None)
 

--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -112,7 +112,7 @@ def test_well_known_endpoints(managed_process, protocol, endpoint, provider, cip
 
     # expect_stderr=True because S2N sometimes receives OCSP responses:
     # https://github.com/aws/s2n-tls/blob/14ed186a13c1ffae7fbb036ed5d2849ce7c17403/bin/echo.c#L180-L184
-    client = managed_process(provider, client_options, timeout=300, expect_stderr=True)
+    client = managed_process(provider, client_options, timeout=30, expect_stderr=True)
 
     expected_result = EXPECTED_RESULTS.get((endpoint, cipher), None)
 

--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from constants import TRUST_STORE_BUNDLE

--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -112,7 +112,7 @@ def test_well_known_endpoints(managed_process, protocol, endpoint, provider, cip
 
     # expect_stderr=True because S2N sometimes receives OCSP responses:
     # https://github.com/aws/s2n-tls/blob/14ed186a13c1ffae7fbb036ed5d2849ce7c17403/bin/echo.c#L180-L184
-    client = managed_process(provider, client_options, timeout=30, expect_stderr=True)
+    client = managed_process(provider, client_options, timeout=60, expect_stderr=True)
 
     expected_result = EXPECTED_RESULTS.get((endpoint, cipher), None)
 

--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -2,10 +2,10 @@ import pytest
 
 from constants import TRUST_STORE_BUNDLE
 from configuration import available_ports, PROTOCOLS
-from common import ProviderOptions, Protocols, Ciphers, pq_enabled
 from fixtures import managed_process
-from global_flags import get_flag, S2N_FIPS_MODE
-from providers import Provider, CriterionS2N
+from common import ProviderOptions, Protocols, Ciphers, pq_enabled
+from global_flags import get_flag, S2N_FIPS_MODE, S2N_USECRITERION
+from providers import Provider, S2N, CriterionS2N
 from utils import invalid_test_parameters, get_parameter_name, to_bytes
 
 ENDPOINTS = [
@@ -83,11 +83,15 @@ else:
             {"cipher": "ECDHE-RSA-AES256-GCM-SHA384", "kem": "NONE"},
     }
 
+if get_flag(S2N_USECRITERION):
+    provider = [CriterionS2N]
+else:
+    provider = [S2N]
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("endpoint", ENDPOINTS, ids=get_parameter_name)
-@pytest.mark.parametrize("provider", [CriterionS2N], ids=get_parameter_name)
+@pytest.mark.parametrize("provider", provider, ids=get_parameter_name)
 @pytest.mark.parametrize("cipher", CIPHERS, ids=get_parameter_name)
 def test_well_known_endpoints(managed_process, protocol, endpoint, provider, cipher):
     port = "443"

--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -1,17 +1,17 @@
 [tox]
-envlist = py38
+envlist = py39
 skipsdist = True
 
 [testenv]
 # install pytest in the virtualenv where commands will be executed
 setenv = S2N_INTEG_TEST = 1
-passenv = DYLD_LIBRARY_PATH LD_LIBRARY_PATH OQS_OPENSSL_1_1_1_INSTALL_DIR
+passenv = DYLD_LIBRARY_PATH LD_LIBRARY_PATH OQS_OPENSSL_1_1_1_INSTALL_DIR PYTEST_XDIST_WORKER_COUNT HOME TOX_TEST_NAME
 deps =
     pep8
     pytest==5.3.5
     pytest-xdist==1.34.0
 commands =
-    pytest -n 2 --cache-clear -rpfsq \
+    pytest -n=1 -o log_cli=true  --cache-clear -rpfs \
         --provider-version={env:S2N_LIBCRYPTO} \
         --fips-mode={env:S2N_TEST_IN_FIPS_MODE:"0"} \
         --no-pq={env:S2N_NO_PQ:"0"} \

--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -6,12 +6,13 @@ skipsdist = True
 # install pytest in the virtualenv where commands will be executed
 setenv = S2N_INTEG_TEST = 1
 passenv = DYLD_LIBRARY_PATH LD_LIBRARY_PATH OQS_OPENSSL_1_1_1_INSTALL_DIR HOME TOX_TEST_NAME
+ignore_errors=False
 deps =
     pep8
     pytest==5.3.5
     pytest-xdist==1.34.0
 commands =
-    pytest -n={env:XDIST_WORKERS:"2"} --cache-clear -rpfs \
+    pytest -x -n={env:XDIST_WORKERS:"2"} --cache-clear -rpfs \
         -o log_cli=true --log-cli-level=INFO \
         --provider-version={env:S2N_LIBCRYPTO} \
         --provider-criterion={env:S2N_USECRITERION:"0"} \

--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist = py38
 skipsdist = True
-minversion = 3.10.0
 
 [testenv]
 # install pytest in the virtualenv where commands will be executed

--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -1,18 +1,21 @@
 [tox]
-envlist = py39
+envlist = py38
 skipsdist = True
+minversion = 3.10.0
 
 [testenv]
 # install pytest in the virtualenv where commands will be executed
 setenv = S2N_INTEG_TEST = 1
-passenv = DYLD_LIBRARY_PATH LD_LIBRARY_PATH OQS_OPENSSL_1_1_1_INSTALL_DIR PYTEST_XDIST_WORKER_COUNT HOME TOX_TEST_NAME
+passenv = DYLD_LIBRARY_PATH LD_LIBRARY_PATH OQS_OPENSSL_1_1_1_INSTALL_DIR HOME TOX_TEST_NAME
 deps =
     pep8
     pytest==5.3.5
     pytest-xdist==1.34.0
 commands =
-    pytest -n=1 -o log_cli=true  --cache-clear -rpfs \
+    pytest -n={env:XDIST_WORKERS:"2"} --cache-clear -rpfs \
+        -o log_cli=true --log-cli-level=INFO \
         --provider-version={env:S2N_LIBCRYPTO} \
+        --provider-criterion={env:S2N_USECRITERION:"0"} \
         --fips-mode={env:S2N_TEST_IN_FIPS_MODE:"0"} \
         --no-pq={env:S2N_NO_PQ:"0"} \
         {env:TOX_TEST_NAME:""}

--- a/tests/integrationv2/utils.py
+++ b/tests/integrationv2/utils.py
@@ -1,6 +1,8 @@
 from common import Protocols, Curves, Ciphers
-from providers import S2N, OpenSSL
+from glob import glob
+import os
 
+EXECUTABLE=33261
 
 def to_bytes(val):
     return bytes(str(val).encode('utf-8'))
@@ -14,7 +16,7 @@ def get_expected_s2n_version(protocol, provider):
     tls12 is always chosen. This is true even when the requested
     protocol is less than tls12.
     """
-    if provider == S2N and protocol != Protocols.TLS13:
+    if (provider == S2N or provider == CriterionS2N) and protocol != Protocols.TLS13:
         version = '33'
     else:
         version = protocol.value
@@ -100,3 +102,25 @@ def invalid_test_parameters(*args, **kwargs):
             return True
 
     return False
+
+
+def find_files(file_glob, root_dir=".", mode=None):
+    # file_glob: a snippet of the filename, e.g. ".py"
+    # root_dir: starting point for search
+    result=[]
+    for root, dirs, files in os.walk(root_dir):
+        for file in files:
+            if file_glob in file:
+                full_name=os.path.abspath(os.path.join(root,file))
+                if mode:
+                    try:
+                        stat = os.stat(full_name)[0]
+                        if stat == mode:
+                                result.append(full_name)
+                    except FileNotFoundError:
+                        # symlinks
+                        pass
+                else:
+                        result.append(full_name)
+
+    return result


### PR DESCRIPTION
Resolved issues:

#3130 

Description of changes:

Without rewriting our benchmarks in  rust, can we run criterion as part of our integrationv2 tests?
Starting with just the well_known_endpoints, create a pattern for wrapping more of the tests.

Call-outs:

- Keeping this change to only wellknown endpoints.
- Makes the Integv2 tests Fail Fast, this was  for troubleshooting, but it could save quite a bit of time; open to thoughts on this change.
- No CI will run because of the changes to buildspecs.

Testing:

How is this change tested (unit tests, fuzz tests, etc.)? Will link to a successful adhoc job.

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.