### PR TITLE
ktls: send alerts

### DIFF
--- a/tests/testlib/s2n_ktls_test_utils.c
+++ b/tests/testlib/s2n_ktls_test_utils.c
@@ -203,8 +203,8 @@ S2N_CLEANUP_RESULT s2n_ktls_io_stuffer_pair_free(struct s2n_test_ktls_io_stuffer
     return S2N_RESULT_OK;
 }
 
-S2N_RESULT s2n_test_validate_data(struct s2n_test_ktls_io_stuffer *ktls_io, uint8_t *expected_data,
-        uint16_t expected_len)
+S2N_RESULT s2n_test_validate_data(struct s2n_test_ktls_io_stuffer *ktls_io,
+        const uint8_t *expected_data, uint16_t expected_len)
 {
     RESULT_ENSURE_REF(ktls_io);
     RESULT_ENSURE_REF(expected_data);

--- a/tests/testlib/s2n_ktls_test_utils.h
+++ b/tests/testlib/s2n_ktls_test_utils.h
@@ -68,8 +68,8 @@ S2N_RESULT s2n_test_init_ktls_io_stuffer(struct s2n_connection *server,
         struct s2n_connection *client, struct s2n_test_ktls_io_stuffer_pair *io_pair);
 S2N_CLEANUP_RESULT s2n_ktls_io_stuffer_free(struct s2n_test_ktls_io_stuffer *io);
 S2N_CLEANUP_RESULT s2n_ktls_io_stuffer_pair_free(struct s2n_test_ktls_io_stuffer_pair *pair);
-S2N_RESULT s2n_test_validate_data(struct s2n_test_ktls_io_stuffer *ktls_io, uint8_t *expected_data,
-        uint16_t expected_len);
+S2N_RESULT s2n_test_validate_data(struct s2n_test_ktls_io_stuffer *ktls_io,
+        const uint8_t *expected_data, uint16_t expected_len);
 S2N_RESULT s2n_test_validate_ancillary(struct s2n_test_ktls_io_stuffer *ktls_io,
         uint8_t expected_record_type, uint16_t expected_len);
 S2N_RESULT s2n_test_records_in_ancillary(struct s2n_test_ktls_io_stuffer *ktls_io,

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -853,11 +853,17 @@ int s2n_connection_use_corked_io(struct s2n_connection *conn)
 
 uint64_t s2n_connection_get_wire_bytes_in(struct s2n_connection *conn)
 {
+    if (conn->ktls_recv_enabled) {
+        return 0;
+    }
     return conn->wire_bytes_in;
 }
 
 uint64_t s2n_connection_get_wire_bytes_out(struct s2n_connection *conn)
 {
+    if (conn->ktls_send_enabled) {
+        return 0;
+    }
     return conn->wire_bytes_out;
 }
 

--- a/tls/s2n_ktls.h
+++ b/tls/s2n_ktls.h
@@ -39,6 +39,7 @@ typedef enum {
 bool s2n_ktls_is_supported_on_platform();
 S2N_RESULT s2n_ktls_get_file_descriptor(struct s2n_connection *conn, s2n_ktls_mode ktls_mode, int *fd);
 
+int s2n_ktls_send_cb(void *io_context, const uint8_t *buf, uint32_t len);
 S2N_RESULT s2n_ktls_sendmsg(void *io_context, uint8_t record_type, const struct iovec *msg_iov,
         size_t msg_iovlen, s2n_blocked_status *blocked, size_t *bytes_written);
 S2N_RESULT s2n_ktls_recvmsg(void *io_context, uint8_t *record_type, uint8_t *buf,
@@ -46,6 +47,8 @@ S2N_RESULT s2n_ktls_recvmsg(void *io_context, uint8_t *record_type, uint8_t *buf
 
 ssize_t s2n_ktls_sendv_with_offset(struct s2n_connection *conn, const struct iovec *bufs,
         ssize_t count, ssize_t offs, s2n_blocked_status *blocked);
+int s2n_ktls_record_writev(struct s2n_connection *conn, uint8_t content_type,
+        const struct iovec *in, int in_count, size_t offs, size_t to_write);
 
 /* These functions will be part of the public API. */
 int s2n_connection_ktls_enable_send(struct s2n_connection *conn);
@@ -61,3 +64,4 @@ S2N_RESULT s2n_ktls_set_sendmsg_cb(struct s2n_connection *conn, s2n_ktls_sendmsg
         void *send_ctx);
 S2N_RESULT s2n_ktls_set_recvmsg_cb(struct s2n_connection *conn, s2n_ktls_recvmsg_fn recv_cb,
         void *recv_ctx);
+S2N_RESULT s2n_ktls_configure_connection(struct s2n_connection *conn, s2n_ktls_mode ktls_mode);

--- a/tls/s2n_ktls.h
+++ b/tls/s2n_ktls.h
@@ -39,9 +39,9 @@ typedef enum {
 bool s2n_ktls_is_supported_on_platform();
 S2N_RESULT s2n_ktls_get_file_descriptor(struct s2n_connection *conn, s2n_ktls_mode ktls_mode, int *fd);
 
-S2N_RESULT s2n_ktls_sendmsg(struct s2n_connection *conn, uint8_t record_type, const struct iovec *msg_iov,
+S2N_RESULT s2n_ktls_sendmsg(void *io_context, uint8_t record_type, const struct iovec *msg_iov,
         size_t msg_iovlen, s2n_blocked_status *blocked, size_t *bytes_written);
-S2N_RESULT s2n_ktls_recvmsg(struct s2n_connection *conn, uint8_t *record_type, uint8_t *buf,
+S2N_RESULT s2n_ktls_recvmsg(void *io_context, uint8_t *record_type, uint8_t *buf,
         size_t buf_len, s2n_blocked_status *blocked, size_t *bytes_read);
 
 ssize_t s2n_ktls_sendv_with_offset(struct s2n_connection *conn, const struct iovec *bufs,

--- a/tls/s2n_ktls_io.c
+++ b/tls/s2n_ktls_io.c
@@ -337,10 +337,9 @@ int s2n_ktls_send_cb(void *io_context, const uint8_t *buf, uint32_t len)
     s2n_blocked_status blocked = S2N_NOT_BLOCKED;
     size_t bytes_written = 0;
 
-    s2n_result result = s2n_ktls_sendmsg(io_context, record_type, &iov, 1,
-            &blocked, &bytes_written);
+    POSIX_GUARD_RESULT(s2n_ktls_sendmsg(io_context, record_type, &iov, 1,
+            &blocked, &bytes_written));
 
-    POSIX_GUARD_RESULT(result);
     POSIX_ENSURE_LTE(bytes_written, len);
     return bytes_written;
 }

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -24,6 +24,7 @@
 #include "tls/s2n_cipher_suites.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_crypto.h"
+#include "tls/s2n_ktls.h"
 #include "tls/s2n_record.h"
 #include "utils/s2n_blob.h"
 #include "utils/s2n_random.h"
@@ -247,6 +248,10 @@ static inline int s2n_record_encrypt(
 
 int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const struct iovec *in, int in_count, size_t offs, size_t to_write)
 {
+    if (conn->ktls_send_enabled) {
+        return s2n_ktls_record_writev(conn, content_type, in, in_count, offs, to_write);
+    }
+
     struct s2n_blob iv = { 0 };
     uint8_t padding = 0;
     uint16_t block_size = 0;

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -115,12 +115,12 @@ ssize_t s2n_sendv_with_offset_impl(struct s2n_connection *conn, const struct iov
     POSIX_ENSURE(s2n_connection_check_io_status(conn, S2N_IO_WRITABLE), S2N_ERR_CLOSED);
     POSIX_ENSURE(!s2n_connection_is_quic_enabled(conn), S2N_ERR_UNSUPPORTED_WITH_QUIC);
 
+    /* Flush any pending I/O */
+    POSIX_GUARD(s2n_flush(conn, blocked));
+
     if (conn->ktls_send_enabled) {
         return s2n_ktls_sendv_with_offset(conn, bufs, count, offs, blocked);
     }
-
-    /* Flush any pending I/O */
-    POSIX_GUARD(s2n_flush(conn, blocked));
 
     /* Acknowledge consumed and flushed user data as sent */
     user_data_sent = conn->current_user_data_consumed;


### PR DESCRIPTION
resolves https://github.com/aws/s2n-tls/issues/4167

### Description of changes: 

Add support for sending alerts (and therefore s2n_shutdown_send). 

If we just want s2n_shutdown_send to work, there's actually an easier way to do this: https://github.com/lrstewart/s2n/commit/ba40159321a40797ff2494c496786065f8710dca. Using conn->out to track progress is a bit of a hack, but we could also use current_user_data_consumed or add a new ktls-specific field.

However, that way isn't eventually extendable to handshake messages. If we follow that pattern, we need to add an "if ktls" everywhere we try to write a record. If we instead replace s2n_record_writev, we automatically insert ktls support anywhere we write a record. Unlike application data, s2n-tls owns control message data and needs to buffer it if sendmsg blocks. s2n_flush will automatically handle that, since we're just writing into conn->out like normal.

I see two downsides of this method:
- We have to allocate on the heap for 2-byte alerts. But alerts are infrequent (only on shutdown) so that shouldn't really be a big problem. If it becomes a problem, we can always allocate two bytes on the connection structure for conn->out to use for alerts.
- get_wire_bytes_out gets a bit odd, because it now reflects control messages sent. We can mitigate this by switching to get_wire_bytes_out/in just always returning 0 for ktls. Not ideal, but no solution for get_wire_bytes_out/in+ktls is ideal :(

### Call-outs:
* If the changes to sendmsg and recvmsg are making this difficult to read, I can merge them first: https://github.com/aws/s2n-tls/pull/4184
* We might eventually be able to consolidate quic and ktls support. They're doing the same thing: writing unencrypted data. Currently quic is [pretty special-cased](https://github.com/aws/s2n-tls/blob/main/tls/s2n_handshake_io.c#L1206-L1210), but I think after [the cleanup I did a while back](https://github.com/aws/s2n-tls/commit/4d4f37e8897691f6c1db8dcb9192a1c92873fb4f) quic can follow the same model as ktls does here.

### Testing:
Unit tests.
Tests are currently failing on some CI setup issue. They were passing previously, so I'm publishing anyway.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
