### PR TITLE
Add clang-format of stuffer to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
 # .git-blame-ignore-revs
 # autopep8 python PR3268
 b9dbef317197b2f450b3e963fb4744cc4dc5e087
+# add clang-format of stuffer/
+918f0791002616f81bf0a5347de83bb0815101ac


### PR DESCRIPTION
Signed-off-by: Harrison Kaiser <uwaces@gmail.com>

### Resolved issues:

Related to clang format tracking issue.

### Description of changes: 

No code change.

### Call-outs:

You can use this with with `git blame` either via `git blame stuffer/s2n_stuffer.c --ignore-revs-file .git-blame-ignore-revs` or `git config blame.ignoreRevsFile .git-blame-ignore-revs`.


### Testing:

CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
