### PR TITLE
Fix npn test bug

### DIFF
--- a/tests/unit/s2n_npn_extension_test.c
+++ b/tests/unit/s2n_npn_extension_test.c
@@ -83,7 +83,7 @@ int main(int argc, char **argv)
 
         /* Server has already negotiated a protocol with the ALPN extension */
         uint8_t first_protocol_len = strlen(protocols[0]);
-        EXPECT_MEMCPY_SUCCESS(server_conn->application_protocol, protocols, first_protocol_len + 1);
+        EXPECT_MEMCPY_SUCCESS(server_conn->application_protocol, protocols[0], first_protocol_len + 1);
         EXPECT_FALSE(s2n_server_npn_extension.should_send(server_conn));
     }
 


### PR DESCRIPTION
### Description of changes: 
Memory stuff like this is tricky to explain, so I'll just put this here: https://godbolt.org/z/dMo54Whz6

Basically, we weren't copying the protocol, we were copying an address. Sometimes the first byte of that address is apparently identical to "\0", so the test fails (see [this test run](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoidUpNb2QzNjZzQ3lrWm1UQ2xzdFZMN1ZGYWE5dVlSQ1ZKd1BnZzZ6aXN1dlZXTmFuZWdvNnR0SitPaFlIcUdjaDZ6RU9KemY2Mi9ybXVBajF0RXo4NmZ1Rnl4dkZrT241UUY4MTVQMkRuNTQ9IiwiaXZQYXJhbWV0ZXJTcGVjIjoiemFRUDgvZUMreVhER0RKaiIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D/build/17974e0b-2fc5-432d-8000-209c00ddf733)). We didn't make the same mistake in the actual source, because the actual source uses blobs.

I'm not sure how the CI didn't catch this in the original PR-- I guess we got lucky / unlucky and the address didn't start with "\0"?

### Testing:
This is a test. Also for manual testing / sanity I temporarily added a "EXPECT_BYTEARRAY_EQUAL" to check that server_conn->application_protocol was the value we expect.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
