### PR TITLE
Add DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.profraw
 *.tmp
 *.pyc
+.DS_Store
 coverage/html/*
 docs/doxygen/output/
 libcrypto-build/*


### PR DESCRIPTION
Mac OS adds files named .DS_Store in all folders which must be ignored.

### Description of changes: 

Editing on a Mac, all the .DS_Store files should be ignored.

### Testing:

None.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
