### PR TITLE
test: cleanup after tests

### DIFF
--- a/tests/unit/s2n_cert_status_response_extension_test.c
+++ b/tests/unit/s2n_cert_status_response_extension_test.c
@@ -18,9 +18,8 @@
 #include "tls/extensions/s2n_cert_status_response.h"
 
 const uint8_t ocsp_data[] = "OCSP DATA";
-struct s2n_cert_chain_and_key *chain_and_key;
 
-int s2n_test_enable_sending_extension(struct s2n_connection *conn)
+int s2n_test_enable_sending_extension(struct s2n_connection *conn, struct s2n_cert_chain_and_key *chain_and_key)
 {
     conn->mode = S2N_SERVER;
     conn->status_type = S2N_STATUS_REQUEST_OCSP;
@@ -34,6 +33,7 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
+    DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = NULL, s2n_cert_chain_and_key_ptr_free);
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
             S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
 
@@ -50,26 +50,26 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_cert_status_response_extension.should_send(conn));
 
         /* Send if all prerequisites met */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         EXPECT_TRUE(s2n_cert_status_response_extension.should_send(conn));
 
         /* Don't send if client */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         conn->mode = S2N_CLIENT;
         EXPECT_FALSE(s2n_cert_status_response_extension.should_send(conn));
 
         /* Don't send if no status request configured */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         conn->status_type = S2N_STATUS_REQUEST_NONE;
         EXPECT_FALSE(s2n_cert_status_response_extension.should_send(conn));
 
         /* Don't send if no certificate set */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         conn->handshake_params.our_chain_and_key = NULL;
         EXPECT_FALSE(s2n_cert_status_response_extension.should_send(conn));
 
         /* Don't send if no ocsp data */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         EXPECT_SUCCESS(s2n_free(&conn->handshake_params.our_chain_and_key->ocsp_status));
         EXPECT_FALSE(s2n_cert_status_response_extension.should_send(conn));
 

--- a/tests/unit/s2n_fragmentation_coalescing_test.c
+++ b/tests/unit/s2n_fragmentation_coalescing_test.c
@@ -435,7 +435,7 @@ int main(int argc, char **argv)
         fragmented_message(p[1]);
         EXPECT_SUCCESS(s2n_config_free(config));
         EXPECT_SUCCESS(s2n_connection_free(conn));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -481,7 +481,7 @@ int main(int argc, char **argv)
         coalesced_message(p[1]);
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -527,7 +527,7 @@ int main(int argc, char **argv)
         interleaved_message(p[1]);
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -573,7 +573,7 @@ int main(int argc, char **argv)
         interleaved_fragmented_warning_alert(p[1]);
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -619,7 +619,7 @@ int main(int argc, char **argv)
         interleaved_fragmented_fatal_alert(p[1]);
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */

--- a/tests/unit/s2n_malformed_handshake_test.c
+++ b/tests/unit/s2n_malformed_handshake_test.c
@@ -227,8 +227,6 @@ void send_messages(int write_fd, uint8_t *server_hello, uint32_t server_hello_le
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
-    struct s2n_config *config;
     s2n_blocked_status blocked;
     int status;
     pid_t pid;
@@ -237,8 +235,8 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-    EXPECT_NOT_NULL(config = s2n_config_new());
+    DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+    DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
     EXPECT_SUCCESS(s2n_config_disable_x509_verification(config));
     EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all"));
     EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -270,7 +268,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -319,7 +317,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -368,7 +366,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -417,7 +415,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -466,7 +464,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -515,7 +513,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));
-        _exit(0);
+        exit(0);
     }
 
     /* This is the parent process, close the write end of the pipe */
@@ -536,8 +534,6 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(waitpid(pid, &status, 0), pid);
     EXPECT_EQUAL(status, 0);
     EXPECT_SUCCESS(close(p[0]));
-    EXPECT_SUCCESS(s2n_connection_free(conn));
-    EXPECT_SUCCESS(s2n_config_free(config));
 
     END_TEST();
 }

--- a/tests/unit/s2n_override_openssl_random_test.c
+++ b/tests/unit/s2n_override_openssl_random_test.c
@@ -129,6 +129,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_dh_params_free(&dh_params));
     EXPECT_SUCCESS(s2n_stuffer_free(&dhparams_out));
     EXPECT_SUCCESS(s2n_stuffer_free(&dhparams_in));
+    EXPECT_SUCCESS(s2n_stuffer_free(&test_entropy));
     free(dhparams_pem);
 
     END_TEST();

--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -329,7 +329,7 @@ static void s2n_fork_test_generate_randomness(int write_fd, S2N_RESULT (*s2n_get
 
     /* Close the pipe and exit */
     close(write_fd);
-    _exit(EXIT_SUCCESS);
+    exit(EXIT_SUCCESS);
 }
 
 static S2N_RESULT s2n_fork_test_verify_result(int *pipes, int proc_id, S2N_RESULT (*s2n_get_random_data_cb)(struct s2n_blob *blob))

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -83,7 +83,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
     s2n_io_pair_shutdown_one_end(io_pair, S2N_CLIENT, SHUT_WR);
 
-    _exit(0);
+    exit(0);
 }
 
 int main(int argc, char **argv)

--- a/tests/unit/s2n_self_talk_custom_io_test.c
+++ b/tests/unit/s2n_self_talk_custom_io_test.c
@@ -46,7 +46,7 @@ int mock_client(struct s2n_test_io_pair *io_pair)
 
     result = s2n_negotiate(conn, &blocked);
     if (result < 0) {
-        _exit(1);
+        exit(1);
     }
 
     s2n_shutdown(conn, &blocked);
@@ -55,7 +55,7 @@ int mock_client(struct s2n_test_io_pair *io_pair)
     s2n_cleanup();
     s2n_io_pair_close_one_end(io_pair, S2N_CLIENT);
 
-    _exit(0);
+    exit(0);
 }
 
 int main(int argc, char **argv)
@@ -68,28 +68,12 @@ int main(int argc, char **argv)
      * from the stuffers.
      */
     {
-        struct s2n_connection *conn;
-        struct s2n_config *config;
         s2n_blocked_status blocked;
         int status;
         pid_t pid;
         char *cert_chain_pem;
         char *private_key_pem;
         char *dhparams_pem;
-        struct s2n_cert_chain_and_key *chain_and_key;
-        struct s2n_stuffer in, out;
-
-        EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_NOT_NULL(dhparams_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_DHPARAMS, dhparams_pem, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-        EXPECT_SUCCESS(s2n_config_add_dhparams(config, dhparams_pem));
 
         /* For convenience, this test will intentionally try to write to closed pipes during shutdown. Ignore the signal to
         * avoid exiting the process on SIGPIPE.
@@ -106,20 +90,32 @@ int main(int argc, char **argv)
             /* This is the client process, close the server end of the pipe */
             EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
 
-            /* Free the config */
-            EXPECT_SUCCESS(s2n_config_free(config));
-            free(cert_chain_pem);
-            free(private_key_pem);
-            free(dhparams_pem);
-
             /* Run the client */
             mock_client(&io_pair);
         }
 
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(),
+                s2n_config_ptr_free);
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = s2n_cert_chain_and_key_new(),
+                s2n_cert_chain_and_key_ptr_free);
+        DEFER_CLEANUP(struct s2n_stuffer in, s2n_stuffer_free);
+        DEFER_CLEANUP(struct s2n_stuffer out, s2n_stuffer_free);
+
+        EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(dhparams_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_DHPARAMS, dhparams_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+        EXPECT_SUCCESS(s2n_config_add_dhparams(config, dhparams_pem));
+
         /* This is the server process, close the client end of the pipe */
         EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));
 
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
         EXPECT_FAILURE(s2n_connection_use_corked_io(conn));
@@ -162,16 +158,10 @@ int main(int argc, char **argv)
             s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out), NULL);
         } while (!server_shutdown);
 
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-
         /* Clean up */
-        EXPECT_SUCCESS(s2n_stuffer_free(&in));
-        EXPECT_SUCCESS(s2n_stuffer_free(&out));
         EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
         EXPECT_EQUAL(status, 0);
         EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
-        EXPECT_SUCCESS(s2n_config_free(config));
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
         free(cert_chain_pem);
         free(private_key_pem);
         free(dhparams_pem);

--- a/tests/unit/s2n_self_talk_min_protocol_version_test.c
+++ b/tests/unit/s2n_self_talk_min_protocol_version_test.c
@@ -57,36 +57,26 @@ int mock_client(struct s2n_test_io_pair *io_pair, uint8_t version)
     s2n_cleanup();
 
     /* Expect failure of handshake */
-    _exit(result == 0 ? 1 : 0);
+    exit(result == 0 ? 1 : 0);
 }
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
-    struct s2n_config *config;
     s2n_blocked_status blocked;
     int status;
     pid_t pid;
     char cert_chain_pem[S2N_MAX_TEST_PEM_SIZE];
     char private_key_pem[S2N_MAX_TEST_PEM_SIZE];
-    struct s2n_cert_chain_and_key *chain_and_key;
 
     BEGIN_TEST();
 
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
-    EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
 
     /* TLS1.2 and TLS1.3 have different version negotiation mechanisms.
      * We should test both.
      */
     for (uint8_t version = S2N_TLS12; version <= S2N_TLS13; version++) {
-        EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-        /* Pick cipher preference with TLSv1.2 as a minimum version */
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "CloudFront-TLS-1-2-2019"));
-
         /* Create a pipe */
         struct s2n_test_io_pair io_pair;
         EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
@@ -101,10 +91,21 @@ int main(int argc, char **argv)
             mock_client(&io_pair, version);
         }
 
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(),
+                s2n_config_ptr_free);
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = s2n_cert_chain_and_key_new(),
+                s2n_cert_chain_and_key_ptr_free);
+
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+        /* Pick cipher preference with TLSv1.2 as a minimum version */
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "CloudFront-TLS-1-2-2019"));
+
         /* This is the server process, close the client end of the pipe */
         EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));
 
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
         EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
 
@@ -117,19 +118,13 @@ int main(int argc, char **argv)
         /* Check that blinding was not invoked */
         EXPECT_EQUAL(s2n_connection_get_delay(conn), 0);
 
-        /* Free connection */
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-
         /* Close the pipes */
         EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
 
         /* Clean up */
         EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
         EXPECT_EQUAL(status, 0);
-
-        EXPECT_SUCCESS(s2n_config_free(config));
     }
 
-    EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
     END_TEST();
 }

--- a/tests/unit/s2n_self_talk_session_id_test.c
+++ b/tests/unit/s2n_self_talk_session_id_test.c
@@ -282,7 +282,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
     sleep(1);
 
     s2n_io_pair_close_one_end(io_pair, S2N_CLIENT);
-    _exit(result);
+    exit(result);
 }
 
 int main(int argc, char **argv)
@@ -310,8 +310,6 @@ int main(int argc, char **argv)
         0xcb, 0x04 };
 
     BEGIN_TEST();
-    EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
 
     /* Create a pipe */
     struct s2n_test_io_pair io_pair;
@@ -326,6 +324,9 @@ int main(int argc, char **argv)
         /* Write the fragmented hello message */
         mock_client(&io_pair);
     }
+
+    EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
 
     /* This is the server process, close the client end of the pipe */
     EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));

--- a/tests/unit/s2n_self_talk_tls12_test.c
+++ b/tests/unit/s2n_self_talk_tls12_test.c
@@ -93,7 +93,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
     s2n_io_pair_close_one_end(io_pair, S2N_CLIENT);
 
-    _exit(0);
+    exit(0);
 }
 
 int main(int argc, char **argv)
@@ -109,10 +109,6 @@ int main(int argc, char **argv)
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
-    EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_NOT_NULL(dhparams_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-
     for (int is_dh_key_exchange = 0; is_dh_key_exchange <= 1; is_dh_key_exchange++) {
         struct s2n_cert_chain_and_key *chain_and_keys[SUPPORTED_CERTIFICATE_FORMATS];
 
@@ -129,6 +125,10 @@ int main(int argc, char **argv)
             /* Write the fragmented hello message */
             mock_client(&io_pair);
         }
+
+        EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_NOT_NULL(dhparams_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
 
         /* This is the server process, close the client end of the pipe */
         EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));
@@ -195,11 +195,11 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
         EXPECT_EQUAL(status, 0);
         EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
-    }
 
-    free(cert_chain_pem);
-    free(private_key_pem);
-    free(dhparams_pem);
+        free(cert_chain_pem);
+        free(private_key_pem);
+        free(dhparams_pem);
+    }
 
     END_TEST();
     return 0;

--- a/tests/unit/s2n_self_talk_tls13_test.c
+++ b/tests/unit/s2n_self_talk_tls13_test.c
@@ -91,7 +91,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
     s2n_io_pair_close_one_end(io_pair, S2N_CLIENT);
 
-    _exit(0);
+    exit(0);
 }
 
 int main(int argc, char **argv)

--- a/tests/unit/s2n_server_sct_list_extension_test.c
+++ b/tests/unit/s2n_server_sct_list_extension_test.c
@@ -18,9 +18,8 @@
 #include "tls/extensions/s2n_server_sct_list.h"
 
 const uint8_t sct_list_data[] = "SCT LIST DATA";
-struct s2n_cert_chain_and_key *chain_and_key;
 
-int s2n_test_enable_sending_extension(struct s2n_connection *conn)
+int s2n_test_enable_sending_extension(struct s2n_connection *conn, struct s2n_cert_chain_and_key *chain_and_key)
 {
     conn->mode = S2N_SERVER;
     conn->ct_level_requested = S2N_CT_SUPPORT_REQUEST;
@@ -34,6 +33,7 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
+    DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = NULL, s2n_cert_chain_and_key_ptr_free);
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
             S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
 
@@ -50,26 +50,26 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_server_sct_list_extension.should_send(conn));
 
         /* Send if all prerequisites met */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         EXPECT_TRUE(s2n_server_sct_list_extension.should_send(conn));
 
         /* Don't send if client */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         conn->mode = S2N_CLIENT;
         EXPECT_FALSE(s2n_server_sct_list_extension.should_send(conn));
 
         /* Don't send if certificate transparency not requested */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         conn->ct_level_requested = S2N_CT_SUPPORT_NONE;
         EXPECT_FALSE(s2n_server_sct_list_extension.should_send(conn));
 
         /* Don't send if no certificate set */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         conn->handshake_params.our_chain_and_key = NULL;
         EXPECT_FALSE(s2n_server_sct_list_extension.should_send(conn));
 
         /* Don't send if no ocsp data */
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
         EXPECT_SUCCESS(s2n_free(&conn->handshake_params.our_chain_and_key->sct_list));
         EXPECT_FALSE(s2n_server_sct_list_extension.should_send(conn));
 
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
     {
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
 
         struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
     {
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn));
+        EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
 
         struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));

--- a/tests/unit/s2n_tls_hybrid_prf_test.c
+++ b/tests/unit/s2n_tls_hybrid_prf_test.c
@@ -119,5 +119,6 @@ int main(int argc, char **argv)
         FAIL_MSG("Found unexpected test vectors in the KAT file. Has the KAT file been changed? Did you update NUM_TEST_VECTORS?");
     }
 
+    fclose(kat_file);
     END_TEST();
 }


### PR DESCRIPTION
This PR is part of a large effort to enable pedantic Valgrind (https://github.com/aws/s2n-tls/pull/3511). Tracking issue:  https://github.com/aws/s2n-tls/issues/3758

### Description of changes: 
In this PR we do some additional cleanup so that resources dont leak.

- The `cleanup()` function (DEFER_CLEANUP) doesnt get called if the process [exists abruptly](https://godbolt.org/z/fb3hc4xYM). Therefore I move memory allocation for config, connection and other resources after the call to `fork`; while trying to keep the diff to a minimum.

- We need to call `exit` instead of [_exit](https://man7.org/linux/man-pages/man2/exit.2.html) so that each process invokes the atexit callback.
> The function _exit() is like exit(3), but does not call any functions registered with atexit(3) ...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
