### PR TITLE
ci: Add a CRT codebuild job

### DIFF
--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -370,6 +370,15 @@ batch:
           TESTS: interning
           BUILD_S2N: 'true'
 
+    - identifier: s2nUnitCRT
+      buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          GCC_VERSION: '6'
+          TESTS: crt
+
     # Fuzz tests
     - identifier: s2nFuzzerOpenSSL111Coverage
       buildspec: codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml


### PR DESCRIPTION
### Resolved issues:

Partial for #1491

### Description of changes: 

With the scripts merged in #3176,  add a CodeBuild job to test [aws-crt](https://github.com/awslabs/aws-crt-cpp).

### Call-outs:

No CI will run for this PR, see the ad-hoc job below.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? [Ad-hoc codebuild](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nGeneralBatch/build/s2nGeneralBatch%3Ae59e5ea7-3d2b-4c5d-992e-8cd882009672/log?region=us-west-2)

 Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
