### PR TITLE
Add additional CBMC dependencies to README

### DIFF
--- a/tests/cbmc/README.md
+++ b/tests/cbmc/README.md
@@ -35,6 +35,9 @@ Installing CBMC
   should add that directory to your `$PATH`.
   If you built CBMC using Make, then those programs will have been installed in the `src/cbmc`, `src/goto-cc`, and `src/goto-instrument` directories respectively.
 
+- Install [Litani](https://github.com/awslabs/aws-build-accumulator).
+
+- Install [cbmc-viewer](https://github.com/model-checking/cbmc-viewer/releases).
 
 Running the proofs
 ------------------


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

Adds additional CBMC dependencies to the readme that are required to run the CBMC tests locally.

### Call-outs:

None

### Testing:

Documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
