### PR TITLE
ci: Update awslc fips version

### DIFF
--- a/codebuild/bin/install_awslc.sh
+++ b/codebuild/bin/install_awslc.sh
@@ -27,7 +27,7 @@ fi
 BUILD_DIR=$1
 INSTALL_DIR=$2
 IS_FIPS=$3
-
+FIPS_VERSION="fips-2022-11-02"
 source codebuild/bin/jobs.sh
 
 mkdir -p "$BUILD_DIR"||true
@@ -36,7 +36,7 @@ git clone https://github.com/awslabs/aws-lc.git
 if [ "$IS_FIPS" == "1" ]; then
   echo "Checking out FIPS branch"
   cd aws-lc
-  git checkout -b fips-2021-10-20 origin/fips-2021-10-20
+  git checkout -b $FIPS_VERSION origin/$FIPS_VERSION
   cd ..
 fi
 


### PR DESCRIPTION
### Resolved issues:

internal

### Description of changes: 

In our testing with libcrypto aws-lc FIPS, we're using the [2021](https://github.com/awslabs/aws-lc/tree/fips-2021-10-20) version, this PR bumps that to the 2022 version.

### Call-outs:

see internal ticket

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? local

```
❯ CC=$(which gcc-12) CXX=$(which g++-12) ./codebuild/bin/install_awslc.sh ./build awslc_fips 1
Cloning into 'aws-lc'...
remote: Enumerating objects: 87296, done.
remote: Counting objects: 100% (422/422), done.
remote: Compressing objects: 100% (251/251), done.
remote: Total 87296 (delta 195), reused 320 (delta 151), pack-reused 86874
Receiving objects: 100% (87296/87296), 142.23 MiB | 25.43 MiB/s, done.
Resolving deltas: 100% (62520/62520), done.
Updating files: 100% (7748/7748), done.
Checking out FIPS branch
branch 'fips-2022-11-02' set up to track 'origin/fips-2022-11-02'.
Switched to a new branch 'fips-2022-11-02'
Building with shared library=1
-- The C compiler identification is GNU 12.2.0
...
ninja: Entering directory `build'
[1/1] Cleaning all built files...
Cleaning... 522 files.
❯ LD_LIBRARY_PATH=./build/awslc_fips/lib ./build/awslc_fips/bin/bssl isfips
1
```

 Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
