### PR TITLE
CI: Restrict Nix integ test to 1 job

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -695,27 +695,24 @@ if (BUILD_TESTING)
     if (S2N_INTEG_TESTS)
         find_package (Python3 COMPONENTS Interpreter Development)
         file(GLOB integv2_test_files "${PROJECT_SOURCE_DIR}/tests/integrationv2/test_*.py")
-        if (DEFINED ENV{CODEBUILD_BUILD_NUMBER})
-            message(STATUS "Codebuild detected: integ test run will be single threaded.")
-        endif()
         foreach(test_file_path ${integv2_test_files})
             get_filename_component(test_filename ${test_file_path} NAME_WE)
             string(REGEX REPLACE "^test_" "integrationv2_" test_target ${test_filename})
-            if (S2N_FAST_INTEG_TESTS)
-                cmake_host_system_information(RESULT N QUERY NUMBER_OF_LOGICAL_CORES)
-                if (N EQUAL 0 OR DEFINED ENV{CODEBUILD_BUILD_NUMBER})
-                    set(N 1)
-                endif()
-                add_test(NAME ${test_target}
-                    COMMAND
-                    pytest
-                    -x -n=${N} --maxfail=1 --reruns=0 --cache-clear -rpfsq
-                    -o log_cli=true --log-cli-level=DEBUG --provider-version=$ENV{S2N_LIBCRYPTO}
-                    --provider-criterion=off --fips-mode=0 --no-pq=0 ${test_file_path}
-                    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/integrationv2
-                )
-            else()
-                add_test(NAME ${test_target}
+	    if (S2N_FAST_INTEG_TESTS)
+	        cmake_host_system_information(RESULT N QUERY NUMBER_OF_LOGICAL_CORES)
+	        if (N EQUAL 0)
+		    set(N 1)
+		endif()
+   	        add_test(NAME ${test_target}
+		  COMMAND
+		  pytest
+		  -x -n=${N} --maxfail=1 --reruns=0 --cache-clear -rpfsq
+		  -o log_cli=true --log-cli-level=DEBUG --provider-version=$ENV{S2N_LIBCRYPTO}
+		  --provider-criterion=off --fips-mode=0 --no-pq=0 ${test_file_path}
+		  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/integrationv2
+		)
+	    else()
+	        add_test(NAME ${test_target}
                   COMMAND
                   ${CMAKE_COMMAND} -E env
                   DYLD_LIBRARY_PATH=${PROJECT_SOURCE_DIR}/libcrypto-root/lib:$ENV{DYLD_LIBRARY_PATH}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -698,32 +698,30 @@ if (BUILD_TESTING)
         foreach(test_file_path ${integv2_test_files})
             get_filename_component(test_filename ${test_file_path} NAME_WE)
             string(REGEX REPLACE "^test_" "integrationv2_" test_target ${test_filename})
-	    if (S2N_FAST_INTEG_TESTS)
-	        cmake_host_system_information(RESULT N QUERY NUMBER_OF_LOGICAL_CORES)
-	        if (N EQUAL 0)
-		    set(N 1)
-		endif()
-   	        add_test(NAME ${test_target}
-		  COMMAND
-		  pytest
-		  -x -n=${N} --maxfail=1 --reruns=0 --cache-clear -rpfsq
-		  -o log_cli=true --log-cli-level=DEBUG --provider-version=$ENV{S2N_LIBCRYPTO}
-		  --provider-criterion=off --fips-mode=0 --no-pq=0 ${test_file_path}
-		  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/integrationv2
-		)
-	    else()
-	        add_test(NAME ${test_target}
-                  COMMAND
-                  ${CMAKE_COMMAND} -E env
-                  DYLD_LIBRARY_PATH=${PROJECT_SOURCE_DIR}/libcrypto-root/lib:$ENV{DYLD_LIBRARY_PATH}
-                  LD_LIBRARY_PATH=${PROJECT_SOURCE_DIR}/libcrypto-root/lib:${PROJECT_SOURCE_DIR}/test-deps/openssl-1.1.1/lib:${PROJECT_SOURCE_DIR}/test-deps/gnutls37/nettle/lib:$ENV{LD_LIBRARY_PATH}
-                  PATH=${PROJECT_SOURCE_DIR}/bin:${PROJECT_SOURCE_DIR}/test-deps/openssl-1.1.1/bin:${PROJECT_SOURCE_DIR}/test-deps/gnutls37/bin:$ENV{PATH}
-                  PYTHONNOUSERSITE=1
-                  S2N_INTEG_TEST=1
-                  TOX_TEST_NAME=${test_file_path}
-                  ${Python3_EXECUTABLE} -m tox
-                  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/integrationv2)
-	    endif()
+            if (S2N_INTEG_DIRECT)
+                # For Nix and environments where LD_LIBRARY_PATH is already correct (no tox).
+                add_test(NAME ${test_target}
+                        COMMAND
+                        pytest
+                        -x -n=1 --maxfail=1 --reruns=0 --cache-clear -rpfsq
+                        -o log_cli=true --log-cli-level=DEBUG --provider-version=$ENV{S2N_LIBCRYPTO}
+                        --provider-criterion=off --fips-mode=0 --no-pq=0 ${test_file_path}
+                        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/integrationv2
+                )
+            else()
+                # For use with libcryptos built into test-deps, and not in LD_LIBRARY_PATH.
+                add_test(NAME ${test_target}
+                        COMMAND
+                        ${CMAKE_COMMAND} -E env
+                        DYLD_LIBRARY_PATH=${PROJECT_SOURCE_DIR}/libcrypto-root/lib:$ENV{DYLD_LIBRARY_PATH}
+                        LD_LIBRARY_PATH=${PROJECT_SOURCE_DIR}/libcrypto-root/lib:${PROJECT_SOURCE_DIR}/test-deps/openssl-1.1.1/lib:${PROJECT_SOURCE_DIR}/test-deps/gnutls37/nettle/lib:$ENV{LD_LIBRARY_PATH}
+                        PATH=${PROJECT_SOURCE_DIR}/bin:${PROJECT_SOURCE_DIR}/test-deps/openssl-1.1.1/bin:${PROJECT_SOURCE_DIR}/test-deps/gnutls37/bin:$ENV{PATH}
+                        PYTHONNOUSERSITE=1
+                        S2N_INTEG_TEST=1
+                        TOX_TEST_NAME=${test_file_path}
+                        ${Python3_EXECUTABLE} -m tox
+                        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/integrationv2)
+            endif()
             set_property(TEST ${test_target} PROPERTY LABELS "integrationv2")
             set_property(TEST ${test_target} PROPERTY TIMEOUT 7200)
         endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -698,8 +698,10 @@ if (BUILD_TESTING)
         foreach(test_file_path ${integv2_test_files})
             get_filename_component(test_filename ${test_file_path} NAME_WE)
             string(REGEX REPLACE "^test_" "integrationv2_" test_target ${test_filename})
-            if (S2N_INTEG_DIRECT)
-                # For Nix and environments where LD_LIBRARY_PATH is already correct (no tox).
+            if (S2N_INTEG_NIX)
+                # For Nix and environments where LD_LIBRARY_PATH is already correct.
+                # We're also dropping tox and calling pytest directly, because
+                # Nix is already handling all of the python setup.
                 add_test(NAME ${test_target}
                         COMMAND
                         pytest
@@ -710,6 +712,8 @@ if (BUILD_TESTING)
                 )
             else()
                 # For use with libcryptos built into test-deps, and not in LD_LIBRARY_PATH.
+                # This is a duplication of tests/integrationv2/Makefile and
+                # can go away once all the Nix porting is finished.
                 add_test(NAME ${test_target}
                         COMMAND
                         ${CMAKE_COMMAND} -E env

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -695,24 +695,27 @@ if (BUILD_TESTING)
     if (S2N_INTEG_TESTS)
         find_package (Python3 COMPONENTS Interpreter Development)
         file(GLOB integv2_test_files "${PROJECT_SOURCE_DIR}/tests/integrationv2/test_*.py")
+        if (DEFINED ENV{CODEBUILD_BUILD_NUMBER})
+            message(STATUS "Codebuild detected: integ test run will be single threaded.")
+        endif()
         foreach(test_file_path ${integv2_test_files})
             get_filename_component(test_filename ${test_file_path} NAME_WE)
             string(REGEX REPLACE "^test_" "integrationv2_" test_target ${test_filename})
-	    if (S2N_FAST_INTEG_TESTS)
-	        cmake_host_system_information(RESULT N QUERY NUMBER_OF_LOGICAL_CORES)
-	        if (N EQUAL 0)
-		    set(N 1)
-		endif()
-   	        add_test(NAME ${test_target}
-		  COMMAND
-		  pytest
-		  -x -n=${N} --maxfail=1 --reruns=0 --cache-clear -rpfsq
-		  -o log_cli=true --log-cli-level=DEBUG --provider-version=$ENV{S2N_LIBCRYPTO}
-		  --provider-criterion=off --fips-mode=0 --no-pq=0 ${test_file_path}
-		  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/integrationv2
-		)
-	    else()
-	        add_test(NAME ${test_target}
+            if (S2N_FAST_INTEG_TESTS)
+                cmake_host_system_information(RESULT N QUERY NUMBER_OF_LOGICAL_CORES)
+                if (N EQUAL 0 OR DEFINED ENV{CODEBUILD_BUILD_NUMBER})
+                    set(N 1)
+                endif()
+                add_test(NAME ${test_target}
+                    COMMAND
+                    pytest
+                    -x -n=${N} --maxfail=1 --reruns=0 --cache-clear -rpfsq
+                    -o log_cli=true --log-cli-level=DEBUG --provider-version=$ENV{S2N_LIBCRYPTO}
+                    --provider-criterion=off --fips-mode=0 --no-pq=0 ${test_file_path}
+                    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/integrationv2
+                )
+            else()
+                add_test(NAME ${test_target}
                   COMMAND
                   ${CMAKE_COMMAND} -E env
                   DYLD_LIBRARY_PATH=${PROJECT_SOURCE_DIR}/libcrypto-root/lib:$ENV{DYLD_LIBRARY_PATH}

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -16,7 +16,7 @@ function configure {
           -DBUILD_TESTING=ON \
           -DS2N_INTEG_TESTS=ON \
           -DS2N_INSTALL_S2NC_S2ND=ON \
-          -DS2N_INTEG_DIRECT=ON \
+          -DS2N_INTEG_NIX=ON \
           -DBUILD_SHARED_LIBS=ON \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo
 }

--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -16,7 +16,7 @@ function configure {
           -DBUILD_TESTING=ON \
           -DS2N_INTEG_TESTS=ON \
           -DS2N_INSTALL_S2NC_S2ND=ON \
-          -DS2N_FAST_INTEG_TESTS=ON \
+          -DS2N_INTEG_DIRECT=ON \
           -DBUILD_SHARED_LIBS=ON \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo
 }


### PR DESCRIPTION
### Resolved issues:

none

### Description of changes: 

For the Nix integ tests, we're running into port collision from (naively) spawning too many tests (see https://github.com/aws/s2n-tls/issues/2127 and related https://github.com/aws/s2n-tls/issues/3547). This renames the CMake flag `S2N_FAST_INTEG_TESTS` and removes the logic to spawn too many test workers.

### Call-outs:

There were tabs in the cmake file that were removed (hence the messy diff)

The legacy integration tests could _still_ be setup with CMake, without the S2N_INTEG_NIX flag.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? locally, CI

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
