### PR TITLE
chore(ci): add CI workflow for OpenBSD

### DIFF
--- a/.github/s2n_openbsd.sh
+++ b/.github/s2n_openbsd.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+set -eu
+export CTEST_PARALLEL_LEVEL=$(sysctl -n hw.ncpuonline)
+
+cmake . -Brelease -GNinja -DCMAKE_BUILD_TYPE=Release
+cmake --build ./release -j $CTEST_PARALLEL_LEVEL
+ninja -C release test
+cmake --build ./release --target clean #Saves on copy back rsync time
+
+cmake . -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Debug
+cmake --build ./build -j $CTEST_PARALLEL_LEVEL
+ninja -C build test
+cmake --build ./build --target clean #Saves on copy back rsync time

--- a/.github/workflows/ci_openbsd.yml
+++ b/.github/workflows/ci_openbsd.yml
@@ -1,0 +1,42 @@
+name: OpenBSD
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  testopenbsd:
+    runs-on: macos-12
+    name: CI OpenBSD
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and test in OpenBSD
+        id: test
+        uses: vmactions/openbsd-vm@v0.1.2
+        with:
+          mem: 2048
+          prepare: |
+            # The / (root) mount point in the VM doesn't have enough disk
+            # space to build the project. These commands put the actual 'work'
+            # directory in the /home mount (which has lots of disk space) and
+            # creates symlinks to 'work' in the locations that the runner uses
+            # when copying artifacts back and forth between the VM and macOS
+            # host.
+            mv /Users/runner /home
+            rm -rf /Users
+            ln -s /home /Users
+            ln -sf /home/work /root/work
+            pkg_add ninja cmake
+            pkg_info
+          run: |
+            sysctl -n kern.version
+            .github/s2n_openbsd.sh
+      - name: upload test results
+        if: always()
+        uses: actions/upload-artifact@master
+        with:
+          name: all_test_output
+          path: |
+            release/testing/temporary
+            build/testing/temporary


### PR DESCRIPTION
### Resolved issues:

n/a

### Description of changes: 

This PR adds CI for OpenBSD. The workflow and shell script are based on the FreeBSD CI files. 

### Call-outs:

Beyond just validating that s2n-tls builds and tests pass on another platform, OpenBSD uses libressl out of the box (no surprise since libressl comes out of the OpenBSD project) therefore, having OpenBSD in CI means s2n-tls will be tested against libressl going forward.

This workflow is slow. Unfortunately, the VM that vmactions/openbsd-vm provides is single-CPU. Combine that with the overhead of virtualization in the runner, and this job easily exceeds 30 minutes.

### Testing:

This results of the workflow triggered by this PR: https://github.com/aws/s2n-tls/actions/runs/3899161024/jobs/6658574365

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
