### PR TITLE
refactor and cleanup some ktls code

### DIFF
--- a/tests/testlib/s2n_ktls_test_utils.c
+++ b/tests/testlib/s2n_ktls_test_utils.c
@@ -21,7 +21,8 @@ S2N_RESULT s2n_ktls_get_control_data(struct msghdr *msg, int cmsg_type, uint8_t 
 
 /* Since it is possible to read partial data, we need a way to update the length
  * of the previous record for the mock stuffer IO implementation. */
-static S2N_RESULT s2n_test_ktls_update_prev_header_len(struct s2n_test_ktls_io_stuffer *io_ctx, uint16_t remaining_len)
+static S2N_RESULT s2n_test_ktls_update_prev_header_len(struct s2n_test_ktls_io_stuffer *io_ctx,
+        uint16_t remaining_len)
 {
     RESULT_ENSURE_REF(io_ctx);
     RESULT_ENSURE(remaining_len > 0, S2N_ERR_IO);
@@ -151,8 +152,8 @@ ssize_t s2n_test_ktls_recvmsg_io_stuffer(void *io_context, struct msghdr *msg)
     return bytes_read;
 }
 
-S2N_RESULT s2n_test_init_ktls_io_stuffer(struct s2n_connection *server, struct s2n_connection *client,
-        struct s2n_test_ktls_io_stuffer_pair *io_pair)
+S2N_RESULT s2n_test_init_ktls_io_stuffer(struct s2n_connection *server,
+        struct s2n_connection *client, struct s2n_test_ktls_io_stuffer_pair *io_pair)
 {
     RESULT_ENSURE_REF(server);
     RESULT_ENSURE_REF(client);

--- a/tests/testlib/s2n_ktls_test_utils.h
+++ b/tests/testlib/s2n_ktls_test_utils.h
@@ -62,6 +62,6 @@ struct s2n_test_ktls_io_stuffer_pair {
 ssize_t s2n_test_ktls_sendmsg_io_stuffer(void *io_context, const struct msghdr *msg);
 ssize_t s2n_test_ktls_recvmsg_io_stuffer(void *io_context, struct msghdr *msg);
 
-S2N_RESULT s2n_test_init_ktls_io_stuffer(struct s2n_connection *server, struct s2n_connection *client,
-        struct s2n_test_ktls_io_stuffer_pair *io_pair);
+S2N_RESULT s2n_test_init_ktls_io_stuffer(struct s2n_connection *server,
+        struct s2n_connection *client, struct s2n_test_ktls_io_stuffer_pair *io_pair);
 S2N_CLEANUP_RESULT s2n_ktls_io_stuffer_pair_free(struct s2n_test_ktls_io_stuffer_pair *pair);

--- a/tests/unit/s2n_ktls_io_test.c
+++ b/tests/unit/s2n_ktls_io_test.c
@@ -29,8 +29,8 @@ int main(int argc, char **argv)
     {
         /* Test: Safety */
         {
-            char buf[100] = { 0 };
             struct msghdr msg = { 0 };
+            char buf[100] = { 0 };
             EXPECT_ERROR_WITH_ERRNO(s2n_ktls_set_control_data(NULL, buf, sizeof(buf), 0, 0),
                     S2N_ERR_NULL);
             EXPECT_ERROR_WITH_ERRNO(s2n_ktls_set_control_data(&msg, NULL, sizeof(buf), 0, 0),
@@ -47,10 +47,10 @@ int main(int argc, char **argv)
 
         /* Test: s2n_ktls_set_control_data msg is parseable by s2n_ktls_get_control_data */
         {
-            struct msghdr msg = { 0 };
-            char buf[100] = { 0 };
             const uint8_t set_record_type = 5;
+            struct msghdr msg = { 0 };
             const int cmsg_type = 11;
+            char buf[100] = { 0 };
             EXPECT_OK(s2n_ktls_set_control_data(&msg, buf, sizeof(buf), cmsg_type, set_record_type));
 
             uint8_t get_record_type = 0;
@@ -61,14 +61,14 @@ int main(int argc, char **argv)
 
         /* Test: s2n_ktls_get_control_data fails with unexpected cmsg_type */
         {
-            struct msghdr msg = { 0 };
-            char buf[100] = { 0 };
             const uint8_t set_record_type = 5;
+            struct msghdr msg = { 0 };
             const int cmsg_type = 11;
+            char buf[100] = { 0 };
             EXPECT_OK(s2n_ktls_set_control_data(&msg, buf, sizeof(buf), cmsg_type, set_record_type));
 
-            uint8_t get_record_type = 0;
             const int bad_cmsg_type = 99;
+            uint8_t get_record_type = 0;
             EXPECT_ERROR_WITH_ERRNO(s2n_ktls_get_control_data(&msg, bad_cmsg_type, &get_record_type),
                     S2N_ERR_KTLS_BAD_CMSG);
         };

--- a/tests/unit/s2n_ktls_test_utils_test.c
+++ b/tests/unit/s2n_ktls_test_utils_test.c
@@ -21,6 +21,7 @@
 
 #define S2N_TEST_TO_SEND     10
 #define S2N_CONTROL_BUF_SIZE 100
+#define S2N_TEST_MSG_IOVLEN  5
 
 S2N_RESULT s2n_ktls_set_control_data(struct msghdr *msg, char *buf, size_t buf_size,
         int cmsg_type, uint8_t record_type);
@@ -155,16 +156,15 @@ int main(int argc, char **argv)
                     s2n_ktls_io_stuffer_pair_free);
             EXPECT_OK(s2n_test_init_ktls_io_stuffer(server, client, &io_pair));
 
-            uint8_t count = 5;
             size_t total_sent = 0;
-            struct iovec send_msg_iov[sizeof(struct iovec) * 5] = { 0 };
-            for (size_t i = 0; i < count; i++) {
+            struct iovec send_msg_iov[sizeof(struct iovec) * S2N_TEST_MSG_IOVLEN] = { 0 };
+            for (size_t i = 0; i < S2N_TEST_MSG_IOVLEN; i++) {
                 send_msg_iov[i].iov_base = test_data + total_sent;
                 send_msg_iov[i].iov_len = S2N_TEST_TO_SEND;
 
                 total_sent += S2N_TEST_TO_SEND;
             }
-            struct msghdr send_msg = { .msg_iov = send_msg_iov, .msg_iovlen = count };
+            struct msghdr send_msg = { .msg_iov = send_msg_iov, .msg_iovlen = S2N_TEST_MSG_IOVLEN };
             char control_buf[S2N_CONTROL_BUF_SIZE] = { 0 };
             EXPECT_OK(s2n_ktls_set_control_data(&send_msg, control_buf, sizeof(control_buf),
                     S2N_TLS_SET_RECORD_TYPE, test_record_type));
@@ -316,15 +316,14 @@ int main(int argc, char **argv)
             io_pair.client_in.data_buffer.growable = false;
             EXPECT_SUCCESS(s2n_stuffer_alloc(&io_pair.client_in.data_buffer, S2N_TEST_TO_SEND));
 
-            uint8_t count = 2;
             uint8_t *test_data_ptr = test_data;
-            struct iovec send_msg_iov[sizeof(struct iovec) * 5] = { 0 };
-            for (size_t i = 0; i < count; i++) {
+            struct iovec send_msg_iov[sizeof(struct iovec) * S2N_TEST_MSG_IOVLEN] = { 0 };
+            for (size_t i = 0; i < S2N_TEST_MSG_IOVLEN; i++) {
                 send_msg_iov[i].iov_base = (void *) test_data_ptr;
                 send_msg_iov[i].iov_len = S2N_TEST_TO_SEND;
                 test_data_ptr += S2N_TEST_TO_SEND;
             }
-            struct msghdr send_msg = { .msg_iov = send_msg_iov, .msg_iovlen = count };
+            struct msghdr send_msg = { .msg_iov = send_msg_iov, .msg_iovlen = S2N_TEST_MSG_IOVLEN };
             char control_buf[S2N_CONTROL_BUF_SIZE] = { 0 };
             EXPECT_OK(s2n_ktls_set_control_data(&send_msg, control_buf, sizeof(control_buf),
                     S2N_TLS_SET_RECORD_TYPE, test_record_type));

--- a/tls/s2n_ktls.h
+++ b/tls/s2n_ktls.h
@@ -36,20 +36,21 @@ typedef enum {
     S2N_KTLS_MODE_RECV,
 } s2n_ktls_mode;
 
-/* Used for overriding setsockopt calls in testing */
-typedef int (*s2n_setsockopt_fn)(int socket, int level, int option_name,
-        const void *option_value, socklen_t option_len);
-S2N_RESULT s2n_ktls_set_setsockopt_cb(s2n_setsockopt_fn cb);
-
 bool s2n_ktls_is_supported_on_platform();
-S2N_RESULT s2n_ktls_get_file_descriptor(struct s2n_connection *conn, s2n_ktls_mode ktls_mode, int *fd);
+S2N_RESULT s2n_ktls_get_file_descriptor(struct s2n_connection *conn, s2n_ktls_mode ktls_mode,
+        int *fd);
 
 /* These functions will be part of the public API. */
 int s2n_connection_ktls_enable_send(struct s2n_connection *conn);
 int s2n_connection_ktls_enable_recv(struct s2n_connection *conn);
 
 /* Testing */
+typedef int (*s2n_setsockopt_fn)(int socket, int level, int option_name, const void *option_value,
+        socklen_t option_len);
+S2N_RESULT s2n_ktls_set_setsockopt_cb(s2n_setsockopt_fn cb);
 typedef ssize_t (*s2n_ktls_sendmsg_fn)(void *io_context, const struct msghdr *msg);
 typedef ssize_t (*s2n_ktls_recvmsg_fn)(void *io_context, struct msghdr *msg);
-S2N_RESULT s2n_ktls_set_sendmsg_cb(struct s2n_connection *conn, s2n_ktls_sendmsg_fn send_cb, void *send_ctx);
-S2N_RESULT s2n_ktls_set_recvmsg_cb(struct s2n_connection *conn, s2n_ktls_recvmsg_fn recv_cb, void *recv_ctx);
+S2N_RESULT s2n_ktls_set_sendmsg_cb(struct s2n_connection *conn, s2n_ktls_sendmsg_fn send_cb,
+        void *send_ctx);
+S2N_RESULT s2n_ktls_set_recvmsg_cb(struct s2n_connection *conn, s2n_ktls_recvmsg_fn recv_cb,
+        void *recv_ctx);

--- a/tls/s2n_ktls_io.c
+++ b/tls/s2n_ktls_io.c
@@ -40,7 +40,8 @@ static ssize_t s2n_ktls_default_recvmsg(void *io_context, struct msghdr *msg);
 s2n_ktls_sendmsg_fn s2n_sendmsg_fn = s2n_ktls_default_sendmsg;
 s2n_ktls_recvmsg_fn s2n_recvmsg_fn = s2n_ktls_default_recvmsg;
 
-S2N_RESULT s2n_ktls_set_sendmsg_cb(struct s2n_connection *conn, s2n_ktls_sendmsg_fn send_cb, void *send_ctx)
+S2N_RESULT s2n_ktls_set_sendmsg_cb(struct s2n_connection *conn, s2n_ktls_sendmsg_fn send_cb,
+        void *send_ctx)
 {
     RESULT_ENSURE_REF(conn);
     RESULT_ENSURE_REF(send_ctx);
@@ -50,7 +51,8 @@ S2N_RESULT s2n_ktls_set_sendmsg_cb(struct s2n_connection *conn, s2n_ktls_sendmsg
     return S2N_RESULT_OK;
 }
 
-S2N_RESULT s2n_ktls_set_recvmsg_cb(struct s2n_connection *conn, s2n_ktls_recvmsg_fn recv_cb, void *recv_ctx)
+S2N_RESULT s2n_ktls_set_recvmsg_cb(struct s2n_connection *conn, s2n_ktls_recvmsg_fn recv_cb,
+        void *recv_ctx)
 {
     RESULT_ENSURE_REF(conn);
     RESULT_ENSURE_REF(recv_ctx);


### PR DESCRIPTION
### Description of changes: 
Mostly just a refactor change (replaces malloc with stack allocation).

### Call-outs:
- I added line width to me IDE and wanted to fix up some long lines of code.
- Also for the sake of readability l moved around variables so that they appear in a reverse christmas tree shape (something linux does. Here is a blog post about its advantages https://hisham.hm/2018/06/16/when-listing-repeated-things-make-pyramids/).
```
int even_longer = 0;
int longer = 0;
int small = 0;
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
