### PR TITLE
build: cast-qual flag in Cmake for aws-lc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,7 +341,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE C)
 set(CMAKE_C_FLAGS_DEBUGOPT "")
 
 target_compile_options(${PROJECT_NAME} PRIVATE -pedantic -std=gnu99 -Wall -Wimplicit -Wunused -Wcomment -Wchar-subscripts
-        -Wuninitialized -Wshadow -Wcast-qual -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security
+        -Wuninitialized -Wshadow -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security
         -Wno-missing-braces -Wa,--noexecstack
 )
 
@@ -476,6 +476,11 @@ if (CLONE_SUPPORTED)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+
+if (NOT $ENV{S2N_LIBCRYPTO} STREQUAL "awslc")
+    # add cast-qual back in for non AWS-LC
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wcast-qual)
+endif()
 
 #work around target differences
 if (TARGET crypto)


### PR DESCRIPTION
### Resolved issues:

partial for #3262

### Description of changes: 

For make, the [s2n.mk](https://github.com/aws/s2n-tls/blob/main/s2n.mk#L40) leaves off the -Wcast-qual flag for aws-lc. No such logic exists in CMakeLists.txt.


### Call-outs:

Splitting up the various interning PRs into smaller chunks.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
