### PR TITLE
Tentative fix proposal for thread crash after shared object unload

### DIFF
--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -466,6 +466,8 @@ S2N_RESULT s2n_rand_cleanup_thread(void)
 
     s2n_per_thread_rand_state.drbgs_initialized = false;
 
+    RESULT_ENSURE(pthread_setspecific(s2n_per_thread_rand_state_key, NULL), S2N_ERR_DRBG);
+
     return S2N_RESULT_OK;
 }
 


### PR DESCRIPTION
### Resolved issues:

https://github.com/aws/s2n-tls/issues/3987

### Description of changes: 

s2n never clears the thread local slot associated with `s2n_per_thread_rand_state_key` which has a destructor callback.  If s2n is unloaded before the callback is set to be invoked, a crash occurs when it is invoked.

This updates thread local cleanup of the random module to zero out the value associated with the `s2n_per_thread_rand_state_key` slot, preventing an invalid destructor callback when s2n was properly shut down before module unload.

### Call-outs:

I am unsure if `s2n_rand_cleanup_thread` can be called while `s2n_per_thread_rand_state_key` is uninitialized.  If that is the case, then error checking the result of `pthread_setspecific` might not be a good idea (if failure in turn disrupts succeeding cleanup).

### Testing:

This change was tested by before-and-after runs of the small repro program in the original issue.  A standalone test that reproduced that might be nice and if requested I could try and put that together as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
