### PR TITLE
ci: enable multicore builds for unit test

### DIFF
--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -95,7 +95,7 @@ run_unit_tests() {
             -D${CMAKE_PQ_OPTION} \
             -DS2N_BLOCK_NONPORTABLE_OPTIMIZATIONS=True \
             -DBUILD_SHARED_LIBS=on
-    cmake --build ./build
+    cmake --build ./build -j $(nproc)
     test_linked_libcrypto ./build/bin/s2nc
     make -C build test ARGS=-j$(nproc);
 }

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -95,7 +95,7 @@ run_unit_tests() {
             -D${CMAKE_PQ_OPTION} \
             -DS2N_BLOCK_NONPORTABLE_OPTIMIZATIONS=True \
             -DBUILD_SHARED_LIBS=on
-    cmake --build ./build -j $(nproc)
+    cmake --build ./build -- -j $(nproc)
     test_linked_libcrypto ./build/bin/s2nc
     make -C build test ARGS=-j$(nproc);
 }


### PR DESCRIPTION
enable multicore builds for unit test build
    
This commit passes in an additional parameter to the cmake build
invocation which will allow the build process to run in parallel. This
saved about 40 seconds on my local machine, and I saw similar
savings in CI runs.

### Description of changes: 

Pass in the `-j` parameter to make. This will allow make to parallelize the build among the number of cores that the build machine has.

### Call-outs:

Note that we can not use `cmake --build ./build -j $(nproc)` because cmake didn't get support for the `-j` argument until `3.12`, but s2n-tls supports `3.0`. I'm also assuming that our CI has some cmake < `3.12` baked in because I saw failures when I had tried to use `cmake --build ./build -j $(nproc)`.

https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-build-j

### Testing:

I timed a single core and multicore build locally and got the following numbers

```
# multicore
real    2m11.085s
user    3m27.258s
sys     0m45.941s
```

```
# single core
real    2m47.246s
user    2m11.676s
sys     0m35.427s
```

I also manually launched CI runs, and saw that a particular build (s2nUnitNoPq) had the build phase (which is build + unit test run) complete in 240 seconds. I spot-checked older builds and saw times of 280, 257, and 262 seconds.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
