### PR TITLE
Add min supported rust version for clippy

### DIFF
--- a/bindings/rust/.clippy.toml
+++ b/bindings/rust/.clippy.toml
@@ -1,0 +1,2 @@
+# This should match rust-toolchain
+msrv = "1.57.0"


### PR DESCRIPTION
### Description of changes: 

clippy is currently failing with "uninlined-format-args". Unfortunately, inlining format args wasn't introduced until Rust 1.58, and our toolchain is 1.57.

jmayclin pointed out that clippy allows you to specify the minimum supported rust version: https://doc.rust-lang.org/clippy/configuration.html#specifying-the-minimum-supported-rust-version So let's use that rather than ignoring specific warnings.

### Testing:
CI passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
