### PR TITLE
Clean up sending supported sig algs

### DIFF
--- a/tests/unit/s2n_client_signature_algorithms_extension_test.c
+++ b/tests/unit/s2n_client_signature_algorithms_extension_test.c
@@ -64,8 +64,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_signature_algorithms_extension.recv(server_conn, &io));
         EXPECT_EQUAL(s2n_stuffer_data_available(&io), 0);
 
-        EXPECT_EQUAL(server_conn->handshake_params.client_sig_hash_algs.len,
-                s2n_supported_sig_schemes_count(client_conn));
+        EXPECT_TRUE(server_conn->handshake_params.client_sig_hash_algs.len > 0);
 
         s2n_stuffer_free(&io);
         s2n_connection_free(client_conn);

--- a/tests/unit/s2n_server_signature_algorithms_extension_test.c
+++ b/tests/unit/s2n_server_signature_algorithms_extension_test.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_server_signature_algorithms_extension.recv(client_conn, &io));
         EXPECT_EQUAL(s2n_stuffer_data_available(&io), 0);
 
-        EXPECT_EQUAL(client_conn->handshake_params.server_sig_hash_algs.len, s2n_supported_sig_schemes_count(server_conn));
+        EXPECT_TRUE(client_conn->handshake_params.server_sig_hash_algs.len > 0);
 
         s2n_stuffer_free(&io);
         EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tests/unit/s2n_signature_algorithms_test.c
+++ b/tests/unit/s2n_signature_algorithms_test.c
@@ -661,7 +661,7 @@ int main(int argc, char **argv)
 
         /* Verify no duplicates - some preferences contain duplicates, but only
          * one should be valid at a time. */
-        uint16_t iana, other_iana;
+        uint16_t iana = 0, other_iana = 0;
         for (size_t a = 0; a < signatures.len; a++) {
             iana = signatures.iana_list[a];
             for (int b = 0; b < signatures.len; b++) {

--- a/tests/unit/s2n_tls13_cert_request_test.c
+++ b/tests/unit/s2n_tls13_cert_request_test.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(s2n_stuffer_data_available(&client_conn->handshake.io) > 0);
         EXPECT_SUCCESS(s2n_tls13_cert_req_recv(client_conn));
 
-        EXPECT_EQUAL(client_conn->handshake_params.server_sig_hash_algs.len, s2n_supported_sig_schemes_count(server_conn));
+        EXPECT_TRUE(client_conn->handshake_params.server_sig_hash_algs.len > 0);
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));

--- a/tls/extensions/s2n_client_signature_algorithms.c
+++ b/tls/extensions/s2n_client_signature_algorithms.c
@@ -24,12 +24,13 @@
 #include "utils/s2n_safety.h"
 
 static bool s2n_client_signature_algorithms_should_send(struct s2n_connection *conn);
+static int s2n_client_signature_algorithms_send(struct s2n_connection *conn, struct s2n_stuffer *extension);
 static int s2n_client_signature_algorithms_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
 const s2n_extension_type s2n_client_signature_algorithms_extension = {
     .iana_value = TLS_EXTENSION_SIGNATURE_ALGORITHMS,
     .is_response = false,
-    .send = s2n_send_supported_sig_scheme_list,
+    .send = s2n_client_signature_algorithms_send,
     .recv = s2n_client_signature_algorithms_recv,
     .should_send = s2n_client_signature_algorithms_should_send,
     .if_missing = s2n_extension_noop_if_missing,
@@ -38,6 +39,12 @@ const s2n_extension_type s2n_client_signature_algorithms_extension = {
 static bool s2n_client_signature_algorithms_should_send(struct s2n_connection *conn)
 {
     return s2n_connection_get_protocol_version(conn) >= S2N_TLS12;
+}
+
+static int s2n_client_signature_algorithms_send(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    POSIX_GUARD_RESULT(s2n_signature_algorithms_supported_list_send(conn, extension));
+    return S2N_SUCCESS;
 }
 
 static int s2n_client_signature_algorithms_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)

--- a/tls/extensions/s2n_server_signature_algorithms.c
+++ b/tls/extensions/s2n_server_signature_algorithms.c
@@ -24,16 +24,23 @@
 #include "tls/s2n_tls_parameters.h"
 #include "utils/s2n_safety.h"
 
+static int s2n_signature_algorithms_send(struct s2n_connection *conn, struct s2n_stuffer *extension);
 static int s2n_signature_algorithms_recv(struct s2n_connection *conn, struct s2n_stuffer *extension);
 
 const s2n_extension_type s2n_server_signature_algorithms_extension = {
     .iana_value = TLS_EXTENSION_SIGNATURE_ALGORITHMS,
     .is_response = false,
-    .send = s2n_send_supported_sig_scheme_list,
+    .send = s2n_signature_algorithms_send,
     .recv = s2n_signature_algorithms_recv,
     .should_send = s2n_extension_always_send,
     .if_missing = s2n_extension_error_if_missing,
 };
+
+static int s2n_signature_algorithms_send(struct s2n_connection *conn, struct s2n_stuffer *extension)
+{
+    POSIX_GUARD_RESULT(s2n_signature_algorithms_supported_list_send(conn, extension));
+    return S2N_SUCCESS;
+}
 
 static int s2n_signature_algorithms_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {

--- a/tls/s2n_server_cert_request.c
+++ b/tls/s2n_server_cert_request.c
@@ -172,7 +172,7 @@ int s2n_cert_req_send(struct s2n_connection *conn)
     }
 
     if (conn->actual_protocol_version == S2N_TLS12) {
-        POSIX_GUARD(s2n_send_supported_sig_scheme_list(conn, out));
+        POSIX_GUARD_RESULT(s2n_signature_algorithms_supported_list_send(conn, out));
     }
 
     /* RFC 5246 7.4.4 - If the certificate_authorities list is empty, then the

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -31,8 +31,10 @@ static S2N_RESULT s2n_signature_scheme_validate_for_send(struct s2n_connection *
 {
     RESULT_ENSURE_REF(conn);
 
-    /* We don't know what protocol version we will eventually negotiate,
-     * but we know that it won't be any higher. */
+    /* If no protocol has been negotiated yet, the actual_protocol_version will
+     * be equivalent to the client_protocol_version and represent the highest
+     * version supported.
+     */
     RESULT_ENSURE_GTE(conn->actual_protocol_version, scheme->minimum_protocol_version);
 
     /* QUIC only supports TLS1.3 */

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -26,27 +26,29 @@
 #include "tls/s2n_signature_scheme.h"
 #include "utils/s2n_safety.h"
 
-static int s2n_signature_scheme_valid_to_offer(struct s2n_connection *conn, const struct s2n_signature_scheme *scheme)
+static S2N_RESULT s2n_signature_scheme_validate_for_send(struct s2n_connection *conn,
+        const struct s2n_signature_scheme *scheme)
 {
-    POSIX_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(conn);
 
-    /* We don't know what protocol version we will eventually negotiate, but we know that it won't be any higher. */
-    POSIX_ENSURE_GTE(conn->actual_protocol_version, scheme->minimum_protocol_version);
+    /* We don't know what protocol version we will eventually negotiate,
+     * but we know that it won't be any higher. */
+    RESULT_ENSURE_GTE(conn->actual_protocol_version, scheme->minimum_protocol_version);
 
     /* QUIC only supports TLS1.3 */
     if (s2n_connection_is_quic_enabled(conn) && scheme->maximum_protocol_version) {
-        POSIX_ENSURE_GTE(scheme->maximum_protocol_version, S2N_TLS13);
+        RESULT_ENSURE_GTE(scheme->maximum_protocol_version, S2N_TLS13);
     }
 
     if (!s2n_is_rsa_pss_signing_supported()) {
-        POSIX_ENSURE_NE(scheme->sig_alg, S2N_SIGNATURE_RSA_PSS_RSAE);
+        RESULT_ENSURE_NE(scheme->sig_alg, S2N_SIGNATURE_RSA_PSS_RSAE);
     }
 
     if (!s2n_is_rsa_pss_certs_supported()) {
-        POSIX_ENSURE_NE(scheme->sig_alg, S2N_SIGNATURE_RSA_PSS_PSS);
+        RESULT_ENSURE_NE(scheme->sig_alg, S2N_SIGNATURE_RSA_PSS_PSS);
     }
 
-    return 0;
+    return S2N_RESULT_OK;
 }
 
 static int s2n_signature_scheme_valid_to_accept(struct s2n_connection *conn, const struct s2n_signature_scheme *scheme)
@@ -54,7 +56,7 @@ static int s2n_signature_scheme_valid_to_accept(struct s2n_connection *conn, con
     POSIX_ENSURE_REF(scheme);
     POSIX_ENSURE_REF(conn);
 
-    POSIX_GUARD(s2n_signature_scheme_valid_to_offer(conn, scheme));
+    POSIX_GUARD_RESULT(s2n_signature_scheme_validate_for_send(conn, scheme));
 
     if (scheme->maximum_protocol_version != S2N_UNKNOWN_PROTOCOL_VERSION) {
         POSIX_ENSURE_LTE(conn->actual_protocol_version, scheme->maximum_protocol_version);
@@ -246,42 +248,25 @@ int s2n_choose_sig_scheme_from_peer_preference_list(struct s2n_connection *conn,
     return S2N_SUCCESS;
 }
 
-int s2n_send_supported_sig_scheme_list(struct s2n_connection *conn, struct s2n_stuffer *out)
+S2N_RESULT s2n_signature_algorithms_supported_list_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
     const struct s2n_signature_preferences *signature_preferences = NULL;
-    POSIX_GUARD(s2n_connection_get_signature_preferences(conn, &signature_preferences));
-    POSIX_ENSURE_REF(signature_preferences);
+    RESULT_GUARD_POSIX(s2n_connection_get_signature_preferences(conn, &signature_preferences));
+    RESULT_ENSURE_REF(signature_preferences);
 
-    POSIX_GUARD(s2n_stuffer_write_uint16(out, s2n_supported_sig_scheme_list_size(conn)));
+    struct s2n_stuffer_reservation size = { 0 };
+    RESULT_GUARD_POSIX(s2n_stuffer_reserve_uint16(out, &size));
 
     for (size_t i = 0; i < signature_preferences->count; i++) {
         const struct s2n_signature_scheme *const scheme = signature_preferences->signature_schemes[i];
-        if (0 == s2n_signature_scheme_valid_to_offer(conn, scheme)) {
-            POSIX_GUARD(s2n_stuffer_write_uint16(out, scheme->iana_value));
+        RESULT_ENSURE_REF(scheme);
+        if (s2n_result_is_ok(s2n_signature_scheme_validate_for_send(conn, scheme))) {
+            RESULT_GUARD_POSIX(s2n_stuffer_write_uint16(out, scheme->iana_value));
         }
     }
+    RESULT_GUARD_POSIX(s2n_stuffer_write_vector_size(&size));
 
-    return 0;
-}
-
-int s2n_supported_sig_scheme_list_size(struct s2n_connection *conn)
-{
-    return s2n_supported_sig_schemes_count(conn) * TLS_SIGNATURE_SCHEME_LEN;
-}
-
-int s2n_supported_sig_schemes_count(struct s2n_connection *conn)
-{
-    const struct s2n_signature_preferences *signature_preferences = NULL;
-    POSIX_GUARD(s2n_connection_get_signature_preferences(conn, &signature_preferences));
-    POSIX_ENSURE_REF(signature_preferences);
-
-    uint8_t count = 0;
-    for (size_t i = 0; i < signature_preferences->count; i++) {
-        if (0 == s2n_signature_scheme_valid_to_offer(conn, signature_preferences->signature_schemes[i])) {
-            count++;
-        }
-    }
-    return count;
+    return S2N_RESULT_OK;
 }
 
 int s2n_recv_supported_sig_scheme_list(struct s2n_stuffer *in, struct s2n_sig_scheme_list *sig_hash_algs)

--- a/tls/s2n_signature_algorithms.h
+++ b/tls/s2n_signature_algorithms.h
@@ -40,6 +40,5 @@ int s2n_get_and_validate_negotiated_signature_scheme(struct s2n_connection *conn
         const struct s2n_signature_scheme **chosen_sig_scheme);
 
 int s2n_recv_supported_sig_scheme_list(struct s2n_stuffer *in, struct s2n_sig_scheme_list *sig_hash_algs);
-int s2n_send_supported_sig_scheme_list(struct s2n_connection *conn, struct s2n_stuffer *out);
-int s2n_supported_sig_schemes_count(struct s2n_connection *conn);
-int s2n_supported_sig_scheme_list_size(struct s2n_connection *conn);
+S2N_RESULT s2n_signature_algorithms_supported_list_send(struct s2n_connection *conn,
+        struct s2n_stuffer *out);


### PR DESCRIPTION
### Description of changes: 

The "send" portion of the signature algorithms selection refactor. Sending is pretty simple, so doesn't need as much cleanup as receiving.

This is a pretty minor change: it swaps from int->result and avoids counting signature algorithms separately by using an s2n_stuffer_reservation. 

### Call-outs:
This isn't super important, it's just a "nice to have" cleanup. Counting the items in a list separately from actually building that list always makes me nervous that the two counts will disagree.

### Testing:
Existing unit tests. Removed the tests around counting the entries.
I also updated some tests to not share important mutable test variables like output stuffers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
