### PR TITLE
Send supported version as long as client supports TLSv1.3

### DIFF
--- a/tests/unit/s2n_extension_type_test.c
+++ b/tests/unit/s2n_extension_type_test.c
@@ -75,10 +75,20 @@ int main()
             EXPECT_FALSE(s2n_extension_never_send(NULL));
 
             struct s2n_connection conn = { 0 };
+            conn.client_protocol_version = S2N_TLS12;
             conn.actual_protocol_version = S2N_TLS12;
             EXPECT_FALSE(s2n_extension_send_if_tls13_connection(&conn));
+            EXPECT_FALSE(s2n_extension_send_if_client_supports_tls13(&conn));
+
+            conn.client_protocol_version = S2N_TLS13;
+            conn.actual_protocol_version = S2N_TLS12;
+            EXPECT_FALSE(s2n_extension_send_if_tls13_connection(&conn));
+            EXPECT_TRUE(s2n_extension_send_if_client_supports_tls13(&conn));
+
+            conn.client_protocol_version = S2N_TLS13;
             conn.actual_protocol_version = S2N_TLS13;
             EXPECT_TRUE(s2n_extension_send_if_tls13_connection(&conn));
+            EXPECT_TRUE(s2n_extension_send_if_client_supports_tls13(&conn));
         };
 
         /* Test common implementations for if_missing */

--- a/tls/extensions/s2n_client_supported_versions.c
+++ b/tls/extensions/s2n_client_supported_versions.c
@@ -52,7 +52,7 @@ const s2n_extension_type s2n_client_supported_versions_extension = {
     .is_response = false,
     .send = s2n_client_supported_versions_send,
     .recv = s2n_client_supported_versions_recv,
-    .should_send = s2n_extension_send_if_tls13_connection,
+    .should_send = s2n_extension_send_if_client_supports_tls13,
     .if_missing = s2n_extension_noop_if_missing,
 };
 

--- a/tls/extensions/s2n_extension_type.c
+++ b/tls/extensions/s2n_extension_type.c
@@ -228,6 +228,11 @@ bool s2n_extension_never_send(struct s2n_connection *conn)
     return false;
 }
 
+bool s2n_extension_send_if_client_supports_tls13(struct s2n_connection *conn)
+{
+    return s2n_connection_get_client_protocol_version(conn) >= S2N_TLS13;
+}
+
 bool s2n_extension_send_if_tls13_connection(struct s2n_connection *conn)
 {
     return s2n_connection_get_protocol_version(conn) >= S2N_TLS13;

--- a/tls/extensions/s2n_extension_type.h
+++ b/tls/extensions/s2n_extension_type.h
@@ -98,6 +98,7 @@ int s2n_extension_recv_noop(struct s2n_connection *conn, struct s2n_stuffer *out
 /* Common implementations for should_send */
 bool s2n_extension_always_send(struct s2n_connection *conn);
 bool s2n_extension_never_send(struct s2n_connection *conn);
+bool s2n_extension_send_if_client_supports_tls13(struct s2n_connection *conn);
 bool s2n_extension_send_if_tls13_connection(struct s2n_connection *conn);
 
 /* Common implementations for if_missing */


### PR DESCRIPTION
### Resolved issues:

resolves #3892

### Description of changes: 

Previously we used to send supported version extension only when the actual protocol was TLSv1.3. This did not work well when client attempted to resume TLSv1.2 or below session on a server which added support for TLSv1.3, as actual protocol version was set to TLS version of that cached session resulting in no supported version extension getting sent. Because server didn't get such extension it would negotiate TLSv1.2 but still indicate support of TLSv1.3, which client would interpret as protocol downgrade.

This commit changes logic to send supported version extension as long as client supports TLSv1.3, allowing server to ignore the session resumption and negotiate TLSv1.3 through a full handshake without causing conneciton failures.

### Call-outs:

None

### Testing:

Updated unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
