### PR TITLE
Disable s2nc/d FIPS calls while interning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -547,6 +547,7 @@ if (S2N_INTERN_LIBCRYPTO)
       DEPENDS libcrypto.symbols
     )
     add_dependencies(${PROJECT_NAME} s2n_libcrypto)
+    add_definitions(-DS2N_INTERN_LIBCRYPTO)
 
     if ((BUILD_SHARED_LIBS AND BUILD_TESTING) OR NOT BUILD_SHARED_LIBS)
         # if libcrypto needs to be interned, rewrite libcrypto references so use of internal functions will link correctly

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -21,8 +21,10 @@
 #include <getopt.h>
 #include <fcntl.h>
 
+#ifndef S2N_INTERN_LIBCRYPTO
 #include <openssl/crypto.h>
 #include <openssl/err.h>
+#endif
 
 #include "api/s2n.h"
 #include "common.h"
@@ -422,6 +424,7 @@ int main(int argc, char *const *argv)
     }
 
     if (fips_mode) {
+#ifndef S2N_INTERN_LIBCRYPTO
 #if defined(OPENSSL_FIPS) || defined(OPENSSL_IS_AWSLC)
         if (FIPS_mode_set(1) == 0) {
             unsigned long fips_rc = ERR_get_error();
@@ -431,8 +434,9 @@ int main(int argc, char *const *argv)
         }
         printf("s2nc entered FIPS mode\n");
 #else
-        fprintf(stderr, "Error entering FIPS mode. s2nc is not linked with a FIPS-capable libcrypto.\n");
+        fprintf(stderr, "Error entering FIPS mode. s2nc was not built against a FIPS-capable libcrypto.\n");
         exit(1);
+#endif
 #endif
     }
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -23,8 +23,10 @@
 #include <getopt.h>
 #include <errno.h>
 
+#ifndef S2N_INTERN_LIBCRYPTO
 #include <openssl/crypto.h>
 #include <openssl/err.h>
+#endif
 
 #include "api/s2n.h"
 #include "common.h"
@@ -490,6 +492,7 @@ int main(int argc, char *const *argv)
     }
 
     if (fips_mode) {
+#ifndef S2N_INTERN_LIBCRYPTO
 #if defined(OPENSSL_FIPS) || defined(OPENSSL_IS_AWSLC)
         if (FIPS_mode_set(1) == 0) {
             unsigned long fips_rc = ERR_get_error();
@@ -499,8 +502,9 @@ int main(int argc, char *const *argv)
         }
         printf("s2nd entered FIPS mode\n");
 #else
-        fprintf(stderr, "Error entering FIPS mode. s2nd is not linked with a FIPS-capable libcrypto.\n");
+        fprintf(stderr, "Error entering FIPS mode. s2nd was not built against a FIPS-capable libcrypto.\n");
         exit(1);
+#endif
 #endif
     }
 

--- a/crypto/s2n_fips.c
+++ b/crypto/s2n_fips.c
@@ -31,6 +31,11 @@ int s2n_fips_init(void)
      * Note: FIPS_mode() does not change the FIPS state of libcrypto. This only returns the current state. Applications
      * using s2n must call FIPS_mode_set(1) prior to s2n_init.
      * */
+
+#if defined(S2N_INTERN_LIBCRYPTO) && defined(OPENSSL_FIPS)
+#error "Interning with OpenSSL fips-validated libcrypto is not currently supported. See https://github.com/aws/s2n-tls/issues/2741"
+#endif
+
 #if defined(OPENSSL_FIPS) || defined(OPENSSL_IS_AWSLC)
     if (FIPS_mode()) {
         s2n_fips_mode = 1;


### PR DESCRIPTION
### Resolved issues:

partial for #3262 

### Description of changes: 

When trying to intern libcrypto with aws-lc (which always responds to a `FIPS_mode` query, unlike openssl), we either need to redo the symbols for s2nc and s2nd, or be explicit about not including FIPS libcrypto calls while interning (can be reversed later). This PR does the latter (both pass interning tests).

### Call-outs:

- Internalizing librcypto is only supported when building with cmake.
- Here is a diff for rewriting the symbols of s2nc/d, as an alternative solution which this PR _is not doing_, here for completeness.

```
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -658,6 +658,21 @@ if (BUILD_TESTING)
     target_include_directories(s2nd PRIVATE api)
     target_compile_options(s2nd PRIVATE -std=gnu99 -D_POSIX_C_SOURCE=200112L)

+        if (S2N_INTERN_LIBCRYPTO)
+            # if libcrypto was interned, rewrite libcrypto symbols so use of internal functions will link correctly
+            add_custom_command(
+                TARGET s2nc PRE_LINK
+                COMMAND
+                  find . -name 's2nc.c.o' -exec objcopy --redefine-syms libcrypto.symbols {} \\\;
+            )
+            add_custom_command(
+                TARGET s2nd PRE_LINK
+                COMMAND
+                  find . -name 's2nd.c.o' -exec objcopy --redefine-syms libcrypto.symbols {} \\\;
+            )
+        endif()
+
```

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? locally and CI also has one aws-lc fips test.

 Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
