### PR TITLE
Use CaDiCaL solver for s2n_stuffer_private_key_from_pem proof

### DIFF
--- a/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/Makefile
@@ -17,6 +17,7 @@ DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
 
 CHECKFLAGS +=
 
+USE_EXTERNAL_SAT_SOLVER ?= --external-sat-solver cadical
 PROOF_UID = s2n_stuffer_private_key_from_pem
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c


### PR DESCRIPTION
### Resolved issues:
N/A.

### Description of changes: 

There is currently a proof failure in CI. The proof is timing out after 6h. We use Kissat as back-end SAT solver for this all proofs, which takes too long to solve the resulting formula from the `s2n_stuffer_private_key_from_pem` proof. This PR updates this proof to use CaDiCaL solver, which showed to be more efficient in this case.

### Call-outs:
N/A.

### Testing:
N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
