### PR TITLE
docs: add notes on s2nc and s2nd usage

### DIFF
--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -47,7 +47,7 @@
 
 /*
  * s2nc is an example client that uses many s2n-tls APIs. It's main purpose is to provide
- * testing functionality for s2n-tls integration tests, and as such, it should be not used
+ * testing functionality for s2n-tls integration tests, and as such, it should not be used
  * for any production purposes.
  */
 void usage()

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -46,9 +46,8 @@
 #define OPT_BUFFERED_SEND      1007
 
 /*
- * s2nc is an example client that uses many s2n-tls APIs. It's main purpose is to provide
- * testing functionality for s2n-tls integration tests, and as such, it should not be used
- * for any production purposes.
+ * s2nc is an example client that uses many s2n-tls APIs.
+ * It is intended for testing purposes only, and should not be used in production.
  */
 void usage()
 {

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -45,6 +45,11 @@
 #define OPT_PREFER_THROUGHPUT  1006
 #define OPT_BUFFERED_SEND      1007
 
+/*
+ * s2nc is an example client that uses many s2n-tls APIs. It's main purpose is to provide
+ * testing functionality for s2n-tls integration tests, and as such, it should be not used
+ * for any production purposes.
+ */
 void usage()
 {
     /* clang-format off */

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -38,6 +38,12 @@
 
 #define MAX_CERTIFICATES 50
 
+/*
+ * s2nd is an example server that uses many s2n-tls APIs. It's main purpose is to provide
+ * testing functionality for s2n-tls integration tests, and as such, it should be not used
+ * for any production purposes.
+ */
+
 static char default_certificate_chain[] =
         "-----BEGIN CERTIFICATE-----"
         "MIIDHTCCAgWgAwIBAgIUPxywpg3/+VHmj8jJSvK62XC06zMwDQYJKoZIhvcNAQEL"

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -40,7 +40,7 @@
 
 /*
  * s2nd is an example server that uses many s2n-tls APIs. It's main purpose is to provide
- * testing functionality for s2n-tls integration tests, and as such, it should be not used
+ * testing functionality for s2n-tls integration tests, and as such, it should not be used
  * for any production purposes.
  */
 

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -39,9 +39,8 @@
 #define MAX_CERTIFICATES 50
 
 /*
- * s2nd is an example server that uses many s2n-tls APIs. It's main purpose is to provide
- * testing functionality for s2n-tls integration tests, and as such, it should not be used
- * for any production purposes.
+ * s2nd is an example server that uses many s2n-tls APIs.
+ * It is intended for testing purposes only, and should not be used in production.
  */
 
 static char default_certificate_chain[] =

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1309,4 +1309,7 @@ int s2n_early_data_cb_async_impl(struct s2n_connection *conn, struct s2n_offered
 # Examples
 
 To understand the API it may be easiest to see examples in action. s2n-tls's [bin/](https://github.com/aws/s2n-tls/blob/main/bin/) directory
-includes an example client (s2nc) and server (s2nd).
+includes an example client (`s2nc`) and server (`s2nd`). 
+
+**Note:** `s2nc` and `s2nd` are primarily intended to provide testing 
+functionality for s2n-tls integration tests, and as such, they should be not used for any production purposes.

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1311,5 +1311,4 @@ int s2n_early_data_cb_async_impl(struct s2n_connection *conn, struct s2n_offered
 To understand the API it may be easiest to see examples in action. s2n-tls's [bin/](https://github.com/aws/s2n-tls/blob/main/bin/) directory
 includes an example client (`s2nc`) and server (`s2nd`). 
 
-**Note:** `s2nc` and `s2nd` are primarily intended to provide testing 
-functionality for s2n-tls integration tests, and as such, they should not be used for any production purposes.
+**Note:** `s2nc` and `s2nd` are intended for testing purposes only, and should not be used in production.

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -1312,4 +1312,4 @@ To understand the API it may be easiest to see examples in action. s2n-tls's [bi
 includes an example client (`s2nc`) and server (`s2nd`). 
 
 **Note:** `s2nc` and `s2nd` are primarily intended to provide testing 
-functionality for s2n-tls integration tests, and as such, they should be not used for any production purposes.
+functionality for s2n-tls integration tests, and as such, they should not be used for any production purposes.


### PR DESCRIPTION
### Description of changes: 

s2nc and s2nd are primarily intended to provide testing functionality for s2n-tls integration tests and ad hoc testing, and as such, they should not be used for any production purposes. This PR adds this messaging to the usage guide and directly to s2nc.c and s2nd.c

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
