### PR TITLE
Add 32 bit buildspec

### DIFF
--- a/codebuild/spec/buildspec_32bit_cross_compile.yml
+++ b/codebuild/spec/buildspec_32bit_cross_compile.yml
@@ -1,0 +1,25 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+version: 0.2
+
+phases:
+  build:
+    on-failure: ABORT
+    commands:
+      - cmake . -Bbuild -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/32-bit.toolchain
+      - cmake --build ./build -j $(nproc)
+  post_build:
+    on-failure: ABORT
+    commands:
+      - CTEST_PARALLEL_LEVEL=$(nproc) make -C build test

--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -232,7 +232,7 @@ batch:
           S2N_LIBCRYPTO: openssl-1.1.1
 
     - identifier: 32BitBuildAndUnit
-      buildspec: codebuild/spec/buildspec_unit_coverage.yml
+      buildspec: codebuild/spec/buildspec_32bit_cross_compile.yml
       env:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE

--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -231,6 +231,13 @@ batch:
         variables:
           S2N_LIBCRYPTO: openssl-1.1.1
 
+    - identifier: 32BitBuildAndUnit
+      buildspec: codebuild/spec/buildspec_unit_coverage.yml
+      env:
+        privileged-mode: true
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
+
     - buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL


### PR DESCRIPTION
### Resolved issues:

Makes progress on #3903 

### Description of changes: 

This PR adds a build-spec for 32 bit cross-compiling builds. The docker image has already been updated to include 32 bit glibc and libcrypto dependencies, so after this is merged the final remaining step is to update the batch configuration in CodeBuild. This will be added to the "general batch" job, and the configuration will mirror that added in the omnibus configuration.

### Call-outs:
This doesn't use the omniscript. This makes it easier for CodeBuild to surface errors and prevents more scripts from ending up in our codebuild directory. It also reduces the configuration that has to be passed in to the build spec.

This also doesn't prepend the `s2n` identifier to the `32BitBuildAndUnit` job name. I don't think adding `s2n` provides any additional information, and there is precedent for this with the `sawHMACPlus` identifier.

### Testing:

Draft: will be running this through the proposed batch change. Will update this section when that is done.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
