### PR TITLE
fix(bindings-rust): move vendored openssl-sys to dev-dependency

### DIFF
--- a/bindings/rust/generate.sh
+++ b/bindings/rust/generate.sh
@@ -7,6 +7,8 @@ set -e
 # cd into the script directory so it can be executed from anywhere
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
+# delete the existing copy in case we have extra files
+rm -rf s2n-tls-sys/lib
 mkdir -p s2n-tls-sys/lib
 mkdir -p s2n-tls-sys/lib/tests
 

--- a/bindings/rust/s2n-tls-sys/Cargo.toml
+++ b/bindings/rust/s2n-tls-sys/Cargo.toml
@@ -35,6 +35,8 @@ openssl-sys = { version = "0.9" }
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
 cmake = { version = "0.1", optional = true }
+
+[dev-dependencies]
 # Pin to this version until s2n-tls supports OpenSSL 3.0
 # Build the vendored version to make it easy to test in dev
 #


### PR DESCRIPTION
### Description of changes: 

In #3294, I mistakenly put the vendored `openssl-sys` in the build-dependencies, when it should have gone in the `dev-dependencies` instead. This issue forces applications to build a vendored version on openssl, even though that may not be wanted.

```
   Compiling autocfg v1.1.0
   Compiling pkg-config v0.3.25
   Compiling jobserver v0.1.24
   Compiling cc v1.0.73
   Compiling openssl-src v111.18.0+1.1.1n
   Compiling openssl-sys v0.9.68
   Compiling s2n-tls-sys v0.0.7
```

### Testing:

After moving this to `dev-dependencies` you can see openssl is no longer built from source in another application:

```
   Compiling autocfg v1.1.0
   Compiling pkg-config v0.3.25
   Compiling jobserver v0.1.24
   Compiling cc v1.0.73
   Compiling openssl-sys v0.9.68
   Compiling s2n-tls-sys v0.0.7
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
