### PR TITLE
Build option to print file basename only (s2n_strerror_debug)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ loaded in an application with an otherwise conflicting libcrypto version." OFF)
 option(S2N_LTO, "Enables link time optimizations when building s2n-tls." OFF)
 option(S2N_STACKTRACE "Enables stacktrace functionality in s2n-tls. Note that this functionality is
 only available on platforms that support execinfo." ON)
+option(S2N_DEBUG_OUTPUT_FILENAME "Enables behaviour to only print file basenames in debug output instead of absolute paths." OFF)
 option(COVERAGE "Enable profiling collection for code coverage calculation" OFF)
 option(S2N_INTEG_TESTS "Enable the integrationv2 tests" OFF)
 option(S2N_FAST_INTEG_TESTS "Enable the integrationv2 with more parallelism, only has effect if S2N_INTEG_TESTS=ON" OFF)
@@ -188,6 +189,10 @@ endif()
 
 if(S2N_NO_PQ)
     add_definitions(-DS2N_NO_PQ)
+endif()
+
+if(S2N_DEBUG_OUTPUT_FILENAME)
+    add_definitions(-DS2N_DEBUG_OUTPUT_FILENAME)
 endif()
 
 # Whether to fail the build when compiling s2n's portable C code with non-portable assembly optimizations. Doing this

--- a/error/s2n_errno.h
+++ b/error/s2n_errno.h
@@ -327,7 +327,15 @@ extern __thread const char *s2n_debug_str;
 #define STRING_(s)     TO_STRING(s)
 #define STRING__LINE__ STRING_(__LINE__)
 
-#define _S2N_DEBUG_LINE "Error encountered in " __FILE__ ":" STRING__LINE__
+#ifdef S2N_DEBUG_OUTPUT_FILENAME
+#ifdef __FILE_NAME__
+    #define _S2N_DEBUG_LINE "Error encountered in " __FILE_NAME__ ":" STRING__LINE__
+#else
+    #define _S2N_DEBUG_LINE "Error encountered in " __FILE__ ":" STRING__LINE__
+#endif /* __FILE_NAME__ */
+#else
+    #define _S2N_DEBUG_LINE "Error encountered in " __FILE__ ":" STRING__LINE__
+#endif /* S2N_DEBUG_OUTPUT_FILENAME */
 #define _S2N_ERROR(x)                    \
     do {                                 \
         s2n_debug_str = _S2N_DEBUG_LINE; \

--- a/s2n.mk
+++ b/s2n.mk
@@ -94,6 +94,11 @@ ifdef S2N_NO_PQ
 	DEFAULT_CFLAGS += -DS2N_NO_PQ
 endif
 
+# Debug output must print file basenames instead of absolute paths
+ifdef S2N_DEBUG_OUTPUT_FILENAME
+	DEFAULT_CFLAGS += -DS2N_DEBUG_OUTPUT_FILENAME
+endif
+
 CFLAGS += ${DEFAULT_CFLAGS}
 
 ifdef GCC_VERSION


### PR DESCRIPTION
### Resolved issues:

Resolves #4208.

### Description of changes: 

Changes to the build scripts and `error/s2n_errno.h` introduce the addition of a build option which enables debug output to only print the file basename instead of the absolute path.

No changes have been made to the client-facing API.

### Call-outs:

`__FILE_NAME__` macro is available in `clang` since 9.0.0, [see the release note](https://releases.llvm.org/9.0.0/tools/clang/docs/ReleaseNotes.html#c-language-changes-in-clang). Current `clang` version is 17.0.1.
`__FILE_NAME__` macro is available in `gcc` since GCC 12, [see comments 10 & 13](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=42579#c10). Current `gcc` version is 13.2.

The `error/s2n_errno.h` checks if `__FILE_NAME__` macro is defined, otherwise defaults to behaviour of full path output.

### Testing:

Local build and tests on Ubuntu succeed. All current tests pass with the `S2N_DEBUG_OUTPUT_FILENAME` flag both ON and OFF. No new tests added by me for this flag, though.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
