### PR TITLE
Don't send close_notify after an alert

### DIFF
--- a/tests/unit/s2n_shutdown_test.c
+++ b/tests/unit/s2n_shutdown_test.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
         EXPECT_FALSE(conn->close_notify_queued);
         EXPECT_FALSE(conn->closed);
 
-        /* Queue reader alert */
+        /* Queue writer alert */
         EXPECT_SUCCESS(s2n_queue_writer_close_alert_warning(conn));
         EXPECT_FALSE(conn->closing);
 

--- a/tests/unit/s2n_shutdown_test.c
+++ b/tests/unit/s2n_shutdown_test.c
@@ -50,6 +50,114 @@ int main(int argc, char **argv)
         S2N_ALERT_LENGTH,
     };
 
+    const uint8_t alert_record_size = sizeof(alert_record_header) + S2N_ALERT_LENGTH;
+
+    /* Test: Do not send close_notify if reader alert already sent */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+
+        DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, conn));
+
+        /* Verify state prior to alert */
+        EXPECT_FALSE(s2n_handshake_is_complete(conn));
+        EXPECT_FALSE(conn->close_notify_received);
+        EXPECT_FALSE(conn->close_notify_queued);
+        EXPECT_FALSE(conn->closed);
+
+        /* Queue reader alert */
+        EXPECT_SUCCESS(s2n_queue_reader_handshake_failure_alert(conn));
+        EXPECT_FALSE(conn->closing);
+
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+        EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
+
+        /* Verify state after shutdown attempt */
+        EXPECT_FALSE(s2n_handshake_is_complete(conn));
+        EXPECT_FALSE(conn->close_notify_received);
+        EXPECT_FALSE(conn->close_notify_queued);
+        EXPECT_TRUE(conn->closing);
+        EXPECT_TRUE(conn->closed);
+
+        /* Verify only one alert sent */
+        EXPECT_EQUAL(s2n_stuffer_data_available(&output), alert_record_size);
+    };
+
+    /* Test: Do not send close_notify if writer alert already sent */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+
+        DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, conn));
+
+        /* Verify state prior to alert */
+        EXPECT_FALSE(s2n_handshake_is_complete(conn));
+        EXPECT_FALSE(conn->close_notify_received);
+        EXPECT_FALSE(conn->close_notify_queued);
+        EXPECT_FALSE(conn->closed);
+
+        /* Queue reader alert */
+        EXPECT_SUCCESS(s2n_queue_writer_close_alert_warning(conn));
+        EXPECT_FALSE(conn->closing);
+
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+        EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
+
+        /* Verify state after shutdown attempt */
+        EXPECT_FALSE(s2n_handshake_is_complete(conn));
+        EXPECT_FALSE(conn->close_notify_received);
+        EXPECT_FALSE(conn->close_notify_queued);
+        EXPECT_TRUE(conn->closing);
+        EXPECT_TRUE(conn->closed);
+
+        /* Verify only one alert sent */
+        EXPECT_EQUAL(s2n_stuffer_data_available(&output), alert_record_size);
+    };
+
+    /* Test: Send close_notify if a warning alert was sent */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+
+        DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, conn));
+
+        /* Verify state prior to alert */
+        EXPECT_FALSE(s2n_handshake_is_complete(conn));
+        EXPECT_FALSE(conn->close_notify_received);
+        EXPECT_FALSE(conn->close_notify_queued);
+        EXPECT_FALSE(conn->closed);
+
+        /* Queue reader warning */
+        EXPECT_OK(s2n_queue_reader_no_renegotiation_alert(conn));
+
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+        EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
+
+        /* Verify state after shutdown attempt */
+        EXPECT_FALSE(s2n_handshake_is_complete(conn));
+        EXPECT_FALSE(conn->close_notify_received);
+        EXPECT_TRUE(conn->close_notify_queued);
+        EXPECT_TRUE(conn->closed);
+
+        /* Verify two alerts sent: the warning + the close_notify */
+        EXPECT_EQUAL(s2n_stuffer_data_available(&output), alert_record_size * 2);
+    };
+
     /* Test: Do not wait for response close_notify if handshake not complete */
     {
         DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -256,8 +256,8 @@ int s2n_queue_writer_close_alert_warning(struct s2n_connection *conn)
     struct s2n_blob out = { 0 };
     POSIX_GUARD(s2n_blob_init(&out, alert, sizeof(alert)));
 
-    /* If there is an alert pending or we've already sent a close_notify, do nothing */
-    if (s2n_stuffer_data_available(&conn->writer_alert_out) || conn->close_notify_queued) {
+    /* If there is an alert pending, do nothing */
+    if (s2n_stuffer_data_available(&conn->writer_alert_out)) {
         return S2N_SUCCESS;
     }
 
@@ -266,7 +266,6 @@ int s2n_queue_writer_close_alert_warning(struct s2n_connection *conn)
     }
 
     POSIX_GUARD(s2n_stuffer_write(&conn->writer_alert_out, &out));
-    conn->close_notify_queued = 1;
 
     return S2N_SUCCESS;
 }

--- a/tls/s2n_shutdown.c
+++ b/tls/s2n_shutdown.c
@@ -51,7 +51,11 @@ int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status *blocked)
     /* Flush any outstanding data or alerts */
     POSIX_GUARD(s2n_flush(conn, blocked));
 
-    /* Send our close_notify alert if not sent yet */
+    /**
+     *= https://tools.ietf.org/rfc/rfc8446#section-6.1
+     *# Each party MUST send a "close_notify" alert before closing its write
+     *# side of the connection, unless it has already sent some error alert.
+     */
     if (s2n_is_close_notify_required(conn)) {
         POSIX_GUARD(s2n_queue_writer_close_alert_warning(conn));
         conn->close_notify_queued = 1;


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/3935

### Description of changes: 

This fixes the issue where close_notify alerts may be sent even after an error alert is sent.

By calling s2n_flush before we queue the close_notify, we flush any pending error alerts, which sets conn->closing. We can then use conn->closing to determine whether a close_notify needs to be sent.

### Call-outs:

* If you look at s2n_flush, it still looks like it's possible to write two error alerts if both error stuffers are full: https://github.com/lrstewart/s2n/blob/0931790cd84015aebeb8bed4446bf733adefb37f/tls/s2n_send.c#L106-L130 However, the only writer alerts are close_notify alerts written by s2n_shutdown (see https://github.com/aws/s2n-tls/issues/3941), so this change prevents that situation too. This is confusing, but I'm going to say that it's outside of the scope of this PR. I'm trying to clean this up one problem at a time :)

* I moved the "should we send a close_notify?" logic out of s2n_queue_writer_close_alert_warning so that s2n_queue_writer_close_alert_warning matches [s2n_queue_reader_alert](https://github.com/lrstewart/s2n/blob/0931790cd84015aebeb8bed4446bf733adefb37f/tls/s2n_alerts.c#L273-L296). We shouldn't send duplicate reader error alerts either, so that didn't seem like the right place for the logic to avoid duplicates.

### Testing:
Added unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
