### PR TITLE
ci: update freebsd image

### DIFF
--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build and test in FreeBSD
         id: test
-        uses: vmactions/freebsd-vm@v0.1.5
+        uses: vmactions/freebsd-vm@v0.2.4
         with:
           prepare: pkg install -y ninja cmake
           run: |


### PR DESCRIPTION
### Description of changes: 
FreeBSD CI tests were failing. This updates the [FreeBSD github CI image](https://github.com/vmactions/freebsd-vm/releases/tag/v0.2.4) to latest; which seems to fix the error.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
