### PR TITLE
bindings: use aws-lc-rs instead of aws-lc-sys

### DIFF
--- a/bindings/rust/s2n-tls-sys/build.rs
+++ b/bindings/rust/s2n-tls-sys/build.rs
@@ -13,7 +13,8 @@ fn main() {
 }
 
 fn env<N: AsRef<str>>(name: N) -> String {
-    option_env(name).expect("missing env var")
+    let name = name.as_ref();
+    option_env(name).unwrap_or_else(|| panic!("missing env var {name:?}"))
 }
 
 fn option_env<N: AsRef<str>>(name: N) -> Option<String> {
@@ -197,9 +198,9 @@ impl Default for Libcrypto {
 
                     eprintln!("cargo:rerun-if-env-changed={}", name);
 
-                    let link = format!("aws_lc_{version}_crypto");
                     let include = value;
                     let root = env(format!("DEP_AWS_LC_{version}_ROOT"));
+                    let link = env(format!("DEP_AWS_LC_{version}_LIBCRYPTO"));
 
                     return Self {
                         version,

--- a/bindings/rust/s2n-tls-sys/src/lib.rs
+++ b/bindings/rust/s2n-tls-sys/src/lib.rs
@@ -7,6 +7,8 @@ mod api;
 pub use api::*;
 
 mod features;
+
+#[allow(unused_imports)]
 pub use features::*;
 
 // Additional defines that don't get imported with bindgen

--- a/bindings/rust/s2n-tls-sys/templates/Cargo.template
+++ b/bindings/rust/s2n-tls-sys/templates/Cargo.template
@@ -35,7 +35,7 @@ stacktrace = []
 # unstable-foo = []
 
 [dependencies]
-aws-lc-sys = { version = "0.13" }
+aws-lc-rs = { version = "1.6.2" }
 libc = "0.2"
 
 [build-dependencies]


### PR DESCRIPTION
### Description of changes: 

After https://github.com/aws/aws-lc-rs/pull/335 was merged, we can now switch to depend on `aws-lc-rs` instead of `aws-lc-sys`. This has the following benefits:

* We can depend on a major version and will run into fewer conflicts with other crates that depend on `aws-lc-rs` or `aws-lc-sys` (e.g. s2n-quic)
* We get FIPS switching for free, since `aws-lc-rs` exposes a `fips` feature.

### Testing:

The existing CI tests should continue to pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
