### PR TITLE
style: fix declarations without initial value

### DIFF
--- a/bin/common.c
+++ b/bin/common.c
@@ -345,8 +345,8 @@ int s2n_set_common_server_config(int max_early_data, struct s2n_config *config, 
 
     if (conn_settings.session_ticket || conn_settings.session_cache) {
         /* Key initialization */
-        uint8_t *st_key;
-        uint32_t st_key_length;
+        uint8_t *st_key = NULL;
+        uint32_t st_key_length = 0;
 
         if (session_ticket_key_file_path) {
             int fd = open(session_ticket_key_file_path, O_RDONLY);

--- a/bin/echo.c
+++ b/bin/echo.c
@@ -139,10 +139,10 @@ int early_data_send(struct s2n_connection *conn, uint8_t *data, uint32_t len)
 
 int print_connection_info(struct s2n_connection *conn)
 {
-    int client_hello_version;
-    int client_protocol_version;
-    int server_protocol_version;
-    int actual_protocol_version;
+    int client_hello_version = 0;
+    int client_protocol_version = 0;
+    int server_protocol_version = 0;
+    int actual_protocol_version = 0;
 
     if ((client_hello_version = s2n_connection_get_client_hello_version(conn)) < 0) {
         fprintf(stderr, "Could not get client hello version\n");
@@ -179,7 +179,7 @@ int print_connection_info(struct s2n_connection *conn)
     printf("KEM: %s\n", s2n_connection_get_kem_name(conn));
     printf("KEM Group: %s\n", s2n_connection_get_kem_group_name(conn));
 
-    uint32_t length;
+    uint32_t length = 0;
     const uint8_t *status = s2n_connection_get_ocsp_response(conn, &length);
     if (status && length > 0) {
         printf("OCSP response received, length %u\n", length);

--- a/bin/s2nc.c
+++ b/bin/s2nc.c
@@ -278,8 +278,8 @@ static void setup_s2n_config(struct s2n_config *config, const char *cipher_prefs
 
 int main(int argc, char *const *argv)
 {
-    struct addrinfo hints, *ai_list, *ai;
-    int r, sockfd = 0;
+    struct addrinfo hints, *ai_list = NULL, *ai = NULL;
+    int r = 0, sockfd = 0;
     bool session_ticket_recv = 0;
     /* Optional args */
     const char *alpn_protocols = NULL;

--- a/bin/s2nd.c
+++ b/bin/s2nd.c
@@ -254,8 +254,8 @@ int handle_connection(int fd, struct s2n_config *config, struct conn_settings se
 
 int main(int argc, char *const *argv)
 {
-    struct addrinfo hints, *ai;
-    int r, sockfd = 0;
+    struct addrinfo hints, *ai = NULL;
+    int r = 0, sockfd = 0;
 
     /* required args */
     const char *host = NULL;
@@ -629,7 +629,7 @@ int main(int argc, char *const *argv)
                 "Failed to set key log callback");
     }
 
-    int fd;
+    int fd = 0;
     while ((fd = accept(sockfd, ai->ai_addr, &ai->ai_addrlen)) > 0) {
         if (non_blocking) {
             int flags = fcntl(sockfd, F_GETFL, 0);

--- a/crypto/s2n_dhe.c
+++ b/crypto/s2n_dhe.c
@@ -34,7 +34,7 @@
  */
 static const BIGNUM *s2n_get_Ys_dh_param(struct s2n_dh_params *dh_params)
 {
-    const BIGNUM *Ys;
+    const BIGNUM *Ys = NULL;
 
 /* DH made opaque in Openssl 1.1.0 */
 #if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0)
@@ -48,7 +48,7 @@ static const BIGNUM *s2n_get_Ys_dh_param(struct s2n_dh_params *dh_params)
 
 static const BIGNUM *s2n_get_p_dh_param(struct s2n_dh_params *dh_params)
 {
-    const BIGNUM *p;
+    const BIGNUM *p = NULL;
 #if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0)
     DH_get0_pqg(dh_params->dh, &p, NULL, NULL);
 #else
@@ -60,7 +60,7 @@ static const BIGNUM *s2n_get_p_dh_param(struct s2n_dh_params *dh_params)
 
 static const BIGNUM *s2n_get_g_dh_param(struct s2n_dh_params *dh_params)
 {
-    const BIGNUM *g;
+    const BIGNUM *g = NULL;
 #if S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0)
     DH_get0_pqg(dh_params->dh, NULL, NULL, &g);
 #else

--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -183,7 +183,7 @@ static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_p
         POSIX_GUARD_OSSL(EC_KEY_check_key(ec_key), S2N_ERR_ECDHE_SHARED_SECRET);
     }
 
-    size_t shared_secret_size;
+    size_t shared_secret_size = 0;
 
     DEFER_CLEANUP(EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(own_key, NULL), EVP_PKEY_CTX_free_pointer);
     S2N_ERROR_IF(ctx == NULL, S2N_ERR_ECDHE_SHARED_SECRET);
@@ -233,7 +233,7 @@ int s2n_ecc_evp_compute_shared_secret_as_server(struct s2n_ecc_evp_params *ecc_e
     POSIX_ENSURE_REF(ecc_evp_params->evp_pkey);
     POSIX_ENSURE_REF(Yc_in);
 
-    uint8_t client_public_len;
+    uint8_t client_public_len = 0;
     struct s2n_blob client_public_blob = { 0 };
 
     DEFER_CLEANUP(EVP_PKEY *peer_key = EVP_PKEY_new(), EVP_PKEY_free_pointer);
@@ -345,8 +345,8 @@ int s2n_ecc_evp_read_params(struct s2n_stuffer *in, struct s2n_blob *data_to_ver
         struct s2n_ecdhe_raw_server_params *raw_server_ecc_params)
 {
     POSIX_ENSURE_REF(in);
-    uint8_t curve_type;
-    uint8_t point_length;
+    uint8_t curve_type = 0;
+    uint8_t point_length = 0;
 
     /* Remember where we started reading the data */
     data_to_verify->data = s2n_stuffer_raw_read(in, 0);
@@ -507,7 +507,7 @@ int s2n_ecc_evp_find_supported_curve(struct s2n_connection *conn, struct s2n_blo
     for (size_t i = 0; i < ecc_prefs->count; i++) {
         const struct s2n_ecc_named_curve *supported_curve = ecc_prefs->ecc_curves[i];
         for (uint32_t j = 0; j < iana_ids->size / 2; j++) {
-            uint16_t iana_id;
+            uint16_t iana_id = 0;
             POSIX_GUARD(s2n_stuffer_read_uint16(&iana_ids_in, &iana_id));
             if (supported_curve->iana_id == iana_id) {
                 *found = supported_curve;

--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -118,7 +118,7 @@ static int s2n_ecdsa_verify(const struct s2n_pkey *pub, s2n_signature_algorithm 
     const s2n_ecdsa_public_key *key = &pub->key.ecdsa_key;
     POSIX_ENSURE_REF(key->ec_key);
 
-    uint8_t digest_length;
+    uint8_t digest_length = 0;
     POSIX_GUARD(s2n_hash_digest_size(digest->alg, &digest_length));
     POSIX_ENSURE_LTE(digest_length, S2N_MAX_DIGEST_LEN);
 

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -621,7 +621,7 @@ int s2n_hash_const_time_get_currently_in_hash_block(struct s2n_hash_state *state
     POSIX_PRECONDITION(s2n_hash_state_validate(state));
     POSIX_ENSURE(S2N_MEM_IS_WRITABLE_CHECK(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
     POSIX_ENSURE(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
-    uint64_t hash_block_size;
+    uint64_t hash_block_size = 0;
     POSIX_GUARD(s2n_hash_block_size(state->alg, &hash_block_size));
 
     /* Requires that hash_block_size is a power of 2. This is true for all hashes we currently support

--- a/crypto/s2n_hkdf.c
+++ b/crypto/s2n_hkdf.c
@@ -76,7 +76,7 @@ static int s2n_custom_hkdf_expand(struct s2n_hmac_state *hmac, s2n_hmac_algorith
     POSIX_ENSURE(total_rounds <= MAX_HKDF_ROUNDS, S2N_ERR_HKDF_OUTPUT_SIZE);
 
     for (uint32_t curr_round = 1; curr_round <= total_rounds; curr_round++) {
-        uint32_t cat_len;
+        uint32_t cat_len = 0;
         POSIX_GUARD(s2n_hmac_init(hmac, alg, pseudo_rand_key->data, pseudo_rand_key->size));
         if (curr_round != 1) {
             POSIX_GUARD(s2n_hmac_update(hmac, prev, hash_len));

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -332,7 +332,7 @@ int s2n_hmac_reset(struct s2n_hmac_state *state)
     POSIX_ENSURE(state->hash_block_size != 0, S2N_ERR_PRECONDITION_VIOLATION);
     POSIX_GUARD(s2n_hash_copy(&state->inner, &state->inner_just_key));
 
-    uint64_t bytes_in_hash;
+    uint64_t bytes_in_hash = 0;
     POSIX_GUARD(s2n_hash_get_currently_in_hash_total(&state->inner, &bytes_in_hash));
     bytes_in_hash %= state->hash_block_size;
     POSIX_ENSURE(bytes_in_hash <= UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);

--- a/crypto/s2n_rsa_signing.c
+++ b/crypto/s2n_rsa_signing.c
@@ -96,8 +96,8 @@ int s2n_rsa_pkcs1v15_sign(const struct s2n_pkey *priv, struct s2n_hash_state *di
 
 int s2n_rsa_pkcs1v15_verify(const struct s2n_pkey *pub, struct s2n_hash_state *digest, struct s2n_blob *signature)
 {
-    uint8_t digest_length;
-    int digest_NID_type;
+    uint8_t digest_length = 0;
+    int digest_NID_type = 0;
     POSIX_GUARD(s2n_hash_digest_size(digest->alg, &digest_length));
     POSIX_GUARD(s2n_hash_NID_type(digest->alg, &digest_NID_type));
     POSIX_ENSURE_LTE(digest_length, S2N_MAX_DIGEST_LEN);
@@ -186,7 +186,7 @@ int s2n_rsa_pss_verify(const struct s2n_pkey *pub, struct s2n_hash_state *digest
 {
     POSIX_ENSURE_REF(pub);
 
-    uint8_t digest_length;
+    uint8_t digest_length = 0;
     uint8_t digest_data[S2N_MAX_DIGEST_LEN];
     POSIX_GUARD(s2n_hash_digest_size(digest->alg, &digest_length));
     POSIX_GUARD(s2n_hash_digest(digest, digest_data, digest_length));

--- a/tests/testlib/s2n_connection_test_utils.c
+++ b/tests/testlib/s2n_connection_test_utils.c
@@ -36,8 +36,8 @@ int s2n_fd_set_non_blocking(int fd)
 
 static int buffer_read(void *io_context, uint8_t *buf, uint32_t len)
 {
-    struct s2n_stuffer *in_buf;
-    int n_read, n_avail;
+    struct s2n_stuffer *in_buf = NULL;
+    int n_read = 0, n_avail = 0;
     errno = EIO;
 
     if (buf == NULL) {
@@ -65,7 +65,7 @@ static int buffer_read(void *io_context, uint8_t *buf, uint32_t len)
 
 static int buffer_write(void *io_context, const uint8_t *buf, uint32_t len)
 {
-    struct s2n_stuffer *out;
+    struct s2n_stuffer *out = NULL;
 
     if (buf == NULL) {
         return 0;

--- a/tests/testlib/s2n_stuffer_hex.c
+++ b/tests/testlib/s2n_stuffer_hex.c
@@ -59,7 +59,7 @@ int s2n_stuffer_read_hex(struct s2n_stuffer *stuffer, struct s2n_stuffer *out, u
     POSIX_ENSURE_GTE(s2n_stuffer_space_remaining(out), n);
 
     for (size_t i = 0; i < n; i++) {
-        uint8_t c;
+        uint8_t c = 0;
         POSIX_GUARD(s2n_stuffer_read_uint8_hex(stuffer, &c));
         POSIX_GUARD(s2n_stuffer_write_uint8(out, c));
     }
@@ -72,7 +72,7 @@ int s2n_stuffer_write_hex(struct s2n_stuffer *stuffer, struct s2n_stuffer *in, u
     POSIX_ENSURE_GTE(s2n_stuffer_space_remaining(stuffer), n * 2);
 
     for (size_t i = 0; i < n; i++) {
-        uint8_t c;
+        uint8_t c = 0;
         POSIX_GUARD(s2n_stuffer_read_uint8(in, &c));
         POSIX_GUARD(s2n_stuffer_write_uint8_hex(stuffer, c));
     }
@@ -87,7 +87,7 @@ int s2n_stuffer_read_uint64_hex(struct s2n_stuffer *stuffer, uint64_t *u)
 
 int s2n_stuffer_read_uint32_hex(struct s2n_stuffer *stuffer, uint32_t *u)
 {
-    uint64_t u64;
+    uint64_t u64 = 0;
 
     POSIX_GUARD(s2n_stuffer_read_n_bits_hex(stuffer, 32, &u64));
 
@@ -98,7 +98,7 @@ int s2n_stuffer_read_uint32_hex(struct s2n_stuffer *stuffer, uint32_t *u)
 
 int s2n_stuffer_read_uint16_hex(struct s2n_stuffer *stuffer, uint16_t *u)
 {
-    uint64_t u64;
+    uint64_t u64 = 0;
 
     POSIX_GUARD(s2n_stuffer_read_n_bits_hex(stuffer, 16, &u64));
 
@@ -109,7 +109,7 @@ int s2n_stuffer_read_uint16_hex(struct s2n_stuffer *stuffer, uint16_t *u)
 
 int s2n_stuffer_read_uint8_hex(struct s2n_stuffer *stuffer, uint8_t *u)
 {
-    uint64_t u64;
+    uint64_t u64 = 0;
 
     POSIX_GUARD(s2n_stuffer_read_n_bits_hex(stuffer, 8, &u64));
 

--- a/tests/unit/s2n_3des_test.c
+++ b/tests/unit/s2n_3des_test.c
@@ -29,7 +29,7 @@
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
+    struct s2n_connection *conn = NULL;
     uint8_t mac_key[] = "sample mac key";
     uint8_t des3_key[] = "12345678901234567890123";
     struct s2n_blob des3 = { 0 };
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
     for (int i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
-        int bytes_written;
+        int bytes_written = 0;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
 
@@ -96,8 +96,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Let's decrypt it */
-        uint8_t content_type;
-        uint16_t fragment_length;
+        uint8_t content_type = 0;
+        uint16_t fragment_length = 0;
         EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
         EXPECT_SUCCESS(s2n_record_parse(conn));
         EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);

--- a/tests/unit/s2n_aead_aes_test.c
+++ b/tests/unit/s2n_aead_aes_test.c
@@ -47,7 +47,7 @@ static int setup_server_keys(struct s2n_connection *server_conn, struct s2n_blob
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
+    struct s2n_connection *conn = NULL;
     uint8_t random_data[S2N_SMALL_FRAGMENT_LENGTH + 1];
     uint8_t aes128_key[] = "123456789012345";
     uint8_t aes256_key[] = "1234567890123456789012345678901";
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
     for (size_t i = 0; i <= max_fragment + 1; i++) {
         struct s2n_blob in = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
-        int bytes_written;
+        int bytes_written = 0;
 
         /* TLS packet on the wire using AES-GCM:
          * https://tools.ietf.org/html/rfc5246#section-6.2.3.3
@@ -135,8 +135,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Let's decrypt it */
-        uint8_t content_type;
-        uint16_t fragment_length;
+        uint8_t content_type = 0;
+        uint16_t fragment_length = 0;
         EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
         EXPECT_SUCCESS(s2n_record_parse(conn));
         EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
@@ -274,7 +274,7 @@ int main(int argc, char **argv)
     for (size_t i = 0; i <= max_fragment + 1; i++) {
         struct s2n_blob in = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
-        int bytes_written;
+        int bytes_written = 0;
 
         EXPECT_SUCCESS(s2n_connection_wipe(conn));
         /* Set prefer low latency for S2N_SMALL_FRAGMENT_LENGTH for */
@@ -323,8 +323,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Let's decrypt it */
-        uint8_t content_type;
-        uint16_t fragment_length;
+        uint8_t content_type = 0;
+        uint16_t fragment_length = 0;
         EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
         EXPECT_SUCCESS(s2n_record_parse(conn));
         EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);

--- a/tests/unit/s2n_aead_chacha20_poly1305_test.c
+++ b/tests/unit/s2n_aead_chacha20_poly1305_test.c
@@ -48,7 +48,7 @@ static int setup_server_keys(struct s2n_connection *server_conn, struct s2n_blob
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
+    struct s2n_connection *conn = NULL;
     uint8_t random_data[S2N_SMALL_FRAGMENT_LENGTH + 1];
     uint8_t chacha20_poly1305_key_data[] = "1234567890123456789012345678901";
     struct s2n_blob chacha20_poly1305_key = { 0 };
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
     for (size_t i = 0; i <= max_fragment + 1; i++) {
         struct s2n_blob in = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
-        int bytes_written;
+        int bytes_written = 0;
 
         /* TLS packet on the wire using ChaCha20-Poly1305:
          * https://tools.ietf.org/html/rfc5246#section-6.2.3.3
@@ -135,8 +135,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Let's decrypt it */
-        uint8_t content_type;
-        uint16_t fragment_length;
+        uint8_t content_type = 0;
+        uint16_t fragment_length = 0;
         EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
         EXPECT_SUCCESS(s2n_record_parse(conn));
         EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);

--- a/tests/unit/s2n_aes_sha_composite_test.c
+++ b/tests/unit/s2n_aes_sha_composite_test.c
@@ -47,7 +47,7 @@ static int ensure_explicit_iv_is_unique(uint8_t existing_explicit_ivs[S2N_DEFAUL
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
+    struct s2n_connection *conn = NULL;
     uint8_t random_data[S2N_DEFAULT_FRAGMENT_LENGTH + 1];
     uint8_t mac_key_sha[20] = "server key shaserve";
     uint8_t mac_key_sha256[32] = "server key sha256server key sha";
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
         for (size_t i = 0; i <= max_aligned_fragment + 1; i++) {
             struct s2n_blob in = { 0 };
             EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
-            int bytes_written;
+            int bytes_written = 0;
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
             conn->actual_protocol_version = proto_versions[j];
 
-            int explicit_iv_len;
+            int explicit_iv_len = 0;
             if (conn->actual_protocol_version > S2N_TLS10) {
                 explicit_iv_len = 16;
             } else {
@@ -151,8 +151,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
-            uint8_t content_type;
-            uint16_t fragment_length;
+            uint8_t content_type = 0;
+            uint16_t fragment_length = 0;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
             EXPECT_SUCCESS(s2n_record_parse(conn));
             EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
         for (int i = 0; i <= max_aligned_fragment + 1; i++) {
             struct s2n_blob in = { 0 };
             EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
-            int bytes_written;
+            int bytes_written = 0;
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
@@ -181,7 +181,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
             conn->actual_protocol_version = proto_versions[j];
 
-            int explicit_iv_len;
+            int explicit_iv_len = 0;
             if (conn->actual_protocol_version > S2N_TLS10) {
                 explicit_iv_len = 16;
             } else {
@@ -227,8 +227,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
-            uint8_t content_type;
-            uint16_t fragment_length;
+            uint8_t content_type = 0;
+            uint16_t fragment_length = 0;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
             EXPECT_SUCCESS(s2n_record_parse(conn));
             EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
@@ -245,7 +245,7 @@ int main(int argc, char **argv)
         for (int i = 0; i < max_aligned_fragment + 1; i++) {
             struct s2n_blob in = { 0 };
             EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
-            int bytes_written;
+            int bytes_written = 0;
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
@@ -257,7 +257,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
             conn->actual_protocol_version = proto_versions[j];
 
-            int explicit_iv_len;
+            int explicit_iv_len = 0;
             if (conn->actual_protocol_version > S2N_TLS10) {
                 explicit_iv_len = 16;
             } else {
@@ -303,8 +303,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
-            uint8_t content_type;
-            uint16_t fragment_length;
+            uint8_t content_type = 0;
+            uint16_t fragment_length = 0;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
             EXPECT_SUCCESS(s2n_record_parse(conn));
             EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
@@ -321,7 +321,7 @@ int main(int argc, char **argv)
         for (int i = 0; i <= max_aligned_fragment + 1; i++) {
             struct s2n_blob in = { 0 };
             EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
-            int bytes_written;
+            int bytes_written = 0;
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
 
@@ -333,7 +333,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
             conn->actual_protocol_version = proto_versions[j];
 
-            int explicit_iv_len;
+            int explicit_iv_len = 0;
             if (conn->actual_protocol_version > S2N_TLS10) {
                 explicit_iv_len = 16;
             } else {
@@ -379,8 +379,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
-            uint8_t content_type;
-            uint16_t fragment_length;
+            uint8_t content_type = 0;
+            uint16_t fragment_length = 0;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
             EXPECT_SUCCESS(s2n_record_parse(conn));
             EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);

--- a/tests/unit/s2n_aes_test.c
+++ b/tests/unit/s2n_aes_test.c
@@ -29,7 +29,7 @@
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
+    struct s2n_connection *conn = NULL;
     uint8_t mac_key[] = "sample mac key";
     uint8_t aes128_key[] = "123456789012345";
     uint8_t aes256_key[] = "1234567890123456789012345678901";
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
     for (size_t i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
-        int bytes_written;
+        int bytes_written = 0;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
 
@@ -99,8 +99,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Let's decrypt it */
-        uint8_t content_type;
-        uint16_t fragment_length;
+        uint8_t content_type = 0;
+        uint16_t fragment_length = 0;
         EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
         EXPECT_SUCCESS(s2n_record_parse(conn));
         EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
@@ -130,7 +130,7 @@ int main(int argc, char **argv)
     for (size_t i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
-        int bytes_written;
+        int bytes_written = 0;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
 
@@ -165,8 +165,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Let's decrypt it */
-        uint8_t content_type;
-        uint16_t fragment_length;
+        uint8_t content_type = 0;
+        uint16_t fragment_length = 0;
         EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
         EXPECT_SUCCESS(s2n_record_parse(conn));
         EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);

--- a/tests/unit/s2n_alerts_test.c
+++ b/tests/unit/s2n_alerts_test.c
@@ -101,7 +101,7 @@ int main(int argc, char **argv)
 
         /* Don't mark close_notify_received = true if we receive an alert other than close_notify alert */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             /* Verify state prior to alert */
@@ -121,7 +121,7 @@ int main(int argc, char **argv)
 
         /* Mark close_notify_received = true if we receive a close_notify alert */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             /* Verify state prior to alert */
@@ -145,10 +145,10 @@ int main(int argc, char **argv)
 
         /* Fails if alerts not supported */
         if (s2n_is_tls13_fully_supported()) {
-            struct s2n_config *config;
+            struct s2n_config *config = NULL;
             EXPECT_NOT_NULL(config = s2n_config_new());
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -182,7 +182,7 @@ int main(int argc, char **argv)
 
             /* Warnings treated as errors by default in TLS1.2 */
             {
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                 EXPECT_EQUAL(conn->config->alert_behavior, S2N_ALERT_FAIL_ON_WARNINGS);
                 conn->actual_protocol_version = S2N_TLS12;
@@ -197,7 +197,7 @@ int main(int argc, char **argv)
 
             /* Warnings treated as errors by default in TLS1.3 */
             {
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                 EXPECT_EQUAL(conn->config->alert_behavior, S2N_ALERT_FAIL_ON_WARNINGS);
                 conn->actual_protocol_version = S2N_TLS13;
@@ -212,11 +212,11 @@ int main(int argc, char **argv)
 
             /* Warnings ignored in TLS1.2 if alert_behavior == S2N_ALERT_IGNORE_WARNINGS */
             {
-                struct s2n_config *config;
+                struct s2n_config *config = NULL;
                 EXPECT_NOT_NULL(config = s2n_config_new());
                 EXPECT_SUCCESS(s2n_config_set_alert_behavior(config, S2N_ALERT_IGNORE_WARNINGS));
 
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                 EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
                 conn->actual_protocol_version = S2N_TLS12;
@@ -232,11 +232,11 @@ int main(int argc, char **argv)
 
             /* Warnings treated as errors in TLS1.3 if alert_behavior == S2N_ALERT_IGNORE_WARNINGS */
             {
-                struct s2n_config *config;
+                struct s2n_config *config = NULL;
                 EXPECT_NOT_NULL(config = s2n_config_new());
                 EXPECT_SUCCESS(s2n_config_set_alert_behavior(config, S2N_ALERT_IGNORE_WARNINGS));
 
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                 EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
                 conn->actual_protocol_version = S2N_TLS13;
@@ -252,10 +252,10 @@ int main(int argc, char **argv)
 
             /* user_canceled ignored in TLS1.3 by default */
             {
-                struct s2n_config *config;
+                struct s2n_config *config = NULL;
                 EXPECT_NOT_NULL(config = s2n_config_new());
 
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                 EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
                 conn->actual_protocol_version = S2N_TLS13;

--- a/tests/unit/s2n_async_pkey_test.c
+++ b/tests/unit/s2n_async_pkey_test.c
@@ -403,7 +403,7 @@ int main(int argc, char **argv)
 
         /*  Test: apply while invoking callback */
         {
-            struct s2n_config *server_config, *client_config;
+            struct s2n_config *server_config = NULL, *client_config = NULL;
             EXPECT_NOT_NULL(server_config = s2n_config_new());
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
@@ -444,7 +444,7 @@ int main(int argc, char **argv)
 
         /*  Test: wipe connection and then perform and apply pkey op */
         {
-            struct s2n_config *server_config, *client_config;
+            struct s2n_config *server_config = NULL, *client_config = NULL;
             EXPECT_NOT_NULL(server_config = s2n_config_new());
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
@@ -485,7 +485,7 @@ int main(int argc, char **argv)
 
         /*  Test: free the pkey op and try s2n_negotiate again */
         {
-            struct s2n_config *server_config, *client_config;
+            struct s2n_config *server_config = NULL, *client_config = NULL;
             EXPECT_NOT_NULL(server_config = s2n_config_new());
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
@@ -527,7 +527,7 @@ int main(int argc, char **argv)
 
         /* Test: Apply invalid signature */
         {
-            struct s2n_config *server_config, *client_config;
+            struct s2n_config *server_config = NULL, *client_config = NULL;
             EXPECT_NOT_NULL(server_config = s2n_config_new());
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));

--- a/tests/unit/s2n_auth_selection_test.c
+++ b/tests/unit/s2n_auth_selection_test.c
@@ -47,7 +47,7 @@ static int s2n_test_auth_combo(struct s2n_connection *conn,
         struct s2n_cipher_suite *cipher_suite, const struct s2n_signature_scheme *sig_scheme,
         struct s2n_cert_chain_and_key *expected_cert_chain)
 {
-    struct s2n_cert_chain_and_key *actual_cert_chain;
+    struct s2n_cert_chain_and_key *actual_cert_chain = NULL;
 
     POSIX_GUARD(s2n_is_cipher_suite_valid_for_auth(conn, cipher_suite));
     conn->secure->cipher_suite = cipher_suite;
@@ -65,11 +65,11 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    struct s2n_cert_chain_and_key *rsa_cert_chain;
+    struct s2n_cert_chain_and_key *rsa_cert_chain = NULL;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&rsa_cert_chain,
             S2N_RSA_2048_PKCS1_CERT_CHAIN, S2N_RSA_2048_PKCS1_KEY));
 
-    struct s2n_cert_chain_and_key *ecdsa_cert_chain;
+    struct s2n_cert_chain_and_key *ecdsa_cert_chain = NULL;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&ecdsa_cert_chain,
             S2N_ECDSA_P384_PKCS1_CERT_CHAIN, S2N_ECDSA_P384_PKCS1_KEY));
 
@@ -181,7 +181,7 @@ int main(int argc, char **argv)
 
         /* Test: If signature algorithm specifies curve, must match cert curve */
         {
-            struct s2n_cert_chain_and_key *ecdsa_cert_chain_for_other_curve;
+            struct s2n_cert_chain_and_key *ecdsa_cert_chain_for_other_curve = NULL;
             EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&ecdsa_cert_chain_for_other_curve,
                     S2N_ECDSA_P256_PKCS1_CERT_CHAIN, S2N_ECDSA_P256_PKCS1_KEY));
 
@@ -298,7 +298,7 @@ int main(int argc, char **argv)
     /* s2n_select_certs_for_server_auth */
     {
         struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
-        struct s2n_cert_chain_and_key *chosen_certs;
+        struct s2n_cert_chain_and_key *chosen_certs = NULL;
 
         /* Requested cert chain exists */
         s2n_connection_set_config(conn, all_certs_config);

--- a/tests/unit/s2n_cert_chain_and_key_test.c
+++ b/tests/unit/s2n_cert_chain_and_key_test.c
@@ -45,14 +45,14 @@ static struct s2n_cert_chain_and_key *test_cert_tiebreak_cb(struct s2n_cert_chai
 
 int main(int argc, char **argv)
 {
-    struct s2n_config *server_config;
-    struct s2n_config *client_config;
-    struct s2n_connection *server_conn;
-    struct s2n_connection *client_conn;
-    char *alligator_cert;
-    char *alligator_key;
-    char *cert_chain;
-    char *private_key;
+    struct s2n_config *server_config = NULL;
+    struct s2n_config *client_config = NULL;
+    struct s2n_connection *server_conn = NULL;
+    struct s2n_connection *client_conn = NULL;
+    char *alligator_cert = NULL;
+    char *alligator_key = NULL;
+    char *cert_chain = NULL;
+    char *private_key = NULL;
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
     /* Create config with s2n_config_add_cert_chain_and_key_to_store API with multiple certs */
     {
-        struct s2n_cert_chain_and_key *default_cert;
+        struct s2n_cert_chain_and_key *default_cert = NULL;
         /* Associated data to attach to each certificate to use in the tiebreak callback. */
         int tiebreak_priorites[NUM_TIED_CERTS] = { 0 };
         /* Collection of certs with the same domain name that need to have ties resolved. */

--- a/tests/unit/s2n_cert_status_extension_test.c
+++ b/tests/unit/s2n_cert_status_extension_test.c
@@ -38,10 +38,10 @@ int main(int argc, char **argv)
 
     /* should_send */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
 
     /* Test send */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
 
@@ -87,16 +87,16 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_cert_status_extension.send(conn, &stuffer));
 
-        uint8_t request_type;
+        uint8_t request_type = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &request_type));
         EXPECT_EQUAL(request_type, S2N_STATUS_REQUEST_OCSP);
 
-        uint32_t ocsp_size;
+        uint32_t ocsp_size = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint24(&stuffer, &ocsp_size));
         EXPECT_EQUAL(ocsp_size, s2n_stuffer_data_available(&stuffer));
         EXPECT_EQUAL(ocsp_size, s2n_array_len(ocsp_data));
 
-        uint8_t *actual_ocsp_data;
+        uint8_t *actual_ocsp_data = NULL;
         EXPECT_NOT_NULL(actual_ocsp_data = s2n_stuffer_raw_read(&stuffer, ocsp_size));
         EXPECT_BYTEARRAY_EQUAL(actual_ocsp_data, ocsp_data, ocsp_size);
 
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
 
     /* Test recv */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
 
@@ -129,7 +129,7 @@ int main(int argc, char **argv)
 
     /* Test recv - not ocsp */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
 

--- a/tests/unit/s2n_cert_status_response_extension_test.c
+++ b/tests/unit/s2n_cert_status_response_extension_test.c
@@ -39,10 +39,10 @@ int main(int argc, char **argv)
 
     /* should_send */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
 
     /* Test send and recv */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         EXPECT_SUCCESS(s2n_cert_status_response_extension.send(conn, NULL));

--- a/tests/unit/s2n_certificate_extensions_test.c
+++ b/tests/unit/s2n_certificate_extensions_test.c
@@ -32,7 +32,7 @@ s2n_pkey_type actual_cert_pkey_type;
 
 static int s2n_skip_cert_chain_size(struct s2n_stuffer *stuffer)
 {
-    uint32_t cert_chain_size;
+    uint32_t cert_chain_size = 0;
     POSIX_GUARD(s2n_stuffer_read_uint24(stuffer, &cert_chain_size));
     POSIX_ENSURE_EQ(cert_chain_size, s2n_stuffer_data_available(stuffer));
     return S2N_SUCCESS;
@@ -40,7 +40,7 @@ static int s2n_skip_cert_chain_size(struct s2n_stuffer *stuffer)
 
 static int s2n_skip_cert(struct s2n_stuffer *stuffer)
 {
-    uint32_t cert_size;
+    uint32_t cert_size = 0;
     POSIX_GUARD(s2n_stuffer_read_uint24(stuffer, &cert_size));
     POSIX_GUARD(s2n_stuffer_skip_read(stuffer, cert_size));
     return S2N_SUCCESS;
@@ -51,7 +51,7 @@ static int s2n_x509_validator_validate_cert_chain_test(struct s2n_connection *co
     POSIX_GUARD(s2n_skip_cert_chain_size(stuffer));
     uint32_t cert_chain_size = s2n_stuffer_data_available(stuffer);
 
-    uint8_t *cert_chain_data;
+    uint8_t *cert_chain_data = NULL;
     POSIX_ENSURE_REF(cert_chain_data = s2n_stuffer_raw_read(stuffer, cert_chain_size));
 
     POSIX_GUARD_RESULT(s2n_x509_validator_validate_cert_chain(&conn->x509_validator, conn,
@@ -71,7 +71,7 @@ static int s2n_write_test_cert(struct s2n_stuffer *stuffer, struct s2n_cert_chai
 
 static int s2n_setup_connection_for_ocsp_validate_test(struct s2n_connection **conn, struct s2n_cert_chain_and_key *chain_and_key)
 {
-    struct s2n_connection *nconn;
+    struct s2n_connection *nconn = NULL;
 
     POSIX_ENSURE_REF(nconn = s2n_connection_new(S2N_SERVER));
     nconn->actual_protocol_version = S2N_TLS13;
@@ -90,13 +90,13 @@ int main(int argc, char **argv)
 
     EXPECT_SUCCESS(s2n_enable_tls13_in_test());
 
-    struct s2n_config *config;
+    struct s2n_config *config = NULL;
     EXPECT_NOT_NULL(config = s2n_config_new());
 
     EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key));
 
     /* Initialize cert chain */
-    struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
             S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
     {
         /* Test: extensions only sent for >= TLS1.3 */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->handshake_params.our_chain_and_key = chain_and_key;
 
@@ -154,7 +154,7 @@ int main(int argc, char **argv)
 
         /* Test: extensions only sent on first certificate */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->handshake_params.our_chain_and_key = chain_and_key;
 
@@ -190,7 +190,7 @@ int main(int argc, char **argv)
     {
         /* Test: with no extensions */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
             conn->handshake_params.our_chain_and_key = chain_and_key;
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
 
         /* Test: with extensions */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
             conn->handshake_params.our_chain_and_key = chain_and_key;
@@ -237,7 +237,7 @@ int main(int argc, char **argv)
     {
         /* Test: extensions only processed for >= TLS1.3 */
         {
-            struct s2n_connection *setup_conn;
+            struct s2n_connection *setup_conn = NULL;
             POSIX_GUARD(s2n_setup_connection_for_ocsp_validate_test(&setup_conn, chain_and_key));
 
             DEFER_CLEANUP(struct s2n_stuffer stuffer, s2n_stuffer_free);
@@ -251,7 +251,7 @@ int main(int argc, char **argv)
 
             /* TLS1.2 does NOT process extensions */
             {
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 POSIX_GUARD(s2n_setup_connection_for_ocsp_validate_test(&conn, chain_and_key));
 
                 EXPECT_SUCCESS(s2n_stuffer_reread(&stuffer));
@@ -267,7 +267,7 @@ int main(int argc, char **argv)
 
             /* TLS1.3 DOES process extensions */
             {
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 POSIX_GUARD(s2n_setup_connection_for_ocsp_validate_test(&conn, chain_and_key));
 
                 EXPECT_SUCCESS(s2n_stuffer_reread(&stuffer));
@@ -290,7 +290,7 @@ int main(int argc, char **argv)
 
             /* Extensions on second cert ignored */
             {
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 POSIX_GUARD(s2n_setup_connection_for_ocsp_validate_test(&conn, chain_and_key));
 
                 DEFER_CLEANUP(struct s2n_stuffer stuffer, s2n_stuffer_free);
@@ -313,7 +313,7 @@ int main(int argc, char **argv)
 
             /* Extensions on first cert processed */
             {
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 POSIX_GUARD(s2n_setup_connection_for_ocsp_validate_test(&conn, chain_and_key));
 
                 DEFER_CLEANUP(struct s2n_stuffer stuffer, s2n_stuffer_free);

--- a/tests/unit/s2n_change_cipher_spec_test.c
+++ b/tests/unit/s2n_change_cipher_spec_test.c
@@ -28,12 +28,12 @@ int main(int argc, char **argv)
 
     /* Test s2n_ccs_send */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         EXPECT_SUCCESS(s2n_ccs_send(conn));
 
-        uint8_t result;
+        uint8_t result = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&conn->handshake.io, &result));
         /* Always 0x01: https://tools.ietf.org/html/rfc5246#section-7.1 */
         EXPECT_EQUAL(result, 0x01);
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
 
     /* Test that s2n_basic_ccs_recv can parse the output of s2n_change_cipher_spec_send */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         EXPECT_SUCCESS(s2n_ccs_send(conn));
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
 
     /* Test that s2n_basic_ccs_recv errors on wrong change cipher spec types */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->handshake.io, 0));
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
 
     /* Test that s2n_client_ccs_recv errors on wrong change cipher spec types */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->handshake.io, 0));
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
 
     /* Test that s2n_server_ccs_recv errors on wrong change cipher spec types */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->handshake.io, 0));
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
 
     /* Test s2n_client_ccs_recv */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         /* Needed to not break prf */
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
 
     /* Test s2n_server_ccs_recv */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         /* Needed to not break prf */

--- a/tests/unit/s2n_cipher_suite_match_test.c
+++ b/tests/unit/s2n_cipher_suite_match_test.c
@@ -152,10 +152,10 @@ int main(int argc, char **argv)
 
     /* Test server cipher selection and scsv detection */
     {
-        struct s2n_connection *conn;
-        struct s2n_config *server_config;
-        char *rsa_cert_chain_pem, *rsa_private_key_pem, *ecdsa_cert_chain_pem, *ecdsa_private_key_pem;
-        struct s2n_cert_chain_and_key *rsa_cert, *ecdsa_cert;
+        struct s2n_connection *conn = NULL;
+        struct s2n_config *server_config = NULL;
+        char *rsa_cert_chain_pem = NULL, *rsa_private_key_pem = NULL, *ecdsa_cert_chain_pem = NULL, *ecdsa_private_key_pem = NULL;
+        struct s2n_cert_chain_and_key *rsa_cert = NULL, *ecdsa_cert = NULL;
         /* Allocate all of the objects and PEMs we'll need for this test. */
         EXPECT_NOT_NULL(rsa_cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
         EXPECT_NOT_NULL(rsa_private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));

--- a/tests/unit/s2n_cipher_suites_test.c
+++ b/tests/unit/s2n_cipher_suites_test.c
@@ -30,7 +30,7 @@ int main()
 
         /* Test: all cipher suites in s2n_all_cipher_suites are in IANA order */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             const uint8_t cipher_suite_count = cipher_preferences_test_all.count;

--- a/tests/unit/s2n_cleanup_with_no_init_test.c
+++ b/tests/unit/s2n_cleanup_with_no_init_test.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST_NO_INIT();
 
-    pthread_key_t my_key;
+    pthread_key_t my_key = 0;
 
     /* Init the pthread key */
     EXPECT_SUCCESS(pthread_key_create(&my_key, my_destructor));

--- a/tests/unit/s2n_client_alpn_extension_test.c
+++ b/tests/unit/s2n_client_alpn_extension_test.c
@@ -26,7 +26,7 @@ int main(int argc, char **argv)
 
     /* Test should_send */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         EXPECT_SUCCESS(s2n_connection_set_protocol_preferences(conn, NULL, 0));
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
 
     /* Test send */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_protocol_preferences(conn, protocols, protocols_count));
 
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_alpn_extension.send(conn, &stuffer));
 
         /* Should have correct size */
-        uint16_t actual_size;
+        uint16_t actual_size = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &actual_size));
         EXPECT_EQUAL(actual_size, s2n_stuffer_data_available(&stuffer));
         EXPECT_EQUAL(actual_size, conn->application_protocols_overridden.size);
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
 
     /* Test receive can accept the output of send */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_protocol_preferences(conn, protocols, protocols_count));
 
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
 
     /* Test receive does nothing if no protocol preferences configured */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         struct s2n_stuffer stuffer = { 0 };
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
 
     /* Test receive does nothing if extension malformed */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         struct s2n_stuffer stuffer = { 0 };

--- a/tests/unit/s2n_client_auth_handshake_test.c
+++ b/tests/unit/s2n_client_auth_handshake_test.c
@@ -37,8 +37,8 @@
 int s2n_test_client_auth_negotiation(struct s2n_config *server_config, struct s2n_config *client_config, struct s2n_cert_chain_and_key *ecdsa_cert, bool no_cert)
 {
     /* Set up client and server connections */
-    struct s2n_connection *client_conn;
-    struct s2n_connection *server_conn;
+    struct s2n_connection *client_conn = NULL;
+    struct s2n_connection *server_conn = NULL;
     EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
     EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
@@ -101,10 +101,10 @@ int s2n_test_client_auth_negotiation(struct s2n_config *server_config, struct s2
  */
 int s2n_test_client_auth_message_by_message(bool no_cert)
 {
-    struct s2n_connection *client_conn;
-    struct s2n_connection *server_conn;
+    struct s2n_connection *client_conn = NULL;
+    struct s2n_connection *server_conn = NULL;
 
-    struct s2n_config *server_config, *client_config;
+    struct s2n_config *server_config = NULL, *client_config = NULL;
     EXPECT_NOT_NULL(server_config = s2n_config_new());
     EXPECT_NOT_NULL(client_config = s2n_config_new());
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(client_config));
@@ -119,7 +119,7 @@ int s2n_test_client_auth_message_by_message(bool no_cert)
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
 
-    struct s2n_cert_chain_and_key *default_cert;
+    struct s2n_cert_chain_and_key *default_cert = NULL;
     EXPECT_NOT_NULL(default_cert = s2n_cert_chain_and_key_new());
     EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(default_cert, cert_chain, private_key));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, default_cert));
@@ -316,12 +316,12 @@ int main(int argc, char **argv)
 
     /* client_auth handshake negotiation */
     {
-        struct s2n_config *server_config, *client_config;
+        struct s2n_config *server_config = NULL, *client_config = NULL;
         uint8_t *cert_chain_pem = NULL;
         uint8_t *private_key_pem = NULL;
         uint32_t cert_chain_len = 0;
         uint32_t private_key_len = 0;
-        struct s2n_cert_chain_and_key *ecdsa_cert;
+        struct s2n_cert_chain_and_key *ecdsa_cert = NULL;
 
         EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
         EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));

--- a/tests/unit/s2n_client_cert_request_context_test.c
+++ b/tests/unit/s2n_client_cert_request_context_test.c
@@ -32,10 +32,10 @@ int main(int argc, char **argv)
 
     /* Test certificate_request_context sent/recv only when TLS 1.3 enabled */
     {
-        struct s2n_config *client_config;
+        struct s2n_config *client_config = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
 
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
         EXPECT_SUCCESS(s2n_connection_set_client_auth_type(client_conn, S2N_CERT_AUTH_OPTIONAL));
@@ -65,10 +65,10 @@ int main(int argc, char **argv)
     /* Test certificate_request_context is zero-length as currently
      * only used for handshake authentication */
     {
-        struct s2n_config *client_config;
+        struct s2n_config *client_config = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
 
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
         EXPECT_SUCCESS(s2n_connection_set_client_auth_type(client_conn, S2N_CERT_AUTH_OPTIONAL));
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->handshake.io), empty_cert_len + certificate_context_len);
 
         uint8_t expected_certificate_request_context_len = 0;
-        uint8_t actual_certificate_request_context_len;
+        uint8_t actual_certificate_request_context_len = 0;
 
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&client_conn->handshake.io, &actual_certificate_request_context_len));
         EXPECT_EQUAL(expected_certificate_request_context_len, actual_certificate_request_context_len);
@@ -89,10 +89,10 @@ int main(int argc, char **argv)
 
     /* Test failure case of non-zero certificate_request_context */
     {
-        struct s2n_config *server_config;
+        struct s2n_config *server_config = NULL;
         EXPECT_NOT_NULL(server_config = s2n_config_new());
 
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
         EXPECT_SUCCESS(s2n_connection_set_client_auth_type(server_conn, S2N_CERT_AUTH_OPTIONAL));

--- a/tests/unit/s2n_client_cert_status_request_extension_test.c
+++ b/tests/unit/s2n_client_cert_status_request_extension_test.c
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
 
     /* Test send */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -63,11 +63,11 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_client_cert_status_request_extension.send(conn, &stuffer));
 
-        uint8_t request_type;
+        uint8_t request_type = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &request_type));
         EXPECT_EQUAL(request_type, S2N_STATUS_REQUEST_OCSP);
 
-        uint32_t unused_values;
+        uint32_t unused_values = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint32(&stuffer, &unused_values));
         EXPECT_EQUAL(unused_values, 0);
 
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
 
     /* Test recv */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -98,7 +98,7 @@ int main(int argc, char **argv)
 
     /* Test recv - malformed length, ignore */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 

--- a/tests/unit/s2n_client_cert_verify_test.c
+++ b/tests/unit/s2n_client_cert_verify_test.c
@@ -171,7 +171,7 @@ int main(int argc, char **argv)
         /* Set any signature scheme. Our test pkey methods ignore it. */
         conn->handshake_params.client_cert_sig_scheme = &s2n_rsa_pkcs1_md5_sha1;
 
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
                 S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
         chain_and_key->private_key->size = test_size;
@@ -180,11 +180,11 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_client_cert_verify_send(conn));
 
-        uint16_t signature_scheme_iana;
+        uint16_t signature_scheme_iana = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&conn->handshake.io, &signature_scheme_iana));
         EXPECT_EQUAL(signature_scheme_iana, s2n_rsa_pkcs1_md5_sha1.iana_value);
 
-        uint16_t signature_size;
+        uint16_t signature_size = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&conn->handshake.io, &signature_size));
         EXPECT_NOT_EQUAL(signature_size, test_max_signature_size);
         EXPECT_EQUAL(signature_size, test_signature_size);
@@ -200,11 +200,11 @@ int main(int argc, char **argv)
 
     /*  Test: async private key operations. */
     {
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
                 S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
 
-        struct s2n_config *client_config;
+        struct s2n_config *client_config = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(client_config, chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(client_config, s2n_async_pkey_store_op));
@@ -220,7 +220,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
         EXPECT_SUCCESS(s2n_connection_set_client_auth_type(client_conn, S2N_CERT_AUTH_REQUIRED));
 
-        struct s2n_config *server_config;
+        struct s2n_config *server_config = NULL;
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(server_config));
@@ -259,11 +259,11 @@ int main(int argc, char **argv)
 
     /* Test: Apply with invalid signature */
     {
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
                 S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
 
-        struct s2n_config *client_config;
+        struct s2n_config *client_config = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(client_config, chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_async_pkey_callback(client_config, s2n_async_pkey_store_op));
@@ -278,7 +278,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
         EXPECT_SUCCESS(s2n_connection_set_client_auth_type(client_conn, S2N_CERT_AUTH_REQUIRED));
 
-        struct s2n_config *server_config;
+        struct s2n_config *server_config = NULL;
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(server_config));

--- a/tests/unit/s2n_client_empty_cert_test.c
+++ b/tests/unit/s2n_client_empty_cert_test.c
@@ -34,7 +34,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_send_empty_cert_chain(&out));
         EXPECT_EQUAL(s2n_stuffer_data_available(&out), 3);
-        uint32_t cert_len;
+        uint32_t cert_len = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint24(&out, &cert_len));
         EXPECT_EQUAL(cert_len, 0);
 
@@ -43,10 +43,10 @@ int main(int argc, char **argv)
 
     /* Client sends the empty cert when no client default chain and key */
     {
-        struct s2n_config *client_config;
+        struct s2n_config *client_config = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
 
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
         EXPECT_SUCCESS(s2n_connection_set_client_auth_type(client_conn, S2N_CERT_AUTH_OPTIONAL));
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
         /* Magic number 3 is the length of the certificate_length field */
         EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->handshake.io), 3);
 
-        uint32_t cert_len;
+        uint32_t cert_len = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint24(&client_conn->handshake.io, &cert_len));
         EXPECT_EQUAL(cert_len, 0);
 
@@ -69,10 +69,10 @@ int main(int argc, char **argv)
 
     /* Client fails to send empty cert when S2N_CERT_AUTH_REQUIRED */
     {
-        struct s2n_config *client_config;
+        struct s2n_config *client_config = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
 
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
         EXPECT_SUCCESS(s2n_connection_set_client_auth_type(client_conn, S2N_CERT_AUTH_REQUIRED));
@@ -86,15 +86,15 @@ int main(int argc, char **argv)
 
     /* Server receives empty cert */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
         EXPECT_SUCCESS(s2n_connection_set_client_auth_type(client_conn, S2N_CERT_AUTH_OPTIONAL));
 
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
         EXPECT_SUCCESS(s2n_connection_set_client_auth_type(server_conn, S2N_CERT_AUTH_OPTIONAL));

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -69,17 +69,17 @@ static int negotiate_kem(const uint8_t client_extensions[], const size_t client_
         const uint8_t client_hello_message[], const size_t client_hello_len,
         const char cipher_pref_version[], const int expected_kem_id, struct s2n_test_io_pair *io_pair)
 {
-    char *cert_chain;
-    char *private_key;
+    char *cert_chain = NULL;
+    char *private_key = NULL;
 
     POSIX_GUARD_PTR(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
     POSIX_GUARD_PTR(private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
     POSIX_GUARD(setenv("S2N_DONT_MLOCK", "1", 0));
 
-    struct s2n_connection *server_conn;
-    struct s2n_config *server_config;
+    struct s2n_connection *server_conn = NULL;
+    struct s2n_config *server_config = NULL;
     s2n_blocked_status server_blocked;
-    struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
     size_t body_len = client_hello_len + client_extensions_len;
     uint8_t message_header[] = {
@@ -130,7 +130,7 @@ static int negotiate_kem(const uint8_t client_extensions[], const size_t client_
         return S2N_FAILURE;
     }
 
-    int negotiated_kem_id;
+    int negotiated_kem_id = 0;
 
     if (server_conn->kex_params.kem_params.kem != NULL) {
         negotiated_kem_id = server_conn->kex_params.kem_params.kem->kem_extension_id;
@@ -168,12 +168,12 @@ int main(int argc, char **argv)
 
     /* Client doesn't use the server name extension. */
     {
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
-        struct s2n_config *client_config;
+        struct s2n_config *client_config = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(client_config, 0));
         EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
@@ -215,15 +215,15 @@ int main(int argc, char **argv)
 
     /* Client uses the server name extension. */
     {
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
         const char *sent_server_name = "www.alligator.com";
-        const char *received_server_name;
+        const char *received_server_name = NULL;
 
-        struct s2n_config *client_config;
+        struct s2n_config *client_config = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(client_config, 0));
         EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
@@ -271,12 +271,12 @@ int main(int argc, char **argv)
 
     /* Client sends multiple server names. */
     {
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
         s2n_blocked_status server_blocked;
         const char *sent_server_name = "svr";
-        const char *received_server_name;
-        struct s2n_cert_chain_and_key *chain_and_key;
+        const char *received_server_name = NULL;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
         uint32_t cert_chain_len = 0;
         uint32_t private_key_len = 0;
 
@@ -397,10 +397,10 @@ int main(int argc, char **argv)
 
     /* Client sends duplicate server name extension */
     {
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
         s2n_blocked_status server_blocked;
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
         uint8_t client_extensions[] = {
             /* Extension type TLS_EXTENSION_SERVER_NAME */
@@ -532,10 +532,10 @@ int main(int argc, char **argv)
 
     /* Client sends a valid initial renegotiation_info */
     {
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
         s2n_blocked_status server_blocked;
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
         uint8_t client_extensions[] = {
             /* Extension type TLS_EXTENSION_RENEGOTIATION_INFO */
@@ -632,10 +632,10 @@ int main(int argc, char **argv)
 
     /* Client sends a non-empty initial renegotiation_info */
     {
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
         s2n_blocked_status server_blocked;
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
         uint8_t buf[5120];
 
         uint8_t client_extensions[] = {
@@ -728,12 +728,12 @@ int main(int argc, char **argv)
 
     /* Client doesn't use the OCSP extension. */
     {
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
-        uint32_t length;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
+        uint32_t length = 0;
 
-        struct s2n_config *client_config;
+        struct s2n_config *client_config = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(client_config, 0));
         EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
@@ -779,7 +779,7 @@ int main(int argc, char **argv)
 
     /* Cannot enable OCSP stapling if there's no support for it */
     if (!s2n_x509_ocsp_stapling_supported()) {
-        struct s2n_config *client_config;
+        struct s2n_config *client_config = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_FAILURE(s2n_config_set_check_stapled_ocsp_response(client_config, 1));
         EXPECT_SUCCESS(s2n_config_free(client_config));
@@ -787,12 +787,12 @@ int main(int argc, char **argv)
 
     /* Server doesn't support the OCSP extension. We can't run this test if ocsp isn't supported by the client. */
     if (s2n_x509_ocsp_stapling_supported()) {
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
-        struct s2n_config *client_config;
-        uint32_t length;
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
+        struct s2n_config *client_config = NULL;
+        uint32_t length = 0;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(client_config, 0));
@@ -844,12 +844,12 @@ int main(int argc, char **argv)
 
     /* Test with s2n_config_set_extension_data(). Can be removed once API is deprecated */
     if (s2n_x509_ocsp_stapling_supported()) {
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
-        struct s2n_config *client_config;
-        const uint8_t *server_ocsp_reply;
-        uint32_t length;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
+        struct s2n_config *client_config = NULL;
+        const uint8_t *server_ocsp_reply = NULL;
+        uint32_t length = 0;
 
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(client_config, 0));
@@ -895,12 +895,12 @@ int main(int argc, char **argv)
 
     /* Server and client support the OCSP extension. Test only runs if ocsp stapled responses are supported by the client */
     if (s2n_x509_ocsp_stapling_supported()) {
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
-        struct s2n_config *client_config;
-        const uint8_t *server_ocsp_reply;
-        uint32_t length;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
+        struct s2n_config *client_config = NULL;
+        const uint8_t *server_ocsp_reply = NULL;
+        uint32_t length = 0;
 
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(client_config, 0));
@@ -953,12 +953,12 @@ int main(int argc, char **argv)
 
     /* Server and client support the OCSP extension. Test Behavior for TLS 1.3 */
     if (s2n_x509_ocsp_stapling_supported() && s2n_is_tls13_fully_supported()) {
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
-        struct s2n_config *client_config;
-        const uint8_t *server_ocsp_reply;
-        uint32_t length;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
+        struct s2n_config *client_config = NULL;
+        const uint8_t *server_ocsp_reply = NULL;
+        uint32_t length = 0;
 
         EXPECT_SUCCESS(s2n_enable_tls13_in_test());
 
@@ -1018,13 +1018,13 @@ int main(int argc, char **argv)
 
     /* Client does not request SCT, but server is configured to serve them. */
     {
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
 
-        uint32_t length;
+        uint32_t length = 0;
 
-        struct s2n_config *client_config;
+        struct s2n_config *client_config = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(client_config, 0));
         EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
@@ -1066,12 +1066,12 @@ int main(int argc, char **argv)
 
     /* Client requests SCT and server does have it. */
     {
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
-        struct s2n_config *client_config;
-        struct s2n_config *server_config;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *client_config = NULL;
+        struct s2n_config *server_config = NULL;
 
-        uint32_t length;
+        uint32_t length = 0;
 
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(client_config, 0));
@@ -1118,13 +1118,13 @@ int main(int argc, char **argv)
 
     /* Client requests SCT and server does *not* have it. */
     {
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
-        struct s2n_config *client_config;
-        struct s2n_config *server_config;
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *client_config = NULL;
+        struct s2n_config *server_config = NULL;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
-        uint32_t length;
+        uint32_t length = 0;
 
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(client_config, 0));
@@ -1173,11 +1173,11 @@ int main(int argc, char **argv)
 
     /* Client requests 512, 1024, 2048, and 4096 maximum fragment lengths */
     for (uint8_t mfl_code = S2N_TLS_MAX_FRAG_LEN_512; mfl_code <= S2N_TLS_MAX_FRAG_LEN_4096; mfl_code++) {
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
-        struct s2n_config *client_config;
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
+        struct s2n_config *client_config = NULL;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         client_conn->actual_protocol_version = S2N_TLS12;
@@ -1226,11 +1226,11 @@ int main(int argc, char **argv)
 
     /* Client requests invalid maximum fragment length */
     {
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
-        struct s2n_config *client_config;
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
+        struct s2n_config *client_config = NULL;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         client_conn->actual_protocol_version = S2N_TLS12;
@@ -1276,11 +1276,11 @@ int main(int argc, char **argv)
 
     /* Server ignores client's request of S2N_TLS_MAX_FRAG_LEN_2048 maximum fragment length when accept_mfl is not set*/
     {
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
-        struct s2n_config *client_config;
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
+        struct s2n_config *client_config = NULL;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         client_conn->actual_protocol_version = S2N_TLS12;

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -33,17 +33,17 @@
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *server_conn;
-    struct s2n_connection *client_conn;
-    struct s2n_stuffer *hello_stuffer;
-    struct s2n_config *tls12_config;
-    struct s2n_config *tls13_config;
-    struct s2n_cert_chain_and_key *chain_and_key;
-    struct s2n_cert_chain_and_key *tls13_chain_and_key;
-    char *cert_chain;
-    char *tls13_cert_chain;
-    char *private_key;
-    char *tls13_private_key;
+    struct s2n_connection *server_conn = NULL;
+    struct s2n_connection *client_conn = NULL;
+    struct s2n_stuffer *hello_stuffer = NULL;
+    struct s2n_config *tls12_config = NULL;
+    struct s2n_config *tls13_config = NULL;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
+    struct s2n_cert_chain_and_key *tls13_chain_and_key = NULL;
+    char *cert_chain = NULL;
+    char *tls13_cert_chain = NULL;
+    char *private_key = NULL;
+    char *tls13_private_key = NULL;
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -389,7 +389,7 @@ int main(int argc, char **argv)
 
         const size_t test_session_id_len = 10;
 
-        struct s2n_config *quic_config;
+        struct s2n_config *quic_config = NULL;
         EXPECT_NOT_NULL(quic_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_enable_quic(quic_config));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(quic_config, tls13_chain_and_key));

--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -64,8 +64,8 @@ int main(int argc, char **argv)
     {
         /* s2n_server_hello_retry_recv must fail when a keyshare for a matching curve was already present */
         {
-            struct s2n_config *config;
-            struct s2n_connection *conn;
+            struct s2n_config *config = NULL;
+            struct s2n_connection *conn = NULL;
 
             EXPECT_NOT_NULL(config = s2n_config_new());
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
@@ -91,8 +91,8 @@ int main(int argc, char **argv)
 
         /* s2n_server_hello_retry_recv must fail for a connection with actual protocol version less than TLS13 */
         {
-            struct s2n_config *config;
-            struct s2n_connection *conn;
+            struct s2n_config *config = NULL;
+            struct s2n_connection *conn = NULL;
 
             EXPECT_NOT_NULL(config = s2n_config_new());
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
@@ -108,13 +108,13 @@ int main(int argc, char **argv)
 
         /* Test ECC success case for s2n_server_hello_retry_recv */
         {
-            struct s2n_config *server_config;
-            struct s2n_config *client_config;
+            struct s2n_config *server_config = NULL;
+            struct s2n_config *client_config = NULL;
 
-            struct s2n_connection *server_conn;
-            struct s2n_connection *client_conn;
+            struct s2n_connection *server_conn = NULL;
+            struct s2n_connection *client_conn = NULL;
 
-            struct s2n_cert_chain_and_key *tls13_chain_and_key;
+            struct s2n_cert_chain_and_key *tls13_chain_and_key = NULL;
             char tls13_cert_chain[S2N_MAX_TEST_PEM_SIZE] = { 0 };
             char tls13_private_key[S2N_MAX_TEST_PEM_SIZE] = { 0 };
 
@@ -179,7 +179,7 @@ int main(int argc, char **argv)
             };
 
             if (!s2n_pq_is_enabled()) {
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                 conn->actual_protocol_version = S2N_TLS13;
                 conn->security_policy_override = &test_security_policy;
@@ -197,7 +197,7 @@ int main(int argc, char **argv)
             } else {
                 /* s2n_server_hello_retry_recv must fail when a keyshare for a matching PQ KEM was already present */
                 {
-                    struct s2n_connection *conn;
+                    struct s2n_connection *conn = NULL;
                     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                     conn->actual_protocol_version = S2N_TLS13;
                     conn->security_policy_override = &test_security_policy;
@@ -235,7 +235,7 @@ int main(int argc, char **argv)
                 };
                 /* Test failure if exactly one of {named_curve, kem_group} isn't non-null */
                 {
-                    struct s2n_connection *conn;
+                    struct s2n_connection *conn = NULL;
                     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                     conn->actual_protocol_version = S2N_TLS13;
                     conn->security_policy_override = &test_security_policy;
@@ -257,10 +257,10 @@ int main(int argc, char **argv)
                 uint32_t available_groups = 0;
                 EXPECT_OK(s2n_kem_preferences_groups_available(test_security_policy.kem_preferences, &available_groups));
                 if (available_groups >= 2) {
-                    struct s2n_config *config;
-                    struct s2n_connection *conn;
+                    struct s2n_config *config = NULL;
+                    struct s2n_connection *conn = NULL;
 
-                    struct s2n_cert_chain_and_key *tls13_chain_and_key;
+                    struct s2n_cert_chain_and_key *tls13_chain_and_key = NULL;
                     char tls13_cert_chain[S2N_MAX_TEST_PEM_SIZE] = { 0 };
                     char tls13_private_key[S2N_MAX_TEST_PEM_SIZE] = { 0 };
 
@@ -311,13 +311,13 @@ int main(int argc, char **argv)
      * hash, and generates a synthetic message. This test verifies that transcript hash recreated is the same
      * on both the server and client side. */
     {
-        struct s2n_config *server_config;
-        struct s2n_config *client_config;
+        struct s2n_config *server_config = NULL;
+        struct s2n_config *client_config = NULL;
 
-        struct s2n_connection *server_conn;
-        struct s2n_connection *client_conn;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_connection *client_conn = NULL;
 
-        struct s2n_cert_chain_and_key *tls13_chain_and_key;
+        struct s2n_cert_chain_and_key *tls13_chain_and_key = NULL;
         char tls13_cert_chain[S2N_MAX_TEST_PEM_SIZE] = { 0 };
         char tls13_private_key[S2N_MAX_TEST_PEM_SIZE] = { 0 };
 
@@ -411,13 +411,13 @@ int main(int argc, char **argv)
      *# HelloRetryRequest and send a second updated ClientHello.
      **/
     {
-        struct s2n_config *server_config;
-        struct s2n_config *client_config;
+        struct s2n_config *server_config = NULL;
+        struct s2n_config *client_config = NULL;
 
-        struct s2n_connection *server_conn;
-        struct s2n_connection *client_conn;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_connection *client_conn = NULL;
 
-        struct s2n_cert_chain_and_key *tls13_chain_and_key;
+        struct s2n_cert_chain_and_key *tls13_chain_and_key = NULL;
         char tls13_cert_chain[S2N_MAX_TEST_PEM_SIZE] = { 0 };
         char tls13_private_key[S2N_MAX_TEST_PEM_SIZE] = { 0 };
 
@@ -476,13 +476,13 @@ int main(int argc, char **argv)
      *# server MUST respond with a HelloRetryRequest (Section 4.1.4) message.
      **/
     if (s2n_is_evp_apis_supported()) {
-        struct s2n_config *server_config;
-        struct s2n_config *client_config;
+        struct s2n_config *server_config = NULL;
+        struct s2n_config *client_config = NULL;
 
-        struct s2n_connection *server_conn;
-        struct s2n_connection *client_conn;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_connection *client_conn = NULL;
 
-        struct s2n_cert_chain_and_key *tls13_chain_and_key;
+        struct s2n_cert_chain_and_key *tls13_chain_and_key = NULL;
         char tls13_cert_chain[S2N_MAX_TEST_PEM_SIZE] = { 0 };
         char tls13_private_key[S2N_MAX_TEST_PEM_SIZE] = { 0 };
 
@@ -547,13 +547,13 @@ int main(int argc, char **argv)
      *# handshake with an "unexpected_message" alert.
      **/
     {
-        struct s2n_config *server_config;
-        struct s2n_config *client_config;
+        struct s2n_config *server_config = NULL;
+        struct s2n_config *client_config = NULL;
 
-        struct s2n_connection *server_conn;
-        struct s2n_connection *client_conn;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_connection *client_conn = NULL;
 
-        struct s2n_cert_chain_and_key *tls13_chain_and_key;
+        struct s2n_cert_chain_and_key *tls13_chain_and_key = NULL;
         char tls13_cert_chain[S2N_MAX_TEST_PEM_SIZE] = { 0 };
         char tls13_private_key[S2N_MAX_TEST_PEM_SIZE] = { 0 };
 
@@ -627,7 +627,7 @@ int main(int argc, char **argv)
      *# it as described in Section 4.1.4).
      **/
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         const uint8_t not_hello_retry_request_random[S2N_TLS_RANDOM_DATA_LEN] = { 0 };
         EXPECT_MEMCPY_SUCCESS(conn->handshake_params.server_random, not_hello_retry_request_random,
@@ -650,8 +650,8 @@ int main(int argc, char **argv)
      *# otherwise abort the handshake with an "illegal_parameter" alert.
      **/
     {
-        struct s2n_connection *server_conn;
-        struct s2n_connection *client_conn;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_connection *client_conn = NULL;
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -50,7 +50,7 @@ S2N_RESULT s2n_client_hello_get_raw_extension(uint16_t extension_iana,
 
 int main(int argc, char **argv)
 {
-    struct s2n_cert_chain_and_key *chain_and_key, *ecdsa_chain_and_key;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL, *ecdsa_chain_and_key = NULL;
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -66,12 +66,12 @@ int main(int argc, char **argv)
     {
         /* Test with invalid parsed extensions */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
             s2n_tls_extension_type test_extension_type = S2N_EXTENSION_SERVER_NAME;
 
-            s2n_extension_type_id test_extension_type_id;
+            s2n_extension_type_id test_extension_type_id = 0;
             EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(test_extension_type, &test_extension_type_id));
 
             uint8_t data[] = "data";
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
 
     /* Test s2n_client_hello_has_extension */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         uint8_t data[] = {
@@ -214,12 +214,12 @@ int main(int argc, char **argv)
     /* Test setting cert chain on recv */
     {
         s2n_enable_tls13_in_test();
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
         /* TLS13 fails to parse client hello when no certs set */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             conn->client_protocol_version = conn->server_protocol_version;
@@ -236,7 +236,7 @@ int main(int argc, char **argv)
 
         /* TLS13 successfully sets certs */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             conn->client_protocol_version = conn->server_protocol_version;
@@ -311,7 +311,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_enable_tls13_in_test());
             }
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
 
@@ -325,7 +325,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_read_uint8(hello_stuffer, &session_id_length));
             EXPECT_EQUAL(session_id_length, S2N_TLS_SESSION_ID_MAX_LEN);
 
-            uint8_t *session_id;
+            uint8_t *session_id = NULL;
             EXPECT_NOT_NULL(session_id = s2n_stuffer_raw_read(hello_stuffer, S2N_TLS_SESSION_ID_MAX_LEN));
             EXPECT_BYTEARRAY_EQUAL(session_id, test_session_id, S2N_TLS_SESSION_ID_MAX_LEN);
 
@@ -339,7 +339,7 @@ int main(int argc, char **argv)
 
             /* Generate a session id by default */
             {
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                 struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
 
@@ -357,11 +357,11 @@ int main(int argc, char **argv)
              * For now, middlebox compatibility mode is only disabled by QUIC.
              */
             {
-                struct s2n_config *config;
+                struct s2n_config *config = NULL;
                 EXPECT_NOT_NULL(config = s2n_config_new());
                 EXPECT_SUCCESS(s2n_config_enable_quic(config));
 
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                 EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
                 struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
@@ -421,7 +421,7 @@ int main(int argc, char **argv)
         {
             /* Do NOT generate a session id by default */
             {
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                 struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
 
@@ -437,11 +437,11 @@ int main(int argc, char **argv)
 
             /* Generate a session id if using tickets */
             {
-                struct s2n_config *config;
+                struct s2n_config *config = NULL;
                 EXPECT_NOT_NULL(config = s2n_config_new());
                 EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, true));
 
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                 EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
                 struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
@@ -465,7 +465,7 @@ int main(int argc, char **argv)
         {
             /* TLS 1.3 cipher suites NOT written by client by default */
             {
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
                 struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
@@ -478,7 +478,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_stuffer_read_uint16(hello_stuffer, &list_length));
                 EXPECT_NOT_EQUAL(list_length, 0);
 
-                uint8_t first_cipher_byte;
+                uint8_t first_cipher_byte = 0;
                 for (int i = 0; i < list_length; i++) {
                     EXPECT_SUCCESS(s2n_stuffer_read_uint8(hello_stuffer, &first_cipher_byte));
                     EXPECT_NOT_EQUAL(first_cipher_byte, 0x13);
@@ -490,7 +490,7 @@ int main(int argc, char **argv)
 
             /* TLS 1.3 cipher suites NOT written by client even if included in security policy */
             {
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                 EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
 
@@ -504,7 +504,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_stuffer_read_uint16(hello_stuffer, &list_length));
                 EXPECT_NOT_EQUAL(list_length, 0);
 
-                uint8_t first_cipher_byte;
+                uint8_t first_cipher_byte = 0;
                 for (int i = 0; i < list_length; i++) {
                     EXPECT_SUCCESS(s2n_stuffer_read_uint8(hello_stuffer, &first_cipher_byte));
                     EXPECT_NOT_EQUAL(first_cipher_byte, 0x13);
@@ -519,13 +519,13 @@ int main(int argc, char **argv)
         if (s2n_is_tls13_fully_supported()) {
             EXPECT_SUCCESS(s2n_enable_tls13_in_test());
 
-            struct s2n_config *config;
+            struct s2n_config *config = NULL;
             EXPECT_NOT_NULL(config = s2n_config_new());
             s2n_config_set_session_tickets_onoff(config, 0);
 
             /* TLS 1.3 cipher suites written by client */
             {
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                 EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -540,7 +540,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_stuffer_read_uint16(hello_stuffer, &list_length));
                 EXPECT_NOT_EQUAL(list_length, 0);
 
-                uint8_t first_cipher_byte;
+                uint8_t first_cipher_byte = 0;
                 int tls13_ciphers_found = 0;
                 for (int i = 0; i < list_length; i++) {
                     EXPECT_SUCCESS(s2n_stuffer_read_uint8(hello_stuffer, &first_cipher_byte));
@@ -705,13 +705,13 @@ int main(int argc, char **argv)
     {
         EXPECT_SUCCESS(s2n_enable_tls13_in_test());
 
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
         {
             /* TLS 1.3 client cipher preference uses TLS13 version */
-            struct s2n_connection *conn;
-            const struct s2n_security_policy *security_policy;
+            struct s2n_connection *conn = NULL;
+            const struct s2n_security_policy *security_policy = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
@@ -728,12 +728,12 @@ int main(int argc, char **argv)
 
         {
             /* TLS 1.2 client cipher preference uses TLS12 version */
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default"));
 
-            const struct s2n_security_policy *security_policy;
+            const struct s2n_security_policy *security_policy = NULL;
             POSIX_GUARD(s2n_connection_get_security_policy(conn, &security_policy));
             EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
 
@@ -747,8 +747,8 @@ int main(int argc, char **argv)
 
         {
             /* TLS 1.3 client cipher preference uses TLS13 version */
-            struct s2n_connection *client_conn, *server_conn;
-            const struct s2n_security_policy *security_policy;
+            struct s2n_connection *client_conn = NULL, *server_conn = NULL;
+            const struct s2n_security_policy *security_policy = NULL;
 
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
@@ -765,7 +765,7 @@ int main(int argc, char **argv)
 
             /* Server configured with TLS 1.2 negotiates TLS12 version */
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
-            struct s2n_config *server_config;
+            struct s2n_config *server_config = NULL;
             EXPECT_NOT_NULL(server_config = s2n_config_new());
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
@@ -794,8 +794,8 @@ int main(int argc, char **argv)
 
     /* SSlv2 client hello */
     {
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
         s2n_blocked_status server_blocked;
 
         uint8_t sslv2_client_hello[] = {
@@ -883,7 +883,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_client_hello_get_extensions_length(client_hello), 0);
 
         /* Verify s2n_client_hello_get_session_id_length correct */
-        uint32_t ch_session_id_length;
+        uint32_t ch_session_id_length = 0;
         EXPECT_SUCCESS(s2n_client_hello_get_session_id_length(client_hello, &ch_session_id_length));
         EXPECT_EQUAL(ch_session_id_length, 0);
 
@@ -917,11 +917,11 @@ int main(int argc, char **argv)
 
     /* Minimal TLS 1.2 client hello. */
     {
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
         s2n_blocked_status server_blocked;
-        uint8_t *sent_client_hello;
-        uint8_t *expected_client_hello;
+        uint8_t *sent_client_hello = NULL;
+        uint8_t *expected_client_hello = NULL;
 
         uint8_t client_extensions[] = {
             /* Extension type TLS_EXTENSION_SERVER_NAME */
@@ -1030,7 +1030,7 @@ int main(int argc, char **argv)
         /* Verify s2n_connection_get_client_hello returns null if client hello not yet processed */
         EXPECT_NULL(s2n_connection_get_client_hello(server_conn));
 
-        uint8_t *ext_data;
+        uint8_t *ext_data = NULL;
         EXPECT_NOT_NULL(ext_data = malloc(server_name_extension_len));
         /* Verify we don't get extension and it's length when client hello is not yet processed */
         EXPECT_FAILURE(s2n_client_hello_get_extension_length(s2n_connection_get_client_hello(server_conn), S2N_EXTENSION_SERVER_NAME));
@@ -1076,7 +1076,7 @@ int main(int argc, char **argv)
         /* Verify s2n_client_hello_get_raw_message_length correct */
         EXPECT_EQUAL(s2n_client_hello_get_raw_message_length(client_hello), sent_client_hello_len);
 
-        uint8_t *raw_ch_out;
+        uint8_t *raw_ch_out = NULL;
 
         /* Verify s2n_client_hello_get_raw_message retrieves the full message when its len <= max_len */
         EXPECT_TRUE(collected_client_hello_len < S2N_LARGE_RECORD_LENGTH);
@@ -1107,7 +1107,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_client_hello_get_cipher_suites_length(client_hello), sizeof(expected_cs));
 
         /* Verify s2n_client_hello_get_cipher_suites correct */
-        uint8_t *cs_out;
+        uint8_t *cs_out = NULL;
 
         /* Verify s2n_client_hello_get_cipher_suites retrieves the full cipher_suites when its len <= max_len */
         EXPECT_TRUE(client_hello->cipher_suites.size < S2N_LARGE_RECORD_LENGTH);
@@ -1137,7 +1137,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_client_hello_get_extensions_length(client_hello), client_extensions_len);
 
         /* Verify s2n_client_hello_get_extensions correct */
-        uint8_t *extensions_out;
+        uint8_t *extensions_out = NULL;
 
         /* Verify s2n_client_hello_get_extensions retrieves the full cipher_suites when its len <= max_len */
         EXPECT_TRUE(client_hello->extensions.raw.size < S2N_LARGE_RECORD_LENGTH);
@@ -1193,7 +1193,7 @@ int main(int argc, char **argv)
         /* Verify s2n_client_hello_get_session_id is what we received in ClientHello */
         uint8_t expected_ch_session_id[] = { ZERO_TO_THIRTY_ONE };
         uint8_t ch_session_id[sizeof(expected_ch_session_id)];
-        uint32_t ch_session_id_length;
+        uint32_t ch_session_id_length = 0;
         EXPECT_SUCCESS(s2n_client_hello_get_session_id_length(client_hello, &ch_session_id_length));
         EXPECT_EQUAL(ch_session_id_length, sizeof(ch_session_id));
         EXPECT_SUCCESS(s2n_client_hello_get_session_id(client_hello, ch_session_id, &ch_session_id_length, sizeof(ch_session_id)));
@@ -1272,7 +1272,7 @@ int main(int argc, char **argv)
     /* Client hello api with NULL inputs */
     {
         uint32_t len = 128;
-        uint8_t *out;
+        uint8_t *out = NULL;
         EXPECT_NOT_NULL(out = malloc(len));
 
         EXPECT_FAILURE(s2n_client_hello_get_raw_message_length(NULL));
@@ -1293,10 +1293,10 @@ int main(int argc, char **argv)
 
     /* test_weird_client_hello_version() */
     {
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
         s2n_blocked_status server_blocked;
-        uint8_t *sent_client_hello;
+        uint8_t *sent_client_hello = NULL;
 
         uint8_t client_extensions[] = {
             /* Extension type TLS_EXTENSION_SERVER_NAME */
@@ -1438,14 +1438,14 @@ int main(int argc, char **argv)
 
         EXPECT_TRUE(client_cipher_suites[0]->available);
 
-        struct s2n_cert_chain_and_key *ecdsa_cert_chain;
+        struct s2n_cert_chain_and_key *ecdsa_cert_chain = NULL;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&ecdsa_cert_chain, S2N_ECDSA_P384_PKCS1_CERT_CHAIN, S2N_ECDSA_P384_PKCS1_KEY));
 
         char dhparams_pem[S2N_MAX_TEST_PEM_SIZE];
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_DHPARAMS, dhparams_pem, S2N_MAX_TEST_PEM_SIZE));
 
         /* Create Configs */
-        struct s2n_config *server_config, *client_config;
+        struct s2n_config *server_config = NULL, *client_config = NULL;
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, ecdsa_cert_chain));
 

--- a/tests/unit/s2n_client_key_share_extension_pq_test.c
+++ b/tests/unit/s2n_client_key_share_extension_pq_test.c
@@ -59,14 +59,14 @@ int main()
             .signature_preferences = &s2n_signature_preferences_20200207,
             .ecc_preferences = &s2n_ecc_preferences_20200310,
         };
-        uint32_t groups_available;
+        uint32_t groups_available = 0;
 
         /* Tests for s2n_client_key_share_extension.send */
         {
             /* Test that s2n_client_key_share_extension.send sends only ECC key shares
              * when PQ is disabled, even if tls13_kem_groups is non-null. */
             if (!s2n_pq_is_enabled()) {
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                 conn->security_policy_override = &security_policy_all;
 
@@ -84,13 +84,13 @@ int main()
                 EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &key_share_extension));
 
                 /* Assert total key shares extension size is correct */
-                uint16_t sent_key_shares_size;
+                uint16_t sent_key_shares_size = 0;
                 EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_key_shares_size));
                 EXPECT_EQUAL(sent_key_shares_size, s2n_stuffer_data_available(&key_share_extension));
 
                 /* ECC key shares should have the format: IANA ID || size || share. Only one ECC key share
                  * should be sent (as per default s2n behavior). */
-                uint16_t iana_value, share_size;
+                uint16_t iana_value = 0, share_size = 0;
                 EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &iana_value));
                 EXPECT_EQUAL(iana_value, ecc_preferences->ecc_curves[0]->iana_id);
                 EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &share_size));
@@ -134,7 +134,7 @@ int main()
 
                     /* Test sending of default hybrid key share (non-HRR) */
                     {
-                        struct s2n_connection *conn;
+                        struct s2n_connection *conn = NULL;
                         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                         conn->security_policy_override = &test_security_policy;
 
@@ -175,13 +175,13 @@ int main()
 
                         /* Now, assert that the client sent the correct bytes over the wire for the key share extension */
                         /* Assert total key shares extension size is correct */
-                        uint16_t sent_key_shares_size;
+                        uint16_t sent_key_shares_size = 0;
                         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_key_shares_size));
                         EXPECT_EQUAL(sent_key_shares_size, s2n_stuffer_data_available(&key_share_extension));
 
                         /* Assert that the hybrid key share is correct:
                          * IANA ID || total hybrid share size || ECC share size || ECC share || PQ share size || PQ share */
-                        uint16_t sent_hybrid_iana_id;
+                        uint16_t sent_hybrid_iana_id = 0;
                         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_hybrid_iana_id));
                         EXPECT_EQUAL(sent_hybrid_iana_id, kem_pref->tls13_kem_groups[0]->iana_id);
 
@@ -215,7 +215,7 @@ int main()
                         EXPECT_SUCCESS(s2n_stuffer_skip_read(&key_share_extension, test_kem_group->kem->public_key_length));
 
                         /* Assert that the ECC key share is correct: IANA ID || size || share */
-                        uint16_t ecc_iana_value, ecc_share_size;
+                        uint16_t ecc_iana_value = 0, ecc_share_size = 0;
                         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &ecc_iana_value));
                         EXPECT_EQUAL(ecc_iana_value, ecc_pref->ecc_curves[0]->iana_id);
                         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &ecc_share_size));
@@ -232,7 +232,7 @@ int main()
                     /* Need at least two KEM's to test ClientHelloRetry fallback */
                     EXPECT_OK(s2n_kem_preferences_groups_available(security_policy_all.kem_preferences, &groups_available));
                     if (groups_available >= 2) {
-                        struct s2n_connection *conn;
+                        struct s2n_connection *conn = NULL;
                         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
                         conn->security_policy_override = &test_security_policy;
                         conn->actual_protocol_version = S2N_TLS13;
@@ -283,17 +283,17 @@ int main()
 
                         /* Assert that the client sent the correct bytes over the wire for the key share extension */
                         /* Assert total key shares extension size is correct */
-                        uint16_t sent_key_shares_size;
+                        uint16_t sent_key_shares_size = 0;
                         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_key_shares_size));
                         EXPECT_EQUAL(sent_key_shares_size, s2n_stuffer_data_available(&key_share_extension));
 
                         /* Assert that the hybrid key share is correct:
                          * IANA ID || total hybrid share size || ECC share size || ECC share || PQ share size || PQ share */
-                        uint16_t sent_hybrid_iana_id;
+                        uint16_t sent_hybrid_iana_id = 0;
                         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_hybrid_iana_id));
                         EXPECT_EQUAL(sent_hybrid_iana_id, kem_pref->tls13_kem_groups[chosen_index]->iana_id);
 
-                        uint16_t expected_hybrid_share_size;
+                        uint16_t expected_hybrid_share_size = 0;
 
                         if (len_prefixed) {
                             expected_hybrid_share_size = S2N_SIZE_OF_KEY_SHARE_SIZE
@@ -304,19 +304,19 @@ int main()
                             expected_hybrid_share_size = negotiated_kem_group->curve->share_size + negotiated_kem_group->kem->public_key_length;
                         }
 
-                        uint16_t sent_hybrid_share_size;
+                        uint16_t sent_hybrid_share_size = 0;
                         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &sent_hybrid_share_size));
                         EXPECT_EQUAL(sent_hybrid_share_size, expected_hybrid_share_size);
 
                         if (len_prefixed) {
-                            uint16_t hybrid_ecc_share_size;
+                            uint16_t hybrid_ecc_share_size = 0;
                             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &hybrid_ecc_share_size));
                             EXPECT_EQUAL(hybrid_ecc_share_size, negotiated_kem_group->curve->share_size);
                         }
                         EXPECT_SUCCESS(s2n_stuffer_skip_read(&key_share_extension, negotiated_kem_group->curve->share_size));
 
                         if (len_prefixed) {
-                            uint16_t hybrid_pq_share_size;
+                            uint16_t hybrid_pq_share_size = 0;
                             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &hybrid_pq_share_size));
                             EXPECT_EQUAL(hybrid_pq_share_size, negotiated_kem_group->kem->public_key_length);
                         }
@@ -604,8 +604,8 @@ int main()
                     EXPECT_TRUE(groups_available >= 2);
 
                     /* Select the two highest priority available KEM groups */
-                    const struct s2n_kem_group *kem_group0;
-                    const struct s2n_kem_group *kem_group1;
+                    const struct s2n_kem_group *kem_group0 = NULL;
+                    const struct s2n_kem_group *kem_group1 = NULL;
                     EXPECT_SUCCESS(s2n_get_two_highest_piority_kem_groups(kem_pref, &kem_group0, &kem_group1));
                     EXPECT_NOT_NULL(kem_group0);
                     EXPECT_NOT_NULL(kem_group1);
@@ -732,8 +732,8 @@ int main()
                     EXPECT_TRUE(groups_available >= 2);
 
                     /* Select the two highest priority available KEM groups */
-                    const struct s2n_kem_group *kem_group0;
-                    const struct s2n_kem_group *kem_group1;
+                    const struct s2n_kem_group *kem_group0 = NULL;
+                    const struct s2n_kem_group *kem_group1 = NULL;
                     EXPECT_SUCCESS(s2n_get_two_highest_piority_kem_groups(kem_pref, &kem_group0, &kem_group1));
                     EXPECT_NOT_NULL(kem_group0);
                     EXPECT_NOT_NULL(kem_group1);
@@ -792,8 +792,8 @@ int main()
                     EXPECT_TRUE(groups_available >= 2);
 
                     /* Select the two highest priority available KEM groups */
-                    const struct s2n_kem_group *kem_group0;
-                    const struct s2n_kem_group *kem_group1;
+                    const struct s2n_kem_group *kem_group0 = NULL;
+                    const struct s2n_kem_group *kem_group1 = NULL;
                     EXPECT_SUCCESS(s2n_get_two_highest_piority_kem_groups(kem_pref, &kem_group0, &kem_group1));
                     EXPECT_NOT_NULL(kem_group0);
                     EXPECT_NOT_NULL(kem_group1);
@@ -858,8 +858,8 @@ int main()
                     EXPECT_TRUE(groups_available >= 2);
 
                     /* Select the two highest priority available KEM groups */
-                    const struct s2n_kem_group *kem_group0;
-                    const struct s2n_kem_group *kem_group1;
+                    const struct s2n_kem_group *kem_group0 = NULL;
+                    const struct s2n_kem_group *kem_group1 = NULL;
                     EXPECT_SUCCESS(s2n_get_two_highest_piority_kem_groups(kem_pref, &kem_group0, &kem_group1));
                     EXPECT_NOT_NULL(kem_group0);
                     EXPECT_NOT_NULL(kem_group1);

--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
     /* Test that s2n_extensions_key_share_size produces the expected constant result */
     {
         struct s2n_stuffer key_share_extension = { 0 };
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         uint32_t key_share_size = 0;
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
         /* Test that s2n_client_key_share_extension.send initializes the client key share list */
         {
             struct s2n_stuffer key_share_extension = { 0 };
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 0));
 
@@ -117,13 +117,13 @@ int main(int argc, char **argv)
         /* Test that s2n_client_key_share_extension.send writes a well-formed list of key shares */
         {
             struct s2n_stuffer key_share_extension = { 0 };
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 0));
             EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &key_share_extension));
 
             /* should have correct shares size */
-            uint16_t key_shares_size;
+            uint16_t key_shares_size = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &key_shares_size));
             uint16_t actual_key_shares_size = s2n_stuffer_data_available(&key_share_extension);
             EXPECT_EQUAL(key_shares_size, actual_key_shares_size);
@@ -134,7 +134,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(ecc_preferences);
 
             /* should contain only the default supported curve */
-            uint16_t iana_value, share_size;
+            uint16_t iana_value = 0, share_size = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &iana_value));
             EXPECT_EQUAL(iana_value, ecc_preferences->ecc_curves[0]->iana_id);
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &share_size));
@@ -150,8 +150,8 @@ int main(int argc, char **argv)
          * but not present in the ecc_preferences list selected */
         if (s2n_is_evp_apis_supported()) {
             struct s2n_stuffer key_share_extension = { 0 };
-            struct s2n_connection *conn;
-            struct s2n_config *config;
+            struct s2n_connection *conn = NULL;
+            struct s2n_config *config = NULL;
             EXPECT_NOT_NULL(config = s2n_config_new());
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             /* Explicitly set the ecc_preferences list to contain the curves p-256 and p-384 */
@@ -198,8 +198,8 @@ int main(int argc, char **argv)
          *# of the triggering HelloRetryRequest.
          **/
         if (s2n_is_evp_apis_supported()) {
-            struct s2n_connection *conn;
-            struct s2n_config *config;
+            struct s2n_connection *conn = NULL;
+            struct s2n_config *config = NULL;
             struct s2n_stuffer key_share_extension = { 0 };
 
             EXPECT_NOT_NULL(config = s2n_config_new());
@@ -230,7 +230,7 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &key_share_extension));
 
-            uint16_t key_shares_size;
+            uint16_t key_shares_size = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &key_shares_size));
             EXPECT_EQUAL(s2n_stuffer_data_available(&key_share_extension), key_shares_size);
 
@@ -238,7 +238,7 @@ int main(int argc, char **argv)
             uint32_t bytes_processed = 0;
             EXPECT_EQUAL(key_shares_size, conn->kex_params.server_ecc_evp_params.negotiated_curve->share_size + S2N_SIZE_OF_NAMED_GROUP + S2N_SIZE_OF_KEY_SHARE_SIZE);
 
-            uint16_t iana_value, share_size;
+            uint16_t iana_value = 0, share_size = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &iana_value));
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&key_share_extension, &share_size));
             bytes_processed += conn->kex_params.server_ecc_evp_params.negotiated_curve->share_size + S2N_SIZE_OF_NAMED_GROUP
@@ -257,8 +257,8 @@ int main(int argc, char **argv)
         /* For HelloRetryRequests, test that s2n_client_key_share_extension.recv can read and parse
          * the result of s2n_client_key_share_extension.send */
         {
-            struct s2n_connection *client_conn;
-            struct s2n_connection *server_conn;
+            struct s2n_connection *client_conn = NULL;
+            struct s2n_connection *server_conn = NULL;
             struct s2n_stuffer key_share_extension = { 0 };
 
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
@@ -309,7 +309,7 @@ int main(int argc, char **argv)
         /* For HelloRetryRequests, test that s2n_client_key_share_extension.send fails,
          * if the server negotiated_curve is not set and is NULL. */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             struct s2n_stuffer key_share_extension = { 0 };
 
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
@@ -378,7 +378,7 @@ int main(int argc, char **argv)
         /* Test that s2n_client_key_share_extension.recv is a no-op
          * if not using TLS1.3 */
         {
-            struct s2n_connection *client_conn, *server_conn;
+            struct s2n_connection *client_conn = NULL, *server_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             EXPECT_OK(s2n_set_all_mutually_supported_groups(server_conn));
@@ -406,7 +406,7 @@ int main(int argc, char **argv)
         /* Test that s2n_client_key_share_extension.recv can read and parse
          * the result of s2n_client_key_share_extension.send */
         {
-            struct s2n_connection *client_conn, *server_conn;
+            struct s2n_connection *client_conn = NULL, *server_conn = NULL;
             struct s2n_stuffer key_share_extension = { 0 };
 
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
@@ -689,7 +689,7 @@ int main(int argc, char **argv)
         /* Test that s2n_client_key_share_extension.recv errors on client shares size larger
          * than available data */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             struct s2n_stuffer key_share_extension = { 0 };
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
@@ -711,7 +711,7 @@ int main(int argc, char **argv)
 
         /* Test that s2n_client_key_share_extension.recv errors on key share size longer than data */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             struct s2n_stuffer key_share_extension = { 0 };
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
@@ -736,7 +736,7 @@ int main(int argc, char **argv)
 
         /* Test that s2n_client_key_share_extension.recv accepts a subset of supported curves */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             struct s2n_stuffer key_share_extension = { 0 };
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
@@ -769,7 +769,7 @@ int main(int argc, char **argv)
 
         /* Test that s2n_client_key_share_extension.recv handles empty client share list */
         {
-            struct s2n_connection *server_conn;
+            struct s2n_connection *server_conn = NULL;
             struct s2n_stuffer key_share_extension = { 0 };
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(server_conn, S2N_TLS13));
@@ -795,7 +795,7 @@ int main(int argc, char **argv)
 
         /* Test that s2n_client_key_share_extension.recv ignores unsupported curves */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             struct s2n_stuffer key_share_extension = { 0 };
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(conn, S2N_TLS13));
@@ -834,7 +834,7 @@ int main(int argc, char **argv)
 
         /* Test that s2n_client_key_share_extension.recv ignores curves with incorrect key size */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             struct s2n_stuffer key_share_extension = { 0 };
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(conn, S2N_TLS13));
@@ -867,7 +867,7 @@ int main(int argc, char **argv)
 
         /* Test that s2n_client_key_share_extension.recv uses first instance of duplicate curves */
         {
-            struct s2n_connection *server_conn;
+            struct s2n_connection *server_conn = NULL;
             struct s2n_stuffer key_share_extension = { 0 };
             struct s2n_ecc_evp_params first_params, second_params;
             int supported_curve_index = 0;
@@ -911,9 +911,9 @@ int main(int argc, char **argv)
 
         /* Test that s2n_client_key_share_extension.recv ignores ECDHE points that can't be parsed */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             struct s2n_stuffer key_share_extension = { 0 };
-            struct s2n_config *config;
+            struct s2n_config *config = NULL;
             EXPECT_NOT_NULL(config = s2n_config_new());
             /* Explicitly set the ecc_preferences list to only contain the curves p-256 and p-384 */
             EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20140601"));
@@ -956,7 +956,7 @@ int main(int argc, char **argv)
         /* Test that s2n_client_key_share_extension.recv ignores ECDHE points that can't be parsed,
          * and continues to parse valid key shares afterwards. */
         {
-            struct s2n_config *config;
+            struct s2n_config *config = NULL;
             EXPECT_NOT_NULL(config = s2n_config_new());
             /* Explicitly set the ecc_preferences list to only contain the curves p-256 and p-384 */
             EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20140601"));
@@ -1064,9 +1064,9 @@ int main(int argc, char **argv)
          */
         {
             if (s2n_is_evp_apis_supported()) {
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 struct s2n_stuffer key_share_extension = { 0 };
-                struct s2n_config *config;
+                struct s2n_config *config = NULL;
                 EXPECT_NOT_NULL(config = s2n_config_new());
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
                 EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(conn, S2N_TLS13));

--- a/tests/unit/s2n_client_max_frag_len_extension_test.c
+++ b/tests/unit/s2n_client_max_frag_len_extension_test.c
@@ -24,10 +24,10 @@ int main(int argc, char **argv)
 
     /* Test should_send */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -43,10 +43,10 @@ int main(int argc, char **argv)
 
     /* Test send */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_max_frag_len_extension.send(conn, &stuffer));
 
         /* Should have correct fragment length */
-        uint8_t actual_frag_len;
+        uint8_t actual_frag_len = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &actual_frag_len));
         EXPECT_EQUAL(actual_frag_len, S2N_TLS_MAX_FRAG_LEN_512);
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
@@ -69,10 +69,10 @@ int main(int argc, char **argv)
 
     /* Test receive - accept_mfl not set */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -102,11 +102,11 @@ int main(int argc, char **argv)
      *# handshake with an "illegal_parameter" alert.
      */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_accept_max_fragment_length(config));
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -129,11 +129,11 @@ int main(int argc, char **argv)
 
     /* Test receive */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_accept_max_fragment_length(config));
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 

--- a/tests/unit/s2n_client_pq_kem_extension_test.c
+++ b/tests/unit/s2n_client_pq_kem_extension_test.c
@@ -37,7 +37,7 @@ int main(int argc, char **argv)
 
         /* Test should_send */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             /* Default cipher preferences do not include PQ, so extension not sent */
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
 
         /* Test send */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy_version));
 
@@ -66,13 +66,13 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_pq_kem_extension.send(conn, &stuffer));
 
             /* Should write correct size */
-            uint16_t size;
+            uint16_t size = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &size));
             EXPECT_EQUAL(size, s2n_stuffer_data_available(&stuffer));
             EXPECT_EQUAL(size, kem_preferences->kem_count * sizeof(kem_extension_size));
 
             /* Should write ids */
-            uint16_t actual_id;
+            uint16_t actual_id = 0;
             for (size_t i = 0; i < kem_preferences->kem_count; i++) {
                 POSIX_GUARD(s2n_stuffer_read_uint16(&stuffer, &actual_id));
                 EXPECT_EQUAL(actual_id, kem_preferences->kems[i]->kem_extension_id);
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
 
         /* Test receive - malformed length */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy_version));
 
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
 
         /* Test receive */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, pq_security_policy_version));
 

--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -151,7 +151,7 @@ int main(int argc, char **argv)
 
     /* Test: s2n_client_psk_is_missing */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         /* Okay if early data not requested */
@@ -176,7 +176,7 @@ int main(int argc, char **argv)
     {
         struct s2n_psk *psk = NULL;
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         EXPECT_FALSE(s2n_client_psk_extension.should_send(NULL));
@@ -289,7 +289,7 @@ int main(int argc, char **argv)
             struct s2n_stuffer out = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             struct s2n_psk *psk = NULL;
@@ -311,7 +311,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&out, &identity_size));
             EXPECT_EQUAL(identity_size, sizeof(test_identity));
 
-            uint8_t *identity_data;
+            uint8_t *identity_data = NULL;
             EXPECT_NOT_NULL(identity_data = s2n_stuffer_raw_read(&out, identity_size));
             EXPECT_BYTEARRAY_EQUAL(identity_data, test_identity, sizeof(test_identity));
 
@@ -333,7 +333,7 @@ int main(int argc, char **argv)
             struct s2n_stuffer out = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             struct s2n_psk_test_case test_cases[] = {
@@ -367,7 +367,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_stuffer_read_uint16(&out, &identity_size));
                 EXPECT_EQUAL(identity_size, test_cases[i].identity_size);
 
-                uint8_t *identity_data;
+                uint8_t *identity_data = NULL;
                 EXPECT_NOT_NULL(identity_data = s2n_stuffer_raw_read(&out, identity_size));
                 EXPECT_BYTEARRAY_EQUAL(identity_data, test_cases[i].identity, test_cases[i].identity_size);
 
@@ -389,7 +389,7 @@ int main(int argc, char **argv)
             struct s2n_stuffer out = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             struct s2n_config *config = s2n_config_new();
@@ -445,7 +445,7 @@ int main(int argc, char **argv)
             };
             struct s2n_psk_test_case test_cases[] = { matching_psk, non_matching_psk };
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             conn->handshake.handshake_type = HELLO_RETRY_REQUEST;
             conn->secure->cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
@@ -557,7 +557,7 @@ int main(int argc, char **argv)
     {
         /* Safety checks */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
             EXPECT_ERROR_WITH_ERRNO(s2n_select_external_psk(conn, NULL), S2N_ERR_NULL);
@@ -643,7 +643,7 @@ int main(int argc, char **argv)
         };
 
         for (size_t i = 0; i < s2n_array_len(test_cases); i++) {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->psk_params.type = S2N_PSK_TYPE_EXTERNAL;
 
@@ -848,7 +848,7 @@ int main(int argc, char **argv)
         {
             struct s2n_stuffer wire_identities_in = { 0 };
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
             EXPECT_ERROR_WITH_ERRNO(s2n_client_psk_recv_identity_list(conn, NULL), S2N_ERR_NULL);
@@ -861,7 +861,7 @@ int main(int argc, char **argv)
         {
             struct s2n_stuffer empty_wire_identities_in = { 0 };
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_OK(s2n_connection_set_psk_type(conn, S2N_PSK_TYPE_EXTERNAL));
 
@@ -873,7 +873,7 @@ int main(int argc, char **argv)
 
         /* Default selection logic: receive a list without a match */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_OK(s2n_connection_set_psk_type(conn, S2N_PSK_TYPE_EXTERNAL));
 
@@ -895,7 +895,7 @@ int main(int argc, char **argv)
 
         /* Default selection logic: receive a list with a match */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_OK(s2n_connection_set_psk_type(conn, S2N_PSK_TYPE_EXTERNAL));
 
@@ -922,7 +922,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(config);
             EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(config, s2n_test_error_select_psk_identity_callback, NULL));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_OK(s2n_connection_set_psk_type(conn, S2N_PSK_TYPE_EXTERNAL));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -945,7 +945,7 @@ int main(int argc, char **argv)
             uint16_t expected_wire_choice = 0;
             EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(config, s2n_test_select_psk_identity_callback, &expected_wire_choice));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             EXPECT_OK(s2n_connection_set_psk_type(conn, S2N_PSK_TYPE_EXTERNAL));
@@ -976,7 +976,7 @@ int main(int argc, char **argv)
             uint16_t expected_wire_choice = 10;
             EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(config, s2n_test_select_psk_identity_callback, &expected_wire_choice));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_OK(s2n_connection_set_psk_type(conn, S2N_PSK_TYPE_EXTERNAL));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -1006,7 +1006,7 @@ int main(int argc, char **argv)
             uint16_t expected_wire_choice = 0;
             EXPECT_SUCCESS(s2n_config_set_psk_selection_callback(config, s2n_test_select_psk_identity_callback, &expected_wire_choice));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_OK(s2n_connection_set_psk_type(conn, S2N_PSK_TYPE_EXTERNAL));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -1136,7 +1136,7 @@ int main(int argc, char **argv)
         struct s2n_blob valid_binder = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&valid_binder, valid_binder_data, sizeof(valid_binder_data)));
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         DEFER_CLEANUP(struct s2n_psk psk = { 0 }, s2n_psk_wipe);
@@ -1227,8 +1227,8 @@ int main(int argc, char **argv)
     /* Test: s2n_client_psk_recv */
     {
         const uint8_t client_hello_data[] = "ClientHello";
-        s2n_extension_type_id key_share_id;
-        s2n_extension_type_id psk_ke_mode_id;
+        s2n_extension_type_id key_share_id = 0;
+        s2n_extension_type_id psk_ke_mode_id = 0;
         EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_PSK_KEY_EXCHANGE_MODES, &psk_ke_mode_id));
         EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_KEY_SHARE, &key_share_id));
 
@@ -1239,7 +1239,7 @@ int main(int argc, char **argv)
                 0x00, 0x00, /* binder list size */
             };
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->client_hello.extensions.count = 1;
 
@@ -1279,7 +1279,7 @@ int main(int argc, char **argv)
                 0x00, 0x00,             /* binder list size */
             };
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_OK(s2n_connection_set_psk_type(conn, S2N_PSK_TYPE_EXTERNAL));
             conn->client_hello.extensions.count = 1;
@@ -1321,7 +1321,7 @@ int main(int argc, char **argv)
         {
             const uint8_t extension_data[] = { 0 };
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->client_hello.extensions.count = 1;
 
@@ -1343,7 +1343,7 @@ int main(int argc, char **argv)
         /* Receive a psk extension with an unknown psk key exchange mode */
         {
             const uint8_t extension_data[] = { 0 };
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->client_hello.extensions.count = 1;
 
@@ -1367,7 +1367,7 @@ int main(int argc, char **argv)
          * keyshare_extension */
         {
             const uint8_t extension_data[] = { 0 };
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->client_hello.extensions.count = 1;
 
@@ -1389,11 +1389,11 @@ int main(int argc, char **argv)
 
         /* The extension does not appear last in the extension list */
         {
-            s2n_extension_type_id psk_ext_id;
+            s2n_extension_type_id psk_ext_id = 0;
             EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_PRE_SHARED_KEY, &psk_ext_id));
 
             struct s2n_stuffer extension = { 0 };
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
             conn->client_hello.extensions.count = 2;
@@ -1415,11 +1415,11 @@ int main(int argc, char **argv)
                 0x12, 0x34, 0x56, /* Message: random data */
             };
 
-            struct s2n_connection *client_conn;
+            struct s2n_connection *client_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             struct s2n_stuffer *client_out = &client_conn->handshake.io;
 
-            struct s2n_connection *server_conn;
+            struct s2n_connection *server_conn = NULL;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             EXPECT_OK(s2n_connection_set_psk_type(server_conn, S2N_PSK_TYPE_EXTERNAL));
             struct s2n_stuffer *server_in = &server_conn->handshake.io;
@@ -1469,7 +1469,7 @@ int main(int argc, char **argv)
     /* Functional test */
     if (s2n_is_tls13_fully_supported()) {
         /* Setup connections */
-        struct s2n_connection *client_conn, *server_conn;
+        struct s2n_connection *client_conn = NULL, *server_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_OK(s2n_connection_set_psk_type(server_conn, S2N_PSK_TYPE_EXTERNAL));

--- a/tests/unit/s2n_client_record_version_test.c
+++ b/tests/unit/s2n_client_record_version_test.c
@@ -32,8 +32,8 @@
 
 int main(int argc, char **argv)
 {
-    char *cert_chain;
-    char *private_key;
+    char *cert_chain = NULL;
+    char *private_key = NULL;
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
@@ -43,8 +43,8 @@ int main(int argc, char **argv)
 
     /* Server negotiates TLS1.2 */
     {
-        struct s2n_connection *client_conn;
-        struct s2n_config *client_config;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_config *client_config = NULL;
         s2n_blocked_status client_blocked;
 
         uint8_t server_hello_message[] = {
@@ -177,8 +177,8 @@ int main(int argc, char **argv)
 
     /* Server negotiates SSLv3 */
     {
-        struct s2n_connection *client_conn;
-        struct s2n_config *client_config;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_config *client_config = NULL;
         s2n_blocked_status client_blocked;
 
         uint8_t server_hello_message[] = {

--- a/tests/unit/s2n_client_renegotiation_info_extension_test.c
+++ b/tests/unit/s2n_client_renegotiation_info_extension_test.c
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
 
     /* Test receive - too much data */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         struct s2n_stuffer stuffer = { 0 };
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
      *# and if it is not, MUST abort the handshake.
      */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         struct s2n_stuffer stuffer = { 0 };
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
 
     /* Test receive */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         struct s2n_stuffer stuffer = { 0 };

--- a/tests/unit/s2n_client_sct_list_extension_test.c
+++ b/tests/unit/s2n_client_sct_list_extension_test.c
@@ -23,10 +23,10 @@ int main(int argc, char **argv)
 
     /* Test should_send */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -43,10 +43,10 @@ int main(int argc, char **argv)
 
     /* Test send */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -63,10 +63,10 @@ int main(int argc, char **argv)
 
     /* Test receive */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 

--- a/tests/unit/s2n_client_secure_renegotiation_test.c
+++ b/tests/unit/s2n_client_secure_renegotiation_test.c
@@ -32,8 +32,8 @@
 
 int main(int argc, char **argv)
 {
-    char *cert_chain;
-    char *private_key;
+    char *cert_chain = NULL;
+    char *private_key = NULL;
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
@@ -43,8 +43,8 @@ int main(int argc, char **argv)
 
     /* Success: server sends an empty initial renegotiation_info */
     {
-        struct s2n_connection *client_conn;
-        struct s2n_config *client_config;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_config *client_config = NULL;
         s2n_blocked_status client_blocked;
 
         uint8_t server_extensions[] = {
@@ -136,8 +136,8 @@ int main(int argc, char **argv)
 
     /* Success: server doesn't send an renegotiation_info extension */
     {
-        struct s2n_connection *client_conn;
-        struct s2n_config *client_config;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_config *client_config = NULL;
         s2n_blocked_status client_blocked;
 
         uint8_t server_hello_message[] = {
@@ -214,8 +214,8 @@ int main(int argc, char **argv)
 
     /* Failure: server sends a non-empty initial renegotiation_info */
     {
-        struct s2n_connection *client_conn;
-        struct s2n_config *client_config;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_config *client_config = NULL;
         s2n_blocked_status client_blocked;
 
         uint8_t server_extensions[] = {

--- a/tests/unit/s2n_client_server_name_extension_test.c
+++ b/tests/unit/s2n_client_server_name_extension_test.c
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
 
     /* should_send */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         /* server_name not set -> don't send */
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
 
     /* send */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_set_server_name(conn, test_server_name));
 
@@ -53,20 +53,20 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_client_server_name_extension.send(conn, &stuffer));
 
-        uint16_t server_name_list_size;
+        uint16_t server_name_list_size = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &server_name_list_size));
         EXPECT_EQUAL(server_name_list_size, s2n_stuffer_data_available(&stuffer));
 
-        uint8_t name_type;
+        uint8_t name_type = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &name_type));
         EXPECT_EQUAL(name_type, 0);
 
-        uint16_t server_name_size;
+        uint16_t server_name_size = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &server_name_size));
         EXPECT_EQUAL(server_name_size, s2n_stuffer_data_available(&stuffer));
         EXPECT_EQUAL(server_name_size, strlen(test_server_name));
 
-        char *server_name_data;
+        char *server_name_data = NULL;
         EXPECT_NOT_NULL(server_name_data = s2n_stuffer_raw_read(&stuffer, server_name_size));
         EXPECT_BYTEARRAY_EQUAL(server_name_data, test_server_name, strlen(test_server_name));
 
@@ -78,10 +78,10 @@ int main(int argc, char **argv)
 
     /* recv - basic */
     {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
         struct s2n_stuffer stuffer = { 0 };
@@ -103,10 +103,10 @@ int main(int argc, char **argv)
 
     /* recv - server name already set */
     {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
 
         struct s2n_stuffer stuffer = { 0 };
@@ -126,10 +126,10 @@ int main(int argc, char **argv)
 
     /* recv - extra data ignored */
     {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
         struct s2n_stuffer stuffer = { 0 };
@@ -150,10 +150,10 @@ int main(int argc, char **argv)
 
     /* recv - malformed */
     {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
         struct s2n_stuffer stuffer = { 0 };

--- a/tests/unit/s2n_client_session_ticket_extension_test.c
+++ b/tests/unit/s2n_client_session_ticket_extension_test.c
@@ -32,16 +32,16 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    struct s2n_config *config;
+    struct s2n_config *config = NULL;
     EXPECT_NOT_NULL(config = s2n_config_new());
 
-    struct s2n_connection *client_conn;
+    struct s2n_connection *client_conn = NULL;
     EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
     EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
     /* should_send */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
 
     /* recv - decrypt ticket */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
 
     /* recv - ignore extension if TLS1.3 */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
 
     /* recv - ignore extension if not correct size */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -149,7 +149,7 @@ int main(int argc, char **argv)
 
     /* recv - ignore extension if tickets not allowed */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 

--- a/tests/unit/s2n_client_signature_algorithms_extension_test.c
+++ b/tests/unit/s2n_client_signature_algorithms_extension_test.c
@@ -28,10 +28,10 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
-    struct s2n_config *config;
+    struct s2n_config *config = NULL;
     EXPECT_NOT_NULL(config = s2n_config_new());
 
-    struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
             S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
             .iana_list = { 0xFF01, 0xFFFF, TLS_SIGNATURE_SCHEME_RSA_PKCS1_SHA384 },
             .len = 3,
         };
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         POSIX_GUARD(s2n_connection_set_config(conn, config));
         conn->actual_protocol_version = S2N_TLS12;

--- a/tests/unit/s2n_client_supported_groups_extension_test.c
+++ b/tests/unit/s2n_client_supported_groups_extension_test.c
@@ -32,7 +32,7 @@ int main()
 
     /* Test s2n_extension_should_send_if_ecc_enabled */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         /* ecc extensions are required for the default config */
@@ -46,7 +46,7 @@ int main()
 
     /* Test send (with default KEM prefs = kem_preferences_null) */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         struct s2n_stuffer stuffer = { 0 };
@@ -63,12 +63,12 @@ int main()
 
         EXPECT_SUCCESS(s2n_client_supported_groups_extension.send(conn, &stuffer));
 
-        uint16_t length;
+        uint16_t length = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &length));
         EXPECT_EQUAL(length, s2n_stuffer_data_available(&stuffer));
         EXPECT_EQUAL(length, ecc_pref->count * sizeof(uint16_t));
 
-        uint16_t curve_id;
+        uint16_t curve_id = 0;
         for (size_t i = 0; i < ecc_pref->count; i++) {
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &curve_id));
             EXPECT_EQUAL(curve_id, ecc_pref->ecc_curves[i]->iana_id);
@@ -99,7 +99,7 @@ int main()
         /* Test send with TLS 1.3 KEM groups */
         {
             EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             DEFER_CLEANUP(struct s2n_stuffer stuffer = { 0 }, s2n_stuffer_free);
@@ -116,7 +116,7 @@ int main()
 
             EXPECT_SUCCESS(s2n_client_supported_groups_extension.send(conn, &stuffer));
 
-            uint16_t length;
+            uint16_t length = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &length));
             uint16_t expected_length = ecc_pref->count * sizeof(uint16_t);
             uint32_t available_groups = 0;
@@ -128,7 +128,7 @@ int main()
             EXPECT_EQUAL(length, expected_length);
 
             if (s2n_pq_is_enabled()) {
-                uint16_t kem_id;
+                uint16_t kem_id = 0;
                 for (size_t i = 0; i < kem_pref->tls13_kem_group_count; i++) {
                     if (!s2n_kem_group_is_available(kem_pref->tls13_kem_groups[i])) {
                         continue;
@@ -138,7 +138,7 @@ int main()
                 }
             }
 
-            uint16_t curve_id;
+            uint16_t curve_id = 0;
             for (size_t i = 0; i < ecc_pref->count; i++) {
                 EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &curve_id));
                 EXPECT_EQUAL(curve_id, ecc_pref->ecc_curves[i]->iana_id);
@@ -149,7 +149,7 @@ int main()
         };
         /* Test that send does not send KEM group IDs for versions != TLS 1.3 */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_EQUAL(s2n_connection_get_protocol_version(conn), S2N_TLS12);
 
@@ -167,12 +167,12 @@ int main()
 
             EXPECT_SUCCESS(s2n_client_supported_groups_extension.send(conn, &stuffer));
 
-            uint16_t length;
+            uint16_t length = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &length));
             EXPECT_EQUAL(length, s2n_stuffer_data_available(&stuffer));
             EXPECT_EQUAL(length, ecc_pref->count * sizeof(uint16_t));
 
-            uint16_t curve_id;
+            uint16_t curve_id = 0;
             for (size_t i = 0; i < ecc_pref->count; i++) {
                 EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &curve_id));
                 EXPECT_EQUAL(curve_id, ecc_pref->ecc_curves[i]->iana_id);
@@ -191,11 +191,11 @@ int main()
 
             for (size_t i = 0; i < s2n_array_len(test_policy_overrides); i++) {
                 EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-                struct s2n_connection *client_conn;
+                struct s2n_connection *client_conn = NULL;
                 EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
                 client_conn->security_policy_override = test_policy_overrides[i][0];
 
-                struct s2n_connection *server_conn;
+                struct s2n_connection *server_conn = NULL;
                 EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
                 server_conn->security_policy_override = test_policy_overrides[i][1];
 
@@ -260,11 +260,11 @@ int main()
 
             for (size_t i = 0; i < NUM_MISMATCH_PQ_TEST_POLICY_OVERRIDES; i++) {
                 EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-                struct s2n_connection *client_conn;
+                struct s2n_connection *client_conn = NULL;
                 EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
                 client_conn->security_policy_override = test_policy_overrides[i][0];
 
-                struct s2n_connection *server_conn;
+                struct s2n_connection *server_conn = NULL;
                 EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
                 server_conn->security_policy_override = test_policy_overrides[i][1];
 
@@ -299,7 +299,7 @@ int main()
         {
             EXPECT_SUCCESS(s2n_enable_tls13_in_test());
 
-            struct s2n_connection *server_conn;
+            struct s2n_connection *server_conn = NULL;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
             server_conn->security_policy_override = &test_pq_security_policy_kyber;
 
@@ -332,7 +332,7 @@ int main()
         /* Test recv - server doesn't recognize PQ group IDs when TLS 1.3 is disabled */
         {
             EXPECT_SUCCESS(s2n_disable_tls13_in_test());
-            struct s2n_connection *client_conn;
+            struct s2n_connection *client_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_EQUAL(s2n_connection_get_protocol_version(client_conn), S2N_TLS12);
             client_conn->security_policy_override = &test_pq_security_policy_kyber;
@@ -345,7 +345,7 @@ int main()
             EXPECT_SUCCESS(s2n_connection_get_kem_preferences(client_conn, &client_kem_pref));
             EXPECT_NOT_NULL(client_kem_pref);
 
-            struct s2n_connection *server_conn;
+            struct s2n_connection *server_conn = NULL;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
             server_conn->security_policy_override = &test_pq_security_policy_kyber;
 
@@ -379,7 +379,7 @@ int main()
         {
             if (!s2n_pq_is_enabled()) {
                 EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-                struct s2n_connection *client_conn;
+                struct s2n_connection *client_conn = NULL;
                 EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
                 client_conn->security_policy_override = &test_pq_security_policy_kyber;
 
@@ -391,7 +391,7 @@ int main()
                 EXPECT_SUCCESS(s2n_connection_get_kem_preferences(client_conn, &client_kem_pref));
                 EXPECT_NOT_NULL(client_kem_pref);
 
-                struct s2n_connection *server_conn;
+                struct s2n_connection *server_conn = NULL;
                 EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
                 server_conn->security_policy_override = &test_pq_security_policy_kyber;
 
@@ -426,7 +426,7 @@ int main()
 
     /* Test recv */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         struct s2n_stuffer stuffer = { 0 };
@@ -451,7 +451,7 @@ int main()
 
     /* Test recv - no common curve */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         struct s2n_stuffer stuffer = { 0 };
@@ -477,7 +477,7 @@ int main()
 
     /* Test recv - malformed extension */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         struct s2n_stuffer stuffer = { 0 };
@@ -508,7 +508,7 @@ int main()
             { .iana_id = 0xFF01, .libcrypto_nid = 0, .name = 0x0, .share_size = 0 },
         };
         int ec_curves_count = s2n_array_len(unsupported_curves);
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         struct s2n_stuffer supported_groups_extension = { 0 };

--- a/tests/unit/s2n_client_supported_versions_extension_test.c
+++ b/tests/unit/s2n_client_supported_versions_extension_test.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
 
     uint8_t latest_version = S2N_TLS13;
 
-    struct s2n_config *config;
+    struct s2n_config *config = NULL;
     EXPECT_NOT_NULL(config = s2n_config_new());
 
     const struct s2n_security_policy *security_policy_with_tls13_and_earlier = &security_policy_20190801;
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
 
     /* Client produces a version list that the server can parse */
     {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
@@ -126,7 +126,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(expected_length, s2n_stuffer_data_available(&extension));
 
         /* Check that the server can process the version list */
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
 
     /* Server selects highest supported version shared by client */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
     /* Server does not process the extension if using TLS1.2. */
     {
         EXPECT_SUCCESS(s2n_disable_tls13_in_test());
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -195,7 +195,7 @@ int main(int argc, char **argv)
 
     /* Server terminates connection if there are no supported version in the list */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -220,7 +220,7 @@ int main(int argc, char **argv)
 
     /* Check grease values for the supported versions */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -247,7 +247,7 @@ int main(int argc, char **argv)
 
     /* Server selects highest supported protocol among list of invalid protocols (that purposefully test our conversion methods) */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -274,7 +274,7 @@ int main(int argc, char **argv)
 
     /* Server alerts if no shared supported version found */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -297,7 +297,7 @@ int main(int argc, char **argv)
 
     /* Server alerts if supported version list is empty */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -316,7 +316,7 @@ int main(int argc, char **argv)
 
     /* Server alerts if version list size exceeds the extension size */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -334,7 +334,7 @@ int main(int argc, char **argv)
 
     /* Server alerts if version list size is less than extension size */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -354,7 +354,7 @@ int main(int argc, char **argv)
 
     /* Server alerts if version list size is odd */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -376,7 +376,7 @@ int main(int argc, char **argv)
      * in the client hello, for backwards compatibility the version field
      * should be set to 1.2 even when a higher version is supported. */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_client_hello_send(conn));
 

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv)
 
     const s2n_mode modes[] = { S2N_CLIENT, S2N_SERVER };
 
-    const struct s2n_security_policy *default_security_policy, *tls13_security_policy, *fips_security_policy;
+    const struct s2n_security_policy *default_security_policy = NULL, *tls13_security_policy = NULL, *fips_security_policy = NULL;
     EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_tls13", &tls13_security_policy));
     EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_fips", &fips_security_policy));
     EXPECT_SUCCESS(s2n_find_security_policy_from_version("default", &default_security_policy));
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
 
     /* Test: s2n_config_new and tls13_default_config match */
     {
-        struct s2n_config *config, *default_config;
+        struct s2n_config *config = NULL, *default_config = NULL;
 
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_NOT_NULL(default_config = s2n_fetch_default_config());
@@ -106,8 +106,8 @@ int main(int argc, char **argv)
     {
         /* For TLS1.2 */
         if (!s2n_is_in_fips_mode()) {
-            struct s2n_connection *conn;
-            const struct s2n_security_policy *security_policy;
+            struct s2n_connection *conn = NULL;
+            const struct s2n_security_policy *security_policy = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             EXPECT_EQUAL(conn->config, s2n_fetch_default_config());
@@ -121,8 +121,8 @@ int main(int argc, char **argv)
         /* For TLS1.3 */
         {
             EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-            struct s2n_connection *conn;
-            const struct s2n_security_policy *security_policy;
+            struct s2n_connection *conn = NULL;
+            const struct s2n_security_policy *security_policy = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             EXPECT_EQUAL(conn->config, s2n_fetch_default_config());
@@ -136,8 +136,8 @@ int main(int argc, char **argv)
 
         /* For fips */
         if (s2n_is_in_fips_mode()) {
-            struct s2n_connection *conn;
-            const struct s2n_security_policy *security_policy;
+            struct s2n_connection *conn = NULL;
+            const struct s2n_security_policy *security_policy = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             EXPECT_EQUAL(conn->config, s2n_fetch_default_config());
@@ -153,7 +153,7 @@ int main(int argc, char **argv)
     /* Test for s2n_config_new() and tls 1.3 behavior */
     {
         if (!s2n_is_in_fips_mode()) {
-            struct s2n_config *config;
+            struct s2n_config *config = NULL;
             EXPECT_NOT_NULL(config = s2n_config_new());
             EXPECT_EQUAL(config->security_policy, default_security_policy);
             EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_20170210);
@@ -205,7 +205,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
-            struct s2n_config *config;
+            struct s2n_config *config = NULL;
             uint8_t num_tickets = 1;
 
             EXPECT_NOT_NULL(config = s2n_config_new());

--- a/tests/unit/s2n_connection_context_test.c
+++ b/tests/unit/s2n_connection_context_test.c
@@ -20,8 +20,8 @@
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
-    int ctx;
+    struct s2n_connection *conn = NULL;
+    int ctx = 0;
 
     struct s2n_connection *conn_null = NULL;
 

--- a/tests/unit/s2n_connection_preferences_test.c
+++ b/tests/unit/s2n_connection_preferences_test.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    const struct s2n_security_policy *default_security_policy, *tls13_security_policy, *fips_security_policy;
+    const struct s2n_security_policy *default_security_policy = NULL, *tls13_security_policy = NULL, *fips_security_policy = NULL;
     EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_tls13", &tls13_security_policy));
     EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_fips", &fips_security_policy));
     EXPECT_SUCCESS(s2n_find_security_policy_from_version("default", &default_security_policy));

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
 
         /* Return NULL by default / for new connection */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             EXPECT_NULL(s2n_get_server_name(conn));
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
 
         /* Return server_name if set */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_set_server_name(conn, test_server_name));
 
@@ -146,7 +146,7 @@ int main(int argc, char **argv)
 
         /* Return server_name if server_name extension parsed, but not yet processed */
         {
-            struct s2n_connection *client_conn, *server_conn;
+            struct s2n_connection *client_conn = NULL, *server_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
@@ -155,7 +155,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_set_server_name(client_conn, test_server_name));
             EXPECT_SUCCESS(s2n_client_server_name_extension.send(client_conn, &stuffer));
 
-            s2n_extension_type_id extension_id;
+            s2n_extension_type_id extension_id = 0;
             EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_SERVER_NAME, &extension_id));
             server_conn->client_hello.extensions.parsed_extensions[extension_id].extension_type = TLS_EXTENSION_SERVER_NAME;
             server_conn->client_hello.extensions.parsed_extensions[extension_id].extension = stuffer.blob;
@@ -173,15 +173,15 @@ int main(int argc, char **argv)
         {
             s2n_server_name_test_callback_flag = false;
 
-            struct s2n_config *config;
+            struct s2n_config *config = NULL;
             EXPECT_NOT_NULL(config = s2n_config_new());
             EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, s2n_server_name_test_callback, &test_server_name));
 
-            struct s2n_connection *client_conn;
+            struct s2n_connection *client_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_set_server_name(client_conn, test_server_name));
 
-            struct s2n_connection *server_conn;
+            struct s2n_connection *server_conn = NULL;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -204,7 +204,7 @@ int main(int argc, char **argv)
 
     /* s2n_connection_get_protocol_version */
     {
-        struct s2n_connection *client_conn, *server_conn;
+        struct s2n_connection *client_conn = NULL, *server_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_set_test_protocol_versions(client_conn));
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -229,7 +229,7 @@ int main(int argc, char **argv)
 
     /* Test: get selected digest alg */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         s2n_tls_hash_algorithm output = { 0 };
@@ -278,7 +278,7 @@ int main(int argc, char **argv)
 
     /* Test: get selected signature alg */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         s2n_tls_signature_algorithm output = { 0 };

--- a/tests/unit/s2n_drain_alert_test.c
+++ b/tests/unit/s2n_drain_alert_test.c
@@ -89,12 +89,12 @@ int main(int argc, char **argv)
         INTERNAL_ERROR_ALERT_HEX,
     };
 
-    struct s2n_connection *server_conn;
-    struct s2n_config *server_config;
+    struct s2n_connection *server_conn = NULL;
+    struct s2n_config *server_config = NULL;
     s2n_blocked_status server_blocked;
     char *cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE);
     char *private_key = malloc(S2N_MAX_TEST_PEM_SIZE);
-    struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
     struct s2n_test_io_pair io_pair;
     EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -351,7 +351,7 @@ int main(int argc, char **argv)
     EXPECT_OK(s2n_drbg_instantiate(&aes128_drbg, &blob, S2N_AES_128_CTR_NO_DF_PR));
     EXPECT_OK(s2n_drbg_instantiate(&aes256_pr_drbg, &blob, S2N_AES_256_CTR_NO_DF_PR));
 
-    struct s2n_config *config;
+    struct s2n_config *config = NULL;
     EXPECT_NOT_NULL(config = s2n_config_new());
 
     /* Use the AES128 DRBG for 32MB of data */

--- a/tests/unit/s2n_ecc_evp_test.c
+++ b/tests/unit/s2n_ecc_evp_test.c
@@ -134,7 +134,7 @@ int main(int argc, char** argv)
         for (size_t i = 0; i < s2n_all_supported_curves_list_len; i++) {
             struct s2n_ecc_evp_params test_params = { 0 };
             struct s2n_stuffer wire = { 0 };
-            uint8_t legacy_form;
+            uint8_t legacy_form = 0;
 
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&wire, 0));
 

--- a/tests/unit/s2n_ecc_point_format_extension_test.c
+++ b/tests/unit/s2n_ecc_point_format_extension_test.c
@@ -23,12 +23,12 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    struct s2n_config *config;
+    struct s2n_config *config = NULL;
     EXPECT_NOT_NULL(config = s2n_config_new());
 
     /* Test server should_send */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         /* Do not send for null connection */
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
 
     /* Test send */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -66,11 +66,11 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_client_ec_point_format_extension.send(conn, &stuffer));
 
-        uint8_t length;
+        uint8_t length = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &length));
         EXPECT_EQUAL(length, s2n_stuffer_data_available(&stuffer));
 
-        uint8_t point_format;
+        uint8_t point_format = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &point_format));
         EXPECT_EQUAL(point_format, TLS_EC_POINT_FORMAT_UNCOMPRESSED);
 
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
 
     /* Test recv */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 

--- a/tests/unit/s2n_encrypted_extensions_test.c
+++ b/tests/unit/s2n_encrypted_extensions_test.c
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
 
         /* Should fail for pre-TLS1.3 */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
 
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
 
         /* Should send no extensions by default */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
             conn->actual_protocol_version = S2N_TLS13;
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_encrypted_extensions_send(conn));
 
-            uint16_t extension_list_size;
+            uint16_t extension_list_size = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(stuffer, &extension_list_size));
             EXPECT_EQUAL(extension_list_size, 0);
             EXPECT_EQUAL(s2n_stuffer_data_available(stuffer), 0);
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
 
         /* Should send a requested extension */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
             conn->actual_protocol_version = S2N_TLS13;
@@ -86,12 +86,12 @@ int main(int argc, char **argv)
             conn->server_name_used = 1;
             EXPECT_SUCCESS(s2n_encrypted_extensions_send(conn));
 
-            uint16_t extension_list_size;
+            uint16_t extension_list_size = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(stuffer, &extension_list_size));
             EXPECT_NOT_EQUAL(extension_list_size, 0);
             EXPECT_EQUAL(s2n_stuffer_data_available(stuffer), extension_list_size);
 
-            uint16_t extension_type;
+            uint16_t extension_type = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(stuffer, &extension_type));
             EXPECT_EQUAL(extension_type, s2n_server_server_name_extension.iana_value);
 
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
 
         /* Should fail for pre-TLS1.3 */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
 
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
 
         /* Should parse an empty list */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
             conn->actual_protocol_version = S2N_TLS13;
@@ -149,7 +149,7 @@ int main(int argc, char **argv)
 
         /* Should parse a requested extension */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
             conn->actual_protocol_version = S2N_TLS13;
@@ -174,11 +174,11 @@ int main(int argc, char **argv)
     if (s2n_is_tls13_fully_supported()) {
         s2n_blocked_status blocked = S2N_NOT_BLOCKED;
 
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
                 S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
 
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));

--- a/tests/unit/s2n_extended_master_secret_test.c
+++ b/tests/unit/s2n_extended_master_secret_test.c
@@ -23,7 +23,7 @@ int main(int argc, char **argv)
 
     /* Test s2n_conn_set_handshake_type is processing EMS data correctly */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         uint64_t current_time = 0;
         EXPECT_NOT_NULL(config = s2n_config_new());
 

--- a/tests/unit/s2n_extension_list_parse_test.c
+++ b/tests/unit/s2n_extension_list_parse_test.c
@@ -75,7 +75,7 @@ int main()
     s2n_extension_type empty_test_extension = test_extension;
     empty_test_extension.send = s2n_extension_send_no_data;
 
-    struct s2n_connection *conn;
+    struct s2n_connection *conn = NULL;
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
     /* Safety checks */
@@ -408,7 +408,7 @@ int main()
 
         uint16_t expected_order[] = { test_extension.iana_value, test_extension_2.iana_value, test_extension_3.iana_value };
         for (size_t i = 0; i < s2n_array_len(expected_order); i++) {
-            s2n_extension_type_id id;
+            s2n_extension_type_id id = 0;
             EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(expected_order[i], &id));
             EXPECT_EQUAL(parsed_extension_list.parsed_extensions[id].wire_index, i);
         }

--- a/tests/unit/s2n_extension_list_process_test.c
+++ b/tests/unit/s2n_extension_list_process_test.c
@@ -78,7 +78,7 @@ int main()
             .if_missing = s2n_extension_noop_if_missing,
         };
 
-        s2n_extension_type_id test_extension_type_internal_id;
+        s2n_extension_type_id test_extension_type_internal_id = 0;
         EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(test_extension_type.iana_value,
                 &test_extension_type_internal_id));
 
@@ -101,7 +101,7 @@ int main()
                 .extension = extension_blob,
             };
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             SET_PARSED_EXTENSION(parsed_extension_list, test_parsed_extension);
@@ -154,7 +154,7 @@ int main()
                 .extension = empty_blob,
             };
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             SET_PARSED_EXTENSION(parsed_extension_list, test_parsed_extension);
@@ -176,7 +176,7 @@ int main()
                 .extension = extension_blob,
             };
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             parsed_extension_list.parsed_extensions[test_extension_type_internal_id] = test_parsed_extension;
@@ -200,7 +200,7 @@ int main()
                 s2n_extension_type test_required_extension_type = test_extension_type;
                 test_required_extension_type.if_missing = s2n_extension_error_if_missing;
 
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
                 received_flag = false;
@@ -220,7 +220,7 @@ int main()
                 s2n_extension_type test_optional_extension_type = test_extension_type;
                 test_optional_extension_type.if_missing = s2n_extension_noop_if_missing;
 
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
                 received_flag = false;
@@ -244,7 +244,7 @@ int main()
 
         /* Set up parsed_extensions for simple real extensions */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
             EXPECT_SUCCESS(s2n_setup_test_parsed_extension(&s2n_server_server_name_extension,
@@ -277,7 +277,7 @@ int main()
         {
             s2n_parsed_extensions_list parsed_extension_list = { 0 };
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
 
@@ -297,7 +297,7 @@ int main()
         {
             s2n_parsed_extensions_list parsed_extension_list = { 0 };
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
 
@@ -319,7 +319,7 @@ int main()
         {
             s2n_parsed_extensions_list parsed_extension_list = { 0 };
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(conn));
 

--- a/tests/unit/s2n_extension_list_send_test.c
+++ b/tests/unit/s2n_extension_list_send_test.c
@@ -39,11 +39,11 @@ int main(int argc, char **argv)
         struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_extension_list_send(S2N_EXTENSION_LIST_EMPTY, conn, &stuffer));
 
-        uint16_t extension_list_size;
+        uint16_t extension_list_size = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &extension_list_size));
         EXPECT_EQUAL(extension_list_size, s2n_stuffer_data_available(&stuffer));
         EXPECT_EQUAL(extension_list_size, 0);
@@ -57,11 +57,11 @@ int main(int argc, char **argv)
         struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_extension_list_send(S2N_EXTENSION_LIST_CLIENT_HELLO, conn, &stuffer));
 
-        uint16_t extension_list_size;
+        uint16_t extension_list_size = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &extension_list_size));
         EXPECT_EQUAL(extension_list_size, s2n_stuffer_data_available(&stuffer));
         EXPECT_NOT_EQUAL(extension_list_size, 0);
@@ -75,14 +75,14 @@ int main(int argc, char **argv)
         struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         /* S2N_EXTENSION_LIST_CERTIFICATE only sends responses, and we haven't received any requests.
          * Therefore, it should write an empty extensions list. */
         EXPECT_SUCCESS(s2n_extension_list_send(S2N_EXTENSION_LIST_CERTIFICATE, conn, &stuffer));
 
-        uint16_t extension_list_size;
+        uint16_t extension_list_size = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &extension_list_size));
         EXPECT_EQUAL(extension_list_size, s2n_stuffer_data_available(&stuffer));
         EXPECT_EQUAL(extension_list_size, 0);
@@ -96,18 +96,18 @@ int main(int argc, char **argv)
         struct s2n_stuffer stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_extension_list_send(S2N_EXTENSION_LIST_CLIENT_HELLO, client_conn, &stuffer));
 
         /* Skip list size - already tested */
         EXPECT_SUCCESS(s2n_stuffer_skip_read(&stuffer, sizeof(uint16_t)));
 
-        uint16_t first_extension_type;
+        uint16_t first_extension_type = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &first_extension_type));
         EXPECT_EQUAL(first_extension_type, TLS_EXTENSION_SUPPORTED_VERSIONS);
 
-        uint16_t first_extension_size;
+        uint16_t first_extension_size = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &first_extension_size));
         EXPECT_NOT_EQUAL(first_extension_size, 0);
 
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&extensions_stuffer, 0));
         EXPECT_SUCCESS(s2n_stuffer_copy(&stuffer, &extensions_stuffer, first_extension_size));
 
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_extension_recv(&s2n_client_supported_versions_extension, server_conn, &extensions_stuffer));
 

--- a/tests/unit/s2n_extension_type_test.c
+++ b/tests/unit/s2n_extension_type_test.c
@@ -251,12 +251,12 @@ int main()
             EXPECT_TRUE(S2N_CBIT_TEST(conn.extension_requests_sent, test_extension_id));
 
             /* writes iana_value */
-            uint16_t iana_value;
+            uint16_t iana_value = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &iana_value));
             EXPECT_EQUAL(iana_value, request_extension_type.iana_value);
 
             /* writes length */
-            uint16_t length;
+            uint16_t length = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &length));
             EXPECT_EQUAL(length, s2n_stuffer_data_available(&stuffer));
             EXPECT_EQUAL(length, S2N_TEST_DATA_LEN);
@@ -301,12 +301,12 @@ int main()
             EXPECT_BITFIELD_CLEAR(conn.extension_requests_sent);
 
             /* writes iana_value */
-            uint16_t iana_value;
+            uint16_t iana_value = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &iana_value));
             EXPECT_EQUAL(iana_value, response_extension_type.iana_value);
 
             /* writes length */
-            uint16_t length;
+            uint16_t length = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &length));
             EXPECT_EQUAL(length, s2n_stuffer_data_available(&stuffer));
             EXPECT_EQUAL(length, S2N_TEST_DATA_LEN);

--- a/tests/unit/s2n_fragmentation_coalescing_test.c
+++ b/tests/unit/s2n_fragmentation_coalescing_test.c
@@ -391,12 +391,12 @@ void interleaved_fragmented_warning_alert(int write_fd)
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
-    struct s2n_config *config;
+    struct s2n_connection *conn = NULL;
+    struct s2n_config *config = NULL;
 
     s2n_blocked_status blocked;
-    int status;
-    pid_t pid;
+    int status = 0;
+    pid_t pid = 0;
     int p[2];
 
     BEGIN_TEST();

--- a/tests/unit/s2n_handshake_errno_test.c
+++ b/tests/unit/s2n_handshake_errno_test.c
@@ -37,7 +37,7 @@ int fake_send(void *io_context, const uint8_t *buf, uint32_t len)
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
+    struct s2n_connection *conn = NULL;
     s2n_blocked_status blocked;
 
     BEGIN_TEST();

--- a/tests/unit/s2n_handshake_invariant_test.c
+++ b/tests/unit/s2n_handshake_invariant_test.c
@@ -68,7 +68,7 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    struct s2n_connection *conn;
+    struct s2n_connection *conn = NULL;
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
     /* Initialize *some* handshake type. Not terribly relevant for this test. */

--- a/tests/unit/s2n_handshake_io_test.c
+++ b/tests/unit/s2n_handshake_io_test.c
@@ -37,7 +37,7 @@ int main(int argc, char **argv)
     /* s2n_negotiate can't be called recursively */
     {
         /* Setup connections */
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_OK(s2n_connection_set_secrets(conn));
 

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -243,9 +243,9 @@ int main(int argc, char **argv)
     for (test_type = TEST_TYPE_START; test_type < TEST_TYPE_END; test_type++) {
         /*  Test: RSA cert */
         {
-            struct s2n_config *server_config, *client_config;
+            struct s2n_config *server_config = NULL, *client_config = NULL;
 
-            struct s2n_cert_chain_and_key *chain_and_key;
+            struct s2n_cert_chain_and_key *chain_and_key = NULL;
             EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
                     S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
 
@@ -278,9 +278,9 @@ int main(int argc, char **argv)
             if (!s2n_is_in_fips_mode()) {
                 /* Enable TLS 1.3 for the client */
                 EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-                struct s2n_config *server_config, *client_config;
+                struct s2n_config *server_config = NULL, *client_config = NULL;
 
-                struct s2n_cert_chain_and_key *chain_and_key;
+                struct s2n_cert_chain_and_key *chain_and_key = NULL;
                 EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
                         S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
 
@@ -314,9 +314,9 @@ int main(int argc, char **argv)
 
         /*  Test: ECDSA cert */
         {
-            struct s2n_config *server_config, *client_config;
+            struct s2n_config *server_config = NULL, *client_config = NULL;
 
-            struct s2n_cert_chain_and_key *chain_and_key;
+            struct s2n_cert_chain_and_key *chain_and_key = NULL;
             EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
                     S2N_ECDSA_P384_PKCS1_CERT_CHAIN, S2N_ECDSA_P384_PKCS1_KEY));
 
@@ -358,9 +358,9 @@ int main(int argc, char **argv)
                 .signature_schemes = rsa_pss_rsae_sig_schemes,
             };
 
-            struct s2n_config *server_config, *client_config;
+            struct s2n_config *server_config = NULL, *client_config = NULL;
 
-            struct s2n_cert_chain_and_key *chain_and_key;
+            struct s2n_cert_chain_and_key *chain_and_key = NULL;
             EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
                     S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
 
@@ -403,9 +403,9 @@ int main(int argc, char **argv)
         if (s2n_is_rsa_pss_certs_supported()) {
             s2n_enable_tls13_in_test();
 
-            struct s2n_config *server_config, *client_config;
+            struct s2n_config *server_config = NULL, *client_config = NULL;
 
-            struct s2n_cert_chain_and_key *chain_and_key;
+            struct s2n_cert_chain_and_key *chain_and_key = NULL;
             EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
                     S2N_RSA_PSS_2048_SHA256_LEAF_CERT, S2N_RSA_PSS_2048_SHA256_LEAF_KEY));
 

--- a/tests/unit/s2n_hash_test.c
+++ b/tests/unit/s2n_hash_test.c
@@ -35,7 +35,7 @@ int main(int argc, char **argv)
     struct s2n_hash_state hash, copy;
     struct s2n_blob out = { 0 };
     POSIX_GUARD(s2n_blob_init(&out, output_pad, sizeof(output_pad)));
-    uint64_t bytes_in_hash;
+    uint64_t bytes_in_hash = 0;
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
 
     if (s2n_hash_is_available(S2N_HASH_MD5)) {
         /* Try MD5 */
-        uint8_t md5_digest_size;
+        uint8_t md5_digest_size = 0;
         POSIX_GUARD(s2n_hash_digest_size(S2N_HASH_MD5, &md5_digest_size));
         EXPECT_EQUAL(md5_digest_size, 16);
         EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_MD5));
@@ -89,7 +89,7 @@ int main(int argc, char **argv)
     }
 
     /* Try SHA1 */
-    uint8_t sha1_digest_size;
+    uint8_t sha1_digest_size = 0;
     POSIX_GUARD(s2n_hash_digest_size(S2N_HASH_SHA1, &sha1_digest_size));
     EXPECT_EQUAL(sha1_digest_size, 20);
     EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_SHA1));
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(bytes_in_hash, 0);
 
     /* Try SHA224 and test s2n_hash_free */
-    uint8_t sha224_digest_size;
+    uint8_t sha224_digest_size = 0;
     POSIX_GUARD(s2n_hash_digest_size(S2N_HASH_SHA224, &sha224_digest_size));
     EXPECT_EQUAL(sha224_digest_size, 28);
     EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_SHA224));
@@ -240,7 +240,7 @@ int main(int argc, char **argv)
     EXPECT_FALSE(s2n_hash_is_ready_for_input(&hash));
     EXPECT_FAILURE(s2n_hash_get_currently_in_hash_total(&hash, &bytes_in_hash));
 
-    uint8_t sha256_digest_size;
+    uint8_t sha256_digest_size = 0;
     POSIX_GUARD(s2n_hash_digest_size(S2N_HASH_SHA256, &sha256_digest_size));
     EXPECT_EQUAL(sha256_digest_size, 32);
     EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_SHA256));
@@ -271,7 +271,7 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(bytes_in_hash, 0);
 
     /* Try SHA384 */
-    uint8_t sha384_digest_size;
+    uint8_t sha384_digest_size = 0;
     POSIX_GUARD(s2n_hash_digest_size(S2N_HASH_SHA384, &sha384_digest_size));
     EXPECT_EQUAL(sha384_digest_size, 48);
     EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_SHA384));
@@ -302,7 +302,7 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(bytes_in_hash, 0);
 
     /* Try SHA512 */
-    uint8_t sha512_digest_size;
+    uint8_t sha512_digest_size = 0;
     POSIX_GUARD(s2n_hash_digest_size(S2N_HASH_SHA512, &sha512_digest_size));
     EXPECT_EQUAL(sha512_digest_size, 64);
     EXPECT_SUCCESS(s2n_hash_init(&hash, S2N_HASH_SHA512));

--- a/tests/unit/s2n_hmac_test.c
+++ b/tests/unit/s2n_hmac_test.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
 
     if (s2n_hmac_is_available(S2N_HMAC_SSLv3_MD5)) {
         /* Try SSLv3 MD5 */
-        uint8_t hmac_sslv3_md5_size;
+        uint8_t hmac_sslv3_md5_size = 0;
         POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_SSLv3_MD5, &hmac_sslv3_md5_size));
         EXPECT_EQUAL(hmac_sslv3_md5_size, 16);
         EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_SSLv3_MD5, sekrit, strlen((char *) sekrit)));
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
 
     if (s2n_hmac_is_available(S2N_HMAC_SSLv3_SHA1)) {
         /* Try SSLv3 SHA1 */
-        uint8_t hmac_sslv3_sha1_size;
+        uint8_t hmac_sslv3_sha1_size = 0;
         POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_SSLv3_SHA1, &hmac_sslv3_sha1_size));
         EXPECT_EQUAL(hmac_sslv3_sha1_size, 20);
         EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_SSLv3_SHA1, sekrit, strlen((char *) sekrit)));
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
 
     if (s2n_hmac_is_available(S2N_HMAC_MD5)) {
         /* Try MD5 */
-        uint8_t hmac_md5_size;
+        uint8_t hmac_md5_size = 0;
         POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_MD5, &hmac_md5_size));
         EXPECT_EQUAL(hmac_md5_size, 16);
         EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_MD5, sekrit, strlen((char *) sekrit)));
@@ -134,7 +134,7 @@ int main(int argc, char **argv)
     }
 
     /* Try SHA1 */
-    uint8_t hmac_sha1_size;
+    uint8_t hmac_sha1_size = 0;
     POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_SHA1, &hmac_sha1_size));
     EXPECT_EQUAL(hmac_sha1_size, 20);
     EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_SHA1, sekrit, strlen((char *) sekrit)));
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
     /* Try SHA224 */
     EXPECT_SUCCESS(s2n_hmac_new(&hmac));
 
-    uint8_t hmac_sha224_size;
+    uint8_t hmac_sha224_size = 0;
     POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_SHA224, &hmac_sha224_size));
     EXPECT_EQUAL(hmac_sha224_size, 28);
     EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_SHA224, sekrit, strlen((char *) sekrit)));
@@ -235,7 +235,7 @@ int main(int argc, char **argv)
     /* Try SHA256 */
     EXPECT_SUCCESS(s2n_hmac_new(&hmac));
 
-    uint8_t hmac_sha256_size;
+    uint8_t hmac_sha256_size = 0;
     POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_SHA256, &hmac_sha256_size));
     EXPECT_EQUAL(hmac_sha256_size, 32);
     EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_SHA256, sekrit, strlen((char *) sekrit)));
@@ -254,7 +254,7 @@ int main(int argc, char **argv)
     /* Try SHA384 */
     EXPECT_SUCCESS(s2n_hmac_new(&hmac));
 
-    uint8_t hmac_sha384_size;
+    uint8_t hmac_sha384_size = 0;
     POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_SHA384, &hmac_sha384_size));
     EXPECT_EQUAL(hmac_sha384_size, 48);
     EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_SHA384, sekrit, strlen((char *) sekrit)));
@@ -273,7 +273,7 @@ int main(int argc, char **argv)
     /* Try SHA512 */
     EXPECT_SUCCESS(s2n_hmac_new(&hmac));
 
-    uint8_t hmac_sha512_size;
+    uint8_t hmac_sha512_size = 0;
     POSIX_GUARD(s2n_hmac_digest_size(S2N_HMAC_SHA512, &hmac_sha512_size));
     EXPECT_EQUAL(hmac_sha512_size, 64);
     EXPECT_SUCCESS(s2n_hmac_init(&hmac, S2N_HMAC_SHA512, sekrit, strlen((char *) sekrit)));

--- a/tests/unit/s2n_kex_with_kem_test.c
+++ b/tests/unit/s2n_kex_with_kem_test.c
@@ -40,8 +40,8 @@ static struct s2n_cipher_suite kyber_test_suite = {
 
 static int do_kex_with_kem(struct s2n_cipher_suite *cipher_suite, const char *security_policy_version, const struct s2n_kem *negotiated_kem)
 {
-    struct s2n_connection *client_conn;
-    struct s2n_connection *server_conn;
+    struct s2n_connection *client_conn = NULL;
+    struct s2n_connection *server_conn = NULL;
 
     POSIX_GUARD_PTR(client_conn = s2n_connection_new(S2N_CLIENT));
     POSIX_GUARD_PTR(server_conn = s2n_connection_new(S2N_SERVER));
@@ -116,7 +116,7 @@ static int do_kex_with_kem(struct s2n_cipher_suite *cipher_suite, const char *se
 
 static int assert_pq_disabled_checks(struct s2n_cipher_suite *cipher_suite, const char *security_policy_version, const struct s2n_kem *negotiated_kem)
 {
-    struct s2n_connection *server_conn;
+    struct s2n_connection *server_conn = NULL;
     POSIX_GUARD_PTR(server_conn = s2n_connection_new(S2N_SERVER));
     const struct s2n_security_policy *security_policy = NULL;
     POSIX_GUARD(s2n_find_security_policy_from_version(security_policy_version, &security_policy));

--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -82,15 +82,15 @@ int main(int argc, char **argv)
             /* Move stuffer write cursor to correct position */
             EXPECT_SUCCESS(s2n_stuffer_skip_write(&key_update_stuffer, S2N_KEY_UPDATE_MESSAGE_SIZE));
 
-            uint8_t post_handshake_id;
+            uint8_t post_handshake_id = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint8(&key_update_stuffer, &post_handshake_id));
             EXPECT_EQUAL(post_handshake_id, TLS_KEY_UPDATE);
 
-            uint32_t request_length;
+            uint32_t request_length = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint24(&key_update_stuffer, &request_length));
             EXPECT_EQUAL(request_length, S2N_KEY_UPDATE_LENGTH);
 
-            uint8_t key_update_request;
+            uint8_t key_update_request = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint8(&key_update_stuffer, &key_update_request));
             EXPECT_EQUAL(key_update_request, S2N_KEY_UPDATE_NOT_REQUESTED);
         };
@@ -111,11 +111,11 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_alloc(&input, test_data_len));
             EXPECT_SUCCESS(s2n_stuffer_skip_write(&input, test_data_len));
 
-            struct s2n_config *quic_config;
+            struct s2n_config *quic_config = NULL;
             EXPECT_NOT_NULL(quic_config = s2n_config_new());
             EXPECT_SUCCESS(s2n_config_enable_quic(quic_config));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, quic_config));
 
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_alloc(&input, test_data_len));
             EXPECT_SUCCESS(s2n_stuffer_skip_write(&input, test_data_len));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS12;
 
@@ -193,7 +193,7 @@ int main(int argc, char **argv)
             DEFER_CLEANUP(struct s2n_stuffer input, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             /* Write invalid value for key update request type */
             EXPECT_SUCCESS(s2n_stuffer_write_uint8(&input, -1));
@@ -208,7 +208,7 @@ int main(int argc, char **argv)
             DEFER_CLEANUP(struct s2n_stuffer input, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
 
-            struct s2n_connection *server_conn;
+            struct s2n_connection *server_conn = NULL;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             server_conn->actual_protocol_version = S2N_TLS13;
             server_conn->secure->cipher_suite = cipher_suite_with_limit;
@@ -231,7 +231,7 @@ int main(int argc, char **argv)
             DEFER_CLEANUP(struct s2n_stuffer input, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
 
-            struct s2n_connection *client_conn;
+            struct s2n_connection *client_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure->cipher_suite = cipher_suite_with_limit;
@@ -322,7 +322,7 @@ int main(int argc, char **argv)
     {
         /* Key update has been requested */
         {
-            struct s2n_connection *client_conn;
+            struct s2n_connection *client_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure->cipher_suite = cipher_suite_with_limit;
@@ -349,7 +349,7 @@ int main(int argc, char **argv)
 
         /* Key update is triggered by encryption limits */
         {
-            struct s2n_connection *client_conn;
+            struct s2n_connection *client_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure->cipher_suite = cipher_suite_with_limit;
@@ -404,7 +404,7 @@ int main(int argc, char **argv)
 
         /* Key update is not triggered */
         {
-            struct s2n_connection *client_conn;
+            struct s2n_connection *client_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure->cipher_suite = cipher_suite_with_limit;

--- a/tests/unit/s2n_malformed_handshake_test.c
+++ b/tests/unit/s2n_malformed_handshake_test.c
@@ -228,8 +228,8 @@ void send_messages(int write_fd, uint8_t *server_hello, uint32_t server_hello_le
 int main(int argc, char **argv)
 {
     s2n_blocked_status blocked;
-    int status;
-    pid_t pid;
+    int status = 0;
+    pid_t pid = 0;
     int p[2];
 
     BEGIN_TEST();

--- a/tests/unit/s2n_map_test.c
+++ b/tests/unit/s2n_map_test.c
@@ -27,10 +27,10 @@ int main(int argc, char **argv)
     char keystr[sizeof("ffff")];
     char valstr[sizeof("16384")];
     uint32_t size = 0;
-    struct s2n_map *empty, *map;
+    struct s2n_map *empty = NULL, *map = NULL;
     struct s2n_blob key = { 0 };
     struct s2n_blob val = { 0 };
-    bool key_found;
+    bool key_found = false;
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());

--- a/tests/unit/s2n_mem_allocator_test.c
+++ b/tests/unit/s2n_mem_allocator_test.c
@@ -45,7 +45,7 @@ static int custom_mem_cleanup(void)
 
 static int custom_mem_malloc(void **ptr, uint32_t requested, uint32_t *allocated)
 {
-    int i;
+    int i = 0;
     for (i = 0; i < HISTOGRAM_SIZE; i++) {
         if (histogram_values[i] == 0) {
             histogram_values[i] = requested;
@@ -78,8 +78,8 @@ static int custom_mem_free(void *ptr, uint32_t size)
 void mock_client(struct s2n_test_io_pair *io_pair)
 {
     char buffer[0xffff];
-    struct s2n_connection *conn;
-    struct s2n_config *config;
+    struct s2n_connection *conn = NULL;
+    struct s2n_config *config = NULL;
     s2n_blocked_status blocked;
 
     /* Give the server a chance to listen */
@@ -101,7 +101,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
     uint16_t timeout = 1;
     s2n_connection_set_dynamic_record_threshold(conn, 0x7fff, timeout);
-    int i;
+    int i = 0;
     for (i = 1; i < 0xffff - 100; i += 100) {
         for (int j = 0; j < i; j++) {
             buffer[j] = 33;
@@ -118,7 +118,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
     /* Simulate timeout second conneciton inactivity and tolerate 50 ms error */
     struct timespec sleep_time = { .tv_sec = timeout, .tv_nsec = 50000000 };
-    int r;
+    int r = 0;
     do {
         r = nanosleep(&sleep_time, &sleep_time);
     } while (r != 0);
@@ -148,10 +148,10 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 int main(int argc, char **argv)
 {
     s2n_blocked_status blocked;
-    int status;
-    char *cert_chain_pem;
-    char *private_key_pem;
-    char *dhparams_pem;
+    int status = 0;
+    char *cert_chain_pem = NULL;
+    char *private_key_pem = NULL;
+    char *dhparams_pem = NULL;
 
     /* We have to set the callback before BEGIN_TEST, because s2n_init() is called
      * there.

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -76,8 +76,8 @@
 ssize_t get_vm_data_size()
 {
 #ifdef __linux__
-    long page_size;
-    ssize_t size, resident, share, text, lib, data, dt;
+    long page_size = 0;
+    ssize_t size = 0, resident = 0, share = 0, text = 0, lib = 0, data = 0, dt = 0;
 
     page_size = sysconf(_SC_PAGESIZE);
     if (page_size < 0) {
@@ -149,8 +149,8 @@ int main(int argc, char **argv)
 {
     size_t connectionsToUse = MAX_CONNECTIONS;
 
-    char *cert_chain;
-    char *private_key;
+    char *cert_chain = NULL;
+    char *private_key = NULL;
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -181,13 +181,13 @@ int main(int argc, char **argv)
     EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
 
-    struct s2n_config *client_config;
+    struct s2n_config *client_config = NULL;
     EXPECT_NOT_NULL(client_config = s2n_config_new());
     EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(client_config, 0));
     EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
 
-    struct s2n_cert_chain_and_key *chain_and_key;
-    struct s2n_config *server_config;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
+    struct s2n_config *server_config = NULL;
     EXPECT_NOT_NULL(server_config = s2n_config_new());
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key, S2N_MAX_TEST_PEM_SIZE));
@@ -200,13 +200,13 @@ int main(int argc, char **argv)
 
     /* Allocate all connections */
     for (size_t i = 0; i < connectionsToUse; i++) {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
         EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
         clients[i] = client_conn;
 
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
         EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));

--- a/tests/unit/s2n_mutual_auth_test.c
+++ b/tests/unit/s2n_mutual_auth_test.c
@@ -39,13 +39,13 @@ static uint8_t verify_host_fn(const char *host_name, size_t host_name_len, void 
 
 int main(int argc, char **argv)
 {
-    struct s2n_config *config;
-    const struct s2n_security_policy *default_security_policy;
-    const struct s2n_cipher_preferences *default_cipher_preferences;
-    char *cert_chain_pem;
-    char *private_key_pem;
-    char *dhparams_pem;
-    struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_config *config = NULL;
+    const struct s2n_security_policy *default_security_policy = NULL;
+    const struct s2n_cipher_preferences *default_cipher_preferences = NULL;
+    char *cert_chain_pem = NULL;
+    char *private_key_pem = NULL;
+    char *dhparams_pem = NULL;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -84,8 +84,8 @@ int main(int argc, char **argv)
         verify_data.callback_invoked = 0;
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_security_policy server_security_policy;
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
         struct s2n_stuffer client_to_server = { 0 };
         struct s2n_stuffer server_to_client = { 0 };
 
@@ -143,8 +143,8 @@ int main(int argc, char **argv)
     for (size_t cipher_idx = 0; cipher_idx < default_cipher_preferences->count; cipher_idx++) {
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_security_policy server_security_policy;
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
         struct s2n_stuffer client_to_server = { 0 };
         struct s2n_stuffer server_to_client = { 0 };
 
@@ -197,8 +197,8 @@ int main(int argc, char **argv)
     for (size_t cipher_idx = 0; cipher_idx < default_cipher_preferences->count; cipher_idx++) {
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_security_policy server_security_policy;
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
         struct s2n_stuffer client_to_server = { 0 };
         struct s2n_stuffer server_to_client = { 0 };
 
@@ -257,8 +257,8 @@ int main(int argc, char **argv)
     for (size_t cipher_idx = 0; cipher_idx < default_cipher_preferences->count; cipher_idx++) {
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_security_policy server_security_policy;
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
         struct s2n_stuffer client_to_server = { 0 };
         struct s2n_stuffer server_to_client = { 0 };
 

--- a/tests/unit/s2n_optional_client_auth_test.c
+++ b/tests/unit/s2n_optional_client_auth_test.c
@@ -25,14 +25,14 @@
 
 int main(int argc, char **argv)
 {
-    struct s2n_config *client_config;
-    struct s2n_config *server_config;
-    const struct s2n_security_policy *default_security_policy;
-    const struct s2n_cipher_preferences *default_cipher_preferences;
-    char *cert_chain_pem;
-    char *private_key_pem;
-    char *dhparams_pem;
-    struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_config *client_config = NULL;
+    struct s2n_config *server_config = NULL;
+    const struct s2n_security_policy *default_security_policy = NULL;
+    const struct s2n_cipher_preferences *default_cipher_preferences = NULL;
+    char *cert_chain_pem = NULL;
+    char *private_key_pem = NULL;
+    char *dhparams_pem = NULL;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -77,8 +77,8 @@ int main(int argc, char **argv)
     for (int cipher_idx = 0; cipher_idx < default_security_policy->cipher_preferences->count; cipher_idx++) {
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_security_policy security_policy;
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
 
         /* Craft a cipher preference with a cipher_idx cipher. */
         EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
@@ -141,8 +141,8 @@ int main(int argc, char **argv)
     for (int cipher_idx = 0; cipher_idx < default_cipher_preferences->count; cipher_idx++) {
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_security_policy security_policy;
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
 
         /* Craft a cipher preference with a cipher_idx cipher. */
         EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
@@ -204,8 +204,8 @@ int main(int argc, char **argv)
     for (int cipher_idx = 0; cipher_idx < default_cipher_preferences->count; cipher_idx++) {
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_security_policy security_policy;
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
 
         /* Craft a cipher preference with a cipher_idx cipher. */
         EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
@@ -268,8 +268,8 @@ int main(int argc, char **argv)
     for (int cipher_idx = 0; cipher_idx < default_cipher_preferences->count; cipher_idx++) {
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_security_policy security_policy;
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
 
         /* Craft a cipher preference with a cipher_idx cipher. */
         EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
@@ -337,8 +337,8 @@ int main(int argc, char **argv)
     for (int cipher_idx = 0; cipher_idx < default_cipher_preferences->count; cipher_idx++) {
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_security_policy security_policy;
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
 
         /* Craft a cipher preference with a cipher_idx cipher. */
         EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));
@@ -414,8 +414,8 @@ int main(int argc, char **argv)
     for (int cipher_idx = 0; cipher_idx < default_cipher_preferences->count; cipher_idx++) {
         struct s2n_cipher_preferences server_cipher_preferences;
         struct s2n_security_policy security_policy;
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
 
         /* Craft a cipher preference with a cipher_idx cipher. */
         EXPECT_MEMCPY_SUCCESS(&server_cipher_preferences, default_cipher_preferences, sizeof(server_cipher_preferences));

--- a/tests/unit/s2n_pem_test.c
+++ b/tests/unit/s2n_pem_test.c
@@ -61,10 +61,10 @@ static const char *invalid_pem_pairs[][2] = {
 
 int main(int argc, char **argv)
 {
-    struct s2n_config *config;
-    char *cert_chain_pem;
-    char *private_key_pem;
-    struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_config *config = NULL;
+    char *cert_chain_pem = NULL;
+    char *private_key_pem = NULL;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());

--- a/tests/unit/s2n_pkey_test.c
+++ b/tests/unit/s2n_pkey_test.c
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
     /* Test each combination of s2n_pkey_types to validate that only keys of
      * the same type can be compared */
     {
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
         char rsa_cert_chain_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
         char rsa_pss_cert_chain_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
         char ecdsa_cert_chain_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
     /* Test the same as above but with non null terminated chain and key and
      * api that accepts length  */
     {
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
         uint8_t rsa_cert_chain_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
         uint8_t rsa_pss_cert_chain_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
         uint8_t ecdsa_cert_chain_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };

--- a/tests/unit/s2n_post_handshake_test.c
+++ b/tests/unit/s2n_post_handshake_test.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
     {
         /* post_handshake_recv processes a key update requested message */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
             conn->secure->cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
@@ -60,7 +60,7 @@ int main(int argc, char **argv)
 
         /* post_handshake_recv rejects an unknown post handshake message */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
             conn->secure->cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
 
         /* post_handshake_recv processes a malformed post handshake message */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS13;
             conn->secure->cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
@@ -145,7 +145,7 @@ int main(int argc, char **argv)
                     break;
                 }
 
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
                 conn->actual_protocol_version = S2N_TLS13;
 
@@ -162,7 +162,7 @@ int main(int argc, char **argv)
                     break;
                 }
 
-                struct s2n_connection *conn;
+                struct s2n_connection *conn = NULL;
                 EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
                 conn->actual_protocol_version = S2N_TLS13;
 

--- a/tests/unit/s2n_protocol_preferences_test.c
+++ b/tests/unit/s2n_protocol_preferences_test.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
 
     /* Test config append */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_EQUAL(config->application_protocols.size, 0);
         size_t prev_size = 0;
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
 
     /* Test connection append */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_EQUAL(conn->application_protocols_overridden.size, 0);
         size_t prev_size = 0;
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
 
     /* Test config set */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_EQUAL(config->application_protocols.size, 0);
 
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
 
     /* Test connection set */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_EQUAL(conn->application_protocols_overridden.size, 0);
 

--- a/tests/unit/s2n_psk_key_exchange_modes_extension_test.c
+++ b/tests/unit/s2n_psk_key_exchange_modes_extension_test.c
@@ -26,7 +26,7 @@ int main(int argc, char **argv)
         struct s2n_stuffer out = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         EXPECT_SUCCESS(s2n_psk_key_exchange_modes_extension.send(conn, &out));
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
             struct s2n_stuffer out = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_EQUAL(conn->psk_params.psk_ke_mode, S2N_PSK_KE_UNKNOWN);
 
@@ -71,7 +71,7 @@ int main(int argc, char **argv)
             struct s2n_stuffer out = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_EQUAL(conn->psk_params.psk_ke_mode, S2N_PSK_KE_UNKNOWN);
 
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
             struct s2n_stuffer out = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_EQUAL(conn->psk_params.psk_ke_mode, S2N_PSK_KE_UNKNOWN);
 
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
             struct s2n_stuffer out = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_EQUAL(conn->psk_params.psk_ke_mode, S2N_PSK_KE_UNKNOWN);
 
@@ -268,8 +268,8 @@ int main(int argc, char **argv)
         struct s2n_stuffer out = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
 
-        struct s2n_connection *server_conn;
-        struct s2n_connection *client_conn;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_EQUAL(server_conn->psk_params.psk_ke_mode, S2N_PSK_KE_UNKNOWN);

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -338,7 +338,7 @@ int main(int argc, char **argv)
          * There are no available test vectors for multiple PSKs, but we should at least
          * verify that we write something relatively sane for this use case. */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             struct s2n_stuffer out = { 0 };
@@ -385,7 +385,7 @@ int main(int argc, char **argv)
          *# ClientHello.
          */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             conn->handshake.handshake_type = HELLO_RETRY_REQUEST;
             conn->secure->cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
@@ -479,7 +479,7 @@ int main(int argc, char **argv)
 
         /* Test s2n_psk_calculate_binder_hash with known values */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             struct s2n_blob hash_value = { 0 };
@@ -509,7 +509,7 @@ int main(int argc, char **argv)
 
         /* Test s2n_psk_verify_binder with known values */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             DEFER_CLEANUP(struct s2n_psk test_psk, s2n_psk_wipe);
@@ -528,7 +528,7 @@ int main(int argc, char **argv)
 
         /* Test s2n_psk_verify_binder with incorrect binder */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             DEFER_CLEANUP(struct s2n_psk test_psk, s2n_psk_wipe);
@@ -549,7 +549,7 @@ int main(int argc, char **argv)
 
         /* Test s2n_psk_write_binder with known values */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             DEFER_CLEANUP(struct s2n_psk psk = { 0 }, s2n_psk_wipe);
@@ -566,7 +566,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(binder_size, s2n_stuffer_data_available(&out));
             EXPECT_EQUAL(binder_size, finished_binder.size);
 
-            uint8_t *binder_data;
+            uint8_t *binder_data = NULL;
             EXPECT_NOT_NULL(binder_data = s2n_stuffer_raw_read(&out, binder_size));
             EXPECT_BYTEARRAY_EQUAL(binder_data, finished_binder.data, binder_size);
 
@@ -576,7 +576,7 @@ int main(int argc, char **argv)
 
         /* Test s2n_psk_write_binder_list with known values */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             struct s2n_psk *psk = NULL;
@@ -599,7 +599,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(binder_size, s2n_stuffer_data_available(&out));
             EXPECT_EQUAL(binder_size, finished_binder.size);
 
-            uint8_t *binder_data;
+            uint8_t *binder_data = NULL;
             EXPECT_NOT_NULL(binder_data = s2n_stuffer_raw_read(&out, binder_size));
             EXPECT_BYTEARRAY_EQUAL(binder_data, finished_binder.data, binder_size);
 
@@ -611,7 +611,7 @@ int main(int argc, char **argv)
         {
             const uint8_t psk_count = 5;
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             for (uint8_t i = 0; i < psk_count; i++) {
@@ -636,7 +636,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_stuffer_read_uint8(&out, &binder_size));
                 EXPECT_EQUAL(binder_size, finished_binder.size);
 
-                uint8_t *binder_data;
+                uint8_t *binder_data = NULL;
                 EXPECT_NOT_NULL(binder_data = s2n_stuffer_raw_read(&out, binder_size));
                 EXPECT_BYTEARRAY_EQUAL(binder_data, finished_binder.data, binder_size);
             }
@@ -649,7 +649,7 @@ int main(int argc, char **argv)
 
         /* Test s2n_psk_write_binder_list with multiple hash algs */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             for (s2n_hmac_algorithm hmac_alg = S2N_HMAC_SHA256; hmac_alg <= S2N_HMAC_SHA384; hmac_alg++) {
@@ -678,7 +678,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_stuffer_read_uint8(&out, &binder_size));
                 EXPECT_EQUAL(binder_size, hash_size);
 
-                uint8_t *binder_data;
+                uint8_t *binder_data = NULL;
                 EXPECT_NOT_NULL(binder_data = s2n_stuffer_raw_read(&out, binder_size));
                 /* We can only actually verify the result for SHA256; we don't have known
                  * values for any other hash. */
@@ -695,7 +695,7 @@ int main(int argc, char **argv)
 
         /* Test s2n_finish_psk_extension with known values */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             EXPECT_SUCCESS(s2n_stuffer_write(&conn->handshake.io, &client_hello_prefix));
@@ -732,7 +732,7 @@ int main(int argc, char **argv)
 
         /* Safety checks */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             EXPECT_FAILURE_WITH_ERRNO(s2n_connection_append_psk(NULL, input_psk), S2N_ERR_NULL);
@@ -743,7 +743,7 @@ int main(int argc, char **argv)
 
         /* Append valid PSK to empty list */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(conn, input_psk));
@@ -766,7 +766,7 @@ int main(int argc, char **argv)
 
         /* Original PSK can be safely freed after being added to a connection */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             struct s2n_psk *original_psk = s2n_external_psk_new();
@@ -794,7 +794,7 @@ int main(int argc, char **argv)
 
         /* Invalid PSK not added to connection */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             /* PSK is invalid because it has no identity */
@@ -814,7 +814,7 @@ int main(int argc, char **argv)
 
         /* Huge PSK not added to client connection */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             DEFER_CLEANUP(struct s2n_psk *invalid_psk = s2n_external_psk_new(), s2n_psk_free);
@@ -844,7 +844,7 @@ int main(int argc, char **argv)
 
         /* Huge PSK added to server connection */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
             DEFER_CLEANUP(struct s2n_psk *invalid_psk = s2n_external_psk_new(), s2n_psk_free);
@@ -861,7 +861,7 @@ int main(int argc, char **argv)
 
         /* New PSK would make existing list too long for client */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             uint32_t offered_psks_size = 0;
@@ -897,7 +897,7 @@ int main(int argc, char **argv)
 
         /* PSK matches existing external PSK */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(conn, input_psk));

--- a/tests/unit/s2n_quic_support_io_test.c
+++ b/tests/unit/s2n_quic_support_io_test.c
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
 
         /* Writes handshake message */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             uint8_t message_data[] = "The client says hello";
@@ -160,7 +160,7 @@ int main(int argc, char **argv)
 
         /* Reads basic handshake message */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             struct s2n_stuffer stuffer = { 0 };
@@ -187,7 +187,7 @@ int main(int argc, char **argv)
 
         /* Blocks on insufficient data for handshake message header */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             struct s2n_stuffer stuffer = { 0 };
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
 
         /* Blocks on insufficient data for handshake message data */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             struct s2n_stuffer stuffer = { 0 };
@@ -227,7 +227,7 @@ int main(int argc, char **argv)
 
         /* Fails for an impossibly large handshake message */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             struct s2n_stuffer stuffer = { 0 };
@@ -265,13 +265,13 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output_stuffer, 0));
 
         /* Setup config */
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_enable_quic(config));
 
         /* Functional: successfully reads full handshake message */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_OK(s2n_setup_conn_for_server_hello(conn));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -287,7 +287,7 @@ int main(int argc, char **argv)
 
         /* Functional: successfully reads fragmented handshake message */
         for (size_t i = 1; i < server_hello.size - 1; i++) {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_OK(s2n_setup_conn_for_server_hello(conn));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -312,7 +312,7 @@ int main(int argc, char **argv)
 
         /* Functional: successfully reads multiple handshake messages */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_OK(s2n_setup_conn_for_server_hello(conn));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -332,7 +332,7 @@ int main(int argc, char **argv)
 
         /* Function: fails to read record instead of handshake message */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_OK(s2n_setup_conn_for_server_hello(conn));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -352,7 +352,7 @@ int main(int argc, char **argv)
 
         /* Function: fails to read Change Cipher Spec record */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_OK(s2n_setup_conn_for_server_hello(conn));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -374,7 +374,7 @@ int main(int argc, char **argv)
 
         /* Functional: successfully writes full handshake message */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_OK(s2n_setup_conn_for_client_hello(conn));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -382,11 +382,11 @@ int main(int argc, char **argv)
             EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(conn, &blocked_status), S2N_ERR_IO_BLOCKED);
             client_hello_length = s2n_stuffer_data_available(&output_stuffer);
 
-            uint8_t actual_message_type;
+            uint8_t actual_message_type = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint8(&output_stuffer, &actual_message_type));
             EXPECT_EQUAL(actual_message_type, TLS_CLIENT_HELLO);
 
-            uint32_t actual_message_size;
+            uint32_t actual_message_size = 0;
             EXPECT_SUCCESS(s2n_stuffer_read_uint24(&output_stuffer, &actual_message_size));
             EXPECT_EQUAL(actual_message_size, TEST_DATA_SIZE);
 
@@ -401,7 +401,7 @@ int main(int argc, char **argv)
 
         /* Functional: successfully retries after blocked write */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_OK(s2n_setup_conn_for_client_hello(conn));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));

--- a/tests/unit/s2n_quic_support_test.c
+++ b/tests/unit/s2n_quic_support_test.c
@@ -163,7 +163,7 @@ int main(int argc, char **argv)
 
         /* Set transport data */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             s2n_connection_set_quic_transport_parameters(conn, TEST_DATA, sizeof(TEST_DATA));
@@ -199,7 +199,7 @@ int main(int argc, char **argv)
             const uint8_t *data_buffer = TEST_DATA;
             uint16_t data_buffer_len = sizeof(TEST_DATA);
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             EXPECT_SUCCESS(s2n_connection_get_quic_transport_parameters(conn, &data_buffer, &data_buffer_len));
@@ -214,7 +214,7 @@ int main(int argc, char **argv)
             const uint8_t *data_buffer = NULL;
             uint16_t data_buffer_len = 0;
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             EXPECT_SUCCESS(s2n_alloc(&conn->peer_quic_transport_parameters, sizeof(TEST_DATA)));
@@ -230,11 +230,11 @@ int main(int argc, char **argv)
 
     /* Test s2n_connection_set_secret_callback */
     {
-        uint8_t test_context;
+        uint8_t test_context = 0;
 
         /* Safety checks */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             EXPECT_FAILURE_WITH_ERRNO(s2n_connection_set_secret_callback(NULL, s2n_test_noop_secret_handler, &test_context), S2N_ERR_NULL);
@@ -248,7 +248,7 @@ int main(int argc, char **argv)
 
         /* Succeeds with NULL context */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_EQUAL(conn->secret_cb, NULL);
             EXPECT_EQUAL(conn->secret_cb_context, NULL);
@@ -263,7 +263,7 @@ int main(int argc, char **argv)
 
         /* Succeeds with context */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_EQUAL(conn->secret_cb, NULL);
             EXPECT_EQUAL(conn->secret_cb_context, NULL);
@@ -279,11 +279,11 @@ int main(int argc, char **argv)
 
     /* Test: no API that sends/receives application data is allowed when QUIC is enabled */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_enable_quic(config));
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 

--- a/tests/unit/s2n_quic_transport_params_extension_test.c
+++ b/tests/unit/s2n_quic_transport_params_extension_test.c
@@ -32,10 +32,10 @@ int main(int argc, char **argv)
 
     /* Test should_send */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -55,10 +55,10 @@ int main(int argc, char **argv)
 
     /* Test if_missing */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
         {
             struct s2n_stuffer out = { 0 };
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             EXPECT_FAILURE_WITH_ERRNO(s2n_quic_transport_parameters_extension.send(NULL, &out), S2N_ERR_NULL);
@@ -105,11 +105,11 @@ int main(int argc, char **argv)
             struct s2n_stuffer out = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
 
-            struct s2n_config *config;
+            struct s2n_config *config = NULL;
             EXPECT_NOT_NULL(config = s2n_config_new());
             EXPECT_SUCCESS(s2n_config_enable_quic(config));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             EXPECT_SUCCESS(s2n_connection_set_quic_transport_parameters(conn, TEST_DATA, sizeof(TEST_DATA)));
@@ -127,11 +127,11 @@ int main(int argc, char **argv)
             struct s2n_stuffer out = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
 
-            struct s2n_config *config;
+            struct s2n_config *config = NULL;
             EXPECT_NOT_NULL(config = s2n_config_new());
             EXPECT_SUCCESS(s2n_config_enable_quic(config));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
         {
             struct s2n_stuffer extension = { 0 };
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             EXPECT_FAILURE_WITH_ERRNO(s2n_quic_transport_parameters_extension.recv(NULL, &extension), S2N_ERR_NULL);
@@ -163,11 +163,11 @@ int main(int argc, char **argv)
 
         /* Save transport parameters */
         {
-            struct s2n_config *config;
+            struct s2n_config *config = NULL;
             EXPECT_NOT_NULL(config = s2n_config_new());
             EXPECT_SUCCESS(s2n_config_enable_quic(config));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -185,11 +185,11 @@ int main(int argc, char **argv)
 
         /* Save empty transport parameters */
         {
-            struct s2n_config *config;
+            struct s2n_config *config = NULL;
             EXPECT_NOT_NULL(config = s2n_config_new());
             EXPECT_SUCCESS(s2n_config_enable_quic(config));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -207,15 +207,15 @@ int main(int argc, char **argv)
             struct s2n_stuffer out = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
 
-            struct s2n_config *config;
+            struct s2n_config *config = NULL;
             EXPECT_NOT_NULL(config = s2n_config_new());
             EXPECT_SUCCESS(s2n_config_enable_quic(config));
 
-            struct s2n_connection *server_conn;
+            struct s2n_connection *server_conn = NULL;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
-            struct s2n_connection *client_conn;
+            struct s2n_connection *client_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
             EXPECT_SUCCESS(s2n_connection_set_quic_transport_parameters(client_conn, TEST_DATA, sizeof(TEST_DATA)));

--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -378,7 +378,7 @@ static S2N_RESULT s2n_fork_test(
         S2N_RESULT (*s2n_get_random_data_cb)(struct s2n_blob *blob),
         S2N_RESULT (*s2n_get_random_data_cb_thread)(struct s2n_blob *blob))
 {
-    pid_t proc_id;
+    pid_t proc_id = 0;
     int pipes[2];
 
     /* A simple fork test. Generates random data in the parent and child, and
@@ -464,7 +464,7 @@ static S2N_RESULT s2n_clone_tests(
 {
 #if defined(S2N_CLONE_SUPPORTED)
 
-    int proc_id;
+    int proc_id = 0;
     int pipes[2];
 
     EXPECT_SUCCESS(pipe(pipes));

--- a/tests/unit/s2n_rc4_test.c
+++ b/tests/unit/s2n_rc4_test.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_rc4.is_available());
     }
 
-    struct s2n_connection *conn;
+    struct s2n_connection *conn = NULL;
     uint8_t mac_key[] = "sample mac key";
     uint8_t rc4_key[] = "123456789012345";
     struct s2n_blob key_iv = { 0 };
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
         for (size_t i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
             struct s2n_blob in = { 0 };
             EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
-            int bytes_written;
+            int bytes_written = 0;
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
 
@@ -115,8 +115,8 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(bytes_written + 20, s2n_stuffer_data_available(&conn->in));
 
             /* Let's decrypt it */
-            uint8_t content_type;
-            uint16_t fragment_length;
+            uint8_t content_type = 0;
+            uint16_t fragment_length = 0;
             EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
             EXPECT_SUCCESS(s2n_record_parse(conn));
             EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);

--- a/tests/unit/s2n_record_size_test.c
+++ b/tests/unit/s2n_record_size_test.c
@@ -122,12 +122,12 @@ int main(int argc, char **argv)
 
     /* Test s2n_record_max_write_payload_size() have proper checks in place */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
         /* we deal with the default null cipher suite for now, as it makes reasoning
          * about easier s2n_record_max_write_payload_size(), as it incur 0 overheads */
-        uint16_t size;
+        uint16_t size = 0;
         server_conn->max_outgoing_fragment_length = ONE_BLOCK;
         EXPECT_OK(s2n_record_max_write_payload_size(server_conn, &size));
         EXPECT_EQUAL(size, ONE_BLOCK);
@@ -231,7 +231,7 @@ int main(int argc, char **argv)
 
     /* Test s2n_record_min_write_payload_size() */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
         uint16_t size = 0;
@@ -397,7 +397,7 @@ int main(int argc, char **argv)
 
     /* Test large fragment/record sending for TLS 1.3 */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         struct s2n_cipher_suite *cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
         server_conn->actual_protocol_version = S2N_TLS13;
@@ -428,7 +428,7 @@ int main(int argc, char **argv)
         small_io_vec.iov_base = small_blob.data;
         small_io_vec.iov_len = small_blob.size;
 
-        int bytes_taken;
+        int bytes_taken = 0;
 
         const uint16_t TLS13_RECORD_OVERHEAD = 22;
         EXPECT_SUCCESS(bytes_taken = s2n_record_writev(server_conn, TLS_APPLICATION_DATA, &small_io_vec, 1, 0, small_blob.size));

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -68,7 +68,7 @@ struct s2n_record_algorithm mock_null_sha1_record_alg = {
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
+    struct s2n_connection *conn = NULL;
     uint8_t mac_key[] = "sample mac key";
     struct s2n_blob fixed_iv = { 0 };
     EXPECT_SUCCESS(s2n_blob_init(&fixed_iv, mac_key, sizeof(mac_key)));
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
     for (size_t i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
-        int bytes_written;
+        int bytes_written = 0;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
 
@@ -123,8 +123,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
-        uint8_t content_type;
-        uint16_t fragment_length;
+        uint8_t content_type = 0;
+        uint16_t fragment_length = 0;
         EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
         EXPECT_SUCCESS(s2n_record_parse(conn));
         EXPECT_EQUAL(content_type, TLS_ALERT);
@@ -141,7 +141,7 @@ int main(int argc, char **argv)
     for (size_t i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
-        int bytes_written;
+        int bytes_written = 0;
 
         EXPECT_SUCCESS(s2n_hmac_reset(&check_mac));
         EXPECT_SUCCESS(s2n_hmac_update(&check_mac, conn->initial->server_sequence_number, 8));
@@ -184,8 +184,8 @@ int main(int argc, char **argv)
         uint8_t original_seq_num[8];
         EXPECT_MEMCPY_SUCCESS(original_seq_num, conn->server->client_sequence_number, 8);
 
-        uint8_t content_type;
-        uint16_t fragment_length;
+        uint8_t content_type = 0;
+        uint16_t fragment_length = 0;
         EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
         EXPECT_SUCCESS(s2n_record_parse(conn));
         EXPECT_EQUAL(content_type, TLS_ALERT);
@@ -204,7 +204,7 @@ int main(int argc, char **argv)
         /* Deliberately corrupt a byte of the output and check that the record
          * won't parse
          */
-        uint64_t byte_to_corrupt;
+        uint64_t byte_to_corrupt = 0;
         EXPECT_OK(s2n_public_random(fragment_length, &byte_to_corrupt));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -225,7 +225,7 @@ int main(int argc, char **argv)
     for (size_t i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
-        int bytes_written;
+        int bytes_written = 0;
 
         EXPECT_SUCCESS(s2n_hmac_reset(&check_mac));
         EXPECT_SUCCESS(s2n_hmac_update(&check_mac, conn->initial->client_sequence_number, 8));
@@ -278,8 +278,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
-        uint8_t content_type;
-        uint16_t fragment_length;
+        uint8_t content_type = 0;
+        uint16_t fragment_length = 0;
         EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
         EXPECT_SUCCESS(s2n_record_parse(conn));
         EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
@@ -295,7 +295,7 @@ int main(int argc, char **argv)
     for (int i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
-        int bytes_written;
+        int bytes_written = 0;
 
         EXPECT_SUCCESS(s2n_hmac_reset(&check_mac));
         EXPECT_SUCCESS(s2n_hmac_update(&check_mac, conn->initial->client_sequence_number, 8));
@@ -346,8 +346,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
-        uint8_t content_type;
-        uint16_t fragment_length;
+        uint8_t content_type = 0;
+        uint16_t fragment_length = 0;
         EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
         EXPECT_SUCCESS(s2n_record_parse(conn));
         EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
@@ -386,8 +386,8 @@ int main(int argc, char **argv)
 
         /* Trigger condition to check for protocol version */
         conn->actual_protocol_version_established = 1;
-        uint8_t content_type;
-        uint16_t fragment_length;
+        uint8_t content_type = 0;
+        uint16_t fragment_length = 0;
         EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
 
         /* If record version on wire is TLS 1.3, check s2n_record_header_parse fails */

--- a/tests/unit/s2n_recv_test.c
+++ b/tests/unit/s2n_recv_test.c
@@ -195,7 +195,7 @@ int main(int argc, char **argv)
     /* s2n_recv cannot be called concurrently */
     {
         /* Setup connection */
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         /* Setup bad recv callback */

--- a/tests/unit/s2n_release_non_empty_buffers_test.c
+++ b/tests/unit/s2n_release_non_empty_buffers_test.c
@@ -33,8 +33,8 @@ static const uint8_t buf_to_send[1023] = { 27 };
 
 int mock_client(struct s2n_test_io_pair *io_pair)
 {
-    struct s2n_connection *conn;
-    struct s2n_config *client_config;
+    struct s2n_connection *conn = NULL;
+    struct s2n_config *client_config = NULL;
     s2n_blocked_status blocked;
     int result = 0;
 
@@ -70,10 +70,10 @@ int mock_client(struct s2n_test_io_pair *io_pair)
 int main(int argc, char **argv)
 {
     s2n_blocked_status blocked;
-    int status;
-    pid_t pid;
-    char *cert_chain_pem;
-    char *private_key_pem;
+    int status = 0;
+    pid_t pid = 0;
+    char *cert_chain_pem = NULL;
+    char *private_key_pem = NULL;
     uint8_t buf[sizeof(buf_to_send)];
     uint32_t n = 0;
     ssize_t ret = 0;

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -393,7 +393,7 @@ int main(int argc, char **argv)
 
     /* s2n_tls12_serialize_resumption_state */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         conn->actual_protocol_version = S2N_TLS12;
 
@@ -448,7 +448,7 @@ int main(int argc, char **argv)
     {
         /* Safety checks */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             struct s2n_stuffer output = { 0 };
 
@@ -464,7 +464,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(config);
             EXPECT_SUCCESS(s2n_config_set_wall_clock(config, mock_time, NULL));
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             conn->actual_protocol_version = S2N_TLS13;
@@ -602,7 +602,7 @@ int main(int argc, char **argv)
             const uint8_t test_early_data_context[] = "context";
             const uint8_t test_app_protocol[] = "protocol";
 
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_server_early_data_context(conn, test_early_data_context, sizeof(test_early_data_context)));
             EXPECT_MEMCPY_SUCCESS(conn->application_protocol, test_app_protocol, sizeof(test_app_protocol));
@@ -770,7 +770,7 @@ int main(int argc, char **argv)
 
         /* Client processes TLS1.2 ticket with EMS data correctly */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             conn->actual_protocol_version = S2N_TLS12;
             /* Security policy must allow chosen cipher suite */
@@ -804,7 +804,7 @@ int main(int argc, char **argv)
 
         /* Server processes TLS1.2 ticket with EMS data correctly */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             conn->actual_protocol_version = S2N_TLS12;
 
@@ -1290,9 +1290,9 @@ int main(int argc, char **argv)
 
         /* Check encrypted data can be decrypted correctly for TLS12 */
         {
-            struct s2n_connection *conn;
-            struct s2n_config *config;
-            uint64_t current_time;
+            struct s2n_connection *conn = NULL;
+            struct s2n_config *config = NULL;
+            uint64_t current_time = 0;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_NOT_NULL(config = s2n_config_new());
 
@@ -1330,9 +1330,9 @@ int main(int argc, char **argv)
 
         /* Check session ticket can be decrypted with a small secret in TLS13 session resumption. */
         {
-            struct s2n_connection *conn;
-            struct s2n_config *config;
-            uint64_t current_time;
+            struct s2n_connection *conn = NULL;
+            struct s2n_config *config = NULL;
+            uint64_t current_time = 0;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_NOT_NULL(config = s2n_config_new());
 
@@ -1372,9 +1372,9 @@ int main(int argc, char **argv)
 
         /* Check session ticket can be decrypted with the maximum size secret in TLS13 session resumption. */
         {
-            struct s2n_connection *conn;
-            struct s2n_config *config;
-            uint64_t current_time;
+            struct s2n_connection *conn = NULL;
+            struct s2n_config *config = NULL;
+            uint64_t current_time = 0;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_NOT_NULL(config = s2n_config_new());
 
@@ -1458,8 +1458,8 @@ int main(int argc, char **argv)
 
     /* s2n_config_set_initial_ticket_count */
     {
-        struct s2n_connection *conn;
-        struct s2n_config *config;
+        struct s2n_connection *conn = NULL;
+        struct s2n_config *config = NULL;
         uint8_t num_tickets = 1;
 
         EXPECT_NOT_NULL(config = s2n_config_new());
@@ -1484,7 +1484,7 @@ int main(int argc, char **argv)
     {
         /* New number of session tickets can be set */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             uint8_t original_num_tickets = 1;
             uint8_t new_num_tickets = 10;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
@@ -1499,7 +1499,7 @@ int main(int argc, char **argv)
 
         /* Overflow error is caught */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             uint8_t new_num_tickets = 1;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             conn->tickets_to_send = UINT16_MAX;

--- a/tests/unit/s2n_rsa_pss_rsae_test.c
+++ b/tests/unit/s2n_rsa_pss_rsae_test.c
@@ -161,7 +161,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
     /* Load the RSA cert */
-    struct s2n_cert_chain_and_key *rsa_cert_chain;
+    struct s2n_cert_chain_and_key *rsa_cert_chain = NULL;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&rsa_cert_chain,
             S2N_RSA_2048_PKCS1_CERT_CHAIN, S2N_RSA_2048_PKCS1_KEY));
 
@@ -198,7 +198,7 @@ int main(int argc, char **argv)
 
 #if RSA_PSS_CERTS_SUPPORTED
 
-    struct s2n_cert_chain_and_key *rsa_pss_cert_chain;
+    struct s2n_cert_chain_and_key *rsa_pss_cert_chain = NULL;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&rsa_pss_cert_chain,
             S2N_RSA_PSS_2048_SHA256_LEAF_CERT, S2N_RSA_PSS_2048_SHA256_LEAF_KEY));
 

--- a/tests/unit/s2n_rsa_pss_test.c
+++ b/tests/unit/s2n_rsa_pss_test.c
@@ -27,9 +27,9 @@
 int s2n_flip_random_bit(struct s2n_blob *blob)
 {
     /* Flip a random bit in the blob */
-    uint64_t byte_flip_pos;
+    uint64_t byte_flip_pos = 0;
     POSIX_GUARD_RESULT(s2n_public_random(blob->size, &byte_flip_pos));
-    uint64_t bit_flip_pos;
+    uint64_t bit_flip_pos = 0;
     POSIX_GUARD_RESULT(s2n_public_random(8, &bit_flip_pos));
 
     uint8_t mask = 0x01 << (uint8_t) bit_flip_pos;
@@ -57,10 +57,10 @@ int main(int argc, char **argv)
      * Pseudocode: assert(SUCCESS == verify(Key1_public, message, sign(Key1_private, message)))
      */
     {
-        struct s2n_config *server_config;
-        char *cert_chain_pem;
-        char *private_key_pem;
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_config *server_config = NULL;
+        char *cert_chain_pem = NULL;
+        char *private_key_pem = NULL;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
         struct s2n_pkey public_key = { 0 };
         s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
 
@@ -98,10 +98,10 @@ int main(int argc, char **argv)
      * Pseudocode: assert(FAILURE == load_pem_pair(Key1_public, Key2_private))
      */
     {
-        struct s2n_config *server_config;
-        char *leaf_cert_chain_pem;
-        char *root_private_key_pem;
-        struct s2n_cert_chain_and_key *misconfigured_chain_and_key;
+        struct s2n_config *server_config = NULL;
+        char *leaf_cert_chain_pem = NULL;
+        char *root_private_key_pem = NULL;
+        struct s2n_cert_chain_and_key *misconfigured_chain_and_key = NULL;
         struct s2n_pkey public_key = { 0 };
 
         EXPECT_NOT_NULL(leaf_cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
@@ -129,10 +129,10 @@ int main(int argc, char **argv)
      * Pseudocode: assert(FAILURE == verify(Key1_public, message, bitflip(sign(Key1_private, message)))
      */
     {
-        struct s2n_config *server_config;
-        char *cert_chain_pem;
-        char *private_key_pem;
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_config *server_config = NULL;
+        char *cert_chain_pem = NULL;
+        char *private_key_pem = NULL;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
         struct s2n_pkey public_key = { 0 };
         s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
 
@@ -194,13 +194,13 @@ int main(int argc, char **argv)
      * Pseudocode: assert(FAILURE == verify(Key2_public, message, sign(Key1_private, message)))
      */
     {
-        struct s2n_config *server_config;
-        char *root_cert_chain_pem;
-        char *root_private_key_pem;
-        char *leaf_cert_chain_pem;
-        char *leaf_private_key_pem;
-        struct s2n_cert_chain_and_key *root_chain_and_key;
-        struct s2n_cert_chain_and_key *leaf_chain_and_key;
+        struct s2n_config *server_config = NULL;
+        char *root_cert_chain_pem = NULL;
+        char *root_private_key_pem = NULL;
+        char *leaf_cert_chain_pem = NULL;
+        char *leaf_private_key_pem = NULL;
+        struct s2n_cert_chain_and_key *root_chain_and_key = NULL;
+        struct s2n_cert_chain_and_key *leaf_chain_and_key = NULL;
         struct s2n_pkey root_public_key = { 0 };
         struct s2n_pkey leaf_public_key = { 0 };
         s2n_pkey_type root_pkey_type = S2N_PKEY_TYPE_UNKNOWN;
@@ -285,10 +285,10 @@ int main(int argc, char **argv)
      * Pseudocode: assert(FAILURE == verify(Key1_public, bitflip(message), sign(Key1_private, message)))
      */
     {
-        struct s2n_config *server_config;
-        char *cert_chain_pem;
-        char *private_key_pem;
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_config *server_config = NULL;
+        char *cert_chain_pem = NULL;
+        char *private_key_pem = NULL;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
         struct s2n_pkey public_key = { 0 };
         s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
 

--- a/tests/unit/s2n_self_talk_alerts_test.c
+++ b/tests/unit/s2n_self_talk_alerts_test.c
@@ -44,8 +44,8 @@ struct alert_ctx {
 
 int mock_client(struct s2n_test_io_pair *io_pair, s2n_alert_behavior alert_behavior, int expect_failure)
 {
-    struct s2n_connection *conn;
-    struct s2n_config *config;
+    struct s2n_connection *conn = NULL;
+    struct s2n_config *config = NULL;
     s2n_blocked_status blocked;
     int result = 0;
     int rc = 0;
@@ -139,13 +139,13 @@ S2N_RESULT cleanup(char **cert_chain_pem, char **private_key_pem,
 int main(int argc, char **argv)
 {
     char buffer[0xffff];
-    struct s2n_connection *conn;
+    struct s2n_connection *conn = NULL;
     s2n_blocked_status blocked;
-    int status;
-    pid_t pid;
-    char *cert_chain_pem;
-    char *private_key_pem;
-    struct s2n_cert_chain_and_key *chain_and_key;
+    int status = 0;
+    pid_t pid = 0;
+    char *cert_chain_pem = NULL;
+    char *private_key_pem = NULL;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
     BEGIN_TEST();
 
     /* Ignore SIGPIPE */

--- a/tests/unit/s2n_self_talk_alpn_test.c
+++ b/tests/unit/s2n_self_talk_alpn_test.c
@@ -45,8 +45,8 @@ int mock_nanoseconds_since_epoch(void *data, uint64_t *nanoseconds)
 int mock_client(int writefd, int readfd, const char **protocols, int count, const char *expected)
 {
     char buffer[0xffff];
-    struct s2n_connection *client_conn;
-    struct s2n_config *client_config;
+    struct s2n_connection *client_conn = NULL;
+    struct s2n_config *client_config = NULL;
     s2n_blocked_status blocked;
     int result = 0;
 
@@ -103,17 +103,17 @@ int mock_client(int writefd, int readfd, const char **protocols, int count, cons
 int main(int argc, char **argv)
 {
     char buffer[0xffff];
-    struct s2n_connection *conn;
-    struct s2n_config *config;
+    struct s2n_connection *conn = NULL;
+    struct s2n_config *config = NULL;
     s2n_blocked_status blocked;
-    int status;
-    pid_t pid;
+    int status = 0;
+    pid_t pid = 0;
     int server_to_client[2];
     int client_to_server[2];
-    char *cert_chain_pem;
-    char *private_key_pem;
-    char *dhparams_pem;
-    struct s2n_cert_chain_and_key *chain_and_key;
+    char *cert_chain_pem = NULL;
+    char *private_key_pem = NULL;
+    char *dhparams_pem = NULL;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
     const char *protocols[] = { "http/1.1", "spdy/3.1", "h2" };
     const int protocols_size = s2n_array_len(protocols);

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -32,8 +32,8 @@ static const char *private_key_paths[SUPPORTED_CERTIFICATE_FORMATS] = { S2N_RSA_
 
 void mock_client(struct s2n_test_io_pair *io_pair)
 {
-    struct s2n_connection *conn;
-    struct s2n_config *config;
+    struct s2n_connection *conn = NULL;
+    struct s2n_config *config = NULL;
     s2n_blocked_status blocked;
 
     /* Give the server a chance to listen */
@@ -88,10 +88,10 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
-    struct s2n_config *config;
+    struct s2n_connection *conn = NULL;
+    struct s2n_config *config = NULL;
     s2n_blocked_status blocked;
-    int status;
+    int status = 0;
     char cert_chain_pem[S2N_MAX_TEST_PEM_SIZE];
     char private_key_pem[S2N_MAX_TEST_PEM_SIZE];
     char dhparams_pem[S2N_MAX_TEST_PEM_SIZE];

--- a/tests/unit/s2n_self_talk_client_hello_cb_test.c
+++ b/tests/unit/s2n_self_talk_client_hello_cb_test.c
@@ -41,8 +41,8 @@ struct client_hello_context {
 
 int mock_client(struct s2n_test_io_pair *io_pair, int expect_failure, int expect_server_name_used)
 {
-    struct s2n_connection *conn;
-    struct s2n_config *config;
+    struct s2n_connection *conn = NULL;
+    struct s2n_config *config = NULL;
     s2n_blocked_status blocked;
     int result = 0;
     int rc = 0;
@@ -106,10 +106,10 @@ int mock_client(struct s2n_test_io_pair *io_pair, int expect_failure, int expect
 
 int client_hello_swap_config(struct s2n_connection *conn, void *ctx)
 {
-    struct client_hello_context *client_hello_ctx;
+    struct client_hello_context *client_hello_ctx = NULL;
     struct s2n_client_hello *client_hello = s2n_connection_get_client_hello(conn);
     const char *sent_server_name = "example.com";
-    const char *received_server_name;
+    const char *received_server_name = NULL;
     if (ctx == NULL) {
         return -1;
     }
@@ -168,7 +168,7 @@ int client_hello_swap_config(struct s2n_connection *conn, void *ctx)
 
 int client_hello_fail_handshake(struct s2n_connection *conn, void *ctx)
 {
-    struct client_hello_context *client_hello_ctx;
+    struct client_hello_context *client_hello_ctx = NULL;
 
     if (ctx == NULL) {
         return -1;
@@ -281,7 +281,7 @@ static int test_case_clean(struct s2n_connection *conn, pid_t client_pid,
         struct client_hello_context *ch_ctx, struct s2n_cert_chain_and_key *chain_and_key)
 {
     s2n_blocked_status blocked;
-    int status;
+    int status = 0;
 
     EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));
     EXPECT_EQUAL(waitpid(-1, &status, 0), client_pid);
@@ -301,11 +301,11 @@ int run_test_config_swap_ch_cb(s2n_client_hello_cb_mode cb_mode,
         struct client_hello_context *ch_ctx)
 {
     struct s2n_test_io_pair io_pair;
-    struct s2n_config *config;
-    struct s2n_connection *conn;
-    struct s2n_config *swap_config;
-    pid_t pid;
-    struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_config *config = NULL;
+    struct s2n_connection *conn = NULL;
+    struct s2n_config *swap_config = NULL;
+    pid_t pid = 0;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
     EXPECT_SUCCESS(start_client_conn(&io_pair, &pid, 0, 1));
 
@@ -359,10 +359,10 @@ int run_test_config_swap_ch_cb(s2n_client_hello_cb_mode cb_mode,
 int run_test_no_config_swap_ch_cb(s2n_client_hello_cb_mode cb_mode, struct client_hello_context *ch_ctx)
 {
     struct s2n_test_io_pair io_pair;
-    struct s2n_config *config;
-    struct s2n_connection *conn;
-    pid_t pid;
-    struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_config *config = NULL;
+    struct s2n_connection *conn = NULL;
+    pid_t pid = 0;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
     EXPECT_SUCCESS(start_client_conn(&io_pair, &pid, 0, 0));
 
@@ -396,11 +396,11 @@ int run_test_no_config_swap_ch_cb(s2n_client_hello_cb_mode cb_mode, struct clien
 int run_test_reject_handshake_ch_cb(s2n_client_hello_cb_mode cb_mode, struct client_hello_context *ch_ctx)
 {
     struct s2n_test_io_pair io_pair;
-    struct s2n_config *config;
-    struct s2n_connection *conn;
-    pid_t pid;
+    struct s2n_config *config = NULL;
+    struct s2n_connection *conn = NULL;
+    pid_t pid = 0;
     s2n_blocked_status blocked;
-    struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
 
     EXPECT_SUCCESS(start_client_conn(&io_pair, &pid, 1, 0));
 

--- a/tests/unit/s2n_self_talk_custom_io_test.c
+++ b/tests/unit/s2n_self_talk_custom_io_test.c
@@ -31,8 +31,8 @@
 
 int mock_client(struct s2n_test_io_pair *io_pair)
 {
-    struct s2n_connection *conn;
-    struct s2n_config *client_config;
+    struct s2n_connection *conn = NULL;
+    struct s2n_config *client_config = NULL;
     s2n_blocked_status blocked;
     int result = 0;
 
@@ -69,11 +69,11 @@ int main(int argc, char **argv)
      */
     {
         s2n_blocked_status blocked;
-        int status;
-        pid_t pid;
-        char *cert_chain_pem;
-        char *private_key_pem;
-        char *dhparams_pem;
+        int status = 0;
+        pid_t pid = 0;
+        char *cert_chain_pem = NULL;
+        char *private_key_pem = NULL;
+        char *dhparams_pem = NULL;
 
         /* For convenience, this test will intentionally try to write to closed pipes during shutdown. Ignore the signal to
         * avoid exiting the process on SIGPIPE.
@@ -131,7 +131,7 @@ int main(int argc, char **argv)
 
         /* Negotiate the handshake. */
         do {
-            int ret;
+            int ret = 0;
 
             ret = s2n_negotiate(conn, &blocked);
             EXPECT_TRUE(ret == 0 || (blocked && (errno == EAGAIN || errno == EWOULDBLOCK)));
@@ -146,7 +146,7 @@ int main(int argc, char **argv)
         /* Shutdown after negotiating */
         uint8_t server_shutdown = 0;
         do {
-            int ret;
+            int ret = 0;
 
             ret = s2n_shutdown(conn, &blocked);
             EXPECT_TRUE(ret == 0 || (blocked && (errno == EAGAIN || errno == EWOULDBLOCK)));

--- a/tests/unit/s2n_self_talk_io_mem_test.c
+++ b/tests/unit/s2n_self_talk_io_mem_test.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv)
         END_TEST();
     }
 
-    struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
             S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
 

--- a/tests/unit/s2n_self_talk_key_log_test.c
+++ b/tests/unit/s2n_self_talk_key_log_test.c
@@ -67,15 +67,15 @@ int main(int argc, char **argv)
     /* TLS 1.2 */
     {
         /* Setup connections */
-        struct s2n_connection *client_conn, *server_conn;
+        struct s2n_connection *client_conn = NULL, *server_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
         /* Setup config */
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
                 S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
-        struct s2n_config *client_config;
+        struct s2n_config *client_config = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "default"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(client_config));
@@ -85,7 +85,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_set_key_log_cb(client_config, s2n_test_key_log_cb, &client_key_log));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
-        struct s2n_config *server_config;
+        struct s2n_config *server_config = NULL;
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "default"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(server_config));
@@ -118,15 +118,15 @@ int main(int argc, char **argv)
     /* TLS 1.3 */
     if (s2n_is_tls13_fully_supported()) {
         /* Setup connections */
-        struct s2n_connection *client_conn, *server_conn;
+        struct s2n_connection *client_conn = NULL, *server_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
         /* Setup config */
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
                 S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
-        struct s2n_config *client_config;
+        struct s2n_config *client_config = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "default_tls13"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(client_config));
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_set_key_log_cb(client_config, s2n_test_key_log_cb, &client_key_log));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
-        struct s2n_config *server_config;
+        struct s2n_config *server_config = NULL;
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "default_tls13"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(server_config));

--- a/tests/unit/s2n_self_talk_min_protocol_version_test.c
+++ b/tests/unit/s2n_self_talk_min_protocol_version_test.c
@@ -26,8 +26,8 @@
 
 int mock_client(struct s2n_test_io_pair *io_pair, uint8_t version)
 {
-    struct s2n_connection *client_conn;
-    struct s2n_config *client_config;
+    struct s2n_connection *client_conn = NULL;
+    struct s2n_config *client_config = NULL;
     s2n_blocked_status blocked;
     int result = 0;
 
@@ -63,7 +63,7 @@ int mock_client(struct s2n_test_io_pair *io_pair, uint8_t version)
 int main(int argc, char **argv)
 {
     s2n_blocked_status blocked;
-    int status;
+    int status = 0;
     char cert_chain_pem[S2N_MAX_TEST_PEM_SIZE];
     char private_key_pem[S2N_MAX_TEST_PEM_SIZE];
 

--- a/tests/unit/s2n_self_talk_nonblocking_test.c
+++ b/tests/unit/s2n_self_talk_nonblocking_test.c
@@ -35,8 +35,8 @@ int mock_client(struct s2n_test_io_pair *io_pair, uint8_t *expected_data, uint32
 {
     uint8_t *buffer = malloc(size);
     uint8_t *ptr = buffer;
-    struct s2n_connection *client_conn;
-    struct s2n_config *client_config;
+    struct s2n_connection *client_conn = NULL;
+    struct s2n_config *client_config = NULL;
     s2n_blocked_status blocked;
     int result = 0;
     /* If something goes wrong, and the server never finishes sending,
@@ -97,11 +97,11 @@ int mock_client(struct s2n_test_io_pair *io_pair, uint8_t *expected_data, uint32
 
 int mock_client_iov(struct s2n_test_io_pair *io_pair, struct iovec *iov, uint32_t iov_size)
 {
-    struct s2n_connection *client_conn;
-    struct s2n_config *client_config;
+    struct s2n_connection *client_conn = NULL;
+    struct s2n_config *client_config = NULL;
     s2n_blocked_status blocked;
     int result = 0;
-    int total_size = 0, i;
+    int total_size = 0, i = 0;
     int should_block = 1;
 
     for (i = 0; i < iov_size; i++) {
@@ -190,8 +190,8 @@ S2N_RESULT cleanup_io_data(struct iovec **iov, int iov_size, struct s2n_blob *bl
 int test_send(int use_tls13, int use_iov, int prefer_throughput)
 {
     s2n_blocked_status blocked;
-    int status;
-    pid_t pid;
+    int status = 0;
+    pid_t pid = 0;
     char cert_chain_pem[S2N_MAX_TEST_PEM_SIZE];
     char private_key_pem[S2N_MAX_TEST_PEM_SIZE];
     char dhparams_pem[S2N_MAX_TEST_PEM_SIZE];

--- a/tests/unit/s2n_self_talk_quic_support_test.c
+++ b/tests/unit/s2n_self_talk_quic_support_test.c
@@ -50,15 +50,15 @@ int main(int argc, char **argv)
     uint16_t transport_params_len = 0;
 
     /* Setup connections */
-    struct s2n_connection *client_conn, *server_conn;
+    struct s2n_connection *client_conn = NULL, *server_conn = NULL;
     EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
     EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
     /* Setup config */
-    struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
             S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
-    struct s2n_config *config;
+    struct s2n_config *config = NULL;
     EXPECT_NOT_NULL(config = s2n_config_new());
     EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));

--- a/tests/unit/s2n_self_talk_session_id_test.c
+++ b/tests/unit/s2n_self_talk_session_id_test.c
@@ -142,8 +142,8 @@ void mock_client(struct s2n_test_io_pair *io_pair)
     size_t serialized_session_state_length = 0;
     uint8_t serialized_session_state[256] = { 0 };
 
-    struct s2n_connection *conn;
-    struct s2n_config *config;
+    struct s2n_connection *conn = NULL;
+    struct s2n_config *config = NULL;
     s2n_blocked_status blocked;
     int result = 0;
 
@@ -288,18 +288,18 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
-    struct s2n_config *config;
+    struct s2n_connection *conn = NULL;
+    struct s2n_config *config = NULL;
     s2n_blocked_status blocked;
-    int status;
-    pid_t pid;
-    char *cert_chain_pem;
-    char *private_key_pem;
-    struct s2n_cert_chain_and_key *chain_and_key;
+    int status = 0;
+    pid_t pid = 0;
+    char *cert_chain_pem = NULL;
+    char *private_key_pem = NULL;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
     char buffer[256];
-    int bytes_read;
+    int bytes_read = 0;
     int shutdown_rc = -1;
-    uint64_t now;
+    uint64_t now = 0;
     uint8_t session_id_from_server[MAX_KEY_LEN];
     uint8_t session_id_from_client[MAX_KEY_LEN];
 

--- a/tests/unit/s2n_self_talk_tls12_test.c
+++ b/tests/unit/s2n_self_talk_tls12_test.c
@@ -32,8 +32,8 @@ static const char *private_key_paths[SUPPORTED_CERTIFICATE_FORMATS] = { S2N_RSA_
 void mock_client(struct s2n_test_io_pair *io_pair)
 {
     char buffer[0xffff];
-    struct s2n_connection *conn;
-    struct s2n_config *config;
+    struct s2n_connection *conn = NULL;
+    struct s2n_config *config = NULL;
     s2n_blocked_status blocked;
 
     /* Give the server a chance to listen */
@@ -52,7 +52,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
     uint16_t timeout = 1;
     s2n_connection_set_dynamic_record_threshold(conn, 0x7fff, timeout);
-    int i;
+    int i = 0;
     for (i = 1; i < 0xffff - 100; i += 100) {
         for (int j = 0; j < i; j++) {
             buffer[j] = 33;
@@ -69,7 +69,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
     /* Simulate timeout second conneciton inactivity and tolerate 50 ms error */
     struct timespec sleep_time = { .tv_sec = timeout, .tv_nsec = 50000000 };
-    int r;
+    int r = 0;
     do {
         r = nanosleep(&sleep_time, &sleep_time);
     } while (r != 0);
@@ -98,13 +98,13 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn;
-    struct s2n_config *config;
+    struct s2n_connection *conn = NULL;
+    struct s2n_config *config = NULL;
     s2n_blocked_status blocked;
-    int status;
-    char *cert_chain_pem;
-    char *private_key_pem;
-    char *dhparams_pem;
+    int status = 0;
+    char *cert_chain_pem = NULL;
+    char *private_key_pem = NULL;
+    char *dhparams_pem = NULL;
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());

--- a/tests/unit/s2n_self_talk_tls13_test.c
+++ b/tests/unit/s2n_self_talk_tls13_test.c
@@ -50,7 +50,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
     uint16_t timeout = 1;
     s2n_connection_set_dynamic_record_threshold(conn, 0x7fff, timeout);
-    int i;
+    int i = 0;
     for (i = 1; i < 0xffff - 100; i += 100) {
         for (int j = 0; j < i; j++) {
             buffer[j] = 33;
@@ -67,7 +67,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
 
     /* Simulate timeout second conneciton inactivity and tolerate 50 ms error */
     struct timespec sleep_time = { .tv_sec = timeout, .tv_nsec = 50000000 };
-    int r;
+    int r = 0;
     do {
         r = nanosleep(&sleep_time, &sleep_time);
     } while (r != 0);
@@ -99,8 +99,8 @@ int main(int argc, char **argv)
     struct s2n_connection *conn = NULL;
     struct s2n_config *config = NULL;
     s2n_blocked_status blocked;
-    int status;
-    pid_t pid;
+    int status = 0;
+    pid_t pid = 0;
 
     BEGIN_TEST();
 
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
 
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
-    struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
             S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
 

--- a/tests/unit/s2n_send_key_update_test.c
+++ b/tests/unit/s2n_send_key_update_test.c
@@ -78,8 +78,8 @@ int main(int argc, char **argv)
 
     /* s2n_send sends key update if necessary */
     {
-        struct s2n_connection *server_conn;
-        struct s2n_connection *client_conn;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         server_conn->actual_protocol_version = S2N_TLS13;
@@ -127,21 +127,21 @@ int main(int argc, char **argv)
     {
         EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-        char *cert_chain;
-        char *private_key;
+        char *cert_chain = NULL;
+        char *private_key = NULL;
         EXPECT_NOT_NULL(cert_chain = malloc(S2N_MAX_TEST_PEM_SIZE));
         EXPECT_NOT_NULL(private_key = malloc(S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(setenv("S2N_DONT_MLOCK", "1", 0));
         struct s2n_test_io_pair io_pair;
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
 
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
         s2n_blocked_status blocked = S2N_NOT_BLOCKED;
 
-        struct s2n_config *client_config;
+        struct s2n_config *client_config = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(client_config, 0));
         EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));

--- a/tests/unit/s2n_server_alpn_extension_test.c
+++ b/tests/unit/s2n_server_alpn_extension_test.c
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
 
     /* Test should_send */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         /* Should not send if protocol not set. Protocol not set by default. */
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
 
     /* Test send */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_MEMCPY_SUCCESS(conn->application_protocol, test_protocol_name, test_protocol_name_size);
 
@@ -52,18 +52,18 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_server_alpn_extension.send(conn, &stuffer));
 
         /* Should have correct total size */
-        uint16_t protocol_name_list_size;
+        uint16_t protocol_name_list_size = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&stuffer, &protocol_name_list_size));
         EXPECT_EQUAL(protocol_name_list_size, s2n_stuffer_data_available(&stuffer));
 
         /* Should have correct protocol name size */
-        uint8_t protocol_name_size;
+        uint8_t protocol_name_size = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &protocol_name_size));
         EXPECT_EQUAL(protocol_name_size, s2n_stuffer_data_available(&stuffer));
         EXPECT_EQUAL(protocol_name_size, test_protocol_name_size);
 
         /* Should have correct protocol name */
-        uint8_t *protocol_name;
+        uint8_t *protocol_name = NULL;
         EXPECT_NOT_NULL(protocol_name = s2n_stuffer_raw_read(&stuffer, protocol_name_size));
         EXPECT_BYTEARRAY_EQUAL(protocol_name, test_protocol_name, test_protocol_name_size);
 
@@ -73,13 +73,13 @@ int main(int argc, char **argv)
 
     /* Test recv */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_MEMCPY_SUCCESS(server_conn->application_protocol, test_protocol_name, test_protocol_name_size);
 
         /* Should accept extension written by send */
         {
-            struct s2n_connection *client_conn;
+            struct s2n_connection *client_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
             struct s2n_stuffer stuffer = { 0 };
@@ -100,7 +100,7 @@ int main(int argc, char **argv)
 
         /* Should ignore extension if protocol name list size incorrect */
         {
-            struct s2n_connection *client_conn;
+            struct s2n_connection *client_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
             struct s2n_stuffer stuffer = { 0 };

--- a/tests/unit/s2n_server_cert_request_test.c
+++ b/tests/unit/s2n_server_cert_request_test.c
@@ -53,8 +53,8 @@ int main(int argc, char **argv)
     /* Test server cert request default behavior when s2n_config_enable_cert_req_dss_legacy_compat is not called
      * Certificate types enabled should be in s2n_cert_type_preference_list */
     {
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
 
         s2n_cert_req_send(server_conn);
         struct s2n_stuffer *in = &server_conn->handshake.io;
-        uint8_t cert_types_len;
+        uint8_t cert_types_len = 0;
 
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(in, &cert_types_len));
 
@@ -80,8 +80,8 @@ int main(int argc, char **argv)
     /* Test certificate types in server cert request when s2n_config_enable_cert_req_dss_legacy_compat is called
      * Certificate types enabled should be in s2n_cert_type_preference_list_legacy_dss */
     {
-        struct s2n_connection *server_conn;
-        struct s2n_config *server_config;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_config *server_config = NULL;
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -90,7 +90,7 @@ int main(int argc, char **argv)
 
         s2n_cert_req_send(server_conn);
         struct s2n_stuffer *in = &server_conn->handshake.io;
-        uint8_t cert_types_len;
+        uint8_t cert_types_len = 0;
 
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(in, &cert_types_len));
 

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -62,19 +62,19 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
             S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
 
     /* s2n_server_extensions_send */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
 
         /* Test Server Extensions Send - No extensions */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
 
         /* Test Server Extensions Send - Server Name */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             s2n_extension_type_id extension_id = 0;
             EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_SERVER_NAME, &extension_id));
@@ -121,7 +121,7 @@ int main(int argc, char **argv)
 
         /* Test Server Extensions Send - Application Protocol */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             s2n_extension_type_id extension_id = 0;
             EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_ALPN, &extension_id));
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
 
         /* Test Server Extensions Send - Maximum Fragment Length (MFL) */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             s2n_extension_type_id extension_id = 0;
             EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_MAX_FRAG_LEN, &extension_id));
@@ -181,7 +181,7 @@ int main(int argc, char **argv)
 
         /* Test Server Extensions Send - Signed Certificate Timestamp extension */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             s2n_extension_type_id extension_id = 0;
             EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_SCT_LIST, &extension_id));
@@ -211,7 +211,7 @@ int main(int argc, char **argv)
 
         /* Test Server Extensions Send - OCSP Status Request */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             s2n_extension_type_id extension_id = 0;
             EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_STATUS_REQUEST, &extension_id));
@@ -242,7 +242,7 @@ int main(int argc, char **argv)
 
         /* Test Server Extensions Send - Secure Negotiation */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
             struct s2n_stuffer *hello_stuffer = &conn->handshake.io;
@@ -259,7 +259,7 @@ int main(int argc, char **argv)
 
         /* Test Server Extensions Send - New Session Ticket */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             s2n_extension_type_id extension_id = 0;
             EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_SESSION_TICKET, &extension_id));
@@ -280,7 +280,7 @@ int main(int argc, char **argv)
         /* Test TLS13 Extensions */
         {
             EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -322,7 +322,7 @@ int main(int argc, char **argv)
         /* Test Secure Negotiation server_hello extension not sent with TLS13 or higher */
         {
             EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -365,7 +365,7 @@ int main(int argc, char **argv)
         /* Test New Session Ticket server_hello extension not sent with TLS13 or higher */
         {
             EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             s2n_extension_type_id extension_id = 0;
             EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_SESSION_TICKET, &extension_id));
@@ -425,7 +425,7 @@ int main(int argc, char **argv)
             const uint8_t cipher_count_tls13 = sizeof(wire_ciphers_with_tls13) / S2N_TLS_CIPHER_SUITE_LEN;
 
             EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -516,7 +516,7 @@ int main(int argc, char **argv)
 
     /* Test ec_point_format extension */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         conn->secure->cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha;
 
@@ -543,7 +543,7 @@ int main(int argc, char **argv)
     {
         EXPECT_SUCCESS(s2n_enable_tls13_in_test());
 
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(server_conn));
 
@@ -561,7 +561,7 @@ int main(int argc, char **argv)
             server_conn->actual_protocol_version = S2N_TLS12;
             server_conn->server_protocol_version = S2N_TLS12;
 
-            struct s2n_connection *client_conn;
+            struct s2n_connection *client_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(client_conn));
 
@@ -590,7 +590,7 @@ int main(int argc, char **argv)
             server_conn->actual_protocol_version = S2N_TLS13;
             server_conn->server_protocol_version = S2N_TLS13;
 
-            struct s2n_connection *client_conn;
+            struct s2n_connection *client_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(client_conn));
 
@@ -640,7 +640,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_write_vector_size(&extension_list_size));
 
             for (size_t is_hrr = 0; is_hrr < 2; is_hrr++) {
-                struct s2n_connection *client_conn;
+                struct s2n_connection *client_conn = NULL;
                 EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
                 EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(client_conn));
                 client_conn->actual_protocol_version = S2N_TLS13;

--- a/tests/unit/s2n_server_hello_retry_test.c
+++ b/tests/unit/s2n_server_hello_retry_test.c
@@ -78,7 +78,7 @@ static int client_hello_detect_duplicate_calls(struct s2n_connection *conn, void
 
 int s2n_client_hello_poll_cb(struct s2n_connection *conn, void *ctx)
 {
-    struct client_hello_context *client_hello_ctx;
+    struct client_hello_context *client_hello_ctx = NULL;
     if (ctx == NULL) {
         return -1;
     }
@@ -157,8 +157,8 @@ int main(int argc, char **argv)
 
     /* Send Hello Retry Request messages */
     {
-        struct s2n_config *server_config;
-        struct s2n_connection *server_conn;
+        struct s2n_config *server_config = NULL;
+        struct s2n_connection *server_conn = NULL;
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -203,8 +203,8 @@ int main(int argc, char **argv)
 
     /* Verify the requires_retry flag causes a retry to be sent */
     {
-        struct s2n_config *conf;
-        struct s2n_connection *conn;
+        struct s2n_config *conf = NULL;
+        struct s2n_connection *conn = NULL;
 
         EXPECT_NOT_NULL(conf = s2n_config_new());
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
@@ -228,8 +228,8 @@ int main(int argc, char **argv)
 
     /* Retry requests with incorrect random data are not accepted */
     {
-        struct s2n_config *conf;
-        struct s2n_connection *conn;
+        struct s2n_config *conf = NULL;
+        struct s2n_connection *conn = NULL;
 
         EXPECT_NOT_NULL(conf = s2n_config_new());
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
@@ -267,8 +267,8 @@ int main(int argc, char **argv)
 
     /* Verify the client key share extension properly handles HelloRetryRequests */
     {
-        struct s2n_connection *server_conn;
-        struct s2n_connection *client_conn;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_connection *client_conn = NULL;
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
@@ -317,8 +317,8 @@ int main(int argc, char **argv)
     /* Verify that the hash transcript recreation function correctly takes the existing ClientHello1
      * hash, and generates a synthetic message. */
     {
-        struct s2n_config *conf;
-        struct s2n_connection *conn;
+        struct s2n_config *conf = NULL;
+        struct s2n_connection *conn = NULL;
 
         EXPECT_NOT_NULL(conf = s2n_config_new());
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
@@ -385,13 +385,13 @@ int main(int argc, char **argv)
 
     /* Send and receive Hello Retry Request messages */
     {
-        struct s2n_config *server_config;
-        struct s2n_config *client_config;
+        struct s2n_config *server_config = NULL;
+        struct s2n_config *client_config = NULL;
 
-        struct s2n_connection *server_conn;
-        struct s2n_connection *client_conn;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_connection *client_conn = NULL;
 
-        struct s2n_cert_chain_and_key *tls13_chain_and_key;
+        struct s2n_cert_chain_and_key *tls13_chain_and_key = NULL;
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_NOT_NULL(client_config = s2n_config_new());
@@ -459,13 +459,13 @@ int main(int argc, char **argv)
 
     /* Send and receive Hello Retry Request messages, test for non blocking client hello callback */
     {
-        struct s2n_config *server_config;
-        struct s2n_config *client_config;
+        struct s2n_config *server_config = NULL;
+        struct s2n_config *client_config = NULL;
 
-        struct s2n_connection *server_conn;
-        struct s2n_connection *client_conn;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_connection *client_conn = NULL;
 
-        struct s2n_cert_chain_and_key *tls13_chain_and_key;
+        struct s2n_cert_chain_and_key *tls13_chain_and_key = NULL;
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_NOT_NULL(client_config = s2n_config_new());
@@ -527,7 +527,7 @@ int main(int argc, char **argv)
     /* Test s2n_set_hello_retry_required correctly sets the handshake type to HELLO_RETRY_REQUEST,
      * when conn->actual_protocol_version is set to TLS1.3 version */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_all_protocol_versions(conn, S2N_TLS13));
 
@@ -540,7 +540,7 @@ int main(int argc, char **argv)
     /* Test s2n_set_hello_retry_required raises a S2N_ERR_INVALID_HELLO_RETRY error
      * when conn->actual_protocol_version is less than TLS1.3 */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         conn->actual_protocol_version = S2N_TLS12;
 

--- a/tests/unit/s2n_server_hello_test.c
+++ b/tests/unit/s2n_server_hello_test.c
@@ -66,16 +66,16 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    struct s2n_cert_chain_and_key *chain_and_key;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
             S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
 
     /* Test basic Server Hello Send */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -133,11 +133,11 @@ int main(int argc, char **argv)
 
     /* Test basic Server Hello Recv */
     {
-        struct s2n_config *server_config;
-        struct s2n_config *client_config;
+        struct s2n_config *server_config = NULL;
+        struct s2n_config *client_config = NULL;
 
-        struct s2n_connection *server_conn;
-        struct s2n_connection *client_conn;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_connection *client_conn = NULL;
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -170,8 +170,8 @@ int main(int argc, char **argv)
 
     /* Test Server Hello Recv with invalid cipher */
     {
-        struct s2n_connection *server_conn;
-        struct s2n_connection *client_conn;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_connection *client_conn = NULL;
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
@@ -196,8 +196,8 @@ int main(int argc, char **argv)
 
     /* Non-matching session IDs turn off EMS for the connection */
     {
-        struct s2n_connection *server_conn;
-        struct s2n_connection *client_conn;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_connection *client_conn = NULL;
 
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
@@ -234,8 +234,8 @@ int main(int argc, char **argv)
     /* Test TLS 1.3 session id matching */
     {
         EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-        struct s2n_config *client_config;
-        struct s2n_connection *client_conn;
+        struct s2n_config *client_config = NULL;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
@@ -297,10 +297,10 @@ int main(int argc, char **argv)
     /* Test TLS 1.3 => 1.1 protocol downgrade detection with a TLS1.3 client */
     {
         EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-        struct s2n_config *client_config;
-        struct s2n_connection *client_conn;
-        struct s2n_config *server_config;
-        struct s2n_connection *server_conn;
+        struct s2n_config *client_config = NULL;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_config *server_config = NULL;
+        struct s2n_connection *server_conn = NULL;
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -341,10 +341,10 @@ int main(int argc, char **argv)
     /* Test TLS 1.3 => 1.2 protocol downgrade detection with a TLS1.3 client */
     {
         EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-        struct s2n_config *client_config;
-        struct s2n_connection *client_conn;
-        struct s2n_config *server_config;
-        struct s2n_connection *server_conn;
+        struct s2n_config *client_config = NULL;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_config *server_config = NULL;
+        struct s2n_connection *server_conn = NULL;
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -384,10 +384,10 @@ int main(int argc, char **argv)
 
     /* Verify a TLS1.2 client can negotiate with a TLS1.3 server */
     {
-        struct s2n_config *client_config;
-        struct s2n_connection *client_conn;
-        struct s2n_config *server_config;
-        struct s2n_connection *server_conn;
+        struct s2n_config *client_config = NULL;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_config *server_config = NULL;
+        struct s2n_connection *server_conn = NULL;
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -426,10 +426,10 @@ int main(int argc, char **argv)
 
     /* Verify a TLS1.3 client can negotiate with a TLS1.2 server */
     {
-        struct s2n_config *client_config;
-        struct s2n_connection *client_conn;
-        struct s2n_config *server_config;
-        struct s2n_connection *server_conn;
+        struct s2n_config *client_config = NULL;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_config *server_config = NULL;
+        struct s2n_connection *server_conn = NULL;
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -468,10 +468,10 @@ int main(int argc, char **argv)
 
     /* Verify a TLS1.2 client can negotiate with a TLS1.3 server */
     {
-        struct s2n_config *client_config;
-        struct s2n_connection *client_conn;
-        struct s2n_config *server_config;
-        struct s2n_connection *server_conn;
+        struct s2n_config *client_config = NULL;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_config *server_config = NULL;
+        struct s2n_connection *server_conn = NULL;
 
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -511,7 +511,7 @@ int main(int argc, char **argv)
 
     /* TLS13 hello retry message received results into S2N_ERR_UNIMPLEMENTED error*/
     {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         struct s2n_stuffer *io = &client_conn->handshake.io;
         client_conn->server_protocol_version = S2N_TLS13;

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
 
     /* Test s2n_extensions_server_key_share_send_size */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         EXPECT_EQUAL(0, s2n_extensions_server_key_share_send_size(conn));
@@ -200,8 +200,8 @@ int main(int argc, char **argv)
 
         int i = 0;
         do {
-            struct s2n_connection *server_send_conn;
-            struct s2n_connection *client_recv_conn;
+            struct s2n_connection *server_send_conn = NULL;
+            struct s2n_connection *client_recv_conn = NULL;
             EXPECT_NOT_NULL(server_send_conn = s2n_connection_new(S2N_SERVER));
             EXPECT_NOT_NULL(client_recv_conn = s2n_connection_new(S2N_CLIENT));
 
@@ -248,7 +248,7 @@ int main(int argc, char **argv)
 
             for (int i = 0; i < 3; i++) {
                 struct s2n_stuffer extension_stuffer = { 0 };
-                struct s2n_connection *client_conn;
+                struct s2n_connection *client_conn = NULL;
 
                 EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
@@ -276,7 +276,7 @@ int main(int argc, char **argv)
              * if tls1.3 not enabled */
             {
                 struct s2n_stuffer extension_stuffer = { 0 };
-                struct s2n_connection *client_conn;
+                struct s2n_connection *client_conn = NULL;
 
                 EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
@@ -312,7 +312,7 @@ int main(int argc, char **argv)
         /* Test error handling parsing broken/trancated p256 key share */
         {
             struct s2n_stuffer extension_stuffer = { 0 };
-            struct s2n_connection *client_conn;
+            struct s2n_connection *client_conn = NULL;
 
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             const char *p256 = "001700410474cfd75c0ab7b57247761a277e1c92b5810dacb251bb758f43e9d15aaf292c4a2be43e886425ba55653ebb7a4f32fe368bacce3df00c618645cf1eb6";
@@ -329,7 +329,7 @@ int main(int argc, char **argv)
         /* Test failure for receiving p256 key share for client configured p384 key share */
         {
             struct s2n_stuffer extension_stuffer = { 0 };
-            struct s2n_connection *client_conn;
+            struct s2n_connection *client_conn = NULL;
 
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             const struct s2n_ecc_preferences *ecc_pref = NULL;
@@ -356,7 +356,7 @@ int main(int argc, char **argv)
 
     /* Test Shared Key Generation */
     {
-        struct s2n_connection *client_conn, *server_conn;
+        struct s2n_connection *client_conn = NULL, *server_conn = NULL;
         struct s2n_stuffer key_share_extension = { 0 };
 
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
@@ -424,7 +424,7 @@ int main(int argc, char **argv)
 
     /* Test s2n_server_key_share_extension.send with supported curve not in s2n_ecc_preferences list selected */
     if (s2n_is_evp_apis_supported()) {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(conn->config);
 
@@ -441,7 +441,7 @@ int main(int argc, char **argv)
 
     /* Test s2n_server_key_share_extension.recv with supported curve not in s2n_ecc_preferences list selected  */
     if (s2n_is_evp_apis_supported()) {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         struct s2n_stuffer *extension_stuffer = &conn->handshake.io;
 
@@ -464,8 +464,8 @@ int main(int argc, char **argv)
         /* For a HelloRetryRequest, we won't have a key share. We just have the server selected group/negotiated curve.
          * Test that s2n_server_key_share_extension.recv obtains the server negotiate curve successfully. */
         {
-            struct s2n_connection *client_conn;
-            struct s2n_connection *server_conn;
+            struct s2n_connection *client_conn = NULL;
+            struct s2n_connection *server_conn = NULL;
 
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
@@ -682,7 +682,7 @@ int main(int argc, char **argv)
                         if (!s2n_kem_group_is_available(kem_group)) {
                             continue;
                         }
-                        struct s2n_connection *client_conn;
+                        struct s2n_connection *client_conn = NULL;
                         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
                         client_conn->security_policy_override = &test_security_policy;
 

--- a/tests/unit/s2n_server_max_frag_len_extension_test.c
+++ b/tests/unit/s2n_server_max_frag_len_extension_test.c
@@ -24,10 +24,10 @@ int main(int argc, char **argv)
 
     /* Test should_send */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -44,11 +44,11 @@ int main(int argc, char **argv)
 
     /* Test send */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_send_max_fragment_length(config, S2N_TLS_MAX_FRAG_LEN_512));
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_server_max_fragment_length_extension.send(conn, &stuffer));
 
         /* Should have correct fragment length */
-        uint8_t actual_fragment_length;
+        uint8_t actual_fragment_length = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&stuffer, &actual_fragment_length));
         EXPECT_EQUAL(actual_fragment_length, S2N_TLS_MAX_FRAG_LEN_512);
 
@@ -80,11 +80,11 @@ int main(int argc, char **argv)
      *# an "illegal_parameter" alert.
      */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_send_max_fragment_length(config, S2N_TLS_MAX_FRAG_LEN_512));
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -104,11 +104,11 @@ int main(int argc, char **argv)
 
     /* Test receive */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_send_max_fragment_length(config, S2N_TLS_MAX_FRAG_LEN_512));
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -133,11 +133,11 @@ int main(int argc, char **argv)
 
     /* Test receive - existing mfl value */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_send_max_fragment_length(config, S2N_TLS_MAX_FRAG_LEN_1024));
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -72,7 +72,7 @@ static int s2n_setup_test_ticket_key(struct s2n_config *config)
             "90b6c73bb50f9c3122ec844ad7c2b3e5");
 
     /* Set up encryption key */
-    uint64_t current_time;
+    uint64_t current_time = 0;
     uint8_t ticket_key_name[16] = "2016.07.26.15\0";
     EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, 1));
     EXPECT_SUCCESS(config->wall_clock(config->sys_clock_ctx, &current_time));
@@ -112,8 +112,8 @@ int main(int argc, char **argv)
     {
         /* Check session ticket message is correctly written. */
         {
-            struct s2n_config *config;
-            struct s2n_connection *conn;
+            struct s2n_config *config = NULL;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_NOT_NULL(config = s2n_config_new());
 
@@ -184,8 +184,8 @@ int main(int argc, char **argv)
 
         /* tickets_sent overflow */
         {
-            struct s2n_config *config;
-            struct s2n_connection *conn;
+            struct s2n_config *config = NULL;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_NOT_NULL(config = s2n_config_new());
 
@@ -214,8 +214,8 @@ int main(int argc, char **argv)
          *#  for each ticket it sends.
          **/
         {
-            struct s2n_config *config;
-            struct s2n_connection *conn;
+            struct s2n_config *config = NULL;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_NOT_NULL(config = s2n_config_new());
 
@@ -327,7 +327,7 @@ int main(int argc, char **argv)
     /* s2n_generate_ticket_lifetime */
     {
         uint32_t min_lifetime = 0;
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         /* Test: encrypt + decrypt key has shortest lifetime */
@@ -829,7 +829,7 @@ int main(int argc, char **argv)
     {
         /* Mode is not server */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             conn->actual_protocol_version = S2N_TLS13;
             conn->tickets_to_send = 1;
@@ -945,8 +945,8 @@ int main(int argc, char **argv)
 
         /* Sends one new session ticket */
         {
-            struct s2n_config *config;
-            struct s2n_connection *conn;
+            struct s2n_config *config = NULL;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_NOT_NULL(config = s2n_config_new());
             EXPECT_SUCCESS(s2n_setup_test_ticket_key(config));
@@ -1130,8 +1130,8 @@ int main(int argc, char **argv)
 
         /* Sends multiple new session tickets */
         {
-            struct s2n_config *config;
-            struct s2n_connection *conn;
+            struct s2n_config *config = NULL;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_NOT_NULL(config = s2n_config_new());
 
@@ -1269,15 +1269,15 @@ int main(int argc, char **argv)
     /* Functional test: s2n_negotiate sends new session tickets after the handshake is complete */
     if (s2n_is_tls13_fully_supported()) {
         /* Setup connections */
-        struct s2n_connection *client_conn, *server_conn;
+        struct s2n_connection *client_conn = NULL, *server_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
         /* Setup config */
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
                 S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));

--- a/tests/unit/s2n_server_psk_extension_test.c
+++ b/tests/unit/s2n_server_psk_extension_test.c
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
 
     /* Test: s2n_server_psk_recv */
     {
-        s2n_extension_type_id key_share_ext_id;
+        s2n_extension_type_id key_share_ext_id = 0;
         EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_KEY_SHARE, &key_share_ext_id));
 
         /* Test s2n_server_psk_recv for invalid TLS versions <= TLS1.2 */
@@ -260,7 +260,7 @@ int main(int argc, char **argv)
     if (s2n_is_tls13_fully_supported()) {
         /* Setup connections */
         EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-        struct s2n_connection *client_conn, *server_conn;
+        struct s2n_connection *client_conn = NULL, *server_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));

--- a/tests/unit/s2n_server_renegotiation_info_test.c
+++ b/tests/unit/s2n_server_renegotiation_info_test.c
@@ -68,7 +68,7 @@ int main(int argc, char **argv)
      *#    message.
      */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         /* TLS1.2 and secure renegotiation not enabled -> DON'T send */
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
      *# that they have been upgraded.
      */
     {
-        struct s2n_connection *server_conn, *client_conn;
+        struct s2n_connection *server_conn = NULL, *client_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
@@ -160,7 +160,7 @@ int main(int argc, char **argv)
 
     /* Test server_renegotiation_info recv during initial handshake - extension too long */
     {
-        struct s2n_connection *server_conn, *client_conn;
+        struct s2n_connection *server_conn = NULL, *client_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
@@ -191,7 +191,7 @@ int main(int argc, char **argv)
      *#    abort the handshake (by sending a fatal handshake_failure alert).
      */
     {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
         struct s2n_stuffer extension = { 0 };

--- a/tests/unit/s2n_server_sct_list_extension_test.c
+++ b/tests/unit/s2n_server_sct_list_extension_test.c
@@ -39,10 +39,10 @@ int main(int argc, char **argv)
 
     /* should_send */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
 
     /* Test send */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
 
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
 
     /* Test recv */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_test_enable_sending_extension(conn, chain_and_key));
 

--- a/tests/unit/s2n_server_server_name_extension_test.c
+++ b/tests/unit/s2n_server_server_name_extension_test.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
 
     /* should_send */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         /* By default, do not send */
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
 
     /* recv */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         /* Recv reads nothing and always succeeds */

--- a/tests/unit/s2n_server_session_ticket_extension_test.c
+++ b/tests/unit/s2n_server_session_ticket_extension_test.c
@@ -39,10 +39,10 @@ int main(int argc, char **argv)
 
     /* Test should_send */
     {
-        struct s2n_config *config;
+        struct s2n_config *config = NULL;
         EXPECT_NOT_NULL(config = s2n_config_new());
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
 
     /* Test server_session_ticket send and recv */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         EXPECT_SUCCESS(s2n_server_session_ticket_extension.send(conn, NULL));

--- a/tests/unit/s2n_server_signature_algorithms_extension_test.c
+++ b/tests/unit/s2n_server_signature_algorithms_extension_test.c
@@ -32,8 +32,8 @@ int main(int argc, char **argv)
     s2n_enable_tls13_in_test();
 
     {
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 

--- a/tests/unit/s2n_server_supported_versions_extension_test.c
+++ b/tests/unit/s2n_server_supported_versions_extension_test.c
@@ -41,12 +41,12 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_enable_tls13_in_test());
     uint8_t latest_version = S2N_TLS13;
 
-    struct s2n_config *config;
+    struct s2n_config *config = NULL;
     EXPECT_NOT_NULL(config = s2n_config_new());
 
     /* Server sends a supported_version the client can parse */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(extension_length, s2n_stuffer_data_available(&extension));
 
         /* Check that the client can process the version */
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
 
     /* Client alerts if supported_version less than min supported by client */
     {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
@@ -100,7 +100,7 @@ int main(int argc, char **argv)
 
     /* Client alerts if supported_version greater than max supported by client */
     {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
 
     /* Client alerts if supported_version is empty */
     {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
 
     /* Client alerts if supported_version is malformed */
     {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -85,15 +85,15 @@ struct small_name_ticket {
 
 int main(int argc, char **argv)
 {
-    char *cert_chain;
-    char *private_key;
-    struct s2n_cert_chain_and_key *chain_and_key;
-    struct s2n_connection *client_conn;
-    struct s2n_connection *server_conn;
-    struct s2n_config *client_config;
-    struct s2n_config *server_config;
-    uint64_t now;
-    struct s2n_ticket_key *ticket_key;
+    char *cert_chain = NULL;
+    char *private_key = NULL;
+    struct s2n_cert_chain_and_key *chain_and_key = NULL;
+    struct s2n_connection *client_conn = NULL;
+    struct s2n_connection *server_conn = NULL;
+    struct s2n_config *client_config = NULL;
+    struct s2n_config *server_config = NULL;
+    uint64_t now = 0;
+    struct s2n_ticket_key *ticket_key = NULL;
     uint32_t ticket_keys_len = 0;
 
     size_t serialized_session_state_length = 0;

--- a/tests/unit/s2n_stuffer_hex_test.c
+++ b/tests/unit/s2n_stuffer_hex_test.c
@@ -24,10 +24,10 @@ int main(int argc, char **argv)
     struct s2n_blob b = { 0 };
     EXPECT_SUCCESS(s2n_blob_init(&b, pad, sizeof(pad)));
     struct s2n_stuffer stuffer = { 0 };
-    uint8_t u8;
-    uint16_t u16;
-    uint32_t u32;
-    uint64_t u64;
+    uint8_t u8 = 0;
+    uint16_t u16 = 0;
+    uint32_t u32 = 0;
+    uint64_t u64 = 0;
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());

--- a/tests/unit/s2n_stuffer_network_order_test.c
+++ b/tests/unit/s2n_stuffer_network_order_test.c
@@ -41,12 +41,12 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, 0x00, 0));
         EXPECT_EQUAL(s2n_stuffer_data_available(&stuffer), 0);
 
-        uint8_t byte_length;
+        uint8_t byte_length = 0;
 
         /* uint8_t */
         {
             byte_length = sizeof(uint8_t);
-            uint8_t actual_value;
+            uint8_t actual_value = 0;
 
             for (int i = 0; i <= UINT8_MAX; i++) {
                 EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, i, byte_length));
@@ -58,7 +58,7 @@ int main(int argc, char **argv)
         /* uint16_t */
         {
             byte_length = sizeof(uint16_t);
-            uint16_t actual_value;
+            uint16_t actual_value = 0;
 
             for (int i = 0; i < UINT16_MAX; i++) {
                 EXPECT_SUCCESS(s2n_stuffer_write_network_order(&stuffer, i, byte_length));
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
         /* uint24 */
         {
             byte_length = 3;
-            uint32_t actual_value;
+            uint32_t actual_value = 0;
             uint32_t test_values[] = { 0x000001, 0x0000FF, 0xABCDEF, 0xFFFFFF };
 
             for (size_t i = 0; i < s2n_array_len(test_values); i++) {
@@ -90,7 +90,7 @@ int main(int argc, char **argv)
         /* uint32_t */
         {
             byte_length = sizeof(uint32_t);
-            uint32_t actual_value;
+            uint32_t actual_value = 0;
             uint32_t test_values[] = { 0x00000001, 0x000000FF, 0xABCDEF12, UINT32_MAX };
 
             for (size_t i = 0; i < s2n_array_len(test_values); i++) {
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
 
     /* s2n_stuffer_reserve_uint16 */
     {
-        uint16_t actual_value;
+        uint16_t actual_value = 0;
         struct s2n_stuffer_reservation reservation = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
@@ -159,7 +159,7 @@ int main(int argc, char **argv)
 
     /* s2n_stuffer_reserve_uint24 */
     {
-        uint16_t actual_value;
+        uint16_t actual_value = 0;
         struct s2n_stuffer_reservation reservation = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
 
     /* s2n_stuffer_write_reservation */
     {
-        uint16_t actual_value;
+        uint16_t actual_value = 0;
         struct s2n_stuffer_reservation reservation = { 0 };
         struct s2n_stuffer_reservation other_reservation = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
@@ -272,7 +272,7 @@ int main(int argc, char **argv)
 
     /* s2n_stuffer_write_vector_size */
     {
-        uint16_t actual_value;
+        uint16_t actual_value = 0;
         struct s2n_stuffer_reservation reservation = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
 

--- a/tests/unit/s2n_stuffer_test.c
+++ b/tests/unit/s2n_stuffer_test.c
@@ -23,10 +23,10 @@ int main(int argc, char **argv)
 {
     uint8_t entropy[2048] = { 0 };
     struct s2n_stuffer stuffer = { 0 };
-    uint8_t u8;
-    uint16_t u16;
-    uint32_t u32;
-    uint64_t u64;
+    uint8_t u8 = 0;
+    uint16_t u16 = 0;
+    uint32_t u32 = 0;
+    uint64_t u64 = 0;
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());

--- a/tests/unit/s2n_stuffer_text_test.c
+++ b/tests/unit/s2n_stuffer_text_test.c
@@ -22,7 +22,7 @@
 
 int main(int argc, char **argv)
 {
-    char c;
+    char c = 0;
     uint32_t skipped = 0;
     struct s2n_stuffer stuffer, token;
     struct s2n_blob pad_blob, token_blob;

--- a/tests/unit/s2n_testlib_test.c
+++ b/tests/unit/s2n_testlib_test.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv)
      * We should always report the actual error to allow better debugging of tests.
      */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
         /* Create nonblocking pipes */

--- a/tests/unit/s2n_timer_test.c
+++ b/tests/unit/s2n_timer_test.c
@@ -26,10 +26,10 @@ int mock_clock(void *in, uint64_t *out)
 
 int main(int argc, char **argv)
 {
-    struct s2n_config *config;
+    struct s2n_config *config = NULL;
     struct s2n_timer timer;
-    uint64_t nanoseconds;
-    uint64_t mock_time;
+    uint64_t nanoseconds = 0;
+    uint64_t mock_time = 0;
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());

--- a/tests/unit/s2n_tls12_handshake_test.c
+++ b/tests/unit/s2n_tls12_handshake_test.c
@@ -449,7 +449,7 @@ int main(int argc, char **argv)
         conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE | CLIENT_AUTH | NO_CLIENT_CERT | TLS12_PERFECT_FORWARD_SECRECY | OCSP_STATUS | WITH_SESSION_TICKET | WITH_NPN;
         EXPECT_STRING_EQUAL(all_flags_handshake_type_name, s2n_connection_get_handshake_type_name(conn));
 
-        const char *handshake_type_name;
+        const char *handshake_type_name = NULL;
         for (int i = 0; i < valid_tls12_handshakes_size; i++) {
             conn->handshake.handshake_type = valid_tls12_handshakes[i];
 

--- a/tests/unit/s2n_tls13_cert_request_extensions_test.c
+++ b/tests/unit/s2n_tls13_cert_request_extensions_test.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv)
 
     /* Test correct required extension (sig_alg) sent and received */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
         conn->actual_protocol_version = S2N_TLS13;
 
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
 
     /* Test client fails to parse certificate request with no extensions */
     {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         client_conn->actual_protocol_version = S2N_TLS13;
 

--- a/tests/unit/s2n_tls13_cert_request_test.c
+++ b/tests/unit/s2n_tls13_cert_request_test.c
@@ -32,15 +32,15 @@ int main(int argc, char **argv)
 
     /* Test the output of s2n_tls13_cert_req_send() */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         server_conn->actual_protocol_version = S2N_TLS13;
 
         EXPECT_SUCCESS(s2n_tls13_cert_req_send(server_conn));
 
         /* verify output */
-        uint8_t request_context_length;
-        uint16_t extensions_length, extension_size, extension_type;
+        uint8_t request_context_length = 0;
+        uint16_t extensions_length = 0, extension_size = 0, extension_type = 0;
         EXPECT_TRUE(s2n_stuffer_data_available(&server_conn->handshake.io) > 7);
         EXPECT_SUCCESS(s2n_stuffer_read_uint8(&server_conn->handshake.io, &request_context_length));
         EXPECT_SUCCESS(s2n_stuffer_read_uint16(&server_conn->handshake.io, &extensions_length));
@@ -56,8 +56,8 @@ int main(int argc, char **argv)
 
     /* Test client can receive and parse certificate request */
     {
-        struct s2n_connection *server_conn;
-        struct s2n_connection *client_conn;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         server_conn->actual_protocol_version = S2N_TLS13;
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
 
     /* Test request context length other than 0 fails */
     {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         client_conn->actual_protocol_version = S2N_TLS13;
 

--- a/tests/unit/s2n_tls13_client_finished_test.c
+++ b/tests/unit/s2n_tls13_client_finished_test.c
@@ -45,7 +45,7 @@ int main(int argc, char **argv)
         };
 
         for (int i = 0; i < 3; i++) {
-            struct s2n_connection *client_conn;
+            struct s2n_connection *client_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
             client_conn->actual_protocol_version = S2N_TLS13;
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_tls13_client_finished_send(client_conn));
             EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->handshake.io), hash_size);
 
-            struct s2n_connection *server_conn;
+            struct s2n_connection *server_conn = NULL;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
             server_conn->actual_protocol_version = S2N_TLS13;
             server_conn->secure->cipher_suite = &cipher_suites[i];
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
 
     /* Test that they can only run in TLS 1.3 mode */
     {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         client_conn->secure->cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
 
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_tls13_client_finished_send(client_conn));
         EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->handshake.io), 48);
 
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
 
         server_conn->secure->cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
@@ -119,7 +119,7 @@ int main(int argc, char **argv)
 
     /* Test for failure cases if cipher suites are incompatible */
     {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
         client_conn->actual_protocol_version = S2N_TLS13;
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_tls13_client_finished_send(client_conn));
         EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->handshake.io), 32);
 
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
         server_conn->actual_protocol_version = S2N_TLS13;
         server_conn->secure->cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
 
     /* Test for failure cases when finished secret key differs */
     {
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
         client_conn->actual_protocol_version = S2N_TLS13;
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_tls13_client_finished_send(client_conn));
         EXPECT_EQUAL(s2n_stuffer_data_available(&client_conn->handshake.io), 48);
 
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
         server_conn->actual_protocol_version = S2N_TLS13;
         server_conn->secure->cipher_suite = &s2n_tls13_aes_256_gcm_sha384;

--- a/tests/unit/s2n_tls13_compute_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_compute_shared_secret_test.c
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
     EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
 
-    struct s2n_connection *client_conn;
+    struct s2n_connection *client_conn = NULL;
 
     /* This test ensures that if the server did not send a keyshare extension in the server hello function,
      * a null pointer error is correctly thrown.

--- a/tests/unit/s2n_tls13_handshake_state_machine_test.c
+++ b/tests/unit/s2n_tls13_handshake_state_machine_test.c
@@ -121,8 +121,8 @@ int main(int argc, char **argv)
      *       message and client CCS messages.
      */
     {
-        uint32_t original_handshake_type, early_data_handshake_type;
-        message_type_t *original_messages, *early_data_messages;
+        uint32_t original_handshake_type = 0, early_data_handshake_type = 0;
+        message_type_t *original_messages = NULL, *early_data_messages = NULL;
 
         for (size_t i = 0; i < valid_tls13_handshakes_size; i++) {
             original_handshake_type = valid_tls13_handshakes[i];
@@ -183,8 +183,8 @@ int main(int argc, char **argv)
     /* Test: A MIDDLEBOX_COMPAT form of every valid, negotiated handshake exists
      *       and matches the non-MIDDLEBOX_COMPAT form EXCEPT for CCS messages */
     {
-        uint32_t handshake_type_original, handshake_type_mc;
-        message_type_t *messages_original, *messages_mc;
+        uint32_t handshake_type_original = 0, handshake_type_mc = 0;
+        message_type_t *messages_original = NULL, *messages_mc = NULL;
 
         for (size_t i = 0; i < valid_tls13_handshakes_size; i++) {
             handshake_type_original = valid_tls13_handshakes[i];
@@ -218,8 +218,8 @@ int main(int argc, char **argv)
 
     /* Test: A non-FULL_HANDSHAKE form of every valid, negotiated handshake exists */
     {
-        uint32_t handshake_type_original, handshake_type_fh;
-        message_type_t *messages_original, *messages_fh;
+        uint32_t handshake_type_original = 0, handshake_type_fh = 0;
+        message_type_t *messages_original = NULL, *messages_fh = NULL;
 
         for (size_t i = 0; i < valid_tls13_handshakes_size; i++) {
             handshake_type_original = valid_tls13_handshakes[i];
@@ -264,8 +264,8 @@ int main(int argc, char **argv)
     /* Test: A EARLY_CLIENT_CCS form of every middlebox compatible handshake exists.
      * Any handshake could start with early data, even if that early data is later rejected. */
     {
-        uint32_t handshake_type_original, handshake_type_test;
-        message_type_t *messages_original, *messages_test;
+        uint32_t handshake_type_original = 0, handshake_type_test = 0;
+        message_type_t *messages_original = NULL, *messages_test = NULL;
 
         for (size_t i = 0; i < valid_tls13_handshakes_size; i++) {
             handshake_type_original = valid_tls13_handshakes[i];
@@ -933,7 +933,7 @@ int main(int argc, char **argv)
                 | MIDDLEBOX_COMPAT | WITH_EARLY_DATA | EARLY_CLIENT_CCS;
         EXPECT_STRING_EQUAL(all_flags_handshake_type_name, s2n_connection_get_handshake_type_name(conn));
 
-        const char *handshake_type_name;
+        const char *handshake_type_name = NULL;
         for (int i = 0; i < valid_tls13_handshakes_size; i++) {
             conn->handshake.handshake_type = valid_tls13_handshakes[i];
 

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
     {
         /* PSKs are wiped when chosen PSK is NULL */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
             const struct s2n_ecc_preferences *ecc_preferences = NULL;
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
 
         /* PSKs are wiped when chosen PSK is NOT NULL */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
             const struct s2n_ecc_preferences *ecc_preferences = NULL;
@@ -161,10 +161,10 @@ int main(int argc, char **argv)
 
     /* Test: Handshake self-talks using s2n_handshake_write_io and s2n_handshake_read_io */
     {
-        struct s2n_connection *client_conn;
-        struct s2n_connection *server_conn;
+        struct s2n_connection *client_conn = NULL;
+        struct s2n_connection *server_conn = NULL;
 
-        struct s2n_config *server_config, *client_config;
+        struct s2n_config *server_config = NULL, *client_config = NULL;
         EXPECT_NOT_NULL(server_config = s2n_config_new());
         EXPECT_NOT_NULL(client_config = s2n_config_new());
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(client_config));
@@ -180,7 +180,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_read_test_pem_and_len(S2N_ECDSA_P384_PKCS1_CERT_CHAIN, cert_chain, &cert_chain_len, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem_and_len(S2N_ECDSA_P384_PKCS1_KEY, private_key, &private_key_len, S2N_MAX_TEST_PEM_SIZE));
 
-        struct s2n_cert_chain_and_key *default_cert;
+        struct s2n_cert_chain_and_key *default_cert = NULL;
         EXPECT_NOT_NULL(default_cert = s2n_cert_chain_and_key_new());
         EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem_bytes(default_cert, cert_chain, cert_chain_len, private_key, private_key_len));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, default_cert));

--- a/tests/unit/s2n_tls13_keys_test.c
+++ b/tests/unit/s2n_tls13_keys_test.c
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
                 "ee85dd54781bd4d8a100589a9fe6ac9a3797b811e977f549cd"
                 "531be2441d7c63e2b9729d145c11d84af35957727565a4");
 
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         server_conn->actual_protocol_version = S2N_TLS13;
         server_conn->secure->cipher_suite = &s2n_tls13_aes_256_gcm_sha384;

--- a/tests/unit/s2n_tls13_new_session_ticket_test.c
+++ b/tests/unit/s2n_tls13_new_session_ticket_test.c
@@ -90,7 +90,7 @@ int main(int argc, char **argv)
         struct s2n_config *client_config = s2n_config_new();
         EXPECT_NOT_NULL(client_config);
 
-        struct s2n_cert_chain_and_key *chain_and_key;
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
                 S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));

--- a/tests/unit/s2n_tls13_parse_record_type_test.c
+++ b/tests/unit/s2n_tls13_parse_record_type_test.c
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    uint8_t record_type;
+    uint8_t record_type = 0;
 
     /* In tls13 the true record type is inserted in the last byte of the encrypted payload. This
     * test creates a fake unencrypted payload and checks that the helper function

--- a/tests/unit/s2n_tls13_prf_test.c
+++ b/tests/unit/s2n_tls13_prf_test.c
@@ -75,25 +75,25 @@ int main(int argc, char **argv)
 
     /* Parse the hex */
     for (size_t i = 0; i < sizeof(client_handshake_message); i++) {
-        uint8_t c;
+        uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&client_handshake_message_in, &c));
         client_handshake_message[i] = c;
     }
 
     for (size_t i = 0; i < sizeof(server_handshake_message); i++) {
-        uint8_t c;
+        uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&server_handshake_message_in, &c));
         server_handshake_message[i] = c;
     }
 
     for (size_t i = 0; i < sizeof(expected_secret); i++) {
-        uint8_t c;
+        uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&expected_secret_in, &c));
         expected_secret[i] = c;
     }
 
     for (size_t i = 0; i < sizeof(expected_expanded); i++) {
-        uint8_t c;
+        uint8_t c = 0;
         EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&expected_expanded_in, &c));
         expected_expanded[i] = c;
     }

--- a/tests/unit/s2n_tls13_record_aead_test.c
+++ b/tests/unit/s2n_tls13_record_aead_test.c
@@ -127,7 +127,7 @@ int main(int argc, char **argv)
 
     /* Test s2n_tls13_aes_128_gcm_sha256 cipher suite with TLS 1.3 test vectors */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         struct s2n_session_key session_key = { 0 };
         EXPECT_SUCCESS(s2n_session_key_alloc(&session_key));
 
@@ -211,7 +211,7 @@ int main(int argc, char **argv)
 
     /* Test s2n_tls13_aes_128_gcm_sha256 cipher suite ENCRYPTION with TLS 1.3 test vectors */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         struct s2n_cipher_suite *cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         conn->actual_protocol_version = S2N_TLS13;
@@ -268,7 +268,7 @@ int main(int argc, char **argv)
 
     /* Test encrypt-decrypt roundtrip */
     {
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         struct s2n_cipher_suite *cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         conn->actual_protocol_version = S2N_TLS13;
@@ -338,7 +338,7 @@ int main(int argc, char **argv)
     {
         s2n_mode modes[] = { S2N_SERVER, S2N_CLIENT };
         for (size_t m = 0; m < s2n_array_len(modes); m++) {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             struct s2n_cipher_suite *cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
             EXPECT_NOT_NULL(conn = s2n_connection_new(modes[m]));
             conn->actual_protocol_version = S2N_TLS13;

--- a/tests/unit/s2n_tls13_server_cert_test.c
+++ b/tests/unit/s2n_tls13_server_cert_test.c
@@ -92,7 +92,7 @@ int main(int argc, char **argv)
     /* Test s2n_server_cert_recv() parses tls13 certificate */
     {
         S2N_BLOB_FROM_HEX(tls13_cert, tls13_cert_message_hex);
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
         conn->x509_validator.skip_cert_validation = 1;
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
 
     /* Test s2n_server_cert_send() verify server's certificate */
     {
-        char *tls13_cert_chain_hex;
+        char *tls13_cert_chain_hex = NULL;
         /* creating a certificate chain by concatenating
            1. chain header
            2. certificate
@@ -130,8 +130,8 @@ int main(int argc, char **argv)
 
         S2N_BLOB_FROM_HEX(tls13_cert_chain, tls13_cert_hex);
 
-        struct s2n_connection *conn;
-        uint8_t certificate_request_context_len;
+        struct s2n_connection *conn = NULL;
+        uint8_t certificate_request_context_len = 0;
 
         struct s2n_cert cert = { .raw = tls13_cert_chain, .next = NULL };
         /* .chain_size is size of cert + 3 for the 3 bytes to express the length */
@@ -172,8 +172,8 @@ int main(int argc, char **argv)
     {
         EXPECT_SUCCESS(s2n_enable_tls13_in_test());
 
-        struct s2n_connection *server_conn;
-        struct s2n_connection *client_conn;
+        struct s2n_connection *server_conn = NULL;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         server_conn->actual_protocol_version = S2N_TLS13;

--- a/tests/unit/s2n_tls13_server_finished_test.c
+++ b/tests/unit/s2n_tls13_server_finished_test.c
@@ -45,7 +45,7 @@ int main(int argc, char **argv)
         };
 
         for (int i = 0; i < 3; i++) {
-            struct s2n_connection *server_conn;
+            struct s2n_connection *server_conn = NULL;
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
 
             server_conn->actual_protocol_version = S2N_TLS13;
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_tls13_server_finished_send(server_conn));
             EXPECT_EQUAL(s2n_stuffer_data_available(&server_conn->handshake.io), hash_size);
 
-            struct s2n_connection *client_conn;
+            struct s2n_connection *client_conn = NULL;
             EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
             client_conn->actual_protocol_version = S2N_TLS13;
             client_conn->secure->cipher_suite = &cipher_suites[i];
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
 
     /* Test that they can only run in TLS 1.3 mode */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
         server_conn->secure->cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
 
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_tls13_server_finished_send(server_conn));
         EXPECT_EQUAL(s2n_stuffer_data_available(&server_conn->handshake.io), 48);
 
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
 
         client_conn->secure->cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
@@ -119,7 +119,7 @@ int main(int argc, char **argv)
 
     /* Test for failure cases if cipher suites are incompatible */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
 
         server_conn->actual_protocol_version = S2N_TLS13;
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_tls13_server_finished_send(server_conn));
         EXPECT_EQUAL(s2n_stuffer_data_available(&server_conn->handshake.io), 32);
 
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         client_conn->actual_protocol_version = S2N_TLS13;
         client_conn->secure->cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
 
     /* Test for failure cases when finished secret key differs */
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
 
         server_conn->actual_protocol_version = S2N_TLS13;
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_tls13_server_finished_send(server_conn));
         EXPECT_EQUAL(s2n_stuffer_data_available(&server_conn->handshake.io), 48);
 
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         client_conn->actual_protocol_version = S2N_TLS13;
         client_conn->secure->cipher_suite = &s2n_tls13_aes_256_gcm_sha384;

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -37,12 +37,12 @@ int main(int argc, char **argv)
     {
         /* Client does not support or configure TLS 1.3 */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             EXPECT_NOT_EQUAL(conn->client_protocol_version, S2N_TLS13);
 
-            const struct s2n_security_policy *security_policy;
+            const struct s2n_security_policy *security_policy = NULL;
             EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
             EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
 
@@ -51,12 +51,12 @@ int main(int argc, char **argv)
 
         /* Server does not support or configure TLS 1.3 */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
             EXPECT_NOT_EQUAL(conn->server_protocol_version, S2N_TLS13);
 
-            const struct s2n_security_policy *security_policy;
+            const struct s2n_security_policy *security_policy = NULL;
             EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
             EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
 
@@ -75,12 +75,12 @@ int main(int argc, char **argv)
     {
         /* Client supports and configures TLS 1.3 */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
             EXPECT_EQUAL(conn->client_protocol_version, S2N_TLS13);
 
-            const struct s2n_security_policy *security_policy;
+            const struct s2n_security_policy *security_policy = NULL;
             EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
             EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
 
@@ -89,12 +89,12 @@ int main(int argc, char **argv)
 
         /* Server supports and configures TLS 1.3 */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
             EXPECT_EQUAL(conn->server_protocol_version, S2N_TLS13);
 
-            const struct s2n_security_policy *security_policy;
+            const struct s2n_security_policy *security_policy = NULL;
             EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
             EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
 
@@ -148,7 +148,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(tls13_server_hello_extensions);
         EXPECT_TRUE(tls13_server_hello_extensions->count > 0);
 
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_allow_all_response_extensions(server_conn));
 
@@ -159,7 +159,7 @@ int main(int argc, char **argv)
         s2n_parsed_extensions_list parsed_extension_list = { 0 };
         for (size_t i = 0; i < tls13_server_hello_extensions->count; i++) {
             const s2n_extension_type *tls13_extension_type = tls13_server_hello_extensions->extension_types[i];
-            s2n_extension_type_id extension_id;
+            s2n_extension_type_id extension_id = 0;
             EXPECT_SUCCESS(s2n_extension_supported_iana_value_to_id(tls13_extension_type->iana_value, &extension_id));
             s2n_parsed_extension *parsed_extension = &parsed_extension_list.parsed_extensions[extension_id];
 

--- a/tests/unit/s2n_tls13_zero_length_payload_test.c
+++ b/tests/unit/s2n_tls13_zero_length_payload_test.c
@@ -51,12 +51,12 @@ int main(int argc, char **argv)
      *# TLSInnerPlaintext.content if the sender desires.
      **/
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         server_conn->actual_protocol_version = S2N_TLS13;
         EXPECT_OK(s2n_connection_set_secrets(server_conn));
 
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         client_conn->actual_protocol_version = S2N_TLS13;
         EXPECT_OK(s2n_connection_set_secrets(client_conn));
@@ -81,8 +81,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_flush(server_conn, &blocked));
         EXPECT_TRUE(s2n_stuffer_data_available(&server_to_client) > 0);
 
-        uint8_t record_type;
-        int isSSLv2;
+        uint8_t record_type = 0;
+        int isSSLv2 = 0;
 
         EXPECT_SUCCESS(s2n_read_full_record(server_conn, &record_type, &isSSLv2));
         EXPECT_EQUAL(record_type, TLS_APPLICATION_DATA);
@@ -103,11 +103,11 @@ int main(int argc, char **argv)
      *# implementation MUST terminate the connection with an "unexpected_message" alert.
      **/
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         server_conn->actual_protocol_version = S2N_TLS13;
 
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         client_conn->actual_protocol_version = S2N_TLS13;
 
@@ -142,11 +142,11 @@ int main(int argc, char **argv)
      *# implementation MUST terminate the connection with an "unexpected_message" alert.
      **/
     {
-        struct s2n_connection *server_conn;
+        struct s2n_connection *server_conn = NULL;
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         server_conn->actual_protocol_version = S2N_TLS13;
 
-        struct s2n_connection *client_conn;
+        struct s2n_connection *client_conn = NULL;
         EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
         client_conn->actual_protocol_version = S2N_TLS13;
 

--- a/tests/unit/s2n_tls_hybrid_prf_test.c
+++ b/tests/unit/s2n_tls_hybrid_prf_test.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
         POSIX_ENSURE_GT(fscanf(kat_file, "%u", &count), 0);
         POSIX_ENSURE_EQ(count, i);
 
-        struct s2n_connection *conn;
+        struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         conn->actual_protocol_version = S2N_TLS12;
         /* Really only need for the hash function in the PRF */
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
         POSIX_GUARD(FindMarker(kat_file, "premaster_kem_secret_length = "));
         POSIX_ENSURE_GT(fscanf(kat_file, "%u", &premaster_kem_secret_length), 0);
 
-        uint8_t *premaster_kem_secret;
+        uint8_t *premaster_kem_secret = NULL;
         POSIX_ENSURE_REF(premaster_kem_secret = malloc(premaster_kem_secret_length));
         POSIX_GUARD(ReadHex(kat_file, premaster_kem_secret, premaster_kem_secret_length, "premaster_kem_secret = "));
 
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
         POSIX_GUARD(FindMarker(kat_file, "client_key_exchange_message_length = "));
         POSIX_ENSURE_GT(fscanf(kat_file, "%u", &client_key_exchange_message_length), 0);
 
-        uint8_t *client_key_exchange_message;
+        uint8_t *client_key_exchange_message = NULL;
         POSIX_ENSURE_REF(client_key_exchange_message = malloc(client_key_exchange_message_length));
         POSIX_GUARD(ReadHex(kat_file, client_key_exchange_message, client_key_exchange_message_length, "client_key_exchange_message = "));
 

--- a/tests/unit/s2n_x509_validator_certificate_signatures_test.c
+++ b/tests/unit/s2n_x509_validator_certificate_signatures_test.c
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
     {
         /* Connection using a security policy with no certificate_signature_preferences allows SHA-1 signatures in certificates */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             struct s2n_config *config = s2n_config_new();
 
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
@@ -89,7 +89,7 @@ int main(int argc, char **argv)
 
         /* Connection using the default_tls13 security policy does not validate SHA-1 signatures in certificates */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             struct s2n_config *config = s2n_config_new();
 
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
 
         /* Connection using the default_tls13 security policy ignores a SHA-1 signature on a root certificate */
         {
-            struct s2n_connection *conn;
+            struct s2n_connection *conn = NULL;
             struct s2n_config *config = s2n_config_new();
 
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));

--- a/tls/extensions/s2n_cert_status.c
+++ b/tls/extensions/s2n_cert_status.c
@@ -77,7 +77,7 @@ int s2n_cert_status_recv(struct s2n_connection *conn, struct s2n_stuffer *in)
      *# (using the ASN.1 type OCSPResponse defined in [RFC2560]).  Only one
      *# OCSP response may be sent.
      **/
-    uint8_t type;
+    uint8_t type = 0;
     POSIX_GUARD(s2n_stuffer_read_uint8(in, &type));
     if (type != S2N_STATUS_REQUEST_OCSP) {
         /* We only support OCSP */
@@ -92,7 +92,7 @@ int s2n_cert_status_recv(struct s2n_connection *conn, struct s2n_stuffer *in)
         conn->status_type = S2N_STATUS_REQUEST_OCSP;
     }
 
-    uint32_t status_size;
+    uint32_t status_size = 0;
     POSIX_GUARD(s2n_stuffer_read_uint24(in, &status_size));
     POSIX_ENSURE_LTE(status_size, s2n_stuffer_data_available(in));
 

--- a/tls/extensions/s2n_client_alpn.c
+++ b/tls/extensions/s2n_client_alpn.c
@@ -39,7 +39,7 @@ const s2n_extension_type s2n_client_alpn_extension = {
 
 bool s2n_client_alpn_should_send(struct s2n_connection *conn)
 {
-    struct s2n_blob *client_app_protocols;
+    struct s2n_blob *client_app_protocols = NULL;
 
     return s2n_connection_get_protocol_preferences(conn, &client_app_protocols) == S2N_SUCCESS
             && client_app_protocols->size != 0 && client_app_protocols->data != NULL;
@@ -47,7 +47,7 @@ bool s2n_client_alpn_should_send(struct s2n_connection *conn)
 
 static int s2n_client_alpn_send(struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    struct s2n_blob *client_app_protocols;
+    struct s2n_blob *client_app_protocols = NULL;
     POSIX_GUARD(s2n_connection_get_protocol_preferences(conn, &client_app_protocols));
     POSIX_ENSURE_REF(client_app_protocols);
 

--- a/tls/extensions/s2n_client_cert_status_request.c
+++ b/tls/extensions/s2n_client_cert_status_request.c
@@ -67,7 +67,7 @@ static int s2n_client_cert_status_request_recv(struct s2n_connection *conn, stru
         return S2N_SUCCESS;
     }
 
-    uint8_t type;
+    uint8_t type = 0;
     POSIX_GUARD(s2n_stuffer_read_uint8(extension, &type));
     if (type != (uint8_t) S2N_STATUS_REQUEST_OCSP) {
         /* We only support OCSP (type 1), ignore the extension */

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -410,7 +410,7 @@ static int s2n_client_key_share_recv(struct s2n_connection *conn, struct s2n_stu
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(extension);
 
-    uint16_t key_shares_size;
+    uint16_t key_shares_size = 0;
     POSIX_GUARD(s2n_stuffer_read_uint16(extension, &key_shares_size));
     POSIX_ENSURE(s2n_stuffer_data_available(extension) == key_shares_size, S2N_ERR_BAD_MESSAGE);
 

--- a/tls/extensions/s2n_client_max_frag_len.c
+++ b/tls/extensions/s2n_client_max_frag_len.c
@@ -51,7 +51,7 @@ static int s2n_client_max_frag_len_recv(struct s2n_connection *conn, struct s2n_
         return S2N_SUCCESS;
     }
 
-    uint8_t mfl_code;
+    uint8_t mfl_code = 0;
     POSIX_GUARD(s2n_stuffer_read_uint8(extension, &mfl_code));
 
     /*

--- a/tls/extensions/s2n_client_pq_kem.c
+++ b/tls/extensions/s2n_client_pq_kem.c
@@ -40,7 +40,7 @@ const s2n_extension_type s2n_client_pq_kem_extension = {
 
 static bool s2n_client_pq_kem_should_send(struct s2n_connection *conn)
 {
-    const struct s2n_security_policy *security_policy;
+    const struct s2n_security_policy *security_policy = NULL;
     return s2n_connection_get_security_policy(conn, &security_policy) == S2N_SUCCESS
             && s2n_pq_kem_is_extension_required(security_policy)
             && s2n_pq_is_enabled();
@@ -62,7 +62,7 @@ static int s2n_client_pq_kem_send(struct s2n_connection *conn, struct s2n_stuffe
 
 static int s2n_client_pq_kem_recv(struct s2n_connection *conn, struct s2n_stuffer *extension)
 {
-    uint16_t size_of_all;
+    uint16_t size_of_all = 0;
     struct s2n_blob *proposed_kems = &conn->kex_params.client_pq_kem_extension;
 
     /* Ignore extension if PQ is disabled */

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -288,7 +288,7 @@ static S2N_RESULT s2n_client_psk_recv_binder_list(struct s2n_connection *conn, s
         uint8_t wire_binder_size = 0;
         RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(wire_binders_in, &wire_binder_size));
 
-        uint8_t *wire_binder_data;
+        uint8_t *wire_binder_data = NULL;
         RESULT_ENSURE_REF(wire_binder_data = s2n_stuffer_raw_read(wire_binders_in, wire_binder_size));
 
         struct s2n_blob wire_binder = { 0 };
@@ -311,7 +311,7 @@ static S2N_RESULT s2n_client_psk_recv_identities(struct s2n_connection *conn, st
     uint16_t identity_list_size = 0;
     RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(extension, &identity_list_size));
 
-    uint8_t *identity_list_data;
+    uint8_t *identity_list_data = NULL;
     RESULT_ENSURE_REF(identity_list_data = s2n_stuffer_raw_read(extension, identity_list_size));
 
     struct s2n_blob identity_list_blob = { 0 };
@@ -331,7 +331,7 @@ static S2N_RESULT s2n_client_psk_recv_binders(struct s2n_connection *conn, struc
     uint16_t binder_list_size = 0;
     RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(extension, &binder_list_size));
 
-    uint8_t *binder_list_data;
+    uint8_t *binder_list_data = NULL;
     RESULT_ENSURE_REF(binder_list_data = s2n_stuffer_raw_read(extension, binder_list_size));
 
     struct s2n_blob binder_list_blob = { 0 };
@@ -364,7 +364,7 @@ int s2n_client_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extensi
      *# Servers MUST check that it is the last extension and otherwise fail
      *# the handshake with an "illegal_parameter" alert.
      */
-    s2n_extension_type_id psk_ext_id;
+    s2n_extension_type_id psk_ext_id = 0;
     POSIX_GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_PRE_SHARED_KEY, &psk_ext_id));
     POSIX_ENSURE_NE(conn->client_hello.extensions.count, 0);
     uint16_t last_wire_index = conn->client_hello.extensions.count - 1;
@@ -379,12 +379,12 @@ int s2n_client_psk_recv(struct s2n_connection *conn, struct s2n_stuffer *extensi
      * We can safely do this check here because s2n_client_psk is
      * required to be the last extension sent in the list.
      */
-    s2n_extension_type_id psk_ke_mode_ext_id;
+    s2n_extension_type_id psk_ke_mode_ext_id = 0;
     POSIX_GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_PSK_KEY_EXCHANGE_MODES, &psk_ke_mode_ext_id));
     POSIX_ENSURE(S2N_CBIT_TEST(conn->extension_requests_received, psk_ke_mode_ext_id), S2N_ERR_MISSING_EXTENSION);
 
     if (conn->psk_params.psk_ke_mode == S2N_PSK_DHE_KE) {
-        s2n_extension_type_id key_share_ext_id;
+        s2n_extension_type_id key_share_ext_id = 0;
         POSIX_GUARD(s2n_extension_supported_iana_value_to_id(TLS_EXTENSION_KEY_SHARE, &key_share_ext_id));
         /* A key_share extension must have been received in order to use a pre-shared key
          * in (EC)DHE key exchange mode.

--- a/tls/extensions/s2n_client_supported_groups.c
+++ b/tls/extensions/s2n_client_supported_groups.c
@@ -40,7 +40,7 @@ const s2n_extension_type s2n_client_supported_groups_extension = {
 
 bool s2n_extension_should_send_if_ecc_enabled(struct s2n_connection *conn)
 {
-    const struct s2n_security_policy *security_policy;
+    const struct s2n_security_policy *security_policy = NULL;
     return s2n_connection_get_security_policy(conn, &security_policy) == S2N_SUCCESS
             && s2n_ecc_is_extension_required(security_policy);
 }

--- a/tls/extensions/s2n_client_supported_versions.c
+++ b/tls/extensions/s2n_client_supported_versions.c
@@ -81,7 +81,7 @@ int s2n_extensions_client_supported_versions_process(struct s2n_connection *conn
     uint8_t minimum_supported_version = s2n_unknown_protocol_version;
     POSIX_GUARD_RESULT(s2n_connection_get_minimum_supported_version(conn, &minimum_supported_version));
 
-    uint8_t size_of_version_list;
+    uint8_t size_of_version_list = 0;
     POSIX_GUARD(s2n_stuffer_read_uint8(extension, &size_of_version_list));
     S2N_ERROR_IF(size_of_version_list != s2n_stuffer_data_available(extension), S2N_ERR_BAD_MESSAGE);
     S2N_ERROR_IF(size_of_version_list % S2N_TLS_PROTOCOL_VERSION_LEN != 0, S2N_ERR_BAD_MESSAGE);

--- a/tls/extensions/s2n_extension_list.c
+++ b/tls/extensions/s2n_extension_list.c
@@ -25,7 +25,7 @@
 
 int s2n_extension_list_send(s2n_extension_list_id list_type, struct s2n_connection *conn, struct s2n_stuffer *out)
 {
-    s2n_extension_type_list *extension_type_list;
+    s2n_extension_type_list *extension_type_list = NULL;
     POSIX_GUARD(s2n_extension_type_list_get(list_type, &extension_type_list));
 
     struct s2n_stuffer_reservation total_extensions_size = { 0 };
@@ -80,7 +80,7 @@ int s2n_extension_process(const s2n_extension_type *extension_type, struct s2n_c
     POSIX_ENSURE_REF(parsed_extension_list);
     POSIX_ENSURE_REF(extension_type);
 
-    s2n_extension_type_id extension_id;
+    s2n_extension_type_id extension_id = 0;
     POSIX_GUARD(s2n_extension_supported_iana_value_to_id(extension_type->iana_value, &extension_id));
 
     s2n_parsed_extension *parsed_extension = &parsed_extension_list->parsed_extensions[extension_id];
@@ -94,7 +94,7 @@ int s2n_extension_list_process(s2n_extension_list_id list_type, struct s2n_conne
 {
     POSIX_ENSURE_REF(parsed_extension_list);
 
-    s2n_extension_type_list *extension_type_list;
+    s2n_extension_type_list *extension_type_list = NULL;
     POSIX_GUARD(s2n_extension_type_list_get(list_type, &extension_type_list));
 
     for (int i = 0; i < extension_type_list->count; i++) {
@@ -123,18 +123,18 @@ static int s2n_extension_parse(struct s2n_stuffer *in, s2n_parsed_extension *par
     POSIX_ENSURE_REF(parsed_extensions);
     POSIX_ENSURE_REF(wire_index);
 
-    uint16_t extension_type;
+    uint16_t extension_type = 0;
     POSIX_ENSURE(s2n_stuffer_read_uint16(in, &extension_type) == S2N_SUCCESS,
             S2N_ERR_BAD_MESSAGE);
 
-    uint16_t extension_size;
+    uint16_t extension_size = 0;
     POSIX_ENSURE(s2n_stuffer_read_uint16(in, &extension_size) == S2N_SUCCESS,
             S2N_ERR_BAD_MESSAGE);
 
     uint8_t *extension_data = s2n_stuffer_raw_read(in, extension_size);
     POSIX_ENSURE(extension_data != NULL, S2N_ERR_BAD_MESSAGE);
 
-    s2n_extension_type_id extension_id;
+    s2n_extension_type_id extension_id = 0;
     if (s2n_extension_supported_iana_value_to_id(extension_type, &extension_id) != S2N_SUCCESS) {
         /* Ignore unknown extensions */
         return S2N_SUCCESS;
@@ -163,7 +163,7 @@ int s2n_extension_list_parse(struct s2n_stuffer *in, s2n_parsed_extensions_list 
     POSIX_CHECKED_MEMSET((s2n_parsed_extension *) parsed_extension_list->parsed_extensions,
             0, sizeof(parsed_extension_list->parsed_extensions));
 
-    uint16_t total_extensions_size;
+    uint16_t total_extensions_size = 0;
     if (s2n_stuffer_read_uint16(in, &total_extensions_size) != S2N_SUCCESS) {
         total_extensions_size = 0;
     }

--- a/tls/extensions/s2n_extension_type.c
+++ b/tls/extensions/s2n_extension_type.c
@@ -86,7 +86,7 @@ int s2n_extension_send(const s2n_extension_type *extension_type, struct s2n_conn
     POSIX_ENSURE_REF(extension_type->send);
     POSIX_ENSURE_REF(conn);
 
-    s2n_extension_type_id extension_id;
+    s2n_extension_type_id extension_id = 0;
     POSIX_GUARD(s2n_extension_supported_iana_value_to_id(extension_type->iana_value, &extension_id));
 
     /* Do not send response if request not received. */
@@ -131,7 +131,7 @@ int s2n_extension_recv(const s2n_extension_type *extension_type, struct s2n_conn
     POSIX_ENSURE_REF(extension_type->recv);
     POSIX_ENSURE_REF(conn);
 
-    s2n_extension_type_id extension_id;
+    s2n_extension_type_id extension_id = 0;
     POSIX_GUARD(s2n_extension_supported_iana_value_to_id(extension_type->iana_value, &extension_id));
 
     /**
@@ -180,7 +180,7 @@ int s2n_extension_is_missing(const s2n_extension_type *extension_type, struct s2
     POSIX_ENSURE_REF(extension_type->if_missing);
     POSIX_ENSURE_REF(conn);
 
-    s2n_extension_type_id extension_id;
+    s2n_extension_type_id extension_id = 0;
     POSIX_GUARD(s2n_extension_supported_iana_value_to_id(extension_type->iana_value, &extension_id));
 
     /* Do not consider an extension missing if we did not send a request */

--- a/tls/extensions/s2n_psk_key_exchange_modes.c
+++ b/tls/extensions/s2n_psk_key_exchange_modes.c
@@ -70,7 +70,7 @@ static int s2n_psk_key_exchange_modes_recv(struct s2n_connection *conn, struct s
 {
     POSIX_ENSURE_REF(conn);
 
-    uint8_t psk_ke_mode_list_len;
+    uint8_t psk_ke_mode_list_len = 0;
     POSIX_GUARD(s2n_stuffer_read_uint8(extension, &psk_ke_mode_list_len));
     if (psk_ke_mode_list_len > s2n_stuffer_data_available(extension)) {
         /* Malformed length, ignore the extension */
@@ -78,7 +78,7 @@ static int s2n_psk_key_exchange_modes_recv(struct s2n_connection *conn, struct s
     }
 
     for (size_t i = 0; i < psk_ke_mode_list_len; i++) {
-        uint8_t wire_psk_ke_mode;
+        uint8_t wire_psk_ke_mode = 0;
         POSIX_GUARD(s2n_stuffer_read_uint8(extension, &wire_psk_ke_mode));
 
         /* s2n currently only supports pre-shared keys with (EC)DHE key establishment */

--- a/tls/extensions/s2n_server_alpn.c
+++ b/tls/extensions/s2n_server_alpn.c
@@ -57,14 +57,14 @@ static int s2n_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer *extens
 {
     POSIX_ENSURE_REF(conn);
 
-    uint16_t size_of_all;
+    uint16_t size_of_all = 0;
     POSIX_GUARD(s2n_stuffer_read_uint16(extension, &size_of_all));
     if (size_of_all > s2n_stuffer_data_available(extension) || size_of_all < 3) {
         /* ignore invalid extension size */
         return S2N_SUCCESS;
     }
 
-    uint8_t protocol_len;
+    uint8_t protocol_len = 0;
     POSIX_GUARD(s2n_stuffer_read_uint8(extension, &protocol_len));
     POSIX_ENSURE_LT(protocol_len, s2n_array_len(conn->application_protocol));
 

--- a/tls/extensions/s2n_server_key_share.c
+++ b/tls/extensions/s2n_server_key_share.c
@@ -135,7 +135,7 @@ static int s2n_server_key_share_send(struct s2n_connection *conn, struct s2n_stu
     /* Retry requests only require the selected named group, not an actual share.
      * https://tools.ietf.org/html/rfc8446#section-4.2.8 */
     if (s2n_is_hello_retry_message(conn)) {
-        uint16_t named_group_id;
+        uint16_t named_group_id = 0;
         if (curve != NULL) {
             named_group_id = curve->iana_id;
         } else {
@@ -291,7 +291,7 @@ static int s2n_server_key_share_recv_ecc(struct s2n_connection *conn, uint16_t n
     POSIX_ENSURE(client_ecc_evp_params->negotiated_curve == server_ecc_evp_params->negotiated_curve, S2N_ERR_BAD_KEY_SHARE);
     POSIX_ENSURE(client_ecc_evp_params->evp_pkey, S2N_ERR_BAD_KEY_SHARE);
 
-    uint16_t share_size;
+    uint16_t share_size = 0;
     S2N_ERROR_IF(s2n_stuffer_data_available(extension) < sizeof(share_size), S2N_ERR_BAD_KEY_SHARE);
     POSIX_GUARD(s2n_stuffer_read_uint16(extension, &share_size));
     S2N_ERROR_IF(s2n_stuffer_data_available(extension) < share_size, S2N_ERR_BAD_KEY_SHARE);

--- a/tls/extensions/s2n_server_max_fragment_length.c
+++ b/tls/extensions/s2n_server_max_fragment_length.c
@@ -54,7 +54,7 @@ static int s2n_max_fragment_length_recv(struct s2n_connection *conn, struct s2n_
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(conn->config);
 
-    uint8_t mfl_code;
+    uint8_t mfl_code = 0;
     POSIX_GUARD(s2n_stuffer_read_uint8(extension, &mfl_code));
 
     /*

--- a/tls/s2n_change_cipher_spec.c
+++ b/tls/s2n_change_cipher_spec.c
@@ -27,7 +27,7 @@
 
 int s2n_basic_ccs_recv(struct s2n_connection *conn)
 {
-    uint8_t type;
+    uint8_t type = 0;
 
     POSIX_GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, &type));
     S2N_ERROR_IF(type != CHANGE_CIPHER_SPEC_TYPE, S2N_ERR_BAD_MESSAGE);

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1089,7 +1089,7 @@ int s2n_set_cipher_as_client(struct s2n_connection *conn, uint8_t wire[S2N_TLS_C
     POSIX_ENSURE_REF(conn->secure);
     POSIX_ENSURE_REF(conn->secure->cipher_suite);
 
-    const struct s2n_security_policy *security_policy;
+    const struct s2n_security_policy *security_policy = NULL;
     POSIX_GUARD(s2n_connection_get_security_policy(conn, &security_policy));
     POSIX_ENSURE_REF(security_policy);
 
@@ -1232,7 +1232,7 @@ static int s2n_set_cipher_as_server(struct s2n_connection *conn, uint8_t *wire, 
         conn->secure_renegotiation = 1;
     }
 
-    const struct s2n_security_policy *security_policy;
+    const struct s2n_security_policy *security_policy = NULL;
     POSIX_GUARD(s2n_connection_get_security_policy(conn, &security_policy));
 
     const struct s2n_cipher_preferences *cipher_preferences = security_policy->cipher_preferences;

--- a/tls/s2n_client_cert.c
+++ b/tls/s2n_client_cert.c
@@ -102,7 +102,7 @@ static S2N_RESULT s2n_client_cert_chain_store(struct s2n_connection *conn,
 int s2n_client_cert_recv(struct s2n_connection *conn)
 {
     if (conn->actual_protocol_version == S2N_TLS13) {
-        uint8_t certificate_request_context_len;
+        uint8_t certificate_request_context_len = 0;
         POSIX_GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, &certificate_request_context_len));
         S2N_ERROR_IF(certificate_request_context_len != 0, S2N_ERR_BAD_MESSAGE);
     }

--- a/tls/s2n_client_cert_verify.c
+++ b/tls/s2n_client_cert_verify.c
@@ -37,7 +37,7 @@ int s2n_client_cert_verify_recv(struct s2n_connection *conn)
     const struct s2n_signature_scheme *chosen_sig_scheme = conn->handshake_params.client_cert_sig_scheme;
     POSIX_ENSURE_REF(chosen_sig_scheme);
 
-    uint16_t signature_size;
+    uint16_t signature_size = 0;
     struct s2n_blob signature = { 0 };
     POSIX_GUARD(s2n_stuffer_read_uint16(in, &signature_size));
     signature.size = signature_size;

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -557,7 +557,7 @@ int s2n_process_client_hello(struct s2n_connection *conn)
      * Negotiate protocol version, cipher suite, ALPN, select a cert, etc. */
     struct s2n_client_hello *client_hello = &conn->client_hello;
 
-    const struct s2n_security_policy *security_policy;
+    const struct s2n_security_policy *security_policy = NULL;
     POSIX_GUARD(s2n_connection_get_security_policy(conn, &security_policy));
 
     if (!s2n_connection_supports_tls13(conn) || !s2n_security_policy_supports_tls13(security_policy)) {
@@ -701,7 +701,7 @@ int s2n_client_hello_send(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
 
-    const struct s2n_security_policy *security_policy;
+    const struct s2n_security_policy *security_policy = NULL;
     POSIX_GUARD(s2n_connection_get_security_policy(conn, &security_policy));
 
     const struct s2n_cipher_preferences *cipher_preferences = security_policy->cipher_preferences;
@@ -821,7 +821,7 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
     POSIX_GUARD(s2n_stuffer_skip_write(&in_stuffer, client_hello->raw_message.size));
     struct s2n_stuffer *in = &in_stuffer;
 
-    const struct s2n_security_policy *security_policy;
+    const struct s2n_security_policy *security_policy = NULL;
     POSIX_GUARD(s2n_connection_get_security_policy(conn, &security_policy));
 
     if (conn->client_protocol_version < security_policy->minimum_protocol_version) {
@@ -831,15 +831,15 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
     conn->actual_protocol_version = MIN(conn->client_protocol_version, conn->server_protocol_version);
 
     /* We start 5 bytes into the record */
-    uint16_t cipher_suites_length;
+    uint16_t cipher_suites_length = 0;
     POSIX_GUARD(s2n_stuffer_read_uint16(in, &cipher_suites_length));
     POSIX_ENSURE(cipher_suites_length > 0, S2N_ERR_BAD_MESSAGE);
     POSIX_ENSURE(cipher_suites_length % S2N_SSLv2_CIPHER_SUITE_LEN == 0, S2N_ERR_BAD_MESSAGE);
 
-    uint16_t session_id_length;
+    uint16_t session_id_length = 0;
     POSIX_GUARD(s2n_stuffer_read_uint16(in, &session_id_length));
 
-    uint16_t challenge_length;
+    uint16_t challenge_length = 0;
     POSIX_GUARD(s2n_stuffer_read_uint16(in, &challenge_length));
 
     S2N_ERROR_IF(challenge_length > S2N_TLS_RANDOM_DATA_LEN, S2N_ERR_BAD_MESSAGE);
@@ -879,7 +879,7 @@ int s2n_client_hello_get_parsed_extension(s2n_tls_extension_type extension_type,
     POSIX_ENSURE_REF(parsed_extension_list);
     POSIX_ENSURE_REF(parsed_extension);
 
-    s2n_extension_type_id extension_type_id;
+    s2n_extension_type_id extension_type_id = 0;
     POSIX_GUARD(s2n_extension_supported_iana_value_to_id(extension_type, &extension_type_id));
 
     s2n_parsed_extension *found_parsed_extension = &parsed_extension_list->parsed_extensions[extension_type_id];

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -111,7 +111,7 @@ int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared
 
     struct s2n_stuffer *in = &conn->handshake.io;
     uint8_t client_hello_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
-    uint16_t length;
+    uint16_t length = 0;
 
     if (conn->actual_protocol_version == S2N_SSLv3) {
         length = s2n_stuffer_data_available(in);

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -288,7 +288,7 @@ int s2n_config_load_system_certs(struct s2n_config *config)
 struct s2n_config *s2n_config_new_minimal(void)
 {
     struct s2n_blob allocator = { 0 };
-    struct s2n_config *new_config;
+    struct s2n_config *new_config = NULL;
 
     PTR_GUARD_POSIX(s2n_alloc(&allocator, sizeof(struct s2n_config)));
     PTR_GUARD_POSIX(s2n_blob_zero(&allocator));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -773,7 +773,7 @@ int s2n_connection_set_client_auth_type(struct s2n_connection *conn, s2n_cert_au
 int s2n_connection_set_read_fd(struct s2n_connection *conn, int rfd)
 {
     struct s2n_blob ctx_mem = { 0 };
-    struct s2n_socket_read_io_context *peer_socket_ctx;
+    struct s2n_socket_read_io_context *peer_socket_ctx = NULL;
 
     POSIX_ENSURE_REF(conn);
     POSIX_GUARD(s2n_alloc(&ctx_mem, sizeof(struct s2n_socket_read_io_context)));
@@ -808,7 +808,7 @@ int s2n_connection_get_read_fd(struct s2n_connection *conn, int *readfd)
 int s2n_connection_set_write_fd(struct s2n_connection *conn, int wfd)
 {
     struct s2n_blob ctx_mem = { 0 };
-    struct s2n_socket_write_io_context *peer_socket_ctx;
+    struct s2n_socket_write_io_context *peer_socket_ctx = NULL;
 
     POSIX_ENSURE_REF(conn);
     POSIX_GUARD(s2n_alloc(&ctx_mem, sizeof(struct s2n_socket_write_io_context)));
@@ -825,7 +825,7 @@ int s2n_connection_set_write_fd(struct s2n_connection *conn, int wfd)
      */
     POSIX_GUARD(s2n_socket_write_snapshot(conn));
 
-    uint8_t ipv6;
+    uint8_t ipv6 = 0;
     if (0 == s2n_socket_is_ipv6(wfd, &ipv6)) {
         conn->ipv6 = (ipv6 ? 1 : 0);
     }

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1397,8 +1397,8 @@ static S2N_RESULT s2n_handshake_app_data_recv(struct s2n_connection *conn)
  */
 static int s2n_handshake_read_io(struct s2n_connection *conn)
 {
-    uint8_t record_type;
-    uint8_t message_type;
+    uint8_t record_type = 0;
+    uint8_t message_type = 0;
     int isSSLv2 = 0;
 
     /* Fill conn->in stuffer necessary for the handshake.
@@ -1487,7 +1487,7 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
     while (s2n_stuffer_data_available(&conn->in)) {
         /* We're done with negotiating but we have trailing data in this record. Bail on the handshake. */
         S2N_ERROR_IF(EXPECTED_RECORD_TYPE(conn) == TLS_APPLICATION_DATA, S2N_ERR_BAD_MESSAGE);
-        int r;
+        int r = 0;
         POSIX_GUARD((r = s2n_read_full_handshake_message(conn, &message_type)));
 
         /* Do we need more data? This happens for message fragmentation */

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -242,7 +242,7 @@ int s2n_choose_kem_with_peer_pref_list(const uint8_t iana_value[S2N_TLS_CIPHER_S
         }
 
         for (uint8_t j = 0; j < num_client_candidate_kems; j++) {
-            kem_extension_size candidate_client_kem_id;
+            kem_extension_size candidate_client_kem_id = 0;
             POSIX_GUARD(s2n_stuffer_read_uint16(&client_kem_ids_stuffer, &candidate_client_kem_id));
 
             if (candidate_server_kem->kem_extension_id == candidate_client_kem_id) {

--- a/tls/s2n_key_update.c
+++ b/tls/s2n_key_update.c
@@ -43,7 +43,7 @@ int s2n_key_update_recv(struct s2n_connection *conn, struct s2n_stuffer *request
     POSIX_ENSURE(!s2n_connection_is_quic_enabled(conn), S2N_ERR_BAD_MESSAGE);
     POSIX_ENSURE(!conn->ktls_recv_enabled, S2N_ERR_KTLS_KEYUPDATE);
 
-    uint8_t key_update_request;
+    uint8_t key_update_request = 0;
     POSIX_GUARD(s2n_stuffer_read_uint8(request, &key_update_request));
     if (key_update_request == S2N_KEY_UPDATE_REQUESTED) {
         POSIX_ENSURE(!conn->ktls_send_enabled, S2N_ERR_KTLS_KEYUPDATE);

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -412,7 +412,7 @@ const struct s2n_p_hash_hmac *s2n_get_hmac_implementation()
 static int s2n_p_hash(struct s2n_prf_working_space *ws, s2n_hmac_algorithm alg, struct s2n_blob *secret, struct s2n_blob *label,
         struct s2n_blob *seed_a, struct s2n_blob *seed_b, struct s2n_blob *seed_c, struct s2n_blob *out)
 {
-    uint8_t digest_size;
+    uint8_t digest_size = 0;
     POSIX_GUARD(s2n_hmac_digest_size(alg, &digest_size));
 
     const struct s2n_p_hash_hmac *hmac = s2n_get_hmac_implementation();

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -136,7 +136,7 @@ S2N_RESULT s2n_quic_read_handshake_message(struct s2n_connection *conn, uint8_t 
 
     RESULT_GUARD(s2n_read_in_bytes(conn, &conn->handshake.io, TLS_HANDSHAKE_HEADER_LENGTH));
 
-    uint32_t message_len;
+    uint32_t message_len = 0;
     RESULT_GUARD(s2n_handshake_parse_header(&conn->handshake.io, message_type, &message_len));
     RESULT_GUARD_POSIX(s2n_stuffer_reread(&conn->handshake.io));
 

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -165,8 +165,8 @@ static bool s2n_is_tls13_plaintext_content(struct s2n_connection *conn, uint8_t 
 
 int s2n_record_parse(struct s2n_connection *conn)
 {
-    uint8_t content_type;
-    uint16_t encrypted_length;
+    uint8_t content_type = 0;
+    uint16_t encrypted_length = 0;
     POSIX_GUARD(s2n_record_header_parse(conn, &content_type, &encrypted_length));
 
     struct s2n_crypto_parameters *current_client_crypto = conn->client;

--- a/tls/s2n_record_read_cbc.c
+++ b/tls/s2n_record_read_cbc.c
@@ -56,7 +56,7 @@ int s2n_record_parse_cbc(
     POSIX_ENSURE_REF(en.data);
 
     uint16_t payload_length = encrypted_length;
-    uint8_t mac_digest_size;
+    uint8_t mac_digest_size = 0;
     POSIX_GUARD(s2n_hmac_digest_size(mac->alg, &mac_digest_size));
 
     POSIX_ENSURE_GTE(payload_length, mac_digest_size);

--- a/tls/s2n_record_read_composite.c
+++ b/tls/s2n_record_read_composite.c
@@ -47,7 +47,7 @@ int s2n_record_parse_composite(
     POSIX_ENSURE_REF(en.data);
 
     uint16_t payload_length = encrypted_length;
-    uint8_t mac_digest_size;
+    uint8_t mac_digest_size = 0;
     POSIX_GUARD(s2n_hmac_digest_size(mac->alg, &mac_digest_size));
 
     POSIX_ENSURE_GTE(payload_length, mac_digest_size);

--- a/tls/s2n_record_read_stream.c
+++ b/tls/s2n_record_read_stream.c
@@ -43,7 +43,7 @@ int s2n_record_parse_stream(
     POSIX_ENSURE_REF(en.data);
 
     uint16_t payload_length = encrypted_length;
-    uint8_t mac_digest_size;
+    uint8_t mac_digest_size = 0;
     POSIX_GUARD(s2n_hmac_digest_size(mac->alg, &mac_digest_size));
 
     POSIX_ENSURE_GTE(payload_length, mac_digest_size);

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -43,7 +43,7 @@ static S2N_RESULT s2n_tls_record_overhead(struct s2n_connection *conn, uint16_t 
         active = conn->client;
     }
 
-    uint8_t extra;
+    uint8_t extra = 0;
     RESULT_GUARD_POSIX(s2n_hmac_digest_size(active->cipher_suite->record_alg->hmac_alg, &extra));
 
     if (active->cipher_suite->record_alg->cipher->type == S2N_CBC) {
@@ -294,7 +294,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
         POSIX_ENSURE(s2n_stuffer_data_available(&conn->out) == 0, S2N_ERR_RECORD_STUFFER_NEEDS_DRAINING);
     }
 
-    uint8_t mac_digest_size;
+    uint8_t mac_digest_size = 0;
     POSIX_GUARD(s2n_hmac_digest_size(mac->alg, &mac_digest_size));
 
     /* Before we do anything, we need to figure out what the length of the
@@ -379,7 +379,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
         }
 
         /* Outputs number of extra bytes required for MAC and padding */
-        int pad_and_mac_len;
+        int pad_and_mac_len = 0;
         POSIX_GUARD(cipher_suite->record_alg->cipher->io.comp.initial_hmac(session_key, sequence_number, content_type, conn->actual_protocol_version,
                 payload_and_eiv_len, &pad_and_mac_len));
         extra += pad_and_mac_len;

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -73,7 +73,7 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t *record_type, int 
     POSIX_GUARD(s2n_stuffer_reread(&conn->header_in));
     POSIX_GUARD_RESULT(s2n_read_in_bytes(conn, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
 
-    uint16_t fragment_length;
+    uint16_t fragment_length = 0;
 
     /* If the first bit is set then this is an SSLv2 record */
     if (conn->header_in.blob.data[0] & S2N_TLS_SSLV2_HEADER_FLAG) {
@@ -150,7 +150,7 @@ ssize_t s2n_recv_impl(struct s2n_connection *conn, void *buf, ssize_t size_signe
 
     while (size && s2n_connection_check_io_status(conn, S2N_IO_READABLE)) {
         int isSSLv2 = 0;
-        uint8_t record_type;
+        uint8_t record_type = 0;
         int r = s2n_read_full_record(conn, &record_type, &isSSLv2);
         if (r < 0) {
             /* Don't propagate the error if we already read some bytes. */

--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -138,7 +138,7 @@ S2N_RESULT s2n_sendv_with_offset_total_size(const struct iovec *bufs, ssize_t co
 ssize_t s2n_sendv_with_offset_impl(struct s2n_connection *conn, const struct iovec *bufs,
         ssize_t count, ssize_t offs, s2n_blocked_status *blocked)
 {
-    ssize_t user_data_sent, total_size = 0;
+    ssize_t user_data_sent = 0, total_size = 0;
 
     POSIX_ENSURE(s2n_connection_check_io_status(conn, S2N_IO_WRITABLE), S2N_ERR_CLOSED);
     POSIX_ENSURE(!s2n_connection_is_quic_enabled(conn), S2N_ERR_UNSUPPORTED_WITH_QUIC);
@@ -175,7 +175,7 @@ ssize_t s2n_sendv_with_offset_impl(struct s2n_connection *conn, const struct iov
     POSIX_GUARD_RESULT(s2n_early_data_validate_send(conn, total_size));
 
     if (conn->dynamic_record_timeout_threshold > 0) {
-        uint64_t elapsed;
+        uint64_t elapsed = 0;
         POSIX_GUARD_RESULT(s2n_timer_elapsed(conn->config, &conn->write_timer, &elapsed));
         /* Reset record size back to a single segment after threshold seconds of inactivity */
         if (elapsed - conn->last_write_elapsed > (uint64_t) conn->dynamic_record_timeout_threshold * 1000000000) {

--- a/tls/s2n_server_cert.c
+++ b/tls/s2n_server_cert.c
@@ -23,12 +23,12 @@
 int s2n_server_cert_recv(struct s2n_connection *conn)
 {
     if (conn->actual_protocol_version == S2N_TLS13) {
-        uint8_t certificate_request_context_len;
+        uint8_t certificate_request_context_len = 0;
         POSIX_GUARD(s2n_stuffer_read_uint8(&conn->handshake.io, &certificate_request_context_len));
         S2N_ERROR_IF(certificate_request_context_len != 0, S2N_ERR_BAD_MESSAGE);
     }
 
-    uint32_t size_of_all_certificates;
+    uint32_t size_of_all_certificates = 0;
     POSIX_GUARD(s2n_stuffer_read_uint24(&conn->handshake.io, &size_of_all_certificates));
 
     S2N_ERROR_IF(size_of_all_certificates > s2n_stuffer_data_available(&conn->handshake.io) || size_of_all_certificates < 3,

--- a/tls/s2n_server_cert_request.c
+++ b/tls/s2n_server_cert_request.c
@@ -62,7 +62,7 @@ static uint8_t s2n_cert_type_preference_list_legacy_dss[] = {
 
 static int s2n_recv_client_cert_preferences(struct s2n_stuffer *in, s2n_cert_type *chosen_cert_type_out)
 {
-    uint8_t cert_types_len;
+    uint8_t cert_types_len = 0;
     POSIX_GUARD(s2n_stuffer_read_uint8(in, &cert_types_len));
 
     uint8_t *their_cert_type_pref_list = s2n_stuffer_raw_read(in, cert_types_len);
@@ -100,7 +100,7 @@ int s2n_tls13_cert_req_recv(struct s2n_connection *conn)
     struct s2n_stuffer *in = &conn->handshake.io;
 
     /* read request context length */
-    uint8_t request_context_length;
+    uint8_t request_context_length = 0;
     POSIX_GUARD(s2n_stuffer_read_uint8(in, &request_context_length));
     /* RFC 8446: This field SHALL be zero length unless used for the post-handshake authentication */
     S2N_ERROR_IF(request_context_length != 0, S2N_ERR_BAD_MESSAGE);

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -99,8 +99,8 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
     POSIX_ENSURE_REF(conn->secure);
 
     struct s2n_stuffer *in = &conn->handshake.io;
-    uint8_t compression_method;
-    uint8_t session_id_len;
+    uint8_t compression_method = 0;
+    uint8_t session_id_len = 0;
     uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
     uint8_t session_id[S2N_TLS_SESSION_ID_MAX_LEN];
 
@@ -212,7 +212,7 @@ static int s2n_server_hello_parse(struct s2n_connection *conn)
          */
         POSIX_ENSURE(conn->early_data_state != S2N_EARLY_DATA_REQUESTED, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 
-        const struct s2n_security_policy *security_policy;
+        const struct s2n_security_policy *security_policy = NULL;
         POSIX_GUARD(s2n_connection_get_security_policy(conn, &security_policy));
 
         if (conn->server_protocol_version < security_policy->minimum_protocol_version

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -65,7 +65,7 @@ int s2n_server_key_recv(struct s2n_connection *conn)
     POSIX_GUARD(s2n_hash_update(signature_hash, data_to_verify.data, data_to_verify.size));
 
     /* Verify the signature */
-    uint16_t signature_length;
+    uint16_t signature_length = 0;
     POSIX_GUARD(s2n_stuffer_read_uint16(in, &signature_length));
 
     struct s2n_blob signature = { 0 };
@@ -107,9 +107,9 @@ int s2n_dhe_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_bl
     struct s2n_stuffer *in = &conn->handshake.io;
     struct s2n_dhe_raw_server_points *dhe_data = &raw_server_data->dhe_data;
 
-    uint16_t p_length;
-    uint16_t g_length;
-    uint16_t Ys_length;
+    uint16_t p_length = 0;
+    uint16_t g_length = 0;
+    uint16_t Ys_length = 0;
 
     /* Keep a copy to the start of the whole structure for the signature check */
     data_to_verify->data = s2n_stuffer_raw_read(in, 0);
@@ -162,7 +162,7 @@ int s2n_kem_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_bl
 
     struct s2n_stuffer kem_id_stuffer = { 0 };
     uint8_t kem_id_arr[2];
-    kem_extension_size kem_id;
+    kem_extension_size kem_id = 0;
     struct s2n_blob kem_id_blob = { 0 };
     POSIX_GUARD(s2n_blob_init(&kem_id_blob, kem_id_arr, s2n_array_len(kem_id_arr)));
     POSIX_GUARD(s2n_stuffer_init(&kem_id_stuffer, &kem_id_blob));

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -43,7 +43,7 @@ int s2n_server_nst_recv(struct s2n_connection *conn)
 {
     POSIX_GUARD(s2n_stuffer_read_uint32(&conn->handshake.io, &conn->ticket_lifetime_hint));
 
-    uint16_t session_ticket_len;
+    uint16_t session_ticket_len = 0;
     POSIX_GUARD(s2n_stuffer_read_uint16(&conn->handshake.io, &session_ticket_len));
 
     if (session_ticket_len > 0) {

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -348,7 +348,7 @@ S2N_RESULT s2n_signature_algorithms_supported_list_send(struct s2n_connection *c
 
 int s2n_recv_supported_sig_scheme_list(struct s2n_stuffer *in, struct s2n_sig_scheme_list *sig_hash_algs)
 {
-    uint16_t length_of_all_pairs;
+    uint16_t length_of_all_pairs = 0;
     POSIX_GUARD(s2n_stuffer_read_uint16(in, &length_of_all_pairs));
     if (length_of_all_pairs > s2n_stuffer_data_available(in)) {
         /* Malformed length, ignore the extension */

--- a/tls/s2n_tls13_certificate_verify.c
+++ b/tls/s2n_tls13_certificate_verify.c
@@ -168,7 +168,7 @@ int s2n_tls13_cert_read_and_verify_signature(struct s2n_connection *conn,
     POSIX_GUARD(s2n_hash_new(&message_hash));
 
     /* Get signature size */
-    uint16_t signature_size;
+    uint16_t signature_size = 0;
     POSIX_GUARD(s2n_stuffer_read_uint16(in, &signature_size));
     S2N_ERROR_IF(signature_size > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
 

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -159,7 +159,7 @@ int s2n_update_application_traffic_keys(struct s2n_connection *conn, s2n_mode mo
     /* get tls13 key context */
     s2n_tls13_connection_keys(keys, conn);
 
-    struct s2n_session_key *old_key;
+    struct s2n_session_key *old_key = NULL;
     struct s2n_blob old_app_secret = { 0 };
     struct s2n_blob app_iv = { 0 };
 

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -888,7 +888,7 @@ S2N_RESULT s2n_x509_validator_validate_cert_stapled_ocsp_response(struct s2n_x50
      *# nextUpdate      The time at or before which newer information will be
      *#                 available about the status of the certificate.
      **/
-    ASN1_GENERALIZEDTIME *revtime, *thisupd, *nextupd;
+    ASN1_GENERALIZEDTIME *revtime = NULL, *thisupd = NULL, *nextupd = NULL;
     /* Actual verification of the response */
     const int ocsp_resp_find_status_res = OCSP_resp_find_status(basic_response, cert_id, &status, &reason, &revtime, &thisupd, &nextupd);
     OCSP_CERTID_free(cert_id);

--- a/utils/s2n_array.c
+++ b/utils/s2n_array.c
@@ -38,12 +38,12 @@ static S2N_RESULT s2n_array_enlarge(struct s2n_array *array, uint32_t capacity)
     RESULT_ENSURE_REF(array);
 
     /* Acquire the memory */
-    uint32_t mem_needed;
+    uint32_t mem_needed = 0;
     RESULT_GUARD_POSIX(s2n_mul_overflow(array->element_size, capacity, &mem_needed));
     RESULT_GUARD_POSIX(s2n_realloc(&array->mem, mem_needed));
 
     /* Zero the extened part */
-    uint32_t array_elements_size;
+    uint32_t array_elements_size = 0;
     RESULT_GUARD_POSIX(s2n_mul_overflow(array->element_size, array->len, &array_elements_size));
     RESULT_CHECKED_MEMSET(array->mem.data + array_elements_size, 0, array->mem.size - array_elements_size);
     RESULT_POSTCONDITION(s2n_array_validate(array));

--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -91,7 +91,7 @@ struct s2n_map *s2n_map_new_with_initial_capacity(uint32_t capacity)
 {
     PTR_ENSURE(capacity != 0, S2N_ERR_MAP_INVALID_MAP_SIZE);
     struct s2n_blob mem = { 0 };
-    struct s2n_map *map;
+    struct s2n_map *map = NULL;
 
     PTR_GUARD_POSIX(s2n_alloc(&mem, sizeof(struct s2n_map)));
 

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -92,7 +92,7 @@ static int s2n_mem_malloc_mlock_impl(void **ptr, uint32_t requested, uint32_t *a
     POSIX_ENSURE_REF(ptr);
 
     /* Page aligned allocation required for mlock */
-    uint32_t allocate;
+    uint32_t allocate = 0;
 
     POSIX_GUARD(s2n_align_to(requested, page_size, &allocate));
 

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -463,7 +463,7 @@ static int s2n_rand_get_entropy_from_urandom(void *ptr, uint32_t size)
  */
 S2N_RESULT s2n_public_random(int64_t bound, uint64_t *output)
 {
-    uint64_t r;
+    uint64_t r = 0;
 
     RESULT_ENSURE_GT(bound, 0);
 

--- a/utils/s2n_rfc5952.c
+++ b/utils/s2n_rfc5952.c
@@ -106,7 +106,7 @@ S2N_RESULT s2n_inet_ntop(int af, const void *addr, struct s2n_blob *dst)
                     (octets[i] & 0x000F) };
 
                 /* Skip up to three leading zeroes */
-                int j;
+                int j = 0;
                 for (j = 0; j < 3; j++) {
                     if (nibbles[j]) {
                         break;

--- a/utils/s2n_socket.c
+++ b/utils/s2n_socket.c
@@ -227,7 +227,7 @@ int s2n_socket_is_ipv6(int fd, uint8_t *ipv6)
 {
     POSIX_ENSURE_REF(ipv6);
 
-    socklen_t len;
+    socklen_t len = 0;
     struct sockaddr_storage addr;
     len = sizeof(addr);
     POSIX_GUARD(getpeername(fd, (struct sockaddr *) &addr, &len));

--- a/utils/s2n_timer.c
+++ b/utils/s2n_timer.c
@@ -29,7 +29,7 @@ S2N_RESULT s2n_timer_start(struct s2n_config *config, struct s2n_timer *timer)
 
 S2N_RESULT s2n_timer_elapsed(struct s2n_config *config, struct s2n_timer *timer, uint64_t *nanoseconds)
 {
-    uint64_t current_time;
+    uint64_t current_time = 0;
 
     RESULT_ENSURE(config->monotonic_clock(config->monotonic_clock_ctx, &current_time) >= S2N_SUCCESS,
             S2N_ERR_CANCELLED);


### PR DESCRIPTION
### Description of changes: 

s2n-tls expects that all variable declarations set an initial value. This commit fixes violations of that rules across our codebase. This commit is an automated fix generated using `clang-tidy`. 

The following script was used to generate the fixes
```
# remove the existing build directory
rm build -rf
# generate a compile command data base so clang-tidy knows the 
# structure of the project and it's included files
cmake . -Bbuild \
      -DCMAKE_C_COMPILER=/usr/bin/clang \
      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
# run clang tidy, and have it fix the violations it can
run-clang-tidy . -p build/ -checks=cppcoreguidelines-init-variables -fix
```

More documentation on the init-variables check can be found [here](https://releases.llvm.org/11.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/cppcoreguidelines-init-variables.html).

### Call-outs:

I plan to add this as a check in the CI, but didn't want to add that into this PR so that this PR would include the minimum manual changes for it to pass CI.

### Testing:

This is an automated fix with no expected behavior change. I have a murky recollection that most modern compilers will zero-init by default, but regardless all tests passing in CI should confirm that this is not a behavior change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
