### PR TITLE
Add AES256-GCM-SHA384 to 20210816 security policies

### DIFF
--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -1747,6 +1747,7 @@ struct s2n_cipher_suite *cipher_suites_20210816[] = {
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
     &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_256_gcm_sha384,
 };
 
 const struct s2n_cipher_preferences cipher_preferences_20210816 = {
@@ -1757,6 +1758,7 @@ const struct s2n_cipher_preferences cipher_preferences_20210816 = {
 struct s2n_cipher_suite *cipher_suites_20210816_gcm[] = {
     &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
 };


### PR DESCRIPTION
This cipher, though it uses RSA key exchange is allowed under the
standard[1] that these security policies conform to. RSA key exchange is
not ideal, however some clients may not support ECDHE key exchange.
Since these are the first policies that support CNSA, I think it makes
more sense to modify the old policies to support more compatibility
and add a *new* hardened CNSA policy if needed.

[1] https://datatracker.ietf.org/doc/html/rfc9151
