### PR TITLE
Update install_awslc to install the correct FIPS branch of AWS-LC

### DIFF
--- a/codebuild/bin/install_awslc.sh
+++ b/codebuild/bin/install_awslc.sh
@@ -31,6 +31,12 @@ source codebuild/bin/jobs.sh
 
 cd "$BUILD_DIR"
 git clone https://github.com/awslabs/aws-lc.git
+if [ "$IS_FIPS" -eq "1" ]; then
+  cd aws-lc
+  git checkout -b fips-2021-10-20 origin/fips-2021-10-20
+  cd ..
+fi
+
 mkdir build
 cd build
 

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -47,7 +47,7 @@
 #ifdef __FreeBSD__
 #define MEM_PER_CONNECTION 57
 #else
-#define MEM_PER_CONNECTION 48
+#define MEM_PER_CONNECTION 49
 #endif
 
 /* This is the maximum memory per connection including 4KB of slack */


### PR DESCRIPTION
### Description of changes: 
When we added the [integration test for AWS-LC FIPS](https://github.com/aws/s2n-tls/commit/6040c6afd8733c19c1b9ca7fa448629fc4b5dac3) on 2021-11-05 we had not cut the official branch yet so the test used AWS-LC's main. AWS-LC now has a [branch](https://github.com/awslabs/aws-lc/tree/fips-2021-10-20) ready for use (it was finalized on 2021-12-22). The unfortunate part is [this s2n change (2022-02-01)](https://github.com/aws/s2n-tls/commit/b956eab5f1676a961b16cb060d41c3844e118af2) changed this memory usage from 49 to 48 which works with the FIPS build of AWS-LC main, but not the FIPS branch. The FIPS branch is based on AWS-LC code from 2021-12-22 and does not have the recent memory savings that this test is relying on.

### Call-outs:
I am hunting down the specific AWS-LC change(s) on main that is saving the memory this test expects. The good news is this can be changed back to a 48 after the next FIPS validation that takes all the latest changes from main.

### Testing:
Tested locally running the install script and unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
