### PR TITLE
bug: fix s2n_connection initialization and wipe

### DIFF
--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -505,7 +505,6 @@ int main(int argc, char **argv)
             EXPECT_TRUE(s2n_is_hello_retry_handshake(client_conn));
 
             /* Verify client received cookie data */
-            EXPECT_TRUE(client_conn->cookie_stuffer.write_cursor > 0);
             EXPECT_TRUE(s2n_stuffer_data_available(&client_conn->cookie_stuffer) > 0);
 
             EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));

--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -510,10 +510,6 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
             EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
-
-            /* free cookie stuffer */
-            EXPECT_SUCCESS(s2n_stuffer_free(&client_conn->cookie_stuffer));
-            EXPECT_SUCCESS(s2n_stuffer_free(&server_conn->cookie_stuffer));
         }
     }
 

--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -482,6 +482,10 @@ int main(int argc, char **argv)
 
         /* Call the test in a loop to ensure that s2n_connection_wipe is implemented correctly */
         for (int i = 0; i < 10; i++) {
+            /* ensure call to s2n_connection_wipe are safe */
+            EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+            EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+
              /* Create nonblocking pipes */
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
@@ -507,14 +511,10 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
             EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
 
-            /* ensure call to s2n_connection_wipe are safe */
-            EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
-            EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+            /* free cookie stuffer */
+            EXPECT_SUCCESS(s2n_stuffer_free(&client_conn->cookie_stuffer));
+            EXPECT_SUCCESS(s2n_stuffer_free(&server_conn->cookie_stuffer));
         }
-
-        /* free cookie stuffer */
-        EXPECT_SUCCESS(s2n_stuffer_wipe(&client_conn->cookie_stuffer));
-        EXPECT_SUCCESS(s2n_stuffer_wipe(&server_conn->cookie_stuffer));
     }
 
     /* Self-Talk test: the client initiates a handshake with an X25519 share.

--- a/tests/unit/s2n_server_hello_retry_test.c
+++ b/tests/unit/s2n_server_hello_retry_test.c
@@ -19,7 +19,6 @@
 #include "tls/extensions/s2n_key_share.h"
 #include "tls/extensions/s2n_server_supported_versions.h"
 
-#include "tls/extensions/s2n_cookie.h"
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_security_policies.h"
 #include "tls/s2n_tls.h"
@@ -436,67 +435,6 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_config_free(conf));
         EXPECT_SUCCESS(s2n_connection_free(conn));
-    }
-
-    /* Test scenario: client connection is wiped + HRR + server sends cookie data as part of HRR
-     *
-     * Tests that calls to `s2n_connection_wipe` are safe and do not cause the connection to end up in
-     * a bad state. s2n_connection_wipe is called when a customer wants to reuse a connection; which is
-     * more performant compared to creating a new connection. */
-    {
-        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
-                s2n_connection_ptr_free);
-        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
-                s2n_connection_ptr_free);
-        /* ensure call to s2n_connection_wipe are safe */
-        EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
-        EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
-
-        DEFER_CLEANUP(struct s2n_config *server_config = s2n_config_new(),
-                s2n_config_ptr_free);
-        DEFER_CLEANUP(struct s2n_config *client_config = s2n_config_new(),
-                s2n_config_ptr_free);
-        DEFER_CLEANUP(struct s2n_cert_chain_and_key *tls13_chain_and_key,
-                s2n_cert_chain_and_key_ptr_free);
-
-        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&tls13_chain_and_key,
-                S2N_ECDSA_P384_PKCS1_CERT_CHAIN, S2N_ECDSA_P384_PKCS1_KEY));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(client_config, tls13_chain_and_key));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, tls13_chain_and_key));
-
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-
-        /* include cookie data as part of HRR */
-        EXPECT_SUCCESS(s2n_stuffer_skip_write(&server_conn->cookie_stuffer, 500));
-        EXPECT_TRUE(s2n_server_cookie_extension.should_send(server_conn));
-
-        /* Force HRR path */
-        client_conn->security_policy_override = &security_policy_test_tls13_retry;
-
-        /* Send the CH message */
-        EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
-        EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
-                                        s2n_stuffer_data_available(&client_conn->handshake.io)));
-
-        /* Receive CH verify HRR path */
-        EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
-
-        EXPECT_TRUE(s2n_is_hello_retry_handshake(server_conn));
-        EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(server_conn));
-        EXPECT_TRUE(s2n_is_hello_retry_message(server_conn));
-
-        EXPECT_SUCCESS(s2n_server_hello_retry_send(server_conn));
-
-        EXPECT_SUCCESS(s2n_stuffer_wipe(&client_conn->handshake.io));
-        EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io,
-                                        s2n_stuffer_data_available(&server_conn->handshake.io)));
-        client_conn->handshake.message_number = HELLO_RETRY_MSG_NO;
-
-        /* Receive HRR */
-        EXPECT_SUCCESS(s2n_server_hello_recv(client_conn));
-        EXPECT_TRUE(s2n_is_hello_retry_handshake(client_conn));
-        EXPECT_TRUE(s2n_is_hello_retry_message(client_conn));
     }
 
     /* Send and receive Hello Retry Request messages */

--- a/tests/unit/s2n_server_hello_retry_test.c
+++ b/tests/unit/s2n_server_hello_retry_test.c
@@ -448,6 +448,9 @@ int main(int argc, char **argv)
                 s2n_connection_ptr_free);
         DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
                 s2n_connection_ptr_free);
+        /* ensure call to s2n_connection_wipe are safe */
+        EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+        EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
 
         DEFER_CLEANUP(struct s2n_config *server_config = s2n_config_new(),
                 s2n_config_ptr_free);
@@ -456,25 +459,13 @@ int main(int argc, char **argv)
         DEFER_CLEANUP(struct s2n_cert_chain_and_key *tls13_chain_and_key,
                 s2n_cert_chain_and_key_ptr_free);
 
-        /* ensure call to s2n_connection_wipe are safe */
-        EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
-        EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
-
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&tls13_chain_and_key,
                 S2N_ECDSA_P384_PKCS1_CERT_CHAIN, S2N_ECDSA_P384_PKCS1_KEY));
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "default_tls13"));
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "default_tls13"));
-
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(client_config, tls13_chain_and_key));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, tls13_chain_and_key));
 
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
-        struct client_hello_context client_hello_ctx = {.invocations = 0, .mode = S2N_CLIENT_HELLO_CB_BLOCKING };
-        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(server_config, client_hello_detect_duplicate_calls, &client_hello_ctx));
-
-        EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
-        EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(client_conn, S2N_TLS13));
 
         /* include cookie data as part of HRR */
         EXPECT_SUCCESS(s2n_stuffer_skip_write(&server_conn->cookie_stuffer, 500));
@@ -483,15 +474,13 @@ int main(int argc, char **argv)
         /* Force HRR path */
         client_conn->security_policy_override = &security_policy_test_tls13_retry;
 
-        /* Send the first CH message */
+        /* Send the CH message */
         EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
         EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
                                         s2n_stuffer_data_available(&client_conn->handshake.io)));
 
-        /* Receive the CH and send an HRR, which will execute the HRR code paths */
-        EXPECT_EQUAL(client_hello_ctx.invocations, 0);
+        /* Receive CH verify HRR path */
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
-        EXPECT_EQUAL(client_hello_ctx.invocations, 1);
 
         EXPECT_TRUE(s2n_is_hello_retry_handshake(server_conn));
         EXPECT_SUCCESS(s2n_set_connection_hello_retry_flags(server_conn));
@@ -503,7 +492,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io,
                                         s2n_stuffer_data_available(&server_conn->handshake.io)));
         client_conn->handshake.message_number = HELLO_RETRY_MSG_NO;
+
+        /* Receive HRR */
         EXPECT_SUCCESS(s2n_server_hello_recv(client_conn));
+        EXPECT_TRUE(s2n_is_hello_retry_handshake(client_conn));
+        EXPECT_TRUE(s2n_is_hello_retry_message(client_conn));
     }
 
     /* Send and receive Hello Retry Request messages */

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -557,6 +557,8 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->out));
+    /* free and wipe the cookie stuffer since it is reallocate below */
+    POSIX_GUARD(s2n_stuffer_free(&conn->cookie_stuffer));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->cookie_stuffer));
 
     POSIX_GUARD_RESULT(s2n_psk_parameters_wipe(&conn->psk_params));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -81,6 +81,10 @@ static int s2n_connection_init_hmacs(struct s2n_connection *conn)
     return 0;
 }
 
+/* Allocates and initializes memory for a new connection.
+ *
+ * Ensure that all initialization happens in `s2n_connection_wipe` since customers can
+ * reuse a connection. */
 struct s2n_connection *s2n_connection_new(s2n_mode mode)
 {
     struct s2n_blob blob = {0};
@@ -94,24 +98,8 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
 
     PTR_GUARD_POSIX(s2n_connection_set_config(conn, s2n_fetch_default_config()));
 
+    /* `mode` is initialized here since its passed in as a parameter. */
     conn->mode = mode;
-    conn->blinding = S2N_BUILT_IN_BLINDING;
-    conn->close_notify_queued = 0;
-    conn->client_session_resumed = 0;
-    conn->session_id_len = 0;
-    conn->verify_host_fn = NULL;
-    conn->data_for_verify_host = NULL;
-    conn->verify_host_fn_overridden = 0;
-    conn->data_for_verify_host = NULL;
-    conn->send = NULL;
-    conn->recv = NULL;
-    conn->send_io_context = NULL;
-    conn->recv_io_context = NULL;
-    conn->corked_io = 0;
-    conn->context = NULL;
-    conn->security_policy_override = NULL;
-    conn->ticket_lifetime_hint = 0;
-    conn->session_ticket_status = S2N_NO_TICKET;
 
     /* Allocate the fixed-size stuffers */
     blob = (struct s2n_blob) {0};
@@ -153,13 +141,15 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
     PTR_GUARD_POSIX(s2n_stuffer_growable_alloc(&conn->in, 0));
     PTR_GUARD_POSIX(s2n_stuffer_growable_alloc(&conn->handshake.io, 0));
     PTR_GUARD_POSIX(s2n_stuffer_growable_alloc(&conn->client_hello.raw_message, 0));
-    PTR_GUARD_POSIX(s2n_connection_wipe(conn));
     PTR_GUARD_RESULT(s2n_timer_start(conn->config, &conn->write_timer));
 
-    /* Initialize the cookie stuffer with zero length. If a cookie extension
-     * is received, the stuffer will be resized according to the cookie length */
-    PTR_GUARD_POSIX(s2n_stuffer_growable_alloc(&conn->cookie_stuffer, 0));
-
+    /* NOTE: s2n_connection_wipe MUST be called last in this function.
+     *
+     * s2n_connection_wipe is used for initializing values but also used by customers to
+     * reset/reuse the connection. Calling it last ensures that s2n_connection_wipe is
+     * implemented correctly and safe.
+     */
+    PTR_GUARD_POSIX(s2n_connection_wipe(conn));
     return conn;
 }
 
@@ -513,6 +503,11 @@ int s2n_connection_free_handshake(struct s2n_connection *conn)
     return 0;
 }
 
+/* An idempotent operation which initializes values on the connection.
+ *
+ * An existing connection should be reset only after all I/O is completed and `s2n_shutdown`
+ * has been called.
+ */
 int s2n_connection_wipe(struct s2n_connection *conn)
 {
     /* First make a copy of everything we'd like to save, which isn't very much. */
@@ -538,7 +533,6 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     /* Some required structures might have been freed to conserve memory between handshakes.
      * Restore them.
      */
-
     if (!conn->handshake.hashes) {
         POSIX_GUARD_RESULT(s2n_handshake_hashes_new(&conn->handshake.hashes));
     }
@@ -658,6 +652,13 @@ int s2n_connection_wipe(struct s2n_connection *conn)
         conn->client_protocol_version = s2n_highest_protocol_version;
         conn->actual_protocol_version = s2n_highest_protocol_version;
     }
+
+    /* Initialize remaining values */
+    conn->blinding = S2N_BUILT_IN_BLINDING;
+    conn->session_ticket_status = S2N_NO_TICKET;
+    /* Initialize the cookie stuffer with zero length. If a cookie extension
+     * is received, the stuffer will be resized according to the cookie length */
+    POSIX_GUARD(s2n_stuffer_growable_alloc(&conn->cookie_stuffer, 0));
 
     return 0;
 }

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -557,6 +557,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->out));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->cookie_stuffer));
 
     POSIX_GUARD_RESULT(s2n_psk_parameters_wipe(&conn->psk_params));
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -557,9 +557,6 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->out));
-    /* free and wipe the cookie stuffer since it is reallocate below */
-    POSIX_GUARD(s2n_stuffer_free(&conn->cookie_stuffer));
-    POSIX_GUARD(s2n_stuffer_wipe(&conn->cookie_stuffer));
 
     POSIX_GUARD_RESULT(s2n_psk_parameters_wipe(&conn->psk_params));
 
@@ -573,6 +570,9 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     POSIX_GUARD(s2n_free(&conn->peer_quic_transport_parameters));
     POSIX_GUARD(s2n_free(&conn->server_early_data_context));
     POSIX_GUARD(s2n_free(&conn->tls13_ticket_fields.session_secret));
+    /* TODO: Simplify cookie_stuffer implementation.
+     * https://github.com/aws/s2n-tls/issues/3287 */
+    POSIX_GUARD(s2n_stuffer_free(&conn->cookie_stuffer));
 
     /* Allocate memory for handling handshakes */
     POSIX_GUARD(s2n_stuffer_resize(&conn->handshake.io, S2N_LARGE_RECORD_LENGTH));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -83,8 +83,8 @@ static int s2n_connection_init_hmacs(struct s2n_connection *conn)
 
 /* Allocates and initializes memory for a new connection.
  *
- * Ensure that all initialization happens in `s2n_connection_wipe` since customers can
- * reuse a connection. */
+ * Since customers can reuse a connection, ensure that values on the connection are
+ * initialized in `s2n_connection_wipe` where possible. */
 struct s2n_connection *s2n_connection_new(s2n_mode mode)
 {
     struct s2n_blob blob = {0};
@@ -505,8 +505,9 @@ int s2n_connection_free_handshake(struct s2n_connection *conn)
 
 /* An idempotent operation which initializes values on the connection.
  *
- * An existing connection should be reset only after all I/O is completed and `s2n_shutdown`
- * has been called.
+ * Called in order to reuse a connection structure for a new connection. Should wipe
+ * any persistent memory, free any temporary memory, and set all fields back to their
+ * defaults.
  */
 int s2n_connection_wipe(struct s2n_connection *conn)
 {
@@ -538,7 +539,6 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     }
     POSIX_GUARD_RESULT(s2n_handshake_hashes_wipe(conn->handshake.hashes));
     struct s2n_handshake_hashes *handshake_hashes = conn->handshake.hashes;
-
     if (!conn->prf_space) {
         POSIX_GUARD_RESULT(s2n_prf_new(conn));
     }


### PR DESCRIPTION
### Description of changes: 
Currently the `conn->cookie_stuffer` is not restored across call to `s2n_connection_wipe`. The result is that when customers attempt to reuse a connection, its possible for the handshake attempt to fail.

This only occurs if the connection is reused `s2n_connection_wipe` + the connection is a client + the client receives a HelloRetryRequest(implies TLS1.3).

To prevent against a similar issue in the future I have moved the call `s2n_connection_wipe` to the end of `s2n_connection_new` and added documentation to ensure its called last and therefore does proper initialization.

### Call-outs:
I feel the function `s2n_connection_wipe` is mis-named for what it currently does and that possibly what lead to this bug. The function actually initializes values on a connection. It also happens to double for resetting the connection so that it can be reused. I have added some documentation in an attempt to clarify this.

### Testing:
Added cookie data to existing HRR test so that the cookie_stuffer code is invoked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
