### PR TITLE
Create New TLS Policy for KMS

### DIFF
--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -580,6 +580,8 @@ int main(int argc, char **argv)
             "PQ-TLS-1-2-2023-04-08",
             "PQ-TLS-1-2-2023-04-09",
             "PQ-TLS-1-2-2023-04-10",
+            /* KMS TLS */
+            "KMS-TLS-1-2-2023-06",
         };
         for (size_t i = 0; i < s2n_array_len(tls13_security_policy_strings); i++) {
             security_policy = NULL;

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -385,6 +385,14 @@ const struct s2n_security_policy security_policy_kms_tls_1_0_2021_08 = {
     .ecc_preferences = &s2n_ecc_preferences_20200310,
 };
 
+const struct s2n_security_policy security_policy_kms_tls_1_2_2023_06 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_kms_tls_1_0_2021_08,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20200310,
+};
+
 const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2019_06 = {
     .minimum_protocol_version = S2N_TLS10,
     .cipher_preferences = &cipher_preferences_kms_pq_tls_1_0_2019_06,
@@ -873,6 +881,7 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     /* KMS TLS Policies*/
     { .version = "KMS-TLS-1-0-2018-10", .security_policy = &security_policy_kms_tls_1_0_2018_10, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "KMS-TLS-1-0-2021-08", .security_policy = &security_policy_kms_tls_1_0_2021_08, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "KMS-TLS-1-2-2023-06", .security_policy = &security_policy_kms_tls_1_2_2023_06, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "KMS-FIPS-TLS-1-2-2018-10", .security_policy = &security_policy_kms_fips_tls_1_2_2018_10, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "KMS-FIPS-TLS-1-2-2021-08", .security_policy = &security_policy_kms_fips_tls_1_2_2021_08, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "KMS-PQ-TLS-1-0-2019-06", .security_policy = &security_policy_kms_pq_tls_1_0_2019_06, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -166,6 +166,7 @@ extern const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2021_
 
 extern const struct s2n_security_policy security_policy_kms_tls_1_0_2018_10;
 extern const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2018_10;
+extern const struct s2n_security_policy security_policy_kms_tls_1_2_2023_06;
 
 extern const struct s2n_security_policy security_policy_20190120;
 extern const struct s2n_security_policy security_policy_20190121;


### PR DESCRIPTION
Create new TLS policy for KMS to support TLS 1.2+ version only.

### Resolved issues:

N/A

### Description of changes: 
Create one new policy for KMS based on existing KMS policy to remover the support of TLS 1.0/1.1.
### Call-outs:

N/A
### Testing:
Unit Tests
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
