### PR TITLE
Add missing safety macro deprecation messages

### DIFF
--- a/docs/SAFETY-MACROS.md
+++ b/docs/SAFETY-MACROS.md
@@ -337,10 +337,14 @@ Ensures `result == _OSSL_SUCCESS`, otherwise the function will `POSIX_BAIL` with
 
 ### POSIX_GUARD_RESULT(result)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `s2n_result_is_ok(result)`, otherwise the function will return `S2N_FAILURE`
 
 
 ### POSIX_GUARD_PTR(result)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures `(result) != NULL`, otherwise the function will return `S2N_FAILURE`
 
@@ -528,10 +532,14 @@ Ensures `result == _OSSL_SUCCESS`, otherwise the function will `PTR_BAIL` with `
 
 ### PTR_GUARD_RESULT(result)
 
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+
 Ensures `s2n_result_is_ok(result)`, otherwise the function will return `NULL`
 
 
 ### PTR_GUARD_POSIX(result)
+
+DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
 
 Ensures `(result) >= S2N_SUCCESS`, otherwise the function will return `NULL`
 

--- a/scripts/s2n_safety_macros.py
+++ b/scripts/s2n_safety_macros.py
@@ -706,6 +706,8 @@ for context in CONTEXTS:
             doc = 'Ensures `{is_ok}`, otherwise the function will return `{error}`'
             if other == PTR:
                 doc += '\n\nDoes not set s2n_errno to S2N_ERR_NULL, so is NOT a direct replacement for {prefix}ENSURE_REF.'
+            if context['ret'] != DEFAULT['ret']:
+                doc = (deprecation_message + "\n\n" + doc)
 
             if other == context:
                 continue;

--- a/utils/s2n_safety_macros.h
+++ b/utils/s2n_safety_macros.h
@@ -388,11 +388,15 @@
 #define POSIX_GUARD_OSSL(result, error)                       __S2N_ENSURE((result) == _OSSL_SUCCESS, POSIX_BAIL(error))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `s2n_result_is_ok(result)`, otherwise the function will return `S2N_FAILURE`
  */
 #define POSIX_GUARD_RESULT(result)                            __S2N_ENSURE(s2n_result_is_ok(result), return S2N_FAILURE)
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `(result) != NULL`, otherwise the function will return `S2N_FAILURE`
  *
  * Does not set s2n_errno to S2N_ERR_NULL, so is NOT a direct replacement for POSIX_ENSURE_REF.
@@ -590,11 +594,15 @@
 #define PTR_GUARD_OSSL(result, error)                         __S2N_ENSURE((result) == _OSSL_SUCCESS, PTR_BAIL(error))
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `s2n_result_is_ok(result)`, otherwise the function will return `NULL`
  */
 #define PTR_GUARD_RESULT(result)                              __S2N_ENSURE(s2n_result_is_ok(result), return NULL)
 
 /**
+ * DEPRECATED: all methods (except those in s2n.h) should return s2n_result.
+ *
  * Ensures `(result) >= S2N_SUCCESS`, otherwise the function will return `NULL`
  */
 #define PTR_GUARD_POSIX(result)                               __S2N_ENSURE((result) >= S2N_SUCCESS, return NULL)


### PR DESCRIPTION
### Resolved issues:
resolves https://github.com/aws/s2n-tls/pull/3239#discussion_r831410296

### Description of changes: 

Add deprecation message to the x_GUARD_y macros too.

### Call-outs:
These were probably missed when the deprecation warnings were added because they're not actually CONTEXTs.

### Testing:
Just documentation change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
