### PR TITLE
ci: skip tests on lint workflows

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -146,7 +146,7 @@ jobs:
       # We don't need to format the generated files,
       # but if they don't exist other code breaks.
       - name: Generate
-        run: ./${{env.ROOT_PATH}}/generate.sh
+        run: ./${{env.ROOT_PATH}}/generate.sh --skip-tests
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1.0.3
@@ -178,7 +178,7 @@ jobs:
       # We don't need to format the generated files,
       # but if they don't exist other code breaks.
       - name: Generate
-        run: ${{env.ROOT_PATH}}/generate.sh
+        run: ${{env.ROOT_PATH}}/generate.sh --skip-tests
 
       # TODO translate json reports to in-action warnings
       - name: Run cargo clippy


### PR DESCRIPTION
### Description of changes: 

Lint jobs run slowly in CI, but they can run a bit faster if we skip the tests in the generate step. We already run these tests in the `generate` CI workflow.

### Testing:

This `--skip-tests` option is already used in the `harness-interop` rust CI workflow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
