### PR TITLE
docs: update openssl docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ s2n-tls avoids implementing rarely used options and extensions, as well as featu
 The security of TLS and its associated encryption algorithms depends upon secure random number generation. s2n-tls provides every thread with two separate random number generators. One for "public" randomly generated data that may appear in the clear, and one for "private" data that should remain secret. This approach lessens the risk of potential predictability weaknesses in random number generation algorithms from leaking information across contexts.
 
 ##### Modularized encryption
-s2n-tls has been structured so that different encryption libraries may be used. Today s2n-tls supports OpenSSL, LibreSSL, BoringSSL, and the Apple Common Crypto framework to perform the underlying cryptographic operations.
+s2n-tls has been structured so that different encryption libraries may be used. Today s2n-tls supports OpenSSL(1.0.2, 1.1.1, 3.0.x), LibreSSL, BoringSSL, and the Apple Common Crypto framework to perform the underlying cryptographic operations.
 
 ##### Timing blinding
 s2n-tls includes structured support for blinding time-based side-channels that may leak sensitive data. For example, if s2n-tls fails to parse a TLS record or handshake message, s2n-tls will add a randomized delay of between 10 and 30 seconds, granular to nanoseconds, before responding. This raises the complexity of real-world timing side-channel attacks by a factor of at least tens of trillions.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ s2n-tls avoids implementing rarely used options and extensions, as well as featu
 The security of TLS and its associated encryption algorithms depends upon secure random number generation. s2n-tls provides every thread with two separate random number generators. One for "public" randomly generated data that may appear in the clear, and one for "private" data that should remain secret. This approach lessens the risk of potential predictability weaknesses in random number generation algorithms from leaking information across contexts.
 
 ##### Modularized encryption
-s2n-tls has been structured so that different encryption libraries may be used. Today s2n-tls supports OpenSSL(1.0.2, 1.1.1, 3.0.x), LibreSSL, BoringSSL, and the Apple Common Crypto framework to perform the underlying cryptographic operations.
+s2n-tls has been structured so that different encryption libraries may be used. Today s2n-tls supports OpenSSL (versions 1.0.2, 1.1.1 and 3.0.x), LibreSSL, BoringSSL, and the Apple Common Crypto framework to perform the underlying cryptographic operations.
 
 ##### Timing blinding
 s2n-tls includes structured support for blinding time-based side-channels that may leak sensitive data. For example, if s2n-tls fails to parse a TLS record or handshake message, s2n-tls will add a randomized delay of between 10 and 30 seconds, granular to nanoseconds, before responding. This raises the complexity of real-world timing side-channel attacks by a factor of at least tens of trillions.

--- a/codebuild/README.md
+++ b/codebuild/README.md
@@ -21,6 +21,7 @@ General flow of the CodeBuild Test Projects
         - codebuild/install_openssl_1_1_1.sh
         - codebuild/install_openssl_1_0_2.sh
         - codebuild/install_openssl_1_0_2_fips.sh
+        - codebuild/install_openssl_3_0.sh
         - codebuild/install_libressl.sh
         - codebuild/install_python.sh
         - codebuild/install_gnutls.sh

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -77,35 +77,57 @@ And when invoking CMake for your project, do one of two things:
  1. Set the `CMAKE_INSTALL_PREFIX` variable with the path to your s2n-tls build.
  2. If you have globally installed s2n-tls, do nothing, it will automatically be found.
 
-## Building s2n-tls with OpenSSL-1.1.1
+## Building s2n-tls with Openssl
 
-To build s2n-tls with OpenSSL-1.1.1, do the following:
-
+We keep the build artifacts in the -build directory:
 ```shell
-# We keep the build artifacts in the -build directory
 cd libcrypto-build
+```
 
-# Download the latest version of OpenSSL
-curl -LO https://www.openssl.org/source/openssl-1.1.1-latest.tar.gz
-tar -xzvf openssl-1.1.1-latest.tar.gz
+Download the desired Openssl version:
+```shell
+# Download Openssl 3.0.5
+curl -L -o openssl.tar.gz https://github.com/openssl/openssl/archive/refs/tags/openssl-3.0.5.tar.gz
+tar -xzvf openssl-3.0.5.tar.gz
+cd `tar ztf openssl-3.0.5.tar.gz | head -n1 | cut -f1 -d/`
 
-# Build openssl libcrypto
-cd `tar ztf openssl-1.1.1-latest.tar.gz | head -n1 | cut -f1 -d/`
+# Download OpenSSL-1.1.1
+curl -LO https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_1_1.tar.gz
+tar -xzvf OpenSSL_1_1_1.tar.gz
+cd `tar ztf OpenSSL_1_1_1.tar.gz | head -n1 | cut -f1 -d/`
+
+# Download OpenSSL-1.0.2
+curl -LO https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_0_2.tar.gz
+tar -xzvf OpenSSL_1_0_2.tar.gz
+cd `tar ztf OpenSSL_1_0_2.tar.gz | head -n1 | cut -f1 -d/`
+```
+
+Build Openssl. The following config command disables numerous Openssl features and algorithms which
+are not used by s2n-tls. A minimal feature-set can help prevent exposure to security vulnerabilities.
+```shell
+# When build openssl 1.0.2 libcrypto also include the following flags
+./config ... no-libunbound no-gmp no-jpake no-krb5 no-store ...
+
+# Build Openssl libcrypto
 ./config -fPIC no-shared              \
          no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-zlib     \
          no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia\
          no-bf no-ripemd no-dsa no-ssl2 no-ssl3 no-capieng                  \
          -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS      \
          --prefix=`pwd`/../../libcrypto-root/
+
+make depend
 make
 make install
+```
 
-# Build s2n-tls
-cd ../../
+Build s2n-tls
+```shell
+cd ../../ # root of project
 make
 ```
-# Note for 32-bit builds.
-The previous instructions work fine with only a few tweaks to your config command. Example:
+
+**OpenSSL_1_1_1 32-bit builds** should use the following config command
 ```shell
 setarch i386 ./config -fPIC no-shared     \
         -m32 no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-zlib     \
@@ -115,36 +137,7 @@ setarch i386 ./config -fPIC no-shared     \
         --prefix=`pwd`/../../libcrypto-root/
 ```
 
-## Building s2n-tls with OpenSSL-1.0.2
-
-To build s2n-tls with OpenSSL-1.0.2, do the following:
-
-```shell
-# We keep the build artifacts in the -build directory
-cd libcrypto-build
-
-# Download the latest version of OpenSSL
-curl -LO https://www.openssl.org/source/openssl-1.0.2-latest.tar.gz
-tar -xzvf openssl-1.0.2-latest.tar.gz
-
-# Build openssl libcrypto
-cd `tar ztf openssl-1.0.2-latest.tar.gz | head -n1 | cut -f1 -d/`
-./config -fPIC no-shared no-libunbound no-gmp no-jpake no-krb5              \
-         no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-store no-zlib     \
-         no-hw no-mdc2 no-seed no-idea enable-ec-nistp_64_gcc_128 no-camellia\
-         no-bf no-ripemd no-dsa no-ssl2 no-ssl3 no-capieng                  \
-         -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS      \
-         --prefix=`pwd`/../../libcrypto-root/
-make depend
-make
-make install
-
-# Build s2n-tls
-cd ../../
-make
-```
-
-**Mac Users:** please replace "./config" with "./Configure darwin64-x86_64-cc".
+**Openssl 1.0.2 Mac Users:** replace "./config" with "./Configure darwin64-x86_64-cc".
 
 ## Building s2n-tls with LibreSSL
 
@@ -529,7 +522,7 @@ Clients should call `s2n_connection_get_session()` to retrieve some serialized s
 
 In TLS1.2, session ticket messages are sent during the handshake and are automatically received as part of calling `s2n_negotiate()`. They will be available as soon as negotiation is complete.
 
-In TLS1.3, session ticket messages are sent after the handshake as "post-handshake" messages, and may not be received as part of calling `s2n_negotiate()`. A s2n-tls server will send tickets immediately after the handshake, so clients can receive them by calling `s2n_recv()` immediately after the handshake completes. However, other server implementations may send their session tickets later, at any time during the connection. 
+In TLS1.3, session ticket messages are sent after the handshake as "post-handshake" messages, and may not be received as part of calling `s2n_negotiate()`. A s2n-tls server will send tickets immediately after the handshake, so clients can receive them by calling `s2n_recv()` immediately after the handshake completes. However, other server implementations may send their session tickets later, at any time during the connection.
 
 Additionally, in TLS1.3, multiple session tickets may be issued for the same connection. Servers can call `s2n_config_set_initial_ticket_count()` to set the number of tickets they want to send and `s2n_connection_add_new_tickets_to_send()` to increase the number of tickets to send during a connection.
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -79,55 +79,66 @@ And when invoking CMake for your project, do one of two things:
 
 ## Building s2n-tls with Openssl
 
-We keep the build artifacts in the -build directory:
+We keep the build artifacts in the *-build directory:
 ```shell
 cd libcrypto-build
 ```
 
-Download the desired Openssl version:
+### Download the desired Openssl version:
+Openssl 3.0.5
 ```shell
-# Download Openssl 3.0.5
 curl -L -o openssl.tar.gz https://github.com/openssl/openssl/archive/refs/tags/openssl-3.0.5.tar.gz
 tar -xzvf openssl-3.0.5.tar.gz
 cd `tar ztf openssl-3.0.5.tar.gz | head -n1 | cut -f1 -d/`
+```
 
-# Download OpenSSL-1.1.1
+OpenSSL-1.1.1
+```shell
 curl -LO https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_1_1.tar.gz
 tar -xzvf OpenSSL_1_1_1.tar.gz
 cd `tar ztf OpenSSL_1_1_1.tar.gz | head -n1 | cut -f1 -d/`
+```
 
-# Download OpenSSL-1.0.2
+OpenSSL-1.0.2
+```shell
 curl -LO https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_0_2.tar.gz
 tar -xzvf OpenSSL_1_0_2.tar.gz
 cd `tar ztf OpenSSL_1_0_2.tar.gz | head -n1 | cut -f1 -d/`
 ```
 
-Build Openssl. The following config command disables numerous Openssl features and algorithms which
-are not used by s2n-tls. A minimal feature-set can help prevent exposure to security vulnerabilities.
-```shell
-# When build openssl 1.0.2 libcrypto also include the following flags
-./config ... no-libunbound no-gmp no-jpake no-krb5 no-store ...
+### Build Openssl
+The following config command disables numerous Openssl features and algorithms which are not used
+by s2n-tls. A minimal feature-set can help prevent exposure to security vulnerabilities.
 
-# Build Openssl libcrypto
+OpenSSL-1.1.1 and OpenSSL-3.0.5
+```shell
 ./config -fPIC no-shared              \
-         no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-zlib     \
-         no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia\
-         no-bf no-ripemd no-dsa no-ssl2 no-ssl3 no-capieng                  \
-         -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS      \
-         --prefix=`pwd`/../../libcrypto-root/
+        no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-zlib     \
+        no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia\
+        no-bf no-ripemd no-dsa no-ssl2 no-ssl3 no-capieng                  \
+        -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS      \
+        --prefix=`pwd`/../../libcrypto-root/
+
+make
+make install
+```
+
+OpenSSL-1.0.2. Mac Users should replace "./config" with "./Configure darwin64-x86_64-cc".
+```shell
+./config -fPIC no-shared              \
+        no-libunbound no-gmp no-jpake no-krb5 no-store    \
+        no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-zlib     \
+        no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia\
+        no-bf no-ripemd no-dsa no-ssl2 no-ssl3 no-capieng                  \
+        -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS      \
+        --prefix=`pwd`/../../libcrypto-root/
 
 make depend
 make
 make install
 ```
 
-Build s2n-tls
-```shell
-cd ../../ # root of project
-make
-```
-
-**OpenSSL_1_1_1 32-bit builds** should use the following config command
+OpenSSL-1.1.1 32-bit
 ```shell
 setarch i386 ./config -fPIC no-shared     \
         -m32 no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-zlib     \
@@ -137,14 +148,18 @@ setarch i386 ./config -fPIC no-shared     \
         --prefix=`pwd`/../../libcrypto-root/
 ```
 
-**Openssl 1.0.2 Mac Users:** replace "./config" with "./Configure darwin64-x86_64-cc".
+### Build s2n-tls
+```shell
+cd ../../ # root of project
+make
+```
 
 ## Building s2n-tls with LibreSSL
 
 To build s2n-tls with LibreSSL, do the following:
 
 ```shell
-# We keep the build artifacts in the -build directory
+# We keep the build artifacts in the *-build directory
 cd libcrypto-build
 
 # Download the latest version of LibreSSL
@@ -171,7 +186,7 @@ directly via git. This procedure has been tested with
 fb68d6c901b98ffe15b8890d00bc819bf44c5f01 of BoringSSL.
 
 ```shell
-# We keep the build artifacts in the -build directory
+# We keep the build artifacts in the *-build directory
 cd libcrypto-build
 
 # Clone BoringSSL


### PR DESCRIPTION
### Description of changes: 
Update docs to include openssl 3 support and consolidate openssl install instructions.

Originally I wanted to describe each flag.. but then we are documenting openssl features. I instead wanted to link to openssl documentation.. but couldn't find any.

Instead I opted to explain the reason for calling `./config` with flags (disable openssl features), which is an improvement to the current docs.

### Callout:
There is no longer a single script than one can copy and paste. Instead a user would need to piece together a few scripts. I would argue this is probably a good thing since it forces the user to read and reason about the config options.

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
