### PR TITLE
Feature cleanup for bench crate

### DIFF
--- a/bindings/rust/bench/Cargo.toml
+++ b/bindings/rust/bench/Cargo.toml
@@ -7,23 +7,40 @@ edition = "2021"
 default = ["rustls", "openssl"]
 rustls = ["dep:rustls", "rustls-pemfile"]
 openssl = ["dep:openssl"]
+memory = ["plotters", "crabgrind"]
+historical-perf = ["plotters", "serde_json", "semver"]
 
 [dependencies]
 s2n-tls = { path = "../s2n-tls" }
+errno = "0.3"
+libc = "0.2"
 rustls = { version = "0.21", optional = true }
 rustls-pemfile = { version = "1.0", optional = true }
 openssl = { version = "0.10", optional = true }
-errno = "0.3"
-libc = "0.2"
-crabgrind = "0.1"
-rand = "0.8"
-rand_distr = "0.4"
-plotters = "0.3"
-serde_json = "1.0"
-semver = "1.0"
+crabgrind = { version = "0.1", optional = true }
+serde_json = { version = "1.0", optional = true }
+semver = { version = "1.0", optional = true }
+
+[dependencies.plotters]
+version = "0.3"
+optional = true
+default-features = false
+features = ["all_series", "all_elements", "full_palette", "svg_backend"]
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.5"
+
+[[bin]]
+name = "memory"
+required-features = ["memory"]
+
+[[bin]]
+name = "graph_memory"
+required-features = ["memory"]
+
+[[bin]]
+name = "graph_perf"
+required-features = ["historical-perf"]
 
 [[bench]]
 name = "handshake"

--- a/bindings/rust/bench/Cargo.toml
+++ b/bindings/rust/bench/Cargo.toml
@@ -4,13 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-historical-perf = []
+default = ["rustls", "openssl"]
+rustls = ["dep:rustls", "rustls-pemfile"]
+openssl = ["dep:openssl"]
 
 [dependencies]
 s2n-tls = { path = "../s2n-tls" }
-rustls = "0.21"
-rustls-pemfile = "1.0"
-openssl = "0.10"
+rustls = { version = "0.21", optional = true }
+rustls-pemfile = { version = "1.0", optional = true }
+openssl = { version = "0.10", optional = true }
 errno = "0.3"
 libc = "0.2"
 crabgrind = "0.1"

--- a/bindings/rust/bench/README.md
+++ b/bindings/rust/bench/README.md
@@ -19,13 +19,17 @@ certs/generate_certs.sh
 cargo bench --config aws-lc-config/s2n.toml
 ```
 
+### Features
+
+Default features (`rustls` and `openssl`) can be disabled by running the benches with `--no-default-features`. The non-default `memory` and `historical-perf` features are used to enable dependencies specific to those types of benches, and are automatically used by the scripts that run those benches.
+
 ## Running benchmarks
 
 The benchmarks can be run with the `cargo bench` command. Criterion will auto-generate an HTML report in `target/criterion/`. 
 
 To run memory benchmarks, run `memory/bench-memory.sh`. A graph of memory usage will be generated in `memory/memory.svg`.
 
-## Historical benchmarks
+### Historical benchmarks
 
 To do historical benchmarks, run `historical-perf/bench-past.sh`. This will checkout old versions of s2n-tls back to v1.3.16 in `target/` and run benchmarks on those with the `historical-perf` feature, disabling Rustls and OpenSSL benches.
 

--- a/bindings/rust/bench/benches/handshake.rs
+++ b/bindings/rust/bench/benches/handshake.rs
@@ -6,8 +6,8 @@ use bench::OpenSslConnection;
 #[cfg(feature = "rustls")]
 use bench::RustlsConnection;
 use bench::{
-    CipherSuite, CryptoConfig, HandshakeType, KXGroup, 
-    S2NConnection, SigType, TlsConnPair, TlsConnection,
+    CipherSuite, CryptoConfig, HandshakeType, KXGroup, S2NConnection, SigType, TlsConnPair,
+    TlsConnection,
 };
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion,

--- a/bindings/rust/bench/benches/handshake.rs
+++ b/bindings/rust/bench/benches/handshake.rs
@@ -1,11 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "openssl")]
+use bench::OpenSslHarness;
+#[cfg(feature = "rustls")]
+use bench::RustlsHarness;
 use bench::{
     CipherSuite, CryptoConfig,
     ECGroup::{self, *},
     HandshakeType::{self, *},
-    OpenSslHarness, RustlsHarness, S2NHarness,
+    S2NHarness,
     SigType::{self, *},
     TlsBenchHarness,
 };
@@ -59,23 +63,22 @@ pub fn bench_handshake_params(c: &mut Criterion) {
                     ec_group,
                     sig_type,
                 );
-                #[cfg(not(feature = "historical-perf"))]
-                {
-                    bench_handshake_for_library::<RustlsHarness>(
-                        &mut bench_group,
-                        "rustls",
-                        handshake_type,
-                        ec_group,
-                        sig_type,
-                    );
-                    bench_handshake_for_library::<OpenSslHarness>(
-                        &mut bench_group,
-                        "openssl",
-                        handshake_type,
-                        ec_group,
-                        sig_type,
-                    );
-                }
+                #[cfg(feature = "rustls")]
+                bench_handshake_for_library::<RustlsHarness>(
+                    &mut bench_group,
+                    "rustls",
+                    handshake_type,
+                    ec_group,
+                    sig_type,
+                );
+                #[cfg(feature = "openssl")]
+                bench_handshake_for_library::<OpenSslHarness>(
+                    &mut bench_group,
+                    "openssl",
+                    handshake_type,
+                    ec_group,
+                    sig_type,
+                );
             }
         }
     }

--- a/bindings/rust/bench/benches/throughput.rs
+++ b/bindings/rust/bench/benches/throughput.rs
@@ -1,10 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "openssl")]
+use bench::OpenSslHarness;
+#[cfg(feature = "rustls")]
+use bench::RustlsHarness;
 use bench::{
+    harness::ConnectedBuffer,
     CipherSuite::{self, *},
-    CryptoConfig, ECGroup, HandshakeType, OpenSslHarness, RustlsHarness, S2NHarness, SigType,
-    TlsBenchHarness, harness::ConnectedBuffer,
+    CryptoConfig, ECGroup, HandshakeType, S2NHarness, SigType, TlsBenchHarness,
 };
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion,
@@ -53,21 +57,20 @@ pub fn bench_throughput_cipher_suite(c: &mut Criterion) {
             &mut shared_buf,
             cipher_suite,
         );
-        #[cfg(not(feature = "historical-perf"))]
-        {
-            bench_throughput_for_library::<RustlsHarness>(
-                &mut bench_group,
-                "rustls",
-                &mut shared_buf,
-                cipher_suite,
-            );
-            bench_throughput_for_library::<OpenSslHarness>(
-                &mut bench_group,
-                "openssl",
-                &mut shared_buf,
-                cipher_suite,
-            );
-        }
+        #[cfg(feature = "rustls")]
+        bench_throughput_for_library::<RustlsHarness>(
+            &mut bench_group,
+            "rustls",
+            &mut shared_buf,
+            cipher_suite,
+        );
+        #[cfg(feature = "openssl")]
+        bench_throughput_for_library::<OpenSslHarness>(
+            &mut bench_group,
+            "openssl",
+            &mut shared_buf,
+            cipher_suite,
+        );
     }
 }
 

--- a/bindings/rust/bench/benches/throughput.rs
+++ b/bindings/rust/bench/benches/throughput.rs
@@ -6,8 +6,8 @@ use bench::OpenSslConnection;
 #[cfg(feature = "rustls")]
 use bench::RustlsConnection;
 use bench::{
-    harness::ConnectedBuffer, CipherSuite, CryptoConfig, HandshakeType, KXGroup,
-    S2NConnection, SigType, TlsConnPair, TlsConnection,
+    harness::ConnectedBuffer, CipherSuite, CryptoConfig, HandshakeType, KXGroup, S2NConnection,
+    SigType, TlsConnPair, TlsConnection,
 };
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion,

--- a/bindings/rust/bench/historical-perf/bench-past.sh
+++ b/bindings/rust/bench/historical-perf/bench-past.sh
@@ -56,7 +56,7 @@ do
         echo "running cargo bench and saving results" >&2
         cd $bench_path
         rm -rf target/criterion
-        cargo bench --features historical-perf --no-fail-fast
+        cargo bench --no-default-features --no-fail-fast
 
         # cache criterion outputs from this bench into target/historical-perf
         for bench_group in $(ls target/criterion | grep -v "report")

--- a/bindings/rust/bench/historical-perf/bench-past.sh
+++ b/bindings/rust/bench/historical-perf/bench-past.sh
@@ -70,6 +70,6 @@ done
 
 # graph results
 cd $bench_path
-cargo run --release --bin graph_perf
+cargo run --release --no-default-features --features historical-perf --bin graph_perf
 
 popd

--- a/bindings/rust/bench/memory/bench-memory.sh
+++ b/bindings/rust/bench/memory/bench-memory.sh
@@ -12,11 +12,11 @@ set -e
 
 pushd "$(dirname "$0")"/.. > /dev/null
 
-cargo build --release --bin memory "$@"
+cargo build --release --features memory --bin memory "$@"
 
 valgrind --tool=massif --depth=1 --massif-out-file="target/memory/massif.out" --time-unit=ms target/release/memory 
 rm target/memory/massif.out
 
-cargo run --release --bin graph_memory "$@"
+cargo run --release --features memory --bin graph_memory "$@"
 
 popd > /dev/null

--- a/bindings/rust/bench/src/bin/memory.rs
+++ b/bindings/rust/bench/src/bin/memory.rs
@@ -6,8 +6,8 @@ use bench::OpenSslConnection;
 #[cfg(feature = "rustls")]
 use bench::RustlsConnection;
 use bench::{
-    harness::ConnectedBuffer, CryptoConfig, HandshakeType,
-    S2NConnection, TlsConnPair, TlsConnection,
+    harness::ConnectedBuffer, CryptoConfig, HandshakeType, S2NConnection, TlsConnPair,
+    TlsConnection,
 };
 use std::{fs::create_dir_all, path::Path};
 
@@ -65,9 +65,9 @@ fn memory_bench<T: TlsConnection>(dir_name: &str) {
 fn main() {
     assert!(!cfg!(debug_assertions), "need to run in release mode");
 
-    memory_bench::<S2NHarness>("s2n-tls");
+    memory_bench::<S2NConnection>("s2n-tls");
     #[cfg(feature = "rustls")]
-    memory_bench::<RustlsHarness>("rustls");
+    memory_bench::<RustlsConnection>("rustls");
     #[cfg(feature = "openssl")]
-    memory_bench::<OpenSslHarness>("openssl");
+    memory_bench::<OpenSslConnection>("openssl");
 }

--- a/bindings/rust/bench/src/bin/memory.rs
+++ b/bindings/rust/bench/src/bin/memory.rs
@@ -1,7 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use bench::{harness::ConnectedBuffer, OpenSslHarness, RustlsHarness, S2NHarness, TlsBenchHarness};
+#[cfg(feature = "openssl")]
+use bench::OpenSslHarness;
+#[cfg(feature = "rustls")]
+use bench::RustlsHarness;
+use bench::{harness::ConnectedBuffer, S2NHarness, TlsBenchHarness};
 use std::{fs::create_dir_all, path::Path};
 
 fn memory_bench<T: TlsBenchHarness>(dir_name: &str) {
@@ -59,6 +63,8 @@ fn main() {
     assert!(!cfg!(debug_assertions), "need to run in release mode");
 
     memory_bench::<S2NHarness>("s2n-tls");
+    #[cfg(feature = "rustls")]
     memory_bench::<RustlsHarness>("rustls");
+    #[cfg(feature = "openssl")]
     memory_bench::<OpenSslHarness>("openssl");
 }

--- a/bindings/rust/bench/src/harness.rs
+++ b/bindings/rust/bench/src/harness.rs
@@ -381,10 +381,10 @@ impl Default for ConnectedBuffer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "rustls")]
-    use crate::RustlsConnection;
     #[cfg(feature = "openssl")]
     use crate::OpenSslConnection;
+    #[cfg(feature = "rustls")]
+    use crate::RustlsConnection;
     use crate::{S2NConnection, TlsConnPair};
     use std::path::Path;
     use strum::IntoEnumIterator;

--- a/bindings/rust/bench/src/harness.rs
+++ b/bindings/rust/bench/src/harness.rs
@@ -87,7 +87,11 @@ impl CryptoConfig {
 pub trait TlsBenchHarness: Sized {
     /// Default harness
     fn default() -> Result<Self, Box<dyn Error>> {
-        Self::new(CryptoConfig::default(), HandshakeType::default(), ConnectedBuffer::default())
+        Self::new(
+            CryptoConfig::default(),
+            HandshakeType::default(),
+            ConnectedBuffer::default(),
+        )
     }
 
     /// Initialize buffers, configs, and connections (pre-handshake)
@@ -238,11 +242,21 @@ macro_rules! test_tls_bench_harnesses {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{OpenSslHarness, RustlsHarness, S2NHarness, TlsBenchHarness};
+    #[cfg(feature = "openssl")]
+    use crate::OpenSslHarness;
+    #[cfg(feature = "rustls")]
+    use crate::RustlsHarness;
+    use crate::{S2NHarness, TlsBenchHarness};
 
     test_tls_bench_harnesses! {
         s2n_tls: S2NHarness,
+    }
+    #[cfg(feature = "rustls")]
+    test_tls_bench_harnesses! {
         rustls: RustlsHarness,
+    }
+    #[cfg(feature = "openssl")]
+    test_tls_bench_harnesses! {
         openssl: OpenSslHarness,
     }
 }

--- a/bindings/rust/bench/src/lib.rs
+++ b/bindings/rust/bench/src/lib.rs
@@ -2,14 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod harness;
+#[cfg(feature = "openssl")]
 pub mod openssl;
+#[cfg(feature = "rustls")]
 pub mod rustls;
 pub mod s2n_tls;
 
+#[cfg(feature = "openssl")]
+pub use crate::openssl::OpenSslHarness;
+#[cfg(feature = "rustls")]
+pub use crate::rustls::RustlsHarness;
 pub use crate::{
     harness::{CipherSuite, CryptoConfig, ECGroup, HandshakeType, Mode, SigType, TlsBenchHarness},
-    openssl::OpenSslHarness,
-    rustls::RustlsHarness,
     s2n_tls::S2NHarness,
 };
 


### PR DESCRIPTION
### Description of changes: 

The bench crate has a lot of dependencies that in reality only need to be loaded for certain functionalities. This PR adds feature logic to all of the dependencies.

### Call-outs:

I decided to unwrap the subtractive `historical-perf` feature into additive `rustls` and `openssl` default features. Originally, the `historical-perf` feature was included because using `--no-default-features` just for historical benching performance felt weird and nonobvious, but separating it out has started to make more sense, especially considering that if run in CI `--no-default-features` to remove rustls and openssl benching might be run more frequently.

### Testing:

To test this change, run all of the benches, scripts, and binaries, with and without default features. No behaviour should have changed, and this can be confirmed by running benches before and after the changes in this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
