### PR TITLE
Allow verification of signatures before sending

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -871,6 +871,8 @@ extern int s2n_config_add_pem_to_trust_store(struct s2n_config *config, const ch
 S2N_API
 extern int s2n_config_wipe_trust_store(struct s2n_config *config);
 
+typedef enum { S2N_VERIFY_AFTER_SIGN_DISABLED, S2N_VERIFY_AFTER_SIGN_ENABLED } s2n_verify_after_sign;
+
 /**
  * Toggle signature verification.
  *
@@ -884,7 +886,7 @@ extern int s2n_config_wipe_trust_store(struct s2n_config *config);
  * Additionally, most libcrypto implementations already check for common errors in signatures.
  */
 S2N_API
-extern int s2n_config_set_verify_after_sign(struct s2n_config *config, bool enable);
+extern int s2n_config_set_verify_after_sign(struct s2n_config *config, s2n_verify_after_sign mode);
 
 /** 
  * Set a custom send buffer size.

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -871,6 +871,26 @@ extern int s2n_config_add_pem_to_trust_store(struct s2n_config *config, const ch
 S2N_API
 extern int s2n_config_wipe_trust_store(struct s2n_config *config);
 
+typedef enum {
+    S2N_VERIFY_SIG_NEVER = 0,
+    S2N_VERIFY_SIG_ALWAYS,
+} s2n_verify_signature_mode;
+
+/**
+ * Turn on signature verification.
+ *
+ * Although signatures produced by the underlying libcrypto should always be valid,
+ * hardware faults, bugs in the signing implementation, or other uncommon factors
+ * can cause unexpected mistakes in the final signatures. Because these mistakes
+ * can leak information about the private key, applications with low trust in their
+ * hardware or libcrypto may want to verify signatures before sending them.
+ *
+ * However, this feature will significantly impact handshake latency.
+ * Additionally, most libcrypto implementations already check for common errors in signatures.
+ */
+S2N_API
+extern int s2n_config_set_verify_signature_mode(struct s2n_config *config, s2n_verify_signature_mode mode);
+
 /** 
  * Set a custom send buffer size.
  *

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -874,7 +874,7 @@ extern int s2n_config_wipe_trust_store(struct s2n_config *config);
 typedef enum { S2N_VERIFY_AFTER_SIGN_DISABLED, S2N_VERIFY_AFTER_SIGN_ENABLED } s2n_verify_after_sign;
 
 /**
- * Toggle signature verification.
+ * Toggle whether generated signatures are verified before being sent.
  *
  * Although signatures produced by the underlying libcrypto should always be valid,
  * hardware faults, bugs in the signing implementation, or other uncommon factors

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -884,7 +884,7 @@ extern int s2n_config_wipe_trust_store(struct s2n_config *config);
  * Additionally, most libcrypto implementations already check for common errors in signatures.
  */
 S2N_API
-extern int s2n_config_set_signature_verification(struct s2n_config *config, bool enable);
+extern int s2n_config_set_verify_after_sign(struct s2n_config *config, bool enable);
 
 /** 
  * Set a custom send buffer size.

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -871,13 +871,8 @@ extern int s2n_config_add_pem_to_trust_store(struct s2n_config *config, const ch
 S2N_API
 extern int s2n_config_wipe_trust_store(struct s2n_config *config);
 
-typedef enum {
-    S2N_VERIFY_SIG_NEVER = 0,
-    S2N_VERIFY_SIG_ALWAYS,
-} s2n_verify_signature_mode;
-
 /**
- * Turn on signature verification.
+ * Toggle signature verification.
  *
  * Although signatures produced by the underlying libcrypto should always be valid,
  * hardware faults, bugs in the signing implementation, or other uncommon factors
@@ -889,7 +884,7 @@ typedef enum {
  * Additionally, most libcrypto implementations already check for common errors in signatures.
  */
 S2N_API
-extern int s2n_config_set_verify_signature_mode(struct s2n_config *config, s2n_verify_signature_mode mode);
+extern int s2n_config_set_signature_verification(struct s2n_config *config, bool enable);
 
 /** 
  * Set a custom send buffer size.

--- a/tests/unit/s2n_async_pkey_test.c
+++ b/tests/unit/s2n_async_pkey_test.c
@@ -588,7 +588,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
 
             /* Enable signature validation */
-            EXPECT_SUCCESS(s2n_config_set_verify_signature_mode(server_config, S2N_VERIFY_SIG_ALWAYS));
+            EXPECT_SUCCESS(s2n_config_set_signature_verification(server_config, true));
             EXPECT_SUCCESS(try_handshake(server_conn, client_conn, async_handler_sign_with_different_pkey_and_apply));
         }
     }

--- a/tests/unit/s2n_async_pkey_test.c
+++ b/tests/unit/s2n_async_pkey_test.c
@@ -588,7 +588,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
 
             /* Enable signature validation */
-            EXPECT_SUCCESS(s2n_config_set_signature_verification(server_config, true));
+            EXPECT_SUCCESS(s2n_config_set_verify_after_sign(server_config, true));
             EXPECT_SUCCESS(try_handshake(server_conn, client_conn, async_handler_sign_with_different_pkey_and_apply));
         }
     }

--- a/tests/unit/s2n_async_pkey_test.c
+++ b/tests/unit/s2n_async_pkey_test.c
@@ -588,7 +588,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
 
             /* Enable signature validation */
-            EXPECT_SUCCESS(s2n_config_set_verify_after_sign(server_config, true));
+            EXPECT_SUCCESS(s2n_config_set_verify_after_sign(server_config, S2N_VERIFY_AFTER_SIGN_ENABLED));
             EXPECT_SUCCESS(try_handshake(server_conn, client_conn, async_handler_sign_with_different_pkey_and_apply));
         }
     }

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -488,12 +488,22 @@ int main(int argc, char **argv)
 
     /* Test s2n_config_set_verify_after_sign */
     {
-        /* Safety */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_verify_after_sign(NULL, S2N_VERIFY_AFTER_SIGN_ENABLED), S2N_ERR_NULL);
-
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
         EXPECT_FALSE(config->verify_after_sign);
+
+        /* Safety */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_verify_after_sign(NULL, S2N_VERIFY_AFTER_SIGN_ENABLED), S2N_ERR_NULL);
+
+        /* Invalid mode */
+        config->verify_after_sign = true;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_verify_after_sign(config, UINT8_MAX), S2N_ERR_INVALID_ARGUMENT);
+        EXPECT_TRUE(config->verify_after_sign);
+        config->verify_after_sign = false;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_verify_after_sign(config, UINT8_MAX), S2N_ERR_INVALID_ARGUMENT);
+        EXPECT_FALSE(config->verify_after_sign);
+
+        /* Set and unset */
         EXPECT_SUCCESS(s2n_config_set_verify_after_sign(config, S2N_VERIFY_AFTER_SIGN_ENABLED));
         EXPECT_TRUE(config->verify_after_sign);
         EXPECT_SUCCESS(s2n_config_set_verify_after_sign(config, S2N_VERIFY_AFTER_SIGN_DISABLED));

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -489,14 +489,14 @@ int main(int argc, char **argv)
     /* Test s2n_config_set_verify_after_sign */
     {
         /* Safety */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_verify_after_sign(NULL, true), S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_verify_after_sign(NULL, S2N_VERIFY_AFTER_SIGN_ENABLED), S2N_ERR_NULL);
 
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
         EXPECT_FALSE(config->verify_after_sign);
-        EXPECT_SUCCESS(s2n_config_set_verify_after_sign(config, true));
+        EXPECT_SUCCESS(s2n_config_set_verify_after_sign(config, S2N_VERIFY_AFTER_SIGN_ENABLED));
         EXPECT_TRUE(config->verify_after_sign);
-        EXPECT_SUCCESS(s2n_config_set_verify_after_sign(config, false));
+        EXPECT_SUCCESS(s2n_config_set_verify_after_sign(config, S2N_VERIFY_AFTER_SIGN_DISABLED));
         EXPECT_FALSE(config->verify_after_sign);
     }
 

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -486,5 +486,19 @@ int main(int argc, char **argv)
         }
     }
 
+    /* Test s2n_config_set_signature_verification */
+    {
+        /* Safety */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_signature_verification(NULL, true), S2N_ERR_NULL);
+
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+        EXPECT_FALSE(config->verify_signatures);
+        EXPECT_SUCCESS(s2n_config_set_signature_verification(config, true));
+        EXPECT_TRUE(config->verify_signatures);
+        EXPECT_SUCCESS(s2n_config_set_signature_verification(config, false));
+        EXPECT_FALSE(config->verify_signatures);
+    }
+
     END_TEST();
 }

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -486,18 +486,18 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Test s2n_config_set_signature_verification */
+    /* Test s2n_config_set_verify_after_sign */
     {
         /* Safety */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_signature_verification(NULL, true), S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_verify_after_sign(NULL, true), S2N_ERR_NULL);
 
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
-        EXPECT_FALSE(config->verify_signatures);
-        EXPECT_SUCCESS(s2n_config_set_signature_verification(config, true));
-        EXPECT_TRUE(config->verify_signatures);
-        EXPECT_SUCCESS(s2n_config_set_signature_verification(config, false));
-        EXPECT_FALSE(config->verify_signatures);
+        EXPECT_FALSE(config->verify_after_sign);
+        EXPECT_SUCCESS(s2n_config_set_verify_after_sign(config, true));
+        EXPECT_TRUE(config->verify_after_sign);
+        EXPECT_SUCCESS(s2n_config_set_verify_after_sign(config, false));
+        EXPECT_FALSE(config->verify_after_sign);
     }
 
     END_TEST();

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -256,7 +256,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
             /* Enable signature validation */
-            EXPECT_SUCCESS(s2n_config_set_verify_signature_mode(server_config, S2N_VERIFY_SIG_ALWAYS));
+            EXPECT_SUCCESS(s2n_config_set_signature_verification(server_config, true));
             if (test_type == TEST_TYPE_ASYNC) {
                 EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_fn));
             }
@@ -290,7 +290,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "test_all_rsa_kex"));
                 EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
                 /* Enable signature validation */
-                EXPECT_SUCCESS(s2n_config_set_verify_signature_mode(server_config, S2N_VERIFY_SIG_ALWAYS));
+                EXPECT_SUCCESS(s2n_config_set_signature_verification(server_config, true));
                 if (test_type == TEST_TYPE_ASYNC) {
                     EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_fn));
                 }
@@ -326,7 +326,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
             /* Enable signature validation */
-            EXPECT_SUCCESS(s2n_config_set_verify_signature_mode(server_config, S2N_VERIFY_SIG_ALWAYS));
+            EXPECT_SUCCESS(s2n_config_set_signature_verification(server_config, true));
             if (test_type == TEST_TYPE_ASYNC) {
                 EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_fn));
             }
@@ -415,7 +415,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "20200207"));
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             /* Enable signature validation */
-            EXPECT_SUCCESS(s2n_config_set_verify_signature_mode(server_config, S2N_VERIFY_SIG_ALWAYS));
+            EXPECT_SUCCESS(s2n_config_set_signature_verification(server_config, true));
             if (test_type == TEST_TYPE_ASYNC) {
                 EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_fn));
             }

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -255,8 +255,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "20170210"));
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
-            /* Enable signature validation for async sign call */
-            EXPECT_SUCCESS(s2n_config_set_async_pkey_validation_mode(server_config, S2N_ASYNC_PKEY_VALIDATION_STRICT));
+            /* Enable signature validation */
+            EXPECT_SUCCESS(s2n_config_set_verify_signature_mode(server_config, S2N_VERIFY_SIG_ALWAYS));
             if (test_type == TEST_TYPE_ASYNC) {
                 EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_fn));
             }
@@ -289,8 +289,8 @@ int main(int argc, char **argv)
                 /* Configures server with maximum version 1.2 with only RSA key exchange ciphersuites */
                 EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "test_all_rsa_kex"));
                 EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
-                /* Enable signature validation for async sign call */
-                EXPECT_SUCCESS(s2n_config_set_async_pkey_validation_mode(server_config, S2N_ASYNC_PKEY_VALIDATION_STRICT));
+                /* Enable signature validation */
+                EXPECT_SUCCESS(s2n_config_set_verify_signature_mode(server_config, S2N_VERIFY_SIG_ALWAYS));
                 if (test_type == TEST_TYPE_ASYNC) {
                     EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_fn));
                 }
@@ -325,8 +325,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "test_all_ecdsa"));
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
-            /* Enable signature validation for async sign call */
-            EXPECT_SUCCESS(s2n_config_set_async_pkey_validation_mode(server_config, S2N_ASYNC_PKEY_VALIDATION_STRICT));
+            /* Enable signature validation */
+            EXPECT_SUCCESS(s2n_config_set_verify_signature_mode(server_config, S2N_VERIFY_SIG_ALWAYS));
             if (test_type == TEST_TYPE_ASYNC) {
                 EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_fn));
             }
@@ -414,8 +414,8 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(server_config = s2n_config_new());
             EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "20200207"));
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
-            /* Enable signature validation for async sign call */
-            EXPECT_SUCCESS(s2n_config_set_async_pkey_validation_mode(server_config, S2N_ASYNC_PKEY_VALIDATION_STRICT));
+            /* Enable signature validation */
+            EXPECT_SUCCESS(s2n_config_set_verify_signature_mode(server_config, S2N_VERIFY_SIG_ALWAYS));
             if (test_type == TEST_TYPE_ASYNC) {
                 EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_fn));
             }

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -256,7 +256,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
             /* Enable signature validation */
-            EXPECT_SUCCESS(s2n_config_set_verify_after_sign(server_config, true));
+            EXPECT_SUCCESS(s2n_config_set_verify_after_sign(server_config, S2N_VERIFY_AFTER_SIGN_ENABLED));
             if (test_type == TEST_TYPE_ASYNC) {
                 EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_fn));
             }
@@ -290,7 +290,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "test_all_rsa_kex"));
                 EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
                 /* Enable signature validation */
-                EXPECT_SUCCESS(s2n_config_set_verify_after_sign(server_config, true));
+                EXPECT_SUCCESS(s2n_config_set_verify_after_sign(server_config, S2N_VERIFY_AFTER_SIGN_ENABLED));
                 if (test_type == TEST_TYPE_ASYNC) {
                     EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_fn));
                 }
@@ -326,7 +326,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
             /* Enable signature validation */
-            EXPECT_SUCCESS(s2n_config_set_verify_after_sign(server_config, true));
+            EXPECT_SUCCESS(s2n_config_set_verify_after_sign(server_config, S2N_VERIFY_AFTER_SIGN_ENABLED));
             if (test_type == TEST_TYPE_ASYNC) {
                 EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_fn));
             }
@@ -415,7 +415,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "20200207"));
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             /* Enable signature validation */
-            EXPECT_SUCCESS(s2n_config_set_verify_after_sign(server_config, true));
+            EXPECT_SUCCESS(s2n_config_set_verify_after_sign(server_config, S2N_VERIFY_AFTER_SIGN_ENABLED));
             if (test_type == TEST_TYPE_ASYNC) {
                 EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_fn));
             }

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -256,7 +256,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
             /* Enable signature validation */
-            EXPECT_SUCCESS(s2n_config_set_signature_verification(server_config, true));
+            EXPECT_SUCCESS(s2n_config_set_verify_after_sign(server_config, true));
             if (test_type == TEST_TYPE_ASYNC) {
                 EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_fn));
             }
@@ -290,7 +290,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "test_all_rsa_kex"));
                 EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
                 /* Enable signature validation */
-                EXPECT_SUCCESS(s2n_config_set_signature_verification(server_config, true));
+                EXPECT_SUCCESS(s2n_config_set_verify_after_sign(server_config, true));
                 if (test_type == TEST_TYPE_ASYNC) {
                     EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_fn));
                 }
@@ -326,7 +326,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
             /* Enable signature validation */
-            EXPECT_SUCCESS(s2n_config_set_signature_verification(server_config, true));
+            EXPECT_SUCCESS(s2n_config_set_verify_after_sign(server_config, true));
             if (test_type == TEST_TYPE_ASYNC) {
                 EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_fn));
             }
@@ -415,7 +415,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "20200207"));
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             /* Enable signature validation */
-            EXPECT_SUCCESS(s2n_config_set_signature_verification(server_config, true));
+            EXPECT_SUCCESS(s2n_config_set_verify_after_sign(server_config, true));
             if (test_type == TEST_TYPE_ASYNC) {
                 EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(server_config, async_pkey_fn));
             }

--- a/tls/s2n_async_pkey.c
+++ b/tls/s2n_async_pkey.c
@@ -253,7 +253,7 @@ S2N_RESULT s2n_async_pkey_sign_async(struct s2n_connection *conn, s2n_signature_
     op->type = S2N_ASYNC_SIGN;
     op->conn = conn;
     op->validation_mode = conn->config->async_pkey_validation_mode;
-    if (conn->config->verify_sig_mode == S2N_VERIFY_SIG_ALWAYS) {
+    if (conn->config->verify_signatures) {
         op->validation_mode = S2N_ASYNC_PKEY_VALIDATION_STRICT;
     }
 
@@ -283,7 +283,7 @@ S2N_RESULT s2n_async_pkey_sign_sync(struct s2n_connection *conn, s2n_signature_a
     RESULT_GUARD_POSIX(s2n_alloc(&signed_content, maximum_signature_length));
 
     RESULT_ENSURE_REF(conn->config);
-    if (conn->config->verify_sig_mode == S2N_VERIFY_SIG_ALWAYS) {
+    if (conn->config->verify_signatures) {
         DEFER_CLEANUP(struct s2n_hash_state digest_for_verify, s2n_hash_free);
         RESULT_GUARD_POSIX(s2n_hash_new(&digest_for_verify));
         RESULT_GUARD_POSIX(s2n_hash_copy(&digest_for_verify, digest));

--- a/tls/s2n_async_pkey.c
+++ b/tls/s2n_async_pkey.c
@@ -253,7 +253,7 @@ S2N_RESULT s2n_async_pkey_sign_async(struct s2n_connection *conn, s2n_signature_
     op->type = S2N_ASYNC_SIGN;
     op->conn = conn;
     op->validation_mode = conn->config->async_pkey_validation_mode;
-    if (conn->config->verify_signatures) {
+    if (conn->config->verify_after_sign) {
         op->validation_mode = S2N_ASYNC_PKEY_VALIDATION_STRICT;
     }
 
@@ -283,7 +283,7 @@ S2N_RESULT s2n_async_pkey_sign_sync(struct s2n_connection *conn, s2n_signature_a
     RESULT_GUARD_POSIX(s2n_alloc(&signed_content, maximum_signature_length));
 
     RESULT_ENSURE_REF(conn->config);
-    if (conn->config->verify_signatures) {
+    if (conn->config->verify_after_sign) {
         DEFER_CLEANUP(struct s2n_hash_state digest_for_verify, s2n_hash_free);
         RESULT_GUARD_POSIX(s2n_hash_new(&digest_for_verify));
         RESULT_GUARD_POSIX(s2n_hash_copy(&digest_for_verify, digest));

--- a/tls/s2n_async_pkey.c
+++ b/tls/s2n_async_pkey.c
@@ -253,6 +253,9 @@ S2N_RESULT s2n_async_pkey_sign_async(struct s2n_connection *conn, s2n_signature_
     op->type = S2N_ASYNC_SIGN;
     op->conn = conn;
     op->validation_mode = conn->config->async_pkey_validation_mode;
+    if (conn->config->verify_sig_mode == S2N_VERIFY_SIG_ALWAYS) {
+        op->validation_mode = S2N_ASYNC_PKEY_VALIDATION_STRICT;
+    }
 
     struct s2n_async_pkey_sign_data *sign = &op->op.sign;
     sign->on_complete                     = on_complete;
@@ -279,7 +282,16 @@ S2N_RESULT s2n_async_pkey_sign_sync(struct s2n_connection *conn, s2n_signature_a
     RESULT_GUARD(s2n_pkey_size(pkey, &maximum_signature_length));
     RESULT_GUARD_POSIX(s2n_alloc(&signed_content, maximum_signature_length));
 
-    RESULT_GUARD_POSIX(s2n_pkey_sign(pkey, sig_alg, digest, &signed_content));
+    RESULT_ENSURE_REF(conn->config);
+    if (conn->config->verify_sig_mode == S2N_VERIFY_SIG_ALWAYS) {
+        DEFER_CLEANUP(struct s2n_hash_state digest_for_verify, s2n_hash_free);
+        RESULT_GUARD_POSIX(s2n_hash_new(&digest_for_verify));
+        RESULT_GUARD_POSIX(s2n_hash_copy(&digest_for_verify, digest));
+        RESULT_GUARD_POSIX(s2n_pkey_sign(pkey, sig_alg, digest, &signed_content));
+        RESULT_GUARD(s2n_async_pkey_verify_signature(conn, sig_alg, &digest_for_verify, &signed_content));
+    } else {
+        RESULT_GUARD_POSIX(s2n_pkey_sign(pkey, sig_alg, digest, &signed_content));
+    }
 
     RESULT_GUARD_POSIX(on_complete(conn, &signed_content));
 

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -1006,7 +1006,6 @@ int s2n_config_set_verify_after_sign(struct s2n_config *config, s2n_verify_after
             break;
         default:
             POSIX_BAIL(S2N_ERR_INVALID_ARGUMENT);
-            break;
     }
     return S2N_SUCCESS;
 }

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -993,3 +993,10 @@ int s2n_config_set_send_buffer_size(struct s2n_config *config, uint32_t size) {
     config->send_buffer_size_override = size;
     return S2N_SUCCESS;
 }
+
+int s2n_config_set_verify_signature_mode(struct s2n_config *config, s2n_verify_signature_mode mode)
+{
+    POSIX_ENSURE_REF(config);
+    config->verify_sig_mode = mode;
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -994,9 +994,9 @@ int s2n_config_set_send_buffer_size(struct s2n_config *config, uint32_t size) {
     return S2N_SUCCESS;
 }
 
-int s2n_config_set_signature_verification(struct s2n_config *config, bool enable)
+int s2n_config_set_verify_after_sign(struct s2n_config *config, bool enable)
 {
     POSIX_ENSURE_REF(config);
-    config->verify_signatures = enable;
+    config->verify_after_sign = enable;
     return S2N_SUCCESS;
 }

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -994,9 +994,9 @@ int s2n_config_set_send_buffer_size(struct s2n_config *config, uint32_t size) {
     return S2N_SUCCESS;
 }
 
-int s2n_config_set_verify_signature_mode(struct s2n_config *config, s2n_verify_signature_mode mode)
+int s2n_config_set_signature_verification(struct s2n_config *config, bool enable)
 {
     POSIX_ENSURE_REF(config);
-    config->verify_sig_mode = mode;
+    config->verify_signatures = enable;
     return S2N_SUCCESS;
 }

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -994,9 +994,19 @@ int s2n_config_set_send_buffer_size(struct s2n_config *config, uint32_t size) {
     return S2N_SUCCESS;
 }
 
-int s2n_config_set_verify_after_sign(struct s2n_config *config, bool enable)
+int s2n_config_set_verify_after_sign(struct s2n_config *config, s2n_verify_after_sign mode)
 {
     POSIX_ENSURE_REF(config);
-    config->verify_after_sign = enable;
+    switch (mode) {
+        case S2N_VERIFY_AFTER_SIGN_DISABLED:
+            config->verify_after_sign = false;
+            break;
+        case S2N_VERIFY_AFTER_SIGN_ENABLED:
+            config->verify_after_sign = true;
+            break;
+        default:
+            POSIX_BAIL(S2N_ERR_INVALID_ARGUMENT);
+            break;
+    }
     return S2N_SUCCESS;
 }

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -144,6 +144,7 @@ struct s2n_config {
     s2n_psk_mode psk_mode;
 
     s2n_async_pkey_validation_mode async_pkey_validation_mode;
+    s2n_verify_signature_mode verify_sig_mode;
 
     /* The user defined context associated with config */
     void *context;

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -67,6 +67,8 @@ struct s2n_config {
      */
     unsigned client_hello_cb_enable_poll:1;
 
+    unsigned verify_signatures:1;
+
     struct s2n_dh_params *dhparams;
     /* Needed until we can deprecate s2n_config_add_cert_chain_and_key. This is
      * used to release memory allocated only in the deprecated API that the application 
@@ -144,7 +146,6 @@ struct s2n_config {
     s2n_psk_mode psk_mode;
 
     s2n_async_pkey_validation_mode async_pkey_validation_mode;
-    s2n_verify_signature_mode verify_sig_mode;
 
     /* The user defined context associated with config */
     void *context;

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -66,8 +66,11 @@ struct s2n_config {
      * Note: This defaults to false to ensure backwards compatibility.
      */
     unsigned client_hello_cb_enable_poll:1;
-
-    unsigned verify_signatures:1;
+    /*
+     * Whether to verify signatures locally before sending them over the wire.
+     * See s2n_config_set_verify_after_sign.
+     */
+    unsigned verify_after_sign:1;
 
     struct s2n_dh_params *dhparams;
     /* Needed until we can deprecate s2n_config_add_cert_chain_and_key. This is


### PR DESCRIPTION
### Description of changes: 

Add a new API that turns on signature verification.

We already have a similar API, [s2n_config_set_async_pkey_validation_mode](https://github.com/aws/s2n-tls/blob/main/api/s2n.h#L3033-L3041), which only applies to signatures that use the [async pkey operations](https://github.com/aws/s2n-tls/blob/main/docs/USAGE-GUIDE.md#private-key-operation-related-calls). The verification is more useful for async operations because it can help detect the case where the operation is performed with the wrong key.

This new API applies to all signatures, both sync and async.

### Call-outs:

* We could deprecate s2n_config_set_async_pkey_validation_mode. However, it's not actually worse than the new API, just more narrowly focused.
  * Alternatively, we could just expand the scope of s2n_config_set_async_pkey_validation_mode to include sync signatures instead of adding a new API. Since you can actually use the async pkey callbacks to do pkey operations synchronously, it wouldn't really be a massive departure. But the the name would still be very deceptive.

### Testing:
Test cases:
* Async signing, valid signature: covered
* Async signing, invalid signature: covered
* Sync signing, valid signature: covered
* Sync signing, invalid signature: NOT COVERED. I'm not sure how to test this with a unit or integ test, since it's not actually possible without libcrypto bugs or hardware issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
