### PR TITLE
Rename OCSP extensions

### DIFF
--- a/tests/unit/s2n_requester_status_request_extension_test.c
+++ b/tests/unit/s2n_requester_status_request_extension_test.c
@@ -14,7 +14,7 @@
  */
 
 #include "s2n_test.h"
-#include "tls/extensions/s2n_client_status_request.h"
+#include "tls/extensions/s2n_requester_status_request.h"
 #include "tls/s2n_resume.h"
 
 int main(int argc, char **argv)
@@ -32,11 +32,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
         /* status request should NOT be sent by default */
-        EXPECT_FALSE(s2n_client_status_request_extension.should_send(conn));
+        EXPECT_FALSE(s2n_requester_status_request_extension.should_send(conn));
 
         /* status request should be sent if ocsp requested */
         config->status_request_type = S2N_STATUS_REQUEST_OCSP;
-        EXPECT_TRUE(s2n_client_status_request_extension.should_send(conn));
+        EXPECT_TRUE(s2n_requester_status_request_extension.should_send(conn));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     };
@@ -53,7 +53,7 @@ int main(int argc, char **argv)
         struct s2n_stuffer stuffer;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        EXPECT_SUCCESS(s2n_client_status_request_extension.send(conn, &stuffer));
+        EXPECT_SUCCESS(s2n_requester_status_request_extension.send(conn, &stuffer));
 
         uint8_t request_type;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &request_type));
@@ -78,10 +78,10 @@ int main(int argc, char **argv)
         struct s2n_stuffer stuffer;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        EXPECT_SUCCESS(s2n_client_status_request_extension.send(conn, &stuffer));
+        EXPECT_SUCCESS(s2n_requester_status_request_extension.send(conn, &stuffer));
 
         EXPECT_EQUAL(conn->status_type, S2N_STATUS_REQUEST_NONE);
-        EXPECT_SUCCESS(s2n_client_status_request_extension.recv(conn, &stuffer));
+        EXPECT_SUCCESS(s2n_requester_status_request_extension.recv(conn, &stuffer));
         EXPECT_EQUAL(conn->status_type, S2N_STATUS_REQUEST_OCSP);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
@@ -97,11 +97,11 @@ int main(int argc, char **argv)
         struct s2n_stuffer stuffer;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        EXPECT_SUCCESS(s2n_client_status_request_extension.send(conn, &stuffer));
+        EXPECT_SUCCESS(s2n_requester_status_request_extension.send(conn, &stuffer));
         EXPECT_SUCCESS(s2n_stuffer_wipe_n(&stuffer, sizeof(uint16_t)));
 
         EXPECT_EQUAL(conn->status_type, S2N_STATUS_REQUEST_NONE);
-        EXPECT_SUCCESS(s2n_client_status_request_extension.recv(conn, &stuffer));
+        EXPECT_SUCCESS(s2n_requester_status_request_extension.recv(conn, &stuffer));
         EXPECT_EQUAL(conn->status_type, S2N_STATUS_REQUEST_NONE);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
@@ -121,10 +121,10 @@ int main(int argc, char **argv)
         struct s2n_stuffer stuffer;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        EXPECT_SUCCESS(s2n_client_status_request_extension.send(conn, &stuffer));
+        EXPECT_SUCCESS(s2n_requester_status_request_extension.send(conn, &stuffer));
 
         EXPECT_EQUAL(conn->status_type, S2N_STATUS_REQUEST_NONE);
-        EXPECT_SUCCESS(s2n_client_status_request_extension.recv(conn, &stuffer));
+        EXPECT_SUCCESS(s2n_requester_status_request_extension.recv(conn, &stuffer));
         EXPECT_EQUAL(conn->status_type, S2N_STATUS_REQUEST_NONE);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));

--- a/tests/unit/s2n_tls13_responder_status_request_extension_test.c
+++ b/tests/unit/s2n_tls13_responder_status_request_extension_test.c
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-#include "tls/extensions/s2n_server_certificate_status.h"
+#include "tls/extensions/s2n_tls13_responder_status_request.h"
 
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
@@ -48,31 +48,31 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
         /* Don't send by default */
-        EXPECT_FALSE(s2n_tls13_server_status_request_extension.should_send(conn));
+        EXPECT_FALSE(s2n_tls13_responder_status_request_extension.should_send(conn));
 
         /* Send if all prerequisites met */
         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
-        EXPECT_TRUE(s2n_tls13_server_status_request_extension.should_send(conn));
+        EXPECT_TRUE(s2n_tls13_responder_status_request_extension.should_send(conn));
 
         /* Don't send if client */
         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
         conn->mode = S2N_CLIENT;
-        EXPECT_FALSE(s2n_tls13_server_status_request_extension.should_send(conn));
+        EXPECT_FALSE(s2n_tls13_responder_status_request_extension.should_send(conn));
 
         /* Don't send if no status request configured */
         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
         conn->status_type = S2N_STATUS_REQUEST_NONE;
-        EXPECT_FALSE(s2n_tls13_server_status_request_extension.should_send(conn));
+        EXPECT_FALSE(s2n_tls13_responder_status_request_extension.should_send(conn));
 
         /* Don't send if no certificate set */
         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
         conn->handshake_params.our_chain_and_key = NULL;
-        EXPECT_FALSE(s2n_tls13_server_status_request_extension.should_send(conn));
+        EXPECT_FALSE(s2n_tls13_responder_status_request_extension.should_send(conn));
 
         /* Don't send if no ocsp data */
         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
         EXPECT_SUCCESS(s2n_free(&conn->handshake_params.our_chain_and_key->ocsp_status));
-        EXPECT_FALSE(s2n_tls13_server_status_request_extension.should_send(conn));
+        EXPECT_FALSE(s2n_tls13_responder_status_request_extension.should_send(conn));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
         struct s2n_stuffer stuffer;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        EXPECT_SUCCESS(s2n_tls13_server_status_request_extension.send(conn, &stuffer));
+        EXPECT_SUCCESS(s2n_tls13_responder_status_request_extension.send(conn, &stuffer));
 
         uint8_t request_type;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &request_type));
@@ -117,10 +117,10 @@ int main(int argc, char **argv)
         struct s2n_stuffer stuffer;
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        EXPECT_SUCCESS(s2n_tls13_server_status_request_extension.send(conn, &stuffer));
+        EXPECT_SUCCESS(s2n_tls13_responder_status_request_extension.send(conn, &stuffer));
 
         EXPECT_EQUAL(conn->status_response.size, 0);
-        EXPECT_SUCCESS(s2n_tls13_server_status_request_extension.recv(conn, &stuffer));
+        EXPECT_SUCCESS(s2n_tls13_responder_status_request_extension.recv(conn, &stuffer));
         EXPECT_BYTEARRAY_EQUAL(conn->status_response.data, ocsp_data, s2n_array_len(ocsp_data));
 
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
@@ -141,7 +141,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, S2N_STATUS_REQUEST_NONE));
 
         EXPECT_EQUAL(conn->status_response.size, 0);
-        EXPECT_SUCCESS(s2n_tls13_server_status_request_extension.recv(conn, &stuffer));
+        EXPECT_SUCCESS(s2n_tls13_responder_status_request_extension.recv(conn, &stuffer));
         EXPECT_EQUAL(conn->status_response.size, 0);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&stuffer));
@@ -157,14 +157,14 @@ int main(int argc, char **argv)
         DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        EXPECT_SUCCESS(s2n_tls13_server_status_request_extension.send(conn, &stuffer));
+        EXPECT_SUCCESS(s2n_tls13_responder_status_request_extension.send(conn, &stuffer));
 
         if (s2n_x509_ocsp_stapling_supported()) {
-            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_server_status_request_extension.recv(conn, &stuffer),
+            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_responder_status_request_extension.recv(conn, &stuffer),
                     S2N_ERR_INVALID_OCSP_RESPONSE);
         } else {
             /* s2n_x509_validator_validate_cert_stapled_ocsp_response returns untrusted error if ocsp is not supported */
-            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_server_status_request_extension.recv(conn, &stuffer),
+            EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_responder_status_request_extension.recv(conn, &stuffer),
                     S2N_ERR_CERT_UNTRUSTED);
         }
 

--- a/tests/unit/s2n_tls13_responder_status_request_extension_test.c
+++ b/tests/unit/s2n_tls13_responder_status_request_extension_test.c
@@ -13,10 +13,9 @@
  * permissions and limitations under the License.
  */
 
-#include "tls/extensions/s2n_tls13_responder_status_request.h"
-
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
+#include "tls/extensions/s2n_tls13_responder_status_request.h"
 
 const uint8_t ocsp_data[] = "OCSP DATA";
 struct s2n_cert_chain_and_key *chain_and_key;

--- a/tls/extensions/s2n_extension_type_lists.c
+++ b/tls/extensions/s2n_extension_type_lists.c
@@ -26,7 +26,6 @@
 #include "tls/extensions/s2n_client_server_name.h"
 #include "tls/extensions/s2n_client_session_ticket.h"
 #include "tls/extensions/s2n_client_signature_algorithms.h"
-#include "tls/extensions/s2n_requester_status_request.h"
 #include "tls/extensions/s2n_client_supported_groups.h"
 #include "tls/extensions/s2n_client_supported_versions.h"
 #include "tls/extensions/s2n_cookie.h"
@@ -36,8 +35,8 @@
 #include "tls/extensions/s2n_npn.h"
 #include "tls/extensions/s2n_psk_key_exchange_modes.h"
 #include "tls/extensions/s2n_quic_transport_params.h"
+#include "tls/extensions/s2n_requester_status_request.h"
 #include "tls/extensions/s2n_server_alpn.h"
-#include "tls/extensions/s2n_tls13_responder_status_request.h"
 #include "tls/extensions/s2n_server_key_share.h"
 #include "tls/extensions/s2n_server_max_fragment_length.h"
 #include "tls/extensions/s2n_server_psk.h"
@@ -48,6 +47,7 @@
 #include "tls/extensions/s2n_server_signature_algorithms.h"
 #include "tls/extensions/s2n_server_status_request.h"
 #include "tls/extensions/s2n_server_supported_versions.h"
+#include "tls/extensions/s2n_tls13_responder_status_request.h"
 #include "tls/s2n_connection.h"
 
 static const s2n_extension_type *const client_hello_extensions[] = {

--- a/tls/extensions/s2n_extension_type_lists.c
+++ b/tls/extensions/s2n_extension_type_lists.c
@@ -26,7 +26,7 @@
 #include "tls/extensions/s2n_client_server_name.h"
 #include "tls/extensions/s2n_client_session_ticket.h"
 #include "tls/extensions/s2n_client_signature_algorithms.h"
-#include "tls/extensions/s2n_client_status_request.h"
+#include "tls/extensions/s2n_requester_status_request.h"
 #include "tls/extensions/s2n_client_supported_groups.h"
 #include "tls/extensions/s2n_client_supported_versions.h"
 #include "tls/extensions/s2n_cookie.h"
@@ -37,7 +37,7 @@
 #include "tls/extensions/s2n_psk_key_exchange_modes.h"
 #include "tls/extensions/s2n_quic_transport_params.h"
 #include "tls/extensions/s2n_server_alpn.h"
-#include "tls/extensions/s2n_server_certificate_status.h"
+#include "tls/extensions/s2n_tls13_responder_status_request.h"
 #include "tls/extensions/s2n_server_key_share.h"
 #include "tls/extensions/s2n_server_max_fragment_length.h"
 #include "tls/extensions/s2n_server_psk.h"
@@ -67,7 +67,7 @@ static const s2n_extension_type *const client_hello_extensions[] = {
     &s2n_client_alpn_extension,
     &s2n_client_npn_extension,
 
-    &s2n_client_status_request_extension,
+    &s2n_requester_status_request_extension,
     &s2n_client_sct_list_extension,
     &s2n_client_max_frag_len_extension,
     &s2n_client_session_ticket_extension,
@@ -132,7 +132,7 @@ static const s2n_extension_type *const cert_req_extensions[] = {
 };
 
 static const s2n_extension_type *const certificate_extensions[] = {
-    &s2n_tls13_server_status_request_extension,
+    &s2n_tls13_responder_status_request_extension,
     &s2n_server_sct_list_extension,
 };
 

--- a/tls/extensions/s2n_requester_status_request.c
+++ b/tls/extensions/s2n_requester_status_request.c
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-#include "tls/extensions/s2n_client_status_request.h"
+#include "tls/extensions/s2n_requester_status_request.h"
 
 #include <stdint.h>
 #include <sys/param.h>
@@ -22,25 +22,25 @@
 #include "tls/s2n_tls_parameters.h"
 #include "utils/s2n_safety.h"
 
-static bool s2n_client_status_request_should_send(struct s2n_connection *conn);
-static int s2n_client_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-static int s2n_client_status_request_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
+static bool s2n_requester_status_request_should_send(struct s2n_connection *conn);
+static int s2n_requester_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+static int s2n_requester_status_request_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
-const s2n_extension_type s2n_client_status_request_extension = {
+const s2n_extension_type s2n_requester_status_request_extension = {
     .iana_value = TLS_EXTENSION_STATUS_REQUEST,
     .is_response = false,
-    .send = s2n_client_status_request_send,
-    .recv = s2n_client_status_request_recv,
-    .should_send = s2n_client_status_request_should_send,
+    .send = s2n_requester_status_request_send,
+    .recv = s2n_requester_status_request_recv,
+    .should_send = s2n_requester_status_request_should_send,
     .if_missing = s2n_extension_noop_if_missing,
 };
 
-static bool s2n_client_status_request_should_send(struct s2n_connection *conn)
+static bool s2n_requester_status_request_should_send(struct s2n_connection *conn)
 {
     return conn->config->status_request_type != S2N_STATUS_REQUEST_NONE;
 }
 
-static int s2n_client_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+static int s2n_requester_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     POSIX_GUARD(s2n_stuffer_write_uint8(out, (uint8_t) conn->config->status_request_type));
 
@@ -60,7 +60,7 @@ static int s2n_client_status_request_send(struct s2n_connection *conn, struct s2
     return S2N_SUCCESS;
 }
 
-static int s2n_client_status_request_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
+static int s2n_requester_status_request_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
     if (s2n_stuffer_data_available(extension) < 5) {
         /* Malformed length, ignore the extension */

--- a/tls/extensions/s2n_requester_status_request.h
+++ b/tls/extensions/s2n_requester_status_request.h
@@ -19,7 +19,4 @@
 #include "tls/extensions/s2n_extension_type.h"
 #include "tls/s2n_connection.h"
 
-extern const s2n_extension_type s2n_tls13_server_status_request_extension;
-
-int s2n_server_certificate_status_send(struct s2n_connection *conn, struct s2n_stuffer *out);
-int s2n_server_certificate_status_recv(struct s2n_connection *conn, struct s2n_stuffer *in);
+extern const s2n_extension_type s2n_requester_status_request_extension;

--- a/tls/extensions/s2n_tls13_responder_status_request.c
+++ b/tls/extensions/s2n_tls13_responder_status_request.c
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-#include "tls/extensions/s2n_server_certificate_status.h"
+#include "tls/extensions/s2n_tls13_responder_status_request.h"
 
 #include "tls/s2n_config.h"
 #include "tls/s2n_connection.h"
@@ -27,23 +27,23 @@
  * status request as well as the OCSP response. This contrasts to TLS 1.2 where
  * the OCSP response is sent in the Certificate Status handshake message */
 
-static bool s2n_tls13_server_status_request_should_send(struct s2n_connection *conn);
+static bool s2n_tls13_responder_status_request_should_send(struct s2n_connection *conn);
 
-const s2n_extension_type s2n_tls13_server_status_request_extension = {
+const s2n_extension_type s2n_tls13_responder_status_request_extension = {
     .iana_value = TLS_EXTENSION_STATUS_REQUEST,
     .is_response = true,
-    .send = s2n_server_certificate_status_send,
-    .recv = s2n_server_certificate_status_recv,
-    .should_send = s2n_tls13_server_status_request_should_send,
+    .send = s2n_tls13_responder_status_request_send,
+    .recv = s2n_tls13_responder_status_request_recv,
+    .should_send = s2n_tls13_responder_status_request_should_send,
     .if_missing = s2n_extension_noop_if_missing,
 };
 
-static bool s2n_tls13_server_status_request_should_send(struct s2n_connection *conn)
+static bool s2n_tls13_responder_status_request_should_send(struct s2n_connection *conn)
 {
     return s2n_server_can_send_ocsp(conn);
 }
 
-int s2n_server_certificate_status_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+int s2n_tls13_responder_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     POSIX_ENSURE_REF(conn);
     struct s2n_blob *ocsp_status = &conn->handshake_params.our_chain_and_key->ocsp_status;
@@ -56,7 +56,7 @@ int s2n_server_certificate_status_send(struct s2n_connection *conn, struct s2n_s
     return S2N_SUCCESS;
 }
 
-int s2n_server_certificate_status_recv(struct s2n_connection *conn, struct s2n_stuffer *in)
+int s2n_tls13_responder_status_request_recv(struct s2n_connection *conn, struct s2n_stuffer *in)
 {
     POSIX_ENSURE_REF(conn);
     /**

--- a/tls/extensions/s2n_tls13_responder_status_request.h
+++ b/tls/extensions/s2n_tls13_responder_status_request.h
@@ -19,4 +19,7 @@
 #include "tls/extensions/s2n_extension_type.h"
 #include "tls/s2n_connection.h"
 
-extern const s2n_extension_type s2n_client_status_request_extension;
+extern const s2n_extension_type s2n_tls13_responder_status_request_extension;
+
+int s2n_tls13_responder_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+int s2n_tls13_responder_status_request_recv(struct s2n_connection *conn, struct s2n_stuffer *in);

--- a/tls/s2n_ocsp_stapling.c
+++ b/tls/s2n_ocsp_stapling.c
@@ -16,7 +16,7 @@
 #include <strings.h>
 
 #include "error/s2n_errno.h"
-#include "tls/extensions/s2n_server_certificate_status.h"
+#include "tls/extensions/s2n_tls13_responder_status_request.h"
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_config.h"
 #include "tls/s2n_connection.h"
@@ -27,7 +27,7 @@
 int s2n_server_status_send(struct s2n_connection *conn)
 {
     if (s2n_server_can_send_ocsp(conn)) {
-        POSIX_GUARD(s2n_server_certificate_status_send(conn, &conn->handshake.io));
+        POSIX_GUARD(s2n_tls13_responder_status_request_send(conn, &conn->handshake.io));
     }
 
     return 0;
@@ -35,5 +35,5 @@ int s2n_server_status_send(struct s2n_connection *conn)
 
 int s2n_server_status_recv(struct s2n_connection *conn)
 {
-    return s2n_server_certificate_status_recv(conn, &conn->handshake.io);
+    return s2n_tls13_responder_status_request_recv(conn, &conn->handshake.io);
 }


### PR DESCRIPTION
### Resolved issues:

Part of https://github.com/aws/s2n-tls/issues/1775

### Description of changes: 

TLS 1.3 allows status_request extensions to be sent in both the client hello, and in the certificate request message. This allows servers to request OCSP stapling from clients:

From [RFC 8446](https://www.rfc-editor.org/rfc/rfc8446#section-4.4.2.1):
```
   A server MAY request that a client present an OCSP response with its
   certificate by sending an empty "status_request" extension in its
   CertificateRequest message.
```

The current names of the OCSP extensions are unintuitive for this behavior. Currently, the names suggest that requesting OCSP stapling is only possible on the client, and sending an OCSP response is only possible on the server. This PR updates the OCSP extension names to be more general, so that the requesting and responding extensions can be applied to both clients and servers.

Renamed extensions:
- s2n_client_status_request -> s2n_requester_status_request
- s2n_server_certificate_status.c / s2n_tls13_server_status_request_extension -> s2n_tls13_responder_status_request

### Call-outs:

Let me know if there are other names that would be better!

A future PR will make the actual change to add OCSP client auth support.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
