### PR TITLE
Remove 1.0 and 1.1 from default security policies

### DIFF
--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -392,7 +392,7 @@ The following chart maps the security policy version to protocol version and cip
 
 |           version                            | SSLv3 | TLS1.0 | TLS1.1 | TLS1.2 | TLS1.3  | AES-CBC | ChaCha20-Poly1305 | ECDSA | AES-GCM | 3DES | RC4 | DHE | ECDHE | ChaCha20-Boosted |
 |----------------------------------------------|-------|--------|--------|--------|---------|---------|-------------------|-------|---------|------|-----|-----|-------|------------------|
-|          "default"                           |       |   X    |    X   |    X   |         |    X    |          X        |       |    X    |      |     |     |   X   |                  |
+|          "default"                           |       |        |        |    X   |         |    X    |          X        |       |    X    |      |     |     |   X   |                  |
 |          "20190214"                          |       |   X    |    X   |    X   |         |    X    |                   |   X   |    X    |  X   |     |  X  |   X   |                  |
 |          "20170718"                          |       |   X    |    X   |    X   |         |    X    |                   |       |    X    |      |     |     |   X   |                  |
 |          "20170405"                          |       |   X    |    X   |    X   |         |    X    |                   |       |    X    |  X   |     |     |   X   |                  |
@@ -409,7 +409,7 @@ The following chart maps the security policy version to protocol version and cip
 |          "20190120"                          |       |   X    |    X   |    X   |         |    X    |                   |       |    X    |  X   |     |     |   X   |                  |
 |          "20190121"                          |       |   X    |    X   |    X   |         |    X    |                   |       |    X    |  X   |     |     |   X   |                  |
 |          "20190122"                          |       |   X    |    X   |    X   |         |    X    |                   |   X   |    X    |  X   |     |  X  |   X   |                  |
-|        "default_tls13"                       |       |   X    |    X   |    X   |    X    |    X    |          X        |   X   |    X    |      |     |     |   X   |                  |
+|        "default_tls13"                       |       |        |        |    X   |    X    |    X    |          X        |   X   |    X    |      |     |     |   X   |                  |
 |          "20190801"                          |       |   X    |    X   |    X   |    X    |    X    |          X        |       |    X    |      |     |     |   X   |                  |
 |          "20190802"                          |       |   X    |    X   |    X   |    X    |    X    |          X        |       |    X    |      |     |     |   X   |                  |
 |          "20200207"                          |       |   X    |    X   |    X   |    X    |    X    |          X        |       |    X    |      |     |     |       |                  |

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -221,6 +221,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
+            conn->actual_protocol_version = i;
 
             conn->session_id_len = S2N_TLS_SESSION_ID_MAX_LEN;
             EXPECT_MEMCPY_SUCCESS(conn->session_id, test_session_id, S2N_TLS_SESSION_ID_MAX_LEN);

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -19,16 +19,16 @@
 #include "tls/s2n_connection.h"
 #include "utils/s2n_safety.h"
 
-const struct s2n_security_policy security_policy_20170210 = {
-    .minimum_protocol_version = S2N_TLS10,
+const struct s2n_security_policy security_policy_default_20230317 = {
+    .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_20170210,
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
 };
 
-const struct s2n_security_policy security_policy_default_tls13 = {
-    .minimum_protocol_version = S2N_TLS10,
+const struct s2n_security_policy security_policy_default_tls13_20230317 = {
+    .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_20210831,
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
@@ -42,13 +42,21 @@ const struct s2n_security_policy security_policy_default_tls13 = {
  *
  * Supports TLS1.2
  */
-const struct s2n_security_policy security_policy_default_fips = {
+const struct s2n_security_policy security_policy_default_fips_20230317 = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_default_fips,
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_default_fips,
     .certificate_signature_preferences = &s2n_signature_preferences_default_fips,
     .ecc_preferences = &s2n_ecc_preferences_default_fips,
+};
+
+const struct s2n_security_policy security_policy_20170210 = {
+    .minimum_protocol_version = S2N_TLS10,
+    .cipher_preferences = &cipher_preferences_20170210,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20140601,
+    .ecc_preferences = &s2n_ecc_preferences_20140601,
 };
 
 const struct s2n_security_policy security_policy_20190801 = {
@@ -784,9 +792,9 @@ const struct s2n_security_policy security_policy_null = {
 };
 
 struct s2n_security_policy_selection security_policy_selection[] = {
-    { .version = "default", .security_policy = &security_policy_20170210, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
-    { .version = "default_tls13", .security_policy = &security_policy_default_tls13, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
-    { .version = "default_fips", .security_policy = &security_policy_default_fips, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "default", .security_policy = &security_policy_default_20230317, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "default_tls13", .security_policy = &security_policy_default_tls13_20230317, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "default_fips", .security_policy = &security_policy_default_fips_20230317, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "ELBSecurityPolicy-TLS-1-0-2015-04", .security_policy = &security_policy_elb_2015_04, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     /* Not a mistake. TLS-1-0-2015-05 and 2016-08 are equivalent */
     { .version = "ELBSecurityPolicy-TLS-1-0-2015-05", .security_policy = &security_policy_elb_2016_08, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -63,8 +63,9 @@ extern const struct s2n_security_policy security_policy_20190214;
 extern const struct s2n_security_policy security_policy_20190214_gcm;
 extern const struct s2n_security_policy security_policy_20190801;
 extern const struct s2n_security_policy security_policy_20190802;
-extern const struct s2n_security_policy security_policy_default_tls13;
-extern const struct s2n_security_policy security_policy_default_fips;
+extern const struct s2n_security_policy security_policy_default_20230317;
+extern const struct s2n_security_policy security_policy_default_tls13_20230317;
+extern const struct s2n_security_policy security_policy_default_fips_20230317;
 extern const struct s2n_security_policy security_policy_test_all;
 
 extern const struct s2n_security_policy security_policy_test_all_tls12;


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/3621
resolves https://github.com/aws/s2n-tls/issues/3898

### Description of changes: 

It might be time.

Our docs state that non-versioned policies can change:
> The "default" and "default_tls13" version is special in that it will be updated with future s2n-tls changes and ciphersuites and protocol versions may be added and removed, or their internal order of preference might change. Numbered versions are fixed and will never change.

TLS1.0 and TLS1.1 are deprecated and shouldn't be used. They really can't be considered "sane defaults" anymore.

### Testing:
* No tests seem to have failed. I searched for tests referencing TLS1.0 or TLS1.1, and found that they generally 1) set actual_protocol_version directly 2) used a custom security policy 3) used a versioned security policy 4) used "test_all". I'm pleasantly surprised.
  * during this search I found one test in s2n_client_hello_test.c that declared a version but didn't use it. I fixed it, but it's not really related to this change.
* I added a test to make sure that when we update defaults, we don't make the updates so drastic that deploying s2n-tls to a fleet using a default policy would be dangerous. This might make updating defaults a little less scary?
* I don't see any code coverage drop between [the report for this change](https://dx1inn44oyl7n.cloudfront.net/1943fac3cf1635c0a93adbb22b08bfada070955d/report/index.html), and [the report for the current tip of main](https://dx1inn44oyl7n.cloudfront.net/805bdcc6251480911c69b7b03e3459bef4dd9506/report/index.html).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
