### PR TITLE
Add API to skip a CRL validation check for a certificate

### DIFF
--- a/tls/s2n_crl.h
+++ b/tls/s2n_crl.h
@@ -31,11 +31,18 @@ typedef enum {
     FINISHED
 } crl_lookup_callback_status;
 
+
+typedef enum {
+    CRL_VALIDATE,
+    CRL_DO_NOT_VALIDATE
+} crl_validate_option;
+
 struct s2n_crl_lookup {
     crl_lookup_callback_status status;
     X509 *cert;
     uint16_t cert_idx;
     struct s2n_crl *crl;
+    crl_validate_option validate_option;
 };
 
 typedef int (*s2n_crl_lookup_callback) (struct s2n_crl_lookup *lookup, void *context);
@@ -47,9 +54,12 @@ int s2n_crl_load_pem(struct s2n_crl *crl, uint8_t *pem, size_t len);
 int s2n_crl_free(struct s2n_crl **crl);
 int s2n_crl_get_issuer_hash(struct s2n_crl *crl, uint64_t *hash);
 int s2n_crl_lookup_get_cert_issuer_hash(struct s2n_crl_lookup *lookup, uint64_t *hash);
+int s2n_crl_lookup_get_cert_index(struct s2n_crl_lookup *lookup, uint16_t *cert_index);
 int s2n_crl_lookup_set(struct s2n_crl_lookup *lookup, struct s2n_crl *crl);
 int s2n_crl_lookup_ignore(struct s2n_crl_lookup *lookup);
+int s2n_crl_lookup_do_not_validate(struct s2n_crl_lookup *lookup);
 
 S2N_RESULT s2n_crl_handle_lookup_callback_result(struct s2n_x509_validator *validator);
 S2N_RESULT s2n_crl_invoke_lookup_callbacks(struct s2n_connection *conn, struct s2n_x509_validator *validator);
 S2N_RESULT s2n_crl_get_crls_from_lookup_list(struct s2n_x509_validator *validator, STACK_OF(X509_CRL) *crl_stack);
+int s2n_crl_ossl_verify_callback(int default_ossl_ret, X509_STORE_CTX *ctx);

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -400,6 +400,8 @@ static S2N_RESULT s2n_x509_validator_verify_cert_chain(struct s2n_x509_validator
     DEFER_CLEANUP(STACK_OF(X509_CRL) *crl_stack = NULL, sk_X509_CRL_free_pointer);
 
     if (conn->config->crl_lookup_cb) {
+        X509_STORE_CTX_set_verify_cb(validator->store_ctx, s2n_crl_ossl_verify_callback);
+
         crl_stack = sk_X509_CRL_new_null();
         RESULT_GUARD(s2n_crl_get_crls_from_lookup_list(validator, crl_stack));
 


### PR DESCRIPTION
### Resolved issues:

Part of https://github.com/aws/s2n-tls/issues/3499

### Description of changes: 

Currently, if a CRL callback is implemented, all received certificates must have a corresponding CRL, or the handshake will fail with a `S2N_ERR_CRL_LOOKUP_FAILED` error. However, it may be desirable to not perform certificate revocation checks on some received certificates. To enable this functionality, a new CRL callback return function has been added.

One use case for this functionality is to skip certificate revocation checks for intermediate certificates, and only check leaf certificates. To enable this functionality, a new function was added to get the certificate's index in the certificate chain. Users can check the certificate index to determine if it is or isn't a leaf certificate, and perform a revocation check accordingly.

### Call-outs:

None

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
- A new unit test was added to check the certificate skip functionality, and a test was added to ensure the certificate index can be retrieved successfully.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
