### PR TITLE
bindings (rust): handle propagating the async client_hello callback error

### DIFF
--- a/bindings/rust/s2n-tls/src/callbacks.rs
+++ b/bindings/rust/s2n-tls/src/callbacks.rs
@@ -201,6 +201,8 @@ pub(crate) fn poll_client_hello_callback(
         match fut.as_mut().poll(conn, &mut ctx) {
             Poll::Ready(result) => {
                 let result = result.and_then(|_| conn.mark_client_hello_cb_done());
+
+                // conn.mark_client_hello_cb_done()?;
                 Poll::Ready(result)
             }
             Poll::Pending => {

--- a/bindings/rust/s2n-tls/src/callbacks.rs
+++ b/bindings/rust/s2n-tls/src/callbacks.rs
@@ -155,7 +155,10 @@ impl ConnectionFuture for ErrorFuture {
         _connection: &mut Connection,
         _ctx: &mut core::task::Context,
     ) -> Poll<Result<(), Error>> {
-        let err = self.error.take().unwrap();
+        let err = self.error.take().expect(
+            "ErrorFuture should be initialized with Some(error) and a Future should never
+            be polled after it returns Poll::Ready",
+        );
         Poll::Ready(Err(err))
     }
 }

--- a/bindings/rust/s2n-tls/src/callbacks.rs
+++ b/bindings/rust/s2n-tls/src/callbacks.rs
@@ -198,6 +198,7 @@ pub(crate) fn poll_client_hello_callback(
     ) -> Poll<Result<(), Error>> {
         let waker = conn.waker().ok_or(Error::MISSING_WAKER)?.clone();
         let mut ctx = core::task::Context::from_waker(&waker);
+        println!("-------here");
         match fut.as_mut().poll(conn, &mut ctx) {
             Poll::Ready(result) => {
                 let result = result.and_then(|_| conn.mark_client_hello_cb_done());

--- a/bindings/rust/s2n-tls/src/callbacks.rs
+++ b/bindings/rust/s2n-tls/src/callbacks.rs
@@ -201,9 +201,7 @@ pub(crate) fn poll_client_hello_callback(
         println!("-------here");
         match fut.as_mut().poll(conn, &mut ctx) {
             Poll::Ready(result) => {
-                let result = result.and_then(|_| conn.mark_client_hello_cb_done());
-
-                // conn.mark_client_hello_cb_done()?;
+                conn.mark_client_hello_cb_done()?;
                 Poll::Ready(result)
             }
             Poll::Pending => {

--- a/bindings/rust/s2n-tls/src/callbacks.rs
+++ b/bindings/rust/s2n-tls/src/callbacks.rs
@@ -216,7 +216,7 @@ fn on_client_hello_callback(conn: &mut Connection) -> Poll<Result<(), Error>> {
             // the application.
             let fut = fut.unwrap_or_else(|err| Box::pin(ErrorFuture { error: Some(err) }));
 
-            // The callback returned a future so store it on the on
+            // The callback returned a future so store it on the
             // connection. This is Asynchronous resolution.
             conn.set_connection_future(InternalConnectionFuture::ClientHello(fut));
             Poll::Pending

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -564,7 +564,7 @@ impl Connection {
     ///
     /// If the Future returns `Poll::Pending` and has not completed, then it
     /// should be re-set using [`Self::set_connection_future()`]
-    pub(crate) fn take_connection_future(&mut self) -> Option<InternalConnectionFuture> {
+    fn take_connection_future(&mut self) -> Option<InternalConnectionFuture> {
         let ctx = self.context_mut();
         ctx.connection_future.take()
     }

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -381,6 +381,7 @@ impl Connection {
         // check if an async task for the client_hello_callback exists and
         // poll it to completion
         if let Some(fut) = self.take_connection_future() {
+            println!("-------poll_negotiate");
             if poll_client_hello_callback(self, Some(fut)).is_pending() {
                 return Poll::Pending;
             }

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -382,15 +382,15 @@ impl Connection {
         // poll it to completion
         if let Some(fut) = self.take_connection_future() {
             println!("-------poll_negotiate");
-            if poll_client_hello_callback(self, Some(fut)).is_pending() {
-                return Poll::Pending;
-            }
-
-            // match poll_client_hello_callback(self, Some(fut)) {
-            //     Poll::Ready(Ok(_)) => (),
-            //     Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
-            //     Poll::Pending => return Poll::Pending,
+            // if poll_client_hello_callback(self, Some(fut)).is_pending() {
+            //     return Poll::Pending;
             // }
+
+            match poll_client_hello_callback(self, Some(fut)) {
+                Poll::Ready(Ok(_)) => (),
+                Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+                Poll::Pending => return Poll::Pending,
+            }
         }
 
         unsafe {

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -384,6 +384,12 @@ impl Connection {
             if poll_client_hello_callback(self, Some(fut)).is_pending() {
                 return Poll::Pending;
             }
+
+            // match poll_client_hello_callback(self, Some(fut)) {
+            //     Poll::Ready(Ok(_)) => (),
+            //     Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+            //     Poll::Pending => return Poll::Pending,
+            // }
         }
 
         unsafe {

--- a/bindings/rust/s2n-tls/src/error.rs
+++ b/bindings/rust/s2n-tls/src/error.rs
@@ -368,7 +368,7 @@ impl std::error::Error for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::enums::Version;
+    use crate::{enums::Version, testing::client_hello::CustomError};
     use errno::set_errno;
 
     const FAILURE: isize = -1;
@@ -437,19 +437,6 @@ mod tests {
 
     #[test]
     fn application_error() {
-        use std::{fmt, io};
-
-        #[derive(Debug)]
-        struct CustomError;
-
-        impl fmt::Display for CustomError {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                write!(f, "custom error")
-            }
-        }
-
-        impl std::error::Error for CustomError {}
-
         // test single level errors
         {
             let error = Error::application(Box::new(CustomError));
@@ -460,11 +447,11 @@ mod tests {
 
         // make sure nested errors work
         {
-            let io_error = io::Error::new(io::ErrorKind::Other, CustomError);
+            let io_error = std::io::Error::new(std::io::ErrorKind::Other, CustomError);
             let error = Error::application(Box::new(io_error));
 
             let app_error = error.application_error().unwrap();
-            let io_error = app_error.downcast_ref::<io::Error>().unwrap();
+            let io_error = app_error.downcast_ref::<std::io::Error>().unwrap();
             let _custom_error = io_error
                 .get_ref()
                 .unwrap()

--- a/bindings/rust/s2n-tls/src/testing.rs
+++ b/bindings/rust/s2n-tls/src/testing.rs
@@ -1,17 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    callbacks::{ClientHelloCallback, ConnectionFuture, VerifyHostNameCallback},
-    config::*,
-    error, security,
-    testing::s2n_tls::Harness,
-};
-use alloc::{collections::VecDeque, sync::Arc};
+use crate::{callbacks::VerifyHostNameCallback, config::*, security, testing::s2n_tls::Harness};
+use alloc::collections::VecDeque;
 use bytes::Bytes;
-use core::{sync::atomic::Ordering, task::Poll};
-use std::{pin::Pin, sync::atomic::AtomicUsize};
+use core::task::Poll;
 
+pub mod client_hello;
 pub mod s2n_tls;
 
 type Error = Box<dyn std::error::Error>;
@@ -182,7 +177,7 @@ pub fn s2n_tls_pair(config: crate::config::Config) {
     let mut client = crate::connection::Connection::new_client();
     client
         .set_config(config)
-        .expect("Unabel to set client config");
+        .expect("Unable to set client config");
     let client = Harness::new(client);
 
     let pair = Pair::new(server, client, SAMPLES);
@@ -203,69 +198,4 @@ pub fn poll_tls_pair(mut pair: Pair<Harness, Harness>) -> Pair<Harness, Harness>
     // TODO add assertions to make sure the handshake actually succeeded
 
     pair
-}
-
-// The Future returned by MockClientHelloHandler.
-//
-// An instance of this Future is stored on the connection and
-// polled to make progress in the async client_hello_callback
-pub struct MockClientHelloFuture {
-    require_pending_count: usize,
-    invoked: Arc<AtomicUsize>,
-}
-
-impl ConnectionFuture for MockClientHelloFuture {
-    fn poll(
-        self: Pin<&mut Self>,
-        connection: &mut crate::connection::Connection,
-        _ctx: &mut core::task::Context,
-    ) -> Poll<Result<(), error::Error>> {
-        if self.invoked.fetch_add(1, Ordering::SeqCst) < self.require_pending_count {
-            // confirm the callback can access the waker
-            connection.waker().unwrap().wake_by_ref();
-            return Poll::Pending;
-        }
-
-        // Test that the config can be changed
-        connection
-            .set_config(build_config(&security::DEFAULT_TLS13).unwrap())
-            .unwrap();
-
-        // Test that server_name_extension_used can be invoked
-        connection.server_name_extension_used();
-
-        Poll::Ready(Ok(()))
-    }
-}
-
-#[derive(Clone)]
-pub struct MockClientHelloHandler {
-    require_pending_count: usize,
-    invoked: Arc<AtomicUsize>,
-}
-
-impl MockClientHelloHandler {
-    pub fn new(require_pending_count: usize) -> Self {
-        Self {
-            require_pending_count,
-            invoked: Arc::new(AtomicUsize::new(0)),
-        }
-    }
-}
-
-impl ClientHelloCallback for MockClientHelloHandler {
-    fn on_client_hello(
-        &self,
-        _connection: &mut crate::connection::Connection,
-    ) -> Result<Option<Pin<Box<dyn ConnectionFuture>>>, crate::error::Error> {
-        let fut = MockClientHelloFuture {
-            require_pending_count: self.require_pending_count,
-            invoked: self.invoked.clone(),
-        };
-
-        // returning `Some` indicates that the client_hello callback is
-        // not yet finished and that the supplied MockClientHelloFuture
-        // needs to be `poll`ed to make progress.
-        Ok(Some(Box::pin(fut)))
-    }
 }

--- a/bindings/rust/s2n-tls/src/testing/client_hello.rs
+++ b/bindings/rust/s2n-tls/src/testing/client_hello.rs
@@ -128,7 +128,7 @@ impl ConnectionFuture for FailingCHFuture {
 }
 
 #[derive(Debug)]
-struct CustomError;
+pub struct CustomError;
 
 impl std::error::Error for CustomError {}
 impl fmt::Display for CustomError {

--- a/bindings/rust/s2n-tls/src/testing/client_hello.rs
+++ b/bindings/rust/s2n-tls/src/testing/client_hello.rs
@@ -127,6 +127,14 @@ impl ConnectionFuture for FailingCHFuture {
     }
 }
 
+impl Drop for FailingCHFuture {
+    // return pending once to simular the async nature of the future and
+    // improve test coverage
+    fn drop(&mut self) {
+        assert!(self.invoked.load(Ordering::SeqCst) >= 1);
+    }
+}
+
 #[derive(Debug)]
 pub struct CustomError;
 

--- a/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
+++ b/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
@@ -383,8 +383,8 @@ mod tests {
 
     #[test]
     fn failing_client_hello_callback_async() -> Result<(), Error> {
-        let (waker, wake_count) = new_count_waker();
-        let handle = FailingAsyncCHHandler;
+        let (waker, _wake_count) = new_count_waker();
+        let handle = FailingAsyncCHHandler::default();
         let config = {
             let mut config = config_builder(&security::DEFAULT_TLS13)?;
             config.set_client_hello_callback(handle)?;
@@ -410,7 +410,7 @@ mod tests {
         loop {
             match pair.poll() {
                 Poll::Ready(result) => {
-                    let err = result.err().unwrap();
+                    let err = result.expect_err("handshake should fail");
                     let err = err.downcast_ref::<crate::error::Error>().unwrap();
                     err.application_error().unwrap();
                     break;
@@ -418,7 +418,6 @@ mod tests {
                 Poll::Pending => continue,
             }
         }
-        assert_eq!(wake_count, 0);
 
         Ok(())
     }

--- a/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
+++ b/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
@@ -300,7 +300,7 @@ mod tests {
     #[test]
     fn failing_client_hello_callback_sync() -> Result<(), Error> {
         let (waker, wake_count) = new_count_waker();
-        let handle = FailingCHHandler;
+        let handle = FailingCHHandler::default();
         let config = {
             let mut config = config_builder(&security::DEFAULT_TLS13)?;
             config.set_client_hello_callback(handle)?;


### PR DESCRIPTION
### Description of changes:
https://github.com/aws/s2n-tls/pull/3631 allowed application to return a future when implementing the client_hello_callback. However, the implementation currently only handles the happy path and doesnt handle the error case.

This PR adds error handling (for both async and sync callback resolution) and propagates any application specific error (`Error::application`) back to the application.

### Testing:
Adds a test for sync and async failing ClientHelloCallback and ensures that the custom Application error is propagated to the application.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
