### PR TITLE
Bump AWS-LC version to v1.17.4

### DIFF
--- a/codebuild/bin/install_awslc.sh
+++ b/codebuild/bin/install_awslc.sh
@@ -36,7 +36,7 @@ source codebuild/bin/jobs.sh
 if [ "$IS_FIPS" == "1" ]; then
   AWSLC_VERSION=AWS-LC-FIPS-1.0.3
 else
-  AWSLC_VERSION=v1.8.0
+  AWSLC_VERSION=v1.17.4
 fi
 mkdir -p "$BUILD_DIR"||true
 cd "$BUILD_DIR"


### PR DESCRIPTION
### Resolved issues:

Prerequisite for https://github.com/aws/s2n-tls/pull/4267

### Description of changes: 

Bump's AWS-LC's default version number to v1.17.4

### Call-outs:

None

### Testing:
Confirmed that this change worked on my Ubuntu host. Have not tried other OS's.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
