### PR TITLE
Adds Exception for the Padding Extension

### DIFF
--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -289,6 +289,13 @@ static S2N_RESULT s2n_client_hello_verify_for_retry(struct s2n_connection *conn,
                 /* Handled when parsing the psk extension */
                 break;
             /*
+             *= https://tools.ietf.org/rfc/rfc8446#section-4.1.2
+             *#    -  Optionally adding, removing, or changing the length of the
+             *#       "padding" extension [RFC7685].
+             */
+            case TLS_EXTENSION_PADDING:
+                break;
+            /*
              * No more exceptions.
              * All other extensions must match.
              */

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -107,6 +107,7 @@
 #define TLS_EXTENSION_SIGNATURE_ALGORITHMS 13
 #define TLS_EXTENSION_ALPN                 16
 #define TLS_EXTENSION_SCT_LIST             18
+#define TLS_EXTENSION_PADDING              21
 #define TLS_EXTENSION_EMS                  23
 #define TLS_EXTENSION_SESSION_TICKET       35
 #define TLS_EXTENSION_PRE_SHARED_KEY       41


### PR DESCRIPTION
### Resolved issues:
N/A

### Description of changes: 

Adds exception in switch statement for the padding extension, which is allowed to change between client hellos based on https://datatracker.ietf.org/doc/html/rfc8446#section-4.2
### Call-outs:

N/A
### Testing:

This change is actually quite difficult to test, based on the fact that s2n doesn't support the padding extension. To test this we need to be able to add an extension to an already-written client hello, which means that we have to modify the handshake array length and the extensions array length by skipping through the client hello. Alternatively we also could overwrite an existing extension that is unimportant to handshake success, but this also ends up being a really weird test. Another alternative is that we could just implement the padding extension and only send it for tests, but that seems overkill? The fact that this is so difficult to test makes me think we need a test function that will write custom extensions, but for right now, we should just fix this issue. 

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
