### PR TITLE
Reinstate Kyber KEM check

### DIFF
--- a/tests/unit/s2n_pq_kem_test.c
+++ b/tests/unit/s2n_pq_kem_test.c
@@ -54,6 +54,13 @@ int main()
 {
     BEGIN_TEST();
 
+#if defined(OPENSSL_IS_AWSLC) && defined(AWSLC_API_VERSION)
+    /* If using non-FIPS AWS-LC >= v1.6 (API vers. 21), expect Kyber512 KEM from AWS-LC */
+    if (!s2n_libcrypto_is_fips() && AWSLC_API_VERSION >= 21) {
+        EXPECT_TRUE(s2n_libcrypto_supports_kyber_512());
+    }
+#endif
+
     for (size_t i = 0; i < s2n_array_len(test_vectors); i++) {
         const struct s2n_kem_test_vector vector = test_vectors[i];
         const struct s2n_kem *kem = vector.kem;


### PR DESCRIPTION
# Notes

Some AWS-LC versions with API v20 (such as v1.3.0) do not have the new
KEM API present, so this test would erroneously fail against slightly
older versions of AWS-LC. Now that [AWS-LC has incremented its API][1]
version, we can reliably key off of the new version to ensure that the
KEM API really is present.

For non-AWS-LC or older AWS-LC without an API version, we don't compile
the check because we only expect the Kyber KEM API to be present in
newer AWS-LC builds.

This commit resolves [Issue #3902][2].

[1]: https://github.com/aws/aws-lc/pull/900
[2]: https://github.com/aws/s2n-tls/issues/3902

# Testing

- built/installed AWS-LC locally checked out at [commit 66beb5d](https://github.com/aws/aws-lc/commit/66beb5d305d582c08966cfee1173fe1dceab84d4), **just before AWS_LC_API_VERSION was added**. tried to build/run s2n-tls against that version of AWS-LC, but build failed for unrelated reasons. `RSA_PSS_SALTLEN_DIGEST` and other symbols couldn't be found. this tells me that sufficiently old versions of AWS-LC aren't supported by s2n-tls regardless of this change.
- CI checks (AWS-LC API version currently at 20 in s2n-tls's CI images)
- built s2n-tls locally against AWS-LC with API version 21 (contents of [AWS-LC PR #900](https://github.com/aws/aws-lc/pull/900), tests passed:

```
$ cat $(which cmake-build.sh)
#!/bin/bash

set -ex
set -o pipefail

rm -rf build
mkdir -p build
cd build

pwd

export INSATLL_DIR=${HOME}/workplace/local-install
export CTEST_OUTPUT_ON_FAILURE=1

NPROC=$(nproc)

mkdir -p ${INSATLL_DIR}
cmake \
    -DCMAKE_PREFIX_PATH=${INSATLL_DIR} \
    -DCMAKE_INSTALL_PREFIX=${INSATLL_DIR} \
    -DCMAKE_VERBOSE_MAKEFILE=1 \
    ..

make -j $NPROC 2>&1 | tee build_debug_output.txt
ctest -j $NPROC | tee test_debug_output.txt
make install -j $NPROC

$ cd /local/home/childw/workplace/github/WillChilds-Klein/aws-lc && cmake-build.sh
...

$ ag '#define AWSLC_API_VERSION'
include/openssl/base.h
211:#define AWSLC_API_VERSION 21

$ cd /local/home/childw/workplace/github/WillChilds-Klein/s2n-tls/build && cmake-build.sh
...
236/236 Test #165: s2n_self_talk_session_id_test ....................   Passed   36.44 sec

100% tests passed, 0 tests failed out of 236

Label Time Summary:
unit    = 292.00 sec*proc (236 tests)

Total Test time (real) =  53.93 sec
...
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
