### PR TITLE
test: remove blinding from self_talk_sesion_id test

### DIFF
--- a/tests/unit/s2n_self_talk_session_id_test.c
+++ b/tests/unit/s2n_self_talk_session_id_test.c
@@ -244,6 +244,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
     /* Session resumption with bad session state */
     conn = s2n_connection_new(S2N_CLIENT);
+    EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
     s2n_connection_set_io_pair(conn, io_pair);
 
     /* Change the format of the session state and check we cannot deserialize it */
@@ -560,6 +561,7 @@ int main(int argc, char **argv)
         /* Wipe connections and set up new handshake */
         EXPECT_SUCCESS(s2n_connection_wipe(server_conn));
         EXPECT_SUCCESS(s2n_connection_wipe(client_conn));
+        EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
         EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));


### PR DESCRIPTION
This test is currently the second slowest test because it trigger blinding twice. The commit set's blinding to self serve so the test takes 4 seconds to execute instead of 40.

### Testing:

I added a print statement to `s2n_connection_kill` sleep logic, and confirmed that there were no print statements in all of our unit tests after I added these connection settings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
