### PR TITLE
(feat): Adds API to allow s2n-quic to check for resumption

### DIFF
--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -918,7 +918,7 @@ impl Connection {
     /// Allows the quic library to check if session tickets are expected
     pub fn are_session_tickets_enabled(&self) -> bool {
         unsafe {
-            return s2n_connection_are_session_tickets_enabled(self.connection.as_ptr());
+            s2n_connection_are_session_tickets_enabled(self.connection.as_ptr())
         }
     }
 }

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -918,16 +918,9 @@ impl Connection {
     /// Allows the quic library to check if session tickets are expected
     pub fn is_client_resumption_enabled(&self) -> bool {
         unsafe {
-            let result = s2n_connection_is_resumption_enabled(self.connection.as_ptr());
-            if !result {
-                return false;
-            }
-            if let Some(config) = self.config() {
-                let ctx = config.context();
-                return ctx.session_ticket_callback.is_some();
-            }
+            let result = s2n_connection_is_client_resumption_enabled(self.connection.as_ptr());
+            return result;
         }
-        false
     }
 }
 

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -916,9 +916,9 @@ impl Connection {
     }
 
     /// Allows the quic library to check if session tickets are expected
-    pub fn is_client_resumption_enabled(&self) -> bool {
+    pub fn are_session_tickets_enabled(&self) -> bool {
         unsafe {
-            let result = s2n_connection_is_client_resumption_enabled(self.connection.as_ptr());
+            let result = s2n_connection_is_resumption_enabled(self.connection.as_ptr());
             return result;
         }
     }

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -916,10 +916,16 @@ impl Connection {
     }
 
     /// Allows the quic library to check if session tickets are expected
-    pub fn client_resumption_enabled(&self) -> bool {
-        if let Some(config) = self.config() {
-            let ctx = config.context();
-            return ctx.session_ticket_callback.is_some();
+    pub fn is_client_resumption_enabled(&self) -> bool {
+        unsafe {
+            let result = s2n_connection_is_resumption_enabled(self.connection.as_ptr());
+            if !result {
+                return false;
+            }
+            if let Some(config) = self.config() {
+                let ctx = config.context();
+                return ctx.session_ticket_callback.is_some();
+            }
         }
         false
     }

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -917,9 +917,7 @@ impl Connection {
 
     /// Allows the quic library to check if session tickets are expected
     pub fn are_session_tickets_enabled(&self) -> bool {
-        unsafe {
-            s2n_connection_are_session_tickets_enabled(self.connection.as_ptr())
-        }
+        unsafe { s2n_connection_are_session_tickets_enabled(self.connection.as_ptr()) }
     }
 }
 

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -914,6 +914,15 @@ impl Connection {
         }?;
         Ok(self)
     }
+
+    /// Allows the quic library to check if session tickets are expected
+    pub fn client_resumption_enabled(&self) -> bool {
+        if let Some(config) = self.config() {
+            let ctx = config.context();
+            return ctx.session_ticket_callback.is_some();
+        }
+        false
+    }
 }
 
 impl AsRef<Connection> for Connection {

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -918,8 +918,7 @@ impl Connection {
     /// Allows the quic library to check if session tickets are expected
     pub fn are_session_tickets_enabled(&self) -> bool {
         unsafe {
-            let result = s2n_connection_is_resumption_enabled(self.connection.as_ptr());
-            return result;
+            return s2n_connection_are_session_tickets_enabled(self.connection.as_ptr());
         }
     }
 }

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -54,9 +54,9 @@ bool s2n_connection_is_quic_enabled(struct s2n_connection *conn)
     return (conn && conn->quic_enabled) || (conn && conn->config && conn->config->quic_enabled);
 }
 
-bool s2n_connection_is_resumption_enabled(struct s2n_connection *conn)
+bool s2n_connection_is_client_resumption_enabled(struct s2n_connection *conn)
 {
-    return conn && conn->config->use_tickets;
+    return conn && conn->config && conn->config->use_tickets && conn->config->session_ticket_cb;
 }
 
 int s2n_connection_set_quic_transport_parameters(struct s2n_connection *conn,

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -54,9 +54,9 @@ bool s2n_connection_is_quic_enabled(struct s2n_connection *conn)
     return (conn && conn->quic_enabled) || (conn && conn->config && conn->config->quic_enabled);
 }
 
-bool s2n_connection_is_client_resumption_enabled(struct s2n_connection *conn)
+bool s2n_connection_is_resumption_enabled(struct s2n_connection *conn)
 {
-    return conn && conn->config && conn->config->use_tickets && conn->config->session_ticket_cb;
+    return conn && conn->config && conn->config->use_tickets;
 }
 
 int s2n_connection_set_quic_transport_parameters(struct s2n_connection *conn,

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -54,7 +54,7 @@ bool s2n_connection_is_quic_enabled(struct s2n_connection *conn)
     return (conn && conn->quic_enabled) || (conn && conn->config && conn->config->quic_enabled);
 }
 
-bool s2n_connection_is_resumption_enabled(struct s2n_connection *conn)
+bool s2n_connection_are_session_tickets_enabled(struct s2n_connection *conn)
 {
     return conn && conn->config && conn->config->use_tickets;
 }

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -54,6 +54,11 @@ bool s2n_connection_is_quic_enabled(struct s2n_connection *conn)
     return (conn && conn->quic_enabled) || (conn && conn->config && conn->config->quic_enabled);
 }
 
+bool s2n_connection_is_resumption_enabled(struct s2n_connection *conn)
+{
+    return conn && conn->config->use_tickets;
+}
+
 int s2n_connection_set_quic_transport_parameters(struct s2n_connection *conn,
         const uint8_t *data_buffer, uint16_t data_len)
 {

--- a/tls/s2n_quic_support.h
+++ b/tls/s2n_quic_support.h
@@ -32,7 +32,7 @@
 S2N_API int s2n_config_enable_quic(struct s2n_config *config);
 S2N_API int s2n_connection_enable_quic(struct s2n_connection *conn);
 S2N_API bool s2n_connection_is_quic_enabled(struct s2n_connection *conn);
-
+S2N_API bool s2n_connection_is_resumption_enabled(struct s2n_connection *conn);
 /*
  * Set the data to be sent in the quic_transport_parameters extension.
  * The data provided will be copied into a buffer owned by S2N.

--- a/tls/s2n_quic_support.h
+++ b/tls/s2n_quic_support.h
@@ -32,7 +32,8 @@
 S2N_API int s2n_config_enable_quic(struct s2n_config *config);
 S2N_API int s2n_connection_enable_quic(struct s2n_connection *conn);
 S2N_API bool s2n_connection_is_quic_enabled(struct s2n_connection *conn);
-S2N_API bool s2n_connection_is_resumption_enabled(struct s2n_connection *conn);
+S2N_API bool s2n_connection_are_session_tickets_enabled(struct s2n_connection *conn);
+
 /*
  * Set the data to be sent in the quic_transport_parameters extension.
  * The data provided will be copied into a buffer owned by S2N.

--- a/tls/s2n_quic_support.h
+++ b/tls/s2n_quic_support.h
@@ -32,7 +32,7 @@
 S2N_API int s2n_config_enable_quic(struct s2n_config *config);
 S2N_API int s2n_connection_enable_quic(struct s2n_connection *conn);
 S2N_API bool s2n_connection_is_quic_enabled(struct s2n_connection *conn);
-S2N_API bool s2n_connection_is_client_resumption_enabled(struct s2n_connection *conn);
+S2N_API bool s2n_connection_is_resumption_enabled(struct s2n_connection *conn);
 /*
  * Set the data to be sent in the quic_transport_parameters extension.
  * The data provided will be copied into a buffer owned by S2N.

--- a/tls/s2n_quic_support.h
+++ b/tls/s2n_quic_support.h
@@ -32,7 +32,7 @@
 S2N_API int s2n_config_enable_quic(struct s2n_config *config);
 S2N_API int s2n_connection_enable_quic(struct s2n_connection *conn);
 S2N_API bool s2n_connection_is_quic_enabled(struct s2n_connection *conn);
-S2N_API bool s2n_connection_is_resumption_enabled(struct s2n_connection *conn);
+S2N_API bool s2n_connection_is_client_resumption_enabled(struct s2n_connection *conn);
 /*
  * Set the data to be sent in the quic_transport_parameters extension.
  * The data provided will be copied into a buffer owned by S2N.


### PR DESCRIPTION
### Description of changes: 

Adds API to allow s2n-quic to check if it needs to keep around the TLS session instead of just tossing it after the handshake. Currently the TLS settings are mostly opaque to s2n-quic. However, if we want to keep the optimization of throwing out the TLS session when it isn't needed, quic needs to know if it should expect a session ticket.

### Callouts:

### Testing:

Does this need a test? I don't think so.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
