### PR TITLE
s2n_shutdown: do not require response during handshake

### DIFF
--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -385,10 +385,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(strlen(received_server_name), strlen(sent_server_name));
         EXPECT_BYTEARRAY_EQUAL(received_server_name, sent_server_name, strlen(received_server_name));
 
-        /* Not a real tls client but make sure we block on its close_notify */
-        int shutdown_rc = s2n_shutdown(server_conn, &server_blocked);
-        EXPECT_EQUAL(shutdown_rc, -1);
-        EXPECT_EQUAL(errno, EAGAIN);
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
         EXPECT_EQUAL(server_conn->close_notify_queued, 1);
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
@@ -623,10 +620,7 @@ int main(int argc, char **argv)
         /* Verify that the that we detected secure_renegotiation */
         EXPECT_EQUAL(server_conn->secure_renegotiation, 1);
 
-        /* Not a real tls client but make sure we block on its close_notify */
-        int shutdown_rc = s2n_shutdown(server_conn, &server_blocked);
-        EXPECT_EQUAL(shutdown_rc, -1);
-        EXPECT_EQUAL(errno, EAGAIN);
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
         EXPECT_EQUAL(server_conn->close_notify_queued, 1);
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -755,11 +755,7 @@ int main(int argc, char **argv)
         EXPECT_NULL(client_hello->raw_message.data);
         EXPECT_EQUAL(client_hello->raw_message.size, 0);
 
-        /* Not a real tls client but make sure we block on its close_notify */
-        int shutdown_rc = s2n_shutdown(server_conn, &server_blocked);
-        EXPECT_EQUAL(shutdown_rc, -1);
-        EXPECT_EQUAL(errno, EAGAIN);
-        EXPECT_EQUAL(server_conn->close_notify_queued, 1);
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
 
         /* Wipe connection */
         EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
@@ -1075,11 +1071,7 @@ int main(int argc, char **argv)
         EXPECT_NULL(client_hello->raw_message.data);
         EXPECT_EQUAL(client_hello->raw_message.size, 0);
 
-        /* Not a real tls client but make sure we block on its close_notify */
-        int shutdown_rc = s2n_shutdown(server_conn, &server_blocked);
-        EXPECT_EQUAL(shutdown_rc, -1);
-        EXPECT_EQUAL(errno, EAGAIN);
-        EXPECT_EQUAL(server_conn->close_notify_queued, 1);
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
 
         /* Wipe connection */
         EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
@@ -1125,11 +1117,7 @@ int main(int argc, char **argv)
         collected_client_hello = client_hello->raw_message.data;
         EXPECT_BYTEARRAY_EQUAL(collected_client_hello, expected_client_hello, sent_client_hello_len);
 
-        /* Not a real tls client but make sure we block on its close_notify */
-        shutdown_rc = s2n_shutdown(server_conn, &server_blocked);
-        EXPECT_EQUAL(shutdown_rc, -1);
-        EXPECT_EQUAL(errno, EAGAIN);
-        EXPECT_EQUAL(server_conn->close_notify_queued, 1);
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
 

--- a/tests/unit/s2n_client_record_version_test.c
+++ b/tests/unit/s2n_client_record_version_test.c
@@ -153,9 +153,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(client_conn->server_protocol_version, S2N_TLS12);
 
         /* Now lets shutdown the connection and verify that alert is sent in record with protocol version TLS1.2 */
-        EXPECT_EQUAL(s2n_shutdown(client_conn, &client_blocked), -1);
-        EXPECT_EQUAL(s2n_errno, S2N_ERR_IO_BLOCKED);
-        EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
+        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));
 
         /* Receive the next record from client and ensure that record protocol version is TLS1.2 */
         buf_occupied = 0;
@@ -289,9 +287,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(client_conn->server_protocol_version, S2N_SSLv3);
 
         /* Now lets shutdown the connection and verify that alert is sent in record with protocol version SSLv3 */
-        EXPECT_EQUAL(s2n_shutdown(client_conn, &client_blocked), -1);
-        EXPECT_EQUAL(s2n_errno, S2N_ERR_IO_BLOCKED);
-        EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
+        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));
 
         /* Receive the next record from client and ensure that record protocol version is SSLv3 */
         buf_occupied = 0;

--- a/tests/unit/s2n_self_talk_client_hello_cb_test.c
+++ b/tests/unit/s2n_self_talk_client_hello_cb_test.c
@@ -469,8 +469,8 @@ int run_test_reject_handshake_ch_cb(s2n_client_hello_cb_mode cb_mode,
     /* Ensure that callback was invoked */
     EXPECT_EQUAL(ch_ctx->invoked, 1);
 
-    /* shutdown to flush alert, expext failure as client doesn't send close notify */
-    EXPECT_FAILURE(s2n_shutdown(conn, &blocked));
+    /* shutdown to flush alert */
+    EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
     EXPECT_SUCCESS(s2n_connection_free(conn));
 
     EXPECT_SUCCESS(test_case_clean(NULL, pid, config, &io_pair, ch_ctx));

--- a/tests/unit/s2n_self_talk_shutdown_test.c
+++ b/tests/unit/s2n_self_talk_shutdown_test.c
@@ -20,67 +20,61 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
-    struct s2n_connection *client_conn, *server_conn;
-    s2n_blocked_status server_blocked, client_blocked;
+    const s2n_mode modes[] = { S2N_CLIENT, S2N_SERVER };
 
-    /* Verify successful shutdown. Server initiated. */
-    {
-        /* Setup connections */
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
+    DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = NULL, s2n_cert_chain_and_key_ptr_free);
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+            S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
 
-        /* Create nonblocking pipes */
-        struct s2n_test_io_pair io_pair;
+    DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+    EXPECT_NOT_NULL(config);
+    EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+
+    /* Self-Talk: shutdown during handshake */
+    for (size_t mode_i = 0; mode_i < s2n_array_len(modes); mode_i++) {
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
-        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
-        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
-        /* Verify state prior to alert */
-        EXPECT_FALSE(server_conn->close_notify_received);
-        EXPECT_FALSE(client_conn->close_notify_received);
+        EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, SERVER_CERT));
+        EXPECT_FALSE(s2n_handshake_is_complete(client_conn));
+        EXPECT_FALSE(s2n_handshake_is_complete(server_conn));
 
-        /* Verify successful shutdown */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(server_conn, &server_blocked), S2N_ERR_IO_BLOCKED);
-        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));
-        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
+        /* Choose which connection will request the shutdown */
+        struct s2n_connection *request = server_conn;
+        struct s2n_connection *response = client_conn;
+        if (modes[mode_i] == S2N_CLIENT) {
+            request = client_conn;
+            response = server_conn;
+        }
 
-        /* Verify state after alert */
-        EXPECT_TRUE(server_conn->close_notify_received);
-        EXPECT_TRUE(client_conn->close_notify_received);
+        /* Both shutdown attempts should succeed */
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+        EXPECT_SUCCESS(s2n_shutdown(request, &blocked));
+        EXPECT_SUCCESS(s2n_shutdown(response, &blocked));
 
-        /* Cleanup */
-        EXPECT_SUCCESS(s2n_connection_free(server_conn));
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
-    };
+        /* Both connections successfully closed */
+        EXPECT_TRUE(server_conn->closed);
+        EXPECT_TRUE(client_conn->closed);
 
-    /* Verify successful shutdown. Client initiated. */
-    {
-        /* Setup connections */
-        EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-
-        /* Create nonblocking pipes */
-        struct s2n_test_io_pair io_pair;
-        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
-        EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
-        EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
-
-        /* Verify state prior to alert */
-        EXPECT_FALSE(server_conn->close_notify_received);
-        EXPECT_FALSE(client_conn->close_notify_received);
-
-        /* Verify successful shutdown. */
-        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(client_conn, &client_blocked), S2N_ERR_IO_BLOCKED);
-        EXPECT_SUCCESS(s2n_shutdown(server_conn, &server_blocked));
-        EXPECT_SUCCESS(s2n_shutdown(client_conn, &client_blocked));
-
-        /* Verify state after alert */
-        EXPECT_TRUE(server_conn->close_notify_received);
-        EXPECT_TRUE(client_conn->close_notify_received);
-
-        /* Cleanup */
-        EXPECT_SUCCESS(s2n_connection_free(server_conn));
-        EXPECT_SUCCESS(s2n_connection_free(client_conn));
+        /* Closed connections behave properly */
+        for (size_t i = 0; i < 5; i++) {
+            /* Future attempts to shutdown succeed (they are no-ops) */
+            EXPECT_SUCCESS(s2n_shutdown(server_conn, &blocked));
+            EXPECT_SUCCESS(s2n_shutdown(client_conn, &blocked));
+        }
     };
 
     END_TEST();

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -222,6 +222,7 @@ S2N_RESULT s2n_handshake_message_send(struct s2n_connection *conn, uint8_t conte
 int s2n_conn_set_handshake_type(struct s2n_connection *conn);
 int s2n_conn_set_handshake_no_client_cert(struct s2n_connection *conn);
 S2N_RESULT s2n_conn_choose_state_machine(struct s2n_connection *conn, uint8_t protocol_version);
+bool s2n_handshake_is_complete(struct s2n_connection *conn);
 
 /* s2n_handshake_transcript */
 S2N_RESULT s2n_handshake_transcript_update(struct s2n_connection *conn);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1601,12 +1601,17 @@ static int s2n_handle_retry_state(struct s2n_connection *conn)
     return S2N_SUCCESS;
 }
 
+bool s2n_handshake_is_complete(struct s2n_connection *conn)
+{
+    return conn && ACTIVE_STATE(conn).writer == 'B';
+}
+
 int s2n_negotiate_impl(struct s2n_connection *conn, s2n_blocked_status *blocked)
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(blocked);
 
-    while (ACTIVE_STATE(conn).writer != 'B' && ACTIVE_MESSAGE(conn) != conn->handshake.end_of_messages) {
+    while (!s2n_handshake_is_complete(conn) && ACTIVE_MESSAGE(conn) != conn->handshake.end_of_messages) {
         errno = 0;
         s2n_errno = S2N_ERR_OK;
 


### PR DESCRIPTION
### Description of changes: 

I ran into the following scenario:
* The client sends its ClientHello
* The server sends its first flight: ServerHello, EncryptedExtensions, ServerCert, ServerCertVerify, ServerFinished
* A post-ServerHello message (say the ServerCert as the most common example) triggers an error on the client.
* The client responds by sending a close_notify
* The server responds with its own close_notify

However because the server has already sent its ServerFinished, it can technically send application data now and is actually using the application sending key instead of the handshake sending key. The client, still receiving with the handshake key, will fail to decrypt the close_notify. For maximum fun, this triggers blinding.

The RFC doesn't address this problem, possibly because it can only occur in response to a close_notify during the handshake, which is already a questionable use case. It just says "Like other messages, alert messages are encrypted as specified by the current connection state." It's unclear whether the handshake or application data key is correct after the ServerFinished, but the RFC's state machine indicates the application data key.

We could try to cover all of the edge cases around close_notify-ing during the handshake, but it seems more straightforward to simply not wait for the response close_notify during the handshake. There isn't a danger of application data truncation, because no application data has been sent yet. Early data isn't a problem, because the EndOfEarlyData message will protect against its truncation.

### Callouts

If this seems too drastic, I can actually fix the encryption. Falling back to the handshake key would be a little tricky, since we'd need to store the 8-byte sequence number last used with the handshake key, but possible. Alternatively we could also just fall back to a plaintext alert ([most of our handshake alerts are already plaintext](https://github.com/aws/s2n-tls/issues/3773)).

Alternatively, the server could wait to switch to the application key until it receives the ClientFinished message. However, this would deviate from the state machine in the RFC, we'd need an exception for QUIC (because QUIC requires the key immediately), and the problem would reoccur if we ever wanted to enable early server data.

### Testing:

New unit and self-talk tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
