### PR TITLE
Set Openssl-1.0.2 locking callback

### DIFF
--- a/crypto/s2n_locking.c
+++ b/crypto/s2n_locking.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <openssl/crypto.h>
+#include <pthread.h>
+
+#include "crypto/s2n_locking.h"
+#include "crypto/s2n_openssl.h"
+#include "utils/s2n_mem.h"
+#include "utils/s2n_safety.h"
+
+/* Writing multithreaded applications using Openssl-1.0.2
+ * requires calling CRYPTO_set_locking_callback.
+ * If the callback is not set, locks are no-ops and unexpected
+ * behavior may occur, particularly for RSA and X509.
+ *
+ * In the past s2n-tls relied on customers setting the callback
+ * themselves, but that seems unnecessary since other parts of
+ * the library (like fork detection) already rely on the pthreads library.
+ *
+ * For more information:
+ * https://www.openssl.org/blog/blog/2017/02/21/threads/
+ * https://www.openssl.org/docs/man1.0.2/man3/threads.html
+ */
+
+#define S2N_MUTEXES(mem) ((pthread_mutex_t *) (void*) (mem).data)
+
+/* While the locking-related APIs "exist" in later versions of
+ * Openssl, they tend to be placeholders or hardcoded values like:
+ * #define CRYPTO_get_locking_callback() (NULL)
+ * So the code will compile with strange warnings / errors like
+ * loop conditions always being false.
+ */
+#if !(S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0))
+
+static struct s2n_blob mutexes_mem = { 0 };
+static size_t mutexes_count = 0;
+
+static void s2n_locking_cb(int mode, int n, char *file, int line)
+{
+    pthread_mutex_t *mutexes = S2N_MUTEXES(mutexes_mem);
+    if (!mutexes_mem.data || n >= mutexes_count) {
+        return;
+    }
+
+    if (mode & CRYPTO_LOCK) {
+        pthread_mutex_lock(&(mutexes[n]));
+    } else {
+        pthread_mutex_unlock(&(mutexes[n]));
+    }
+}
+
+S2N_RESULT s2n_locking_init(void)
+{
+    if (CRYPTO_get_locking_callback() != NULL) {
+        return S2N_RESULT_OK;
+    }
+
+    int num_locks = CRYPTO_num_locks();
+
+    RESULT_GUARD_POSIX(s2n_realloc(&mutexes_mem, num_locks * sizeof(pthread_mutex_t)));
+
+    pthread_mutex_t *mutexes = S2N_MUTEXES(mutexes_mem);
+    mutexes_count = 0;
+    for (size_t i = 0; i < num_locks; i++) {
+        RESULT_ENSURE_EQ(pthread_mutex_init(&(mutexes[i]), NULL), 0);
+        mutexes_count++;
+    }
+
+    CRYPTO_set_locking_callback((void (*)()) s2n_locking_cb);
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_locking_cleanup(void)
+{
+    if (CRYPTO_get_locking_callback() == (void (*)()) s2n_locking_cb) {
+        CRYPTO_set_locking_callback(NULL);
+    }
+
+    pthread_mutex_t *mutexes = S2N_MUTEXES(mutexes_mem);
+    if (mutexes) {
+        for (int i = mutexes_count - 1; i >= 0; i--) {
+            RESULT_ENSURE_EQ(pthread_mutex_destroy(&(mutexes[i])), 0);
+            mutexes_count--;
+        }
+        RESULT_GUARD_POSIX(s2n_free(&mutexes_mem));
+    }
+
+    return S2N_RESULT_OK;
+}
+
+#else
+
+S2N_RESULT s2n_locking_init(void)
+{
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_locking_cleanup(void)
+{
+    return S2N_RESULT_OK;
+}
+
+#endif

--- a/crypto/s2n_locking.c
+++ b/crypto/s2n_locking.c
@@ -91,8 +91,8 @@ S2N_RESULT s2n_locking_cleanup(void)
 
     pthread_mutex_t *mutexes = S2N_MUTEXES(mutexes_mem);
     if (mutexes) {
-        for (int i = mutexes_count - 1; i >= 0; i--) {
-            RESULT_ENSURE_EQ(pthread_mutex_destroy(&(mutexes[i])), 0);
+        while(mutexes_count > 0) {
+            RESULT_ENSURE_EQ(pthread_mutex_destroy(&(mutexes[mutexes_count - 1])), 0);
             mutexes_count--;
         }
         RESULT_GUARD_POSIX(s2n_free(&mutexes_mem));

--- a/crypto/s2n_locking.h
+++ b/crypto/s2n_locking.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "utils/s2n_result.h"
+
+S2N_RESULT s2n_locking_init(void);
+S2N_RESULT s2n_locking_cleanup(void);

--- a/tests/unit/s2n_locking_test.c
+++ b/tests/unit/s2n_locking_test.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include <pthread.h>
+
+#include "crypto/s2n_locking.h"
+
+#define LOCK_N 1
+
+#if !(S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0))
+
+static void* s2n_test_thread(void *arg)
+{
+    bool *passed_lock = (bool*) arg;
+    CRYPTO_lock(CRYPTO_LOCK, LOCK_N, NULL, 0);
+    *passed_lock = true;
+    CRYPTO_lock(CRYPTO_UNLOCK, LOCK_N, NULL, 0);
+    return NULL;
+}
+
+static void s2n_test_locking_cb(int mode, int n, char *file, int line)
+{
+    return;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test: libcrypto locks should actually lock.
+     *
+     * If libcrypto locking is not configured properly, then
+     * libcrypto locks will be no-ops and will not block threads.
+     */
+    {
+        /* Lock one of the libcrypto locks */
+        CRYPTO_lock(CRYPTO_LOCK, LOCK_N, NULL, 0);
+
+        /* Create a new thread which will try to take the lock held by this thread
+         * in order to set a flag.
+         */
+        bool passed_lock = false;
+        pthread_t thread = { 0 };
+        EXPECT_EQUAL(pthread_create(&thread, NULL, s2n_test_thread, &passed_lock), 0);
+
+        /* Expect the flag NOT to be set because we still hold the lock */
+        sleep(1);
+        EXPECT_FALSE(passed_lock);
+
+        /* Release the libcrypto lock */
+        CRYPTO_lock(CRYPTO_UNLOCK, LOCK_N, NULL, 0);
+
+        /* Expect the flag to be set because the new thread took the lock */
+        sleep(1);
+        EXPECT_TRUE(passed_lock);
+    }
+
+    /* Test: basic lifecycle
+     */
+    {
+        EXPECT_OK(s2n_locking_cleanup());
+        EXPECT_OK(s2n_locking_init());
+    }
+
+    /* Test: s2n-tls should not override locking configured by the application */
+    {
+        /* Manually override the existing callback. */
+        CRYPTO_set_locking_callback((void (*)()) s2n_test_locking_cb);
+        EXPECT_EQUAL(CRYPTO_get_locking_callback(), (void (*)()) s2n_test_locking_cb);
+
+        /* Cleaning up does not affect the application-set callback */
+        EXPECT_OK(s2n_locking_cleanup());
+        EXPECT_EQUAL(CRYPTO_get_locking_callback(), (void (*)()) s2n_test_locking_cb);
+
+        /* Initializing again doesn't override the application-set callback */
+        EXPECT_OK(s2n_locking_init());
+        EXPECT_EQUAL(CRYPTO_get_locking_callback(), (void (*)()) s2n_test_locking_cb);
+        EXPECT_OK(s2n_locking_cleanup());
+        EXPECT_EQUAL(CRYPTO_get_locking_callback(), (void (*)()) s2n_test_locking_cb);
+
+        /* Reset the callback */
+        CRYPTO_set_locking_callback(NULL);
+        EXPECT_EQUAL(CRYPTO_get_locking_callback(), NULL);
+
+        /* Initializing now sets the missing callback */
+        EXPECT_OK(s2n_locking_init());
+        EXPECT_NOT_EQUAL(CRYPTO_get_locking_callback(), NULL);
+    }
+
+    END_TEST();
+}
+
+#else
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+    END_TEST();
+}
+
+#endif

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -14,6 +14,7 @@
  */
 #include "crypto/s2n_fips.h"
 #include "crypto/s2n_libcrypto.h"
+#include "crypto/s2n_locking.h"
 
 #include "error/s2n_errno.h"
 
@@ -52,6 +53,7 @@ int s2n_init(void)
     POSIX_GUARD(s2n_fips_init());
     POSIX_GUARD(s2n_mem_init());
     POSIX_GUARD_RESULT(s2n_rand_init());
+    POSIX_GUARD_RESULT(s2n_locking_init());
     POSIX_GUARD(s2n_cipher_suites_init());
     POSIX_GUARD(s2n_security_policies_init());
     POSIX_GUARD(s2n_config_defaults_init());
@@ -80,11 +82,12 @@ static bool s2n_cleanup_atexit_impl(void)
     /* the configs need to be wiped before resetting the memory callbacks */
     s2n_wipe_static_configs();
 
-    bool a = s2n_result_is_ok(s2n_rand_cleanup_thread());
-    bool b = s2n_result_is_ok(s2n_rand_cleanup());
-    bool c = s2n_mem_cleanup() == 0;
+    bool a = s2n_result_is_ok(s2n_locking_cleanup());
+    bool b = s2n_result_is_ok(s2n_rand_cleanup_thread());
+    bool c = s2n_result_is_ok(s2n_rand_cleanup());
+    bool d = s2n_mem_cleanup() == 0;
 
-    return a && b && c;
+    return a && b && c && d;
 }
 
 int s2n_cleanup(void)

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -82,12 +82,10 @@ static bool s2n_cleanup_atexit_impl(void)
     /* the configs need to be wiped before resetting the memory callbacks */
     s2n_wipe_static_configs();
 
-    bool a = s2n_result_is_ok(s2n_locking_cleanup());
-    bool b = s2n_result_is_ok(s2n_rand_cleanup_thread());
-    bool c = s2n_result_is_ok(s2n_rand_cleanup());
-    bool d = s2n_mem_cleanup() == 0;
-
-    return a && b && c && d;
+    return s2n_result_is_ok(s2n_locking_cleanup()) &&
+           s2n_result_is_ok(s2n_rand_cleanup_thread()) &&
+           s2n_result_is_ok(s2n_rand_cleanup()) &&
+           (s2n_mem_cleanup() == S2N_SUCCESS);
 }
 
 int s2n_cleanup(void)


### PR DESCRIPTION
### Description of changes: 

Writing multithreaded applications using Openssl-1.0.2 requires calling CRYPTO_set_locking_callback.
If the callback is not set, locks are no-ops and unexpected behavior may occur, particularly for RSA and X509.

In the past s2n-tls relied on customers setting the callback themselves, but that seems like an unnecessary sharp edge since other parts of the library (like fork detection) already rely on the pthreads library. However, we do have to be careful; existing customers of s2n-tls should be assumed to have implemented their own solutions, and we don't want to step on their toes. This change shouldn't affect customers who call CRYPTO_set_locking_callback directly.

For more information:
 * https://www.openssl.org/blog/blog/2017/02/21/threads/
 * https://www.openssl.org/docs/man1.0.2/man3/threads.html

### Testing:
New unit tests. I wrote a test that fails if libcrypto locks are no-ops, and verified that it does fail before this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
