### PR TITLE
Add FS2 Scala Native binding to binding list

### DIFF
--- a/docs/BINDINGS.md
+++ b/docs/BINDINGS.md
@@ -11,3 +11,7 @@ Let us know if you know of a language binding to s2n-tls that's not listed below
 ## Python
 
 * [cys2n](https://github.com/samrushing/cys2n)
+
+## Scala Native
+
+* [FS2](https://fs2.io/#/io?id=tls)


### PR DESCRIPTION
### Description of changes: 

Adds [FS2](https://github.com/typelevel/fs2) as a [Scala Native](https://github.com/scala-native/scala-native) binding to the list of external bindings.

### Call-outs:

I'm a maintainer of the FS2 project 😅 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
