### PR TITLE
style(bindings): address new clippy lint

### DIFF
--- a/bindings/rust/s2n-tls-tokio/src/lib.rs
+++ b/bindings/rust/s2n-tls-tokio/src/lib.rs
@@ -112,10 +112,11 @@ where
         let result = match self.error.take() {
             Some(err) => Err(err),
             None => {
-                ready!(self.tls.with_io(ctx, |context| {
+                let handshake_poll = self.tls.with_io(ctx, |context| {
                     let conn = context.get_mut().as_mut();
                     conn.poll_negotiate().map(|r| r.map(|_| ()))
-                }))
+                });
+                ready!(handshake_poll)
             }
         };
         // If the result isn't a fatal error, return it immediately.


### PR DESCRIPTION
With the new rust version, we are seeing the following clippy error.

```
 error: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
Error:    --> s2n-tls-tokio/src/lib.rs:115:56
    |
115 |                   ready!(self.tls.with_io(ctx, |context| {
    |  ________________________________________________________^
116 | |                     let conn = context.get_mut().as_mut();
117 | |                     conn.poll_negotiate().map(|r| r.map(|_| ()))
118 | |                 }))
    | |_________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#blocks_in_conditions
    = note: `-D clippy::blocks-in-conditions` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::blocks_in_conditions)]`

```
This PR fixes that clippy error.

### Testing:

Existing CI should pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
