### PR TITLE
Enable CTEST_OUTPUT_ON_FAILURE on all targets

### DIFF
--- a/.github/s2n_freebsd.sh
+++ b/.github/s2n_freebsd.sh
@@ -13,6 +13,7 @@
 # permissions and limitations under the License.
 #
 set -eu
+export CTEST_OUTPUT_ON_FAILURE=1
 export CTEST_PARALLEL_LEVEL=$(sysctl hw.ncpu | awk '{print $2}')
 
 cmake . -Brelease -GNinja -DCMAKE_BUILD_TYPE=Release

--- a/.github/s2n_openbsd.sh
+++ b/.github/s2n_openbsd.sh
@@ -13,6 +13,7 @@
 # permissions and limitations under the License.
 #
 set -eu
+export CTEST_OUTPUT_ON_FAILURE=1
 export CTEST_PARALLEL_LEVEL=$(sysctl -n hw.ncpuonline)
 
 cmake . -Brelease -GNinja -DCMAKE_BUILD_TYPE=Release

--- a/.github/s2n_osx.sh
+++ b/.github/s2n_osx.sh
@@ -16,6 +16,7 @@
 set -eu
 source codebuild/bin/s2n_setup_env.sh
 
+export CTEST_OUTPUT_ON_FAILURE=1
 BREWINSTLLPATH=$(brew --prefix openssl@1.1)
 OPENSSL_1_1_1_INSTALL_DIR="${BREWINSTLLPATH:-"/usr/local/Cellar/openssl@1.1/1.1.1?"}"
 

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -97,7 +97,7 @@ run_unit_tests() {
             -DBUILD_SHARED_LIBS=on
     cmake --build ./build -- -j $(nproc)
     test_linked_libcrypto ./build/bin/s2nc
-    make -C build test ARGS=-j$(nproc);
+    env CTEST_OUTPUT_ON_FAILURE=1 make -C build test ARGS=-j$(nproc);
 }
 
 # Run Multiple tests on one flag.


### PR DESCRIPTION
### Resolved issues:

Make it easier to see the failures in CI.

### Description of changes: 

CTest relies on CTEST_OUTPUT_ON_FAILURE to tell it weather to suppress output from a failing unit test or not. 

So we set it to 1 on all the different target platforms where we test s2n_tls.

### Call-outs:

Discovered while debugging CMake.

### Testing:

Used this pattern successfully while debugging previously. Didn't test on all platforms (could do so by adding a failing unit test and running CI).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
