### PR TITLE
bindings: update version in preperation for publishing the bindings to crates.io

### DIFF
--- a/bindings/rust/integration/Cargo.toml
+++ b/bindings/rust/integration/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 publish = false
 
 [dependencies]
-s2n-tls = { version = "=0.0.4", path = "../s2n-tls", features = ["testing"] }
-s2n-tls-sys = { version = "=0.0.4", path = "../s2n-tls-sys" }
+s2n-tls = { path = "../s2n-tls", features = ["testing"] }
+s2n-tls-sys = { path = "../s2n-tls-sys" }
 criterion = { version = "0.3", features = ["html_reports"] }
 
 [[bench]]

--- a/bindings/rust/integration/Cargo.toml
+++ b/bindings/rust/integration/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 publish = false
 
 [dependencies]
-s2n-tls = { version = "0.0.2", path = "../s2n-tls", features = ["testing"] }
-s2n-tls-sys = { version = "0.0.2", path = "../s2n-tls-sys" }
+s2n-tls = { version = "=0.0.4", path = "../s2n-tls", features = ["testing"] }
+s2n-tls-sys = { version = "=0.0.4", path = "../s2n-tls-sys" }
 criterion = { version = "0.3", features = ["html_reports"] }
 
 [[bench]]

--- a/bindings/rust/s2n-tls-sys/Cargo.toml
+++ b/bindings/rust/s2n-tls-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-sys"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.0.2"
+version = "0.0.4"
 authors = ["AWS s2n"]
 edition = "2018"
 links = "s2n-tls"

--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.0.2"
+version = "0.0.4"
 authors = ["AWS s2n"]
 edition = "2018"
 repository = "https://github.com/aws/s2n-tls"
@@ -17,7 +17,7 @@ testing = ["errno", "bytes"]
 bytes = { version = "1", optional = true }
 errno = { version = "0.2", optional = true }
 libc = "0.2"
-s2n-tls-sys = { version = "0.0.2", path = "../s2n-tls-sys", features = ["internal"] }
+s2n-tls-sys = { version = "=0.0.4", path = "../s2n-tls-sys", features = ["internal"] }
 
 [dev-dependencies]
 bytes = { version = "1" }


### PR DESCRIPTION
**Note: do not merge until after the 3 PRs in the callout section are merged.**

### Description of changes: 
The current published version is [`0.0.3`](https://crates.io/crates/s2n-tls/0.0.3) so the next version is `0.0.4`

### Call-outs:

Waiting to include the following PRs before merging and releasing a new version.
- [x] https://github.com/aws/s2n-tls/pull/3230
- [x] https://github.com/aws/s2n-tls/pull/3216
- [x] https://github.com/aws/s2n-tls/pull/3229

### Testing:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
