### PR TITLE
Cmake/gcc analyzer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,14 @@ set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION ${VERSION_MAJOR})
 
 set(CMAKE_C_FLAGS_DEBUGOPT "")
 
+# Static analyzer support for GCC was added in the 10.0 release
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    if (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+        message(STATUS "Turning on static analyer")
+        target_compile_options(${PROJECT_NAME} PRIVATE -fanalyzer)
+    endif()
+endif()
+
 target_compile_options(${PROJECT_NAME} PRIVATE -pedantic -std=gnu99 -Wall -Wimplicit -Wunused -Wcomment -Wchar-subscripts
         -Wuninitialized -Wshadow -Wcast-align -Wwrite-strings -Wno-deprecated-declarations -Wno-unknown-pragmas -Wformat-security
         -Wno-missing-braces -Wsign-compare -Wno-strict-prototypes -Wa,--noexecstack


### PR DESCRIPTION
### Resolved issues:

revisiting #498 for gcc and cmake. 

### Description of changes: 

GCC, starting with version 10, accept a `-fsanitizer` flag, which was already added to [Make](https://github.com/aws/s2n-tls/blob/main/s2n.mk#L109), but not cmake.

### Call-outs:

Mostly interesting on nix, where the default is 11.

example (with GCC11.3.0):
```
/home/dougch/gitrepos/s2n-tls/tls/s2n_async_pkey.c:254:14: error: dereference of NULL ‘0’ [CWE-476] [-Werror=analyzer-null-dereference]
  254 |     op->type = S2N_ASYNC_SIGN;
      |     ~~~~~~~~~^~~~~~~~~~~~~~~~
  ‘s2n_async_pkey_sign_async’: event 1
    |
    |  244 | S2N_RESULT s2n_async_pkey_sign_async(struct s2n_connection *conn, s2n_signature_algorithm sig_alg,
    |      |            ^~~~~~~~~~~~~~~~~~~~~~~~~
    |      |            |
    |      |            (1) entry to ‘s2n_async_pkey_sign_async’
    |
  ‘s2n_async_pkey_sign_async’: event 2
    |
    |/home/dougch/gitrepos/s2n-tls/utils/s2n_ensure.h:35:12:
    |   35 |         if (!(cond)) {             \
    |      |            ^
    |      |            |
    |      |            (2) following ‘false’ branch (when ‘conn’ is non-NULL)...
```

### Testing:

 How is this change tested (unit tests, fuzz tests, etc.)? locally


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
