### PR TITLE
Enable CRL validation for only leaf certificates

### DIFF
--- a/tests/unit/s2n_crl_test.c
+++ b/tests/unit/s2n_crl_test.c
@@ -38,13 +38,23 @@ struct crl_lookup_data {
     struct s2n_crl *crls[5];
     X509 *certs[5];
     uint8_t callback_invoked_count;
+    crl_validate_option validate_options[5];
 };
 
 static int crl_lookup_test_callback(struct s2n_crl_lookup *lookup, void *context)
 {
+    uint16_t cert_idx = 0;
+    POSIX_GUARD(s2n_crl_lookup_get_cert_index(lookup, &cert_idx));
+
     struct crl_lookup_data *crl_data = (struct crl_lookup_data*) context;
     crl_data->callback_invoked_count += 1;
-    crl_data->certs[lookup->cert_idx] = lookup->cert;
+    crl_data->certs[cert_idx] = lookup->cert;
+    crl_validate_option validate_option = crl_data->validate_options[cert_idx];
+
+    if (validate_option == CRL_DO_NOT_VALIDATE) {
+        POSIX_GUARD(s2n_crl_lookup_do_not_validate(lookup));
+        return 0;
+    }
 
     struct s2n_crl *crl = crl_data->crls[lookup->cert_idx];
     if (crl == NULL) {
@@ -213,6 +223,44 @@ int main(int argc, char *argv[])
         }
     }
 
+    /* CRL validation succeeds for a single certificate in the chain */
+    {
+        DEFER_CLEANUP(struct s2n_x509_trust_store trust_store = { 0 }, s2n_x509_trust_store_wipe);
+        s2n_x509_trust_store_init_empty(&trust_store);
+
+        char root_cert[S2N_MAX_TEST_PEM_SIZE];
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_CRL_ROOT_CERT, root_cert, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_x509_trust_store_add_pem(&trust_store, root_cert));
+
+        DEFER_CLEANUP(struct s2n_x509_validator validator, s2n_x509_validator_wipe);
+        EXPECT_SUCCESS(s2n_x509_validator_init(&validator, &trust_store, 0));
+
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
+        struct crl_lookup_data data = { 0 };
+        config->crl_lookup_cb = crl_lookup_test_callback;
+        config->crl_lookup_ctx = (void*) &data;
+
+        DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(connection);
+        EXPECT_SUCCESS(s2n_connection_set_config(connection, config));
+        EXPECT_SUCCESS(s2n_set_server_name(connection, "root"));
+
+        DEFER_CLEANUP(struct s2n_stuffer cert_chain_stuffer = { 0 }, s2n_stuffer_free);
+        EXPECT_OK(s2n_test_cert_chain_data_from_pem(connection, S2N_CRL_ROOT_CERT, &cert_chain_stuffer));
+        uint32_t chain_len = s2n_stuffer_data_available(&cert_chain_stuffer);
+        uint8_t *chain_data = s2n_stuffer_raw_read(&cert_chain_stuffer, chain_len);
+        EXPECT_NOT_NULL(chain_data);
+
+        DEFER_CLEANUP(struct s2n_pkey public_key_out = { 0 }, s2n_pkey_free);
+        EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key_out));
+        s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
+        EXPECT_OK(s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &pkey_type,
+                &public_key_out));
+        EXPECT_TRUE(data.callback_invoked_count == 1);
+    }
+
     /* CRL validation errors when a leaf certificate is revoked */
     {
         DEFER_CLEANUP(struct s2n_x509_trust_store trust_store = { 0 }, s2n_x509_trust_store_wipe);
@@ -336,6 +384,95 @@ int main(int argc, char *argv[])
         s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
         EXPECT_ERROR_WITH_ERRNO(s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data,
                 chain_len, &pkey_type, &public_key_out), S2N_ERR_CRL_LOOKUP_FAILED);
+        EXPECT_TRUE(data.callback_invoked_count == CRL_TEST_CHAIN_LEN);
+    }
+
+
+    /* CRL validation succeeds when a revoked leaf certificate is marked as DO_NOT_VALIDATE */
+    {
+        DEFER_CLEANUP(struct s2n_x509_trust_store trust_store = { 0 }, s2n_x509_trust_store_wipe);
+        s2n_x509_trust_store_init_empty(&trust_store);
+
+        char root_cert[S2N_MAX_TEST_PEM_SIZE];
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_CRL_ROOT_CERT, root_cert, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_x509_trust_store_add_pem(&trust_store, root_cert));
+
+        DEFER_CLEANUP(struct s2n_x509_validator validator, s2n_x509_validator_wipe);
+        EXPECT_SUCCESS(s2n_x509_validator_init(&validator, &trust_store, 0));
+
+        struct crl_lookup_data data = { 0 };
+        data.crls[0] = intermediate_crl;
+        data.crls[1] = root_crl;
+
+        /* return s2n_crl_lookup_do_not_validate for the leaf certificate */
+        data.validate_options[0] = CRL_DO_NOT_VALIDATE;
+
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
+        config->crl_lookup_cb = crl_lookup_test_callback;
+        config->crl_lookup_ctx = (void*) &data;
+
+        DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(connection);
+        EXPECT_SUCCESS(s2n_connection_set_config(connection, config));
+        EXPECT_SUCCESS(s2n_set_server_name(connection, "localhost"));
+
+        DEFER_CLEANUP(struct s2n_stuffer cert_chain_stuffer = { 0 }, s2n_stuffer_free);
+        EXPECT_OK(s2n_test_cert_chain_data_from_pem(connection, S2N_CRL_LEAF_REVOKED_CERT_CHAIN, &cert_chain_stuffer));
+        uint32_t chain_len = s2n_stuffer_data_available(&cert_chain_stuffer);
+        uint8_t *chain_data = s2n_stuffer_raw_read(&cert_chain_stuffer, chain_len);
+        EXPECT_NOT_NULL(chain_data);
+
+        DEFER_CLEANUP(struct s2n_pkey public_key_out = { 0 }, s2n_pkey_free);
+        EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key_out));
+        s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
+        EXPECT_OK(s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &pkey_type,
+                &public_key_out));
+        EXPECT_TRUE(data.callback_invoked_count == CRL_TEST_CHAIN_LEN);
+    }
+
+    /* CRL validation succeeds when a revoked intermediate certificate is marked as DO_NOT_VALIDATE */
+    {
+        DEFER_CLEANUP(struct s2n_x509_trust_store trust_store = { 0 }, s2n_x509_trust_store_wipe);
+        s2n_x509_trust_store_init_empty(&trust_store);
+
+        char root_cert[S2N_MAX_TEST_PEM_SIZE];
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_CRL_ROOT_CERT, root_cert, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_x509_trust_store_add_pem(&trust_store, root_cert));
+
+        DEFER_CLEANUP(struct s2n_x509_validator validator, s2n_x509_validator_wipe);
+        EXPECT_SUCCESS(s2n_x509_validator_init(&validator, &trust_store, 0));
+
+        struct crl_lookup_data data = { 0 };
+        data.crls[0] = intermediate_revoked_crl;
+        data.crls[1] = root_crl;
+
+        /* return s2n_crl_lookup_do_not_validate for the intermediate certificate */
+        data.validate_options[1] = CRL_DO_NOT_VALIDATE;
+
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
+        config->crl_lookup_cb = crl_lookup_test_callback;
+        config->crl_lookup_ctx = (void*) &data;
+
+        DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(connection);
+        EXPECT_SUCCESS(s2n_connection_set_config(connection, config));
+        EXPECT_SUCCESS(s2n_set_server_name(connection, "localhost"));
+
+        DEFER_CLEANUP(struct s2n_stuffer cert_chain_stuffer = { 0 }, s2n_stuffer_free);
+        EXPECT_OK(s2n_test_cert_chain_data_from_pem(connection, S2N_CRL_INTERMEDIATE_REVOKED_CERT_CHAIN, &cert_chain_stuffer));
+        uint32_t chain_len = s2n_stuffer_data_available(&cert_chain_stuffer);
+        uint8_t *chain_data = s2n_stuffer_raw_read(&cert_chain_stuffer, chain_len);
+        EXPECT_NOT_NULL(chain_data);
+
+        DEFER_CLEANUP(struct s2n_pkey public_key_out = { 0 }, s2n_pkey_free);
+        EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key_out));
+        s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
+        EXPECT_OK(s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &pkey_type,
+                &public_key_out));
         EXPECT_TRUE(data.callback_invoked_count == CRL_TEST_CHAIN_LEN);
     }
 
@@ -673,19 +810,43 @@ int main(int argc, char *argv[])
         EXPECT_TRUE(data.callback_invoked_count == CRL_TEST_CHAIN_LEN);
     }
 
-    /* Calling s2n_crl_lookup return functions correctly set context fields */
+    /* Calling s2n_crl_lookup return functions correctly set lookup fields */
     {
         struct s2n_crl_lookup lookup = { 0 };
 
+        /* The crl_lookup async return functions require an internal X509 to be set. Set an arbitrary
+         * X509 created by s2n_x509_validator_validate_cert_chain in a previous test. */
+        EXPECT_TRUE(sk_X509_num(received_lookup_data_validator.cert_chain_from_wire) > 1);
+        X509 *cert = sk_X509_value(received_lookup_data_validator.cert_chain_from_wire, 0);
+        EXPECT_NOT_NULL(cert);
+        lookup.cert = cert;
+
         lookup.status = AWAITING_RESPONSE;
+        crl_validate_option *validate_option = NULL;
         EXPECT_SUCCESS(s2n_crl_lookup_set(&lookup, root_crl));
         EXPECT_TRUE(lookup.status == FINISHED);
         EXPECT_NOT_NULL(lookup.crl);
+        validate_option = (crl_validate_option *) X509_get_ex_data(cert, 0);
+        EXPECT_NOT_NULL(validate_option);
+        EXPECT_EQUAL(*validate_option, CRL_VALIDATE);
 
         lookup.status = AWAITING_RESPONSE;
+        validate_option = NULL;
         EXPECT_SUCCESS(s2n_crl_lookup_ignore(&lookup));
         EXPECT_TRUE(lookup.status == FINISHED);
         EXPECT_NULL(lookup.crl);
+        validate_option = (crl_validate_option *) X509_get_ex_data(cert, 0);
+        EXPECT_NOT_NULL(validate_option);
+        EXPECT_EQUAL(*validate_option, CRL_VALIDATE);
+
+        lookup.status = AWAITING_RESPONSE;
+        validate_option = NULL;
+        EXPECT_SUCCESS(s2n_crl_lookup_do_not_validate(&lookup));
+        EXPECT_TRUE(lookup.status == FINISHED);
+        EXPECT_NULL(lookup.crl);
+        validate_option = (crl_validate_option *) X509_get_ex_data(cert, 0);
+        EXPECT_NOT_NULL(validate_option);
+        EXPECT_EQUAL(*validate_option, CRL_DO_NOT_VALIDATE);
     }
 
     /* Certificate issuer hash is retrieved successfully */
@@ -735,6 +896,21 @@ int main(int argc, char *argv[])
 
         /* If the certificate and CRL were issued by different CAs, their hashes should not match */
         EXPECT_TRUE(leaf_cert_hash != root_crl_hash);
+    }
+
+    /* Certificate index is retrieved successfully */
+    {
+        struct s2n_crl_lookup lookup = { 0 };
+
+        for (int i = 0; i < 10; i++) {
+            int cert_idx = i * i;
+            lookup.cert_idx = cert_idx;
+
+            uint16_t retrieved_cert_index = 0;
+            EXPECT_SUCCESS(s2n_crl_lookup_get_cert_index(&lookup, &retrieved_cert_index));
+
+            EXPECT_TRUE(retrieved_cert_index == cert_idx);
+        }
     }
 
     END_TEST();

--- a/tls/s2n_crl.c
+++ b/tls/s2n_crl.c
@@ -198,6 +198,46 @@ S2N_RESULT s2n_crl_invoke_lookup_callbacks(struct s2n_connection *conn, struct s
     return S2N_RESULT_OK;
 }
 
+int s2n_crl_ossl_verify_callback(int default_ossl_ret, X509_STORE_CTX *ctx) {
+    /* If Openssl would have returned successfully, return success. */
+    if (default_ossl_ret > 0) {
+        return default_ossl_ret;
+    }
+
+    int err = X509_STORE_CTX_get_error(ctx);
+    switch (err) {
+        case X509_V_ERR_UNABLE_TO_GET_CRL: {
+            X509 *cert = X509_STORE_CTX_get_current_cert(ctx);
+            if (cert == NULL) {
+                return default_ossl_ret;
+            }
+
+            /* Openssl tries to find CRLs for root certificates, which usually succeeds because the CRL of the n - 1
+             * certificate has the same subject name as the root certificate, since the root is self-signed. The root
+             * certificate, however, will never have a CRL. So, ignore all CRL lookup errors for self-signed
+             * certificates. */
+            unsigned long subject_hash = X509_subject_name_hash(cert);
+            unsigned long issuer_hash = X509_issuer_name_hash(cert);
+            if (subject_hash == issuer_hash) {
+                return 1;
+            }
+
+            crl_validate_option *validate_option = (crl_validate_option *) X509_get_ex_data(cert, 0);
+            if (validate_option == NULL) {
+                return default_ossl_ret;
+            }
+
+            if (*validate_option == CRL_DO_NOT_VALIDATE) {
+                return 1;
+            }
+
+            return default_ossl_ret;
+        }
+        default:
+            return default_ossl_ret;
+    }
+}
+
 int s2n_crl_lookup_get_cert_issuer_hash(struct s2n_crl_lookup *lookup, uint64_t *hash)
 {
     POSIX_ENSURE_REF(lookup);
@@ -212,12 +252,23 @@ int s2n_crl_lookup_get_cert_issuer_hash(struct s2n_crl_lookup *lookup, uint64_t 
     return S2N_SUCCESS;
 }
 
+int s2n_crl_lookup_get_cert_index(struct s2n_crl_lookup *lookup, uint16_t *cert_index) {
+    POSIX_ENSURE_REF(lookup);
+    *cert_index = lookup->cert_idx;
+    return S2N_SUCCESS;
+}
+
 int s2n_crl_lookup_set(struct s2n_crl_lookup *lookup, struct s2n_crl *crl)
 {
     POSIX_ENSURE_REF(lookup);
     POSIX_ENSURE_REF(crl);
     lookup->crl = crl;
     lookup->status = FINISHED;
+
+    POSIX_ENSURE_REF(lookup->cert);
+    lookup->validate_option = CRL_VALIDATE;
+    POSIX_GUARD_OSSL(X509_set_ex_data(lookup->cert, 0, &lookup->validate_option), S2N_ERR_INTERNAL_LIBCRYPTO_ERROR);
+
     return S2N_SUCCESS;
 }
 
@@ -226,5 +277,22 @@ int s2n_crl_lookup_ignore(struct s2n_crl_lookup *lookup)
     POSIX_ENSURE_REF(lookup);
     lookup->crl = NULL;
     lookup->status = FINISHED;
+
+    POSIX_ENSURE_REF(lookup->cert);
+    lookup->validate_option = CRL_VALIDATE;
+    POSIX_GUARD_OSSL(X509_set_ex_data(lookup->cert, 0, &lookup->validate_option), S2N_ERR_INTERNAL_LIBCRYPTO_ERROR);
+
+    return S2N_SUCCESS;
+}
+
+int s2n_crl_lookup_do_not_validate(struct s2n_crl_lookup *lookup) {
+    POSIX_ENSURE_REF(lookup);
+    lookup->crl = NULL;
+    lookup->status = FINISHED;
+
+    POSIX_ENSURE_REF(lookup->cert);
+    lookup->validate_option = CRL_DO_NOT_VALIDATE;
+    POSIX_GUARD_OSSL(X509_set_ex_data(lookup->cert, 0, &lookup->validate_option), S2N_ERR_INTERNAL_LIBCRYPTO_ERROR);
+
     return S2N_SUCCESS;
 }

--- a/tls/s2n_crl.c
+++ b/tls/s2n_crl.c
@@ -198,7 +198,8 @@ S2N_RESULT s2n_crl_invoke_lookup_callbacks(struct s2n_connection *conn, struct s
     return S2N_RESULT_OK;
 }
 
-int s2n_crl_ossl_verify_callback(int default_ossl_ret, X509_STORE_CTX *ctx) {
+int s2n_crl_ossl_verify_callback(int default_ossl_ret, X509_STORE_CTX *ctx)
+{
     /* If Openssl would have returned successfully, return success. */
     if (default_ossl_ret > 0) {
         return default_ossl_ret;
@@ -252,7 +253,8 @@ int s2n_crl_lookup_get_cert_issuer_hash(struct s2n_crl_lookup *lookup, uint64_t 
     return S2N_SUCCESS;
 }
 
-int s2n_crl_lookup_get_cert_index(struct s2n_crl_lookup *lookup, uint16_t *cert_index) {
+int s2n_crl_lookup_get_cert_index(struct s2n_crl_lookup *lookup, uint16_t *cert_index)
+{
     POSIX_ENSURE_REF(lookup);
     *cert_index = lookup->cert_idx;
     return S2N_SUCCESS;
@@ -285,7 +287,8 @@ int s2n_crl_lookup_ignore(struct s2n_crl_lookup *lookup)
     return S2N_SUCCESS;
 }
 
-int s2n_crl_lookup_do_not_validate(struct s2n_crl_lookup *lookup) {
+int s2n_crl_lookup_do_not_validate(struct s2n_crl_lookup *lookup)
+{
     POSIX_ENSURE_REF(lookup);
     lookup->crl = NULL;
     lookup->status = FINISHED;

--- a/tls/s2n_crl.h
+++ b/tls/s2n_crl.h
@@ -31,11 +31,18 @@ typedef enum {
     FINISHED
 } crl_lookup_callback_status;
 
+
+typedef enum {
+    CRL_VALIDATE,
+    CRL_DO_NOT_VALIDATE
+} crl_validate_option;
+
 struct s2n_crl_lookup {
     crl_lookup_callback_status status;
     X509 *cert;
     uint16_t cert_idx;
     struct s2n_crl *crl;
+    crl_validate_option validate_option;
 };
 
 typedef int (*s2n_crl_lookup_callback) (struct s2n_crl_lookup *lookup, void *context);
@@ -47,9 +54,12 @@ int s2n_crl_load_pem(struct s2n_crl *crl, uint8_t *pem, size_t len);
 int s2n_crl_free(struct s2n_crl **crl);
 int s2n_crl_get_issuer_hash(struct s2n_crl *crl, uint64_t *hash);
 int s2n_crl_lookup_get_cert_issuer_hash(struct s2n_crl_lookup *lookup, uint64_t *hash);
+int s2n_crl_lookup_get_cert_index(struct s2n_crl_lookup *lookup, uint16_t *cert_index);
 int s2n_crl_lookup_set(struct s2n_crl_lookup *lookup, struct s2n_crl *crl);
 int s2n_crl_lookup_ignore(struct s2n_crl_lookup *lookup);
+int s2n_crl_lookup_do_not_validate(struct s2n_crl_lookup *lookup);
 
 S2N_RESULT s2n_crl_handle_lookup_callback_result(struct s2n_x509_validator *validator);
 S2N_RESULT s2n_crl_invoke_lookup_callbacks(struct s2n_connection *conn, struct s2n_x509_validator *validator);
 S2N_RESULT s2n_crl_get_crls_from_lookup_list(struct s2n_x509_validator *validator, STACK_OF(X509_CRL) *crl_stack);
+int s2n_crl_ossl_verify_callback(int default_ossl_ret, X509_STORE_CTX *ctx);

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -400,6 +400,8 @@ static S2N_RESULT s2n_x509_validator_verify_cert_chain(struct s2n_x509_validator
     DEFER_CLEANUP(STACK_OF(X509_CRL) *crl_stack = NULL, sk_X509_CRL_free_pointer);
 
     if (conn->config->crl_lookup_cb) {
+        X509_STORE_CTX_set_verify_cb(validator->store_ctx, s2n_crl_ossl_verify_callback);
+
         crl_stack = sk_X509_CRL_new_null();
         RESULT_GUARD(s2n_crl_get_crls_from_lookup_list(validator, crl_stack));
 


### PR DESCRIPTION
### Resolved issues:

Part of https://github.com/aws/s2n-tls/issues/3499

### Description of changes: 

Currently, if a CRL callback is implemented, all certificates in the chain of trust must have a corresponding CRL, or the handshake will fail with a `S2N_ERR_CRL_LOOKUP_FAILED` error. However, it may be desirable to not perform certificate revocation checks on some certificates. To enable this functionality, a new CRL lookup return function has been added, `s2n_crl_lookup_do_not_validate`.

One use case for this functionality is to skip certificate revocation checks for intermediate certificates, and only check leaf certificates. To allow for this, a new function has been added to get the certificate's index in the chain, `s2n_crl_lookup_get_cert_index`. Customers can check the certificate index to determine if it is or isn't a leaf certificate, and perform a revocation check accordingly.

Additionally, the `s2n_crl_lookup_do_not_validate` function allows customers to perform best-effort CRL validation checks. If a CRL is cached, validation can be performed with `s2n_crl_lookup_set`. And, if a CRL has not been found in the cache, the handshake can proceed without a CRL validation check with `s2n_crl_lookup_do_not_validate`.

### Call-outs:

- Is a best-effort CRL lookup a reasonable use case? An alternative to this API would be a simple configuration option to toggle the `X509_V_FLAG_CRL_CHECK_ALL` flag, telling the libcrypto to check only leaf certificates vs all certificates. This might be a simpler and less dangerous option.

- In testing this API, I found an interesting Openssl behavior. It seems that a CRL lookup is always performed on root certificates. This caused problems when marking an n - 1 certificate as `DO_NOT_VALIDATE`, since this also caused the root certificate's CRL lookup to fail. A check has been added in the Openssl verify callback to ignore root certificate lookups, since root certificates will never have a corresponding CRL. A test has been added for this, which sets the intermediate (n - 1) cert as `DO_NOT_VALIDATE`. Additionally, this behavior can be caused by having only the root certificate in the chain of trust. A test has been added for this case as well.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
- New unit tests.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
