### PR TITLE
ci: Fix libfuzzer path for third-party-src dir

### DIFF
--- a/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
+++ b/codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
@@ -23,6 +23,7 @@ phases:
       - |
         if [ -d "third-party-src" ]; then
           cd third-party-src;
+          ln -s /usr/local $CODEBUILD_SRC_DIR/third-party-src/test-deps;
         fi
       - ln -s /usr/local $CODEBUILD_SRC_DIR/test-deps
       - touch tests/fuzz/placeholder_results.txt tests/fuzz/placeholder_output.txt


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

The fuzz tests in the omnibus Codebuild job are failing due to not finding libFuzzer.a in the test-deps directory. The docker image places libFuzzer.a in /usr/local, and symlinks /usr/local to test-deps. However, test-deps is located in third-party-src during a release, and currently /usr/local is not symlinked to this directory in the fuzz test spec.

This PR creates a symlink to this directory in the fuzz test spec during a release, similar to the other specs:
https://github.com/aws/s2n-tls/blob/155be191a77b8ab61d7c4bb66e148095d00c80ad/codebuild/spec/buildspec_ubuntu_integrationv2.yml#L24-L28


### Call-outs:

None

### Testing:

Codebuild runs:
- [Failing omnibus job during release](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nOmnibus/batch/s2nOmnibus%3A37746cc1-615f-4d3f-91fb-07fed6d0834c?region=us-west-2)
- [Successful omnibus job during release, with the fix](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nOmnibus/batch/s2nOmnibus%3Adcdbda57-564c-40ef-9e94-4bae2d62f7fa?region=us-west-2)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
