### PR TITLE
Use client_hello.parsed as precondition for retrieving client_hello

### DIFF
--- a/tests/unit/s2n_self_talk_tls13_test.c
+++ b/tests/unit/s2n_self_talk_tls13_test.c
@@ -138,6 +138,7 @@ int main(int argc, char **argv)
 
     /* Negotiate the handshake. */
     EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
+    EXPECT_NOT_NULL(s2n_connection_get_client_hello(conn));
     EXPECT_EQUAL(conn->actual_protocol_version, s2n_get_highest_fully_supported_tls_version());
 
     char buffer[0xffff];

--- a/tests/unit/s2n_server_hello_retry_test.c
+++ b/tests/unit/s2n_server_hello_retry_test.c
@@ -507,6 +507,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(server_conn->handshake.handshake_type & HELLO_RETRY_REQUEST);
         EXPECT_EQUAL(client_hello_ctx.invocations, 1);
 
+        EXPECT_NOT_NULL(s2n_connection_get_client_hello(server_conn));
         EXPECT_TRUE(IS_HELLO_RETRY_HANDSHAKE(client_conn));
         EXPECT_TRUE(IS_HELLO_RETRY_HANDSHAKE(server_conn));
 

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -43,7 +43,7 @@
 
 struct s2n_client_hello *s2n_connection_get_client_hello(struct s2n_connection *conn)
 {
-    if (conn->client_hello.callback_invoked != 1) {
+    if (conn->client_hello.parsed != 1) {
         return NULL;
     }
 
@@ -638,6 +638,7 @@ int s2n_client_hello_recv(struct s2n_connection *conn)
     /* Only parse the ClientHello once */
     if (!conn->client_hello.parsed) {
         POSIX_GUARD(s2n_parse_client_hello(conn));
+        /* Mark the collected client hello as available when parsing is done and before the client hello callback */
         conn->client_hello.parsed = true;
     }
 
@@ -647,7 +648,7 @@ int s2n_client_hello_recv(struct s2n_connection *conn)
      * callback state may have been cleared while parsing the second ClientHello.
      */
     if (!conn->client_hello.callback_invoked && !IS_HELLO_RETRY_HANDSHAKE(conn)) {
-        /* Mark the collected client hello as available when parsing is done and before the client hello callback */
+        /* Mark the client hello callback as invoked to avoid calling it again. */
         conn->client_hello.callback_invoked = true;
 
         /* Call client_hello_cb if exists, letting application to modify s2n_connection or swap s2n_config */


### PR DESCRIPTION


### Resolved issues:
#4141 

### Description of changes: 

Previously the s2n_connection_get_client_hello function used invoking the client_hello callback as a precondition to allow retrieving a client_hello. This does not work for handshakes that use a HelloRetryRequest(HRR) because HRR does not currently trigger a client_hello callback in s2n.

resolves #4141

### Call-outs:

I have tried to think of negative side effects of this been unable to come up with any. Please feel free to apply paranoia and call out reasons this change will be risky.

### Testing:

I added verification to two existing test cases to verify the client_hello is returned for an HRR 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
