### PR TITLE
Store explicit length of verify_data

### DIFF
--- a/tests/unit/s2n_change_cipher_spec_test.c
+++ b/tests/unit/s2n_change_cipher_spec_test.c
@@ -97,6 +97,7 @@ int main(int argc, char **argv)
         /* Check preconditions */
         conn->secure->client_sequence_number[0] = 1;
         EXPECT_BYTEARRAY_EQUAL(&conn->handshake.client_finished, &empty_finished_array, S2N_TLS_FINISHED_LEN);
+        EXPECT_EQUAL(conn->handshake.finished_len, 0);
         EXPECT_NOT_EQUAL(conn->client, conn->secure);
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->alert_in, 1));
 
@@ -106,10 +107,36 @@ int main(int argc, char **argv)
         /* Check for expected updates */
         EXPECT_EQUAL(conn->secure->client_sequence_number[0], 0);
         EXPECT_BYTEARRAY_NOT_EQUAL(&conn->handshake.client_finished, &empty_finished_array, S2N_TLS_FINISHED_LEN);
+        EXPECT_EQUAL(conn->handshake.finished_len, S2N_TLS_FINISHED_LEN);
         EXPECT_EQUAL(conn->client, conn->secure);
         EXPECT_FALSE(s2n_stuffer_data_available(&conn->alert_in));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test SSLv3 s2n_client_ccs_recv */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        conn->secure->cipher_suite = &s2n_ecdhe_rsa_with_aes_128_cbc_sha;
+        conn->actual_protocol_version = S2N_SSLv3;
+
+        /* Check preconditions */
+        conn->secure->client_sequence_number[0] = 1;
+        EXPECT_BYTEARRAY_EQUAL(&conn->handshake.client_finished, &empty_finished_array, S2N_TLS_FINISHED_LEN);
+        EXPECT_EQUAL(conn->handshake.finished_len, 0);
+        EXPECT_NOT_EQUAL(conn->client, conn->secure);
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->alert_in, 1));
+
+        EXPECT_SUCCESS(s2n_ccs_send(conn));
+        EXPECT_SUCCESS(s2n_client_ccs_recv(conn));
+
+        /* Check for expected updates */
+        EXPECT_EQUAL(conn->secure->client_sequence_number[0], 0);
+        EXPECT_BYTEARRAY_NOT_EQUAL(&conn->handshake.client_finished, &empty_finished_array, S2N_TLS_FINISHED_LEN);
+        EXPECT_EQUAL(conn->handshake.finished_len, S2N_SSL_FINISHED_LEN);
+        EXPECT_EQUAL(conn->client, conn->secure);
+        EXPECT_FALSE(s2n_stuffer_data_available(&conn->alert_in));
     }
 
     /* Test s2n_server_ccs_recv */
@@ -123,6 +150,7 @@ int main(int argc, char **argv)
         /* Check preconditions */
         conn->secure->server_sequence_number[0] = 1;
         EXPECT_BYTEARRAY_EQUAL(&conn->handshake.server_finished, &empty_finished_array, S2N_TLS_FINISHED_LEN);
+        EXPECT_EQUAL(conn->handshake.finished_len, 0);
         EXPECT_NOT_EQUAL(conn->server, conn->secure);
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->alert_in, 1));
 
@@ -132,10 +160,36 @@ int main(int argc, char **argv)
         /* Check for expected updates */
         EXPECT_EQUAL(conn->secure->server_sequence_number[0], 0);
         EXPECT_BYTEARRAY_NOT_EQUAL(&conn->handshake.server_finished, &empty_finished_array, S2N_TLS_FINISHED_LEN);
+        EXPECT_EQUAL(conn->handshake.finished_len, S2N_TLS_FINISHED_LEN);
         EXPECT_EQUAL(conn->server, conn->secure);
         EXPECT_FALSE(s2n_stuffer_data_available(&conn->alert_in));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
+    }
+
+    /* Test SSLv3 s2n_server_ccs_recv */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        conn->secure->cipher_suite = &s2n_ecdhe_rsa_with_aes_128_cbc_sha;
+        conn->actual_protocol_version = S2N_SSLv3;
+
+        /* Check preconditions */
+        conn->secure->server_sequence_number[0] = 1;
+        EXPECT_BYTEARRAY_EQUAL(&conn->handshake.server_finished, &empty_finished_array, S2N_TLS_FINISHED_LEN);
+        EXPECT_EQUAL(conn->handshake.finished_len, 0);
+        EXPECT_NOT_EQUAL(conn->server, conn->secure);
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->alert_in, 1));
+
+        EXPECT_SUCCESS(s2n_ccs_send(conn));
+        EXPECT_SUCCESS(s2n_server_ccs_recv(conn));
+
+        /* Check for expected updates */
+        EXPECT_EQUAL(conn->secure->server_sequence_number[0], 0);
+        EXPECT_BYTEARRAY_NOT_EQUAL(&conn->handshake.server_finished, &empty_finished_array, S2N_TLS_FINISHED_LEN);
+        EXPECT_EQUAL(conn->handshake.finished_len, S2N_SSL_FINISHED_LEN);
+        EXPECT_EQUAL(conn->server, conn->secure);
+        EXPECT_FALSE(s2n_stuffer_data_available(&conn->alert_in));
     }
 
     END_TEST();

--- a/tests/unit/s2n_client_finished_test.c
+++ b/tests/unit/s2n_client_finished_test.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "api/s2n.h"
+#include "tls/s2n_tls.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Send and receive correct ClientFinished */
+    {
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+        server_conn->secure->cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
+        server_conn->actual_protocol_version = S2N_TLS12;
+
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+        client_conn->secure->cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
+        client_conn->actual_protocol_version = S2N_TLS12;
+
+        /* Calculate valid verify_data */
+        POSIX_GUARD(s2n_prf_client_finished(server_conn));
+
+        EXPECT_EQUAL(client_conn->client, client_conn->initial);
+
+        EXPECT_SUCCESS(s2n_client_finished_send(client_conn));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
+                s2n_stuffer_data_available(&client_conn->handshake.io)));
+        EXPECT_SUCCESS(s2n_client_finished_recv(server_conn));
+
+        EXPECT_EQUAL(client_conn->client, client_conn->secure);
+    }
+
+    /* Server rejects incorrect ClientFinished */
+    {
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+        server_conn->secure->cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
+        server_conn->actual_protocol_version = S2N_TLS12;
+
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+        client_conn->secure->cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
+        client_conn->actual_protocol_version = S2N_TLS12;
+
+        /* Mutate valid verify_data */
+        POSIX_GUARD(s2n_prf_client_finished(server_conn));
+        server_conn->handshake.client_finished[0]++;
+
+        EXPECT_SUCCESS(s2n_client_finished_send(client_conn));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
+                s2n_stuffer_data_available(&client_conn->handshake.io)));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_client_finished_recv(server_conn), S2N_ERR_BAD_MESSAGE);
+    }
+
+    /* Error if local verify_data has wrong length */
+    {
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+        server_conn->secure->cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
+        server_conn->actual_protocol_version = S2N_TLS12;
+
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+        client_conn->secure->cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
+        client_conn->actual_protocol_version = S2N_TLS12;
+
+        /* Change the length of valid verify_data */
+        POSIX_GUARD(s2n_prf_client_finished(server_conn));
+        server_conn->handshake.finished_len = 1;
+
+        EXPECT_SUCCESS(s2n_client_finished_send(client_conn));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io,
+                s2n_stuffer_data_available(&client_conn->handshake.io)));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_client_finished_recv(server_conn), S2N_ERR_SAFETY);
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_handshake_misc_test.c
+++ b/tests/unit/s2n_handshake_misc_test.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+
+#include "tls/s2n_handshake.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test s2n_handshake_set_finished_len */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        const uint8_t max_len = sizeof(conn->handshake.client_finished);
+
+        /* Safety */
+        EXPECT_ERROR_WITH_ERRNO(s2n_handshake_set_finished_len(NULL, 0), S2N_ERR_NULL);
+
+        /* Length must be less than available memory */
+        EXPECT_ERROR_WITH_ERRNO(s2n_handshake_set_finished_len(conn, UINT8_MAX), S2N_ERR_SAFETY);
+        EXPECT_ERROR_WITH_ERRNO(s2n_handshake_set_finished_len(conn, max_len + 1), S2N_ERR_SAFETY);
+
+        /* Length must be greater than zero */
+        EXPECT_ERROR_WITH_ERRNO(s2n_handshake_set_finished_len(conn, 0), S2N_ERR_SAFETY);
+
+        /* Length can change from zero to a valid length */
+        EXPECT_EQUAL(conn->handshake.finished_len, 0);
+        EXPECT_OK(s2n_handshake_set_finished_len(conn, max_len));
+        EXPECT_EQUAL(conn->handshake.finished_len, max_len);
+
+        /* Length can't change if already set.
+         * This method will be called when calculating both the client and server finished / verify_data.
+         * Both client and server should have the same length, or something has gone wrong in our implementation.
+         */
+        EXPECT_ERROR_WITH_ERRNO(s2n_handshake_set_finished_len(conn, max_len - 1), S2N_ERR_SAFETY);
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_server_finished_test.c
+++ b/tests/unit/s2n_server_finished_test.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#include "api/s2n.h"
+#include "tls/s2n_tls.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Send and receive correct ServerFinished */
+    {
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+        server_conn->secure->cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
+        server_conn->actual_protocol_version = S2N_TLS12;
+
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+        client_conn->secure->cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
+        client_conn->actual_protocol_version = S2N_TLS12;
+
+        /* Calculate valid verify_data */
+        POSIX_GUARD(s2n_prf_server_finished(client_conn));
+
+        EXPECT_EQUAL(server_conn->server, server_conn->initial);
+
+        EXPECT_SUCCESS(s2n_server_finished_send(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io,
+                s2n_stuffer_data_available(&server_conn->handshake.io)));
+        EXPECT_SUCCESS(s2n_server_finished_recv(client_conn));
+
+        EXPECT_EQUAL(server_conn->server, server_conn->secure);
+    }
+
+    /* Client rejects incorrect ServerFinished */
+    {
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+        server_conn->secure->cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
+        server_conn->actual_protocol_version = S2N_TLS12;
+
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+        client_conn->secure->cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
+        client_conn->actual_protocol_version = S2N_TLS12;
+
+        /* Mutate valid verify_data */
+        POSIX_GUARD(s2n_prf_server_finished(client_conn));
+        client_conn->handshake.server_finished[0]++;
+
+        EXPECT_SUCCESS(s2n_server_finished_send(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io,
+                s2n_stuffer_data_available(&server_conn->handshake.io)));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_client_finished_recv(client_conn), S2N_ERR_BAD_MESSAGE);
+    }
+
+    /* Error if local verify_data has wrong length */
+    {
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+        server_conn->secure->cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
+        server_conn->actual_protocol_version = S2N_TLS12;
+
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+        client_conn->secure->cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
+        client_conn->actual_protocol_version = S2N_TLS12;
+
+        /* Change the length of valid verify_data */
+        POSIX_GUARD(s2n_prf_server_finished(client_conn));
+        client_conn->handshake.finished_len = 1;
+
+        EXPECT_SUCCESS(s2n_server_finished_send(server_conn));
+        EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io,
+                s2n_stuffer_data_available(&server_conn->handshake.io)));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_client_finished_recv(client_conn), S2N_ERR_SAFETY);
+    }
+
+    END_TEST();
+}

--- a/tls/s2n_client_finished.c
+++ b/tls/s2n_client_finished.c
@@ -30,8 +30,8 @@ S2N_RESULT s2n_finished_send(struct s2n_connection *conn, uint8_t *seq_num, uint
 
 int s2n_client_finished_recv(struct s2n_connection *conn)
 {
-    uint8_t *our_version = conn->handshake.client_finished;
-    POSIX_GUARD_RESULT(s2n_finished_recv(conn, our_version));
+    uint8_t *verify_data = conn->handshake.client_finished;
+    POSIX_GUARD_RESULT(s2n_finished_recv(conn, verify_data));
     POSIX_ENSURE(!conn->handshake.rsa_failed, S2N_ERR_BAD_MESSAGE);
     return S2N_SUCCESS;
 }
@@ -40,10 +40,10 @@ int s2n_client_finished_send(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
 
-    uint8_t *our_version = conn->handshake.client_finished;
+    uint8_t *verify_data = conn->handshake.client_finished;
     uint8_t *seq_num = conn->secure->client_sequence_number;
     POSIX_GUARD(s2n_prf_client_finished(conn));
-    POSIX_GUARD_RESULT(s2n_finished_send(conn, seq_num, our_version));
+    POSIX_GUARD_RESULT(s2n_finished_send(conn, seq_num, verify_data));
 
     POSIX_ENSURE_REF(conn->secure);
     conn->client = conn->secure;

--- a/tls/s2n_client_finished.c
+++ b/tls/s2n_client_finished.c
@@ -30,6 +30,7 @@ S2N_RESULT s2n_finished_send(struct s2n_connection *conn, uint8_t *seq_num, uint
 
 int s2n_client_finished_recv(struct s2n_connection *conn)
 {
+    POSIX_ENSURE_REF(conn);
     uint8_t *verify_data = conn->handshake.client_finished;
     POSIX_GUARD_RESULT(s2n_finished_recv(conn, verify_data));
     POSIX_ENSURE(!conn->handshake.rsa_failed, S2N_ERR_BAD_MESSAGE);

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -354,11 +354,19 @@ S2N_RESULT s2n_handshake_set_finished_len(struct s2n_connection *conn, uint8_t l
     RESULT_ENSURE_LTE(len, sizeof(conn->handshake.server_finished));
     RESULT_ENSURE_LTE(len, sizeof(conn->handshake.client_finished));
 
+    /*
+     * We maintain a version of the "finished" / "verify_data" field
+     * for both the client and server, so this method will be called
+     * once for the client version and once for the server version.
+     *
+     * The lengths of both versions must match, or something has
+     * gone wrong in our implementation.
+     */
     uint8_t *finished_length = &conn->handshake.finished_len;
     if (*finished_length == 0) {
         *finished_length = len;
     }
-
     RESULT_ENSURE_EQ(*finished_length, len);
+
     return S2N_RESULT_OK;
 }

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -346,3 +346,19 @@ S2N_RESULT s2n_handshake_validate(const struct s2n_handshake *s2n_handshake)
     RESULT_DEBUG_ENSURE(s2n_handshake->message_number >= 0 && s2n_handshake->message_number < 32, S2N_ERR_SAFETY);
     return S2N_RESULT_OK;
 }
+
+S2N_RESULT s2n_handshake_set_finished_len(struct s2n_connection *conn, uint8_t len)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_GT(len, 0);
+    RESULT_ENSURE_LTE(len, sizeof(conn->handshake.server_finished));
+    RESULT_ENSURE_LTE(len, sizeof(conn->handshake.client_finished));
+
+    uint8_t *finished_length = &conn->handshake.finished_len;
+    if (*finished_length == 0) {
+        *finished_length = len;
+    }
+
+    RESULT_ENSURE_EQ(*finished_length, len);
+    return S2N_RESULT_OK;
+}

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -143,9 +143,13 @@ struct s2n_handshake {
     uint8_t required_hash_algs[S2N_HASH_SENTINEL];
 
     /*
-     * The data required by the Finished messages.
-     * The data will be different for the client and server,
-     * but the length of the data will be the same.
+     * Data required by the Finished messages.
+     * In TLS1.2 and earlier, the data is the verify_data.
+     * In TLS1.3, the data is the finished_key used to calculate the verify_data.
+     *
+     * The data will be different for the client and server.
+     * The length of the data will be the same for the client and server.
+     * The length of the data depends on protocol version and cipher suite.
      */
     uint8_t server_finished[S2N_TLS_SECRET_LEN];
     uint8_t client_finished[S2N_TLS_SECRET_LEN];

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -144,6 +144,7 @@ struct s2n_handshake {
 
     uint8_t server_finished[S2N_TLS_SECRET_LEN];
     uint8_t client_finished[S2N_TLS_SECRET_LEN];
+    uint8_t finished_len;
 
     /* Which message-order affecting features are enabled */
     uint32_t handshake_type;
@@ -186,6 +187,7 @@ int s2n_create_wildcard_hostname(struct s2n_stuffer *hostname, struct s2n_stuffe
 struct s2n_cert_chain_and_key *s2n_get_compatible_cert_chain_and_key(struct s2n_connection *conn, const s2n_pkey_type cert_type);
 S2N_RESULT s2n_negotiate_until_message(struct s2n_connection *conn, s2n_blocked_status *blocked, message_type_t end_message);
 S2N_RESULT s2n_handshake_validate(const struct s2n_handshake *s2n_handshake);
+S2N_RESULT s2n_handshake_set_finished_len(struct s2n_connection *conn, uint8_t len);
 
 /* s2n_handshake_io */
 int s2n_conn_set_handshake_type(struct s2n_connection *conn);

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -142,6 +142,11 @@ struct s2n_handshake {
      */
     uint8_t required_hash_algs[S2N_HASH_SENTINEL];
 
+    /*
+     * The data required by the Finished messages.
+     * The data will be different for the client and server,
+     * but the length of the data will be the same.
+     */
     uint8_t server_finished[S2N_TLS_SECRET_LEN];
     uint8_t client_finished[S2N_TLS_SECRET_LEN];
     uint8_t finished_len;

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -621,7 +621,7 @@ static int s2n_sslv3_finished(struct s2n_connection *conn, uint8_t prefix[4], st
     uint8_t *md5_digest = out;
     uint8_t *sha_digest = out + MD5_DIGEST_LENGTH;
 
-    POSIX_ENSURE_LTE(MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH, sizeof(conn->handshake.client_finished));
+    POSIX_GUARD_RESULT(s2n_handshake_set_finished_len(conn, MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH));
 
     struct s2n_hash_state *md5 = hash_workspace;
     POSIX_GUARD(s2n_hash_copy(md5, &conn->handshake.hashes->md5));
@@ -659,7 +659,6 @@ static int s2n_sslv3_client_finished(struct s2n_connection *conn)
 
     uint8_t prefix[4] = { 0x43, 0x4c, 0x4e, 0x54 };
 
-    POSIX_ENSURE_LTE(MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH, sizeof(conn->handshake.client_finished));
     return s2n_sslv3_finished(conn, prefix, &conn->handshake.hashes->hash_workspace, conn->handshake.client_finished);
 }
 
@@ -670,7 +669,6 @@ static int s2n_sslv3_server_finished(struct s2n_connection *conn)
 
     uint8_t prefix[4] = { 0x53, 0x52, 0x56, 0x52 };
 
-    POSIX_ENSURE_LTE(MD5_DIGEST_LENGTH + SHA_DIGEST_LENGTH, sizeof(conn->handshake.server_finished));
     return s2n_sslv3_finished(conn, prefix, &conn->handshake.hashes->hash_workspace, conn->handshake.server_finished);
 }
 
@@ -693,6 +691,7 @@ int s2n_prf_client_finished(struct s2n_connection *conn)
 
     client_finished.data = conn->handshake.client_finished;
     client_finished.size = S2N_TLS_FINISHED_LEN;
+    POSIX_GUARD_RESULT(s2n_handshake_set_finished_len(conn, client_finished.size));
     label.data = client_finished_label;
     label.size = sizeof(client_finished_label) - 1;
 
@@ -750,6 +749,7 @@ int s2n_prf_server_finished(struct s2n_connection *conn)
 
     server_finished.data = conn->handshake.server_finished;
     server_finished.size = S2N_TLS_FINISHED_LEN;
+    POSIX_GUARD_RESULT(s2n_handshake_set_finished_len(conn, server_finished.size));
     label.data = server_finished_label;
     label.size = sizeof(server_finished_label) - 1;
 

--- a/tls/s2n_server_finished.c
+++ b/tls/s2n_server_finished.c
@@ -62,6 +62,7 @@ S2N_RESULT s2n_finished_send(struct s2n_connection *conn, uint8_t *seq_num, uint
 
 int s2n_server_finished_recv(struct s2n_connection *conn)
 {
+    POSIX_ENSURE_REF(conn);
     uint8_t *verify_data = conn->handshake.server_finished;
     POSIX_GUARD_RESULT(s2n_finished_recv(conn, verify_data));
     return S2N_SUCCESS;


### PR DESCRIPTION
### Description of changes: 

Currently, the actual lengths of the finished / verify_data fields `conn->handshake.client_finished` and `conn->handshake.server_finished` are implicit, determined by the protocol version and (in TLS1.3) the cipher suite. During renegotiation, connection parameters like protocol version and cipher suite can change. Also during renegotiation, the "finished" fields from the first connection are sent and received/verified as part of the "secure" part of secure renegotiation. 

That _probably_ isn't a huge deal. The cipher suite only matters to the length in TLS1.3, which doesn't support renegotiation, and the actual protocol version doesn't change until late enough in the handshake that it shouldn't affect our use of verify_data. However, the implicit length still makes me very nervous and seems like a potential future foot gun.

I decided to just add an explicit length field that applies to both client_finished and server_finished. I considered adding blobs to represent both, but that required more memory and wouldn't provide much value without an even bigger refactor. We'd just be doing "blob.size =" instead of "finished_len =". Additionally, blobs don't give the nice "both lengths must be equal" guarantee I got with the setter for the shared length field, so we'd still need the setter with blobs.

While making this change, I also cleaned up the <TLS1.3 Finished messages so that they share common code. I was a little lazy about it and left the shared logic in "s2n_server_finished.c" instead of creating a new module, because honestly a module named "s2n_finished" felt weird :/

### Callouts
Sorry about the disaster of a diff in "s2n_server_finished.c". I tried a couple different orderings of the new and old functions, and git hates all of them. See if split mode is good enough, otherwise I may have to create the separate "s2n_finished" module just for a cleaner diff.

### Testing:
* We had no existing unit tests for Client/ServerFinished, so I added new ones. However, technically any test that performed the TLS1.2 handshake tested at least the happy path for Client/ServerFinished.
* I added more unit tests for the SSLv3 path. The verify_data is larger in SSLv3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
