### PR TITLE
Address new-ish python warning

### DIFF
--- a/tests/integrationv2/conftest.py
+++ b/tests/integrationv2/conftest.py
@@ -19,9 +19,9 @@ def pytest_configure(config):
 
     no_pq = config.getoption('no-pq', 0)
     fips_mode = config.getoption('fips-mode', 0)
-    if no_pq is 1:
+    if no_pq == 1:
         set_flag(S2N_NO_PQ, True)
-    if fips_mode is 1:
+    if fips_mode == 1:
         set_flag(S2N_FIPS_MODE, True)
 
     set_flag(S2N_PROVIDER_VERSION, config.getoption('provider-version', None))


### PR DESCRIPTION
### Resolved issues:

none

### Description of changes: 

With #3186, we've bumped from  python 3.6 to 3.9 and we're seeing a new warning in the integrationv2 tests w/r/t PQ and FIPS flags.

See [Identity checks vs literals](https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior). 

### Call-outs:

- Minor annoyance only.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? CI

 Is this a refactor change? No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
