### PR TITLE
Clarify SSLv2 ClientHellos

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1325,12 +1325,16 @@ S2N_API extern ssize_t s2n_client_hello_get_raw_message_length(struct s2n_client
 /**
  * Copies `max_length` bytes of the ClientHello message into the `out` buffer.
  * The ClientHello instrumented using this function will have the Random bytes
- * zero-ed out. For SSLv2 ClientHello messages, the raw message contains only
- * the cipher_specs, session_id and members portions of the hello message
- * (see [RFC5246](https://tools.ietf.org/html/rfc5246#appendix-E.2)). To access other
- * members, you may use s2n_connection_get_client_hello_version(),
- * s2n_connection_get_client_protocol_version() and s2n_connection_get_session_id_length()
- * accessors functions.
+ * zero-ed out.
+ *
+ * Note: SSLv2 ClientHello messages follow a different structure than more modern
+ * ClientHello messages. See [RFC5246](https://tools.ietf.org/html/rfc5246#appendix-E.2).
+ * In addition, due to how s2n-tls parses SSLv2 ClientHellos, the raw message is
+ * missing the first three bytes (the msg_type and version) and instead begins with
+ * the cipher_specs. To determine whether a ClientHello is an SSLv2 ClientHello,
+ * you will need to use s2n_connection_get_client_hello_version(). To get the
+ * protocol version advertised in the SSLv2 ClientHello (which may be higher
+ * than SSLv2), you will need to use s2n_connection_get_client_protocol_version().
  *
  * @param ch The Client Hello handle
  * @param out The destination buffer for the raw Client Hello
@@ -1350,6 +1354,11 @@ S2N_API extern ssize_t s2n_client_hello_get_cipher_suites_length(struct s2n_clie
 
 /**
  * Copies into the `out` buffer `max_length` bytes of the cipher_suites on the ClientHello.
+ *
+ * Note: SSLv2 ClientHello cipher suites follow a different structure than modern
+ * ClientHello messages. See [RFC5246](https://tools.ietf.org/html/rfc5246#appendix-E.2).
+ * To determine whether a ClientHello is an SSLv2 ClientHello,
+ * you will need to use s2n_connection_get_client_hello_version().
  *
  * @param ch The Client Hello handle
  * @param out The destination buffer for the raw Client Hello cipher suites

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -625,13 +625,28 @@ In TLS1.3, connections that resume using a session ticket CAN issue new session 
 
 s2n-tls stores the received Client Hello and makes it available to the application. Call `s2n_connection_get_client_hello()` to get a pointer to the `s2n_client_hello` struct storing the Client Hello message. A NULL value will be returned if the connection has not yet received the Client Hello. The earliest point in the handshake when this struct is available is during the [Client Hello Callback](#client-hello-callback). The stored Client Hello message will not be available after calling `s2n_connection_free_handshake()`.
 
-Call `s2n_client_hello_get_raw_message()` to retrieve the complete Client Hello message with the random bytes on it zeroed out. Note that SSLv2 Client Hello messages are structured differently than other versions and thus their raw messages should be parsed accordingly (see [RFC5246](https://tools.ietf.org/html/rfc5246#appendix-E.2).) Call `s2n_connection_get_client_hello_version()` to retrieve the Client Hello version.
+Call `s2n_client_hello_get_raw_message()` to retrieve the complete Client Hello message with the random bytes on it zeroed out.
 
-`s2n_client_hello_get_cipher_suites()` will retrieve the list of cipher suites sent by the client.
+Call `s2n_client_hello_get_cipher_suites()` to retrieve the list of cipher suites sent by the client.
 
-`s2n_client_hello_get_session_id()` will get the session ID sent by the client in the ClientHello message. Note that this value may not be the session ID eventually associated with this particular connection since the session ID can change when the server sends the Server Hello. The official session ID can be retrieved with `s2n_connection_get_session_id()`after the handshake completes.
+Call `s2n_client_hello_get_session_id()` to retrieve the session ID sent by the client in the ClientHello message. Note that this value may not be the session ID eventually associated with this particular connection since the session ID can change when the server sends the Server Hello. The official session ID can be retrieved with `s2n_connection_get_session_id()`after the handshake completes.
 
 Call `s2n_client_hello_get_extensions()` to retrieve the entire list of extensions sent in the Client Hello. Calling `s2n_client_hello_get_extension_by_id()` allows you to interrogate the `s2n_client_hello` struct for a specific extension.
+
+### SSLv2
+s2n-tls will not negotiate SSLv2, but will accept SSLv2 ClientHellos advertising a
+higher protocol version like SSLv3 or TLS1.0. This was a backwards compatibility
+strategy used by some old clients when connecting to a server that might only support SSLv2.
+
+You can determine whether an SSLv2 ClientHello was received by checking the value
+of `s2n_connection_get_client_hello_version()`. If an SSLv2 ClientHello was
+received, then `s2n_connection_get_client_protocol_version()` will still report
+the real protocol version requested by the client.
+
+SSLv2 ClientHellos are formatted differently than ClientHellos in later versions.
+`s2n_client_hello_get_raw_message()` and `s2n_client_hello_get_cipher_suites()`
+will produce differently formatted data. See the documentation for those methods
+for details about proper SSLv2 ClientHello parsing.
 
 ### Client Hello Callback
 

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -652,10 +652,24 @@ int s2n_client_hello_send(struct s2n_connection *conn)
     return S2N_SUCCESS;
 }
 
-/* See http://www-archive.mozilla.org/projects/security/pki/nss/ssl/draft02.html 2.5 */
+/*
+ * s2n-tls does NOT support SSLv2. However, it does support SSLv2 ClientHellos.
+ * Clients may send SSLv2 ClientHellos advertising higher protocol versions for
+ * backwards compatibility reasons. See https://tools.ietf.org/rfc/rfc2246 Appendix E.
+ *
+ * In this case, conn->client_hello_version will be SSLv2, but conn->client_protocol_version
+ * will likely be higher.
+ *
+ * See http://www-archive.mozilla.org/projects/security/pki/nss/ssl/draft02.html Section 2.5
+ * for a description of the expected SSLv2 format.
+ * Alternatively, the TLS1.0 RFC includes a more modern description of the format:
+ * https://tools.ietf.org/rfc/rfc2246 Appendix E.1
+ */
 int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
 {
     struct s2n_client_hello *client_hello = &conn->client_hello;
+    client_hello->sslv2 = true;
+
     struct s2n_stuffer in_stuffer = { 0 };
     POSIX_GUARD(s2n_stuffer_init(&in_stuffer, &client_hello->raw_message));
     POSIX_GUARD(s2n_stuffer_skip_write(&in_stuffer, client_hello->raw_message.size));

--- a/tls/s2n_client_hello.h
+++ b/tls/s2n_client_hello.h
@@ -46,8 +46,9 @@ struct s2n_client_hello {
 
     /*
      * SSLv2 ClientHellos have a different format.
-     * Due to how s2n-tls parses them, the raw_message
-     * will not contain the protocol version.
+     * Cipher suites are each three bytes instead of two.
+     * And due to how s2n-tls parses the record,
+     * the raw_message will not contain the protocol version.
      */
     unsigned int sslv2 : 1;
 };

--- a/tls/s2n_client_hello.h
+++ b/tls/s2n_client_hello.h
@@ -43,6 +43,13 @@ struct s2n_client_hello {
      * issues a hello retry.
      */
     unsigned int parsed : 1;
+
+    /*
+     * SSLv2 ClientHellos have a different format.
+     * Due to how s2n-tls parses them, the raw_message
+     * will not contain the protocol version.
+     */
+    unsigned int sslv2 : 1;
 };
 
 int s2n_client_hello_free(struct s2n_client_hello *client_hello);

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -40,20 +40,37 @@ int s2n_sslv2_record_header_parse(
 
     POSIX_GUARD(s2n_stuffer_read_uint16(in, fragment_length));
 
-    /* Adjust to account for the 3 bytes of payload data we consumed in the header */
+    /* The SSLv2 header is only a 2 byte record length (technically 3 bytes if
+     * padding is included, but s2n-tls assumes no padding).
+     * See https://www.ietf.org/archive/id/draft-hickman-netscape-ssl-00.txt.
+     *
+     * So by reading 5 bytes for a standard header we have also read the first
+     * 3 bytes of the record payload. s2n-tls only supports SSLv2 ClientHellos,
+     * so we assume that those 3 bytes are the first two fields of the
+     * SSLv2 ClientHello.
+     */
+
+    /* Because we already read 3 bytes of the record payload while trying to
+     * read a standard header, we need to adjust the length so that we only
+     * try to read the remainder of the record payload.
+     */
     POSIX_ENSURE_GTE(*fragment_length, 3);
     *fragment_length -= 3;
 
+    /*
+     * The first field of an SSLv2 ClientHello is the msg_type.
+     *
+     * This is always '1', matching the ClientHello msg_type used by later
+     * handshake messages.
+     */
     POSIX_GUARD(s2n_stuffer_read_uint8(in, record_type));
 
-    /* The SSLv2 header is only 3 bytes (technically sometimes 2, but we only support 3 --
-     * see https://www.ietf.org/archive/id/draft-hickman-netscape-ssl-00.txt). So by reading
-     * 5 bytes for a standard header we have also read the first two bytes of the record contents.
+    /*
+     * The second field of an SSLv2 ClientHello is the version.
      *
-     * s2n-tls ONLY supports SSLv2 ClientHellos, so we assume that those two bytes are
-     * the first field of the SSLv2 ClientHello. The first field is the protocol version.
-     *
-     * Note: the protocol version read here will likely NOT be SSLv2. See s2n_sslv2_client_hello_recv.
+     * The protocol version read here will likely not be SSLv2, since we only
+     * accept SSLv2 ClientHellos offering higher protocol versions.
+     * See s2n_sslv2_client_hello_recv.
      */
     uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN] = { 0 };
     POSIX_GUARD(s2n_stuffer_read_bytes(in, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -46,7 +46,16 @@ int s2n_sslv2_record_header_parse(
 
     POSIX_GUARD(s2n_stuffer_read_uint8(in, record_type));
 
-    uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
+    /* The SSLv2 header is only 3 bytes (technically sometimes 2, but we only support 3 --
+     * see https://www.ietf.org/archive/id/draft-hickman-netscape-ssl-00.txt). So by reading
+     * 5 bytes for a standard header we have also read the first two bytes of the record contents.
+     *
+     * s2n-tls ONLY supports SSLv2 ClientHellos, so we assume that those two bytes are
+     * the first field of the SSLv2 ClientHello. The first field is the protocol version.
+     *
+     * Note: the protocol version read here will likely NOT be SSLv2. See s2n_sslv2_client_hello_recv.
+     */
+    uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN] = { 0 };
     POSIX_GUARD(s2n_stuffer_read_bytes(in, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
 
     *client_protocol_version = (protocol_version[0] * 10) + protocol_version[1];


### PR DESCRIPTION
### Description of changes: 

While working on fingerprinting ClientHellos, I was reminded how confusing our SSLv2 "support" is. I've expanded the documentation around SSLv2 in hopes that future developers won't need to cover the same ground. If you don't understand s2n-tls's SSLv2 support from this PR, then I probably need to revise the comments.

I also added a flag to the s2n_client_hello structure to identify SSLv2 ClientHellos, because they are formatted very differently from other ClientHellos. Nothing in this PR uses that flag yet.

### Testing:
I added checks for the new field to existing tests, but otherwise there were no functionality changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
