### PR TITLE
cleanup: add getter for sequence number

### DIFF
--- a/tests/unit/s2n_key_update_threads_test.c
+++ b/tests/unit/s2n_key_update_threads_test.c
@@ -106,13 +106,7 @@ static S2N_RESULT s2n_send_and_recv_random_data(struct s2n_connection *conn)
 static S2N_RESULT s2n_sanity_check_key_updates_sent(struct s2n_connection *conn)
 {
     struct s2n_blob seq_num_blob = { 0 };
-    if (conn->mode == S2N_CLIENT) {
-        RESULT_GUARD_POSIX(s2n_blob_init(&seq_num_blob, conn->secure->client_sequence_number,
-                sizeof(conn->secure->client_sequence_number)));
-    } else {
-        RESULT_GUARD_POSIX(s2n_blob_init(&seq_num_blob, conn->secure->server_sequence_number,
-                sizeof(conn->secure->server_sequence_number)));
-    }
+    RESULT_GUARD(s2n_connection_get_sequence_number(conn, conn->mode, &seq_num_blob));
 
     uint64_t seq_num = 0;
     RESULT_GUARD_POSIX(s2n_sequence_number_to_uint64(&seq_num_blob, &seq_num));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1666,3 +1666,26 @@ S2N_RESULT s2n_connection_get_secure_cipher(struct s2n_connection *conn, const s
     *cipher = conn->secure->cipher_suite->record_alg->cipher;
     return S2N_RESULT_OK;
 }
+
+S2N_RESULT s2n_connection_get_sequence_number(struct s2n_connection *conn,
+        s2n_mode mode, struct s2n_blob *seq_num)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(seq_num);
+    RESULT_ENSURE_REF(conn->secure);
+
+    switch (mode) {
+        case S2N_CLIENT:
+            RESULT_GUARD_POSIX(s2n_blob_init(seq_num, conn->secure->client_sequence_number,
+                    sizeof(conn->secure->client_sequence_number)));
+            break;
+        case S2N_SERVER:
+            RESULT_GUARD_POSIX(s2n_blob_init(seq_num, conn->secure->server_sequence_number,
+                    sizeof(conn->secure->server_sequence_number)));
+            break;
+        default:
+            RESULT_BAIL(S2N_ERR_SAFETY);
+    }
+
+    return S2N_RESULT_OK;
+}

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -422,3 +422,5 @@ int s2n_connection_get_peer_cert_chain(const struct s2n_connection *conn, struct
 uint8_t s2n_connection_get_protocol_version(const struct s2n_connection *conn);
 S2N_RESULT s2n_connection_set_max_fragment_length(struct s2n_connection *conn, uint16_t length);
 S2N_RESULT s2n_connection_get_secure_cipher(struct s2n_connection *conn, const struct s2n_cipher **cipher);
+S2N_RESULT s2n_connection_get_sequence_number(struct s2n_connection *conn,
+        s2n_mode mode, struct s2n_blob *seq_num);

--- a/tls/s2n_key_update.c
+++ b/tls/s2n_key_update.c
@@ -67,12 +67,7 @@ int s2n_key_update_send(struct s2n_connection *conn, s2n_blocked_status *blocked
     POSIX_ENSURE_GTE(conn->actual_protocol_version, S2N_TLS13);
 
     struct s2n_blob sequence_number = { 0 };
-    if (conn->mode == S2N_CLIENT) {
-        POSIX_GUARD(s2n_blob_init(&sequence_number, conn->secure->client_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
-    } else {
-        POSIX_GUARD(s2n_blob_init(&sequence_number, conn->secure->server_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
-    }
-
+    POSIX_GUARD_RESULT(s2n_connection_get_sequence_number(conn, conn->mode, &sequence_number));
     POSIX_GUARD(s2n_check_record_limit(conn, &sequence_number));
 
     if (s2n_atomic_flag_test(&conn->key_update_pending)) {

--- a/tls/s2n_ktls.c
+++ b/tls/s2n_ktls.c
@@ -161,15 +161,12 @@ static S2N_RESULT s2n_ktls_crypto_info_init(struct s2n_connection *conn, s2n_ktl
         inputs.key = key_material.client_key;
         RESULT_GUARD_POSIX(s2n_blob_init(&inputs.iv,
                 secure->client_implicit_iv, sizeof(secure->client_implicit_iv)));
-        RESULT_GUARD_POSIX(s2n_blob_init(&inputs.seq,
-                secure->client_sequence_number, sizeof(secure->client_sequence_number)));
     } else {
         inputs.key = key_material.server_key;
         RESULT_GUARD_POSIX(s2n_blob_init(&inputs.iv,
                 secure->server_implicit_iv, sizeof(secure->server_implicit_iv)));
-        RESULT_GUARD_POSIX(s2n_blob_init(&inputs.seq,
-                secure->server_sequence_number, sizeof(secure->server_sequence_number)));
     }
+    RESULT_GUARD(s2n_connection_get_sequence_number(conn, key_mode, &inputs.seq));
 
     const struct s2n_cipher *cipher = NULL;
     RESULT_GUARD(s2n_connection_get_secure_cipher(conn, &cipher));

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -24,11 +24,7 @@ static int s2n_zero_sequence_number(struct s2n_connection *conn, s2n_mode mode)
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(conn->secure);
     struct s2n_blob sequence_number = { 0 };
-    if (mode == S2N_CLIENT) {
-        POSIX_GUARD(s2n_blob_init(&sequence_number, conn->secure->client_sequence_number, sizeof(conn->secure->client_sequence_number)));
-    } else {
-        POSIX_GUARD(s2n_blob_init(&sequence_number, conn->secure->server_sequence_number, sizeof(conn->secure->server_sequence_number)));
-    }
+    POSIX_GUARD_RESULT(s2n_connection_get_sequence_number(conn, mode, &sequence_number));
     POSIX_GUARD(s2n_blob_zero(&sequence_number));
     return S2N_SUCCESS;
 }

--- a/tls/s2n_tls13_key_schedule.c
+++ b/tls/s2n_tls13_key_schedule.c
@@ -36,13 +36,7 @@ static S2N_RESULT s2n_zero_sequence_number(struct s2n_connection *conn, s2n_mode
     RESULT_ENSURE_REF(conn);
     RESULT_ENSURE_REF(conn->secure);
     struct s2n_blob sequence_number = { 0 };
-    if (mode == S2N_CLIENT) {
-        RESULT_GUARD_POSIX(s2n_blob_init(&sequence_number,
-                conn->secure->client_sequence_number, sizeof(conn->secure->client_sequence_number)));
-    } else {
-        RESULT_GUARD_POSIX(s2n_blob_init(&sequence_number,
-                conn->secure->server_sequence_number, sizeof(conn->secure->server_sequence_number)));
-    }
+    RESULT_GUARD(s2n_connection_get_sequence_number(conn, mode, &sequence_number));
     RESULT_GUARD_POSIX(s2n_blob_zero(&sequence_number));
     return S2N_RESULT_OK;
 }


### PR DESCRIPTION
### Description of changes: 

Just some minor cleanup before my next ktls change. I'm tired of writing the same if/else everywhere for sequence numbers, so I moved it to a separate method. 

### Testing:
Existing tests pass. I could write a unit test for this getter, but it seems kind of trivial :/ And it is covered by the unit tests for all the logic that used to reimplement it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
