### PR TITLE
s2n_peek should not report partial, encrypted data

### DIFF
--- a/tests/unit/s2n_recv_test.c
+++ b/tests/unit/s2n_recv_test.c
@@ -35,6 +35,145 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
+    DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key,
+            s2n_cert_chain_and_key_ptr_free);
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+            S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+
+    DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(),
+            s2n_config_ptr_free);
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+    EXPECT_SUCCESS(s2n_config_disable_x509_verification(config));
+
+    /* s2n_peek */
+    {
+        /* We do full handshakes and send with a real connection here instead of
+         * just calling s2n_connection_set_secrets because s2n_peek depends on details
+         * of how data is encrypted, and we don't want to make any incorrect assumptions.
+         */
+
+        /* Safety check */
+        EXPECT_EQUAL(s2n_peek(NULL), 0);
+
+        const uint8_t test_data[100] = "hello world";
+        const size_t test_data_size = sizeof(test_data);
+
+        /* s2n_peek reports available plaintext bytes */
+        {
+            s2n_blocked_status blocked = 0;
+
+            DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+            DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+            struct s2n_test_io_pair io_pair = { 0 };
+            EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+            EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+            EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+            /* Write some data */
+            EXPECT_EQUAL(s2n_send(client_conn, test_data, sizeof(test_data), &blocked), sizeof(test_data));
+
+            /* Initially, no data reported as available */
+            EXPECT_EQUAL(s2n_peek(server_conn), 0);
+
+            /* Read some, but not all, of the data written */
+            uint8_t output[sizeof(test_data)] = { 0 };
+            const size_t expected_peek_size = 10;
+            const size_t recv_size = test_data_size - expected_peek_size;
+            EXPECT_EQUAL(s2n_recv(server_conn, output, recv_size, &blocked), recv_size);
+
+            /* After a partial read, some data reported as available */
+            EXPECT_EQUAL(s2n_peek(server_conn), expected_peek_size);
+
+            /* Read the rest of the data */
+            EXPECT_EQUAL(s2n_recv(server_conn, output, expected_peek_size, &blocked), expected_peek_size);
+
+            /* After the complete read, no data reported as available */
+            EXPECT_EQUAL(s2n_peek(server_conn), 0);
+        }
+
+        /* s2n_peek doesn't report bytes belonging to partially read, still encrypted records */
+        {
+            s2n_blocked_status blocked = 0;
+
+            DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+            DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+            /* Use stuffers for IO so that we can trigger a block on a read */
+            DEFER_CLEANUP(struct s2n_stuffer server_in = { 0 }, s2n_stuffer_free);
+            DEFER_CLEANUP(struct s2n_stuffer server_out = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_in, 0));
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_out, 0));
+            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_out, &server_in, client_conn));
+            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_in, &server_out, server_conn));
+
+            EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+            /* Write some data */
+            EXPECT_EQUAL(s2n_send(client_conn, test_data, sizeof(test_data), &blocked), sizeof(test_data));
+
+            /* Drop some of the data */
+            EXPECT_SUCCESS(s2n_stuffer_wipe_n(&server_in, 10));
+
+            /* Try to read the data, but block */
+            uint8_t output[sizeof(test_data)] = { 0 };
+            EXPECT_FAILURE_WITH_ERRNO(s2n_recv(server_conn, output, sizeof(test_data), &blocked),
+                    S2N_ERR_IO_BLOCKED);
+
+            /* conn->in contains data, but s2n_peek reports no data available */
+            EXPECT_TRUE(s2n_stuffer_data_available(&server_conn->in));
+            EXPECT_EQUAL(s2n_peek(server_conn), 0);
+        }
+
+        /* s2n_peek doesn't report bytes belonging to post-handshake messages */
+        {
+            s2n_blocked_status blocked = 0;
+
+            DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+            DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+            /* Use stuffers for IO so that we can trigger a block on a read */
+            DEFER_CLEANUP(struct s2n_stuffer server_in = { 0 }, s2n_stuffer_free);
+            DEFER_CLEANUP(struct s2n_stuffer server_out = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_in, 0));
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_out, 0));
+            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_out, &server_in, client_conn));
+            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_in, &server_out, server_conn));
+
+            EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+            /* Send a KeyUpdate message */
+            client_conn->key_update_pending = true;
+            EXPECT_SUCCESS(s2n_key_update_send(client_conn, &blocked));
+            EXPECT_FALSE(client_conn->key_update_pending);
+
+            /* Drop some of the data */
+            EXPECT_SUCCESS(s2n_stuffer_wipe_n(&server_in, 10));
+
+            /* Try to read the KeyUpdate message, but block */
+            uint8_t output[1] = { 0 };
+            EXPECT_FAILURE_WITH_ERRNO(s2n_recv(server_conn, output, sizeof(output), &blocked),
+                    S2N_ERR_IO_BLOCKED);
+
+            /* conn->in contains data, but s2n_peek reports no data available */
+            EXPECT_TRUE(s2n_stuffer_data_available(&server_conn->in));
+            EXPECT_EQUAL(s2n_peek(server_conn), 0);
+        }
+    }
+
     /* s2n_recv cannot be called concurrently */
     {
         /* Setup connection */

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -213,6 +213,17 @@ ssize_t s2n_recv(struct s2n_connection * conn, void *buf, ssize_t size, s2n_bloc
 }
 
 uint32_t s2n_peek(struct s2n_connection *conn) {
+    if (conn == NULL) {
+        return 0;
+    }
+
+    /* If we have partially buffered an encrypted record,
+     * we should not report those bytes as available to read.
+     */
+    if (conn->in_status != PLAINTEXT) {
+        return 0;
+    }
+
     return s2n_stuffer_data_available(&conn->in);
 }
 


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/3440

### Description of changes: 

s2n_peek is intended to tell the application whether there is still data available from the last record read, meaning that s2n_recv can be called without another network read. It does this [by reporting the size of the conn->in buffer](https://github.com/aws/s2n-tls/blob/main/tls/s2n_recv.c#L216), the buffer records are read into.

However, conn->in doesn't just hold final, decrypted application data. First, s2n_recv reads the full encrypted record into conn->in, then decrypts it in place. Because [we try to read the record into conn->in in a loop](https://github.com/aws/s2n-tls/blob/main/tls/s2n_recv.c#L43-L61), we can end up with a partial, still-encrypted record in the buffer if a read blocks or otherwise errors. Therefore, if s2n_peek is used after s2n_recv fails, it can report very deceptive results. No actual application data is available until we successfully read the rest of the record, which will require at least one more network read, but s2n_peek reports that a basically random number of bytes are available.

### Call-outs:

This does change the behavior of a public API. However, the behavior change seems low risk. The number of bytes reported by s2n_peek if called incorrectly has basically no relationship to any data relevant to the calling application and is essentially useless. The data might not even be a partial application data record, since the same situation can occur with post-handshake messages in TLS1.3. 

### Testing:

New unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
