### PR TITLE
ci: pin cbmc version

### DIFF
--- a/.github/workflows/proof_ci_resources/config.yaml
+++ b/.github/workflows/proof_ci_resources/config.yaml
@@ -1,5 +1,5 @@
 cadical-tag: latest
-cbmc-version: latest
+cbmc-version: 5.87.0
 cbmc-viewer-version: latest
 kissat-tag: latest
 litani-version: latest

--- a/tests/cbmc/README.md
+++ b/tests/cbmc/README.md
@@ -43,6 +43,13 @@ Running the proofs
 ------------------
 
 Each of the leaf directories under `proofs` is a proof of the memory safety of a single entry point.
+
+Before running proofs, you must pull in the `aws-verification-model-for-libcrypto`. That can be done by running
+```shell
+git submodule update --init
+```
+in the main s2n-tls folder.
+
 To run a proof, change into the directory for that proof and run `make` on Linux or macOS.
 The proofs may take some time to run; they eventually write their output to `cbmc.txt`, which should have the text `VERIFICATION SUCCESSFUL` at the end.
 


### PR DESCRIPTION
The latest published cbmc version seems to have a regression. Pin to the previous version until they get that fixed.

As far as I understand, the fix was merged in https://github.com/diffblue/cbmc/pull/7824, so once there is a CBMC release that contains that, we can switch back to latest.

### Description of changes: 
Pin CBMC to the older version


### Testing
CI (including cbmc) should pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
