### PR TITLE
Fix documentation for record sizes

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1620,7 +1620,9 @@ S2N_API
 extern int s2n_connection_set_send_cb(struct s2n_connection *conn, s2n_send_fn send);
 
 /**
- * Change the behavior of s2n-tls when sending data to prefer high throughput. Connections preferring throughput will use
+ * Change the behavior of s2n-tls when sending data to prefer high throughput.
+ *
+ * Connections preferring throughput will use
  * large record sizes that minimize overhead.
  *
  * @param conn The connection object being updated
@@ -1630,7 +1632,9 @@ S2N_API
 extern int s2n_connection_prefer_throughput(struct s2n_connection *conn);
 
 /**
- * Change the behavior of s2n-tls when sending data to prefer low latency. Connections preferring low latency will be encrypted
+ * Change the behavior of s2n-tls when sending data to prefer low latency.
+ *
+ * Connections preferring low latency will be encrypted
  * using small record sizes that can be decrypted sooner by the recipient. 
  *
  * @param conn The connection object being updated
@@ -1654,10 +1658,15 @@ S2N_API
 extern int s2n_connection_set_dynamic_buffers(struct s2n_connection *conn, bool enabled);
 
 /**
- * Provides a smooth transition from s2n_connection_prefer_low_latency() to s2n_connection_prefer_throughput().
+ * Changes the behavior of s2n-tls when sending data to initially prefer records
+ * small enough to fit in single ethernet frames.
+ *
+ * The connection will send the first resize_threshold bytes in records small enough to
+ * fit in a single standard 1500 byte ethernet frame. Later, whenever timeout_threshold seconds
+ * pass without sending data, the connection will revert to this behavior and send small records again.
  *
  * @param conn The connection object being updated
- * @param resize_threshold The number of bytes to send before changing the record size
+ * @param resize_threshold The number of bytes to send before changing the record size. Maximum 8MiB.
  * @param timeout_threshold Reset record size back to a single segment after threshold seconds of inactivity
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
  */
@@ -1689,7 +1698,7 @@ extern int s2n_connection_set_verify_host_callback(struct s2n_connection *conn, 
  * Setting the S2N_SELF_SERVICE_BLINDING option with s2n_connection_set_blinding()
  * turns off this behavior. This is useful for applications that are handling many connections
  * in a single thread. In that case, if s2n_recv() or s2n_negotiate() return an error,
- * self-service applications should call *2n_connection_get_delay() and pause
+ * self-service applications should call s2n_connection_get_delay() and pause
  * activity on the connection  for the specified number of nanoseconds before calling
  * close() or shutdown().
  */

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1661,9 +1661,12 @@ extern int s2n_connection_set_dynamic_buffers(struct s2n_connection *conn, bool 
  * Changes the behavior of s2n-tls when sending data to initially prefer records
  * small enough to fit in single ethernet frames.
  *
- * The connection will send the first resize_threshold bytes in records small enough to
- * fit in a single standard 1500 byte ethernet frame. Later, whenever timeout_threshold seconds
- * pass without sending data, the connection will revert to this behavior and send small records again.
+ * When dynamic record sizing is active, the connection sends records small enough
+ * to fit in a single standard 1500 byte ethernet frame. Otherwise, the connection
+ * chooses record sizes according to the configured maximum fragment length.
+ *
+ * Dynamic record sizing is active for the first resize_threshold bytes of a connection,
+ * and is reactivated whenever timeout_threshold seconds pass without sending data.
  *
  * @param conn The connection object being updated
  * @param resize_threshold The number of bytes to send before changing the record size. Maximum 8MiB.

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -625,7 +625,10 @@ configured by **s2n_connection_prefer_throughput** and **s2n_connection_prefer_l
 
 ### Dynamic Record Sizing
 
-**s2n_connection_set_dynamic_record_threshold** can be called to change the record size dynamically.
+Sending smaller records at the beginning of a connection can decrease first byte latency,
+particularly if TCP slow start is used.
+
+**s2n_connection_set_dynamic_record_threshold** can be called to to initially send smaller records.
 The connection will send the first **resize_threshold** bytes in records small enough to
 fit in a single standard 1500 byte ethernet frame. Whenever **timeout_threshold** seconds
 pass without sending data, the connection will revert to this behavior and send small records again.

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -611,9 +611,10 @@ and is set to 2^14 bytes by default. Regardless of the maximum record size that 
 uses when sending, it may receive records containing up to 2^14 bytes of plaintext.
 
 A client can request a lower maximum fragment length by calling **s2n_config_send_max_fragment_length**,
-reducing the size of TLS records and providing benefits similar to **s2n_connection_prefer_low_latency**.
+reducing the size of TLS records sent and providing benefits similar to **s2n_connection_prefer_low_latency**.
 However, many TLS servers either ignore these requests or handle them incorrectly, so a client should
-never assume that a lower maximum fragment length will be honored.
+never assume that a lower maximum fragment length will be honored. If a server accepts the requested
+maximum fragment length, the client will respect that maximum when sending.
 
 By default, an s2n-tls server will ignore a client's requested maximum fragment length.
 If **s2n_config_accept_max_fragment_length** is called, the server will respect the client's requested

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -628,7 +628,7 @@ configured by **s2n_connection_prefer_throughput** and **s2n_connection_prefer_l
 Sending smaller records at the beginning of a connection can decrease first byte latency,
 particularly if TCP slow start is used.
 
-**s2n_connection_set_dynamic_record_threshold** can be called to to initially send smaller records.
+**s2n_connection_set_dynamic_record_threshold** can be called to initially send smaller records.
 The connection will send the first **resize_threshold** bytes in records small enough to
 fit in a single standard 1500 byte ethernet frame. Whenever **timeout_threshold** seconds
 pass without sending data, the connection will revert to this behavior and send small records again.

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -588,6 +588,53 @@ Indicates that connection properties were changed on the basis of server_name.
 Triggers a s2n-tls server to send the server_name extension. Must be called
 before s2n-tls finishes processing the ClientHello.
 
+## Record sizes
+
+### Throughput vs Latency
+
+When sending data, s2n-tls uses a default maximum record size which experimentation
+has suggested provides a reasonable balance of performance and throughput.
+
+**s2n_connection_prefer_throughput** can be called to increase the record size, which
+minimizes overhead. It also increases s2n-tls's memory usage.
+
+**s2n_connection_prefer_low_latency** can be called to decrease the record size, which
+allows the receiver to decrypt the data faster. It also decreases s2n-tls's memory usage.
+
+These options only affect the size of the records that s2n-tls sends, not the behavior
+of the peer.
+
+### Maximum Fragment Length
+
+The maximum number of bytes that can be sent in a TLS record is called the "maximum fragment length",
+and is set to 2^14 bytes by default. Regardless of the maximum record size that s2n-tls
+uses when sending, it may receive records containing up to 2^14 bytes of plaintext.
+
+A client can request a lower maximum fragment length by calling **s2n_config_send_max_fragment_length**,
+reducing the size of TLS records and providing benefits similar to **s2n_connection_prefer_low_latency**.
+However, many TLS servers either ignore these requests or handle them incorrectly, so a client should
+never assume that a lower maximum fragment length will be honored.
+
+By default, an s2n-tls server will ignore a client's requested maximum fragment length.
+If **s2n_config_accept_max_fragment_length** is called, the server will respect the client's requested
+maximum fragment length when sending, but will not reject client records with a larger fragment size.
+
+If a maximum fragment length is negotiated during the connection, it will override the behavior
+configured by **s2n_connection_prefer_throughput** and **s2n_connection_prefer_low_latency**.
+
+### Dynamic Record Sizing
+
+**s2n_connection_set_dynamic_record_threshold** can be called to change the record size dynamically.
+The connection will send the first **resize_threshold** bytes in records small enough to
+fit in a single standard 1500 byte ethernet frame. Whenever **timeout_threshold** seconds
+pass without sending data, the connection will revert to this behavior and send small records again.
+
+Dynamic record sizing doesn't completely override **s2n_connection_prefer_throughput**,
+**s2n_connection_prefer_low_latency**, or the negotiated maximum fragment length.
+Once **resize_threshold** is hit, records return to the maximum size configured for the connection.
+And if the maximum fragment length negotiated with the peer is lower than what dynamic record sizing
+would normally produce, the lower value will be used.
+
 ## Connection-oriented functions
 
 ### s2n\_connection\_new
@@ -638,27 +685,6 @@ types of I/O).
 If the read end of the pipe is closed unexpectedly, writing to the pipe will raise
 a SIGPIPE signal. **s2n-tls does NOT handle SIGPIPE.** A SIGPIPE signal will cause
 the process to terminate unless it is handled or ignored by the application.
-
-### s2n\_connection\_prefer\_throughput(struct s2n_connection *conn)
-
-```c
-int s2n_connection_prefer_throughput(struct s2n_connection *conn);
-int s2n_connection_prefer_low_latency(struct s2n_connection *conn);
-int s2n_connection_set_dynamic_record_threshold(struct s2n_connection *conn, uint32_t resize_threshold, uint16_t timeout_threshold);
-```
-
-**s2n_connection_prefer_throughput** and **s2n_connection_prefer_low_latency**
-change the behavior of s2n-tls when sending data to prefer either throughput
-or low latency. Connections preferring low latency will be encrypted using small
-record sizes that can be decrypted sooner by the recipient. Connections
-preferring throughput will use large record sizes that minimize overhead.
-
--Connections default to an 8k outgoing maximum
-
-**s2n_connection_set_dynamic_record_threshold**
-provides a smooth transition from **s2n_connection_prefer_low_latency** to **s2n_connection_prefer_throughput**.
-**s2n_send** uses small TLS records that fit into a single TCP segment for the resize_threshold bytes (cap to 8M) of data
-and reset record size back to a single segment after timeout_threshold seconds of inactivity.
 
 ### s2n\_connection\_get\_protocol\_version
 

--- a/tests/unit/s2n_send_test.c
+++ b/tests/unit/s2n_send_test.c
@@ -502,5 +502,88 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(conn->out.blob.size, out_size[mfl]);
     }
 
+    /* Test dynamic record threshold */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        EXPECT_OK(s2n_connection_set_secrets(conn));
+
+        /* Retrieve the fragment size to expect */
+        uint16_t single_mtu_mfl = 0;
+        EXPECT_OK(s2n_record_min_write_payload_size(conn, &single_mtu_mfl));
+
+        /* Set the dynamic record threshold large enough for two small records */
+        const uint32_t resize_threshold = single_mtu_mfl * 2;
+        EXPECT_SUCCESS(s2n_connection_set_dynamic_record_threshold(conn, resize_threshold, UINT16_MAX));
+
+        struct s2n_send_result results[] = {
+                /* Block before sending the first record so that we can examine
+                 * the connection state after buffering the first record.
+                 */
+                BLOCK_SEND_RESULT, OK_SEND_RESULT,
+                /* Send the second record */
+                BLOCK_SEND_RESULT, OK_SEND_RESULT,
+                /* Send the third record */
+                OK_SEND_RESULT,
+                BLOCK_SEND_RESULT
+        };
+        struct s2n_send_context context = { .results = results, .results_len = s2n_array_len(results) };
+        EXPECT_SUCCESS(s2n_connection_set_send_ctx(conn, (void*) &context));
+        EXPECT_SUCCESS(s2n_connection_set_send_cb(conn, s2n_test_send_cb));
+
+        s2n_blocked_status blocked = 0;
+        const size_t send_size = single_mtu_mfl * 2;
+
+        /* The first call to s2n_send blocks before sending the first record. */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_send(conn, large_test_data, send_size, &blocked),
+                S2N_ERR_IO_BLOCKED);
+        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_WRITE);
+        /* No records have been sent yet. */
+        EXPECT_EQUAL(context.bytes_sent, 0);
+        /* The first record is buffered,
+         * so its bytes still count towards the resize_threshold.
+         * We have NOT passed the threshold.
+         */
+        EXPECT_EQUAL(conn->active_application_bytes_consumed, single_mtu_mfl);
+        EXPECT_TRUE(conn->active_application_bytes_consumed < resize_threshold);
+
+        /* The second call to s2n_send flushes the buffered first record,
+         * but blocks before sending the second record.
+         */
+        ssize_t result = s2n_send(conn, large_test_data, send_size, &blocked);
+        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_WRITE);
+        /* First small, single-MTU record was sent. */
+        EXPECT_EQUAL(result, single_mtu_mfl);
+        EXPECT_TRUE(context.bytes_sent < ETH_MTU);
+        /* The second record is buffered,
+         * so its bytes count towards the resize_threshold.
+         * We have therefore hit the threshold.
+         */
+        EXPECT_EQUAL(conn->active_application_bytes_consumed, resize_threshold);
+
+        /* The third call to s2n_send flushes the second record. */
+        result = s2n_send(conn, large_test_data, send_size - single_mtu_mfl, &blocked);
+        EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+        /* Second small, single-MTU record was sent. */
+        EXPECT_EQUAL(result, single_mtu_mfl);
+        /* There should be no change regarding the resize_threshold,
+         * since we did not construct any new records.
+         */
+        EXPECT_EQUAL(conn->active_application_bytes_consumed, resize_threshold);
+
+        /* The fourth call to s2n_send sends the third record. */
+        result = s2n_send(conn, large_test_data, conn->max_outgoing_fragment_length * 2, &blocked);
+        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_WRITE);
+        /* We have passed the resize_threshold, so records are no longer small.
+         * Instead they use the standard connection fragment length.
+         */
+        EXPECT_TRUE(result > single_mtu_mfl);
+        EXPECT_EQUAL(result, conn->max_outgoing_fragment_length);
+
+        /* Verify output buffer */
+        EXPECT_EQUAL(conn->out.blob.size, out_size[S2N_MFL_DEFAULT]);
+    }
+
     END_TEST();
 }


### PR DESCRIPTION
### Description of changes: 

Updates to the usage guide related to record sizes.

The biggest change is the dynamic record sizing documentation. The old documentation claimed that it "provides a smooth transition from s2n_connection_prefer_low_latency to s2n_connection_prefer_throughput", but that is inaccurate. Dynamic record sizing actually starts with records smaller than s2n_connection_prefer_low_latency, the transition is abrupt instead of smooth, and the final record size isn't s2n_connection_prefer_throughput unless you also call s2n_connection_prefer_throughput. 

### Testing:

I wrote a test to verify that the behavior I described in the documentation was the actual behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
