### PR TITLE
Unnest loops over parameters in handshake bench

### DIFF
--- a/bindings/rust/bench/benches/handshake.rs
+++ b/bindings/rust/bench/benches/handshake.rs
@@ -40,41 +40,70 @@ fn bench_handshake_for_library<T: TlsConnection>(
     });
 }
 
-pub fn bench_handshake_params(c: &mut Criterion) {
-    for handshake_type in HandshakeType::iter() {
-        for kx_group in KXGroup::iter() {
-            for sig_type in SigType::iter() {
-                let mut bench_group = c.benchmark_group(match handshake_type {
-                    HandshakeType::ServerAuth => format!("handshake-{:?}-{:?}", kx_group, sig_type),
-                    HandshakeType::MutualAuth => {
-                        format!("handshake-mTLS-{:?}-{:?}", kx_group, sig_type)
-                    }
-                });
-                bench_handshake_for_library::<S2NConnection>(
-                    &mut bench_group,
-                    handshake_type,
-                    kx_group,
-                    sig_type,
-                );
-                #[cfg(not(feature = "historical-perf"))]
-                {
-                    bench_handshake_for_library::<RustlsConnection>(
-                        &mut bench_group,
-                        handshake_type,
-                        kx_group,
-                        sig_type,
-                    );
-                    bench_handshake_for_library::<OpenSslConnection>(
-                        &mut bench_group,
-                        handshake_type,
-                        kx_group,
-                        sig_type,
-                    );
-                }
-            }
-        }
+fn bench_handshake_with_params(
+    bench_group: &mut BenchmarkGroup<WallTime>,
+    handshake_type: HandshakeType,
+    kx_group: KXGroup,
+    sig_type: SigType,
+) {
+    bench_handshake_for_library::<S2NConnection>(bench_group, handshake_type, kx_group, sig_type);
+    #[cfg(not(feature = "historical-perf"))]
+    {
+        bench_handshake_for_library::<RustlsConnection>(
+            bench_group,
+            handshake_type,
+            kx_group,
+            sig_type,
+        );
+        bench_handshake_for_library::<OpenSslConnection>(
+            bench_group,
+            handshake_type,
+            kx_group,
+            sig_type,
+        );
     }
 }
 
-criterion_group!(benches, bench_handshake_params);
+pub fn bench_handshake_types(c: &mut Criterion) {
+    for handshake_type in HandshakeType::iter() {
+        let mut bench_group = c.benchmark_group(format!("handshake-{handshake_type:?}"));
+        bench_handshake_with_params(
+            &mut bench_group,
+            handshake_type,
+            KXGroup::default(),
+            SigType::default(),
+        );
+    }
+}
+
+pub fn bench_handshake_kx_groups(c: &mut Criterion) {
+    for kx_group in KXGroup::iter() {
+        let mut bench_group = c.benchmark_group(format!("handshake-{kx_group:?}"));
+        bench_handshake_with_params(
+            &mut bench_group,
+            HandshakeType::default(),
+            kx_group,
+            SigType::default(),
+        );
+    }
+}
+
+pub fn bench_handshake_sig_types(c: &mut Criterion) {
+    for sig_type in SigType::iter() {
+        let mut bench_group = c.benchmark_group(format!("handshake-{sig_type:?}"));
+        bench_handshake_with_params(
+            &mut bench_group,
+            HandshakeType::default(),
+            KXGroup::default(),
+            sig_type,
+        );
+    }
+}
+
+criterion_group!(
+    benches,
+    bench_handshake_types,
+    bench_handshake_kx_groups,
+    bench_handshake_sig_types
+);
 criterion_main!(benches);

--- a/bindings/rust/bench/benches/throughput.rs
+++ b/bindings/rust/bench/benches/throughput.rs
@@ -39,7 +39,7 @@ fn bench_throughput_for_library<T: TlsConnection>(
     });
 }
 
-pub fn bench_throughput_cipher_suite(c: &mut Criterion) {
+pub fn bench_throughput_cipher_suites(c: &mut Criterion) {
     // arbitrarily large to cut across TLS record boundaries
     let mut shared_buf = [0u8; 100000];
 
@@ -67,5 +67,5 @@ pub fn bench_throughput_cipher_suite(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_throughput_cipher_suite);
+criterion_group!(benches, bench_throughput_cipher_suites);
 criterion_main!(benches);

--- a/bindings/rust/bench/src/harness.rs
+++ b/bindings/rust/bench/src/harness.rs
@@ -86,6 +86,15 @@ pub enum HandshakeType {
     MutualAuth,
 }
 
+impl Debug for HandshakeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HandshakeType::ServerAuth => write!(f, "no-mTLS"),
+            HandshakeType::MutualAuth => write!(f, "mTLS"),
+        }
+    }
+}
+
 // these parameters were the only ones readily usable for all three libaries:
 // s2n-tls, rustls, and openssl
 #[allow(non_camel_case_types)]
@@ -105,14 +114,10 @@ pub enum KXGroup {
 
 impl Debug for KXGroup {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::Secp256R1 => "secp256r1",
-                Self::X25519 => "x25519",
-            }
-        )
+        match self {
+            Self::Secp256R1 => write!(f, "secp256r1"),
+            Self::X25519 => write!(f, "x25519"),
+        }
     }
 }
 


### PR DESCRIPTION
### Description of changes: 

The benchmarks iterate through all possible combination of parameters for handshaking right now, but the matrix of possibilities isn't needed for almost all use cases and takes a very long time. This PR tests unnests the loops over the parameters and tests each parameter individually.

### Testing:

Run all scripts and benchmarks to test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
