### PR TITLE
[bindings] Make errno a required dependency

### DIFF
--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -11,15 +11,14 @@ license = "Apache-2.0"
 default = []
 quic = ["s2n-tls-sys/quic"]
 pq = ["s2n-tls-sys/pq"]
-testing = ["errno", "bytes"]
+testing = ["bytes"]
 
 [dependencies]
 bytes = { version = "1", optional = true }
-errno = { version = "0.2", optional = true }
+errno = { version = "0.2" }
 libc = "0.2"
 s2n-tls-sys = { version = "=0.0.10", path = "../s2n-tls-sys", features = ["internal"] }
 
 [dev-dependencies]
 bytes = { version = "1" }
-errno = { version = "0.2" }
 futures-test = "0.3"


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

`cargo publish` failed during the bindings release for the `s2n-tls` crate due to the `errno` crate being used outside of a test. This PR moves the `errno` dependency out of `dev-dependencies` and makes it required in `dependencies`.

### Call-outs:

None

### Testing:

Failed during `cargo publish --dry-run --allow-dirty`, and succeeded with the fix. Additionally ran `cargo test` which succeeded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
