### PR TITLE
Fix a type error in GNU TLS Provider

### DIFF
--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -509,7 +509,7 @@ class OpenSSL(Provider):
 
 class JavaSSL(Provider):
     """
-    NOTE: Only a Java SSL client has been set up. The server has not been 
+    NOTE: Only a Java SSL client has been set up. The server has not been
     implemented yet.
     """
 
@@ -688,27 +688,27 @@ class GnuTLS(Provider):
     def create_priority_str(self):
         priority_str = "NONE"
 
-        if self.options.protocol:
-            priority_str += ":+" + \
-                self.protocol_to_priority_str(self.options.protocol)
+        protocol_to_priority_str = self.protocol_to_priority_str(self.options.protocol)
+        if protocol_to_priority_str:
+            priority_str += ":+" + protocol_to_priority_str
         else:
             priority_str += ":+VERS-ALL"
 
-        if self.options.cipher:
-            priority_str += ":+" + \
-                self.cipher_to_priority_str(self.options.cipher)
+        cipher_to_priority_str = self.cipher_to_priority_str(self.options.cipher)
+        if cipher_to_priority_str:
+            priority_str += ":+" + cipher_to_priority_str
         else:
             priority_str += ":+KX-ALL:+CIPHER-ALL:+MAC-ALL"
 
-        if self.options.curve:
-            priority_str += ":+" + \
-                self.curve_to_priority_str(self.options.curve)
+        curve_to_priority_str = self.curve_to_priority_str(self.options.curve)
+        if curve_to_priority_str:
+            priority_str += ":+" + curve_to_priority_str
         else:
             priority_str += ":+GROUP-ALL"
 
-        if self.options.signature_algorithm:
-            priority_str += ":+" + \
-                self.sigalg_to_priority_str(self.options.signature_algorithm)
+        sigalg_to_priority_str = self.sigalg_to_priority_str(self.options.signature_algorithm)
+        if sigalg_to_priority_str:
+            priority_str += ":+" + sigalg_to_priority_str
         else:
             priority_str += ":+SIGN-ALL"
 


### PR DESCRIPTION


### Resolved issues:

None

### Description of changes: 

I ran into this type error while working on my send buffer integration test. My python linter also discovered it. The functions *_to_priority_str can return None, even if their argument is not None. Re-arranging the conditionals here avoids a type error on string addition.

### Call-outs:

Should we have some better type checking in our Python code? Can we do anything with gradual types?

### Testing:

Both by re-running the failing test and observing the output of the linter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
