### PR TITLE
Fix fatal no_renegotiation alert

### DIFF
--- a/tests/unit/s2n_client_hello_request_test.c
+++ b/tests/unit/s2n_client_hello_request_test.c
@@ -221,8 +221,12 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_send_client_hello_request(server_conn));
 
         /* Send some more data */
-        EXPECT_OK(s2n_test_send_and_recv(server_conn, client_conn));
-        EXPECT_OK(s2n_test_send_and_recv(client_conn, server_conn));
+        for (size_t i = 0; i < 10; i++) {
+            EXPECT_OK(s2n_test_send_and_recv(server_conn, client_conn));
+            EXPECT_OK(s2n_test_send_and_recv(client_conn, server_conn));
+            EXPECT_FALSE(client_conn->closing);
+            EXPECT_FALSE(client_conn->closed);
+        }
     }
 
     /* Test: Hello requests received after the handshake trigger a no_renegotiation alert

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -136,7 +136,7 @@ static bool s2n_alerts_supported(struct s2n_connection *conn)
     return !s2n_connection_is_quic_enabled(conn);
 }
 
-static bool s2n_handle_as_warning(struct s2n_connection *conn, uint8_t level, uint8_t type)
+static bool s2n_process_as_warning(struct s2n_connection *conn, uint8_t level, uint8_t type)
 {
     /* Only TLS1.2 considers the alert level. The alert level field is
      * considered deprecated in TLS1.3. */
@@ -149,6 +149,20 @@ static bool s2n_handle_as_warning(struct s2n_connection *conn, uint8_t level, ui
      * We need to treat it as a warning regardless of alert_behavior to avoid marking
      * correctly-closed connections as failed. */
     return type == S2N_TLS_ALERT_USER_CANCELED;
+}
+
+S2N_RESULT s2n_alerts_close_if_fatal(struct s2n_connection *conn, struct s2n_blob *alert)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(alert);
+    RESULT_ENSURE_EQ(alert->size, S2N_ALERT_LENGTH);
+    /* Only one alert should currently be treated as a warning */
+    if (alert->data[1] == S2N_TLS_ALERT_NO_RENEGOTIATION) {
+        RESULT_ENSURE_EQ(alert->data[0], S2N_TLS_ALERT_LEVEL_WARNING);
+        return S2N_RESULT_OK;
+    }
+    conn->closing = true;
+    return S2N_RESULT_OK;
 }
 
 int s2n_error_get_alert(int error, uint8_t *alert)
@@ -206,7 +220,7 @@ int s2n_process_alert_fragment(struct s2n_connection *conn)
             }
 
             /* Ignore warning-level alerts if we're in warning-tolerant mode */
-            if (s2n_handle_as_warning(conn, conn->alert_in_data[0], conn->alert_in_data[1])) {
+            if (s2n_process_as_warning(conn, conn->alert_in_data[0], conn->alert_in_data[1])) {
                 POSIX_GUARD(s2n_stuffer_wipe(&conn->alert_in));
                 return 0;
             }

--- a/tls/s2n_alerts.h
+++ b/tls/s2n_alerts.h
@@ -107,3 +107,4 @@ extern int s2n_queue_writer_close_alert_warning(struct s2n_connection *conn);
 extern int s2n_queue_reader_unsupported_protocol_version_alert(struct s2n_connection *conn);
 extern int s2n_queue_reader_handshake_failure_alert(struct s2n_connection *conn);
 S2N_RESULT s2n_queue_reader_no_renegotiation_alert(struct s2n_connection *conn);
+S2N_RESULT s2n_alerts_close_if_fatal(struct s2n_connection *conn, struct s2n_blob *alert);

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -19,6 +19,7 @@
 
 #include "error/s2n_errno.h"
 
+#include "tls/s2n_alerts.h"
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_handshake.h"
@@ -103,7 +104,7 @@ int s2n_flush(struct s2n_connection *conn, s2n_blocked_status *blocked)
         alert.size = 2;
         POSIX_GUARD(s2n_record_write(conn, TLS_ALERT, &alert));
         POSIX_GUARD(s2n_stuffer_rewrite(&conn->reader_alert_out));
-        conn->closing = 1;
+        POSIX_GUARD_RESULT(s2n_alerts_close_if_fatal(conn, &alert));
 
         /* Actually write it ... */
         goto WRITE;
@@ -116,7 +117,7 @@ int s2n_flush(struct s2n_connection *conn, s2n_blocked_status *blocked)
         alert.size = 2;
         POSIX_GUARD(s2n_record_write(conn, TLS_ALERT, &alert));
         POSIX_GUARD(s2n_stuffer_rewrite(&conn->writer_alert_out));
-        conn->closing = 1;
+        POSIX_GUARD_RESULT(s2n_alerts_close_if_fatal(conn, &alert));
 
         /* Actually write it ... */
         goto WRITE;


### PR DESCRIPTION
### Description of changes: 

We are writing the no_renegotiation alert with the level byte correct for a warning. However, when we send an alert, we assume that alert is fatal and the connection now needs to close. This is not the case for no_renegotiation.

I check for no_renegotiation specifically atm because close_notify is also technically a warning, but should cause the connection to close.

### Testing:
Unit tests. My original tests missed it because I only called send once after the alert was written. The first send sets closed==true, but we need at least a second send to raise an error about the connection being closed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
