### PR TITLE
openssl3 integration: use EVP_PKEY_get1_RSA to avoid modifying const RSA key

### DIFF
--- a/crypto/s2n_rsa_pss.c
+++ b/crypto/s2n_rsa_pss.c
@@ -176,6 +176,7 @@ static int s2n_rsa_pss_keys_match(const struct s2n_pkey *pub, const struct s2n_p
 
 static int s2n_rsa_pss_key_free(struct s2n_pkey *pkey)
 {
+    POSIX_ENSURE_REF(pkey);
     struct s2n_rsa_key *rsa_key = &pkey->key.rsa_key;
     if (rsa_key->rsa == NULL) { return 0; }
 

--- a/crypto/s2n_rsa_pss.c
+++ b/crypto/s2n_rsa_pss.c
@@ -17,10 +17,6 @@
 #include <openssl/rsa.h>
 #include <stdint.h>
 
-#include "error/s2n_errno.h"
-
-#include "stuffer/s2n_stuffer.h"
-
 #include "crypto/s2n_evp_signing.h"
 #include "crypto/s2n_hash.h"
 #include "crypto/s2n_openssl.h"
@@ -28,7 +24,8 @@
 #include "crypto/s2n_rsa_pss.h"
 #include "crypto/s2n_rsa_signing.h"
 #include "crypto/s2n_pkey.h"
-
+#include "error/s2n_errno.h"
+#include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_blob.h"
 #include "utils/s2n_random.h"
 #include "utils/s2n_safety.h"
@@ -177,9 +174,10 @@ static int s2n_rsa_pss_keys_match(const struct s2n_pkey *pub, const struct s2n_p
 static int s2n_rsa_pss_key_free(struct s2n_pkey *pkey)
 {
     POSIX_ENSURE_REF(pkey);
-    POSIX_ENSURE_REF(&pkey->key.rsa_key);
     struct s2n_rsa_key *rsa_key = &pkey->key.rsa_key;
-    if (rsa_key->rsa == NULL) { return 0; }
+    if (rsa_key->rsa == NULL) {
+        return 0;
+    }
 
     RSA_free(rsa_key->rsa);
     rsa_key->rsa = NULL;

--- a/crypto/s2n_rsa_pss.c
+++ b/crypto/s2n_rsa_pss.c
@@ -177,6 +177,7 @@ static int s2n_rsa_pss_keys_match(const struct s2n_pkey *pub, const struct s2n_p
 static int s2n_rsa_pss_key_free(struct s2n_pkey *pkey)
 {
     POSIX_ENSURE_REF(pkey);
+    POSIX_ENSURE_REF(&pkey->key.rsa_key);
     struct s2n_rsa_key *rsa_key = &pkey->key.rsa_key;
     if (rsa_key->rsa == NULL) { return 0; }
 

--- a/tests/unit/s2n_rsa_pss_rsae_test.c
+++ b/tests/unit/s2n_rsa_pss_rsae_test.c
@@ -247,15 +247,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&rsa_pss_public_key, &rsa_pss_pkey_type, &rsa_pss_cert_chain->cert_chain->head->raw));
             EXPECT_EQUAL(rsa_pss_pkey_type, S2N_PKEY_TYPE_RSA_PSS);
 
-            /* Set the keys equal.
-             *
-             * In openssl 3 the function `EVP_PKEY_get1_RSA` returns a pre-cached copy of PKEY
-             * rather than the original copy. For this reason it is not possible to modify the
-             * original underlying RSA key.
-             *
-             * As a workaround, `rsa_key_copy` is modified, `rsa_pss_public_key` is set using
-             * `EVP_PKEY_set1_RSA` and finally rsa_key_copy is freed. This change is also
-             * backwards compatible with other ossl impl down to 1.0.2. */
+            /* Set the keys equal. */
             RSA *rsa_key_copy = EVP_PKEY_get1_RSA(rsa_public_key.pkey);
             POSIX_GUARD_OSSL(EVP_PKEY_set1_RSA(rsa_pss_public_key.pkey, rsa_key_copy), S2N_ERR_KEY_INIT);
             RSA_free(rsa_key_copy);
@@ -294,15 +286,7 @@ int main(int argc, char **argv)
                 &rsa_cert_chain->cert_chain->head->raw));
         EXPECT_EQUAL(rsa_pkey_type, S2N_PKEY_TYPE_RSA);
 
-        /* Modify the rsa_public_key for the new test_case.
-         *
-         * In openssl 3 the function `EVP_PKEY_get1_RSA` returns a pre-cached copy of PKEY
-         * rather than the original copy. For this reason it is not possible to modify the
-         * original underlying RSA key.
-         *
-         * As a workaround, `rsa_key_copy` is modified, `rsa_pss_public_key` is set using
-         * `EVP_PKEY_set1_RSA` and finally rsa_key_copy is freed. This change is also
-         * backwards compatible with other ossl impl down to 1.0.2. */
+        /* Modify the rsa_public_key for each test_case. */
         RSA *rsa_key_copy = EVP_PKEY_get1_RSA(rsa_public_key.pkey);
         BIGNUM *n = BN_new(), *e = BN_new(), *d = BN_new();
         EXPECT_SUCCESS(BN_hex2bn(&n, test_case.key_param_n));

--- a/tests/unit/s2n_rsa_pss_rsae_test.c
+++ b/tests/unit/s2n_rsa_pss_rsae_test.c
@@ -16,13 +16,13 @@
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
 
-#include "error/s2n_errno.h"
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 
 #include "crypto/s2n_hash.h"
 #include "crypto/s2n_rsa.h"
 #include "crypto/s2n_rsa_pss.h"
+#include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_config.h"


### PR DESCRIPTION
_**This change is based on top of a [previous PR](https://github.com/aws/s2n-tls/pull/3466) and the relevant commit is https://github.com/aws/s2n-tls/pull/3473/commits/a7f134edde30574212b66c488b22f021811a0e29**_

https://github.com/aws/s2n-tls/issues/3442

### Description of changes:
The API and behavior for `EVP_PKEY_get0_RSA` has change in openssl3. The main difference is that the return value is now marked as `const`, which triggers warnings across the codebase. The second difference is that the return value is no longer direct reference to the PKEY, but instead a reference to a pre-cached value.

[oss1 EVP_PKEY_get0_RSA](https://www.openssl.org/docs/man1.1.1/man3/EVP_PKEY_get0_RSA.html): direct reference, not-const, should not be freed
[oss3 EVP_PKEY_get0_RSA](https://www.openssl.org/docs/man3.0/man3/EVP_PKEY_get0_RSA.html): pre-cached copy, const, should not be freed

Our codebase is making a few assumptions at the moment:
- for a rsa_pss key we use [`EVP_PKEY_get0_RSA`](https://github.com/aws/s2n-tls/blob/1d9538b12121b70af1f395a2e6361cab37d08eea/crypto/s2n_rsa_pss.c#L186) which is not a copy, we [DO NOT need to free the RSA key](https://github.com/aws/s2n-tls/blob/1d9538b12121b70af1f395a2e6361cab37d08eea/crypto/s2n_rsa_pss.c#L177-L183)
- s2n_rsa_pss reuses the [`(s2n_rsa_key) rsa_key->rsa`](https://github.com/aws/s2n-tls/blob/1d9538b12121b70af1f395a2e6361cab37d08eea/crypto/s2n_rsa_pss.c#L207) field in [pkey](https://github.com/aws/s2n-tls/blob/1d9538b12121b70af1f395a2e6361cab37d08eea/crypto/s2n_pkey.h#L42)
- for a s2n_rsa key we use [`EVP_PKEY_get1_RSA`](https://github.com/aws/s2n-tls/blob/1d9538b12121b70af1f395a2e6361cab37d08eea/crypto/s2n_rsa.c#L171), which does need to be [freed](https://github.com/aws/s2n-tls/blob/1d9538b12121b70af1f395a2e6361cab37d08eea/crypto/s2n_rsa.c#L151-L160)

---
**Solution**
1) The solution to the above issue is that we should use the same implementation for s2n_rsa and s2n_rsa_pss keys.. switch to using `EVP_PKEY_get1_RSA`. Since `EVP_PKEY_get1_RSA` returns a copy, and needs to be freed, we need to free the key in s2n_rsa_pass.c.
2) We need to update all usage of `EVP_PKEY_get0_RSA` -> `EVP_PKEY_get1_RSA` in tests and subsequently call free.
3) We need to call `EVP_PKEY_set1_RSA` to set an PKEY since in ossl3 a pre-cached value is returned rather than the direct key

### Testing:
  - openssl 1.0.2 (unit tests pass)
  - openssl 3 (unit tests and asan tests passes locally)
    `Running /home/ubuntu/projects/rsync/s2n-tls/tests/unit/s2n_rsa_pss_rsae_test.c ... PASSED        213 tests`

#### Code analysis:
- EVP_PKEY_get0_RSA
  - https://github.com/openssl/openssl/blob/openssl-3.0.5/crypto/evp/p_legacy.c#L43
    - https://github.com/openssl/openssl/blob/openssl-3.0.5/crypto/evp/p_lib.c#L2069
      - *returns pk->legacy_cache_pkey.ptr*
  - https://github.com/openssl/openssl/blob/OpenSSL_1_1_1/crypto/evp/p_lib.c#L461
    - *returns pkey->pkey.rsa*
- EVP_PKEY_set1_RSA
  - https://github.com/openssl/openssl/blob/openssl-3.0.5/crypto/evp/p_legacy.c#L25
    - https://github.com/openssl/openssl/blob/openssl-3.0.5/crypto/evp/p_lib.c#L741
      - *sets pkey->pkey.ptr = key;* which is similar to modifying EVP_PKEY_get0_RSA value in openssl1.1.1
---

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
