### PR TITLE
docs: add citations for alert behavior

### DIFF
--- a/compliance/initialize_duvet.sh
+++ b/compliance/initialize_duvet.sh
@@ -1,5 +1,6 @@
 #/usr/bin/env bash
 
+duvet extract https://tools.ietf.org/rfc/rfc5246 # The Transport Layer Security (TLS) Protocol Version 1.2
 duvet extract https://tools.ietf.org/rfc/rfc5869 # HMAC-based Extract-and-Expand Key Derivation Function (HKDF)
 duvet extract https://tools.ietf.org/rfc/rfc8446 # The Transport Layer Security (TLS) Protocol Version 1.3
 duvet extract https://tools.ietf.org/rfc/rfc8448 # Example Handshake Traces for TLS 1.3

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -222,7 +222,14 @@ int s2n_process_alert_fragment(struct s2n_connection *conn)
                 conn->config->cache_delete(conn, conn->config->cache_delete_data, conn->session_id, conn->session_id_len);
             }
 
-            /* All other alerts are treated as fatal errors */
+            /*
+             *= https://tools.ietf.org/rfc/rfc8446#section-6
+             *# MUST be treated as error alerts when received
+             *# regardless of the AlertLevel in the message.  Unknown Alert types
+             *# MUST be treated as error alerts.
+             *
+             * All other alerts are treated as fatal errors.
+             */
             POSIX_GUARD_RESULT(s2n_connection_set_closed(conn));
             s2n_atomic_flag_set(&conn->error_alert_received);
             POSIX_BAIL(S2N_ERR_ALERT);
@@ -279,8 +286,17 @@ S2N_RESULT s2n_alerts_write_error_or_close_notify(struct s2n_connection *conn)
         return S2N_RESULT_OK;
     }
 
-    /* By default, s2n-tls sends a generic close_notify alert, even in
-     * response to fatal errors.
+    /*
+     *= https://tools.ietf.org/rfc/rfc8446#section-6.2
+     *= type=exception
+     *# The phrases "terminate the connection with an X
+     *# alert" and "abort the handshake with an X alert" mean that the
+     *# implementation MUST send alert X if it sends any alert.
+     *
+     * By default, s2n-tls sends a generic close_notify alert, even in
+     * response to fatal errors. This is done to avoid potential
+     * side-channel attacks since specific alerts could reveal information
+     * about why the error occured.
      */
     uint8_t code = S2N_TLS_ALERT_CLOSE_NOTIFY;
     uint8_t level = S2N_TLS_ALERT_LEVEL_WARNING;

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -143,17 +143,16 @@ static bool s2n_alerts_supported(struct s2n_connection *conn)
     return !s2n_connection_is_quic_enabled(conn);
 }
 
+/*
+ * In TLS1.3 all Alerts
+ *= https://tools.ietf.org/rfc/rfc8446#section-6
+ *# MUST be treated as error alerts when received
+ *# regardless of the AlertLevel in the message.
+ */
 static bool s2n_process_as_warning(struct s2n_connection *conn, uint8_t level, uint8_t type)
 {
-    /*
-     *= https://tools.ietf.org/rfc/rfc8446#section-6
-     *# All the alerts listed in Section 6.2 MUST be sent with
-     *# AlertLevel=fatal and MUST be treated as error alerts when received
-     *# regardless of the AlertLevel in the message.
-     *
-     * Only TLS1.2 considers the alert level. The alert level field is
-     * considered deprecated in TLS1.3.
-     */
+    /* Only TLS1.2 considers the alert level. The alert level field is
+     * considered deprecated in TLS1.3. */
     if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
         return level == S2N_TLS_ALERT_LEVEL_WARNING
                 && conn->config->alert_behavior == S2N_ALERT_IGNORE_WARNINGS;
@@ -231,8 +230,7 @@ int s2n_process_alert_fragment(struct s2n_connection *conn)
 
             /*
              *= https://tools.ietf.org/rfc/rfc8446#section-6
-             *# Unknown Alert types
-             *# MUST be treated as error alerts.
+             *# Unknown Alert types MUST be treated as error alerts.
              *
              * All other alerts are treated as fatal errors.
              */

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -228,11 +228,10 @@ int s2n_process_alert_fragment(struct s2n_connection *conn)
                 conn->config->cache_delete(conn, conn->config->cache_delete_data, conn->session_id, conn->session_id_len);
             }
 
-            /*
+            /* All other alerts are treated as fatal errors.
+             *
              *= https://tools.ietf.org/rfc/rfc8446#section-6
              *# Unknown Alert types MUST be treated as error alerts.
-             *
-             * All other alerts are treated as fatal errors.
              */
             POSIX_GUARD_RESULT(s2n_connection_set_closed(conn));
             s2n_atomic_flag_set(&conn->error_alert_received);

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -143,8 +143,7 @@ static bool s2n_alerts_supported(struct s2n_connection *conn)
     return !s2n_connection_is_quic_enabled(conn);
 }
 
-/*
- * In TLS1.3 all Alerts
+/* In TLS1.3 all Alerts
  *= https://tools.ietf.org/rfc/rfc8446#section-6
  *# MUST be treated as error alerts when received
  *# regardless of the AlertLevel in the message.


### PR DESCRIPTION
### Description of changes: 
s2n deviates from the RFC when handling alerts. The RFC calls for sending fatal alerts but s2n-tls defaults to sending close_notify alerts (which are level `warning`). This is intentional and and done to avoid potential side-channel attacks.

Since this is atypical behavior which often confuses new users, this PR adds duvet citations and expands on the comments to increase discoverability.

I also added a compliance comment for alert receiving behavior.

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
