### PR TITLE
Fix end-of-data behavior

### DIFF
--- a/tests/unit/s2n_alerts_protocol_test.c
+++ b/tests/unit/s2n_alerts_protocol_test.c
@@ -164,7 +164,7 @@ int main(int argc, char **argv)
                     EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(receiver, &blocked), S2N_ERR_CLOSED);
                 } else {
                     EXPECT_FAILURE_WITH_ERRNO(s2n_recv(receiver, data, sizeof(data), &blocked), S2N_ERR_ALERT);
-                    EXPECT_EQUAL(s2n_recv(receiver, data, sizeof(data), &blocked), END_OF_DATA);
+                    EXPECT_FAILURE_WITH_ERRNO(s2n_recv(receiver, data, sizeof(data), &blocked), S2N_ERR_CLOSED);
                     EXPECT_FAILURE_WITH_ERRNO(s2n_send(receiver, data, sizeof(data), &blocked), S2N_ERR_CLOSED);
                 }
 
@@ -319,6 +319,7 @@ int main(int argc, char **argv)
              */
             if (expected_alert == S2N_TLS_ALERT_CLOSE_NOTIFY) {
                 EXPECT_EQUAL(s2n_recv(closed_conn, data, sizeof(data), &blocked), END_OF_DATA);
+                EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
             } else {
                 EXPECT_FAILURE_WITH_ERRNO(s2n_recv(closed_conn, data, sizeof(data), &blocked), S2N_ERR_ALERT);
             }
@@ -331,7 +332,7 @@ int main(int argc, char **argv)
              */
             EXPECT_FAILURE_WITH_ERRNO(s2n_send(failed_conn, data, sizeof(data), &blocked),
                     S2N_ERR_CLOSED);
-            EXPECT_EQUAL(s2n_recv(failed_conn, data, sizeof(data), &blocked), END_OF_DATA);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_recv(failed_conn, data, sizeof(data), &blocked), S2N_ERR_CLOSED);
         }
     };
 
@@ -384,6 +385,7 @@ int main(int argc, char **argv)
                 EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(receiver, &blocked), S2N_ERR_CLOSED);
             } else {
                 EXPECT_EQUAL(s2n_recv(receiver, data, sizeof(data), &blocked), END_OF_DATA);
+                EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
             }
             EXPECT_FALSE(s2n_connection_check_io_status(receiver, S2N_IO_READABLE));
 
@@ -397,6 +399,7 @@ int main(int argc, char **argv)
                 EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(receiver, &blocked), S2N_ERR_CLOSED);
             } else {
                 EXPECT_EQUAL(s2n_recv(receiver, data, sizeof(data), &blocked), END_OF_DATA);
+                EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
             }
         };
     };
@@ -520,6 +523,109 @@ int main(int argc, char **argv)
         /* Respond with close_notify */
         EXPECT_SUCCESS(s2n_shutdown(receiver, &blocked));
         EXPECT_SUCCESS(s2n_shutdown(sender, &blocked));
+    };
+
+    /* Test: End-of-Data
+     *
+     *= https://tools.ietf.org/rfc/rfc8446#6.1
+     *# If a transport-level close
+     *# is received prior to a "close_notify", the receiver cannot know that
+     *# all the data that was sent has been received.
+     *
+     *= https://tools.ietf.org/rfc/rfc8446#6.1
+     *# If the application protocol using TLS provides that any data may be
+     *# carried over the underlying transport after the TLS connection is
+     *# closed, the TLS implementation MUST receive a "close_notify" alert
+     *# before indicating end-of-data to the application layer.
+     */
+    for (uint8_t mode = 0; mode < MODE_COUNT; mode++) {
+        /* Test: Without partial read */
+        {
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_blinding(server, S2N_SELF_SERVICE_BLINDING));
+            EXPECT_SUCCESS(s2n_connection_set_config(server, config));
+
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_blinding(client, S2N_SELF_SERVICE_BLINDING));
+            EXPECT_SUCCESS(s2n_connection_set_config(client, config));
+
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+            EXPECT_SUCCESS(s2n_connections_set_io_pair(client, server, &io_pair));
+
+            /* Perform handshake */
+            EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server, client));
+
+            /* Close one end of pipe */
+            EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, mode));
+
+            struct s2n_connection *receiver = client;
+            if (mode == S2N_CLIENT) {
+                receiver = server;
+            }
+
+            /* Subsequent reads should NOT report END_OF_DATA, but instead an error */
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            for (size_t i = 0; i < 5; i++) {
+                EXPECT_FAILURE_WITH_ERRNO(s2n_recv(receiver, data, sizeof(data), &blocked),
+                        S2N_ERR_CLOSED);
+                EXPECT_FALSE(s2n_connection_check_io_status(receiver, S2N_IO_READABLE));
+            }
+        };
+
+        /* Test: With partial read */
+        {
+            /* In order to trigger a partial read, we need to encounter end-of-data
+             * when some data has already been successfully read. For that to be true,
+             * we need to read multiple records (one successfully, then end-of-data).
+             */
+            struct s2n_config partial_write_config_copy = *config;
+            partial_write_config_copy.recv_multi_record = true;
+
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_blinding(server, S2N_SELF_SERVICE_BLINDING));
+            EXPECT_SUCCESS(s2n_connection_set_config(server, &partial_write_config_copy));
+
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_blinding(client, S2N_SELF_SERVICE_BLINDING));
+            EXPECT_SUCCESS(s2n_connection_set_config(client, &partial_write_config_copy));
+
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+            EXPECT_SUCCESS(s2n_connections_set_io_pair(client, server, &io_pair));
+
+            /* Perform handshake */
+            EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server, client));
+
+            struct s2n_connection *sender = server;
+            struct s2n_connection *receiver = client;
+            if (mode == S2N_CLIENT) {
+                sender = client;
+                receiver = server;
+            }
+
+            /* Send some data */
+            const uint8_t partial_write = sizeof(data) / 2;
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            EXPECT_EQUAL(s2n_send(sender, data, partial_write, &blocked), partial_write);
+
+            /* Close one end of pipe */
+            EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, mode));
+
+            /* First read should report a partial read, but also close the connection */
+            EXPECT_EQUAL(s2n_recv(receiver, data, sizeof(data), &blocked), partial_write);
+            EXPECT_FALSE(s2n_connection_check_io_status(receiver, S2N_IO_READABLE));
+
+            /* Subsequent reads should NOT report END_OF_DATA, but instead an error */
+            for (size_t i = 0; i < 5; i++) {
+                EXPECT_FAILURE_WITH_ERRNO(s2n_recv(receiver, data, sizeof(data), &blocked),
+                        S2N_ERR_CLOSED);
+            }
+        };
     };
 
     END_TEST();

--- a/tests/unit/s2n_alerts_protocol_test.c
+++ b/tests/unit/s2n_alerts_protocol_test.c
@@ -532,11 +532,13 @@ int main(int argc, char **argv)
     /* Test: End-of-Data
      *
      *= https://tools.ietf.org/rfc/rfc8446#6.1
+     *= type=test
      *# If a transport-level close
      *# is received prior to a "close_notify", the receiver cannot know that
      *# all the data that was sent has been received.
      *
      *= https://tools.ietf.org/rfc/rfc8446#6.1
+     *= type=test
      *# If the application protocol using TLS provides that any data may be
      *# carried over the underlying transport after the TLS connection is
      *# closed, the TLS implementation MUST receive a "close_notify" alert

--- a/tls/s2n_shutdown.c
+++ b/tls/s2n_shutdown.c
@@ -73,6 +73,7 @@ int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status *blocked)
      */
     if (!s2n_handshake_is_complete(conn)) {
         POSIX_GUARD_RESULT(s2n_connection_set_closed(conn));
+        *blocked = S2N_NOT_BLOCKED;
         return S2N_SUCCESS;
     }
 


### PR DESCRIPTION
### Resolved issues:

 resolves https://github.com/aws/s2n-tls/issues/3936

### Description of changes: 

s2n-tls was reporting "end of data" to the application even if the peer closed the transport unexpectedly. Unless we receive a close_notify, we should not indicate end-of-data.

### Testing:
This is another bug I found while writing s2n_alerts_protocol_test, so more tests in that file and updates to correct expectations :)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
