### PR TITLE
Expose curve details on rust bindings

### DIFF
--- a/bindings/rust/s2n-tls-tokio/tests/handshake.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/handshake.rs
@@ -33,6 +33,7 @@ async fn handshake_basic() -> Result<(), Box<dyn std::error::Error>> {
         assert!(tls.as_ref().handshake_type()?.contains("NEGOTIATED"));
         // Cipher suite may change, so just makes sure we can retrieve it.
         assert!(tls.as_ref().cipher_suite().is_ok());
+        assert!(tls.as_ref().selected_curve().is_ok());
     }
 
     Ok(())

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -50,6 +50,9 @@ impl fmt::Debug for Connection {
         if let Ok(version) = self.actual_protocol_version() {
             debug.field("actual_protocol_version", &version);
         }
+        if let Ok(curve) = self.selected_curve() {
+            debug.field("selected_curve", &curve);
+        }
         debug.finish_non_exhaustive()
     }
 }
@@ -665,6 +668,11 @@ impl Connection {
         // The strings returned by s2n_connection_get_cipher
         // are static and immutable since they are const fields on static const structs
         static_const_str!(cipher)
+    }
+
+    pub fn selected_curve(&self) -> Result<&str, Error> {
+        let curve = unsafe { s2n_connection_get_curve(self.connection.as_ptr()).into_result()? };
+        static_const_str!(curve)
     }
 
     pub fn selected_signature_algorithm(&self) -> Result<SignatureAlgorithm, Error> {


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

This PR provides a mechanism to retrieve curve information on rust bindings.

### Call-outs:

None

### Testing:

Added a new assertion in existing test to verify the curve value is retrieved. Existing tests pass. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
