### PR TITLE
fix(bindings): enable session tickets after setting callback

### DIFF
--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -494,6 +494,9 @@ impl Builder {
         &mut self,
         handler: T,
     ) -> Result<&mut Self, Error> {
+        // enable session tickets automatically
+        self.enable_session_tickets(true)?;
+
         // Define C callback function that can be set on the s2n_config struct
         unsafe extern "C" fn session_ticket_cb(
             conn_ptr: *mut s2n_connection,


### PR DESCRIPTION
### Description of changes: 

The current API requires the caller to both call `enable_session_tickets(true)` and `set_session_ticket_callback(cb)`. This PR, instead, automatically enables session tickets when setting the session ticket callback, since that should be explicit enough of the intention to handle session tickets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
