### PR TITLE
[bindings] Apply async blinding

### DIFF
--- a/bindings/rust/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/s2n-tls-tokio/Cargo.toml
@@ -14,9 +14,9 @@ default = []
 errno = { version = "0.2" }
 libc = { version = "0.2" }
 s2n-tls = { version = "=0.0.8", path = "../s2n-tls" }
-tokio = { version = "1", features = ["net"] }
+tokio = { version = "1", features = ["net", "time"] }
 
 [dev-dependencies]
 clap = { version = "3.1", features = ["derive"] }
 rand = { version = "0.8" }
-tokio = { version = "1", features = [ "io-std", "io-util", "macros", "net", "rt-multi-thread", "time"] }
+tokio = { version = "1", features = [ "io-std", "io-util", "macros", "net", "rt-multi-thread", "test-util", "time"] }

--- a/bindings/rust/s2n-tls-tokio/src/lib.rs
+++ b/bindings/rust/s2n-tls-tokio/src/lib.rs
@@ -299,14 +299,13 @@ where
         if tls.blinding.is_none() {
             let delay = tls
                 .as_ref()
-                .remaining_blinding_nanos()
+                .remaining_blinding_delay()
                 .map_err(io::Error::from)?;
-            if delay > 0 {
+            if !delay.is_zero() {
                 // Sleep operates at the milisecond resolution, so add an extra
                 // millisecond to account for any stray nanoseconds.
                 let safety = Duration::from_millis(1);
-                let delay = Duration::from_nanos(delay).saturating_add(safety);
-                tls.blinding = Some(Box::pin(sleep(delay)));
+                tls.blinding = Some(Box::pin(sleep(delay.saturating_add(safety))));
             }
         };
 

--- a/bindings/rust/s2n-tls-tokio/src/lib.rs
+++ b/bindings/rust/s2n-tls-tokio/src/lib.rs
@@ -5,7 +5,7 @@ use errno::{set_errno, Errno};
 use s2n_tls::raw::{
     config::Config,
     connection::{Builder, Connection},
-    enums::{CallbackResult, Mode},
+    enums::{Blinding, CallbackResult, Mode},
     error::Error,
 };
 use std::{
@@ -14,9 +14,24 @@ use std::{
     io,
     os::raw::{c_int, c_void},
     pin::Pin,
-    task::{Context, Poll},
+    task::{
+        Context, Poll,
+        Poll::{Pending, Ready},
+    },
 };
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    time::{sleep, Duration, Sleep},
+};
+
+macro_rules! ready {
+    ($x:expr) => {
+        match $x {
+            Ready(r) => r,
+            Pending => return Pending,
+        }
+    };
+}
 
 #[derive(Clone)]
 pub struct TlsAcceptor<B: Builder = Config>
@@ -79,6 +94,7 @@ where
     S: AsyncRead + AsyncWrite + Unpin,
 {
     tls: &'a mut TlsStream<S, C>,
+    error: Option<Error>,
 }
 
 impl<S, C> Future for TlsHandshake<'_, S, C>
@@ -89,10 +105,26 @@ where
     type Output = Result<(), Error>;
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.tls.with_io(ctx, |context| {
-            let conn = context.get_mut().as_mut();
-            conn.negotiate().map(|r| r.map(|_| ()))
-        })
+        let result = match self.error.take() {
+            Some(err) => Err(err),
+            None => {
+                ready!(self.tls.with_io(ctx, |context| {
+                    let conn = context.get_mut().as_mut();
+                    conn.negotiate().map(|r| r.map(|_| ()))
+                }))
+            }
+        };
+        match result {
+            Ok(r) => Ok(r).into(),
+            Err(e) if e.is_retryable() => Err(e).into(),
+            Err(e) => match Pin::new(&mut self.tls).poll_shutdown(ctx) {
+                Pending => {
+                    self.error = Some(e);
+                    Pending
+                }
+                Ready(_) => Err(e).into(),
+            },
+        }
     }
 }
 
@@ -103,6 +135,7 @@ where
 {
     conn: C,
     stream: S,
+    blinding: Option<Pin<Box<Sleep>>>,
 }
 
 impl<S, C> TlsStream<S, C>
@@ -110,9 +143,18 @@ where
     C: AsRef<Connection> + AsMut<Connection> + Unpin,
     S: AsyncRead + AsyncWrite + Unpin,
 {
-    async fn open(conn: C, stream: S) -> Result<Self, Error> {
-        let mut tls = TlsStream { conn, stream };
-        TlsHandshake { tls: &mut tls }.await?;
+    async fn open(mut conn: C, stream: S) -> Result<Self, Error> {
+        conn.as_mut().set_blinding(Blinding::SelfService)?;
+        let mut tls = TlsStream {
+            conn,
+            stream,
+            blinding: None,
+        };
+        TlsHandshake {
+            tls: &mut tls,
+            error: None,
+        }
+        .await?;
         Ok(tls)
     }
 
@@ -211,17 +253,17 @@ where
         ctx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        self.get_mut()
-            .with_io(ctx, |mut context| {
-                context
-                    .conn
-                    .as_mut()
-                    .recv(buf.initialize_unfilled())
-                    .map_ok(|size| {
-                        buf.advance(size);
-                    })
-            })
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+        let tls = self.get_mut();
+        tls.with_io(ctx, |mut context| {
+            context
+                .conn
+                .as_mut()
+                .recv(buf.initialize_unfilled())
+                .map_ok(|size| {
+                    buf.advance(size);
+                })
+        })
+        .map_err(io::Error::from)
     }
 }
 
@@ -235,37 +277,50 @@ where
         ctx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        self.get_mut()
-            .with_io(ctx, |mut context| context.conn.as_mut().send(buf))
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+        let tls = self.get_mut();
+        tls.with_io(ctx, |mut context| context.conn.as_mut().send(buf))
+            .map_err(io::Error::from)
     }
 
     fn poll_flush(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let tls = self.get_mut();
-        let tls_flush = tls
-            .with_io(ctx, |mut context| {
-                context.conn.as_mut().flush().map(|r| r.map(|_| ()))
-            })
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e));
-        if tls_flush.is_ready() {
-            Pin::new(&mut tls.stream).poll_flush(ctx)
-        } else {
-            tls_flush
-        }
+
+        ready!(tls.with_io(ctx, |mut context| {
+            context.conn.as_mut().flush().map(|r| r.map(|_| ()))
+        }))
+        .map_err(io::Error::from)?;
+
+        Pin::new(&mut tls.stream).poll_flush(ctx)
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let tls = self.get_mut();
-        let tls_shutdown = tls
-            .with_io(ctx, |mut context| {
-                context.conn.as_mut().shutdown().map(|r| r.map(|_| ()))
-            })
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e));
-        if tls_shutdown.is_ready() {
-            Pin::new(&mut tls.stream).poll_shutdown(ctx)
-        } else {
-            tls_shutdown
+
+        if tls.blinding.is_none() {
+            let delay = tls
+                .as_ref()
+                .remaining_blinding_nanos()
+                .map_err(io::Error::from)?;
+            if delay > 0 {
+                // Sleep operates at the milisecond resolution, so add an extra
+                // millisecond to account for any stray nanoseconds.
+                let safety = Duration::from_millis(1);
+                let delay = Duration::from_nanos(delay).saturating_add(safety);
+                tls.blinding = Some(Box::pin(sleep(delay)));
+            }
+        };
+
+        if let Some(timer) = tls.blinding.as_mut() {
+            ready!(timer.as_mut().poll(ctx));
+            tls.blinding = None;
         }
+
+        ready!(tls.with_io(ctx, |mut context| {
+            context.conn.as_mut().shutdown().map(|r| r.map(|_| ()))
+        }))
+        .map_err(io::Error::from)?;
+
+        Pin::new(&mut tls.stream).poll_shutdown(ctx)
     }
 }
 

--- a/bindings/rust/s2n-tls-tokio/tests/common/stream.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/common/stream.rs
@@ -1,0 +1,103 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    io,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{Context, Poll},
+};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::TcpStream,
+};
+
+type ReadFn = Box<dyn Fn(Pin<&mut TcpStream>, &mut Context, &mut ReadBuf) -> Poll<io::Result<()>>>;
+type WriteFn = Box<dyn Fn(Pin<&mut TcpStream>, &mut Context, &[u8]) -> Poll<io::Result<usize>>>;
+
+#[derive(Default)]
+struct OverrideMethods {
+    next_read: Option<ReadFn>,
+    next_write: Option<WriteFn>,
+}
+
+#[derive(Default)]
+pub struct Overrides(Mutex<OverrideMethods>);
+
+impl Overrides {
+    pub fn next_read(&self, input: Option<ReadFn>) {
+        if let Ok(mut overrides) = self.0.lock() {
+            overrides.next_read = input;
+        }
+    }
+
+    pub fn next_write(&self, input: Option<WriteFn>) {
+        if let Ok(mut overrides) = self.0.lock() {
+            overrides.next_write = input;
+        }
+    }
+}
+
+pub struct TestStream {
+    stream: TcpStream,
+    overrides: Arc<Overrides>,
+}
+
+impl TestStream {
+    pub fn new(stream: TcpStream) -> Self {
+        let overrides = Arc::new(Overrides::default());
+        Self { stream, overrides }
+    }
+
+    pub fn overrides(&self) -> Arc<Overrides> {
+        self.overrides.clone()
+    }
+}
+
+impl AsyncRead for TestStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        ctx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let s = self.get_mut();
+        let stream = Pin::new(&mut s.stream);
+        let action = match s.overrides.0.lock() {
+            Ok(mut overrides) => overrides.next_read.take(),
+            _ => None,
+        };
+        if let Some(f) = action {
+            (f)(stream, ctx, buf)
+        } else {
+            stream.poll_read(ctx, buf)
+        }
+    }
+}
+
+impl AsyncWrite for TestStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        ctx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let s = self.get_mut();
+        let stream = Pin::new(&mut s.stream);
+        let action = match s.overrides.0.lock() {
+            Ok(mut overrides) => overrides.next_write.take(),
+            _ => None,
+        };
+        if let Some(f) = action {
+            (f)(stream, ctx, buf)
+        } else {
+            stream.poll_write(ctx, buf)
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.stream).poll_flush(ctx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.stream).poll_shutdown(ctx)
+    }
+}

--- a/bindings/rust/s2n-tls-tokio/tests/send_and_recv.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/send_and_recv.rs
@@ -1,10 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use s2n_tls::raw::error::Error;
 use s2n_tls_tokio::{TlsAcceptor, TlsConnector};
+use std::{io, task::Poll::*};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-mod common;
+pub mod common;
 
 const TEST_DATA: &[u8] = "hello world".as_bytes();
 
@@ -78,6 +80,53 @@ async fn send_and_recv_split() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(server_bytes, LARGE_TEST_DATA.len());
     assert_eq!(LARGE_TEST_DATA, client_received);
     assert_eq!(LARGE_TEST_DATA, server_received);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn send_error() -> Result<(), Box<dyn std::error::Error>> {
+    let client = TlsConnector::new(common::client_config()?.build()?);
+    let server = TlsAcceptor::new(common::server_config()?.build()?);
+
+    let (server_stream, client_stream) = common::get_streams().await?;
+    let client_stream = common::TestStream::new(client_stream);
+    let overrides = client_stream.overrides();
+    let (mut client, _) =
+        common::run_negotiate(&client, client_stream, &server, server_stream).await?;
+
+    // Setup write to fail
+    overrides.next_write(Some(Box::new(|_, _, _| {
+        Ready(Err(io::Error::from(Error::InvalidInput)))
+    })));
+
+    // Verify write fails
+    let result = client.write_all(TEST_DATA).await;
+    assert!(result.is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn recv_error() -> Result<(), Box<dyn std::error::Error>> {
+    let client = TlsConnector::new(common::client_config()?.build()?);
+    let server = TlsAcceptor::new(common::server_config()?.build()?);
+
+    let (server_stream, client_stream) = common::get_streams().await?;
+    let client_stream = common::TestStream::new(client_stream);
+    let overrides = client_stream.overrides();
+    let (mut client, _) =
+        common::run_negotiate(&client, client_stream, &server, server_stream).await?;
+
+    // Setup read to fail
+    overrides.next_read(Some(Box::new(|_, _, _| {
+        Ready(Err(io::Error::from(Error::InvalidInput)))
+    })));
+
+    // Verify read fails
+    let mut received = [0; 1];
+    let result = client.read_exact(&mut received).await;
+    assert!(result.is_err());
 
     Ok(())
 }

--- a/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
@@ -114,7 +114,11 @@ async fn shutdown_with_blinding() -> Result<(), Box<dyn std::error::Error>> {
     );
     assert!(timeout.is_err());
 
-    // Shutdown MUST eventually gracefully complete after blinding
+    // Shutdown MUST eventually complete after blinding.
+    //
+    // We check for completion, but not for success. At the moment, the
+    // call to s2n_shutdown will fail. See `shutdown_with_blinding_slow()`
+    // for verification that s2n_shutdown eventually suceeds.
     let (timeout, _) = join!(
         time::timeout(common::MAX_BLINDING_SECS, server.shutdown()),
         time::timeout(common::MAX_BLINDING_SECS, read_until_shutdown(&mut client)),

--- a/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
@@ -5,13 +5,15 @@ use s2n_tls::raw::error;
 use s2n_tls_tokio::{TlsAcceptor, TlsConnector, TlsStream};
 use std::convert::TryFrom;
 use tokio::{
-    io::{AsyncReadExt, AsyncWrite, AsyncWriteExt},
-    net::TcpStream,
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    join, time,
 };
 
-mod common;
+pub mod common;
 
-async fn read_until_shutdown(stream: &mut TlsStream<TcpStream>) -> Result<(), std::io::Error> {
+async fn read_until_shutdown<S: AsyncRead + AsyncWrite + Unpin>(
+    stream: &mut TlsStream<S>,
+) -> Result<(), std::io::Error> {
     let mut received = [0; 1];
     // Zero bytes read indicates EOF
     while stream.read(&mut received).await? != 0 {}
@@ -78,6 +80,90 @@ async fn shutdown_after_split() -> Result<(), Box<dyn std::error::Error>> {
         client_reader.read(&mut received),
         write_until_shutdown(&mut client_writer),
     )?;
+
+    Ok(())
+}
+
+#[tokio::test(start_paused = true)]
+async fn shutdown_with_blinding() -> Result<(), Box<dyn std::error::Error>> {
+    let client = TlsConnector::new(common::client_config()?.build()?);
+    let server = TlsAcceptor::new(common::server_config()?.build()?);
+
+    let (server_stream, client_stream) = common::get_streams().await?;
+    let server_stream = common::TestStream::new(server_stream);
+    let overrides = server_stream.overrides();
+    let (mut client, mut server) =
+        common::run_negotiate(&client, client_stream, &server, server_stream).await?;
+
+    // Trigger a blinded error.
+    overrides.next_read(Some(Box::new(|_, _, buf| {
+        // Parsing the header is one of the blinded operations
+        // in s2n_recv, so provide a malformed header.
+        let zeroed_header = [23, 0, 0, 0, 0];
+        buf.put_slice(&zeroed_header);
+        Ok(()).into()
+    })));
+    let mut received = [0; 1];
+    let result = server.read_exact(&mut received).await;
+    assert!(result.is_err());
+
+    // Shutdown MUST NOT complete faster than minimal blinding time.
+    let (timeout, _) = join!(
+        time::timeout(common::MIN_BLINDING_SECS, server.shutdown()),
+        time::timeout(common::MIN_BLINDING_SECS, read_until_shutdown(&mut client)),
+    );
+    assert!(timeout.is_err());
+
+    // Shutdown MUST eventually gracefully complete after blinding
+    let (timeout, _) = join!(
+        time::timeout(common::MAX_BLINDING_SECS, server.shutdown()),
+        time::timeout(common::MAX_BLINDING_SECS, read_until_shutdown(&mut client)),
+    );
+    assert!(timeout.is_ok());
+
+    Ok(())
+}
+
+// Ignore because:
+// 1) This test is slow. We can avoid Tokio sleeps with time::pause,
+//    but I couldn't find a good way to do the same to the system time the underlying C uses.
+// 2) This test currently fails due to bugs in the underlying s2n_shutdown method.
+#[ignore]
+#[tokio::test]
+async fn shutdown_with_blinding_slow() -> Result<(), Box<dyn std::error::Error>> {
+    let client = TlsConnector::new(common::client_config()?.build()?);
+    let server = TlsAcceptor::new(common::server_config()?.build()?);
+
+    let (server_stream, client_stream) = common::get_streams().await?;
+    let server_stream = common::TestStream::new(server_stream);
+    let overrides = server_stream.overrides();
+    let (mut client, mut server) =
+        common::run_negotiate(&client, client_stream, &server, server_stream).await?;
+
+    // Trigger a blinded error.
+    overrides.next_read(Some(Box::new(|_, _, buf| {
+        // Parsing the header is one of the blinded operations
+        // in s2n_recv, so provide a malformed header.
+        let zeroed_header = [23, 0, 0, 0, 0];
+        buf.put_slice(&zeroed_header);
+        Ok(()).into()
+    })));
+    let mut received = [0; 1];
+    let result = server.read_exact(&mut received).await;
+    assert!(result.is_err());
+
+    // Shutdown MUST eventually gracefully complete after blinding
+    let (timeout, _) = join!(
+        time::timeout(common::MAX_BLINDING_SECS.mul_f32(1.1), server.shutdown()),
+        time::timeout(
+            common::MAX_BLINDING_SECS.mul_f32(1.1),
+            read_until_shutdown(&mut client)
+        ),
+    );
+
+    // Verify shutdown succeeded
+    let result = timeout?;
+    assert!(result.is_ok());
 
     Ok(())
 }

--- a/bindings/rust/s2n-tls/src/raw/connection.rs
+++ b/bindings/rust/s2n-tls/src/raw/connection.rs
@@ -123,6 +123,13 @@ impl Connection {
         Ok(self)
     }
 
+    /// Reports the remaining nanoseconds before the connection may be safely closed.
+    ///
+    /// If [`shutdown`] is called before this method reports "0", then an error will occur.
+    pub fn remaining_blinding_nanos(&self) -> Result<u64, Error> {
+        unsafe { s2n_connection_get_delay(self.connection.as_ptr()).into_result() }
+    }
+
     /// Sets whether or not a Client Certificate should be required to complete the TLS Connection.
     ///
     /// If this is set to ClientAuthType::Optional the server will request a client certificate

--- a/bindings/rust/s2n-tls/src/raw/connection.rs
+++ b/bindings/rust/s2n-tls/src/raw/connection.rs
@@ -19,7 +19,7 @@ use core::{
 };
 use libc::c_void;
 use s2n_tls_sys::*;
-use std::{ffi::CStr, mem};
+use std::{ffi::CStr, mem, time::Duration};
 
 mod builder;
 pub use builder::*;
@@ -126,8 +126,9 @@ impl Connection {
     /// Reports the remaining nanoseconds before the connection may be safely closed.
     ///
     /// If [`shutdown`] is called before this method reports "0", then an error will occur.
-    pub fn remaining_blinding_nanos(&self) -> Result<u64, Error> {
-        unsafe { s2n_connection_get_delay(self.connection.as_ptr()).into_result() }
+    pub fn remaining_blinding_delay(&self) -> Result<Duration, Error> {
+        let nanos = unsafe { s2n_connection_get_delay(self.connection.as_ptr()).into_result() }?;
+        Ok(Duration::from_nanos(nanos))
     }
 
     /// Sets whether or not a Client Certificate should be required to complete the TLS Connection.

--- a/bindings/rust/s2n-tls/src/raw/error.rs
+++ b/bindings/rust/s2n-tls/src/raw/error.rs
@@ -70,6 +70,27 @@ impl Fallible for isize {
     }
 }
 
+impl Fallible for u64 {
+    type Output = Self;
+
+    /// Converts a u64 to a Result by checking for the maximum value.
+    ///
+    /// If a method that returns an unsigned int is fallible,
+    /// then the -1 error result wraps around to the maximum value.
+    /// The maximum value must not be possible otherwise.
+    ///
+    /// For example, [`s2n_connection_get_delay`] can't return
+    /// the maximum value because s2n-tls blinding delays are limited
+    /// to 30s, or a return value of 3^10.
+    fn into_result(self) -> Result<Self::Output, Error> {
+        if self != Self::MAX {
+            Ok(self)
+        } else {
+            Err(Error::capture())
+        }
+    }
+}
+
 impl<T> Fallible for *mut T {
     type Output = NonNull<T>;
 
@@ -218,6 +239,12 @@ impl TryFrom<std::io::Error> for Error {
             .downcast::<Self>()
             .map(|error| *error)
             .map_err(|_| Error::InvalidInput)
+    }
+}
+
+impl From<Error> for std::io::Error {
+    fn from(input: Error) -> Self {
+        std::io::Error::new(std::io::ErrorKind::Other, input)
     }
 }
 

--- a/bindings/rust/s2n-tls/src/raw/error.rs
+++ b/bindings/rust/s2n-tls/src/raw/error.rs
@@ -73,15 +73,17 @@ impl Fallible for isize {
 impl Fallible for u64 {
     type Output = Self;
 
-    /// Converts a u64 to a Result by checking for the maximum value.
+    /// Converts a u64 to a Result by checking for u64::MAX.
     ///
     /// If a method that returns an unsigned int is fallible,
-    /// then the -1 error result wraps around to the maximum value.
-    /// The maximum value must not be possible otherwise.
+    /// then the -1 error result wraps around to u64::MAX.
     ///
-    /// For example, [`s2n_connection_get_delay`] can't return
-    /// the maximum value because s2n-tls blinding delays are limited
-    /// to 30s, or a return value of 3^10.
+    /// For a u64 to be Fallible, a result of u64::MAX must not be
+    /// possible without an error. For example, [`s2n_connection_get_delay`]
+    /// can't return u64::MAX as a valid result because
+    /// s2n-tls blinding delays are limited to 30s, or a return value of 3^10 ns,
+    /// which is significantly less than u64::MAX. [`s2n_connection_get_delay`]
+    /// would therefore only return u64::MAX for a -1 error result.
     fn into_result(self) -> Result<Self::Output, Error> {
         if self != Self::MAX {
             Ok(self)

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1365,6 +1365,11 @@ int s2n_negotiate_impl(struct s2n_connection *conn, s2n_blocked_status *blocked)
         /* Flush any pending I/O or alert messages */
         POSIX_GUARD(s2n_flush(conn, blocked));
 
+        /* If the connection is closed, the handshake will never complete. */
+        if (conn->closed) {
+            POSIX_BAIL(S2N_ERR_CLOSED);
+        }
+
         /* If the handshake was paused, retry the current message */
         if (conn->handshake.paused) {
             *blocked = S2N_BLOCKED_ON_APPLICATION_INPUT;


### PR DESCRIPTION
### Description of changes: 

This one's a little long, but mostly tests.

Currently, TlsStream uses the default built-in blinding, which means that a blinded error causes the underlying s2n-tls library to block the thread until the blinding delay (10-30s) has passed. Instead, we need to use self-service blinding and wait asynchronously on the blinding.

I added the wait to `poll_shutdown()`. s2n-tls actually enforces the wait immediately when the error occurs (so in s2n_negotiate or s2n_recv), but that complicated the implementation since I'd need to save the result of s2n_negotiate and s2n_recv to be returned after the blinding. Enforcing the blinding in shutdown should be sufficient, since shutdown is what responds to the peer and closes the connection.

I also added logic to call shutdown if the handshake fails. Because the TlsStream isn't returned to the caller if the handshake fails, the caller can't be responsible for gracefully shutting down connections after failed handshakes. We need to do it for them.

Currently, calling s2n_shutdown usually doesn't work:
* If a close_notify alert is received during s2n_negotiate, it is not considered an error and the handshake tries to continue. However, there will be no more data, so the handshake just hangs. I added a minimal fix for this by at least checking that the connection isn't closed before trying to continue the handshake.
* If a blinded error occurs during s2n_recv, and we try to call s2n_negotiate afterwards, usually the fatal error in s2n_recv will have left the connection in such a state that it can't receive the peer's close_notify and s2n_shutdown will fail. I did not fix this bug as part of this PR.

### Testing:

Testing this proved a little tricky, since it required specific errors from send / receive. All the existing test utilities I found required knowing the exact sequence of reads and writes, which we don't because of the handshake. So I added a little test stream that allows read and write to be temporarily overridden, but usually just calls a real stream.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
