### PR TITLE
ci: Test all rust bindings crates in CI

### DIFF
--- a/bindings/rust/.gitignore
+++ b/bindings/rust/.gitignore
@@ -7,3 +7,5 @@ s2n-tls-sys/lib
 s2n-tls-sys/src/api.rs
 s2n-tls-sys/src/quic.rs
 s2n-tls-sys/src/tests.rs
+s2n-tls/src/testing/pems
+

--- a/bindings/rust/generate.sh
+++ b/bindings/rust/generate.sh
@@ -39,15 +39,16 @@ cargo run -- ../s2n-tls-sys
 popd 
 
 # make sure everything builds and passes sanity checks
-pushd s2n-tls-sys
-cargo test
-cargo test --features pq
-cargo test --features quic
-cargo test --features internal
-cargo test --release
-cargo publish --dry-run --allow-dirty 
-cargo publish --dry-run --allow-dirty --all-features
-popd
+crates=("s2n-tls-sys" "s2n-tls" "s2n-tls-tokio")
+for crate in ${crates[@]}; do
+  pushd $crate
+  cargo test
+  cargo test --all-features
+  cargo test --release
+  cargo test --release --all-features
+  cargo publish --dry-run --allow-dirty 
+  popd
+done
 
 pushd integration
 cargo run

--- a/bindings/rust/generate.sh
+++ b/bindings/rust/generate.sh
@@ -38,6 +38,15 @@ pushd generate
 cargo run -- ../s2n-tls-sys
 popd 
 
+# copy pems used for testing into crate
+rm -rf s2n-tls/src/testing/pems
+mkdir -p s2n-tls/src/testing/pems
+
+cp \
+  ../../tests/pems/rsa_4096_sha512_client_cert.pem \
+  ../../tests/pems/rsa_4096_sha512_client_key.pem \
+  s2n-tls/src/testing/pems/
+
 # make sure everything builds and passes sanity checks
 crates=("s2n-tls-sys" "s2n-tls" "s2n-tls-tokio")
 for crate in ${crates[@]}; do
@@ -46,7 +55,8 @@ for crate in ${crates[@]}; do
   cargo test --all-features
   cargo test --release
   cargo test --release --all-features
-  cargo publish --dry-run --allow-dirty 
+  cargo publish --dry-run --allow-dirty
+  cargo publish --dry-run --allow-dirty --all-features
   popd
 done
 

--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["AWS s2n"]
 edition = "2021"
 repository = "https://github.com/aws/s2n-tls"
 license = "Apache-2.0"
+include = [
+  "src"
+]
 
 [features]
 default = []

--- a/bindings/rust/s2n-tls/src/testing.rs
+++ b/bindings/rust/s2n-tls/src/testing.rs
@@ -120,8 +120,8 @@ struct CertKeyPair {
 impl Default for CertKeyPair {
     fn default() -> Self {
         CertKeyPair {
-            cert: &include_bytes!("../../../../tests/pems/rsa_4096_sha512_client_cert.pem")[..],
-            key: &include_bytes!("../../../../tests/pems/rsa_4096_sha512_client_key.pem")[..],
+            cert: &include_bytes!("testing/pems/rsa_4096_sha512_client_cert.pem")[..],
+            key: &include_bytes!("testing/pems/rsa_4096_sha512_client_key.pem")[..],
         }
     }
 }


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

Currently, only the s2n-tls-sys crate is tested in CI on PR updates. This PR runs tests and `cargo publish` dry runs on the other crates as well.

### Call-outs:

- Running `cargo publish` with `--all--features` enabled builds the `testing` feature. Enabling the testing feature requires building `testing.rs`, which uses pems in tests/pems, outside of the crate. During `cargo publish`, `include_bytes` cannot reference files outside of the crate. To fix this, generate.sh was modified to add the required pems to the s2n-tls crate.
- This causes the generate github action for macOS to fail when testing the s2n-tls-tokio crate due to https://github.com/aws/s2n-tls/issues/3417. This will be fixed in a future PR.

### Testing:

All testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
