### PR TITLE
Basic renegotiation integ tests

### DIFF
--- a/bin/common.h
+++ b/bin/common.h
@@ -82,6 +82,7 @@ void send_data(struct s2n_connection *conn, int sockfd, const char *data, uint64
 int echo(struct s2n_connection *conn, int sockfd, bool *stop_echo);
 int wait_for_event(int fd, s2n_blocked_status blocked);
 int negotiate(struct s2n_connection *conn, int sockfd);
+int renegotiate(struct s2n_connection *conn, int sockfd);
 int early_data_recv(struct s2n_connection *conn);
 int early_data_send(struct s2n_connection *conn, uint8_t *data, uint32_t len);
 int print_connection_info(struct s2n_connection *conn);

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -232,7 +232,7 @@ int print_connection_info(struct s2n_connection *conn)
 int negotiate(struct s2n_connection *conn, int fd)
 {
     s2n_blocked_status blocked;
-    while (s2n_negotiate(conn, &blocked) != S2N_SUCCESS) {
+    while(s2n_negotiate(conn, &blocked) != S2N_SUCCESS) {
         if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
             fprintf(stderr, "Failed to negotiate: '%s'. %s\n",
                     s2n_strerror(s2n_errno, "EN"),
@@ -264,7 +264,7 @@ int renegotiate(struct s2n_connection *conn, int fd)
     fprintf(stdout, "RENEGOTIATE\n");
     fflush(stdout);
 
-    while (s2n_renegotiate(conn, buffer, sizeof(buffer), &data_read, &blocked) != S2N_SUCCESS) {
+    while(s2n_renegotiate(conn, buffer, sizeof(buffer), &data_read, &blocked) != S2N_SUCCESS) {
         uint8_t *data_ptr = buffer;
         while(data_read > 0) {
             ssize_t data_written = write(STDOUT_FILENO, data_ptr, data_read);

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -36,7 +36,7 @@
 #define OPT_TICKET_IN 1000
 #define OPT_TICKET_OUT 1001
 #define OPT_SEND_FILE 1002
-#define OPT_TICKET_RENEG 1003
+#define OPT_RENEG 1003
 
 void usage()
 {
@@ -135,13 +135,15 @@ struct reneg_req_ctx {
 
 static int reneg_req_cb(struct s2n_connection *conn, void *context, s2n_renegotiate_response *response)
 {
+    if (!conn || !context || !response) {
+        return S2N_FAILURE;
+    }
     struct reneg_req_ctx *reneg_ctx = (struct reneg_req_ctx *) context;
 
     *response = reneg_ctx->response;
     if (*response == S2N_RENEGOTIATE_ACCEPT) {
         reneg_ctx->do_renegotiate = true;
     }
-
     return S2N_SUCCESS;
 }
 
@@ -320,7 +322,7 @@ int main(int argc, char *const *argv)
         {"key-log", required_argument, 0, 'L'},
         {"psk", required_argument, 0, 'P'},
         {"early-data", required_argument, 0, 'E'},
-        {"renegotiation", required_argument, 0, OPT_TICKET_RENEG},
+        {"renegotiation", required_argument, 0, OPT_RENEG},
         { 0 },
     };
 
@@ -420,7 +422,7 @@ int main(int argc, char *const *argv)
             early_data = load_file_to_cstring(optarg);
             GUARD_EXIT_NULL(early_data);
             break;
-        case OPT_TICKET_RENEG:
+        case OPT_RENEG:
             setup_reneg_cb = true;
             if (strcmp(optarg, "accept") == 0) {
                 reneg_ctx.response = S2N_RENEGOTIATE_ACCEPT;

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -135,9 +135,9 @@ struct reneg_req_ctx {
 
 static int reneg_req_cb(struct s2n_connection *conn, void *context, s2n_renegotiate_response *response)
 {
-    if (!conn || !context || !response) {
-        return S2N_FAILURE;
-    }
+    GUARD_EXIT_NULL(conn);
+    GUARD_EXIT_NULL(context);
+    GUARD_EXIT_NULL(response);
     struct reneg_req_ctx *reneg_ctx = (struct reneg_req_ctx *) context;
 
     *response = reneg_ctx->response;

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -27,6 +27,7 @@
 #endif
 
 #include "api/s2n.h"
+#include "api/unstable/renegotiate.h"
 #include "common.h"
 #include "error/s2n_errno.h"
 
@@ -35,6 +36,7 @@
 #define OPT_TICKET_IN 1000
 #define OPT_TICKET_OUT 1001
 #define OPT_SEND_FILE 1002
+#define OPT_TICKET_RENEG 1003
 
 void usage()
 {
@@ -97,12 +99,13 @@ void usage()
                     "    Note that the maximum number of permitted psks is 10, the psk-secret is hex-encoded, and whitespace is not allowed before or after the commas.\n"
                     "    Ex: --psk psk_id,psk_secret,SHA256 --psk shared_id,shared_secret,SHA384.\n");
     fprintf(stderr, "  -E ,--early-data <file path>\n");
-    fprintf(stderr, "    Sends data in file path as early data to the server. Early data will only be sent if s2nc receives a session ticket and resumes a session.");
+    fprintf(stderr, "    Sends data in file path as early data to the server. Early data will only be sent if s2nc receives a session ticket and resumes a session.\n");
+    fprintf(stderr, "  --renegotiation [accept|reject]\n"
+                    "    accept: Accept all server requests for a new handshake\n"
+                    "    reject: Reject all server requests for a new handshake\n");
     fprintf(stderr, "\n");
     exit(1);
 }
-
-
 
 size_t session_state_length = 0;
 uint8_t *session_state = NULL;
@@ -121,6 +124,23 @@ static int test_session_ticket_cb(struct s2n_connection *conn, void *ctx, struct
 
     bool *session_ticket_recv = (bool *)ctx;
     *session_ticket_recv = 1;
+
+    return S2N_SUCCESS;
+}
+
+struct reneg_req_ctx {
+    bool do_renegotiate;
+    s2n_renegotiate_response response;
+};
+
+static int reneg_req_cb(struct s2n_connection *conn, void *context, s2n_renegotiate_response *response)
+{
+    struct reneg_req_ctx *reneg_ctx = (struct reneg_req_ctx *) context;
+
+    *response = reneg_ctx->response;
+    if (*response == S2N_RENEGOTIATE_ACCEPT) {
+        reneg_ctx->do_renegotiate = true;
+    }
 
     return S2N_SUCCESS;
 }
@@ -261,7 +281,7 @@ int main(int argc, char *const *argv)
     const char *host = NULL;
     struct verify_data unsafe_verify_data;
     const char *port = "443";
-    int echo_input = 0;
+    bool echo_input = false;
     const char *send_file = NULL;
     int use_corked_io = 0;
     uint8_t non_blocking = 0;
@@ -270,6 +290,8 @@ int main(int argc, char *const *argv)
     char *psk_optarg_list[S2N_MAX_PSK_LIST_LENGTH];
     size_t psk_list_len = 0;
     char *early_data = NULL;
+    bool setup_reneg_cb = false;
+    struct reneg_req_ctx reneg_ctx = { 0 };
 
     static struct option long_options[] = {
         {"alpn", required_argument, 0, 'a'},
@@ -298,6 +320,7 @@ int main(int argc, char *const *argv)
         {"key-log", required_argument, 0, 'L'},
         {"psk", required_argument, 0, 'P'},
         {"early-data", required_argument, 0, 'E'},
+        {"renegotiation", required_argument, 0, OPT_TICKET_RENEG},
         { 0 },
     };
 
@@ -321,7 +344,7 @@ int main(int argc, char *const *argv)
             fips_mode = 1;
             break;
         case 'e':
-            echo_input = 1;
+            echo_input = true;
             break;
         case OPT_SEND_FILE:
             send_file = load_file_to_cstring(optarg);
@@ -396,6 +419,17 @@ int main(int argc, char *const *argv)
         case 'E':
             early_data = load_file_to_cstring(optarg);
             GUARD_EXIT_NULL(early_data);
+            break;
+        case OPT_TICKET_RENEG:
+            setup_reneg_cb = true;
+            if (strcmp(optarg, "accept") == 0) {
+                reneg_ctx.response = S2N_RENEGOTIATE_ACCEPT;
+            } else if (strcmp(optarg, "reject") == 0) {
+                reneg_ctx.response = S2N_RENEGOTIATE_REJECT;
+            } else {
+                fprintf(stderr, "Unrecognized option: %s\n", optarg);
+                exit(1);
+            }
             break;
         case '?':
         default:
@@ -527,6 +561,11 @@ int main(int argc, char *const *argv)
             );
         }
 
+        if (setup_reneg_cb) {
+            GUARD_EXIT(s2n_config_set_renegotiate_request_cb(config, reneg_req_cb, &reneg_ctx),
+                    "Error setting renegotiation request callback");
+        }
+
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
 
         if (conn == NULL) {
@@ -623,11 +662,17 @@ int main(int argc, char *const *argv)
             send_data(conn, sockfd, send_file, send_file_len, &blocked);
         }
 
-        if (echo_input == 1) {
-            bool stop_echo = false;
+        while (echo_input) {
             fflush(stdout);
             fflush(stderr);
-            echo(conn, sockfd, &stop_echo);
+            echo(conn, sockfd, &reneg_ctx.do_renegotiate);
+
+            if (!reneg_ctx.do_renegotiate) {
+                break;
+            }
+
+            reneg_ctx.do_renegotiate = false;
+            GUARD_EXIT(renegotiate(conn, sockfd), "Renegotiation failed");
         }
 
         /* The following call can block on receiving a close_notify if we initiate the shutdown or if the */

--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -56,6 +56,16 @@ ALL_TEST_CERTS = [
 ]
 
 
+# List of certificates which enable all cipher suites
+MINIMAL_TEST_CERTS = [
+    Certificates.RSA_2048_SHA512,
+    Certificates.RSA_4096_SHA256,
+    Certificates.ECDSA_256,
+    Certificates.ECDSA_384,
+    Certificates.RSA_PSS_2048_SHA256
+]
+
+
 # List of all ciphers that will be tested.
 ALL_TEST_CIPHERS = [
     Ciphers.DHE_RSA_AES128_SHA,

--- a/tests/integrationv2/processes.py
+++ b/tests/integrationv2/processes.py
@@ -192,6 +192,7 @@ class _processCommunicator(object):
                                 # Data destined for stdin is stored in a memoryview
                                 input_view = memoryview(message)
                                 input_data_len = len(message)
+                                input_data_sent = False
                             else:
                                 input_data_sent = True
 
@@ -207,7 +208,7 @@ class _processCommunicator(object):
 
                 # If we have finished sending all our input, and have received the
                 # ready-to-send marker, we can close out stdin.
-                if self.proc.stdin and input_data_sent:
+                if self.proc.stdin and input_data_sent and not input_data:
                     if close_marker is None or (close_marker and close_marker in str(data)):
                         input_data_sent = None
                         self.proc.stdin.close()

--- a/tests/integrationv2/utils.py
+++ b/tests/integrationv2/utils.py
@@ -63,6 +63,8 @@ def invalid_test_parameters(*args, **kwargs):
     signature = kwargs.get('signature')
 
     providers = [provider_ for provider_ in [provider, other_provider] if provider_]
+    # Always consider S2N
+    providers.append(S2N)
 
     # Only TLS1.3 supports RSA-PSS-PSS certificates
     # (Earlier versions support RSA-PSS signatures, just via RSA-PSS-RSAE)


### PR DESCRIPTION
### Description of changes: 

Enable renegotiation with s2nc and add very basic renegotiation integration tests.

### Call-outs:

This was apparently our first integration test to send a significant amount of application data after the handshake, and I ran into some issues with the framework.

### Testing:

I will post links to a manually run Codebuild job in comments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
