### PR TITLE
allows cmake to force crypto linkage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ option(COVERAGE "Enable profiling collection for code coverage calculation" OFF)
 option(S2N_INTEG_TESTS "Enable the integrationv2 tests" OFF)
 option(S2N_FAST_INTEG_TESTS "Enable the integrationv2 with more parallelism, only has effect if S2N_INTEG_TESTS=ON" ON)
 option(S2N_INSTALL_S2NC_S2ND "Install the binaries s2nc and s2nd" OFF)
+option(S2N_USE_CRYPTO_SHARED_LIBS "For S2N to use shared libs in Findcrypto" OFF)
 option(TSAN "Enable ThreadSanitizer to test thread safety" OFF)
 option(ASAN "Enable AddressSanitizer to test memory safety" OFF)
 

--- a/cmake/modules/Findcrypto.cmake
+++ b/cmake/modules/Findcrypto.cmake
@@ -56,7 +56,7 @@ else()
     )
 
     if (NOT crypto_LIBRARY)
-        if (BUILD_SHARED_LIBS)
+        if (BUILD_SHARED_LIBS OR S2N_USE_CRYPTO_SHARED_LIBS)
             if (crypto_SHARED_LIBRARY)
                 set(crypto_LIBRARY ${crypto_SHARED_LIBRARY})
             else()


### PR DESCRIPTION
### Description of changes: 

Describe s2n’s current behavior and how your code changes that behavior. If there are no issues this PR is resolving, explain why this change is necessary.

This mirrors the [AWS C++ SDK's PR](https://github.com/aws/aws-sdk-cpp/pull/2829) that uses the same `FindCrypto` module. There is a user that wants to be able to control static linkage outside of the `BUILD_SHARED_LIBS` variable and force using a dynamic libcrypto while setting `BUILD_SHARED_LIBS` to `OFF` this will check two new variables `FORCE_SHARED_CRYPTO` and `FORCE_STATIC_CRYPTO` to force the usage of the corresponding library.

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? 

N/A

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

I tested locally to verify that when using the cpp sdk that the correct crypto was used in linking.

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
