### PR TITLE
Move secret type out of tls12/tls13 union

### DIFF
--- a/tests/testlib/s2n_key_schedule_testlib.c
+++ b/tests/testlib/s2n_key_schedule_testlib.c
@@ -32,9 +32,9 @@ S2N_RESULT s2n_connection_set_test_early_secret(struct s2n_connection *conn,
 {
     RESULT_ENSURE_REF(conn);
     RESULT_ENSURE_REF(early_secret);
-    RESULT_CHECKED_MEMCPY(conn->secrets.tls13.extract_secret,
+    RESULT_CHECKED_MEMCPY(conn->secrets.version.tls13.extract_secret,
             early_secret->data, early_secret->size);
-    conn->secrets.tls13.extract_secret_type = S2N_EARLY_SECRET;
+    conn->secrets.extract_secret_type = S2N_EARLY_SECRET;
     return S2N_RESULT_OK;
 }
 
@@ -43,9 +43,9 @@ S2N_RESULT s2n_connection_set_test_handshake_secret(struct s2n_connection *conn,
 {
     RESULT_ENSURE_REF(conn);
     RESULT_ENSURE_REF(handshake_secret);
-    RESULT_CHECKED_MEMCPY(conn->secrets.tls13.extract_secret,
+    RESULT_CHECKED_MEMCPY(conn->secrets.version.tls13.extract_secret,
             handshake_secret->data, handshake_secret->size);
-    conn->secrets.tls13.extract_secret_type = S2N_HANDSHAKE_SECRET;
+    conn->secrets.extract_secret_type = S2N_HANDSHAKE_SECRET;
     return S2N_RESULT_OK;
 }
 
@@ -54,8 +54,8 @@ S2N_RESULT s2n_connection_set_test_master_secret(struct s2n_connection *conn,
 {
     RESULT_ENSURE_REF(conn);
     RESULT_ENSURE_REF(master_secret);
-    RESULT_CHECKED_MEMCPY(conn->secrets.tls13.extract_secret,
+    RESULT_CHECKED_MEMCPY(conn->secrets.version.tls13.extract_secret,
             master_secret->data, master_secret->size);
-    conn->secrets.tls13.extract_secret_type = S2N_MASTER_SECRET;
+    conn->secrets.extract_secret_type = S2N_MASTER_SECRET;
     return S2N_RESULT_OK;
 }

--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -172,7 +172,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             server_conn->actual_protocol_version = S2N_TLS13;
             server_conn->secure->cipher_suite = cipher_suite_with_limit;
-            POSIX_CHECKED_MEMCPY(server_conn->secrets.tls13.client_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(server_conn->secrets.version.tls13.client_app_secret, application_secret.data, application_secret.size);
 
             server_conn->secure->client_sequence_number[0] = 1;
             /* Write the key update request to the correct stuffer */
@@ -194,7 +194,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure->cipher_suite = cipher_suite_with_limit;
-            POSIX_CHECKED_MEMCPY(client_conn->secrets.tls13.server_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(client_conn->secrets.version.tls13.server_app_secret, application_secret.data, application_secret.size);
 
             client_conn->secure->server_sequence_number[0] = 1;
             /* Write the key update request to the correct stuffer */
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure->cipher_suite = cipher_suite_with_limit;
-            POSIX_CHECKED_MEMCPY(client_conn->secrets.tls13.client_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(client_conn->secrets.version.tls13.client_app_secret, application_secret.data, application_secret.size);
 
             /* Setup io */
             struct s2n_stuffer stuffer = { 0 };
@@ -242,7 +242,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure->cipher_suite = cipher_suite_with_limit;
-            POSIX_CHECKED_MEMCPY(client_conn->secrets.tls13.client_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(client_conn->secrets.version.tls13.client_app_secret, application_secret.data, application_secret.size);
 
             /* Setup io */
             struct s2n_stuffer stuffer = { 0 };
@@ -269,7 +269,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure->cipher_suite = cipher_suite_with_limit;
-            POSIX_CHECKED_MEMCPY(client_conn->secrets.tls13.client_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(client_conn->secrets.version.tls13.client_app_secret, application_secret.data, application_secret.size);
             uint8_t expected_sequence_number[S2N_TLS_SEQUENCE_NUM_LEN] = { 0 };
 
             /* Setup io */
@@ -302,7 +302,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn);
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure->cipher_suite = cipher_suite_with_limit;
-            POSIX_CHECKED_MEMCPY(client_conn->secrets.tls13.client_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(client_conn->secrets.version.tls13.client_app_secret, application_secret.data, application_secret.size);
 
             /* Setup io */
             DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
@@ -340,7 +340,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn);
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure->cipher_suite = cipher_suite_without_limit;
-            POSIX_CHECKED_MEMCPY(client_conn->secrets.tls13.client_app_secret, application_secret.data, application_secret.size);
+            POSIX_CHECKED_MEMCPY(client_conn->secrets.version.tls13.client_app_secret, application_secret.data, application_secret.size);
 
             /* Setup io */
             DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -310,7 +310,7 @@ int main(int argc, char **argv)
 
         struct s2n_blob blob = { 0 };
         struct s2n_stuffer stuffer = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secrets.tls12.master_secret, S2N_TLS_SECRET_LEN));
+        EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN));
         EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &blob));
         EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
         conn->secure->cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
@@ -706,7 +706,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS12);
             EXPECT_EQUAL(conn->secure->cipher_suite, &s2n_rsa_with_aes_128_gcm_sha256);
 
-            EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, conn->secrets.tls12.master_secret, S2N_TLS_SECRET_LEN);
+            EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         };
@@ -721,7 +721,7 @@ int main(int argc, char **argv)
 
             struct s2n_blob blob = { 0 };
             struct s2n_stuffer stuffer = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secrets.tls12.master_secret, S2N_TLS_SECRET_LEN));
+            EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN));
             EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &blob));
             EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
             conn->secure->cipher_suite = &s2n_rsa_with_aes_128_gcm_sha256;
@@ -740,7 +740,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS12);
             EXPECT_EQUAL(conn->secure->cipher_suite, &s2n_rsa_with_aes_128_gcm_sha256);
 
-            EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, conn->secrets.tls12.master_secret, S2N_TLS_SECRET_LEN);
+            EXPECT_BYTEARRAY_EQUAL(test_master_secret.data, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         };
@@ -753,7 +753,7 @@ int main(int argc, char **argv)
 
             struct s2n_blob blob = { 0 };
             struct s2n_stuffer stuffer = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secrets.tls12.master_secret, S2N_TLS_SECRET_LEN));
+            EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN));
             EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &blob));
             EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
             conn->secure->cipher_suite = &s2n_rsa_with_aes_128_gcm_sha256;
@@ -1249,7 +1249,7 @@ int main(int argc, char **argv)
 
             struct s2n_blob secret = { 0 };
             struct s2n_stuffer secret_stuffer = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&secret, conn->secrets.tls12.master_secret, S2N_TLS_SECRET_LEN));
+            EXPECT_SUCCESS(s2n_blob_init(&secret, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN));
             EXPECT_SUCCESS(s2n_stuffer_init(&secret_stuffer, &secret));
             EXPECT_SUCCESS(s2n_stuffer_write_bytes(&secret_stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
             conn->secure->cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
@@ -1258,13 +1258,13 @@ int main(int argc, char **argv)
             EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&conn->client_ticket_to_decrypt), 0);
 
             /* Wiping the master secret to prove that the decryption function actually writes the master secret */
-            memset(conn->secrets.tls12.master_secret, 0, test_master_secret.size);
+            memset(conn->secrets.version.tls12.master_secret, 0, test_master_secret.size);
 
             EXPECT_SUCCESS(s2n_decrypt_session_ticket(conn, &conn->client_ticket_to_decrypt));
             EXPECT_EQUAL(s2n_stuffer_data_available(&conn->client_ticket_to_decrypt), 0);
 
             /* Check decryption was successful by comparing master key */
-            EXPECT_BYTEARRAY_EQUAL(conn->secrets.tls12.master_secret, test_master_secret.data, test_master_secret.size);
+            EXPECT_BYTEARRAY_EQUAL(conn->secrets.version.tls12.master_secret, test_master_secret.data, test_master_secret.size);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
             EXPECT_SUCCESS(s2n_config_free(config));

--- a/tests/unit/s2n_send_key_update_test.c
+++ b/tests/unit/s2n_send_key_update_test.c
@@ -55,8 +55,8 @@ static int s2n_test_init_encryption(struct s2n_connection *conn)
     POSIX_GUARD(cipher_suite->record_alg->cipher->set_decryption_key(client_session_key, &key));
 
     /* Initialized secrets */
-    POSIX_CHECKED_MEMCPY(conn->secrets.tls13.server_app_secret, application_secret.data, application_secret.size);
-    POSIX_CHECKED_MEMCPY(conn->secrets.tls13.client_app_secret, application_secret.data, application_secret.size);
+    POSIX_CHECKED_MEMCPY(conn->secrets.version.tls13.server_app_secret, application_secret.data, application_secret.size);
+    POSIX_CHECKED_MEMCPY(conn->secrets.version.tls13.client_app_secret, application_secret.data, application_secret.size);
 
     /* Copy iv bytes from input data */
     POSIX_CHECKED_MEMCPY(server_implicit_iv, iv.data, iv.size);
@@ -106,14 +106,14 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_send(server_conn, message, sizeof(message), &blocked));
 
         /* Verify key update happened */
-        EXPECT_BYTEARRAY_NOT_EQUAL(server_conn->secrets.tls13.server_app_secret, client_conn->secrets.tls13.server_app_secret, S2N_TLS13_SECRET_MAX_LEN);
+        EXPECT_BYTEARRAY_NOT_EQUAL(server_conn->secrets.version.tls13.server_app_secret, client_conn->secrets.version.tls13.server_app_secret, S2N_TLS13_SECRET_MAX_LEN);
         EXPECT_BYTEARRAY_EQUAL(server_conn->secure->server_sequence_number, zero_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN);
 
         /* Receive keyupdate message */
         uint8_t data[100];
         EXPECT_SUCCESS(s2n_recv(client_conn, data, sizeof(message), &blocked));
         EXPECT_BYTEARRAY_EQUAL(data, message, sizeof(message));
-        EXPECT_BYTEARRAY_EQUAL(client_conn->secrets.tls13.server_app_secret, server_conn->secrets.tls13.server_app_secret, S2N_TLS13_SECRET_MAX_LEN);
+        EXPECT_BYTEARRAY_EQUAL(client_conn->secrets.version.tls13.server_app_secret, server_conn->secrets.version.tls13.server_app_secret, S2N_TLS13_SECRET_MAX_LEN);
         EXPECT_BYTEARRAY_EQUAL(client_conn->secure->server_sequence_number, zero_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN);
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -97,7 +97,7 @@ static int s2n_setup_test_resumption_secret(struct s2n_connection *conn)
     /* Set up resumption secret */
     struct s2n_blob secret = { 0 };
     struct s2n_stuffer secret_stuffer = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&secret, conn->secrets.tls13.resumption_master_secret, S2N_TLS_SECRET_LEN));
+    EXPECT_SUCCESS(s2n_blob_init(&secret, conn->secrets.version.tls13.resumption_master_secret, S2N_TLS_SECRET_LEN));
     EXPECT_SUCCESS(s2n_stuffer_init(&secret_stuffer, &secret));
     EXPECT_SUCCESS(s2n_stuffer_write_bytes(&secret_stuffer, test_resumption_secret.data, test_resumption_secret.size));
 

--- a/tests/unit/s2n_ssl_prf_test.c
+++ b/tests/unit/s2n_ssl_prf_test.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv)
     for (int i = 0; i < 48; i++) {
         uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&premaster_secret_in, &c));
-        conn->secrets.tls12.rsa_premaster_secret[i] = c;
+        conn->secrets.version.tls12.rsa_premaster_secret[i] = c;
     }
     for (int i = 0; i < 32; i++) {
         uint8_t c = 0;
@@ -84,13 +84,13 @@ int main(int argc, char **argv)
 
     /* Set the protocol version to sslv3 */
     conn->actual_protocol_version = S2N_SSLv3;
-    pms.data = conn->secrets.tls12.rsa_premaster_secret;
-    pms.size = sizeof(conn->secrets.tls12.rsa_premaster_secret);
+    pms.data = conn->secrets.version.tls12.rsa_premaster_secret;
+    pms.size = sizeof(conn->secrets.version.tls12.rsa_premaster_secret);
     EXPECT_SUCCESS(s2n_tls_prf_master_secret(conn, &pms));
 
     /* Convert the master secret to hex */
     for (int i = 0; i < 48; i++) {
-        EXPECT_SUCCESS(s2n_stuffer_write_uint8_hex(&master_secret_hex_out, conn->secrets.tls12.master_secret[i]));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8_hex(&master_secret_hex_out, conn->secrets.version.tls12.master_secret[i]));
     }
 
     EXPECT_EQUAL(memcmp(master_secret_hex_pad, master_secret_hex_in, sizeof(master_secret_hex_pad)), 0);

--- a/tests/unit/s2n_tls13_handshake_early_data_test.c
+++ b/tests/unit/s2n_tls13_handshake_early_data_test.c
@@ -287,8 +287,8 @@ int main()
             EXPECT_OK(s2n_tls13_key_schedule_update(client_conn));
 
             /* Check early secret secret set correctly */
-            EXPECT_EQUAL(client_conn->secrets.tls13.extract_secret_type, S2N_EARLY_SECRET);
-            EXPECT_BYTEARRAY_EQUAL(client_conn->secrets.tls13.extract_secret, early_secret.data, early_secret.size);
+            EXPECT_EQUAL(client_conn->secrets.extract_secret_type, S2N_EARLY_SECRET);
+            EXPECT_BYTEARRAY_EQUAL(client_conn->secrets.version.tls13.extract_secret, early_secret.data, early_secret.size);
 
             /* Check IV calculated correctly */
             EXPECT_BYTEARRAY_EQUAL(client_conn->secure->client_implicit_iv, iv.data, iv.size);

--- a/tests/unit/s2n_tls13_key_schedule_rfc8448_test.c
+++ b/tests/unit/s2n_tls13_key_schedule_rfc8448_test.c
@@ -66,7 +66,7 @@ static S2N_RESULT s2n_set_test_secret(struct s2n_connection *conn, uint8_t *secr
      * indicate that all secrets have already been derived.
      * This test is interested in keys, not secrets.
      */
-    conn->secrets.tls13.extract_secret_type = S2N_MASTER_SECRET;
+    conn->secrets.extract_secret_type = S2N_MASTER_SECRET;
     return S2N_RESULT_OK;
 }
 
@@ -138,7 +138,7 @@ int main(int argc, char **argv)
                 DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(modes[i]), s2n_connection_ptr_free);
                 conn->secure->cipher_suite = cipher_suite;
                 conn->actual_protocol_version = S2N_TLS13;
-                EXPECT_OK(s2n_set_test_secret(conn, conn->secrets.tls13.server_handshake_secret, secret));
+                EXPECT_OK(s2n_set_test_secret(conn, conn->secrets.version.tls13.server_handshake_secret, secret));
 
                 conn->handshake.handshake_type = one_rtt_handshake_type;
                 conn->handshake.message_number = one_rtt_message_nums[SERVER_HELLO];
@@ -185,7 +185,7 @@ int main(int argc, char **argv)
                 conn->secure->cipher_suite = cipher_suite;
                 conn->actual_protocol_version = S2N_TLS13;
                 EXPECT_OK(s2n_conn_choose_state_machine(conn, S2N_TLS13));
-                EXPECT_OK(s2n_set_test_secret(conn, conn->secrets.tls13.client_handshake_secret, secret));
+                EXPECT_OK(s2n_set_test_secret(conn, conn->secrets.version.tls13.client_handshake_secret, secret));
 
                 conn->handshake.handshake_type = one_rtt_handshake_type;
                 conn->handshake.message_number = one_rtt_message_nums[SERVER_FINISHED];
@@ -238,7 +238,7 @@ int main(int argc, char **argv)
                 conn->secure->cipher_suite = cipher_suite;
                 conn->actual_protocol_version = S2N_TLS13;
                 EXPECT_OK(s2n_conn_choose_state_machine(conn, S2N_TLS13));
-                EXPECT_OK(s2n_set_test_secret(conn, conn->secrets.tls13.server_app_secret, secret));
+                EXPECT_OK(s2n_set_test_secret(conn, conn->secrets.version.tls13.server_app_secret, secret));
 
                 conn->handshake.handshake_type = one_rtt_handshake_type;
                 conn->handshake.message_number = one_rtt_message_nums[trigger_message];
@@ -285,7 +285,7 @@ int main(int argc, char **argv)
                 conn->secure->cipher_suite = cipher_suite;
                 conn->actual_protocol_version = S2N_TLS13;
                 EXPECT_OK(s2n_conn_choose_state_machine(conn, S2N_TLS13));
-                EXPECT_OK(s2n_set_test_secret(conn, conn->secrets.tls13.client_app_secret, secret));
+                EXPECT_OK(s2n_set_test_secret(conn, conn->secrets.version.tls13.client_app_secret, secret));
 
                 conn->handshake.handshake_type = one_rtt_handshake_type;
                 conn->handshake.message_number = one_rtt_message_nums[CLIENT_FINISHED];
@@ -348,7 +348,7 @@ int main(int argc, char **argv)
                 conn->actual_protocol_version = S2N_TLS13;
                 EXPECT_OK(s2n_conn_choose_state_machine(conn, S2N_TLS13));
                 conn->early_data_state = S2N_EARLY_DATA_REQUESTED;
-                EXPECT_OK(s2n_set_test_secret(conn, conn->secrets.tls13.client_early_secret, secret));
+                EXPECT_OK(s2n_set_test_secret(conn, conn->secrets.version.tls13.client_early_secret, secret));
 
                 conn->handshake.handshake_type = resumed_handshake_type;
                 conn->handshake.message_number = resumed_message_nums[trigger_message];

--- a/tests/unit/s2n_tls13_pq_handshake_test.c
+++ b/tests/unit/s2n_tls13_pq_handshake_test.c
@@ -185,15 +185,15 @@ int s2n_test_tls13_pq_handshake(const struct s2n_security_policy *client_sec_pol
     /* Verify secrets aren't just zero'ed memory */
     uint8_t all_zeros[S2N_TLS13_SECRET_MAX_LEN] = { 0 };
     POSIX_CHECKED_MEMSET((void *) all_zeros, 0, S2N_TLS13_SECRET_MAX_LEN);
-    struct s2n_tls13_secrets *client_secrets = &client_conn->secrets.tls13;
-    struct s2n_tls13_secrets *server_secrets = &server_conn->secrets.tls13;
+    struct s2n_tls13_secrets *client_secrets = &client_conn->secrets.version.tls13;
+    struct s2n_tls13_secrets *server_secrets = &server_conn->secrets.version.tls13;
     POSIX_ENSURE_EQ(server_secret_info.size, client_secret_info.size);
     uint8_t size = server_secret_info.size;
-    POSIX_ENSURE_EQ(client_secrets->extract_secret_type, S2N_HANDSHAKE_SECRET);
+    POSIX_ENSURE_EQ(client_conn->secrets.extract_secret_type, S2N_HANDSHAKE_SECRET);
     POSIX_ENSURE_NE(0, memcmp(all_zeros, client_secrets->extract_secret, size));
     POSIX_ENSURE_NE(0, memcmp(all_zeros, client_secrets->client_handshake_secret, size));
     POSIX_ENSURE_NE(0, memcmp(all_zeros, client_secrets->server_handshake_secret, size));
-    POSIX_ENSURE_EQ(server_secrets->extract_secret_type, S2N_HANDSHAKE_SECRET);
+    POSIX_ENSURE_EQ(server_conn->secrets.extract_secret_type, S2N_HANDSHAKE_SECRET);
     POSIX_ENSURE_NE(0, memcmp(all_zeros, server_secrets->extract_secret, size));
     POSIX_ENSURE_NE(0, memcmp(all_zeros, server_secrets->client_handshake_secret, size));
     POSIX_ENSURE_NE(0, memcmp(all_zeros, server_secrets->server_handshake_secret, size));

--- a/tests/unit/s2n_tls13_secrets_rfc8448_test.c
+++ b/tests/unit/s2n_tls13_secrets_rfc8448_test.c
@@ -75,9 +75,9 @@ int main(int argc, char **argv)
                 conn->secure->cipher_suite = cipher_suite;
 
                 EXPECT_OK(s2n_tls13_extract_secret(conn, S2N_EARLY_SECRET));
-                EXPECT_BYTEARRAY_EQUAL(conn->secrets.tls13.extract_secret,
+                EXPECT_BYTEARRAY_EQUAL(conn->secrets.version.tls13.extract_secret,
                         early_secret.data, early_secret.size);
-                EXPECT_EQUAL(conn->secrets.tls13.extract_secret_type, S2N_EARLY_SECRET);
+                EXPECT_EQUAL(conn->secrets.extract_secret_type, S2N_EARLY_SECRET);
             }
         };
 
@@ -161,9 +161,9 @@ int main(int argc, char **argv)
                 EXPECT_NOT_NULL(conn->kex_params.client_ecc_evp_params.evp_pkey);
 
                 EXPECT_OK(s2n_tls13_extract_secret(conn, S2N_HANDSHAKE_SECRET));
-                EXPECT_BYTEARRAY_EQUAL(conn->secrets.tls13.extract_secret,
+                EXPECT_BYTEARRAY_EQUAL(conn->secrets.version.tls13.extract_secret,
                         handshake_secret.data, handshake_secret.size);
-                EXPECT_EQUAL(conn->secrets.tls13.extract_secret_type, S2N_HANDSHAKE_SECRET);
+                EXPECT_EQUAL(conn->secrets.extract_secret_type, S2N_HANDSHAKE_SECRET);
             };
 
             /* Client */
@@ -183,9 +183,9 @@ int main(int argc, char **argv)
                 EXPECT_NOT_NULL(conn->kex_params.client_ecc_evp_params.evp_pkey);
 
                 EXPECT_OK(s2n_tls13_extract_secret(conn, S2N_HANDSHAKE_SECRET));
-                EXPECT_BYTEARRAY_EQUAL(conn->secrets.tls13.extract_secret,
+                EXPECT_BYTEARRAY_EQUAL(conn->secrets.version.tls13.extract_secret,
                         handshake_secret.data, handshake_secret.size);
-                EXPECT_EQUAL(conn->secrets.tls13.extract_secret_type, S2N_HANDSHAKE_SECRET);
+                EXPECT_EQUAL(conn->secrets.extract_secret_type, S2N_HANDSHAKE_SECRET);
             };
         }
 #endif
@@ -362,9 +362,9 @@ int main(int argc, char **argv)
                 EXPECT_OK(s2n_connection_set_test_handshake_secret(conn, &handshake_secret));
 
                 EXPECT_OK(s2n_tls13_extract_secret(conn, S2N_MASTER_SECRET));
-                EXPECT_BYTEARRAY_EQUAL(conn->secrets.tls13.extract_secret,
+                EXPECT_BYTEARRAY_EQUAL(conn->secrets.version.tls13.extract_secret,
                         master_secret.data, master_secret.size);
-                EXPECT_EQUAL(conn->secrets.tls13.extract_secret_type, S2N_MASTER_SECRET);
+                EXPECT_EQUAL(conn->secrets.extract_secret_type, S2N_MASTER_SECRET);
             }
         };
 
@@ -494,7 +494,7 @@ int main(int argc, char **argv)
 
                 EXPECT_OK(s2n_derive_resumption_master_secret(conn));
                 EXPECT_EQUAL(derived_secret.size, secret.size);
-                EXPECT_BYTEARRAY_EQUAL(conn->secrets.tls13.resumption_master_secret,
+                EXPECT_BYTEARRAY_EQUAL(conn->secrets.version.tls13.resumption_master_secret,
                         secret.data, secret.size);
             }
         };
@@ -542,9 +542,9 @@ int main(int argc, char **argv)
                 /* Early secret retrieved and saved for connection */
                 conn->psk_params.chosen_psk = psk;
                 EXPECT_OK(s2n_tls13_extract_secret(conn, S2N_EARLY_SECRET));
-                EXPECT_BYTEARRAY_EQUAL(conn->secrets.tls13.extract_secret,
+                EXPECT_BYTEARRAY_EQUAL(conn->secrets.version.tls13.extract_secret,
                         early_secret.data, early_secret.size);
-                EXPECT_EQUAL(conn->secrets.tls13.extract_secret_type, S2N_EARLY_SECRET);
+                EXPECT_EQUAL(conn->secrets.extract_secret_type, S2N_EARLY_SECRET);
             }
         };
 

--- a/tests/unit/s2n_tls_hybrid_prf_test.c
+++ b/tests/unit/s2n_tls_hybrid_prf_test.c
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
         EXPECT_MEMCPY_SUCCESS(conn->kex_params.client_key_exchange_message.data, client_key_exchange_message, client_key_exchange_message_length);
 
         EXPECT_SUCCESS(s2n_hybrid_prf_master_secret(conn, &combined_pms));
-        EXPECT_BYTEARRAY_EQUAL(expected_master_secret, conn->secrets.tls12.master_secret, S2N_TLS_SECRET_LEN);
+        EXPECT_BYTEARRAY_EQUAL(expected_master_secret, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN);
         EXPECT_SUCCESS(s2n_free(&conn->kex_params.client_key_exchange_message));
         EXPECT_SUCCESS(s2n_connection_free(conn));
 

--- a/tests/unit/s2n_tls_prf_test.c
+++ b/tests/unit/s2n_tls_prf_test.c
@@ -54,14 +54,14 @@ int main(int argc, char **argv)
         /* Check the most common PRF */
         conn->actual_protocol_version = S2N_TLS11;
 
-        EXPECT_MEMCPY_SUCCESS(conn->secrets.tls12.rsa_premaster_secret, premaster_secret_in.data, premaster_secret_in.size);
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.version.tls12.rsa_premaster_secret, premaster_secret_in.data, premaster_secret_in.size);
         EXPECT_MEMCPY_SUCCESS(conn->handshake_params.client_random, client_random_in.data, client_random_in.size);
         EXPECT_MEMCPY_SUCCESS(conn->handshake_params.server_random, server_random_in.data, server_random_in.size);
 
         struct s2n_blob pms = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&pms, conn->secrets.tls12.rsa_premaster_secret, sizeof(conn->secrets.tls12.rsa_premaster_secret)));
+        EXPECT_SUCCESS(s2n_blob_init(&pms, conn->secrets.version.tls12.rsa_premaster_secret, sizeof(conn->secrets.version.tls12.rsa_premaster_secret)));
         EXPECT_SUCCESS(s2n_tls_prf_master_secret(conn, &pms));
-        EXPECT_EQUAL(memcmp(conn->secrets.tls12.master_secret, master_secret_in.data, master_secret_in.size), 0);
+        EXPECT_EQUAL(memcmp(conn->secrets.version.tls12.master_secret, master_secret_in.data, master_secret_in.size), 0);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     };
@@ -98,7 +98,7 @@ int main(int argc, char **argv)
          *#                    [0..47];
          */
         EXPECT_OK(s2n_tls_prf_extended_master_secret(conn, &premaster_secret, &hash_digest, NULL));
-        EXPECT_BYTEARRAY_EQUAL(extended_master_secret.data, conn->secrets.tls12.master_secret, S2N_TLS_SECRET_LEN);
+        EXPECT_BYTEARRAY_EQUAL(extended_master_secret.data, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     };
@@ -109,12 +109,12 @@ int main(int argc, char **argv)
 
         conn->secure->cipher_suite = &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384;
 
-        EXPECT_MEMCPY_SUCCESS(conn->secrets.tls12.rsa_premaster_secret, premaster_secret_in.data, premaster_secret_in.size);
+        EXPECT_MEMCPY_SUCCESS(conn->secrets.version.tls12.rsa_premaster_secret, premaster_secret_in.data, premaster_secret_in.size);
         EXPECT_MEMCPY_SUCCESS(conn->handshake_params.client_random, client_random_in.data, client_random_in.size);
         EXPECT_MEMCPY_SUCCESS(conn->handshake_params.server_random, server_random_in.data, server_random_in.size);
 
         struct s2n_blob pms = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&pms, conn->secrets.tls12.rsa_premaster_secret, sizeof(conn->secrets.tls12.rsa_premaster_secret)));
+        EXPECT_SUCCESS(s2n_blob_init(&pms, conn->secrets.version.tls12.rsa_premaster_secret, sizeof(conn->secrets.version.tls12.rsa_premaster_secret)));
 
         /* Errors when handshake is not at the Client Key Exchange message */
         EXPECT_FAILURE_WITH_ERRNO(s2n_prf_calculate_master_secret(conn, &pms), S2N_ERR_SAFETY);
@@ -127,17 +127,17 @@ int main(int argc, char **argv)
 
         /* Master secret is calculated when handshake is at Client Key Exchange message*/
         EXPECT_SUCCESS(s2n_prf_calculate_master_secret(conn, &pms));
-        EXPECT_EQUAL(memcmp(conn->secrets.tls12.master_secret, master_secret_in.data, master_secret_in.size), 0);
+        EXPECT_EQUAL(memcmp(conn->secrets.version.tls12.master_secret, master_secret_in.data, master_secret_in.size), 0);
 
         /* s2n_prf_calculate_master_secret will produce the same master secret if given the same inputs */
         EXPECT_SUCCESS(s2n_prf_calculate_master_secret(conn, &pms));
-        EXPECT_EQUAL(memcmp(conn->secrets.tls12.master_secret, master_secret_in.data, master_secret_in.size), 0);
+        EXPECT_EQUAL(memcmp(conn->secrets.version.tls12.master_secret, master_secret_in.data, master_secret_in.size), 0);
 
         conn->ems_negotiated = true;
         EXPECT_SUCCESS(s2n_prf_calculate_master_secret(conn, &pms));
 
         /* Extended master secret calculated is different than the master secret calculated */
-        EXPECT_NOT_EQUAL(memcmp(conn->secrets.tls12.master_secret, master_secret_in.data, master_secret_in.size), 0);
+        EXPECT_NOT_EQUAL(memcmp(conn->secrets.version.tls12.master_secret, master_secret_in.data, master_secret_in.size), 0);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     };
@@ -287,24 +287,24 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_blob_init(&pms, premaster_secret_in.data, premaster_secret_in.size));
 
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
-            EXPECT_MEMCPY_SUCCESS(conn->secrets.tls12.rsa_premaster_secret, premaster_secret_in.data, premaster_secret_in.size);
+            EXPECT_MEMCPY_SUCCESS(conn->secrets.version.tls12.rsa_premaster_secret, premaster_secret_in.data, premaster_secret_in.size);
             EXPECT_MEMCPY_SUCCESS(conn->handshake_params.client_random, client_random_in.data, client_random_in.size);
             EXPECT_MEMCPY_SUCCESS(conn->handshake_params.server_random, server_random_in.data, server_random_in.size);
             EXPECT_SUCCESS(s2n_tls_prf_master_secret(conn, &pms));
-            EXPECT_EQUAL(memcmp(conn->secrets.tls12.master_secret, master_secret_in.data, master_secret_in.size), 0);
+            EXPECT_EQUAL(memcmp(conn->secrets.version.tls12.master_secret, master_secret_in.data, master_secret_in.size), 0);
 
             EXPECT_SUCCESS(s2n_connection_free_handshake(conn));
-            EXPECT_MEMCPY_SUCCESS(conn->secrets.tls12.rsa_premaster_secret, premaster_secret_in.data, premaster_secret_in.size);
+            EXPECT_MEMCPY_SUCCESS(conn->secrets.version.tls12.rsa_premaster_secret, premaster_secret_in.data, premaster_secret_in.size);
             EXPECT_MEMCPY_SUCCESS(conn->handshake_params.client_random, client_random_in.data, client_random_in.size);
             EXPECT_MEMCPY_SUCCESS(conn->handshake_params.server_random, server_random_in.data, server_random_in.size);
             EXPECT_FAILURE_WITH_ERRNO(s2n_tls_prf_master_secret(conn, &pms), S2N_ERR_NULL);
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
-            EXPECT_MEMCPY_SUCCESS(conn->secrets.tls12.rsa_premaster_secret, premaster_secret_in.data, premaster_secret_in.size);
+            EXPECT_MEMCPY_SUCCESS(conn->secrets.version.tls12.rsa_premaster_secret, premaster_secret_in.data, premaster_secret_in.size);
             EXPECT_MEMCPY_SUCCESS(conn->handshake_params.client_random, client_random_in.data, client_random_in.size);
             EXPECT_MEMCPY_SUCCESS(conn->handshake_params.server_random, server_random_in.data, server_random_in.size);
             EXPECT_SUCCESS(s2n_tls_prf_master_secret(conn, &pms));
-            EXPECT_EQUAL(memcmp(conn->secrets.tls12.master_secret, master_secret_in.data, master_secret_in.size), 0);
+            EXPECT_EQUAL(memcmp(conn->secrets.version.tls12.master_secret, master_secret_in.data, master_secret_in.size), 0);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         };

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -209,7 +209,7 @@ struct s2n_connection {
     /* Our crypto parameters */
     struct s2n_crypto_parameters *initial;
     struct s2n_crypto_parameters *secure;
-    union s2n_secrets secrets;
+    struct s2n_secrets secrets;
 
     /* Which set is the client/server actually using? */
     struct s2n_crypto_parameters *client;

--- a/tls/s2n_crypto.h
+++ b/tls/s2n_crypto.h
@@ -47,9 +47,12 @@ struct s2n_tls12_secrets {
     uint8_t master_secret[S2N_TLS_SECRET_LEN];
 };
 
-union s2n_secrets {
-    struct s2n_tls12_secrets tls12;
-    struct s2n_tls13_secrets tls13;
+struct s2n_secrets {
+    union {
+        struct s2n_tls12_secrets tls12;
+        struct s2n_tls13_secrets tls13;
+    } version;
+    s2n_extract_secret_type_t extract_secret_type;
 };
 
 struct s2n_crypto_parameters {

--- a/tls/s2n_key_log.c
+++ b/tls/s2n_key_log.c
@@ -160,7 +160,7 @@ S2N_RESULT s2n_key_log_tls12_secret(struct s2n_connection *conn)
     RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(&output, label, label_size));
     RESULT_GUARD(s2n_key_log_hex_encode(&output, conn->handshake_params.client_random, S2N_TLS_RANDOM_DATA_LEN));
     RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(&output, ' '));
-    RESULT_GUARD(s2n_key_log_hex_encode(&output, conn->secrets.tls12.master_secret, S2N_TLS_SECRET_LEN));
+    RESULT_GUARD(s2n_key_log_hex_encode(&output, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN));
 
     uint8_t *data = s2n_stuffer_raw_read(&output, len);
     RESULT_ENSURE_REF(data);

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -507,7 +507,7 @@ int s2n_tls_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *prem
     struct s2n_blob server_random = { 0 };
     POSIX_GUARD(s2n_blob_init(&server_random, conn->handshake_params.server_random, sizeof(conn->handshake_params.server_random)));
     struct s2n_blob master_secret = { 0 };
-    POSIX_GUARD(s2n_blob_init(&master_secret, conn->secrets.tls12.master_secret, sizeof(conn->secrets.tls12.master_secret)));
+    POSIX_GUARD(s2n_blob_init(&master_secret, conn->secrets.version.tls12.master_secret, sizeof(conn->secrets.version.tls12.master_secret)));
 
     uint8_t master_secret_label[] = "master secret";
     struct s2n_blob label = { 0 };
@@ -525,7 +525,7 @@ int s2n_hybrid_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *p
     struct s2n_blob server_random = { 0 };
     POSIX_GUARD(s2n_blob_init(&server_random, conn->handshake_params.server_random, sizeof(conn->handshake_params.server_random)));
     struct s2n_blob master_secret = { 0 };
-    POSIX_GUARD(s2n_blob_init(&master_secret, conn->secrets.tls12.master_secret, sizeof(conn->secrets.tls12.master_secret)));
+    POSIX_GUARD(s2n_blob_init(&master_secret, conn->secrets.version.tls12.master_secret, sizeof(conn->secrets.version.tls12.master_secret)));
 
     uint8_t master_secret_label[] = "hybrid master secret";
     struct s2n_blob label = { 0 };
@@ -590,7 +590,7 @@ S2N_RESULT s2n_tls_prf_extended_master_secret(struct s2n_connection *conn, struc
     RESULT_ENSURE_REF(conn);
 
     struct s2n_blob extended_master_secret = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&extended_master_secret, conn->secrets.tls12.master_secret, sizeof(conn->secrets.tls12.master_secret)));
+    RESULT_GUARD_POSIX(s2n_blob_init(&extended_master_secret, conn->secrets.version.tls12.master_secret, sizeof(conn->secrets.version.tls12.master_secret)));
 
     uint8_t extended_master_secret_label[] = "extended master secret";
     /* Subtract one from the label size to remove the "\0" */
@@ -639,11 +639,11 @@ static int s2n_sslv3_finished(struct s2n_connection *conn, uint8_t prefix[4], st
     struct s2n_hash_state *md5 = hash_workspace;
     POSIX_GUARD(s2n_hash_copy(md5, &conn->handshake.hashes->md5));
     POSIX_GUARD(s2n_hash_update(md5, prefix, 4));
-    POSIX_GUARD(s2n_hash_update(md5, conn->secrets.tls12.master_secret, sizeof(conn->secrets.tls12.master_secret)));
+    POSIX_GUARD(s2n_hash_update(md5, conn->secrets.version.tls12.master_secret, sizeof(conn->secrets.version.tls12.master_secret)));
     POSIX_GUARD(s2n_hash_update(md5, xorpad1, 48));
     POSIX_GUARD(s2n_hash_digest(md5, md5_digest, MD5_DIGEST_LENGTH));
     POSIX_GUARD(s2n_hash_reset(md5));
-    POSIX_GUARD(s2n_hash_update(md5, conn->secrets.tls12.master_secret, sizeof(conn->secrets.tls12.master_secret)));
+    POSIX_GUARD(s2n_hash_update(md5, conn->secrets.version.tls12.master_secret, sizeof(conn->secrets.version.tls12.master_secret)));
     POSIX_GUARD(s2n_hash_update(md5, xorpad2, 48));
     POSIX_GUARD(s2n_hash_update(md5, md5_digest, MD5_DIGEST_LENGTH));
     POSIX_GUARD(s2n_hash_digest(md5, md5_digest, MD5_DIGEST_LENGTH));
@@ -652,11 +652,11 @@ static int s2n_sslv3_finished(struct s2n_connection *conn, uint8_t prefix[4], st
     struct s2n_hash_state *sha1 = hash_workspace;
     POSIX_GUARD(s2n_hash_copy(sha1, &conn->handshake.hashes->sha1));
     POSIX_GUARD(s2n_hash_update(sha1, prefix, 4));
-    POSIX_GUARD(s2n_hash_update(sha1, conn->secrets.tls12.master_secret, sizeof(conn->secrets.tls12.master_secret)));
+    POSIX_GUARD(s2n_hash_update(sha1, conn->secrets.version.tls12.master_secret, sizeof(conn->secrets.version.tls12.master_secret)));
     POSIX_GUARD(s2n_hash_update(sha1, xorpad1, 40));
     POSIX_GUARD(s2n_hash_digest(sha1, sha_digest, SHA_DIGEST_LENGTH));
     POSIX_GUARD(s2n_hash_reset(sha1));
-    POSIX_GUARD(s2n_hash_update(sha1, conn->secrets.tls12.master_secret, sizeof(conn->secrets.tls12.master_secret)));
+    POSIX_GUARD(s2n_hash_update(sha1, conn->secrets.version.tls12.master_secret, sizeof(conn->secrets.version.tls12.master_secret)));
     POSIX_GUARD(s2n_hash_update(sha1, xorpad2, 40));
     POSIX_GUARD(s2n_hash_update(sha1, sha_digest, SHA_DIGEST_LENGTH));
     POSIX_GUARD(s2n_hash_digest(sha1, sha_digest, SHA_DIGEST_LENGTH));
@@ -708,8 +708,8 @@ int s2n_prf_client_finished(struct s2n_connection *conn)
     label.data = client_finished_label;
     label.size = sizeof(client_finished_label) - 1;
 
-    master_secret.data = conn->secrets.tls12.master_secret;
-    master_secret.size = sizeof(conn->secrets.tls12.master_secret);
+    master_secret.data = conn->secrets.version.tls12.master_secret;
+    master_secret.size = sizeof(conn->secrets.version.tls12.master_secret);
     if (conn->actual_protocol_version == S2N_TLS12) {
         switch (conn->secure->cipher_suite->prf_alg) {
             case S2N_HMAC_SHA256:
@@ -766,8 +766,8 @@ int s2n_prf_server_finished(struct s2n_connection *conn)
     label.data = server_finished_label;
     label.size = sizeof(server_finished_label) - 1;
 
-    master_secret.data = conn->secrets.tls12.master_secret;
-    master_secret.size = sizeof(conn->secrets.tls12.master_secret);
+    master_secret.data = conn->secrets.version.tls12.master_secret;
+    master_secret.size = sizeof(conn->secrets.version.tls12.master_secret);
     if (conn->actual_protocol_version == S2N_TLS12) {
         switch (conn->secure->cipher_suite->prf_alg) {
             case S2N_HMAC_SHA256:
@@ -849,7 +849,7 @@ int s2n_prf_key_expansion(struct s2n_connection *conn)
     struct s2n_blob server_random = { 0 };
     POSIX_GUARD(s2n_blob_init(&server_random, conn->handshake_params.server_random, sizeof(conn->handshake_params.server_random)));
     struct s2n_blob master_secret = { 0 };
-    POSIX_GUARD(s2n_blob_init(&master_secret, conn->secrets.tls12.master_secret, sizeof(conn->secrets.tls12.master_secret)));
+    POSIX_GUARD(s2n_blob_init(&master_secret, conn->secrets.version.tls12.master_secret, sizeof(conn->secrets.version.tls12.master_secret)));
     struct s2n_blob label, out;
     uint8_t key_expansion_label[] = "key expansion";
     uint8_t key_block[S2N_MAX_KEY_BLOCK_LEN];

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -61,7 +61,7 @@ static int s2n_tls12_serialize_resumption_state(struct s2n_connection *conn, str
     POSIX_GUARD(s2n_stuffer_write_uint8(to, conn->actual_protocol_version));
     POSIX_GUARD(s2n_stuffer_write_bytes(to, conn->secure->cipher_suite->iana_value, S2N_TLS_CIPHER_SUITE_LEN));
     POSIX_GUARD(s2n_stuffer_write_uint64(to, now));
-    POSIX_GUARD(s2n_stuffer_write_bytes(to, conn->secrets.tls12.master_secret, S2N_TLS_SECRET_LEN));
+    POSIX_GUARD(s2n_stuffer_write_bytes(to, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN));
     POSIX_GUARD(s2n_stuffer_write_uint8(to, conn->ems_negotiated));
 
     return S2N_SUCCESS;
@@ -158,7 +158,7 @@ static int s2n_tls12_deserialize_resumption_state(struct s2n_connection *conn, s
     S2N_ERROR_IF(then > now, S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
     S2N_ERROR_IF(now - then > conn->config->session_state_lifetime_in_nanos, S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
 
-    POSIX_GUARD(s2n_stuffer_read_bytes(from, conn->secrets.tls12.master_secret, S2N_TLS_SECRET_LEN));
+    POSIX_GUARD(s2n_stuffer_read_bytes(from, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN));
 
     if (s2n_stuffer_data_available(from)) {
         uint8_t ems_negotiated = 0;
@@ -225,7 +225,7 @@ static S2N_RESULT s2n_tls12_client_deserialize_session_state(struct s2n_connecti
     uint64_t then = 0;
     RESULT_GUARD_POSIX(s2n_stuffer_read_uint64(from, &then));
 
-    RESULT_GUARD_POSIX(s2n_stuffer_read_bytes(from, conn->secrets.tls12.master_secret, S2N_TLS_SECRET_LEN));
+    RESULT_GUARD_POSIX(s2n_stuffer_read_bytes(from, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN));
 
     if (s2n_stuffer_data_available(from)) {
         uint8_t ems_negotiated = 0;

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -242,7 +242,7 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
             conn->actual_protocol_version = actual_protocol_version;
             POSIX_GUARD(s2n_set_cipher_as_client(conn, cipher_suite_wire));
             /* Erase master secret which might have been set for session resumption */
-            POSIX_CHECKED_MEMSET((uint8_t *) conn->secrets.tls12.master_secret, 0, S2N_TLS_SECRET_LEN);
+            POSIX_CHECKED_MEMSET((uint8_t *) conn->secrets.version.tls12.master_secret, 0, S2N_TLS_SECRET_LEN);
 
             /* Erase client session ticket which might have been set for session resumption */
             POSIX_GUARD(s2n_free(&conn->client_ticket));

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -243,7 +243,7 @@ static int s2n_generate_session_secret(struct s2n_connection *conn, struct s2n_b
 
     s2n_tls13_connection_keys(secrets, conn);
     struct s2n_blob master_secret = { 0 };
-    POSIX_GUARD(s2n_blob_init(&master_secret, conn->secrets.tls13.resumption_master_secret, secrets.size));
+    POSIX_GUARD(s2n_blob_init(&master_secret, conn->secrets.version.tls13.resumption_master_secret, secrets.size));
     POSIX_GUARD(s2n_realloc(output, secrets.size));
     POSIX_GUARD_RESULT(s2n_tls13_derive_session_ticket_secret(&secrets, &master_secret, nonce, output));
 

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -168,11 +168,11 @@ int s2n_update_application_traffic_keys(struct s2n_connection *conn, s2n_mode mo
 
     if (mode == S2N_CLIENT) {
         old_key = &conn->secure->client_key;
-        POSIX_GUARD(s2n_blob_init(&old_app_secret, conn->secrets.tls13.client_app_secret, keys.size));
+        POSIX_GUARD(s2n_blob_init(&old_app_secret, conn->secrets.version.tls13.client_app_secret, keys.size));
         POSIX_GUARD(s2n_blob_init(&app_iv, conn->secure->client_implicit_iv, S2N_TLS13_FIXED_IV_LEN));
     } else {
         old_key = &conn->secure->server_key;
-        POSIX_GUARD(s2n_blob_init(&old_app_secret, conn->secrets.tls13.server_app_secret, keys.size));
+        POSIX_GUARD(s2n_blob_init(&old_app_secret, conn->secrets.version.tls13.server_app_secret, keys.size));
         POSIX_GUARD(s2n_blob_init(&app_iv, conn->secure->server_implicit_iv, S2N_TLS13_FIXED_IV_LEN));
     }
 

--- a/tls/s2n_tls13_key_schedule.c
+++ b/tls/s2n_tls13_key_schedule.c
@@ -332,6 +332,6 @@ S2N_RESULT s2n_tls13_key_schedule_reset(struct s2n_connection *conn)
     RESULT_ENSURE_REF(conn->initial);
     conn->client = conn->initial;
     conn->server = conn->initial;
-    conn->secrets.tls13.extract_secret_type = S2N_NONE_SECRET;
+    conn->secrets.extract_secret_type = S2N_NONE_SECRET;
     return S2N_RESULT_OK;
 }

--- a/tls/s2n_tls13_secrets.h
+++ b/tls/s2n_tls13_secrets.h
@@ -32,7 +32,6 @@ typedef enum {
 
 struct s2n_tls13_secrets {
     uint8_t extract_secret[S2N_TLS13_SECRET_MAX_LEN];
-    s2n_extract_secret_type_t extract_secret_type;
 
     uint8_t client_early_secret[S2N_TLS13_SECRET_MAX_LEN];
     uint8_t client_handshake_secret[S2N_TLS13_SECRET_MAX_LEN];


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/aws/s2n-tls/pull/3907/files#r1147175285

### Description of changes: 

The TLS1.3 secrets and the TLS1.2 secrets are fields in a union so share memory. Setting the TLS1.2 master secret when resuming a TLS1.2 session overwrote the extract_secret_type field because of its early position in the structure. When we fell back to a full TLS1.3 handshake, extract_secret_type wasn't 0 as expected and secret generation failed.

I could reset extract_secret_type in this case, but it seems safer to move this field out of the union, since it can be used as a "type" field to determine whether we're using TLS1.2 or TLS1.3. There's no memory cost to doing so, since the TLS1.3 part of the union is much bigger than the TLS1.2 part.

### Call-outs:

Most of this change is just updating references to the reorganized fields. The actual change is in [tls/s2n_crypto.h](https://github.com/aws/s2n-tls/pull/3908/files#diff-c1edfd72d4badbe6da8da1ac8d625ab08947e2ec0f3e5015b5e5cb1efbdb656b) and [tls/s2n_tls13_secrets.h](https://github.com/aws/s2n-tls/pull/3908/files#diff-3d771593ad9fede63e6b73d21643dcdb1a1dbd5532de9b731e318c40fe6b943c).

### Testing:

Existing tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
