### PR TITLE
Finish compliance comments for secure renegotiation (RFC5746)

### DIFF
--- a/compliance/specs/exceptions/rfc5746/4.4.toml
+++ b/compliance/specs/exceptions/rfc5746/4.4.toml
@@ -1,0 +1,33 @@
+target = "https://tools.ietf.org/rfc/rfc5746#4.4"
+
+[[exception]]
+quote = '''
+It is RECOMMENDED that servers not permit legacy renegotiation.  If
+servers nevertheless do permit it, they MUST follow the requirements
+in this section.
+'''
+reason = '''
+s2n-tls servers do not support renegotiation
+and do not allow clients to renegotiate.
+'''
+
+[[exception]]
+quote = '''
+o  When a ClientHello is received, the server MUST verify that it
+does not contain the TLS_EMPTY_RENEGOTIATION_INFO_SCSV SCSV.  If
+the SCSV is present, the server MUST abort the handshake.
+'''
+reason = '''
+s2n-tls servers do not support renegotiation
+and do not allow clients to renegotiate.
+'''
+
+[[exception]]
+quote = '''
+o  The server MUST verify that the "renegotiation_info" extension is
+not present; if it is, the server MUST abort the handshake.
+'''
+reason = '''
+s2n-tls servers do not support renegotiation
+and do not allow clients to renegotiate.
+'''

--- a/compliance/specs/exceptions/rfc5746/5.toml
+++ b/compliance/specs/exceptions/rfc5746/5.toml
@@ -1,0 +1,11 @@
+target = "https://tools.ietf.org/rfc/rfc5746#5"
+
+[[exception]]
+quote = '''
+Servers SHOULD NOT allow
+clients to renegotiate without using this extension.
+'''
+reason = '''
+s2n-tls servers do not support renegotiation
+and do not allow clients to renegotiate.
+'''

--- a/tests/unit/s2n_client_hello_request_test.c
+++ b/tests/unit/s2n_client_hello_request_test.c
@@ -274,6 +274,11 @@ int main(int argc, char **argv)
     /* Test: Hello requests received after the handshake trigger a no_renegotiation alert
      * if the application rejects the renegotiation request
      *
+     *= https://tools.ietf.org/rfc/rfc5746#5
+     *= type=test
+     *# TLS implementations SHOULD provide a mechanism to disable and enable
+     *# renegotiation.
+     *
      *= https://tools.ietf.org/rfc/rfc5246#section-7.4.1.1
      *= type=test
      *# This message MAY be ignored by
@@ -318,6 +323,11 @@ int main(int argc, char **argv)
 
     /* Test: Hello requests received after the handshake do not trigger a no_renegotiation alert
      * if the application accepts the renegotiation request
+     *
+     *= https://tools.ietf.org/rfc/rfc5746#5
+     *= type=test
+     *# TLS implementations SHOULD provide a mechanism to disable and enable
+     *# renegotiation.
      */
     {
         struct s2n_test_reneg_req_ctx ctx = { .app_decision = S2N_RENEGOTIATE_ACCEPT };
@@ -407,6 +417,50 @@ int main(int argc, char **argv)
         /* Callback was not triggered */
         EXPECT_NOT_NULL(client_conn->config->renegotiate_request_cb);
         EXPECT_EQUAL(ctx.call_count, 0);
+    }
+
+    /* Test: SSLv3 sends a fatal handshake_failure alert instead of no_renegotiate
+     *
+     *= https://tools.ietf.org/rfc/rfc5746#4.5
+     *= type=test
+     *# SSLv3 does not define the "no_renegotiation" alert (and does
+     *# not offer a way to indicate a refusal to renegotiate at a "warning"
+     *# level).  SSLv3 clients that refuse renegotiation SHOULD use a fatal
+     *# handshake_failure alert.
+     **/
+    if (s2n_hash_is_available(S2N_HASH_MD5)) {
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "test_all"));
+
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "test_all"));
+
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        /* Force an SSLv3 handshake */
+        client_conn->client_protocol_version = S2N_SSLv3;
+        client_conn->actual_protocol_version = S2N_SSLv3;
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_SSLv3);
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_SSLv3);
+
+        /* Send the hello request message. */
+        EXPECT_OK(s2n_send_client_hello_request(server_conn));
+
+        /* handshake_failure alert sent and received */
+        EXPECT_OK(s2n_test_send_and_recv(server_conn, client_conn));
+        EXPECT_ERROR_WITH_ERRNO(s2n_test_send_and_recv(client_conn, server_conn), S2N_ERR_ALERT);
+        EXPECT_EQUAL(s2n_connection_get_alert(server_conn), S2N_TLS_ALERT_HANDSHAKE_FAILURE);
+        EXPECT_TRUE(client_conn->closed);
+        EXPECT_TRUE(server_conn->closed);
     }
 
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));

--- a/tests/unit/s2n_server_renegotiation_info_test.c
+++ b/tests/unit/s2n_server_renegotiation_info_test.c
@@ -45,6 +45,16 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
+    DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = NULL, s2n_cert_chain_and_key_ptr_free);
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+            S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+
+    DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+    EXPECT_NOT_NULL(config);
+    EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+
     /* Test should_send
      *
      *= https://tools.ietf.org/rfc/rfc5746#3.6
@@ -80,7 +90,15 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test server_renegotiation_info send and recv during initial handshake */
+    /* Test server_renegotiation_info send and recv during initial handshake
+     *
+     *= https://tools.ietf.org/rfc/rfc5746#4.3
+     *= type=test
+     *# In order to enable clients to probe, even servers that do not support
+     *# renegotiation MUST implement the minimal version of the extension
+     *# described in this document for initial handshakes, thus signaling
+     *# that they have been upgraded.
+     */
     {
         struct s2n_connection *server_conn, *client_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -102,6 +120,38 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_free(&extension));
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
+    }
+
+    /* Test server_renegotiation_info recv when using SSLv3
+     *
+     *= https://tools.ietf.org/rfc/rfc5746#4.5
+     *= type=test
+     *# Clients that support SSLv3 and offer secure renegotiation (either via SCSV or
+     *# "renegotiation_info") MUST accept the "renegotiation_info" extension
+     *# from the server, even if the server version is {0x03, 0x00}, and
+     *# behave as described in this specification.
+     */
+    {
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+
+        DEFER_CLEANUP(struct s2n_stuffer extension = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extension, 0));
+
+        server_conn->actual_protocol_version = S2N_TLS12;
+        server_conn->secure_renegotiation = true;
+        EXPECT_SUCCESS(s2n_server_renegotiation_info_extension.send(server_conn, &extension));
+        EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&extension), 0);
+
+        client_conn->client_protocol_version = S2N_SSLv3;
+        client_conn->actual_protocol_version = S2N_SSLv3;
+        EXPECT_SUCCESS(s2n_server_renegotiation_info_extension.recv(client_conn, &extension));
+        EXPECT_EQUAL(client_conn->secure_renegotiation, 1);
+        EXPECT_EQUAL(s2n_stuffer_data_available(&extension), 0);
     }
 
     /* Test server_renegotiation_info recv during initial handshake - extension too long */
@@ -313,13 +363,6 @@ int main(int argc, char **argv)
      *#    includes the "renegotiation_info" extension:
      */
     {
-        DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = NULL, s2n_cert_chain_and_key_ptr_free);
-        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
-                S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
-
-        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
-        EXPECT_NOT_NULL(config);
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
 
         DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
                 s2n_connection_ptr_free);
@@ -362,6 +405,46 @@ int main(int argc, char **argv)
 
             EXPECT_TRUE(client_conn->secure_renegotiation);
         }
+    }
+
+    /* Functional Test: SSLv3
+     *
+     *= https://tools.ietf.org/rfc/rfc5746#4.5
+     *= type=test
+     *# Clients that support SSLv3 and offer secure renegotiation (either via SCSV or
+     *# "renegotiation_info") MUST accept the "renegotiation_info" extension
+     *# from the server, even if the server version is {0x03, 0x00}, and
+     *# behave as described in this specification.  TLS servers that support
+     *# secure renegotiation and support SSLv3 MUST accept SCSV or the
+     *# "renegotiation_info" extension and respond as described in this
+     *# specification even if the offered client version is {0x03, 0x00}.
+     **/
+    if (s2n_hash_is_available(S2N_HASH_MD5)) {
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "test_all"));
+        client_conn->client_protocol_version = S2N_SSLv3;
+        client_conn->actual_protocol_version = S2N_SSLv3;
+
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "test_all"));
+        server_conn->server_protocol_version = S2N_SSLv3;
+        server_conn->actual_protocol_version = S2N_SSLv3;
+
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_TRUE(client_conn->secure_renegotiation);
+        EXPECT_TRUE(server_conn->secure_renegotiation);
+        EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_SSLv3);
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_SSLv3);
     }
 
     END_TEST();

--- a/tls/extensions/s2n_client_renegotiation_info.c
+++ b/tls/extensions/s2n_client_renegotiation_info.c
@@ -37,13 +37,12 @@ const s2n_extension_type s2n_client_renegotiation_info_extension = {
      *# o  If neither the TLS_EMPTY_RENEGOTIATION_INFO_SCSV SCSV nor the
      *#    "renegotiation_info" extension was included, set the
      *#    secure_renegotiation flag to FALSE.  In this case, some servers
-     *#    may want to terminate the handshake instead of continuing
+     *#    may want to terminate the handshake instead of continuing; see
+     *#    Section 4.3 for discussion.
      *
      * The conn->secure_renegotiation flag defaults to false, so this is a no-op.
-     * We do not terminate the handshake, although missing messaging for secure
-     * renegotiation degrades client security.
-     *
-     * We could introduce an option to fail in this case in the future.
+     * We do not terminate the handshake for compatibility reasons.
+     * See https://github.com/aws/s2n-tls/issues/3528
      */
     .if_missing = s2n_extension_noop_if_missing,
 };
@@ -85,6 +84,12 @@ static int s2n_client_renegotiation_send(struct s2n_connection *conn, struct s2n
  *= https://tools.ietf.org/rfc/rfc5746#3.6
  *# o  The server MUST check if the "renegotiation_info" extension is
  *# included in the ClientHello.
+ *
+ * Note that this extension must also work for SSLv3:
+ *= https://tools.ietf.org/rfc/rfc5746#4.5
+ *# TLS servers that support secure renegotiation and support SSLv3 MUST accept SCSV or the
+ *# "renegotiation_info" extension and respond as described in this
+ *# specification even if the offered client version is {0x03, 0x00}.
  */
 static int s2n_client_renegotiation_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -300,6 +300,18 @@ int s2n_queue_reader_handshake_failure_alert(struct s2n_connection *conn)
 
 S2N_RESULT s2n_queue_reader_no_renegotiation_alert(struct s2n_connection *conn)
 {
+    /**
+     *= https://tools.ietf.org/rfc/rfc5746#4.5
+     *# SSLv3 does not define the "no_renegotiation" alert (and does
+     *# not offer a way to indicate a refusal to renegotiate at a "warning"
+     *# level).  SSLv3 clients that refuse renegotiation SHOULD use a fatal
+     *# handshake_failure alert.
+     **/
+    if (s2n_connection_get_protocol_version(conn) == S2N_SSLv3) {
+        RESULT_GUARD_POSIX(s2n_queue_reader_alert(conn, S2N_TLS_ALERT_LEVEL_FATAL, S2N_TLS_ALERT_HANDSHAKE_FAILURE));
+        return S2N_RESULT_OK;
+    }
+
     RESULT_GUARD_POSIX(s2n_queue_reader_alert(conn, S2N_TLS_ALERT_LEVEL_WARNING, S2N_TLS_ALERT_NO_RENEGOTIATION));
     return S2N_RESULT_OK;
 }

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -1019,6 +1019,11 @@ int s2n_config_set_verify_after_sign(struct s2n_config *config, s2n_verify_after
     return S2N_SUCCESS;
 }
 
+/*
+ *= https://tools.ietf.org/rfc/rfc5746#5
+ *# TLS implementations SHOULD provide a mechanism to disable and enable
+ *# renegotiation.
+ */
 int s2n_config_set_renegotiate_request_cb(struct s2n_config *config, s2n_renegotiate_request_cb cb, void *ctx)
 {
     POSIX_ENSURE_REF(config);


### PR DESCRIPTION
### Description of changes: 

With these comments, RFC5746 has 100% coverage! It's mostly exceptions to the server renegotiation requirements and SSLv3 compatibility.

Report: https://d3fqnyekunr9xg.cloudfront.net/lrstewart/rfc5746.html#/spec/https%3A%2F%2Ftools.ietf.org%2Frfc%2Frfc5746

### Testing:

New unit tests for the requirements covered.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
