### PR TITLE
pass padding of 0 to EVP_CIPHER_CTX_set_padding

### DIFF
--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -57,7 +57,7 @@ static int s2n_cbc_cipher_3des_set_decryption_key(struct s2n_session_key *key, s
 {
     POSIX_ENSURE_EQ(in->size, 192 / 8);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
@@ -67,7 +67,7 @@ static int s2n_cbc_cipher_3des_set_encryption_key(struct s2n_session_key *key, s
 {
     POSIX_ENSURE_EQ(in->size, 192 / 8);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -62,7 +62,7 @@ int s2n_cbc_cipher_aes128_set_decryption_key(struct s2n_session_key *key, struct
     POSIX_ENSURE_EQ(in->size, 128 / 8);
 
     /* Always returns 1 */
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
@@ -72,7 +72,7 @@ static int s2n_cbc_cipher_aes128_set_encryption_key(struct s2n_session_key *key,
 {
     POSIX_ENSURE_EQ(in->size, 128 / 8);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
@@ -82,7 +82,7 @@ static int s2n_cbc_cipher_aes256_set_decryption_key(struct s2n_session_key *key,
 {
     POSIX_ENSURE_EQ(in->size, 256 / 8);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;
@@ -92,7 +92,7 @@ int s2n_cbc_cipher_aes256_set_encryption_key(struct s2n_session_key *key, struct
 {
     POSIX_ENSURE_EQ(in->size, 256 / 8);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
 
     return 0;

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -205,7 +205,7 @@ static int s2n_composite_cipher_aes128_sha_set_encryption_key(struct s2n_session
 {
     POSIX_ENSURE_EQ(in->size, 16);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     EVP_EncryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_128_cbc_hmac_sha1(), NULL, in->data, NULL);
 
     return 0;
@@ -215,7 +215,7 @@ static int s2n_composite_cipher_aes128_sha_set_decryption_key(struct s2n_session
 {
     POSIX_ENSURE_EQ(in->size, 16);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     EVP_DecryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_128_cbc_hmac_sha1(), NULL, in->data, NULL);
 
     return 0;
@@ -225,7 +225,7 @@ static int s2n_composite_cipher_aes256_sha_set_encryption_key(struct s2n_session
 {
     POSIX_ENSURE_EQ(in->size, 32);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     EVP_EncryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_256_cbc_hmac_sha1(), NULL, in->data, NULL);
 
     return 0;
@@ -235,7 +235,7 @@ static int s2n_composite_cipher_aes256_sha_set_decryption_key(struct s2n_session
 {
     POSIX_ENSURE_EQ(in->size, 32);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     EVP_DecryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_256_cbc_hmac_sha1(), NULL, in->data, NULL);
 
     return 0;
@@ -245,7 +245,7 @@ static int s2n_composite_cipher_aes128_sha256_set_encryption_key(struct s2n_sess
 {
     POSIX_ENSURE_EQ(in->size, 16);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     EVP_EncryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_128_cbc_hmac_sha256(), NULL, in->data, NULL);
 
     return 0;
@@ -255,7 +255,7 @@ static int s2n_composite_cipher_aes128_sha256_set_decryption_key(struct s2n_sess
 {
     POSIX_ENSURE_EQ(in->size, 16);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     EVP_DecryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_128_cbc_hmac_sha256(), NULL, in->data, NULL);
 
     return 0;
@@ -265,7 +265,7 @@ static int s2n_composite_cipher_aes256_sha256_set_encryption_key(struct s2n_sess
 {
     POSIX_ENSURE_EQ(in->size, 32);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     EVP_EncryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_256_cbc_hmac_sha256(), NULL, in->data, NULL);
 
     return 0;
@@ -275,7 +275,7 @@ static int s2n_composite_cipher_aes256_sha256_set_decryption_key(struct s2n_sess
 {
     POSIX_ENSURE_EQ(in->size, 32);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, EVP_CIPH_NO_PADDING);
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     EVP_DecryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_256_cbc_hmac_sha256(), NULL, in->data, NULL);
 
     return 0;


### PR DESCRIPTION
### Security concerns:
Padding currently being enabled in main branch is **not a security issue** since we apply padding manually and provide the encrypt function with data that is a multiple of the block size. This essentially mean a noop when openssl tries to apply padding.

### Description of changes: 
This is part of the effort to integrate s2n-tls with openssl3.

The error originates from the usage of the function `EVP_CIPHER_CTX_set_padding`. This function controls padding when performing encrypt/decrypt operations on a block of data. Padding is enabled by default and can be disabled if desired.
  > If the pad parameter is zero then no padding is performed, the total amount of data encrypted or decrypted must then be a multiple of the block size or an error will occur.

Based on the [documentation](https://www.openssl.org/docs/manmaster/man3/EVP_CIPHER_CTX_set_padding.html#Gettable-and-Settable-EVP_CIPHER_CTX-parameters) and source code this doesnt seem to have been used correctly. The `EVP_CIPHER_CTX_set_padding` fn expects 1 or 0 while the value of `EVP_CIPH_NO_PADDING` is `0x100` and seems to be used to toggle the flag on the internally used context.

**FIX:**
The fix here should be to call `EVP_CIPHER_CTX_set_padding` with `0` instead of `EVP_CIPH_NO_PADDING`.
https://github.com/toidiu/s2n-tls/compare/ak-openssl3_padding?expand=1

Links:
EVP_CIPHER_CTX_set_padding
  https://github.com/openssl/openssl/blob/openssl-3.0.5/crypto/evp/evp_enc.c#L1024
  https://github.com/openssl/openssl/blob/OpenSSL_1_1_0/crypto/evp/evp_enc.c#L561

EVP_CIPH_NO_PADDING             0x100
  https://github.com/openssl/openssl/blob/openssl-3.0.5/include/openssl/evp.h#L321
  https://github.com/openssl/openssl/blob/OpenSSL_1_1_0/include/openssl/evp.h#L243

### Testing:
Unit tests for openssl1.1.1 and openssl3 passed.

```
$ ldd build/bin/s2nd | grep libcrypto

-------libcrypto
        libcrypto.so.3 => /home/ubuntu/projects/rsync/s2n-tls/test-deps/openssl-3.0/lib/libcrypto.so.3 (0x00007f33d81e7000)
-------libcrypto

Running /home/ubuntu/projects/rsync/s2n-tls/tests/unit/s2n_3des_test.c ... PASSED     153692 tests
Running /home/ubuntu/projects/rsync/s2n-tls/tests/unit/s2n_aes_test.c ... PASSED     307382 tests
```

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
