### PR TITLE
Add note about server_name spec requirements

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1711,10 +1711,16 @@ S2N_API extern int s2n_connection_set_protocol_preferences(struct s2n_connection
 /**
  * Sets the server name for the connection.
  *
- * It may be desirable for clients
+ * The provided server name will be sent by the client to the server in the
+ * server_name ClientHello extension. It may be desirable for clients
  * to provide this information to facilitate secure connections to
  * servers that host multiple 'virtual' servers at a single underlying
  * network address.
+ *
+ * s2n-tls does not place any restrictions on the provided server name. However,
+ * other TLS implementations might. Specifically, the TLS specification for the
+ * server_name extension requires that it be an ASCII-encoded DNS name without a
+ * trailing dot, and explicitly forbids literal IPv4 or IPv6 addresses.
  *
  * @param conn The connection object being queried
  * @param server_name A pointer to a string containing the desired server name


### PR DESCRIPTION
### Description of changes: 

The [server_name RFC](https://www.rfc-editor.org/rfc/rfc6066#section-3) has a bunch of rules for the format of the server_name value provided by the client. However, s2n-tls has never enforced those requirements, either when sending or receiving the server_name extension, and instead treats the server_name as opaque data. And the RFC does say:
> TLS MAY treat
   provided server names as opaque data and pass the names and types to
   the application.

Trying to enforce the RFC's rules now would likely break existing customers, and the only real value it would provide would be to preempt the peer rejecting the server_name. Instead, I'd rather just add a note about the requirements to the API docs.


### Testing:
Just a documentation change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
