### PR TITLE
Pin pytest-rerunfailures version in integration tests

### DIFF
--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -7,12 +7,14 @@ skipsdist = True
 setenv = S2N_INTEG_TEST = 1
 passenv = DYLD_LIBRARY_PATH, LD_LIBRARY_PATH, OQS_OPENSSL_1_1_1_INSTALL_DIR, HOME, TOX_TEST_NAME
 ignore_errors=False
+# NOTE: pytest-rerunfailures 11.0 drops support for pytest 5.x, so we need to
+#       pin our pytest-rerunfailures version until we upgrade pytest.
 deps =
     pep8
     pytest==5.3.5
     pytest-xdist==1.34.0
     sslyze==5.0.2
-    pytest-rerunfailures
+    pytest-rerunfailures==10.2
 commands =
     pytest -x -n={env:XDIST_WORKERS:"2"} --maxfail=1 --reruns=2 --cache-clear -rpfsq \
         -o log_cli=true --log-cli-level=INFO \


### PR DESCRIPTION
# Notes

We've been seeing many failures of the `test_well_known_endpoints` integration tests in PR CI. Upon inspecting the output, I noticed that there was none of the [expected "rerun" output][1] in our failed codebuild jobs. Examining the pytest-rerunfailures plugin's changelog indicated that [version 11.0 dropped support for pytest 5.x][2]. We currently pin our pytest version to 5.3 and do not pin pytest-rerunfailures, so tox takes the latest version of the pytest-rerunfailures, which is incompatible with our version of pytest.

[1]: https://github.com/pytest-dev/pytest-rerunfailures/#output
[2]: https://github.com/pytest-dev/pytest-rerunfailures/blob/master/CHANGES.rst#110-2023-01-12
[3]: https://github.com/aws/s2n-tls/blob/2da0bf416cae49bc2a58222494c1b3ef5aa7f492/tests/integrationv2/tox.ini#L12

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
