### PR TITLE
feat: Turns off automatic ticket creation for quic

### DIFF
--- a/tests/unit/s2n_self_talk_session_resumption_test.c
+++ b/tests/unit/s2n_self_talk_session_resumption_test.c
@@ -176,6 +176,36 @@ static S2N_RESULT s2n_test_negotiate(struct s2n_connection *server_conn, struct 
     return S2N_RESULT_OK;
 }
 
+static int s2n_wipe_psk_ke_ext(struct s2n_connection *conn, void *ctx)
+{
+    struct s2n_client_hello *client_hello = s2n_connection_get_client_hello(conn);
+    POSIX_ENSURE_REF(client_hello);
+    s2n_parsed_extension *parsed_extension = NULL;
+    POSIX_GUARD(s2n_client_hello_get_parsed_extension(TLS_EXTENSION_PSK_KEY_EXCHANGE_MODES, &client_hello->extensions, &parsed_extension));
+    POSIX_ENSURE_REF(parsed_extension);
+    POSIX_GUARD(s2n_blob_zero(&parsed_extension->extension));
+
+    return S2N_SUCCESS;
+}
+
+static int s2n_alter_psk_ke_ext(struct s2n_connection *conn, void *ctx)
+{
+    struct s2n_client_hello *client_hello = s2n_connection_get_client_hello(conn);
+    POSIX_ENSURE_REF(client_hello);
+    s2n_parsed_extension *parsed_extension = NULL;
+    POSIX_GUARD(s2n_client_hello_get_parsed_extension(TLS_EXTENSION_PSK_KEY_EXCHANGE_MODES, &client_hello->extensions, &parsed_extension));
+    POSIX_ENSURE_REF(parsed_extension);
+
+    /* Overwrite the extension so it only supports PSK_DHE mode */
+    struct s2n_stuffer psk_ke_extension = { 0 };
+    POSIX_GUARD(s2n_stuffer_init(&psk_ke_extension, &parsed_extension->extension));
+    POSIX_GUARD(s2n_stuffer_skip_write(&psk_ke_extension, 1));
+    uint8_t mode = TLS_PSK_KE_MODE;
+    POSIX_GUARD(s2n_stuffer_write_bytes(&psk_ke_extension, &mode, 1));
+
+    return S2N_SUCCESS;
+}
+
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
@@ -1098,6 +1128,87 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
         EXPECT_SUCCESS(s2n_stuffer_rewrite(&cb_session_data));
     }
+
+    /* Functional: Server in QUIC mode sends a session ticket if and only if psk_dhe_ke mode was received */
+    {
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+
+        /* Enable QUIC mode */
+        EXPECT_SUCCESS(s2n_config_enable_quic(tls13_client_config));
+        EXPECT_SUCCESS(s2n_config_enable_quic(server_config));
+
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls13_client_config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+
+        /* Create nonblocking pipes */
+        DEFER_CLEANUP(struct s2n_stuffer input = { 0 }, s2n_stuffer_free);
+        DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, server_conn));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&output, &input, client_conn));
+
+        /* Wipe psk_ke extension when it is received */
+        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(server_config, s2n_wipe_psk_ke_ext, NULL));
+
+        /* Negotiate handshake */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+        /* Server did not send a ticket since the client did not send the psk_ke extension */
+        uint16_t tickets_sent = 0;
+        EXPECT_SUCCESS(s2n_connection_get_tickets_sent(server_conn, &tickets_sent));
+        EXPECT_EQUAL(tickets_sent, 0);
+
+        /* Prepare for new connection */
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&output));
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&input));
+        EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+        EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, server_conn));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&output, &input, client_conn));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls13_client_config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+
+        /* Alter psk_ke extension when it is received so that it only supports psk_ke mode */
+        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(server_config, s2n_alter_psk_ke_ext, NULL));
+
+        /* Negotiate handshake */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+        /* Server did not send a ticket since the client does not support psk_dhe_ke mode */
+        tickets_sent = 0;
+        EXPECT_SUCCESS(s2n_connection_get_tickets_sent(server_conn, &tickets_sent));
+        EXPECT_EQUAL(tickets_sent, 0);
+
+        /* Prepare for new connection */
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&output));
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&input));
+        EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+        EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&input, &output, server_conn));
+        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&output, &input, client_conn));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls13_client_config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
+
+        /* Disable any client hello cb changes */
+        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(server_config, NULL, NULL));
+
+        /* Negotiate handshake */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+
+        /* Server sent one ticket since the client by default indicates it supports psk_dhe_ke mode */
+        tickets_sent = 0;
+        EXPECT_SUCCESS(s2n_connection_get_tickets_sent(server_conn, &tickets_sent));
+        EXPECT_EQUAL(tickets_sent, 1);
+
+        /* Disable QUIC mode */
+        server_config->quic_enabled = false;
+        tls13_client_config->quic_enabled = false;
+    };
 
     /* Clean-up */
     EXPECT_SUCCESS(s2n_config_free(server_config));

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -126,6 +126,14 @@ S2N_RESULT s2n_tls13_server_nst_send(struct s2n_connection *conn, s2n_blocked_st
         return S2N_RESULT_OK;
     }
 
+    /* Legacy behavior is that the s2n server sends a NST even if the client did not indicate support
+     * for resumption or does not support the psk_dhe_ke mode. This is potentially wasteful so we 
+     * choose to not extend this behavior to QUIC.
+     */
+    if (conn->quic_enabled && conn->psk_params.psk_ke_mode != S2N_PSK_DHE_KE) {
+        return S2N_RESULT_OK;
+    }
+
     /* No-op if all tickets already sent.
      * Clean up the stuffer used for the ticket to conserve memory. */
     if (conn->tickets_to_send == conn->tickets_sent) {


### PR DESCRIPTION
### Resolved issues:

Related to #4124
### Description of changes: 

Small optimization for QUIC resumption. s2n servers with quic enabled will not send a session ticket to the client if the client didn't indicate support for TLS1.3 resumption with the psk_ke extension or the advertised mode is not psk_dhe_ke (our only supported mode.)
Keeps the legacy behavior the same if quic is not enabled.

### Call-outs:
Is my testing overkill?
### Testing:

Adds unit test and functional tests since I want to test the interaction between the extension code and the post-handshake code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
