### PR TITLE
Resolve compiler issues with 32-bit architectures.

### DIFF
--- a/crypto/s2n_dhe.c
+++ b/crypto/s2n_dhe.c
@@ -18,6 +18,7 @@
 #include <openssl/bn.h>
 #include <openssl/dh.h>
 #include <openssl/evp.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include "crypto/s2n_openssl.h"
@@ -142,7 +143,7 @@ int s2n_pkcs3_to_dh_params(struct s2n_dh_params *dh_params, struct s2n_blob *pkc
     uint8_t *original_ptr = pkcs3->data;
     dh_params->dh = d2i_DHparams(NULL, (const unsigned char **) (void *) &pkcs3->data, pkcs3->size);
     POSIX_GUARD(s2n_check_p_g_dh_params(dh_params));
-    if (pkcs3->data && (pkcs3->data - original_ptr != pkcs3->size)) {
+    if (pkcs3->data && (pkcs3->data - original_ptr != (ptrdiff_t) pkcs3->size)) {
         DH_free(dh_params->dh);
         POSIX_BAIL(S2N_ERR_INVALID_PKCS3);
     }

--- a/tls/s2n_early_data_io.c
+++ b/tls/s2n_early_data_io.c
@@ -180,7 +180,7 @@ S2N_RESULT s2n_send_early_data_impl(struct s2n_connection *conn, const uint8_t *
      * We only care about the result of this call if it fails. */
     uint32_t early_data_to_send = 0;
     RESULT_GUARD_POSIX(s2n_connection_get_remaining_early_data_size(conn, &early_data_to_send));
-    early_data_to_send = MIN(data_len, early_data_to_send);
+    early_data_to_send = MIN((uint32_t) data_len, early_data_to_send);
     if (early_data_to_send) {
         ssize_t send_result = s2n_send(conn, data, early_data_to_send, blocked);
         RESULT_GUARD_POSIX(send_result);

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -193,7 +193,7 @@ ssize_t s2n_recv_impl(struct s2n_connection *conn, void *buf, ssize_t size, s2n_
             continue;
         }
 
-        out.size = MIN(size, s2n_stuffer_data_available(&conn->in));
+        out.size = MIN((uint32_t) size, s2n_stuffer_data_available(&conn->in));
 
         POSIX_GUARD(s2n_stuffer_erase_and_read(&conn->in, &out));
         bytes_read += out.size;

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -20,6 +20,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <limits.h>
 #include <sys/mman.h>
 #include <unistd.h>
 
@@ -51,7 +52,7 @@ static int s2n_mem_init_impl(void)
     POSIX_ENSURE_GT(sysconf_rc, 0);
 
     /* page_size must be a valid uint32 */
-    POSIX_ENSURE_LTE(sysconf_rc, UINT32_MAX);
+    POSIX_ENSURE_LTE(sysconf_rc, ((LONG_MAX > UINT32_MAX) ? (long) UINT32_MAX : LONG_MAX));
 
     page_size = (uint32_t) sysconf_rc;
 


### PR DESCRIPTION
Builds on 32-bit or 64-bit x86.

Fixes issue #3861 (-Werror=sign-compare fails on 32-bit architectures since 1.3.38). See also issue #3896.

This is a refresh of pull request #3868 against the latest master.

It should build with or without -Werror=sign-compare on x86_32 or x86_64.

### Resolved issues:

 resolves #3861, related to #3896

### Description of changes: 

Changes to support building on 32-bit architectures - in particular, those with 32-bit size_t and 32-bit long int.

### Call-outs:

### Testing:

32-bit CI is still desirable (see #3896).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
