### PR TITLE
Fix memory leaked by s2n_cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ CMakeCache.txt
 CMakeFiles/*
 .project
 ./codebuild/spec/buildspec_*_batch.yml
+build/

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1028,7 +1028,7 @@ int s2n_cipher_suites_init(void)
 }
 
 /* Reset any selected record algorithms */
-int s2n_cipher_suites_cleanup(void)
+S2N_RESULT s2n_cipher_suites_cleanup(void)
 {
     const int num_cipher_suites = sizeof(s2n_all_cipher_suites) / sizeof(struct s2n_cipher_suite *);
     for (int i = 0; i < num_cipher_suites; i++) {
@@ -1038,7 +1038,7 @@ int s2n_cipher_suites_cleanup(void)
 
         /* Release custom SSLv3 cipher suites */
         if (cur_suite->sslv3_cipher_suite != cur_suite) {
-            POSIX_GUARD(s2n_free_object((uint8_t **)&cur_suite->sslv3_cipher_suite, sizeof(struct s2n_cipher_suite)));
+            RESULT_GUARD_POSIX(s2n_free_object((uint8_t **)&cur_suite->sslv3_cipher_suite, sizeof(struct s2n_cipher_suite)));
         }
         cur_suite->sslv3_cipher_suite = NULL;
     }
@@ -1053,7 +1053,7 @@ int s2n_cipher_suites_cleanup(void)
 #endif
     }
 
-    return 0;
+    return S2N_RESULT_OK;
 }
 
 S2N_RESULT s2n_cipher_suite_from_iana(const uint8_t iana[static S2N_TLS_CIPHER_SUITE_LEN], struct s2n_cipher_suite **cipher_suite)

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -159,7 +159,7 @@ extern struct s2n_cipher_suite s2n_tls13_aes_128_gcm_sha256;
 extern struct s2n_cipher_suite s2n_tls13_chacha20_poly1305_sha256;
 
 extern int s2n_cipher_suites_init(void);
-extern int s2n_cipher_suites_cleanup(void);
+S2N_RESULT s2n_cipher_suites_cleanup(void);
 S2N_RESULT s2n_cipher_suite_from_iana(const uint8_t iana[S2N_TLS_CIPHER_SUITE_LEN], struct s2n_cipher_suite **cipher_suite);
 extern int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_CIPHER_SUITE_LEN]);
 extern int s2n_set_cipher_as_sslv2_server(struct s2n_connection *conn, uint8_t * wire, uint16_t count);

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -89,9 +89,10 @@ static bool s2n_cleanup_atexit_impl(void)
     /* the configs need to be wiped before resetting the memory callbacks */
     s2n_wipe_static_configs();
 
-    return s2n_result_is_ok(s2n_libcrypto_cleanup()) &&
+    return s2n_result_is_ok(s2n_cipher_suites_cleanup()) &&
         s2n_result_is_ok(s2n_rand_cleanup_thread()) &&
         s2n_result_is_ok(s2n_rand_cleanup()) &&
+        s2n_result_is_ok(s2n_libcrypto_cleanup()) &&
         s2n_result_is_ok(s2n_locking_cleanup()) &&
         (s2n_mem_cleanup() == S2N_SUCCESS);
 }


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

As part of a separate project, I integrated S2N with a pedantic allocator and found that although `s2n_cipher_suites_cleanup` is defined, nothing was calling it.  I added it to the `s2n_cleanup` and that resolved the memory leak I was seeing in the init/cleanup cycle.

### Call-outs:

I fixed the call ordering in cleanup to be the opposite of the init call ordering for correctness (if this is not correct, there is an architectural issue).  All tests pass.

### Testing:

I added a separate init/cleanup memory leak test using the memory callbacks - it's simple but effective, and it worries me that valgrind testing does not catch this.

### Licensing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
