### PR TITLE
Removes double semicolons and expands simple_mistakes.sh

### DIFF
--- a/codebuild/bin/grep_simple_mistakes.sh
+++ b/codebuild/bin/grep_simple_mistakes.sh
@@ -149,10 +149,12 @@ done
 
 #############################################
 # Assert that we didn't accidentally add an extra semicolon when ending a line.
+# This also errors when there is whitespace in-between semicolons, as that is an empty
+# statement and usually not purposeful.
 #############################################
 S2N_FILES_ASSERT_DOUBLE_SEMICOLON=$(find "$PWD" -type f -name "s2n*.[ch]" -not -path "*/bindings/*")
 for file in $S2N_FILES_ASSERT_DOUBLE_SEMICOLON; do
-  RESULT_DOUBLE_SEMICOLON=`grep -Ern ';{2,}' $file`
+  RESULT_DOUBLE_SEMICOLON=`grep -Ern ';[[:space:]]*;' $file`
   if [ "${#RESULT_DOUBLE_SEMICOLON}" != "0" ]; then
     FAILED=1
     printf "\e[1;34mFound a double semicolon in $file:\e[0m\n$RESULT_DOUBLE_SEMICOLON\n\n"

--- a/codebuild/bin/grep_simple_mistakes.sh
+++ b/codebuild/bin/grep_simple_mistakes.sh
@@ -148,6 +148,18 @@ for file in $S2N_FILES_ASSERT_VARIABLE_NAME_INDEX; do
 done
 
 #############################################
+# Assert that we didn't accidentally add an extra semicolon when ending a line.
+#############################################
+S2N_FILES_ASSERT_DOUBLE_SEMICOLON=$(find "$PWD" -type f -name "s2n*.[ch]" -not -path "*/bindings/*")
+for file in $S2N_FILES_ASSERT_DOUBLE_SEMICOLON; do
+  RESULT_DOUBLE_SEMICOLON=`grep -Ern ';{2,}' $file`
+  if [ "${#RESULT_DOUBLE_SEMICOLON}" != "0" ]; then
+    FAILED=1
+    printf "\e[1;34mFound a double semicolon in $file:\e[0m\n$RESULT_DOUBLE_SEMICOLON\n\n"
+  fi
+done
+
+#############################################
 ## Assert that there are no new uses of S2N_ERROR_IF
 # TODO add crypto, tls (see https://github.com/aws/s2n-tls/issues/2635)
 #############################################

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -165,8 +165,8 @@ static int s2n_low_level_hash_init(struct s2n_hash_state *state, s2n_hash_algori
         POSIX_GUARD_OSSL(SHA512_Init(&state->digest.low_level.sha512), S2N_ERR_HASH_INIT_FAILED);
         break;
     case S2N_HASH_MD5_SHA1:
-        POSIX_GUARD_OSSL(SHA1_Init(&state->digest.low_level.md5_sha1.sha1), S2N_ERR_HASH_INIT_FAILED);;
-        POSIX_GUARD_OSSL(MD5_Init(&state->digest.low_level.md5_sha1.md5), S2N_ERR_HASH_INIT_FAILED);;
+        POSIX_GUARD_OSSL(SHA1_Init(&state->digest.low_level.md5_sha1.sha1), S2N_ERR_HASH_INIT_FAILED);
+        POSIX_GUARD_OSSL(MD5_Init(&state->digest.low_level.md5_sha1.md5), S2N_ERR_HASH_INIT_FAILED);
         break;
 
     default:

--- a/tests/testlib/s2n_pq_kat_test_utils.c
+++ b/tests/testlib/s2n_pq_kat_test_utils.c
@@ -91,7 +91,6 @@ static S2N_RESULT s2n_get_random_data_for_pq_kat_tests(struct s2n_blob *blob)
         struct s2n_blob slice = { 0 };
 
         RESULT_GUARD_POSIX(s2n_blob_slice(blob, &slice, offset, MIN(remaining, S2N_DRBG_GENERATE_LIMIT)));
-        ;
         RESULT_GUARD(s2n_drbg_generate_for_pq_kat_tests(&drbg_for_pq_kats, &slice));
 
         remaining -= slice.size;

--- a/tests/unit/s2n_array_test.c
+++ b/tests/unit/s2n_array_test.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_array_insert(array, 16, (void **)&insert_element));
         EXPECT_NOT_NULL(insert_element);
         insert_element->first = 20;
-        insert_element->second = 'a' + 20;;
+        insert_element->second = 'a' + 20;
 
         /* Validate array parameters */
         EXPECT_OK(s2n_array_capacity(array, &capacity));

--- a/tests/unit/s2n_extensions_server_key_share_select_test.c
+++ b/tests/unit/s2n_extensions_server_key_share_select_test.c
@@ -357,7 +357,7 @@ int main() {
             /* Server would have initially chosen kem_group[0] when processing the supported_groups extension */
             EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             struct s2n_kem_group_params *server_params = &server_conn->kex_params.server_kem_group_params;
-            const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];;
+            const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];
             server_params->kem_group = kem_group0;
             server_params->kem_params.kem = kem_group0->kem;
             server_params->ecc_params.negotiated_curve = kem_group0->curve;
@@ -411,7 +411,7 @@ int main() {
             /* Server would have initially chosen kem_group[0] when processing the supported_groups extension */
             EXPECT_NULL(server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
             struct s2n_kem_group_params *server_params = &server_conn->kex_params.server_kem_group_params;
-            const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];;
+            const struct s2n_kem_group *kem_group0 = kem_pref->tls13_kem_groups[0];
             server_params->kem_group = kem_group0;
             server_params->kem_params.kem = kem_group0->kem;
             server_params->ecc_params.negotiated_curve = kem_group0->curve;

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -160,7 +160,7 @@ static int s2n_config_update_domain_name_to_cert_map(struct s2n_config *config,
         POSIX_GUARD_RESULT(s2n_map_add(domain_name_to_cert_map, name, &s2n_map_value));
         POSIX_GUARD_RESULT(s2n_map_complete(domain_name_to_cert_map));
     } else {
-        struct certs_by_type *value = (void *) s2n_map_value.data;;
+        struct certs_by_type *value = (void *) s2n_map_value.data;
         if (value->certs[cert_type] == NULL) {
             value->certs[cert_type] = cert_key_pair;
         } else if (config->cert_tiebreak_cb) {


### PR DESCRIPTION
### Resolved issues:

 N/A
### Description of changes: 

I added a simple_mistakes check for this case because it is really hard to catch during PR review. I don't think this can be caught by the clang formatter; it doesn't alter any behavior. But lmk if there's a more efficient way of doing this.
### Call-outs:
N/A
### Testing:

simple_mistakes script fails until the double semicolons are removed.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
