### PR TITLE
ci: remove verify_s2n_hmac_sha256 saw test from Makefile

### DIFF
--- a/tests/saw/Makefile
+++ b/tests/saw/Makefile
@@ -94,7 +94,6 @@ failure-tests : bitcode
 	@${MAKE} clean-failure-logs
 	@${MAKE} failure_tests/tls_early_ccs.log
 	@${MAKE} failure_tests/tls_missing_full_handshake.log
-	@${MAKE} failure_tests/sha_bad_magic_mod.log
 	@${MAKE} failure_tests/cork_one.log
 	@${MAKE} failure_tests/cork_two.log
 
@@ -103,12 +102,6 @@ failure-tests : bitcode
 
 # We're just making separate prefix targets for each saw script we want to do
 # negative tests on
-failure_tests/sha_%.log : bitcode/sha_%.bc
-        #this might not be necessary
-	cp $< bitcode/all_llvm.bc 
-	@set -o pipefail; \
-	! (saw verify_s2n_hmac_sha256.saw 2>&1 | tee $@)
-
 failure_tests/tls_%.log : bitcode/tls_%.bc
         #this might not be necessary
 	cp $< bitcode/all_llvm.bc 

--- a/tests/saw/Makefile
+++ b/tests/saw/Makefile
@@ -105,14 +105,16 @@ failure-tests : bitcode
 failure_tests/tls_%.log : bitcode/tls_%.bc
         #this might not be necessary
 	cp $< bitcode/all_llvm.bc 
-	@set -o pipefail; \
+	set -o pipefail; \
 	! (saw verify_state_machine.saw 2>&1 | tee $@)
+	grep "Proof failed." $@
 
 failure_tests/cork_%.log : bitcode/cork_%.bc
         #this might not be necessary
 	cp $< bitcode/all_llvm.bc 
-	@set -o pipefail; \
+	set -o pipefail; \
 	! (saw verify_cork_uncork.saw 2>&1 | tee $@)
+	grep "Proof failed." $@
 
 
 # we patch the s2n dir, build it with the top level s2n makefile, and


### PR DESCRIPTION
### Resolved issues:

Resolves https://github.com/aws/s2n-tls/issues/3598.

### Description of changes: 

`verify_s2n_hmac_sha256.saw` was removed in https://github.com/aws/s2n-tls/pull/1571. However, a line in the Makefile still invokes this test. This PR removes this line from `failure_tests`, to stop calling the test that no longer exists.

Calling this test complained with a file not found error:
```
[19:46:23.227] /[...]/s2n-tls/tests/saw/verify_s2n_hmac_sha256.saw: openFile: does not exist (No such file or directory)
rm bitcode/sha_bad_magic_mod.bc
```

However, this failed silently. The `failure_tests` are negative tests. They work by patching s2n-tls with errors, running the proof, and then making sure the proof fails. The check for the proof failure simply made sure the return code indicated a failure. However, the test not existing also produced a failing return code. This PR updates these negative tests to additionally check for "proof failed" in the output, to make sure the test actually ran.

### Call-outs:

None

### Testing:

The general batch should succeed on this PR. 

Additionally, I ran a general batch with the new check and the old test, to make sure the new check would have caught this problem: https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nGeneralBatch/build/s2nGeneralBatch%3Ae2b9286b-d3e7-4d17-8738-ae85fb21a195/?region=us-west-2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
