### PR TITLE
Add logging for failed CRT tests

### DIFF
--- a/codebuild/bin/build_aws_crt_cpp.sh
+++ b/codebuild/bin/build_aws_crt_cpp.sh
@@ -41,7 +41,7 @@ mv s2n aws-crt-cpp/crt/
 
 cmake ./aws-crt-cpp -Bbuild -GNinja -DBUILD_DEPS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
 ninja -C ./build install
-CTEST_PARALLEL_LEVEL=$(nproc) ninja -C ./build test
+CTEST_OUTPUT_ON_FAILURE=1 CTEST_PARALLEL_LEVEL=$(nproc) ninja -C ./build test
 
 popd
 


### PR DESCRIPTION
### Description of changes: 

Just a minor fix. The output of the CRT unit tests was pretty unhelpful to debug the recent failures. I'm adding the CTEST_OUTPUT_ON_FAILURE flag so that we log some information about why the tests fail.

I will never understand why CTEST_OUTPUT_ON_FAILURE isn't on by default -_-

### Testing:
I ran this version of the command locally to debug the CRT tests: https://github.com/awslabs/aws-crt-cpp/pull/495

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
