### PR TITLE
Fix initialization errors in unit tests

### DIFF
--- a/.github/s2n_osx.sh
+++ b/.github/s2n_osx.sh
@@ -28,3 +28,12 @@ cmake . -Bbuild -GNinja \
 
 cmake --build ./build -j $(nproc)
 time CTEST_PARALLEL_LEVEL=$(nproc) ninja -C build test
+
+# Build shared library
+cmake . -Bbuild -GNinja \
+-DCMAKE_BUILD_TYPE=Debug \
+-DCMAKE_PREFIX_PATH=${OPENSSL_1_1_1_INSTALL_DIR} .. \
+-DBUILD_SHARED_LIBS=ON
+
+cmake --build ./build -j $(nproc)
+time CTEST_PARALLEL_LEVEL=$(nproc) ninja -C build test

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -135,18 +135,41 @@ int s2n_mem_set_callbacks(s2n_mem_init_callback mem_init_callback, s2n_mem_clean
         s2n_mem_malloc_callback mem_malloc_callback, s2n_mem_free_callback mem_free_callback)
 {
     POSIX_ENSURE(!initialized, S2N_ERR_INITIALIZED);
+    POSIX_GUARD_RESULT(s2n_mem_override_callbacks(mem_init_callback, mem_cleanup_callback,
+            mem_malloc_callback, mem_free_callback));
+    return S2N_SUCCESS;
+}
 
-    POSIX_ENSURE_REF(mem_init_callback);
-    POSIX_ENSURE_REF(mem_cleanup_callback);
-    POSIX_ENSURE_REF(mem_malloc_callback);
-    POSIX_ENSURE_REF(mem_free_callback);
+S2N_RESULT s2n_mem_override_callbacks(s2n_mem_init_callback mem_init_callback, s2n_mem_cleanup_callback mem_cleanup_callback,
+        s2n_mem_malloc_callback mem_malloc_callback, s2n_mem_free_callback mem_free_callback)
+{
+    RESULT_ENSURE_REF(mem_init_callback);
+    RESULT_ENSURE_REF(mem_cleanup_callback);
+    RESULT_ENSURE_REF(mem_malloc_callback);
+    RESULT_ENSURE_REF(mem_free_callback);
 
     s2n_mem_init_cb = mem_init_callback;
     s2n_mem_cleanup_cb = mem_cleanup_callback;
     s2n_mem_malloc_cb = mem_malloc_callback;
     s2n_mem_free_cb = mem_free_callback;
 
-    return S2N_SUCCESS;
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_mem_get_callbacks(s2n_mem_init_callback *mem_init_callback, s2n_mem_cleanup_callback *mem_cleanup_callback,
+        s2n_mem_malloc_callback *mem_malloc_callback, s2n_mem_free_callback *mem_free_callback)
+{
+    RESULT_ENSURE_REF(mem_init_callback);
+    RESULT_ENSURE_REF(mem_cleanup_callback);
+    RESULT_ENSURE_REF(mem_malloc_callback);
+    RESULT_ENSURE_REF(mem_free_callback);
+
+    *mem_init_callback = s2n_mem_init_cb;
+    *mem_cleanup_callback = s2n_mem_cleanup_cb;
+    *mem_malloc_callback = s2n_mem_malloc_cb;
+    *mem_free_callback = s2n_mem_free_cb;
+
+    return S2N_RESULT_OK;
 }
 
 int s2n_alloc(struct s2n_blob *b, uint32_t size)

--- a/utils/s2n_mem.h
+++ b/utils/s2n_mem.h
@@ -44,3 +44,8 @@ int s2n_dup(struct s2n_blob *from, struct s2n_blob *to);
  * Prefer s2n_free. Only use this method if completely necessary.
  */
 int s2n_free_or_wipe(struct s2n_blob *b);
+
+S2N_RESULT s2n_mem_override_callbacks(s2n_mem_init_callback mem_init_callback, s2n_mem_cleanup_callback mem_cleanup_callback,
+        s2n_mem_malloc_callback mem_malloc_callback, s2n_mem_free_callback mem_free_callback);
+S2N_RESULT s2n_mem_get_callbacks(s2n_mem_init_callback *mem_init_callback, s2n_mem_cleanup_callback *mem_cleanup_callback,
+        s2n_mem_malloc_callback *mem_malloc_callback, s2n_mem_free_callback *mem_free_callback);


### PR DESCRIPTION
### Resolved issues:

Resolves https://github.com/aws/s2n-tls/issues/4204.

### Description of changes: 

In some environments, some unit tests currently error with `s2n not initialized` when linked to the shared library of s2n-tls. For example, see the [the result of this GH action](https://github.com/aws/s2n-tls/actions/runs/7575957607/job/20633716787?pr=4370) that builds s2n-tls with a shared library on macOS before this fix was applied.

This error is due to including `utils/s2n_mem.c` in .c files:
https://github.com/aws/s2n-tls/blob/7f84701e4efef70f65d7f0208d190f440f5b7a37/tests/testlib/s2n_mem_testlib.c#L20-L21

When `s2n_init()` is called, `initialized` in `s2m_mem.c` is set to `true` in `s2n_mem_init()`:
https://github.com/aws/s2n-tls/blob/7f84701e4efef70f65d7f0208d190f440f5b7a37/utils/s2n_mem.c#L249-L253

When `s2n_mem.c` is included from a .c file, this seems to cause `initialized` to be set to false when checked by functions such as `s2n_free_without_wipe()`, which is causing unit tests to incorrectly fail:
https://github.com/aws/s2n-tls/blob/7f84701e4efef70f65d7f0208d190f440f5b7a37/utils/s2n_mem.c#L287-L291 

This PR removes the `s2n_mem.c` include from .c files, and instead uses new get/override functions to get and set the mem callbacks.

### Testing:

I modified the macOS GH action to additionally build and test the s2n-tls shared library, which [fails without this fix](https://github.com/aws/s2n-tls/actions/runs/7575957607/job/20633716787?pr=4370).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
