### PR TITLE
feat(benchmarks): add session resumption support

### DIFF
--- a/bindings/rust/bench/Cargo.toml
+++ b/bindings/rust/bench/Cargo.toml
@@ -32,6 +32,10 @@ features = ["all_series", "all_elements", "full_palette", "svg_backend"]
 [dev-dependencies]
 criterion = "0.5"
 pprof = { version = "0.12", features = ["criterion", "flamegraph"] }
+# env_logger and log are used to enable logging for rustls, which can help with
+# debugging interop failures
+env_logger = "0.10"
+log = "0.4"
 
 [[bin]]
 name = "memory"
@@ -51,4 +55,8 @@ harness = false
 
 [[bench]]
 name = "throughput"
+harness = false
+
+[[bench]]
+name = "resumption"
 harness = false

--- a/bindings/rust/bench/benches/handshake.rs
+++ b/bindings/rust/bench/benches/handshake.rs
@@ -6,8 +6,8 @@ use bench::OpenSslConnection;
 #[cfg(feature = "rustls")]
 use bench::RustlsConnection;
 use bench::{
-    ConnectedBuffer, CipherSuite, CryptoConfig, HandshakeType, KXGroup, Mode,
-    S2NConnection, SigType, TlsConnPair, TlsConnection, PROFILER_FREQUENCY,
+    CipherSuite, ConnectedBuffer, CryptoConfig, HandshakeType, KXGroup, Mode, S2NConnection,
+    SigType, TlsConnPair, TlsConnection, PROFILER_FREQUENCY,
 };
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion,
@@ -37,8 +37,8 @@ fn bench_handshake_for_library<T: TlsConnection>(
                 {
                     let connected_buffer = ConnectedBuffer::default();
                     let client =
-                        T::new_from_config(&client_config, connected_buffer.clone_inverse())?;
-                    let server = T::new_from_config(&server_config, connected_buffer)?;
+                        T::new_from_config(client_config, connected_buffer.clone_inverse())?;
+                    let server = T::new_from_config(server_config, connected_buffer)?;
                     Ok(TlsConnPair::wrap(client, server))
                 } else {
                     Err("invalid configs".into())

--- a/bindings/rust/bench/benches/resumption.rs
+++ b/bindings/rust/bench/benches/resumption.rs
@@ -68,14 +68,14 @@ fn bench_handshake_server_1rtt<T: TlsConnection>(
 pub fn bench_resumption(c: &mut Criterion) {
     // compare resumption savings across both client and server
     for sig_type in [SigType::Rsa2048, SigType::Ecdsa384] {
-        let mut bench_group = c.benchmark_group(format!("resumption-pair{:?}", sig_type));
+        let mut bench_group = c.benchmark_group(format!("resumption-pair-{:?}", sig_type));
         bench_handshake_pair::<S2NConnection>(&mut bench_group, sig_type);
     }
 
     // only look at resumption savings for the server, specifically the work
     // done in the first rtt.
     for sig_type in [SigType::Rsa2048, SigType::Ecdsa384] {
-        let mut bench_group = c.benchmark_group(format!("resumption-server-1rtt{:?}", sig_type));
+        let mut bench_group = c.benchmark_group(format!("resumption-server-1rtt-{:?}", sig_type));
         bench_handshake_server_1rtt::<S2NConnection>(&mut bench_group, sig_type);
     }
 }

--- a/bindings/rust/bench/benches/resumption.rs
+++ b/bindings/rust/bench/benches/resumption.rs
@@ -1,0 +1,84 @@
+use bench::{
+    CipherSuite, CryptoConfig, HandshakeType, KXGroup, S2NConnection, SigType, TlsConnPair,
+    TlsConnection,
+};
+use criterion::{
+    criterion_group, criterion_main, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion,
+};
+
+fn bench_handshake_pair<T: TlsConnection>(
+    bench_group: &mut BenchmarkGroup<WallTime>,
+    sig_type: SigType,
+) {
+    // generate all harnesses (TlsConnPair structs) beforehand so that benchmarks
+    // only include negotiation and not config/connection initialization
+    for handshake in [HandshakeType::Resumption, HandshakeType::ServerAuth] {
+        bench_group.bench_function(format!("{:?}-{}", handshake, T::name()), |b| {
+            b.iter_batched_ref(
+                || {
+                    TlsConnPair::<T, T>::new(
+                        CryptoConfig::new(CipherSuite::default(), KXGroup::default(), sig_type),
+                        handshake,
+                        Default::default(),
+                    )
+                },
+                |conn_pair_res| {
+                    if let Ok(conn_pair) = conn_pair_res {
+                        let _ = conn_pair.handshake();
+                    }
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+}
+
+fn bench_handshake_server_1rtt<T: TlsConnection>(
+    bench_group: &mut BenchmarkGroup<WallTime>,
+    sig_type: SigType,
+) {
+    for handshake in [HandshakeType::Resumption, HandshakeType::ServerAuth] {
+        bench_group.bench_function(format!("{:?}-{}", handshake, T::name()), |b| {
+            b.iter_batched_ref(
+                || {
+                    let pair = TlsConnPair::<T, T>::new(
+                        CryptoConfig::new(CipherSuite::default(), KXGroup::default(), sig_type),
+                        handshake,
+                        Default::default(),
+                    )
+                    .unwrap();
+                    let (mut c, s) = pair.split();
+                    c.handshake().unwrap();
+                    s
+                },
+                |server| {
+                    // this represents the work that the server does during the
+                    // first RTT
+                    server.handshake().unwrap()
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+}
+
+/// This benchmark compares resumption savings across a single implementation.
+/// E.g. "how much faster is session resumption than a full handshake for
+/// s2n-tls?".
+pub fn bench_resumption(c: &mut Criterion) {
+    // compare resumption savings across both client and server
+    for sig_type in [SigType::Rsa2048, SigType::Ecdsa384] {
+        let mut bench_group = c.benchmark_group(format!("resumption-pair{:?}", sig_type));
+        bench_handshake_pair::<S2NConnection>(&mut bench_group, sig_type);
+    }
+
+    // only look at resumption savings for the server, specifically the work
+    // done in the first rtt.
+    for sig_type in [SigType::Rsa2048, SigType::Ecdsa384] {
+        let mut bench_group = c.benchmark_group(format!("resumption-server-1rtt{:?}", sig_type));
+        bench_handshake_server_1rtt::<S2NConnection>(&mut bench_group, sig_type);
+    }
+}
+
+criterion_group!(benches, bench_resumption);
+criterion_main!(benches);

--- a/bindings/rust/bench/benches/throughput.rs
+++ b/bindings/rust/bench/benches/throughput.rs
@@ -6,8 +6,8 @@ use bench::OpenSslConnection;
 #[cfg(feature = "rustls")]
 use bench::RustlsConnection;
 use bench::{
-    ConnectedBuffer, CipherSuite, CryptoConfig, HandshakeType, KXGroup, Mode,
-    S2NConnection, SigType, TlsConnPair, TlsConnection, PROFILER_FREQUENCY,
+    CipherSuite, ConnectedBuffer, CryptoConfig, HandshakeType, KXGroup, Mode, S2NConnection,
+    SigType, TlsConnPair, TlsConnection, PROFILER_FREQUENCY,
 };
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion,
@@ -34,8 +34,8 @@ fn bench_throughput_for_library<T: TlsConnection>(
                 {
                     let connected_buffer = ConnectedBuffer::default();
                     let client =
-                        T::new_from_config(&client_config, connected_buffer.clone_inverse())?;
-                    let server = T::new_from_config(&server_config, connected_buffer)?;
+                        T::new_from_config(client_config, connected_buffer.clone_inverse())?;
+                    let server = T::new_from_config(server_config, connected_buffer)?;
                     let mut conn_pair = TlsConnPair::wrap(client, server);
                     conn_pair.handshake()?;
                     Ok(conn_pair)

--- a/bindings/rust/bench/src/bin/memory.rs
+++ b/bindings/rust/bench/src/bin/memory.rs
@@ -6,8 +6,7 @@ use bench::OpenSslConnection;
 #[cfg(feature = "rustls")]
 use bench::RustlsConnection;
 use bench::{
-    ConnectedBuffer, CryptoConfig, HandshakeType, Mode,
-    S2NConnection, TlsConnPair, TlsConnection,
+    ConnectedBuffer, CryptoConfig, HandshakeType, Mode, S2NConnection, TlsConnPair, TlsConnection,
 };
 use std::{error::Error, fs::create_dir_all};
 use structopt::{clap::arg_enum, StructOpt};

--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -640,7 +640,7 @@ impl Builder {
     }
 
     /// Adds a key which will be used to encrypt and decrypt session tickets. The intro_time parameter is time since
-    /// the Unix epoch (Midnight, January 1st, 1970).
+    /// the Unix epoch (Midnight, January 1st, 1970). The key must be at least 16 bytes.
     pub fn add_session_ticket_key(
         &mut self,
         key_name: &[u8],


### PR DESCRIPTION
### Description of changes: 

This adds support for session resumption to the benchmark harness.

This is accomplished by adding additional logic to the harness creation. When a "resumption" harness is requested, a sacrificial client and server will be created and handshaken. The session ticket from the handshake will be stored on the config. This session ticket will be automatically pulled into the _real_ client connection that is created.

### Call-outs:

I commented out one of the tests, which I acknowledge it normally bad practice but I wanted to make it very visible. I have the fix in this commit: https://github.com/jmayclin/s2n-tls/commit/119ca588f4b1d7c009e6c23b4b26b74cb1105347 and will merge that fix after this PR is merged in. 

### Testing:
Added unit tests, and also manually looked at the benchmark reports.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
