### PR TITLE
s2n_shutdown should ignore unread messages

### DIFF
--- a/bin/common.c
+++ b/bin/common.c
@@ -516,10 +516,9 @@ int wait_for_shutdown(struct s2n_connection *conn, int fd)
                 }
                 /* Otherwise, IO errors are fatal and should be investigated */
                 fprintf(stderr, "Unexpected IO error during shutdown: %s\n", strerror(errno_val));
-                exit(1);
+                return S2N_FAILURE;
             default:
-                fprintf(stderr, "Unexpected error during shutdown: %s\n", s2n_strerror(s2n_errno, NULL));
-                exit(1);
+                return S2N_FAILURE;
         }
     }
     return S2N_SUCCESS;

--- a/bin/common.h
+++ b/bin/common.h
@@ -84,6 +84,7 @@ int echo(struct s2n_connection *conn, int sockfd, bool *stop_echo);
 int wait_for_event(int fd, s2n_blocked_status blocked);
 int negotiate(struct s2n_connection *conn, int sockfd);
 int renegotiate(struct s2n_connection *conn, int sockfd, bool wait);
+int wait_for_shutdown(struct s2n_connection *conn, int sockfd);
 int early_data_recv(struct s2n_connection *conn);
 int early_data_send(struct s2n_connection *conn, uint8_t *data, uint32_t len);
 int print_connection_info(struct s2n_connection *conn);

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -743,16 +743,7 @@ int main(int argc, char *const *argv)
             GUARD_EXIT(renegotiate(conn, sockfd, reneg_ctx.wait), "Renegotiation failed");
         }
 
-        /* The following call can block on receiving a close_notify if we initiate the shutdown or if the */
-        /* peer fails to send a close_notify. */
-        /* TODO: However, we should expect to receive a close_notify from the peer and shutdown gracefully. */
-        /* Please see tracking issue for more detail: https://github.com/aws/s2n-tls/issues/2692 */
-        s2n_blocked_status blocked;
-        int shutdown_rc = s2n_shutdown(conn, &blocked);
-        if (shutdown_rc == -1 && blocked != S2N_BLOCKED_ON_READ) {
-            fprintf(stderr, "Unexpected error during shutdown: '%s'\n", s2n_strerror(s2n_errno, "NULL"));
-            exit(1);
-        }
+        wait_for_shutdown(conn, sockfd);
 
         GUARD_EXIT(s2n_connection_free(conn), "Error freeing connection");
 

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -743,7 +743,7 @@ int main(int argc, char *const *argv)
             GUARD_EXIT(renegotiate(conn, sockfd, reneg_ctx.wait), "Renegotiation failed");
         }
 
-        wait_for_shutdown(conn, sockfd);
+        GUARD_EXIT(wait_for_shutdown(conn, sockfd), "Error closing connection");
 
         GUARD_EXIT(s2n_connection_free(conn), "Error freeing connection");
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -236,7 +236,7 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
         echo(conn, fd, &stop_echo);
     }
 
-    wait_for_shutdown(conn, fd);
+    GUARD_RETURN(wait_for_shutdown(conn, fd), "Error closing connection");
 
     GUARD_RETURN(s2n_connection_wipe(conn), "Error wiping connection");
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -236,12 +236,7 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
         echo(conn, fd, &stop_echo);
     }
 
-    /* The following call can block on receiving a close_notify if we initiate the shutdown or if the */
-    /* peer fails to send a close_notify. */
-    /* TODO: However, we should expect to receive a close_notify from the peer and shutdown gracefully. */
-    /* Please see tracking issue for more detail: https://github.com/aws/s2n-tls/issues/2692 */
-    s2n_blocked_status blocked;
-    s2n_shutdown(conn, &blocked);
+    wait_for_shutdown(conn, fd);
 
     GUARD_RETURN(s2n_connection_wipe(conn), "Error wiping connection");
 

--- a/tests/unit/s2n_shutdown_test.c
+++ b/tests/unit/s2n_shutdown_test.c
@@ -30,66 +30,145 @@ int main(int argc, char **argv)
         0 /* AlertDescription = close_notify */
     };
 
-    /* Test s2n_shutdown */
+    const uint8_t alert_record_header[] = {
+        /* record type */
+        TLS_ALERT,
+        /* protocol version */
+        S2N_TLS12 / 10,
+        S2N_TLS12 % 10,
+        /* length */
+        0,
+        S2N_ALERT_LENGTH,
+    };
+
+    /* Test: Await close_notify if no close_notify received yet */
     {
-        /* Await close_notify if close_notify_received is not set */
-        {
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
 
-            struct s2n_stuffer input;
-            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
-            struct s2n_stuffer output;
-            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
-            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, conn));
+        DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, conn));
 
-            /* Verify state prior to alert */
-            EXPECT_FALSE(conn->close_notify_received);
+        /* Verify state prior to alert */
+        EXPECT_FALSE(conn->close_notify_received);
+        EXPECT_FALSE(conn->closed);
 
-            s2n_blocked_status blocked;
-            EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(conn, &blocked), S2N_ERR_IO_BLOCKED);
-            EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(conn, &blocked), S2N_ERR_IO_BLOCKED);
+        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
 
-            /* Verify state after shutdown attempt */
-            EXPECT_FALSE(conn->close_notify_received);
+        /* Verify state after shutdown attempt */
+        EXPECT_FALSE(conn->close_notify_received);
+        EXPECT_TRUE(conn->closed);
+    };
 
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-            EXPECT_SUCCESS(s2n_stuffer_free(&input));
-            EXPECT_SUCCESS(s2n_stuffer_free(&output));
+    /* Test: Do not await close_notify if close_notify already received */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+
+        DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, conn));
+
+        /* Verify state prior to alert */
+        EXPECT_FALSE(conn->close_notify_received);
+        EXPECT_FALSE(conn->closed);
+
+        /* Write and process the alert */
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->in, close_notify_alert, sizeof(close_notify_alert)));
+        EXPECT_SUCCESS(s2n_process_alert_fragment(conn));
+
+        /* Verify state after alert */
+        EXPECT_TRUE(conn->close_notify_received);
+        EXPECT_TRUE(conn->closed);
+
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+        EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
+        EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+
+        /* Verify state after shutdown attempt */
+        EXPECT_TRUE(conn->close_notify_received);
+        EXPECT_TRUE(conn->closed);
+    };
+
+    /* Test: s2n_shutdown ignores data received after a close_notify */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+
+        DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, conn));
+
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(conn, &blocked), S2N_ERR_IO_BLOCKED);
+        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
+
+        /* Receive a non-alert record */
+        uint8_t record_bytes[] = {
+            /* record type */
+            TLS_HANDSHAKE,
+            /* protocol version */
+            S2N_TLS12 / 10,
+            S2N_TLS12 % 10,
+            /* length */
+            0,
+            1,
+            /* data */
+            'x'
         };
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&input, record_bytes, sizeof(record_bytes)));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(conn, &blocked), S2N_ERR_IO_BLOCKED);
+        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
 
-        /* Do not await close_notify if close_notify_received is set */
-        {
-            struct s2n_connection *conn;
-            EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
+        /* Receive the response close_notify */
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&input, alert_record_header, sizeof(alert_record_header)));
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&input, close_notify_alert, sizeof(close_notify_alert)));
+        EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
+    };
 
-            struct s2n_stuffer input;
-            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
-            struct s2n_stuffer output;
-            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
-            EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, conn));
+    /* Test: s2n_shutdown with aggressive socket close */
+    {
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
 
-            /* Verify state prior to alert */
-            EXPECT_FALSE(conn->close_notify_received);
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
 
-            /* Write and process the alert */
-            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->in, close_notify_alert, sizeof(close_notify_alert)));
-            EXPECT_SUCCESS(s2n_process_alert_fragment(conn));
+        struct s2n_test_io_pair io_pair = { 0 };
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
-            /* Verify state after alert */
-            EXPECT_TRUE(conn->close_notify_received);
+        /* The client's first shutdown attempt blocks on the server's close_notify */
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(client_conn, &blocked), S2N_ERR_IO_BLOCKED);
+        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
 
-            s2n_blocked_status blocked;
-            EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
-            EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+        /* The server's next shutdown succeeds.
+         * From the server's perspective the connection is now gracefully shutdown and
+         * the socket can be closed.
+         */
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &blocked));
+        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
 
-            /* Verify state after shutdown attempt */
-            EXPECT_TRUE(conn->close_notify_received);
-
-            EXPECT_SUCCESS(s2n_connection_free(conn));
-            EXPECT_SUCCESS(s2n_stuffer_free(&input));
-            EXPECT_SUCCESS(s2n_stuffer_free(&output));
-        };
+        /* Even though the socket is now closed, we should be able to finish
+         * shutting down the client connection too.
+         */
+        EXPECT_SUCCESS(s2n_shutdown(client_conn, &blocked));
+        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));
     };
 
     END_TEST();

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -251,22 +251,3 @@ uint32_t s2n_peek(struct s2n_connection *conn)
 
     return s2n_stuffer_data_available(&conn->in);
 }
-
-int s2n_recv_close_notify(struct s2n_connection *conn, s2n_blocked_status *blocked)
-{
-    uint8_t record_type;
-    int isSSLv2;
-    *blocked = S2N_BLOCKED_ON_READ;
-
-    POSIX_GUARD(s2n_read_full_record(conn, &record_type, &isSSLv2));
-
-    S2N_ERROR_IF(isSSLv2, S2N_ERR_BAD_MESSAGE);
-
-    S2N_ERROR_IF(record_type != TLS_ALERT, S2N_ERR_SHUTDOWN_RECORD_TYPE);
-
-    /* Only succeeds for an incoming close_notify alert */
-    POSIX_GUARD(s2n_process_alert_fragment(conn));
-
-    *blocked = S2N_NOT_BLOCKED;
-    return 0;
-}

--- a/tls/s2n_shutdown.c
+++ b/tls/s2n_shutdown.c
@@ -19,38 +19,45 @@
 #include "tls/s2n_tls.h"
 #include "utils/s2n_safety.h"
 
-int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status *more)
+int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status *blocked)
 {
     POSIX_ENSURE_REF(conn);
-    POSIX_ENSURE_REF(more);
+    POSIX_ENSURE_REF(blocked);
 
     /* Treat this call as a no-op if already wiped */
     if (conn->send == NULL && conn->recv == NULL) {
-        return 0;
+        return S2N_SUCCESS;
     }
 
-    uint64_t elapsed;
+    uint64_t elapsed = 0;
     POSIX_GUARD_RESULT(s2n_timer_elapsed(conn->config, &conn->write_timer, &elapsed));
     S2N_ERROR_IF(elapsed < conn->delay, S2N_ERR_SHUTDOWN_PAUSED);
 
-    /* Queue our close notify, once. Use warning level so clients don't give up */
+    /* Queue our close_notify alert.
+     * If we have already sent a close_notify, then this operation is a no-op.
+     */
     POSIX_GUARD(s2n_queue_writer_close_alert_warning(conn));
 
-    /* Write it */
-    POSIX_GUARD(s2n_flush(conn, more));
+    /* Flush any pending records, then send the queued close_notify. */
+    POSIX_GUARD(s2n_flush(conn, blocked));
 
-    /* Assume caller isn't interested in pending incoming data */
-    if (conn->in_status == PLAINTEXT) {
+    /* Wait for the peer's close_notify. */
+    uint8_t record_type = 0;
+    int isSSLv2 = false;
+    *blocked = S2N_BLOCKED_ON_READ;
+    while (!conn->close_notify_received) {
+        POSIX_GUARD(s2n_read_full_record(conn, &record_type, &isSSLv2));
+        POSIX_ENSURE(!isSSLv2, S2N_ERR_BAD_MESSAGE);
+        if (record_type == TLS_ALERT) {
+            POSIX_GUARD(s2n_process_alert_fragment(conn));
+        }
+
+        /* Wipe and keep trying */
         POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
         POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
         conn->in_status = ENCRYPTED;
     }
 
-    /* Dont expect to receive another close notify alert if we have already received it */
-    if (!conn->close_notify_received) {
-        /* Fails with S2N_ERR_SHUTDOWN_RECORD_TYPE or S2N_ERR_ALERT on receipt of anything but a close_notify */
-        POSIX_GUARD(s2n_recv_close_notify(conn, more));
-    }
-
-    return 0;
+    *blocked = S2N_NOT_BLOCKED;
+    return S2N_SUCCESS;
 }

--- a/tls/s2n_tls.h
+++ b/tls/s2n_tls.h
@@ -83,7 +83,6 @@ int s2n_handshake_write_header(struct s2n_stuffer *out, uint8_t message_type);
 int s2n_handshake_finish_header(struct s2n_stuffer *out);
 S2N_RESULT s2n_handshake_parse_header(struct s2n_stuffer *io, uint8_t *message_type, uint32_t *length);
 int s2n_read_full_record(struct s2n_connection *conn, uint8_t *record_type, int *isSSLv2);
-int s2n_recv_close_notify(struct s2n_connection *conn, s2n_blocked_status *blocked);
 
 extern uint16_t mfl_code_to_length[5];
 


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/2846

### Description of changes: 

Currently, any messages received after s2n_shutdown is called are considered errors. This is incorrect-- according to the TLS1.2 spec and the old comments in the method, we should ignore any messages received after the close_notify. I also based the corrected behavior off [the old usage guide entry](https://github.com/aws/s2n-tls/blob/1fe97e83fbae7d4aca9cd08beedab3e0f34432c6/docs/USAGE-GUIDE.md#s2n_shutdown).

This change allows us to correctly ignore any non-close_notify records received during shutdown.

### Call-outs:

* This PR is currently failing one of the Rust library tests for a valid reason. With handshake messages no longer triggering S2N_ERR_SHUTDOWN_RECORD_TYPE, the client is able to receive the server's response alert... which is encrypted with the wrong key (the application data key instead of the handshake key). This leads to a decryption error, which triggers another round of blinding, which causes the test to fail. This PR therefore can't be merged until that bug is addressed by https://github.com/aws/s2n-tls/pull/3772.
* Different behavior is expected for TLS1.3. This PR does NOT address TLS1.3 requirements; it only fixes TLS1.2. Still, this behavior will generally work for TLS1.3 if half-close is not required.

### Testing:
I added unit tests.

I also fixed s2nc and s2nd so that they correctly check the return of s2n_shutdown. Unfortunately, most of our integration tests don't perform a graceful shutdown because we just kill the peer's process.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
