### PR TITLE
bindings: Fix clippy issues and formatting in bindings

### DIFF
--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -156,7 +156,7 @@ impl Builder {
         crate::init::init();
         let config = unsafe { s2n_config_new().into_result() }.unwrap();
 
-        let context = Box::new(Context::default());
+        let context = Box::<Context>::default();
         let context = Box::into_raw(context) as *mut c_void;
 
         unsafe {

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -83,7 +83,7 @@ impl Connection {
     }
 
     fn init_context(&mut self) {
-        let context = Box::new(Context::default());
+        let context = Box::<Context>::default();
         let context = Box::into_raw(context) as *mut c_void;
         // allocate a new context object
         unsafe {

--- a/bindings/rust/s2n-tls/src/pool.rs
+++ b/bindings/rust/s2n-tls/src/pool.rs
@@ -311,9 +311,10 @@ mod tests {
         let conn = pooled_conn.deref();
         assert_eq!(pooled_conn.config(), conn.config());
 
-        let mut mut_pooled_conn: PooledConnection<ConfigPoolRef> = PooledConnection::new(&config_pool)?;
+        let mut mut_pooled_conn: PooledConnection<ConfigPoolRef> =
+            PooledConnection::new(&config_pool)?;
         let waker = futures_test::task::new_count_waker().0;
-        mut_pooled_conn.set_waker(Some(&waker.clone()))?;
+        mut_pooled_conn.set_waker(Some(&waker))?;
         assert!(mut_pooled_conn.waker().unwrap().will_wake(&waker));
 
         Ok(())


### PR DESCRIPTION
### Description of changes: 

This change fixed a couple Clippy lints and rust formatting issues in the Rust bindings:

```rust
error: redundant clone
Error:    --> s2n-tls/src/pool.rs:316:46
    |
316 |         mut_pooled_conn.set_waker(Some(&waker.clone()))?;
    |                                              ^^^^^^^^ help: remove this
    |
    = note: `-D clippy::redundant-clone` implied by `-D warnings`
note: cloned value is neither consumed nor mutated
   --> s2n-tls/src/pool.rs:316:41
    |
316 |         mut_pooled_conn.set_waker(Some(&waker.clone()))?;
    |                                         ^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone
```

```rust
error: `Box::new(_)` of default value
   --> s2n-tls/src/config.rs:159:23
    |
159 |         let context = Box::new(Context::default());
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::<config::Context>::default()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#box_default
    = note: `-D clippy::box-default` implied by `-D warnings`
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
