### PR TITLE
ktls: recv alerts

### DIFF
--- a/tests/unit/s2n_ktls_io_test.c
+++ b/tests/unit/s2n_ktls_io_test.c
@@ -952,7 +952,7 @@ int main(int argc, char **argv)
             EXPECT_BYTEARRAY_EQUAL(read, test_data, max_frag_len);
         };
 
-        /* Test: Small read succeeds */
+        /* Test: Receive does not completely fill the output buffer */
         {
             const size_t small_frag_len = 10;
             EXPECT_TRUE(small_frag_len < max_frag_len);
@@ -977,6 +977,9 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_ktls_read_full_record(conn, &record_type));
             EXPECT_EQUAL(record_type, TLS_ALERT);
 
+            /* Verify that conn->in reflects the correct size of the "record"
+             * read and doesn't just assume the maximum read size.
+             */
             EXPECT_EQUAL(conn->in.blob.allocated, max_frag_len);
             EXPECT_EQUAL(s2n_stuffer_data_available(&conn->in), small_frag_len);
             uint8_t *read = s2n_stuffer_raw_read(&conn->in, small_frag_len);

--- a/tests/unit/s2n_ktls_io_test.c
+++ b/tests/unit/s2n_ktls_io_test.c
@@ -911,9 +911,12 @@ int main(int argc, char **argv)
         };
         s2n_blocked_status blocked = S2N_NOT_BLOCKED;
 
-        const size_t max_frag_len = S2N_DEFAULT_FRAGMENT_LENGTH;
+        const size_t max_frag_len = S2N_KTLS_CONTROL_MESSAGE_MAX_FRAG_LEN;
+        const size_t app_data_max_frag_len = S2N_DEFAULT_FRAGMENT_LENGTH;
         /* Our test assumptions are wrong if this isn't true */
         EXPECT_TRUE(max_frag_len < sizeof(test_data));
+        EXPECT_TRUE(app_data_max_frag_len < sizeof(test_data));
+        EXPECT_TRUE(app_data_max_frag_len + max_frag_len < sizeof(test_data));
 
         /* Safety */
         {
@@ -954,7 +957,7 @@ int main(int argc, char **argv)
 
         /* Test: Receive does not completely fill the output buffer */
         {
-            const size_t small_frag_len = 10;
+            const size_t small_frag_len = 3;
             EXPECT_TRUE(small_frag_len < max_frag_len);
             EXPECT_TRUE(small_frag_len < sizeof(test_data));
             struct iovec small_test_iovec = test_iovec;
@@ -984,6 +987,44 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(s2n_stuffer_data_available(&conn->in), small_frag_len);
             uint8_t *read = s2n_stuffer_raw_read(&conn->in, small_frag_len);
             EXPECT_BYTEARRAY_EQUAL(read, test_data, small_frag_len);
+        };
+
+        /* Test: Receive resizes to handle application data */
+        {
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(conn);
+
+            DEFER_CLEANUP(struct s2n_test_ktls_io_stuffer_pair pair = { 0 },
+                    s2n_ktls_io_stuffer_pair_free);
+            EXPECT_OK(s2n_test_init_ktls_io_stuffer(conn, conn, &pair));
+            struct s2n_test_ktls_io_stuffer *ctx = &pair.client_in;
+
+            size_t written = 0;
+            EXPECT_OK(s2n_ktls_sendmsg(ctx, TLS_APPLICATION_DATA,
+                    &test_iovec, 1, &blocked, &written));
+            EXPECT_EQUAL(written, sizeof(test_data));
+
+            uint8_t record_type = 0;
+            uint8_t *read = NULL;
+
+            /* First read returns first fragment */
+            EXPECT_SUCCESS(s2n_ktls_read_full_record(conn, &record_type));
+            EXPECT_EQUAL(record_type, TLS_APPLICATION_DATA);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&conn->in), max_frag_len);
+            read = s2n_stuffer_raw_read(&conn->in, max_frag_len);
+            EXPECT_BYTEARRAY_EQUAL(read, test_data, max_frag_len);
+
+            /* Verify that conn->in was resized for future reads */
+            EXPECT_EQUAL(conn->in.blob.allocated, app_data_max_frag_len);
+            EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
+
+            /* Second read returns larger fragment */
+            EXPECT_SUCCESS(s2n_ktls_read_full_record(conn, &record_type));
+            EXPECT_EQUAL(record_type, TLS_APPLICATION_DATA);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&conn->in), app_data_max_frag_len);
+            read = s2n_stuffer_raw_read(&conn->in, app_data_max_frag_len);
+            EXPECT_BYTEARRAY_EQUAL(read, test_data + max_frag_len, app_data_max_frag_len);
         };
     };
 

--- a/tests/unit/s2n_self_talk_ktls_test.c
+++ b/tests/unit/s2n_self_talk_ktls_test.c
@@ -167,7 +167,11 @@ int main(int argc, char **argv)
     };
 
     /* Test sending with ktls */
-    for (size_t mode_i = 0; mode_i < s2n_array_len(modes) && ktls_send_supported; mode_i++) {
+    for (size_t mode_i = 0; mode_i < s2n_array_len(modes); mode_i++) {
+        if (!ktls_send_supported) {
+            break;
+        }
+
         const s2n_mode mode = modes[mode_i];
 
         DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
@@ -281,7 +285,11 @@ int main(int argc, char **argv)
     };
 
     /* Test receiving with ktls */
-    for (size_t mode_i = 0; mode_i < s2n_array_len(modes) && ktls_recv_supported; mode_i++) {
+    for (size_t mode_i = 0; mode_i < s2n_array_len(modes); mode_i++) {
+        if (!ktls_recv_supported) {
+            break;
+        }
+
         const s2n_mode mode = modes[mode_i];
 
         DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),

--- a/tests/unit/s2n_self_talk_ktls_test.c
+++ b/tests/unit/s2n_self_talk_ktls_test.c
@@ -345,6 +345,9 @@ int main(int argc, char **argv)
 
             /* Verify that the reader skips the application data and successfully
              * receives the close_notify.
+             *
+             * The close_notify was sent after the application data, so if the
+             * close_notify was received, then the application data was also received.
              */
             EXPECT_SUCCESS(s2n_shutdown(reader, &blocked));
             EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);

--- a/tests/unit/s2n_shutdown_test.c
+++ b/tests/unit/s2n_shutdown_test.c
@@ -704,5 +704,140 @@ int main(int argc, char **argv)
         };
     };
 
+    /* Test: ktls enabled */
+    {
+        /* Test: Successfully shutdown */
+        {
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(client);
+            EXPECT_OK(s2n_ktls_configure_connection(client, S2N_KTLS_MODE_SEND));
+            EXPECT_OK(s2n_ktls_configure_connection(client, S2N_KTLS_MODE_RECV));
+            EXPECT_OK(s2n_skip_handshake(client));
+
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(server);
+            EXPECT_OK(s2n_ktls_configure_connection(server, S2N_KTLS_MODE_SEND));
+            EXPECT_OK(s2n_ktls_configure_connection(server, S2N_KTLS_MODE_RECV));
+            EXPECT_OK(s2n_skip_handshake(server));
+
+            DEFER_CLEANUP(struct s2n_test_ktls_io_stuffer_pair io_pair = { 0 },
+                    s2n_ktls_io_stuffer_pair_free);
+            EXPECT_OK(s2n_test_init_ktls_io_stuffer(server, client, &io_pair));
+
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            EXPECT_SUCCESS(s2n_shutdown_send(client, &blocked));
+            EXPECT_TRUE(client->alert_sent);
+
+            EXPECT_SUCCESS(s2n_shutdown(server, &blocked));
+            EXPECT_TRUE(server->alert_sent);
+            EXPECT_TRUE(s2n_connection_check_io_status(server, S2N_IO_CLOSED));
+        };
+
+        /* Test: Successfully shutdown after blocking */
+        {
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(client);
+            EXPECT_OK(s2n_ktls_configure_connection(client, S2N_KTLS_MODE_SEND));
+            EXPECT_OK(s2n_ktls_configure_connection(client, S2N_KTLS_MODE_RECV));
+            EXPECT_OK(s2n_skip_handshake(client));
+
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(server);
+            EXPECT_OK(s2n_ktls_configure_connection(server, S2N_KTLS_MODE_SEND));
+            EXPECT_OK(s2n_ktls_configure_connection(server, S2N_KTLS_MODE_RECV));
+            EXPECT_OK(s2n_skip_handshake(server));
+
+            DEFER_CLEANUP(struct s2n_test_ktls_io_stuffer_pair io_pair = { 0 },
+                    s2n_ktls_io_stuffer_pair_free);
+            EXPECT_OK(s2n_test_init_ktls_io_stuffer(server, client, &io_pair));
+
+            /* Setup the client->server stuffer to not fit the entire close_notify */
+            EXPECT_SUCCESS(s2n_stuffer_free(&io_pair.server_in.data_buffer));
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&io_pair.server_in.data_buffer, 1));
+
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(client, &blocked), S2N_ERR_IO_BLOCKED);
+            EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_WRITE);
+            EXPECT_FALSE(s2n_connection_check_io_status(client, S2N_IO_WRITABLE));
+            EXPECT_TRUE(s2n_connection_check_io_status(client, S2N_IO_READABLE));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(server, &blocked), S2N_ERR_IO_BLOCKED);
+            EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
+            EXPECT_FALSE(s2n_connection_check_io_status(server, S2N_IO_WRITABLE));
+            EXPECT_TRUE(s2n_connection_check_io_status(server, S2N_IO_READABLE));
+
+            /* Reuse the client->server stuffer for the remaining close_notify */
+            EXPECT_SUCCESS(s2n_stuffer_wipe(&io_pair.server_in.data_buffer));
+
+            EXPECT_SUCCESS(s2n_shutdown(client, &blocked));
+            EXPECT_SUCCESS(s2n_shutdown(server, &blocked));
+        };
+
+        /* Test: Skip application data when waiting for close_notify */
+        {
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(client);
+            EXPECT_OK(s2n_ktls_configure_connection(client, S2N_KTLS_MODE_SEND));
+            EXPECT_OK(s2n_ktls_configure_connection(client, S2N_KTLS_MODE_RECV));
+            EXPECT_OK(s2n_skip_handshake(client));
+
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(server);
+            EXPECT_OK(s2n_ktls_configure_connection(server, S2N_KTLS_MODE_SEND));
+            EXPECT_OK(s2n_ktls_configure_connection(server, S2N_KTLS_MODE_RECV));
+            EXPECT_OK(s2n_skip_handshake(server));
+
+            DEFER_CLEANUP(struct s2n_test_ktls_io_stuffer_pair io_pair = { 0 },
+                    s2n_ktls_io_stuffer_pair_free);
+            EXPECT_OK(s2n_test_init_ktls_io_stuffer(server, client, &io_pair));
+
+            /* Send some application data for shutdown to skip */
+            uint8_t app_data[] = "hello world";
+            size_t app_data_size = sizeof(app_data);
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            size_t app_data_count = 5;
+            for (size_t i = 0; i < app_data_count; i++) {
+                EXPECT_SUCCESS(s2n_send(client, app_data, app_data_size, &blocked));
+                EXPECT_SUCCESS(s2n_send(server, app_data, app_data_size, &blocked));
+            }
+            EXPECT_OK(s2n_test_validate_ancillary(&io_pair.client_in, TLS_APPLICATION_DATA, app_data_size));
+            EXPECT_OK(s2n_test_validate_ancillary(&io_pair.server_in, TLS_APPLICATION_DATA, app_data_size));
+            EXPECT_OK(s2n_test_records_in_ancillary(&io_pair.client_in, app_data_count));
+            EXPECT_OK(s2n_test_records_in_ancillary(&io_pair.server_in, app_data_count));
+
+            /* Client's first shutdown blocks on reading the close_notify,
+             * but successfully writes the close_notify and skips all the app data.*/
+            EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown(client, &blocked), S2N_ERR_IO_BLOCKED);
+            EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
+            EXPECT_FALSE(s2n_connection_check_io_status(client, S2N_IO_WRITABLE));
+            EXPECT_TRUE(s2n_connection_check_io_status(client, S2N_IO_READABLE));
+            EXPECT_TRUE(client->alert_sent);
+            EXPECT_OK(s2n_test_records_in_ancillary(&io_pair.client_in, 0));
+            EXPECT_OK(s2n_test_records_in_ancillary(&io_pair.server_in, app_data_count + 1));
+
+            /* Server's first shutdown successfully skips all the app data
+             * and receives the close_notify */
+            EXPECT_SUCCESS(s2n_shutdown(server, &blocked));
+            EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+            EXPECT_TRUE(s2n_connection_check_io_status(server, S2N_IO_CLOSED));
+            EXPECT_TRUE(server->alert_sent);
+            EXPECT_OK(s2n_test_records_in_ancillary(&io_pair.client_in, 1));
+            EXPECT_OK(s2n_test_records_in_ancillary(&io_pair.server_in, 0));
+
+            /* Client's second shutdown successfully receives the close_notify */
+            EXPECT_SUCCESS(s2n_shutdown(client, &blocked));
+            EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+            EXPECT_TRUE(s2n_connection_check_io_status(client, S2N_IO_CLOSED));
+            EXPECT_OK(s2n_test_records_in_ancillary(&io_pair.client_in, 0));
+            EXPECT_OK(s2n_test_records_in_ancillary(&io_pair.server_in, 0));
+        };
+    };
+
     END_TEST();
 }

--- a/tls/s2n_ktls.h
+++ b/tls/s2n_ktls.h
@@ -26,12 +26,6 @@
  */
 #include "tls/s2n_ktls_parameters.h"
 
-/* ktls currently only handles alerts and HelloRequests.
- * HelloRequests are empty handshake messages (just the header).
- */
-#define S2N_KTLS_CONTROL_MESSAGE_MAX_FRAG_LEN \
-    MAX(S2N_ALERT_LENGTH, TLS_HANDSHAKE_HEADER_LENGTH)
-
 /* A set of kTLS configurations representing the combination of sending
  * and receiving.
  */

--- a/tls/s2n_ktls.h
+++ b/tls/s2n_ktls.h
@@ -26,6 +26,12 @@
  */
 #include "tls/s2n_ktls_parameters.h"
 
+/* ktls currently only handles alerts and HelloRequests.
+ * HelloRequests are empty handshake messages (just the header).
+ */
+#define S2N_KTLS_CONTROL_MESSAGE_MAX_FRAG_LEN \
+    MAX(S2N_ALERT_LENGTH, TLS_HANDSHAKE_HEADER_LENGTH)
+
 /* A set of kTLS configurations representing the combination of sending
  * and receiving.
  */

--- a/tls/s2n_ktls.h
+++ b/tls/s2n_ktls.h
@@ -49,6 +49,7 @@ ssize_t s2n_ktls_sendv_with_offset(struct s2n_connection *conn, const struct iov
         ssize_t count, ssize_t offs, s2n_blocked_status *blocked);
 int s2n_ktls_record_writev(struct s2n_connection *conn, uint8_t content_type,
         const struct iovec *in, int in_count, size_t offs, size_t to_write);
+int s2n_ktls_read_full_record(struct s2n_connection *conn, uint8_t *record_type);
 
 /* These functions will be part of the public API. */
 int s2n_connection_ktls_enable_send(struct s2n_connection *conn);

--- a/tls/s2n_ktls_io.c
+++ b/tls/s2n_ktls_io.c
@@ -431,9 +431,9 @@ int s2n_ktls_read_full_record(struct s2n_connection *conn, uint8_t *record_type)
     /* Since recvmsg is responsible for decrypting the record in ktls,
      * we apply blinding to the recvmsg call.
      */
-    WITH_ERROR_BLINDING(conn,
-            POSIX_GUARD_RESULT(s2n_ktls_recvmsg(conn->recv_io_context, record_type,
-                    buf, len, &blocked, &bytes_read)));
+    s2n_result result = s2n_ktls_recvmsg(conn->recv_io_context, record_type,
+            buf, len, &blocked, &bytes_read);
+    WITH_ERROR_BLINDING(conn, POSIX_GUARD_RESULT(result));
 
     POSIX_GUARD(s2n_stuffer_skip_write(&conn->in, bytes_read));
     return S2N_SUCCESS;

--- a/tls/s2n_ktls_io.c
+++ b/tls/s2n_ktls_io.c
@@ -413,12 +413,10 @@ int s2n_ktls_read_full_record(struct s2n_connection *conn, uint8_t *record_type)
     POSIX_ENSURE_REF(record_type);
 
     /* This method copies data into conn->in, so is intended for control messages
-     * rather than application data. However in some cases-- such as when attempting
-     * to read the close_notify alert during s2n_shutdown-- it may encounter application
-     * data. Set a reasonable conn->in size to avoid an excessive number of calls
-     * to recvmsg when reading a larger record.
+     * rather than application data. Set a fragment size that should result in
+     * only one recvmsg call for any reasonably-sized control message.
      */
-    POSIX_GUARD(s2n_stuffer_resize_if_empty(&conn->in, S2N_DEFAULT_FRAGMENT_LENGTH));
+    POSIX_GUARD(s2n_stuffer_resize_if_empty(&conn->in, S2N_KTLS_CONTROL_MESSAGE_MAX_FRAG_LEN));
 
     struct s2n_stuffer record_stuffer = conn->in;
     size_t len = s2n_stuffer_space_remaining(&record_stuffer);
@@ -434,6 +432,15 @@ int s2n_ktls_read_full_record(struct s2n_connection *conn, uint8_t *record_type)
     s2n_result result = s2n_ktls_recvmsg(conn->recv_io_context, record_type,
             buf, len, &blocked, &bytes_read);
     WITH_ERROR_BLINDING(conn, POSIX_GUARD_RESULT(result));
+
+    /* While this method normally only handles control messages, during
+     * s2n_shutdown it may encounter unprocessed application data which needs to
+     * be discarded. In that case, resize the input buffer to reduce the number
+     * of recvmsg calls required to finish reading the application data.
+     */
+    if (*record_type == TLS_APPLICATION_DATA) {
+        POSIX_GUARD(s2n_stuffer_resize(&conn->in, S2N_DEFAULT_FRAGMENT_LENGTH));
+    }
 
     POSIX_GUARD(s2n_stuffer_skip_write(&conn->in, bytes_read));
     return S2N_SUCCESS;


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/4169

### Description of changes: 

Add support for receiving alerts.

Unlike send, I didn't use the existing IO callback. Unlike send I can't make any assumptions about the record type, so I'd need to immediately implement a mechanism for passing the record type back from the IO callback as noted in my send PR. For now, this works.

ktls promises that a call to recvmsg will only return data from a single record type, but potentially from multiple records. But that's basically the same guarantee we have reading records normally too: one alert / handshake message can be split across records, or multiple can appear in the same record. With ktls, we just choose our own artificial record size for the read instead of whatever the peer chose :)

### Call-outs:

Receiving might not be as straightforward to consolidate with quic support as sending. quic only needs handshake messages, so it can ensure a read of the exact correct size by reading the handshake header first. ktls must also handle application data and alerts, so can't make any assumptions about the size of the data. But I can check the current s2n-quic implementation and see how it'd work with less accurately sized reads-- if it's just reading from a big blob of handshake data, we should be fine. And minimally we can switch between a couple different read_full_record implementations.

### Testing:
Unit and self-talk tests.

Locally, I also made a minimal change to s2n_ktls_read_full_record so that it could also be used to (very inefficiently) read application data from s2n_recv. Basically, that works if we assume any data remaining in conn->in when s2n_ktls_read_full_record is called again is application data (basically [this logic](https://github.com/aws/s2n-tls/blob/f40c6b9bd5beb977f7cb3d2200d4c52a40b08518/tls/s2n_recv.c#L63-L68)). With that modification I ran some self-talk tests and they worked. So we could use this for application data, it'd just involve copying and buffering :)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
