### PR TITLE
openssl3 integration: store const RSA and EC_KEY

### DIFF
--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -44,7 +44,7 @@ S2N_RESULT s2n_unsafe_ecdsa_get_mut(const struct s2n_ecdsa_key *ecdsa_key, EC_KE
     RESULT_ENSURE_EQ(*out_ec_key, NULL);
 
     /* pragma gcc diagnostic was added in gcc 4.6 */
-#if S2N_GCC_VERSION_AT_LEAST(4,6,0)
+#if S2N_GCC_VERSION_AT_LEAST_OR_CLANG(4,6,0)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #endif

--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -16,10 +16,13 @@
 #include <openssl/ec.h>
 #include <openssl/ecdsa.h>
 #include <openssl/x509.h>
-#include "stuffer/s2n_stuffer.h"
 
 #include "error/s2n_errno.h"
+#include "stuffer/s2n_stuffer.h"
+
+#include "utils/s2n_safety_macros.h"
 #include "utils/s2n_blob.h"
+#include "utils/s2n_compiler.h"
 #include "utils/s2n_mem.h"
 #include "utils/s2n_random.h"
 #include "utils/s2n_result.h"
@@ -32,7 +35,28 @@
 #include "crypto/s2n_openssl.h"
 #include "crypto/s2n_pkey.h"
 
+
 #define S2N_ECDSA_TYPE 0
+
+S2N_RESULT s2n_unsafe_ecdsa_get_mut(const struct s2n_ecdsa_key *ecdsa_key, EC_KEY **out_ec_key) {
+    RESULT_ENSURE_REF(ecdsa_key);
+    RESULT_ENSURE_REF(ecdsa_key->ec_key);
+    RESULT_ENSURE_EQ(*out_ec_key, NULL);
+
+    /* pragma gcc diagnostic was added in gcc 4.6 */
+#if S2N_GCC_VERSION_AT_LEAST(4,6,0)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
+    *out_ec_key = (EC_KEY *) ecdsa_key->ec_key;
+#if S2N_GCC_VERSION_AT_LEAST(4,6,0)
+#pragma GCC diagnostic pop
+#endif
+
+    RESULT_ENSURE_REF(*out_ec_key);
+
+    return S2N_RESULT_OK;
+}
 
 S2N_RESULT s2n_ecdsa_der_signature_size(const struct s2n_pkey *pkey, uint32_t *size_out)
 {
@@ -59,7 +83,12 @@ int s2n_ecdsa_sign_digest(const struct s2n_pkey *priv, struct s2n_blob *digest, 
     POSIX_ENSURE_REF(key->ec_key);
 
     unsigned int signature_size = signature->size;
-    POSIX_GUARD_OSSL(ECDSA_sign(S2N_ECDSA_TYPE, digest->data, digest->size, signature->data, &signature_size, key->ec_key), S2N_ERR_SIGN);
+
+    /* Safety: ECDSA_sign does not mutate the key */
+    EC_KEY *ec_key = NULL;
+    POSIX_GUARD_RESULT(s2n_unsafe_ecdsa_get_mut(key, &ec_key));
+
+    POSIX_GUARD_OSSL(ECDSA_sign(S2N_ECDSA_TYPE, digest->data, digest->size, signature->data, &signature_size, ec_key), S2N_ERR_SIGN);
     POSIX_ENSURE(signature_size <= signature->size, S2N_ERR_SIZE_MISMATCH);
     signature->size = signature_size;
 
@@ -84,7 +113,7 @@ static int s2n_ecdsa_sign(const struct s2n_pkey *priv, s2n_signature_algorithm s
     POSIX_GUARD(s2n_ecdsa_sign_digest(priv, &digest_blob, signature));
 
     POSIX_GUARD(s2n_hash_reset(digest));
-    
+
     return S2N_SUCCESS;
 }
 
@@ -102,16 +131,20 @@ static int s2n_ecdsa_verify(const struct s2n_pkey *pub, s2n_signature_algorithm 
 
     uint8_t digest_out[S2N_MAX_DIGEST_LEN];
     POSIX_GUARD(s2n_hash_digest(digest, digest_out, digest_length));
-    
+
+    /* Safety: ECDSA_verify does not mutate the key */
+    EC_KEY *ec_key = NULL;
+    POSIX_GUARD_RESULT(s2n_unsafe_ecdsa_get_mut(key, &ec_key));
+
     /* ECDSA_verify ignores the first parameter */
-    POSIX_GUARD_OSSL(ECDSA_verify(0, digest_out, digest_length, signature->data, signature->size, key->ec_key), S2N_ERR_VERIFY_SIGNATURE);
+    POSIX_GUARD_OSSL(ECDSA_verify(0, digest_out, digest_length, signature->data, signature->size, ec_key), S2N_ERR_VERIFY_SIGNATURE);
 
     POSIX_GUARD(s2n_hash_reset(digest));
-    
+
     return 0;
 }
 
-static int s2n_ecdsa_keys_match(const struct s2n_pkey *pub, const struct s2n_pkey *priv) 
+static int s2n_ecdsa_keys_match(const struct s2n_pkey *pub, const struct s2n_pkey *priv)
 {
     uint8_t input[16] = { 1 };
     DEFER_CLEANUP(struct s2n_blob signature = { 0 }, s2n_free);
@@ -139,15 +172,20 @@ static int s2n_ecdsa_keys_match(const struct s2n_pkey *pub, const struct s2n_pke
 
 static int s2n_ecdsa_key_free(struct s2n_pkey *pkey)
 {
+    POSIX_ENSURE_REF(pkey);
     struct s2n_ecdsa_key *ecdsa_key = &pkey->key.ecdsa_key;
     if (ecdsa_key->ec_key == NULL) {
-        return 0;
+        return S2N_SUCCESS;
     }
-    
-    EC_KEY_free(ecdsa_key->ec_key);
+
+    /* Safety: freeing the key owned by this object */
+    EC_KEY *ec_key = NULL;
+    POSIX_GUARD_RESULT(s2n_unsafe_ecdsa_get_mut(ecdsa_key, &ec_key));
+
+    EC_KEY_free(ec_key);
     ecdsa_key->ec_key = NULL;
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 static int s2n_ecdsa_check_key_exists(const struct s2n_pkey *pkey)
@@ -159,18 +197,18 @@ static int s2n_ecdsa_check_key_exists(const struct s2n_pkey *pkey)
 
 int s2n_evp_pkey_to_ecdsa_private_key(s2n_ecdsa_private_key *ecdsa_key, EVP_PKEY *evp_private_key)
 {
-    EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(evp_private_key);
+    const EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(evp_private_key);
     S2N_ERROR_IF(ec_key == NULL, S2N_ERR_DECODE_PRIVATE_KEY);
-    
+
     ecdsa_key->ec_key = ec_key;
     return 0;
 }
 
 int s2n_evp_pkey_to_ecdsa_public_key(s2n_ecdsa_public_key *ecdsa_key, EVP_PKEY *evp_public_key)
 {
-    EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(evp_public_key);
+    const EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(evp_public_key);
     S2N_ERROR_IF(ec_key == NULL, S2N_ERR_DECODE_CERTIFICATE);
-    
+
     ecdsa_key->ec_key = ec_key;
     return 0;
 }
@@ -194,7 +232,8 @@ int s2n_ecdsa_pkey_matches_curve(const struct s2n_ecdsa_key *ecdsa_key, const st
     POSIX_ENSURE_REF(ecdsa_key->ec_key);
     POSIX_ENSURE_REF(curve);
 
-    int curve_id = EC_GROUP_get_curve_name(EC_KEY_get0_group(ecdsa_key->ec_key));
+    const EC_KEY *key = ecdsa_key->ec_key;
+    int curve_id = EC_GROUP_get_curve_name(EC_KEY_get0_group(key));
     POSIX_ENSURE_EQ(curve_id, curve->libcrypto_nid);
 
     return 0;

--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -39,9 +39,7 @@
 #define S2N_ECDSA_TYPE 0
 
 EC_KEY *s2n_unsafe_ecdsa_get_non_const(const struct s2n_ecdsa_key *ecdsa_key) {
-    if(ecdsa_key == NULL) {
-        return NULL;
-    }
+    PTR_ENSURE_REF(ecdsa_key);
 
     /* pragma gcc diagnostic was added in gcc 4.6 */
 #if defined(__clang__) || S2N_GCC_VERSION_AT_LEAST(4,6,0)

--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -49,7 +49,7 @@ EC_KEY *s2n_unsafe_ecdsa_get_non_const(const struct s2n_ecdsa_key *ecdsa_key) {
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #endif
     EC_KEY *out_ec_key = (EC_KEY *) ecdsa_key->ec_key;
-#if S2N_GCC_VERSION_AT_LEAST(4,6,0)
+#if defined(__clang__) || S2N_GCC_VERSION_AT_LEAST(4,6,0)
 #pragma GCC diagnostic pop
 #endif
 

--- a/crypto/s2n_ecdsa.h
+++ b/crypto/s2n_ecdsa.h
@@ -30,6 +30,15 @@
 struct s2n_pkey;
 
 struct s2n_ecdsa_key {
+    /*
+     * Starting in openssl_3, `EVP_PKEY_get1_EC_KEY` and `EVP_PKEY_get0_EC_KEY`
+     * functions return a pre-cached copy of the underlying key. This means that any
+     * mutations are not reflected back onto the underlying key.
+     *
+     * The `const` identifier is present to help ensure that the key is not mutated.
+     * Usecases which require a non-const EC_KEY (some openssl functions), should
+     * use `s2n_unsafe_ecdsa_get_non_const` while ensuring that the usage is safe.
+     */
     const EC_KEY *ec_key;
 };
 

--- a/crypto/s2n_ecdsa.h
+++ b/crypto/s2n_ecdsa.h
@@ -30,7 +30,7 @@
 struct s2n_pkey;
 
 struct s2n_ecdsa_key {
-    EC_KEY *ec_key;
+    const EC_KEY *ec_key;
 };
 
 typedef struct s2n_ecdsa_key s2n_ecdsa_public_key;

--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -34,9 +34,7 @@
 #include "utils/s2n_safety.h"
 
 RSA *s2n_unsafe_rsa_get_non_const(const struct s2n_rsa_key *rsa_key) {
-    if(rsa_key == NULL) {
-        return NULL;
-    }
+    PTR_ENSURE_REF(rsa_key);
 
     /* pragma gcc diagnostic was added in gcc 4.6 */
 #if defined(__clang__) || S2N_GCC_VERSION_AT_LEAST(4,6,0)

--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -44,7 +44,7 @@ RSA *s2n_unsafe_rsa_get_non_const(const struct s2n_rsa_key *rsa_key) {
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #endif
     RSA *out_rsa_key = (RSA *) rsa_key->rsa;
-#if S2N_GCC_VERSION_AT_LEAST(4,6,0)
+#if defined(__clang__) || S2N_GCC_VERSION_AT_LEAST(4,6,0)
 #pragma GCC diagnostic pop
 #endif
 

--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -39,7 +39,7 @@ S2N_RESULT s2n_unsafe_rsa_get_mut(const struct s2n_rsa_key *rsa_key, RSA **out_r
     RESULT_ENSURE_EQ(*out_rsa_key, NULL);
 
     /* pragma gcc diagnostic was added in gcc 4.6 */
-#if S2N_GCC_VERSION_AT_LEAST(4,6,0)
+#if S2N_GCC_VERSION_AT_LEAST_OR_CLANG(4,6,0)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #endif

--- a/crypto/s2n_rsa.h
+++ b/crypto/s2n_rsa.h
@@ -28,8 +28,10 @@
 struct s2n_pkey;
 
 struct s2n_rsa_key {
-    RSA *rsa;
+    const RSA *rsa;
 };
+
+S2N_RESULT s2n_unsafe_rsa_get_mut(const struct s2n_rsa_key *rsa_key, RSA **out_rsa_key);
 
 typedef struct s2n_rsa_key s2n_rsa_public_key;
 typedef struct s2n_rsa_key s2n_rsa_private_key;

--- a/crypto/s2n_rsa.h
+++ b/crypto/s2n_rsa.h
@@ -28,10 +28,19 @@
 struct s2n_pkey;
 
 struct s2n_rsa_key {
+    /*
+     * Starting in openssl_3, `EVP_PKEY_get1_RSA` and `EVP_PKEY_get0_RSA` functions
+     * return a pre-cached copy of the underlying key. This means that any mutations
+     * are not reflected back onto the underlying key.
+     *
+     * The `const` identifier is present to help ensure that the key is not mutated.
+     * Usecases which require a non-const RSA key (some openssl functions), should
+     * use `s2n_unsafe_rsa_get_non_const` while ensuring that the usage is safe.
+     */
     const RSA *rsa;
 };
 
-S2N_RESULT s2n_unsafe_rsa_get_mut(const struct s2n_rsa_key *rsa_key, RSA **out_rsa_key);
+RSA *s2n_unsafe_rsa_get_non_const(const struct s2n_rsa_key *rsa_key);
 
 typedef struct s2n_rsa_key s2n_rsa_public_key;
 typedef struct s2n_rsa_key s2n_rsa_private_key;

--- a/crypto/s2n_rsa_signing.c
+++ b/crypto/s2n_rsa_signing.c
@@ -69,10 +69,8 @@ int s2n_rsa_pkcs1v15_sign_digest(const struct s2n_pkey *priv, s2n_hash_algorithm
     unsigned int signature_size = signature->size;
 
     /* Safety: RSA_sign does not mutate the key */
-    RSA *key = NULL;
-    POSIX_GUARD_RESULT(s2n_unsafe_rsa_get_mut(rsa_key, &key));
-
-    POSIX_GUARD_OSSL(RSA_sign(NID_type, digest->data, digest->size, signature->data, &signature_size, key), S2N_ERR_SIGN);
+    POSIX_GUARD_OSSL(RSA_sign(NID_type, digest->data, digest->size, signature->data, &signature_size,
+                s2n_unsafe_rsa_get_non_const(rsa_key)), S2N_ERR_SIGN);
     POSIX_ENSURE(signature_size <= signature->size, S2N_ERR_SIZE_MISMATCH);
     signature->size = signature_size;
 
@@ -111,10 +109,8 @@ int s2n_rsa_pkcs1v15_verify(const struct s2n_pkey *pub, struct s2n_hash_state *d
     POSIX_GUARD(s2n_hash_digest(digest, digest_out, digest_length));
 
     /* Safety: RSA_verify does not mutate the key */
-    RSA *key = NULL;
-    POSIX_GUARD_RESULT(s2n_unsafe_rsa_get_mut(rsa_key, &key));
-
-    POSIX_GUARD_OSSL(RSA_verify(digest_NID_type, digest_out, digest_length, signature->data, signature->size, key), S2N_ERR_VERIFY_SIGNATURE);
+    POSIX_GUARD_OSSL(RSA_verify(digest_NID_type, digest_out, digest_length, signature->data, signature->size,
+                s2n_unsafe_rsa_get_non_const(rsa_key)), S2N_ERR_VERIFY_SIGNATURE);
 
     return 0;
 }

--- a/tests/unit/s2n_rsa_pss_rsae_test.c
+++ b/tests/unit/s2n_rsa_pss_rsae_test.c
@@ -22,9 +22,11 @@
 #include "crypto/s2n_hash.h"
 #include "crypto/s2n_rsa.h"
 #include "crypto/s2n_rsa_pss.h"
+#include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_config.h"
+#include "utils/s2n_safety.h"
 #include "utils/s2n_random.h"
 
 #define HASH_ALG S2N_HASH_SHA256
@@ -195,7 +197,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_pkey_free(&rsa_public_key));
     }
 
-    #if RSA_PSS_CERTS_SUPPORTED
+#if RSA_PSS_CERTS_SUPPORTED
 
     struct s2n_cert_chain_and_key *rsa_pss_cert_chain;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&rsa_pss_cert_chain,
@@ -245,11 +247,10 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&rsa_pss_public_key, &rsa_pss_pkey_type, &rsa_pss_cert_chain->cert_chain->head->raw));
             EXPECT_EQUAL(rsa_pss_pkey_type, S2N_PKEY_TYPE_RSA_PSS);
 
-            /* Set the keys equal */
-            const BIGNUM *n, *e, *d;
-            RSA_get0_key(EVP_PKEY_get0_RSA(rsa_public_key.pkey), &n, &e, &d);
-            EXPECT_SUCCESS(RSA_set0_key(EVP_PKEY_get0_RSA(rsa_pss_public_key.pkey),
-                    BN_dup(n), BN_dup(e), BN_dup(d)));
+            /* Set the keys equal. */
+            RSA *rsa_key_copy = EVP_PKEY_get1_RSA(rsa_public_key.pkey);
+            POSIX_GUARD_OSSL(EVP_PKEY_set1_RSA(rsa_pss_public_key.pkey, rsa_key_copy), S2N_ERR_KEY_INIT);
+            RSA_free(rsa_key_copy);
 
             /* RSA signed with PSS, RSA_PSS verified with PSS */
             {
@@ -285,12 +286,15 @@ int main(int argc, char **argv)
                 &rsa_cert_chain->cert_chain->head->raw));
         EXPECT_EQUAL(rsa_pkey_type, S2N_PKEY_TYPE_RSA);
 
-        RSA *rsa_key = EVP_PKEY_get0_RSA(rsa_public_key.pkey);
+        /* Modify the rsa_public_key for each test_case. */
+        RSA *rsa_key_copy = EVP_PKEY_get1_RSA(rsa_public_key.pkey);
         BIGNUM *n = BN_new(), *e = BN_new(), *d = BN_new();
         EXPECT_SUCCESS(BN_hex2bn(&n, test_case.key_param_n));
         EXPECT_SUCCESS(BN_hex2bn(&e, test_case.key_param_e));
         EXPECT_SUCCESS(BN_hex2bn(&d, test_case.key_param_d));
-        EXPECT_SUCCESS(RSA_set0_key(rsa_key, n, e, d));
+        EXPECT_SUCCESS(RSA_set0_key(rsa_key_copy, n, e, d));
+        POSIX_GUARD_OSSL(EVP_PKEY_set1_RSA(rsa_public_key.pkey, rsa_key_copy), S2N_ERR_KEY_INIT);
+        RSA_free(rsa_key_copy);
 
         struct s2n_stuffer message_stuffer = { 0 }, signature_stuffer = { 0 };
         s2n_stuffer_alloc_ro_from_hex_string(&message_stuffer, test_case.message);
@@ -311,7 +315,8 @@ int main(int argc, char **argv)
     }
 
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(rsa_pss_cert_chain));
-    #endif
+#endif
+
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(rsa_cert_chain));
     END_TEST();
 }

--- a/utils/s2n_compiler.h
+++ b/utils/s2n_compiler.h
@@ -22,3 +22,11 @@
 #define S2N_GCC_VERSION_AT_LEAST(major, minor, patch_level) \
     ((S2N_GCC_VERSION) >= ((major) * 10000 + (minor) * 100 + (patch_level)))
 
+#if defined (__clang__)
+    #define S2N_GCC_VERSION_AT_LEAST_OR_CLANG(major, minor, patch_level) \
+        true
+#else
+    #define S2N_GCC_VERSION_AT_LEAST_OR_CLANG(major, minor, patch_level) \
+        ((S2N_GCC_VERSION) >= ((major) * 10000 + (minor) * 100 + (patch_level)))
+#endif
+

--- a/utils/s2n_compiler.h
+++ b/utils/s2n_compiler.h
@@ -22,11 +22,3 @@
 #define S2N_GCC_VERSION_AT_LEAST(major, minor, patch_level) \
     ((S2N_GCC_VERSION) >= ((major) * 10000 + (minor) * 100 + (patch_level)))
 
-#if defined (__clang__)
-    #define S2N_GCC_VERSION_AT_LEAST_OR_CLANG(major, minor, patch_level) \
-        true
-#else
-    #define S2N_GCC_VERSION_AT_LEAST_OR_CLANG(major, minor, patch_level) \
-        ((S2N_GCC_VERSION) >= ((major) * 10000 + (minor) * 100 + (patch_level)))
-#endif
-


### PR DESCRIPTION
tracking issue: https://github.com/aws/s2n-tls/issues/3442

previous closed PR: ~~https://github.com/aws/s2n-tls/pull/3473~~ (this stored a non-const RSA key. while this worked, it was brittle)

### Description of changes:
The API and behavior for `EVP_PKEY_get0_RSA` has change in openssl3. The main difference is that the return value is now marked as `const`, which triggers warnings across the codebase. The second difference is that the return value is no longer direct reference to the PKEY, but instead a reference to a pre-cached value.

[oss1 EVP_PKEY_get0_RSA](https://www.openssl.org/docs/man1.1.1/man3/EVP_PKEY_get0_RSA.html): direct reference, not-const, should not be freed
[oss3 EVP_PKEY_get0_RSA](https://www.openssl.org/docs/man3.0/man3/EVP_PKEY_get0_RSA.html): pre-cached copy, const, should not be freed

Our codebase is making a few assumptions at the moment:
- for a rsa_pss key we use [`EVP_PKEY_get0_RSA`](https://github.com/aws/s2n-tls/blob/1d9538b12121b70af1f395a2e6361cab37d08eea/crypto/s2n_rsa_pss.c#L186) which is not a copy, we [DO NOT need to free the RSA key](https://github.com/aws/s2n-tls/blob/1d9538b12121b70af1f395a2e6361cab37d08eea/crypto/s2n_rsa_pss.c#L177-L183)
- for a s2n_rsa key we use [`EVP_PKEY_get1_RSA`](https://github.com/aws/s2n-tls/blob/1d9538b12121b70af1f395a2e6361cab37d08eea/crypto/s2n_rsa.c#L171), which does need to be [freed](https://github.com/aws/s2n-tls/blob/1d9538b12121b70af1f395a2e6361cab37d08eea/crypto/s2n_rsa.c#L151-L160)

---
**Solution**
1) switch to using `EVP_PKEY_get1_RSA` and store `const RSA`. Since `EVP_PKEY_get1_RSA` returns a copy, and needs to be freed, we need to free the key in s2n_rsa_pass.c.
1) Update ecdsa code to also store `const EC_KEY`
1) We need to update all usage of `EVP_PKEY_get0_RSA` -> `EVP_PKEY_get1_RSA` in tests and subsequently call free.
1) We need to call `EVP_PKEY_set1_RSA` to set an PKEY since in ossl3 a pre-cached value is returned rather than the direct key

### Testing:
  - openssl 1.0.2 (unit tests pass)
  - openssl 3 (unit tests and asan tests passes locally)
    `Running /home/ubuntu/projects/rsync/s2n-tls/tests/unit/s2n_rsa_pss_rsae_test.c ... PASSED        213 tests`

#### Code analysis:
- EVP_PKEY_get0_RSA
  - https://github.com/openssl/openssl/blob/openssl-3.0.5/crypto/evp/p_legacy.c#L43
    - https://github.com/openssl/openssl/blob/openssl-3.0.5/crypto/evp/p_lib.c#L2069
      - *returns pk->legacy_cache_pkey.ptr*
  - https://github.com/openssl/openssl/blob/OpenSSL_1_1_1/crypto/evp/p_lib.c#L461
    - *returns pkey->pkey.rsa*
- EVP_PKEY_set1_RSA
  - https://github.com/openssl/openssl/blob/openssl-3.0.5/crypto/evp/p_legacy.c#L25
    - https://github.com/openssl/openssl/blob/openssl-3.0.5/crypto/evp/p_lib.c#L741
      - *sets pkey->pkey.ptr = key;* which is similar to modifying EVP_PKEY_get0_RSA value in openssl1.1.1

### Callouts:

I also attempted to store the PKEY directly instead of `RSA`, however ossl1.0.2 doesnt have `EVP_PKEY_get0_RSA` API, which means excessive calls to `EVP_PKEY_get1_RSA` and free when an RSA key is needed. The solution in this PR instead calls EVP_PKEY_get1_RSA once and stores the RSA key.

---

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
