### PR TITLE
Fix FreeBSD build test bug

### DIFF
--- a/.github/s2n_freebsd.sh
+++ b/.github/s2n_freebsd.sh
@@ -15,7 +15,7 @@
 set -eu
 export CTEST_PARALLEL_LEVEL=$(sysctl hw.ncpu | awk '{print $2}')
 
-cmake . -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug
+cmake . -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release
 cmake --build ./build -j $CTEST_PARALLEL_LEVEL
 ninja -C build test
 cmake --build ./build --target clean #Saves on copy back rsync time

--- a/.github/s2n_freebsd.sh
+++ b/.github/s2n_freebsd.sh
@@ -15,10 +15,10 @@
 set -eu
 export CTEST_PARALLEL_LEVEL=$(sysctl hw.ncpu | awk '{print $2}')
 
-cmake . -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release
-cmake --build ./build -j $CTEST_PARALLEL_LEVEL
-ninja -C build test
-cmake --build ./build --target clean #Saves on copy back rsync time
+cmake . -Brelease -GNinja -DCMAKE_BUILD_TYPE=Release
+cmake --build ./release -j $CTEST_PARALLEL_LEVEL
+ninja -C release test
+cmake --build ./release --target clean #Saves on copy back rsync time
 
 cmake . -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug
 cmake --build ./build -j $CTEST_PARALLEL_LEVEL

--- a/.github/s2n_freebsd.sh
+++ b/.github/s2n_freebsd.sh
@@ -19,3 +19,8 @@ cmake . -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release
 cmake --build ./build -j $CTEST_PARALLEL_LEVEL
 ninja -C build test
 cmake --build ./build --target clean #Saves on copy back rsync time
+
+cmake . -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug
+cmake --build ./build -j $CTEST_PARALLEL_LEVEL
+ninja -C build test
+cmake --build ./build --target clean #Saves on copy back rsync time

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -24,4 +24,6 @@ jobs:
         uses: actions/upload-artifact@master
         with:
           name: all_test_output
-          path: build/Testing/Temporary
+          path: |
+            release/Testing/Temporary
+            build/Testing/Temporary

--- a/tests/unit/s2n_cipher_suites_test.c
+++ b/tests/unit/s2n_cipher_suites_test.c
@@ -77,24 +77,28 @@ int main()
         {
             uint8_t iana[S2N_TLS_CIPHER_SUITE_LEN] = { 0 };
             struct s2n_cipher_suite *cipher_suite = NULL;
-            EXPECT_ERROR_WITH_ERRNO(s2n_cipher_suite_from_iana(NULL, &cipher_suite), S2N_ERR_NULL);
-            EXPECT_ERROR_WITH_ERRNO(s2n_cipher_suite_from_iana(iana, NULL), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_cipher_suite_from_iana(NULL, sizeof(iana), &cipher_suite), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_cipher_suite_from_iana(iana, sizeof(iana), NULL), S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(s2n_cipher_suite_from_iana(iana, sizeof(iana) - 1, &cipher_suite), S2N_ERR_SAFETY);
+            EXPECT_ERROR_WITH_ERRNO(s2n_cipher_suite_from_iana(iana, sizeof(iana) + 1, &cipher_suite), S2N_ERR_SAFETY);
         }
 
         /* Known values */
         {
             uint8_t null_iana[S2N_TLS_CIPHER_SUITE_LEN] = { 0 };
             struct s2n_cipher_suite *cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
-            EXPECT_ERROR_WITH_ERRNO(s2n_cipher_suite_from_iana(null_iana, &cipher_suite), S2N_ERR_CIPHER_NOT_SUPPORTED);
+            EXPECT_ERROR_WITH_ERRNO(s2n_cipher_suite_from_iana(null_iana, sizeof(null_iana), &cipher_suite),
+                    S2N_ERR_CIPHER_NOT_SUPPORTED);
             EXPECT_EQUAL(cipher_suite, NULL);
 
             uint8_t tls12_iana[] = { TLS_RSA_WITH_AES_128_CBC_SHA };
             cipher_suite = NULL;
-            EXPECT_OK(s2n_cipher_suite_from_iana(tls12_iana, &cipher_suite));
+            EXPECT_OK(s2n_cipher_suite_from_iana(tls12_iana, sizeof(tls12_iana), &cipher_suite));
             EXPECT_EQUAL(cipher_suite, &s2n_rsa_with_aes_128_cbc_sha);
 
             cipher_suite = NULL;
-            EXPECT_OK(s2n_cipher_suite_from_iana(s2n_tls13_aes_256_gcm_sha384.iana_value, &cipher_suite));
+            EXPECT_OK(s2n_cipher_suite_from_iana(s2n_tls13_aes_256_gcm_sha384.iana_value,
+                    sizeof(s2n_tls13_aes_256_gcm_sha384.iana_value), &cipher_suite));
             EXPECT_EQUAL(cipher_suite, &s2n_tls13_aes_256_gcm_sha384);
         }
 
@@ -106,7 +110,8 @@ int main()
                 expected_cipher_suite = cipher_preferences_test_all.suites[i];
                 actual_cipher_suite = NULL;
 
-                EXPECT_OK(s2n_cipher_suite_from_iana(expected_cipher_suite->iana_value, &actual_cipher_suite));
+                EXPECT_OK(s2n_cipher_suite_from_iana(expected_cipher_suite->iana_value,
+                        sizeof(expected_cipher_suite->iana_value), &actual_cipher_suite));
                 EXPECT_EQUAL(expected_cipher_suite, actual_cipher_suite);
             }
         }
@@ -121,7 +126,7 @@ int main()
                 for (size_t i1 = 0; i1 <= UINT8_MAX; i1++) {
                     iana_value[1] = i1;
 
-                    s2n_result r = s2n_cipher_suite_from_iana(iana_value, &actual_cipher_suite);
+                    s2n_result r = s2n_cipher_suite_from_iana(iana_value, sizeof(iana_value), &actual_cipher_suite);
 
                     bool is_supported = supported_i < cipher_preferences_test_all.count
                             && memcmp(iana_value, cipher_preferences_test_all.suites[supported_i]->iana_value, S2N_TLS_CIPHER_SUITE_LEN) == 0;

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1056,7 +1056,7 @@ S2N_RESULT s2n_cipher_suites_cleanup(void)
     return S2N_RESULT_OK;
 }
 
-S2N_RESULT s2n_cipher_suite_from_iana(const uint8_t iana[static S2N_TLS_CIPHER_SUITE_LEN], struct s2n_cipher_suite **cipher_suite)
+S2N_RESULT s2n_cipher_suite_from_iana(const uint8_t *iana, struct s2n_cipher_suite **cipher_suite)
 {
     RESULT_ENSURE_REF(cipher_suite);
     *cipher_suite = NULL;

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1056,11 +1056,12 @@ S2N_RESULT s2n_cipher_suites_cleanup(void)
     return S2N_RESULT_OK;
 }
 
-S2N_RESULT s2n_cipher_suite_from_iana(const uint8_t *iana, struct s2n_cipher_suite **cipher_suite)
+S2N_RESULT s2n_cipher_suite_from_iana(const uint8_t *iana, size_t iana_len, struct s2n_cipher_suite **cipher_suite)
 {
     RESULT_ENSURE_REF(cipher_suite);
     *cipher_suite = NULL;
     RESULT_ENSURE_REF(iana);
+    RESULT_ENSURE_EQ(iana_len, S2N_TLS_CIPHER_SUITE_LEN);
 
     int low = 0;
     int top = s2n_array_len(s2n_all_cipher_suites) - 1;

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -160,7 +160,7 @@ extern struct s2n_cipher_suite s2n_tls13_chacha20_poly1305_sha256;
 
 extern int s2n_cipher_suites_init(void);
 S2N_RESULT s2n_cipher_suites_cleanup(void);
-S2N_RESULT s2n_cipher_suite_from_iana(const uint8_t iana[S2N_TLS_CIPHER_SUITE_LEN], struct s2n_cipher_suite **cipher_suite);
+S2N_RESULT s2n_cipher_suite_from_iana(const uint8_t *iana, size_t iana_len, struct s2n_cipher_suite **cipher_suite);
 extern int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_CIPHER_SUITE_LEN]);
 extern int s2n_set_cipher_as_sslv2_server(struct s2n_connection *conn, uint8_t * wire, uint16_t count);
 extern int s2n_set_cipher_as_tls_server(struct s2n_connection *conn, uint8_t * wire, uint16_t count);

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -216,7 +216,7 @@ int s2n_psk_configure_early_data(struct s2n_psk *psk, uint32_t max_early_data_si
 
     const uint8_t cipher_suite_iana[] = { cipher_suite_first_byte, cipher_suite_second_byte };
     struct s2n_cipher_suite *cipher_suite = NULL;
-    POSIX_GUARD_RESULT(s2n_cipher_suite_from_iana(cipher_suite_iana, &cipher_suite));
+    POSIX_GUARD_RESULT(s2n_cipher_suite_from_iana(cipher_suite_iana, sizeof(cipher_suite_iana), &cipher_suite));
     POSIX_ENSURE_REF(cipher_suite);
     POSIX_ENSURE(cipher_suite->prf_alg == psk->hmac_alg, S2N_ERR_INVALID_ARGUMENT);
 

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -262,7 +262,7 @@ static S2N_RESULT s2n_tls13_deserialize_session_state(struct s2n_connection *con
     uint8_t iana_id[S2N_TLS_CIPHER_SUITE_LEN] = { 0 };
     RESULT_GUARD_POSIX(s2n_stuffer_read_bytes(from, iana_id, S2N_TLS_CIPHER_SUITE_LEN));
     struct s2n_cipher_suite *cipher_suite = NULL;
-    RESULT_GUARD(s2n_cipher_suite_from_iana(iana_id, &cipher_suite));
+    RESULT_GUARD(s2n_cipher_suite_from_iana(iana_id, sizeof(iana_id), &cipher_suite));
     RESULT_ENSURE_REF(cipher_suite);
     psk.hmac_alg = cipher_suite->prf_alg;
 


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/3489

### Description of changes:
Apparently FreeBSD takes static array sizes VERY seriously. Since we indicated that iana would be at least S2N_TLS_CIPHER_SUITE_LEN bytes long, it decided to optimize out the iana null check. This caused [the unit test verifying null safety](https://github.com/aws/s2n-tls/blob/main/tests/unit/s2n_cipher_suites_test.c#L80) to seg fault when any level of optimization was requested.

I'm simplifying the declaration of iana and switching our tests to use "Release" instead of "Debug".

### Call-outs:

Alternatively, we could decide that the static array size is more useful than the unit test and that `s2n_cipher_suite_from_iana` CAN assume that iana will never be null. In that case, I'll just delete the test and leave the declaration of iana untouched. However, my paranoia says that's a bad idea.

### Testing:

Switching the build type to Release caused the CI job to seg fault. This fix prevents the seg fault.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
