### PR TITLE
fix: improve compatibility with old Linux versions

### DIFF
--- a/crypto/s2n_openssl_x509.c
+++ b/crypto/s2n_openssl_x509.c
@@ -25,7 +25,7 @@ S2N_CLEANUP_RESULT s2n_openssl_x509_stack_pop_free(STACK_OF(X509) **cert_chain)
     return S2N_RESULT_OK;
 }
 
-S2N_CLEANUP_RESULT s2n_openssl_asn1_time_free_pointer(ASN1_GENERALIZEDTIME **time)
+S2N_CLEANUP_RESULT s2n_openssl_asn1_time_free_pointer(ASN1_GENERALIZEDTIME **time_ptr)
 {
     /* The ANS1_*TIME structs are just typedef wrappers around ASN1_STRING
      *
@@ -34,8 +34,8 @@ S2N_CLEANUP_RESULT s2n_openssl_asn1_time_free_pointer(ASN1_GENERALIZEDTIME **tim
      * ASN1_STRING_free().
      * https://www.openssl.org/docs/man1.1.1/man3/ASN1_TIME_to_tm.html
      */
-    RESULT_ENSURE_REF(*time);
-    ASN1_STRING_free((ASN1_STRING *) *time);
-    *time = NULL;
+    RESULT_ENSURE_REF(*time_ptr);
+    ASN1_STRING_free((ASN1_STRING *) *time_ptr);
+    *time_ptr = NULL;
     return S2N_RESULT_OK;
 }

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -72,6 +72,12 @@
 
 #define ENTROPY_SOURCE "/dev/urandom"
 
+#if defined(O_CLOEXEC)
+    #define ENTROPY_FLAGS O_RDONLY | O_CLOEXEC
+#else
+    #define ENTROPY_FLAGS O_RDONLY
+#endif
+
 /* See https://en.wikipedia.org/wiki/CPUID */
 #define RDRAND_ECX_FLAG 0x40000000
 
@@ -429,7 +435,7 @@ RAND_METHOD s2n_openssl_rand_method = {
 static int s2n_rand_init_impl(void)
 {
 OPEN:
-    entropy_fd = open(ENTROPY_SOURCE, O_RDONLY | O_CLOEXEC);
+    entropy_fd = open(ENTROPY_SOURCE, ENTROPY_FLAGS);
     if (entropy_fd == -1) {
         if (errno == EINTR) {
             goto OPEN;


### PR DESCRIPTION
### Description of changes: 

There were a couple of changes since the last release that broke compatibility with old versions of Linux. Namely:

* Variables can't be named `time`, as it causes a shadow warning to be emitted
* `O_CLOEXEC` may not be defined so we should only use it if it is

### Testing:

I ran the build/tests on RHEL5 and these changes fixed it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
