### PR TITLE
Custom ubuntu18 image

### DIFF
--- a/codebuild/bin/install_openssl_3_0.sh
+++ b/codebuild/bin/install_openssl_3_0.sh
@@ -44,7 +44,7 @@ mkdir -p $INSTALL_DIR
 $CONFIGURE shared -g3 -fPIC              \
          no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-zlib     \
          no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia\
-         no-bf no-ripemd no-dsa no-ssl2 no-ssl3 no-capieng                  \
+         no-bf no-ripemd no-dsa no-ssl2 no-ssl3 no-capieng no-dtls          \
          -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS      \
          --prefix="$INSTALL_DIR"
 

--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -21,6 +21,7 @@ batch:
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         variables:
           TESTS: sawHMACPlus
           SAW: true
@@ -31,6 +32,7 @@ batch:
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         variables:
           TESTS: tls
           SAW: true
@@ -52,6 +54,7 @@ batch:
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         variables:
           TESTS: valgrind
           GCC_VERSION: 6
@@ -63,6 +66,7 @@ batch:
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         variables:
           TESTS: valgrind
           GCC_VERSION: 9
@@ -74,6 +78,7 @@ batch:
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         variables:
           TESTS: valgrind
           GCC_VERSION: '6'
@@ -85,6 +90,7 @@ batch:
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         variables:
           TESTS: valgrind
           GCC_VERSION: '6'
@@ -96,6 +102,7 @@ batch:
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         variables:
           TESTS: valgrind
           GCC_VERSION: '6'
@@ -107,6 +114,7 @@ batch:
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         variables:
           TESTS: asan
           GCC_VERSION: '6'
@@ -119,6 +127,7 @@ batch:
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         variables:
           TESTS: asan
           GCC_VERSION: '6'
@@ -130,6 +139,7 @@ batch:
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_SMALL
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         variables:
           TESTS: unit
           GCC_VERSION: '9'
@@ -163,6 +173,7 @@ batch:
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         variables:
           TESTS: interning
           BUILD_S2N: 'true'
@@ -172,6 +183,7 @@ batch:
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         variables:
           TESTS: interning
           BUILD_S2N: 'true'
@@ -181,6 +193,7 @@ batch:
       buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         privileged-mode: true
         variables:
           GCC_VERSION: '6'
@@ -190,6 +203,7 @@ batch:
       buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         privileged-mode: true
         variables:
           TESTS: sharedandstatic
@@ -199,6 +213,7 @@ batch:
     - buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         privileged-mode: true
         variables:
           BUILD_S2N: true
@@ -211,6 +226,7 @@ batch:
     - buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         privileged-mode: true
         variables:
           BUILD_S2N: 'true'
@@ -223,6 +239,7 @@ batch:
     - buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         privileged-mode: true
         variables:
           BUILD_S2N: 'true'

--- a/codebuild/spec/buildspec_ubuntu.yml
+++ b/codebuild/spec/buildspec_ubuntu.yml
@@ -19,42 +19,6 @@ env:
     CB_BIN_DIR: "./codebuild/bin"
 
 phases:
-  install:
-    runtime-versions:
-      python: 3.x
-    commands:
-      - echo Entered the install phase...
-      - |
-        if [ -d "third-party-src" ]; then
-          cd third-party-src;
-        fi
-      - $CB_BIN_DIR/install_ubuntu_dependencies.sh
-      - echo "We need a test PPA for gcc-9."
-      - add-apt-repository ppa:ubuntu-toolchain-r/test -y
-      - apt-get update -o Acquire::CompressionTypes::Order::=gz
-      - apt-get update -y
-      - |
-        if expr "${GCC_VERSION}" : "9" >/dev/null; then
-          apt-get install -y --no-install-recommends g++ g++-9 gcc gcc-9;
-        fi
-      - |
-        if expr "${GCC_VERSION}" : "6" >/dev/null; then
-          apt-get install -y --no-install-recommends g++ g++-6 gcc gcc-6;
-        fi
-
-      # Don't install old clang and llvm if LATEST_CLANG is enabled, handle it in install_clang.sh instead
-      - |
-        if expr "${LATEST_CLANG}" != "true" >/dev/null; then
-          apt-get install -y --no-install-recommends clang-3.9 llvm-3.9;
-        fi
-      - apt-get install -y --no-install-recommends indent iproute2 kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc cmake tox libtool ninja-build
-  pre_build:
-    commands:
-      - |
-        if [ -d "third-party-src" ]; then
-          cd third-party-src;
-        fi
-      - $CB_BIN_DIR/install_default_dependencies.sh
   build:
     commands:
       - printenv

--- a/codebuild/spec/buildspec_ubuntu.yml
+++ b/codebuild/spec/buildspec_ubuntu.yml
@@ -19,6 +19,13 @@ env:
     CB_BIN_DIR: "./codebuild/bin"
 
 phases:
+  pre_build:
+    commands:
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+          ln -s /usr/local $CODEBUILD_SRC_DIR/third-party-src/test-deps;
+        fi
   build:
     commands:
       - printenv

--- a/codebuild/spec/buildspec_ubuntu.yml
+++ b/codebuild/spec/buildspec_ubuntu.yml
@@ -22,7 +22,5 @@ phases:
   build:
     commands:
       - printenv
+      - ln -s /usr/local $CODEBUILD_SRC_DIR/test-deps
       - $CB_BIN_DIR/s2n_codebuild.sh
-  post_build:
-    commands:
-      - echo Build completed on `date`

--- a/codebuild/spec/buildspec_ubuntu_integrationv2.yml
+++ b/codebuild/spec/buildspec_ubuntu_integrationv2.yml
@@ -19,31 +19,6 @@ env:
     CB_BIN_DIR: "./codebuild/bin"
 
 phases:
-  install:
-    runtime-versions:
-      python: 3.x
-    commands:
-      - echo Entered the install phase...
-      - |
-        if [ -d "third-party-src" ]; then
-          cd third-party-src;
-        fi
-      - codebuild-breakpoint
-      - $CB_BIN_DIR/install_ubuntu_dependencies.sh
-      # Don't install old clang and llvm if LATEST_CLANG is enabled, handle it in install_clang.sh instead
-      - |
-        if expr "${LATEST_CLANG}" != "true" >/dev/null; then
-          apt-get install -y --no-install-recommends clang-3.9 llvm-3.9;
-        fi
-      - apt-get install -y --no-install-recommends indent iproute2 kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc cmake tox libtool ninja-build
-  pre_build:
-    commands:
-      - |
-        if [ -d "third-party-src" ]; then
-          cd third-party-src;
-        fi
-      - $CB_BIN_DIR/install_default_dependencies.sh
-      - $CB_BIN_DIR/s2n_setup_env.sh
   build:
     commands:
       # For jdk integration test

--- a/codebuild/spec/buildspec_ubuntu_integrationv2.yml
+++ b/codebuild/spec/buildspec_ubuntu_integrationv2.yml
@@ -23,4 +23,5 @@ phases:
     commands:
       # For jdk integration test
       - javac tests/integrationv2/bin/SSLSocketClient.java
+      - ln -s /usr/local $CODEBUILD_SRC_DIR/test-deps
       - TOX_TEST_NAME=$INTEGV2_TEST TESTS=integrationv2 $CB_BIN_DIR/s2n_codebuild.sh

--- a/codebuild/spec/buildspec_ubuntu_integrationv2.yml
+++ b/codebuild/spec/buildspec_ubuntu_integrationv2.yml
@@ -19,6 +19,13 @@ env:
     CB_BIN_DIR: "./codebuild/bin"
 
 phases:
+  pre_build:
+    commands:
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+          ln -s /usr/local $CODEBUILD_SRC_DIR/third-party-src/test-deps;
+        fi
   build:
     commands:
       # For jdk integration test


### PR DESCRIPTION
### Resolved issues:

internal

### Description of changes: 

Move to custom ubuntu18 CodeBuild container.  Reduces run-times and works around flaky upstream repositories.

### Call-outs:

- The fuzz tests are on ubuntu20 (standard5) and are not part of this PR.
- Sidetrail has it's own container that is not part of this PR


### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? 
ad-hoc CodeBuild: 
- [Omnibus](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nOmnibus/batch/s2nOmnibus%3A8c5ea91b-4bc0-43da-8e73-09ae12835fd0?region=us-west-2)  
- [Integrationv2](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/S2nIntegrationV2SmallBatch/batch/S2nIntegrationV2SmallBatch%3A3d268645-a08a-4afd-9739-c0a4e1d4d2ac?region=us-west-2) 
- c.a.c [Omnibus](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nOmnibus/batch/s2nOmnibus%3Ac0715420-a9fd-41e0-becf-5578eaa8a6c9/builds?region=us-west-2) sidetrail and fuzz still affected

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
