### PR TITLE
ci: ignore cbmc prereleases

### DIFF
--- a/.github/workflows/proof_ci.yaml
+++ b/.github/workflows/proof_ci.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           # Search within 5 most recent releases for latest available package
           CBMC_REL="https://api.github.com/repos/diffblue/cbmc/releases?page=1&per_page=5"
-          CBMC_DEB=$(curl -s $CBMC_REL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq -r '.[].assets[].browser_download_url' | grep -e 'ubuntu-20.04' | head -n 1)
+          CBMC_DEB=$(curl -s $CBMC_REL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq -r '.[]|select(.prerelease|not).assets[].browser_download_url' | grep -e 'ubuntu-20.04' | head -n 1)
           CBMC_ARTIFACT_NAME=$(basename $CBMC_DEB)
           curl -o $CBMC_ARTIFACT_NAME -L $CBMC_DEB
           sudo dpkg -i $CBMC_ARTIFACT_NAME

--- a/.github/workflows/proof_ci.yaml
+++ b/.github/workflows/proof_ci.yaml
@@ -96,7 +96,7 @@ jobs:
         run: |
           # Search within 5 most recent releases for latest available package
           LITANI_REL="https://api.github.com/repos/awslabs/aws-build-accumulator/releases?page=1&per_page=5"
-          LITANI_DEB=$(curl -s $LITANI_REL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq -r '.[].assets[0].browser_download_url' | head -n 1)
+          LITANI_DEB=$(curl -s $LITANI_REL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq -r '.[]|select(.prerelease|not).assets[0].browser_download_url' | head -n 1)
           DBN_PKG_FILENAME=$(basename $LITANI_DEB)
           curl -L $LITANI_DEB -o $DBN_PKG_FILENAME
           sudo apt-get update


### PR DESCRIPTION
### Description of changes: 
Some of our CBMC proofs are currently failing with a python error from the CBMC viewer about missing goal descriptions: https://github.com/aws/s2n-tls/actions/runs/7215710149/job/19660493232

The issue seems to be the latest CBMC release: https://github.com/diffblue/cbmc/releases The latest release is a pre-release and even comes with a warning about not using it in production. However, the logic in our github action that queries for the latest CBMC release doesn't check the "prerelease" field in the response. I've updated it to ignore prereleases to avoid errors like this without needing to pin the version.

### Call-outs:
I preemptively made the same change for litani. The other dependencies use tags to indicate what "latest" means.

### Testing:
The CBMC proofs now pass, and you can see that version 5.59.1 is being chosen instead of 6.0.0 [here](https://github.com/aws/s2n-tls/actions/runs/7217204272/job/19664642341?pr=4328#step:5:28).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
