### PR TITLE
[bindings] Parity with unofficial bindings

### DIFF
--- a/bindings/rust/s2n-tls-tokio/tests/common/mod.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/common/mod.rs
@@ -11,6 +11,8 @@ use tokio::{
 
 mod stream;
 pub use stream::*;
+mod time;
+pub use time::*;
 
 /// NOTE: this certificate and key are used for testing purposes only!
 pub static CERT_PEM: &[u8] = include_bytes!(concat!(

--- a/bindings/rust/s2n-tls-tokio/tests/common/time.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/common/time.rs
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_tls::callbacks::MonotonicClockCallback;
+use std::time::Duration;
+use tokio::time::Instant;
+
+/// A monotonic clock that allows the s2n-tls C library time
+/// to follow the tokio::time::pause behavior.
+pub struct TokioTime(Instant);
+
+impl Default for TokioTime {
+    fn default() -> Self {
+        TokioTime(Instant::now())
+    }
+}
+
+impl MonotonicClockCallback for TokioTime {
+    fn get_time(&self) -> Duration {
+        self.0.elapsed()
+    }
+}

--- a/bindings/rust/s2n-tls-tokio/tests/common/time.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/common/time.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use s2n_tls::callbacks::MonotonicClockCallback;
+use s2n_tls::callbacks::MonotonicClock;
 use std::time::Duration;
 use tokio::time::Instant;
 
@@ -15,7 +15,7 @@ impl Default for TokioTime {
     }
 }
 
-impl MonotonicClockCallback for TokioTime {
+impl MonotonicClock for TokioTime {
     fn get_time(&self) -> Duration {
         self.0.elapsed()
     }

--- a/bindings/rust/s2n-tls-tokio/tests/handshake.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/handshake.rs
@@ -6,7 +6,7 @@ use s2n_tls::{
     config::Config,
     connection::{Connection, ModifiedBuilder},
     enums::{ClientAuthType, Mode, Version},
-    error::Error,
+    error::{Error, ErrorType},
     pool::ConfigPoolBuilder,
     security::DEFAULT_TLS13,
 };
@@ -150,10 +150,13 @@ async fn handshake_error() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test(start_paused = true)]
 async fn handshake_error_with_blinding() -> Result<(), Box<dyn std::error::Error>> {
+    let clock = common::TokioTime::default();
+
     // Config::builder() does not include a trust store.
     // The client will reject the server certificate as untrusted.
     let mut bad_config = Config::builder();
     bad_config.set_security_policy(&DEFAULT_TLS13)?;
+    bad_config.set_monotonic_clock_callback(clock)?;
     let client_config = bad_config.build()?;
     let server_config = common::server_config()?.build()?;
 
@@ -178,6 +181,7 @@ async fn handshake_error_with_blinding() -> Result<(), Box<dyn std::error::Error
     .await;
     let result = timeout?;
     assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind(), Some(ErrorType::ProtocolError));
 
     Ok(())
 }

--- a/bindings/rust/s2n-tls-tokio/tests/handshake.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/handshake.rs
@@ -156,7 +156,7 @@ async fn handshake_error_with_blinding() -> Result<(), Box<dyn std::error::Error
     // The client will reject the server certificate as untrusted.
     let mut bad_config = Config::builder();
     bad_config.set_security_policy(&DEFAULT_TLS13)?;
-    bad_config.set_monotonic_clock_callback(clock)?;
+    bad_config.set_monotonic_clock(clock)?;
     let client_config = bad_config.build()?;
     let server_config = common::server_config()?.build()?;
 

--- a/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
@@ -88,7 +88,7 @@ async fn shutdown_after_split() -> Result<(), Box<dyn std::error::Error>> {
 async fn shutdown_with_blinding() -> Result<(), Box<dyn std::error::Error>> {
     let clock = common::TokioTime::default();
     let mut server_config = common::server_config()?;
-    server_config.set_monotonic_clock_callback(clock)?;
+    server_config.set_monotonic_clock(clock)?;
 
     let client = TlsConnector::new(common::client_config()?.build()?);
     let server = TlsAcceptor::new(server_config.build()?);

--- a/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
@@ -86,8 +86,12 @@ async fn shutdown_after_split() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::test(start_paused = true)]
 async fn shutdown_with_blinding() -> Result<(), Box<dyn std::error::Error>> {
+    let clock = common::TokioTime::default();
+    let mut server_config = common::server_config()?;
+    server_config.set_monotonic_clock_callback(clock)?;
+
     let client = TlsConnector::new(common::client_config()?.build()?);
-    let server = TlsAcceptor::new(common::server_config()?.build()?);
+    let server = TlsAcceptor::new(server_config.build()?);
 
     let (server_stream, client_stream) = common::get_streams().await?;
     let server_stream = common::TestStream::new(server_stream);
@@ -95,7 +99,7 @@ async fn shutdown_with_blinding() -> Result<(), Box<dyn std::error::Error>> {
     let (mut client, mut server) =
         common::run_negotiate(&client, client_stream, &server, server_stream).await?;
 
-    // Trigger a blinded error.
+    // Trigger a blinded error for the server.
     overrides.next_read(Some(Box::new(|_, _, buf| {
         // Parsing the header is one of the blinded operations
         // in s2n_recv, so provide a malformed header.
@@ -117,57 +121,12 @@ async fn shutdown_with_blinding() -> Result<(), Box<dyn std::error::Error>> {
     // Shutdown MUST eventually complete after blinding.
     //
     // We check for completion, but not for success. At the moment, the
-    // call to s2n_shutdown will fail. See `shutdown_with_blinding_slow()`
-    // for verification that s2n_shutdown eventually suceeds.
+    // call to s2n_shutdown will fail due to issues in the underlying C library.
     let (timeout, _) = join!(
         time::timeout(common::MAX_BLINDING_SECS, server.shutdown()),
         time::timeout(common::MAX_BLINDING_SECS, read_until_shutdown(&mut client)),
     );
     assert!(timeout.is_ok());
-
-    Ok(())
-}
-
-// Ignore because:
-// 1) This test is slow. We can avoid Tokio sleeps with time::pause,
-//    but I couldn't find a good way to do the same to the system time the underlying C uses.
-// 2) This test currently fails due to bugs in the underlying s2n_shutdown method.
-#[ignore]
-#[tokio::test]
-async fn shutdown_with_blinding_slow() -> Result<(), Box<dyn std::error::Error>> {
-    let client = TlsConnector::new(common::client_config()?.build()?);
-    let server = TlsAcceptor::new(common::server_config()?.build()?);
-
-    let (server_stream, client_stream) = common::get_streams().await?;
-    let server_stream = common::TestStream::new(server_stream);
-    let overrides = server_stream.overrides();
-    let (mut client, mut server) =
-        common::run_negotiate(&client, client_stream, &server, server_stream).await?;
-
-    // Trigger a blinded error.
-    overrides.next_read(Some(Box::new(|_, _, buf| {
-        // Parsing the header is one of the blinded operations
-        // in s2n_recv, so provide a malformed header.
-        let zeroed_header = [23, 0, 0, 0, 0];
-        buf.put_slice(&zeroed_header);
-        Ok(()).into()
-    })));
-    let mut received = [0; 1];
-    let result = server.read_exact(&mut received).await;
-    assert!(result.is_err());
-
-    // Shutdown MUST eventually gracefully complete after blinding
-    let (timeout, _) = join!(
-        time::timeout(common::MAX_BLINDING_SECS.mul_f32(1.1), server.shutdown()),
-        time::timeout(
-            common::MAX_BLINDING_SECS.mul_f32(1.1),
-            read_until_shutdown(&mut client)
-        ),
-    );
-
-    // Verify shutdown succeeded
-    let result = timeout?;
-    assert!(result.is_ok());
 
     Ok(())
 }

--- a/bindings/rust/s2n-tls/src/callbacks.rs
+++ b/bindings/rust/s2n-tls/src/callbacks.rs
@@ -155,11 +155,11 @@ pub trait VerifyHostNameCallback {
 }
 
 /// A trait for the callback used to retrieve the system / wall clock time.
-pub trait WallClockCallback {
+pub trait WallClock {
     fn get_time_since_epoch(&self) -> Duration;
 }
 
 /// A trait for the callback used to retrieve the monotonic time.
-pub trait MonotonicClockCallback {
+pub trait MonotonicClock {
     fn get_time(&self) -> Duration;
 }

--- a/bindings/rust/s2n-tls/src/callbacks.rs
+++ b/bindings/rust/s2n-tls/src/callbacks.rs
@@ -23,7 +23,7 @@
 //!   can be used to register the task for wakeup. See [`ClientHelloCallback`] as an example.
 
 use crate::{connection::Connection, enums::CallbackResult, error::Error};
-use core::{mem::ManuallyDrop, ptr::NonNull, task::Poll};
+use core::{mem::ManuallyDrop, ptr::NonNull, task::Poll, time::Duration};
 use s2n_tls_sys::s2n_connection;
 
 const READY_OK: Poll<Result<(), Error>> = Poll::Ready(Ok(()));
@@ -152,4 +152,14 @@ impl AsyncCallback for AsyncClientHelloCallback {
 /// if the name is valid, `false` otherwise.
 pub trait VerifyHostNameCallback {
     fn verify_host_name(&self, host_name: &str) -> bool;
+}
+
+/// A trait for the callback used to retrieve the system / wall clock time.
+pub trait WallClockCallback {
+    fn get_time_since_epoch(&self) -> Duration;
+}
+
+/// A trait for the callback used to retrieve the monotonic time.
+pub trait MonotonicClockCallback {
+    fn get_time(&self) -> Duration;
 }

--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -11,6 +11,7 @@ use core::{convert::TryInto, ptr::NonNull};
 use s2n_tls_sys::*;
 use std::{
     ffi::{c_void, CString},
+    path::Path,
     sync::atomic::{AtomicUsize, Ordering},
 };
 
@@ -73,7 +74,7 @@ impl Config {
     }
 
     /// Retrieve a mutable reference to the [`Context`] stored on the config.
-    fn context_mut(&mut self) -> &mut Context {
+    pub(crate) fn context_mut(&mut self) -> &mut Context {
         let mut ctx = core::ptr::null_mut();
         unsafe {
             s2n_config_get_ctx(self.as_mut_ptr(), &mut ctx)
@@ -230,6 +231,12 @@ impl Builder {
         Ok(self)
     }
 
+    pub fn add_dhparams(&mut self, pem: &[u8]) -> Result<&mut Self, Error> {
+        let cstring = CString::new(pem).map_err(|_| Error::InvalidInput)?;
+        unsafe { s2n_config_add_dhparams(self.as_mut_ptr(), cstring.as_ptr()).into_result() }?;
+        Ok(self)
+    }
+
     pub fn load_pem(&mut self, certificate: &[u8], private_key: &[u8]) -> Result<&mut Self, Error> {
         let certificate = CString::new(certificate).map_err(|_| Error::InvalidInput)?;
         let private_key = CString::new(private_key).map_err(|_| Error::InvalidInput)?;
@@ -252,6 +259,41 @@ impl Builder {
         Ok(self)
     }
 
+    pub fn trust_location(
+        &mut self,
+        file: Option<&Path>,
+        dir: Option<&Path>,
+    ) -> Result<&mut Self, Error> {
+        fn to_cstr(input: Option<&Path>) -> Result<Option<CString>, Error> {
+            Ok(match input {
+                Some(input) => {
+                    let string = input.to_str().ok_or(Error::InvalidInput)?;
+                    let cstring = CString::new(string).map_err(|_| Error::InvalidInput)?;
+                    Some(cstring)
+                }
+                None => None,
+            })
+        }
+
+        let file_cstr = to_cstr(file)?;
+        let file_ptr = file_cstr
+            .as_ref()
+            .map(|f| f.as_ptr())
+            .unwrap_or(core::ptr::null());
+
+        let dir_cstr = to_cstr(dir)?;
+        let dir_ptr = dir_cstr
+            .as_ref()
+            .map(|f| f.as_ptr())
+            .unwrap_or(core::ptr::null());
+
+        unsafe {
+            s2n_config_set_verification_ca_location(self.as_mut_ptr(), file_ptr, dir_ptr)
+                .into_result()
+        }?;
+        Ok(self)
+    }
+
     pub fn wipe_trust_store(&mut self) -> Result<&mut Self, Error> {
         unsafe { s2n_config_wipe_trust_store(self.as_mut_ptr()).into_result()? };
         Ok(self)
@@ -265,6 +307,39 @@ impl Builder {
             s2n_config_set_client_auth_type(self.as_mut_ptr(), auth_type.into()).into_result()
         }?;
         Ok(self)
+    }
+
+    /// Clients will request OCSP stapling from the server.
+    pub fn enable_ocsp(&mut self) -> Result<&mut Self, Error> {
+        unsafe {
+            s2n_config_set_status_request_type(self.as_mut_ptr(), s2n_status_request_type::OCSP)
+                .into_result()
+        }?;
+        Ok(self)
+    }
+
+    /// Sets the OCSP data for the default certificate chain associated with the Config.
+    ///
+    /// Servers will send the data in response to OCSP stapling requests from clients.
+    //
+    // NOTE: this modifies a certificate chain, NOT the Config itself. This is currently safe
+    // because the certificate chain is set with s2n_config_add_cert_chain_and_key, which
+    // creates a new certificate chain only accessible by the given config. It will
+    // NOT be safe when we add support for the newer s2n_config_add_cert_chain_and_key_to_store API,
+    // which allows certificate chains to be shared across configs.
+    // In that case, we'll need additional guard rails either in these bindings or in the underlying C.
+    pub fn set_ocsp_data(&mut self, data: &[u8]) -> Result<&mut Self, Error> {
+        let size: u32 = data.len().try_into().map_err(|_| Error::InvalidInput)?;
+        unsafe {
+            s2n_config_set_extension_data(
+                self.as_mut_ptr(),
+                s2n_tls_extension_type::OCSP_STAPLING,
+                data.as_ptr(),
+                size,
+            )
+            .into_result()
+        }?;
+        self.enable_ocsp()
     }
 
     /// Set a custom callback function which is run during client certificate validation during
@@ -358,6 +433,80 @@ impl Builder {
         Ok(self)
     }
 
+    /// Set a callback function that will be used to get the system time.
+    ///
+    /// The wall clock time is the best-guess at the real time, measured since the epoch.
+    /// Unlike monotonic time, it CAN move backwards.
+    /// It is used by s2n-tls for timestamps.
+    pub fn set_wall_clock_callback<T: 'static + WallClockCallback>(
+        &mut self,
+        handler: T,
+    ) -> Result<&mut Self, Error> {
+        unsafe extern "C" fn clock_cb(
+            context: *mut ::libc::c_void,
+            time_in_nanos: *mut u64,
+        ) -> libc::c_int {
+            let context = &mut *(context as *mut Context);
+            if let Some(handler) = context.wall_clock_callback.as_mut() {
+                if let Ok(nanos) = handler.get_time_since_epoch().as_nanos().try_into() {
+                    *time_in_nanos = nanos;
+                    return CallbackResult::Success.into();
+                }
+            }
+            CallbackResult::Failure.into()
+        }
+
+        let handler = Box::new(handler);
+        let context = self.0.context_mut();
+        context.wall_clock_callback = Some(handler);
+        unsafe {
+            s2n_config_set_wall_clock(
+                self.as_mut_ptr(),
+                Some(clock_cb),
+                self.0.context_mut() as *mut _ as *mut c_void,
+            )
+            .into_result()?;
+        }
+        Ok(self)
+    }
+
+    /// Set a callback function that will be used to get the monotonic time.
+    ///
+    /// The monotonic time is the time since an arbitrary, unspecified point.
+    /// Unlike wall clock time, it MUST never move backwards.
+    /// It is used by s2n-tls for timers.
+    pub fn set_monotonic_clock_callback<T: 'static + MonotonicClockCallback>(
+        &mut self,
+        handler: T,
+    ) -> Result<&mut Self, Error> {
+        unsafe extern "C" fn clock_cb(
+            context: *mut ::libc::c_void,
+            time_in_nanos: *mut u64,
+        ) -> libc::c_int {
+            let context = &mut *(context as *mut Context);
+            if let Some(handler) = context.monotonic_clock_callback.as_mut() {
+                if let Ok(nanos) = handler.get_time().as_nanos().try_into() {
+                    *time_in_nanos = nanos;
+                    return CallbackResult::Success.into();
+                }
+            }
+            CallbackResult::Failure.into()
+        }
+
+        let handler = Box::new(handler);
+        let context = self.0.context_mut();
+        context.monotonic_clock_callback = Some(handler);
+        unsafe {
+            s2n_config_set_monotonic_clock(
+                self.as_mut_ptr(),
+                Some(clock_cb),
+                self.0.context_mut() as *mut _ as *mut c_void,
+            )
+            .into_result()?;
+        }
+        Ok(self)
+    }
+
     pub fn build(self) -> Result<Config, Error> {
         Ok(self.0)
     }
@@ -379,6 +528,8 @@ pub(crate) struct Context {
     refcount: AtomicUsize,
     pub(crate) client_hello_callback: Option<Box<dyn ClientHelloCallback>>,
     pub(crate) verify_host_callback: Option<Box<dyn VerifyHostNameCallback>>,
+    pub(crate) wall_clock_callback: Option<Box<dyn WallClockCallback>>,
+    pub(crate) monotonic_clock_callback: Option<Box<dyn MonotonicClockCallback>>,
 }
 
 impl Default for Context {
@@ -391,6 +542,8 @@ impl Default for Context {
             refcount,
             client_hello_callback: None,
             verify_host_callback: None,
+            wall_clock_callback: None,
+            monotonic_clock_callback: None,
         }
     }
 }

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -420,7 +420,7 @@ impl Connection {
     }
 
     /// Gets the number of bytes that are currently available in the buffer to be read.
-    pub fn available(&self) -> usize {
+    pub fn peek_len(&self) -> usize {
         unsafe { s2n_peek(self.connection.as_ptr()) as usize }
     }
 

--- a/bindings/rust/s2n-tls/src/testing.rs
+++ b/bindings/rust/s2n-tls/src/testing.rs
@@ -189,7 +189,7 @@ pub fn s2n_tls_pair(config: crate::config::Config) {
     poll_tls_pair(pair);
 }
 
-pub fn poll_tls_pair(mut pair: Pair<Harness, Harness>) {
+pub fn poll_tls_pair(mut pair: Pair<Harness, Harness>) -> Pair<Harness, Harness> {
     loop {
         match pair.poll() {
             Poll::Ready(result) => {
@@ -201,6 +201,8 @@ pub fn poll_tls_pair(mut pair: Pair<Harness, Harness>) {
     }
 
     // TODO add assertions to make sure the handshake actually succeeded
+
+    pair
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
### Description of changes: 

Last few changes to reach parity with the unofficial bindings:
- Add missing APIs present in unofficial bindings
- Check blinding delay in Connection::shutdown (this led to some changes in s2n-tokio-tls tests)

### Testing:

I added a test for the trust store API, since its interface was a little tricky, and the client cert API. I also technically added a test for the clock callback, since I used it in the tokio tests ;) The other APIs are simple enough that I didn't add tests, which seems to be in line with the rest of the s2n-tls crate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
