### PR TITLE
Initialize blobs and stuffers

### DIFF
--- a/tests/testlib/s2n_testlib_ecc_keys.c
+++ b/tests/testlib/s2n_testlib_ecc_keys.c
@@ -22,7 +22,7 @@ int s2n_public_ecc_keys_are_equal(struct s2n_ecc_evp_params *params_1, struct s2
     POSIX_ENSURE_REF(params_1);
     POSIX_ENSURE_REF(params_2);
 
-    struct s2n_stuffer point_stuffer;
+    struct s2n_stuffer point_stuffer = { 0 };
     int size = params_1->negotiated_curve->share_size;
 
     if (params_1->negotiated_curve != params_2->negotiated_curve) {

--- a/tests/unit/s2n_blob_test.c
+++ b/tests/unit/s2n_blob_test.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv)
     EXPECT_FAILURE(s2n_free(NULL));
 
     /* Static blob is not growable or freeable */
-    struct s2n_blob g1;
+    struct s2n_blob g1 = { 0 };
     EXPECT_SUCCESS(s2n_blob_init(&g1, array, 12));
     EXPECT_FALSE(s2n_blob_is_growable(&g1));
     EXPECT_FAILURE(s2n_realloc(&g1, 24));

--- a/tests/unit/s2n_cert_status_extension_test.c
+++ b/tests/unit/s2n_cert_status_extension_test.c
@@ -83,7 +83,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_cert_status_extension.send(conn, &stuffer));
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_cert_status_extension.send(conn, &stuffer));
@@ -134,7 +134,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, S2N_STATUS_REQUEST_NONE));

--- a/tests/unit/s2n_client_alpn_extension_test.c
+++ b/tests/unit/s2n_client_alpn_extension_test.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_protocol_preferences(conn, protocols, protocols_count));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_client_alpn_extension.send(conn, &stuffer));
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_protocol_preferences(conn, protocols, protocols_count));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_client_alpn_extension.send(conn, &stuffer));
@@ -89,7 +89,7 @@ int main(int argc, char **argv)
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_client_alpn_extension.send(conn, &stuffer));
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_client_alpn_extension.send(conn, &stuffer));

--- a/tests/unit/s2n_client_auth_handshake_test.c
+++ b/tests/unit/s2n_client_auth_handshake_test.c
@@ -141,8 +141,8 @@ int s2n_test_client_auth_message_by_message(bool no_cert)
         server_conn->x509_validator.skip_cert_validation = 1;
     }
 
-    struct s2n_stuffer client_to_server;
-    struct s2n_stuffer server_to_client;
+    struct s2n_stuffer client_to_server = { 0 };
+    struct s2n_stuffer server_to_client = { 0 };
 
     EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_to_server, 0));
     EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_to_client, 0));

--- a/tests/unit/s2n_client_cert_status_request_extension_test.c
+++ b/tests/unit/s2n_client_cert_status_request_extension_test.c
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_client_cert_status_request_extension.send(conn, &stuffer));
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_client_cert_status_request_extension.send(conn, &stuffer));
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_client_cert_status_request_extension.send(conn, &stuffer));
@@ -118,7 +118,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, bad_config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_client_cert_status_request_extension.send(conn, &stuffer));

--- a/tests/unit/s2n_client_empty_cert_test.c
+++ b/tests/unit/s2n_client_empty_cert_test.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
 
     /* Test s2n_send_empty_cert_chain */
     {
-        struct s2n_stuffer out;
+        struct s2n_stuffer out = { 0 };
         /* Magic number 3 is the length of the certificate_length field */
         EXPECT_SUCCESS(s2n_stuffer_alloc(&out, 3));
 

--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -373,7 +373,7 @@ int main(int argc, char **argv)
         POSIX_GUARD_RESULT(s2n_handshake_copy_hash_state(server_conn, server_keys.hash_algorithm, &server_hash));
         POSIX_GUARD(s2n_hash_digest(&server_hash, server_digest_out, hash_digest_length));
 
-        struct s2n_blob server_blob;
+        struct s2n_blob server_blob = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&server_blob, server_digest_out, hash_digest_length));
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&client_conn->handshake.io));
@@ -394,7 +394,7 @@ int main(int argc, char **argv)
         POSIX_GUARD_RESULT(s2n_handshake_copy_hash_state(client_conn, client_keys.hash_algorithm, &client_hash));
         POSIX_GUARD(s2n_hash_digest(&client_hash, client_digest_out, hash_digest_length));
 
-        struct s2n_blob client_blob;
+        struct s2n_blob client_blob = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&client_blob, client_digest_out, hash_digest_length));
 
         /* Test that the transcript hash recreated MUST be the same on the server and client side */

--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
 
     /* Test that s2n_extensions_key_share_size produces the expected constant result */
     {
-        struct s2n_stuffer key_share_extension;
+        struct s2n_stuffer key_share_extension = { 0 };
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
     {
         /* Test that s2n_client_key_share_extension.send initializes the client key share list */
         {
-            struct s2n_stuffer key_share_extension;
+            struct s2n_stuffer key_share_extension = { 0 };
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 0));
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
 
         /* Test that s2n_client_key_share_extension.send writes a well-formed list of key shares */
         {
-            struct s2n_stuffer key_share_extension;
+            struct s2n_stuffer key_share_extension = { 0 };
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 0));
@@ -129,7 +129,7 @@ int main(int argc, char **argv)
         /* Test s2n_client_key_share_extension.send for a supported curve present in s2n_all_supported_curves_list,
          * but not present in the ecc_preferences list selected */
         if (s2n_is_evp_apis_supported()) {
-            struct s2n_stuffer key_share_extension;
+            struct s2n_stuffer key_share_extension = { 0 };
             struct s2n_connection *conn;
             struct s2n_config *config;
             EXPECT_NOT_NULL(config = s2n_config_new());
@@ -180,7 +180,7 @@ int main(int argc, char **argv)
         if (s2n_is_evp_apis_supported()) {
             struct s2n_connection *conn;
             struct s2n_config *config;
-            struct s2n_stuffer key_share_extension;
+            struct s2n_stuffer key_share_extension = { 0 };
 
             EXPECT_NOT_NULL(config = s2n_config_new());
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
@@ -239,7 +239,7 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *client_conn;
             struct s2n_connection *server_conn;
-            struct s2n_stuffer key_share_extension;
+            struct s2n_stuffer key_share_extension = { 0 };
 
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -290,7 +290,7 @@ int main(int argc, char **argv)
          * if the server negotiated_curve is not set and is NULL. */
         {
             struct s2n_connection *conn;
-            struct s2n_stuffer key_share_extension;
+            struct s2n_stuffer key_share_extension = { 0 };
 
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
@@ -387,7 +387,7 @@ int main(int argc, char **argv)
          * the result of s2n_client_key_share_extension.send */
         {
             struct s2n_connection *client_conn, *server_conn;
-            struct s2n_stuffer key_share_extension;
+            struct s2n_stuffer key_share_extension = { 0 };
 
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -670,7 +670,7 @@ int main(int argc, char **argv)
          * than available data */
         {
             struct s2n_connection *conn;
-            struct s2n_stuffer key_share_extension;
+            struct s2n_stuffer key_share_extension = { 0 };
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
             EXPECT_OK(s2n_set_all_mutually_supported_groups(conn));
@@ -692,7 +692,7 @@ int main(int argc, char **argv)
         /* Test that s2n_client_key_share_extension.recv errors on key share size longer than data */
         {
             struct s2n_connection *conn;
-            struct s2n_stuffer key_share_extension;
+            struct s2n_stuffer key_share_extension = { 0 };
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
             EXPECT_OK(s2n_set_all_mutually_supported_groups(conn));
@@ -717,7 +717,7 @@ int main(int argc, char **argv)
         /* Test that s2n_client_key_share_extension.recv accepts a subset of supported curves */
         {
             struct s2n_connection *conn;
-            struct s2n_stuffer key_share_extension;
+            struct s2n_stuffer key_share_extension = { 0 };
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
             EXPECT_OK(s2n_set_all_mutually_supported_groups(conn));
@@ -750,7 +750,7 @@ int main(int argc, char **argv)
         /* Test that s2n_client_key_share_extension.recv handles empty client share list */
         {
             struct s2n_connection *server_conn;
-            struct s2n_stuffer key_share_extension;
+            struct s2n_stuffer key_share_extension = { 0 };
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
             EXPECT_OK(s2n_set_all_mutually_supported_groups(server_conn));
@@ -776,7 +776,7 @@ int main(int argc, char **argv)
         /* Test that s2n_client_key_share_extension.recv ignores unsupported curves */
         {
             struct s2n_connection *conn;
-            struct s2n_stuffer key_share_extension;
+            struct s2n_stuffer key_share_extension = { 0 };
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(conn, S2N_TLS13));
             EXPECT_OK(s2n_set_all_mutually_supported_groups(conn));
@@ -815,7 +815,7 @@ int main(int argc, char **argv)
         /* Test that s2n_client_key_share_extension.recv ignores curves with incorrect key size */
         {
             struct s2n_connection *conn;
-            struct s2n_stuffer key_share_extension;
+            struct s2n_stuffer key_share_extension = { 0 };
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(conn, S2N_TLS13));
             EXPECT_OK(s2n_set_all_mutually_supported_groups(conn));
@@ -848,7 +848,7 @@ int main(int argc, char **argv)
         /* Test that s2n_client_key_share_extension.recv uses first instance of duplicate curves */
         {
             struct s2n_connection *server_conn;
-            struct s2n_stuffer key_share_extension;
+            struct s2n_stuffer key_share_extension = { 0 };
             struct s2n_ecc_evp_params first_params, second_params;
             int supported_curve_index = 0;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -892,7 +892,7 @@ int main(int argc, char **argv)
         /* Test that s2n_client_key_share_extension.recv ignores ECDHE points that can't be parsed */
         {
             struct s2n_connection *conn;
-            struct s2n_stuffer key_share_extension;
+            struct s2n_stuffer key_share_extension = { 0 };
             struct s2n_config *config;
             EXPECT_NOT_NULL(config = s2n_config_new());
             /* Explicitly set the ecc_preferences list to only contain the curves p-256 and p-384 */
@@ -1045,7 +1045,7 @@ int main(int argc, char **argv)
         {
             if (s2n_is_evp_apis_supported()) {
                 struct s2n_connection *conn;
-                struct s2n_stuffer key_share_extension;
+                struct s2n_stuffer key_share_extension = { 0 };
                 struct s2n_config *config;
                 EXPECT_NOT_NULL(config = s2n_config_new());
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));

--- a/tests/unit/s2n_client_max_frag_len_extension_test.c
+++ b/tests/unit/s2n_client_max_frag_len_extension_test.c
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_config_send_max_fragment_length(config, S2N_TLS_MAX_FRAG_LEN_512));
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_config_send_max_fragment_length(config, S2N_TLS_MAX_FRAG_LEN_512));
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Send invalid mfl code */
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_config_send_max_fragment_length(conn->config, S2N_TLS_MAX_FRAG_LEN_512));

--- a/tests/unit/s2n_client_pq_kem_extension_test.c
+++ b/tests/unit/s2n_client_pq_kem_extension_test.c
@@ -60,7 +60,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy_version));
 
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
             EXPECT_SUCCESS(s2n_client_pq_kem_extension.send(conn, &stuffer));
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy_version));
 
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
             EXPECT_SUCCESS(s2n_client_pq_kem_extension.send(conn, &stuffer));
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy_version));
 
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
             EXPECT_SUCCESS(s2n_client_pq_kem_extension.send(conn, &stuffer));

--- a/tests/unit/s2n_client_renegotiation_info_extension_test.c
+++ b/tests/unit/s2n_client_renegotiation_info_extension_test.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint16(&stuffer, 0));
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 1));
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, 0));

--- a/tests/unit/s2n_client_sct_list_extension_test.c
+++ b/tests/unit/s2n_client_sct_list_extension_test.c
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_client_sct_list_extension.send(conn, &stuffer));
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_client_sct_list_extension.send(conn, &stuffer));

--- a/tests/unit/s2n_client_server_name_extension_test.c
+++ b/tests/unit/s2n_client_server_name_extension_test.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_set_server_name(conn, test_server_name));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_client_server_name_extension.send(conn, &stuffer));
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_set_server_name(client_conn, test_server_name));
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_set_server_name(client_conn, "DIFFERENT SERVER NAME"));
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_set_server_name(client_conn, test_server_name));
@@ -156,7 +156,7 @@ int main(int argc, char **argv)
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_set_server_name(client_conn, test_server_name));

--- a/tests/unit/s2n_client_session_ticket_extension_test.c
+++ b/tests/unit/s2n_client_session_ticket_extension_test.c
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
 
     /* send */
     {
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         s2n_set_test_ticket(client_conn, test_ticket, s2n_array_len(test_ticket));
@@ -85,7 +85,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         s2n_set_test_ticket(client_conn, test_ticket, S2N_TLS12_TICKET_SIZE_IN_BYTES);
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         s2n_set_test_ticket(client_conn, test_ticket, S2N_TLS12_TICKET_SIZE_IN_BYTES);
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         s2n_set_test_ticket(client_conn, test_ticket, S2N_TLS12_TICKET_SIZE_IN_BYTES - 1);
@@ -153,7 +153,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         s2n_set_test_ticket(client_conn, test_ticket, S2N_TLS12_TICKET_SIZE_IN_BYTES);

--- a/tests/unit/s2n_client_signature_algorithms_extension_test.c
+++ b/tests/unit/s2n_client_signature_algorithms_extension_test.c
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
         struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
         struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
 
-        struct s2n_stuffer io;
+        struct s2n_stuffer io = { 0 };
         s2n_stuffer_growable_alloc(&io, 0);
 
         EXPECT_SUCCESS(s2n_client_signature_algorithms_extension.send(client_conn, &io));
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
-        struct s2n_stuffer signature_algorithms_extension;
+        struct s2n_stuffer signature_algorithms_extension = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_alloc(&signature_algorithms_extension, 2 + (sig_hash_algs.len * 2)));
         POSIX_GUARD(s2n_stuffer_write_uint16(&signature_algorithms_extension, sig_hash_algs.len * 2));
         for (int i = 0; i < sig_hash_algs.len; i++) {
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
         POSIX_GUARD(s2n_connection_set_config(conn, config));
         conn->actual_protocol_version = S2N_TLS12;
 
-        struct s2n_stuffer signature_algorithms_extension;
+        struct s2n_stuffer signature_algorithms_extension = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_alloc(&signature_algorithms_extension, 2 + (sig_hash_algs.len * 2)));
         EXPECT_SUCCESS(s2n_stuffer_write_uint16(&signature_algorithms_extension, sig_hash_algs.len * 2));
         for (int i = 0; i < sig_hash_algs.len; i++) {

--- a/tests/unit/s2n_client_supported_groups_extension_test.c
+++ b/tests/unit/s2n_client_supported_groups_extension_test.c
@@ -49,7 +49,7 @@ int main()
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         const struct s2n_ecc_preferences *ecc_pref = NULL;
@@ -429,7 +429,7 @@ int main()
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         const struct s2n_ecc_preferences *ecc_pref = NULL;
@@ -454,7 +454,7 @@ int main()
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         const struct s2n_ecc_preferences *ecc_pref = NULL;
@@ -480,7 +480,7 @@ int main()
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         const struct s2n_ecc_preferences *ecc_pref = NULL;
@@ -511,7 +511,7 @@ int main()
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
-        struct s2n_stuffer supported_groups_extension;
+        struct s2n_stuffer supported_groups_extension = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_alloc(&supported_groups_extension, 2 + ec_curves_count * 2));
         POSIX_GUARD(s2n_stuffer_write_uint16(&supported_groups_extension, ec_curves_count * 2));
         for (int i = 0; i < ec_curves_count; i++) {

--- a/tests/unit/s2n_client_supported_versions_extension_test.c
+++ b/tests/unit/s2n_client_supported_versions_extension_test.c
@@ -124,7 +124,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_EQUAL(size_result, -1);
         uint16_t expected_length = size_result - S2N_EXTENSION_TYPE_FIELD_LENGTH - S2N_EXTENSION_LENGTH_FIELD_LENGTH;
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, expected_length);
 
         EXPECT_SUCCESS(s2n_client_supported_versions_extension.send(client_conn, &extension));
@@ -158,7 +158,7 @@ int main(int argc, char **argv)
         uint8_t supported_version_list[] = { S2N_TLS11, S2N_TLS12, S2N_TLS13, unsupported_client_version };
         uint8_t supported_version_list_length = sizeof(supported_version_list);
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, supported_version_list_length * 2 + 1);
 
         EXPECT_SUCCESS(write_test_supported_versions_list(&extension, supported_version_list,
@@ -184,7 +184,7 @@ int main(int argc, char **argv)
         uint8_t supported_version_list[] = { S2N_TLS11, S2N_TLS12, S2N_TLS13, unsupported_client_version };
         uint8_t supported_version_list_length = sizeof(supported_version_list);
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, supported_version_list_length * 2 + 1);
 
         EXPECT_SUCCESS(write_test_supported_versions_list(&extension, supported_version_list,
@@ -209,7 +209,7 @@ int main(int argc, char **argv)
         uint16_t invalid_version_list[] = { 0x0020, 0x0021, 0x0403, 0x0305, 0x7a7a, 0x0201 };
         uint8_t invalid_version_list_length = s2n_array_len(invalid_version_list);
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, invalid_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN + 1);
 
         POSIX_GUARD(s2n_stuffer_write_uint8(&extension, invalid_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN));
@@ -234,7 +234,7 @@ int main(int argc, char **argv)
         uint16_t grease_version_list[] = { 0x0304, GREASED_SUPPORTED_VERSION_EXTENSION_VALUES };
         uint8_t grease_version_list_length = s2n_array_len(grease_version_list);
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, grease_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN + 1);
 
         POSIX_GUARD(s2n_stuffer_write_uint8(&extension, grease_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN));
@@ -261,7 +261,7 @@ int main(int argc, char **argv)
         uint16_t invalid_version_list[] = { 0x0020, 0x0200, 0x0201, 0x0304, 0x0021, 0x0305, 0x0403, 0x7a7a };
         uint8_t invalid_version_list_length = s2n_array_len(invalid_version_list);
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, invalid_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN + 1);
 
         POSIX_GUARD(s2n_stuffer_write_uint8(&extension, invalid_version_list_length * S2N_TLS_PROTOCOL_VERSION_LEN));
@@ -288,7 +288,7 @@ int main(int argc, char **argv)
         uint8_t supported_version_list[] = { S2N_SSLv3 };
         uint8_t supported_version_list_length = sizeof(supported_version_list);
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, supported_version_list_length * 2 + 1);
 
         EXPECT_SUCCESS(write_test_supported_versions_list(&extension, supported_version_list,
@@ -308,7 +308,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, 1);
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&extension, 0));
@@ -327,7 +327,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, 1);
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&extension, 13));
@@ -345,7 +345,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, 5);
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&extension, 2));
@@ -365,7 +365,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, 4);
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&extension, 3));

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -39,7 +39,7 @@
  * [ReturnedBitsLen = 512]
  */
 
-struct s2n_stuffer nist_aes128_reference_entropy;
+struct s2n_stuffer nist_aes128_reference_entropy = { 0 };
 const char nist_aes128_reference_entropy_hex[] =
         "528ccd2d6c143800a34ad33e7f153cfaceaa2411abbaf4bfcfe9796898d0ece6"
         "478fd1eaa7ed293294d370979b0f0f1948d5a3161b12eeebf2cf6bd1bf059adf"
@@ -150,7 +150,7 @@ const char nist_aes128_reference_returned_bits_hex[] =
  * [ReturnedBitsLen = 512]
  */
 
-struct s2n_stuffer nist_aes256_reference_entropy;
+struct s2n_stuffer nist_aes256_reference_entropy = { 0 };
 const char nist_aes256_reference_entropy_hex_part1[] =
         "c8f0c7b9bdf7e7d524c998aedeabb3b7dd4fa8f95c51b582010a5e09d0b4b1ad510302422df738fbef002a051543b4cc"
         "c1a7b160c8e33a01fbd49743dc1161539390d9ba6b876fe63b58e8fd605b98617322578b17aca9db71e858b154f97910"

--- a/tests/unit/s2n_ecc_evp_test.c
+++ b/tests/unit/s2n_ecc_evp_test.c
@@ -133,7 +133,7 @@ int main(int argc, char** argv)
         /* Test s2n_ecc_evp_write_params_point for all supported curves */
         for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params test_params = { 0 };
-            struct s2n_stuffer wire;
+            struct s2n_stuffer wire = { 0 };
             uint8_t legacy_form;
 
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&wire, 0));
@@ -164,8 +164,8 @@ int main(int argc, char** argv)
         /* TEST s2n_ecc_evp_read_params_point for all supported curves */
         for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params write_params = { 0 };
-            struct s2n_blob point_blob;
-            struct s2n_stuffer wire;
+            struct s2n_blob point_blob = { 0 };
+            struct s2n_stuffer wire = { 0 };
 
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&wire, 0));
 
@@ -192,8 +192,8 @@ int main(int argc, char** argv)
         for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params write_params = { 0 };
             struct s2n_ecc_evp_params read_params = { 0 };
-            struct s2n_blob point_blob;
-            struct s2n_stuffer wire;
+            struct s2n_blob point_blob = { 0 };
+            struct s2n_stuffer wire = { 0 };
 
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&wire, 0));
 
@@ -227,7 +227,7 @@ int main(int argc, char** argv)
         for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params write_params = { 0 };
             struct s2n_ecc_evp_params read_params = { 0 };
-            struct s2n_stuffer wire;
+            struct s2n_stuffer wire = { 0 };
             struct s2n_blob ecdh_params_sent, ecdh_params_received;
 
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&wire, 1024));
@@ -265,7 +265,7 @@ int main(int argc, char** argv)
             struct s2n_ecc_evp_params server_params = { 0 };
             struct s2n_ecc_evp_params read_params = { 0 };
             struct s2n_ecc_evp_params client_params = { 0 };
-            struct s2n_stuffer wire;
+            struct s2n_stuffer wire = { 0 };
             struct s2n_blob ecdh_params_sent, ecdh_params_received;
             struct s2n_blob server_shared_secret, client_shared_secret;
 
@@ -322,7 +322,7 @@ int main(int argc, char** argv)
         /* Test generate->write->read->compute_shared with all supported curves */
         for (int i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params server_params = { 0 }, client_params = { 0 };
-            struct s2n_stuffer wire;
+            struct s2n_stuffer wire = { 0 };
             struct s2n_blob server_shared, client_shared, ecdh_params_sent, ecdh_params_received;
 
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&wire, 1024));

--- a/tests/unit/s2n_ecc_point_format_extension_test.c
+++ b/tests/unit/s2n_ecc_point_format_extension_test.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_client_ec_point_format_extension.send(conn, &stuffer));
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_client_ec_point_format_extension.send(conn, &stuffer));

--- a/tests/unit/s2n_extension_list_process_test.c
+++ b/tests/unit/s2n_extension_list_process_test.c
@@ -66,7 +66,7 @@ int main()
     /* Test s2n_extension_process */
     {
         uint8_t extension_data[] = "data";
-        struct s2n_blob extension_blob;
+        struct s2n_blob extension_blob = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&extension_blob, extension_data, sizeof(extension_data)));
 
         const s2n_extension_type test_extension_type = {

--- a/tests/unit/s2n_extension_list_send_test.c
+++ b/tests/unit/s2n_extension_list_send_test.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
 
     /* Writes just size if extension type list empty */
     {
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         struct s2n_connection *conn;
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
 
     /* Send performs basic, non-zero write */
     {
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         struct s2n_connection *conn;
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
 
     /* Write empty list */
     {
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         struct s2n_connection *conn;
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
 
     /* Send writes valid supported_versions extension */
     {
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         struct s2n_connection *client_conn;
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &first_extension_size));
         EXPECT_NOT_EQUAL(first_extension_size, 0);
 
-        struct s2n_stuffer extensions_stuffer;
+        struct s2n_stuffer extensions_stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extensions_stuffer, 0));
         EXPECT_SUCCESS(s2n_stuffer_copy(&stuffer, &extensions_stuffer, first_extension_size));
 

--- a/tests/unit/s2n_hash_test.c
+++ b/tests/unit/s2n_hash_test.c
@@ -31,7 +31,7 @@ int main(int argc, char **argv)
     uint8_t hello[] = "Hello world!\n";
     uint8_t string1[] = "String 1\n";
     uint8_t string2[] = "and String 2\n";
-    struct s2n_stuffer output;
+    struct s2n_stuffer output = { 0 };
     struct s2n_hash_state hash, copy;
     struct s2n_blob out = { .data = output_pad, .size = sizeof(output_pad) };
     uint64_t bytes_in_hash;

--- a/tests/unit/s2n_hmac_test.c
+++ b/tests/unit/s2n_hmac_test.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv)
     uint8_t digest_pad[256];
     uint8_t check_pad[256];
     uint8_t output_pad[256];
-    struct s2n_stuffer output;
+    struct s2n_stuffer output = { 0 };
     uint8_t sekrit[] = "sekrit";
     uint8_t longsekrit[] = "This is a really really really long key on purpose to make sure that it's longer than the block size";
     uint8_t hello[] = "Hello world!";

--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -201,7 +201,7 @@ int main(int argc, char **argv)
 
         /* Fill the kem_group_params with secrets */
         EXPECT_SUCCESS(alloc_test_kem_params(&kem_group_params.kem_params));
-        struct s2n_stuffer wire;
+        struct s2n_stuffer wire = { 0 };
         POSIX_GUARD(s2n_stuffer_growable_alloc(&wire, 1024));
         kem_group_params.ecc_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
         POSIX_GUARD(s2n_ecdhe_parameters_send(&kem_group_params.ecc_params, &wire));

--- a/tests/unit/s2n_key_share_extension_test.c
+++ b/tests/unit/s2n_key_share_extension_test.c
@@ -31,7 +31,7 @@ int main(int argc, char **argv)
 
     /* Test s2n_ecdhe_parameters_send write with valid ecc params */
     {
-        struct s2n_stuffer out;
+        struct s2n_stuffer out = { 0 };
 
         struct s2n_ecc_evp_params ecc_evp_params;
         ecc_evp_params.negotiated_curve = test_curve;
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
 
     /* Test s2n_ecdhe_parameters_send failure with bad ecc params */
     {
-        struct s2n_stuffer out;
+        struct s2n_stuffer out = { 0 };
 
         struct s2n_ecc_evp_params ecc_evp_params;
         const struct s2n_ecc_named_curve bad_curve = {

--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -219,7 +219,7 @@ int main(int argc, char **argv)
             POSIX_CHECKED_MEMCPY(client_conn->secrets.tls13.client_app_secret, application_secret.data, application_secret.size);
 
             /* Setup io */
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, client_conn));
 
@@ -245,7 +245,7 @@ int main(int argc, char **argv)
             POSIX_CHECKED_MEMCPY(client_conn->secrets.tls13.client_app_secret, application_secret.data, application_secret.size);
 
             /* Setup io */
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, client_conn));
 
@@ -273,7 +273,7 @@ int main(int argc, char **argv)
             uint8_t expected_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN] = { 0 };
 
             /* Setup io */
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, client_conn));
 

--- a/tests/unit/s2n_map_test.c
+++ b/tests/unit/s2n_map_test.c
@@ -25,8 +25,8 @@ int main(int argc, char **argv)
     char keystr[sizeof("ffff")];
     char valstr[sizeof("16384")];
     struct s2n_map *empty, *map;
-    struct s2n_blob key;
-    struct s2n_blob val;
+    struct s2n_blob key = { 0 };
+    struct s2n_blob val = { 0 };
     bool key_found;
 
     BEGIN_TEST();

--- a/tests/unit/s2n_mutual_auth_test.c
+++ b/tests/unit/s2n_mutual_auth_test.c
@@ -86,8 +86,8 @@ int main(int argc, char **argv)
         struct s2n_security_policy server_security_policy;
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
-        struct s2n_stuffer client_to_server;
-        struct s2n_stuffer server_to_client;
+        struct s2n_stuffer client_to_server = { 0 };
+        struct s2n_stuffer server_to_client = { 0 };
 
         /* Craft a cipher preference with a cipher_idx cipher */
         EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
@@ -145,8 +145,8 @@ int main(int argc, char **argv)
         struct s2n_security_policy server_security_policy;
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
-        struct s2n_stuffer client_to_server;
-        struct s2n_stuffer server_to_client;
+        struct s2n_stuffer client_to_server = { 0 };
+        struct s2n_stuffer server_to_client = { 0 };
 
         /* Craft a cipher preference with a cipher_idx cipher */
         EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
@@ -199,8 +199,8 @@ int main(int argc, char **argv)
         struct s2n_security_policy server_security_policy;
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
-        struct s2n_stuffer client_to_server;
-        struct s2n_stuffer server_to_client;
+        struct s2n_stuffer client_to_server = { 0 };
+        struct s2n_stuffer server_to_client = { 0 };
 
         /* Craft a cipher preference with a cipher_idx cipher */
         EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
@@ -259,8 +259,8 @@ int main(int argc, char **argv)
         struct s2n_security_policy server_security_policy;
         struct s2n_connection *client_conn;
         struct s2n_connection *server_conn;
-        struct s2n_stuffer client_to_server;
-        struct s2n_stuffer server_to_client;
+        struct s2n_stuffer client_to_server = { 0 };
+        struct s2n_stuffer server_to_client = { 0 };
 
         /* Craft a cipher preference with a cipher_idx cipher */
         EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));

--- a/tests/unit/s2n_override_openssl_random_test.c
+++ b/tests/unit/s2n_override_openssl_random_test.c
@@ -47,7 +47,7 @@ const char expected_dhe_key_hex[] = "0100cb5fa155609f350a0f07e340ef7dc854e38d97c
                                     "ddbaa47646a497793e0a8e129e00e4fcd4b11b68897afb0987a48f51e3a3079e3d0573d340597c2c7b8ec839ea608a341c8d3ae8fb8a30c2d80e7083f64adf790"
                                     "18a19c";
 
-struct s2n_stuffer test_entropy;
+struct s2n_stuffer test_entropy = { 0 };
 int s2n_entropy_generator(void *data, uint32_t size)
 {
     struct s2n_blob blob = { .data = data, .size = size };

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -482,7 +482,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-            struct s2n_blob hash_value;
+            struct s2n_blob hash_value = { 0 };
             uint8_t hash_value_data[SHA256_DIGEST_LENGTH];
             EXPECT_SUCCESS(s2n_blob_init(&hash_value, hash_value_data, sizeof(hash_value_data)));
 
@@ -498,7 +498,7 @@ int main(int argc, char **argv)
             EXPECT_OK(s2n_psk_init(&test_psk, S2N_PSK_TYPE_RESUMPTION));
             EXPECT_SUCCESS(s2n_psk_set_secret(&test_psk, resumption_secret.data, resumption_secret.size));
 
-            struct s2n_blob binder_value;
+            struct s2n_blob binder_value = { 0 };
             uint8_t binder_value_data[SHA256_DIGEST_LENGTH];
             EXPECT_SUCCESS(s2n_blob_init(&binder_value, binder_value_data, sizeof(binder_value_data)));
 
@@ -516,7 +516,7 @@ int main(int argc, char **argv)
             EXPECT_OK(s2n_psk_init(&test_psk, S2N_PSK_TYPE_RESUMPTION));
             EXPECT_SUCCESS(s2n_psk_set_secret(&test_psk, resumption_secret.data, resumption_secret.size));
 
-            struct s2n_blob binder_value;
+            struct s2n_blob binder_value = { 0 };
             uint8_t binder_value_data[SHA256_DIGEST_LENGTH];
             EXPECT_SUCCESS(s2n_blob_init(&binder_value, binder_value_data, sizeof(binder_value_data)));
 
@@ -537,7 +537,7 @@ int main(int argc, char **argv)
 
             struct s2n_blob *incorrect_binder_value = &resumption_secret;
 
-            struct s2n_blob binder_value;
+            struct s2n_blob binder_value = { 0 };
             uint8_t binder_value_data[SHA256_DIGEST_LENGTH];
             EXPECT_SUCCESS(s2n_blob_init(&binder_value, binder_value_data, sizeof(binder_value_data)));
 

--- a/tests/unit/s2n_quic_support_io_test.c
+++ b/tests/unit/s2n_quic_support_io_test.c
@@ -80,7 +80,7 @@ static S2N_RESULT s2n_write_test_message(struct s2n_blob *out, message_type_t me
 {
     RESULT_GUARD_POSIX(s2n_alloc(out, TEST_DATA_SIZE + TLS_HANDSHAKE_HEADER_LENGTH));
 
-    struct s2n_stuffer stuffer;
+    struct s2n_stuffer stuffer = { 0 };
     RESULT_GUARD_POSIX(s2n_stuffer_init(&stuffer, out));
 
     RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(&stuffer, message_type));
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
 
@@ -177,7 +177,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
 
@@ -196,7 +196,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
 
@@ -217,7 +217,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
 
@@ -394,7 +394,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
             /* Sabotage the output stuffer to block writing */
-            struct s2n_stuffer bad_stuffer;
+            struct s2n_stuffer bad_stuffer = { 0 };
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input_stuffer, &bad_stuffer, conn));
 
             EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked_status), S2N_ERR_IO_BLOCKED);

--- a/tests/unit/s2n_self_talk_nonblocking_test.c
+++ b/tests/unit/s2n_self_talk_nonblocking_test.c
@@ -238,7 +238,7 @@ int test_send(int use_tls13, int use_iov, int prefer_throughput)
         iov = malloc(sizeof(*iov) * iov_size);
         data_size = 0;
         for (int i = 0; i < iov_size; i++, iov_payload_size *= 2) {
-            struct s2n_blob blob_local;
+            struct s2n_blob blob_local = { 0 };
             iov[i].iov_base = blob_local.data = malloc(iov_payload_size);
             iov[i].iov_len = blob_local.size = iov_payload_size;
             EXPECT_OK(s2n_get_public_random_data(&blob));

--- a/tests/unit/s2n_server_alpn_extension_test.c
+++ b/tests/unit/s2n_server_alpn_extension_test.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_MEMCPY_SUCCESS(conn->application_protocol, test_protocol_name, test_protocol_name_size);
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_server_alpn_extension.send(conn, &stuffer));
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
             struct s2n_connection *client_conn;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
             EXPECT_SUCCESS(s2n_server_alpn_extension.send(server_conn, &stuffer));
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
             struct s2n_connection *client_conn;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
             EXPECT_SUCCESS(s2n_server_alpn_extension.send(server_conn, &stuffer));

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -520,7 +520,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         conn->secure->cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha;
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_server_extensions_send(conn, &stuffer));

--- a/tests/unit/s2n_server_hello_retry_test.c
+++ b/tests/unit/s2n_server_hello_retry_test.c
@@ -378,7 +378,7 @@ int main(int argc, char **argv)
 
         s2n_tls13_connection_keys(keys, conn);
         uint8_t hash_digest_length = keys.size;
-        struct s2n_blob compare_blob;
+        struct s2n_blob compare_blob = { 0 };
 
         DEFER_CLEANUP(struct s2n_hash_state client_hello1_hash = { 0 }, s2n_hash_free);
         EXPECT_SUCCESS(s2n_hash_new(&client_hello1_hash));

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -247,7 +247,7 @@ int main(int argc, char **argv)
             };
 
             for (int i = 0; i < 3; i++) {
-                struct s2n_stuffer extension_stuffer;
+                struct s2n_stuffer extension_stuffer = { 0 };
                 struct s2n_connection *client_conn;
 
                 EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
@@ -275,7 +275,7 @@ int main(int argc, char **argv)
             /* Test that s2n_server_key_share_extension.recv is a no-op
              * if tls1.3 not enabled */
             {
-                struct s2n_stuffer extension_stuffer;
+                struct s2n_stuffer extension_stuffer = { 0 };
                 struct s2n_connection *client_conn;
 
                 EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
@@ -311,7 +311,7 @@ int main(int argc, char **argv)
 
         /* Test error handling parsing broken/trancated p256 key share */
         {
-            struct s2n_stuffer extension_stuffer;
+            struct s2n_stuffer extension_stuffer = { 0 };
             struct s2n_connection *client_conn;
 
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
@@ -328,7 +328,7 @@ int main(int argc, char **argv)
 
         /* Test failure for receiving p256 key share for client configured p384 key share */
         {
-            struct s2n_stuffer extension_stuffer;
+            struct s2n_stuffer extension_stuffer = { 0 };
             struct s2n_connection *client_conn;
 
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
@@ -357,7 +357,7 @@ int main(int argc, char **argv)
     /* Test Shared Key Generation */
     {
         struct s2n_connection *client_conn, *server_conn;
-        struct s2n_stuffer key_share_extension;
+        struct s2n_stuffer key_share_extension = { 0 };
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));

--- a/tests/unit/s2n_server_max_frag_len_extension_test.c
+++ b/tests/unit/s2n_server_max_frag_len_extension_test.c
@@ -52,7 +52,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_1024;
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         conn->negotiated_mfl_code = S2N_TLS_MAX_FRAG_LEN_512;
@@ -141,7 +141,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         /* Existing mfl value lower */

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -835,7 +835,7 @@ int main(int argc, char **argv)
             conn->tickets_to_send = 1;
 
             /* Setup io */
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
 
@@ -857,7 +857,7 @@ int main(int argc, char **argv)
             conn->tickets_to_send = 1;
 
             /* Setup io */
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
 
@@ -885,7 +885,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_EQUAL(0, s2n_stuffer_space_remaining(&conn->handshake.io));
 
             /* Setup io */
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
 
@@ -919,7 +919,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_EQUAL(s2n_stuffer_space_remaining(&conn->handshake.io), 0);
 
             /* Setup io */
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
 
@@ -969,7 +969,7 @@ int main(int argc, char **argv)
             conn->tickets_to_send = current_tickets;
             EXPECT_TICKETS_SENT(conn, current_tickets);
 
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
 
@@ -1025,7 +1025,7 @@ int main(int argc, char **argv)
             conn->secure->cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
             /* Setup io */
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
 
@@ -1075,7 +1075,7 @@ int main(int argc, char **argv)
             conn->secure->cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
             /* Setup io */
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
 
@@ -1105,7 +1105,7 @@ int main(int argc, char **argv)
             conn->tickets_to_send = tickets_to_send;
 
             /* Setup io */
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
 
@@ -1252,8 +1252,8 @@ int main(int argc, char **argv)
         uint16_t tickets_to_send = 5;
         server_conn->tickets_to_send = tickets_to_send;
 
-        struct s2n_stuffer client_to_server;
-        struct s2n_stuffer server_to_client;
+        struct s2n_stuffer client_to_server = { 0 };
+        struct s2n_stuffer server_to_client = { 0 };
 
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_to_server, 0));
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_to_client, 0));

--- a/tests/unit/s2n_server_renegotiation_info_test.c
+++ b/tests/unit/s2n_server_renegotiation_info_test.c
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extension, 0));
 
         server_conn->actual_protocol_version = S2N_TLS12;
@@ -164,7 +164,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extension, 0));
 
         server_conn->actual_protocol_version = S2N_TLS12;
@@ -194,7 +194,7 @@ int main(int argc, char **argv)
         struct s2n_connection *client_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extension, 0));
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&extension, 5));

--- a/tests/unit/s2n_server_sct_list_extension_test.c
+++ b/tests/unit/s2n_server_sct_list_extension_test.c
@@ -83,7 +83,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_server_sct_list_extension.send(conn, &stuffer));
@@ -101,7 +101,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
         EXPECT_SUCCESS(s2n_server_sct_list_extension.send(conn, &stuffer));

--- a/tests/unit/s2n_server_signature_algorithms_extension_test.c
+++ b/tests/unit/s2n_server_signature_algorithms_extension_test.c
@@ -37,7 +37,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
-        struct s2n_stuffer io;
+        struct s2n_stuffer io = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&io, 0));
 
         EXPECT_SUCCESS(s2n_server_signature_algorithms_extension.send(server_conn, &io));

--- a/tests/unit/s2n_server_supported_versions_extension_test.c
+++ b/tests/unit/s2n_server_supported_versions_extension_test.c
@@ -52,7 +52,7 @@ int main(int argc, char **argv)
 
         uint16_t expected_length = 6;
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, expected_length);
 
         EXPECT_SUCCESS(s2n_server_supported_versions_extension.send(server_conn, &extension));
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
 
         uint16_t supported_version_length = 6;
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, supported_version_length);
 
         EXPECT_SUCCESS(write_test_supported_version(&extension, unsupported_version_unknown));
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
 
         uint16_t supported_version_length = 6;
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, supported_version_length);
 
         EXPECT_SUCCESS(write_test_supported_version(&extension, unsupported_version_gt_tls13));
@@ -124,7 +124,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, 1);
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&extension, 0));
 
@@ -140,7 +140,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-        struct s2n_stuffer extension;
+        struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, 1);
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&extension, 13));

--- a/tests/unit/s2n_signature_algorithms_test.c
+++ b/tests/unit/s2n_signature_algorithms_test.c
@@ -118,7 +118,7 @@ int main(int argc, char **argv)
 
         config->security_policy = &test_security_policy;
 
-        struct s2n_stuffer result;
+        struct s2n_stuffer result = { 0 };
         s2n_stuffer_growable_alloc(&result, STUFFER_SIZE);
 
         uint16_t size, iana_value;
@@ -223,7 +223,7 @@ int main(int argc, char **argv)
 
         config->security_policy = &test_security_policy;
 
-        struct s2n_stuffer choice;
+        struct s2n_stuffer choice = { 0 };
         s2n_stuffer_growable_alloc(&choice, STUFFER_SIZE);
 
         struct s2n_signature_scheme result;
@@ -308,7 +308,7 @@ int main(int argc, char **argv)
 
         config->security_policy = &test_security_policy;
 
-        struct s2n_stuffer choice;
+        struct s2n_stuffer choice = { 0 };
         s2n_stuffer_growable_alloc(&choice, STUFFER_SIZE);
 
         struct s2n_signature_scheme result;
@@ -631,7 +631,7 @@ int main(int argc, char **argv)
     {
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
 
-        struct s2n_stuffer result;
+        struct s2n_stuffer result = { 0 };
         s2n_stuffer_growable_alloc(&result, STUFFER_SIZE);
 
         struct s2n_sig_scheme_list signatures;
@@ -702,7 +702,7 @@ int main(int argc, char **argv)
         /* Do not offer PSS signatures schemes if unsupported:
          * s2n_send_supported_sig_scheme_list + PSS */
         {
-            struct s2n_stuffer result;
+            struct s2n_stuffer result = { 0 };
             s2n_stuffer_growable_alloc(&result, STUFFER_SIZE);
 
             EXPECT_SUCCESS(s2n_send_supported_sig_scheme_list(conn, &result));
@@ -724,7 +724,7 @@ int main(int argc, char **argv)
         /* Do not accept a PSS signature scheme if unsupported:
          * s2n_get_and_validate_negotiated_signature_scheme + PSS */
         {
-            struct s2n_stuffer choice;
+            struct s2n_stuffer choice = { 0 };
             s2n_stuffer_growable_alloc(&choice, STUFFER_SIZE);
             s2n_stuffer_write_uint16(&choice, s2n_rsa_pss_rsae_sha256.iana_value);
 

--- a/tests/unit/s2n_stuffer_hex_test.c
+++ b/tests/unit/s2n_stuffer_hex_test.c
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
 {
     uint8_t pad[100];
     struct s2n_blob b = { .data = pad, .size = sizeof(pad) };
-    struct s2n_stuffer stuffer;
+    struct s2n_stuffer stuffer = { 0 };
     uint8_t u8;
     uint16_t u16;
     uint32_t u32;

--- a/tests/unit/s2n_stuffer_network_order_test.c
+++ b/tests/unit/s2n_stuffer_network_order_test.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    struct s2n_stuffer stuffer;
+    struct s2n_stuffer stuffer = { 0 };
 
     /* s2n_stuffer_write_network_order */
     {

--- a/tests/unit/s2n_stuffer_test.c
+++ b/tests/unit/s2n_stuffer_test.c
@@ -22,7 +22,7 @@
 int main(int argc, char **argv)
 {
     uint8_t entropy[2048] = { 0 };
-    struct s2n_stuffer stuffer;
+    struct s2n_stuffer stuffer = { 0 };
     uint8_t u8;
     uint16_t u16;
     uint32_t u32;
@@ -139,24 +139,24 @@ int main(int argc, char **argv)
 
 #ifndef NDEBUG
     /* Invalid blob should fail init */
-    struct s2n_stuffer s1;
+    struct s2n_stuffer s1 = { 0 };
     struct s2n_blob b1 = { .data = 0, .size = 101 };
     EXPECT_FAILURE(s2n_stuffer_init(&s1, &b1));
 #endif
 
     /* Valid empty blob should succeed init */
-    struct s2n_stuffer s2;
+    struct s2n_stuffer s2 = { 0 };
     struct s2n_blob b2 = { .data = 0, .size = 0 };
     EXPECT_SUCCESS(s2n_stuffer_init(&s2, &b2));
 
     /* Valid blob should succeed init */
-    struct s2n_stuffer s3;
+    struct s2n_stuffer s3 = { 0 };
     uint8_t a3[12];
     struct s2n_blob b3 = { .data = a3, .size = sizeof(a3) };
     EXPECT_SUCCESS(s2n_stuffer_init(&s3, &b3));
 
     /* Null blob should fail init */
-    struct s2n_stuffer s4;
+    struct s2n_stuffer s4 = { 0 };
     EXPECT_FAILURE(s2n_stuffer_init(&s4, NULL));
 
     /* Null stuffer should fail init */

--- a/tests/unit/s2n_stuffer_text_test.c
+++ b/tests/unit/s2n_stuffer_text_test.c
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
     /* Check line reading */
     {
         struct s2n_blob line_blob = { 0 };
-        struct s2n_stuffer lstuffer;
+        struct s2n_stuffer lstuffer = { 0 };
         char lf_line[] = "a LF terminated line\n";
         char crlf_line[] = "a CRLF terminated line\r\n";
         char lf_line_trailing_cr[] = "a LF terminated line with trailing CR\n\r\r\r\r\r\r";

--- a/tests/unit/s2n_tls12_handshake_test.c
+++ b/tests/unit/s2n_tls12_handshake_test.c
@@ -197,7 +197,7 @@ int main(int argc, char **argv)
         struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
         conn->actual_protocol_version = S2N_TLS12;
 
-        struct s2n_stuffer input;
+        struct s2n_stuffer input = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 
@@ -237,7 +237,7 @@ int main(int argc, char **argv)
         struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
         conn->actual_protocol_version = S2N_TLS12;
 
-        struct s2n_stuffer input;
+        struct s2n_stuffer input = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 
@@ -312,7 +312,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
             conn->actual_protocol_version = S2N_TLS12;
 
-            struct s2n_stuffer input;
+            struct s2n_stuffer input = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 
@@ -337,7 +337,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
             conn->actual_protocol_version = S2N_TLS12;
 
-            struct s2n_stuffer input;
+            struct s2n_stuffer input = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 
@@ -362,7 +362,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
             conn->actual_protocol_version = S2N_TLS12;
 
-            struct s2n_stuffer input;
+            struct s2n_stuffer input = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 
@@ -397,7 +397,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
             conn->actual_protocol_version = S2N_TLS12;
 
-            struct s2n_stuffer input;
+            struct s2n_stuffer input = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 

--- a/tests/unit/s2n_tls13_handshake_state_machine_test.c
+++ b/tests/unit/s2n_tls13_handshake_state_machine_test.c
@@ -428,7 +428,7 @@ int main(int argc, char **argv)
         conn->actual_protocol_version = S2N_TLS13;
         EXPECT_OK(s2n_conn_choose_state_machine(conn, S2N_TLS13));
 
-        struct s2n_stuffer input;
+        struct s2n_stuffer input = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 
@@ -470,7 +470,7 @@ int main(int argc, char **argv)
         conn->actual_protocol_version = S2N_TLS13;
         EXPECT_OK(s2n_conn_choose_state_machine(conn, S2N_TLS13));
 
-        struct s2n_stuffer input;
+        struct s2n_stuffer input = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 
@@ -514,7 +514,7 @@ int main(int argc, char **argv)
             conn->actual_protocol_version = S2N_TLS13;
             EXPECT_OK(s2n_conn_choose_state_machine(conn, S2N_TLS13));
 
-            struct s2n_stuffer input;
+            struct s2n_stuffer input = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 
@@ -541,7 +541,7 @@ int main(int argc, char **argv)
             conn->actual_protocol_version = S2N_TLS13;
             EXPECT_OK(s2n_conn_choose_state_machine(conn, S2N_TLS13));
 
-            struct s2n_stuffer input;
+            struct s2n_stuffer input = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 
@@ -567,7 +567,7 @@ int main(int argc, char **argv)
             conn->actual_protocol_version = S2N_TLS13;
             EXPECT_OK(s2n_conn_choose_state_machine(conn, S2N_TLS13));
 
-            struct s2n_stuffer input;
+            struct s2n_stuffer input = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 
@@ -603,7 +603,7 @@ int main(int argc, char **argv)
             conn->actual_protocol_version = S2N_TLS13;
             EXPECT_OK(s2n_conn_choose_state_machine(conn, S2N_TLS13));
 
-            struct s2n_stuffer input;
+            struct s2n_stuffer input = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 
@@ -632,7 +632,7 @@ int main(int argc, char **argv)
             EXPECT_OK(s2n_conn_choose_state_machine(conn, S2N_TLS13));
             POSIX_GUARD(s2n_connection_set_client_auth_type(conn, S2N_CERT_AUTH_OPTIONAL));
 
-            struct s2n_stuffer input;
+            struct s2n_stuffer input = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, NULL, conn));
 

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -190,8 +190,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
-        struct s2n_stuffer client_to_server;
-        struct s2n_stuffer server_to_client;
+        struct s2n_stuffer client_to_server = { 0 };
+        struct s2n_stuffer server_to_client = { 0 };
 
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&client_to_server, 0));
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_to_client, 0));

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -388,7 +388,7 @@ static int set_up_conns(struct s2n_connection *client_conn, struct s2n_connectio
     POSIX_ENSURE_REF(server_conn->kex_params.server_kem_group_params.ecc_params.evp_pkey);
 
     /* Each peer sends its public ECC key to the other */
-    struct s2n_stuffer wire;
+    struct s2n_stuffer wire = { 0 };
     struct s2n_blob server_point_blob, client_point_blob;
     uint16_t share_size = kem_group->curve->share_size;
 

--- a/tests/unit/s2n_tls13_parse_record_type_test.c
+++ b/tests/unit/s2n_tls13_parse_record_type_test.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
 
     /* Test for record padding handling */
     {
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
 
         /* no padding */
@@ -129,7 +129,7 @@ int main(int argc, char **argv)
     {
         EXPECT_EQUAL(S2N_MAXIMUM_INNER_PLAINTEXT_LENGTH, 16385);
 
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, not_padding_value));
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
 
     /* Test maximum record length size (maximum data) */
     {
-        struct s2n_stuffer stuffer;
+        struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
 
         /* fill up stuffer to before the limit */
@@ -176,7 +176,7 @@ int main(int argc, char **argv)
         const size_t extra_length_tolerated = 16;
         /* Test slightly overlarge record for compatibility (empty data) */
         {
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
 
             EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, not_padding_value));
@@ -195,7 +195,7 @@ int main(int argc, char **argv)
 
         /* Test slightly overlarge record for compatibility (maximum data) */
         {
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
 
             /* fill up stuffer to before the limit */
@@ -218,7 +218,7 @@ int main(int argc, char **argv)
 
         /* Test slightly overlarge record for compatibility (with too much data) */
         {
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
 
             /* Finally, do this with an overall length which should pass, but too much data before the padding */
@@ -239,7 +239,7 @@ int main(int argc, char **argv)
 
         /* Test slightly overlarge + 1 record for compatibility (empty data) */
         {
-            struct s2n_stuffer stuffer;
+            struct s2n_stuffer stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 1024));
 
             EXPECT_SUCCESS(s2n_stuffer_write_uint8(&stuffer, not_padding_value));

--- a/tests/unit/s2n_tls13_prf_test.c
+++ b/tests/unit/s2n_tls13_prf_test.c
@@ -60,8 +60,8 @@ int main(int argc, char **argv)
 
     uint8_t digest_buf[SHA256_DIGEST_LENGTH];
     uint8_t secret_buf[SHA256_DIGEST_LENGTH];
-    struct s2n_blob digest;
-    struct s2n_blob secret;
+    struct s2n_blob digest = { 0 };
+    struct s2n_blob secret = { 0 };
 
     struct s2n_hash_state transcript_hash, transcript_hash_snapshot;
 

--- a/tests/unit/s2n_tls13_record_aead_test.c
+++ b/tests/unit/s2n_tls13_record_aead_test.c
@@ -163,7 +163,7 @@ int main(int argc, char **argv)
          * we copy the contents for verification.
          */
         s2n_stack_blob(decrypted, plaintext_record.size, 1000);
-        struct s2n_stuffer decrypted_stuffer;
+        struct s2n_stuffer decrypted_stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_init(&decrypted_stuffer, &decrypted));
 
         EXPECT_SUCCESS(s2n_stuffer_write_bytes(&decrypted_stuffer, conn->in.blob.data, plaintext_record.size));

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(server_conn));
 
-        struct s2n_stuffer extension_data;
+        struct s2n_stuffer extension_data = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extension_data, 0));
         EXPECT_SUCCESS(s2n_stuffer_write_str(&extension_data, "bad extension"));
 

--- a/tests/unit/s2n_wildcard_hostname_test.c
+++ b/tests/unit/s2n_wildcard_hostname_test.c
@@ -49,8 +49,8 @@ int main(int argc, char **argv)
         struct s2n_blob hostname_blob = { .data = (uint8_t *) (uintptr_t) hostname, .size = strlen(hostname) };
         uint8_t output[S2N_MAX_SERVER_NAME] = { 0 };
         struct s2n_blob output_blob = { .data = (uint8_t *) (uintptr_t) output, .size = sizeof(output) };
-        struct s2n_stuffer hostname_stuffer;
-        struct s2n_stuffer output_stuffer;
+        struct s2n_stuffer hostname_stuffer = { 0 };
+        struct s2n_stuffer output_stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_init(&hostname_stuffer, &hostname_blob));
         EXPECT_SUCCESS(s2n_stuffer_skip_write(&hostname_stuffer, hostname_blob.size));
         EXPECT_SUCCESS(s2n_stuffer_init(&output_stuffer, &output_blob));

--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -834,7 +834,7 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &pkey_type, &public_key_out));
 
         EXPECT_EQUAL(1, verify_data.callback_invoked);
-        struct s2n_stuffer ocsp_data_stuffer;
+        struct s2n_stuffer ocsp_data_stuffer = { 0 };
         EXPECT_SUCCESS(read_file(&ocsp_data_stuffer, S2N_OCSP_RESPONSE_DER, S2N_MAX_TEST_PEM_SIZE));
         uint32_t ocsp_data_len = s2n_stuffer_data_available(&ocsp_data_stuffer);
         EXPECT_TRUE(ocsp_data_len > 0);
@@ -874,7 +874,7 @@ int main(int argc, char **argv)
         s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
         EXPECT_OK(s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &pkey_type, &public_key_out));
 
-        struct s2n_stuffer ocsp_data_stuffer;
+        struct s2n_stuffer ocsp_data_stuffer = { 0 };
         EXPECT_SUCCESS(read_file(&ocsp_data_stuffer, S2N_OCSP_RESPONSE_NO_NEXT_UPDATE_DER, S2N_MAX_TEST_PEM_SIZE));
         uint32_t ocsp_data_len = s2n_stuffer_data_available(&ocsp_data_stuffer);
         EXPECT_TRUE(ocsp_data_len > 0);
@@ -929,7 +929,7 @@ int main(int argc, char **argv)
         s2n_pkey_free(&public_key_out);
 
         EXPECT_EQUAL(1, verify_data.callback_invoked);
-        struct s2n_stuffer ocsp_data_stuffer;
+        struct s2n_stuffer ocsp_data_stuffer = { 0 };
         EXPECT_SUCCESS(read_file(&ocsp_data_stuffer, S2N_OCSP_RESPONSE_DER, S2N_MAX_TEST_PEM_SIZE));
         uint32_t ocsp_data_len = s2n_stuffer_data_available(&ocsp_data_stuffer);
         EXPECT_TRUE(ocsp_data_len > 0);
@@ -972,7 +972,7 @@ int main(int argc, char **argv)
         s2n_clock_time_nanoseconds old_clock = connection->config->wall_clock;
         s2n_config_set_wall_clock(connection->config, fetch_expired_after_ocsp_timestamp, NULL);
 
-        struct s2n_stuffer ocsp_data_stuffer;
+        struct s2n_stuffer ocsp_data_stuffer = { 0 };
         EXPECT_SUCCESS(read_file(&ocsp_data_stuffer, S2N_OCSP_RESPONSE_DER, S2N_MAX_TEST_PEM_SIZE));
         uint32_t ocsp_data_len = s2n_stuffer_data_available(&ocsp_data_stuffer);
         EXPECT_TRUE(ocsp_data_len > 0);
@@ -1018,7 +1018,7 @@ int main(int argc, char **argv)
         s2n_clock_time_nanoseconds old_clock = connection->config->wall_clock;
         s2n_config_set_wall_clock(connection->config, fetch_invalid_before_ocsp_timestamp, NULL);
 
-        struct s2n_stuffer ocsp_data_stuffer;
+        struct s2n_stuffer ocsp_data_stuffer = { 0 };
         EXPECT_SUCCESS(read_file(&ocsp_data_stuffer, S2N_OCSP_RESPONSE_DER, S2N_MAX_TEST_PEM_SIZE));
         uint32_t ocsp_data_len = s2n_stuffer_data_available(&ocsp_data_stuffer);
         EXPECT_TRUE(ocsp_data_len > 0);
@@ -1062,7 +1062,7 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &pkey_type, &public_key_out));
 
         EXPECT_EQUAL(1, verify_data.callback_invoked);
-        struct s2n_stuffer ocsp_data_stuffer;
+        struct s2n_stuffer ocsp_data_stuffer = { 0 };
         EXPECT_SUCCESS(read_file(&ocsp_data_stuffer, S2N_OCSP_RESPONSE_DER, S2N_MAX_TEST_PEM_SIZE));
         uint32_t ocsp_data_len = s2n_stuffer_data_available(&ocsp_data_stuffer);
         EXPECT_TRUE(ocsp_data_len > 0);
@@ -1110,7 +1110,7 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &pkey_type, &public_key_out));
 
         EXPECT_EQUAL(1, verify_data.callback_invoked);
-        struct s2n_stuffer ocsp_data_stuffer;
+        struct s2n_stuffer ocsp_data_stuffer = { 0 };
         EXPECT_SUCCESS(read_file(&ocsp_data_stuffer, S2N_OCSP_RESPONSE_DER, S2N_MAX_TEST_PEM_SIZE));
         uint32_t ocsp_data_len = s2n_stuffer_data_available(&ocsp_data_stuffer);
         EXPECT_TRUE(ocsp_data_len > 0);
@@ -1156,7 +1156,7 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &pkey_type, &public_key_out));
 
         EXPECT_EQUAL(1, verify_data.callback_invoked);
-        struct s2n_stuffer ocsp_data_stuffer;
+        struct s2n_stuffer ocsp_data_stuffer = { 0 };
         EXPECT_SUCCESS(read_file(&ocsp_data_stuffer, S2N_OCSP_RESPONSE_DER, S2N_MAX_TEST_PEM_SIZE));
         uint32_t ocsp_data_len = s2n_stuffer_data_available(&ocsp_data_stuffer);
         EXPECT_TRUE(ocsp_data_len > 0);
@@ -1203,7 +1203,7 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &pkey_type, &public_key_out));
 
         EXPECT_EQUAL(1, verify_data.callback_invoked);
-        struct s2n_stuffer ocsp_data_stuffer;
+        struct s2n_stuffer ocsp_data_stuffer = { 0 };
         EXPECT_SUCCESS(read_file(&ocsp_data_stuffer, S2N_OCSP_RESPONSE_WRONG_SIGNER_DER, S2N_MAX_TEST_PEM_SIZE));
         uint32_t ocsp_data_len = s2n_stuffer_data_available(&ocsp_data_stuffer);
         EXPECT_TRUE(ocsp_data_len > 0);
@@ -1248,7 +1248,7 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &pkey_type, &public_key_out));
 
         EXPECT_EQUAL(1, verify_data.callback_invoked);
-        struct s2n_stuffer ocsp_data_stuffer;
+        struct s2n_stuffer ocsp_data_stuffer = { 0 };
         EXPECT_SUCCESS(read_file(&ocsp_data_stuffer, S2N_OCSP_RESPONSE_REVOKED_DER, S2N_MAX_TEST_PEM_SIZE));
         uint32_t ocsp_data_len = s2n_stuffer_data_available(&ocsp_data_stuffer);
         EXPECT_TRUE(ocsp_data_len > 0);
@@ -1414,7 +1414,7 @@ int main(int argc, char **argv)
         struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT);
         EXPECT_NOT_NULL(connection);
 
-        struct s2n_stuffer chain_stuffer;
+        struct s2n_stuffer chain_stuffer = { 0 };
         EXPECT_SUCCESS(read_file(&chain_stuffer, S2N_ONE_TRAILING_BYTE_CERT_BIN, S2N_MAX_TEST_PEM_SIZE));
         uint32_t chain_len = s2n_stuffer_data_available(&chain_stuffer);
         EXPECT_TRUE(chain_len > 0);
@@ -1438,7 +1438,7 @@ int main(int argc, char **argv)
         struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT);
         EXPECT_NOT_NULL(connection);
 
-        struct s2n_stuffer chain_stuffer;
+        struct s2n_stuffer chain_stuffer = { 0 };
         EXPECT_SUCCESS(read_file(&chain_stuffer, S2N_FOUR_TRAILING_BYTE_CERT_BIN, S2N_MAX_TEST_PEM_SIZE));
         uint32_t chain_len = s2n_stuffer_data_available(&chain_stuffer);
         EXPECT_TRUE(chain_len > 0);

--- a/tls/extensions/s2n_extension_list.c
+++ b/tls/extensions/s2n_extension_list.c
@@ -173,7 +173,7 @@ int s2n_extension_list_parse(struct s2n_stuffer *in, s2n_parsed_extensions_list 
 
     POSIX_GUARD(s2n_blob_init(&parsed_extension_list->raw, extensions_data, total_extensions_size));
 
-    struct s2n_stuffer extensions_stuffer;
+    struct s2n_stuffer extensions_stuffer = { 0 };
     POSIX_GUARD(s2n_stuffer_init(&extensions_stuffer, &parsed_extension_list->raw));
     POSIX_GUARD(s2n_stuffer_skip_write(&extensions_stuffer, total_extensions_size));
 

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -206,7 +206,7 @@ static int s2n_server_key_share_recv_pq_hybrid(struct s2n_connection *conn, uint
 
     /* Parse ECC key share */
     uint16_t ecc_share_size;
-    struct s2n_blob point_blob;
+    struct s2n_blob point_blob = { 0 };
     POSIX_GUARD(s2n_stuffer_read_uint16(extension, &ecc_share_size));
     POSIX_ENSURE(s2n_ecc_evp_read_params_point(extension, ecc_share_size, &point_blob) == S2N_SUCCESS, S2N_ERR_BAD_KEY_SHARE);
     POSIX_ENSURE(s2n_ecc_evp_parse_params_point(&point_blob, &server_kem_group_params->ecc_params) == S2N_SUCCESS, S2N_ERR_BAD_KEY_SHARE);
@@ -285,7 +285,7 @@ static int s2n_server_key_share_recv_ecc(struct s2n_connection *conn, uint16_t n
     S2N_ERROR_IF(s2n_stuffer_data_available(extension) < share_size, S2N_ERR_BAD_KEY_SHARE);
 
     /* Proceed to parse share */
-    struct s2n_blob point_blob;
+    struct s2n_blob point_blob = { 0 };
     S2N_ERROR_IF(s2n_ecc_evp_read_params_point(extension, share_size, &point_blob) < 0, S2N_ERR_BAD_KEY_SHARE);
     S2N_ERROR_IF(s2n_ecc_evp_parse_params_point(&point_blob, server_ecc_evp_params) < 0, S2N_ERR_BAD_KEY_SHARE);
     S2N_ERROR_IF(server_ecc_evp_params->evp_pkey == NULL, S2N_ERR_BAD_KEY_SHARE);

--- a/tls/extensions/s2n_server_sct_list.c
+++ b/tls/extensions/s2n_server_sct_list.c
@@ -54,7 +54,7 @@ int s2n_server_sct_list_recv(struct s2n_connection *conn, struct s2n_stuffer *ex
 {
     POSIX_ENSURE_REF(conn);
 
-    struct s2n_blob sct_list;
+    struct s2n_blob sct_list = { 0 };
     size_t data_available = s2n_stuffer_data_available(extension);
     POSIX_GUARD(s2n_blob_init(&sct_list,
             s2n_stuffer_raw_read(extension, data_available),

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -224,7 +224,7 @@ static int s2n_find_cert_matches(struct s2n_map *domain_name_to_cert_map,
         struct s2n_cert_chain_and_key *matches[S2N_CERT_TYPE_COUNT],
         uint8_t *match_exists)
 {
-    struct s2n_blob map_value;
+    struct s2n_blob map_value = { 0 };
     bool key_found = false;
     POSIX_GUARD_RESULT(s2n_map_lookup(domain_name_to_cert_map, dns_name, &map_value, &key_found));
     if (key_found) {
@@ -260,7 +260,7 @@ int s2n_conn_find_name_matching_certs(struct s2n_connection *conn)
     POSIX_GUARD(s2n_blob_init(&normalized_name, (uint8_t *) normalized_hostname, hostname_blob.size));
 
     POSIX_GUARD(s2n_blob_char_to_lower(&normalized_name));
-    struct s2n_stuffer normalized_hostname_stuffer;
+    struct s2n_stuffer normalized_hostname_stuffer = { 0 };
     POSIX_GUARD(s2n_stuffer_init(&normalized_hostname_stuffer, &normalized_name));
     POSIX_GUARD(s2n_stuffer_skip_write(&normalized_hostname_stuffer, normalized_name.size));
 
@@ -275,7 +275,7 @@ int s2n_conn_find_name_matching_certs(struct s2n_connection *conn)
         char wildcard_hostname[S2N_MAX_SERVER_NAME + 1] = { 0 };
         struct s2n_blob wildcard_blob = { 0 };
         POSIX_GUARD(s2n_blob_init(&wildcard_blob, (uint8_t *) wildcard_hostname, sizeof(wildcard_hostname)));
-        struct s2n_stuffer wildcard_stuffer;
+        struct s2n_stuffer wildcard_stuffer = { 0 };
         POSIX_GUARD(s2n_stuffer_init(&wildcard_stuffer, &wildcard_blob));
         POSIX_GUARD(s2n_create_wildcard_hostname(&normalized_hostname_stuffer, &wildcard_stuffer));
         const uint32_t wildcard_len = s2n_stuffer_data_available(&wildcard_stuffer);

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -460,7 +460,7 @@ static S2N_RESULT s2n_psk_write_binder(struct s2n_connection *conn, struct s2n_p
 {
     RESULT_ENSURE_REF(binder_hash);
 
-    struct s2n_blob binder;
+    struct s2n_blob binder = { 0 };
     uint8_t binder_data[S2N_TLS13_SECRET_MAX_LEN] = { 0 };
     RESULT_GUARD_POSIX(s2n_blob_init(&binder, binder_data, binder_hash->size));
 

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -443,7 +443,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
                  * NOTE: We can't use the same random IV blob as both the initial block and IV since it will result in:
                  * AES(Key, XOR(random_iv, random_iv)) == AES(Key, 0), which will be shared by all records in this session.
                  */
-                struct s2n_blob explicit_iv_placeholder;
+                struct s2n_blob explicit_iv_placeholder = { 0 };
                 uint8_t zero_block[S2N_TLS_MAX_IV_LEN] = { 0 };
                 POSIX_GUARD(s2n_blob_init(&explicit_iv_placeholder, zero_block, block_size));
                 POSIX_GUARD_RESULT(s2n_get_public_random_data(&explicit_iv_placeholder));

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -78,7 +78,7 @@ int s2n_server_nst_send(struct s2n_connection *conn)
     uint8_t data[S2N_TLS12_TICKET_SIZE_IN_BYTES] = { 0 };
     struct s2n_blob entry = { 0 };
     POSIX_GUARD(s2n_blob_init(&entry, data, sizeof(data)));
-    struct s2n_stuffer to;
+    struct s2n_stuffer to = { 0 };
     uint32_t lifetime_hint_in_secs =
             (conn->config->encrypt_decrypt_key_lifetime_in_nanos + conn->config->decrypt_key_lifetime_in_nanos) / ONE_SEC_IN_NANOS;
 

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -23,7 +23,7 @@ static int s2n_zero_sequence_number(struct s2n_connection *conn, s2n_mode mode)
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(conn->secure);
-    struct s2n_blob sequence_number;
+    struct s2n_blob sequence_number = { 0 };
     if (mode == S2N_CLIENT) {
         POSIX_GUARD(s2n_blob_init(&sequence_number, conn->secure->client_sequence_number, sizeof(conn->secure->client_sequence_number)));
     } else {
@@ -163,8 +163,8 @@ int s2n_update_application_traffic_keys(struct s2n_connection *conn, s2n_mode mo
     s2n_tls13_connection_keys(keys, conn);
 
     struct s2n_session_key *old_key;
-    struct s2n_blob old_app_secret;
-    struct s2n_blob app_iv;
+    struct s2n_blob old_app_secret = { 0 };
+    struct s2n_blob app_iv = { 0 };
 
     if (mode == S2N_CLIENT) {
         old_key = &conn->secure->client_key;

--- a/tls/s2n_tls13_key_schedule.c
+++ b/tls/s2n_tls13_key_schedule.c
@@ -35,7 +35,7 @@ static S2N_RESULT s2n_zero_sequence_number(struct s2n_connection *conn, s2n_mode
 {
     RESULT_ENSURE_REF(conn);
     RESULT_ENSURE_REF(conn->secure);
-    struct s2n_blob sequence_number;
+    struct s2n_blob sequence_number = { 0 };
     if (mode == S2N_CLIENT) {
         RESULT_GUARD_POSIX(s2n_blob_init(&sequence_number,
                 conn->secure->client_sequence_number, sizeof(conn->secure->client_sequence_number)));


### PR DESCRIPTION
### Description of changes: 

[This](https://github.com/lrstewart/s2n/blob/7c395a069c0ad59ce510813ff60d268c1fe13e31/tests/unit/s2n_quic_support_io_test.c#L397) unintialized stuffer in s2n_quic_support_io_test.c caused our tests to fail in a particular build environment that doesn't automatically initialize stack variables.

This exact problem has bitten us a several times, so I did a simple find and replace that _should_ have caught any uninitialized s2n_blob or s2n_stuffer structures. Fixing ALL unintialized variables is a much more challenging change (with a much larger diff). This is just better than fixing only the single instance that broke the build.

### Call-outs:

Automating this in grep_simple_mistakes is probably doable, but tricky. I ran into a couple false positives with my simple search due to it being difficult to distinguish between stack variables and entries in a struct definition. An automated test would need to iterate over every line and keep "are we in a struct definition" state.

### Testing:

Existing tests pass. I also verified this fixes the build issue I saw.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
