### PR TITLE
Allow client hellos from raw bytes

### DIFF
--- a/api/unstable/fingerprint.h
+++ b/api/unstable/fingerprint.h
@@ -87,7 +87,7 @@ int s2n_client_hello_get_fingerprint_string(struct s2n_client_hello *ch,
  * @param size The size of raw_message.
  * @returns A new s2n_client_hello on success, or NULL on failure.
  */
-struct s2n_client_hello *s2n_client_hello_parse_bytes(uint8_t *bytes, uint32_t size);
+struct s2n_client_hello *s2n_client_hello_parse_message(uint8_t *bytes, uint32_t size);
 
 /**
  * Frees an s2n_client_hello structure.

--- a/api/unstable/fingerprint.h
+++ b/api/unstable/fingerprint.h
@@ -74,3 +74,28 @@ int s2n_client_hello_get_fingerprint_hash(struct s2n_client_hello *ch,
 int s2n_client_hello_get_fingerprint_string(struct s2n_client_hello *ch,
         s2n_fingerprint_type type, uint32_t max_size,
         uint8_t *output, uint32_t *output_size);
+
+/**
+ * Creates an s2n_client_hello from bytes representing a ClientHello message.
+ *
+ * Unlike s2n_connection_get_client_hello, the s2n_client_hello produced by this
+ * method is owned by the application and must be freed with s2n_client_hello_free.
+ *
+ * This method does not support SSLv2 ClientHellos.
+ *
+ * @param raw_message The raw bytes representing the ClientHello.
+ * @param raw_message_size The actual size of the data written to `output`.
+ * @returns An new s2n_client_hello on success, or NULL on failure.
+ */
+struct s2n_client_hello *s2n_client_hello_parse_raw_message(uint8_t *raw_message, uint32_t raw_message_size);
+
+/**
+ * Frees an s2n_client_hello structure.
+ *
+ * This method will error if called to free an s2n_client_hello received from
+ * s2n_connection_get_client_hello and associated with a connection.
+ *
+ * @param ch The structure to be freed.
+ * @returns S2N_SUCCESS on success, S2N_FAILURE on failure.
+ */
+int s2n_client_hello_free(struct s2n_client_hello **ch);

--- a/api/unstable/fingerprint.h
+++ b/api/unstable/fingerprint.h
@@ -83,11 +83,11 @@ int s2n_client_hello_get_fingerprint_string(struct s2n_client_hello *ch,
  *
  * This method does not support SSLv2 ClientHellos.
  *
- * @param raw_message The raw bytes representing the ClientHello.
- * @param raw_message_size The actual size of the data written to `output`.
- * @returns An new s2n_client_hello on success, or NULL on failure.
+ * @param bytes The raw bytes representing the ClientHello.
+ * @param size The size of raw_message.
+ * @returns A new s2n_client_hello on success, or NULL on failure.
  */
-struct s2n_client_hello *s2n_client_hello_parse_raw_message(uint8_t *raw_message, uint32_t raw_message_size);
+struct s2n_client_hello *s2n_client_hello_parse_bytes(uint8_t *bytes, uint32_t size);
 
 /**
  * Frees an s2n_client_hello structure.

--- a/api/unstable/fingerprint.h
+++ b/api/unstable/fingerprint.h
@@ -78,7 +78,7 @@ int s2n_client_hello_get_fingerprint_string(struct s2n_client_hello *ch,
 /**
  * Creates an s2n_client_hello from bytes representing a ClientHello message.
  *
- * Unlike s2n_connection_get_client_hello, the s2n_client_hello produced by this
+ * Unlike s2n_connection_get_client_hello, the s2n_client_hello returned by this
  * method is owned by the application and must be freed with s2n_client_hello_free.
  *
  * This method does not support SSLv2 ClientHellos.
@@ -92,8 +92,9 @@ struct s2n_client_hello *s2n_client_hello_parse_message(uint8_t *bytes, uint32_t
 /**
  * Frees an s2n_client_hello structure.
  *
- * This method will error if called to free an s2n_client_hello received from
- * s2n_connection_get_client_hello and associated with a connection.
+ * This method should be called to free s2n_client_hellos returned by
+ * s2n_client_hello_parse_message. It will error if passed an s2n_client_hello
+ * returned by s2n_connection_get_client_hello and owned by the connection.
  *
  * @param ch The structure to be freed.
  * @returns S2N_SUCCESS on success, S2N_FAILURE on failure.

--- a/api/unstable/fingerprint.h
+++ b/api/unstable/fingerprint.h
@@ -87,7 +87,7 @@ int s2n_client_hello_get_fingerprint_string(struct s2n_client_hello *ch,
  * @param size The size of raw_message.
  * @returns A new s2n_client_hello on success, or NULL on failure.
  */
-struct s2n_client_hello *s2n_client_hello_parse_message(uint8_t *bytes, uint32_t size);
+struct s2n_client_hello *s2n_client_hello_parse_message(const uint8_t *bytes, uint32_t size);
 
 /**
  * Frees an s2n_client_hello structure.

--- a/codebuild/bin/grep_simple_mistakes.sh
+++ b/codebuild/bin/grep_simple_mistakes.sh
@@ -122,9 +122,8 @@ for file in $S2N_FILES_ASSERT_NOTNULL_CHECK; do
     # $line_one definitely contains an assignment from s2n_stuffer_raw_read(),
     # because that's what we grepped for. So verify that either $line_one or
     # $line_two contains a null check.
-    manual_null_check_regex="(.*(if|ENSURE_POSIX|POSIX_ENSURE).*=\ NULL)|(ENSURE_REF)"
-    if [[ $line_one == *"notnull_check("* ]] || [[ $line_one =~ $manual_null_check_regex ]] ||\
-    [[ $line_two == *"notnull_check("* ]] || [[ $line_two =~ $manual_null_check_regex ]]; then
+    null_check_regex="(.*(if|ENSURE).*=\ NULL)|(ENSURE_REF)"
+    if [[ $line_one =~ $null_check_regex ]] || [[ $line_two =~ $null_check_regex ]]; then
       # Found a notnull_check
       continue
     else

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -1397,10 +1397,10 @@ int main(int argc, char **argv)
         EXPECT_FAILURE_WITH_ERRNO(s2n_parse_client_hello(server_conn), S2N_ERR_SAFETY);
     };
 
-    /* Test s2n_client_hello_parse_raw_message
+    /* Test s2n_client_hello_parse_bytes
      *
      * Comparing ClientHellos produced by connection IO parsing vs
-     * produced by s2n_client_hello_parse_raw_message is difficult, but we can
+     * produced by s2n_client_hello_parse_bytes is difficult, but we can
      * use JA3 fingerprints as an approximation. See s2n_fingerprint_ja3_test.c
      */
     {
@@ -1425,7 +1425,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(raw);
 
             DEFER_CLEANUP(struct s2n_client_hello *client_hello = NULL, s2n_client_hello_free);
-            EXPECT_NOT_NULL(client_hello = s2n_client_hello_parse_raw_message(raw, raw_size));
+            EXPECT_NOT_NULL(client_hello = s2n_client_hello_parse_bytes(raw, raw_size));
             EXPECT_TRUE(client_hello->alloced);
         };
 
@@ -1437,12 +1437,12 @@ int main(int argc, char **argv)
             struct s2n_client_hello *client_hello = NULL;
 
             uint8_t too_short[] = { 0x03, 0x03 };
-            client_hello = s2n_client_hello_parse_raw_message(too_short, sizeof(too_short));
+            client_hello = s2n_client_hello_parse_bytes(too_short, sizeof(too_short));
             EXPECT_NULL(client_hello);
             EXPECT_EQUAL(s2n_errno, S2N_ERR_STUFFER_OUT_OF_DATA);
 
             uint8_t all_zeroes[50] = { 0 };
-            client_hello = s2n_client_hello_parse_raw_message(all_zeroes, sizeof(all_zeroes));
+            client_hello = s2n_client_hello_parse_bytes(all_zeroes, sizeof(all_zeroes));
             EXPECT_NULL(client_hello);
             EXPECT_EQUAL(s2n_errno, S2N_ERR_BAD_MESSAGE);
         };
@@ -1461,7 +1461,7 @@ int main(int argc, char **argv)
              * but s2n-tls usually starts parsing after the first five bytes.
              */
             for (size_t i = 0; i <= S2N_TLS_RECORD_HEADER_LENGTH; i++) {
-                struct s2n_client_hello *client_hello = s2n_client_hello_parse_raw_message(
+                struct s2n_client_hello *client_hello = s2n_client_hello_parse_bytes(
                         sslv2_client_hello + i, sizeof(sslv2_client_hello) - i);
                 EXPECT_NULL(client_hello);
                 EXPECT_EQUAL(s2n_errno, S2N_ERR_BAD_MESSAGE);
@@ -1539,7 +1539,7 @@ int main(int argc, char **argv)
             uint8_t *raw = s2n_stuffer_raw_read(&client->handshake.io, raw_size);
             EXPECT_NOT_NULL(raw);
 
-            struct s2n_client_hello *client_hello = s2n_client_hello_parse_raw_message(
+            struct s2n_client_hello *client_hello = s2n_client_hello_parse_bytes(
                     raw, raw_size);
             EXPECT_NOT_NULL(client_hello);
 

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -1397,10 +1397,10 @@ int main(int argc, char **argv)
         EXPECT_FAILURE_WITH_ERRNO(s2n_parse_client_hello(server_conn), S2N_ERR_SAFETY);
     };
 
-    /* Test s2n_client_hello_parse_bytes
+    /* Test s2n_client_hello_parse_message
      *
      * Comparing ClientHellos produced by connection IO parsing vs
-     * produced by s2n_client_hello_parse_bytes is difficult, but we can
+     * produced by s2n_client_hello_parse_message is difficult, but we can
      * use JA3 fingerprints as an approximation. See s2n_fingerprint_ja3_test.c
      */
     {
@@ -1428,7 +1428,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(raw);
 
             DEFER_CLEANUP(struct s2n_client_hello *client_hello = NULL, s2n_client_hello_free);
-            EXPECT_NOT_NULL(client_hello = s2n_client_hello_parse_bytes(raw, raw_size));
+            EXPECT_NOT_NULL(client_hello = s2n_client_hello_parse_message(raw, raw_size));
             EXPECT_TRUE(client_hello->alloced);
         };
 
@@ -1440,22 +1440,22 @@ int main(int argc, char **argv)
             struct s2n_client_hello *client_hello = NULL;
 
             uint8_t wrong_message_type[50] = { 0x02, 0x00, 0x00, 1 };
-            client_hello = s2n_client_hello_parse_bytes(wrong_message_type, sizeof(wrong_message_type));
+            client_hello = s2n_client_hello_parse_message(wrong_message_type, sizeof(wrong_message_type));
             EXPECT_NULL(client_hello);
             EXPECT_EQUAL(s2n_errno, S2N_ERR_BAD_MESSAGE);
 
             uint8_t wrong_message_size[50] = { 0x01, 0x00, 0x00, UINT8_MAX };
-            client_hello = s2n_client_hello_parse_bytes(wrong_message_size, sizeof(wrong_message_size));
+            client_hello = s2n_client_hello_parse_message(wrong_message_size, sizeof(wrong_message_size));
             EXPECT_NULL(client_hello);
             EXPECT_EQUAL(s2n_errno, S2N_ERR_BAD_MESSAGE);
 
             uint8_t too_short[5] = { 0x01, 0x00, 0x00, 1 };
-            client_hello = s2n_client_hello_parse_bytes(too_short, sizeof(too_short));
+            client_hello = s2n_client_hello_parse_message(too_short, sizeof(too_short));
             EXPECT_NULL(client_hello);
             EXPECT_EQUAL(s2n_errno, S2N_ERR_STUFFER_OUT_OF_DATA);
 
             uint8_t all_zeroes[50] = { 0x01, 0x00, 0x00, 46 };
-            client_hello = s2n_client_hello_parse_bytes(all_zeroes, sizeof(all_zeroes));
+            client_hello = s2n_client_hello_parse_message(all_zeroes, sizeof(all_zeroes));
             EXPECT_NULL(client_hello);
             EXPECT_EQUAL(s2n_errno, S2N_ERR_BAD_MESSAGE);
         };
@@ -1474,7 +1474,7 @@ int main(int argc, char **argv)
              * but s2n-tls usually starts parsing after the first five bytes.
              */
             for (size_t i = 0; i <= S2N_TLS_RECORD_HEADER_LENGTH; i++) {
-                struct s2n_client_hello *client_hello = s2n_client_hello_parse_bytes(
+                struct s2n_client_hello *client_hello = s2n_client_hello_parse_message(
                         sslv2_client_hello + i, sizeof(sslv2_client_hello) - i);
                 EXPECT_NULL(client_hello);
                 EXPECT_EQUAL(s2n_errno, S2N_ERR_BAD_MESSAGE);
@@ -1555,7 +1555,7 @@ int main(int argc, char **argv)
             uint8_t *raw = s2n_stuffer_raw_read(&client->handshake.io, raw_size);
             EXPECT_NOT_NULL(raw);
 
-            struct s2n_client_hello *client_hello = s2n_client_hello_parse_bytes(
+            struct s2n_client_hello *client_hello = s2n_client_hello_parse_message(
                     raw, raw_size);
             EXPECT_NOT_NULL(client_hello);
 

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -1500,35 +1500,6 @@ int main(int argc, char **argv)
                 EXPECT_FALSE(server->client_hello.alloced);
             }
         };
-
-        /* Test: Does NOT modify input */
-        {
-            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
-                    s2n_connection_ptr_free);
-            EXPECT_SUCCESS(s2n_connection_set_config(client, config));
-
-            EXPECT_SUCCESS(s2n_handshake_write_header(&client->handshake.io, TLS_CLIENT_HELLO));
-            EXPECT_SUCCESS(s2n_client_hello_send(client));
-            EXPECT_SUCCESS(s2n_handshake_finish_header(&client->handshake.io));
-
-            uint32_t raw_size = s2n_stuffer_data_available(&client->handshake.io);
-            EXPECT_NOT_EQUAL(raw_size, 0);
-            uint8_t *raw = s2n_stuffer_raw_read(&client->handshake.io, raw_size);
-            EXPECT_NOT_NULL(raw);
-
-            DEFER_CLEANUP(struct s2n_stuffer saved = { 0 }, s2n_stuffer_free);
-            EXPECT_SUCCESS(s2n_stuffer_alloc(&saved, raw_size));
-            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&saved, raw, raw_size));
-            uint8_t *saved_raw = s2n_stuffer_raw_read(&saved, raw_size);
-            EXPECT_NOT_NULL(saved_raw);
-            EXPECT_NOT_EQUAL(raw, saved_raw);
-
-            DEFER_CLEANUP(struct s2n_client_hello *client_hello = NULL, s2n_client_hello_free);
-            EXPECT_NOT_NULL(client_hello = s2n_client_hello_parse_message(raw, raw_size));
-
-            /* Expect input unchanged */
-            EXPECT_BYTEARRAY_EQUAL(raw, saved_raw, raw_size);
-        };
     };
 
     /* Test s2n_client_hello_free */

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -1500,6 +1500,35 @@ int main(int argc, char **argv)
                 EXPECT_FALSE(server->client_hello.alloced);
             }
         };
+
+        /* Test: Does NOT modify input */
+        {
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_config(client, config));
+
+            EXPECT_SUCCESS(s2n_handshake_write_header(&client->handshake.io, TLS_CLIENT_HELLO));
+            EXPECT_SUCCESS(s2n_client_hello_send(client));
+            EXPECT_SUCCESS(s2n_handshake_finish_header(&client->handshake.io));
+
+            uint32_t raw_size = s2n_stuffer_data_available(&client->handshake.io);
+            EXPECT_NOT_EQUAL(raw_size, 0);
+            uint8_t *raw = s2n_stuffer_raw_read(&client->handshake.io, raw_size);
+            EXPECT_NOT_NULL(raw);
+
+            DEFER_CLEANUP(struct s2n_stuffer saved = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&saved, raw_size));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&saved, raw, raw_size));
+            uint8_t *saved_raw = s2n_stuffer_raw_read(&saved, raw_size);
+            EXPECT_NOT_NULL(saved_raw);
+            EXPECT_NOT_EQUAL(raw, saved_raw);
+
+            DEFER_CLEANUP(struct s2n_client_hello *client_hello = NULL, s2n_client_hello_free);
+            EXPECT_NOT_NULL(client_hello = s2n_client_hello_parse_message(raw, raw_size));
+
+            /* Expect input unchanged */
+            EXPECT_BYTEARRAY_EQUAL(raw, saved_raw, raw_size);
+        };
     };
 
     /* Test s2n_client_hello_free */

--- a/tests/unit/s2n_fingerprint_ja3_test.c
+++ b/tests/unit/s2n_fingerprint_ja3_test.c
@@ -112,7 +112,7 @@ static S2N_RESULT s2n_client_hello_from_source(struct s2n_client_hello **client_
             RESULT_ENSURE_REF(*client_hello);
             break;
         case S2N_CH_FROM_RAW:
-            *client_hello = s2n_client_hello_parse_bytes(input, input_size);
+            *client_hello = s2n_client_hello_parse_message(input, input_size);
             RESULT_GUARD_PTR(*client_hello);
             break;
     }

--- a/tests/unit/s2n_fingerprint_ja3_test.c
+++ b/tests/unit/s2n_fingerprint_ja3_test.c
@@ -101,7 +101,7 @@ static S2N_RESULT s2n_client_hello_from_source(struct s2n_client_hello **client_
             RESULT_ENSURE_REF(*client_hello);
             break;
         case S2N_CH_FROM_RAW:
-            *client_hello = s2n_client_hello_parse_raw_message(input, input_size);
+            *client_hello = s2n_client_hello_parse_bytes(input, input_size);
             RESULT_GUARD_PTR(*client_hello);
             break;
     }

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -460,7 +460,7 @@ int s2n_parse_client_hello(struct s2n_connection *conn)
     return S2N_SUCCESS;
 }
 
-static S2N_RESULT s2n_client_hello_parse_bytes_impl(struct s2n_client_hello **result,
+static S2N_RESULT s2n_client_hello_parse_message_impl(struct s2n_client_hello **result,
         uint8_t *raw_message, uint32_t raw_message_size)
 {
     RESULT_ENSURE_REF(result);
@@ -497,10 +497,10 @@ static S2N_RESULT s2n_client_hello_parse_bytes_impl(struct s2n_client_hello **re
     return S2N_RESULT_OK;
 }
 
-struct s2n_client_hello *s2n_client_hello_parse_bytes(uint8_t *raw_message, uint32_t raw_message_size)
+struct s2n_client_hello *s2n_client_hello_parse_message(uint8_t *raw_message, uint32_t raw_message_size)
 {
     struct s2n_client_hello *result = NULL;
-    PTR_GUARD_RESULT(s2n_client_hello_parse_bytes_impl(&result, raw_message, raw_message_size));
+    PTR_GUARD_RESULT(s2n_client_hello_parse_message_impl(&result, raw_message, raw_message_size));
     return result;
 }
 

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -460,7 +460,7 @@ int s2n_parse_client_hello(struct s2n_connection *conn)
     return S2N_SUCCESS;
 }
 
-static S2N_RESULT s2n_client_hello_parse_raw_message_impl(struct s2n_client_hello **result,
+static S2N_RESULT s2n_client_hello_parse_bytes_impl(struct s2n_client_hello **result,
         uint8_t *raw_message, uint32_t raw_message_size)
 {
     RESULT_ENSURE_REF(result);
@@ -490,10 +490,10 @@ static S2N_RESULT s2n_client_hello_parse_raw_message_impl(struct s2n_client_hell
     return S2N_RESULT_OK;
 }
 
-struct s2n_client_hello *s2n_client_hello_parse_raw_message(uint8_t *raw_message, uint32_t raw_message_size)
+struct s2n_client_hello *s2n_client_hello_parse_bytes(uint8_t *raw_message, uint32_t raw_message_size)
 {
     struct s2n_client_hello *result = NULL;
-    PTR_GUARD_RESULT(s2n_client_hello_parse_raw_message_impl(&result, raw_message, raw_message_size));
+    PTR_GUARD_RESULT(s2n_client_hello_parse_bytes_impl(&result, raw_message, raw_message_size));
     return result;
 }
 

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -363,7 +363,7 @@ S2N_RESULT s2n_client_hello_parse_raw(struct s2n_client_hello *client_hello,
     RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(in, &session_id_len));
     RESULT_ENSURE(session_id_len <= S2N_TLS_SESSION_ID_MAX_LEN, S2N_ERR_BAD_MESSAGE);
     uint8_t *session_id = s2n_stuffer_raw_read(in, session_id_len);
-    RESULT_ENSURE(session_id, S2N_ERR_BAD_MESSAGE);
+    RESULT_ENSURE(session_id != NULL, S2N_ERR_BAD_MESSAGE);
     RESULT_GUARD_POSIX(s2n_blob_init(&client_hello->session_id, session_id, session_id_len));
 
     /* cipher suites */
@@ -372,7 +372,7 @@ S2N_RESULT s2n_client_hello_parse_raw(struct s2n_client_hello *client_hello,
     RESULT_ENSURE(cipher_suites_length > 0, S2N_ERR_BAD_MESSAGE);
     RESULT_ENSURE(cipher_suites_length % S2N_TLS_CIPHER_SUITE_LEN == 0, S2N_ERR_BAD_MESSAGE);
     uint8_t *cipher_suites = s2n_stuffer_raw_read(in, cipher_suites_length);
-    RESULT_ENSURE(cipher_suites, S2N_ERR_BAD_MESSAGE);
+    RESULT_ENSURE(cipher_suites != NULL, S2N_ERR_BAD_MESSAGE);
     RESULT_GUARD_POSIX(s2n_blob_init(&client_hello->cipher_suites, cipher_suites, cipher_suites_length));
 
     /* legacy_compression_methods (ignored) */

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -460,7 +460,7 @@ int s2n_parse_client_hello(struct s2n_connection *conn)
 }
 
 static S2N_RESULT s2n_client_hello_parse_message_impl(struct s2n_client_hello **result,
-        uint8_t *raw_message, uint32_t raw_message_size)
+        const uint8_t *raw_message, uint32_t raw_message_size)
 {
     RESULT_ENSURE_REF(result);
 
@@ -473,10 +473,9 @@ static S2N_RESULT s2n_client_hello_parse_message_impl(struct s2n_client_hello **
     client_hello->alloced = true;
     ZERO_TO_DISABLE_DEFER_CLEANUP(mem);
 
-    struct s2n_blob in_blob = { 0 };
-    struct s2n_stuffer in = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&in_blob, raw_message, raw_message_size));
-    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&in, &in_blob));
+    DEFER_CLEANUP(struct s2n_stuffer in = { 0 }, s2n_stuffer_free);
+    RESULT_GUARD_POSIX(s2n_stuffer_alloc(&in, raw_message_size));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(&in, raw_message, raw_message_size));
 
     uint8_t message_type = 0;
     uint32_t message_len = 0;
@@ -496,7 +495,7 @@ static S2N_RESULT s2n_client_hello_parse_message_impl(struct s2n_client_hello **
     return S2N_RESULT_OK;
 }
 
-struct s2n_client_hello *s2n_client_hello_parse_message(uint8_t *raw_message, uint32_t raw_message_size)
+struct s2n_client_hello *s2n_client_hello_parse_message(const uint8_t *raw_message, uint32_t raw_message_size)
 {
     struct s2n_client_hello *result = NULL;
     PTR_GUARD_RESULT(s2n_client_hello_parse_message_impl(&result, raw_message, raw_message_size));

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -329,8 +329,7 @@ S2N_RESULT s2n_client_hello_parse_raw(struct s2n_client_hello *client_hello,
     RESULT_ENSURE_REF(client_hello);
 
     struct s2n_stuffer in_stuffer = { 0 };
-    RESULT_GUARD_POSIX(s2n_stuffer_init(&in_stuffer, &client_hello->raw_message));
-    RESULT_GUARD_POSIX(s2n_stuffer_skip_write(&in_stuffer, client_hello->raw_message.size));
+    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&in_stuffer, &client_hello->raw_message));
     struct s2n_stuffer *in = &in_stuffer;
 
     /**

--- a/tls/s2n_client_hello.h
+++ b/tls/s2n_client_hello.h
@@ -43,7 +43,6 @@ struct s2n_client_hello {
      * issues a hello retry.
      */
     unsigned int parsed : 1;
-
     /*
      * SSLv2 ClientHellos have a different format.
      * Cipher suites are each three bytes instead of two.
@@ -51,9 +50,20 @@ struct s2n_client_hello {
      * the raw_message will not contain the protocol version.
      */
     unsigned int sslv2 : 1;
+    /*
+     * The memory for this structure can be either owned by the application
+     * or tied to and managed by a connection.
+     *
+     * If owned by the application, it can be freed using s2n_client_hello_free.
+     * Otherwise, it is freed with s2n_connection_free.
+     *
+     * We could simplify this by moving the client hello structure off of the
+     * connection structure.
+     */
+    unsigned int alloced : 1;
 };
 
-int s2n_client_hello_free(struct s2n_client_hello *client_hello);
+int s2n_client_hello_free_raw_message(struct s2n_client_hello *client_hello);
 
 struct s2n_client_hello *s2n_connection_get_client_hello(struct s2n_connection *conn);
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -267,7 +267,7 @@ int s2n_connection_free(struct s2n_connection *conn)
     POSIX_GUARD(s2n_stuffer_free(&conn->handshake.io));
     POSIX_GUARD(s2n_stuffer_free(&conn->post_handshake.in));
     s2n_x509_validator_wipe(&conn->x509_validator);
-    POSIX_GUARD(s2n_client_hello_free(&conn->client_hello));
+    POSIX_GUARD(s2n_client_hello_free_raw_message(&conn->client_hello));
     POSIX_GUARD(s2n_free(&conn->application_protocols_overridden));
     POSIX_GUARD(s2n_free(&conn->cookie));
     POSIX_GUARD_RESULT(s2n_crypto_parameters_free(&conn->initial));


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/3852

### Description of changes: 

Add a method to create an s2n_client_hello structure from bytes representing a ClientHello.

As part of this change, I refactored the existing s2n_client_hello_parse method so that it only does work that requires a connection or config, like setting conn->client_protocol_version. I moved the pure parsing to a new method called by both the existing s2n_client_hello_parse and my new method.

### Call-outs:
* I wonder if I should change "s2n_client_hello_parse_bytes" to just "s2n_client_hello_parse" and rename the internal method to something like "s2n_client_hello_parse_for_connection".
* I went back and forth on whether s2n_client_hello_parse_bytes should return int or a pointer. I think a pointer is the right choice so that it matches s2n_connection_get_client_hello and we never have an uninitialized s2n_client_hello. 
* I also updated the grep_simple_mistakes script. The part verifying that we null-checked pointers returned by s2n_stuffer_raw_read was very out of date and checking for macros that no longer exist.

### Testing:

I added some basic unit tests for the new methods.
I also integrated the new methods into the ja3 fingerprinting tests, including the known-value tests. This should ensure that client hellos from raw bytes and client hellos from connections don't parse input differently and produce the same JA3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
