### PR TITLE
bindings(rust): make callbacks Send + Sync

### DIFF
--- a/bindings/rust/s2n-tls/src/callbacks.rs
+++ b/bindings/rust/s2n-tls/src/callbacks.rs
@@ -67,17 +67,17 @@ where
 ///
 /// The implementation should verify the certificate host name and return `true`
 /// if the name is valid, `false` otherwise.
-pub trait VerifyHostNameCallback {
+pub trait VerifyHostNameCallback: 'static + Send + Sync {
     fn verify_host_name(&self, host_name: &str) -> bool;
 }
 
 /// A trait for the callback used to retrieve the system / wall clock time.
-pub trait WallClock {
+pub trait WallClock: 'static + Send + Sync {
     fn get_time_since_epoch(&self) -> Duration;
 }
 
 /// A trait for the callback used to retrieve the monotonic time.
-pub trait MonotonicClock {
+pub trait MonotonicClock: 'static + Send + Sync {
     fn get_time(&self) -> Duration;
 }
 

--- a/bindings/rust/s2n-tls/src/callbacks/async_cb.rs
+++ b/bindings/rust/s2n-tls/src/callbacks/async_cb.rs
@@ -26,7 +26,7 @@ use std::pin::Pin;
 /// if it wants to run an asynchronous operation (disk read, network call).
 /// The application can return an error ([Err(Error::application())])
 /// to indicate connection failure.
-pub trait ConnectionFuture {
+pub trait ConnectionFuture: 'static + Send {
     fn poll(
         self: Pin<&mut Self>,
         connection: &mut Connection,
@@ -58,7 +58,7 @@ impl ConnectionFuture for ErrorFuture {
 pin_project! {
     /// A wrapper around an optional [`ConnectionFuture`]
     /// which either polls the future or immediately reports success.
-    struct OptionalFuture{
+    struct OptionalFuture {
         option: Option<Pin<Box<dyn ConnectionFuture>>>,
     }
 }

--- a/bindings/rust/s2n-tls/src/callbacks/pkey.rs
+++ b/bindings/rust/s2n-tls/src/callbacks/pkey.rs
@@ -109,7 +109,7 @@ impl Drop for PrivateKeyOperation {
     }
 }
 
-pub trait PrivateKeyCallback {
+pub trait PrivateKeyCallback: 'static + Send + Sync {
     fn handle_operation(
         &self,
         connection: &mut Connection,

--- a/bindings/rust/s2n-tls/src/callbacks/session_ticket.rs
+++ b/bindings/rust/s2n-tls/src/callbacks/session_ticket.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// A trait to retrieve session tickets from the connection
-pub trait SessionTicketCallback: Send + Sync + 'static {
+pub trait SessionTicketCallback: 'static + Send + Sync {
     fn on_session_ticket(&self, connection: &mut Connection, session_ticket: &SessionTicket);
 }
 

--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -754,3 +754,15 @@ impl Default for Context {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ensure the config context is send and sync
+    #[test]
+    fn context_send_sync_test() {
+        fn assert_send_sync<T: 'static + Send + Sync>() {}
+        assert_send_sync::<Context>();
+    }
+}

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -942,3 +942,15 @@ impl Drop for Connection {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ensure the config context is send and sync
+    #[test]
+    fn context_send_test() {
+        fn assert_send<T: 'static + Send>() {}
+        assert_send::<Context>();
+    }
+}

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -63,12 +63,6 @@ impl fmt::Debug for Connection {
 /// s2n_connection objects can be sent across threads
 unsafe impl Send for Connection {}
 
-/// # Safety
-///
-/// All C methods that mutate the s2n_connection are wrapped
-/// in Rust methods that require a mutable reference.
-unsafe impl Sync for Connection {}
-
 impl Connection {
     pub fn new(mode: Mode) -> Self {
         crate::init::init();
@@ -947,7 +941,7 @@ impl Drop for Connection {
 mod tests {
     use super::*;
 
-    // ensure the config context is send and sync
+    // ensure the connection context is send
     #[test]
     fn context_send_test() {
         fn assert_send<T: 'static + Send>() {}


### PR DESCRIPTION
### Resolved issues:

Resolves #4131, #4282

### Description of changes: 

All of the callbacks should have been marked as Send + Sync, since the `Config` impls Send + Sync.

### Testing:

I've ensured any new callbacks are Send + Sync by adding a simple test that ensures the Config's context is Send + Sync.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
