### PR TITLE
feat: Adds ConnectionInitializer to Rust bindings

### DIFF
--- a/bindings/rust/s2n-tls/src/callbacks/session_ticket.rs
+++ b/bindings/rust/s2n-tls/src/callbacks/session_ticket.rs
@@ -15,11 +15,6 @@ pub trait SessionTicketCallback: 'static + Send + Sync {
     fn on_session_ticket(&self, connection: &mut Connection, session_ticket: &SessionTicket);
 }
 
-// A trait to give session tickets to new TLS connections
-pub trait SessionTicketProvider: 'static + Send + Sync {
-    fn provide_session_ticket(&self) -> Option<Vec<u8>>;
-}
-
 pub struct SessionTicket(s2n_session_ticket);
 
 impl SessionTicket {

--- a/bindings/rust/s2n-tls/src/callbacks/session_ticket.rs
+++ b/bindings/rust/s2n-tls/src/callbacks/session_ticket.rs
@@ -56,3 +56,8 @@ impl SessionTicket {
         Ok(())
     }
 }
+
+// A trait to give session tickets to new TLS connections
+pub trait SessionTicketProvider: 'static + Send + Sync {
+    fn provide_session_ticket(&self) -> Option<Vec<u8>>;
+}

--- a/bindings/rust/s2n-tls/src/callbacks/session_ticket.rs
+++ b/bindings/rust/s2n-tls/src/callbacks/session_ticket.rs
@@ -15,6 +15,11 @@ pub trait SessionTicketCallback: 'static + Send + Sync {
     fn on_session_ticket(&self, connection: &mut Connection, session_ticket: &SessionTicket);
 }
 
+// A trait to give session tickets to new TLS connections
+pub trait SessionTicketProvider: 'static + Send + Sync {
+    fn provide_session_ticket(&self) -> Option<Vec<u8>>;
+}
+
 pub struct SessionTicket(s2n_session_ticket);
 
 impl SessionTicket {
@@ -55,9 +60,4 @@ impl SessionTicket {
         };
         Ok(())
     }
-}
-
-// A trait to give session tickets to new TLS connections
-pub trait SessionTicketProvider: 'static + Send + Sync {
-    fn provide_session_ticket(&self) -> Option<Vec<u8>>;
 }

--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -775,12 +775,12 @@ impl Default for Context {
 
 /// A trait executed asynchronously before a new connection negotiates TLS.
 ///
-/// Used for dynamic configuration of a specific connection. Note that this trait
+/// Used for dynamic configuration of a specific connection.
 ///
-/// <div class="warning">This trait is polled to completion inside of the
-/// [connection::poll_negotiate function].(`crate::connection::poll_negotiate()`)
+/// # Safety: This trait is polled to completion at the beginning of the
+/// [connection::poll_negotiate](`crate::connection::poll_negotiate()`) function.
 /// Therefore, negotiation of the TLS connection will not begin until the Future has completed.
-/// </div>
+///
 ///
 pub trait ConnectionInitializer: 'static + Send + Sync {
     /// The application can return an `Ok(None)` to resolve the callback

--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -780,13 +780,10 @@ impl Default for Context {
 /// # Safety: This trait is polled to completion at the beginning of the
 /// [connection::poll_negotiate](`crate::connection::poll_negotiate()`) function.
 /// Therefore, negotiation of the TLS connection will not begin until the Future has completed.
-///
-///
 pub trait ConnectionInitializer: 'static + Send + Sync {
     /// The application can return an `Ok(None)` to resolve the callback
     /// synchronously or return an `Ok(Some(ConnectionFuture))` if it wants to
     /// run some asynchronous task before resolving the callback.
-    ///
     fn initialize_connection(
         &self,
         connection: &mut crate::connection::Connection,

--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -773,11 +773,15 @@ impl Default for Context {
     }
 }
 
-/// A trait executed before a new connection negotiates TLS.
+/// A trait executed asynchronously before a new connection negotiates TLS.
 ///
-/// Used for any dynamic configuration of the connection.
-/// Use in conjunction with
-/// [config::Builder::set_connection_initializer](`crate::config::Builder::set_connection_initializer()`).
+/// Used for dynamic configuration of a specific connection. Note that this trait
+///
+/// <div class="warning">This trait is polled to completion inside of the
+/// [connection::poll_negotiate function].(`crate::connection::poll_negotiate()`)
+/// Therefore, negotiation of the TLS connection will not begin until the Future has completed.
+/// </div>
+///
 pub trait ConnectionInitializer: 'static + Send + Sync {
     /// The application can return an `Ok(None)` to resolve the callback
     /// synchronously or return an `Ok(Some(ConnectionFuture))` if it wants to

--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -527,6 +527,17 @@ impl Builder {
         Ok(self)
     }
 
+    pub fn set_session_ticket_provider<T: 'static + SessionTicketProvider>(
+        &mut self,
+        handler: T,
+    ) -> Result<&mut Self, Error> {
+        // Store callback in context
+        let handler = Box::new(handler);
+        let context = self.config.context_mut();
+        context.session_ticket_provider = Some(handler);
+        Ok(self)
+    }
+
     /// Set a callback function triggered by operations requiring the private key.
     ///
     /// See https://github.com/aws/s2n-tls/blob/main/docs/USAGE-GUIDE.md#private-key-operation-related-calls
@@ -736,6 +747,7 @@ pub(crate) struct Context {
     pub(crate) private_key_callback: Option<Box<dyn PrivateKeyCallback>>,
     pub(crate) verify_host_callback: Option<Box<dyn VerifyHostNameCallback>>,
     pub(crate) session_ticket_callback: Option<Box<dyn SessionTicketCallback>>,
+    pub(crate) session_ticket_provider: Option<Box<dyn SessionTicketProvider>>,
     pub(crate) wall_clock: Option<Box<dyn WallClock>>,
     pub(crate) monotonic_clock: Option<Box<dyn MonotonicClock>>,
 }
@@ -752,6 +764,7 @@ impl Default for Context {
             private_key_callback: None,
             verify_host_callback: None,
             session_ticket_callback: None,
+            session_ticket_provider: None,
             wall_clock: None,
             monotonic_clock: None,
         }

--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -12,7 +12,9 @@ use s2n_tls_sys::*;
 use std::{
     ffi::{c_void, CString},
     path::Path,
+    pin::Pin,
     sync::atomic::{AtomicUsize, Ordering},
+    task::Poll,
     time::{Duration, SystemTime},
 };
 
@@ -489,6 +491,17 @@ impl Builder {
         Ok(self)
     }
 
+    pub fn set_connection_initializer<T: 'static + ConnectionInitializer>(
+        &mut self,
+        handler: T,
+    ) -> Result<&mut Self, Error> {
+        // Store callback in config context
+        let handler = Box::new(handler);
+        let context = self.config.context_mut();
+        context.connection_initializer = Some(handler);
+        Ok(self)
+    }
+
     /// Sets a custom callback which provides access to session tickets when they arrive
     pub fn set_session_ticket_callback<T: 'static + SessionTicketCallback>(
         &mut self,
@@ -524,17 +537,6 @@ impl Builder {
             )
             .into_result()
         }?;
-        Ok(self)
-    }
-
-    pub fn set_session_ticket_provider<T: 'static + SessionTicketProvider>(
-        &mut self,
-        handler: T,
-    ) -> Result<&mut Self, Error> {
-        // Store callback in context
-        let handler = Box::new(handler);
-        let context = self.config.context_mut();
-        context.session_ticket_provider = Some(handler);
         Ok(self)
     }
 
@@ -747,7 +749,7 @@ pub(crate) struct Context {
     pub(crate) private_key_callback: Option<Box<dyn PrivateKeyCallback>>,
     pub(crate) verify_host_callback: Option<Box<dyn VerifyHostNameCallback>>,
     pub(crate) session_ticket_callback: Option<Box<dyn SessionTicketCallback>>,
-    pub(crate) session_ticket_provider: Option<Box<dyn SessionTicketProvider>>,
+    pub(crate) connection_initializer: Option<Box<dyn ConnectionInitializer>>,
     pub(crate) wall_clock: Option<Box<dyn WallClock>>,
     pub(crate) monotonic_clock: Option<Box<dyn MonotonicClock>>,
 }
@@ -764,9 +766,80 @@ impl Default for Context {
             private_key_callback: None,
             verify_host_callback: None,
             session_ticket_callback: None,
-            session_ticket_provider: None,
+            connection_initializer: None,
             wall_clock: None,
             monotonic_clock: None,
+        }
+    }
+}
+
+/// A trait executed before a new connection negotiates TLS.
+///
+/// Used for any dynamic configuration of the connection.
+/// Use in conjunction with
+/// [config::Builder::set_connection_initializer](`crate::config::Builder::set_connection_initializer()`).
+pub trait ConnectionInitializer: 'static + Send + Sync {
+    /// The application can return an `Ok(None)` to resolve the callback
+    /// synchronously or return an `Ok(Some(ConnectionFuture))` if it wants to
+    /// run some asynchronous task before resolving the callback.
+    ///
+    fn initialize_connection(
+        &self,
+        connection: &mut crate::connection::Connection,
+    ) -> ConnectionFutureResult;
+}
+
+impl<A: ConnectionInitializer, B: ConnectionInitializer> ConnectionInitializer for (A, B) {
+    fn initialize_connection(
+        &self,
+        connection: &mut crate::connection::Connection,
+    ) -> ConnectionFutureResult {
+        let a = self.0.initialize_connection(connection)?;
+        let b = self.1.initialize_connection(connection)?;
+        match (a, b) {
+            (None, None) => Ok(None),
+            (None, Some(fut)) => Ok(Some(fut)),
+            (Some(fut), None) => Ok(Some(fut)),
+            (Some(fut_a), Some(fut_b)) => Ok(Some(Box::pin(ConcurrentConnectionFuture::new([
+                fut_a, fut_b,
+            ])))),
+        }
+    }
+}
+
+struct ConcurrentConnectionFuture<const N: usize> {
+    futures: [Option<Pin<Box<dyn ConnectionFuture>>>; N],
+}
+
+impl<const N: usize> ConcurrentConnectionFuture<N> {
+    fn new(futures: [Pin<Box<dyn ConnectionFuture>>; N]) -> Self {
+        let futures = futures.map(Some);
+        Self { futures }
+    }
+}
+
+impl<const N: usize> ConnectionFuture for ConcurrentConnectionFuture<N> {
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        connection: &mut crate::connection::Connection,
+        ctx: &mut core::task::Context,
+    ) -> std::task::Poll<Result<(), Error>> {
+        let mut is_pending = false;
+        for container in self.futures.iter_mut() {
+            if let Some(future) = container.as_mut() {
+                match future.as_mut().poll(connection, ctx) {
+                    Poll::Ready(result) => {
+                        result?;
+                        *container = None;
+                    }
+                    Poll::Pending => is_pending = true,
+                }
+            }
+        }
+        if is_pending {
+            Poll::Pending
+        } else {
+            Poll::Ready(Ok(()))
         }
     }
 }

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -196,6 +196,13 @@ impl Connection {
                 "s2n_connection_set_config was successful"
             };
 
+            let context = config.context();
+            if let Some(callback) = &context.session_ticket_provider {
+                if let Some(ticket) = callback.provide_session_ticket() {
+                    self.set_session_ticket(&ticket)?;
+                }
+            }
+
             // Setting the config on the connection creates one additional reference to the config
             // so do not drop so prevent Rust from calling `drop()` at the end of this function.
             mem::forget(config);

--- a/bindings/rust/s2n-tls/src/testing/resumption.rs
+++ b/bindings/rust/s2n-tls/src/testing/resumption.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 mod tests {
     use crate::{
-        callbacks::{SessionTicket, SessionTicketCallback},
+        callbacks::{SessionTicket, SessionTicketCallback, SessionTicketProvider},
         connection,
         testing::{s2n_tls::*, *},
     };
@@ -32,6 +32,12 @@ mod tests {
         }
     }
 
+    impl SessionTicketProvider for SessionTicketHandler {
+        fn provide_session_ticket(&self) -> Option<Vec<u8>> {
+            (*self.stored_ticket).lock().unwrap().clone()
+        }
+    }
+
     // Create test ticket key
     const KEY: [u8; 16] = [0; 16];
     const KEYNAME: [u8; 3] = [1, 3, 4];
@@ -56,7 +62,8 @@ mod tests {
             .enable_session_tickets(true)?
             .set_session_ticket_callback(handler.clone())?
             .trust_pem(keypair.cert())?
-            .set_verify_host_callback(InsecureAcceptAllCertificatesHandler {})?;
+            .set_verify_host_callback(InsecureAcceptAllCertificatesHandler {})?
+            .set_session_ticket_provider(handler.clone())?;
         let client_config = client_config_builder.build()?;
 
         // create and configure a server connection
@@ -93,13 +100,7 @@ mod tests {
         // create a client connection with a resumption ticket
         let mut client = connection::Connection::new_client();
 
-        let ticket = (*handler.stored_ticket)
-            .lock()
-            .unwrap()
-            .clone()
-            .expect("Ticket should not be None");
         client
-            .set_session_ticket(&ticket)?
             .set_config(client_config)
             .expect("Unable to set client config");
 
@@ -134,6 +135,7 @@ mod tests {
         client_config_builder
             .enable_session_tickets(true)?
             .set_session_ticket_callback(handler.clone())?
+            .set_session_ticket_provider(handler.clone())?
             .trust_pem(keypair.cert())?
             .set_verify_host_callback(InsecureAcceptAllCertificatesHandler {})?
             .set_security_policy(&security::DEFAULT_TLS13)?;
@@ -175,16 +177,9 @@ mod tests {
             .set_config(server_config)
             .expect("Failed to bind config to server connection");
 
-        let ticket = (*handler.stored_ticket)
-            .lock()
-            .unwrap()
-            .clone()
-            .expect("Ticket should not be None");
-
         // create a client connection with a resumption ticket
         let mut client = connection::Connection::new_client();
         client
-            .set_session_ticket(&ticket)?
             .set_config(client_config)
             .expect("Unable to set client config");
 


### PR DESCRIPTION
### Resolved issues:

N/A
### Description of changes: 

Adds an async callback that gets triggered before s2n_poll_negotiate in order to dynamically configure the s2n connection. Users should create this callback when the config is built, and it will trigger each time a new connection is negotiated. 

This is relevant to session resumption as the user can configure a callback to dynamically give session tickets to the s2n connection.
### Call-outs:

N/A

### Testing:

Includes modifications to the rust bindings resumption test to use this callback.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
