### PR TITLE
refactor: Consolidate record wiping

### DIFF
--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -78,3 +78,4 @@ int s2n_sslv2_record_header_parse(struct s2n_connection *conn, uint8_t *record_t
 int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, struct s2n_blob *decrypted);
 S2N_RESULT s2n_aead_aad_init(const struct s2n_connection *conn, uint8_t *sequence_number, uint8_t content_type, uint16_t record_length, struct s2n_blob *ad);
 S2N_RESULT s2n_tls13_aead_aad_init(uint16_t record_length, uint8_t tag_length, struct s2n_blob *ad);
+S2N_RESULT s2n_record_wipe(struct s2n_connection *conn);

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -252,3 +252,12 @@ int s2n_tls13_parse_record_type(struct s2n_stuffer *stuffer, uint8_t *record_typ
 
     return 0;
 }
+
+S2N_RESULT s2n_record_wipe(struct s2n_connection *conn)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_GUARD_POSIX(s2n_stuffer_wipe(&conn->header_in));
+    RESULT_GUARD_POSIX(s2n_stuffer_wipe(&conn->in));
+    conn->in_status = ENCRYPTED;
+    return S2N_RESULT_OK;
+}

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -203,9 +203,7 @@ ssize_t s2n_recv_impl(struct s2n_connection *conn, void *buf, ssize_t size_signe
                     break;
                 }
             }
-            POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
-            POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
-            conn->in_status = ENCRYPTED;
+            POSIX_GUARD_RESULT(s2n_record_wipe(conn));
             continue;
         }
 
@@ -219,9 +217,7 @@ ssize_t s2n_recv_impl(struct s2n_connection *conn, void *buf, ssize_t size_signe
 
         /* Are we ready for more encrypted data? */
         if (s2n_stuffer_data_available(&conn->in) == 0) {
-            POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
-            POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
-            conn->in_status = ENCRYPTED;
+            POSIX_GUARD_RESULT(s2n_record_wipe(conn));
         }
 
         /* If we've read some data, return it in legacy mode */

--- a/tls/s2n_shutdown.c
+++ b/tls/s2n_shutdown.c
@@ -124,9 +124,7 @@ int s2n_shutdown(struct s2n_connection *conn, s2n_blocked_status *blocked)
         /* Reset IO. Make sure we do this before attempting to read a record in
          * case a previous failed read left IO in a bad state.
          */
-        POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
-        POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
-        conn->in_status = ENCRYPTED;
+        POSIX_GUARD_RESULT(s2n_record_wipe(conn));
 
         POSIX_GUARD(s2n_read_full_record(conn, &record_type, &isSSLv2));
         POSIX_ENSURE(!isSSLv2, S2N_ERR_BAD_MESSAGE);


### PR DESCRIPTION
### Description of changes: 

We repeat the same three lines in many places. s2n_handshake_io.c had factored it out into a static method, but I've now finished that refactor by moving it to a non-static method so that s2n_recv.c and s2n_shutdown.c can also use the same method.

I've ensured I found all the instances by searching for "conn->in_status = ENCRYPTED".

### Testing:
Just moving code around. No behavior change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
