### PR TITLE
Port drbg.c functions to use S2N_RESULT

### DIFF
--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -29,7 +29,7 @@
 /* This function is the same as s2n_increment_sequence_number
     but it does not check for overflow, since overflow is
     acceptable in DRBG */
-int s2n_increment_drbg_counter(struct s2n_blob *counter)
+S2N_RESULT s2n_increment_drbg_counter(struct s2n_blob *counter)
 {
     for (uint32_t i = counter->size; i > 0; i--) {
         counter->data[i-1] += 1;
@@ -39,60 +39,62 @@ int s2n_increment_drbg_counter(struct s2n_blob *counter)
 
        /* seq[i] wrapped, so let it carry */
     }
-    return 0;
+    return S2N_RESULT_OK;
 }
 
-static int s2n_drbg_block_encrypt(EVP_CIPHER_CTX * ctx, uint8_t in[S2N_DRBG_BLOCK_SIZE], uint8_t out[S2N_DRBG_BLOCK_SIZE])
+static S2N_RESULT s2n_drbg_block_encrypt(EVP_CIPHER_CTX *ctx, uint8_t in[S2N_DRBG_BLOCK_SIZE], uint8_t out[S2N_DRBG_BLOCK_SIZE])
 {
-    POSIX_ENSURE_REF(ctx);
+    RESULT_ENSURE_REF(ctx);
+
     int len = S2N_DRBG_BLOCK_SIZE;
-    POSIX_GUARD_OSSL(EVP_EncryptUpdate(ctx, out, &len, in, S2N_DRBG_BLOCK_SIZE), S2N_ERR_DRBG);
-    POSIX_ENSURE_EQ(len, S2N_DRBG_BLOCK_SIZE);
+    RESULT_GUARD_OSSL(EVP_EncryptUpdate(ctx, out, &len, in, S2N_DRBG_BLOCK_SIZE), S2N_ERR_DRBG);
+    RESULT_ENSURE_EQ(len, S2N_DRBG_BLOCK_SIZE);
 
-    return 0;
+    return S2N_RESULT_OK;
 }
 
-static int s2n_drbg_bits(struct s2n_drbg *drbg, struct s2n_blob *out)
+static S2N_RESULT s2n_drbg_bits(struct s2n_drbg *drbg, struct s2n_blob *out)
 {
-    POSIX_ENSURE_REF(drbg);
-    POSIX_ENSURE_REF(drbg->ctx);
-    POSIX_ENSURE_REF(out);
+    RESULT_ENSURE_REF(drbg);
+    RESULT_ENSURE_REF(drbg->ctx);
+    RESULT_ENSURE_REF(out);
 
     struct s2n_blob value = {0};
-    POSIX_GUARD(s2n_blob_init(&value, drbg->v, sizeof(drbg->v)));
+    RESULT_GUARD_POSIX(s2n_blob_init(&value, drbg->v, sizeof(drbg->v)));
     int block_aligned_size = out->size - (out->size % S2N_DRBG_BLOCK_SIZE);
 
     /* Per NIST SP800-90A 10.2.1.2: */
     for (int i = 0; i < block_aligned_size; i += S2N_DRBG_BLOCK_SIZE) {
-        POSIX_GUARD(s2n_increment_drbg_counter(&value));
-        POSIX_GUARD(s2n_drbg_block_encrypt(drbg->ctx, drbg->v, out->data + i));
+        RESULT_GUARD(s2n_increment_drbg_counter(&value));
+        RESULT_GUARD(s2n_drbg_block_encrypt(drbg->ctx, drbg->v, out->data + i));
         drbg->bytes_used += S2N_DRBG_BLOCK_SIZE;
     }
 
     if (out->size <= block_aligned_size) {
-        return 0;
+        return S2N_RESULT_OK;
     }
 
     uint8_t spare_block[S2N_DRBG_BLOCK_SIZE];
-    POSIX_GUARD(s2n_increment_drbg_counter(&value));
-    POSIX_GUARD(s2n_drbg_block_encrypt(drbg->ctx, drbg->v, spare_block));
+    RESULT_GUARD(s2n_increment_drbg_counter(&value));
+    RESULT_GUARD(s2n_drbg_block_encrypt(drbg->ctx, drbg->v, spare_block));
     drbg->bytes_used += S2N_DRBG_BLOCK_SIZE;
 
-    POSIX_CHECKED_MEMCPY(out->data + block_aligned_size, spare_block, out->size - block_aligned_size);
+    RESULT_CHECKED_MEMCPY(out->data + block_aligned_size, spare_block, out->size - block_aligned_size);
 
-    return 0;
+    return S2N_RESULT_OK;
 }
 
-static int s2n_drbg_update(struct s2n_drbg *drbg, struct s2n_blob *provided_data)
+static S2N_RESULT s2n_drbg_update(struct s2n_drbg *drbg, struct s2n_blob *provided_data)
 {
-    POSIX_ENSURE_REF(drbg);
-    POSIX_ENSURE_REF(drbg->ctx);
+    RESULT_ENSURE_REF(drbg);
+    RESULT_ENSURE_REF(drbg->ctx);
+    RESULT_ENSURE_REF(provided_data);
 
-    s2n_stack_blob(temp_blob, s2n_drbg_seed_size(drgb), S2N_DRBG_MAX_SEED_SIZE);
+    s2n_stack_blob_result(temp_blob, s2n_drbg_seed_size(drgb), S2N_DRBG_MAX_SEED_SIZE);
 
-    POSIX_ENSURE_EQ(provided_data->size, s2n_drbg_seed_size(drbg));
+    RESULT_ENSURE_EQ(provided_data->size, s2n_drbg_seed_size(drbg));
 
-    POSIX_GUARD(s2n_drbg_bits(drbg, &temp_blob));
+    RESULT_GUARD(s2n_drbg_bits(drbg, &temp_blob));
 
     /* XOR in the provided data */
     for (uint32_t i = 0; i < provided_data->size; i++) {
@@ -100,102 +102,104 @@ static int s2n_drbg_update(struct s2n_drbg *drbg, struct s2n_blob *provided_data
     }
 
     /* Update the key and value */
-    POSIX_GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, NULL, NULL, temp_blob.data, NULL), S2N_ERR_DRBG);
+    RESULT_GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, NULL, NULL, temp_blob.data, NULL), S2N_ERR_DRBG);
 
-    POSIX_CHECKED_MEMCPY(drbg->v, temp_blob.data + s2n_drbg_key_size(drbg), S2N_DRBG_BLOCK_SIZE);
+    RESULT_CHECKED_MEMCPY(drbg->v, temp_blob.data + s2n_drbg_key_size(drbg), S2N_DRBG_BLOCK_SIZE);
 
-    return 0;
+    return S2N_RESULT_OK;
 }
 
-static int s2n_drbg_mix_in_entropy(struct s2n_drbg *drbg, struct s2n_blob *entropy, struct s2n_blob *ps)
+static S2N_RESULT s2n_drbg_mix_in_entropy(struct s2n_drbg *drbg, struct s2n_blob *entropy, struct s2n_blob *ps)
 {
-    POSIX_ENSURE_REF(drbg);
-    POSIX_ENSURE_REF(drbg->ctx);
-    POSIX_ENSURE_REF(entropy);
+    RESULT_ENSURE_REF(drbg);
+    RESULT_ENSURE_REF(drbg->ctx);
+    RESULT_ENSURE_REF(entropy);
 
-    POSIX_ENSURE_GTE(entropy->size, ps->size);
+    RESULT_ENSURE_GTE(entropy->size, ps->size);
 
     for (uint32_t i = 0; i < ps->size; i++) {
         entropy->data[i] ^= ps->data[i];
     }
 
-    POSIX_GUARD(s2n_drbg_update(drbg, entropy));
+    RESULT_GUARD(s2n_drbg_update(drbg, entropy));
 
-    return 0;
+    return S2N_RESULT_OK;
 }
 
-static int s2n_drbg_seed(struct s2n_drbg *drbg, struct s2n_blob *ps)
+static S2N_RESULT s2n_drbg_seed(struct s2n_drbg *drbg, struct s2n_blob *ps)
 {
-    s2n_stack_blob(blob, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
+    s2n_stack_blob_result(blob, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
 
-    POSIX_GUARD_RESULT(s2n_get_seed_entropy(&blob));
-    POSIX_GUARD(s2n_drbg_mix_in_entropy(drbg, &blob, ps));
+    RESULT_GUARD(s2n_get_seed_entropy(&blob));
+    RESULT_GUARD(s2n_drbg_mix_in_entropy(drbg, &blob, ps));
 
     drbg->bytes_used = 0;
 
-    return 0;
+    return S2N_RESULT_OK;
 }
 
-static int s2n_drbg_mix(struct s2n_drbg *drbg, struct s2n_blob *ps)
+static S2N_RESULT s2n_drbg_mix(struct s2n_drbg *drbg, struct s2n_blob *ps)
 {
-    s2n_stack_blob(blob, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
+    s2n_stack_blob_result(blob, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
 
-    POSIX_GUARD_RESULT(s2n_get_mix_entropy(&blob));
-    POSIX_GUARD(s2n_drbg_mix_in_entropy(drbg, &blob, ps));
+    RESULT_GUARD(s2n_get_mix_entropy(&blob));
+    RESULT_GUARD(s2n_drbg_mix_in_entropy(drbg, &blob, ps));
 
     drbg->mixes += 1;
 
-    return 0;
+    return S2N_RESULT_OK;
 }
 
-int s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personalization_string, const s2n_drbg_mode mode)
+S2N_RESULT s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personalization_string, const s2n_drbg_mode mode)
 {
-    POSIX_ENSURE_REF(drbg);
+    RESULT_ENSURE_REF(drbg);
+    RESULT_ENSURE_REF(personalization_string);
 
     drbg->ctx = EVP_CIPHER_CTX_new();
-    S2N_ERROR_IF(!drbg->ctx, S2N_ERR_DRBG);
+    RESULT_GUARD_PTR(drbg->ctx);
 
     s2n_evp_ctx_init(drbg->ctx);
 
     switch(mode) {
         case S2N_AES_128_CTR_NO_DF_PR:
-            POSIX_GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, EVP_aes_128_ecb(), NULL, NULL, NULL), S2N_ERR_DRBG);
+            RESULT_GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, EVP_aes_128_ecb(), NULL, NULL, NULL), S2N_ERR_DRBG);
             break;
         case S2N_AES_256_CTR_NO_DF_PR:
-            POSIX_GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, EVP_aes_256_ecb(), NULL, NULL, NULL), S2N_ERR_DRBG);
+            RESULT_GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, EVP_aes_256_ecb(), NULL, NULL, NULL), S2N_ERR_DRBG);
             break;
         default:
-            POSIX_BAIL(S2N_ERR_DRBG);
+            RESULT_BAIL(S2N_ERR_DRBG);
     }
 
-    POSIX_ENSURE_LTE(s2n_drbg_key_size(drbg), S2N_DRBG_MAX_KEY_SIZE);
-    POSIX_ENSURE_LTE(s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
+    RESULT_ENSURE_LTE(s2n_drbg_key_size(drbg), S2N_DRBG_MAX_KEY_SIZE);
+    RESULT_ENSURE_LTE(s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
 
     static const uint8_t zero_key[S2N_DRBG_MAX_KEY_SIZE] = {0};
 
     /* Start off with zeroed data, per 10.2.1.3.1 item 4 and 5 */
     memset(drbg->v, 0, sizeof(drbg->v));
-    POSIX_GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, NULL, NULL, zero_key, NULL), S2N_ERR_DRBG);
+    RESULT_GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, NULL, NULL, zero_key, NULL), S2N_ERR_DRBG);
 
     /* Copy the personalization string */
-    s2n_stack_blob(ps, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
-    POSIX_GUARD(s2n_blob_zero(&ps));
+    s2n_stack_blob_result(ps, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
+    RESULT_GUARD_POSIX(s2n_blob_zero(&ps));
 
-    POSIX_CHECKED_MEMCPY(ps.data, personalization_string->data, MIN(ps.size, personalization_string->size));
+    RESULT_CHECKED_MEMCPY(ps.data, personalization_string->data, MIN(ps.size, personalization_string->size));
 
     /* Seed the DRBG */
-    POSIX_GUARD(s2n_drbg_seed(drbg, &ps));
+    RESULT_GUARD(s2n_drbg_seed(drbg, &ps));
 
-    return 0;
+    return S2N_RESULT_OK;
 }
 
-int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob)
+S2N_RESULT s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob)
 {
-    POSIX_ENSURE_REF(drbg);
-    POSIX_ENSURE_REF(drbg->ctx);
-    s2n_stack_blob(zeros, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
+    RESULT_ENSURE_REF(drbg);
+    RESULT_ENSURE_REF(drbg->ctx);
 
-    S2N_ERROR_IF(blob->size > S2N_DRBG_GENERATE_LIMIT, S2N_ERR_DRBG_REQUEST_SIZE);
+    s2n_stack_blob_result(zeros, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
+
+    RESULT_ENSURE(blob->size <= S2N_DRBG_GENERATE_LIMIT, S2N_ERR_DRBG_REQUEST_SIZE);
 
     /* Mix in additional entropy for every randomness generation call. This
      * defense mechanism is referred to as "prediction resistance".
@@ -205,31 +209,33 @@ int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob)
      *  2. Re-consider whether the current fork detection strategy is still
      *     sufficient.
      */
-    POSIX_GUARD(s2n_drbg_mix(drbg, &zeros));
-    POSIX_GUARD(s2n_drbg_bits(drbg, blob));
-    POSIX_GUARD(s2n_drbg_update(drbg, &zeros));
+    RESULT_GUARD(s2n_drbg_mix(drbg, &zeros));
+    RESULT_GUARD(s2n_drbg_bits(drbg, blob));
+    RESULT_GUARD(s2n_drbg_update(drbg, &zeros));
 
-    return 0;
+    return S2N_RESULT_OK;
 }
 
-int s2n_drbg_wipe(struct s2n_drbg *drbg)
+S2N_RESULT s2n_drbg_wipe(struct s2n_drbg *drbg)
 {
-    POSIX_ENSURE_REF(drbg);
+    RESULT_ENSURE_REF(drbg);
+
     if (drbg->ctx) {
-        POSIX_GUARD_OSSL(EVP_CIPHER_CTX_cleanup(drbg->ctx), S2N_ERR_DRBG);
+        RESULT_GUARD_OSSL(EVP_CIPHER_CTX_cleanup(drbg->ctx), S2N_ERR_DRBG);
 
         EVP_CIPHER_CTX_free(drbg->ctx);
         drbg->ctx = NULL;
     }
 
     *drbg = (struct s2n_drbg) {0};
-    return 0;
+    return S2N_RESULT_OK;
 }
 
-int s2n_drbg_bytes_used(struct s2n_drbg *drbg, uint64_t *bytes_used)
+S2N_RESULT s2n_drbg_bytes_used(struct s2n_drbg *drbg, uint64_t *bytes_used)
 {
-    POSIX_ENSURE_REF(drbg);
-    POSIX_ENSURE_REF(bytes_used);
+    RESULT_ENSURE_REF(drbg);
+    RESULT_ENSURE_REF(bytes_used);
+
     *bytes_used = drbg->bytes_used;
-    return 0;
+    return S2N_RESULT_OK;
 }

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -90,7 +90,7 @@ static S2N_RESULT s2n_drbg_update(struct s2n_drbg *drbg, struct s2n_blob *provid
     RESULT_ENSURE_REF(drbg->ctx);
     RESULT_ENSURE_REF(provided_data);
 
-    S2N_RESULT_STACK_BLOB(temp_blob, s2n_drbg_seed_size(drgb), S2N_DRBG_MAX_SEED_SIZE);
+    RESULT_STACK_BLOB(temp_blob, s2n_drbg_seed_size(drgb), S2N_DRBG_MAX_SEED_SIZE);
 
     RESULT_ENSURE_EQ(provided_data->size, s2n_drbg_seed_size(drbg));
 
@@ -128,7 +128,7 @@ static S2N_RESULT s2n_drbg_mix_in_entropy(struct s2n_drbg *drbg, struct s2n_blob
 
 static S2N_RESULT s2n_drbg_seed(struct s2n_drbg *drbg, struct s2n_blob *ps)
 {
-    S2N_RESULT_STACK_BLOB(blob, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
+    RESULT_STACK_BLOB(blob, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
 
     RESULT_GUARD(s2n_get_seed_entropy(&blob));
     RESULT_GUARD(s2n_drbg_mix_in_entropy(drbg, &blob, ps));
@@ -140,7 +140,7 @@ static S2N_RESULT s2n_drbg_seed(struct s2n_drbg *drbg, struct s2n_blob *ps)
 
 static S2N_RESULT s2n_drbg_mix(struct s2n_drbg *drbg, struct s2n_blob *ps)
 {
-    S2N_RESULT_STACK_BLOB(blob, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
+    RESULT_STACK_BLOB(blob, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
 
     RESULT_GUARD(s2n_get_mix_entropy(&blob));
     RESULT_GUARD(s2n_drbg_mix_in_entropy(drbg, &blob, ps));
@@ -158,7 +158,7 @@ S2N_RESULT s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personal
     drbg->ctx = EVP_CIPHER_CTX_new();
     RESULT_GUARD_PTR(drbg->ctx);
 
-    S2N_RESULT_EVP_CTX_INIT(drbg->ctx);
+    RESULT_EVP_CTX_INIT(drbg->ctx);
 
     switch(mode) {
         case S2N_AES_128_CTR_NO_DF_PR:
@@ -181,7 +181,7 @@ S2N_RESULT s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personal
     RESULT_GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, NULL, NULL, zero_key, NULL), S2N_ERR_DRBG);
 
     /* Copy the personalization string */
-    S2N_RESULT_STACK_BLOB(ps, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
+    RESULT_STACK_BLOB(ps, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
     RESULT_GUARD_POSIX(s2n_blob_zero(&ps));
 
     RESULT_CHECKED_MEMCPY(ps.data, personalization_string->data, MIN(ps.size, personalization_string->size));
@@ -197,7 +197,7 @@ S2N_RESULT s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob)
     RESULT_ENSURE_REF(drbg);
     RESULT_ENSURE_REF(drbg->ctx);
 
-    S2N_RESULT_STACK_BLOB(zeros, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
+    RESULT_STACK_BLOB(zeros, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
 
     RESULT_ENSURE(blob->size <= S2N_DRBG_GENERATE_LIMIT, S2N_ERR_DRBG_REQUEST_SIZE);
 

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -90,7 +90,7 @@ static S2N_RESULT s2n_drbg_update(struct s2n_drbg *drbg, struct s2n_blob *provid
     RESULT_ENSURE_REF(drbg->ctx);
     RESULT_ENSURE_REF(provided_data);
 
-    s2n_stack_blob_result(temp_blob, s2n_drbg_seed_size(drgb), S2N_DRBG_MAX_SEED_SIZE);
+    S2N_RESULT_STACK_BLOB(temp_blob, s2n_drbg_seed_size(drgb), S2N_DRBG_MAX_SEED_SIZE);
 
     RESULT_ENSURE_EQ(provided_data->size, s2n_drbg_seed_size(drbg));
 
@@ -128,7 +128,7 @@ static S2N_RESULT s2n_drbg_mix_in_entropy(struct s2n_drbg *drbg, struct s2n_blob
 
 static S2N_RESULT s2n_drbg_seed(struct s2n_drbg *drbg, struct s2n_blob *ps)
 {
-    s2n_stack_blob_result(blob, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
+    S2N_RESULT_STACK_BLOB(blob, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
 
     RESULT_GUARD(s2n_get_seed_entropy(&blob));
     RESULT_GUARD(s2n_drbg_mix_in_entropy(drbg, &blob, ps));
@@ -140,7 +140,7 @@ static S2N_RESULT s2n_drbg_seed(struct s2n_drbg *drbg, struct s2n_blob *ps)
 
 static S2N_RESULT s2n_drbg_mix(struct s2n_drbg *drbg, struct s2n_blob *ps)
 {
-    s2n_stack_blob_result(blob, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
+    S2N_RESULT_STACK_BLOB(blob, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
 
     RESULT_GUARD(s2n_get_mix_entropy(&blob));
     RESULT_GUARD(s2n_drbg_mix_in_entropy(drbg, &blob, ps));
@@ -158,7 +158,7 @@ S2N_RESULT s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personal
     drbg->ctx = EVP_CIPHER_CTX_new();
     RESULT_GUARD_PTR(drbg->ctx);
 
-    s2n_evp_ctx_init_result(drbg->ctx);
+    S2N_RESULT_EVP_CTX_INIT(drbg->ctx);
 
     switch(mode) {
         case S2N_AES_128_CTR_NO_DF_PR:
@@ -181,7 +181,7 @@ S2N_RESULT s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personal
     RESULT_GUARD_OSSL(EVP_EncryptInit_ex(drbg->ctx, NULL, NULL, zero_key, NULL), S2N_ERR_DRBG);
 
     /* Copy the personalization string */
-    s2n_stack_blob_result(ps, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
+    S2N_RESULT_STACK_BLOB(ps, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
     RESULT_GUARD_POSIX(s2n_blob_zero(&ps));
 
     RESULT_CHECKED_MEMCPY(ps.data, personalization_string->data, MIN(ps.size, personalization_string->size));
@@ -197,7 +197,7 @@ S2N_RESULT s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob)
     RESULT_ENSURE_REF(drbg);
     RESULT_ENSURE_REF(drbg->ctx);
 
-    s2n_stack_blob_result(zeros, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
+    S2N_RESULT_STACK_BLOB(zeros, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
 
     RESULT_ENSURE(blob->size <= S2N_DRBG_GENERATE_LIMIT, S2N_ERR_DRBG_REQUEST_SIZE);
 

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -158,7 +158,7 @@ S2N_RESULT s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personal
     drbg->ctx = EVP_CIPHER_CTX_new();
     RESULT_GUARD_PTR(drbg->ctx);
 
-    s2n_evp_ctx_init(drbg->ctx);
+    s2n_evp_ctx_init_result(drbg->ctx);
 
     switch(mode) {
         case S2N_AES_128_CTR_NO_DF_PR:

--- a/crypto/s2n_drbg.h
+++ b/crypto/s2n_drbg.h
@@ -52,12 +52,13 @@ typedef enum {S2N_AES_128_CTR_NO_DF_PR, S2N_AES_256_CTR_NO_DF_PR} s2n_drbg_mode;
 
 /* Per NIST SP 800-90C 6.3
  *
- * s2n's DRBG does provide prediction resistance
- * and does not support the additional_input parameter (which per 800-90C may be zero).
+ * s2n's DRBG uses prediction resistance and does not support the
+ * additional_input parameter (which per 800-90C may be zero).
  *
-  * The security strength provided by s2n's DRBG is either 128 or 256 bits depending on the s2n_drbg_mode passed in.
+ * The security strength provided by s2n's DRBG is either 128 or 256 bits
+ * depending on the s2n_drbg_mode passed in.
  */
-extern int s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personalization_string, const s2n_drbg_mode mode);
-extern int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *returned_bits);
-extern int s2n_drbg_wipe(struct s2n_drbg *drbg);
-extern int s2n_drbg_bytes_used(struct s2n_drbg *drbg, uint64_t *bytes_used);
+S2N_RESULT s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personalization_string, const s2n_drbg_mode mode);
+S2N_RESULT s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *returned_bits);
+S2N_RESULT s2n_drbg_wipe(struct s2n_drbg *drbg);
+S2N_RESULT s2n_drbg_bytes_used(struct s2n_drbg *drbg, uint64_t *bytes_used);

--- a/crypto/s2n_openssl.h
+++ b/crypto/s2n_openssl.h
@@ -40,10 +40,10 @@
 
 #if (S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0)) && (!defined(OPENSSL_IS_BORINGSSL)) && (!defined(OPENSSL_IS_AWSLC))
 #define s2n_evp_ctx_init(ctx) POSIX_GUARD_OSSL(EVP_CIPHER_CTX_init(ctx), S2N_ERR_DRBG)
-#define S2N_RESULT_EVP_CTX_INIT(ctx) RESULT_GUARD_OSSL(EVP_CIPHER_CTX_init(ctx), S2N_ERR_DRBG)
+#define RESULT_EVP_CTX_INIT(ctx) RESULT_GUARD_OSSL(EVP_CIPHER_CTX_init(ctx), S2N_ERR_DRBG)
 #else
 #define s2n_evp_ctx_init(ctx) EVP_CIPHER_CTX_init(ctx)
-#define S2N_RESULT_EVP_CTX_INIT(ctx) EVP_CIPHER_CTX_init(ctx)
+#define RESULT_EVP_CTX_INIT(ctx) EVP_CIPHER_CTX_init(ctx)
 #endif
 
 #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_FIPS) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_AWSLC) && !defined(OPENSSL_NO_ENGINE)

--- a/crypto/s2n_openssl.h
+++ b/crypto/s2n_openssl.h
@@ -40,13 +40,9 @@
 
 #if (S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0)) && (!defined(OPENSSL_IS_BORINGSSL)) && (!defined(OPENSSL_IS_AWSLC))
 #define s2n_evp_ctx_init(ctx) POSIX_GUARD_OSSL(EVP_CIPHER_CTX_init(ctx), S2N_ERR_DRBG)
-#else
-#define s2n_evp_ctx_init(ctx) EVP_CIPHER_CTX_init(ctx)
-#endif
-
-#if (S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0)) && (!defined(OPENSSL_IS_BORINGSSL)) && (!defined(OPENSSL_IS_AWSLC))
 #define s2n_evp_ctx_init_result(ctx) RESULT_GUARD_OSSL(EVP_CIPHER_CTX_init(ctx), S2N_ERR_DRBG)
 #else
+#define s2n_evp_ctx_init(ctx) EVP_CIPHER_CTX_init(ctx)
 #define s2n_evp_ctx_init_result(ctx) EVP_CIPHER_CTX_init(ctx)
 #endif
 

--- a/crypto/s2n_openssl.h
+++ b/crypto/s2n_openssl.h
@@ -40,10 +40,10 @@
 
 #if (S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0)) && (!defined(OPENSSL_IS_BORINGSSL)) && (!defined(OPENSSL_IS_AWSLC))
 #define s2n_evp_ctx_init(ctx) POSIX_GUARD_OSSL(EVP_CIPHER_CTX_init(ctx), S2N_ERR_DRBG)
-#define s2n_evp_ctx_init_result(ctx) RESULT_GUARD_OSSL(EVP_CIPHER_CTX_init(ctx), S2N_ERR_DRBG)
+#define S2N_RESULT_EVP_CTX_INIT(ctx) RESULT_GUARD_OSSL(EVP_CIPHER_CTX_init(ctx), S2N_ERR_DRBG)
 #else
 #define s2n_evp_ctx_init(ctx) EVP_CIPHER_CTX_init(ctx)
-#define s2n_evp_ctx_init_result(ctx) EVP_CIPHER_CTX_init(ctx)
+#define S2N_RESULT_EVP_CTX_INIT(ctx) EVP_CIPHER_CTX_init(ctx)
 #endif
 
 #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_FIPS) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_AWSLC) && !defined(OPENSSL_NO_ENGINE)

--- a/crypto/s2n_openssl.h
+++ b/crypto/s2n_openssl.h
@@ -44,6 +44,12 @@
 #define s2n_evp_ctx_init(ctx) EVP_CIPHER_CTX_init(ctx)
 #endif
 
+#if (S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0)) && (!defined(OPENSSL_IS_BORINGSSL)) && (!defined(OPENSSL_IS_AWSLC))
+#define s2n_evp_ctx_init_result(ctx) RESULT_GUARD_OSSL(EVP_CIPHER_CTX_init(ctx), S2N_ERR_DRBG)
+#else
+#define s2n_evp_ctx_init_result(ctx) EVP_CIPHER_CTX_init(ctx)
+#endif
+
 #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_FIPS) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_AWSLC) && !defined(OPENSSL_NO_ENGINE)
 #define S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND 1
 #else

--- a/tests/fuzz/LD_PRELOAD/global_overrides.c
+++ b/tests/fuzz/LD_PRELOAD/global_overrides.c
@@ -27,15 +27,15 @@
 #include "utils/s2n_safety.h"
 #include "utils/s2n_random.h"
 
-int s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob) {
+S2N_RESULT s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *blob) {
 
     /* If fuzzing, only generate "fake" random numbers in order to ensure that fuzz tests are deterministic and repeatable.
      * This function should generate non-zero values since this function may be called repeatedly at startup until a
      * non-zero value is generated.
      */
-    POSIX_GUARD_RESULT(s2n_get_public_random_data(blob));
+    RESULT_GUARD(s2n_get_public_random_data(blob));
     drbg->bytes_used += blob->size;
-    return S2N_SUCCESS;
+    return S2N_RESULT_OK;
 }
 
 int s2n_stuffer_send_to_fd(struct s2n_stuffer *stuffer, const int wfd, const uint32_t len, uint32_t *bytes_sent)

--- a/tests/testlib/s2n_pq_kat_test_utils.c
+++ b/tests/testlib/s2n_pq_kat_test_utils.c
@@ -69,8 +69,8 @@ static S2N_RESULT s2n_drbg_generate_for_pq_kat_tests(struct s2n_drbg *drbg, stru
     RESULT_ENSURE(blob->size <= S2N_DRBG_GENERATE_LIMIT, S2N_ERR_DRBG_REQUEST_SIZE);
 
     /* We do NOT mix in additional entropy */
-    RESULT_GUARD_POSIX(s2n_drbg_bits(drbg, blob));
-    RESULT_GUARD_POSIX(s2n_drbg_update(drbg, &zeros));
+    RESULT_GUARD(s2n_drbg_bits(drbg, blob));
+    RESULT_GUARD(s2n_drbg_update(drbg, &zeros));
 
     return S2N_RESULT_OK;
 }
@@ -145,7 +145,7 @@ static int s2n_test_kem_with_kat(const struct s2n_kem *kem, const char *kat_file
          * we use the custom function s2n_drbg_generate_for_pq_kat_tests() defined above to turn off the
          * prediction resistance. */
         POSIX_GUARD(ReadHex(kat_file, kat_entropy_blob.data, SEED_LENGTH, "seed = "));
-        POSIX_GUARD(s2n_drbg_instantiate(&drbg_for_pq_kats, &personalization_string, S2N_AES_256_CTR_NO_DF_PR));
+        POSIX_GUARD_RESULT(s2n_drbg_instantiate(&drbg_for_pq_kats, &personalization_string, S2N_AES_256_CTR_NO_DF_PR));
 
         /* Generate the public/private key pair */
         POSIX_GUARD(kem->generate_keypair(pk, sk));
@@ -172,7 +172,7 @@ static int s2n_test_kem_with_kat(const struct s2n_kem *kem, const char *kat_file
         POSIX_ENSURE_EQ(memcmp(ss_answer, server_shared_secret, kem->shared_secret_key_length ), 0);
 
         /* Wipe the DRBG; it will reseed for each KAT test vector. */
-        POSIX_GUARD(s2n_drbg_wipe(&drbg_for_pq_kats));
+        POSIX_GUARD_RESULT(s2n_drbg_wipe(&drbg_for_pq_kats));
     }
     fclose(kat_file);
     free(ct);

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -299,7 +299,7 @@ int check_drgb_version(s2n_drbg_mode mode, int (*generator)(void *, uint32_t), i
         POSIX_GUARD(s2n_rand_set_callbacks(nist_fake_entropy_init_cleanup, nist_fake_entropy_init_cleanup, generator, generator));
 
         /* Instantiate the DRBG */
-        POSIX_GUARD(s2n_drbg_instantiate(&nist_drbg, &personalization_string, mode));
+        POSIX_GUARD_RESULT(s2n_drbg_instantiate(&nist_drbg, &personalization_string, mode));
 
         uint8_t nist_v[16];
 
@@ -309,13 +309,13 @@ int check_drgb_version(s2n_drbg_mode mode, int (*generator)(void *, uint32_t), i
         /* Generate 512 bits (FIRST CALL) */
         uint8_t out[64];
         struct s2n_blob generated = {.data = out, .size = 64 };
-        POSIX_GUARD(s2n_drbg_generate(&nist_drbg, &generated));
+        POSIX_GUARD_RESULT(s2n_drbg_generate(&nist_drbg, &generated));
 
         POSIX_GUARD(s2n_stuffer_read_bytes(&reference_values, nist_v, sizeof(nist_v)));
         POSIX_ENSURE_EQ(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)), 0);
 
         /* Generate another 512 bits (SECOND CALL) */
-        POSIX_GUARD(s2n_drbg_generate(&nist_drbg, &generated));
+        POSIX_GUARD_RESULT(s2n_drbg_generate(&nist_drbg, &generated));
 
         POSIX_GUARD(s2n_stuffer_read_bytes(&reference_values, nist_v, sizeof(nist_v)));
         POSIX_ENSURE_EQ(memcmp(nist_v, nist_drbg.v, sizeof(nist_drbg.v)), 0);
@@ -331,7 +331,7 @@ int check_drgb_version(s2n_drbg_mode mode, int (*generator)(void *, uint32_t), i
             POSIX_BAIL(S2N_ERR_DRBG);
         }
 
-        POSIX_GUARD(s2n_drbg_wipe(&nist_drbg));
+        POSIX_GUARD_RESULT(s2n_drbg_wipe(&nist_drbg));
     }
     return 0;
 }
@@ -346,21 +346,21 @@ int main(int argc, char **argv)
     struct s2n_drbg aes256_pr_drbg = {0};
     struct s2n_blob blob = {.data = data, .size = 64 };
 
-    EXPECT_SUCCESS(s2n_drbg_instantiate(&aes128_drbg, &blob, S2N_AES_128_CTR_NO_DF_PR));
-    EXPECT_SUCCESS(s2n_drbg_instantiate(&aes256_pr_drbg, &blob, S2N_AES_256_CTR_NO_DF_PR));
+    EXPECT_OK(s2n_drbg_instantiate(&aes128_drbg, &blob, S2N_AES_128_CTR_NO_DF_PR));
+    EXPECT_OK(s2n_drbg_instantiate(&aes256_pr_drbg, &blob, S2N_AES_256_CTR_NO_DF_PR));
 
     struct s2n_config *config;
     EXPECT_NOT_NULL(config = s2n_config_new());
 
     /* Use the AES128 DRBG for 32MB of data */
     for (int i = 0; i < 500000; i++) {
-        EXPECT_SUCCESS(s2n_drbg_generate(&aes128_drbg, &blob));
+        EXPECT_OK(s2n_drbg_generate(&aes128_drbg, &blob));
     }
     EXPECT_EQUAL(aes128_drbg.mixes, 500000);
 
     /* Use the AES256 DRBG with prediction resistance for 32MB of data */
     for (int i = 0; i < 500000; i++) {
-        EXPECT_SUCCESS(s2n_drbg_generate(&aes256_pr_drbg, &blob));
+        EXPECT_OK(s2n_drbg_generate(&aes256_pr_drbg, &blob));
     }
     EXPECT_EQUAL(aes256_pr_drbg.mixes, 500000);
 
@@ -368,8 +368,8 @@ int main(int argc, char **argv)
     /* the DRBG state is 128 bytes, test that we can get more than that */
     blob.size = 129;
     for (int i = 0; i < 10; i++) {
-        EXPECT_SUCCESS(s2n_drbg_generate(&aes128_drbg, &blob));
-        EXPECT_SUCCESS(s2n_drbg_generate(&aes256_pr_drbg, &blob));
+        EXPECT_OK(s2n_drbg_generate(&aes128_drbg, &blob));
+        EXPECT_OK(s2n_drbg_generate(&aes256_pr_drbg, &blob));
     }
     EXPECT_EQUAL(aes128_drbg.mixes, 500010);
     EXPECT_EQUAL(aes256_pr_drbg.mixes, 500010);
@@ -380,7 +380,7 @@ int main(int argc, char **argv)
      * that the last 15 bytes are not all equal to guard against this. */
     POSIX_CHECKED_MEMSET((void*)data, 0, 31);
     blob.size = 31;
-    EXPECT_SUCCESS(s2n_drbg_generate(&aes128_drbg, &blob));
+    EXPECT_OK(s2n_drbg_generate(&aes128_drbg, &blob));
     bool bytes_are_all_equal = true;
     for (size_t i = 17; i < 31; i++) {
         if (data[16] != data[i]) {
@@ -392,7 +392,7 @@ int main(int argc, char **argv)
 
     POSIX_CHECKED_MEMSET((void*)data, 0, 31);
     blob.size = 31;
-    EXPECT_SUCCESS(s2n_drbg_generate(&aes256_pr_drbg, &blob));
+    EXPECT_OK(s2n_drbg_generate(&aes256_pr_drbg, &blob));
     bytes_are_all_equal = true;
     for (size_t i = 17; i < 31; i++) {
         if (data[16] != data[i]) {
@@ -402,8 +402,8 @@ int main(int argc, char **argv)
     }
     EXPECT_FALSE(bytes_are_all_equal);
 
-    EXPECT_SUCCESS(s2n_drbg_wipe(&aes128_drbg));
-    EXPECT_SUCCESS(s2n_drbg_wipe(&aes256_pr_drbg));
+    EXPECT_OK(s2n_drbg_wipe(&aes128_drbg));
+    EXPECT_OK(s2n_drbg_wipe(&aes256_pr_drbg));
 
     /* Check everything against the NIST AES 128 vectors with prediction resistance */
     EXPECT_SUCCESS(s2n_stuffer_alloc_ro_from_hex_string(&nist_aes128_reference_entropy, nist_aes128_reference_entropy_hex));

--- a/tests/unit/s2n_override_openssl_random_test.c
+++ b/tests/unit/s2n_override_openssl_random_test.c
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_rand_set_callbacks(s2n_entropy_init_cleanup, s2n_entropy_init_cleanup, s2n_entropy_generator, s2n_entropy_generator));
 
     s2n_stack_blob(personalization_string, 32, 32);
-    EXPECT_SUCCESS(s2n_drbg_instantiate(&drbg, &personalization_string, S2N_AES_256_CTR_NO_DF_PR));
+    EXPECT_OK(s2n_drbg_instantiate(&drbg, &personalization_string, S2N_AES_256_CTR_NO_DF_PR));
     EXPECT_OK(s2n_set_private_drbg_for_test(drbg));
     /* Verify we switched to a new DRBG */
     EXPECT_OK(s2n_get_private_random_bytes_used(&bytes_used));

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -61,14 +61,14 @@ extern int s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint
     struct s2n_blob name = {0};                                 \
     RESULT_GUARD_POSIX(s2n_blob_init(&name, name ## _buf, name ## _requested_size))
 
-#define S2N_BLOB_LABEL(name, str) \
-    static uint8_t name##_data[] = str;   \
+#define S2N_BLOB_LABEL(name, str)       \
+    static uint8_t name##_data[] = str; \
     const struct s2n_blob name = { .data = name##_data, .size = sizeof(name##_data) - 1 };
 
 /* The S2N_BLOB_FROM_HEX macro creates a s2n_blob with the contents of a hex string.
  * It is allocated on a stack so there no need to free after use.
  * hex should be a const char[]. This function checks against using char*,
  * because sizeof needs to refer to the buffer length rather than a pointer size */
-#define S2N_BLOB_FROM_HEX( name, hex ) \
+#define S2N_BLOB_FROM_HEX( name, hex )                                  \
     s2n_stack_blob(name, (sizeof(hex) - 1) / 2, (sizeof(hex) - 1) / 2); \
     POSIX_GUARD(s2n_hex_string_to_bytes((const uint8_t*)hex, &name));

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -54,7 +54,7 @@ extern int s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint
     struct s2n_blob name = {0};                             \
     POSIX_GUARD(s2n_blob_init(&name, name ## _buf, name ## _requested_size))
 
-#define s2n_stack_blob_result(name, requested_size, maximum)    \
+#define S2N_RESULT_STACK_BLOB(name, requested_size, maximum)    \
     size_t name ## _requested_size = (requested_size);          \
     uint8_t name ## _buf[(maximum)] = {0};                      \
     RESULT_ENSURE_LTE(name ## _requested_size, (maximum));      \

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -54,6 +54,13 @@ extern int s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint
     struct s2n_blob name = {0};						\
     POSIX_GUARD(s2n_blob_init(&name, name ## _buf, name ## _requested_size))
 
+#define s2n_stack_blob_result(name, requested_size, maximum)           \
+    size_t name ## _requested_size = (requested_size);          \
+    uint8_t name ## _buf[(maximum)] = {0};              \
+    RESULT_ENSURE_LTE(name ## _requested_size, (maximum));           \
+    struct s2n_blob name = {0};                     \
+    RESULT_GUARD_POSIX(s2n_blob_init(&name, name ## _buf, name ## _requested_size))
+
 #define S2N_BLOB_LABEL(name, str) \
     static uint8_t name##_data[] = str;   \
     const struct s2n_blob name = { .data = name##_data, .size = sizeof(name##_data) - 1 };

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -54,7 +54,7 @@ extern int s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint
     struct s2n_blob name = {0};                             \
     POSIX_GUARD(s2n_blob_init(&name, name ## _buf, name ## _requested_size))
 
-#define S2N_RESULT_STACK_BLOB(name, requested_size, maximum)    \
+#define RESULT_STACK_BLOB(name, requested_size, maximum)    \
     size_t name ## _requested_size = (requested_size);          \
     uint8_t name ## _buf[(maximum)] = {0};                      \
     RESULT_ENSURE_LTE(name ## _requested_size, (maximum));      \

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -47,18 +47,18 @@ extern int s2n_blob_char_to_lower(struct s2n_blob *b);
 extern int s2n_hex_string_to_bytes(const uint8_t *str, struct s2n_blob *blob);
 extern int s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint32_t offset, uint32_t size);
 
-#define s2n_stack_blob(name, requested_size, maximum)			\
-    size_t name ## _requested_size = (requested_size);			\
-    uint8_t name ## _buf[(maximum)] = {0};				\
-    POSIX_ENSURE_LTE(name ## _requested_size, (maximum));			\
-    struct s2n_blob name = {0};						\
+#define s2n_stack_blob(name, requested_size, maximum)       \
+    size_t name ## _requested_size = (requested_size);      \
+    uint8_t name ## _buf[(maximum)] = {0};                  \
+    POSIX_ENSURE_LTE(name ## _requested_size, (maximum));   \
+    struct s2n_blob name = {0};                             \
     POSIX_GUARD(s2n_blob_init(&name, name ## _buf, name ## _requested_size))
 
-#define s2n_stack_blob_result(name, requested_size, maximum)           \
+#define s2n_stack_blob_result(name, requested_size, maximum)    \
     size_t name ## _requested_size = (requested_size);          \
-    uint8_t name ## _buf[(maximum)] = {0};              \
-    RESULT_ENSURE_LTE(name ## _requested_size, (maximum));           \
-    struct s2n_blob name = {0};                     \
+    uint8_t name ## _buf[(maximum)] = {0};                      \
+    RESULT_ENSURE_LTE(name ## _requested_size, (maximum));      \
+    struct s2n_blob name = {0};                                 \
     RESULT_GUARD_POSIX(s2n_blob_init(&name, name ## _buf, name ## _requested_size))
 
 #define S2N_BLOB_LABEL(name, str) \

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -144,8 +144,8 @@ static inline S2N_RESULT s2n_defend_if_forked(void)
         /* Clean up the old drbg first */
         RESULT_GUARD(s2n_rand_cleanup_thread());
         /* Instantiate the new ones */
-        RESULT_GUARD_POSIX(s2n_drbg_instantiate(&per_thread_public_drbg, &public, S2N_AES_128_CTR_NO_DF_PR));
-        RESULT_GUARD_POSIX(s2n_drbg_instantiate(&per_thread_private_drbg, &private, S2N_AES_128_CTR_NO_DF_PR));
+        RESULT_GUARD(s2n_drbg_instantiate(&per_thread_public_drbg, &public, S2N_AES_128_CTR_NO_DF_PR));
+        RESULT_GUARD(s2n_drbg_instantiate(&per_thread_private_drbg, &private, S2N_AES_128_CTR_NO_DF_PR));
         zero_if_forked_ptr = zeroed_when_forked_page;
         zero_if_forked = 1;
     }
@@ -165,7 +165,7 @@ S2N_RESULT s2n_get_public_random_data(struct s2n_blob *blob)
 
         RESULT_GUARD_POSIX(s2n_blob_slice(blob, &slice, offset, MIN(remaining, S2N_DRBG_GENERATE_LIMIT)));;
 
-        RESULT_GUARD_POSIX(s2n_drbg_generate(&per_thread_public_drbg, &slice));
+        RESULT_GUARD(s2n_drbg_generate(&per_thread_public_drbg, &slice));
 
         remaining -= slice.size;
         offset += slice.size;
@@ -186,7 +186,7 @@ S2N_RESULT s2n_get_private_random_data(struct s2n_blob *blob)
 
         RESULT_GUARD_POSIX(s2n_blob_slice(blob, &slice, offset, MIN(remaining, S2N_DRBG_GENERATE_LIMIT)));;
 
-        RESULT_GUARD_POSIX(s2n_drbg_generate(&per_thread_private_drbg, &slice));
+        RESULT_GUARD(s2n_drbg_generate(&per_thread_private_drbg, &slice));
 
         remaining -= slice.size;
         offset += slice.size;
@@ -197,13 +197,13 @@ S2N_RESULT s2n_get_private_random_data(struct s2n_blob *blob)
 
 S2N_RESULT s2n_get_public_random_bytes_used(uint64_t *bytes_used)
 {
-    RESULT_GUARD_POSIX(s2n_drbg_bytes_used(&per_thread_public_drbg, bytes_used));
+    RESULT_GUARD(s2n_drbg_bytes_used(&per_thread_public_drbg, bytes_used));
     return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_get_private_random_bytes_used(uint64_t *bytes_used)
 {
-    RESULT_GUARD_POSIX(s2n_drbg_bytes_used(&per_thread_private_drbg, bytes_used));
+    RESULT_GUARD(s2n_drbg_bytes_used(&per_thread_private_drbg, bytes_used));
     return S2N_RESULT_OK;
 }
 
@@ -439,8 +439,8 @@ S2N_RESULT s2n_rand_cleanup(void)
 
 S2N_RESULT s2n_rand_cleanup_thread(void)
 {
-    RESULT_GUARD_POSIX(s2n_drbg_wipe(&per_thread_private_drbg));
-    RESULT_GUARD_POSIX(s2n_drbg_wipe(&per_thread_public_drbg));
+    RESULT_GUARD(s2n_drbg_wipe(&per_thread_private_drbg));
+    RESULT_GUARD(s2n_drbg_wipe(&per_thread_public_drbg));
 
     return S2N_RESULT_OK;
 }
@@ -452,7 +452,7 @@ S2N_RESULT s2n_rand_cleanup_thread(void)
 S2N_RESULT s2n_set_private_drbg_for_test(struct s2n_drbg drbg)
 {
     RESULT_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
-    RESULT_GUARD_POSIX(s2n_drbg_wipe(&per_thread_private_drbg));
+    RESULT_GUARD(s2n_drbg_wipe(&per_thread_private_drbg));
 
     per_thread_private_drbg = drbg;
     return S2N_RESULT_OK;


### PR DESCRIPTION
### Description of changes: 

Functions in `s2n_drbg.c` use clean `0` when returning, not `S2N_SUCCESS`. Instead of replacing `0` with `S2N_SUCCESS`, just port all functions to use the best practice `S2N_RESULT`.

The porting requires quite a few changes throughout, but compiler should be able to pick up any mistakes since type will no longer match.

`s2n_stack_blob` is a macro that uses POSIX-returning guards. Not sure about the RESULT-returning replacement I defined `s2n_stack_blob_result`. Any other ideas?
Same issue with `s2n_evp_ctx_init` vs `s2n_evp_ctx_init_result`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.