### PR TITLE
test: Nix s3 cache

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -104,6 +104,7 @@
             pkgs.which
           ];
         };
+        packages.devShell = devShells.default.inputDerivation;
         packages.default = packages.s2n-tls;
         packages.s2n-tls-openssl3 = packages.s2n-tls.overrideAttrs
           (finalAttrs: previousAttrs: { doCheck = true; });

--- a/nix/README.md
+++ b/nix/README.md
@@ -30,7 +30,7 @@ integ
 Nix can store build artifacts in an external store, to reduce build times, and to allow CI to only do the build task once.
 While there are [services to handle this](https://www.cachix.org/), for s2n-tls' CI, we're relying on S3 buckets.
 
-In it's simplest form, the `nix copy` command can be used to stash a specific pacakge, but in the case of CI, where we'd like to stash an entire build environment,
+In its simplest form, the `nix copy` command can be used to stash a specific package, but in the case of CI, where we'd like to stash an entire build environment,
  more sophistication is required.
 
 By using inputDerivation, we can create a meta-package that contains all the packages in our devShell.

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,54 @@
+### Nix support
+
+### Devshell
+
+To enter a development shell with everything needed to build and test, run `nix develop` at the root of the project.
+
+There are some helper scripts in the environment to make building easier, but if you're familiar with Nix, note that these are 
+separate from the buildPhase, configurePhase and checkPhase.
+
+### Unit tests
+
+- Oneshot: `nix develop --max-jobs auto --ignore-environnment --command bash -c "source ./nix/shell.sh; configure;build;unit" `
+
+### Integration tests
+
+- Oneshot: `nix develop --max-jobs auto --ignore-environnment --command bash -c "source ./nix/shell.sh; configure;build;integ" `
+- Specific test: `nix develop --max-jobs auto --ignore-environnment --command bash -c "source ./nix/shell.sh; configure;build;integ happy_path"`
+
+- Interactivly: 
+
+```
+nix develop
+configure
+build
+integ
+```
+
+### S3 Binary Cache
+
+Nix can store build artifacts in an external store, to reduce build times, and to allow CI to only do the build task once.
+While there are [services to handle this](https://www.cachix.org/), for s2n-tls' CI, we're relying on S3 buckets.
+
+In it's simplest form, the `nix copy` command can be used to stash a specific pacakge, but in the case of CI, where we'd like to stash an entire build environment,
+ more sophistication is required.
+
+By using inputDerivation, we can create a meta-package that contains all the packages in our devShell.
+
+As an exmample, this copy will stash the s2n-tls devShell:
+
+```
+nix copy --to 's3://my-nix-chache-bucket?region=us-west-2' .#devShell
+```
+
+To retrieve these:
+
+```
+nix copy --from  's3://my-nix-cache-bucket?region=us-west-2' --all --no-check-sigs
+```
+
+(--no-check-sigs because this bucket is private and authenticated)
+
+#### Links
+
+- nix copy [documentation](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-copy.html)

--- a/nix/README.md
+++ b/nix/README.md
@@ -16,7 +16,7 @@ separate from the buildPhase, configurePhase and checkPhase.
 - Oneshot: `nix develop --max-jobs auto --ignore-environnment --command bash -c "source ./nix/shell.sh; configure;build;integ" `
 - Specific test: `nix develop --max-jobs auto --ignore-environnment --command bash -c "source ./nix/shell.sh; configure;build;integ happy_path"`
 
-- Interactivly: 
+- interactively: 
 
 ```
 nix develop


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

Use `inputDerivation` to make it easier to stash binary artifacts for a nix devShell in s3.

### Call-outs:

The bulk of the s3 cache work is in CI and setting up the s3 bucket and policies.

The Readme is incomplete, and should be iterated on in future PRs

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? private CI

 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
