### PR TITLE
feature: Use S2N_FAST_INTEG_TESTS to run pytest in parallel under nix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,6 +551,10 @@ if (BUILD_TESTING)
     if (S2N_INTEG_TESTS)
         find_package (Python3 COMPONENTS Interpreter Development)
         file(GLOB integv2_test_files "${PROJECT_SOURCE_DIR}/tests/integrationv2/test_*.py")
+        set(N 1)
+        if (S2N_FAST_INTEG_TESTS)
+            set(N auto)
+        endif()
         foreach(test_file_path ${integv2_test_files})
             get_filename_component(test_filename ${test_file_path} NAME_WE)
             string(REGEX REPLACE "^test_" "integrationv2_" test_target ${test_filename})
@@ -567,7 +571,7 @@ if (BUILD_TESTING)
                 add_test(NAME ${test_target}
                         COMMAND
                         pytest
-                        -x -n=1 --maxfail=1 --reruns=0 --cache-clear -rpfsq
+                        -x -n=${N} --maxfail=1 --reruns=0 --cache-clear -rpfsq
                         -o log_cli=true --log-cli-level=DEBUG --provider-version=$ENV{S2N_LIBCRYPTO}
                         --provider-criterion=off --fips-mode=0 --no-pq=0 ${test_file_path}
                         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/integrationv2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ option(S2N_STACKTRACE "Enables stacktrace functionality in s2n-tls. Note that th
 only available on platforms that support execinfo." ON)
 option(COVERAGE "Enable profiling collection for code coverage calculation" OFF)
 option(S2N_INTEG_TESTS "Enable the integrationv2 tests" OFF)
-option(S2N_FAST_INTEG_TESTS "Enable the integrationv2 with more parallelism, only has effect if S2N_INTEG_TESTS=ON" OFF)
+option(S2N_FAST_INTEG_TESTS "Enable the integrationv2 with more parallelism, only has effect if S2N_INTEG_TESTS=ON" ON)
 option(S2N_INSTALL_S2NC_S2ND "Install the binaries s2nc and s2nd" OFF)
 option(TSAN "Enable ThreadSanitizer to test thread safety" OFF)
 option(ASAN "Enable AddressSanitizer to test memory safety" OFF)


### PR DESCRIPTION
### Resolved issues:

https://github.com/aws/s2n-tls/issues/2469

### Description of changes: 

While we don't have a root-cause, there is anecdata that nix (newer toolchain) has a better record of running more than 2 integration test runners in parallel.  The original PR for nix contained a CMAKE flag to enable this, but [it was removed](https://github.com/aws/s2n-tls/pull/3897).

This PR adds it back in and turns on `S2N_FAST_INTEG_TESTS` by default, which currently only affects nix. The regular integration jobs are built with Make/tox and are pinned at [2 workers](https://github.com/aws/s2n-tls/blob/main/tests/integrationv2/tox.ini#L21)

Example use with it enabled by default (basically how CI works now):
```
nix develop
clean; configure; build; integ sni
```

Falling back to 1 xdist worker in nix:
```
nix develop
clean
S2N_CMAKE_OPTIONS="-DS2N_FAST_INTEG_TESTS=OFF" configure
build
integ sni
```

With "auto" as the `pytest xdist` runner count, the current batch of integration tests finish in 64 minutes vs. 2 hours with 4 workers [sample](https://us-east-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/Integv2NixBatchBF1FB83F-7tcZOiMDWPH0/batch/Integv2NixBatchBF1FB83F-7tcZOiMDWPH0%3Ad74418e1-850c-4381-9584-aafae05b60e0?region=us-east-2) - both only having 2 "waves".

### Call-outs:

The CMake section updated is specifically for Nix.
Not all of the current integration tests run successfully under nix.
Using a default xdist value of 1 could take upwards of 6 hours to finish an integration test run.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? Locally and ad-hoc CodeBuild.  CI run just verifies that no Makefile based integ tests are broken.

Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
