### PR TITLE
ktls: add method to enable TLS1.3

### DIFF
--- a/api/unstable/ktls.h
+++ b/api/unstable/ktls.h
@@ -127,7 +127,7 @@ S2N_API int s2n_connection_ktls_enable_recv(struct s2n_connection *conn);
  *   the request with an alert, making debugging the failures difficult.
  *   We choose to fail as soon as the request is received.
  *
- * If kTLS is enabled for sending, the application must NOT send enough data to
+ * If kTLS is enabled for sending, the application must NOT attempt to send enough data to
  * reach the AES-GCM key usage limits. The limit is defined as 2^24.5 (about 24 million)
  * full-sized TLS records, which is 2^38.5 bytes (about 38GB). However, because
  * s2n-tls tracks the limit by record count instead of bytes, the actual limit
@@ -135,11 +135,15 @@ S2N_API int s2n_connection_ktls_enable_recv(struct s2n_connection *conn);
  * kernel. Likely this requirement can only be met if the application sends
  * less than 35GB AND makes fewer than 24 million calls to s2n_send. If this requirement
  * is violated, s2n-tls will return an S2N_ERR_KTLS_KEY_LIMIT S2N_ERR_T_USAGE error.
+ * - Note: s2n-tls uses the `count` argument when checking key usages limits for
+ *   s2n_sendfile, even if the file is smaller than `count` so less than `count`
+ *   bytes will be sent. Applications must set reasonable `count` values to ensure
+ *   that s2n_sendfile can't violate the key usage limit.
  *
  * @param config A pointer to the config.
  * @returns S2N_SUCCESS if successfully enabled, S2N_FAILURE otherwise.
  */
-S2N_API int s2n_config_ktls_enable_tls13(struct s2n_config *config);
+S2N_API int s2n_config_ktls_enable_unsafe_tls13(struct s2n_config *config);
 
 /**
  * Sends the contents of a file as application data.

--- a/tests/unit/s2n_ktls_test.c
+++ b/tests/unit/s2n_ktls_test.c
@@ -303,7 +303,27 @@ int main(int argc, char **argv)
             EXPECT_FAILURE_WITH_ERRNO(s2n_connection_ktls_enable_recv(server_conn), S2N_ERR_HANDSHAKE_NOT_COMPLETE);
         };
 
-        /* Fail if unsupported protocols */
+        /* Fail if TLS1.3 and TLS1.3 not enabled */
+        {
+            DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+            EXPECT_OK(s2n_test_configure_connection_for_ktls(conn));
+            conn->actual_protocol_version = S2N_TLS13;
+            conn->secure->cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
+
+            /* TLS1.3 disabled by default */
+            EXPECT_FAILURE_WITH_ERRNO(
+                    s2n_connection_ktls_enable_send(conn),
+                    S2N_ERR_KTLS_UNSUPPORTED_CONN);
+
+            /* Enable TlS1.3 */
+            EXPECT_SUCCESS(s2n_config_ktls_enable_tls13(config));
+            EXPECT_SUCCESS(s2n_connection_ktls_enable_send(conn));
+        }
+
+        /* Fail if other unsupported protocols */
         {
             DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
                     s2n_connection_ptr_free);

--- a/tests/unit/s2n_ktls_test.c
+++ b/tests/unit/s2n_ktls_test.c
@@ -319,7 +319,7 @@ int main(int argc, char **argv)
                     S2N_ERR_KTLS_UNSUPPORTED_CONN);
 
             /* Enable TlS1.3 */
-            EXPECT_SUCCESS(s2n_config_ktls_enable_tls13(config));
+            EXPECT_SUCCESS(s2n_config_ktls_enable_unsafe_tls13(config));
             EXPECT_SUCCESS(s2n_connection_ktls_enable_send(conn));
         }
 
@@ -578,6 +578,26 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_ktls_enable_recv(server_conn));
         EXPECT_TRUE(server_conn->ktls_recv_enabled);
         EXPECT_NOT_EQUAL(server_conn->recv, s2n_socket_read);
+    };
+
+    /* Test s2n_config_ktls_enable_unsafe_tls13 */
+    {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+        EXPECT_FALSE(config->ktls_tls13_enabled);
+
+        /* Safety */
+        EXPECT_FAILURE_WITH_ERRNO(
+                s2n_config_ktls_enable_unsafe_tls13(NULL),
+                S2N_ERR_NULL);
+
+        /* Success */
+        EXPECT_SUCCESS(s2n_config_ktls_enable_unsafe_tls13(config));
+        EXPECT_TRUE(config->ktls_tls13_enabled);
+
+        /* Noop if called again */
+        EXPECT_SUCCESS(s2n_config_ktls_enable_unsafe_tls13(config));
+        EXPECT_TRUE(config->ktls_tls13_enabled);
     };
 
     END_TEST();

--- a/tests/unit/s2n_self_talk_ktls_test.c
+++ b/tests/unit/s2n_self_talk_ktls_test.c
@@ -144,6 +144,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
     EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+    EXPECT_SUCCESS(s2n_config_ktls_enable_tls13(config));
 
     /* Even if we detected ktls support at compile time, enabling ktls
      * can fail at runtime if the system is not properly configured.

--- a/tests/unit/s2n_self_talk_ktls_test.c
+++ b/tests/unit/s2n_self_talk_ktls_test.c
@@ -144,7 +144,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
     EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
-    EXPECT_SUCCESS(s2n_config_ktls_enable_tls13(config));
+    EXPECT_SUCCESS(s2n_config_ktls_enable_unsafe_tls13(config));
 
     /* Even if we detected ktls support at compile time, enabling ktls
      * can fail at runtime if the system is not properly configured.

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -1181,3 +1181,10 @@ int s2n_config_get_supported_groups(struct s2n_config *config, uint16_t *groups,
 
     return S2N_SUCCESS;
 }
+
+int s2n_config_ktls_enable_tls13(struct s2n_config *config)
+{
+    POSIX_ENSURE_REF(config);
+    config->ktls_tls13_enabled = true;
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -1181,10 +1181,3 @@ int s2n_config_get_supported_groups(struct s2n_config *config, uint16_t *groups,
 
     return S2N_SUCCESS;
 }
-
-int s2n_config_ktls_enable_tls13(struct s2n_config *config)
-{
-    POSIX_ENSURE_REF(config);
-    config->ktls_tls13_enabled = true;
-    return S2N_SUCCESS;
-}

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -102,6 +102,9 @@ struct s2n_config {
     /* Indicates whether s2n has enabled OCSP status requests, for backwards compatibility */
     unsigned ocsp_status_requested_by_s2n : 1;
 
+    /* TLS1.3 can be dangerous with kTLS. Require it to be explicitly enabled. */
+    unsigned ktls_tls13_enabled : 1;
+
     struct s2n_dh_params *dhparams;
     /* Needed until we can deprecate s2n_config_add_cert_chain_and_key. This is
      * used to release memory allocated only in the deprecated API that the application 

--- a/tls/s2n_ktls.c
+++ b/tls/s2n_ktls.c
@@ -272,3 +272,10 @@ int s2n_connection_ktls_enable_recv(struct s2n_connection *conn)
     POSIX_GUARD_RESULT(s2n_connection_ktls_enable(conn, S2N_KTLS_MODE_RECV));
     return S2N_SUCCESS;
 }
+
+int s2n_config_ktls_enable_unsafe_tls13(struct s2n_config *config)
+{
+    POSIX_ENSURE_REF(config);
+    config->ktls_tls13_enabled = true;
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_ktls.c
+++ b/tls/s2n_ktls.c
@@ -55,15 +55,15 @@ static S2N_RESULT s2n_ktls_validate(struct s2n_connection *conn, s2n_ktls_mode k
     /* kTLS enable should only be called once the handshake has completed. */
     RESULT_ENSURE(is_handshake_complete(conn), S2N_ERR_HANDSHAKE_NOT_COMPLETE);
 
-    /* For now, only allow TLS1.3 for testing.
+    /* For now, only allow TlS1.3 if explicitly enabled.
      *
      * TLS1.3 is potentially more dangerous to enable than TLS1.2, since the kernel
      * does not currently support updating TLS keys and therefore will fail if
      * KeyUpdate messages are encountered.
      */
-    if (!s2n_in_test()) {
-        RESULT_ENSURE(conn->actual_protocol_version == S2N_TLS12, S2N_ERR_KTLS_UNSUPPORTED_CONN);
-    }
+    bool version_supported = (conn->actual_protocol_version == S2N_TLS12)
+            || (conn->config->ktls_tls13_enabled && conn->actual_protocol_version == S2N_TLS13);
+    RESULT_ENSURE(version_supported, S2N_ERR_KTLS_UNSUPPORTED_CONN);
 
     /* Check if the cipher supports kTLS */
     const struct s2n_cipher *cipher = NULL;


### PR DESCRIPTION
### Description of changes: 

Last step for minimal TLS1.3 ktls support. Because TLS1.3 is dangerous without the KeyUpdate kernel patch, applications should deliberately enable it, separate from enabling ktls.

Hopefully this method will never make it out of the unstable API.

### Call-outs:
I made this a config method, rather than a connection method, because it needs to be enabled before ktls is enabled. If I put it on the connection, there will be an ordering foot gun.

### Testing:
Unit tests continue to pass with the new mechanism to enable TLS1.3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
