### PR TITLE
ktls: s2n_ktls_mode and building blocks

### DIFF
--- a/tests/unit/s2n_ktls_mode_test.c
+++ b/tests/unit/s2n_ktls_mode_test.c
@@ -29,10 +29,7 @@ int main(int argc, char **argv)
         EXPECT_FALSE(config->ktls_recv_requested);
     };
 
-    /* Request config kTLS mode
-     *
-     * Requesting modes is additive and Duplex means both Send and Recv are requested
-     */
+    /* Request config kTLS mode */
     {
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
@@ -42,7 +39,7 @@ int main(int argc, char **argv)
         EXPECT_FALSE(config->ktls_recv_requested);
 
         EXPECT_SUCCESS(s2n_config_set_ktls_mode(config, S2N_KTLS_MODE_RECV));
-        EXPECT_TRUE(config->ktls_send_requested);
+        EXPECT_FALSE(config->ktls_send_requested);
         EXPECT_TRUE(config->ktls_recv_requested);
 
         EXPECT_SUCCESS(s2n_config_set_ktls_mode(config, S2N_KTLS_MODE_DISABLED));

--- a/tests/unit/s2n_ktls_mode_test.c
+++ b/tests/unit/s2n_ktls_mode_test.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+#include "tls/s2n_ktls.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Default config kTLS mode */
+    {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+        EXPECT_FALSE(config->ktls_send_requested);
+        EXPECT_FALSE(config->ktls_recv_requested);
+    };
+
+    /* Request config kTLS mode
+     *
+     * Requesting modes is additive and Duplex means both Send and Recv are requested
+     */
+    {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
+        EXPECT_SUCCESS(s2n_config_set_ktls_mode(config, S2N_KTLS_MODE_SEND));
+        EXPECT_TRUE(config->ktls_send_requested);
+        EXPECT_FALSE(config->ktls_recv_requested);
+
+        EXPECT_SUCCESS(s2n_config_set_ktls_mode(config, S2N_KTLS_MODE_RECV));
+        EXPECT_TRUE(config->ktls_send_requested);
+        EXPECT_TRUE(config->ktls_recv_requested);
+
+        EXPECT_SUCCESS(s2n_config_set_ktls_mode(config, S2N_KTLS_MODE_DISABLED));
+        EXPECT_FALSE(config->ktls_send_requested);
+        EXPECT_FALSE(config->ktls_recv_requested);
+
+        EXPECT_SUCCESS(s2n_config_set_ktls_mode(config, S2N_KTLS_MODE_DUPLEX));
+        EXPECT_TRUE(config->ktls_send_requested);
+        EXPECT_TRUE(config->ktls_recv_requested);
+    };
+
+    /* Default connection kTLS mode */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(conn, &io_pair));
+        EXPECT_TRUE(conn->managed_send_io);
+        EXPECT_TRUE(conn->managed_recv_io);
+
+        EXPECT_FALSE(conn->ktls_recv_enabled);
+        EXPECT_FALSE(conn->ktls_send_enabled);
+    };
+
+    END_TEST();
+}

--- a/tests/unit/s2n_ktls_mode_test.c
+++ b/tests/unit/s2n_ktls_mode_test.c
@@ -59,8 +59,6 @@ int main(int argc, char **argv)
         DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(conn, &io_pair));
-        EXPECT_TRUE(conn->managed_send_io);
-        EXPECT_TRUE(conn->managed_recv_io);
 
         EXPECT_FALSE(conn->ktls_recv_enabled);
         EXPECT_FALSE(conn->ktls_send_enabled);

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -1084,10 +1084,12 @@ int s2n_config_set_ktls_mode(struct s2n_config *config, s2n_ktls_mode ktls_mode)
             config->ktls_send_requested = true;
             break;
         case S2N_KTLS_MODE_SEND:
+            config->ktls_recv_requested = false;
             config->ktls_send_requested = true;
             break;
         case S2N_KTLS_MODE_RECV:
             config->ktls_recv_requested = true;
+            config->ktls_send_requested = false;
             break;
         case S2N_KTLS_MODE_DISABLED:
             config->ktls_recv_requested = false;

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -22,6 +22,7 @@
 #include "error/s2n_errno.h"
 #include "tls/s2n_cipher_preferences.h"
 #include "tls/s2n_internal.h"
+#include "tls/s2n_ktls.h"
 #include "tls/s2n_security_policies.h"
 #include "tls/s2n_tls13.h"
 #include "utils/s2n_blob.h"
@@ -1068,6 +1069,31 @@ int s2n_config_set_recv_multi_record(struct s2n_config *config, bool enabled)
     POSIX_ENSURE_REF(config);
 
     config->recv_multi_record = enabled;
+
+    return S2N_SUCCESS;
+}
+
+/* Indicates if the connection should attempt to enable kTLS. */
+int s2n_config_set_ktls_mode(struct s2n_config *config, s2n_ktls_mode ktls_mode)
+{
+    POSIX_ENSURE_REF(config);
+
+    switch (ktls_mode) {
+        case S2N_KTLS_MODE_DUPLEX:
+            config->ktls_recv_requested = true;
+            config->ktls_send_requested = true;
+            break;
+        case S2N_KTLS_MODE_SEND:
+            config->ktls_send_requested = true;
+            break;
+        case S2N_KTLS_MODE_RECV:
+            config->ktls_recv_requested = true;
+            break;
+        case S2N_KTLS_MODE_DISABLED:
+            config->ktls_recv_requested = false;
+            config->ktls_send_requested = false;
+            break;
+    }
 
     return S2N_SUCCESS;
 }

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -101,6 +101,12 @@ struct s2n_config {
      */
     unsigned recv_multi_record : 1;
 
+    /* Depending on OS and configuration it is possible to use kTLS.
+     *
+     * This option indicates if connections should attempt to use kTLS. */
+    unsigned ktls_send_requested : 1;
+    unsigned ktls_recv_requested : 1;
+
     struct s2n_dh_params *dhparams;
     /* Needed until we can deprecate s2n_config_add_cert_chain_and_key. This is
      * used to release memory allocated only in the deprecated API that the application 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -134,6 +134,10 @@ struct s2n_connection {
      * instead of the ALPN extension */
     unsigned npn_negotiated : 1;
 
+    /* Marks if kTLS has been enabled for this connection. */
+    unsigned ktls_send_enabled : 1;
+    unsigned ktls_recv_enabled : 1;
+
     /* The configuration (cert, key .. etc ) */
     struct s2n_config *config;
 
@@ -283,8 +287,8 @@ struct s2n_connection {
      */
     uint16_t max_outgoing_fragment_length;
 
-    /* The number of bytes to send before changing the record size. 
-     * If this value > 0 then dynamic TLS record size is enabled. Otherwise, the feature is disabled (default). 
+    /* The number of bytes to send before changing the record size.
+     * If this value > 0 then dynamic TLS record size is enabled. Otherwise, the feature is disabled (default).
      */
     uint32_t dynamic_record_resize_threshold;
 

--- a/tls/s2n_ktls.h
+++ b/tls/s2n_ktls.h
@@ -25,9 +25,9 @@ typedef enum {
     S2N_KTLS_MODE_DISABLED,
     /* Enable kTLS for the send socket. */
     S2N_KTLS_MODE_SEND,
-    /* Enable kTLS for the recv socket. */
+    /* Enable kTLS for the receive socket. */
     S2N_KTLS_MODE_RECV,
-    /* Enable kTLS for both rx and tx socket. */
+    /* Enable kTLS for both receive and send sockets. */
     S2N_KTLS_MODE_DUPLEX,
 } s2n_ktls_mode;
 

--- a/tls/s2n_ktls.h
+++ b/tls/s2n_ktls.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "tls/s2n_config.h"
+
+/* A set of kTLS configurations representing the combination of sending
+ * and receiving.
+ */
+typedef enum {
+    /* Disable kTLS. */
+    S2N_KTLS_MODE_DISABLED,
+    /* Enable kTLS for the send socket. */
+    S2N_KTLS_MODE_SEND,
+    /* Enable kTLS for the recv socket. */
+    S2N_KTLS_MODE_RECV,
+    /* Enable kTLS for both rx and tx socket. */
+    S2N_KTLS_MODE_DUPLEX,
+} s2n_ktls_mode;
+
+int s2n_config_set_ktls_mode(struct s2n_config *config, s2n_ktls_mode ktls_mode);


### PR DESCRIPTION
### Description of changes: 
This PR introduces enum `s2n_ktls_mode`, fields on config and connection to track that mode and a method to set the state on config.

### Testing:
unit tests

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
