### PR TITLE
Fixes for CBMC_ENSURE_REF

### DIFF
--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -14,6 +14,7 @@
  */
 
 #include <cbmc_proof/make_common_datastructures.h>
+#include <utils/s2n_safety_macros.h>
 
 bool s2n_blob_is_bounded(const struct s2n_blob *blob, const size_t max_size) { return (blob->size <= max_size); }
 
@@ -359,7 +360,7 @@ struct s2n_ecc_preferences *cbmc_allocate_s2n_ecc_preferences()
 struct s2n_security_policy *cbmc_allocate_s2n_security_policy()
 {
     struct s2n_security_policy *s2n_security_policy = malloc(sizeof(*s2n_security_policy));
-    CBMC_ENSURE_REF(s2n_security_policy);
+    PTR_ENSURE_REF(s2n_security_policy);
     s2n_security_policy->cipher_preferences                = cbmc_allocate_s2n_cipher_preferences();
     s2n_security_policy->kem_preferences                   = cbmc_allocate_s2n_kem_preferences();
     s2n_security_policy->signature_preferences             = cbmc_allocate_s2n_signature_preferences();
@@ -383,7 +384,7 @@ void cbmc_populate_s2n_x509_trust_store(struct s2n_x509_trust_store *s2n_x509_tr
 struct s2n_config *cbmc_allocate_s2n_config()
 {
     struct s2n_config *s2n_config = malloc(sizeof(*s2n_config));
-    CBMC_ENSURE_REF(s2n_config);
+    PTR_ENSURE_REF(s2n_config);
     s2n_config->dhparams                = cbmc_allocate_dh_params();
     s2n_config->domain_name_to_cert_map = cbmc_allocate_s2n_map();
     /* `s2n_config->default_certs_by_type` is never allocated.
@@ -478,7 +479,7 @@ struct s2n_kem *cbmc_allocate_s2n_kem()
 struct s2n_kem_group *cbmc_allocate_s2n_kem_group()
 {
     struct s2n_kem_group *s2n_kem_group = malloc(sizeof(*s2n_kem_group));
-    CBMC_ENSURE_REF(s2n_kem_group);
+    PTR_ENSURE_REF(s2n_kem_group);
     /* `s2n_kem_group->name` is never allocated.
      * If required, this initialization should be done in the proof harness.
      */
@@ -554,7 +555,7 @@ struct s2n_cipher *cbmc_allocate_s2n_cipher()
 struct s2n_record_algorithm *cbmc_allocate_s2n_record_algorithm()
 {
     struct s2n_record_algorithm *s2n_record_algorithm = malloc(sizeof(*s2n_record_algorithm));
-    CBMC_ENSURE_REF(s2n_record_algorithm);
+    PTR_ENSURE_REF(s2n_record_algorithm);
     s2n_record_algorithm->cipher = cbmc_allocate_s2n_cipher();
     return s2n_record_algorithm;
 }
@@ -562,7 +563,7 @@ struct s2n_record_algorithm *cbmc_allocate_s2n_record_algorithm()
 struct s2n_cipher_suite *cbmc_allocate_s2n_cipher_suite()
 {
     struct s2n_cipher_suite *s2n_cipher_suite = malloc(sizeof(*s2n_cipher_suite));
-    CBMC_ENSURE_REF(s2n_cipher_suite);
+    PTR_ENSURE_REF(s2n_cipher_suite);
     /* `s2n_cipher_suite->name`
      * `s2n_cipher_suite->all_record_algs`
      * `s2n_cipher_suite->sslv3_cipher_suite` are never allocated.


### PR DESCRIPTION
### Description of changes: 

Changes add a version of `CBMC_ENSURE_REF` that returns NULL in functions with non-void return type.

Some of the CBMC proof collateral makes calls to `CBMC_ENSURE_REF`, which checks the validity of a pointer and returns if the pointer is invalid.  This macro provides an early escape from functions where s2n structures are populated.  Usage of this macro should be limited to functions with a void return type, but it was also used in situations where a pointer was expected.

The addition of `CBMC_ENSURE_REF_RETURN_NULL` will fix these problems in the collateral.

### Testing:

Tested locally on CBMC proofs.  Should not impact s2n-tls source.
