### PR TITLE
chore: bump rust bindings for 1.3.39 release

### DIFF
--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -24,5 +24,5 @@ $ ./bindings/rust/generate.sh
 
 `s2n-tls` will maintain a rolling MSRV (minimum supported rust version) policy of at least 6 months. The current s2n-quic version is not guaranteed to build on Rust versions earlier than the MSRV.
 
-The current MSRV is [1.57.0][msrv-url].
+The current MSRV is [1.63.0][msrv-url].
 

--- a/bindings/rust/s2n-tls-sys/Cargo.toml
+++ b/bindings/rust/s2n-tls-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-sys"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.0.26"
+version = "0.0.27"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.63.0"

--- a/bindings/rust/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/s2n-tls-tokio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-tokio"
 description = "An implementation of TLS streams for Tokio built on top of s2n-tls"
-version = "0.0.26"
+version = "0.0.27"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.63.0"
@@ -15,7 +15,7 @@ default = []
 errno = { version = "0.3" }
 libc = { version = "0.2" }
 pin-project-lite = { version = "0.2" }
-s2n-tls = { version = "=0.0.26", path = "../s2n-tls" }
+s2n-tls = { version = "=0.0.27", path = "../s2n-tls" }
 tokio = { version = "1", features = ["net", "time"] }
 
 [dev-dependencies]

--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.0.26"
+version = "0.0.27"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.63.0"
@@ -18,7 +18,7 @@ testing = ["bytes"]
 bytes = { version = "1", optional = true }
 errno = { version = "0.3" }
 libc = "0.2"
-s2n-tls-sys = { version = "=0.0.26", path = "../s2n-tls-sys", features = ["internal"] }
+s2n-tls-sys = { version = "=0.0.27", path = "../s2n-tls-sys", features = ["internal"] }
 pin-project-lite = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
Bumps the version for 
- s2n-tls-sys
- s2n-tls
- s2n-tls-tokio

### Testing:
Built successfully locally.
CI should pass successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
