### PR TITLE
Bump rust bindings for 1.3.29 release

### DIFF
--- a/bindings/rust/s2n-tls-sys/Cargo.toml
+++ b/bindings/rust/s2n-tls-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-sys"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.0.19"
+version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
 links = "s2n-tls"

--- a/bindings/rust/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/s2n-tls-tokio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-tokio"
 description = "An implementation of TLS streams for Tokio built on top of s2n-tls"
-version = "0.0.19"
+version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
 repository = "https://github.com/aws/s2n-tls"
@@ -13,7 +13,7 @@ default = []
 [dependencies]
 errno = { version = "0.2" }
 libc = { version = "0.2" }
-s2n-tls = { version = "=0.0.19", path = "../s2n-tls" }
+s2n-tls = { version = "=0.1.0", path = "../s2n-tls" }
 tokio = { version = "1", features = ["net", "time"] }
 
 [dev-dependencies]

--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.0.19"
+version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
 repository = "https://github.com/aws/s2n-tls"
@@ -17,7 +17,7 @@ testing = ["bytes"]
 bytes = { version = "1", optional = true }
 errno = { version = "0.2" }
 libc = "0.2"
-s2n-tls-sys = { version = "=0.0.19", path = "../s2n-tls-sys", features = ["internal"] }
+s2n-tls-sys = { version = "=0.1.0", path = "../s2n-tls-sys", features = ["internal"] }
 
 [dev-dependencies]
 bytes = { version = "1" }


### PR DESCRIPTION
This change bumps the rust bindings to 0.1.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
