### PR TITLE
Refactor HMAC into impl functions

### DIFF
--- a/crypto/s2n_hmac.h
+++ b/crypto/s2n_hmac.h
@@ -67,7 +67,7 @@ int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out);
 
 int s2n_hmac_new(struct s2n_hmac_state *state);
 S2N_RESULT s2n_hmac_state_validate(struct s2n_hmac_state *state);
-int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen);
+int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t key_len);
 int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size);
 int s2n_hmac_digest(struct s2n_hmac_state *state, void *out, uint32_t size);
 int s2n_hmac_digest_two_compression_rounds(struct s2n_hmac_state *state, void *out, uint32_t size);

--- a/tests/saw/failure_tests/sha_bad_magic_mod.patch
+++ b/tests/saw/failure_tests/sha_bad_magic_mod.patch
@@ -2,21 +2,21 @@ diff --git a/crypto/s2n_hmac.c b/crypto/s2n_hmac.c
 index 29ded952..f7a24a01 100644
 --- a/crypto/s2n_hmac.c
 +++ b/crypto/s2n_hmac.c
-@@ -266,8 +266,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
+@@ -244,8 +244,7 @@ static S2N_RESULT s2n_hmac_update_impl(struct s2n_hmac_state *state, const void
       * input. On some platforms, including Intel, the operation can take a
       * smaller number of cycles if the input is "small".
       */
 -    const uint32_t HIGHEST_32_BIT = 4294949760;
--    POSIX_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
+-    RESULT_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
 +    const uint32_t HIGHEST_32_BIT = 4294949761;
      uint32_t value = (HIGHEST_32_BIT + size) % state->hash_block_size;
-     POSIX_GUARD(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
+     RESULT_GUARD_POSIX(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
      state->currently_in_hash_block %= state->hash_block_size;
 diff --git a/utils/s2n_safety.c b/utils/s2n_safety.c
 index b26e2d9c..e662c8da 100644
 --- a/utils/s2n_safety.c
 +++ b/utils/s2n_safety.c
-@@ -198,7 +198,6 @@ int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out)
+@@ -211,7 +211,6 @@ int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t *out)
  {
      POSIX_ENSURE_REF(out);
      uint64_t result = ((uint64_t) a) + ((uint64_t) b);

--- a/tests/sidetrail/DEBUGGING.md
+++ b/tests/sidetrail/DEBUGGING.md
@@ -249,7 +249,7 @@ so bumping `__VERIFIER_ASSERT_MAX_LEAKAGE` up to `100` resolved the issue.
 | Test name                         | Runtime | 
 | --------------------------------- |--------:|
 | s2n-record-read-cbc-negative-test |     30s |
-| s2n-cbc                           |     35m |
+| s2n-cbc                           |     41m |
 | s2n-record-read-aead              |     30s |
 | s2n-record-read-cbc               |     20s |
 | s2n-record-read-composite         |     15s |

--- a/tests/sidetrail/DEBUGGING.md
+++ b/tests/sidetrail/DEBUGGING.md
@@ -247,11 +247,11 @@ so bumping `__VERIFIER_ASSERT_MAX_LEAKAGE` up to `100` resolved the issue.
 ## Expected runtimes:
 
 | Test name                         | Runtime | 
-| --------------------------------- | ------: |
-| s2n-record-read-cbc-negative-test | 20s     |
-| s2n-cbc                           | 5m 45s  |
-| s2n-record-read-composite         | 15s     |
-| s2n-record-read-aead              | 4m 10s  |
-| s2n-record-read-stream            | 25s     |
-| s2n-record-read-cbc               | 20s     |
+| --------------------------------- |--------:|
+| s2n-record-read-cbc-negative-test |     30s |
+| s2n-cbc                           |     35m |
+| s2n-record-read-aead              |     30s |
+| s2n-record-read-cbc               |     20s |
+| s2n-record-read-composite         |     15s |
+| s2n-record-read-stream            |  1m 30s |
 

--- a/tests/sidetrail/working/patches/hmac.patch
+++ b/tests/sidetrail/working/patches/hmac.patch
@@ -12,7 +12,7 @@ index 3405781..3beeacf 100644
  #include <stdint.h>
  
  int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
-@@ -246,7 +249,7 @@ static S2N_RESULT s2n_hmac_update_impl(struct s2n_hmac_state *state, const void
+@@ -268,7 +271,7 @@ static S2N_RESULT s2n_hmac_update_impl(struct s2n_hmac_state *state, const void
       */
      const uint32_t HIGHEST_32_BIT = 4294949760;
      RESULT_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
@@ -21,7 +21,7 @@ index 3405781..3beeacf 100644
      RESULT_GUARD_POSIX(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
      state->currently_in_hash_block %= state->hash_block_size;
  
-@@ -299,8 +302,8 @@ static S2N_RESULT s2n_hmac_copy_impl(struct s2n_hmac_state *to, struct s2n_hmac_
+@@ -333,8 +336,8 @@ static S2N_RESULT s2n_hmac_copy_impl(struct s2n_hmac_state *to, struct s2n_hmac_
      RESULT_GUARD_POSIX(s2n_hash_copy(&to->outer, &from->outer));
      RESULT_GUARD_POSIX(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
  
@@ -32,7 +32,7 @@ index 3405781..3beeacf 100644
  
      return S2N_RESULT_OK;
  }
-@@ -422,28 +425,28 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+@@ -440,28 +443,28 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
  /* Preserve the handlers for hmac state pointers to avoid re-allocation
   * Only valid if the HMAC is in EVP mode
   */

--- a/tests/sidetrail/working/patches/hmac.patch
+++ b/tests/sidetrail/working/patches/hmac.patch
@@ -5,34 +5,34 @@ index 3405781..3beeacf 100644
 @@ -28,6 +28,9 @@
  #include "utils/s2n_blob.h"
  #include "utils/s2n_mem.h"
-
+ 
 +#include "smack.h"
 +#include "sidetrail.h"
 +
  #include <stdint.h>
-
+ 
  int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
-@@ -270,7 +273,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
+@@ -246,7 +249,7 @@ static S2N_RESULT s2n_hmac_update_impl(struct s2n_hmac_state *state, const void
       */
      const uint32_t HIGHEST_32_BIT = 4294949760;
-     POSIX_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
+     RESULT_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
 -    uint32_t value = (HIGHEST_32_BIT + size) % state->hash_block_size;
 +    uint32_t value = (size) % state->hash_block_size;
-     POSIX_GUARD(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
+     RESULT_GUARD_POSIX(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
      state->currently_in_hash_block %= state->hash_block_size;
-
-@@ -363,8 +366,8 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
-     POSIX_GUARD(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
-
-
--    POSIX_CHECKED_MEMCPY(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
--    POSIX_CHECKED_MEMCPY(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
-+    //POSIX_CHECKED_MEMCPY(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
-+    //POSIX_CHECKED_MEMCPY(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
-     POSIX_POSTCONDITION(s2n_hmac_state_validate(to));
-     POSIX_POSTCONDITION(s2n_hmac_state_validate(from));
-     return S2N_SUCCESS;
-@@ -374,28 +377,28 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+ 
+@@ -299,8 +302,8 @@ static S2N_RESULT s2n_hmac_copy_impl(struct s2n_hmac_state *to, struct s2n_hmac_
+     RESULT_GUARD_POSIX(s2n_hash_copy(&to->outer, &from->outer));
+     RESULT_GUARD_POSIX(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
+ 
+-    RESULT_CHECKED_MEMCPY(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
+-    RESULT_CHECKED_MEMCPY(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
++//    RESULT_CHECKED_MEMCPY(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
++//    RESULT_CHECKED_MEMCPY(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
+ 
+     return S2N_RESULT_OK;
+ }
+@@ -422,28 +425,28 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
  /* Preserve the handlers for hmac state pointers to avoid re-allocation
   * Only valid if the HMAC is in EVP mode
   */
@@ -58,29 +58,29 @@ index 3405781..3beeacf 100644
 -    POSIX_POSTCONDITION(s2n_hmac_state_validate(hmac));
 -    return S2N_SUCCESS;
 -}
-+// int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
-+// {
-+//     POSIX_ENSURE_REF(backup);
-+//     POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
-+//     backup->inner = hmac->inner.digest.high_level;
-+//     backup->inner_just_key = hmac->inner_just_key.digest.high_level;
-+//     backup->outer = hmac->outer.digest.high_level;
-+//     backup->outer_just_key = hmac->outer_just_key.digest.high_level;
-+//     return S2N_SUCCESS;
-+// }
++//int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
++//{
++//    POSIX_ENSURE_REF(backup);
++//    POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
++//    backup->inner = hmac->inner.digest.high_level;
++//    backup->inner_just_key = hmac->inner_just_key.digest.high_level;
++//    backup->outer = hmac->outer.digest.high_level;
++//    backup->outer_just_key = hmac->outer_just_key.digest.high_level;
++//    return S2N_SUCCESS;
++//}
 +//
-+// int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
-+// {
-+//     POSIX_ENSURE_REF(backup);
-+//     POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
-+//     hmac->inner.digest.high_level = backup->inner;
-+//     hmac->inner_just_key.digest.high_level = backup->inner_just_key;
-+//     hmac->outer.digest.high_level = backup->outer;
-+//     hmac->outer_just_key.digest.high_level = backup->outer_just_key;
-+//     POSIX_POSTCONDITION(s2n_hmac_state_validate(hmac));
-+//     return S2N_SUCCESS;
-+// }
-
++//int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
++//{
++//    POSIX_ENSURE_REF(backup);
++//    POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
++//    hmac->inner.digest.high_level = backup->inner;
++//    hmac->inner_just_key.digest.high_level = backup->inner_just_key;
++//    hmac->outer.digest.high_level = backup->outer;
++//    hmac->outer_just_key.digest.high_level = backup->outer_just_key;
++//    POSIX_POSTCONDITION(s2n_hmac_state_validate(hmac));
++//    return S2N_SUCCESS;
++//}
+ 
  S2N_RESULT s2n_hmac_md_from_alg(s2n_hmac_algorithm alg, const EVP_MD **md)
  {
 diff --git a/tests/sidetrail/working/s2n-cbc/crypto/s2n_hmac.h b/tests/sidetrail/working/s2n-cbc/crypto/s2n_hmac.h
@@ -90,20 +90,20 @@ index 7af7e61..e6382ce 100644
 @@ -53,12 +53,12 @@ struct s2n_hmac_state {
      uint8_t digest_pad[SHA512_DIGEST_LENGTH];
  };
-
+ 
 -struct s2n_hmac_evp_backup {
 -    struct s2n_hash_evp_digest inner;
 -    struct s2n_hash_evp_digest inner_just_key;
 -    struct s2n_hash_evp_digest outer;
 -    struct s2n_hash_evp_digest outer_just_key;
 -};
-+/* struct s2n_hmac_evp_backup { */
-+/*     struct s2n_hash_evp_digest inner; */
-+/*     struct s2n_hash_evp_digest inner_just_key; */
-+/*     struct s2n_hash_evp_digest outer; */
-+/*     struct s2n_hash_evp_digest outer_just_key; */
-+/* }; */
-
++//struct s2n_hmac_evp_backup {
++//    struct s2n_hash_evp_digest inner;
++//    struct s2n_hash_evp_digest inner_just_key;
++//    struct s2n_hash_evp_digest outer;
++//    struct s2n_hash_evp_digest outer_just_key;
++//};
+ 
  int s2n_hmac_digest_size(s2n_hmac_algorithm alg, uint8_t *out);
  bool s2n_hmac_is_available(s2n_hmac_algorithm alg);
 @@ -75,7 +75,7 @@ int s2n_hmac_digest_verify(const void *a, const void *b, uint32_t len);
@@ -114,5 +114,5 @@ index 7af7e61..e6382ce 100644
 -int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
 +//int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
 +//int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
-
+ 
  S2N_RESULT s2n_hmac_md_from_alg(s2n_hmac_algorithm alg, const EVP_MD **md);


### PR DESCRIPTION
### Description of changes: 

This PR refactors the HMAC implementation into impl functions in preparation for my next PR, which will add the libcrypto HMAC implementation in addition to our custom one. Having impl functions for each of the HMAC APIs will allow for there to be custom impl functions and libcrypto impl functions, and each HMAC API will call the correct implementation based on what mode it's in.

Originally, I wanted to define an implementation struct which would contain function pointers to a specific HMAC implementation (custom or libcrypto):
```
struct s2n_hmac_impl {
    S2N_RESULT (*init)(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, const void *key, uint32_t klen);
    S2N_RESULT (*update)(struct s2n_hmac_state *hmac, const void *data, uint32_t size);
    ...
};
```

However, sidetrail did not like this implementation struct, and proofs were failing after defining it, even if it wasn't used in the code. Instead, I plan to call the correct implementation with if statements in each HMAC API like this:
```
int s2n_hmac_digest(struct s2n_hmac_state *state, void *out, uint32_t size) {
    if (state->impl_type == S2N_HMAC_CUSTOM_IMPL) {
        s2n_hmac_digest_custom(state, out, len);
    else {
        s2n_hmac_digest_libcrypto(state, out, len);
    }
}
```

### Call-outs:

- No functionality should change as a result of this PR.
- This PR slows down sidetrail (specifically the `s2n-cbc` test) by ~5x. Previously, sidetrail finished in ~10 minutes. Now, sidetrail finishes in ~50 minutes. The performance issue is due to adding an additional nested function call to each of the HMAC APIs. To avoid this, we'd have to put both the custom implementation and the libcrypto implementation into the same functions, which doesn't seem worth it.
  - Related to this: I updated the sidetrail documentation that lists the expected proof runtimes. The time for `s2n-record-read-aead` was listed as ~4 minutes, and I timed this to be ~30 seconds, which seemed odd since it improved. However, I checked [a sidetrail run without these changes](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nGeneralBatch/build/s2nGeneralBatch%3A26d54c84-0dcc-434d-88db-812715b4474d/log?region=us-west-2) and it was also ~30 seconds, so I think it was just listed incorrectly.

### Testing:

Existing HMAC tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
