### PR TITLE
aws-lc Intern test linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -623,6 +623,9 @@ if (BUILD_TESTING)
                 COMMAND
                   find . -name '${test_case_name}.c.o' -exec objcopy --redefine-syms libcrypto.symbols {} \\\;
             )
+            # if we're building tests, we export the prefixed symbols so tests can link to them
+            set_target_properties(${test_case_name} PROPERTIES LINK_FLAGS
+                "-Wl,--whole-archive s2n_libcrypto.a -Wl,--no-whole-archive")
         endif()
         target_compile_options(${test_case_name} PRIVATE -Wno-implicit-function-declaration -Wno-deprecated -D_POSIX_C_SOURCE=200809L -std=gnu99)
         add_test(NAME ${test_case_name} COMMAND $<TARGET_FILE:${test_case_name}> WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit)


### PR DESCRIPTION
### Resolved issues:

partial for #3262 

### Description of changes: 

Address missing symbol errors when building tests with interned non-FIPS aws-lc; [gist](https://gist.github.com/dougch/701e311e336abfb20674a4e84907e37b).

### Call-outs:

- one of three PRs, must be merged over #3270 and a yet to be finish s2nc/d FIPS fix.
- Is there a re-usable CMake target for all tests?

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? locally

 Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
