### PR TITLE
Add new PQ TLS Policies

### DIFF
--- a/tests/unit/s2n_security_rules_test.c
+++ b/tests/unit/s2n_security_rules_test.c
@@ -126,6 +126,7 @@ int main(int argc, char **argv)
         .signature_preferences = &valid_sig_prefs,
         .certificate_signature_preferences = &valid_sig_prefs,
         .ecc_preferences = &valid_ecc_prefs,
+        .kem_preferences = &kem_preferences_null,
         .minimum_protocol_version = VALID_VERSION,
     };
     const struct s2n_security_policy invalid_policy = {
@@ -133,6 +134,7 @@ int main(int argc, char **argv)
         .signature_preferences = &invalid_sig_prefs,
         .certificate_signature_preferences = &invalid_sig_prefs,
         .ecc_preferences = &invalid_ecc_prefs,
+        .kem_preferences = &kem_preferences_null,
         .minimum_protocol_version = EXAMPLE_INVALID_VERSION,
     };
 

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -1891,6 +1891,46 @@ const struct s2n_cipher_preferences cipher_preferences_pq_tls_1_3_2023_06_01 = {
     .allow_chacha20_boosting = false,
 };
 
+struct s2n_cipher_suite *cipher_suites_20231213[] = {
+    &s2n_tls13_aes_128_gcm_sha256,
+    &s2n_tls13_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_128_cbc_sha256,
+    &s2n_rsa_with_aes_256_cbc_sha256,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_20231213 = {
+    .count = s2n_array_len(cipher_suites_20231213),
+    .suites = cipher_suites_20231213,
+};
+
+struct s2n_cipher_suite *cipher_suites_20231214[] = {
+    &s2n_tls13_aes_128_gcm_sha256,
+    &s2n_tls13_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_20231214 = {
+        .count = s2n_array_len(cipher_suites_20231214),
+        .suites = cipher_suites_20231214,
+};
+
 struct s2n_cipher_suite *cipher_suites_kms_fips_tls_1_2_2018_10[] = {
     &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
     &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -55,6 +55,9 @@ extern const struct s2n_cipher_preferences cipher_preferences_20210816_gcm;
 extern const struct s2n_cipher_preferences cipher_preferences_20210825;
 extern const struct s2n_cipher_preferences cipher_preferences_20210825_gcm;
 extern const struct s2n_cipher_preferences cipher_preferences_20210831;
+extern const struct s2n_cipher_preferences cipher_preferences_20231213;
+extern const struct s2n_cipher_preferences cipher_preferences_20231214;
+
 extern const struct s2n_cipher_preferences cipher_preferences_default_fips;
 
 extern const struct s2n_cipher_preferences cipher_preferences_test_all;

--- a/tls/s2n_kem_preferences.c
+++ b/tls/s2n_kem_preferences.c
@@ -34,6 +34,13 @@ const struct s2n_kem_group *pq_kem_groups_r3_2023_06[] = {
     &s2n_x25519_kyber_512_r3,
 };
 
+const struct s2n_kem_group *pq_kem_groups_r3_2023_12[] = {
+    &s2n_secp256r1_kyber_768_r3,
+    &s2n_secp384r1_kyber_768_r3,
+    &s2n_secp521r1_kyber_1024_r3,
+    &s2n_secp256r1_kyber_512_r3,
+};
+
 const struct s2n_kem_preferences kem_preferences_pq_tls_1_0_2021_05 = {
     .kem_count = s2n_array_len(pq_kems_r3_2021_05),
     .kems = pq_kems_r3_2021_05,
@@ -56,6 +63,15 @@ const struct s2n_kem_preferences kem_preferences_pq_tls_1_3_2023_06 = {
     .kems = NULL,
     .tls13_kem_group_count = s2n_array_len(pq_kem_groups_r3_2023_06),
     .tls13_kem_groups = pq_kem_groups_r3_2023_06,
+    .tls13_pq_hybrid_draft_revision = 5
+};
+
+/* Same as kem_preferences_pq_tls_1_3_2023_06, but without x25519 */
+const struct s2n_kem_preferences kem_preferences_pq_tls_1_3_2023_12 = {
+    .kem_count = 0,
+    .kems = NULL,
+    .tls13_kem_group_count = s2n_array_len(pq_kem_groups_r3_2023_12),
+    .tls13_kem_groups = pq_kem_groups_r3_2023_12,
     .tls13_pq_hybrid_draft_revision = 5
 };
 

--- a/tls/s2n_kem_preferences.h
+++ b/tls/s2n_kem_preferences.h
@@ -47,6 +47,7 @@ extern const struct s2n_kem_group *pq_kem_groups_r3_2023_06[];
 extern const struct s2n_kem_preferences kem_preferences_pq_tls_1_0_2021_05;
 extern const struct s2n_kem_preferences kem_preferences_pq_tls_1_0_2023_01;
 extern const struct s2n_kem_preferences kem_preferences_pq_tls_1_3_2023_06;
+extern const struct s2n_kem_preferences kem_preferences_pq_tls_1_3_2023_12;
 extern const struct s2n_kem_preferences kem_preferences_all;
 extern const struct s2n_kem_preferences kem_preferences_null;
 

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -731,6 +731,7 @@ const struct s2n_security_policy security_policy_pq_tls_1_2_2023_10_10 = {
     .ecc_preferences = &s2n_ecc_preferences_20200310,
 };
 
+/* General purpose "mostly" FIPS + PQ policy (with the exception of supporting RSA Key Exchange for backwards compatibility). */
 const struct s2n_security_policy security_policy_pq_20231213 = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_20231213,
@@ -739,6 +740,7 @@ const struct s2n_security_policy security_policy_pq_20231213 = {
     .ecc_preferences = &s2n_ecc_preferences_20201021,
 };
 
+/* General purpose FIPS + PQ policy that meets all current FIPS requirements. */
 const struct s2n_security_policy security_policy_pq_20231214 = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_20231214,
@@ -750,6 +752,7 @@ const struct s2n_security_policy security_policy_pq_20231214 = {
     },
 };
 
+/* FIPS + PQ Policy that uses KMS's FIPS cipher preference list and meets all current FIPS requirements. */
 const struct s2n_security_policy security_policy_pq_20231215 = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_kms_fips_tls_1_2_2021_08,

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -731,6 +731,30 @@ const struct s2n_security_policy security_policy_pq_tls_1_2_2023_10_10 = {
     .ecc_preferences = &s2n_ecc_preferences_20200310,
 };
 
+const struct s2n_security_policy security_policy_pq_20231213 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_20231213,
+    .kem_preferences = &kem_preferences_pq_tls_1_3_2023_06,
+    .signature_preferences = &s2n_signature_preferences_20230317,
+    .ecc_preferences = &s2n_ecc_preferences_20201021,
+};
+
+const struct s2n_security_policy security_policy_pq_20231214 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_20231214,
+    .kem_preferences = &kem_preferences_pq_tls_1_3_2023_06,
+    .signature_preferences = &s2n_signature_preferences_20230317,
+    .ecc_preferences = &s2n_ecc_preferences_20201021,
+};
+
+const struct s2n_security_policy security_policy_pq_20231215 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_kms_fips_tls_1_2_2021_08,
+    .kem_preferences = &kem_preferences_pq_tls_1_3_2023_06,
+    .signature_preferences = &s2n_signature_preferences_20230317,
+    .ecc_preferences = &s2n_ecc_preferences_20201021,
+};
+
 const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2018_10 = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_kms_fips_tls_1_2_2018_10,
@@ -1103,6 +1127,9 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "PQ-TLS-1-2-2023-10-08", .security_policy = &security_policy_pq_tls_1_2_2023_10_08, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "PQ-TLS-1-2-2023-10-09", .security_policy = &security_policy_pq_tls_1_2_2023_10_09, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "PQ-TLS-1-2-2023-10-10", .security_policy = &security_policy_pq_tls_1_2_2023_10_10, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "PQ-TLS-1-2-2023-12-13", .security_policy = &security_policy_pq_20231213, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "PQ-TLS-1-2-2023-12-14", .security_policy = &security_policy_pq_20231214, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "PQ-TLS-1-2-2023-12-15", .security_policy = &security_policy_pq_20231215, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20140601", .security_policy = &security_policy_20140601, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20141001", .security_policy = &security_policy_20141001, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20150202", .security_policy = &security_policy_20150202, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -734,7 +734,7 @@ const struct s2n_security_policy security_policy_pq_tls_1_2_2023_10_10 = {
 const struct s2n_security_policy security_policy_pq_20231213 = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_20231213,
-    .kem_preferences = &kem_preferences_pq_tls_1_3_2023_06,
+    .kem_preferences = &kem_preferences_pq_tls_1_3_2023_12,
     .signature_preferences = &s2n_signature_preferences_20230317,
     .ecc_preferences = &s2n_ecc_preferences_20201021,
 };
@@ -742,17 +742,23 @@ const struct s2n_security_policy security_policy_pq_20231213 = {
 const struct s2n_security_policy security_policy_pq_20231214 = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_20231214,
-    .kem_preferences = &kem_preferences_pq_tls_1_3_2023_06,
+    .kem_preferences = &kem_preferences_pq_tls_1_3_2023_12,
     .signature_preferences = &s2n_signature_preferences_20230317,
     .ecc_preferences = &s2n_ecc_preferences_20201021,
+    .rules = {
+            [S2N_FIPS_140_3] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_pq_20231215 = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_kms_fips_tls_1_2_2021_08,
-    .kem_preferences = &kem_preferences_pq_tls_1_3_2023_06,
+    .kem_preferences = &kem_preferences_pq_tls_1_3_2023_12,
     .signature_preferences = &s2n_signature_preferences_20230317,
     .ecc_preferences = &s2n_ecc_preferences_20201021,
+    .rules = {
+            [S2N_FIPS_140_3] = true,
+    },
 };
 
 const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2018_10 = {

--- a/tls/s2n_security_rules.c
+++ b/tls/s2n_security_rules.c
@@ -166,6 +166,20 @@ S2N_RESULT s2n_security_rule_validate_policy(const struct s2n_security_rule *rul
                 "curve", curve->name, i + 1));
     }
 
+    const struct s2n_kem_preferences *kem_prefs = policy->kem_preferences;
+    RESULT_ENSURE_REF(kem_prefs);
+    for (size_t i = 0; i < kem_prefs->tls13_kem_group_count; i++) {
+        const struct s2n_kem_group *kem_group = kem_prefs->tls13_kem_groups[i];
+        const struct s2n_ecc_named_curve *curve = kem_group->curve;
+        RESULT_ENSURE_REF(curve);
+        bool is_valid = false;
+        RESULT_ENSURE_REF(rule->validate_curve);
+        RESULT_GUARD(rule->validate_curve(curve, &is_valid));
+        RESULT_GUARD(s2n_security_rule_result_process(result, is_valid,
+                error_msg_format_name, rule->name, policy_name,
+                "curve", curve->name, i + 1));
+    }
+
     bool is_valid = false;
     RESULT_ENSURE_REF(rule->validate_version);
     RESULT_GUARD(rule->validate_version(policy->minimum_protocol_version, &is_valid));


### PR DESCRIPTION
### Resolved issues:
None


### Description of changes: 

Creates some new PQ TLS Policies that are also FIPS compliant.


### Call-outs:
RSA Key Exchange is currently FIPS compliant, but was excluded from the FIPS rules due to it being removed in upcoming 2024 FIPS standards, ([further discussion here](https://github.com/aws/s2n-tls/pull/4315/files#r1419432323)). 

Rather than create the secondary `S2N_FIPS_140_3_LEGACY_SUPPORT` that was proposed in that previous PR, I opted to instead not add the `S2N_FIPS_140_3` rule to `PQ-TLS-1-2-2023-12-13`.

### Testing:
Unit Testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
