### PR TITLE
S2N client negotation of un-offered group fix 

### DIFF
--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -124,7 +124,6 @@ int s2n_is_evp_apis_supported()
 
 #if EVP_APIS_SUPPORTED
 static int s2n_ecc_evp_generate_key_x25519(const struct s2n_ecc_named_curve *named_curve, EVP_PKEY **evp_pkey) {
-
     DEFER_CLEANUP(EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(named_curve->libcrypto_nid, NULL),
                   EVP_PKEY_CTX_free_pointer);
     S2N_ERROR_IF(pctx == NULL, S2N_ERR_ECDHE_GEN_KEY);
@@ -132,13 +131,11 @@ static int s2n_ecc_evp_generate_key_x25519(const struct s2n_ecc_named_curve *nam
     POSIX_GUARD_OSSL(EVP_PKEY_keygen_init(pctx), S2N_ERR_ECDHE_GEN_KEY);
     POSIX_GUARD_OSSL(EVP_PKEY_keygen(pctx, evp_pkey), S2N_ERR_ECDHE_GEN_KEY);
     S2N_ERROR_IF(evp_pkey == NULL, S2N_ERR_ECDHE_GEN_KEY);
-
     return 0;
 }
 #endif
 
 static int s2n_ecc_evp_generate_key_nist_curves(const struct s2n_ecc_named_curve *named_curve, EVP_PKEY **evp_pkey) {
-
     DEFER_CLEANUP(EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL), EVP_PKEY_CTX_free_pointer);
     S2N_ERROR_IF(pctx == NULL, S2N_ERR_ECDHE_GEN_KEY);
 
@@ -155,14 +152,12 @@ static int s2n_ecc_evp_generate_key_nist_curves(const struct s2n_ecc_named_curve
     POSIX_GUARD_OSSL(EVP_PKEY_keygen_init(kctx), S2N_ERR_ECDHE_GEN_KEY);
     POSIX_GUARD_OSSL(EVP_PKEY_keygen(kctx, evp_pkey), S2N_ERR_ECDHE_GEN_KEY);
     S2N_ERROR_IF(evp_pkey == NULL, S2N_ERR_ECDHE_GEN_KEY);
-
     return 0;
 }
 
 static int s2n_ecc_evp_generate_own_key(const struct s2n_ecc_named_curve *named_curve, EVP_PKEY **evp_pkey) {
     POSIX_ENSURE_REF(named_curve);
     S2N_ERROR_IF(named_curve->generate_key == NULL, S2N_ERR_ECDHE_GEN_KEY);
-
     return named_curve->generate_key(named_curve, evp_pkey);
 }
 
@@ -492,7 +487,7 @@ int s2n_ecc_evp_parse_params(struct s2n_connection* conn,
 
 int s2n_ecc_evp_find_supported_curve(struct s2n_connection* conn, struct s2n_blob *iana_ids, const struct s2n_ecc_named_curve **found) {
     const s2n_ecc_preferences* ecc_prefs;
-    s2n_connection_get_ecc_preferences(conn, &ecc_prefs);
+    POSIX_GUARD(s2n_connection_get_ecc_preferences(conn, &ecc_prefs));
 
     struct s2n_stuffer iana_ids_in = {0};
 

--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -23,6 +23,9 @@
 
 #include <stdint.h>
 
+#include "tls/s2n_connection.h"
+#include "tls/s2n_ecc_preferences.h"
+#include "tls/s2n_security_policies.h"
 #include "tls/s2n_tls_parameters.h"
 #include "utils/s2n_mem.h"
 #include "utils/s2n_safety.h"
@@ -478,21 +481,25 @@ int s2n_ecc_evp_parse_params_point(struct s2n_blob *point_blob, struct s2n_ecc_e
     return 0;
 }
 
-int s2n_ecc_evp_parse_params(struct s2n_ecdhe_raw_server_params *raw_server_ecc_params,
-                             struct s2n_ecc_evp_params *ecc_evp_params) {
+int s2n_ecc_evp_parse_params(struct s2n_connection* conn,
+                                struct s2n_ecdhe_raw_server_params* raw_server_ecc_params,
+                                struct s2n_ecc_evp_params* ecc_evp_params) {
     S2N_ERROR_IF(
-        s2n_ecc_evp_find_supported_curve(&raw_server_ecc_params->curve_blob, &ecc_evp_params->negotiated_curve) != 0,
-        S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+            s2n_ecc_evp_find_supported_curve(conn, &raw_server_ecc_params->curve_blob, &ecc_evp_params->negotiated_curve) != 0,
+            S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
     return s2n_ecc_evp_parse_params_point(&raw_server_ecc_params->point_blob, ecc_evp_params);
 }
 
-int s2n_ecc_evp_find_supported_curve(struct s2n_blob *iana_ids, const struct s2n_ecc_named_curve **found) {
+int s2n_ecc_evp_find_supported_curve(struct s2n_connection* conn, struct s2n_blob *iana_ids, const struct s2n_ecc_named_curve **found) {
+    const s2n_ecc_preferences* ecc_prefs;
+    s2n_connection_get_ecc_preferences(conn, &ecc_prefs);
+
     struct s2n_stuffer iana_ids_in = {0};
 
     POSIX_GUARD(s2n_stuffer_init(&iana_ids_in, iana_ids));
     POSIX_GUARD(s2n_stuffer_write(&iana_ids_in, iana_ids));
-    for (size_t i = 0; i < s2n_all_supported_curves_list_len; i++) {
-        const struct s2n_ecc_named_curve *supported_curve = s2n_all_supported_curves_list[i];
+    for (size_t i = 0; i < ecc_prefs->count; i++) {
+        const struct s2n_ecc_named_curve *supported_curve = ecc_prefs->ecc_curves[i];
         for (uint32_t j = 0; j < iana_ids->size / 2; j++) {
             uint16_t iana_id;
             POSIX_GUARD(s2n_stuffer_read_uint16(&iana_ids_in, &iana_id));

--- a/tests/unit/s2n_ecc_evp_test.c
+++ b/tests/unit/s2n_ecc_evp_test.c
@@ -17,12 +17,32 @@
 
 #include "api/s2n.h"
 
+#include "tls/s2n_connection.h"
+#include "tls/s2n_security_policies.h"
 #include "crypto/s2n_ecc_evp.h"
 #include "stuffer/s2n_stuffer.h"
 #include "testlib/s2n_testlib.h"
 #include "utils/s2n_mem.h"
 
 #define ECDHE_PARAMS_LEGACY_FORM 4
+
+/**
+ * Small helper function that builds a client connection w/ specified version
+ * @param version Requested version for a particular security policy
+ * @param connection Mock connection - will have its config set to the requested version
+ * @return success status
+ */
+static int get_test_s2n_connection_with_version(const char* version, struct s2n_connection* connection) {
+    EXPECT_NOT_NULL(connection);
+    const struct s2n_security_policy* sec_policy;
+    EXPECT_SUCCESS(s2n_find_security_policy_from_version(version, &sec_policy));
+
+    struct s2n_connection* conn = NULL;
+    EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+    conn->config->security_policy = sec_policy;
+    *connection = *conn;
+    return S2N_SUCCESS;
+}
 
 int main(int argc, char **argv) {
     BEGIN_TEST();
@@ -89,7 +109,7 @@ int main(int argc, char **argv) {
     }
     {
         /* Test failure case for computing shared key for all supported curves when the server
-        and client curves donot match */
+        and client curves do not match */
         for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
             for (int j = 0; j < s2n_all_supported_curves_list_len; j++) {
                 struct s2n_ecc_evp_params server_params = {0};
@@ -216,8 +236,11 @@ int main(int argc, char **argv) {
         }
     }
     {
+        struct s2n_connection conn = {0};
+        get_test_s2n_connection_with_version("test_all", &conn);
         /* Test read/write/parse params for all supported curves */
         for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
+
             struct s2n_ecc_evp_params write_params = {0};
             struct s2n_ecc_evp_params read_params = {0};
             struct s2n_stuffer wire;
@@ -238,18 +261,20 @@ int main(int argc, char **argv) {
 
              /* Read params points from the wire */
             EXPECT_SUCCESS(s2n_ecc_evp_read_params(&wire, &ecdh_params_received, &ecdhe_data));
-            EXPECT_SUCCESS(s2n_ecc_evp_parse_params(&ecdhe_data, &read_params));
+            EXPECT_SUCCESS(s2n_ecc_evp_parse_params(&conn, &ecdhe_data, &read_params));
 
             /* Check that the point we read is the same we wrote */
             EXPECT_TRUE(EVP_PKEY_cmp(write_params.evp_pkey, read_params.evp_pkey));
 
-            /* Clean up */ 
+            /* Clean up */
             EXPECT_SUCCESS(s2n_stuffer_free(&wire));
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&write_params));
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&read_params));
         }
     }
     {
+        struct s2n_connection conn = {0};
+        get_test_s2n_connection_with_version("test_all", &conn);
         /* Test generate/read/write/parse and compute shared secrets for all supported curves */
         for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params server_params = {0};
@@ -274,7 +299,7 @@ int main(int argc, char **argv) {
             /* Client reads the public */
             struct s2n_ecdhe_raw_server_params ecdhe_data = {0};
             EXPECT_SUCCESS(s2n_ecc_evp_read_params(&wire, &ecdh_params_received, &ecdhe_data));
-            EXPECT_SUCCESS(s2n_ecc_evp_parse_params(&ecdhe_data, &read_params));
+            EXPECT_SUCCESS(s2n_ecc_evp_parse_params(&conn, &ecdhe_data, &read_params));
 
             /* Verify if the client correctly read the server public */
             EXPECT_TRUE(EVP_PKEY_cmp(server_params.evp_pkey, read_params.evp_pkey));
@@ -306,8 +331,10 @@ int main(int argc, char **argv) {
         }
     }
     {
+        struct s2n_connection conn = {0};
+        get_test_s2n_connection_with_version("test_all", &conn);
         /* Test generate->write->read->compute_shared with all supported curves */
-    for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
+        for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params server_params = {0}, client_params = {0};
             struct s2n_stuffer wire;
             struct s2n_blob server_shared, client_shared, ecdh_params_sent, ecdh_params_received;
@@ -323,7 +350,7 @@ int main(int argc, char **argv) {
             /* Client reads the public */
             struct s2n_ecdhe_raw_server_params ecdhe_data = {0};
             EXPECT_SUCCESS(s2n_ecc_evp_read_params(&wire, &ecdh_params_received, &ecdhe_data));
-            EXPECT_SUCCESS(s2n_ecc_evp_parse_params(&ecdhe_data, &client_params));
+            EXPECT_SUCCESS(s2n_ecc_evp_parse_params(&conn, &ecdhe_data, &client_params));
 
             /* The client got the curve */
             EXPECT_EQUAL(client_params.negotiated_curve, server_params.negotiated_curve);
@@ -342,6 +369,120 @@ int main(int argc, char **argv) {
             EXPECT_SUCCESS(s2n_free(&client_shared));
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&server_params));
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&client_params));
+        }
+    }
+    /* Test that the client does not negotiate a group that was not
+     * offered in EC preferences */
+    {
+        const struct s2n_security_policy* security_policy = NULL;
+
+        struct s2n_connection conn = {0};
+        get_test_s2n_connection_with_version("20190802", &conn);
+
+        EXPECT_SUCCESS(s2n_connection_get_security_policy(&conn, &security_policy));
+
+        // Ensure that the applied security policy uses the correct ecc preferences
+        const uint8_t EXPECTED_ECC_PREF_COUNT = 2;
+        EXPECT_EQUAL(security_policy->ecc_preferences, &s2n_ecc_preferences_20140601);
+        EXPECT_EQUAL(security_policy->ecc_preferences->count, EXPECTED_ECC_PREF_COUNT);
+
+        // Setup & verify invalid curves, which will be selected by a malicious server
+        const struct s2n_ecc_named_curve* const unrequested_curves[] = {
+                &s2n_ecc_curve_x25519,
+                &s2n_ecc_curve_secp521r1,
+        };
+
+        // Test that client's preferred ecc's do NOT include the curves selected by the server
+        for (uint8_t ix = 0; ix < EXPECTED_ECC_PREF_COUNT; ix++) {
+            const struct s2n_ecc_named_curve* curve = security_policy->ecc_preferences->ecc_curves[ix];
+            for (uint8_t iy = 0; iy < s2n_array_len(unrequested_curves); iy++) {
+                EXPECT_NOT_EQUAL(curve->name, unrequested_curves[iy]->name);
+            }
+        }
+
+        // Verify that the client broadcasts an error code when the server attempts to
+        // negotiate a curve that was never offered
+        for (uint8_t i = 0; i < s2n_array_len(unrequested_curves); i++) {
+            struct s2n_ecc_evp_params server_params = {0}, client_params = {0};
+            struct s2n_stuffer wire;
+            struct s2n_blob ecdh_params_sent, ecdh_params_received;
+
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&wire, 1024));
+
+            /* Server maliciously chooses an unsupported curve */
+            server_params.negotiated_curve = unrequested_curves[i];
+            EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_params));
+            EXPECT_NOT_NULL(server_params.evp_pkey);
+            /* Server sends the public */
+            EXPECT_SUCCESS(s2n_ecc_evp_write_params(&server_params, &wire, &ecdh_params_sent));
+            /* Client reads the public */
+            struct s2n_ecdhe_raw_server_params ecdhe_data = {0};
+            EXPECT_SUCCESS(s2n_ecc_evp_read_params(&wire, &ecdh_params_received, &ecdhe_data));
+            EXPECT_FAILURE_WITH_ERRNO(
+                    s2n_ecc_evp_parse_params(&conn, &ecdhe_data, &client_params), S2N_ERR_ECDHE_UNSUPPORTED_CURVE);
+
+            /* The client didn't agree on a curve*/
+            EXPECT_NULL(client_params.negotiated_curve);
+
+            // Clean up
+            EXPECT_SUCCESS(s2n_stuffer_free(&wire));
+            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&server_params));
+            EXPECT_SUCCESS(s2n_ecc_evp_params_free(&client_params));
+        }
+    }
+
+    /* Batch test that the client selects a curve that was initially offered in EC preferences
+     * and correctly offered by the server*/
+    {
+        if (s2n_is_evp_apis_supported()) {
+            const struct s2n_security_policy* security_policy = NULL;
+
+            struct s2n_connection conn = {0};
+            get_test_s2n_connection_with_version("default_tls13", &conn);
+
+            EXPECT_SUCCESS(s2n_connection_get_security_policy(&conn, &security_policy));
+
+            // Ensure that the applied security policy uses the correct ecc preferences
+            const uint8_t EXPECTED_ECC_PREF_COUNT = 3;
+            EXPECT_EQUAL(security_policy->ecc_preferences, &s2n_ecc_preferences_20200310);
+            EXPECT_EQUAL(security_policy->ecc_preferences->count, EXPECTED_ECC_PREF_COUNT);
+
+            // Setup & verify which curves the client can accept
+            const struct s2n_ecc_named_curve* const acceptable_curves[] = {
+                    &s2n_ecc_curve_x25519,
+                    &s2n_ecc_curve_secp256r1,
+                    &s2n_ecc_curve_secp384r1,
+            };
+
+            struct s2n_ecc_evp_params server_params = {0}, client_params = {0};
+            struct s2n_stuffer wire;
+            struct s2n_blob ecdh_params_sent, ecdh_params_received;
+
+            // Iterate through the acceptable curves and ensure the client
+            // correctly accepts
+            for (size_t i = 0; i < s2n_array_len(acceptable_curves); i++) {
+                const s2n_ecc_named_curve* acceptable_curve = acceptable_curves[i];
+
+                /* Server chooses an acceptable curve */
+                server_params.negotiated_curve = acceptable_curve;
+                EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&wire, 1024));
+                EXPECT_SUCCESS(s2n_ecc_evp_generate_ephemeral_key(&server_params));
+                EXPECT_NOT_NULL(server_params.evp_pkey);
+                /* Server sends the public */
+                EXPECT_SUCCESS(s2n_ecc_evp_write_params(&server_params, &wire, &ecdh_params_sent));
+                /* Client reads the public */
+                struct s2n_ecdhe_raw_server_params ecdhe_data = {0};
+                EXPECT_SUCCESS(s2n_ecc_evp_read_params(&wire, &ecdh_params_received, &ecdhe_data));
+                EXPECT_SUCCESS(s2n_ecc_evp_parse_params(&conn, &ecdhe_data, &client_params));
+
+                /* The client agrees on the curve*/
+                EXPECT_EQUAL(client_params.negotiated_curve, server_params.negotiated_curve);
+
+                // Clean up
+                EXPECT_SUCCESS(s2n_stuffer_free(&wire));
+                EXPECT_SUCCESS(s2n_ecc_evp_params_free(&server_params));
+                EXPECT_SUCCESS(s2n_ecc_evp_params_free(&client_params));
+            }
         }
     }
 

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -198,13 +198,11 @@ static int s2n_client_key_share_send(struct s2n_connection *conn, struct s2n_stu
         /* Ensure a new key share will be sent after a hello retry request */
         POSIX_ENSURE(server_curve != client_curve || server_group != client_group, S2N_ERR_BAD_KEY_SHARE);
     }
-
     struct s2n_stuffer_reservation shares_size = {0};
     POSIX_GUARD(s2n_stuffer_reserve_uint16(out, &shares_size));
     POSIX_GUARD(s2n_generate_default_pq_hybrid_key_share(conn, out));
     POSIX_GUARD(s2n_generate_default_ecc_key_share(conn, out));
     POSIX_GUARD(s2n_stuffer_write_vector_size(&shares_size));
-
     /* We must have written at least one share */
     POSIX_ENSURE(s2n_stuffer_data_available(out) > shares_size.length, S2N_ERR_BAD_KEY_SHARE);
 

--- a/tls/s2n_ecc_preferences.h
+++ b/tls/s2n_ecc_preferences.h
@@ -21,10 +21,10 @@
 
 #include "crypto/s2n_ecc_evp.h"
 
-struct s2n_ecc_preferences {
+typedef struct s2n_ecc_preferences {
     uint8_t count;
     const struct s2n_ecc_named_curve *const *ecc_curves;
-};
+} s2n_ecc_preferences;
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_20140601;
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_20200310;
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_default_fips;

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -24,14 +24,14 @@
 /* Kept up-to-date by s2n_security_policies_test */
 #define NUM_RSA_PSS_SCHEMES 6
 
-struct s2n_security_policy {
+typedef struct s2n_security_policy {
     uint8_t minimum_protocol_version;
     const struct s2n_cipher_preferences *cipher_preferences;
     const struct s2n_kem_preferences *kem_preferences;
     const struct s2n_signature_preferences *signature_preferences;
     const struct s2n_signature_preferences *certificate_signature_preferences;
     const struct s2n_ecc_preferences *ecc_preferences;
-};
+} s2n_security_policy;
 
 struct s2n_security_policy_selection {
     const char *version;

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -100,7 +100,7 @@ int s2n_ecdhe_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_
 
 int s2n_ecdhe_server_key_recv_parse_data(struct s2n_connection *conn, struct s2n_kex_raw_server_data *raw_server_data)
 {
-    POSIX_GUARD(s2n_ecc_evp_parse_params(&raw_server_data->ecdhe_data, &conn->kex_params.server_ecc_evp_params));
+    POSIX_GUARD(s2n_ecc_evp_parse_params(conn, &raw_server_data->ecdhe_data, &conn->kex_params.server_ecc_evp_params));
 
     return 0;
 }


### PR DESCRIPTION
### Resolved issues:

 * addresses one finding made by tls-anvil, which is reproduced below
```
s2n Like MatrixSSL, the s2n client accepts a ServerKeyExchange message that negotiates an unproposed named group. In this case, this only applies to the groups X25519 and secp521r1, which are not deprecated and have strong parameters. Nevertheless, we stress that even these particular groups could be targeted in the future. Secure parameter negotiation is a fundamental security property of every cryptographic protocol that prevents future attacks on particular algorithms.
```
 * no corresponding git issue (will add later for documentation)

### Description of changes: 

S2N client now considers the existing security policy context when verifying the server's ecc selection. This prevents the client from negotiating a curve that it never presented as an option. Upon failure of verification, the client handshake terminates and broadcasts an `S2N_ERR_ECDHE_UNSUPPORTED_CURVE` signal.

### Call-outs:

n/a
### Testing:

* existing unit tests modified to account for new apis
* two additional unit tests added to test client rejection of unsupported ecc and client acceptance of a supported ecc
* sanity manual execution of s2nc/s2nd handshake

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
