### PR TITLE
S2N client negotation of un-offered group fix

### DIFF
--- a/crypto/s2n_ecc_evp.h
+++ b/crypto/s2n_ecc_evp.h
@@ -45,6 +45,7 @@ extern const struct s2n_ecc_named_curve s2n_ecc_curve_secp256r1;
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_secp384r1;
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_secp521r1;
 extern const struct s2n_ecc_named_curve s2n_ecc_curve_x25519;
+extern const struct s2n_ecc_named_curve s2n_unsupported_curve;
 
 /* BoringSSL only supports using EVP_PKEY_X25519 with "modern" EC EVP APIs. BoringSSL has a note to possibly add this in
  * the future. See https://github.com/google/boringssl/blob/master/crypto/evp/p_x25519_asn1.c#L233

--- a/tests/unit/s2n_ecc_evp_test.c
+++ b/tests/unit/s2n_ecc_evp_test.c
@@ -28,7 +28,7 @@
 #define ECDHE_PARAMS_LEGACY_FORM 4
 #define IS_CURVE_TESTABLE_IN_CURR_ENV(curve) \
             (((s2n_is_in_fips_mode() && curve->iana_id == TLS_EC_CURVE_ECDH_X25519) \
-            || (!S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && curve->iana_id == TLS_EC_CURVE_ECDH_X25519)) ? false : true)
+            || (!s2n_is_evp_apis_supported() && curve->iana_id == TLS_EC_CURVE_ECDH_X25519)) ? false : true)
 /**
  * Small helper function that builds a client connection w/ specified version
  * @param version Requested version for a particular security policy

--- a/tests/unit/s2n_ecc_evp_test.c
+++ b/tests/unit/s2n_ecc_evp_test.c
@@ -27,7 +27,7 @@
 
 #define ECDHE_PARAMS_LEGACY_FORM 4
 #define IS_SUPPORTED_CURVE_FOR_TESTING_WITH_FIPS(curve) \
-            (s2n_is_in_fips_mode() && curve->iana_id == TLS_EC_CURVE_ECDH_X25519) ? false : true
+            ((s2n_is_in_fips_mode() && curve->iana_id == TLS_EC_CURVE_ECDH_X25519) ? false : true)
 /**
  * Small helper function that builds a client connection w/ specified version
  * @param version Requested version for a particular security policy
@@ -404,7 +404,7 @@ int main(int argc, char **argv) {
         /* Verify that the client broadcasts an error code when the server attempts to
          negotiate a curve that was never offered */
         for (uint8_t i = 0; i < s2n_array_len(unrequested_curves); i++) {
-            if (IS_SUPPORTED_CURVE_FOR_TESTING_WITH_FIPS(unrequested_curves[i])) {
+            if (!IS_SUPPORTED_CURVE_FOR_TESTING_WITH_FIPS(unrequested_curves[i])) {
                 continue;
             }
             struct s2n_ecc_evp_params server_params = {0}, client_params = {0};
@@ -432,8 +432,8 @@ int main(int argc, char **argv) {
             EXPECT_SUCCESS(s2n_stuffer_free(&wire));
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&server_params));
             EXPECT_SUCCESS(s2n_ecc_evp_params_free(&client_params));
-            EXPECT_SUCCESS(s2n_connection_free(conn));
         }
+        EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
     /* Batch test that the client selects a curve that was initially offered in EC preferences
@@ -466,7 +466,7 @@ int main(int argc, char **argv) {
             /* Iterate through the acceptable curves and ensure the client correctly accepts */
             for (size_t i = 0; i < s2n_array_len(acceptable_curves); i++) {
                 const s2n_ecc_named_curve* acceptable_curve = acceptable_curves[i];
-                if (IS_SUPPORTED_CURVE_FOR_TESTING_WITH_FIPS(acceptable_curve)) {
+                if (!IS_SUPPORTED_CURVE_FOR_TESTING_WITH_FIPS(acceptable_curve)) {
                     continue;
                 }
 

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -198,13 +198,11 @@ static int s2n_client_key_share_send(struct s2n_connection *conn, struct s2n_stu
         /* Ensure a new key share will be sent after a hello retry request */
         POSIX_ENSURE(server_curve != client_curve || server_group != client_group, S2N_ERR_BAD_KEY_SHARE);
     }
-
     struct s2n_stuffer_reservation shares_size = {0};
     POSIX_GUARD(s2n_stuffer_reserve_uint16(out, &shares_size));
     POSIX_GUARD(s2n_generate_default_pq_hybrid_key_share(conn, out));
     POSIX_GUARD(s2n_generate_default_ecc_key_share(conn, out));
     POSIX_GUARD(s2n_stuffer_write_vector_size(&shares_size));
-
     /* We must have written at least one share */
     POSIX_ENSURE(s2n_stuffer_data_available(out) > shares_size.length, S2N_ERR_BAD_KEY_SHARE);
 

--- a/tls/s2n_ecc_preferences.h
+++ b/tls/s2n_ecc_preferences.h
@@ -21,10 +21,10 @@
 
 #include "crypto/s2n_ecc_evp.h"
 
-struct s2n_ecc_preferences {
+typedef struct s2n_ecc_preferences {
     uint8_t count;
     const struct s2n_ecc_named_curve *const *ecc_curves;
-};
+} s2n_ecc_preferences;
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_20140601;
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_20200310;
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_default_fips;

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -24,14 +24,14 @@
 /* Kept up-to-date by s2n_security_policies_test */
 #define NUM_RSA_PSS_SCHEMES 6
 
-struct s2n_security_policy {
+typedef struct s2n_security_policy {
     uint8_t minimum_protocol_version;
     const struct s2n_cipher_preferences *cipher_preferences;
     const struct s2n_kem_preferences *kem_preferences;
     const struct s2n_signature_preferences *signature_preferences;
     const struct s2n_signature_preferences *certificate_signature_preferences;
     const struct s2n_ecc_preferences *ecc_preferences;
-};
+} s2n_security_policy;
 
 struct s2n_security_policy_selection {
     const char *version;

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -100,7 +100,7 @@ int s2n_ecdhe_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_
 
 int s2n_ecdhe_server_key_recv_parse_data(struct s2n_connection *conn, struct s2n_kex_raw_server_data *raw_server_data)
 {
-    POSIX_GUARD(s2n_ecc_evp_parse_params(&raw_server_data->ecdhe_data, &conn->kex_params.server_ecc_evp_params));
+    POSIX_GUARD(s2n_ecc_evp_parse_params(conn, &raw_server_data->ecdhe_data, &conn->kex_params.server_ecc_evp_params));
 
     return 0;
 }


### PR DESCRIPTION
### Resolved issues:

 * addresses one finding made by tls-anvil, which is reproduced below
```
s2n Like MatrixSSL, the s2n client accepts a ServerKeyExchange message that negotiates an unproposed named group. In this case, this only applies to the groups X25519 and secp521r1, which are not deprecated and have strong parameters. Nevertheless, we stress that even these particular groups could be targeted in the future. Secure parameter negotiation is a fundamental security property of every cryptographic protocol that prevents future attacks on particular algorithms.
```
 * no corresponding git issue (will add later for documentation)

### Description of changes: 

S2N client now considers the existing security policy context when verifying the server's ecc selection. This prevents the client from negotiating a curve that it never presented as an option. Upon failure of verification, the client handshake terminates and broadcasts an `S2N_ERR_ECDHE_UNSUPPORTED_CURVE` signal.

### Call-outs:

n/a
### Testing:

* existing unit tests modified to account for new apis
* two additional unit tests added to test client rejection of unsupported ecc and client acceptance of a supported ecc
* sanity manual execution of s2nc/s2nd handshake

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
