### PR TITLE
Prevent get_peer_cert_chain from modifying existing cert chain

### DIFF
--- a/tests/unit/s2n_certificate_test.c
+++ b/tests/unit/s2n_certificate_test.c
@@ -272,25 +272,41 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(server_conn->x509_validator.state, VALIDATED);
             EXPECT_NOT_EQUAL(client_conn->x509_validator.state, VALIDATED);
 
-            struct s2n_cert_chain_and_key *test_peer_chain = s2n_cert_chain_and_key_new();
-            EXPECT_NOT_NULL(test_peer_chain);
-
             /* Safety checks */
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_peer_cert_chain(NULL, chain_and_key), S2N_ERR_NULL);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_peer_cert_chain(server_conn, NULL), S2N_ERR_NULL);
+            {
+                DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain = s2n_cert_chain_and_key_new(),
+                        s2n_cert_chain_and_key_ptr_free);
+                EXPECT_NOT_NULL(chain);
+                EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_peer_cert_chain(NULL, chain), S2N_ERR_NULL);
+                EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_peer_cert_chain(server_conn, NULL), S2N_ERR_NULL);
+            }
 
             /* Input certificate chain is not empty */
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_peer_cert_chain(server_conn, chain_and_key),
-                    S2N_ERR_INVALID_ARGUMENT);
+            {
+                DEFER_CLEANUP(struct s2n_cert_chain_and_key *input = NULL, s2n_cert_chain_and_key_ptr_free);
+                EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&input,
+                        S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
+                EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_peer_cert_chain(server_conn, input),
+                        S2N_ERR_INVALID_ARGUMENT);
+
+                /* Validate original cert chain not modified */
+                EXPECT_NOT_NULL(input->cert_chain);
+                EXPECT_NOT_NULL(input->cert_chain->head);
+                EXPECT_EQUAL(input->cert_chain->head->pkey_type, S2N_PKEY_TYPE_ECDSA);
+            }
 
             /* x509 verification is skipped on client side */
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_peer_cert_chain(client_conn, test_peer_chain),
-                    S2N_ERR_CERT_NOT_VALIDATED);
+            {
+                DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain = s2n_cert_chain_and_key_new(),
+                        s2n_cert_chain_and_key_ptr_free);
+                EXPECT_NOT_NULL(chain);
+                EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_peer_cert_chain(client_conn, chain),
+                        S2N_ERR_CERT_NOT_VALIDATED);
+            }
 
             EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 
             /* Clean-up */
-            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(test_peer_chain));
             EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
             EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
         };

--- a/tests/unit/s2n_certificate_test.c
+++ b/tests/unit/s2n_certificate_test.c
@@ -289,7 +289,7 @@ int main(int argc, char **argv)
                 EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_peer_cert_chain(server_conn, input),
                         S2N_ERR_INVALID_ARGUMENT);
 
-                /* Validate original cert chain not modified */
+                /* Validate that the original cert chain was not modified */
                 EXPECT_NOT_NULL(input->cert_chain);
                 EXPECT_NOT_NULL(input->cert_chain->head);
                 EXPECT_EQUAL(input->cert_chain->head->pkey_type, S2N_PKEY_TYPE_ECDSA);

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -519,11 +519,15 @@ static int s2n_config_add_cert_chain_and_key_impl(struct s2n_config *config, str
 {
     POSIX_ENSURE_REF(config->domain_name_to_cert_map);
     POSIX_ENSURE_REF(cert_key_pair);
+
     s2n_pkey_type cert_type = s2n_cert_chain_and_key_get_pkey_type(cert_key_pair);
     config->is_rsa_cert_configured |= (cert_type == S2N_PKEY_TYPE_RSA);
+
     POSIX_GUARD(s2n_config_build_domain_name_to_cert_map(config, cert_key_pair));
 
     if (!config->default_certs_are_explicit) {
+        POSIX_ENSURE(cert_type >= 0, S2N_ERR_CERT_TYPE_UNSUPPORTED);
+        POSIX_ENSURE(cert_type < S2N_CERT_TYPE_COUNT, S2N_ERR_CERT_TYPE_UNSUPPORTED);
         /* Attempt to auto set default based on ordering. ie: first RSA cert is the default, first ECDSA cert is the
          * default, etc. */
         if (config->default_certs_by_type.certs[cert_type] == NULL) {

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1348,10 +1348,15 @@ int s2n_connection_get_peer_cert_chain(const struct s2n_connection *conn, struct
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(cert_chain_and_key);
+    POSIX_ENSURE_REF(cert_chain_and_key->cert_chain);
+
+    /* Ensure that cert_chain_and_key is empty BEFORE we modify it in any way.
+     * That includes before tying its cert_chain to DEFER_CLEANUP.
+     */
+    POSIX_ENSURE(cert_chain_and_key->cert_chain->head == NULL, S2N_ERR_INVALID_ARGUMENT);
 
     DEFER_CLEANUP(struct s2n_cert_chain *cert_chain = cert_chain_and_key->cert_chain, s2n_cert_chain_free_pointer);
     struct s2n_cert **insert = &cert_chain->head;
-    POSIX_ENSURE(*insert == NULL, S2N_ERR_INVALID_ARGUMENT);
 
     const struct s2n_x509_validator *validator = &conn->x509_validator;
     POSIX_ENSURE_REF(validator);


### PR DESCRIPTION
### Description of changes: 

I found a minor bug while trying to add a new test to s2n_certificates_test. If given an existing `s2n_cert_chain_and_key` as its output parameter, `s2n_connection_get_peer_cert_chain` will free the contents of that `s2n_cert_chain_and_key`. Because we were using the "global" `chain_and_key` to test that case, `chain_and_key` became invalid and subsequent tests that tried to use it failed.

I modified `s2n_connection_get_peer_cert_chain` to prevent the bug. I also modified `s2n_config_add_cert_chain_and_key` to detect it more easily, because it presented confusingly as basically "no valid certs" because the freed s2n_cert_chain_and_key didn't have a valid pkey type (cert_type == -1) so couldn't be added to the default cert mapping.

### Testing:
Existing tests pass. I isolated them better too; they shouldn't be potentially modifying `s2n_cert_chain_and_key`s that could be used elsewhere.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
