### PR TITLE
ktls: add ktls_supported field to s2n_cipher

### DIFF
--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -390,6 +390,7 @@ const struct s2n_cipher s2n_aes128_gcm = {
     .set_encryption_key = s2n_aead_cipher_aes128_gcm_set_encryption_key,
     .set_decryption_key = s2n_aead_cipher_aes128_gcm_set_decryption_key,
     .destroy_key = s2n_aead_cipher_aes_gcm_destroy_key,
+    .ktls_supported = true,
 };
 
 const struct s2n_cipher s2n_aes256_gcm = {

--- a/crypto/s2n_cipher.h
+++ b/crypto/s2n_cipher.h
@@ -81,6 +81,7 @@ struct s2n_cipher {
         struct s2n_composite_cipher comp;
     } io;
     uint8_t key_material_size;
+    bool ktls_supported;
     uint8_t (*is_available)(void);
     int (*init)(struct s2n_session_key *key);
     int (*set_decryption_key)(struct s2n_session_key *key, struct s2n_blob *in);

--- a/tests/unit/s2n_ktls_test.c
+++ b/tests/unit/s2n_ktls_test.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "crypto/s2n_cipher.h"
+#include "s2n_test.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* ktls_supported ciphers */
+    {
+        struct s2n_cipher cipher = s2n_aes128_gcm;
+        EXPECT_TRUE(cipher.ktls_supported);
+
+        cipher = s2n_aes256_gcm;
+        EXPECT_FALSE(cipher.ktls_supported);
+
+        cipher = s2n_tls13_aes128_gcm;
+        EXPECT_FALSE(cipher.ktls_supported);
+
+        cipher = s2n_tls13_aes256_gcm;
+        EXPECT_FALSE(cipher.ktls_supported);
+
+        cipher = s2n_chacha20_poly1305;
+        EXPECT_FALSE(cipher.ktls_supported);
+    };
+
+    END_TEST();
+}


### PR DESCRIPTION
### Description of changes: 
A small pr to make s2n_cipher ktls aware. For the MVP we will only support AES128_GCM

### Testing:
unit test

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
