### PR TITLE
ci: add workflow for rust bench crate

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -59,6 +59,26 @@ jobs:
           ./generate.sh
           ldd target/debug/integration | grep libs2n.so
 
+  # our benchmark testing includes interop tests between s2n-tls, rustls, and
+  # openssl
+  bench-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          toolchain: stable
+          override: true
+
+      - name: generate bindings
+        run: ${{env.ROOT_PATH}}/generate.sh --skip-tests
+
+      - name: bench tests
+        working-directory: ${{env.ROOT_PATH}}/bench
+        run: cargo test
+
   generate-openssl-102:
     runs-on: ubuntu-latest
     steps:

--- a/bindings/rust/generate.sh
+++ b/bindings/rust/generate.sh
@@ -39,6 +39,11 @@ pushd generate
 cargo run -- ../s2n-tls-sys
 popd
 
+if [ "$1" == "--skip-tests" ]; then
+    echo "skipping tests"
+    exit;
+fi;
+
 # make sure everything builds and passes sanity checks
 pushd s2n-tls-sys
 cargo test


### PR DESCRIPTION
The bench crate contains interop testing that would be useful to have in our ci runs. This commit adds a github workflow to run that. It also adds an options to generate the bindings without running the tests, since the tests take several minutes to run.

### Description of changes: 
- adds CI workflow for bench crate
- adds option to skip tests in bindings generation

### Testing:

The workflow should pass.

After this workflow has been added, we should make it a required success for merging.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
