### PR TITLE
Fixes failing FreeBSD build in CI

### DIFF
--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Build and test in FreeBSD
         id: test
         uses: cross-platform-actions/action@v0.20.0
-        timeout-minutes: 20
+        timeout-minutes: 25
         with:
           operating_system: freebsd
-          version: '13.2'
+          version: '13.1'
           run: |
             freebsd-version
             sudo pkg install -y ninja cmake

--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Build and test in FreeBSD
         id: test
         uses: cross-platform-actions/action@v0.20.0
+        timeout-minutes: 20
         with:
           operating_system: freebsd
           version: '13.2'


### PR DESCRIPTION
### Resolved issues:

N/A
### Description of changes: 

Our FreeBSD builds are hanging. [It seems like the workflow doesn't go past 20 minutes normally](https://github.com/aws/s2n-tls/actions/workflows/ci_freebsd.yml). We recently changed how we run our [FreeBSD github action](https://github.com/aws/s2n-tls/commit/aa41c9ba065c561f66deb1df98547769f29840ca). During that switch, we explicitly set the version to FreeBSD 13.2. However, previously we were using vmactions/freebsd-vm@v0.3.0. This action did not add support for FreeBSD 13.2 until this [June, in v0.3.1](https://github.com/vmactions/freebsd-vm/commit/7d8195d91011f3bbfd87eeae91508b2db171a4a3). I suspect that we accidentally bumped the version of FreeBSD we were running when we switched to the new github action.

So essentially getting us back to 13.1 should get the CI working again, and we have more investigation to do if we want to support 13.2. I also added a timeout because this action should not be going longer than that.

### Callouts
Note that this is _not the only issue with this action_. I've seen this other failure as well: [cross-platform-actions-64](https://github.com/cross-platform-actions/action/issues/64), although it can be fixed with a retry.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
