### PR TITLE
Add libcrypto HMAC state to s2n_hmac_state

### DIFF
--- a/crypto/s2n_hmac.h
+++ b/crypto/s2n_hmac.h
@@ -67,7 +67,7 @@ int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out);
 
 int s2n_hmac_new(struct s2n_hmac_state *state);
 S2N_RESULT s2n_hmac_state_validate(struct s2n_hmac_state *state);
-int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen);
+int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t key_len);
 int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size);
 int s2n_hmac_digest(struct s2n_hmac_state *state, void *out, uint32_t size);
 int s2n_hmac_digest_two_compression_rounds(struct s2n_hmac_state *state, void *out, uint32_t size);

--- a/crypto/s2n_hmac.h
+++ b/crypto/s2n_hmac.h
@@ -33,7 +33,11 @@ typedef enum {
     S2N_HMAC_SSLv3_SHA1
 } s2n_hmac_algorithm;
 
-struct s2n_hmac_state {
+typedef enum {
+    S2N_HMAC_CUSTOM_IMPL
+} s2n_hmac_implementation_type;
+
+struct s2n_custom_hmac_state {
     s2n_hmac_algorithm alg;
 
     uint16_t hash_block_size;
@@ -51,6 +55,19 @@ struct s2n_hmac_state {
 
     /* For storing the inner digest */
     uint8_t digest_pad[SHA512_DIGEST_LENGTH];
+};
+
+struct s2n_libcrypto_hmac_state {
+    HMAC_CTX *ctx;
+};
+
+struct s2n_hmac_state {
+    s2n_hmac_implementation_type impl_type;
+
+    struct {
+        struct s2n_custom_hmac_state custom;
+        struct s2n_libcrypto_hmac_state libcrypto;
+    } impl_state;
 };
 
 struct s2n_hmac_evp_backup {
@@ -75,6 +92,8 @@ int s2n_hmac_digest_verify(const void *a, const void *b, uint32_t len);
 int s2n_hmac_free(struct s2n_hmac_state *state);
 int s2n_hmac_reset(struct s2n_hmac_state *state);
 int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from);
+int s2n_hmac_currently_in_hash_block(struct s2n_hmac_state *state, uint32_t *out);
+int s2n_hmac_size(struct s2n_hmac_state *state, uint8_t *out);
 int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
 int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
 

--- a/tests/saw/HMAC/spec/HMAC.saw
+++ b/tests/saw/HMAC/spec/HMAC.saw
@@ -216,7 +216,7 @@ let hash_get_currently_in_hash_total_spec = do {
 // HMAC.
 
 let setup_hmac_state alg0 hash_block_size0 block_size0 digest_size0 = do {
-    pstate <- crucible_alloc (llvm_struct "struct.s2n_hmac_state");
+    pstate <- crucible_alloc (llvm_struct "struct.s2n_custom_hmac_state");
     currently_in_hash_block0 <- crucible_fresh_var "currently_in_hash_block" (llvm_int 32);
     xor_pad0 <- crucible_fresh_var "xor_pad" (llvm_array 128 (llvm_int 8));
     let digest_size = eval_size {| SHA512_DIGEST_LENGTH |};

--- a/tests/saw/failure_tests/sha_bad_magic_mod.patch
+++ b/tests/saw/failure_tests/sha_bad_magic_mod.patch
@@ -2,21 +2,21 @@ diff --git a/crypto/s2n_hmac.c b/crypto/s2n_hmac.c
 index 29ded952..f7a24a01 100644
 --- a/crypto/s2n_hmac.c
 +++ b/crypto/s2n_hmac.c
-@@ -266,8 +266,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
+@@ -244,8 +244,7 @@ static S2N_RESULT s2n_hmac_update_impl(struct s2n_hmac_state *state, const void
       * input. On some platforms, including Intel, the operation can take a
       * smaller number of cycles if the input is "small".
       */
 -    const uint32_t HIGHEST_32_BIT = 4294949760;
--    POSIX_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
+-    RESULT_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
 +    const uint32_t HIGHEST_32_BIT = 4294949761;
      uint32_t value = (HIGHEST_32_BIT + size) % state->hash_block_size;
-     POSIX_GUARD(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
+     RESULT_GUARD_POSIX(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
      state->currently_in_hash_block %= state->hash_block_size;
 diff --git a/utils/s2n_safety.c b/utils/s2n_safety.c
 index b26e2d9c..e662c8da 100644
 --- a/utils/s2n_safety.c
 +++ b/utils/s2n_safety.c
-@@ -198,7 +198,6 @@ int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t* out)
+@@ -211,7 +211,6 @@ int s2n_add_overflow(uint32_t a, uint32_t b, uint32_t *out)
  {
      POSIX_ENSURE_REF(out);
      uint64_t result = ((uint64_t) a) + ((uint64_t) b);

--- a/tests/saw/failure_tests/sha_bad_magic_mod.patch
+++ b/tests/saw/failure_tests/sha_bad_magic_mod.patch
@@ -2,7 +2,7 @@ diff --git a/crypto/s2n_hmac.c b/crypto/s2n_hmac.c
 index 29ded952..f7a24a01 100644
 --- a/crypto/s2n_hmac.c
 +++ b/crypto/s2n_hmac.c
-@@ -244,8 +244,7 @@ static S2N_RESULT s2n_hmac_update_impl(struct s2n_hmac_state *state, const void
+@@ -283,8 +283,7 @@ static S2N_RESULT s2n_hmac_update_impl(struct s2n_custom_hmac_state *state, cons
       * input. On some platforms, including Intel, the operation can take a
       * smaller number of cycles if the input is "small".
       */

--- a/tests/saw/verify_HMAC.saw
+++ b/tests/saw/verify_HMAC.saw
@@ -61,7 +61,7 @@ let verify_s2n_hmac_init
     ];
   let block_size = cfg.block_size;
   
-  with_time (crucible_llvm_verify m "s2n_hmac_init" ovs false (hmac_init_spec cfg) z3_hash_unint);
+  with_time (crucible_llvm_verify m "s2n_hmac_init_impl" ovs false (hmac_init_spec cfg) z3_hash_unint);
         
   print "Finished proving s2n_hmac_init";
 };
@@ -80,7 +80,7 @@ let verify_s2n_hmac_update
   print (str_concat "Verifying HMAC update: alg = " cfg.name);
   
   (t, hash_update_msg_size_ov) <- with_time (crucible_llvm_unsafe_assume_spec m "s2n_hash_update" hash_update_unbounded_spec);
-  with_time (crucible_llvm_verify m "s2n_hmac_update" [hash_update_msg_size_ov] false (hmac_update_spec cfg) z3_hash_unint);
+  with_time (crucible_llvm_verify m "s2n_hmac_update_impl" [hash_update_msg_size_ov] false (hmac_update_spec cfg) z3_hash_unint);
         
   print "Finished proving s2n_hmac_update";
 };
@@ -111,7 +111,7 @@ let verify_s2n_hmac_digest
     ];
   
   (t, hmac_digest_ov) <-
-    with_time (crucible_llvm_verify m "s2n_hmac_digest" ovs false (hmac_digest_spec cfg) z3_hash_unint);
+    with_time (crucible_llvm_verify m "s2n_hmac_digest_impl" ovs false (hmac_digest_spec cfg) z3_hash_unint);
         
   print "Finished proving s2n_hmac_digest";
 };

--- a/tests/sidetrail/DEBUGGING.md
+++ b/tests/sidetrail/DEBUGGING.md
@@ -249,7 +249,7 @@ so bumping `__VERIFIER_ASSERT_MAX_LEAKAGE` up to `100` resolved the issue.
 | Test name                         | Runtime | 
 | --------------------------------- |--------:|
 | s2n-record-read-cbc-negative-test |     30s |
-| s2n-cbc                           |     35m |
+| s2n-cbc                           |     41m |
 | s2n-record-read-aead              |     30s |
 | s2n-record-read-cbc               |     20s |
 | s2n-record-read-composite         |     15s |

--- a/tests/sidetrail/DEBUGGING.md
+++ b/tests/sidetrail/DEBUGGING.md
@@ -247,11 +247,11 @@ so bumping `__VERIFIER_ASSERT_MAX_LEAKAGE` up to `100` resolved the issue.
 ## Expected runtimes:
 
 | Test name                         | Runtime | 
-| --------------------------------- | ------: |
-| s2n-record-read-cbc-negative-test | 20s     |
-| s2n-cbc                           | 5m 45s  |
-| s2n-record-read-composite         | 15s     |
-| s2n-record-read-aead              | 4m 10s  |
-| s2n-record-read-stream            | 25s     |
-| s2n-record-read-cbc               | 20s     |
+| --------------------------------- |--------:|
+| s2n-record-read-cbc-negative-test |     30s |
+| s2n-cbc                           |     35m |
+| s2n-record-read-aead              |     30s |
+| s2n-record-read-cbc               |     20s |
+| s2n-record-read-composite         |     15s |
+| s2n-record-read-stream            |  1m 30s |
 

--- a/tests/sidetrail/working/patches/cbc.patch
+++ b/tests/sidetrail/working/patches/cbc.patch
@@ -2,9 +2,9 @@ diff --git a/tests/sidetrail/working/s2n-cbc/tls/s2n_cbc.c b/tests/sidetrail/wor
 index 401ab760..f39cc7e2 100644
 --- a/tests/sidetrail/working/s2n-cbc/tls/s2n_cbc.c
 +++ b/tests/sidetrail/working/s2n-cbc/tls/s2n_cbc.c
-@@ -26,6 +26,28 @@
- #include "tls/s2n_connection.h"
- #include "tls/s2n_record.h"
+@@ -23,6 +23,28 @@
+ #include "utils/s2n_mem.h"
+ #include "utils/s2n_safety.h"
  
 +#include <smack.h>
 +#include <smack-contracts.h>
@@ -16,29 +16,29 @@ index 401ab760..f39cc7e2 100644
 + * a fix soon
 + */
 +int double_loop(int old_mismatches, struct s2n_blob *decrypted, int check, int cutoff, int padding_length) {
-+  __VERIFIER_assert(decrypted->size >= 0);
-+  __VERIFIER_assert(decrypted->size <= MAX_SIZE);
-+  int mismatches = old_mismatches;
-+  for (uint32_t i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
-+    invariant(i <= check);
-+    invariant(j == i + decrypted->size - check - 1);
-+    uint8_t mask = ~(0xff << ((i >= cutoff) * 8));
-+    mismatches |= (decrypted->data[j] ^ padding_length) & mask;
-+  }
-+  return mismatches;
++    __VERIFIER_assert(decrypted->size >= 0);
++    __VERIFIER_assert(decrypted->size <= MAX_SIZE);
++    int mismatches = old_mismatches;
++    for (uint32_t i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
++        invariant(i <= check);
++        invariant(j == i + decrypted->size - check - 1);
++        uint8_t mask = ~(0xff << ((i >= cutoff) * 8));
++        mismatches |= (decrypted->data[j] ^ padding_length) & mask;
++    }
++    return mismatches;
 +}
 +
  /* A TLS CBC record looks like ..
   *
   * [ Payload data ] [ HMAC ] [ Padding ] [ Padding length byte ]
-@@ -48,23 +70,28 @@
+@@ -45,17 +67,20 @@
   */
  int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, struct s2n_blob *decrypted)
  {
 -    uint8_t mac_digest_size;
--    POSIX_GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));
+-    POSIX_GUARD(s2n_hmac_size(hmac, &mac_digest_size));
 +    uint8_t mac_digest_size = DIGEST_SIZE;
-+    //POSIX_GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));
++    //POSIX_GUARD(s2n_hmac_size(hmac, &mac_digest_size));
  
      /* The record has to be at least big enough to contain the MAC,
       * plus the padding length byte */
@@ -54,15 +54,16 @@ index 401ab760..f39cc7e2 100644
  
      int payload_length = MAX(payload_and_padding_size - padding_length - 1, 0);
  
-     /* Update the MAC */
+@@ -63,6 +88,8 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
      POSIX_GUARD(s2n_hmac_update(hmac, decrypted->data, payload_length));
-     int currently_in_hash_block = hmac->currently_in_hash_block;
+     uint32_t currently_in_hash_block = 0;
+     POSIX_GUARD(s2n_hmac_currently_in_hash_block(hmac, &currently_in_hash_block));
 +    __VERIFIER_assume(currently_in_hash_block >= 0);
 +    __VERIFIER_assume(currently_in_hash_block < BLOCK_SIZE);
  
      /* Check the MAC */
      uint8_t check_digest[S2N_MAX_DIGEST_LEN];
-@@ -81,18 +108,19 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
+@@ -79,9 +106,9 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
      POSIX_GUARD(s2n_hmac_update(hmac, decrypted->data + payload_length + mac_digest_size, decrypted->size - payload_length - mac_digest_size - 1));
  
      /* SSLv3 doesn't specify what the padding should actually be */
@@ -75,9 +76,9 @@ index 401ab760..f39cc7e2 100644
  
      /* Check the maximum amount that could theoretically be padding */
      uint32_t check = MIN(255, (payload_and_padding_size - 1));
-
+@@ -89,10 +116,11 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
      POSIX_ENSURE_GTE(check, padding_length);
-
+ 
      uint32_t cutoff = check - padding_length;
 -    for (size_t i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
 -        uint8_t mask = ~(0xff << ((i >= cutoff) * 8));

--- a/tests/sidetrail/working/patches/hmac.patch
+++ b/tests/sidetrail/working/patches/hmac.patch
@@ -12,7 +12,7 @@ index 3405781..3beeacf 100644
  #include <stdint.h>
  
  int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
-@@ -246,7 +249,7 @@ static S2N_RESULT s2n_hmac_update_impl(struct s2n_hmac_state *state, const void
+@@ -268,7 +271,7 @@ static S2N_RESULT s2n_hmac_update_impl(struct s2n_hmac_state *state, const void
       */
      const uint32_t HIGHEST_32_BIT = 4294949760;
      RESULT_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
@@ -21,7 +21,7 @@ index 3405781..3beeacf 100644
      RESULT_GUARD_POSIX(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
      state->currently_in_hash_block %= state->hash_block_size;
  
-@@ -299,8 +302,8 @@ static S2N_RESULT s2n_hmac_copy_impl(struct s2n_hmac_state *to, struct s2n_hmac_
+@@ -333,8 +336,8 @@ static S2N_RESULT s2n_hmac_copy_impl(struct s2n_hmac_state *to, struct s2n_hmac_
      RESULT_GUARD_POSIX(s2n_hash_copy(&to->outer, &from->outer));
      RESULT_GUARD_POSIX(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
  
@@ -32,7 +32,7 @@ index 3405781..3beeacf 100644
  
      return S2N_RESULT_OK;
  }
-@@ -422,28 +425,28 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+@@ -440,28 +443,28 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
  /* Preserve the handlers for hmac state pointers to avoid re-allocation
   * Only valid if the HMAC is in EVP mode
   */

--- a/tests/sidetrail/working/patches/hmac.patch
+++ b/tests/sidetrail/working/patches/hmac.patch
@@ -12,7 +12,7 @@ index 3405781..3beeacf 100644
  #include <stdint.h>
  
  int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
-@@ -268,7 +271,7 @@ static S2N_RESULT s2n_hmac_update_impl(struct s2n_hmac_state *state, const void
+@@ -285,7 +288,7 @@ static S2N_RESULT s2n_hmac_update_impl(struct s2n_custom_hmac_state *state, cons
       */
      const uint32_t HIGHEST_32_BIT = 4294949760;
      RESULT_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
@@ -21,7 +21,7 @@ index 3405781..3beeacf 100644
      RESULT_GUARD_POSIX(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
      state->currently_in_hash_block %= state->hash_block_size;
  
-@@ -333,8 +336,8 @@ static S2N_RESULT s2n_hmac_copy_impl(struct s2n_hmac_state *to, struct s2n_hmac_
+@@ -331,8 +334,8 @@ static S2N_RESULT s2n_hmac_copy_impl(struct s2n_custom_hmac_state *to, struct s2
      RESULT_GUARD_POSIX(s2n_hash_copy(&to->outer, &from->outer));
      RESULT_GUARD_POSIX(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
  
@@ -32,7 +32,7 @@ index 3405781..3beeacf 100644
  
      return S2N_RESULT_OK;
  }
-@@ -440,28 +443,28 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+@@ -469,32 +472,32 @@ int s2n_hmac_size(struct s2n_hmac_state *state, uint8_t *out)
  /* Preserve the handlers for hmac state pointers to avoid re-allocation
   * Only valid if the HMAC is in EVP mode
   */
@@ -40,10 +40,12 @@ index 3405781..3beeacf 100644
 -{
 -    POSIX_ENSURE_REF(backup);
 -    POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
--    backup->inner = hmac->inner.digest.high_level;
--    backup->inner_just_key = hmac->inner_just_key.digest.high_level;
--    backup->outer = hmac->outer.digest.high_level;
--    backup->outer_just_key = hmac->outer_just_key.digest.high_level;
+-
+-    struct s2n_custom_hmac_state *state = &hmac->impl_state.custom;
+-    backup->inner = state->inner.digest.high_level;
+-    backup->inner_just_key = state->inner_just_key.digest.high_level;
+-    backup->outer = state->outer.digest.high_level;
+-    backup->outer_just_key = state->outer_just_key.digest.high_level;
 -    return S2N_SUCCESS;
 -}
 -
@@ -51,10 +53,12 @@ index 3405781..3beeacf 100644
 -{
 -    POSIX_ENSURE_REF(backup);
 -    POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
--    hmac->inner.digest.high_level = backup->inner;
--    hmac->inner_just_key.digest.high_level = backup->inner_just_key;
--    hmac->outer.digest.high_level = backup->outer;
--    hmac->outer_just_key.digest.high_level = backup->outer_just_key;
+-
+-    struct s2n_custom_hmac_state *state = &hmac->impl_state.custom;
+-    state->inner.digest.high_level = backup->inner;
+-    state->inner_just_key.digest.high_level = backup->inner_just_key;
+-    state->outer.digest.high_level = backup->outer;
+-    state->outer_just_key.digest.high_level = backup->outer_just_key;
 -    POSIX_POSTCONDITION(s2n_hmac_state_validate(hmac));
 -    return S2N_SUCCESS;
 -}
@@ -62,10 +66,12 @@ index 3405781..3beeacf 100644
 +//{
 +//    POSIX_ENSURE_REF(backup);
 +//    POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
-+//    backup->inner = hmac->inner.digest.high_level;
-+//    backup->inner_just_key = hmac->inner_just_key.digest.high_level;
-+//    backup->outer = hmac->outer.digest.high_level;
-+//    backup->outer_just_key = hmac->outer_just_key.digest.high_level;
++//
++//    struct s2n_custom_hmac_state *state = &hmac->impl_state.custom;
++//    backup->inner = state->inner.digest.high_level;
++//    backup->inner_just_key = state->inner_just_key.digest.high_level;
++//    backup->outer = state->outer.digest.high_level;
++//    backup->outer_just_key = state->outer_just_key.digest.high_level;
 +//    return S2N_SUCCESS;
 +//}
 +//
@@ -73,10 +79,12 @@ index 3405781..3beeacf 100644
 +//{
 +//    POSIX_ENSURE_REF(backup);
 +//    POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
-+//    hmac->inner.digest.high_level = backup->inner;
-+//    hmac->inner_just_key.digest.high_level = backup->inner_just_key;
-+//    hmac->outer.digest.high_level = backup->outer;
-+//    hmac->outer_just_key.digest.high_level = backup->outer_just_key;
++//
++//    struct s2n_custom_hmac_state *state = &hmac->impl_state.custom;
++//    state->inner.digest.high_level = backup->inner;
++//    state->inner_just_key.digest.high_level = backup->inner_just_key;
++//    state->outer.digest.high_level = backup->outer;
++//    state->outer_just_key.digest.high_level = backup->outer_just_key;
 +//    POSIX_POSTCONDITION(s2n_hmac_state_validate(hmac));
 +//    return S2N_SUCCESS;
 +//}
@@ -87,8 +95,8 @@ diff --git a/tests/sidetrail/working/s2n-cbc/crypto/s2n_hmac.h b/tests/sidetrail
 index 7af7e61..e6382ce 100644
 --- a/tests/sidetrail/working/s2n-cbc/crypto/s2n_hmac.h
 +++ b/tests/sidetrail/working/s2n-cbc/crypto/s2n_hmac.h
-@@ -53,12 +53,12 @@ struct s2n_hmac_state {
-     uint8_t digest_pad[SHA512_DIGEST_LENGTH];
+@@ -70,12 +70,12 @@ struct s2n_hmac_state {
+     } impl_state;
  };
  
 -struct s2n_hmac_evp_backup {
@@ -106,10 +114,10 @@ index 7af7e61..e6382ce 100644
  
  int s2n_hmac_digest_size(s2n_hmac_algorithm alg, uint8_t *out);
  bool s2n_hmac_is_available(s2n_hmac_algorithm alg);
-@@ -75,7 +75,7 @@ int s2n_hmac_digest_verify(const void *a, const void *b, uint32_t len);
- int s2n_hmac_free(struct s2n_hmac_state *state);
- int s2n_hmac_reset(struct s2n_hmac_state *state);
+@@ -94,7 +94,7 @@ int s2n_hmac_reset(struct s2n_hmac_state *state);
  int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from);
+ int s2n_hmac_currently_in_hash_block(struct s2n_hmac_state *state, uint32_t *out);
+ int s2n_hmac_size(struct s2n_hmac_state *state, uint8_t *out);
 -int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
 -int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
 +//int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);

--- a/tests/sidetrail/working/patches/hmac.patch
+++ b/tests/sidetrail/working/patches/hmac.patch
@@ -5,34 +5,34 @@ index 3405781..3beeacf 100644
 @@ -28,6 +28,9 @@
  #include "utils/s2n_blob.h"
  #include "utils/s2n_mem.h"
-
+ 
 +#include "smack.h"
 +#include "sidetrail.h"
 +
  #include <stdint.h>
-
+ 
  int s2n_hash_hmac_alg(s2n_hash_algorithm hash_alg, s2n_hmac_algorithm *out)
-@@ -270,7 +273,7 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
+@@ -246,7 +249,7 @@ static S2N_RESULT s2n_hmac_update_impl(struct s2n_hmac_state *state, const void
       */
      const uint32_t HIGHEST_32_BIT = 4294949760;
-     POSIX_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
+     RESULT_ENSURE(size <= (UINT32_MAX - HIGHEST_32_BIT), S2N_ERR_INTEGER_OVERFLOW);
 -    uint32_t value = (HIGHEST_32_BIT + size) % state->hash_block_size;
 +    uint32_t value = (size) % state->hash_block_size;
-     POSIX_GUARD(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
+     RESULT_GUARD_POSIX(s2n_add_overflow(state->currently_in_hash_block, value, &state->currently_in_hash_block));
      state->currently_in_hash_block %= state->hash_block_size;
-
-@@ -363,8 +366,8 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
-     POSIX_GUARD(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
-
-
--    POSIX_CHECKED_MEMCPY(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
--    POSIX_CHECKED_MEMCPY(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
-+    //POSIX_CHECKED_MEMCPY(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
-+    //POSIX_CHECKED_MEMCPY(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
-     POSIX_POSTCONDITION(s2n_hmac_state_validate(to));
-     POSIX_POSTCONDITION(s2n_hmac_state_validate(from));
-     return S2N_SUCCESS;
-@@ -374,28 +377,28 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
+ 
+@@ -299,8 +302,8 @@ static S2N_RESULT s2n_hmac_copy_impl(struct s2n_hmac_state *to, struct s2n_hmac_
+     RESULT_GUARD_POSIX(s2n_hash_copy(&to->outer, &from->outer));
+     RESULT_GUARD_POSIX(s2n_hash_copy(&to->outer_just_key, &from->outer_just_key));
+ 
+-    RESULT_CHECKED_MEMCPY(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
+-    RESULT_CHECKED_MEMCPY(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
++//    RESULT_CHECKED_MEMCPY(to->xor_pad, from->xor_pad, sizeof(to->xor_pad));
++//    RESULT_CHECKED_MEMCPY(to->digest_pad, from->digest_pad, sizeof(to->digest_pad));
+ 
+     return S2N_RESULT_OK;
+ }
+@@ -422,28 +425,28 @@ int s2n_hmac_copy(struct s2n_hmac_state *to, struct s2n_hmac_state *from)
  /* Preserve the handlers for hmac state pointers to avoid re-allocation
   * Only valid if the HMAC is in EVP mode
   */
@@ -58,29 +58,29 @@ index 3405781..3beeacf 100644
 -    POSIX_POSTCONDITION(s2n_hmac_state_validate(hmac));
 -    return S2N_SUCCESS;
 -}
-+// int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
-+// {
-+//     POSIX_ENSURE_REF(backup);
-+//     POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
-+//     backup->inner = hmac->inner.digest.high_level;
-+//     backup->inner_just_key = hmac->inner_just_key.digest.high_level;
-+//     backup->outer = hmac->outer.digest.high_level;
-+//     backup->outer_just_key = hmac->outer_just_key.digest.high_level;
-+//     return S2N_SUCCESS;
-+// }
++//int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
++//{
++//    POSIX_ENSURE_REF(backup);
++//    POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
++//    backup->inner = hmac->inner.digest.high_level;
++//    backup->inner_just_key = hmac->inner_just_key.digest.high_level;
++//    backup->outer = hmac->outer.digest.high_level;
++//    backup->outer_just_key = hmac->outer_just_key.digest.high_level;
++//    return S2N_SUCCESS;
++//}
 +//
-+// int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
-+// {
-+//     POSIX_ENSURE_REF(backup);
-+//     POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
-+//     hmac->inner.digest.high_level = backup->inner;
-+//     hmac->inner_just_key.digest.high_level = backup->inner_just_key;
-+//     hmac->outer.digest.high_level = backup->outer;
-+//     hmac->outer_just_key.digest.high_level = backup->outer_just_key;
-+//     POSIX_POSTCONDITION(s2n_hmac_state_validate(hmac));
-+//     return S2N_SUCCESS;
-+// }
-
++//int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac)
++//{
++//    POSIX_ENSURE_REF(backup);
++//    POSIX_PRECONDITION(s2n_hmac_state_validate(hmac));
++//    hmac->inner.digest.high_level = backup->inner;
++//    hmac->inner_just_key.digest.high_level = backup->inner_just_key;
++//    hmac->outer.digest.high_level = backup->outer;
++//    hmac->outer_just_key.digest.high_level = backup->outer_just_key;
++//    POSIX_POSTCONDITION(s2n_hmac_state_validate(hmac));
++//    return S2N_SUCCESS;
++//}
+ 
  S2N_RESULT s2n_hmac_md_from_alg(s2n_hmac_algorithm alg, const EVP_MD **md)
  {
 diff --git a/tests/sidetrail/working/s2n-cbc/crypto/s2n_hmac.h b/tests/sidetrail/working/s2n-cbc/crypto/s2n_hmac.h
@@ -90,20 +90,20 @@ index 7af7e61..e6382ce 100644
 @@ -53,12 +53,12 @@ struct s2n_hmac_state {
      uint8_t digest_pad[SHA512_DIGEST_LENGTH];
  };
-
+ 
 -struct s2n_hmac_evp_backup {
 -    struct s2n_hash_evp_digest inner;
 -    struct s2n_hash_evp_digest inner_just_key;
 -    struct s2n_hash_evp_digest outer;
 -    struct s2n_hash_evp_digest outer_just_key;
 -};
-+/* struct s2n_hmac_evp_backup { */
-+/*     struct s2n_hash_evp_digest inner; */
-+/*     struct s2n_hash_evp_digest inner_just_key; */
-+/*     struct s2n_hash_evp_digest outer; */
-+/*     struct s2n_hash_evp_digest outer_just_key; */
-+/* }; */
-
++//struct s2n_hmac_evp_backup {
++//    struct s2n_hash_evp_digest inner;
++//    struct s2n_hash_evp_digest inner_just_key;
++//    struct s2n_hash_evp_digest outer;
++//    struct s2n_hash_evp_digest outer_just_key;
++//};
+ 
  int s2n_hmac_digest_size(s2n_hmac_algorithm alg, uint8_t *out);
  bool s2n_hmac_is_available(s2n_hmac_algorithm alg);
 @@ -75,7 +75,7 @@ int s2n_hmac_digest_verify(const void *a, const void *b, uint32_t len);
@@ -114,5 +114,5 @@ index 7af7e61..e6382ce 100644
 -int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
 +//int s2n_hmac_save_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
 +//int s2n_hmac_restore_evp_hash_state(struct s2n_hmac_evp_backup* backup, struct s2n_hmac_state* hmac);
-
+ 
  S2N_RESULT s2n_hmac_md_from_alg(s2n_hmac_algorithm alg, const EVP_MD **md);

--- a/tests/sidetrail/working/s2n-cbc/cbc.c
+++ b/tests/sidetrail/working/s2n-cbc/cbc.c
@@ -42,24 +42,29 @@ int simple_cbc_wrapper(int currently_in_hash_block, int size, int *xor_pad, int 
   __VERIFIER_assume(currently_in_hash_block < BLOCK_SIZE);
 
   struct s2n_hmac_state hmac = {
-    .alg = S2N_HMAC_SHA1,
-    .hash_block_size = BLOCK_SIZE,
-    .currently_in_hash_block = 0,
-    .digest_size = SHA_DIGEST_LENGTH,
-    .xor_pad_size = BLOCK_SIZE,
-    .inner.alg = S2N_HASH_SHA1,
-    .inner.currently_in_hash_block = 0,
-    .inner_just_key.alg = S2N_HASH_SHA1,
-    .inner_just_key.currently_in_hash_block = 0,
-    .outer.alg = S2N_HASH_SHA1,
-    .outer.currently_in_hash_block = 0,
-    .outer_just_key.alg = S2N_HASH_SHA1,
-    .outer_just_key.currently_in_hash_block = 0,
-     .xor_pad = *xor_pad,
-    //xor_pad is an array
-    .digest_pad = *digest_pad
+    .impl_type = S2N_HMAC_CUSTOM_IMPL,
+    .impl_state = {
+      .custom = {
+        .alg = S2N_HMAC_SHA1,
+        .hash_block_size = BLOCK_SIZE,
+        .currently_in_hash_block = 0,
+        .digest_size = SHA_DIGEST_LENGTH,
+        .xor_pad_size = BLOCK_SIZE,
+        .inner.alg = S2N_HASH_SHA1,
+        .inner.currently_in_hash_block = 0,
+        .inner_just_key.alg = S2N_HASH_SHA1,
+        .inner_just_key.currently_in_hash_block = 0,
+        .outer.alg = S2N_HASH_SHA1,
+        .outer.currently_in_hash_block = 0,
+        .outer_just_key.alg = S2N_HASH_SHA1,
+        .outer_just_key.currently_in_hash_block = 0,
+        .xor_pad = *xor_pad,
+        //xor_pad is an array
+        .digest_pad = *digest_pad
+      },
+      .libcrypto = { 0 }
+    }
   };
-
 
   struct s2n_crypto_parameters client;
   struct s2n_connection conn = {

--- a/tests/sidetrail/working/s2n-record-read-aead/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-aead/s2n_record_read_wrapper.c
@@ -81,23 +81,28 @@ int s2n_record_parse_wrapper(int *xor_pad,
   public_in(__SMACK_value(flags));
   
   struct s2n_hmac_state hmac = {
-    .alg = S2N_HMAC_SHA1,
-    .hash_block_size = BLOCK_SIZE,
-    .currently_in_hash_block = 0,
-    .digest_size = SHA_DIGEST_LENGTH,
-    .xor_pad_size = BLOCK_SIZE,
-    .inner.alg = S2N_HASH_SHA1,
-    .inner.currently_in_hash_block = 0,
-    .inner_just_key.alg = S2N_HASH_SHA1,
-    .inner_just_key.currently_in_hash_block = 0,
-    .outer.alg = S2N_HASH_SHA1,
-    .outer.currently_in_hash_block = 0,
-    .outer_just_key.alg = S2N_HASH_SHA1,
-    .outer_just_key.currently_in_hash_block = 0,
-     .xor_pad = *xor_pad,
-    .digest_pad = *digest_pad
+    .impl_type = S2N_HMAC_CUSTOM_IMPL,
+    .impl_state = {
+      .custom = {
+        .alg = S2N_HMAC_SHA1,
+        .hash_block_size = BLOCK_SIZE,
+        .currently_in_hash_block = 0,
+        .digest_size = SHA_DIGEST_LENGTH,
+        .xor_pad_size = BLOCK_SIZE,
+        .inner.alg = S2N_HASH_SHA1,
+        .inner.currently_in_hash_block = 0,
+        .inner_just_key.alg = S2N_HASH_SHA1,
+        .inner_just_key.currently_in_hash_block = 0,
+        .outer.alg = S2N_HASH_SHA1,
+        .outer.currently_in_hash_block = 0,
+        .outer_just_key.alg = S2N_HASH_SHA1,
+        .outer_just_key.currently_in_hash_block = 0,
+        .xor_pad = *xor_pad,
+        .digest_pad = *digest_pad
+      },
+      .libcrypto = { 0 }
+    }
   };
-
   
   struct s2n_cipher aead_cipher = {
     .type = S2N_AEAD,

--- a/tests/sidetrail/working/s2n-record-read-cbc-negative-test/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-cbc-negative-test/s2n_record_read_wrapper.c
@@ -78,25 +78,30 @@ int s2n_record_parse_wrapper(int *xor_pad,
   __VERIFIER_assume(padding_length < 256);
   public_in(__SMACK_value(padding_length));
   public_in(__SMACK_value(encrypted_length));
-  
-  struct s2n_hmac_state hmac = {
-    .alg = S2N_HMAC_SHA1,
-    .hash_block_size = BLOCK_SIZE,
-    .currently_in_hash_block = 0,
-    .digest_size = SHA_DIGEST_LENGTH,
-    .xor_pad_size = BLOCK_SIZE,
-    .inner.alg = S2N_HASH_SHA1,
-    .inner.currently_in_hash_block = 0,
-    .inner_just_key.alg = S2N_HASH_SHA1,
-    .inner_just_key.currently_in_hash_block = 0,
-    .outer.alg = S2N_HASH_SHA1,
-    .outer.currently_in_hash_block = 0,
-    .outer_just_key.alg = S2N_HASH_SHA1,
-    .outer_just_key.currently_in_hash_block = 0,
-     .xor_pad = *xor_pad,
-    .digest_pad = *digest_pad
-  };
 
+  struct s2n_hmac_state hmac = {
+    .impl_type = S2N_HMAC_CUSTOM_IMPL,
+    .impl_state = {
+      .custom = {
+        .alg = S2N_HMAC_SHA1,
+        .hash_block_size = BLOCK_SIZE,
+        .currently_in_hash_block = 0,
+        .digest_size = SHA_DIGEST_LENGTH,
+        .xor_pad_size = BLOCK_SIZE,
+        .inner.alg = S2N_HASH_SHA1,
+        .inner.currently_in_hash_block = 0,
+        .inner_just_key.alg = S2N_HASH_SHA1,
+        .inner_just_key.currently_in_hash_block = 0,
+        .outer.alg = S2N_HASH_SHA1,
+        .outer.currently_in_hash_block = 0,
+        .outer_just_key.alg = S2N_HASH_SHA1,
+        .outer_just_key.currently_in_hash_block = 0,
+         .xor_pad = *xor_pad,
+        .digest_pad = *digest_pad
+      },
+      .libcrypto = { 0 }
+    }
+  };
   
   struct s2n_cipher cbc_cipher = {
     .type = S2N_CBC,

--- a/tests/sidetrail/working/s2n-record-read-cbc/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-cbc/s2n_record_read_wrapper.c
@@ -78,25 +78,30 @@ int s2n_record_parse_wrapper(int *xor_pad,
   __VERIFIER_assume(padding_length < 256);
   public_in(__SMACK_value(padding_length));
   public_in(__SMACK_value(encrypted_length));
-  
-  struct s2n_hmac_state hmac = {
-    .alg = S2N_HMAC_SHA1,
-    .hash_block_size = BLOCK_SIZE,
-    .currently_in_hash_block = 0,
-    .digest_size = SHA_DIGEST_LENGTH,
-    .xor_pad_size = BLOCK_SIZE,
-    .inner.alg = S2N_HASH_SHA1,
-    .inner.currently_in_hash_block = 0,
-    .inner_just_key.alg = S2N_HASH_SHA1,
-    .inner_just_key.currently_in_hash_block = 0,
-    .outer.alg = S2N_HASH_SHA1,
-    .outer.currently_in_hash_block = 0,
-    .outer_just_key.alg = S2N_HASH_SHA1,
-    .outer_just_key.currently_in_hash_block = 0,
-     .xor_pad = *xor_pad,
-    .digest_pad = *digest_pad
-  };
 
+  struct s2n_hmac_state hmac = {
+    .impl_type = S2N_HMAC_CUSTOM_IMPL,
+    .impl_state = {
+      .custom = {
+        .alg = S2N_HMAC_SHA1,
+        .hash_block_size = BLOCK_SIZE,
+        .currently_in_hash_block = 0,
+        .digest_size = SHA_DIGEST_LENGTH,
+        .xor_pad_size = BLOCK_SIZE,
+        .inner.alg = S2N_HASH_SHA1,
+        .inner.currently_in_hash_block = 0,
+        .inner_just_key.alg = S2N_HASH_SHA1,
+        .inner_just_key.currently_in_hash_block = 0,
+        .outer.alg = S2N_HASH_SHA1,
+        .outer.currently_in_hash_block = 0,
+        .outer_just_key.alg = S2N_HASH_SHA1,
+        .outer_just_key.currently_in_hash_block = 0,
+        .xor_pad = *xor_pad,
+        .digest_pad = *digest_pad
+      },
+      .libcrypto = { 0 }
+    }
+  };
   
   struct s2n_cipher cbc_cipher = {
     .type = S2N_CBC,

--- a/tests/sidetrail/working/s2n-record-read-composite/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-composite/s2n_record_read_wrapper.c
@@ -87,23 +87,29 @@ int s2n_record_parse_wrapper(int *xor_pad,
   __VERIFIER_assume(padding_length < 256);
   public_in(__SMACK_value(padding_length));
   public_in(__SMACK_value(encrypted_length));
-  
+
   struct s2n_hmac_state hmac = {
-    .alg = S2N_HMAC_SHA1,
-    .hash_block_size = BLOCK_SIZE,
-    .currently_in_hash_block = 0,
-    .digest_size = SHA_DIGEST_LENGTH,
-    .xor_pad_size = BLOCK_SIZE,
-    .inner.alg = S2N_HASH_SHA1,
-    .inner.currently_in_hash_block = 0,
-    .inner_just_key.alg = S2N_HASH_SHA1,
-    .inner_just_key.currently_in_hash_block = 0,
-    .outer.alg = S2N_HASH_SHA1,
-    .outer.currently_in_hash_block = 0,
-    .outer_just_key.alg = S2N_HASH_SHA1,
-    .outer_just_key.currently_in_hash_block = 0,
-    .xor_pad = *xor_pad,
-    .digest_pad = *digest_pad
+    .impl_type = S2N_HMAC_CUSTOM_IMPL,
+    .impl_state = {
+      .custom = {
+        .alg = S2N_HMAC_SHA1,
+        .hash_block_size = BLOCK_SIZE,
+        .currently_in_hash_block = 0,
+        .digest_size = SHA_DIGEST_LENGTH,
+        .xor_pad_size = BLOCK_SIZE,
+        .inner.alg = S2N_HASH_SHA1,
+        .inner.currently_in_hash_block = 0,
+        .inner_just_key.alg = S2N_HASH_SHA1,
+        .inner_just_key.currently_in_hash_block = 0,
+        .outer.alg = S2N_HASH_SHA1,
+        .outer.currently_in_hash_block = 0,
+        .outer_just_key.alg = S2N_HASH_SHA1,
+        .outer_just_key.currently_in_hash_block = 0,
+        .xor_pad = *xor_pad,
+        .digest_pad = *digest_pad
+      },
+      .libcrypto = { 0 }
+    }
   };
 
   struct s2n_cipher comp_cipher = {

--- a/tests/sidetrail/working/s2n-record-read-stream/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-stream/s2n_record_read_wrapper.c
@@ -77,25 +77,30 @@ int s2n_record_parse_wrapper(int *xor_pad,
   __VERIFIER_assume(padding_length < 256);
   public_in(__SMACK_value(padding_length));
   public_in(__SMACK_value(encrypted_length));
-  
-  struct s2n_hmac_state hmac = {
-    .alg = S2N_HMAC_SHA1,
-    .hash_block_size = BLOCK_SIZE,
-    .currently_in_hash_block = 0,
-    .digest_size = SHA_DIGEST_LENGTH,
-    .xor_pad_size = BLOCK_SIZE,
-    .inner.alg = S2N_HASH_SHA1,
-    .inner.currently_in_hash_block = 0,
-    .inner_just_key.alg = S2N_HASH_SHA1,
-    .inner_just_key.currently_in_hash_block = 0,
-    .outer.alg = S2N_HASH_SHA1,
-    .outer.currently_in_hash_block = 0,
-    .outer_just_key.alg = S2N_HASH_SHA1,
-    .outer_just_key.currently_in_hash_block = 0,
-    .xor_pad = *xor_pad,
-    .digest_pad = *digest_pad
-  };
 
+  struct s2n_hmac_state hmac = {
+    .impl_type = S2N_HMAC_CUSTOM_IMPL,
+    .impl_state = {
+      .custom = {
+        .alg = S2N_HMAC_SHA1,
+        .hash_block_size = BLOCK_SIZE,
+        .currently_in_hash_block = 0,
+        .digest_size = SHA_DIGEST_LENGTH,
+        .xor_pad_size = BLOCK_SIZE,
+        .inner.alg = S2N_HASH_SHA1,
+        .inner.currently_in_hash_block = 0,
+        .inner_just_key.alg = S2N_HASH_SHA1,
+        .inner_just_key.currently_in_hash_block = 0,
+        .outer.alg = S2N_HASH_SHA1,
+        .outer.currently_in_hash_block = 0,
+        .outer_just_key.alg = S2N_HASH_SHA1,
+        .outer_just_key.currently_in_hash_block = 0,
+        .xor_pad = *xor_pad,
+        .digest_pad = *digest_pad
+      },
+      .libcrypto = { 0 }
+    }
+  };
   
   struct s2n_cipher stream_cipher = {
     .type = S2N_STREAM,

--- a/tls/s2n_cbc.c
+++ b/tls/s2n_cbc.c
@@ -46,7 +46,7 @@
 int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, struct s2n_blob *decrypted)
 {
     uint8_t mac_digest_size;
-    POSIX_GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));
+    POSIX_GUARD(s2n_hmac_size(hmac, &mac_digest_size));
 
     /* The record has to be at least big enough to contain the MAC,
      * plus the padding length byte */
@@ -61,7 +61,8 @@ int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, str
 
     /* Update the MAC */
     POSIX_GUARD(s2n_hmac_update(hmac, decrypted->data, payload_length));
-    int currently_in_hash_block = hmac->currently_in_hash_block;
+    uint32_t currently_in_hash_block = 0;
+    POSIX_GUARD(s2n_hmac_currently_in_hash_block(hmac, &currently_in_hash_block));
 
     /* Check the MAC */
     uint8_t check_digest[S2N_MAX_DIGEST_LEN];

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -371,13 +371,7 @@ static int s2n_hmac_p_hash_digest(struct s2n_prf_working_space *ws, void *digest
 
 static int s2n_hmac_p_hash_reset(struct s2n_prf_working_space *ws)
 {
-    /* If we actually initialized s2n_hmac, wipe it.
-     * A valid, initialized s2n_hmac_state will have a valid block size.
-     */
-    if (ws->p_hash.s2n_hmac.hash_block_size != 0) {
-        return s2n_hmac_reset(&ws->p_hash.s2n_hmac);
-    }
-    return S2N_SUCCESS;
+    return s2n_hmac_reset(&ws->p_hash.s2n_hmac);
 }
 
 static int s2n_hmac_p_hash_cleanup(struct s2n_prf_working_space *ws)

--- a/tls/s2n_record_read_cbc.c
+++ b/tls/s2n_record_read_cbc.c
@@ -56,8 +56,8 @@ int s2n_record_parse_cbc(
     POSIX_ENSURE_REF(en.data);
 
     uint16_t payload_length = encrypted_length;
-    uint8_t mac_digest_size;
-    POSIX_GUARD(s2n_hmac_digest_size(mac->alg, &mac_digest_size));
+    uint8_t mac_digest_size = 0;
+    POSIX_GUARD(s2n_hmac_size(mac, &mac_digest_size));
 
     POSIX_ENSURE_GTE(payload_length, mac_digest_size);
     payload_length -= mac_digest_size;

--- a/tls/s2n_record_read_composite.c
+++ b/tls/s2n_record_read_composite.c
@@ -47,8 +47,8 @@ int s2n_record_parse_composite(
     POSIX_ENSURE_REF(en.data);
 
     uint16_t payload_length = encrypted_length;
-    uint8_t mac_digest_size;
-    POSIX_GUARD(s2n_hmac_digest_size(mac->alg, &mac_digest_size));
+    uint8_t mac_digest_size = 0;
+    POSIX_GUARD(s2n_hmac_size(mac, &mac_digest_size));
 
     POSIX_ENSURE_GTE(payload_length, mac_digest_size);
     payload_length -= mac_digest_size;

--- a/tls/s2n_record_read_stream.c
+++ b/tls/s2n_record_read_stream.c
@@ -43,8 +43,8 @@ int s2n_record_parse_stream(
     POSIX_ENSURE_REF(en.data);
 
     uint16_t payload_length = encrypted_length;
-    uint8_t mac_digest_size;
-    POSIX_GUARD(s2n_hmac_digest_size(mac->alg, &mac_digest_size));
+    uint8_t mac_digest_size = 0;
+    POSIX_GUARD(s2n_hmac_size(mac, &mac_digest_size));
 
     POSIX_ENSURE_GTE(payload_length, mac_digest_size);
     payload_length -= mac_digest_size;

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -289,8 +289,8 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
         POSIX_ENSURE(s2n_stuffer_data_available(&conn->out) == 0, S2N_ERR_RECORD_STUFFER_NEEDS_DRAINING);
     }
 
-    uint8_t mac_digest_size;
-    POSIX_GUARD(s2n_hmac_digest_size(mac->alg, &mac_digest_size));
+    uint8_t mac_digest_size = 0;
+    POSIX_GUARD(s2n_hmac_size(mac, &mac_digest_size));
 
     /* Before we do anything, we need to figure out what the length of the
      * fragment is going to be.


### PR DESCRIPTION
### Description of changes: 

To add the libcrypto HMAC implementation to s2n-tls, the libcrypto HMAC `ctx` needs to be kept in `s2n_hmac_state` in addition to our custom HMAC state fields. This PR adds the libcrypto `ctx` to the `s2n_hmac_state` struct, and fixes Sidetrail and SAW, which both break with this change.

My goal with this PR is to make the necessary Sidetrail changes so I don't have to pollute the followup PRs with Sidetrail stuff, so the `s2n_hmac_state` unfortunately contains fields which aren't being used yet. The current `s2n_hmac_state` fields are moved to a new struct, `s2n_custom_hmac_state`, which all of the HMAC impl functions now use to access the same fields as before.

The purpose of the new `s2n_hmac_state` fields are as follows:

**`impl_type`**
- Will be set in `s2n_hmac_init` to specify whether the custom or libcrypto HMAC implementations will be used for all HMAC operations on the `s2n_hmac_state`.

**`impl_state`**
- Contains both HMAC state structs - one for the custom HMAC implementation and one for the libcrypto implementation. `s2n_custom_hmac_state` is the same struct as the previous `s2n_hmac_state`, and the custom HMAC operations continue to access the same fields. The `s2n_libcrypto_hmac_state` will be used by the libcrypto versions of the HMAC implementation functions. 
- This field is a struct and not a union because it must be possible for an allocated `s2n_hmac_state` to switch between the custom and libcrypto HMAC implementations. So, both states are needed in the struct.

Since the `s2n_custom_hmac_state` struct is exactly the same as the previous `s2n_hmac_state` struct, fixing SAW involves simply updating the struct and function names. Rather than have the SAW proofs use `s2n_hmac_state` with the exposed `s2n_hmac` APIs, SAW proofs now use `s2n_custom_hmac_state` with the custom HMAC implementation functions directly.

Fixing Sidetrail involved updating each of the proof wrappers to create a `s2n_hmac_state` with the new version of the struct. 

### Call-outs:
- No functionality should change as a result of this PR.
- Updating the `s2n_hmac_state` struct broke HMAC callers that relied on internal state fields. Since accessing internal fields will become complicated with the libcrypto implementation, I added getters for these fields instead.
  - `s2n_hmac_p_hash_reset()` was using the `hash_block_size` field to avoid performing an unnecessary `s2n_hmac_reset()` call. Since `s2n_hmac_reset()` is cheap and this is the only external place relying on `hash_block_size`, I updated this function to just make the `s2n_hmac_reset()` call without checking rather than provide a getter for it.

### Testing:

Existing s2n_hmac tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
