### PR TITLE
[bindings] Generalize async in preparation for pkey offloading

### DIFF
--- a/bindings/rust/s2n-tls/src/callbacks.rs
+++ b/bindings/rust/s2n-tls/src/callbacks.rs
@@ -17,218 +17,43 @@
 //! * "sync" callbacks return an immediate result and will block the task
 //!   performing the handshake until they return success or failure. See
 //!   [`VerifyHostNameCallback`] as an example.
-//! * "async" callbacks return a [`Poll`] and should not block the task performing the handshake.
-//!   They will be polled until they return [`Poll::Ready`].
+//! * "async" callbacks return a [Poll](`core::task::Poll`) and should not block the task performing the handshake.
+//!   They will be polled until they return [Poll::Ready](`core::task::Poll::Ready`).
 //!   [Connection::waker()](`crate::connection::Connection::waker()`)
 //!   can be used to register the task for wakeup. See [`ClientHelloCallback`] as an example.
 
-use crate::{
-    config::Config,
-    connection::{Connection, InternalConnectionFuture},
-    enums::CallbackResult,
-    error::Error,
-};
-use core::{mem::ManuallyDrop, ptr::NonNull, task::Poll, time::Duration};
-use pin_project_lite::pin_project;
+use crate::{config::Context, connection::Connection};
+use core::{mem::ManuallyDrop, ptr::NonNull, time::Duration};
 use s2n_tls_sys::s2n_connection;
-use std::{future::Future, pin::Pin};
+
+mod async_cb;
+pub use async_cb::*;
+
+mod client_hello;
+pub use client_hello::*;
 
 /// Convert the connection pointer provided to a callback into a Connection
-/// useable with the Rust bindings.
+/// and Context useable with the Rust bindings.
 ///
 /// # Safety
 ///
 /// This must ONLY be used for connection pointers provided to callbacks,
 /// which can be assumed to point to valid Connections because the
 /// callbacks were configured through the Rust bindings.
-pub(crate) unsafe fn with_connection<F, T>(conn_ptr: *mut s2n_connection, action: F) -> T
+pub(crate) unsafe fn with_context<F, T>(conn_ptr: *mut s2n_connection, action: F) -> T
 where
-    F: FnOnce(&mut Connection) -> T,
+    F: FnOnce(&mut Connection, &mut Context) -> T,
 {
     let raw = NonNull::new(conn_ptr).expect("connection should not be null");
     let mut conn = Connection::from_raw(raw);
-    let r = action(&mut conn);
+    let mut config = conn.config().expect("config should not be null");
+    let context = config.context_mut();
+    let r = action(&mut conn, context);
     // Since this is a callback, it receives a pointer to the connection
     // but doesn't own that connection or control its lifecycle.
     // Do not drop / free the connection.
     let _ = ManuallyDrop::new(conn);
     r
-}
-
-/// Begins execution of an asyc callback.
-///
-/// Polls the async callback once, then registers it for later retries if
-/// necessary.
-///
-/// The C-style callback method passed to the underlying s2n-tls implementation
-/// should call this method instead of using the Rust callback implementation
-/// directly. The C-style callback will only execute once, so the underlying
-/// poll implementation should ensures that the Rust callback is polled until
-/// it completes.
-///
-/// Using [`config::set_client_hello_callback`] as an example, the execution
-/// roughly looks like:
-///
-/// Connection::poll_negotiate                                    (Rust)
-/// |   s2n_negotiate                                             (C)
-/// |   |   s2n_client_hello_cb                                   (C)
-/// |   |   |   trigger_async_client_hello_callback               (Rust)
-/// |   |   |   |   on_client_hello_callback                      (Rust)
-/// |   |   |   |   |   ClientHelloCallback::on_client_hello      (Rust)
-/// |   |   |   |   |   +-> return Ok(Some(ConnectionFuture))     (Rust)
-/// |   |   |   |   +-> return Poll::Pending                      (Rust)
-/// |   |   |   +-> return Callback::Success                      (Rust)
-/// |   |   +-> return S2N_SUCCESS                                (C)
-/// |   +-> return S2N_ERR_T_BLOCKED                              (C)
-/// +-> return Poll::Pending                                      (Rust)
-///
-/// Connection::poll_negotiate                                    (Rust)
-/// |   ConnectionFuture::poll                                    (Rust)
-/// |   +-> return Poll::Pending                                  (Rust)
-/// +-> return Poll::Pending                                      (Rust)
-///
-/// Connection::poll_negotiate                                    (Rust)
-/// |   ConnectionFuture::poll                                    (Rust)
-/// |   +-> return Poll::Ready                                    (Rust)
-/// |   s2n_negotiate                                             (C)
-/// |
-/// v   ...handshake continues.
-///
-/// Note that "s2n_client_hello_cb" is only called once.
-/// After the initial call, the retries are handled by the Rust bindings.
-/// s2n_negotiate is not called again until the callback completes.
-///
-pub(crate) fn trigger_async_client_hello_callback(conn: &mut Connection) -> CallbackResult {
-    // Try once first.
-    match on_client_hello_callback(conn) {
-        // If callback completes, no need for retry.
-        Poll::Ready(r) => r.into(),
-        // If callback doesn't complete, prepare connection for retry.
-        Poll::Pending => CallbackResult::Success,
-    }
-}
-
-/// The Future associated with the async connection callback.
-///
-/// The calling application can provide an instance of [`ConnectionFuture`]
-/// when implementing an async callback, eg. [`ClientHelloCallback`], if it wants
-/// to run an asynchronous operation (disk read, network call). The application
-/// can return an error ([`Err(error::Error::application())`]), to indicate
-/// connection failure.
-///
-/// [`ConfigResolver`] should be used if the application wants to set a new
-/// [`Config`] on the connection.
-pub trait ConnectionFuture {
-    fn poll(
-        self: Pin<&mut Self>,
-        connection: &mut Connection,
-        ctx: &mut core::task::Context,
-    ) -> Poll<Result<(), Error>>;
-}
-
-// For more information on projection:
-// https://doc.rust-lang.org/std/pin/index.html#projections-and-structural-pinning
-pin_project! {
-/// An implementation of [`ConnectionFuture`] which resolves the provided
-/// future and sets the config on the [`connection::Connection`].
-pub struct ConfigResolver<F: Future<Output = Result<Config, Error>>> {
-    #[pin]
-    fut: F,
-}
-}
-
-impl<F: Future<Output = Result<Config, Error>>> ConfigResolver<F> {
-    pub fn new(fut: F) -> Self {
-        ConfigResolver { fut }
-    }
-}
-
-// Useful for propagating [`error::Error`] from the ClientHelloCallback
-// to the Application
-struct ErrorFuture {
-    error: Option<Error>,
-}
-
-impl ConnectionFuture for ErrorFuture {
-    fn poll(
-        mut self: Pin<&mut Self>,
-        _connection: &mut Connection,
-        _ctx: &mut core::task::Context,
-    ) -> Poll<Result<(), Error>> {
-        let err = self.error.take().expect(
-            "ErrorFuture should be initialized with Some(error) and a Future should never
-            be polled after it returns Poll::Ready",
-        );
-        Poll::Ready(Err(err))
-    }
-}
-
-impl<F: Future<Output = Result<Config, Error>>> ConnectionFuture for ConfigResolver<F> {
-    fn poll(
-        self: Pin<&mut Self>,
-        connection: &mut Connection,
-        ctx: &mut core::task::Context,
-    ) -> Poll<Result<(), Error>> {
-        let this = self.project();
-        let config = match this.fut.poll(ctx) {
-            Poll::Ready(config) => config?,
-            Poll::Pending => return Poll::Pending,
-        };
-
-        connection.set_config(config)?;
-
-        Poll::Ready(Ok(()))
-    }
-}
-
-/// A trait for the callback executed after parsing the TLS Client Hello.
-///
-/// Use in conjunction with
-/// [config::Builder::set_client_hello_callback](`crate::config::Builder::set_client_hello_callback()`).
-pub trait ClientHelloCallback {
-    /// The application can return a `Ok(None)` to resolve the client_hello_callback
-    /// synchronously or return a `Ok(Some(ConnectionFuture))` if it wants to
-    /// run some asynchronous task before resolving the callback.
-    ///
-    /// [`ConfigResolver`], which implements [`ConnectionFuture`] can be
-    /// returned if the application wants to set a new [`Config`] on the connection.
-    ///
-    /// If the server_name is used to configure the connection then the application
-    /// must call [`connection::Connection::server_name_extension_used()`].
-    fn on_client_hello(
-        // this method takes an immutable reference to self to prevent the
-        // Config from being mutated by one connection and then used in another
-        // connection, leading to undefined behavior
-        &self,
-        connection: &mut Connection,
-    ) -> Result<Option<Pin<Box<dyn ConnectionFuture>>>, Error>;
-}
-
-// Calls the ClientHelloCallback and sets connection future if the application
-// provided one.
-fn on_client_hello_callback(conn: &mut Connection) -> Poll<Result<(), Error>> {
-    let async_future = conn
-        .config()
-        .as_mut()
-        .and_then(|config| config.context_mut().client_hello_callback.as_mut())
-        .and_then(|callback| callback.on_client_hello(conn).transpose());
-
-    match async_future {
-        Some(fut) => {
-            // Return a ErrorFuture and propagates the error back up to
-            // the application.
-            let fut = fut.unwrap_or_else(|err| Box::pin(ErrorFuture { error: Some(err) }));
-
-            // The callback returned a future so store it on the
-            // connection. This is Asynchronous resolution.
-            conn.set_connection_future(InternalConnectionFuture::ClientHello(fut));
-            Poll::Pending
-        }
-        None => {
-            // Done with the client_hello_callback. This is Synchronous resolution.
-            Poll::Ready(conn.mark_client_hello_cb_done())
-        }
-    }
 }
 
 /// A trait for the callback used to verify host name(s) during X509

--- a/bindings/rust/s2n-tls/src/callbacks/async_cb.rs
+++ b/bindings/rust/s2n-tls/src/callbacks/async_cb.rs
@@ -59,7 +59,6 @@ pin_project! {
     /// A wrapper around an optional [`ConnectionFuture`]
     /// which either polls the future or immediately reports success.
     struct OptionalFuture{
-        #[pin]
         option: Option<Pin<Box<dyn ConnectionFuture>>>,
     }
 }

--- a/bindings/rust/s2n-tls/src/callbacks/async_cb.rs
+++ b/bindings/rust/s2n-tls/src/callbacks/async_cb.rs
@@ -1,0 +1,155 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Support for asynchronous callbacks.
+//!
+//! The general flow for an async callback is:
+//! 1. The application sets FooCallback on the [`crate::config::Config`] with
+//!    a method like Config::set_foo_callback.
+//! 2. When the underlying C library reaches the trigger for that specific
+//!    callback (for example, the ClientHello for [`crate::callbacks::ClientHelloCallback`])
+//!    it calls the callback implementation to get a [`ConnectionFuture`].
+//! 3. The [`ConnectionFuture`] is stored on the connection. Every time
+//!    the handshake is polled, the [`ConnectionFuture`] is polled instead.
+//! 4. Once the [`ConnectionFuture`] returns a result, the connection
+//!    drops the future and proceeds as usual.
+
+use crate::{connection::Connection, enums::CallbackResult, error::Error};
+use core::task::Poll;
+use pin_project_lite::pin_project;
+use std::pin::Pin;
+
+/// The Future associated with the async connection callback.
+///
+/// The calling application can provide an instance of [`ConnectionFuture`]
+/// when implementing an async callback, eg. [`crate::callbacks::ClientHelloCallback`],
+/// if it wants to run an asynchronous operation (disk read, network call).
+/// The application can return an error ([Err(Error::application())])
+/// to indicate connection failure.
+pub trait ConnectionFuture {
+    fn poll(
+        self: Pin<&mut Self>,
+        connection: &mut Connection,
+        ctx: &mut core::task::Context,
+    ) -> Poll<Result<(), Error>>;
+}
+
+pub(crate) type ConnectionFutureResult = Result<Option<Pin<Box<dyn ConnectionFuture>>>, Error>;
+
+// Useful for propagating [`error::Error`] from a C callback back to the Rust application.
+pub(crate) struct ErrorFuture {
+    error: Option<Error>,
+}
+
+impl ConnectionFuture for ErrorFuture {
+    fn poll(
+        mut self: Pin<&mut Self>,
+        _connection: &mut Connection,
+        _ctx: &mut core::task::Context,
+    ) -> Poll<Result<(), Error>> {
+        let err = self.error.take().expect(
+            "ErrorFuture should be initialized with Some(error) and a Future should never
+            be polled after it returns Poll::Ready",
+        );
+        Poll::Ready(Err(err))
+    }
+}
+
+pin_project! {
+    /// A wrapper around an optional [`ConnectionFuture`]
+    /// which either polls the future or immediately reports success.
+    struct OptionalFuture{
+        #[pin]
+        option: Option<Pin<Box<dyn ConnectionFuture>>>,
+    }
+}
+
+impl OptionalFuture {
+    fn new(input: ConnectionFutureResult) -> Self {
+        match input {
+            Ok(option) => OptionalFuture { option },
+            Err(error) => {
+                let error = Some(error);
+                OptionalFuture {
+                    option: Some(Box::pin(ErrorFuture { error })),
+                }
+            }
+        }
+    }
+}
+
+impl ConnectionFuture for OptionalFuture {
+    fn poll(
+        mut self: Pin<&mut Self>,
+        conn: &mut Connection,
+        ctx: &mut core::task::Context,
+    ) -> Poll<Result<(), Error>> {
+        match self.option.as_mut() {
+            Some(future) => future.as_mut().poll(conn, ctx),
+            None => Poll::Ready(Ok(())),
+        }
+    }
+}
+
+/// Any work necessary after the callback completes.
+//
+// We do not expect any callback except [`ClientHelloCallback`] to require MarkDone.
+// More recent callbacks follow a different model that doesn't require separate cleanup.
+//
+// This enum is sufficient while only ClientHello is special-cased, but will not
+// scale well. If we need more MarkDone variants, then we should consider a different
+// solution, like another stored future.
+#[non_exhaustive]
+#[derive(PartialEq)]
+enum MarkDone {
+    ClientHello,
+    // None,
+}
+
+pin_project! {
+    // Stores the [`ConnectionFuture`] and associated state.
+    pub(crate) struct AsyncCallback {
+        #[pin]
+        future: OptionalFuture,
+        cleanup: MarkDone,
+    }
+}
+
+impl AsyncCallback {
+    pub(crate) fn poll(
+        self: Pin<&mut Self>,
+        conn: &mut Connection,
+        ctx: &mut core::task::Context,
+    ) -> Poll<Result<(), Error>> {
+        let this = self.project();
+        let poll = this.future.poll(conn, ctx);
+        if let Poll::Ready(Ok(())) = poll {
+            if this.cleanup == &MarkDone::ClientHello {
+                conn.mark_client_hello_cb_done()?;
+            }
+        }
+        poll
+    }
+
+    pub(crate) fn trigger_client_hello_cb(
+        future: ConnectionFutureResult,
+        conn: &mut Connection,
+    ) -> CallbackResult {
+        let future = OptionalFuture::new(future);
+        let cleanup = MarkDone::ClientHello;
+        let callback = AsyncCallback { future, cleanup };
+        conn.set_async_callback(callback);
+        CallbackResult::Success
+    }
+
+    // pub(crate) fn trigger(
+    //    future: ConnectionFutureResult,
+    //    conn: &mut Connection,
+    //) -> CallbackResult {
+    //    let future = OptionalFuture::new(future);
+    //    let cleanup = MarkDone::None;
+    //    let callback = AsyncCallback { future, cleanup };
+    //    conn.set_async_callback(callback);
+    //    CallbackResult::Success
+    //}
+}

--- a/bindings/rust/s2n-tls/src/callbacks/client_hello.rs
+++ b/bindings/rust/s2n-tls/src/callbacks/client_hello.rs
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Support for application-implemented ClientHello callbacks.
+
+use crate::{callbacks::*, config::Config, connection::Connection, error::Error};
+use core::task::Poll;
+use pin_project_lite::pin_project;
+use std::{future::Future, pin::Pin};
+
+/// A trait for the callback executed after parsing the ClientHello message.
+///
+/// Use in conjunction with
+/// [config::Builder::set_client_hello_callback](`crate::config::Builder::set_client_hello_callback()`).
+pub trait ClientHelloCallback {
+    /// The application can return an `Ok(None)` to resolve the callback
+    /// synchronously or return an `Ok(Some(ConnectionFuture))` if it wants to
+    /// run some asynchronous task before resolving the callback.
+    ///
+    /// [`ConfigResolver`], which implements [`ConnectionFuture`] can be
+    /// returned if the application wants to set a new [`Config`] on the connection.
+    ///
+    /// If the server_name is used to configure the connection then the application
+    /// should call [`Connection::server_name_extension_used()`].
+    fn on_client_hello(
+        // this method takes an immutable reference to self to prevent the
+        // Config from being mutated by one connection and then used in another
+        // connection, leading to undefined behavior
+        &self,
+        connection: &mut Connection,
+    ) -> ConnectionFutureResult;
+}
+
+// For more information on projection:
+// https://doc.rust-lang.org/std/pin/index.html#projections-and-structural-pinning
+pin_project! {
+    /// An implementation of [`ConnectionFuture`] which resolves the provided
+    /// future and sets the config on the [`Connection`].
+    pub struct ConfigResolver<F: Future<Output = Result<Config, Error>>> {
+        #[pin]
+        fut: F,
+    }
+}
+
+impl<F: Future<Output = Result<Config, Error>>> ConfigResolver<F> {
+    pub fn new(fut: F) -> Self {
+        ConfigResolver { fut }
+    }
+}
+
+impl<F: Future<Output = Result<Config, Error>>> ConnectionFuture for ConfigResolver<F> {
+    fn poll(
+        self: Pin<&mut Self>,
+        connection: &mut Connection,
+        ctx: &mut core::task::Context,
+    ) -> Poll<Result<(), Error>> {
+        let this = self.project();
+        let config = match this.fut.poll(ctx) {
+            Poll::Ready(config) => config?,
+            Poll::Pending => return Poll::Pending,
+        };
+
+        connection.set_config(config)?;
+
+        Poll::Ready(Ok(()))
+    }
+}

--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -47,7 +47,7 @@ impl Config {
     /// This config _MUST_ have been initialized with a [`Builder`].
     /// Additionally, this does NOT increment the config reference count,
     /// so consider cloning the result if the source pointer is still
-    /// valid and useable afterwards.
+    /// valid and usable afterwards.
     pub(crate) unsafe fn from_raw(config: NonNull<s2n_config>) -> Self {
         let config = Self(config);
 

--- a/bindings/rust/s2n-tls/src/error.rs
+++ b/bindings/rust/s2n-tls/src/error.rs
@@ -161,7 +161,7 @@ impl Error {
 
     /// An error occurred while running application code.
     ///
-    /// Can be emitted from [`callbacks::ConnectionFuture::poll()`] to indicate
+    /// Can be emitted from [`crate::callbacks::ConnectionFuture::poll()`] to indicate
     /// async task failure.
     pub fn application(error: Box<dyn std::error::Error + Send + Sync + 'static>) -> Self {
         Self(Context::Application(error))


### PR DESCRIPTION
### Description of changes: 

The previous async logic was very ClientHello-specific. I've refactored so that only one struct has special casing for the ClientHello callback.

I initially didn't even have that special casing and was using Futures to handle the mark_client_hello_cb_done, but that seemed like overkill since more recent async callbacks can handle their own "mark_done". For example: pkey callbacks have s2n_async_pkey_op_apply(s2n_async_pkey_op*), psks have s2n_offered_psk_list_choose_psk(struct s2n_offered_psk_list *), early data has s2n_offered_early_data_accept(struct s2n_offered_early_data *). Basically, our usual model is that async callbacks have a specific instance of a callback-specific context, and the application calls a method on that context to set a result or indicate completion. We don't need to wait for the ConnectionFuture to complete.

Here's an example of one of the new callbacks implemented: https://github.com/lrstewart/s2n/commit/0a1505a156dd374a25b753d5c98b458051bde16f

### Call-outs:

* I've got the non-special cased version of AsyncCallback::trigger commented out, but I left it there as an example.
* PLEASE REVIEW MY PINNING. I think the Pins got away from me and multiplied more than they needed to? I may never truly understand Pins. The thought of my memory moving around horrifies me.

### Testing:

Existing ClientHello callback tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
