### PR TITLE
ci: Update AWSLC test dependency to v1.8.0

### DIFF
--- a/codebuild/bin/install_awslc.sh
+++ b/codebuild/bin/install_awslc.sh
@@ -36,7 +36,7 @@ source codebuild/bin/jobs.sh
 if [ "$IS_FIPS" == "1" ]; then
   AWSLC_VERSION=AWS-LC-FIPS-1.0.3
 else
-  AWSLC_VERSION=v1.4.0
+  AWSLC_VERSION=v1.8.0
 fi
 mkdir -p "$BUILD_DIR"||true
 cd "$BUILD_DIR"


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

This PR updates AWSLC to v1.8.0 in CI, unblocking https://github.com/aws/s2n-tls/pull/3905.

### Call-outs:

The ubuntu18 and ubuntu22 codebuild images have been rebuilt with this change. After this PR is merged, these new images will replace our current images in CI.

### Testing:

The following codebuild runs were performed with the new ubuntu18 and ubuntu22 images:
- [General batch](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nGeneralBatch/batch/s2nGeneralBatch%3A215325d4-425a-4cbd-a97e-1f2a2f175f0b?region=us-west-2)
- [Integ batch](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/S2nIntegrationV2SmallBatch/batch/S2nIntegrationV2SmallBatch%3Affba4881-ef0c-4e32-9029-c765aaa82d76?region=us-west-2)
- [Fuzz batch](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nFuzzBatch/batch/s2nFuzzBatch%3A500a76d3-84de-4387-8dd3-5272e43fc223?region=us-west-2)

It was confirmed that the correct AWSLC version was built when rebuilding the docker images:

**ubuntu18**:
```
Checking out tag=v1.8.0
Cloning into 'aws-lc'...
Note: switching to '8668d2dbe3342d4f304382cf5b5a82f63a6adc75'.
```

**ubuntu22**:
```
Checking out tag=v1.8.0
Cloning into 'aws-lc'...
Note: switching to '8668d2dbe3342d4f304382cf5b5a82f63a6adc75'.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
