### PR TITLE
draft: lrstewart fix with disable rc4

### DIFF
--- a/crypto/s2n_libcrypto.c
+++ b/crypto/s2n_libcrypto.c
@@ -17,17 +17,13 @@
 
 #include <openssl/crypto.h>
 #include <openssl/opensslv.h>
+#include <string.h>
 
 #include "crypto/s2n_crypto.h"
 #include "crypto/s2n_fips.h"
 #include "crypto/s2n_openssl.h"
 #include "utils/s2n_safety.h"
 #include "utils/s2n_safety_macros.h"
-#if S2N_OPENSSL_VERSION_AT_LEAST(3, 0, 0)
-    #include <openssl/provider.h>
-#endif
-
-#include <string.h>
 
 /* Note: OpenSSL 1.0.2 -> 1.1.0 implemented a new API to get the version number
  * and version name. We have to handle that by using old functions
@@ -148,40 +144,6 @@ bool s2n_libcrypto_is_libressl()
     return false;
 #endif
 }
-
-S2N_RESULT s2n_libcrypto_init(void)
-{
-#if S2N_OPENSSL_VERSION_AT_LEAST(3, 0, 0)
-    RESULT_ENSURE(OSSL_PROVIDER_load(NULL, "default") != NULL, S2N_ERR_OSSL_PROVIDER);
-    #ifdef S2N_LIBCRYPTO_SUPPORTS_EVP_RC4
-    /* needed to support RC4 algorithm
-     * https://www.openssl.org/docs/man3.0/man7/OSSL_PROVIDER-legacy.html
-     */
-    RESULT_ENSURE(OSSL_PROVIDER_load(NULL, "legacy") != NULL, S2N_ERR_OSSL_PROVIDER);
-    #endif
-#endif
-
-    return S2N_RESULT_OK;
-}
-
-#if S2N_OPENSSL_VERSION_AT_LEAST(3, 0, 0)
-int s2n_libcrypto_cleanup_cb(OSSL_PROVIDER *provider, void *cbdata)
-{
-    return OSSL_PROVIDER_unload(provider);
-}
-
-S2N_RESULT s2n_libcrypto_cleanup(void)
-{
-    RESULT_GUARD_OSSL(OSSL_PROVIDER_do_all(NULL, *s2n_libcrypto_cleanup_cb, NULL), S2N_ERR_ATEXIT);
-
-    return S2N_RESULT_OK;
-}
-#else
-S2N_RESULT s2n_libcrypto_cleanup(void)
-{
-    return S2N_RESULT_OK;
-}
-#endif
 
 /* Performs various checks to validate that the libcrypto used at compile-time
  * is the same libcrypto being used at run-time.

--- a/crypto/s2n_libcrypto.h
+++ b/crypto/s2n_libcrypto.h
@@ -17,6 +17,4 @@
 
 #include "utils/s2n_result.h"
 
-S2N_RESULT s2n_libcrypto_init(void);
 S2N_RESULT s2n_libcrypto_validate_runtime(void);
-S2N_RESULT s2n_libcrypto_cleanup(void);

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -183,7 +183,7 @@ make
 Not all algorithms are available from all versions of Openssl:
 * ChaChaPoly is not supported before Openssl-1.1.1
 * RSA-PSS is not supported before Openssl-1.1.1
-* RC4 is not supported after Openssl-3.
+* RC4 is not supported with Openssl-3.0 or later.
 
 ## Building s2n-tls with LibreSSL
 

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -179,6 +179,12 @@ cd ../../ # root of project
 make
 ```
 
+### Available algorithms
+Not all algorithms are available from all versions of Openssl:
+* ChaChaPoly is not supported before Openssl-1.1.1
+* RSA-PSS is not supported before Openssl-1.1.1
+* RC4 is not supported after Openssl-3.
+
 ## Building s2n-tls with LibreSSL
 
 To build s2n-tls with LibreSSL, do the following:

--- a/tests/unit/s2n_rc4_test.c
+++ b/tests/unit/s2n_rc4_test.c
@@ -20,6 +20,7 @@
 #include "crypto/s2n_cipher.h"
 #include "crypto/s2n_fips.h"
 #include "crypto/s2n_hmac.h"
+#include "crypto/s2n_openssl.h"
 #include "s2n_test.h"
 #include "stuffer/s2n_stuffer.h"
 #include "testlib/s2n_testlib.h"
@@ -31,6 +32,16 @@
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
+
+    /* Test Openssl-3.0 does not support RC4 */
+    if (S2N_OPENSSL_VERSION_AT_LEAST(3, 0, 0)) {
+        EXPECT_FALSE(s2n_rc4.is_available());
+    }
+
+    /* Test FIPS does not support RC4 */
+    if (s2n_is_in_fips_mode()) {
+        EXPECT_FALSE(s2n_rc4.is_available());
+    }
 
     struct s2n_connection *conn;
     uint8_t mac_key[] = "sample mac key";
@@ -57,9 +68,9 @@ int main(int argc, char **argv)
 
     /* test the RC4 cipher with a SHA1 hash */
     conn->secure->cipher_suite->record_alg = &s2n_record_alg_rc4_sha;
+    EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->server_key));
+    EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->client_key));
     if (conn->secure->cipher_suite->record_alg->cipher->is_available()) {
-        EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->server_key));
-        EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->client_key));
         EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure->client_key, &key_iv));
         EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure->server_key, &key_iv));
         EXPECT_SUCCESS(s2n_hmac_init(&conn->secure->client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
@@ -119,10 +130,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->destroy_key(&conn->secure->client_key));
         EXPECT_SUCCESS(s2n_connection_free(conn));
     } else {
-        EXPECT_FAILURE_WITH_ERRNO(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->server_key), S2N_ERR_UNIMPLEMENTED);
-        EXPECT_FAILURE_WITH_ERRNO(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->client_key), S2N_ERR_UNIMPLEMENTED);
-        EXPECT_FAILURE_WITH_ERRNO(conn->secure->cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure->client_key, &key_iv), S2N_ERR_UNIMPLEMENTED);
-        EXPECT_FAILURE_WITH_ERRNO(conn->secure->cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure->server_key, &key_iv), S2N_ERR_UNIMPLEMENTED);
+        EXPECT_FAILURE(conn->secure->cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure->client_key, &key_iv));
+        EXPECT_FAILURE(conn->secure->cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure->server_key, &key_iv));
     }
 
     END_TEST();

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -66,7 +66,6 @@ int s2n_init(void)
     POSIX_GUARD(s2n_mem_init());
     /* Must run before any init method that calls libcrypto methods. */
     POSIX_GUARD_RESULT(s2n_locking_init());
-    POSIX_GUARD_RESULT(s2n_libcrypto_init());
     POSIX_GUARD(s2n_fips_init());
     POSIX_GUARD_RESULT(s2n_rand_init());
     POSIX_GUARD(s2n_cipher_suites_init());
@@ -100,7 +99,6 @@ static bool s2n_cleanup_atexit_impl(void)
     bool cleaned_up = s2n_result_is_ok(s2n_cipher_suites_cleanup())
             && s2n_result_is_ok(s2n_rand_cleanup_thread())
             && s2n_result_is_ok(s2n_rand_cleanup())
-            && s2n_result_is_ok(s2n_libcrypto_cleanup())
             && s2n_result_is_ok(s2n_locking_cleanup())
             && (s2n_mem_cleanup() == S2N_SUCCESS);
 


### PR DESCRIPTION
### Description of changes: 

This is a draft PR to see if we can get a passing CI run on #3982 by configuring the integv2 test not to run when the provider is openssl-3.0. The integ tests are difficult to get running locally, so for right now the lowest friction alternative is to just open this draft PR.

If all the CI run's pass, then I can open a separate PR to merge in this fix, then rebase #3982 on top of that and we should be good to go.

### Testing:

The CI should pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
