### PR TITLE
ktls: rm kTLS request field on config

### DIFF
--- a/tests/unit/s2n_ktls_mode_test.c
+++ b/tests/unit/s2n_ktls_mode_test.c
@@ -21,36 +21,6 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
-    /* Default config kTLS mode */
-    {
-        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
-        EXPECT_NOT_NULL(config);
-        EXPECT_FALSE(config->ktls_send_requested);
-        EXPECT_FALSE(config->ktls_recv_requested);
-    };
-
-    /* Request config kTLS mode */
-    {
-        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
-        EXPECT_NOT_NULL(config);
-
-        EXPECT_SUCCESS(s2n_config_set_ktls_mode(config, S2N_KTLS_MODE_SEND));
-        EXPECT_TRUE(config->ktls_send_requested);
-        EXPECT_FALSE(config->ktls_recv_requested);
-
-        EXPECT_SUCCESS(s2n_config_set_ktls_mode(config, S2N_KTLS_MODE_RECV));
-        EXPECT_FALSE(config->ktls_send_requested);
-        EXPECT_TRUE(config->ktls_recv_requested);
-
-        EXPECT_SUCCESS(s2n_config_set_ktls_mode(config, S2N_KTLS_MODE_DISABLED));
-        EXPECT_FALSE(config->ktls_send_requested);
-        EXPECT_FALSE(config->ktls_recv_requested);
-
-        EXPECT_SUCCESS(s2n_config_set_ktls_mode(config, S2N_KTLS_MODE_DUPLEX));
-        EXPECT_TRUE(config->ktls_send_requested);
-        EXPECT_TRUE(config->ktls_recv_requested);
-    };
-
     /* Default connection kTLS mode */
     {
         DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -1072,30 +1072,3 @@ int s2n_config_set_recv_multi_record(struct s2n_config *config, bool enabled)
 
     return S2N_SUCCESS;
 }
-
-/* Indicates if the connection should attempt to enable kTLS. */
-int s2n_config_set_ktls_mode(struct s2n_config *config, s2n_ktls_mode ktls_mode)
-{
-    POSIX_ENSURE_REF(config);
-
-    switch (ktls_mode) {
-        case S2N_KTLS_MODE_DUPLEX:
-            config->ktls_recv_requested = true;
-            config->ktls_send_requested = true;
-            break;
-        case S2N_KTLS_MODE_SEND:
-            config->ktls_recv_requested = false;
-            config->ktls_send_requested = true;
-            break;
-        case S2N_KTLS_MODE_RECV:
-            config->ktls_recv_requested = true;
-            config->ktls_send_requested = false;
-            break;
-        case S2N_KTLS_MODE_DISABLED:
-            config->ktls_recv_requested = false;
-            config->ktls_send_requested = false;
-            break;
-    }
-
-    return S2N_SUCCESS;
-}

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -101,12 +101,6 @@ struct s2n_config {
      */
     unsigned recv_multi_record : 1;
 
-    /* Depending on OS and configuration it is possible to use kTLS.
-     *
-     * This option indicates if connections should attempt to use kTLS. */
-    unsigned ktls_send_requested : 1;
-    unsigned ktls_recv_requested : 1;
-
     struct s2n_dh_params *dhparams;
     /* Needed until we can deprecate s2n_config_add_cert_chain_and_key. This is
      * used to release memory allocated only in the deprecated API that the application 


### PR DESCRIPTION
### Description of changes: 
Upon further discussion, we decided to shift the API call pattern for kTLS. Instead of requesting kTLS on the config, the application will now call `s2n_ktls_enable(conn)` after the handshake is complete (s2n_negotiate).

The primary advantage of this is that the application can get immediate feedback on if kTLS was enabled. This PR removes some fields which were added in prior PRs.


 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
