### PR TITLE
test: Add missing packages to nix devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,8 @@
             pythonEnv
             corretto-8
             gnutls-3-7
+            pkgs.iproute2
+            pkgs.apacheHttpd
 
             # C Compiler Tooling: llvmPkgs.clangUseLLVM -- wrapper to overwrite default compiler with clang
             llvmPkgs.llvm


### PR DESCRIPTION
### Resolved issues:

none

### Description of changes: 

The integrationv2 test dynamic_record_sizes expects iproute2 to be available.

The apacheHttp package is needed by the renegotiate_apache integration test, although more work will be needed in a future PR to get this test to pass.

### Call-outs:

none

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? CI

 Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
