### PR TITLE
feat: add dynamic buffer capabilities

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1640,6 +1640,20 @@ S2N_API
 extern int s2n_connection_prefer_low_latency(struct s2n_connection *conn);
 
 /**
+ * Configure the connection to free IO buffers after they are no longer used.
+ *
+ * This configuration can be used to minimize connection memory footprint size, at the cost
+ * of more calls to alloc and free. Some of these costs can be mitigated by configuring s2n-tls
+ * to use an allocator that includes thread-local caches or lock-free allocation patterns.
+ *
+ * @param conn The connection object being update
+ * @param enabled Set to `true` if dynamic buffers are enabled; `false` if disabled
+ * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
+ */
+S2N_API
+extern int s2n_connection_set_dynamic_buffers(struct s2n_connection *conn, bool enabled);
+
+/**
  * Provides a smooth transition from s2n_connection_prefer_low_latency() to s2n_connection_prefer_throughput().
  *
  * @param conn The connection object being updated

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1640,7 +1640,7 @@ S2N_API
 extern int s2n_connection_prefer_low_latency(struct s2n_connection *conn);
 
 /**
- * Configure the connection to free IO buffers after they are no longer used.
+ * Configure the connection to free IO buffers when they are not currently in use.
  *
  * This configuration can be used to minimize connection memory footprint size, at the cost
  * of more calls to alloc and free. Some of these costs can be mitigated by configuring s2n-tls

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -102,16 +102,30 @@ int s2n_stuffer_growable_alloc(struct s2n_stuffer *stuffer, const uint32_t size)
     return S2N_SUCCESS;
 }
 
-int s2n_stuffer_free(struct s2n_stuffer *stuffer)
+static int s2n_stuffer_free_impl(struct s2n_stuffer *stuffer, bool zeroed)
 {
     POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
     if (stuffer != NULL) {
         if (stuffer->alloced) {
-            POSIX_GUARD(s2n_free(&stuffer->blob));
+            if (zeroed) {
+                POSIX_GUARD(s2n_free(&stuffer->blob));
+            } else {
+                POSIX_GUARD(s2n_free_non_zeroed(&stuffer->blob));
+            }
         }
         *stuffer = (struct s2n_stuffer) {0};
     }
     return S2N_SUCCESS;
+}
+
+int s2n_stuffer_free(struct s2n_stuffer *stuffer)
+{
+    return s2n_stuffer_free_impl(stuffer, true);
+}
+
+int s2n_stuffer_free_non_zeroed(struct s2n_stuffer *stuffer)
+{
+    return s2n_stuffer_free_impl(stuffer, false);
 }
 
 int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -102,30 +102,24 @@ int s2n_stuffer_growable_alloc(struct s2n_stuffer *stuffer, const uint32_t size)
     return S2N_SUCCESS;
 }
 
-static int s2n_stuffer_free_impl(struct s2n_stuffer *stuffer, bool zeroed)
+int s2n_stuffer_free(struct s2n_stuffer *stuffer)
 {
     POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
-    if (stuffer != NULL) {
-        if (stuffer->alloced) {
-            if (zeroed) {
-                POSIX_GUARD(s2n_free(&stuffer->blob));
-            } else {
-                POSIX_GUARD(s2n_free_non_zeroed(&stuffer->blob));
-            }
-        }
-        *stuffer = (struct s2n_stuffer) {0};
+    if (stuffer->alloced) {
+        POSIX_GUARD(s2n_free(&stuffer->blob));
     }
+    *stuffer = (struct s2n_stuffer) {0};
     return S2N_SUCCESS;
 }
 
-int s2n_stuffer_free(struct s2n_stuffer *stuffer)
+int s2n_stuffer_free_without_wipe(struct s2n_stuffer *stuffer)
 {
-    return s2n_stuffer_free_impl(stuffer, true);
-}
-
-int s2n_stuffer_free_non_zeroed(struct s2n_stuffer *stuffer)
-{
-    return s2n_stuffer_free_impl(stuffer, false);
+    POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
+    if (stuffer->alloced) {
+        POSIX_GUARD(s2n_free_without_wipe(&stuffer->blob));
+    }
+    *stuffer = (struct s2n_stuffer) {0};
+    return S2N_SUCCESS;
 }
 
 int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size)

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -68,6 +68,13 @@ extern int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in);
 extern int s2n_stuffer_alloc(struct s2n_stuffer *stuffer, const uint32_t size);
 extern int s2n_stuffer_growable_alloc(struct s2n_stuffer *stuffer, const uint32_t size);
 extern int s2n_stuffer_free(struct s2n_stuffer *stuffer);
+/**
+ * Frees the stuffer without zeroizing the contained data.
+ *
+ * This should only be used in scenarios where the data is encrypted or has been
+ * cleared with `s2n_stuffer_erase_and_read`. In most cases, prefer `s2n_stuffer_free`.
+ */
+extern int s2n_stuffer_free_non_zeroed(struct s2n_stuffer *stuffer);
 extern int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size);
 extern int s2n_stuffer_resize_if_empty(struct s2n_stuffer *stuffer, const uint32_t size);
 extern int s2n_stuffer_rewind_read(struct s2n_stuffer *stuffer, const uint32_t size);

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -74,7 +74,7 @@ extern int s2n_stuffer_free(struct s2n_stuffer *stuffer);
  * This should only be used in scenarios where the data is encrypted or has been
  * cleared with `s2n_stuffer_erase_and_read`. In most cases, prefer `s2n_stuffer_free`.
  */
-extern int s2n_stuffer_free_non_zeroed(struct s2n_stuffer *stuffer);
+extern int s2n_stuffer_free_without_wipe(struct s2n_stuffer *stuffer);
 extern int s2n_stuffer_resize(struct s2n_stuffer *stuffer, const uint32_t size);
 extern int s2n_stuffer_resize_if_empty(struct s2n_stuffer *stuffer, const uint32_t size);
 extern int s2n_stuffer_rewind_read(struct s2n_stuffer *stuffer, const uint32_t size);

--- a/tests/unit/s2n_self_talk_io_mem_test.c
+++ b/tests/unit/s2n_self_talk_io_mem_test.c
@@ -222,11 +222,11 @@ int main(int argc, char **argv)
 
     /* Test that dynamic buffers work correctly */
     {
-        struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(client_conn);
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-        struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(server_conn);
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -234,25 +234,51 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_dynamic_buffers(client_conn, true));
         EXPECT_SUCCESS(s2n_connection_set_dynamic_buffers(server_conn, true));
 
-        /* Create nonblocking pipes */
-        struct s2n_test_io_pair io_pair;
-        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
-        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
-        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+        /* Configure the connection to use stuffers instead of fds.
+         * This will let us block the send.
+         */
+        DEFER_CLEANUP(struct s2n_stuffer client_in = { 0 }, s2n_stuffer_free);
+        DEFER_CLEANUP(struct s2n_stuffer client_out = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_in, 0));
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_out, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&client_in, &client_out, client_conn));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&client_out, &client_in, server_conn));
 
         /* Do handshake */
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
+        /* all IO buffers should be empty after the handshake */
+        EXPECT_EQUAL(client_conn->in.blob.size, 0);
+        EXPECT_EQUAL(client_conn->out.blob.size, 0);
+        EXPECT_EQUAL(server_conn->in.blob.size, 0);
+        EXPECT_EQUAL(server_conn->out.blob.size, 0);
+
+        /* block the server from sending */
+        EXPECT_SUCCESS(s2n_stuffer_free(&client_in));
+
         s2n_blocked_status blocked = 0;
+        int send_status = S2N_SUCCESS;
+
+        /* choose a large enough payload to send a full record, 4k is a common page size so we'll go with that */
         uint8_t buf[4096] = { 42 };
 
-        size_t sent_amount = 0;
+        send_status = s2n_send(server_conn, &buf, s2n_array_len(buf), &blocked);
 
-        while (sent_amount < s2n_array_len(buf)) {
-            int send_status = s2n_send(server_conn, &buf, s2n_array_len(buf) - sent_amount, &blocked);
-            EXPECT_SUCCESS(send_status);
-            sent_amount += s2n_array_len(buf);
-        }
+        /* the first send call should block */
+        EXPECT_FAILURE(send_status);
+        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_WRITE);
+
+        /* the `out` buffer should not be freed until it's completely flushed to the socket */
+        EXPECT_NOT_EQUAL(server_conn->out.blob.size, 0);
+
+        /* unblock the send call by letting the stuffer grow */
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_in, 0));
+
+        send_status = s2n_send(server_conn, &buf, s2n_array_len(buf), &blocked);
+        EXPECT_SUCCESS(send_status);
+
+        /* the entire payload should have been sent */
+        EXPECT_EQUAL(send_status, s2n_array_len(buf));
 
         /* make sure the `out` buffer was freed after sending */
         EXPECT_EQUAL(server_conn->out.blob.size, 0);
@@ -277,9 +303,6 @@ int main(int argc, char **argv)
 
         /* make sure the `in` buffer was freed after receiving the full message */
         EXPECT_EQUAL(client_conn->in.blob.size, 0);
-
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-        EXPECT_SUCCESS(s2n_connection_free(server_conn));
     }
 
     EXPECT_SUCCESS(s2n_config_free(config));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1208,6 +1208,13 @@ int s2n_connection_prefer_low_latency(struct s2n_connection *conn)
     return S2N_SUCCESS;
 }
 
+int s2n_connection_set_dynamic_buffers(struct s2n_connection *conn, bool enabled)
+{
+    POSIX_ENSURE_REF(conn);
+    conn->dynamic_buffers = enabled;
+    return S2N_SUCCESS;
+}
+
 int s2n_connection_set_dynamic_record_threshold(struct s2n_connection *conn, uint32_t resize_threshold, uint16_t timeout_threshold)
 {
     POSIX_ENSURE_REF(conn);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1490,7 +1490,7 @@ int s2n_connection_get_config(struct s2n_connection *conn, struct s2n_config **c
     return S2N_SUCCESS;
 }
 
-S2N_RESULT s2n_connection_complete_send(struct s2n_connection *conn)
+S2N_RESULT s2n_connection_dynamic_free_out_buffer(struct s2n_connection *conn)
 {
     RESULT_ENSURE_REF(conn);
 
@@ -1506,7 +1506,7 @@ S2N_RESULT s2n_connection_complete_send(struct s2n_connection *conn)
     return S2N_RESULT_OK;
 }
 
-S2N_RESULT s2n_connection_complete_recv(struct s2n_connection *conn)
+S2N_RESULT s2n_connection_dynamic_free_in_buffer(struct s2n_connection *conn)
 {
     RESULT_ENSURE_REF(conn);
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -127,6 +127,10 @@ struct s2n_connection {
      * This allows multiple records to be written with one socket send. */
     unsigned multirecord_send:1;
 
+    /* If enabled, this connection will free each of its IO buffers after all data
+     * has been flushed */
+    unsigned dynamic_buffers:1;
+
     /* The configuration (cert, key .. etc ) */
     struct s2n_config *config;
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -394,12 +394,9 @@ int s2n_connection_recv_stuffer(struct s2n_stuffer *stuffer, struct s2n_connecti
 
 S2N_RESULT s2n_connection_wipe_all_keyshares(struct s2n_connection *conn);
 
-/* Completes the send/recv processing on the connection
- *
- * If dynamic buffers are enabled, the IO buffers may be freed if it is completely consumed
- */
-S2N_RESULT s2n_connection_complete_send(struct s2n_connection *conn);
-S2N_RESULT s2n_connection_complete_recv(struct s2n_connection *conn);
+/* If dynamic buffers are enabled, the IO buffers may be freed if they are completely consumed */
+S2N_RESULT s2n_connection_dynamic_free_in_buffer(struct s2n_connection *conn);
+S2N_RESULT s2n_connection_dynamic_free_out_buffer(struct s2n_connection *conn);
 
 int s2n_connection_get_cipher_preferences(struct s2n_connection *conn, const struct s2n_cipher_preferences **cipher_preferences);
 int s2n_connection_get_security_policy(struct s2n_connection *conn, const struct s2n_security_policy **security_policy);

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -394,6 +394,13 @@ int s2n_connection_recv_stuffer(struct s2n_stuffer *stuffer, struct s2n_connecti
 
 S2N_RESULT s2n_connection_wipe_all_keyshares(struct s2n_connection *conn);
 
+/* Completes the send/recv processing on the connection
+ *
+ * If dynamic buffers are enabled, the IO buffers may be freed if it is completely consumed
+ */
+S2N_RESULT s2n_connection_complete_send(struct s2n_connection *conn);
+S2N_RESULT s2n_connection_complete_recv(struct s2n_connection *conn);
+
 int s2n_connection_get_cipher_preferences(struct s2n_connection *conn, const struct s2n_cipher_preferences **cipher_preferences);
 int s2n_connection_get_security_policy(struct s2n_connection *conn, const struct s2n_security_policy **security_policy);
 int s2n_connection_get_kem_preferences(struct s2n_connection *conn, const struct s2n_kem_preferences **kem_preferences);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1459,8 +1459,8 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
     int result = s2n_negotiate_impl(conn, blocked);
 
     /* finish up sending and receiving */
-    POSIX_GUARD_RESULT(s2n_connection_complete_recv(conn));
-    POSIX_GUARD_RESULT(s2n_connection_complete_send(conn));
+    POSIX_GUARD_RESULT(s2n_connection_dynamic_free_in_buffer(conn));
+    POSIX_GUARD_RESULT(s2n_connection_dynamic_free_out_buffer(conn));
 
     conn->negotiate_in_use = false;
     return result;

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -62,7 +62,7 @@ static int s2n_always_fail_recv(struct s2n_connection *conn)
     POSIX_BAIL(S2N_ERR_HANDSHAKE_UNREACHABLE);
 }
 
-/* Client and Server handlers for each message type we support.  
+/* Client and Server handlers for each message type we support.
  * See http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-7 for the list of handshake message types
  */
 static struct s2n_handshake_action state_machine[] = {
@@ -1455,7 +1455,13 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE(!conn->negotiate_in_use, S2N_ERR_REENTRANCY);
     conn->negotiate_in_use = true;
+
     int result = s2n_negotiate_impl(conn, blocked);
+
+    /* finish up sending and receiving */
+    POSIX_GUARD_RESULT(s2n_connection_complete_recv(conn));
+    POSIX_GUARD_RESULT(s2n_connection_complete_send(conn));
+
     conn->negotiate_in_use = false;
     return result;
 }

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -210,14 +210,8 @@ ssize_t s2n_recv(struct s2n_connection * conn, void *buf, ssize_t size, s2n_bloc
     ssize_t result = s2n_recv_impl(conn, buf, size, blocked);
     POSIX_GUARD_RESULT(s2n_early_data_record_bytes(conn, result));
 
-    /* free the `in` buffer if we're in dynamic mode and it's completely flushed */
-    if (conn->dynamic_buffers && s2n_stuffer_is_consumed(&conn->in)) {
-        /* when copying the buffer into the application, we use `s2n_stuffer_erase_and_read`, which already zeroes the memory */
-        POSIX_GUARD(s2n_stuffer_free_non_zeroed(&conn->in));
-
-        /* reset the stuffer to its initial state */
-        POSIX_GUARD(s2n_stuffer_growable_alloc(&conn->in, 0));
-    }
+    /* finish the recv call */
+    POSIX_GUARD_RESULT(s2n_connection_complete_recv(conn));
 
     conn->recv_in_use = false;
     return result;

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -211,7 +211,7 @@ ssize_t s2n_recv(struct s2n_connection * conn, void *buf, ssize_t size, s2n_bloc
     POSIX_GUARD_RESULT(s2n_early_data_record_bytes(conn, result));
 
     /* finish the recv call */
-    POSIX_GUARD_RESULT(s2n_connection_complete_recv(conn));
+    POSIX_GUARD_RESULT(s2n_connection_dynamic_free_in_buffer(conn));
 
     conn->recv_in_use = false;
     return result;

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -206,8 +206,19 @@ ssize_t s2n_recv(struct s2n_connection * conn, void *buf, ssize_t size, s2n_bloc
 {
     POSIX_ENSURE(!conn->recv_in_use, S2N_ERR_REENTRANCY);
     conn->recv_in_use = true;
+
     ssize_t result = s2n_recv_impl(conn, buf, size, blocked);
     POSIX_GUARD_RESULT(s2n_early_data_record_bytes(conn, result));
+
+    /* free the `in` buffer if we're in dynamic mode and it's completely flushed */
+    if (conn->dynamic_buffers && s2n_stuffer_is_consumed(&conn->in)) {
+        /* when copying the buffer into the application, we use `s2n_stuffer_erase_and_read`, which already zeroes the memory */
+        POSIX_GUARD(s2n_stuffer_free_non_zeroed(&conn->in));
+
+        /* reset the stuffer to its initial state */
+        POSIX_GUARD(s2n_stuffer_growable_alloc(&conn->in, 0));
+    }
+
     conn->recv_in_use = false;
     return result;
 }

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -251,8 +251,7 @@ ssize_t s2n_sendv_with_offset(struct s2n_connection *conn, const struct iovec *b
     ssize_t result = s2n_sendv_with_offset_impl(conn, bufs, count, offs, blocked);
     POSIX_GUARD_RESULT(s2n_early_data_record_bytes(conn, result));
 
-    /* finish the send call */
-    POSIX_GUARD_RESULT(s2n_connection_complete_send(conn));
+    POSIX_GUARD_RESULT(s2n_connection_dynamic_free_out_buffer(conn));
 
     conn->send_in_use = false;
     return result;

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -209,7 +209,7 @@ ssize_t s2n_sendv_with_offset_impl(struct s2n_connection *conn, const struct iov
         }
 
         POSIX_GUARD(s2n_post_handshake_send(conn, blocked));
-    
+
         /* Write and encrypt the record */
         int written_to_record = s2n_record_writev(conn, TLS_APPLICATION_DATA, bufs, count,
                     conn->current_user_data_consumed + offs, to_write);
@@ -247,8 +247,19 @@ ssize_t s2n_sendv_with_offset(struct s2n_connection *conn, const struct iovec *b
 {
     POSIX_ENSURE(!conn->send_in_use, S2N_ERR_REENTRANCY);
     conn->send_in_use = true;
+
     ssize_t result = s2n_sendv_with_offset_impl(conn, bufs, count, offs, blocked);
     POSIX_GUARD_RESULT(s2n_early_data_record_bytes(conn, result));
+
+    /* free the out buffer if we're in dynamic mode and it's completely flushed */
+    if (conn->dynamic_buffers && s2n_stuffer_is_consumed(&conn->out)) {
+        /* since outgoing buffers are already encrypted, the buffers don't need to be zeroed, which saves some overhead */
+        POSIX_GUARD(s2n_stuffer_free_non_zeroed(&conn->out));
+
+        /* reset the stuffer to its initial state */
+        POSIX_GUARD(s2n_stuffer_growable_alloc(&conn->out, 0));
+    }
+
     conn->send_in_use = false;
     return result;
 }

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -273,13 +273,13 @@ int s2n_mem_cleanup(void)
     return S2N_SUCCESS;
 }
 
-int s2n_free(struct s2n_blob *b)
+static int s2n_free_impl(struct s2n_blob *b, bool zeroed)
 {
     POSIX_PRECONDITION(s2n_blob_validate(b));
 
     /* To avoid memory leaks, don't exit the function until the memory
        has been freed */
-    int zero_rc = s2n_blob_zero(b);
+    int zero_rc = zeroed ? s2n_blob_zero(b) : S2N_SUCCESS;
 
     POSIX_ENSURE(initialized, S2N_ERR_NOT_INITIALIZED);
     POSIX_ENSURE(s2n_blob_is_growable(b), S2N_ERR_FREE_STATIC_BLOB);
@@ -291,6 +291,16 @@ int s2n_free(struct s2n_blob *b)
     POSIX_GUARD(zero_rc);
 
     return S2N_SUCCESS;
+}
+
+int s2n_free(struct s2n_blob *b)
+{
+    return s2n_free_impl(b, true);
+}
+
+int s2n_free_non_zeroed(struct s2n_blob *b)
+{
+    return s2n_free_impl(b, false);
 }
 
 int s2n_blob_zeroize_free(struct s2n_blob *b) {

--- a/utils/s2n_mem.h
+++ b/utils/s2n_mem.h
@@ -26,6 +26,7 @@ int s2n_mem_cleanup(void);
 int s2n_alloc(struct s2n_blob *b, uint32_t size);
 int s2n_realloc(struct s2n_blob *b, uint32_t size);
 int s2n_free(struct s2n_blob *b);
+int s2n_free_non_zeroed(struct s2n_blob *b);
 int s2n_blob_zeroize_free(struct s2n_blob *b);
 int s2n_free_object(uint8_t **p_data, uint32_t size);
 int s2n_dup(struct s2n_blob *from, struct s2n_blob *to);

--- a/utils/s2n_mem.h
+++ b/utils/s2n_mem.h
@@ -26,7 +26,7 @@ int s2n_mem_cleanup(void);
 int s2n_alloc(struct s2n_blob *b, uint32_t size);
 int s2n_realloc(struct s2n_blob *b, uint32_t size);
 int s2n_free(struct s2n_blob *b);
-int s2n_free_non_zeroed(struct s2n_blob *b);
+int s2n_free_without_wipe(struct s2n_blob *b);
 int s2n_blob_zeroize_free(struct s2n_blob *b);
 int s2n_free_object(uint8_t **p_data, uint32_t size);
 int s2n_dup(struct s2n_blob *from, struct s2n_blob *to);


### PR DESCRIPTION
### Description of changes: 

When connections read and write from a socket, they allocate IO buffers to do so. After allocation, these buffers are retained until the connection itself is freed or the application explicitly calls `s2n_connection_release_buffers`. For environments that are memory constrained, these options are somewhat limited.

This changes adds a configuration option to the connection to free IO buffers after they are used via the `s2n_connection_set_dynamic_buffers` function. This option can drastically reduce the amount of required memory for a connection, especially if it's not actively being used.

When paired with an allocator that has a thread-local cache or lock-free allocation, the overhead of allocating and freeing buffers with each call is practically eliminated. The following graphs show CPU efficiency with current `main` (no dynamic buffers), `openssl`, `mimalloc` (with dynamic buffers), and `system` (with glibc allocator and dynamic buffers).

![bytes/cpu](https://user-images.githubusercontent.com/799311/187303902-3ad45bdc-51ee-4537-be35-645010347f76.png)

### Call-outs:

Because we are freeing memory more often, it also means we are zeroizing memory more often, which can decrease throughput a bit:

#### Before
![image](https://user-images.githubusercontent.com/799311/187305882-55d7eaf1-505e-4cc5-8741-5ec4574008ac.png)
#### After
![image](https://user-images.githubusercontent.com/799311/187305906-d2fa1010-d768-4203-a286-d3f9127f9852.png)


To overcome this issue, I've added support for non-zeroizing frees for stuffers and blobs. The reasoning here is that:

* for `out` buffers, the bytes have already been encrypted and can be considered as "public" data, so zeroizing provides little benefit
* for `in` buffers we use the `s2n_stuffer_erase_and_read` call to copy out bytes, which already zeroizes the data:
  https://github.com/aws/s2n-tls/blob/1d9538b12121b70af1f395a2e6361cab37d08eea/stuffer/s2n_stuffer.c#L251-L252

I plan on updating the USAGE_GUIDE with instructions on optimizing s2n-tls and discussing some of the tradeoffs of each option.

### Testing:

I've included a test that sends and receives data and asserts that the buffers are empty after they're completely flushed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
