### PR TITLE
Remove duplicate leaf cert parse in x509 validator

### DIFF
--- a/crypto/s2n_openssl_x509.h
+++ b/crypto/s2n_openssl_x509.h
@@ -19,6 +19,7 @@
 #include <openssl/x509.h>
 #include <stdint.h>
 
+#include "utils/s2n_blob.h"
 #include "utils/s2n_safety.h"
 
 DEFINE_POINTER_CLEANUP_FUNC(X509 *, X509_free);
@@ -26,3 +27,6 @@ DEFINE_POINTER_CLEANUP_FUNC(X509 *, X509_free);
 S2N_CLEANUP_RESULT s2n_openssl_x509_stack_pop_free(STACK_OF(X509) **cert_chain);
 
 S2N_CLEANUP_RESULT s2n_openssl_asn1_time_free_pointer(ASN1_GENERALIZEDTIME **time);
+
+S2N_RESULT s2n_openssl_x509_parse(struct s2n_blob *cert_asn1_der, X509 **cert, uint32_t *cert_len);
+S2N_RESULT s2n_openssl_x509_validate_length(struct s2n_blob *cert_asn1_der, uint32_t cert_len);

--- a/crypto/s2n_pkey.h
+++ b/crypto/s2n_pkey.h
@@ -70,4 +70,5 @@ int s2n_pkey_match(const struct s2n_pkey *pub_key, const struct s2n_pkey *priv_k
 int s2n_pkey_free(struct s2n_pkey *pkey);
 
 int s2n_asn1der_to_private_key(struct s2n_pkey *priv_key, struct s2n_blob *asn1der, int type_hint);
-int s2n_asn1der_to_public_key_and_type(struct s2n_pkey *pub_key, s2n_pkey_type *pkey_type, struct s2n_blob *asn1der);
+int s2n_asn1der_to_public_key_and_type(struct s2n_pkey *pub_key, s2n_pkey_type *pkey_type_out, struct s2n_blob *asn1der);
+S2N_RESULT s2n_pkey_x509_to_public_key_and_type(X509 *cert, struct s2n_pkey *pub_key, s2n_pkey_type *pkey_type_out);

--- a/tests/unit/s2n_pkey_test.c
+++ b/tests/unit/s2n_pkey_test.c
@@ -17,6 +17,8 @@
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 
+S2N_RESULT s2n_x509_validator_read_asn1_cert(struct s2n_stuffer *cert_chain_in_stuffer, struct s2n_blob *asn1_cert);
+
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
@@ -166,6 +168,54 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
         }
     };
+
+    /* s2n_asn1der_to_public_key_and_type tests */
+    {
+        /* A certificate with one trailing byte is parsed successfully */
+        {
+            uint8_t cert_chain_data[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+            uint32_t cert_chain_len = 0;
+            EXPECT_SUCCESS(s2n_read_test_pem_and_len(S2N_ONE_TRAILING_BYTE_CERT_BIN, cert_chain_data, &cert_chain_len,
+                    S2N_MAX_TEST_PEM_SIZE));
+
+            struct s2n_blob cert_chain_blob = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&cert_chain_blob, cert_chain_data, cert_chain_len));
+            DEFER_CLEANUP(struct s2n_stuffer cert_chain_stuffer = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_init_written(&cert_chain_stuffer, &cert_chain_blob));
+
+            struct s2n_blob cert_asn1_der = { 0 };
+            EXPECT_OK(s2n_x509_validator_read_asn1_cert(&cert_chain_stuffer, &cert_asn1_der));
+
+            DEFER_CLEANUP(struct s2n_pkey public_key = { 0 }, s2n_pkey_free);
+            EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key));
+            s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
+
+            EXPECT_SUCCESS(s2n_asn1der_to_public_key_and_type(&public_key, &pkey_type, &cert_asn1_der));
+        }
+
+        /* A certificate with too many trailing bytes errors */
+        {
+            uint8_t cert_chain_data[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+            uint32_t cert_chain_len = 0;
+            EXPECT_SUCCESS(s2n_read_test_pem_and_len(S2N_FOUR_TRAILING_BYTE_CERT_BIN, cert_chain_data, &cert_chain_len,
+                    S2N_MAX_TEST_PEM_SIZE));
+
+            struct s2n_blob cert_chain_blob = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&cert_chain_blob, cert_chain_data, cert_chain_len));
+            DEFER_CLEANUP(struct s2n_stuffer cert_chain_stuffer = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_init_written(&cert_chain_stuffer, &cert_chain_blob));
+
+            struct s2n_blob cert_asn1_der = { 0 };
+            EXPECT_OK(s2n_x509_validator_read_asn1_cert(&cert_chain_stuffer, &cert_asn1_der));
+
+            DEFER_CLEANUP(struct s2n_pkey public_key = { 0 }, s2n_pkey_free);
+            EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key));
+            s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_asn1der_to_public_key_and_type(&public_key, &pkey_type, &cert_asn1_der),
+                    S2N_ERR_DECODE_CERTIFICATE);
+        }
+    }
 
     END_TEST();
 }

--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -1812,6 +1812,47 @@ int main(int argc, char **argv)
         s2n_x509_validator_wipe(&validator);
     };
 
+    /* Ensure that certs after the leaf cert can have an arbitrary number of trailing bytes */
+    {
+        DEFER_CLEANUP(struct s2n_x509_validator validator = { 0 }, s2n_x509_validator_wipe);
+        EXPECT_SUCCESS(s2n_x509_validator_init_no_x509_validation(&validator));
+
+        DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(connection);
+
+        DEFER_CLEANUP(struct s2n_stuffer one_trailing_byte_chain = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(read_file(&one_trailing_byte_chain, S2N_ONE_TRAILING_BYTE_CERT_BIN, S2N_MAX_TEST_PEM_SIZE));
+        uint32_t one_trailing_byte_chain_len = s2n_stuffer_data_available(&one_trailing_byte_chain);
+        uint8_t *one_trailing_byte_chain_data = s2n_stuffer_raw_read(&one_trailing_byte_chain,
+                one_trailing_byte_chain_len);
+
+        DEFER_CLEANUP(struct s2n_stuffer four_trailing_bytes_chain = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(read_file(&four_trailing_bytes_chain, S2N_FOUR_TRAILING_BYTE_CERT_BIN, S2N_MAX_TEST_PEM_SIZE));
+        uint32_t four_trailing_bytes_chain_len = s2n_stuffer_data_available(&four_trailing_bytes_chain);
+        uint8_t *four_trailing_bytes_chain_data = s2n_stuffer_raw_read(&four_trailing_bytes_chain,
+                four_trailing_bytes_chain_len);
+
+        DEFER_CLEANUP(struct s2n_stuffer chain_stuffer = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_alloc(&chain_stuffer, S2N_MAX_TEST_PEM_SIZE * 2));
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&chain_stuffer, one_trailing_byte_chain_data,
+                one_trailing_byte_chain_len));
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&chain_stuffer, four_trailing_bytes_chain_data,
+                four_trailing_bytes_chain_len));
+
+        uint32_t chain_len = s2n_stuffer_data_available(&chain_stuffer);
+        EXPECT_TRUE(chain_len > 0);
+        uint8_t *chain_data = s2n_stuffer_raw_read(&chain_stuffer, chain_len);
+
+        DEFER_CLEANUP(struct s2n_pkey public_key = { 0 }, s2n_pkey_free);
+        EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key));
+        s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
+
+        EXPECT_OK(s2n_x509_validator_validate_cert_chain(&validator, connection, chain_data, chain_len, &pkey_type,
+                &public_key));
+
+        EXPECT_EQUAL(sk_X509_num(validator.cert_chain_from_wire), 2);
+    };
+
     /* Test validator trusts a SHA-1 signature in a certificate chain if certificate validation is off */
     {
         struct s2n_x509_trust_store trust_store;
@@ -1897,6 +1938,23 @@ int main(int argc, char **argv)
         s2n_x509_validator_wipe(&validator);
         s2n_x509_trust_store_wipe(&trust_store);
     };
+
+    /* Validator fails if cert chain is empty */
+    {
+        DEFER_CLEANUP(struct s2n_x509_validator validator = { 0 }, s2n_x509_validator_wipe);
+        EXPECT_SUCCESS(s2n_x509_validator_init_no_x509_validation(&validator));
+
+        DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(connection);
+
+        struct s2n_pkey public_key = { 0 };
+        EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key));
+        s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
+
+        EXPECT_ERROR_WITH_ERRNO(s2n_x509_validator_validate_cert_chain(&validator, connection, NULL, 0, &pkey_type,
+                                        &public_key),
+                S2N_ERR_NO_CERT_FOUND);
+    }
 
     /* Test trust store can be wiped */
     {


### PR DESCRIPTION
### Resolved issues:

Resolves https://github.com/aws/s2n-tls/issues/4163

### Description of changes: 

s2n-tls processes received certificates in [`s2n_x509_validator_validate_cert_chain()`](https://github.com/aws/s2n-tls/blob/62dc7a6d4876e5eee0dea3690d528a4c7080a1d5/tls/s2n_x509_validator.c#L581). Among other things, this function performs the following:
- Each of the received asn1-encoded certificates are parsed via the `d2i_X509()` libcrypto API. The parsed `X509` libcrypto objects are provided to the libcrypto to validate the certificate chain.
- The public key and public key type are retrieved from the leaf certificate, and returned via the output arguments.

Currently, the leaf certificate is parsed when parsing all of the other received certificates in [`s2n_x509_validator_read_cert_chain()`](https://github.com/aws/s2n-tls/blob/5d5400aea80e033d73b0343dd03d915a83aaa549/tls/s2n_x509_validator.c#L404), and then parsed again later when getting the public key and public key type in [`s2n_x509_validator_read_leaf_info()`](https://github.com/aws/s2n-tls/blob/5d5400aea80e033d73b0343dd03d915a83aaa549/tls/s2n_x509_validator.c#L554).

The libcrypto API used to parse certificates, `d2i_X509()`, isn't free. The duplicate `d2i_X509()` call can be observed in following flamegraph:

<details>
<summary>Pre-fix flamegraph</summary>

<img width="1019" alt="Screenshot 2023-08-30 at 13 09 34" src="https://github.com/aws/s2n-tls/assets/3758302/eaf44158-2fc0-4e5c-a814-7d24d0212b73">
</details>

This PR refactors [`s2n_x509_validator_validate_cert_chain()`](https://github.com/aws/s2n-tls/blob/62dc7a6d4876e5eee0dea3690d528a4c7080a1d5/tls/s2n_x509_validator.c#L581) and [`s2n_asn1der_to_public_key_and_type()`](https://github.com/aws/s2n-tls/blob/62dc7a6d4876e5eee0dea3690d528a4c7080a1d5/crypto/s2n_pkey.c#L199) to remove the duplicate leaf cert parse, improving total handshake performance by 8.4% in the example shown above.

The refactor involves splitting up `s2n_asn1der_to_public_key_and_type()` into a separate function that gets the public key and type from an already parsed cert, so that the x509 validator can call this version instead. However, this is complicated by some [additional validation](https://github.com/aws/s2n-tls/blob/62dc7a6d4876e5eee0dea3690d528a4c7080a1d5/crypto/s2n_pkey.c#L210-L213) performed in `s2n_asn1der_to_public_key_and_type()` which checks the number of trailing bytes after parsing the cert. To ensure no behavior change, this validation was kept, and moved to when the leaf cert was parsed for the first time.

### Call-outs:

- My intent was to not change any observable existing behavior in this PR.

### Testing:

New unit tests were added to make sure the existing behavior of `s2n_x509_validator_validate_cert_chain()` and `s2n_asn1der_to_public_key_and_type()` were preserved. I've confirmed that all of the new tests also succeed on the unmodified code.

There are existing tests that ensure trailing bytes are checked when validating received leaf certificates in `s2n_x509_validator_validate_cert_chain()`:
https://github.com/aws/s2n-tls/blob/5d5400aea80e033d73b0343dd03d915a83aaa549/tests/unit/s2n_x509_validator_test.c#L1763

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
