### PR TITLE
docs: add compliance notes for RFC 6125

### DIFF
--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -354,11 +354,26 @@ static S2N_RESULT s2n_verify_host_information(struct s2n_connection *conn, X509 
 
     /* Check SubjectAltNames before CommonName as per RFC 6125 6.4.4 */
     s2n_result result = s2n_verify_host_information_san(conn, public_cert, &entry_found);
+
+    /*
+     *= https://www.rfc-editor.org/rfc/rfc6125#section-6.4.4
+     *# As noted, a client MUST NOT seek a match for a reference identifier
+     *# of CN-ID if the presented identifiers include a DNS-ID, SRV-ID,
+     *# URI-ID, or any application-specific identifier types supported by the
+     *# client.
+     */
     if (entry_found) {
         return result;
     }
 
-    /* if no SubjectAltNames of type DNS found, go to the common name. */
+    /*
+     *= https://www.rfc-editor.org/rfc/rfc6125#section-6.4.4
+     *# Therefore, if and only if the presented identifiers do not include a
+     *# DNS-ID, SRV-ID, URI-ID, or any application-specific identifier types
+     *# supported by the client, then the client MAY as a last resort check
+     *# for a string whose form matches that of a fully qualified DNS domain
+     *# name in a Common Name field of the subject field (i.e., a CN-ID).
+     */
     result = s2n_verify_host_information_common_name(conn, public_cert, &entry_found);
     if (entry_found) {
         return result;


### PR DESCRIPTION
### Description of changes: 

In #3793, a change was made to the SAN/CN field handling logic that brings it in line with RFC 6125, specifically section [6.4.4](https://www.rfc-editor.org/rfc/rfc6125#section-6.4.4):

> [6.4.4](https://www.rfc-editor.org/rfc/rfc6125#section-6.4.4).  Checking of Common Names
>
>   As noted, a client MUST NOT seek a match for a reference identifier
>   of CN-ID if the presented identifiers include a DNS-ID, SRV-ID,
>   URI-ID, or any application-specific identifier types supported by the
>   client.
>
>   Therefore, if and only if the presented identifiers do not include a
>   DNS-ID, SRV-ID, URI-ID, or any application-specific identifier types
>   supported by the client, then the client MAY as a last resort check
>   for a string whose form matches that of a fully qualified DNS domain
>   name in a Common Name field of the subject field (i.e., a CN-ID).  If
>   the client chooses to compare a reference identifier of type CN-ID
>   against that string, it MUST follow the comparison rules for the DNS
>   domain name portion of an identifier of type DNS-ID, SRV-ID, or
>   URI-ID, as described under [Section 6.4.1](https://www.rfc-editor.org/rfc/rfc6125#section-6.4.1), [Section 6.4.2](https://www.rfc-editor.org/rfc/rfc6125#section-6.4.2), and
>   [Section 6.4.3](https://www.rfc-editor.org/rfc/rfc6125#section-6.4.3).

The previous code was [missing an assignment to the `san_found` variable in the URI branch](https://github.com/aws/s2n-tls/pull/3793/files#diff-2d8b296c14d5d919678cb24d3cc7745598be69458d2dd600bda448da1ed20534L238). This cause the implementation to incorrectly fall back to the Common Name field.

I've updated the inline comments to better reflect the new and correct behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
