### PR TITLE
Allow static and shared libs to be mixed (take 2)

### DIFF
--- a/cmake/s2n-config.cmake
+++ b/cmake/s2n-config.cmake
@@ -8,9 +8,19 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
 find_dependency(crypto)
 
+# Allow static or shared lib to be used.
+# If both are installed, choose based on BUILD_SHARED_LIBS.
 if (BUILD_SHARED_LIBS)
-    include(${CMAKE_CURRENT_LIST_DIR}/shared/@PROJECT_NAME@-targets.cmake)
+    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/shared")
+        include(${CMAKE_CURRENT_LIST_DIR}/shared/@PROJECT_NAME@-targets.cmake)
+    else()
+        include(${CMAKE_CURRENT_LIST_DIR}/static/@PROJECT_NAME@-targets.cmake)
+    endif()
 else()
-    include(${CMAKE_CURRENT_LIST_DIR}/static/@PROJECT_NAME@-targets.cmake)
+    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/static")
+        include(${CMAKE_CURRENT_LIST_DIR}/static/@PROJECT_NAME@-targets.cmake)
+    else()
+        include(${CMAKE_CURRENT_LIST_DIR}/shared/@PROJECT_NAME@-targets.cmake)
+    endif()
 endif()
 

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -75,6 +75,7 @@ if [[ "$TESTS" == "ALL" || "$TESTS" == "asan" ]]; then make clean; S2N_ADDRESS_S
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integration" ]]; then make clean; S2N_NO_SSLYZE=1 make integration ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2" ]]; then $CB_BIN_DIR/install_s2n_head.sh "$(mktemp -d)"; make clean; make integrationv2 ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "crt" ]]; then ./codebuild/bin/build_aws_crt_cpp.sh $(mktemp -d) $(mktemp -d); fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "sharedandstatic" ]]; then ./codebuild/bin/test_install_shared_and_static.sh $(mktemp -d); fi
 # Env must have S2N_USE_CRITERION set for the following to work
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2crit" ]]; then make install; make -C bindings/rust ; make -C tests/integrationv2 "${INTEGV2_TEST}"; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "fuzz" ]]; then (make clean && make fuzz) ; fi

--- a/codebuild/bin/test_install_shared_and_static.sh
+++ b/codebuild/bin/test_install_shared_and_static.sh
@@ -39,9 +39,9 @@ export CMAKE_BUILD_PARALLEL_LEVEL=$JOBS
 # its path is stored in the RPATH/RUNPATH of libs2n.so. But many tools (CMake, Ninja)
 # strip the RPATH/RUNPATH during installation. Setting LD_LIBRARY_PATH ensures
 # the desired libcrypto.so is found.
-for LIBDIR in $LIBCRYPTO_ROOT/lib*; do
-  export LD_LIBRARY_PATH=$LIBDIR${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
-done
+# for LIBDIR in $LIBCRYPTO_ROOT/lib*; do
+#   export LD_LIBRARY_PATH=$LIBDIR${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+# done
 
 COMMON_S2N_BUILD_ARGS=(-H. -DCMAKE_PREFIX_PATH=$LIBCRYPTO_ROOT -DBUILD_TESTING=OFF)
 

--- a/codebuild/bin/test_install_shared_and_static.sh
+++ b/codebuild/bin/test_install_shared_and_static.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+set -e
+
+usage() {
+    echo "test_install_shared_and_static.sh build_dir"
+    echo "tests that installed s2n-config.cmake chooses appropriately between shared and static"
+    exit 1
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+fi
+
+WORK_DIR=$1
+
+source codebuild/bin/s2n_setup_env.sh
+source codebuild/bin/jobs.sh
+export CMAKE_BUILD_PARALLEL_LEVEL=$JOBS
+
+# Add $LIBCRYPTO_ROOT/lib to LD_LIBRARY_PATH ("lib" could also be "lib64" or "lib32").
+# This addresses the issue where, after installation, s2n can't find the libcrypto.so it was built against.
+#
+# When s2n is built, if libcrypto.so isn't in an official system lib dir,
+# its path is stored in the RPATH/RUNPATH of libs2n.so. But many tools (CMake, Ninja)
+# strip the RPATH/RUNPATH during installation. Setting LD_LIBRARY_PATH ensures
+# the desired libcrypto.so is found.
+for LIBDIR in $LIBCRYPTO_ROOT/lib*; do
+  export LD_LIBRARY_PATH=$LIBDIR${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+done
+
+COMMON_S2N_BUILD_ARGS=(-H. -DCMAKE_PREFIX_PATH=$LIBCRYPTO_ROOT -DBUILD_TESTING=OFF)
+
+# create installation dir with libs2n.so
+if [ ! -d $WORK_DIR/s2n-install-shared ]; then
+    (set -x; cmake -B$WORK_DIR/s2n-build-shared -DCMAKE_INSTALL_PREFIX=$WORK_DIR/s2n-install-shared -DBUILD_SHARED_LIBS=ON ${COMMON_S2N_BUILD_ARGS[@]})
+    (set -x; cmake --build $WORK_DIR/s2n-build-shared --target install)
+fi
+
+# create installation dir with libs2n.a
+if [ ! -d $WORK_DIR/s2n-install-static ]; then
+    (set -x; cmake -B$WORK_DIR/s2n-build-static -DCMAKE_INSTALL_PREFIX=$WORK_DIR/s2n-install-static -DBUILD_SHARED_LIBS=OFF ${COMMON_S2N_BUILD_ARGS[@]})
+    (set -x; cmake --build $WORK_DIR/s2n-build-static --target install)
+fi
+
+# create installation dir with both libs2n.so and libs2n.a
+if [ ! -d $WORK_DIR/s2n-install-both ]; then
+    (set -x; cmake -B$WORK_DIR/s2n-build-shared-both -DCMAKE_INSTALL_PREFIX=$WORK_DIR/s2n-install-both -DBUILD_SHARED_LIBS=ON ${COMMON_S2N_BUILD_ARGS[@]})
+    (set -x; cmake --build $WORK_DIR/s2n-build-shared-both --target install)
+
+    (set -x; cmake -B$WORK_DIR/s2n-build-static-both -DCMAKE_INSTALL_PREFIX=$WORK_DIR/s2n-install-both -DBUILD_SHARED_LIBS=OFF  ${COMMON_S2N_BUILD_ARGS[@]})
+    (set -x; cmake --build $WORK_DIR/s2n-build-static-both --target install)
+fi
+
+# write out source of a small cmake project, containing:
+# - mylib: a library that uses s2n
+# - myapp: executable that uses mylib
+rm -rf $WORK_DIR/myapp-src
+mkdir -p $WORK_DIR/myapp-src
+
+cat <<EOF > $WORK_DIR/myapp-src/mylib.c
+extern int s2n_init(void);
+
+void mylib_init(void) {
+    s2n_init();
+}
+EOF
+
+cat <<EOF > $WORK_DIR/myapp-src/myapp.c
+extern void mylib_init(void);
+
+int main() {
+    mylib_init();
+}
+EOF
+
+cat <<EOF > $WORK_DIR/myapp-src/CMakeLists.txt
+cmake_minimum_required (VERSION 3.0)
+project (myapp C)
+
+add_library(mylib mylib.c)
+find_package(s2n REQUIRED)
+target_link_libraries(mylib PRIVATE AWS::s2n)
+
+add_executable(myapp myapp.c)
+target_link_libraries(myapp PRIVATE mylib)
+EOF
+
+# build myapp and mylib, confirm that expected type of libs2n is used
+build_myapp() {
+    local BUILD_SHARED_LIBS=$1 # ("BUILD_SHARED_LIBS=ON" or "BUILD_SHARED_LIBS=OFF")
+    local S2N_INSTALL_DIR=$2 # which s2n-install dir should be used
+    local LIBS2N_EXPECTED=$3 # ("libs2n.so" or "libs2n.a") which type of libs2n is expected to be used
+
+    echo "---------------------------------------------------------------------"
+    echo "building myapp with $BUILD_SHARED_LIBS looking-in:$S2N_INSTALL_DIR should-use:$LIBS2N_EXPECTED"
+
+    local MYAPP_BUILD_DIR=$WORK_DIR/myapp-build
+    rm -rf $MYAPP_BUILD_DIR/
+
+    local S2N_INSTALL_PATH=$(realpath $WORK_DIR/$S2N_INSTALL_DIR)
+
+    (set -x; cmake -H$WORK_DIR/myapp-src -B$MYAPP_BUILD_DIR -D$BUILD_SHARED_LIBS "-DCMAKE_PREFIX_PATH=$S2N_INSTALL_PATH;$LIBCRYPTO_ROOT")
+    (set -x; cmake --build $MYAPP_BUILD_DIR)
+    (set -x; ldd $MYAPP_BUILD_DIR/myapp)
+
+    if ldd $MYAPP_BUILD_DIR/myapp | grep -q libs2n.so; then
+        local LIBS2N_ACTUAL=libs2n.so
+    else
+        local LIBS2N_ACTUAL=libs2n.a
+    fi
+
+    if [ $LIBS2N_ACTUAL != $LIBS2N_EXPECTED ]; then
+        echo "test failure: used $LIBS2N_ACTUAL, but expected to use $LIBS2N_EXPECTED"
+        exit 1
+    fi
+}
+
+# if only shared libs2n.so is available, that's what should get used
+build_myapp BUILD_SHARED_LIBS=ON s2n-install-shared libs2n.so
+build_myapp BUILD_SHARED_LIBS=OFF s2n-install-shared libs2n.so
+
+# if only static libs2n.a is available, that's what should get used
+build_myapp BUILD_SHARED_LIBS=ON s2n-install-static libs2n.a
+build_myapp BUILD_SHARED_LIBS=OFF s2n-install-static libs2n.a
+
+# if both libs2n.so and libs2n.a are available...
+build_myapp BUILD_SHARED_LIBS=ON s2n-install-both libs2n.so # should choose libs2n.so
+build_myapp BUILD_SHARED_LIBS=OFF s2n-install-both libs2n.a # should choose libs2n.a

--- a/codebuild/bin/test_install_shared_and_static.sh
+++ b/codebuild/bin/test_install_shared_and_static.sh
@@ -12,7 +12,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 #
-set -e
+set -exo pipefail
 
 usage() {
     echo "test_install_shared_and_static.sh build_dir"
@@ -45,23 +45,23 @@ COMMON_S2N_BUILD_ARGS=(-H. -DCMAKE_PREFIX_PATH=$LIBCRYPTO_ROOT -DBUILD_TESTING=O
 
 # create installation dir with libs2n.so
 if [ ! -d $WORK_DIR/s2n-install-shared ]; then
-    (set -x; cmake -B$WORK_DIR/s2n-build-shared -DCMAKE_INSTALL_PREFIX=$WORK_DIR/s2n-install-shared -DBUILD_SHARED_LIBS=ON ${COMMON_S2N_BUILD_ARGS[@]})
-    (set -x; cmake --build $WORK_DIR/s2n-build-shared --target install)
+    cmake -B$WORK_DIR/s2n-build-shared -DCMAKE_INSTALL_PREFIX=$WORK_DIR/s2n-install-shared -DBUILD_SHARED_LIBS=ON ${COMMON_S2N_BUILD_ARGS[@]}
+    cmake --build $WORK_DIR/s2n-build-shared --target install
 fi
 
 # create installation dir with libs2n.a
 if [ ! -d $WORK_DIR/s2n-install-static ]; then
-    (set -x; cmake -B$WORK_DIR/s2n-build-static -DCMAKE_INSTALL_PREFIX=$WORK_DIR/s2n-install-static -DBUILD_SHARED_LIBS=OFF ${COMMON_S2N_BUILD_ARGS[@]})
-    (set -x; cmake --build $WORK_DIR/s2n-build-static --target install)
+    cmake -B$WORK_DIR/s2n-build-static -DCMAKE_INSTALL_PREFIX=$WORK_DIR/s2n-install-static -DBUILD_SHARED_LIBS=OFF ${COMMON_S2N_BUILD_ARGS[@]}
+    cmake --build $WORK_DIR/s2n-build-static --target install
 fi
 
 # create installation dir with both libs2n.so and libs2n.a
 if [ ! -d $WORK_DIR/s2n-install-both ]; then
-    (set -x; cmake -B$WORK_DIR/s2n-build-shared-both -DCMAKE_INSTALL_PREFIX=$WORK_DIR/s2n-install-both -DBUILD_SHARED_LIBS=ON ${COMMON_S2N_BUILD_ARGS[@]})
-    (set -x; cmake --build $WORK_DIR/s2n-build-shared-both --target install)
+    cmake -B$WORK_DIR/s2n-build-shared-both -DCMAKE_INSTALL_PREFIX=$WORK_DIR/s2n-install-both -DBUILD_SHARED_LIBS=ON ${COMMON_S2N_BUILD_ARGS[@]}
+    cmake --build $WORK_DIR/s2n-build-shared-both --target install
 
-    (set -x; cmake -B$WORK_DIR/s2n-build-static-both -DCMAKE_INSTALL_PREFIX=$WORK_DIR/s2n-install-both -DBUILD_SHARED_LIBS=OFF  ${COMMON_S2N_BUILD_ARGS[@]})
-    (set -x; cmake --build $WORK_DIR/s2n-build-static-both --target install)
+    cmake -B$WORK_DIR/s2n-build-static-both -DCMAKE_INSTALL_PREFIX=$WORK_DIR/s2n-install-both -DBUILD_SHARED_LIBS=OFF  ${COMMON_S2N_BUILD_ARGS[@]}
+    cmake --build $WORK_DIR/s2n-build-static-both --target install
 fi
 
 # write out source of a small cmake project, containing:
@@ -112,9 +112,9 @@ build_myapp() {
 
     local S2N_INSTALL_PATH=$(realpath $WORK_DIR/$S2N_INSTALL_DIR)
 
-    (set -x; cmake -H$WORK_DIR/myapp-src -B$MYAPP_BUILD_DIR -D$BUILD_SHARED_LIBS "-DCMAKE_PREFIX_PATH=$S2N_INSTALL_PATH;$LIBCRYPTO_ROOT")
-    (set -x; cmake --build $MYAPP_BUILD_DIR)
-    (set -x; ldd $MYAPP_BUILD_DIR/myapp)
+    cmake -H$WORK_DIR/myapp-src -B$MYAPP_BUILD_DIR -D$BUILD_SHARED_LIBS "-DCMAKE_PREFIX_PATH=$S2N_INSTALL_PATH;$LIBCRYPTO_ROOT"
+    cmake --build $MYAPP_BUILD_DIR
+    ldd $MYAPP_BUILD_DIR/myapp
 
     if ldd $MYAPP_BUILD_DIR/myapp | grep -q libs2n.so; then
         local LIBS2N_ACTUAL=libs2n.so

--- a/codebuild/bin/test_install_shared_and_static.sh
+++ b/codebuild/bin/test_install_shared_and_static.sh
@@ -26,6 +26,8 @@ fi
 
 WORK_DIR=$1
 
+echo "YES IN FACT I AM THE NEW VERSION"
+
 source codebuild/bin/s2n_setup_env.sh
 source codebuild/bin/jobs.sh
 export CMAKE_BUILD_PARALLEL_LEVEL=$JOBS

--- a/codebuild/bin/test_install_shared_and_static.sh
+++ b/codebuild/bin/test_install_shared_and_static.sh
@@ -16,7 +16,9 @@ set -eo pipefail
 
 usage() {
     echo "test_install_shared_and_static.sh build_dir"
-    echo "tests that installed s2n-config.cmake chooses appropriately between shared and static"
+    echo "Checks that installed s2n-config.cmake chooses appropriately between shared and static."
+    echo "Note that you MUST build against the version of libcrypto that's actually installed on the system,"
+    echo "because installing libs2n.so forces it to use the system's libcrypto.so."
     exit 1
 }
 

--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -186,6 +186,15 @@ batch:
           GCC_VERSION: '6'
           TESTS: crt
 
+    - identifier: s2nInstallSharedAndStatic
+      buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_SMALL
+        privileged-mode: true
+        variables:
+          TESTS: sharedandstatic
+          S2N_LIBCRYPTO: openssl-1.1.1
+
     - buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE

--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -193,6 +193,7 @@ batch:
         privileged-mode: true
         variables:
           TESTS: sharedandstatic
+          # must use the libcrypto that's actually installed on the system
           S2N_LIBCRYPTO: openssl-1.1.1
 
     - buildspec: codebuild/spec/buildspec_ubuntu.yml


### PR DESCRIPTION
This was previously reviewed here: https://github.com/aws/s2n-tls/pull/3467
That was merged to main, but then it broke many other tests, so the commit was reverted.
This PR is exactly the same thing, except LD_LIBRARY_PATH is no longer being tampered with.

I've run the s2nOmnibus tests on this branch, and they're all passing.

### Resolved issues:

This is part of a fix for an issue from another repo: https://github.com/aws4embeddedlinux/meta-aws/pull/191

### Description of changes: 

Currently, users cannot build a shared lib that uses a static libs2n.a, and they cannot build a static lib that uses a shared libs2n.so.

With this change, a library can use either static libs2n.a or shared libs2n.so. If both are static and shared libs2n are installed, BUILD_SHARED_LIBS serves as a tie-breaker.

### Testing:

Added new unit test.

Did local testing:
* installed static libs2n.a and then built a shared library that used it.
* installed shared libs2n.so and then built a static library that used it.
* installed BOTH static libs2n.a and shared libs2n.so
  * Built my own shared library and confirmed that it used picked libs2n.so
  * Built my own static library and confirmed that it picked libs2n.a
* CodeBuild [ad-hoc job](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nOmnibus/batch/s2nOmnibus%3A57766702-8e9b-412e-9804-fbdbc7accebd?region=us-west-2)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
