### PR TITLE
Add Rust bindings method to create certs without private keys

### DIFF
--- a/bindings/rust/s2n-tls-sys/src/internal.rs
+++ b/bindings/rust/s2n-tls-sys/src/internal.rs
@@ -18,3 +18,10 @@ extern "C" {
         config: *mut *mut s2n_config,
     ) -> ::libc::c_int;
 }
+extern "C" {
+    pub fn s2n_config_add_cert_chain(
+        config: *mut s2n_config,
+        cert_chain_pem: *mut u8,
+        cert_chain_pem_size: u32,
+    ) -> ::libc::c_int;
+}

--- a/bindings/rust/s2n-tls/src/callbacks/pkey.rs
+++ b/bindings/rust/s2n-tls/src/callbacks/pkey.rs
@@ -150,7 +150,7 @@ mod tests {
         let config = {
             let mut config = config::Builder::new();
             config.set_security_policy(&security::DEFAULT_TLS13)?;
-            config.load_pem(CERT, KEY)?;
+            config.load_public_pem(CERT)?;
             config.set_private_key_callback(callback)?;
             // Our test certificates are untrusted, but disabling certificate
             // verification does not affect handshake signatures.

--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -264,6 +264,16 @@ impl Builder {
         Ok(self)
     }
 
+    pub fn load_public_pem(&mut self, certificate: &[u8]) -> Result<&mut Self, Error> {
+        let size: u32 = certificate
+            .len()
+            .try_into()
+            .map_err(|_| Error::INVALID_INPUT)?;
+        let certificate = certificate.as_ptr() as *mut u8;
+        unsafe { s2n_config_add_cert_chain(self.as_mut_ptr(), certificate, size) }.into_result()?;
+        Ok(self)
+    }
+
     pub fn trust_pem(&mut self, certificate: &[u8]) -> Result<&mut Self, Error> {
         let certificate = CString::new(certificate).map_err(|_| Error::INVALID_INPUT)?;
         unsafe {

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -526,6 +526,25 @@ int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cer
     return S2N_SUCCESS;
 }
 
+/* Only used in the Rust bindings. Superseded by s2n_config_add_cert_chain_and_key_to_store */
+int s2n_config_add_cert_chain(struct s2n_config *config,
+        uint8_t *cert_chain_pem, uint32_t cert_chain_pem_size)
+{
+    POSIX_ENSURE_REF(config);
+    POSIX_ENSURE(config->cert_ownership != S2N_APP_OWNED, S2N_ERR_CERT_OWNERSHIP);
+
+    DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = s2n_cert_chain_and_key_new(),
+            s2n_cert_chain_and_key_ptr_free);
+    POSIX_ENSURE_REF(chain_and_key);
+    POSIX_GUARD(s2n_cert_chain_and_key_load_public_pem_bytes(chain_and_key,
+            cert_chain_pem, cert_chain_pem_size));
+    POSIX_GUARD(s2n_config_add_cert_chain_and_key_impl(config, chain_and_key));
+    config->cert_ownership = S2N_LIB_OWNED;
+
+    ZERO_TO_DISABLE_DEFER_CLEANUP(chain_and_key);
+    return S2N_SUCCESS;
+}
+
 int s2n_config_add_cert_chain_and_key_to_store(struct s2n_config *config, struct s2n_cert_chain_and_key *cert_key_pair)
 {
     POSIX_ENSURE_REF(config);

--- a/tls/s2n_internal.h
+++ b/tls/s2n_internal.h
@@ -44,3 +44,12 @@ struct s2n_connection;
  * modified after it has been built. Doing so is undefined behavior.
  */
 S2N_PRIVATE_API int s2n_connection_get_config(struct s2n_connection *conn, struct s2n_config **config);
+
+/*
+ * Sets a certificate chain on the config.
+ *
+ * It does NOT set a private key, so the connection will need to be configured to
+ * [offload private key operations](https://github.com/aws/s2n-tls/blob/main/docs/USAGE-GUIDE.md#offloading-asynchronous-private-key-operations).
+ */
+S2N_PRIVATE_API int s2n_config_add_cert_chain(struct s2n_config *config,
+        uint8_t *cert_chain_pem, uint32_t cert_chain_pem_size);


### PR DESCRIPTION
### Description of changes: 

There are two mutually exclusive approaches to configuring certs in s2n-tls. You can either set a single "s2n-owned" certificate of each type on the config via [s2n_config_add_cert_chain_and_key](https://github.com/aws/s2n-tls/blob/main/api/s2n.h#L745), or you can set a variable number of "application-owned" certificates of each type via [s2n_cert_chain_and_key_new](https://github.com/aws/s2n-tls/blob/main/api/s2n.h#L603) and [s2n_config_add_cert_chain_and_key_to_store](https://github.com/aws/s2n-tls/blob/main/api/s2n.h#L764). s2n-tls will manage the lifecycle of "s2n-owned" certs, but the application is responsible for managing "application-owned" certificates. s2n-tls currently prefers "application-owned", and the "s2n-owned" methods are marked deprecated.

The current method to load a certificate without a private key is only available from the "application-owned" approach: [s2n_cert_chain_and_key_load_public_pem_bytes](https://github.com/aws/s2n-tls/blob/main/api/s2n.h#L650). However, the s2n-tls Rust bindings currently only use "s2n-owned" certificates, and don't offer the CertChainAndKey structure that would be required to support "application-owned" certificates.

Adding "application-owned" certificates to the bindings wouldn't be particularly easy. We'd need to add some C methods to retrieve the certificates associated with a config in order to properly implement Drop for CertChainAndKey. We'd also need to replace the current "s2n-owned" implementation of the existing methods, because you can't mix "s2n-owned" and "application-owned" so supporting both would be a bit of a foot gun. We'd either need to remove [set_ocsp_data](https://github.com/aws/s2n-tls/blob/main/bindings/rust/s2n-tls/src/config.rs#L344), accept that it's a sharp edge and will fail when combined with setting more than one cert, or find a way to make it inaccessible if the Config builder has a second cert set.

So as a faster, simpler solution, I've chosen to add an API to allow "s2n-owned" certificates to be created without public keys. I made it internal, so we should be able to remove it when/if we switch the bindings to "application-owned" certificates. However, there wouldn't really be any harm in adding it to the public API, so I could do that instead.

### Testing:

Basic unit test for the new C method.
Switched the async pkey tests to use the new Rust method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
