### PR TITLE
Allow client_protocol_version to report TLS 1.3 on TLS 1.2 servers

### DIFF
--- a/tests/integrationv2/test_version_negotiation.py
+++ b/tests/integrationv2/test_version_negotiation.py
@@ -77,12 +77,14 @@ def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, certificate
 
     for results in server.get_results():
         results.assert_success()
+        # This check only cares about S2N. Trying to maintain expected output of other providers doesn't
+        # add benefit to whether the S2N client was able to negotiate a lower TLS version.
         if provider is S2N:
-            # The server is only TLS12, so it reads the version from the CLIENT_HELLO, which is never above TLS12
-            # This check only cares about S2N. Trying to maintain expected output of other providers doesn't
-            # add benefit to whether the S2N client was able to negotiate a lower TLS version.
+            # The client sends a TLS 1.3 client hello, so TLS 1.3 should be expected regardless of the actual protocol
+            # version selected.
             assert to_bytes("Client protocol version: {}".format(
-                actual_version)) in results.stdout
+                Protocols.TLS13.value)) in results.stdout
+
             assert to_bytes("Actual protocol version: {}".format(
                 actual_version)) in results.stdout
 

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -776,7 +776,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
             EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS12);
             EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
-            EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
+            EXPECT_EQUAL(server_conn->client_protocol_version, s2n_get_highest_fully_supported_tls_version());
             EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS12);
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_client_supported_versions_extension_test.c
+++ b/tests/unit/s2n_client_supported_versions_extension_test.c
@@ -29,6 +29,9 @@
 #define PROTOCOL_VERSION_ALERT                     70
 #define GREASED_SUPPORTED_VERSION_EXTENSION_VALUES 0x0A0A, 0x1A1A, 0x2A2A, 0x3A3A, 0x4A4A, 0x5A5A, 0x6A6A, 0x7A7A, 0x8A8A, 0x9A9A, 0xAAAA, 0xBABA, 0xCACA, 0xDADA, 0xEAEA, 0xFAFA
 
+#define S2N_TEST_MAX_SUPPORTED_VERSIONS            10
+#define S2N_TEST_SUPPORTED_VERSIONS_EXTENSION_SIZE (1 + (S2N_TEST_MAX_SUPPORTED_VERSIONS * 2))
+
 int write_test_supported_versions_list(struct s2n_stuffer *list, uint8_t *supported_versions, uint8_t length)
 {
     POSIX_GUARD(s2n_stuffer_write_uint8(list, length * S2N_TLS_PROTOCOL_VERSION_LEN));
@@ -41,20 +44,47 @@ int write_test_supported_versions_list(struct s2n_stuffer *list, uint8_t *suppor
     return 0;
 }
 
+struct s2n_override_extension_ctx {
+    struct s2n_blob extension_blob;
+    int invoked_count;
+};
+
+static int s2n_override_supported_versions_cb(struct s2n_connection *conn, void *ctx)
+{
+    EXPECT_NOT_NULL(conn);
+    EXPECT_NOT_NULL(ctx);
+
+    struct s2n_override_extension_ctx *context = (struct s2n_override_extension_ctx *) ctx;
+    context->invoked_count += 1;
+
+    struct s2n_client_hello *client_hello = s2n_connection_get_client_hello(conn);
+    EXPECT_NOT_NULL(client_hello);
+
+    s2n_extension_type_id supported_versions_id = 0;
+    EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(S2N_EXTENSION_SUPPORTED_VERSIONS, &supported_versions_id));
+
+    s2n_parsed_extension *supported_versions_extension = &client_hello->extensions.parsed_extensions[supported_versions_id];
+    supported_versions_extension->extension_type = S2N_EXTENSION_SUPPORTED_VERSIONS;
+    supported_versions_extension->extension = context->extension_blob;
+
+    return S2N_SUCCESS;
+}
+
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
-    EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-
     uint8_t latest_version = S2N_TLS13;
-
-    struct s2n_config *config;
-    EXPECT_NOT_NULL(config = s2n_config_new());
 
     const struct s2n_security_policy *security_policy_with_tls13_and_earlier = &security_policy_20190801;
     EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy_with_tls13_and_earlier));
     EXPECT_EQUAL(security_policy_with_tls13_and_earlier->minimum_protocol_version, S2N_TLS10);
+
+    DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = NULL, s2n_cert_chain_and_key_ptr_free);
+    EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+            S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+
+    const uint8_t unknown_client_version = 255;
 
     /* Client offers all supported versions in version list */
     {
@@ -109,6 +139,9 @@ int main(int argc, char **argv)
 
     /* Client produces a version list that the server can parse */
     {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
         struct s2n_connection *client_conn;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
@@ -142,13 +175,16 @@ int main(int argc, char **argv)
     };
 
     /* Server selects highest supported version shared by client */
-    {
+    for (uint8_t server_version = S2N_TLS12; server_version <= S2N_TLS13; server_version++) {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        server_conn->server_protocol_version = server_version;
 
-        uint8_t unsupported_client_version = 255;
-        uint8_t supported_version_list[] = { S2N_TLS11, S2N_TLS12, S2N_TLS13, unsupported_client_version };
+        uint8_t supported_version_list[] = { S2N_TLS11, S2N_TLS12, S2N_TLS13, unknown_client_version };
         uint8_t supported_version_list_length = sizeof(supported_version_list);
 
         struct s2n_stuffer extension = { 0 };
@@ -159,45 +195,22 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_client_supported_versions_extension.recv(server_conn, &extension));
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS13);
-        EXPECT_EQUAL(server_conn->server_protocol_version, latest_version);
-        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
-
-        EXPECT_SUCCESS(s2n_connection_free(server_conn));
-        EXPECT_SUCCESS(s2n_stuffer_free(&extension));
-    };
-
-    /* Server does not process the extension if using TLS1.2. */
-    {
-        EXPECT_SUCCESS(s2n_disable_tls13_in_test());
-        struct s2n_connection *server_conn;
-        EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-
-        uint8_t unsupported_client_version = 255;
-        uint8_t supported_version_list[] = { S2N_TLS11, S2N_TLS12, S2N_TLS13, unsupported_client_version };
-        uint8_t supported_version_list_length = sizeof(supported_version_list);
-
-        struct s2n_stuffer extension = { 0 };
-        s2n_stuffer_alloc(&extension, supported_version_list_length * 2 + 1);
-
-        EXPECT_SUCCESS(write_test_supported_versions_list(&extension, supported_version_list,
-                supported_version_list_length));
-
-        EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-        EXPECT_SUCCESS(s2n_client_supported_versions_extension.recv(server_conn, &extension));
-        EXPECT_EQUAL(server_conn->client_protocol_version, S2N_UNKNOWN_PROTOCOL_VERSION);
-        EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS12);
-        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_UNKNOWN_PROTOCOL_VERSION);
+        EXPECT_EQUAL(server_conn->server_protocol_version, server_version);
+        EXPECT_EQUAL(server_conn->actual_protocol_version, server_version);
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_stuffer_free(&extension));
     };
 
     /* Server terminates connection if there are no supported version in the list */
-    {
+    for (uint8_t server_version = S2N_TLS12; server_version <= S2N_TLS13; server_version++) {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        server_conn->server_protocol_version = server_version;
 
         uint16_t invalid_version_list[] = { 0x0020, 0x0021, 0x0403, 0x0305, 0x7a7a, 0x0201 };
         uint8_t invalid_version_list_length = s2n_array_len(invalid_version_list);
@@ -211,8 +224,16 @@ int main(int argc, char **argv)
             POSIX_GUARD(s2n_stuffer_write_uint16(&extension, invalid_version_list[i]));
         }
 
-        EXPECT_FAILURE_WITH_ERRNO(s2n_client_supported_versions_extension.recv(server_conn, &extension),
-                S2N_ERR_UNKNOWN_PROTOCOL_VERSION);
+        int ret = s2n_client_supported_versions_extension.recv(server_conn, &extension);
+        if (server_version == S2N_TLS13) {
+            EXPECT_FAILURE_WITH_ERRNO(ret, S2N_ERR_UNKNOWN_PROTOCOL_VERSION);
+            EXPECT_EQUAL(server_conn->reader_alert_out, PROTOCOL_VERSION_ALERT);
+        } else {
+            /* TLS 1.2 servers should ignore the supported versions extension if a compatible
+             * version can't be determined.
+             */
+            EXPECT_SUCCESS(ret);
+        }
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_stuffer_free(&extension));
@@ -220,6 +241,9 @@ int main(int argc, char **argv)
 
     /* Check grease values for the supported versions */
     {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
@@ -246,12 +270,16 @@ int main(int argc, char **argv)
     };
 
     /* Server selects highest supported protocol among list of invalid protocols (that purposefully test our conversion methods) */
-    {
+    for (uint8_t server_version = S2N_TLS12; server_version <= S2N_TLS13; server_version++) {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        server_conn->server_protocol_version = server_version;
 
-        uint16_t invalid_version_list[] = { 0x0020, 0x0200, 0x0201, 0x0304, 0x0021, 0x0305, 0x0403, 0x7a7a };
+        uint16_t invalid_version_list[] = { 0x0020, 0x0200, 0x0201, 0x0303, 0x0304, 0x0021, 0x0305, 0x0403, 0x7a7a };
         uint8_t invalid_version_list_length = s2n_array_len(invalid_version_list);
 
         struct s2n_stuffer extension = { 0 };
@@ -265,18 +293,22 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_client_supported_versions_extension.recv(server_conn, &extension));
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS13);
-        EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
-        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
+        EXPECT_EQUAL(server_conn->server_protocol_version, server_version);
+        EXPECT_EQUAL(server_conn->actual_protocol_version, server_version);
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_stuffer_free(&extension));
     };
 
     /* Server alerts if no shared supported version found */
-    {
+    for (uint8_t server_version = S2N_TLS12; server_version <= S2N_TLS13; server_version++) {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        server_conn->server_protocol_version = server_version;
 
         uint8_t supported_version_list[] = { S2N_SSLv3 };
         uint8_t supported_version_list_length = sizeof(supported_version_list);
@@ -287,56 +319,89 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(write_test_supported_versions_list(&extension, supported_version_list,
                 supported_version_list_length));
 
-        EXPECT_FAILURE_WITH_ERRNO(s2n_client_supported_versions_extension.recv(server_conn, &extension),
-                S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
-        EXPECT_EQUAL(server_conn->reader_alert_out, PROTOCOL_VERSION_ALERT);
+        int ret = s2n_client_supported_versions_extension.recv(server_conn, &extension);
+        if (server_version == S2N_TLS13) {
+            EXPECT_FAILURE_WITH_ERRNO(ret, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+            EXPECT_EQUAL(server_conn->reader_alert_out, PROTOCOL_VERSION_ALERT);
+        } else {
+            /* TLS 1.2 servers should ignore the supported versions extension if a compatible
+             * version can't be determined.
+             */
+            EXPECT_SUCCESS(ret);
+        }
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_stuffer_free(&extension));
     };
 
     /* Server alerts if supported version list is empty */
-    {
+    for (uint8_t server_version = S2N_TLS12; server_version <= S2N_TLS13; server_version++) {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        server_conn->server_protocol_version = server_version;
 
         struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, 1);
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&extension, 0));
 
-        EXPECT_FAILURE_WITH_ERRNO(s2n_client_supported_versions_extension.recv(server_conn, &extension),
-                S2N_ERR_UNKNOWN_PROTOCOL_VERSION);
-        EXPECT_EQUAL(server_conn->reader_alert_out, PROTOCOL_VERSION_ALERT);
+        int ret = s2n_client_supported_versions_extension.recv(server_conn, &extension);
+
+        if (server_version == S2N_TLS13) {
+            EXPECT_FAILURE_WITH_ERRNO(ret, S2N_ERR_UNKNOWN_PROTOCOL_VERSION);
+            EXPECT_EQUAL(server_conn->reader_alert_out, PROTOCOL_VERSION_ALERT);
+        } else {
+            /* TLS 1.2 servers should ignore the supported versions extension if a compatible
+             * version can't be determined.
+             */
+            EXPECT_SUCCESS(ret);
+        }
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_stuffer_free(&extension));
     };
 
     /* Server alerts if version list size exceeds the extension size */
-    {
+    for (uint8_t server_version = S2N_TLS12; server_version <= S2N_TLS13; server_version++) {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        server_conn->server_protocol_version = server_version;
 
         struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, 1);
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&extension, 13));
 
-        EXPECT_FAILURE_WITH_ERRNO(s2n_client_supported_versions_extension.recv(server_conn, &extension), S2N_ERR_BAD_MESSAGE);
-        EXPECT_EQUAL(server_conn->reader_alert_out, PROTOCOL_VERSION_ALERT);
+        int ret = s2n_client_supported_versions_extension.recv(server_conn, &extension);
+        if (server_version == S2N_TLS13) {
+            EXPECT_FAILURE_WITH_ERRNO(ret, S2N_ERR_BAD_MESSAGE);
+            EXPECT_EQUAL(server_conn->reader_alert_out, PROTOCOL_VERSION_ALERT);
+        } else {
+            /* TLS 1.2 servers should ignore a supported versions extension that's invalid. */
+            EXPECT_SUCCESS(ret);
+        }
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_stuffer_free(&extension));
     };
 
     /* Server alerts if version list size is less than extension size */
-    {
+    for (uint8_t server_version = S2N_TLS12; server_version <= S2N_TLS13; server_version++) {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        server_conn->server_protocol_version = server_version;
 
         struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, 5);
@@ -345,18 +410,29 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_write_uint16(&extension, 0x0302));
         EXPECT_SUCCESS(s2n_stuffer_write_uint16(&extension, 0x0303));
 
-        EXPECT_FAILURE_WITH_ERRNO(s2n_client_supported_versions_extension.recv(server_conn, &extension), S2N_ERR_BAD_MESSAGE);
-        EXPECT_EQUAL(server_conn->reader_alert_out, PROTOCOL_VERSION_ALERT);
+        int ret = s2n_client_supported_versions_extension.recv(server_conn, &extension);
+
+        if (server_version == S2N_TLS13) {
+            EXPECT_FAILURE_WITH_ERRNO(ret, S2N_ERR_BAD_MESSAGE);
+            EXPECT_EQUAL(server_conn->reader_alert_out, PROTOCOL_VERSION_ALERT);
+        } else {
+            /* TLS 1.2 servers should ignore a supported versions extension that's invalid. */
+            EXPECT_SUCCESS(ret);
+        }
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_stuffer_free(&extension));
     };
 
     /* Server alerts if version list size is odd */
-    {
+    for (uint8_t server_version = S2N_TLS12; server_version <= S2N_TLS13; server_version++) {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+
         struct s2n_connection *server_conn;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        server_conn->server_protocol_version = server_version;
 
         struct s2n_stuffer extension = { 0 };
         s2n_stuffer_alloc(&extension, 4);
@@ -365,8 +441,15 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_write_uint16(&extension, 0x0302));
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&extension, 0x03));
 
-        EXPECT_FAILURE_WITH_ERRNO(s2n_client_supported_versions_extension.recv(server_conn, &extension), S2N_ERR_BAD_MESSAGE);
-        EXPECT_EQUAL(server_conn->reader_alert_out, PROTOCOL_VERSION_ALERT);
+        int ret = s2n_client_supported_versions_extension.recv(server_conn, &extension);
+
+        if (server_version == S2N_TLS13) {
+            EXPECT_FAILURE_WITH_ERRNO(ret, S2N_ERR_BAD_MESSAGE);
+            EXPECT_EQUAL(server_conn->reader_alert_out, PROTOCOL_VERSION_ALERT);
+        } else {
+            /* TLS 1.2 servers should ignore a supported versions extension that's invalid. */
+            EXPECT_SUCCESS(ret);
+        }
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
         EXPECT_SUCCESS(s2n_stuffer_free(&extension));
@@ -398,15 +481,10 @@ int main(int argc, char **argv)
      *# described in Section 4.2.1.
      */
     if (s2n_is_tls13_fully_supported()) {
-        DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = NULL,
-                s2n_cert_chain_and_key_ptr_free);
-        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
-                S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN,
-                S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
-
         DEFER_CLEANUP(struct s2n_config *config_with_cert = s2n_config_new(),
                 s2n_config_ptr_free);
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config_with_cert, chain_and_key));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config_with_cert, "default_tls13"));
 
         DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
                 s2n_connection_ptr_free);
@@ -443,7 +521,250 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS10);
     }
 
-    EXPECT_SUCCESS(s2n_config_free(config));
+    /* Test protocol version selection with the supported versions extension. */
+    {
+        struct test_case {
+            uint8_t server_version;
+            uint8_t client_hello_version;
+            uint8_t client_supported_versions[S2N_TEST_MAX_SUPPORTED_VERSIONS];
+            uint8_t expected_client_protocol_version;
+            uint8_t expected_actual_protocol_version;
+            s2n_error expected_error;
+        } test_cases[] = {
+            /* Receive a standard TLS 1.3 client hello. */
+            {
+                    .server_version = S2N_TLS12,
+                    .client_hello_version = S2N_TLS12,
+                    .client_supported_versions = { S2N_TLS12, S2N_TLS13 },
+                    /* Ensure that a TLS 1.2 server correctly reports a client protocol version of
+                     * TLS 1.3.
+                     */
+                    .expected_client_protocol_version = S2N_TLS13,
+                    .expected_actual_protocol_version = S2N_TLS12,
+            },
+            {
+                    .server_version = S2N_TLS13,
+                    .client_hello_version = S2N_TLS12,
+                    .client_supported_versions = { S2N_TLS12, S2N_TLS13 },
+                    .expected_client_protocol_version = S2N_TLS13,
+                    .expected_actual_protocol_version = S2N_TLS13,
+            },
+
+            /* Receive a client hello with a TLS version higher than 1.3. */
+            {
+                    .server_version = S2N_TLS12,
+                    .client_hello_version = S2N_TLS12,
+                    .client_supported_versions = { S2N_TLS12, S2N_TLS13, 35 },
+                    .expected_client_protocol_version = S2N_TLS13,
+                    .expected_actual_protocol_version = S2N_TLS12,
+            },
+            {
+                    .server_version = S2N_TLS13,
+                    .client_hello_version = S2N_TLS12,
+                    .client_supported_versions = { S2N_TLS12, S2N_TLS13, 35 },
+                    .expected_client_protocol_version = S2N_TLS13,
+                    .expected_actual_protocol_version = S2N_TLS13,
+            },
+
+            /* Receive an empty supported versions list. */
+            {
+                    .server_version = S2N_TLS12,
+                    .client_hello_version = S2N_TLS12,
+                    .client_supported_versions = { 0 },
+                    .expected_client_protocol_version = S2N_TLS12,
+                    .expected_actual_protocol_version = S2N_TLS12,
+            },
+            {
+                    .server_version = S2N_TLS13,
+                    .client_hello_version = S2N_TLS12,
+                    .client_supported_versions = { 0 },
+                    .expected_error = S2N_ERR_UNKNOWN_PROTOCOL_VERSION,
+            },
+
+            /* Receive an unknown supported version. */
+            {
+                    .server_version = S2N_TLS12,
+                    .client_hello_version = S2N_TLS12,
+                    .client_supported_versions = { unknown_client_version },
+                    .expected_client_protocol_version = S2N_TLS12,
+                    .expected_actual_protocol_version = S2N_TLS12,
+            },
+            {
+                    .server_version = S2N_TLS13,
+                    .client_hello_version = S2N_TLS12,
+                    .client_supported_versions = { unknown_client_version },
+                    .expected_error = S2N_ERR_UNKNOWN_PROTOCOL_VERSION,
+            },
+
+            /* Receive a supported version that's not supported by the security policy. */
+            {
+                    .server_version = S2N_TLS12,
+                    .client_hello_version = S2N_TLS12,
+                    .client_supported_versions = { S2N_SSLv3 },
+                    .expected_client_protocol_version = S2N_TLS12,
+                    .expected_actual_protocol_version = S2N_TLS12,
+            },
+            {
+                    .server_version = S2N_TLS13,
+                    .client_hello_version = S2N_TLS12,
+                    .client_supported_versions = { S2N_SSLv3 },
+                    .expected_error = S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED,
+            },
+
+            /* Receive a supported version and a client hello version that aren't supported by the
+             * security policy.
+             */
+            {
+                    .server_version = S2N_TLS12,
+                    .client_hello_version = S2N_SSLv3,
+                    .client_supported_versions = { S2N_SSLv3 },
+                    .expected_error = S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED,
+            },
+            {
+                    .server_version = S2N_TLS13,
+                    .client_hello_version = S2N_SSLv3,
+                    .client_supported_versions = { S2N_SSLv3 },
+                    .expected_error = S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED,
+            },
+
+            /* Ensure that the supported versions extension is used to select a protocol version,
+             * even if the client hello version is less than TLS 1.2.
+             */
+            {
+                    .server_version = S2N_TLS12,
+                    .client_hello_version = S2N_TLS10,
+                    .client_supported_versions = { S2N_TLS12, S2N_TLS13 },
+                    .expected_client_protocol_version = S2N_TLS13,
+                    .expected_actual_protocol_version = S2N_TLS12,
+            },
+            {
+                    .server_version = S2N_TLS13,
+                    .client_hello_version = S2N_TLS10,
+                    .client_supported_versions = { S2N_TLS12, S2N_TLS13 },
+                    .expected_client_protocol_version = S2N_TLS13,
+                    .expected_actual_protocol_version = S2N_TLS13,
+            },
+
+            /* Ensure that the supported versions extension is used to select a protocol version,
+             * even if this version is less than the client hello version.
+             */
+            {
+                    .server_version = S2N_TLS12,
+                    .client_hello_version = S2N_TLS12,
+                    .client_supported_versions = { S2N_TLS10 },
+                    .expected_client_protocol_version = S2N_TLS10,
+                    .expected_actual_protocol_version = S2N_TLS10,
+            },
+            {
+                    .server_version = S2N_TLS13,
+                    .client_hello_version = S2N_TLS12,
+                    .client_supported_versions = { S2N_TLS10 },
+                    .expected_client_protocol_version = S2N_TLS10,
+                    .expected_actual_protocol_version = S2N_TLS10,
+            },
+
+            /* Receive a client hello that only supports TLS 1.3. */
+            {
+                    .server_version = S2N_TLS12,
+                    .client_hello_version = S2N_TLS12,
+                    .client_supported_versions = { S2N_TLS13 },
+                    /* A TLS 1.2 server will fail to process the supported versions extension due
+                     * to not finding a compatible version, and will fall back to using the client
+                     * hello version for protocol version selection. This will prevent the server
+                     * from knowing the true client protocol version of TLS 1.3.
+                     */
+                    .expected_client_protocol_version = S2N_TLS12,
+                    .expected_actual_protocol_version = S2N_TLS12,
+            },
+            {
+                    .server_version = S2N_TLS13,
+                    .client_hello_version = S2N_TLS12,
+                    .client_supported_versions = { S2N_TLS13 },
+                    .expected_client_protocol_version = S2N_TLS13,
+                    .expected_actual_protocol_version = S2N_TLS13,
+            },
+        };
+
+        for (int test_index = 0; test_index < s2n_array_len(test_cases); test_index++) {
+            struct test_case test = test_cases[test_index];
+
+            DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+
+            if (test.server_version == S2N_TLS12) {
+                EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+            } else {
+                if (!s2n_is_tls13_fully_supported()) {
+                    continue;
+                }
+                EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+            }
+
+            size_t supported_versions_list_len = 0;
+            for (int i = 0; i < S2N_TEST_MAX_SUPPORTED_VERSIONS; i++) {
+                if (test.client_supported_versions[i] == 0) {
+                    break;
+                }
+                supported_versions_list_len += 1;
+            }
+            /* 1 length byte + space for each of the versions in the test case. */
+            size_t supported_versions_extension_size = 1 + (supported_versions_list_len * 2);
+
+            uint8_t supported_versions_data[S2N_TEST_SUPPORTED_VERSIONS_EXTENSION_SIZE] = { 0 };
+            struct s2n_blob supported_versions_blob = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&supported_versions_blob, supported_versions_data, supported_versions_extension_size));
+
+            struct s2n_stuffer supported_versions_stuffer = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_init(&supported_versions_stuffer, &supported_versions_blob));
+            EXPECT_SUCCESS(write_test_supported_versions_list(&supported_versions_stuffer, test.client_supported_versions,
+                    supported_versions_list_len));
+
+            /* The override_supported_versions client hello callback is used to set or replace the
+             * supported versions extension before the extension is processed.
+             */
+            struct s2n_override_extension_ctx context = {
+                .extension_blob = supported_versions_blob
+            };
+            EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, s2n_override_supported_versions_cb, &context));
+
+            DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(client);
+            EXPECT_SUCCESS(s2n_connection_set_config(client, config));
+
+            DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(server);
+            EXPECT_SUCCESS(s2n_connection_set_config(server, config));
+
+            struct s2n_stuffer *hello_stuffer = &client->handshake.io;
+            EXPECT_SUCCESS(s2n_client_hello_send(client));
+
+            /* Overwrite the client hello version according to the test case. */
+            uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN] = { 0 };
+            protocol_version[0] = test.client_hello_version / 10;
+            protocol_version[1] = test.client_hello_version % 10;
+
+            EXPECT_SUCCESS(s2n_stuffer_rewrite(hello_stuffer));
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(hello_stuffer, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
+            EXPECT_SUCCESS(s2n_stuffer_write(&server->handshake.io, &hello_stuffer->blob));
+
+            int ret = s2n_client_hello_recv(server);
+
+            if (test.expected_error) {
+                EXPECT_FAILURE_WITH_ERRNO(ret, test.expected_error);
+            } else {
+                EXPECT_SUCCESS(ret);
+
+                EXPECT_EQUAL(s2n_connection_get_server_protocol_version(server), test.server_version);
+                EXPECT_EQUAL(s2n_connection_get_client_hello_version(server), test.client_hello_version);
+                EXPECT_EQUAL(s2n_connection_get_client_protocol_version(server), test.expected_client_protocol_version);
+                EXPECT_EQUAL(s2n_connection_get_actual_protocol_version(server), test.expected_actual_protocol_version);
+            }
+
+            EXPECT_EQUAL(context.invoked_count, 1);
+        }
+    }
 
     END_TEST();
     return 0;

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -551,7 +551,9 @@ int s2n_process_client_hello(struct s2n_connection *conn)
         POSIX_GUARD(s2n_extensions_server_key_share_select(conn));
     }
 
-    /* for pre TLS 1.3 connections, protocol selection is not done in supported_versions extensions, so do it here */
+    /* For pre-TLS 1.3 connections, protocol selection may not be performed in the processing of a
+     * supported versions extension, so a version is selected here instead.
+     */
     if (conn->actual_protocol_version < S2N_TLS13) {
         conn->actual_protocol_version = MIN(conn->server_protocol_version, conn->client_protocol_version);
     }


### PR DESCRIPTION
### Resolved issues:

Resolves https://github.com/aws/s2n-tls/issues/4158

### Description of changes: 

Currently, TLS 1.2 servers ignore the supported versions extension if it exists on the client hello. This means that the client protocol version is always determined by the client hello version, rather than a version in the supported groups extension. This can lead to incorrect reporting of the `s2n_connection_get_client_protocol_version()` API on TLS 1.2 servers, in which the client could actually support TLS 1.3, but the API reports TLS 1.2.

This PR changes TLS 1.2 servers to start processing the supported versions extension to correctly update the client protocol version. However, for backwards compatibility, if the TLS 1.2 server can't parse the extension, or if a protocol version determined by the extension isn't compatible, the TLS 1.2 server will fall back to using the client hello version for protocol version selection.

### Call-outs:

This PR may introduce a behavior change when selecting a protocol version for TLS 1.2 servers. For instance, a client may send a TLS 1.0 client hello with a supported versions extension including TLS 1.2, and TLS 1.2 servers will now assume an actual protocol version of TLS 1.2. Inversely, a client may send a TLS 1.2 client hello with a supported versions extension including TLS 1.0, and TLS 1.2 servers will now assume an actual protocol version of TLS 1.0. This is the same behavior as TLS 1.3 servers, except that TLS 1.2 servers will fall back to the client hello version in the case that a compatible version can't be determined by the extension.

To avoid this behavior change, rather than actually processing the extension on TLS 1.2 servers to determine the actual protocol version, we could instead add a new "actual_client_protocol_version" field that gets set to the highest version in the extension and reported from the get_client_protocol_version API.

### Testing:

The existing supported versions tests were modified to include TLS 1.2 servers. Also, a new unit test was added to ensure that protocol version selection is correct when processing a supported versions extension for TLS 1.2 and TLS 1.3 servers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
