### PR TITLE
bug: Fixes mdbook action

### DIFF
--- a/.github/workflows/usage_guide.yml
+++ b/.github/workflows/usage_guide.yml
@@ -44,8 +44,8 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         if: github.event_name == 'push'
         with:
-          destination_dir: usage-guide
-          publish_dir: docs/usage-guide/book
+          target-folder: usage-guide
+          folder: docs/usage-guide/book
   
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4.0.1

--- a/docs/usage-guide/topics/ch01-api.md
+++ b/docs/usage-guide/topics/ch01-api.md
@@ -14,10 +14,6 @@ The [VERSIONING.rst](https://github.com/aws/s2n-tls/blob/main/VERSIONING.rst) do
 
 s2n-tls uses [Doxygen](https://doxygen.nl/index.html) to document its public API. The latest s2n-tls documentation can be found on [GitHub pages](https://aws.github.io/s2n-tls/doxygen/).
 
-Documentation for older versions or branches of s2n-tls can be generated locally. To generate the documentation, install doxygen and run `doxygen docs/doxygen/Doxyfile`. The doxygen documentation can now be found at `docs/doxygen/output/html/index.html`.
-
-Doxygen installation instructions are available at the [Doxygen](https://doxygen.nl/download.html) webpage.
-
 The doxygen documentation should be used in conjunction with this guide.
 
 ## Examples


### PR DESCRIPTION
### Description of changes: 

My previous mdbook PR[ didn't actually deploy the mdbook](https://github.com/aws/s2n-tls/blob/51c49fd1c7ea25345f95c5e7ccde4d67e4b1f8cc/.github/workflows/docs.yml#L31C15-L31C24) because I messed up the arguments for the github action 😮‍💨 . Here I am fixing this action and including a doc change in this PR so that the mdbook actually deploys (I'm not sure the action will trigger if the docs don't change, so I included a change that I've been meaning to make just to be sure.)

### Testing:

I tested this on my fork and the action does actually [complete this time](https://github.com/maddeleine/s2n/actions/runs/7452788104/job/20276797942). Although of course the push to S3 fails because my repo doesn't have credentials.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
