### PR TITLE
Fix reference to wrong function

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2985,7 +2985,7 @@ extern int s2n_config_set_async_pkey_callback(struct s2n_config *config, s2n_asy
  *
  * @param op An opaque object representing the private key operation
  * @param key The private key used for the operation. It can be extracted from
- * `conn` through the `s2n_connection_get_selected_cert` and `s2n_cert_chain_and_key_get_key` calls
+ * `conn` through the `s2n_connection_get_selected_cert` and `s2n_cert_chain_and_key_get_private_key` calls
  */
 S2N_API
 extern int s2n_async_pkey_op_perform(struct s2n_async_pkey_op *op, s2n_cert_private_key *key);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -853,7 +853,7 @@ always eventually be freed by calling **s2n_async_pkey_op_free**.
 
 The private key operation can be performed by calling **s2n_async_pkey_op_perform**
 (or **s2n_async_pkey_op_set_output**: see [Offloading private key operations](#Offloading-private-key-operations)).
-The required private key can be retrieved using the **s2n_connection_get_selected_cert** and **s2n_cert_chain_and_key_get_key** calls. The operation can then be finalized with **s2n_async_pkey_op_apply** to continue the handshake.
+The required private key can be retrieved using the **s2n_connection_get_selected_cert** and **s2n_cert_chain_and_key_get_private_key** calls. The operation can then be finalized with **s2n_async_pkey_op_apply** to continue the handshake.
 
 ### Asynchronous Private Key Operations
 


### PR DESCRIPTION
### Resolved issues:

n/a

### Description of changes: 

The documentation references a function `s2n_cert_chain_and_key_get_key` that does not exist. I believe it meant to reference `s2n_cert_chain_and_key_get_private_key`.

### Call-outs:

n/a

### Testing:

n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
