### PR TITLE
Switch sig schemes from copies to references

### DIFF
--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -660,7 +660,7 @@ void cbmc_populate_s2n_handshake_parameters(struct s2n_handshake_parameters *s2n
     CBMC_ENSURE_REF(s2n_handshake_parameters);
     cbmc_populate_s2n_pkey(&(s2n_handshake_parameters->server_public_key));
     cbmc_populate_s2n_pkey(&(s2n_handshake_parameters->client_public_key));
-    cbmc_populate_s2n_signature_scheme(&(s2n_handshake_parameters->conn_sig_scheme));
+    cbmc_populate_s2n_signature_scheme(&(s2n_handshake_parameters->server_cert_sig_scheme));
     cbmc_populate_s2n_blob(&(s2n_handshake_parameters->client_cert_chain));
     cbmc_populate_s2n_signature_scheme(&(s2n_handshake_parameters->client_cert_sig_scheme));
     cbmc_populate_s2n_cert_chain_and_key(s2n_handshake_parameters->our_chain_and_key);

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -518,6 +518,13 @@ void cbmc_populate_s2n_signature_scheme(struct s2n_signature_scheme *s2n_signatu
     s2n_signature_scheme->signature_curve = cbmc_allocate_s2n_ecc_named_curve();
 }
 
+struct s2n_signature_scheme *cbmc_allocate_s2n_signature_scheme()
+{
+    struct s2n_signature_scheme *s2n_signature_scheme = malloc(sizeof(*s2n_signature_scheme));
+    cbmc_populate_s2n_signature_scheme(s2n_signature_scheme);
+    return s2n_signature_scheme;
+}
+
 struct s2n_kex *cbmc_allocate_s2n_kex()
 {
     struct s2n_kex *s2n_kex = malloc(sizeof(*s2n_kex));
@@ -660,10 +667,10 @@ void cbmc_populate_s2n_handshake_parameters(struct s2n_handshake_parameters *s2n
     CBMC_ENSURE_REF(s2n_handshake_parameters);
     cbmc_populate_s2n_pkey(&(s2n_handshake_parameters->server_public_key));
     cbmc_populate_s2n_pkey(&(s2n_handshake_parameters->client_public_key));
-    cbmc_populate_s2n_signature_scheme(&(s2n_handshake_parameters->server_cert_sig_scheme));
     cbmc_populate_s2n_blob(&(s2n_handshake_parameters->client_cert_chain));
-    cbmc_populate_s2n_signature_scheme(&(s2n_handshake_parameters->client_cert_sig_scheme));
     cbmc_populate_s2n_cert_chain_and_key(s2n_handshake_parameters->our_chain_and_key);
+    s2n_handshake_parameters->server_cert_sig_scheme = cbmc_allocate_s2n_signature_scheme();
+    s2n_handshake_parameters->client_cert_sig_scheme = cbmc_allocate_s2n_signature_scheme();
     /* `s2n_handshake_parameters->exact_sni_matches`
      * `s2n_handshake_parameters->wc_sni_matches` are never allocated.
      * If required, these initializations should be done in the proof harness.

--- a/tests/fuzz/s2n_hybrid_ecdhe_kyber_r3_fuzz_test.c
+++ b/tests/fuzz/s2n_hybrid_ecdhe_kyber_r3_fuzz_test.c
@@ -55,7 +55,7 @@ static int setup_connection(struct s2n_connection *server_conn, struct s2n_kem_p
     server_conn->kex_params.server_ecc_evp_params.evp_pkey = NULL;
     server_conn->kex_params.kem_params.kem = &s2n_kyber_512_r3;
     server_conn->secure->cipher_suite = &s2n_ecdhe_kyber_rsa_with_aes_256_gcm_sha384;
-    server_conn->handshake_params.conn_sig_scheme = s2n_rsa_pkcs1_sha384;
+    server_conn->handshake_params.server_cert_sig_scheme = &s2n_rsa_pkcs1_sha384;
 
     POSIX_GUARD(s2n_dup(&params->private_key, &server_conn->kex_params.kem_params.private_key));
     POSIX_GUARD(s2n_ecc_evp_generate_ephemeral_key(&server_conn->kex_params.server_ecc_evp_params));

--- a/tests/unit/s2n_auth_selection_test.c
+++ b/tests/unit/s2n_auth_selection_test.c
@@ -53,7 +53,7 @@ static int s2n_test_auth_combo(struct s2n_connection *conn,
     conn->secure->cipher_suite = cipher_suite;
 
     POSIX_GUARD(s2n_is_sig_scheme_valid_for_auth(conn, sig_scheme));
-    conn->handshake_params.conn_sig_scheme.sig_alg = sig_scheme->sig_alg;
+    conn->handshake_params.server_cert_sig_scheme = sig_scheme;
 
     POSIX_GUARD(s2n_select_certs_for_server_auth(conn, &actual_cert_chain));
     POSIX_ENSURE_EQ(actual_cert_chain, expected_cert_chain);
@@ -303,38 +303,48 @@ int main(int argc, char **argv)
         /* Requested cert chain exists */
         s2n_connection_set_config(conn, all_certs_config);
 
-        conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA;
+        struct s2n_signature_scheme test_sig_scheme = { 0 };
+        conn->handshake_params.server_cert_sig_scheme = &test_sig_scheme;
+
+        test_sig_scheme.sig_alg = S2N_SIGNATURE_RSA;
         EXPECT_SUCCESS(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_EQUAL(chosen_certs, rsa_cert_chain);
 
-        conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_PSS;
+        /* cppcheck-suppress redundantAssignment */
+        test_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_PSS;
         EXPECT_SUCCESS_IF_RSA_PSS_CERTS_SUPPORTED(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_EQUAL(chosen_certs, rsa_pss_cert_chain);
 
-        conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_RSAE;
+        /* cppcheck-suppress redundantAssignment */
+        test_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_RSAE;
         EXPECT_SUCCESS(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_EQUAL(chosen_certs, rsa_cert_chain);
 
-        conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_ECDSA;
+        /* cppcheck-suppress redundantAssignment */
+        test_sig_scheme.sig_alg = S2N_SIGNATURE_ECDSA;
         EXPECT_SUCCESS(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_EQUAL(chosen_certs, ecdsa_cert_chain);
 
         /* Requested cert chain does NOT exist */
         s2n_connection_set_config(conn, no_certs_config);
 
-        conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA;
+        /* cppcheck-suppress redundantAssignment */
+        test_sig_scheme.sig_alg = S2N_SIGNATURE_RSA;
         EXPECT_FAILURE(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_NULL(chosen_certs);
 
-        conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_PSS;
+        /* cppcheck-suppress redundantAssignment */
+        test_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_PSS;
         EXPECT_FAILURE(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_NULL(chosen_certs);
 
-        conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_RSAE;
+        /* cppcheck-suppress redundantAssignment */
+        test_sig_scheme.sig_alg = S2N_SIGNATURE_RSA_PSS_RSAE;
         EXPECT_FAILURE(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_NULL(chosen_certs);
 
-        conn->handshake_params.conn_sig_scheme.sig_alg = S2N_SIGNATURE_ECDSA;
+        /* cppcheck-suppress redundantAssignment */
+        test_sig_scheme.sig_alg = S2N_SIGNATURE_ECDSA;
         EXPECT_FAILURE(s2n_select_certs_for_server_auth(conn, &chosen_certs));
         EXPECT_NULL(chosen_certs);
 

--- a/tests/unit/s2n_client_auth_handshake_test.c
+++ b/tests/unit/s2n_client_auth_handshake_test.c
@@ -47,8 +47,8 @@ int s2n_test_client_auth_negotiation(struct s2n_config *server_config, struct s2
     client_conn->server_protocol_version = S2N_TLS13;
     client_conn->client_protocol_version = S2N_TLS13;
     client_conn->actual_protocol_version = S2N_TLS13;
-    client_conn->handshake_params.conn_sig_scheme = s2n_ecdsa_secp256r1_sha256;
-    client_conn->handshake_params.client_cert_sig_scheme = s2n_ecdsa_secp256r1_sha256;
+    client_conn->handshake_params.server_cert_sig_scheme = &s2n_ecdsa_secp256r1_sha256;
+    client_conn->handshake_params.client_cert_sig_scheme = &s2n_ecdsa_secp256r1_sha256;
     client_conn->secure->cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
     if (!no_cert) {
         client_conn->handshake_params.our_chain_and_key = ecdsa_cert;
@@ -58,7 +58,7 @@ int s2n_test_client_auth_negotiation(struct s2n_config *server_config, struct s2
     server_conn->server_protocol_version = S2N_TLS13;
     server_conn->client_protocol_version = S2N_TLS13;
     server_conn->actual_protocol_version = S2N_TLS13;
-    server_conn->handshake_params.conn_sig_scheme = s2n_ecdsa_secp256r1_sha256;
+    server_conn->handshake_params.server_cert_sig_scheme = &s2n_ecdsa_secp256r1_sha256;
     server_conn->secure->cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
     if (no_cert) {

--- a/tests/unit/s2n_client_cert_verify_test.c
+++ b/tests/unit/s2n_client_cert_verify_test.c
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn);
 
         /* Set any signature scheme. Our test pkey methods ignore it. */
-        conn->handshake_params.client_cert_sig_scheme = s2n_rsa_pkcs1_md5_sha1;
+        conn->handshake_params.client_cert_sig_scheme = &s2n_rsa_pkcs1_md5_sha1;
 
         struct s2n_cert_chain_and_key *chain_and_key;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -453,7 +453,7 @@ int main(int argc, char **argv)
         server_conn->psk_params.chosen_psk = &chosen_psk;
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
 
-        EXPECT_EQUAL(server_conn->handshake_params.conn_sig_scheme.iana_value, 0);
+        EXPECT_EQUAL(server_conn->handshake_params.server_cert_sig_scheme->iana_value, 0);
         EXPECT_NULL(server_conn->handshake_params.our_chain_and_key);
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -1480,10 +1480,10 @@ int main(int argc, char **argv)
 
         EXPECT_EQUAL(server_conn->secure->cipher_suite, &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha);
         EXPECT_EQUAL(client_conn->secure->cipher_suite, &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha);
-        EXPECT_EQUAL(server_conn->handshake_params.conn_sig_scheme.sig_alg, S2N_SIGNATURE_ECDSA);
-        EXPECT_EQUAL(server_conn->handshake_params.conn_sig_scheme.hash_alg, S2N_HASH_SHA1);
-        EXPECT_EQUAL(client_conn->handshake_params.conn_sig_scheme.sig_alg, S2N_SIGNATURE_ECDSA);
-        EXPECT_EQUAL(client_conn->handshake_params.conn_sig_scheme.hash_alg, S2N_HASH_SHA1);
+        EXPECT_EQUAL(server_conn->handshake_params.server_cert_sig_scheme->sig_alg, S2N_SIGNATURE_ECDSA);
+        EXPECT_EQUAL(server_conn->handshake_params.server_cert_sig_scheme->hash_alg, S2N_HASH_SHA1);
+        EXPECT_EQUAL(client_conn->handshake_params.server_cert_sig_scheme->sig_alg, S2N_SIGNATURE_ECDSA);
+        EXPECT_EQUAL(client_conn->handshake_params.server_cert_sig_scheme->hash_alg, S2N_HASH_SHA1);
 
         /* Free the data */
         EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_client_signature_algorithms_extension_test.c
+++ b/tests/unit/s2n_client_signature_algorithms_extension_test.c
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_signature_algorithms_extension.recv(conn, &signature_algorithms_extension));
         EXPECT_EQUAL(conn->handshake_params.client_sig_hash_algs.len, sig_hash_algs.len);
         EXPECT_FAILURE(s2n_choose_sig_scheme_from_peer_preference_list(conn, &conn->handshake_params.client_sig_hash_algs,
-                &conn->handshake_params.conn_sig_scheme));
+                &conn->handshake_params.server_cert_sig_scheme));
 
         EXPECT_SUCCESS(s2n_stuffer_free(&signature_algorithms_extension));
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -121,8 +121,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_signature_algorithms_extension.recv(conn, &signature_algorithms_extension));
         EXPECT_EQUAL(conn->handshake_params.client_sig_hash_algs.len, sig_hash_algs.len);
         EXPECT_SUCCESS(s2n_choose_sig_scheme_from_peer_preference_list(conn, &conn->handshake_params.client_sig_hash_algs,
-                &conn->handshake_params.conn_sig_scheme));
-        EXPECT_EQUAL(conn->handshake_params.conn_sig_scheme.iana_value, TLS_SIGNATURE_SCHEME_RSA_PKCS1_SHA384);
+                &conn->handshake_params.server_cert_sig_scheme));
+        EXPECT_EQUAL(conn->handshake_params.server_cert_sig_scheme->iana_value, TLS_SIGNATURE_SCHEME_RSA_PKCS1_SHA384);
 
         EXPECT_SUCCESS(s2n_stuffer_free(&signature_algorithms_extension));
         EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -253,8 +253,10 @@ int main(int argc, char **argv)
         };
 
         for (size_t i = S2N_TLS_HASH_NONE; i <= UINT16_MAX; i++) {
-            conn->handshake_params.client_cert_sig_scheme.hash_alg = i;
-            conn->handshake_params.conn_sig_scheme.hash_alg = i;
+            struct s2n_signature_scheme test_scheme = *conn->handshake_params.client_cert_sig_scheme;
+            test_scheme.hash_alg = i;
+            conn->handshake_params.client_cert_sig_scheme = &test_scheme;
+            conn->handshake_params.server_cert_sig_scheme = &test_scheme;
             if (i <= S2N_HASH_SENTINEL) {
                 EXPECT_SUCCESS(s2n_connection_get_selected_client_cert_digest_algorithm(conn, &output));
                 EXPECT_EQUAL(expected_output[i], output);
@@ -300,8 +302,10 @@ int main(int argc, char **argv)
         };
 
         for (size_t i = 0; i <= UINT16_MAX; i++) {
-            conn->handshake_params.client_cert_sig_scheme.sig_alg = i;
-            conn->handshake_params.conn_sig_scheme.sig_alg = i;
+            struct s2n_signature_scheme test_scheme = *conn->handshake_params.client_cert_sig_scheme;
+            test_scheme.sig_alg = i;
+            conn->handshake_params.client_cert_sig_scheme = &test_scheme;
+            conn->handshake_params.server_cert_sig_scheme = &test_scheme;
 
             if (i < s2n_array_len(expected_output)) {
                 EXPECT_SUCCESS(s2n_connection_get_selected_client_cert_signature_algorithm(conn, &output));

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -187,7 +187,8 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
             EXPECT_STRING_EQUAL(s2n_connection_get_cipher(server_conn), expected_cipher->name);
 
             EXPECT_EQUAL(server_conn->handshake_params.our_chain_and_key, expected_cert_chain);
-            EXPECT_EQUAL(server_conn->handshake_params.conn_sig_scheme.sig_alg, expected_sig_alg);
+            EXPECT_NOT_NULL(server_conn->handshake_params.server_cert_sig_scheme);
+            EXPECT_EQUAL(server_conn->handshake_params.server_cert_sig_scheme->sig_alg, expected_sig_alg);
 
             EXPECT_TRUE(IS_NEGOTIATED(server_conn));
             EXPECT_TRUE(IS_NEGOTIATED(client_conn));

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -151,7 +151,7 @@ int main(int argc, char **argv)
                     client_conn->secure->cipher_suite = &tls_13_ciphers[i];
                     server_conn->secure->cipher_suite = &tls_13_ciphers[i];
 
-                    struct s2n_signature_scheme chosen_scheme = { 0 };
+                    const struct s2n_signature_scheme *chosen_scheme = NULL;
 
                     if (s2n_is_rsa_pss_signing_supported()) {
                         /* If RSA PSS signing is supported, then we should always be able to select a default Signature
@@ -214,7 +214,7 @@ int main(int argc, char **argv)
                     client_conn->secure->cipher_suite = &tls_13_ciphers[i];
                     server_conn->secure->cipher_suite = &tls_13_ciphers[i];
 
-                    struct s2n_signature_scheme chosen_scheme = { 0 };
+                    const struct s2n_signature_scheme *chosen_scheme = NULL;
 
                     /* If an ECDSA Certificate is configured, then we should always be able to pick a default Signature
                      * Scheme (even if RSA PSS is not supported by the libcrypto) */

--- a/tests/unit/s2n_self_talk_offload_signing_test.c
+++ b/tests/unit/s2n_self_talk_offload_signing_test.c
@@ -55,13 +55,13 @@ static S2N_RESULT s2n_async_pkey_sign(struct s2n_cert_chain_and_key *complete_ch
 
     /* Get signature algorithm */
     s2n_tls_signature_algorithm sig_alg = 0;
-    struct s2n_signature_scheme *sig_scheme = NULL;
+    const struct s2n_signature_scheme *sig_scheme = NULL;
     if (pkey_op_conn->mode == S2N_CLIENT) {
         RESULT_GUARD_POSIX(s2n_connection_get_selected_client_cert_signature_algorithm(pkey_op_conn, &sig_alg));
-        sig_scheme = &pkey_op_conn->handshake_params.client_cert_sig_scheme;
+        sig_scheme = pkey_op_conn->handshake_params.client_cert_sig_scheme;
     } else {
         RESULT_GUARD_POSIX(s2n_connection_get_selected_signature_algorithm(pkey_op_conn, &sig_alg));
-        sig_scheme = &pkey_op_conn->handshake_params.conn_sig_scheme;
+        sig_scheme = pkey_op_conn->handshake_params.server_cert_sig_scheme;
     }
 
     /* These are our "external" / "offloaded" operations.

--- a/tests/unit/s2n_tls13_cert_verify_test.c
+++ b/tests/unit/s2n_tls13_cert_verify_test.c
@@ -328,7 +328,7 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         EXPECT_SUCCESS(s2n_hash_init(&verifying_conn->handshake.hashes->sha256, S2N_HASH_SHA256));
         EXPECT_SUCCESS(s2n_hash_update(&verifying_conn->handshake.hashes->sha256, hello, strlen((char *) hello)));
 
-        /* In this case it doesn't matter if we use conn_sig_scheme or client_cert_sig_scheme as they are currently equal */
+        /* In this case it doesn't matter if we use server_cert_sig_scheme or client_cert_sig_scheme as they are currently equal */
         struct s2n_signature_scheme test_scheme = *verifying_conn->handshake_params.server_cert_sig_scheme;
         verifying_conn->handshake_params.server_cert_sig_scheme = &test_scheme;
         test_scheme.hash_alg = S2N_HASH_SHA1;

--- a/tls/s2n_auth_selection.c
+++ b/tls/s2n_auth_selection.c
@@ -221,9 +221,11 @@ int s2n_is_cert_type_valid_for_auth(struct s2n_connection *conn, s2n_pkey_type c
 int s2n_select_certs_for_server_auth(struct s2n_connection *conn, struct s2n_cert_chain_and_key **chosen_certs)
 {
     POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(conn->handshake_params.server_cert_sig_scheme);
+    s2n_signature_algorithm sig_alg = conn->handshake_params.server_cert_sig_scheme->sig_alg;
 
-    s2n_pkey_type cert_type;
-    POSIX_GUARD(s2n_get_cert_type_for_sig_alg(conn->handshake_params.conn_sig_scheme.sig_alg, &cert_type));
+    s2n_pkey_type cert_type = 0;
+    POSIX_GUARD(s2n_get_cert_type_for_sig_alg(sig_alg, &cert_type));
 
     *chosen_certs = s2n_get_compatible_cert_chain_and_key(conn, cert_type);
     S2N_ERROR_IF(*chosen_certs == NULL, S2N_ERR_CERT_TYPE_UNSUPPORTED);

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -42,6 +42,7 @@ int s2n_client_cert_verify_recv(struct s2n_connection *conn)
                 &conn->handshake_params.client_cert_sig_scheme));
     }
     const struct s2n_signature_scheme *chosen_sig_scheme = conn->handshake_params.client_cert_sig_scheme;
+    POSIX_ENSURE_REF(chosen_sig_scheme);
 
     uint16_t signature_size;
     struct s2n_blob signature = { 0 };
@@ -78,6 +79,7 @@ int s2n_client_cert_verify_send(struct s2n_connection *conn)
         POSIX_GUARD(s2n_stuffer_write_uint16(out, conn->handshake_params.client_cert_sig_scheme->iana_value));
     }
     const struct s2n_signature_scheme *chosen_sig_scheme = conn->handshake_params.client_cert_sig_scheme;
+    POSIX_ENSURE_REF(chosen_sig_scheme);
 
     /* Use a copy of the hash state since the verify digest computation may modify the running hash state we need later. */
     struct s2n_hash_state *hash_state = &hashes->hash_workspace;

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -598,7 +598,7 @@ int s2n_process_client_hello(struct s2n_connection *conn)
     /* And set the signature and hash algorithm used for key exchange signatures */
     POSIX_GUARD(s2n_choose_sig_scheme_from_peer_preference_list(conn,
             &conn->handshake_params.client_sig_hash_algs,
-            &conn->handshake_params.conn_sig_scheme));
+            &conn->handshake_params.server_cert_sig_scheme));
 
     /* And finally, set the certs specified by the final auth + sig_alg combo. */
     POSIX_GUARD(s2n_select_certs_for_server_auth(conn, &conn->handshake_params.our_chain_and_key));
@@ -833,7 +833,7 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
     POSIX_GUARD(s2n_conn_find_name_matching_certs(conn));
 
     POSIX_GUARD(s2n_set_cipher_as_sslv2_server(conn, client_hello->cipher_suites.data, client_hello->cipher_suites.size / S2N_SSLv2_CIPHER_SUITE_LEN));
-    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &conn->handshake_params.conn_sig_scheme, S2N_SERVER));
+    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &conn->handshake_params.server_cert_sig_scheme, S2N_SERVER));
     POSIX_GUARD(s2n_select_certs_for_server_auth(conn, &conn->handshake_params.our_chain_and_key));
 
     S2N_ERROR_IF(session_id_length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -557,6 +557,8 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     conn->secure = secure;
     conn->client = conn->initial;
     conn->server = conn->initial;
+    conn->handshake_params.client_cert_sig_scheme = &s2n_null_sig_scheme;
+    conn->handshake_params.server_cert_sig_scheme = &s2n_null_sig_scheme;
 
     POSIX_GUARD_RESULT(s2n_psk_parameters_init(&conn->psk_params));
     conn->server_keying_material_lifetime = ONE_WEEK_IN_SEC;
@@ -1404,7 +1406,8 @@ int s2n_connection_get_peer_cert_chain(const struct s2n_connection *conn, struct
     return S2N_SUCCESS;
 }
 
-static S2N_RESULT s2n_signature_scheme_to_tls_iana(struct s2n_signature_scheme *sig_scheme, s2n_tls_hash_algorithm *converted_scheme)
+static S2N_RESULT s2n_signature_scheme_to_tls_iana(const struct s2n_signature_scheme *sig_scheme,
+        s2n_tls_hash_algorithm *converted_scheme)
 {
     RESULT_ENSURE_REF(sig_scheme);
     RESULT_ENSURE_REF(converted_scheme);
@@ -1439,26 +1442,31 @@ static S2N_RESULT s2n_signature_scheme_to_tls_iana(struct s2n_signature_scheme *
     return S2N_RESULT_OK;
 }
 
-int s2n_connection_get_selected_digest_algorithm(struct s2n_connection *conn, s2n_tls_hash_algorithm *converted_scheme)
+int s2n_connection_get_selected_digest_algorithm(struct s2n_connection *conn,
+        s2n_tls_hash_algorithm *converted_scheme)
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(converted_scheme);
 
-    POSIX_GUARD_RESULT(s2n_signature_scheme_to_tls_iana(&conn->handshake_params.conn_sig_scheme, converted_scheme));
+    POSIX_GUARD_RESULT(s2n_signature_scheme_to_tls_iana(
+            conn->handshake_params.server_cert_sig_scheme, converted_scheme));
 
     return S2N_SUCCESS;
 }
 
-int s2n_connection_get_selected_client_cert_digest_algorithm(struct s2n_connection *conn, s2n_tls_hash_algorithm *converted_scheme)
+int s2n_connection_get_selected_client_cert_digest_algorithm(struct s2n_connection *conn,
+        s2n_tls_hash_algorithm *converted_scheme)
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(converted_scheme);
 
-    POSIX_GUARD_RESULT(s2n_signature_scheme_to_tls_iana(&conn->handshake_params.client_cert_sig_scheme, converted_scheme));
+    POSIX_GUARD_RESULT(s2n_signature_scheme_to_tls_iana(
+            conn->handshake_params.client_cert_sig_scheme, converted_scheme));
     return S2N_SUCCESS;
 }
 
-static S2N_RESULT s2n_signature_scheme_to_signature_algorithm(struct s2n_signature_scheme *sig_scheme, s2n_tls_signature_algorithm *converted_scheme)
+static S2N_RESULT s2n_signature_scheme_to_signature_algorithm(const struct s2n_signature_scheme *sig_scheme,
+        s2n_tls_signature_algorithm *converted_scheme)
 {
     RESULT_ENSURE_REF(sig_scheme);
     RESULT_ENSURE_REF(converted_scheme);
@@ -1484,22 +1492,26 @@ static S2N_RESULT s2n_signature_scheme_to_signature_algorithm(struct s2n_signatu
     return S2N_RESULT_OK;
 }
 
-int s2n_connection_get_selected_signature_algorithm(struct s2n_connection *conn, s2n_tls_signature_algorithm *converted_scheme)
+int s2n_connection_get_selected_signature_algorithm(struct s2n_connection *conn,
+        s2n_tls_signature_algorithm *converted_scheme)
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(converted_scheme);
 
-    POSIX_GUARD_RESULT(s2n_signature_scheme_to_signature_algorithm(&conn->handshake_params.conn_sig_scheme, converted_scheme));
+    POSIX_GUARD_RESULT(s2n_signature_scheme_to_signature_algorithm(
+            conn->handshake_params.server_cert_sig_scheme, converted_scheme));
 
     return S2N_SUCCESS;
 }
 
-int s2n_connection_get_selected_client_cert_signature_algorithm(struct s2n_connection *conn, s2n_tls_signature_algorithm *converted_scheme)
+int s2n_connection_get_selected_client_cert_signature_algorithm(struct s2n_connection *conn,
+        s2n_tls_signature_algorithm *converted_scheme)
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(converted_scheme);
 
-    POSIX_GUARD_RESULT(s2n_signature_scheme_to_signature_algorithm(&conn->handshake_params.client_cert_sig_scheme, converted_scheme));
+    POSIX_GUARD_RESULT(s2n_signature_scheme_to_signature_algorithm(
+            conn->handshake_params.client_cert_sig_scheme, converted_scheme));
 
     return S2N_SUCCESS;
 }

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -104,12 +104,12 @@ struct s2n_handshake_parameters {
     /* Signature/hash algorithm pairs offered by the client in the signature_algorithms extension */
     struct s2n_sig_scheme_list client_sig_hash_algs;
     /* Signature scheme chosen by the server */
-    struct s2n_signature_scheme conn_sig_scheme;
+    const struct s2n_signature_scheme *server_cert_sig_scheme;
 
     /* Signature/hash algorithm pairs offered by the server in the certificate request */
     struct s2n_sig_scheme_list server_sig_hash_algs;
     /* Signature scheme chosen by the client */
-    struct s2n_signature_scheme client_cert_sig_scheme;
+    const struct s2n_signature_scheme *client_cert_sig_scheme;
 
     /* The cert chain we will send the peer. */
     struct s2n_cert_chain_and_key *our_chain_and_key;

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -287,7 +287,7 @@ int s2n_server_hello_recv(struct s2n_connection *conn)
     }
 
     /* Choose a default signature scheme */
-    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &conn->handshake_params.conn_sig_scheme, S2N_SERVER));
+    POSIX_GUARD(s2n_choose_default_sig_scheme(conn, &conn->handshake_params.server_cert_sig_scheme, S2N_SERVER));
 
     /* Update the required hashes for this connection */
     POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -54,6 +54,7 @@ int s2n_server_key_recv(struct s2n_connection *conn)
         POSIX_GUARD(s2n_get_and_validate_negotiated_signature_scheme(conn, in, &conn->handshake_params.server_cert_sig_scheme));
     }
     const struct s2n_signature_scheme *active_sig_scheme = conn->handshake_params.server_cert_sig_scheme;
+    POSIX_ENSURE_REF(active_sig_scheme);
 
     /* FIPS specifically allows MD5 for <TLS1.2 */
     if (s2n_is_in_fips_mode() && conn->actual_protocol_version < S2N_TLS12) {
@@ -258,6 +259,7 @@ int s2n_server_key_send(struct s2n_connection *conn)
     struct s2n_hash_state *signature_hash = &conn->handshake.hashes->hash_workspace;
     const struct s2n_kex *key_exchange = conn->secure->cipher_suite->key_exchange_alg;
     const struct s2n_signature_scheme *sig_scheme = conn->handshake_params.server_cert_sig_scheme;
+    POSIX_ENSURE_REF(sig_scheme);
     struct s2n_stuffer *out = &conn->handshake.io;
     struct s2n_blob data_to_sign = { 0 };
 

--- a/tls/s2n_signature_algorithms.h
+++ b/tls/s2n_signature_algorithms.h
@@ -28,13 +28,16 @@ struct s2n_sig_scheme_list {
     uint8_t len;
 };
 
-int s2n_choose_default_sig_scheme(struct s2n_connection *conn, struct s2n_signature_scheme *sig_scheme_out, s2n_mode signer);
-int s2n_tls13_default_sig_scheme(struct s2n_connection *conn, struct s2n_signature_scheme *sig_scheme_out);
+int s2n_choose_default_sig_scheme(struct s2n_connection *conn,
+        const struct s2n_signature_scheme **sig_scheme_out, s2n_mode signer);
+int s2n_tls13_default_sig_scheme(struct s2n_connection *conn,
+        const struct s2n_signature_scheme **sig_scheme_out);
 
-int s2n_choose_sig_scheme_from_peer_preference_list(struct s2n_connection *conn, struct s2n_sig_scheme_list *sig_hash_algs,
-        struct s2n_signature_scheme *sig_scheme_out);
+int s2n_choose_sig_scheme_from_peer_preference_list(struct s2n_connection *conn,
+        struct s2n_sig_scheme_list *sig_hash_algs,
+        const struct s2n_signature_scheme **sig_scheme_out);
 int s2n_get_and_validate_negotiated_signature_scheme(struct s2n_connection *conn, struct s2n_stuffer *in,
-        struct s2n_signature_scheme *chosen_sig_scheme);
+        const struct s2n_signature_scheme **chosen_sig_scheme);
 
 int s2n_recv_supported_sig_scheme_list(struct s2n_stuffer *in, struct s2n_sig_scheme_list *sig_hash_algs);
 int s2n_send_supported_sig_scheme_list(struct s2n_connection *conn, struct s2n_stuffer *out);

--- a/tls/s2n_signature_scheme.c
+++ b/tls/s2n_signature_scheme.c
@@ -22,6 +22,15 @@
 #include "tls/s2n_connection.h"
 #include "utils/s2n_safety.h"
 
+const struct s2n_signature_scheme s2n_null_sig_scheme = {
+    .iana_value = 0,
+    .hash_alg = S2N_HASH_NONE,
+    .sig_alg = S2N_SIGNATURE_ANONYMOUS,
+    .libcrypto_nid = 0,
+    .signature_curve = NULL,
+    .maximum_protocol_version = 0,
+};
+
 /* RSA PKCS1 */
 const struct s2n_signature_scheme s2n_rsa_pkcs1_md5_sha1 = {
     .iana_value = TLS_SIGNATURE_SCHEME_PRIVATE_INTERNAL_RSA_PKCS1_MD5_SHA1,

--- a/tls/s2n_signature_scheme.h
+++ b/tls/s2n_signature_scheme.h
@@ -39,6 +39,8 @@ struct s2n_signature_preferences {
     const struct s2n_signature_scheme *const *signature_schemes;
 };
 
+extern const struct s2n_signature_scheme s2n_null_sig_scheme;
+
 /* RSA PKCS1 */
 /* s2n_rsa_pkcs1_md5_sha1 is not in any preference list, but it is needed since it's the default for TLS 1.0 and 1.1 if
  * no SignatureScheme is sent. */


### PR DESCRIPTION
### Description of changes: 

Currently we store a copy of the chosen signature scheme on the connection instead of a pointer to the constant signature scheme. In this PR I switch us to use pointers, which is how we handle other parameters like ciphers suites and curves. Pointers to constant values make the most sense, since signature schemes must match a small, well-defined set of options.

### Call-outs:
This touches a lot of files, but most of the changes are pretty trivial updates.
The interesting files:
* [tls/s2n_handshake.h](https://github.com/aws/s2n-tls/compare/main...lrstewart:s2n:sig_schemes_1?expand=1#diff-9ef339ddd8d33a1e5a47649af2a2370b5698d0ca4066e845a3afeab927ef6d3c) - the actual change of copy -> pointer
* [tls/s2n_signature_scheme.c](https://github.com/aws/s2n-tls/compare/main...lrstewart:s2n:sig_schemes_1?expand=1#diff-c7384b567952f207999f46367429bc2fbdcc16ddb037cddc78d6d91680b839e3) - add an empty signature scheme

### Testing:
This is a minor refactor, and existing tests pass. In general, I'd expect build failures instead of test failures if I messed up part of this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
