### PR TITLE
Fix clippy warnings

### DIFF
--- a/bindings/rust/s2n-tls-tokio/tests/common/stream.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/common/stream.rs
@@ -38,6 +38,9 @@ impl Overrides {
     }
 }
 
+unsafe impl Send for Overrides {}
+unsafe impl Sync for Overrides {}
+
 pub struct TestStream {
     stream: TcpStream,
     overrides: Arc<Overrides>,

--- a/bindings/rust/s2n-tls/src/callbacks/pkey.rs
+++ b/bindings/rust/s2n-tls/src/callbacks/pkey.rs
@@ -92,7 +92,7 @@ impl PrivateKeyOperation {
     /// Sets the output of the operation
     pub fn set_output(self, conn: &mut Connection, buf: &[u8]) -> Result<(), Error> {
         let buf_len: u32 = buf.len().try_into().map_err(|_| Error::INVALID_INPUT)?;
-        let buf_ptr = buf.as_ptr() as *const u8;
+        let buf_ptr = buf.as_ptr();
         unsafe {
             s2n_async_pkey_op_set_output(self.raw.as_ptr(), buf_ptr, buf_len).into_result()?;
             s2n_async_pkey_op_apply(self.raw.as_ptr(), conn.as_ptr()).into_result()?;


### PR DESCRIPTION
### Description of changes: 

Resolves the following two clippy warnings:

```
error: casting raw pointers to the same type and constness is unnecessary (`*const u8` -> `*const u8`)
  --> s2n-tls/src/callbacks/pkey.rs:95:23
   |
95 |         let buf_ptr = buf.as_ptr() as *const u8;
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `buf.as_ptr()`
```

```
error: usage of an `Arc` that is not `Send` or `Sync`
  --> s2n-tls-tokio/tests/common/stream.rs:48:25
   |
48 |         let overrides = Arc::new(Overrides::default());
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

### Call-outs:

- `Overrides` contains a mutex and it looks like it locks it before doing anything, so I think it's safe to add Send + Sync to `Overrides`? Let me know if this isn't the correct fix for this warning.

### Testing:

Clippy should succeed on the PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
