### PR TITLE
Import Microsoft's recent PQCrypto-SIDH SIKE patches into s2n

### DIFF
--- a/pq-crypto/sike_r1/ec_isogeny_r1.c
+++ b/pq-crypto/sike_r1/ec_isogeny_r1.c
@@ -31,11 +31,10 @@ void xDBLe(const point_proj_t P, point_proj_t Q, const f2elm_t *A24plus, const f
 { // Computes [2^e](X:Z) on Montgomery curve with projective constant via e repeated doublings.
   // Input: projective Montgomery x-coordinates P = (XP:ZP), such that xP=XP/ZP and Montgomery curve constants A+2C and 4C.
   // Output: projective Montgomery x-coordinates Q <- (2^e)*P.
-    int i;
     
     copy_words((const digit_t*)P, (digit_t*)Q, 2*2*NWORDS_FIELD);
 
-    for (i = 0; i < e; i++) {
+    for (int i = 0; i < e; i++) {
         xDBL(Q, Q, A24plus, C24);
     }
 }
@@ -121,11 +120,10 @@ void xTPLe(const point_proj_t P, point_proj_t Q, const f2elm_t *A24minus, const 
 { // Computes [3^e](X:Z) on Montgomery curve with projective constant via e repeated triplings.
   // Input: projective Montgomery x-coordinates P = (XP:ZP), such that xP=XP/ZP and Montgomery curve constants A24plus = A+2C and A24minus = A-2C.
   // Output: projective Montgomery x-coordinates Q <- (3^e)*P.
-    int i;
         
     copy_words((const digit_t*)P, (digit_t*)Q, 2*2*NWORDS_FIELD);
 
-    for (i = 0; i < e; i++) {
+    for (int i = 0; i < e; i++) {
         xTPL(Q, Q, A24minus, A24plus);
     }
 }
@@ -342,5 +340,49 @@ static void LADDER3PT(const f2elm_t *xP, const f2elm_t *xQ, const f2elm_t *xPQ, 
         swap_points(R, R2, mask);
         xDBLADD(R0, R2, &R->X, A24);
         fp2mul_mont(&R2->X, &R->Z, &R2->X);
+    }
+}
+
+void xTPL_fast(const point_proj_t P, point_proj_t Q, const f2elm_t *A2)
+{ // Montgomery curve (E: y^2 = x^3 + A*x^2 + x) x-only tripling at a cost of 5M + 6S + 11A.
+  // Input : projective Montgomery x-coordinates P = (X:Z), where x=X/Z and Montgomery curve constant A/2.
+  // Output: projective Montgomery x-coordinates Q = 3*P = (X3:Z3).
+    f2elm_t _t1, _t2, _t3, _t4;
+    f2elm_t *t1=&_t1, *t2=&_t2, *t3=&_t3, *t4=&_t4;
+
+    fp2sqr_mont(&P->X, t1);       // t1 = x^2
+    fp2sqr_mont(&P->Z, t2);       // t2 = z^2
+    fp2add(t1, t2, t3);           // t3 = t1 + t2
+    fp2add(&P->X, &P->Z, t4);       // t4 = x + z
+    fp2sqr_mont(t4, t4);          // t4 = t4^2
+    fp2sub(t4, t3, t4);           // t4 = t4 - t3
+    fp2mul_mont(A2, t4, t4);      // t4 = t4*A2
+    fp2add(t3, t4, t4);           // t4 = t4 + t3
+    fp2sub(t1, t2, t3);           // t3 = t1 - t2
+    fp2sqr_mont(t3, t3);          // t3 = t3^2
+    fp2mul_mont(t1, t4, t1);      // t1 = t1*t4
+    fp2add(t1, t1, t1);           // t1 = 2*t1
+    fp2add(t1, t1, t1);           // t1 = 4*t1
+    fp2sub(t1, t3, t1);           // t1 = t1 - t3
+    fp2sqr_mont(t1, t1);          // t1 = t1^2
+    fp2mul_mont(t2, t4, t2);      // t2 = t2*t4
+    fp2add(t2, t2, t2);           // t2 = 2*t2
+    fp2add(t2, t2, t2);           // t2 = 4*t2
+    fp2sub(t2, t3, t2);           // t2 = t2 - t3
+    fp2sqr_mont(t2, t2);          // t2 = t2^2
+    fp2mul_mont(&P->X, t2, &Q->X);  // x = x*t2
+    fp2mul_mont(&P->Z, t1, &Q->Z);  // z = z*t1
+}
+
+
+void xTPLe_fast(point_proj_t P, point_proj_t Q, const f2elm_t *A2, int e)
+{ // Computes [3^e](X:Z) on Montgomery curve with projective constant via e repeated triplings. e triplings in E costs e*(5M + 6S + 11A)
+  // Input: projective Montgomery x-coordinates P = (X:Z), where x=X/Z, Montgomery curve constant A2 = A/2 and the number of triplings e.
+  // Output: projective Montgomery x-coordinates Q <- [3^e]P.
+
+    copy_words((digit_t*)P, (digit_t*)Q, 2 * 2 * NWORDS_FIELD);
+
+    for (int i = 0; i < e; i++) {
+        xTPL_fast(Q, Q, A2);
     }
 }

--- a/pq-crypto/sike_r1/fpx_r1.c
+++ b/pq-crypto/sike_r1/fpx_r1.c
@@ -333,6 +333,17 @@ void from_fp2mont(const f2elm_t *ma, f2elm_t *c)
     from_mont(ma->e[1], c->e[1]);
 }
 
+unsigned int is_felm_zero(const felm_t x)
+{ // Is x = 0? return 1 (TRUE) if condition is true, 0 (FALSE) otherwise.
+  // SECURITY NOTE: This function does not run in constant-time.
+
+    for (unsigned int i = 0; i < NWORDS_FIELD; i++) {
+        if (x[i] != 0) {
+            return 0;
+        }
+    }
+    return 1;
+}
 
 unsigned int mp_add(const digit_t* a, const digit_t* b, digit_t* c, const unsigned int nwords)
 { // Multiprecision addition, c = a+b, where lng(a) = lng(b) = nwords. Returns the carry bit.

--- a/pq-crypto/sike_r1/sike_r1_namespace.h
+++ b/pq-crypto/sike_r1/sike_r1_namespace.h
@@ -20,6 +20,8 @@
 #define xDBLADD xDBLADD_r1
 #define swap_points swap_points_r1
 #define LADDER3PT LADDER3PT_r1
+#define xTPL_fast xTPL_fast_r1
+#define xTPLe_fast xTPLe_fast_r1
 #define load64 load64_r1
 #define store64 store64_r1
 #define KeccakF1600_StatePermute KeccakF1600_StatePermute_r1
@@ -39,6 +41,7 @@
 #define mp_subfast mp_subfast_r1
 #define to_fp2mont to_fp2mont_r1
 #define from_fp2mont from_fp2mont_r1
+#define is_felm_zero is_felm_zero_r1
 #define mp_add mp_add_r1
 #define mp_shiftr1 mp_shiftr1_r1
 #define Alice_order Alice_order_r1

--- a/pq-crypto/sike_r3/sikep434r3_ec_isogeny.c
+++ b/pq-crypto/sike_r3/sikep434r3_ec_isogeny.c
@@ -33,11 +33,9 @@ void xDBL(const point_proj_t P, point_proj_t Q, const f2elm_t *A24plus, const f2
  * Output: projective Montgomery x-coordinates Q <- (2^e)*P. */
 void xDBLe(const point_proj_t P, point_proj_t Q, const f2elm_t *A24plus, const f2elm_t *C24, const int e)
 {
-    int i;
-    
     copy_words((const digit_t*)P, (digit_t*)Q, 2*2*S2N_SIKE_P434_R3_NWORDS_FIELD);
 
-    for (i = 0; i < e; i++) {
+    for (int i = 0; i < e; i++) {
         xDBL(Q, Q, A24plus, C24);
     }
 }
@@ -121,11 +119,9 @@ void xTPL(const point_proj_t P, point_proj_t Q, const f2elm_t *A24minus, const f
  * Output: projective Montgomery x-coordinates Q <- (3^e)*P. */
 void xTPLe(const point_proj_t P, point_proj_t Q, const f2elm_t *A24minus, const f2elm_t *A24plus, const int e)
 {
-    int i;
-        
     copy_words((const digit_t*)P, (digit_t*)Q, 2*2*S2N_SIKE_P434_R3_NWORDS_FIELD);
 
-    for (i = 0; i < e; i++) {
+    for (int i = 0; i < e; i++) {
         xTPL(Q, Q, A24minus, A24plus);
     }
 }
@@ -345,4 +341,48 @@ void LADDER3PT(const f2elm_t *xP, const f2elm_t *xQ, const f2elm_t *xPQ, const d
     swap = 0 ^ prevbit;
     mask = 0 - (digit_t)swap;
     swap_points(R, R2, mask);
+}
+
+void xTPL_fast(const point_proj_t P, point_proj_t Q, const f2elm_t *A2)
+{ // Montgomery curve (E: y^2 = x^3 + A*x^2 + x) x-only tripling at a cost of 5M + 6S + 11A.
+  // Input : projective Montgomery x-coordinates P = (X:Z), where x=X/Z and Montgomery curve constant A/2.
+  // Output: projective Montgomery x-coordinates Q = 3*P = (X3:Z3).
+    f2elm_t _t1, _t2, _t3, _t4;
+    f2elm_t *t1=&_t1, *t2=&_t2, *t3=&_t3, *t4=&_t4;
+
+    fp2sqr_mont(&P->X, t1);       // t1 = x^2
+    fp2sqr_mont(&P->Z, t2);       // t2 = z^2
+    fp2add(t1, t2, t3);           // t3 = t1 + t2
+    fp2add(&P->X, &P->Z, t4);       // t4 = x + z
+    fp2sqr_mont(t4, t4);          // t4 = t4^2
+    fp2sub(t4, t3, t4);           // t4 = t4 - t3
+    fp2mul_mont(A2, t4, t4);      // t4 = t4*A2
+    fp2add(t3, t4, t4);           // t4 = t4 + t3
+    fp2sub(t1, t2, t3);           // t3 = t1 - t2
+    fp2sqr_mont(t3, t3);          // t3 = t3^2
+    fp2mul_mont(t1, t4, t1);      // t1 = t1*t4
+    fp2add(t1, t1, t1);           // t1 = 2*t1
+    fp2add(t1, t1, t1);           // t1 = 4*t1
+    fp2sub(t1, t3, t1);           // t1 = t1 - t3
+    fp2sqr_mont(t1, t1);          // t1 = t1^2
+    fp2mul_mont(t2, t4, t2);      // t2 = t2*t4
+    fp2add(t2, t2, t2);           // t2 = 2*t2
+    fp2add(t2, t2, t2);           // t2 = 4*t2
+    fp2sub(t2, t3, t2);           // t2 = t2 - t3
+    fp2sqr_mont(t2, t2);          // t2 = t2^2
+    fp2mul_mont(&P->X, t2, &Q->X);  // x = x*t2
+    fp2mul_mont(&P->Z, t1, &Q->Z);  // z = z*t1
+}
+
+
+void xTPLe_fast(point_proj_t P, point_proj_t Q, const f2elm_t *A2, int e)
+{ // Computes [3^e](X:Z) on Montgomery curve with projective constant via e repeated triplings. e triplings in E costs e*(5M + 6S + 11A)
+  // Input: projective Montgomery x-coordinates P = (X:Z), where x=X/Z, Montgomery curve constant A2 = A/2 and the number of triplings e.
+  // Output: projective Montgomery x-coordinates Q <- [3^e]P.
+
+    copy_words((digit_t*)P, (digit_t*)Q, 2 * 2 * S2N_SIKE_P434_R3_NWORDS_FIELD);
+
+    for (int i = 0; i < e; i++) {
+        xTPL_fast(Q, Q, A2);
+    }
 }

--- a/pq-crypto/sike_r3/sikep434r3_ec_isogeny.h
+++ b/pq-crypto/sike_r3/sikep434r3_ec_isogeny.h
@@ -44,3 +44,9 @@ void j_inv(const f2elm_t *A, const f2elm_t *C, f2elm_t *jinv);
 #define LADDER3PT S2N_SIKE_P434_R3_NAMESPACE(LADDER3PT)
 void LADDER3PT(const f2elm_t *xP, const f2elm_t *xQ, const f2elm_t *xPQ, const digit_t *m,
         const unsigned int AliceOrBob, point_proj_t R, const f2elm_t *A);
+
+#define xTPL_fast S2N_SIKE_P434_R3_NAMESPACE(xTPL_fast)
+void xTPL_fast(const point_proj_t P, point_proj_t Q, const f2elm_t *A2);
+
+#define xTPLe_fast S2N_SIKE_P434_R3_NAMESPACE(xTPLe_fast)
+void xTPLe_fast(point_proj_t P, point_proj_t Q, const f2elm_t *A2, int e);

--- a/pq-crypto/sike_r3/sikep434r3_fpx.h
+++ b/pq-crypto/sike_r3/sikep434r3_fpx.h
@@ -25,6 +25,9 @@ void fp2copy(const f2elm_t *a, f2elm_t *c);
 #define fp2div2 S2N_SIKE_P434_R3_NAMESPACE(fp2div2)
 void fp2div2(const f2elm_t *a, f2elm_t *c);
 
+#define fp2correction S2N_SIKE_P434_R3_NAMESPACE(fp2correction)
+void fp2correction(f2elm_t *a);
+
 #define mp_add S2N_SIKE_P434_R3_NAMESPACE(mp_add)
 unsigned int mp_add(const digit_t* a, const digit_t* b, digit_t* c, const unsigned int nwords);
 
@@ -39,6 +42,9 @@ void fp2inv_mont(f2elm_t *a);
 
 #define mp_shiftr1 S2N_SIKE_P434_R3_NAMESPACE(mp_shiftr1)
 void mp_shiftr1(digit_t* x, const unsigned int nwords);
+
+#define is_felm_zero S2N_SIKE_P434_R3_NAMESPACE(is_felm_zero)
+unsigned int is_felm_zero(const felm_t x);
 
 #define decode_to_digits S2N_SIKE_P434_R3_NAMESPACE(decode_to_digits)
 void decode_to_digits(const unsigned char* x, digit_t* dec, int nbytes, int ndigits);

--- a/pq-crypto/sike_r3/sikep434r3_kem.c
+++ b/pq-crypto/sike_r3/sikep434r3_kem.c
@@ -81,9 +81,13 @@ int s2n_sike_p434_r3_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, 
     unsigned char h_[S2N_SIKE_P434_R3_MSG_BYTES];
     unsigned char c0_[S2N_SIKE_P434_R3_PUBLIC_KEY_BYTES];
     unsigned char temp[S2N_SIKE_P434_R3_CIPHERTEXT_BYTES+S2N_SIKE_P434_R3_MSG_BYTES];
+    bool dont_copy = 1;
 
     /* Decrypt */
-    EphemeralSecretAgreement_B(sk + S2N_SIKE_P434_R3_MSG_BYTES, ct, jinvariant_);
+    if (!(EphemeralSecretAgreement_B(sk + S2N_SIKE_P434_R3_MSG_BYTES, ct, jinvariant_) == 0)) {
+        goto S2N_SIKE_P434_R3_HASHING;
+    }
+
     shake256(h_, S2N_SIKE_P434_R3_MSG_BYTES, jinvariant_, S2N_SIKE_P434_R3_FP2_ENCODED_BYTES);
     for (int i = 0; i < S2N_SIKE_P434_R3_MSG_BYTES; i++) {
         temp[i] = ct[i + S2N_SIKE_P434_R3_PUBLIC_KEY_BYTES] ^ h_[i];
@@ -103,7 +107,8 @@ int s2n_sike_p434_r3_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, 
      *
      * If c0_ and ct are equal, then decaps succeeded and we skip the overwrite and output
      * the actual shared secret: ss = H(m||ct) (dont_copy = true). */
-    bool dont_copy = s2n_constant_time_equals(c0_, ct, S2N_SIKE_P434_R3_PUBLIC_KEY_BYTES);
+    dont_copy = s2n_constant_time_equals(c0_, ct, S2N_SIKE_P434_R3_PUBLIC_KEY_BYTES);
+S2N_SIKE_P434_R3_HASHING:
     POSIX_GUARD(s2n_constant_time_copy_or_dont(temp, sk, S2N_SIKE_P434_R3_MSG_BYTES, dont_copy));
     memcpy(&temp[S2N_SIKE_P434_R3_MSG_BYTES], ct, S2N_SIKE_P434_R3_CIPHERTEXT_BYTES);
     shake256(ss, S2N_SIKE_P434_R3_SHARED_SECRET_BYTES, temp, S2N_SIKE_P434_R3_CIPHERTEXT_BYTES+S2N_SIKE_P434_R3_MSG_BYTES);

--- a/pq-crypto/sike_r3/sikep434r3_sidh.c
+++ b/pq-crypto/sike_r3/sikep434r3_sidh.c
@@ -245,15 +245,57 @@ int EphemeralSecretAgreement_A(const unsigned char* PrivateKeyA, const unsigned 
     return 0;
 }
 
+int sike_p434_r3_publickey_validation(const f2elm_t *PKB, const f2elm_t *A)
+{ // Public key validation
+    point_proj_t P = { 0 }, Q = { 0 };
+    f2elm_t _A2={0}, _tmp1={0}, _tmp2={0};
+    f2elm_t *A2=&_A2, *tmp1=&_tmp1, *tmp2=&_tmp2;
+
+    // Verify that P and Q generate E_A[3^e_3] by checking that [3^(e_3-1)]P != [+-3^(e_3-1)]Q
+    fp2div2(A, A2);
+    fp2copy(&PKB[0], &P->X);
+    fpcopy((const digit_t*)&Montgomery_one, (digit_t*)&P->Z);
+    fp2copy(&PKB[1], &Q->X);
+    fpcopy((const digit_t*)&Montgomery_one, (digit_t*)&Q->Z);
+
+    xTPLe_fast(P, P, A2, S2N_SIKE_P434_R3_MAX_BOB - 1);
+    xTPLe_fast(Q, Q, A2, S2N_SIKE_P434_R3_MAX_BOB - 1);
+    fp2correction(&P->Z);
+    fp2correction(&Q->Z);
+
+    if ((is_felm_zero((P->Z.e)[0]) && is_felm_zero((P->Z.e)[1])) || (is_felm_zero((Q->Z.e)[0]) && is_felm_zero((Q->Z.e)[1]))) {
+        return 1;
+    }
+
+    fp2mul_mont(&P->X, &Q->Z, tmp1);
+    fp2mul_mont(&P->Z, &Q->X, tmp2);
+    fp2correction(tmp1);
+    fp2correction(tmp2);
+
+    if (memcmp((uint8_t*)tmp1, (uint8_t*)tmp2, S2N_SIKE_P434_R3_FP2_ENCODED_BYTES) == 0) {
+        return 1;
+    }
+
+    // Check that Ord(P) = Ord(Q) = 3^(e_3)
+    xTPL_fast(P, P, A2);
+    xTPL_fast(Q, Q, A2);
+    fp2correction(&P->Z);
+    fp2correction(&Q->Z);
+
+    if (!is_felm_zero((P->Z.e)[0]) || !is_felm_zero((P->Z.e)[1]) || !is_felm_zero((Q->Z.e)[0]) || !is_felm_zero((Q->Z.e)[1])) {
+        return 1;
+    }
+
+    return 0;
+}
+
 /* Bob's ephemeral shared secret computation
  * It produces a shared secret key SharedSecretB using his secret key PrivateKeyB and Alice's public key PublicKeyA
  * Inputs: Bob's PrivateKeyB is an integer in the range [0, 2^Floor(Log(2,oB)) - 1].
  *     Alice's PublicKeyA consists of 3 elements in GF(p^2) encoded by removing leading 0 bytes.
  * Output: a shared secret SharedSecretB that consists of one element in GF(p^2) encoded
  *     by removing leading 0 bytes.   */
-int EphemeralSecretAgreement_B(const unsigned char* PrivateKeyB, const unsigned char* PublicKeyA,
-        unsigned char* SharedSecretB)
-{
+int EphemeralSecretAgreement_B(const unsigned char* PrivateKeyB, const unsigned char* PublicKeyA, unsigned char* SharedSecretB) {
     point_proj_t R, pts[S2N_SIKE_P434_R3_MAX_INT_POINTS_BOB];
     f2elm_t coeff[3], PKB[3], _jinv;
     f2elm_t _A24plus = {0}, _A24minus = {0}, _A = {0};
@@ -271,6 +313,11 @@ int EphemeralSecretAgreement_B(const unsigned char* PrivateKeyB, const unsigned 
     mp_add((const digit_t*)&Montgomery_one, (const digit_t*)&Montgomery_one, A24minus->e[0], S2N_SIKE_P434_R3_NWORDS_FIELD);
     mp2_add(A, A24minus, A24plus);
     mp2_sub_p2(A, A24minus, A24minus);
+
+    // Always perform public key validation before using peer's public key
+    if (sike_p434_r3_publickey_validation(PKB, A) == 1) {
+        return 1;
+    }
 
     /* Retrieve kernel point */
     decode_to_digits(PrivateKeyB, SecretKeyB, S2N_SIKE_P434_R3_SECRETKEY_B_BYTES, S2N_SIKE_P434_R3_NWORDS_ORDER);

--- a/tests/saw/sike_r1/proof/sidh.saw
+++ b/tests/saw/sike_r1/proof/sidh.saw
@@ -30,10 +30,11 @@ let fp2_encode_spec = do {
 };
 
 let sike_p503_r1_publickey_validation_spec = do {
-    (PKB, PKBp) <- A_f2elm_t "PKB";
-    (A, Ap) <- A_f2elm_t "A";
+    // Assume that sike_p503_r1_publickey_validation() always returns zero, and does not have any side effects when 
+    // called with pointers to two disjoint memory regions.
+    PKBp <- crucible_alloc_readonly f2elm_t;
+    Ap <- crucible_alloc_readonly f2elm_t;
     crucible_execute_func [PKBp, Ap];
-    // Assume that PublicKey Validation always succeeds
     crucible_return (crucible_term {{ 0:[32] }});
 };
 

--- a/tests/saw/sike_r1/proof/sidh.saw
+++ b/tests/saw/sike_r1/proof/sidh.saw
@@ -29,6 +29,14 @@ let fp2_encode_spec = do {
     crucible_points_to encp (tm enc);
 };
 
+let sike_p503_r1_publickey_validation_spec = do {
+    (PKB, PKBp) <- A_f2elm_t "PKB";
+    (A, Ap) <- A_f2elm_t "A";
+    crucible_execute_func [PKBp, Ap];
+    // Assume that PublicKey Validation always succeeds
+    crucible_return (crucible_term {{ 0:[32] }});
+};
+
 let random_mod_order_B_spec = do {
     random_digits_p <- crucible_alloc (llvm_array SECRETKEY_B_BYTES char_t);
     crucible_execute_func [random_digits_p];
@@ -89,6 +97,8 @@ fp2_encode_ov <- verify fp2_encode_fun_name
     [from_fp2mont_ov]
     fp2_encode_spec;
 
+sike_p503_r1_publickey_validation_ov <- crucible_llvm_unsafe_assume_spec m sike_p503_r1_publickey_validation_fun_name sike_p503_r1_publickey_validation_spec;
+
 let O_base_Key =
     [ fpcopy_ov
     , fpzero_ov
@@ -118,7 +128,8 @@ let O_base_KeyA = concat O_base_Key [ LADDER3PT_A_ov ];
 let O_base_KeyB = concat O_base_Key [ LADDER3PT_B_ov ];
 
 let O_base_Secret =
-    [ fpcopy_ov
+    [ sike_p503_r1_publickey_validation_ov
+    , fpcopy_ov
     , fpzero_ov
     , fp2copy_ov
     , fp2add_ov

--- a/tests/saw/sike_r1/proof/sike_r1_defs.saw
+++ b/tests/saw/sike_r1/proof/sike_r1_defs.saw
@@ -87,6 +87,7 @@ let random_mod_order_B_fun_name = "random_mod_order_B_r1";
 let init_basis_fun_name = "init_basis_r1";
 let fp2_decode_fun_name = "fp2_decode_r1";
 let fp2_encode_fun_name = "fp2_encode_r1";
+let sike_p503_r1_publickey_validation_fun_name = "sike_p503_r1_publickey_validation";
 let EphemeralKeyGeneration_A_fun_name = "EphemeralKeyGeneration_A_r1";
 let EphemeralKeyGeneration_B_fun_name = "EphemeralKeyGeneration_B_r1";
 let EphemeralSecretAgreement_A_fun_name = "EphemeralSecretAgreement_A_r1";


### PR DESCRIPTION
### Resolved issues:

Import Microsoft's recent PQCrypto-SIDH SIKE patches into s2n. 

### Description of changes: 

s2n-tls is **not** impacted by the Hertzbleed issue.

This PR is a port of this Microsoft PQCrypto-SIDH patch into s2n's SIKE Round 1 & Round 3 implementations: [microsoft/PQCrypto-SIDH@75ed5b0](https://github.com/microsoft/PQCrypto-SIDH/commit/75ed5b09bd06a19cdad7660bef10e820074f808f)

There are no s2n changes for SIKE Round 2 since s2n skipped adding support for SIKE Round 2 because there were no wire-format changes between SIKE Round 1 and SIKE Round 2.

### Call-outs:

Minor edits were made to Microsoft's PQCrypto-SIDH patch since s2n only supports `SIKE_p503_r1` and `SIKE_p434_r3` (instead of all SIKE parameter sizes). s2n also does not support the compressed versions of SIKE so those changes were not ported over either.

We are not impacted by Hertzbleed due to s2n's Hybrid PQ TLS design choices:
1. s2n currently always uses PQ KEM algorithms in Hybrid-mode where the PQ key is combined with a 2nd ECDHE key. Both keys are fed into a key derivation function (KDF) to generate the final TLS connection secret. An attacker who recovers a SIKE key would also need to recover the ECDHE key too in order to calculate the final TLS connection secret.
2. s2n doesn't re-use any PQ keys between TLS connections. Any PQ timing side channel will only have a single opportunity to be measured before the SIKE key for that TLS connection is discarded and a new one is generated.


### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Unit tests pass locally on my development machine.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
