### PR TITLE
Removing Some LGTM Warnings

### DIFF
--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -121,9 +121,11 @@ S2N_RESULT s2n_array_insert(struct s2n_array *array, uint32_t idx, void **elemen
 
     /* If we are adding at an existing index, slide everything down. */
     if (idx < array->len) {
+        uint32_t size = 0;
+        RESULT_GUARD_POSIX(s2n_mul_overflow(array->len - idx, array->element_size, &size));
         memmove(array->mem.data + array->element_size * (idx + 1),
                 array->mem.data + array->element_size * idx,
-                (array->len - idx) * array->element_size);
+                size);
     }
 
     *element = array->mem.data + array->element_size * idx;
@@ -141,9 +143,11 @@ S2N_RESULT s2n_array_remove(struct s2n_array *array, uint32_t idx)
     /* If the removed element is the last one, no need to move anything.
      * Otherwise, shift everything down */
     if (idx != array->len - 1) {
+        uint32_t size = 0;
+        RESULT_GUARD_POSIX(s2n_mul_overflow(array->len - idx - 1, array->element_size, &size));
         memmove(array->mem.data + array->element_size * idx,
                 array->mem.data + array->element_size * (idx + 1),
-                (array->len - idx - 1) * array->element_size);
+                size);
     }
     array->len--;
 


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 
LGTM has a warning about these two lines of code, so I'm getting rid of them. 
https://lgtm.com/projects/g/aws/s2n-tls/alerts/?mode=list&severity=warning
### Call-outs:
Not going to bother with the other warnings in LGTM because they're not issues.
### Testing:
LGTM should have two less warnings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
