### PR TITLE
chore: pin dependency to fix rust MSRV issues

### DIFF
--- a/bindings/rust/generate/Cargo.toml
+++ b/bindings/rust/generate/Cargo.toml
@@ -10,3 +10,4 @@ publish = false
 [dependencies]
 bindgen = "0.65"
 glob = "0.3"
+regex = "=1.9.6" # newer versions require rust 1.65, see https://github.com/aws/s2n-tls/issues/4242

--- a/bindings/rust/integration/Cargo.toml
+++ b/bindings/rust/integration/Cargo.toml
@@ -22,3 +22,6 @@ harness = false
 [[bench]]
 name = "s2nd"
 harness = false
+
+[dev-dependencies]
+regex = "=1.9.6" # newer versions require rust 1.65, see https://github.com/aws/s2n-tls/issues/4242

--- a/bindings/rust/s2n-tls-sys/templates/Cargo.template
+++ b/bindings/rust/s2n-tls-sys/templates/Cargo.template
@@ -43,6 +43,7 @@ cc = { version = "1.0", features = ["parallel"] }
 cmake = { version = "0.1", optional = true }
 
 [dev-dependencies]
+jobserver = "=0.1.26" # newer versions require rust 1.66, see https://github.com/aws/s2n-tls/issues/4241
 # Build the vendored version to make it easy to test in dev
 #
 # NOTE: The version of the `openssl-sys` crate is not the same as OpenSSL itself.


### PR DESCRIPTION
### Resolved issues:
https://github.com/aws/s2n-tls/issues/4242 and https://github.com/aws/s2n-tls/issues/4241

### Description of changes: 
Some of our test dependencies have updated their MSRV so we need to pin those version in order for our CI task to succeed.

### Testing:
CI should pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
