### PR TITLE
ci: Add some pytest marks and reporting.

### DIFF
--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -69,6 +69,19 @@ function integ {
     fi
 }
 
+function pytestmark_report {
+    # Basically a pytest dry-run, showing which tests will run with a given mark and which ones will not.
+    if [[ -z "$1" ]]; then
+        echo -e "\nUsage: pytest_report <pytest mark>\n"
+        echo -e "This function runs pytest in a dry-run mode,showing a high level \ncount of tests that would run with and without a certain mark.\n" 
+    else
+        banner "Tests with the $1 mark"
+        pytest -n auto -m $1 --provider-version=$S2N_LIBCRYPTO --provider-criterion=off --fips-mode=0 --no-pq=0 --collect-only -qq $SRC_ROOT/tests/integrationv2;
+        banner "Tests without the $1 mark"
+        pytest -n auto -m "not $1" --provider-version=$S2N_LIBCRYPTO --provider-criterion=off --fips-mode=0 --no-pq=0 --collect-only -qq $SRC_ROOT/tests/integrationv2;
+    fi
+}
+
 function check-clang-format {
     banner "Dry run of clang-format"
     (cd $SRC_ROOT;

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -44,7 +44,7 @@ class AvailablePorts(object):
     """
 
     def __init__(self, low=8000, high=30000):
-        worker_count = int(os.getenv('PYTEST_XDIST_WORKER_COUNT'))
+        worker_count = int(os.getenv('PYTEST_XDIST_WORKER_COUNT',1))
         chunk_size = int((high - low) / worker_count)
 
         # If xdist is being used, parse the workerid from the envvar. This can

--- a/tests/integrationv2/conftest.py
+++ b/tests/integrationv2/conftest.py
@@ -20,6 +20,9 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "uncollect_if(*, func): function to unselect tests from parametrization"
     )
+    config.addinivalue_line(
+        "markers", "nix: test is expected to pass on nix."
+    )
 
     no_pq = config.getoption('no-pq', 0)
     fips_mode = config.getoption('fips-mode', 0)

--- a/tests/integrationv2/test_buffered_send.py
+++ b/tests/integrationv2/test_buffered_send.py
@@ -36,6 +36,7 @@ FRAGMENT_PREFERENCE = [
 ]
 
 
+@pytest.mark.nix
 def test_SEND_BUFFER_SIZE_MIN_is_s2ns_min_buffer_size(managed_process):
     port = next(available_ports)
 
@@ -58,6 +59,7 @@ def test_SEND_BUFFER_SIZE_MIN_is_s2ns_min_buffer_size(managed_process):
         assert results.exit_code != 0
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [GnuTLS, OpenSSL, S2N], ids=get_parameter_name)
@@ -111,6 +113,7 @@ def test_s2n_server_buffered_send(managed_process, cipher, provider, protocol, c
         results.assert_success()
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [S2N, OpenSSL], ids=get_parameter_name)

--- a/tests/integrationv2/test_client_authentication.py
+++ b/tests/integrationv2/test_client_authentication.py
@@ -38,6 +38,7 @@ def assert_s2n_handshake_complete(results, protocol, provider, is_complete=True)
             expected_version)) not in results.stdout
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
@@ -86,6 +87,7 @@ def test_client_auth_with_s2n_server(managed_process, provider, other_provider, 
         assert random_bytes in results.stdout
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
@@ -140,6 +142,7 @@ def test_client_auth_with_s2n_server_using_nonmatching_certs(managed_process, pr
         assert_s2n_handshake_complete(results, protocol, provider, False)
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
@@ -186,6 +189,7 @@ def test_client_auth_with_s2n_client_no_cert(managed_process, provider, other_pr
             assert_s2n_handshake_complete(results, protocol, provider, False)
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
@@ -245,6 +249,7 @@ TLS1.3, even if its security policy would normally allow TLS1.3.
 """
 
 
+@pytest.mark.nix
 @pytest.mark.parametrize("certificate", [Certificates.RSA_2048_PKCS1, Certificates.ECDSA_256], ids=get_parameter_name)
 def test_tls_12_client_auth_downgrade(managed_process, certificate):
     port = next(available_ports)

--- a/tests/integrationv2/test_early_data.py
+++ b/tests/integrationv2/test_early_data.py
@@ -137,6 +137,7 @@ def get_ticket_from_s2n_server(options, managed_process, provider, certificate):
     assert os.path.exists(options.ticket_file)
 
 
+@pytest.mark.nix
 def test_nothing():
     """
     Sometimes the early data test parameters in combination with the s2n libcrypto
@@ -154,6 +155,7 @@ then another resumption connection with early data.
 """
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -212,6 +214,7 @@ That means we don't need to manually perform the initial full connection, and th
 """
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
@@ -267,6 +270,7 @@ test_session_resumption but with validation that no early data is sent.
 """
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
@@ -324,6 +328,7 @@ reconnects automatically, without any mechanism to modify the connection in betw
 """
 
 
+@pytest.mark.nix
 @pytest.mark.flaky(reruns=5)
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
@@ -384,6 +389,7 @@ does not send key shares for.
 """
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", S2N_HRR_CURVES, ids=get_parameter_name)
@@ -446,6 +452,7 @@ S2N doesn't support while still supporting at least one curve S2N does support.
 """
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -502,6 +509,7 @@ Test the S2N server fails if it receives too much early data.
 """
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)

--- a/tests/integrationv2/test_fragmentation.py
+++ b/tests/integrationv2/test_fragmentation.py
@@ -20,6 +20,7 @@ CERTIFICATES_TO_TEST = [
 ]
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", CIPHERS_TO_TEST, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL, GnuTLS], ids=get_parameter_name)
@@ -77,6 +78,7 @@ def invalid_test_parameters_frag_len(*args, **kwargs):
     return invalid_test_parameters(*args, **kwargs)
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters_frag_len)
 @pytest.mark.parametrize("cipher", CIPHERS_TO_TEST, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL, GnuTLS], ids=get_parameter_name)

--- a/tests/integrationv2/test_hello_retry_requests.py
+++ b/tests/integrationv2/test_hello_retry_requests.py
@@ -20,6 +20,7 @@ CURVE_NAMES = {
 }
 
 
+@pytest.mark.nix
 def test_nothing():
     """
     Sometimes the hello retry test parameters in combination with the s2n libcrypto
@@ -29,6 +30,7 @@ def test_nothing():
     assert True
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL])
@@ -84,6 +86,7 @@ def test_hrr_with_s2n_as_client(managed_process, cipher, provider, other_provide
         assert random_bytes in results.stdout
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL])
@@ -148,6 +151,7 @@ def test_hrr_with_s2n_as_server(managed_process, cipher, provider, other_provide
 TEST_CURVES = ALL_TEST_CURVES[1:]
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL])

--- a/tests/integrationv2/test_key_update.py
+++ b/tests/integrationv2/test_key_update.py
@@ -8,6 +8,7 @@ from providers import Provider, S2N, OpenSSL
 from utils import invalid_test_parameters, get_parameter_name
 
 
+@pytest.mark.nix
 def test_nothing():
     """
     Sometimes the key update test parameters in combination with the s2n libcrypto
@@ -17,6 +18,7 @@ def test_nothing():
     assert True
 
 
+@pytest.mark.nix
 @pytest.mark.flaky(reruns=5)
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
@@ -73,6 +75,7 @@ def test_s2n_server_key_update(managed_process, cipher, provider, other_provider
         assert client_data in results.stdout
 
 
+@pytest.mark.nix
 @pytest.mark.flaky(reruns=5)
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)

--- a/tests/integrationv2/test_npn.py
+++ b/tests/integrationv2/test_npn.py
@@ -59,6 +59,7 @@ The s2n-tls client successfully negotiates an application protocol using NPN.
 """
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -86,6 +87,7 @@ The s2n-tls client chooses a server-preferred protocol.
 """
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -113,6 +115,7 @@ The s2n-tls client chooses its preferred protocol since there is no overlap.
 """
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -167,6 +170,7 @@ The s2n-tls server successfully negotiates an application protocol using NPN.
 """
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -198,6 +202,7 @@ the client chooses its own protocol.
 """
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)

--- a/tests/integrationv2/test_ocsp.py
+++ b/tests/integrationv2/test_ocsp.py
@@ -12,6 +12,7 @@ from global_flags import get_flag, S2N_PROVIDER_VERSION
 OCSP_CERTS = [Certificates.OCSP, Certificates.OCSP_ECDSA]
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [S2N, OpenSSL, GnuTLS], ids=get_parameter_name)
@@ -74,6 +75,7 @@ def test_s2n_client_ocsp_response(managed_process, cipher, provider, other_provi
         assert random_bytes[1:] in server_results.stdout or random_bytes[1:] in server_results.stderr
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [GnuTLS, OpenSSL], ids=get_parameter_name)

--- a/tests/integrationv2/test_pq_handshake.py
+++ b/tests/integrationv2/test_pq_handshake.py
@@ -204,6 +204,7 @@ def test_nothing():
     assert True
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_pq_handshake_test_parameters)
 @pytest.mark.parametrize("protocol", [Protocols.TLS12, Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", [Certificates.RSA_4096_SHA512], ids=get_parameter_name)

--- a/tests/integrationv2/test_record_padding.py
+++ b/tests/integrationv2/test_record_padding.py
@@ -70,6 +70,7 @@ def test_nothing():
     assert True
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL])

--- a/tests/integrationv2/test_renegotiate.py
+++ b/tests/integrationv2/test_renegotiate.py
@@ -207,6 +207,7 @@ This tests the default behavior for customers who do not enable renegotiation.
 """
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -235,6 +236,7 @@ Renegotiation request rejected by s2n-tls client.
 """
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -260,6 +262,7 @@ Renegotiation request accepted by s2n-tls client.
 """
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -292,6 +295,7 @@ but does require client auth during the second handshake.
 """
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -341,6 +345,7 @@ The s2n-tls client successfully reads ApplicationData during the renegotiation h
 """
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)

--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -9,6 +9,7 @@ from providers import Provider, S2N, OpenSSL
 from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -56,6 +57,7 @@ def test_session_resumption_s2n_server(managed_process, cipher, curve, certifica
             to_bytes("Actual protocol version: {}".format(expected_version))) == 6
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -101,6 +103,7 @@ def test_session_resumption_s2n_client(managed_process, cipher, curve, protocol,
         assert results.stdout.count(to_bytes("6 server accepts that finished"))
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -180,6 +183,7 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
             s2n_version)) in results.stdout
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -243,6 +247,7 @@ def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, cer
                 b'SSL_accept:SSLv3/TLS write certificate') == num_full_connections
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -322,6 +327,7 @@ def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, c
             s2n_version)) in results.stdout
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)

--- a/tests/integrationv2/test_signature_algorithms.py
+++ b/tests/integrationv2/test_signature_algorithms.py
@@ -68,6 +68,7 @@ def skip_ciphers(*args, **kwargs):
     return invalid_test_parameters(*args, **kwargs)
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=skip_ciphers)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL, GnuTLS])

--- a/tests/integrationv2/test_sni_match.py
+++ b/tests/integrationv2/test_sni_match.py
@@ -26,6 +26,7 @@ def filter_cipher_list(*args, **kwargs):
     return invalid_test_parameters(*args, **kwargs)
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=filter_cipher_list)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)

--- a/tests/integrationv2/test_version_negotiation.py
+++ b/tests/integrationv2/test_version_negotiation.py
@@ -9,6 +9,7 @@ from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_
     to_bytes, get_expected_gnutls_version
 
 
+@pytest.mark.nix
 def test_nothing():
     """
     Sometimes the version negotiation test parameters in combination with the s2n
@@ -29,6 +30,7 @@ def invalid_version_negotiation_test_parameters(*args, **kwargs):
     return invalid_test_parameters(*args, **kwargs)
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_version_negotiation_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -92,6 +94,7 @@ def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, certificate
         ])
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_version_negotiation_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)

--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -85,6 +85,7 @@ else:
     }
 
 
+@pytest.mark.nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("endpoint", ENDPOINTS, ids=get_parameter_name)


### PR DESCRIPTION
### Resolved issues:

none

### Description of changes: 

While sorting out the integration tests needing attention when running in a nix environment, we were looking for a way to track what's left.  Using pytest's [mark](https://docs.pytest.org/en/latest/how-to/mark.html) feature, simply as a reporting mechanism is helpful.  This PR is intended to spark discussion about the use of marks.

Sample output
```
>nix develop
>pytestmark_report nix
+---------------------------------------------------------+
| Tests with the nix mark                                 |
+---------------------------------------------------------+
tests/integrationv2/test_buffered_send.py: 7651
tests/integrationv2/test_client_authentication.py: 1308
tests/integrationv2/test_early_data.py: 3964
tests/integrationv2/test_fragmentation.py: 72
tests/integrationv2/test_hello_retry_requests.py: 457
tests/integrationv2/test_key_update.py: 7
tests/integrationv2/test_npn.py: 1010
tests/integrationv2/test_ocsp.py: 576
tests/integrationv2/test_pq_handshake.py: 82
tests/integrationv2/test_record_padding.py: 126
tests/integrationv2/test_renegotiate.py: 1010
tests/integrationv2/test_session_resumption.py: 7412
tests/integrationv2/test_signature_algorithms.py: 6126
tests/integrationv2/test_sni_match.py: 88
tests/integrationv2/test_version_negotiation.py: 6673
tests/integrationv2/test_well_known_endpoints.py: 480

+---------------------------------------------------------+
| Tests without the nix mark                              |
+---------------------------------------------------------+
tests/integrationv2/test_cross_compatibility.py: 3336
tests/integrationv2/test_dynamic_record_sizes.py: 1278
tests/integrationv2/test_external_psk.py: 4159
tests/integrationv2/test_happy_path.py: 8552
tests/integrationv2/test_pq_handshake.py: 5
tests/integrationv2/test_record_padding.py: 127
tests/integrationv2/test_renegotiate_apache.py: 28
tests/integrationv2/test_signature_algorithms.py: 6126

```

### Call-outs:

This changes nothing about how tests are currently run.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? locally

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
