### PR TITLE
Enforce security rules on security policies

### DIFF
--- a/codebuild/bin/grep_simple_mistakes.sh
+++ b/codebuild/bin/grep_simple_mistakes.sh
@@ -227,6 +227,30 @@ if [[ -n $S2N_ENSURE_WITH_INVALID_ERROR_CODE ]]; then
 fi
 
 #############################################
+# Assert policy rule flags used correctly
+#############################################
+SECURITY_POLICY_FLAGS=$(grep "rules = " tls/s2n_security_policies.c)
+CORRECT_FLAGS_REGEX="rules = ([ |]*S2N_[A-Z_]+_FLAG)+,"
+INCORRECT_FLAGS=$(echo "$SECURITY_POLICY_FLAGS" | grep -Ev "$CORRECT_FLAGS_REGEX")
+if [[ -n $INCORRECT_FLAGS ]]; then
+  FAILED=1
+  printf "\e[1;34mSecurity policies require the _FLAG version of security rules:\e[0m\n"
+  printf "$INCORRECT_FLAGS\n\n"
+else
+  EXPECTED_CORRECT_FLAGS=$(echo "$SECURITY_POLICY_FLAGS" | wc -l)
+  if [[ $EXPECTED_CORRECT_FLAGS < 10 ]]; then
+    FAILED=1
+    printf "\e[1;34mOnly found $EXPECTED_CORRECT_FLAGS flags\e[0m\n"
+  fi
+  CORRECT_FLAGS=$(echo "$SECURITY_POLICY_FLAGS" | grep -E "$CORRECT_FLAGS_REGEX")
+  ACTUAL_CORRECT_FLAGS=$(echo "$CORRECT_FLAGS" | wc -l)
+  if [[ $EXPECTED_CORRECT_FLAGS != $ACTUAL_CORRECT_FLAGS ]]; then
+    FAILED=1
+    printf "\e[1;34mExpected $EXPECTED_CORRECT_FLAGS flags but found $ACTUAL_CORRECT_FLAGS:\e[0m\n"
+  fi
+fi
+
+#############################################
 # REPORT FINAL RESULTS
 #############################################
 if [ $FAILED == 1 ]; then

--- a/codebuild/bin/grep_simple_mistakes.sh
+++ b/codebuild/bin/grep_simple_mistakes.sh
@@ -227,30 +227,6 @@ if [[ -n $S2N_ENSURE_WITH_INVALID_ERROR_CODE ]]; then
 fi
 
 #############################################
-# Assert policy rule flags used correctly
-#############################################
-SECURITY_POLICY_FLAGS=$(grep "rules = " tls/s2n_security_policies.c)
-CORRECT_FLAGS_REGEX="rules = ([ |]*S2N_[A-Z_]+_FLAG)+,"
-INCORRECT_FLAGS=$(echo "$SECURITY_POLICY_FLAGS" | grep -Ev "$CORRECT_FLAGS_REGEX")
-if [[ -n $INCORRECT_FLAGS ]]; then
-  FAILED=1
-  printf "\e[1;34mSecurity policies require the _FLAG version of security rules:\e[0m\n"
-  printf "$INCORRECT_FLAGS\n\n"
-else
-  EXPECTED_CORRECT_FLAGS=$(echo "$SECURITY_POLICY_FLAGS" | wc -l)
-  if [[ $EXPECTED_CORRECT_FLAGS < 10 ]]; then
-    FAILED=1
-    printf "\e[1;34mOnly found $EXPECTED_CORRECT_FLAGS flags\e[0m\n"
-  fi
-  CORRECT_FLAGS=$(echo "$SECURITY_POLICY_FLAGS" | grep -E "$CORRECT_FLAGS_REGEX")
-  ACTUAL_CORRECT_FLAGS=$(echo "$CORRECT_FLAGS" | wc -l)
-  if [[ $EXPECTED_CORRECT_FLAGS != $ACTUAL_CORRECT_FLAGS ]]; then
-    FAILED=1
-    printf "\e[1;34mExpected $EXPECTED_CORRECT_FLAGS flags but found $ACTUAL_CORRECT_FLAGS:\e[0m\n"
-  fi
-fi
-
-#############################################
 # REPORT FINAL RESULTS
 #############################################
 if [ $FAILED == 1 ]; then

--- a/tests/unit/s2n_security_policies_rules_test.c
+++ b/tests/unit/s2n_security_policies_rules_test.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "tls/s2n_security_policies.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    DEFER_CLEANUP(struct s2n_security_rule_result result = { 0 },
+            s2n_security_rule_result_free);
+    EXPECT_OK(s2n_security_rule_result_init_output(&result));
+
+    for (size_t i = 0; security_policy_selection[i].version != NULL; i++) {
+        const struct s2n_security_policy *security_policy = security_policy_selection[i].security_policy;
+        EXPECT_NOT_NULL(security_policy);
+        EXPECT_OK(s2n_security_policy_validate_security_rules(security_policy, &result));
+    }
+
+    if (result.found_error) {
+        int output_size = s2n_stuffer_data_available(&result.output);
+        char *output_str = s2n_stuffer_raw_read(&result.output, output_size);
+        EXPECT_NOT_NULL(output_str);
+        fprintf(stdout, "%.*s", output_size, output_str);
+        FAIL_MSG("Security policies violate configured policy rules. See stdout for details.");
+    }
+
+    END_TEST();
+}

--- a/tests/unit/s2n_security_rules_test.c
+++ b/tests/unit/s2n_security_rules_test.c
@@ -333,7 +333,7 @@ int main(int argc, char **argv)
 
         /* Test: valid policy passes */
         {
-            test_policy.rules = S2N_PERFECT_FORWARD_SECRECY_FLAG;
+            test_policy.rules[S2N_PERFECT_FORWARD_SECRECY] = true;
             test_policy.cipher_preferences = &forward_secret_prefs;
 
             struct s2n_security_rule_result result = { 0 };
@@ -343,7 +343,7 @@ int main(int argc, char **argv)
 
         /* Test: invalid policy fails */
         {
-            test_policy.rules = S2N_PERFECT_FORWARD_SECRECY_FLAG;
+            test_policy.rules[S2N_PERFECT_FORWARD_SECRECY] = true;
             test_policy.cipher_preferences = &not_forward_secret_prefs;
 
             struct s2n_security_rule_result result = { 0 };
@@ -353,7 +353,7 @@ int main(int argc, char **argv)
 
         /* Test: valid policy without rule passes */
         {
-            test_policy.rules = 0;
+            test_policy.rules[S2N_PERFECT_FORWARD_SECRECY] = false;
             test_policy.cipher_preferences = &forward_secret_prefs;
 
             struct s2n_security_rule_result result = { 0 };
@@ -363,7 +363,7 @@ int main(int argc, char **argv)
 
         /* Test: invalid policy without rule passes */
         {
-            test_policy.rules = 0;
+            test_policy.rules[S2N_PERFECT_FORWARD_SECRECY] = false;
             test_policy.cipher_preferences = &not_forward_secret_prefs;
 
             struct s2n_security_rule_result result = { 0 };

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -49,7 +49,9 @@ const struct s2n_security_policy security_policy_default_fips = {
     .signature_preferences = &s2n_signature_preferences_default_fips,
     .certificate_signature_preferences = &s2n_signature_preferences_default_fips,
     .ecc_preferences = &s2n_ecc_preferences_default_fips,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_20230317 = {
@@ -59,7 +61,9 @@ const struct s2n_security_policy security_policy_20230317 = {
     .signature_preferences = &s2n_signature_preferences_20230317,
     .certificate_signature_preferences = &s2n_signature_preferences_20230317,
     .ecc_preferences = &s2n_ecc_preferences_20201021,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_20190801 = {
@@ -150,7 +154,9 @@ const struct s2n_security_policy security_policy_elb_fs_2018_06 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_elb_fs_1_2_2019_08 = {
@@ -159,7 +165,9 @@ const struct s2n_security_policy security_policy_elb_fs_1_2_2019_08 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_elb_fs_1_1_2019_08 = {
@@ -168,7 +176,9 @@ const struct s2n_security_policy security_policy_elb_fs_1_1_2019_08 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_elb_fs_1_2_Res_2019_08 = {
@@ -177,7 +187,9 @@ const struct s2n_security_policy security_policy_elb_fs_1_2_Res_2019_08 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 /* CloudFront upstream */
@@ -268,7 +280,9 @@ const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2019 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2021 = {
@@ -277,7 +291,9 @@ const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2021 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2021_chacha20_boosted = {
@@ -286,7 +302,9 @@ const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2021_chacha2
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 /* CloudFront viewer facing legacy TLS 1.2 policies */
@@ -336,7 +354,9 @@ const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2019_legacy 
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_aws_crt_sdk_ssl_v3 = {
@@ -377,7 +397,9 @@ const struct s2n_security_policy security_policy_aws_crt_sdk_tls_13 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_aws_crt_sdk_ssl_v3_06_23 = {
@@ -418,7 +440,9 @@ const struct s2n_security_policy security_policy_aws_crt_sdk_tls_13_06_23 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20230623,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_kms_tls_1_0_2018_10 = {
@@ -427,7 +451,9 @@ const struct s2n_security_policy security_policy_kms_tls_1_0_2018_10 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_kms_tls_1_0_2021_08 = {
@@ -436,7 +462,9 @@ const struct s2n_security_policy security_policy_kms_tls_1_0_2021_08 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_kms_tls_1_2_2023_06 = {
@@ -445,7 +473,9 @@ const struct s2n_security_policy security_policy_kms_tls_1_2_2023_06 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2019_06 = {
@@ -454,7 +484,9 @@ const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2019_06 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2020_02 = {
@@ -463,7 +495,9 @@ const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2020_02 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_pq_sike_test_tls_1_0_2019_11 = {
@@ -472,7 +506,9 @@ const struct s2n_security_policy security_policy_pq_sike_test_tls_1_0_2019_11 = 
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_pq_sike_test_tls_1_0_2020_02 = {
@@ -481,7 +517,9 @@ const struct s2n_security_policy security_policy_pq_sike_test_tls_1_0_2020_02 = 
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2020_07 = {
@@ -490,7 +528,9 @@ const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2020_07 = {
     .kem_preferences = &kem_preferences_pq_tls_1_0_2021_05,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_pq_tls_1_0_2020_12 = {
@@ -499,7 +539,9 @@ const struct s2n_security_policy security_policy_pq_tls_1_0_2020_12 = {
     .kem_preferences = &kem_preferences_pq_tls_1_0_2021_05,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_pq_tls_1_1_2021_05_17 = {
@@ -534,7 +576,9 @@ const struct s2n_security_policy security_policy_pq_tls_1_0_2021_05_20 = {
     .kem_preferences = &kem_preferences_pq_tls_1_0_2021_05,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_pq_tls_1_1_2021_05_21 = {
@@ -567,7 +611,9 @@ const struct s2n_security_policy security_policy_pq_tls_1_0_2021_05_24 = {
     .kem_preferences = &kem_preferences_pq_tls_1_0_2021_05,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_pq_tls_1_0_2021_05_25 = {
@@ -592,7 +638,9 @@ const struct s2n_security_policy security_policy_pq_tls_1_0_2023_01_24 = {
     .kem_preferences = &kem_preferences_pq_tls_1_0_2023_01,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 /* Same as security_policy_pq_tls_1_1_2021_05_21, but with TLS 1.2 as minimum */
@@ -620,7 +668,9 @@ const struct s2n_security_policy security_policy_pq_tls_1_2_2023_04_09 = {
     .kem_preferences = &kem_preferences_pq_tls_1_0_2021_05,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 /* Same as security_policy_pq_tls_1_0_2021_05_26, but with TLS 1.2 as minimum */
@@ -665,7 +715,9 @@ const struct s2n_security_policy security_policy_pq_tls_1_2_2023_10_09 = {
     .kem_preferences = &kem_preferences_pq_tls_1_3_2023_06,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 /* Same as security_policy_pq_tls_1_2_2023_04_10, but with updated KEM prefs */
@@ -683,7 +735,9 @@ const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2018_10 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2021_08 = {
@@ -692,7 +746,9 @@ const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2021_08 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_20140601 = {
@@ -861,7 +917,9 @@ const struct s2n_security_policy security_policy_20210816 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20210816,
     .ecc_preferences = &s2n_ecc_preferences_20210816,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_20210816_gcm = {
@@ -870,7 +928,9 @@ const struct s2n_security_policy security_policy_20210816_gcm = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20210816,
     .ecc_preferences = &s2n_ecc_preferences_20210816,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 /*
@@ -916,7 +976,9 @@ const struct s2n_security_policy security_policy_test_all_ecdsa = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20201021,
     .ecc_preferences = &s2n_ecc_preferences_test_all,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_test_all_rsa_kex = {
@@ -933,7 +995,9 @@ const struct s2n_security_policy security_policy_test_all_tls13 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20201021,
     .ecc_preferences = &s2n_ecc_preferences_test_all,
-    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_test_ecdsa_priority = {

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -49,6 +49,7 @@ const struct s2n_security_policy security_policy_default_fips = {
     .signature_preferences = &s2n_signature_preferences_default_fips,
     .certificate_signature_preferences = &s2n_signature_preferences_default_fips,
     .ecc_preferences = &s2n_ecc_preferences_default_fips,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_20230317 = {
@@ -58,6 +59,7 @@ const struct s2n_security_policy security_policy_20230317 = {
     .signature_preferences = &s2n_signature_preferences_20230317,
     .certificate_signature_preferences = &s2n_signature_preferences_20230317,
     .ecc_preferences = &s2n_ecc_preferences_20201021,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_20190801 = {
@@ -148,6 +150,7 @@ const struct s2n_security_policy security_policy_elb_fs_2018_06 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_elb_fs_1_2_2019_08 = {
@@ -156,6 +159,7 @@ const struct s2n_security_policy security_policy_elb_fs_1_2_2019_08 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_elb_fs_1_1_2019_08 = {
@@ -164,6 +168,7 @@ const struct s2n_security_policy security_policy_elb_fs_1_1_2019_08 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_elb_fs_1_2_Res_2019_08 = {
@@ -172,6 +177,7 @@ const struct s2n_security_policy security_policy_elb_fs_1_2_Res_2019_08 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 /* CloudFront upstream */
@@ -262,6 +268,7 @@ const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2019 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2021 = {
@@ -270,6 +277,7 @@ const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2021 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2021_chacha20_boosted = {
@@ -278,6 +286,7 @@ const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2021_chacha2
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 /* CloudFront viewer facing legacy TLS 1.2 policies */
@@ -327,6 +336,7 @@ const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2019_legacy 
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_aws_crt_sdk_ssl_v3 = {
@@ -367,6 +377,7 @@ const struct s2n_security_policy security_policy_aws_crt_sdk_tls_13 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_aws_crt_sdk_ssl_v3_06_23 = {
@@ -407,6 +418,7 @@ const struct s2n_security_policy security_policy_aws_crt_sdk_tls_13_06_23 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20230623,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_kms_tls_1_0_2018_10 = {
@@ -415,6 +427,7 @@ const struct s2n_security_policy security_policy_kms_tls_1_0_2018_10 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_kms_tls_1_0_2021_08 = {
@@ -423,6 +436,7 @@ const struct s2n_security_policy security_policy_kms_tls_1_0_2021_08 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_kms_tls_1_2_2023_06 = {
@@ -431,6 +445,7 @@ const struct s2n_security_policy security_policy_kms_tls_1_2_2023_06 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2019_06 = {
@@ -439,6 +454,7 @@ const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2019_06 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2020_02 = {
@@ -447,6 +463,7 @@ const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2020_02 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_pq_sike_test_tls_1_0_2019_11 = {
@@ -455,6 +472,7 @@ const struct s2n_security_policy security_policy_pq_sike_test_tls_1_0_2019_11 = 
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_pq_sike_test_tls_1_0_2020_02 = {
@@ -463,6 +481,7 @@ const struct s2n_security_policy security_policy_pq_sike_test_tls_1_0_2020_02 = 
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2020_07 = {
@@ -471,6 +490,7 @@ const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2020_07 = {
     .kem_preferences = &kem_preferences_pq_tls_1_0_2021_05,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_pq_tls_1_0_2020_12 = {
@@ -479,6 +499,7 @@ const struct s2n_security_policy security_policy_pq_tls_1_0_2020_12 = {
     .kem_preferences = &kem_preferences_pq_tls_1_0_2021_05,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_pq_tls_1_1_2021_05_17 = {
@@ -513,6 +534,7 @@ const struct s2n_security_policy security_policy_pq_tls_1_0_2021_05_20 = {
     .kem_preferences = &kem_preferences_pq_tls_1_0_2021_05,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_pq_tls_1_1_2021_05_21 = {
@@ -545,6 +567,7 @@ const struct s2n_security_policy security_policy_pq_tls_1_0_2021_05_24 = {
     .kem_preferences = &kem_preferences_pq_tls_1_0_2021_05,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_pq_tls_1_0_2021_05_25 = {
@@ -569,6 +592,7 @@ const struct s2n_security_policy security_policy_pq_tls_1_0_2023_01_24 = {
     .kem_preferences = &kem_preferences_pq_tls_1_0_2023_01,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 /* Same as security_policy_pq_tls_1_1_2021_05_21, but with TLS 1.2 as minimum */
@@ -596,6 +620,7 @@ const struct s2n_security_policy security_policy_pq_tls_1_2_2023_04_09 = {
     .kem_preferences = &kem_preferences_pq_tls_1_0_2021_05,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 /* Same as security_policy_pq_tls_1_0_2021_05_26, but with TLS 1.2 as minimum */
@@ -640,6 +665,7 @@ const struct s2n_security_policy security_policy_pq_tls_1_2_2023_10_09 = {
     .kem_preferences = &kem_preferences_pq_tls_1_3_2023_06,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20200310,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 /* Same as security_policy_pq_tls_1_2_2023_04_10, but with updated KEM prefs */
@@ -657,6 +683,7 @@ const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2018_10 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20140601,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2021_08 = {
@@ -665,6 +692,7 @@ const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2021_08 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20200207,
     .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_20140601 = {
@@ -833,6 +861,7 @@ const struct s2n_security_policy security_policy_20210816 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20210816,
     .ecc_preferences = &s2n_ecc_preferences_20210816,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_20210816_gcm = {
@@ -841,6 +870,7 @@ const struct s2n_security_policy security_policy_20210816_gcm = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20210816,
     .ecc_preferences = &s2n_ecc_preferences_20210816,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 /*
@@ -886,6 +916,7 @@ const struct s2n_security_policy security_policy_test_all_ecdsa = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20201021,
     .ecc_preferences = &s2n_ecc_preferences_test_all,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_test_all_rsa_kex = {
@@ -902,6 +933,7 @@ const struct s2n_security_policy security_policy_test_all_tls13 = {
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20201021,
     .ecc_preferences = &s2n_ecc_preferences_test_all,
+    .rules = S2N_PERFECT_FORWARD_SECRECY_FLAG,
 };
 
 const struct s2n_security_policy security_policy_test_ecdsa_priority = {
@@ -1136,6 +1168,16 @@ int s2n_security_policies_init()
         }
 
         POSIX_GUARD(s2n_validate_kem_preferences(kem_preference, security_policy_selection[i].pq_kem_extension_required));
+
+        /* Validate that security rules are correctly applied.
+         * This should be checked by a unit test, but outside of unit tests we
+         * check again here to cover the case where the unit tests are not run.
+         */
+        if (!s2n_in_unit_test()) {
+            struct s2n_security_rule_result result = { 0 };
+            POSIX_GUARD_RESULT(s2n_security_policy_validate_security_rules(security_policy, &result));
+            POSIX_ENSURE(!result.found_error, S2N_ERR_INVALID_SECURITY_POLICY);
+        }
     }
     return 0;
 }

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -70,7 +70,7 @@ struct s2n_security_policy {
      * https://www.rfc-editor.org/rfc/rfc8446#section-4.2.7
      */
     const struct s2n_ecc_preferences *ecc_preferences;
-    s2n_security_flag rules;
+    bool rules[S2N_SECURITY_RULES_COUNT];
 };
 
 struct s2n_security_policy_selection {

--- a/tls/s2n_security_rules.c
+++ b/tls/s2n_security_rules.c
@@ -147,43 +147,17 @@ S2N_RESULT s2n_security_rule_validate_policy(const struct s2n_security_rule *rul
     return S2N_RESULT_OK;
 }
 
-static S2N_RESULT s2n_security_policy_get_security_rules(
-        const struct s2n_security_policy *policy, const struct s2n_security_rule **rules,
-        size_t max_rules_count, size_t *rules_count)
-{
-    RESULT_ENSURE_REF(policy);
-    RESULT_ENSURE_REF(rules_count);
-    *rules_count = 0;
-
-    size_t flags = policy->rules;
-    size_t count = 0;
-    for (size_t rule = 0; rule < S2N_SECURITY_RULES_COUNT; rule++) {
-        bool is_set = flags % 2;
-        flags = flags >> 1;
-
-        if (!is_set) {
-            continue;
-        }
-
-        RESULT_ENSURE_INCLUSIVE_RANGE(0, rule, s2n_array_len(security_rule_definitions));
-        RESULT_ENSURE_LT(count, max_rules_count);
-        rules[count] = &security_rule_definitions[rule];
-        count++;
-    }
-
-    *rules_count = count;
-    return S2N_RESULT_OK;
-}
-
 S2N_RESULT s2n_security_policy_validate_security_rules(
         const struct s2n_security_policy *policy, struct s2n_security_rule_result *result)
 {
-    const struct s2n_security_rule *rules[S2N_SECURITY_RULES_COUNT] = { 0 };
-    size_t rules_count = 0;
-    RESULT_GUARD(s2n_security_policy_get_security_rules(policy,
-            rules, s2n_array_len(rules), &rules_count));
-    for (size_t i = 0; i < rules_count; i++) {
-        RESULT_GUARD(s2n_security_rule_validate_policy(rules[i], policy, result));
+    RESULT_ENSURE_REF(policy);
+    for (size_t rule_id = 0; rule_id < s2n_array_len(policy->rules); rule_id++) {
+        if (!policy->rules[rule_id]) {
+            continue;
+        }
+        RESULT_ENSURE_LT(rule_id, s2n_array_len(security_rule_definitions));
+        const struct s2n_security_rule *rule = &security_rule_definitions[rule_id];
+        RESULT_GUARD(s2n_security_rule_validate_policy(rule, policy, result));
     }
     return S2N_RESULT_OK;
 }

--- a/tls/s2n_security_rules.h
+++ b/tls/s2n_security_rules.h
@@ -23,9 +23,9 @@ typedef enum {
     S2N_SECURITY_RULES_COUNT,
 } s2n_security_rule_id;
 
-#define TO_FLAG(rule) rule##_FLAG = (1 << (rule))
+#define S2N_SECURITY_RULE_TO_FLAG(rule) rule##_FLAG = (1 << (rule))
 typedef enum {
-    TO_FLAG(S2N_PERFECT_FORWARD_SECRECY),
+    S2N_SECURITY_RULE_TO_FLAG(S2N_PERFECT_FORWARD_SECRECY),
 } s2n_security_flag;
 
 struct s2n_security_rule_result {

--- a/tls/s2n_security_rules.h
+++ b/tls/s2n_security_rules.h
@@ -23,11 +23,6 @@ typedef enum {
     S2N_SECURITY_RULES_COUNT,
 } s2n_security_rule_id;
 
-#define S2N_SECURITY_RULE_TO_FLAG(rule) rule##_FLAG = (1 << (rule))
-typedef enum {
-    S2N_SECURITY_RULE_TO_FLAG(S2N_PERFECT_FORWARD_SECRECY),
-} s2n_security_flag;
-
 struct s2n_security_rule_result {
     bool found_error;
     bool write_output;


### PR DESCRIPTION
### Resolved issues:

Related to https://github.com/aws/s2n-tls/issues/4299

### Description of changes: 
Start enforcing security rules on security policies. I also set S2N_PERFECT_FORWARD_SECRECY on every policy that currently meets that rule.

### Call-outs:
~I don't love the way I'm turning the security rule enum into flags for the security policies. We really need a way to clearly set the rules per-security policy, without relying on another hard-coded list tracked elsewhere like we do for the other fields. However, I'm worried that developers will accidentally use the security rule enum itself instead of the _FLAG version-- I've done it a couple times in testing. I added a grep_simple_mistakes check to try to prevent that, but that feels like a hack.~ After some discussion, I've switched to Alternative 2 from the link below.

I've got a couple other options in https://godbolt.org/z/T65ajzE7j. Take a look and see if any are preferable. ~I'm leaning towards Alternative 3.~

### Testing:
#### Full list of forward-secret policies
Here are the policies I added the rule to:
```
default_fips
20230317
ELBSecurityPolicy-FS-2018-06
ELBSecurityPolicy-FS-1-2-2019-08
ELBSecurityPolicy-FS-1-1-2019-08
ELBSecurityPolicy-FS-1-2-Res-2019-08
CloudFront-TLS-1-2-2019
CloudFront-TLS-1-2-2021
CloudFront-TLS-1-2-2021-Chacha20-Boosted
CloudFront-TLS-1-2-2019-Legacy
AWS-CRT-SDK-TLSv1.3
AWS-CRT-SDK-TLSv1.3-2023
KMS-TLS-1-0-2018-10
KMS-TLS-1-0-2021-08
KMS-TLS-1-2-2023-06
KMS-FIPS-TLS-1-2-2018-10
KMS-FIPS-TLS-1-2-2021-08
KMS-PQ-TLS-1-0-2019-06
KMS-PQ-TLS-1-0-2020-02
KMS-PQ-TLS-1-0-2020-07
PQ-SIKE-TEST-TLS-1-0-2019-11
PQ-SIKE-TEST-TLS-1-0-2020-02
PQ-TLS-1-0-2020-12
PQ-TLS-1-0-2021-05-20
PQ-TLS-1-0-2021-05-24
PQ-TLS-1-0-2023-01-24
PQ-TLS-1-2-2023-04-09
PQ-TLS-1-2-2023-10-09
20200207
20210816
20210816_GCM
test_all_ecdsa
test_all_tls13
```
I didn't do any manual validation of the service-specific policies, but the named ones look reasonable.
#### Security policy does not comply with security rule
I added the flag to two non-forward secret policies. This is the output from the test:
```
Running s2n_security_policies_rules_test.c                 ... 
Perfect Forward Secrecy: policy 20140601: cipher suite: AES128-SHA256 (#4)
Perfect Forward Secrecy: policy 20140601: cipher suite: AES128-SHA (#5)
Perfect Forward Secrecy: policy 20140601: cipher suite: DES-CBC3-SHA (#6)
Perfect Forward Secrecy: policy 20140601: cipher suite: RC4-SHA (#7)
Perfect Forward Secrecy: policy 20140601: cipher suite: RC4-MD5 (#8)
Perfect Forward Secrecy: policy 20141001: cipher suite: AES128-SHA256 (#4)
Perfect Forward Secrecy: policy 20141001: cipher suite: AES128-SHA (#5)
Perfect Forward Secrecy: policy 20141001: cipher suite: DES-CBC3-SHA (#6)
Perfect Forward Secrecy: policy 20141001: cipher suite: RC4-SHA (#7)
Perfect Forward Secrecy: policy 20141001: cipher suite: RC4-MD5 (#8)
NOTE: Some details are omitted, run with S2N_PRINT_STACKTRACE=1 for a verbose backtrace.
See https://github.com/aws/s2n-tls/blob/main/docs/USAGE-GUIDE.md
FAILED test 224
Security policies violate configured policy rules. See stdout for details. (s2n_security_policies_rules_test.c:38)
Error Message: 'no error'
 Debug String: 'no error'
 System Error: No such file or directory (2)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
