### PR TITLE
Don't exit nix dev shell on integ test failure

### DIFF
--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -62,7 +62,7 @@ function integ {
             ctest --test-dir ./build -L integrationv2 --no-tests=error --output-on-failure -R "$test" --verbose
             if [ "$?" -ne 0 ]; then
                echo "Test failed, stopping execution"
-               exit 1
+               return 1
             fi
         done
     fi


### PR DESCRIPTION
### Description of changes: 

I was running the integration tests in nix, which is a big improvement. But every time they failed they exited my nix dev shell >:|

Swapped the exit for a return so I can keep running my tests in peace.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
