### PR TITLE
Bump cross-platform actions to pull in fix for failing to eject a disk

### DIFF
--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build and test in FreeBSD
         id: test
-        uses: cross-platform-actions/action@v0.20.0
+        uses: cross-platform-actions/action@v0.21.1
         timeout-minutes: 25
         with:
           operating_system: freebsd

--- a/.github/workflows/ci_openbsd.yml
+++ b/.github/workflows/ci_openbsd.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build and test in OpenBSD
         id: test
-        uses: cross-platform-actions/action@v0.10.0
+        uses: cross-platform-actions/action@v0.21.1
         with:
           operating_system: openbsd
           architecture: x86-64


### PR DESCRIPTION
### Resolved issues:

N/A
### Description of changes: 

Maybe this is too early to tell if this is a real fix, but the cross-platform actions repo [just put out a commit](https://github.com/cross-platform-actions/action/issues/64#issuecomment-1793029014) to make the BSD builds less flaky. Here I'm updating the version to pull in this new fix. I think they just changed it so when this particular error happens the build retries.

### Call-outs:

N/A
### Testing:

Unsure how to test this one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
