### PR TITLE
Cover more situations where no close_notify is sent/received

### DIFF
--- a/tests/unit/s2n_shutdown_test.c
+++ b/tests/unit/s2n_shutdown_test.c
@@ -52,20 +52,20 @@ int main(int argc, char **argv)
 
     const uint8_t alert_record_size = sizeof(alert_record_header) + S2N_ALERT_LENGTH;
 
-    /* Test: Do not send close_notify if reader alert already sent */
+    /* Test: Do not send or await close_notify if reader alert already sent */
     {
         DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
                 s2n_connection_ptr_free);
         EXPECT_NOT_NULL(conn);
+        EXPECT_OK(s2n_skip_handshake(conn));
 
-        DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
-        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        /* Setup output, but no input. We expect no reads. */
         DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
-        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, conn));
+        EXPECT_SUCCESS(s2n_connection_set_send_io_stuffer(&output, conn));
 
         /* Verify state prior to alert */
-        EXPECT_FALSE(s2n_handshake_is_complete(conn));
+        EXPECT_TRUE(s2n_handshake_is_complete(conn));
         EXPECT_FALSE(conn->close_notify_received);
         EXPECT_FALSE(conn->close_notify_queued);
         EXPECT_TRUE(s2n_connection_check_io_status(conn, S2N_IO_FULL_DUPLEX));
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
 
         /* Verify state after shutdown attempt */
-        EXPECT_FALSE(s2n_handshake_is_complete(conn));
+        EXPECT_TRUE(s2n_handshake_is_complete(conn));
         EXPECT_FALSE(conn->close_notify_received);
         EXPECT_FALSE(conn->close_notify_queued);
         EXPECT_TRUE(conn->write_closing);
@@ -88,20 +88,20 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_stuffer_data_available(&output), alert_record_size);
     };
 
-    /* Test: Do not send close_notify if writer alert already sent */
+    /* Test: Do not send or await close_notify if writer alert already sent */
     {
         DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
                 s2n_connection_ptr_free);
         EXPECT_NOT_NULL(conn);
+        EXPECT_OK(s2n_skip_handshake(conn));
 
-        DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
-        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        /* Setup output, but no input. We expect no reads. */
         DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
-        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, conn));
+        EXPECT_SUCCESS(s2n_connection_set_send_io_stuffer(&output, conn));
 
         /* Verify state prior to alert */
-        EXPECT_FALSE(s2n_handshake_is_complete(conn));
+        EXPECT_TRUE(s2n_handshake_is_complete(conn));
         EXPECT_FALSE(conn->close_notify_received);
         EXPECT_FALSE(conn->close_notify_queued);
         EXPECT_TRUE(s2n_connection_check_io_status(conn, S2N_IO_FULL_DUPLEX));
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
 
         /* Verify state after shutdown attempt */
-        EXPECT_FALSE(s2n_handshake_is_complete(conn));
+        EXPECT_TRUE(s2n_handshake_is_complete(conn));
         EXPECT_FALSE(conn->close_notify_received);
         EXPECT_FALSE(conn->close_notify_queued);
         EXPECT_TRUE(conn->write_closing);
@@ -124,11 +124,12 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_stuffer_data_available(&output), alert_record_size);
     };
 
-    /* Test: Send close_notify if a warning alert was sent */
+    /* Test: Send and await close_notify if a warning alert was sent */
     {
         DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
                 s2n_connection_ptr_free);
         EXPECT_NOT_NULL(conn);
+        EXPECT_OK(s2n_skip_handshake(conn));
 
         DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
@@ -137,7 +138,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, conn));
 
         /* Verify state prior to alert */
-        EXPECT_FALSE(s2n_handshake_is_complete(conn));
+        EXPECT_TRUE(s2n_handshake_is_complete(conn));
         EXPECT_FALSE(conn->close_notify_received);
         EXPECT_FALSE(conn->close_notify_queued);
         EXPECT_TRUE(s2n_connection_check_io_status(conn, S2N_IO_FULL_DUPLEX));
@@ -146,16 +147,68 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_queue_reader_no_renegotiation_alert(conn));
 
         s2n_blocked_status blocked = S2N_NOT_BLOCKED;
-        EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(conn, &blocked),
+                S2N_ERR_IO_BLOCKED);
+        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
 
         /* Verify state after shutdown attempt */
-        EXPECT_FALSE(s2n_handshake_is_complete(conn));
+        EXPECT_TRUE(s2n_handshake_is_complete(conn));
         EXPECT_FALSE(conn->close_notify_received);
         EXPECT_TRUE(conn->close_notify_queued);
-        EXPECT_TRUE(s2n_connection_check_io_status(conn, S2N_IO_CLOSED));
+        EXPECT_FALSE(s2n_connection_check_io_status(conn, S2N_IO_WRITABLE));
 
         /* Verify two alerts sent: the warning + the close_notify */
         EXPECT_EQUAL(s2n_stuffer_data_available(&output), alert_record_size * 2);
+    };
+
+    /* Test: Do not send or await close_notify if error alert was already received */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        EXPECT_OK(s2n_skip_handshake(conn));
+
+        DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, conn));
+
+        /* Verify state prior to alert */
+        EXPECT_TRUE(s2n_handshake_is_complete(conn));
+        EXPECT_FALSE(conn->close_notify_received);
+        EXPECT_FALSE(conn->close_notify_queued);
+        EXPECT_TRUE(s2n_connection_check_io_status(conn, S2N_IO_FULL_DUPLEX));
+
+        /* Queue input alert */
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&input, alert_record_header,
+                sizeof(alert_record_header)));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&input, 2));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&input, S2N_TLS_ALERT_INTERNAL_ERROR));
+
+        /* Receive alert */
+        uint8_t buffer[1] = { 0 };
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_recv(conn, buffer, sizeof(buffer), &blocked),
+                S2N_ERR_ALERT);
+
+        /* Call s2n_connection_get_alert(), to make sure that
+         * https://github.com/aws/s2n-tls/issues/3933 doesn't affect shutdown.
+         */
+        EXPECT_EQUAL(s2n_connection_get_alert(conn), S2N_TLS_ALERT_INTERNAL_ERROR);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_alert(conn), S2N_ERR_NO_ALERT);
+
+        /* Shutdown should succeed, since it's a no-op */
+        EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
+
+        /* Verify state after shutdown attempt */
+        EXPECT_TRUE(s2n_handshake_is_complete(conn));
+        EXPECT_FALSE(conn->close_notify_received);
+        EXPECT_FALSE(conn->close_notify_queued);
+        EXPECT_TRUE(s2n_connection_check_io_status(conn, S2N_IO_CLOSED));
+
+        /* Verify no alerts sent */
+        EXPECT_EQUAL(s2n_stuffer_data_available(&output), 0);
     };
 
     /* Test: Do not wait for response close_notify if handshake not complete */
@@ -253,7 +306,46 @@ int main(int argc, char **argv)
         EXPECT_TRUE(s2n_connection_check_io_status(conn, S2N_IO_CLOSED));
     };
 
-    /* Test: s2n_shutdown ignores data received after a close_notify */
+    /* Test: s2n_shutdown reports alerts received after a close_notify is sent */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        EXPECT_OK(s2n_skip_handshake(conn));
+
+        DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, conn));
+
+        /* Verify s2n_shutdown is waiting for a close_notify */
+        s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(conn, &blocked), S2N_ERR_IO_BLOCKED);
+        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
+
+        /* Queue an input error alert */
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&input, alert_record_header, sizeof(alert_record_header)));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&input, 2));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&input, S2N_TLS_ALERT_INTERNAL_ERROR));
+
+        /* Receive and report the error alert */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(conn, &blocked), S2N_ERR_ALERT);
+
+        /* Verify state after shutdown attempt */
+        EXPECT_FALSE(conn->close_notify_received);
+        EXPECT_TRUE(conn->close_notify_queued);
+        EXPECT_TRUE(s2n_connection_check_io_status(conn, S2N_IO_CLOSED));
+        EXPECT_EQUAL(s2n_stuffer_data_available(&output), alert_record_size);
+
+        /* Future calls are no-ops */
+        for (size_t i = 0; i < 5; i++) {
+            EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
+            EXPECT_FALSE(conn->close_notify_received);
+        }
+    };
+
+    /* Test: s2n_shutdown ignores data received after a close_notify is sent */
     {
         DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
                 s2n_connection_ptr_free);

--- a/tls/s2n_shutdown.c
+++ b/tls/s2n_shutdown.c
@@ -38,7 +38,7 @@ static bool s2n_error_alert_received(struct s2n_connection *conn)
 
 static bool s2n_error_alert_sent(struct s2n_connection *conn)
 {
-    /* Sending an alert always sets conn->closing: see s2n_flush() */
+    /* Sending an alert always sets conn->write_closing: see s2n_flush() */
     if (!conn->write_closing) {
         return false;
     }

--- a/tls/s2n_shutdown.c
+++ b/tls/s2n_shutdown.c
@@ -19,16 +19,31 @@
 #include "tls/s2n_tls.h"
 #include "utils/s2n_safety.h"
 
-static bool s2n_is_close_notify_required(struct s2n_connection *conn)
+static bool s2n_error_alert_received(struct s2n_connection *conn)
 {
-    /* We only send one close_notify */
-    if (conn->close_notify_queued) {
+    /* We don't check s2n_connection_get_alert() or s2n_stuffer_data_available()
+     * because of https://github.com/aws/s2n-tls/issues/3933.
+     * We need to check if the stuffer contains an alert, regardless of its
+     * read state.
+     */
+    if (conn->alert_in.write_cursor == 0) {
         return false;
     }
-    /* We don't send a close_notify if an error alert was already sent.
-     * Sending an error alert always sets conn->closing: see s2n_flush.
-     */
-    if (conn->write_closing) {
+    /* Verify that the stuffer doesn't just contain a close_notify alert */
+    if (conn->close_notify_received) {
+        return false;
+    }
+    return true;
+}
+
+static bool s2n_error_alert_sent(struct s2n_connection *conn)
+{
+    /* Sending an alert always sets conn->closing: see s2n_flush() */
+    if (!conn->write_closing) {
+        return false;
+    }
+    /* Verify that the alert sent wasn't just a close_notify */
+    if (conn->close_notify_queued) {
         return false;
     }
     return true;
@@ -44,6 +59,16 @@ int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status *blocked)
         return S2N_SUCCESS;
     }
 
+    /* Treat this call as a no-op if an error alert was already received.
+     * Error alerts close the connection without any exchange of close_notify alerts. */
+    if (s2n_error_alert_received(conn)) {
+        return S2N_SUCCESS;
+    }
+
+    /* Enforce blinding.
+     * If an application is using self-service blinding, ensure that they have
+     * waited the required time before triggering the close_notify alert.
+     */
     uint64_t elapsed = 0;
     POSIX_GUARD_RESULT(s2n_timer_elapsed(conn->config, &conn->write_timer, &elapsed));
     S2N_ERROR_IF(elapsed < conn->delay, S2N_ERR_SHUTDOWN_PAUSED);
@@ -51,12 +76,20 @@ int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status *blocked)
     /* Flush any outstanding data or alerts */
     POSIX_GUARD(s2n_flush(conn, blocked));
 
+    /* Error alerts close the connection without any exchange of close_notify alerts.
+     * We need to check after flushing to account for any pending alerts.
+     */
+    if (s2n_error_alert_sent(conn)) {
+        conn->read_closed = 1;
+        return S2N_SUCCESS;
+    }
+
     /**
      *= https://tools.ietf.org/rfc/rfc8446#section-6.1
      *# Each party MUST send a "close_notify" alert before closing its write
      *# side of the connection, unless it has already sent some error alert.
      */
-    if (s2n_is_close_notify_required(conn)) {
+    if (!conn->close_notify_queued) {
         POSIX_GUARD(s2n_queue_writer_close_alert_warning(conn));
         conn->close_notify_queued = 1;
         POSIX_GUARD(s2n_flush(conn, blocked));


### PR DESCRIPTION
### Description of changes: 

My fix in https://github.com/aws/s2n-tls/commit/53af3e980e74bfac889fd424c682f71cc77f97ad was incomplete. It covered the specific case in the issue (Don't send close_notify after an error alert is sent), but not all the other situations related to error alerts:
* Don't send close_notify after an error alert is received
* Don't expect close_notify from the peer if an error alert was sent
* Don't expect close_notify from the peer if an error alert was received

### Call-outs:

Are there any other alert scenarios I'm missing here?

### Testing:
Even more s2n_shutdown tests!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
