### PR TITLE
Fix default X509 store flags

### DIFF
--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -71,8 +71,6 @@ int s2n_x509_trust_store_from_system_defaults(struct s2n_x509_trust_store *store
         POSIX_BAIL(S2N_ERR_X509_TRUST_STORE);
     }
 
-    X509_STORE_set_flags(store->trust_store, X509_VP_FLAG_DEFAULT);
-
     return 0;
 }
 
@@ -127,8 +125,7 @@ int s2n_x509_trust_store_from_ca_file(struct s2n_x509_trust_store *store, const 
      * without a trust anchor. However if you call this function, the assumption is you trust ca_file or path and if a certificate
      * is encountered that's in that path, it should be trusted. The following flag tells libcrypto to not care that the cert
      * is missing a root anchor. */
-    unsigned long flags = X509_VP_FLAG_DEFAULT;
-    flags |=  X509_V_FLAG_PARTIAL_CHAIN;
+    unsigned long flags = X509_V_FLAG_PARTIAL_CHAIN;
     X509_STORE_set_flags(store->trust_store, flags);
 
     return 0;


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

Currently, when a trust store is created in s2n-tls, via the trust store APIs, the X509 store flags are initialized to `X509_VP_FLAG_DEFAULT`. However, this is not the intended use of this flag. This flag is an inheritance flag, intended to be set with `X509_VERIFY_PARAM_set_inh_flags`. See the following documentation: https://www.openssl.org/docs/man1.1.1/man3/X509_VERIFY_PARAM_set_purpose.html

The value of this flag inheritance flag is 1, which corresponds to the deprecated `X509_V_FLAG_CB_ISSUER_CHECK` verification flag.  In most libcryptos, this has no effect, since the flag is deprecated. However, this flag was instructing LibreSSL to override the X509 store's error values, which caused a CRL test to fail.

This PR removes the `X509_VP_FLAG_DEFAULT` flag from both trust store APIs.

### Call-outs:

This test failure should have been caught in CI. A fix for this will be in a future PR.

### Testing:

Tested locally on LibreSSL.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
