### PR TITLE
Upgrade CBMC infrastructure (starter-kit 2.8.8)

### DIFF
--- a/tests/cbmc/proofs/Makefile.common
+++ b/tests/cbmc/proofs/Makefile.common
@@ -4,7 +4,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-CBMC_STARTER_KIT_VERSION = CBMC starter kit 2.8
+CBMC_STARTER_KIT_VERSION = CBMC starter kit 2.8.8
 
 ################################################################
 # The CBMC Starter Kit depends on the files Makefile.common and

--- a/tests/cbmc/proofs/lib/print_tool_versions.py
+++ b/tests/cbmc/proofs/lib/print_tool_versions.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+
+import logging
+import pathlib
+import shutil
+import subprocess
+
+
+_TOOLS = [
+    "cadical",
+    "cbmc",
+    "cbmc-viewer",
+    "cbmc-starter-kit-update",
+    "kissat",
+    "litani",
+]
+
+
+def _format_versions(table):
+    lines = [
+        "<table>",
+        '<tr><td colspan="2" style="font-weight: bold">Tool Versions</td></tr>',
+    ]
+    for tool, version in table.items():
+        if version:
+            v_str = f'<code><pre style="margin: 0">{version}</pre></code>'
+        else:
+            v_str = '<em>not found</em>'
+        lines.append(
+            f'<tr><td style="font-weight: bold; padding-right: 1em; '
+            f'text-align: right;">{tool}:</td>'
+            f'<td>{v_str}</td></tr>')
+    lines.append("</table>")
+    return "\n".join(lines)
+
+
+def _get_tool_versions():
+    ret = {}
+    for tool in _TOOLS:
+        err = f"Could not determine version of {tool}: "
+        ret[tool] = None
+        if not shutil.which(tool):
+            logging.error("%s'%s' not found on $PATH", err, tool)
+            continue
+        cmd = [tool, "--version"]
+        proc = subprocess.Popen(cmd, text=True, stdout=subprocess.PIPE)
+        try:
+            out, _ = proc.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            logging.error("%s'%s --version' timed out", err, tool)
+            continue
+        if proc.returncode:
+            logging.error(
+                "%s'%s --version' returned %s", err, tool, str(proc.returncode))
+            continue
+        ret[tool] = out.strip()
+    return ret
+
+
+def main():
+    exe_name = pathlib.Path(__file__).name
+    logging.basicConfig(format=f"{exe_name}: %(message)s")
+
+    table = _get_tool_versions()
+    out = _format_versions(table)
+    print(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cbmc/proofs/run-cbmc-proofs.py
+++ b/tests/cbmc/proofs/run-cbmc-proofs.py
@@ -154,7 +154,7 @@ def get_args():
     }, {
             "flags": ["--version"],
             "action": "version",
-            "version": "CBMC starter kit 2.8",
+            "version": "CBMC starter kit 2.8.8",
             "help": "display version and exit"
     }, {
             "flags": ["--no-coverage"],
@@ -337,7 +337,7 @@ async def configure_proof_dirs( # pylint: disable=too-many-arguments
 def add_tool_version_job():
     cmd = [
         "litani", "add-job",
-        "--command", "cbmc-starter-kit-print-tool-versions .",
+        "--command", "./lib/print_tool_versions.py .",
         "--description", "printing out tool versions",
         "--phony-outputs", str(uuid.uuid4()),
         "--pipeline-name", "print_tool_versions",


### PR DESCRIPTION
A followup to #3727 

Updating the CBMC infrastructure to use version 2.8.8 of our [starter-kit](https://github.com/model-checking/cbmc-starter-kit). This update changes how proof tool versions get printed, such that no dependency on the `cbmc-starter-kit` is expected of users or the CI environment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
