### PR TITLE
Add test utility for fork tests

### DIFF
--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -23,7 +23,7 @@
 #include "utils/s2n_random.h"
 #include "utils/s2n_blob.h"
 
-bool ignore_prediction_resistance_for_testing = false;
+static bool ignore_prediction_resistance_for_testing = false;
 
 #define s2n_drbg_key_size(drgb) EVP_CIPHER_CTX_key_length((drbg)->ctx)
 #define s2n_drbg_seed_size(drgb) (S2N_DRBG_BLOCK_SIZE + s2n_drbg_key_size(drgb))

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -143,8 +143,8 @@ static S2N_RESULT s2n_drbg_seed(struct s2n_drbg *drbg, struct s2n_blob *ps)
 static S2N_RESULT s2n_drbg_mix(struct s2n_drbg *drbg, struct s2n_blob *ps)
 {
     if (s2n_unlikely(ignore_prediction_resistance_for_testing == true)) {
-        POSIX_ENSURE(s2n_in_unit_test() == true, S2N_ERR_NOT_IN_UNIT_TEST);
-        return 0;
+        RESULT_ENSURE(s2n_in_unit_test() == true, S2N_ERR_NOT_IN_UNIT_TEST);
+        return S2N_RESULT_OK;
     }
 
     RESULT_STACK_BLOB(blob, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -142,8 +142,8 @@ static S2N_RESULT s2n_drbg_seed(struct s2n_drbg *drbg, struct s2n_blob *ps)
 
 static S2N_RESULT s2n_drbg_mix(struct s2n_drbg *drbg, struct s2n_blob *ps)
 {
-    if (s2n_unlikely(ignore_prediction_resistance_for_testing == true)) {
-        RESULT_ENSURE(s2n_in_unit_test() == true, S2N_ERR_NOT_IN_UNIT_TEST);
+    if (s2n_unlikely(ignore_prediction_resistance_for_testing)) {
+        RESULT_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
         return S2N_RESULT_OK;
     }
 

--- a/crypto/s2n_drbg.h
+++ b/crypto/s2n_drbg.h
@@ -62,3 +62,5 @@ S2N_RESULT s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personal
 S2N_RESULT s2n_drbg_generate(struct s2n_drbg *drbg, struct s2n_blob *returned_bits);
 S2N_RESULT s2n_drbg_wipe(struct s2n_drbg *drbg);
 S2N_RESULT s2n_drbg_bytes_used(struct s2n_drbg *drbg, uint64_t *bytes_used);
+/* Use for testing only */
+S2N_RESULT s2n_ignore_prediction_resistance_for_testing(bool true_or_false);

--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -55,8 +55,7 @@ int test_count;
         else {                                                                      \
             fprintf(stdout, "SKIPPED       ALL tests\n" );                          \
         }                                                                           \
-    }                                                                               \
-    return 0;
+    }
 
 /* This is a very basic, but functional unit testing framework. All testing
  * should happen in main() and start with a BEGIN_TEST() and end with an
@@ -76,18 +75,14 @@ int test_count;
         EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(false));  \
         EXPECT_SUCCESS_WITHOUT_COUNT(s2n_cleanup());                \
         END_TEST_PRINT()                                            \
+        return 0;                                                   \
     } while(0)
 
-/* Macro's similar to BEGIN_TEST() and END_TEST() but for tests that forks at
- * the start of the test. {BEGIN,END}_FORK_TEST is used in the parent process,
- * while {BEGIN,END}_FORK_TEST_IN_CHILD should be used at the start,
- * respectively, end of the child process test code. BEGIN_FORK_TEST_IN_CHILD
- * might be called after child-specific setup code. For example,
- * s2n_fork_generation_number_test will disable a varying subset of available
- * fork detection methods in childs spawned, before calling
- * BEGIN_FORK_TEST_IN_CHILD.
+/* Macros similar to BEGIN_TEST() and END_TEST() but for tests where s2n should
+ * not initialise at the start of the test. Useful for tests that e.g spawn a
+ * number of independent childs at the start of a unit test.
  */
-#define BEGIN_FORK_TEST()                                           \
+#define BEGIN_TEST_NO_INIT()                                        \
     do {                                                            \
         test_count = 0;                                             \
         EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(true));   \
@@ -95,22 +90,11 @@ int test_count;
         fprintf(stdout, "Running %-50s ... ", __FILE__);            \
     } while(0)
 
-#define BEGIN_FORK_TEST_IN_CHILD()                                  \
-    do {                                                            \
-        EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(true));   \
-        EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init());                   \
-    } while(0)
-
-#define END_FORK_TEST()                                             \
+#define END_TEST_NO_INIT()                                          \
     do {                                                            \
         EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(false));  \
         END_TEST_PRINT()                                            \
-    } while(0)
-
-#define END_FORK_TEST_IN_CHILD()                                    \
-    do {                                                            \
-        EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(false));  \
-        EXPECT_SUCCESS_WITHOUT_COUNT(s2n_cleanup());                \
+        return 0;                                                   \
     } while(0)
 
 #define FAIL()      FAIL_MSG("")

--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -107,11 +107,11 @@ int test_count;
         END_TEST_PRINT()                                            \
     } while(0)
 
-#define END_FORK_TEST_IN_CHILD()                                \
-  do {                                                          \
-    EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(true));   \
-    EXPECT_SUCCESS_WITHOUT_COUNT(s2n_cleanup());                \
-  } while(0)
+#define END_FORK_TEST_IN_CHILD()                                    \
+    do {                                                            \
+        EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(false));  \
+        EXPECT_SUCCESS_WITHOUT_COUNT(s2n_cleanup());                \
+    } while(0)
 
 #define FAIL()      FAIL_MSG("")
 

--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -65,14 +65,13 @@ int test_count;
  * BEGIN_TEST() prints unit test information to stdout. But this often gets
  * buffered by the kernel and will then be flushed in each child spawned. The
  * result is a number of repeated messages being send to stdout and, in turn,
- * appear in the logs. Instead of printing the start test message now, each test
- * using BEGIN_TEST_NO_INIT must print before calling END_TEST_NO_INIT(). This
- * makes error outputs look a bit less standard, but avoids very ugly looking
- * and confusing log outputs where messages are randomly out of order.
+ * appear in the logs. At the moment, we think this is better than risking not
+ * having any printing at all.
  */
 #define BEGIN_TEST_NO_INIT()                                        \
     do {                                                            \
         test_count = 0;                                             \
+        fprintf(stdout, "Running %-50s ... ", __FILE__);            \
         EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(true));   \
         S2N_TEST_OPTIONALLY_ENABLE_FIPS_MODE();                     \
     } while(0)
@@ -92,7 +91,6 @@ int test_count;
     do {                                                            \
         BEGIN_TEST_NO_INIT();                                       \
         EXPECT_SUCCESS_WITHOUT_COUNT(s2n_init());                   \
-        fprintf(stdout, "Running %-50s ... ", __FILE__);            \
     } while(0)
 
 #define END_TEST()                                                  \

--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -60,7 +60,7 @@ int test_count;
 
 /* This is a very basic, but functional unit testing framework. All testing
  * should happen in main() and start with a BEGIN_TEST() and end with an
- * END_TEST();
+ * END_TEST().
  */
 #define BEGIN_TEST()                                                \
     do {                                                            \

--- a/tests/saw/spec/DRBG/DRBG.saw
+++ b/tests/saw/spec/DRBG/DRBG.saw
@@ -322,9 +322,12 @@ let instantiate_spec n = do {
 };
 
 let generate_spec = do {
+    (crucible_alloc_global "ignore_prediction_resistance_for_testing");
+    (crucible_points_to (crucible_global "ignore_prediction_resistance_for_testing") (crucible_term {{ 0 : [8] }}) );
     (sp, keyp, s) <- drbg_state "drbg";
     (psp, datap) <- alloc_blob seedsize;
     crucible_execute_func [sp, psp];
+    (crucible_points_to (crucible_global "ignore_prediction_resistance_for_testing") (crucible_term {{ 0 : [8] }}) );
     let {{ res = drbg_generate_seedlen s fake_entropy True }};
     crucible_points_to datap (tm {{ split res.0 : [seedsize][8] }});
     ensure_drbg_state sp keyp {{ res.1 }};

--- a/tests/saw/spec/DRBG/DRBG.saw
+++ b/tests/saw/spec/DRBG/DRBG.saw
@@ -62,6 +62,7 @@ let tm = crucible_term;
 
 let bytes_type n = llvm_array n i8;
 let alloc_bytes n = crucible_alloc (bytes_type n);
+let ignore_prediction_resistance_for_testing_guard = llvm_alloc_global "ignore_prediction_resistance_for_testing"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Convenient Cryptol definitions

--- a/tests/saw/spec/DRBG/DRBG.saw
+++ b/tests/saw/spec/DRBG/DRBG.saw
@@ -62,7 +62,6 @@ let tm = crucible_term;
 
 let bytes_type n = llvm_array n i8;
 let alloc_bytes n = crucible_alloc (bytes_type n);
-let ignore_prediction_resistance_for_testing_guard = llvm_alloc_global "ignore_prediction_resistance_for_testing";
 
 ////////////////////////////////////////////////////////////////////////////////
 // Convenient Cryptol definitions
@@ -297,13 +296,13 @@ let seed_spec n = do {
 
 let mix_spec n = do {
     (crucible_alloc_global "ignore_prediction_resistance_for_testing");
-    (crucible_points_to (crucible_global "ignore_prediction_resistance_for_testing") (crucible_term {{ 0 : [1] }}) );
+    (crucible_points_to (crucible_global "ignore_prediction_resistance_for_testing") (crucible_term {{ 0 : [8] }}) );
     (state_ptr, key_ptr, state) <- drbg_state "drbg";
     (personalization_string_ptr, data_ptr) <- alloc_blob_readonly n;
     data <- crucible_fresh_var "data" (bytes_type n);
     crucible_points_to data_ptr (tm data);
     crucible_execute_func [state_ptr, personalization_string_ptr];
-    (crucible_points_to (crucible_global "ignore_prediction_resistance_for_testing") (crucible_term {{ 0 : [1] }}) );
+    (crucible_points_to (crucible_global "ignore_prediction_resistance_for_testing") (crucible_term {{ 0 : [8] }}) );
     ensure_drbg_state state_ptr key_ptr {{ drbg_mix state fake_entropy (join data) }};
     crucible_return (tm {{ 0 : [32] }});
 };

--- a/tests/saw/spec/DRBG/DRBG.saw
+++ b/tests/saw/spec/DRBG/DRBG.saw
@@ -62,7 +62,7 @@ let tm = crucible_term;
 
 let bytes_type n = llvm_array n i8;
 let alloc_bytes n = crucible_alloc (bytes_type n);
-let ignore_prediction_resistance_for_testing_guard = llvm_alloc_global "ignore_prediction_resistance_for_testing"
+let ignore_prediction_resistance_for_testing_guard = llvm_alloc_global "ignore_prediction_resistance_for_testing";
 
 ////////////////////////////////////////////////////////////////////////////////
 // Convenient Cryptol definitions

--- a/tests/saw/spec/DRBG/DRBG.saw
+++ b/tests/saw/spec/DRBG/DRBG.saw
@@ -296,11 +296,14 @@ let seed_spec n = do {
 };
 
 let mix_spec n = do {
+    (crucible_alloc_global "ignore_prediction_resistance_for_testing");
+    (crucible_points_to (crucible_global "ignore_prediction_resistance_for_testing") (crucible_term {{ 0 : [1] }}) );
     (state_ptr, key_ptr, state) <- drbg_state "drbg";
     (personalization_string_ptr, data_ptr) <- alloc_blob_readonly n;
     data <- crucible_fresh_var "data" (bytes_type n);
     crucible_points_to data_ptr (tm data);
     crucible_execute_func [state_ptr, personalization_string_ptr];
+    (crucible_points_to (crucible_global "ignore_prediction_resistance_for_testing") (crucible_term {{ 0 : [1] }}) );
     ensure_drbg_state state_ptr key_ptr {{ drbg_mix state fake_entropy (join data) }};
     crucible_return (tm {{ 0 : [32] }});
 };

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -379,8 +379,8 @@ int main(int argc, char **argv)
     uint64_t aes128_drbg_mixes_start = aes128_drbg.mixes;
     uint64_t aes256_pr_drbg_mixes_start = aes256_pr_drbg.mixes;
     for (int i = 0; i < 10; i++) {
-        EXPECT_SUCCESS(s2n_drbg_generate(&aes128_drbg, &blob));
-        EXPECT_SUCCESS(s2n_drbg_generate(&aes256_pr_drbg, &blob));
+        EXPECT_OK(s2n_drbg_generate(&aes128_drbg, &blob));
+        EXPECT_OK(s2n_drbg_generate(&aes256_pr_drbg, &blob));
     }
     EXPECT_EQUAL(aes128_drbg.mixes, aes128_drbg_mixes_start);
     EXPECT_EQUAL(aes256_pr_drbg.mixes, aes256_pr_drbg_mixes_start);
@@ -388,8 +388,8 @@ int main(int argc, char **argv)
     /* Check that we can enable prediction resistance again */
     EXPECT_OK(s2n_ignore_prediction_resistance_for_testing(false));
     for (int i = 0; i < 10; i++) {
-        EXPECT_SUCCESS(s2n_drbg_generate(&aes128_drbg, &blob));
-        EXPECT_SUCCESS(s2n_drbg_generate(&aes256_pr_drbg, &blob));
+        EXPECT_OK(s2n_drbg_generate(&aes128_drbg, &blob));
+        EXPECT_OK(s2n_drbg_generate(&aes256_pr_drbg, &blob));
     }
     EXPECT_EQUAL(aes128_drbg.mixes, aes128_drbg_mixes_start + 10);
     EXPECT_EQUAL(aes256_pr_drbg.mixes, aes256_pr_drbg_mixes_start + 10);

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -374,6 +374,26 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(aes128_drbg.mixes, 500010);
     EXPECT_EQUAL(aes256_pr_drbg.mixes, 500010);
 
+    /* Check that ignoring prediction resistance works */
+    EXPECT_OK(s2n_ignore_prediction_resistance_for_testing(true));
+    uint64_t aes128_drbg_mixes_start = aes128_drbg.mixes;
+    uint64_t aes256_pr_drbg_mixes_start = aes256_pr_drbg.mixes;
+    for (int i = 0; i < 10; i++) {
+        EXPECT_SUCCESS(s2n_drbg_generate(&aes128_drbg, &blob));
+        EXPECT_SUCCESS(s2n_drbg_generate(&aes256_pr_drbg, &blob));
+    }
+    EXPECT_EQUAL(aes128_drbg.mixes, aes128_drbg_mixes_start);
+    EXPECT_EQUAL(aes256_pr_drbg.mixes, aes256_pr_drbg_mixes_start);
+
+    /* Check that we can enable prediction resistance again */
+    EXPECT_OK(s2n_ignore_prediction_resistance_for_testing(false));
+    for (int i = 0; i < 10; i++) {
+        EXPECT_SUCCESS(s2n_drbg_generate(&aes128_drbg, &blob));
+        EXPECT_SUCCESS(s2n_drbg_generate(&aes256_pr_drbg, &blob));
+    }
+    EXPECT_EQUAL(aes128_drbg.mixes, aes128_drbg_mixes_start + 10);
+    EXPECT_EQUAL(aes256_pr_drbg.mixes, aes256_pr_drbg_mixes_start + 10);
+
     /* Generate 31 (= 16 + 15) bytes. Since the DRBG generates 16 bytes at a time,
      * a common error is to incorrectly fill the last (not-aligned) bytes. Sometimes
      * they are left unchanged and sometimes a single byte is copied in. We ensure

--- a/tests/unit/s2n_fork_generation_number_test.c
+++ b/tests/unit/s2n_fork_generation_number_test.c
@@ -255,11 +255,11 @@ static int s2n_unit_tests_common(struct fgn_test_case *test_case)
 
 static int s2n_test_case_default_cb(struct fgn_test_case *test_case)
 {
-    BEGIN_FORK_TEST_IN_CHILD();
+    EXPECT_SUCCESS(s2n_init());
 
     EXPECT_EQUAL(s2n_unit_tests_common(test_case), S2N_SUCCESS);
 
-    END_FORK_TEST_IN_CHILD();
+    EXPECT_SUCCESS(s2n_cleanup());
 
     return S2N_SUCCESS;
 }
@@ -268,11 +268,11 @@ static int s2n_test_case_pthread_atfork_cb(struct fgn_test_case *test_case)
 {
     POSIX_GUARD_RESULT(s2n_ignore_wipeonfork_and_inherit_zero_for_testing());
 
-    BEGIN_FORK_TEST_IN_CHILD();
+    EXPECT_SUCCESS(s2n_init());
 
     EXPECT_EQUAL(s2n_unit_tests_common(test_case), S2N_SUCCESS);
 
-    END_FORK_TEST_IN_CHILD();
+    EXPECT_SUCCESS(s2n_cleanup());
 
     return S2N_SUCCESS;
 }
@@ -285,11 +285,11 @@ static int s2n_test_case_madv_wipeonfork_cb(struct fgn_test_case *test_case)
     }
     POSIX_GUARD_RESULT(s2n_ignore_pthread_atfork_for_testing());
 
-    BEGIN_FORK_TEST_IN_CHILD();
+    EXPECT_SUCCESS(s2n_init());
 
     EXPECT_EQUAL(s2n_unit_tests_common(test_case), S2N_SUCCESS);
 
-    END_FORK_TEST_IN_CHILD();
+    EXPECT_SUCCESS(s2n_cleanup());
 
     return S2N_SUCCESS;
 }
@@ -302,11 +302,11 @@ static int s2n_test_case_map_inherit_zero_cb(struct fgn_test_case *test_case)
     }
     POSIX_GUARD_RESULT(s2n_ignore_pthread_atfork_for_testing());
 
-    BEGIN_FORK_TEST_IN_CHILD();
+    EXPECT_SUCCESS(s2n_init());
 
     EXPECT_EQUAL(s2n_unit_tests_common(test_case), S2N_SUCCESS);
 
-    END_FORK_TEST_IN_CHILD();
+    EXPECT_SUCCESS(s2n_cleanup());
 
     return S2N_SUCCESS;
 }
@@ -320,7 +320,15 @@ struct fgn_test_case fgn_test_cases[NUMBER_OF_FGN_TEST_CASES] = {
 
 int main(int argc, char **argv)
 {
-    BEGIN_FORK_TEST();
+    BEGIN_TEST_NO_INIT();
+
+    /* BEGIN_TEST_NO_INIT prints unit test information to stdout. But this often
+     * gets buffered by the kernel and will then be flushed in each child
+     * spawned below. The result is a number of repeated messages being send to
+     * stdout and, in turn, in the logs. Flushing now to prevent leaking the
+     * stdout print into childs.
+     */
+    fflush(stdout);
 
     EXPECT_TRUE(s2n_array_len(fgn_test_cases) == NUMBER_OF_FGN_TEST_CASES);
 
@@ -354,5 +362,5 @@ int main(int argc, char **argv)
         }
     }
 
-    END_FORK_TEST();
+    END_TEST_NO_INIT();
 }

--- a/tests/unit/s2n_fork_generation_number_test.c
+++ b/tests/unit/s2n_fork_generation_number_test.c
@@ -322,14 +322,6 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST_NO_INIT();
 
-    /* BEGIN_TEST_NO_INIT prints unit test information to stdout. But this often
-     * gets buffered by the kernel and will then be flushed in each child
-     * spawned below. The result is a number of repeated messages being send to
-     * stdout and, in turn, in the logs. Flushing now to prevent leaking the
-     * stdout print into childs.
-     */
-    fflush(stdout);
-
     EXPECT_TRUE(s2n_array_len(fgn_test_cases) == NUMBER_OF_FGN_TEST_CASES);
 
     /* Create NUMBER_OF_FGN_TEST_CASES number of child processes that run each
@@ -362,5 +354,6 @@ int main(int argc, char **argv)
         }
     }
 
+    fprintf(stdout, "Running %-50s ... ", __FILE__);
     END_TEST_NO_INIT();
 }

--- a/tests/unit/s2n_fork_generation_number_test.c
+++ b/tests/unit/s2n_fork_generation_number_test.c
@@ -354,6 +354,5 @@ int main(int argc, char **argv)
         }
     }
 
-    fprintf(stdout, "Running %-50s ... ", __FILE__);
     END_TEST_NO_INIT();
 }

--- a/tests/unit/s2n_fork_generation_number_test.c
+++ b/tests/unit/s2n_fork_generation_number_test.c
@@ -255,7 +255,11 @@ static int s2n_unit_tests_common(struct fgn_test_case *test_case)
 
 static int s2n_test_case_default_cb(struct fgn_test_case *test_case)
 {
+    BEGIN_FORK_TEST_IN_CHILD();
+
     EXPECT_EQUAL(s2n_unit_tests_common(test_case), S2N_SUCCESS);
+
+    END_FORK_TEST_IN_CHILD();
 
     return S2N_SUCCESS;
 }
@@ -263,7 +267,12 @@ static int s2n_test_case_default_cb(struct fgn_test_case *test_case)
 static int s2n_test_case_pthread_atfork_cb(struct fgn_test_case *test_case)
 {
     POSIX_GUARD_RESULT(s2n_ignore_wipeonfork_and_inherit_zero_for_testing());
+
+    BEGIN_FORK_TEST_IN_CHILD();
+
     EXPECT_EQUAL(s2n_unit_tests_common(test_case), S2N_SUCCESS);
+
+    END_FORK_TEST_IN_CHILD();
 
     return S2N_SUCCESS;
 }
@@ -274,9 +283,13 @@ static int s2n_test_case_madv_wipeonfork_cb(struct fgn_test_case *test_case)
         TEST_DEBUG_PRINT("s2n_fork_generation_number_test.c test case not supported. Skipping.\nTest case: %s\n", test_case->test_case_label);
         return S2N_SUCCESS;
     }
-
     POSIX_GUARD_RESULT(s2n_ignore_pthread_atfork_for_testing());
+
+    BEGIN_FORK_TEST_IN_CHILD();
+
     EXPECT_EQUAL(s2n_unit_tests_common(test_case), S2N_SUCCESS);
+
+    END_FORK_TEST_IN_CHILD();
 
     return S2N_SUCCESS;
 }
@@ -287,9 +300,13 @@ static int s2n_test_case_map_inherit_zero_cb(struct fgn_test_case *test_case)
         TEST_DEBUG_PRINT("s2n_fork_generation_number_test.c test case not supported. Skipping.\nTest case: %s\n", test_case->test_case_label);
         return S2N_SUCCESS;
     }
-
     POSIX_GUARD_RESULT(s2n_ignore_pthread_atfork_for_testing());
+
+    BEGIN_FORK_TEST_IN_CHILD();
+
     EXPECT_EQUAL(s2n_unit_tests_common(test_case), S2N_SUCCESS);
+
+    END_FORK_TEST_IN_CHILD();
 
     return S2N_SUCCESS;
 }
@@ -303,7 +320,7 @@ struct fgn_test_case fgn_test_cases[NUMBER_OF_FGN_TEST_CASES] = {
 
 int main(int argc, char **argv)
 {
-    BEGIN_TEST();
+    BEGIN_FORK_TEST();
 
     EXPECT_TRUE(s2n_array_len(fgn_test_cases) == NUMBER_OF_FGN_TEST_CASES);
 
@@ -337,5 +354,5 @@ int main(int argc, char **argv)
         }
     }
 
-    END_TEST();
+    END_FORK_TEST();
 }

--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -54,59 +54,28 @@ void process_safety_tester(int write_fd)
     _exit(0);
 }
 
-static int init(void) {
-    return S2N_SUCCESS;
-}
-
-static int cleanup(void) {
-    return S2N_SUCCESS;
-}
-
-static int entropy(void *ptr, uint32_t size) {
-    return S2N_SUCCESS;
-}
-
-int main(int argc, char **argv)
+static int init(void)
 {
-    uint8_t bits[8] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 };
-    uint8_t bit_set_run[8];
-    int p[2], status;
+    return S2N_SUCCESS;
+}
+
+static int cleanup(void)
+{
+    return S2N_SUCCESS;
+}
+
+static int entropy(void *ptr, uint32_t size)
+{
+    return S2N_SUCCESS;
+}
+
+static int fork_test(void)
+{
     pid_t pid;
-    uint8_t data[5120];
+    int p[2], status;
+    uint8_t data[100];
     uint8_t child_data[100];
-    struct s2n_blob blob = {.data = data };
-
-    pthread_t threads[2];
-
-    BEGIN_TEST();
-    EXPECT_SUCCESS(s2n_disable_tls13_in_test());
-
-    /* Verify that randomness callbacks can't be set to NULL */
-    EXPECT_FAILURE(s2n_rand_set_callbacks(NULL, cleanup, entropy, entropy));
-    EXPECT_FAILURE(s2n_rand_set_callbacks(init, NULL, entropy, entropy));
-    EXPECT_FAILURE(s2n_rand_set_callbacks(init, cleanup, NULL, entropy));
-    EXPECT_FAILURE(s2n_rand_set_callbacks(init, cleanup, entropy, NULL));
-
-    /* Get one byte of data, to make sure the pool is (almost) full */
-    blob.size = 1;
-    EXPECT_OK(s2n_get_public_random_data(&blob));
-
-    /* Create two threads and have them each grab 100 bytes */
-    EXPECT_SUCCESS(pthread_create(&threads[0], NULL, thread_safety_tester, (void *)0));
-    EXPECT_SUCCESS(pthread_create(&threads[1], NULL, thread_safety_tester, (void *)1));
-
-    /* Wait for those threads to finish */
-    EXPECT_SUCCESS(pthread_join(threads[0], NULL));
-    EXPECT_SUCCESS(pthread_join(threads[1], NULL));
-
-    /* Confirm that their data differs from each other */
-    EXPECT_NOT_EQUAL(memcmp(thread_data[0], thread_data[1], 100), 0);
-
-    /* Confirm that their data differs from the parent thread */
-    blob.size = 100;
-    EXPECT_OK(s2n_get_public_random_data(&blob));
-    EXPECT_NOT_EQUAL(memcmp(thread_data[0], data, 100), 0);
-    EXPECT_NOT_EQUAL(memcmp(thread_data[1], data, 100), 0);
+    struct s2n_blob blob = {.data = data, .size = 100};
 
     /* Create a pipe */
     EXPECT_SUCCESS(pipe(p));
@@ -145,6 +114,54 @@ int main(int argc, char **argv)
     blob.data = data;
     EXPECT_OK(s2n_get_public_random_data(&blob));
     EXPECT_NOT_EQUAL(memcmp(child_data, data, 100), 0);
+}
+
+int main(int argc, char **argv)
+{
+    uint8_t bits[8] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 };
+    uint8_t bit_set_run[8];
+    uint8_t data[5120];
+    struct s2n_blob blob = {.data = data };
+
+    pthread_t threads[2];
+
+    BEGIN_TEST();
+    EXPECT_SUCCESS(s2n_disable_tls13_in_test());
+
+    /* Verify that randomness callbacks can't be set to NULL */
+    EXPECT_FAILURE(s2n_rand_set_callbacks(NULL, cleanup, entropy, entropy));
+    EXPECT_FAILURE(s2n_rand_set_callbacks(init, NULL, entropy, entropy));
+    EXPECT_FAILURE(s2n_rand_set_callbacks(init, cleanup, NULL, entropy));
+    EXPECT_FAILURE(s2n_rand_set_callbacks(init, cleanup, entropy, NULL));
+
+    /* Get one byte of data, to make sure the pool is (almost) full */
+    blob.size = 1;
+    EXPECT_OK(s2n_get_public_random_data(&blob));
+
+    /* Create two threads and have them each grab 100 bytes */
+    EXPECT_SUCCESS(pthread_create(&threads[0], NULL, thread_safety_tester, (void *)0));
+    EXPECT_SUCCESS(pthread_create(&threads[1], NULL, thread_safety_tester, (void *)1));
+
+    /* Wait for those threads to finish */
+    EXPECT_SUCCESS(pthread_join(threads[0], NULL));
+    EXPECT_SUCCESS(pthread_join(threads[1], NULL));
+
+    /* Confirm that their data differs from each other */
+    EXPECT_NOT_EQUAL(memcmp(thread_data[0], thread_data[1], 100), 0);
+
+    /* Confirm that their data differs from the parent thread */
+    blob.size = 100;
+    EXPECT_OK(s2n_get_public_random_data(&blob));
+    EXPECT_NOT_EQUAL(memcmp(thread_data[0], data, 100), 0);
+    EXPECT_NOT_EQUAL(memcmp(thread_data[1], data, 100), 0);
+
+    /* Fork with prediction resistance */
+    fork_test();
+
+    /* Fork without prediction resistance */
+    EXPECT_OK(s2n_ignore_prediction_resistance_for_testing(true));
+    fork_test();
+    EXPECT_OK(s2n_ignore_prediction_resistance_for_testing(false));
 
     /* Try to fetch a volume of randomly generated data, every size between 1 and 5120
      * bytes.

--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -114,6 +114,8 @@ static int fork_test(void)
     blob.data = data;
     EXPECT_OK(s2n_get_public_random_data(&blob));
     EXPECT_NOT_EQUAL(memcmp(child_data, data, 100), 0);
+
+    return S2N_SUCCESS;
 }
 
 int main(int argc, char **argv)
@@ -156,11 +158,11 @@ int main(int argc, char **argv)
     EXPECT_NOT_EQUAL(memcmp(thread_data[1], data, 100), 0);
 
     /* Fork with prediction resistance */
-    fork_test();
+    EXPECT_SUCCESS(fork_test());
 
     /* Fork without prediction resistance */
     EXPECT_OK(s2n_ignore_prediction_resistance_for_testing(true));
-    fork_test();
+    EXPECT_SUCCESS(fork_test());
     EXPECT_OK(s2n_ignore_prediction_resistance_for_testing(false));
 
     /* Try to fetch a volume of randomly generated data, every size between 1 and 5120


### PR DESCRIPTION
### Description of changes: 

This change adds some utilities that are useful for testing when forking is involved.

Firstly, extend the test framework with 4 new macro's that allows instantiating a test suite without initialising s2n. This is needed for future fork tests where we want to test randomness generation (via the public API) with some/all fork detection mechanism disabled; Calling `BEGIN_TEST` will automatically enable all possible fork detection mechanisms through `s2n_init()`.
Also fixed indentation.

Secondly, make it possible to ignore prediction resistance for the drbg implementation. It's impossible to test fork detection from the viewpoint of the public API without disabling prediction resistance - you just can't tell what caused the drbg state randomisation. This is only callable during testing, and would otherwise hard fail.
There might be other ways to implement this, open for suggestions.

Thirdly, factor out the fork tests in the existing randomness tests to take advantage of the new ability to ignore prediction resistance.

Git is really being not-nice with changes in `tests/unit/s2n_random_test.c`. Probably easier to view this without even looking at the Git diff...

SAW fixes by @apetcher-amazon.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
