### PR TITLE
ci: Switch from vmactions to cross-platform-actions

### DIFF
--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -15,11 +15,13 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build and test in FreeBSD
         id: test
-        uses: vmactions/freebsd-vm@v0.3.0
+        uses: cross-platform-actions/action@v0.20.0
         with:
-          prepare: pkg install -y ninja cmake
+          operating_system: freebsd
+          version: '13.2'
           run: |
             freebsd-version
+            sudo pkg install -y ninja cmake
             .github/s2n_bsd.sh
       - name: Upload test results
         if: ${{ failure() }}


### PR DESCRIPTION
### Resolved issues:
Our FreeBSD CI action has stopped working. It enters an infinite loop as described in https://github.com/vmactions/freebsd-vm/issues/74

### Description of changes: 
Switch to cross-platform-actions. Our [OpenBSD action](https://github.com/aws/s2n-tls/blob/main/.github/workflows/ci_openbsd.yml#L18) already uses cross-platform-actions, as do several of the awslabs CRT libraries (aws-c-common, aws-c-cal, and aws-crt-python).

### Testing:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
