### PR TITLE
fix: stack-use-after-scope variable ordering

### DIFF
--- a/tls/s2n_ktls_io.c
+++ b/tls/s2n_ktls_io.c
@@ -423,6 +423,11 @@ ssize_t s2n_ktls_sendv_with_offset(struct s2n_connection *conn, const struct iov
     POSIX_GUARD_RESULT(s2n_sendv_with_offset_total_size(bufs, count_in, offs_in, &total_bytes));
     POSIX_GUARD_RESULT(s2n_ktls_check_estimated_record_limit(conn, total_bytes));
 
+    /* new_bufs_mem must be defined before new_bufs to avoid a
+     * stack-use-after-scope error when s2n_free_or_wipe is called.
+     * See https://github.com/aws/s2n-tls/issues/4354 for more context. This is
+     * enforced by our ASAN builds.
+     */
     uint8_t new_bufs_mem[S2N_MAX_STACK_IOVECS_MEM] = { 0 };
     DEFER_CLEANUP(struct s2n_blob new_bufs = { 0 }, s2n_free_or_wipe);
     POSIX_GUARD(s2n_blob_init(&new_bufs, new_bufs_mem, sizeof(new_bufs_mem)));

--- a/tls/s2n_ktls_io.c
+++ b/tls/s2n_ktls_io.c
@@ -423,11 +423,7 @@ ssize_t s2n_ktls_sendv_with_offset(struct s2n_connection *conn, const struct iov
     POSIX_GUARD_RESULT(s2n_sendv_with_offset_total_size(bufs, count_in, offs_in, &total_bytes));
     POSIX_GUARD_RESULT(s2n_ktls_check_estimated_record_limit(conn, total_bytes));
 
-    /* new_bufs_mem must be defined before new_bufs to avoid a
-     * stack-use-after-scope error when s2n_free_or_wipe is called.
-     * See https://github.com/aws/s2n-tls/issues/4354 for more context. This is
-     * enforced by our ASAN builds.
-     */
+    /* The order of new_bufs and new_bufs_mem matters. See https://github.com/aws/s2n-tls/issues/4354 */
     uint8_t new_bufs_mem[S2N_MAX_STACK_IOVECS_MEM] = { 0 };
     DEFER_CLEANUP(struct s2n_blob new_bufs = { 0 }, s2n_free_or_wipe);
     POSIX_GUARD(s2n_blob_init(&new_bufs, new_bufs_mem, sizeof(new_bufs_mem)));

--- a/tls/s2n_ktls_io.c
+++ b/tls/s2n_ktls_io.c
@@ -423,8 +423,8 @@ ssize_t s2n_ktls_sendv_with_offset(struct s2n_connection *conn, const struct iov
     POSIX_GUARD_RESULT(s2n_sendv_with_offset_total_size(bufs, count_in, offs_in, &total_bytes));
     POSIX_GUARD_RESULT(s2n_ktls_check_estimated_record_limit(conn, total_bytes));
 
-    DEFER_CLEANUP(struct s2n_blob new_bufs = { 0 }, s2n_free_or_wipe);
     uint8_t new_bufs_mem[S2N_MAX_STACK_IOVECS_MEM] = { 0 };
+    DEFER_CLEANUP(struct s2n_blob new_bufs = { 0 }, s2n_free_or_wipe);
     POSIX_GUARD(s2n_blob_init(&new_bufs, new_bufs_mem, sizeof(new_bufs_mem)));
     if (offs > 0) {
         POSIX_GUARD_RESULT(s2n_ktls_update_bufs_with_offset(&bufs, &count, offs, &new_bufs));


### PR DESCRIPTION
### Resolved issues:

#4354 

### Description of changes: 
```
Co-authored-by: Lindsay Stewart <slindsay@amazon.com>
```

When running with newer address sanitizers, ASAN detects a `stack-use-after-scope` variable ordering issue.

```
  This frame has 4 object(s):
    [32, 40) 'total_bytes' (line 422)
    [64, 88) 'new_bufs' (line 426)
    [128, 384) 'new_bufs_mem' (line 427) <== Memory access at offset 128 is inside this variable
    [448, 456) 'bytes_written' (line 433)
```
Sequence of events
1. `s2n_blob` `new_bufs` is defined
2. `new_bufs_mem` is defined
3. function finishes
4. `new_bufs_mem` goes out of scope first (because it was defined last)
5. `s2n_blob` `new_bufs` goes out of scope, triggering the DEFER_CLEANUP
6. this zeros the buffer of `new_bufs`, but that buffer (`new_bufs_mem`) is already out of scope

This commit switches the order of `new_bufs` and `new_bufs_mem` so that `new_bufs_mem` is still in scope when `s2n_free_or_wipe` accesses it.

### Call-outs:

This failure does reproduce in #4048. [build dashboard](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiZUNRMGVsWlRzOEZndkRTUHZ6Vk93Mlp1cnJYQzJBOUVDRHdaN1ZSNDE1RktMNjNIWHNYQVkwU01sdnBodWJVRW91ZDlqZzBlWUNRZGdQVGt6cEJvangxWEYwdzFBbXVVT00xMWJUb0Q4UHdsIiwiaXZQYXJhbWV0ZXJTcGVjIjoiWFQvNll0cFZOdmVsWGdVSyIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D) I cleaned up that PR and will be merging it after this fix is merged in.

### Testing:

Confirmed on local host that ASAN errors no longer occur. I then rebased this commit on the ASAN commit [branch](asan-and-stack-issue) and ran it under the new codebuild job to confirm that no errors were found.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
