### PR TITLE
Fix clippy warnings

### DIFF
--- a/bindings/rust/s2n-tls-tokio/src/lib.rs
+++ b/bindings/rust/s2n-tls-tokio/src/lib.rs
@@ -264,7 +264,7 @@ where
         self: Pin<&mut Self>,
         mut remembered_error: Result<(), Error>,
     ) -> Result<(), Error> {
-        let mut tls = self.get_mut();
+        let tls = self.get_mut();
 
         if tls.blinding.is_none() {
             let delay = tls.as_ref().remaining_blinding_delay()?;

--- a/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
+++ b/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
@@ -309,10 +309,9 @@ mod tests {
     #[test]
     fn failing_client_hello_callback_sync() -> Result<(), Error> {
         let (waker, wake_count) = new_count_waker();
-        let handle = FailingCHHandler::default();
         let config = {
             let mut config = config_builder(&security::DEFAULT_TLS13)?;
-            config.set_client_hello_callback(handle)?;
+            config.set_client_hello_callback(FailingCHHandler)?;
             config.build()?
         };
 
@@ -359,10 +358,9 @@ mod tests {
     #[test]
     fn failing_client_hello_callback_async() -> Result<(), Error> {
         let (waker, wake_count) = new_count_waker();
-        let handle = FailingAsyncCHHandler::default();
         let config = {
             let mut config = config_builder(&security::DEFAULT_TLS13)?;
-            config.set_client_hello_callback(handle)?;
+            config.set_client_hello_callback(FailingAsyncCHHandler)?;
             config.build()?
         };
 


### PR DESCRIPTION
# Notes

This commit fixes some recent clippy linting failures. Before this change:

```
$ cargo clippy --manifest-path bindings/rust/Cargo.toml --all-targets -- -D warnings
...
 error: variable does not need to be mutable
Error:    --> s2n-tls-tokio/src/lib.rs:267:13
    |
267 |         let mut tls = self.get_mut();
    |             ----^^^
    |             |
    |             help: remove this `mut`
    |
    = note: `-D unused-mut` implied by `-D warnings`

error: could not compile `s2n-tls-tokio` (lib) due to previous error
Error: warning: build failed, waiting for other jobs to finish...
error: use of `default` to create a unit struct
Error:    --> s2n-tls/src/testing/s2n_tls.rs:312:38
    |
312 |         let handle = FailingCHHandler::default();
    |                                      ^^^^^^^^^^^ help: remove this call to `default`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#default_constructed_unit_structs
    = note: `-D clippy::default-constructed-unit-structs` implied by `-D warnings`

error: use of `default` to create a unit struct
Error:    --> s2n-tls/src/testing/s2n_tls.rs:362:43
    |
362 |         let handle = FailingAsyncCHHandler::default();
    |                                           ^^^^^^^^^^^ help: remove this call to `default`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#default_constructed_unit_structs

error: could not compile `s2n-tls` (lib test) due to 2 previous errors
Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
