### PR TITLE
Use pointer to variable type as required by cleanup attribute

### DIFF
--- a/utils/s2n_fork_detection.c
+++ b/utils/s2n_fork_detection.c
@@ -294,9 +294,9 @@ S2N_RESULT s2n_get_fork_generation_number(uint64_t *return_fork_generation_numbe
     return S2N_RESULT_OK;
 }
 
-static void s2n_cleanup_cb_munmap(void *probe_addr)
+static void s2n_cleanup_cb_munmap(void **probe_addr)
 {
-    munmap(probe_addr, (size_t) sysconf(_SC_PAGESIZE));
+    munmap(*probe_addr, (size_t) sysconf(_SC_PAGESIZE));
 }
 
 /* Run-time probe checking whether the system supports the MADV_WIPEONFORK fork


### PR DESCRIPTION

### Description of changes: 

The cleanup attribute requires;
> cleanup (cleanup_function)
The cleanup attribute runs a function when the variable goes out of scope. This attribute can only be applied to auto function scope variables; it may not be applied to parameters or variables with static storage duration. **_The function must take one parameter, a pointer to a type compatible with the variable_**. The return value of the function (if any) is ignored.

But the current implementation does not do this; it uses a pointer to `void` while it should be a pointer to `void *`.

All CI targets somehow passed with this, but starting failing on freebsd, when that target was fixed in https://github.com/aws/s2n-tls/pull/3284

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
