### PR TITLE
Only enable non-portable optimizations safety checks during GitHub CI builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,6 +290,15 @@ if(S2N_NO_PQ)
     target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_NO_PQ)
 endif()
 
+# Whether to fail the build when compiling s2n's portable C code with non-portable assembly optimizations. Doing this
+# can lead to runtime crashes if build artifacts are built on modern hardware, but deployed to older hardware without
+# newer CPU instructions. s2n, by default, should be backwards compatible with older CPU types so this flag should be
+# enabled in s2n's CI builds and tests, but other consumers of s2n may have stronger control of what CPU types they
+# deploy to, and can enable more CPU optimizations.
+if(S2N_BLOCK_NONPORTABLE_OPTIMIZATIONS)
+    target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_BLOCK_NONPORTABLE_OPTIMIZATIONS=1)
+endif()
+
 if(KYBER512R3_AVX2_BMI2_OPT_SUPPORTED)
     FILE(GLOB KYBER512R3_AVX2_BMI2_SRCS "pq-crypto/kyber_r3/*_avx2.c")
     set_source_files_properties(${KYBER512R3_AVX2_BMI2_SRCS} PROPERTIES COMPILE_FLAGS ${KYBER512R3_AVX2_BMI2_FLAGS})

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -69,7 +69,7 @@ fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMACPlus" ]] && [[ "$OS_NAME" == "linux" ]]; then make -C tests/saw tmp/verify_HMAC.log tmp/verify_drbg.log failure-tests; fi
 
 # Run Individual tests
-if [[ "$TESTS" == "ALL" || "$TESTS" == "unit" ]]; then cmake . -Bbuild -DCMAKE_PREFIX_PATH=$LIBCRYPTO_ROOT -D${CMAKE_PQ_OPTION} -DBUILD_SHARED_LIBS=on; cmake --build ./build; make -C build test ARGS=-j$(nproc); fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "unit" ]]; then cmake . -Bbuild -DCMAKE_PREFIX_PATH=$LIBCRYPTO_ROOT -D${CMAKE_PQ_OPTION} -DS2N_BLOCK_NONPORTABLE_OPTIMIZATIONS=True -DBUILD_SHARED_LIBS=on; cmake --build ./build; make -C build test ARGS=-j$(nproc); fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "interning" ]]; then ./codebuild/bin/test_libcrypto_interning.sh; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "asan" ]]; then make clean; S2N_ADDRESS_SANITIZER=1 make -j $JOBS ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integration" ]]; then make clean; S2N_NO_SSLYZE=1 make integration ; fi

--- a/codebuild/bin/s2n_codebuild_al2.sh
+++ b/codebuild/bin/s2n_codebuild_al2.sh
@@ -30,7 +30,7 @@ fi
 
 # Linker flags are a workaround for openssl
 case "$TESTS" in
-  "unit") cmake . -Bbuild -DCMAKE_EXE_LINKER_FLAGS="-lcrypto -lz" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -D${CMAKE_PQ_OPTION}
+  "unit") cmake . -Bbuild -DCMAKE_EXE_LINKER_FLAGS="-lcrypto -lz" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -D${CMAKE_PQ_OPTION} -DS2N_BLOCK_NONPORTABLE_OPTIMIZATIONS=True
           cmake --build ./build -j $(nproc)
           CTEST_PARALLEL_LEVEL=$(nproc) make -C build test;;
   *) echo "Unknown test"

--- a/pq-crypto/kyber_r3/kyber512r3_cbd.c
+++ b/pq-crypto/kyber_r3/kyber512r3_cbd.c
@@ -2,9 +2,7 @@
 #include "kyber512r3_params.h"
 #include "kyber512r3_cbd.h"
 
-#if S2N_ANY_NONPORTABLE_OPTIMIZATIONS_ENABLED
-#error "Compiling portable code with non-portable assembly optimizations is not allowed"
-#endif
+S2N_ENSURE_PORTABLE_OPTIMIZATIONS
 
 /*************************************************
 * Name:        load32_littleendian

--- a/pq-crypto/kyber_r3/kyber512r3_fips202.c
+++ b/pq-crypto/kyber_r3/kyber512r3_fips202.c
@@ -14,9 +14,7 @@
 #define NROUNDS 24
 #define ROL(a, offset) (((a) << (offset)) ^ ((a) >> (64 - (offset))))
 
-#if S2N_ANY_NONPORTABLE_OPTIMIZATIONS_ENABLED
-#error "Compiling portable code with non-portable assembly optimizations is not allowed"
-#endif
+S2N_ENSURE_PORTABLE_OPTIMIZATIONS
 
 /*************************************************
  * Name:        load64

--- a/pq-crypto/kyber_r3/kyber512r3_indcpa.c
+++ b/pq-crypto/kyber_r3/kyber512r3_indcpa.c
@@ -9,9 +9,7 @@
 #include "pq-crypto/s2n_pq_random.h"
 #include "utils/s2n_safety.h"
 
-#if S2N_ANY_NONPORTABLE_OPTIMIZATIONS_ENABLED
-#error "Compiling portable code with non-portable assembly optimizations is not allowed"
-#endif
+S2N_ENSURE_PORTABLE_OPTIMIZATIONS
 
 /*************************************************
 * Name:        pack_pk

--- a/pq-crypto/kyber_r3/kyber512r3_kem.c
+++ b/pq-crypto/kyber_r3/kyber512r3_kem.c
@@ -9,9 +9,7 @@
 #include "pq-crypto/s2n_pq_random.h"
 #include "pq-crypto/s2n_pq.h"
 
-#if S2N_ANY_NONPORTABLE_OPTIMIZATIONS_ENABLED
-#error "Compiling portable code with non-portable assembly optimizations is not allowed"
-#endif
+S2N_ENSURE_PORTABLE_OPTIMIZATIONS
 
 /*************************************************
 * Name:        crypto_kem_keypair

--- a/pq-crypto/kyber_r3/kyber512r3_ntt.c
+++ b/pq-crypto/kyber_r3/kyber512r3_ntt.c
@@ -3,9 +3,7 @@
 #include "kyber512r3_ntt.h"
 #include "kyber512r3_reduce.h"
 
-#if S2N_ANY_NONPORTABLE_OPTIMIZATIONS_ENABLED
-#error "Compiling portable code with non-portable assembly optimizations is not allowed"
-#endif
+S2N_ENSURE_PORTABLE_OPTIMIZATIONS
 
 const int16_t zetas[128] = {
     2285, 2571, 2970, 1812, 1493, 1422, 287, 202, 3158, 622, 1577, 182, 962,

--- a/pq-crypto/kyber_r3/kyber512r3_poly.c
+++ b/pq-crypto/kyber_r3/kyber512r3_poly.c
@@ -6,9 +6,7 @@
 #include "kyber512r3_cbd.h"
 #include "kyber512r3_symmetric.h"
 
-#if S2N_ANY_NONPORTABLE_OPTIMIZATIONS_ENABLED
-#error "Compiling portable code with non-portable assembly optimizations is not allowed"
-#endif
+S2N_ENSURE_PORTABLE_OPTIMIZATIONS
 
 /*************************************************
 * Name:        poly_compress

--- a/pq-crypto/kyber_r3/kyber512r3_polyvec.c
+++ b/pq-crypto/kyber_r3/kyber512r3_polyvec.c
@@ -3,9 +3,7 @@
 #include "kyber512r3_poly.h"
 #include "kyber512r3_polyvec.h"
 
-#if S2N_ANY_NONPORTABLE_OPTIMIZATIONS_ENABLED
-#error "Compiling portable code with non-portable assembly optimizations is not allowed"
-#endif
+S2N_ENSURE_PORTABLE_OPTIMIZATIONS
 
 /*************************************************
 * Name:        polyvec_compress

--- a/pq-crypto/kyber_r3/kyber512r3_reduce.c
+++ b/pq-crypto/kyber_r3/kyber512r3_reduce.c
@@ -2,9 +2,7 @@
 #include "kyber512r3_params.h"
 #include "kyber512r3_reduce.h"
 
-#if S2N_ANY_NONPORTABLE_OPTIMIZATIONS_ENABLED
-#error "Compiling portable code with non-portable assembly optimizations is not allowed"
-#endif
+S2N_ENSURE_PORTABLE_OPTIMIZATIONS
 
 /*************************************************
 * Name:        montgomery_reduce

--- a/pq-crypto/s2n_pq_asm.h
+++ b/pq-crypto/s2n_pq_asm.h
@@ -15,4 +15,15 @@
 
 #pragma once
 
+#ifndef S2N_BLOCK_NONPORTABLE_OPTIMIZATIONS
+#define S2N_BLOCK_NONPORTABLE_OPTIMIZATIONS 0
+#endif
+
 #define S2N_ANY_NONPORTABLE_OPTIMIZATIONS_ENABLED   __AVX__ || __AVX2__ || __BMI2__
+
+#if S2N_BLOCK_NONPORTABLE_OPTIMIZATIONS && S2N_ANY_NONPORTABLE_OPTIMIZATIONS_ENABLED
+#define S2N_ENSURE_PORTABLE_OPTIMIZATIONS \
+    #error "Compiling portable code with non-portable assembly optimizations. This can result in runtime crashes if artifacts are deployed to older CPU's without these CPU instructions"
+#else
+#define S2N_ENSURE_PORTABLE_OPTIMIZATIONS
+#endif


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 
Only enable non-portable optimizations safety checks during GitHub CI builds

### Call-outs:


### Testing:
Unit tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
