### PR TITLE
Remove unused s2n_config_client_hello_cb_enable_poll

### DIFF
--- a/bindings/rust/s2n-tls-sys/src/internal.rs
+++ b/bindings/rust/s2n-tls-sys/src/internal.rs
@@ -18,6 +18,3 @@ extern "C" {
         config: *mut *mut s2n_config,
     ) -> ::libc::c_int;
 }
-extern "C" {
-    pub fn s2n_config_client_hello_cb_enable_poll(config: *mut s2n_config) -> ::libc::c_int;
-}

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -516,7 +516,10 @@ int s2n_client_hello_recv(struct s2n_connection *conn)
     }
 
     /* Only invoke the ClientHello callback once.
-     * Do not invoke again for a HelloRetry, even if we've reset the client hello */
+     * This means that we do NOT invoke the callback again on the second ClientHello
+     * in a TLS1.3 retry handshake. We explicitly check for a retry because the
+     * callback state may have been cleared while parsing the second ClientHello.
+     */
     if (!conn->client_hello.callback_invoked && !IS_HELLO_RETRY_HANDSHAKE(conn)) {
         /* Mark the collected client hello as available when parsing is done and before the client hello callback */
         conn->client_hello.callback_invoked = true;

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -505,31 +505,21 @@ fail:
     RESULT_BAIL(S2N_ERR_CANCELLED);
 }
 
-bool s2n_client_hello_invoke_callback(struct s2n_connection *conn)
-{
-    /* Invoke only if the callback has not been called or if polling mode is enabled */
-    bool invoke = !conn->client_hello.callback_invoked || conn->config->client_hello_cb_enable_poll;
-    /*
-     * The callback should not be called if this client_hello is in response to a hello retry.
-     */
-    return invoke && !IS_HELLO_RETRY_HANDSHAKE(conn);
-}
-
 int s2n_client_hello_recv(struct s2n_connection *conn)
 {
-    if (conn->config->client_hello_cb_enable_poll == 0) {
-        POSIX_ENSURE(conn->client_hello.callback_async_blocked == 0, S2N_ERR_ASYNC_BLOCKED);
+    POSIX_ENSURE(!conn->client_hello.callback_async_blocked, S2N_ERR_ASYNC_BLOCKED);
+
+    /* Only parse the ClientHello once */
+    if (!conn->client_hello.parsed) {
+        POSIX_GUARD(s2n_parse_client_hello(conn));
+        conn->client_hello.parsed = true;
     }
 
-    if (conn->client_hello.parsed == 0) {
-        /* Parse client hello */
-        POSIX_GUARD(s2n_parse_client_hello(conn));
-        conn->client_hello.parsed = 1;
-    }
-    /* Call the client_hello_cb once unless polling is enabled. */
-    if (s2n_client_hello_invoke_callback(conn)) {
+    /* Only invoke the ClientHello callback once.
+     * Do not invoke again for a HelloRetry, even if we've reset the client hello */
+    if (!conn->client_hello.callback_invoked && !IS_HELLO_RETRY_HANDSHAKE(conn)) {
         /* Mark the collected client hello as available when parsing is done and before the client hello callback */
-        conn->client_hello.callback_invoked = 1;
+        conn->client_hello.callback_invoked = true;
 
         /* Call client_hello_cb if exists, letting application to modify s2n_connection or swap s2n_config */
         if (conn->config->client_hello_cb) {

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -990,20 +990,6 @@ int s2n_config_get_ctx(struct s2n_config *config, void **ctx)
     return S2N_SUCCESS;
 }
 
-/*
- * Set the client_hello callback behavior to polling.
- *
- * Polling means that the callback function can be called multiple times.
- */
-int s2n_config_client_hello_cb_enable_poll(struct s2n_config *config)
-{
-    POSIX_ENSURE_REF(config);
-
-    config->client_hello_cb_enable_poll = 1;
-
-    return S2N_SUCCESS;
-}
-
 int s2n_config_set_send_buffer_size(struct s2n_config *config, uint32_t size)
 {
     POSIX_ENSURE_REF(config);

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -80,12 +80,6 @@ struct s2n_config {
      */
     unsigned no_signing_key : 1;
     /*
-     * This option exists to allow for polling the client_hello callback.
-     *
-     * Note: This defaults to false to ensure backwards compatibility.
-     */
-    unsigned client_hello_cb_enable_poll : 1;
-    /*
      * Whether to verify signatures locally before sending them over the wire.
      * See s2n_config_set_verify_after_sign.
      */

--- a/tls/s2n_internal.h
+++ b/tls/s2n_internal.h
@@ -44,11 +44,3 @@ struct s2n_connection;
  * modified after it has been built. Doing so is undefined behavior.
  */
 S2N_PRIVATE_API int s2n_connection_get_config(struct s2n_connection *conn, struct s2n_config **config);
-
-/*
- * Enable polling the async client_hello callback to make progress.
- *
- * `s2n_negotiate` must be called multiple times to poll the callback function
- * and make progress.
- */
-S2N_PRIVATE_API int s2n_config_client_hello_cb_enable_poll(struct s2n_config *config);


### PR DESCRIPTION
### Description of changes: 

s2n_config_client_hello_cb_enable_poll was initially added to make the ClientHello callback follow the polling model that Rust uses. However, that solution wouldn't have scaled to other async callbacks, and we went with a different solution. s2n_config_client_hello_cb_enable_poll complicates the already complex ClientHello callback logic, so I'd like to remove it.

Here's the commit that added it: https://github.com/aws/s2n-tls/commit/70884dc665047796d7a70ae7d487d5c159046ad6#diff-4a6a5adbf833174fde04f3043fd5575868bebc5085b7dee3c71abb4270c8d900

It's old enough that I couldn't `git revert` it without an unreasonable number of conflicts, so I manually reverted it.

### Testing:

Existing tests pass. I removed tests that turned on the polling feature, but kept the extra HRR tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
