### PR TITLE
Fixes some compiler warnings coming from tests

### DIFF
--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -1385,8 +1385,8 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn);
 
         /* Handshake is hello retry and TLS1.3 was negotiated */
-        EXPECT_OK(s2n_handshake_type_set_flag(server_conn, HELLO_RETRY_REQUEST));
         server_conn->actual_protocol_version = S2N_TLS13;
+        EXPECT_OK(s2n_handshake_type_set_tls13_flag(server_conn, HELLO_RETRY_REQUEST));
 
         /* Second client hello has version SSLv2 */
         server_conn->client_hello_version = S2N_SSLv2;

--- a/tests/unit/s2n_extended_master_secret_test.c
+++ b/tests/unit/s2n_extended_master_secret_test.c
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_conn_set_handshake_type(conn));
 
             /* Fallback to full handshake */
-            EXPECT_TRUE(s2n_handshake_type_check_tls12_flag(conn, FULL_HANDSHAKE));
+            EXPECT_TRUE(s2n_handshake_type_check_flag(conn, FULL_HANDSHAKE));
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         };
@@ -156,7 +156,7 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_conn_set_handshake_type(conn));
 
-            EXPECT_FALSE(s2n_handshake_type_check_tls12_flag(conn, FULL_HANDSHAKE));
+            EXPECT_FALSE(s2n_handshake_type_check_flag(conn, FULL_HANDSHAKE));
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         };


### PR DESCRIPTION
### Resolved issues:

N/A
### Description of changes: 

We weren't using the right s2n_handshake_type_set_flag() functions. This change fixes those warnings.
### Call-outs:

N/A
### Testing:

Warnings no longer appear when building s2n.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
