### PR TITLE
test: ensure s2n_recv blocked status behavior doesn't change

### DIFF
--- a/tests/unit/s2n_alerts_protocol_test.c
+++ b/tests/unit/s2n_alerts_protocol_test.c
@@ -620,7 +620,9 @@ int main(int argc, char **argv)
             /* First read should report a partial read, but also close the connection */
             EXPECT_EQUAL(s2n_recv(receiver, data, sizeof(data), &blocked), partial_write);
             EXPECT_FALSE(s2n_connection_check_io_status(receiver, S2N_IO_READABLE));
-            EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
+
+            /* Since we read at least one byte, the blocked status should be S2N_NOT_BLOCKED */
+            EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
 
             /* Subsequent reads should NOT report END_OF_DATA, but instead an error */
             for (size_t i = 0; i < 5; i++) {

--- a/tests/unit/s2n_recv_test.c
+++ b/tests/unit/s2n_recv_test.c
@@ -270,7 +270,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_set_recv_multi_record(config, multi_record));
             size_t max_recv_size = test_data_size;
 
-            /* in multi-record, we can read all of the records in one go */
+            /* In multi-record, we can read all of the records in one go */
             if (multi_record) {
                 max_recv_size *= record_count;
             }
@@ -291,20 +291,20 @@ int main(int argc, char **argv)
                 while (recv_bytes < total_data_size) {
                     size_t expected_recv_size = MIN(MIN(read_size, total_data_size - recv_bytes), max_recv_size);
 
-                    /* perform the actual recv call */
+                    /* Perform the actual recv call */
                     ssize_t actual_recv_size = s2n_recv(server_conn, output.data, read_size, &blocked);
 
                     if (multi_record) {
-                        /* in multi-record mode we should always read the size we expect */
+                        /* In multi-record mode we should always read the size we expect */
                         EXPECT_EQUAL(actual_recv_size, expected_recv_size);
                     } else {
-                        /* in single-record mode, we could potentially get a smaller read than a full record due to
+                        /* In single-record mode, we could potentially get a smaller read than a full record due to
                          * random record boundaries so we can only assert it's within the range we expect. */
                         EXPECT_NOT_EQUAL(actual_recv_size, 0);
                         EXPECT_TRUE(actual_recv_size <= expected_recv_size);
                     }
 
-                    /* keep track of the total amount of bytes read */
+                    /* Keep track of the total amount of bytes read */
                     recv_bytes += actual_recv_size;
 
                     /* Due to the history of this API, some applications depend on the blocked status to know if
@@ -321,7 +321,7 @@ int main(int argc, char **argv)
                     }
                 }
 
-                /* the final read should return blocked since we don't have any more data from the socket */
+                /* The final read should return blocked since we don't have any more data from the socket */
                 EXPECT_FAILURE_WITH_ERRNO(s2n_recv(server_conn, output.data, read_size, &blocked), S2N_ERR_IO_BLOCKED);
                 EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
             }

--- a/tests/unit/s2n_recv_test.c
+++ b/tests/unit/s2n_recv_test.c
@@ -197,11 +197,13 @@ int main(int argc, char **argv)
 
     /* s2n_config_set_recv_multi_record */
     {
-#define TEST_DATA_SIZE 100
-        const uint8_t test_data[TEST_DATA_SIZE] = "hello world";
-        const size_t test_data_size = sizeof(test_data);
-        uint8_t output[TEST_DATA_SIZE * 2];
-        const size_t recv_size = sizeof(output);
+        const uint8_t test_data_size = 100;
+        DEFER_CLEANUP(struct s2n_blob test_data = { 0 }, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&test_data, test_data_size));
+
+        const size_t recv_size = test_data_size * 2;
+        DEFER_CLEANUP(struct s2n_blob output = { 0 }, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&output, recv_size));
 
         {
             s2n_blocked_status blocked = 0;
@@ -219,21 +221,125 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
             /* Write some data, in three records */
-            EXPECT_EQUAL(s2n_send(client_conn, test_data, sizeof(test_data), &blocked), sizeof(test_data));
-            EXPECT_EQUAL(s2n_send(client_conn, test_data, sizeof(test_data), &blocked), sizeof(test_data));
-            EXPECT_EQUAL(s2n_send(client_conn, test_data, sizeof(test_data), &blocked), sizeof(test_data));
+            for (size_t i = 0; i < 3; i++) {
+                EXPECT_EQUAL(s2n_send(client_conn, test_data.data, test_data.size, &blocked), test_data.size);
+            }
 
-            /* Disable multi-recod recv, set legavy behvaior */
+            /* Disable multi-record recv, set legacy behavior */
             EXPECT_SUCCESS(s2n_config_set_recv_multi_record(config, false));
 
-            EXPECT_EQUAL(s2n_recv(server_conn, output, recv_size, &blocked), test_data_size);
+            EXPECT_EQUAL(s2n_recv(server_conn, output.data, recv_size, &blocked), test_data_size);
 
             /* Now enable multi record recv */
             EXPECT_SUCCESS(s2n_config_set_recv_multi_record(config, true));
 
             /* So we should be able to read the remaining two records in a single call */
-            EXPECT_EQUAL(s2n_recv(server_conn, output, recv_size, &blocked), recv_size);
+            EXPECT_EQUAL(s2n_recv(server_conn, output.data, recv_size, &blocked), recv_size);
         }
+    }
+
+    /* recv blocked status
+     *
+     * This test preserves the `blocked` parameter contract with various states of the connection
+     */
+    {
+        const uint8_t test_data_size = 100;
+        const size_t record_count = 3;
+        DEFER_CLEANUP(struct s2n_blob test_data = { 0 }, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&test_data, test_data_size));
+
+        const size_t total_data_size = test_data_size * record_count;
+        DEFER_CLEANUP(struct s2n_blob output = { 0 }, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&output, total_data_size));
+
+        s2n_blocked_status blocked = 0;
+
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        struct s2n_test_io_pair io_pair = { 0 };
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+        for (size_t multi_record = 0; multi_record <= 1; multi_record++) {
+            EXPECT_SUCCESS(s2n_config_set_recv_multi_record(config, multi_record));
+            size_t max_recv_size = test_data_size;
+
+            /* in multi-record, we can read all of the records in one go */
+            if (multi_record) {
+                max_recv_size *= record_count;
+            }
+
+            for (size_t read_size = 1; read_size <= total_data_size; read_size++) {
+                /* Write some data across multiple records */
+                for (size_t send_count = 0; send_count < record_count; send_count++) {
+                    EXPECT_EQUAL(s2n_send(client_conn, test_data.data, test_data.size, &blocked), test_data.size);
+                }
+
+                /* Call `s2n_recv` multiple times with an empty buffer to make sure that's handled correctly */
+                for (size_t empty_count = 0; empty_count < 10; empty_count++) {
+                    EXPECT_EQUAL(s2n_recv(server_conn, output.data, 0, &blocked), 0);
+                    EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+                }
+
+                size_t recv_bytes = 0;
+                while (recv_bytes < total_data_size) {
+                    size_t expected_recv_size = MIN(MIN(read_size, total_data_size - recv_bytes), max_recv_size);
+
+                    /* perform the actual recv call */
+                    ssize_t actual_recv_size = s2n_recv(server_conn, output.data, read_size, &blocked);
+
+                    if (multi_record) {
+                        /* in multi-record mode we should always read the size we expect */
+                        EXPECT_EQUAL(actual_recv_size, expected_recv_size);
+                    } else {
+                        /* in single-record mode, we could potentially get a smaller read than a full record due to
+                         * random record boundaries so we can only assert it's within the range we expect. */
+                        EXPECT_NOT_EQUAL(actual_recv_size, 0);
+                        EXPECT_TRUE(actual_recv_size <= expected_recv_size);
+                    }
+
+                    /* keep track of the total amount of bytes read */
+                    recv_bytes += actual_recv_size;
+
+                    /* Due to the history of this API, some applications depend on the blocked status to know if
+                     * the connection's `in` stuffer was completely cleared. This behavior needs to be preserved.
+                     *
+                     * Moving forward, applications should instead use `s2n_peek`, which accomplishes the same thing
+                     * without conflating being blocked on reading from the OS socket vs blocked on the application's
+                     * buffer size.
+                     */
+                    if (s2n_peek(server_conn) == 0) {
+                        EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+                    } else {
+                        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
+                    }
+                }
+
+                /* the final read should return blocked since we don't have any more data from the socket */
+                EXPECT_FAILURE_WITH_ERRNO(s2n_recv(server_conn, output.data, read_size, &blocked), S2N_ERR_IO_BLOCKED);
+                EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
+            }
+        }
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(client_conn, &blocked), S2N_ERR_IO_BLOCKED);
+        EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
+
+        /* Call `s2n_recv` multiple times at the end of the stream after receiving a shutdown */
+        for (size_t eos_count = 0; eos_count < 10; eos_count++) {
+            EXPECT_EQUAL(s2n_recv(server_conn, output.data, output.size, &blocked), 0);
+            EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+        }
+
+        EXPECT_SUCCESS(s2n_shutdown(server_conn, &blocked));
+        EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+        EXPECT_SUCCESS(s2n_shutdown(client_conn, &blocked));
+        EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
     }
 
     END_TEST();


### PR DESCRIPTION
### Description of changes: 

I've seen a few applications in the wild use the `blocked` status from `s2n_recv` incorrectly and actually check that before reading the return value.  Ideally, they wouldn't be doing this and this `blocked` parameter was removed entirely, but we're kind of stuck with it.

Unfortunately, after reviewing our options, I'm not sure there's much we can do to change this, due to behavior ossification. If we change something to help one behavior, then there's risk of breaking someone else depending on that. As such, I've added tests to better preserve our `blocked` status behavior to avoid breaking anything in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
