### PR TITLE
Fix incorrect inline assembly usage in s2n_rand_rdrand_impl

### DIFF
--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -613,14 +613,14 @@ static int s2n_rand_rdrand_impl(void *data, uint32_t size)
             __asm__ __volatile__(
                     ".byte 0x0f, 0xc7, 0xf0;\n"
                     "setc %b1;\n"
-                    : "=a"(output.i386_fields.u_low), "=qm"(success_low)
+                    : "=&a"(output.i386_fields.u_low), "=qm"(success_low)
                     :
                     : "cc");
 
             __asm__ __volatile__(
                     ".byte 0x0f, 0xc7, 0xf0;\n"
                     "setc %b1;\n"
-                    : "=a"(output.i386_fields.u_high), "=qm"(success_high)
+                    : "=&a"(output.i386_fields.u_high), "=qm"(success_high)
                     :
                     : "cc");
             /* cppcheck-suppress knownConditionTrueFalse */
@@ -644,7 +644,7 @@ static int s2n_rand_rdrand_impl(void *data, uint32_t size)
             __asm__ __volatile__(
                     ".byte 0x48, 0x0f, 0xc7, 0xf0;\n"
                     "setc %b1;\n"
-                    : "=a"(output.u64), "=qm"(success)
+                    : "=&a"(output.u64), "=qm"(success)
                     :
                     : "cc");
     #endif /* defined(__i386__) */


### PR DESCRIPTION
### Description of changes: 

This PR fixes an incorrect inline assembly usage in s2n_rand_rdrand_impl.

The compiler may reuse a register for both input and output of an inline assembly statement, and the input should be consumed before writing to any output registers.

In s2n_rand_rdrand_impl there is an implicit input (an address of success variable) that is read by `setc` instruction after `rdrand` had already written to an output register. If the compiler reuses a register for input and output in that case, the `setc` instruction will try to write to an incorrect memory address, causing SIGSEGV or memory corruption.

Marking the output register as earlyclobber (`&`) prevents the compiler from reusing the output register for input.

We've encountered such SIGSEGV in s2n_rand_rdrand_impl  during running our application under ASAN build, which actually produced the binary code described above.

Here is the related issue with the explanation of the bug:
https://github.com/google/sanitizers/issues/1629

And here is a more detailed explanation from [gcc documentaion on how to use inline assembly](https://gcc.gnu.org/onlinedocs/gcc/extensions-to-the-c-language-family/how-to-use-inline-assembly-language-in-c-code.html#output-operands
):

> Use the & constraint modifier (see [Constraint Modifier Characters](https://gcc.gnu.org/onlinedocs/gcc/extensions-to-the-c-language-family/how-to-use-inline-assembly-language-in-c-code.html#modifiers)) on all output operands that must not overlap an input. Otherwise, GCC may allocate the output operand in the same register as an unrelated input operand, on the assumption that the assembler code consumes its inputs before producing outputs. This assumption may be false if the assembler code actually consists of more than one instruction.
>
> The same problem can occur if one output parameter (a) allows a register constraint and another output parameter (b) allows a memory constraint. The code generated by GCC to access the memory address in b can contain registers which might be shared by a, and GCC considers those registers to be inputs to the asm. As above, GCC assumes that such input registers are consumed before any outputs are written. This assumption may result in incorrect behavior if the asm statement writes to a before using b. Combining the & modifier with the register constraint on a ensures that modifying a does not affect the address referenced by b. Otherwise, the location of b is undefined if a is modified before using b.

### Testing:

I've build our application with s2n-tls under ASAN and checked that the SIGSEGV has gone away.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
