### PR TITLE
auto format integv2 python

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# autopep8 python PR3268
+b9dbef317197b2f450b3e963fb4744cc4dc5e087

--- a/tests/integrationv2/.pep8
+++ b/tests/integrationv2/.pep8
@@ -1,0 +1,4 @@
+[pep8]
+max_line_length = 80
+in-place = true
+recursive = true

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -79,6 +79,7 @@ class TimeoutException(subprocess.SubprocessError):
     TimeoutException wraps the subprocess class giving more control
     over the formatting of output.
     """
+
     def __init__(self, timeout_exception):
         self.exception = timeout_exception
 
@@ -141,8 +142,10 @@ class Certificates(object):
     ECDSA_256 = Cert("ECDSA_256", "localhost_ecdsa_p256")
     ECDSA_384 = Cert("ECDSA_384", "ecdsa_p384_pkcs1")
 
-    RSA_2048_SHA256_WILDCARD = Cert("RSA_2048_SHA256_WILDCARD", "rsa_2048_sha256_wildcard")
-    RSA_PSS_2048_SHA256 = Cert("RSA_PSS_2048_SHA256", "localhost_rsa_pss_2048_sha256")
+    RSA_2048_SHA256_WILDCARD = Cert(
+        "RSA_2048_SHA256_WILDCARD", "rsa_2048_sha256_wildcard")
+    RSA_PSS_2048_SHA256 = Cert(
+        "RSA_PSS_2048_SHA256", "localhost_rsa_pss_2048_sha256")
 
     OCSP = Cert("OCSP_RSA", "ocsp/server")
     OCSP_ECDSA = Cert("OCSP_ECDSA_256", "ocsp/server_ecdsa")
@@ -223,56 +226,94 @@ class Ciphers(object):
     """
     When referencing ciphers, use these class values.
     """
-    DHE_RSA_DES_CBC3_SHA = Cipher("DHE-RSA-DES-CBC3-SHA", Protocols.SSLv3, False, False, iana_standard_name="SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA")
-    DHE_RSA_AES128_SHA = Cipher("DHE-RSA-AES128-SHA", Protocols.SSLv3, True, False, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_128_CBC_SHA")
-    DHE_RSA_AES256_SHA = Cipher("DHE-RSA-AES256-SHA", Protocols.SSLv3, True, False, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_256_CBC_SHA")
-    DHE_RSA_AES128_SHA256 = Cipher("DHE-RSA-AES128-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_128_CBC_SHA256")
-    DHE_RSA_AES256_SHA256 = Cipher("DHE-RSA-AES256-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_256_CBC_SHA256")
-    DHE_RSA_AES128_GCM_SHA256 = Cipher("DHE-RSA-AES128-GCM-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_128_GCM_SHA256")
-    DHE_RSA_AES256_GCM_SHA384 = Cipher("DHE-RSA-AES256-GCM-SHA384", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_256_GCM_SHA384")
-    DHE_RSA_CHACHA20_POLY1305 = Cipher("DHE-RSA-CHACHA20-POLY1305", Protocols.TLS12, True, False, TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_256_GCM_SHA384")
+    DHE_RSA_DES_CBC3_SHA = Cipher("DHE-RSA-DES-CBC3-SHA", Protocols.SSLv3,
+                                  False, False, iana_standard_name="SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA")
+    DHE_RSA_AES128_SHA = Cipher("DHE-RSA-AES128-SHA", Protocols.SSLv3, True, False, TEST_CERT_DIRECTORY +
+                                'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_128_CBC_SHA")
+    DHE_RSA_AES256_SHA = Cipher("DHE-RSA-AES256-SHA", Protocols.SSLv3, True, False, TEST_CERT_DIRECTORY +
+                                'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_256_CBC_SHA")
+    DHE_RSA_AES128_SHA256 = Cipher("DHE-RSA-AES128-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY +
+                                   'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_128_CBC_SHA256")
+    DHE_RSA_AES256_SHA256 = Cipher("DHE-RSA-AES256-SHA256", Protocols.TLS12, True, True, TEST_CERT_DIRECTORY +
+                                   'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_256_CBC_SHA256")
+    DHE_RSA_AES128_GCM_SHA256 = Cipher("DHE-RSA-AES128-GCM-SHA256", Protocols.TLS12, True, True,
+                                       TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_128_GCM_SHA256")
+    DHE_RSA_AES256_GCM_SHA384 = Cipher("DHE-RSA-AES256-GCM-SHA384", Protocols.TLS12, True, True,
+                                       TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_256_GCM_SHA384")
+    DHE_RSA_CHACHA20_POLY1305 = Cipher("DHE-RSA-CHACHA20-POLY1305", Protocols.TLS12, True, False,
+                                       TEST_CERT_DIRECTORY + 'dhparams_2048.pem', iana_standard_name="TLS_DHE_RSA_WITH_AES_256_GCM_SHA384")
 
-    AES128_SHA = Cipher("AES128-SHA", Protocols.SSLv3, True, True, iana_standard_name="TLS_RSA_WITH_AES_128_CBC_SHA")
-    AES256_SHA = Cipher("AES256-SHA", Protocols.SSLv3, True, True, iana_standard_name="TLS_RSA_WITH_AES_256_CBC_SHA")
-    AES128_SHA256 = Cipher("AES128-SHA256", Protocols.TLS12, True, True, iana_standard_name="TLS_RSA_WITH_AES_128_CBC_SHA256")
-    AES256_SHA256 = Cipher("AES256-SHA256", Protocols.TLS12, True, True, iana_standard_name="TLS_RSA_WITH_AES_256_CBC_SHA256")
-    AES128_GCM_SHA256 = Cipher("TLS_AES_128_GCM_SHA256", Protocols.TLS13, True, True, iana_standard_name="TLS_AES_128_GCM_SHA256")
-    AES256_GCM_SHA384 = Cipher("TLS_AES_256_GCM_SHA384", Protocols.TLS13, True, True, iana_standard_name="TLS_AES_256_GCM_SHA384")
+    AES128_SHA = Cipher("AES128-SHA", Protocols.SSLv3, True,
+                        True, iana_standard_name="TLS_RSA_WITH_AES_128_CBC_SHA")
+    AES256_SHA = Cipher("AES256-SHA", Protocols.SSLv3, True,
+                        True, iana_standard_name="TLS_RSA_WITH_AES_256_CBC_SHA")
+    AES128_SHA256 = Cipher("AES128-SHA256", Protocols.TLS12, True,
+                           True, iana_standard_name="TLS_RSA_WITH_AES_128_CBC_SHA256")
+    AES256_SHA256 = Cipher("AES256-SHA256", Protocols.TLS12, True,
+                           True, iana_standard_name="TLS_RSA_WITH_AES_256_CBC_SHA256")
+    AES128_GCM_SHA256 = Cipher("TLS_AES_128_GCM_SHA256", Protocols.TLS13,
+                               True, True, iana_standard_name="TLS_AES_128_GCM_SHA256")
+    AES256_GCM_SHA384 = Cipher("TLS_AES_256_GCM_SHA384", Protocols.TLS13,
+                               True, True, iana_standard_name="TLS_AES_256_GCM_SHA384")
 
-    ECDHE_ECDSA_AES128_SHA = Cipher("ECDHE-ECDSA-AES128-SHA", Protocols.SSLv3, True, False, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA")
-    ECDHE_ECDSA_AES256_SHA = Cipher("ECDHE-ECDSA-AES256-SHA", Protocols.SSLv3, True, False, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA")
-    ECDHE_ECDSA_AES128_SHA256 = Cipher("ECDHE-ECDSA-AES128-SHA256", Protocols.TLS12, True, True, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256")
-    ECDHE_ECDSA_AES256_SHA384 = Cipher("ECDHE-ECDSA-AES256-SHA384", Protocols.TLS12, True, True, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384")
-    ECDHE_ECDSA_AES128_GCM_SHA256 = Cipher("ECDHE-ECDSA-AES128-GCM-SHA256", Protocols.TLS12, True, True, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256")
-    ECDHE_ECDSA_AES256_GCM_SHA384 = Cipher("ECDHE-ECDSA-AES256-GCM-SHA384", Protocols.TLS12, True, True, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384")
-    ECDHE_ECDSA_CHACHA20_POLY1305 = Cipher("ECDHE-ECDSA-CHACHA20-POLY1305", Protocols.TLS12, True, False, iana_standard_name="TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256")
+    ECDHE_ECDSA_AES128_SHA = Cipher("ECDHE-ECDSA-AES128-SHA", Protocols.SSLv3,
+                                    True, False, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA")
+    ECDHE_ECDSA_AES256_SHA = Cipher("ECDHE-ECDSA-AES256-SHA", Protocols.SSLv3,
+                                    True, False, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA")
+    ECDHE_ECDSA_AES128_SHA256 = Cipher("ECDHE-ECDSA-AES128-SHA256", Protocols.TLS12,
+                                       True, True, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256")
+    ECDHE_ECDSA_AES256_SHA384 = Cipher("ECDHE-ECDSA-AES256-SHA384", Protocols.TLS12,
+                                       True, True, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384")
+    ECDHE_ECDSA_AES128_GCM_SHA256 = Cipher("ECDHE-ECDSA-AES128-GCM-SHA256", Protocols.TLS12,
+                                           True, True, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256")
+    ECDHE_ECDSA_AES256_GCM_SHA384 = Cipher("ECDHE-ECDSA-AES256-GCM-SHA384", Protocols.TLS12,
+                                           True, True, iana_standard_name="TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384")
+    ECDHE_ECDSA_CHACHA20_POLY1305 = Cipher("ECDHE-ECDSA-CHACHA20-POLY1305", Protocols.TLS12,
+                                           True, False, iana_standard_name="TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256")
 
-    ECDHE_RSA_DES_CBC3_SHA = Cipher("ECDHE-RSA-DES-CBC3-SHA", Protocols.SSLv3, False, False, iana_standard_name="TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA")
-    ECDHE_RSA_AES128_SHA = Cipher("ECDHE-RSA-AES128-SHA", Protocols.SSLv3, True, False, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA")
-    ECDHE_RSA_AES256_SHA = Cipher("ECDHE-RSA-AES256-SHA", Protocols.SSLv3, True, False, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA")
-    ECDHE_RSA_RC4_SHA = Cipher("ECDHE-RSA-RC4-SHA", Protocols.SSLv3, False, False, iana_standard_name="TLS_ECDHE_RSA_WITH_RC4_128_SHA")
-    ECDHE_RSA_AES128_SHA256 = Cipher("ECDHE-RSA-AES128-SHA256", Protocols.TLS12, True, True, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256")
-    ECDHE_RSA_AES256_SHA384 = Cipher("ECDHE-RSA-AES256-SHA384", Protocols.TLS12, True, True, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384")
-    ECDHE_RSA_AES128_GCM_SHA256 = Cipher("ECDHE-RSA-AES128-GCM-SHA256", Protocols.TLS12, True, True, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-    ECDHE_RSA_AES256_GCM_SHA384 = Cipher("ECDHE-RSA-AES256-GCM-SHA384", Protocols.TLS12, True, True, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
-    ECDHE_RSA_CHACHA20_POLY1305 = Cipher("ECDHE-RSA-CHACHA20-POLY1305", Protocols.TLS12, True, False, iana_standard_name="TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256")
-    CHACHA20_POLY1305_SHA256 = Cipher("TLS_CHACHA20_POLY1305_SHA256", Protocols.TLS13, True, False, iana_standard_name="TLS_CHACHA20_POLY1305_SHA256")
+    ECDHE_RSA_DES_CBC3_SHA = Cipher("ECDHE-RSA-DES-CBC3-SHA", Protocols.SSLv3,
+                                    False, False, iana_standard_name="TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA")
+    ECDHE_RSA_AES128_SHA = Cipher("ECDHE-RSA-AES128-SHA", Protocols.SSLv3,
+                                  True, False, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA")
+    ECDHE_RSA_AES256_SHA = Cipher("ECDHE-RSA-AES256-SHA", Protocols.SSLv3,
+                                  True, False, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA")
+    ECDHE_RSA_RC4_SHA = Cipher("ECDHE-RSA-RC4-SHA", Protocols.SSLv3,
+                               False, False, iana_standard_name="TLS_ECDHE_RSA_WITH_RC4_128_SHA")
+    ECDHE_RSA_AES128_SHA256 = Cipher("ECDHE-RSA-AES128-SHA256", Protocols.TLS12,
+                                     True, True, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256")
+    ECDHE_RSA_AES256_SHA384 = Cipher("ECDHE-RSA-AES256-SHA384", Protocols.TLS12,
+                                     True, True, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384")
+    ECDHE_RSA_AES128_GCM_SHA256 = Cipher("ECDHE-RSA-AES128-GCM-SHA256", Protocols.TLS12,
+                                         True, True, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+    ECDHE_RSA_AES256_GCM_SHA384 = Cipher("ECDHE-RSA-AES256-GCM-SHA384", Protocols.TLS12,
+                                         True, True, iana_standard_name="TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+    ECDHE_RSA_CHACHA20_POLY1305 = Cipher("ECDHE-RSA-CHACHA20-POLY1305", Protocols.TLS12,
+                                         True, False, iana_standard_name="TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256")
+    CHACHA20_POLY1305_SHA256 = Cipher("TLS_CHACHA20_POLY1305_SHA256", Protocols.TLS13,
+                                      True, False, iana_standard_name="TLS_CHACHA20_POLY1305_SHA256")
 
-    KMS_TLS_1_0_2018_10 = Cipher("KMS-TLS-1-0-2018-10", Protocols.TLS10, False, False, s2n=True)
-    KMS_PQ_TLS_1_0_2019_06 = Cipher("KMS-PQ-TLS-1-0-2019-06", Protocols.TLS10, False, False, s2n=True, pq=True)
-    KMS_PQ_TLS_1_0_2020_02 = Cipher("KMS-PQ-TLS-1-0-2020-02", Protocols.TLS10, False, False, s2n=True, pq=True)
-    KMS_PQ_TLS_1_0_2020_07 = Cipher("KMS-PQ-TLS-1-0-2020-07", Protocols.TLS10, False, False, s2n=True, pq=True)
-    PQ_SIKE_TEST_TLS_1_0_2019_11 = Cipher("PQ-SIKE-TEST-TLS-1-0-2019-11", Protocols.TLS10, False, False, s2n=True, pq=True)
-    PQ_SIKE_TEST_TLS_1_0_2020_02 = Cipher("PQ-SIKE-TEST-TLS-1-0-2020-02", Protocols.TLS10, False, False, s2n=True, pq=True)
-    PQ_TLS_1_0_2020_12 = Cipher("PQ-TLS-1-0-2020-12", Protocols.TLS10, False, False, s2n=True, pq=True)
+    KMS_TLS_1_0_2018_10 = Cipher(
+        "KMS-TLS-1-0-2018-10", Protocols.TLS10, False, False, s2n=True)
+    KMS_PQ_TLS_1_0_2019_06 = Cipher(
+        "KMS-PQ-TLS-1-0-2019-06", Protocols.TLS10, False, False, s2n=True, pq=True)
+    KMS_PQ_TLS_1_0_2020_02 = Cipher(
+        "KMS-PQ-TLS-1-0-2020-02", Protocols.TLS10, False, False, s2n=True, pq=True)
+    KMS_PQ_TLS_1_0_2020_07 = Cipher(
+        "KMS-PQ-TLS-1-0-2020-07", Protocols.TLS10, False, False, s2n=True, pq=True)
+    PQ_SIKE_TEST_TLS_1_0_2019_11 = Cipher(
+        "PQ-SIKE-TEST-TLS-1-0-2019-11", Protocols.TLS10, False, False, s2n=True, pq=True)
+    PQ_SIKE_TEST_TLS_1_0_2020_02 = Cipher(
+        "PQ-SIKE-TEST-TLS-1-0-2020-02", Protocols.TLS10, False, False, s2n=True, pq=True)
+    PQ_TLS_1_0_2020_12 = Cipher(
+        "PQ-TLS-1-0-2020-12", Protocols.TLS10, False, False, s2n=True, pq=True)
 
     @staticmethod
     def from_iana(iana_name):
         ciphers = [
             cipher for attr in vars(Ciphers)
             if not callable(cipher := getattr(Ciphers, attr))
-               and not attr.startswith("_")
-               and cipher.iana_standard_name
+            and not attr.startswith("_")
+            and cipher.iana_standard_name
         ]
         return {
             cipher.iana_standard_name: cipher
@@ -340,7 +381,7 @@ class Signature(object):
 
 
 class Signatures(object):
-    RSA_SHA1   = Signature('RSA+SHA1',   max_protocol=Protocols.TLS12)
+    RSA_SHA1 = Signature('RSA+SHA1',   max_protocol=Protocols.TLS12)
     RSA_SHA224 = Signature('RSA+SHA224', max_protocol=Protocols.TLS12)
     RSA_SHA256 = Signature('RSA+SHA256', max_protocol=Protocols.TLS12)
     RSA_SHA384 = Signature('RSA+SHA384', max_protocol=Protocols.TLS12)

--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -107,105 +107,105 @@ available_ports = AvailablePorts()
 # Server certificates used to test matching domain names client with server_name
 # ( cert_path, private_key_path, domains[] )
 SNI_CERTS = {
-    "alligator" : (
+    "alligator": (
         TEST_SNI_CERT_DIRECTORY + "alligator_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "alligator_key.pem",
         ["www.alligator.com"]
     ),
-    "second_alligator_rsa" : (
+    "second_alligator_rsa": (
         TEST_SNI_CERT_DIRECTORY + "second_alligator_rsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "second_alligator_rsa_key.pem",
         ["www.alligator.com"]
     ),
-    "alligator_ecdsa" : (
+    "alligator_ecdsa": (
         TEST_SNI_CERT_DIRECTORY + "alligator_ecdsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "alligator_ecdsa_key.pem",
         ["www.alligator.com"]
     ),
-    "beaver" : (
+    "beaver": (
         TEST_SNI_CERT_DIRECTORY + "beaver_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "beaver_key.pem",
         ["www.beaver.com"]
     ),
-    "many_animals" : (
+    "many_animals": (
         TEST_SNI_CERT_DIRECTORY + "many_animal_sans_rsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "many_animal_sans_rsa_key.pem",
         ["www.catfish.com",
-        "www.dolphin.com",
-        "www.elephant.com",
-        "www.falcon.com",
-        "www.gorilla.com",
-        "www.horse.com",
-        "www.impala.com",
-        # "Simple hostname"
-        "Jackal",
-        "k.e.e.l.b.i.l.l.e.d.t.o.u.c.a.n",
-        # SAN on this cert is actually "ladybug.ladybug"
-        # Verify case insensitivity works as expected.
-        "LADYBUG.LADYBUG",
-        "com.penguin.macaroni"]
+         "www.dolphin.com",
+         "www.elephant.com",
+         "www.falcon.com",
+         "www.gorilla.com",
+         "www.horse.com",
+         "www.impala.com",
+         # "Simple hostname"
+         "Jackal",
+         "k.e.e.l.b.i.l.l.e.d.t.o.u.c.a.n",
+         # SAN on this cert is actually "ladybug.ladybug"
+         # Verify case insensitivity works as expected.
+         "LADYBUG.LADYBUG",
+         "com.penguin.macaroni"]
     ),
-    "narwhal_cn" : (
+    "narwhal_cn": (
         TEST_SNI_CERT_DIRECTORY + "narwhal_cn_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "narwhal_cn_key.pem",
         ["www.narwhal.com"]
     ),
-    "octopus_cn_platypus_san" : (
+    "octopus_cn_platypus_san": (
         TEST_SNI_CERT_DIRECTORY + "octopus_cn_platypus_san_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "octopus_cn_platypus_san_key.pem",
         ["www.platypus.com"]
     ),
-    "quail_cn_rattlesnake_cn" : (
+    "quail_cn_rattlesnake_cn": (
         TEST_SNI_CERT_DIRECTORY + "quail_cn_rattlesnake_cn_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "quail_cn_rattlesnake_cn_key.pem",
         ["www.quail.com", "www.rattlesnake.com"]
     ),
-    "many_animals_mixed_case" : (
+    "many_animals_mixed_case": (
         TEST_SNI_CERT_DIRECTORY + "many_animal_sans_mixed_case_rsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "many_animal_sans_mixed_case_rsa_key.pem",
         ["alligator.com",
-        "beaver.com",
-        "catFish.com",
-        "WWW.dolphin.COM",
-        "www.ELEPHANT.com",
-        "www.Falcon.Com",
-        "WWW.gorilla.COM",
-        "www.horse.com",
-        "WWW.IMPALA.COM",
-        "WwW.jAcKaL.cOm"]
+         "beaver.com",
+         "catFish.com",
+         "WWW.dolphin.COM",
+         "www.ELEPHANT.com",
+         "www.Falcon.Com",
+         "WWW.gorilla.COM",
+         "www.horse.com",
+         "WWW.IMPALA.COM",
+         "WwW.jAcKaL.cOm"]
     ),
-    "embedded_wildcard" : (
+    "embedded_wildcard": (
         TEST_SNI_CERT_DIRECTORY + "embedded_wildcard_rsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "embedded_wildcard_rsa_key.pem",
         ["www.labelstart*labelend.com"]
     ),
-    "non_empty_label_wildcard" : (
+    "non_empty_label_wildcard": (
         TEST_SNI_CERT_DIRECTORY + "non_empty_label_wildcard_rsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "non_empty_label_wildcard_rsa_key.pem",
         ["WILD*.middle.end"]
     ),
-    "trailing_wildcard" : (
+    "trailing_wildcard": (
         TEST_SNI_CERT_DIRECTORY + "trailing_wildcard_rsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "trailing_wildcard_rsa_key.pem",
         ["the.prefix.*"]
     ),
-    "wildcard_insect" : (
+    "wildcard_insect": (
         TEST_SNI_CERT_DIRECTORY + "wildcard_insect_rsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "wildcard_insect_rsa_key.pem",
         ["ant.insect.hexapod",
-        "BEE.insect.hexapod",
-        "wasp.INSECT.hexapod",
-        "butterfly.insect.hexapod"]
+         "BEE.insect.hexapod",
+         "wasp.INSECT.hexapod",
+         "butterfly.insect.hexapod"]
     ),
-    "termite" : (
+    "termite": (
         TEST_SNI_CERT_DIRECTORY + "termite_rsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "termite_rsa_key.pem",
-        [ "termite.insect.hexapod" ]
+        ["termite.insect.hexapod"]
     ),
-    "underwing" : (
+    "underwing": (
         TEST_SNI_CERT_DIRECTORY + "underwing_ecdsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "underwing_ecdsa_key.pem",
-        [ "underwing.insect.hexapod" ]
+        ["underwing.insect.hexapod"]
     )
 }
 
@@ -213,105 +213,117 @@ SNI_CERTS = {
 # Test cases for certificate selection.
 # Test inputs: server certificates to load into s2nd, client SNI and capabilities, outputs are selected server cert
 # and negotiated cipher.
-MultiCertTest = collections.namedtuple('MultiCertTest', 'description server_certs client_sni client_ciphers expected_cert expect_matching_hostname')
-MULTI_CERT_TEST_CASES= [
+MultiCertTest = collections.namedtuple(
+    'MultiCertTest', 'description server_certs client_sni client_ciphers expected_cert expect_matching_hostname')
+MULTI_CERT_TEST_CASES = [
     MultiCertTest(
         description="Test basic SNI match for default cert.",
-        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        server_certs=[SNI_CERTS["alligator"],
+                      SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
         client_sni="www.alligator.com",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator"],
         expect_matching_hostname=True),
     MultiCertTest(
         description="Test basic SNI matches for non-default cert.",
-        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        server_certs=[SNI_CERTS["alligator"],
+                      SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
         client_sni="www.beaver.com",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["beaver"],
         expect_matching_hostname=True),
     MultiCertTest(
         description="Test default cert is selected when there are no SNI matches.",
-        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        server_certs=[SNI_CERTS["alligator"],
+                      SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
         client_sni="not.a.match",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator"],
         expect_matching_hostname=False),
     MultiCertTest(
         description="Test default cert is selected when no SNI is sent.",
-        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        server_certs=[SNI_CERTS["alligator"],
+                      SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
         client_sni=None,
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator"],
         expect_matching_hostname=False),
     MultiCertTest(
         description="Test ECDSA cert is selected with matching domain and client only supports ECDSA.",
-        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        server_certs=[SNI_CERTS["alligator"],
+                      SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
         client_sni="www.alligator.com",
         client_ciphers=[Ciphers.ECDHE_ECDSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator_ecdsa"],
         expect_matching_hostname=True),
     MultiCertTest(
-        description="Test ECDSA cert selected when: domain matches for both ECDSA+RSA, client supports ECDSA+RSA "\
+        description="Test ECDSA cert selected when: domain matches for both ECDSA+RSA, client supports ECDSA+RSA "
                     " ciphers, ECDSA is higher priority on server side.",
-        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        server_certs=[SNI_CERTS["alligator"],
+                      SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
         client_sni="www.alligator.com",
-        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA, Ciphers.ECDHE_ECDSA_AES128_SHA],
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA,
+                        Ciphers.ECDHE_ECDSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator_ecdsa"],
         expect_matching_hostname=True),
     MultiCertTest(
-        description="Test domain match is highest priority. Domain matching ECDSA certificate should be selected"\
+        description="Test domain match is highest priority. Domain matching ECDSA certificate should be selected"
                     " even if domain mismatched RSA certificate is available and RSA cipher is higher priority.",
         server_certs=[SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
         client_sni="www.alligator.com",
-        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA256, Ciphers.ECDHE_ECDSA_AES128_SHA256],
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA256,
+                        Ciphers.ECDHE_ECDSA_AES128_SHA256],
         expected_cert=SNI_CERTS["alligator_ecdsa"],
         expect_matching_hostname=True),
     MultiCertTest(
         description="Test certificate with single SAN entry matching is selected before mismatched multi SAN cert",
-        server_certs=[SNI_CERTS["many_animals"] , SNI_CERTS["alligator"]],
+        server_certs=[SNI_CERTS["many_animals"], SNI_CERTS["alligator"]],
         client_sni="www.alligator.com",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator"],
         expect_matching_hostname=True),
-        # many_animals was the first cert added
+    # many_animals was the first cert added
     MultiCertTest(
         description="Test default cert with multiple sans and no SNI sent.",
-        server_certs=[SNI_CERTS["many_animals"] , SNI_CERTS["alligator"]],
+        server_certs=[SNI_CERTS["many_animals"], SNI_CERTS["alligator"]],
         client_sni=None,
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["many_animals"],
         expect_matching_hostname=False),
     MultiCertTest(
         description="Test certificate match with CN",
-        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["narwhal_cn"] ],
+        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["narwhal_cn"]],
         client_sni="www.narwhal.com",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["narwhal_cn"],
         expect_matching_hostname=True),
     MultiCertTest(
         description="Test SAN+CN cert can match using SAN.",
-        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["octopus_cn_platypus_san"] ],
+        server_certs=[SNI_CERTS["alligator"],
+                      SNI_CERTS["octopus_cn_platypus_san"]],
         client_sni="www.platypus.com",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["octopus_cn_platypus_san"],
         expect_matching_hostname=True),
     MultiCertTest(
         description="Test that CN is not considered for matching if the certificate contains SANs.",
-        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["octopus_cn_platypus_san"] ],
+        server_certs=[SNI_CERTS["alligator"],
+                      SNI_CERTS["octopus_cn_platypus_san"]],
         client_sni="www.octopus.com",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator"],
         expect_matching_hostname=False),
     MultiCertTest(
         description="Test certificate with multiple CNs can match.",
-        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["quail_cn_rattlesnake_cn"] ],
+        server_certs=[SNI_CERTS["alligator"],
+                      SNI_CERTS["quail_cn_rattlesnake_cn"]],
         client_sni="www.rattlesnake.com",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["quail_cn_rattlesnake_cn"],
         expect_matching_hostname=False),
     MultiCertTest(
         description="Test cert with embedded wildcard is not treated as a wildcard.",
-        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["embedded_wildcard"] ],
+        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["embedded_wildcard"]],
         client_sni="www.labelstartWILDCARDlabelend.com",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator"],
@@ -319,14 +331,15 @@ MULTI_CERT_TEST_CASES= [
     MultiCertTest(
         description="Test non empty left label wildcard cert is not treated as a wildcard."\
                     " s2n only supports wildcards with a single * as the left label",
-        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["non_empty_label_wildcard"] ],
+        server_certs=[SNI_CERTS["alligator"],
+                      SNI_CERTS["non_empty_label_wildcard"]],
         client_sni="WILDCARD.middle.end",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator"],
         expect_matching_hostname=False),
     MultiCertTest(
         description="Test cert with trailing * is not treated as wildcard.",
-        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["trailing_wildcard"] ],
+        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["trailing_wildcard"]],
         client_sni="the.prefix.WILDCARD",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator"],
@@ -334,7 +347,8 @@ MULTI_CERT_TEST_CASES= [
     MultiCertTest(
         description="Certificate with exact sni match(termite.insect.hexapod) is preferred over wildcard"\
                     " *.insect.hexapod",
-        server_certs=[ SNI_CERTS["wildcard_insect"], SNI_CERTS["alligator"], SNI_CERTS["termite"] ],
+        server_certs=[SNI_CERTS["wildcard_insect"],
+                      SNI_CERTS["alligator"], SNI_CERTS["termite"]],
         client_sni="termite.insect.hexapod",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["termite"],
@@ -342,46 +356,52 @@ MULTI_CERT_TEST_CASES= [
     MultiCertTest(
         description="ECDSA Certificate with exact sni match(underwing.insect.hexapod) is preferred over RSA wildcard"\
                     " *.insect.hexapod when RSA ciphers are higher priority than ECDSA in server preferences.",
-        server_certs=[ SNI_CERTS["wildcard_insect"], SNI_CERTS["alligator"], SNI_CERTS["underwing"] ],
+        server_certs=[SNI_CERTS["wildcard_insect"],
+                      SNI_CERTS["alligator"], SNI_CERTS["underwing"]],
         client_sni="underwing.insect.hexapod",
-        client_ciphers=[Ciphers.ECDHE_RSA_AES128_GCM_SHA256, Ciphers.ECDHE_ECDSA_AES128_GCM_SHA256],
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_GCM_SHA256,
+                        Ciphers.ECDHE_ECDSA_AES128_GCM_SHA256],
         expected_cert=SNI_CERTS["underwing"],
         expect_matching_hostname=True),
     MultiCertTest(
         description="Firstly loaded matching certificate should be selected among certificates with the same domain names",
-        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["second_alligator_rsa"] ],
+        server_certs=[SNI_CERTS["alligator"],
+                      SNI_CERTS["second_alligator_rsa"]],
         client_sni="www.alligator.com",
         client_ciphers=[Ciphers.AES128_GCM_SHA256],
         expected_cert=SNI_CERTS["alligator"],
         expect_matching_hostname=True),
     MultiCertTest(
         description="Firstly loaded matching certificate should be selected among matching+non-matching certificates",
-        server_certs=[ SNI_CERTS["beaver"], SNI_CERTS["alligator"], SNI_CERTS["second_alligator_rsa"] ],
+        server_certs=[SNI_CERTS["beaver"], SNI_CERTS["alligator"],
+                      SNI_CERTS["second_alligator_rsa"]],
         client_sni="www.alligator.com",
         client_ciphers=[Ciphers.AES128_GCM_SHA256],
         expected_cert=SNI_CERTS["alligator"],
         expect_matching_hostname=True)]
 # Positive test for wildcard matches
 MULTI_CERT_TEST_CASES.extend([MultiCertTest(
-        description="Test wildcard *.insect.hexapod matches subdomain " + specific_insect_domain,
-        server_certs=[ SNI_CERTS["alligator"], SNI_CERTS["wildcard_insect"] ],
-        client_sni=specific_insect_domain,
-        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
-        expected_cert=SNI_CERTS["wildcard_insect"],
-        expect_matching_hostname=True) for specific_insect_domain in SNI_CERTS["wildcard_insect"][2]])
+    description="Test wildcard *.insect.hexapod matches subdomain " + specific_insect_domain,
+    server_certs=[SNI_CERTS["alligator"], SNI_CERTS["wildcard_insect"]],
+    client_sni=specific_insect_domain,
+    client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+    expected_cert=SNI_CERTS["wildcard_insect"],
+    expect_matching_hostname=True) for specific_insect_domain in SNI_CERTS["wildcard_insect"][2]])
 # Positive test for basic SAN matches
 MULTI_CERT_TEST_CASES.extend([MultiCertTest(
-        description="Match SAN " + many_animal_domain + " in many_animals cert",
-        server_certs= [ SNI_CERTS["alligator"], SNI_CERTS["many_animals"] ],
-        client_sni=many_animal_domain,
-        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
-        expected_cert=SNI_CERTS["many_animals"],
-        expect_matching_hostname=True) for many_animal_domain in SNI_CERTS["many_animals"][2]])
+    description="Match SAN " + many_animal_domain + " in many_animals cert",
+    server_certs=[SNI_CERTS["alligator"], SNI_CERTS["many_animals"]],
+    client_sni=many_animal_domain,
+    client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+    expected_cert=SNI_CERTS["many_animals"],
+    expect_matching_hostname=True) for many_animal_domain in SNI_CERTS["many_animals"][2]])
 # Positive test for mixed cased SAN matches
 MULTI_CERT_TEST_CASES.extend([MultiCertTest(
-        description="Match SAN " + many_animal_domain + " in many_animals_mixed_case cert",
-        server_certs= [SNI_CERTS["alligator"] , SNI_CERTS["many_animals_mixed_case"]],
-        client_sni=many_animal_domain,
-        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
-        expected_cert=SNI_CERTS["many_animals_mixed_case"],
-        expect_matching_hostname=True) for many_animal_domain in SNI_CERTS["many_animals_mixed_case"][2]])
+    description="Match SAN " + many_animal_domain +
+    " in many_animals_mixed_case cert",
+    server_certs=[SNI_CERTS["alligator"],
+                  SNI_CERTS["many_animals_mixed_case"]],
+    client_sni=many_animal_domain,
+    client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+    expected_cert=SNI_CERTS["many_animals_mixed_case"],
+    expect_matching_hostname=True) for many_animal_domain in SNI_CERTS["many_animals_mixed_case"][2]])

--- a/tests/integrationv2/conftest.py
+++ b/tests/integrationv2/conftest.py
@@ -3,9 +3,12 @@ from global_flags import set_flag, S2N_PROVIDER_VERSION, S2N_FIPS_MODE, S2N_NO_P
 
 
 def pytest_addoption(parser):
-    parser.addoption("--provider-version", action="store", dest="provider-version", default=None, type=str, help="Set the version of the TLS provider")
-    parser.addoption("--fips-mode", action="store", dest="fips-mode", default=False, type=int, help="S2N is running in FIPS mode")
-    parser.addoption("--no-pq", action="store", dest="no-pq", default=False, type=int, help="Turn off PQ support")
+    parser.addoption("--provider-version", action="store", dest="provider-version",
+                     default=None, type=str, help="Set the version of the TLS provider")
+    parser.addoption("--fips-mode", action="store", dest="fips-mode",
+                     default=False, type=int, help="S2N is running in FIPS mode")
+    parser.addoption("--no-pq", action="store", dest="no-pq",
+                     default=False, type=int, help="Turn off PQ support")
 
 
 def pytest_configure(config):

--- a/tests/integrationv2/constants.py
+++ b/tests/integrationv2/constants.py
@@ -1,6 +1,7 @@
-TEST_CERT_DIRECTORY="../pems/"
-TEST_SNI_CERT_DIRECTORY="../pems/sni/"
-TEST_OCSP_DIRECTORY="../pems/ocsp/"
+TEST_CERT_DIRECTORY = "../pems/"
+TEST_SNI_CERT_DIRECTORY = "../pems/sni/"
+TEST_OCSP_DIRECTORY = "../pems/ocsp/"
 
-TRUST_STORE_BUNDLE=TEST_CERT_DIRECTORY + 'trust-store/ca-bundle.crt'
-TRUST_STORE_TRUSTED_BUNDLE=TEST_CERT_DIRECTORY + 'trust-store/ca-bundle.trust.crt'
+TRUST_STORE_BUNDLE = TEST_CERT_DIRECTORY + 'trust-store/ca-bundle.crt'
+TRUST_STORE_TRUSTED_BUNDLE = TEST_CERT_DIRECTORY + \
+    'trust-store/ca-bundle.trust.crt'

--- a/tests/integrationv2/fixtures.py
+++ b/tests/integrationv2/fixtures.py
@@ -52,7 +52,8 @@ def managed_process():
             p.start()
             with provider._provider_ready_condition:
                 # Don't continue processing until the provider has indicated it is ready.
-                provider._provider_ready_condition.wait_for(provider.is_provider_ready, timeout)
+                provider._provider_ready_condition.wait_for(
+                    provider.is_provider_ready, timeout)
         return p
 
     try:
@@ -73,7 +74,8 @@ def _swap_mtu(device, new_mtu):
     Return the original MTU so it can be reset later.
     """
     cmd = ["ip", "link", "show", device]
-    p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(cmd, stdin=subprocess.PIPE,
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     mtu = 65536
     for line in p.stdout.readlines():
         s = line.decode("utf-8")

--- a/tests/integrationv2/global_flags.py
+++ b/tests/integrationv2/global_flags.py
@@ -14,6 +14,7 @@ S2N_PROVIDER_VERSION = 's2n_provider_version'
 
 _flags = {}
 
+
 def get_flag(name, default=None):
     """Return the value of a flag"""
     return _flags.get(name, default)

--- a/tests/integrationv2/processes.py
+++ b/tests/integrationv2/processes.py
@@ -33,6 +33,7 @@ class _processCommunicator(object):
     framework. We rely on sleeps and waits, and still hit hard to debug deadlocks from
     time to time.
     """
+
     def __init__(self, proc):
         self.proc = proc
         self.wait_for_marker = None
@@ -156,7 +157,7 @@ class _processCommunicator(object):
                 for key, events in ready:
                     # STDIN is only registered to receive events after the send_marker is found.
                     if key.fileobj is self.proc.stdin:
-                        chunk = input_view[input_data_offset :
+                        chunk = input_view[input_data_offset:
                                            input_data_offset + _PIPE_BUF]
                         try:
                             input_data_offset += os.write(key.fd, chunk)
@@ -183,7 +184,8 @@ class _processCommunicator(object):
                         # just mark input_send as true so we can close out STDIN.
                         if send_marker is not None and send_marker in str(data):
                             if self.proc.stdin and input_data:
-                                selector.register(self.proc.stdin, selectors.EVENT_WRITE)
+                                selector.register(
+                                    self.proc.stdin, selectors.EVENT_WRITE)
                                 message = input_data.pop(0)
                                 if send_with_newline:
                                     message += b'\n'
@@ -239,9 +241,9 @@ class _processCommunicator(object):
             return
         if skip_check_and_raise or _time() > endtime:
             raise subprocess.TimeoutExpired(
-                    self.proc.args, orig_timeout,
-                    output=b''.join(stdout_seq) if stdout_seq else None,
-                    stderr=b''.join(stderr_seq) if stderr_seq else None)
+                self.proc.args, orig_timeout,
+                output=b''.join(stdout_seq) if stdout_seq else None,
+                stderr=b''.join(stderr_seq) if stderr_seq else None)
 
 
 class ManagedProcess(threading.Thread):
@@ -252,6 +254,7 @@ class ManagedProcess(threading.Thread):
     The stdin/stdout/stderr and exist code a monitored and results
     are made available to the caller.
     """
+
     def __init__(self, cmd_line, provider_set_ready_condition, wait_for_marker=None, send_marker_list=None,
                  close_marker=None, timeout=5, data_source=None, env_overrides=dict(), expect_stderr=False,
                  kill_marker=None, send_with_newline=False):
@@ -300,10 +303,12 @@ class ManagedProcess(threading.Thread):
     def run(self):
         with self.results_condition:
             try:
-                proc = subprocess.Popen(self.cmd_line, env=self.proc_env, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+                proc = subprocess.Popen(self.cmd_line, env=self.proc_env, stdin=subprocess.PIPE,
+                                        stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
                 self.proc = proc
             except Exception as ex:
-                self.results = Results(None, None, None, ex, self.expect_stderr)
+                self.results = Results(
+                    None, None, None, ex, self.expect_stderr)
                 raise ex
 
             communicator = _processCommunicator(proc)
@@ -339,17 +344,21 @@ class ManagedProcess(threading.Thread):
 
                 # Read any remaining output
                 proc_results = communicator.communicate()
-                self.results = Results(proc_results[0], proc_results[1], proc.returncode, wrapped_ex, self.expect_stderr)
+                self.results = Results(
+                    proc_results[0], proc_results[1], proc.returncode, wrapped_ex, self.expect_stderr)
             except Exception as ex:
-                self.results = Results(proc_results[0], proc_results[1], proc.returncode, ex, self.expect_stderr)
+                self.results = Results(
+                    proc_results[0], proc_results[1], proc.returncode, ex, self.expect_stderr)
                 raise ex
             finally:
                 # This data is dumped to stdout so we capture this
                 # information no matter where a test fails.
                 print("Command line: {}".format(" ".join(self.cmd_line)))
                 print("Exit code: {}".format(proc.returncode))
-                print("Stdout: {}".format(proc_results[0].decode("utf-8", "backslashreplace")))
-                print("Stderr: {}".format(proc_results[1].decode("utf-8", "backslashreplace")))
+                print("Stdout: {}".format(
+                    proc_results[0].decode("utf-8", "backslashreplace")))
+                print("Stderr: {}".format(
+                    proc_results[1].decode("utf-8", "backslashreplace")))
 
     def kill(self):
         self.proc.kill()
@@ -378,7 +387,8 @@ class ManagedProcess(threading.Thread):
         Return the results, or raise the timeout exception.
         """
         with self.results_condition:
-            result = self.results_condition.wait_for(self._results_ready, timeout=self.timeout)
+            result = self.results_condition.wait_for(
+                self._results_ready, timeout=self.timeout)
 
             if result is False:
                 raise Exception("Timeout")

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -98,6 +98,7 @@ class Tcpdump(Provider):
     This class still follows the provider setup, but all values are hardcoded
     because this isn't expected to be used outside of the dynamic record test.
     """
+
     def __init__(self, options: ProviderOptions):
         Provider.__init__(self, options)
 
@@ -106,22 +107,22 @@ class Tcpdump(Provider):
         tcpdump_filter = "dst port {}".format(self.options.port)
 
         cmd_line = ["tcpdump",
-            # Line buffer the output
-            "-l",
+                    # Line buffer the output
+                    "-l",
 
-            # Only read 10 packets before exiting. This is enough to find a large
-            # packet, and still exit before the timeout.
-            "-c", "10",
+                    # Only read 10 packets before exiting. This is enough to find a large
+                    # packet, and still exit before the timeout.
+                    "-c", "10",
 
-            # Watch the loopback device
-            "-i", "lo",
+                    # Watch the loopback device
+                    "-i", "lo",
 
-            # Don't resolve IP addresses
-            "-nn",
+                    # Don't resolve IP addresses
+                    "-nn",
 
-            # Set the buffer size to 1k
-            "-B", "1024",
-            tcpdump_filter]
+                    # Set the buffer size to 1k
+                    "-B", "1024",
+                    tcpdump_filter]
 
         return cmd_line
 
@@ -130,6 +131,7 @@ class S2N(Provider):
     """
     The S2N provider translates flags into s2nc/s2nd command line arguments.
     """
+
     def __init__(self, options: ProviderOptions):
         Provider.__init__(self, options)
 
@@ -253,7 +255,8 @@ class S2N(Provider):
             cmd_line.append('-T')
 
         if self.options.reconnects_before_exit is not None:
-            cmd_line.append('--max-conns={}'.format(self.options.reconnects_before_exit))
+            cmd_line.append(
+                '--max-conns={}'.format(self.options.reconnects_before_exit))
 
         if self.options.ocsp_response is not None:
             cmd_line.extend(["--ocsp", self.options.ocsp_response])
@@ -301,10 +304,12 @@ class OpenSSL(Provider):
             # In the case of a cipher list we need to be sure TLS13 specific ciphers aren't
             # mixed with ciphers from previous versions
             is_tls13_or_above = (cipher[0].min_version >= Protocols.TLS13)
-            mismatch = [c for c in cipher if (c.min_version >= Protocols.TLS13) != is_tls13_or_above]
+            mismatch = [c for c in cipher if (
+                c.min_version >= Protocols.TLS13) != is_tls13_or_above]
 
             if len(mismatch) > 0:
-                raise Exception("Cannot combine ciphers for TLS1.3 or above with older ciphers: {}".format([c.name for c in cipher]))
+                raise Exception("Cannot combine ciphers for TLS1.3 or above with older ciphers: {}".format(
+                    [c.name for c in cipher]))
 
             ciphers.append(self._join_ciphers(cipher))
         else:
@@ -365,7 +370,8 @@ class OpenSSL(Provider):
 
     def setup_client(self):
         cmd_line = ['openssl', 's_client']
-        cmd_line.extend(['-connect', '{}:{}'.format(self.options.host, self.options.port)])
+        cmd_line.extend(
+            ['-connect', '{}:{}'.format(self.options.host, self.options.port)])
 
         # Additional debugging that will be captured incase of failure
         cmd_line.extend(['-debug', '-tlsextdebug', '-state'])
@@ -411,7 +417,8 @@ class OpenSSL(Provider):
             cmd_line.append("-status")
 
         if self.options.signature_algorithm is not None:
-            cmd_line.extend(["-sigalgs", self.options.signature_algorithm.name])
+            cmd_line.extend(
+                ["-sigalgs", self.options.signature_algorithm.name])
 
         if self.options.record_size is not None:
             cmd_line.extend(["-max_send_frag", str(self.options.record_size)])
@@ -430,7 +437,8 @@ class OpenSSL(Provider):
 
         if self.options.reconnects_before_exit is not None:
             # If the user request a specific reconnection count, set it here
-            cmd_line.extend(['-naccept', str(self.options.reconnects_before_exit)])
+            cmd_line.extend(
+                ['-naccept', str(self.options.reconnects_before_exit)])
         else:
             # Exit after the first connection by default
             cmd_line.extend(['-naccept', '1'])
@@ -469,7 +477,8 @@ class OpenSSL(Provider):
             cmd_line.extend(["-status_file", self.options.ocsp_response])
 
         if self.options.signature_algorithm is not None:
-            cmd_line.extend(["-sigalgs", self.options.signature_algorithm.name])
+            cmd_line.extend(
+                ["-sigalgs", self.options.signature_algorithm.name])
 
         if self.options.extra_flags is not None:
             cmd_line.extend(self.options.extra_flags)
@@ -482,6 +491,7 @@ class JavaSSL(Provider):
     NOTE: Only a Java SSL client has been set up. The server has not been 
     implemented yet.
     """
+
     def __init__(self, options: ProviderOptions):
         Provider.__init__(self, options)
 
@@ -498,7 +508,7 @@ class JavaSSL(Provider):
 
     @classmethod
     def supports_cipher(cls, cipher, with_curve=None):
-        # Java SSL does not support CHACHA20 
+        # Java SSL does not support CHACHA20
         if 'CHACHA20' in cipher.name:
             return False
 
@@ -536,6 +546,7 @@ class BoringSSL(Provider):
     is not yet supported. The client works, the server has not yet been
     implemented, neither are in the default configuration.
     """
+
     def __init__(self, options: ProviderOptions):
         Provider.__init__(self, options)
 
@@ -548,18 +559,22 @@ class BoringSSL(Provider):
 
     def setup_client(self):
         cmd_line = ['bssl', 's_client']
-        cmd_line.extend(['-connect', '{}:{}'.format(self.options.host, self.options.port)])
+        cmd_line.extend(
+            ['-connect', '{}:{}'.format(self.options.host, self.options.port)])
         if self.options.cert is not None:
             cmd_line.extend(['-cert', self.options.cert])
         if self.options.key is not None:
             cmd_line.extend(['-key', self.options.key])
         if self.options.cipher is not None:
             if self.options.cipher == Ciphersuites.TLS_CHACHA20_POLY1305_SHA256:
-                cmd_line.extend(['-cipher', 'TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256'])
+                cmd_line.extend(
+                    ['-cipher', 'TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256'])
             elif self.options.cipher == Ciphersuites.TLS_AES_128_GCM_256:
-                pytest.skip('BoringSSL does not support Cipher {}'.format(self.options.cipher))
+                pytest.skip('BoringSSL does not support Cipher {}'.format(
+                    self.options.cipher))
             elif self.options.cipher == Ciphersuites.TLS_AES_256_GCM_384:
-                pytest.skip('BoringSSL does not support Cipher {}'.format(self.options.cipher))
+                pytest.skip('BoringSSL does not support Cipher {}'.format(
+                    self.options.cipher))
         if self.options.curve is not None:
             if self.options.curve == Curves.P256:
                 cmd_line.extend(['-curves', 'P-256'])
@@ -568,7 +583,8 @@ class BoringSSL(Provider):
             elif self.options.curve == Curves.P521:
                 cmd_line.extend(['-curves', 'P-521'])
             elif self.options.curve == Curves.X25519:
-                pytest.skip('BoringSSL does not support curve {}'.format(self.options.curve))
+                pytest.skip('BoringSSL does not support curve {}'.format(
+                    self.options.curve))
 
         # Clients are always ready to connect
         self.set_provider_ready()
@@ -652,22 +668,26 @@ class GnuTLS(Provider):
         priority_str = "NONE"
 
         if self.options.protocol:
-            priority_str += ":+" + self.protocol_to_priority_str(self.options.protocol)
+            priority_str += ":+" + \
+                self.protocol_to_priority_str(self.options.protocol)
         else:
             priority_str += ":+VERS-ALL"
 
         if self.options.cipher:
-            priority_str += ":+" + self.cipher_to_priority_str(self.options.cipher)
+            priority_str += ":+" + \
+                self.cipher_to_priority_str(self.options.cipher)
         else:
             priority_str += ":+KX-ALL:+CIPHER-ALL:+MAC-ALL"
 
         if self.options.curve:
-            priority_str += ":+" + self.curve_to_priority_str(self.options.curve)
+            priority_str += ":+" + \
+                self.curve_to_priority_str(self.options.curve)
         else:
             priority_str += ":+GROUP-ALL"
 
         if self.options.signature_algorithm:
-            priority_str += ":+" + self.sigalg_to_priority_str(self.options.signature_algorithm)
+            priority_str += ":+" + \
+                self.sigalg_to_priority_str(self.options.signature_algorithm)
         else:
             priority_str += ":+SIGN-ALL"
 

--- a/tests/integrationv2/test_client_authentication.py
+++ b/tests/integrationv2/test_client_authentication.py
@@ -4,7 +4,7 @@ import pytest
 import time
 
 from configuration import (available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES,
-    ALL_TEST_CERTS, PROTOCOLS)
+                           ALL_TEST_CERTS, PROTOCOLS)
 from common import Certificates, ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process
 from providers import Provider, S2N, OpenSSL
@@ -21,6 +21,7 @@ CERTS_TO_TEST = [
     Certificates.RSA_PSS_2048_SHA256,
 ]
 
+
 def assert_openssl_handshake_complete(results, is_complete=True):
     if is_complete:
         assert b'read finished' in results.stderr
@@ -32,9 +33,11 @@ def assert_openssl_handshake_complete(results, is_complete=True):
 def assert_s2n_handshake_complete(results, protocol, provider, is_complete=True):
     expected_version = get_expected_s2n_version(protocol, provider)
     if is_complete:
-        assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
+        assert to_bytes("Actual protocol version: {}".format(
+            expected_version)) in results.stdout
     else:
-        assert to_bytes("Actual protocol version: {}".format(expected_version)) not in results.stdout
+        assert to_bytes("Actual protocol version: {}".format(
+            expected_version)) not in results.stdout
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -76,7 +79,6 @@ def test_client_auth_with_s2n_server(managed_process, cipher, provider, protocol
         assert b'write certificate verify' in results.stderr
         assert_openssl_handshake_complete(results)
 
-
     # S2N should successfully connect
     for results in server.get_results():
         results.assert_success()
@@ -112,7 +114,7 @@ def test_client_auth_with_s2n_server_using_nonmatching_certs(managed_process, ci
     server_options.cert = certificate.cert
 
     # Tell the server to expect the wrong certificate
-    server_options.trust_store=Certificates.RSA_2048_SHA256_WILDCARD.cert
+    server_options.trust_store = Certificates.RSA_2048_SHA256_WILDCARD.cert
 
     server = managed_process(S2N, server_options, timeout=5)
     client = managed_process(OpenSSL, client_options, timeout=5)
@@ -174,9 +176,9 @@ def test_client_auth_with_s2n_client_no_cert(managed_process, cipher, protocol, 
 
     for results in client.get_results():
         assert results.exception is None
-         # TLS1.3 OpenSSL fails after the handshake, but pre-TLS1.3 fails during
+        # TLS1.3 OpenSSL fails after the handshake, but pre-TLS1.3 fails during
         if protocol is not Protocols.TLS13:
-            assert (results.exit_code != 0) 
+            assert (results.exit_code != 0)
             assert b"Failed to negotiate: 'TLS alert received'" in results.stderr
             assert_s2n_handshake_complete(results, protocol, provider, False)
 

--- a/tests/integrationv2/test_cross_compatibility.py
+++ b/tests/integrationv2/test_cross_compatibility.py
@@ -19,12 +19,14 @@ RESUMPTION_PROTOCOLS = [Protocols.TLS12, Protocols.TLS13]
 An old S2N server can resume a session with a new S2N server's session ticket. 
 Tests that S2N tickets are backwards-compatible.
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", RESUMPTION_PROTOCOLS, ids=get_parameter_name)
-@pytest.mark.parametrize("provider", [ OpenSSL ], ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_old_server_new_ticket(managed_process, tmp_path, cipher, curve, protocol, provider, certificate):
     ticket_file = str(tmp_path / TICKET_FILE)
     assert not os.path.exists(ticket_file)
@@ -48,8 +50,10 @@ def test_s2n_old_server_new_ticket(managed_process, tmp_path, cipher, curve, pro
     server_options.cert = certificate.cert
     server_options.data_to_send = CLOSE_MARKER_BYTES
 
-    s2n_server = managed_process(S2N, server_options, send_marker=S2N.get_send_marker())
-    client = managed_process(provider, client_options, close_marker=str(CLOSE_MARKER_BYTES))
+    s2n_server = managed_process(
+        S2N, server_options, send_marker=S2N.get_send_marker())
+    client = managed_process(provider, client_options,
+                             close_marker=str(CLOSE_MARKER_BYTES))
 
     for results in client.get_results():
         results.assert_success()
@@ -61,8 +65,10 @@ def test_s2n_old_server_new_ticket(managed_process, tmp_path, cipher, curve, pro
     client_options.extra_flags = ['-sess_in', ticket_file]
     server_options.use_mainline_version = True
 
-    s2n_server = managed_process(S2N, server_options, send_marker=S2N.get_send_marker())
-    client = managed_process(provider, client_options, close_marker=str(CLOSE_MARKER_BYTES))
+    s2n_server = managed_process(
+        S2N, server_options, send_marker=S2N.get_send_marker())
+    client = managed_process(provider, client_options,
+                             close_marker=str(CLOSE_MARKER_BYTES))
 
     for results in client.get_results():
         results.assert_success()
@@ -76,12 +82,14 @@ def test_s2n_old_server_new_ticket(managed_process, tmp_path, cipher, curve, pro
 A new S2N server can resume a session with an old S2N server's session ticket. 
 Tests that S2N tickets are forwards-compatible.
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", RESUMPTION_PROTOCOLS, ids=get_parameter_name)
-@pytest.mark.parametrize("provider", [ OpenSSL ], ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_new_server_old_ticket(managed_process, tmp_path, cipher, curve, protocol, provider, certificate):
     ticket_file = str(tmp_path / TICKET_FILE)
     assert not os.path.exists(ticket_file)
@@ -106,8 +114,10 @@ def test_s2n_new_server_old_ticket(managed_process, tmp_path, cipher, curve, pro
     server_options.cert = certificate.cert
     server_options.data_to_send = CLOSE_MARKER_BYTES
 
-    s2n_server = managed_process(S2N, server_options, send_marker=S2N.get_send_marker())
-    client = managed_process(provider, client_options, close_marker=str(CLOSE_MARKER_BYTES))
+    s2n_server = managed_process(
+        S2N, server_options, send_marker=S2N.get_send_marker())
+    client = managed_process(provider, client_options,
+                             close_marker=str(CLOSE_MARKER_BYTES))
 
     for results in client.get_results():
         results.assert_success()
@@ -119,8 +129,10 @@ def test_s2n_new_server_old_ticket(managed_process, tmp_path, cipher, curve, pro
     client_options.extra_flags = ['-sess_in', ticket_file]
     server_options.use_mainline_version = False
 
-    s2n_server = managed_process(S2N, server_options, send_marker=S2N.get_send_marker())
-    client = managed_process(provider, client_options, close_marker=str(CLOSE_MARKER_BYTES))
+    s2n_server = managed_process(
+        S2N, server_options, send_marker=S2N.get_send_marker())
+    client = managed_process(provider, client_options,
+                             close_marker=str(CLOSE_MARKER_BYTES))
 
     for results in client.get_results():
         results.assert_success()
@@ -135,12 +147,14 @@ An old S2N client can resume a session with an new S2N client's session ticket.
 Tests that S2N tickets are backwards-compatible. In our client tests we use an S2N
 server because the Openssl server uses a different ticket key for each session.
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", RESUMPTION_PROTOCOLS, ids=get_parameter_name)
-@pytest.mark.parametrize("provider", [ S2N ], ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [S2N], ids=get_parameter_name)
 def test_s2n_old_client_new_ticket(managed_process, tmp_path, cipher, curve, protocol, provider, certificate):
     ticket_file = str(tmp_path / TICKET_FILE)
     assert not os.path.exists(ticket_file)
@@ -192,12 +206,14 @@ def test_s2n_old_client_new_ticket(managed_process, tmp_path, cipher, curve, pro
 A new S2N client can resume a session with an old S2N client's session ticket. 
 Tests that S2N tickets are forwards-compatible.
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", RESUMPTION_PROTOCOLS, ids=get_parameter_name)
-@pytest.mark.parametrize("provider", [ S2N ], ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [S2N], ids=get_parameter_name)
 def test_s2n_new_client_old_ticket(managed_process, tmp_path, cipher, curve, protocol, provider, certificate):
     ticket_file = str(tmp_path / TICKET_FILE)
     assert not os.path.exists(ticket_file)

--- a/tests/integrationv2/test_dynamic_record_sizes.py
+++ b/tests/integrationv2/test_dynamic_record_sizes.py
@@ -73,7 +73,8 @@ def test_s2n_client_dynamic_record(custom_mtu, managed_process, cipher, curve, p
 
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
+        assert to_bytes("Actual protocol version: {}".format(
+            expected_version)) in results.stdout
 
     for results in server.get_results():
         results.assert_success()

--- a/tests/integrationv2/test_early_data.py
+++ b/tests/integrationv2/test_early_data.py
@@ -16,22 +16,27 @@ from test_hello_retry_requests import S2N_HRR_MARKER
 TICKET_FILE = 'ticket'
 EARLY_DATA_FILE = 'early_data'
 
-MAX_EARLY_DATA = 500 # Arbitrary largish number
-DATA_TO_SEND = data_bytes(500) # Arbitrary large number
+MAX_EARLY_DATA = 500  # Arbitrary largish number
+DATA_TO_SEND = data_bytes(500)  # Arbitrary large number
 
-NUM_RESUMES = 5 # Hardcoded for s2nc --reconnect
-NUM_CONNECTIONS = NUM_RESUMES + 1 # resumes + initial
+NUM_RESUMES = 5  # Hardcoded for s2nc --reconnect
+NUM_CONNECTIONS = NUM_RESUMES + 1  # resumes + initial
 
 S2N_DEFAULT_CURVE = Curves.X25519
-S2N_UNSUPPORTED_CURVE = 'X448' # We have no plans to support this curve any time soon
-S2N_HRR_CURVES = list(curve for curve in ALL_TEST_CURVES if curve != S2N_DEFAULT_CURVE)
+# We have no plans to support this curve any time soon
+S2N_UNSUPPORTED_CURVE = 'X448'
+S2N_HRR_CURVES = list(
+    curve for curve in ALL_TEST_CURVES if curve != S2N_DEFAULT_CURVE)
 
 S2N_EARLY_DATA_MARKER = to_bytes("WITH_EARLY_DATA")
 S2N_EARLY_DATA_RECV_MARKER = "Early Data received: "
 S2N_EARLY_DATA_STATUS_MARKER = "Early Data status: {status}"
-S2N_EARLY_DATA_ACCEPTED_MARKER = S2N_EARLY_DATA_STATUS_MARKER.format(status="ACCEPTED")
-S2N_EARLY_DATA_REJECTED_MARKER = S2N_EARLY_DATA_STATUS_MARKER.format(status="REJECTED")
-S2N_EARLY_DATA_NOT_REQUESTED_MARKER = S2N_EARLY_DATA_STATUS_MARKER.format(status="NOT REQUESTED")
+S2N_EARLY_DATA_ACCEPTED_MARKER = S2N_EARLY_DATA_STATUS_MARKER.format(
+    status="ACCEPTED")
+S2N_EARLY_DATA_REJECTED_MARKER = S2N_EARLY_DATA_STATUS_MARKER.format(
+    status="REJECTED")
+S2N_EARLY_DATA_NOT_REQUESTED_MARKER = S2N_EARLY_DATA_STATUS_MARKER.format(
+    status="NOT REQUESTED")
 
 
 class S2N(S2NBase):
@@ -79,8 +84,8 @@ class OpenSSL(OpenSSLBase):
 # The `-sess_in`/`-sess_out` options can be used instead, but don't have an s2nc equivalent.
 # As we add more providers, we may need both a `-reconnect`-like and a `-sess_in/out`-like S2N server test,
 # but for now we can just use `-sess_in/out` and cover the S2N->S2N case in the S2N client tests.
-CLIENT_PROVIDERS = [ OpenSSL ]
-SERVER_PROVIDERS = [ OpenSSL, S2N ]
+CLIENT_PROVIDERS = [OpenSSL]
+SERVER_PROVIDERS = [OpenSSL, S2N]
 
 
 def get_early_data_bytes(file_path, early_data_size):
@@ -113,8 +118,10 @@ def get_ticket_from_s2n_server(options, managed_process, provider, certificate):
 
     assert not os.path.exists(options.ticket_file)
 
-    s2n_server = managed_process(S2N, server_options, send_marker=S2N.get_send_marker())
-    client = managed_process(provider, client_options, close_marker=str(close_marker_bytes))
+    s2n_server = managed_process(
+        S2N, server_options, send_marker=S2N.get_send_marker())
+    client = managed_process(provider, client_options,
+                             close_marker=str(close_marker_bytes))
 
     for results in s2n_server.get_results():
         results.assert_success()
@@ -131,6 +138,8 @@ Basic S2N server happy case.
 We make one full connection to get a session ticket with early data enabled,
 then another resumption connection with early data.
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -173,7 +182,8 @@ def test_s2n_server_with_early_data(managed_process, tmp_path, cipher, curve, pr
     for results in s2n_server.get_results():
         results.assert_success()
         assert S2N_EARLY_DATA_MARKER in results.stdout
-        assert (to_bytes(S2N_EARLY_DATA_RECV_MARKER) + early_data) in results.stdout
+        assert (to_bytes(S2N_EARLY_DATA_RECV_MARKER) +
+                early_data) in results.stdout
         assert to_bytes(S2N_EARLY_DATA_ACCEPTED_MARKER) in results.stdout
         assert DATA_TO_SEND in results.stdout
 
@@ -184,6 +194,8 @@ Basic S2N client happy case.
 The S2N client tests session resumption by repeatedly reconnecting.
 That means we don't need to manually perform the initial full connection, and there is no external ticket file.
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
@@ -211,8 +223,8 @@ def test_s2n_client_with_early_data(managed_process, tmp_path, cipher, protocol,
 
     server_options = copy.copy(options)
     server_options.mode = Provider.ServerMode
-    server_options.key = certificate.key # Required for the initial connection
-    server_options.cert = certificate.cert # Required for the initial connection
+    server_options.key = certificate.key  # Required for the initial connection
+    server_options.cert = certificate.cert  # Required for the initial connection
     server_options.reconnects_before_exit = NUM_CONNECTIONS
 
     server = managed_process(provider, server_options)
@@ -221,7 +233,8 @@ def test_s2n_client_with_early_data(managed_process, tmp_path, cipher, protocol,
     for results in s2n_client.get_results():
         results.assert_success()
         assert S2N_EARLY_DATA_MARKER in results.stdout
-        assert results.stdout.count(to_bytes(S2N_EARLY_DATA_ACCEPTED_MARKER)) == NUM_RESUMES
+        assert results.stdout.count(
+            to_bytes(S2N_EARLY_DATA_ACCEPTED_MARKER)) == NUM_RESUMES
 
     for results in server.get_results():
         results.assert_success()
@@ -234,6 +247,8 @@ Verify that the S2N client doesn't request early data when a server doesn't supp
 We repeatedly reconnect with max_early_data set to 0. This is basically a test from
 test_session_resumption but with validation that no early data is sent.
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
@@ -260,8 +275,8 @@ def test_s2n_client_without_early_data(managed_process, tmp_path, cipher, protoc
 
     server_options = copy.copy(options)
     server_options.mode = Provider.ServerMode
-    server_options.key = certificate.key # Required for the initial connection
-    server_options.cert = certificate.cert # Required for the initial connection
+    server_options.key = certificate.key  # Required for the initial connection
+    server_options.cert = certificate.cert  # Required for the initial connection
     server_options.reconnects_before_exit = NUM_CONNECTIONS
 
     server = managed_process(provider, server_options)
@@ -274,7 +289,8 @@ def test_s2n_client_without_early_data(managed_process, tmp_path, cipher, protoc
     for results in s2n_client.get_results():
         results.assert_success()
         assert S2N_EARLY_DATA_MARKER not in results.stdout
-        assert results.stdout.count(to_bytes(S2N_EARLY_DATA_NOT_REQUESTED_MARKER)) == NUM_CONNECTIONS
+        assert results.stdout.count(
+            to_bytes(S2N_EARLY_DATA_NOT_REQUESTED_MARKER)) == NUM_CONNECTIONS
 
 
 """
@@ -286,6 +302,8 @@ When the client attempts to use the ticket to send early data, the server reject
 We can't perform an S2N client version of this test because the S2N client performs its hardcoded
 reconnects automatically, without any mechanism to modify the connection in between.
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -341,6 +359,8 @@ Test the S2N client attempting to send early data, but the server triggering a h
 We trigger the HRR by configuring the server to only accept curves that the S2N client
 does not send key shares for.
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", S2N_HRR_CURVES, ids=get_parameter_name)
@@ -350,7 +370,8 @@ does not send key shares for.
 @pytest.mark.parametrize("early_data_size", [int(MAX_EARLY_DATA/2), int(MAX_EARLY_DATA-1), MAX_EARLY_DATA, 1])
 def test_s2n_client_with_early_data_rejected_via_hrr(managed_process, tmp_path, cipher, curve, protocol, provider, certificate, early_data_size):
     if provider == S2N:
-        pytest.skip("S2N does not respect ProviderOptions.curve, so does not trigger a retry")
+        pytest.skip(
+            "S2N does not respect ProviderOptions.curve, so does not trigger a retry")
 
     early_data_file = str(tmp_path / EARLY_DATA_FILE)
     early_data = get_early_data_bytes(early_data_file, early_data_size)
@@ -373,8 +394,8 @@ def test_s2n_client_with_early_data_rejected_via_hrr(managed_process, tmp_path, 
 
     server_options = copy.copy(options)
     server_options.mode = Provider.ServerMode
-    server_options.key = certificate.key # Required for the initial connection
-    server_options.cert = certificate.cert # Required for the initial connection
+    server_options.key = certificate.key  # Required for the initial connection
+    server_options.cert = certificate.cert  # Required for the initial connection
     server_options.reconnects_before_exit = NUM_CONNECTIONS
 
     server = managed_process(provider, server_options)
@@ -384,7 +405,8 @@ def test_s2n_client_with_early_data_rejected_via_hrr(managed_process, tmp_path, 
         results.assert_success()
         assert S2N_EARLY_DATA_MARKER not in results.stdout
         assert S2N_HRR_MARKER in results.stdout
-        assert results.stdout.count(to_bytes(S2N_EARLY_DATA_REJECTED_MARKER)) == NUM_RESUMES
+        assert results.stdout.count(
+            to_bytes(S2N_EARLY_DATA_REJECTED_MARKER)) == NUM_RESUMES
 
     for results in server.get_results():
         results.assert_success()
@@ -397,6 +419,8 @@ Test the S2N server rejecting early data because of a hello retry request.
 In order to trigger a successful retry, we need to force the peer to offer us a key share that
 S2N doesn't support while still supporting at least one curve S2N does support.
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -449,6 +473,8 @@ def test_s2n_server_with_early_data_rejected_via_hrr(managed_process, tmp_path, 
 """
 Test the S2N server fails if it receives too much early data.
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -459,7 +485,8 @@ Test the S2N server fails if it receives too much early data.
 def test_s2n_server_with_early_data_max_exceeded(managed_process, tmp_path, cipher, curve, protocol, provider, certificate, excess_early_data):
     ticket_file = str(tmp_path / TICKET_FILE)
     early_data_file = str(tmp_path / EARLY_DATA_FILE)
-    early_data = get_early_data_bytes(early_data_file, MAX_EARLY_DATA + excess_early_data)
+    early_data = get_early_data_bytes(
+        early_data_file, MAX_EARLY_DATA + excess_early_data)
 
     options = ProviderOptions(
         port=next(available_ports),
@@ -502,6 +529,6 @@ def test_s2n_server_with_early_data_max_exceeded(managed_process, tmp_path, ciph
         # Full early data should not be reported
         assert early_data not in results.stdout
         # Partial early data should be reported
-        assert (to_bytes(S2N_EARLY_DATA_RECV_MARKER) + early_data[:MAX_EARLY_DATA]) in results.stdout
+        assert (to_bytes(S2N_EARLY_DATA_RECV_MARKER) +
+                early_data[:MAX_EARLY_DATA]) in results.stdout
         assert to_bytes("Bad message encountered") in results.stderr
-

--- a/tests/integrationv2/test_external_psk.py
+++ b/tests/integrationv2/test_external_psk.py
@@ -18,15 +18,15 @@ known_psk_identity = '2c035d829359ee5ff7af4ec900000000262a6494dc486d2c8a34cb33fa
 known_psk_secret = '4ecd0eb6ec3b4d87f5d6028f922ca4c5851a277fd41311c9e62d2c9492e1c4f3'
 
 # Arbitrary test vectors
-PSK_IDENTITY_LIST = [ known_psk_identity, 'psk_identity', 'test_psk_identity' ]
-PSK_SECRET_LIST = [ known_psk_secret, 'a6dadae4567876', 'a64dafcd0fc67d2a' ]
+PSK_IDENTITY_LIST = [known_psk_identity, 'psk_identity', 'test_psk_identity']
+PSK_SECRET_LIST = [known_psk_secret, 'a6dadae4567876', 'a64dafcd0fc67d2a']
 PSK_IDENTITY_NO_MATCH = "PSK_IDENTITY_NO_MATCH"
 PSK_SECRET_NO_MATCH = "e9492e1c"
 PSK_IDENTITY_NO_MATCH_2 = "PSK_IDENTITY_NO_MATCH_2"
 PSK_SECRET_NO_MATCH_2 = "c1e29493fd"
 
-ALL_TEST_CERTS_WITH_EMPTY_CERT = ALL_TEST_CERTS + [ None ]
-PSK_PROVIDERS = [ OpenSSL, S2N ] 
+ALL_TEST_CERTS_WITH_EMPTY_CERT = ALL_TEST_CERTS + [None]
+PSK_PROVIDERS = [OpenSSL, S2N]
 
 
 class Outcome(Enum):
@@ -36,11 +36,11 @@ class Outcome(Enum):
 
 
 def setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg):
-    return [ '--psk', psk_identity + ',' + psk_secret + ',' + psk_hash_alg ]
+    return ['--psk', psk_identity + ',' + psk_secret + ',' + psk_hash_alg]
 
 
 def setup_openssl_psk_params(psk_identity, psk_secret):
-    return [ '-psk_identity', psk_identity, '--psk', psk_secret ]
+    return ['-psk_identity', psk_identity, '--psk', psk_secret]
 
 
 def setup_provider_options(mode, port, cipher, curve, certificate, data_to_send, client_psk_params):
@@ -65,18 +65,18 @@ def get_psk_hash_alg_from_cipher(cipher):
     # S2N supports only SHA256 and SHA384 PSK Hash Algorithms
     if 'SHA256' in cipher.name:
         return 'SHA256'
-    elif 'SHA384' in cipher.name: 
+    elif 'SHA384' in cipher.name:
         return 'SHA384'
     else:
         return None
 
-   
+
 def skip_invalid_psk_tests(provider, psk_hash_alg):
-    # If the PSK hash algorithm is None, it is not supported and we can safely skip the test case. 
+    # If the PSK hash algorithm is None, it is not supported and we can safely skip the test case.
     if psk_hash_alg is None:
         pytest.skip()
 
-    # In OpenSSL, PSK works only with TLS1.3 ciphersuites based on SHA256 hash algorithm which includes 
+    # In OpenSSL, PSK works only with TLS1.3 ciphersuites based on SHA256 hash algorithm which includes
     # all TLS1.3 ciphersuites supported by S2N except TLS_AES_256_GCM_SHA384.
     if provider == OpenSSL and psk_hash_alg == 'SHA384':
         pytest.skip()
@@ -84,19 +84,23 @@ def skip_invalid_psk_tests(provider, psk_hash_alg):
 
 def validate_negotiated_psk_s2n(outcome, psk_identity, results):
     if outcome == Outcome.psk_connection:
-        assert to_bytes("Negotiated PSK identity: {}".format(psk_identity)) in results.stdout
+        assert to_bytes("Negotiated PSK identity: {}".format(
+            psk_identity)) in results.stdout
     elif outcome == Outcome.full_handshake:
-        assert to_bytes("Negotiated PSK identity: {}".format(psk_identity)) not in results.stdout
+        assert to_bytes("Negotiated PSK identity: {}".format(
+            psk_identity)) not in results.stdout
     else:
         assert results.exit_code != 0
-        assert to_bytes("Failed to negotiate: 'TLS alert received'") in results.stderr
+        assert to_bytes(
+            "Failed to negotiate: 'TLS alert received'") in results.stderr
 
 
 def validate_negotiated_psk_openssl(outcome, results):
     if outcome == Outcome.psk_connection:
         assert to_bytes("extension \"psk\"") in results.stdout
     elif outcome == Outcome.full_handshake:
-        assert to_bytes("SSL_connect:SSLv3/TLS read server certificate") in results.stderr
+        assert to_bytes(
+            "SSL_connect:SSLv3/TLS read server certificate") in results.stderr
     else:
         assert to_bytes("SSL_accept:error in error") in results.stderr
 
@@ -106,6 +110,8 @@ Basic S2N server happy case.
 
 Tests a single psk connection with no fallback option.
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -120,27 +126,34 @@ def test_s2n_server_psk_connection(managed_process, cipher, curve, protocol, pro
     skip_invalid_psk_tests(provider, psk_hash_alg)
 
     if provider == S2N:
-        client_psk_params = setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
+        client_psk_params = setup_s2n_psk_params(
+            psk_identity, psk_secret, psk_hash_alg)
     else:
         client_psk_params = setup_openssl_psk_params(psk_identity, psk_secret)
-    client_options = setup_provider_options(provider.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params)
+    client_options = setup_provider_options(
+        provider.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params)
 
-    server_psk_params = setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
-    server_options = setup_provider_options(S2N.ServerMode, port, cipher, curve, None, None, server_psk_params)
+    server_psk_params = setup_s2n_psk_params(
+        psk_identity, psk_secret, psk_hash_alg)
+    server_options = setup_provider_options(
+        S2N.ServerMode, port, cipher, curve, None, None, server_psk_params)
 
-    server = managed_process(S2N, server_options, timeout=5, close_marker=str(random_bytes))
+    server = managed_process(
+        S2N, server_options, timeout=5, close_marker=str(random_bytes))
     client = managed_process(provider, client_options, timeout=5)
 
     for results in client.get_results():
         results.assert_success()
         if provider == S2N:
-            validate_negotiated_psk_s2n(Outcome.psk_connection, psk_identity, results)
+            validate_negotiated_psk_s2n(
+                Outcome.psk_connection, psk_identity, results)
         else:
             validate_negotiated_psk_openssl(Outcome.psk_connection, results)
 
     for results in server.get_results():
         results.assert_success()
-        validate_negotiated_psk_s2n(Outcome.psk_connection, psk_identity, results)
+        validate_negotiated_psk_s2n(
+            Outcome.psk_connection, psk_identity, results)
         assert random_bytes in results.stdout
 
 
@@ -149,6 +162,8 @@ Tests S2N server's behavior with multiple PSKs and no fallback options.
 
 Note that OpenSSL does not support multiple PSKs. 
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -168,30 +183,41 @@ def test_s2n_server_multiple_psks(managed_process, cipher, curve, protocol, prov
         OpenSSL Provider does not support multiple PSKs in the same connection, 
         the last psk parameter is the psk parameter used in the connection. 
         """
-        client_psk_params.extend(setup_openssl_psk_params(PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH))
-        client_psk_params.extend(setup_openssl_psk_params(psk_identity, psk_secret))
+        client_psk_params.extend(setup_openssl_psk_params(
+            PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH))
+        client_psk_params.extend(
+            setup_openssl_psk_params(psk_identity, psk_secret))
     else:
-        client_psk_params.extend(setup_s2n_psk_params(PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH, psk_hash_alg))
-        client_psk_params.extend(setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg))
-    client_options = setup_provider_options(provider.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params)
+        client_psk_params.extend(setup_s2n_psk_params(
+            PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH, psk_hash_alg))
+        client_psk_params.extend(setup_s2n_psk_params(
+            psk_identity, psk_secret, psk_hash_alg))
+    client_options = setup_provider_options(
+        provider.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params)
 
-    server_psk_params = setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
-    server_psk_params.extend(setup_s2n_psk_params(PSK_IDENTITY_NO_MATCH_2, PSK_SECRET_NO_MATCH_2, psk_hash_alg))
-    server_options = setup_provider_options(S2N.ServerMode, port, cipher, curve, None, None, server_psk_params)
+    server_psk_params = setup_s2n_psk_params(
+        psk_identity, psk_secret, psk_hash_alg)
+    server_psk_params.extend(setup_s2n_psk_params(
+        PSK_IDENTITY_NO_MATCH_2, PSK_SECRET_NO_MATCH_2, psk_hash_alg))
+    server_options = setup_provider_options(
+        S2N.ServerMode, port, cipher, curve, None, None, server_psk_params)
 
-    server = managed_process(S2N, server_options, timeout=5, close_marker=str(random_bytes))
+    server = managed_process(
+        S2N, server_options, timeout=5, close_marker=str(random_bytes))
     client = managed_process(provider, client_options, timeout=5)
 
     for results in client.get_results():
         results.assert_success()
         if provider == S2N:
-            validate_negotiated_psk_s2n(Outcome.psk_connection, psk_identity, results)
+            validate_negotiated_psk_s2n(
+                Outcome.psk_connection, psk_identity, results)
         else:
             validate_negotiated_psk_openssl(Outcome.psk_connection, results)
 
     for results in server.get_results():
         results.assert_success()
-        validate_negotiated_psk_s2n(Outcome.psk_connection, psk_identity, results)
+        validate_negotiated_psk_s2n(
+            Outcome.psk_connection, psk_identity, results)
         assert random_bytes in results.stdout
 
 
@@ -204,6 +230,8 @@ Note that S2N Server succeeds with a full handshake when an invalid PSK paramete
 certificate is provided as the input, as S2N Server uses a default certificate if a certificate is not provided 
 as the input.
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -219,27 +247,34 @@ def test_s2n_server_full_handshake(managed_process, cipher, curve, protocol, pro
     skip_invalid_psk_tests(provider, psk_hash_alg)
 
     if provider == S2N:
-        client_psk_params = setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
+        client_psk_params = setup_s2n_psk_params(
+            psk_identity, psk_secret, psk_hash_alg)
     else:
         client_psk_params = setup_openssl_psk_params(psk_identity, psk_secret)
-    client_options = setup_provider_options(provider.ClientMode, port, cipher, curve, certificate, random_bytes, client_psk_params)
+    client_options = setup_provider_options(
+        provider.ClientMode, port, cipher, curve, certificate, random_bytes, client_psk_params)
 
-    server_psk_params = setup_s2n_psk_params(PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH, psk_hash_alg)
-    server_options = setup_provider_options(S2N.ServerMode, port, cipher, curve, certificate, None, server_psk_params)
+    server_psk_params = setup_s2n_psk_params(
+        PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH, psk_hash_alg)
+    server_options = setup_provider_options(
+        S2N.ServerMode, port, cipher, curve, certificate, None, server_psk_params)
 
-    server = managed_process(S2N, server_options, timeout=5, close_marker=str(random_bytes))
+    server = managed_process(
+        S2N, server_options, timeout=5, close_marker=str(random_bytes))
     client = managed_process(provider, client_options, timeout=5)
 
     for results in client.get_results():
         results.assert_success()
         if provider == S2N:
-            validate_negotiated_psk_s2n(Outcome.full_handshake, psk_identity, results)
+            validate_negotiated_psk_s2n(
+                Outcome.full_handshake, psk_identity, results)
         else:
             validate_negotiated_psk_openssl(Outcome.full_handshake, results)
 
     for results in server.get_results():
         results.assert_success()
-        validate_negotiated_psk_s2n(Outcome.full_handshake, PSK_IDENTITY_NO_MATCH, results)
+        validate_negotiated_psk_s2n(
+            Outcome.full_handshake, PSK_IDENTITY_NO_MATCH, results)
         assert random_bytes in results.stdout
 
 
@@ -248,6 +283,8 @@ Basic S2N client happy case.
 
 Tests a single psk connection with no fallback option.
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -261,27 +298,34 @@ def test_s2n_client_psk_connection(managed_process, cipher, curve, protocol, pro
     psk_hash_alg = get_psk_hash_alg_from_cipher(cipher)
     skip_invalid_psk_tests(provider, psk_hash_alg)
 
-    client_psk_params = setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
-    client_options = setup_provider_options(S2N.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params)
+    client_psk_params = setup_s2n_psk_params(
+        psk_identity, psk_secret, psk_hash_alg)
+    client_options = setup_provider_options(
+        S2N.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params)
 
     if provider == S2N:
-        server_psk_params = setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
+        server_psk_params = setup_s2n_psk_params(
+            psk_identity, psk_secret, psk_hash_alg)
     else:
         server_psk_params = setup_openssl_psk_params(psk_identity, psk_secret)
-        server_psk_params += [ '-nocert' ]
-    server_options = setup_provider_options(provider.ServerMode, port, cipher, curve, None, None, server_psk_params)
+        server_psk_params += ['-nocert']
+    server_options = setup_provider_options(
+        provider.ServerMode, port, cipher, curve, None, None, server_psk_params)
 
-    server = managed_process(provider, server_options, timeout=5, close_marker=str(random_bytes))
+    server = managed_process(provider, server_options,
+                             timeout=5, close_marker=str(random_bytes))
     client = managed_process(S2N, client_options, timeout=5)
 
     for results in client.get_results():
         results.assert_success()
-        validate_negotiated_psk_s2n(Outcome.psk_connection, psk_identity, results)
+        validate_negotiated_psk_s2n(
+            Outcome.psk_connection, psk_identity, results)
 
     for results in server.get_results():
         results.assert_success()
         if provider == S2N:
-            validate_negotiated_psk_s2n(Outcome.psk_connection, psk_identity, results)
+            validate_negotiated_psk_s2n(
+                Outcome.psk_connection, psk_identity, results)
         else:
             validate_negotiated_psk_openssl(Outcome.psk_connection, results)
         assert random_bytes in results.stdout
@@ -292,6 +336,8 @@ Tests S2N client's behavior with multiple PSKs and no fallback option.
 
 Note that OpenSSL does not support multiple PSKs. 
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -305,9 +351,12 @@ def test_s2n_client_multiple_psks(managed_process, cipher, curve, protocol, prov
     psk_hash_alg = get_psk_hash_alg_from_cipher(cipher)
     skip_invalid_psk_tests(provider, psk_hash_alg)
 
-    client_psk_params = setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
-    client_psk_params.extend(setup_s2n_psk_params(PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH, psk_hash_alg))
-    client_options = setup_provider_options(S2N.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params)
+    client_psk_params = setup_s2n_psk_params(
+        psk_identity, psk_secret, psk_hash_alg)
+    client_psk_params.extend(setup_s2n_psk_params(
+        PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH, psk_hash_alg))
+    client_options = setup_provider_options(
+        S2N.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params)
 
     server_psk_params = []
     if provider == OpenSSL:
@@ -315,25 +364,33 @@ def test_s2n_client_multiple_psks(managed_process, cipher, curve, protocol, prov
         OpenSSL Provider does not support multiple PSKs in the same connection, 
         the last psk params is the final psk used in the connection. 
         """
-        server_psk_params.extend(setup_openssl_psk_params(PSK_IDENTITY_NO_MATCH_2, PSK_SECRET_NO_MATCH_2))
-        server_psk_params.extend(setup_openssl_psk_params(psk_identity, psk_secret))
-        server_psk_params += [ '-nocert' ]
+        server_psk_params.extend(setup_openssl_psk_params(
+            PSK_IDENTITY_NO_MATCH_2, PSK_SECRET_NO_MATCH_2))
+        server_psk_params.extend(
+            setup_openssl_psk_params(psk_identity, psk_secret))
+        server_psk_params += ['-nocert']
     else:
-        server_psk_params.extend(setup_s2n_psk_params(PSK_IDENTITY_NO_MATCH_2, PSK_SECRET_NO_MATCH_2, psk_hash_alg))
-        server_psk_params.extend(setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg))
-    server_options = setup_provider_options(provider.ServerMode, port, cipher, curve, None, None, server_psk_params)
+        server_psk_params.extend(setup_s2n_psk_params(
+            PSK_IDENTITY_NO_MATCH_2, PSK_SECRET_NO_MATCH_2, psk_hash_alg))
+        server_psk_params.extend(setup_s2n_psk_params(
+            psk_identity, psk_secret, psk_hash_alg))
+    server_options = setup_provider_options(
+        provider.ServerMode, port, cipher, curve, None, None, server_psk_params)
 
-    server = managed_process(provider, server_options, timeout=5, close_marker=str(random_bytes))
+    server = managed_process(provider, server_options,
+                             timeout=5, close_marker=str(random_bytes))
     client = managed_process(S2N, client_options, timeout=5)
 
     for results in client.get_results():
         results.assert_success()
-        validate_negotiated_psk_s2n(Outcome.psk_connection, psk_identity, results)
+        validate_negotiated_psk_s2n(
+            Outcome.psk_connection, psk_identity, results)
 
     for results in server.get_results():
         results.assert_success()
         if provider == S2N:
-            validate_negotiated_psk_s2n(Outcome.psk_connection, psk_identity, results)
+            validate_negotiated_psk_s2n(
+                Outcome.psk_connection, psk_identity, results)
         else:
             validate_negotiated_psk_openssl(Outcome.psk_connection, results)
         assert random_bytes in results.stdout
@@ -346,6 +403,8 @@ and an invalid certificate is provided as the input.
 Note that we cannot use S2N Server as a provider input for this test as S2N Server 
 uses a default certificate if a certificate is not provided as the input.
 """
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -359,22 +418,28 @@ def test_s2n_client_psk_handshake_failure(managed_process, cipher, curve, protoc
     psk_hash_alg = get_psk_hash_alg_from_cipher(cipher)
     skip_invalid_psk_tests(provider, psk_hash_alg)
 
-    client_psk_params = setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
-    client_options = setup_provider_options(S2N.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params)
+    client_psk_params = setup_s2n_psk_params(
+        psk_identity, psk_secret, psk_hash_alg)
+    client_options = setup_provider_options(
+        S2N.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params)
 
-    server_psk_params = setup_openssl_psk_params(PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH)
-    server_psk_params += [ '-nocert' ]
-    server_options = setup_provider_options(provider.ServerMode, port, cipher, curve, None, None, server_psk_params)
+    server_psk_params = setup_openssl_psk_params(
+        PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH)
+    server_psk_params += ['-nocert']
+    server_options = setup_provider_options(
+        provider.ServerMode, port, cipher, curve, None, None, server_psk_params)
 
-    server = managed_process(provider, server_options, timeout=5, close_marker=str(random_bytes))
+    server = managed_process(provider, server_options,
+                             timeout=5, close_marker=str(random_bytes))
     client = managed_process(S2N, client_options, timeout=5)
 
     for results in client.get_results():
-        assert to_bytes("Failed to negotiate: 'TLS alert received'") in results.stderr
-        validate_negotiated_psk_s2n(Outcome.handshake_failed, psk_identity, results)
+        assert to_bytes(
+            "Failed to negotiate: 'TLS alert received'") in results.stderr
+        validate_negotiated_psk_s2n(
+            Outcome.handshake_failed, psk_identity, results)
 
     for results in server.get_results():
         assert to_bytes("SSL_accept:error in error") in results.stderr
         validate_negotiated_psk_openssl(Outcome.handshake_failed, results)
         assert random_bytes not in results.stdout
-

--- a/tests/integrationv2/test_fragmentation.py
+++ b/tests/integrationv2/test_fragmentation.py
@@ -27,7 +27,8 @@ CERTIFICATES_TO_TEST = [
 @pytest.mark.parametrize("certificate", CERTIFICATES_TO_TEST, ids=get_parameter_name)
 def test_s2n_server_low_latency(managed_process, cipher, provider, protocol, certificate):
     if provider is OpenSSL and 'openssl-1.0.2' in provider.get_version():
-        pytest.skip('{} does not allow setting max fragmentation for packets'.format(provider))
+        pytest.skip(
+            '{} does not allow setting max fragmentation for packets'.format(provider))
 
     port = next(available_ports)
 
@@ -58,7 +59,8 @@ def test_s2n_server_low_latency(managed_process, cipher, provider, protocol, cer
 
     for results in server.get_results():
         results.assert_success()
-        assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
+        assert to_bytes("Actual protocol version: {}".format(
+            expected_version)) in results.stdout
         assert random_bytes in results.stdout
 
 
@@ -82,7 +84,8 @@ def invalid_test_parameters_frag_len(*args, **kwargs):
 @pytest.mark.parametrize("frag_len", [512, 2048, 8192, 12345, 16384], ids=get_parameter_name)
 def test_s2n_server_fragmented_data(managed_process, cipher, provider, protocol, frag_len, certificate):
     if provider is OpenSSL and 'openssl-1.0.2' in provider.get_version():
-        pytest.skip('{} does not allow setting max fragmentation for packets'.format(provider))
+        pytest.skip(
+            '{} does not allow setting max fragmentation for packets'.format(provider))
 
     port = next(available_ports)
 
@@ -115,7 +118,8 @@ def test_s2n_server_fragmented_data(managed_process, cipher, provider, protocol,
 
     for server_results in server.get_results():
         server_results.assert_success()
-        assert to_bytes("Actual protocol version: {}".format(expected_version)) in server_results.stdout
+        assert to_bytes("Actual protocol version: {}".format(
+            expected_version)) in server_results.stdout
 
         if provider == GnuTLS:
             # GnuTLS ignores data sent through stdin past frag_len up to the application data

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -57,11 +57,13 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
     # the stdout reliably.
     for server_results in server.get_results():
         server_results.assert_success()
-        assert to_bytes("Actual protocol version: {}".format(expected_version)) in server_results.stdout
+        assert to_bytes("Actual protocol version: {}".format(
+            expected_version)) in server_results.stdout
         assert random_bytes in server_results.stdout
 
         if provider is not S2N:
-            assert to_bytes("Cipher negotiated: {}".format(cipher.name)) in server_results.stdout
+            assert to_bytes("Cipher negotiated: {}".format(
+                cipher.name)) in server_results.stdout
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -102,7 +104,8 @@ def test_s2n_client_happy_path(managed_process, cipher, provider, curve, protoco
 
     # Passing the type of client and server as a parameter will
     # allow us to use a fixture to enumerate all possibilities.
-    server = managed_process(provider, server_options, timeout=5, kill_marker=kill_marker)
+    server = managed_process(provider, server_options,
+                             timeout=5, kill_marker=kill_marker)
     client = managed_process(S2N, client_options, timeout=5)
 
     expected_version = get_expected_s2n_version(protocol, provider)
@@ -111,7 +114,8 @@ def test_s2n_client_happy_path(managed_process, cipher, provider, curve, protoco
     # the stdout reliably.
     for client_results in client.get_results():
         client_results.assert_success()
-        assert to_bytes("Actual protocol version: {}".format(expected_version)) in client_results.stdout
+        assert to_bytes("Actual protocol version: {}".format(
+            expected_version)) in client_results.stdout
 
     # The server will be one of all supported providers. We
     # just want to make sure there was no exception and that
@@ -119,4 +123,5 @@ def test_s2n_client_happy_path(managed_process, cipher, provider, curve, protoco
     for server_results in server.get_results():
         server_results.assert_success()
         # Avoid debugging information that sometimes gets inserted after the first character.
-        assert any([random_bytes[1:] in stream for stream in server_results.output_streams()])
+        assert any(
+            [random_bytes[1:] in stream for stream in server_results.output_streams()])

--- a/tests/integrationv2/test_hello_retry_requests.py
+++ b/tests/integrationv2/test_hello_retry_requests.py
@@ -20,6 +20,7 @@ CURVE_NAMES = {
     "P-521": "secp521r1"
 }
 
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL])
@@ -29,7 +30,7 @@ CURVE_NAMES = {
 def test_hrr_with_s2n_as_client(managed_process, cipher, provider, curve, protocol, certificate):
     if curve == S2N_DEFAULT_CURVE:
         pytest.skip("No retry if server curve matches client curve")
-        
+
     port = next(available_ports)
 
     random_bytes = data_bytes(64)
@@ -57,7 +58,8 @@ def test_hrr_with_s2n_as_client(managed_process, cipher, provider, curve, protoc
     # The client should connect and return without error
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes("Curve: {}".format(CURVE_NAMES[curve.name])) in results.stdout
+        assert to_bytes("Curve: {}".format(
+            CURVE_NAMES[curve.name])) in results.stdout
         assert S2N_HRR_MARKER in results.stdout
 
     marker_part1 = b"cf 21 ad 74 e5"
@@ -67,7 +69,8 @@ def test_hrr_with_s2n_as_client(managed_process, cipher, provider, curve, protoc
         results.assert_success()
         assert marker_part1 in results.stdout and marker_part2 in results.stdout
         assert b'Supported Elliptic Groups: X25519:P-256:P-384' in results.stdout
-        assert to_bytes("Shared Elliptic groups: {}".format(server_options.curve)) in results.stdout
+        assert to_bytes("Shared Elliptic groups: {}".format(
+            server_options.curve)) in results.stdout
         assert random_bytes in results.stdout
 
 
@@ -88,7 +91,7 @@ def test_hrr_with_s2n_as_server(managed_process, cipher, provider, curve, protoc
         data_to_send=random_bytes,
         insecure=True,
         curve=curve,
-        extra_flags = ['-msg', '-curves', 'X448:'+str(curve)],
+        extra_flags=['-msg', '-curves', 'X448:'+str(curve)],
         protocol=protocol)
 
     server_options = copy.copy(client_options)
@@ -107,7 +110,8 @@ def test_hrr_with_s2n_as_server(managed_process, cipher, provider, curve, protoc
     for results in server.get_results():
         results.assert_success()
         assert random_bytes in results.stdout
-        assert to_bytes("Curve: {}".format(CURVE_NAMES[curve.name])) in results.stdout
+        assert to_bytes("Curve: {}".format(
+            CURVE_NAMES[curve.name])) in results.stdout
         assert random_bytes in results.stdout
         assert S2N_HRR_MARKER in results.stdout
 
@@ -128,8 +132,11 @@ def test_hrr_with_s2n_as_server(managed_process, cipher, provider, curve, protoc
     assert server_hello_count == 2
     assert finished_count == 2
 
-# Default Keyshare for TLS v1.3 is x25519 
-TEST_CURVES = ALL_TEST_CURVES[1:] 
+
+# Default Keyshare for TLS v1.3 is x25519
+TEST_CURVES = ALL_TEST_CURVES[1:]
+
+
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL])
@@ -164,7 +171,8 @@ def test_hrr_with_default_keyshare(managed_process, cipher, provider, curve, pro
     # The client should connect and return without error
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes("Curve: {}".format(CURVE_NAMES[curve.name])) in results.stdout
+        assert to_bytes("Curve: {}".format(
+            CURVE_NAMES[curve.name])) in results.stdout
         assert S2N_HRR_MARKER in results.stdout
 
     marker_part1 = b"cf 21 ad 74 e5"
@@ -174,6 +182,6 @@ def test_hrr_with_default_keyshare(managed_process, cipher, provider, curve, pro
         results.assert_success()
         assert marker_part1 in results.stdout and marker_part2 in results.stdout
         assert b'Supported Elliptic Groups: X25519:P-256:P-384' in results.stdout
-        assert to_bytes("Shared Elliptic groups: {}".format(server_options.curve)) in results.stdout
+        assert to_bytes("Shared Elliptic groups: {}".format(
+            server_options.curve)) in results.stdout
         assert random_bytes in results.stdout
-

--- a/tests/integrationv2/test_ocsp.py
+++ b/tests/integrationv2/test_ocsp.py
@@ -112,7 +112,8 @@ def test_s2n_server_ocsp_response(managed_process, cipher, provider, curve, prot
         kill_marker = b"Sent: "
 
     server = managed_process(S2N, server_options, timeout=2000)
-    client = managed_process(provider, client_options, timeout=2000, kill_marker=kill_marker)
+    client = managed_process(provider, client_options,
+                             timeout=2000, kill_marker=kill_marker)
 
     for client_results in client.get_results():
         client_results.assert_success()
@@ -127,4 +128,5 @@ def test_s2n_server_ocsp_response(managed_process, cipher, provider, curve, prot
     for server_results in server.get_results():
         server_results.assert_success()
         # Avoid debugging information that sometimes gets inserted after the first character.
-        assert any([random_bytes[1:] in stream for stream in server_results.output_streams()])
+        assert any(
+            [random_bytes[1:] in stream for stream in server_results.output_streams()])

--- a/tests/integrationv2/test_pq_handshake.py
+++ b/tests/integrationv2/test_pq_handshake.py
@@ -27,76 +27,106 @@ KEM_GROUPS = [
 EXPECTED_RESULTS = {
     # The tuple keys have the form (client_{cipher, kem_group}, server_{cipher, kem_group})
     (Ciphers.KMS_PQ_TLS_1_0_2019_06, Ciphers.KMS_PQ_TLS_1_0_2019_06):
-        {"cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "kem": "BIKE1r1-Level1", "kem_group": "NONE"},
+        {"cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
+            "kem": "BIKE1r1-Level1", "kem_group": "NONE"},
     (Ciphers.KMS_PQ_TLS_1_0_2019_06, Ciphers.KMS_PQ_TLS_1_0_2020_02):
-        {"cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "kem": "BIKE1r1-Level1", "kem_group": "NONE"},
+        {"cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
+            "kem": "BIKE1r1-Level1", "kem_group": "NONE"},
     (Ciphers.KMS_PQ_TLS_1_0_2019_06, Ciphers.KMS_PQ_TLS_1_0_2020_07):
-        {"cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "kem": "BIKE1r1-Level1", "kem_group": "NONE"},
+        {"cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
+            "kem": "BIKE1r1-Level1", "kem_group": "NONE"},
 
     (Ciphers.KMS_PQ_TLS_1_0_2020_02, Ciphers.KMS_PQ_TLS_1_0_2019_06):
-        {"cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "kem": "BIKE1r1-Level1", "kem_group": "NONE"},
+        {"cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
+            "kem": "BIKE1r1-Level1", "kem_group": "NONE"},
     (Ciphers.KMS_PQ_TLS_1_0_2020_02, Ciphers.KMS_PQ_TLS_1_0_2020_02):
-        {"cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "kem": "BIKE1r2-Level1", "kem_group": "NONE"},
+        {"cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
+            "kem": "BIKE1r2-Level1", "kem_group": "NONE"},
     (Ciphers.KMS_PQ_TLS_1_0_2020_02, Ciphers.KMS_PQ_TLS_1_0_2020_07):
-        {"cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "kem": "BIKE1r2-Level1", "kem_group": "NONE"},
+        {"cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
+            "kem": "BIKE1r2-Level1", "kem_group": "NONE"},
 
     (Ciphers.KMS_PQ_TLS_1_0_2020_07, Ciphers.KMS_PQ_TLS_1_0_2019_06):
-        {"cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "kem": "BIKE1r1-Level1", "kem_group": "NONE"},
+        {"cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
+            "kem": "BIKE1r1-Level1", "kem_group": "NONE"},
     (Ciphers.KMS_PQ_TLS_1_0_2020_07, Ciphers.KMS_PQ_TLS_1_0_2020_02):
-        {"cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384", "kem": "BIKE1r2-Level1", "kem_group": "NONE"},
+        {"cipher": "ECDHE-BIKE-RSA-AES256-GCM-SHA384",
+            "kem": "BIKE1r2-Level1", "kem_group": "NONE"},
     (Ciphers.KMS_PQ_TLS_1_0_2020_07, Ciphers.KMS_PQ_TLS_1_0_2020_07):
-        {"cipher": "ECDHE-KYBER-RSA-AES256-GCM-SHA384", "kem": "kyber512r2", "kem_group": "NONE"},
+        {"cipher": "ECDHE-KYBER-RSA-AES256-GCM-SHA384",
+            "kem": "kyber512r2", "kem_group": "NONE"},
 
     (Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11, Ciphers.KMS_PQ_TLS_1_0_2019_06):
-        {"cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "kem": "SIKEp503r1-KEM", "kem_group": "NONE"},
+        {"cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
+            "kem": "SIKEp503r1-KEM", "kem_group": "NONE"},
     (Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11, Ciphers.KMS_PQ_TLS_1_0_2020_02):
-        {"cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "kem": "SIKEp503r1-KEM", "kem_group": "NONE"},
+        {"cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
+            "kem": "SIKEp503r1-KEM", "kem_group": "NONE"},
     (Ciphers.PQ_SIKE_TEST_TLS_1_0_2019_11, Ciphers.KMS_PQ_TLS_1_0_2020_07):
-        {"cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "kem": "SIKEp503r1-KEM", "kem_group": "NONE"},
+        {"cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
+            "kem": "SIKEp503r1-KEM", "kem_group": "NONE"},
 
     (Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02, Ciphers.KMS_PQ_TLS_1_0_2019_06):
-        {"cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "kem": "SIKEp503r1-KEM", "kem_group": "NONE"},
+        {"cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
+            "kem": "SIKEp503r1-KEM", "kem_group": "NONE"},
     (Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02, Ciphers.KMS_PQ_TLS_1_0_2020_02):
-        {"cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "kem": "SIKEp434r3-KEM", "kem_group": "NONE"},
+        {"cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
+            "kem": "SIKEp434r3-KEM", "kem_group": "NONE"},
     (Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02, Ciphers.KMS_PQ_TLS_1_0_2020_07):
-        {"cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384", "kem": "SIKEp434r3-KEM", "kem_group": "NONE"},
+        {"cipher": "ECDHE-SIKE-RSA-AES256-GCM-SHA384",
+            "kem": "SIKEp434r3-KEM", "kem_group": "NONE"},
 
     (Ciphers.KMS_PQ_TLS_1_0_2019_06, Ciphers.KMS_TLS_1_0_2018_10):
-        {"cipher": "ECDHE-RSA-AES256-GCM-SHA384", "kem": "NONE", "kem_group": "NONE"},
+        {"cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+            "kem": "NONE", "kem_group": "NONE"},
     (Ciphers.KMS_PQ_TLS_1_0_2020_02, Ciphers.KMS_TLS_1_0_2018_10):
-        {"cipher": "ECDHE-RSA-AES256-GCM-SHA384", "kem": "NONE", "kem_group": "NONE"},
+        {"cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+            "kem": "NONE", "kem_group": "NONE"},
     (Ciphers.KMS_PQ_TLS_1_0_2020_07, Ciphers.KMS_TLS_1_0_2018_10):
-        {"cipher": "ECDHE-RSA-AES256-GCM-SHA384", "kem": "NONE", "kem_group": "NONE"},
+        {"cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+            "kem": "NONE", "kem_group": "NONE"},
 
     (Ciphers.KMS_TLS_1_0_2018_10, Ciphers.KMS_PQ_TLS_1_0_2019_06):
-        {"cipher": "ECDHE-RSA-AES256-GCM-SHA384", "kem": "NONE", "kem_group": "NONE"},
+        {"cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+            "kem": "NONE", "kem_group": "NONE"},
     (Ciphers.KMS_TLS_1_0_2018_10, Ciphers.KMS_PQ_TLS_1_0_2020_02):
-        {"cipher": "ECDHE-RSA-AES256-GCM-SHA384", "kem": "NONE", "kem_group": "NONE"},
+        {"cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+            "kem": "NONE", "kem_group": "NONE"},
     (Ciphers.KMS_TLS_1_0_2018_10, Ciphers.KMS_PQ_TLS_1_0_2020_07):
-        {"cipher": "ECDHE-RSA-AES256-GCM-SHA384", "kem": "NONE", "kem_group": "NONE"},
+        {"cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+            "kem": "NONE", "kem_group": "NONE"},
 
     # The expected kem_group string for this case purposefully excludes a curve;
     # depending on how s2n was compiled, the curve may be either x25519 or p256.
     (Ciphers.PQ_TLS_1_0_2020_12, Ciphers.PQ_TLS_1_0_2020_12):
-        {"cipher": "TLS_AES_256_GCM_SHA384", "kem": "NONE", "kem_group": "_kyber-512-r2"},
+        {"cipher": "TLS_AES_256_GCM_SHA384",
+            "kem": "NONE", "kem_group": "_kyber-512-r2"},
     (Ciphers.PQ_TLS_1_0_2020_12, Ciphers.KMS_PQ_TLS_1_0_2020_07):
-        {"cipher": "ECDHE-KYBER-RSA-AES256-GCM-SHA384", "kem": "kyber512r2", "kem_group": "NONE"},
+        {"cipher": "ECDHE-KYBER-RSA-AES256-GCM-SHA384",
+            "kem": "kyber512r2", "kem_group": "NONE"},
     (Ciphers.KMS_PQ_TLS_1_0_2020_07, Ciphers.PQ_TLS_1_0_2020_12):
-        {"cipher": "ECDHE-KYBER-RSA-AES256-GCM-SHA384", "kem": "kyber512r2", "kem_group": "NONE"},
+        {"cipher": "ECDHE-KYBER-RSA-AES256-GCM-SHA384",
+            "kem": "kyber512r2", "kem_group": "NONE"},
 
     (Ciphers.PQ_TLS_1_0_2020_12, KemGroups.P256_KYBER512R2):
-        {"cipher": "AES256_GCM_SHA384", "kem": "NONE", "kem_group": "secp256r1_kyber-512-r2"},
+        {"cipher": "AES256_GCM_SHA384", "kem": "NONE",
+            "kem_group": "secp256r1_kyber-512-r2"},
     (Ciphers.PQ_TLS_1_0_2020_12, KemGroups.P256_BIKE1L1FOR2):
-        {"cipher": "AES256_GCM_SHA384", "kem": "NONE", "kem_group": "secp256r1_bike-1l1fo-r2"},
+        {"cipher": "AES256_GCM_SHA384", "kem": "NONE",
+            "kem_group": "secp256r1_bike-1l1fo-r2"},
     (Ciphers.PQ_TLS_1_0_2020_12, KemGroups.P256_SIKEP434R3):
-        {"cipher": "AES256_GCM_SHA384", "kem": "NONE", "kem_group": "secp256r1_sike-p434-r3"},
+        {"cipher": "AES256_GCM_SHA384", "kem": "NONE",
+            "kem_group": "secp256r1_sike-p434-r3"},
 
     (KemGroups.P256_KYBER512R2, Ciphers.PQ_TLS_1_0_2020_12):
-        {"cipher": "AES256_GCM_SHA384", "kem": "NONE", "kem_group": "secp256r1_kyber-512-r2"},
+        {"cipher": "AES256_GCM_SHA384", "kem": "NONE",
+            "kem_group": "secp256r1_kyber-512-r2"},
     (KemGroups.P256_BIKE1L1FOR2, Ciphers.PQ_TLS_1_0_2020_12):
-        {"cipher": "AES256_GCM_SHA384", "kem": "NONE", "kem_group": "secp256r1_bike-1l1fo-r2"},
+        {"cipher": "AES256_GCM_SHA384", "kem": "NONE",
+            "kem_group": "secp256r1_bike-1l1fo-r2"},
     (KemGroups.P256_SIKEP434R3, Ciphers.PQ_TLS_1_0_2020_12):
-        {"cipher": "AES256_GCM_SHA384", "kem": "NONE", "kem_group": "secp256r1_sike-p434-r3"},
+        {"cipher": "AES256_GCM_SHA384", "kem": "NONE",
+            "kem_group": "secp256r1_sike-p434-r3"},
 }
 
 """
@@ -104,6 +134,8 @@ Similar to invalid_test_parameters(), this validates the test parameters for
 both client and server. Returns True if the test case using these parameters
 should be skipped.
 """
+
+
 def invalid_pq_handshake_test_parameters(*args, **kwargs):
     client_cipher_kwargs = kwargs.copy()
     client_cipher_kwargs["cipher"] = kwargs["client_cipher"]
@@ -128,8 +160,10 @@ def get_oqs_openssl_override_env_vars():
 
 def assert_s2n_negotiation_parameters(s2n_results, expected_result):
     if expected_result is not None:
-        assert to_bytes(("Cipher negotiated: " + expected_result['cipher'])) in s2n_results.stdout
-        assert to_bytes(("KEM: " + expected_result['kem'])) in s2n_results.stdout
+        assert to_bytes(
+            ("Cipher negotiated: " + expected_result['cipher'])) in s2n_results.stdout
+        assert to_bytes(
+            ("KEM: " + expected_result['kem'])) in s2n_results.stdout
         # Purposefully leave off the "KEM Group: " prefix in order to perform partial matches
         # without specifying the curve.
         assert to_bytes(expected_result['kem_group']) in s2n_results.stdout
@@ -161,7 +195,8 @@ def test_s2nc_to_s2nd_pq_handshake(managed_process, protocol, client_cipher, ser
     client = managed_process(S2N, client_options, timeout=5)
 
     if pq_enabled():
-        expected_result = EXPECTED_RESULTS.get((client_cipher, server_cipher), None)
+        expected_result = EXPECTED_RESULTS.get(
+            (client_cipher, server_cipher), None)
     else:
         # If PQ is not enabled in s2n, we expect classic handshakes to be negotiated.
         # Leave the expected cipher blank, as there are multiple possibilities - the
@@ -176,6 +211,7 @@ def test_s2nc_to_s2nd_pq_handshake(managed_process, protocol, client_cipher, ser
     for results in server.get_results():
         results.assert_success()
         assert_s2n_negotiation_parameters(results, expected_result)
+
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
@@ -217,6 +253,7 @@ def test_s2nc_to_oqs_openssl_pq_handshake(managed_process, protocol, cipher, kem
     for results in server.get_results():
         # Server is OQS OpenSSL; just ensure the process exited successfully
         results.assert_success()
+
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)

--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -32,7 +32,7 @@ def test_session_resumption_s2n_server(managed_process, cipher, curve, protocol,
     server_options = copy.copy(client_options)
     server_options.reconnects_before_exit = 6
     server_options.mode = Provider.ServerMode
-    server_options.use_session_ticket=use_ticket,
+    server_options.use_session_ticket = use_ticket,
     server_options.key = certificate.key
     server_options.cert = certificate.cert
 
@@ -51,7 +51,8 @@ def test_session_resumption_s2n_server(managed_process, cipher, curve, protocol,
     # S2N should indicate the procotol version in a successful connection.
     for results in server.get_results():
         results.assert_success()
-        assert results.stdout.count(to_bytes("Actual protocol version: {}".format(expected_version))) == 6
+        assert results.stdout.count(
+            to_bytes("Actual protocol version: {}".format(expected_version))) == 6
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -89,7 +90,8 @@ def test_session_resumption_s2n_client(managed_process, cipher, curve, protocol,
     expected_version = get_expected_s2n_version(protocol, OpenSSL)
     for results in client.get_results():
         results.assert_success()
-        assert results.stdout.count(to_bytes("Actual protocol version: {}".format(expected_version))) == 6
+        assert results.stdout.count(
+            to_bytes("Actual protocol version: {}".format(expected_version))) == 6
 
     for results in server.get_results():
         results.assert_success()
@@ -118,7 +120,7 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
         curve=curve,
         insecure=True,
         reconnect=False,
-        extra_flags = ['-sess_out', path_to_ticket],
+        extra_flags=['-sess_out', path_to_ticket],
         protocol=protocol)
 
     server_options = copy.copy(client_options)
@@ -129,8 +131,10 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
     server_options.extra_flags = None
     server_options.data_to_send = close_marker_bytes
 
-    server = managed_process(S2N, server_options, timeout=5, send_marker=S2N.get_send_marker())
-    client = managed_process(provider, client_options, timeout=5, close_marker=str(close_marker_bytes))
+    server = managed_process(
+        S2N, server_options, timeout=5, send_marker=S2N.get_send_marker())
+    client = managed_process(provider, client_options,
+                             timeout=5, close_marker=str(close_marker_bytes))
 
     # The client should have received a session ticket
     for results in client.get_results():
@@ -150,21 +154,25 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
     client_options.port = port
     server_options.port = port
 
-    server = managed_process(S2N, server_options, timeout=5, send_marker=S2N.get_send_marker())
-    client = managed_process(provider, client_options, timeout=5, close_marker=str(close_marker_bytes))
+    server = managed_process(
+        S2N, server_options, timeout=5, send_marker=S2N.get_send_marker())
+    client = managed_process(provider, client_options,
+                             timeout=5, close_marker=str(close_marker_bytes))
 
     s2n_version = get_expected_s2n_version(protocol, provider)
 
     # Client has not read server certificate message as this is a resumed session
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes("SSL_connect:SSLv3/TLS read server certificate") not in results.stderr
+        assert to_bytes(
+            "SSL_connect:SSLv3/TLS read server certificate") not in results.stderr
 
     # The server should indicate a session has been resumed
     for results in server.get_results():
         results.assert_success()
         assert b'Resumed session' in results.stdout
-        assert to_bytes("Actual protocol version: {}".format(s2n_version)) in results.stdout
+        assert to_bytes("Actual protocol version: {}".format(
+            s2n_version)) in results.stdout
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -206,20 +214,27 @@ def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, pro
     # s2nc indicates the number of resumed connections in its output
     for results in client.get_results():
         results.assert_success()
-        assert results.stdout.count(b'Resumed session') == num_resumed_connections
-        assert to_bytes("Actual protocol version: {}".format(s2n_version)) in results.stdout
+        assert results.stdout.count(
+            b'Resumed session') == num_resumed_connections
+        assert to_bytes("Actual protocol version: {}".format(
+            s2n_version)) in results.stdout
 
-    server_accepts_str = str(num_resumed_connections + num_full_connections) + " server accepts that finished"
+    server_accepts_str = str(
+        num_resumed_connections + num_full_connections) + " server accepts that finished"
 
     for results in server.get_results():
         results.assert_success()
         if provider is S2N:
-            assert results.stdout.count(b'Resumed session') == num_resumed_connections
-            assert to_bytes("Actual protocol version: {}".format(s2n_version)) in results.stdout
+            assert results.stdout.count(
+                b'Resumed session') == num_resumed_connections
+            assert to_bytes("Actual protocol version: {}".format(
+                s2n_version)) in results.stdout
         else:
             assert to_bytes(server_accepts_str) in results.stdout
             # s_server only writes one certificate message in all of the connections
-            assert results.stderr.count(b'SSL_accept:SSLv3/TLS write certificate') == num_full_connections
+            assert results.stderr.count(
+                b'SSL_accept:SSLv3/TLS write certificate') == num_full_connections
+
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
@@ -247,8 +262,8 @@ def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, c
         curve=curve,
         insecure=True,
         reconnect=False,
-        extra_flags = ['-sess_out', path_to_ticket],
-        data_to_send = data_bytes(4069),
+        extra_flags=['-sess_out', path_to_ticket],
+        data_to_send=data_bytes(4069),
         protocol=protocol)
 
     server_options = copy.copy(client_options)
@@ -287,10 +302,12 @@ def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, c
     # Client has read server certificate because this is a full connection
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes("SSL_connect:SSLv3/TLS read server certificate") in results.stderr
+        assert to_bytes(
+            "SSL_connect:SSLv3/TLS read server certificate") in results.stderr
 
     # The server should indicate a session has not been resumed
     for results in server.get_results():
         results.assert_success()
         assert b'Resumed session' not in results.stdout
-        assert to_bytes("Actual protocol version: {}".format(s2n_version)) in results.stdout
+        assert to_bytes("Actual protocol version: {}".format(
+            s2n_version)) in results.stdout

--- a/tests/integrationv2/test_signature_algorithms.py
+++ b/tests/integrationv2/test_signature_algorithms.py
@@ -29,8 +29,8 @@ all_sigs = [
 
 
 def signature_marker(mode, signature):
-    return to_bytes("{mode} signature negotiated: {type}+{digest}" \
-        .format(mode=mode.title(), type=signature.sig_type, digest=signature.sig_digest))
+    return to_bytes("{mode} signature negotiated: {type}+{digest}"
+                    .format(mode=mode.title(), type=signature.sig_type, digest=signature.sig_digest))
 
 
 def skip_ciphers(*args, **kwargs):
@@ -103,9 +103,12 @@ def test_s2n_server_signature_algorithms(managed_process, cipher, provider, prot
 
     for results in server.get_results():
         results.assert_success()
-        assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
-        assert signature_marker(Provider.ServerMode, signature) in results.stdout
-        assert (signature_marker(Provider.ClientMode, signature) in results.stdout) == client_auth
+        assert to_bytes("Actual protocol version: {}".format(
+            expected_version)) in results.stdout
+        assert signature_marker(Provider.ServerMode,
+                                signature) in results.stdout
+        assert (signature_marker(Provider.ClientMode, signature)
+                in results.stdout) == client_auth
         assert random_bytes in results.stdout
 
 
@@ -143,12 +146,14 @@ def test_s2n_client_signature_algorithms(managed_process, cipher, provider, prot
     if provider == GnuTLS:
         kill_marker = random_bytes
 
-    server = managed_process(provider, server_options, timeout=5, kill_marker=kill_marker)
+    server = managed_process(provider, server_options,
+                             timeout=5, kill_marker=kill_marker)
     client = managed_process(S2N, client_options, timeout=5)
 
     for results in server.get_results():
         results.assert_success()
-        assert any([random_bytes in stream for stream in results.output_streams()])
+        assert any(
+            [random_bytes in stream for stream in results.output_streams()])
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
@@ -160,10 +165,14 @@ def test_s2n_client_signature_algorithms(managed_process, cipher, provider, prot
     #
     # This mostly has to be inferred from the RFCs, but this blog post is a pretty good summary
     # of the situation: https://timtaubert.de/blog/2016/07/the-evolution-of-signatures-in-tls/
-    server_sigalg_used = not cipher.iana_standard_name.startswith("TLS_RSA_WITH_")
+    server_sigalg_used = not cipher.iana_standard_name.startswith(
+        "TLS_RSA_WITH_")
 
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
-        assert signature_marker(Provider.ServerMode, signature) in results.stdout or not server_sigalg_used
-        assert (signature_marker(Provider.ClientMode, signature) in results.stdout) == client_auth
+        assert to_bytes("Actual protocol version: {}".format(
+            expected_version)) in results.stdout
+        assert signature_marker(
+            Provider.ServerMode, signature) in results.stdout or not server_sigalg_used
+        assert (signature_marker(Provider.ClientMode, signature)
+                in results.stdout) == client_auth

--- a/tests/integrationv2/test_sni_match.py
+++ b/tests/integrationv2/test_sni_match.py
@@ -19,7 +19,8 @@ def filter_cipher_list(*args, **kwargs):
     protocol = kwargs.get('protocol')
     cert_test_case = kwargs.get('cert_test_case')
 
-    lowest_protocol_cipher = min(cert_test_case.client_ciphers, key=lambda x: x.min_version)
+    lowest_protocol_cipher = min(
+        cert_test_case.client_ciphers, key=lambda x: x.min_version)
     if protocol < lowest_protocol_cipher.min_version:
         return True
 
@@ -39,17 +40,18 @@ def test_sni_match(managed_process, provider, protocol, cert_test_case):
         insecure=False,
         verify_hostname=True,
         server_name=cert_test_case.client_sni,
-        cipher = cert_test_case.client_ciphers,
+        cipher=cert_test_case.client_ciphers,
         protocol=protocol)
 
     server_options = ProviderOptions(
-        mode = Provider.ServerMode,
+        mode=Provider.ServerMode,
         port=port,
         extra_flags=[],
         protocol=protocol)
 
     # Setup the certificate chain for S2ND based on the multicert test case
-    cert_key_list = [(cert[0],cert[1]) for cert in cert_test_case.server_certs]
+    cert_key_list = [(cert[0], cert[1])
+                     for cert in cert_test_case.server_certs]
     for cert_key_path in cert_key_list:
         server_options.extra_flags.extend(['--cert', cert_key_path[0]])
         server_options.extra_flags.extend(['--key', cert_key_path[1]])
@@ -64,7 +66,8 @@ def test_sni_match(managed_process, provider, protocol, cert_test_case):
 
     for results in server.get_results():
         results.assert_success()
-        assert to_bytes("Actual protocol version: {}".format(expected_version)) in results.stdout
+        assert to_bytes("Actual protocol version: {}".format(
+            expected_version)) in results.stdout
         if cert_test_case.client_sni is not None:
-            assert to_bytes("Server name: {}".format(cert_test_case.client_sni)) in results.stdout
-
+            assert to_bytes("Server name: {}".format(
+                cert_test_case.client_sni)) in results.stdout

--- a/tests/integrationv2/test_sslyze.py
+++ b/tests/integrationv2/test_sslyze.py
@@ -177,8 +177,10 @@ def validate_scan_result(scan_attempt, protocol, certificate=None):
 def get_scan_attempts(scan_results):
     # scan_results (sslyze.AllScanCommandsAttempts) is an object containing parameters mapped to scan attempts. convert
     # this to a list containing just scan attempts, and then filter out tests that were not scheduled.
-    scan_attribute_names = [attr_name for attr_name in dir(scan_results) if not attr_name.startswith("__")]
-    scan_attempts = [getattr(scan_results, attr_name) for attr_name in scan_attribute_names]
+    scan_attribute_names = [attr_name for attr_name in dir(
+        scan_results) if not attr_name.startswith("__")]
+    scan_attempts = [getattr(scan_results, attr_name)
+                     for attr_name in scan_attribute_names]
     scan_attempts = [
         scan_attempt for scan_attempt in scan_attempts
         if scan_attempt.status != sslyze.ScanCommandAttemptStatusEnum.NOT_SCHEDULED
@@ -224,7 +226,8 @@ def test_sslyze_scans(managed_process, protocol, scan_command):
 
     # test 1.3 exclusively
     if protocol == Protocols.TLS13:
-        server_options.cipher = Cipher("test_all_tls13", Protocols.TLS13, False, False, s2n=True)
+        server_options.cipher = Cipher(
+            "test_all_tls13", Protocols.TLS13, False, False, s2n=True)
 
     if scan_command == sslyze.ScanCommand.SESSION_RESUMPTION:
         server_options.reconnect = True,

--- a/tests/integrationv2/test_version_negotiation.py
+++ b/tests/integrationv2/test_version_negotiation.py
@@ -40,7 +40,8 @@ def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, protocol, p
     if provider == GnuTLS:
         kill_marker = random_bytes
 
-    server = managed_process(provider, server_options, timeout=5, kill_marker=kill_marker)
+    server = managed_process(provider, server_options,
+                             timeout=5, kill_marker=kill_marker)
     client = managed_process(S2N, client_options, timeout=5)
 
     client_version = get_expected_s2n_version(Protocols.TLS13, provider)
@@ -48,8 +49,10 @@ def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, protocol, p
 
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes("Client protocol version: {}".format(client_version)) in results.stdout
-        assert to_bytes("Actual protocol version: {}".format(actual_version)) in results.stdout
+        assert to_bytes("Client protocol version: {}".format(
+            client_version)) in results.stdout
+        assert to_bytes("Actual protocol version: {}".format(
+            actual_version)) in results.stdout
 
     for results in server.get_results():
         results.assert_success()
@@ -57,10 +60,13 @@ def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, protocol, p
             # The server is only TLS12, so it reads the version from the CLIENT_HELLO, which is never above TLS12
             # This check only cares about S2N. Trying to maintain expected output of other providers doesn't
             # add benefit to whether the S2N client was able to negotiate a lower TLS version.
-            assert to_bytes("Client protocol version: {}".format(actual_version)) in results.stdout
-            assert to_bytes("Actual protocol version: {}".format(actual_version)) in results.stdout
+            assert to_bytes("Client protocol version: {}".format(
+                actual_version)) in results.stdout
+            assert to_bytes("Actual protocol version: {}".format(
+                actual_version)) in results.stdout
 
-        assert any([random_bytes in stream for stream in results.output_streams()])
+        assert any(
+            [random_bytes in stream for stream in results.output_streams()])
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -102,19 +108,24 @@ def test_s2nd_tls13_negotiates_tls12(managed_process, cipher, curve, protocol, p
         results.assert_success()
         if provider is S2N:
             # The client will get the server version from the SERVER HELLO, which will be the negotiated version
-            assert to_bytes("Server protocol version: {}".format(actual_version)) in results.stdout
-            assert to_bytes("Actual protocol version: {}".format(actual_version)) in results.stdout
+            assert to_bytes("Server protocol version: {}".format(
+                actual_version)) in results.stdout
+            assert to_bytes("Actual protocol version: {}".format(
+                actual_version)) in results.stdout
         elif provider is OpenSSL:
             # This check cares about other providers because we want to know that they did negotiate the version
             # that our S2N server intended to negotiate.
             openssl_version = get_expected_openssl_version(protocol)
-            assert to_bytes("Protocol  : {}".format(openssl_version)) in results.stdout
+            assert to_bytes("Protocol  : {}".format(
+                openssl_version)) in results.stdout
         elif provider is GnuTLS:
             gnutls_version = get_expected_gnutls_version(protocol)
             assert to_bytes(f"Version: {gnutls_version}") in results.stdout
 
     for results in server.get_results():
         results.assert_success()
-        assert to_bytes("Server protocol version: {}".format(server_version)) in results.stdout
-        assert to_bytes("Actual protocol version: {}".format(actual_version)) in results.stdout
+        assert to_bytes("Server protocol version: {}".format(
+            server_version)) in results.stdout
+        assert to_bytes("Actual protocol version: {}".format(
+            actual_version)) in results.stdout
         assert random_bytes in results.stdout

--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -22,8 +22,8 @@ ENDPOINTS = [
     "rsa2048.badssl.com",
     "rsa4096.badssl.com",
     "sha256.badssl.com",
-    #"sha384.badssl.com",
-    #"sha512.badssl.com",
+    # "sha384.badssl.com",
+    # "sha512.badssl.com",
     "tls-v1-0.badssl.com",
     "tls-v1-1.badssl.com",
     "tls-v1-2.badssl.com",
@@ -109,7 +109,8 @@ def test_well_known_endpoints(managed_process, protocol, endpoint, provider, cip
 
     # expect_stderr=True because S2N sometimes receives OCSP responses:
     # https://github.com/aws/s2n-tls/blob/14ed186a13c1ffae7fbb036ed5d2849ce7c17403/bin/echo.c#L180-L184
-    client = managed_process(provider, client_options, timeout=5, expect_stderr=True)
+    client = managed_process(provider, client_options,
+                             timeout=5, expect_stderr=True)
 
     expected_result = EXPECTED_RESULTS.get((endpoint, cipher), None)
 


### PR DESCRIPTION
### Resolved issues:

n/a

### Description of changes: 

Before we start flagging python with a linter, reformat the python so it'll (more) likely pass.

### Call-outs:

Config file in the directory, with mostly defaults.

Local run:
```
python3 -m pip install autopep8
python3 -m autopep8 ./tests/integrationv2/*.py
```

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? CI

 Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
