### PR TITLE
fix(s2n-tls-sys): add cmake files to the include directive

### DIFF
--- a/bindings/rust/generate.sh
+++ b/bindings/rust/generate.sh
@@ -2,6 +2,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+set -e
+
 # cd into the script directory so it can be executed from anywhere
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
@@ -39,6 +41,8 @@ cd s2n-tls-sys \
   && cargo test --features quic \
   && cargo test --features internal \
   && cargo test --release \
+  && cargo publish --dry-run --allow-dirty \
+  && cargo publish --dry-run --allow-dirty --all-features \
   && cd ..
 
 cd integration \

--- a/bindings/rust/s2n-tls-sys/Cargo.toml
+++ b/bindings/rust/s2n-tls-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-sys"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["AWS s2n"]
 edition = "2018"
 links = "s2n-tls"
@@ -13,6 +13,9 @@ include = [
   "files.rs",
   "lib/**/*.c",
   "lib/**/*.h",
+  "lib/**/*.S",
+  "lib/CMakeLists.txt",
+  "lib/**/*.cmake",
   "src/**/*.rs",
   "tests/**/*.rs",
 ]

--- a/bindings/rust/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/s2n-tls-tokio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-tokio"
 description = "An implementation of TLS streams for Tokio built on top of s2n-tls"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["AWS s2n"]
 edition = "2018"
 repository = "https://github.com/aws/s2n-tls"
@@ -13,7 +13,7 @@ default = []
 [dependencies]
 errno = { version = "0.2" }
 libc = { version = "0.2" }
-s2n-tls = { version = "=0.0.6", path = "../s2n-tls" }
+s2n-tls = { version = "=0.0.7", path = "../s2n-tls" }
 tokio = { version = "1", features = ["net"] }
 
 [dev-dependencies]

--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["AWS s2n"]
 edition = "2018"
 repository = "https://github.com/aws/s2n-tls"
@@ -17,7 +17,7 @@ testing = ["errno", "bytes"]
 bytes = { version = "1", optional = true }
 errno = { version = "0.2", optional = true }
 libc = "0.2"
-s2n-tls-sys = { version = "=0.0.6", path = "../s2n-tls-sys", features = ["internal"] }
+s2n-tls-sys = { version = "=0.0.7", path = "../s2n-tls-sys", features = ["internal"] }
 
 [dev-dependencies]
 bytes = { version = "1" }


### PR DESCRIPTION
### Description of changes: 

In #3294, I added support for building the rust bindings with cmake. Unfortunately I forgot to add the cmake files to the included list of files for the `Cargo.toml` so they didn't end up getting published.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
