### PR TITLE
style: simplfy api for test utility

### DIFF
--- a/bindings/rust/s2n-tls/src/callbacks/pkey.rs
+++ b/bindings/rust/s2n-tls/src/callbacks/pkey.rs
@@ -128,7 +128,6 @@ mod tests {
     use futures_test::task::new_count_waker;
     use openssl::{ec::EcKey, ecdsa::EcdsaSig};
 
-    const MAX_POLLS: usize = 100;
     type Error = Box<dyn std::error::Error>;
 
     const KEY: &[u8] = include_bytes!(concat!(
@@ -171,7 +170,7 @@ mod tests {
             Harness::new(client)
         };
 
-        Ok(Pair::new(server, client, MAX_POLLS))
+        Ok(Pair::new(server, client))
     }
 
     fn ecdsa_sign(

--- a/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
+++ b/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
@@ -323,7 +323,7 @@ mod tests {
             Harness::new(client)
         };
 
-        let mut pair = Pair::new(server, client, SAMPLES);
+        let mut pair = Pair::new(server, client);
         loop {
             match pair.poll() {
                 Poll::Ready(result) => {
@@ -373,7 +373,7 @@ mod tests {
             Harness::new(client)
         };
 
-        let mut pair = Pair::new(server, client, SAMPLES);
+        let mut pair = Pair::new(server, client);
         loop {
             match pair.poll() {
                 Poll::Ready(result) => {
@@ -427,7 +427,7 @@ mod tests {
             Harness::new(client)
         };
 
-        let pair = Pair::new(server, client, SAMPLES);
+        let pair = Pair::new(server, client);
 
         poll_tls_pair(pair);
         // confirm that the callback returned Pending `require_pending_count` times
@@ -496,7 +496,7 @@ mod tests {
             Harness::new(client)
         };
 
-        let pair = Pair::new(server, client, SAMPLES);
+        let pair = Pair::new(server, client);
 
         assert_eq!(callback.count(), 0);
         poll_tls_pair(pair);
@@ -590,7 +590,7 @@ mod tests {
             Harness::new(client)
         };
 
-        let pair = Pair::new(server, client, SAMPLES);
+        let pair = Pair::new(server, client);
         let pair = poll_tls_pair(pair);
         let server = pair.server.0.connection;
         let client = pair.client.0.connection;
@@ -630,7 +630,7 @@ mod tests {
             Harness::new(client)
         };
 
-        let pair = Pair::new(server, client, SAMPLES);
+        let pair = Pair::new(server, client);
         let pair = poll_tls_pair(pair);
         let server = pair.server.0.connection;
         let client = pair.client.0.connection;


### PR DESCRIPTION
### Description of changes: 

The current test pair API requires a parameter dictating the number of iterations (which I'm assuming is roughly the number of "polls" each peer gets) but we always use the same paramter. The general end consumer behavior is "enough iterations to make the handshake complete successfully", so the test constant of 100 was starting to proliferate across different files. We should make this the default.

### Call-outs:
I originally just rolled this into a separate PR but it was making the other PR hard to read so separating this out.

### Testing:

All CI should pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
