### PR TITLE
Remove CBMC proof typechecking warnings

### DIFF
--- a/tests/cbmc/include/cbmc_proof/endian.h
+++ b/tests/cbmc/include/cbmc_proof/endian.h
@@ -19,6 +19,20 @@
 #    define __LONG_LONG_PAIR(HI, LO) HI, LO
 #endif
 
+#undef htobe16
+#undef htole16
+#undef htobe32
+#undef htole32
+#undef htobe64
+#undef htole64
+
+#undef be16toh
+#undef le16toh
+#undef be32toh
+#undef le32toh
+#undef be64toh
+#undef le64toh
+
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 #    define htobe16(x) __builtin_bswap16(x)
 #    define htole16(x) (x)

--- a/tests/cbmc/proofs/s2n_array_capacity/s2n_array_capacity_harness.c
+++ b/tests/cbmc/proofs/s2n_array_capacity/s2n_array_capacity_harness.c
@@ -18,6 +18,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_array_capacity_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_array_free/s2n_array_free_harness.c
+++ b/tests/cbmc/proofs/s2n_array_free/s2n_array_free_harness.c
@@ -18,6 +18,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_array_free_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_array_free_p/s2n_array_free_p_harness.c
+++ b/tests/cbmc/proofs/s2n_array_free_p/s2n_array_free_p_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_array_free_p_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_array_get/s2n_array_get_harness.c
+++ b/tests/cbmc/proofs/s2n_array_get/s2n_array_get_harness.c
@@ -18,6 +18,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_array_get_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_array_init/s2n_array_init_harness.c
+++ b/tests/cbmc/proofs/s2n_array_init/s2n_array_init_harness.c
@@ -18,6 +18,8 @@
 #include <cbmc_proof/make_common_datastructures.h>
 #include <cbmc_proof/cbmc_utils.h>
 
+#include <assert.h>
+
 void s2n_array_init_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_array_insert/s2n_array_insert_harness.c
+++ b/tests/cbmc/proofs/s2n_array_insert/s2n_array_insert_harness.c
@@ -19,6 +19,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_array_insert_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_array_insert_and_copy/s2n_array_insert_and_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_array_insert_and_copy/s2n_array_insert_and_copy_harness.c
@@ -18,6 +18,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_array_insert_and_copy_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_array_new/s2n_array_new_harness.c
+++ b/tests/cbmc/proofs/s2n_array_new/s2n_array_new_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_array_new_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_array_num_elements/s2n_array_num_elements_harness.c
+++ b/tests/cbmc/proofs/s2n_array_num_elements/s2n_array_num_elements_harness.c
@@ -18,6 +18,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_array_num_elements_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_array_pushback/s2n_array_pushback_harness.c
+++ b/tests/cbmc/proofs/s2n_array_pushback/s2n_array_pushback_harness.c
@@ -18,6 +18,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_array_pushback_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_array_remove/s2n_array_remove_harness.c
+++ b/tests/cbmc/proofs/s2n_array_remove/s2n_array_remove_harness.c
@@ -18,6 +18,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_array_remove_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_connection_get_last_message_name/s2n_connection_get_last_message_name_harness.c
+++ b/tests/cbmc/proofs/s2n_connection_get_last_message_name/s2n_connection_get_last_message_name_harness.c
@@ -15,6 +15,8 @@
 
 #include <tls/s2n_connection.h>
 
+#include <assert.h>
+
 void s2n_connection_get_last_message_name_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_constant_time_pkcs1_unpad_or_dont/Makefile
+++ b/tests/cbmc/proofs/s2n_constant_time_pkcs1_unpad_or_dont/Makefile
@@ -16,7 +16,7 @@
 MAX_ARR_LEN = 10
 
 # Bound for copy or dont must be at at least three higher than the maximum array length
-BOUND = $(MAX_ARR_LEN) + 3
+BOUND = $(MAX_ARR_LEN)+3
 
 DEFINES += -DMAX_ARR_LEN=$(MAX_ARR_LEN)
 DEFINES += -DBOUND=$(BOUND)

--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips/s2n_digest_allow_md5_for_fips_harness.c
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips/s2n_digest_allow_md5_for_fips_harness.c
@@ -18,6 +18,8 @@
 #include "crypto/s2n_fips.h"
 #include "crypto/s2n_evp.h"
 
+#include <assert.h>
+
 void s2n_digest_allow_md5_for_fips_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/s2n_digest_allow_md5_for_fips_boringssl_awslc_harness.c
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/s2n_digest_allow_md5_for_fips_boringssl_awslc_harness.c
@@ -18,6 +18,8 @@
 #include "api/s2n.h"
 #include "crypto/s2n_evp.h"
 
+#include <assert.h>
+
 void s2n_digest_allow_md5_for_fips_boringssl_awslc_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/s2n_digest_allow_md5_for_fips_boringssl_awslc_harness.c
+++ b/tests/cbmc/proofs/s2n_digest_allow_md5_for_fips_boringssl_awslc/s2n_digest_allow_md5_for_fips_boringssl_awslc_harness.c
@@ -17,6 +17,7 @@
 
 #include "api/s2n.h"
 #include "crypto/s2n_evp.h"
+#include "crypto/s2n_fips.h"
 
 #include <assert.h>
 

--- a/tests/cbmc/proofs/s2n_digest_is_md5_allowed_for_fips/s2n_digest_is_md5_allowed_for_fips_harness.c
+++ b/tests/cbmc/proofs/s2n_digest_is_md5_allowed_for_fips/s2n_digest_is_md5_allowed_for_fips_harness.c
@@ -19,6 +19,8 @@
 #include "crypto/s2n_evp.h"
 #include "utils/s2n_result.h"
 
+#include <assert.h>
+
 void s2n_digest_is_md5_allowed_for_fips_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_free/s2n_free_harness.c
+++ b/tests/cbmc/proofs/s2n_free/s2n_free_harness.c
@@ -35,7 +35,7 @@ void s2n_free_harness()
     if (result == S2N_SUCCESS) {
         /* Postconditions. */
         assert(S2N_IMPLIES(old_blob.allocated, blob->data == NULL));
-        assert_all_zeroes(blob, sizeof(*blob));
+        assert_all_zeroes((const uint8_t *)blob, sizeof(*blob));
         if (old_blob.size != 0 && s2n_blob_is_growable(&old_blob)) {
             assert(!S2N_MEM_IS_READABLE(blob->data, old_blob.size));
         }

--- a/tests/cbmc/proofs/s2n_hash_allow_md5_for_fips/s2n_hash_allow_md5_for_fips_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_allow_md5_for_fips/s2n_hash_allow_md5_for_fips_harness.c
@@ -18,6 +18,8 @@
 #include "crypto/s2n_fips.h"
 #include "crypto/s2n_hash.h"
 
+#include <assert.h>
+
 void s2n_hash_allow_md5_for_fips_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_block_size/s2n_hash_block_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_block_size/s2n_hash_block_size_harness.c
@@ -40,7 +40,7 @@ void s2n_hash_block_size_harness()
             case S2N_HASH_SHA512:
                 assert(*block_size == 128); break;
             default:
-                __CPROVER_assert(0, "Unssuported algorithm.");
+                __CPROVER_assert(0, "Unsupported algorithm.");
         }
     }
 }

--- a/tests/cbmc/proofs/s2n_hash_block_size/s2n_hash_block_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_block_size/s2n_hash_block_size_harness.c
@@ -17,6 +17,8 @@
 
 #include "crypto/s2n_hash.h"
 
+#include <assert.h>
+
 void s2n_hash_block_size_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/s2n_hash_const_time_get_currently_in_hash_block_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/s2n_hash_const_time_get_currently_in_hash_block_harness.c
@@ -19,6 +19,8 @@
 
 #include <assert.h>
 
+int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
+
 void s2n_hash_const_time_get_currently_in_hash_block_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/s2n_hash_const_time_get_currently_in_hash_block_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/s2n_hash_const_time_get_currently_in_hash_block_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_hash_const_time_get_currently_in_hash_block_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_copy/s2n_hash_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_copy/s2n_hash_copy_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_hash_copy_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_copy/s2n_hash_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_copy/s2n_hash_copy_harness.c
@@ -19,6 +19,8 @@
 
 #include <assert.h>
 
+int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
+
 void s2n_hash_copy_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_digest/s2n_hash_digest_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_digest/s2n_hash_digest_harness.c
@@ -19,6 +19,8 @@
 
 #include <assert.h>
 
+int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
+
 void s2n_hash_digest_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_digest/s2n_hash_digest_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_digest/s2n_hash_digest_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_hash_digest_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_digest_size/s2n_hash_digest_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_digest_size/s2n_hash_digest_size_harness.c
@@ -38,7 +38,7 @@ void s2n_hash_digest_size_harness()
         case S2N_HASH_SHA512:   assert(*out == SHA512_DIGEST_LENGTH); break;
         case S2N_HASH_MD5_SHA1: assert(*out == MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH); break;
         default:
-            __CPROVER_assert(0, "Unssuported algorithm.");
+            __CPROVER_assert(0, "Unsupported algorithm.");
         }
     }
 }

--- a/tests/cbmc/proofs/s2n_hash_digest_size/s2n_hash_digest_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_digest_size/s2n_hash_digest_size_harness.c
@@ -17,6 +17,8 @@
 
 #include "crypto/s2n_hash.h"
 
+#include <assert.h>
+
 void s2n_hash_digest_size_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_free/s2n_hash_free_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_free/s2n_hash_free_harness.c
@@ -18,6 +18,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_hash_free_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/s2n_hash_get_currently_in_hash_total_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/s2n_hash_get_currently_in_hash_total_harness.c
@@ -19,6 +19,8 @@
 
 #include <assert.h>
 
+int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
+
 void s2n_hash_get_currently_in_hash_total_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/s2n_hash_get_currently_in_hash_total_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/s2n_hash_get_currently_in_hash_total_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_hash_get_currently_in_hash_total_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_hmac_alg/s2n_hash_hmac_alg_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_hmac_alg/s2n_hash_hmac_alg_harness.c
@@ -17,6 +17,8 @@
 
 #include "crypto/s2n_hmac.h"
 
+#include <assert.h>
+
 void s2n_hash_hmac_alg_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_hmac_alg/s2n_hash_hmac_alg_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_hmac_alg/s2n_hash_hmac_alg_harness.c
@@ -40,7 +40,7 @@ void s2n_hash_hmac_alg_harness()
         case S2N_HASH_SHA384:     assert(*out == S2N_HMAC_SHA384); break;
         case S2N_HASH_SHA512:     assert(*out == S2N_HMAC_SHA512); break;
         default:
-            __CPROVER_assert(0, "Unssuported algorithm.");
+            __CPROVER_assert(0, "Unsupported algorithm.");
         }
     } else {
         assert(IMPLIES(out != NULL && hash_alg == S2N_HASH_MD5_SHA1, *out == old_out));

--- a/tests/cbmc/proofs/s2n_hash_init/s2n_hash_init_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_init/s2n_hash_init_harness.c
@@ -17,6 +17,8 @@
 
 #include "crypto/s2n_hash.h"
 
+#include <assert.h>
+
 void s2n_hash_init_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_is_available/s2n_hash_is_available_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_is_available/s2n_hash_is_available_harness.c
@@ -43,6 +43,6 @@ void s2n_hash_is_available_harness()
         case S2N_HASH_SENTINEL:
             assert(!is_available); break;
         default:
-            __CPROVER_assert(!is_available, "Unssuported algorithm.");
+            __CPROVER_assert(!is_available, "Unsupported algorithm.");
     }
 }

--- a/tests/cbmc/proofs/s2n_hash_is_available/s2n_hash_is_available_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_is_available/s2n_hash_is_available_harness.c
@@ -18,6 +18,8 @@
 #include "crypto/s2n_fips.h"
 #include "crypto/s2n_hash.h"
 
+#include <assert.h>
+
 void s2n_hash_is_available_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_is_ready_for_input/s2n_hash_is_ready_for_input_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_is_ready_for_input/s2n_hash_is_ready_for_input_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_hash_is_ready_for_input_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_new/s2n_hash_new_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_new/s2n_hash_new_harness.c
@@ -17,6 +17,8 @@
 
 #include "crypto/s2n_hash.h"
 
+#include <assert.h>
+
 void s2n_hash_new_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_reset/s2n_hash_reset_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_reset/s2n_hash_reset_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_hash_reset_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_update/s2n_hash_update_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_update/s2n_hash_update_harness.c
@@ -19,6 +19,8 @@
 
 #include <assert.h>
 
+int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
+
 void s2n_hash_update_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hash_update/s2n_hash_update_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_update/s2n_hash_update_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_hash_update_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hex_string_to_bytes/s2n_hex_string_to_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_hex_string_to_bytes/s2n_hex_string_to_bytes_harness.c
@@ -20,6 +20,8 @@
 #include "error/s2n_errno.h"
 #include "utils/s2n_blob.h"
 
+#include <assert.h>
+
 void s2n_hex_string_to_bytes_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_copy/s2n_hmac_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_copy/s2n_hmac_copy_harness.c
@@ -19,6 +19,8 @@
 
 #include <assert.h>
 
+int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
+
 void s2n_hmac_copy_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_copy/s2n_hmac_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_copy/s2n_hmac_copy_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_hmac_copy_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_digest/s2n_hmac_digest_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_digest/s2n_hmac_digest_harness.c
@@ -19,6 +19,8 @@
 
 #include <assert.h>
 
+int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
+
 void s2n_hmac_digest_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_digest/s2n_hmac_digest_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_digest/s2n_hmac_digest_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_hmac_digest_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_digest_size/s2n_hmac_digest_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_digest_size/s2n_hmac_digest_size_harness.c
@@ -39,7 +39,7 @@ void s2n_hmac_digest_size_harness()
         case S2N_HMAC_SSLv3_MD5:  assert(*out == MD5_DIGEST_LENGTH);    break;
         case S2N_HMAC_SSLv3_SHA1: assert(*out == SHA_DIGEST_LENGTH);    break;
         default:
-            __CPROVER_assert(0, "Unssuported algorithm.");
+            __CPROVER_assert(0, "Unsupported algorithm.");
         }
     }
 }

--- a/tests/cbmc/proofs/s2n_hmac_digest_size/s2n_hmac_digest_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_digest_size/s2n_hmac_digest_size_harness.c
@@ -17,6 +17,8 @@
 
 #include "crypto/s2n_hmac.h"
 
+#include <assert.h>
+
 void s2n_hmac_digest_size_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/s2n_hmac_digest_two_compression_rounds_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/s2n_hmac_digest_two_compression_rounds_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_hmac_digest_two_compression_rounds_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/s2n_hmac_digest_two_compression_rounds_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/s2n_hmac_digest_two_compression_rounds_harness.c
@@ -19,6 +19,8 @@
 
 #include <assert.h>
 
+int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
+
 void s2n_hmac_digest_two_compression_rounds_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_free/s2n_hmac_free_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_free/s2n_hmac_free_harness.c
@@ -18,6 +18,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_hmac_free_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_hash_alg/s2n_hmac_hash_alg_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_hash_alg/s2n_hmac_hash_alg_harness.c
@@ -17,6 +17,8 @@
 
 #include "crypto/s2n_hmac.h"
 
+#include <assert.h>
+
 void s2n_hmac_hash_alg_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_hash_alg/s2n_hmac_hash_alg_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_hash_alg/s2n_hmac_hash_alg_harness.c
@@ -39,7 +39,7 @@ void s2n_hmac_hash_alg_harness()
         case S2N_HMAC_SSLv3_MD5:  assert(*out == S2N_HASH_MD5);    break;
         case S2N_HMAC_SSLv3_SHA1: assert(*out == S2N_HASH_SHA1);   break;
         default:
-            __CPROVER_assert(0, "Unssuported algorithm.");
+            __CPROVER_assert(0, "Unsupported algorithm.");
         }
     }
 }

--- a/tests/cbmc/proofs/s2n_hmac_hash_block_size/s2n_hmac_hash_block_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_hash_block_size/s2n_hmac_hash_block_size_harness.c
@@ -19,6 +19,8 @@
 
 #include <assert.h>
 
+int s2n_hmac_hash_block_size(s2n_hmac_algorithm, uint16_t *);
+
 void s2n_hmac_hash_block_size_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_hash_block_size/s2n_hmac_hash_block_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_hash_block_size/s2n_hmac_hash_block_size_harness.c
@@ -17,6 +17,8 @@
 
 #include "crypto/s2n_hmac.h"
 
+#include <assert.h>
+
 void s2n_hmac_hash_block_size_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_hash_block_size/s2n_hmac_hash_block_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_hash_block_size/s2n_hmac_hash_block_size_harness.c
@@ -43,7 +43,7 @@ void s2n_hmac_hash_block_size_harness()
             case S2N_HMAC_SHA512:
                 assert(*block_size == 128); break;
             default:
-                __CPROVER_assert(0, "Unssuported algorithm.");
+                __CPROVER_assert(0, "Unsupported algorithm.");
         }
     }
 }

--- a/tests/cbmc/proofs/s2n_hmac_init/s2n_hmac_init_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_init/s2n_hmac_init_harness.c
@@ -17,6 +17,8 @@
 
 #include "crypto/s2n_hmac.h"
 
+#include <assert.h>
+
 void s2n_hmac_init_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_is_available/s2n_hmac_is_available_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_is_available/s2n_hmac_is_available_harness.c
@@ -42,6 +42,6 @@ void s2n_hmac_is_available_harness()
         case S2N_HASH_SHA512:
             assert(is_available); break;
         default:
-            __CPROVER_assert(!is_available, "Unssuported algorithm.");
+            __CPROVER_assert(!is_available, "Unsupported algorithm.");
     }
 }

--- a/tests/cbmc/proofs/s2n_hmac_is_available/s2n_hmac_is_available_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_is_available/s2n_hmac_is_available_harness.c
@@ -18,6 +18,8 @@
 #include "crypto/s2n_fips.h"
 #include "crypto/s2n_hmac.h"
 
+#include <assert.h>
+
 void s2n_hmac_is_available_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_new/s2n_hmac_new_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_new/s2n_hmac_new_harness.c
@@ -18,6 +18,8 @@
 #include "crypto/s2n_hmac.h"
 #include "utils/s2n_result.h"
 
+#include <assert.h>
+
 void s2n_hmac_new_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_reset/s2n_hmac_reset_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_reset/s2n_hmac_reset_harness.c
@@ -19,6 +19,8 @@
 
 #include <assert.h>
 
+int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
+
 void s2n_hmac_reset_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_reset/s2n_hmac_reset_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_reset/s2n_hmac_reset_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_hmac_reset_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_restore_evp_hash_state/s2n_hmac_restore_evp_hash_state_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_restore_evp_hash_state/s2n_hmac_restore_evp_hash_state_harness.c
@@ -17,6 +17,8 @@
 
 #include "crypto/s2n_hmac.h"
 
+#include <assert.h>
+
 void s2n_hmac_restore_evp_hash_state_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_save_evp_hash_state/s2n_hmac_save_evp_hash_state_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_save_evp_hash_state/s2n_hmac_save_evp_hash_state_harness.c
@@ -17,6 +17,8 @@
 
 #include "crypto/s2n_hmac.h"
 
+#include <assert.h>
+
 void s2n_hmac_save_evp_hash_state_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_update/s2n_hmac_update_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_update/s2n_hmac_update_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_hmac_update_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_update/s2n_hmac_update_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_update/s2n_hmac_update_harness.c
@@ -19,6 +19,8 @@
 
 #include <assert.h>
 
+int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
+
 void s2n_hmac_update_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_xor_pad_size/s2n_hmac_xor_pad_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_xor_pad_size/s2n_hmac_xor_pad_size_harness.c
@@ -17,6 +17,8 @@
 
 #include "crypto/s2n_hmac.h"
 
+#include <assert.h>
+
 void s2n_hmac_xor_pad_size_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_hmac_xor_pad_size/s2n_hmac_xor_pad_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_xor_pad_size/s2n_hmac_xor_pad_size_harness.c
@@ -41,7 +41,7 @@ void s2n_hmac_xor_pad_size_harness()
             case S2N_HMAC_SSLv3_MD5:  assert(*xor_pad_size == 48);  break;
             case S2N_HMAC_SSLv3_SHA1: assert(*xor_pad_size == 40);  break;
             default:
-                __CPROVER_assert(0, "Unssuported algorithm.");
+                __CPROVER_assert(0, "Unsupported algorithm.");
         }
     }
 }

--- a/tests/cbmc/proofs/s2n_hmac_xor_pad_size/s2n_hmac_xor_pad_size_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_xor_pad_size/s2n_hmac_xor_pad_size_harness.c
@@ -19,6 +19,8 @@
 
 #include <assert.h>
 
+int s2n_hmac_xor_pad_size(s2n_hmac_algorithm, uint16_t *);
+
 void s2n_hmac_xor_pad_size_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_is_hello_retry_handshake/s2n_is_hello_retry_handshake_harness.c
+++ b/tests/cbmc/proofs/s2n_is_hello_retry_handshake/s2n_is_hello_retry_handshake_harness.c
@@ -15,6 +15,8 @@
 
 #include <tls/s2n_connection.h>
 
+#include <assert.h>
+
 void s2n_is_hello_retry_handshake_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_is_hello_retry_message/s2n_is_hello_retry_message_harness.c
+++ b/tests/cbmc/proofs/s2n_is_hello_retry_message/s2n_is_hello_retry_message_harness.c
@@ -15,6 +15,8 @@
 
 #include <tls/s2n_connection.h>
 
+#include <assert.h>
+
 void s2n_is_hello_retry_message_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_set_add/s2n_set_add_harness.c
+++ b/tests/cbmc/proofs/s2n_set_add/s2n_set_add_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_set_add_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_set_free/s2n_set_free_harness.c
+++ b/tests/cbmc/proofs/s2n_set_free/s2n_set_free_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_set_free_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_set_free_p/s2n_set_free_p_harness.c
+++ b/tests/cbmc/proofs/s2n_set_free_p/s2n_set_free_p_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_set_free_p_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_set_get/s2n_set_get_harness.c
+++ b/tests/cbmc/proofs/s2n_set_get/s2n_set_get_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_set_get_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_set_len/s2n_set_len_harness.c
+++ b/tests/cbmc/proofs/s2n_set_len/s2n_set_len_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_set_len_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_set_new/s2n_set_new_harness.c
+++ b/tests/cbmc/proofs/s2n_set_new/s2n_set_new_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_set_new_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_set_remove/s2n_set_remove_harness.c
+++ b/tests/cbmc/proofs/s2n_set_remove/s2n_set_remove_harness.c
@@ -17,6 +17,8 @@
 
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_set_remove_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_socket_is_ipv6/s2n_socket_is_ipv6_harness.c
+++ b/tests/cbmc/proofs/s2n_socket_is_ipv6/s2n_socket_is_ipv6_harness.c
@@ -8,6 +8,8 @@
 
 #include <utils/s2n_socket.h>
 
+#include <assert.h>
+
 void s2n_socket_is_ipv6_harness()
 {
   /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_socket_quickack/s2n_socket_quickack_harness.c
+++ b/tests/cbmc/proofs/s2n_socket_quickack/s2n_socket_quickack_harness.c
@@ -9,6 +9,8 @@
 #include <utils/s2n_socket.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_socket_quickack_harness()
 {
   /* Non-deterministic inputs. */  

--- a/tests/cbmc/proofs/s2n_socket_read/s2n_socket_read_harness.c
+++ b/tests/cbmc/proofs/s2n_socket_read/s2n_socket_read_harness.c
@@ -9,6 +9,8 @@
 #include "utils/s2n_socket.h"
 #include "cbmc_proof/make_common_datastructures.h"
 
+#include <assert.h>
+
 void s2n_socket_read_harness()
 {
   /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_socket_read_restore/s2n_socket_read_restore_harness.c
+++ b/tests/cbmc/proofs/s2n_socket_read_restore/s2n_socket_read_restore_harness.c
@@ -9,6 +9,8 @@
 #include <utils/s2n_socket.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_socket_read_restore_harness()
 {
   /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_socket_read_snapshot/s2n_socket_read_snapshot_harness.c
+++ b/tests/cbmc/proofs/s2n_socket_read_snapshot/s2n_socket_read_snapshot_harness.c
@@ -9,6 +9,8 @@
 #include <utils/s2n_socket.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_socket_read_snapshot_harness()
 {
   /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_socket_set_read_size/s2n_socket_set_read_size_harness.c
+++ b/tests/cbmc/proofs/s2n_socket_set_read_size/s2n_socket_set_read_size_harness.c
@@ -10,6 +10,8 @@
 #include <utils/s2n_socket.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_socket_set_read_size_harness()
 {
   /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_socket_was_corked/s2n_socket_was_corked_harness.c
+++ b/tests/cbmc/proofs/s2n_socket_was_corked/s2n_socket_was_corked_harness.c
@@ -9,6 +9,8 @@
 #include <utils/s2n_socket.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_socket_was_corked_harness()
 {
   /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_socket_write/s2n_socket_write_harness.c
+++ b/tests/cbmc/proofs/s2n_socket_write/s2n_socket_write_harness.c
@@ -9,6 +9,8 @@
 #include <utils/s2n_socket.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_socket_write_harness()
 {
   /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_socket_write_cork/s2n_socket_write_cork_harness.c
+++ b/tests/cbmc/proofs/s2n_socket_write_cork/s2n_socket_write_cork_harness.c
@@ -9,6 +9,8 @@
 #include <utils/s2n_socket.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_socket_write_cork_harness()
 {
   /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_socket_write_restore/s2n_socket_write_restore_harness.c
+++ b/tests/cbmc/proofs/s2n_socket_write_restore/s2n_socket_write_restore_harness.c
@@ -9,6 +9,8 @@
 #include <utils/s2n_socket.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_socket_write_restore_harness()
 {
   /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_socket_write_snapshot/s2n_socket_write_snapshot_harness.c
+++ b/tests/cbmc/proofs/s2n_socket_write_snapshot/s2n_socket_write_snapshot_harness.c
@@ -9,6 +9,8 @@
 #include <utils/s2n_socket.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_socket_write_snapshot_harness()
 {
   /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_socket_write_uncork/s2n_socket_write_uncork_harness.c
+++ b/tests/cbmc/proofs/s2n_socket_write_uncork/s2n_socket_write_uncork_harness.c
@@ -9,6 +9,8 @@
 #include <utils/s2n_socket.h>
 #include <cbmc_proof/make_common_datastructures.h>
 
+#include <assert.h>
+
 void s2n_socket_write_uncork_harness()
 {
   /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/s2n_stuffer_alloc_ro_from_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_fd/s2n_stuffer_alloc_ro_from_fd_harness.c
@@ -21,6 +21,8 @@
 #include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"
 
+int s2n_stuffer_alloc_ro_from_fd(struct s2n_stuffer *, int);
+
 void s2n_stuffer_alloc_ro_from_fd_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/s2n_stuffer_alloc_ro_from_file_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_alloc_ro_from_file/s2n_stuffer_alloc_ro_from_file_harness.c
@@ -22,6 +22,8 @@
 #include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"
 
+int s2n_stuffer_alloc_ro_from_file(struct s2n_stuffer *, const char *);
+
 void s2n_stuffer_alloc_ro_from_file_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_stuffer_erase_and_read/s2n_stuffer_erase_and_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_erase_and_read/s2n_stuffer_erase_and_read_harness.c
@@ -65,5 +65,5 @@ void s2n_stuffer_erase_and_read_harness()
     assert(blob->size == old_blob.size);
 
     assert(s2n_result_is_ok(s2n_stuffer_validate(stuffer)));
-    assert(s2n_result_is_ok(s2n_blob_validate(stuffer)));
+    assert(s2n_result_is_ok(s2n_blob_validate(blob)));
 }

--- a/tests/cbmc/proofs/s2n_stuffer_free/s2n_stuffer_free_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_free/s2n_stuffer_free_harness.c
@@ -36,7 +36,7 @@ void s2n_stuffer_free_harness()
     /* Operation under verification. */
     int result = s2n_stuffer_free(stuffer);
     if (result == S2N_SUCCESS && stuffer != NULL) {
-        assert_all_zeroes(stuffer, sizeof(*stuffer));
+        assert_all_zeroes((const uint8_t *)stuffer, sizeof(*stuffer));
     } else if (result == S2N_FAILURE && s2n_errno == S2N_ERR_FREE_STATIC_BLOB) {
         assert(!old_blob.growable);
     }

--- a/tests/cbmc/proofs/s2n_stuffer_is_consumed/s2n_stuffer_is_consumed_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_is_consumed/s2n_stuffer_is_consumed_harness.c
@@ -19,6 +19,8 @@
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 
+#include <assert.h>
+
 void s2n_stuffer_is_consumed_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_stuffer_read/s2n_stuffer_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read/s2n_stuffer_read_harness.c
@@ -53,5 +53,5 @@ void s2n_stuffer_read_harness()
 
     assert_byte_from_blob_matches(&stuffer->blob, &old_byte);
     assert(s2n_result_is_ok(s2n_stuffer_validate(stuffer)));
-    assert(s2n_result_is_ok(s2n_blob_validate(stuffer)));
+    assert(s2n_result_is_ok(s2n_blob_validate(blob)));
 }

--- a/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/s2n_stuffer_recv_from_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_recv_from_fd/s2n_stuffer_recv_from_fd_harness.c
@@ -20,6 +20,8 @@
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
+#include <assert.h>
+
 void s2n_stuffer_recv_from_fd_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_stuffer_reserve/s2n_stuffer_reserve_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_reserve/s2n_stuffer_reserve_harness.c
@@ -23,6 +23,8 @@
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
+int s2n_stuffer_reserve(struct s2n_stuffer *, struct s2n_stuffer_reservation *, const uint8_t);
+
 void s2n_stuffer_reserve_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_stuffer_resize/s2n_stuffer_resize_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_resize/s2n_stuffer_resize_harness.c
@@ -20,6 +20,8 @@
 #include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"
 
+#include <assert.h>
+
 void s2n_stuffer_resize_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/s2n_stuffer_resize_if_empty_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_resize_if_empty/s2n_stuffer_resize_if_empty_harness.c
@@ -20,6 +20,8 @@
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
+#include <assert.h>
+
 /*
  * The reason we don't have full coverage is that we only call s2n_realloc
  * with blob-data == NULL.

--- a/tests/cbmc/proofs/s2n_stuffer_send_to_fd/s2n_stuffer_send_to_fd_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_send_to_fd/s2n_stuffer_send_to_fd_harness.c
@@ -20,6 +20,8 @@
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
+#include <assert.h>
+
 void s2n_stuffer_send_to_fd_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_stuffer_write_network_order/s2n_stuffer_write_network_order_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_network_order/s2n_stuffer_write_network_order_harness.c
@@ -22,6 +22,8 @@
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_safety.h"
 
+int s2n_stuffer_write_network_order(struct s2n_stuffer *, uint64_t, uint8_t);
+
 void s2n_stuffer_write_network_order_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/proofs/s2n_stuffer_write_reservation/s2n_stuffer_write_reservation_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_write_reservation/s2n_stuffer_write_reservation_harness.c
@@ -23,6 +23,8 @@
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
+int s2n_stuffer_write_reservation(struct s2n_stuffer_reservation *, const uint32_t);
+
 void s2n_stuffer_write_reservation_harness()
 {
     /* Non-deterministic inputs. */

--- a/tests/cbmc/sources/cbmc_utils.c
+++ b/tests/cbmc/sources/cbmc_utils.c
@@ -15,6 +15,7 @@
 
 #include <assert.h>
 #include <crypto/s2n_hash.h>
+#include <utils/s2n_mem.h>
 #include <cbmc_proof/cbmc_utils.h>
 
 /**

--- a/tests/cbmc/sources/cbmc_utils.c
+++ b/tests/cbmc/sources/cbmc_utils.c
@@ -242,7 +242,10 @@ void save_abstract_evp_ctx(const EVP_PKEY_CTX *pctx, struct rc_keys_from_evp_pke
 
 void save_rc_keys_from_hash_state(const struct s2n_hash_state *state, struct rc_keys_from_hash_state *storage)
 {
-    storage->evp.pkey = storage->evp.pkey_eckey = storage->evp_md5.pkey = storage->evp_md5.pkey_eckey = NULL;
+    storage->evp.pkey = NULL;
+    storage->evp.pkey_eckey = NULL;
+    storage->evp_md5.pkey = NULL;
+    storage->evp_md5.pkey_eckey = NULL;
     storage->evp.pkey_refs = storage->evp.pkey_eckey_refs = storage->evp_md5.pkey_refs = storage->evp_md5.pkey_eckey_refs = 0;
 
     if (state) {

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -663,7 +663,7 @@ void cbmc_populate_s2n_handshake_parameters(struct s2n_handshake_parameters *s2n
     cbmc_populate_s2n_signature_scheme(&(s2n_handshake_parameters->conn_sig_scheme));
     cbmc_populate_s2n_blob(&(s2n_handshake_parameters->client_cert_chain));
     cbmc_populate_s2n_signature_scheme(&(s2n_handshake_parameters->client_cert_sig_scheme));
-    cbmc_populate_s2n_cert_chain_and_key(&(s2n_handshake_parameters->our_chain_and_key));
+    cbmc_populate_s2n_cert_chain_and_key(s2n_handshake_parameters->our_chain_and_key);
     /* `s2n_handshake_parameters->exact_sni_matches`
      * `s2n_handshake_parameters->wc_sni_matches` are never allocated.
      * If required, these initializations should be done in the proof harness.
@@ -709,7 +709,7 @@ void cbmc_populate_s2n_prf_working_space(struct s2n_prf_working_space *s2n_prf_w
      * If required, this initialization should be done in the validation function.
      */
     cbmc_populate_s2n_hmac_state(&(s2n_prf_working_space->p_hash.s2n_hmac));
-    cbmc_populate_s2n_evp_hmac_state(&(s2n_prf_working_space->p_hash.s2n_hmac));
+    cbmc_populate_s2n_evp_hmac_state(&(s2n_prf_working_space->p_hash.evp_hmac));
 }
 
 struct s2n_prf_working_space* cbmc_allocate_s2n_prf_working_space()

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -115,8 +115,8 @@ bool s2n_set_is_bounded(const struct s2n_set *set, const size_t max_len, const s
 
 static int nondet_comparator(const void *a, const void *b)
 {
-    assert(a != NULL);
-    assert(b != NULL);
+    __CPROVER_assert(a != NULL, "a is not NULL");
+    __CPROVER_assert(b != NULL, "b is not NULL");
     return nondet_int();
 }
 

--- a/tests/cbmc/stubs/madvise.c
+++ b/tests/cbmc/stubs/madvise.c
@@ -14,6 +14,8 @@
  */
 
 #include <cbmc_proof/nondet.h>
+
+#include <assert.h>
 #include <errno.h>
 
 #include "error/s2n_errno.h"

--- a/tests/cbmc/stubs/mlock.c
+++ b/tests/cbmc/stubs/mlock.c
@@ -20,6 +20,6 @@
 
 int mlock(const void *addr, size_t len)
 {
-    assert(S2N_MEM_IS_WRITABLE(addr, len));
+    __CPROVER_assert(S2N_MEM_IS_WRITABLE(addr, len), "memory is writable");
     return nondet_int();
 }

--- a/tests/cbmc/stubs/mmap.c
+++ b/tests/cbmc/stubs/mmap.c
@@ -15,6 +15,7 @@
 
 #include <assert.h>
 #include <cbmc_proof/nondet.h>
+#include <stdlib.h>
 #include <sys/mman.h>
 
 void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)

--- a/tests/cbmc/stubs/munlock.c
+++ b/tests/cbmc/stubs/munlock.c
@@ -20,6 +20,6 @@
 
 int munlock(const void *addr, size_t len)
 {
-    assert(S2N_MEM_IS_WRITABLE(addr, len));
+    __CPROVER_assert(S2N_MEM_IS_WRITABLE(addr, len), "memory is writable");
     return nondet_int();
 }

--- a/tests/cbmc/stubs/posix_memalign_override.c
+++ b/tests/cbmc/stubs/posix_memalign_override.c
@@ -17,7 +17,7 @@
 
 #include <cbmc_proof/nondet.h>
 #include <errno.h>
-#include <stdint.h>
+#include <stdlib.h>
 
 /**
  * Overrides the version of posix_memalign used by CBMC.

--- a/tests/unit/s2n_stuffer_network_order_test.c
+++ b/tests/unit/s2n_stuffer_network_order_test.c
@@ -21,7 +21,7 @@
 
 #define SIZEOF_UINT24 3
 
-int s2n_stuffer_write_network_order(struct s2n_stuffer *stuffer, uint32_t input, uint8_t length);
+int s2n_stuffer_write_network_order(struct s2n_stuffer *stuffer, uint64_t input, uint8_t length);
 int s2n_stuffer_write_reservation(struct s2n_stuffer_reservation* reservation, const uint32_t u);
 
 int main(int argc, char **argv)


### PR DESCRIPTION
### Description of changes: 

See each commit subject: each of them improves code cleanliness in CBMC proofs.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Local compilation.

 Is this a refactor change? Proofs continue to run in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
