### PR TITLE
ci: Upgrade asan to catch use after scope

### DIFF
--- a/codebuild/spec/buildspec_generalbatch.yml
+++ b/codebuild/spec/buildspec_generalbatch.yml
@@ -119,18 +119,29 @@ batch:
           S2N_LIBCRYPTO: 'awslc-fips'
           TESTS: valgrind
       identifier: s2nValgrindAwslcFips
-    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+    - identifier: s2nAsanOpenSSL111Coverage
+      buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         privileged-mode: true
         variables:
           BUILD_S2N: 'true'
-          GCC_VERSION: '6'
+          GCC_VERSION: '9'
           S2N_COVERAGE: 'true'
           S2N_LIBCRYPTO: 'openssl-1.1.1'
           TESTS: asan
-      identifier: s2nAsanOpenSSL111Coverage
+    - identifier: s2nAsanAwslc
+      buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
+        privileged-mode: true
+        variables:
+          BUILD_S2N: 'true'
+          GCC_VERSION: '9'
+          S2N_LIBCRYPTO: 'awslc'
+          TESTS: asan
     - identifier: s2nAsanOpenssl3
       buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
@@ -139,20 +150,20 @@ batch:
         image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         variables:
           TESTS: asan
-          GCC_VERSION: '6'
+          GCC_VERSION: '9'
           S2N_LIBCRYPTO: 'openssl-3.0'
           BUILD_S2N: 'true'
-    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+    - identifier: s2nAsanOpenssl102
+      buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
         image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         privileged-mode: true
         variables:
           BUILD_S2N: 'true'
-          GCC_VERSION: '6'
+          GCC_VERSION: '9'
           S2N_LIBCRYPTO: 'openssl-1.0.2'
           TESTS: asan
-      identifier: s2nAsanOpenssl102
     - buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL


### PR DESCRIPTION
### Description of changes: 
Upgrade gcc (and therefore AddressSanitizer) to gcc 9. We shouldn't be intentionally using a worse version of AddressSanitizer. If we want to check memory safety of features that require an old gcc version, we should use Valgrind instead (and several of our Valgrind builds do currently use gcc 6).

This is important because old AddressSanitizer may miss leaks. In particular, before 7.1 AddressSanitizer doesn't detect stack-use-after-scope. Try playing with the compiler version on https://godbolt.org/z/ed7ro9hrM. Our gcc 6 AddressSanitizer missed this issue in one of my PRs: https://github.com/aws/s2n-tls/pull/4181/commits/68f6c5ad52f8700def86168ea8108d17f71b3bfc

I also added an asan test for awslc, because we were missing one and that's an important libcrypto to test.

### Callouts
This only moves ASAN to GCC9, which adds the "use after scope" check. We can do better though: https://github.com/aws/s2n-tls/issues/4193

### Testing:
* The current CI still passes.
* I added an "[s2n_asan_test](https://github.com/aws/s2n-tls/commit/7f41c55e0be9045c4a1c7b26ea9bb31d1ef81074)" that fails with the upgraded gcc: https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nGeneralBatch/batch/s2nGeneralBatch%3Abbd18080-69e6-4a6b-a370-cc7cec4e9f4c?region=us-west-2
* Note that s2nGeneralBatch passed for https://github.com/aws/s2n-tls/pull/4181/commits/ef89981060984526855c7257693f63d2bca0e483 (click the red x by the commit title, or trust me and see [link](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoidUpNb2QzNjZzQ3lrWm1UQ2xzdFZMN1ZGYWE5dVlSQ1ZKd1BnZzZ6aXN1dlZXTmFuZWdvNnR0SitPaFlIcUdjaDZ6RU9KemY2Mi9ybXVBajF0RXo4NmZ1Rnl4dkZrT241UUY4MTVQMkRuNTQ9IiwiaXZQYXJhbWV0ZXJTcGVjIjoiemFRUDgvZUMreVhER0RKaiIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D/batch/9c0a0c4b-4e82-49e9-b4cb-d71ac4f8b104)), despite a stack-use-after-scope error I later fixed. I ran [the original buggy code with the upgraded gcc](https://github.com/aws/s2n-tls/compare/main...lrstewart:s2n:asan_ci_451a8efe) and it failed: https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nGeneralBatch/batch/s2nGeneralBatch%3A718bc438-6f62-4308-9457-672ffc755e34?region=us-west-2


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
