### PR TITLE
CBMC: do not use prerelease versions

### DIFF
--- a/.github/workflows/proof_ci.yaml
+++ b/.github/workflows/proof_ci.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           # Search within 5 most recent releases for latest available package
           CBMC_REL="https://api.github.com/repos/diffblue/cbmc/releases?page=1&per_page=5"
-          CBMC_DEB=$(curl -s $CBMC_REL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq -r '.[].assets[].browser_download_url' | grep -e 'ubuntu-20.04' | head -n 1)
+          CBMC_DEB=$(curl -s $CBMC_REL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq -r '. | map(select(.prerelease == false)) | [.[0].assets[].browser_download_url] | map(select(test("ubuntu-20.04"))) | .[0]')
           CBMC_ARTIFACT_NAME=$(basename $CBMC_DEB)
           curl -o $CBMC_ARTIFACT_NAME -L $CBMC_DEB
           sudo dpkg -i $CBMC_ARTIFACT_NAME


### PR DESCRIPTION
### Description of changes: 

Use jq to filter out versions that have "prerelease" set to true. While at it, do all filtering using jq rather than additionally relying on `grep` and `head`.

### Call-outs:

This will avoid CI failures seen with the 6.0 CBMC prerelease. We may still, however, need to add changes once the full 6.0 release lands as CBMC is making breaking changes with this major-version upgrade.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? CBMC CI jobs.

Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
