### PR TITLE
Fix throughput bench issues and add documentation

### DIFF
--- a/bindings/rust/bench/README.md
+++ b/bindings/rust/bench/README.md
@@ -2,6 +2,8 @@
 
 We use to Criterion.rs to benchmark s2n-tls against two commonly used TLS libraries, Rustls and OpenSSL.
 
+All benchmarks are run in an idealized environment, using only a single thread and with custom IO bypassing the networking stack. As such, performance numbers will be different from in practice, but relative performance between the libraries should still be accurate.
+
 ## Quickstart
 ```
 # generate rust bindings

--- a/bindings/rust/bench/README.md
+++ b/bindings/rust/bench/README.md
@@ -32,6 +32,8 @@ To bench with AWS-LC, Amazon's custom libcrypto implementation, first run `scrip
 
 The benchmarks can be run with the `cargo bench` command. Criterion will auto-generate an HTML report in `target/criterion/`. 
 
+Throughput benchmarks measure round-trip throughput with the client and server connections in the same thread for symmetry. In practice, throughput for a single connection would be ~4x higher than the values from the benchmarks.
+
 To run memory benchmarks, run `scripts/bench-memory.sh`. A graph of memory usage will be generated in `images/memory.svg`.
 
 ## Historical benchmarks

--- a/bindings/rust/bench/README.md
+++ b/bindings/rust/bench/README.md
@@ -32,7 +32,7 @@ To bench with AWS-LC, Amazon's custom libcrypto implementation, first run `scrip
 
 The benchmarks can be run with the `cargo bench` command. Criterion will auto-generate an HTML report in `target/criterion/`. 
 
-Throughput benchmarks measure round-trip throughput with the client and server connections in the same thread for symmetry. In practice, throughput for a single connection would be ~4x higher than the values from the benchmarks.
+Throughput benchmarks measure round-trip throughput with the client and server connections in the same thread for symmetry. In practice, a machine would either host only the client or only the server and use multiple threads, so throughput for a single connection could theoretically be up to ~4x higher than the values from the benchmarks (when run on the same machine).
 
 To run memory benchmarks, run `scripts/bench-memory.sh`. A graph of memory usage will be generated in `images/memory.svg`.
 

--- a/bindings/rust/bench/src/bin/graph_perf.rs
+++ b/bindings/rust/bench/src/bin/graph_perf.rs
@@ -136,6 +136,7 @@ fn convert_to_data_series(
 /// Plots given DataSeries with given chart parameters
 fn plot_data<F: Fn(&i32) -> String, G: Fn(&f64) -> String>(
     data: &[DataSeries],
+    image_name: &str,
     bench_name: &str,
     x_label_formatter: &F,
     y_label: &str,
@@ -154,7 +155,7 @@ fn plot_data<F: Fn(&i32) -> String, G: Fn(&f64) -> String>(
         .unwrap();
 
     // setup plotting
-    let path = format!("images/historical-perf-{bench_name}.svg");
+    let path = format!("images/historical-perf-{image_name}.svg");
     let drawing_area = SVGBackend::new(&path, (1000, 500)).into_drawing_area();
     drawing_area.fill(&WHITE).unwrap();
 
@@ -289,6 +290,7 @@ fn main() {
     plot_data(
         &handshake_data,
         "handshake",
+        "handshake",
         &x_label_formatter,
         "Time",
         &|y| format!("{} ms", y / 1e6),
@@ -296,6 +298,7 @@ fn main() {
     plot_data(
         &throughput_data,
         "throughput",
+        "round trip throughput",
         &x_label_formatter,
         "Throughput",
         &|y| format!("{} GB/s", y / 1e9),


### PR DESCRIPTION
### Description of changes: 

s2n-tls's `send()` and `recv()` in the benches currently ignore partial reads and writes; this PR adds functionality to properly handle partial reads/writes. 

Also, this PR adds more documentation for throughput benchmarks and more clearly calls out how throughput benches are round-trip and single-threaded. 

### Testing:

Results from benching don't seem to have changed. To test, run all scripts and benchmarks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
