### PR TITLE
[bindings] Fix constant name

### DIFF
--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -214,7 +214,10 @@ impl Builder {
             s2n_config_append_protocol_preference(
                 self.as_mut_ptr(),
                 protocol.as_ptr(),
-                protocol.len().try_into().map_err(|_| Error::InvalidInput)?,
+                protocol
+                    .len()
+                    .try_into()
+                    .map_err(|_| Error::INVALID_INPUT)?,
             )
             .into_result()
         }?;
@@ -232,14 +235,14 @@ impl Builder {
     }
 
     pub fn add_dhparams(&mut self, pem: &[u8]) -> Result<&mut Self, Error> {
-        let cstring = CString::new(pem).map_err(|_| Error::InvalidInput)?;
+        let cstring = CString::new(pem).map_err(|_| Error::INVALID_INPUT)?;
         unsafe { s2n_config_add_dhparams(self.as_mut_ptr(), cstring.as_ptr()).into_result() }?;
         Ok(self)
     }
 
     pub fn load_pem(&mut self, certificate: &[u8], private_key: &[u8]) -> Result<&mut Self, Error> {
-        let certificate = CString::new(certificate).map_err(|_| Error::InvalidInput)?;
-        let private_key = CString::new(private_key).map_err(|_| Error::InvalidInput)?;
+        let certificate = CString::new(certificate).map_err(|_| Error::INVALID_INPUT)?;
+        let private_key = CString::new(private_key).map_err(|_| Error::INVALID_INPUT)?;
         unsafe {
             s2n_config_add_cert_chain_and_key(
                 self.as_mut_ptr(),
@@ -252,7 +255,7 @@ impl Builder {
     }
 
     pub fn trust_pem(&mut self, certificate: &[u8]) -> Result<&mut Self, Error> {
-        let certificate = CString::new(certificate).map_err(|_| Error::InvalidInput)?;
+        let certificate = CString::new(certificate).map_err(|_| Error::INVALID_INPUT)?;
         unsafe {
             s2n_config_add_pem_to_trust_store(self.as_mut_ptr(), certificate.as_ptr()).into_result()
         }?;
@@ -267,8 +270,8 @@ impl Builder {
         fn to_cstr(input: Option<&Path>) -> Result<Option<CString>, Error> {
             Ok(match input {
                 Some(input) => {
-                    let string = input.to_str().ok_or(Error::InvalidInput)?;
-                    let cstring = CString::new(string).map_err(|_| Error::InvalidInput)?;
+                    let string = input.to_str().ok_or(Error::INVALID_INPUT)?;
+                    let cstring = CString::new(string).map_err(|_| Error::INVALID_INPUT)?;
                     Some(cstring)
                 }
                 None => None,
@@ -329,7 +332,7 @@ impl Builder {
     // which allows certificate chains to be shared across configs.
     // In that case, we'll need additional guard rails either in these bindings or in the underlying C.
     pub fn set_ocsp_data(&mut self, data: &[u8]) -> Result<&mut Self, Error> {
-        let size: u32 = data.len().try_into().map_err(|_| Error::InvalidInput)?;
+        let size: u32 = data.len().try_into().map_err(|_| Error::INVALID_INPUT)?;
         unsafe {
             s2n_config_set_extension_data(
                 self.as_mut_ptr(),

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -28,7 +28,7 @@ macro_rules! static_const_str {
     ($c_chars:expr) => {
         unsafe { CStr::from_ptr($c_chars) }
             .to_str()
-            .map_err(|_| Error::InvalidInput)
+            .map_err(|_| Error::INVALID_INPUT)
     };
 }
 
@@ -275,7 +275,10 @@ impl Connection {
             s2n_connection_append_protocol_preference(
                 self.connection.as_ptr(),
                 protocol.as_ptr(),
-                protocol.len().try_into().map_err(|_| Error::InvalidInput)?,
+                protocol
+                    .len()
+                    .try_into()
+                    .map_err(|_| Error::INVALID_INPUT)?,
             )
             .into_result()
         }?;
@@ -400,7 +403,7 @@ impl Connection {
     /// Returns the number of bytes written, and may indicate a partial write.
     pub fn poll_send(&mut self, buf: &[u8]) -> Poll<Result<usize, Error>> {
         let mut blocked = s2n_blocked_status::NOT_BLOCKED;
-        let buf_len: isize = buf.len().try_into().map_err(|_| Error::InvalidInput)?;
+        let buf_len: isize = buf.len().try_into().map_err(|_| Error::INVALID_INPUT)?;
         let buf_ptr = buf.as_ptr() as *const ::libc::c_void;
         unsafe { s2n_send(self.connection.as_ptr(), buf_ptr, buf_len, &mut blocked).into_poll() }
     }
@@ -412,7 +415,7 @@ impl Connection {
     /// 0 bytes returned indicates EOF due to connection closure.
     pub fn poll_recv(&mut self, buf: &mut [u8]) -> Poll<Result<usize, Error>> {
         let mut blocked = s2n_blocked_status::NOT_BLOCKED;
-        let buf_len: isize = buf.len().try_into().map_err(|_| Error::InvalidInput)?;
+        let buf_len: isize = buf.len().try_into().map_err(|_| Error::INVALID_INPUT)?;
         let buf_ptr = buf.as_ptr() as *mut ::libc::c_void;
         unsafe { s2n_recv(self.connection.as_ptr(), buf_ptr, buf_len, &mut blocked).into_poll() }
     }
@@ -453,7 +456,7 @@ impl Connection {
 
     /// Sets the server name value for the connection
     pub fn set_server_name(&mut self, server_name: &str) -> Result<&mut Self, Error> {
-        let server_name = std::ffi::CString::new(server_name).map_err(|_| Error::InvalidInput)?;
+        let server_name = std::ffi::CString::new(server_name).map_err(|_| Error::INVALID_INPUT)?;
         unsafe {
             s2n_set_server_name(self.connection.as_ptr(), server_name.as_ptr()).into_result()
         }?;
@@ -603,7 +606,7 @@ impl Connection {
             s2n_connection_set_quic_transport_parameters(
                 self.connection.as_ptr(),
                 buffer.as_ptr(),
-                buffer.len().try_into().map_err(|_| Error::InvalidInput)?,
+                buffer.len().try_into().map_err(|_| Error::INVALID_INPUT)?,
             )
             .into_result()
         }?;

--- a/bindings/rust/s2n-tls/src/connection/builder.rs
+++ b/bindings/rust/s2n-tls/src/connection/builder.rs
@@ -32,7 +32,7 @@ impl<T: Pool + Clone> Builder for T {
         if mode == self.mode() {
             Ok(PooledConnection::new(self)?)
         } else {
-            Err(Error::InvalidInput)
+            Err(Error::INVALID_INPUT)
         }
     }
 }

--- a/bindings/rust/s2n-tls/src/enums.rs
+++ b/bindings/rust/s2n-tls/src/enums.rs
@@ -68,7 +68,7 @@ impl TryFrom<s2n_tls_version::Type> for Version {
             s2n_tls_version::TLS11 => Self::TLS11,
             s2n_tls_version::TLS12 => Self::TLS12,
             s2n_tls_version::TLS13 => Self::TLS13,
-            _ => return Err(Error::InvalidInput),
+            _ => return Err(Error::INVALID_INPUT),
         };
         Ok(version)
     }

--- a/bindings/rust/s2n-tls/src/error.rs
+++ b/bindings/rust/s2n-tls/src/error.rs
@@ -147,11 +147,7 @@ impl<T: Fallible> Pollable for T {
 }
 
 impl Error {
-    // Previously we referenced InvalidInput via Error::InvalidInput.
-    // Keep this naming.
-    // TODO: Update this + all references to all upper case.
-    #[allow(non_upper_case_globals)]
-    pub(crate) const InvalidInput: Error = Self(Context::InvalidInput);
+    pub(crate) const INVALID_INPUT: Error = Self(Context::InvalidInput);
 
     pub fn new<T: Fallible>(value: T) -> Result<T::Output, Self> {
         value.into_result()
@@ -267,11 +263,11 @@ unsafe fn cstr_to_str(v: *const c_char) -> &'static str {
 impl TryFrom<std::io::Error> for Error {
     type Error = Error;
     fn try_from(value: std::io::Error) -> Result<Self, Self::Error> {
-        let io_inner = value.into_inner().ok_or(Error::InvalidInput)?;
+        let io_inner = value.into_inner().ok_or(Error::INVALID_INPUT)?;
         io_inner
             .downcast::<Self>()
             .map(|error| *error)
-            .map_err(|_| Error::InvalidInput)
+            .map_err(|_| Error::INVALID_INPUT)
     }
 }
 

--- a/bindings/rust/s2n-tls/src/security.rs
+++ b/bindings/rust/s2n-tls/src/security.rs
@@ -26,7 +26,7 @@ impl Policy {
     }
 
     pub fn from_version(version: &str) -> Result<Policy, Error> {
-        let cstr = CString::new(version).map_err(|_| Error::InvalidInput)?;
+        let cstr = CString::new(version).map_err(|_| Error::INVALID_INPUT)?;
         let context = Context::Owned(cstr);
         Ok(Self(context))
     }


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/aws/s2n-tls/pull/3403#discussion_r927253331

### Description of changes: 

s/InvalidInput/INVALID_INPUT to use the correct naming convention for a constant.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
