### PR TITLE
Enforce that clippy msrv matches rust-toolchain

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -10,7 +10,7 @@ env:
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
   RUST_NIGHTLY_TOOLCHAIN: nightly-2022-08-03
-  MANIFEST_PATH: bindings/rust/Cargo.toml
+  ROOT_PATH: bindings/rust
 
 jobs:
   generate:
@@ -31,10 +31,10 @@ jobs:
       - uses: camshaft/rust-cache@v1
 
       - name: Generate
-        run: ./bindings/rust/generate.sh
+        run: ${{env.ROOT_PATH}}/generate.sh
 
       - name: Tests
-        working-directory: bindings/rust
+        working-directory: ${{env.ROOT_PATH}}
         run: cargo test
 
       - name: Test external build
@@ -47,7 +47,7 @@ jobs:
           export S2N_TLS_INCLUDE_DIR=`pwd`/api
           export LD_LIBRARY_PATH=$S2N_TLS_LIB_DIR:$LD_LIBRARY_PATH
 
-          cd bindings/rust
+          cd ${{env.ROOT_PATH}}
           ./generate.sh
           ldd target/debug/integration | grep libs2n.so
 
@@ -71,13 +71,13 @@ jobs:
       # We don't need to format the generated files,
       # but if they don't exist other code breaks.
       - name: Generate
-        run: ./bindings/rust/generate.sh
+        run: ./${{env.ROOT_PATH}}/generate.sh
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1.0.3
         with:
           command: fmt
-          args: --manifest-path ${{ env.MANIFEST_PATH}} --all -- --check
+          args: --manifest-path ${{env.ROOT_PATH}}/Cargo.toml --all -- --check
 
   clippy:
     runs-on: ubuntu-latest
@@ -96,14 +96,18 @@ jobs:
 
       - uses: camshaft/rust-cache@v1
 
+      # Enforce that clippy's msrv matches rust-toolchain
+      - name: Check MSRV
+        run: grep $(cat ${{env.ROOT_PATH}}/rust-toolchain) ${{env.ROOT_PATH}}/.clippy.toml
+
       # We don't need to format the generated files,
       # but if they don't exist other code breaks.
       - name: Generate
-        run: ./bindings/rust/generate.sh
+        run: ${{env.ROOT_PATH}}/generate.sh
 
       # TODO translate json reports to in-action warnings
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1.0.3
         with:
           command: clippy
-          args: --manifest-path ${{ env.MANIFEST_PATH}} --all-targets -- -D warnings
+          args: --manifest-path ${{env.ROOT_PATH}}/Cargo.toml --all-targets -- -D warnings


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/3786

### Description of changes: 

I'm not sure if this is too hacky. But because our rust-toolchain is just a text file, we can VERY easily use it in a grep command to enforce that it matches clippy.toml. It's a cheap check we can always revise later.

### Testing:

I opened a pull request to my fork with the rust-toolchain version bumped: https://github.com/lrstewart/s2n/pull/26 The [clippy CI job](https://github.com/lrstewart/s2n/actions/runs/4028106743/jobs/6924620910) failed because of this check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
