### PR TITLE
Test if go is already installed

### DIFF
--- a/codebuild/bin/install_ubuntu_dependencies.sh
+++ b/codebuild/bin/install_ubuntu_dependencies.sh
@@ -34,14 +34,22 @@ get_rust() {
 }
 
 base_packages() {
+  # Prebuild CodeBuild images have golang already (manually) installed
+  export GO_MISSING=$(which go &> /dev/null; echo $?)
   echo "Installing repositories and base packages"
   apt update -y
   apt install -y software-properties-common
   add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  add-apt-repository ppa:longsleep/golang-backports -y
+  if [[ "$GO_MISSING" -eq 1 ]]; then
+      add-apt-repository ppa:longsleep/golang-backports -y
+  fi
   apt-get update -o Acquire::CompressionTypes::Order::=gz
 
-  DEPENDENCIES="unzip make indent iproute2 kwstyle libssl-dev net-tools  tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config psmisc gcc g++ zlibc zlib1g-dev python3-pip python3-testresources llvm curl shellcheck git tox cmake libtool ninja-build golang-go quilt jq"
+  DEPENDENCIES="unzip make indent iproute2 kwstyle libssl-dev net-tools  tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config psmisc gcc g++ zlibc zlib1g-dev python3-pip python3-testresources llvm curl shellcheck git tox cmake libtool ninja-build quilt jq"
+
+  if [[ $"GO_MISSING" -eq 1 ]]; then
+      DEPENDENCIES+=" golang-go"
+  fi
   if [[ -n "${GCC_VERSION:-}" ]] && [[ "${GCC_VERSION:-}" != "NONE" ]]; then
     DEPENDENCIES+=" gcc-$GCC_VERSION g++-$GCC_VERSION";
   fi


### PR DESCRIPTION
### Resolved issues:

Trying to workaround archive.ubuntu.com flakiness 

### Description of changes: 

Codebuild images come with go 1.14.  We're re-install 1.19, trying to see if that's really a hard requirement.

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? [ad-hoc CodeBuild](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nOmnibus/batch/s2nOmnibus%3A5d96f736-5a74-4ead-bfbc-63bbb96e3988?region=us-west-2)

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
