### PR TITLE
Add new CRT policies

### DIFF
--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -576,6 +576,11 @@ int main(int argc, char **argv)
             "AWS-CRT-SDK-TLSv1.1",
             "AWS-CRT-SDK-TLSv1.2",
             "AWS-CRT-SDK-TLSv1.3",
+            "AWS-CRT-SDK-SSLv3.0-2023",
+            "AWS-CRT-SDK-TLSv1.0-2023",
+            "AWS-CRT-SDK-TLSv1.1-2023",
+            "AWS-CRT-SDK-TLSv1.2-2023",
+            "AWS-CRT-SDK-TLSv1.3-2023",
             /* PQ TLS */
             "PQ-TLS-1-2-2023-04-07",
             "PQ-TLS-1-2-2023-04-08",

--- a/tls/s2n_ecc_preferences.c
+++ b/tls/s2n_ecc_preferences.c
@@ -33,6 +33,15 @@ const struct s2n_ecc_named_curve *const s2n_ecc_pref_list_20200310[] = {
     &s2n_ecc_curve_secp384r1,
 };
 
+/* Curve p256 is at the top of the list in order to minimize HRR */
+const struct s2n_ecc_named_curve *const s2n_ecc_pref_list_20230623[] = {
+    &s2n_ecc_curve_secp256r1,
+#if EVP_APIS_SUPPORTED
+    &s2n_ecc_curve_x25519,
+#endif
+    &s2n_ecc_curve_secp384r1,
+};
+
 /*
  * These curves were chosen based on the following specification:
  * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r2.pdf
@@ -69,6 +78,11 @@ const struct s2n_ecc_preferences s2n_ecc_preferences_20140601 = {
 const struct s2n_ecc_preferences s2n_ecc_preferences_20200310 = {
     .count = s2n_array_len(s2n_ecc_pref_list_20200310),
     .ecc_curves = s2n_ecc_pref_list_20200310,
+};
+
+const struct s2n_ecc_preferences s2n_ecc_preferences_20230623 = {
+    .count = s2n_array_len(s2n_ecc_pref_list_20230623),
+    .ecc_curves = s2n_ecc_pref_list_20230623,
 };
 
 const struct s2n_ecc_preferences s2n_ecc_preferences_default_fips = {

--- a/tls/s2n_ecc_preferences.h
+++ b/tls/s2n_ecc_preferences.h
@@ -27,6 +27,7 @@ struct s2n_ecc_preferences {
 };
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_20140601;
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_20200310;
+extern const struct s2n_ecc_preferences s2n_ecc_preferences_20230623;
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_default_fips;
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_20201021;
 extern const struct s2n_ecc_preferences s2n_ecc_preferences_20210816;

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -369,6 +369,46 @@ const struct s2n_security_policy security_policy_aws_crt_sdk_tls_13 = {
     .ecc_preferences = &s2n_ecc_preferences_20200310,
 };
 
+const struct s2n_security_policy security_policy_aws_crt_sdk_ssl_v3_06_23 = {
+    .minimum_protocol_version = S2N_SSLv3,
+    .cipher_preferences = &cipher_preferences_aws_crt_sdk_ssl_v3,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20230623,
+};
+
+const struct s2n_security_policy security_policy_aws_crt_sdk_tls_10_06_23 = {
+    .minimum_protocol_version = S2N_TLS10,
+    .cipher_preferences = &cipher_preferences_aws_crt_sdk_default,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20230623,
+};
+
+const struct s2n_security_policy security_policy_aws_crt_sdk_tls_11_06_23 = {
+    .minimum_protocol_version = S2N_TLS11,
+    .cipher_preferences = &cipher_preferences_aws_crt_sdk_default,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20230623,
+};
+
+const struct s2n_security_policy security_policy_aws_crt_sdk_tls_12_06_23 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_aws_crt_sdk_default,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20230623,
+};
+
+const struct s2n_security_policy security_policy_aws_crt_sdk_tls_13_06_23 = {
+    .minimum_protocol_version = S2N_TLS13,
+    .cipher_preferences = &cipher_preferences_aws_crt_sdk_tls_13,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20230623,
+};
+
 const struct s2n_security_policy security_policy_kms_tls_1_0_2018_10 = {
     .minimum_protocol_version = S2N_TLS10,
     .cipher_preferences = &cipher_preferences_kms_tls_1_0_2018_10,
@@ -873,11 +913,17 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "CloudFront-TLS-1-1-2016-Legacy", .security_policy = &security_policy_cloudfront_tls_1_1_2016_legacy, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "CloudFront-TLS-1-2-2018-Legacy", .security_policy = &security_policy_cloudfront_tls_1_2_2018_legacy, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "CloudFront-TLS-1-2-2019-Legacy", .security_policy = &security_policy_cloudfront_tls_1_2_2019_legacy, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    /* CRT allows users to choose the minimal TLS protocol they want to negotiate with. This translates to 5 different security policies in s2n */
     { .version = "AWS-CRT-SDK-SSLv3.0", .security_policy = &security_policy_aws_crt_sdk_ssl_v3, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "AWS-CRT-SDK-TLSv1.0", .security_policy = &security_policy_aws_crt_sdk_tls_10, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "AWS-CRT-SDK-TLSv1.1", .security_policy = &security_policy_aws_crt_sdk_tls_11, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "AWS-CRT-SDK-TLSv1.2", .security_policy = &security_policy_aws_crt_sdk_tls_12, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "AWS-CRT-SDK-TLSv1.3", .security_policy = &security_policy_aws_crt_sdk_tls_13, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "AWS-CRT-SDK-SSLv3.0-2023", .security_policy = &security_policy_aws_crt_sdk_ssl_v3_06_23, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "AWS-CRT-SDK-TLSv1.0-2023", .security_policy = &security_policy_aws_crt_sdk_tls_10_06_23, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "AWS-CRT-SDK-TLSv1.1-2023", .security_policy = &security_policy_aws_crt_sdk_tls_11_06_23, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "AWS-CRT-SDK-TLSv1.2-2023", .security_policy = &security_policy_aws_crt_sdk_tls_12_06_23, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "AWS-CRT-SDK-TLSv1.3-2023", .security_policy = &security_policy_aws_crt_sdk_tls_13_06_23, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     /* KMS TLS Policies*/
     { .version = "KMS-TLS-1-0-2018-10", .security_policy = &security_policy_kms_tls_1_0_2018_10, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "KMS-TLS-1-0-2021-08", .security_policy = &security_policy_kms_tls_1_0_2021_08, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 
s2n clients only generate and send one keyshare in the client hello because it is expensive. This means that if the server does not support the curve used, they will send a HRR and the client will have to generate a different keyshare. The HRR mechanism is therefore expensive and should be avoided. This PR replicates CRT policies that send x25519 on the client hello with ones that send p256. This is an optimization since there are servers that only support p256.
### Call-outs:
It's not sustainable to recreate 5 policies each time the CRT wants a change. :( Not sure we have a choice right now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
