### PR TITLE
CBMC proofs: remove type-conflicting definition of s2n_calculate_stacktrace

### DIFF
--- a/tests/cbmc/proofs/s2n_stuffer_erase_and_read/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_erase_and_read/Makefile
@@ -22,6 +22,7 @@ HARNESS_FILE = $(HARNESS_ENTRY).c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c

--- a/tests/cbmc/proofs/s2n_stuffer_erase_and_read/s2n_stuffer_erase_and_read_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_erase_and_read/s2n_stuffer_erase_and_read_harness.c
@@ -20,8 +20,6 @@
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 
-void s2n_calculate_stacktrace() {}
-
 void s2n_stuffer_erase_and_read_harness()
 {
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();

--- a/tests/cbmc/proofs/s2n_stuffer_read_bytes/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_read_bytes/Makefile
@@ -22,6 +22,7 @@ HARNESS_FILE = $(HARNESS_ENTRY).c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
 
 PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c

--- a/tests/cbmc/proofs/s2n_stuffer_read_bytes/s2n_stuffer_read_bytes_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_read_bytes/s2n_stuffer_read_bytes_harness.c
@@ -20,8 +20,6 @@
 #include "api/s2n.h"
 #include "stuffer/s2n_stuffer.h"
 
-void s2n_calculate_stacktrace() {}
-
 void s2n_stuffer_read_bytes_harness()
 {
     struct s2n_stuffer *stuffer = cbmc_allocate_s2n_stuffer();


### PR DESCRIPTION
### Description of changes: 

We have a type-consistent stub, and should use just that to avoid linking failures.

### Testing:

Used by CBMC proof CI job.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
