### PR TITLE
tokio-s2n-tls: add poll_blinding and fix blinding on shutdown

### DIFF
--- a/bindings/rust/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/s2n-tls-tokio/Cargo.toml
@@ -13,6 +13,7 @@ default = []
 [dependencies]
 errno = { version = "0.2" }
 libc = { version = "0.2" }
+pin-project-lite = { version = "0.2" }
 s2n-tls = { version = "=0.0.21", path = "../s2n-tls" }
 tokio = { version = "1", features = ["net", "time"] }
 

--- a/bindings/rust/s2n-tls-tokio/src/lib.rs
+++ b/bindings/rust/s2n-tls-tokio/src/lib.rs
@@ -308,8 +308,8 @@ where
         Poll::Ready(Ok(()))
     }
 
-    pub fn apply_blinding(&'_ mut self) -> impl Future<Output = Result<(), Error>> + '_ {
-        ApplyBlinding { stream: self }
+    pub async fn apply_blinding(&mut self) -> Result<(), Error> {
+        ApplyBlinding { stream: self }.await
     }
 }
 

--- a/bindings/rust/s2n-tls-tokio/src/lib.rs
+++ b/bindings/rust/s2n-tls-tokio/src/lib.rs
@@ -254,9 +254,7 @@ where
         let tls = self.get_mut();
 
         if tls.blinding.is_none() {
-            let delay = tls
-                .as_ref()
-                .remaining_blinding_delay()?;
+            let delay = tls.as_ref().remaining_blinding_delay()?;
             if !delay.is_zero() {
                 // Sleep operates at the milisecond resolution, so add an extra
                 // millisecond to account for any stray nanoseconds.

--- a/bindings/rust/s2n-tls-tokio/src/lib.rs
+++ b/bindings/rust/s2n-tls-tokio/src/lib.rs
@@ -246,7 +246,7 @@ where
     }
 
     // Sets the blinding timer to the remaining blinding delay and possibly
-    // rembemers an error.
+    // remembers an error.
     //
     // Returns the error if there was no blinding needed and the error
     // did not need to be remembered.

--- a/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use s2n_tls::error;
 use s2n_tls::connection::Connection;
+use s2n_tls::error;
 use s2n_tls_tokio::{TlsAcceptor, TlsConnector, TlsStream};
 use std::convert::TryFrom;
 use std::future::Future;
@@ -198,14 +198,16 @@ async fn shutdown_with_poll_blinding() -> Result<(), Box<dyn std::error::Error>>
     let (mut client, mut server) =
         common::run_negotiate(&client, client_stream, &server, server_stream).await?;
 
-    struct PollBlinding<'a, S, C> where
+    struct PollBlinding<'a, S, C>
+    where
         C: AsRef<Connection> + AsMut<Connection> + Unpin,
         S: AsyncRead + AsyncWrite + Unpin,
     {
-        stream: &'a mut TlsStream<S, C>
+        stream: &'a mut TlsStream<S, C>,
     }
 
-    impl<'a, S, C> Future for PollBlinding<'a, S, C> where
+    impl<'a, S, C> Future for PollBlinding<'a, S, C>
+    where
         C: AsRef<Connection> + AsMut<Connection> + Unpin,
         S: AsyncRead + AsyncWrite + Unpin,
     {
@@ -230,7 +232,12 @@ async fn shutdown_with_poll_blinding() -> Result<(), Box<dyn std::error::Error>>
 
     // poll_blinding MUST NOT complete faster than minimal blinding time.
     let (timeout, _) = join!(
-        time::timeout(common::MIN_BLINDING_SECS, PollBlinding { stream: &mut server }),
+        time::timeout(
+            common::MIN_BLINDING_SECS,
+            PollBlinding {
+                stream: &mut server
+            }
+        ),
         time::timeout(common::MIN_BLINDING_SECS, read_until_shutdown(&mut client)),
     );
     assert!(timeout.is_err());
@@ -240,7 +247,12 @@ async fn shutdown_with_poll_blinding() -> Result<(), Box<dyn std::error::Error>>
     // We check for completion, but not for success. At the moment, the
     // call to s2n_shutdown will fail due to issues in the underlying C library.
     let (timeout, _) = join!(
-        time::timeout(common::MAX_BLINDING_SECS, PollBlinding { stream: &mut server }),
+        time::timeout(
+            common::MAX_BLINDING_SECS,
+            PollBlinding {
+                stream: &mut server
+            }
+        ),
         time::timeout(common::MAX_BLINDING_SECS, read_until_shutdown(&mut client)),
     );
     assert!(timeout.is_ok());

--- a/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use s2n_tls::error;
+use s2n_tls::connection::Connection;
 use s2n_tls_tokio::{TlsAcceptor, TlsConnector, TlsStream};
 use std::convert::TryFrom;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     join, time,
@@ -126,6 +130,71 @@ async fn shutdown_with_blinding() -> Result<(), Box<dyn std::error::Error>> {
     // call to s2n_shutdown will fail due to issues in the underlying C library.
     let (timeout, _) = join!(
         time::timeout(common::MAX_BLINDING_SECS, server.shutdown()),
+        time::timeout(common::MAX_BLINDING_SECS, read_until_shutdown(&mut client)),
+    );
+    assert!(timeout.is_ok());
+
+    Ok(())
+}
+
+#[tokio::test(start_paused = true)]
+async fn shutdown_with_poll_blinding() -> Result<(), Box<dyn std::error::Error>> {
+    let clock = common::TokioTime::default();
+    let mut server_config = common::server_config()?;
+    server_config.set_monotonic_clock(clock)?;
+
+    let client = TlsConnector::new(common::client_config()?.build()?);
+    let server = TlsAcceptor::new(server_config.build()?);
+
+    let (server_stream, client_stream) = common::get_streams().await?;
+    let server_stream = common::TestStream::new(server_stream);
+    let overrides = server_stream.overrides();
+    let (mut client, mut server) =
+        common::run_negotiate(&client, client_stream, &server, server_stream).await?;
+
+    struct PollBlinding<'a, S, C> where
+        C: AsRef<Connection> + AsMut<Connection> + Unpin,
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        stream: &'a mut TlsStream<S, C>
+    }
+
+    impl<'a, S, C> Future for PollBlinding<'a, S, C> where
+        C: AsRef<Connection> + AsMut<Connection> + Unpin,
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        type Output = Result<(), error::Error>;
+
+        fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
+            Pin::new(&mut *self.as_mut().stream).poll_blinding(ctx)
+        }
+    }
+
+    // Trigger a blinded error for the server.
+    overrides.next_read(Some(Box::new(|_, _, buf| {
+        // Parsing the header is one of the blinded operations
+        // in s2n_recv, so provide a malformed header.
+        let zeroed_header = [23, 0, 0, 0, 0];
+        buf.put_slice(&zeroed_header);
+        Ok(()).into()
+    })));
+    let mut received = [0; 1];
+    let result = server.read_exact(&mut received).await;
+    assert!(result.is_err());
+
+    // poll_blinding MUST NOT complete faster than minimal blinding time.
+    let (timeout, _) = join!(
+        time::timeout(common::MIN_BLINDING_SECS, PollBlinding { stream: &mut server }),
+        time::timeout(common::MIN_BLINDING_SECS, read_until_shutdown(&mut client)),
+    );
+    assert!(timeout.is_err());
+
+    // Shutdown MUST eventually complete after blinding.
+    //
+    // We check for completion, but not for success. At the moment, the
+    // call to s2n_shutdown will fail due to issues in the underlying C library.
+    let (timeout, _) = join!(
+        time::timeout(common::MAX_BLINDING_SECS, PollBlinding { stream: &mut server }),
         time::timeout(common::MAX_BLINDING_SECS, read_until_shutdown(&mut client)),
     );
     assert!(timeout.is_ok());


### PR DESCRIPTION
### Description of changes: 

First, this CR adds a public poll_blinding function, which allows users to wait for blinding to complete without running a function that has an indefinite timeout.

Second, this fixes a minor security bug where if a bad TLS close record was received during shutdown, blinding would be skipped.

### Testing:

Tests have been written for both the bug and poll_blinding.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
