### PR TITLE
ktls: feature probe test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,6 +458,17 @@ if(S2N_AWSLC_KYBER_UNSTABLE AND LIBCRYPTO_SUPPORTS_EVP_KYBER_512)
     target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_LIBCRYPTO_SUPPORTS_KYBER512)
 endif()
 
+# Determine if kTLS is supported
+try_compile(
+        PLATFORM_SUPPORTS_KTLS
+        ${CMAKE_BINARY_DIR}
+        SOURCES "${CMAKE_CURRENT_LIST_DIR}/tests/features/ktls.c"
+)
+if(PLATFORM_SUPPORTS_KTLS)
+    message(STATUS "feature probe: kTLS supported")
+    target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_PLATFORM_SUPPORTS_KTLS)
+endif()
+
 if (NOT DEFINED CMAKE_AR)
 	message(STATUS "CMAKE_AR undefined, setting to `ar` by default")
 	SET(CMAKE_AR ar)

--- a/s2n.mk
+++ b/s2n.mk
@@ -219,7 +219,7 @@ ifeq ($(TRY_EVP_MD5_SHA1_HASH), 0)
 	DEFAULT_CFLAGS += -DS2N_LIBCRYPTO_SUPPORTS_EVP_MD5_SHA1_HASH
 endif
 
-# Determine if EVP_md5_sha1 is available
+# Determine if EVP_RC4 is available
 TRY_EVP_RC4 := $(call try_compile,$(S2N_ROOT)/tests/features/evp_rc4.c)
 ifeq ($(TRY_EVP_RC4), 0)
 	DEFAULT_CFLAGS += -DS2N_LIBCRYPTO_SUPPORTS_EVP_RC4
@@ -247,6 +247,12 @@ endif
 TRY_COMPILE_CLONE := $(call try_compile,$(S2N_ROOT)/tests/features/clone.c)
 ifeq ($(TRY_COMPILE_CLONE), 0)
 	DEFAULT_CFLAGS += -DS2N_CLONE_SUPPORTED
+endif
+
+# Determine if kTLS is available
+TRY_COMPILE_KTLS := $(call try_compile,$(S2N_ROOT)/tests/features/ktls.c)
+ifeq ($(TRY_COMPILE_KTLS), 0)
+	DEFAULT_CFLAGS += -DS2N_PLATFORM_SUPPORTS_KTLS
 endif
 
 CFLAGS_LLVM = ${DEFAULT_CFLAGS} -emit-llvm -c -g -O1

--- a/tests/features/ktls.c
+++ b/tests/features/ktls.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * _GNU_SOURCE is needed for resolving the constant SOL_TCP
+ * when building `tls/s2n_ktls.c`.
+ *
+ * https://github.com/aws/s2n-tls/issues/3813
+ * _GNU_SOURCE seems to be present during feature probe but not the source.
+ * Even though the following is not required we should maintain parity
+ * between the two usage to reduce the differences. In the long term we
+ * should ensure both the feature probe and source are compiled with the
+ * same flags.
+ */
+#ifndef _GNU_SOURCE
+    #define _GNU_SOURCE
+    #include <netinet/tcp.h>
+    #undef _GNU_SOURCE
+#else
+    #include <netinet/tcp.h>
+#endif
+
+#include <linux/tls.h>
+
+int main()
+{
+    /* Prepare dummy crypto info for socket */
+    struct tls12_crypto_info_aes_gcm_128 crypto_info;
+
+    /* API calls to enable kTLS for socket */
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    setsockopt(sock, SOL_TCP, TCP_ULP, "tls", sizeof("tls"));
+    setsockopt(sock, SOL_TLS, TLS_TX, &crypto_info, sizeof(crypto_info));
+
+    return 0;
+}

--- a/tests/unit/s2n_ktls_feature_probe_test.c
+++ b/tests/unit/s2n_ktls_feature_probe_test.c
@@ -13,23 +13,30 @@
  * permissions and limitations under the License.
  */
 
-#pragma once
+#include "s2n_test.h"
+#include "tls/s2n_ktls.h"
 
-#include "tls/s2n_config.h"
+#if defined(__linux__)
+    #include "linux/version.h"
+#endif
 
-/* A set of kTLS configurations representing the combination of sending
- * and receiving.
- */
-typedef enum {
-    /* Disable kTLS. */
-    S2N_KTLS_MODE_DISABLED,
-    /* Enable kTLS for the send socket. */
-    S2N_KTLS_MODE_SEND,
-    /* Enable kTLS for the receive socket. */
-    S2N_KTLS_MODE_RECV,
-    /* Enable kTLS for both receive and send sockets. */
-    S2N_KTLS_MODE_DUPLEX,
-} s2n_ktls_mode;
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
 
-int s2n_config_set_ktls_mode(struct s2n_config *config, s2n_ktls_mode ktls_mode);
-bool platform_supports_ktls();
+    /* kTLS feature probe */
+    {
+#if defined(__linux__)
+    /* kTLS support was first added to AL2 starting in 5.10.130. */
+    #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 130))
+        if (!platform_supports_ktls()) {
+            FAIL_MSG("kTLS feature probe is not working");
+        } else {
+            EXPECT_TRUE(true);
+        }
+    #endif
+#endif
+    };
+
+    END_TEST();
+}

--- a/tests/unit/s2n_ktls_feature_probe_test.c
+++ b/tests/unit/s2n_ktls_feature_probe_test.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv)
 #if defined(__linux__)
     /* kTLS support was first added to AL2 starting in 5.10.130. */
     #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 130))
-        if (!platform_supports_ktls()) {
+        if (!s2n_ktls_is_supported_on_platform()) {
             FAIL_MSG("kTLS feature probe is not working");
         } else {
             EXPECT_TRUE(true);

--- a/tests/unit/s2n_ktls_feature_probe_test.c
+++ b/tests/unit/s2n_ktls_feature_probe_test.c
@@ -29,11 +29,7 @@ int main(int argc, char **argv)
 #if defined(__linux__)
     /* kTLS support was first added to AL2 starting in 5.10.130. */
     #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 130))
-        if (!s2n_ktls_is_supported_on_platform()) {
-            FAIL_MSG("kTLS feature probe is not working");
-        } else {
-            EXPECT_TRUE(true);
-        }
+        EXPECT_TRUE(s2n_ktls_is_supported_on_platform());
     #endif
 #endif
     };

--- a/tls/s2n_ktls.c
+++ b/tls/s2n_ktls.c
@@ -15,7 +15,7 @@
 
 #include "tls/s2n_ktls.h"
 
-bool platform_supports_ktls()
+bool s2n_ktls_is_supported_on_platform()
 {
 #ifdef S2N_PLATFORM_SUPPORTS_KTLS
     return true;

--- a/tls/s2n_ktls.c
+++ b/tls/s2n_ktls.c
@@ -13,23 +13,13 @@
  * permissions and limitations under the License.
  */
 
-#pragma once
+#include "tls/s2n_ktls.h"
 
-#include "tls/s2n_config.h"
-
-/* A set of kTLS configurations representing the combination of sending
- * and receiving.
- */
-typedef enum {
-    /* Disable kTLS. */
-    S2N_KTLS_MODE_DISABLED,
-    /* Enable kTLS for the send socket. */
-    S2N_KTLS_MODE_SEND,
-    /* Enable kTLS for the receive socket. */
-    S2N_KTLS_MODE_RECV,
-    /* Enable kTLS for both receive and send sockets. */
-    S2N_KTLS_MODE_DUPLEX,
-} s2n_ktls_mode;
-
-int s2n_config_set_ktls_mode(struct s2n_config *config, s2n_ktls_mode ktls_mode);
-bool platform_supports_ktls();
+bool platform_supports_ktls()
+{
+#ifdef S2N_PLATFORM_SUPPORTS_KTLS
+    return true;
+#else
+    return false;
+#endif
+}

--- a/tls/s2n_ktls.h
+++ b/tls/s2n_ktls.h
@@ -32,4 +32,4 @@ typedef enum {
 } s2n_ktls_mode;
 
 int s2n_config_set_ktls_mode(struct s2n_config *config, s2n_ktls_mode ktls_mode);
-bool platform_supports_ktls();
+bool s2n_ktls_is_supported_on_platform();


### PR DESCRIPTION
### Description of changes: 
This PR adds a feature probe test to detect if kTLS is available on the platform.

### Call-outs:
Feature probe and source are compiled with different flags. I have created an issue for this and in the meantime we will need to define _GNU_SOURCE for kTLS if its missing https://github.com/aws/s2n-tls/issues/3813

### Testing:
- Added a feature probe test. The test runs successfully (kTLS is available) on our Ubuntu test images:  https://github.com/aws/s2n-tls/pull/3808#discussion_r1106485019
```s2nValgrindOpenSSL111Gcc9
kTLS SUPPORTED!!!! (s2n_ktls_feature_probe_test.c:24)
```

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
