### PR TITLE
ci: error on all valgrind errors

### DIFF
--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -47,7 +47,15 @@ if [[ "$OS_NAME" == "linux" && "$TESTS" == "valgrind" ]]; then
     # We have to output something every 9 minutes, as some test may run longer than 10 minutes
     # and will not produce any output
     while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
-    S2N_DEBUG=true make -j $JOBS valgrind
+
+    if [[ "$GCC_VERSION" == "9" && "$LIBCRYPTO_ROOT" == "openssl-1.1.1" ]]; then
+        # https://github.com/aws/s2n-tls/pull/3511
+        # Run valgrind in pedantic mode (--errors-for-leak-kinds=all)
+        S2N_DEBUG=true make -j $JOBS valgrind_gcc9_ossl_111
+    else
+        S2N_DEBUG=true make -j $JOBS valgrind
+    fi
+
     kill %1
 fi
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -33,6 +33,9 @@ benchmark: libs
 valgrind: libs
 	${MAKE} -C unit valgrind
 
+valgrind_gcc9_ossl_111: libs
+	${MAKE} -C unit valgrind_gcc9_ossl_111
+
 .PHONY : libs
 libs:
 	${MAKE} -C testlib

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -54,17 +54,30 @@ $(UNIT_TESTS)::
 	./$@
 endif
 
+$(VALGRIND_PEDANTIC_TESTS)::
+	@${CC} ${CFLAGS} -o $(@:.valgrind=) $(@:.valgrind=.c) ${LDFLAGS} 2>&1
+	@DYLD_LIBRARY_PATH="$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
+	LD_LIBRARY_PATH="$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
+	S2N_VALGRIND=1 \
+	valgrind --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=all --run-libc-freeres=yes -q --error-exitcode=9 --gen-suppressions=all --num-callers=40 --leak-resolution=high --undef-value-errors=no --trace-children=yes --suppressions=valgrind.suppressions \
+	./$(@:.valgrind=)
+
 $(VALGRIND_TESTS)::
 	@${CC} ${CFLAGS} -o $(@:.valgrind=) $(@:.valgrind=.c) ${LDFLAGS} 2>&1
 	@DYLD_LIBRARY_PATH="$(LIBCRYPTO_ROOT)/lib:$$DYLD_LIBRARY_PATH" \
 	LD_LIBRARY_PATH="$(LIBCRYPTO_ROOT)/lib:$$LD_LIBRARY_PATH" \
 	S2N_VALGRIND=1 \
-	valgrind --leak-check=full --run-libc-freeres=no -q --error-exitcode=9 --gen-suppressions=all --log-fd=2 --num-callers=40 --leak-resolution=high --undef-value-errors=no --trace-children=yes --suppressions=valgrind.suppressions \
+	valgrind --leak-check=full --run-libc-freeres=yes -q --error-exitcode=9 --gen-suppressions=all --num-callers=40 --leak-resolution=high --undef-value-errors=no --trace-children=yes --suppressions=valgrind.suppressions \
 	./$(@:.valgrind=)
 
 .PHONY : valgrind
 valgrind: $(VALGRIND_TESTS)
 
+.PHONY : valgrind_gcc9_ossl_111
+	echo "running valgrind_gcc9_ossl_111"
+	# https://github.com/aws/s2n-tls/pull/3511
+	# Run valgrind in pedantic mode (--errors-for-leak-kinds=all)
+	valgrind: $(VALGRIND_PEDANTIC_TESTS)
 
 .PHONY : clean
 clean: decruft

--- a/tests/unit/s2n_cert_status_extension_test.c
+++ b/tests/unit/s2n_cert_status_extension_test.c
@@ -18,9 +18,8 @@
 #include "tls/extensions/s2n_cert_status.h"
 
 const uint8_t ocsp_data[] = "OCSP DATA";
-struct s2n_cert_chain_and_key *chain_and_key;
 
-int s2n_test_enable_sending_extension(struct s2n_connection *conn)
+int s2n_test_enable_sending_extension(struct s2n_connection *conn, struct s2n_cert_chain_and_key *chain_and_key)
 {
     conn->mode = S2N_SERVER;
     conn->status_type = S2N_STATUS_REQUEST_OCSP;
@@ -34,6 +33,7 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
+    DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = NULL, s2n_cert_chain_and_key_ptr_free);
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
             S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
 
@@ -50,26 +50,26 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_cert_status_extension.should_send(conn));
 
         /* Send if all prerequisites met */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         EXPECT_TRUE(s2n_cert_status_extension.should_send(conn));
 
         /* Don't send if client */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         conn->mode = S2N_CLIENT;
         EXPECT_FALSE(s2n_cert_status_extension.should_send(conn));
 
         /* Don't send if no status request configured */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         conn->status_type = S2N_STATUS_REQUEST_NONE;
         EXPECT_FALSE(s2n_cert_status_extension.should_send(conn));
 
         /* Don't send if no certificate set */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         conn->handshake_params.our_chain_and_key = NULL;
         EXPECT_FALSE(s2n_cert_status_extension.should_send(conn));
 
         /* Don't send if no ocsp data */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         EXPECT_SUCCESS(s2n_free(&conn->handshake_params.our_chain_and_key->ocsp_status));
         EXPECT_FALSE(s2n_cert_status_extension.should_send(conn));
 
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
     {
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
 
         struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
     {
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
 
         struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
     {
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
 
         struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
@@ -151,7 +151,7 @@ int main(int argc, char **argv)
     {
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
         EXPECT_NOT_NULL(conn);
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
 
         DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));

--- a/tests/unit/s2n_cert_status_response_extension_test.c
+++ b/tests/unit/s2n_cert_status_response_extension_test.c
@@ -18,9 +18,8 @@
 #include "tls/extensions/s2n_cert_status_response.h"
 
 const uint8_t ocsp_data[] = "OCSP DATA";
-struct s2n_cert_chain_and_key *chain_and_key;
 
-int s2n_test_enable_sending_extension(struct s2n_connection *conn)
+int s2n_test_enable_sending_extension(struct s2n_connection *conn, struct s2n_cert_chain_and_key *chain_and_key)
 {
     conn->mode = S2N_SERVER;
     conn->status_type = S2N_STATUS_REQUEST_OCSP;
@@ -34,6 +33,7 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
+    DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = NULL, s2n_cert_chain_and_key_ptr_free);
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
             S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
 
@@ -50,26 +50,37 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_cert_status_response_extension.should_send(conn));
 
         /* Send if all prerequisites met */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         EXPECT_TRUE(s2n_cert_status_response_extension.should_send(conn));
 
+        /* <<<<<<< HEAD:tests/unit/s2n_cert_status_response_extension_test.c */
+        /*         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn)); */
+        /*         EXPECT_TRUE(s2n_cert_status_response_extension.should_send(conn)); */
+        /* ||||||| parent of 3b9159e4 (ci: error on all valgrind errors):tests/unit/s2n_server_status_request_extension_test.c */
+        /*         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn)); */
+        /*         EXPECT_TRUE(s2n_server_status_request_extension.should_send(conn)); */
+        /* ======= */
+        /*         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key)); */
+        /*         EXPECT_TRUE(s2n_server_status_request_extension.should_send(conn)); */
+        /* >>>>>>> 3b9159e4 (ci: error on all valgrind errors):tests/unit/s2n_server_status_request_extension_test.c */
+
         /* Don't send if client */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         conn->mode = S2N_CLIENT;
         EXPECT_FALSE(s2n_cert_status_response_extension.should_send(conn));
 
         /* Don't send if no status request configured */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         conn->status_type = S2N_STATUS_REQUEST_NONE;
         EXPECT_FALSE(s2n_cert_status_response_extension.should_send(conn));
 
         /* Don't send if no certificate set */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         conn->handshake_params.our_chain_and_key = NULL;
         EXPECT_FALSE(s2n_cert_status_response_extension.should_send(conn));
 
         /* Don't send if no ocsp data */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         EXPECT_SUCCESS(s2n_free(&conn->handshake_params.our_chain_and_key->ocsp_status));
         EXPECT_FALSE(s2n_cert_status_response_extension.should_send(conn));
 

--- a/tests/unit/s2n_fork_generation_number_test.c
+++ b/tests/unit/s2n_fork_generation_number_test.c
@@ -256,7 +256,7 @@ static int s2n_unit_tests_common(struct fgn_test_case *test_case)
     return S2N_SUCCESS;
 }
 
-static int s2n_test_case_default_cb(struct fgn_test_case *test_case)
+static int s2n_test_case_default_cb_valgrind_marker(struct fgn_test_case *test_case)
 {
     EXPECT_SUCCESS(s2n_init());
 
@@ -284,7 +284,7 @@ static int s2n_test_case_pthread_atfork_cb(struct fgn_test_case *test_case)
     return S2N_SUCCESS;
 }
 
-static int s2n_test_case_madv_wipeonfork_cb(struct fgn_test_case *test_case)
+static int s2n_test_case_madv_wipeonfork_cb_valgrind_marker(struct fgn_test_case *test_case)
 {
     if (s2n_is_madv_wipeonfork_supported() == false) {
         TEST_DEBUG_PRINT("s2n_fork_generation_number_test.c test case not supported. Skipping.\nTest case: %s\n", test_case->test_case_label);
@@ -319,9 +319,9 @@ static int s2n_test_case_map_inherit_zero_cb(struct fgn_test_case *test_case)
 }
 
 struct fgn_test_case fgn_test_cases[NUMBER_OF_FGN_TEST_CASES] = {
-    { "Default fork detect mechanisms.", s2n_test_case_default_cb, CLONE_TEST_DETERMINE_AT_RUNTIME },
+    { "Default fork detect mechanisms.", s2n_test_case_default_cb_valgrind_marker, CLONE_TEST_DETERMINE_AT_RUNTIME },
     { "Only pthread_atfork fork detection mechanism.", s2n_test_case_pthread_atfork_cb, CLONE_TEST_NO },
-    { "Only madv_wipeonfork fork detection mechanism.", s2n_test_case_madv_wipeonfork_cb, CLONE_TEST_YES },
+    { "Only madv_wipeonfork fork detection mechanism.", s2n_test_case_madv_wipeonfork_cb_valgrind_marker, CLONE_TEST_YES },
     { "Only map_inherit_zero fork detection mechanism.", s2n_test_case_map_inherit_zero_cb, CLONE_TEST_YES }
 };
 

--- a/tests/unit/s2n_fragmentation_coalescing_test.c
+++ b/tests/unit/s2n_fragmentation_coalescing_test.c
@@ -435,7 +435,7 @@ int main(int argc, char **argv)
         fragmented_message(p[1]);
         EXPECT_SUCCESS(s2n_config_free(config));
         EXPECT_SUCCESS(s2n_connection_free(conn));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -481,7 +481,7 @@ int main(int argc, char **argv)
         coalesced_message(p[1]);
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -527,7 +527,7 @@ int main(int argc, char **argv)
         interleaved_message(p[1]);
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -573,7 +573,7 @@ int main(int argc, char **argv)
         interleaved_fragmented_warning_alert(p[1]);
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -619,7 +619,7 @@ int main(int argc, char **argv)
         interleaved_fragmented_fatal_alert(p[1]);
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */

--- a/tests/unit/s2n_malformed_handshake_test.c
+++ b/tests/unit/s2n_malformed_handshake_test.c
@@ -227,8 +227,6 @@ void send_messages(int write_fd, uint8_t *server_hello, uint32_t server_hello_le
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
-    struct s2n_config *config;
     s2n_blocked_status blocked;
     int status;
     pid_t pid;
@@ -237,8 +235,8 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-    EXPECT_NOT_NULL(config = s2n_config_new());
+    DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+    DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
     EXPECT_SUCCESS(s2n_config_disable_x509_verification(config));
     EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all"));
     EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -270,7 +268,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -319,7 +317,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -368,7 +366,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -417,7 +415,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -466,7 +464,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -515,7 +513,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -536,8 +534,6 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(waitpid(pid, &status, 0), pid);
     EXPECT_EQUAL(status, 0);
     EXPECT_SUCCESS(close(p[0]));
-    EXPECT_SUCCESS(s2n_connection_free(conn));
-    EXPECT_SUCCESS(s2n_config_free(config));
 
     END_TEST();
 }

--- a/tests/unit/s2n_mem_allocator_test.c
+++ b/tests/unit/s2n_mem_allocator_test.c
@@ -142,7 +142,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
     s2n_io_pair_close_one_end(io_pair, S2N_CLIENT);
 
-    _exit(0);
+    exit(0);
 }
 
 int main(int argc, char **argv)
@@ -184,6 +184,10 @@ int main(int argc, char **argv)
         if (pid == 0) {
             /* This is the client process, close the server end of the pipe */
             EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
+
+            free(cert_chain_pem);
+            free(private_key_pem);
+            free(dhparams_pem);
 
             /* Write the fragmented hello message */
             mock_client(&io_pair);

--- a/tests/unit/s2n_override_openssl_random_test.c
+++ b/tests/unit/s2n_override_openssl_random_test.c
@@ -129,6 +129,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_dh_params_free(&dh_params));
     EXPECT_SUCCESS(s2n_stuffer_free(&dhparams_out));
     EXPECT_SUCCESS(s2n_stuffer_free(&dhparams_in));
+    EXPECT_SUCCESS(s2n_stuffer_free(&test_entropy));
     free(dhparams_pem);
 
     END_TEST();

--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -329,7 +329,7 @@ static void s2n_fork_test_generate_randomness(int write_fd, S2N_RESULT (*s2n_get
 
     /* Close the pipe and exit */
     close(write_fd);
-    _exit(EXIT_SUCCESS);
+    exit(EXIT_SUCCESS);
 }
 
 static S2N_RESULT s2n_fork_test_verify_result(int *pipes, int proc_id, S2N_RESULT (*s2n_get_random_data_cb)(struct s2n_blob *blob))

--- a/tests/unit/s2n_release_non_empty_buffers_test.c
+++ b/tests/unit/s2n_release_non_empty_buffers_test.c
@@ -60,7 +60,7 @@ int mock_client(struct s2n_test_io_pair *io_pair)
     s2n_config_free(client_config);
     s2n_cleanup();
 
-    _exit(0);
+    exit(0);
 }
 
 /**
@@ -106,6 +106,7 @@ int main(int argc, char **argv)
 
         /* Free the config */
         EXPECT_SUCCESS(s2n_config_free(config));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
         free(cert_chain_pem);
         free(private_key_pem);
 
@@ -191,13 +192,13 @@ int main(int argc, char **argv)
         s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out), NULL);
     } while (!server_shutdown);
 
-    EXPECT_SUCCESS(s2n_connection_free(conn));
-
     /* Clean up */
-    EXPECT_SUCCESS(s2n_stuffer_free(&in));
-    EXPECT_SUCCESS(s2n_stuffer_free(&out));
     EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
     EXPECT_EQUAL(status, 0);
+
+    EXPECT_SUCCESS(s2n_stuffer_free(&in));
+    EXPECT_SUCCESS(s2n_stuffer_free(&out));
+    EXPECT_SUCCESS(s2n_connection_free(conn));
     EXPECT_SUCCESS(s2n_config_free(config));
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
     free(cert_chain_pem);

--- a/tests/unit/s2n_self_talk_alerts_test.c
+++ b/tests/unit/s2n_self_talk_alerts_test.c
@@ -90,7 +90,7 @@ int mock_client(struct s2n_test_io_pair *io_pair, s2n_alert_behavior alert_behav
 
     s2n_cleanup();
 
-    _exit(result);
+    exit(result);
 }
 
 int mock_nanoseconds_since_epoch(void *data, uint64_t *nanoseconds)
@@ -117,7 +117,7 @@ int client_hello_send_alerts(struct s2n_connection *conn, void *ctx)
 
     for (int i = 0; i < alert->count; i++) {
         if (write(alert->write_fd, alert_msg, sizeof(alert_msg)) != sizeof(alert_msg)) {
-            _exit(100);
+            exit(100);
         }
 
         alert->invoked++;
@@ -169,6 +169,10 @@ int main(int argc, char **argv)
             /* This is the client process, close the server end of the pipe */
             EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
 
+            EXPECT_SUCCESS(s2n_config_free(config));
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+            free(cert_chain_pem);
+            free(private_key_pem);
             mock_client(&io_pair, S2N_ALERT_IGNORE_WARNINGS, 0);
         }
 
@@ -236,6 +240,11 @@ int main(int argc, char **argv)
             /* This is the client process, close the server end of the pipe */
             EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
 
+            EXPECT_SUCCESS(s2n_config_free(config));
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+            free(cert_chain_pem);
+            free(private_key_pem);
+
             mock_client(&io_pair, S2N_ALERT_IGNORE_WARNINGS, 1);
         }
 
@@ -284,6 +293,10 @@ int main(int argc, char **argv)
             /* This is the client process, close the server end of the pipe */
             EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
 
+            EXPECT_SUCCESS(s2n_config_free(config));
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+            free(cert_chain_pem);
+            free(private_key_pem);
             mock_client(&io_pair, S2N_ALERT_FAIL_ON_WARNINGS, 1);
         }
 

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -83,7 +83,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
     s2n_io_pair_shutdown_one_end(io_pair, S2N_CLIENT, SHUT_WR);
 
-    _exit(0);
+    exit(0);
 }
 
 int main(int argc, char **argv)

--- a/tests/unit/s2n_self_talk_client_hello_cb_test.c
+++ b/tests/unit/s2n_self_talk_client_hello_cb_test.c
@@ -102,7 +102,7 @@ int mock_client(struct s2n_test_io_pair *io_pair, int expect_failure, int expect
     s2n_cleanup();
     s2n_io_pair_close_one_end(io_pair, S2N_CLIENT);
 
-    _exit(result);
+    exit(result);
 }
 
 int client_hello_swap_config(struct s2n_connection *conn, void *ctx)
@@ -306,26 +306,10 @@ int init_server_conn(struct s2n_connection **conn, struct s2n_test_io_pair *io_p
     return S2N_SUCCESS;
 }
 
-int start_client_conn(struct s2n_test_io_pair *io_pair, pid_t *pid,
-        int expect_failure, int expect_server_name_used)
-{
-    /* Create a pipe */
-    EXPECT_SUCCESS(s2n_io_pair_init(io_pair));
-
-    /* Create a child process */
-    *pid = fork();
-    if (*pid == 0) {
-        /* This is the client process, close the server end of the pipe */
-        EXPECT_SUCCESS(s2n_io_pair_close_one_end(io_pair, S2N_SERVER));
-
-        mock_client(io_pair, expect_failure, expect_server_name_used);
-    }
-    return S2N_SUCCESS;
-}
-
 static int test_case_clean(struct s2n_connection *conn, pid_t client_pid,
         struct s2n_config *config, struct s2n_test_io_pair *io_pair,
-        struct client_hello_context *ch_ctx)
+        struct client_hello_context *ch_ctx, struct s2n_cert_chain_and_key *chain_and_key,
+        char *cert_chain_pem, char *private_key_pem)
 {
     s2n_blocked_status blocked;
     int status;
@@ -337,15 +321,29 @@ static int test_case_clean(struct s2n_connection *conn, pid_t client_pid,
     EXPECT_EQUAL(waitpid(-1, &status, 0), client_pid);
     EXPECT_EQUAL(status, 0);
     EXPECT_SUCCESS(s2n_config_free(config));
+
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+    free(cert_chain_pem);
+    free(private_key_pem);
+
     /* client process cleans their end, we just need to close server side */
     EXPECT_SUCCESS(s2n_io_pair_close_one_end(io_pair, S2N_SERVER));
     memset(ch_ctx, 0, sizeof(struct client_hello_context));
     return S2N_SUCCESS;
 }
 
-int run_test_config_swap_ch_cb(s2n_client_hello_cb_mode cb_mode,
-        struct s2n_cert_chain_and_key *chain_and_key, struct client_hello_context *ch_ctx)
+int run_test_config_swap_ch_cb(s2n_client_hello_cb_mode cb_mode, struct client_hello_context *ch_ctx)
 {
+    char *cert_chain_pem;
+    char *private_key_pem;
+    struct s2n_cert_chain_and_key *chain_and_key;
+    EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
+
     struct s2n_test_io_pair io_pair;
     struct s2n_config *config;
     struct s2n_connection *conn;
@@ -371,7 +369,24 @@ int run_test_config_swap_ch_cb(s2n_client_hello_cb_mode cb_mode,
     EXPECT_SUCCESS(s2n_config_set_client_hello_cb_mode(config, cb_mode));
     EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_swap_config, ch_ctx));
 
-    EXPECT_SUCCESS(start_client_conn(&io_pair, &pid, 0, 1));
+    /* Create a pipe */
+    EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
+    /* Create a child process */
+    pid = fork();
+    if (pid == 0) {
+        /* This is the client process, close the server end of the pipe */
+        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
+
+        /* Cleanup */
+        EXPECT_SUCCESS(s2n_config_free(config));
+        EXPECT_SUCCESS(s2n_config_free(swap_config));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        free(cert_chain_pem);
+        free(private_key_pem);
+
+        mock_client(&io_pair, 0, 1);
+    }
+
     EXPECT_SUCCESS(init_server_conn(&conn, &io_pair, config));
 
     /* do the handshake */
@@ -394,15 +409,27 @@ int run_test_config_swap_ch_cb(s2n_client_hello_cb_mode cb_mode,
 
     EXPECT_SUCCESS(server_recv(conn));
 
-    EXPECT_SUCCESS(test_case_clean(conn, pid, config, &io_pair, ch_ctx));
+    /* Cleanup */
+    EXPECT_SUCCESS(test_case_clean(conn, pid, config, &io_pair, ch_ctx,
+            chain_and_key, cert_chain_pem, private_key_pem));
     EXPECT_SUCCESS(s2n_config_free(swap_config));
+
     return S2N_SUCCESS;
 }
 
 int run_test_no_config_swap_ch_cb(s2n_client_hello_cb_mode cb_mode,
-        struct s2n_cert_chain_and_key *chain_and_key,
         struct client_hello_context *ch_ctx)
 {
+    char *cert_chain_pem;
+    char *private_key_pem;
+    struct s2n_cert_chain_and_key *chain_and_key;
+    EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
+
     struct s2n_test_io_pair io_pair;
     struct s2n_config *config;
     struct s2n_connection *conn;
@@ -414,7 +441,24 @@ int run_test_no_config_swap_ch_cb(s2n_client_hello_cb_mode cb_mode,
     /* Setup ClientHello callback */
     EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_swap_config, ch_ctx));
     EXPECT_SUCCESS(s2n_config_set_client_hello_cb_mode(config, cb_mode));
-    EXPECT_SUCCESS(start_client_conn(&io_pair, &pid, 0, 0));
+
+    /* Create a pipe */
+    EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
+    /* Create a child process */
+    pid = fork();
+    if (pid == 0) {
+        /* This is the client process, close the server end of the pipe */
+        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
+
+        /* Cleanup */
+        EXPECT_SUCCESS(s2n_config_free(config));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        free(cert_chain_pem);
+        free(private_key_pem);
+
+        mock_client(&io_pair, 0, 0);
+    }
+
     EXPECT_SUCCESS(init_server_conn(&conn, &io_pair, config));
 
     /* do the handshake */
@@ -431,14 +475,23 @@ int run_test_no_config_swap_ch_cb(s2n_client_hello_cb_mode cb_mode,
 
     EXPECT_SUCCESS(server_recv(conn));
 
-    EXPECT_SUCCESS(test_case_clean(conn, pid, config, &io_pair, ch_ctx));
+    EXPECT_SUCCESS(test_case_clean(conn, pid, config, &io_pair, ch_ctx,
+            chain_and_key, cert_chain_pem, private_key_pem));
     return S2N_SUCCESS;
 }
 
-int run_test_reject_handshake_ch_cb(s2n_client_hello_cb_mode cb_mode,
-        struct s2n_cert_chain_and_key *chain_and_key,
-        struct client_hello_context *ch_ctx)
+int run_test_reject_handshake_ch_cb(s2n_client_hello_cb_mode cb_mode, struct client_hello_context *ch_ctx)
 {
+    char *cert_chain_pem;
+    char *private_key_pem;
+    struct s2n_cert_chain_and_key *chain_and_key;
+    EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
+
     struct s2n_test_io_pair io_pair;
     struct s2n_config *config;
     struct s2n_connection *conn;
@@ -452,7 +505,22 @@ int run_test_reject_handshake_ch_cb(s2n_client_hello_cb_mode cb_mode,
     EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_fail_handshake, ch_ctx));
     EXPECT_SUCCESS(s2n_config_set_client_hello_cb_mode(config, cb_mode));
 
-    EXPECT_SUCCESS(start_client_conn(&io_pair, &pid, 1, 0));
+    /* Create a pipe */
+    EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
+    /* Create a child process */
+    pid = fork();
+    if (pid == 0) {
+        /* This is the client process, close the server end of the pipe */
+        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
+
+        /* Cleanup */
+        EXPECT_SUCCESS(s2n_config_free(config));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        free(cert_chain_pem);
+        free(private_key_pem);
+
+        mock_client(&io_pair, 1, 0);
+    }
 
     EXPECT_SUCCESS(init_server_conn(&conn, &io_pair, config));
     /* If s2n_negotiate fails, it usually would delay with a sleep. In order to
@@ -472,15 +540,26 @@ int run_test_reject_handshake_ch_cb(s2n_client_hello_cb_mode cb_mode,
     /* shutdown to flush alert */
     EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
     EXPECT_SUCCESS(s2n_connection_free(conn));
+    /* indicate cleaup is already done */
+    conn = NULL;
 
-    EXPECT_SUCCESS(test_case_clean(NULL, pid, config, &io_pair, ch_ctx));
+    EXPECT_SUCCESS(test_case_clean(conn, pid, config, &io_pair, ch_ctx,
+            chain_and_key, cert_chain_pem, private_key_pem));
     return S2N_SUCCESS;
 }
 
-int run_test_poll_ch_cb(s2n_client_hello_cb_mode cb_mode,
-        struct s2n_cert_chain_and_key *chain_and_key,
-        struct client_hello_context *ch_ctx)
+int run_test_poll_ch_cb(s2n_client_hello_cb_mode cb_mode, struct client_hello_context *ch_ctx)
 {
+    char *cert_chain_pem;
+    char *private_key_pem;
+    struct s2n_cert_chain_and_key *chain_and_key;
+    EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
+
     struct s2n_test_io_pair io_pair = { 0 };
     struct s2n_config *config = s2n_config_new();
     EXPECT_NOT_NULL(config);
@@ -496,7 +575,22 @@ int run_test_poll_ch_cb(s2n_client_hello_cb_mode cb_mode,
     /* Enable callback polling mode */
     EXPECT_SUCCESS(s2n_config_client_hello_cb_enable_poll(config));
 
-    EXPECT_SUCCESS(start_client_conn(&io_pair, &pid, 0, 0));
+    /* Create a pipe */
+    EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
+    /* Create a child process */
+    pid = fork();
+    if (pid == 0) {
+        /* This is the client process, close the server end of the pipe */
+        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
+
+        /* Cleanup */
+        EXPECT_SUCCESS(s2n_config_free(config));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        free(cert_chain_pem);
+        free(private_key_pem);
+
+        mock_client(&io_pair, 0, 0);
+    }
     EXPECT_SUCCESS(init_server_conn(&conn, &io_pair, config));
 
     /* negotiate and make assertions */
@@ -504,69 +598,48 @@ int run_test_poll_ch_cb(s2n_client_hello_cb_mode cb_mode,
 
     EXPECT_SUCCESS(server_recv(conn));
 
-    EXPECT_SUCCESS(test_case_clean(conn, pid, config, &io_pair, ch_ctx));
+    EXPECT_SUCCESS(test_case_clean(conn, pid, config, &io_pair, ch_ctx,
+            chain_and_key, cert_chain_pem, private_key_pem));
     return S2N_SUCCESS;
 }
 
 int main(int argc, char **argv)
 {
     struct client_hello_context client_hello_ctx = { 0 };
-    char *cert_chain_pem;
-    char *private_key_pem;
-    struct s2n_cert_chain_and_key *chain_and_key;
     BEGIN_TEST();
 
-    EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
-    EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
     /** Test config swapping in client hello callback **/
 
     /* we want to update the config outside of callback so don't swap in callback */
     client_hello_ctx.swap_config_nonblocking_mode = 1;
-    EXPECT_SUCCESS(run_test_config_swap_ch_cb(S2N_CLIENT_HELLO_CB_NONBLOCKING,
-            chain_and_key, &client_hello_ctx));
+    EXPECT_SUCCESS(run_test_config_swap_ch_cb(S2N_CLIENT_HELLO_CB_NONBLOCKING, &client_hello_ctx));
 
     /* non blocking callback when callback marks cb_done during the callback */
     client_hello_ctx.swap_config_during_callback = 1;
     client_hello_ctx.mark_done_during_callback = 1;
-    EXPECT_SUCCESS(run_test_config_swap_ch_cb(S2N_CLIENT_HELLO_CB_NONBLOCKING,
-            chain_and_key, &client_hello_ctx));
+    EXPECT_SUCCESS(run_test_config_swap_ch_cb(S2N_CLIENT_HELLO_CB_NONBLOCKING, &client_hello_ctx));
 
     /* we want to update the config in the callback */
     client_hello_ctx.swap_config_during_callback = 1;
-    EXPECT_SUCCESS(run_test_config_swap_ch_cb(S2N_CLIENT_HELLO_CB_BLOCKING,
-            chain_and_key, &client_hello_ctx));
+    EXPECT_SUCCESS(run_test_config_swap_ch_cb(S2N_CLIENT_HELLO_CB_BLOCKING, &client_hello_ctx));
 
     /* validate legacy behavior for server_name_used */
     /* we want to update the config in the callback */
     client_hello_ctx.swap_config_during_callback = 1;
     client_hello_ctx.legacy_rc_for_server_name_used = 1;
-    EXPECT_SUCCESS(run_test_config_swap_ch_cb(S2N_CLIENT_HELLO_CB_BLOCKING,
-            chain_and_key, &client_hello_ctx));
+    EXPECT_SUCCESS(run_test_config_swap_ch_cb(S2N_CLIENT_HELLO_CB_BLOCKING, &client_hello_ctx));
 
     /** Tests for test when server_name_used is not set **/
-    EXPECT_SUCCESS(run_test_no_config_swap_ch_cb(S2N_CLIENT_HELLO_CB_BLOCKING,
-            chain_and_key, &client_hello_ctx));
+    EXPECT_SUCCESS(run_test_no_config_swap_ch_cb(S2N_CLIENT_HELLO_CB_BLOCKING, &client_hello_ctx));
 
-    EXPECT_SUCCESS(run_test_no_config_swap_ch_cb(S2N_CLIENT_HELLO_CB_NONBLOCKING,
-            chain_and_key, &client_hello_ctx));
+    EXPECT_SUCCESS(run_test_no_config_swap_ch_cb(S2N_CLIENT_HELLO_CB_NONBLOCKING, &client_hello_ctx));
 
     /** Test rejecting connection in client hello callback **/
-    EXPECT_SUCCESS(run_test_reject_handshake_ch_cb(S2N_CLIENT_HELLO_CB_BLOCKING,
-            chain_and_key, &client_hello_ctx));
+    EXPECT_SUCCESS(run_test_reject_handshake_ch_cb(S2N_CLIENT_HELLO_CB_BLOCKING, &client_hello_ctx));
 
-    EXPECT_SUCCESS(run_test_reject_handshake_ch_cb(S2N_CLIENT_HELLO_CB_NONBLOCKING,
-            chain_and_key, &client_hello_ctx));
+    EXPECT_SUCCESS(run_test_reject_handshake_ch_cb(S2N_CLIENT_HELLO_CB_NONBLOCKING, &client_hello_ctx));
 
-    EXPECT_SUCCESS(run_test_poll_ch_cb(S2N_CLIENT_HELLO_CB_NONBLOCKING,
-            chain_and_key, &client_hello_ctx));
-
-    EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
-    free(cert_chain_pem);
-    free(private_key_pem);
+    EXPECT_SUCCESS(run_test_poll_ch_cb(S2N_CLIENT_HELLO_CB_NONBLOCKING, &client_hello_ctx));
 
     END_TEST();
 

--- a/tests/unit/s2n_self_talk_custom_io_test.c
+++ b/tests/unit/s2n_self_talk_custom_io_test.c
@@ -46,7 +46,7 @@ int mock_client(struct s2n_test_io_pair *io_pair)
 
     result = s2n_negotiate(conn, &blocked);
     if (result < 0) {
-        _exit(1);
+        exit(1);
     }
 
     s2n_shutdown(conn, &blocked);
@@ -55,7 +55,7 @@ int mock_client(struct s2n_test_io_pair *io_pair)
     s2n_cleanup();
     s2n_io_pair_close_one_end(io_pair, S2N_CLIENT);
 
-    _exit(0);
+    exit(0);
 }
 
 int main(int argc, char **argv)
@@ -108,6 +108,7 @@ int main(int argc, char **argv)
 
             /* Free the config */
             EXPECT_SUCCESS(s2n_config_free(config));
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
             free(cert_chain_pem);
             free(private_key_pem);
             free(dhparams_pem);

--- a/tests/unit/s2n_self_talk_min_protocol_version_test.c
+++ b/tests/unit/s2n_self_talk_min_protocol_version_test.c
@@ -57,7 +57,7 @@ int mock_client(struct s2n_test_io_pair *io_pair, uint8_t version)
     s2n_cleanup();
 
     /* Expect failure of handshake */
-    _exit(result == 0 ? 1 : 0);
+    exit(result == 0 ? 1 : 0);
 }
 
 int main(int argc, char **argv)
@@ -97,6 +97,8 @@ int main(int argc, char **argv)
             /* This is the client process, close the server end of the pipe */
             EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
 
+            EXPECT_SUCCESS(s2n_config_free(config));
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
             /* Send the client hello with TLSv1 and validate that we failed handshake */
             mock_client(&io_pair, version);
         }

--- a/tests/unit/s2n_self_talk_session_id_test.c
+++ b/tests/unit/s2n_self_talk_session_id_test.c
@@ -282,7 +282,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
     sleep(1);
 
     s2n_io_pair_close_one_end(io_pair, S2N_CLIENT);
-    _exit(result);
+    exit(result);
 }
 
 int main(int argc, char **argv)
@@ -322,6 +322,8 @@ int main(int argc, char **argv)
     if (pid == 0) {
         /* This is the client process, close the server end of the pipe */
         EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
+        free(cert_chain_pem);
+        free(private_key_pem);
 
         /* Write the fragmented hello message */
         mock_client(&io_pair);

--- a/tests/unit/s2n_self_talk_tls12_test.c
+++ b/tests/unit/s2n_self_talk_tls12_test.c
@@ -93,7 +93,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
     s2n_io_pair_close_one_end(io_pair, S2N_CLIENT);
 
-    _exit(0);
+    exit(0);
 }
 
 int main(int argc, char **argv)
@@ -125,6 +125,9 @@ int main(int argc, char **argv)
         if (pid == 0) {
             /* This is the client process, close the server end of the pipe */
             EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
+            free(cert_chain_pem);
+            free(private_key_pem);
+            free(dhparams_pem);
 
             /* Write the fragmented hello message */
             mock_client(&io_pair);

--- a/tests/unit/s2n_self_talk_tls13_test.c
+++ b/tests/unit/s2n_self_talk_tls13_test.c
@@ -91,7 +91,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
     s2n_io_pair_close_one_end(io_pair, S2N_CLIENT);
 
-    _exit(0);
+    exit(0);
 }
 
 int main(int argc, char **argv)

--- a/tests/unit/s2n_tls_hybrid_prf_test.c
+++ b/tests/unit/s2n_tls_hybrid_prf_test.c
@@ -119,5 +119,6 @@ int main(int argc, char **argv)
         FAIL_MSG("Found unexpected test vectors in the KAT file. Has the KAT file been changed? Did you update NUM_TEST_VECTORS?");
     }
 
+    fclose(kat_file);
     END_TEST();
 }

--- a/tests/unit/valgrind.suppressions
+++ b/tests/unit/valgrind.suppressions
@@ -10,3 +10,51 @@
    fun:pthread_create@@GLIBC_2.2.5
    fun:main
 }
+
+# --errors-for-leak-kinds=all reports pedantic `reachable` leaks so we
+# suppress some trivial ones here
+{
+   ignore_fprint_allocations
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:fprintf
+   fun:main
+}
+{
+   ignore_setenv_allocations
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:setenv
+   fun:main
+}
+
+
+# TODO: fix the pedantic leak errors from s2n_fork_generation_number_test
+{
+   ignore_s2n_fork_generation_number_test
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:s2n_test_case_default_cb_valgrind_marker
+   fun:main
+}
+{
+   ignore_s2n_fork_generation_number_test
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:s2n_test_case_madv_wipeonfork_cb_valgrind_marker
+   fun:main
+}
+
+# TODO: fix the pedantic leak errors from s2n_self_talk_alpn_test
+{
+   ignore_s2n_fork_generation_number_test
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:main_alpn_valgrind_marker
+   fun:main
+}


### PR DESCRIPTION
### TODO
A important point that I didnt convey is that we get ~80% of the benefit from covering a single combination. Covering other combinations is alot of work for diminishing returns.

Action items/next steps:
- break changes into a small PR
- make logic around Makefile cleaner
- create an issue listing followup work and how coverage should extend to other combinations


### Description of changes:
This PR enables the `--errors-for-leak-kinds=all` option to help us catch all potential memory leaks.

Valgrind by default doesn't report "still reachable" errors: `--errors-for-leak-kinds=<set> [default: definite,possible]`. Some resources suggest that this should in general be ok [1] [2]. However, as we can see from https://github.com/aws/s2n-tls/pull/3506 we should be more pedantic in our testing.

### Callouts:
- Different compiler implementations and libcrypto invoke different code paths and have different underlying implementations which leak memory. This PR only fixes and adds the pedantic check for Openssl 1.1.1 + GCC9. Adding the remaining configuration is a future task.

- I was not able to resolve the leaks in `s2n_fork_generation_number_test` and `s2n_self_talk_alpn_test` and therefore suppressed those warnings.

- We can remove `--log-fd=2` since that is the default value: [man page](https://linux.die.net/man/1/valgrind).
> --log-fd=<number> [default: 2, stderr] 

- We need to call `exit` instead of [`_exit`](https://man7.org/linux/man-pages/man2/exit.2.html) so that each process invokes the `atexit` callback.
> The function _exit() is like exit(3), but does not call any functions registered with atexit(3) ...


### Testing:

NOTE: Due to codebuild change not being applied until the PR is merged please take a look at this  **[CI run](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoidUpNb2QzNjZzQ3lrWm1UQ2xzdFZMN1ZGYWE5dVlSQ1ZKd1BnZzZ6aXN1dlZXTmFuZWdvNnR0SitPaFlIcUdjaDZ6RU9KemY2Mi9ybXVBajF0RXo4NmZ1Rnl4dkZrT241UUY4MTVQMkRuNTQ9IiwiaXZQYXJhbWV0ZXJTcGVjIjoiemFRUDgvZUMreVhER0RKaiIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D/batch/aa58120d-cb84-473a-853a-b2f55b09afb9) with Valgrind pedantic enabled. Not Ossl1.1.1 GCC9 passes**


Local testing script:
```
TESTS=(
# s2n_fork_generation_number_test # undo supressions
s2n_self_talk_alpn_test
)

# run specified tests in array
for TEST in ${TESTS[@]}; do

# run for all tests
# for TEST in "../../build/bin"/*_test; do
#     TEST=$(basename $TEST)

    echo $TEST

    pushd tests/unit
    S2N_VALGRIND=1 \
        valgrind --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=all \
        --run-libc-freeres=yes -q --error-exitcode=9 --gen-suppressions=all \
        --num-callers=40 --leak-resolution=high --undef-value-errors=no --trace-children=yes \
        --suppressions=valgrind.suppressions --log-file="../../valgrind/${TEST}" \
              ../../build/bin/$TEST
    popd

done
```

---

[1] https://valgrind.org/docs/manual/faq.html#faq.deflost
> "still reachable" means your program is probably ok -- it didn't free some memory it could have. This is quite common and often reasonable.

[2] https://eklitzke.org/an-introduction-to-valgrind-memcheck
> Memory that is "still reachable" is the least worrisome kind of memory leak: it's memory that could have been freed, but wasn't allocated in an unbounded way.


Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
