### PR TITLE
Implement Sync trait in config

### DIFF
--- a/bindings/rust/s2n-tls/src/raw/config.rs
+++ b/bindings/rust/s2n-tls/src/raw/config.rs
@@ -20,6 +20,7 @@ pub struct Config(NonNull<s2n_config>);
 ///
 /// Safety: s2n_config objects can be sent across threads
 unsafe impl Send for Config {}
+unsafe impl Sync for Config {}
 
 impl Config {
     /// Returns a Config object with pre-defined defaults.


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

Additionally implements the Sync trait for Config, along with the Send trait, to indicate that Configs are safe to share between threads.

### Call-outs:

None

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
