### PR TITLE
Add and document CRL APIs

### DIFF
--- a/api/unstable/crl.h
+++ b/api/unstable/crl.h
@@ -23,11 +23,12 @@ struct s2n_crl_lookup;
  * A callback which can be implemented to provide s2n-tls with CRLs to use for CRL validation.
  *
  * This callback is triggered once for each certificate received during the handshake. To provide s2n-tls with a CRL for
- * the certificate, use `s2n_crl_lookup_set()`. To skip the certificate ant not provide a CRL, use
+ * the certificate, use `s2n_crl_lookup_set()`. To ignore the certificate and not provide a CRL, use
  * `s2n_crl_lookup_ignore()`. See the CRL Validation section in the usage guide for more information.
  *
  * This callback can be synchronous or asynchronous. For asynchronous behavior, return success without calling
- * `s2n_crl_lookup_set()` or `s2n_crl_lookup_ignore()`. The connection will block until one these functions is called.
+ * `s2n_crl_lookup_set()` or `s2n_crl_lookup_ignore()`. The connection will block until one of these functions is
+ * called.
  *
  * @param lookup The CRL lookup for the given certificate.
  * @param context Context for the callback function.
@@ -39,30 +40,30 @@ typedef int (*s2n_crl_lookup_callback) (struct s2n_crl_lookup *lookup, void *con
  * Set a callback to provide CRLs to use for CRL validation.
  *
  * @param config A pointer to the connection config
- * @param crl_lookup_fn A pointer to the implementation of the callback
- * @param data A user supplied opaque context to pass back to the callback
+ * @param s2n_crl_lookup_callback The function to be called for each received certificate.
+ * @param context Context to be passed to the callback function.
  * @return S2N_SUCCESS on success, S2N_FAILURE on failure
  */
 S2N_API
 int s2n_config_set_crl_lookup_cb(struct s2n_config *config, s2n_crl_lookup_callback callback, void *context);
 
 /**
- * Allocates a new s2n_crl struct.
+ * Allocates a new `s2n_crl` struct.
  *
  * Use `s2n_crl_load_pem()` to load the struct with a CRL pem.
  *
  * The allocated struct must be freed with `s2n_crl_free()`.
  *
- * @return A pointer to the new s2n_crl struct.
+ * @return A pointer to the allocated `s2n_crl` struct.
  */
 S2N_API
 struct s2n_crl *s2n_crl_new(void);
 
 /**
- * Loads a s2n_crl with a CRL pem.
+ * Loads a CRL with pem data.
  *
- * @param crl The CRL to load with the PEM.
- * @param pem The pem data to use to load the s2n_crl with.
+ * @param crl The CRL to load with the PEM data.
+ * @param pem The PEM data to load `crl` with.
  * @param len The length of the pem data.
  * @return S2N_SUCCESS on success, S2N_FAILURE on error.
  */
@@ -70,9 +71,9 @@ S2N_API
 int s2n_crl_load_pem(struct s2n_crl *crl, uint8_t *pem, size_t len);
 
 /**
- * Frees a s2n_crl.
+ * Frees a CRL.
  *
- * Frees an allocated s2n_crl and sets `crl` to NULL.
+ * Frees an allocated `s2n_crl` and sets `crl` to NULL.
  *
  * @param crl The CRL to free.
  * @return S2N_SUCCESS on success, S2N_FAILURE on error.
@@ -81,13 +82,13 @@ S2N_API
 int s2n_crl_free(struct s2n_crl **crl);
 
 /**
- * Retrieves the issuer hash of a s2n_crl.
+ * Retrieves the issuer hash of a CRL.
  *
  * This function can be used to find the CRL associated with a certificate received in the s2n_crl_lookup callback. The
  * hash value, `hash`, corresponds with the issuer hash of a certificate, retrieved via
  * `s2n_crl_lookup_get_cert_issuer_hash()`.
  *
- * @param crl The CRL to obtain the hash value from.
+ * @param crl The CRL to obtain the hash value of.
  * @param hash A pointer that will be set to the hash value.
  * @return S2N_SUCCESS on success. S2N_FAILURE on failure
  */
@@ -98,7 +99,7 @@ int s2n_crl_get_issuer_hash(struct s2n_crl *crl, uint64_t *hash);
  * Determines if the CRL is currently active.
  *
  * CRLs contain a thisUpdate field, which specifies the date at which the CRL becomes valid. This function can be called
- * to check this field relative to the current time. If the thisUpdate field is in the past, the CRL is considered
+ * to check this field relative to the current time. If the thisUpdate date is in the past, the CRL is considered
  * active.
  *
  * @param crl The CRL to validate.
@@ -110,8 +111,9 @@ int s2n_crl_validate_active(struct s2n_crl *crl);
 /**
  * Determines if the CRL has expired.
  *
- * CRLs contain a nextUpdate field, which specifies the date at which the CRL is expired. This function can be called
- * to check this field relative to the current time. If the nextUpdate field is in the future, the CRL has not expired.
+ * CRLs contain a nextUpdate field, which specifies the date at which the CRL becomes expired. This function can be
+ * called to check this field relative to the current time. If the nextUpdate date is in the future, the CRL has not
+ * expired.
  *
  * If the CRL does not contain a thisUpdate field, the CRL is assumed to never expire.
  *
@@ -145,7 +147,7 @@ int s2n_crl_lookup_get_cert_issuer_hash(struct s2n_crl_lookup *lookup, uint64_t 
  * To skip providing a CRL from the callback, use `s2n_crl_lookup_ignore()`.
  *
  * @param lookup The CRL lookup for the given certificate.
- * @param crl The CRL to include in the list of CRLs to validate the certificate chain.
+ * @param crl The CRL to include in the list of CRLs used to validate the certificate chain.
  * @return S2N_SUCCESS on success, S2N_FAILURE on failure.
  */
 S2N_API

--- a/api/unstable/crl.h
+++ b/api/unstable/crl.h
@@ -17,6 +17,17 @@
 
 #include <s2n.h>
 
+/**
+ * @file crl.h
+ *
+ * The following APIs enable applications to determine if a received certificate has been revoked by its CA, via
+ * Certificate Revocation Lists (CRLs). Please see the CRL Validation section in the usage guide for more information.
+ *
+ * The CRL APIs are currently considered unstable, since they have been recently added to s2n-tls. After gaining more
+ * confidence in the correctness and usability of these APIs, they will be made stable.
+ *
+ */
+
 struct s2n_crl_lookup;
 
 /**
@@ -24,7 +35,7 @@ struct s2n_crl_lookup;
  *
  * This callback is triggered once for each certificate received during the handshake. To provide s2n-tls with a CRL for
  * the certificate, use `s2n_crl_lookup_set()`. To ignore the certificate and not provide a CRL, use
- * `s2n_crl_lookup_ignore()`. See the CRL Validation section in the usage guide for more information.
+ * `s2n_crl_lookup_ignore()`.
  *
  * This callback can be synchronous or asynchronous. For asynchronous behavior, return success without calling
  * `s2n_crl_lookup_set()` or `s2n_crl_lookup_ignore()`. The connection will block until one of these functions is
@@ -32,7 +43,7 @@ struct s2n_crl_lookup;
  *
  * @param lookup The CRL lookup for the given certificate.
  * @param context Context for the callback function.
- * @returns A POSIX error signal.
+ * @returns 0 on success, -1 on failure.
  */
 typedef int (*s2n_crl_lookup_callback) (struct s2n_crl_lookup *lookup, void *context);
 
@@ -99,7 +110,7 @@ int s2n_crl_get_issuer_hash(struct s2n_crl *crl, uint64_t *hash);
  * Determines if the CRL is currently active.
  *
  * CRLs contain a thisUpdate field, which specifies the date at which the CRL becomes valid. This function can be called
- * to check this field relative to the current time. If the thisUpdate date is in the past, the CRL is considered
+ * to check thisUpdate relative to the current time. If the thisUpdate date is in the past, the CRL is considered
  * active.
  *
  * @param crl The CRL to validate.
@@ -112,7 +123,7 @@ int s2n_crl_validate_active(struct s2n_crl *crl);
  * Determines if the CRL has expired.
  *
  * CRLs contain a nextUpdate field, which specifies the date at which the CRL becomes expired. This function can be
- * called to check this field relative to the current time. If the nextUpdate date is in the future, the CRL has not
+ * called to check nextUpdate relative to the current time. If the nextUpdate date is in the future, the CRL has not
  * expired.
  *
  * If the CRL does not contain a thisUpdate field, the CRL is assumed to never expire.
@@ -159,9 +170,9 @@ int s2n_crl_lookup_set(struct s2n_crl_lookup *lookup, struct s2n_crl *crl);
  * A return function for `s2n_crl_lookup_cb`. This function should be used from within the CRL lookup callback to ignore
  * the certificate, and skip providing s2n-tls with a CRL.
  *
- * If a certificate is ignored, and is ultimately included in the chain of trust, the handshake will fail with a
- * S2N_ERR_CRL_LOOKUP_FAILED error. However, if the certificate is extraneous and not included in the chain of trust,
- * the handshake will proceed.
+ * If a certificate is ignored, and is ultimately included in the chain of trust, certificate chain validation will
+ * fail with a S2N_ERR_CRL_LOOKUP_FAILED error. However, if the certificate is extraneous and not included in the chain
+ * of trust, validation is able to proceed.
  *
  * @param lookup The CRL lookup for the given certificate.
  * @return S2N_SUCCESS on success, S2N_FAILURE on failure.

--- a/api/unstable/crl.h
+++ b/api/unstable/crl.h
@@ -1,0 +1,25 @@
+/*
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+#pragma once
+
+#include <s2n.h>
+
+struct s2n_crl_lookup;
+
+typedef int (*s2n_crl_lookup_callback) (struct s2n_crl_lookup *lookup, void *context);
+
+S2N_API
+int s2n_config_set_crl_lookup_cb(struct s2n_config *config, s2n_crl_lookup_callback callback, void *context);

--- a/api/unstable/crl.h
+++ b/api/unstable/crl.h
@@ -38,8 +38,8 @@ struct s2n_crl_lookup;
  * `s2n_crl_lookup_ignore()`.
  *
  * This callback can be synchronous or asynchronous. For asynchronous behavior, return success without calling
- * `s2n_crl_lookup_set()` or `s2n_crl_lookup_ignore()`. The connection will block until one of these functions is
- * called.
+ * `s2n_crl_lookup_set()` or `s2n_crl_lookup_ignore()`. `s2n_negotiate()` will return S2N_BLOCKED_ON_APPLICATION_INPUT
+ * until one of these functions is called for each invoked callback.
  *
  * @param lookup The CRL lookup for the given certificate.
  * @param context Context for the callback function.

--- a/api/unstable/crl.h
+++ b/api/unstable/crl.h
@@ -19,7 +19,150 @@
 
 struct s2n_crl_lookup;
 
+/**
+ * A callback which can be implemented to provide s2n-tls with CRLs to use for CRL validation.
+ *
+ * This callback is triggered once for each certificate received during the handshake. To provide s2n-tls with a CRL for
+ * the certificate, use `s2n_crl_lookup_set()`. To skip the certificate ant not provide a CRL, use
+ * `s2n_crl_lookup_ignore()`. See the CRL Validation section in the usage guide for more information.
+ *
+ * This callback can be synchronous or asynchronous. For asynchronous behavior, return success without calling
+ * `s2n_crl_lookup_set()` or `s2n_crl_lookup_ignore()`. The connection will block until one these functions is called.
+ *
+ * @param lookup The CRL lookup for the given certificate.
+ * @param context Context for the callback function.
+ * @returns A POSIX error signal.
+ */
 typedef int (*s2n_crl_lookup_callback) (struct s2n_crl_lookup *lookup, void *context);
 
+/**
+ * Set a callback to provide CRLs to use for CRL validation.
+ *
+ * @param config A pointer to the connection config
+ * @param crl_lookup_fn A pointer to the implementation of the callback
+ * @param data A user supplied opaque context to pass back to the callback
+ * @return S2N_SUCCESS on success, S2N_FAILURE on failure
+ */
 S2N_API
 int s2n_config_set_crl_lookup_cb(struct s2n_config *config, s2n_crl_lookup_callback callback, void *context);
+
+/**
+ * Allocates a new s2n_crl struct.
+ *
+ * Use `s2n_crl_load_pem()` to load the struct with a CRL pem.
+ *
+ * The allocated struct must be freed with `s2n_crl_free()`.
+ *
+ * @return A pointer to the new s2n_crl struct.
+ */
+S2N_API
+struct s2n_crl *s2n_crl_new(void);
+
+/**
+ * Loads a s2n_crl with a CRL pem.
+ *
+ * @param crl The CRL to load with the PEM.
+ * @param pem The pem data to use to load the s2n_crl with.
+ * @param len The length of the pem data.
+ * @return S2N_SUCCESS on success, S2N_FAILURE on error.
+ */
+S2N_API
+int s2n_crl_load_pem(struct s2n_crl *crl, uint8_t *pem, size_t len);
+
+/**
+ * Frees a s2n_crl.
+ *
+ * Frees an allocated s2n_crl and sets `crl` to NULL.
+ *
+ * @param crl The CRL to free.
+ * @return S2N_SUCCESS on success, S2N_FAILURE on error.
+ */
+S2N_API
+int s2n_crl_free(struct s2n_crl **crl);
+
+/**
+ * Retrieves the issuer hash of a s2n_crl.
+ *
+ * This function can be used to find the CRL associated with a certificate received in the s2n_crl_lookup callback. The
+ * hash value, `hash`, corresponds with the issuer hash of a certificate, retrieved via
+ * `s2n_crl_lookup_get_cert_issuer_hash()`.
+ *
+ * @param crl The CRL to obtain the hash value from.
+ * @param hash A pointer that will be set to the hash value.
+ * @return S2N_SUCCESS on success. S2N_FAILURE on failure
+ */
+S2N_API
+int s2n_crl_get_issuer_hash(struct s2n_crl *crl, uint64_t *hash);
+
+/**
+ * Determines if the CRL is currently active.
+ *
+ * CRLs contain a thisUpdate field, which specifies the date at which the CRL becomes valid. This function can be called
+ * to check this field relative to the current time. If the thisUpdate field is in the past, the CRL is considered
+ * active.
+ *
+ * @param crl The CRL to validate.
+ * @return S2N_SUCCESS if `crl` is active, S2N_FAILURE if `crl` is not active, or the active status cannot be determined.
+ */
+S2N_API
+int s2n_crl_validate_active(struct s2n_crl *crl);
+
+/**
+ * Determines if the CRL has expired.
+ *
+ * CRLs contain a nextUpdate field, which specifies the date at which the CRL is expired. This function can be called
+ * to check this field relative to the current time. If the nextUpdate field is in the future, the CRL has not expired.
+ *
+ * If the CRL does not contain a thisUpdate field, the CRL is assumed to never expire.
+ *
+ * @param crl The CRL to validate.
+ * @return S2N_SUCCESS if `crl` has not expired, S2N_FAILURE if `crl` has expired, or the expiration status cannot be determined.
+ */
+S2N_API
+int s2n_crl_validate_not_expired(struct s2n_crl *crl);
+
+/**
+ * Retrieves the issuer hash of the certificate.
+ *
+ * The CRL lookup callback is triggered once for each received certificate. This function is used to get the issuer hash
+ * of this certificate. The hash value, `hash`, corresponds with the issuer hash of the CRL, retrieved via
+ * `s2n_crl_get_issuer_hash()`.
+ *
+ * @param lookup The CRL lookup for the given certificate.
+ * @param hash A pointer that will be set to the hash value.
+ * @return S2N_SUCCESS on success, S2N_FAILURE on failure.
+ */
+S2N_API
+int s2n_crl_lookup_get_cert_issuer_hash(struct s2n_crl_lookup *lookup, uint64_t *hash);
+
+/**
+ * Provide s2n-tls with a CRL from the CRL lookup callback.
+ *
+ * A return function for `s2n_crl_lookup_cb`. This function should be used from within the CRL lookup callback to
+ * provide s2n-tls with a CRL for the given certificate. The provided CRL will be included in the list of CRLs to use
+ * when validating the certificate chain.
+ *
+ * To skip providing a CRL from the callback, use `s2n_crl_lookup_ignore()`.
+ *
+ * @param lookup The CRL lookup for the given certificate.
+ * @param crl The CRL to include in the list of CRLs to validate the certificate chain.
+ * @return S2N_SUCCESS on success, S2N_FAILURE on failure.
+ */
+S2N_API
+int s2n_crl_lookup_set(struct s2n_crl_lookup *lookup, struct s2n_crl *crl);
+
+/**
+ * Skip providing a CRL from the CRL lookup callback.
+ *
+ * A return function for `s2n_crl_lookup_cb`. This function should be used from within the CRL lookup callback to ignore
+ * the certificate, and skip providing s2n-tls with a CRL.
+ *
+ * If a certificate is ignored, and is ultimately included in the chain of trust, the handshake will fail with a
+ * S2N_ERR_CRL_LOOKUP_FAILED error. However, if the certificate is extraneous and not included in the chain of trust,
+ * the handshake will proceed.
+ *
+ * @param lookup The CRL lookup for the given certificate.
+ * @return S2N_SUCCESS on success, S2N_FAILURE on failure.
+ */
+S2N_API
+int s2n_crl_lookup_ignore(struct s2n_crl_lookup *lookup);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -536,14 +536,13 @@ Certificate Revocation Lists (CRLs) are lists of issued, unexpired certificates 
 
 To enable CRL validation in s2n-tls, the s2n CRL lookup callback must be implemented via `s2n_config_set_crl_lookup_callback()`. This callback is triggered once for each certificate received in the handshake. The received certificate's issuer hash can be retrieved in the callback via `s2n_crl_lookup_get_cert_issuer_hash()`. The issuer hash can be used to find the correct CRL for the given certificate.
 
-The s2n CRL lookup callback expects a CRL to be returned via `s2n_crl_lookup_set()`. `s2n_crl`s can be created from PEMs via `s2n_crl_new()` and `s2n_crl_load_pem()`, and then freed via `s2n_crl_free()`. The issuer hash of the CRL can be obtained with `s2n_crl_get_issuer_hash()`. This issuer hash of a certificate contained in a CRL will match the issuer hash of that CRL.
+The s2n CRL lookup callback expects a CRL to be returned via `s2n_crl_lookup_set()`. `s2n_crl`s can be created from PEMs via `s2n_crl_new()` and `s2n_crl_load_pem()`, and then freed via `s2n_crl_free()`. The issuer hash of the CRL can be obtained with `s2n_crl_get_issuer_hash()`. This issuer hash of a certificate will match the issuer hash of its CRL.
 
-Calling `s2n_crl_lookup_set` will add the provided CRL to a list that will be used to verify the certificate chain. Received certificates can also be ignored from the callback, via `s2n_crl_lookup_ignore`. When a CRL lookup callback calls `s2n_crl_lookup_ignore`, no CRL is added to this list. If a certificate in the chain of trust cannot find a corresponding CRL in this list, the handshake fails with a `S2N_ERR_CRL_LOOKUP_FAILED` error.
+Calling `s2n_crl_lookup_set` will add the provided CRL to the list of CRLs that will be used to verify the certificate chain. Received certificates can also be ignored from the callback, via `s2n_crl_lookup_ignore`. When a certificate is ignored from the callback, no CRL is added to this list. If a certificate in the chain of trust cannot find a corresponding CRL in this list, the handshake will fail with a `S2N_ERR_CRL_LOOKUP_FAILED` error.
 
-Some received certificates, however, may be extraneous. These certificates are additional certificates that aren't ultimately included in the chain of trust used to validate the end-entity certificate. If such a certificate is ignored from the callback, the handshake will proceed with no error.
+Some received certificates may be extraneous. Extraneous certificates are additional certificates that aren't ultimately included in the chain of trust used to validate the end-entity certificate. If such a certificate is ignored from the callback, the handshake will proceed with no error.
 
 By default, CRL timestamp validation is not performed. If a CRL returned from the CRL lookup callback is not yet active, or is expired, the CRL validation checks will continue and can succeed. If timestamp validation is desired, it should be performed in the CRL lookup callback with `s2n_crl_validate_active` and `s2n_crl_validate_not_expired`.
-
 
 ### Certificate Transparency
 

--- a/tests/unit/s2n_crl_test.c
+++ b/tests/unit/s2n_crl_test.c
@@ -193,9 +193,7 @@ int main(int argc, char *argv[])
 
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
-
-        config->crl_lookup_cb = crl_lookup_test_callback;
-        config->crl_lookup_ctx = (void*) &received_lookup_data;
+        EXPECT_SUCCESS(s2n_config_set_crl_lookup_cb(config, crl_lookup_test_callback, &received_lookup_data));
 
         DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(connection);
@@ -239,9 +237,7 @@ int main(int argc, char *argv[])
 
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
-
-        config->crl_lookup_cb = crl_lookup_test_callback;
-        config->crl_lookup_ctx = (void*) &data;
+        EXPECT_SUCCESS(s2n_config_set_crl_lookup_cb(config, crl_lookup_test_callback, &data));
 
         DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(connection);
@@ -280,9 +276,7 @@ int main(int argc, char *argv[])
 
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
-
-        config->crl_lookup_cb = crl_lookup_test_callback;
-        config->crl_lookup_ctx = (void*) &data;
+        EXPECT_SUCCESS(s2n_config_set_crl_lookup_cb(config, crl_lookup_test_callback, &data));
 
         DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(connection);
@@ -321,12 +315,11 @@ int main(int argc, char *argv[])
         DEFER_CLEANUP(struct s2n_x509_validator validator, s2n_x509_validator_wipe);
         EXPECT_SUCCESS(s2n_x509_validator_init(&validator, &trust_store, 0));
 
+        struct crl_lookup_data data = { 0 };
+
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
-
-        struct crl_lookup_data data = { 0 };
-        config->crl_lookup_cb = crl_lookup_test_callback;
-        config->crl_lookup_ctx = (void*) &data;
+        EXPECT_SUCCESS(s2n_config_set_crl_lookup_cb(config, crl_lookup_test_callback, &data));
 
         DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(connection);
@@ -368,9 +361,7 @@ int main(int argc, char *argv[])
 
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
-
-        config->crl_lookup_cb = crl_lookup_test_callback;
-        config->crl_lookup_ctx = (void*) &data;
+        EXPECT_SUCCESS(s2n_config_set_crl_lookup_cb(config, crl_lookup_test_callback, &data));
 
         DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(connection);
@@ -417,8 +408,7 @@ int main(int argc, char *argv[])
 
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
-
-        config->crl_lookup_cb = crl_lookup_noop;
+        EXPECT_SUCCESS(s2n_config_set_crl_lookup_cb(config, crl_lookup_noop, NULL));
 
         DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(connection);
@@ -474,8 +464,7 @@ int main(int argc, char *argv[])
 
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
-
-        config->crl_lookup_cb = crl_lookup_callback_fail;
+        EXPECT_SUCCESS(s2n_config_set_crl_lookup_cb(config, crl_lookup_callback_fail, NULL));
 
         DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(connection);
@@ -513,9 +502,7 @@ int main(int argc, char *argv[])
 
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
-
-        config->crl_lookup_cb = crl_lookup_test_callback;
-        config->crl_lookup_ctx = (void*) &data;
+        EXPECT_SUCCESS(s2n_config_set_crl_lookup_cb(config, crl_lookup_test_callback, &data));
 
         DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(connection);
@@ -554,9 +541,7 @@ int main(int argc, char *argv[])
 
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
-
-        config->crl_lookup_cb = crl_lookup_test_callback;
-        config->crl_lookup_ctx = (void*) &data;
+        EXPECT_SUCCESS(s2n_config_set_crl_lookup_cb(config, crl_lookup_test_callback, &data));
 
         DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(connection);
@@ -595,9 +580,7 @@ int main(int argc, char *argv[])
 
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
-
-        config->crl_lookup_cb = crl_lookup_test_callback;
-        config->crl_lookup_ctx = (void*) &data;
+        EXPECT_SUCCESS(s2n_config_set_crl_lookup_cb(config, crl_lookup_test_callback, &data));
 
         DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(connection);
@@ -636,9 +619,7 @@ int main(int argc, char *argv[])
 
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
-
-        config->crl_lookup_cb = crl_lookup_test_callback;
-        config->crl_lookup_ctx = (void*) &data;
+        EXPECT_SUCCESS(s2n_config_set_crl_lookup_cb(config, crl_lookup_test_callback, &data));
 
         DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(connection);
@@ -674,9 +655,7 @@ int main(int argc, char *argv[])
         struct crl_lookup_data data = { 0 };
         data.crls[0] = intermediate_crl;
         data.crls[1] = root_crl;
-
-        config->crl_lookup_cb = crl_lookup_test_callback;
-        config->crl_lookup_ctx = (void*) &data;
+        EXPECT_SUCCESS(s2n_config_set_crl_lookup_cb(config, crl_lookup_test_callback, &data));
 
         DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(server_conn);
@@ -712,9 +691,7 @@ int main(int argc, char *argv[])
         struct crl_lookup_data data = { 0 };
         data.crls[0] = intermediate_crl;
         data.crls[1] = root_crl;
-
-        config->crl_lookup_cb = crl_lookup_test_callback;
-        config->crl_lookup_ctx = (void*) &data;
+        EXPECT_SUCCESS(s2n_config_set_crl_lookup_cb(config, crl_lookup_test_callback, &data));
 
         DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(server_conn);
@@ -765,9 +742,7 @@ int main(int argc, char *argv[])
         struct crl_lookup_data data = { 0 };
         data.crls[0] = intermediate_crl;
         data.crls[1] = root_crl;
-
-        server_config->crl_lookup_cb = crl_lookup_test_callback;
-        server_config->crl_lookup_ctx = (void*) &data;
+        EXPECT_SUCCESS(s2n_config_set_crl_lookup_cb(server_config, crl_lookup_test_callback, &data));
 
         DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(server_conn);
@@ -818,9 +793,7 @@ int main(int argc, char *argv[])
         struct crl_lookup_data data = { 0 };
         data.crls[0] = intermediate_crl;
         data.crls[1] = root_crl;
-
-        server_config->crl_lookup_cb = crl_lookup_test_callback;
-        server_config->crl_lookup_ctx = (void*) &data;
+        EXPECT_SUCCESS(s2n_config_set_crl_lookup_cb(server_config, crl_lookup_test_callback, &data));
 
         DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(server_conn);

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -1050,3 +1050,11 @@ S2N_RESULT s2n_config_wall_clock(struct s2n_config *config, uint64_t *output)
     RESULT_ENSURE(config->wall_clock(config->sys_clock_ctx, output) >= S2N_SUCCESS, S2N_ERR_CANCELLED);
     return S2N_RESULT_OK;
 }
+
+int s2n_config_set_crl_lookup_cb(struct s2n_config *config, s2n_crl_lookup_callback cb, void *ctx)
+{
+    POSIX_ENSURE_REF(config);
+    config->crl_lookup_cb = cb;
+    config->crl_lookup_ctx = ctx;
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_crl.h
+++ b/tls/s2n_crl.h
@@ -39,18 +39,6 @@ struct s2n_crl_lookup {
     struct s2n_crl *crl;
 };
 
-/* TODO: APIs are part of an unfinished CRL validation feature and are temporarily hidden
- * https://github.com/aws/s2n-tls/issues/3499 */
-struct s2n_crl *s2n_crl_new(void);
-int s2n_crl_load_pem(struct s2n_crl *crl, uint8_t *pem, size_t len);
-int s2n_crl_free(struct s2n_crl **crl);
-int s2n_crl_get_issuer_hash(struct s2n_crl *crl, uint64_t *hash);
-int s2n_crl_validate_active(struct s2n_crl *crl);
-int s2n_crl_validate_not_expired(struct s2n_crl *crl);
-int s2n_crl_lookup_get_cert_issuer_hash(struct s2n_crl_lookup *lookup, uint64_t *hash);
-int s2n_crl_lookup_set(struct s2n_crl_lookup *lookup, struct s2n_crl *crl);
-int s2n_crl_lookup_ignore(struct s2n_crl_lookup *lookup);
-
 S2N_RESULT s2n_crl_handle_lookup_callback_result(struct s2n_x509_validator *validator);
 S2N_RESULT s2n_crl_invoke_lookup_callbacks(struct s2n_connection *conn, struct s2n_x509_validator *validator);
 S2N_RESULT s2n_crl_get_crls_from_lookup_list(struct s2n_x509_validator *validator, STACK_OF(X509_CRL) *crl_stack);

--- a/tls/s2n_crl.h
+++ b/tls/s2n_crl.h
@@ -17,6 +17,7 @@
 
 #include "api/s2n.h"
 #include "utils/s2n_result.h"
+#include "api/unstable/crl.h"
 
 #include <openssl/x509v3.h>
 
@@ -37,8 +38,6 @@ struct s2n_crl_lookup {
     uint16_t cert_idx;
     struct s2n_crl *crl;
 };
-
-typedef int (*s2n_crl_lookup_callback) (struct s2n_crl_lookup *lookup, void *context);
 
 /* TODO: APIs are part of an unfinished CRL validation feature and are temporarily hidden
  * https://github.com/aws/s2n-tls/issues/3499 */


### PR DESCRIPTION
### Resolved issues:

Resolves https://github.com/aws/s2n-tls/issues/3499

### Description of changes: 

Moves CRL APIs out of `s2n_crl.h` and into `crl.h`. Also adds documentation for each API and a new CRL section in the usage guide.

### Call-outs:

The config API to set the CRL lookup callback has been added, and all of the tests have been changed to use this function instead of setting the callback on the config manually.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
