### PR TITLE
Improve cmake logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,8 +497,12 @@ if (TARGET crypto)
     set(LINK_LIB "crypto")
 else()
     find_package(crypto REQUIRED)
-    message("Using libcrypto from the cmake path.")
+    message(STATUS "Using libcrypto from the cmake path")
     set(LINK_LIB "AWS::crypto")
+endif()
+
+if (S2N_INTERN_LIBCRYPTO)
+    message(STATUS "Enabling libcrypto interning")
 endif()
 
 # Determine if EVP_md5_sha1 is available in libcrypto


### PR DESCRIPTION
### Description of changes: 

cmake log statements looks something like this:
```
cmake3 [...]
-- The C compiler identification is GNU 7.3.1
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
[...]
-- LibCrypto Static Lib:  /home/[...]/libcrypto.a
Using libcrypto from the cmake path.
-- Configuring done
-- Generating done
[...]
```

This PR just ensures `Using libcrypto from the cmake path.` is printed as `STATUS` and adds a log output for the interning feature. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
