### PR TITLE
Update CloudFront's upstream ECC preference list

### DIFF
--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -180,7 +180,7 @@ const struct s2n_security_policy security_policy_cloudfront_upstream = {
     .cipher_preferences = &cipher_preferences_cloudfront_upstream,
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
-    .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .ecc_preferences = &s2n_ecc_preferences_20230623,
 };
 
 const struct s2n_security_policy security_policy_cloudfront_upstream_tls10 = {
@@ -188,7 +188,7 @@ const struct s2n_security_policy security_policy_cloudfront_upstream_tls10 = {
     .cipher_preferences = &cipher_preferences_cloudfront_upstream_tls10,
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
-    .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .ecc_preferences = &s2n_ecc_preferences_20230623,
 };
 
 const struct s2n_security_policy security_policy_cloudfront_upstream_tls11 = {
@@ -196,7 +196,7 @@ const struct s2n_security_policy security_policy_cloudfront_upstream_tls11 = {
     .cipher_preferences = &cipher_preferences_cloudfront_upstream_tls11,
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
-    .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .ecc_preferences = &s2n_ecc_preferences_20230623,
 };
 
 const struct s2n_security_policy security_policy_cloudfront_upstream_tls12 = {
@@ -204,7 +204,7 @@ const struct s2n_security_policy security_policy_cloudfront_upstream_tls12 = {
     .cipher_preferences = &cipher_preferences_cloudfront_upstream_tls12,
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
-    .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .ecc_preferences = &s2n_ecc_preferences_20230623,
 };
 
 /* CloudFront viewer facing */


### PR DESCRIPTION
### Description of changes: 

updating Update CloudFront's upstream ECC preference list  from s2n_ecc_pref_list_20140601 to s2n_ecc_pref_list_20230623 to include X25519 inline with CloudFront's documentation in https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-ciphers-cloudfront-to-origin.html

This should only update the following security policies

- CloudFront-Upstream
- CloudFront-Upstream-TLS-1-0
- CloudFront-Upstream-TLS-1-1
- CloudFront-Upstream-TLS-1-2


### Call-outs:

as mentioned in https://github.com/aws/s2n-tls/blob/e4f5bf6e779c153d9063805be81c547584398f7a/tls/s2n_ecc_preferences.c#L36,


s2n_ecc_pref_list_20230623 prefers p256 over x25519. using that over s2n_ecc_pref_list_20200310 should have no differences in TLS 1.2, but could improve compatibility when moving to support TLS 1.3 to origins

### Testing:
Unit tests and integration tests with s2nc (see comment)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
