### PR TITLE
Test for legacy version vs SupportedVersions priority

### DIFF
--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -378,7 +378,7 @@ static int s2n_aead_cipher_aes_gcm_destroy_key(struct s2n_session_key *key)
 
 #endif
 
-struct s2n_cipher s2n_aes128_gcm = {
+const struct s2n_cipher s2n_aes128_gcm = {
     .key_material_size = S2N_TLS_AES_128_GCM_KEY_LEN,
     .type = S2N_AEAD,
     .io.aead = {
@@ -394,7 +394,7 @@ struct s2n_cipher s2n_aes128_gcm = {
     .destroy_key = s2n_aead_cipher_aes_gcm_destroy_key,
 };
 
-struct s2n_cipher s2n_aes256_gcm = {
+const struct s2n_cipher s2n_aes256_gcm = {
     .key_material_size = S2N_TLS_AES_256_GCM_KEY_LEN,
     .type = S2N_AEAD,
     .io.aead = {
@@ -411,7 +411,7 @@ struct s2n_cipher s2n_aes256_gcm = {
 };
 
 /* TLS 1.3 GCM ciphers */
-struct s2n_cipher s2n_tls13_aes128_gcm = {
+const struct s2n_cipher s2n_tls13_aes128_gcm = {
     .key_material_size = S2N_TLS_AES_128_GCM_KEY_LEN,
     .type = S2N_AEAD,
     .io.aead = {
@@ -427,7 +427,7 @@ struct s2n_cipher s2n_tls13_aes128_gcm = {
     .destroy_key = s2n_aead_cipher_aes_gcm_destroy_key,
 };
 
-struct s2n_cipher s2n_tls13_aes256_gcm = {
+const struct s2n_cipher s2n_tls13_aes256_gcm = {
     .key_material_size = S2N_TLS_AES_256_GCM_KEY_LEN,
     .type = S2N_AEAD,
     .io.aead = {

--- a/crypto/s2n_aead_cipher_chacha20_poly1305.c
+++ b/crypto/s2n_aead_cipher_chacha20_poly1305.c
@@ -262,7 +262,7 @@ static int s2n_aead_chacha20_poly1305_destroy_key(struct s2n_session_key *key)
 
 #endif
 
-struct s2n_cipher s2n_chacha20_poly1305 = {
+const struct s2n_cipher s2n_chacha20_poly1305 = {
     .key_material_size = S2N_TLS_CHACHA20_POLY1305_KEY_LEN,
     .type = S2N_AEAD,
     .io.aead = {

--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -90,7 +90,7 @@ static int s2n_cbc_cipher_3des_destroy_key(struct s2n_session_key *key)
     return 0;
 }
 
-struct s2n_cipher s2n_3des = {
+const struct s2n_cipher s2n_3des = {
     .key_material_size = 24,
     .type = S2N_CBC,
     .io.cbc = {

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -116,7 +116,7 @@ static int s2n_cbc_cipher_aes_destroy_key(struct s2n_session_key *key)
     return 0;
 }
 
-struct s2n_cipher s2n_aes128 = {
+const struct s2n_cipher s2n_aes128 = {
     .key_material_size = 16,
     .type = S2N_CBC,
     .io.cbc = {
@@ -131,7 +131,7 @@ struct s2n_cipher s2n_aes128 = {
     .destroy_key = s2n_cbc_cipher_aes_destroy_key,
 };
 
-struct s2n_cipher s2n_aes256 = {
+const struct s2n_cipher s2n_aes256 = {
     .key_material_size = 32,
     .type = S2N_CBC,
     .io.cbc = {

--- a/crypto/s2n_cipher.h
+++ b/crypto/s2n_cipher.h
@@ -37,7 +37,7 @@ struct s2n_session_key {
 #endif
 };
 
-struct s2n_stream_cipher {
+const struct s2n_stream_cipher {
     int (*decrypt) (struct s2n_session_key * key, struct s2n_blob * in, struct s2n_blob * out);
     int (*encrypt) (struct s2n_session_key * key, struct s2n_blob * in, struct s2n_blob * out);
 };
@@ -87,18 +87,18 @@ struct s2n_cipher {
 extern int s2n_session_key_alloc(struct s2n_session_key *key);
 extern int s2n_session_key_free(struct s2n_session_key *key);
 
-extern struct s2n_cipher s2n_null_cipher;
-extern struct s2n_cipher s2n_rc4;
-extern struct s2n_cipher s2n_aes128;
-extern struct s2n_cipher s2n_aes256;
-extern struct s2n_cipher s2n_3des;
-extern struct s2n_cipher s2n_aes128_gcm;
-extern struct s2n_cipher s2n_aes256_gcm;
-extern struct s2n_cipher s2n_aes128_sha;
-extern struct s2n_cipher s2n_aes256_sha;
-extern struct s2n_cipher s2n_aes128_sha256;
-extern struct s2n_cipher s2n_aes256_sha256;
-extern struct s2n_cipher s2n_chacha20_poly1305;
+extern const struct s2n_cipher s2n_null_cipher;
+extern const struct s2n_cipher s2n_rc4;
+extern const struct s2n_cipher s2n_aes128;
+extern const struct s2n_cipher s2n_aes256;
+extern const struct s2n_cipher s2n_3des;
+extern const struct s2n_cipher s2n_aes128_gcm;
+extern const struct s2n_cipher s2n_aes256_gcm;
+extern const struct s2n_cipher s2n_aes128_sha;
+extern const struct s2n_cipher s2n_aes256_sha;
+extern const struct s2n_cipher s2n_aes128_sha256;
+extern const struct s2n_cipher s2n_aes256_sha256;
+extern const struct s2n_cipher s2n_chacha20_poly1305;
 
-extern struct s2n_cipher s2n_tls13_aes128_gcm;
-extern struct s2n_cipher s2n_tls13_aes256_gcm;
+extern const struct s2n_cipher s2n_tls13_aes128_gcm;
+extern const struct s2n_cipher s2n_tls13_aes256_gcm;

--- a/crypto/s2n_cipher.h
+++ b/crypto/s2n_cipher.h
@@ -37,7 +37,7 @@ struct s2n_session_key {
 #endif
 };
 
-const struct s2n_stream_cipher {
+struct s2n_stream_cipher {
     int (*decrypt) (struct s2n_session_key * key, struct s2n_blob * in, struct s2n_blob * out);
     int (*encrypt) (struct s2n_session_key * key, struct s2n_blob * in, struct s2n_blob * out);
 };

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -303,7 +303,7 @@ static int s2n_composite_cipher_aes_sha_destroy_key(struct s2n_session_key *key)
     return 0;
 }
 
-struct s2n_cipher s2n_aes128_sha = {
+const struct s2n_cipher s2n_aes128_sha = {
     .key_material_size = 16,
     .type = S2N_COMPOSITE,
     .io.comp = {
@@ -321,7 +321,7 @@ struct s2n_cipher s2n_aes128_sha = {
     .destroy_key = s2n_composite_cipher_aes_sha_destroy_key,
 };
 
-struct s2n_cipher s2n_aes256_sha = {
+const struct s2n_cipher s2n_aes256_sha = {
     .key_material_size = 32,
     .type = S2N_COMPOSITE,
     .io.comp = {
@@ -339,7 +339,7 @@ struct s2n_cipher s2n_aes256_sha = {
     .destroy_key = s2n_composite_cipher_aes_sha_destroy_key,
 };
 
-struct s2n_cipher s2n_aes128_sha256 = {
+const struct s2n_cipher s2n_aes128_sha256 = {
     .key_material_size = 16,
     .type = S2N_COMPOSITE,
     .io.comp = {
@@ -357,7 +357,7 @@ struct s2n_cipher s2n_aes128_sha256 = {
     .destroy_key = s2n_composite_cipher_aes_sha_destroy_key,
 };
 
-struct s2n_cipher s2n_aes256_sha256 = {
+const struct s2n_cipher s2n_aes256_sha256 = {
     .key_material_size = 32,
     .type = S2N_COMPOSITE,
     .io.comp = {

--- a/crypto/s2n_stream_cipher_null.c
+++ b/crypto/s2n_stream_cipher_null.c
@@ -50,7 +50,7 @@ static int s2n_stream_cipher_null_init(struct s2n_session_key *key)
     return 0;
 }
 
-struct s2n_cipher s2n_null_cipher = {
+const struct s2n_cipher s2n_null_cipher = {
     .type = S2N_STREAM,
     .key_material_size = 0,
     .io.stream = {

--- a/crypto/s2n_stream_cipher_rc4.c
+++ b/crypto/s2n_stream_cipher_rc4.c
@@ -125,7 +125,7 @@ static int s2n_stream_cipher_rc4_destroy_key(struct s2n_session_key *key)
 
 #endif /* S2N_LIBCRYPTO_SUPPORTS_EVP_RC4 */
 
-struct s2n_cipher s2n_rc4 = {
+const struct s2n_cipher s2n_rc4 = {
     .type = S2N_STREAM,
     .key_material_size = 16,
     .io.stream = {


### PR DESCRIPTION
### Resolved issues:

https://github.com/aws/s2n-tls/issues/1417

### Description of changes: 

Adding a functional test to that creates a ClientHello with a small protocol version (TLS10) but a supported_versions extension that includes TLS13. Processing the ClientHello to verify that the client and actual protocol versions are set properly.

### Call-outs:

### Testing:

All tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
