### PR TITLE
Fix s2n_record_write return value

### DIFF
--- a/tests/unit/s2n_3des_test.c
+++ b/tests/unit/s2n_3des_test.c
@@ -61,13 +61,14 @@ int main(int argc, char **argv)
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
-        EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
+        s2n_result result = s2n_record_write(conn, TLS_APPLICATION_DATA, &in);
         if (i <= S2N_DEFAULT_FRAGMENT_LENGTH) {
-            EXPECT_EQUAL(bytes_written, i);
+            EXPECT_OK(result);
+            bytes_written = i;
         } else {
-            /* application data size of intended fragment size + 1 should only send max fragment */
-            EXPECT_EQUAL(bytes_written, S2N_DEFAULT_FRAGMENT_LENGTH);
+            EXPECT_ERROR_WITH_ERRNO(result, S2N_ERR_FRAGMENT_LENGTH_TOO_LARGE);
+            bytes_written = S2N_DEFAULT_FRAGMENT_LENGTH;
         }
 
         uint16_t predicted_length = bytes_written + 1 + 20 + 8;

--- a/tests/unit/s2n_aead_aes_test.c
+++ b/tests/unit/s2n_aead_aes_test.c
@@ -95,13 +95,14 @@ int main(int argc, char **argv)
         conn->initial->cipher_suite->record_alg = &s2n_record_alg_aes128_gcm;
         EXPECT_SUCCESS(destroy_server_keys(conn));
         EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
-        EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
+        s2n_result result = s2n_record_write(conn, TLS_APPLICATION_DATA, &in);
         if (i <= max_fragment) {
-            EXPECT_EQUAL(bytes_written, i);
+            EXPECT_OK(result);
+            bytes_written = i;
         } else {
-            /* application data size of intended fragment size + 1 should only send max fragment */
-            EXPECT_EQUAL(bytes_written, max_fragment);
+            EXPECT_ERROR_WITH_ERRNO(result, S2N_ERR_FRAGMENT_LENGTH_TOO_LARGE);
+            bytes_written = max_fragment;
         }
 
         uint16_t predicted_length = bytes_written;
@@ -149,7 +150,7 @@ int main(int argc, char **argv)
         conn->initial->cipher_suite->record_alg = &s2n_record_alg_aes128_gcm;
         EXPECT_SUCCESS(destroy_server_keys(conn));
         EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
-        EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
+        EXPECT_OK(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
         /* Now lets corrupt some data and ensure the tests pass */
         /* Copy the encrypted out data to the in data */
@@ -189,7 +190,7 @@ int main(int argc, char **argv)
             conn->initial->cipher_suite->record_alg = &s2n_record_alg_aes128_gcm;
             EXPECT_SUCCESS(destroy_server_keys(conn));
             EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
-            EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
+            EXPECT_OK(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -215,7 +216,7 @@ int main(int argc, char **argv)
             conn->initial->cipher_suite->record_alg = &s2n_record_alg_aes128_gcm;
             EXPECT_SUCCESS(destroy_server_keys(conn));
             EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
-            EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
+            EXPECT_OK(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -241,7 +242,7 @@ int main(int argc, char **argv)
             conn->initial->cipher_suite->record_alg = &s2n_record_alg_aes128_gcm;
             EXPECT_SUCCESS(destroy_server_keys(conn));
             EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
-            EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
+            EXPECT_OK(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -281,13 +282,14 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(destroy_server_keys(conn));
         EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
         conn->actual_protocol_version = S2N_TLS12;
-        EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
+        s2n_result result = s2n_record_write(conn, TLS_APPLICATION_DATA, &in);
         if (i <= max_fragment) {
-            EXPECT_EQUAL(bytes_written, i);
+            EXPECT_OK(result);
+            bytes_written = i;
         } else {
-            /* application data size of intended fragment size + 1 should only send max fragment */
-            EXPECT_EQUAL(bytes_written, max_fragment);
+            EXPECT_ERROR_WITH_ERRNO(result, S2N_ERR_FRAGMENT_LENGTH_TOO_LARGE);
+            bytes_written = max_fragment;
         }
 
         uint16_t predicted_length = bytes_written;
@@ -334,7 +336,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(destroy_server_keys(conn));
         EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
         conn->actual_protocol_version = S2N_TLS12;
-        EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
+        EXPECT_OK(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
         /* Now lets corrupt some data and ensure the tests pass */
         /* Copy the encrypted out data to the in data */
@@ -363,7 +365,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(destroy_server_keys(conn));
             EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
             conn->actual_protocol_version = S2N_TLS12;
-            EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
+            EXPECT_OK(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -390,7 +392,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(destroy_server_keys(conn));
             EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
             conn->actual_protocol_version = S2N_TLS12;
-            EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
+            EXPECT_OK(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -417,7 +419,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(destroy_server_keys(conn));
             EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
             conn->actual_protocol_version = S2N_TLS12;
-            EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
+            EXPECT_OK(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));

--- a/tests/unit/s2n_aead_chacha20_poly1305_test.c
+++ b/tests/unit/s2n_aead_chacha20_poly1305_test.c
@@ -96,13 +96,14 @@ int main(int argc, char **argv)
         conn->actual_protocol_version = S2N_TLS12;
         EXPECT_SUCCESS(destroy_server_keys(conn));
         EXPECT_SUCCESS(setup_server_keys(conn, &chacha20_poly1305_key));
-        EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
+        s2n_result result = s2n_record_write(conn, TLS_APPLICATION_DATA, &in);
         if (i <= max_fragment) {
-            EXPECT_EQUAL(bytes_written, i);
+            EXPECT_OK(result);
+            bytes_written = i;
         } else {
-            /* application data size of intended fragment size + 1 should only send max fragment */
-            EXPECT_EQUAL(bytes_written, max_fragment);
+            EXPECT_ERROR_WITH_ERRNO(result, S2N_ERR_FRAGMENT_LENGTH_TOO_LARGE);
+            bytes_written = max_fragment;
         }
 
         static const int overhead = S2N_TLS_CHACHA20_POLY1305_EXPLICIT_IV_LEN /* Should be 0 */
@@ -149,7 +150,7 @@ int main(int argc, char **argv)
         conn->actual_protocol_version = S2N_TLS12;
         EXPECT_SUCCESS(destroy_server_keys(conn));
         EXPECT_SUCCESS(setup_server_keys(conn, &chacha20_poly1305_key));
-        EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
+        EXPECT_OK(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
         /* Now lets corrupt some data and ensure the tests pass */
         /* Copy the encrypted out data to the in data */
@@ -190,7 +191,7 @@ int main(int argc, char **argv)
             conn->actual_protocol_version = S2N_TLS12;
             EXPECT_SUCCESS(destroy_server_keys(conn));
             EXPECT_SUCCESS(setup_server_keys(conn, &chacha20_poly1305_key));
-            EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
+            EXPECT_OK(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -217,7 +218,7 @@ int main(int argc, char **argv)
             conn->actual_protocol_version = S2N_TLS12;
             EXPECT_SUCCESS(destroy_server_keys(conn));
             EXPECT_SUCCESS(setup_server_keys(conn, &chacha20_poly1305_key));
-            EXPECT_SUCCESS(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
+            EXPECT_OK(s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
             /* Copy the encrypted out data to the in data */
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));

--- a/tests/unit/s2n_aes_sha_composite_test.c
+++ b/tests/unit/s2n_aes_sha_composite_test.c
@@ -100,7 +100,6 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
             conn->actual_protocol_version = proto_versions[j];
-            EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
             int explicit_iv_len;
             if (conn->actual_protocol_version > S2N_TLS10) {
@@ -109,11 +108,13 @@ int main(int argc, char **argv)
                 explicit_iv_len = 0;
             }
 
+            s2n_result result = s2n_record_write(conn, TLS_APPLICATION_DATA, &in);
             if (i <= max_aligned_fragment) {
-                EXPECT_EQUAL(bytes_written, i);
+                EXPECT_OK(result);
+                bytes_written = i;
             } else {
-                /* application data size of intended fragment size + 1 should only send max fragment */
-                EXPECT_EQUAL(bytes_written, max_aligned_fragment);
+                EXPECT_ERROR_WITH_ERRNO(result, S2N_ERR_FRAGMENT_LENGTH_TOO_LARGE);
+                bytes_written = max_aligned_fragment;
             }
 
             uint16_t predicted_length = bytes_written + 1 + SHA_DIGEST_LENGTH + explicit_iv_len;
@@ -174,7 +175,6 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
             conn->actual_protocol_version = proto_versions[j];
-            EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
             int explicit_iv_len;
             if (conn->actual_protocol_version > S2N_TLS10) {
@@ -183,11 +183,13 @@ int main(int argc, char **argv)
                 explicit_iv_len = 0;
             }
 
+            s2n_result result = s2n_record_write(conn, TLS_APPLICATION_DATA, &in);
             if (i <= max_aligned_fragment) {
-                EXPECT_EQUAL(bytes_written, i);
+                EXPECT_OK(result);
+                bytes_written = i;
             } else {
-                /* application data size of intended fragment size + 1 should only send max fragment */
-                EXPECT_EQUAL(bytes_written, max_aligned_fragment);
+                EXPECT_ERROR_WITH_ERRNO(result, S2N_ERR_FRAGMENT_LENGTH_TOO_LARGE);
+                bytes_written = max_aligned_fragment;
             }
 
             uint16_t predicted_length = bytes_written + 1 + SHA_DIGEST_LENGTH + explicit_iv_len;
@@ -248,7 +250,6 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
             conn->actual_protocol_version = proto_versions[j];
-            EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
             int explicit_iv_len;
             if (conn->actual_protocol_version > S2N_TLS10) {
@@ -257,11 +258,13 @@ int main(int argc, char **argv)
                 explicit_iv_len = 0;
             }
 
+            s2n_result result = s2n_record_write(conn, TLS_APPLICATION_DATA, &in);
             if (i <= max_aligned_fragment) {
-                EXPECT_EQUAL(bytes_written, i);
+                EXPECT_OK(result);
+                bytes_written = i;
             } else {
-                /* application data size of intended fragment size + 1 should only send max fragment */
-                EXPECT_EQUAL(bytes_written, max_aligned_fragment);
+                EXPECT_ERROR_WITH_ERRNO(result, S2N_ERR_FRAGMENT_LENGTH_TOO_LARGE);
+                bytes_written = max_aligned_fragment;
             }
 
             uint16_t predicted_length = bytes_written + 1 + SHA256_DIGEST_LENGTH + explicit_iv_len;
@@ -322,7 +325,6 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
             conn->actual_protocol_version = proto_versions[j];
-            EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
             int explicit_iv_len;
             if (conn->actual_protocol_version > S2N_TLS10) {
@@ -331,11 +333,13 @@ int main(int argc, char **argv)
                 explicit_iv_len = 0;
             }
 
+            s2n_result result = s2n_record_write(conn, TLS_APPLICATION_DATA, &in);
             if (i <= max_aligned_fragment) {
-                EXPECT_EQUAL(bytes_written, i);
+                EXPECT_OK(result);
+                bytes_written = i;
             } else {
-                /* application data size of intended fragment size + 1 should only send max fragment */
-                EXPECT_EQUAL(bytes_written, max_aligned_fragment);
+                EXPECT_ERROR_WITH_ERRNO(result, S2N_ERR_FRAGMENT_LENGTH_TOO_LARGE);
+                bytes_written = max_aligned_fragment;
             }
 
             uint16_t predicted_length = bytes_written + 1 + SHA256_DIGEST_LENGTH + explicit_iv_len;

--- a/tests/unit/s2n_aes_test.c
+++ b/tests/unit/s2n_aes_test.c
@@ -63,13 +63,14 @@ int main(int argc, char **argv)
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
-        EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
+        s2n_result result = s2n_record_write(conn, TLS_APPLICATION_DATA, &in);
         if (i <= S2N_DEFAULT_FRAGMENT_LENGTH) {
-            EXPECT_EQUAL(bytes_written, i);
+            EXPECT_OK(result);
+            bytes_written = i;
         } else {
-            /* application data size of intended fragment size + 1 should only send max fragment */
-            EXPECT_EQUAL(bytes_written, S2N_DEFAULT_FRAGMENT_LENGTH);
+            EXPECT_ERROR_WITH_ERRNO(result, S2N_ERR_FRAGMENT_LENGTH_TOO_LARGE);
+            bytes_written = S2N_DEFAULT_FRAGMENT_LENGTH;
         }
 
         uint16_t predicted_length = bytes_written + 1 + 20 + 16;
@@ -127,13 +128,14 @@ int main(int argc, char **argv)
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
-        EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
+        s2n_result result = s2n_record_write(conn, TLS_APPLICATION_DATA, &in);
         if (i <= S2N_DEFAULT_FRAGMENT_LENGTH) {
-            EXPECT_EQUAL(bytes_written, i);
+            EXPECT_OK(result);
+            bytes_written = i;
         } else {
-            /* application data size of intended fragment size + 1 should only send max fragment */
-            EXPECT_EQUAL(bytes_written, S2N_DEFAULT_FRAGMENT_LENGTH);
+            EXPECT_ERROR_WITH_ERRNO(result, S2N_ERR_FRAGMENT_LENGTH_TOO_LARGE);
+            bytes_written = S2N_DEFAULT_FRAGMENT_LENGTH;
         }
 
         uint16_t predicted_length = bytes_written + 1 + 20 + 16;

--- a/tests/unit/s2n_client_hello_request_test.c
+++ b/tests/unit/s2n_client_hello_request_test.c
@@ -55,7 +55,7 @@ static S2N_RESULT s2n_send_client_hello_request(struct s2n_connection *server_co
 
     /* Send */
     s2n_blocked_status blocked = S2N_NOT_BLOCKED;
-    RESULT_GUARD_POSIX(s2n_record_write(server_conn, TLS_HANDSHAKE, &message_blob));
+    RESULT_GUARD(s2n_record_write(server_conn, TLS_HANDSHAKE, &message_blob));
     RESULT_GUARD_POSIX(s2n_flush(server_conn, &blocked));
 
     /* Cleanup */

--- a/tests/unit/s2n_post_handshake_recv_test.c
+++ b/tests/unit/s2n_post_handshake_recv_test.c
@@ -69,9 +69,7 @@ static S2N_RESULT s2n_test_send_records(struct s2n_connection *conn, struct s2n_
     while ((remaining = s2n_stuffer_data_available(&messages)) > 0) {
         record_data.size = MIN(record_data.size, remaining);
         RESULT_GUARD_POSIX(s2n_stuffer_read(&messages, &record_data));
-        int r = s2n_record_write(conn, TLS_HANDSHAKE, &record_data);
-        RESULT_GUARD_POSIX(r);
-        RESULT_ENSURE_EQ(r, record_data.size);
+        RESULT_GUARD(s2n_record_write(conn, TLS_HANDSHAKE, &record_data));
         RESULT_GUARD_POSIX(s2n_flush(conn, &blocked));
     };
 

--- a/tests/unit/s2n_rc4_test.c
+++ b/tests/unit/s2n_rc4_test.c
@@ -69,13 +69,14 @@ int main(int argc, char **argv)
             int bytes_written;
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
-            EXPECT_SUCCESS(bytes_written = s2n_record_write(conn, TLS_APPLICATION_DATA, &in));
 
+            s2n_result result = s2n_record_write(conn, TLS_APPLICATION_DATA, &in);
             if (i <= S2N_DEFAULT_FRAGMENT_LENGTH) {
-                EXPECT_EQUAL(bytes_written, i);
+                EXPECT_OK(result);
+                bytes_written = i;
             } else {
-                /* application data size of intended fragment size + 1 should only send max fragment */
-                EXPECT_EQUAL(bytes_written, S2N_DEFAULT_FRAGMENT_LENGTH);
+                EXPECT_ERROR_WITH_ERRNO(result, S2N_ERR_FRAGMENT_LENGTH_TOO_LARGE);
+                bytes_written = S2N_DEFAULT_FRAGMENT_LENGTH;
             }
 
             uint16_t predicted_length = bytes_written + 20;

--- a/tests/unit/s2n_record_size_test.c
+++ b/tests/unit/s2n_record_size_test.c
@@ -430,7 +430,7 @@ int main(int argc, char **argv)
 
         const uint16_t TLS13_RECORD_OVERHEAD = 22;
         EXPECT_SUCCESS(bytes_taken = s2n_record_writev(server_conn, TLS_APPLICATION_DATA, &small_io_vec, 1, 0, small_blob.size));
-        EXPECT_EQUAL(bytes_taken, ONE_BLOCK); /* we wrote the full blob size */
+        EXPECT_EQUAL(bytes_taken, ONE_BLOCK);                                                           /* we wrote the full blob size */
         EXPECT_EQUAL(s2n_stuffer_data_available(&server_conn->out), ONE_BLOCK + TLS13_RECORD_OVERHEAD); /* bytes on the wire */
 
         /* Check we get a friendly error if we use s2n_record_write again */
@@ -445,12 +445,12 @@ int main(int argc, char **argv)
         big_io_vec.iov_base = big_blob.data;
         big_io_vec.iov_len = big_blob.size;
 
-        /* Test that s2n_record_write() doesn't error on writing large payloads.
+        /* Test that s2n_record_writev() doesn't error on writing large payloads.
          * Also asserts the bytes written on the wire.
          */
         EXPECT_SUCCESS(bytes_taken = s2n_record_writev(server_conn, TLS_APPLICATION_DATA, &big_io_vec, 1, 0, big_blob.size));
 
-        /* We verify that s2n_record_write() is able to send the maximum fragment length as specified by TLS RFCs */
+        /* We verify that s2n_record_writev() is able to send the maximum fragment length as specified by TLS RFCs */
         const uint16_t TLS_MAX_FRAG_LEN = 16384;
         EXPECT_EQUAL(bytes_taken, TLS_MAX_FRAG_LEN);                                                           /* plaintext bytes taken */
         EXPECT_EQUAL(s2n_stuffer_data_available(&server_conn->out), TLS_MAX_FRAG_LEN + TLS13_RECORD_OVERHEAD); /* bytes sent on the wire */

--- a/tests/unit/s2n_tls13_handshake_early_data_test.c
+++ b/tests/unit/s2n_tls13_handshake_early_data_test.c
@@ -294,7 +294,7 @@ int main()
             EXPECT_BYTEARRAY_EQUAL(client_conn->secure->client_implicit_iv, iv.data, iv.size);
 
             /* Check payload encrypted correctly */
-            EXPECT_SUCCESS(s2n_record_write(client_conn, TLS_APPLICATION_DATA, &payload));
+            EXPECT_OK(s2n_record_write(client_conn, TLS_APPLICATION_DATA, &payload));
             EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->out), complete_record.size);
             EXPECT_BYTEARRAY_EQUAL(client_conn->out.blob.data, complete_record.data, complete_record.size);
 

--- a/tests/unit/s2n_tls13_record_aead_test.c
+++ b/tests/unit/s2n_tls13_record_aead_test.c
@@ -245,7 +245,7 @@ int main(int argc, char **argv)
         };
 
         /* Takes an input blob and writes to out stuffer then encrypt the payload */
-        EXPECT_SUCCESS(s2n_record_write(conn, TLS_HANDSHAKE, &in));
+        EXPECT_OK(s2n_record_write(conn, TLS_HANDSHAKE, &in));
 
         /* Verify opaque content type in tls 1.3 */
         EXPECT_EQUAL(conn->out.blob.data[0], TLS_APPLICATION_DATA);
@@ -298,7 +298,7 @@ int main(int argc, char **argv)
         struct s2n_blob plaintext = { .data = hello_data, .size = sizeof(hello_data) - 1 };
 
         /* Takes an input blob and writes to out stuffer then encrypt the payload */
-        EXPECT_SUCCESS(s2n_record_write(conn, TLS_HANDSHAKE, &plaintext));
+        EXPECT_OK(s2n_record_write(conn, TLS_HANDSHAKE, &plaintext));
 
         /* Reset sequence number */
         conn->secure->client_sequence_number[7] = 0;
@@ -369,7 +369,7 @@ int main(int argc, char **argv)
             struct s2n_blob in = { .data = change_cipher_spec, .size = sizeof(change_cipher_spec) };
 
             /* Takes an input blob and writes to out stuffer then encrypt the payload */
-            EXPECT_SUCCESS(s2n_record_write(conn, TLS_CHANGE_CIPHER_SPEC, &in));
+            EXPECT_OK(s2n_record_write(conn, TLS_CHANGE_CIPHER_SPEC, &in));
 
             S2N_STUFFER_READ_EXPECT_EQUAL(&conn->out, TLS_CHANGE_CIPHER_SPEC, uint8);
             S2N_STUFFER_READ_EXPECT_EQUAL(&conn->out, 0x0303, uint16);
@@ -379,7 +379,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
 
             /* An encrypted TLS 1.3 HANDSHAKE type will look like a APPLICATION_DATA over the wire */
-            EXPECT_SUCCESS(s2n_record_write(conn, TLS_HANDSHAKE, &in));
+            EXPECT_OK(s2n_record_write(conn, TLS_HANDSHAKE, &in));
 
             /* now test that application data writes encrypted payload */
             S2N_STUFFER_READ_EXPECT_EQUAL(&conn->out, TLS_APPLICATION_DATA, uint8);

--- a/tests/unit/s2n_tls13_zero_length_payload_test.c
+++ b/tests/unit/s2n_tls13_zero_length_payload_test.c
@@ -67,11 +67,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&client_to_server, &server_to_client, server_conn));
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_to_client, &client_to_server, client_conn));
 
-        EXPECT_SUCCESS(s2n_record_write(client_conn, TLS_APPLICATION_DATA, &zero_length_data));
+        EXPECT_OK(s2n_record_write(client_conn, TLS_APPLICATION_DATA, &zero_length_data));
         EXPECT_SUCCESS(s2n_flush(client_conn, &blocked));
         EXPECT_TRUE(s2n_stuffer_data_available(&client_to_server) > 0);
 
-        EXPECT_SUCCESS(s2n_record_write(server_conn, TLS_APPLICATION_DATA, &zero_length_data));
+        EXPECT_OK(s2n_record_write(server_conn, TLS_APPLICATION_DATA, &zero_length_data));
         EXPECT_SUCCESS(s2n_flush(server_conn, &blocked));
         EXPECT_TRUE(s2n_stuffer_data_available(&server_to_client) > 0);
 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1203,7 +1203,7 @@ static int s2n_handshake_write_io(struct s2n_connection *conn)
         if (s2n_connection_is_quic_enabled(conn)) {
             POSIX_GUARD_RESULT(s2n_quic_write_handshake_message(conn, &out));
         } else {
-            POSIX_GUARD(s2n_record_write(conn, record_type, &out));
+            POSIX_GUARD_RESULT(s2n_record_write(conn, record_type, &out));
         }
 
         /* MD5 and SHA sum the handshake data too */

--- a/tls/s2n_key_update.c
+++ b/tls/s2n_key_update.c
@@ -80,7 +80,7 @@ int s2n_key_update_send(struct s2n_connection *conn, s2n_blocked_status *blocked
         POSIX_GUARD(s2n_key_update_write(&key_update_blob));
 
         /* Encrypt the message */
-        POSIX_GUARD(s2n_record_write(conn, TLS_HANDSHAKE, &key_update_blob));
+        POSIX_GUARD_RESULT(s2n_record_write(conn, TLS_HANDSHAKE, &key_update_blob));
 
         /* Update encryption key */
         POSIX_GUARD(s2n_update_application_traffic_keys(conn, conn->mode, SENDING));

--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -81,7 +81,7 @@
 S2N_RESULT s2n_record_max_write_size(struct s2n_connection *conn, uint16_t max_fragment_size, uint16_t *max_record_size);
 S2N_RESULT s2n_record_max_write_payload_size(struct s2n_connection *conn, uint16_t *max_fragment_size);
 S2N_RESULT s2n_record_min_write_payload_size(struct s2n_connection *conn, uint16_t *payload_size);
-int s2n_record_write(struct s2n_connection *conn, uint8_t content_type, struct s2n_blob *in);
+S2N_RESULT s2n_record_write(struct s2n_connection *conn, uint8_t content_type, struct s2n_blob *in);
 int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const struct iovec *in, int in_count, size_t offs, size_t to_write);
 int s2n_record_parse(struct s2n_connection *conn);
 int s2n_record_header_parse(struct s2n_connection *conn, uint8_t *content_type, uint16_t *fragment_length);

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -519,10 +519,13 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
     return data_bytes_to_take;
 }
 
-int s2n_record_write(struct s2n_connection *conn, uint8_t content_type, struct s2n_blob *in)
+S2N_RESULT s2n_record_write(struct s2n_connection *conn, uint8_t content_type, struct s2n_blob *in)
 {
     struct iovec iov;
     iov.iov_base = in->data;
     iov.iov_len = in->size;
-    return s2n_record_writev(conn, content_type, &iov, 1, 0, in->size);
+    int written = s2n_record_writev(conn, content_type, &iov, 1, 0, in->size);
+    RESULT_GUARD_POSIX(written);
+    RESULT_ENSURE(written == in->size, S2N_ERR_FRAGMENT_LENGTH_TOO_LARGE);
+    return S2N_RESULT_OK;
 }

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -98,7 +98,7 @@ WRITE:
         struct s2n_blob alert = { 0 };
         alert.data = conn->reader_alert_out.blob.data;
         alert.size = 2;
-        POSIX_GUARD(s2n_record_write(conn, TLS_ALERT, &alert));
+        POSIX_GUARD_RESULT(s2n_record_write(conn, TLS_ALERT, &alert));
         POSIX_GUARD(s2n_stuffer_rewrite(&conn->reader_alert_out));
         POSIX_GUARD_RESULT(s2n_alerts_close_if_fatal(conn, &alert));
 
@@ -111,7 +111,7 @@ WRITE:
         struct s2n_blob alert = { 0 };
         alert.data = conn->writer_alert_out.blob.data;
         alert.size = 2;
-        POSIX_GUARD(s2n_record_write(conn, TLS_ALERT, &alert));
+        POSIX_GUARD_RESULT(s2n_record_write(conn, TLS_ALERT, &alert));
         POSIX_GUARD(s2n_stuffer_rewrite(&conn->writer_alert_out));
         POSIX_GUARD_RESULT(s2n_alerts_close_if_fatal(conn, &alert));
 

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -182,7 +182,7 @@ S2N_RESULT s2n_tls13_server_nst_send(struct s2n_connection *conn, s2n_blocked_st
         RESULT_ENSURE_REF(nst_data);
         RESULT_GUARD_POSIX(s2n_blob_init(&nst_blob, nst_data, nst_size));
 
-        RESULT_GUARD_POSIX(s2n_record_write(conn, TLS_HANDSHAKE, &nst_blob));
+        RESULT_GUARD(s2n_record_write(conn, TLS_HANDSHAKE, &nst_blob));
         RESULT_GUARD_POSIX(s2n_flush(conn, blocked));
         RESULT_GUARD_POSIX(s2n_stuffer_wipe(nst_stuffer));
     }


### PR DESCRIPTION
### Description of changes: 

s2n_record_write returns the number of bytes written, but we're not checking that return anywhere. Everywhere s2n_record_write is called, we just assume all input data was actually written.

To fix this, I changed the return type of s2n_record_write to s2n_result (so it CAN'T be mishandled) and added an error if we don't write all the input data.

### Testing:

Unfortunately, while we don't handle the return value of s2n_record_write properly anywhere in the source, we do use it in unit tests. I had to update a lot of unit tests, but the changes were pretty simple.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
