### PR TITLE
fix(bindings): remove optional cmake dependency

### DIFF
--- a/bindings/rust/s2n-tls-sys/build.rs
+++ b/bindings/rust/s2n-tls-sys/build.rs
@@ -97,10 +97,6 @@ fn build_vendored() {
         }
     }
 
-    if option_env("CARGO_FEATURE_PQ").is_none() {
-        build.define("S2N_NO_PQ", "1");
-    }
-
     let out_dir = PathBuf::from(env("OUT_DIR"));
 
     let features = FeatureDetector::new(&out_dir, &libcrypto);

--- a/bindings/rust/s2n-tls-sys/build.rs
+++ b/bindings/rust/s2n-tls-sys/build.rs
@@ -8,17 +8,6 @@ fn main() {
     if external.is_enabled() {
         external.link();
     } else {
-        #[cfg(feature = "cmake")]
-        {
-            // branch on a runtime value so we don't get unused code warnings
-            if option_env("CARGO_FEATURE_CMAKE").is_some() {
-                build_cmake();
-            } else {
-                build_vendored();
-            }
-        }
-
-        #[cfg(not(feature = "cmake"))]
         build_vendored();
     }
 }
@@ -93,26 +82,7 @@ fn build_vendored() {
 
     let mut build = builder(&libcrypto);
 
-    // TODO: update rust bindings to handle no pq-crypto dir
-
-    let pq = option_env("CARGO_FEATURE_PQ").is_some();
-
-    // TODO each pq section needs to be built separately since it
-    //      has its own relative include paths
-    assert!(!pq, "pq builds are not currently supported without cmake");
-
-    build.files(include!("./files.rs").iter().copied().filter(|file| {
-        // the pq entry file is still needed
-        if *file == "lib/pq-crypto/s2n_pq.c" {
-            return true;
-        }
-
-        if file.starts_with("lib/pq-crypto/") {
-            return pq;
-        }
-
-        true
-    }));
+    build.files(include!("./files.rs"));
 
     if env("PROFILE") == "release" {
         // fortify source is only available in release mode
@@ -127,7 +97,7 @@ fn build_vendored() {
         }
     }
 
-    if !pq {
+    if option_env("CARGO_FEATURE_PQ").is_none() {
         build.define("S2N_NO_PQ", "1");
     }
 
@@ -212,49 +182,6 @@ fn builder(libcrypto: &Libcrypto) -> cc::Build {
         .define("_POSIX_C_SOURCE", "200112L");
 
     build
-}
-
-#[cfg(feature = "cmake")]
-fn build_cmake() {
-    let mut config = cmake::Config::new("lib");
-
-    let libcrypto = Libcrypto::default();
-
-    config
-        .register_dep(&format!("aws_lc_{}", libcrypto.version))
-        .configure_arg("-DBUILD_TESTING=off");
-
-    if option_env("CARGO_FEATURE_PQ").is_none() {
-        config.configure_arg("-DS2N_NO_PQ=on");
-    }
-
-    let dst = config.build();
-
-    let lib = search(dst.join("lib64"))
-        .or_else(|| search(dst.join("lib")))
-        .or_else(|| search(dst.join("build").join("lib")))
-        .expect("could not build libs2n");
-
-    // link the built artifact
-    if lib.join("libs2n.a").exists() {
-        println!("cargo:rustc-link-lib=static=s2n");
-    } else {
-        println!("cargo:rustc-link-lib=s2n");
-    }
-
-    println!("cargo:include={}", dst.join("include").display());
-
-    // tell rust we're linking with libcrypto
-    println!("cargo:rustc-link-lib={}", libcrypto.link);
-
-    fn search(path: PathBuf) -> Option<PathBuf> {
-        if path.exists() {
-            println!("cargo:rustc-link-search={}", path.display());
-            Some(path)
-        } else {
-            None
-        }
-    }
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]

--- a/bindings/rust/s2n-tls-sys/templates/Cargo.template
+++ b/bindings/rust/s2n-tls-sys/templates/Cargo.template
@@ -24,8 +24,10 @@ include = [
 
 [features]
 default = []
+# preserve the cmake feature in case any consumers had it enabled before
+cmake = []
 quic = []
-pq = ["cmake"] # the pq build logic is complicated so just use cmake instead
+pq = []
 internal = []
 stacktrace = []
 <TOKEN_REPLACED_WITH_UNSTABLE_FEATURES>
@@ -38,7 +40,6 @@ libc = "0.2"
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
-cmake = { version = "0.1", optional = true }
 
 [dev-dependencies]
 jobserver = "=0.1.26" # newer versions require rust 1.66, see https://github.com/aws/s2n-tls/issues/4241


### PR DESCRIPTION
### Description of changes: 

In https://github.com/aws/s2n-tls/pull/4283 we removed the PQ implementation in favor of using the underlying libcrypto implementation. The Rust build logic wasn't updated as part of that PR, though.

This change fixes PQ builds for the Rust bindings by removing the `cmake` build entirely, which isn't needed anymore.

### Call-outs:

I've kept the `cmake` feature flag on the `s2n-tls-sys` crate, in case any customers were enabling it. But no one should notice that we aren't supporting building `cmake` anymore.

### Testing:

I've tested the change locally as well as the CI build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
