### PR TITLE
ci: pin home crate to fix rust build

### DIFF
--- a/bindings/rust/generate/Cargo.toml
+++ b/bindings/rust/generate/Cargo.toml
@@ -11,3 +11,4 @@ publish = false
 bindgen = "0.65"
 glob = "0.3"
 regex = "=1.9.6" # newer versions require rust 1.65, see https://github.com/aws/s2n-tls/issues/4242
+home = "=0.5.5" # newer versions require rust 1.70


### PR DESCRIPTION
### Description of changes: 
Fix broken Rust ci builds. The "home" crate required by "bindgen" updated its MSRV: https://github.com/rust-lang/cargo/commit/7ce9c26f399ceec6e4750291f39ce381f71eab1f#diff-b98dc008dc4091e293e0c37bbe32de4b54ae1b98703609eada091e9c4209d5d5R13-R14
So now we need to pin to the previous version.

### Call-outs:
We should really also bump our MSRV. It's time.

### Testing:
CI passes now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
