### PR TITLE
overwrite the random state key only if initialized

### DIFF
--- a/tests/unit/s2n_cleanup_with_no_init_test.c
+++ b/tests/unit/s2n_cleanup_with_no_init_test.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <pthread.h>
+
+#include "s2n_test.h"
+
+static int my_global;
+
+static void my_destructor(void *arg) {}
+
+/* Checks that calling s2n_cleanup without s2n_init does not corrupt
+ * thread-local storage. */
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST_NO_INIT();
+
+    pthread_key_t my_key;
+
+    /* Init the pthread key */
+    EXPECT_SUCCESS(pthread_key_create(&my_key, my_destructor));
+
+    /* Set it a value */
+    EXPECT_SUCCESS(pthread_setspecific(my_key, &my_global));
+
+    /* Call s2n_cleanup with no init */
+    EXPECT_SUCCESS(s2n_cleanup());
+
+    /* Check that the key is not corrupted */
+    int *new_value = (int *) pthread_getspecific(my_key);
+    EXPECT_EQUAL(new_value, &my_global);
+
+    /* Delete the key */
+    EXPECT_SUCCESS(pthread_key_delete(my_key));
+
+    END_TEST_NO_INIT();
+}

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -549,7 +549,9 @@ S2N_RESULT s2n_rand_cleanup_thread(void)
     s2n_per_thread_rand_state.drbgs_initialized = false;
 
     /* Unset the thread-local destructor */
-    pthread_setspecific(s2n_per_thread_rand_state_key, NULL);
+    if (s2n_is_initialized()) {
+        pthread_setspecific(s2n_per_thread_rand_state_key, NULL);
+    }
 
     return S2N_RESULT_OK;
 }


### PR DESCRIPTION
if `s2n_cleanup` is called without `s2n_init` being called, then `s2n_per_thread_rand_state_key` is not initialized anywhere, which means it remains 0. Overwriting TLS key 0 will overwrite someone else's TLS key, leading to misbehavior. Fix that.

### Resolved issues:

Resolves #4226

### Description of changes: 

Added check to `s2n_rand_cleanup_thread` to avoid TLS overwrites when s2n is not initialized.

### Testing:

Added unit test. Confirmed locally that unit test fails without the fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
