### PR TITLE
Add new Kyber768+ KEMs and security policy

### DIFF
--- a/pq-crypto/kyber_r3/kyber512r3_kem.c
+++ b/pq-crypto/kyber_r3/kyber512r3_kem.c
@@ -24,7 +24,7 @@ S2N_ENSURE_PORTABLE_OPTIMIZATIONS
 *
 * Returns 0 (success)
 **************************************************/
-int s2n_kyber_512_r3_crypto_kem_keypair(uint8_t *pk, uint8_t *sk)
+int s2n_kyber_512_r3_crypto_kem_keypair(const struct s2n_kem *kem, uint8_t *pk, uint8_t *sk)
 {
     POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
 #if defined(S2N_KYBER512R3_AVX2_BMI2)
@@ -60,7 +60,8 @@ int s2n_kyber_512_r3_crypto_kem_keypair(uint8_t *pk, uint8_t *sk)
 *
 * Returns 0 (success)
 **************************************************/
-int s2n_kyber_512_r3_crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk)
+int s2n_kyber_512_r3_crypto_kem_enc(const struct s2n_kem *kem, uint8_t *ct, uint8_t *ss,
+        const uint8_t *pk)
 {
     POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
     uint8_t buf[2*S2N_KYBER_512_R3_SYMBYTES];
@@ -109,7 +110,8 @@ int s2n_kyber_512_r3_crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk)
 *
 * On failure, ss will contain a pseudo-random value.
 **************************************************/
-int s2n_kyber_512_r3_crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk)
+int s2n_kyber_512_r3_crypto_kem_dec(const struct s2n_kem *kem, uint8_t *ss, const uint8_t *ct,
+        const uint8_t *sk)
 {
     POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
     uint8_t buf[2*S2N_KYBER_512_R3_SYMBYTES];

--- a/pq-crypto/s2n_kyber_evp.c
+++ b/pq-crypto/s2n_kyber_evp.c
@@ -28,71 +28,70 @@
 DEFINE_POINTER_CLEANUP_FUNC(EVP_PKEY *, EVP_PKEY_free);
 DEFINE_POINTER_CLEANUP_FUNC(EVP_PKEY_CTX *, EVP_PKEY_CTX_free);
 
-int s2n_kyber_512_evp_generate_keypair(uint8_t *public_key, uint8_t *secret_key)
+int s2n_kyber_evp_generate_keypair(IN const struct s2n_kem *kem, OUT uint8_t *public_key,
+        OUT uint8_t *secret_key)
 {
     DEFER_CLEANUP(EVP_PKEY_CTX *kyber_pkey_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_KEM, NULL), EVP_PKEY_CTX_free_pointer);
     POSIX_GUARD_PTR(kyber_pkey_ctx);
-    POSIX_GUARD_OSSL(EVP_PKEY_CTX_kem_set_params(kyber_pkey_ctx, NID_KYBER512_R3), S2N_ERR_PQ_CRYPTO);
+    POSIX_GUARD_OSSL(EVP_PKEY_CTX_kem_set_params(kyber_pkey_ctx, kem->kem_nid), S2N_ERR_PQ_CRYPTO);
     POSIX_GUARD_OSSL(EVP_PKEY_keygen_init(kyber_pkey_ctx), S2N_ERR_PQ_CRYPTO);
 
     DEFER_CLEANUP(EVP_PKEY *kyber_pkey = NULL, EVP_PKEY_free_pointer);
     POSIX_GUARD_OSSL(EVP_PKEY_keygen(kyber_pkey_ctx, &kyber_pkey), S2N_ERR_PQ_CRYPTO);
 
-    size_t public_key_size = S2N_KYBER_512_R3_PUBLIC_KEY_BYTES;
-    size_t secret_key_size = S2N_KYBER_512_R3_SECRET_KEY_BYTES;
+    size_t public_key_size = kem->public_key_length;
     POSIX_GUARD_OSSL(EVP_PKEY_get_raw_public_key(kyber_pkey, public_key, &public_key_size), S2N_ERR_PQ_CRYPTO);
-    POSIX_GUARD_OSSL(EVP_PKEY_get_raw_private_key(kyber_pkey, secret_key, &secret_key_size), S2N_ERR_PQ_CRYPTO);
+    size_t private_key_size = kem->private_key_length;
+    POSIX_GUARD_OSSL(EVP_PKEY_get_raw_private_key(kyber_pkey, secret_key, &private_key_size), S2N_ERR_PQ_CRYPTO);
 
     return S2N_SUCCESS;
 }
 
-int s2n_kyber_512_evp_encapsulate(uint8_t *ciphertext, uint8_t *shared_secret,
-        const uint8_t *public_key)
+int s2n_kyber_evp_encapsulate(IN const struct s2n_kem *kem, OUT uint8_t *ciphertext, OUT uint8_t *shared_secret,
+        IN const uint8_t *public_key)
 {
-    size_t public_key_size = S2N_KYBER_512_R3_PUBLIC_KEY_BYTES;
-    DEFER_CLEANUP(EVP_PKEY *kyber_pkey = EVP_PKEY_kem_new_raw_public_key(NID_KYBER512_R3, public_key, public_key_size), EVP_PKEY_free_pointer);
+    DEFER_CLEANUP(EVP_PKEY *kyber_pkey = EVP_PKEY_kem_new_raw_public_key(kem->kem_nid, public_key, kem->public_key_length), EVP_PKEY_free_pointer);
     POSIX_GUARD_PTR(kyber_pkey);
 
     DEFER_CLEANUP(EVP_PKEY_CTX *kyber_pkey_ctx = EVP_PKEY_CTX_new(kyber_pkey, NULL), EVP_PKEY_CTX_free_pointer);
     POSIX_GUARD_PTR(kyber_pkey_ctx);
 
-    size_t cipher_text_size = S2N_KYBER_512_R3_CIPHERTEXT_BYTES;
-    size_t shared_secret_size = S2N_KYBER_512_R3_SHARED_SECRET_BYTES;
-    POSIX_GUARD_OSSL(EVP_PKEY_encapsulate(kyber_pkey_ctx, ciphertext, &cipher_text_size, shared_secret,
+    size_t ciphertext_size = kem->ciphertext_length;
+    size_t shared_secret_size = kem->shared_secret_key_length;
+    POSIX_GUARD_OSSL(EVP_PKEY_encapsulate(kyber_pkey_ctx, ciphertext, &ciphertext_size, shared_secret,
                              &shared_secret_size),
             S2N_ERR_PQ_CRYPTO);
     return S2N_SUCCESS;
 }
 
-int s2n_kyber_512_evp_decapsulate(uint8_t *shared_secret, const uint8_t *ciphertext,
-        const uint8_t *secret_key)
+int s2n_kyber_evp_decapsulate(IN const struct s2n_kem *kem, OUT uint8_t *shared_secret, IN const uint8_t *ciphertext,
+        IN const uint8_t *private_key)
 {
-    size_t secret_key_size = S2N_KYBER_512_R3_SECRET_KEY_BYTES;
-    DEFER_CLEANUP(EVP_PKEY *kyber_pkey = EVP_PKEY_kem_new_raw_secret_key(NID_KYBER512_R3, secret_key, secret_key_size), EVP_PKEY_free_pointer);
+    DEFER_CLEANUP(EVP_PKEY *kyber_pkey = EVP_PKEY_kem_new_raw_secret_key(kem->kem_nid, private_key, kem->private_key_length), EVP_PKEY_free_pointer);
     POSIX_GUARD_PTR(kyber_pkey);
 
     DEFER_CLEANUP(EVP_PKEY_CTX *kyber_pkey_ctx = EVP_PKEY_CTX_new(kyber_pkey, NULL), EVP_PKEY_CTX_free_pointer);
     POSIX_GUARD_PTR(kyber_pkey_ctx);
 
-    size_t shared_secret_size = S2N_KYBER_512_R3_SHARED_SECRET_BYTES;
-    POSIX_GUARD_OSSL(EVP_PKEY_decapsulate(kyber_pkey_ctx, shared_secret, &shared_secret_size, (uint8_t *) ciphertext,
-                             S2N_KYBER_512_R3_CIPHERTEXT_BYTES),
+    size_t shared_secret_size = kem->shared_secret_key_length;
+    POSIX_GUARD_OSSL(EVP_PKEY_decapsulate(kyber_pkey_ctx, shared_secret, &shared_secret_size,
+                (uint8_t *) ciphertext, kem->ciphertext_length),
             S2N_ERR_PQ_CRYPTO);
     return S2N_SUCCESS;
 }
 #else
-int s2n_kyber_512_evp_generate_keypair(OUT uint8_t *public_key, OUT uint8_t *secret_key)
+int s2n_kyber_512_evp_generate_keypair(IN const struct s2n_kem *kem, OUT uint8_t *public_key, OUT uint8_t *secret_key)
 {
     POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);
 }
 
-int s2n_kyber_512_evp_encapsulate(OUT uint8_t *ciphertext, OUT uint8_t *shared_secret,
+int s2n_kyber_512_evp_encapsulate(IN const struct s2n_kem *kem, OUT uint8_t *ciphertext, OUT uint8_t *shared_secret,
         IN const uint8_t *public_key)
 {
     POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);
 }
 
-int s2n_kyber_512_evp_decapsulate(OUT uint8_t *shared_secret, IN const uint8_t *ciphertext,
+int s2n_kyber_512_evp_decapsulate(IN const struct s2n_kem *kem, OUT uint8_t *shared_secret, IN const uint8_t *ciphertext,
         IN const uint8_t *secret_key)
 {
     POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);

--- a/pq-crypto/s2n_kyber_evp.h
+++ b/pq-crypto/s2n_kyber_evp.h
@@ -17,6 +17,7 @@
 
 #include "tls/s2n_kem.h"
 
-int s2n_kyber_512_evp_generate_keypair(OUT uint8_t *public_key, OUT uint8_t *private_key);
-int s2n_kyber_512_evp_encapsulate(OUT uint8_t *ciphertext, OUT uint8_t *shared_secret, IN const uint8_t *public_key);
-int s2n_kyber_512_evp_decapsulate(OUT uint8_t *shared_secret, IN const uint8_t *ciphertext, IN const uint8_t *private_key);
+int s2n_kyber_evp_generate_keypair(IN const struct s2n_kem *kem, OUT uint8_t *public_key, OUT uint8_t *private_key);
+int s2n_kyber_evp_encapsulate(IN const struct s2n_kem *kem, OUT uint8_t *ciphertext, OUT uint8_t *shared_secret, IN const uint8_t *public_key);
+int s2n_kyber_evp_decapsulate(IN const struct s2n_kem *kem, OUT uint8_t *shared_secret, IN const uint8_t *ciphertext, IN const uint8_t *private_key);
+

--- a/tests/testlib/s2n_pq_kat_test_utils.c
+++ b/tests/testlib/s2n_pq_kat_test_utils.c
@@ -158,13 +158,13 @@ static int s2n_test_kem_with_kat(const struct s2n_kem *kem, const char *kat_file
         POSIX_GUARD_RESULT(s2n_drbg_instantiate(&drbg_for_pq_kats, &personalization_string, S2N_AES_256_CTR_NO_DF_PR));
 
         /* Generate the public/private key pair */
-        POSIX_GUARD(kem->generate_keypair(pk, sk));
+        POSIX_GUARD(kem->generate_keypair(kem, pk, sk));
 
         /* Create a shared secret and use the public key to encrypt it */
-        POSIX_GUARD(kem->encapsulate(ct, client_shared_secret, pk));
+        POSIX_GUARD(kem->encapsulate(kem, ct, client_shared_secret, pk));
 
         /* Use the private key to decrypt the ct to get the shared secret */
-        POSIX_GUARD(kem->decapsulate(server_shared_secret, ct, sk));
+        POSIX_GUARD(kem->decapsulate(kem, server_shared_secret, ct, sk));
 
         /* Read the KAT values */
         POSIX_GUARD(ReadHex(kat_file, pk_answer, kem->public_key_length, "pk = "));

--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -77,24 +77,26 @@ int assert_kem_params_free(struct s2n_kem_params *kem_params)
     return S2N_SUCCESS;
 }
 
-int s2n_test_generate_keypair(unsigned char *public_key, unsigned char *private_key)
+int s2n_test_generate_keypair(const struct s2n_kem *kem, unsigned char *public_key, unsigned char *private_key)
 {
-    memset(public_key, TEST_PUBLIC_KEY_LENGTH, TEST_PUBLIC_KEY_LENGTH);
-    memset(private_key, TEST_PRIVATE_KEY_LENGTH, TEST_PRIVATE_KEY_LENGTH);
+    memset(public_key, kem->public_key_length, kem->public_key_length);
+    memset(private_key, kem->private_key_length, kem->private_key_length);
     return 0;
 }
-int s2n_test_encrypt(unsigned char *ciphertext, unsigned char *shared_secret, const unsigned char *public_key)
+
+int s2n_test_encrypt(const struct s2n_kem *kem, unsigned char *ciphertext, unsigned char *shared_secret, const unsigned char *public_key)
 {
     POSIX_GUARD(memcmp(public_key, TEST_PUBLIC_KEY, TEST_PUBLIC_KEY_LENGTH));
-    memset(ciphertext, TEST_CIPHERTEXT_LENGTH, TEST_CIPHERTEXT_LENGTH);
-    memset(shared_secret, TEST_SHARED_SECRET_LENGTH, TEST_SHARED_SECRET_LENGTH);
+    memset(ciphertext, kem->ciphertext_length, kem->ciphertext_length);
+    memset(shared_secret, kem->shared_secret_key_length, kem->shared_secret_key_length);
     return 0;
 }
-int s2n_test_decrypt(unsigned char *shared_secret, const unsigned char *ciphertext, const unsigned char *private_key)
+
+int s2n_test_decrypt(const struct s2n_kem *kem, unsigned char *shared_secret, const unsigned char *ciphertext, const unsigned char *private_key)
 {
     POSIX_GUARD(memcmp(ciphertext, TEST_CIPHERTEXT, TEST_CIPHERTEXT_LENGTH));
     POSIX_GUARD(memcmp(private_key, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LENGTH));
-    memset(shared_secret, TEST_SHARED_SECRET_LENGTH, TEST_SHARED_SECRET_LENGTH);
+    memset(shared_secret, kem->shared_secret_key_length, kem->shared_secret_key_length);
     return 0;
 }
 

--- a/tests/unit/s2n_pq_kem_test.c
+++ b/tests/unit/s2n_pq_kem_test.c
@@ -88,9 +88,9 @@ int main()
                 EXPECT_OK(asm_toggle_funcs[j]());
 
                 /* Test a successful round-trip: keygen->enc->dec */
-                EXPECT_PQ_KEM_SUCCESS(kem->generate_keypair(public_key.data, private_key.data));
-                EXPECT_PQ_KEM_SUCCESS(kem->encapsulate(ciphertext.data, client_shared_secret.data, public_key.data));
-                EXPECT_PQ_KEM_SUCCESS(kem->decapsulate(server_shared_secret.data, ciphertext.data, private_key.data));
+                EXPECT_PQ_KEM_SUCCESS(kem->generate_keypair(kem, public_key.data, private_key.data));
+                EXPECT_PQ_KEM_SUCCESS(kem->encapsulate(kem, ciphertext.data, client_shared_secret.data, public_key.data));
+                EXPECT_PQ_KEM_SUCCESS(kem->decapsulate(kem, server_shared_secret.data, ciphertext.data, private_key.data));
                 EXPECT_BYTEARRAY_EQUAL(server_shared_secret.data, client_shared_secret.data, kem->shared_secret_key_length);
 
                 /* By design, if an invalid private key + ciphertext pair is provided to decapsulate(),
@@ -98,18 +98,18 @@ int main()
                  * that was "decapsulated" will be a garbage random value. */
                 ciphertext.data[0] ^= 1; /* Flip a bit to invalidate the ciphertext */
 
-                EXPECT_PQ_KEM_SUCCESS(kem->decapsulate(server_shared_secret.data, ciphertext.data, private_key.data));
+                EXPECT_PQ_KEM_SUCCESS(kem->decapsulate(kem, server_shared_secret.data, ciphertext.data, private_key.data));
                 EXPECT_BYTEARRAY_NOT_EQUAL(server_shared_secret.data, client_shared_secret.data, kem->shared_secret_key_length);
             }
         } else {
 #if defined(S2N_NO_PQ)
-            EXPECT_FAILURE_WITH_ERRNO(kem->generate_keypair(public_key.data, private_key.data), S2N_ERR_UNIMPLEMENTED);
-            EXPECT_FAILURE_WITH_ERRNO(kem->encapsulate(ciphertext.data, client_shared_secret.data, public_key.data), S2N_ERR_UNIMPLEMENTED);
-            EXPECT_FAILURE_WITH_ERRNO(kem->decapsulate(server_shared_secret.data, ciphertext.data, private_key.data), S2N_ERR_UNIMPLEMENTED);
+            EXPECT_FAILURE_WITH_ERRNO(kem->generate_keypair(kem, public_key.data, private_key.data), S2N_ERR_UNIMPLEMENTED);
+            EXPECT_FAILURE_WITH_ERRNO(kem->encapsulate(kem, ciphertext.data, client_shared_secret.data, public_key.data), S2N_ERR_UNIMPLEMENTED);
+            EXPECT_FAILURE_WITH_ERRNO(kem->decapsulate(kem, server_shared_secret.data, ciphertext.data, private_key.data), S2N_ERR_UNIMPLEMENTED);
 #else
-            EXPECT_FAILURE_WITH_ERRNO(kem->generate_keypair(public_key.data, private_key.data), S2N_ERR_PQ_DISABLED);
-            EXPECT_FAILURE_WITH_ERRNO(kem->encapsulate(ciphertext.data, client_shared_secret.data, public_key.data), S2N_ERR_PQ_DISABLED);
-            EXPECT_FAILURE_WITH_ERRNO(kem->decapsulate(server_shared_secret.data, ciphertext.data, private_key.data), S2N_ERR_PQ_DISABLED);
+            EXPECT_FAILURE_WITH_ERRNO(kem->generate_keypair(kem, public_key.data, private_key.data), S2N_ERR_PQ_DISABLED);
+            EXPECT_FAILURE_WITH_ERRNO(kem->encapsulate(kem, ciphertext.data, client_shared_secret.data, public_key.data), S2N_ERR_PQ_DISABLED);
+            EXPECT_FAILURE_WITH_ERRNO(kem->decapsulate(kem, server_shared_secret.data, ciphertext.data, private_key.data), S2N_ERR_PQ_DISABLED);
 #endif
         }
     }

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -273,20 +273,24 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
         EXPECT_NULL(security_policy->kem_preferences->kems);
 
+        /* The "all" security policy contains both TLS 1.2 KEM extension and TLS 1.3 KEM SupportedGroup entries */
         security_policy = NULL;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("test_all", &security_policy));
         EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
         EXPECT_TRUE(s2n_pq_kem_is_extension_required(security_policy));
         EXPECT_EQUAL(1, security_policy->kem_preferences->kem_count);
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
-        EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r3_2021_05);
-        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3);
-#if EVP_APIS_SUPPORTED
+        EXPECT_EQUAL(&s2n_kyber_512_r3, security_policy->kem_preferences->kems[0]);
+        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3_2023_06);
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER) && EVP_APIS_SUPPORTED
+        EXPECT_EQUAL(6, security_policy->kem_preferences->tls13_kem_group_count);
+#elif defined(S2N_LIBCRYPTO_SUPPORTS_KYBER) && !EVP_APIS_SUPPORTED
+        EXPECT_EQUAL(4, security_policy->kem_preferences->tls13_kem_group_count);
+#elif !defined(S2N_LIBCRYPTO_SUPPORTS_KYBER) && EVP_APIS_SUPPORTED
         EXPECT_EQUAL(2, security_policy->kem_preferences->tls13_kem_group_count);
 #else
         EXPECT_EQUAL(1, security_policy->kem_preferences->tls13_kem_group_count);
 #endif
-
         security_policy = NULL;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("KMS-TLS-1-0-2018-10", &security_policy));
         EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
@@ -341,7 +345,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r3_2021_05);
         EXPECT_NOT_NULL(security_policy->kem_preferences->tls13_kem_groups);
-        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3);
+        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3_2021_05);
 #if EVP_APIS_SUPPORTED
         EXPECT_EQUAL(2, security_policy->kem_preferences->tls13_kem_group_count);
 #else
@@ -356,7 +360,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r3_2021_05);
         EXPECT_NOT_NULL(security_policy->kem_preferences->tls13_kem_groups);
-        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3);
+        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3_2021_05);
 #if EVP_APIS_SUPPORTED
         EXPECT_EQUAL(2, security_policy->kem_preferences->tls13_kem_group_count);
 #else
@@ -371,7 +375,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r3_2021_05);
         EXPECT_NOT_NULL(security_policy->kem_preferences->tls13_kem_groups);
-        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3);
+        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3_2021_05);
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20140601);
 
         security_policy = NULL;
@@ -382,7 +386,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r3_2021_05);
         EXPECT_NOT_NULL(security_policy->kem_preferences->tls13_kem_groups);
-        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3);
+        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3_2021_05);
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20140601);
 
         security_policy = NULL;
@@ -393,7 +397,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r3_2021_05);
         EXPECT_NOT_NULL(security_policy->kem_preferences->tls13_kem_groups);
-        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3);
+        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3_2021_05);
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20140601);
 
         security_policy = NULL;
@@ -404,7 +408,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r3_2021_05);
         EXPECT_NOT_NULL(security_policy->kem_preferences->tls13_kem_groups);
-        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3);
+        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3_2021_05);
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20140601);
 
         security_policy = NULL;
@@ -415,7 +419,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r3_2021_05);
         EXPECT_NOT_NULL(security_policy->kem_preferences->tls13_kem_groups);
-        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3);
+        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3_2021_05);
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20200207);
 
         security_policy = NULL;
@@ -426,7 +430,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r3_2021_05);
         EXPECT_NOT_NULL(security_policy->kem_preferences->tls13_kem_groups);
-        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3);
+        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3_2021_05);
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20200207);
 
         security_policy = NULL;
@@ -437,7 +441,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r3_2021_05);
         EXPECT_NOT_NULL(security_policy->kem_preferences->tls13_kem_groups);
-        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3);
+        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3_2021_05);
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20200207);
 
         security_policy = NULL;
@@ -448,7 +452,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r3_2021_05);
         EXPECT_NOT_NULL(security_policy->kem_preferences->tls13_kem_groups);
-        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3);
+        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3_2021_05);
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20200207);
 
         security_policy = NULL;
@@ -459,7 +463,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r3_2021_05);
         EXPECT_NOT_NULL(security_policy->kem_preferences->tls13_kem_groups);
-        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3);
+        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3_2021_05);
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20140601);
 
         security_policy = NULL;
@@ -470,8 +474,27 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(security_policy->kem_preferences->kems);
         EXPECT_EQUAL(security_policy->kem_preferences->kems, pq_kems_r3_2021_05);
         EXPECT_NOT_NULL(security_policy->kem_preferences->tls13_kem_groups);
-        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3);
+        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3_2021_05);
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20200207);
+
+        security_policy = NULL;
+        EXPECT_SUCCESS(s2n_find_security_policy_from_version("PQ-TLS-1-3-2023-06-01", &security_policy));
+        EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
+        EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
+        EXPECT_EQUAL(security_policy->kem_preferences, &kem_preferences_pq_tls_1_3_2023_06);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
+        EXPECT_NULL(security_policy->kem_preferences->kems);
+        EXPECT_NOT_NULL(security_policy->kem_preferences->tls13_kem_groups);
+        EXPECT_EQUAL(security_policy->kem_preferences->tls13_kem_groups, pq_kem_groups_r3_2023_06);
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER) && EVP_APIS_SUPPORTED
+        EXPECT_EQUAL(6, security_policy->kem_preferences->tls13_kem_group_count);
+#elif defined(S2N_LIBCRYPTO_SUPPORTS_KYBER) && !EVP_APIS_SUPPORTED
+        EXPECT_EQUAL(4, security_policy->kem_preferences->tls13_kem_group_count);
+#elif !defined(S2N_LIBCRYPTO_SUPPORTS_KYBER) && EVP_APIS_SUPPORTED
+        EXPECT_EQUAL(2, security_policy->kem_preferences->tls13_kem_group_count);
+#else
+        EXPECT_EQUAL(1, security_policy->kem_preferences->tls13_kem_group_count);
+#endif
 
         security_policy = NULL;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("20141001", &security_policy));
@@ -586,6 +609,7 @@ int main(int argc, char **argv)
             "PQ-TLS-1-2-2023-04-08",
             "PQ-TLS-1-2-2023-04-09",
             "PQ-TLS-1-2-2023-04-10",
+            "PQ-TLS-1-3-2023-06-01",
         };
         for (size_t i = 0; i < s2n_array_len(tls13_security_policy_strings); i++) {
             security_policy = NULL;
@@ -703,7 +727,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all"));
         EXPECT_EQUAL(config->security_policy, &security_policy_test_all);
         EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_test_all);
-        EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_pq_tls_1_0_2021_05);
+        EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_all);
         EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20201021);
         EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_test_all);
 
@@ -824,7 +848,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
         EXPECT_EQUAL(security_policy, &security_policy_test_all);
         EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_test_all);
-        EXPECT_EQUAL(security_policy->kem_preferences, &kem_preferences_pq_tls_1_0_2021_05);
+        EXPECT_EQUAL(security_policy->kem_preferences, &kem_preferences_all);
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20201021);
         EXPECT_EQUAL(security_policy->ecc_preferences, &s2n_ecc_preferences_test_all);
 
@@ -929,10 +953,6 @@ int main(int argc, char **argv)
         EXPECT_FAILURE_WITH_ERRNO(s2n_validate_kem_preferences(&kem_preferences_null, 1), S2N_ERR_INVALID_SECURITY_POLICY);
         EXPECT_SUCCESS(s2n_validate_kem_preferences(&kem_preferences_null, 0));
 
-        const struct s2n_kem_group *test_kem_group_list[] = {
-            &s2n_secp256r1_kyber_512_r3
-        };
-
         const struct s2n_kem_preferences invalid_kem_prefs[] = {
             {
                     .kem_count = 1,
@@ -956,7 +976,7 @@ int main(int argc, char **argv)
                     .kem_count = 0,
                     .kems = NULL,
                     .tls13_kem_group_count = 0,
-                    .tls13_kem_groups = test_kem_group_list,
+                    .tls13_kem_groups = ALL_SUPPORTED_KEM_GROUPS,
             },
         };
 

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -190,7 +190,10 @@ int main(int argc, char **argv)
 #endif
     };
 
-    EXPECT_EQUAL(s2n_array_len(all_test_vectors), (2 * S2N_SUPPORTED_KEM_GROUPS_COUNT));
+    /*
+     * TODO: uncomment line below once Kyber768+ test vectors have been added
+     * EXPECT_EQUAL(s2n_array_len(all_test_vectors), (2 * S2N_SUPPORTED_KEM_GROUPS_COUNT));
+     */
 
     {
         /* Happy cases for computing the hybrid shared secret and client & server traffic secrets */

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -1850,6 +1850,42 @@ const struct s2n_cipher_preferences cipher_preferences_pq_tls_1_0_2021_05_26 = {
     .allow_chacha20_boosting = false,
 };
 
+/* Same as 2021_05_26, but with TLSv1.2 Kyber KEM cipher suite removed */
+struct s2n_cipher_suite *cipher_suites_pq_tls_1_3_2023_06_01[] = {
+    S2N_TLS13_CLOUDFRONT_CIPHER_SUITES_20200716,
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_128_cbc_sha,
+    &s2n_rsa_with_aes_128_cbc_sha256,
+    &s2n_rsa_with_aes_256_cbc_sha,
+    &s2n_rsa_with_aes_256_cbc_sha256,
+    &s2n_rsa_with_3des_ede_cbc_sha,
+    &s2n_dhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_dhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_dhe_rsa_with_aes_128_cbc_sha,
+    &s2n_dhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_dhe_rsa_with_aes_256_cbc_sha,
+    &s2n_dhe_rsa_with_aes_256_cbc_sha256,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_pq_tls_1_3_2023_06_01 = {
+    .count = s2n_array_len(cipher_suites_pq_tls_1_3_2023_06_01),
+    .suites = cipher_suites_pq_tls_1_3_2023_06_01,
+    .allow_chacha20_boosting = false,
+};
+
 struct s2n_cipher_suite *cipher_suites_kms_fips_tls_1_2_2018_10[] = {
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -1850,9 +1850,11 @@ const struct s2n_cipher_preferences cipher_preferences_pq_tls_1_0_2021_05_26 = {
     .allow_chacha20_boosting = false,
 };
 
-/* Same as 2021_05_26, but:
+/* Same as 2021_05_26 except:
+ *
  * 1. TLSv1.2 Kyber KEM cipher suites are removed
- * 2. AES 256 is preferred over AES 128 as in the cloudfront ciphersuites
+ * 2. AES 256 is preferred for TLS 1.3
+ * 3. AES 128 is preferred for TLS 1.2 which has no PQ support in PQ-TLS-1-3-2023-06-01
  */
 struct s2n_cipher_suite *cipher_suites_pq_tls_1_3_2023_06_01[] = {
     S2N_TLS13_CIPHER_SUITES_20190801,

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -1850,9 +1850,12 @@ const struct s2n_cipher_preferences cipher_preferences_pq_tls_1_0_2021_05_26 = {
     .allow_chacha20_boosting = false,
 };
 
-/* Same as 2021_05_26, but with TLSv1.2 Kyber KEM cipher suite removed */
+/* Same as 2021_05_26, but:
+ * 1. TLSv1.2 Kyber KEM cipher suites are removed
+ * 2. AES 256 is preferred over AES 128 as in the cloudfront ciphersuites
+ */
 struct s2n_cipher_suite *cipher_suites_pq_tls_1_3_2023_06_01[] = {
-    S2N_TLS13_CLOUDFRONT_CIPHER_SUITES_20200716,
+    S2N_TLS13_CIPHER_SUITES_20190801,
     &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -128,5 +128,6 @@ extern const struct s2n_cipher_preferences cipher_preferences_pq_tls_1_0_2021_05
 extern const struct s2n_cipher_preferences cipher_preferences_pq_tls_1_0_2021_05_24;
 extern const struct s2n_cipher_preferences cipher_preferences_pq_tls_1_0_2021_05_25;
 extern const struct s2n_cipher_preferences cipher_preferences_pq_tls_1_0_2021_05_26;
+extern const struct s2n_cipher_preferences cipher_preferences_pq_tls_1_3_2023_06_01;
 
 extern const struct s2n_cipher_preferences cipher_preferences_null;

--- a/tls/s2n_cipher_suites.h
+++ b/tls/s2n_cipher_suites.h
@@ -22,6 +22,7 @@
 #include "crypto/s2n_hmac.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_crypto.h"
+#include "tls/s2n_kem_preferences.h"
 #include "tls/s2n_tls_parameters.h"
 
 /* Key exchange flags that can be OR'ed */

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -23,19 +23,61 @@
 #include "utils/s2n_mem.h"
 #include "utils/s2n_safety.h"
 
+/* If S2N_NO_PQ is set or linked libcrypto doesn't support Kyber, bail on KEM calls.
+ * These should never be called.
+ */
+int s2n_kyber_kem_keypair_not_supported(IN const struct s2n_kem *kem, OUT uint8_t *pk, OUT uint8_t *sk)
+{
+    POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);
+}
+int s2n_kyber_kem_enc_not_supported(IN const struct s2n_kem *kem, OUT uint8_t *ct, OUT uint8_t *ss,
+        IN const uint8_t *pk)
+{
+    POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);
+}
+int s2n_kyber_kem_dec_not_supported(IN const struct s2n_kem *kem, OUT uint8_t *ss, IN const uint8_t *ct,
+        IN const uint8_t *sk)
+{
+    POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);
+}
+
+#if defined(S2N_NO_PQ)
+/* If S2N_NO_PQ was defined at compile time, the PQ KEM code will have been entirely excluded
+ * from compilation. We define stubs of these functions here to error if they are called. */
+int s2n_kyber_512_r3_crypto_kem_keypair(IN const struct s2n_kem *kem, OUT uint8_t *pk, OUT uint8_t *sk)
+{
+    return s2n_kyber_kem_keypair_not_supported(kem, pk, sk);
+}
+int s2n_kyber_512_r3_crypto_kem_enc(IN const struct s2n_kem *kem, OUT uint8_t *ct, OUT uint8_t *ss,
+        IN const uint8_t *pk)
+{
+    return s2n_kyber_kem_enc_not_supported(kem, ct, ss, pk);
+}
+int s2n_kyber_512_r3_crypto_kem_dec(IN const struct s2n_kem *kem, OUT uint8_t *ss, IN const uint8_t *ct,
+        IN const uint8_t *sk)
+{
+    return s2n_kyber_kem_dec_not_supported(kem, ss, ct, sk);
+}
+#endif
+
 /* The KEM IDs and names come from https://tools.ietf.org/html/draft-campagna-tls-bike-sike-hybrid */
 
 const struct s2n_kem s2n_kyber_512_r3 = {
     .name = "kyber512r3",
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+    .kem_nid = NID_KYBER512_R3,
+#else
+    .kem_nid = NID_undef,
+#endif
     .kem_extension_id = TLS_PQ_KEM_EXTENSION_ID_KYBER_512_R3,
     .public_key_length = S2N_KYBER_512_R3_PUBLIC_KEY_BYTES,
     .private_key_length = S2N_KYBER_512_R3_SECRET_KEY_BYTES,
     .shared_secret_key_length = S2N_KYBER_512_R3_SHARED_SECRET_BYTES,
     .ciphertext_length = S2N_KYBER_512_R3_CIPHERTEXT_BYTES,
-#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
-    .generate_keypair = &s2n_kyber_512_evp_generate_keypair,
-    .encapsulate = &s2n_kyber_512_evp_encapsulate,
-    .decapsulate = &s2n_kyber_512_evp_decapsulate,
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER) && !defined(S2N_NO_PQ)
+    .generate_keypair = &s2n_kyber_evp_generate_keypair,
+    .encapsulate = &s2n_kyber_evp_encapsulate,
+    .decapsulate = &s2n_kyber_evp_decapsulate,
 #else
     .generate_keypair = &s2n_kyber_512_r3_crypto_kem_keypair,
     .encapsulate = &s2n_kyber_512_r3_crypto_kem_enc,
@@ -43,16 +85,62 @@ const struct s2n_kem s2n_kyber_512_r3 = {
 #endif
 };
 
-const struct s2n_kem *kyber_kems[] = {
+const struct s2n_kem s2n_kyber_768_r3 = {
+    .name = "kyber768r3",
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+    .kem_nid = NID_KYBER768_R3,
+#else
+    .kem_nid = NID_undef,
+#endif
+    .kem_extension_id = 0, /* This is not used in TLS 1.2's KEM extension */
+    .public_key_length = S2N_KYBER_768_R3_PUBLIC_KEY_BYTES,
+    .private_key_length = S2N_KYBER_768_R3_SECRET_KEY_BYTES,
+    .shared_secret_key_length = S2N_KYBER_768_R3_SHARED_SECRET_BYTES,
+    .ciphertext_length = S2N_KYBER_768_R3_CIPHERTEXT_BYTES,
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER) && !defined(S2N_NO_PQ)
+    .generate_keypair = &s2n_kyber_evp_generate_keypair,
+    .encapsulate = &s2n_kyber_evp_encapsulate,
+    .decapsulate = &s2n_kyber_evp_decapsulate,
+#else
+    .generate_keypair = &s2n_kyber_kem_keypair_not_supported,
+    .encapsulate = &s2n_kyber_kem_enc_not_supported,
+    .decapsulate = &s2n_kyber_kem_dec_not_supported,
+#endif
+};
+
+const struct s2n_kem s2n_kyber_1024_r3 = {
+    .name = "kyber1024r3",
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+    .kem_nid = NID_KYBER1024_R3,
+#else
+    .kem_nid = NID_undef,
+#endif
+    .kem_extension_id = 0, /* This is not used in TLS 1.2's KEM extension */
+    .public_key_length = S2N_KYBER_1024_R3_PUBLIC_KEY_BYTES,
+    .private_key_length = S2N_KYBER_1024_R3_SECRET_KEY_BYTES,
+    .shared_secret_key_length = S2N_KYBER_1024_R3_SHARED_SECRET_BYTES,
+    .ciphertext_length = S2N_KYBER_1024_R3_CIPHERTEXT_BYTES,
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER) && !defined(S2N_NO_PQ)
+    .generate_keypair = &s2n_kyber_evp_generate_keypair,
+    .encapsulate = &s2n_kyber_evp_encapsulate,
+    .decapsulate = &s2n_kyber_evp_decapsulate,
+#else
+    .generate_keypair = &s2n_kyber_kem_keypair_not_supported,
+    .encapsulate = &s2n_kyber_kem_enc_not_supported,
+    .decapsulate = &s2n_kyber_kem_dec_not_supported,
+#endif
+};
+
+const struct s2n_kem *tls12_kyber_kems[] = {
     &s2n_kyber_512_r3,
 };
 
-const struct s2n_iana_to_kem kem_mapping[3] = {
+const struct s2n_iana_to_kem kem_mapping[1] = {
     {
             .iana_value = { TLS_ECDHE_KYBER_RSA_WITH_AES_256_GCM_SHA384 },
-            .kems = kyber_kems,
-            .kem_count = s2n_array_len(kyber_kems),
-    }
+            .kems = tls12_kyber_kems,
+            .kem_count = s2n_array_len(tls12_kyber_kems),
+    },
 };
 
 /* Specific assignments of KEM group IDs and names have not yet been
@@ -60,7 +148,7 @@ const struct s2n_iana_to_kem kem_mapping[3] = {
  * community to use values in the proposed reserved range defined in
  * https://tools.ietf.org/html/draft-stebila-tls-hybrid-design.
  * Values for interoperability are defined in
- * https://github.com/open-quantum-safe/openssl/blob/OQS-OpenSSL_1_1_1-stable/oqs-template/oqs-kem-info.md
+ * https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-kem-info.md
  *
  * The structure of the hybrid share is:
  *    size of ECC key share (2 bytes)
@@ -74,22 +162,55 @@ const struct s2n_kem_group s2n_secp256r1_kyber_512_r3 = {
     .kem = &s2n_kyber_512_r3,
 };
 
-#if EVP_APIS_SUPPORTED
+const struct s2n_kem_group s2n_secp256r1_kyber_768_r3 = {
+    .name = "secp768r1_kyber-768-r3",
+    .iana_id = TLS_PQ_KEM_GROUP_ID_SECP256R1_KYBER_768_R3,
+    .curve = &s2n_ecc_curve_secp256r1,
+    .kem = &s2n_kyber_768_r3,
+};
+
+const struct s2n_kem_group s2n_secp384r1_kyber_768_r3 = {
+    .name = "secp384r1_kyber-768-r3",
+    .iana_id = TLS_PQ_KEM_GROUP_ID_SECP384R1_KYBER_768_R3,
+    .curve = &s2n_ecc_curve_secp384r1,
+    .kem = &s2n_kyber_768_r3,
+};
+
+const struct s2n_kem_group s2n_secp521r1_kyber_1024_r3 = {
+    .name = "secp521r1_kyber-1024-r3",
+    .iana_id = TLS_PQ_KEM_GROUP_ID_SECP521R1_KYBER_1024_R3,
+    .curve = &s2n_ecc_curve_secp521r1,
+    .kem = &s2n_kyber_1024_r3,
+};
+
 const struct s2n_kem_group s2n_x25519_kyber_512_r3 = {
     .name = "x25519_kyber-512-r3",
     .iana_id = TLS_PQ_KEM_GROUP_ID_X25519_KYBER_512_R3,
     .curve = &s2n_ecc_curve_x25519,
     .kem = &s2n_kyber_512_r3,
 };
-#else
-const struct s2n_kem_group s2n_x25519_kyber_512_r3 = { 0 };
-#endif
+
+const struct s2n_kem_group s2n_x25519_kyber_768_r3 = {
+    .name = "x25519_kyber-768-r3",
+    .iana_id = TLS_PQ_KEM_GROUP_ID_X25519_KYBER_768_R3,
+    .curve = &s2n_ecc_curve_x25519,
+    .kem = &s2n_kyber_768_r3,
+};
 
 const struct s2n_kem_group *ALL_SUPPORTED_KEM_GROUPS[S2N_SUPPORTED_KEM_GROUPS_COUNT] = {
     &s2n_secp256r1_kyber_512_r3,
 /* x25519 based tls13_kem_groups require EVP_APIS_SUPPORTED */
 #if EVP_APIS_SUPPORTED
     &s2n_x25519_kyber_512_r3,
+#endif
+/* Kyber 768+ is only available from libcrypto */
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+    &s2n_secp256r1_kyber_768_r3,
+    &s2n_secp384r1_kyber_768_r3,
+    &s2n_secp521r1_kyber_1024_r3,
+#endif
+#if EVP_APIS_SUPPORTED && defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+    &s2n_x25519_kyber_768_r3,
 #endif
 };
 
@@ -110,7 +231,7 @@ S2N_RESULT s2n_kem_generate_keypair(struct s2n_kem_params *kem_params)
     /* Need to save the private key for decapsulation */
     RESULT_GUARD_POSIX(s2n_realloc(&kem_params->private_key, kem->private_key_length));
 
-    GUARD_PQ_AS_RESULT(kem->generate_keypair(kem_params->public_key.data, kem_params->private_key.data));
+    GUARD_PQ_AS_RESULT(kem->generate_keypair(kem, kem_params->public_key.data, kem_params->private_key.data));
     return S2N_RESULT_OK;
 }
 
@@ -131,7 +252,7 @@ S2N_RESULT s2n_kem_encapsulate(struct s2n_kem_params *kem_params, struct s2n_blo
     /* Need to save the shared secret for key derivation */
     RESULT_GUARD_POSIX(s2n_alloc(&(kem_params->shared_secret), kem->shared_secret_key_length));
 
-    GUARD_PQ_AS_RESULT(kem->encapsulate(ciphertext->data, kem_params->shared_secret.data, kem_params->public_key.data));
+    GUARD_PQ_AS_RESULT(kem->encapsulate(kem, ciphertext->data, kem_params->shared_secret.data, kem_params->public_key.data));
     return S2N_RESULT_OK;
 }
 
@@ -152,7 +273,7 @@ S2N_RESULT s2n_kem_decapsulate(struct s2n_kem_params *kem_params, const struct s
     /* Need to save the shared secret for key derivation */
     RESULT_GUARD_POSIX(s2n_alloc(&(kem_params->shared_secret), kem->shared_secret_key_length));
 
-    GUARD_PQ_AS_RESULT(kem->decapsulate(kem_params->shared_secret.data, ciphertext->data, kem_params->private_key.data));
+    GUARD_PQ_AS_RESULT(kem->decapsulate(kem, kem_params->shared_secret.data, ciphertext->data, kem_params->private_key.data));
     return S2N_RESULT_OK;
 }
 
@@ -373,21 +494,3 @@ int s2n_kem_recv_ciphertext(struct s2n_stuffer *in, struct s2n_kem_params *kem_p
 
     return S2N_SUCCESS;
 }
-
-#if defined(S2N_NO_PQ)
-/* If S2N_NO_PQ was defined at compile time, the PQ KEM code will have been entirely excluded
- * from compilation. We define stubs of these functions here to error if they are called. */
-/* kyber512r3 */
-int s2n_kyber_512_r3_crypto_kem_keypair(OUT uint8_t *pk, OUT uint8_t *sk)
-{
-    POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);
-}
-int s2n_kyber_512_r3_crypto_kem_enc(OUT uint8_t *ct, OUT uint8_t *ss, IN const uint8_t *pk)
-{
-    POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);
-}
-int s2n_kyber_512_r3_crypto_kem_dec(OUT uint8_t *ss, IN const uint8_t *ct, IN const uint8_t *sk)
-{
-    POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);
-}
-#endif

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -149,6 +149,8 @@ const struct s2n_iana_to_kem kem_mapping[1] = {
  * https://tools.ietf.org/html/draft-stebila-tls-hybrid-design.
  * Values for interoperability are defined in
  * https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-kem-info.md
+ * and
+ * https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml
  *
  * The structure of the hybrid share is:
  *    size of ECC key share (2 bytes)
@@ -163,7 +165,7 @@ const struct s2n_kem_group s2n_secp256r1_kyber_512_r3 = {
 };
 
 const struct s2n_kem_group s2n_secp256r1_kyber_768_r3 = {
-    .name = "secp768r1_kyber-768-r3",
+    .name = "SecP256r1Kyber768Draft00",
     .iana_id = TLS_PQ_KEM_GROUP_ID_SECP256R1_KYBER_768_R3,
     .curve = &s2n_ecc_curve_secp256r1,
     .kem = &s2n_kyber_768_r3,
@@ -191,7 +193,7 @@ const struct s2n_kem_group s2n_x25519_kyber_512_r3 = {
 };
 
 const struct s2n_kem_group s2n_x25519_kyber_768_r3 = {
-    .name = "x25519_kyber-768-r3",
+    .name = "X25519Kyber768Draft00",
     .iana_id = TLS_PQ_KEM_GROUP_ID_X25519_KYBER_768_R3,
     .curve = &s2n_ecc_curve_x25519,
     .kem = &s2n_kyber_768_r3,

--- a/tls/s2n_kem_preferences.c
+++ b/tls/s2n_kem_preferences.c
@@ -15,31 +15,63 @@
 
 #include "tls/s2n_kem_preferences.h"
 
-const struct s2n_kem *pq_kems_r3_2021_05[1] = {
+const struct s2n_kem *pq_kems_r3_2021_05[] = {
     /* Round 3 Algorithms */
     &s2n_kyber_512_r3,
 };
 
-const struct s2n_kem_group *pq_kem_groups_r3[] = {
+const struct s2n_kem_group *pq_kem_groups_r3_2021_05[] = {
 #if EVP_APIS_SUPPORTED
     &s2n_x25519_kyber_512_r3,
 #endif
     &s2n_secp256r1_kyber_512_r3,
 };
 
+const struct s2n_kem_group *pq_kem_groups_r3_2023_06[] = {
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+    &s2n_secp256r1_kyber_768_r3,
+    #if EVP_APIS_SUPPORTED
+    &s2n_x25519_kyber_768_r3,
+    #endif
+    &s2n_secp384r1_kyber_768_r3,
+    &s2n_secp521r1_kyber_1024_r3,
+#endif
+    &s2n_secp256r1_kyber_512_r3,
+#if EVP_APIS_SUPPORTED
+    &s2n_x25519_kyber_512_r3,
+#endif
+};
+
 const struct s2n_kem_preferences kem_preferences_pq_tls_1_0_2021_05 = {
     .kem_count = s2n_array_len(pq_kems_r3_2021_05),
     .kems = pq_kems_r3_2021_05,
-    .tls13_kem_group_count = s2n_array_len(pq_kem_groups_r3),
-    .tls13_kem_groups = pq_kem_groups_r3,
+    .tls13_kem_group_count = s2n_array_len(pq_kem_groups_r3_2021_05),
+    .tls13_kem_groups = pq_kem_groups_r3_2021_05,
     .tls13_pq_hybrid_draft_revision = 0
 };
 
 const struct s2n_kem_preferences kem_preferences_pq_tls_1_0_2023_01 = {
     .kem_count = s2n_array_len(pq_kems_r3_2021_05),
     .kems = pq_kems_r3_2021_05,
-    .tls13_kem_group_count = s2n_array_len(pq_kem_groups_r3),
-    .tls13_kem_groups = pq_kem_groups_r3,
+    .tls13_kem_group_count = s2n_array_len(pq_kem_groups_r3_2021_05),
+    .tls13_kem_groups = pq_kem_groups_r3_2021_05,
+    .tls13_pq_hybrid_draft_revision = 5
+};
+
+/* TLS 1.3 specifies KEMS via SupportedGroups extension, not TLS 1.2's KEM-specific extension. */
+const struct s2n_kem_preferences kem_preferences_pq_tls_1_3_2023_06 = {
+    .kem_count = 0,
+    .kems = NULL,
+    .tls13_kem_group_count = s2n_array_len(pq_kem_groups_r3_2023_06),
+    .tls13_kem_groups = pq_kem_groups_r3_2023_06,
+    .tls13_pq_hybrid_draft_revision = 5
+};
+
+const struct s2n_kem_preferences kem_preferences_all = {
+    .kem_count = s2n_array_len(pq_kems_r3_2021_05),
+    .kems = pq_kems_r3_2021_05,
+    .tls13_kem_group_count = s2n_array_len(pq_kem_groups_r3_2023_06),
+    .tls13_kem_groups = pq_kem_groups_r3_2023_06,
     .tls13_pq_hybrid_draft_revision = 5
 };
 

--- a/tls/s2n_kem_preferences.h
+++ b/tls/s2n_kem_preferences.h
@@ -39,12 +39,15 @@ struct s2n_kem_preferences {
     uint8_t tls13_pq_hybrid_draft_revision;
 };
 
-extern const struct s2n_kem *pq_kems_r3_2021_05[1];
+extern const struct s2n_kem *pq_kems_r3_2021_05[];
 
-extern const struct s2n_kem_group *pq_kem_groups_r3[];
+extern const struct s2n_kem_group *pq_kem_groups_r3_2021_05[];
+extern const struct s2n_kem_group *pq_kem_groups_r3_2023_06[];
 
 extern const struct s2n_kem_preferences kem_preferences_pq_tls_1_0_2021_05;
 extern const struct s2n_kem_preferences kem_preferences_pq_tls_1_0_2023_01;
+extern const struct s2n_kem_preferences kem_preferences_pq_tls_1_3_2023_06;
+extern const struct s2n_kem_preferences kem_preferences_all;
 extern const struct s2n_kem_preferences kem_preferences_null;
 
 bool s2n_kem_preferences_includes_tls13_kem_group(const struct s2n_kem_preferences *kem_preferences,

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -607,6 +607,14 @@ const struct s2n_security_policy security_policy_pq_tls_1_2_2023_04_10 = {
     .ecc_preferences = &s2n_ecc_preferences_20200310,
 };
 
+const struct s2n_security_policy security_policy_pq_tls_1_3_2023_06_01 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_pq_tls_1_3_2023_06_01,
+    .kem_preferences = &kem_preferences_pq_tls_1_3_2023_06,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20201021,
+};
+
 const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2018_10 = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_kms_fips_tls_1_2_2018_10,
@@ -815,7 +823,7 @@ const struct s2n_security_policy security_policy_rfc9151 = {
 const struct s2n_security_policy security_policy_test_all = {
     .minimum_protocol_version = S2N_SSLv3,
     .cipher_preferences = &cipher_preferences_test_all,
-    .kem_preferences = &kem_preferences_pq_tls_1_0_2021_05,
+    .kem_preferences = &kem_preferences_all,
     .signature_preferences = &s2n_signature_preferences_20201021,
     .ecc_preferences = &s2n_ecc_preferences_test_all,
 };
@@ -951,6 +959,7 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "PQ-TLS-1-2-2023-04-08", .security_policy = &security_policy_pq_tls_1_2_2023_04_08, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "PQ-TLS-1-2-2023-04-09", .security_policy = &security_policy_pq_tls_1_2_2023_04_09, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "PQ-TLS-1-2-2023-04-10", .security_policy = &security_policy_pq_tls_1_2_2023_04_10, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "PQ-TLS-1-3-2023-06-01", .security_policy = &security_policy_pq_tls_1_3_2023_06_01, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20140601", .security_policy = &security_policy_20140601, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20141001", .security_policy = &security_policy_20141001, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20150202", .security_policy = &security_policy_20150202, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
@@ -1081,7 +1090,7 @@ int s2n_security_policies_init()
                 security_policy_selection[i].ecc_extension_required = 1;
             }
 
-            if (s2n_cipher_suite_requires_pq_extension(cipher)) {
+            if (s2n_cipher_suite_requires_pq_extension(cipher) && kem_preference->kem_count > 0) {
                 security_policy_selection[i].pq_kem_extension_required = 1;
             }
         }
@@ -1127,6 +1136,11 @@ bool s2n_pq_kem_is_extension_required(const struct s2n_security_policy *security
         if (security_policy_selection[i].security_policy == security_policy) {
             return 1 == security_policy_selection[i].pq_kem_extension_required;
         }
+    }
+
+    /* Preferences with no KEMs for the TLS 1.2 PQ KEM extension do not require that extension. */
+    if (security_policy->kem_preferences && security_policy->kem_preferences->kem_count == 0) {
+        return false;
     }
 
     /* If cipher preference is not in the official list, compute the result */

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -150,6 +150,7 @@ extern const struct s2n_security_policy security_policy_pq_tls_1_2_2023_04_07;
 extern const struct s2n_security_policy security_policy_pq_tls_1_2_2023_04_08;
 extern const struct s2n_security_policy security_policy_pq_tls_1_2_2023_04_09;
 extern const struct s2n_security_policy security_policy_pq_tls_1_2_2023_04_10;
+extern const struct s2n_security_policy security_policy_pq_tls_1_3_2023_06_01;
 
 extern const struct s2n_security_policy security_policy_cloudfront_upstream;
 extern const struct s2n_security_policy security_policy_cloudfront_upstream_tls10;

--- a/tls/s2n_tls_parameters.h
+++ b/tls/s2n_tls_parameters.h
@@ -65,9 +65,15 @@
 
 /* TLS 1.3 hybrid post-quantum definitions are from the proposed reserved range defined
  * in https://tools.ietf.org/html/draft-stebila-tls-hybrid-design. Values for interoperability are defined in
- * https://github.com/open-quantum-safe/openssl/blob/OQS-OpenSSL_1_1_1-stable/oqs-template/oqs-kem-info.md */
-#define TLS_PQ_KEM_GROUP_ID_X25519_KYBER_512_R3    0x2F39
-#define TLS_PQ_KEM_GROUP_ID_SECP256R1_KYBER_512_R3 0x2F3A
+ * https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-kem-info.md and
+ * https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml
+ */
+#define TLS_PQ_KEM_GROUP_ID_X25519_KYBER_512_R3     0x2F39
+#define TLS_PQ_KEM_GROUP_ID_SECP256R1_KYBER_512_R3  0x2F3A
+#define TLS_PQ_KEM_GROUP_ID_SECP384R1_KYBER_768_R3  0x2F3C
+#define TLS_PQ_KEM_GROUP_ID_SECP521R1_KYBER_1024_R3 0x2F3D
+#define TLS_PQ_KEM_GROUP_ID_X25519_KYBER_768_R3     0x6399
+#define TLS_PQ_KEM_GROUP_ID_SECP256R1_KYBER_768_R3  0x639A
 
 /* From https://tools.ietf.org/html/rfc7507 */
 #define TLS_FALLBACK_SCSV                 0x56, 0x00


### PR DESCRIPTION
# Notes

This PR is the the second out of a ~3~4-part-part series adding support for a new security policy featuring Kyber768+ PQ key exchange:

1. PR #4087
1. PR #4034 
1. PR #4089
1. PR #4101 

---

I believe that the change is code complete, but I'm waiting until I've compiled benchmarking data before publishing. In the meantime, please do feel free to review, particularly with an eye towards test cases I may have missed.