### PR TITLE
openssl3 integration: update EVP_PKEY_get/set methods

### DIFF
--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -185,6 +185,12 @@ static int s2n_rsa_key_free(struct s2n_pkey *pkey)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #endif
+    /**
+     * # !Safety
+     *
+     * THIS IS NOT SAFE
+     *
+     */
     RSA_free((RSA *) rsa_key->rsa);
 #if S2N_GCC_VERSION_AT_LEAST(4,6,0)
 #pragma GCC diagnostic pop

--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -104,6 +104,12 @@ static int s2n_rsa_encrypt(const struct s2n_pkey *pub, struct s2n_blob *in, stru
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #endif
+    /**
+     * # Safety
+     *
+     * The function `RSA_public_encrypt` does not modify the RSA key so its is
+     * safe to cast the const RSA key to a non-const RSA key.
+     */
     int r = RSA_public_encrypt(in->size, ( unsigned char * )in->data, ( unsigned char * )out->data, (RSA *) key->rsa,
                                RSA_PKCS1_PADDING);
 #if S2N_GCC_VERSION_AT_LEAST(4,6,0)
@@ -131,6 +137,12 @@ static int s2n_rsa_decrypt(const struct s2n_pkey *priv, struct s2n_blob *in, str
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #endif
+    /**
+     * # Safety
+     *
+     * The function `RSA_private_decrypt` does not modify the RSA key so its is
+     * safe to cast the const RSA key to a non-const RSA key.
+     */
     int r = RSA_private_decrypt(in->size, ( unsigned char * )in->data, intermediate, (RSA *) key->rsa, RSA_NO_PADDING);
 #if S2N_GCC_VERSION_AT_LEAST(4,6,0)
 #pragma GCC diagnostic pop

--- a/crypto/s2n_rsa.h
+++ b/crypto/s2n_rsa.h
@@ -28,7 +28,7 @@
 struct s2n_pkey;
 
 struct s2n_rsa_key {
-    RSA *rsa;
+    const RSA *rsa;
 };
 
 typedef struct s2n_rsa_key s2n_rsa_public_key;

--- a/crypto/s2n_rsa_pss.c
+++ b/crypto/s2n_rsa_pss.c
@@ -30,9 +30,9 @@
 #include "crypto/s2n_pkey.h"
 
 #include "utils/s2n_blob.h"
+#include "utils/s2n_compiler.h"
 #include "utils/s2n_random.h"
 #include "utils/s2n_safety.h"
-#include "utils/s2n_blob.h"
 
 /* Checks whether PSS Certs is supported */
 int s2n_is_rsa_pss_certs_supported()
@@ -55,7 +55,7 @@ static S2N_RESULT s2n_rsa_pss_size(const struct s2n_pkey *key, uint32_t *size_ou
     return S2N_RESULT_OK;
 }
 
-static int s2n_rsa_is_private_key(RSA *rsa_key)
+static int s2n_rsa_is_private_key(const RSA *rsa_key)
 {
     const BIGNUM *d = NULL;
     RSA_get0_key(rsa_key, NULL, NULL, &d);
@@ -147,8 +147,8 @@ static int s2n_rsa_validate_params_match(const struct s2n_pkey *pub, const struc
      *  - https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_get0_RSA.html
      *  - https://www.openssl.org/docs/manmaster/man3/RSA_get0_key.html
      */
-    RSA *pub_rsa_key = pub->key.rsa_key.rsa;
-    RSA *priv_rsa_key = priv->key.rsa_key.rsa;
+    const RSA *pub_rsa_key = pub->key.rsa_key.rsa;
+    const RSA *priv_rsa_key = priv->key.rsa_key.rsa;
 
     POSIX_ENSURE_REF(pub_rsa_key);
     POSIX_ENSURE_REF(priv_rsa_key);
@@ -183,7 +183,7 @@ static int s2n_rsa_pss_key_free(struct s2n_pkey *pkey)
 }
 
 int s2n_evp_pkey_to_rsa_pss_public_key(struct s2n_rsa_key *rsa_key, EVP_PKEY *pkey) {
-    RSA *pub_rsa_key = EVP_PKEY_get0_RSA(pkey);
+    const RSA *pub_rsa_key = EVP_PKEY_get0_RSA(pkey);
 
     S2N_ERROR_IF(s2n_rsa_is_private_key(pub_rsa_key), S2N_ERR_KEY_MISMATCH);
 
@@ -193,7 +193,7 @@ int s2n_evp_pkey_to_rsa_pss_public_key(struct s2n_rsa_key *rsa_key, EVP_PKEY *pk
 
 int s2n_evp_pkey_to_rsa_pss_private_key(struct s2n_rsa_key *rsa_key, EVP_PKEY *pkey)
 {
-    RSA *priv_rsa_key = EVP_PKEY_get0_RSA(pkey);
+    const RSA *priv_rsa_key = EVP_PKEY_get0_RSA(pkey);
     POSIX_ENSURE_REF(priv_rsa_key);
 
     /* Documentation: https://www.openssl.org/docs/man1.1.1/man3/RSA_check_key.html */
@@ -230,12 +230,12 @@ int s2n_rsa_pss_pkey_init(struct s2n_pkey *pkey)
 
 #else
 
-int s2n_evp_pkey_to_rsa_pss_public_key(struct s2n_rsa_key *rsa_pss_key, EVP_PKEY *pkey)
+int s2n_evp_pkey_to_rsa_pss_public_key(struct s2n_rsa_key *rsa_key, EVP_PKEY *pkey)
 {
     POSIX_BAIL(S2N_RSA_PSS_NOT_SUPPORTED);
 }
 
-int s2n_evp_pkey_to_rsa_pss_private_key(struct s2n_rsa_key *rsa_pss_key, EVP_PKEY *pkey)
+int s2n_evp_pkey_to_rsa_pss_private_key(struct s2n_rsa_key *rsa_key, EVP_PKEY *pkey)
 {
     POSIX_BAIL(S2N_RSA_PSS_NOT_SUPPORTED);
 }

--- a/crypto/s2n_rsa_signing.c
+++ b/crypto/s2n_rsa_signing.c
@@ -72,7 +72,14 @@ int s2n_rsa_pkcs1v15_sign_digest(const struct s2n_pkey *priv, s2n_hash_algorithm
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #endif
-    POSIX_GUARD_OSSL(RSA_sign(NID_type, digest->data, digest->size, signature->data, &signature_size, (RSA *) key->rsa), S2N_ERR_SIGN);
+    /**
+     * # Safety
+     *
+     * The function `RSA_sign` does not modify the RSA key so its is safe to
+     * cast the const RSA key to a non-const RSA key.
+     */
+    POSIX_GUARD_OSSL(RSA_sign(NID_type, digest->data, digest->size, signature->data, &signature_size,
+                (RSA *) key->rsa), S2N_ERR_SIGN);
 #if S2N_GCC_VERSION_AT_LEAST(4,6,0)
 #pragma GCC diagnostic pop
 #endif
@@ -117,7 +124,14 @@ int s2n_rsa_pkcs1v15_verify(const struct s2n_pkey *pub, struct s2n_hash_state *d
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #endif
-    POSIX_GUARD_OSSL(RSA_verify(digest_NID_type, digest_out, digest_length, signature->data, signature->size, (RSA *) key->rsa), S2N_ERR_VERIFY_SIGNATURE);
+    /**
+     * # Safety
+     *
+     * The function `RSA_verify` does not modify the RSA key so its is safe to
+     * cast the const RSA key to a non-const RSA key.
+     */
+    POSIX_GUARD_OSSL(RSA_verify(digest_NID_type, digest_out, digest_length, signature->data, signature->size,
+                (RSA *) key->rsa), S2N_ERR_VERIFY_SIGNATURE);
 #if S2N_GCC_VERSION_AT_LEAST(4,6,0)
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
### Description of changes: 
https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_get0_RSA.html
Previously `EVP_PKEY_get0_RSA` returned a mutable pkey, but now returns an immutable(const) one. This causes -Werror to emit a warning. It is possible to use `EVP_PKEY_get1_RSA`, which is not `const`, but this is the cached version of the key and cannot be modified.

https://www.openssl.org/docs/man3.0/man3/EVP_PKEY_set1_RSA.html
  > Note that if an EVP_PKEY was not constructed using one of the deprecated functions such as EVP_PKEY_set1_RSA(),then the internal key will be managed by a provider. In that case the key returned by EVP_PKEY_get1_RSA() will be a cached copy of the provider's key.

For the same reason, we were able to call `EVP_PKEY_get0_RSA` and then modify the key inline. Now since an immutable PKEY is returned, the low level API `EVP_PKEY_set1_RSA` must be used to set PKEY after it is modified.

### Testing:
  - openssl 1.0.2 (all unit tests pass)
  - openssl 1.1.1 (all unit tests pass)
  - openssl 3 (passes)
    `Running /home/ubuntu/projects/rsync/s2n-tls/tests/unit/s2n_rsa_pss_rsae_test.c ... PASSED        213 tests`

### Code analysis:
**EVP_PKEY_get0_RSA**
- https://github.com/openssl/openssl/blob/openssl-3.0.5/crypto/evp/p_legacy.c#L43
  - https://github.com/openssl/openssl/blob/openssl-3.0.5/crypto/evp/p_lib.c#L2069
  *returns pk->legacy_cache_pkey.ptr*
- https://github.com/openssl/openssl/blob/OpenSSL_1_1_1/crypto/evp/p_lib.c#L461
  *returns pkey->pkey.rsa*

**EVP_PKEY_set1_RSA**
- https://github.com/openssl/openssl/blob/openssl-3.0.5/crypto/evp/p_legacy.c#L25
  - https://github.com/openssl/openssl/blob/openssl-3.0.5/crypto/evp/p_lib.c#L741
  *sets pkey->pkey.ptr = key;* which is similar to modifying EVP_PKEY_get0_RSA value in openssl1.1.1


---

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
