### PR TITLE
Add additional compliance comments and tests for TLS RFC section 4.1.4

### DIFF
--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -990,6 +990,32 @@ int main(int argc, char **argv)
     }
 
     /**
+     * Ensure all hello retry extensions sent by the server will have first
+     * been sent by the client.
+     *
+     *= https://tools.ietf.org/rfc/rfc8446#4.1.4
+     *= type=test
+     *# As with the ServerHello, a HelloRetryRequest MUST NOT contain any
+     *# extensions that were not first offered by the client in its
+     *# ClientHello, with the exception of optionally the "cookie" (see
+     *# Section 4.2.2) extension.
+     **/
+    {
+        s2n_extension_type_list *hello_retry_extension_types;
+        POSIX_GUARD(s2n_extension_type_list_get(S2N_EXTENSION_LIST_HELLO_RETRY_REQUEST, &hello_retry_extension_types));
+
+        for (int i = 0; i < hello_retry_extension_types->count; ++i) {
+            const s2n_extension_type *const extension_type = hello_retry_extension_types->extension_types[i];
+
+            /* with the exception of optionally the "cookie" extension. */
+            if (extension_type->iana_value == TLS_EXTENSION_COOKIE) {
+                continue;
+            }
+
+            EXPECT_TRUE(extension_type->is_response);
+        }
+    }
+
      * Ensure each of the following are checked: legacy_version,
      * legacy_session_id_echo, cipher_suite, and
      * legacy_compression_method
@@ -1260,7 +1286,7 @@ int main(int argc, char **argv)
 
          /* Client receives HelloRetryRequest */
          EXPECT_FAILURE_WITH_ERRNO(s2n_server_hello_recv(client_conn),
-                                   S2N_ERR_BAD_MESSAGE);
+                                   S2N_ERR_MISSING_EXTENSION);
      }
 
      /**

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -37,6 +37,7 @@
 
 #include "utils/s2n_safety.h"
 #include "utils/s2n_random.h"
+#include "utils/s2n_bitmap.h"
 
 /* From RFC5246 7.4.1.2. */
 #define S2N_TLS_COMPRESSION_METHOD_NULL 0
@@ -164,6 +165,17 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
     }
 
     POSIX_GUARD(s2n_server_extensions_recv(conn, in));
+
+    /**
+    *= https://tools.ietf.org/rfc/rfc8446#4.1.4
+    *# The server's extensions MUST contain "supported_versions".
+    **/
+    if (s2n_is_hello_retry_message(conn)) {
+        s2n_extension_type_id supported_versions_id;
+        POSIX_GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_SUPPORTED_VERSIONS, &supported_versions_id));
+        POSIX_ENSURE(S2N_CBIT_TEST(conn->extension_responses_received, supported_versions_id),
+                     S2N_ERR_MISSING_EXTENSION);
+    }
 
     if (conn->server_protocol_version >= S2N_TLS13) {
 


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

This PR is an extension of #3337, that adds additional comments/tests from the TLS RFC section 4.1.4 that depend on changes in #3358.

This PR depends on #3358.

### Call-outs:

None

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
