### PR TITLE
Replace existing fork detection with the FGN implementation

### DIFF
--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -552,6 +552,46 @@ static int s2n_random_test_case_without_pr_pthread_atfork_cb(struct random_test_
     return EXIT_SUCCESS;
 }
 
+static int s2n_random_test_case_without_pr_madv_wipeonfork_cb(struct random_test_case *test_case)
+{
+    if (s2n_is_madv_wipeonfork_supported() == false) {
+        TEST_DEBUG_PRINT("s2n_random_test.c test case not supported. Skipping.\nTest case: %s\n", test_case->test_case_label);
+        return S2N_SUCCESS;
+    }
+
+    POSIX_GUARD_RESULT(s2n_ignore_pthread_atfork_for_testing());
+
+    EXPECT_SUCCESS(s2n_init());
+
+    POSIX_GUARD_RESULT(s2n_ignore_prediction_resistance_for_testing(true));
+    EXPECT_EQUAL(s2n_common_tests(test_case), S2N_SUCCESS);
+    POSIX_GUARD_RESULT(s2n_ignore_prediction_resistance_for_testing(false));
+
+    EXPECT_SUCCESS(s2n_cleanup());
+
+    return S2N_SUCCESS;
+}
+
+static int s2n_random_test_case_without_pr_map_inherit_zero_cb(struct random_test_case *test_case)
+{
+    if (s2n_is_map_inherit_zero_supported() == false) {
+        TEST_DEBUG_PRINT("s2n_random_test.c test case not supported. Skipping.\nTest case: %s\n", test_case->test_case_label);
+        return S2N_SUCCESS;
+    }
+
+    POSIX_GUARD_RESULT(s2n_ignore_pthread_atfork_for_testing());
+
+    EXPECT_SUCCESS(s2n_init());
+
+    POSIX_GUARD_RESULT(s2n_ignore_prediction_resistance_for_testing(true));
+    EXPECT_EQUAL(s2n_common_tests(test_case), S2N_SUCCESS);
+    POSIX_GUARD_RESULT(s2n_ignore_prediction_resistance_for_testing(false));
+
+    EXPECT_SUCCESS(s2n_cleanup());
+
+    return S2N_SUCCESS;
+}
+
 static int s2n_random_test_case_failure_cb(struct random_test_case *test_case)
 {
     EXPECT_SUCCESS(s2n_init());
@@ -569,37 +609,36 @@ static int s2n_random_test_case_failure_cb(struct random_test_case *test_case)
     return EXIT_SUCCESS;
 }
 
-#define NUMBER_OF_RANDOM_TEST_CASES 4
-struct random_test_case random_test_cases[NUMBER_OF_RANDOM_TEST_CASES] = {
+struct random_test_case random_test_cases[] = {
     {"Random API.", s2n_random_test_case_default_cb, CLONE_TEST_DETERMINE_AT_RUNTIME, EXIT_SUCCESS},
     {"Random API without prediction resistance.", s2n_random_test_case_without_pr_cb, CLONE_TEST_DETERMINE_AT_RUNTIME, EXIT_SUCCESS},
     {"Random API without prediction resistance and with only pthread_atfork fork detection mechanism.", s2n_random_test_case_without_pr_pthread_atfork_cb, CLONE_TEST_NO, EXIT_SUCCESS},
+    {"Random API without prediction resistance and with only madv_wipeonfork fork detection mechanism.", s2n_random_test_case_without_pr_madv_wipeonfork_cb, CLONE_TEST_YES},
+    {"Random API without prediction resistance and with only map_inheret_zero fork detection mechanism.", s2n_random_test_case_without_pr_map_inherit_zero_cb, CLONE_TEST_YES},
     /* The s2n FAIL_MSG() macro uses exit(1) not exit(EXIT_FAILURE). So, we need
      * to use 1 below and in s2n_random_test_case_failure_cb().
      */
-    {"Test failure.", s2n_random_test_case_failure_cb, CLONE_TEST_DETERMINE_AT_RUNTIME, 1},};
+    {"Test failure.", s2n_random_test_case_failure_cb, CLONE_TEST_DETERMINE_AT_RUNTIME, 1},
+};
 
 int main(int argc, char **argv)
 {
     BEGIN_TEST_NO_INIT();
 
-    EXPECT_TRUE(s2n_array_len(random_test_cases) == NUMBER_OF_RANDOM_TEST_CASES);
-
-    /* Create NUMBER_OF_RANDOM_TEST_CASES number of child processes that each
-     * run a test case.
+    /* For each test case, creates a child processes that runs the test case.
      *
      * Fork detection is lazily initialised on first invocation of
      * s2n_get_fork_generation_number(). Hence, it is important that children
      * are created before calling into the fork detection code.
      */
-    pid_t proc_ids[NUMBER_OF_RANDOM_TEST_CASES] = {0};
+    for (size_t i = 0; i < s2n_array_len(random_test_cases); i++) {
 
-    for (size_t i = 0; i < NUMBER_OF_RANDOM_TEST_CASES; i++) {
+        pid_t proc_id = 0;
 
-        proc_ids[i] = fork();
-        EXPECT_TRUE(proc_ids[i] >= 0);
+        proc_id = fork();
+        EXPECT_TRUE(proc_id >= 0);
 
-        if (proc_ids[i] == 0) {
+        if (proc_id == 0) {
             /* In child */
             EXPECT_EQUAL(random_test_cases[i].test_case_cb(&random_test_cases[i]), EXIT_SUCCESS);
 
@@ -611,7 +650,7 @@ int main(int argc, char **argv)
             exit(EXIT_SUCCESS);
         }
         else {
-            s2n_verify_child_exit_status(proc_ids[i], random_test_cases[i].expected_return_status);
+            s2n_verify_child_exit_status(proc_id, random_test_cases[i].expected_return_status);
         }
     }
 

--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -625,7 +625,7 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST_NO_INIT();
 
-    /* For each test case, creates a child processes that runs the test case.
+    /* For each test case, creates a child process that runs the test case.
      *
      * Fork detection is lazily initialised on first invocation of
      * s2n_get_fork_generation_number(). Hence, it is important that children

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -60,14 +60,14 @@ struct s2n_rand_state {
     uint64_t cached_fork_generation_number;
     struct s2n_drbg public_drbg;
     struct s2n_drbg private_drbg;
-    bool drbgs_initialised;
+    bool drbgs_initialized;
 };
 
 static __thread struct s2n_rand_state s2n_per_thread_rand_state = {
     .cached_fork_generation_number = 0,
     .public_drbg = {0},
     .private_drbg = {0},
-    .drbgs_initialised = false
+    .drbgs_initialized = false
 };
 
 static int s2n_rand_init_impl(void);
@@ -130,7 +130,7 @@ S2N_RESULT s2n_get_mix_entropy(struct s2n_blob *blob)
     return S2N_RESULT_OK;
 }
 
-static S2N_RESULT s2n_initialise_drbgs(void)
+static S2N_RESULT s2n_init_drbgs(void)
 {
     uint8_t s2n_public_drbg[] = "s2n public drbg";
     uint8_t s2n_private_drbg[] = "s2n private drbg";
@@ -140,17 +140,17 @@ static S2N_RESULT s2n_initialise_drbgs(void)
     RESULT_GUARD(s2n_drbg_instantiate(&s2n_per_thread_rand_state.public_drbg, &public, S2N_AES_128_CTR_NO_DF_PR));
     RESULT_GUARD(s2n_drbg_instantiate(&s2n_per_thread_rand_state.private_drbg, &private, S2N_AES_256_CTR_NO_DF_PR));
 
-    s2n_per_thread_rand_state.drbgs_initialised = true;
+    s2n_per_thread_rand_state.drbgs_initialized = true;
 
     return S2N_RESULT_OK;
 }
 
-static S2N_RESULT s2n_maybe_initialise_drbgs(void)
+static S2N_RESULT s2n_maybe_init_drbgs(void)
 {
-    if (s2n_per_thread_rand_state.drbgs_initialised == false) {
-        RESULT_GUARD(s2n_initialise_drbgs());
+    if (s2n_per_thread_rand_state.drbgs_initialized == false) {
+        RESULT_GUARD(s2n_init_drbgs());
 
-        /* Then cache the fork generation number. We just initialised the drbg
+        /* Then cache the fork generation number. We just initialized the drbg
          * states with new entropy and forking is not an external event.
          */
         uint64_t returned_fork_generation_number = 0;
@@ -161,10 +161,11 @@ static S2N_RESULT s2n_maybe_initialise_drbgs(void)
     return S2N_RESULT_OK;
 }
 
-/* s2n_defend_against_ube() implements defenses against ube's (uniqueness
- * breaking events). Currently, only implements fork detection.
+/* s2n_ensure_uniqueness() implements defenses against uniqueness
+ * breaking events that might cause duplicated drbg states. Currently, only
+ * implements fork detection.
  */
-static S2N_RESULT s2n_defend_against_ube(void)
+static S2N_RESULT s2n_ensure_uniqueness(void)
 {
     uint64_t returned_fork_generation_number = 0;
     RESULT_GUARD(s2n_get_fork_generation_number(&returned_fork_generation_number));
@@ -172,12 +173,12 @@ static S2N_RESULT s2n_defend_against_ube(void)
     if (returned_fork_generation_number != s2n_per_thread_rand_state.cached_fork_generation_number) {
 
         /* This assumes that s2n_rand_cleanup_thread() doesn't mutate any other
-         * state than the drbg states and it resets the drbg initialisation
-         * boolean to false. s2n_maybe_initialise_drbgs() will cache the new
-         * fork generation number in the per thread state.
+         * state than the drbg states and it resets the drbg initialization
+         * boolean to false. s2n_maybe_init_drbgs() will cache the new fork
+         * generation number in the per thread state.
          */
         RESULT_GUARD(s2n_rand_cleanup_thread());
-        RESULT_GUARD(s2n_maybe_initialise_drbgs());
+        RESULT_GUARD(s2n_maybe_init_drbgs());
     }
 
     return S2N_RESULT_OK;
@@ -186,8 +187,8 @@ static S2N_RESULT s2n_defend_against_ube(void)
 static S2N_RESULT s2n_get_random_data(struct s2n_blob *out_blob,
     struct s2n_drbg *drbg_state)
 {
-    RESULT_GUARD(s2n_maybe_initialise_drbgs());
-    RESULT_GUARD(s2n_defend_against_ube());
+    RESULT_GUARD(s2n_maybe_init_drbgs());
+    RESULT_GUARD(s2n_ensure_uniqueness());
 
     uint32_t offset = 0;
     uint32_t remaining = out_blob->size;
@@ -231,7 +232,59 @@ S2N_RESULT s2n_get_private_random_bytes_used(uint64_t *bytes_used)
     return S2N_RESULT_OK;
 }
 
-/* Return a random number in the range [0, bound) */
+static int s2n_rand_urandom_impl(void *ptr, uint32_t size)
+{
+    POSIX_ENSURE(entropy_fd != UNINITIALIZED_ENTROPY_FD, S2N_ERR_NOT_INITIALIZED);
+
+    uint8_t *data = ptr;
+    uint32_t n = size;
+    struct timespec sleep_time = {.tv_sec = 0, .tv_nsec = 0 };
+    long backoff = 1;
+
+    while (n) {
+        errno = 0;
+        int r = read(entropy_fd, data, n);
+        if (r <= 0) {
+            /*
+             * A non-blocking read() on /dev/urandom should "never" fail,
+             * except for EINTR. If it does, briefly pause and use
+             * exponential backoff to avoid creating a tight spinning loop.
+             *
+             * iteration          delay
+             * ---------    -----------------
+             *    1         10          nsec
+             *    2         100         nsec
+             *    3         1,000       nsec
+             *    4         10,000      nsec
+             *    5         100,000     nsec
+             *    6         1,000,000   nsec
+             *    7         10,000,000  nsec
+             *    8         99,999,999  nsec
+             *    9         99,999,999  nsec
+             *    ...
+             */
+            if (errno != EINTR) {
+                backoff = MIN(backoff * 10, ONE_S - 1);
+                sleep_time.tv_nsec = backoff;
+                do {
+                    r = nanosleep(&sleep_time, &sleep_time);
+                }
+                while (r != 0);
+            }
+
+            continue;
+        }
+
+        data += r;
+        n -= r;
+    }
+
+    return S2N_SUCCESS;
+}
+
+/*
+ * Return a random number in the range [0, bound)
+ */
 S2N_RESULT s2n_public_random(int64_t bound, uint64_t *output)
 {
     uint64_t r;
@@ -239,20 +292,21 @@ S2N_RESULT s2n_public_random(int64_t bound, uint64_t *output)
     RESULT_ENSURE_GT(bound, 0);
 
     while (1) {
-        struct s2n_blob blob = { .data = (void *)&r, sizeof(r) };
+        struct s2n_blob blob = {.data = (void *)&r, sizeof(r) };
         RESULT_GUARD(s2n_get_public_random_data(&blob));
 
-        /* Imagine an int was one byte and UINT_MAX was 256. If the caller asked
-         * for s2n_random(129, ...) we'd end up in trouble. Each number in the
-         * range 0...127 would be twice as likely as 128. That's because
-         * r == 0 % 129 -> 0, and r == 129 % 129 -> 0, but only
-         * r == 128 returns 128, r == 257 is out of range.
+        /* Imagine an int was one byte and UINT_MAX was 256. If the
+         * caller asked for s2n_random(129, ...) we'd end up in
+         * trouble. Each number in the range 0...127 would be twice
+         * as likely as 128. That's because r == 0 % 129 -> 0, and
+         * r == 129 % 129 -> 0, but only r == 128 returns 128,
+         * r == 257 is out of range.
          *
-         * To de-bias the dice, we discard values of r that are higher that the
-         * highest multiple of 'bound' an int can support. If bound is a uint,
-         * then in the worst case we discard 50% - 1 r's. But since 'bound' is
-         * an int and INT_MAX is <= UINT_MAX / 2, in the worst case we discard
-         * 25% - 1 r's.
+         * To de-bias the dice, we discard values of r that are higher
+         * that the highest multiple of 'bound' an int can support. If
+         * bound is a uint, then in the worst case we discard 50% - 1 r's.
+         * But since 'bound' is an int and INT_MAX is <= UINT_MAX / 2,
+         * in the worst case we discard 25% - 1 r's.
          */
         if (r < (UINT64_MAX - (UINT64_MAX % bound))) {
             *output = r % bound;
@@ -267,7 +321,7 @@ S2N_RESULT s2n_public_random(int64_t bound, uint64_t *output)
 
 int s2n_openssl_compat_rand(unsigned char *buf, int num)
 {
-    struct s2n_blob out = { .data = buf,.size = num };
+    struct s2n_blob out = {.data = buf,.size = num };
 
     if (s2n_result_is_error(s2n_get_private_random_data(&out))) {
         return 0;
@@ -317,7 +371,7 @@ S2N_RESULT s2n_rand_init(void)
 {
     RESULT_GUARD_POSIX(s2n_rand_init_cb());
 
-    RESULT_GUARD(s2n_maybe_initialise_drbgs());
+    RESULT_GUARD(s2n_maybe_init_drbgs());
 
 #if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
     /* Create an engine */
@@ -381,68 +435,34 @@ S2N_RESULT s2n_rand_cleanup(void)
 S2N_RESULT s2n_rand_cleanup_thread(void)
 {
     /* Currently, it is only safe for this function to mutate the drbg states
-     * in the per thread rand state. See s2n_defend_against_ube().
+     * in the per thread rand state. See s2n_ensure_uniqueness().
      */
     RESULT_GUARD(s2n_drbg_wipe(&s2n_per_thread_rand_state.private_drbg));
     RESULT_GUARD(s2n_drbg_wipe(&s2n_per_thread_rand_state.public_drbg));
 
-    s2n_per_thread_rand_state.drbgs_initialised = false;
+    s2n_per_thread_rand_state.drbgs_initialized = false;
 
     return S2N_RESULT_OK;
 }
 
-static int s2n_rand_urandom_impl(void *ptr, uint32_t size)
+/* This must only be used for unit tests. Any real use is dangerous and will be
+ * overwritten in s2n_ensure_uniqueness() if it is forked. This was added to
+ * support known answer tests that use OpenSSL and s2n_get_private_random_data
+ * directly.
+ */
+S2N_RESULT s2n_set_private_drbg_for_test(struct s2n_drbg drbg)
 {
-    POSIX_ENSURE(entropy_fd != UNINITIALIZED_ENTROPY_FD, S2N_ERR_NOT_INITIALIZED);
+    RESULT_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
+    RESULT_GUARD(s2n_drbg_wipe(&s2n_per_thread_rand_state.private_drbg));
 
-    uint8_t *data = ptr;
-    uint32_t n = size;
-    struct timespec sleep_time = { .tv_sec = 0, .tv_nsec = 0 };
-    long backoff = 1;
+    s2n_per_thread_rand_state.private_drbg = drbg;
 
-    while (n) {
-        errno = 0;
-        int r = read(entropy_fd, data, n);
-        if (r <= 0) {
-            /*
-             * A non-blocking read() on /dev/urandom should "never" fail, except
-             * for EINTR. If it does, briefly pause and use exponential backoff
-             * to avoid creating a tight spinning loop.
-             *
-             * iteration          delay
-             * ---------    -----------------
-             *    1         10          nsec
-             *    2         100         nsec
-             *    3         1,000       nsec
-             *    4         10,000      nsec
-             *    5         100,000     nsec
-             *    6         1,000,000   nsec
-             *    7         10,000,000  nsec
-             *    8         99,999,999  nsec
-             *    9         99,999,999  nsec
-             *    ...
-             */
-            if (errno != EINTR) {
-                backoff = MIN(backoff * 10, ONE_S - 1);
-                sleep_time.tv_nsec = backoff;
-                do {
-                    r = nanosleep(&sleep_time, &sleep_time);
-                }
-                while (r != 0);
-            }
-
-            continue;
-        }
-
-        data += r;
-        n -= r;
-    }
-
-    return S2N_SUCCESS;
+    return S2N_RESULT_OK;
 }
 
-/* Volatile is important to prevent the compiler from re-ordering or optimizing
- * the use of RDRAND.
+/*
+ * volatile is important to prevent the compiler from
+ * re-ordering or optimizing the use of RDRAND.
  */
 static int s2n_rand_rdrand_impl(void *data, uint32_t size)
 {
@@ -454,9 +474,7 @@ static int s2n_rand_rdrand_impl(void *data, uint32_t size)
         uint64_t u64;
 #if defined(__i386__)
         struct {
-            /* Since we check first that we're on intel, we can safely assume
-             * little endian
-             */
+            /* since we check first that we're on intel, we can safely assume little endian. */
             uint32_t u_low;
             uint32_t u_high;
         } i386_fields;
@@ -471,15 +489,14 @@ static int s2n_rand_rdrand_impl(void *data, uint32_t size)
 
         for (int tries = 0; tries < 10; tries++) {
 #if defined(__i386__)
-            /* Execute the rdrand instruction, store the result in a general
-             * purpose register (it's assigned to output.i386_fields.u_low).
-             * Check the carry bit, which will be set on success. Then clobber
-             * the register and reset the carry bit. Due to needing to support
-             * an ancient assembler we use the opcode syntax. the %b1 is to
-             * force compilers to use c1 instead of ecx. Here's a description of
-             * how the opcode is encoded: 0x0fc7 (rdrand) 0xf0 (store the result
-             * in eax).
-             */
+            /* execute the rdrand instruction, store the result in a general purpose register (it's assigned to
+            * output.i386_fields.u_low). Check the carry bit, which will be set on success. Then clober the register and reset
+            * the carry bit. Due to needing to support an ancient assembler we use the opcode syntax.
+            * the %b1 is to force compilers to use c1 instead of ecx.
+            * Here's a description of how the opcode is encoded:
+            * 0x0fc7 (rdrand)
+            * 0xf0 (store the result in eax).
+            */
             unsigned char success_high = 0, success_low = 0;
             __asm__ __volatile__(".byte 0x0f, 0xc7, 0xf0;\n" "setc %b1;\n": "=a"(output.i386_fields.u_low), "=qm"(success_low)
                                  :
@@ -492,8 +509,7 @@ static int s2n_rand_rdrand_impl(void *data, uint32_t size)
             success = success_high & success_low;
 
             /* Treat either all 1 or all 0 bits in either the high or low order
-             * bits as failure
-             */
+             * bits as failure */
             if (output.i386_fields.u_low == 0 ||
                     output.i386_fields.u_low == UINT32_MAX ||
                     output.i386_fields.u_high == 0 ||
@@ -501,36 +517,30 @@ static int s2n_rand_rdrand_impl(void *data, uint32_t size)
                 success = 0;
             }
 #else
-            /* Execute the rdrand instruction, store the result in a general
-             * purpose register (it's assigned to output.u64). Check the carry
-             * bit, which will be set on success. Then clober the carry bit. Due
-             * to needing to support an ancient assembler we use the opcode
-             * syntax. the %b1 is to force compilers to use c1 instead of ecx.
-             * Here's a description of how the opcode is encoded:
-             * 0x48 (pick a 64-bit register it does more too, but that's all
-             *  that matters there)
-             * 0x0fc7 (rdrand)
-             * 0xf0 (store the result in rax).
-             */
+            /* execute the rdrand instruction, store the result in a general purpose register (it's assigned to
+            * output.u64). Check the carry bit, which will be set on success. Then clober the carry bit.
+            * Due to needing to support an ancient assembler we use the opcode syntax.
+            * the %b1 is to force compilers to use c1 instead of ecx.
+            * Here's a description of how the opcode is encoded:
+            * 0x48 (pick a 64-bit register it does more too, but that's all that matters there)
+            * 0x0fc7 (rdrand)
+            * 0xf0 (store the result in rax). */
             __asm__ __volatile__(".byte 0x48, 0x0f, 0xc7, 0xf0;\n" "setc %b1;\n": "=a"(output.u64), "=qm"(success)
             :
             :"cc");
 #endif /* defined(__i386__) */
 
-            /* Some AMD CPUs will find that RDRAND "sticks" on all 1s but still
-             * reports success. Some other very old CPUs use all 0s as an error
-             * condition while still reporting success. If we encounter either
-             * of these suspicious values (a 1/2^63 chance) we'll treat them as
+            /* Some AMD CPUs will find that RDRAND "sticks" on all 1s but still reports success.
+             * Some other very old CPUs use all 0s as an error condition while still reporting success.
+             * If we encounter either of these suspicious values (a 1/2^63 chance) we'll treat them as
              * a failure and generate a new value.
              *
-             * In the future we could add CPUID checks to detect processors with
-             * these known bugs, however it does not appear worth it. The
-             * entropy loss is negligible and the corresponding likelihood that
-             * a healthy CPU generates either of these values is also negligible
-             * (1/2^63). Finally, adding processor specific logic would greatly
-             * increase the complexity and would cause us to "miss" any unknown
-             * processors with similar bugs.
-             */
+             * In the future we could add CPUID checks to detect processors with these known bugs,
+             * however it does not appear worth it. The entropy loss is negligible and the
+             * corresponding likelihood that a healthy CPU generates either of these values is also
+             * negligible (1/2^63). Finally, adding processor specific logic would greatly
+             * increase the complexity and would cause us to "miss" any unknown processors with
+             * similar bugs. */
             if (output.u64 == UINT64_MAX ||
                 output.u64 == 0) {
                 success = 0;
@@ -552,18 +562,4 @@ static int s2n_rand_rdrand_impl(void *data, uint32_t size)
 #else
     POSIX_BAIL(S2N_ERR_UNSUPPORTED_CPU);
 #endif
-}
-
-/* This must only be used for unit tests. Any real use is dangerous and will be
- * overwritten in s2n_defend_against_ube if it is forked. This was added to
- * support known answer tests that use OpenSSL and s2n_get_private_random_data
- * directly.
- */
-S2N_RESULT s2n_set_private_drbg_for_test(struct s2n_drbg drbg)
-{
-    RESULT_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
-    RESULT_ENSURE_OK(s2n_drbg_wipe(&s2n_per_thread_rand_state.private_drbg), S2N_ERR_NOT_IN_UNIT_TEST);
-    s2n_per_thread_rand_state.private_drbg = drbg;
-
-    return S2N_RESULT_OK;
 }

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -145,7 +145,7 @@ static S2N_RESULT s2n_init_drbgs(void)
     return S2N_RESULT_OK;
 }
 
-static S2N_RESULT s2n_maybe_init_drbgs(void)
+static S2N_RESULT s2n_ensure_initialized_drbgs(void)
 {
     if (s2n_per_thread_rand_state.drbgs_initialized == false) {
         RESULT_GUARD(s2n_init_drbgs());
@@ -174,11 +174,11 @@ static S2N_RESULT s2n_ensure_uniqueness(void)
 
         /* This assumes that s2n_rand_cleanup_thread() doesn't mutate any other
          * state than the drbg states and it resets the drbg initialization
-         * boolean to false. s2n_maybe_init_drbgs() will cache the new fork
-         * generation number in the per thread state.
+         * boolean to false. s2n_ensure_initialized_drbgs() will cache the new
+         * fork generation number in the per thread state.
          */
         RESULT_GUARD(s2n_rand_cleanup_thread());
-        RESULT_GUARD(s2n_maybe_init_drbgs());
+        RESULT_GUARD(s2n_ensure_initialized_drbgs());
     }
 
     return S2N_RESULT_OK;
@@ -187,7 +187,7 @@ static S2N_RESULT s2n_ensure_uniqueness(void)
 static S2N_RESULT s2n_get_random_data(struct s2n_blob *out_blob,
     struct s2n_drbg *drbg_state)
 {
-    RESULT_GUARD(s2n_maybe_init_drbgs());
+    RESULT_GUARD(s2n_ensure_initialized_drbgs());
     RESULT_GUARD(s2n_ensure_uniqueness());
 
     uint32_t offset = 0;
@@ -371,7 +371,7 @@ S2N_RESULT s2n_rand_init(void)
 {
     RESULT_GUARD_POSIX(s2n_rand_init_cb());
 
-    RESULT_GUARD(s2n_maybe_init_drbgs());
+    RESULT_GUARD(s2n_ensure_initialized_drbgs());
 
 #if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
     /* Create an engine */

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -80,7 +80,8 @@ static s2n_rand_cleanup_callback s2n_rand_cleanup_cb = s2n_rand_cleanup_impl;
 static s2n_rand_seed_callback s2n_rand_seed_cb = s2n_rand_urandom_impl;
 static s2n_rand_mix_callback s2n_rand_mix_cb = s2n_rand_urandom_impl;
 
-static bool s2n_cpu_supports_rdrand() {
+/* non-static for SAW proof */
+bool s2n_cpu_supports_rdrand() {
 #if defined(S2N_CPUID_AVAILABLE)
     uint32_t eax, ebx, ecx, edx;
     if (!__get_cpuid(1, &eax, &ebx, &ecx, &edx)) {

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -196,7 +196,7 @@ static S2N_RESULT s2n_get_random_data(struct s2n_blob *out_blob,
     while(remaining) {
         struct s2n_blob slice = { 0 };
 
-        RESULT_GUARD_POSIX(s2n_blob_slice(out_blob, &slice, offset, MIN(remaining, S2N_DRBG_GENERATE_LIMIT)));;
+        RESULT_GUARD_POSIX(s2n_blob_slice(out_blob, &slice, offset, MIN(remaining, S2N_DRBG_GENERATE_LIMIT)));
         RESULT_GUARD(s2n_drbg_generate(drbg_state, &slice));
 
         remaining -= slice.size;


### PR DESCRIPTION
### Resolved issues:

P46856694

### Description of changes: 

Incremental version of https://github.com/aws/s2n-tls/pull/3292

Step 1: refactor randomness API tests https://github.com/aws/s2n-tls/pull/3328
Step 2: Expand random api tests https://github.com/aws/s2n-tls/pull/3342
Step 3: **this pr** Move existing fork detection to fgn implementation
Step 4: Implement clone test and additional small unit tests.

This change takes the fork detection backend implemented in https://github.com/aws/s2n-tls/pull/3191 and wires up the randomness generation frontend to it. In turn, replacing the existing fork detection mechanism.

In addition, it implement two test cases that verifies more fork detection methods in isolation.

Two important notes:
* A per-thread state is introduced to manage the DRBG states and the cached FGN.
* Each public randomness generation function now ensures that the DRBG states are initialised.

### Call-outs:

Re-organise and clean up the source code in `s2n_random.c`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
