### PR TITLE
Don't wipe extensions after processing

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1705,10 +1705,12 @@ S2N_API
 extern int s2n_connection_set_protocol_preferences(struct s2n_connection *conn, const char * const *protocols, int protocol_count);
 
 /**
- * Sets the server name for the connection. 
+ * Sets the server name for the connection.
  *
- * @note In the future, this can be used by clients who wish to use the TLS "Server Name indicator"
- * extension. At present, client functionality is disabled.
+ * It may be desirable for clients
+ * to provide this information to facilitate secure connections to
+ * servers that host multiple 'virtual' servers at a single underlying
+ * network address.
  *
  * @param conn The connection object being queried
  * @param server_name A pointer to a string containing the desired server name

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -165,9 +165,9 @@ int main(int argc, char **argv)
             server_conn->actual_protocol_version = S2N_TLS12;
             EXPECT_SUCCESS(s2n_extension_process(tls13_extension_type, server_conn, &parsed_extension_list));
 
-            /* Create parsed extension again, because s2n_extension_process cleared the last one */
-            parsed_extension->extension = extension_data.blob;
-            parsed_extension->extension_type = tls13_extension_type->iana_value;
+            /* Reuse processed extension */
+            EXPECT_TRUE(parsed_extension->processed);
+            parsed_extension->processed = false;
 
             server_conn->actual_protocol_version = S2N_TLS13;
             EXPECT_FAILURE(s2n_extension_process(tls13_extension_type, server_conn, &parsed_extension_list));

--- a/tls/extensions/s2n_extension_list.h
+++ b/tls/extensions/s2n_extension_list.h
@@ -24,6 +24,7 @@ typedef struct {
     uint16_t extension_type;
     struct s2n_blob extension;
     uint16_t wire_index;
+    unsigned processed:1;
 } s2n_parsed_extension;
 
 typedef struct {

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -405,11 +405,7 @@ int s2n_process_client_hello(struct s2n_connection *conn)
         conn->actual_protocol_version = MIN(conn->server_protocol_version, S2N_TLS12);
     }
 
-    /* s2n_extension_list_process clears the parsed extensions as it processes them.
-     * To keep the version in client_hello intact for the extension retrieval APIs, process a copy instead.
-     */
-    s2n_parsed_extensions_list copy_of_parsed_extensions = conn->client_hello.extensions;
-    POSIX_GUARD(s2n_extension_list_process(S2N_EXTENSION_LIST_CLIENT_HELLO, conn, &copy_of_parsed_extensions));
+    POSIX_GUARD(s2n_extension_list_process(S2N_EXTENSION_LIST_CLIENT_HELLO, conn, &conn->client_hello.extensions));
 
     /* After parsing extensions, select a curve and corresponding keyshare to use */
     if (conn->actual_protocol_version >= S2N_TLS13) {


### PR DESCRIPTION
### Description of changes: 
I've got a comment on a test explaining the issue:
```
         * This test exists because of a previously released bug. Triggering the bug
         * required a specific series of events:
         * - The first ClientHello is received.
         * - The extensions are parsed.
         * - The ClientHello callback triggers.
         * - The customer's ClientHello callback implementation calls the s2n_get_server_name API.
         *   - To retrieve the server name, s2n_get_server_name processes the server name extension early.
         *     - The server name extension is wiped. Before the "processed" flag, we wiped extensions
         *       to mark that they had been processed.
         * - The server sends a HelloRetryRequest, triggering a retry.
         * - The second ClientHello is received.
         * - The extensions are parsed.
         * - The customer's ClientHello callback does NOT trigger this time. The callback only
         *   triggers after the first ClientHello.
         *   - Therefore, s2n_get_server_name is not called and the server name extension is not
         *     processed early or wiped.
         * - The first ClientHello is compared to the second ClientHello. The second ClientHello
         *   appears to contain a server name extension not present in the first ClientHello.
         * - The handshake fails because the ClientHellos must match.
```
I fixed this by no longer tracking processed extensions by wiping them. We now set a bitflag to indicate that an extension has been processed and shouldn't be processed again.

### Testing:

Added a new functional test that reproduces the bug, failing before this fix and passing aftewards. Updated existing extension processing unit tests, including a new one that verifies correct re-processing behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
