### PR TITLE
Use custom library context for rc4 instead of global default context

### DIFF
--- a/bindings/rust/s2n-tls-sys/tests/s2n_init.rs
+++ b/bindings/rust/s2n-tls-sys/tests/s2n_init.rs
@@ -10,11 +10,8 @@ fn s2n_init_test() {
         std::env::set_var("S2N_DONT_MLOCK", "1");
 
         // try to initialize the library
-        s2n_init();
-
-        // make sure it was successful
-        let error = *s2n_errno_location();
-        if error != 0 {
+        if s2n_init() != 0 {
+            let error = *s2n_errno_location();
             let msg = s2n_strerror_name(error);
             let msg = std::ffi::CStr::from_ptr(msg);
             panic!("s2n did not initialize correctly: {:?}", msg);

--- a/crypto/s2n_cipher.h
+++ b/crypto/s2n_cipher.h
@@ -107,3 +107,6 @@ extern const struct s2n_cipher s2n_chacha20_poly1305;
 
 extern const struct s2n_cipher s2n_tls13_aes128_gcm;
 extern const struct s2n_cipher s2n_tls13_aes256_gcm;
+
+S2N_RESULT s2n_rc4_init();
+S2N_RESULT s2n_rc4_cleanup();

--- a/crypto/s2n_libcrypto.c
+++ b/crypto/s2n_libcrypto.c
@@ -17,17 +17,13 @@
 
 #include <openssl/crypto.h>
 #include <openssl/opensslv.h>
+#include <string.h>
 
 #include "crypto/s2n_crypto.h"
 #include "crypto/s2n_fips.h"
 #include "crypto/s2n_openssl.h"
 #include "utils/s2n_safety.h"
 #include "utils/s2n_safety_macros.h"
-#if S2N_OPENSSL_VERSION_AT_LEAST(3, 0, 0)
-    #include <openssl/provider.h>
-#endif
-
-#include <string.h>
 
 /* Note: OpenSSL 1.0.2 -> 1.1.0 implemented a new API to get the version number
  * and version name. We have to handle that by using old functions
@@ -148,40 +144,6 @@ bool s2n_libcrypto_is_libressl()
     return false;
 #endif
 }
-
-S2N_RESULT s2n_libcrypto_init(void)
-{
-#if S2N_OPENSSL_VERSION_AT_LEAST(3, 0, 0)
-    RESULT_ENSURE(OSSL_PROVIDER_load(NULL, "default") != NULL, S2N_ERR_OSSL_PROVIDER);
-    #ifdef S2N_LIBCRYPTO_SUPPORTS_EVP_RC4
-    /* needed to support RC4 algorithm
-     * https://www.openssl.org/docs/man3.0/man7/OSSL_PROVIDER-legacy.html
-     */
-    RESULT_ENSURE(OSSL_PROVIDER_load(NULL, "legacy") != NULL, S2N_ERR_OSSL_PROVIDER);
-    #endif
-#endif
-
-    return S2N_RESULT_OK;
-}
-
-#if S2N_OPENSSL_VERSION_AT_LEAST(3, 0, 0)
-int s2n_libcrypto_cleanup_cb(OSSL_PROVIDER *provider, void *cbdata)
-{
-    return OSSL_PROVIDER_unload(provider);
-}
-
-S2N_RESULT s2n_libcrypto_cleanup(void)
-{
-    RESULT_GUARD_OSSL(OSSL_PROVIDER_do_all(NULL, *s2n_libcrypto_cleanup_cb, NULL), S2N_ERR_ATEXIT);
-
-    return S2N_RESULT_OK;
-}
-#else
-S2N_RESULT s2n_libcrypto_cleanup(void)
-{
-    return S2N_RESULT_OK;
-}
-#endif
 
 /* Performs various checks to validate that the libcrypto used at compile-time
  * is the same libcrypto being used at run-time.

--- a/crypto/s2n_libcrypto.h
+++ b/crypto/s2n_libcrypto.h
@@ -17,6 +17,4 @@
 
 #include "utils/s2n_result.h"
 
-S2N_RESULT s2n_libcrypto_init(void);
 S2N_RESULT s2n_libcrypto_validate_runtime(void);
-S2N_RESULT s2n_libcrypto_cleanup(void);

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -971,6 +971,9 @@ int s2n_crypto_disable_init(void)
 /* Determines cipher suite availability and selects record algorithms */
 int s2n_cipher_suites_init(void)
 {
+    /* RC4 requires some extra setup */
+    POSIX_GUARD_RESULT(s2n_rc4_init());
+
     const int num_cipher_suites = s2n_array_len(s2n_all_cipher_suites);
     for (int i = 0; i < num_cipher_suites; i++) {
         struct s2n_cipher_suite *cur_suite = s2n_all_cipher_suites[i];
@@ -1051,6 +1054,9 @@ S2N_RESULT s2n_cipher_suites_cleanup(void)
         * cleanup in later versions */
 #endif
     }
+
+    /* RC4 requires some extra cleanup */
+    RESULT_GUARD(s2n_rc4_cleanup());
 
     return S2N_RESULT_OK;
 }

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -66,7 +66,6 @@ int s2n_init(void)
     POSIX_GUARD(s2n_mem_init());
     /* Must run before any init method that calls libcrypto methods. */
     POSIX_GUARD_RESULT(s2n_locking_init());
-    POSIX_GUARD_RESULT(s2n_libcrypto_init());
     POSIX_GUARD(s2n_fips_init());
     POSIX_GUARD_RESULT(s2n_rand_init());
     POSIX_GUARD(s2n_cipher_suites_init());
@@ -100,7 +99,6 @@ static bool s2n_cleanup_atexit_impl(void)
     bool cleaned_up = s2n_result_is_ok(s2n_cipher_suites_cleanup())
             && s2n_result_is_ok(s2n_rand_cleanup_thread())
             && s2n_result_is_ok(s2n_rand_cleanup())
-            && s2n_result_is_ok(s2n_libcrypto_cleanup())
             && s2n_result_is_ok(s2n_locking_cleanup())
             && (s2n_mem_cleanup() == S2N_SUCCESS);
 


### PR DESCRIPTION
### Description of changes: 

We forgot to add Openssl-3.0 to the unit tests, so missed that [the newest unit](https://github.com/aws/s2n-tls/commit/405a88883489e4599e2736d58fa84ba0f14dea1b) test broke with Openssl-3.0.

The problem is that the default openssl context is global. So when we manually loaded providers so that we could access the legacy RC4 algorithm, that change affected any other uses of openssl within the same process. When we then unloaded those providers, we unloaded them for everyone, and openssl basically stopped working because it had no algorithms.

So instead, I now load the legacy provider required for RC4 into a custom openssl context so that we can retrieve the RC4 algorithm. 

### Callouts
I put the call to s2n_rc4_init in s2n_cipher_suites_init instead of the base s2n_init method because we have to setup RC4 before we can setup any cipher suites that use RC4. I thought it might be clearer. But maybe I should just put it in s2n_init with a comment?

### Testing:
The failing s2n_random_test now passes. I also added some sanity checks to s2n_rc4_test to make sure we're still using RC4 where expected.
I also double checked that the Openssl-3.0 test was actually running (s2nUnitOpenSSL3GCC9 in GeneralBatch).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
