### PR TITLE
Create new PQ TLS Policies with minimum of TLSv1.2

### DIFF
--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -575,6 +575,11 @@ int main(int argc, char **argv)
             "AWS-CRT-SDK-TLSv1.1",
             "AWS-CRT-SDK-TLSv1.2",
             "AWS-CRT-SDK-TLSv1.3",
+            /* PQ TLS */
+            "PQ-TLS-1-2-2023-04-07",
+            "PQ-TLS-1-2-2023-04-08",
+            "PQ-TLS-1-2-2023-04-09",
+            "PQ-TLS-1-2-2023-04-10",
         };
         for (size_t i = 0; i < s2n_array_len(tls13_security_policy_strings); i++) {
             security_policy = NULL;

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -523,6 +523,42 @@ const struct s2n_security_policy security_policy_pq_tls_1_0_2023_01_24 = {
     .ecc_preferences = &s2n_ecc_preferences_20200310,
 };
 
+/* Same as security_policy_pq_tls_1_1_2021_05_21, but with TLS 1.2 as minimum */
+const struct s2n_security_policy security_policy_pq_tls_1_2_2023_04_07 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_pq_tls_1_1_2021_05_21,
+    .kem_preferences = &kem_preferences_pq_tls_1_0_2021_05,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20200310,
+};
+
+/* Same as security_policy_pq_tls_1_0_2021_05_22, but with TLS 1.2 as minimum */
+const struct s2n_security_policy security_policy_pq_tls_1_2_2023_04_08 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_pq_tls_1_0_2021_05_22,
+    .kem_preferences = &kem_preferences_pq_tls_1_0_2021_05,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20200310,
+};
+
+/* Same as security_policy_pq_tls_1_0_2021_05_24, but with TLS 1.2 as minimum */
+const struct s2n_security_policy security_policy_pq_tls_1_2_2023_04_09 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_pq_tls_1_0_2021_05_24,
+    .kem_preferences = &kem_preferences_pq_tls_1_0_2021_05,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20200310,
+};
+
+/* Same as security_policy_pq_tls_1_0_2021_05_26, but with TLS 1.2 as minimum */
+const struct s2n_security_policy security_policy_pq_tls_1_2_2023_04_10 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_pq_tls_1_0_2021_05_26,
+    .kem_preferences = &kem_preferences_pq_tls_1_0_2021_05,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20200310,
+};
+
 const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2018_10 = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_kms_fips_tls_1_2_2018_10,
@@ -856,6 +892,10 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "PQ-TLS-1-0-2021-05-25", .security_policy = &security_policy_pq_tls_1_0_2021_05_25, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "PQ-TLS-1-0-2021-05-26", .security_policy = &security_policy_pq_tls_1_0_2021_05_26, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "PQ-TLS-1-0-2023-01-24", .security_policy = &security_policy_pq_tls_1_0_2023_01_24, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "PQ-TLS-1-2-2023-04-07", .security_policy = &security_policy_pq_tls_1_2_2023_04_07, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "PQ-TLS-1-2-2023-04-08", .security_policy = &security_policy_pq_tls_1_2_2023_04_08, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "PQ-TLS-1-2-2023-04-09", .security_policy = &security_policy_pq_tls_1_2_2023_04_09, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "PQ-TLS-1-2-2023-04-10", .security_policy = &security_policy_pq_tls_1_2_2023_04_10, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20140601", .security_policy = &security_policy_20140601, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20141001", .security_policy = &security_policy_20141001, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20150202", .security_policy = &security_policy_20150202, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -109,6 +109,10 @@ extern const struct s2n_security_policy security_policy_pq_tls_1_0_2021_05_24;
 extern const struct s2n_security_policy security_policy_pq_tls_1_0_2021_05_25;
 extern const struct s2n_security_policy security_policy_pq_tls_1_0_2021_05_26;
 extern const struct s2n_security_policy security_policy_pq_tls_1_0_2023_01_24;
+extern const struct s2n_security_policy security_policy_pq_tls_1_2_2023_04_07;
+extern const struct s2n_security_policy security_policy_pq_tls_1_2_2023_04_08;
+extern const struct s2n_security_policy security_policy_pq_tls_1_2_2023_04_09;
+extern const struct s2n_security_policy security_policy_pq_tls_1_2_2023_04_10;
 
 extern const struct s2n_security_policy security_policy_cloudfront_upstream;
 extern const struct s2n_security_policy security_policy_cloudfront_upstream_tls10;


### PR DESCRIPTION
### Resolved issues:
N/A

### Description of changes: 
Creates 4 new PQ TLS Policies based on existing PQ TLS Policies, but with TLS 1.2 as the minimum supported TLS version. 

### Call-outs:
N/A

### Testing:
Unit tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
