### PR TITLE
Arithmetic overflow in s2n_check_record_limit

### DIFF
--- a/tls/s2n_key_update.c
+++ b/tls/s2n_key_update.c
@@ -110,7 +110,7 @@ int s2n_check_record_limit(struct s2n_connection *conn, struct s2n_blob *sequenc
     uint64_t output = 0;
     POSIX_GUARD(s2n_sequence_number_to_uint64(sequence_number, &output));
 
-    if (output + 1 > conn->secure.cipher_suite->record_alg->encryption_limit) {
+    if (output >= conn->secure.cipher_suite->record_alg->encryption_limit) {
         conn->key_update_pending = true;
     }
 


### PR DESCRIPTION
### Description of changes: 

There is a potential arithmetic overflow bug in `s2n_check_record_limit`.  The code increments a sequence number and then compares if the new value is strictly greater than then encryption limit.

There are two scenarios where this could be acceptable.
1. The first is if the overflow case is intentional from a design perspective.
2. The second is if we know that the input constraints on the sequence number will never result in a maximal value.

### Call-outs:

If arithmetic overflow is not possible in this exercise, can the reviewer provide an explanation to be used in formal verification proofs?

### Testing:

This case was observed using CBMC on the `s2n_check_record_limit` function.  With the submitted code change, the arithmetic overflow failure is resolved.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
