### PR TITLE
test: Bump nix devShell python to 3.10

### DIFF
--- a/nix/pyenv.nix
+++ b/nix/pyenv.nix
@@ -1,9 +1,7 @@
 { pkgs }:
 let
-  pythonPkgs = pkgs.python39Packages;
+  pythonPkgs = pkgs.python310Packages;
   cryptography = pythonPkgs.cryptography;
-  # TODO: move to should we Python 3.10? Not broken there.
-  # This package is marked at broken on stdenv.isDarwin && stdenv.isAarch64 see https://github.com/pyca/pyopenssl/issues/873
   pyOpenSSL = pythonPkgs.pyopenssl;
   nassl = with pythonPkgs;
     buildPythonPackage rec {
@@ -13,8 +11,9 @@ let
       src = builtins.fetchurl {
         # TODO make this work on other platforms: https://pypi.org/project/nassl/5.0.0/#files
         url =
-          "https://files.pythonhosted.org/packages/b2/5b/74deb03184dbd2500a94d6d50c95e48db566653a1c2d5203af7c468bed48/nassl-5.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
-        sha256 = "sha256:02m9p7hq5895674drjn0c98yzlf8lr5yilhg12pzws77720z2a9n";
+          "https://files.pythonhosted.org/packages/5b/c4/1af344cedf2dff7329d4bdbba03f3512c37b7972e5119fa874fb9472ce00/nassl-5.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+        sha256 =
+          "sha256:c2c4ff3d0cb1daae984dc99b6673722263b960fdf0b6aecd2d46020652e4f86f";
       };
       propagatedBuildInputs = [ pyOpenSSL ];
 
@@ -34,7 +33,7 @@ let
         pydantic # >=1.7,<1.9 TODO: check if this version is correct/if it matters
       ];
     };
-in pkgs.python39.withPackages (ps: [
+in pkgs.python310.withPackages (ps: [
   ps.pep8
   ps.pytest # ==5.3.5 TODO: check if this version is correct/if it matters
   ps.pytest-xdist # ==1.34.0 TODO: check if this version is correct/if it matters


### PR DESCRIPTION
### Resolved issues:

 partial https://github.com/aws/s2n-tls/issues/3841 

### Description of changes: 

Bump python version in nix devShell to python 3.10.  Python3.9 is marked broken on arm.

### Call-outs:

Current make/tox setup is to use python3.9, upgrading requires a CodeBuild Docker image rebuild.

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? locally and in CI

 Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
