### PR TITLE
[bindings] Clean up async behavior

### DIFF
--- a/bindings/rust/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/s2n-tls-tokio/Cargo.toml
@@ -18,4 +18,4 @@ tokio = { version = "1", features = ["net"] }
 
 [dev-dependencies]
 clap = { version = "3.1", features = ["derive"] }
-tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread"] }
+tokio = { version = "1", features = [ "io-std", "io-util", "macros", "net", "rt-multi-thread"] }

--- a/bindings/rust/s2n-tls-tokio/examples/client.rs
+++ b/bindings/rust/s2n-tls-tokio/examples/client.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use s2n_tls::raw::{config::Config, security::DEFAULT_TLS13};
 use s2n_tls_tokio::TlsConnector;
 use std::{error::Error, fs};
-use tokio::net::TcpStream;
+use tokio::{io::AsyncWriteExt, net::TcpStream};
 
 /// NOTE: this certificate is to be used for demonstration purposes only!
 const DEFAULT_CERT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/certs/cert.pem");
@@ -32,7 +32,20 @@ async fn run_client(trust_pem: &[u8], addr: &str) -> Result<(), Box<dyn Error>> 
     let tls = client.connect("localhost", stream).await?;
     println!("{:#?}", tls);
 
-    // TODO: echo
+    // Split the stream.
+    // This allows us to call read and write from different tasks.
+    let (mut reader, mut writer) = tokio::io::split(tls);
+
+    // Copy data from the server to stdout
+    tokio::spawn(async move {
+        let mut stdout = tokio::io::stdout();
+        tokio::io::copy(&mut reader, &mut stdout).await
+    });
+
+    // Send data from stdin to the server
+    let mut stdin = tokio::io::stdin();
+    tokio::io::copy(&mut stdin, &mut writer).await?;
+    writer.shutdown().await?;
 
     Ok(())
 }

--- a/bindings/rust/s2n-tls-tokio/src/lib.rs
+++ b/bindings/rust/s2n-tls-tokio/src/lib.rs
@@ -17,6 +17,7 @@ use std::{
 };
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
+#[derive(Clone)]
 pub struct TlsAcceptor {
     config: Config,
 }
@@ -30,10 +31,11 @@ impl TlsAcceptor {
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
-        TlsStream::open(self.config.clone(), Mode::Server, stream).await
+        TlsStream::open(&self.config, Mode::Server, stream).await
     }
 }
 
+#[derive(Clone)]
 pub struct TlsConnector {
     config: Config,
 }
@@ -47,7 +49,7 @@ impl TlsConnector {
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
-        TlsStream::open(self.config.clone(), Mode::Client, stream).await
+        TlsStream::open(&self.config, Mode::Client, stream).await
     }
 }
 
@@ -62,9 +64,8 @@ where
     type Output = Result<(), Error>;
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.tls.with_io(|context| {
+        self.tls.with_io(ctx, |context| {
             let conn = context.get_mut().get_mut();
-            conn.set_waker(Some(ctx.waker()))?;
             conn.negotiate().map(|r| r.map(|_| ()))
         })
     }
@@ -79,16 +80,16 @@ impl<S> TlsStream<S>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
-    async fn open(config: Config, mode: Mode, stream: S) -> Result<Self, Error> {
+    async fn open(config: &Config, mode: Mode, stream: S) -> Result<Self, Error> {
         let mut conn = Connection::new(mode);
-        conn.set_config(config)?;
+        conn.set_config(config.clone())?;
 
         let mut tls = TlsStream { conn, stream };
         TlsHandshake { tls: &mut tls }.await?;
         Ok(tls)
     }
 
-    fn with_io<F, R>(&mut self, action: F) -> Poll<Result<R, Error>>
+    fn with_io<F, R>(&mut self, ctx: &mut Context, action: F) -> Poll<Result<R, Error>>
     where
         F: FnOnce(Pin<&mut Self>) -> Poll<Result<R, Error>>,
     {
@@ -103,6 +104,7 @@ where
             self.conn.set_send_callback(Some(Self::send_io_cb))?;
             self.conn.set_receive_context(context)?;
             self.conn.set_send_context(context)?;
+            self.conn.set_waker(Some(ctx.waker()))?;
 
             let result = action(Pin::new(self));
 
@@ -170,8 +172,7 @@ where
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
         self.get_mut()
-            .with_io(|mut context| {
-                context.conn.set_waker(Some(ctx.waker()))?;
+            .with_io(ctx, |mut context| {
                 context.conn.recv(buf.initialize_unfilled()).map_ok(|size| {
                     buf.advance(size);
                 })
@@ -190,18 +191,14 @@ where
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         self.get_mut()
-            .with_io(|mut context| {
-                context.conn.set_waker(Some(ctx.waker()))?;
-                context.conn.send(buf)
-            })
+            .with_io(ctx, |mut context| context.conn.send(buf))
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
     }
 
     fn poll_flush(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let tls = self.get_mut();
         let tls_flush = tls
-            .with_io(|mut context| {
-                context.conn.set_waker(Some(ctx.waker()))?;
+            .with_io(ctx, |mut context| {
                 context.conn.flush().map(|r| r.map(|_| ()))
             })
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e));
@@ -215,8 +212,7 @@ where
     fn poll_shutdown(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let tls = self.get_mut();
         let tls_shutdown = tls
-            .with_io(|mut context| {
-                context.conn.set_waker(Some(ctx.waker()))?;
+            .with_io(ctx, |mut context| {
                 context.conn.shutdown().map(|r| r.map(|_| ()))
             })
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e));

--- a/bindings/rust/s2n-tls-tokio/src/lib.rs
+++ b/bindings/rust/s2n-tls-tokio/src/lib.rs
@@ -31,7 +31,7 @@ impl TlsAcceptor {
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
-        TlsStream::open(&self.config, Mode::Server, stream).await
+        TlsStream::open(self.config.clone(), Mode::Server, stream).await
     }
 }
 
@@ -49,7 +49,7 @@ impl TlsConnector {
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
-        TlsStream::open(&self.config, Mode::Client, stream).await
+        TlsStream::open(self.config.clone(), Mode::Client, stream).await
     }
 }
 
@@ -80,9 +80,9 @@ impl<S> TlsStream<S>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
-    async fn open(config: &Config, mode: Mode, stream: S) -> Result<Self, Error> {
+    async fn open(config: Config, mode: Mode, stream: S) -> Result<Self, Error> {
         let mut conn = Connection::new(mode);
-        conn.set_config(config.clone())?;
+        conn.set_config(config)?;
 
         let mut tls = TlsStream { conn, stream };
         TlsHandshake { tls: &mut tls }.await?;

--- a/bindings/rust/s2n-tls-tokio/tests/send_and_recv.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/send_and_recv.rs
@@ -8,6 +8,10 @@ mod common;
 
 const TEST_DATA: &[u8] = "hello world".as_bytes();
 
+// The maximum TLS record payload is 2^14 bytes.
+// Send more to ensure multiple records.
+const LARGE_TEST_DATA: &[u8] = &[5; (1 << 15)];
+
 #[tokio::test]
 async fn send_and_recv_basic() -> Result<(), Box<dyn std::error::Error>> {
     let (server_stream, client_stream) = common::get_streams().await?;
@@ -29,10 +33,6 @@ async fn send_and_recv_basic() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test]
 async fn send_and_recv_multiple_records() -> Result<(), Box<dyn std::error::Error>> {
-    // The maximum TLS record payload is 2^14 bytes.
-    // Send more to ensure multiple records.
-    const LARGE_TEST_DATA: &[u8] = &[5; (1 << 15)];
-
     let (server_stream, client_stream) = common::get_streams().await?;
 
     let connector = TlsConnector::new(common::client_config()?.build()?);
@@ -48,6 +48,36 @@ async fn send_and_recv_multiple_records() -> Result<(), Box<dyn std::error::Erro
     )?;
     assert_eq!(LARGE_TEST_DATA.len(), read_size);
     assert_eq!(LARGE_TEST_DATA, received);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn send_and_recv_split() -> Result<(), Box<dyn std::error::Error>> {
+    let (server_stream, client_stream) = common::get_streams().await?;
+
+    let connector = TlsConnector::new(common::client_config()?.build()?);
+    let acceptor = TlsAcceptor::new(common::server_config()?.build()?);
+
+    let (client, server) =
+        common::run_negotiate(connector, client_stream, acceptor, server_stream).await?;
+
+    let (mut client_read, mut client_write) = tokio::io::split(client);
+    let (mut server_read, mut server_write) = tokio::io::split(server);
+
+    let mut client_received = [0; LARGE_TEST_DATA.len()];
+    let mut server_received = [0; LARGE_TEST_DATA.len()];
+    let (_, _, client_bytes, server_bytes) = tokio::try_join!(
+        client_write.write_all(LARGE_TEST_DATA),
+        server_write.write_all(LARGE_TEST_DATA),
+        client_read.read_exact(&mut client_received),
+        server_read.read_exact(&mut server_received)
+    )?;
+
+    assert_eq!(client_bytes, LARGE_TEST_DATA.len());
+    assert_eq!(server_bytes, LARGE_TEST_DATA.len());
+    assert_eq!(LARGE_TEST_DATA, client_received);
+    assert_eq!(LARGE_TEST_DATA, server_received);
 
     Ok(())
 }

--- a/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
@@ -1,27 +1,36 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use s2n_tls::raw::error;
 use s2n_tls_tokio::{TlsAcceptor, TlsConnector, TlsStream};
+use std::convert::TryFrom;
 use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
+    io::{AsyncReadExt, AsyncWrite, AsyncWriteExt},
     net::TcpStream,
 };
 
 mod common;
 
-async fn listen_for_shutdown(
-    stream: &mut TlsStream<TcpStream>,
-) -> Result<(), Box<dyn std::error::Error>> {
+async fn read_until_shutdown(stream: &mut TlsStream<TcpStream>) -> Result<(), std::io::Error> {
     let mut received = [0; 1];
     // Zero bytes read indicates EOF
-    assert_eq!(stream.read(&mut received).await?, 0);
-    stream.shutdown().await?;
-    Ok(())
+    while stream.read(&mut received).await? != 0 {}
+    stream.shutdown().await
 }
 
-async fn shutdown(stream: &mut TlsStream<TcpStream>) -> Result<(), Box<dyn std::error::Error>> {
-    stream.shutdown().await?;
-    Ok(())
+async fn write_until_shutdown<S: AsyncWrite + Unpin>(stream: &mut S) -> Result<(), std::io::Error> {
+    let sent = [0; 1];
+    loop {
+        let r = stream.write(&sent).await;
+        if r.is_ok() {
+            continue;
+        } else {
+            let tls_err = error::Error::try_from(r.unwrap_err()).unwrap();
+            assert_eq!(tls_err.kind(), Some(error::ErrorType::ConnectionClosed));
+            break;
+        }
+    }
+    stream.shutdown().await
 }
 
 #[tokio::test]
@@ -34,7 +43,7 @@ async fn client_initiated_shutdown() -> Result<(), Box<dyn std::error::Error>> {
     let (mut client, mut server) =
         common::run_negotiate(client, client_stream, server, server_stream).await?;
 
-    tokio::try_join!(listen_for_shutdown(&mut server), shutdown(&mut client))?;
+    tokio::try_join!(read_until_shutdown(&mut server), client.shutdown())?;
 
     Ok(())
 }
@@ -49,7 +58,29 @@ async fn server_initiated_shutdown() -> Result<(), Box<dyn std::error::Error>> {
     let (mut client, mut server) =
         common::run_negotiate(client, client_stream, server, server_stream).await?;
 
-    tokio::try_join!(listen_for_shutdown(&mut client), shutdown(&mut server))?;
+    tokio::try_join!(read_until_shutdown(&mut client), server.shutdown())?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn shutdown_after_split() -> Result<(), Box<dyn std::error::Error>> {
+    let (server_stream, client_stream) = common::get_streams().await?;
+
+    let client = TlsConnector::new(common::client_config()?.build()?);
+    let server = TlsAcceptor::new(common::server_config()?.build()?);
+
+    let (client, mut server) =
+        common::run_negotiate(client, client_stream, server, server_stream).await?;
+
+    let (mut client_reader, mut client_writer) = tokio::io::split(client);
+
+    let mut received = [0; 1];
+    tokio::try_join!(
+        server.shutdown(),
+        client_reader.read(&mut received),
+        write_until_shutdown(&mut client_writer),
+    )?;
 
     Ok(())
 }

--- a/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
@@ -21,11 +21,8 @@ async fn read_until_shutdown(stream: &mut TlsStream<TcpStream>) -> Result<(), st
 async fn write_until_shutdown<S: AsyncWrite + Unpin>(stream: &mut S) -> Result<(), std::io::Error> {
     let sent = [0; 1];
     loop {
-        let r = stream.write(&sent).await;
-        if r.is_ok() {
-            continue;
-        } else {
-            let tls_err = error::Error::try_from(r.unwrap_err()).unwrap();
+        if let Err(err) = stream.write(&sent).await {
+            let tls_err = error::Error::try_from(err).unwrap();
             assert_eq!(tls_err.kind(), Some(error::ErrorType::ConnectionClosed));
             break;
         }

--- a/bindings/rust/s2n-tls/src/raw/config.rs
+++ b/bindings/rust/s2n-tls/src/raw/config.rs
@@ -21,6 +21,12 @@ pub struct Config(NonNull<s2n_config>);
 /// Safety: s2n_config objects can be sent across threads
 unsafe impl Send for Config {}
 
+/// # Safety
+///
+/// Safety: All C methods that mutate the s2n_config are wrapped
+/// in Rust methods that require a mutable reference.
+unsafe impl Sync for Config {}
+
 impl Config {
     /// Returns a Config object with pre-defined defaults.
     ///

--- a/bindings/rust/s2n-tls/src/raw/connection.rs
+++ b/bindings/rust/s2n-tls/src/raw/connection.rs
@@ -111,6 +111,12 @@ impl fmt::Debug for Connection {
 /// Safety: s2n_connection objects can be sent across threads
 unsafe impl Send for Connection {}
 
+/// # Safety
+///
+/// Safety: All C methods that mutate the s2n_connection are wrapped
+/// in Rust methods that require a mutable reference.
+unsafe impl Sync for Connection {}
+
 impl Connection {
     pub fn new(mode: Mode) -> Self {
         crate::raw::init::init();


### PR DESCRIPTION
### Description of changes: 

I was definitely over thinking the split behavior. TlsStreams behave as expected with tokio's split method.

I did need to mark Config as Sync in order to use TlsAcceptor / TlsConnector in spawned tasks (like to offload the handshake). This is correct-- the underlying C structs wouldn't be Sync, but because we only allow modifications via Rust methods that use &mut correctly, the Rust wrapper structs are. I made the same change for Connection while I was at it.

I also did some minor cleanup, like removing all the duplicate calls to set the wakers.

### Call-outs:

* Tokio automatically handles split safely by locking access to the inner stream: https://docs.rs/tokio/0.2.5/src/tokio/io/split.rs.html#35-51 So TlsStream doesn't actually have to be threadsafe. This probably isn't the most efficient way to handle split, but we can always add an optimized TlsStream::split later if necessary.
* From [the Sync docs](https://doc.rust-lang.org/std/marker/trait.Sync.html): "Types that are not Sync are those that have “interior mutability” in a non-thread-safe form, such as [Cell](https://doc.rust-lang.org/std/cell/struct.Cell.html) and RefCell. These types allow for mutation of their contents even through an immutable, shared reference."
### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
