### PR TITLE
Add additional Kyber768 tests

### DIFF
--- a/codebuild/bin/clang_format_changed_files.sh
+++ b/codebuild/bin/clang_format_changed_files.sh
@@ -13,7 +13,9 @@
 # permissions and limitations under the License.
 
 # Get a list of changed files
-changed_files=$(git diff origin/main --name-only )
+REMOTE="${1:-origin}"
+BRANCH="${2:-main}"
+changed_files=$(git diff "$REMOTE"/"$BRANCH" --name-only )
 
 # Run clang-format on each changed file
 for file in $changed_files

--- a/pq-crypto/kyber_r3/kyber512r3_kem.c
+++ b/pq-crypto/kyber_r3/kyber512r3_kem.c
@@ -1,13 +1,14 @@
 #include <stddef.h>
 #include <stdint.h>
-#include "kyber512r3_params.h"
-#include "kyber512r3_symmetric.h"
+
 #include "kyber512r3_indcpa.h"
 #include "kyber512r3_indcpa_avx2.h"
+#include "kyber512r3_params.h"
+#include "kyber512r3_symmetric.h"
+#include "pq-crypto/s2n_pq.h"
+#include "pq-crypto/s2n_pq_random.h"
 #include "tls/s2n_kem.h"
 #include "utils/s2n_safety.h"
-#include "pq-crypto/s2n_pq_random.h"
-#include "pq-crypto/s2n_pq.h"
 
 S2N_ENSURE_PORTABLE_OPTIMIZATIONS
 
@@ -30,18 +31,18 @@ int s2n_kyber_512_r3_crypto_kem_keypair(const struct s2n_kem *kem, uint8_t *pk, 
 #if defined(S2N_KYBER512R3_AVX2_BMI2)
     if (s2n_kyber512r3_is_avx2_bmi2_enabled()) {
         POSIX_GUARD(indcpa_keypair_avx2(pk, sk));
-    }else
+    } else
 #endif
     {
         POSIX_GUARD(indcpa_keypair(pk, sk));
     }
-    
-    for(size_t i = 0; i < S2N_KYBER_512_R3_INDCPA_PUBLICKEYBYTES; i++) {
+
+    for (size_t i = 0; i < S2N_KYBER_512_R3_INDCPA_PUBLICKEYBYTES; i++) {
         sk[i + S2N_KYBER_512_R3_INDCPA_SECRETKEYBYTES] = pk[i];
     }
-    sha3_256(sk+S2N_KYBER_512_R3_SECRET_KEY_BYTES-2*S2N_KYBER_512_R3_SYMBYTES, pk, S2N_KYBER_512_R3_PUBLIC_KEY_BYTES);
+    sha3_256(sk + S2N_KYBER_512_R3_SECRET_KEY_BYTES - 2 * S2N_KYBER_512_R3_SYMBYTES, pk, S2N_KYBER_512_R3_PUBLIC_KEY_BYTES);
     /* Value z for pseudo-random output on reject */
-    POSIX_GUARD_RESULT(s2n_get_random_bytes(sk+S2N_KYBER_512_R3_SECRET_KEY_BYTES-S2N_KYBER_512_R3_SYMBYTES, S2N_KYBER_512_R3_SYMBYTES));
+    POSIX_GUARD_RESULT(s2n_get_random_bytes(sk + S2N_KYBER_512_R3_SECRET_KEY_BYTES - S2N_KYBER_512_R3_SYMBYTES, S2N_KYBER_512_R3_SYMBYTES));
     return S2N_SUCCESS;
 }
 
@@ -64,32 +65,32 @@ int s2n_kyber_512_r3_crypto_kem_enc(const struct s2n_kem *kem, uint8_t *ct, uint
         const uint8_t *pk)
 {
     POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
-    uint8_t buf[2*S2N_KYBER_512_R3_SYMBYTES];
+    uint8_t buf[2 * S2N_KYBER_512_R3_SYMBYTES];
     /* Will contain key, coins */
-    uint8_t kr[2*S2N_KYBER_512_R3_SYMBYTES];
+    uint8_t kr[2 * S2N_KYBER_512_R3_SYMBYTES];
 
     POSIX_GUARD_RESULT(s2n_get_random_bytes(buf, S2N_KYBER_512_R3_SYMBYTES));
     /* Don't release system RNG output */
     sha3_256(buf, buf, S2N_KYBER_512_R3_SYMBYTES);
 
     /* Multitarget countermeasure for coins + contributory KEM */
-    sha3_256(buf+S2N_KYBER_512_R3_SYMBYTES, pk, S2N_KYBER_512_R3_PUBLIC_KEY_BYTES);
-    sha3_512(kr, buf, 2*S2N_KYBER_512_R3_SYMBYTES);
+    sha3_256(buf + S2N_KYBER_512_R3_SYMBYTES, pk, S2N_KYBER_512_R3_PUBLIC_KEY_BYTES);
+    sha3_512(kr, buf, 2 * S2N_KYBER_512_R3_SYMBYTES);
 
     /* coins are in kr+S2N_KYBER_512_R3_SYMBYTES */
 #if defined(S2N_KYBER512R3_AVX2_BMI2)
     if (s2n_kyber512r3_is_avx2_bmi2_enabled()) {
-        indcpa_enc_avx2(ct, buf, pk, kr+S2N_KYBER_512_R3_SYMBYTES);
-    }else
+        indcpa_enc_avx2(ct, buf, pk, kr + S2N_KYBER_512_R3_SYMBYTES);
+    } else
 #endif
     {
-        indcpa_enc(ct, buf, pk, kr+S2N_KYBER_512_R3_SYMBYTES);
+        indcpa_enc(ct, buf, pk, kr + S2N_KYBER_512_R3_SYMBYTES);
     }
-    
+
     /* overwrite coins in kr with H(c) */
-    sha3_256(kr+S2N_KYBER_512_R3_SYMBYTES, ct, S2N_KYBER_512_R3_CIPHERTEXT_BYTES);
+    sha3_256(kr + S2N_KYBER_512_R3_SYMBYTES, ct, S2N_KYBER_512_R3_CIPHERTEXT_BYTES);
     /* hash concatenation of pre-k and H(c) to k */
-    shake256(ss, S2N_KYBER_512_R3_SSBYTES, kr, 2*S2N_KYBER_512_R3_SYMBYTES);
+    shake256(ss, S2N_KYBER_512_R3_SSBYTES, kr, 2 * S2N_KYBER_512_R3_SYMBYTES);
     return S2N_SUCCESS;
 }
 
@@ -114,49 +115,49 @@ int s2n_kyber_512_r3_crypto_kem_dec(const struct s2n_kem *kem, uint8_t *ss, cons
         const uint8_t *sk)
 {
     POSIX_ENSURE(s2n_pq_is_enabled(), S2N_ERR_PQ_DISABLED);
-    uint8_t buf[2*S2N_KYBER_512_R3_SYMBYTES];
+    uint8_t buf[2 * S2N_KYBER_512_R3_SYMBYTES];
     /* Will contain key, coins */
-    uint8_t kr[2*S2N_KYBER_512_R3_SYMBYTES];
+    uint8_t kr[2 * S2N_KYBER_512_R3_SYMBYTES];
     uint8_t cmp[S2N_KYBER_512_R3_CIPHERTEXT_BYTES];
-    const uint8_t *pk = sk+S2N_KYBER_512_R3_INDCPA_SECRETKEYBYTES;
+    const uint8_t *pk = sk + S2N_KYBER_512_R3_INDCPA_SECRETKEYBYTES;
 
 #if defined(S2N_KYBER512R3_AVX2_BMI2)
     if (s2n_kyber512r3_is_avx2_bmi2_enabled()) {
         indcpa_dec_avx2(buf, ct, sk);
-    }else
+    } else
 #endif
     {
         indcpa_dec(buf, ct, sk);
     }
-    
+
     /* Multitarget countermeasure for coins + contributory KEM */
-    for(size_t i = 0; i < S2N_KYBER_512_R3_SYMBYTES; i++) {
+    for (size_t i = 0; i < S2N_KYBER_512_R3_SYMBYTES; i++) {
         buf[S2N_KYBER_512_R3_SYMBYTES + i] = sk[S2N_KYBER_512_R3_SECRET_KEY_BYTES - 2 * S2N_KYBER_512_R3_SYMBYTES + i];
     }
-    sha3_512(kr, buf, 2*S2N_KYBER_512_R3_SYMBYTES);
+    sha3_512(kr, buf, 2 * S2N_KYBER_512_R3_SYMBYTES);
 
     /* coins are in kr+S2N_KYBER_512_R3_SYMBYTES */
 #if defined(S2N_KYBER512R3_AVX2_BMI2)
     if (s2n_kyber512r3_is_avx2_bmi2_enabled()) {
-        indcpa_enc_avx2(cmp, buf, pk, kr+S2N_KYBER_512_R3_SYMBYTES);
-    }else
+        indcpa_enc_avx2(cmp, buf, pk, kr + S2N_KYBER_512_R3_SYMBYTES);
+    } else
 #endif
     {
-        indcpa_enc(cmp, buf, pk, kr+S2N_KYBER_512_R3_SYMBYTES);
+        indcpa_enc(cmp, buf, pk, kr + S2N_KYBER_512_R3_SYMBYTES);
     }
-    
+
     /* If ct and cmp are equal (dont_copy = 1), decryption has succeeded and we do NOT overwrite pre-k below.
      * If ct and cmp are not equal (dont_copy = 0), decryption fails and we do overwrite pre-k. */
     int dont_copy = s2n_constant_time_equals(ct, cmp, S2N_KYBER_512_R3_CIPHERTEXT_BYTES);
 
     /* overwrite coins in kr with H(c) */
-    sha3_256(kr+S2N_KYBER_512_R3_SYMBYTES, ct, S2N_KYBER_512_R3_CIPHERTEXT_BYTES);
+    sha3_256(kr + S2N_KYBER_512_R3_SYMBYTES, ct, S2N_KYBER_512_R3_CIPHERTEXT_BYTES);
 
     /* Overwrite pre-k with z on re-encryption failure */
-    POSIX_GUARD(s2n_constant_time_copy_or_dont(kr, sk+S2N_KYBER_512_R3_SECRET_KEY_BYTES-S2N_KYBER_512_R3_SYMBYTES,
+    POSIX_GUARD(s2n_constant_time_copy_or_dont(kr, sk + S2N_KYBER_512_R3_SECRET_KEY_BYTES - S2N_KYBER_512_R3_SYMBYTES,
             S2N_KYBER_512_R3_SYMBYTES, dont_copy));
 
     /* hash concatenation of pre-k and H(c) to k */
-    shake256(ss, S2N_KYBER_512_R3_SSBYTES, kr, 2*S2N_KYBER_512_R3_SYMBYTES);
+    shake256(ss, S2N_KYBER_512_R3_SSBYTES, kr, 2 * S2N_KYBER_512_R3_SYMBYTES);
     return S2N_SUCCESS;
 }

--- a/pq-crypto/s2n_kyber_evp.c
+++ b/pq-crypto/s2n_kyber_evp.c
@@ -81,7 +81,7 @@ int s2n_kyber_evp_decapsulate(IN const struct s2n_kem *kem, OUT uint8_t *shared_
 
     size_t shared_secret_size = kem->shared_secret_key_length;
     POSIX_GUARD_OSSL(EVP_PKEY_decapsulate(kyber_pkey_ctx, shared_secret, &shared_secret_size,
-                (uint8_t *) ciphertext, kem->ciphertext_length),
+                             (uint8_t *) ciphertext, kem->ciphertext_length),
             S2N_ERR_PQ_CRYPTO);
     POSIX_ENSURE_EQ(kem->shared_secret_key_length, shared_secret_size);
 

--- a/pq-crypto/s2n_kyber_evp.h
+++ b/pq-crypto/s2n_kyber_evp.h
@@ -20,4 +20,3 @@
 int s2n_kyber_evp_generate_keypair(IN const struct s2n_kem *kem, OUT uint8_t *public_key, OUT uint8_t *private_key);
 int s2n_kyber_evp_encapsulate(IN const struct s2n_kem *kem, OUT uint8_t *ciphertext, OUT uint8_t *shared_secret, IN const uint8_t *public_key);
 int s2n_kyber_evp_decapsulate(IN const struct s2n_kem *kem, OUT uint8_t *shared_secret, IN const uint8_t *ciphertext, IN const uint8_t *private_key);
-

--- a/tests/fuzz/s2n_kyber_r3_recv_public_key_fuzz_test.c
+++ b/tests/fuzz/s2n_kyber_r3_recv_public_key_fuzz_test.c
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-/* Target Functions: s2n_kem_recv_public_key s2n_kem_encapsulate kyber_512_r3_crypto_kem_enc */
+/* Target Functions: s2n_kem_recv_public_key s2n_kem_encapsulate kyber_512_r3_crypto_kem_enc kyber_768_r3_crypto_kem_enc kyber_1024_r3_crypto_kem_enc */
 
 #include "tests/s2n_test.h"
 #include "tests/testlib/s2n_testlib.h"
@@ -25,11 +25,19 @@
  * hex-encoded bytes. This is how we would expect it to appear on the wire. */
 static struct s2n_kem_params kyber512_r3_draft0_params = { .kem = &s2n_kyber_512_r3, .len_prefixed = true };
 static struct s2n_kem_params kyber512_r3_draft5_params = { .kem = &s2n_kyber_512_r3, .len_prefixed = false };
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+static struct s2n_kem_params kyber768_r3_draft5_params = { .kem = &s2n_kyber_768_r3, .len_prefixed = false };
+static struct s2n_kem_params kyber1024_r3_draft5_params = { .kem = &s2n_kyber_1024_r3, .len_prefixed = false };
+#endif
 
 int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     POSIX_GUARD(s2n_kem_recv_public_key_fuzz_test(buf, len, &kyber512_r3_draft0_params));
     POSIX_GUARD(s2n_kem_recv_public_key_fuzz_test(buf, len, &kyber512_r3_draft5_params));
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+    POSIX_GUARD(s2n_kem_recv_public_key_fuzz_test(buf, len, &kyber768_r3_draft5_params));
+    POSIX_GUARD(s2n_kem_recv_public_key_fuzz_test(buf, len, &kyber1024_r3_draft5_params));
+#endif
     return S2N_SUCCESS;
 }
 

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -309,6 +309,8 @@ class Ciphers(object):
         "PQ-TLS-1-0-2020-12", Protocols.TLS10, False, False, s2n=True, pq=True)
     PQ_TLS_1_0_2023_01 = Cipher(
         "PQ-TLS-1-0-2023-01-24", Protocols.TLS10, False, False, s2n=True, pq=True)
+    PQ_TLS_1_3_2023_06_01 = Cipher(
+        "PQ-TLS-1-3-2023-06-01", Protocols.TLS12, False, False, s2n=True, pq=True)
 
     SECURITY_POLICY_20210816 = Cipher(
         "20210816", Protocols.TLS12, False, False, s2n=True, pq=False)
@@ -356,8 +358,11 @@ class KemGroup(object):
 
 
 class KemGroups(object):
-    # oqs_openssl does not support x25519 based KEM groups
+    # oqs_openssl 1.1.1 does not support KEM groups with 128-bit secuirty ECC + Kyber >512
+    X25519_KYBER512R3 = KemGroup("X25519_kyber512")
     P256_KYBER512R3 = KemGroup("p256_kyber512")
+    P384_KYBER768R3 = KemGroup("p384_kyber768")
+    P521_KYBER1024R3 = KemGroup("p521_kyber1024")
 
 
 class Signature(object):

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -358,7 +358,10 @@ class KemGroup(object):
 
 
 class KemGroups(object):
-    # oqs_openssl 1.1.1 does not support KEM groups with 128-bit secuirty ECC + Kyber >512
+    # Though s2n and oqs_openssl 3.x support KEM groups with 128-bit security
+    # ECC + Kyber >512, oqs_openssl 1.1.1 does not:
+    #
+    # https://github.com/open-quantum-safe/openssl/blob/OQS-OpenSSL_1_1_1-stable/oqs-template/oqs-kem-info.md
     X25519_KYBER512R3 = KemGroup("X25519_kyber512")
     P256_KYBER512R3 = KemGroup("p256_kyber512")
     P384_KYBER768R3 = KemGroup("p384_kyber768")

--- a/tests/integrationv2/test_pq_handshake.py
+++ b/tests/integrationv2/test_pq_handshake.py
@@ -17,10 +17,14 @@ CIPHERS = [
     Ciphers.PQ_SIKE_TEST_TLS_1_0_2020_02,
     Ciphers.KMS_TLS_1_0_2018_10,
     Ciphers.PQ_TLS_1_0_2020_12,
+    Ciphers.PQ_TLS_1_3_2023_06_01,
 ]
 
 KEM_GROUPS = [
+    KemGroups.X25519_KYBER512R3,
     KemGroups.P256_KYBER512R3,
+    KemGroups.P384_KYBER768R3,
+    KemGroups.P521_KYBER1024R3,
 ]
 
 EXPECTED_RESULTS = {
@@ -96,7 +100,8 @@ EXPECTED_RESULTS = {
             "kem": "NONE", "kem_group": "NONE"},
 
     # The expected kem_group string for this case purposefully excludes a curve;
-    # depending on how s2n was compiled, the curve may be either x25519 or p256.
+    # depending on how s2n was compiled, the curve may be either x25519 or one
+    # of the NIST curves.
     (Ciphers.PQ_TLS_1_0_2020_12, Ciphers.PQ_TLS_1_0_2020_12):
         {"cipher": "TLS_AES_256_GCM_SHA384",
             "kem": "NONE", "kem_group": "_kyber-512-r3"},
@@ -124,6 +129,15 @@ EXPECTED_RESULTS = {
     (KemGroups.P256_KYBER512R3, Ciphers.PQ_TLS_1_0_2023_01):
         {"cipher": "AES256_GCM_SHA384", "kem": "NONE",
             "kem_group": "secp256r1_kyber-512-r3"},
+    (KemGroups.P256_KYBER512R3, Ciphers.PQ_TLS_1_3_2023_06_01):
+        {"cipher": "AES256_GCM_SHA384", "kem": "NONE",
+            "kem_group": "secp256r1_kyber-512-r3"},
+    (KemGroups.P384_KYBER768R3, Ciphers.PQ_TLS_1_3_2023_06_01):
+        {"cipher": "AES256_GCM_SHA384", "kem": "NONE",
+            "kem_group": "secp384r1_kyber-768-r3"},
+    (KemGroups.P521_KYBER1024R3, Ciphers.PQ_TLS_1_3_2023_06_01):
+        {"cipher": "AES256_GCM_SHA384", "kem": "NONE",
+            "kem_group": "secp521r1_kyber-1024-r3"},
 }
 
 """

--- a/tests/unit/kats/generate_pq_hybrid_tls13_handshake_kats.py
+++ b/tests/unit/kats/generate_pq_hybrid_tls13_handshake_kats.py
@@ -1,34 +1,9 @@
 import hashlib
 import hmac
 
-# The following PEM-encoded ECC private keys were used to generate the ECC shared secrets.
-# These private keys are also used in s2n/tests/unit/s2n_tls13_hybrid_shared_secret_test.c.
-#
-# #define CLIENT_X25519_PRIV_KEY "-----BEGIN PRIVATE KEY-----\n"\
-#                                "MC4CAQAwBQYDK2VuBCIEIIgzBrAp631nCDaoA7ilx/8S/cW1lddVQOw9869sROBF\n"\
-#                                "-----END PRIVATE KEY-----"
-#
-# #define SERVER_X25519_PRIV_KEY "-----BEGIN PRIVATE KEY-----\n"\
-#                                "MC4CAQAwBQYDK2VuBCIEIIBo+KJ2Zs3vRHQ3sYgHL4zTQPlJPl1y7sW8HT9qRE96\n"\
-#                                "-----END PRIVATE KEY-----"
-#
-# #define CLIENT_SECP256R1_PRIV_KEY "-----BEGIN EC PARAMETERS-----\n"\
-#                                   "BggqhkjOPQMBBw==\n"\
-#                                   "-----END EC PARAMETERS-----\n"\
-#                                   "-----BEGIN EC PRIVATE KEY-----\n"\
-#                                   "MHcCAQEEIFCkEmNXACRbWdizfAKP8/Qvx9aplVxLE+Sm2vmCcsY3oAoGCCqGSM49\n"\
-#                                   "AwEHoUQDQgAESk526eZ9lf6xrNOiTF8qkYvJDOfc4qqShcbB7qnT67As4pyeQzVm\n"\
-#                                   "xfMjmXYBOUnPVBL3FKnIk45sDSCfu++gug==\n"\
-#                                   "-----END EC PRIVATE KEY-----"
-#
-# #define SERVER_SECP256R1_PRIV_KEY "-----BEGIN EC PARAMETERS-----\n"\
-#                                   "BggqhkjOPQMBBw==\n"\
-#                                   "-----END EC PARAMETERS-----\n"\
-#                                   "-----BEGIN EC PRIVATE KEY-----\n"\
-#                                   "MHcCAQEEINXLCaZuyYG0HrlSFcHLPFmSnyFm5RqrmyZfgdrxqprXoAoGCCqGSM49\n"\
-#                                   "AwEHoUQDQgAEMDuuxEQ1yaA13ceuJP+RC0sbf5ksW6DPlL+yXJiD7cUeWUPrtxbP\n"\
-#                                   "ViSR6ex8fYV69oCHgnDnElfE3xaiXiQWBw==\n"\
-#                                   "-----END EC PRIVATE KEY-----"
+# The PEM-encoded ECC private keys were used to generate the ECC shared secrets
+# are located in in s2n/tests/unit/s2n_tls13_hybrid_shared_secret_test.c with
+# names like "CLIENT_{CURVE}_PRIV_KEY" and "SERVER_{CURVE}_PRIV_KEY".
 
 # We aren't really concerned with the actual bytes of the transcript, only the hash.
 # The transcript_hash values were calculated as:
@@ -135,8 +110,7 @@ input_vectors = [
         "ec_shared_secret": "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910",
         "pq_shared_secret": "0A6925676F24B22C286F4C81A4224CEC506C9B257D480E02E3B49F44CAA3237F",
         "transcript_hash": "35412cebcf35cb8a7af8f78278a486fc798f8702eaebd067c97acb27bffe13524d8426a4ed57956b4fd0ffdc4c90be52",
-    },
-    {
+    },    {
         "group_name": "secp256r1_kyber512r3",
         "cipher_suite": "TLS_AES_128_GCM_SHA256",
         "ec_shared_secret": "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60",
@@ -176,6 +150,62 @@ input_vectors = [
         "cipher_suite": "TLS_AES_256_GCM_SHA384",
         "ec_shared_secret": "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60",
         "pq_shared_secret": "1A88B3A458EE42906A5FD423817E043532579C4F79518A81213DC91D0F2FCEA9",
+        "transcript_hash": "35412cebcf35cb8a7af8f78278a486fc798f8702eaebd067c97acb27bffe13524d8426a4ed57956b4fd0ffdc4c90be52",
+    },
+    {
+        "group_name": "x25519_kyber768r3",
+        "cipher_suite": "TLS_AES_128_GCM_SHA256",
+        "ec_shared_secret": "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910",
+        "pq_shared_secret": "914CB67FE5C38E73BF74181C0AC50428DEDF7750A98058F7D536708774535B29",
+        "transcript_hash": "f5f7f7867668be4b792159d4d194a03ec5cfa238b6409b5ca2ddccfddcc92a2b",
+    },
+    {
+        "group_name": "x25519_kyber768r3",
+        "cipher_suite": "TLS_AES_256_GCM_SHA384",
+        "ec_shared_secret": "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910",
+        "pq_shared_secret": "914CB67FE5C38E73BF74181C0AC50428DEDF7750A98058F7D536708774535B29",
+        "transcript_hash": "35412cebcf35cb8a7af8f78278a486fc798f8702eaebd067c97acb27bffe13524d8426a4ed57956b4fd0ffdc4c90be52",
+    },
+    {
+        "group_name": "secp256r1_kyber768r3",
+        "cipher_suite": "TLS_AES_128_GCM_SHA256",
+        "ec_shared_secret": "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60",
+        "pq_shared_secret": "914CB67FE5C38E73BF74181C0AC50428DEDF7750A98058F7D536708774535B29",
+        "transcript_hash": "f5f7f7867668be4b792159d4d194a03ec5cfa238b6409b5ca2ddccfddcc92a2b",
+    },
+    {
+        "group_name": "secp256r1_kyber768r3",
+        "cipher_suite": "TLS_AES_256_GCM_SHA384",
+        "ec_shared_secret": "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60",
+        "pq_shared_secret": "914CB67FE5C38E73BF74181C0AC50428DEDF7750A98058F7D536708774535B29",
+        "transcript_hash": "35412cebcf35cb8a7af8f78278a486fc798f8702eaebd067c97acb27bffe13524d8426a4ed57956b4fd0ffdc4c90be52",
+    },
+    {
+        "group_name": "secp384r1_kyber768r3",
+        "cipher_suite": "TLS_AES_128_GCM_SHA256",
+        "ec_shared_secret": "b72536062cd8e8eced91046e33413b027cabde0576747aa47863b8dcb914100585c600fafc8ff4927a34abb0aa6b3b68",
+        "pq_shared_secret": "914CB67FE5C38E73BF74181C0AC50428DEDF7750A98058F7D536708774535B29",
+        "transcript_hash": "f5f7f7867668be4b792159d4d194a03ec5cfa238b6409b5ca2ddccfddcc92a2b",
+    },
+    {
+        "group_name": "secp384r1_kyber768r3",
+        "cipher_suite": "TLS_AES_256_GCM_SHA384",
+        "ec_shared_secret": "b72536062cd8e8eced91046e33413b027cabde0576747aa47863b8dcb914100585c600fafc8ff4927a34abb0aa6b3b68",
+        "pq_shared_secret": "914CB67FE5C38E73BF74181C0AC50428DEDF7750A98058F7D536708774535B29",
+        "transcript_hash": "35412cebcf35cb8a7af8f78278a486fc798f8702eaebd067c97acb27bffe13524d8426a4ed57956b4fd0ffdc4c90be52",
+    },
+    {
+        "group_name": "secp521r1_kyber1024r3",
+        "cipher_suite": "TLS_AES_128_GCM_SHA256",
+        "ec_shared_secret": "009643bb20199e8f408b7c19bb98d1d19f0cef9104e2ec790c398c6abe7dc5cf47afb96de70aa14c86bc546a12f9ea3abbf2eec399b4d586083114cbc37f53ed2d8b",
+        "pq_shared_secret": "B10F7394926AD3B49C5D62D5AEB531D5757538BCC0DA9E550D438F1B61BD7419",
+        "transcript_hash": "f5f7f7867668be4b792159d4d194a03ec5cfa238b6409b5ca2ddccfddcc92a2b",
+    },
+    {
+        "group_name": "secp521r1_kyber1024r3",
+        "cipher_suite": "TLS_AES_256_GCM_SHA384",
+        "ec_shared_secret": "009643bb20199e8f408b7c19bb98d1d19f0cef9104e2ec790c398c6abe7dc5cf47afb96de70aa14c86bc546a12f9ea3abbf2eec399b4d586083114cbc37f53ed2d8b",
+        "pq_shared_secret": "B10F7394926AD3B49C5D62D5AEB531D5757538BCC0DA9E550D438F1B61BD7419",
         "transcript_hash": "35412cebcf35cb8a7af8f78278a486fc798f8702eaebd067c97acb27bffe13524d8426a4ed57956b4fd0ffdc4c90be52",
     },
 ]

--- a/tests/unit/s2n_choose_supported_group_test.c
+++ b/tests/unit/s2n_choose_supported_group_test.c
@@ -146,6 +146,10 @@ int main()
 #if EVP_APIS_SUPPORTED
             &s2n_x25519_kyber_512_r3,
 #endif
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+            &s2n_secp384r1_kyber_768_r3,
+            &s2n_secp521r1_kyber_1024_r3,
+#endif
         };
 
         const struct s2n_kem_preferences test_kem_prefs = {

--- a/tests/unit/s2n_kem_preferences_test.c
+++ b/tests/unit/s2n_kem_preferences_test.c
@@ -24,13 +24,20 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
+    EXPECT_FALSE(s2n_kem_preferences_includes_tls13_kem_group(&kem_preferences_null, TLS_PQ_KEM_GROUP_ID_X25519_KYBER_512_R3));
     EXPECT_FALSE(s2n_kem_preferences_includes_tls13_kem_group(&kem_preferences_null, TLS_PQ_KEM_GROUP_ID_SECP256R1_KYBER_512_R3));
+    EXPECT_FALSE(s2n_kem_preferences_includes_tls13_kem_group(&kem_preferences_null, TLS_PQ_KEM_GROUP_ID_SECP384R1_KYBER_768_R3));
+    EXPECT_FALSE(s2n_kem_preferences_includes_tls13_kem_group(&kem_preferences_null, TLS_PQ_KEM_GROUP_ID_SECP521R1_KYBER_1024_R3));
 
     {
         const struct s2n_kem_group *test_kem_groups[] = {
             &s2n_secp256r1_kyber_512_r3,
 #if EVP_APIS_SUPPORTED
             &s2n_x25519_kyber_512_r3,
+#endif
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+            &s2n_secp384r1_kyber_768_r3,
+            &s2n_secp521r1_kyber_1024_r3,
 #endif
         };
 
@@ -47,6 +54,14 @@ int main(int argc, char **argv)
         EXPECT_TRUE(s2n_kem_preferences_includes_tls13_kem_group(&test_prefs, TLS_PQ_KEM_GROUP_ID_X25519_KYBER_512_R3));
 #else
         EXPECT_FALSE(s2n_kem_preferences_includes_tls13_kem_group(&test_prefs, TLS_PQ_KEM_GROUP_ID_X25519_KYBER_512_R3));
+#endif
+
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+        EXPECT_TRUE(s2n_kem_preferences_includes_tls13_kem_group(&test_prefs, TLS_PQ_KEM_GROUP_ID_SECP384R1_KYBER_768_R3));
+        EXPECT_TRUE(s2n_kem_preferences_includes_tls13_kem_group(&test_prefs, TLS_PQ_KEM_GROUP_ID_SECP521R1_KYBER_1024_R3));
+#else
+        EXPECT_FALSE(s2n_kem_preferences_includes_tls13_kem_group(&test_prefs, TLS_PQ_KEM_GROUP_ID_SECP384R1_KYBER_768_R3));
+        EXPECT_FALSE(s2n_kem_preferences_includes_tls13_kem_group(&test_prefs, TLS_PQ_KEM_GROUP_ID_SECP521R1_KYBER_1024_R3));
 #endif
     };
 

--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -172,11 +172,11 @@ int main(int argc, char **argv)
 
         /* The kem_extensions and kems arrays should be kept in sync with each other */
         kem_extension_size kem_extensions[] = {
-            TLS_PQ_KEM_EXTENSION_ID_KYBER_512_R3
+            TLS_PQ_KEM_EXTENSION_ID_KYBER_512_R3,
         };
 
         const struct s2n_kem *kems[] = {
-            &s2n_kyber_512_r3
+            &s2n_kyber_512_r3,
         };
 
         for (size_t i = 0; i < s2n_array_len(kems); i++) {

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -52,7 +52,10 @@ struct hybrid_test_vector {
     struct s2n_blob *expected_server_traffic_secret;
 };
 
-/* PEM-encoded ECC private keys */
+/* PEM-encoded ECC private keys generated using openssl commands like:
+ *
+ * $ openssl ecparam -name ${CURVE_NAME} -genkey
+ */
 #define CLIENT_X25519_PRIV_KEY "-----BEGIN PRIVATE KEY-----\n"                                      \
                                "MC4CAQAwBQYDK2VuBCIEIIgzBrAp631nCDaoA7ilx/8S/cW1lddVQOw9869sROBF\n" \
                                "-----END PRIVATE KEY-----"
@@ -79,16 +82,69 @@ struct hybrid_test_vector {
                                   "ViSR6ex8fYV69oCHgnDnElfE3xaiXiQWBw==\n"                             \
                                   "-----END EC PRIVATE KEY-----"
 
-/* ECDHE shared secrets computed from the private keys above */
+#define CLIENT_SECP384R1_PRIV_KEY "-----BEGIN EC PARAMETERS-----\n"                                    \
+                                  "BgUrgQQAIg==\n"                                                     \
+                                  "-----END EC PARAMETERS-----\n"                                      \
+                                  "-----BEGIN EC PRIVATE KEY-----\n"                                   \
+                                  "MIGkAgEBBDCq+TiiEmbFT2xiIj1s6q+Tk/qw3DRHrpH1SWb36XNmv+FcASF24EmU\n" \
+                                  "QSffpZLGRk6gBwYFK4EEACKhZANiAAQp0Y+a+SfYB9V/TDF9jzwoa5ccedThv4mY\n" \
+                                  "ddHwoynSGE95n7f8T25/276MHOoi79P5WP82aiLoIOL68IVflQPLMPFYnN9BumVo\n" \
+                                  "UjmCWR9yl8gEBWl4teiaRvvMf2i7ayM=\n"                                 \
+                                  "-----END EC PRIVATE KEY-----\n"
+
+#define SERVER_SECP384R1_PRIV_KEY "-----BEGIN EC PARAMETERS-----\n"                                    \
+                                  "BgUrgQQAIg==\n"                                                     \
+                                  "-----END EC PARAMETERS-----\n"                                      \
+                                  "-----BEGIN EC PRIVATE KEY-----\n"                                   \
+                                  "MIGkAgEBBDATrNZMWEQHj/8iJFBUy+X3fG1zvhZE9zWX5qHVkxlSH3iY14y7NBhh\n" \
+                                  "6UQIrBRiPHagBwYFK4EEACKhZANiAAQlvEGmcz6hluErpKBxJPNRh6wf6qb9ceu7\n" \
+                                  "8CwgDMHbLFYzrnLPDDIaUVRfkrfYBEtL9WSJZUIelJIw8hK1qoXkaL+D/aKWz7Wm\n" \
+                                  "9MWDKS15M62Q2PAfjjFoO69nFPHcqM0=\n"                                 \
+                                  "-----END EC PRIVATE KEY-----\n"
+
+#define CLIENT_SECP521R1_PRIV_KEY "-----BEGIN EC PARAMETERS-----\n"                                    \
+                                  "BgUrgQQAIw==\n"                                                     \
+                                  "-----END EC PARAMETERS-----\n"                                      \
+                                  "-----BEGIN EC PRIVATE KEY-----\n"                                   \
+                                  "MIHcAgEBBEIB4Cj94bbC/xIDnrd8kqlmfum2L6C6l2uajrPXR5dnartodZl1Sswg\n" \
+                                  "IWSimNW2k1LELdDQC+MfOIjCopANRFH5fgmgBwYFK4EEACOhgYkDgYYABAF+9lQh\n" \
+                                  "7WgX0eNpMQEQmMDMiwfb/7QxmlVxHvl/1+Bh89pxzLwrFjGGKmwgSV5f85/vNQdo\n" \
+                                  "jAhzWUTIes3j/qWmBAB63FI2S+yBkhD1tfZl4sUUoLX20T1OexFEk0RRPQI6oCdZ\n" \
+                                  "TFusCC+4trkSnj9gEgLFfwShb0kUFYoBpJzmVFN1BA==\n"                     \
+                                  "-----END EC PRIVATE KEY-----\n"
+
+#define SERVER_SECP521R1_PRIV_KEY "-----BEGIN EC PARAMETERS-----\n"                                    \
+                                  "BgUrgQQAIw==\n"                                                     \
+                                  "-----END EC PARAMETERS-----\n"                                      \
+                                  "-----BEGIN EC PRIVATE KEY-----\n"                                   \
+                                  "MIHcAgEBBEIAYwEZ+1dvjYoQZhu+0ZS+gY1uB0ON1YvtblgWJI/Blw/pXv4oUfFX\n" \
+                                  "QLXyjkx5ctQzNDKIGEdZ5BcSkBZ+3mJXyuagBwYFK4EEACOhgYkDgYYABACoLmHw\n" \
+                                  "oiWFRf4LAKWTFXEAmx7mVLHvP5YY01PWbbjY2AL3+O5CMBODj3rGuL0lJgRWondF\n" \
+                                  "R6KTS/zw9VK4gyDOXAAyeB4EfVx47ANXQO7bB+dS6WrmUAPY9L6MYkoqngorCf5j\n" \
+                                  "A24QOAiftXdo/IcvXOephiffhGigGetVLd1tIfNM/w==\n"                     \
+                                  "-----END EC PRIVATE KEY-----\n"
+
+/* ECDHE shared secrets computed from the private keys above using openssl commands like:
+ *
+ * $ openssl pkeyutl -derive -inkey ${CLIENT_PRIV}.pem -peerkey ${SERVER_PUB}.pem -hexdump
+ */
 #define X25519_SHARED_SECRET    "519be87fa0599077e5673d6f2d910aa150d7fef783c5e1491961fdf63b255910"
 #define SECP256R1_SHARED_SECRET "9348e27655539e08fffe46b35f863dd634e7437cc6bc11c7d329ef5484ec3b60"
+#define SECP384R1_SHARED_SECRET "b72536062cd8e8eced91046e33413b027cabde0576747aa47863b8dcb914100585c600fafc8ff4927a34abb0aa6b3b68"
+#define SECP521R1_SHARED_SECRET "009643bb20199e8f408b7c19bb98d1d19f0cef9104e2ec790c398c6abe7dc5cf47afb96de70aa14c86bc546a12f9ea3abbf2eec399b4d586083114cbc37f53ed2d8b"
 
 /* PQ shared secrets taken from the first entry in the NIST KAT files */
-#define KYBER512R3_SECRET "0A6925676F24B22C286F4C81A4224CEC506C9B257D480E02E3B49F44CAA3237F"
+#define KYBER512R3_SECRET  "0A6925676F24B22C286F4C81A4224CEC506C9B257D480E02E3B49F44CAA3237F"
+#define KYBER768R3_SECRET  "914CB67FE5C38E73BF74181C0AC50428DEDF7750A98058F7D536708774535B29"
+#define KYBER1024R3_SECRET "B10F7394926AD3B49C5D62D5AEB531D5757538BCC0DA9E550D438F1B61BD7419"
 
 /* Hybrid shared secrets are the concatenation: ECDHE || PQ */
-#define X25519_KYBER512R3_HYBRID_SECRET    (X25519_SHARED_SECRET KYBER512R3_SECRET)
-#define SECP256R1_KYBER512R3_HYBRID_SECRET (SECP256R1_SHARED_SECRET KYBER512R3_SECRET)
+#define X25519_KYBER512R3_HYBRID_SECRET     (X25519_SHARED_SECRET KYBER512R3_SECRET)
+#define X25519_KYBER768R3_HYBRID_SECRET     (X25519_SHARED_SECRET KYBER768R3_SECRET)
+#define SECP256R1_KYBER512R3_HYBRID_SECRET  (SECP256R1_SHARED_SECRET KYBER512R3_SECRET)
+#define SECP256R1_KYBER768R3_HYBRID_SECRET  (SECP256R1_SHARED_SECRET KYBER768R3_SECRET)
+#define SECP384R1_KYBER768R3_HYBRID_SECRET  (SECP384R1_SHARED_SECRET KYBER768R3_SECRET)
+#define SECP521R1_KYBER1024R3_HYBRID_SECRET (SECP521R1_SHARED_SECRET KYBER1024R3_SECRET)
 
 /* The expected traffic secrets were calculated from an independent Python implementation located in the KAT directory,
  * using the ECDHE & PQ secrets defined above. */
@@ -97,10 +153,30 @@ struct hybrid_test_vector {
 #define AES_256_X25519_KYBER512R3_CLIENT_TRAFFIC_SECRET "b929a21fae51da944f32d55976c3da4a2f612f9594f7f4fadd853cab614b3cc4c141d85b920f665eec44c6fbd47bee6b"
 #define AES_256_X25519_KYBER512R3_SERVER_TRAFFIC_SECRET "e78dbedab82db5c9fe58db87d0d5cdf031ba7e11dd0cb1c9e2bfe3615569e627142737fc31d659b423b7ebdb476d3672"
 
+#define AES_128_X25519_KYBER768R3_CLIENT_TRAFFIC_SECRET "0e00d63f0b013fe94d4d376674c0fe68b68a22ddff476429d2a8cee3de607f7c"
+#define AES_128_X25519_KYBER768R3_SERVER_TRAFFIC_SECRET "2dba3047b037e34a9bd2413b1f2d39d1071fe97fde6ab8d1be3c53eca074b7cd"
+#define AES_256_X25519_KYBER768R3_CLIENT_TRAFFIC_SECRET "84b20ee32e6df46e17b3ad035a670708acc851256ae9a579f57a8135d1f49ea9a720065f09b59b345b4c76300098a899"
+#define AES_256_X25519_KYBER768R3_SERVER_TRAFFIC_SECRET "7109a3aebf9f393d53c16480db7881b70f48d464564f08d14ee9895b29ad5c1ad612ce2b45267709b77027c9fbf94599"
+
 #define AES_128_SECP256R1_KYBER512R3_CLIENT_TRAFFIC_SECRET "f14d3873f61f422a0b59100e0b6da0a970300103a634ad444cf4ca78d3ef4fe4"
 #define AES_128_SECP256R1_KYBER512R3_SERVER_TRAFFIC_SECRET "04064ddebdbeaa7b51c15d5e919d8a31da94e6fc979fb354ffe453c15abedf3f"
 #define AES_256_SECP256R1_KYBER512R3_CLIENT_TRAFFIC_SECRET "48204afd077b9620c6220fbffa30a6de8867d6b4c96e2194cba1220b603b00850baf9dd041ef5074df86bb241023a0cd"
 #define AES_256_SECP256R1_KYBER512R3_SERVER_TRAFFIC_SECRET "f2939045fbe7b612da2e96959c64760e763f2f4ef9be049742f51061e063f89668b9acec12440e2b794352f43173243c"
+
+#define AES_128_SECP256R1_KYBER768R3_CLIENT_TRAFFIC_SECRET "7570805b40dff0c6aad5d7336e485cae75a43e6d1b7ef813102fcef3e94bb4cb"
+#define AES_128_SECP256R1_KYBER768R3_SERVER_TRAFFIC_SECRET "a0f2dda5657466d2bd2de5a0805c5bd93e48da7d3cb5eb43fabf22b67134708e"
+#define AES_256_SECP256R1_KYBER768R3_CLIENT_TRAFFIC_SECRET "b5ed2082847839f6fa9f1dd314f6723393c9c793b2190b5fd5d4c8942619388caf8397b856cf4464b2f4787da15f7e16"
+#define AES_256_SECP256R1_KYBER768R3_SERVER_TRAFFIC_SECRET "0f3d043c96e012a3563af99ce668ec943969d667340f99619aa69abf1e0b28f3589760f683644b63b578ac0954ff22ae"
+
+#define AES_128_SECP384R1_KYBER768R3_CLIENT_TRAFFIC_SECRET "ab9ebbb393aa0045da704576c82ee644e8cff724bae443ec9c0e42e07d6c8a04"
+#define AES_128_SECP384R1_KYBER768R3_SERVER_TRAFFIC_SECRET "77be795ac50035948de1ef49dd8966197e6056de4a78e563cdec0dcf586f0389"
+#define AES_256_SECP384R1_KYBER768R3_CLIENT_TRAFFIC_SECRET "9ffabbee2bede48da18b8b9104744e4eadf3c5360103fc06ffcfb97cc90160035ae0a56a4213fb2dacfae8ff5e72349d"
+#define AES_256_SECP384R1_KYBER768R3_SERVER_TRAFFIC_SECRET "ff24d13771ba73281728cf90445b1382247168163b03c87c1fdd28254b73fab6a7da6d2a5a41146c07710e44cb7057bd"
+
+#define AES_128_SECP521R1_KYBER1024R3_CLIENT_TRAFFIC_SECRET "bd1fda77b536e2f7619a6e7d186a39708e461e0079ffa2462dbe583a7359a890"
+#define AES_128_SECP521R1_KYBER1024R3_SERVER_TRAFFIC_SECRET "ee825af01207fb7935f862018f0cd083f88ab5019c8c5e7797afcab77f9fbb0e"
+#define AES_256_SECP521R1_KYBER1024R3_CLIENT_TRAFFIC_SECRET "660838cb79c4852258346112f481b75463b39aec83b961cd999741d720b18c95df0c3eabc1ec6b1505703ce1925bf396"
+#define AES_256_SECP521R1_KYBER1024R3_SERVER_TRAFFIC_SECRET "19cb80a0d66c0e616891370273b92cf700d1cf32146be6402eb3de62eab6d1ce2d259b404ff29249e8c2af6df416d503"
 
 /* A fake transcript string to hash when deriving handshake secrets */
 #define FAKE_TRANSCRIPT "client_hello || server_hello"
@@ -111,9 +187,9 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
     S2N_BLOB_FROM_HEX(secp256r1_secret, SECP256R1_SHARED_SECRET);
-
     S2N_BLOB_FROM_HEX(kyber512r3_secret, KYBER512R3_SECRET);
     S2N_BLOB_FROM_HEX(secp256r1_kyber512r3_hybrid_secret, SECP256R1_KYBER512R3_HYBRID_SECRET);
+
     S2N_BLOB_FROM_HEX(aes_128_secp256r1_kyber512r3_client_secret, AES_128_SECP256R1_KYBER512R3_CLIENT_TRAFFIC_SECRET);
     S2N_BLOB_FROM_HEX(aes_128_secp256r1_kyber512r3_server_secret, AES_128_SECP256R1_KYBER512R3_SERVER_TRAFFIC_SECRET);
 
@@ -178,7 +254,141 @@ int main(int argc, char **argv)
         .expected_client_traffic_secret = &aes_256_x25519_kyber512r3_client_secret,
         .expected_server_traffic_secret = &aes_256_x25519_kyber512r3_server_secret,
     };
+#endif
 
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+    S2N_BLOB_FROM_HEX(secp256r1_kyber768r3_hybrid_secret, SECP256R1_KYBER768R3_HYBRID_SECRET);
+
+    S2N_BLOB_FROM_HEX(secp384r1_secret, SECP384R1_SHARED_SECRET);
+    S2N_BLOB_FROM_HEX(kyber768r3_secret, KYBER768R3_SECRET);
+    S2N_BLOB_FROM_HEX(secp384r1_kyber768r3_hybrid_secret, SECP384R1_KYBER768R3_HYBRID_SECRET);
+
+    S2N_BLOB_FROM_HEX(secp521r1_secret, SECP521R1_SHARED_SECRET);
+    S2N_BLOB_FROM_HEX(kyber1024r3_secret, KYBER1024R3_SECRET);
+    S2N_BLOB_FROM_HEX(secp521r1_kyber1024r3_hybrid_secret, SECP521R1_KYBER1024R3_HYBRID_SECRET);
+
+    S2N_BLOB_FROM_HEX(aes_128_secp256r1_kyber768r3_client_secret, AES_128_SECP256R1_KYBER768R3_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_secp256r1_kyber768r3_server_secret, AES_128_SECP256R1_KYBER768R3_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_128_sha_256_secp256r1_kyber768r3_vector = {
+        .cipher_suite = &s2n_tls13_aes_128_gcm_sha256,
+        .transcript = FAKE_TRANSCRIPT,
+        .kem_group = &s2n_secp256r1_kyber_768_r3,
+        .client_ecc_key = CLIENT_SECP256R1_PRIV_KEY,
+        .server_ecc_key = SERVER_SECP256R1_PRIV_KEY,
+        .pq_secret = &kyber768r3_secret,
+        .expected_hybrid_secret = &secp256r1_kyber768r3_hybrid_secret,
+        .expected_client_traffic_secret = &aes_128_secp256r1_kyber768r3_client_secret,
+        .expected_server_traffic_secret = &aes_128_secp256r1_kyber768r3_server_secret,
+    };
+
+    S2N_BLOB_FROM_HEX(aes_256_secp256r1_kyber768r3_client_secret, AES_256_SECP256R1_KYBER768R3_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_256_secp256r1_kyber768r3_server_secret, AES_256_SECP256R1_KYBER768R3_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_256_sha_384_secp256r1_kyber768r3_vector = {
+        .cipher_suite = &s2n_tls13_aes_256_gcm_sha384,
+        .transcript = FAKE_TRANSCRIPT,
+        .kem_group = &s2n_secp256r1_kyber_768_r3,
+        .client_ecc_key = CLIENT_SECP256R1_PRIV_KEY,
+        .server_ecc_key = SERVER_SECP256R1_PRIV_KEY,
+        .pq_secret = &kyber768r3_secret,
+        .expected_hybrid_secret = &secp256r1_kyber768r3_hybrid_secret,
+        .expected_client_traffic_secret = &aes_256_secp256r1_kyber768r3_client_secret,
+        .expected_server_traffic_secret = &aes_256_secp256r1_kyber768r3_server_secret,
+    };
+
+    S2N_BLOB_FROM_HEX(aes_128_secp384r1_kyber768r3_client_secret, AES_128_SECP384R1_KYBER768R3_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_secp384r1_kyber768r3_server_secret, AES_128_SECP384R1_KYBER768R3_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_128_sha_256_secp384r1_kyber768r3_vector = {
+        .cipher_suite = &s2n_tls13_aes_128_gcm_sha256,
+        .transcript = FAKE_TRANSCRIPT,
+        .kem_group = &s2n_secp384r1_kyber_768_r3,
+        .client_ecc_key = CLIENT_SECP384R1_PRIV_KEY,
+        .server_ecc_key = SERVER_SECP384R1_PRIV_KEY,
+        .pq_secret = &kyber768r3_secret,
+        .expected_hybrid_secret = &secp384r1_kyber768r3_hybrid_secret,
+        .expected_client_traffic_secret = &aes_128_secp384r1_kyber768r3_client_secret,
+        .expected_server_traffic_secret = &aes_128_secp384r1_kyber768r3_server_secret,
+    };
+
+    S2N_BLOB_FROM_HEX(aes_256_secp384r1_kyber768r3_client_secret, AES_256_SECP384R1_KYBER768R3_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_256_secp384r1_kyber768r3_server_secret, AES_256_SECP384R1_KYBER768R3_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_256_sha_384_secp384r1_kyber768r3_vector = {
+        .cipher_suite = &s2n_tls13_aes_256_gcm_sha384,
+        .transcript = FAKE_TRANSCRIPT,
+        .kem_group = &s2n_secp384r1_kyber_768_r3,
+        .client_ecc_key = CLIENT_SECP384R1_PRIV_KEY,
+        .server_ecc_key = SERVER_SECP384R1_PRIV_KEY,
+        .pq_secret = &kyber768r3_secret,
+        .expected_hybrid_secret = &secp384r1_kyber768r3_hybrid_secret,
+        .expected_client_traffic_secret = &aes_256_secp384r1_kyber768r3_client_secret,
+        .expected_server_traffic_secret = &aes_256_secp384r1_kyber768r3_server_secret,
+    };
+
+    S2N_BLOB_FROM_HEX(aes_128_secp521r1_kyber1024r3_client_secret, AES_128_SECP521R1_KYBER1024R3_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_secp521r1_kyber1024r3_server_secret, AES_128_SECP521R1_KYBER1024R3_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_128_sha_256_secp521r1_kyber1024r3_vector = {
+        .cipher_suite = &s2n_tls13_aes_128_gcm_sha256,
+        .transcript = FAKE_TRANSCRIPT,
+        .kem_group = &s2n_secp521r1_kyber_1024_r3,
+        .client_ecc_key = CLIENT_SECP521R1_PRIV_KEY,
+        .server_ecc_key = SERVER_SECP521R1_PRIV_KEY,
+        .pq_secret = &kyber1024r3_secret,
+        .expected_hybrid_secret = &secp521r1_kyber1024r3_hybrid_secret,
+        .expected_client_traffic_secret = &aes_128_secp521r1_kyber1024r3_client_secret,
+        .expected_server_traffic_secret = &aes_128_secp521r1_kyber1024r3_server_secret,
+    };
+
+    S2N_BLOB_FROM_HEX(aes_256_secp521r1_kyber1024r3_client_secret, AES_256_SECP521R1_KYBER1024R3_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_256_secp521r1_kyber1024r3_server_secret, AES_256_SECP521R1_KYBER1024R3_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_256_sha_384_secp521r1_kyber1024r3_vector = {
+        .cipher_suite = &s2n_tls13_aes_256_gcm_sha384,
+        .transcript = FAKE_TRANSCRIPT,
+        .kem_group = &s2n_secp521r1_kyber_1024_r3,
+        .client_ecc_key = CLIENT_SECP521R1_PRIV_KEY,
+        .server_ecc_key = SERVER_SECP521R1_PRIV_KEY,
+        .pq_secret = &kyber1024r3_secret,
+        .expected_hybrid_secret = &secp521r1_kyber1024r3_hybrid_secret,
+        .expected_client_traffic_secret = &aes_256_secp521r1_kyber1024r3_client_secret,
+        .expected_server_traffic_secret = &aes_256_secp521r1_kyber1024r3_server_secret,
+    };
+#endif
+
+#if EVP_APIS_SUPPORTED && defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+    S2N_BLOB_FROM_HEX(x25519_kyber768r3_hybrid_secret, X25519_KYBER768R3_HYBRID_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_x25519_kyber768r3_client_secret, AES_128_X25519_KYBER768R3_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_128_x25519_kyber768r3_server_secret, AES_128_X25519_KYBER768R3_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_128_sha_256_x25519_kyber768r3_vector = {
+        .cipher_suite = &s2n_tls13_aes_128_gcm_sha256,
+        .transcript = FAKE_TRANSCRIPT,
+        .kem_group = &s2n_x25519_kyber_768_r3,
+        .client_ecc_key = CLIENT_X25519_PRIV_KEY,
+        .server_ecc_key = SERVER_X25519_PRIV_KEY,
+        .pq_secret = &kyber768r3_secret,
+        .expected_hybrid_secret = &x25519_kyber768r3_hybrid_secret,
+        .expected_client_traffic_secret = &aes_128_x25519_kyber768r3_client_secret,
+        .expected_server_traffic_secret = &aes_128_x25519_kyber768r3_server_secret,
+    };
+
+    S2N_BLOB_FROM_HEX(aes_256_x25519_kyber768r3_client_secret, AES_256_X25519_KYBER768R3_CLIENT_TRAFFIC_SECRET);
+    S2N_BLOB_FROM_HEX(aes_256_x25519_kyber768r3_server_secret, AES_256_X25519_KYBER768R3_SERVER_TRAFFIC_SECRET);
+
+    const struct hybrid_test_vector aes_256_sha_384_x25519_kyber768r3_vector = {
+        .cipher_suite = &s2n_tls13_aes_256_gcm_sha384,
+        .transcript = FAKE_TRANSCRIPT,
+        .kem_group = &s2n_x25519_kyber_768_r3,
+        .client_ecc_key = CLIENT_X25519_PRIV_KEY,
+        .server_ecc_key = SERVER_X25519_PRIV_KEY,
+        .pq_secret = &kyber768r3_secret,
+        .expected_hybrid_secret = &x25519_kyber768r3_hybrid_secret,
+        .expected_client_traffic_secret = &aes_256_x25519_kyber768r3_client_secret,
+        .expected_server_traffic_secret = &aes_256_x25519_kyber768r3_server_secret,
+    };
 #endif
 
     const struct hybrid_test_vector *all_test_vectors[] = {
@@ -187,6 +397,18 @@ int main(int argc, char **argv)
 #if EVP_APIS_SUPPORTED
         &aes_128_sha_256_x25519_kyber512r3_vector,
         &aes_256_sha_384_x25519_kyber512r3_vector,
+#endif
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+        &aes_128_sha_256_secp256r1_kyber768r3_vector,
+        &aes_256_sha_384_secp256r1_kyber768r3_vector,
+        &aes_128_sha_256_secp384r1_kyber768r3_vector,
+        &aes_256_sha_384_secp384r1_kyber768r3_vector,
+        &aes_128_sha_256_secp521r1_kyber1024r3_vector,
+        &aes_256_sha_384_secp521r1_kyber1024r3_vector,
+#endif
+#if EVP_APIS_SUPPORTED && defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+        &aes_128_sha_256_x25519_kyber768r3_vector,
+        &aes_256_sha_384_x25519_kyber768r3_vector,
 #endif
     };
 

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -412,10 +412,7 @@ int main(int argc, char **argv)
 #endif
     };
 
-    /*
-     * TODO: uncomment line below once Kyber768+ test vectors have been added
-     * EXPECT_EQUAL(s2n_array_len(all_test_vectors), (2 * S2N_SUPPORTED_KEM_GROUPS_COUNT));
-     */
+     EXPECT_EQUAL(s2n_array_len(all_test_vectors), (2 * S2N_SUPPORTED_KEM_GROUPS_COUNT));
 
     {
         /* Happy cases for computing the hybrid shared secret and client & server traffic secrets */

--- a/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_shared_secret_test.c
@@ -412,7 +412,7 @@ int main(int argc, char **argv)
 #endif
     };
 
-     EXPECT_EQUAL(s2n_array_len(all_test_vectors), (2 * S2N_SUPPORTED_KEM_GROUPS_COUNT));
+    EXPECT_EQUAL(s2n_array_len(all_test_vectors), (2 * S2N_SUPPORTED_KEM_GROUPS_COUNT));
 
     {
         /* Happy cases for computing the hybrid shared secret and client & server traffic secrets */

--- a/tests/unit/s2n_tls13_pq_handshake_test.c
+++ b/tests/unit/s2n_tls13_pq_handshake_test.c
@@ -579,11 +579,13 @@ int main()
         bool len_prefix_expected = vector->len_prefix_expected;
 
         if (!s2n_pq_is_enabled()) {
-            /* If PQ is disabled, for older policies we expect to negotiate x25519 if available.
-             * For newer policies, we always expect to negotiate NIST curves on ECC-only fallback.
+            /* If PQ is disabled, for older policies we expect to negotiate
+             * x25519 ECDH if available.  Newer policies only include NIST
+             * curves, so if the server policy doesn't contain x25519, modify
+             * that expectation to a NIST curve.
              */
             kem_group = NULL;
-            if (server_policy == &security_policy_pq_tls_1_3_2023_06_01) {
+            if (!s2n_ecc_preferences_includes_curve(server_policy->ecc_preferences, expected_curve->iana_id)) {
                 curve = &s2n_ecc_curve_secp256r1;
             } else {
                 curve = expected_curve;

--- a/tests/unit/s2n_tls13_pq_handshake_test.c
+++ b/tests/unit/s2n_tls13_pq_handshake_test.c
@@ -237,6 +237,14 @@ int main()
         &s2n_x25519_kyber_512_r3,
 #endif
         &s2n_secp256r1_kyber_512_r3,
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+        &s2n_secp256r1_kyber_768_r3,
+        &s2n_secp384r1_kyber_768_r3,
+        &s2n_secp521r1_kyber_1024_r3,
+#endif
+#if EVP_APIS_SUPPORTED && defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+        &s2n_x25519_kyber_768_r3,
+#endif
     };
 
     const struct s2n_kem_preferences kyber_test_prefs_draft0 = {
@@ -269,6 +277,52 @@ int main()
         .kem_preferences = &kyber_test_prefs_draft5,
         .signature_preferences = &s2n_signature_preferences_20200207,
         .ecc_preferences = &s2n_ecc_preferences_20200310,
+    };
+
+    const struct s2n_kem_group *kyber768_test_kem_groups[] = {
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+        &s2n_secp384r1_kyber_768_r3,
+#endif
+        &s2n_secp256r1_kyber_512_r3,
+    };
+
+    const struct s2n_kem_preferences kyber768_test_prefs = {
+        .kem_count = 0,
+        .kems = NULL,
+        .tls13_kem_group_count = s2n_array_len(kyber768_test_kem_groups),
+        .tls13_kem_groups = kyber768_test_kem_groups,
+        .tls13_pq_hybrid_draft_revision = 5,
+    };
+
+    const struct s2n_security_policy kyber768_test_policy = {
+        .minimum_protocol_version = S2N_TLS13,
+        .cipher_preferences = &cipher_preferences_20190801,
+        .kem_preferences = &kyber768_test_prefs,
+        .signature_preferences = &s2n_signature_preferences_20200207,
+        .ecc_preferences = &s2n_ecc_preferences_20201021,
+    };
+
+    const struct s2n_kem_group *kyber1024_test_kem_groups[] = {
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+        &s2n_secp521r1_kyber_1024_r3,
+#endif
+        &s2n_secp256r1_kyber_512_r3,
+    };
+
+    const struct s2n_kem_preferences kyber1024_test_prefs = {
+        .kem_count = 0,
+        .kems = NULL,
+        .tls13_kem_group_count = s2n_array_len(kyber1024_test_kem_groups),
+        .tls13_kem_groups = kyber1024_test_kem_groups,
+        .tls13_pq_hybrid_draft_revision = 5,
+    };
+
+    const struct s2n_security_policy kyber1024_test_policy = {
+        .minimum_protocol_version = S2N_TLS13,
+        .cipher_preferences = &cipher_preferences_20190801,
+        .kem_preferences = &kyber1024_test_prefs,
+        .signature_preferences = &s2n_signature_preferences_20200207,
+        .ecc_preferences = &s2n_ecc_preferences_20201021,
     };
 
     const struct s2n_security_policy ecc_retry_policy = {
@@ -349,7 +403,58 @@ int main()
                 .hrr_expected = false,
                 .len_prefix_expected = false,
         },
-
+        /* Kyber768 should be preferred over 1024, which should be preferred over 512
+         * when available. Note that nlike older KEM group preferences, 2023_06_01
+         * prefers secp256r1 over x25519 for the hybrid EC.
+         */
+        {
+                .client_policy = &security_policy_pq_tls_1_3_2023_06_01,
+                .server_policy = &security_policy_pq_tls_1_3_2023_06_01,
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+                .expected_kem_group = &s2n_secp256r1_kyber_768_r3,
+#else
+                .expected_kem_group = &s2n_secp256r1_kyber_512_r3,
+#endif
+                .expected_curve = NULL,
+                .hrr_expected = false,
+                .len_prefix_expected = false,
+        },
+        {
+                .client_policy = &kyber1024_test_policy,
+                .server_policy = &security_policy_pq_tls_1_3_2023_06_01,
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+                .expected_kem_group = &s2n_secp521r1_kyber_1024_r3,
+#else
+                .expected_kem_group = &s2n_secp256r1_kyber_512_r3,
+#endif
+                .expected_curve = NULL,
+                .hrr_expected = false,
+                .len_prefix_expected = false,
+        },
+        {
+                .client_policy = &kyber768_test_policy,
+                .server_policy = &security_policy_pq_tls_1_3_2023_06_01,
+#if defined(S2N_LIBCRYPTO_SUPPORTS_KYBER)
+                .expected_kem_group = &s2n_secp384r1_kyber_768_r3,
+#else
+                .expected_kem_group = &s2n_secp256r1_kyber_512_r3,
+#endif
+                .expected_curve = NULL,
+                .hrr_expected = false,
+                .len_prefix_expected = false,
+        },
+        /* Server supports Kyber768+ parameters, Client only supports Kyber512.
+         * Expect Kyber512 to be negotiated if PQ is enabled, else fall back to
+         * ECC on hello retry.
+         */
+        {
+                .client_policy = &security_policy_pq_tls_1_1_2021_05_21,
+                .server_policy = &security_policy_pq_tls_1_3_2023_06_01,
+                .expected_kem_group = expected_kyber_r3_group,
+                .expected_curve = NULL,
+                .hrr_expected = !s2n_pq_is_enabled(),
+                .len_prefix_expected = true,
+        },
         /* Check that we're backwards and forwards compatible with different Hybrid PQ draft revisions*/
         {
                 .client_policy = &kyber_test_policy_draft0,
@@ -474,9 +579,15 @@ int main()
         bool len_prefix_expected = vector->len_prefix_expected;
 
         if (!s2n_pq_is_enabled()) {
-            /* If PQ is disabled, we always expected to negotiate ECC. */
+            /* If PQ is disabled, for older policies we expect to negotiate x25519 if available.
+             * For newer policies, we always expect to negotiate NIST curves on ECC-only fallback.
+             */
             kem_group = NULL;
-            curve = expected_curve;
+            if (server_policy == &security_policy_pq_tls_1_3_2023_06_01) {
+                curve = &s2n_ecc_curve_secp256r1;
+            } else {
+                curve = expected_curve;
+            }
         }
 
         EXPECT_SUCCESS(s2n_test_tls13_pq_handshake(client_policy, server_policy, kem_group, curve, hrr_expected, len_prefix_expected));

--- a/tests/unit/s2n_tls13_pq_handshake_test.c
+++ b/tests/unit/s2n_tls13_pq_handshake_test.c
@@ -404,7 +404,7 @@ int main()
                 .len_prefix_expected = false,
         },
         /* Kyber768 should be preferred over 1024, which should be preferred over 512
-         * when available. Note that nlike older KEM group preferences, 2023_06_01
+         * when available. Note that unlike older KEM group preferences, 2023_06_01
          * prefers secp256r1 over x25519 for the hybrid EC.
          */
         {


### PR DESCRIPTION
# Notes

This PR is the the third out of a ~3~4-part series adding support for a new security policy featuring Kyber768+ PQ key exchange:

1. PR #4087
1. PR #4034 
1. PR #4089
1. PR #4101

# Status

_DRAFT_ pending merge of preceding PR(s) in the series.

---

I believe that the change is code complete, but I'm waiting until I've compiled benchmarking data before publishing. In the meantime, please do feel free to review, particularly with an eye towards test cases I may have missed.