### PR TITLE
Tweaks to HelloRequest handling

### DIFF
--- a/tests/unit/s2n_client_hello_request_test.c
+++ b/tests/unit/s2n_client_hello_request_test.c
@@ -229,7 +229,7 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Test: Hello requests received after the handshake trigger a no_renegotiation alert
+    /* Test: Hello requests received after the handshake do NOT trigger a no_renegotiation alert
      * if renegotiation callbacks not set.
      *
      *= https://tools.ietf.org/rfc/rfc5246#section-7.4.1.1
@@ -262,10 +262,9 @@ int main(int argc, char **argv)
         /* Send the hello request message. */
         EXPECT_OK(s2n_send_client_hello_request(server_conn));
 
-        /* no_renegotation alert sent and received */
+        /* no_renegotation alert NOT sent and received */
         EXPECT_OK(s2n_test_send_and_recv(server_conn, client_conn));
-        EXPECT_ERROR_WITH_ERRNO(s2n_test_send_and_recv(client_conn, server_conn), S2N_ERR_ALERT);
-        EXPECT_EQUAL(s2n_connection_get_alert(server_conn), S2N_TLS_ALERT_NO_RENEGOTIATION);
+        EXPECT_OK(s2n_test_send_and_recv(client_conn, server_conn));
 
         /* Callback was not set */
         EXPECT_NULL(client_conn->config->renegotiate_request_cb);
@@ -419,6 +418,46 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(ctx.call_count, 0);
     }
 
+    /* Test: Application callback method fails */
+    {
+        struct s2n_test_reneg_req_ctx ctx = { .app_decision = S2N_RENEGOTIATE_ACCEPT };
+
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config_with_reneg_cb));
+        EXPECT_SUCCESS(s2n_config_set_renegotiate_request_cb(config_with_reneg_cb, s2n_test_reneg_req_cb, &ctx));
+
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+
+        /* Complete the handshake */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+        /* Send the hello request message. */
+        EXPECT_OK(s2n_send_client_hello_request(server_conn));
+
+        /* Force the callback to fail.
+         * We're only allowed to call it UINT8_MAX times, so calling
+         * one more time will cause it to fail with S2N_ERR_SAFETY.
+         */
+        EXPECT_NOT_NULL(client_conn->config->renegotiate_request_cb);
+        ctx.call_count = UINT8_MAX;
+
+        /* s2n_recv should not surface the callback error as S2N_ERR_SAFETY.
+         * Applications won't be able to set s2n_errno to a meaningful value,
+         * so we need to set it to S2N_ERR_CANCELED for them.
+         */
+        EXPECT_ERROR_WITH_ERRNO(s2n_test_send_and_recv(server_conn, client_conn), S2N_ERR_CANCELLED);
+    }
+
     /* Test: SSLv3 sends a fatal handshake_failure alert instead of no_renegotiate
      *
      *= https://tools.ietf.org/rfc/rfc5746#4.5
@@ -429,11 +468,14 @@ int main(int argc, char **argv)
      *# handshake_failure alert.
      **/
     if (s2n_hash_is_available(S2N_HASH_MD5)) {
+        struct s2n_test_reneg_req_ctx ctx = { .app_decision = S2N_RENEGOTIATE_REJECT };
+
         DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
                 s2n_connection_ptr_free);
         EXPECT_NOT_NULL(client_conn);
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config_with_reneg_cb));
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "test_all"));
+        EXPECT_SUCCESS(s2n_config_set_renegotiate_request_cb(config_with_reneg_cb, s2n_test_reneg_req_cb, &ctx));
 
         DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
                 s2n_connection_ptr_free);
@@ -461,6 +503,10 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_connection_get_alert(server_conn), S2N_TLS_ALERT_HANDSHAKE_FAILURE);
         EXPECT_TRUE(client_conn->closed);
         EXPECT_TRUE(server_conn->closed);
+
+        /* Callback triggered */
+        EXPECT_NOT_NULL(client_conn->config->renegotiate_request_cb);
+        EXPECT_EQUAL(ctx.call_count, 1);
     }
 
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));

--- a/tls/s2n_client_hello_request.c
+++ b/tls/s2n_client_hello_request.c
@@ -41,6 +41,13 @@ S2N_RESULT s2n_client_hello_request_recv(struct s2n_connection *conn)
     RESULT_ENSURE_REF(conn->config);
     RESULT_GUARD(s2n_client_hello_request_validate(conn));
 
+    /* Maintain the old s2n-tls behavior by default.
+     * Traditionally, s2n-tls has just ignored all hello requests.
+     */
+    if (!conn->config->renegotiate_request_cb) {
+        return S2N_RESULT_OK;
+    }
+
     /*
      *= https://tools.ietf.org/rfc/rfc5746#section-4.2
      *# This text applies if the connection's "secure_renegotiation" flag is
@@ -61,10 +68,8 @@ S2N_RESULT s2n_client_hello_request_recv(struct s2n_connection *conn)
     }
 
     s2n_renegotiate_response response = S2N_RENEGOTIATE_REJECT;
-    if (conn->config->renegotiate_request_cb) {
-        RESULT_GUARD_POSIX((conn->config->renegotiate_request_cb)(
-                conn, conn->config->renegotiate_request_ctx, &response));
-    }
+    int result = conn->config->renegotiate_request_cb(conn, conn->config->renegotiate_request_ctx, &response);
+    RESULT_ENSURE(result == S2N_SUCCESS, S2N_ERR_CANCELLED);
 
     /*
      *= https://tools.ietf.org/rfc/rfc5246#section-7.4.1.1


### PR DESCRIPTION
### Description of changes: 

We should go back to ignoring HelloRequest by default. [This issue](https://github.com/aws/s2n-tls/commit/af80f6b47a17bab71cfdc5377e3d1af7530ba540) makes me think we should maintain our legacy behavior to avoid unnecessary impact to customers who don't care about renegotiation. Sending warning-level alerts is new behavior. Ignoring HelloRequests was working for most customers before.

While fixing this, I also noticed that we were using GUARD_POSIX on the callback function. That won't work, since customers / applications don't have access to specific error codes and can't set s2n_errno. So we would have successfully indicated an error, but with s2n_errno set to whatever the last unrelated error we encountered was. I chose S2N_ERR_CANCELED because that's how we indicate that the client hello callback failed.

### Testing:
New unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
