### PR TITLE
ci: Temporarily pin AWS-LC to a commit before gcc 4.8 breaks

### DIFF
--- a/codebuild/bin/install_awslc.sh
+++ b/codebuild/bin/install_awslc.sh
@@ -38,6 +38,10 @@ if [ "$IS_FIPS" == "1" ]; then
   cd aws-lc
   git checkout -b fips-2021-10-20 origin/fips-2021-10-20
   cd ..
+else
+  cd aws-lc
+  git checkout a219726caf0c4585b80193570369627ed9a3a931
+  cd ..
 fi
 
 install_awslc() {


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

A recent commit in awslc seems to have caused an issue building with gcc 4.8. This PR temporarily pins the awslc version in CI to a commit before gcc 4.8 breaks.

### Call-outs:

None

### Testing:

Single integration v2 run before fix: https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/S2nIntegrationV2Batch2/build/S2nIntegrationV2Batch2%3A6bb97ba1-90a2-4a3e-ab6e-6443be93ae80/env_var?region=us-west-2

After fix: https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/SingleIntegrationV2/build/SingleIntegrationV2%3A8e99a802-1116-4120-9b44-f6c8cbeae4ff?region=us-west-2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
