### PR TITLE
Handle fragmented post-handshake messages

### DIFF
--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -696,24 +696,6 @@ int main(int argc, char **argv)
                     S2N_ERR_STUFFER_HAS_UNPROCESSED_DATA);
             EXPECT_NOT_EQUAL(conn->post_handshake.in.blob.size, 0);
         }
-
-        /* s2n_connection_free_handshake */
-        {
-            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
-                    s2n_connection_ptr_free);
-            EXPECT_NOT_NULL(conn);
-            for (size_t i = 0; i < 3; i++) {
-                EXPECT_SUCCESS(s2n_connection_free_handshake(conn));
-                EXPECT_EQUAL(conn->post_handshake.in.blob.size, 0);
-                EXPECT_SUCCESS(s2n_stuffer_resize_if_empty(&conn->post_handshake.in, size));
-                EXPECT_EQUAL(conn->post_handshake.in.blob.size, size);
-            }
-
-            /* Fails to release if in use */
-            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->post_handshake.in, 1));
-            EXPECT_SUCCESS(s2n_connection_free_handshake(conn));
-            EXPECT_NOT_EQUAL(conn->post_handshake.in.blob.size, 0);
-        }
     }
 
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(ecdsa_chain_and_key));

--- a/tests/unit/s2n_post_handshake_test.c
+++ b/tests/unit/s2n_post_handshake_test.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_write_uint24(&conn->in, S2N_KEY_UPDATE_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->in, S2N_KEY_UPDATE_REQUESTED));
 
-            EXPECT_SUCCESS(s2n_post_handshake_recv(conn));
+            EXPECT_OK(s2n_post_handshake_recv(conn));
             EXPECT_TRUE(conn->key_update_pending);
 
             EXPECT_SUCCESS(s2n_connection_free(conn)); 
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_write_uint24(&conn->in, S2N_KEY_UPDATE_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->in, S2N_KEY_UPDATE_REQUESTED));
 
-            EXPECT_SUCCESS(s2n_post_handshake_recv(conn));
+            EXPECT_OK(s2n_post_handshake_recv(conn));
             EXPECT_FALSE(conn->key_update_pending);
 
             EXPECT_SUCCESS(s2n_connection_free(conn)); 
@@ -92,7 +92,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->in, TLS_KEY_UPDATE));
             EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->in, S2N_KEY_UPDATE_LENGTH));
 
-            EXPECT_FAILURE(s2n_post_handshake_recv(conn));
+            EXPECT_ERROR(s2n_post_handshake_recv(conn));
             EXPECT_FALSE(conn->key_update_pending);
 
             EXPECT_SUCCESS(s2n_connection_free(conn)); 
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->in, key_update_message.data, key_update_message.size));
             }
 
-            EXPECT_SUCCESS(s2n_post_handshake_recv(conn));
+            EXPECT_OK(s2n_post_handshake_recv(conn));
 
             /* All three key update messages have been read */
             EXPECT_EQUAL(s2n_stuffer_data_available(&conn->in), 0);
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->in, TLS_HELLO_REQUEST));
             EXPECT_SUCCESS(s2n_stuffer_write_uint24(&conn->in, 0));
-            EXPECT_SUCCESS(s2n_post_handshake_recv(conn));
+            EXPECT_OK(s2n_post_handshake_recv(conn));
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         }
@@ -154,7 +154,7 @@ int main(int argc, char **argv)
 
                 EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->in, state_machine[i].message_type));
                 EXPECT_SUCCESS(s2n_stuffer_write_uint24(&conn->in, 0));
-                EXPECT_FAILURE_WITH_ERRNO(s2n_post_handshake_recv(conn), S2N_ERR_BAD_MESSAGE);
+                EXPECT_ERROR_WITH_ERRNO(s2n_post_handshake_recv(conn), S2N_ERR_BAD_MESSAGE);
 
                 EXPECT_SUCCESS(s2n_connection_free(conn));
             }
@@ -171,7 +171,7 @@ int main(int argc, char **argv)
 
                 EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->in, tls13_state_machine[i].message_type));
                 EXPECT_SUCCESS(s2n_stuffer_write_uint24(&conn->in, 0));
-                EXPECT_FAILURE_WITH_ERRNO(s2n_post_handshake_recv(conn), S2N_ERR_BAD_MESSAGE);
+                EXPECT_ERROR_WITH_ERRNO(s2n_post_handshake_recv(conn), S2N_ERR_BAD_MESSAGE);
 
                 EXPECT_SUCCESS(s2n_connection_free(conn));
             }

--- a/tests/unit/s2n_recv_post_handshake_test.c
+++ b/tests/unit/s2n_recv_post_handshake_test.c
@@ -271,6 +271,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(tickets_count, 0);
 
         /* Restore the full input to unblock the connection */
+        // cppcheck-suppress redundantAssignment
         client_in.write_cursor = write_cursor;
 
         EXPECT_EQUAL(s2n_recv(client_conn, app_data, sizeof(app_data), &blocked), sizeof(app_data));

--- a/tests/unit/s2n_recv_post_handshake_test.c
+++ b/tests/unit/s2n_recv_post_handshake_test.c
@@ -271,7 +271,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(tickets_count, 0);
 
         /* Restore the full input to unblock the connection */
-        // cppcheck-suppress redundantAssignment
+        /* cppcheck-suppress redundantAssignment */
         client_in.write_cursor = write_cursor;
 
         EXPECT_EQUAL(s2n_recv(client_conn, app_data, sizeof(app_data), &blocked), sizeof(app_data));

--- a/tests/unit/s2n_recv_post_handshake_test.c
+++ b/tests/unit/s2n_recv_post_handshake_test.c
@@ -1,0 +1,394 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/param.h>
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "error/s2n_errno.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_post_handshake.h"
+#include "tls/s2n_tls.h"
+#include "utils/s2n_safety.h"
+
+int s2n_ticket_count_cb(struct s2n_connection *conn, void *ctx, struct s2n_session_ticket *ticket)
+{
+    uint8_t *count = (uint8_t *) ctx;
+    (*count)++;
+    return S2N_SUCCESS;
+}
+
+S2N_RESULT s2n_test_enable_tickets(struct s2n_config *config)
+{
+    RESULT_ENSURE_REF(config);
+
+    uint8_t ticket_key_name[16] = "key name";
+    uint8_t ticket_key[] = "key data";
+
+    uint64_t current_time = 0;
+    RESULT_GUARD_POSIX(config->wall_clock(config->sys_clock_ctx, &current_time));
+
+    RESULT_GUARD_POSIX(s2n_config_set_session_tickets_onoff(config, 1));
+    RESULT_GUARD_POSIX(s2n_config_add_ticket_crypto_key(config, ticket_key_name, strlen((char *)ticket_key_name),
+                    ticket_key, sizeof(ticket_key), current_time/ONE_SEC_IN_NANOS));
+
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_test_init_client_and_server(struct s2n_config *config,
+        struct s2n_connection *client_conn, struct s2n_connection *server_conn,
+        struct s2n_test_io_pair *io_pair)
+{
+    RESULT_ENSURE_REF(config);
+    RESULT_GUARD(s2n_test_enable_tickets(config));
+
+    RESULT_ENSURE_REF(client_conn);
+    RESULT_GUARD_POSIX(s2n_connection_set_config(client_conn, config));
+    RESULT_GUARD(s2n_connection_set_secrets(client_conn));
+
+    RESULT_ENSURE_REF(server_conn);
+    RESULT_GUARD_POSIX(s2n_connection_set_config(server_conn, config));
+    RESULT_GUARD(s2n_connection_set_secrets(server_conn));
+
+    RESULT_ENSURE_REF(io_pair);
+    EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(io_pair));
+    EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, io_pair));
+
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_test_write_nst_messages(struct s2n_connection *conn, struct s2n_stuffer *messages, size_t message_count)
+{
+    RESULT_GUARD_POSIX(s2n_stuffer_growable_alloc(messages, 0));
+    for (size_t i = 0; i < message_count; i++) {
+        RESULT_GUARD(s2n_tls13_server_nst_write(conn, messages));
+    }
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_test_send_nst_records(struct s2n_connection *conn, struct s2n_stuffer *messages, size_t record_count)
+{
+    size_t fragment_size = (s2n_stuffer_data_available(messages) / (record_count));
+    if (s2n_stuffer_data_available(messages) % record_count != 0) {
+        fragment_size++;
+    }
+
+    DEFER_CLEANUP(struct s2n_blob record_data = { 0 }, s2n_free);
+    RESULT_GUARD_POSIX(s2n_alloc(&record_data, fragment_size));
+
+    s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+    uint32_t remaining = 0;
+    while((remaining = s2n_stuffer_data_available(messages)) > 0){
+        record_data.size = MIN(record_data.size, remaining);
+        RESULT_GUARD_POSIX(s2n_stuffer_read(messages, &record_data));
+        RESULT_ENSURE_EQ(s2n_record_write(conn, TLS_HANDSHAKE, &record_data), record_data.size);
+        RESULT_GUARD_POSIX(s2n_flush(conn, &blocked));
+    };
+
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_get_seq_num(uint8_t *seq_num_bytes, uint64_t *seq_num)
+{
+    struct s2n_blob seq_num_blob = { 0 };
+    RESULT_GUARD_POSIX(s2n_blob_init(&seq_num_blob, seq_num_bytes, S2N_TLS_SEQUENCE_NUM_LEN));
+
+    struct s2n_stuffer seq_num_stuffer = { 0 };
+    RESULT_GUARD_POSIX(s2n_stuffer_init(&seq_num_stuffer, &seq_num_blob));
+    RESULT_GUARD_POSIX(s2n_stuffer_skip_write(&seq_num_stuffer, S2N_TLS_SEQUENCE_NUM_LEN));
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint64(&seq_num_stuffer, seq_num));
+
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_test_recv(struct s2n_config *config,
+        struct s2n_connection *client_conn, struct s2n_connection *server_conn,
+        uint8_t expected_messages, uint8_t expected_records)
+{
+    uint8_t tickets_count = 0;
+    RESULT_GUARD_POSIX(s2n_config_set_session_ticket_cb(config, s2n_ticket_count_cb, &tickets_count));
+
+    s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+    uint8_t app_data[1] = { 0 };
+    RESULT_ENSURE_EQ(s2n_send(server_conn, app_data, sizeof(app_data), &blocked), sizeof(app_data));
+    RESULT_ENSURE_EQ(s2n_recv(client_conn, app_data, sizeof(app_data), &blocked), sizeof(app_data));
+
+    /* Verify post-handshake message count.
+     * We should have received one ticket for each message. */
+    RESULT_ENSURE_EQ(tickets_count, expected_messages);
+
+    /* Verify record count.
+     * We can get the number of records received by the client
+     * by looking at the client's view of the server's sequence number.
+     */
+    uint64_t seq_num = 0;
+    RESULT_GUARD(s2n_get_seq_num(client_conn->secure.server_sequence_number, &seq_num));
+    /*
+     * We should have received one more record than "expected",
+     * because we sent and received one ApplicationData record.
+     */
+    RESULT_ENSURE_EQ(seq_num, expected_records + 1);
+
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_basic_recv_test(uint8_t expected_messages, uint8_t expected_records)
+{
+    DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+    DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+    DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+    DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+    RESULT_GUARD(s2n_test_init_client_and_server(config, client_conn, server_conn, &io_pair));
+
+    DEFER_CLEANUP(struct s2n_stuffer messages = { 0 }, s2n_stuffer_free);
+    RESULT_GUARD(s2n_test_write_nst_messages(server_conn, &messages, expected_messages));
+    RESULT_GUARD(s2n_test_send_nst_records(server_conn, &messages, expected_records));
+    RESULT_GUARD(s2n_test_recv(config, client_conn, server_conn, expected_messages, expected_records));
+    return S2N_RESULT_OK;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Recv a single record with a single post-handshake message */
+    {
+        const uint8_t expected_messages = 1;
+        const uint8_t expected_records = 1;
+        EXPECT_OK(s2n_basic_recv_test(expected_messages, expected_records));
+    }
+
+    /* Recv a single record with multiple post-handshake messages */
+    {
+        const uint8_t expected_messages = 5;
+        const uint8_t expected_records = 1;
+        EXPECT_OK(s2n_basic_recv_test(expected_messages, expected_records));
+    }
+
+    /* Recv multiple records with a single fragmented post-handshake message */
+    {
+        /* Split message across two records */
+        {
+            const uint8_t expected_messages = 1;
+            const uint8_t expected_records = 2;
+            EXPECT_OK(s2n_basic_recv_test(expected_messages, expected_records));
+        }
+
+        /* Split message across many records */
+        {
+            const uint8_t expected_messages = 1;
+            const uint8_t expected_records = 5;
+            EXPECT_OK(s2n_basic_recv_test(expected_messages, expected_records));
+        }
+
+        /* Split message into fragments smaller than the message header */
+        {
+            const uint8_t expected_messages = 1;
+
+            DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+            DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+            DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_init_client_and_server(config, client_conn, server_conn, &io_pair));
+
+            DEFER_CLEANUP(struct s2n_stuffer messages = { 0 }, s2n_stuffer_free);
+            EXPECT_OK(s2n_test_write_nst_messages(server_conn, &messages, expected_messages));
+
+            /* Split the messages into single byte fragments,
+             * ensuring that we have to read multiple records to reconstruct the header.
+             */
+            uint32_t expected_records = s2n_stuffer_data_available(&messages);
+            EXPECT_OK(s2n_test_send_nst_records(server_conn, &messages, expected_records));
+
+            EXPECT_OK(s2n_test_recv(config, client_conn, server_conn, expected_messages, expected_records));
+        }
+    }
+
+    /* Recv multiple records with multiple post-handshake messages */
+    {
+        const uint8_t expected_messages = 10;
+        const uint8_t expected_records = 3;
+        EXPECT_OK(s2n_basic_recv_test(expected_messages, expected_records));
+    }
+
+    /* Recv blocks while reading fragmented post-handshake messages */
+    {
+        const uint8_t expected_messages = 1;
+        const uint8_t expected_records = 2;
+
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+        EXPECT_OK(s2n_test_init_client_and_server(config, client_conn, server_conn, &io_pair));
+
+        /* Use stuffer io to control blocking */
+        DEFER_CLEANUP(struct s2n_stuffer server_in, s2n_stuffer_free);
+        DEFER_CLEANUP(struct s2n_stuffer client_in, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_in, 0));
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_in, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_in, &client_in, server_conn));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&client_in, &server_in, client_conn));
+
+        uint8_t tickets_count = 0;
+        EXPECT_SUCCESS(s2n_config_set_session_ticket_cb(config, s2n_ticket_count_cb, &tickets_count));
+
+        DEFER_CLEANUP(struct s2n_stuffer messages = { 0 }, s2n_stuffer_free);
+        EXPECT_OK(s2n_test_write_nst_messages(server_conn, &messages, expected_messages));
+        EXPECT_OK(s2n_test_send_nst_records(server_conn, &messages, expected_records));
+        uint32_t messages_len = s2n_stuffer_data_available(&client_in);
+
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+        uint8_t app_data[1] = { 0 };
+        EXPECT_EQUAL(s2n_send(server_conn, app_data, sizeof(app_data), &blocked), sizeof(app_data));
+
+        /* Drop some bytes off the end of the input so that
+         * reading the last handshake record will block.
+         */
+        uint32_t write_cursor = client_in.write_cursor;
+        client_in.write_cursor = messages_len - 1;
+
+        uint64_t seq_num = 0;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_recv(client_conn, app_data, sizeof(app_data), &blocked), S2N_ERR_IO_BLOCKED);
+        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
+        EXPECT_OK(s2n_get_seq_num(client_conn->secure.server_sequence_number, &seq_num));
+
+        /* One record successfully read, but not a full message yet */
+        EXPECT_EQUAL(seq_num, 1 /* 1 handshake */ );
+        EXPECT_EQUAL(tickets_count, 0);
+
+        /* Restore the full input to unblock the connection */
+        client_in.write_cursor = write_cursor;
+
+        EXPECT_EQUAL(s2n_recv(client_conn, app_data, sizeof(app_data), &blocked), sizeof(app_data));
+        EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+        EXPECT_OK(s2n_get_seq_num(client_conn->secure.server_sequence_number, &seq_num));
+
+        /* Both records read and the message processed */
+        EXPECT_EQUAL(seq_num, 3 /* 2 handshake + 1 app data */);
+        EXPECT_EQUAL(tickets_count, 1);
+    }
+
+    /* Test conn->post_handshake.in memory management */
+    {
+        const uint8_t expected_messages = 3;
+        const uint8_t expected_records = 2;
+
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+        EXPECT_OK(s2n_test_init_client_and_server(config, client_conn, server_conn, &io_pair));
+
+        /* Initially uninitialized, but growable */
+        EXPECT_EQUAL(client_conn->post_handshake.in.blob.data, NULL);
+        EXPECT_EQUAL(client_conn->post_handshake.in.blob.size, 0);
+        EXPECT_EQUAL(client_conn->post_handshake.in.growable, true);
+
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+        uint8_t app_data[1] = { 0 };
+        uint64_t seq_num = 0;
+
+        /* Allocated for fragmented handshake message */
+        {
+            DEFER_CLEANUP(struct s2n_stuffer messages = { 0 }, s2n_stuffer_free);
+            EXPECT_OK(s2n_test_write_nst_messages(server_conn, &messages, expected_messages));
+            EXPECT_OK(s2n_test_send_nst_records(server_conn, &messages, expected_records));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_recv(client_conn, app_data, sizeof(app_data), &blocked), S2N_ERR_IO_BLOCKED);
+            EXPECT_OK(s2n_get_seq_num(client_conn->secure.server_sequence_number, &seq_num));
+            EXPECT_EQUAL(seq_num, expected_records);
+
+            EXPECT_NOT_EQUAL(client_conn->post_handshake.in.blob.size, 0);
+        }
+
+        /* Kept after handshake message / reused for multiple handshake messages */
+        {
+            uint8_t *old_mem = client_conn->post_handshake.in.blob.data;
+
+            DEFER_CLEANUP(struct s2n_stuffer messages = { 0 }, s2n_stuffer_free);
+            EXPECT_OK(s2n_test_write_nst_messages(server_conn, &messages, expected_messages));
+            EXPECT_OK(s2n_test_send_nst_records(server_conn, &messages, expected_records));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_recv(client_conn, app_data, sizeof(app_data), &blocked), S2N_ERR_IO_BLOCKED);
+            EXPECT_OK(s2n_get_seq_num(client_conn->secure.server_sequence_number, &seq_num));
+            EXPECT_EQUAL(seq_num, expected_records * 2);
+
+            EXPECT_NOT_EQUAL(client_conn->post_handshake.in.blob.size, 0);
+            EXPECT_EQUAL(old_mem, client_conn->post_handshake.in.blob.data);
+        }
+
+        /* Freed after successful s2n_recv call */
+        {
+            EXPECT_EQUAL(s2n_send(server_conn, app_data, sizeof(app_data), &blocked), sizeof(app_data));
+            EXPECT_EQUAL(s2n_recv(client_conn, app_data, sizeof(app_data), &blocked), sizeof(app_data));
+            EXPECT_EQUAL(client_conn->post_handshake.in.blob.size, 0);
+        }
+    }
+
+    /*
+     *= https://tools.ietf.org/rfc/rfc8446#section-5.1
+     *= type=test
+     *#    -  Handshake messages MUST NOT be interleaved with other record
+     *#       types.  That is, if a handshake message is split over two or more
+     *#       records, there MUST NOT be any other records between them.
+     */
+    {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+        EXPECT_OK(s2n_test_init_client_and_server(config, client_conn, server_conn, &io_pair));
+
+        uint8_t tickets_count = 0;
+        EXPECT_SUCCESS(s2n_config_set_session_ticket_cb(config, s2n_ticket_count_cb, &tickets_count));
+
+        DEFER_CLEANUP(struct s2n_stuffer messages = { 0 }, s2n_stuffer_free);
+        EXPECT_OK(s2n_test_write_nst_messages(server_conn, &messages, 1));
+
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+
+        /* Send a fragment of a post-handshake message */
+        DEFER_CLEANUP(struct s2n_blob record_data = { 0 }, s2n_free);
+        EXPECT_SUCCESS(s2n_realloc(&record_data, 10));
+        EXPECT_SUCCESS(s2n_stuffer_read(&messages, &record_data));
+        EXPECT_EQUAL(s2n_record_write(server_conn, TLS_HANDSHAKE, &record_data), record_data.size);
+        EXPECT_SUCCESS(s2n_flush(server_conn, &blocked));
+
+        /* Send Application Data.
+         * (Just reuse the last data we sent, but with a different record type) */
+        EXPECT_EQUAL(s2n_record_write(server_conn, TLS_APPLICATION_DATA, &record_data), record_data.size);
+        EXPECT_SUCCESS(s2n_flush(server_conn, &blocked));
+
+        /* Send the rest of the post-handshake message */
+        EXPECT_SUCCESS(s2n_realloc(&record_data, s2n_stuffer_data_available(&messages)));
+        EXPECT_SUCCESS(s2n_stuffer_read(&messages, &record_data));
+        EXPECT_EQUAL(s2n_record_write(server_conn, TLS_HANDSHAKE, &record_data), record_data.size);
+        EXPECT_SUCCESS(s2n_flush(server_conn, &blocked));
+
+        uint64_t seq_num = 0;
+        uint8_t app_data[1] = { 0 };
+        EXPECT_FAILURE_WITH_ERRNO(s2n_recv(client_conn, app_data, sizeof(app_data), &blocked), S2N_ERR_BAD_MESSAGE);
+        EXPECT_OK(s2n_get_seq_num(client_conn->secure.server_sequence_number, &seq_num));
+
+        /* The error occurred when processing the unexpected application data record,
+         * so we've read both the first handshake record and the application data record. */
+        EXPECT_EQUAL(seq_num, 2);
+        EXPECT_EQUAL(tickets_count, 0);
+    }
+
+    END_TEST();
+}

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -353,6 +353,7 @@ int s2n_connection_free(struct s2n_connection *conn)
     POSIX_GUARD(s2n_stuffer_free(&conn->in));
     POSIX_GUARD(s2n_stuffer_free(&conn->out));
     POSIX_GUARD(s2n_stuffer_free(&conn->handshake.io));
+    POSIX_GUARD(s2n_stuffer_free(&conn->post_handshake.in));
     s2n_x509_validator_wipe(&conn->x509_validator);
     POSIX_GUARD(s2n_client_hello_free(&conn->client_hello));
     POSIX_GUARD(s2n_free(&conn->application_protocols_overridden));
@@ -477,6 +478,9 @@ int s2n_connection_release_buffers(struct s2n_connection *conn)
     POSIX_ENSURE(s2n_stuffer_is_consumed(&conn->in), S2N_ERR_STUFFER_HAS_UNPROCESSED_DATA);
     POSIX_GUARD(s2n_stuffer_resize(&conn->in, 0));
 
+    POSIX_ENSURE(s2n_stuffer_is_consumed(&conn->post_handshake.in), S2N_ERR_STUFFER_HAS_UNPROCESSED_DATA);
+    POSIX_GUARD(s2n_stuffer_resize(&conn->post_handshake.in, 0));
+
     POSIX_POSTCONDITION(s2n_stuffer_validate(&conn->out));
     POSIX_POSTCONDITION(s2n_stuffer_validate(&conn->in));
     return S2N_SUCCESS;
@@ -502,6 +506,11 @@ int s2n_connection_free_handshake(struct s2n_connection *conn)
     POSIX_GUARD(s2n_free(&conn->our_quic_transport_parameters));
     POSIX_GUARD(s2n_free(&conn->application_protocols_overridden));
     POSIX_GUARD(s2n_free(&conn->cookie));
+
+    /* We can free any post handshake buffers, if not currently in use */
+    if (s2n_stuffer_is_consumed(&conn->post_handshake.in)) {
+        POSIX_GUARD(s2n_stuffer_resize(&conn->post_handshake.in, 0));
+    }
 
     return 0;
 }
@@ -555,10 +564,14 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     POSIX_GUARD(s2n_stuffer_wipe(&conn->writer_alert_out));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->client_ticket_to_decrypt));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
+    POSIX_GUARD(s2n_stuffer_wipe(&conn->post_handshake.in));
     POSIX_GUARD(s2n_blob_zero(&conn->client_hello.raw_message));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->out));
+
+    /* Free stuffers we plan to just recreate */
+    POSIX_GUARD(s2n_stuffer_free(&conn->post_handshake.in));
 
     POSIX_GUARD_RESULT(s2n_psk_parameters_wipe(&conn->psk_params));
 
@@ -629,6 +642,9 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     POSIX_GUARD(s2n_connection_restore_hmac_state(conn, &hmac_handles));
     conn->handshake.hashes = handshake_hashes;
     conn->prf_space = prf_workspace;
+
+    /* Setup resizeable buffers */
+    POSIX_GUARD(s2n_stuffer_growable_alloc(&conn->post_handshake.in, 0));
 
     /* Re-initialize hash and hmac states */
     POSIX_GUARD(s2n_connection_init_hmacs(conn));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -507,11 +507,6 @@ int s2n_connection_free_handshake(struct s2n_connection *conn)
     POSIX_GUARD(s2n_free(&conn->application_protocols_overridden));
     POSIX_GUARD(s2n_free(&conn->cookie));
 
-    /* We can free any post handshake buffers, if not currently in use */
-    if (s2n_stuffer_is_consumed(&conn->post_handshake.in)) {
-        POSIX_GUARD(s2n_stuffer_resize(&conn->post_handshake.in, 0));
-    }
-
     return 0;
 }
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -30,6 +30,7 @@
 #include "tls/s2n_handshake.h"
 #include "tls/s2n_kem_preferences.h"
 #include "tls/s2n_key_update.h"
+#include "tls/s2n_post_handshake.h"
 #include "tls/s2n_prf.h"
 #include "tls/s2n_quic_support.h"
 #include "tls/s2n_record.h"
@@ -374,6 +375,8 @@ struct s2n_connection {
     uint32_t server_max_early_data_size;
     struct s2n_blob server_early_data_context;
     uint32_t server_keying_material_lifetime;
+
+    struct s2n_post_handshake post_handshake;
 };
 
 S2N_CLEANUP_RESULT s2n_connection_ptr_free(struct s2n_connection **s2n_connection);

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -57,7 +57,7 @@ int s2n_handshake_finish_header(struct s2n_stuffer *out)
     return S2N_SUCCESS;
 }
 
-S2N_RESULT s2n_handshake_parse_header(struct s2n_connection *conn, struct s2n_stuffer *io, uint8_t * message_type, uint32_t * length)
+S2N_RESULT s2n_handshake_parse_header(struct s2n_stuffer *io, uint8_t * message_type, uint32_t * length)
 {
     RESULT_ENSURE(s2n_stuffer_data_available(io) >= TLS_HANDSHAKE_HEADER_LENGTH, S2N_ERR_SIZE_MISMATCH);
 

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -57,15 +57,15 @@ int s2n_handshake_finish_header(struct s2n_stuffer *out)
     return S2N_SUCCESS;
 }
 
-int s2n_handshake_parse_header(struct s2n_connection *conn, uint8_t * message_type, uint32_t * length)
+S2N_RESULT s2n_handshake_parse_header(struct s2n_connection *conn, struct s2n_stuffer *io, uint8_t * message_type, uint32_t * length)
 {
-    S2N_ERROR_IF(s2n_stuffer_data_available(&conn->handshake.io) < TLS_HANDSHAKE_HEADER_LENGTH, S2N_ERR_SIZE_MISMATCH);
+    RESULT_ENSURE(s2n_stuffer_data_available(io) >= TLS_HANDSHAKE_HEADER_LENGTH, S2N_ERR_SIZE_MISMATCH);
 
     /* read the message header */
-    POSIX_GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, message_type));
-    POSIX_GUARD(s2n_stuffer_read_uint24(&conn->handshake.io, length));
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(io, message_type));
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint24(io, length));
 
-    return S2N_SUCCESS;
+    return S2N_RESULT_OK;
 }
 
 static int s2n_handshake_get_hash_state_ptr(struct s2n_connection *conn, s2n_hash_algorithm hash_alg, struct s2n_hash_state **hash_state)

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1017,48 +1017,41 @@ static int s2n_handshake_write_io(struct s2n_connection *conn)
     return S2N_SUCCESS;
 }
 
-/*
- * Returns:
- *  1  - more data is needed to complete the handshake message.
- *  0  - we read the whole handshake message.
- * -1  - error processing the handshake message.
- */
-static int s2n_read_full_handshake_message(struct s2n_connection *conn, uint8_t *message_type)
+S2N_RESULT s2n_read_full_handshake_message(struct s2n_connection *conn, struct s2n_stuffer *io, uint8_t *message_type)
 {
-    uint32_t current_handshake_data = s2n_stuffer_data_available(&conn->handshake.io);
+    uint32_t current_handshake_data = s2n_stuffer_data_available(io);
     if (current_handshake_data < TLS_HANDSHAKE_HEADER_LENGTH) {
         /* The message may be so badly fragmented that we don't even read the full header, take
          * what we can and then continue to the next record read iteration.
          */
         if (s2n_stuffer_data_available(&conn->in) < (TLS_HANDSHAKE_HEADER_LENGTH - current_handshake_data)) {
-            POSIX_GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, s2n_stuffer_data_available(&conn->in)));
-            return 1;
+            RESULT_GUARD_POSIX(s2n_stuffer_copy(&conn->in, io, s2n_stuffer_data_available(&conn->in)));
+            RESULT_BAIL(S2N_ERR_IO_BLOCKED);
         }
 
         /* Get the remainder of the header */
-        POSIX_GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, (TLS_HANDSHAKE_HEADER_LENGTH - current_handshake_data)));
+        RESULT_GUARD_POSIX(s2n_stuffer_copy(&conn->in, io, (TLS_HANDSHAKE_HEADER_LENGTH - current_handshake_data)));
     }
 
-    uint32_t handshake_message_length;
-    POSIX_GUARD(s2n_handshake_parse_header(conn, message_type, &handshake_message_length));
+    uint32_t handshake_message_length = 0;
+    RESULT_GUARD(s2n_handshake_parse_header(conn, io, message_type, &handshake_message_length));
 
-    S2N_ERROR_IF(handshake_message_length > S2N_MAXIMUM_HANDSHAKE_MESSAGE_LENGTH, S2N_ERR_BAD_MESSAGE);
+    RESULT_ENSURE(handshake_message_length <= S2N_MAXIMUM_HANDSHAKE_MESSAGE_LENGTH, S2N_ERR_BAD_MESSAGE);
 
-    uint32_t bytes_to_take = handshake_message_length - s2n_stuffer_data_available(&conn->handshake.io);
+    uint32_t bytes_to_take = handshake_message_length - s2n_stuffer_data_available(io);
     bytes_to_take = MIN(bytes_to_take, s2n_stuffer_data_available(&conn->in));
 
     /* If the record is handshake data, add it to the handshake buffer */
-    POSIX_GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, bytes_to_take));
+    RESULT_GUARD_POSIX(s2n_stuffer_copy(&conn->in, io, bytes_to_take));
 
     /* If we have the whole handshake message, then success */
-    if (s2n_stuffer_data_available(&conn->handshake.io) == handshake_message_length) {
-        return 0;
+    if (s2n_stuffer_data_available(io) == handshake_message_length) {
+        return S2N_RESULT_OK;
     }
 
     /* We don't have the whole message, so we'll need to go again */
-    POSIX_GUARD(s2n_stuffer_reread(&conn->handshake.io));
-
-    return 1;
+    RESULT_GUARD_POSIX(s2n_stuffer_reread(io));
+    RESULT_BAIL(S2N_ERR_IO_BLOCKED);
 }
 
 static int s2n_handshake_conn_update_hashes(struct s2n_connection *conn)
@@ -1067,7 +1060,7 @@ static int s2n_handshake_conn_update_hashes(struct s2n_connection *conn)
     uint32_t handshake_message_length;
 
     POSIX_GUARD(s2n_stuffer_reread(&conn->handshake.io));
-    POSIX_GUARD(s2n_handshake_parse_header(conn, &message_type, &handshake_message_length));
+    POSIX_GUARD_RESULT(s2n_handshake_parse_header(conn, &conn->handshake.io, &message_type, &handshake_message_length));
 
     struct s2n_blob handshake_record = {0};
     handshake_record.data = conn->handshake.io.blob.data;
@@ -1247,11 +1240,10 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
     while (s2n_stuffer_data_available(&conn->in)) {
         /* We're done with negotiating but we have trailing data in this record. Bail on the handshake. */
         S2N_ERROR_IF(EXPECTED_RECORD_TYPE(conn) == TLS_APPLICATION_DATA, S2N_ERR_BAD_MESSAGE);
-        int r;
-        POSIX_GUARD((r = s2n_read_full_handshake_message(conn, &message_type)));
 
+        s2n_result r = s2n_read_full_handshake_message(conn, &conn->handshake.io, &message_type);
         /* Do we need more data? This happens for message fragmentation */
-        if (r == 1) {
+        if (!s2n_result_is_ok(r) && s2n_errno == S2N_ERR_IO_BLOCKED) {
             /* Break out of this inner loop, but since we're not changing the state, the
              * outer loop in s2n_handshake_io() will read another record.
              */

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1034,7 +1034,7 @@ S2N_RESULT s2n_read_full_handshake_message(struct s2n_connection *conn, struct s
     }
 
     uint32_t handshake_message_length = 0;
-    RESULT_GUARD(s2n_handshake_parse_header(conn, io, message_type, &handshake_message_length));
+    RESULT_GUARD(s2n_handshake_parse_header(io, message_type, &handshake_message_length));
 
     RESULT_ENSURE(handshake_message_length <= S2N_MAXIMUM_HANDSHAKE_MESSAGE_LENGTH, S2N_ERR_BAD_MESSAGE);
 
@@ -1060,7 +1060,7 @@ static int s2n_handshake_conn_update_hashes(struct s2n_connection *conn)
     uint32_t handshake_message_length;
 
     POSIX_GUARD(s2n_stuffer_reread(&conn->handshake.io));
-    POSIX_GUARD_RESULT(s2n_handshake_parse_header(conn, &conn->handshake.io, &message_type, &handshake_message_length));
+    POSIX_GUARD_RESULT(s2n_handshake_parse_header(&conn->handshake.io, &message_type, &handshake_message_length));
 
     struct s2n_blob handshake_record = {0};
     handshake_record.data = conn->handshake.io.blob.data;

--- a/tls/s2n_post_handshake.c
+++ b/tls/s2n_post_handshake.c
@@ -20,59 +20,116 @@
 #include "tls/s2n_tls.h"
 #include "utils/s2n_safety.h"
 
-int s2n_post_handshake_recv(struct s2n_connection *conn) 
+static S2N_RESULT s2n_post_handshake_process(struct s2n_connection *conn, struct s2n_stuffer *in, uint8_t message_type)
 {
-    POSIX_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(in);
 
-    uint8_t post_handshake_id;
-    uint32_t message_length;
+    switch (message_type)
+    {
+        case TLS_KEY_UPDATE:
+            RESULT_GUARD_POSIX(s2n_key_update_recv(conn, in));
+            break;
+        case TLS_SERVER_NEW_SESSION_TICKET:
+            RESULT_GUARD(s2n_tls13_server_nst_recv(conn, in));
+            break;
+        case TLS_HELLO_REQUEST:
+            RESULT_GUARD_POSIX(s2n_client_hello_request_recv(conn));
+            break;
+        case TLS_CLIENT_HELLO:
+        case TLS_SERVER_HELLO:
+        case TLS_END_OF_EARLY_DATA:
+        case TLS_ENCRYPTED_EXTENSIONS:
+        case TLS_CERTIFICATE:
+        case TLS_SERVER_KEY:
+        case TLS_CERT_REQ:
+        case TLS_SERVER_HELLO_DONE:
+        case TLS_CERT_VERIFY:
+        case TLS_CLIENT_KEY:
+        case TLS_FINISHED:
+        case TLS_SERVER_CERT_STATUS:
+            /* All other known handshake messages should be rejected */
+            RESULT_BAIL(S2N_ERR_BAD_MESSAGE);
+            break;
+        default:
+            /* Ignore all other messages */
+            break;
+    }
+
+    return S2N_RESULT_OK;
+}
+
+/*
+ * Attempt to read a full handshake message.
+ * If we fail, don't modify the input buffer so that we can attempt different processing.
+ */
+static S2N_RESULT s2n_try_read_full_handshake_message(struct s2n_connection *conn, uint8_t *message_type, uint32_t *message_len)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(message_len);
+
+    struct s2n_stuffer in_copy = conn->in;
+    if (s2n_stuffer_data_available(&in_copy) >= TLS_HANDSHAKE_HEADER_LENGTH) {
+       RESULT_GUARD(s2n_handshake_parse_header(conn, &in_copy, message_type, message_len));
+       if (s2n_stuffer_data_available(&in_copy) >= *message_len) {
+           conn->in = in_copy;
+           return S2N_RESULT_OK;
+       }
+    }
+    RESULT_BAIL(S2N_ERR_IO_BLOCKED);
+}
+
+S2N_RESULT s2n_post_handshake_recv(struct s2n_connection *conn)
+{
+    RESULT_ENSURE_REF(conn);
+
+    uint8_t message_type = 0;
+    uint32_t message_len = 0;
 
     while(s2n_stuffer_data_available(&conn->in)) {
-        POSIX_GUARD(s2n_stuffer_read_uint8(&conn->in, &post_handshake_id));
-        POSIX_GUARD(s2n_stuffer_read_uint24(&conn->in, &message_length));
 
-        struct s2n_blob post_handshake_blob = { 0 };
-        uint8_t *message_data = s2n_stuffer_raw_read(&conn->in, message_length);
-        POSIX_ENSURE_REF(message_data);
-        POSIX_GUARD(s2n_blob_init(&post_handshake_blob, message_data, message_length));
+        /* We have buffered a partial message.
+         * Continue trying to read the complete message.
+         */
+        if (s2n_stuffer_data_available(&conn->post_handshake.in) > 0) {
+            RESULT_GUARD(s2n_read_full_handshake_message(conn, &conn->post_handshake.in, &message_type));
+            RESULT_GUARD(s2n_post_handshake_process(conn, &conn->post_handshake.in, message_type));
+            RESULT_GUARD_POSIX(s2n_stuffer_wipe(&conn->post_handshake.in));
+        }
 
-        struct s2n_stuffer post_handshake_stuffer = { 0 };
-        POSIX_GUARD(s2n_stuffer_init(&post_handshake_stuffer, &post_handshake_blob));
-        POSIX_GUARD(s2n_stuffer_skip_write(&post_handshake_stuffer, message_length));
+        /* Because post-handshake messages are not necessarily common compared
+         * to application data, we don't want to keep a dedicated buffer for them.
+         * However, we also don't want to unnecessarily allocate large chunks of memory.
+         *
+         * Therefore, if the handshake message isn't fragmented, just read it from conn->in.
+         * Only allocate new memory if we need to combine multiple fragments.
+         */
+        else if (s2n_result_is_ok(s2n_try_read_full_handshake_message(conn, &message_type, &message_len))) {
+            struct s2n_blob message_blob = { 0 };
+            uint8_t *message_data = s2n_stuffer_raw_read(&conn->in, message_len);
+            RESULT_ENSURE_REF(message_data);
+            RESULT_GUARD_POSIX(s2n_blob_init(&message_blob, message_data, message_len));
 
-        switch (post_handshake_id)
-        {
-            case TLS_KEY_UPDATE:
-                POSIX_GUARD(s2n_key_update_recv(conn, &post_handshake_stuffer));
-                break;
-            case TLS_SERVER_NEW_SESSION_TICKET:
-                POSIX_GUARD_RESULT(s2n_tls13_server_nst_recv(conn, &post_handshake_stuffer));
-                break;
-            case TLS_HELLO_REQUEST:
-                POSIX_GUARD(s2n_client_hello_request_recv(conn));
-                break;
-            case TLS_CLIENT_HELLO:
-            case TLS_SERVER_HELLO:
-            case TLS_END_OF_EARLY_DATA:
-            case TLS_ENCRYPTED_EXTENSIONS:
-            case TLS_CERTIFICATE:
-            case TLS_SERVER_KEY:
-            case TLS_CERT_REQ:
-            case TLS_SERVER_HELLO_DONE:
-            case TLS_CERT_VERIFY:
-            case TLS_CLIENT_KEY:
-            case TLS_FINISHED:
-            case TLS_SERVER_CERT_STATUS:
-                /* All other known handshake messages should be rejected */
-                POSIX_BAIL(S2N_ERR_BAD_MESSAGE);
-                break;
-            default:
-                /* Ignore all other messages */
-                break;
+            struct s2n_stuffer message_stuffer = { 0 };
+            RESULT_GUARD_POSIX(s2n_stuffer_init(&message_stuffer, &message_blob));
+            RESULT_GUARD_POSIX(s2n_stuffer_skip_write(&message_stuffer, message_len));
+
+            RESULT_GUARD(s2n_post_handshake_process(conn, &message_stuffer, message_type));
+        }
+
+        /* If we can't read a full message, we'll need to buffer the partial message
+         * so that we can read a new record.
+         */
+        else {
+            uint32_t remaining = s2n_stuffer_data_available(&conn->in);
+            RESULT_ENSURE_LTE(remaining, S2N_LARGE_RECORD_LENGTH);
+            RESULT_GUARD_POSIX(s2n_stuffer_resize_if_empty(&conn->post_handshake.in, S2N_LARGE_RECORD_LENGTH));
+            RESULT_GUARD_POSIX(s2n_stuffer_copy(&conn->in, &conn->post_handshake.in, remaining));
+            RESULT_BAIL(S2N_ERR_IO_BLOCKED);
         }
     }
 
-    return S2N_SUCCESS;
+    return S2N_RESULT_OK;
 }
 
 int s2n_post_handshake_send(struct s2n_connection *conn, s2n_blocked_status *blocked)

--- a/tls/s2n_post_handshake.h
+++ b/tls/s2n_post_handshake.h
@@ -15,7 +15,11 @@
 
 #pragma once
 
-#include "tls/s2n_connection.h"
+struct s2n_connection;
 
-int s2n_post_handshake_recv(struct s2n_connection *conn);
+struct s2n_post_handshake {
+    struct s2n_stuffer in;
+};
+
+S2N_RESULT s2n_post_handshake_recv(struct s2n_connection *conn);
 int s2n_post_handshake_send(struct s2n_connection *conn, s2n_blocked_status *blocked);

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -105,7 +105,7 @@ S2N_RESULT s2n_quic_read_handshake_message(struct s2n_connection *conn, uint8_t 
     RESULT_GUARD(s2n_read_in_bytes(conn, &conn->handshake.io, TLS_HANDSHAKE_HEADER_LENGTH));
 
     uint32_t message_len;
-    RESULT_GUARD_POSIX(s2n_handshake_parse_header(conn, message_type, &message_len));
+    RESULT_GUARD(s2n_handshake_parse_header(conn, &conn->handshake.io, message_type, &message_len));
     RESULT_GUARD_POSIX(s2n_stuffer_reread(&conn->handshake.io));
 
     RESULT_ENSURE(message_len < S2N_MAXIMUM_HANDSHAKE_MESSAGE_LENGTH, S2N_ERR_BAD_MESSAGE);

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -105,7 +105,7 @@ S2N_RESULT s2n_quic_read_handshake_message(struct s2n_connection *conn, uint8_t 
     RESULT_GUARD(s2n_read_in_bytes(conn, &conn->handshake.io, TLS_HANDSHAKE_HEADER_LENGTH));
 
     uint32_t message_len;
-    RESULT_GUARD(s2n_handshake_parse_header(conn, &conn->handshake.io, message_type, &message_len));
+    RESULT_GUARD(s2n_handshake_parse_header(&conn->handshake.io, message_type, &message_len));
     RESULT_GUARD_POSIX(s2n_stuffer_reread(&conn->handshake.io));
 
     RESULT_ENSURE(message_len < S2N_MAXIMUM_HANDSHAKE_MESSAGE_LENGTH, S2N_ERR_BAD_MESSAGE);

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -167,7 +167,8 @@ ssize_t s2n_recv_impl(struct s2n_connection * conn, void *buf, ssize_t size, s2n
             POSIX_ENSURE(s2n_stuffer_is_wiped(&conn->post_handshake.in), S2N_ERR_BAD_MESSAGE);
 
             /* If not handling a handshake message, free the post-handshake memory.
-             * If this causes too much churn, we could consider hanging onto the memory longer.
+             * Post-handshake messages are infrequent enough that we don't want to
+             * keep a potentially large buffer around unnecessarily.
              */
             if (!s2n_stuffer_is_freed(&conn->post_handshake.in)) {
                 POSIX_GUARD(s2n_stuffer_resize(&conn->post_handshake.in, 0));

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -78,7 +78,9 @@ extern int s2n_end_of_early_data_recv(struct s2n_connection *conn);
 extern int s2n_process_client_hello(struct s2n_connection *conn);
 extern int s2n_handshake_write_header(struct s2n_stuffer *out, uint8_t message_type);
 extern int s2n_handshake_finish_header(struct s2n_stuffer *out);
-extern int s2n_handshake_parse_header(struct s2n_connection *conn, uint8_t * message_type, uint32_t * length);
+S2N_RESULT s2n_handshake_parse_header(struct s2n_connection *conn, struct s2n_stuffer *io,
+        uint8_t *message_type, uint32_t *length);
+S2N_RESULT s2n_read_full_handshake_message(struct s2n_connection *conn, struct s2n_stuffer *io, uint8_t *message_type);
 extern int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int *isSSLv2);
 extern int s2n_recv_close_notify(struct s2n_connection *conn, s2n_blocked_status * blocked);
 

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -78,8 +78,7 @@ extern int s2n_end_of_early_data_recv(struct s2n_connection *conn);
 extern int s2n_process_client_hello(struct s2n_connection *conn);
 extern int s2n_handshake_write_header(struct s2n_stuffer *out, uint8_t message_type);
 extern int s2n_handshake_finish_header(struct s2n_stuffer *out);
-S2N_RESULT s2n_handshake_parse_header(struct s2n_connection *conn, struct s2n_stuffer *io,
-        uint8_t *message_type, uint32_t *length);
+S2N_RESULT s2n_handshake_parse_header(struct s2n_stuffer *io, uint8_t *message_type, uint32_t *length);
 S2N_RESULT s2n_read_full_handshake_message(struct s2n_connection *conn, struct s2n_stuffer *io, uint8_t *message_type);
 extern int s2n_read_full_record(struct s2n_connection *conn, uint8_t * record_type, int *isSSLv2);
 extern int s2n_recv_close_notify(struct s2n_connection *conn, s2n_blocked_status * blocked);


### PR DESCRIPTION
### Resolved issues:
Related to https://github.com/aws/s2n-tls/issues/3432, but cover s2n_recv instead of s2n_send.

### Description of changes: 

Currently, s2n-tls assumes that no post-handshake messages will be fragmented. This is not a valid assumption, since the RFC allows fragmenting of post-handshake messages just like any other handshake record. If s2n-tls currently receives a fragmented post-handshake message, the message fails to parse and the connection is closed with a blinded error.

After this change, s2n-tls can handle fragmented post-handshake messages. If dealing with complete messages, there's no behavior change: s2n-tls processes the message directly from conn->in. However, if we encounter a fragmented message, we allocate the new post_handshake.in buffer in order to store the fragment while we read the next record into conn->in.

The bulk of the changes are in s2n_recv and s2n_post_handshake. The other changes are largely just about reusing existing handshake parsing functions.

### Call-outs:

The memory here is tricky, since we don't have handshake.io to use to reconstruct fragmented messages. Currently, we allocate S2N_LARGE_RECORD_LENGTH (the same size allocated for handshake.io) if fragmented post-handshake messages are encountered, and free them on the next non-handshake record. Instead, we could:
* Allocate less than S2N_LARGE_RECORD_LENGTH. Post handshake messages tend to be much shorter than other handshake messages.
* Allocate EXACTLY enough memory for the current message. That could lead to a smaller allocation, but if we encounter multiple fragmented messages in a row, we'll potentially have to re-allocate to handle a larger message. It also adds potential complexity, since we'd still have to allocate the "maximum" size if the fragment is too small to contain the message size. I'm still very tempted to take this approach.
  * We could allocated the message size + some buffer space in case the next fragmented messages is slightly longer.
* "inherit" handshake.io. Once the handshake ends, instead of freeing handshake.io, we could move it to post_handshake.in. This would help the standard case of receiving session tickets immediately after a handshake. However, it complicates cleanup of handshake.io: what if the application never calls s2n_recv, so we never free the memory?
* Hold onto post_handshake.in longer. Instead of freeing it when s2n_recv succeeds, we could hold it for a certain number of messages or time period. However, this also relies on the application eventually calling s2n_recv again to clean it up. And since post-handshake messages aren't common, this is probably an inefficient use of memory.

### Testing:

New unit and self-talk tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
