### PR TITLE
Change PR template formatting to be more consistent

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,19 @@
 ### Resolved issues:
 
- resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.
+Resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.
 
 ### Description of changes: 
 
-Describe s2n’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.
+Describe s2n’s current behavior and how your code changes that behavior. If there are no issues this PR is resolving, explain why this change is necessary.
+
 ### Call-outs:
 
 Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 
+
 ### Testing:
 
- How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
+How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
 
- Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?
+Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


### PR DESCRIPTION
### Description of changes: 

The spacing and capitalization in the PR template is weird and inconsistent.

### Testing:

No code has changed; this is just a github thing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
