### PR TITLE
Make header deps explicit in preperation for clang-format

### DIFF
--- a/tls/s2n_protocol_preferences.h
+++ b/tls/s2n_protocol_preferences.h
@@ -17,7 +17,9 @@
 
 #include "api/s2n.h"
 
+#include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_result.h"
+#include "utils/s2n_blob.h"
 
 S2N_RESULT s2n_protocol_preferences_read(struct s2n_stuffer *protocol_preferences, struct s2n_blob *protocol);
 S2N_RESULT s2n_protocol_preferences_contain(struct s2n_blob *protocol_preferences, struct s2n_blob *protocol, bool *contains);

--- a/tls/s2n_signature_algorithms.h
+++ b/tls/s2n_signature_algorithms.h
@@ -22,6 +22,8 @@
 
 #include "stuffer/s2n_stuffer.h"
 
+#include "tls/s2n_signature_scheme.h"
+
 struct s2n_connection;
 
 struct s2n_sig_scheme_list {


### PR DESCRIPTION
### Description of changes: 

My clang-format PR revealed an issue with `s2n_protocol_preferences.h` in the PR we re-order headers in a test causing a build error. Turns out `s2n_protocol_preferences.h` implicitly relied to `s2n_blob.h` and `s2n_stuffer.h` being defined. A good bet almost anywhere in our code base, except in `s2n_protocol_preferences_test.c` where `s2n_protocol_preferences.h` was placed at the top of the include list.

PR: https://github.com/aws/s2n-tls/pull/3677
Failing Tests: https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiQzJvYzVDcjhhQ21KZzJCbzN5eDVEV2pOcGNaTlhpSzIvNm5ESktJT01mMS9NZ0FtMjUzV1htd0NoeEJNTGRqTG10NWkzeUt1djR2QjFHc3RraG1wWmhSUHNjbHdxZ1pSMHVMRlZ0MitQKzBUSUJPVkJKNTFtY3Q4Wnc9PSIsIml2UGFyYW1ldGVyU3BlYyI6IjF3VDZIVTFhaDJsMlhzSy8iLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D/build/ecb26868-c42a-403d-bb55-813d446fd46f

```
In file included from s2n_protocol_preferences_test.c:16:
/codebuild/output/src016882767/src/github.com/aws/s2n-tls/tls/s2n_protocol_preferences.h:22:91: error: 'struct s2n_blob' declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
   22 | S2N_RESULT s2n_protocol_preferences_read(struct s2n_stuffer *protocol_preferences, struct s2n_blob *protocol);
      |                                                                                           ^~~~~~~~
/codebuild/output/src016882767/src/github.com/aws/s2n-tls/tls/s2n_protocol_preferences.h:22:49: error: 'struct s2n_stuffer' declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
   22 | S2N_RESULT s2n_protocol_preferences_read(struct s2n_stuffer *protocol_preferences, struct s2n_blob *protocol);
      |                                                 ^~~~~~~~~~~
```

This PR adds stuffer and blob to protocol_preferences

### Testing:

CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
