### PR TITLE
ktls: add method to track key updates

### DIFF
--- a/api/unstable/ktls.h
+++ b/api/unstable/ktls.h
@@ -102,6 +102,8 @@ S2N_API int s2n_connection_ktls_enable_recv(struct s2n_connection *conn);
  *
  * Enabling TLS1.3 with this method is considered "unsafe" because the kernel
  * currently doesn't support updating encryption keys, which is required in TLS1.3.
+ * s2n_connection_get_key_update_counts can be used to gather metrics on whether
+ * key updates are occurring on your connections before enabling TLS1.3.
  *
  * In order to safely enable TLS1.3, an application must ensure that its peer will
  * not send any KeyUpdate messages. If s2n-tls receives a KeyUpdate message while
@@ -118,6 +120,22 @@ S2N_API int s2n_connection_ktls_enable_recv(struct s2n_connection *conn);
  * @returns S2N_SUCCESS if successfully enabled, S2N_FAILURE otherwise.
  */
 S2N_API int s2n_config_ktls_enable_unsafe_tls13(struct s2n_config *config);
+
+/**
+ * Reports the number of times sending and receiving keys have been updated.
+ *
+ * This only applies to TLS1.3. Earlier versions do not support key updates.
+ *
+ * @warning s2n-tls only tracks up to UINT8_MAX (255) key updates. If this method
+ * reports 255 updates, then more than 255 updates may have occurred.
+ *
+ * @param conn A pointer to the connection.
+ * @param send_key_updates Number of times the sending key was updated.
+ * @param recv_key_updates Number of times the receiving key was updated.
+ * @returns S2N_SUCCESS if successful, S2N_FAILURE otherwise.
+ */
+S2N_API int s2n_connection_get_key_update_counts(struct s2n_connection *conn,
+        uint8_t *send_key_updates, uint8_t *recv_key_updates);
 
 /**
  * Sends the contents of a file as application data.

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1690,7 +1690,7 @@ S2N_RESULT s2n_connection_get_sequence_number(struct s2n_connection *conn,
     return S2N_RESULT_OK;
 }
 
-S2N_API int s2n_connection_get_key_update_counts(struct s2n_connection *conn,
+int s2n_connection_get_key_update_counts(struct s2n_connection *conn,
         uint8_t *send_key_updates, uint8_t *recv_key_updates)
 {
     POSIX_ENSURE_REF(conn);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -25,6 +25,8 @@
 #include <unistd.h>
 
 #include "api/s2n.h"
+/* Required for s2n_connection_get_key_update_counts */
+#include "api/unstable/ktls.h"
 #include "crypto/s2n_certificate.h"
 #include "crypto/s2n_cipher.h"
 #include "crypto/s2n_crypto.h"

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1689,3 +1689,14 @@ S2N_RESULT s2n_connection_get_sequence_number(struct s2n_connection *conn,
 
     return S2N_RESULT_OK;
 }
+
+S2N_API int s2n_connection_get_key_update_counts(struct s2n_connection *conn,
+        uint8_t *send_key_updates, uint8_t *recv_key_updates)
+{
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(send_key_updates);
+    POSIX_ENSURE_REF(recv_key_updates);
+    *send_key_updates = conn->send_key_updated;
+    *recv_key_updates = conn->recv_key_updated;
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -383,6 +383,10 @@ struct s2n_connection {
      * The writer clears it after a KeyUpdate is sent.
      */
     s2n_atomic_flag key_update_pending;
+
+    /* Track KeyUpdates for metrics */
+    uint8_t send_key_updated;
+    uint8_t recv_key_updated;
 };
 
 S2N_CLEANUP_RESULT s2n_connection_ptr_free(struct s2n_connection **s2n_connection);

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -182,12 +182,20 @@ int s2n_update_application_traffic_keys(struct s2n_connection *conn, s2n_mode mo
     s2n_tls13_key_blob(app_key, conn->secure->cipher_suite->record_alg->cipher->key_material_size);
 
     /* Derives next generation of traffic key */
+    uint8_t *count = NULL;
     POSIX_GUARD(s2n_tls13_derive_traffic_keys(&keys, &app_secret_update, &app_key, &app_iv));
     if (status == RECEIVING) {
         POSIX_GUARD(conn->secure->cipher_suite->record_alg->cipher->set_decryption_key(old_key, &app_key));
+        count = &conn->recv_key_updated;
     } else {
         POSIX_GUARD(conn->secure->cipher_suite->record_alg->cipher->set_encryption_key(old_key, &app_key));
+        count = &conn->send_key_updated;
     }
+
+    /* Increment the count.
+     * Don't treat overflows as errors-- we only do best-effort reporting.
+     */
+    *count = MIN(UINT8_MAX, *count + 1);
 
     /* According to https://tools.ietf.org/html/rfc8446#section-5.3:
      * Each sequence number is set to zero at the beginning of a connection and


### PR DESCRIPTION
### Description of changes: 
Add key update count tracking. A customer interesting in TLS1.3 + ktls wants to measure how often they currently update their keys.

I think it's safe to cap the fields at 255. We really don't expect any connections to get anywhere near that many updates. When awslc saw that many, it was because of a bug :) 255 key updates would be enough for using AES to send 50TB of data with average sized records or 100TB with maximum sized records. If I bumped the fields up to uint16_t, it'd be 12PB/25PB.

### Callouts:
I can see the argument that this method is pretty useless. If you don't control your clients, it's never going to be safe to assume that no clients will ever require a key update. But maybe the number is low enough that you're willing to take the availability hit? Minimally this should be unstable until we decide it's really necessary for ktls or find another use case.

### Testing:
Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
