### PR TITLE
tokio-s2n-tls: Enable access to the IO instance from TcpStream

### DIFF
--- a/bindings/rust/s2n-tls-tokio/src/lib.rs
+++ b/bindings/rust/s2n-tls-tokio/src/lib.rs
@@ -166,13 +166,13 @@ where
     C: AsRef<Connection> + AsMut<Connection> + Unpin,
     S: AsyncRead + AsyncWrite + Unpin,
 {
-    ///Access a reference to the underlaying io stream
-    pub fn io_ref(&self) -> &S {
+    ///Access a shared reference to the underlaying io stream
+    pub fn get_ref(&self) -> &S {
         &self.stream
     }
 
     ///Access the mutable reference to the underlaying io stream
-    pub fn io_mut(&mut self) -> &mut S {
+    pub fn get_mut(&mut self) -> &mut S {
         &mut self.stream
     }
 

--- a/bindings/rust/s2n-tls-tokio/src/lib.rs
+++ b/bindings/rust/s2n-tls-tokio/src/lib.rs
@@ -166,6 +166,16 @@ where
     C: AsRef<Connection> + AsMut<Connection> + Unpin,
     S: AsyncRead + AsyncWrite + Unpin,
 {
+    ///Access a reference to the underlaying io stream
+    pub fn io_ref(&self) -> &S {
+        &self.stream
+    }
+
+    ///Access the mutable reference to the underlaying io stream
+    pub fn io_mut(&mut self) -> &mut S {
+        &mut self.stream
+    }
+
     async fn open(mut conn: C, stream: S) -> Result<Self, Error> {
         conn.as_mut().set_blinding(Blinding::SelfService)?;
         let mut tls = TlsStream {

--- a/bindings/rust/s2n-tls-tokio/tests/handshake.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/handshake.rs
@@ -197,8 +197,8 @@ async fn io_stream_access() -> Result<(), Box<dyn std::error::Error>> {
     let (mut client_result, _server_result) =
         common::run_negotiate(&client, client_stream, &server, server_stream).await?;
 
-    assert_eq!(client_result.io_ref().local_addr().unwrap(), client_addr);
-    assert_eq!(client_result.io_mut().local_addr().unwrap(), client_addr);
+    assert_eq!(client_result.get_ref().local_addr().unwrap(), client_addr);
+    assert_eq!(client_result.get_mut().local_addr().unwrap(), client_addr);
 
     Ok(())
 }

--- a/bindings/rust/s2n-tls-tokio/tests/handshake.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/handshake.rs
@@ -185,3 +185,20 @@ async fn handshake_error_with_blinding() -> Result<(), Box<dyn std::error::Error
 
     Ok(())
 }
+
+#[tokio::test]
+async fn io_stream_access() -> Result<(), Box<dyn std::error::Error>> {
+    let (server_stream, client_stream) = common::get_streams().await?;
+
+    let client_addr = client_stream.local_addr().unwrap();
+    let client = TlsConnector::new(common::client_config()?.build()?);
+    let server = TlsAcceptor::new(common::server_config()?.build()?);
+
+    let (mut client_result, _server_result) =
+        common::run_negotiate(&client, client_stream, &server, server_stream).await?;
+
+    assert_eq!(client_result.io_ref().local_addr().unwrap(), client_addr);
+    assert_eq!(client_result.io_mut().local_addr().unwrap(), client_addr);
+
+    Ok(())
+}


### PR DESCRIPTION
### Description of changes: 

Allow access to the underlaying `stream` instance from TcpStream to the applications. TlsStream is often wrapped over a tokio:TcpStream instance, which (understandably so) doesn't implement `try_clone` making it hard for applications to retain access to the underlaying TcpStream to perform any operations on the socket themselves. 

### Testing:
unit-test

```
unning 7 tests
test handshake_error ... ok
test handshake_error_with_blinding ... ok
test handshake_with_connection_config ... ok
test handshake_basic ... ok
test io_stream_access ... ok
test handshake_with_pool_multithread ... ok
test handshake_with_connection_config_with_pool ... ok
```