### PR TITLE
ktls: send and recv cmsg 

### DIFF
--- a/tests/unit/s2n_ktls_cmsg_test.c
+++ b/tests/unit/s2n_ktls_cmsg_test.c
@@ -1,0 +1,365 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/socket.h>
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+#include "tls/s2n_ktls.h"
+#include "utils/s2n_random.h"
+
+S2N_RESULT s2n_ktls_send_msg_impl(int sock, struct msghdr *msg,
+        struct iovec *msg_iov, size_t count, s2n_blocked_status *blocked, ssize_t *send_len);
+S2N_RESULT s2n_ktls_recv_msg_impl(struct s2n_connection *conn, int sock, struct msghdr *msg,
+        struct iovec *msg_iov, s2n_blocked_status *blocked, ssize_t *bytes_read);
+S2N_RESULT s2n_ktls_set_ancillary_data(struct msghdr *msg, uint8_t record_type);
+S2N_RESULT s2n_ktls_parse_ancillary_data(struct msghdr *msg, uint8_t *record_type);
+
+#define TEST_MAX_DATA_LEN 20000
+uint8_t TEST_SEND_RECORD_TYPE = 10;
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+#if !S2N_KTLS_SUPPORTED /* CMSG_* macros are platform specific */
+    char buf[sizeof(uint8_t)] = { 0 };
+
+    /* Init msghdr */
+    struct msghdr msg = { 0 };
+    msg.msg_control = buf;
+    msg.msg_controllen = sizeof(uint8_t);
+
+    EXPECT_ERROR_WITH_ERRNO(s2n_ktls_set_ancillary_data(&msg, TEST_SEND_RECORD_TYPE), S2N_ERR_KTLS_UNSUPPORTED_PLATFORM);
+    uint8_t record_type = 0;
+    EXPECT_ERROR_WITH_ERRNO(s2n_ktls_parse_ancillary_data(&msg, &record_type), S2N_ERR_KTLS_UNSUPPORTED_PLATFORM);
+
+#else /* kTLS supported */
+
+    uint8_t test_data[TEST_MAX_DATA_LEN] = { 0 };
+    struct s2n_blob test_data_blob = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&test_data_blob, test_data, sizeof(test_data)));
+    EXPECT_OK(s2n_get_public_random_data(&test_data_blob));
+
+    /* Test send/recv msg */
+    {
+        /* ctrl_msg send and recv data */
+        for (size_t to_send = 1; to_send < TEST_MAX_DATA_LEN; to_send += 500) {
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+
+            /* init send msg */
+            struct msghdr send_msg = { 0 };
+            struct iovec send_msg_iov = { 0 };
+            send_msg_iov.iov_base = (void *) (uintptr_t) test_data;
+            send_msg_iov.iov_len = to_send;
+            /* init rev msg */
+            uint8_t recv_buffer[TEST_MAX_DATA_LEN] = { 0 };
+            struct msghdr recv_msg = { 0 };
+            struct iovec recv_msg_iov = { 0 };
+            recv_msg_iov.iov_base = recv_buffer;
+            recv_msg_iov.iov_len = to_send;
+
+            /* send msg */
+            ssize_t sent_len = 0;
+            EXPECT_OK(s2n_ktls_send_msg_impl(io_pair.client, &send_msg, &send_msg_iov, 1, &blocked, &sent_len));
+            EXPECT_EQUAL(sent_len, to_send);
+
+            /* recv msg */
+            ssize_t recv_len = 0;
+            EXPECT_OK(s2n_ktls_recv_msg_impl(conn, io_pair.server, &recv_msg, &recv_msg_iov, &blocked, &recv_len));
+            EXPECT_EQUAL(recv_len, to_send);
+            EXPECT_EQUAL(memcmp(test_data, recv_buffer, recv_len), 0);
+        }
+
+        /* partial reads */
+        {
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+
+            /* only read half the total data sent to simulate multiple reads */
+            size_t to_send = 10;
+            size_t to_recv = 4;
+
+            /* init send msg */
+            struct msghdr send_msg = { 0 };
+            struct iovec send_msg_iov = { 0 };
+            send_msg_iov.iov_base = (void *) (uintptr_t) test_data;
+            send_msg_iov.iov_len = to_send;
+            /* init rev msg */
+            uint8_t recv_buffer[TEST_MAX_DATA_LEN] = { 0 };
+            struct msghdr recv_msg = { 0 };
+            struct iovec recv_msg_iov = { 0 };
+            recv_msg_iov.iov_base = recv_buffer;
+
+            /* send msg */
+            ssize_t sent_len = 0;
+            EXPECT_OK(s2n_ktls_send_msg_impl(io_pair.client, &send_msg, &send_msg_iov, 1, &blocked, &sent_len));
+            EXPECT_EQUAL(sent_len, to_send);
+
+            /* read partial amount */
+            recv_msg_iov.iov_len = to_recv;
+            ssize_t recv_len = 0;
+            EXPECT_OK(s2n_ktls_recv_msg_impl(conn, io_pair.server, &recv_msg, &recv_msg_iov, &blocked, &recv_len));
+            EXPECT_EQUAL(recv_len, to_recv);
+            EXPECT_EQUAL(memcmp(test_data, recv_buffer, to_recv), 0);
+
+            /* read remaining amount */
+            recv_len = 0;
+            recv_msg_iov.iov_len = to_send - to_recv;
+            recv_msg_iov.iov_base = recv_buffer + to_recv;
+            EXPECT_OK(s2n_ktls_recv_msg_impl(conn, io_pair.server, &recv_msg, &recv_msg_iov, &blocked, &recv_len));
+            EXPECT_EQUAL(recv_len, to_send - to_recv);
+
+            /* confirm that all data was read and matches sent data of length `to_send` */
+            EXPECT_EQUAL(memcmp(test_data, recv_buffer, to_send), 0);
+        }
+
+        /* blocked reads */
+        {
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+
+            size_t to_send = 10;
+
+            /* init send msg */
+            struct msghdr send_msg = { 0 };
+            struct iovec send_msg_iov = { 0 };
+            send_msg_iov.iov_base = (void *) (uintptr_t) test_data;
+            send_msg_iov.iov_len = to_send;
+            /* init rev msg */
+            uint8_t recv_buffer[TEST_MAX_DATA_LEN] = { 0 };
+            struct msghdr recv_msg = { 0 };
+            struct iovec recv_msg_iov = { 0 };
+            recv_msg_iov.iov_base = recv_buffer;
+            recv_msg_iov.iov_len = to_send;
+
+            /* send msg */
+            ssize_t sent_len = 0;
+            EXPECT_OK(s2n_ktls_send_msg_impl(io_pair.client, &send_msg, &send_msg_iov, 1, &blocked, &sent_len));
+            EXPECT_EQUAL(sent_len, to_send);
+
+            /* recv msg */
+            ssize_t recv_len = 0;
+            EXPECT_OK(s2n_ktls_recv_msg_impl(conn, io_pair.server, &recv_msg, &recv_msg_iov, &blocked, &recv_len));
+            EXPECT_EQUAL(recv_len, to_send);
+            EXPECT_EQUAL(memcmp(test_data, recv_buffer, to_send), 0);
+
+            /* calling recv after all data has been read blocks */
+            recv_len = 0;
+            recv_msg_iov.iov_len = 1;
+            EXPECT_ERROR_WITH_ERRNO(s2n_ktls_recv_msg_impl(conn, io_pair.server, &recv_msg, &recv_msg_iov, &blocked, &recv_len), S2N_ERR_IO_BLOCKED);
+            EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
+        }
+
+        /* check for peer closed */
+        {
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+
+            size_t to_send = 10;
+
+            /* init send msg */
+            struct msghdr send_msg = { 0 };
+            struct iovec send_msg_iov = { 0 };
+            send_msg_iov.iov_base = (void *) (uintptr_t) test_data;
+            send_msg_iov.iov_len = to_send;
+            /* init rev msg */
+            uint8_t recv_buffer[TEST_MAX_DATA_LEN] = { 0 };
+            struct msghdr recv_msg = { 0 };
+            struct iovec recv_msg_iov = { 0 };
+            recv_msg_iov.iov_base = recv_buffer;
+            recv_msg_iov.iov_len = to_send;
+
+            /* send msg */
+            ssize_t sent_len = 0;
+            EXPECT_OK(s2n_ktls_send_msg_impl(io_pair.client, &send_msg, &send_msg_iov, 1, &blocked, &sent_len));
+            EXPECT_EQUAL(sent_len, to_send);
+
+            /* recv msg */
+            ssize_t recv_len = 0;
+            EXPECT_OK(s2n_ktls_recv_msg_impl(conn, io_pair.server, &recv_msg, &recv_msg_iov, &blocked, &recv_len));
+            EXPECT_EQUAL(recv_len, to_send);
+            EXPECT_EQUAL(memcmp(test_data, recv_buffer, to_send), 0);
+
+            /* simulate the peer closing the socket */
+            close(io_pair.client);
+
+            /* calling recv after all data has been read blocks */
+            EXPECT_FALSE(s2n_atomic_flag_test(&conn->read_closed));
+            recv_len = 0;
+            recv_msg_iov.iov_len = 1;
+            EXPECT_ERROR_WITH_ERRNO(s2n_ktls_recv_msg_impl(conn, io_pair.server, &recv_msg, &recv_msg_iov, &blocked, &recv_len), S2N_ERR_CLOSED);
+            EXPECT_TRUE(s2n_atomic_flag_test(&conn->read_closed));
+        }
+    }
+
+    /* Test parse/add ancillary data */
+    {
+        /* set ancillary data */
+        {
+            union {
+                char buf[CMSG_SPACE(sizeof(uint8_t)) * 2];
+                struct cmsghdr _align;
+            } control_msg = { 0 };
+
+            /* Init msghdr */
+            struct msghdr send_msg = { 0 };
+            send_msg.msg_control = control_msg.buf;
+            send_msg.msg_controllen = sizeof(control_msg.buf);
+            EXPECT_TRUE(send_msg.msg_controllen == CMSG_SPACE(sizeof(uint8_t)) * 2);
+
+            /* add ancillary data */
+            EXPECT_OK(s2n_ktls_set_ancillary_data(&send_msg, TEST_SEND_RECORD_TYPE));
+
+            /* validate 1st header */
+            struct cmsghdr *hdr = CMSG_FIRSTHDR(&send_msg);
+            EXPECT_NOT_NULL(hdr);
+            EXPECT_EQUAL(hdr->cmsg_level, S2N_SOL_TLS);
+            EXPECT_EQUAL(hdr->cmsg_type, S2N_TLS_SET_RECORD_TYPE);
+            uint8_t *record_type = (unsigned char *) CMSG_DATA(hdr);
+            EXPECT_EQUAL(*record_type, TEST_SEND_RECORD_TYPE);
+
+            /* validate that there is a 2 header and is zeroed */
+            hdr = CMSG_NXTHDR(&send_msg, hdr);
+            EXPECT_NOT_NULL(hdr);
+            EXPECT_EQUAL(hdr->cmsg_level, 0);
+            EXPECT_EQUAL(hdr->cmsg_type, 0);
+            record_type = (unsigned char *) CMSG_DATA(hdr);
+            EXPECT_EQUAL(*record_type, 0);
+
+            /* validate that a 3rd header doesnt exist */
+            hdr = CMSG_NXTHDR(&send_msg, hdr);
+            EXPECT_NULL(hdr);
+        }
+
+        /* creating and parsing ancillary data */
+        {
+            union {
+                char buf[CMSG_SPACE(sizeof(uint8_t)) * 2];
+                struct cmsghdr _align;
+            } control_msg = { 0 };
+            /* Init msghdr */
+            struct msghdr msg = { 0 };
+            msg.msg_control = control_msg.buf;
+            msg.msg_controllen = sizeof(control_msg.buf);
+
+            /* add ancillary data */
+            EXPECT_OK(s2n_ktls_set_ancillary_data(&msg, TEST_SEND_RECORD_TYPE));
+            /* modify control_msg for the recv side. cmsg_type is GET_RECORD_TYPE on the receiving socket */
+            struct cmsghdr *hdr = CMSG_FIRSTHDR(&msg);
+            hdr->cmsg_type = S2N_TLS_GET_RECORD_TYPE;
+
+            /* parse ancillary data */
+            uint8_t recv_record_type = 0;
+            EXPECT_OK(s2n_ktls_parse_ancillary_data(&msg, &recv_record_type));
+            EXPECT_EQUAL(recv_record_type, TEST_SEND_RECORD_TYPE);
+        }
+
+        /* iterating multiple ancillary data */
+        {
+            uint8_t MALFORMED_RECORD_TYPE = 32;
+            uint8_t CORRECT_RECORD_TYPE = 42;
+
+            union {
+                /* Space large enough to hold 2 record_type */
+                char buf[CMSG_SPACE(sizeof(uint8_t)) * 2];
+                struct cmsghdr _align;
+            } control_msg = { 0 };
+
+            /* Init msghdr */
+            struct msghdr msg = { 0 };
+            memset(&control_msg.buf, 0, sizeof(control_msg.buf));
+            msg.msg_control = control_msg.buf;
+            msg.msg_controllen = sizeof(control_msg.buf);
+
+            /* add ancillary data */
+            EXPECT_OK(s2n_ktls_set_ancillary_data(&msg, MALFORMED_RECORD_TYPE));
+            /* modify control_msg for the recv side */
+            struct cmsghdr *hdr = CMSG_FIRSTHDR(&msg);
+            /* tamper with the first header (MALFORMED_RECORD_TYPE) */
+            hdr->cmsg_type = 0;
+
+            /* add second correctly formatted cmsg (CORRECT_RECORD_TYPE)  */
+            hdr = CMSG_NXTHDR(&msg, hdr);
+            EXPECT_NOT_NULL(hdr);
+            hdr->cmsg_level = S2N_SOL_TLS;
+            hdr->cmsg_type = S2N_TLS_GET_RECORD_TYPE;
+            hdr->cmsg_len = CMSG_LEN(sizeof(uint8_t));
+            POSIX_CHECKED_MEMCPY(CMSG_DATA(hdr), &CORRECT_RECORD_TYPE, sizeof(uint8_t));
+
+            /* receive CORRECT_RECORD_TYPE, set on the second header */
+            uint8_t recv_record_type = 0;
+            EXPECT_OK(s2n_ktls_parse_ancillary_data(&msg, &recv_record_type));
+            EXPECT_NOT_EQUAL(recv_record_type, MALFORMED_RECORD_TYPE);
+            EXPECT_EQUAL(recv_record_type, CORRECT_RECORD_TYPE);
+        }
+
+        /* missing ancillary data */
+        {
+            union {
+                char buf[CMSG_SPACE(sizeof(uint8_t)) * 4];
+                struct cmsghdr _align;
+            } control_msg = { 0 };
+
+            /* Init msghdr */
+            struct msghdr msg = { 0 };
+            msg.msg_control = control_msg.buf;
+            msg.msg_controllen = sizeof(control_msg.buf);
+
+            /* attempt to parse missing ancillary data */
+            uint8_t recv_record_type = 0;
+            EXPECT_ERROR_WITH_ERRNO(s2n_ktls_parse_ancillary_data(&msg, &recv_record_type), S2N_ERR_IO);
+        }
+
+        /* malformed ancillary data */
+        {
+            union {
+                char buf[CMSG_SPACE(sizeof(uint8_t)) * 4];
+                struct cmsghdr _align;
+            } control_msg = { 0 };
+
+            /* Init msghdr */
+            struct msghdr msg = { 0 };
+            msg.msg_control = control_msg.buf;
+            msg.msg_controllen = sizeof(control_msg.buf);
+
+            /* add ancillary data */
+            EXPECT_OK(s2n_ktls_set_ancillary_data(&msg, TEST_SEND_RECORD_TYPE));
+            /* modify control_msg for the recv side */
+            struct cmsghdr *hdr = CMSG_FIRSTHDR(&msg);
+            /* tamper with the first header (MALFORMED_RECORD_TYPE) */
+            hdr->cmsg_type = 0;
+
+            uint8_t recv_record_type = 0;
+            EXPECT_ERROR_WITH_ERRNO(s2n_ktls_parse_ancillary_data(&msg, &recv_record_type), S2N_ERR_IO);
+        }
+    }
+#endif
+
+    END_TEST();
+}

--- a/tls/s2n_ktls_io.c
+++ b/tls/s2n_ktls_io.c
@@ -87,13 +87,7 @@ S2N_RESULT s2n_ktls_send_msg(
     RESULT_ENSURE_REF(blocked);
     RESULT_ENSURE_REF(send_len);
 
-    /* Init msghdr
-     *
-     * The control message buffer must be zero-initialized in order for the
-     * CMSG_NXTHDR() macro to work correctly. However since we dont use
-     * CMSG_NXTHDR for kTLS and this code path is performance sensitive we skip
-     * this step.
-     */
+    /* Init msghdr */
     struct msghdr msg = { 0 };
 
 #if S2N_KTLS_SUPPORTED /* CMSG_* macros are platform specific */
@@ -105,7 +99,6 @@ S2N_RESULT s2n_ktls_send_msg(
         char buf[CMSG_SPACE(sizeof(uint8_t))];
         struct cmsghdr _align;
     } control_msg = { 0 };
-
     msg.msg_control = control_msg.buf;
     msg.msg_controllen = sizeof(control_msg.buf);
 #endif
@@ -203,14 +196,6 @@ S2N_RESULT s2n_ktls_recv_msg(struct s2n_connection *conn, int sock, uint8_t *buf
         char buf[CMSG_SPACE(sizeof(uint8_t)) * 4];
         struct cmsghdr _align;
     } control_msg = { 0 };
-
-    /* The control message buffer must be zero-initialized in order for the
-     * CMSG_NXTHDR() macro to work correctly.
-     *
-     * https://man7.org/tlpi/code/online/dist/sockets/scm_cred_send.c.html
-     */
-    RESULT_CHECKED_MEMSET(&control_msg.buf, 0, sizeof(control_msg.buf));
-
     msg.msg_control = control_msg.buf;
     msg.msg_controllen = sizeof(control_msg.buf);
 #endif

--- a/tls/s2n_ktls_io.c
+++ b/tls/s2n_ktls_io.c
@@ -1,0 +1,227 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <sys/socket.h>
+
+#include "tls/s2n_ktls.h"
+#include "utils/s2n_socket.h"
+
+/*
+ * sendmsg and recvmsg are syscalls which can be used to send 'real' data along
+ * with ancillary data. Ancillary data is used to communicate to the socket the
+ * type of the TLS record being sent/received.
+ *
+ * Ancillary data macros (CMSG_*) are platform specific and gated.
+ */
+
+S2N_RESULT s2n_ktls_send_msg_impl(int sock, struct msghdr *msg,
+        struct iovec *msg_iov, size_t count, s2n_blocked_status *blocked, ssize_t *send_len)
+{
+    RESULT_ENSURE_REF(msg);
+    RESULT_ENSURE_REF(msg_iov);
+    RESULT_ENSURE_REF(blocked);
+    RESULT_ENSURE_REF(send_len);
+    RESULT_ENSURE_GT(count, 0);
+
+    /* set send buffer */
+    msg->msg_iov = msg_iov;
+    msg->msg_iovlen = count;
+
+    *blocked = S2N_BLOCKED_ON_WRITE;
+    *send_len = sendmsg(sock, msg, 0);
+    if (*send_len < 0) {
+        if (errno == EWOULDBLOCK || errno == EAGAIN) {
+            RESULT_BAIL(S2N_ERR_IO_BLOCKED);
+        }
+        RESULT_BAIL(S2N_ERR_IO);
+    }
+    *blocked = S2N_NOT_BLOCKED;
+
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_ktls_set_ancillary_data(struct msghdr *msg, uint8_t record_type)
+{
+    RESULT_ENSURE_REF(msg);
+
+#if !S2N_KTLS_SUPPORTED /* CMSG_* macros are platform specific */
+    RESULT_BAIL(S2N_ERR_KTLS_UNSUPPORTED_PLATFORM);
+#else
+    RESULT_ENSURE_REF(msg->msg_control);
+    RESULT_ENSURE_GTE(msg->msg_controllen, CMSG_SPACE(sizeof(uint8_t)));
+
+    /* set ancillary data */
+    struct cmsghdr *hdr = CMSG_FIRSTHDR(msg);
+    RESULT_ENSURE(hdr != NULL, S2N_ERR_IO);
+    hdr->cmsg_level = S2N_SOL_TLS;
+    hdr->cmsg_type = S2N_TLS_SET_RECORD_TYPE;
+    hdr->cmsg_len = CMSG_LEN(sizeof(uint8_t));
+    RESULT_CHECKED_MEMCPY(CMSG_DATA(hdr), &record_type, sizeof(uint8_t));
+#endif
+
+    return S2N_RESULT_OK;
+}
+
+/* Best practices taken from
+ * https://man7.org/tlpi/code/online/dist/sockets/scm_cred_send.c.html */
+S2N_RESULT s2n_ktls_send_msg(
+        int sock, uint8_t record_type, struct iovec *msg_iov,
+        size_t count, s2n_blocked_status *blocked, ssize_t *send_len)
+{
+    RESULT_ENSURE_REF(msg_iov);
+    RESULT_ENSURE_REF(msg_iov->iov_base);
+    RESULT_ENSURE_GT(msg_iov->iov_len, 0);
+    RESULT_ENSURE_GT(count, 0);
+    RESULT_ENSURE_REF(blocked);
+    RESULT_ENSURE_REF(send_len);
+
+    /* Init msghdr
+     *
+     * The control message buffer must be zero-initialized in order for the
+     * CMSG_NXTHDR() macro to work correctly. However since we dont use
+     * CMSG_NXTHDR for kTLS and this code path is performance sensitive we skip
+     * this step.
+     */
+    struct msghdr msg = { 0 };
+
+#if S2N_KTLS_SUPPORTED /* CMSG_* macros are platform specific */
+    /* Allocate a char array of suitable size to hold the ancillary data.
+     * However, since this buffer is in reality a 'struct cmsghdr', use a
+     * union to ensure that it is aligned as required for that structure.
+     */
+    union {
+        char buf[CMSG_SPACE(sizeof(uint8_t))];
+        struct cmsghdr _align;
+    } control_msg = { 0 };
+
+    msg.msg_control = control_msg.buf;
+    msg.msg_controllen = sizeof(control_msg.buf);
+#endif
+
+    RESULT_GUARD(s2n_ktls_set_ancillary_data(&msg, record_type));
+    RESULT_GUARD(s2n_ktls_send_msg_impl(sock, &msg, msg_iov, count, blocked, send_len));
+
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_ktls_recv_msg_impl(struct s2n_connection *conn, int sock, struct msghdr *msg,
+        struct iovec *msg_iov, s2n_blocked_status *blocked, ssize_t *bytes_read)
+{
+    RESULT_ENSURE_REF(msg);
+    RESULT_ENSURE_REF(msg_iov);
+    RESULT_ENSURE_REF(blocked);
+    RESULT_ENSURE_REF(bytes_read);
+
+    /* set receive buffer */
+    msg->msg_iov = msg_iov;
+    msg->msg_iovlen = 1;
+
+    *blocked = S2N_BLOCKED_ON_READ;
+    *bytes_read = recvmsg(sock, msg, 0);
+
+    /* The return value will be 0 when the peer has performed an orderly shutdown. */
+    if (*bytes_read == 0) {
+        *bytes_read = 0;
+        s2n_atomic_flag_set(&conn->read_closed);
+        RESULT_BAIL(S2N_ERR_CLOSED);
+    } else if (*bytes_read < 0) {
+        if (errno == EWOULDBLOCK || errno == EAGAIN) {
+            RESULT_BAIL(S2N_ERR_IO_BLOCKED);
+        }
+        RESULT_BAIL(S2N_ERR_IO);
+    }
+    *blocked = S2N_NOT_BLOCKED;
+
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_ktls_parse_ancillary_data(struct msghdr *msg, uint8_t *record_type)
+{
+    RESULT_ENSURE_REF(msg);
+    RESULT_ENSURE_REF(record_type);
+
+#if !S2N_KTLS_SUPPORTED /* CMSG_* macros are platform specific */
+    RESULT_BAIL(S2N_ERR_KTLS_UNSUPPORTED_PLATFORM);
+#else
+    RESULT_ENSURE_REF(msg->msg_control);
+    RESULT_ENSURE_GTE(msg->msg_controllen, CMSG_SPACE(sizeof(uint8_t)));
+
+    /* attempt to read the ancillary data */
+    struct cmsghdr *hdr = CMSG_FIRSTHDR(msg);
+    RESULT_ENSURE(hdr != NULL, S2N_ERR_IO);
+
+    /* iterate over all headers until it matches RECORD_TYPE.
+     * CMSG_NXTHDR will return NULL if there are no more cmsg */
+    while (hdr != NULL) {
+        if (hdr->cmsg_level == S2N_SOL_TLS && hdr->cmsg_type == S2N_TLS_GET_RECORD_TYPE) {
+            *record_type = *(unsigned char *) CMSG_DATA(hdr);
+            return S2N_RESULT_OK;
+        }
+
+        /* attempt to get the next header */
+        hdr = CMSG_NXTHDR(msg, hdr);
+    }
+#endif
+
+    /* return an IO error if no record was received */
+    RESULT_BAIL(S2N_ERR_IO);
+}
+
+/* Best practices taken from
+ * https://man7.org/tlpi/code/online/dist/sockets/scm_cred_recv.c.html */
+S2N_RESULT s2n_ktls_recv_msg(struct s2n_connection *conn, int sock, uint8_t *buf, size_t length,
+        uint8_t *record_type, s2n_blocked_status *blocked, ssize_t *bytes_read)
+{
+    RESULT_ENSURE_REF(buf);
+    RESULT_ENSURE_REF(record_type);
+    RESULT_ENSURE_REF(blocked);
+    RESULT_ENSURE_REF(bytes_read);
+    RESULT_ENSURE_GT(length, 0);
+
+    /* Init msghdr */
+    struct msghdr msg = { 0 };
+
+#if S2N_KTLS_SUPPORTED /* CMSG_* macros are platform specific */
+    /* Allocate a char array of suitable size to hold the ancillary data.
+     * However, since this buffer is in reality a 'struct cmsghdr', use a
+     * union to ensure that it is aligned as required for that structure.
+     */
+    union {
+        /* alloc enough space incase the application recieves more than one cmsg */
+        char buf[CMSG_SPACE(sizeof(uint8_t)) * 4];
+        struct cmsghdr _align;
+    } control_msg = { 0 };
+
+    /* The control message buffer must be zero-initialized in order for the
+     * CMSG_NXTHDR() macro to work correctly.
+     *
+     * https://man7.org/tlpi/code/online/dist/sockets/scm_cred_send.c.html
+     */
+    RESULT_CHECKED_MEMSET(&control_msg.buf, 0, sizeof(control_msg.buf));
+
+    msg.msg_control = control_msg.buf;
+    msg.msg_controllen = sizeof(control_msg.buf);
+#endif
+
+    struct iovec msg_iov = { 0 };
+    msg_iov.iov_base = buf;
+    msg_iov.iov_len = length;
+
+    /* receive msg */
+    RESULT_GUARD(s2n_ktls_recv_msg_impl(conn, sock, &msg, &msg_iov, blocked, bytes_read));
+    RESULT_GUARD(s2n_ktls_parse_ancillary_data(&msg, record_type));
+
+    return S2N_RESULT_OK;
+}

--- a/tls/s2n_ktls_parameters.h
+++ b/tls/s2n_ktls_parameters.h
@@ -33,12 +33,22 @@
     /* socket definitions */
     #define S2N_TCP_ULP 31 /* Attach a ULP to a TCP connection.  */
     #define S2N_SOL_TCP 6  /* TCP level */
+    #define S2N_SOL_TLS 282
+
+    /* cmsg */
+    #define S2N_TLS_SET_RECORD_TYPE 1
+    #define S2N_TLS_GET_RECORD_TYPE 2
 
 #else
     /* For unsupported platforms 0-init all values. */
-    #define S2N_KTLS_SUPPORTED false
+    #define S2N_KTLS_SUPPORTED      false
 
     /* socket definitions */
-    #define S2N_TCP_ULP        0
-    #define S2N_SOL_TCP        0
+    #define S2N_TCP_ULP             0
+    #define S2N_SOL_TCP             0
+    #define S2N_SOL_TLS             0
+
+    /* cmsg */
+    #define S2N_TLS_SET_RECORD_TYPE 0
+    #define S2N_TLS_GET_RECORD_TYPE 0
 #endif


### PR DESCRIPTION
### Description of changes: 
This PR adds methods to read and write cmsg via sendmsg and recvmsg. These methods can be used to send data but also ancillary data, which is needed to communicate the record type when using kTLS.

Since some of the functionality is linux specific (the first platform for which kTLS support will be added), I gate compilation to only that platform. Finally, since kTLS specific headers are not expose by linux uapi (https://github.com/aws/s2n-tls/pull/4064), I also define these headers inline in `s2n_ktls_linux.h`.

### Testing:
Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
