### PR TITLE
ci: Update fuzz test buildspec to use custom codebuild image

### DIFF
--- a/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
+++ b/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
@@ -19,49 +19,17 @@ env:
     CB_BIN_DIR: "./codebuild/bin"
 
 phases:
-  install:
-    runtime-versions:
-      python: 3.x
-    commands:
-      - echo Entered the install phase...
-      - |
-        if [ -d "third-party-src" ]; then
-          cd third-party-src;
-        fi
-      - $CB_BIN_DIR/install_ubuntu_dependencies.sh
-      - apt-key list
-      - add-apt-repository ppa:ubuntu-toolchain-r/test -y
-      - apt-get update -o Acquire::CompressionTypes::Order::=gz
-      - apt-get update -y
-      - |
-        if expr "${GCC_VERSION}" : "9" >/dev/null; then
-          apt-get install -y --no-install-recommends g++ g++-9 gcc gcc-9;
-        fi
-      - |
-        if expr "${GCC_VERSION}" : "6" >/dev/null; then
-          apt-get install -y --no-install-recommends g++ g++-6 gcc gcc-6;
-        fi
-      # Don't install old clang and llvm if LATEST_CLANG is enabled, handle it in install_clang.sh instead
-      - |
-        if expr "${LATEST_CLANG}" != "true" >/dev/null; then
-          apt-get install -y --no-install-recommends clang-3.9 llvm-3.9;
-        fi
-      - apt-get install -y --no-install-recommends indent iproute2 kwstyle lcov libssl-dev m4 make net-tools nettle-bin nettle-dev pkg-config psmisc python3-pip shellcheck sudo tcpdump unzip valgrind zlib1g-dev zlibc cmake
   pre_build:
     commands:
       - |
         if [ -d "third-party-src" ]; then
           cd third-party-src;
         fi
-      - $CB_BIN_DIR/install_default_dependencies.sh
+      - ln -s /usr/local $CODEBUILD_SRC_DIR/test-deps
       - touch tests/fuzz/placeholder_results.txt tests/fuzz/placeholder_output.txt
   build:
     commands:
-      - printenv
       - $CB_BIN_DIR/s2n_codebuild.sh
-  post_build:
-    commands:
-      - echo Build completed on `date`
 artifacts:
   files:
     - "./tests/fuzz/corpus/$FUZZ_TESTS/*"


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

The fuzz test jobs have been failing due to ppa issues. The buildspecs for the PR fuzz tests have been temporarily overridden in codebuild to use the custom ubuntu docker image instead of installing everything on each run, which solves the problem. 

The buildspecs in codebuild should point to the ones in the repository, though. And, the batch job for the release must point to these buildspecs. So, this PR updates the fuzz test buildspec to run on the custom codebuild image.

### Call-outs:

None

### Testing:

In the following PR run, the buildspec was reverted in codebuild to point to `buildspec_ubuntu_fuzz_artifacts.yml` in the repo, and set to use the custom codebuild image:

- [s2nFuzzBatch](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nFuzzBatch/batch/s2nFuzzBatch%3Ae739004c-a3c3-4608-87bd-83e6f621336e?region=us-west-2)

In the following release run, the buildspec was set to use the custom codebuild image:

- [s2nOmnibus](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nOmnibus/batch/s2nOmnibus%3Aae1c2232-be16-4847-bd86-df6a56e21529?region=us-west-2)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
