### PR TITLE
Blob Initialization fix-Test

### DIFF
--- a/tests/fuzz/s2n_deserialize_resumption_state_test.c
+++ b/tests/fuzz/s2n_deserialize_resumption_state_test.c
@@ -55,7 +55,8 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     POSIX_GUARD(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
 
     uint8_t test_data[] = "test psk identity";
-    struct s2n_blob test_blob   = { .data = test_data, .size = sizeof(test_data) };
+    struct s2n_blob test_blob   = { 0 };
+    POSIX_GUARD(s2n_blob_init(&test_blob, test_data, sizeof(test_data)));
 
     /* Ignore the result of this function */
     s2n_result_ignore(s2n_deserialize_resumption_state(server_conn, &test_blob, &fuzzed_ticket));

--- a/tests/fuzz/s2n_deserialize_resumption_state_test.c
+++ b/tests/fuzz/s2n_deserialize_resumption_state_test.c
@@ -55,7 +55,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     POSIX_GUARD(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
 
     uint8_t test_data[] = "test psk identity";
-    struct s2n_blob test_blob   = { 0 };
+    struct s2n_blob test_blob = { 0 };
     POSIX_GUARD(s2n_blob_init(&test_blob, test_data, sizeof(test_data)));
 
     /* Ignore the result of this function */

--- a/tests/testlib/s2n_pq_kat_test_utils.c
+++ b/tests/testlib/s2n_pq_kat_test_utils.c
@@ -69,7 +69,8 @@ static S2N_RESULT s2n_drbg_generate_for_pq_kat_tests(struct s2n_drbg *drbg, stru
     RESULT_ENSURE_REF(drbg);
     RESULT_ENSURE_REF(drbg->ctx);
     uint8_t zeros_buffer[S2N_DRBG_MAX_SEED_SIZE] = { 0 };
-    struct s2n_blob zeros = { .data = zeros_buffer, .size = s2n_drbg_seed_size(drbg) };
+    struct s2n_blob zeros = { 0 };
+    RESULT_GUARD_POSIX(s2n_blob_init(&zeros, zeros_buffer, s2n_drbg_seed_size(drbg)));
 
     RESULT_ENSURE(blob->size <= S2N_DRBG_GENERATE_LIMIT, S2N_ERR_DRBG_REQUEST_SIZE);
 
@@ -103,7 +104,8 @@ static S2N_RESULT s2n_get_random_data_for_pq_kat_tests(struct s2n_blob *blob)
 S2N_RESULT s2n_get_random_bytes_for_pq_kat_tests(uint8_t *buffer, uint32_t num_bytes)
 {
     RESULT_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
-    struct s2n_blob out = { .data = buffer, .size = num_bytes };
+    struct s2n_blob out = { 0 };
+    RESULT_GUARD_POSIX(s2n_blob_init(&out, buffer, num_bytes));
 
     RESULT_GUARD(s2n_get_random_data_for_pq_kat_tests(&out));
 

--- a/tests/testlib/s2n_stuffer_hex.c
+++ b/tests/testlib/s2n_stuffer_hex.c
@@ -30,7 +30,8 @@ static uint8_t hex[16] = {
 static int s2n_stuffer_read_n_bits_hex(struct s2n_stuffer *stuffer, uint8_t n, uint64_t *u)
 {
     uint8_t hex_data[16] = { 0 };
-    struct s2n_blob b = { .data = hex_data, .size = n / 4 };
+    struct s2n_blob b = { 0 };
+    POSIX_GUARD(s2n_blob_init(&b, hex_data, n / 4));
 
     POSIX_GUARD(s2n_stuffer_read(stuffer, &b));
 
@@ -123,7 +124,8 @@ int s2n_stuffer_read_uint8_hex(struct s2n_stuffer *stuffer, uint8_t *u)
 static int s2n_stuffer_write_n_bits_hex(struct s2n_stuffer *stuffer, uint8_t n, uint64_t u)
 {
     uint8_t hex_data[16] = { 0 };
-    struct s2n_blob b = { .data = hex_data, .size = n / 4 };
+    struct s2n_blob b = { 0 };
+    POSIX_GUARD(s2n_blob_init(&b, hex_data, n / 4));
 
     POSIX_ENSURE_LTE(n, 64);
 

--- a/tests/unit/s2n_3des_test.c
+++ b/tests/unit/s2n_3des_test.c
@@ -32,9 +32,11 @@ int main(int argc, char **argv)
     struct s2n_connection *conn;
     uint8_t mac_key[] = "sample mac key";
     uint8_t des3_key[] = "12345678901234567890123";
-    struct s2n_blob des3 = { .data = des3_key, .size = sizeof(des3_key) };
+    struct s2n_blob des3 = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&des3, des3_key, sizeof(des3_key)));
     uint8_t random_data[S2N_DEFAULT_FRAGMENT_LENGTH + 1];
-    struct s2n_blob r = { .data = random_data, .size = sizeof(random_data) };
+    struct s2n_blob r = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&r, random_data, sizeof(random_data)));
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -57,7 +59,8 @@ int main(int argc, char **argv)
     conn->actual_protocol_version = S2N_TLS11;
 
     for (int i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
-        struct s2n_blob in = { .data = random_data, .size = i };
+        struct s2n_blob in = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));

--- a/tests/unit/s2n_aead_aes_test.c
+++ b/tests/unit/s2n_aead_aes_test.c
@@ -51,9 +51,12 @@ int main(int argc, char **argv)
     uint8_t random_data[S2N_SMALL_FRAGMENT_LENGTH + 1];
     uint8_t aes128_key[] = "123456789012345";
     uint8_t aes256_key[] = "1234567890123456789012345678901";
-    struct s2n_blob aes128 = { .data = aes128_key, .size = sizeof(aes128_key) };
-    struct s2n_blob aes256 = { .data = aes256_key, .size = sizeof(aes256_key) };
-    struct s2n_blob r = { .data = random_data, .size = sizeof(random_data) };
+    struct s2n_blob aes128 = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&aes128, aes128_key, sizeof(aes128_key)));
+    struct s2n_blob aes256 = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&aes256, aes256_key, sizeof(aes256_key)));
+    struct s2n_blob r = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&r, random_data, sizeof(random_data)));
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -71,7 +74,8 @@ int main(int argc, char **argv)
 
     int max_fragment = S2N_SMALL_FRAGMENT_LENGTH;
     for (size_t i = 0; i <= max_fragment + 1; i++) {
-        struct s2n_blob in = { .data = random_data, .size = i };
+        struct s2n_blob in = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
         int bytes_written;
 
         /* TLS packet on the wire using AES-GCM:
@@ -268,7 +272,8 @@ int main(int argc, char **argv)
     conn->actual_protocol_version = S2N_TLS12;
 
     for (size_t i = 0; i <= max_fragment + 1; i++) {
-        struct s2n_blob in = { .data = random_data, .size = i };
+        struct s2n_blob in = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_connection_wipe(conn));

--- a/tests/unit/s2n_aead_chacha20_poly1305_test.c
+++ b/tests/unit/s2n_aead_chacha20_poly1305_test.c
@@ -51,8 +51,10 @@ int main(int argc, char **argv)
     struct s2n_connection *conn;
     uint8_t random_data[S2N_SMALL_FRAGMENT_LENGTH + 1];
     uint8_t chacha20_poly1305_key_data[] = "1234567890123456789012345678901";
-    struct s2n_blob chacha20_poly1305_key = { .data = chacha20_poly1305_key_data, sizeof(chacha20_poly1305_key_data) };
-    struct s2n_blob r = { .data = random_data, .size = sizeof(random_data) };
+    struct s2n_blob chacha20_poly1305_key = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&chacha20_poly1305_key, chacha20_poly1305_key_data, sizeof(chacha20_poly1305_key_data)));
+    struct s2n_blob r = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&r, random_data, sizeof(random_data)));
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -75,7 +77,8 @@ int main(int argc, char **argv)
 
     int max_fragment = S2N_SMALL_FRAGMENT_LENGTH;
     for (size_t i = 0; i <= max_fragment + 1; i++) {
-        struct s2n_blob in = { .data = random_data, .size = i };
+        struct s2n_blob in = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
         int bytes_written;
 
         /* TLS packet on the wire using ChaCha20-Poly1305:

--- a/tests/unit/s2n_aes_sha_composite_test.c
+++ b/tests/unit/s2n_aes_sha_composite_test.c
@@ -53,9 +53,12 @@ int main(int argc, char **argv)
     uint8_t mac_key_sha256[32] = "server key sha256server key sha";
     uint8_t aes128_key[] = "123456789012345";
     uint8_t aes256_key[] = "1234567890123456789012345678901";
-    struct s2n_blob aes128 = { .data = aes128_key, .size = sizeof(aes128_key) };
-    struct s2n_blob aes256 = { .data = aes256_key, .size = sizeof(aes256_key) };
-    struct s2n_blob r = { .data = random_data, .size = sizeof(random_data) };
+    struct s2n_blob aes128 = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&aes128, aes128_key, sizeof(aes128_key)));
+    struct s2n_blob aes256 = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&aes256, aes256_key, sizeof(aes256_key)));
+    struct s2n_blob r = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&r, random_data, sizeof(random_data)));
     /* Stores explicit IVs used in each test case to validate uniqueness. */
     uint8_t existing_explicit_ivs[S2N_DEFAULT_FRAGMENT_LENGTH + 2][S2N_TLS_MAX_IV_LEN];
 
@@ -88,7 +91,8 @@ int main(int argc, char **argv)
      */
     for (int j = 0; j < 3; j++) {
         for (int i = 0; i <= max_aligned_fragment + 1; i++) {
-            struct s2n_blob in = { .data = random_data, .size = i };
+            struct s2n_blob in = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
             int bytes_written;
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
@@ -163,7 +167,8 @@ int main(int argc, char **argv)
     conn->initial->cipher_suite->record_alg = &s2n_record_alg_aes256_sha_composite;
     for (int j = 0; j < 3; j++) {
         for (int i = 0; i <= max_aligned_fragment + 1; i++) {
-            struct s2n_blob in = { .data = random_data, .size = i };
+            struct s2n_blob in = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
             int bytes_written;
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
@@ -238,7 +243,8 @@ int main(int argc, char **argv)
     conn->initial->cipher_suite->record_alg = &s2n_record_alg_aes128_sha256_composite;
     for (int j = 0; j < 3; j++) {
         for (int i = 0; i < max_aligned_fragment + 1; i++) {
-            struct s2n_blob in = { .data = random_data, .size = i };
+            struct s2n_blob in = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
             int bytes_written;
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
@@ -313,7 +319,8 @@ int main(int argc, char **argv)
     conn->initial->cipher_suite->record_alg = &s2n_record_alg_aes256_sha256_composite;
     for (int j = 0; j < 3; j++) {
         for (int i = 0; i <= max_aligned_fragment + 1; i++) {
-            struct s2n_blob in = { .data = random_data, .size = i };
+            struct s2n_blob in = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
             int bytes_written;
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));

--- a/tests/unit/s2n_aes_test.c
+++ b/tests/unit/s2n_aes_test.c
@@ -33,10 +33,13 @@ int main(int argc, char **argv)
     uint8_t mac_key[] = "sample mac key";
     uint8_t aes128_key[] = "123456789012345";
     uint8_t aes256_key[] = "1234567890123456789012345678901";
-    struct s2n_blob aes128 = { .data = aes128_key, .size = sizeof(aes128_key) };
-    struct s2n_blob aes256 = { .data = aes256_key, .size = sizeof(aes256_key) };
+    struct s2n_blob aes128 = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&aes128, aes128_key, sizeof(aes128_key)));
+    struct s2n_blob aes256 = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&aes256, aes256_key, sizeof(aes256_key)));
     uint8_t random_data[S2N_DEFAULT_FRAGMENT_LENGTH + 1];
-    struct s2n_blob r = { .data = random_data, .size = sizeof(random_data) };
+    struct s2n_blob r = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&r, random_data, sizeof(random_data)));
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -59,7 +62,8 @@ int main(int argc, char **argv)
     conn->actual_protocol_version = S2N_TLS11;
 
     for (int i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
-        struct s2n_blob in = { .data = random_data, .size = i };
+        struct s2n_blob in = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
@@ -124,7 +128,8 @@ int main(int argc, char **argv)
     conn->actual_protocol_version = S2N_TLS11;
 
     for (int i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
-        struct s2n_blob in = { .data = random_data, .size = i };
+        struct s2n_blob in = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));

--- a/tests/unit/s2n_blob_test.c
+++ b/tests/unit/s2n_blob_test.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
     /* Valid blob is valid */
     uint8_t array[12];
     struct s2n_blob b3 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&b3, array,sizeof(array)));
+    EXPECT_SUCCESS(s2n_blob_init(&b3, array, sizeof(array)));
     EXPECT_OK(s2n_blob_validate(&b3));
 
     /* Null blob is not growable */

--- a/tests/unit/s2n_blob_test.c
+++ b/tests/unit/s2n_blob_test.c
@@ -34,12 +34,14 @@ int main(int argc, char **argv)
 #endif
 
     /* Size of 0 is OK if data is null */
-    struct s2n_blob b2 = { .data = 0, .size = 0 };
+    struct s2n_blob b2 = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&b2, 0, 0));
     EXPECT_OK(s2n_blob_validate(&b2));
 
     /* Valid blob is valid */
     uint8_t array[12];
-    struct s2n_blob b3 = { .data = array, .size = sizeof(array) };
+    struct s2n_blob b3 = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&b3, array,sizeof(array)));
     EXPECT_OK(s2n_blob_validate(&b3));
 
     /* Null blob is not growable */

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -258,7 +258,8 @@ int nist_fake_entropy_init_cleanup(void)
 
 int nist_fake_128_entropy_data(void *data, uint32_t size)
 {
-    struct s2n_blob blob = { .data = data, .size = size };
+    struct s2n_blob blob = { 0 };
+    POSIX_GUARD(s2n_blob_init(&blob, data, size));
 
     POSIX_GUARD(s2n_stuffer_read(&nist_aes128_reference_entropy, &blob));
 
@@ -267,7 +268,8 @@ int nist_fake_128_entropy_data(void *data, uint32_t size)
 
 int nist_fake_256_entropy_data(void *data, uint32_t size)
 {
-    struct s2n_blob blob = { .data = data, .size = size };
+    struct s2n_blob blob = { 0 };
+    POSIX_GUARD(s2n_blob_init(&blob, data, size));
 
     POSIX_GUARD(s2n_stuffer_read(&nist_aes256_reference_entropy, &blob));
 
@@ -287,7 +289,8 @@ int check_drgb_version(s2n_drbg_mode mode, int (*generator)(void *, uint32_t), i
     for (int i = 0; i < 14; i++) {
         uint8_t ps[S2N_DRBG_MAX_SEED_SIZE] = { 0 };
         struct s2n_drbg nist_drbg = { 0 };
-        struct s2n_blob personalization_string = { .data = ps, .size = personalization_size };
+        struct s2n_blob personalization_string = { 0 };
+        POSIX_GUARD(s2n_blob_init(&personalization_string, ps, personalization_size));
 
         /* Read the next personalization string */
         POSIX_GUARD(s2n_stuffer_read(&personalization, &personalization_string));
@@ -305,7 +308,8 @@ int check_drgb_version(s2n_drbg_mode mode, int (*generator)(void *, uint32_t), i
 
         /* Generate 512 bits (FIRST CALL) */
         uint8_t out[64];
-        struct s2n_blob generated = { .data = out, .size = 64 };
+        struct s2n_blob generated = { 0 };
+        POSIX_GUARD(s2n_blob_init(&generated, out, 64));
         POSIX_GUARD_RESULT(s2n_drbg_generate(&nist_drbg, &generated));
 
         POSIX_GUARD(s2n_stuffer_read_bytes(&reference_values, nist_v, sizeof(nist_v)));
@@ -341,7 +345,8 @@ int main(int argc, char **argv)
     uint8_t data[256] = { 0 };
     struct s2n_drbg aes128_drbg = { 0 };
     struct s2n_drbg aes256_pr_drbg = { 0 };
-    struct s2n_blob blob = { .data = data, .size = 64 };
+    struct s2n_blob blob = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&blob, data, 64));
 
     EXPECT_OK(s2n_drbg_instantiate(&aes128_drbg, &blob, S2N_AES_128_CTR_NO_DF_PR));
     EXPECT_OK(s2n_drbg_instantiate(&aes256_pr_drbg, &blob, S2N_AES_256_CTR_NO_DF_PR));

--- a/tests/unit/s2n_hash_test.c
+++ b/tests/unit/s2n_hash_test.c
@@ -33,7 +33,8 @@ int main(int argc, char **argv)
     uint8_t string2[] = "and String 2\n";
     struct s2n_stuffer output;
     struct s2n_hash_state hash, copy;
-    struct s2n_blob out = { .data = output_pad, .size = sizeof(output_pad) };
+    struct s2n_blob out = { 0 };
+    POSIX_GUARD(s2n_blob_init(&out, output_pad, sizeof(output_pad)));
     uint64_t bytes_in_hash;
 
     BEGIN_TEST();

--- a/tests/unit/s2n_hkdf_test.c
+++ b/tests/unit/s2n_hkdf_test.c
@@ -402,10 +402,12 @@ int main(int argc, char **argv)
     struct s2n_hmac_state hmac;
 
     uint8_t prk_pad[MAX_PSEUDO_RAND_KEY_SIZE];
-    struct s2n_blob prk_result = { .data = prk_pad, .size = sizeof(prk_pad) };
+    struct s2n_blob prk_result = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&prk_result, prk_pad, sizeof(prk_pad)));
 
     uint8_t output_pad[MAX_OUTPUT_SIZE];
-    struct s2n_blob out_result = { .data = output_pad, .size = sizeof(output_pad) };
+    struct s2n_blob out_result = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&out_result, output_pad, sizeof(output_pad)));
 
     struct s2n_blob in_key_blob, salt_blob, info_blob, actual_prk_blob, actual_output_blob;
 
@@ -435,8 +437,10 @@ int main(int argc, char **argv)
      * then adding 1
      */
     uint8_t error_out_pad[5101];
-    struct s2n_blob error_out = { .data = error_out_pad, .size = sizeof(error_out_pad) };
-    struct s2n_blob zero_out = { .data = output_pad, .size = 0 };
+    struct s2n_blob error_out = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&error_out, error_out_pad, sizeof(error_out_pad)));
+    struct s2n_blob zero_out = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&zero_out, output_pad, 0));
 
     s2n_hmac_algorithm alg = S2N_HMAC_SHA1;
 

--- a/tests/unit/s2n_hmac_test.c
+++ b/tests/unit/s2n_hmac_test.c
@@ -37,7 +37,8 @@ int main(int argc, char **argv)
     uint8_t string2[] = "and String 2";
     struct s2n_hmac_state hmac, copy, cmac;
 
-    struct s2n_blob out = { .data = output_pad, .size = sizeof(output_pad) };
+    struct s2n_blob out = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&out, output_pad, sizeof(output_pad)));
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());

--- a/tests/unit/s2n_override_openssl_random_test.c
+++ b/tests/unit/s2n_override_openssl_random_test.c
@@ -50,7 +50,8 @@ const char expected_dhe_key_hex[] = "0100cb5fa155609f350a0f07e340ef7dc854e38d97c
 struct s2n_stuffer test_entropy;
 int s2n_entropy_generator(void *data, uint32_t size)
 {
-    struct s2n_blob blob = { .data = data, .size = size };
+    struct s2n_blob blob = { 0 };
+    POSIX_GUARD(s2n_blob_init(&blob, data, size));
     POSIX_GUARD(s2n_stuffer_read(&test_entropy, &blob));
     return 0;
 }

--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -102,7 +102,8 @@ static S2N_RESULT s2n_basic_pattern_tests(S2N_RESULT (*s2n_get_random_data_cb)(s
     uint8_t bits[8] = { 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01 };
     uint8_t bit_set_run[8];
     uint8_t data[MAX_RANDOM_GENERATE_DATA_SIZE];
-    struct s2n_blob blob = { .data = data };
+    struct s2n_blob blob = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&blob, data, 0));
     int trailing_zeros[8] = { 0 };
 
     for (int size = 0; size < MAX_RANDOM_GENERATE_DATA_SIZE; size++) {
@@ -172,7 +173,8 @@ static S2N_RESULT s2n_tests_get_range(void)
     uint64_t current_output = 0;
     /* The type of the `bound` parameter in s2n_public_random() is signed */
     int64_t chosen_upper_bound = 0;
-    struct s2n_blob upper_bound_blob = { .data = (void *) &chosen_upper_bound, .size = sizeof(chosen_upper_bound) };
+    struct s2n_blob upper_bound_blob = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&upper_bound_blob, (void *) &chosen_upper_bound, sizeof(chosen_upper_bound))) ;
 
     /* 0 is not a legal upper bound */
     chosen_upper_bound = 0;
@@ -263,7 +265,8 @@ void *s2n_thread_test_cb(void *thread_comms)
 {
     struct random_communication *thread_comms_ptr = (struct random_communication *) thread_comms;
 
-    struct s2n_blob thread_blob = { .data = thread_comms_ptr->thread_data, .size = RANDOM_GENERATE_DATA_SIZE };
+    struct s2n_blob thread_blob = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&thread_blob, thread_comms_ptr->thread_data, RANDOM_GENERATE_DATA_SIZE));
 
     EXPECT_NOT_NULL(thread_comms_ptr->s2n_get_random_data_cb_1);
     EXPECT_OK(thread_comms_ptr->s2n_get_random_data_cb_1(&thread_blob));
@@ -282,7 +285,8 @@ static S2N_RESULT s2n_thread_test(
         S2N_RESULT (*s2n_get_random_data_cb_thread)(struct s2n_blob *blob))
 {
     uint8_t data[RANDOM_GENERATE_DATA_SIZE];
-    struct s2n_blob blob = { .data = data };
+    struct s2n_blob blob = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&blob, data, 0));
     pthread_t threads[MAX_NUMBER_OF_TEST_THREADS];
 
     struct random_communication thread_communication_0 = { .s2n_get_random_data_cb_1 = s2n_get_random_data_cb_thread };
@@ -314,7 +318,8 @@ static void s2n_fork_test_generate_randomness(int write_fd, S2N_RESULT (*s2n_get
 {
     uint8_t data[RANDOM_GENERATE_DATA_SIZE];
 
-    struct s2n_blob blob = { .data = data, .size = RANDOM_GENERATE_DATA_SIZE };
+    struct s2n_blob blob = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&blob, data, RANDOM_GENERATE_DATA_SIZE));
     EXPECT_OK(s2n_get_random_data_cb(&blob));
 
     /* Write the data we got to our pipe */
@@ -331,7 +336,8 @@ static S2N_RESULT s2n_fork_test_verify_result(int *pipes, int proc_id, S2N_RESUL
 {
     uint8_t child_data[RANDOM_GENERATE_DATA_SIZE];
     uint8_t parent_data[RANDOM_GENERATE_DATA_SIZE];
-    struct s2n_blob parent_blob = { .data = parent_data, .size = RANDOM_GENERATE_DATA_SIZE };
+    struct s2n_blob parent_blob = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&parent_blob, parent_data, RANDOM_GENERATE_DATA_SIZE));
 
     /* Quickly verify we are in the parent process and not the child */
     EXPECT_NOT_EQUAL(proc_id, 0);
@@ -496,8 +502,10 @@ static S2N_RESULT s2n_basic_generate_tests(void)
 {
     uint8_t data1[RANDOM_GENERATE_DATA_SIZE];
     uint8_t data2[RANDOM_GENERATE_DATA_SIZE];
-    struct s2n_blob blob1 = { .data = data1 };
-    struct s2n_blob blob2 = { .data = data2 };
+    struct s2n_blob blob1 = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&blob1, data1, 0));
+    struct s2n_blob blob2 = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&blob2, data2, 0));
 
     /* Generate two random data blobs and confirm that they are unique */
     blob1.size = RANDOM_GENERATE_DATA_SIZE;
@@ -518,8 +526,10 @@ static int s2n_common_tests(struct random_test_case *test_case)
 {
     uint8_t data1[RANDOM_GENERATE_DATA_SIZE];
     uint8_t data2[RANDOM_GENERATE_DATA_SIZE];
-    struct s2n_blob blob1 = { .data = data1 };
-    struct s2n_blob blob2 = { .data = data2 };
+    struct s2n_blob blob1 = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&blob1, data1, 0));
+    struct s2n_blob blob2 = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&blob2, data2, 0));
     int64_t bound = 0;
     uint64_t output = 0;
 

--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -174,7 +174,7 @@ static S2N_RESULT s2n_tests_get_range(void)
     /* The type of the `bound` parameter in s2n_public_random() is signed */
     int64_t chosen_upper_bound = 0;
     struct s2n_blob upper_bound_blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&upper_bound_blob, (void *) &chosen_upper_bound, sizeof(chosen_upper_bound))) ;
+    EXPECT_SUCCESS(s2n_blob_init(&upper_bound_blob, (void *) &chosen_upper_bound, sizeof(chosen_upper_bound)));
 
     /* 0 is not a legal upper bound */
     chosen_upper_bound = 0;

--- a/tests/unit/s2n_rc4_test.c
+++ b/tests/unit/s2n_rc4_test.c
@@ -35,9 +35,11 @@ int main(int argc, char **argv)
     struct s2n_connection *conn;
     uint8_t mac_key[] = "sample mac key";
     uint8_t rc4_key[] = "123456789012345";
-    struct s2n_blob key_iv = { .data = rc4_key, .size = sizeof(rc4_key) };
+    struct s2n_blob key_iv = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&key_iv, rc4_key, sizeof(rc4_key)));
     uint8_t random_data[S2N_DEFAULT_FRAGMENT_LENGTH + 1];
-    struct s2n_blob r = { .data = random_data, .size = sizeof(random_data) };
+    struct s2n_blob r = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&r, random_data, sizeof(random_data)));
 
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
@@ -65,7 +67,8 @@ int main(int argc, char **argv)
         conn->actual_protocol_version = S2N_TLS11;
 
         for (int i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
-            struct s2n_blob in = { .data = random_data, .size = i };
+            struct s2n_blob in = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
             int bytes_written;
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));

--- a/tests/unit/s2n_record_size_test.c
+++ b/tests/unit/s2n_record_size_test.c
@@ -62,11 +62,13 @@ int main(int argc, char **argv)
     uint8_t mac_key[] = "sample mac key";
 
     uint8_t random_data[S2N_LARGE_RECORD_LENGTH + 1];
-    struct s2n_blob r = { .data = random_data, .size = sizeof(random_data) };
+    struct s2n_blob r = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&r, random_data, sizeof(random_data)));
     EXPECT_OK(s2n_get_public_random_data(&r));
 
     uint8_t aes128_key[] = "123456789012345";
-    struct s2n_blob aes128 = { .data = aes128_key, .size = sizeof(aes128_key) };
+    struct s2n_blob aes128 = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&aes128, aes128_key, sizeof(aes128_key)));
 
     /* Test record sizes with s2n_record_write */
     {


### PR DESCRIPTION
### Resolved issues:

Related to : https://github.com/aws/s2n-tls/issues/1610
There are many blobs in s2n that have been created without using the s2n_init function and do not follow the new criteria.
This PR fixes that, and uses s2n_blob_init to initialize blobs.

### Description of changes: 
Initialization of blobs in s2n using the s2n_init function.

### Call-outs:

- Changes to code in test files. I will be opening 2 PR's for this issue.

### Testing:

 All test pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
