### PR TITLE
Read until error or supplied buffer is full

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -869,6 +869,18 @@ S2N_API extern int s2n_config_set_verify_after_sign(struct s2n_config *config, s
 S2N_API extern int s2n_config_set_send_buffer_size(struct s2n_config *config, uint32_t size);
 
 /**
+ * Enable or disable recieving of multiple TLS records in a single s2n_recv call
+ *
+ * Legacy behavior is to return after reading a single TLS record which may not be the most
+ * efficient way to invoke this function, especially if larger receive buffers are used.
+ *
+ * @param config The configuration object being updated
+ * @param enabled Set to `true` if multiple record recieve is to be enabled; `false` to disable.
+ * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
+ */
+S2N_API extern int s2n_config_set_recv_multi_record(struct s2n_config *config, bool enabled);
+
+/**
  * A callback function invoked (usually multiple times) during X.509 validation for each
  * name encountered in the leaf certificate.
  *

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1111,6 +1111,10 @@ ssize_t s2n_recv(struct s2n_connection *conn,
 connection. **s2n_recv** will return the number of bytes read and also return
 "0" on connection shutdown by the peer.
 
+**NOTE:** By default, **s2n_recv** will return after reading a single TLS record. To change this
+behavior such that it will read up to **size**, the config for the connection can be updated
+by calling **s2n_config_set_recv_multi_record**.
+
 **NOTE:** Unlike OpenSSL, repeated calls to **s2n_recv** should not duplicate the original parameters, but should update **buf** and **size** per the indication of size read. For example;
 
 ```c

--- a/tests/unit/s2n_recv_test.c
+++ b/tests/unit/s2n_recv_test.c
@@ -196,5 +196,46 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
+    /* s2n_config_set_recv_multi_record */
+    {
+        #define TEST_DATA_SIZE 100
+        const uint8_t test_data[TEST_DATA_SIZE] = "hello world";
+        const size_t test_data_size = sizeof(test_data);
+        uint8_t output[TEST_DATA_SIZE * 2];
+        const size_t recv_size = sizeof(output);
+
+        {
+            s2n_blocked_status blocked = 0;
+
+            DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+            DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+            struct s2n_test_io_pair io_pair = { 0 };
+            EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+            EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+            EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+            /* Write some data, in three records */
+            EXPECT_EQUAL(s2n_send(client_conn, test_data, sizeof(test_data), &blocked), sizeof(test_data));
+            EXPECT_EQUAL(s2n_send(client_conn, test_data, sizeof(test_data), &blocked), sizeof(test_data));
+            EXPECT_EQUAL(s2n_send(client_conn, test_data, sizeof(test_data), &blocked), sizeof(test_data));
+
+            /* Disable multi-recod recv, set legavy behvaior */
+            EXPECT_SUCCESS(s2n_config_set_recv_multi_record(config, false));
+
+            EXPECT_EQUAL(s2n_recv(server_conn, output, recv_size, &blocked), test_data_size);
+
+            /* Now enable multi record recv */
+            EXPECT_SUCCESS(s2n_config_set_recv_multi_record(config, true));
+
+            /* So we should be able to read the remaining two records in a single call */
+            EXPECT_EQUAL(s2n_recv(server_conn, output, recv_size, &blocked), recv_size);
+        }
+    }
+
     END_TEST();
 }

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -1058,3 +1058,12 @@ int s2n_config_set_crl_lookup_cb(struct s2n_config *config, s2n_crl_lookup_callb
     config->crl_lookup_ctx = ctx;
     return S2N_SUCCESS;
 }
+
+int s2n_config_set_recv_multi_record(struct s2n_config *config, bool enabled)
+{
+    POSIX_ENSURE_REF(config);
+
+    config->recv_multi_record = enabled;
+
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -77,6 +77,13 @@ struct s2n_config {
     /* Indicates support for the npn extension */
     unsigned npn_supported:1;
 
+    /* Indicates s2n_recv should read as much as it can into the output buffer
+     *
+     * Note: This defaults to false to ensure backwards compatability with
+     * applications which relied on s2n_recv returning a single record.
+     */
+    unsigned recv_multi_record:1;
+
     struct s2n_dh_params *dhparams;
     /* Needed until we can deprecate s2n_config_add_cert_chain_and_key. This is
      * used to release memory allocated only in the deprecated API that the application 

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -207,8 +207,8 @@ ssize_t s2n_recv_impl(struct s2n_connection *conn, void *buf, ssize_t size, s2n_
             conn->in_status = ENCRYPTED;
         }
 
-        /* If we've read some data, return it */
-        if (bytes_read) {
+        /* If we've read some data, return it in legacy mode */
+        if (bytes_read && !conn->config->recv_multi_record) {
             break;
         }
     }


### PR DESCRIPTION
The code appeared to be designed to read multiple TLS records, until the buffer was full, however a break statement at the end limited the logic to a single TLS record. This change introduces a config which allows changing of this behavior to read as much as possible in order to fill the supplied buffer.

In order to maintain legacy behavior, the config is defaulted to off.

### Resolved issues:

 resolves #3438 

### Description of changes: 

This change removes the break condition, such that `s2n_recv` will continue to read until it receives an error or fills the supplied output buffer when the new config is enabled.

### Call-outs:

This change is backwards compatible as the default behavior remains unchanged.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

* Added a new test in `s2c_recv_test` to ensure this behavior is correctly honored for legacy and new settings.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
