### PR TITLE
ci: run duvet when commits are merged into main branch

### DIFF
--- a/.github/workflows/ci_compliance.yml
+++ b/.github/workflows/ci_compliance.yml
@@ -2,6 +2,8 @@
 name: Compliance
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
   merge_group:


### PR DESCRIPTION
### Description of changes: 
The duvet job only runs in PRs but is unable to publish to s3 since the AWS creds are not available from forks.

This PR changes the workflow to also run when commits are merged(push) to the `main` branch. Since the merge to main happens on the repo itself, we should be able to access the AWS creds and publish the duvet report to s3.

### Call-outs:
I kept the run in PRs since it helps validate that the compliance comments were done correctly and catch any mistakes at PR time.

### Testing:
I tested that the action now run on merge to main on my [fork](https://github.com/toidiu/s2n-tls) (click on the running checks and see that duvet is running).



Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
