### PR TITLE
Don't set actual_protocol_version early when resuming a session

### DIFF
--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -284,13 +284,14 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_config_free(config));
             };
 
-            /* Generate a session id if the negotiated protocol is less than TLS1.3 */
+            /* Generate a session id if trying to resume a <TLS1.3 session */
             {
                 DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
                         s2n_connection_ptr_free);
                 EXPECT_NOT_NULL(conn);
                 struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
-                conn->actual_protocol_version = S2N_TLS12;
+                conn->resume_protocol_version = S2N_TLS12;
+                EXPECT_TRUE(conn->actual_protocol_version >= S2N_TLS13);
                 EXPECT_TRUE(conn->client_protocol_version >= S2N_TLS13);
 
                 EXPECT_SUCCESS(s2n_client_hello_send(conn));
@@ -299,7 +300,26 @@ int main(int argc, char **argv)
                 uint8_t session_id_length = 0;
                 EXPECT_SUCCESS(s2n_stuffer_read_uint8(hello_stuffer, &session_id_length));
                 EXPECT_EQUAL(session_id_length, S2N_TLS_SESSION_ID_MAX_LEN);
-            }
+            };
+
+            /* Fail if we need to generate a session id to resume a <TLS1.3 session
+             * with QUIC support enabled.
+             *
+             * This should never happen because QUIC requires TLS1.3, so a QUIC
+             * client should never receive a valid TLS1.2 ticket from a QUIC server.
+             */
+            {
+                DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                        s2n_connection_ptr_free);
+                EXPECT_NOT_NULL(conn);
+                conn->resume_protocol_version = S2N_TLS12;
+                EXPECT_TRUE(conn->actual_protocol_version >= S2N_TLS13);
+                EXPECT_TRUE(conn->client_protocol_version >= S2N_TLS13);
+                conn->quic_enabled = true;
+
+                EXPECT_FAILURE_WITH_ERRNO(s2n_client_hello_send(conn),
+                        S2N_ERR_UNSUPPORTED_WITH_QUIC);
+            };
 
             EXPECT_SUCCESS(s2n_disable_tls13_in_test());
         }

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -1271,7 +1271,6 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_free(config));
         };
 
-
         /* Check session ticket can be decrypted with a small secret in TLS13 session resumption. */
         {
             struct s2n_connection *conn;

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -703,7 +703,7 @@ int main(int argc, char **argv)
             EXPECT_OK(s2n_deserialize_resumption_state(conn, NULL, &ticket_stuffer));
 
             EXPECT_TRUE(conn->ems_negotiated);
-            EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS12);
+            EXPECT_EQUAL(conn->resume_protocol_version, S2N_TLS12);
             EXPECT_EQUAL(conn->secure->cipher_suite, &s2n_rsa_with_aes_128_gcm_sha256);
 
             EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, conn->secrets.tls12.master_secret, S2N_TLS_SECRET_LEN);
@@ -1246,6 +1246,7 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             conn->actual_protocol_version = S2N_TLS12;
+            conn->handshake.handshake_type = NEGOTIATED;
 
             struct s2n_blob secret = { 0 };
             struct s2n_stuffer secret_stuffer = { 0 };
@@ -1269,6 +1270,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_free(conn));
             EXPECT_SUCCESS(s2n_config_free(config));
         };
+
 
         /* Check session ticket can be decrypted with a small secret in TLS13 session resumption. */
         {

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -201,6 +201,11 @@ struct s2n_connection {
     uint8_t client_protocol_version;
     uint8_t server_protocol_version;
     uint8_t actual_protocol_version;
+    /* The version stored in the ticket / session we are resuming.
+     * We expect the connection to negotiate this version during
+     * the resumption handshake.
+     */
+    uint8_t resume_protocol_version;
 
     /* Flag indicating whether a protocol version has been
      * negotiated yet. */
@@ -366,7 +371,6 @@ struct s2n_connection {
     struct s2n_blob client_ticket;
     uint32_t ticket_lifetime_hint;
     struct s2n_ticket_fields tls13_ticket_fields;
-    uint8_t resume_protocol_version;
 
     /* Session ticket extension from client to attempt to decrypt as the server. */
     uint8_t ticket_ext_data[S2N_TLS12_TICKET_SIZE_IN_BYTES];

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -366,6 +366,7 @@ struct s2n_connection {
     struct s2n_blob client_ticket;
     uint32_t ticket_lifetime_hint;
     struct s2n_ticket_fields tls13_ticket_fields;
+    uint8_t resume_protocol_version;
 
     /* Session ticket extension from client to attempt to decrypt as the server. */
     uint8_t ticket_ext_data[S2N_TLS12_TICKET_SIZE_IN_BYTES];

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -43,14 +43,13 @@ int s2n_allowed_to_cache_connection(struct s2n_connection *conn)
     return config->use_session_cache;
 }
 
-/* A quirk of the TLS1.2 session resumption behavior is that if a ticket is set
- * on the connection using s2n_connection_set_session, s2n_connection_get_session
- * will return a valid ticket, even before actually receiving a new session ticket
- * from the server.
+/* If a protocol version is required before the actual_protocol_version
+ * is negotiated, we should fall back to resume_protocol_version if available.
  *
- * To maintain this behavior, we use resume_protocol_version (set when a ticket
- * is set on the connection) instead of actual_protocol_version before the
- * connection is negotiated.
+ * This covers the case where the application requests a ticket / session state
+ * before a NewSessionTicket message has been sent or received. Historically,
+ * in that case we return the ticket / session state already set for the connection.
+ * resume_protocol_version represents the protocol version of that existing ticket / state.
  */
 static uint8_t s2n_resume_protocol_version(struct s2n_connection *conn)
 {

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -218,7 +218,7 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
             POSIX_BAIL(S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
         }
 
-        uint8_t actual_protocol_version = MIN(conn->server_protocol_version, conn->client_protocol_version);
+        conn->actual_protocol_version = MIN(conn->server_protocol_version, conn->client_protocol_version);
 
         /*
          *= https://tools.ietf.org/rfc/rfc5077#section-3.4
@@ -230,8 +230,8 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
          */
         if (session_ids_match) {
             /* check if the resumed session state is valid */
-            S2N_ERROR_IF(conn->actual_protocol_version != actual_protocol_version, S2N_ERR_BAD_MESSAGE);
-            S2N_ERROR_IF(memcmp(conn->secure->cipher_suite->iana_value, cipher_suite_wire, S2N_TLS_CIPHER_SUITE_LEN) != 0,
+            POSIX_ENSURE(conn->resume_protocol_version == conn->actual_protocol_version, S2N_ERR_BAD_MESSAGE);
+            POSIX_ENSURE(memcmp(conn->secure->cipher_suite->iana_value, cipher_suite_wire, S2N_TLS_CIPHER_SUITE_LEN) == 0,
                     S2N_ERR_BAD_MESSAGE);
 
             /* Session is resumed */
@@ -239,7 +239,6 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
         } else {
             conn->session_id_len = session_id_len;
             POSIX_CHECKED_MEMCPY(conn->session_id, session_id, session_id_len);
-            conn->actual_protocol_version = actual_protocol_version;
             POSIX_GUARD(s2n_set_cipher_as_client(conn, cipher_suite_wire));
             /* Erase master secret which might have been set for session resumption */
             POSIX_CHECKED_MEMSET((uint8_t *) conn->secrets.tls12.master_secret, 0, S2N_TLS_SECRET_LEN);

--- a/tls/s2n_tls13_secrets.h
+++ b/tls/s2n_tls13_secrets.h
@@ -32,7 +32,6 @@ typedef enum {
 
 struct s2n_tls13_secrets {
     uint8_t extract_secret[S2N_TLS13_SECRET_MAX_LEN];
-    s2n_extract_secret_type_t extract_secret_type;
 
     uint8_t client_early_secret[S2N_TLS13_SECRET_MAX_LEN];
     uint8_t client_handshake_secret[S2N_TLS13_SECRET_MAX_LEN];
@@ -41,6 +40,8 @@ struct s2n_tls13_secrets {
     uint8_t client_app_secret[S2N_TLS13_SECRET_MAX_LEN];
     uint8_t server_app_secret[S2N_TLS13_SECRET_MAX_LEN];
     uint8_t resumption_master_secret[S2N_TLS13_SECRET_MAX_LEN];
+
+    s2n_extract_secret_type_t extract_secret_type;
 };
 
 S2N_RESULT s2n_tls13_empty_transcripts_init();


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/3892
An alternative fix for https://github.com/aws/s2n-tls/pull/3893
Addresses previous PR comment https://github.com/aws/s2n-tls/pull/3845#discussion_r1113726104

### Description of changes: 

If you're deploying TLS1.3 support to a fleet of servers, you can currently run into failed connections if session resumption is enabled. A TLS1.3 client can receive a valid TLS1.2 ticket from an un-updated TLS1.2 server and then attempt to use it to connect to an updated TLS1.3 server. When a client attempts to use a TLS1.2 ticket, it immediately sets its actual_protocol_version, cipher suite, and master secret to those in the ticket. This causes the client not to send the TLS1.3 supported_versions extension, so the server assumes that the client doesn't support TLS1.3. When it then reasonably negotiates TLS1.2 instead, the client flags this as a downgrade attack.

The underlying problem is that we set actual_protocol_version when loading a TLS1.2 session, even if the server later rejects that session. We use the actual_protocol_version in many places in the ClientHello to make choices about how we construct the message, including when [deciding whether to send the supported_versions extension](https://github.com/aws/s2n-tls/pull/3893) and until recently in [deciding whether to generate a new session id](https://github.com/aws/s2n-tls/commit/4afc68ce68cc8886ce65103957497b3d7d1b57cd). This is a dangerously sharp edge, as developers don't always consider that actual_protocol_version might actually be the resumption protocol version. It's particularly dangerous because code that works elsewhere in the handshake can behave unexpectedly if called before the ClientHello; in hindsight, a contributing factor for the session id problem was that the definition of middlebox compatibility mode [quietly uses actual_protocol_version](https://github.com/aws/s2n-tls/blob/main/tls/s2n_tls13.c#L105-L109).

Rather than try to correct every use of client_protocol_version vs actual_protocol_version, I added a new, separate version for the protocol version read from the session ticket. That way, we only use the resumption protocol version if we explicitly reference it, and actual_protocol_version behaves in a more predictable way.

The other fields set by the session ticket aren't as dangerous as actual_protocol_version. We don't really have any reason to reference the master secret or cipher suite before the handshake is negotiated. But if we keep running into problems, we could consider moving TLS1.2 resumption to use TLS1.3' s PSK model: store a PSK representing the session state, and then only apply that PSK later if the server agrees to use that session.

### Call-outs:

I refactored https://github.com/aws/s2n-tls/commit/4afc68ce68cc8886ce65103957497b3d7d1b57cd a bit because I was struggling to reason about how it worked with my change; the old negative conditionals were a bit hard to keep straight. I think it better represents when we generate a session id now, and hopefully it's more readable.

### Testing:

I added new unit tests. A functional test actually already existed for this case, it just checked for a failure instead of for a success.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
