### PR TITLE
Update README.md

### DIFF
--- a/tests/sidetrail/README.md
+++ b/tests/sidetrail/README.md
@@ -129,12 +129,10 @@ export S2N=<path_to_s2n>
 
 ### Building the image
 
-To build the image, start with `s2n/codebuild/spec/sidetrail/Dockerfile`
-
-```shell
-cd $S2N
-docker build -f codebuild/spec/sidetrail/Dockerfile --tag sidetrail .
-```
+To build the image, run this scripts:
+- [install sidetrail dependencies]("https://github.com/aws/s2n-tls/blob/main/codebuild/bin/install_sidetrail_dependencies.sh")
+- [install sidetrail]("https://github.com/aws/s2n-tls/blob/main/codebuild/bin/install_sidetrail.sh")
+- [run sidetrail]("https://github.com/aws/s2n-tls/blob/main/codebuild/bin/run_sidetrail.sh")
 
 This step takes about 25 minutes on my laptop.
 


### PR DESCRIPTION


### Resolved issues:

 resolves #3881 ,  #3518

### Description of changes: 

The documentation states that to build the image, this code should be run:
```
cd $S2N
docker build -f codebuild/spec/sidetrail/Dockerfile --tag sidetrail .
```

But this dockerfile has been shifted/removed and hence the builds fails. 

### Call-outs:

The documentation is updated as mentioned in #3881 discussion by @jmayclin to ```install_sidetrail_dependencies.sh```, ```install_sidetrail.sh``` and finally ```run_sidetrail.sh``` .

### Testing:
This change can be tested out by actually building the img & running sidetrail by using the shell links provided.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
