### PR TITLE
Audit connection bitfield for thread safety

### DIFF
--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -223,7 +223,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, client_conn));
 
-            client_conn->key_update_pending = true;
+            client_conn->key_update_pending = 1;
 
             s2n_blocked_status blocked = 0;
             EXPECT_SUCCESS(s2n_key_update_send(client_conn, &blocked));
@@ -278,7 +278,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, conn));
 
             /* Key update both pending and required by record limit */
-            conn->key_update_pending = true;
+            conn->key_update_pending = 1;
             EXPECT_OK(s2n_write_uint64(record_limit, conn->secure->client_sequence_number));
 
             s2n_blocked_status blocked = 0;
@@ -514,7 +514,7 @@ int main(int argc, char **argv)
             /* Sanity check: send buffer just large enough for KeyUpdate record */
             config->send_buffer_size_override = key_update_record_size;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
-            conn->key_update_pending = true;
+            conn->key_update_pending = 1;
             EXPECT_SUCCESS(s2n_key_update_send(conn, &blocked));
 
             EXPECT_SUCCESS(s2n_connection_release_buffers(conn));
@@ -522,7 +522,7 @@ int main(int argc, char **argv)
             /* Test: send buffer too small for KeyUpdate record */
             config->send_buffer_size_override = key_update_record_size - 1;
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
-            conn->key_update_pending = true;
+            conn->key_update_pending = 1;
             EXPECT_FAILURE_WITH_ERRNO(s2n_key_update_send(conn, &blocked), S2N_ERR_FRAGMENT_LENGTH_TOO_LARGE);
         };
     };

--- a/tests/unit/s2n_key_update_threads_test.c
+++ b/tests/unit/s2n_key_update_threads_test.c
@@ -1,0 +1,230 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "testlib/s2n_examples.h"
+
+#include <pthread.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include "crypto/s2n_sequence.h"
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+#include "utils/s2n_random.h"
+
+#define S2N_TEST_BUFFER_SIZE       1000
+#define S2N_TEST_ENCRYPTION_LIMIT  3
+#define S2N_TEST_KEY_UPDATE_COUNT  10
+#define S2N_TEST_RECORD_COUNT      (S2N_TEST_ENCRYPTION_LIMIT * S2N_TEST_KEY_UPDATE_COUNT)
+#define S2N_TEST_BYTES_TO_SEND     (S2N_DEFAULT_FRAGMENT_LENGTH * S2N_TEST_RECORD_COUNT)
+
+static void *s2n_send_random_data(void *arg)
+{
+    struct s2n_connection *conn = (struct s2n_connection *) arg;
+
+    uint8_t buffer[100] = "hello world";
+
+    size_t bytes_to_send = S2N_TEST_BYTES_TO_SEND;
+    s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+    while(bytes_to_send) {
+        int r = s2n_send(conn, buffer, MIN(sizeof(buffer), bytes_to_send), &blocked);
+        if (r >= 0) {
+            bytes_to_send -= r;
+        } else if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
+            fprintf(stderr, "Send error: %s. %s\n", s2n_strerror(s2n_errno, NULL), s2n_strerror_debug(s2n_errno, NULL));
+            return NULL;
+        }
+    }
+    return conn;
+}
+
+static void *s2n_recv_random_data(void *arg)
+{
+    struct s2n_connection *conn = (struct s2n_connection *) arg;
+
+    uint8_t buffer[S2N_TEST_BUFFER_SIZE] = { 0 };
+
+    size_t bytes_to_read = S2N_TEST_BYTES_TO_SEND;
+    s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+    while(bytes_to_read) {
+        int r = s2n_recv(conn, buffer, MIN(sizeof(buffer), bytes_to_read), &blocked);
+        if (r >= 0) {
+            bytes_to_read -= r;
+        } else if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
+            fprintf(stderr, "Recv error: %s. %s\n", s2n_strerror(s2n_errno, NULL), s2n_strerror_debug(s2n_errno, NULL));
+            return NULL;
+        }
+    }
+    return conn;
+}
+
+static S2N_RESULT s2n_test_shutdown(struct s2n_connection *conn)
+{
+    s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+    int r = 0;
+    while ((r = s2n_shutdown(conn, &blocked)) != S2N_SUCCESS) {
+        if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
+            RESULT_GUARD_POSIX(r);
+        }
+    }
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_send_and_recv_random_data(struct s2n_connection *conn)
+{
+    /*
+     * This test is intended to find concurrency issues when sending and receiving
+     * KeyUpdates, so we need to run the reader and writer in separate threads.
+     */
+
+    pthread_t reader = 0;
+    RESULT_ENSURE_EQ(pthread_create(&reader, NULL, s2n_recv_random_data, (void *) conn), 0);
+
+    pthread_t writer = 0;
+    RESULT_ENSURE_EQ(pthread_create(&writer, NULL, s2n_send_random_data, (void *) conn), 0);
+
+    void *reader_return = NULL;
+    RESULT_ENSURE_EQ(pthread_join(reader, &reader_return), 0);
+    RESULT_ENSURE_REF(reader_return);
+
+    void *writer_return = NULL;
+    RESULT_ENSURE_EQ(pthread_join(writer, &writer_return), 0);
+    RESULT_ENSURE_REF(writer_return);
+
+    RESULT_ENSURE_GT(conn->wire_bytes_out, S2N_TEST_BYTES_TO_SEND);
+    RESULT_ENSURE_GT(conn->wire_bytes_in, S2N_TEST_BYTES_TO_SEND);
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_test_key_update(struct s2n_connection *conn)
+{
+    RESULT_GUARD_POSIX(s2n_example_negotiate(conn));
+
+    /* Force frequent KeyUpdates by lowering the chosen cipher's encryption limit */
+    struct s2n_cipher_suite cipher_suite = *conn->secure->cipher_suite;
+    struct s2n_record_algorithm record_alg = *cipher_suite.record_alg;
+    record_alg.encryption_limit = S2N_TEST_ENCRYPTION_LIMIT;
+    cipher_suite.record_alg = &record_alg;
+    conn->secure->cipher_suite = &cipher_suite;
+
+    /* Send and receive ApplicationData + KeyUpdates */
+    RESULT_GUARD(s2n_send_and_recv_random_data(conn));
+
+    uint64_t client_seq_num = 0;
+    struct s2n_blob client_seq_num_blob = { 0 };
+    RESULT_GUARD_POSIX(s2n_blob_init(&client_seq_num_blob, conn->secure->client_sequence_number,
+            sizeof(conn->secure->client_sequence_number)));
+    RESULT_GUARD_POSIX(s2n_sequence_number_to_uint64(&client_seq_num_blob, &client_seq_num));
+    RESULT_ENSURE_GTE(client_seq_num, 0);
+    RESULT_ENSURE_LTE(client_seq_num, S2N_TEST_ENCRYPTION_LIMIT);
+
+    uint64_t server_seq_num = 0;
+    struct s2n_blob server_seq_num_blob = { 0 };
+    RESULT_GUARD_POSIX(s2n_blob_init(&server_seq_num_blob, conn->secure->server_sequence_number,
+            sizeof(conn->secure->server_sequence_number)));
+    RESULT_GUARD_POSIX(s2n_sequence_number_to_uint64(&server_seq_num_blob, &server_seq_num));
+    RESULT_ENSURE_GTE(server_seq_num, 0);
+    RESULT_ENSURE_LTE(server_seq_num, S2N_TEST_ENCRYPTION_LIMIT);
+
+    uint64_t out_seq_num = server_seq_num;
+    uint64_t in_seq_num = client_seq_num;
+    if (conn->mode == S2N_CLIENT) {
+        out_seq_num = client_seq_num;
+        in_seq_num = server_seq_num;
+    }
+
+    /* We don't track the number of KeyUpdates sent or received, but we can at
+     * least sanity check that we could not have sent enough records to account
+     * for `wire_bytes_out` or `wire_bytes_in` without having reset the sequence number.
+     */
+    RESULT_ENSURE_EQ(conn->max_outgoing_fragment_length, S2N_DEFAULT_FRAGMENT_LENGTH);
+    RESULT_ENSURE_GT(conn->wire_bytes_out, S2N_DEFAULT_RECORD_LENGTH * out_seq_num);
+    RESULT_ENSURE_GT(conn->wire_bytes_in, S2N_DEFAULT_RECORD_LENGTH * in_seq_num);
+
+    RESULT_GUARD(s2n_test_shutdown(conn));
+    conn->secure->cipher_suite = NULL;
+    return S2N_RESULT_OK;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* KeyUpdate requires TLS1.3 */
+    if (!s2n_is_tls13_fully_supported()) {
+        END_TEST();
+    }
+
+    DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = NULL,
+            s2n_cert_chain_and_key_ptr_free);
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+            S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+
+    DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(),
+            s2n_config_ptr_free);
+    EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+
+    DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+    EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+
+    /* We're going to fork, so flush the initial test output first */
+    EXPECT_EQUAL(fflush(stdout), 0);
+
+    pid_t client_pid = fork();
+    if (client_pid == 0) {
+        /* Suppress stdout when running the examples.
+         * This only affects the new client process.
+         */
+        fclose(stdout);
+
+        DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_SUCCESS(s2n_connection_set_config(client, config));
+
+        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(client, &io_pair));
+
+        EXPECT_OK(s2n_test_key_update(client));
+        exit(EXIT_SUCCESS);
+    }
+
+    pid_t server_pid = fork();
+    if (server_pid == 0) {
+        /* Suppress stdout when running the examples.
+         * This only affects the new server process.
+         */
+        fclose(stdout);
+
+        DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_SUCCESS(s2n_connection_set_config(server, config));
+
+        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_io_pair(server, &io_pair));
+
+        EXPECT_OK(s2n_test_key_update(server));
+        exit(EXIT_SUCCESS);
+    }
+
+    int status = 0;
+    EXPECT_EQUAL(waitpid(client_pid, &status, 0), client_pid);
+    EXPECT_EQUAL(status, EXIT_SUCCESS);
+    EXPECT_EQUAL(waitpid(server_pid, &status, 0), server_pid);
+    EXPECT_EQUAL(status, EXIT_SUCCESS);
+
+    END_TEST();
+}

--- a/tests/unit/s2n_key_update_threads_test.c
+++ b/tests/unit/s2n_key_update_threads_test.c
@@ -13,22 +13,21 @@
  * permissions and limitations under the License.
  */
 
-#include "testlib/s2n_examples.h"
-
 #include <pthread.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 
 #include "crypto/s2n_sequence.h"
 #include "s2n_test.h"
+#include "testlib/s2n_examples.h"
 #include "testlib/s2n_testlib.h"
 #include "utils/s2n_random.h"
 
-#define S2N_TEST_BUFFER_SIZE       1000
-#define S2N_TEST_ENCRYPTION_LIMIT  3
-#define S2N_TEST_KEY_UPDATE_COUNT  10
-#define S2N_TEST_RECORD_COUNT      (S2N_TEST_ENCRYPTION_LIMIT * S2N_TEST_KEY_UPDATE_COUNT)
-#define S2N_TEST_BYTES_TO_SEND     (S2N_DEFAULT_FRAGMENT_LENGTH * S2N_TEST_RECORD_COUNT)
+#define S2N_TEST_BUFFER_SIZE      1000
+#define S2N_TEST_ENCRYPTION_LIMIT 3
+#define S2N_TEST_KEY_UPDATE_COUNT 10
+#define S2N_TEST_RECORD_COUNT     (S2N_TEST_ENCRYPTION_LIMIT * S2N_TEST_KEY_UPDATE_COUNT)
+#define S2N_TEST_BYTES_TO_SEND    (S2N_DEFAULT_FRAGMENT_LENGTH * S2N_TEST_RECORD_COUNT)
 
 static void *s2n_send_random_data(void *arg)
 {
@@ -38,7 +37,7 @@ static void *s2n_send_random_data(void *arg)
 
     size_t bytes_to_send = S2N_TEST_BYTES_TO_SEND;
     s2n_blocked_status blocked = S2N_NOT_BLOCKED;
-    while(bytes_to_send) {
+    while (bytes_to_send) {
         int r = s2n_send(conn, buffer, MIN(sizeof(buffer), bytes_to_send), &blocked);
         if (r >= 0) {
             bytes_to_send -= r;
@@ -58,7 +57,7 @@ static void *s2n_recv_random_data(void *arg)
 
     size_t bytes_to_read = S2N_TEST_BYTES_TO_SEND;
     s2n_blocked_status blocked = S2N_NOT_BLOCKED;
-    while(bytes_to_read) {
+    while (bytes_to_read) {
         int r = s2n_recv(conn, buffer, MIN(sizeof(buffer), bytes_to_read), &blocked);
         if (r >= 0) {
             bytes_to_read -= r;

--- a/tests/unit/s2n_post_handshake_test.c
+++ b/tests/unit/s2n_post_handshake_test.c
@@ -189,7 +189,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_send_io_stuffer(&output, conn));
 
             conn->actual_protocol_version = S2N_TLS13;
-            conn->key_update_pending = true;
+            conn->key_update_pending = 1;
 
             s2n_blocked_status blocked = S2N_NOT_BLOCKED;
             EXPECT_SUCCESS(s2n_post_handshake_send(conn, &blocked));
@@ -221,7 +221,7 @@ int main(int argc, char **argv)
             EXPECT_OK(s2n_connection_set_secrets(conn));
 
             conn->actual_protocol_version = S2N_TLS12;
-            conn->key_update_pending = true;
+            conn->key_update_pending = 1;
 
             s2n_blocked_status blocked = S2N_NOT_BLOCKED;
             EXPECT_SUCCESS(s2n_post_handshake_send(conn, &blocked));

--- a/tests/unit/s2n_recv_test.c
+++ b/tests/unit/s2n_recv_test.c
@@ -155,7 +155,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
             /* Send a KeyUpdate message */
-            client_conn->key_update_pending = true;
+            client_conn->key_update_pending = 1;
             EXPECT_SUCCESS(s2n_key_update_send(client_conn, &blocked));
             EXPECT_FALSE(client_conn->key_update_pending);
 

--- a/tests/unit/s2n_send_multirecord_test.c
+++ b/tests/unit/s2n_send_multirecord_test.c
@@ -402,7 +402,7 @@ int main(int argc, char **argv)
             struct s2n_send_context context = context_all_ok;
             EXPECT_SUCCESS(s2n_connection_set_send_ctx(conn, (void *) &context));
 
-            conn->key_update_pending = true;
+            conn->key_update_pending = 1;
             EXPECT_SUCCESS(s2n_post_handshake_send(conn, &blocked));
             EXPECT_FALSE(conn->key_update_pending);
             key_update_size = context.bytes_sent;
@@ -512,7 +512,7 @@ int main(int argc, char **argv)
             struct s2n_send_context context = context_all_ok;
             EXPECT_SUCCESS(s2n_connection_set_send_ctx(conn, (void *) &context));
 
-            conn->key_update_pending = true;
+            conn->key_update_pending = 1;
             EXPECT_SUCCESS(s2n_post_handshake_send(conn, &blocked));
             EXPECT_FALSE(conn->key_update_pending);
             key_update_size = context.bytes_sent;

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -54,7 +54,22 @@ typedef enum {
     S2N_NEW_TICKET
 } s2n_session_ticket_status;
 
+/* s2n-tls allows s2n_send and s2n_recv to be called concurrently.
+ * There are a handful of values that both methods need to access.
+ * However, C99 has no concept of concurrency, so provides no atomic data types.
+ * We use sig_atomic_t for its weak guarantee of atomicity for interrupts,
+ * but any use of this type should not assume true thread safety.
+ */
+typedef volatile sig_atomic_t s2n_shared_flag;
+
 struct s2n_connection {
+    /*
+     * For thread safety, new bitflags in the below shared bitfield must NOT
+     * be set after the handshake / during application data.
+     * s2n_send and s2n_recv may be called concurrently,
+     * so must not attempt to set flags in the same bitfield.
+     */
+
     /* Is this connection using CORK/SO_RCVLOWAT optimizations? Only valid when the connection is using
      * managed_send_io
      */
@@ -93,9 +108,6 @@ struct s2n_connection {
     unsigned managed_send_io : 1;
     unsigned managed_recv_io : 1;
 
-    /* Key update data */
-    unsigned key_update_pending : 1;
-
     /* Early data supported by caller.
      * If a caller does not use any APIs that support early data,
      * do not negotiate early data.
@@ -109,9 +121,6 @@ struct s2n_connection {
      * This means that the connection will keep the existing value of psk_params->type,
      * even when setting a new config. */
     unsigned psk_mode_overridden : 1;
-
-    /* Have we received a close notify alert from the peer. */
-    unsigned close_notify_received : 1;
 
     /* Connection negotiated an EMS */
     unsigned ems_negotiated : 1;
@@ -137,6 +146,13 @@ struct s2n_connection {
 
     /* Indicates whether the connection should request OCSP stapling from the peer */
     unsigned request_ocsp_status : 1;
+
+    /*
+     * For thread safety, new bitflags in the above shared bitfield must NOT
+     * be set after the handshake / during application data.
+     * s2n_send and s2n_recv may be called concurrently,
+     * so must not attempt to set flags in the same bitfield.
+     */
 
     /* The configuration (cert, key .. etc ) */
     struct s2n_config *config;
@@ -270,6 +286,7 @@ struct s2n_connection {
     uint8_t writer_alert_out;
     uint8_t reader_alert_out;
     uint8_t reader_warning_out;
+    bool close_notify_received;
     bool alert_sent;
 
     /* Our handshake state machine */
@@ -308,13 +325,24 @@ struct s2n_connection {
     uint64_t wire_bytes_out;
     uint64_t early_data_bytes;
 
-    /* Is the connection open or closed?
-     *
-     * We use C's only atomic type as an error requires shutting down both read
-     * and write, so both the reader and writer threads may access both fields.
+    /* Either the reader or the writer can trigger both sides of the connection
+     * to close in response to a fatal error.
+     * These variables are only ever set, never cleared, so should be relatively
+     * safe to access from multiple threads even if not atomic.
      */
-    sig_atomic_t read_closed;
-    sig_atomic_t write_closed;
+    s2n_shared_flag read_closed;
+    s2n_shared_flag write_closed;
+
+    /* The reader can set key_update_pending if we receive a request for an update.
+     * The writer can set key_update_pending if we reach the encryption limit.
+     * The writer can clear key_update_pending if we send an update.
+     *
+     * This should be relatively thread-safe even without an atomic variable,
+     * since we don't care about the exact value (just 0 or !0) and we don't care
+     * about keeping/losing values set by s2n_recv while we're clearing in s2n_send.
+     * At worst, we'll send an arguably unnecessary KeyUpdate due to a failed clear.
+     */
+    s2n_shared_flag key_update_pending;
 
     /* TLS extension data */
     char server_name[S2N_MAX_SERVER_NAME + 1];


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/4026

### Description of changes: 

I went through the bitfield in s2n_connection and pulled out the two variables set post-handshake. I also added more documentation to make the situation clearer.

### Testing:
Existing tests pass.

I also added a new test that runs with separate threads for send and receive. When [run with ThreadSanitizer](https://github.com/aws/s2n-tls/commit/b4aee0cadfaad31f6b5ccafbe327bb7dde03e1c6), it detected the issues fixed in this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
