### PR TITLE
Revert "ci: Temporarily pin AWS-LC to a commit before gcc 4.8 breaks"

### DIFF
--- a/codebuild/bin/install_awslc.sh
+++ b/codebuild/bin/install_awslc.sh
@@ -38,10 +38,6 @@ if [ "$IS_FIPS" == "1" ]; then
   cd aws-lc
   git checkout -b fips-2021-10-20 origin/fips-2021-10-20
   cd ..
-else
-  cd aws-lc
-  git checkout a219726caf0c4585b80193570369627ed9a3a931
-  cd ..
 fi
 
 install_awslc() {


### PR DESCRIPTION
Reverts aws/s2n-tls#3414

aws-lc merged https://github.com/awslabs/aws-lc/pull/571. `V649762450` confirmed the fix can work. 