### PR TITLE
Fix FreeBSD minherit arg naming

### DIFF
--- a/tests/unit/s2n_fork_generation_number_test.c
+++ b/tests/unit/s2n_fork_generation_number_test.c
@@ -330,6 +330,11 @@ int main(int argc, char **argv)
 
     EXPECT_TRUE(s2n_array_len(fgn_test_cases) == NUMBER_OF_FGN_TEST_CASES);
 
+    /* Sanity check that MAP_INHERIT_ZERO is supported where we know it should be supported */
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
+    EXPECT_TRUE(s2n_is_map_inherit_zero_supported());
+#endif
+
     /* Create NUMBER_OF_FGN_TEST_CASES number of child processes that run each
      * test case.
      *

--- a/tests/unit/s2n_fork_generation_number_test.c
+++ b/tests/unit/s2n_fork_generation_number_test.c
@@ -29,6 +29,7 @@
 #include <sched.h>
 #include <stdio.h>
 #include <sys/wait.h>
+#include <sys/param.h>
 
 #define NUMBER_OF_FGN_TEST_CASES 4
 #define MAX_NUMBER_OF_TEST_THREADS 2
@@ -321,7 +322,7 @@ struct fgn_test_case fgn_test_cases[NUMBER_OF_FGN_TEST_CASES] = {
     {"Default fork detect mechanisms.", s2n_test_case_default_cb, CLONE_TEST_DETERMINE_AT_RUNTIME},
     {"Only pthread_atfork fork detection mechanism.", s2n_test_case_pthread_atfork_cb, CLONE_TEST_NO},
     {"Only madv_wipeonfork fork detection mechanism.", s2n_test_case_madv_wipeonfork_cb, CLONE_TEST_YES},
-    {"Only map_inheret_zero fork detection mechanism.", s2n_test_case_map_inherit_zero_cb, CLONE_TEST_YES}
+    {"Only map_inherit_zero fork detection mechanism.", s2n_test_case_map_inherit_zero_cb, CLONE_TEST_YES}
 };
 
 int main(int argc, char **argv)
@@ -330,9 +331,15 @@ int main(int argc, char **argv)
 
     EXPECT_TRUE(s2n_array_len(fgn_test_cases) == NUMBER_OF_FGN_TEST_CASES);
 
-    /* Sanity check that MAP_INHERIT_ZERO is supported where we know it should be supported */
-#if defined(__FreeBSD__) || defined(__OpenBSD__)
+/* Test: FreeBSD >= 12.0 should use map_inherit_zero */
+#ifdef __FreeBSD__
+    #ifndef __FreeBSD_version
+        #error "Unknown FreeBSD version"
+    #endif
+
+    #if __FreeBSD_version >= 1200000
     EXPECT_TRUE(s2n_is_map_inherit_zero_supported());
+    #endif
 #endif
 
     /* Create NUMBER_OF_FGN_TEST_CASES number of child processes that run each

--- a/utils/s2n_fork_detection.c
+++ b/utils/s2n_fork_detection.c
@@ -53,6 +53,11 @@ typedef __darwin_pthread_once_t pthread_once_t;
     #define MADV_WIPEONFORK 18
 #endif
 
+/* Sometimes (for example, on FreeBSD) MAP_INHERIT_ZERO is called INHERIT_ZERO */
+#if !defined(MAP_INHERIT_ZERO) && defined(INHERIT_ZERO)
+    #define MAP_INHERIT_ZERO INHERIT_ZERO
+#endif
+
 /* These variables are used to disable all fork detection mechanisms or at the
  * individual level during testing.
  */
@@ -107,7 +112,7 @@ static inline S2N_RESULT s2n_initialise_wipeonfork_best_effort(void *addr, long 
 static inline S2N_RESULT s2n_initialise_inherit_zero(void *addr, long page_size)
 {
 #if defined(S2N_MINHERIT_SUPPORTED) && defined(MAP_INHERIT_ZERO)
-    RESULT_ENSURE(minherit(addr, pagesize, MAP_INHERIT_ZERO) == 0, S2N_ERR_FORK_DETECTION_INIT);
+    RESULT_ENSURE(minherit(addr, page_size, MAP_INHERIT_ZERO) == 0, S2N_ERR_FORK_DETECTION_INIT);
 #endif
 
     return S2N_RESULT_OK;
@@ -338,7 +343,7 @@ bool s2n_is_madv_wipeonfork_supported(void)
 bool s2n_is_map_inherit_zero_supported(void)
 {
 #if defined(S2N_MINHERIT_SUPPORTED) && defined(MAP_INHERIT_ZERO)
-    return true
+    return true;
 #else
     return false;
 #endif


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/3674

### Description of changes: 

Handle the case where minherit takes "INHERIT_ZERO" instead of "MAP_INHERIT_ZERO".


### Callouts
This test duplicates a couple typo fixes from https://github.com/aws/s2n-tls/pull/3670, since that PR deals with OpenBSD, which also hits the path with the typos.

### Testing:

I added a basic test for two OSes we know should support minherit, one that uses MAP_INHERIT_ZERO (OpenBSD) and one that uses INHERIT_ZERO (FreeBSD). The OpenBSD version of the test won't get executed until we add an OpenBSD build to the CI, which is blocked by https://github.com/aws/s2n-tls/pull/3670.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
