### PR TITLE
Add compliance comments for Section 5: Record Protocol, fix some edge cases

### DIFF
--- a/tests/unit/s2n_change_cipher_spec_test.c
+++ b/tests/unit/s2n_change_cipher_spec_test.c
@@ -53,7 +53,14 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test that s2n_basic_ccs_recv errors on wrong change cipher spec types */
+    /* Test that s2n_basic_ccs_recv errors on wrong change cipher spec types
+    *= https://tools.ietf.org/rfc/rfc8446#5
+    *= type=test
+    *# An
+    *# implementation which receives any other change_cipher_spec value or
+    *# which receives a protected change_cipher_spec record MUST abort the
+    *# handshake with an "unexpected_message" alert.
+    */
     {
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
@@ -64,7 +71,14 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test that s2n_client_ccs_recv errors on wrong change cipher spec types */
+    /* Test that s2n_client_ccs_recv errors on wrong change cipher spec types
+    *= https://tools.ietf.org/rfc/rfc8446#5
+    *= type=test
+    *# An
+    *# implementation which receives any other change_cipher_spec value or
+    *# which receives a protected change_cipher_spec record MUST abort the
+    *# handshake with an "unexpected_message" alert.
+    */
     {
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
@@ -75,7 +89,14 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test that s2n_server_ccs_recv errors on wrong change cipher spec types */
+    /* Test that s2n_server_ccs_recv errors on wrong change cipher spec types
+    *= https://tools.ietf.org/rfc/rfc8446#5
+    *= type=test
+    *# An
+    *# implementation which receives any other change_cipher_spec value or
+    *# which receives a protected change_cipher_spec record MUST abort the
+    *# handshake with an "unexpected_message" alert.
+    */
     {
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));

--- a/tests/unit/s2n_fragmentation_coalescing_test.c
+++ b/tests/unit/s2n_fragmentation_coalescing_test.c
@@ -472,6 +472,7 @@ int main(int argc, char **argv)
     /* Pretend the client hello has already been set */
     conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
     conn->handshake.message_number = SERVER_HELLO;
+    conn->handshake.client_hello_received = 1;
 
     /* Create a child process */
     pid = fork();
@@ -518,6 +519,7 @@ int main(int argc, char **argv)
     /* Pretend the client hello has already been set */
     conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
     conn->handshake.message_number = SERVER_HELLO;
+    conn->handshake.client_hello_received = 1;
 
     /* Create a child process */
     pid = fork();

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -387,6 +387,19 @@ int main(int argc, char **argv)
         EXPECT_FAILURE_WITH_ERRNO(s2n_record_header_parse(conn, &content_type, &fragment_length), S2N_ERR_BAD_MESSAGE);
     }
 
+    /* Test TLS 1.3 Record can't have an unknown content type 
+     *= https://tools.ietf.org/rfc/rfc8446#5
+     *= type=test
+     *# Implementations MUST NOT send record types not defined in this
+     *# document unless negotiated by some extension.
+     */
+    {
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
+
+        conn->actual_protocol_version = S2N_TLS13;
+        EXPECT_FAILURE(s2n_record_write(conn, 255, &empty_blob));
+    }
+
     /* Test: ApplicationData MUST be encrypted */
     {
         EXPECT_SUCCESS(s2n_connection_wipe(conn));

--- a/tests/unit/s2n_tls13_handshake_state_machine_test.c
+++ b/tests/unit/s2n_tls13_handshake_state_machine_test.c
@@ -488,13 +488,14 @@ int main(int argc, char **argv)
 
             conn->handshake.handshake_type = handshake;
             conn->in_status = ENCRYPTED;
+            conn->handshake.client_hello_received = 1;
 
             /* Don't loop over all 32 potential messages just up until the last one. */
             for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH && (j+1 < S2N_MAX_HANDSHAKE_LENGTH && tls13_handshakes[handshake][j+1] != 0); j++) {
                 conn->handshake.message_number = j;
 
                 EXPECT_SUCCESS(s2n_test_write_header(&input, TLS_CHANGE_CIPHER_SPEC, 0));
-
+                
                 EXPECT_SUCCESS(s2n_handshake_read_io(conn));
 
                 if (tls13_handshakes[handshake][j] == SERVER_CHANGE_CIPHER_SPEC) {
@@ -538,6 +539,7 @@ int main(int argc, char **argv)
 
             conn->handshake.handshake_type = handshake;
             conn->in_status = ENCRYPTED;
+            conn->handshake.client_hello_received = 1;
 
             for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH && (j+1 < S2N_MAX_HANDSHAKE_LENGTH && tls13_handshakes[handshake][j+1] != 0); j++) {
                 conn->handshake.message_number = j;
@@ -610,6 +612,7 @@ int main(int argc, char **argv)
 
             conn->handshake.handshake_type = 0;
             conn->handshake.message_number = 0;
+            conn->handshake.client_hello_received = 0;
             EXPECT_EQUAL(ACTIVE_MESSAGE(conn), CLIENT_HELLO);
             EXPECT_SUCCESS(s2n_setup_handler_to_expect(CLIENT_HELLO, S2N_SERVER));
 
@@ -643,6 +646,7 @@ int main(int argc, char **argv)
 
             conn->handshake.handshake_type = NEGOTIATED;
             conn->handshake.message_number = 5;
+            conn->handshake.client_hello_received = 1;
             EXPECT_EQUAL(ACTIVE_MESSAGE(conn), APPLICATION_DATA);
             EXPECT_SUCCESS(s2n_setup_handler_to_expect(APPLICATION_DATA, S2N_SERVER));
 

--- a/tests/unit/s2n_tls13_handshake_state_machine_test.c
+++ b/tests/unit/s2n_tls13_handshake_state_machine_test.c
@@ -488,7 +488,7 @@ int main(int argc, char **argv)
 
             conn->handshake.handshake_type = handshake;
             conn->in_status = ENCRYPTED;
-            conn->handshake.client_hello_received = 1;
+            conn->handshake.client_hello_seen = 1;
 
             /* Don't loop over all 32 potential messages just up until the last one. */
             for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH && (j+1 < S2N_MAX_HANDSHAKE_LENGTH && tls13_handshakes[handshake][j+1] != 0); j++) {
@@ -539,7 +539,7 @@ int main(int argc, char **argv)
 
             conn->handshake.handshake_type = handshake;
             conn->in_status = ENCRYPTED;
-            conn->handshake.client_hello_received = 1;
+            conn->handshake.client_hello_seen = 1;
 
             for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH && (j+1 < S2N_MAX_HANDSHAKE_LENGTH && tls13_handshakes[handshake][j+1] != 0); j++) {
                 conn->handshake.message_number = j;
@@ -613,6 +613,7 @@ int main(int argc, char **argv)
             conn->handshake.handshake_type = 0;
             conn->handshake.message_number = 0;
             conn->handshake.client_hello_received = 0;
+            conn->handshake.client_hello_seen = 0;
             EXPECT_EQUAL(ACTIVE_MESSAGE(conn), CLIENT_HELLO);
             EXPECT_SUCCESS(s2n_setup_handler_to_expect(CLIENT_HELLO, S2N_SERVER));
 
@@ -646,7 +647,7 @@ int main(int argc, char **argv)
 
             conn->handshake.handshake_type = NEGOTIATED;
             conn->handshake.message_number = 5;
-            conn->handshake.client_hello_received = 1;
+            conn->handshake.client_hello_seen = 1;
             EXPECT_EQUAL(ACTIVE_MESSAGE(conn), APPLICATION_DATA);
             EXPECT_SUCCESS(s2n_setup_handler_to_expect(APPLICATION_DATA, S2N_SERVER));
 

--- a/tests/unit/s2n_tls13_handshake_state_machine_test.c
+++ b/tests/unit/s2n_tls13_handshake_state_machine_test.c
@@ -122,6 +122,13 @@ int main(int argc, char **argv)
     /* Test: A WITH_EARLY_DATA form of every non-full, non-retry handshake exists
      *       and matches the non-WITH_EARLY_DATA form EXCEPT for the END_OF_EARLY_DATA
      *       message and client CCS messages.
+     *= https://tools.ietf.org/rfc/rfc8446#5
+     *= type=test
+     *# An implementation may receive an unencrypted record of type
+     *# change_cipher_spec consisting of the single byte value 0x01 at any
+     *# time after the first ClientHello message has been sent or received
+     *# and before the peer's Finished message has been received and MUST
+     *# simply drop it without further processing.
      */
     {
         uint32_t original_handshake_type, early_data_handshake_type;
@@ -183,7 +190,15 @@ int main(int argc, char **argv)
     }
 
     /* Test: A MIDDLEBOX_COMPAT form of every valid, negotiated handshake exists
-     *       and matches the non-MIDDLEBOX_COMPAT form EXCEPT for CCS messages */
+     *       and matches the non-MIDDLEBOX_COMPAT form EXCEPT for CCS messages
+     *= https://tools.ietf.org/rfc/rfc8446#5
+     *= type=test
+     *# An implementation may receive an unencrypted record of type
+     *# change_cipher_spec consisting of the single byte value 0x01 at any
+     *# time after the first ClientHello message has been sent or received
+     *# and before the peer's Finished message has been received and MUST
+     *# simply drop it without further processing.
+     */
     {
         uint32_t handshake_type_original, handshake_type_mc;
         message_type_t *messages_original, *messages_mc;
@@ -314,7 +329,15 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test: TLS1.3 server does not wait for client cipher change requests */
+    /* Test: TLS1.3 server does not wait for client cipher change requests.
+    *= https://tools.ietf.org/rfc/rfc8446#5
+    *= type=test
+    *# An implementation may receive an unencrypted record of type
+    *# change_cipher_spec consisting of the single byte value 0x01 at any
+    *# time after the first ClientHello message has been sent or received
+    *# and before the peer's Finished message has been received and MUST
+    *# simply drop it without further processing.
+    */
     {
         struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
         conn->actual_protocol_version = S2N_TLS13;
@@ -368,7 +391,15 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test: TLS1.3 client does not wait for server cipher change requests */
+    /* Test: TLS1.3 client does not wait for server cipher change requests
+    *= https://tools.ietf.org/rfc/rfc8446#5
+    *= type=test
+    *# An implementation may receive an unencrypted record of type
+    *# change_cipher_spec consisting of the single byte value 0x01 at any
+    *# time after the first ClientHello message has been sent or received
+    *# and before the peer's Finished message has been received and MUST
+    *# simply drop it without further processing.
+    */
     {
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
         conn->actual_protocol_version = S2N_TLS13;
@@ -421,8 +452,16 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
-
-    /* Test: TLS1.3 client can receive a server cipher change spec at any time. */
+    
+    /* Test: TLS1.3 client can receive a server cipher change spec at any time.
+    *= https://tools.ietf.org/rfc/rfc8446#5
+    *= type=test
+    *# An implementation may receive an unencrypted record of type
+    *# change_cipher_spec consisting of the single byte value 0x01 at any
+    *# time after the first ClientHello message has been sent or received
+    *# and before the peer's Finished message has been received and MUST
+    *# simply drop it without further processing.
+    */
     {
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
         conn->actual_protocol_version = S2N_TLS13;
@@ -463,7 +502,15 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test: TLS1.3 server can receive a client cipher change request at any time. */
+    /* Test: TLS1.3 server can receive a client cipher change request at any time.
+     *= https://tools.ietf.org/rfc/rfc8446#5
+     *= type=test
+     *# An implementation may receive an unencrypted record of type
+     *# change_cipher_spec consisting of the single byte value 0x01 at any
+     *# time after the first ClientHello message has been sent or received
+     *# and before the peer's Finished message has been received and MUST
+     *# simply drop it without further processing.
+     */
     {
         struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
         conn->actual_protocol_version = S2N_TLS13;

--- a/tests/unit/s2n_tls13_handshake_state_machine_test.c
+++ b/tests/unit/s2n_tls13_handshake_state_machine_test.c
@@ -85,7 +85,7 @@ static bool s2n_is_end_of_tls13_handshake(size_t handshake, size_t message_numbe
     EXPECT_TRUE(handshake < S2N_HANDSHAKES_COUNT);
     EXPECT_TRUE(message_number < S2N_MAX_HANDSHAKE_LENGTH);
 
-    bool is_app_data = s2n_tls13_handshake_message_is_application_data(handshake, message_number);
+    bool is_app_data = s2n_tls13_handshake_message_is_application_data(handshake, message_number + 1);
     
     bool plus_one_is_uninit_or_client_hello = s2n_tls13_handshake_message_is_uninit_or_client_hello(handshake, message_number + 1);
     bool plus_two_is_uninit_or_client_hello = s2n_tls13_handshake_message_is_uninit_or_client_hello(handshake, message_number + 2);

--- a/tests/unit/s2n_tls13_handshake_state_machine_test.c
+++ b/tests/unit/s2n_tls13_handshake_state_machine_test.c
@@ -491,7 +491,9 @@ int main(int argc, char **argv)
             conn->handshake.client_hello_seen = 1;
 
             /* Don't loop over all 32 potential messages just up until the last one. */
-            for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH && (j+1 < S2N_MAX_HANDSHAKE_LENGTH && tls13_handshakes[handshake][j+1] != 0); j++) {
+            for (int j = 1; (j+1 < S2N_MAX_HANDSHAKE_LENGTH && tls13_handshakes[handshake][j+1] != 0) ||
+                            (j+1 == S2N_MAX_HANDSHAKE_LENGTH);
+                j++) {
                 conn->handshake.message_number = j;
 
                 EXPECT_SUCCESS(s2n_test_write_header(&input, TLS_CHANGE_CIPHER_SPEC, 0));
@@ -541,7 +543,9 @@ int main(int argc, char **argv)
             conn->in_status = ENCRYPTED;
             conn->handshake.client_hello_seen = 1;
 
-            for (int j = 1; j < S2N_MAX_HANDSHAKE_LENGTH && (j+1 < S2N_MAX_HANDSHAKE_LENGTH && tls13_handshakes[handshake][j+1] != 0); j++) {
+            for (int j = 1; (j+1 < S2N_MAX_HANDSHAKE_LENGTH && tls13_handshakes[handshake][j+1] != 0) || 
+                            (j+1 == S2N_MAX_HANDSHAKE_LENGTH);
+                j++) {
                 conn->handshake.message_number = j;
 
                 EXPECT_SUCCESS(s2n_test_write_header(&input, TLS_CHANGE_CIPHER_SPEC, 0));

--- a/tests/unit/s2n_tls13_handshake_state_machine_test.c
+++ b/tests/unit/s2n_tls13_handshake_state_machine_test.c
@@ -66,7 +66,7 @@ static int s2n_setup_handler_to_expect(message_type_t expected, uint8_t directio
 }
 
 static bool s2n_tls13_handshake_message_is_uninit_or_client_hello(size_t handshake, size_t message_number) {
-    if (S2N_MAX_HANDSHAKE_LENGTH > message_number && message_number >= 0) {
+    if (message_number < S2N_MAX_HANDSHAKE_LENGTH) {
         return tls13_handshakes[handshake][message_number] == 0;
     } else {
         return true;
@@ -74,7 +74,7 @@ static bool s2n_tls13_handshake_message_is_uninit_or_client_hello(size_t handsha
 }
 
 static bool s2n_tls13_handshake_message_is_application_data(size_t handshake, size_t message_number) {
-    if (S2N_MAX_HANDSHAKE_LENGTH > message_number && message_number >= 0) {
+    if (message_number < S2N_MAX_HANDSHAKE_LENGTH) {
         return tls13_handshakes[handshake][message_number] == APPLICATION_DATA;
     } else {
         return false;

--- a/tls/s2n_change_cipher_spec.c
+++ b/tls/s2n_change_cipher_spec.c
@@ -33,6 +33,13 @@ int s2n_basic_ccs_recv(struct s2n_connection *conn)
     uint8_t type;
 
     POSIX_GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, &type));
+    /*
+    *= https://tools.ietf.org/rfc/rfc8446#5
+    *# An
+    *# implementation which receives any other change_cipher_spec value or
+    *# which receives a protected change_cipher_spec record MUST abort the
+    *# handshake with an "unexpected_message" alert.
+    */
     S2N_ERROR_IF(type != CHANGE_CIPHER_SPEC_TYPE, S2N_ERR_BAD_MESSAGE);
 
     return 0;

--- a/tls/s2n_establish_session.c
+++ b/tls/s2n_establish_session.c
@@ -36,6 +36,7 @@ int s2n_establish_session(struct s2n_connection *conn)
     if (!conn->handshake.client_hello_received) {
         POSIX_GUARD(s2n_client_hello_recv(conn));
         conn->handshake.client_hello_received = 1;
+        conn->handshake.client_hello_seen = 1;
     }
 
     POSIX_GUARD_RESULT(s2n_early_data_accept_or_reject(conn));

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -165,6 +165,9 @@ struct s2n_handshake {
     /* Indicates the CLIENT_HELLO message has been completely received */
     unsigned client_hello_received:1;
 
+    /* Indicates the CLIENT_HELLO message has been seen previously */
+    unsigned client_hello_seen:1;
+
     /* Indicates the handshake blocked while trying to read or write data, and has been paused */
     unsigned paused:1;
 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1238,7 +1238,7 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
          */
         if (IS_TLS13_HANDSHAKE(conn)) {
             S2N_ERROR_IF(EXPECTED_RECORD_TYPE(conn) == TLS_APPLICATION_DATA, S2N_ERR_BAD_MESSAGE);
-            S2N_ERROR_IF(!(conn->handshake.client_hello_received), S2N_ERR_BAD_MESSAGE);
+            S2N_ERROR_IF(CONNECTION_WRITER(conn) == 'S' && !(conn->handshake.client_hello_received), S2N_ERR_BAD_MESSAGE);
             S2N_ERROR_IF(ACTIVE_MESSAGE(conn) == APPLICATION_DATA, S2N_ERR_BAD_MESSAGE);
         }
 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1211,7 +1211,14 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
         /* TLS1.3 can receive unexpected CCS messages at any point in the handshake
          * due to a peer operating in middlebox compatibility mode.
          * However, when operating in QUIC mode, S2N should not accept ANY CCS messages,
-         * including these unexpected ones.*/
+         * including these unexpected ones.
+         *= https://tools.ietf.org/rfc/rfc8446#5
+         *# An implementation may receive an unencrypted record of type
+         *# change_cipher_spec consisting of the single byte value 0x01 at any
+         *# time after the first ClientHello message has been sent or received
+         *# and before the peer's Finished message has been received and MUST
+         *# simply drop it without further processing.
+         */
         if (!IS_TLS13_HANDSHAKE(conn) || s2n_connection_is_quic_enabled(conn)) {
             POSIX_ENSURE(EXPECTED_RECORD_TYPE(conn) == TLS_CHANGE_CIPHER_SPEC, S2N_ERR_BAD_MESSAGE);
             POSIX_ENSURE(!CONNECTION_IS_WRITER(conn), S2N_ERR_BAD_MESSAGE);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1238,7 +1238,6 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
          */
         if (IS_TLS13_HANDSHAKE(conn)) {
             S2N_ERROR_IF(EXPECTED_RECORD_TYPE(conn) == TLS_APPLICATION_DATA, S2N_ERR_BAD_MESSAGE);
-            S2N_ERROR_IF(CONNECTION_WRITER(conn) == 'S' && !(conn->handshake.client_hello_received), S2N_ERR_BAD_MESSAGE);
             S2N_ERROR_IF(ACTIVE_MESSAGE(conn) == APPLICATION_DATA, S2N_ERR_BAD_MESSAGE);
         }
 


### PR DESCRIPTION
### Description of changes: 

Here is a walk through of the RFC section:

## 5 Record Protocol



>The TLS record protocol takes messages to be transmitted, fragments
the data into manageable blocks, protects the records, and transmits
the result.  Received data is verified, decrypted, reassembled, and
then delivered to higher-level clients.

Reading a single record is implemented in s2n_recv.c by s2n_read_full_record.

>TLS records are typed, which allows multiple higher-level protocols
to be multiplexed over the same record layer.  This document
specifies four content types: handshake, application_data, alert, and
change_cipher_spec.  The change_cipher_spec record is used only for
compatibility purposes (see Appendix D.4).

These content types, sometimes called record types in the code, take on values defined in s2n_tls_parameters. 

>An implementation may receive an unencrypted record of type change_cipher_spec consisting of the single byte value 0x01 at any time after the first ClientHello message has been sent or received
and before the peer's Finished message has been received and MUST
simply drop it without further processing.

Our implementation process the change cipher spec message in s2n_handshake_read_io in s2n_handshake_io.c. It first reads the full record (potentially decrypting it in the process) and then explicitly handles the case when the record type is change cipher spec by calling the handler and potentially advancing the state machine. In the case of non-quic tls13 we don’t check the state machine, making it valid to receive a change cipher spec message anytime s2n_handshake_read_io is called. 

This PR adds a check that ensures we only are receiving the change_cipher_spec during the handshake. The check ensures that the expected record type is not Application Data (which would put us after the handshake). It also checks, perhaps redundantly, that the active message in the state machine is not application data. Finally it checks that if we are the server we have never before seen the client_hello message. This required *adding* a bit to the handshake struct called client_hello_seen which parallels client_hello_received, but never gets reset on a hello retry request. -- I attempted other solutions, like looking at the state machine for a client hello. But a client hello can occur multiple times during a handshake making it hard to detect `the first ClientHello message` as called out in the RFC.

I'd personally like a better solution that doesn't require the extra bit. Let me know if you think of something!


>Note that this record may
appear at a point at the handshake where the implementation is
expecting protected records, and so it is necessary to detect this
condition prior to attempting to deprotect the record.  An
implementation which receives any other change_cipher_spec value or
which receives a protected change_cipher_spec record MUST abort the
handshake with an "unexpected_message" alert. 


This is handled by the s2n_basic_ccs_recv which is called upon to process the record format and errors if the value is not 1.


> If an implementation
detects a change_cipher_spec record received before the first
ClientHello message or after the peer's Finished message, it MUST be
treated as an unexpected record type (though stateless servers may
not be able to distinguish these cases from allowed cases).


I updated the implementation in s2n_handshake_read_io to detect a change cipher spec message before the client hello or after the peer’s finish. And added tests to match. See tests/unit/s2n_tls13_handshake_state_machine_test.c. Some of the tests had to be modified be more precise in what they did, since ccs messages are no-longer allowed after or before the handshake.  

Unfortunately detecting a change_cipher_spec record received before the first
ClientHello proved difficult due to the hello retry request. — It’s not enough to check that the active message is CLIENT_HELLO and the mode is server.  — You also have to know that that is the first client hello. That information isn’t currently encoded anywhere. I’ve added it to s2n_connection.


>Implementations MUST NOT send record types not defined in this
document unless negotiated by some extension.


I wrote the record types out in s2n_handshake_write_io. The record type written is extracted by the EXPECTED_RECORD_TYPE macro from the state machine. Since the state machine don’t contain any record types not defined in this document we don’t send any unexpected record types. To test this we test all states in the state machine contain a valid expected record type: see tests/unit/s2n_tls13_handshake_state_machine_test.c.

Post handshake I wrote an assert in the s2n_record_writev to ensure that the content type is a valid content type in the case the protocol is TLS13. This should prevent us from ever sending an undefined record type.


>If a TLS
implementation receives an unexpected record type, it MUST terminate
the connection with an "unexpected_message" alert.  New record
content type values are assigned by IANA in the TLS ContentType
registry as described in Section 11.


This arguably required a minor change in s2n_handshake_read_io, we now BAIL in the event that we don’t recognize the record type. Presumably since all the call sights of s2n_handshake_read_io are internal this isn't required. But my choice was to defend in depth.



### Call-outs:

Most of this PR is just duvet comments.

There are two minor things that got implemented:

client_hello_seen:
tests/unit/s2n_fragmentation_coalescing_test.c -- Added a setup line for client_hello_seen
tests/unit/s2n_tls13_handshake_state_machine_test.c -- Added some tests
tls/s2n_establish_session.c -- Added setup line for  client_hello_seen
tls/s2n_handshake.h -- Implemented tls/s2n_handshake.h

Don't write/read bad message types:
tls/s2n_record_write.c
tls/s2n_handshake_io.c
tests/unit/s2n_tls13_handshake_state_machine_test.c

### Testing:

Ran the duvet tool to generate an HTML compliance coverage report and observed a `Complete` status for this requirement.

Got the implementations reviewed. 
