### PR TITLE
build: fix libcrypto interning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,53 +516,50 @@ if (S2N_INTERN_LIBCRYPTO)
         message(FATAL_ERROR "libcrypto interning requires a static build of libcrypto.a to be available")
     endif()
 
+    # LINK_LIB is set above after checking targets. It handles the find_package craziness.
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${LINK_LIB})
+
     add_custom_command(
         OUTPUT libcrypto.symbols
         COMMAND
           # copy the static version of libcrypto
-          cp ${crypto_STATIC_LIBRARY} libcrypto.a &&
+          cp ${crypto_STATIC_LIBRARY} s2n_libcrypto.a &&
           # dump all of the symbols and prefix them with `s2n$`
-          bash -c "nm libcrypto.a | awk '/ [A-Z] /{print $3\" s2n$\"$3}' | sort | uniq > libcrypto.symbols" &&
+          bash -c "nm s2n_libcrypto.a | awk '/ [A-Z] /{print $3\" s2n$\"$3}' | sort | uniq > libcrypto.symbols" &&
           # redefine the libcrypto libary symbols
-          objcopy --redefine-syms libcrypto.symbols libcrypto.a &&
-          rm -rf libcrypto &&
-          mkdir libcrypto &&
-          cd libcrypto &&
+          objcopy --redefine-syms libcrypto.symbols s2n_libcrypto.a &&
+          rm -rf s2n_libcrypto &&
+          mkdir s2n_libcrypto &&
+          cd s2n_libcrypto &&
           # extract libcrypto objects from the archive
-          ar x ../libcrypto.a &&
+          ar x ../s2n_libcrypto.a &&
           # rename all of the object files so we don't have any object name collisions
           bash -c "find . -name '*.o' -type f -print0 | xargs -0 -n1 -- basename | xargs -I{} mv {} s2n_crypto__{}"
         VERBATIM
     )
 
-    add_custom_target(libcrypto ALL
+    add_custom_target(s2n_libcrypto ALL
       DEPENDS libcrypto.symbols
     )
-    add_dependencies(${PROJECT_NAME} libcrypto)
-
-    add_custom_command(
-        TARGET ${PROJECT_NAME} PRE_LINK
-        DEPENDS libcrypto.symbols
-        COMMAND
-        find ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${PROJECT_NAME}.dir -name '*.o' -exec objcopy --redefine-syms libcrypto.symbols {} \\\;
-    )
+    add_dependencies(${PROJECT_NAME} s2n_libcrypto)
 
     # copy the static libcrypto into the final artifact
     if (BUILD_SHARED_LIBS)
-        # if we're building for testing, we export the prefixed symbols so tests can link to them
         if (BUILD_TESTING)
+          # if we're building tests, we export the prefixed symbols so tests can link to them
           set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS
-              "-Wl,--whole-archive libcrypto.a -Wl,--no-whole-archive")
+              "-Wl,--whole-archive s2n_libcrypto.a -Wl,--no-whole-archive")
         else()
+          # if we're not building tests, then just copy the original archive, unmodified
           set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS
-              "-Wl,--whole-archive libcrypto.a -Wl,--no-whole-archive -Wl,--exclude-libs=ALL")
+              "-Wl,--whole-archive ${crypto_STATIC_LIBRARY} -Wl,--no-whole-archive -Wl,--exclude-libs=ALL")
         endif()
     else()
         add_custom_command(
             TARGET ${PROJECT_NAME} POST_BUILD
             DEPENDS libcrypto.symbols
             COMMAND
-              bash -c "ar -r lib/libs2n.a libcrypto/*.o"
+              bash -c "ar -r lib/libs2n.a s2n_libcrypto/*.o"
             VERBATIM
         )
     endif()
@@ -588,6 +585,9 @@ if (BUILD_TESTING)
     target_link_libraries(testss2n PUBLIC ${PROJECT_NAME})
 
     if (S2N_INTERN_LIBCRYPTO)
+        # build the tests with the correct headers
+        include_directories("${crypto_INCLUDE_DIR}")
+
         # if libcrypto was interned, rewrite libcrypto symbols so use of internal functions will link correctly
         add_custom_command(
             TARGET testss2n POST_BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,8 +516,8 @@ if (S2N_INTERN_LIBCRYPTO)
         message(FATAL_ERROR "libcrypto interning requires a static build of libcrypto.a to be available")
     endif()
 
-    # LINK_LIB is set above after checking targets. It handles the find_package craziness.
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${LINK_LIB})
+    # Don't call link_target_libraries here, just make sure the libcrypto include dir is in the path
+    include_directories("${crypto_INCLUDE_DIR}")
 
     add_custom_command(
         OUTPUT libcrypto.symbols
@@ -543,18 +543,28 @@ if (S2N_INTERN_LIBCRYPTO)
     )
     add_dependencies(${PROJECT_NAME} s2n_libcrypto)
 
+    if ((BUILD_SHARED_LIBS AND BUILD_TESTING) OR NOT BUILD_SHARED_LIBS)
+        # if libcrypto needs to be interned, rewrite libcrypto references so use of internal functions will link correctly
+        add_custom_command(
+            TARGET ${PROJECT_NAME} PRE_LINK
+            COMMAND
+              find "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${PROJECT_NAME}.dir" -name '*.c.o' -exec objcopy --redefine-syms libcrypto.symbols {} \\\;
+        )
+    endif()
+
     # copy the static libcrypto into the final artifact
     if (BUILD_SHARED_LIBS)
         if (BUILD_TESTING)
-          # if we're building tests, we export the prefixed symbols so tests can link to them
-          set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS
-              "-Wl,--whole-archive s2n_libcrypto.a -Wl,--no-whole-archive")
+            # if we're building tests, we export the prefixed symbols so tests can link to them
+            set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS
+                "-Wl,--whole-archive s2n_libcrypto.a -Wl,--no-whole-archive")
         else()
-          # if we're not building tests, then just copy the original archive, unmodified
-          set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS
-              "-Wl,--whole-archive ${crypto_STATIC_LIBRARY} -Wl,--no-whole-archive -Wl,--exclude-libs=ALL")
+            # if we're not building tests, then just copy the original archive, unmodified
+            set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS
+                "-Wl,--whole-archive ${crypto_STATIC_LIBRARY} -Wl,--no-whole-archive -Wl,--exclude-libs=ALL")
         endif()
     else()
+        # add all of the prefixed symbols to the archive
         add_custom_command(
             TARGET ${PROJECT_NAME} POST_BUILD
             DEPENDS libcrypto.symbols
@@ -585,9 +595,6 @@ if (BUILD_TESTING)
     target_link_libraries(testss2n PUBLIC ${PROJECT_NAME})
 
     if (S2N_INTERN_LIBCRYPTO)
-        # build the tests with the correct headers
-        include_directories("${crypto_INCLUDE_DIR}")
-
         # if libcrypto was interned, rewrite libcrypto symbols so use of internal functions will link correctly
         add_custom_command(
             TARGET testss2n POST_BUILD


### PR DESCRIPTION
### Resolved issues:

Resolves #3201, #3203

### Description of changes: 

#3181 missed testing the libcrypto interning functionality and has been broken since. This change fixes the issue by adding `include_directories("${crypto_INCLUDE_DIR}")` to the build script.

I've also:

* Disabled symbol prefixing when building a shared library without tests, as it isn't actually needed. This _should_ help with the fips build but that will be for another PR.
* Cleaned the test script up a bit and made sure the unit tests still pass with the wrong libcrypto version loaded

- ad-hoc [codebuild](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nGeneralBatch/build/s2nGeneralBatch%3A35b6c067-d7c3-400d-af3c-8c7ed583c919/log?region=us-west-2) test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
