### PR TITLE
Send no_renegotiation alert

### DIFF
--- a/tests/unit/s2n_client_hello_request_test.c
+++ b/tests/unit/s2n_client_hello_request_test.c
@@ -34,10 +34,12 @@ static S2N_RESULT s2n_test_send_and_recv(struct s2n_connection *send_conn, struc
 
     const uint8_t send_data[] = "hello world";
     ssize_t send_size = s2n_send(send_conn, send_data, sizeof(send_data), &blocked);
+    RESULT_GUARD_POSIX(send_size);
     RESULT_ENSURE_EQ(send_size, sizeof(send_data));
 
     uint8_t recv_data[sizeof(send_data)] = { 0 };
     ssize_t recv_size = s2n_recv(recv_conn, recv_data, send_size, &blocked);
+    RESULT_GUARD_POSIX(recv_size);
     RESULT_ENSURE_EQ(recv_size, send_size);
     EXPECT_BYTEARRAY_EQUAL(recv_data, send_data, send_size);
 
@@ -71,6 +73,10 @@ int main(int argc, char **argv)
     static struct s2n_cert_chain_and_key *chain_and_key = NULL;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
             S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+
+    DEFER_CLEANUP(struct s2n_cert_chain_and_key *ecdsa_chain_and_key = NULL, s2n_cert_chain_and_key_ptr_free);
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&ecdsa_chain_and_key,
+            S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
 
     DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
     EXPECT_NOT_NULL(config);
@@ -108,17 +114,66 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
     }
 
-    /* Test: Hello request received after the handshake */
-    {
+    /* Test: Hello request not accepted for TLS1.3 */
+    if (s2n_is_tls13_fully_supported()) {
         DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
                 s2n_connection_ptr_free);
         EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
         DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
                 s2n_connection_ptr_free);
         EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+
+        /* Start the handshake */
+        EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
+                SERVER_HELLO));
+
+        /* Send a hello request.
+         * We should be able to receive the hello request before the version is negotiated. */
+        EXPECT_OK(s2n_send_client_hello_request(server_conn));
+
+        /* Continue the handshake */
+        EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
+                ENCRYPTED_EXTENSIONS));
+
+        /* Send a hello request.
+         * We should NOT be able to receive the hello request after TLS1.3 is negotiated */
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
+        EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
+        EXPECT_OK(s2n_send_client_hello_request(server_conn));
+
+        /* Handshake should fail because the HelloRequest is unexpected in TLS1.3 */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_test_server_and_client(server_conn, client_conn),
+                S2N_ERR_BAD_MESSAGE);
+    }
+
+    /* Test: Hello request received after the handshake */
+    {
+        DEFER_CLEANUP(struct s2n_config *config_with_warns = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config_with_warns);
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config_with_warns, "default"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config_with_warns));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config_with_warns, chain_and_key));
+        EXPECT_SUCCESS(s2n_config_set_alert_behavior(config_with_warns, S2N_ALERT_IGNORE_WARNINGS));
+
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config_with_warns));
+
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config_with_warns));
 
         DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
@@ -138,6 +193,35 @@ int main(int argc, char **argv)
         /* Send some more data */
         EXPECT_OK(s2n_test_send_and_recv(server_conn, client_conn));
         EXPECT_OK(s2n_test_send_and_recv(client_conn, server_conn));
+    }
+
+    /* Test: no_renegotiation sent in response to valid hello request */
+    {
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+
+        /* Complete the handshake */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+        /* Send the hello request message. */
+        EXPECT_OK(s2n_send_client_hello_request(server_conn));
+
+        /* no_renegotation alert sent and received */
+        EXPECT_OK(s2n_test_send_and_recv(server_conn, client_conn));
+        EXPECT_ERROR_WITH_ERRNO(s2n_test_send_and_recv(client_conn, server_conn), S2N_ERR_ALERT);
+        EXPECT_EQUAL(s2n_connection_get_alert(server_conn), S2N_TLS_ALERT_NO_RENEGOTIATION);
     }
 
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -275,3 +275,9 @@ int s2n_queue_reader_handshake_failure_alert(struct s2n_connection *conn)
 {
     return s2n_queue_reader_alert(conn, S2N_TLS_ALERT_LEVEL_FATAL, S2N_TLS_ALERT_HANDSHAKE_FAILURE);
 }
+
+S2N_RESULT s2n_queue_reader_no_renegotiation_alert(struct s2n_connection *conn)
+{
+    RESULT_GUARD_POSIX(s2n_queue_reader_alert(conn, S2N_TLS_ALERT_LEVEL_WARNING, S2N_TLS_ALERT_NO_RENEGOTIATION));
+    return S2N_RESULT_OK;
+}

--- a/tls/s2n_alerts.h
+++ b/tls/s2n_alerts.h
@@ -74,6 +74,11 @@ typedef enum {
     S2N_TLS_ALERT_INAPPROPRIATE_FALLBACK = 86,
     S2N_TLS_ALERT_USER_CANCELED = 90,
     /*
+     *= https://tools.ietf.org/rfc/rfc5246#section-7.2
+     *#     no_renegotiation(100),
+     */
+    S2N_TLS_ALERT_NO_RENEGOTIATION = 100,
+    /*
      *= https://tools.ietf.org/rfc/rfc8446#section-6
      *#     missing_extension(109),
      *#     unsupported_extension(110),
@@ -101,3 +106,4 @@ extern int s2n_process_alert_fragment(struct s2n_connection *conn);
 extern int s2n_queue_writer_close_alert_warning(struct s2n_connection *conn);
 extern int s2n_queue_reader_unsupported_protocol_version_alert(struct s2n_connection *conn);
 extern int s2n_queue_reader_handshake_failure_alert(struct s2n_connection *conn);
+S2N_RESULT s2n_queue_reader_no_renegotiation_alert(struct s2n_connection *conn);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1289,7 +1289,7 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
          *# SHOULD be ignored by the client if it arrives in the middle of a handshake.
          */
         if (message_type == TLS_HELLO_REQUEST) {
-            POSIX_GUARD(s2n_client_hello_request_recv(conn));
+            POSIX_GUARD_RESULT(s2n_client_hello_request_validate(conn));
             POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
             continue;
         }

--- a/tls/s2n_post_handshake.c
+++ b/tls/s2n_post_handshake.c
@@ -49,7 +49,7 @@ int s2n_post_handshake_recv(struct s2n_connection *conn)
                 POSIX_GUARD_RESULT(s2n_tls13_server_nst_recv(conn, &post_handshake_stuffer));
                 break;
             case TLS_HELLO_REQUEST:
-                POSIX_GUARD(s2n_client_hello_request_recv(conn));
+                POSIX_GUARD_RESULT(s2n_client_hello_request_recv(conn));
                 break;
             case TLS_CLIENT_HELLO:
             case TLS_SERVER_HELLO:

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -24,7 +24,8 @@ extern uint8_t s2n_unknown_protocol_version;
 extern uint8_t s2n_highest_protocol_version;
 
 extern int s2n_flush(struct s2n_connection *conn, s2n_blocked_status * more);
-int s2n_client_hello_request_recv(struct s2n_connection *conn);
+S2N_RESULT s2n_client_hello_request_validate(struct s2n_connection *conn);
+S2N_RESULT s2n_client_hello_request_recv(struct s2n_connection *conn);
 extern int s2n_client_hello_send(struct s2n_connection *conn);
 extern int s2n_client_hello_recv(struct s2n_connection *conn);
 extern int s2n_establish_session(struct s2n_connection *conn);


### PR DESCRIPTION
### Description of changes: 

Previously, s2n-tls ignored all HelloRequest messages instead of sending the no_renegotation alert, which was allowed by the TLS1.2 spec ([RFC5246](https://www.rfc-editor.org/rfc/rfc5246)). However, some behavior in the secure renegotiation spec ([RFC5746](https://www.rfc-editor.org/rfc/rfc5746)) explicitly requires the no_renegotation alert, without listing "do nothing" as an alternative. Since we will be implementing the rest of the secure renegotiation spec, we need to add the no_renegotiation alert.

And since sending the no_renegotation alert is more standard than silently ignoring the message, I also updated the existing logic to use the alert.

### Callouts
This does have the same issue that many of our post-handshake messages have: the alert is queued for sending during s2n_recv, but won't actually be sent until the application calls s2n_send. This isn't a problem for the other existing "reader alerts" because they're fatal, so the application should call s2n_shutdown after they're queued, which handles the send.

We really need a mechanism to indicate to the application that s2n-tls needs to do work. That would also ensure NewSessionTicket and KeyUpdate messages get sent.

### Testing:
I added a new test to make sure the alert is sent/received when the request is received after the handshake.

Since s2n-tls treats warning alerts as fatal alerts if s2n_config_set_alert_behavior isn't used, and none of the tests for receiving the request during the handshake call s2n_config_set_alert_behavior, those tests also verify that the alert isn't sent/received when the request is received during the handshake.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
