### PR TITLE
Filter do_not_merge label from Ready to merge in Dashboard

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -68,7 +68,7 @@ jobs:
               widgets:
               - type: 'number'
                 title: 'Ready to merge'
-                issue_query: 'repo:aws/s2n-tls is:open is:pr review:approved'
+                issue_query: 'repo:aws/s2n-tls is:open is:pr review:approved -label:do_not_merge'
                 color: 'green'
               - type: 'number'
                 title: 'No review (external) last 14 days'


### PR DESCRIPTION
### Description of changes: 

I noticed the "Ready to merge" section of the [s2n-tls dashboard](https://aws.github.io/s2n-tls/dashboard/) included a [PR](https://github.com/aws/s2n-tls/pull/3835) that was labeled with `do_not_merge`, and is thus *not* "ready to merge". This change filters out PRs with the `do_not_merge` label.

### Testing:

I tried the new issue query in GitHub: https://github.com/aws/s2n-tls/pulls?q=repo%3Aaws%2Fs2n-tls+is%3Aopen+is%3Apr+review%3Aapproved+-label%3Ado_not_merge

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
