### PR TITLE
docs: compliance citations for extensions

### DIFF
--- a/tls/extensions/s2n_cert_status.c
+++ b/tls/extensions/s2n_cert_status.c
@@ -80,7 +80,18 @@ int s2n_cert_status_recv(struct s2n_connection *conn, struct s2n_stuffer *in)
     uint8_t type;
     POSIX_GUARD(s2n_stuffer_read_uint8(in, &type));
     if (type != S2N_STATUS_REQUEST_OCSP) {
-        /* We only support OCSP */
+
+        /*
+         *= https://tools.ietf.org/rfc/rfc6066#section-8
+         *= type=exception
+         *= reason=For compatibility, we choose to ignore malformed extensions if they are optional
+         *# Clients requesting an OCSP response and receiving an OCSP response in
+         *# a "CertificateStatus" message MUST check the OCSP response and abort
+         *# the handshake if the response is not satisfactory with
+         *# bad_certificate_status_response(113) alert.
+         *
+         * We only support OCSP
+         */
         return S2N_SUCCESS;
     }
 

--- a/tls/extensions/s2n_extension_list.c
+++ b/tls/extensions/s2n_extension_list.c
@@ -111,6 +111,13 @@ int s2n_extension_list_process(s2n_extension_list_id list_type, struct s2n_conne
      *# which it appears, it MUST abort the handshake with an
      *# "illegal_parameter" alert.
      *
+     *= https://tools.ietf.org/rfc/rfc8446#section-4.3.1
+     *= type=exception
+     *= reason=Incorrect implementations exist in the wild. Ignoring instead.
+     *# The client MUST check EncryptedExtensions for the
+     *# presence of any forbidden extensions and if any are found MUST abort
+     *# the handshake with an "illegal_parameter" alert.
+     *
      * If we want to enforce this restriction in the future, we can verify
      * that no parsed extensions exist without the "processed" flag set.
      */
@@ -142,7 +149,11 @@ static int s2n_extension_parse(struct s2n_stuffer *in, s2n_parsed_extension *par
 
     s2n_parsed_extension *parsed_extension = &parsed_extensions[extension_id];
 
-    /* Error if extension is a duplicate */
+    /*
+     *= https://tools.ietf.org/rfc/rfc8446#section-4.2
+     *# There MUST NOT be more than one extension of the
+     *# same type in a given extension block.
+     */
     POSIX_ENSURE(s2n_parsed_extension_is_empty(parsed_extension),
             S2N_ERR_DUPLICATE_EXTENSION);
 

--- a/tls/extensions/s2n_server_signature_algorithms.c
+++ b/tls/extensions/s2n_server_signature_algorithms.c
@@ -26,6 +26,13 @@
 
 static int s2n_signature_algorithms_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
+/*
+ *= https://tools.ietf.org/rfc/rfc8446#4.2.3
+ *# If a server is authenticating via
+ *# a certificate and the client has not sent a "signature_algorithms"
+ *# extension, then the server MUST abort the handshake with a
+ *# "missing_extension" alert (see Section 9.2).
+ */
 const s2n_extension_type s2n_server_signature_algorithms_extension = {
     .iana_value = TLS_EXTENSION_SIGNATURE_ALGORITHMS,
     .is_response = false,


### PR DESCRIPTION
### Description of changes: 
Add some duvet citations around how s2n handles extensions.

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
