### PR TITLE
Bump rust bindings for 1.3.36 release

### DIFF
--- a/bindings/rust/s2n-tls-sys/Cargo.toml
+++ b/bindings/rust/s2n-tls-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-sys"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.0.24"
+version = "0.0.25"
 authors = ["AWS s2n"]
 edition = "2021"
 links = "s2n-tls"

--- a/bindings/rust/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/s2n-tls-tokio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-tokio"
 description = "An implementation of TLS streams for Tokio built on top of s2n-tls"
-version = "0.0.24"
+version = "0.0.25"
 authors = ["AWS s2n"]
 edition = "2021"
 repository = "https://github.com/aws/s2n-tls"
@@ -14,7 +14,7 @@ default = []
 errno = { version = "0.2" }
 libc = { version = "0.2" }
 pin-project-lite = { version = "0.2" }
-s2n-tls = { version = "=0.0.24", path = "../s2n-tls" }
+s2n-tls = { version = "=0.0.25", path = "../s2n-tls" }
 tokio = { version = "1", features = ["net", "time"] }
 
 [dev-dependencies]

--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.0.24"
+version = "0.0.25"
 authors = ["AWS s2n"]
 edition = "2021"
 repository = "https://github.com/aws/s2n-tls"
@@ -17,7 +17,7 @@ testing = ["bytes"]
 bytes = { version = "1", optional = true }
 errno = { version = "0.2" }
 libc = "0.2"
-s2n-tls-sys = { version = "=0.0.24", path = "../s2n-tls-sys", features = ["internal"] }
+s2n-tls-sys = { version = "=0.0.25", path = "../s2n-tls-sys", features = ["internal"] }
 pin-project-lite = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

Bumps the rust bindings versions for the 1.3.36 release.

### Call-outs:

None

### Testing:

None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
