### PR TITLE
Document behavior of s2n_negotiate for a client with client auth

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1776,6 +1776,11 @@ typedef enum {
 /**
  * Performs the initial "handshake" phase of a TLS connection and must be called before any s2n_recv() or s2n_send() calls.
  *
+ * @note When using client authentication with TLS1.3, s2n_negotiate() will report a successful
+ * handshake to clients before the server validates the client certificate. If the server then
+ * rejects the client certificate, the client may later receive an alert while calling s2n_recv,
+ * potentially after already having sent application data with s2n_send.
+ *
  * @param conn A pointer to the s2n_connection object
  * @param blocked A pointer which will be set to the blocked status. 
  * @returns S2N_SUCCESS if the handshake completed. S2N_FAILURE if the handshake encountered an error or is blocked.

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -525,7 +525,7 @@ When using client authentication, the server MUST implement the `s2n_verify_host
 
 When using client authentication with TLS1.3, `s2n_negotiate` will report a successful
 handshake to clients before the server validates the client certificate. If the server then
-rejects the client certificate, the client may later receive an alert while calling s2n_recv,
+rejects the client certificate, the client may later receive an alert while calling `s2n_recv`,
 potentially after already having sent application data with s2n_send. This is a quirk of the
 TLS1.3 protocol message ordering: the server does not send any more handshake messages
 after the client sends the client certificate (see the [TLS1.3 state machine](https://www.rfc-editor.org/rfc/rfc8446.html#appendix-A.2)).

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -526,7 +526,7 @@ When using client authentication, the server MUST implement the `s2n_verify_host
 When using client authentication with TLS1.3, `s2n_negotiate` will report a successful
 handshake to clients before the server validates the client certificate. If the server then
 rejects the client certificate, the client may later receive an alert while calling `s2n_recv`,
-potentially after already having sent application data with s2n_send. This is a quirk of the
+potentially after already having sent application data with `s2n_send`. This is a quirk of the
 TLS1.3 protocol message ordering: the server does not send any more handshake messages
 after the client sends the client certificate (see the [TLS1.3 state machine](https://www.rfc-editor.org/rfc/rfc8446.html#appendix-A.2)).
 There is no security risk, since the client has already authenticated the server,


### PR DESCRIPTION
### Description of changes: 

A customer noticed some behavior that looks wrong, but is actually correct according to the RFC. I'm adding documentation for that behavior so that hopefully other customers don't have to puzzle it out themselves too.

### Testing:
Just a documentation change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
