### PR TITLE
Fix early data reporting on partial send

### DIFF
--- a/tests/unit/s2n_early_data_test.c
+++ b/tests/unit/s2n_early_data_test.c
@@ -1156,6 +1156,28 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(conn->early_data_bytes, limit + 1);
         }
 
+        /* Negative bytes are "recorded" */
+        {
+            conn->early_data_bytes = 0;
+            EXPECT_OK(s2n_early_data_record_bytes(conn, -1));
+            EXPECT_EQUAL(conn->early_data_bytes, 0);
+
+            conn->early_data_bytes = limit / 2;
+            EXPECT_OK(s2n_early_data_record_bytes(conn, -1));
+            EXPECT_EQUAL(conn->early_data_bytes, limit / 2);
+
+            conn->early_data_bytes = limit;
+            EXPECT_OK(s2n_early_data_record_bytes(conn, -1));
+            EXPECT_EQUAL(conn->early_data_bytes, limit);
+
+            /* Unlike with other inputs, does not return an error and set S2N_ERR_MAX_EARLY_DATA_SIZE.
+             * That would overwrite whatever send error caused the -1 result.
+             */
+            conn->early_data_bytes = limit + 1;
+            EXPECT_OK(s2n_early_data_record_bytes(conn, -1));
+            EXPECT_EQUAL(conn->early_data_bytes, limit + 1);
+        }
+
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 

--- a/tls/s2n_early_data_io.c
+++ b/tls/s2n_early_data_io.c
@@ -84,7 +84,7 @@ static bool s2n_is_early_data_io(struct s2n_connection *conn)
 S2N_RESULT s2n_early_data_record_bytes(struct s2n_connection *conn, ssize_t data_len)
 {
     RESULT_ENSURE_REF(conn);
-    if (!s2n_is_early_data_io(conn)) {
+    if (data_len < 0 || !s2n_is_early_data_io(conn)) {
         return S2N_RESULT_OK;
     }
 

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -199,7 +199,6 @@ ssize_t s2n_recv_impl(struct s2n_connection * conn, void *buf, ssize_t size, s2n
         *blocked = S2N_NOT_BLOCKED;
     }
 
-    POSIX_GUARD_RESULT(s2n_early_data_record_bytes(conn, bytes_read));
     return bytes_read;
 }
 
@@ -208,6 +207,7 @@ ssize_t s2n_recv(struct s2n_connection * conn, void *buf, ssize_t size, s2n_bloc
     POSIX_ENSURE(!conn->recv_in_use, S2N_ERR_REENTRANCY);
     conn->recv_in_use = true;
     ssize_t result = s2n_recv_impl(conn, buf, size, blocked);
+    POSIX_GUARD_RESULT(s2n_early_data_record_bytes(conn, result));
     conn->recv_in_use = false;
     return result;
 }

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -200,8 +200,6 @@ ssize_t s2n_sendv_with_offset_impl(struct s2n_connection *conn, const struct iov
     conn->current_user_data_consumed = 0;
 
     *blocked = S2N_NOT_BLOCKED;
-
-    POSIX_GUARD_RESULT(s2n_early_data_record_bytes(conn, total_size));
     return total_size;
 }
 
@@ -210,6 +208,7 @@ ssize_t s2n_sendv_with_offset(struct s2n_connection *conn, const struct iovec *b
     POSIX_ENSURE(!conn->send_in_use, S2N_ERR_REENTRANCY);
     conn->send_in_use = true;
     ssize_t result = s2n_sendv_with_offset_impl(conn, bufs, count, offs, blocked);
+    POSIX_GUARD_RESULT(s2n_early_data_record_bytes(conn, result));
     conn->send_in_use = false;
     return result;
 }


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/3433

### Description of changes: 

If s2n_send blocks after sending at least one record but before sending all the data requested by the application, it returns the number of bytes sent and indicates that it's blocked on writing. Previously, the bytes written during one of these "partial send"s were not counted towards the early data maximum. This change starts counting them properly.

I preemptively also fixed the same potential issue in s2n_recv, but the code paths that could have triggered a "partial recv" are not actually accessible. See https://github.com/aws/s2n-tls/issues/3438.

### Testing:
I verified that s2n_send now counts partial writes and made sure that s2n_send_early_data reports the partial writes back to application properly. I couldn't test s2n_recv/s2n_recv_early_data since the code path is inaccessible, but the existing tests continue to pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
