### PR TITLE
openssl3 integration: workaround for new EVP_Cipher return code

### DIFF
--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -62,6 +62,7 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
 
     /* Adjust input length to account for the Tag length */
     size_t in_len = in->size - S2N_TLS_GCM_TAG_LEN;
+    /* out_len is set by EVP_AEAD_CTX_seal and checked post operation */
     size_t out_len = 0;
 
     POSIX_GUARD_OSSL(EVP_AEAD_CTX_seal(key->evp_aead_ctx, out->data, &out_len, out->size, iv->data, iv->size, in->data, in_len, aad->data, aad->size), S2N_ERR_ENCRYPT);
@@ -83,6 +84,7 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
     POSIX_ENSURE_GTE(out->size, in->size - S2N_TLS_GCM_TAG_LEN);
     POSIX_ENSURE_EQ(iv->size, S2N_TLS_GCM_IV_LEN);
 
+    /* out_len is set by EVP_AEAD_CTX_open and checked post operation */
     size_t out_len = 0;
 
     POSIX_GUARD_OSSL(EVP_AEAD_CTX_open(key->evp_aead_ctx, out->data, &out_len, out->size, iv->data, iv->size, in->data, in->size, aad->data, aad->size), S2N_ERR_DECRYPT);
@@ -222,6 +224,7 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
     int in_len = in->size - S2N_TLS_GCM_TAG_LEN;
     uint8_t *tag_data = out->data + out->size - S2N_TLS_GCM_TAG_LEN;
 
+    /* out_len is set by EVP_EncryptUpdate and checked post operation */
     int out_len = 0;
     /* Specify the AAD */
     POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size), S2N_ERR_ENCRYPT);
@@ -260,6 +263,9 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
     /* Set the TAG */
     POSIX_GUARD_OSSL(EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_TAG, S2N_TLS_GCM_TAG_LEN, tag_data), S2N_ERR_DECRYPT);
 
+    /* out_len is set by EVP_DecryptUpdate. While we verify the content of out_len in
+     * s2n_aead_chacha20_poly1305_encrypt, we refrain from this here. This is to avoid
+     * doing any branching before the ciphertext is verified. */
     int out_len = 0;
     /* Specify the AAD */
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size), S2N_ERR_DECRYPT);
@@ -272,8 +278,6 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
     evp_decrypt_rc &= EVP_DecryptFinal_ex(key->evp_cipher_ctx, out->data, &out_len);
 
     S2N_ERROR_IF(evp_decrypt_rc != 1, S2N_ERR_DECRYPT);
-
-    /* While we verify the content of out_len in s2n_aead_cipher_aes_gcm_encrypt, we refrain from this here. This is to avoid doing any branching before the ciphertext is verified. */
 
     return S2N_SUCCESS;
 }

--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -222,7 +222,7 @@ static int s2n_aead_cipher_aes_gcm_encrypt(struct s2n_session_key *key, struct s
     int in_len = in->size - S2N_TLS_GCM_TAG_LEN;
     uint8_t *tag_data = out->data + out->size - S2N_TLS_GCM_TAG_LEN;
 
-    int out_len;
+    int out_len = 0;
     /* Specify the AAD */
     POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size), S2N_ERR_ENCRYPT);
 
@@ -260,7 +260,7 @@ static int s2n_aead_cipher_aes_gcm_decrypt(struct s2n_session_key *key, struct s
     /* Set the TAG */
     POSIX_GUARD_OSSL(EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_TAG, S2N_TLS_GCM_TAG_LEN, tag_data), S2N_ERR_DECRYPT);
 
-    int out_len;
+    int out_len = 0;
     /* Specify the AAD */
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size), S2N_ERR_DECRYPT);
 

--- a/crypto/s2n_aead_cipher_chacha20_poly1305.c
+++ b/crypto/s2n_aead_cipher_chacha20_poly1305.c
@@ -61,6 +61,7 @@ static int s2n_aead_chacha20_poly1305_encrypt(struct s2n_session_key *key, struc
     int in_len = in->size - S2N_TLS_CHACHA20_POLY1305_TAG_LEN;
     uint8_t *tag_data = out->data + out->size - S2N_TLS_CHACHA20_POLY1305_TAG_LEN;
 
+    /* out_len is set by EVP_EncryptUpdate and checked post operation */
     int out_len = 0;
     /* Specify the AAD */
     POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size), S2N_ERR_ENCRYPT);
@@ -99,6 +100,9 @@ static int s2n_aead_chacha20_poly1305_decrypt(struct s2n_session_key *key, struc
     /* Set the TAG */
     POSIX_GUARD_OSSL(EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_TAG, S2N_TLS_CHACHA20_POLY1305_TAG_LEN, tag_data), S2N_ERR_DECRYPT);
 
+    /* out_len is set by EVP_DecryptUpdate. While we verify the content of out_len in
+     * s2n_aead_chacha20_poly1305_encrypt, we refrain from this here. This is to avoid
+     * doing any branching before the ciphertext is verified. */
     int out_len = 0;
     /* Specify the AAD */
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size), S2N_ERR_DECRYPT);
@@ -111,8 +115,6 @@ static int s2n_aead_chacha20_poly1305_decrypt(struct s2n_session_key *key, struc
     evp_decrypt_rc &= EVP_DecryptFinal_ex(key->evp_cipher_ctx, out->data, &out_len);
 
     S2N_ERROR_IF(evp_decrypt_rc != 1, S2N_ERR_DECRYPT);
-
-    /* While we verify the content of out_len in s2n_aead_chacha20_poly1305_encrypt, we refrain from this here. This is to avoid doing any branching before the ciphertext is verified. */
 
     return 0;
 }
@@ -168,6 +170,7 @@ static int s2n_aead_chacha20_poly1305_encrypt(struct s2n_session_key *key, struc
 
     /* Adjust input length to account for the Tag length */
     size_t in_len = in->size - S2N_TLS_CHACHA20_POLY1305_TAG_LEN;
+    /* out_len is set by EVP_AEAD_CTX_seal and checked post operation */
     size_t out_len = 0;
 
     POSIX_GUARD_OSSL(EVP_AEAD_CTX_seal(key->evp_aead_ctx, out->data, &out_len, out->size, iv->data, iv->size, in->data, in_len, aad->data, aad->size), S2N_ERR_ENCRYPT);
@@ -183,6 +186,7 @@ static int s2n_aead_chacha20_poly1305_decrypt(struct s2n_session_key *key, struc
     POSIX_ENSURE_GTE(out->size, in->size - S2N_TLS_CHACHA20_POLY1305_TAG_LEN);
     POSIX_ENSURE_EQ(iv->size, S2N_TLS_CHACHA20_POLY1305_IV_LEN);
 
+    /* out_len is set by EVP_AEAD_CTX_open and checked post operation */
     size_t out_len = 0;
 
     POSIX_GUARD_OSSL(EVP_AEAD_CTX_open(key->evp_aead_ctx, out->data, &out_len, out->size, iv->data, iv->size, in->data, in->size, aad->data, aad->size), S2N_ERR_DECRYPT);

--- a/crypto/s2n_aead_cipher_chacha20_poly1305.c
+++ b/crypto/s2n_aead_cipher_chacha20_poly1305.c
@@ -61,7 +61,7 @@ static int s2n_aead_chacha20_poly1305_encrypt(struct s2n_session_key *key, struc
     int in_len = in->size - S2N_TLS_CHACHA20_POLY1305_TAG_LEN;
     uint8_t *tag_data = out->data + out->size - S2N_TLS_CHACHA20_POLY1305_TAG_LEN;
 
-    int out_len;
+    int out_len = 0;
     /* Specify the AAD */
     POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size), S2N_ERR_ENCRYPT);
 
@@ -99,7 +99,7 @@ static int s2n_aead_chacha20_poly1305_decrypt(struct s2n_session_key *key, struc
     /* Set the TAG */
     POSIX_GUARD_OSSL(EVP_CIPHER_CTX_ctrl(key->evp_cipher_ctx, EVP_CTRL_GCM_SET_TAG, S2N_TLS_CHACHA20_POLY1305_TAG_LEN, tag_data), S2N_ERR_DECRYPT);
 
-    int out_len;
+    int out_len = 0;
     /* Specify the AAD */
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, NULL, &out_len, aad->data, aad->size), S2N_ERR_DECRYPT);
 

--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -34,7 +34,7 @@ static int s2n_cbc_cipher_3des_encrypt(struct s2n_session_key *key, struct s2n_b
 
     POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
-    int len = out->size;
+    int len = 0;
     POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
     S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
 
@@ -47,7 +47,7 @@ static int s2n_cbc_cipher_3des_decrypt(struct s2n_session_key *key, struct s2n_b
 
     POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
-    int len = out->size;
+    int len = 0;
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
 
     return 0;

--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -34,6 +34,7 @@ static int s2n_cbc_cipher_3des_encrypt(struct s2n_session_key *key, struct s2n_b
 
     POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
+    /* len is set by EVP_EncryptUpdate and checked post operation */
     int len = 0;
     POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
     S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
@@ -47,6 +48,8 @@ static int s2n_cbc_cipher_3des_decrypt(struct s2n_session_key *key, struct s2n_b
 
     POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
+    /* len is set by EVP_DecryptUpdate. It is not checked here but padding is manually removed and therefore
+     * the decryption operation is validated. */
     int len = 0;
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
 

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -39,7 +39,7 @@ static int s2n_cbc_cipher_aes_encrypt(struct s2n_session_key *key, struct s2n_bl
 
     POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
-    int len = out->size;
+    int len = 0;
     POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
     S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
 
@@ -51,7 +51,7 @@ int s2n_cbc_cipher_aes_decrypt(struct s2n_session_key *key, struct s2n_blob *iv,
     POSIX_ENSURE_GTE(out->size, in->size);
 
     POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
-    int len = out->size;
+    int len = 0;
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
 
     return 0;

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -39,6 +39,7 @@ static int s2n_cbc_cipher_aes_encrypt(struct s2n_session_key *key, struct s2n_bl
 
     POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
+    /* len is set by EVP_EncryptUpdate and checked post operation */
     int len = 0;
     POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
     S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
@@ -51,6 +52,9 @@ int s2n_cbc_cipher_aes_decrypt(struct s2n_session_key *key, struct s2n_blob *iv,
     POSIX_ENSURE_GTE(out->size, in->size);
 
     POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
+
+    /* len is set by EVP_DecryptUpdate. It is not checked here but padding is manually removed and therefore
+     * the decryption operation is validated. */
     int len = 0;
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
 

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -168,6 +168,7 @@ static int s2n_composite_cipher_aes_sha_encrypt(struct s2n_session_key *key, str
 
     POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
+    /* len is set by EVP_EncryptUpdate and checked post operation */
     int len = 0;
     POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
 
@@ -181,6 +182,8 @@ static int s2n_composite_cipher_aes_sha_decrypt(struct s2n_session_key *key, str
     POSIX_ENSURE_EQ(out->size, in->size);
     POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
+    /* len is set by EVP_DecryptUpdate. It is not checked here but padding is manually removed and therefore
+     * the decryption operation is validated. */
     int len = 0;
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
 

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -167,7 +167,10 @@ static int s2n_composite_cipher_aes_sha_encrypt(struct s2n_session_key *key, str
     POSIX_ENSURE_EQ(out->size, in->size);
 
     POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
-    POSIX_GUARD_OSSL(EVP_Cipher(key->evp_cipher_ctx, out->data, in->data, in->size), S2N_ERR_ENCRYPT);
+
+    int len = out->size;
+    POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
+    S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
 
     return 0;
 }
@@ -175,9 +178,10 @@ static int s2n_composite_cipher_aes_sha_encrypt(struct s2n_session_key *key, str
 static int s2n_composite_cipher_aes_sha_decrypt(struct s2n_session_key *key, struct s2n_blob *iv, struct s2n_blob *in, struct s2n_blob *out)
 {
     POSIX_ENSURE_EQ(out->size, in->size);
-
     POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
-    POSIX_GUARD_OSSL(EVP_Cipher(key->evp_cipher_ctx, out->data, in->data, in->size), S2N_ERR_DECRYPT);
+
+    int len = out->size;
+    POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
 
     return 0;
 }

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -168,8 +168,9 @@ static int s2n_composite_cipher_aes_sha_encrypt(struct s2n_session_key *key, str
 
     POSIX_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
-    int len = out->size;
+    int len = 0;
     POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
+
     S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
 
     return 0;
@@ -180,7 +181,7 @@ static int s2n_composite_cipher_aes_sha_decrypt(struct s2n_session_key *key, str
     POSIX_ENSURE_EQ(out->size, in->size);
     POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
-    int len = out->size;
+    int len = 0;
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
 
     return 0;

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -48,7 +48,7 @@ static S2N_RESULT s2n_drbg_block_encrypt(EVP_CIPHER_CTX *ctx, uint8_t in[S2N_DRB
 {
     RESULT_ENSURE_REF(ctx);
 
-    int len = S2N_DRBG_BLOCK_SIZE;
+    int len = 0;
     RESULT_GUARD_OSSL(EVP_EncryptUpdate(ctx, out, &len, in, S2N_DRBG_BLOCK_SIZE), S2N_ERR_DRBG);
     RESULT_ENSURE_EQ(len, S2N_DRBG_BLOCK_SIZE);
 

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -48,7 +48,8 @@ static S2N_RESULT s2n_drbg_block_encrypt(EVP_CIPHER_CTX *ctx, uint8_t in[S2N_DRB
 {
     RESULT_ENSURE_REF(ctx);
 
-    int len = 0;
+    /* len is set by EVP_EncryptUpdate and checked post operation */
+    int len = S2N_DRBG_BLOCK_SIZE;
     RESULT_GUARD_OSSL(EVP_EncryptUpdate(ctx, out, &len, in, S2N_DRBG_BLOCK_SIZE), S2N_ERR_DRBG);
     RESULT_ENSURE_EQ(len, S2N_DRBG_BLOCK_SIZE);
 

--- a/crypto/s2n_stream_cipher_rc4.c
+++ b/crypto/s2n_stream_cipher_rc4.c
@@ -40,6 +40,7 @@ static int s2n_stream_cipher_rc4_encrypt(struct s2n_session_key *key, struct s2n
 {
     POSIX_ENSURE_GTE(out->size, in->size);
 
+    /* len is set by EVP_EncryptUpdate and checked post operation */
     int len = 0;
     POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
 
@@ -52,10 +53,11 @@ static int s2n_stream_cipher_rc4_decrypt(struct s2n_session_key *key, struct s2n
 {
     POSIX_ENSURE_GTE(out->size, in->size);
 
+    /* len is set by EVP_DecryptUpdate and checked post operation */
     int len = 0;
-    POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
+    POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
 
-    S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
+    S2N_ERROR_IF(len != in->size, S2N_ERR_DECRYPT);
 
     return 0;
 }

--- a/crypto/s2n_stream_cipher_rc4.c
+++ b/crypto/s2n_stream_cipher_rc4.c
@@ -40,7 +40,7 @@ static int s2n_stream_cipher_rc4_encrypt(struct s2n_session_key *key, struct s2n
 {
     POSIX_ENSURE_GTE(out->size, in->size);
 
-    int len = out->size;
+    int len = 0;
     POSIX_GUARD_OSSL(EVP_EncryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
 
     S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);
@@ -52,7 +52,7 @@ static int s2n_stream_cipher_rc4_decrypt(struct s2n_session_key *key, struct s2n
 {
     POSIX_ENSURE_GTE(out->size, in->size);
 
-    int len = out->size;
+    int len = 0;
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_ENCRYPT);
 
     S2N_ERROR_IF(len != in->size, S2N_ERR_ENCRYPT);


### PR DESCRIPTION
### Description of changes: 
In openssl3 EVP_Cipher checks if a provider has been set and then introduces different functionality:
- before: returns 1 on success or 0 on failure
- now: returns the amount of encrypted / decrypted bytes, or -1 on failure

So based on the source code, openssl3 now checks if there is a provider (cipher→prov) set on the ctx and based on that triggers the new behavior.

**Fix1 (recommended):**
A solution is to use `EVP_EncryptUpdate` and `EVP_DecryptUpdate` as is done in the other cipher implemenations: [code](https://github.com/aws/s2n-tls/blob/fb1e57c104eea441f0a928bfa15eca6979810b00/crypto/s2n_cbc_cipher_aes.c#L36-L58).

pros:
- avoids the new return code behavior change
- consolidates cipher impl across the codebase

**Fix2:**
Since in ossl3 we [load the "default" and "legacy" providers](https://github.com/aws/s2n-tls/pull/3457), we can assume and handle the new return code behavior.

This however introduces the need for `ifdef` which makes the code more complicated to reason about.

### Testing:
Locally unit test passes in ossl3 and also ossl2 locally.

```

-------libcrypto
    libcrypto.so.3 => /home/ubuntu/projects/rsync/s2n-tls/test-deps/openssl-3.0/lib/libcrypto.so.3 (0x00007fe95a89e000)
-------libcrypto

~/projects/rsync/s2n-tls/tests/unit ~/projects/rsync/s2n-tls
Running /home/ubuntu/projects/rsync/s2n-tls/tests/unit/s2n_aes_sha_composite_test.c ... PASSED    2297077 tests
Running /home/ubuntu/projects/rsync/s2n-tls/tests/unit/s2n_certificate_test.c ... PASSED        392 tests
Running /home/ubuntu/projects/rsync/s2n-tls/tests/unit/s2n_client_hello_test.c ... PASSED        708 tests
Running /home/ubuntu/projects/rsync/s2n-tls/tests/unit/s2n_extension_type_test.c ... PASSED        306 tests
Running /home/ubuntu/projects/rsync/s2n-tls/tests/unit/s2n_mutual_auth_test.c ... PASSED        634 tests
Running /home/ubuntu/projects/rsync/s2n-tls/tests/unit/s2n_optional_client_auth_test.c ... PASSED        774 tests
Running /home/ubuntu/projects/rsync/s2n-tls/tests/unit/s2n_record_size_test.c ... PASSED        183 tests
Running /home/ubuntu/projects/rsync/s2n-tls/tests/unit/s2n_self_talk_offload_signing_test.c ... PASSED         59 tests
Running /home/ubuntu/projects/rsync/s2n-tls/tests/unit/s2n_handshake_test.c ... PASSED       2961 tests
Running /home/ubuntu/projects/rsync/s2n-tls/tests/unit/s2n_self_talk_nonblocking_test.c ... PASSED        271 tests
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
