### PR TITLE
ktls: make usable outside of tests

### DIFF
--- a/tls/s2n_ktls.c
+++ b/tls/s2n_ktls.c
@@ -202,7 +202,6 @@ void s2n_ktls_configure_connection(struct s2n_connection *conn, s2n_ktls_mode kt
 static S2N_RESULT s2n_connection_ktls_enable(struct s2n_connection *conn, s2n_ktls_mode ktls_mode)
 {
     RESULT_ENSURE_REF(conn);
-    RESULT_ENSURE(s2n_in_test(), S2N_ERR_NOT_IN_TEST);
     RESULT_GUARD(s2n_ktls_validate(conn, ktls_mode));
 
     int fd = 0;


### PR DESCRIPTION
### Description of changes: 
I forgot to remove this restriction in https://github.com/aws/s2n-tls/commit/2c8f025c5d59ba385ea80c202c2fbfebaceaeb3f -_- Nice catch @goatgoose 

### Testing:
I manually tested with `s2n_in_unit_test_set(false)` in s2n_self_talk_ktls_test, and we can now do ktls without marking it as a unit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
