### PR TITLE
Move around and update scripts in bench crate

### DIFF
--- a/bindings/rust/bench/.cargo/config.toml
+++ b/bindings/rust/bench/.cargo/config.toml
@@ -1,3 +1,0 @@
-[env]
-S2N_TLS_LIB_DIR = "/home/ubuntu/s2n-tls/bindings/rust/bench/target/s2n-tls-build/lib"
-LD_LIBRARY_PATH = "/home/ubuntu/s2n-tls/bindings/rust/bench/target/s2n-tls-build/lib"

--- a/bindings/rust/bench/README.md
+++ b/bindings/rust/bench/README.md
@@ -2,32 +2,38 @@
 
 We use to Criterion.rs to benchmark s2n-tls against two commonly used TLS libraries, Rustls and OpenSSL.
 
+## Quickstart
+```
+# generate rust bindings
+../generate.sh
+
+# set up bench crate
+scripts/generate-certs.sh
+scripts/install-aws-lc.sh
+
+# run all benchmarks (s2n-tls with AWS-LC)
+cargo bench --config aws-lc-config/s2n.toml
+scripts/bench-memory.sh --config aws-lc-config/s2n.toml
+scripts/bench-past.sh --config aws-lc-config/s2n.toml
+```
+
 ## Setup 
 
-Setup is easy! Just have OpenSSL installed, generate Rust bindings for s2n-tls using `../generate.sh`, and generate certs using `generate_certs.sh`. 
+Setup is easy! Just have OpenSSL installed, generate Rust bindings for s2n-tls using `../generate.sh`, and generate certs using `scripts/generate-certs.sh`. 
 
 Dependencies are the same as with s2n-tls. Currently, this crate has only been tested on Ubuntu (both x86 and ARM), but we expect everything to work with other Unix environments. 
 
-To bench with AWS-LC, Amazon's custom libcrypto implementation, first run `install-aws-lc.sh` to install AWS-LC for the bench crate. To then run the benchmarks with AWS-LC, use Cargo with either the flag `--config aws-lc-config/s2n.toml` or `--config aws-lc-config/rustls.toml` (or both). You can also append these configs to `.cargo/config.toml` to let Cargo automatically detect the settings without specifying the flags each time.  
-
-For example, to get started with benching s2n-tls with AWS-LC:
-
-```
-../generate.sh
-scripts/generate_certs.sh
-scripts/install-aws-lc.sh
-cargo bench --config aws-lc-config/s2n.toml
-```
+To bench with AWS-LC, Amazon's custom libcrypto implementation, first run `scripts/install-aws-lc.sh` to install AWS-LC for the bench crate. To then run the benchmarks with AWS-LC, use Cargo with either the flag `--config aws-lc-config/s2n.toml` or `--config aws-lc-config/rustls.toml` (or both). You can also append these configs to `.cargo/config.toml` to let Cargo automatically detect the settings without specifying the flags each time.  
 
 ## Running benchmarks
 
 The benchmarks can be run with the `cargo bench` command. Criterion will auto-generate an HTML report in `target/criterion/`. 
 
-To run memory benchmarks, run `bench-memory.sh`. A graph of memory usage will be generated in `memory/memory.svg`.
+To run memory benchmarks, run `scripts/bench-memory.sh`. A graph of memory usage will be generated in `memory/memory.svg`.
 
 ## Historical benchmarks
 
-To do historical benchmarks, run `bench-past.sh`. This will checkout old versions of s2n-tls back to v1.3.16 in `target/` and run benchmarks on those with the `historical-perf` feature, disabling Rustls and OpenSSL benches.
+To do historical benchmarks, run `scripts/bench-past.sh`. This will checkout old versions of s2n-tls back to v1.3.16 in `target/` and run benchmarks on those with the `historical-perf` feature, disabling Rustls and OpenSSL benches.
 
 ### Caveats
 

--- a/bindings/rust/bench/README.md
+++ b/bindings/rust/bench/README.md
@@ -4,7 +4,7 @@ We use to Criterion.rs to benchmark s2n-tls against two commonly used TLS librar
 
 ## Setup 
 
-Setup is easy! Just have OpenSSL installed, generate Rust bindings for s2n-tls using `../generate.sh`, and generate certs using `certs/generate_certs.sh`. 
+Setup is easy! Just have OpenSSL installed, generate Rust bindings for s2n-tls using `../generate.sh`, and generate certs using `generate_certs.sh`. 
 
 Dependencies are the same as with s2n-tls. Currently, this crate has only been tested on Ubuntu (both x86 and ARM), but we expect everything to work with other Unix environments. 
 
@@ -14,8 +14,8 @@ For example, to get started with benching s2n-tls with AWS-LC:
 
 ```
 ../generate.sh
-certs/generate_certs.sh
-./install-aws-lc.sh
+scripts/generate_certs.sh
+scripts/install-aws-lc.sh
 cargo bench --config aws-lc-config/s2n.toml
 ```
 
@@ -23,11 +23,11 @@ cargo bench --config aws-lc-config/s2n.toml
 
 The benchmarks can be run with the `cargo bench` command. Criterion will auto-generate an HTML report in `target/criterion/`. 
 
-To run memory benchmarks, run `memory/bench-memory.sh`. A graph of memory usage will be generated in `memory/memory.svg`.
+To run memory benchmarks, run `bench-memory.sh`. A graph of memory usage will be generated in `memory/memory.svg`.
 
 ## Historical benchmarks
 
-To do historical benchmarks, run `historical-perf/bench-past.sh`. This will checkout old versions of s2n-tls back to v1.3.16 in `target/` and run benchmarks on those with the `historical-perf` feature, disabling Rustls and OpenSSL benches.
+To do historical benchmarks, run `bench-past.sh`. This will checkout old versions of s2n-tls back to v1.3.16 in `target/` and run benchmarks on those with the `historical-perf` feature, disabling Rustls and OpenSSL benches.
 
 ### Caveats
 

--- a/bindings/rust/bench/README.md
+++ b/bindings/rust/bench/README.md
@@ -32,7 +32,7 @@ To bench with AWS-LC, Amazon's custom libcrypto implementation, first run `scrip
 
 The benchmarks can be run with the `cargo bench` command. Criterion will auto-generate an HTML report in `target/criterion/`. 
 
-To run memory benchmarks, run `scripts/bench-memory.sh`. A graph of memory usage will be generated in `memory/memory.svg`.
+To run memory benchmarks, run `scripts/bench-memory.sh`. A graph of memory usage will be generated in `images/memory.svg`.
 
 ## Historical benchmarks
 

--- a/bindings/rust/bench/README.md
+++ b/bindings/rust/bench/README.md
@@ -12,9 +12,12 @@ scripts/generate-certs.sh
 scripts/install-aws-lc.sh
 
 # run all benchmarks (s2n-tls with AWS-LC)
-cargo bench --config aws-lc-config/s2n.toml
-scripts/bench-memory.sh --config aws-lc-config/s2n.toml
-scripts/bench-past.sh --config aws-lc-config/s2n.toml
+mkdir .cargo
+cat aws-lc-config/s2n.toml > .cargo/config.toml
+cargo bench
+scripts/bench-memory.sh
+scripts/bench-past.sh
+rm -rf .cargo
 ```
 
 ## Setup 

--- a/bindings/rust/bench/aws-lc-config/rustls.toml
+++ b/bindings/rust/bench/aws-lc-config/rustls.toml
@@ -1,2 +1,2 @@
 [patch.crates-io]
-rustls = { path = "target/rustls/rustls" }
+ring = { path = "target/aws-lc-rs/aws-lc-rs" }

--- a/bindings/rust/bench/scripts/bench-memory.sh
+++ b/bindings/rust/bench/scripts/bench-memory.sh
@@ -5,14 +5,15 @@
 
 # Use Valgrind and Massif to heap profile the memory taken by different TLS libraries
 # Uses Valgrind monitor commands to take snapshots of heap size while making connections
+# All given arguments (ex. `--config aws-lc-config/s2n.toml` to use AWS-LC) are passed to Cargo
 
-# Snapshots get stored in target memory/[library-name]/ as [number].snapshot
+# Snapshots get stored in target/memory/[library-name]/ as [number].snapshot
 
 set -e
 
 pushd "$(dirname "$0")"/.. > /dev/null
 
-cargo build --release --bin memory "$@"
+cargo build --release --bin memory --bin graph_memory "$@"
 
 valgrind --tool=massif --depth=1 --massif-out-file="target/memory/massif.out" --time-unit=ms target/release/memory 
 rm target/memory/massif.out

--- a/bindings/rust/bench/scripts/bench-past.sh
+++ b/bindings/rust/bench/scripts/bench-past.sh
@@ -3,6 +3,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Run historical benchmarking by checking out old version of s2n-tls into target/
+# Criterion JSON results get cached to target/historical-perf/[bench-group-name]/[version].json
+# Results are then plotted, saved to images/historical-perf-[bench-name].svg
+# The default configuration (without AWS-LC) is used
+
 # immediately bail if any command fails
 set -e
 
@@ -11,7 +16,7 @@ exec >/dev/null
 export CARGO_TERM_QUIET=true
 export RUSTFLAGS=-Awarnings
 
-# go to s2n-tls/bindings/rust/bench/
+# go to bench directory
 pushd "$(dirname "$0")"/../
 bench_path="$(pwd)"
 

--- a/bindings/rust/bench/scripts/bench-past.sh
+++ b/bindings/rust/bench/scripts/bench-past.sh
@@ -6,7 +6,7 @@
 # Run historical benchmarking by checking out old version of s2n-tls into target/
 # Criterion JSON results get cached to target/historical-perf/[bench-group-name]/[version].json
 # Results are then plotted, saved to images/historical-perf-[bench-name].svg
-# The default configuration (without AWS-LC) is used
+# All given arguments (ex. `--config aws-lc-config/s2n.toml` to use AWS-LC) are passed to Cargo
 
 # immediately bail if any command fails
 set -e
@@ -61,7 +61,7 @@ do
         echo "running cargo bench and saving results" >&2
         cd $bench_path
         rm -rf target/criterion
-        cargo bench --features historical-perf --no-fail-fast
+        cargo bench --features historical-perf --no-fail-fast "$@"
 
         # cache criterion outputs from this bench into target/historical-perf
         for bench_group in $(ls target/criterion | grep -v "report")

--- a/bindings/rust/bench/scripts/generate-certs.sh
+++ b/bindings/rust/bench/scripts/generate-certs.sh
@@ -10,8 +10,8 @@
 # immediately bail if any command fails
 set -e
 
-# go to directory script is located in
-pushd "$(dirname "$0")" > /dev/null
+# go to directory certs are located
+pushd "$(dirname "$0")"/../certs > /dev/null
 
 # Generates certs with given algorithms and bits in $1$2/, ex. ec384/
 # $1: rsa or ec

--- a/bindings/rust/bench/scripts/install-aws-lc.sh
+++ b/bindings/rust/bench/scripts/install-aws-lc.sh
@@ -3,34 +3,43 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Usage: ./install-aws-lc.sh
 # Sets up bench crate to use aws-lc for either s2n-tls or rustls if desired
-# To run with aws-lc, use any cargo command with:
+
+# To run benches with aws-lc, use any cargo command with:
 # --config aws-lc-config/s2n.toml
 # --config aws-lc-config/rustls.toml
 # or both
 
+# How Rustls with aws-lc-rs works:
+# Clones aws-lc-rs, changes its name to ring with a compatible version number, and
+# patches it into Rustls
+
+# How s2n-tls with aws-lc works:
+# Builds s2n-tls static lib with AWS-LC interned, required to avoid symbol collisions with OpenSSL
+# Checks for libs2n.a at target/s2n-tls-build/lib/libs2n.a
+# Checks for libcrypto.a at target/aws-lc/install/lib/libcrypto.a
+
 set -e 
 
 # go to bench directory
-pushd "$(dirname "$0")" > /dev/null
+pushd "$(dirname "$0")"/.. > /dev/null
 bench_dir="$(pwd)"
 
 
 
 # ----- rustls -----
 
-# clone rustls to bench/target/rustls and checkout compatible version
-rm -rf target/rustls
-git clone https://github.com/rustls/rustls target/rustls
-cd target/rustls
-git checkout 'v/0.21.5'
+# clone aws-lc-rs to target
+rm -rf target/aws-lc-rs
+git clone https://github.com/aws/aws-lc-rs target/aws-lc-rs
+cd target/aws-lc-rs/aws-lc-rs
+git submodule init
+git submodule update
 
-# go to dir with rustls crate
-cd rustls
-rustls_dir="$(pwd)"
-
-# change rustls to use aws-lc-rs
-sed -i 's|ring = .*|ring = { package = "aws-lc-rs" }|' Cargo.toml
+# change aws-lc-rs to look like compatible ring (name and version)
+# assumes name and version are in the first 5 lines of the Cargo.toml and replaces them
+sed -i '1,5s|name = .*|name = "ring"| ; 1,5s|version = .*|version = "0.16.20"|' Cargo.toml
 
 
 
@@ -41,7 +50,7 @@ s2n_tls_build_dir="$bench_dir"/target/s2n-tls-build
 aws_lc_dir="$bench_dir"/target/aws-lc
 
 # go to repo directory
-cd "$bench_dir"/../../../ > /dev/null
+cd "$bench_dir"/../../../
 repo_dir="$(pwd)"
 
 # if libs2n not found, build it

--- a/bindings/rust/bench/scripts/install-aws-lc.sh
+++ b/bindings/rust/bench/scripts/install-aws-lc.sh
@@ -38,9 +38,13 @@ git submodule init
 git submodule update
 
 # change aws-lc-rs to look like API compatible ring (name and version)
-# changes first occurrence of 'name = .*' and 'version = .*' to be 
-# 'name = "ring"' and 'version = "0.16.20"'
-sed -i '1,/name = .*/{s|name = .*|name = "ring"|} ; 1,/version = .*/{s|version = .*|version = "0.16.20"|}' Cargo.toml
+# first get the version of ring that Cargo expects with `cargo tree`
+pushd "$bench_dir" > /dev/null
+version="$(cargo tree -p ring | head -n 1 | sed 's|ring v||')"
+popd > /dev/null
+# next change first occurrence of 'name = .*' and 'version = .*' in Cargo.toml
+# to be 'name = "ring"' and 'version = "[curr_version]"'
+sed -i "1,/name = .*/{s|name = .*|name = \"ring\"|} ; 1,/version = .*/{s|version = .*|version = \"$version\"|}" Cargo.toml
 
 
 

--- a/bindings/rust/bench/scripts/install-aws-lc.sh
+++ b/bindings/rust/bench/scripts/install-aws-lc.sh
@@ -38,8 +38,9 @@ git submodule init
 git submodule update
 
 # change aws-lc-rs to look like API compatible ring (name and version)
-# assumes name and version are in the first 5 lines of the Cargo.toml and replaces them
-sed -i '1,5s|name = .*|name = "ring"| ; 1,5s|version = .*|version = "0.16.20"|' Cargo.toml
+# changes first occurrence of 'name = .*' and 'version = .*' to be 
+# 'name = "ring"' and 'version = "0.16.20"'
+sed -i '1,/name = .*/{s|name = .*|name = "ring"|} ; 1,/version = .*/{s|version = .*|version = "0.16.20"|}' Cargo.toml
 
 
 

--- a/bindings/rust/bench/scripts/install-aws-lc.sh
+++ b/bindings/rust/bench/scripts/install-aws-lc.sh
@@ -37,7 +37,7 @@ cd target/aws-lc-rs/aws-lc-rs
 git submodule init
 git submodule update
 
-# change aws-lc-rs to look like compatible ring (name and version)
+# change aws-lc-rs to look like API compatible ring (name and version)
 # assumes name and version are in the first 5 lines of the Cargo.toml and replaces them
 sed -i '1,5s|name = .*|name = "ring"| ; 1,5s|version = .*|version = "0.16.20"|' Cargo.toml
 

--- a/bindings/rust/bench/src/bin/graph_memory.rs
+++ b/bindings/rust/bench/src/bin/graph_memory.rs
@@ -66,7 +66,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .1
         .mean;
 
-    let drawing_area = SVGBackend::new("memory/memory.svg", (1000, 500)).into_drawing_area();
+    let drawing_area = SVGBackend::new("images/memory.svg", (1000, 500)).into_drawing_area();
     drawing_area.fill(&WHITE)?;
 
     let mut ctx = ChartBuilder::on(&drawing_area)


### PR DESCRIPTION
### Description of changes: 

Right now, the bench crate has four scripts (`bench-past.sh`, `bench-memory.sh`, `generate-certs.sh`, `install-aws-lc.sh`) that all live in different directories. This PR collapses them into a `scripts` directory, adds more comments, and changes how Rustls was benched with aws-lc-rs (instead of ring) to be slightly more thorough and transitive dependency-aware. (Before, subdependencies of Rustls that used ring still pulled ring from crates-io, but by patching ring with aws-lc-rs directly, 

### Call-outs:

Before, dependencies of Rustls that then used ring (ex. rustls-webpki) still pulled ring from crates-io, but by patching ring with aws-lc-rs directly, all occurences of ring in the dependency tree are replaced with aws-lc-rs. The changes reflecting this are in `scripts/install-aws-lc.sh` and in `aws-lc-config/rustls.toml`.

### Testing:

Calling the scripts will be slightly different because of the different locations. To test, run all of the benchmarks with and without AWS-LC (`cargo bench`, `bench-memory.sh`, and `bench-past.sh`), as well as `cargo test`. To make sure the behavior hasn't changed, run all of the benchmarks before and after the refactor.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
