### PR TITLE
enforce result checking for blob and mem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,7 +500,7 @@ if (BUILD_TESTING)
                   find . -name '${test_case_name}.c.o' -exec objcopy --redefine-syms libcrypto.symbols {} \\\;
             )
         endif()
-        target_compile_options(${test_case_name} PRIVATE -Wno-implicit-function-declaration -Wno-deprecated -D_POSIX_C_SOURCE=200809L -std=gnu99)
+        target_compile_options(${test_case_name} PRIVATE -Wno-implicit-function-declaration -Wno-deprecated -Wunused-result -D_POSIX_C_SOURCE=200809L -std=gnu99)
         if (S2N_LTO)
             target_compile_options(${test_case_name} PRIVATE -flto)
         endif()

--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -371,7 +371,7 @@ int main(int argc, char **argv)
             struct s2n_stuffer io_stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_init(&io_stuffer, &io_blob));
 
-            s2n_alloc(&(kem_params.private_key), TEST_PRIVATE_KEY_LENGTH);
+            EXPECT_SUCCESS(s2n_alloc(&(kem_params.private_key), TEST_PRIVATE_KEY_LENGTH));
             POSIX_CHECKED_MEMCPY(kem_params.private_key.data, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LENGTH);
 
             /* {0, 5} = length of ciphertext to follow

--- a/tests/unit/s2n_self_talk_nonblocking_test.c
+++ b/tests/unit/s2n_self_talk_nonblocking_test.c
@@ -221,7 +221,7 @@ int test_send(int use_tls13, int use_iov, int prefer_throughput)
     struct iovec *iov = NULL;
     if (!use_iov) {
         data_size = 10000000;
-        s2n_alloc(&blob, data_size);
+        EXPECT_SUCCESS(s2n_alloc(&blob, data_size));
         EXPECT_OK(s2n_get_public_random_data(&blob));
     } else {
         iov = malloc(sizeof(*iov) * iov_size);

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -191,7 +191,7 @@ int main(int argc, char **argv)
 
             struct s2n_cert_chain_and_key fake_chain_and_key = { 0 };
             static uint8_t sct_list[] = { 0xff, 0xff, 0xff };
-            s2n_blob_init(&fake_chain_and_key.sct_list, sct_list, sizeof(sct_list));
+            EXPECT_SUCCESS(s2n_blob_init(&fake_chain_and_key.sct_list, sct_list, sizeof(sct_list)));
 
             conn->ct_level_requested = S2N_CT_SUPPORT_REQUEST;
             conn->handshake_params.our_chain_and_key = &fake_chain_and_key;
@@ -221,7 +221,7 @@ int main(int argc, char **argv)
 
             struct s2n_cert_chain_and_key fake_chain_and_key = { 0 };
             static uint8_t fake_ocsp[] = { 0xff, 0xff, 0xff };
-            s2n_blob_init(&fake_chain_and_key.ocsp_status, fake_ocsp, sizeof(fake_ocsp));
+            EXPECT_SUCCESS(s2n_blob_init(&fake_chain_and_key.ocsp_status, fake_ocsp, sizeof(fake_ocsp)));
 
             conn->status_type = S2N_STATUS_REQUEST_OCSP;
             conn->handshake_params.our_chain_and_key = &fake_chain_and_key;
@@ -549,7 +549,7 @@ int main(int argc, char **argv)
 
         struct s2n_cert_chain_and_key fake_chain_and_key = { 0 };
         static uint8_t fake_ocsp[] = { 0xff, 0xff, 0xff };
-        s2n_blob_init(&fake_chain_and_key.ocsp_status, fake_ocsp, sizeof(fake_ocsp));
+        EXPECT_SUCCESS(s2n_blob_init(&fake_chain_and_key.ocsp_status, fake_ocsp, sizeof(fake_ocsp)));
 
         /* For our test status_request extension */
         server_conn->status_type = S2N_STATUS_REQUEST_OCSP;

--- a/tls/s2n_client_finished.c
+++ b/tls/s2n_client_finished.c
@@ -57,7 +57,7 @@ int s2n_tls13_client_finished_recv(struct s2n_connection *conn)
 
     /* read finished mac from handshake */
     struct s2n_blob wire_finished_mac = { 0 };
-    s2n_blob_init(&wire_finished_mac, s2n_stuffer_raw_read(&conn->handshake.io, length), length);
+    POSIX_GUARD(s2n_blob_init(&wire_finished_mac, s2n_stuffer_raw_read(&conn->handshake.io, length), length));
 
     /* get tls13 keys */
     s2n_tls13_connection_keys(keys, conn);

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -401,7 +401,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
     /* If we're AEAD, write the sequence number as an IV, and generate the AAD */
     if (cipher_suite->record_alg->cipher->type == S2N_AEAD) {
         struct s2n_stuffer iv_stuffer = { 0 };
-        s2n_blob_init(&iv, aad_iv, sizeof(aad_iv));
+        POSIX_GUARD(s2n_blob_init(&iv, aad_iv, sizeof(aad_iv)));
         POSIX_GUARD(s2n_stuffer_init(&iv_stuffer, &iv));
 
         if (cipher_suite->record_alg->flags & S2N_TLS12_AES_GCM_AEAD_NONCE) {
@@ -429,7 +429,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
             POSIX_GUARD_RESULT(s2n_aead_aad_init(conn, sequence_number, content_type, data_bytes_to_take, &aad));
         }
     } else if (cipher_suite->record_alg->cipher->type == S2N_CBC || cipher_suite->record_alg->cipher->type == S2N_COMPOSITE) {
-        s2n_blob_init(&iv, implicit_iv, block_size);
+        POSIX_GUARD(s2n_blob_init(&iv, implicit_iv, block_size));
 
         /* For TLS1.1/1.2; write the IV with random data */
         if (conn->actual_protocol_version > S2N_TLS10) {

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -844,7 +844,7 @@ int s2n_decrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *
 
     POSIX_GUARD(s2n_stuffer_read(from, &iv));
 
-    s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN);
+    POSIX_GUARD(s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN));
     POSIX_GUARD(s2n_session_key_alloc(&aes_ticket_key));
     POSIX_GUARD(s2n_aes256_gcm.init(&aes_ticket_key));
     POSIX_GUARD(s2n_aes256_gcm.set_decryption_key(&aes_ticket_key, &aes_key_blob));
@@ -925,7 +925,7 @@ int s2n_decrypt_session_cache(struct s2n_connection *conn, struct s2n_stuffer *f
 
     POSIX_GUARD(s2n_stuffer_read(from, &iv));
 
-    s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN);
+    POSIX_GUARD(s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN));
     POSIX_GUARD(s2n_session_key_alloc(&aes_ticket_key));
     POSIX_GUARD(s2n_aes256_gcm.init(&aes_ticket_key));
     POSIX_GUARD(s2n_aes256_gcm.set_decryption_key(&aes_ticket_key, &aes_key_blob));

--- a/tls/s2n_server_finished.c
+++ b/tls/s2n_server_finished.c
@@ -86,7 +86,7 @@ int s2n_tls13_server_finished_recv(struct s2n_connection *conn)
 
     /* read finished mac from handshake */
     struct s2n_blob wire_finished_mac = { 0 };
-    s2n_blob_init(&wire_finished_mac, s2n_stuffer_raw_read(&conn->handshake.io, length), length);
+    POSIX_GUARD(s2n_blob_init(&wire_finished_mac, s2n_stuffer_raw_read(&conn->handshake.io, length), length));
 
     /* get tls13 keys */
     s2n_tls13_connection_keys(keys, conn);

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -40,11 +40,11 @@ struct s2n_blob {
 
 bool s2n_blob_is_growable(const struct s2n_blob *b);
 S2N_RESULT s2n_blob_validate(const struct s2n_blob *b);
-int s2n_blob_init(struct s2n_blob *b, uint8_t *data, uint32_t size);
-int s2n_blob_zero(struct s2n_blob *b);
-int s2n_blob_char_to_lower(struct s2n_blob *b);
-int s2n_hex_string_to_bytes(const uint8_t *str, struct s2n_blob *blob);
-int s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint32_t offset, uint32_t size);
+int S2N_RESULT_MUST_USE s2n_blob_init(struct s2n_blob *b, uint8_t *data, uint32_t size);
+int S2N_RESULT_MUST_USE s2n_blob_zero(struct s2n_blob *b);
+int S2N_RESULT_MUST_USE s2n_blob_char_to_lower(struct s2n_blob *b);
+int S2N_RESULT_MUST_USE s2n_hex_string_to_bytes(const uint8_t *str, struct s2n_blob *blob);
+int S2N_RESULT_MUST_USE s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint32_t offset, uint32_t size);
 
 #define s2n_stack_blob(name, requested_size, maximum)   \
     size_t name##_requested_size = (requested_size);    \

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -41,7 +41,7 @@ struct s2n_blob {
 bool s2n_blob_is_growable(const struct s2n_blob *b);
 S2N_RESULT s2n_blob_validate(const struct s2n_blob *b);
 int S2N_RESULT_MUST_USE s2n_blob_init(struct s2n_blob *b, uint8_t *data, uint32_t size);
-int S2N_RESULT_MUST_USE s2n_blob_zero(struct s2n_blob *b);
+int s2n_blob_zero(struct s2n_blob *b);
 int S2N_RESULT_MUST_USE s2n_blob_char_to_lower(struct s2n_blob *b);
 int S2N_RESULT_MUST_USE s2n_hex_string_to_bytes(const uint8_t *str, struct s2n_blob *blob);
 int S2N_RESULT_MUST_USE s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint32_t offset, uint32_t size);

--- a/utils/s2n_mem.h
+++ b/utils/s2n_mem.h
@@ -28,12 +28,12 @@ int s2n_mem_cleanup(void);
  * Generally, s2n_realloc is preferred over s2n_alloc. This is because calling
  * s2n_alloc on a blob that already has memory allocated will leak memory.
 */
-int s2n_alloc(struct s2n_blob *b, uint32_t size);
-int s2n_realloc(struct s2n_blob *b, uint32_t size);
+int S2N_RESULT_MUST_USE s2n_alloc(struct s2n_blob *b, uint32_t size);
+int S2N_RESULT_MUST_USE s2n_realloc(struct s2n_blob *b, uint32_t size);
 int s2n_free(struct s2n_blob *b);
 int s2n_free_without_wipe(struct s2n_blob *b);
 int s2n_free_object(uint8_t **p_data, uint32_t size);
-int s2n_dup(struct s2n_blob *from, struct s2n_blob *to);
+int S2N_RESULT_MUST_USE s2n_dup(struct s2n_blob *from, struct s2n_blob *to);
 
 /* Unlike free, s2n_free_or_wipe accepts static blobs.
  * It frees allocated blobs and wipes static blobs.


### PR DESCRIPTION
### Description of changes: 

s2n-tls has strict standard for checking the results of functions, but we rely on contributors remembering to check all of these values. This PR adds "must use" attributes to emit warnings when these conventions are not followed, and also fixed all of those warning that currently exist in our codebase.

### Call-outs:

We should probably be adding `MUST_USE` in more places. Additionally, we should consider `Werror` for unit tests, but we need to fix the remaining `enum-conversion` warning in `s2n_signature_algorithms_test.c` before doing that.

Ideally we'd switch everything to S2N_RESULT, but that is a much larger effort. This PR instead aims for incremental progress.

`s2n_blob_zero` does not force usage of the return result because it is used in DEFER_CLEANUP's in a few places.

### Testing:

I manually added the `-Werror` flag to our unit tests and then fixed all failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
