### PR TITLE
fix: Unsets global libcrypto rand

### DIFF
--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -61,17 +61,12 @@ int test_count;
  * not initialise at the start of the test. Useful for tests that e.g spawn a
  * number of independent childs at the start of a unit test and where you want
  * each child to have its own independently initialised s2n.
- *
- * BEGIN_TEST() prints unit test information to stdout. But this often gets
- * buffered by the kernel and will then be flushed in each child spawned. The
- * result is a number of repeated messages being send to stdout and, in turn,
- * appear in the logs. At the moment, we think this is better than risking not
- * having any printing at all.
  */
 #define BEGIN_TEST_NO_INIT()                                        \
     do {                                                            \
         test_count = 0;                                             \
         fprintf(stdout, "Running %-50s ... ", __FILE__);            \
+        fflush(stdout);                                             \
         EXPECT_SUCCESS_WITHOUT_COUNT(s2n_in_unit_test_set(true));   \
         S2N_TEST_OPTIONALLY_ENABLE_FIPS_MODE();                     \
     } while(0)

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -553,6 +553,10 @@ S2N_RESULT s2n_rand_init(void)
         return S2N_RESULT_OK;
     }
 
+    /* Unset any existing random engine */
+    RAND_set_rand_engine(NULL);
+    RAND_set_rand_method(NULL);
+
     /* Create an engine */
     ENGINE *e = ENGINE_new();
 


### PR DESCRIPTION
### Resolved issues:

Resolves #4253

### Description of changes: 

Fixes issue where global random is not our custom rand implementation after calling s2n_init(). 

### Call-outs:

There's actually quite a few different ways of fixing this issue since Openssl has a surplus of methods to mess with the RAND implementation. I picked unsetting the random function before setting our own custom rand impl because that mirrors how we clean up our custom rand impl. But I could also call RAND_set_rand_method() with our custom impl, and that would work too.

### Testing:

Includes tests. Also, I am fixing the bug where a bunch of test output gets printed when running the s2n_random_test.c file. This seems like a really obvious fix, so maybe someone can explain to me why we never fixed this?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
