### PR TITLE
Disable retry client random validation outside of tests

### DIFF
--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -800,6 +800,40 @@ int main(int argc, char **argv)
                     S2N_ERR_BAD_MESSAGE);
         };
 
+        /* Test: outside of testing, the server accepts an incorrectly updated ClientHello */
+        {
+            DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(server_conn);
+            EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
+            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+            DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(client_conn);
+            EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
+            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+            struct s2n_test_io_pair io_pair = { 0 };
+            EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+            EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+            /* Force the HRR path */
+            client_conn->security_policy_override = &security_policy_test_tls13_retry;
+
+            /* Send ClientHello */
+            s2n_blocked_status blocked = 0;
+            EXPECT_OK(s2n_negotiate_until_message(client_conn, &blocked, SERVER_HELLO));
+
+            /* Change client random */
+            client_conn->handshake_params.client_random[0]++;
+
+            /* Expect success if we pretend that this isn't a unit test */
+            EXPECT_SUCCESS(s2n_in_unit_test_set(false));
+            EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+            EXPECT_SUCCESS(s2n_in_unit_test_set(true));
+        }
+
         /* Test: The server rejects a second ClientHello with a changed extension */
         {
             DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -232,7 +232,7 @@ static S2N_RESULT s2n_client_hello_verify_for_retry(struct s2n_connection *conn,
      * enforce this validation outside of tests. We continue to enforce it during
      * tests to avoid regressions.
      */
-    if (!S2N_IN_TEST) {
+    if (!s2n_in_test()) {
         return S2N_RESULT_OK;
     }
 

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -222,6 +222,20 @@ static S2N_RESULT s2n_client_hello_verify_for_retry(struct s2n_connection *conn,
         return S2N_RESULT_OK;
     }
 
+    /* In the past, the s2n-tls client updated the client hello in ways not
+     * allowed by RFC8446: https://github.com/aws/s2n-tls/pull/3311
+     * Although the issue was addressed, its existence means that old versions
+     * of the s2n-tls client will fail this validation.
+     *
+     * RFC8446 doesn't explicitly require that servers enforce the
+     * client requirements. So to avoid breaking old s2n-tls clients, we do not
+     * enforce this validation outside of tests. We continue to enforce it during
+     * tests to avoid regressions.
+     */
+    if (!S2N_IN_TEST) {
+        return S2N_RESULT_OK;
+    }
+
     /*
      *= https://tools.ietf.org/rfc/rfc8446#section-4.1.2
      *# The client will also send a


### PR DESCRIPTION
### Description of changes: 

In the past, the s2n-tls client updated the client hello in ways not
allowed by RFC8446: https://github.com/aws/s2n-tls/pull/3311
Although the issue was addressed, its existence means that old versions
of the s2n-tls client will fail this validation.

RFC8446 doesn't explicitly require that servers enforce the
client requirements. So to avoid breaking old s2n-tls clients, we do not
enforce this validation outside of tests. We continue to enforce it during
tests to avoid regressions.

### Testing:
Existing tests are unaffected. I added a new test that lies about being a test to verify the change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
