### PR TITLE
Fix interning build for cmake version 3.15+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,7 +491,16 @@ if (NOT $ENV{S2N_LIBCRYPTO} STREQUAL "awslc")
     target_compile_options(${PROJECT_NAME} PRIVATE -Wcast-qual)
 endif()
 
-#work around target differences
+# For interning, we need to find the static libcrypto library. Cmake configs
+# can branch on the variable BUILD_SHARED_LIBS to e.g. avoid having to define
+# multiple targets. An example is AWS-LC:
+# https://github.com/awslabs/aws-lc/blob/main/crypto/cmake/crypto-config.cmake#L5
+if (S2N_INTERN_LIBCRYPTO)
+    set(BUILD_SHARED_LIBS_BACKUP ${BUILD_SHARED_LIBS})
+    set(BUILD_SHARED_LIBS OFF)
+endif()
+
+# Work around target differences
 if (TARGET crypto)
     message(STATUS "S2N found target: crypto")
     set(LINK_LIB "crypto")
@@ -502,6 +511,8 @@ else()
 endif()
 
 if (S2N_INTERN_LIBCRYPTO)
+    # Restore the old BUILD_SHARED_LIBS value
+    set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_BACKUP})
     message(STATUS "Enabling libcrypto interning")
 endif()
 
@@ -542,9 +553,31 @@ if (LIBCRYPTO_SUPPORTS_EVP_MD_CTX_SET_PKEY_CTX)
 endif()
 
 if (S2N_INTERN_LIBCRYPTO)
+
+    # Check if the AWS::crypto target has beeen added and handle it
+    if (TARGET AWS::crypto)
+        # Get the target library type (shared or static)
+        get_target_property(target_type AWS::crypto TYPE)
+        message(STATUS "AWS::crypto target type: ${target_type}")
+
+        # If we didn't find the a target with static library type, fallback to
+        # existing crypto_STATIC_LIBRARY and crypto_INCLUDE_DIR
+        if (target_type STREQUAL STATIC_LIBRARY)
+            # We need an path to the include directory and libcrypto.a archive.
+            # The finder module defines these appropriately, but if we go through
+            # the target config we need to query this information from the target
+            # first.
+            get_target_property(crypto_STATIC_LIBRARY AWS::crypto LOCATION)
+            get_target_property(crypto_INCLUDE_DIR AWS::crypto INTERFACE_INCLUDE_DIRECTORIES)
+        endif()
+    endif()
+
     if (NOT crypto_STATIC_LIBRARY)
         message(FATAL_ERROR "libcrypto interning requires a static build of libcrypto.a to be available")
     endif()
+
+    message(STATUS "crypto_STATIC_LIBRARY: ${crypto_STATIC_LIBRARY}")
+    message(STATUS "crypto_INCLUDE_DIR: ${crypto_INCLUDE_DIR}")
 
     # Don't call link_target_libraries here, just make sure the libcrypto include dir is in the path
     include_directories("${crypto_INCLUDE_DIR}")


### PR DESCRIPTION
### Resolved issues:

Fixes https://github.com/aws/s2n-tls/issues/3308

### Description of changes: 

Two methods are supported in s2n to resolve the libcrypto dependency through `find_package()`: the in-source finder package module or config search mode. The former defines the variable `crypto_STATIC_LIBRARY`, which is **required** for the interning build. But when finding the config from AWS-LC, this variable is not defined, leading to the interning build failing.

This PR fixes this by first checking whether the target `AWS::crypto` has been added, and then querying it for information to determine whether we have found the static library. Since the interning build needs `libcrypto.a`, the actual path to the archive must also be constructed using properties set for the target `AWS::crypto`.

Unfortunately, the AWS-LC cmake config branches on the value of the variable `BUILD_SHARED_LIBS`. Hence, we also have to handle this case for the interning build. Otherwise, interning+shared s2n build would not work, because `AWS::crypto` would export only the shared AWS-LC libcrypto. And, of course, without breaking the regular build. 

I can think of 3 ways to handle that:
1. As is implemented in this PR
2. Define a function which encapsulates a variable scope and call `find_package()` form there. We can then set `set(BUILD_SHARED_LIBS OFF)` for this function scope only. I don't think this works though, because `find_package()` will export (required) variables (e.g. `crypto_STATIC_LIBRARY`) for the regular build, which will also only be defined for the function scope.
3. Define special variables in AWS-LC config. For example, could be a special `SUPPORT_INTERNING` that can be used to condition on the branching in addition to `BUILD_SHARED_LIBS`.

I picked (1) because it seems slightly more general than (3). And as noted, I don't think (2) works.

### Call-outs:

This PR also adds a few more configuration log messages.

### Testing:

Tested this locally. In addition, this [test build in AWS-LC repository](https://github.com/awslabs/aws-lc/pull/483) uses the `fix_cmake_interning_build` branch to go through the s2n-interning build test in the AWS-LC CI. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
