### PR TITLE
Make test_install_shared_and_static easier to debug

### DIFF
--- a/codebuild/bin/test_install_shared_and_static.sh
+++ b/codebuild/bin/test_install_shared_and_static.sh
@@ -104,9 +104,11 @@ build_myapp() {
 
     (set -x; cmake -H$WORK_DIR/myapp-src -B$MYAPP_BUILD_DIR -D$BUILD_SHARED_LIBS "-DCMAKE_PREFIX_PATH=$S2N_INSTALL_PATH;$LIBCRYPTO_ROOT")
     (set -x; cmake --build $MYAPP_BUILD_DIR)
-    (set -x; ldd $MYAPP_BUILD_DIR/myapp)
 
-    if ldd $MYAPP_BUILD_DIR/myapp | grep -q libs2n.so; then
+    LDD_OUTPUT=$(ldd $MYAPP_BUILD_DIR/myapp)
+    echo "$LDD_OUTPUT"
+
+    if echo "$LDD_OUTPUT" | grep -q libs2n.so; then
         local LIBS2N_ACTUAL=libs2n.so
     else
         local LIBS2N_ACTUAL=libs2n.a


### PR DESCRIPTION
### Resolved issues:

 N/A

### Description of changes: 
We've had an issue with this test being flaky. One difficulty with debugging the failure is that the output being printed and the output being inputted to the grep command are two different calls to `ldd myapp`. Technically these two calls should have exactly the same output, but to aid in debugging if this happens again I had the function print the output that is being grepped.
### Call-outs:

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
