### PR TITLE
refactor: ossl verify cb logic

### DIFF
--- a/tls/s2n_crl.c
+++ b/tls/s2n_crl.c
@@ -232,20 +232,6 @@ S2N_RESULT s2n_crl_invoke_lookup_callbacks(struct s2n_connection *conn, struct s
     return S2N_RESULT_OK;
 }
 
-int s2n_crl_ossl_verify_callback(int default_ossl_ret, X509_STORE_CTX *ctx)
-{
-    int err = X509_STORE_CTX_get_error(ctx);
-    switch (err) {
-        case X509_V_ERR_CRL_NOT_YET_VALID:
-        case X509_V_ERR_CRL_HAS_EXPIRED:
-        case X509_V_ERR_ERROR_IN_CRL_LAST_UPDATE_FIELD:
-        case X509_V_ERR_ERROR_IN_CRL_NEXT_UPDATE_FIELD:
-            return 1;
-        default:
-            return default_ossl_ret;
-    }
-}
-
 int s2n_crl_lookup_get_cert_issuer_hash(struct s2n_crl_lookup *lookup, uint64_t *hash)
 {
     POSIX_ENSURE_REF(lookup);

--- a/tls/s2n_x509_validator.h
+++ b/tls/s2n_x509_validator.h
@@ -41,6 +41,11 @@ typedef enum {
 typedef uint8_t (*verify_host)(const char *host_name, size_t host_name_len, void *data);
 struct s2n_connection;
 
+struct s2n_ossl_verify_cb_config {
+    unsigned crl_callback : 1;
+    unsigned disable_time_validation : 1;
+};
+
 /**
  * Trust store simply contains the trust store each connection should validate certs against.
  * For most use cases, you only need one of these per application.
@@ -64,6 +69,7 @@ struct s2n_x509_validator {
     STACK_OF(X509) *cert_chain_from_wire;
     int state;
     struct s2n_array *crl_lookup_list;
+    struct s2n_ossl_verify_cb_config verify_cb_config;
 };
 
 struct s2n_cert_validation_info {

--- a/tls/s2n_x509_validator.h
+++ b/tls/s2n_x509_validator.h
@@ -41,11 +41,6 @@ typedef enum {
 typedef uint8_t (*verify_host)(const char *host_name, size_t host_name_len, void *data);
 struct s2n_connection;
 
-struct s2n_ossl_verify_cb_config {
-    unsigned crl_callback : 1;
-    unsigned disable_time_validation : 1;
-};
-
 /**
  * Trust store simply contains the trust store each connection should validate certs against.
  * For most use cases, you only need one of these per application.
@@ -69,7 +64,6 @@ struct s2n_x509_validator {
     STACK_OF(X509) *cert_chain_from_wire;
     int state;
     struct s2n_array *crl_lookup_list;
-    struct s2n_ossl_verify_cb_config verify_cb_config;
 };
 
 struct s2n_cert_validation_info {


### PR DESCRIPTION
```
The default X509_STORE_CTX only allows for a single verify callback, but s2n-tls 
sometimes requires multiple pieces of functionality for that callback. Previously we 
did this by chaining function together, but this will become more difficult as we add 
more verify functions that we wish to call.

This commit adds a generic config and callback that allows for verify callbacks to 
be more easily configured.
```

### Description of changes: 

This commit adds a new `s2n_ossl_verify_cb_config` struct on the `s2n_x509_validator`, which is used to control which verify callbacks are invoked.

This is being done in preparation for the cert key restrictions, which will add yet another verify callback to enforce cert key restrictions.

### Call-outs:

Alternate implementation.

Rather than adding a new config, we could instead pass the entire `s2n_connection *`  as the application data, and then use the original checks from `s2n_x509_validator_verify_cert_chain` to toggle the callbacks, 
E.g. instead of 
```
    if (callback_config->disable_time_validation
            && s2n_disable_time_validation_ossl_verify_callback(default_ossl_ret, ctx) == OSSL_VERIFY_CALLBACK_OK) {
        return OSSL_VERIFY_CALLBACK_OK;
    }
```

We could do
```
    if (conn->config->crl_lookup_cb
            && s2n_disable_time_validation_ossl_verify_callback(default_ossl_ret, ctx) == OSSL_VERIFY_CALLBACK_OK) {
        return OSSL_VERIFY_CALLBACK_OK;
    }
```
But duplicating all of the conditional checks felt odd, so I went with the config route.

### Testing:

This refactor should not change any behavior, which is confirmed by existing unit tests passing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
