### PR TITLE
Fix how KeyUpdates trigger

### DIFF
--- a/tests/unit/s2n_sequence_number_test.c
+++ b/tests/unit/s2n_sequence_number_test.c
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
         /* Converts zero */
         {
             uint64_t output = 1;
-            uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN]= {0};
+            uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN] = {0};
             struct s2n_blob sequence_number = {0};
             
             EXPECT_SUCCESS(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
@@ -45,7 +45,7 @@ int main(int argc, char **argv)
         /* Converts one */
         {
             uint64_t output = 0;
-            uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN]  = {0};
+            uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN] = {0};
             data[S2N_TLS_SEQUENCE_NUM_LEN - 1] = 1;
             struct s2n_blob sequence_number = {0};
             
@@ -87,6 +87,25 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_sequence_number_to_uint64(&sequence_number, &output));
 
             EXPECT_EQUAL(output, S2N_TLS13_AES_GCM_MAXIMUM_RECORD_NUMBER);   
+        }
+
+        /* Matches network order stuffer methods */
+        {
+            uint64_t input = 0x1234ABCD;
+
+            /* Use stuffer to convert to network order */
+            uint8_t stuffer_bytes[S2N_TLS_SEQUENCE_NUM_LEN] = { 0 };
+            struct s2n_blob stuffer_blob = { 0 };
+            struct s2n_stuffer stuffer = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&stuffer_blob, stuffer_bytes, sizeof(stuffer_bytes)));
+            EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &stuffer_blob));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint64(&stuffer, input));
+
+            /* Use s2n_sequence_number_to_uint64 to convert back */
+            uint64_t output = 0;
+            EXPECT_SUCCESS(s2n_sequence_number_to_uint64(&stuffer_blob, &output));
+
+            EXPECT_EQUAL(input, output);
         }
     }
     END_TEST();


### PR DESCRIPTION
### Resolved issues:

Follow up to https://github.com/aws/s2n-tls/pull/3364
 resolves https://github.com/awslabs/private-s2n-cbmc/pull/79

### Description of changes: 

I fixed the potential overflow in `s2n_check_record_limit`. We don't actually need to check sequence number + 1, because the current value of the sequence number is actually the next record's sequence number (see [here](https://github.com/aws/s2n-tls/blob/e6516d30fa5b05d9db288f4fcf929595033ec92b/tls/s2n_record_write.c#L409-L411)).

### Call-outs:

I'm not sure [`s2n_sequence_number_to_uint64`](https://github.com/aws/s2n-tls/blob/a862c877a9e101d010c08375675897afa50f7a89/crypto/s2n_sequence.c#L47-L59) needs its own implementation of network order uint64 conversion. We could just use the stuffer method like I do in the tests. Were we concerned that creating a stuffer and doing all the stuffer validation is too slow?

### Testing:

I rewrote the s2n_check_record_limit tests to more systematically cover all the cases. I also added two new tests that iterate the sequence number and make sure that we (successfully) send the KeyUpdate on the expected sequence number. 

The diff for the tests is kind of a mess :\ Let me know if it's too messy, and I can see if moving the new tests around produces a cleaner diff.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
