### PR TITLE
Remove unused libcrypto HMAC code from s2n_prf

### DIFF
--- a/crypto/s2n_evp.h
+++ b/crypto/s2n_evp.h
@@ -26,14 +26,6 @@ struct s2n_evp_digest {
     EVP_MD_CTX *ctx;
 };
 
-struct s2n_evp_hmac_state {
-    struct s2n_evp_digest evp_digest;
-    union {
-        HMAC_CTX *hmac_ctx;
-        EVP_PKEY *evp_pkey;
-    } ctx;
-};
-
 /* Define API's that change based on the OpenSSL Major Version. */
 #if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0) && !defined(LIBRESSL_VERSION_NUMBER)
     #define S2N_EVP_MD_CTX_NEW()         (EVP_MD_CTX_new())

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -79,11 +79,11 @@ int s2n_hmac_digest_size(s2n_hmac_algorithm hmac_alg, uint8_t *out)
 bool s2n_hmac_is_available(s2n_hmac_algorithm hmac_alg)
 {
     switch(hmac_alg) {
-    case S2N_HMAC_MD5:
     case S2N_HMAC_SSLv3_MD5:
     case S2N_HMAC_SSLv3_SHA1:
         /* Set is_available to 0 if in FIPS mode, as MD5/SSLv3 algs are not available in FIPS mode. */
         return !s2n_is_in_fips_mode();
+    case S2N_HMAC_MD5:
     case S2N_HMAC_NONE:
     case S2N_HMAC_SHA1:
     case S2N_HMAC_SHA224:
@@ -198,6 +198,18 @@ S2N_RESULT s2n_hmac_state_validate(struct s2n_hmac_state *state)
     RESULT_GUARD(s2n_hash_state_validate(&state->outer));
     RESULT_GUARD(s2n_hash_state_validate(&state->outer_just_key));
     return S2N_RESULT_OK;
+}
+
+int s2n_hmac_allow_md5_for_fips(struct s2n_hmac_state *state)
+{
+    POSIX_ENSURE_REF(state);
+
+    POSIX_GUARD(s2n_hash_allow_md5_for_fips(&state->inner));
+    POSIX_GUARD(s2n_hash_allow_md5_for_fips(&state->inner_just_key));
+    POSIX_GUARD(s2n_hash_allow_md5_for_fips(&state->outer));
+    POSIX_GUARD(s2n_hash_allow_md5_for_fips(&state->outer_just_key));
+
+    return S2N_SUCCESS;
 }
 
 int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen)

--- a/crypto/s2n_hmac.h
+++ b/crypto/s2n_hmac.h
@@ -67,6 +67,7 @@ int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out);
 
 int s2n_hmac_new(struct s2n_hmac_state *state);
 S2N_RESULT s2n_hmac_state_validate(struct s2n_hmac_state *state);
+int s2n_hmac_allow_md5_for_fips(struct s2n_hmac_state *state);
 int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen);
 int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size);
 int s2n_hmac_digest(struct s2n_hmac_state *state, void *out, uint32_t size);

--- a/tests/sidetrail/working/patches/hmac.patch
+++ b/tests/sidetrail/working/patches/hmac.patch
@@ -12,7 +12,7 @@ index 3405781..3beeacf 100644
  #include <stdint.h>
 
  int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
-@@ -270,7 +273,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
+@@ -282,7 +285,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
       */
      const uint32_t HIGHEST_32_BIT = 4294949760;
      POSIX_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
@@ -21,7 +21,7 @@ index 3405781..3beeacf 100644
      POSIX_GUARD(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
      state->currently_in_hash_block %= state->hash_block_size;
 
-@@ -363,8 +366,8 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+@@ -375,8 +378,8 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
      POSIX_GUARD(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
 
 
@@ -32,7 +32,7 @@ index 3405781..3beeacf 100644
      POSIX_POSTCONDITION(s2n_hmac_state_validate(to));
      POSIX_POSTCONDITION(s2n_hmac_state_validate(from));
      return S2N_SUCCESS;
-@@ -374,28 +377,28 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+@@ -386,28 +389,28 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
  /* Preserve the handlers for hmac state pointers to avoid re-allocation
   * Only valid if the HMAC is in EVP mode
   */

--- a/tests/sidetrail/working/s2n-cbc/stubs/s2n_hash.c
+++ b/tests/sidetrail/working/s2n-cbc/stubs/s2n_hash.c
@@ -49,6 +49,11 @@ S2N_RESULT s2n_hash_state_validate(struct s2n_hash_state *state)
     return S2N_RESULT_OK;
 }
 
+int s2n_hash_allow_md5_for_fips(struct s2n_hash_state *state)
+{
+    return SUCCESS;
+}
+
 int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 {
   __VERIFIER_ASSUME_LEAKAGE(0);

--- a/tests/sidetrail/working/stubs/s2n_hash.c
+++ b/tests/sidetrail/working/stubs/s2n_hash.c
@@ -49,6 +49,11 @@ S2N_RESULT s2n_hash_state_validate(struct s2n_hash_state *state)
     return S2N_RESULT_OK;
 }
 
+int s2n_hash_allow_md5_for_fips(struct s2n_hash_state *state)
+{
+    return SUCCESS;
+}
+
 int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 {
   __VERIFIER_ASSUME_LEAKAGE(0);

--- a/tests/unit/s2n_hmac_test.c
+++ b/tests/unit/s2n_hmac_test.c
@@ -118,6 +118,9 @@ int main(int argc, char **argv)
         uint8_t hmac_md5_size;
         POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_MD5, &hmac_md5_size));
         EXPECT_EQUAL(hmac_md5_size, 16);
+        if (s2n_is_in_fips_mode()) {
+            EXPECT_SUCCESS(s2n_hmac_allow_md5_for_fips(&hmac));
+        }
         EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_MD5, sekrit, strlen((char *) sekrit)));
         EXPECT_SUCCESS(s2n_hmac_update(&hmac, hello, strlen((char *) hello)));
         EXPECT_SUCCESS(s2n_hmac_digest(&hmac, digest_pad, 16));

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -177,278 +177,46 @@ static int s2n_sslv3_prf(struct s2n_connection *conn, struct s2n_blob *secret, s
     return 0;
 }
 
-#if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
-static int s2n_evp_pkey_p_hash_alloc(struct s2n_prf_working_space *ws)
-{
-    POSIX_ENSURE_REF(ws->p_hash.evp_hmac.evp_digest.ctx = S2N_EVP_MD_CTX_NEW());
-    return 0;
-}
-
-static int s2n_evp_pkey_p_hash_digest_init(struct s2n_prf_working_space *ws)
-{
-    POSIX_ENSURE_REF(ws->p_hash.evp_hmac.evp_digest.md);
-    POSIX_ENSURE_REF(ws->p_hash.evp_hmac.evp_digest.ctx);
-    POSIX_ENSURE_REF(ws->p_hash.evp_hmac.ctx.evp_pkey);
-
-    /* Ignore the MD5 check when in FIPS mode to comply with the TLS 1.0 RFC */
-    if (s2n_is_in_fips_mode()) {
-        POSIX_GUARD(s2n_digest_allow_md5_for_fips(&ws->p_hash.evp_hmac.evp_digest));
-    }
-
-    POSIX_GUARD_OSSL(EVP_DigestSignInit(ws->p_hash.evp_hmac.evp_digest.ctx, NULL, ws->p_hash.evp_hmac.evp_digest.md, NULL, ws->p_hash.evp_hmac.ctx.evp_pkey),
-            S2N_ERR_P_HASH_INIT_FAILED);
-
-    return 0;
-}
-
-static int s2n_evp_pkey_p_hash_init(struct s2n_prf_working_space *ws, s2n_hmac_algorithm alg, struct s2n_blob *secret)
-{
-    /* Initialize the message digest */
-    POSIX_GUARD_RESULT(s2n_hmac_md_from_alg(alg, &ws->p_hash.evp_hmac.evp_digest.md));
-
-    /* Initialize the mac key using the provided secret */
-    POSIX_ENSURE_REF(ws->p_hash.evp_hmac.ctx.evp_pkey = EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL, secret->data, secret->size));
-
-    /* Initialize the message digest context with the above message digest and mac key */
-    return s2n_evp_pkey_p_hash_digest_init(ws);
-}
-
-static int s2n_evp_pkey_p_hash_update(struct s2n_prf_working_space *ws, const void *data, uint32_t size)
-{
-    POSIX_GUARD_OSSL(EVP_DigestSignUpdate(ws->p_hash.evp_hmac.evp_digest.ctx, data, (size_t) size), S2N_ERR_P_HASH_UPDATE_FAILED);
-
-    return 0;
-}
-
-static int s2n_evp_pkey_p_hash_final(struct s2n_prf_working_space *ws, void *digest, uint32_t size)
-{
-    /* EVP_DigestSign API's require size_t data structures */
-    size_t digest_size = size;
-
-    POSIX_GUARD_OSSL(EVP_DigestSignFinal(ws->p_hash.evp_hmac.evp_digest.ctx, (unsigned char *) digest, &digest_size), S2N_ERR_P_HASH_FINAL_FAILED);
-
-    return 0;
-}
-
-static int s2n_evp_pkey_p_hash_wipe(struct s2n_prf_working_space *ws)
-{
-    POSIX_GUARD_OSSL(S2N_EVP_MD_CTX_RESET(ws->p_hash.evp_hmac.evp_digest.ctx), S2N_ERR_P_HASH_WIPE_FAILED);
-
-    return 0;
-}
-
-static int s2n_evp_pkey_p_hash_reset(struct s2n_prf_working_space *ws)
-{
-    POSIX_GUARD(s2n_evp_pkey_p_hash_wipe(ws));
-
-    /*
-     * On some cleanup paths s2n_evp_pkey_p_hash_reset can be called before s2n_evp_pkey_p_hash_init so there is nothing
-     * to reset.
-     */
-    if (ws->p_hash.evp_hmac.ctx.evp_pkey == NULL) {
-        return S2N_SUCCESS;
-    }
-    return s2n_evp_pkey_p_hash_digest_init(ws);
-}
-
-static int s2n_evp_pkey_p_hash_cleanup(struct s2n_prf_working_space *ws)
-{
-    /* Prepare the workspace md_ctx for the next p_hash */
-    POSIX_GUARD(s2n_evp_pkey_p_hash_wipe(ws));
-
-    /* Free mac key - PKEYs cannot be reused */
-    POSIX_ENSURE_REF(ws->p_hash.evp_hmac.ctx.evp_pkey);
-    EVP_PKEY_free(ws->p_hash.evp_hmac.ctx.evp_pkey);
-    ws->p_hash.evp_hmac.ctx.evp_pkey = NULL;
-
-    return 0;
-}
-
-static int s2n_evp_pkey_p_hash_free(struct s2n_prf_working_space *ws)
-{
-    POSIX_ENSURE_REF(ws->p_hash.evp_hmac.evp_digest.ctx);
-    S2N_EVP_MD_CTX_FREE(ws->p_hash.evp_hmac.evp_digest.ctx);
-    ws->p_hash.evp_hmac.evp_digest.ctx = NULL;
-
-    return 0;
-}
-
-static const struct s2n_p_hash_hmac s2n_evp_pkey_p_hash_hmac = {
-    .alloc = &s2n_evp_pkey_p_hash_alloc,
-    .init = &s2n_evp_pkey_p_hash_init,
-    .update = &s2n_evp_pkey_p_hash_update,
-    .final = &s2n_evp_pkey_p_hash_final,
-    .reset = &s2n_evp_pkey_p_hash_reset,
-    .cleanup = &s2n_evp_pkey_p_hash_cleanup,
-    .free = &s2n_evp_pkey_p_hash_free,
-};
-#else
-static int s2n_evp_hmac_p_hash_alloc(struct s2n_prf_working_space *ws)
-{
-    POSIX_ENSURE_REF(ws->p_hash.evp_hmac.ctx.hmac_ctx = HMAC_CTX_new());
-    return S2N_SUCCESS;
-}
-
-static int s2n_evp_hmac_p_hash_init(struct s2n_prf_working_space *ws, s2n_hmac_algorithm alg, struct s2n_blob *secret)
-{
-    /* Figure out the correct EVP_MD from s2n_hmac_algorithm  */
-    POSIX_GUARD_RESULT(s2n_hmac_md_from_alg(alg, &ws->p_hash.evp_hmac.evp_digest.md));
-
-    /* Initialize the mac and digest */
-    POSIX_GUARD_OSSL(HMAC_Init_ex(ws->p_hash.evp_hmac.ctx.hmac_ctx, secret->data, secret->size, ws->p_hash.evp_hmac.evp_digest.md, NULL), S2N_ERR_P_HASH_INIT_FAILED);
-    return S2N_SUCCESS;
-}
-
-static int s2n_evp_hmac_p_hash_update(struct s2n_prf_working_space *ws, const void *data, uint32_t size)
-{
-    POSIX_GUARD_OSSL(HMAC_Update(ws->p_hash.evp_hmac.ctx.hmac_ctx, data, (size_t) size), S2N_ERR_P_HASH_UPDATE_FAILED);
-    return S2N_SUCCESS;
-}
-
-static int s2n_evp_hmac_p_hash_final(struct s2n_prf_working_space *ws, void *digest, uint32_t size)
-{
-    /* HMAC_Final API's require size_t data structures */
-    unsigned int digest_size = size;
-    POSIX_GUARD_OSSL(HMAC_Final(ws->p_hash.evp_hmac.ctx.hmac_ctx, (unsigned char *) digest, &digest_size), S2N_ERR_P_HASH_FINAL_FAILED);
-    return S2N_SUCCESS;
-}
-
-static int s2n_evp_hmac_p_hash_reset(struct s2n_prf_working_space *ws)
-{
-    POSIX_ENSURE_REF(ws);
-    if (ws->p_hash.evp_hmac.evp_digest.md == NULL) {
-        return S2N_SUCCESS;
-    }
-    POSIX_GUARD_OSSL(HMAC_Init_ex(ws->p_hash.evp_hmac.ctx.hmac_ctx, NULL, 0, ws->p_hash.evp_hmac.evp_digest.md, NULL), S2N_ERR_P_HASH_INIT_FAILED);
-    return S2N_SUCCESS;
-}
-
-static int s2n_evp_hmac_p_hash_cleanup(struct s2n_prf_working_space *ws)
-{
-    /* Prepare the workspace md_ctx for the next p_hash */
-    HMAC_CTX_reset(ws->p_hash.evp_hmac.ctx.hmac_ctx);
-    return S2N_SUCCESS;
-}
-
-static int s2n_evp_hmac_p_hash_free(struct s2n_prf_working_space *ws)
-{
-    HMAC_CTX_free(ws->p_hash.evp_hmac.ctx.hmac_ctx);
-    return S2N_SUCCESS;
-}
-
-static const struct s2n_p_hash_hmac s2n_evp_hmac_p_hash_hmac = {
-    .alloc = &s2n_evp_hmac_p_hash_alloc,
-    .init = &s2n_evp_hmac_p_hash_init,
-    .update = &s2n_evp_hmac_p_hash_update,
-    .final = &s2n_evp_hmac_p_hash_final,
-    .reset = &s2n_evp_hmac_p_hash_reset,
-    .cleanup = &s2n_evp_hmac_p_hash_cleanup,
-    .free = &s2n_evp_hmac_p_hash_free,
-};
-#endif /* !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC) */
-
-static int s2n_hmac_p_hash_new(struct s2n_prf_working_space *ws)
-{
-    POSIX_GUARD(s2n_hmac_new(&ws->p_hash.s2n_hmac));
-
-    return s2n_hmac_init(&ws->p_hash.s2n_hmac, S2N_HMAC_NONE, NULL, 0);
-}
-
-static int s2n_hmac_p_hash_init(struct s2n_prf_working_space *ws, s2n_hmac_algorithm alg, struct s2n_blob *secret)
-{
-    return s2n_hmac_init(&ws->p_hash.s2n_hmac, alg, secret->data, secret->size);
-}
-
-static int s2n_hmac_p_hash_update(struct s2n_prf_working_space *ws, const void *data, uint32_t size)
-{
-    return s2n_hmac_update(&ws->p_hash.s2n_hmac, data, size);
-}
-
-static int s2n_hmac_p_hash_digest(struct s2n_prf_working_space *ws, void *digest, uint32_t size)
-{
-    return s2n_hmac_digest(&ws->p_hash.s2n_hmac, digest, size);
-}
-
-static int s2n_hmac_p_hash_reset(struct s2n_prf_working_space *ws)
-{
-    /* If we actually initialized s2n_hmac, wipe it.
-     * A valid, initialized s2n_hmac_state will have a valid block size.
-     */
-    if (ws->p_hash.s2n_hmac.hash_block_size != 0) {
-        return s2n_hmac_reset(&ws->p_hash.s2n_hmac);
-    }
-    return S2N_SUCCESS;
-}
-
-static int s2n_hmac_p_hash_cleanup(struct s2n_prf_working_space *ws)
-{
-    return s2n_hmac_p_hash_reset(ws);
-}
-
-static int s2n_hmac_p_hash_free(struct s2n_prf_working_space *ws)
-{
-    return s2n_hmac_free(&ws->p_hash.s2n_hmac);
-}
-
-static const struct s2n_p_hash_hmac s2n_internal_p_hash_hmac = {
-    .alloc = &s2n_hmac_p_hash_new,
-    .init = &s2n_hmac_p_hash_init,
-    .update = &s2n_hmac_p_hash_update,
-    .final = &s2n_hmac_p_hash_digest,
-    .reset = &s2n_hmac_p_hash_reset,
-    .cleanup = &s2n_hmac_p_hash_cleanup,
-    .free = &s2n_hmac_p_hash_free,
-};
-
-const struct s2n_p_hash_hmac *s2n_get_hmac_implementation()
-{
-#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
-    return s2n_is_in_fips_mode() ? &s2n_evp_hmac_p_hash_hmac : &s2n_internal_p_hash_hmac;
-#else
-    return s2n_is_in_fips_mode() ? &s2n_evp_pkey_p_hash_hmac : &s2n_internal_p_hash_hmac;
-#endif
-}
-
 static int s2n_p_hash(struct s2n_prf_working_space *ws, s2n_hmac_algorithm alg, struct s2n_blob *secret, struct s2n_blob *label,
         struct s2n_blob *seed_a, struct s2n_blob *seed_b, struct s2n_blob *seed_c, struct s2n_blob *out)
 {
-    uint8_t digest_size;
+    uint8_t digest_size = 0;
     POSIX_GUARD(s2n_hmac_digest_size(alg, &digest_size));
 
-    const struct s2n_p_hash_hmac *hmac = s2n_get_hmac_implementation();
+    struct s2n_hmac_state *hmac = &ws->hmac;
 
     /* First compute hmac(secret + A(0)) */
-    POSIX_GUARD(hmac->init(ws, alg, secret));
-    POSIX_GUARD(hmac->update(ws, label->data, label->size));
-    POSIX_GUARD(hmac->update(ws, seed_a->data, seed_a->size));
+    POSIX_GUARD(s2n_hmac_init(hmac, alg, secret->data, secret->size));
+    POSIX_GUARD(s2n_hmac_update(hmac, label->data, label->size));
+    POSIX_GUARD(s2n_hmac_update(hmac, seed_a->data, seed_a->size));
 
     if (seed_b) {
-        POSIX_GUARD(hmac->update(ws, seed_b->data, seed_b->size));
+        POSIX_GUARD(s2n_hmac_update(hmac, seed_b->data, seed_b->size));
         if (seed_c) {
-            POSIX_GUARD(hmac->update(ws, seed_c->data, seed_c->size));
+            POSIX_GUARD(s2n_hmac_update(hmac, seed_c->data, seed_c->size));
         }
     }
-    POSIX_GUARD(hmac->final(ws, ws->digest0, digest_size));
+    POSIX_GUARD(s2n_hmac_digest(hmac, ws->digest0, digest_size));
 
     uint32_t outputlen = out->size;
     uint8_t *output = out->data;
 
     while (outputlen) {
         /* Now compute hmac(secret + A(N - 1) + seed) */
-        POSIX_GUARD(hmac->reset(ws));
-        POSIX_GUARD(hmac->update(ws, ws->digest0, digest_size));
+        POSIX_GUARD(s2n_hmac_reset(hmac));
+        POSIX_GUARD(s2n_hmac_update(hmac, ws->digest0, digest_size));
 
         /* Add the label + seed and compute this round's A */
-        POSIX_GUARD(hmac->update(ws, label->data, label->size));
-        POSIX_GUARD(hmac->update(ws, seed_a->data, seed_a->size));
+        POSIX_GUARD(s2n_hmac_update(hmac, label->data, label->size));
+        POSIX_GUARD(s2n_hmac_update(hmac, seed_a->data, seed_a->size));
         if (seed_b) {
-            POSIX_GUARD(hmac->update(ws, seed_b->data, seed_b->size));
+            POSIX_GUARD(s2n_hmac_update(hmac, seed_b->data, seed_b->size));
             if (seed_c) {
-                POSIX_GUARD(hmac->update(ws, seed_c->data, seed_c->size));
+                POSIX_GUARD(s2n_hmac_update(hmac, seed_c->data, seed_c->size));
             }
         }
 
-        POSIX_GUARD(hmac->final(ws, ws->digest1, digest_size));
+        POSIX_GUARD(s2n_hmac_digest(hmac, ws->digest1, digest_size));
 
         uint32_t bytes_to_xor = MIN(outputlen, digest_size);
 
@@ -459,12 +227,12 @@ static int s2n_p_hash(struct s2n_prf_working_space *ws, s2n_hmac_algorithm alg, 
         }
 
         /* Stash a digest of A(N), in A(N), for the next round */
-        POSIX_GUARD(hmac->reset(ws));
-        POSIX_GUARD(hmac->update(ws, ws->digest0, digest_size));
-        POSIX_GUARD(hmac->final(ws, ws->digest0, digest_size));
+        POSIX_GUARD(s2n_hmac_reset(hmac));
+        POSIX_GUARD(s2n_hmac_update(hmac, ws->digest0, digest_size));
+        POSIX_GUARD(s2n_hmac_digest(hmac, ws->digest0, digest_size));
     }
 
-    POSIX_GUARD(hmac->cleanup(ws));
+    POSIX_GUARD(s2n_hmac_init(hmac, S2N_HMAC_NONE, NULL, 0));
 
     return 0;
 }
@@ -481,8 +249,8 @@ S2N_RESULT s2n_prf_new(struct s2n_connection *conn)
     ZERO_TO_DISABLE_DEFER_CLEANUP(mem);
 
     /* Allocate the hmac state */
-    const struct s2n_p_hash_hmac *hmac_impl = s2n_get_hmac_implementation();
-    RESULT_GUARD_POSIX(hmac_impl->alloc(conn->prf_space));
+    RESULT_GUARD_POSIX(s2n_hmac_new(&conn->prf_space->hmac));
+
     return S2N_RESULT_OK;
 }
 
@@ -491,8 +259,7 @@ S2N_RESULT s2n_prf_wipe(struct s2n_connection *conn)
     RESULT_ENSURE_REF(conn);
     RESULT_ENSURE_REF(conn->prf_space);
 
-    const struct s2n_p_hash_hmac *hmac_impl = s2n_get_hmac_implementation();
-    RESULT_GUARD_POSIX(hmac_impl->reset(conn->prf_space));
+    RESULT_GUARD_POSIX(s2n_hmac_init(&conn->prf_space->hmac, S2N_HMAC_NONE, NULL, 0));
 
     return S2N_RESULT_OK;
 }
@@ -504,10 +271,9 @@ S2N_RESULT s2n_prf_free(struct s2n_connection *conn)
         return S2N_RESULT_OK;
     }
 
-    const struct s2n_p_hash_hmac *hmac_impl = s2n_get_hmac_implementation();
-    RESULT_GUARD_POSIX(hmac_impl->free(conn->prf_space));
-
+    RESULT_GUARD_POSIX(s2n_hmac_free(&conn->prf_space->hmac));
     RESULT_GUARD_POSIX(s2n_free_object((uint8_t **) &conn->prf_space, sizeof(struct s2n_prf_working_space)));
+
     return S2N_RESULT_OK;
 }
 

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -185,6 +185,11 @@ static int s2n_p_hash(struct s2n_prf_working_space *ws, s2n_hmac_algorithm alg, 
 
     struct s2n_hmac_state *hmac = &ws->hmac;
 
+    /* Ignore the MD5 check when in FIPS mode */
+    if (s2n_is_in_fips_mode()) {
+        POSIX_GUARD(s2n_hmac_allow_md5_for_fips(hmac));
+    }
+
     /* First compute hmac(secret + A(0)) */
     POSIX_GUARD(s2n_hmac_init(hmac, alg, secret->data, secret->size));
     POSIX_GUARD(s2n_hmac_update(hmac, label->data, label->size));

--- a/tls/s2n_prf.h
+++ b/tls/s2n_prf.h
@@ -31,13 +31,8 @@
     #define S2N_LIBCRYPTO_SUPPORTS_TLS_PRF 0
 #endif
 
-union p_hash_state {
-    struct s2n_hmac_state s2n_hmac;
-    struct s2n_evp_hmac_state evp_hmac;
-};
-
 struct s2n_prf_working_space {
-    union p_hash_state p_hash;
+    struct s2n_hmac_state hmac;
     uint8_t digest0[S2N_MAX_DIGEST_LEN];
     uint8_t digest1[S2N_MAX_DIGEST_LEN];
 };


### PR DESCRIPTION
### Description of changes: 

The custom PRF implementation in s2n-tls is designed to swap the underlying HMAC implementation based on the FIPS mode. Normally, the custom HMAC implementation in s2n-tls is used, but if s2n-tls is operating in FIPS mode, the implementation is swapped to the libcrypto HMAC implementation.

However, after https://github.com/aws/s2n-tls/pull/4020, the PRF implementation itself is swapped to the libcrypto PRF implementation when s2n-tls is operating in FIPS mode. As such, the libcrypto HMAC implementation in s2n_prf is no longer needed, so it's removed in this PR.

### Call-outs:

- This change does impact the HMAC implementation for OpenSSL-FIPS in the PRF. Currently, OpenSSL-FIPS uses our custom PRF implementation backed with the HMAC implementation from the libcrypto. In all other usages of HMAC, OpenSSL-FIPS uses our custom HMAC implementation. Now, OpenSSL-FIPS also uses our custom HMAC implementation in the PRF.
- `hmac->cleanup` and `s2n_prf_wipe()` currently call `s2n_hmac_reset()`. Resetting doesn't actually clean/wipe the state, though. Instead, it prepares the state for a future HMAC calculation with the same key and algorithm. It seemed more correct to actually wipe the state in these places instead, so I changed it.

### Testing:

Existing s2n_prf unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
