### PR TITLE
kTLS: implement sendmsg

### DIFF
--- a/tests/testlib/s2n_ktls_test_utils.c
+++ b/tests/testlib/s2n_ktls_test_utils.c
@@ -207,7 +207,7 @@ S2N_RESULT s2n_test_validate_ancillary(struct s2n_test_ktls_io_stuffer *ktls_io,
     uint8_t tag = 0;
     RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(&validate_ancillary_stuffer, &tag));
     RESULT_ENSURE_EQ(tag, expected_record_type);
-    uint16_t len;
+    uint16_t len = 0;
     RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&validate_ancillary_stuffer, &len));
     RESULT_ENSURE_EQ(len, expected_len);
 

--- a/tests/testlib/s2n_ktls_test_utils.c
+++ b/tests/testlib/s2n_ktls_test_utils.c
@@ -182,3 +182,34 @@ S2N_CLEANUP_RESULT s2n_ktls_io_stuffer_pair_free(struct s2n_test_ktls_io_stuffer
 
     return S2N_RESULT_OK;
 }
+
+S2N_RESULT s2n_test_validate_data(struct s2n_test_ktls_io_stuffer *ktls_io, uint8_t *expected_data,
+        uint16_t expected_len)
+{
+    RESULT_ENSURE_REF(ktls_io);
+    RESULT_ENSURE_REF(expected_data);
+
+    struct s2n_stuffer validate_data_stuffer = ktls_io->data_buffer;
+    RESULT_ENSURE_EQ(s2n_stuffer_data_available(&validate_data_stuffer), expected_len);
+    uint8_t *data_ptr = s2n_stuffer_raw_read(&validate_data_stuffer, expected_len);
+    RESULT_ENSURE_REF(data_ptr);
+    RESULT_ENSURE_EQ(memcmp(data_ptr, expected_data, expected_len), 0);
+
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_test_validate_ancillary(struct s2n_test_ktls_io_stuffer *ktls_io,
+        uint8_t expected_record_type, uint16_t expected_len)
+{
+    RESULT_ENSURE_REF(ktls_io);
+
+    struct s2n_stuffer validate_ancillary_stuffer = ktls_io->ancillary_buffer;
+    uint8_t tag = 0;
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(&validate_ancillary_stuffer, &tag));
+    RESULT_ENSURE_EQ(tag, expected_record_type);
+    uint16_t len;
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&validate_ancillary_stuffer, &len));
+    RESULT_ENSURE_EQ(len, expected_len);
+
+    return S2N_RESULT_OK;
+}

--- a/tests/testlib/s2n_ktls_test_utils.h
+++ b/tests/testlib/s2n_ktls_test_utils.h
@@ -62,8 +62,11 @@ struct s2n_test_ktls_io_stuffer_pair {
 ssize_t s2n_test_ktls_sendmsg_io_stuffer(void *io_context, const struct msghdr *msg);
 ssize_t s2n_test_ktls_recvmsg_io_stuffer(void *io_context, struct msghdr *msg);
 
+S2N_RESULT s2n_test_init_ktls_io_stuffer_send(struct s2n_connection *conn,
+        struct s2n_test_ktls_io_stuffer *io);
 S2N_RESULT s2n_test_init_ktls_io_stuffer(struct s2n_connection *server,
         struct s2n_connection *client, struct s2n_test_ktls_io_stuffer_pair *io_pair);
+S2N_CLEANUP_RESULT s2n_ktls_io_stuffer_free(struct s2n_test_ktls_io_stuffer *io);
 S2N_CLEANUP_RESULT s2n_ktls_io_stuffer_pair_free(struct s2n_test_ktls_io_stuffer_pair *pair);
 S2N_RESULT s2n_test_validate_data(struct s2n_test_ktls_io_stuffer *ktls_io, uint8_t *expected_data,
         uint16_t expected_len);

--- a/tests/testlib/s2n_ktls_test_utils.h
+++ b/tests/testlib/s2n_ktls_test_utils.h
@@ -65,3 +65,7 @@ ssize_t s2n_test_ktls_recvmsg_io_stuffer(void *io_context, struct msghdr *msg);
 S2N_RESULT s2n_test_init_ktls_io_stuffer(struct s2n_connection *server,
         struct s2n_connection *client, struct s2n_test_ktls_io_stuffer_pair *io_pair);
 S2N_CLEANUP_RESULT s2n_ktls_io_stuffer_pair_free(struct s2n_test_ktls_io_stuffer_pair *pair);
+S2N_RESULT s2n_test_validate_data(struct s2n_test_ktls_io_stuffer *ktls_io, uint8_t *expected_data,
+        uint16_t expected_len);
+S2N_RESULT s2n_test_validate_ancillary(struct s2n_test_ktls_io_stuffer *ktls_io,
+        uint8_t expected_record_type, uint16_t expected_len);

--- a/tests/unit/s2n_ktls_io_test.c
+++ b/tests/unit/s2n_ktls_io_test.c
@@ -124,6 +124,10 @@ int main(int argc, char **argv)
                     s2n_ktls_sendmsg(
                             server, test_record_type, &msg_iov_valid, 1, NULL, &bytes_written),
                     S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(
+                    s2n_ktls_sendmsg(
+                            server, test_record_type, &msg_iov_valid, 1, &blocked, NULL),
+                    S2N_ERR_NULL);
 
             struct iovec msg_iov_null_data = { .iov_base = NULL, .iov_len = S2N_TEST_TO_SEND };
             EXPECT_ERROR_WITH_ERRNO(

--- a/tests/unit/s2n_ktls_io_test.c
+++ b/tests/unit/s2n_ktls_io_test.c
@@ -19,7 +19,8 @@
 #include "tls/s2n_ktls.h"
 #include "utils/s2n_random.h"
 
-#define S2N_TEST_TO_SEND 10
+#define S2N_TEST_TO_SEND    10
+#define S2N_TEST_MSG_IOVLEN 5
 
 S2N_RESULT s2n_ktls_set_control_data(struct msghdr *msg, char *buf, size_t buf_size,
         int cmsg_type, uint8_t record_type);
@@ -121,18 +122,15 @@ int main(int argc, char **argv)
                     s2n_ktls_sendmsg(server, test_record_type, NULL, 1, &blocked, &bytes_written),
                     S2N_ERR_NULL);
             EXPECT_ERROR_WITH_ERRNO(
-                    s2n_ktls_sendmsg(
-                            server, test_record_type, &msg_iov_valid, 1, NULL, &bytes_written),
+                    s2n_ktls_sendmsg(server, test_record_type, &msg_iov_valid, 1, NULL, &bytes_written),
                     S2N_ERR_NULL);
             EXPECT_ERROR_WITH_ERRNO(
-                    s2n_ktls_sendmsg(
-                            server, test_record_type, &msg_iov_valid, 1, &blocked, NULL),
+                    s2n_ktls_sendmsg(server, test_record_type, &msg_iov_valid, 1, &blocked, NULL),
                     S2N_ERR_NULL);
 
             struct iovec msg_iov_null_data = { .iov_base = NULL, .iov_len = S2N_TEST_TO_SEND };
             EXPECT_ERROR_WITH_ERRNO(
-                    s2n_ktls_sendmsg(
-                            server, test_record_type, &msg_iov_null_data, 1, &blocked, &bytes_written),
+                    s2n_ktls_sendmsg(server, test_record_type, &msg_iov_null_data, 1, &blocked, &bytes_written),
                     S2N_ERR_INVALID_ARGUMENT);
         };
 
@@ -154,8 +152,8 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
 
             /* confirm sent data */
-            EXPECT_OK(s2n_test_validate_data(&io_pair.client_in, test_data, S2N_TEST_TO_SEND));
             EXPECT_OK(s2n_test_validate_ancillary(&io_pair.client_in, test_record_type, S2N_TEST_TO_SEND));
+            EXPECT_OK(s2n_test_validate_data(&io_pair.client_in, test_data, S2N_TEST_TO_SEND));
 
             EXPECT_EQUAL(io_pair.client_in.sendmsg_invoked_count, 1);
             EXPECT_EQUAL(io_pair.server_in.sendmsg_invoked_count, 0);
@@ -171,10 +169,9 @@ int main(int argc, char **argv)
                     s2n_ktls_io_stuffer_pair_free);
             EXPECT_OK(s2n_test_init_ktls_io_stuffer(server, client, &io_pair));
 
+            struct iovec msg_iov[sizeof(struct iovec) * S2N_TEST_MSG_IOVLEN] = { 0 };
             size_t total_sent = 0;
-            uint8_t count = 5;
-            struct iovec msg_iov[sizeof(struct iovec) * 5] = { 0 };
-            for (size_t i = 0; i < count; i++) {
+            for (size_t i = 0; i < S2N_TEST_MSG_IOVLEN; i++) {
                 msg_iov[i].iov_base = test_data + total_sent;
                 msg_iov[i].iov_len = S2N_TEST_TO_SEND;
                 total_sent += S2N_TEST_TO_SEND;
@@ -182,14 +179,13 @@ int main(int argc, char **argv)
 
             s2n_blocked_status blocked = S2N_NOT_BLOCKED;
             size_t bytes_written = 0;
-            EXPECT_OK(s2n_ktls_sendmsg(
-                    server, test_record_type, msg_iov, count, &blocked, &bytes_written));
-            EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+            EXPECT_OK(s2n_ktls_sendmsg(server, test_record_type, msg_iov, S2N_TEST_MSG_IOVLEN, &blocked, &bytes_written));
             EXPECT_EQUAL(bytes_written, total_sent);
+            EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
 
             /* confirm sent data */
-            EXPECT_OK(s2n_test_validate_data(&io_pair.client_in, test_data, total_sent));
             EXPECT_OK(s2n_test_validate_ancillary(&io_pair.client_in, test_record_type, total_sent));
+            EXPECT_OK(s2n_test_validate_data(&io_pair.client_in, test_data, total_sent));
             /* validate only 1 record was sent  */
             EXPECT_EQUAL(s2n_stuffer_data_available(&io_pair.client_in.ancillary_buffer),
                     S2N_TEST_KTLS_MOCK_HEADER_SIZE);
@@ -209,10 +205,10 @@ int main(int argc, char **argv)
             /* disable growable to simulate blocked/network buffer full */
             io_pair.client_in.data_buffer.growable = false;
 
+            struct iovec msg_iov = { .iov_base = test_data, .iov_len = S2N_TEST_TO_SEND };
             s2n_blocked_status blocked = S2N_NOT_BLOCKED;
             size_t blocked_invoked_count = 5;
             size_t bytes_written = 0;
-            struct iovec msg_iov = { .iov_base = test_data, .iov_len = S2N_TEST_TO_SEND };
             for (size_t i = 0; i < blocked_invoked_count; i++) {
                 EXPECT_ERROR_WITH_ERRNO(
                         s2n_ktls_sendmsg(server, test_record_type, &msg_iov, 1, &blocked, &bytes_written),
@@ -223,13 +219,12 @@ int main(int argc, char **argv)
             /* enable growable to unblock write */
             /* cppcheck-suppress redundantAssignment */
             io_pair.client_in.data_buffer.growable = true;
-            EXPECT_OK(
-                    s2n_ktls_sendmsg(server, test_record_type, &msg_iov, 1, &blocked, &bytes_written));
+            EXPECT_OK(s2n_ktls_sendmsg(server, test_record_type, &msg_iov, 1, &blocked, &bytes_written));
             EXPECT_EQUAL(bytes_written, S2N_TEST_TO_SEND);
 
             /* confirm sent data */
-            EXPECT_OK(s2n_test_validate_data(&io_pair.client_in, test_data, S2N_TEST_TO_SEND));
             EXPECT_OK(s2n_test_validate_ancillary(&io_pair.client_in, test_record_type, S2N_TEST_TO_SEND));
+            EXPECT_OK(s2n_test_validate_data(&io_pair.client_in, test_data, S2N_TEST_TO_SEND));
 
             EXPECT_EQUAL(io_pair.client_in.sendmsg_invoked_count, blocked_invoked_count + 1);
         };
@@ -295,14 +290,12 @@ int main(int argc, char **argv)
 
             struct iovec msg_iov = { .iov_base = test_data, .iov_len = S2N_TEST_TO_SEND };
             size_t iovlen_zero = 0;
-            EXPECT_OK(s2n_ktls_sendmsg(
-                    server, test_record_type, &msg_iov, iovlen_zero, &blocked, &bytes_written));
+            EXPECT_OK(s2n_ktls_sendmsg(server, test_record_type, &msg_iov, iovlen_zero, &blocked, &bytes_written));
             EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
             EXPECT_EQUAL(bytes_written, 0);
 
             struct iovec msg_iov_len_zero = { .iov_base = test_data, .iov_len = 0 };
-            EXPECT_OK(s2n_ktls_sendmsg(
-                    server, test_record_type, &msg_iov_len_zero, 1, &blocked, &bytes_written));
+            EXPECT_OK(s2n_ktls_sendmsg(server, test_record_type, &msg_iov_len_zero, 1, &blocked, &bytes_written));
             EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
             EXPECT_EQUAL(bytes_written, 0);
 

--- a/tests/unit/s2n_ktls_io_test.c
+++ b/tests/unit/s2n_ktls_io_test.c
@@ -124,11 +124,6 @@ int main(int argc, char **argv)
             EXPECT_ERROR_WITH_ERRNO(
                     s2n_ktls_sendmsg(server, test_record_type, &msg_iov_valid, 1, &blocked, NULL),
                     S2N_ERR_NULL);
-
-            struct iovec msg_iov_null_data = { .iov_base = NULL, .iov_len = S2N_TEST_TO_SEND };
-            EXPECT_ERROR_WITH_ERRNO(
-                    s2n_ktls_sendmsg(server, test_record_type, &msg_iov_null_data, 1, &blocked, &bytes_written),
-                    S2N_ERR_INVALID_ARGUMENT);
         };
 
         /* Happy case: msg_iovlen = 1 */

--- a/tests/unit/s2n_ktls_io_test.c
+++ b/tests/unit/s2n_ktls_io_test.c
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
             size_t bytes_written = 0;
 
             EXPECT_ERROR_WITH_ERRNO(
-                    s2n_ktls_sendmsg(NULL, test_record_type, NULL, 1, &blocked, &bytes_written),
+                    s2n_ktls_sendmsg(NULL, test_record_type, &msg_iov_valid, 1, &blocked, &bytes_written),
                     S2N_ERR_NULL);
             EXPECT_ERROR_WITH_ERRNO(
                     s2n_ktls_sendmsg(server, test_record_type, NULL, 1, &blocked, &bytes_written),

--- a/tests/unit/s2n_ktls_io_test.c
+++ b/tests/unit/s2n_ktls_io_test.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
-    uint8_t test_record_type = 43;
+    const uint8_t test_record_type = 43;
     /* test data */
     uint8_t test_data[S2N_TLS_MAXIMUM_FRAGMENT_LENGTH] = { 0 };
     struct s2n_blob test_data_blob = { 0 };
@@ -108,16 +108,14 @@ int main(int argc, char **argv)
         {
             DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
                     s2n_connection_ptr_free);
-            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
-                    s2n_connection_ptr_free);
-            DEFER_CLEANUP(struct s2n_test_ktls_io_stuffer_pair io_pair = { 0 },
-                    s2n_ktls_io_stuffer_pair_free);
-            EXPECT_OK(s2n_test_init_ktls_io_stuffer(server, client, &io_pair));
 
             struct iovec msg_iov_valid = { .iov_base = test_data, .iov_len = S2N_TEST_TO_SEND };
             s2n_blocked_status blocked = S2N_NOT_BLOCKED;
             size_t bytes_written = 0;
 
+            EXPECT_ERROR_WITH_ERRNO(
+                    s2n_ktls_sendmsg(NULL, test_record_type, NULL, 1, &blocked, &bytes_written),
+                    S2N_ERR_NULL);
             EXPECT_ERROR_WITH_ERRNO(
                     s2n_ktls_sendmsg(server, test_record_type, NULL, 1, &blocked, &bytes_written),
                     S2N_ERR_NULL);
@@ -169,7 +167,7 @@ int main(int argc, char **argv)
                     s2n_ktls_io_stuffer_pair_free);
             EXPECT_OK(s2n_test_init_ktls_io_stuffer(server, client, &io_pair));
 
-            struct iovec msg_iov[sizeof(struct iovec) * S2N_TEST_MSG_IOVLEN] = { 0 };
+            struct iovec msg_iov[S2N_TEST_MSG_IOVLEN] = { 0 };
             size_t total_sent = 0;
             for (size_t i = 0; i < S2N_TEST_MSG_IOVLEN; i++) {
                 msg_iov[i].iov_base = test_data + total_sent;

--- a/tests/unit/s2n_ktls_io_test.c
+++ b/tests/unit/s2n_ktls_io_test.c
@@ -28,8 +28,8 @@ S2N_RESULT s2n_ktls_get_control_data(struct msghdr *msg, int cmsg_type, uint8_t 
 
 /* Mock implementation used for validating failure behavior */
 struct s2n_test_ktls_io_fail {
-    size_t errno_code;
     size_t invoked_count;
+    size_t errno_code;
 };
 
 static ssize_t s2n_test_ktls_sendmsg_fail(void *io_context, const struct msghdr *msg)
@@ -37,7 +37,6 @@ static ssize_t s2n_test_ktls_sendmsg_fail(void *io_context, const struct msghdr 
     struct s2n_test_ktls_io_fail *io_ctx = (struct s2n_test_ktls_io_fail *) io_context;
     POSIX_ENSURE_REF(io_ctx);
     io_ctx->invoked_count++;
-
     errno = io_ctx->errno_code;
     return -1;
 }
@@ -254,9 +253,9 @@ int main(int argc, char **argv)
             };
             EXPECT_OK(s2n_ktls_set_sendmsg_cb(server, s2n_test_ktls_sendmsg_fail, &io_ctx));
 
+            struct iovec msg_iov = { .iov_base = test_data, .iov_len = S2N_TEST_TO_SEND };
             s2n_blocked_status blocked = S2N_NOT_BLOCKED;
             size_t bytes_written = 0;
-            struct iovec msg_iov = { .iov_base = test_data, .iov_len = S2N_TEST_TO_SEND };
             EXPECT_ERROR_WITH_ERRNO(
                     s2n_ktls_sendmsg(server, test_record_type, &msg_iov, 1, &blocked, &bytes_written),
                     S2N_ERR_IO);
@@ -274,10 +273,10 @@ int main(int argc, char **argv)
                     s2n_ktls_io_stuffer_free);
             EXPECT_OK(s2n_test_init_ktls_io_stuffer_send(server, &client_in));
 
+            struct iovec msg_iov = { .iov_base = test_data, .iov_len = S2N_TEST_TO_SEND };
             s2n_blocked_status blocked = S2N_NOT_BLOCKED;
             size_t bytes_written = 0;
 
-            struct iovec msg_iov = { .iov_base = test_data, .iov_len = S2N_TEST_TO_SEND };
             size_t iovlen_zero = 0;
             EXPECT_OK(s2n_ktls_sendmsg(server, test_record_type, &msg_iov, iovlen_zero, &blocked, &bytes_written));
             EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);

--- a/tests/unit/s2n_ktls_io_test.c
+++ b/tests/unit/s2n_ktls_io_test.c
@@ -14,16 +14,43 @@
  */
 
 #include "s2n_test.h"
+#include "testlib/s2n_ktls_test_utils.h"
 #include "testlib/s2n_testlib.h"
 #include "tls/s2n_ktls.h"
+#include "utils/s2n_random.h"
+
+#define S2N_TEST_TO_SEND 10
 
 S2N_RESULT s2n_ktls_set_control_data(struct msghdr *msg, char *buf, size_t buf_size,
         int cmsg_type, uint8_t record_type);
 S2N_RESULT s2n_ktls_get_control_data(struct msghdr *msg, int cmsg_type, uint8_t *record_type);
 
+/* Mock implementation used for validating failure behavior */
+struct s2n_test_ktls_io_fail {
+    size_t errno_code;
+    size_t invoked_count;
+};
+
+static ssize_t s2n_test_ktls_sendmsg_fail(void *io_context, const struct msghdr *msg)
+{
+    struct s2n_test_ktls_io_fail *io_ctx = (struct s2n_test_ktls_io_fail *) io_context;
+    POSIX_ENSURE_REF(io_ctx);
+    io_ctx->invoked_count++;
+
+    errno = io_ctx->errno_code;
+    return -1;
+}
+
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
+
+    uint8_t test_record_type = 43;
+    /* test data */
+    uint8_t test_data[S2N_TLS_MAXIMUM_FRAGMENT_LENGTH] = { 0 };
+    struct s2n_blob test_data_blob = { 0 };
+    EXPECT_SUCCESS(s2n_blob_init(&test_data_blob, test_data, sizeof(test_data)));
+    EXPECT_OK(s2n_get_public_random_data(&test_data_blob));
 
     /* Test s2n_ktls_set_control_data and s2n_ktls_get_control_data */
     {
@@ -71,6 +98,211 @@ int main(int argc, char **argv)
             uint8_t get_record_type = 0;
             EXPECT_ERROR_WITH_ERRNO(s2n_ktls_get_control_data(&msg, bad_cmsg_type, &get_record_type),
                     S2N_ERR_KTLS_BAD_CMSG);
+        };
+    };
+
+    /* Test s2n_ktls_sendmsg */
+    {
+        /* Safety */
+        {
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            DEFER_CLEANUP(struct s2n_test_ktls_io_stuffer_pair io_pair = { 0 },
+                    s2n_ktls_io_stuffer_pair_free);
+            EXPECT_OK(s2n_test_init_ktls_io_stuffer(server, client, &io_pair));
+
+            struct iovec msg_iov_valid = { .iov_base = test_data, .iov_len = S2N_TEST_TO_SEND };
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            size_t bytes_written = 0;
+
+            EXPECT_ERROR_WITH_ERRNO(
+                    s2n_ktls_sendmsg(server, test_record_type, NULL, 1, &blocked, &bytes_written),
+                    S2N_ERR_NULL);
+            EXPECT_ERROR_WITH_ERRNO(
+                    s2n_ktls_sendmsg(
+                            server, test_record_type, &msg_iov_valid, 1, NULL, &bytes_written),
+                    S2N_ERR_NULL);
+
+            struct iovec msg_iov_null_data = { .iov_base = NULL, .iov_len = S2N_TEST_TO_SEND };
+            EXPECT_ERROR_WITH_ERRNO(
+                    s2n_ktls_sendmsg(
+                            server, test_record_type, &msg_iov_null_data, 1, &blocked, &bytes_written),
+                    S2N_ERR_INVALID_ARGUMENT);
+        };
+
+        /* Happy case: msg_iovlen = 1 */
+        {
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            DEFER_CLEANUP(struct s2n_test_ktls_io_stuffer_pair io_pair = { 0 },
+                    s2n_ktls_io_stuffer_pair_free);
+            EXPECT_OK(s2n_test_init_ktls_io_stuffer(server, client, &io_pair));
+
+            struct iovec msg_iov = { .iov_base = test_data, .iov_len = S2N_TEST_TO_SEND };
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            size_t bytes_written = 0;
+            EXPECT_OK(s2n_ktls_sendmsg(server, test_record_type, &msg_iov, 1, &blocked, &bytes_written));
+            EXPECT_EQUAL(bytes_written, S2N_TEST_TO_SEND);
+            EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+
+            /* confirm sent data */
+            EXPECT_OK(s2n_test_validate_data(&io_pair.client_in, test_data, S2N_TEST_TO_SEND));
+            EXPECT_OK(s2n_test_validate_ancillary(&io_pair.client_in, test_record_type, S2N_TEST_TO_SEND));
+
+            EXPECT_EQUAL(io_pair.client_in.sendmsg_invoked_count, 1);
+            EXPECT_EQUAL(io_pair.server_in.sendmsg_invoked_count, 0);
+        };
+
+        /* Happy case: msg_iovlen > 1 */
+        {
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            DEFER_CLEANUP(struct s2n_test_ktls_io_stuffer_pair io_pair = { 0 },
+                    s2n_ktls_io_stuffer_pair_free);
+            EXPECT_OK(s2n_test_init_ktls_io_stuffer(server, client, &io_pair));
+
+            size_t total_sent = 0;
+            uint8_t count = 5;
+            struct iovec msg_iov[sizeof(struct iovec) * 5] = { 0 };
+            for (size_t i = 0; i < count; i++) {
+                msg_iov[i].iov_base = test_data + total_sent;
+                msg_iov[i].iov_len = S2N_TEST_TO_SEND;
+                total_sent += S2N_TEST_TO_SEND;
+            }
+
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            size_t bytes_written = 0;
+            EXPECT_OK(s2n_ktls_sendmsg(
+                    server, test_record_type, msg_iov, count, &blocked, &bytes_written));
+            EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+            EXPECT_EQUAL(bytes_written, total_sent);
+
+            /* confirm sent data */
+            EXPECT_OK(s2n_test_validate_data(&io_pair.client_in, test_data, total_sent));
+            EXPECT_OK(s2n_test_validate_ancillary(&io_pair.client_in, test_record_type, total_sent));
+            /* validate only 1 record was sent  */
+            EXPECT_EQUAL(s2n_stuffer_data_available(&io_pair.client_in.ancillary_buffer),
+                    S2N_TEST_KTLS_MOCK_HEADER_SIZE);
+
+            EXPECT_EQUAL(io_pair.client_in.sendmsg_invoked_count, 1);
+        };
+
+        /* Simulate a blocked network and handle a S2N_ERR_IO_BLOCKED error */
+        {
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            DEFER_CLEANUP(struct s2n_test_ktls_io_stuffer_pair io_pair = { 0 },
+                    s2n_ktls_io_stuffer_pair_free);
+            EXPECT_OK(s2n_test_init_ktls_io_stuffer(server, client, &io_pair));
+            /* disable growable to simulate blocked/network buffer full */
+            io_pair.client_in.data_buffer.growable = false;
+
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            size_t blocked_invoked_count = 5;
+            size_t bytes_written = 0;
+            struct iovec msg_iov = { .iov_base = test_data, .iov_len = S2N_TEST_TO_SEND };
+            for (size_t i = 0; i < blocked_invoked_count; i++) {
+                EXPECT_ERROR_WITH_ERRNO(
+                        s2n_ktls_sendmsg(server, test_record_type, &msg_iov, 1, &blocked, &bytes_written),
+                        S2N_ERR_IO_BLOCKED);
+                EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_WRITE);
+            }
+
+            /* enable growable to unblock write */
+            /* cppcheck-suppress redundantAssignment */
+            io_pair.client_in.data_buffer.growable = true;
+            EXPECT_OK(
+                    s2n_ktls_sendmsg(server, test_record_type, &msg_iov, 1, &blocked, &bytes_written));
+            EXPECT_EQUAL(bytes_written, S2N_TEST_TO_SEND);
+
+            /* confirm sent data */
+            EXPECT_OK(s2n_test_validate_data(&io_pair.client_in, test_data, S2N_TEST_TO_SEND));
+            EXPECT_OK(s2n_test_validate_ancillary(&io_pair.client_in, test_record_type, S2N_TEST_TO_SEND));
+
+            EXPECT_EQUAL(io_pair.client_in.sendmsg_invoked_count, blocked_invoked_count + 1);
+        };
+
+        /* Both EWOULDBLOCK and EAGAIN should return a S2N_ERR_IO_BLOCKED error */
+        {
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            struct s2n_test_ktls_io_fail io_ctx = { 0 };
+            EXPECT_OK(s2n_ktls_set_sendmsg_cb(server, s2n_test_ktls_sendmsg_fail, &io_ctx));
+
+            struct iovec msg_iov = { .iov_base = test_data, .iov_len = S2N_TEST_TO_SEND };
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            size_t bytes_written = 0;
+
+            io_ctx.errno_code = EWOULDBLOCK;
+            EXPECT_ERROR_WITH_ERRNO(
+                    s2n_ktls_sendmsg(server, test_record_type, &msg_iov, 1, &blocked, &bytes_written),
+                    S2N_ERR_IO_BLOCKED);
+
+            /* cppcheck-suppress redundantAssignment */
+            io_ctx.errno_code = EAGAIN;
+            EXPECT_ERROR_WITH_ERRNO(
+                    s2n_ktls_sendmsg(server, test_record_type, &msg_iov, 1, &blocked, &bytes_written),
+                    S2N_ERR_IO_BLOCKED);
+
+            EXPECT_EQUAL(io_ctx.invoked_count, 2);
+        };
+
+        /* Handle a S2N_ERR_IO error */
+        {
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            struct s2n_test_ktls_io_fail io_ctx = {
+                .errno_code = EINVAL,
+            };
+            EXPECT_OK(s2n_ktls_set_sendmsg_cb(server, s2n_test_ktls_sendmsg_fail, &io_ctx));
+
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            size_t bytes_written = 0;
+            struct iovec msg_iov = { .iov_base = test_data, .iov_len = S2N_TEST_TO_SEND };
+            EXPECT_ERROR_WITH_ERRNO(
+                    s2n_ktls_sendmsg(server, test_record_type, &msg_iov, 1, &blocked, &bytes_written),
+                    S2N_ERR_IO);
+            /* Blocked status intentionally not reset to preserve legacy s2n_send behavior */
+            EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_WRITE);
+
+            EXPECT_EQUAL(io_ctx.invoked_count, 1);
+        };
+
+        /* Should be able to invoke s2n_ktls_sendmsg with '0' data */
+        {
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            DEFER_CLEANUP(struct s2n_test_ktls_io_stuffer_pair io_pair = { 0 },
+                    s2n_ktls_io_stuffer_pair_free);
+            EXPECT_OK(s2n_test_init_ktls_io_stuffer(server, client, &io_pair));
+
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            size_t bytes_written = 0;
+
+            struct iovec msg_iov = { .iov_base = test_data, .iov_len = S2N_TEST_TO_SEND };
+            size_t iovlen_zero = 0;
+            EXPECT_OK(s2n_ktls_sendmsg(
+                    server, test_record_type, &msg_iov, iovlen_zero, &blocked, &bytes_written));
+            EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+            EXPECT_EQUAL(bytes_written, 0);
+
+            struct iovec msg_iov_len_zero = { .iov_base = test_data, .iov_len = 0 };
+            EXPECT_OK(s2n_ktls_sendmsg(
+                    server, test_record_type, &msg_iov_len_zero, 1, &blocked, &bytes_written));
+            EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+            EXPECT_EQUAL(bytes_written, 0);
+
+            EXPECT_EQUAL(io_pair.client_in.sendmsg_invoked_count, 2);
         };
     };
 

--- a/tests/unit/s2n_ktls_test_utils_test.c
+++ b/tests/unit/s2n_ktls_test_utils_test.c
@@ -31,7 +31,7 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
-    uint8_t test_record_type = 43;
+    const uint8_t test_record_type = 43;
     /* test data */
     uint8_t test_data[S2N_TLS_MAXIMUM_FRAGMENT_LENGTH] = { 0 };
     struct s2n_blob test_data_blob = { 0 };
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
             EXPECT_OK(s2n_test_init_ktls_io_stuffer(server, client, &io_pair));
 
             size_t total_sent = 0;
-            struct iovec send_msg_iov[sizeof(struct iovec) * S2N_TEST_MSG_IOVLEN] = { 0 };
+            struct iovec send_msg_iov[S2N_TEST_MSG_IOVLEN] = { 0 };
             for (size_t i = 0; i < S2N_TEST_MSG_IOVLEN; i++) {
                 send_msg_iov[i].iov_base = test_data + total_sent;
                 send_msg_iov[i].iov_len = S2N_TEST_TO_SEND;
@@ -288,7 +288,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_alloc(&io_pair.client_in.data_buffer, S2N_TEST_TO_SEND));
 
             uint8_t *test_data_ptr = test_data;
-            struct iovec send_msg_iov[sizeof(struct iovec) * S2N_TEST_MSG_IOVLEN] = { 0 };
+            struct iovec send_msg_iov[S2N_TEST_MSG_IOVLEN] = { 0 };
             for (size_t i = 0; i < S2N_TEST_MSG_IOVLEN; i++) {
                 send_msg_iov[i].iov_base = (void *) test_data_ptr;
                 send_msg_iov[i].iov_len = S2N_TEST_TO_SEND;

--- a/tests/unit/s2n_ktls_test_utils_test.c
+++ b/tests/unit/s2n_ktls_test_utils_test.c
@@ -27,35 +27,6 @@ S2N_RESULT s2n_ktls_set_control_data(struct msghdr *msg, char *buf, size_t buf_s
         int cmsg_type, uint8_t record_type);
 S2N_RESULT s2n_ktls_get_control_data(struct msghdr *msg, int cmsg_type, uint8_t *record_type);
 
-S2N_RESULT s2n_test_validate_data(struct s2n_test_ktls_io_stuffer *ktls_io, uint8_t *expected_data, uint16_t expected_len)
-{
-    RESULT_ENSURE_REF(ktls_io);
-    RESULT_ENSURE_REF(expected_data);
-
-    struct s2n_stuffer validate_data_stuffer = ktls_io->data_buffer;
-    RESULT_ENSURE_EQ(s2n_stuffer_data_available(&validate_data_stuffer), expected_len);
-    uint8_t *data_ptr = s2n_stuffer_raw_read(&validate_data_stuffer, expected_len);
-    RESULT_ENSURE_REF(data_ptr);
-    EXPECT_BYTEARRAY_EQUAL(data_ptr, expected_data, expected_len);
-
-    return S2N_RESULT_OK;
-}
-
-S2N_RESULT s2n_test_validate_ancillary(struct s2n_test_ktls_io_stuffer *ktls_io, uint8_t expected_record_type, uint16_t expected_len)
-{
-    RESULT_ENSURE_REF(ktls_io);
-
-    struct s2n_stuffer validate_ancillary_stuffer = ktls_io->ancillary_buffer;
-    uint8_t tag = 0;
-    RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(&validate_ancillary_stuffer, &tag));
-    RESULT_ENSURE_EQ(tag, expected_record_type);
-    uint16_t len;
-    RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&validate_ancillary_stuffer, &len));
-    RESULT_ENSURE_EQ(len, expected_len);
-
-    return S2N_RESULT_OK;
-}
-
 int main(int argc, char **argv)
 {
     BEGIN_TEST();

--- a/tls/s2n_ktls.h
+++ b/tls/s2n_ktls.h
@@ -39,9 +39,8 @@ typedef enum {
 bool s2n_ktls_is_supported_on_platform();
 S2N_RESULT s2n_ktls_get_file_descriptor(struct s2n_connection *conn, s2n_ktls_mode ktls_mode, int *fd);
 
-S2N_RESULT s2n_ktls_sendmsg(struct s2n_connection *conn, uint8_t record_type,
-        const struct iovec *msg_iov, size_t msg_iovlen, s2n_blocked_status *blocked,
-        size_t *bytes_written);
+S2N_RESULT s2n_ktls_sendmsg(struct s2n_connection *conn, uint8_t record_type, const struct iovec *msg_iov,
+        size_t msg_iovlen, s2n_blocked_status *blocked, size_t *bytes_written);
 
 /* These functions will be part of the public API. */
 int s2n_connection_ktls_enable_send(struct s2n_connection *conn);

--- a/tls/s2n_ktls.h
+++ b/tls/s2n_ktls.h
@@ -37,8 +37,11 @@ typedef enum {
 } s2n_ktls_mode;
 
 bool s2n_ktls_is_supported_on_platform();
-S2N_RESULT s2n_ktls_get_file_descriptor(struct s2n_connection *conn, s2n_ktls_mode ktls_mode,
-        int *fd);
+S2N_RESULT s2n_ktls_get_file_descriptor(struct s2n_connection *conn, s2n_ktls_mode ktls_mode, int *fd);
+
+S2N_RESULT s2n_ktls_sendmsg(struct s2n_connection *conn, uint8_t record_type,
+        const struct iovec *msg_iov, size_t msg_iovlen, s2n_blocked_status *blocked,
+        size_t *bytes_written);
 
 /* These functions will be part of the public API. */
 int s2n_connection_ktls_enable_send(struct s2n_connection *conn);

--- a/tls/s2n_ktls_io.c
+++ b/tls/s2n_ktls_io.c
@@ -180,6 +180,7 @@ S2N_RESULT s2n_ktls_sendmsg(struct s2n_connection *conn, uint8_t record_type,
         const struct iovec *msg_iov, size_t msg_iovlen, s2n_blocked_status *blocked,
         size_t *bytes_written)
 {
+    RESULT_ENSURE_REF(bytes_written);
     RESULT_ENSURE_REF(msg_iov);
     RESULT_ENSURE_REF(blocked);
     RESULT_ENSURE_REF(conn);

--- a/tls/s2n_ktls_io.c
+++ b/tls/s2n_ktls_io.c
@@ -176,9 +176,8 @@ S2N_RESULT s2n_ktls_get_control_data(struct msghdr *msg, int cmsg_type, uint8_t 
     return S2N_RESULT_OK;
 }
 
-S2N_RESULT s2n_ktls_sendmsg(struct s2n_connection *conn, uint8_t record_type,
-        const struct iovec *msg_iov, size_t msg_iovlen, s2n_blocked_status *blocked,
-        size_t *bytes_written)
+S2N_RESULT s2n_ktls_sendmsg(struct s2n_connection *conn, uint8_t record_type, const struct iovec *msg_iov,
+        size_t msg_iovlen, s2n_blocked_status *blocked, size_t *bytes_written)
 {
     RESULT_ENSURE_REF(bytes_written);
     RESULT_ENSURE_REF(msg_iov);

--- a/tls/s2n_ktls_io.c
+++ b/tls/s2n_ktls_io.c
@@ -186,8 +186,6 @@ S2N_RESULT s2n_ktls_sendmsg(struct s2n_connection *conn, uint8_t record_type, co
 
     *blocked = S2N_BLOCKED_ON_WRITE;
 
-    RESULT_ENSURE(msg_iov->iov_base, S2N_ERR_INVALID_ARGUMENT);
-
     struct msghdr msg = {
         /* msghdr requires a non-const iovec. This is safe because s2n-tls does
          * not modify msg_iov after this point.


### PR DESCRIPTION
### Description of changes: 
This PR adds an implementation for s2n_ktls_sendmsg. This essentially takes some data and some record_type and calls the `sendmsg` syscall. It creates a `msghdr` and configures the control data on it. Finally it is also doing some error handling (mainly IO blocked error).

### Call-outs:
- In the next PR we will add a s2n_ktls_recvmsg.
- We will also handle the IO errors (should result in closing the connection) at higher layers.

### Testing:
Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
