### PR TITLE
[bindings] Fix client hello callback with config swap

### DIFF
--- a/bindings/rust/s2n-tls/src/testing.rs
+++ b/bindings/rust/s2n-tls/src/testing.rs
@@ -231,6 +231,11 @@ impl ClientHelloCallback for MockClientHelloHandler {
             return Poll::Pending;
         }
 
+        // Test that the config can be changed
+        connection
+            .set_config(build_config(&security::DEFAULT_TLS13).unwrap())
+            .unwrap();
+
         // Test that server_name_extension_used can be invoked
         connection.server_name_extension_used();
 

--- a/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
+++ b/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
@@ -350,7 +350,14 @@ mod tests {
                 &self,
                 connection: &mut crate::connection::Connection,
             ) -> Poll<Result<(), error::Error>> {
+                // Test that the config can be changed
+                connection
+                    .set_config(build_config(&security::DEFAULT_TLS13).unwrap())
+                    .unwrap();
+
+                // Test that server_name_extension_used can be invoked
                 connection.server_name_extension_used();
+
                 self.0.fetch_add(1, Ordering::Relaxed);
                 Poll::Ready(Ok(()))
             }


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/1562

### Description of changes: 

Originally, the client hello callback was always blocking. When non-blocking behavior was introduced later, s2n_config_set_client_hello_cb_mode was added to turn on non-blocking mode. s2n-tls still defaults to blocking mode for backwards compatibility.

However, the Rust bindings always use non-blocking mode, because Rust prefers a polling model. Currently we set non-blocking mode when the client hello callback is set, but that means that if no callback is set we stay in blocking mode. This is a problem because if the config is swapped out during the callback for a config without a callback (allowed by the C library), then we incorrectly assume blocking mode and incorrectly handle the callback's return value.

We can fix this by always setting new configs to use non-blocking mode, even if they don't set the client hello callback. There's no problem with backwards compatibility like in the C library, because the Rust bindings have always used non-blocking mode.

### Call-outs:

This is arguably also a problem for the C library, which requires s2n_config_set_client_hello_cb_mode to be called on the new config. But it's harder to solve for the C library :)

### Testing:
Updated existing tests. They failed before the fix, passed after.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
