### PR TITLE
Add test to verify TLS1.2 downgrade 

### DIFF
--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -146,6 +146,8 @@ class Certificates(object):
     RSA_PSS_2048_SHA256 = Cert(
         "RSA_PSS_2048_SHA256", "localhost_rsa_pss_2048_sha256")
 
+    RSA_2048_PKCS1 = Cert("RSA_2048_PKCS1", "rsa_2048_pkcs1")
+
     OCSP = Cert("OCSP_RSA", "ocsp/server")
     OCSP_ECDSA = Cert("OCSP_ECDSA_256", "ocsp/server_ecdsa")
 

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -750,6 +750,8 @@ class GnuTLS(Provider):
 
     @staticmethod
     def protocol_to_priority_str(protocol):
+        if not protocol:
+            return None
         return {
             Protocols.TLS10.value: "VERS-TLS1.0",
             Protocols.TLS11.value: "VERS-TLS1.1",


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/3049

### Description of changes: 

This test case is for a rare edge case which ensures protocol version downgrades to TLS1.2 when :

- Server requires client authentication.
- Libcrypto doesn't support RSA PSS(openssl1.02).
- Server uses ECDSA certificate.
- Client responds with RSA and PKCS1 certificate.

Also fixes a bug in `protocol_to_priority_str`. 

### Call-outs:

### Testing:
All test pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
