### PR TITLE
Fix clippy toolchain to match rest of CI

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions-rs/toolchain@v1.0.7
         id: toolchain
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
           profile: minimal
           override: true
           components: clippy

--- a/bindings/rust/s2n-tls-sys/build.rs
+++ b/bindings/rust/s2n-tls-sys/build.rs
@@ -29,7 +29,7 @@ fn env<N: AsRef<str>>(name: N) -> String {
 
 fn option_env<N: AsRef<str>>(name: N) -> Option<String> {
     let name = name.as_ref();
-    eprintln!("cargo:rerun-if-env-changed={name}");
+    eprintln!("cargo:rerun-if-env-changed={}", name);
     std::env::var(name).ok()
 }
 

--- a/bindings/rust/s2n-tls-sys/build.rs
+++ b/bindings/rust/s2n-tls-sys/build.rs
@@ -29,7 +29,7 @@ fn env<N: AsRef<str>>(name: N) -> String {
 
 fn option_env<N: AsRef<str>>(name: N) -> Option<String> {
     let name = name.as_ref();
-    eprintln!("cargo:rerun-if-env-changed={}", name);
+    eprintln!("cargo:rerun-if-env-changed={name}");
     std::env::var(name).ok()
 }
 


### PR DESCRIPTION
### Resolved issues:

Clippy was reporting the error: Inline a format string arg.  https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args.

Fixing it caused the project to not compile. The recommended fix used a feature implemented in 1.58. We are using 1.57 to build the project. Clippy was making this recommendation because it was out of step with the rest of the project on the stable tool-chain.

### Description of changes: 

Change Clippy CI to use the same toolchain as the rest of the CI: ${{ env.RUST_NIGHTLY_TOOLCHAIN }} which currently is `nightly-2022-08-03`.

### Call-outs:

Should the whole project be on a stable branch? / Should we update to a particular release?

### Testing:

Against clippy in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
