### PR TITLE
Bump Doxygen version 1.9.3 -> 1.9.5

### DIFF
--- a/.github/s2n_doxygen.sh
+++ b/.github/s2n_doxygen.sh
@@ -14,7 +14,7 @@
 #
 set -eu
 
-export DOXYGEN_VERSION="doxygen-1.9.3"
+export DOXYGEN_VERSION="doxygen-1.9.5"
 curl -L "https://www.doxygen.nl/files/$DOXYGEN_VERSION.linux.bin.tar.gz" -o "$DOXYGEN_VERSION.tar.gz"
 tar -xvf "$DOXYGEN_VERSION.tar.gz"
 


### PR DESCRIPTION
### Resolved issues:
Doxygen nl recently updated the current version on their site from 1.9.3 to 1.9.5. They no longer hosts the 1.9.3 binary but only the 1.9.5 one. This caused the doxygen CI to fail.

### Description of changes: 

Bump from 1.9.3 to 1.9.5.

### Testing:

Does it pass CI?