### PR TITLE
ktls: support aes256

### DIFF
--- a/crypto/s2n_cipher.h
+++ b/crypto/s2n_cipher.h
@@ -23,6 +23,7 @@
 #include <openssl/rsa.h>
 
 #include "crypto/s2n_crypto.h"
+#include "crypto/s2n_ktls_crypto.h"
 #include "utils/s2n_blob.h"
 
 #if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
@@ -81,12 +82,13 @@ struct s2n_cipher {
         struct s2n_composite_cipher comp;
     } io;
     uint8_t key_material_size;
-    bool ktls_supported;
     uint8_t (*is_available)(void);
     int (*init)(struct s2n_session_key *key);
     int (*set_decryption_key)(struct s2n_session_key *key, struct s2n_blob *in);
     int (*set_encryption_key)(struct s2n_session_key *key, struct s2n_blob *in);
     int (*destroy_key)(struct s2n_session_key *key);
+    S2N_RESULT (*set_ktls_info)(struct s2n_ktls_crypto_info_inputs *inputs,
+            struct s2n_ktls_crypto_info *crypto_info);
 };
 
 int s2n_session_key_alloc(struct s2n_session_key *key);

--- a/crypto/s2n_ktls_crypto.h
+++ b/crypto/s2n_ktls_crypto.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "utils/s2n_blob.h"
+
+/* clang-format off */
+#if defined(S2N_KTLS_SUPPORTED)
+    #include <linux/tls.h>
+
+    typedef struct tls12_crypto_info_aes_gcm_128 s2n_ktls_crypto_info_tls12_aes_gcm_128;
+    typedef struct tls12_crypto_info_aes_gcm_256 s2n_ktls_crypto_info_tls12_aes_gcm_256;
+#else
+    #define TLS_1_2_VERSION 0
+
+    #define TLS_CIPHER_AES_GCM_128 0
+    typedef struct s2n_ktls_crypto_info_stub s2n_ktls_crypto_info_tls12_aes_gcm_128;
+    #define TLS_CIPHER_AES_GCM_256 0
+    typedef struct s2n_ktls_crypto_info_stub s2n_ktls_crypto_info_tls12_aes_gcm_256;
+#endif
+/* clang-format on */
+
+/* To avoid compile-time errors, this must contain every field that we reference
+ * from any crypto_info. However, it is only a placeholder-- it should never
+ * actually be used.
+ */
+struct s2n_ktls_crypto_info_stub {
+    struct {
+        uint8_t version;
+        uint8_t cipher_type;
+    } info;
+    uint8_t iv[1];
+    uint8_t key[1];
+    uint8_t salt[1];
+    uint8_t rec_seq[1];
+};
+
+struct s2n_ktls_crypto_info {
+    struct s2n_blob value;
+    union {
+        s2n_ktls_crypto_info_tls12_aes_gcm_128 aes_gcm_128;
+        s2n_ktls_crypto_info_tls12_aes_gcm_256 aes_gcm_256;
+    } ciphers;
+};
+
+struct s2n_ktls_crypto_info_inputs {
+    struct s2n_blob iv;
+    struct s2n_blob key;
+    struct s2n_blob seq;
+};

--- a/tests/unit/s2n_ktls_test.c
+++ b/tests/unit/s2n_ktls_test.c
@@ -53,7 +53,7 @@ static int s2n_test_setsockopt_aes128_tx(int fd, int level, int optname, const v
     POSIX_ENSURE_EQ(fd, S2N_TEST_SEND_FD);
     if (level == S2N_SOL_TLS) {
         POSIX_ENSURE_EQ(optname, S2N_TLS_TX);
-        POSIX_ENSURE_EQ(optlen, sizeof(struct tls12_crypto_info_aes_gcm_128));
+        POSIX_ENSURE_EQ(optlen, sizeof(s2n_ktls_crypto_info_tls12_aes_gcm_128));
     } else if (level == S2N_SOL_TCP) {
         POSIX_ENSURE_EQ(optname, S2N_TCP_ULP);
         POSIX_ENSURE_EQ(optlen, S2N_TLS_ULP_NAME_SIZE);
@@ -68,7 +68,7 @@ static int s2n_test_setsockopt_aes128_rx(int fd, int level, int optname, const v
     POSIX_ENSURE_EQ(fd, S2N_TEST_RECV_FD);
     if (level == S2N_SOL_TLS) {
         POSIX_ENSURE_EQ(optname, S2N_TLS_RX);
-        POSIX_ENSURE_EQ(optlen, sizeof(struct tls12_crypto_info_aes_gcm_128));
+        POSIX_ENSURE_EQ(optlen, sizeof(s2n_ktls_crypto_info_tls12_aes_gcm_128));
     } else if (level == S2N_SOL_TCP) {
         POSIX_ENSURE_EQ(optname, S2N_TCP_ULP);
         POSIX_ENSURE_EQ(optlen, S2N_TLS_ULP_NAME_SIZE);

--- a/tests/unit/s2n_ktls_test.c
+++ b/tests/unit/s2n_ktls_test.c
@@ -444,7 +444,8 @@ int main(int argc, char **argv)
                         s2n_connection_ptr_free);
                 EXPECT_OK(s2n_test_configure_connection_for_ktls(server));
                 EXPECT_OK(s2n_ktls_set_setsockopt_cb(s2n_test_setsockopt_tls_cb));
-                *(server->secure) = crypto_params;
+                EXPECT_OK(s2n_crypto_parameters_free(&server->secure));
+                server->secure = &crypto_params;
 
                 struct s2n_key_material key_material = { 0 };
                 EXPECT_OK(s2n_prf_generate_key_material(server, &key_material));
@@ -474,6 +475,7 @@ int main(int argc, char **argv)
                 };
                 EXPECT_SUCCESS(s2n_connection_ktls_enable_send(server));
                 EXPECT_EQUAL(s2n_test_setsockopt_expected.count, 1);
+                server->secure = NULL;
             };
 
             /* Test client */
@@ -482,7 +484,8 @@ int main(int argc, char **argv)
                         s2n_connection_ptr_free);
                 EXPECT_OK(s2n_test_configure_connection_for_ktls(client));
                 EXPECT_OK(s2n_ktls_set_setsockopt_cb(s2n_test_setsockopt_tls_cb));
-                *(client->secure) = crypto_params;
+                EXPECT_OK(s2n_crypto_parameters_free(&client->secure));
+                client->secure = &crypto_params;
 
                 struct s2n_key_material key_material = { 0 };
                 EXPECT_OK(s2n_prf_generate_key_material(client, &key_material));
@@ -512,6 +515,7 @@ int main(int argc, char **argv)
                 };
                 EXPECT_SUCCESS(s2n_connection_ktls_enable_send(client));
                 EXPECT_EQUAL(s2n_test_setsockopt_expected.count, 1);
+                client->secure = NULL;
             };
         };
     };

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1598,6 +1598,7 @@ bool s2n_connection_check_io_status(struct s2n_connection *conn, s2n_io_status s
 S2N_RESULT s2n_connection_get_secure_cipher(struct s2n_connection *conn, const struct s2n_cipher **cipher)
 {
     RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(cipher);
     RESULT_ENSURE_REF(conn->secure);
     RESULT_ENSURE_REF(conn->secure->cipher_suite);
     RESULT_ENSURE_REF(conn->secure->cipher_suite->record_alg);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1594,3 +1594,13 @@ bool s2n_connection_check_io_status(struct s2n_connection *conn, s2n_io_status s
 
     return false;
 }
+
+S2N_RESULT s2n_connection_get_secure_cipher(struct s2n_connection *conn, const struct s2n_cipher **cipher)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn->secure);
+    RESULT_ENSURE_REF(conn->secure->cipher_suite);
+    RESULT_ENSURE_REF(conn->secure->cipher_suite->record_alg);
+    *cipher = conn->secure->cipher_suite->record_alg->cipher;
+    return S2N_RESULT_OK;
+}

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -421,3 +421,4 @@ int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **
 int s2n_connection_get_peer_cert_chain(const struct s2n_connection *conn, struct s2n_cert_chain_and_key *cert_chain_and_key);
 uint8_t s2n_connection_get_protocol_version(const struct s2n_connection *conn);
 S2N_RESULT s2n_connection_set_max_fragment_length(struct s2n_connection *conn, uint16_t length);
+S2N_RESULT s2n_connection_get_secure_cipher(struct s2n_connection *conn, const struct s2n_cipher **cipher);


### PR DESCRIPTION
### Description of changes: 

Adds support for AES256 GCM, as well as refactors how ciphers are supported to make future ciphers easier to add.

After this change, support for new ciphers can be added by appending the new crypto_info to the union in s2n_ktls_crypto_info and implementing the cipher set_ktls_info function. Theoretically the new union member in s2n_ktls_crypto_info is optional: we could allocate the memory for the crypto_info on the heap instead, but the union is an easy way to avoid that.

### Call-outs:
To avoid the conditional compilation leaking into more files in /crypto, I made versions of the symbols that ktls needs for crypto_info available even without ktls support.

### Testing:
Rewrote the unit tests to use the new cipher method, + added tests of each cipher to the self-talk test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
