### PR TITLE
Fix openssl-1.0.2k x509 validator test failure

### DIFF
--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -123,12 +123,11 @@ static bool s2n_supports_large_time_t()
  */
 static bool s2n_libcrypto_supports_2050()
 {
-    if (!s2n_supports_large_time_t()) {
-        return false;
-    }
     ASN1_TIME *utc_time = ASN1_UTCTIME_set(NULL, 0);
     time_t time_2050 = 2524608000;
-    return (X509_cmp_time(utc_time, &time_2050) != 0);
+    int result = X509_cmp_time(utc_time, &time_2050);
+    ASN1_STRING_free(utc_time);
+    return (result != 0);
 }
 
 int main(int argc, char **argv)

--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -118,7 +118,7 @@ static bool s2n_supports_large_time_t()
  * and therefore reject any date with a year after 2050.
  * This is an issue because RFC5280 requires that dates in certificates be in
  * UTCTime format for years before 2050.
- * We disable affected tests where necessary.
+ * Affected tests are modified to account for this bug.
  * See https://github.com/openssl/openssl/blob/OpenSSL_1_0_2k/crypto/x509/x509_vfy.c#L2027C1-L2027C26
  */
 static bool s2n_libcrypto_supports_2050()

--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -112,10 +112,34 @@ static bool s2n_supports_large_time_t()
     return sizeof(time_t) == 8;
 }
 
+/* Early versions of Openssl (Openssl-1.0.2k confirmed) included a bug where UTCTime
+ * formatted dates in certificates could not be compared to dates after the year 2050,
+ * because Openssl would assume that the validation date was also UTCTime formatted
+ * and therefore reject any date with a year after 2050.
+ * This is an issue because RFC5280 requires that dates in certificates be in
+ * UTCTime format for years before 2050.
+ * We disable affected tests where necessary.
+ * See https://github.com/openssl/openssl/blob/OpenSSL_1_0_2k/crypto/x509/x509_vfy.c#L2027C1-L2027C26
+ */
+static bool s2n_libcrypto_supports_2050()
+{
+    if (!s2n_supports_large_time_t()) {
+        return false;
+    }
+    ASN1_TIME *utc_time = ASN1_UTCTIME_set(NULL, 0);
+    time_t time_2050 = 2524608000;
+    return (X509_cmp_time(utc_time, &time_2050) != 0);
+}
+
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
+
+    /* The issues with 2050 only affected openssl-1.0.2 */
+    if (S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0)) {
+        EXPECT_TRUE(s2n_libcrypto_supports_2050());
+    }
 
     /* test empty trust store */
     {
@@ -474,20 +498,18 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key_out));
         s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
 
-        if (s2n_supports_large_time_t()) {
-            EXPECT_ERROR_WITH_ERRNO(
-                    s2n_x509_validator_validate_cert_chain(&validator, connection,
-                            chain_data, chain_len, &pkey_type, &public_key_out),
-                    S2N_ERR_CERT_EXPIRED);
-        } else {
-            /* fetch_expired_after_ocsp_timestamp is in 2200 which is not
-             * representable for 32 bit time_t's.
-             */
-            EXPECT_ERROR_WITH_ERRNO(
-                    s2n_x509_validator_validate_cert_chain(&validator, connection,
-                            chain_data, chain_len, &pkey_type, &public_key_out),
-                    S2N_ERR_SAFETY);
+        int expected_errno = S2N_ERR_CERT_EXPIRED;
+        /* In some cases validation may fail with a less specific error due to
+         * issues with large dates, but validation does always fail. */
+        if (!s2n_supports_large_time_t()) {
+            expected_errno = S2N_ERR_SAFETY;
+        } else if (!s2n_libcrypto_supports_2050()) {
+            expected_errno = S2N_ERR_CERT_UNTRUSTED;
         }
+        EXPECT_ERROR_WITH_ERRNO(
+                s2n_x509_validator_validate_cert_chain(&validator, connection,
+                        chain_data, chain_len, &pkey_type, &public_key_out),
+                expected_errno);
 
         EXPECT_EQUAL(1, verify_data.callback_invoked);
         s2n_config_set_wall_clock(connection->config, old_clock, NULL);


### PR DESCRIPTION
### Resolved issues:

related to https://github.com/aws/s2n-tls/issues/3949

### Description of changes: 

There's a bug in openssl-1.0.2k. If a certificate's notBefore value is earlier than 2050, [RFC5280 requires](https://www.rfc-editor.org/rfc/rfc5280.html#section-4.1.2.5) that it be represented in UTCTime format. When comparing the date from the certificate to "now", openssl-1.0.2k makes [the incorrect assumption that the two dates can be represented in the same format](https://github.com/openssl/openssl/blob/OpenSSL_1_0_2k/crypto/x509/x509_vfy.c#L2027). So if the notBefore date is in UTCTime, then "now" must be representable in UTCTime, which [requires that the year be <2050](https://github.com/openssl/openssl/blob/OpenSSL_1_0_2k/crypto/asn1/a_utctm.c#L259-L260). This means that openssl-1.0.2k can't compare pre-2050 dates to post-2050 dates.

This is a problem in the failing s2n_x509_validator test because we set "now" to 2200 in order to test certificate expiration. Since the certificate's notBefore is 2016, this triggers the openssl-1.0.2k bug.

I fix this by just checking for the bug and accepting the wrong error code if the bug is present.

### Call-outs:

Alternatives I rejected:
- Change the cert notBefore from UTCTime to GeneralizedTime. This is probably technically possible, but not allowed by the X509 RFC.
- Generate a new cert, just for this test, with an expiration date >2038 but <2050. This seems like too much complexity, particularly because we already generated special "pre-2038" dates to work around the 32-bit problem.
- Regenerate the existing cert with an expiration date >2038 but <2050. Possible, but still seems like overkill to work around an issue in a very old patch version of openssl-1.0.2. Regenerating the existing cert is also kind of risky, since it's our default test cert and is used basically everywhere. Also 2049 seems so close :)

### Testing:
I'm still trying to figure out how to get a working AL2 test into the CI. But I reproduced the original failure with openssl-1.0.2k locally, and this fixes it. If that's not sufficient testing, this can wait until I figure out the CI, but minimally it doesn't break any of the existing CI tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
