### PR TITLE
Print Wire Bytes In and Out for s2nc

### DIFF
--- a/bin/echo.c
+++ b/bin/echo.c
@@ -14,6 +14,7 @@
  */
 
 #include <errno.h>
+#include <inttypes.h>
 #include <netdb.h>
 #include <openssl/rsa.h>
 #include <openssl/x509.h>
@@ -250,8 +251,8 @@ int print_connection_info(struct s2n_connection *conn)
         printf("\n");
     }
 
-    printf("Wire Bytes In: %lu\n", s2n_connection_get_wire_bytes_in(conn));
-    printf("Wire Bytes Out: %lu\n", s2n_connection_get_wire_bytes_out(conn));
+    printf("Wire bytes in: %"PRIu64"\n", s2n_connection_get_wire_bytes_in(conn));
+    printf("Wire bytes out: %"PRIu64"\n", s2n_connection_get_wire_bytes_out(conn));
 
     return 0;
 }

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -251,8 +251,8 @@ int print_connection_info(struct s2n_connection *conn)
         printf("\n");
     }
 
-    printf("Wire bytes in: %"PRIu64"\n", s2n_connection_get_wire_bytes_in(conn));
-    printf("Wire bytes out: %"PRIu64"\n", s2n_connection_get_wire_bytes_out(conn));
+    printf("Wire bytes in: %" PRIu64 "\n", s2n_connection_get_wire_bytes_in(conn));
+    printf("Wire bytes out: %" PRIu64 "\n", s2n_connection_get_wire_bytes_out(conn));
 
     return 0;
 }

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -250,6 +250,9 @@ int print_connection_info(struct s2n_connection *conn)
         printf("\n");
     }
 
+    printf("Wire Bytes In: %lu\n", s2n_connection_get_wire_bytes_in(conn));
+    printf("Wire Bytes Out: %lu\n", s2n_connection_get_wire_bytes_out(conn));
+
     return 0;
 }
 


### PR DESCRIPTION
### Resolved issues:
N/A

### Description of changes: 
Updates s2nc to print out the number of bytes sent and received over the connection. This is useful for comparing the amount of bandwidth required by the TLS Handshake for different TLS settings. 

### Call-outs:
None


### Testing:
Ran unit tests locally. Manually confirmed that s2nc prints out values expected.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
