### PR TITLE
[bindings] Add basic send and recv

### DIFF
--- a/bindings/rust/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/s2n-tls-tokio/Cargo.toml
@@ -18,4 +18,4 @@ tokio = { version = "1", features = ["net"] }
 
 [dev-dependencies]
 clap = { version = "3.1", features = ["derive"] }
-tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread"] }

--- a/bindings/rust/s2n-tls-tokio/tests/common/mod.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/common/mod.rs
@@ -1,0 +1,58 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_tls::raw::{
+    config::{Builder, Config},
+    error::Error,
+    security::DEFAULT_TLS13,
+};
+use s2n_tls_tokio::{TlsAcceptor, TlsConnector, TlsStream};
+use tokio::net::{TcpListener, TcpStream};
+
+/// NOTE: this certificate and key are used for testing purposes only!
+pub static CERT_PEM: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/examples/certs/cert.pem"
+));
+pub static KEY_PEM: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/examples/certs/key.pem"
+));
+
+pub async fn get_streams() -> Result<(TcpStream, TcpStream), tokio::io::Error> {
+    let localhost = "127.0.0.1".to_owned();
+    let listener = TcpListener::bind(format!("{}:0", localhost)).await?;
+    let addr = listener.local_addr()?;
+    let client_stream = TcpStream::connect(&addr).await?;
+    let (server_stream, _) = listener.accept().await?;
+    Ok((server_stream, client_stream))
+}
+
+pub fn client_config() -> Result<Builder, Error> {
+    let mut builder = Config::builder();
+    builder.set_security_policy(&DEFAULT_TLS13)?;
+    builder.trust_pem(CERT_PEM)?;
+    unsafe {
+        builder.disable_x509_verification()?;
+    }
+    Ok(builder)
+}
+
+pub fn server_config() -> Result<Builder, Error> {
+    let mut builder = Config::builder();
+    builder.set_security_policy(&DEFAULT_TLS13)?;
+    builder.load_pem(CERT_PEM, KEY_PEM)?;
+    Ok(builder)
+}
+
+pub async fn run_negotiate(
+    client: TlsConnector,
+    client_stream: TcpStream,
+    server: TlsAcceptor,
+    server_stream: TcpStream,
+) -> Result<(TlsStream<TcpStream>, TlsStream<TcpStream>), Error> {
+    tokio::try_join!(
+        client.connect("localhost", client_stream),
+        server.accept(server_stream)
+    )
+}

--- a/bindings/rust/s2n-tls-tokio/tests/handshake.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/handshake.rs
@@ -1,68 +1,28 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use s2n_tls::raw::{config::Config, connection::Version, error::Error, security::DEFAULT_TLS13};
-use s2n_tls_tokio::{TlsAcceptor, TlsConnector, TlsStream};
-use tokio::net::{TcpListener, TcpStream};
+use s2n_tls::raw::connection::Version;
+use s2n_tls_tokio::{TlsAcceptor, TlsConnector};
 
-/// NOTE: this certificate and key are used for testing purposes only!
-pub static CERT_PEM: &[u8] = include_bytes!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/examples/certs/cert.pem"
-));
-pub static KEY_PEM: &[u8] = include_bytes!(concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/examples/certs/key.pem"
-));
-
-async fn get_streams() -> Result<(TcpStream, TcpStream), tokio::io::Error> {
-    let localhost = "127.0.0.1".to_owned();
-    let listener = TcpListener::bind(format!("{}:0", localhost)).await?;
-    let addr = listener.local_addr()?;
-    let client_stream = TcpStream::connect(&addr).await?;
-    let (server_stream, _) = listener.accept().await?;
-    Ok((server_stream, client_stream))
-}
-
-async fn run_client(config: Config, stream: TcpStream) -> Result<TlsStream<TcpStream>, Error> {
-    let client = TlsConnector::new(config);
-    client.connect("localhost", stream).await
-}
-
-async fn run_server(config: Config, stream: TcpStream) -> Result<TlsStream<TcpStream>, Error> {
-    let server = TlsAcceptor::new(config);
-    server.accept(stream).await
-}
+mod common;
 
 #[tokio::test]
 async fn handshake_basic() -> Result<(), Box<dyn std::error::Error>> {
-    let (server_stream, client_stream) = get_streams().await?;
+    let (server_stream, client_stream) = common::get_streams().await?;
 
-    let mut client_config = Config::builder();
-    client_config.set_security_policy(&DEFAULT_TLS13)?;
-    client_config.trust_pem(CERT_PEM)?;
-    unsafe {
-        client_config.disable_x509_verification()?;
-    }
-    let client_config = client_config.build()?;
+    let client = TlsConnector::new(common::client_config()?.build()?);
+    let server = TlsAcceptor::new(common::server_config()?.build()?);
 
-    let mut server_config = Config::builder();
-    server_config.set_security_policy(&DEFAULT_TLS13)?;
-    server_config.load_pem(CERT_PEM, KEY_PEM)?;
-    let server_config = server_config.build()?;
-
-    let (client_result, server_result) = tokio::try_join!(
-        run_client(client_config, client_stream),
-        run_server(server_config, server_stream)
-    )?;
+    let (client_result, server_result) =
+        common::run_negotiate(client, client_stream, server, server_stream).await?;
 
     for tls in [client_result, server_result] {
         // Security policy ensures TLS1.3.
-        assert_eq!(tls.conn.actual_protocol_version()?, Version::TLS13);
+        assert_eq!(tls.get_ref().actual_protocol_version()?, Version::TLS13);
         // Handshake types may change, but will at least be negotiated.
-        assert!(tls.conn.handshake_type()?.contains("NEGOTIATED"));
+        assert!(tls.get_ref().handshake_type()?.contains("NEGOTIATED"));
         // Cipher suite may change, so just makes sure we can retrieve it.
-        assert!(tls.conn.cipher_suite().is_ok());
+        assert!(tls.get_ref().cipher_suite().is_ok());
     }
 
     Ok(())

--- a/bindings/rust/s2n-tls-tokio/tests/send_and_recv.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/send_and_recv.rs
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_tls_tokio::{TlsAcceptor, TlsConnector};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+mod common;
+
+const TEST_DATA: &[u8] = "hello world".as_bytes();
+
+#[tokio::test]
+async fn send_and_recv_basic() -> Result<(), Box<dyn std::error::Error>> {
+    let (server_stream, client_stream) = common::get_streams().await?;
+
+    let connector = TlsConnector::new(common::client_config()?.build()?);
+    let acceptor = TlsAcceptor::new(common::server_config()?.build()?);
+
+    let (mut client, mut server) =
+        common::run_negotiate(connector, client_stream, acceptor, server_stream).await?;
+
+    assert_eq!(client.write(TEST_DATA).await?, TEST_DATA.len());
+
+    let mut received = [0; TEST_DATA.len()];
+    assert_eq!(server.read(&mut received).await?, TEST_DATA.len());
+    assert_eq!(TEST_DATA, received);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn send_and_recv_multiple_records() -> Result<(), Box<dyn std::error::Error>> {
+    // The maximum TLS record payload is 2^14 bytes.
+    // Send more to ensure multiple records.
+    const LARGE_TEST_DATA: &[u8] = &[5; (1 << 15)];
+
+    let (server_stream, client_stream) = common::get_streams().await?;
+
+    let connector = TlsConnector::new(common::client_config()?.build()?);
+    let acceptor = TlsAcceptor::new(common::server_config()?.build()?);
+
+    let (mut client, mut server) =
+        common::run_negotiate(connector, client_stream, acceptor, server_stream).await?;
+
+    let mut received = [0; LARGE_TEST_DATA.len()];
+    let (write_size, read_size) = tokio::try_join!(
+        client.write(LARGE_TEST_DATA),
+        server.read_exact(&mut received)
+    )?;
+    assert_eq!(write_size, read_size);
+    assert_eq!(LARGE_TEST_DATA, received);
+
+    Ok(())
+}

--- a/bindings/rust/s2n-tls/src/raw/connection.rs
+++ b/bindings/rust/s2n-tls/src/raw/connection.rs
@@ -5,7 +5,7 @@
 
 use crate::raw::{
     config::Config,
-    error::{Error, Fallible},
+    error::{Error, Fallible, Pollable},
     security,
 };
 use core::{
@@ -362,10 +362,37 @@ impl Connection {
     pub fn negotiate(&mut self) -> Poll<Result<&mut Self, Error>> {
         let mut blocked = s2n_blocked_status::NOT_BLOCKED;
 
-        match unsafe { s2n_negotiate(self.connection.as_ptr(), &mut blocked).into_result() } {
-            Ok(_) => Ok(self).into(),
-            Err(err) if err.is_retryable() => Poll::Pending,
-            Err(err) => Err(err).into(),
+        unsafe {
+            s2n_negotiate(self.connection.as_ptr(), &mut blocked)
+                .into_poll()
+                .map_ok(|_| self)
+        }
+    }
+
+    pub fn send(&mut self, buf: &[u8]) -> Poll<Result<usize, Error>> {
+        let mut blocked = s2n_blocked_status::NOT_BLOCKED;
+        let buf_len: isize = buf.len().try_into().map_err(|_| Error::InvalidInput)?;
+        let buf_ptr = buf.as_ptr() as *const ::libc::c_void;
+        unsafe { s2n_send(self.connection.as_ptr(), buf_ptr, buf_len, &mut blocked).into_poll() }
+    }
+
+    pub fn recv(&mut self, buf: &mut [u8]) -> Poll<Result<usize, Error>> {
+        let mut blocked = s2n_blocked_status::NOT_BLOCKED;
+        let buf_len: isize = buf.len().try_into().map_err(|_| Error::InvalidInput)?;
+        let buf_ptr = buf.as_ptr() as *mut ::libc::c_void;
+        unsafe { s2n_recv(self.connection.as_ptr(), buf_ptr, buf_len, &mut blocked).into_poll() }
+    }
+
+    pub fn flush(&mut self) -> Poll<Result<&mut Self, Error>> {
+        self.send(&[0; 0]).map_ok(|_| self)
+    }
+
+    pub fn shutdown(&mut self) -> Poll<Result<&mut Self, Error>> {
+        let mut blocked = s2n_blocked_status::NOT_BLOCKED;
+        unsafe {
+            s2n_shutdown(self.connection.as_ptr(), &mut blocked)
+                .into_poll()
+                .map_ok(|_| self)
         }
     }
 

--- a/bindings/rust/s2n-tls/src/raw/error.rs
+++ b/bindings/rust/s2n-tls/src/raw/error.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use core::{fmt, ptr::NonNull};
+use core::{convert::TryInto, fmt, ptr::NonNull, task::Poll};
 use libc::c_char;
 use s2n_tls_sys::*;
 use std::ffi::CStr;
@@ -60,6 +60,16 @@ impl Fallible for s2n_status_code::Type {
     }
 }
 
+impl Fallible for isize {
+    type Output = usize;
+
+    fn into_result(self) -> Result<Self::Output, Error> {
+        // Negative values can't be converted to a real size
+        // and instead indicate an error.
+        self.try_into().map_err(|_| Error::capture())
+    }
+}
+
 impl<T> Fallible for *mut T {
     type Output = NonNull<T>;
 
@@ -80,6 +90,24 @@ impl<T> Fallible for *const T {
             Ok(self)
         } else {
             Err(Error::capture())
+        }
+    }
+}
+
+pub trait Pollable {
+    type Output;
+
+    fn into_poll(self) -> Poll<Result<Self::Output, Error>>;
+}
+
+impl<T: Fallible> Pollable for T {
+    type Output = T::Output;
+
+    fn into_poll(self) -> Poll<Result<Self::Output, Error>> {
+        match self.into_result() {
+            Ok(r) => Ok(r).into(),
+            Err(err) if err.is_retryable() => Poll::Pending,
+            Err(err) => Err(err).into(),
         }
     }
 }


### PR DESCRIPTION
### Description of changes: 

Add s2n_send and s2n_recv to the bindings, and implement AsyncRead and AsyncWrite to the tokio version.

### Call-outs:

* Read and write currently use the same waker. This is not a problem at the moment, because TlsConnection isn't Sync and doesn't support `split`, so the waker will always wake up the same task for both read and write. When we implement `split`, we will need to set separate wakers.
* I did not add echo to the examples yet. Without `split`, the implementation of echo is possible but kind of awkward: either IO could only flow in one direction, or I'd need to create a future that polled stdin and the tlsconnection sequentially. The implementation will be much cleaner with `split`.

### Testing:
Added two new tests. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
