### PR TITLE
NPN integration tests

### DIFF
--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -107,7 +107,7 @@ void usage()
                     "    reject: Reject all server requests for a new handshake\n"
                     "    wait: Wait for additional application data before accepting server requests. Intended for the integ tests.\n");
     fprintf(stderr, "  --npn \n");
-    fprintf(stderr, "    Indicates support for the NPN extension. The alpn option MUST be used with this option to signal the protocols supported."); 
+    fprintf(stderr, "    Indicates support for the NPN extension. The '--alpn' option MUST be used with this option to signal the protocols supported."); 
     fprintf(stderr, "\n");
     exit(1);
 }

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -132,6 +132,9 @@ void usage()
     fprintf(stderr, " host: hostname or IP address to listen on\n");
     fprintf(stderr, " port: port to listen on\n");
     fprintf(stderr, "\n Options:\n\n");
+    fprintf(stderr, "  -a [protocol]\n");
+    fprintf(stderr, "  --alpn [protocol]\n");
+    fprintf(stderr, "    Sets a single application protocol supported by this server.\n");
     fprintf(stderr, "  -c [version_string]\n");
     fprintf(stderr, "  --ciphers [version_string]\n");
     fprintf(stderr, "    Set the cipher preference version string. Defaults to \"default\". See USAGE-GUIDE.md\n");
@@ -191,7 +194,7 @@ void usage()
     fprintf(stderr, "  -E, --max-early-data \n");
     fprintf(stderr, "    Sets maximum early data allowed in session tickets. \n");
     fprintf(stderr, "  -N --npn \n");
-    fprintf(stderr, "    Indicates support for the NPN extension. The alpn option MUST be used with this option to signal the protocols supported."); 
+    fprintf(stderr, "    Indicates support for the NPN extension. The '--alpn' option MUST be used with this option to signal the protocols supported."); 
     fprintf(stderr, "  -h,--help\n");
     fprintf(stderr, "    Display this message and quit.\n");
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -29,6 +29,7 @@
 #endif
 
 #include "api/s2n.h"
+#include "api/unstable/npn.h"
 #include "common.h"
 
 #include "utils/s2n_safety.h"
@@ -189,6 +190,8 @@ void usage()
                     "    Ex: --psk psk_id,psk_secret,SHA256 --psk shared_id,shared_secret,SHA384.\n");
     fprintf(stderr, "  -E, --max-early-data \n");
     fprintf(stderr, "    Sets maximum early data allowed in session tickets. \n");
+    fprintf(stderr, "  -N --npn \n");
+    fprintf(stderr, "    Indicates support for the NPN extension. The alpn option MUST be used with this option to signal the protocols supported."); 
     fprintf(stderr, "  -h,--help\n");
     fprintf(stderr, "    Display this message and quit.\n");
 
@@ -273,6 +276,7 @@ int main(int argc, char *const *argv)
     conn_settings.max_conns = -1;
     conn_settings.psk_list_len = 0;
     int max_early_data = 0;
+    bool npn = false;
 
     struct option long_options[] = {
         {"ciphers", required_argument, NULL, 'c'},
@@ -299,6 +303,7 @@ int main(int argc, char *const *argv)
         {"https-server", no_argument, 0, 'w'},
         {"https-bench", required_argument, 0, 'b'},
         {"alpn", required_argument, 0, 'A'},
+        {"npn", no_argument, 0, 'N'},
         {"non-blocking", no_argument, 0, 'B'},
         {"key-log", required_argument, 0, 'L'},
         {"psk", required_argument, 0, 'P'},
@@ -418,6 +423,9 @@ int main(int argc, char *const *argv)
             break;
         case 'E':
             max_early_data = atoi(optarg);
+            break;
+        case 'N':
+            npn = true;
             break;
         case '?':
         default:
@@ -577,6 +585,10 @@ int main(int argc, char *const *argv)
     if (alpn) {
         const char *protocols[] = { alpn };
         GUARD_EXIT(s2n_config_set_protocol_preferences(config, protocols, s2n_array_len(protocols)), "Failed to set alpn");
+    }
+
+    if (npn) {
+        GUARD_EXIT(s2n_config_set_npn(config, 1), "Error setting npn support");
     }
 
     FILE *key_log_file = NULL;

--- a/tests/integrationv2/test_npn.py
+++ b/tests/integrationv2/test_npn.py
@@ -1,0 +1,251 @@
+import pytest
+import copy
+
+from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, MINIMAL_TEST_CERTS, PROTOCOLS
+from common import ProviderOptions, Protocols
+from fixtures import managed_process
+from providers import OpenSSL, S2N, Provider
+from utils import invalid_test_parameters, get_parameter_name, to_bytes
+
+
+# NPN not supported in TLS1.3
+TLS_PROTOCOLS = [x for x in PROTOCOLS if x.value < Protocols.TLS13.value]
+
+# Output indicating NPN status
+S2N_NPN_MARKER = "WITH_NPN"
+S2N_APPLICATION_MARKER = "Application protocol: "
+OPENSSL_SERVER_NPN_MARKER = "NEXTPROTO is "
+# The OpenSSL client uses "(1)" to indicate that a protocol was selected from
+# the server's advertised list. "(2)" indicates the client couldn't find any overlap
+# with the server's list and had to select from its own list.
+OPENSSL_CLIENT_NPN_MARKER = "Next protocol: (1) "
+OPENSSL_CLIENT_NPN_NO_OVERLAP_MARKER = "Next protocol: (2) "
+
+# Test lists
+PROTOCOL_LIST = 'http/1.1,h2,h3'
+PROTOCOL_LIST_ALT_ORDER = 'h2,h3,http/1.1'
+PROTOCOL_LIST_NO_OVERLAP = 'spdy'
+
+
+"""
+The s2n-tls client successfully negotiates an application protocol using NPN.
+"""
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
+@pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
+def test_s2n_client_npn(managed_process, cipher, curve, certificate, protocol, provider):
+    options = ProviderOptions(
+        port=next(available_ports),
+        cipher=cipher,
+        curve=curve,
+        key=certificate.key,
+        cert=certificate.cert,
+        protocol=protocol,
+        insecure=True,
+    )
+
+    client_options = copy.copy(options)
+    client_options.mode = Provider.ClientMode
+    # Flags to turn on NPN for s2nc
+    client_options.extra_flags = ['--alpn', PROTOCOL_LIST, '--npn']
+
+    server_options = copy.copy(options)
+    server_options.mode = Provider.ServerMode
+    # Flags to turn on NPN for OpenSSL server
+    server_options.extra_flags = ['-nextprotoneg', PROTOCOL_LIST]
+
+    server = managed_process(provider, server_options, timeout=5)
+    client = managed_process(S2N, client_options, timeout=5)
+
+    expected_protocol = 'http/1.1'
+
+    for results in server.get_results():
+        results.assert_success()
+        assert to_bytes(OPENSSL_SERVER_NPN_MARKER + expected_protocol) in results.stdout
+
+    for results in client.get_results():
+        results.assert_success()
+        assert to_bytes(S2N_NPN_MARKER) in results.stdout
+        assert to_bytes(S2N_APPLICATION_MARKER + expected_protocol) in results.stdout
+
+"""
+The s2n-tls client chooses a server-preferred protocol.
+"""
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
+@pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
+def test_s2n_client_npn_server_preference(managed_process, cipher, curve, certificate, protocol, provider):
+    options = ProviderOptions(
+        port=next(available_ports),
+        cipher=cipher,
+        curve=curve,
+        key=certificate.key,
+        cert=certificate.cert,
+        protocol=protocol,
+        insecure=True,
+    )
+
+    client_options = copy.copy(options)
+    client_options.mode = Provider.ClientMode
+    # Flags to turn on NPN for s2nc
+    client_options.extra_flags = ['--alpn', PROTOCOL_LIST, '--npn']
+
+    server_options = copy.copy(options)
+    server_options.mode = Provider.ServerMode
+    # Flags to turn on NPN for OpenSSL server
+    server_options.extra_flags = ['-nextprotoneg', PROTOCOL_LIST_ALT_ORDER]
+
+    server = managed_process(provider, server_options, timeout=5)
+    client = managed_process(S2N, client_options, timeout=5)
+
+    expected_protocol = 'h2'
+
+    for results in server.get_results():
+        results.assert_success()
+        assert to_bytes(OPENSSL_SERVER_NPN_MARKER + expected_protocol) in results.stdout
+
+    for results in client.get_results():
+        results.assert_success()
+        assert to_bytes(S2N_NPN_MARKER) in results.stdout
+        assert to_bytes(S2N_APPLICATION_MARKER + expected_protocol) in results.stdout
+
+"""
+The s2n-tls client chooses its preferred protocol since there is no overlap.
+"""
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
+@pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
+def test_s2n_client_npn_no_overlap(managed_process, cipher, curve, certificate, protocol, provider):
+    options = ProviderOptions(
+        port=next(available_ports),
+        cipher=cipher,
+        curve=curve,
+        key=certificate.key,
+        cert=certificate.cert,
+        protocol=protocol,
+        insecure=True,
+    )
+
+    client_options = copy.copy(options)
+    client_options.mode = Provider.ClientMode
+    # Flags to turn on NPN for s2nc
+    client_options.extra_flags = ['--alpn', PROTOCOL_LIST, '--npn']
+
+    server_options = copy.copy(options)
+    server_options.mode = Provider.ServerMode
+    # Flags to turn on NPN for OpenSSL server
+    server_options.extra_flags = ['-nextprotoneg', PROTOCOL_LIST_NO_OVERLAP]
+
+    server = managed_process(provider, server_options, timeout=5)
+    client = managed_process(S2N, client_options, timeout=5)
+
+    expected_protocol = 'http/1.1'
+
+    for results in server.get_results():
+        results.assert_success()
+        assert to_bytes(OPENSSL_SERVER_NPN_MARKER + expected_protocol) in results.stdout
+
+    for results in client.get_results():
+        results.assert_success()
+        assert to_bytes(S2N_NPN_MARKER) in results.stdout
+        assert to_bytes(S2N_APPLICATION_MARKER + expected_protocol) in results.stdout
+
+"""
+The s2n-tls server successfully negotiates an application protocol using NPN.
+"""
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
+@pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
+def test_s2n_server_npn(managed_process, cipher, curve, certificate, protocol, provider):
+    options = ProviderOptions(
+        port=next(available_ports),
+        cipher=cipher,
+        curve=curve,
+        key=certificate.key,
+        cert=certificate.cert,
+        protocol=protocol,
+        insecure=True,
+    )
+
+    client_options = copy.copy(options)
+    client_options.mode = Provider.ClientMode
+    # Flags to turn on NPN for OpenSSL client
+    client_options.extra_flags = ['-nextprotoneg', PROTOCOL_LIST]
+
+    server_options = copy.copy(options)
+    server_options.mode = Provider.ServerMode
+    # Flags to turn on NPN for s2nd. We only send one protocol on the s2n server
+    # due to the fact that it re-purposes the alpn list(which only sends one protocol)
+    # to work for the NPN list.
+    server_options.extra_flags = ['--alpn', 'http/1.1', '--npn']
+
+    server = managed_process(S2N, server_options, timeout=5)
+    client = managed_process(provider, client_options, timeout=5)
+
+    expected_protocol = 'http/1.1'
+
+    for results in server.get_results():
+        results.assert_success()
+        assert to_bytes(S2N_NPN_MARKER) in results.stdout
+        assert to_bytes(S2N_APPLICATION_MARKER + expected_protocol) in results.stdout
+
+    for results in client.get_results():
+        results.assert_success()
+        assert to_bytes(OPENSSL_CLIENT_NPN_MARKER + expected_protocol) in results.stdout
+
+"""
+The s2n-tls server can handle the case where there is no mutually supported protocol and 
+the client chooses its own protocol.
+"""
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
+@pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
+def test_s2n_server_npn_no_overlap(managed_process, cipher, curve, certificate, protocol, provider):
+    options = ProviderOptions(
+        port=next(available_ports),
+        cipher=cipher,
+        curve=curve,
+        key=certificate.key,
+        cert=certificate.cert,
+        protocol=protocol,
+        insecure=True,
+    )
+
+    client_options = copy.copy(options)
+    client_options.mode = Provider.ClientMode
+    # Flags to turn on NPN for OpenSSL client
+    client_options.extra_flags = ['-nextprotoneg', PROTOCOL_LIST_NO_OVERLAP]
+
+    server_options = copy.copy(options)
+    server_options.mode = Provider.ServerMode
+    # Flags to turn on NPN for s2nd
+    server_options.extra_flags = ['--alpn', PROTOCOL_LIST, '--npn']
+
+    server = managed_process(S2N, server_options, timeout=5)
+    client = managed_process(provider, client_options, timeout=5)
+
+    expected_protocol = 'spdy'
+
+    for results in server.get_results():
+        results.assert_success()
+        assert to_bytes(S2N_NPN_MARKER) in results.stdout
+        assert to_bytes(S2N_APPLICATION_MARKER + expected_protocol) in results.stdout
+
+    for results in client.get_results():
+        results.assert_success()
+        assert to_bytes(OPENSSL_CLIENT_NPN_NO_OVERLAP_MARKER + expected_protocol) in results.stdout

--- a/tests/integrationv2/test_npn.py
+++ b/tests/integrationv2/test_npn.py
@@ -1,5 +1,5 @@
-import pytest
 import copy
+import pytest
 
 from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, MINIMAL_TEST_CERTS, PROTOCOLS
 from common import ProviderOptions, Protocols

--- a/tests/integrationv2/test_npn.py
+++ b/tests/integrationv2/test_npn.py
@@ -63,7 +63,7 @@ The s2n-tls client successfully negotiates an application protocol using NPN.
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_npn(managed_process, cipher, curve, certificate, protocol, provider):
     s2n_client, server = s2n_client_npn_handshake(managed_process, cipher, curve, certificate, protocol, provider, \
-        PROTOCOL_LIST)
+        server_list=PROTOCOL_LIST)
 
     expected_protocol = 'http/1.1'
 
@@ -87,7 +87,7 @@ The s2n-tls client chooses a server-preferred protocol.
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_npn_server_preference(managed_process, cipher, curve, certificate, protocol, provider):
     s2n_client, server = s2n_client_npn_handshake(managed_process, cipher, curve, certificate, protocol, provider, \
-        PROTOCOL_LIST_ALT_ORDER)
+        server_list=PROTOCOL_LIST_ALT_ORDER)
 
     expected_protocol = 'h2'
 
@@ -111,7 +111,7 @@ The s2n-tls client chooses its preferred protocol since there is no overlap.
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_npn_no_overlap(managed_process, cipher, curve, certificate, protocol, provider):
     s2n_client, server = s2n_client_npn_handshake(managed_process, cipher, curve, certificate, protocol, provider, \
-        PROTOCOL_LIST_NO_OVERLAP)
+        server_list=PROTOCOL_LIST_NO_OVERLAP)
 
     expected_protocol = 'http/1.1'
 
@@ -124,16 +124,8 @@ def test_s2n_client_npn_no_overlap(managed_process, cipher, curve, certificate, 
         assert to_bytes(S2N_NPN_MARKER) in results.stdout
         assert to_bytes(S2N_APPLICATION_MARKER + expected_protocol) in results.stdout
 
-"""
-The s2n-tls server successfully negotiates an application protocol using NPN.
-"""
-@pytest.mark.uncollect_if(func=invalid_test_parameters)
-@pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
-@pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
-@pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
-@pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
-@pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
-def test_s2n_server_npn(managed_process, cipher, curve, certificate, protocol, provider):
+
+def s2n_server_npn_handshake(managed_process, cipher, curve, certificate, protocol, provider, server_list):
     options = ProviderOptions(
         port=next(available_ports),
         cipher=cipher,
@@ -151,17 +143,33 @@ def test_s2n_server_npn(managed_process, cipher, curve, certificate, protocol, p
 
     server_options = copy.copy(options)
     server_options.mode = Provider.ServerMode
-    # Flags to turn on NPN for s2nd. We only send one protocol on the s2n server
+    # Flags to turn on NPN for s2nd.
+    server_options.extra_flags = ['--alpn', server_list, '--npn']
+
+    s2n_server = managed_process(S2N, server_options, timeout=5)
+    client = managed_process(provider, client_options, timeout=5)
+
+    return (client, s2n_server)
+
+"""
+The s2n-tls server successfully negotiates an application protocol using NPN.
+"""
+@pytest.mark.uncollect_if(func=invalid_test_parameters)
+@pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
+@pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
+@pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
+@pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
+@pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
+def test_s2n_server_npn(managed_process, cipher, curve, certificate, protocol, provider):
+    # We only send one protocol on the s2n server
     # due to the fact that it re-purposes the alpn list(which only sends one protocol)
     # to work for the NPN list.
-    server_options.extra_flags = ['--alpn', 'http/1.1', '--npn']
-
-    server = managed_process(S2N, server_options, timeout=5)
-    client = managed_process(provider, client_options, timeout=5)
+    client, s2n_server = s2n_server_npn_handshake(managed_process, cipher, curve, certificate, protocol, provider, \
+        server_list='http/1.1')
 
     expected_protocol = 'http/1.1'
 
-    for results in server.get_results():
+    for results in s2n_server.get_results():
         results.assert_success()
         assert to_bytes(S2N_NPN_MARKER) in results.stdout
         assert to_bytes(S2N_APPLICATION_MARKER + expected_protocol) in results.stdout
@@ -181,32 +189,12 @@ the client chooses its own protocol.
 @pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_server_npn_no_overlap(managed_process, cipher, curve, certificate, protocol, provider):
-    options = ProviderOptions(
-        port=next(available_ports),
-        cipher=cipher,
-        curve=curve,
-        key=certificate.key,
-        cert=certificate.cert,
-        protocol=protocol,
-        insecure=True,
-    )
+    client, s2n_server = s2n_server_npn_handshake(managed_process, cipher, curve, certificate, protocol, provider, \
+        server_list=PROTOCOL_LIST_NO_OVERLAP)
 
-    client_options = copy.copy(options)
-    client_options.mode = Provider.ClientMode
-    # Flags to turn on NPN for OpenSSL client
-    client_options.extra_flags = ['-nextprotoneg', PROTOCOL_LIST_NO_OVERLAP]
+    expected_protocol = 'http/1.1'
 
-    server_options = copy.copy(options)
-    server_options.mode = Provider.ServerMode
-    # Flags to turn on NPN for s2nd
-    server_options.extra_flags = ['--alpn', PROTOCOL_LIST, '--npn']
-
-    server = managed_process(S2N, server_options, timeout=5)
-    client = managed_process(provider, client_options, timeout=5)
-
-    expected_protocol = 'spdy'
-
-    for results in server.get_results():
+    for results in s2n_server.get_results():
         results.assert_success()
         assert to_bytes(S2N_NPN_MARKER) in results.stdout
         assert to_bytes(S2N_APPLICATION_MARKER + expected_protocol) in results.stdout


### PR DESCRIPTION
### Resolved issues:

parent: #3516 

### Description of changes: 

Adds integration tests for the NPN feature. Also adds changes to s2nc and s2nd to be able to negotiate NPN.
### Call-outs:

In s2nc/d the npn flag doesn't take a list of protocols. It relies on the alpn flag to set up the list of protocols. This mimics how the feature actually works in the s2n code. I can change this if we really don't like it.
### Testing:
Codebuild passes: 
https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/S2nIntegrationV2SmallBatch/batch/S2nIntegrationV2SmallBatch%3A653b011c-5090-46a0-a227-7d686589c590?region=us-west-2

How do we feel about the test cases I created? I could add some that include resumption and renegotiate, I just think it's kind of overkill. I could also add a couple of cases about the interaction between alpn and npn, if we don't think we've covered that enough in unit/self-talk tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
