### PR TITLE
Prevent auto-enabling OCSP requests for servers

### DIFF
--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -905,14 +905,13 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(client_config, 0));
         EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
+        EXPECT_SUCCESS(s2n_config_set_status_request_type(client_config, S2N_STATUS_REQUEST_OCSP));
+
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
         client_conn->actual_protocol_version = S2N_TLS12;
         client_conn->server_protocol_version = S2N_TLS12;
         client_conn->client_protocol_version = S2N_TLS12;
-
-        EXPECT_SUCCESS(s2n_config_set_status_request_type(client_config, S2N_STATUS_REQUEST_OCSP));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         server_conn->actual_protocol_version = S2N_TLS12;
@@ -967,14 +966,13 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "default_tls13"));
         EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(client_config, 0));
         EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
+        EXPECT_SUCCESS(s2n_config_set_status_request_type(client_config, S2N_STATUS_REQUEST_OCSP));
+
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
         client_conn->actual_protocol_version = S2N_TLS13;
         client_conn->server_protocol_version = S2N_TLS13;
         client_conn->client_protocol_version = S2N_TLS13;
-
-        EXPECT_SUCCESS(s2n_config_set_status_request_type(client_config, S2N_STATUS_REQUEST_OCSP));
-        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         server_conn->actual_protocol_version = S2N_TLS13;

--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -920,14 +920,6 @@ int main(int argc, char **argv)
                     s2n_config_ptr_free);
             EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
 
-            /* Setup all extensions */
-            uint8_t apn[] = "https";
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "PQ-TLS-1-1-2021-05-21"));
-            EXPECT_SUCCESS(s2n_config_set_status_request_type(client_config, S2N_STATUS_REQUEST_OCSP));
-            EXPECT_SUCCESS(s2n_config_set_ct_support_level(client_config, S2N_CT_SUPPORT_REQUEST));
-            EXPECT_SUCCESS(s2n_config_send_max_fragment_length(client_config, S2N_TLS_MAX_FRAG_LEN_4096));
-            EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(client_config, 1));
-
             DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
                     s2n_connection_ptr_free);
             EXPECT_NOT_NULL(server_conn);
@@ -938,7 +930,6 @@ int main(int argc, char **argv)
                     s2n_connection_ptr_free);
             EXPECT_NOT_NULL(client_conn);
             EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
-            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
             struct s2n_test_io_pair io_pair = { 0 };
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
@@ -954,6 +945,14 @@ int main(int argc, char **argv)
             };
             client_conn->security_policy_override = &security_policy_test_tls13_retry_with_pq;
 
+            /* Setup all extensions */
+            uint8_t apn[] = "https";
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "PQ-TLS-1-1-2021-05-21"));
+            EXPECT_SUCCESS(s2n_config_set_status_request_type(client_config, S2N_STATUS_REQUEST_OCSP));
+            EXPECT_SUCCESS(s2n_config_set_ct_support_level(client_config, S2N_CT_SUPPORT_REQUEST));
+            EXPECT_SUCCESS(s2n_config_send_max_fragment_length(client_config, S2N_TLS_MAX_FRAG_LEN_4096));
+            EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(client_config, 1));
+            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
             EXPECT_SUCCESS(s2n_set_server_name(client_conn, "localhost"));
             EXPECT_SUCCESS(s2n_connection_append_protocol_preference(client_conn, apn, sizeof(apn)));
             EXPECT_SUCCESS(s2n_connection_set_early_data_expected(client_conn));

--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -920,6 +920,14 @@ int main(int argc, char **argv)
                     s2n_config_ptr_free);
             EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
 
+            /* Setup all extensions */
+            uint8_t apn[] = "https";
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "PQ-TLS-1-1-2021-05-21"));
+            EXPECT_SUCCESS(s2n_config_set_status_request_type(client_config, S2N_STATUS_REQUEST_OCSP));
+            EXPECT_SUCCESS(s2n_config_set_ct_support_level(client_config, S2N_CT_SUPPORT_REQUEST));
+            EXPECT_SUCCESS(s2n_config_send_max_fragment_length(client_config, S2N_TLS_MAX_FRAG_LEN_4096));
+            EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(client_config, 1));
+
             DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
                     s2n_connection_ptr_free);
             EXPECT_NOT_NULL(server_conn);
@@ -946,13 +954,6 @@ int main(int argc, char **argv)
             };
             client_conn->security_policy_override = &security_policy_test_tls13_retry_with_pq;
 
-            /* Setup all extensions */
-            uint8_t apn[] = "https";
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "PQ-TLS-1-1-2021-05-21"));
-            EXPECT_SUCCESS(s2n_config_set_status_request_type(client_config, S2N_STATUS_REQUEST_OCSP));
-            EXPECT_SUCCESS(s2n_config_set_ct_support_level(client_config, S2N_CT_SUPPORT_REQUEST));
-            EXPECT_SUCCESS(s2n_config_send_max_fragment_length(client_config, S2N_TLS_MAX_FRAG_LEN_4096));
-            EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(client_config, 1));
             EXPECT_SUCCESS(s2n_set_server_name(client_conn, "localhost"));
             EXPECT_SUCCESS(s2n_connection_append_protocol_preference(client_conn, apn, sizeof(apn)));
             EXPECT_SUCCESS(s2n_connection_set_early_data_expected(client_conn));

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -637,6 +637,9 @@ int main(int argc, char **argv)
                     EXPECT_SUCCESS(s2n_config_set_verification_ca_location(config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
                     break;
                 case 1:
+                    /* If a user intentionally disables OCSP stapling, s2n_config_set_verification_ca_location
+                     * should not re-enable it.
+                     */
                     EXPECT_SUCCESS(s2n_config_set_status_request_type(config, S2N_STATUS_REQUEST_NONE));
                     EXPECT_SUCCESS(s2n_config_set_verification_ca_location(config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
                     break;

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -609,7 +609,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn);
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-            EXPECT_TRUE(conn->status_request_type == S2N_STATUS_REQUEST_NONE);
+            EXPECT_EQUAL(conn->status_request_type, S2N_STATUS_REQUEST_NONE);
         }
 
         /* status_request_type is set via s2n_config_set_status_request_type */
@@ -622,7 +622,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn);
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-            EXPECT_TRUE(conn->status_request_type == S2N_STATUS_REQUEST_OCSP);
+            EXPECT_EQUAL(conn->status_request_type, S2N_STATUS_REQUEST_OCSP);
         }
 
         /* For backwards compatibility, status_request_type is set via s2n_config_set_verification_ca_location
@@ -652,9 +652,9 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
             if (mode == S2N_CLIENT) {
-                EXPECT_TRUE(conn->status_request_type == S2N_STATUS_REQUEST_OCSP);
+                EXPECT_EQUAL(conn->status_request_type, S2N_STATUS_REQUEST_OCSP);
             } else {
-                EXPECT_TRUE(conn->status_request_type == S2N_STATUS_REQUEST_NONE);
+                EXPECT_EQUAL(conn->status_request_type, S2N_STATUS_REQUEST_NONE);
             }
         }
 
@@ -672,7 +672,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(conn);
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-            EXPECT_TRUE(conn->status_request_type == S2N_STATUS_REQUEST_OCSP);
+            EXPECT_EQUAL(conn->status_request_type, S2N_STATUS_REQUEST_OCSP);
         }
     }
 

--- a/tls/extensions/s2n_client_cert_status_request.c
+++ b/tls/extensions/s2n_client_cert_status_request.c
@@ -37,12 +37,12 @@ const s2n_extension_type s2n_client_cert_status_request_extension = {
 
 static bool s2n_client_cert_status_request_should_send(struct s2n_connection *conn)
 {
-    return conn->config->status_request_type != S2N_STATUS_REQUEST_NONE;
+    return conn->status_request_type != S2N_STATUS_REQUEST_NONE;
 }
 
 static int s2n_client_cert_status_request_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    POSIX_GUARD(s2n_stuffer_write_uint8(out, (uint8_t) conn->config->status_request_type));
+    POSIX_GUARD(s2n_stuffer_write_uint8(out, (uint8_t) conn->status_request_type));
 
     /* responder_id_list
      *

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -439,6 +439,7 @@ int s2n_config_set_status_request_type(struct s2n_config *config, s2n_status_req
 
     POSIX_ENSURE_REF(config);
     config->status_request_type = type;
+    config->status_request_type_set = type == S2N_STATUS_REQUEST_OCSP;
 
     return 0;
 }

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -108,9 +108,14 @@ struct s2n_config {
     struct s2n_map *domain_name_to_cert_map;
     struct certs_by_type default_certs_by_type;
     struct s2n_blob application_protocols;
-    s2n_status_request_type status_request_type;
     s2n_clock_time_nanoseconds wall_clock;
     s2n_clock_time_nanoseconds monotonic_clock;
+
+    /* Indicates whether the connection will request OCSP stapling from the peer */
+    s2n_status_request_type status_request_type;
+
+    /* Indicates whether a user has set the status request type */
+    unsigned status_request_type_set : 1;
 
     const struct s2n_security_policy *security_policy;
 

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -101,6 +101,9 @@ struct s2n_config {
      */
     unsigned recv_multi_record : 1;
 
+    /* Indicates whether a user has set the status request type */
+    unsigned status_request_type_set : 1;
+
     struct s2n_dh_params *dhparams;
     /* Needed until we can deprecate s2n_config_add_cert_chain_and_key. This is
      * used to release memory allocated only in the deprecated API that the application 
@@ -113,9 +116,6 @@ struct s2n_config {
 
     /* Indicates whether the connection will request OCSP stapling from the peer */
     s2n_status_request_type status_request_type;
-
-    /* Indicates whether a user has set the status request type */
-    unsigned status_request_type_set : 1;
 
     const struct s2n_security_policy *security_policy;
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -352,6 +352,19 @@ int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *co
         conn->multirecord_send = true;
     }
 
+    conn->status_request_type = config->status_request_type;
+
+    /* status_request_type defaults to S2N_STATUS_REQUEST_NONE, and is set by users via
+     * s2n_config_set_status_request_type. However, status_request_type can also be set
+     * via s2n_config_set_verification_ca_location. To ensure backwards compatibility,
+     * this behavior is kept for clients. For servers, however, this value is reset to
+     * S2N_STATUS_REQUEST_NONE if the user did not intentionally set this value in
+     * s2n_config_set_status_request_type.
+     */
+    if (!config->status_request_type_set && conn->mode == S2N_SERVER) {
+        conn->status_request_type = S2N_STATUS_REQUEST_NONE;
+    }
+
     conn->config = config;
     return S2N_SUCCESS;
 }

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -330,6 +330,9 @@ struct s2n_connection {
      */
     char application_protocol[256];
 
+    /* Indicates whether the connection will request OCSP stapling from the peer */
+    s2n_status_request_type status_request_type;
+
     /* OCSP stapling response data */
     s2n_status_request_type status_type;
     struct s2n_blob status_response;


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

In writing tests for https://github.com/aws/s2n-tls/pull/3770, I discovered that `s2n_config_set_verification_ca_location` is enabling the sending of OCSP status requests:
https://github.com/aws/s2n-tls/blob/70ce2c572ea0a0f8c445783c5642c4652f3f5685/tls/s2n_config.c#L470-L472

After merging https://github.com/aws/s2n-tls/pull/3770, this would mean that most servers in mutual auth scenarios would begin requesting OCSP responses from clients, since `s2n_config_set_verification_ca_location` is called on the server to set the trusted certificates for client auth.

This behavior can't really be changed for clients without a risk of breaking existing user's environments. Instead, this PR disables this behavior only for servers, since OCSP stapling for client auth is not yet supported and thus won't break anyone. The fix works by checking to see if the user intentionally enabled OCSP status requests via `s2n_config_set_status_request_type` before setting `status_request_type`.

### Call-outs:

A `status_request_type` field was added to the connection, to avoid changing the config itself in `s2n_connection_set_config`. Some tests were calling `s2n_config_set_status_request_type` after calling `s2n_connection_set_config`, so these tests were updated.

### Testing:

New s2n_config tests were added to ensure the correct behavior of `s2n_config_set_status_request_type` and `s2n_config_set_verification_ca_location`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
