### PR TITLE
Add integration test for buffered send

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -365,6 +365,22 @@ extern int s2n_config_set_wall_clock(struct s2n_config *config, s2n_clock_time_n
 S2N_API
 extern int s2n_config_set_monotonic_clock(struct s2n_config *config, s2n_clock_time_nanoseconds clock_fn, void *ctx);
 
+/** 
+ * Allows the caller to set a custom send buffer size. This buffer size will be use to override the default
+ * `s2n_send()` behavior of immediately sending created TLS records over the wire. After enabling this feature
+ * s2n-tls will use the specified buffer size and fill it with as many TLS records as possible before sending
+ * the buffer over the wire.
+ *
+ * @note The requested `buffer_byte_size` must be larger than 16KB to ensure that the buffer is larger than the maximum
+ * possible TLS record size.
+ *
+ * @param config The configuration object being updated
+ * @param buffer_byte_size The desired custom buffer size
+ * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
+ */
+S2N_API
+extern int s2n_config_set_custom_send_buffer_size(struct s2n_config *config, uint32_t buffer_byte_size);
+
 /**
  * Translates an s2n_error code to a human readable string explaining the error.
  *

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -231,7 +231,7 @@ static void setup_s2n_config(struct s2n_config *config, const char *cipher_prefs
     GUARD_EXIT(s2n_config_send_max_fragment_length(config, mfl_code), "Error setting maximum fragment length");
 
     if (send_buffer_byte_size > 0) {
-        GUARD_EXIT(s2n_config_set_send_buffer_size(config, send_buffer_byte_size), "Error setting send buffer size.");
+        GUARD_EXIT(s2n_config_set_custom_send_buffer_size(config, send_buffer_byte_size), "Error setting send buffer size.");
     }
 }
 

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -96,6 +96,8 @@ void usage()
     fprintf(stderr, "  -E ,--early-data <file path>\n");
     fprintf(stderr, "    Sends data in file path as early data to the server. Early data will only be sent if s2nc receives a session ticket and resumes a session.");
     fprintf(stderr, "\n");
+    fprintf(stderr, "  -b,--buffered-send <number of bytes>\n");
+    fprintf(stderr, "    Set s2n-send to buffer tls-records by <number of bytes> before sending them over the wire.\n");
     exit(1);
 }
 
@@ -123,7 +125,7 @@ static int test_session_ticket_cb(struct s2n_connection *conn, void *ctx, struct
 }
 
 static void setup_s2n_config(struct s2n_config *config, const char *cipher_prefs, s2n_status_request_type type,
-    struct verify_data *unsafe_verify_data, const char *host, const char *alpn_protocols, uint16_t mfl_value) {
+    struct verify_data *unsafe_verify_data, const char *host, const char *alpn_protocols, uint16_t mfl_value, uint32_t send_buffer_byte_size) {
 
     if (config == NULL) {
         print_s2n_error("Error getting new config");
@@ -227,6 +229,10 @@ static void setup_s2n_config(struct s2n_config *config, const char *cipher_prefs
     }
 
     GUARD_EXIT(s2n_config_send_max_fragment_length(config, mfl_code), "Error setting maximum fragment length");
+
+    if (send_buffer_byte_size > 0) {
+        GUARD_EXIT(s2n_config_set_send_buffer_size(config, send_buffer_byte_size), "Error setting send buffer size.");
+    }
 }
 
 int main(int argc, char *const *argv)
@@ -266,6 +272,7 @@ int main(int argc, char *const *argv)
     char *psk_optarg_list[S2N_MAX_PSK_LIST_LENGTH];
     size_t psk_list_len = 0;
     char *early_data = NULL;
+    uint32_t           send_buffer_byte_size = 0;
 
     static struct option long_options[] = {
         {"alpn", required_argument, 0, 'a'},
@@ -293,12 +300,13 @@ int main(int argc, char *const *argv)
         {"key-log", required_argument, 0, 'L'},
         {"psk", required_argument, 0, 'P'},
         {"early-data", required_argument, 0, 'E'},
+        { "buffered-send", required_argument, 0, 'b' },
         { 0 },
     };
 
     while (1) {
         int option_index = 0;
-        int c = getopt_long(argc, argv, "a:c:ehn:m:sf:d:l:k:D:t:irTCBL:P:E:", long_options, &option_index);
+        int c = getopt_long(argc, argv, "a:c:ehn:m:sf:d:l:k:D:t:irTCBL:P:E:b:", long_options, &option_index);
         if (c == -1) {
             break;
         }
@@ -389,6 +397,13 @@ int main(int argc, char *const *argv)
             early_data = load_file_to_cstring(optarg);
             GUARD_EXIT_NULL(early_data);
             break;
+        case 'b':
+            send_buffer_byte_size = (uint32_t) atoi(optarg);
+            if (send_buffer_byte_size < S2N_TLS_MAXIMUM_RECORD_LENGTH) {
+                fprintf(stderr, "Error setting buffered send size, the number of bytes must be larger than 16KB.\n");
+                exit(1);
+            }
+            break;
         case '?':
         default:
             usage();
@@ -478,7 +493,7 @@ int main(int argc, char *const *argv)
         }
 
         struct s2n_config *config = s2n_config_new();
-        setup_s2n_config(config, cipher_prefs, type, &unsafe_verify_data, host, alpn_protocols, mfl_value);
+        setup_s2n_config(config, cipher_prefs, type, &unsafe_verify_data, host, alpn_protocols, mfl_value, send_buffer_byte_size);
 
         if (client_cert_input != client_key_input) {
             print_s2n_error("Client cert/key pair must be given.");

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -96,6 +96,8 @@ void usage()
     fprintf(stderr, "  -E ,--early-data <file path>\n");
     fprintf(stderr, "    Sends data in file path as early data to the server. Early data will only be sent if s2nc receives a session ticket and resumes a session.");
     fprintf(stderr, "\n");
+    fprintf(stderr, "  -u,--buffered-send <number of bytes>\n");
+    fprintf(stderr, "    Set s2n-send to buffer tls-records by <number of bytes> before sending them over the wire.\n");
     exit(1);
 }
 
@@ -123,7 +125,7 @@ static int test_session_ticket_cb(struct s2n_connection *conn, void *ctx, struct
 }
 
 static void setup_s2n_config(struct s2n_config *config, const char *cipher_prefs, s2n_status_request_type type,
-    struct verify_data *unsafe_verify_data, const char *host, const char *alpn_protocols, uint16_t mfl_value) {
+    struct verify_data *unsafe_verify_data, const char *host, const char *alpn_protocols, uint16_t mfl_value, uint32_t send_buffer_byte_size) {
 
     if (config == NULL) {
         print_s2n_error("Error getting new config");
@@ -227,6 +229,10 @@ static void setup_s2n_config(struct s2n_config *config, const char *cipher_prefs
     }
 
     GUARD_EXIT(s2n_config_send_max_fragment_length(config, mfl_code), "Error setting maximum fragment length");
+
+    if (send_buffer_byte_size > 0) {
+        GUARD_EXIT(s2n_config_set_custom_send_buffer_size(config, send_buffer_byte_size), "Error setting send buffer size.");
+    }
 }
 
 int main(int argc, char *const *argv)
@@ -266,6 +272,7 @@ int main(int argc, char *const *argv)
     char *psk_optarg_list[S2N_MAX_PSK_LIST_LENGTH];
     size_t psk_list_len = 0;
     char *early_data = NULL;
+    uint32_t send_buffer_byte_size = 0;
 
     static struct option long_options[] = {
         {"alpn", required_argument, 0, 'a'},
@@ -293,12 +300,13 @@ int main(int argc, char *const *argv)
         {"key-log", required_argument, 0, 'L'},
         {"psk", required_argument, 0, 'P'},
         {"early-data", required_argument, 0, 'E'},
+        {"buffered-send", required_argument, 0, 'u' },
         { 0 },
     };
 
     while (1) {
         int option_index = 0;
-        int c = getopt_long(argc, argv, "a:c:ehn:m:sf:d:l:k:D:t:irTCBL:P:E:", long_options, &option_index);
+        int c = getopt_long(argc, argv, "a:c:ehn:m:sf:d:l:k:D:t:irTCBL:P:E:u:", long_options, &option_index);
         if (c == -1) {
             break;
         }
@@ -389,6 +397,9 @@ int main(int argc, char *const *argv)
             early_data = load_file_to_cstring(optarg);
             GUARD_EXIT_NULL(early_data);
             break;
+        case 'u':
+            send_buffer_byte_size = (uint32_t) atoi(optarg);
+            break;
         case '?':
         default:
             usage();
@@ -478,7 +489,7 @@ int main(int argc, char *const *argv)
         }
 
         struct s2n_config *config = s2n_config_new();
-        setup_s2n_config(config, cipher_prefs, type, &unsafe_verify_data, host, alpn_protocols, mfl_value);
+        setup_s2n_config(config, cipher_prefs, type, &unsafe_verify_data, host, alpn_protocols, mfl_value, send_buffer_byte_size);
 
         if (client_cert_input != client_key_input) {
             print_s2n_error("Client cert/key pair must be given.");

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -272,7 +272,7 @@ int main(int argc, char *const *argv)
     char *psk_optarg_list[S2N_MAX_PSK_LIST_LENGTH];
     size_t psk_list_len = 0;
     char *early_data = NULL;
-    uint32_t           send_buffer_byte_size = 0;
+    uint32_t send_buffer_byte_size = 0;
 
     static struct option long_options[] = {
         {"alpn", required_argument, 0, 'a'},
@@ -300,7 +300,7 @@ int main(int argc, char *const *argv)
         {"key-log", required_argument, 0, 'L'},
         {"psk", required_argument, 0, 'P'},
         {"early-data", required_argument, 0, 'E'},
-        { "buffered-send", required_argument, 0, 'b' },
+        {"buffered-send", required_argument, 0, 'b' },
         { 0 },
     };
 

--- a/codebuild/bin/install_openssl_1_1_1.sh
+++ b/codebuild/bin/install_openssl_1_1_1.sh
@@ -33,8 +33,13 @@ RELEASE=1_1_1-stable
 
 mkdir -p $BUILD_DIR
 cd "$BUILD_DIR"
-curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_${RELEASE}.zip --output OpenSSL_${RELEASE}.zip
+# Re-enable once OpenSSL 1.1.1 stable release is working.
+# curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_${RELEASE}.zip --output OpenSSL_${RELEASE}.zip
+curl --retry 3 -L https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_1_1o.zip --output OpenSSL_${RELEASE}.zip
+
 unzip OpenSSL_${RELEASE}.zip
+# Renae to avoid modfiying rest of script
+mv openssl-OpenSSL_1_1_1o openssl-OpenSSL_${RELEASE}
 cd openssl-OpenSSL_${RELEASE}
 
 if [ "$OS_NAME" == "linux" ]; then

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1654,7 +1654,7 @@ has stablized it can be reached from api/s2n.h. */
 int main(void) {
     struct s2n_config *config = s2n_config_new();
     /* Specify the desired send buffer size in bytes. */
-    s2n_config_set_send_buffer_size(config, SEND_BUFFER_SIZE_BYTES);
+    s2n_config_set_custom_send_buffer_size(config, SEND_BUFFER_SIZE_BYTES);
 
     struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
     /* The connection object will now be configured with the desired send buffer size. */

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1660,7 +1660,7 @@ int main(void) {
     /* The connection object will now be configured with the desired send buffer size. */
     s2n_connection_set_config(conn, config);
 
-    /* Now further changes are required for the feature to work. */
+    /* No further changes are required for the feature to work. */
 
     ...
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1321,8 +1321,6 @@ This buffer size cannot be smaller than 16KB, which is the maximum possible TLS 
 
 ### Example
 ```c
-/* Since this feature is unstable the required API can only be reached from a private header file. Once the feature
-has stablized it can be reached from api/s2n.h. */
 #include "api/s2n.h"
 
 #define SEND_BUFFER_SIZE_BYTES 65536

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1628,3 +1628,42 @@ int s2n_early_data_cb_async_impl(struct s2n_connection *conn, struct s2n_offered
 
 To understand the API it may be easiest to see examples in action. s2n-tls's [bin/](https://github.com/aws/s2n-tls/blob/main/bin/) directory
 includes an example client (s2nc) and server (s2nd).
+
+# Unstable Features
+
+This section covers new s2n-tls features that are not yet ready to join the public s2n-tls API. The use of these APIs should not be used for production workloads and 
+they are subject to changes. All public APIs can be found in [api/s2n.h](../api/s2n.h).
+
+## Buffered s2n_send
+
+s2n-tls has an unstable feature that allows `s2n_send` to buffer TLS records until the allotted buffer size is reached. This can improve throughput and CPU usage for applications
+that need to send a large number of bytes.
+
+This buffer size cannot be smaller than 16KB, which is the maximum possible TLS record size.
+
+**Warning**: The underlying buffer for the records may grow to be larger than the configured buffer size. This feature does not guarantee any exact memory limits but a ballpark limit. This does not affect the sizes of the buffers written over send, only the underlying memory allocation.
+
+### Example
+```c
+/* Since this feature is unstable the required API can only be reached from a private header file. Once the feature
+has stablized it can be reached from api/s2n.h. */
+#include "tls/s2n_config.h"
+
+#define SEND_BUFFER_SIZE_BYTES 65536
+
+int main(void) {
+    struct s2n_config *config = s2n_config_new();
+    /* Specify the desired send buffer size in bytes. */
+    s2n_config_set_send_buffer_size(config, SEND_BUFFER_SIZE_BYTES);
+
+    struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+    /* The connection object will now be configured with the desired send buffer size. */
+    s2n_connection_set_config(conn, config);
+
+    /* Now further changes are required for the feature to work. */
+
+    ...
+
+    return 0;
+}
+```

--- a/tests/integrationv2/test_buffered_send.py
+++ b/tests/integrationv2/test_buffered_send.py
@@ -1,7 +1,7 @@
 import copy
 import pytest
 
-from configuration import available_ports, PROTOCOLS 
+from configuration import available_ports, PROTOCOLS, ALL_TEST_CIPHERS, ALL_TEST_CERTS
 from common import ProviderOptions, Ciphers, Certificates, data_bytes
 from fixtures import managed_process
 from providers import Provider, S2N, OpenSSL, GnuTLS
@@ -9,24 +9,13 @@ from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_
 
 SEND_BUFFER_SIZE = 2 ** 16
 
-CIPHERS_TO_TEST = [
-    Ciphers.AES256_SHA,
-    Ciphers.ECDHE_ECDSA_AES256_SHA,
-    Ciphers.AES256_GCM_SHA384
-]
-
-CERTIFICATES_TO_TEST = [
-    Certificates.RSA_4096_SHA384,
-    Certificates.ECDSA_384
-]
-
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
-@pytest.mark.parametrize("cipher", CIPHERS_TO_TEST, ids=get_parameter_name)
+@pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("client_provider", [OpenSSL, GnuTLS, S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("server_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
-@pytest.mark.parametrize("certificate", CERTIFICATES_TO_TEST, ids=get_parameter_name)
-@pytest.mark.parametrize("buffer_size", [ 2 ** y for y in range(14, 20, 2)] , ids=get_parameter_name) # Test various buffer sizes until the buffer size is larger than SEND_BUFFER_SIZE
+@pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
+@pytest.mark.parametrize("buffer_size", [ 2 ** y for y in range(15, 20, 2)] , ids=get_parameter_name) # Test various buffer sizes until the buffer size is larger than SEND_BUFFER_SIZE
 def test_s2n_buffered_send(managed_process, cipher, client_provider, server_provider, protocol, certificate, buffer_size):
     port = next(available_ports)
 

--- a/tests/integrationv2/test_buffered_send.py
+++ b/tests/integrationv2/test_buffered_send.py
@@ -1,0 +1,61 @@
+import copy
+import pytest
+
+from configuration import available_ports, PROTOCOLS 
+from common import ProviderOptions, Ciphers, Certificates, data_bytes
+from fixtures import managed_process
+from providers import Provider, S2N, OpenSSL, GnuTLS
+from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
+
+SEND_BUFFER_SIZE = 2 ** 16
+
+CIPHERS_TO_TEST = [
+    Ciphers.AES256_SHA,
+    Ciphers.ECDHE_ECDSA_AES256_SHA,
+    Ciphers.AES256_GCM_SHA384
+]
+
+CERTIFICATES_TO_TEST = [
+    Certificates.RSA_4096_SHA384,
+    Certificates.ECDSA_384
+]
+
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", CIPHERS_TO_TEST, ids=get_parameter_name)
+@pytest.mark.parametrize("client_provider", [OpenSSL, GnuTLS, S2N], ids=get_parameter_name)
+@pytest.mark.parametrize("server_provider", [S2N], ids=get_parameter_name)
+@pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", CERTIFICATES_TO_TEST, ids=get_parameter_name)
+@pytest.mark.parametrize("buffer_size", [ 2 ** y for y in range(14, 20, 2)] , ids=get_parameter_name) # Test various buffer sizes until the buffer size is larger than SEND_BUFFER_SIZE
+def test_s2n_buffered_send(managed_process, cipher, client_provider, server_provider, protocol, certificate, buffer_size):
+    port = next(available_ports)
+
+    random_bytes = data_bytes(SEND_BUFFER_SIZE)
+    client_options = ProviderOptions(
+        mode=Provider.ClientMode,
+        port=port,
+        cipher=cipher,
+        data_to_send=random_bytes,
+        insecure=True,
+        protocol=protocol)
+
+    if client_provider is S2N:
+        client_options.extra_flags = ['--buffered-send', buffer_size]
+
+    server_options = copy.copy(client_options)
+    server_options.data_to_send = None
+    server_options.mode = Provider.ServerMode
+    server_options.extra_flags = ['--buffered-send', buffer_size]
+    server_options.key = certificate.key
+    server_options.cert = certificate.cert
+    server_options.cipher = None
+
+    server = managed_process(server_provider, server_options, timeout=5)
+    client = managed_process(client_provider, client_options, timeout=5)
+
+    for results in client.get_results():
+        results.assert_success()
+
+    for results in server.get_results():
+        results.assert_success()
+        assert random_bytes in results.stdout

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -277,7 +277,7 @@ int main(int argc, char **argv)
     /* s2n_config_set_custom_send_buffer_size */
     {
         uint32_t invalid_buffer_size = 42;
-        struct s2n_config *config = s2n_config_new();
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
 
         EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_custom_send_buffer_size(config, invalid_buffer_size), S2N_ERR_INVALID_ARGUMENT);
@@ -285,8 +285,6 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_config_set_custom_send_buffer_size(config, S2N_TLS_MAXIMUM_RECORD_LENGTH));
         EXPECT_EQUAL(config->custom_send_buffer_size, S2N_TLS_MAXIMUM_RECORD_LENGTH);
-
-        EXPECT_SUCCESS(s2n_config_free(config));
     }
 
     END_TEST();

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -274,17 +274,17 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(config));
     }
 
-    /* s2n_config_set_send_buffer_size */
+    /* s2n_config_set_custom_send_buffer_size */
     {
         uint32_t invalid_buffer_size = 42;
         struct s2n_config *config = s2n_config_new();
         EXPECT_NOT_NULL(config);
 
-        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_send_buffer_size(config, invalid_buffer_size), S2N_ERR_INVALID_ARGUMENT);
-        EXPECT_FAILURE(s2n_config_set_send_buffer_size(NULL, invalid_buffer_size));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_custom_send_buffer_size(config, invalid_buffer_size), S2N_ERR_INVALID_ARGUMENT);
+        EXPECT_FAILURE(s2n_config_set_custom_send_buffer_size(NULL, invalid_buffer_size));
 
-        EXPECT_SUCCESS(s2n_config_set_send_buffer_size(config, S2N_TLS_MAXIMUM_RECORD_LENGTH));
-        EXPECT_EQUAL(config->send_buffer_size, S2N_TLS_MAXIMUM_RECORD_LENGTH);
+        EXPECT_SUCCESS(s2n_config_set_custom_send_buffer_size(config, S2N_TLS_MAXIMUM_RECORD_LENGTH));
+        EXPECT_EQUAL(config->custom_send_buffer_size, S2N_TLS_MAXIMUM_RECORD_LENGTH);
 
         EXPECT_SUCCESS(s2n_config_free(config));
     }

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -274,5 +274,20 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(config));
     }
 
+    /* s2n_config_set_send_buffer_size */
+    {
+        uint32_t invalid_buffer_size = 42;
+        struct s2n_config *config = s2n_config_new();
+        EXPECT_NOT_NULL(config);
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_send_buffer_size(config, invalid_buffer_size), S2N_ERR_INVALID_ARGUMENT);
+        EXPECT_FAILURE(s2n_config_set_send_buffer_size(NULL, invalid_buffer_size));
+
+        EXPECT_SUCCESS(s2n_config_set_send_buffer_size(config, S2N_TLS_MAXIMUM_RECORD_LENGTH));
+        EXPECT_EQUAL(config->send_buffer_size, S2N_TLS_MAXIMUM_RECORD_LENGTH);
+
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
     END_TEST();
 }

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -672,6 +672,7 @@ int main(int argc, char **argv)
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
         EXPECT_EQUAL(valid_buffer_size, conn->send_buffer_size);
+        EXPECT_EQUAL(conn->send_mode, S2N_BUFFERED_SEND);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -661,17 +661,17 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(magic_number, s2n_connection_get_wire_bytes_out(conn));
     }
 
-    /* Test s2n_config_set_send_buffer_size */
+    /* Test s2n_config_set_custom_send_buffer_size */
     {
         uint32_t valid_buffer_size = S2N_TLS_MAXIMUM_RECORD_LENGTH;
         struct s2n_config *config = s2n_config_new();
         EXPECT_NOT_NULL(config);
 
-        EXPECT_SUCCESS(s2n_config_set_send_buffer_size(config, valid_buffer_size));
+        EXPECT_SUCCESS(s2n_config_set_custom_send_buffer_size(config, valid_buffer_size));
 
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
-        EXPECT_EQUAL(valid_buffer_size, conn->send_buffer_size);
+        EXPECT_EQUAL(valid_buffer_size, conn->custom_send_buffer_size);
         EXPECT_EQUAL(conn->send_mode, S2N_BUFFERED_SEND);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -661,6 +661,22 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(magic_number, s2n_connection_get_wire_bytes_out(conn));
     }
 
+    /* Test s2n_config_set_send_buffer_size */
+    {
+        uint32_t valid_buffer_size = S2N_TLS_MAXIMUM_RECORD_LENGTH;
+        struct s2n_config *config = s2n_config_new();
+        EXPECT_NOT_NULL(config);
+
+        EXPECT_SUCCESS(s2n_config_set_send_buffer_size(config, valid_buffer_size));
+
+        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+        EXPECT_EQUAL(valid_buffer_size, conn->send_buffer_size);
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(ecdsa_chain_and_key));
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(rsa_chain_and_key));
     END_TEST();

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -672,7 +672,7 @@ int main(int argc, char **argv)
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
         EXPECT_EQUAL(valid_buffer_size, conn->custom_send_buffer_size);
-        EXPECT_EQUAL(conn->send_mode, S2N_BUFFERED_SEND);
+        EXPECT_EQUAL(conn->send_mode, S2N_MULTI_RECORD_SEND);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -664,18 +664,18 @@ int main(int argc, char **argv)
     /* Test s2n_config_set_custom_send_buffer_size */
     {
         uint32_t valid_buffer_size = S2N_TLS_MAXIMUM_RECORD_LENGTH;
-        struct s2n_config *config = s2n_config_new();
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
+
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
 
         EXPECT_SUCCESS(s2n_config_set_custom_send_buffer_size(config, valid_buffer_size));
 
-        struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
         EXPECT_EQUAL(valid_buffer_size, conn->custom_send_buffer_size);
         EXPECT_EQUAL(conn->send_mode, S2N_MULTI_RECORD_SEND);
-
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-        EXPECT_SUCCESS(s2n_config_free(config));
     }
 
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(ecdsa_chain_and_key));

--- a/tests/unit/s2n_send_test.c
+++ b/tests/unit/s2n_send_test.c
@@ -221,6 +221,51 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(sent_bytes, s2n_connection_get_wire_bytes_out(conn));
     }
 
+    /* s2n_should_flush */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        ssize_t mock_total_message_size = 1 << 15;
+
+        /* Make stuffer larger than the send buffer size so we can test that the conn->send_buffer_size
+         * bound is enforced. */
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&conn->out, mock_total_message_size*2));
+
+        uint16_t mock_max_record_fragment_size = 1 << 13;
+
+        /* Unbuffered send should always return true. */
+        EXPECT_TRUE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_fragment_size));
+
+        /* Buffered send won't flush an empty connection. */
+        conn->send_mode = S2N_BUFFERED_SEND;
+        conn->send_buffer_size = mock_total_message_size;
+        EXPECT_FALSE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_fragment_size));
+
+        /* If the whole user buffer has been consumed it is time to flush. */
+        conn->current_user_data_consumed = mock_total_message_size;
+        EXPECT_TRUE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_fragment_size));
+        conn->current_user_data_consumed = 0;
+
+        /* If the data available in the out stuffer + the max_write_size is > the send buffer size, we should flush */
+        conn->out.write_cursor = (uint32_t)(mock_total_message_size - (mock_max_record_fragment_size/2));
+        EXPECT_TRUE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_fragment_size));
+
+        /* If the data available in the out stuffer + the max_write_size is == the send buffer size, we should not flush */
+        conn->out.write_cursor = (uint32_t)(mock_total_message_size - mock_max_record_fragment_size);
+        EXPECT_FALSE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_fragment_size));
+
+        /* If the data available in the out stuffer + the max_write_size is < the send buffer size, we should not flush */
+        conn->out.write_cursor = (uint32_t)(mock_total_message_size - mock_max_record_fragment_size*2);
+        EXPECT_FALSE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_fragment_size));
+
+        conn->out.write_cursor = 0;
+        /* Resize the out stuffer to always be smaller than the max fragment size. This means that 
+         * we will flush because there is not enough space in the stuffer to store another record. */
+        EXPECT_SUCCESS(s2n_stuffer_resize(&conn->out, mock_max_record_fragment_size - 1));
+        EXPECT_TRUE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_fragment_size));
+    }
+
     /* s2n_send buffered send */
     {
         /* Setup connections */

--- a/tests/unit/s2n_send_test.c
+++ b/tests/unit/s2n_send_test.c
@@ -229,7 +229,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn);
         ssize_t mock_total_message_size = 1 << 15;
 
-        /* Make stuffer larger than the send buffer size so we can test that the conn->send_buffer_size
+        /* Make stuffer larger than the send buffer size so we can test that the conn->custom_send_buffer_size
          * bound is enforced. */
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&conn->out, mock_total_message_size*2));
 
@@ -240,7 +240,7 @@ int main(int argc, char **argv)
 
         /* Buffered send won't flush an empty connection. */
         conn->send_mode = S2N_BUFFERED_SEND;
-        conn->send_buffer_size = mock_total_message_size;
+        conn->custom_send_buffer_size = mock_total_message_size;
         EXPECT_FALSE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_fragment_size));
 
         /* If the whole user buffer has been consumed it is time to flush. */
@@ -271,7 +271,7 @@ int main(int argc, char **argv)
     {
         /* Setup connections */
         struct s2n_config *config = s2n_config_new();
-        EXPECT_SUCCESS(s2n_config_set_send_buffer_size(config, SEND_BUFFER_SIZE));
+        EXPECT_SUCCESS(s2n_config_set_custom_send_buffer_size(config, SEND_BUFFER_SIZE));
 
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));

--- a/tests/unit/s2n_send_test.c
+++ b/tests/unit/s2n_send_test.c
@@ -284,7 +284,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
 
         /* Send test data */
-        uint8_t test_data[SEND_BUFFER_SIZE] = {0xB, 0xE, 0xE, 0xF}; /* Rest is 0x0, but we only care about the buffer size */
+        uint8_t test_data[SEND_BUFFER_SIZE] = {0xA, 0xB, 0xC, 0xD}; /* Rest is 0x0, but we only care about the buffer size */
 
         s2n_blocked_status blocked = 0;
         s2n_custom_send_fn_called = false;
@@ -319,7 +319,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
 
         /* Send test data */
-        uint8_t test_data[SEND_BUFFER_SIZE] = {0xB, 0xE, 0xE, 0xF}; /* Rest is 0x0, but we only care about the buffer size */
+        uint8_t test_data[SEND_BUFFER_SIZE] = {0xA, 0xB, 0xC, 0xD}; /* Rest is 0x0, but we only care about the buffer size */
 
         s2n_blocked_status blocked = 0;
         s2n_custom_send_fn_called = false;

--- a/tests/unit/s2n_send_test.c
+++ b/tests/unit/s2n_send_test.c
@@ -18,8 +18,18 @@
 
 #include "api/s2n.h"
 
+/* s2n_send buffered send test case parameter.
+ *
+ * If this constant is modified then s2n_expected_buffered_send_fn will likely need
+ * to be updated to match.
+ *
+ * This constant is used to buffer TLS records before they are sent over the socket. This
+ * number was chosen at random. */
+#define SEND_BUFFER_SIZE 20480
+
 bool s2n_custom_send_fn_called = false;
 static uint64_t sent_bytes = 0;
+uint32_t s2n_expected_size_call_count = 0;
 
 int s2n_expect_concurrent_error_send_fn(void *io_context, const uint8_t *buf, uint32_t len)
 {
@@ -63,6 +73,79 @@ static int s2n_track_sent_bytes_partial_send_fn(void *io_context, const uint8_t 
     return partial_read;
 }
 
+
+int s2n_expected_unbuffered_send_fn(void *io_context, const uint8_t *buf, uint32_t len)
+{
+    struct s2n_connection *conn = (struct s2n_connection*) io_context;
+
+    uint16_t max_record_payload_size = 0;
+
+    EXPECT_OK(s2n_record_max_write_payload_size(conn, &max_record_payload_size));
+    EXPECT_EQUAL(max_record_payload_size, 8087);
+
+    uint16_t max_record_fragment_size = 0;
+
+    EXPECT_OK(s2n_record_max_write_size(conn, max_record_payload_size, &max_record_fragment_size));
+    EXPECT_EQUAL(max_record_fragment_size, 9116);
+
+    uint32_t expected_send_sizes[] = {8109, 8109, 4328};
+    uint32_t expected_stuffer_space_remaining[] = {1007, 1007, 4788};
+
+    /* Drain outbound stuffer like send implementation would. */
+    EXPECT_SUCCESS(s2n_stuffer_skip_read(&conn->out, len));
+    s2n_custom_send_fn_called = true;
+
+    EXPECT_EQUAL(len, expected_send_sizes[s2n_expected_size_call_count]);
+    EXPECT_EQUAL(s2n_stuffer_space_remaining(&conn->out), expected_stuffer_space_remaining[s2n_expected_size_call_count]);
+
+    s2n_expected_size_call_count += 1;
+
+    return S2N_SUCCESS;
+}
+
+int s2n_expected_buffered_send_fn(void *io_context, const uint8_t *buf, uint32_t len)
+{
+    struct s2n_connection *conn = (struct s2n_connection*) io_context;
+
+    uint16_t max_record_payload_size = 0;
+
+    EXPECT_OK(s2n_record_max_write_payload_size(conn, &max_record_payload_size));
+    EXPECT_EQUAL(max_record_payload_size, 8087);
+
+    uint16_t max_record_fragment_size = 0;
+
+    EXPECT_OK(s2n_record_max_write_size(conn, max_record_payload_size, &max_record_fragment_size));
+    EXPECT_EQUAL(max_record_fragment_size, 9116);
+
+    /* Hard coded to make sure that records are not split across multiple sends.
+     *
+     * This assumes that `s2n_record_max_write_payload_size()` returns 8087. If different
+     * sized records are being sent then the constants in this test case need to be adjusted.
+     *
+     * Expected behavior by record:
+     * 1. First 8087 byte record added to conn->out
+     * 2. Second 8087 byte record added to conn->out
+     * 3. conn->out contains 16218 bytes now. There should be 4262 bytes left in conn->out.
+     *    This is larger than the last record so we should flush the connection.
+     * 4. conn->out should be flushed now and the entire buffer should be available.
+     *    16174 bytes were successfully sent in the first two records, which leave 4306 bytes to
+     *    write. Note these sizes are missing the TLS record overhead.
+     * 5. Rest of data is sent so we expected a partial record containing 4328 bytes, leaving
+     *    16152 bytes in the conn->out stuffer. */
+    uint32_t expected_send_sizes[] = {16218, 4328};
+    uint32_t expected_stuffer_space_remaining[] = {4262, 16152};
+
+    /* Drain outbound stuffer like send implementation would. */
+    EXPECT_SUCCESS(s2n_stuffer_skip_read(&conn->out, len));
+    s2n_custom_send_fn_called = true;
+
+    EXPECT_EQUAL(len, expected_send_sizes[s2n_expected_size_call_count]);
+    EXPECT_EQUAL(s2n_stuffer_space_remaining(&conn->out), expected_stuffer_space_remaining[s2n_expected_size_call_count]);
+
+    s2n_expected_size_call_count += 1;
+
+    return S2N_SUCCESS;
+}
 
 int main(int argc, char **argv)
 {
@@ -136,6 +219,75 @@ int main(int argc, char **argv)
         EXPECT_TRUE(s2n_custom_send_fn_called);
         EXPECT_EQUAL(sent_bytes, conn->wire_bytes_out);
         EXPECT_EQUAL(sent_bytes, s2n_connection_get_wire_bytes_out(conn));
+    }
+
+    /* s2n_send buffered send */
+    {
+        /* Setup connections */
+        struct s2n_config *config = s2n_config_new();
+        EXPECT_SUCCESS(s2n_config_set_send_buffer_size(config, SEND_BUFFER_SIZE));
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+        EXPECT_OK(s2n_connection_set_secrets(conn));
+
+        /* Setup bad send callback */
+        EXPECT_SUCCESS(s2n_connection_set_send_cb(conn, s2n_expected_buffered_send_fn));
+        EXPECT_SUCCESS(s2n_connection_set_send_ctx(conn, (void*) conn));
+        EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
+
+        /* Send test data */
+        uint8_t test_data[SEND_BUFFER_SIZE] = {0xB, 0xE, 0xE, 0xF}; /* Rest is 0x0, but we only care about the buffer size */
+
+        s2n_blocked_status blocked = 0;
+        s2n_custom_send_fn_called = false;
+        EXPECT_EQUAL(s2n_send(conn, test_data, sizeof(test_data), &blocked),
+                SEND_BUFFER_SIZE);
+        EXPECT_TRUE(s2n_custom_send_fn_called);
+
+        /* Magic number based on buffer sizes. See `s2n_expected_buffered_send_fn` for
+         * a breakdown. */
+        EXPECT_TRUE(s2n_expected_size_call_count == 2);
+
+        /* Cleanup */
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
+    }
+
+    /* s2n_send unbuffered send */
+    {
+        s2n_expected_size_call_count = 0;
+
+        /* Setup connections */
+        struct s2n_config *config = s2n_config_new();
+
+        struct s2n_connection *conn;
+        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+        EXPECT_OK(s2n_connection_set_secrets(conn));
+
+        /* Setup bad send callback */
+        EXPECT_SUCCESS(s2n_connection_set_send_cb(conn, s2n_expected_unbuffered_send_fn));
+        EXPECT_SUCCESS(s2n_connection_set_send_ctx(conn, (void*) conn));
+        EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
+
+        /* Send test data */
+        uint8_t test_data[SEND_BUFFER_SIZE] = {0xB, 0xE, 0xE, 0xF}; /* Rest is 0x0, but we only care about the buffer size */
+
+        s2n_blocked_status blocked = 0;
+        s2n_custom_send_fn_called = false;
+        EXPECT_EQUAL(s2n_send(conn, test_data, sizeof(test_data), &blocked),
+                SEND_BUFFER_SIZE);
+        EXPECT_TRUE(s2n_custom_send_fn_called);
+
+        /* Magic number based on buffer sizes. See `s2n_expected_unbuffered_send_fn` for
+         * a breakdown. */
+        EXPECT_TRUE(s2n_expected_size_call_count == 3);
+
+        /* Cleanup */
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_config_free(config));
     }
 
     END_TEST();

--- a/tests/unit/s2n_send_test.c
+++ b/tests/unit/s2n_send_test.c
@@ -19,18 +19,11 @@
 #include "api/s2n.h"
 #include "tls/s2n_tls.h"
 
-/* s2n_send buffered send test case parameter.
- *
- * If this constant is modified then s2n_expected_buffered_send_fn will likely need
- * to be updated to match.
- *
- * This constant is used to buffer TLS records before they are sent over the socket. This
- * number was chosen at random. */
 #define SEND_BUFFER_SIZE 20480
 
 bool s2n_custom_send_fn_called = false;
 static uint64_t sent_bytes = 0;
-uint32_t s2n_expected_size_call_count = 0;
+uint32_t writes = 0;
 
 int s2n_expect_concurrent_error_send_fn(void *io_context, const uint8_t *buf, uint32_t len)
 {
@@ -77,75 +70,57 @@ static int s2n_track_sent_bytes_partial_send_fn(void *io_context, const uint8_t 
 
 int s2n_expected_unbuffered_send_fn(void *io_context, const uint8_t *buf, uint32_t len)
 {
+    s2n_custom_send_fn_called = true;
     struct s2n_connection *conn = (struct s2n_connection*) io_context;
 
     uint16_t max_record_payload_size = 0;
 
     EXPECT_OK(s2n_record_max_write_payload_size(conn, &max_record_payload_size));
-    EXPECT_EQUAL(max_record_payload_size, 8087);
+    EXPECT_EQUAL(max_record_payload_size, S2N_DEFAULT_FRAGMENT_LENGTH);
 
-    uint16_t max_record_fragment_size = 0;
+    /* In unbuffered mode s2n-tls should flush one record at at time. The last record is smaller
+     * than S2N_DEFAULT_FRAGMENT_LENGTH but should contain the rest of the test data. */
+    uint32_t expected_send_sizes[] = {S2N_DEFAULT_FRAGMENT_LENGTH, S2N_DEFAULT_FRAGMENT_LENGTH * 2, SEND_BUFFER_SIZE};
+    POSIX_GUARD(writes < sizeof(expected_send_sizes));
+    EXPECT_EQUAL(conn->current_user_data_consumed, expected_send_sizes[writes]);
 
-    EXPECT_OK(s2n_record_max_write_size(conn, max_record_payload_size, &max_record_fragment_size));
-    EXPECT_EQUAL(max_record_fragment_size, 9116);
+    writes += 1;
 
-    uint32_t expected_send_sizes[] = {8087, 16174, SEND_BUFFER_SIZE};
-    uint32_t expected_stuffer_space_remaining[] = {1007, 1007, 4788};
-
-    /* Drain outbound stuffer like send implementation would. */
-    EXPECT_SUCCESS(s2n_stuffer_skip_read(&conn->out, len));
-    s2n_custom_send_fn_called = true;
-
-    EXPECT_EQUAL(conn->current_user_data_consumed, expected_send_sizes[s2n_expected_size_call_count]);
-    EXPECT_EQUAL(s2n_stuffer_space_remaining(&conn->out), expected_stuffer_space_remaining[s2n_expected_size_call_count]);
-
-    s2n_expected_size_call_count += 1;
-
-    return S2N_SUCCESS;
+    return len;
 }
 
-int s2n_expected_buffered_send_fn(void *io_context, const uint8_t *buf, uint32_t len)
+int s2n_partial_buffered_send_fn(void *io_context, const uint8_t *buf, uint32_t len)
 {
+    s2n_custom_send_fn_called = true;
     struct s2n_connection *conn = (struct s2n_connection*) io_context;
 
     uint16_t max_record_payload_size = 0;
 
     EXPECT_OK(s2n_record_max_write_payload_size(conn, &max_record_payload_size));
-    EXPECT_EQUAL(max_record_payload_size, 8087);
+    EXPECT_EQUAL(max_record_payload_size, S2N_DEFAULT_FRAGMENT_LENGTH);
 
-    uint16_t max_record_fragment_size = 0;
+    /* The buffer should be able to contain two records until it runs out of space and is flushed
+     * over the socket. The second send will contain the rest of the test data. */
+    uint32_t expected_send_sizes[] = {S2N_DEFAULT_FRAGMENT_LENGTH * 2, SEND_BUFFER_SIZE};
 
-    EXPECT_OK(s2n_record_max_write_size(conn, max_record_payload_size, &max_record_fragment_size));
-    EXPECT_EQUAL(max_record_fragment_size, 9116);
+    POSIX_GUARD(writes < sizeof(expected_send_sizes));
+    EXPECT_EQUAL(conn->current_user_data_consumed, expected_send_sizes[writes]);
 
-    /* Hard coded to make sure that records are not split across multiple sends.
-     *
-     * This assumes that `s2n_record_max_write_payload_size()` returns 8087. If different
-     * sized records are being sent then the constants in this test case need to be adjusted.
-     *
-     * Expected behavior by record:
-     * 1. First 8087 byte record added to conn->out
-     * 2. Second 8087 byte record added to conn->out
-     * 3. conn->out contains 16218 bytes now. There should be 4262 bytes left in conn->out.
-     *    This is larger than the last record so we should flush the connection.
-     * 4. conn->out should be flushed now and the entire buffer should be available.
-     *    16174 bytes were successfully sent in the first two records, which leave 4306 bytes to
-     *    write. Note these sizes are missing the TLS record overhead.
-     * 5. Rest of data is sent so we expected a partial record containing 4328 bytes, leaving
-     *    16152 bytes in the conn->out stuffer. */
-    uint32_t expected_send_sizes[] = {16174, SEND_BUFFER_SIZE};
-    uint32_t expected_stuffer_space_remaining[] = {4262, 16152};
+    writes += 1;
 
-    /* Drain outbound stuffer like send implementation would. */
-    EXPECT_SUCCESS(s2n_stuffer_skip_read(&conn->out, len));
+    return len;
+}
+
+int s2n_full_buffered_send_fn(void *io_context, const uint8_t *buf, uint32_t len)
+{
     s2n_custom_send_fn_called = true;
+    struct s2n_connection *conn = (struct s2n_connection*) io_context;
 
-    EXPECT_EQUAL(conn->current_user_data_consumed, expected_send_sizes[s2n_expected_size_call_count]);
-    EXPECT_EQUAL(s2n_stuffer_space_remaining(&conn->out), expected_stuffer_space_remaining[s2n_expected_size_call_count]);
+    EXPECT_EQUAL(conn->current_user_data_consumed, SEND_BUFFER_SIZE);
 
-    s2n_expected_size_call_count += 1;
+    writes += 1;
 
-    return S2N_SUCCESS;
+    return len;
 }
 
 int main(int argc, char **argv)
@@ -230,36 +205,38 @@ int main(int argc, char **argv)
         ssize_t mock_total_message_size = S2N_TLS_MAXIMUM_RECORD_LENGTH * 2;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&conn->out, mock_total_message_size));
 
-        uint16_t mock_max_record_fragment_size = S2N_TLS_MAXIMUM_RECORD_LENGTH;
+        uint16_t mock_max_record_size = S2N_TLS_MAXIMUM_RECORD_LENGTH;
 
         /* Unbuffered send should always return true. */
-        EXPECT_TRUE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_fragment_size));
+        EXPECT_TRUE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_size));
 
         /* Buffered send won't flush an empty connection. */
         conn->send_mode = S2N_MULTI_RECORD_SEND;
         conn->custom_send_buffer_size = mock_total_message_size;
-        EXPECT_FALSE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_fragment_size));
+        EXPECT_FALSE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_size));
 
         /* If the whole user buffer has been consumed it is time to flush. */
         conn->current_user_data_consumed = mock_total_message_size;
-        EXPECT_TRUE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_fragment_size));
+        EXPECT_TRUE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_size));
         conn->current_user_data_consumed = 0;
 
-        /* If the space available in the out stuffer is < than mock_max_record_fragment_size, it's time to flush. */
-        conn->out.write_cursor = (uint32_t)(mock_total_message_size - (mock_max_record_fragment_size/2));
-        EXPECT_TRUE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_fragment_size));
+        /* If the space available in the out stuffer is < than mock_max_record_size, it's time to flush. */
+        conn->out.write_cursor = (uint32_t)(mock_total_message_size - (mock_max_record_size/2));
+        EXPECT_TRUE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_size));
 
         /* If the data available in the out stuffer + the max_write_size is == the send buffer size, we should not flush */
-        conn->out.write_cursor = (uint32_t)(mock_total_message_size - mock_max_record_fragment_size);
-        EXPECT_FALSE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_fragment_size));
+        conn->out.write_cursor = (uint32_t)(mock_total_message_size - mock_max_record_size);
+        EXPECT_FALSE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_size));
 
-        /* If the space available in the out stuffer is > than mock_max_record_fragment_size, we should not flush. */
-        conn->out.write_cursor = (uint32_t)(mock_total_message_size - mock_max_record_fragment_size*2);
-        EXPECT_FALSE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_fragment_size));
+        /* If the space available in the out stuffer is > than mock_max_record_size, we should not flush. */
+        conn->out.write_cursor = (uint32_t)(mock_total_message_size - mock_max_record_size*2);
+        EXPECT_FALSE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_size));
     }
 
-    /* s2n_send buffered send */
+    /* s2n_send partial buffered send */
     {
+        writes = 0;
+
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
 
@@ -271,7 +248,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
         EXPECT_OK(s2n_connection_set_secrets(conn));
 
-        EXPECT_SUCCESS(s2n_connection_set_send_cb(conn, s2n_expected_buffered_send_fn));
+        EXPECT_SUCCESS(s2n_connection_set_send_cb(conn, s2n_partial_buffered_send_fn));
         EXPECT_SUCCESS(s2n_connection_set_send_ctx(conn, (void*) conn));
         EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
 
@@ -283,14 +260,47 @@ int main(int argc, char **argv)
                 SEND_BUFFER_SIZE);
         EXPECT_TRUE(s2n_custom_send_fn_called);
 
-        /* Magic number based on buffer sizes. See `s2n_expected_buffered_send_fn` for
+        /* Magic number based on buffer sizes. See `s2n_partial_buffered_send_fn` for
          * a breakdown. */
-        EXPECT_TRUE(s2n_expected_size_call_count == 2);
+        EXPECT_TRUE(writes == 2);
+    }
+
+    /* s2n_send full buffered send */
+    {
+        writes = 0;
+
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+
+        /* Increase the s2n_send buffer size so the entire test_data buffer fits in a single send. */
+        EXPECT_SUCCESS(s2n_config_set_custom_send_buffer_size(config, SEND_BUFFER_SIZE * 2));
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+        EXPECT_OK(s2n_connection_set_secrets(conn));
+
+        EXPECT_SUCCESS(s2n_connection_set_send_cb(conn, s2n_full_buffered_send_fn));
+        EXPECT_SUCCESS(s2n_connection_set_send_ctx(conn, (void*) conn));
+        EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
+
+        uint8_t test_data[SEND_BUFFER_SIZE] = {0xA, 0xB, 0xC, 0xD}; /* Rest is 0x0, but we only care about the buffer size */
+
+        s2n_blocked_status blocked = 0;
+        s2n_custom_send_fn_called = false;
+        EXPECT_EQUAL(s2n_send(conn, test_data, sizeof(test_data), &blocked),
+                SEND_BUFFER_SIZE);
+        EXPECT_TRUE(s2n_custom_send_fn_called);
+
+        /* Magic number based on buffer sizes. See `s2n_partial_buffered_send_fn` for
+         * a breakdown. */
+        EXPECT_TRUE(writes == 1);
     }
 
     /* s2n_send unbuffered send */
     {
-        s2n_expected_size_call_count = 0;
+        writes = 0;
 
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
@@ -316,7 +326,7 @@ int main(int argc, char **argv)
 
         /* Magic number based on buffer sizes. See `s2n_expected_unbuffered_send_fn` for
          * a breakdown. */
-        EXPECT_TRUE(s2n_expected_size_call_count == 3);
+        EXPECT_TRUE(writes == 3);
     }
 
     END_TEST();

--- a/tests/unit/s2n_send_test.c
+++ b/tests/unit/s2n_send_test.c
@@ -239,7 +239,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_fragment_size));
 
         /* Buffered send won't flush an empty connection. */
-        conn->send_mode = S2N_BUFFERED_SEND;
+        conn->send_mode = S2N_MULTI_RECORD_SEND;
         conn->custom_send_buffer_size = mock_total_message_size;
         EXPECT_FALSE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_fragment_size));
 

--- a/tests/unit/s2n_send_test.c
+++ b/tests/unit/s2n_send_test.c
@@ -197,7 +197,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(sent_bytes, s2n_connection_get_wire_bytes_out(conn));
     }
 
-    /* s2n_should_flush */
+    /* s2n_send_should_flush */
     {
         DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
                 s2n_connection_ptr_free);
@@ -208,29 +208,29 @@ int main(int argc, char **argv)
         uint16_t mock_max_record_size = S2N_TLS_MAXIMUM_RECORD_LENGTH;
 
         /* Unbuffered send should always return true. */
-        EXPECT_TRUE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_size));
+        EXPECT_TRUE(s2n_send_should_flush(conn, mock_total_message_size, mock_max_record_size));
 
         /* Buffered send won't flush an empty connection. */
         conn->send_mode = S2N_MULTI_RECORD_SEND;
         conn->custom_send_buffer_size = mock_total_message_size;
-        EXPECT_FALSE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_size));
+        EXPECT_FALSE(s2n_send_should_flush(conn, mock_total_message_size, mock_max_record_size));
 
         /* If the whole user buffer has been consumed it is time to flush. */
         conn->current_user_data_consumed = mock_total_message_size;
-        EXPECT_TRUE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_size));
+        EXPECT_TRUE(s2n_send_should_flush(conn, mock_total_message_size, mock_max_record_size));
         conn->current_user_data_consumed = 0;
 
         /* If the space available in the out stuffer is < than mock_max_record_size, it's time to flush. */
         conn->out.write_cursor = (uint32_t)(mock_total_message_size - (mock_max_record_size/2));
-        EXPECT_TRUE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_size));
+        EXPECT_TRUE(s2n_send_should_flush(conn, mock_total_message_size, mock_max_record_size));
 
         /* If the data available in the out stuffer + the max_write_size is == the send buffer size, we should not flush */
         conn->out.write_cursor = (uint32_t)(mock_total_message_size - mock_max_record_size);
-        EXPECT_FALSE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_size));
+        EXPECT_FALSE(s2n_send_should_flush(conn, mock_total_message_size, mock_max_record_size));
 
         /* If the space available in the out stuffer is > than mock_max_record_size, we should not flush. */
         conn->out.write_cursor = (uint32_t)(mock_total_message_size - mock_max_record_size*2);
-        EXPECT_FALSE(s2n_should_flush(conn, mock_total_message_size, mock_max_record_size));
+        EXPECT_FALSE(s2n_send_should_flush(conn, mock_total_message_size, mock_max_record_size));
     }
 
     /* s2n_send partial buffered send */

--- a/tests/unit/s2n_send_test.c
+++ b/tests/unit/s2n_send_test.c
@@ -81,7 +81,7 @@ int s2n_expected_unbuffered_send_fn(void *io_context, const uint8_t *buf, uint32
     /* In unbuffered mode s2n-tls should flush one record at at time. The last record is smaller
      * than S2N_DEFAULT_FRAGMENT_LENGTH but should contain the rest of the test data. */
     uint32_t expected_send_sizes[] = {S2N_DEFAULT_FRAGMENT_LENGTH, S2N_DEFAULT_FRAGMENT_LENGTH * 2, SEND_BUFFER_SIZE};
-    POSIX_GUARD(writes < sizeof(expected_send_sizes));
+    EXPECT_TRUE(writes < sizeof(expected_send_sizes));
     EXPECT_EQUAL(conn->current_user_data_consumed, expected_send_sizes[writes]);
 
     writes += 1;
@@ -103,7 +103,7 @@ int s2n_partial_buffered_send_fn(void *io_context, const uint8_t *buf, uint32_t 
      * over the socket. The second send will contain the rest of the test data. */
     uint32_t expected_send_sizes[] = {S2N_DEFAULT_FRAGMENT_LENGTH * 2, SEND_BUFFER_SIZE};
 
-    POSIX_GUARD(writes < sizeof(expected_send_sizes));
+    EXPECT_TRUE(writes < sizeof(expected_send_sizes));
     EXPECT_EQUAL(conn->current_user_data_consumed, expected_send_sizes[writes]);
 
     writes += 1;

--- a/tests/unit/s2n_send_test.c
+++ b/tests/unit/s2n_send_test.c
@@ -89,14 +89,14 @@ int s2n_expected_unbuffered_send_fn(void *io_context, const uint8_t *buf, uint32
     EXPECT_OK(s2n_record_max_write_size(conn, max_record_payload_size, &max_record_fragment_size));
     EXPECT_EQUAL(max_record_fragment_size, 9116);
 
-    uint32_t expected_send_sizes[] = {8109, 8109, 4328};
+    uint32_t expected_send_sizes[] = {8087, 16174, SEND_BUFFER_SIZE};
     uint32_t expected_stuffer_space_remaining[] = {1007, 1007, 4788};
 
     /* Drain outbound stuffer like send implementation would. */
     EXPECT_SUCCESS(s2n_stuffer_skip_read(&conn->out, len));
     s2n_custom_send_fn_called = true;
 
-    EXPECT_EQUAL(len, expected_send_sizes[s2n_expected_size_call_count]);
+    EXPECT_EQUAL(conn->current_user_data_consumed, expected_send_sizes[s2n_expected_size_call_count]);
     EXPECT_EQUAL(s2n_stuffer_space_remaining(&conn->out), expected_stuffer_space_remaining[s2n_expected_size_call_count]);
 
     s2n_expected_size_call_count += 1;
@@ -133,14 +133,14 @@ int s2n_expected_buffered_send_fn(void *io_context, const uint8_t *buf, uint32_t
      *    write. Note these sizes are missing the TLS record overhead.
      * 5. Rest of data is sent so we expected a partial record containing 4328 bytes, leaving
      *    16152 bytes in the conn->out stuffer. */
-    uint32_t expected_send_sizes[] = {16218, 4328};
+    uint32_t expected_send_sizes[] = {16174, SEND_BUFFER_SIZE};
     uint32_t expected_stuffer_space_remaining[] = {4262, 16152};
 
     /* Drain outbound stuffer like send implementation would. */
     EXPECT_SUCCESS(s2n_stuffer_skip_read(&conn->out, len));
     s2n_custom_send_fn_called = true;
 
-    EXPECT_EQUAL(len, expected_send_sizes[s2n_expected_size_call_count]);
+    EXPECT_EQUAL(conn->current_user_data_consumed, expected_send_sizes[s2n_expected_size_call_count]);
     EXPECT_EQUAL(s2n_stuffer_space_remaining(&conn->out), expected_stuffer_space_remaining[s2n_expected_size_call_count]);
 
     s2n_expected_size_call_count += 1;

--- a/tests/unit/s2n_send_test.c
+++ b/tests/unit/s2n_send_test.c
@@ -17,6 +17,7 @@
 #include "testlib/s2n_testlib.h"
 
 #include "api/s2n.h"
+#include "tls/s2n_tls.h"
 
 /* s2n_send buffered send test case parameter.
  *

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -938,3 +938,12 @@ int s2n_config_client_hello_cb_enable_poll(struct s2n_config *config) {
 
     return S2N_SUCCESS;
 }
+
+int s2n_config_set_send_buffer_size(struct s2n_config *config, uint32_t buffer_byte_size) {
+    POSIX_ENSURE_REF(config);
+    S2N_ERROR_IF(buffer_byte_size < S2N_TLS_MAXIMUM_RECORD_LENGTH, S2N_ERR_INVALID_ARGUMENT);
+
+    config->send_buffer_size = buffer_byte_size;
+
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -939,11 +939,11 @@ int s2n_config_client_hello_cb_enable_poll(struct s2n_config *config) {
     return S2N_SUCCESS;
 }
 
-int s2n_config_set_send_buffer_size(struct s2n_config *config, uint32_t buffer_byte_size) {
+int s2n_config_set_custom_send_buffer_size(struct s2n_config *config, uint32_t buffer_byte_size) {
     POSIX_ENSURE_REF(config);
     S2N_ERROR_IF(buffer_byte_size < S2N_TLS_MAXIMUM_RECORD_LENGTH, S2N_ERR_INVALID_ARGUMENT);
 
-    config->send_buffer_size = buffer_byte_size;
+    config->custom_send_buffer_size = buffer_byte_size;
 
     return S2N_SUCCESS;
 }

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -143,8 +143,8 @@ struct s2n_config {
     /* The user defined context associated with config */
     void *context;
 
-    /* Used to determine the stuffer size for a connection's `out` stuffer. */
-    uint32_t send_buffer_size;
+    /* Used to override the stuffer size for a connection's `out` stuffer. */
+    uint32_t custom_send_buffer_size;
 };
 
 S2N_CLEANUP_RESULT s2n_config_ptr_free(struct s2n_config **config);
@@ -160,4 +160,4 @@ void s2n_wipe_static_configs(void);
 extern struct s2n_cert_chain_and_key *s2n_config_get_single_default_cert(struct s2n_config *config);
 int s2n_config_get_num_default_certs(struct s2n_config *config);
 
-int s2n_config_set_send_buffer_size(struct s2n_config *config, uint32_t buffer_byte_size);
+int s2n_config_set_custom_send_buffer_size(struct s2n_config *config, uint32_t buffer_byte_size);

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -142,6 +142,9 @@ struct s2n_config {
 
     /* The user defined context associated with config */
     void *context;
+
+    /* Used to determine the stuffer size for a connection's `out` stuffer. */
+    uint32_t send_buffer_size;
 };
 
 S2N_CLEANUP_RESULT s2n_config_ptr_free(struct s2n_config **config);
@@ -156,3 +159,5 @@ int s2n_config_free_session_ticket_keys(struct s2n_config *config);
 void s2n_wipe_static_configs(void);
 extern struct s2n_cert_chain_and_key *s2n_config_get_single_default_cert(struct s2n_config *config);
 int s2n_config_get_num_default_certs(struct s2n_config *config);
+
+int s2n_config_set_send_buffer_size(struct s2n_config *config, uint32_t buffer_byte_size);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -434,8 +434,8 @@ int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *co
         POSIX_GUARD(s2n_connection_enable_quic(conn));
     }
 
-    conn->send_buffer_size = config->send_buffer_size;
-    if (conn->send_buffer_size != 0) {
+    conn->custom_send_buffer_size = config->custom_send_buffer_size;
+    if (conn->custom_send_buffer_size != 0) {
         conn->send_mode = S2N_BUFFERED_SEND;
     } else {
         conn->send_mode = S2N_UNBUFFERED_SEND;

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -436,9 +436,9 @@ int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *co
 
     conn->custom_send_buffer_size = config->custom_send_buffer_size;
     if (conn->custom_send_buffer_size != 0) {
-        conn->send_mode = S2N_BUFFERED_SEND;
+        conn->send_mode = S2N_MULTI_RECORD_SEND;
     } else {
-        conn->send_mode = S2N_UNBUFFERED_SEND;
+        conn->send_mode = S2N_DEFAULT_SEND;
     }
 
     conn->config = config;

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -434,6 +434,13 @@ int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *co
         POSIX_GUARD(s2n_connection_enable_quic(conn));
     }
 
+    conn->send_buffer_size = config->send_buffer_size;
+    if (conn->send_buffer_size != 0) {
+        conn->send_mode = S2N_BUFFERED_SEND;
+    } else {
+        conn->send_mode = S2N_UNBUFFERED_SEND;
+    }
+
     conn->config = config;
     return S2N_SUCCESS;
 }

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -53,7 +53,7 @@ typedef enum {
     /** The conn->out stuffer is flushed every time a record is written to it. */
     S2N_DEFAULT_SEND,
     /** The conn->out stuffer is flushed based on a custom send buffer size. This allows multiple
-     * records to be written at in one socket send. */
+     * records to be written with one socket send. */
     S2N_MULTI_RECORD_SEND
 } s2n_send_mode;
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -374,8 +374,8 @@ struct s2n_connection {
     struct s2n_blob server_early_data_context;
     uint32_t server_keying_material_lifetime;
 
-    /* Used to determine the stuffer size for the `out` stuffer. */
-    uint32_t send_buffer_size;
+    /* Used to override the stuffer size for the `out` stuffer. */
+    uint32_t custom_send_buffer_size;
     /* Tracks the current send mode. */
     s2n_send_mode send_mode;
 };

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -50,8 +50,11 @@
 #define is_handshake_complete(conn) (APPLICATION_DATA == s2n_conn_get_current_message_type(conn))
 
 typedef enum {
-    S2N_UNBUFFERED_SEND,
-    S2N_BUFFERED_SEND
+    /** The conn->out stuffer is flushed every time a record is written to it. */
+    S2N_DEFAULT_SEND,
+    /** The conn->out stuffer is flushed based on a custom send buffer size. This allows multiple
+     * records to be written at in one socket send. */
+    S2N_MULTI_RECORD_SEND
 } s2n_send_mode;
 
 typedef enum {

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -50,6 +50,11 @@
 #define is_handshake_complete(conn) (APPLICATION_DATA == s2n_conn_get_current_message_type(conn))
 
 typedef enum {
+    S2N_UNBUFFERED_SEND,
+    S2N_BUFFERED_SEND
+} s2n_send_mode;
+
+typedef enum {
     S2N_NO_TICKET = 0,
     S2N_DECRYPT_TICKET,
     S2N_NEW_TICKET
@@ -368,6 +373,11 @@ struct s2n_connection {
     uint32_t server_max_early_data_size;
     struct s2n_blob server_early_data_context;
     uint32_t server_keying_material_lifetime;
+
+    /* Used to determine the stuffer size for the `out` stuffer. */
+    uint32_t send_buffer_size;
+    /* Tracks the current send mode. */
+    s2n_send_mode send_mode;
 };
 
 S2N_CLEANUP_RESULT s2n_connection_ptr_free(struct s2n_connection **s2n_connection);

--- a/tls/s2n_key_update.c
+++ b/tls/s2n_key_update.c
@@ -65,6 +65,9 @@ int s2n_key_update_send(struct s2n_connection *conn, s2n_blocked_status *blocked
     POSIX_GUARD(s2n_check_record_limit(conn, &sequence_number));
 
     if (conn->key_update_pending) {
+        /* Flush any pending messages. */
+        POSIX_GUARD(s2n_flush(conn, blocked));
+
         uint8_t key_update_data[S2N_KEY_UPDATE_MESSAGE_SIZE];
         struct s2n_blob key_update_blob = {0};
         POSIX_GUARD(s2n_blob_init(&key_update_blob, key_update_data, sizeof(key_update_data)));

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -493,7 +493,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
     struct s2n_blob en = { .size = encrypted_length, .data = s2n_stuffer_raw_write(&record_stuffer, encrypted_length) };
     POSIX_GUARD(s2n_record_encrypt(conn, cipher_suite, session_key, &iv, &aad, &en, implicit_iv, block_size));
 
-    /* Sync the out stuffer write cursor to with the record stuffer. */
+    /* Sync the out stuffer write cursor with the record stuffer. */
     POSIX_GUARD(s2n_stuffer_skip_write(&conn->out, s2n_stuffer_data_available(&record_stuffer)));
 
     if (conn->actual_protocol_version == S2N_TLS13 && content_type == TLS_CHANGE_CIPHER_SPEC) {

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -219,7 +219,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
     uint16_t block_size = 0;
     uint8_t aad_iv[S2N_TLS_MAX_IV_LEN] = { 0 };
 
-    if (conn->send_mode == S2N_UNBUFFERED_SEND) {
+    if (conn->send_mode == S2N_DEFAULT_SEND) {
         /* If the user has not specified a send buffer size then the TLS records
          * are flushed immediately. This implies a logic error if the stuffer was
          * not reset in this mode. */
@@ -297,7 +297,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
          */
         uint16_t max_wire_record_size = 0;
         POSIX_GUARD_RESULT(s2n_record_max_write_size(conn, max_write_payload_size, &max_wire_record_size));
-        if (conn->send_mode == S2N_BUFFERED_SEND) {
+        if (conn->send_mode == S2N_MULTI_RECORD_SEND) {
             POSIX_GUARD(s2n_stuffer_growable_alloc(&conn->out, conn->custom_send_buffer_size));
         } else {
             POSIX_GUARD(s2n_stuffer_growable_alloc(&conn->out, max_wire_record_size));

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -298,7 +298,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
         uint16_t max_wire_record_size = 0;
         POSIX_GUARD_RESULT(s2n_record_max_write_size(conn, max_write_payload_size, &max_wire_record_size));
         if (conn->send_mode == S2N_BUFFERED_SEND) {
-            POSIX_GUARD(s2n_stuffer_growable_alloc(&conn->out, conn->send_buffer_size));
+            POSIX_GUARD(s2n_stuffer_growable_alloc(&conn->out, conn->custom_send_buffer_size));
         } else {
             POSIX_GUARD(s2n_stuffer_growable_alloc(&conn->out, max_wire_record_size));
         }

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -305,9 +305,10 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
 
     /* A record only local stuffer used to avoid tainting the conn->out stuffer. It should be
      * used to add an individual record to the out stuffer. */
-    struct s2n_stuffer record_stuffer = {0};
-    POSIX_GUARD(s2n_stuffer_init(&record_stuffer, &conn->out.blob));
-    POSIX_GUARD(s2n_stuffer_skip_write(&record_stuffer, conn->out.write_cursor));
+    struct s2n_blob record_blob = { 0 };
+    struct s2n_stuffer record_stuffer = { 0 };
+    POSIX_GUARD(s2n_blob_init(&record_blob, &conn->out.blob + conn->out.write_cursor, s2n_stuffer_space_remaining(&conn->out);
+    POSIX_GUARD(s2n_stuffer_init(&record_stuffer, &record_blob));
 
     /* Now that we know the length, start writing the record */
     POSIX_GUARD(s2n_stuffer_write_uint8(&record_stuffer, is_tls13_record ?

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -303,6 +303,8 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
         }
     }
 
+    /* A record only local stuffer used to avoid tainting the conn->out stuffer. It should be
+     * used to add an individual record to the out stuffer. */
     struct s2n_stuffer record_stuffer = {0};
     POSIX_GUARD(s2n_stuffer_init(&record_stuffer, &conn->out.blob));
     POSIX_GUARD(s2n_stuffer_skip_write(&record_stuffer, conn->out.write_cursor));
@@ -490,6 +492,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
     struct s2n_blob en = { .size = encrypted_length, .data = s2n_stuffer_raw_write(&record_stuffer, encrypted_length) };
     POSIX_GUARD(s2n_record_encrypt(conn, cipher_suite, session_key, &iv, &aad, &en, implicit_iv, block_size));
 
+    /* Sync the out stuffer write cursor to with the record stuffer. */
     POSIX_GUARD(s2n_stuffer_rewrite(&conn->out));
     POSIX_GUARD(s2n_stuffer_skip_write(&conn->out, record_stuffer.write_cursor));
 

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -50,7 +50,10 @@ bool s2n_should_flush(struct s2n_connection *conn, ssize_t total_message_size, u
 
     uint32_t bytes_in_stuffer = s2n_stuffer_data_available(&conn->out);
 
-    /* If the stuffer cannot contain a max fragment size record then it is time to flush. */
+    /* If the stuffer cannot contain a max fragment size record then it is time to flush.
+     * This is not redundant with the above check if the conn->send_buffer_size is smaller
+     * than the conn->out stuffer. This is possible because the conn->out stuffer MUST 
+     * be growable currently. */
     if (bytes_in_stuffer + max_write_size > conn->send_buffer_size) {
         return true;
     }

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -45,17 +45,10 @@ bool s2n_should_flush(struct s2n_connection *conn, ssize_t total_message_size, u
     }
 
     uint32_t available_space = s2n_stuffer_space_remaining(&conn->out);
-    uint32_t bytes_in_stuffer = s2n_stuffer_data_available(&conn->out);
 
     /* If the stuffer can't store the max possible max fragment size 
-     * without growing it's time to flush.
-     *
-     * We must check if conn->custom_send_buffer_size is smaller than the conn->out
-     * stuffer because is it possible that the conn->out stuffer grew larger
-     * then conn->custom_send_buffer_size. 
-     *
-     * We must also check that the stuffer has enough space for another max_write_size record. */
-    if ((bytes_in_stuffer + max_write_size > conn->custom_send_buffer_size) || available_space < max_write_size) {
+     * without growing it's time to flush. */
+    if (available_space < max_write_size) {
         return true;
     }
 

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -35,8 +35,8 @@
 bool s2n_should_flush(struct s2n_connection *conn, ssize_t total_message_size, uint16_t max_write_size)
 {
     /* If the connection is unbuffered then flush on every record written.
-     * The rest of this function assumes conn->send_mode == S2N_BUFFERED_SEND */
-    if (conn->send_mode == S2N_UNBUFFERED_SEND) {
+     * The rest of this function assumes conn->send_mode == S2N_MULTI_RECORD_SEND */
+    if (conn->send_mode == S2N_DEFAULT_SEND) {
         return true;
     }
 

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -40,6 +40,10 @@ bool s2n_should_flush(struct s2n_connection *conn, ssize_t total_message_size, u
         return true;
     }
 
+    if (conn->send_buffer_size < S2N_TLS_MAXIMUM_RECORD_LENGTH) {
+        return true;
+    }
+
     uint32_t available_space = s2n_stuffer_space_remaining(&conn->out);
 
     /* If the stuffer can't store the max possible max fragment size 

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -125,6 +125,9 @@ S2N_RESULT s2n_tls13_server_nst_send(struct s2n_connection *conn, s2n_blocked_st
         return S2N_RESULT_OK;
     }
 
+    /* Flush any pending messages. */
+    RESULT_GUARD_POSIX(s2n_flush(conn, blocked));
+
     /* No-op if all tickets already sent.
      * Clean up the stuffer used for the ticket to conserve memory. */
     if (conn->tickets_to_send == conn->tickets_sent) {

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -23,6 +23,7 @@
 extern uint8_t s2n_unknown_protocol_version;
 extern uint8_t s2n_highest_protocol_version;
 
+extern bool s2n_should_flush(struct s2n_connection *conn, ssize_t total_message_size, uint16_t max_write_size);
 extern int s2n_flush(struct s2n_connection *conn, s2n_blocked_status * more);
 int s2n_client_hello_request_recv(struct s2n_connection *conn);
 extern int s2n_client_hello_send(struct s2n_connection *conn);

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -23,7 +23,7 @@
 extern uint8_t s2n_unknown_protocol_version;
 extern uint8_t s2n_highest_protocol_version;
 
-extern bool s2n_should_flush(struct s2n_connection *conn, ssize_t total_message_size, uint16_t max_write_size);
+extern bool s2n_send_should_flush(struct s2n_connection *conn, ssize_t total_message_size, uint16_t max_write_size);
 extern int s2n_flush(struct s2n_connection *conn, s2n_blocked_status * more);
 int s2n_client_hello_request_recv(struct s2n_connection *conn);
 extern int s2n_client_hello_send(struct s2n_connection *conn);


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Adds an integration test for the buffered send feature.

### Call-outs:

I scoped down a lot of the cipher combinations and certificate combinations. We should increase them to capture "ALL" combinations.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer? Ran integration tests on local codebuild agent.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
