### PR TITLE
Update get_client_cert_chain API documentation

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2127,14 +2127,18 @@ S2N_API extern int s2n_connection_get_client_auth_type(struct s2n_connection *co
 S2N_API extern int s2n_connection_set_client_auth_type(struct s2n_connection *conn, s2n_cert_auth_type client_auth_type);
 
 /**
- * Gets the client certificate chain and places it in the `der_cert_chain_out` buffer. `cert_chain_len` is updated
- * to match the size the chain buffer.
+ * Gets the raw certificate chain received from the client.
  *
- * @warning The buffers share a lifetime with the s2n_connection object.
+ * The retrieved certificate chain has the format described by the TLS 1.2 RFC:
+ * https://datatracker.ietf.org/doc/html/rfc5246#section-7.4.2. Each certificate is a DER-encoded ASN.1 X.509,
+ * prepended by a 3 byte network-endian length value. Note that this format is used regardless of the connection's
+ * protocol version.
+ *
+ * @warning The buffer pointed to by `cert_chain_out` shares its lifetime with the s2n_connection object.
  *
  * @param conn A pointer to the s2n_connection object
- * @param der_cert_chain_out A uint8_t pointer. This will be updated to point to the client certificate chain.
- * @param cert_chain_len A pointer to a uint32_t. This will be updated to match the size of the buffer `der_cert_chain_out` points to.
+ * @param cert_chain_out A pointer that's set to the client certificate chain.
+ * @param cert_chain_len A pointer that's set to the size of the `cert_chain_out` buffer.
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
  */
 S2N_API extern int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **der_cert_chain_out, uint32_t *cert_chain_len);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -619,17 +619,17 @@ int s2n_connection_set_send_cb(struct s2n_connection *conn, s2n_send_fn send)
     return S2N_SUCCESS;
 }
 
-int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **der_cert_chain_out, uint32_t *cert_chain_len)
+int s2n_connection_get_client_cert_chain(struct s2n_connection *conn, uint8_t **cert_chain_out, uint32_t *cert_chain_len)
 {
     POSIX_ENSURE_REF(conn);
-    POSIX_ENSURE_REF(der_cert_chain_out);
+    POSIX_ENSURE_REF(cert_chain_out);
     POSIX_ENSURE_REF(cert_chain_len);
     POSIX_ENSURE_REF(conn->handshake_params.client_cert_chain.data);
 
-    *der_cert_chain_out = conn->handshake_params.client_cert_chain.data;
+    *cert_chain_out = conn->handshake_params.client_cert_chain.data;
     *cert_chain_len = conn->handshake_params.client_cert_chain.size;
 
-    return 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_connection_get_cipher_preferences(struct s2n_connection *conn, const struct s2n_cipher_preferences **cipher_preferences)


### PR DESCRIPTION
### Description of changes: 

Currently the [`s2n_connection_get_client_cert_chain()`](https://github.com/aws/s2n-tls/blob/e4f5bf6e779c153d9063805be81c547584398f7a/api/s2n.h#L2140) API documentation is a bit unclear as to what's being retrieved. The output argument is called "der_cert_chain_out", which implies that the output is just a list of DER-encoded certificates. Without reading the [client_cert code](https://github.com/aws/s2n-tls/blob/e4f5bf6e779c153d9063805be81c547584398f7a/tls/s2n_client_cert.c#L54), it's not clear that this function actually returns the certificate chain as received from the client, which includes length values prepending each DER-encoding.

This PR updates the API documentation to make this more clear.

### Testing:

Documentation change - no new tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
