### PR TITLE
ci: add clang-tidy job 

### DIFF
--- a/codebuild/spec/buildspec_lints.yml
+++ b/codebuild/spec/buildspec_lints.yml
@@ -1,0 +1,23 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+version: 0.2
+
+batch:
+  build-list:
+    - identifier: clang_tidy
+      buildspec: codebuild/spec/lints/clang_tidy.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:lints
+        privileged-mode: true

--- a/codebuild/spec/lints/clang_tidy.yml
+++ b/codebuild/spec/lints/clang_tidy.yml
@@ -1,0 +1,36 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+version: 0.2
+
+phases:
+  pre_build:
+    on-failure: ABORT
+    commands:
+      # The exported compile commands will by used by clang-tidy to "build" the 
+      # project for static analysis.
+      - cmake . -Bbuild -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+  build:
+    on-failure: ABORT
+    commands:
+      # The ugly sed command is used to remove ANSI color from clang-tidy output,
+      # since run-clang-tidy turns that on by default the and the version that we 
+      # use doesn't have an option to disable it.
+      - run-clang-tidy . -p build/ -quiet -checks=cppcoreguidelines-init-variables | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' > clang-tidy.report
+      - cat clang-tidy.report | grep warning
+      # This if statement will exit with a non-zero code if grep found any warnings 
+      # in the clang-tidy report.
+      - |
+        if [ $? -eq 0 ]; then
+          exit 1
+        fi

--- a/codebuild/spec/lints/clang_tidy.yml
+++ b/codebuild/spec/lints/clang_tidy.yml
@@ -26,7 +26,11 @@ phases:
       # The ugly sed command is used to remove ANSI color from clang-tidy output,
       # since run-clang-tidy turns that on by default the and the version that we 
       # use doesn't have an option to disable it.
-      - run-clang-tidy . -p build/ -quiet -checks=cppcoreguidelines-init-variables | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' > clang-tidy.report
+      - |
+        run-clang-tidy . \
+        -p build/ \
+        -quiet \
+        -checks=-*,cppcoreguidelines-init-variables,clang-analyzer-core.NullDereference,clang-analyzer-core.UndefinedBinaryOperatorResult | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' > clang-tidy.report
       - cat clang-tidy.report | grep warning
       # This if statement will exit with a non-zero code if grep found any warnings 
       # in the clang-tidy report.


### PR DESCRIPTION
### Description of changes: 

This commit adds a clang-tidy job to our CI

This is in preparation of the merging of #4404. Note that I am not disabling the clang-static-analyzer warnings, because most of those don't look like false positives. Rather I will put out PR's to fix those before I make this a required check.

### Call-outs:

This will likely stay in draft for a while until
- #4404 is merged in
- clang static analyzer errors are fixed

I also have a cppcheck job written, but the new cppcheck introduces a large number of new lints, so we either have a lot of things to fix or a lot of things to suppress.

### Testing:

I verified that new codebuild job runs correctly (although it is currently failing)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
