### PR TITLE
Fix expected negotiated version in client auth downgrade test

### DIFF
--- a/tests/integrationv2/test_client_authentication.py
+++ b/tests/integrationv2/test_client_authentication.py
@@ -277,17 +277,11 @@ def test_tls_12_client_auth_downgrade(managed_process):
     # The downgrade occurs because openssl-1.0.2 doesn't support RSA-PSS signature scheme.
     #
     # TLS 1.3 is disabled when s2n-tls is built with libressl and boringssl, so TLS 1.2 will be negotiated
-    # with these libcryptos as well. https://github.com/aws/s2n-tls/issues/3250
-    if any([
-        libcrypto_str in get_flag(S2N_PROVIDER_VERSION) for libcrypto_str in [
-            "openssl-1.0.2",
-            "libressl",
-            "boringssl"
-        ]
-    ]):
-        expected_protocol_version = Protocols.TLS12.value
-    else:
+    # with these libcryptos as well. See https://github.com/aws/s2n-tls/issues/3250.
+    if S2N.supports_signature(Signatures.RSA_PSS_RSAE_SHA256):
         expected_protocol_version = Protocols.TLS13.value
+    else:
+        expected_protocol_version = Protocols.TLS12.value
 
     # The client signature algorithm type will be always 'RSA-PSS' when the protocol version is TLS1.3 and 'RSA'
     # if it's TLS1.2.

--- a/tests/integrationv2/test_client_authentication.py
+++ b/tests/integrationv2/test_client_authentication.py
@@ -275,7 +275,16 @@ def test_tls_12_client_auth_downgrade(managed_process):
 
     # A s2n server built with OpenSSL1.0.2 and enabling client auth will downgrade the protocol to TLS1.2.
     # The downgrade occurs because openssl-1.0.2 doesn't support RSA-PSS signature scheme.
-    if "openssl-1.0.2" in get_flag(S2N_PROVIDER_VERSION):
+    #
+    # TLS 1.3 is disabled when s2n-tls is built with libressl and boringssl, so TLS 1.2 will be negotiated
+    # with these libcryptos as well. https://github.com/aws/s2n-tls/issues/3250
+    if any([
+        libcrypto_str in get_flag(S2N_PROVIDER_VERSION) for libcrypto_str in [
+            "openssl-1.0.2",
+            "libressl",
+            "boringssl"
+        ]
+    ]):
         expected_protocol_version = Protocols.TLS12.value
     else:
         expected_protocol_version = Protocols.TLS13.value


### PR DESCRIPTION
### Description of changes: 

The TLS 1.2 client auth downgrade test, added in https://github.com/aws/s2n-tls/pull/3939, failed when testing with s2n-tls linked to LibreSSL and BoringSSL. This is because the test expects TLS 1.3 to be negotiated with LibreSSL and BoringSSL, even though TLS 1.3 is currently disabled with these libcryptos (see https://github.com/aws/s2n-tls/issues/3250).

This PR updates the TLS 1.2 client auth downgrade test to expect a TLS 1.2 handshake when linked to LibreSSL and BoringSSL.

### Testing:

- [Codebuild integ batch that includes LibreSSL and BoringSSL](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/S2nIntegrationV2SmallBatch/batch/S2nIntegrationV2SmallBatch%3A2ba42530-ebdf-4c6b-934e-516e911027a6?region=us-west-2)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
