### PR TITLE
Fix very minor DeprecationWarning in integrationv2

### DIFF
--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -53,7 +53,7 @@ class AvailablePorts(object):
         worker = os.getenv('PYTEST_XDIST_WORKER')
         worker_id = 0
         if worker is not None:
-            worker_id = re.findall('gw(\d+)', worker)
+            worker_id = re.findall(r"gw(\d+)", worker)
             if len(worker_id) != 0:
                 worker_id = int(worker_id[0])
 


### PR DESCRIPTION
### Resolved issues:
None in Github.

### Description of changes: 
I discovered this while working on an integrationv2 test. I got the following warning:

    DeprecationWarning: invalid escape sequence

The invalid escape sequence here is `'\d'`. In Python 3.6 and above this warning was added. The suggested fix here is to use a raw string or properly escape the backslash. For regex source raw strings are the better choice.

```python
r"\d"
```

Quoting [String and Bytes Literals](https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals):

> Changed in version 3.6: Unrecognized escape sequences produce a [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning). In a future Python version they will be a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning) and eventually a [SyntaxError](https://docs.python.org/3/library/exceptions.html#SyntaxError).



### Call-outs:

None 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
