### PR TITLE
fix: Add option to disable stacktrace feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ option(S2N_INTERN_LIBCRYPTO "This ensures that s2n-tls is compiled and deployed 
 version of libcrypto by interning the code and hiding symbols. This also enables s2n-tls to be
 loaded in an application with an otherwise conflicting libcrypto version." OFF)
 option(S2N_LTO, "Enables link time optimizations when building s2n-tls." OFF)
+option(S2N_NO_STACKTRACE "Disables stacktrace functionality in s2n-tls." OFF)
+
 # Turn BUILD_TESTING=ON by default
 include(CTest)
 
@@ -434,8 +436,8 @@ if(ADX_SUPPORTED)
     message(STATUS "Support for ADX assembly instructions detected")
 endif()
 
-if(S2N_HAVE_EXECINFO)
-    target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_HAVE_EXECINFO)
+if(NOT S2N_HAVE_EXECINFO OR S2N_NO_STACKTRACE)
+    target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_NO_STACKTRACE)
 endif()
 
 if(S2N_CPUID_AVAILABLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ option(S2N_INTERN_LIBCRYPTO "This ensures that s2n-tls is compiled and deployed 
 version of libcrypto by interning the code and hiding symbols. This also enables s2n-tls to be
 loaded in an application with an otherwise conflicting libcrypto version." OFF)
 option(S2N_LTO, "Enables link time optimizations when building s2n-tls." OFF)
-option(S2N_NO_STACKTRACE "Disables stacktrace functionality in s2n-tls." OFF)
+option(S2N_STACKTRACE "Enables stacktrace functionality in s2n-tls." ON)
 
 # Turn BUILD_TESTING=ON by default
 include(CTest)
@@ -436,8 +436,9 @@ if(ADX_SUPPORTED)
     message(STATUS "Support for ADX assembly instructions detected")
 endif()
 
-if(NOT S2N_HAVE_EXECINFO OR S2N_NO_STACKTRACE)
-    target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_NO_STACKTRACE)
+if(S2N_HAVE_EXECINFO AND S2N_STACKTRACE)
+    target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_STACKTRACE)
+else()
     message(STATUS "Disabling stacktrace functionality")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,6 +438,7 @@ endif()
 
 if(NOT S2N_HAVE_EXECINFO OR S2N_NO_STACKTRACE)
     target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_NO_STACKTRACE)
+    message(STATUS "Disabling stacktrace functionality")
 endif()
 
 if(S2N_CPUID_AVAILABLE)

--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -24,7 +24,7 @@
 #include "utils/s2n_map.h"
 #include "utils/s2n_safety.h"
 
-#ifndef S2N_NO_STACKTRACE
+#ifdef S2N_STACKTRACE
 #   include <execinfo.h>
 #endif
 
@@ -367,7 +367,7 @@ int s2n_stack_traces_enabled_set(bool newval)
     return S2N_SUCCESS;
 }
 
-#ifndef S2N_NO_STACKTRACE
+#ifdef S2N_STACKTRACE
 
 #define MAX_BACKTRACE_DEPTH 20
 __thread struct s2n_stacktrace tl_stacktrace = {0};
@@ -418,7 +418,7 @@ int s2n_print_stacktrace(FILE *fptr)
     return S2N_SUCCESS;
 }
 
-#else /* !S2N_NO_STACKTRACE */
+#else /* !S2N_STACKTRACE */
 int s2n_free_stacktrace(void)
 {
     S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
@@ -443,4 +443,4 @@ int s2n_print_stacktrace(FILE *fptr)
 {
     S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
 }
-#endif /* S2N_NO_STACKTRACE */
+#endif /* S2N_STACKTRACE */

--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -24,7 +24,7 @@
 #include "utils/s2n_map.h"
 #include "utils/s2n_safety.h"
 
-#if S2N_HAVE_EXECINFO
+#ifndef S2N_NO_STACKTRACE
 #   include <execinfo.h>
 #endif
 
@@ -367,7 +367,7 @@ int s2n_stack_traces_enabled_set(bool newval)
     return S2N_SUCCESS;
 }
 
-#ifdef S2N_HAVE_EXECINFO
+#ifndef S2N_NO_STACKTRACE
 
 #define MAX_BACKTRACE_DEPTH 20
 __thread struct s2n_stacktrace tl_stacktrace = {0};
@@ -418,7 +418,7 @@ int s2n_print_stacktrace(FILE *fptr)
     return S2N_SUCCESS;
 }
 
-#else /* !S2N_HAVE_EXECINFO */
+#else /* !S2N_NO_STACKTRACE */
 int s2n_free_stacktrace(void)
 {
     S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
@@ -443,4 +443,4 @@ int s2n_print_stacktrace(FILE *fptr)
 {
     S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
 }
-#endif /* S2N_HAVE_EXECINFO */
+#endif /* S2N_NO_STACKTRACE */

--- a/s2n.mk
+++ b/s2n.mk
@@ -185,8 +185,8 @@ try_compile = $(shell $(CC) $(CFLAGS) -c -o tmp.o $(1) > /dev/null 2>&1; echo $$
 
 # Determine if execinfo.h is available
 TRY_COMPILE_EXECINFO := $(call try_compile,$(S2N_ROOT)/tests/features/execinfo.c)
-ifeq ($(TRY_COMPILE_EXECINFO), 0)
-	DEFAULT_CFLAGS += -DS2N_HAVE_EXECINFO
+ifneq ($(TRY_COMPILE_EXECINFO), 0)
+	DEFAULT_CFLAGS += -DS2N_NO_STACKTRACE
 endif
 
 # Determine if cpuid.h is available

--- a/s2n.mk
+++ b/s2n.mk
@@ -185,8 +185,8 @@ try_compile = $(shell $(CC) $(CFLAGS) -c -o tmp.o $(1) > /dev/null 2>&1; echo $$
 
 # Determine if execinfo.h is available
 TRY_COMPILE_EXECINFO := $(call try_compile,$(S2N_ROOT)/tests/features/execinfo.c)
-ifneq ($(TRY_COMPILE_EXECINFO), 0)
-	DEFAULT_CFLAGS += -DS2N_NO_STACKTRACE
+ifeq ($(TRY_COMPILE_EXECINFO), 0)
+	DEFAULT_CFLAGS += -DS2N_STACKTRACE
 endif
 
 # Determine if cpuid.h is available

--- a/tests/unit/s2n_stacktrace_test.c
+++ b/tests/unit/s2n_stacktrace_test.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
-#ifdef S2N_HAVE_EXECINFO
+#ifndef S2N_NO_STACKTRACE
     EXPECT_SUCCESS(s2n_stack_traces_enabled_set(true));
     struct s2n_stacktrace trace;
     /* If nothing has errored yet, we have no stacktrace */

--- a/tests/unit/s2n_stacktrace_test.c
+++ b/tests/unit/s2n_stacktrace_test.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
-#ifndef S2N_NO_STACKTRACE
+#ifdef S2N_STACKTRACE
     EXPECT_SUCCESS(s2n_stack_traces_enabled_set(true));
     struct s2n_stacktrace trace;
     /* If nothing has errored yet, we have no stacktrace */


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

Currently, stacktrace functionality is enabled/disabled via a try compile:
https://github.com/aws/s2n-tls/blob/433f0640bc0e2a4763f23471009439578142711c/CMakeLists.txt#L243-L248

This PR adds a new cmake option, `S2N_NO_STACKTRACE`, that will also disable the stacktrace feature if set.

### Call-outs:

Additionally, the `S2N_HAVE_EXECINFO` variable was renamed to `S2N_NO_STACKTRACE` for consistency.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
