### PR TITLE
Remove unnecessary flush

### DIFF
--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -174,7 +174,6 @@ ssize_t s2n_recv_impl(struct s2n_connection *conn, void *buf, ssize_t size, s2n_
             switch (record_type) {
                 case TLS_ALERT:
                     POSIX_GUARD(s2n_process_alert_fragment(conn));
-                    POSIX_GUARD(s2n_flush(conn, blocked));
                     break;
                 case TLS_HANDSHAKE: {
                     s2n_result result = s2n_post_handshake_recv(conn);


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/3934

### Description of changes: 

Removing an unnecessary flush. As mentioned in https://github.com/aws/s2n-tls/issues/3934, this flush doesn't actually do any useful work.

s2n_recv should not be sending any data anyway. We need to keep sending and receiving separate. Any alerts triggered by s2n_recv should be sent by calling s2n_send (if specific and not blinded :( ) or s2n_shutdown.

### Testing:
Existing tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
