### PR TITLE
ktls: send app data

### DIFF
--- a/tests/testlib/s2n_ktls_test_utils.c
+++ b/tests/testlib/s2n_ktls_test_utils.c
@@ -43,6 +43,7 @@ static S2N_RESULT s2n_test_ktls_update_prev_header_len(struct s2n_test_ktls_io_s
 
 ssize_t s2n_test_ktls_sendmsg_io_stuffer(void *io_context, const struct msghdr *msg)
 {
+    errno = EINVAL;
     POSIX_ENSURE_REF(msg);
 
     struct s2n_test_ktls_io_stuffer *io_ctx = (struct s2n_test_ktls_io_stuffer *) io_context;
@@ -62,9 +63,8 @@ ssize_t s2n_test_ktls_sendmsg_io_stuffer(void *io_context, const struct msghdr *
 
         if (s2n_stuffer_write_bytes(data_buffer, buf, len) != S2N_SUCCESS) {
             size_t partial_len = MIN(len, s2n_stuffer_space_remaining(data_buffer));
-            if (s2n_stuffer_write_bytes(data_buffer, buf, partial_len) == S2N_SUCCESS) {
-                total_len += partial_len;
-            }
+            POSIX_GUARD(s2n_stuffer_write_bytes(data_buffer, buf, partial_len));
+            total_len += partial_len;
             if (total_len) {
                 break;
             }
@@ -89,6 +89,7 @@ ssize_t s2n_test_ktls_sendmsg_io_stuffer(void *io_context, const struct msghdr *
  * are of the same type. */
 ssize_t s2n_test_ktls_recvmsg_io_stuffer(void *io_context, struct msghdr *msg)
 {
+    errno = EINVAL;
     POSIX_ENSURE_REF(msg);
     POSIX_ENSURE_REF(msg->msg_iov);
 

--- a/tests/testlib/s2n_ktls_test_utils.c
+++ b/tests/testlib/s2n_ktls_test_utils.c
@@ -44,10 +44,10 @@ static S2N_RESULT s2n_test_ktls_update_prev_header_len(struct s2n_test_ktls_io_s
 ssize_t s2n_test_ktls_sendmsg_io_stuffer(void *io_context, const struct msghdr *msg)
 {
     POSIX_ENSURE_REF(msg);
-    POSIX_ENSURE_REF(msg->msg_iov);
 
     struct s2n_test_ktls_io_stuffer *io_ctx = (struct s2n_test_ktls_io_stuffer *) io_context;
     POSIX_ENSURE_REF(io_ctx);
+    struct s2n_stuffer *data_buffer = &io_ctx->data_buffer;
     io_ctx->sendmsg_invoked_count++;
 
     uint8_t record_type = 0;
@@ -56,22 +56,21 @@ ssize_t s2n_test_ktls_sendmsg_io_stuffer(void *io_context, const struct msghdr *
 
     size_t total_len = 0;
     for (size_t count = 0; count < msg->msg_iovlen; count++) {
+        POSIX_ENSURE_REF(msg->msg_iov);
         uint8_t *buf = msg->msg_iov[count].iov_base;
-        POSIX_ENSURE_REF(buf);
         size_t len = msg->msg_iov[count].iov_len;
 
-        if (s2n_stuffer_write_bytes(&io_ctx->data_buffer, buf, len) < 0) {
-            /* This mock implementation only handles partial writes for msg_iovlen == 1.
-             *
-             * This simplifies the implementation and importantly doesn't limit our test
-             * coverage because partial writes are handled the same regardless of
-             * msg_iovlen. */
-            POSIX_ENSURE(msg->msg_iovlen == 1, S2N_ERR_SAFETY);
-
+        if (s2n_stuffer_write_bytes(data_buffer, buf, len) != S2N_SUCCESS) {
+            size_t partial_len = MIN(len, s2n_stuffer_space_remaining(data_buffer));
+            if (s2n_stuffer_write_bytes(data_buffer, buf, partial_len) == S2N_SUCCESS) {
+                total_len += partial_len;
+            }
+            if (total_len) {
+                break;
+            }
             errno = EAGAIN;
             return -1;
         }
-
         total_len += len;
     }
     if (total_len) {
@@ -231,5 +230,19 @@ S2N_RESULT s2n_test_validate_ancillary(struct s2n_test_ktls_io_stuffer *ktls_io,
     RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&validate_ancillary_stuffer, &len));
     RESULT_ENSURE_EQ(len, expected_len);
 
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_test_records_in_ancillary(struct s2n_test_ktls_io_stuffer *ktls_io,
+        uint16_t expected_records)
+{
+    RESULT_ENSURE_REF(ktls_io);
+
+    size_t size = s2n_stuffer_data_available(&ktls_io->ancillary_buffer);
+    size_t records = size / S2N_TEST_KTLS_MOCK_HEADER_SIZE;
+    size_t extra = size % S2N_TEST_KTLS_MOCK_HEADER_SIZE;
+
+    RESULT_ENSURE_EQ(records, expected_records);
+    RESULT_ENSURE_EQ(extra, 0);
     return S2N_RESULT_OK;
 }

--- a/tests/testlib/s2n_ktls_test_utils.h
+++ b/tests/testlib/s2n_ktls_test_utils.h
@@ -72,3 +72,5 @@ S2N_RESULT s2n_test_validate_data(struct s2n_test_ktls_io_stuffer *ktls_io, uint
         uint16_t expected_len);
 S2N_RESULT s2n_test_validate_ancillary(struct s2n_test_ktls_io_stuffer *ktls_io,
         uint8_t expected_record_type, uint16_t expected_len);
+S2N_RESULT s2n_test_records_in_ancillary(struct s2n_test_ktls_io_stuffer *ktls_io,
+        uint16_t expected_records);

--- a/tls/s2n_ktls.h
+++ b/tls/s2n_ktls.h
@@ -44,6 +44,9 @@ S2N_RESULT s2n_ktls_sendmsg(struct s2n_connection *conn, uint8_t record_type, co
 S2N_RESULT s2n_ktls_recvmsg(struct s2n_connection *conn, uint8_t *record_type, uint8_t *buf,
         size_t buf_len, s2n_blocked_status *blocked, size_t *bytes_read);
 
+ssize_t s2n_ktls_sendv_with_offset(struct s2n_connection *conn, const struct iovec *bufs,
+        ssize_t count, ssize_t offs, s2n_blocked_status *blocked);
+
 /* These functions will be part of the public API. */
 int s2n_connection_ktls_enable_send(struct s2n_connection *conn);
 int s2n_connection_ktls_enable_recv(struct s2n_connection *conn);

--- a/tls/s2n_ktls_io.c
+++ b/tls/s2n_ktls_io.c
@@ -296,7 +296,8 @@ static S2N_RESULT s2n_ktls_new_iovecs_with_offset(const struct iovec *bufs,
             offs -= old_len;
         }
     }
-    RESULT_ENSURE_EQ(offs, 0);
+    /* The offset cannot be greater than the total size of all iovecs */
+    RESULT_ENSURE(offs == 0, S2N_ERR_INVALID_ARGUMENT);
     return S2N_RESULT_OK;
 }
 

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -24,6 +24,7 @@
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_handshake.h"
+#include "tls/s2n_ktls.h"
 #include "tls/s2n_post_handshake.h"
 #include "tls/s2n_record.h"
 #include "utils/s2n_blob.h"
@@ -113,6 +114,10 @@ ssize_t s2n_sendv_with_offset_impl(struct s2n_connection *conn, const struct iov
 
     POSIX_ENSURE(s2n_connection_check_io_status(conn, S2N_IO_WRITABLE), S2N_ERR_CLOSED);
     POSIX_ENSURE(!s2n_connection_is_quic_enabled(conn), S2N_ERR_UNSUPPORTED_WITH_QUIC);
+
+    if (conn->ktls_send_enabled) {
+        return s2n_ktls_sendv_with_offset(conn, bufs, count, offs, blocked);
+    }
 
     /* Flush any pending I/O */
     POSIX_GUARD(s2n_flush(conn, blocked));


### PR DESCRIPTION
### Description of changes: 

Send application data using ktls. The process is fairly simple: just update the iovecs according to the offset, then call sendmsg.

This also implements our other two send methods, s2n_send and s2n_sendv. They're wrappers around s2n_sendv_with_offset with offset==0.

### Call-outs:
We could just call `sendv` instead of `sendmsg`, but using sendmsg / recvmsg for all IO seems simpler. It's definitely easier to test.

### Testing:
Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
