### PR TITLE
build(bindings): use cmake when building with pq feature

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -19,9 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest]
-    env:
-      S2N_LIBCRYPTO: openssl-1.1.1
-      TESTS: unit
     steps:
       - uses: actions/checkout@v2
 
@@ -33,28 +30,12 @@ jobs:
 
       - uses: camshaft/rust-cache@v1
 
-      - name: Install ubuntu depdendencies
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          sudo S2N_LIBCRYPTO=$S2N_LIBCRYPTO ./codebuild/bin/install_ubuntu_dependencies.sh
-          ./codebuild/bin/install_default_dependencies.sh
-
-      - name: Install macOS depdendencies
-        if: ${{ matrix.os == 'macOS-latest' }}
-        run: |
-          ./.github/install_osx_dependencies.sh
-          ./codebuild/bin/install_default_dependencies.sh
-
       - name: Generate
-        run: |
-          export OPENSSL_DIR="$(pwd)/test-deps/$S2N_LIBCRYPTO"
-          ./bindings/rust/generate.sh
+        run: ./bindings/rust/generate.sh
 
       - name: Test external build
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          export OPENSSL_DIR="test-deps/$S2N_LIBCRYPTO"
-
           cmake . -Bbuild -DBUILD_SHARED_LIBS=on -DBUILD_TESTING=off
           cmake --build build
 
@@ -68,9 +49,6 @@ jobs:
 
   rustfmt:
     runs-on: ubuntu-latest
-    env:
-      S2N_LIBCRYPTO: openssl-1.1.1
-      TESTS: unit
     steps:
       - uses: actions/checkout@v2
         with:
@@ -86,17 +64,10 @@ jobs:
 
       - uses: camshaft/rust-cache@v1
 
-      - name: Install ubuntu depdendencies
-        run: |
-          sudo S2N_LIBCRYPTO=$S2N_LIBCRYPTO ./codebuild/bin/install_ubuntu_dependencies.sh
-          ./codebuild/bin/install_default_dependencies.sh
-
       # We don't need to format the generated files,
       # but if they don't exist other code breaks.
       - name: Generate
-        run: |
-          export OPENSSL_DIR="$(pwd)/test-deps/$S2N_LIBCRYPTO"
-          ./bindings/rust/generate.sh
+        run: ./bindings/rust/generate.sh
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1.0.3
@@ -106,9 +77,6 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
-    env:
-      S2N_LIBCRYPTO: openssl-1.1.1
-      TESTS: unit
     steps:
       - uses: actions/checkout@v2
         with:
@@ -124,17 +92,10 @@ jobs:
 
       - uses: camshaft/rust-cache@v1
 
-      - name: Install ubuntu depdendencies
-        run: |
-          sudo S2N_LIBCRYPTO=$S2N_LIBCRYPTO ./codebuild/bin/install_ubuntu_dependencies.sh
-          ./codebuild/bin/install_default_dependencies.sh
-
       # We don't need to format the generated files,
       # but if they don't exist other code breaks.
       - name: Generate
-        run: |
-          export OPENSSL_DIR="$(pwd)/test-deps/$S2N_LIBCRYPTO"
-          ./bindings/rust/generate.sh
+        run: ./bindings/rust/generate.sh
 
       # TODO translate json reports to in-action warnings
       - name: Run cargo clippy

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -16,8 +16,12 @@ jobs:
   generate:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest]
+    env:
+      S2N_LIBCRYPTO: openssl-1.1.1
+      TESTS: unit
     steps:
       - uses: actions/checkout@v2
 
@@ -29,12 +33,28 @@ jobs:
 
       - uses: camshaft/rust-cache@v1
 
+      - name: Install ubuntu depdendencies
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          sudo S2N_LIBCRYPTO=$S2N_LIBCRYPTO ./codebuild/bin/install_ubuntu_dependencies.sh
+          ./codebuild/bin/install_default_dependencies.sh
+
+      - name: Install macOS depdendencies
+        if: ${{ matrix.os == 'macOS-latest' }}
+        run: |
+          ./.github/install_osx_dependencies.sh
+          ./codebuild/bin/install_default_dependencies.sh
+
       - name: Generate
-        run: ./bindings/rust/generate.sh
+        run: |
+          export OPENSSL_DIR="$(pwd)/test-deps/$S2N_LIBCRYPTO"
+          ./bindings/rust/generate.sh
 
       - name: Test external build
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
+          export OPENSSL_DIR="test-deps/$S2N_LIBCRYPTO"
+
           cmake . -Bbuild -DBUILD_SHARED_LIBS=on -DBUILD_TESTING=off
           cmake --build build
 
@@ -48,6 +68,9 @@ jobs:
 
   rustfmt:
     runs-on: ubuntu-latest
+    env:
+      S2N_LIBCRYPTO: openssl-1.1.1
+      TESTS: unit
     steps:
       - uses: actions/checkout@v2
         with:
@@ -63,10 +86,17 @@ jobs:
 
       - uses: camshaft/rust-cache@v1
 
+      - name: Install ubuntu depdendencies
+        run: |
+          sudo S2N_LIBCRYPTO=$S2N_LIBCRYPTO ./codebuild/bin/install_ubuntu_dependencies.sh
+          ./codebuild/bin/install_default_dependencies.sh
+
       # We don't need to format the generated files,
       # but if they don't exist other code breaks.
       - name: Generate
-        run: ./bindings/rust/generate.sh
+        run: |
+          export OPENSSL_DIR="$(pwd)/test-deps/$S2N_LIBCRYPTO"
+          ./bindings/rust/generate.sh
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1.0.3
@@ -76,8 +106,9 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
+    env:
+      S2N_LIBCRYPTO: openssl-1.1.1
+      TESTS: unit
     steps:
       - uses: actions/checkout@v2
         with:
@@ -93,10 +124,17 @@ jobs:
 
       - uses: camshaft/rust-cache@v1
 
+      - name: Install ubuntu depdendencies
+        run: |
+          sudo S2N_LIBCRYPTO=$S2N_LIBCRYPTO ./codebuild/bin/install_ubuntu_dependencies.sh
+          ./codebuild/bin/install_default_dependencies.sh
+
       # We don't need to format the generated files,
       # but if they don't exist other code breaks.
       - name: Generate
-        run: ./bindings/rust/generate.sh
+        run: |
+          export OPENSSL_DIR="$(pwd)/test-deps/$S2N_LIBCRYPTO"
+          ./bindings/rust/generate.sh
 
       # TODO translate json reports to in-action warnings
       - name: Run cargo clippy

--- a/bindings/rust/generate.sh
+++ b/bindings/rust/generate.sh
@@ -36,9 +36,9 @@ cd generate && cargo run -- ../s2n-tls-sys && cd ..
 cd s2n-tls-sys \
   && cargo test \
   && cargo test --features pq \
-  && cargo test --release \
   && cargo test --features quic \
   && cargo test --features internal \
+  && cargo test --release \
   && cd ..
 
 cd integration \

--- a/bindings/rust/generate.sh
+++ b/bindings/rust/generate.sh
@@ -24,12 +24,18 @@ cp -r \
   ../../tests/features \
   s2n-tls-sys/lib/tests/
 
+cp -r \
+  ../../CMakeLists.txt \
+  ../../cmake \
+  s2n-tls-sys/lib/
+
 # generate the bindings modules from the copied sources
 cd generate && cargo run -- ../s2n-tls-sys && cd ..
 
 # make sure everything builds and passes sanity checks
 cd s2n-tls-sys \
   && cargo test \
+  && cargo test --features pq \
   && cargo test --release \
   && cargo test --features quic \
   && cargo test --features internal \

--- a/bindings/rust/s2n-tls-sys/Cargo.toml
+++ b/bindings/rust/s2n-tls-sys/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 
 [features]
 default = []
-pq = []
+pq = ["cmake"] # the pq build logic is complicated so just use cmake instead
 quic = []
 internal = []
 
@@ -31,3 +31,4 @@ openssl-sys = { version = "0.9" }
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
+cmake = { version = "0.1", optional = true }

--- a/bindings/rust/s2n-tls-sys/Cargo.toml
+++ b/bindings/rust/s2n-tls-sys/Cargo.toml
@@ -32,3 +32,9 @@ openssl-sys = { version = "0.9" }
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
 cmake = { version = "0.1", optional = true }
+# Pin to this version until s2n-tls supports OpenSSL 3.0
+# Build the vendored version to make it easy to test in dev
+#
+# NOTE: The version of the `openssl-sys` crate is not the same as OpenSSL itself.
+#       Versions 1.0.1 - 3.0.0 are automatically discovered.
+openssl-sys = { version = "<= 0.9.68", features = ["vendored"] }

--- a/bindings/rust/s2n-tls-sys/build.rs
+++ b/bindings/rust/s2n-tls-sys/build.rs
@@ -8,6 +8,17 @@ fn main() {
     if external.is_enabled() {
         external.link();
     } else {
+        #[cfg(feature = "cmake")]
+        {
+            // branch on a runtime value so we don't get unused code warnings
+            if option_env("CARGO_FEATURE_CMAKE").is_some() {
+                build_cmake();
+            } else {
+                build_vendored();
+            }
+        }
+
+        #[cfg(not(feature = "cmake"))]
         build_vendored();
     }
 }
@@ -60,7 +71,7 @@ fn build_vendored() {
 
     // TODO each pq section needs to be built separately since it
     //      has its own relative include paths
-    assert!(!pq, "pq builds are not currently supported");
+    assert!(!pq, "pq builds are not currently supported without cmake");
 
     build.files(include!("./files.rs").iter().copied().filter(|file| {
         // the pq entry file is still needed
@@ -133,6 +144,39 @@ fn build_vendored() {
     std::fs::create_dir_all(&include_dir).unwrap();
     std::fs::copy("lib/api/s2n.h", include_dir.join("s2n.h")).unwrap();
     println!("cargo:include={}", include_dir.display());
+}
+
+#[cfg(feature = "cmake")]
+fn build_cmake() {
+    let mut config = cmake::Config::new("lib");
+
+    config
+        .register_dep("openssl")
+        .configure_arg("-DBUILD_TESTING=off");
+
+    if option_env("CARGO_FEATURE_PQ").is_none() {
+        config.configure_arg("-DS2N_NO_PQ=on");
+    }
+
+    let dst = config.build();
+
+    // tell rust we're linking with libcrypto
+    println!("cargo:rustc-link-lib=crypto");
+
+    // link the built artifact
+    println!("cargo:rustc-link-lib=s2n");
+
+    fn search(path: PathBuf) {
+        if path.exists() {
+            println!("cargo:rustc-link-search=native={}", path.display());
+        }
+    }
+
+    search(dst.join("lib64"));
+    search(dst.join("lib"));
+    search(dst.join("build").join("lib"));
+
+    println!("cargo:include={}", dst.join("include").display());
 }
 
 struct External {

--- a/bindings/rust/s2n-tls/src/raw/security.rs
+++ b/bindings/rust/s2n-tls/src/raw/security.rs
@@ -31,4 +31,12 @@ macro_rules! policy {
 policy!(DEFAULT, "default");
 policy!(DEFAULT_TLS13, "default_tls13");
 
-pub const ALL_POLICIES: &[Policy] = &[DEFAULT, DEFAULT_TLS13];
+#[cfg(feature = "pq")]
+policy!(TESTING_PQ, "PQ-TLS-1-0-2021-05-26");
+
+pub const ALL_POLICIES: &[Policy] = &[
+    DEFAULT,
+    DEFAULT_TLS13,
+    #[cfg(feature = "pq")]
+    TESTING_PQ,
+];

--- a/codebuild/bin/install_openssl_1_1_1.sh
+++ b/codebuild/bin/install_openssl_1_1_1.sh
@@ -39,7 +39,7 @@ cd openssl-OpenSSL_${RELEASE}
 
 if [ "$OS_NAME" == "linux" ]; then
     CONFIGURE="./config -d"
-elif [ "$OS_NAME" == "osx" ]; then
+elif [[ "$OS_NAME" == "osx" || "$OS_NAME" == "darwin" ]]; then
     CONFIGURE="./Configure darwin64-x86_64-cc"
 else
     echo "Invalid platform! $OS_NAME"


### PR DESCRIPTION
### Description of changes: 

We currently don't have support for building the rust bindings when vendored with PQ support. The PQ crypto build logic is quite complicated so it hasn't been ported to the `build.rs`.

Instead of porting the logic, this PR builds s2n-tls with cmake when the PQ feature is enabled. This is a lot less work _but_ does require that cmake is installed on the build machine.

### Testing:

I've added `cargo test --features pq` to our `generate.sh` script to catch any issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
