### PR TITLE
Add OCSP stapling for client auth

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -997,7 +997,7 @@ S2N_API extern int s2n_config_set_protocol_preferences(struct s2n_config *config
 
 /**
  * Enum used to define the type, if any, of certificate status request
- * an S2N_CLIENT should make during the handshake. The only supported status request type is
+ * a connection should make during the handshake. The only supported status request type is
  * OCSP, `S2N_STATUS_REQUEST_OCSP`.
 */
 typedef enum {
@@ -1006,7 +1006,7 @@ typedef enum {
 } s2n_status_request_type;
 
 /**
- * Sets up an S2N_CLIENT to request the server certificate status during an SSL handshake. If set
+ * Sets up a connection to request the certificate status of a peer during an SSL handshake. If set
  * to S2N_STATUS_REQUEST_NONE, no status request is made.
  *
  * @param config The configuration object being updated
@@ -2208,7 +2208,7 @@ S2N_API extern int s2n_connection_get_session_id(struct s2n_connection *conn, ui
 S2N_API extern int s2n_connection_is_session_resumed(struct s2n_connection *conn);
 
 /**
- * Check is the connection is OCSP stapled.
+ * Check if the connection is OCSP stapled.
  *
  * @param conn A pointer to the s2n_connection object
  *

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -543,7 +543,7 @@ Online Certificate Status Protocol (OCSP) is a protocol to establish whether or 
 
 OCSP stapling can be applied to both client and server certificates when using TLS1.3, but only to server certificates when using TLS1.2.
 
-To use OCSP stapling, the requesting connection must call `s2n_config_set_status_request_type()` with S2N_STATUS_REQUEST_OCSP. The server (or client, if using client authentication) will also need to call `s2n_cert_chain_and_key_set_ocsp_data()` to set the raw bytes of the OCSP stapling data.
+To use OCSP stapling, the requester must call `s2n_config_set_status_request_type()` with S2N_STATUS_REQUEST_OCSP. The server (or client, if using client authentication) will also need to call `s2n_cert_chain_and_key_set_ocsp_data()` to set the raw bytes of the OCSP stapling data.
 
 The OCSP stapling information will be automatically validated if the underlying libcrypto supports OCSP validation. `s2n_config_set_check_stapled_ocsp_response()` can be called with "0" to turn this off. Call `s2n_connection_get_ocsp_response()` to retrieve the received OCSP stapling information for manual verification.
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -543,7 +543,7 @@ Online Certificate Status Protocol (OCSP) is a protocol to establish whether or 
 
 OCSP stapling can be applied to both client and server certificates when using TLS1.3, but only to server certificates when using TLS1.2.
 
-To use OCSP stapling, both server and client must call `s2n_config_set_status_request_type()` with S2N_STATUS_REQUEST_OCSP. The server (or client, if using client authentication) will also need to call `s2n_cert_chain_and_key_set_ocsp_data()` to set the raw bytes of the OCSP stapling data.
+To use OCSP stapling, the requesting connection must call `s2n_config_set_status_request_type()` with S2N_STATUS_REQUEST_OCSP. The server (or client, if using client authentication) will also need to call `s2n_cert_chain_and_key_set_ocsp_data()` to set the raw bytes of the OCSP stapling data.
 
 The OCSP stapling information will be automatically validated if the underlying libcrypto supports OCSP validation. `s2n_config_set_check_stapled_ocsp_response()` can be called with "0" to turn this off. Call `s2n_connection_get_ocsp_response()` to retrieve the received OCSP stapling information for manual verification.
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -543,7 +543,7 @@ Online Certificate Status Protocol (OCSP) is a protocol to establish whether or 
 
 OCSP stapling can be applied to both client and server certificates when using TLS1.3, but only to server certificates when using TLS1.2.
 
-To use OCSP stapling, the requester must call `s2n_config_set_status_request_type()` with S2N_STATUS_REQUEST_OCSP. The server (or client, if using client authentication) will also need to call `s2n_cert_chain_and_key_set_ocsp_data()` to set the raw bytes of the OCSP stapling data.
+To use OCSP stapling, the requester must call `s2n_config_set_status_request_type()` with S2N_STATUS_REQUEST_OCSP. The responder will need to call `s2n_cert_chain_and_key_set_ocsp_data()` to set the raw bytes of the OCSP stapling data.
 
 The OCSP stapling information will be automatically validated if the underlying libcrypto supports OCSP validation. `s2n_config_set_check_stapled_ocsp_response()` can be called with "0" to turn this off. Call `s2n_connection_get_ocsp_response()` to retrieve the received OCSP stapling information for manual verification.
 

--- a/tests/unit/s2n_cert_status_extension_test.c
+++ b/tests/unit/s2n_cert_status_extension_test.c
@@ -209,8 +209,8 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
-            EXPECT_TRUE(server_conn->actual_protocol_version == S2N_TLS13);
-            EXPECT_TRUE(client_conn->actual_protocol_version == S2N_TLS13);
+            EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
+            EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
 
             uint32_t client_received_ocsp_response_len = 0;
             const uint8_t *client_received_ocsp_response = s2n_connection_get_ocsp_response(client_conn,
@@ -264,8 +264,8 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
-            EXPECT_TRUE(server_conn->actual_protocol_version == S2N_TLS13);
-            EXPECT_TRUE(client_conn->actual_protocol_version == S2N_TLS13);
+            EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
+            EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
 
             uint32_t client_received_ocsp_response_len = 0;
             const uint8_t *client_received_ocsp_response = s2n_connection_get_ocsp_response(client_conn,
@@ -319,8 +319,8 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
-            EXPECT_TRUE(server_conn->actual_protocol_version == S2N_TLS13);
-            EXPECT_TRUE(client_conn->actual_protocol_version == S2N_TLS13);
+            EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
+            EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
 
             uint32_t client_received_ocsp_response_len = 0;
             const uint8_t *client_received_ocsp_response = s2n_connection_get_ocsp_response(client_conn,
@@ -366,8 +366,8 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
-            EXPECT_TRUE(server_conn->actual_protocol_version == S2N_TLS13);
-            EXPECT_TRUE(client_conn->actual_protocol_version == S2N_TLS13);
+            EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
+            EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
 
             uint32_t client_received_ocsp_response_len = 0;
             const uint8_t *client_received_ocsp_response = s2n_connection_get_ocsp_response(client_conn,

--- a/tests/unit/s2n_server_cert_status_request_extension_test.c
+++ b/tests/unit/s2n_server_cert_status_request_extension_test.c
@@ -1,0 +1,68 @@
+/*
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+#include "s2n_test.h"
+#include "tls/extensions/s2n_server_cert_status_request.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Extension should not be sent by default */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+
+        EXPECT_FALSE(s2n_server_cert_status_request_extension.should_send(conn));
+    }
+
+    /* Extension should be sent if OCSP stapling is supported and was requested  */
+    {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+
+        if (s2n_x509_ocsp_stapling_supported()) {
+            EXPECT_SUCCESS(s2n_config_set_status_request_type(config, S2N_STATUS_REQUEST_OCSP));
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+            EXPECT_TRUE(s2n_server_cert_status_request_extension.should_send(conn));
+        } else {
+            /* Requesting OCSP stapling should not be possible if not supported */
+            EXPECT_FAILURE_WITH_ERRNO(s2n_config_set_status_request_type(config, S2N_STATUS_REQUEST_OCSP),
+                    S2N_ERR_OCSP_NOT_SUPPORTED);
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+            EXPECT_FALSE(s2n_server_cert_status_request_extension.should_send(conn));
+        }
+    }
+
+    /* Extension should be empty */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+
+        struct s2n_stuffer stuffer = { 0 };
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
+
+        EXPECT_SUCCESS(s2n_server_cert_status_request_extension.send(conn, &stuffer));
+
+        EXPECT_TRUE(s2n_stuffer_data_available(&stuffer) == 0);
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_server_cert_status_request_extension_test.c
+++ b/tests/unit/s2n_server_cert_status_request_extension_test.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_server_cert_status_request_extension.send(conn, &stuffer));
 
-        EXPECT_TRUE(s2n_stuffer_data_available(&stuffer) == 0);
+        EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
     }
 
     END_TEST();

--- a/tls/extensions/s2n_cert_status.c
+++ b/tls/extensions/s2n_cert_status.c
@@ -23,12 +23,14 @@
 
 #define U24_SIZE 3
 
-/* In TLS 1.3, a response to a Status Request extension is sent as an extension with
- * status request as well as the OCSP response. This contrasts to TLS 1.2 where
- * the OCSP response is sent in the Certificate Status handshake message */
-
 static bool s2n_cert_status_should_send(struct s2n_connection *conn);
 
+/*
+ * The cert_status extension is sent in response to OCSP status requests in TLS 1.3. The
+ * OCSP response is contained in the extension data. In TLS 1.2, the cert_status_response
+ * extension is sent instead, indicating that the OCSP response will be sent in a
+ * Certificate Status handshake message.
+ */
 const s2n_extension_type s2n_cert_status_extension = {
     .iana_value = TLS_EXTENSION_STATUS_REQUEST,
     .is_response = true,

--- a/tls/extensions/s2n_cert_status.c
+++ b/tls/extensions/s2n_cert_status.c
@@ -84,9 +84,9 @@ int s2n_cert_status_recv(struct s2n_connection *conn, struct s2n_stuffer *in)
         return S2N_SUCCESS;
     }
 
-    /* status_type keeps track of the OCSP status of a connection when a client requests
-     * OCSP stapling from a server. status_type should not be updated if the server requested
-     * OCSP stapling.
+    /* The status_type variable is only used when a client requests OCSP stapling from a
+     * server. A server can request OCSP stapling from a client, but it is not tracked
+     * with this variable.
      */
     if (conn->mode == S2N_CLIENT) {
         conn->status_type = S2N_STATUS_REQUEST_OCSP;

--- a/tls/extensions/s2n_extension_type_lists.c
+++ b/tls/extensions/s2n_extension_type_lists.c
@@ -39,6 +39,7 @@
 #include "tls/extensions/s2n_psk_key_exchange_modes.h"
 #include "tls/extensions/s2n_quic_transport_params.h"
 #include "tls/extensions/s2n_server_alpn.h"
+#include "tls/extensions/s2n_server_cert_status_request.h"
 #include "tls/extensions/s2n_server_key_share.h"
 #include "tls/extensions/s2n_server_max_fragment_length.h"
 #include "tls/extensions/s2n_server_psk.h"
@@ -129,6 +130,7 @@ static const s2n_extension_type *const encrypted_extensions[] = {
 
 static const s2n_extension_type *const cert_req_extensions[] = {
     &s2n_server_signature_algorithms_extension,
+    &s2n_server_cert_status_request_extension,
 };
 
 static const s2n_extension_type *const certificate_extensions[] = {

--- a/tls/extensions/s2n_server_cert_status_request.c
+++ b/tls/extensions/s2n_server_cert_status_request.c
@@ -42,5 +42,5 @@ static int s2n_server_cert_status_request_send(struct s2n_connection *conn, stru
 
 static bool s2n_server_cert_status_request_should_send(struct s2n_connection *conn)
 {
-    return conn->config->status_request_type != S2N_STATUS_REQUEST_NONE;
+    return conn->config->status_request_type == S2N_STATUS_REQUEST_OCSP;
 }

--- a/tls/extensions/s2n_server_cert_status_request.c
+++ b/tls/extensions/s2n_server_cert_status_request.c
@@ -1,0 +1,46 @@
+/*
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+#include "tls/extensions/s2n_server_cert_status_request.h"
+
+#include "tls/s2n_connection.h"
+
+static bool s2n_server_cert_status_request_should_send(struct s2n_connection *conn);
+static int s2n_server_cert_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out);
+
+const s2n_extension_type s2n_server_cert_status_request_extension = {
+    .iana_value = TLS_EXTENSION_STATUS_REQUEST,
+    .is_response = false,
+    .send = s2n_server_cert_status_request_send,
+    .recv = s2n_extension_recv_noop,
+    .should_send = s2n_server_cert_status_request_should_send,
+    .if_missing = s2n_extension_noop_if_missing,
+};
+
+static int s2n_server_cert_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out)
+{
+    /**
+     *= https://tools.ietf.org/rfc/rfc8446#4.4.2.1
+     *# A server MAY request that a client present an OCSP response with its
+     *# certificate by sending an empty "status_request" extension in its
+     *# CertificateRequest message.
+     */
+    return S2N_SUCCESS;
+}
+
+static bool s2n_server_cert_status_request_should_send(struct s2n_connection *conn)
+{
+    return conn->config->status_request_type != S2N_STATUS_REQUEST_NONE;
+}

--- a/tls/extensions/s2n_server_cert_status_request.c
+++ b/tls/extensions/s2n_server_cert_status_request.c
@@ -42,5 +42,5 @@ static int s2n_server_cert_status_request_send(struct s2n_connection *conn, stru
 
 static bool s2n_server_cert_status_request_should_send(struct s2n_connection *conn)
 {
-    return conn->config->status_request_type == S2N_STATUS_REQUEST_OCSP;
+    return conn->request_ocsp_status;
 }

--- a/tls/extensions/s2n_server_cert_status_request.h
+++ b/tls/extensions/s2n_server_cert_status_request.h
@@ -1,0 +1,20 @@
+/*
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+*
+*  http://aws.amazon.com/apache2.0
+*
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+
+#pragma once
+
+#include "tls/extensions/s2n_extension_type.h"
+
+extern const s2n_extension_type s2n_server_cert_status_request_extension;


### PR DESCRIPTION
### Resolved issues:

Resolves https://github.com/aws/s2n-tls/issues/1775

### Description of changes: 

TLS 1.3 allows status_request extensions to be sent in both the client hello, and in the certificate request message. This allows servers to request OCSP stapling from clients:

From [RFC 8446](https://www.rfc-editor.org/rfc/rfc8446#section-4.4.2.1):
```
   A server MAY request that a client present an OCSP response with its
   certificate by sending an empty "status_request" extension in its
   CertificateRequest message.
```

This PR adds a new extension, `s2n_server_cert_status_request_extension`, which servers can use to request OCSP responses from clients in the Certificate Request message. Clients can then respond with the existing `s2n_cert_status_extension` in their Certificate message.

Currently, the s2n-tls OCSP APIs are one-sided. `s2n_config_set_status_request_type` is called on the client to request OCSP stapling from the server, and `s2n_cert_chain_and_key_set_ocsp_data` is called on the server to set the OCSP response. With this PR, the existing APIs can be called on both the client and server to request and respond with OCSP data in both directions.

### Call-outs:

Care was taken to not interfere with the [`s2n_connection_is_ocsp_stapled` API](https://aws.github.io/s2n-tls/doxygen/s2n_8h.html#addfbc4fdc9d191bb4d6d9040762b208b). This API is specifically documented to determine the OCSP status of a connection in one direction, where the client requests a response from the server. With this PR, the meaning of this API is preserved. Another option for this API would be to change the definition to mean OCSP stapled in either direction, but I'm not sure if that would be very useful. We could also provide an additional API to determine if the connection is OCSP stapled in the other direction, but with this PR users can use `s2n_connection_get_ocsp_response` on both the client and server to determine if a response was received, so another API for this doesn't seem useful either.

Some documentation changes were made to describe the new behavior. However, the usage guide section for OCSP stapling already mostly describes the behavior in this PR.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
- Tests added for the new extension.
- Added self-talk tests for TLS 1.3 OCSP stapling.

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
