### PR TITLE
Adding rfc4492 to duvet

### DIFF
--- a/compliance/initialize_duvet.sh
+++ b/compliance/initialize_duvet.sh
@@ -5,4 +5,5 @@ duvet extract https://tools.ietf.org/rfc/rfc8446 # The Transport Layer Security 
 duvet extract https://tools.ietf.org/rfc/rfc8448 # Example Handshake Traces for TLS 1.3
 duvet extract https://tools.ietf.org/rfc/rfc7627 # Transport Layer Security (TLS) Session Hash and Extended Master Secret Extension
 duvet extract https://tools.ietf.org/rfc/rfc5746 # Transport Layer Security (TLS) Renegotiation Indication Extension
+duvet extract https://tools.ietf.org/rfc/rfc4492 # Elliptic Curve Cryptography (ECC) Cipher Suites for Transport Layer Security (TLS)
 


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 
This PR adds rfc4492 to duvet. This will allow checking code coverage based on rfc4492.
### Call-outs:

### Testing:
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
