### PR TITLE
Add support for AWS-LC PQ KEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,11 @@ set(VERSION_MAJOR 1)
 set(VERSION_MINOR 0)
 set(VERSION_PATCH 0)
 
-
 option(S2N_NO_PQ "Disables all Post Quantum Crypto code. You likely want this
 for older compilers or uncommon platforms." OFF)
 option(S2N_NO_PQ_ASM "Turns off the ASM for PQ Crypto even if it's available for the toolchain.
 You likely want this on older compilers." OFF)
+option(S2N_AWSLC_KYBER_UNSTABLE "Prefer the AWS-LC provided PQ implementation." OFF)
 option(SEARCH_LIBCRYPTO "Set this if you want to let S2N search libcrypto for you,
 otherwise a crypto target needs to be defined." ON)
 option(UNSAFE_TREAT_WARNINGS_AS_ERRORS "Compiler warnings are treated as errors. Warnings may
@@ -425,6 +425,19 @@ try_compile(
 
 if (LIBCRYPTO_SUPPORTS_EVP_MD_CTX_SET_PKEY_CTX)
     target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_LIBCRYPTO_SUPPORTS_EVP_MD_CTX_SET_PKEY_CTX)
+endif()
+
+# Determine if Kyber512 implementation from AWS-LC is available
+try_compile(
+        LIBCRYPTO_SUPPORTS_EVP_KYBER_512
+        ${CMAKE_BINARY_DIR}
+        SOURCES "${CMAKE_CURRENT_LIST_DIR}/tests/features/evp_kyber_512.c"
+        LINK_LIBRARIES ${LINK_LIB} ${OS_LIBS}
+        COMPILE_DEFINITIONS "-Werror"
+)
+
+if(S2N_AWSLC_KYBER_UNSTABLE AND LIBCRYPTO_SUPPORTS_EVP_KYBER_512)
+    target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_LIBCRYPTO_SUPPORTS_KYBER512)
 endif()
 
 if (NOT DEFINED CMAKE_AR)

--- a/pq-crypto/kyber_r3/kyber512r3_kem.c
+++ b/pq-crypto/kyber_r3/kyber512r3_kem.c
@@ -24,7 +24,7 @@ S2N_ENSURE_PORTABLE_OPTIMIZATIONS
 *
 * Returns 0 (success)
 **************************************************/
-int s2n_kyber_512_r3_crypto_kem_keypair(unsigned char *pk, unsigned char *sk)
+int s2n_kyber_512_r3_crypto_kem_keypair(uint8_t *pk, uint8_t *sk)
 {
     POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 #if defined(S2N_KYBER512R3_AVX2_BMI2)
@@ -60,7 +60,7 @@ int s2n_kyber_512_r3_crypto_kem_keypair(unsigned char *pk, unsigned char *sk)
 *
 * Returns 0 (success)
 **************************************************/
-int s2n_kyber_512_r3_crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsigned char *pk)
+int s2n_kyber_512_r3_crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk)
 {
     POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
     uint8_t buf[2*S2N_KYBER_512_R3_SYMBYTES];
@@ -109,7 +109,7 @@ int s2n_kyber_512_r3_crypto_kem_enc(unsigned char *ct, unsigned char *ss, const 
 *
 * On failure, ss will contain a pseudo-random value.
 **************************************************/
-int s2n_kyber_512_r3_crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned char *sk)
+int s2n_kyber_512_r3_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk)
 {
     POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
     uint8_t buf[2*S2N_KYBER_512_R3_SYMBYTES];

--- a/pq-crypto/s2n_kyber_512_evp.c
+++ b/pq-crypto/s2n_kyber_512_evp.c
@@ -1,0 +1,86 @@
+/*
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+#include "s2n_kyber_512_evp.h"
+
+#include <openssl/evp.h>
+#include <stddef.h>
+
+#include "error/s2n_errno.h"
+#include "tls/s2n_kem.h"
+#include "utils/s2n_safety_macros.h"
+
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER512)
+int s2n_kyber_512_evp_generate_keypair(uint8_t *public_key, uint8_t *private_key) {
+    EVP_PKEY_CTX *kyber_pkey_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_KYBER512, NULL);
+    POSIX_GUARD_PTR(kyber_pkey_ctx);
+    POSIX_ENSURE(EVP_PKEY_keygen_init(kyber_pkey_ctx), S2N_FAILURE);
+
+    EVP_PKEY *kyber_pkey = NULL;
+    POSIX_ENSURE(EVP_PKEY_keygen(kyber_pkey_ctx, &kyber_pkey), S2N_FAILURE);
+
+    size_t public_key_size = S2N_KYBER_512_R3_PUBLIC_KEY_BYTES;
+    size_t private_key_size = S2N_KYBER_512_R3_SECRET_KEY_BYTES;
+    POSIX_ENSURE(EVP_PKEY_get_raw_public_key(kyber_pkey, public_key, &public_key_size), S2N_FAILURE);
+    POSIX_ENSURE(EVP_PKEY_get_raw_private_key(kyber_pkey, private_key, &private_key_size), S2N_FAILURE);
+
+    return S2N_SUCCESS;
+}
+
+int s2n_kyber_512_evp_encapsulate(uint8_t *ciphertext, uint8_t *shared_secret,
+                                  const uint8_t *public_key) {
+    size_t public_key_size = S2N_KYBER_512_R3_PUBLIC_KEY_BYTES;
+    EVP_PKEY *kyber_pkey = EVP_PKEY_new_raw_public_key(EVP_PKEY_KYBER512, NULL, public_key, public_key_size);
+    POSIX_GUARD_PTR(kyber_pkey);
+
+    EVP_PKEY_CTX *kyber_pkey_ctx = EVP_PKEY_CTX_new(kyber_pkey, NULL);
+    POSIX_GUARD_PTR(kyber_pkey_ctx);
+
+    size_t cipher_text_size = S2N_KYBER_512_R3_CIPHERTEXT_BYTES;
+    size_t shared_secret_size = S2N_KYBER_512_R3_SHARED_SECRET_BYTES;
+    POSIX_ENSURE(EVP_PKEY_encapsulate(kyber_pkey_ctx, ciphertext, &cipher_text_size, shared_secret,
+                                      &shared_secret_size), S2N_FAILURE);
+    return S2N_SUCCESS;
+}
+
+int s2n_kyber_512_evp_decapsulate(uint8_t *shared_secret, const uint8_t *ciphertext,
+                                  const uint8_t *private_key) {
+    size_t private_key_size = S2N_KYBER_512_R3_SECRET_KEY_BYTES;
+    EVP_PKEY *kyber_pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_KYBER512, NULL, private_key, private_key_size);
+    POSIX_GUARD_PTR(kyber_pkey);
+
+    EVP_PKEY_CTX *kyber_pkey_ctx = EVP_PKEY_CTX_new(kyber_pkey, NULL);
+    POSIX_GUARD_PTR(kyber_pkey_ctx);
+
+    size_t shared_secret_size = S2N_KYBER_512_R3_SHARED_SECRET_BYTES;
+    POSIX_ENSURE(EVP_PKEY_decapsulate(kyber_pkey_ctx, shared_secret, &shared_secret_size, (uint8_t *) ciphertext,
+                                      S2N_KYBER_512_R3_CIPHERTEXT_BYTES), S2N_FAILURE);
+    return S2N_SUCCESS;
+}
+#else
+int s2n_kyber_512_evp_generate_keypair(OUT uint8_t *public_key, OUT uint8_t *private_key) {
+    POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);
+}
+
+int s2n_kyber_512_evp_encapsulate(OUT uint8_t *ciphertext, OUT uint8_t *shared_secret,
+                                  IN const uint8_t *public_key) {
+    POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);
+}
+
+int s2n_kyber_512_evp_decapsulate(OUT uint8_t *shared_secret, IN const uint8_t *ciphertext,
+                                  IN const uint8_t *private_key) {
+    POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);
+}
+#endif

--- a/pq-crypto/s2n_kyber_512_evp.h
+++ b/pq-crypto/s2n_kyber_512_evp.h
@@ -1,0 +1,22 @@
+/*
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+#pragma once
+
+#include "tls/s2n_kem.h"
+
+int s2n_kyber_512_evp_generate_keypair(OUT uint8_t *public_key, OUT uint8_t *private_key);
+int s2n_kyber_512_evp_encapsulate(OUT uint8_t *ciphertext, OUT uint8_t *shared_secret, IN const uint8_t *public_key);
+int s2n_kyber_512_evp_decapsulate(OUT uint8_t *shared_secret, IN const uint8_t *ciphertext, IN const uint8_t *private_key);

--- a/pq-crypto/s2n_pq.c
+++ b/pq-crypto/s2n_pq.c
@@ -14,7 +14,9 @@
  */
 
 #include "s2n_pq.h"
+
 #include "crypto/s2n_openssl.h"
+#include "s2n_kyber_512_evp.h"
 
 static bool kyber512r3_avx2_bmi2_enabled = false;
 
@@ -97,6 +99,13 @@ bool s2n_pq_is_enabled() {
 #endif
 }
 
+bool s2n_libcrypto_supports_kyber_512() {
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER512)
+    return true;
+#else
+    return false;
+#endif
+}
 
 S2N_RESULT s2n_disable_kyber512r3_opt_avx2_bmi2() {
     kyber512r3_avx2_bmi2_enabled = false;

--- a/pq-crypto/s2n_pq.h
+++ b/pq-crypto/s2n_pq.h
@@ -26,4 +26,5 @@ S2N_RESULT s2n_try_enable_kyber512r3_opt_avx2_bmi2(void);
 S2N_RESULT s2n_disable_kyber512r3_opt_avx2_bmi2(void);
  
 bool s2n_pq_is_enabled(void);
+bool s2n_libcrypto_supports_kyber_512(void);
 S2N_RESULT s2n_pq_init(void);

--- a/tests/features/evp_kyber_512.c
+++ b/tests/features/evp_kyber_512.c
@@ -1,0 +1,21 @@
+/*
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+#include <openssl/evp.h>
+
+int main() {
+    EVP_PKEY_CTX *kyber_pkey_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_KYBER512, NULL);
+   return 0;
+}

--- a/tests/unit/s2n_pq_kem_kat_kyber_r3_test.c
+++ b/tests/unit/s2n_pq_kem_kat_kyber_r3_test.c
@@ -36,9 +36,14 @@ static const struct s2n_kem_kat_test_vector test_vectors[] = {
 
 int main() {
     BEGIN_TEST();
-    if (!s2n_pq_is_enabled()) {
+    if (!s2n_pq_is_enabled() || s2n_libcrypto_supports_kyber_512() ) {
         /* The KAT tests rely on the low-level PQ crypto functions;
-         * there is nothing to test if PQ is disabled. */
+         * there is nothing to test if PQ is disabled.
+         *
+         * In the case where we are using AWS-LC backed PQ, we rely on the
+         * KAT tests implemented in the AWS-LC repository. Implementing these
+         * tests within S2N is impossible due to the lack of AWS-LC interfaces
+         * for initializing the RNG. */
         END_TEST();
     }
     EXPECT_OK(s2n_pq_kem_kat_test(test_vectors, s2n_array_len(test_vectors)));

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -38,9 +38,9 @@ struct s2n_kem {
     const kem_shared_secret_size shared_secret_key_length;
     const kem_ciphertext_key_size ciphertext_length;
     /* NIST Post Quantum KEM submissions require the following API for compatibility */
-    int (*generate_keypair)(OUT unsigned char *public_key, OUT unsigned char *private_key);
-    int (*encapsulate)(OUT unsigned char *ciphertext, OUT unsigned char *shared_secret, IN const unsigned char *public_key);
-    int (*decapsulate)(OUT unsigned char *shared_secret, IN const unsigned char *ciphertext, IN const unsigned char *private_key);
+    int (*generate_keypair)(OUT uint8_t *public_key, OUT uint8_t *private_key);
+    int (*encapsulate)(OUT uint8_t *ciphertext, OUT uint8_t *shared_secret, IN const uint8_t *public_key);
+    int (*decapsulate)(OUT uint8_t *shared_secret, IN const uint8_t *ciphertext, IN const uint8_t *private_key);
 };
 
 struct s2n_kem_params {
@@ -135,6 +135,6 @@ extern int s2n_kem_recv_ciphertext(struct s2n_stuffer *in, struct s2n_kem_params
 #define S2N_KYBER_512_R3_SECRET_KEY_BYTES 1632
 #define S2N_KYBER_512_R3_CIPHERTEXT_BYTES 768
 #define S2N_KYBER_512_R3_SHARED_SECRET_BYTES 32
-int s2n_kyber_512_r3_crypto_kem_keypair(OUT unsigned char *pk, OUT unsigned char *sk);
-int s2n_kyber_512_r3_crypto_kem_enc(OUT unsigned char *ct, OUT unsigned char *ss, IN const unsigned char *pk);
-int s2n_kyber_512_r3_crypto_kem_dec(OUT unsigned char *ss, IN const unsigned char *ct, IN const unsigned char *sk);
+int s2n_kyber_512_r3_crypto_kem_keypair(OUT uint8_t *pk, OUT uint8_t *sk);
+int s2n_kyber_512_r3_crypto_kem_enc(OUT uint8_t *ct, OUT uint8_t *ss, IN const uint8_t *pk);
+int s2n_kyber_512_r3_crypto_kem_dec(OUT uint8_t *ss, IN const uint8_t *ct, IN const uint8_t *sk);


### PR DESCRIPTION
### Description of changes: 

Describe s2n’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.

S2N contains an implementation of the Kyber key encapsulation mechanism (KEM) which is made redundant by an equivalent implementation in AWS-LC. We introduce `pq-crypto/s2n_kyber_evp.{c/h}` which implement the KEM functions using AWS-LC's EVP interface. We also introduce a forward compatibility layer which will prefer the AWS-LC implementation if it's available at compile time. Once this changeset is deployed to all known consumers, we can remove the redundant Kyber implementation within S2N. This will free the S2N maintainers of the need to maintain/optimize the redundant implementation of the Kyber algorithm.

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 

- This is my first contribution to this code base so please flag anything that's out of step with convention/style. In particular, I'd like some pointers around: legal obligations with these license headers, use of preprocessor definitions, naming convention, and directory choice.
- The `s2n_pq_kem_kat_kyber_r3_test` test case is now skipped when S2N is built using AWS-LC's Kyber implementation. A redundant implementation of this test exists in [AWS-LC](https://github.com/awslabs/aws-lc/blob/ed738e7201d22db96ea8bd14e46b803ef0566c18/crypto/evp_extra/pq_kem_kat_tests_kyber512.cc). Fixing this for S2N will require seeding AWS-LC's RNG properly to force determinism in the Kyber key generation algorithm. This level of depth is not appropriate in the case where S2N is not using its own Kyber implementation. Other S2N unit tests validate that AWS-LC's Kyber implementation can generate a key and use it to perform encapsulate/decapsulate operations.
- This depends on a related [PR to AWS-LC](https://github.com/awslabs/aws-lc/pull/691) which bumps `AWSLC_API_VERSION`.
- Looks like the `cppcheck` linter is broken, expected?

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

- Built the source and successfully ran all unit tests against the following configurations:
  - Mac, OpenSSL-1.1, S2N_NO_PQ defined.
  - Mac, OpenSSL-1.1. Validated that the S2N Kyber implementation was used.
  - Mac, AWS-LC, with `AWSLC_API_VERSION = 19`. Validated that the S2N Kyber implementation was used.
  - Mac, AWS-LC with  `AWSLC_API_VERSION = 20`. Validated that the AWS-LC implementation was used.
  - Ubuntu,  AWS-LC with  `AWSLC_API_VERSION = 20`.

Still learning how the CI tests are setup, but will track that down and make sure we didn't cause any regressions there.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

No, but I did alphabetize the includes in a source file. It all still builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
