### PR TITLE
test: add retry logic for well-known endpoints

### DIFF
--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -6,7 +6,7 @@ from common import ProviderOptions, Ciphers, pq_enabled
 from fixtures import managed_process  # lgtm [py/unused-import]
 from global_flags import get_flag, is_criterion_on, S2N_FIPS_MODE, S2N_USE_CRITERION
 from providers import Provider, S2N
-from utils import invalid_test_parameters, get_parameter_name, to_bytes
+from utils import invalid_test_parameters, get_parameter_name, to_bytes, flaky_test
 
 
 ENDPOINTS = [
@@ -90,6 +90,7 @@ else:
 @pytest.mark.parametrize("endpoint", ENDPOINTS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("cipher", CIPHERS, ids=get_parameter_name)
+@flaky_test()
 def test_well_known_endpoints(managed_process, protocol, endpoint, provider, cipher):
     port = "443"
 

--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -6,7 +6,7 @@ from common import ProviderOptions, Ciphers, pq_enabled
 from fixtures import managed_process  # lgtm [py/unused-import]
 from global_flags import get_flag, is_criterion_on, S2N_FIPS_MODE, S2N_USE_CRITERION
 from providers import Provider, S2N
-from utils import invalid_test_parameters, get_parameter_name, to_bytes, flaky_test
+from utils import invalid_test_parameters, get_parameter_name, to_bytes
 
 
 ENDPOINTS = [
@@ -90,7 +90,7 @@ else:
 @pytest.mark.parametrize("endpoint", ENDPOINTS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("cipher", CIPHERS, ids=get_parameter_name)
-@flaky_test()
+@pytest.mark.flaky(reruns=5, reruns_delay=4)
 def test_well_known_endpoints(managed_process, protocol, endpoint, provider, cipher):
     port = "443"
 

--- a/tests/integrationv2/utils.py
+++ b/tests/integrationv2/utils.py
@@ -1,8 +1,6 @@
 from common import Protocols
-from functools import wraps
 from providers import S2N
 from global_flags import get_flag, S2N_FIPS_MODE
-import time
 
 
 def to_bytes(val):
@@ -131,30 +129,3 @@ def invalid_test_parameters(*args, **kwargs):
                 return True
 
     return False
-
-
-def flaky_test(max_iterations=5):
-    def decorator(fun):
-        @wraps(fun)
-        def wrapper(*args, **kwargs):
-            iterations = 0
-
-            while iterations + 1 < max_iterations:
-                try:
-                    return fun(*args, **kwargs)
-
-                except AssertionError as assert_error:
-                    # compute an exponential back off starting at 500ms
-                    sleep_time = 2 ** iterations / 2
-                    iterations += 1
-                    print(f"Flaky test failure in \"{fun.__name__}\" "
-                          f"({iterations}/{max_iterations}). Retrying in {sleep_time} second(s).")
-                    for line in assert_error.__str__().strip().split("\n"):
-                        print(f"  {line}")
-                    time.sleep(sleep_time)
-
-            # don't wrap the last iteration
-            return fun(*args, **kwargs)
-
-        return wrapper
-    return decorator


### PR DESCRIPTION
### Description of changes: 

Connecting to a well-known endpoint can potentially fail for a number of unrelated reasons. This change adds a `pytest.mark.flaky` decorator to the `integrationv2` well-known tests which retries failures (up to 5 times).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
