### PR TITLE
Fix free error when using jemalloc

### DIFF
--- a/bindings/rust/s2n-tls/src/init.rs
+++ b/bindings/rust/s2n-tls/src/init.rs
@@ -93,7 +93,9 @@ mod mem {
             return s2n_status_code::FAILURE;
         };
 
-        dealloc(ptr as *mut _, layout);
+        if !ptr.is_null() {
+            dealloc(ptr as *mut _, layout);
+        }
 
         s2n_status_code::SUCCESS
     }

--- a/tests/unit/s2n_mem_test.c
+++ b/tests/unit/s2n_mem_test.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "utils/s2n_safety.h"
+
+/* Required to override memory callbacks at runtime */
+#include "utils/s2n_mem.c"
+
+int s2n_strict_mem_free_cb(void *ptr, uint32_t size)
+{
+    POSIX_ENSURE_REF(ptr);
+    POSIX_ENSURE_GT(size, 0);
+    return S2N_SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test safety of all mem free methods */
+    {
+        /* Test: no-op for empty blob */
+        {
+            struct s2n_blob blob = { 0 };
+            EXPECT_SUCCESS(s2n_free(&blob));
+            EXPECT_SUCCESS(s2n_free_without_wipe(&blob));
+            EXPECT_SUCCESS(s2n_blob_zeroize_free(&blob));
+        }
+
+        /* Test: no-op for already freed blob */
+        {
+            struct s2n_blob blob = { 0 };
+            EXPECT_SUCCESS(s2n_alloc(&blob, 10));
+            EXPECT_SUCCESS(s2n_free(&blob));
+
+            EXPECT_SUCCESS(s2n_free(&blob));
+            EXPECT_SUCCESS(s2n_free_without_wipe(&blob));
+            EXPECT_SUCCESS(s2n_blob_zeroize_free(&blob));
+        }
+
+        /* Test: error for NULL */
+        {
+            EXPECT_FAILURE_WITH_ERRNO(s2n_free(NULL), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_free_without_wipe(NULL), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_blob_zeroize_free(NULL), S2N_ERR_NULL);
+        }
+
+        /* Test: faulty / overly strict free implementation
+         *
+         * A correct implementation of free() should be a no-op for a NULL pointer.
+         * However, we have encountered cases where faulty implementations of free()
+         * seg faulted on NULL: our Rust bindings initially incorrectly assumed that
+         * Rust's dealloc() handled NULLs like C's free().
+         *
+         * As an easy way to avoid this, we should just never call the free mem callback for NULL.
+         */
+        {
+            /* Save real free callback */
+            s2n_mem_free_callback saved_free_cb = s2n_mem_free_cb;
+
+            /* Set callback that won't accepts NULLs / zeros */
+            s2n_mem_free_cb = s2n_strict_mem_free_cb;
+
+            /* No-op for empty blob */
+            struct s2n_blob blob = { 0 };
+            EXPECT_SUCCESS(s2n_free(&blob));
+            EXPECT_SUCCESS(s2n_free_without_wipe(&blob));
+            EXPECT_SUCCESS(s2n_blob_zeroize_free(&blob));
+
+            /* Restore real free callback */
+            s2n_mem_free_cb = saved_free_cb;
+        }
+    }
+
+    END_TEST();
+}

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -289,7 +289,9 @@ int s2n_free_without_wipe(struct s2n_blob *b)
     POSIX_ENSURE(initialized, S2N_ERR_NOT_INITIALIZED);
     POSIX_ENSURE(s2n_blob_is_growable(b), S2N_ERR_FREE_STATIC_BLOB);
 
-    POSIX_GUARD(s2n_mem_free_cb(b->data, b->allocated));
+    if (b->data) {
+        POSIX_GUARD(s2n_mem_free_cb(b->data, b->allocated));
+    }
 
     *b = (struct s2n_blob) {0};
 


### PR DESCRIPTION
### Description of changes: 

A customer trying to use jemallocator with the Rust bindings encountered a seg fault.

We were assuming that Rust's dealloc would treat NULLs as a no-op like C's free() does, but dealloc's behavior is actually undefined for NULL. We therefore need to check for NULL before calling it.

I also added a NULL check to `s2n_free_without_wipe`, because this seems like a potentially sharp edge when implementing custom memory callbacks. If we think that this is overkill, I can remove the check.

### Testing:
Added some safety tests for the memory free methods, including one with a faulty free implementation.

I also manually tested by adding jemallocator to s2n-tls-tokio to reproduce the problem. I verified that each of these fixes individually solved it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
