### PR TITLE
Fix SAW overflow precond values for bad magic mod

### DIFF
--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -84,7 +84,7 @@ run_integration_v2_tests() {
 }
 
 # Run Multiple tests on one flag.
-if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMACPlus" ]] && [[ "$OS_NAME" == "linux" ]]; then make -C tests/saw tmp/verify_HMAC.log tmp/verify_drbg.log failure-tests; fi
+if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMACPlus" ]] && [[ "$OS_NAME" == "linux" ]]; then make -C tests/saw tmp/verify_HMAC_all.log tmp/verify_drbg.log failure-tests; fi
 
 # Run Individual tests
 if [[ "$TESTS" == "ALL" || "$TESTS" == "unit" ]]; then cmake . -Bbuild -DCMAKE_PREFIX_PATH=$LIBCRYPTO_ROOT -D${CMAKE_PQ_OPTION} -DS2N_BLOCK_NONPORTABLE_OPTIMIZATIONS=True -DBUILD_SHARED_LIBS=on; cmake --build ./build; make -C build test ARGS=-j$(nproc); fi

--- a/tests/saw/HMAC/spec/HMAC.saw
+++ b/tests/saw/HMAC/spec/HMAC.saw
@@ -283,6 +283,7 @@ let hmac_invariants
              , digest_size     : Int
              , block_size      : Int
              , hash_block_size : Int
+             , highest_32_bit  : Int
              }) = do {
     // Specify the HMAC algorithm.
     crucible_equal (crucible_term {{ st.alg }}) (crucible_term cfg.hmac_alg);
@@ -304,6 +305,7 @@ let hmac_init_spec
              , digest_size     : Int
              , block_size      : Int
              , hash_block_size : Int
+             , highest_32_bit  : Int
              }) = do {
     alg0 <- crucible_fresh_var "alg" (llvm_int 32);
     hash_block_size0 <- crucible_fresh_var "hash_block_size" (llvm_int 16);
@@ -341,6 +343,7 @@ let hmac_update_spec
              , digest_size     : Int
              , block_size      : Int
              , hash_block_size : Int
+             , highest_32_bit  : Int
              }) = do {
     let digest_size = cfg.digest_size;
     let block_size = cfg.block_size;
@@ -355,7 +358,8 @@ let hmac_update_spec
 
     size <- crucible_fresh_var "size" (llvm_int 32);
     let uint32_max = {{~0 : [32]}};
-    let highest_32_bit = {{4294949760 : [32]}};
+    let highest_32_bit = cfg.highest_32_bit;
+    let highest_32_bit = {{ `highest_32_bit : [32] }};
     crucible_precond {{ size <= uint32_max - highest_32_bit }};
     crucible_precond {{ ((highest_32_bit + size) % (0 # st0.hash_block_size)) <= uint32_max - st0.currently_in_hash_block }};
 
@@ -378,6 +382,7 @@ let hmac_digest_spec
              , digest_size     : Int
              , block_size      : Int
              , hash_block_size : Int
+             , highest_32_bit  : Int
              }) = do {
     (out, pout) <- ptr_to_fresh "out" (llvm_array cfg.digest_size (llvm_int 8));
 
@@ -413,6 +418,7 @@ let hmac_digest_size_spec
              , digest_size     : Int
              , block_size      : Int
              , hash_block_size : Int
+             , highest_32_bit  : Int
              }) = do {
     psize <- crucible_alloc (llvm_int 8);
     crucible_execute_func [crucible_term cfg.hmac_alg, psize];

--- a/tests/saw/HMAC/spec/verify_HMAC.saw
+++ b/tests/saw/HMAC/spec/verify_HMAC.saw
@@ -21,9 +21,9 @@
 
 enable_experimental;
 
-include "HMAC/spec/HMAC.saw";
+include "HMAC.saw";
 
-m <- llvm_load_module "bitcode/all_llvm.bc";
+m <- llvm_load_module "../../bitcode/all_llvm.bc";
 
 // Verifies s2n_hmac_init at 3 key sizes in the given config
 let verify_s2n_hmac_init
@@ -32,6 +32,7 @@ let verify_s2n_hmac_init
              , digest_size     : Int
              , block_size      : Int
              , hash_block_size : Int
+             , highest_32_bit  : Int
              }) = do {
   set_base 16;
   
@@ -73,6 +74,7 @@ let verify_s2n_hmac_update
              , digest_size     : Int
              , block_size      : Int
              , hash_block_size : Int
+             , highest_32_bit  : Int
              }) = do {
   set_base 16;
   
@@ -92,6 +94,7 @@ let verify_s2n_hmac_digest
              , digest_size     : Int
              , block_size      : Int
              , hash_block_size : Int
+             , highest_32_bit  : Int
              }) = do {
   set_base 16;
   
@@ -122,6 +125,7 @@ let none_cfg =
   , digest_size     = 0
   , block_size      = 64
   , hash_block_size = 64
+  , highest_32_bit  = 4294949760
   };
 
 // let sslv3_md5_cfg = <not supported>
@@ -132,6 +136,7 @@ let md5_cfg =
   , digest_size     = 16
   , block_size      = 64
   , hash_block_size = 64
+  , highest_32_bit  = 4294949760
   };
 
 // let sslv3_sha1_cfg = <not supported>
@@ -142,6 +147,7 @@ let sha1_cfg =
   , digest_size     = 20
   , block_size      = 64
   , hash_block_size = 64
+  , highest_32_bit  = 4294949760
   };
 
 let sha224_cfg =
@@ -150,6 +156,7 @@ let sha224_cfg =
   , digest_size     = 28
   , block_size      = 64
   , hash_block_size = 64
+  , highest_32_bit  = 4294949760
   };
 
 let sha256_cfg =
@@ -158,6 +165,7 @@ let sha256_cfg =
   , digest_size     = 32
   , block_size      = 64
   , hash_block_size = 64
+  , highest_32_bit  = 4294949760
   };
 
 let sha384_cfg =
@@ -166,6 +174,7 @@ let sha384_cfg =
   , digest_size     = 48
   , block_size      = 128
   , hash_block_size = 128
+  , highest_32_bit  = 4294949760
   };
 
 let sha512_cfg =
@@ -174,6 +183,7 @@ let sha512_cfg =
   , digest_size     = 64
   , block_size      = 128
   , hash_block_size = 128
+  , highest_32_bit  = 4294949760
   };
 
 let verify_s2n_hmac_at_config
@@ -182,6 +192,7 @@ let verify_s2n_hmac_at_config
              , digest_size     : Int
              , block_size      : Int
              , hash_block_size : Int
+             , highest_32_bit  : Int
              }) = do {
   verify_s2n_hmac_init cfg;
   verify_s2n_hmac_update cfg;
@@ -193,5 +204,3 @@ let verify_s2n_hmac = do {
   
   for configs (\config -> verify_s2n_hmac_at_config config);
 };
-
-verify_s2n_hmac;

--- a/tests/saw/Makefile
+++ b/tests/saw/Makefile
@@ -107,7 +107,7 @@ failure_tests/sha_%.log : bitcode/sha_%.bc
         #this might not be necessary
 	cp $< bitcode/all_llvm.bc 
 	set -o pipefail; \
-	! (saw verify_HMAC.saw 2>&1 | tee $@)
+	! (saw verify_HMAC_bad_magic_mod.saw 2>&1 | tee $@)
 	grep "error: in _SAW_verify_prestate" $@
 
 failure_tests/tls_%.log : bitcode/tls_%.bc

--- a/tests/saw/failure_tests/sha_bad_magic_mod.patch
+++ b/tests/saw/failure_tests/sha_bad_magic_mod.patch
@@ -1,26 +1,13 @@
 diff --git a/crypto/s2n_hmac.c b/crypto/s2n_hmac.c
-index 29ded952..f7a24a01 100644
+index 29ded952..b4a92583 100644
 --- a/crypto/s2n_hmac.c
 +++ b/crypto/s2n_hmac.c
-@@ -266,8 +266,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
+@@ -266,7 +266,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
       * input. On some platforms, including Intel, the operation can take a
       * smaller number of cycles if the input is "small".
       */
 -    const uint32_t HIGHEST_32_BIT = 4294949760;
--    POSIX_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
 +    const uint32_t HIGHEST_32_BIT = 4294949761;
+     POSIX_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
      uint32_t value = (HIGHEST_32_BIT + size) % state->hash_block_size;
      POSIX_GUARD(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
-     state->currently_in_hash_block %= state->hash_block_size;
-diff --git a/utils/s2n_safety.c b/utils/s2n_safety.c
-index b26e2d9c..e662c8da 100644
---- a/utils/s2n_safety.c
-+++ b/utils/s2n_safety.c
-@@ -198,7 +198,6 @@ int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out)
- {
-     POSIX_ENSURE_REF(out);
-     uint64_t result = ((uint64_t) a) + ((uint64_t) b);
--    POSIX_ENSURE(result <= UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
-     *out = (uint32_t) result;
-     return S2N_SUCCESS;
- }

--- a/tests/saw/verify_HMAC_all.saw
+++ b/tests/saw/verify_HMAC_all.saw
@@ -1,0 +1,4 @@
+
+include "HMAC/spec/verify_HMAC.saw";
+
+verify_s2n_hmac;

--- a/tests/saw/verify_HMAC_bad_magic_mod.saw
+++ b/tests/saw/verify_HMAC_bad_magic_mod.saw
@@ -1,6 +1,11 @@
 
 include "HMAC/spec/verify_HMAC.saw";
 
+/*
+ * The sha_bad_magic_mod patch changes the highest_32_bit value in s2n_hmac_update from 4294949760 to 4294949761. To
+ * ensure SAW tests this function with the correct values when this patch is applied, the highest_32_bit value is
+ * increased in SAW as well, via this config.
+ */
 let sha256_bad_magic_mod_cfg =
   { name            = "SHA256_bad_magic_mod"
   , hmac_alg        = {{ S2N_HMAC_SHA256 }}

--- a/tests/saw/verify_HMAC_bad_magic_mod.saw
+++ b/tests/saw/verify_HMAC_bad_magic_mod.saw
@@ -1,0 +1,13 @@
+
+include "HMAC/spec/verify_HMAC.saw";
+
+let sha256_bad_magic_mod_cfg =
+  { name            = "SHA256_bad_magic_mod"
+  , hmac_alg        = {{ S2N_HMAC_SHA256 }}
+  , digest_size     = 32
+  , block_size      = 64
+  , hash_block_size = 64
+  , highest_32_bit  = 4294949761
+  };
+
+verify_s2n_hmac_at_config sha256_bad_magic_mod_cfg;


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

In https://github.com/aws/s2n-tls/pull/3617, the SAW bad magic mod failure test was updated to remove safety macros in the patch to avoid bailing due to overflow before the proof could finish. However, it seems that overflow was occurring due to incorrect preconditions, rather than unnecessary safety macros. 

The following preconditions are used to determine the correct values to provide to `s2n_hmac_update`:
https://github.com/aws/s2n-tls/blob/ee3df080077242b6b765d02b21da59e4194ee485/tests/saw/HMAC/spec/HMAC.saw#L359-L360

The same checks also exists in s2n-tls, which caused the function to fail due to overflow.

SAW sets the values of both `size` and `st0.currently_in_hash_block`. In the bad magic mod patch, `highest_32_bit` is incremented by 1 in s2n-tls. However, in SAW, this value remains the same. This means the proof is testing the function with invalid values.

Consider the following case, where `st0.hash_block_size = 64`, and SAW sets `st0.currently_in_hash_block = uint32_max`, causing the right side of the comparison to evaluate to 0. In this case, valid values for the left side of the comparison become multiples of 64. However, since `highest_32_bit` is changed in s2n-tls from the bad magic mod patch, SAW finds a different value for `size` that causes a multiple of 64 to occur. For example, in SAW, a valid value for `size` is 0, since `4294949760 % 64 = 0`, but in s2n-tls with the bad magic mod patch, `size = 0` is not valid, since `4294949761 % 64 = 1`.

This PR updates SAW to provide only valid values to `s2n_hmac_update` with the bad magic mod patch.

### Call-outs:

I implemented this by adding a highest_32_bit value to the hmac configs, and then calling a separate config with the altered highest_32_bit value in the bad magic mod failure test. I'm not sure if there's a better way to do this or not.

The bad magic mod test needs to run SAW with a special config that sets a different `highest_32_bit` value. To do this, the call to `verify_s2n_hmac` was moved to a separate file that's called by the makefile for the normal proof run, which allows this test to include `verify_HMAC.saw` and call `verify_s2n_hmac_at_config`.

### Testing:

Codebuild run for the single failure test:
- [sha_bad_magic_mod](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nGeneralBatch/build/s2nGeneralBatch%3Aea3d0c29-6e37-420d-9299-50e2fad6d7fa?region=us-west-2)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
