### PR TITLE
ci: switch FreeBSD back to vmactions

### DIFF
--- a/.github/workflows/ci_freebsd.yml
+++ b/.github/workflows/ci_freebsd.yml
@@ -9,20 +9,18 @@ on:
 
 jobs:
   testfreebsd:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     name: CI FreeBSD
     steps:
       - uses: actions/checkout@v3
       - name: Build and test in FreeBSD
         id: test
-        uses: cross-platform-actions/action@v0.21.1
-        timeout-minutes: 25
+        uses: vmactions/freebsd-vm@v1
+        timeout-minutes: 45
         with:
-          operating_system: freebsd
-          version: '13.1'
+          prepare: pkg install -y ninja cmake
           run: |
             freebsd-version
-            sudo pkg install -y ninja cmake
             .github/s2n_bsd.sh
       - name: Upload test results
         if: ${{ failure() }}


### PR DESCRIPTION
### Resolved issues:

Resolves https://github.com/aws/s2n-tls/issues/4280

### Description of changes: 
We've been having issues with our FreeBSD action hanging. We've theorized it's some issue with qemu and forking, but haven't made much progress with the investigation. It blocks a lot of PRs.

To unblock our dev process, I'm just going to switch us back to vmactions/freebsd-vm, basically reverting https://github.com/aws/s2n-tls/commit/aa41c9ba065c561f66deb1df98547769f29840ca. The bug that prompted that original switch has been fixed, and the action has a 1.0 version now.

### Callouts
The switch from macos to ubuntu is intentional and part of the v1 update for the action: https://github.com/vmactions/freebsd-vm#run-github-ci-in-freebsd-
> If you are migrating from the previous v0, please change the runs-on: to runs-on: ubuntu-latest

### Testing:
I've retried the action in the CI on my fork 7 times with no failures: https://github.com/lrstewart/s2n/actions/runs/7200552618?pr=35
I've retried the action in the CI here 5 times with no failures: https://github.com/aws/s2n-tls/actions/runs/7201935117?pr=4326

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
