### PR TITLE
ci: Remove Integration Tests from Omnibus

### DIFF
--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -211,7 +211,7 @@ batch:
           S2N_COVERAGE: true
           S2N_LIBCRYPTO: openssl-1.1.1
           TESTS: unit
-      identifier: s2nOpenSSL111Gcc6Coverage
+      identifier: s2nUnitOpenSSL111Gcc6Coverage
       
     - buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:

--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -16,217 +16,6 @@ version: 0.2
 # Doc for batch https://docs.aws.amazon.com/codebuild/latest/userguide/batch-build-buildspec.html#build-spec.batch.build-list
 batch:
   build-list:
-    # Consolidated Integration v1 tests
-    - identifier: s2nIntegrationBoringLibre
-      buildspec: codebuild/spec/buildspec_ubuntu_integ_boringlibre.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-
-    - identifier: s2nIntegrationAwsLc
-      buildspec: codebuild/spec/buildspec_ubuntu_integ_awslc.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-
-    - identifier: s2nIntegrationOpenSSL111PlusCoverage
-      buildspec: codebuild/spec/buildspec_ubuntu_integ_openssl111.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-
-    - identifier: s2nIntegrationOpenSSL102Plus
-      buildspec: codebuild/spec/buildspec_ubuntu_integ_openssl102.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-
-    - identifier: s2nIntegrationOpenSSL102AsanValgrind
-      buildspec: codebuild/spec/buildspec_ubuntu_integ_openssl102_asanvalgrind.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-
-    # Integration V2 tests
-    - identifier: s2nIntegrationV2ClientAuthentication
-      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          INTEGV2_TEST: test_client_authentication
-
-    - identifier: s2nIntegrationV2DynamicRecordSizes
-      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          INTEGV2_TEST: test_dynamic_record_sizes
-
-    - identifier: s2nIntegrationV2KeyUpdate
-      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          INTEGV2_TEST: test_key_update
-
-    - identifier: s2nIntegrationV2HappyPath
-      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          INTEGV2_TEST: test_happy_path
-
-    - identifier: s2nIntegrationV2SessionResumption
-      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          INTEGV2_TEST: test_session_resumption
-
-    - identifier: s2nIntegrationV2SniMatch
-      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          INTEGV2_TEST: test_sni_match
-
-    - identifier: s2nIntegrationV2Fragmentation
-      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          INTEGV2_TEST: test_fragmentation
-
-    - identifier: s2nIntegrationV2HelloRetryRequests
-      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          INTEGV2_TEST: test_hello_retry_requests
-
-    - identifier: s2nIntegrationV2PqHandshake
-      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          INTEGV2_TEST: test_pq_handshake
-
-    - identifier: s2nIntegrationV2SignatureAlgorithms
-      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          INTEGV2_TEST: test_signature_algorithms
-
-    - identifier: s2nIntegrationV2VersionNegotiation
-      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          INTEGV2_TEST: test_version_negotiation
-
-    - identifier: s2nIntegrationV2WellKnownEndpoints
-      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          INTEGV2_TEST: test_well_known_endpoints
-
-    - identifier: s2nIntegrationV2EarlyData
-      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          INTEGV2_TEST: test_early_data
-
-    - identifier: s2nIntegrationV2ExternalPSK
-      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          INTEGV2_TEST: test_external_psk
-
-    - identifier: s2nIntegrationV2CrossCompatibility
-      buildspec: codebuild/spec/buildspec_ubuntu_integrationv2.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          INTEGV2_TEST: test_cross_compatibility
-
-    # Individual Integration tests
-    - identifier: s2nIntegrationBoringSSLGcc9
-      buildspec: codebuild/spec/buildspec_ubuntu.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          S2N_LIBCRYPTO: boringssl
-          BUILD_S2N: true
-          TESTS: integration
-          GCC_VERSION: 9
-
-    - identifier: s2nIntegrationOpenSSL111Gcc6SoftCrypto
-      buildspec: codebuild/spec/buildspec_ubuntu.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          S2N_LIBCRYPTO: openssl-1.1.1
-          BUILD_S2N: true
-          TESTS: integration
-          GCC_VERSION: 6
-          OPENSSL_ia32cap: "~0x200000200000000"
-
-    - identifier: s2nIntegrationOpenSSL111Gcc9
-      buildspec: codebuild/spec/buildspec_ubuntu.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          S2N_LIBCRYPTO: openssl-1.1.1
-          BUILD_S2N: true
-          TESTS: integration
-          GCC_VERSION: 9
-
-    - identifier: s2nIntegrationLibreSSLGcc9
-      buildspec: codebuild/spec/buildspec_ubuntu.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          S2N_LIBCRYPTO: libressl
-          BUILD_S2N: true
-          TESTS: integration
-          GCC_VERSION: 9
-
-    - identifier: s2nIntegrationOpenSSL111Gcc6Coverage
-      buildspec: codebuild/spec/buildspec_ubuntu.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          S2N_LIBCRYPTO: openssl-1.1.1
-          BUILD_S2N: true
-          TESTS: integration
-          GCC_VERSION: 6
-          S2N_COVERAGE: true
-          CODECOV_IO_UPLOAD: true
-
     # Saw
     - identifier: s2nSawBike
       buildspec: codebuild/spec/buildspec_ubuntu.yml
@@ -410,6 +199,43 @@ batch:
         variables:
           GCC_VERSION: '6'
           TESTS: crt
+          
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        privileged-mode: true
+        variables:
+          BUILD_S2N: true
+          CODECOV_IO_UPLOAD: true
+          GCC_VERSION: 6
+          S2N_COVERAGE: true
+          S2N_LIBCRYPTO: openssl-1.1.1
+          TESTS: unit
+      identifier: s2nOpenSSL111Gcc6Coverage
+      
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        privileged-mode: true
+        variables:
+          BUILD_S2N: 'true'
+          GCC_VERSION: '6'
+          S2N_LIBCRYPTO: 'libressl'
+          S2N_NO_PQ: 1
+          TESTS: unit
+      identifier: s2nUnitLibressl
+      
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        privileged-mode: true
+        variables:
+          BUILD_S2N: 'true'
+          GCC_VERSION: '9'
+          S2N_LIBCRYPTO: 'boringssl'
+          S2N_NO_PQ: 1
+          TESTS: unit
+      identifier: s2nUnitBoringssl
 
     # Fuzz tests
     - identifier: s2nFuzzerOpenSSL111Coverage


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

Recently, the s2n-tls release process has been changed to run both the omnibus job and a new job specifically for integration v2 tests. This is because the omnibus job uses a Codebuild build list, and the v2 integration batch uses a build-matrix, and these are not compatible in the same buildspec. As such, this PR removes all v2 tests from the omnibus job. 

And, given that the release v2 batch runs the entire set of v2 tests on all build environments, the v1 tests are no longer needed, and were also removed.

Additionally, this PR adds two new unit tests:
- libressl with GCC 6
- boringssl with GCC 9

Since the integration tests (which also run unit tests) for libressl and boringssl now run nightly, rather than on every PR, these unit tests were added so the general batch will run them instead.

A coverage test was also added:
- openssl 1.1.1 with GCC 6

Which was originally in the v1 batch, and will now be in the general batch. This allows for the v1 batch to be safely removed from PR updates.

### Call-outs:

None

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Codebuild run with the updated omnibus buildspec:
https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nOmnibus/batch/s2nOmnibus%3Ae39bd144-8d19-4fcf-8396-22a41e1c827c/builds?region=us-west-2

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
