### PR TITLE
Secret reorder for s2n-quic

### DIFF
--- a/tests/unit/s2n_tls13_key_schedule_test.c
+++ b/tests/unit/s2n_tls13_key_schedule_test.c
@@ -52,6 +52,18 @@ static int s2n_test_secret_cb(void* context, struct s2n_connection *conn,
     POSIX_GUARD(s2n_blob_init(&secrets->blobs[secret_type],
             secrets->bytes[secret_type], secret_size));
     POSIX_CHECKED_MEMCPY(secrets->bytes[secret_type], secret_bytes, secret_size);
+
+    /* s2n-quic requires that all handshake secrets be emitted before
+     * any application secrets.
+     *
+     * This requirement is not supported for 0RTT yet.
+     */
+    bool is_handshake_secret = (secret_type == S2N_CLIENT_HANDSHAKE_TRAFFIC_SECRET
+            || secret_type == S2N_SERVER_HANDSHAKE_TRAFFIC_SECRET);
+    if (!WITH_EARLY_DATA(conn) && is_handshake_secret) {
+        POSIX_ENSURE_EQ(secrets->blobs[S2N_CLIENT_APPLICATION_TRAFFIC_SECRET].size, 0);
+        POSIX_ENSURE_EQ(secrets->blobs[S2N_SERVER_APPLICATION_TRAFFIC_SECRET].size, 0);
+    }
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_tls13_key_schedule.c
+++ b/tls/s2n_tls13_key_schedule.c
@@ -246,21 +246,22 @@ static S2N_RESULT s2n_server_key_schedule(struct s2n_connection *conn)
      *# Can send                       | [Send Certificate + CertificateVerify]
      *# app data                       | Send Finished
      *# after   -->                    | K_send = application
-     */
-    if (message_type == SERVER_FINISHED) {
-        K_send(conn, S2N_APPLICATION_SECRET);
-    /**
-     *= https://tools.ietf.org/rfc/rfc8446#appendix-A.2
      *# here                  +--------+--------+
      *#              No 0-RTT |                 | 0-RTT
      *#                       |                 |
      *#   K_recv = handshake  |                 | K_recv = early data
      */
+    if (message_type == SERVER_FINISHED) {
+        /* Warning: s2n-quic currently requires that we emit secrets in pairs.
+         * Therefore, we must handle the handshake secret before we handle
+         * the application secret here.
+         */
         if (WITH_EARLY_DATA(conn)) {
             K_recv(conn, S2N_EARLY_SECRET);
         } else {
             K_recv(conn, S2N_HANDSHAKE_SECRET);
         }
+        K_send(conn, S2N_APPLICATION_SECRET);
     }
     /**
      *= https://tools.ietf.org/rfc/rfc8446#appendix-A.2


### PR DESCRIPTION
### Description of changes: 
On the ServerHello, we emit both the client handshake secret and the server application secret. At the moment, we match the state machine from the RFC and set the sending key before the receiving key, meaning that we emit the server application secret before the client handshake secret. This breaks s2n-quic, which assumes a specific order for the secrets.

I just reordered the logic so that we set the receiving key before the sending key. This has no impact on s2n-tls (besides less pretty compliance comments), but should unblock s2n-quic.

### Testing:
Added a new test to remind us of this requirement, since it'd be easy to accidentally revert.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
