### PR TITLE
test: cleanup tests

### DIFF
--- a/tests/unit/s2n_self_talk_alpn_test.c
+++ b/tests/unit/s2n_self_talk_alpn_test.c
@@ -97,7 +97,7 @@ int mock_client(int writefd, int readfd, const char **protocols, int count, cons
 
     s2n_cleanup();
 
-    _exit(result);
+    exit(result);
 }
 
 int main(int argc, char **argv)

--- a/tests/unit/s2n_self_talk_nonblocking_test.c
+++ b/tests/unit/s2n_self_talk_nonblocking_test.c
@@ -198,7 +198,9 @@ int test_send(int use_tls13, int use_iov, int prefer_throughput)
     s2n_blocked_status blocked;
     int status;
     pid_t pid;
-    char *cert_chain_pem, *private_key_pem, *dhparams_pem;
+    char cert_chain_pem[S2N_MAX_TEST_PEM_SIZE];
+    char private_key_pem[S2N_MAX_TEST_PEM_SIZE];
+    char dhparams_pem[S2N_MAX_TEST_PEM_SIZE];
 
     /* Get some random data to send/receive */
     uint32_t data_size = 0;
@@ -256,10 +258,6 @@ int test_send(int use_tls13, int use_iov, int prefer_throughput)
         EXPECT_OK(cleanup_io_data(&iov, iov_size, &blob));
         exit(client_rc);
     }
-
-    EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-    EXPECT_NOT_NULL(dhparams_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
 
     DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
     DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
@@ -377,9 +375,6 @@ int test_send(int use_tls13, int use_iov, int prefer_throughput)
     /* Clean up */
     EXPECT_OK(cleanup_io_data(&iov, iov_size, &blob));
     EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
-    free(cert_chain_pem);
-    free(private_key_pem);
-    free(dhparams_pem);
 
     return 0;
 }


### PR DESCRIPTION
This PR is part of a large effort to enable pedantic Valgrind. Tracking issue: https://github.com/aws/s2n-tls/issues/3758

This continues the effort from the [previous PR](https://github.com/aws/s2n-tls/pull/3831) to cleanup resources, however these files required a bit more refactoring than the prior PR.

The tenets remain similar:
- keep change to minimum
- avoid extra calls to free (move init/alloc after call to fork)
- simplify where possible (use DEFER when it made sense)


### Description of changes: 
In this PR we do some additional cleanup so that resources dont leak.

- The `cleanup()` function (DEFER_CLEANUP) doesnt get called if the process [exists abruptly](https://godbolt.org/z/fb3hc4xYM). Therefore I move memory allocation for config, connection and other resources after the call to `fork`; while trying to keep the diff to a minimum.

- We need to call `exit` instead of [_exit](https://man7.org/linux/man-pages/man2/exit.2.html) so that each process invokes the atexit callback.
> The function _exit() is like exit(3), but does not call any functions registered with atexit(3) ...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.