### PR TITLE
ci: upgrade checkout action to v3

### DIFF
--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-12
     name: CI FreeBSD
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build and test in FreeBSD
         id: test
         uses: vmactions/freebsd-vm@v0.3.0

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       CPPCHECK_INSTALL_DIR: test-deps/cppcheck
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup
         run: source ./codebuild/bin/s2n_setup_env.sh
@@ -37,7 +37,7 @@ jobs:
   copyright:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup
         run: source ./codebuild/bin/s2n_setup_env.sh
@@ -48,7 +48,7 @@ jobs:
   simple-mistakes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup
         run: source ./codebuild/bin/s2n_setup_env.sh
@@ -59,7 +59,7 @@ jobs:
   comments:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup
         run: source ./codebuild/bin/s2n_setup_env.sh
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: pep8 exp
         uses: harrisonkaiser/autopep8_action@python-latest
         with:

--- a/.github/workflows/ci_openbsd.yml
+++ b/.github/workflows/ci_openbsd.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-12
     name: CI OpenBSD
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build and test in OpenBSD
         id: test
         uses: vmactions/openbsd-vm@v0.1.2

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions-rs/toolchain@v1
         id: toolchain
@@ -54,7 +54,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -82,7 +82,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check out GitHub Pages branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: 'gh-pages'
 

--- a/.github/workflows/gha_failure_monitor.yml
+++ b/.github/workflows/gha_failure_monitor.yml
@@ -18,7 +18,7 @@ jobs:
           - {ORG: "dougch", REPO: "s2n"}
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.x
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/gha_osx_tests.yml
+++ b/.github/workflows/gha_osx_tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout Dependencies
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Prebuild
         run: |

--- a/.github/workflows/private_sync.yml
+++ b/.github/workflows/private_sync.yml
@@ -9,7 +9,7 @@ jobs:
     if: contains(github.repository, 'aws/s2n-tls')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           persist-credentials: false
           fetch-depth: 0


### PR DESCRIPTION
A CI run failed with the following message:"Please update the following actions to use Node.js 16: actions/checkout@v2". We can accomplish the node upgrade by just moving to the newest version of the action.

https://github.com/aws/s2n-tls/actions/runs/3942181338

### Description of changes: 

find and replace `actions/checkout@v2` to `actions/checkout@v3`
### Call-outs:

https://stackoverflow.com/questions/73473617/what-is-the-difference-between-github-actions-checkoutv3-and-v2

I don't expect any differences in behavior besides the node version bump.
### Testing:
No unit testing, as long as it passes CI we should be good to go.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
