### PR TITLE
ci: Reminder that spec file changes disable codebuild

### DIFF
--- a/.github/workflows/ci_wontrun.yml
+++ b/.github/workflows/ci_wontrun.yml
@@ -1,0 +1,27 @@
+name: CodeBuild
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+    branches: [main]
+jobs:
+  buildspec:
+    runs-on: ubuntu-latest
+    name: Check for modified spec files
+    steps:
+      - users: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Get altered spec files
+        id: spec-files-changed
+        uses: tj-actions/changed-files@v35
+        with:
+          files: codebuild/spec/*.{yml,yaml}
+      - name: Run step if any file(s) in the docs folder change
+        if: steps.spec-files-changed.outputs.any_changed == 'true'
+        run: |
+          echo "Our CodeBuild CI will not trigger if any buildspec files changed- please provide manual testing links in the PR."
+          echo "This PR touched ${{ steps.spec-files-changed.outputs.all_changed_files }}"
+          exit 1
+


### PR DESCRIPTION
### Resolved issues:

none

### Description of changes: 

Make it clear when CodeBuild won't trigger by failing a simple PR file change check. 

### Call-outs:

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? private fork: [happy path](https://github.com/dougch/s2n-tls/actions/runs/4440971656/jobs/7795443770) [failure path](https://github.com/dougch/s2n-tls/actions/runs/4440942308/jobs/7795377235?pr=56)

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
