### PR TITLE
Correct CODEOWNERS team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @s2n-core
-/codebuild @dougch @s2n-core
+* @aws/s2n-core
+/codebuild @dougch @aws/s2n-core


### PR DESCRIPTION
### Description of changes: 

Github added nifty little warnings about CODEOWNERS files being valid/invalid. Our old one was invalid, this fixes it.


### Testing:

This little Github warning says it's valid now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
