### PR TITLE
Ensures no switching between state machines

### DIFF
--- a/tests/unit/s2n_self_talk_state_machine_test.c
+++ b/tests/unit/s2n_self_talk_state_machine_test.c
@@ -31,6 +31,13 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key, S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
 
+        /* Generic TLS12 config */
+        DEFER_CLEANUP(struct s2n_config *tls12_config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(tls12_config);
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(tls12_config));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(tls12_config, "default"));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(tls12_config, chain_and_key));
+
         DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
         EXPECT_NOT_NULL(server_conn);
         EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
@@ -39,24 +46,72 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn);
         EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
 
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-
         /* Create nonblocking pipes */
         struct s2n_test_io_pair io_pair;
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
-        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
-        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
-        /* A server cannot switch from the state machine negotiated midway through the handshake */
+        /* A connection cannot switch to the TLS12 state machine midway through the handshake */
         {
+            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
             /* Do handshake until the cert message is reached */
             EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, SERVER_CERT));
 
             EXPECT_EQUAL(s2n_connection_get_actual_protocol_version(server_conn), S2N_TLS13);
             EXPECT_EQUAL(s2n_connection_get_actual_protocol_version(client_conn), S2N_TLS13);
 
-            /* Alter which state machine the server is using */
+            /* Alter which state machine the connection is using */
+            server_conn->actual_protocol_version = S2N_TLS12;
+            client_conn->actual_protocol_version = S2N_TLS12;
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_test_server_and_client(server_conn, client_conn), S2N_ERR_SAFETY);
+        }
+
+        /* A connection cannot switch to the TLS13 state machine midway through the handshake */
+        {
+            EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+            EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, tls12_config));
+            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls12_config));
+            EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+            /* Do handshake until the server hello message is reached */
+            EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, SERVER_HELLO));
+
+            EXPECT_EQUAL(s2n_connection_get_actual_protocol_version(server_conn), S2N_TLS12);
+            EXPECT_EQUAL(s2n_connection_get_actual_protocol_version(client_conn), S2N_TLS12);
+
+            /* Alter which state machine the connection is using */
+            server_conn->actual_protocol_version = S2N_TLS13;
+            client_conn->actual_protocol_version = S2N_TLS13;
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_test_server_and_client(server_conn, client_conn), S2N_ERR_SAFETY);
+        }
+
+        /* A hello retry handshake cannot change state machines */
+        {
+            EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+            EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+            EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+            /* Force the HRR path */
+            client_conn->security_policy_override = &security_policy_test_tls13_retry;
+
+            /* Negotiate handshake until cert message */
+            EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, SERVER_CERT));
+
+            EXPECT_EQUAL(s2n_connection_get_actual_protocol_version(server_conn), S2N_TLS13);
+            EXPECT_EQUAL(s2n_connection_get_actual_protocol_version(client_conn), S2N_TLS13);
+
+            EXPECT_TRUE(IS_HELLO_RETRY_HANDSHAKE(server_conn));
+            EXPECT_TRUE(IS_HELLO_RETRY_HANDSHAKE(client_conn));
+
+            /* Alter which state machine the connection is using */
+            client_conn->actual_protocol_version = S2N_TLS12;
             server_conn->actual_protocol_version = S2N_TLS12;
 
             EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_test_server_and_client(server_conn, client_conn), S2N_ERR_SAFETY);

--- a/tests/unit/s2n_self_talk_state_machine_test.c
+++ b/tests/unit/s2n_self_talk_state_machine_test.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Set up generic TLS13 config */
+    DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+    EXPECT_NOT_NULL(config);
+    EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key, S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+
+    DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+    EXPECT_NOT_NULL(server_conn);
+    EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
+
+    DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+    EXPECT_NOT_NULL(client_conn);
+    EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
+
+    EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+    EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+    /* Create nonblocking pipes */
+    struct s2n_test_io_pair io_pair;
+    EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+    EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
+    EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+   
+    /* A server cannot switch from the state machine negotiated midway through the handshake */
+    {
+        /* Do handshake until the cert message is reached */
+        EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, SERVER_CERT));
+
+        EXPECT_EQUAL(s2n_connection_get_actual_protocol_version(server_conn), S2N_TLS13);
+        EXPECT_EQUAL(s2n_connection_get_actual_protocol_version(client_conn), S2N_TLS13);
+
+        /* Alter which state machine the server is using */
+        server_conn->actual_protocol_version = S2N_TLS12;
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_test_server_and_client(server_conn, client_conn), S2N_ERR_SAFETY);
+    }
+
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+
+    END_TEST();
+}

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -136,6 +136,9 @@ struct s2n_connection {
      * instead of the ALPN extension */
     unsigned npn_negotiated:1;
 
+    /* Records which state machine is being used by this handshake */
+    unsigned is_tls13_state_machine:1;
+
     /* The configuration (cert, key .. etc ) */
     struct s2n_config *config;
 
@@ -196,9 +199,6 @@ struct s2n_connection {
     uint8_t client_protocol_version;
     uint8_t server_protocol_version;
     uint8_t actual_protocol_version;
-
-    /* Records which state machine is being used by this handshake */
-    unsigned is_tls13_state_machine:1;
 
     /* Flag indicating whether a protocol version has been
      * negotiated yet. */

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -197,6 +197,9 @@ struct s2n_connection {
     uint8_t server_protocol_version;
     uint8_t actual_protocol_version;
 
+    /* Records which state machine is being used by this handshake */
+    unsigned is_tls13_state_machine:1;
+
     /* Flag indicating whether a protocol version has been
      * negotiated yet. */
     uint8_t actual_protocol_version_established;

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -856,8 +856,8 @@ static S2N_RESULT s2n_execute_handler(struct s2n_connection *conn)
 {
     RESULT_ENSURE_REF(conn);
 
-    /* Ensure the state machine referenced is consistant throughout the handshake */
-    if (conn->actual_protocol_version_established) {
+    /* Ensure the state machine referenced is consistent throughout the handshake */
+    if (conn->actual_protocol_version_established || IS_HELLO_RETRY_HANDSHAKE(conn) || WITH_EARLY_DATA(conn)) {
         RESULT_ENSURE_EQ(IS_TLS13_HANDSHAKE(conn), conn->is_tls13_state_machine);
     }
 

--- a/tls/s2n_handshake_type.c
+++ b/tls/s2n_handshake_type.c
@@ -56,6 +56,7 @@ S2N_RESULT s2n_handshake_type_set_tls13_flag(struct s2n_connection *conn, s2n_tl
     RESULT_ENSURE_REF(conn);
     RESULT_ENSURE(s2n_connection_get_protocol_version(conn) >= S2N_TLS13, S2N_ERR_HANDSHAKE_STATE);
     conn->handshake.handshake_type |= flag;
+    conn->is_tls13_state_machine = true;
     return S2N_RESULT_OK;
 }
 

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -273,6 +273,9 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
 
     conn->actual_protocol_version_established = 1;
 
+    /* At this point, we have selected a state machine for this handshake */
+    conn->is_tls13_state_machine = (conn->actual_protocol_version == S2N_TLS13);
+
     POSIX_GUARD(s2n_conn_set_handshake_type(conn));
 
     /* If this is a HelloRetryRequest, we don't process the ServerHello.
@@ -342,6 +345,9 @@ int s2n_server_hello_send(struct s2n_connection *conn)
     POSIX_GUARD(s2n_server_extensions_send(conn, &conn->handshake.io));
 
     conn->actual_protocol_version_established = 1;
+
+    /* At this point, we have selected a state machine for this handshake */
+    conn->is_tls13_state_machine = (conn->actual_protocol_version == S2N_TLS13);
 
     return 0;
 }


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 
Once the protocol version is established, we should not be switching which state machine we're using. Here's some code to make sure we haven't switched state machines.

### Testing:
I have mixed feelings about the test I wrote. Its very difficult to get the code to fail exactly at the check I added as there is usually other problems that occur if you switch the state machine. I feel like I could use some input on the best way to test this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
