### PR TITLE
Switch OpenBSD CI job GH action to something more robust

### DIFF
--- a/.github/workflows/ci_openbsd.yml
+++ b/.github/workflows/ci_openbsd.yml
@@ -15,23 +15,15 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build and test in OpenBSD
         id: test
-        uses: vmactions/openbsd-vm@v0.1.2
+        uses: cross-platform-actions/action@v0.10.0
         with:
-          mem: 2048
-          prepare: |
-            # The / (root) mount point in the VM doesn't have enough disk
-            # space to build the project. These commands put the actual 'work'
-            # directory in the /home mount (which has lots of disk space) and
-            # creates symlinks to 'work' in the locations that the runner uses
-            # when copying artifacts back and forth between the VM and macOS
-            # host.
-            mv /Users/runner /home
-            rm -rf /Users
-            ln -s /home /Users
-            ln -sf /home/work /root/work
-            pkg_add ninja cmake
-            pkg_info
+          operating_system: openbsd
+          architecture: x86-64
+          version: '7.2'
+          shell: bash
           run: |
+            sudo pkg_add ninja cmake
+            pkg_info
             sysctl -n kern.version
             .github/s2n_bsd.sh
       - name: upload test results


### PR DESCRIPTION
### Resolved issues:

#3795

### Description of changes: 

Change GH action for the OpenBSD CI job to something which doesn't use VirtualBox as the hypervisor. This action has been more robust in other projects I've used it in.

### Call-outs:

n/a

### Testing:

This worked well for me in a fork where I triggered the action multiple times. No test failures, and 'KB used per connection' in s2n_mem_usage_test stabilized at 58-59.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
