### PR TITLE
Update blocked status documentation

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1835,8 +1835,11 @@ typedef enum {
  * rejects the client certificate, the client may later receive an alert while calling s2n_recv,
  * potentially after already having sent application data with s2n_send.
  *
+ * See the following example for guidance on calling `s2n_negotiate()`:
+ * https://github.com/aws/s2n-tls/blob/main/docs/examples/s2n_negotiate.c
+ *
  * @param conn A pointer to the s2n_connection object
- * @param blocked A pointer which will be set to the blocked status. 
+ * @param blocked A pointer which will be set to the blocked status if an `S2N_ERR_T_BLOCKED` error is returned.
  * @returns S2N_SUCCESS if the handshake completed. S2N_FAILURE if the handshake encountered an error or is blocked.
  */
 S2N_API extern int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked);
@@ -1847,24 +1850,15 @@ S2N_API extern int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status
  *
  * @note Partial writes are possible not just for non-blocking I/O, but also for connections aborted while active. 
  * @note Unlike OpenSSL, repeated calls to s2n_send() should not duplicate the original parameters, but should 
- * update `buf` and `size` per the indication of size written. For example;
- * ```c
- * s2n_blocked_status blocked;
- * int written = 0;
- * char data[10]; 
- * do {
- *     int w = s2n_send(conn, data + written, 10 - written, &blocked);
- *     if (w < 0) {
- *         break;
- *     }
- *     written += w;
- * } while (blocked != S2N_NOT_BLOCKED);
- * ```
+ * update `buf` and `size` per the indication of size written.
+ *
+ * See the following example for guidance on calling `s2n_send()`:
+ * https://github.com/aws/s2n-tls/blob/main/docs/examples/s2n_send.c
  *
  * @param conn A pointer to the s2n_connection object
  * @param buf A pointer to a buffer that s2n will write data from
  * @param size The size of buf
- * @param blocked A pointer which will be set to the blocked status, as in s2n_negotiate()
+ * @param blocked A pointer which will be set to the blocked status if an `S2N_ERR_T_BLOCKED` error is returned.
  * @returns The number of bytes written, and may indicate a partial write
  */
 S2N_API extern ssize_t s2n_send(struct s2n_connection *conn, const void *buf, ssize_t size, s2n_blocked_status *blocked);
@@ -1877,7 +1871,7 @@ S2N_API extern ssize_t s2n_send(struct s2n_connection *conn, const void *buf, ss
  * @param conn A pointer to the s2n_connection object
  * @param bufs A pointer to a vector of buffers that s2n will write data from.
  * @param count The number of buffers in `bufs`
- * @param blocked A pointer which will be set to the blocked status, as in s2n_negotiate()
+ * @param blocked A pointer which will be set to the blocked status if an `S2N_ERR_T_BLOCKED` error is returned.
  * @returns The number of bytes written, and may indicate a partial write. 
  */
 S2N_API extern ssize_t s2n_sendv(struct s2n_connection *conn, const struct iovec *bufs, ssize_t count, s2n_blocked_status *blocked);
@@ -1887,29 +1881,16 @@ S2N_API extern ssize_t s2n_sendv(struct s2n_connection *conn, const struct iovec
  *
  * @note Partial writes are possible not just for non-blocking I/O, but also for connections aborted while active.
  *
- * @note Unlike OpenSSL, repeated calls to s2n_sendv_with_offset() should not duplicate the original parameters, but should update `bufs` and `count` per the indication of size written. For example;
- * 
- * ```c
- * s2n_blocked_status blocked;
- * int written = 0;
- * char data[10]; 
- * struct iovec iov[1];
- * iov[0].iov_base = data;
- * iov[0].iov_len = 10;
- * do {
- *     int w = s2n_sendv_with_offset(conn, iov, 1, written, &blocked);
- *     if (w < 0) {
- *         break;
- *     }
- *     written += w;
- * } while (blocked != S2N_NOT_BLOCKED);
- * ```
+ * @note Unlike OpenSSL, repeated calls to s2n_sendv_with_offset() should not duplicate the original parameters, but should update `bufs` and `count` per the indication of size written.
+ *
+ * See the following example for guidance on calling `s2n_sendv_with_offset()`:
+ * https://github.com/aws/s2n-tls/blob/main/docs/examples/s2n_send.c
  *
  * @param conn A pointer to the s2n_connection object
  * @param bufs A pointer to a vector of buffers that s2n will write data from.
  * @param count The number of buffers in `bufs`
  * @param offs The write cursor offset. This should be updated as data is written. See the example code.
- * @param blocked A pointer which will be set to the blocked status, as in s2n_negotiate()
+ * @param blocked A pointer which will be set to the blocked status if an `S2N_ERR_T_BLOCKED` error is returned.
  * @returns The number of bytes written, and may indicate a partial write. 
  */
 S2N_API extern ssize_t s2n_sendv_with_offset(struct s2n_connection *conn, const struct iovec *bufs, ssize_t count, ssize_t offs, s2n_blocked_status *blocked);
@@ -1918,24 +1899,15 @@ S2N_API extern ssize_t s2n_sendv_with_offset(struct s2n_connection *conn, const 
  * Decrypts and reads **size* to `buf` data from the associated
  * connection. 
  * 
- * @note Unlike OpenSSL, repeated calls to `s2n_recv` should not duplicate the original parameters, but should update `buf` and `size` per the indication of size read. For example;
- * ```c
- * s2n_blocked_status blocked;
- * int bytes_read = 0;
- * char data[10];
- * do {
- *     int r = s2n_recv(conn, data + bytes_read, 10 - bytes_read, &blocked);
- *     if (r < 0) {
- *         break;
- *     }
- *     bytes_read += r;
- * } while (blocked != S2N_NOT_BLOCKED);
- * ```
+ * @note Unlike OpenSSL, repeated calls to `s2n_recv` should not duplicate the original parameters, but should update `buf` and `size` per the indication of size read.
+ *
+ * See the following example for guidance on calling `s2n_recv()`:
+ * https://github.com/aws/s2n-tls/blob/main/docs/examples/s2n_recv.c
  *
  * @param conn A pointer to the s2n_connection object
  * @param buf A pointer to a buffer that s2n will place read data into.
  * @param size Size of `buf`
- * @param blocked A pointer which will be set to the blocked status, as in s2n_negotiate()
+ * @param blocked A pointer which will be set to the blocked status if an `S2N_ERR_T_BLOCKED` error is returned.
  * @returns number of bytes read. 0 if the connection was shutdown by peer.
  */
 S2N_API extern ssize_t s2n_recv(struct s2n_connection *conn, void *buf, ssize_t size, s2n_blocked_status *blocked);
@@ -2009,7 +1981,7 @@ S2N_API extern int s2n_connection_free(struct s2n_connection *conn);
  * * The s2n_connection handle can be freed via s2n_connection_free() or reused via s2n_connection_wipe()
  *
  * @param conn A pointer to the s2n_connection object
- * @param blocked A pointer which will be set to the blocked status, as in s2n_negotiate()
+ * @param blocked A pointer which will be set to the blocked status if an `S2N_ERR_T_BLOCKED` error is returned.
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
  */
 S2N_API extern int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status *blocked);
@@ -2037,7 +2009,7 @@ S2N_API extern int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status 
  * the read side of the underlying transport.
  *
  * @param conn A pointer to the s2n_connection object
- * @param blocked A pointer which will be set to the blocked status, as in s2n_negotiate()
+ * @param blocked A pointer which will be set to the blocked status if an `S2N_ERR_T_BLOCKED` error is returned.
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
  */
 S2N_API extern int s2n_shutdown_send(struct s2n_connection *conn, s2n_blocked_status *blocked);

--- a/docs/examples/s2n_recv.c
+++ b/docs/examples/s2n_recv.c
@@ -21,11 +21,24 @@ int s2n_example_recv(struct s2n_connection *conn, uint8_t *buffer, size_t buffer
     int bytes_read = 0;
     while (bytes_read < buffer_size) {
         int r = s2n_recv(conn, buffer + bytes_read, buffer_size - bytes_read, &blocked);
-        if (r == 0) {
-            break;
-        } else if (r > 0) {
+        if (r > 0) {
+            /* `r` bytes were successfully received. Update `bytes_read` so the next `s2n_recv()`
+             * call writes into the buffer with the correct offset.
+             */
             bytes_read += r;
-        } else if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
+        } else if (r == 0) {
+            /* The connection was closed. No more data will be received, so bail out of the loop. */
+            break;
+        } else if (s2n_error_get_type(s2n_errno) == S2N_ERR_T_BLOCKED) {
+            /* The return of `s2n_recv()` indicates an error. If this error is `S2N_ERR_T_BLOCKED`,
+             * the socket is blocked waiting to receive more data from the peer. In a typical
+             * non-blocking environment, `poll()` or `select()` would be used re-enter
+             * `s2n_example_recv()` and call `s2n_recv()` again after the socket has more data
+             * available.
+             */
+            continue;
+        } else {
+            /* `s2n_recv()` encountered an irrecoverable error. Log the error and return. */
             fprintf(stderr, "Error: %s. %s\n", s2n_strerror(s2n_errno, NULL), s2n_strerror_debug(s2n_errno, NULL));
             return -1;
         }

--- a/docs/examples/s2n_recv.c
+++ b/docs/examples/s2n_recv.c
@@ -31,10 +31,12 @@ int s2n_example_recv(struct s2n_connection *conn, uint8_t *buffer, size_t buffer
             break;
         } else if (s2n_error_get_type(s2n_errno) == S2N_ERR_T_BLOCKED) {
             /* The return of `s2n_recv()` indicates an error. If this error is `S2N_ERR_T_BLOCKED`,
-             * the socket is blocked waiting to receive more data from the peer. In a typical
-             * non-blocking environment, `poll()` or `select()` would be used re-enter
+             * the socket is blocked waiting to receive more data from the peer.
+             *
+             * In a typical non-blocking environment, `poll()` or `select()` would be used re-enter
              * `s2n_example_recv()` and call `s2n_recv()` again after the socket has more data
-             * available.
+             * available. But this example just busy-waits, so we immediately call `s2n_recv()`
+             * again.
              */
             continue;
         } else {

--- a/docs/examples/s2n_send.c
+++ b/docs/examples/s2n_send.c
@@ -22,8 +22,19 @@ int s2n_example_send(struct s2n_connection *conn, uint8_t *data, size_t data_siz
     while (bytes_written < data_size) {
         int w = s2n_send(conn, data + bytes_written, data_size - bytes_written, &blocked);
         if (w >= 0) {
+            /* `w` bytes were successfully sent. Update `bytes_written` so the next call to
+             * `s2n_send()` will send data from the correct offset in the buffer.
+             */
             bytes_written += w;
-        } else if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
+        } else if (s2n_error_get_type(s2n_errno) == S2N_ERR_T_BLOCKED) {
+            /* The return of `s2n_send()` indicates an error. If this error is `S2N_ERR_T_BLOCKED`,
+             * the socket is blocked waiting to send more data. In a typical non-blocking
+             * environment, `poll()` or `select()` would be used re-enter `s2n_example_send()` and
+             * call `s2n_send()` again after the socket is ready to send more data.
+             */
+            continue;
+        } else {
+            /* `s2n_send()` encountered an irrecoverable error. Log the error and return. */
             fprintf(stderr, "Error: %s. %s\n", s2n_strerror(s2n_errno, NULL), s2n_strerror_debug(s2n_errno, NULL));
             return -1;
         }

--- a/docs/examples/s2n_send.c
+++ b/docs/examples/s2n_send.c
@@ -28,9 +28,12 @@ int s2n_example_send(struct s2n_connection *conn, uint8_t *data, size_t data_siz
             bytes_written += w;
         } else if (s2n_error_get_type(s2n_errno) == S2N_ERR_T_BLOCKED) {
             /* The return of `s2n_send()` indicates an error. If this error is `S2N_ERR_T_BLOCKED`,
-             * the socket is blocked waiting to send more data. In a typical non-blocking
-             * environment, `poll()` or `select()` would be used re-enter `s2n_example_send()` and
-             * call `s2n_send()` again after the socket is ready to send more data.
+             * the socket is blocked waiting to send more data.
+             *
+             * In a typical non-blocking environment, `poll()` or `select()` would be used re-enter
+             * `s2n_example_send()` and call `s2n_send()` again after the socket is ready to send
+             * more data. But this example just busy-waits, so we immediately call `s2n_send()`
+             * again.
              */
             continue;
         } else {


### PR DESCRIPTION
### Description of changes: 

The `blocked` status argument in  the `s2n_recv()` and `s2n_send()` APIs is confusing, and some of our documentation incorrectly describe how this `blocked` argument should be used. This PR tries to clarify how these APIs should be called, and what the `blocked` status argument should and should not be used for.

### Call-outs:

- I thought it might be best to point to our tested code examples in the API docs, and then we only have to update the examples in one place. But let me know if it seems better to have inline code examples for doxygen.
- Please let me know if I'm not describing something accurately, or if there's a better way to explain something.

### Testing:

`s2n_examples_test.c` tests my changes to the examples.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
