### PR TITLE
Ensure data is stuffer is empty

### DIFF
--- a/tls/extensions/s2n_client_ems.c
+++ b/tls/extensions/s2n_client_ems.c
@@ -46,7 +46,8 @@ static int s2n_client_ems_recv(struct s2n_connection *conn, struct s2n_stuffer *
 {
     POSIX_ENSURE_REF(conn);
 
-    /* Read nothing. The extension just needs to exist. */
+    /* Read nothing. The extension just needs to exist without data. */
+    POSIX_ENSURE(s2n_stuffer_data_available(extension) == 0, S2N_ERR_UNSUPPORTED_EXTENSION);
     conn->ems_negotiated = true;
 
     return S2N_SUCCESS;

--- a/tls/extensions/s2n_server_ems.c
+++ b/tls/extensions/s2n_server_ems.c
@@ -47,7 +47,8 @@ static int s2n_server_ems_recv(struct s2n_connection *conn, struct s2n_stuffer *
 {
     POSIX_ENSURE_REF(conn);
 
-    /* Read nothing. The extension just needs to exist. */
+    /* Read nothing. The extension just needs to exist without any data. */
+    POSIX_ENSURE(s2n_stuffer_data_available(extension) == 0, S2N_ERR_UNSUPPORTED_EXTENSION);
     conn->ems_negotiated = true;
 
     return S2N_SUCCESS;


### PR DESCRIPTION
RFC 7627, section 5.2:
This document defines a new TLS extension, "extended_master_secret" (with extension type 0x0017), which is used to signal both client and server to use the extended master secret computation. The "extension_data" field of this extension is empty. Thus, the entire encoding of the extension is 00 17 00 00 (in hexadecimal.)

We should therefore ensure that there is no data in the extension.

### Resolved issues:


### Description of changes: 

Adds a check to ensure there is no extension data.

### Testing:

Ran unit tests. 