### PR TITLE
[bindings] Fix clap dependency

### DIFF
--- a/bindings/rust/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/s2n-tls-tokio/Cargo.toml
@@ -17,6 +17,6 @@ s2n-tls = { version = "=0.0.8", path = "../s2n-tls" }
 tokio = { version = "1", features = ["net", "time"] }
 
 [dev-dependencies]
-clap = { version = "3.1", features = ["derive"] }
+clap = { version = "~3.1", features = ["derive"] }
 rand = { version = "0.8" }
 tokio = { version = "1", features = [ "io-std", "io-util", "macros", "net", "rt-multi-thread", "test-util", "time"] }


### PR DESCRIPTION
### Description of changes: 

Looks like clap deprecated a bunch of stuff in 3.2. 

I made a quick attempt to figure out how our use of the clap derive annotations is affected by what they deprecated, but couldn't find anything. We don't use any of the affected stuff directly, and our annotations still match the examples. So I'm still not sure why we're getting deprecation warnings from clippy.

To avoid breaking the CI and blocking PRs, let's just not upgrade clap to 3.2 for now.

### Testing:
clippy passes locally and in the CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
