### PR TITLE
Disable strict-prototypes diagnostic flag in Clang

### DIFF
--- a/s2n.mk
+++ b/s2n.mk
@@ -49,7 +49,7 @@ DEFAULT_CFLAGS += -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-s
                  -Wshadow  -Wcast-align -Wwrite-strings -fPIC -Wno-missing-braces\
                  -D_POSIX_C_SOURCE=200809L -O2 -I$(LIBCRYPTO_ROOT)/include/ \
                  -I$(S2N_ROOT)/api/ -I$(S2N_ROOT) -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security \
-                 -D_FORTIFY_SOURCE=2 -fgnu89-inline -fvisibility=hidden -DS2N_EXPORTS
+                 -D_FORTIFY_SOURCE=2 -fgnu89-inline -fvisibility=hidden -DS2N_EXPORTS -Wno-strict-prototypes
 
 COVERAGE_CFLAGS = -fprofile-arcs -ftest-coverage
 COVERAGE_LDFLAGS = --coverage

--- a/s2n.mk
+++ b/s2n.mk
@@ -49,7 +49,7 @@ DEFAULT_CFLAGS += -pedantic -Wall -Werror -Wimplicit -Wunused -Wcomment -Wchar-s
                  -Wshadow  -Wcast-align -Wwrite-strings -fPIC -Wno-missing-braces\
                  -D_POSIX_C_SOURCE=200809L -O2 -I$(LIBCRYPTO_ROOT)/include/ \
                  -I$(S2N_ROOT)/api/ -I$(S2N_ROOT) -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security \
-                 -D_FORTIFY_SOURCE=2 -fgnu89-inline -fvisibility=hidden -DS2N_EXPORTS -Wno-strict-prototypes
+                 -D_FORTIFY_SOURCE=2 -fgnu89-inline -fvisibility=hidden -DS2N_EXPORTS
 
 COVERAGE_CFLAGS = -fprofile-arcs -ftest-coverage
 COVERAGE_LDFLAGS = --coverage
@@ -156,6 +156,13 @@ ifeq ($(S2N_UNSAFE_FUZZING_MODE),1)
     CPPFLAGS := $(filter-out -fvisibility=hidden,$(CPPFLAGS))
     CPPFLAGS := $(filter-out -DS2N_EXPORTS,$(CPPFLAGS))
 
+endif
+
+# Disable strict-prototypes check in clang
+ifneq '' '$(findstring clang,$(CC))'
+	CFLAGS += -Wno-strict-prototypes
+	DEFAULT_CFLAGS += -Wno-strict-prototypes
+	CPPFLAGS += -Wno-strict-prototypes
 endif
 
 # If COV_TOOL isn't set, pick a default COV_TOOL depending on if the LLVM Marker File was created.


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

LLVM has a diagnostic flag, `strict-prototypes`, which checks for functions without prototypes. This has been disabled by default. However, [in a recent commit](https://github.com/llvm/llvm-project/commit/11da1b53d8cd3507959022cd790d5a7ad4573d94), LLVM has enabled this flag in pedantic mode, which [s2n-tls enables](https://github.com/aws/s2n-tls/blob/6e46e1351b5bfb2c0dc1de7d2cb8464563251d97/s2n.mk#L48). s2n-tls now [fails to build in our fuzz tests](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nFuzzBatch/batch/s2nFuzzBatch%3A849be3d0-f374-45f3-98bb-c462e9b4bd32?region=us-west-2) due to this flag.

Also in the LLVM commit, the functionality of the `strict-prototypes` flag was changed to only throw warnings for definitions which *won't* change in [C2x](https://en.wikipedia.org/wiki/C2x). As such, it seems safe to disable this warning. A new, `deprecated-non-prototype`, flag was added which checks for definitions that *will* change in C2x, and is enabled by default.

### Call-outs:

None

### Testing:

The fuzz test webhook should succeed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
