### PR TITLE
S2N init clean up bug fix

### DIFF
--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -89,6 +89,8 @@ static bool s2n_cleanup_atexit_impl(void)
     /* the configs need to be wiped before resetting the memory callbacks */
     s2n_wipe_static_configs();
 
+    initialized = false;
+    atexit_cleanup = true;
     return s2n_result_is_ok(s2n_libcrypto_cleanup()) &&
         s2n_result_is_ok(s2n_rand_cleanup_thread()) &&
         s2n_result_is_ok(s2n_rand_cleanup()) &&

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -90,7 +90,6 @@ static bool s2n_cleanup_atexit_impl(void)
     s2n_wipe_static_configs();
 
     initialized = false;
-    atexit_cleanup = true;
     return s2n_result_is_ok(s2n_libcrypto_cleanup()) &&
         s2n_result_is_ok(s2n_rand_cleanup_thread()) &&
         s2n_result_is_ok(s2n_rand_cleanup()) &&


### PR DESCRIPTION
### Resolved issues:
This is part of a fix for an issue in another repo: https://github.com/awslabs/aws-crt-swift

### Description of changes: 

Currently, s2n_init.c has a static variable initialized with a default value of false. That value is changed to true in s2n_init function. If we perform clean up and call s2n_disable_atexit again, it fails because initialized value was never reset to false.

This change resets the value of static variables during at exit clean up.

### Testing:

I tested it locally in aws-crt-swift.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
