### PR TITLE
fail generate.sh when cargo fails

### DIFF
--- a/bindings/rust/generate.sh
+++ b/bindings/rust/generate.sh
@@ -5,7 +5,7 @@
 set -e
 
 # cd into the script directory so it can be executed from anywhere
-cd "$(dirname "${BASH_SOURCE[0]}")"
+pushd "$(dirname "${BASH_SOURCE[0]}")"
 
 # delete the existing copy in case we have extra files
 rm -rf s2n-tls-sys/lib
@@ -37,16 +37,18 @@ cp -r \
 cd generate && cargo run -- ../s2n-tls-sys && cd ..
 
 # make sure everything builds and passes sanity checks
-cd s2n-tls-sys \
-  && cargo test \
-  && cargo test --features pq \
-  && cargo test --features quic \
-  && cargo test --features internal \
-  && cargo test --release \
-  && cargo publish --dry-run --allow-dirty \
-  && cargo publish --dry-run --allow-dirty --all-features \
-  && cd ..
+pushd s2n-tls-sys
+cargo test
+cargo test --features pq
+cargo test --features quic \
+cargo test --features internal \
+cargo test --release \
+cargo publish --dry-run --allow-dirty \
+cargo publish --dry-run --allow-dirty --all-features \
+popd
 
-cd integration \
-  && cargo run \
-  && cd ..
+pushd integration
+cargo run
+popd
+
+popd

--- a/bindings/rust/generate.sh
+++ b/bindings/rust/generate.sh
@@ -34,17 +34,19 @@ cp -r \
   s2n-tls-sys/lib/
 
 # generate the bindings modules from the copied sources
-cd generate && cargo run -- ../s2n-tls-sys && cd ..
+pushd generate
+cargo run -- ../s2n-tls-sys
+popd 
 
 # make sure everything builds and passes sanity checks
 pushd s2n-tls-sys
 cargo test
 cargo test --features pq
-cargo test --features quic \
-cargo test --features internal \
-cargo test --release \
-cargo publish --dry-run --allow-dirty \
-cargo publish --dry-run --allow-dirty --all-features \
+cargo test --features quic
+cargo test --features internal
+cargo test --release
+cargo publish --dry-run --allow-dirty 
+cargo publish --dry-run --allow-dirty --all-features
 popd
 
 pushd integration


### PR DESCRIPTION
### Resolved issues:
The generate.sh for Rust bindings currently would not fail if the cargo tests fail (as might be expected with a script using `set -e`). See documentation for `set -e` here: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html

### Description of changes: 

* Removed the “&&” chaining together the cargo commands.
* Use pushd/popd instead of cd for changing directories.

### Call-outs:
N/A

### Testing:
 Successfully ran generate script locally.