### PR TITLE
ci: Remove integv1 tests

### DIFF
--- a/codebuild/README.md
+++ b/codebuild/README.md
@@ -1,5 +1,7 @@
 ### CodeBuild script info
 
+Note: The create_projects.py script, associated *.config files, and non-batch CodeBuild jobs are being deprecated.
+
 #### Design
 
 - How does CodeBuild decide what to install/test ?
@@ -7,8 +9,6 @@
    dictate what is installed and which tests get run. CodeBuild has a pattern where environment
    variables can be over-ridden by CloudWatch events or batch jobs, so in some cases the CodeBuild job definition
    is generic or filled with placeholders (e.g. s2nFuzzScheduled).
-- Why not build docker images with the dependencies layered in ?
-  This is the end goal: get tests running in CodeBuild first, then optimize the containers where it makes sense.
 
 #### Dep tree
 
@@ -93,14 +93,6 @@ With extensive testing, we've learned this number appears to be weighted based o
 The `spec/buildspec_omnibus_batch.yml` contains a complete list of all CodeBuild jobs.  In the future, this will replace the individual jobs created by the create_project.py script.
 
 The broken out batch jobs: fuzz, integration and general, are created with the script create_batch.sh, which uses jq to parse out the jobs by title.
-
-### Notes on moving from Travis-ci
-
-- Install_clang from Travis is using google chromium clang commit from 2017- which requires python2.7 (EOL); updated for CodeBuild.
-- CodeBuild's environment is more restrictive than Travis- these jobs require elevated privilege to function.
-- Warning message from the fuzzer about test speed appear in CodeBuild output, but not in Travis-CI with the same test (See comments on AWS forums about a difference in ANSI TERM support); this also affects colorized output.
-- macOS/OSX platform files were not copied because CodeBuild does not support macOS builds.
-
 
 ### Querying CodeBuild projects
 

--- a/codebuild/codebuild.config
+++ b/codebuild/codebuild.config
@@ -16,40 +16,6 @@ env: S2N_LIBCRYPTO=openssl-1.1.1 LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=6
 snippet: UbuntuFuzzJob
 env: S2N_LIBCRYPTO=openssl-1.0.2-fips LATEST_CLANG=true TESTS=fuzz FUZZ_TIMEOUT_SEC=60
 
-# Integration tests
-
-[CodeBuild:s2nIntegrationOpenSSL111Gcc9]
-snippet: UbuntuBoilerplate2XL
-env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=9
-
-[CodeBuild:s2nIntegrationLibreSSLGcc9]
-snippet: UbuntuBoilerplate2XL
-env: S2N_LIBCRYPTO=libressl BUILD_S2N=true TESTS=integration GCC_VERSION=9
-
-[CodeBuild:s2nIntegrationOpenSSL111Gcc6Coverage]
-snippet: UbuntuBoilerplate2XL
-env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6 S2N_COVERAGE=true
-
-[CodeBuild:s2nIntegrationOpenSSL111Gcc6Corked]
-snippet: UbuntuBoilerplate2XL
-env: S2N_LIBCRYPTO=openssl-1.1.1 BUILD_S2N=true TESTS=integration GCC_VERSION=6 S2N_CORKED_IO=true
-
-[CodeBuild:s2nIntegrationOpenSSL102Gcc6]
-snippet: UbuntuBoilerplate2XL
-env: S2N_LIBCRYPTO=openssl-1.0.2 BUILD_S2N=true TESTS=integration GCC_VERSION=6
-
-[CodeBuild:s2nIntegrationOpenSSL102Gcc6FIPS]
-snippet: UbuntuBoilerplate2XL
-env: S2N_LIBCRYPTO=openssl-1.0.2-fips BUILD_S2N=true TESTS=integration GCC_VERSION=6
-
-[CodeBuild:s2nIntegrationOpenSSL111Gcc6SoftCrypto]
-snippet: UbuntuBoilerplate2XL
-env: S2N_LIBCRYPTO=openssl-1.1.1 OPENSSL_ia32cap="~0x200000200000000" BUILD_S2N=true TESTS=integration GCC_VERSION=6
-
-[CodeBuild:s2nIntegrationBoringSSLGcc9]
-snippet: UbuntuBoilerplate2XL
-env: S2N_LIBCRYPTO=boringssl BUILD_S2N=true TESTS=integration GCC_VERSION=9
-
 # Asan Test
 [CodeBuild:s2nAsanOpenSSL111Gcc6Coverage]
 snippet: UbuntuBoilerplateLarge


### PR DESCRIPTION
### Resolved issues:

none

### Description of changes: 

Now that the [integv2](https://github.com/aws/s2n-tls/issues/2114) work is done, we can remove the original integration v1 jobs from codebuild.

### Call-outs:

The scheduled saw, valgrind, asan, etc tests remaining need to be setup in CodeBuild before being deleted in a future PR.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? ci

 Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
