### PR TITLE
doc fix: Update documentation for s2n_connection_get_cipher.

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2721,6 +2721,13 @@ extern int s2n_connection_client_cert_used(struct s2n_connection *conn);
 /**
  * A function that provides a human readable string of the cipher suite that was chosen
  * for a connection.
+ *
+ * @warning The string "TLS_NULL_WITH_NULL_NULL" is returned before the TLS handshake has been performed.
+ * This does not mean that the ciphersuite "TLS_NULL_WITH_NULL_NULL" will be used by the connection,
+ * it is merely being used as a placeholder.
+ *
+ * @note This function is only accurate after the TLS handshake.
+ *
  * @param conn A pointer to the connection
  * @returns A string indicating the cipher suite negotiated by s2n in OpenSSL format.
  */


### PR DESCRIPTION
### Resolved issues:

 Resolves https://github.com/aws/s2n-tls/issues/2766.

### Description of changes: 

The behavior of is misleading and can be confusing for users. This expands on the existing documentation to try to address the points made in https://github.com/aws/s2n-tls/issues/2766.

### Call-outs:

No

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
 N/A

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?
 N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
