### PR TITLE
ci: Minor cppcheck speedup

### DIFF
--- a/codebuild/bin/install_cppcheck.sh
+++ b/codebuild/bin/install_cppcheck.sh
@@ -32,7 +32,8 @@ cd "$INSTALL_DIR"
 git clone --branch 2.3 --depth 1 https://github.com/danmar/cppcheck.git cppcheck-src
 cd cppcheck-src
 
-make -j $JOBS
+# See https://github.com/danmar/cppcheck#gnu-make for build recommendations
+make -j $JOBS MATCHCOMPILER=yes CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function"
 
 mv cppcheck ..
 mv cfg ..


### PR DESCRIPTION
### Description of changes: 
We can get a speedup for cppcheck if we change how we compile it. From my testing, this seems to bring it down from 1:30-2:00 to 1:00-1:10. Most of the savings likely come from MATCHCOMPILER, but maybe the optimizations help a little?

For a bigger speedup we'll need a cache, like Cameron started to add in https://github.com/aws/s2n-tls/pull/2642.

### Testing:
Here's one of my test runs: https://github.com/lrstewart/s2n/actions/runs/6661235504/job/18103779503?pr=31

We cache our build of cppcheck, but the cppcheck action doesn't run on main so this PR won't use a cached value from main without my build changes. I verified that by checking our caches: https://github.com/aws/s2n-tls/actions/caches

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
