### PR TITLE
ci: remove go from aws-lc build; bump to latest version

### DIFF
--- a/codebuild/bin/install_awslc.sh
+++ b/codebuild/bin/install_awslc.sh
@@ -36,7 +36,7 @@ source codebuild/bin/jobs.sh
 if [ "$IS_FIPS" == "1" ]; then
   AWSLC_VERSION=AWS-LC-FIPS-1.0.3
 else
-  AWSLC_VERSION=v1.4.0
+  AWSLC_VERSION=v1.5.0
 fi
 mkdir -p "$BUILD_DIR"||true
 cd "$BUILD_DIR"
@@ -47,7 +47,7 @@ git clone https://github.com/awslabs/aws-lc.git --branch "$AWSLC_VERSION" --dept
 
 install_awslc() {
 	echo "Building with shared library=$1"
-	cmake ./aws-lc -Bbuild -GNinja -DBUILD_SHARED_LIBS=$1 -DCMAKE_BUILD_TYPE=relwithdebinfo -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" -DFIPS="${IS_FIPS}"
+	cmake ./aws-lc -Bbuild -GNinja -DDISABLE_GO=ON -DBUILD_SHARED_LIBS=$1 -DCMAKE_BUILD_TYPE=relwithdebinfo -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" -DFIPS="${IS_FIPS}"
 	ninja -j "${JOBS}" -C build install
 	ninja -C build clean
 }


### PR DESCRIPTION
### Resolved issues:

partial for #3848

### Description of changes: 

Build aws-lc with go.

### Call-outs:

We might want this to be configurable, to  turn on optimizations in aws-lc.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
