### PR TITLE
Make invalid chains available via get_client_cert_chain

### DIFF
--- a/tests/unit/s2n_certificate_test.c
+++ b/tests/unit/s2n_certificate_test.c
@@ -18,6 +18,7 @@
 #include "crypto/s2n_openssl_x509.h"
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
+#include "tls/s2n_tls.h"
 #include "utils/s2n_safety.h"
 
 #define S2N_DEFAULT_TEST_CERT_CHAIN_LENGTH 3
@@ -707,7 +708,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_EQUAL(tls12_server_conn->handshake_params.client_cert_chain.size, 0);
         };
 
-        /* Perform TLS1.3 handshake and verify cert chain is NOT available.
+        /* Perform TLS1.3 handshake and verify cert chain is available.
          *
          * The TLS1.3 handshake is only possible if TLS1.3 is fully supported because of client auth:
          * the server doesn't know whether the client will offer a RSA-PSS certificate or not.
@@ -726,7 +727,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(tls13_server_conn->actual_protocol_version, S2N_TLS13);
             EXPECT_NOT_NULL(tls13_server_conn->handshake_params.client_cert_chain.data);
             EXPECT_NOT_EQUAL(tls13_server_conn->handshake_params.client_cert_chain.size, 0);
-        }
+        };
 
         /* Should error if called by client */
         {
@@ -754,7 +755,184 @@ int main(int argc, char **argv)
 
             EXPECT_EQUAL(tls12_output_len, tls13_output_len);
             EXPECT_BYTEARRAY_EQUAL(tls12_output, tls13_output, tls13_output_len);
-        }
+        };
+
+        /* Test: Certificate that skips validation still available */
+        {
+            DEFER_CLEANUP(struct s2n_config *unsafe_config = s2n_config_new(),
+                    s2n_config_ptr_free);
+            EXPECT_SUCCESS(s2n_config_set_client_auth_type(unsafe_config, S2N_CERT_AUTH_REQUIRED));
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(unsafe_config, chain_and_key));
+
+            /* Disable certificate verification */
+            EXPECT_SUCCESS(s2n_config_disable_x509_verification(unsafe_config));
+
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_config(client, unsafe_config));
+
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_config(server, unsafe_config));
+
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+            EXPECT_SUCCESS(s2n_connections_set_io_pair(client, server, &io_pair));
+
+            EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server, client));
+            EXPECT_NOT_EQUAL(server->handshake_params.client_cert_chain.size, 0);
+            EXPECT_NOT_NULL(server->handshake_params.client_cert_chain.data);
+        };
+
+        /* Test: Certificate that fails validation still available */
+        {
+            DEFER_CLEANUP(struct s2n_config *client_config = s2n_config_new(),
+                    s2n_config_ptr_free);
+            EXPECT_SUCCESS(s2n_config_set_client_auth_type(client_config, S2N_CERT_AUTH_REQUIRED));
+            EXPECT_SUCCESS(s2n_config_set_verify_host_callback(client_config, always_verify_host_fn, NULL));
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(client_config, chain_and_key));
+
+            DEFER_CLEANUP(struct s2n_config *server_config = s2n_config_new(),
+                    s2n_config_ptr_free);
+            EXPECT_SUCCESS(s2n_config_set_client_auth_type(server_config, S2N_CERT_AUTH_REQUIRED));
+            EXPECT_SUCCESS(s2n_config_set_verify_host_callback(server_config, always_verify_host_fn, NULL));
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+
+            /* Disable client verification of the server cert.
+             * Do not disable server verification of the client cert, but also
+             * don't provide any trust store to successfully perform the verification.
+             */
+            EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
+
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_blinding(client, S2N_SELF_SERVICE_BLINDING));
+            EXPECT_SUCCESS(s2n_connection_set_config(client, client_config));
+
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_blinding(server, S2N_SELF_SERVICE_BLINDING));
+            EXPECT_SUCCESS(s2n_connection_set_config(server, server_config));
+
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+            EXPECT_SUCCESS(s2n_connections_set_io_pair(client, server, &io_pair));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate_test_server_and_client(server, client),
+                    S2N_ERR_CERT_UNTRUSTED);
+            /* Both the client and server could produce S2N_ERR_CERT_UNTRUSTED.
+             * Verify that only the server encountered an error and therefore only
+             * the server closed the connection.
+             */
+            EXPECT_TRUE(s2n_connection_check_io_status(server, S2N_IO_CLOSED));
+            EXPECT_FALSE(s2n_connection_check_io_status(client, S2N_IO_CLOSED));
+
+            EXPECT_NOT_EQUAL(server->handshake_params.client_cert_chain.size, 0);
+            EXPECT_NOT_NULL(server->handshake_params.client_cert_chain.data);
+        };
+
+        /* Test: Malformed TLS1.2 certificate chain is still available */
+        {
+            DEFER_CLEANUP(struct s2n_stuffer input, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+
+            struct s2n_stuffer_reservation total_size = { 0 };
+            const uint32_t cert_size = 24;
+            EXPECT_SUCCESS(s2n_stuffer_reserve_uint24(&input, &total_size));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint24(&input, cert_size));
+            EXPECT_SUCCESS(s2n_stuffer_skip_write(&input, cert_size));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint24(&input, cert_size));
+            EXPECT_SUCCESS(s2n_stuffer_skip_write(&input, cert_size));
+            EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&total_size));
+
+            /* Sanity check: test cert chain is well-formed (but invalid) */
+            {
+                DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                        s2n_connection_ptr_free);
+                server->actual_protocol_version = S2N_TLS12;
+                EXPECT_SUCCESS(s2n_stuffer_copy(&input, &server->handshake.io,
+                        s2n_stuffer_data_available(&input)));
+
+                EXPECT_FAILURE_WITH_ERRNO(s2n_client_cert_recv(server), S2N_ERR_CERT_INVALID);
+                EXPECT_NOT_EQUAL(server->handshake_params.client_cert_chain.size, 0);
+                EXPECT_NOT_NULL(server->handshake_params.client_cert_chain.data);
+            };
+
+            /* Modify last cert to be malformed. Keep correct total size */
+            EXPECT_SUCCESS(s2n_stuffer_reread(&input));
+            EXPECT_SUCCESS(s2n_stuffer_wipe_n(&input, 1));
+            EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&total_size));
+
+            /* Data available even if malformed: we don't parse pre-TLS1.3 chains
+             * before storing them.
+             */
+            {
+                DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                        s2n_connection_ptr_free);
+                server->actual_protocol_version = S2N_TLS12;
+                EXPECT_SUCCESS(s2n_stuffer_copy(&input, &server->handshake.io,
+                        s2n_stuffer_data_available(&input)));
+
+                EXPECT_FAILURE_WITH_ERRNO(s2n_client_cert_recv(server), S2N_ERR_CERT_INVALID);
+                EXPECT_NOT_EQUAL(server->handshake_params.client_cert_chain.size, 0);
+                EXPECT_NOT_NULL(server->handshake_params.client_cert_chain.data);
+            };
+        };
+
+        /* Test: Malformed TLS1.3 certificate chain is not available */
+        {
+            DEFER_CLEANUP(struct s2n_stuffer input, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+
+            /* Since it's TLS1.3, we also need a zero-length request context */
+            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&input, 0));
+
+            struct s2n_stuffer_reservation total_size = { 0 };
+            const uint32_t cert_size = 24, extensions_size = 20;
+            EXPECT_SUCCESS(s2n_stuffer_reserve_uint24(&input, &total_size));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint24(&input, cert_size));
+            EXPECT_SUCCESS(s2n_stuffer_skip_write(&input, cert_size));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint16(&input, extensions_size));
+            EXPECT_SUCCESS(s2n_stuffer_skip_write(&input, extensions_size));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint24(&input, cert_size));
+            EXPECT_SUCCESS(s2n_stuffer_skip_write(&input, cert_size));
+            EXPECT_SUCCESS(s2n_stuffer_write_uint16(&input, extensions_size));
+            EXPECT_SUCCESS(s2n_stuffer_skip_write(&input, extensions_size));
+            EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&total_size));
+
+            /* Sanity check: test cert chain is well-formed (but invalid) */
+            {
+                DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                        s2n_connection_ptr_free);
+                server->actual_protocol_version = S2N_TLS13;
+                EXPECT_SUCCESS(s2n_stuffer_copy(&input, &server->handshake.io,
+                        s2n_stuffer_data_available(&input)));
+
+                EXPECT_FAILURE_WITH_ERRNO(s2n_client_cert_recv(server), S2N_ERR_CERT_INVALID);
+                EXPECT_NOT_EQUAL(server->handshake_params.client_cert_chain.size, 0);
+                EXPECT_NOT_NULL(server->handshake_params.client_cert_chain.data);
+            };
+
+            /* Modify last extension list to be malformed. Keep correct total size */
+            EXPECT_SUCCESS(s2n_stuffer_reread(&input));
+            EXPECT_SUCCESS(s2n_stuffer_wipe_n(&input, 1));
+            EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&total_size));
+
+            /* Data not available if any certs or extensions malformed: we have
+             * to parse the chain in TLS1.3 to remove the TLS extension lists
+             */
+            {
+                DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                        s2n_connection_ptr_free);
+                server->actual_protocol_version = S2N_TLS13;
+                EXPECT_SUCCESS(s2n_stuffer_copy(&input, &server->handshake.io,
+                        s2n_stuffer_data_available(&input)));
+
+                EXPECT_FAILURE_WITH_ERRNO(s2n_client_cert_recv(server), S2N_ERR_BAD_MESSAGE);
+                EXPECT_EQUAL(server->handshake_params.client_cert_chain.size, 0);
+                EXPECT_NULL(server->handshake_params.client_cert_chain.data);
+            };
+        };
     };
 
     /* Test s2n_cert_chain_and_key_set_ocsp_data */

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -425,7 +425,7 @@ static S2N_RESULT s2n_x509_validator_read_cert_chain(struct s2n_x509_validator *
 
         /* the cert is der encoded, just convert it. */
         server_cert = d2i_X509(NULL, &data, asn1_cert.size);
-        RESULT_ENSURE_REF(server_cert);
+        RESULT_ENSURE(server_cert, S2N_ERR_CERT_INVALID);
 
         /* add the cert to the chain. */
         if (!sk_X509_push(validator->cert_chain_from_wire, server_cert)) {


### PR DESCRIPTION
### Description of changes: 

Currently, [s2n_connection_get_client_cert_chain](https://github.com/aws/s2n-tls/blob/2da0bf416cae49bc2a58222494c1b3ef5aa7f492/api/s2n.h#L2109) does not return certificate chains if certificate verification fails. A customer has requested we change that behavior so that invalid certificates can be logged and examined.

While this is a behavior change for an existing API, I think it's a safely minor one. This would only affect connections that failed / closed due to client cert certificate verification. The error message would still indicate that the certificate chain was untrusted. Additionally, we already return certificate chains that pass the checks in the Certificate message (expiration, chain of trust) but fail the CertificateVerify (proven ownership of private key). The API documentation also never mentioned that the API only returned verified certificate chains.

The alternative would be that we either add a new API specifically for untrusted certificate chains or add an API to toggle this behavior, both of which seem like overkill. Particularly the new API to return untrusted cert chains, since we already have both s2n_connection_get_client_cert_chain and s2n_connection_get_peer_cert_chain to do that for trusted cert chains.

### Testing:
New tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
