### PR TITLE
openssl3 integration: work around for broken make build

### DIFF
--- a/codebuild/bin/install_openssl_3_0.sh
+++ b/codebuild/bin/install_openssl_3_0.sh
@@ -54,4 +54,9 @@ make -j $JOBS install
 
 popd
 
+# sym-link lib -> lib64 since codebuild assumes /lib path
+pushd $INSTALL_DIR
+ln -s lib64 lib
+popd
+
 exit 0


### PR DESCRIPTION
### Description of changes: 
openssl3 gets installed in the directory `lib64`, while all codebuild scripts assume the dir `lib`. This change sym-links the lib->lib64 directory so that make build continue to work.

Another solution could be to parametrize over lib, LIB_PATH, but the change would be [much large](https://github.com/aws/s2n-tls/search?p=2&q=LIBCRYPTO_ROOT) and not necessarily more useful.

### Testing:
Integrationv2 test (ossl3) successfully run with the above change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
