### PR TITLE
bindings: clean up blinding tests

### DIFF
--- a/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/shutdown.rs
@@ -6,7 +6,7 @@ use s2n_tls_tokio::{TlsAcceptor, TlsConnector, TlsStream};
 use std::{convert::TryFrom, sync::Arc};
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
-    join, time,
+    time,
 };
 
 pub mod common;
@@ -157,7 +157,14 @@ async fn shutdown_with_blinding() -> Result<(), Box<dyn std::error::Error>> {
     let (mut client, mut server) =
         common::run_negotiate(&client, client_stream, &server, server_stream).await?;
 
-    // Trigger a blinded error for the server.
+    // Attempt to shutdown the client. This will eventually fail because the
+    // server has not written the close_notify message yet, but it will at least
+    // write the close_notify message that the server needs.
+    // Because time is mocked for testing, this does not actually take 10 minutes.
+    // TODO: replace this with a half-close once the bindings support half-close.
+    _ = time::timeout(time::Duration::from_secs(600), client.shutdown()).await;
+
+    // Setup a bad record for the next read
     overrides.next_read(Some(Box::new(|_, _, buf| {
         // Parsing the header is one of the blinded operations
         // in s2n_recv, so provide a malformed header.
@@ -165,26 +172,29 @@ async fn shutdown_with_blinding() -> Result<(), Box<dyn std::error::Error>> {
         buf.put_slice(&zeroed_header);
         Ok(()).into()
     })));
+
+    // Trigger the blinded error
     let mut received = [0; 1];
     let result = server.read_exact(&mut received).await;
     assert!(result.is_err());
 
-    // Shutdown MUST NOT complete faster than minimal blinding time.
-    let (timeout, _) = join!(
-        time::timeout(common::MIN_BLINDING_SECS, server.shutdown()),
-        time::timeout(common::MIN_BLINDING_SECS, read_until_shutdown(&mut client)),
-    );
-    assert!(timeout.is_err());
+    let time_start = time::Instant::now();
+    let result = server.shutdown().await;
+    let time_elapsed = time_start.elapsed();
 
-    // Shutdown MUST eventually complete after blinding.
-    //
-    // We check for completion, but not for success. At the moment, the
-    // call to s2n_shutdown will fail due to issues in the underlying C library.
-    let (timeout, _) = join!(
-        time::timeout(common::MAX_BLINDING_SECS, server.shutdown()),
-        time::timeout(common::MAX_BLINDING_SECS, read_until_shutdown(&mut client)),
-    );
-    assert!(timeout.is_ok());
+    // Shutdown MUST NOT complete faster than minimal blinding time.
+    assert!(time_elapsed > common::MIN_BLINDING_SECS);
+
+    // TODO: While the server SHOULD successfully shutdown, there is currently
+    // a C bug preventing it from doing so: https://github.com/aws/s2n-tls/pull/4350
+    let io_error = result.unwrap_err();
+    let error: error::Error = io_error.try_into()?;
+    assert!(error.kind() == error::ErrorType::IOError);
+    assert!(error.name() == "S2N_ERR_IO");
+
+    // Shutdown MUST have sent the close_notify message needed by the peer
+    // to also shutdown successfully.
+    client.shutdown().await?;
 
     Ok(())
 }
@@ -204,33 +214,31 @@ async fn shutdown_with_blinding_bad_close_record() -> Result<(), Box<dyn std::er
     let (mut client, mut server) =
         common::run_negotiate(&client, client_stream, &server, server_stream).await?;
 
-    // Turn the closure alert to a bad message
+    // Setup a bad record for the next read
     overrides.next_read(Some(Box::new(|_, _, buf| {
         // Parsing the header is one of the blinded operations
-        // in s2n_recv, so provide a malformed header.
+        // in s2n_shutdown, so provide a malformed header.
         let zeroed_header = [23, 0, 0, 0, 0];
         buf.put_slice(&zeroed_header);
         Ok(()).into()
     })));
 
-    // Shutdown MUST NOT complete faster than minimal blinding time.
-    let (timeout, _) = join!(
-        time::timeout(common::MIN_BLINDING_SECS, server.shutdown()),
-        time::timeout(common::MIN_BLINDING_SECS, read_until_shutdown(&mut client)),
-    );
-    assert!(timeout.is_err());
+    let time_start = time::Instant::now();
+    let result = server.shutdown().await;
+    let time_elapsed = time_start.elapsed();
 
-    // Shutdown MUST eventually complete after blinding.
-    //
-    // We check for completion, but not for success. At the moment, the
-    // call to s2n_shutdown will fail due to issues in the underlying C library.
-    let (timeout, _) = join!(
-        time::timeout(common::MAX_BLINDING_SECS, server.shutdown()),
-        time::timeout(common::MAX_BLINDING_SECS, read_until_shutdown(&mut client)),
-    );
-    // timeout should be OK, but shutdown should return an error because of
-    // the bad record.
-    assert!(matches!(timeout, Ok(Err(_))));
+    // Shutdown MUST NOT complete faster than minimal blinding time.
+    assert!(time_elapsed > common::MIN_BLINDING_SECS);
+
+    // Shutdown MUST eventually complete with the correct error after blinding.
+    let io_error = result.unwrap_err();
+    let error: error::Error = io_error.try_into()?;
+    assert!(error.kind() == error::ErrorType::ProtocolError);
+    assert!(error.name() == "S2N_ERR_BAD_MESSAGE");
+
+    // Shutdown MUST have sent the close_notify message needed by the peer
+    // to also shutdown successfully.
+    client.shutdown().await?;
 
     Ok(())
 }
@@ -247,10 +255,10 @@ async fn shutdown_with_poll_blinding() -> Result<(), Box<dyn std::error::Error>>
     let (server_stream, client_stream) = common::get_streams().await?;
     let server_stream = common::TestStream::new(server_stream);
     let overrides = server_stream.overrides();
-    let (mut client, mut server) =
+    let (_, mut server) =
         common::run_negotiate(&client, client_stream, &server, server_stream).await?;
 
-    // Trigger a blinded error for the server.
+    // Setup a bad record for the next read
     overrides.next_read(Some(Box::new(|_, _, buf| {
         // Parsing the header is one of the blinded operations
         // in s2n_recv, so provide a malformed header.
@@ -258,26 +266,21 @@ async fn shutdown_with_poll_blinding() -> Result<(), Box<dyn std::error::Error>>
         buf.put_slice(&zeroed_header);
         Ok(()).into()
     })));
+
+    // Trigger the blinded error
     let mut received = [0; 1];
     let result = server.read_exact(&mut received).await;
     assert!(result.is_err());
 
-    // poll_blinding MUST NOT complete faster than minimal blinding time.
-    let (timeout, _) = join!(
-        time::timeout(common::MIN_BLINDING_SECS, server.apply_blinding()),
-        time::timeout(common::MIN_BLINDING_SECS, read_until_shutdown(&mut client)),
-    );
-    assert!(timeout.is_err());
+    let time_start = time::Instant::now();
+    let result = server.apply_blinding().await;
+    let time_elapsed = time_start.elapsed();
 
-    // Shutdown MUST eventually complete after blinding.
-    //
-    // We check for completion, but not for success. At the moment, the
-    // call to s2n_shutdown will fail due to issues in the underlying C library.
-    let (timeout, _) = join!(
-        time::timeout(common::MAX_BLINDING_SECS, server.apply_blinding()),
-        time::timeout(common::MAX_BLINDING_SECS, read_until_shutdown(&mut client)),
-    );
-    assert!(timeout.is_ok());
+    // poll_blinding MUST NOT complete faster than minimal blinding time.
+    assert!(time_elapsed > common::MIN_BLINDING_SECS);
+
+    // poll_blinding MUST eventually complete
+    assert!(result.is_ok());
 
     Ok(())
 }


### PR DESCRIPTION
### Resolved issues:

Resolves https://github.com/aws/s2n-tls/issues/3976

### Description of changes: 
handshake_error_with_blinding sometimes failed. The sequence of events was:
* s2n_recv failed as intended, triggering blinding.
* shutdown waited 10-30 seconds for the blinding to expire. 
* shutdown tried to read the close_notify message but failed because of https://github.com/aws/s2n-tls/pull/4350. That failure triggered blinding again.
* shutdown waited 10-30 seconds for the blinding to expire.

handshake_error_with_blinding calls shutdown twice, once with a timeout of 10s and once with a timeout of 30s. That gives shutdown a total of 40s to complete both blindings. I'm honestly surprised it doesn't fail more often :)

I've rewritten the tests to be clearer and less reliant on timeouts. Each test now specifically times the execution of s2n_shutdown and makes assertions about its execution time and result. I'm also specifically checking for the correct errors to ensure we're not overlooking more issues like https://github.com/aws/s2n-tls/pull/4350.

I could also check that the time_elapsed doesn't exceed some upper bound (40s maybe? max blinding + safety margin for actual work), but I worry that has the potential to continue to be flaky if the environment introduces some delay. I think the combo of checking error types + testing both sources of blinding separately makes me pretty confident.

### Callouts:
This PR cleans up the tests, but does not fix https://github.com/aws/s2n-tls/pull/4350. They're really two different problems, so I'd like to fix them separately and not split reviewers' attention.

### Testing:
This change is nothing but tests.
I'm having trouble consistently reproing the flaky test failure in CI, but it failed frequently on my mac. After this change, I have seen zero failures on my mac, even after leaving it running in a loop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
