### PR TITLE
Criterion delta

### DIFF
--- a/codebuild/bin/criterion_baseline.sh
+++ b/codebuild/bin/criterion_baseline.sh
@@ -51,10 +51,12 @@ if [ -z "${LOCAL_TESTING:-}" ]; then
   if [ "$zip_count" -eq 0 ]; then
     echo "File ${AWS_S3_URL}${AWS_S3_PATH} not found"
     criterion_install_deps
+    ORIGINAL_COMMIT=$(git rev-parse HEAD)
     git fetch --tags
     git checkout "$LATEST_RELEASE_VER"
     S2N_USE_CRITERION=baseline make -C tests/integrationv2 "$INTEGV2_TEST"
     upload_artifacts
+    git reset --hard  ${ORIGINAL_COMMIT}
   else
     echo "Found existing artifact for ${LATEST_RELEASE_VER}, not rebuilding."
     exit 0

--- a/codebuild/bin/criterion_delta.sh
+++ b/codebuild/bin/criterion_delta.sh
@@ -31,7 +31,7 @@ download_artifacts(){
   echo "Downloading ${AWS_S3_BUCKET}${AWS_S3_BASE_PATH}"
   pushd  ./tests/integrationv2/target/criterion/
   aws s3 cp "${AWS_S3_BUCKET}${AWS_S3_BASE_PATH}" .
-  unzip -o "${AWS_S3_BASE_PATH}"
+  unzip -o "${AWS_ZIP_FILE}"
   echo "S3 download complete"
   popd
 }
@@ -46,7 +46,8 @@ upload_report(){
 # Fetch creds and the latest release number.
 gh_login s2n_codebuild_PRs
 LATEST_RELEASE_VER=$(get_latest_release)
-AWS_S3_BASE_PATH="release/integv2criterion_${INTEGV2_TEST}_${LATEST_RELEASE_VER}.zip"
+export AWS_ZIPFILE="integv2criterion_${INTEGV2_TEST}_${LATEST_RELEASE_VER}.zip"
+export AWS_S3_BASE_PATH="release/${AWS_ZIPFILE}"
 criterion_install_deps
 download_artifacts
 

--- a/codebuild/bin/criterion_delta.sh
+++ b/codebuild/bin/criterion_delta.sh
@@ -11,7 +11,6 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-
 set -eu
 source ./codebuild/bin/utils.sh
 # Disable PQ
@@ -28,10 +27,10 @@ export AWS_S3_REPORT_PATH="reports/${INTEGV2_TEST}/$(date +%Y%m%d_%H%M_${GIT_COM
 # scipting the baseline download steps here.
 download_artifacts(){
   mkdir -p ./tests/integrationv2/target/criterion || true
-  echo "Downloading ${AWS_S3_BUCKET}${AWS_S3_BASE_PATH}"
+  echo "Downloading ${AWS_S3_BUCKET}${1}/${2}"
   pushd  ./tests/integrationv2/target/criterion/
-  aws s3 cp "${AWS_S3_BUCKET}${AWS_S3_BASE_PATH}" .
-  unzip -o "${AWS_ZIP_FILE}"
+  aws s3 cp "${AWS_S3_BUCKET}${1}/${2}" .
+  unzip -o "${2}"
   echo "S3 download complete"
   popd
 }
@@ -46,10 +45,10 @@ upload_report(){
 # Fetch creds and the latest release number.
 gh_login s2n_codebuild_PRs
 LATEST_RELEASE_VER=$(get_latest_release)
-export AWS_ZIPFILE="integv2criterion_${INTEGV2_TEST}_${LATEST_RELEASE_VER}.zip"
-export AWS_S3_BASE_PATH="release/${AWS_ZIPFILE}"
+AWS_ZIPFILE="integv2criterion_${INTEGV2_TEST}_${LATEST_RELEASE_VER}.zip"
+AWS_S3_BASE_PATH="release"
 criterion_install_deps
-download_artifacts
+download_artifacts ${AWS_S3_BASE_PATH} ${AWS_ZIPFILE}
 
 echo "Current dir: $(pwd)"
 S2N_USE_CRITERION=delta make -C tests/integrationv2 "$INTEGV2_TEST"


### PR DESCRIPTION
### Resolved issues:

#3130 

### Description of changes: 

Fixes file naming variables and resets state when doing the initial baseline.

### Call-outs:

- [Ad hoc](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nIntegrationv2CriterionBatch/build/s2nIntegrationv2CriterionBatch%3A8085902c-ae8b-4c17-ab07-8d6ea454edf9?region=us-west-2#) codebuild run 
- [Example report](https://d17xuyslvs6yyp.cloudfront.net/reports/test_well_known_endpoints/20230203_2300_5db8a48f/report/index.html) comparing v1.3.35 to main on 2/3 

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? ad-hoc and CI

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
