### PR TITLE
Add JA3 fingerprinting

### DIFF
--- a/tests/unit/s2n_fingerprint_ja3_test.c
+++ b/tests/unit/s2n_fingerprint_ja3_test.c
@@ -22,7 +22,7 @@
 /* SSLv2 == 0x0200 == 512 */
 #define S2N_JA3_SSLV2_VAL 512
 
-// clang-format off
+/* clang-format off */
 #define S2N_TEST_CLIENT_HELLO_AFTER_VERSION \
     /* random */ \
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, \
@@ -31,7 +31,7 @@
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, \
     /* session id */ \
     0x00
-// clang-format on
+/* clang-format on */
 
 #define S2N_TEST_CLIENT_HELLO_AFTER_CIPHERS \
     /* legacy compression methods */        \

--- a/tests/unit/s2n_fingerprint_ja3_test.c
+++ b/tests/unit/s2n_fingerprint_ja3_test.c
@@ -1,0 +1,913 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_sslv2_client_hello.h"
+#include "testlib/s2n_testlib.h"
+#include "tls/s2n_fingerprint.h"
+#include "tls/s2n_tls.h"
+
+/* SSLv2 == 0x0200 == 512 */
+#define S2N_JA3_SSLV2_VAL 512
+
+// clang-format off
+#define S2N_TEST_CLIENT_HELLO_AFTER_VERSION \
+    /* random */ \
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, \
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, \
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, \
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, \
+    /* session id */ \
+    0x00
+// clang-format on
+
+#define S2N_TEST_CLIENT_HELLO_AFTER_CIPHERS \
+    /* legacy compression methods */        \
+    0x01, 0x00
+
+static S2N_RESULT s2n_validate_ja3_str_list(struct s2n_stuffer *input)
+{
+    uint32_t skipped = 0;
+    size_t count = 0;
+    DEFER_CLEANUP(struct s2n_stuffer list = { 0 }, s2n_stuffer_free);
+    RESULT_GUARD_POSIX(s2n_stuffer_growable_alloc(&list, 0));
+    RESULT_GUARD_POSIX(s2n_stuffer_read_token(input, &list, ','));
+    while (s2n_stuffer_data_available(&list)) {
+        RESULT_GUARD_POSIX(s2n_stuffer_skip_to_char(&list, '-'));
+        RESULT_GUARD_POSIX(s2n_stuffer_skip_expected_char(&list, '-',
+                0, 1, &skipped));
+        count++;
+    }
+    RESULT_ENSURE_GT(count, 1);
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_validate_ja3_str(uint8_t *ja3, uint32_t ja3_size,
+        const char *expected_version)
+{
+    struct s2n_blob input_blob = { 0 };
+    struct s2n_stuffer input = { 0 };
+    RESULT_GUARD_POSIX(s2n_blob_init(&input_blob, ja3, ja3_size));
+    RESULT_GUARD_POSIX(s2n_stuffer_init(&input, &input_blob));
+    RESULT_GUARD_POSIX(s2n_stuffer_skip_write(&input, ja3_size));
+
+    /* Expect the provided version */
+    RESULT_GUARD_POSIX(s2n_stuffer_read_expected_str(&input, expected_version));
+    RESULT_GUARD_POSIX(s2n_stuffer_read_expected_str(&input, ","));
+
+    /* Expect at least one entry in the cipher list */
+    RESULT_GUARD(s2n_validate_ja3_str_list(&input));
+
+    /* Expect at least one entry in the extensions list */
+    RESULT_GUARD(s2n_validate_ja3_str_list(&input));
+
+    /* Expect at least one entry in the curves list */
+    RESULT_GUARD(s2n_validate_ja3_str_list(&input));
+
+    /* Expect only one point format: 0 / uncompressed */
+    RESULT_GUARD_POSIX(s2n_stuffer_read_expected_str(&input, "0"));
+
+    RESULT_ENSURE_EQ(s2n_stuffer_data_available(&input), 0);
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_client_hello_from_raw(struct s2n_client_hello **client_hello,
+        struct s2n_connection *server, uint8_t *input, uint32_t input_size)
+{
+    RESULT_GUARD_POSIX(s2n_connection_wipe(server));
+
+    RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(&server->handshake.io, input, input_size));
+    RESULT_GUARD_POSIX(s2n_client_hello_recv(server));
+
+    *client_hello = s2n_connection_get_client_hello(server);
+    return S2N_RESULT_OK;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    uint8_t output_mem[500] = { 0 };
+
+    DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = NULL,
+            s2n_cert_chain_and_key_ptr_free);
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+            S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+
+    DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+    EXPECT_NOT_NULL(config);
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all"));
+
+    uint8_t empty_md5_hash[MD5_DIGEST_LENGTH] = { 0 };
+    DEFER_CLEANUP(struct s2n_hash_state md5_hash = { 0 }, s2n_hash_free);
+    POSIX_GUARD(s2n_hash_new(&md5_hash));
+    POSIX_GUARD(s2n_hash_init(&md5_hash, S2N_HASH_MD5));
+    POSIX_GUARD(s2n_hash_digest(&md5_hash, empty_md5_hash, MD5_DIGEST_LENGTH));
+
+    /* Test: safety / input validation */
+    {
+        struct s2n_connection server = { 0 };
+        struct s2n_client_hello *client_hello = &server.client_hello;
+        uint32_t output_size = 0, str_size = 0;
+
+        /* Valid client hello required */
+        EXPECT_FAILURE_WITH_ERRNO(
+                s2n_client_hello_get_fingerprint_string(NULL, S2N_FINGERPRINT_JA3,
+                        sizeof(output_mem), output_mem, &output_size),
+                S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(
+                s2n_client_hello_get_fingerprint_hash(NULL, S2N_FINGERPRINT_JA3,
+                        sizeof(output_mem), output_mem, &output_size, &str_size),
+                S2N_ERR_NULL);
+
+        /* Valid output buffer required */
+        EXPECT_FAILURE_WITH_ERRNO(
+                s2n_client_hello_get_fingerprint_string(client_hello, S2N_FINGERPRINT_JA3,
+                        sizeof(output_mem), NULL, &output_size),
+                S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(
+                s2n_client_hello_get_fingerprint_hash(client_hello, S2N_FINGERPRINT_JA3,
+                        sizeof(output_mem), NULL, &output_size, &str_size),
+                S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(
+                s2n_client_hello_get_fingerprint_string(client_hello, S2N_FINGERPRINT_JA3,
+                        0, NULL, &output_size),
+                S2N_ERR_INSUFFICIENT_MEM_SIZE);
+        EXPECT_FAILURE_WITH_ERRNO(
+                s2n_client_hello_get_fingerprint_hash(client_hello, S2N_FINGERPRINT_JA3,
+                        0, NULL, &output_size, &str_size),
+                S2N_ERR_INSUFFICIENT_MEM_SIZE);
+
+        /* Valid size ptr required */
+        EXPECT_FAILURE_WITH_ERRNO(
+                s2n_client_hello_get_fingerprint_string(client_hello, S2N_FINGERPRINT_JA3,
+                        sizeof(output_mem), output_mem, NULL),
+                S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(
+                s2n_client_hello_get_fingerprint_hash(client_hello, S2N_FINGERPRINT_JA3,
+                        sizeof(output_mem), output_mem, NULL, &str_size),
+                S2N_ERR_NULL);
+        EXPECT_FAILURE_WITH_ERRNO(
+                s2n_client_hello_get_fingerprint_hash(client_hello, S2N_FINGERPRINT_JA3,
+                        sizeof(output_mem), output_mem, &output_size, NULL),
+                S2N_ERR_NULL);
+
+        /* Only JA3 currently supported */
+        EXPECT_FAILURE_WITH_ERRNO(
+                s2n_client_hello_get_fingerprint_string(client_hello, S2N_FINGERPRINT_JA3 + 1,
+                        sizeof(output_mem), output_mem, &output_size),
+                S2N_ERR_INVALID_ARGUMENT);
+        EXPECT_FAILURE_WITH_ERRNO(
+                s2n_client_hello_get_fingerprint_hash(client_hello, S2N_FINGERPRINT_JA3 + 1,
+                        sizeof(output_mem), output_mem, &output_size, &str_size),
+                S2N_ERR_INVALID_ARGUMENT);
+    };
+
+    /* Test: ja3 string */
+    {
+        /* Test: basic case */
+        {
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(client);
+
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(server);
+            EXPECT_SUCCESS(s2n_connection_set_config(server, config));
+
+            EXPECT_SUCCESS(s2n_client_hello_send(client));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&client->handshake.io, &server->handshake.io,
+                    s2n_stuffer_data_available(&client->handshake.io)));
+            EXPECT_SUCCESS(s2n_client_hello_recv(server));
+
+            struct s2n_client_hello *client_hello = s2n_connection_get_client_hello(server);
+            EXPECT_NOT_NULL(client_hello);
+            EXPECT_FALSE(client_hello->sslv2);
+
+            uint32_t output_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_string(client_hello,
+                    S2N_FINGERPRINT_JA3, sizeof(output_mem), output_mem, &output_size));
+
+            /* Expect valid ja3.
+             * TLS1.2 == 0x0303 == 771 */
+            EXPECT_OK(s2n_validate_ja3_str(output_mem, output_size, "771"));
+        };
+
+        /* Test: SSLv2 not supported */
+        {
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(server);
+            EXPECT_SUCCESS(s2n_connection_set_config(server, config));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server, "test_all"));
+
+            /* SSLv2 ClientHellos are used by clients as a backwards-compatible attempt
+             * to communicate with servers that don't support later versions.
+             * s2n-tls DOES support later versions, so requires that SSLv2 ClientHellos
+             * advertise a higher version.
+             *
+             * This version negotiation is done when processing the record,
+             * not when processing the actual ClientHello message.
+             * So we need to set the versions manually.
+             */
+            server->client_hello_version = S2N_SSLv2;
+            server->client_protocol_version = S2N_TLS12;
+
+            uint8_t sslv2_client_hello[] = {
+                SSLv2_CLIENT_HELLO_PREFIX,
+                SSLv2_CLIENT_HELLO_CIPHER_SUITES,
+                SSLv2_CLIENT_HELLO_CHALLENGE,
+            };
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&server->handshake.io,
+                    sslv2_client_hello, sizeof(sslv2_client_hello)));
+            EXPECT_SUCCESS(s2n_client_hello_recv(server));
+
+            struct s2n_client_hello *client_hello = s2n_connection_get_client_hello(server);
+            EXPECT_NOT_NULL(client_hello);
+            EXPECT_TRUE(client_hello->sslv2);
+
+            uint32_t output_size = 0;
+            EXPECT_FAILURE_WITH_ERRNO(
+                    s2n_client_hello_get_fingerprint_string(client_hello,
+                            S2N_FINGERPRINT_JA3, sizeof(output_mem), output_mem, &output_size),
+                    S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+            EXPECT_EQUAL(output_size, 0);
+        };
+
+        /* Test: single entry lists */
+        {
+            uint8_t minimal_client_hello[] = {
+                /* protocol version */
+                0x03, 0x02,
+                S2N_TEST_CLIENT_HELLO_AFTER_VERSION,
+                /* cipher suites size */
+                0x00, 0x02,
+                /* cipher suites */
+                TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                S2N_TEST_CLIENT_HELLO_AFTER_CIPHERS,
+                /* extensions size */
+                0x00, 0x08,
+                /* extension: supported groups */
+                0x00, TLS_EXTENSION_SUPPORTED_GROUPS, 0x00, 0x04,
+                0x00, 0x02, 0x00, TLS_EC_CURVE_SECP_256_R1
+            };
+            const uint8_t expected_ja3[] = "770,49199,10,23,";
+            size_t expected_ja3_size = strlen((const char *) expected_ja3);
+
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(server);
+            EXPECT_SUCCESS(s2n_connection_set_config(server, config));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server, "test_all"));
+
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&server->handshake.io,
+                    minimal_client_hello, sizeof(minimal_client_hello)));
+            EXPECT_SUCCESS(s2n_client_hello_recv(server));
+
+            struct s2n_client_hello *client_hello = s2n_connection_get_client_hello(server);
+            EXPECT_NOT_NULL(client_hello);
+
+            uint32_t output_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_string(client_hello,
+                    S2N_FINGERPRINT_JA3, expected_ja3_size, output_mem, &output_size));
+            EXPECT_EQUAL(output_size, expected_ja3_size);
+            EXPECT_BYTEARRAY_EQUAL(expected_ja3, output_mem, output_size);
+        };
+
+        /* Test: missing fields
+         *
+         * We have to provide a protocol version and one cipher suite
+         * in order for the ClientHello to be considered valid, but all
+         * other fields can be empty.
+         */
+        {
+            uint8_t minimal_client_hello[] = {
+                /* protocol version */
+                0x03, 0x01,
+                S2N_TEST_CLIENT_HELLO_AFTER_VERSION,
+                /* cipher suites size */
+                0x00, 0x02,
+                /* cipher suites */
+                TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                S2N_TEST_CLIENT_HELLO_AFTER_CIPHERS,
+                /* extensions size */
+                0x00, 0x00
+            };
+            const uint8_t expected_ja3[] = "769,49199,,,";
+            size_t expected_ja3_size = strlen((const char *) expected_ja3);
+
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(server);
+            EXPECT_SUCCESS(s2n_connection_set_config(server, config));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server, "test_all"));
+
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&server->handshake.io,
+                    minimal_client_hello, sizeof(minimal_client_hello)));
+            EXPECT_SUCCESS(s2n_client_hello_recv(server));
+
+            struct s2n_client_hello *client_hello = s2n_connection_get_client_hello(server);
+            EXPECT_NOT_NULL(client_hello);
+
+            uint32_t output_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_string(client_hello,
+                    S2N_FINGERPRINT_JA3, expected_ja3_size, output_mem, &output_size));
+            EXPECT_EQUAL(output_size, expected_ja3_size);
+            EXPECT_BYTEARRAY_EQUAL(expected_ja3, output_mem, output_size);
+        };
+
+        /* Test: fails if insufficient memory */
+        {
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(client);
+
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(server);
+            EXPECT_SUCCESS(s2n_connection_set_config(server, config));
+
+            EXPECT_SUCCESS(s2n_client_hello_send(client));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&client->handshake.io, &server->handshake.io,
+                    s2n_stuffer_data_available(&client->handshake.io)));
+            EXPECT_SUCCESS(s2n_client_hello_recv(server));
+
+            struct s2n_client_hello *client_hello = s2n_connection_get_client_hello(server);
+            EXPECT_NOT_NULL(client_hello);
+
+            uint32_t output_size = 0;
+            for (size_t i = 0; i < 10; i++) {
+                EXPECT_FAILURE_WITH_ERRNO(
+                        s2n_client_hello_get_fingerprint_string(client_hello,
+                                S2N_FINGERPRINT_JA3, i, output_mem, &output_size),
+                        S2N_ERR_INSUFFICIENT_MEM_SIZE);
+                EXPECT_EQUAL(output_size, 0);
+            }
+        };
+
+        /* Test: grease values ignored */
+        {
+            const uint8_t grease_value = 0x0A;
+            uint8_t minimal_client_hello[] = {
+                /* protocol version */
+                0x03, 0x02,
+                S2N_TEST_CLIENT_HELLO_AFTER_VERSION,
+                /* cipher suites size */
+                0x00, 0x04,
+                /* cipher suites */
+                TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                grease_value, grease_value,
+                S2N_TEST_CLIENT_HELLO_AFTER_CIPHERS,
+                /* extensions size */
+                0x00, 0x0E,
+                /* extension: grease */
+                grease_value, grease_value, 0x00, 0x00,
+                /* extension: supported groups */
+                0x00, TLS_EXTENSION_SUPPORTED_GROUPS, 0x00, 0x06,
+                0x00, 0x04, 0x00, TLS_EC_CURVE_SECP_256_R1, grease_value, grease_value
+            };
+            const uint8_t expected_ja3[] = "770,49199,10,23,";
+            size_t expected_ja3_size = strlen((const char *) expected_ja3);
+
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(server);
+            EXPECT_SUCCESS(s2n_connection_set_config(server, config));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server, "test_all"));
+
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&server->handshake.io,
+                    minimal_client_hello, sizeof(minimal_client_hello)));
+            EXPECT_SUCCESS(s2n_client_hello_recv(server));
+
+            struct s2n_client_hello *client_hello = s2n_connection_get_client_hello(server);
+            EXPECT_NOT_NULL(client_hello);
+
+            uint32_t output_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_string(client_hello,
+                    S2N_FINGERPRINT_JA3, expected_ja3_size, output_mem, &output_size));
+            EXPECT_EQUAL(output_size, expected_ja3_size);
+            EXPECT_BYTEARRAY_EQUAL(expected_ja3, output_mem, output_size);
+        };
+    };
+
+    /* Test: ja3 hash */
+    {
+        /* Test: basic case */
+        {
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(client);
+
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(server);
+            EXPECT_SUCCESS(s2n_connection_set_config(server, config));
+
+            EXPECT_SUCCESS(s2n_client_hello_send(client));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&client->handshake.io, &server->handshake.io,
+                    s2n_stuffer_data_available(&client->handshake.io)));
+            EXPECT_SUCCESS(s2n_client_hello_recv(server));
+
+            struct s2n_client_hello *client_hello = s2n_connection_get_client_hello(server);
+            EXPECT_NOT_NULL(client_hello);
+
+            /* Assert reasonable result */
+            uint32_t output_size = 0, str_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_hash(client_hello,
+                    S2N_FINGERPRINT_JA3, MD5_DIGEST_LENGTH, output_mem, &output_size, &str_size));
+            EXPECT_TRUE(str_size > MD5_DIGEST_LENGTH);
+            EXPECT_EQUAL(output_size, MD5_DIGEST_LENGTH);
+            EXPECT_BYTEARRAY_NOT_EQUAL(empty_md5_hash, output_mem, output_size);
+
+            /* Assert same result when given same inputs again */
+            uint8_t output_mem_2[MD5_DIGEST_LENGTH] = { 0 };
+            uint32_t output_size_2 = 0, str_size_2 = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_hash(client_hello,
+                    S2N_FINGERPRINT_JA3, MD5_DIGEST_LENGTH, output_mem_2,
+                    &output_size_2, &str_size_2));
+            EXPECT_EQUAL(str_size, str_size_2);
+            EXPECT_EQUAL(output_size, output_size_2);
+            EXPECT_BYTEARRAY_EQUAL(output_mem, output_mem_2, output_size_2);
+
+            /* Assert length for full ja3 string is correct */
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_string(client_hello,
+                    S2N_FINGERPRINT_JA3, str_size, output_mem, &output_size));
+            EXPECT_FAILURE_WITH_ERRNO(
+                    s2n_client_hello_get_fingerprint_string(client_hello,
+                            S2N_FINGERPRINT_JA3, str_size - 1, output_mem, &output_size),
+                    S2N_ERR_INSUFFICIENT_MEM_SIZE);
+        };
+
+        /* Test: fails if insufficient memory */
+        {
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(client);
+
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(server);
+            EXPECT_SUCCESS(s2n_connection_set_config(server, config));
+
+            EXPECT_SUCCESS(s2n_client_hello_send(client));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&client->handshake.io, &server->handshake.io,
+                    s2n_stuffer_data_available(&client->handshake.io)));
+            EXPECT_SUCCESS(s2n_client_hello_recv(server));
+
+            struct s2n_client_hello *client_hello = s2n_connection_get_client_hello(server);
+            EXPECT_NOT_NULL(client_hello);
+
+            uint32_t output_size = 0, str_size = 0;
+            for (size_t i = 0; i < MD5_DIGEST_LENGTH; i++) {
+                EXPECT_FAILURE_WITH_ERRNO(
+                        s2n_client_hello_get_fingerprint_hash(client_hello,
+                                S2N_FINGERPRINT_JA3, i, output_mem, &output_size, &str_size),
+                        S2N_ERR_INSUFFICIENT_MEM_SIZE);
+            }
+            EXPECT_EQUAL(output_size, 0);
+        };
+    };
+
+    /* Test: Known values
+     *
+     * No definitive source exists for JA3 test vectors.
+     * We sample some test values used by other implementations.
+     */
+    {
+        DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server);
+        EXPECT_SUCCESS(s2n_connection_set_config(server, config));
+
+        /* Known value from Java implementation:
+         * https://github.com/lafaspot/ja3_4java/blob/d605ea2b51c1024eb9056568aac68c2d26011c4f/src/test/resources/openssl-ssl3.bin
+         */
+        {
+            uint8_t raw_client_hello[] = {
+                0x03, 0x00, 0x54, 0x3D, 0xD2, 0xA9, 0xB2, 0xD7, 0x59, 0xF7, 0xC4,
+                0xCF, 0x64, 0x30, 0xEB, 0xCC, 0xF7, 0x36, 0x58, 0x9B, 0x78, 0xB8,
+                0x9D, 0xB5, 0x0D, 0x59, 0xAF, 0x82, 0xA6, 0xC0, 0xAC, 0xFB, 0xA0,
+                0xB1, 0x00, 0x00, 0x5C, 0xC0, 0x14, 0xC0, 0x0A, 0x00, 0x39, 0x00,
+                0x38, 0x00, 0x88, 0x00, 0x87, 0xC0, 0x0F, 0xC0, 0x05, 0x00, 0x35,
+                0x00, 0x84, 0xC0, 0x12, 0xC0, 0x08, 0x00, 0x16, 0x00, 0x13, 0xC0,
+                0x0D, 0xC0, 0x03, 0x00, 0x0A, 0xC0, 0x13, 0xC0, 0x09, 0x00, 0x33,
+                0x00, 0x32, 0x00, 0x9A, 0x00, 0x99, 0x00, 0x45, 0x00, 0x44, 0xC0,
+                0x0E, 0xC0, 0x04, 0x00, 0x2F, 0x00, 0x96, 0x00, 0x41, 0x00, 0x07,
+                0xC0, 0x11, 0xC0, 0x07, 0xC0, 0x0C, 0xC0, 0x02, 0x00, 0x05, 0x00,
+                0x04, 0x00, 0x15, 0x00, 0x12, 0x00, 0x09, 0x00, 0x14, 0x00, 0x11,
+                0x00, 0x08, 0x00, 0x06, 0x00, 0x03, 0x00, 0xFF, 0x01, 0x00
+            };
+            const char expected_ja3[] = "768,49172-49162-57-56-136-135-49167-"
+                                        "49157-53-132-49170-49160-22-19-49165-49155-"
+                                        "10-49171-49161-51-50-154-153-69-68-49166-"
+                                        "49156-47-150-65-7-49169-49159-49164-49154-"
+                                        "5-4-21-18-9-20-17-8-6-3-255,,,";
+
+            struct s2n_client_hello *client_hello = NULL;
+            EXPECT_OK(s2n_client_hello_from_raw(&client_hello, server,
+                    raw_client_hello, sizeof(raw_client_hello)));
+
+            uint32_t output_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_string(client_hello,
+                    S2N_FINGERPRINT_JA3, sizeof(output_mem), output_mem, &output_size));
+            EXPECT_EQUAL(strlen(expected_ja3), output_size);
+            EXPECT_BYTEARRAY_EQUAL(expected_ja3, output_mem, output_size);
+        };
+
+        /* Known value from Java implementation:
+         * https://github.com/lafaspot/ja3_4java/blob/d605ea2b51c1024eb9056568aac68c2d26011c4f/src/test/resources/openssl-ssl3.bin
+         */
+        {
+            uint8_t raw_client_hello[] = {
+                0x03, 0x01, 0x54, 0x3D, 0xD2, 0xDD, 0x48, 0xF5, 0x17, 0xCA, 0x9A,
+                0x93, 0xB1, 0xE5, 0x99, 0xF0, 0x19, 0xFD, 0xEC, 0xE7, 0x04, 0xA2,
+                0x3E, 0x86, 0xC1, 0xDC, 0xAC, 0x58, 0x84, 0x27, 0xAB, 0xBA, 0xDD,
+                0xF2, 0x00, 0x00, 0x5C, 0xC0, 0x14, 0xC0, 0x0A, 0x00, 0x39, 0x00,
+                0x38, 0x00, 0x88, 0x00, 0x87, 0xC0, 0x0F, 0xC0, 0x05, 0x00, 0x35,
+                0x00, 0x84, 0xC0, 0x12, 0xC0, 0x08, 0x00, 0x16, 0x00, 0x13, 0xC0,
+                0x0D, 0xC0, 0x03, 0x00, 0x0A, 0xC0, 0x13, 0xC0, 0x09, 0x00, 0x33,
+                0x00, 0x32, 0x00, 0x9A, 0x00, 0x99, 0x00, 0x45, 0x00, 0x44, 0xC0,
+                0x0E, 0xC0, 0x04, 0x00, 0x2F, 0x00, 0x96, 0x00, 0x41, 0x00, 0x07,
+                0xC0, 0x11, 0xC0, 0x07, 0xC0, 0x0C, 0xC0, 0x02, 0x00, 0x05, 0x00,
+                0x04, 0x00, 0x15, 0x00, 0x12, 0x00, 0x09, 0x00, 0x14, 0x00, 0x11,
+                0x00, 0x08, 0x00, 0x06, 0x00, 0x03, 0x00, 0xFF, 0x01, 0x00, 0x00,
+                0x1B, 0x00, 0x0B, 0x00, 0x04, 0x03, 0x00, 0x01, 0x02, 0x00, 0x0A,
+                0x00, 0x06, 0x00, 0x04, 0x00, 0x18, 0x00, 0x17, 0x00, 0x23, 0x00,
+                0x00, 0x00, 0x0F, 0x00, 0x01, 0x01
+            };
+            const char expected_ja3[] = "769,49172-49162-57-56-136-135-49167-"
+                                        "49157-53-132-49170-49160-22-19-49165-49155-"
+                                        "10-49171-49161-51-50-154-153-69-68-49166-"
+                                        "49156-47-150-65-7-49169-49159-49164-49154-"
+                                        "5-4-21-18-9-20-17-8-6-3-255,11-10-35-15,"
+                                        "24-23,0-1-2";
+
+            struct s2n_client_hello *client_hello = NULL;
+            EXPECT_OK(s2n_client_hello_from_raw(&client_hello, server,
+                    raw_client_hello, sizeof(raw_client_hello)));
+
+            uint32_t output_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_string(client_hello,
+                    S2N_FINGERPRINT_JA3, sizeof(output_mem), output_mem, &output_size));
+            EXPECT_EQUAL(strlen(expected_ja3), output_size);
+            EXPECT_BYTEARRAY_EQUAL(expected_ja3, output_mem, output_size);
+        };
+
+        /* Known value from Java implementation:
+         * https://github.com/lafaspot/ja3_4java/blob/d605ea2b51c1024eb9056568aac68c2d26011c4f/src/test/resources/openssl-tls1_1.bin
+         */
+        {
+            uint8_t raw_client_hello[] = {
+                0x03, 0x02, 0x54, 0x3D, 0xD2, 0xED, 0x90, 0x7E, 0x47, 0xD0, 0x08,
+                0x6F, 0x34, 0xBE, 0xE2, 0xC5, 0x2D, 0xD6, 0xCC, 0xD8, 0xDE, 0x63,
+                0xBA, 0x93, 0x87, 0xF5, 0xE8, 0x10, 0xB0, 0x9D, 0x9D, 0x49, 0xB3,
+                0x80, 0x00, 0x00, 0x5C, 0xC0, 0x14, 0xC0, 0x0A, 0x00, 0x39, 0x00,
+                0x38, 0x00, 0x88, 0x00, 0x87, 0xC0, 0x0F, 0xC0, 0x05, 0x00, 0x35,
+                0x00, 0x84, 0xC0, 0x12, 0xC0, 0x08, 0x00, 0x16, 0x00, 0x13, 0xC0,
+                0x0D, 0xC0, 0x03, 0x00, 0x0A, 0xC0, 0x13, 0xC0, 0x09, 0x00, 0x33,
+                0x00, 0x32, 0x00, 0x9A, 0x00, 0x99, 0x00, 0x45, 0x00, 0x44, 0xC0,
+                0x0E, 0xC0, 0x04, 0x00, 0x2F, 0x00, 0x96, 0x00, 0x41, 0x00, 0x07,
+                0xC0, 0x11, 0xC0, 0x07, 0xC0, 0x0C, 0xC0, 0x02, 0x00, 0x05, 0x00,
+                0x04, 0x00, 0x15, 0x00, 0x12, 0x00, 0x09, 0x00, 0x14, 0x00, 0x11,
+                0x00, 0x08, 0x00, 0x06, 0x00, 0x03, 0x00, 0xFF, 0x01, 0x00, 0x00,
+                0x1B, 0x00, 0x0B, 0x00, 0x04, 0x03, 0x00, 0x01, 0x02, 0x00, 0x0A,
+                0x00, 0x06, 0x00, 0x04, 0x00, 0x18, 0x00, 0x17, 0x00, 0x23, 0x00,
+                0x00, 0x00, 0x0F, 0x00, 0x01, 0x01
+            };
+            const char expected_ja3[] = "770,49172-49162-57-56-136-135-49167-"
+                                        "49157-53-132-49170-49160-22-19-49165-49155-"
+                                        "10-49171-49161-51-50-154-153-69-68-49166-"
+                                        "49156-47-150-65-7-49169-49159-49164-49154-"
+                                        "5-4-21-18-9-20-17-8-6-3-255,11-10-35-15,"
+                                        "24-23,0-1-2";
+
+            struct s2n_client_hello *client_hello = NULL;
+            EXPECT_OK(s2n_client_hello_from_raw(&client_hello, server,
+                    raw_client_hello, sizeof(raw_client_hello)));
+
+            uint32_t output_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_string(client_hello,
+                    S2N_FINGERPRINT_JA3, sizeof(output_mem), output_mem, &output_size));
+            EXPECT_EQUAL(strlen(expected_ja3), output_size);
+            EXPECT_BYTEARRAY_EQUAL(expected_ja3, output_mem, output_size);
+        };
+
+        /* Known value from Java implementation:
+         * https://github.com/lafaspot/ja3_4java/blob/d605ea2b51c1024eb9056568aac68c2d26011c4f/src/test/resources/openssl-tls1_2.bin
+         */
+        {
+            uint8_t raw_client_hello[] = {
+                0x03, 0x03, 0x54, 0x3D, 0xD3, 0x28, 0x32, 0x83, 0x69, 0x2D, 0x85,
+                0xF9, 0x41, 0x6B, 0x5C, 0xCC, 0x65, 0xD2, 0xAA, 0xFC, 0xA4, 0x5C,
+                0x65, 0x30, 0xB3, 0xC6, 0xEA, 0xFB, 0xF6, 0xD3, 0x71, 0xB6, 0xA0,
+                0x15, 0x00, 0x00, 0x94, 0xC0, 0x30, 0xC0, 0x2C, 0xC0, 0x28, 0xC0,
+                0x24, 0xC0, 0x14, 0xC0, 0x0A, 0x00, 0xA3, 0x00, 0x9F, 0x00, 0x6B,
+                0x00, 0x6A, 0x00, 0x39, 0x00, 0x38, 0x00, 0x88, 0x00, 0x87, 0xC0,
+                0x32, 0xC0, 0x2E, 0xC0, 0x2A, 0xC0, 0x26, 0xC0, 0x0F, 0xC0, 0x05,
+                0x00, 0x9D, 0x00, 0x3D, 0x00, 0x35, 0x00, 0x84, 0xC0, 0x12, 0xC0,
+                0x08, 0x00, 0x16, 0x00, 0x13, 0xC0, 0x0D, 0xC0, 0x03, 0x00, 0x0A,
+                0xC0, 0x2F, 0xC0, 0x2B, 0xC0, 0x27, 0xC0, 0x23, 0xC0, 0x13, 0xC0,
+                0x09, 0x00, 0xA2, 0x00, 0x9E, 0x00, 0x67, 0x00, 0x40, 0x00, 0x33,
+                0x00, 0x32, 0x00, 0x9A, 0x00, 0x99, 0x00, 0x45, 0x00, 0x44, 0xC0,
+                0x31, 0xC0, 0x2D, 0xC0, 0x29, 0xC0, 0x25, 0xC0, 0x0E, 0xC0, 0x04,
+                0x00, 0x9C, 0x00, 0x3C, 0x00, 0x2F, 0x00, 0x96, 0x00, 0x41, 0x00,
+                0x07, 0xC0, 0x11, 0xC0, 0x07, 0xC0, 0x0C, 0xC0, 0x02, 0x00, 0x05,
+                0x00, 0x04, 0x00, 0x15, 0x00, 0x12, 0x00, 0x09, 0x00, 0x14, 0x00,
+                0x11, 0x00, 0x08, 0x00, 0x06, 0x00, 0x03, 0x00, 0xFF, 0x01, 0x00,
+                0x00, 0x41, 0x00, 0x0B, 0x00, 0x04, 0x03, 0x00, 0x01, 0x02, 0x00,
+                0x0A, 0x00, 0x06, 0x00, 0x04, 0x00, 0x18, 0x00, 0x17, 0x00, 0x23,
+                0x00, 0x00, 0x00, 0x0D, 0x00, 0x22, 0x00, 0x20, 0x06, 0x01, 0x06,
+                0x02, 0x06, 0x03, 0x05, 0x01, 0x05, 0x02, 0x05, 0x03, 0x04, 0x01,
+                0x04, 0x02, 0x04, 0x03, 0x03, 0x01, 0x03, 0x02, 0x03, 0x03, 0x02,
+                0x01, 0x02, 0x02, 0x02, 0x03, 0x01, 0x01, 0x00, 0x0F, 0x00, 0x01,
+                0x01
+            };
+            const char expected_ja3[] = "771,49200-49196-49192-49188-49172-49162-"
+                                        "163-159-107-106-57-56-136-135-49202-49198-"
+                                        "49194-49190-49167-49157-157-61-53-132-"
+                                        "49170-49160-22-19-49165-49155-10-49199-"
+                                        "49195-49191-49187-49171-49161-162-158-103-"
+                                        "64-51-50-154-153-69-68-49201-49197-49193-"
+                                        "49189-49166-49156-156-60-47-150-65-7-"
+                                        "49169-49159-49164-49154-5-4-21-18-9-20-"
+                                        "17-8-6-3-255,11-10-35-13-15,24-23,0-1-2";
+
+            struct s2n_client_hello *client_hello = NULL;
+            EXPECT_OK(s2n_client_hello_from_raw(&client_hello, server,
+                    raw_client_hello, sizeof(raw_client_hello)));
+
+            uint32_t output_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_string(client_hello,
+                    S2N_FINGERPRINT_JA3, sizeof(output_mem), output_mem, &output_size));
+            EXPECT_EQUAL(strlen(expected_ja3), output_size);
+            EXPECT_BYTEARRAY_EQUAL(expected_ja3, output_mem, output_size);
+        };
+
+        /* Known values from Rust implementation:
+         * https://github.com/jabedude/ja3-rs/blob/4f2629b86ce3496b4614296f754954806c9c849c/tests/chrome-grease-single.pcap
+         */
+        {
+            uint8_t raw_client_hello[508] = {
+                0x03, 0x03, 0x86, 0xad, 0xa4, 0xcc, 0x19, 0xe7, 0x14, 0x54, 0x54,
+                0xfd, 0xe7, 0x37, 0x33, 0xdf, 0x66, 0xcb, 0xf6, 0xef, 0x3e, 0xc0,
+                0xa1, 0x54, 0xc6, 0xdd, 0x14, 0x5e, 0xc0, 0x83, 0xac, 0xb9, 0xb4,
+                0xe7, 0x20, 0x1c, 0x64, 0xae, 0xa7, 0xa2, 0xc3, 0xe1, 0x8c, 0xd1,
+                0x25, 0x02, 0x4d, 0xf7, 0x86, 0x4a, 0xc7, 0x19, 0xd0, 0xc4, 0xbd,
+                0xfb, 0x40, 0xc2, 0xef, 0x7f, 0x6d, 0xd3, 0x9a, 0xa7, 0x53, 0xdf,
+                0xdd, 0x00, 0x22, 0x1a, 0x1a, 0x13, 0x01, 0x13, 0x02, 0x13, 0x03,
+                0xc0, 0x2b, 0xc0, 0x2f, 0xc0, 0x2c, 0xc0, 0x30, 0xcc, 0xa9, 0xcc,
+                0xa8, 0xc0, 0x13, 0xc0, 0x14, 0x00, 0x9c, 0x00, 0x9d, 0x00, 0x2f,
+                0x00, 0x35, 0x00, 0x0a, 0x01, 0x00, 0x01, 0x91, 0x0a, 0x0a, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x1e, 0x00, 0x00, 0x1b, 0x67,
+                0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x61, 0x64, 0x73, 0x2e, 0x67, 0x2e,
+                0x64, 0x6f, 0x75, 0x62, 0x6c, 0x65, 0x63, 0x6c, 0x69, 0x63, 0x6b,
+                0x2e, 0x6e, 0x65, 0x74, 0x00, 0x17, 0x00, 0x00, 0xff, 0x01, 0x00,
+                0x01, 0x00, 0x00, 0x0a, 0x00, 0x0a, 0x00, 0x08, 0x9a, 0x9a, 0x00,
+                0x1d, 0x00, 0x17, 0x00, 0x18, 0x00, 0x0b, 0x00, 0x02, 0x01, 0x00,
+                0x00, 0x23, 0x00, 0x00, 0x00, 0x10, 0x00, 0x0e, 0x00, 0x0c, 0x02,
+                0x68, 0x32, 0x08, 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31,
+                0x00, 0x05, 0x00, 0x05, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0d,
+                0x00, 0x14, 0x00, 0x12, 0x04, 0x03, 0x08, 0x04, 0x04, 0x01, 0x05,
+                0x03, 0x08, 0x05, 0x05, 0x01, 0x08, 0x06, 0x06, 0x01, 0x02, 0x01,
+                0x00, 0x12, 0x00, 0x00, 0x00, 0x33, 0x00, 0x2b, 0x00, 0x29, 0x9a,
+                0x9a, 0x00, 0x01, 0x00, 0x00, 0x1d, 0x00, 0x20, 0x59, 0x08, 0x6f,
+                0x41, 0x9a, 0xa5, 0xaa, 0x1d, 0x81, 0xe3, 0x47, 0xf0, 0x25, 0x5f,
+                0x92, 0x07, 0xfc, 0x4b, 0x13, 0x74, 0x51, 0x46, 0x98, 0x08, 0x74,
+                0x3b, 0xde, 0x57, 0x86, 0xe8, 0x2c, 0x74, 0x00, 0x2d, 0x00, 0x02,
+                0x01, 0x01, 0x00, 0x2b, 0x00, 0x0b, 0x0a, 0xfa, 0xfa, 0x03, 0x04,
+                0x03, 0x03, 0x03, 0x02, 0x03, 0x01, 0x00, 0x1b, 0x00, 0x03, 0x02,
+                0x00, 0x02, 0xba, 0xba, 0x00, 0x01, 0x00, 0x00, 0x15, 0x00, 0xbd
+            };
+            const char expected_ja3[] = "771,4865-4866-4867-49195-49199-49196-"
+                                        "49200-52393-52392-49171-49172-156-157-47-"
+                                        "53-10,0-23-65281-10-11-35-16-5-13-18-51-"
+                                        "45-43-27-21,29-23-24,0";
+            S2N_BLOB_FROM_HEX(expected_hash, "66918128f1b9b03303d77c6f2eefd128");
+
+            struct s2n_client_hello *client_hello = NULL;
+            EXPECT_OK(s2n_client_hello_from_raw(&client_hello, server,
+                    raw_client_hello, sizeof(raw_client_hello)));
+
+            uint32_t output_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_string(client_hello,
+                    S2N_FINGERPRINT_JA3, sizeof(output_mem), output_mem, &output_size));
+            EXPECT_EQUAL(strlen(expected_ja3), output_size);
+            EXPECT_BYTEARRAY_EQUAL(expected_ja3, output_mem, output_size);
+
+            uint32_t str_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_hash(client_hello,
+                    S2N_FINGERPRINT_JA3, sizeof(output_mem), output_mem, &output_size,
+                    &str_size));
+            EXPECT_EQUAL(strlen(expected_ja3), str_size);
+            EXPECT_EQUAL(expected_hash.size, output_size);
+            EXPECT_BYTEARRAY_EQUAL(expected_hash.data, output_mem, output_size);
+        };
+
+        /* Known values from Rust implementation:
+         * https://github.com/jabedude/ja3-rs/blob/4f2629b86ce3496b4614296f754954806c9c849c/tests/curl-ipv6.pcap
+         */
+        {
+            uint8_t raw_client_hello[508] = {
+                0x03, 0x03, 0x40, 0xc7, 0x8a, 0xef, 0x5c, 0x7f, 0xed, 0x98, 0x4a,
+                0x19, 0x8a, 0x03, 0x0b, 0xc0, 0x2d, 0xc0, 0xd6, 0x8f, 0x0b, 0x14,
+                0x7d, 0x23, 0x3d, 0x90, 0xb4, 0x2b, 0x4b, 0x28, 0x2c, 0x44, 0x0c,
+                0x4d, 0x20, 0xf4, 0x73, 0x04, 0xed, 0x17, 0x42, 0xd6, 0xb5, 0x08,
+                0x2e, 0x73, 0x78, 0x71, 0x25, 0x52, 0x5c, 0xea, 0xe7, 0xd7, 0xe5,
+                0x7c, 0xfa, 0x27, 0xfe, 0xa3, 0x52, 0x63, 0x7a, 0x27, 0xc3, 0x5d,
+                0x58, 0x00, 0x3e, 0x13, 0x02, 0x13, 0x03, 0x13, 0x01, 0xc0, 0x2c,
+                0xc0, 0x30, 0x00, 0x9f, 0xcc, 0xa9, 0xcc, 0xa8, 0xcc, 0xaa, 0xc0,
+                0x2b, 0xc0, 0x2f, 0x00, 0x9e, 0xc0, 0x24, 0xc0, 0x28, 0x00, 0x6b,
+                0xc0, 0x23, 0xc0, 0x27, 0x00, 0x67, 0xc0, 0x0a, 0xc0, 0x14, 0x00,
+                0x39, 0xc0, 0x09, 0xc0, 0x13, 0x00, 0x33, 0x00, 0x9d, 0x00, 0x9c,
+                0x00, 0x3d, 0x00, 0x3c, 0x00, 0x35, 0x00, 0x2f, 0x00, 0xff, 0x01,
+                0x00, 0x01, 0x75, 0x00, 0x00, 0x00, 0x10, 0x00, 0x0e, 0x00, 0x00,
+                0x0b, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f,
+                0x6d, 0x00, 0x0b, 0x00, 0x04, 0x03, 0x00, 0x01, 0x02, 0x00, 0x0a,
+                0x00, 0x0c, 0x00, 0x0a, 0x00, 0x1d, 0x00, 0x17, 0x00, 0x1e, 0x00,
+                0x19, 0x00, 0x18, 0x33, 0x74, 0x00, 0x00, 0x00, 0x10, 0x00, 0x0e,
+                0x00, 0x0c, 0x02, 0x68, 0x32, 0x08, 0x68, 0x74, 0x74, 0x70, 0x2f,
+                0x31, 0x2e, 0x31, 0x00, 0x16, 0x00, 0x00, 0x00, 0x17, 0x00, 0x00,
+                0x00, 0x0d, 0x00, 0x30, 0x00, 0x2e, 0x04, 0x03, 0x05, 0x03, 0x06,
+                0x03, 0x08, 0x07, 0x08, 0x08, 0x08, 0x09, 0x08, 0x0a, 0x08, 0x0b,
+                0x08, 0x04, 0x08, 0x05, 0x08, 0x06, 0x04, 0x01, 0x05, 0x01, 0x06,
+                0x01, 0x03, 0x03, 0x02, 0x03, 0x03, 0x01, 0x02, 0x01, 0x03, 0x02,
+                0x02, 0x02, 0x04, 0x02, 0x05, 0x02, 0x06, 0x02, 0x00, 0x2b, 0x00,
+                0x09, 0x08, 0x03, 0x04, 0x03, 0x03, 0x03, 0x02, 0x03, 0x01, 0x00,
+                0x2d, 0x00, 0x02, 0x01, 0x01, 0x00, 0x33, 0x00, 0x26, 0x00, 0x24,
+                0x00, 0x1d, 0x00, 0x20, 0x29, 0x90, 0xc2, 0xec, 0x21, 0x68, 0x2c,
+                0x5a, 0x7a, 0x5a, 0x46, 0x49, 0x59, 0x42, 0x54, 0x66, 0x02, 0x92,
+                0x0c, 0x08, 0x16, 0x59, 0xf6, 0xcc, 0x75, 0xb8, 0x16, 0x53, 0x20,
+                0x46, 0x79, 0x23, 0x00, 0x15, 0x00, 0xb6
+            };
+            const char expected_ja3[] = "771,4866-4867-4865-49196-49200-159-52393-"
+                                        "52392-52394-49195-49199-158-49188-49192-"
+                                        "107-49187-49191-103-49162-49172-57-49161-"
+                                        "49171-51-157-156-61-60-53-47-255,0-11-"
+                                        "10-13172-16-22-23-13-43-45-51-21,29-23-"
+                                        "30-25-24,0-1-2";
+            S2N_BLOB_FROM_HEX(expected_hash, "456523fc94726331a4d5a2e1d40b2cd7");
+
+            struct s2n_client_hello *client_hello = NULL;
+            EXPECT_OK(s2n_client_hello_from_raw(&client_hello, server,
+                    raw_client_hello, sizeof(raw_client_hello)));
+
+            uint32_t output_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_string(client_hello,
+                    S2N_FINGERPRINT_JA3, sizeof(output_mem), output_mem, &output_size));
+            EXPECT_EQUAL(strlen(expected_ja3), output_size);
+            EXPECT_BYTEARRAY_EQUAL(expected_ja3, output_mem, output_size);
+
+            uint32_t str_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_hash(client_hello,
+                    S2N_FINGERPRINT_JA3, sizeof(output_mem), output_mem, &output_size,
+                    &str_size));
+            EXPECT_EQUAL(strlen(expected_ja3), str_size);
+            EXPECT_EQUAL(expected_hash.size, output_size);
+            EXPECT_BYTEARRAY_EQUAL(expected_hash.data, output_mem, output_size);
+        };
+
+        /* Known values from Rust implementation:
+         * https://github.com/jabedude/ja3-rs/blob/4f2629b86ce3496b4614296f754954806c9c849c/tests/test.pcap
+         */
+        {
+            uint8_t raw_client_hello[] = {
+                0x03, 0x03, 0x90, 0xe8, 0xcc, 0xee, 0xe5, 0x70, 0xa2, 0xa1, 0x2f,
+                0x6b, 0x69, 0xd2, 0x66, 0x96, 0x0f, 0xcf, 0x20, 0xd5, 0x32, 0x6e,
+                0xc4, 0xb2, 0x8c, 0xc7, 0xbd, 0x0a, 0x06, 0xc2, 0xa5, 0x14, 0xfc,
+                0x34, 0x20, 0xaf, 0x72, 0xbf, 0x39, 0x99, 0xfb, 0x20, 0x70, 0xc3,
+                0x10, 0x83, 0x0c, 0xee, 0xfb, 0xfa, 0x72, 0xcc, 0x5d, 0xa8, 0x99,
+                0xb4, 0xc5, 0x53, 0xd6, 0x3d, 0xa0, 0x53, 0x7a, 0x5c, 0xbc, 0xf5,
+                0x0b, 0x00, 0x1e, 0xc0, 0x2b, 0xc0, 0x2f, 0xcc, 0xa9, 0xcc, 0xa8,
+                0xc0, 0x2c, 0xc0, 0x30, 0xc0, 0x0a, 0xc0, 0x09, 0xc0, 0x13, 0xc0,
+                0x14, 0x00, 0x33, 0x00, 0x39, 0x00, 0x2f, 0x00, 0x35, 0x00, 0x0a,
+                0x01, 0x00, 0x00, 0x85, 0x00, 0x00, 0x00, 0x23, 0x00, 0x21, 0x00,
+                0x00, 0x1e, 0x69, 0x6e, 0x63, 0x6f, 0x6d, 0x69, 0x6e, 0x67, 0x2e,
+                0x74, 0x65, 0x6c, 0x65, 0x6d, 0x65, 0x74, 0x72, 0x79, 0x2e, 0x6d,
+                0x6f, 0x7a, 0x69, 0x6c, 0x6c, 0x61, 0x2e, 0x6f, 0x72, 0x67, 0x00,
+                0x17, 0x00, 0x00, 0xff, 0x01, 0x00, 0x01, 0x00, 0x00, 0x0a, 0x00,
+                0x0a, 0x00, 0x08, 0x00, 0x1d, 0x00, 0x17, 0x00, 0x18, 0x00, 0x19,
+                0x00, 0x0b, 0x00, 0x02, 0x01, 0x00, 0x00, 0x23, 0x00, 0x00, 0x00,
+                0x10, 0x00, 0x0e, 0x00, 0x0c, 0x02, 0x68, 0x32, 0x08, 0x68, 0x74,
+                0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31, 0x00, 0x05, 0x00, 0x05, 0x01,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x18, 0x00, 0x16, 0x04,
+                0x03, 0x05, 0x03, 0x06, 0x03, 0x08, 0x04, 0x08, 0x05, 0x08, 0x06,
+                0x04, 0x01, 0x05, 0x01, 0x06, 0x01, 0x02, 0x03, 0x02, 0x01, 0x00,
+                0x1c, 0x00, 0x02, 0x40, 0x00
+            };
+            const char expected_ja3[] = "771,49195-49199-52393-52392-49196-49200-"
+                                        "49162-49161-49171-49172-51-57-47-53-10,0-"
+                                        "23-65281-10-11-35-16-5-13-28,29-23-24-25,0";
+            S2N_BLOB_FROM_HEX(expected_hash, "839bbe3ed07fed922ded5aaf714d6842");
+
+            struct s2n_client_hello *client_hello = NULL;
+            EXPECT_OK(s2n_client_hello_from_raw(&client_hello, server,
+                    raw_client_hello, sizeof(raw_client_hello)));
+
+            uint32_t output_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_string(client_hello,
+                    S2N_FINGERPRINT_JA3, sizeof(output_mem), output_mem, &output_size));
+            EXPECT_EQUAL(strlen(expected_ja3), output_size);
+            EXPECT_BYTEARRAY_EQUAL(expected_ja3, output_mem, output_size);
+
+            uint32_t str_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_hash(client_hello,
+                    S2N_FINGERPRINT_JA3, sizeof(output_mem), output_mem, &output_size,
+                    &str_size));
+            EXPECT_EQUAL(strlen(expected_ja3), str_size);
+            EXPECT_EQUAL(expected_hash.size, output_size);
+            EXPECT_BYTEARRAY_EQUAL(expected_hash.data, output_mem, output_size);
+        };
+
+        /* Known values from Rust implementation:
+         * https://github.com/jabedude/ja3-rs/blob/4f2629b86ce3496b4614296f754954806c9c849c/tests/ncat-port-4450.pcap
+         */
+        {
+            uint8_t raw_client_hello[508] = {
+                0x03, 0x03, 0xf4, 0x0f, 0xfd, 0xee, 0xc7, 0x27, 0xc2, 0x1e, 0x32,
+                0x70, 0x5f, 0x85, 0x25, 0xa6, 0xbb, 0x6c, 0xca, 0x4b, 0x6c, 0xbe,
+                0x01, 0x66, 0x32, 0x66, 0x76, 0x4b, 0x67, 0x74, 0x3b, 0x91, 0xbd,
+                0xb2, 0x20, 0x83, 0xd4, 0x9e, 0x77, 0xaf, 0xc1, 0x5a, 0x63, 0x35,
+                0xba, 0x2f, 0xe9, 0x76, 0xbe, 0x9a, 0x42, 0x6b, 0x2e, 0xb5, 0x58,
+                0x23, 0x84, 0x2a, 0x99, 0x2b, 0x37, 0x88, 0xd1, 0xf7, 0x9d, 0xd6,
+                0x20, 0x00, 0x9c, 0x13, 0x02, 0x13, 0x03, 0x13, 0x01, 0xc0, 0x2c,
+                0xc0, 0x30, 0x00, 0xa3, 0x00, 0x9f, 0xcc, 0xa9, 0xcc, 0xa8, 0xcc,
+                0xaa, 0xc0, 0xaf, 0xc0, 0xad, 0xc0, 0xa3, 0xc0, 0x9f, 0xc0, 0x5d,
+                0xc0, 0x61, 0xc0, 0x57, 0xc0, 0x53, 0xc0, 0x24, 0xc0, 0x28, 0x00,
+                0x6b, 0x00, 0x6a, 0xc0, 0x73, 0xc0, 0x77, 0x00, 0xc4, 0x00, 0xc3,
+                0xc0, 0x0a, 0xc0, 0x14, 0x00, 0x39, 0x00, 0x38, 0x00, 0x88, 0x00,
+                0x87, 0x00, 0x9d, 0xc0, 0xa1, 0xc0, 0x9d, 0xc0, 0x51, 0x00, 0x3d,
+                0x00, 0xc0, 0x00, 0x35, 0x00, 0x84, 0xc0, 0x2b, 0xc0, 0x2f, 0x00,
+                0xa2, 0x00, 0x9e, 0xc0, 0xae, 0xc0, 0xac, 0xc0, 0xa2, 0xc0, 0x9e,
+                0xc0, 0x5c, 0xc0, 0x60, 0xc0, 0x56, 0xc0, 0x52, 0xc0, 0x23, 0xc0,
+                0x27, 0x00, 0x67, 0x00, 0x40, 0xc0, 0x72, 0xc0, 0x76, 0x00, 0xbe,
+                0x00, 0xbd, 0xc0, 0x09, 0xc0, 0x13, 0x00, 0x33, 0x00, 0x32, 0x00,
+                0x9a, 0x00, 0x99, 0x00, 0x45, 0x00, 0x44, 0x00, 0x9c, 0xc0, 0xa0,
+                0xc0, 0x9c, 0xc0, 0x50, 0x00, 0x3c, 0x00, 0xba, 0x00, 0x2f, 0x00,
+                0x96, 0x00, 0x41, 0x00, 0xff, 0x01, 0x00, 0x01, 0x17, 0x00, 0x00,
+                0x00, 0x0e, 0x00, 0x0c, 0x00, 0x00, 0x09, 0x31, 0x32, 0x37, 0x2e,
+                0x30, 0x2e, 0x30, 0x2e, 0x31, 0x00, 0x0b, 0x00, 0x04, 0x03, 0x00,
+                0x01, 0x02, 0x00, 0x0a, 0x00, 0x0c, 0x00, 0x0a, 0x00, 0x1d, 0x00,
+                0x17, 0x00, 0x1e, 0x00, 0x19, 0x00, 0x18, 0x00, 0x23, 0x00, 0x00,
+                0x00, 0x16, 0x00, 0x00, 0x00, 0x17, 0x00, 0x00, 0x00, 0x0d, 0x00,
+                0x30, 0x00, 0x2e, 0x04, 0x03, 0x05, 0x03, 0x06, 0x03, 0x08, 0x07,
+                0x08, 0x08, 0x08, 0x09, 0x08, 0x0a, 0x08, 0x0b, 0x08, 0x04, 0x08,
+                0x05, 0x08, 0x06, 0x04, 0x01, 0x05, 0x01, 0x06, 0x01, 0x03, 0x03,
+                0x02, 0x03, 0x03, 0x01, 0x02, 0x01, 0x03, 0x02, 0x02, 0x02, 0x04,
+                0x02, 0x05, 0x02, 0x06, 0x02, 0x00, 0x2b, 0x00, 0x09, 0x08, 0x03,
+                0x04, 0x03, 0x03, 0x03, 0x02, 0x03, 0x01, 0x00, 0x2d, 0x00, 0x02,
+                0x01, 0x01, 0x00, 0x33, 0x00, 0x26, 0x00, 0x24, 0x00, 0x1d, 0x00,
+                0x20, 0x29, 0x61, 0x96, 0xc4, 0x0c, 0x16, 0x7c, 0xde, 0x20, 0x01,
+                0x86, 0x32, 0xdf, 0x84, 0x2f, 0x67, 0x2f, 0x3f, 0x64, 0x17, 0xc0,
+                0x2e, 0xa2, 0xb2, 0x9e, 0xfc, 0xa8, 0xb0, 0xc5, 0x71, 0x6e, 0x7d,
+                0x00, 0x15, 0x00, 0x6c
+            };
+            const char expected_ja3[] = "771,4866-4867-4865-49196-49200-163-159-"
+                                        "52393-52392-52394-49327-49325-49315-"
+                                        "49311-49245-49249-49239-49235-49188-49192-"
+                                        "107-106-49267-49271-196-195-49162-49172-"
+                                        "57-56-136-135-157-49313-49309-49233-61-"
+                                        "192-53-132-49195-49199-162-158-49326-"
+                                        "49324-49314-49310-49244-49248-49238-49234-"
+                                        "49187-49191-103-64-49266-49270-190-189-"
+                                        "49161-49171-51-50-154-153-69-68-156-49312-"
+                                        "49308-49232-60-186-47-150-65-255,0-11-"
+                                        "10-35-22-23-13-43-45-51-21,29-23-30-25-"
+                                        "24,0-1-2";
+            S2N_BLOB_FROM_HEX(expected_hash, "10a6b69a81bac09072a536ce9d35dd43");
+
+            struct s2n_client_hello *client_hello = NULL;
+            EXPECT_OK(s2n_client_hello_from_raw(&client_hello, server,
+                    raw_client_hello, sizeof(raw_client_hello)));
+
+            uint32_t output_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_string(client_hello,
+                    S2N_FINGERPRINT_JA3, sizeof(output_mem), output_mem, &output_size));
+            EXPECT_EQUAL(strlen(expected_ja3), output_size);
+            EXPECT_BYTEARRAY_EQUAL(expected_ja3, output_mem, output_size);
+
+            uint32_t str_size = 0;
+            EXPECT_SUCCESS(s2n_client_hello_get_fingerprint_hash(client_hello,
+                    S2N_FINGERPRINT_JA3, sizeof(output_mem), output_mem, &output_size,
+                    &str_size));
+            EXPECT_EQUAL(strlen(expected_ja3), str_size);
+            EXPECT_EQUAL(expected_hash.size, output_size);
+            EXPECT_BYTEARRAY_EQUAL(expected_hash.data, output_mem, output_size);
+        };
+    };
+
+    END_TEST();
+}

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -727,7 +727,7 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
     return 0;
 }
 
-static int s2n_client_hello_get_parsed_extension(s2n_tls_extension_type extension_type,
+int s2n_client_hello_get_parsed_extension(s2n_tls_extension_type extension_type,
         s2n_parsed_extensions_list *parsed_extension_list, s2n_parsed_extension **parsed_extension)
 {
     POSIX_ENSURE_REF(parsed_extension_list);

--- a/tls/s2n_client_hello.h
+++ b/tls/s2n_client_hello.h
@@ -63,5 +63,7 @@ ssize_t s2n_client_hello_get_raw_message(struct s2n_client_hello *ch, uint8_t *o
 ssize_t s2n_client_hello_get_cipher_suites_length(struct s2n_client_hello *ch);
 ssize_t s2n_client_hello_get_cipher_suites(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);
 
+int s2n_client_hello_get_parsed_extension(s2n_tls_extension_type extension_type,
+        s2n_parsed_extensions_list *parsed_extension_list, s2n_parsed_extension **parsed_extension);
 ssize_t s2n_client_hello_get_extensions_length(struct s2n_client_hello *ch);
 ssize_t s2n_client_hello_get_extensions(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);

--- a/tls/s2n_fingerprint.c
+++ b/tls/s2n_fingerprint.c
@@ -31,14 +31,14 @@
 /* UINT16_MAX == 65535 */
 #define S2N_UINT16_STR_MAX_SIZE 5
 
-// clang-format off
+/* clang-format off */
 const bool s2n_grease_values[] = {
         [0x0A] = true, [0x1A] = true, [0x2A] = true, [0x3A] = true,
         [0x4A] = true, [0x5A] = true, [0x6A] = true, [0x7A] = true,
         [0x8A] = true, [0x9A] = true, [0xAA] = true, [0xBA] = true,
         [0xCA] = true, [0xDA] = true, [0xEA] = true, [0xFA] = true,
 };
-// clang-format on
+/* clang-format on */
 
 /* Both bytes of a GREASE IANA value will be identical, and will
  * match one of the values in s2n_grease_values.

--- a/tls/s2n_fingerprint.c
+++ b/tls/s2n_fingerprint.c
@@ -283,11 +283,11 @@ int s2n_client_hello_get_fingerprint_hash(struct s2n_client_hello *ch, s2n_finge
      */
     DEFER_CLEANUP(struct s2n_hash_state md5_hash = { 0 }, s2n_hash_free);
     POSIX_GUARD(s2n_hash_new(&md5_hash));
-    POSIX_GUARD(s2n_hash_init(&md5_hash, S2N_HASH_MD5));
     if (s2n_is_in_fips_mode()) {
         /* This hash is unrelated to TLS and does not affect FIPS */
         POSIX_GUARD(s2n_hash_allow_md5_for_fips(&md5_hash));
     }
+    POSIX_GUARD(s2n_hash_init(&md5_hash, S2N_HASH_MD5));
 
     POSIX_GUARD_RESULT(s2n_fingerprint_ja3(ch, &string_stuffer, hash_size, &md5_hash));
     POSIX_GUARD_RESULT(s2n_fingerprint_hash_flush(&md5_hash, &string_stuffer));

--- a/tls/s2n_fingerprint.c
+++ b/tls/s2n_fingerprint.c
@@ -1,0 +1,323 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tls/s2n_fingerprint.h"
+
+#include "crypto/s2n_fips.h"
+#include "crypto/s2n_hash.h"
+#include "stuffer/s2n_stuffer.h"
+#include "tls/extensions/s2n_extension_list.h"
+#include "tls/s2n_client_hello.h"
+#include "tls/s2n_crypto_constants.h"
+#include "utils/s2n_blob.h"
+#include "utils/s2n_result.h"
+#include "utils/s2n_safety.h"
+
+#define S2N_JA3_FIELD_DIV ','
+#define S2N_JA3_LIST_DIV  '-'
+
+/* UINT16_MAX == 65535 */
+#define S2N_UINT16_STR_MAX_SIZE 5
+
+// clang-format off
+const bool s2n_grease_values[] = {
+        [0x0A] = true, [0x1A] = true, [0x2A] = true, [0x3A] = true,
+        [0x4A] = true, [0x5A] = true, [0x6A] = true, [0x7A] = true,
+        [0x8A] = true, [0x9A] = true, [0xAA] = true, [0xBA] = true,
+        [0xCA] = true, [0xDA] = true, [0xEA] = true, [0xFA] = true,
+};
+// clang-format on
+
+/* Both bytes of a GREASE IANA value will be identical, and will
+ * match one of the values in s2n_grease_values.
+ *
+ * See https://datatracker.ietf.org/doc/html/rfc8701
+ */
+static S2N_RESULT s2n_assert_grease_value(uint16_t val)
+{
+    uint8_t byte1 = val >> 8;
+    uint8_t byte2 = val & 0x00FF;
+    RESULT_ENSURE_EQ(byte1, byte2);
+    RESULT_ENSURE_LT(byte1, s2n_array_len(s2n_grease_values));
+    RESULT_ENSURE_EQ(s2n_grease_values[byte1], true);
+    return S2N_RESULT_OK;
+}
+
+static bool s2n_is_grease_value(uint16_t val)
+{
+    return s2n_result_is_ok(s2n_assert_grease_value(val));
+}
+
+static S2N_RESULT s2n_fingerprint_hash_flush(struct s2n_hash_state *hash, struct s2n_stuffer *in)
+{
+    if (hash == NULL) {
+        RESULT_BAIL(S2N_ERR_INSUFFICIENT_MEM_SIZE);
+    }
+
+    uint32_t hash_data_len = s2n_stuffer_data_available(in);
+    uint8_t *hash_data = s2n_stuffer_raw_read(in, hash_data_len);
+    RESULT_ENSURE_REF(hash_data);
+    RESULT_GUARD_POSIX(s2n_hash_update(hash, hash_data, hash_data_len));
+    RESULT_GUARD_POSIX(s2n_stuffer_wipe(in));
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_fingerprint_write_char(struct s2n_stuffer *stuffer,
+        char c, struct s2n_hash_state *hash)
+{
+    if (s2n_stuffer_space_remaining(stuffer) < 1) {
+        RESULT_GUARD(s2n_fingerprint_hash_flush(hash, stuffer));
+    }
+    RESULT_GUARD_POSIX(s2n_stuffer_write_char(stuffer, c));
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_fingerprint_write_entry(struct s2n_stuffer *stuffer,
+        bool *is_list, uint16_t value, struct s2n_hash_state *hash)
+{
+    RESULT_ENSURE_REF(is_list);
+    if (*is_list) {
+        RESULT_GUARD(s2n_fingerprint_write_char(stuffer, S2N_JA3_LIST_DIV, hash));
+    }
+    *is_list = true;
+
+    /* snprintf always appends an '\0' to the output,
+     * but that extra '\0' is not included in the return value */
+    uint8_t entry[S2N_UINT16_STR_MAX_SIZE + 1] = { 0 };
+    int written = snprintf((char *) entry, sizeof(entry), "%i", value);
+    RESULT_ENSURE_GT(written, 0);
+    RESULT_ENSURE_LTE(written, S2N_UINT16_STR_MAX_SIZE);
+
+    if (s2n_stuffer_space_remaining(stuffer) < written) {
+        RESULT_GUARD(s2n_fingerprint_hash_flush(hash, stuffer));
+    }
+    RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(stuffer, entry, written));
+
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_fingerprint_write_version(struct s2n_client_hello *ch,
+        struct s2n_stuffer *output, struct s2n_hash_state *hash)
+{
+    RESULT_ENSURE_REF(ch);
+    bool is_list = false;
+    uint16_t version = 0;
+    struct s2n_stuffer message = { 0 };
+    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&message, &ch->raw_message));
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&message, &version));
+    RESULT_GUARD(s2n_fingerprint_write_entry(output, &is_list, version, hash));
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_fingerprint_write_ciphers(struct s2n_client_hello *ch,
+        struct s2n_stuffer *output, struct s2n_hash_state *hash)
+{
+    RESULT_ENSURE_REF(ch);
+
+    bool cipher_found = false;
+    struct s2n_stuffer ciphers = { 0 };
+    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&ciphers, &ch->cipher_suites));
+    while (s2n_stuffer_data_available(&ciphers)) {
+        uint16_t cipher = 0;
+        RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&ciphers, &cipher));
+        if (s2n_is_grease_value(cipher)) {
+            continue;
+        }
+        RESULT_GUARD(s2n_fingerprint_write_entry(output, &cipher_found, cipher, hash));
+    }
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_fingerprint_write_extensions(struct s2n_client_hello *ch,
+        struct s2n_stuffer *output, struct s2n_hash_state *hash)
+{
+    RESULT_ENSURE_REF(ch);
+
+    /* We have to use the raw extensions instead of the parsed extensions
+     * because s2n-tls both intentionally ignores any unknown extensions
+     * and reorders the extensions when parsing the list.
+     */
+    struct s2n_stuffer extensions = { 0 };
+    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&extensions, &ch->extensions.raw));
+
+    bool extension_found = false;
+    while (s2n_stuffer_data_available(&extensions)) {
+        uint16_t extension = 0, extension_size = 0;
+        RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&extensions, &extension));
+        RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&extensions, &extension_size));
+        RESULT_GUARD_POSIX(s2n_stuffer_skip_read(&extensions, extension_size));
+        if (s2n_is_grease_value(extension)) {
+            continue;
+        }
+        RESULT_GUARD(s2n_fingerprint_write_entry(output, &extension_found, extension, hash));
+    }
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_fingerprint_write_elliptic_curves(struct s2n_client_hello *ch,
+        struct s2n_stuffer *output, struct s2n_hash_state *hash)
+{
+    RESULT_ENSURE_REF(ch);
+
+    s2n_parsed_extension *elliptic_curves_extension = NULL;
+    int result = s2n_client_hello_get_parsed_extension(S2N_EXTENSION_SUPPORTED_GROUPS,
+            &ch->extensions, &elliptic_curves_extension);
+    if (result != S2N_SUCCESS) {
+        return S2N_RESULT_OK;
+    }
+
+    struct s2n_stuffer elliptic_curves = { 0 };
+    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&elliptic_curves,
+            &elliptic_curves_extension->extension));
+
+    uint16_t count = 0;
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&elliptic_curves, &count));
+
+    bool curve_found = false;
+    while (s2n_stuffer_data_available(&elliptic_curves)) {
+        uint16_t curve = 0;
+        RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&elliptic_curves, &curve));
+        if (s2n_is_grease_value(curve)) {
+            continue;
+        }
+        RESULT_GUARD(s2n_fingerprint_write_entry(output, &curve_found, curve, hash));
+    }
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_fingerprint_write_point_formats(struct s2n_client_hello *ch,
+        struct s2n_stuffer *output, struct s2n_hash_state *hash)
+{
+    RESULT_ENSURE_REF(ch);
+
+    s2n_parsed_extension *point_formats_extension = NULL;
+    int result = s2n_client_hello_get_parsed_extension(S2N_EXTENSION_EC_POINT_FORMATS,
+            &ch->extensions, &point_formats_extension);
+    if (result != S2N_SUCCESS) {
+        return S2N_RESULT_OK;
+    }
+
+    struct s2n_stuffer point_formats = { 0 };
+    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&point_formats,
+            &point_formats_extension->extension));
+
+    uint8_t count = 0;
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(&point_formats, &count));
+
+    bool format_found = false;
+    while (s2n_stuffer_data_available(&point_formats)) {
+        uint8_t format = 0;
+        RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(&point_formats, &format));
+        RESULT_GUARD(s2n_fingerprint_write_entry(output, &format_found, format, hash));
+    }
+    return S2N_RESULT_OK;
+}
+
+/* JA3 involves concatenating a set of fields from the ClientHello:
+ *      SSLVersion,Cipher,SSLExtension,EllipticCurve,EllipticCurvePointFormat
+ * For example:
+ *      769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0
+ * See https://github.com/salesforce/ja3
+ */
+static S2N_RESULT s2n_fingerprint_ja3(struct s2n_client_hello *ch,
+        struct s2n_stuffer *output, uint32_t *output_size, struct s2n_hash_state *hash)
+{
+    RESULT_ENSURE_REF(ch);
+    RESULT_ENSURE(!ch->sslv2, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+
+    RESULT_GUARD(s2n_fingerprint_write_version(ch, output, hash));
+    RESULT_GUARD(s2n_fingerprint_write_char(output, S2N_JA3_FIELD_DIV, hash));
+    RESULT_GUARD(s2n_fingerprint_write_ciphers(ch, output, hash));
+    RESULT_GUARD(s2n_fingerprint_write_char(output, S2N_JA3_FIELD_DIV, hash));
+    RESULT_GUARD(s2n_fingerprint_write_extensions(ch, output, hash));
+    RESULT_GUARD(s2n_fingerprint_write_char(output, S2N_JA3_FIELD_DIV, hash));
+    RESULT_GUARD(s2n_fingerprint_write_elliptic_curves(ch, output, hash));
+    RESULT_GUARD(s2n_fingerprint_write_char(output, S2N_JA3_FIELD_DIV, hash));
+    RESULT_GUARD(s2n_fingerprint_write_point_formats(ch, output, hash));
+
+    return S2N_RESULT_OK;
+}
+
+int s2n_client_hello_get_fingerprint_hash(struct s2n_client_hello *ch, s2n_fingerprint_type type,
+        uint32_t max_hash_size, uint8_t *hash, uint32_t *hash_size, uint32_t *str_size)
+{
+    POSIX_ENSURE(type == S2N_FINGERPRINT_JA3, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE(max_hash_size >= MD5_DIGEST_LENGTH, S2N_ERR_INSUFFICIENT_MEM_SIZE);
+    POSIX_ENSURE_REF(hash);
+    POSIX_ENSURE_REF(hash_size);
+    POSIX_ENSURE_REF(str_size);
+    *hash_size = 0;
+    *str_size = 0;
+
+    /* The maximum size of the JA3 string is variable and could theoretically
+     * be extremely large. However, we don't need enough memory to hold the full
+     * string when calculating a hash. We can calculate and add the JA3 string
+     * to the hash in chunks, similarly to how the TLS transcript hash is
+     * calculated by adding handshake messages to the hash as they become
+     * available. After a chunk is added to the hash, the string buffer can be
+     * wiped and reused for the next chunk.
+     *
+     * The size of this buffer was chosen fairly arbitrarily.
+     */
+    uint8_t string_mem[50] = { 0 };
+    struct s2n_blob string_blob = { 0 };
+    struct s2n_stuffer string_stuffer = { 0 };
+    POSIX_GUARD(s2n_blob_init(&string_blob, string_mem, sizeof(string_mem)));
+    POSIX_GUARD(s2n_stuffer_init(&string_stuffer, &string_blob));
+
+    /* JA3 uses an MD5 hash.
+     * The hash doesn't have to be cryptographically secure,
+     * so the weakness of MD5 shouldn't be a problem.
+     */
+    DEFER_CLEANUP(struct s2n_hash_state md5_hash = { 0 }, s2n_hash_free);
+    POSIX_GUARD(s2n_hash_new(&md5_hash));
+    POSIX_GUARD(s2n_hash_init(&md5_hash, S2N_HASH_MD5));
+    if (s2n_is_in_fips_mode()) {
+        /* This hash is unrelated to TLS and does not affect FIPS */
+        POSIX_GUARD(s2n_hash_allow_md5_for_fips(&md5_hash));
+    }
+
+    POSIX_GUARD_RESULT(s2n_fingerprint_ja3(ch, &string_stuffer, hash_size, &md5_hash));
+    POSIX_GUARD_RESULT(s2n_fingerprint_hash_flush(&md5_hash, &string_stuffer));
+
+    uint64_t in_hash = 0;
+    POSIX_GUARD(s2n_hash_get_currently_in_hash_total(&md5_hash, &in_hash));
+    POSIX_ENSURE_LTE(in_hash, UINT32_MAX);
+    *str_size = in_hash;
+
+    POSIX_GUARD(s2n_hash_digest(&md5_hash, hash, MD5_DIGEST_LENGTH));
+    *hash_size = MD5_DIGEST_LENGTH;
+    return S2N_SUCCESS;
+}
+
+int s2n_client_hello_get_fingerprint_string(struct s2n_client_hello *ch, s2n_fingerprint_type type,
+        uint32_t max_size, uint8_t *output, uint32_t *output_size)
+{
+    POSIX_ENSURE(type == S2N_FINGERPRINT_JA3, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE(max_size > 0, S2N_ERR_INSUFFICIENT_MEM_SIZE);
+    POSIX_ENSURE_REF(output);
+    POSIX_ENSURE_REF(output_size);
+    *output_size = 0;
+
+    struct s2n_blob output_blob = { 0 };
+    struct s2n_stuffer output_stuffer = { 0 };
+    POSIX_GUARD(s2n_blob_init(&output_blob, output, max_size));
+    POSIX_GUARD(s2n_stuffer_init(&output_stuffer, &output_blob));
+
+    POSIX_GUARD_RESULT(s2n_fingerprint_ja3(ch, &output_stuffer, output_size, NULL));
+    *output_size = s2n_stuffer_data_available(&output_stuffer);
+
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_fingerprint.h
+++ b/tls/s2n_fingerprint.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "api/s2n.h"
+
+typedef enum {
+    S2N_FINGERPRINT_JA3,
+} s2n_fingerprint_type;
+
+int s2n_client_hello_get_fingerprint_hash(struct s2n_client_hello *ch, s2n_fingerprint_type type, uint32_t max_hash_size,
+        uint8_t *hash, uint32_t *hash_size, uint32_t *str_size);
+int s2n_client_hello_get_fingerprint_string(struct s2n_client_hello *ch, s2n_fingerprint_type type, uint32_t max_size,
+        uint8_t *output, uint32_t *output_size);


### PR DESCRIPTION
### Description of changes: 

Add JA3 fingerprinting functionality. For now, it's not publicly accessible.

JA3 is a method for identifying clients. See this blog post from its creator: https://engineering.salesforce.com/tls-fingerprinting-with-ja3-and-ja3s-247362855967/

We provide two methods, one to retrieve the full JA3 string and one to retrieve just the hash of the JA3 string. While the hash should be sufficient to identify a client, some customers have requested access to the full JA3 string. 

### Callouts

* For now, the API will error for SSLv2 ClientHellos. Clients would only send SSLv2 ClientHellos if they're unsure whether a server supports SSLv3 or higher. Since SSLv3 was released in 1996 and deprecated in 2015, I imagine we can live without SSLv2 support. If not, we can add it, but it complicates some of the parsing. SSLv2 JA3s also likely won't be particularly useful, since the only fields available are the protocol version and the cipher suites.
* If a customer wants both the full string and the hash, we calculate the JA3 string twice, once for each API call. But at least there's some benefit from this duplicate work: we can calculate the length of the JA3 string while calculating the hash, allowing a customer to allocate the correct amount of memory for the variable-length JA3 string.
* I didn't end up managing to reuse nearly as much of our parsing as I'd hoped. Luckily, most of the parsing we do is pretty simple.

### Testing:

I wrote unit tests and a small number of known value tests.

In the future, I'd like to add fuzzing and call the API in s2nd so that it gets run for all the integration tests. Let me know if you have other testing ideas!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
