### PR TITLE
fix: parse fragmented sslv2 client hellos

### DIFF
--- a/tests/unit/s2n_record_read_test.c
+++ b/tests/unit/s2n_record_read_test.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+#include "tls/s2n_record.h"
+#include "tls/s2n_tls.h"
+#include "utils/s2n_safety.h"
+
+#define SSLV2_MIN_SIZE 3
+
+int main(int argc, char *argv[])
+{
+    BEGIN_TEST();
+
+    /* Test s2n_sslv2_record_header_parse */
+    {
+        const struct {
+            uint8_t bytes[S2N_TLS_RECORD_HEADER_LENGTH];
+            uint16_t length;
+            uint8_t type;
+            uint8_t version;
+        } test_cases[] = {
+            {
+                    .bytes = { S2N_TLS_SSLV2_HEADER_FLAG, SSLV2_MIN_SIZE, TLS_CLIENT_HELLO, 0x03, 0x03 },
+                    .length = 0,
+                    .type = TLS_CLIENT_HELLO,
+                    .version = S2N_TLS12,
+            },
+            {
+                    .bytes = { S2N_TLS_SSLV2_HEADER_FLAG, SSLV2_MIN_SIZE + 1, TLS_CLIENT_HELLO, 0x03, 0x03 },
+                    .length = 1,
+                    .type = TLS_CLIENT_HELLO,
+                    .version = S2N_TLS12,
+            },
+            {
+                    .bytes = { S2N_TLS_SSLV2_HEADER_FLAG, 0xFF, TLS_CLIENT_HELLO, 0x03, 0x03 },
+                    .length = 0xFF - SSLV2_MIN_SIZE,
+                    .type = TLS_CLIENT_HELLO,
+                    .version = S2N_TLS12,
+            },
+            {
+                    .bytes = { S2N_TLS_SSLV2_HEADER_FLAG, 0x84, TLS_CLIENT_HELLO, 0x03, 0x03 },
+                    .length = 0x84 - SSLV2_MIN_SIZE,
+                    .type = TLS_CLIENT_HELLO,
+                    .version = S2N_TLS12,
+            },
+            {
+                    .bytes = { 0x84, 0x84, TLS_CLIENT_HELLO, 0x03, 0x03 },
+                    .length = 0x484 - SSLV2_MIN_SIZE,
+                    .type = TLS_CLIENT_HELLO,
+                    .version = S2N_TLS12,
+            },
+            {
+                    .bytes = { 0xFF, 0xFF, TLS_CLIENT_HELLO, 0x03, 0x03 },
+                    .length = 0x7FFF - SSLV2_MIN_SIZE,
+                    .type = TLS_CLIENT_HELLO,
+                    .version = S2N_TLS12,
+            },
+            {
+                    .bytes = { S2N_TLS_SSLV2_HEADER_FLAG, SSLV2_MIN_SIZE, 0, 0x03, 0x03 },
+                    .length = 0,
+                    .type = 0,
+                    .version = S2N_TLS12,
+            },
+            {
+                    .bytes = { S2N_TLS_SSLV2_HEADER_FLAG, SSLV2_MIN_SIZE, 77, 0x03, 0x03 },
+                    .length = 0,
+                    .type = 77,
+                    .version = S2N_TLS12,
+            },
+            {
+                    .bytes = { S2N_TLS_SSLV2_HEADER_FLAG, SSLV2_MIN_SIZE, TLS_SERVER_HELLO, 0x03, 0x03 },
+                    .length = 0,
+                    .type = TLS_SERVER_HELLO,
+                    .version = S2N_TLS12,
+            },
+            {
+                    .bytes = { S2N_TLS_SSLV2_HEADER_FLAG, SSLV2_MIN_SIZE, TLS_CLIENT_HELLO, 0x03, 0x04 },
+                    .length = 0,
+                    .type = TLS_CLIENT_HELLO,
+                    .version = S2N_TLS13,
+            },
+            {
+                    .bytes = { S2N_TLS_SSLV2_HEADER_FLAG, SSLV2_MIN_SIZE, TLS_CLIENT_HELLO, 0, 0 },
+                    .length = 0,
+                    .type = TLS_CLIENT_HELLO,
+                    .version = 0,
+            },
+        };
+
+        /* Test: parse valid record headers */
+        for (size_t i = 0; i < s2n_array_len(test_cases); i++) {
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(conn);
+
+            EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->header_in,
+                    test_cases[i].bytes, sizeof(test_cases[i].bytes)));
+
+            uint8_t type = 0, version = 0;
+            uint16_t length = 0;
+            EXPECT_SUCCESS(s2n_sslv2_record_header_parse(conn, &type, &version, &length));
+            EXPECT_EQUAL(test_cases[i].type, type);
+            EXPECT_EQUAL(test_cases[i].version, version);
+            EXPECT_EQUAL(test_cases[i].length, length);
+
+            EXPECT_BYTEARRAY_EQUAL(conn->header_in_data,
+                    test_cases[i].bytes, sizeof(test_cases[i].bytes));
+
+            EXPECT_EQUAL(s2n_stuffer_data_available(&conn->header_in), S2N_TLS_RECORD_HEADER_LENGTH);
+        }
+
+        /* Test: parse header with bad length
+         *
+         * We already read 3 bytes by reading the header, so logically the message
+         * is at least 3 bytes long.
+         */
+        {
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_stuffer_skip_write(&conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
+            conn->header_in_data[0] = S2N_TLS_SSLV2_HEADER_FLAG;
+
+            uint8_t type = 0, version = 0;
+            uint16_t length = 0;
+
+            conn->header_in_data[1] = SSLV2_MIN_SIZE - 1;
+            EXPECT_FAILURE_WITH_ERRNO(
+                    s2n_sslv2_record_header_parse(conn, &type, &version, &length),
+                    S2N_ERR_BAD_MESSAGE);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&conn->header_in), 3);
+            EXPECT_SUCCESS(s2n_stuffer_reread(&conn->header_in));
+
+            conn->header_in_data[1] = SSLV2_MIN_SIZE;
+            EXPECT_SUCCESS(s2n_sslv2_record_header_parse(conn, &type, &version, &length));
+            EXPECT_EQUAL(s2n_stuffer_data_available(&conn->header_in), S2N_TLS_RECORD_HEADER_LENGTH);
+            EXPECT_SUCCESS(s2n_stuffer_reread(&conn->header_in));
+
+            conn->header_in_data[1] = 0;
+            EXPECT_FAILURE_WITH_ERRNO(
+                    s2n_sslv2_record_header_parse(conn, &type, &version, &length),
+                    S2N_ERR_BAD_MESSAGE);
+            EXPECT_EQUAL(s2n_stuffer_data_available(&conn->header_in), 3);
+            EXPECT_SUCCESS(s2n_stuffer_reread(&conn->header_in));
+        };
+    };
+
+    END_TEST();
+}

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -411,24 +411,6 @@ int main(int argc, char **argv)
         EXPECT_FAILURE_WITH_ERRNO(s2n_record_parse(conn), S2N_ERR_DECRYPT);
     };
 
-    /* Test s2n_sslv2_record_header_parse fails when fragment_length < 3 */
-    {
-        EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
-
-        uint8_t record_type = 0;
-        uint8_t protocol_version = 0;
-        uint16_t fragment_length = 0;
-
-        /* First two bytes are the fragment length */
-        uint8_t header_bytes[] = { 0x00, 0x00, 0x00, 0x00, 0x00 };
-        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->header_in, header_bytes, sizeof(header_bytes)));
-
-        EXPECT_FAILURE_WITH_ERRNO(s2n_sslv2_record_header_parse(conn, &record_type, &protocol_version, &fragment_length), S2N_ERR_SAFETY);
-
-        /* Check the rest of the stuffer has not been read yet */
-        EXPECT_EQUAL(s2n_stuffer_data_available(&conn->header_in), 3);
-    };
-
     /* Record version is recorded for the first message received (Client Hello) */
     {
         DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),

--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -22,7 +22,7 @@
 
 #define S2N_TLS_CONTENT_TYPE_LENGTH 1
 
-#define S2N_TLS_SSLV2_HEADER_FLAG (0x80)
+#define S2N_TLS_SSLV2_HEADER_FLAG        (0x80)
 #define S2N_TLS_SSLV2_HEADER_FLAG_UINT16 (S2N_TLS_SSLV2_HEADER_FLAG << 8)
 
 /* All versions of TLS define the record header the same:

--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -23,6 +23,7 @@
 #define S2N_TLS_CONTENT_TYPE_LENGTH 1
 
 #define S2N_TLS_SSLV2_HEADER_FLAG (0x80)
+#define S2N_TLS_SSLV2_HEADER_FLAG_UINT16 (S2N_TLS_SSLV2_HEADER_FLAG << 8)
 
 /* All versions of TLS define the record header the same:
  * ContentType + ProtocolVersion + length

--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -22,6 +22,8 @@
 
 #define S2N_TLS_CONTENT_TYPE_LENGTH 1
 
+#define S2N_TLS_SSLV2_HEADER_FLAG (0x80)
+
 /* All versions of TLS define the record header the same:
  * ContentType + ProtocolVersion + length
  */

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -53,9 +53,10 @@ int s2n_sslv2_record_header_parse(
      * Since the first bit is not actually used to indicate length, we need to
      * remove it from the length.
      *
-     *= https://datatracker.ietf.org/doc/html/rfc5246#appendix-E.2
-     *# The highest bit MUST be 1; the remaining bits contain the length
-     *# of the following data in bytes.
+     *= https://tools.ietf.org/rfc/rfc5246#appendix-E.2
+     *# msg_length
+     *#    The highest bit MUST be 1; the remaining bits contain the length
+     *#    of the following data in bytes.
      */
     POSIX_ENSURE(*fragment_length & S2N_TLS_SSLV2_HEADER_FLAG_UINT16, S2N_ERR_BAD_MESSAGE);
     *fragment_length ^= S2N_TLS_SSLV2_HEADER_FLAG_UINT16;


### PR DESCRIPTION
### Description of changes: 
Fixes an issue where parsing sslv2 messages fails if the first call to conn->recv doesn't return the whole message.
Usually we block in that case and try again later. But we weren't rereading conn->header_in for sslv2, so the second attempt would try to read a whole new header and fail because conn->header_in was already full of the actual header. After I fixed that, I also found that we were removing the sslv2 bit flag while parsing, so the second attempt wouldn't be detected as sslv2.

I also added a conn->header_in reread before attempting to read a new header, just in case there's another code path that leads to us not rereading conn->header_in. conn->header_in is a 5-byte static stuffer, so in order for it to contain a full 5-byte header the read cursor always needs to be 0. I didn't consider that sufficient to solve the problem though, since non-sslv2 headers are available immediately after parsing and some code could theoretically rely on that fact. So I still think the reread at the end of the header parsing methods is necessary.

### Testing:
New tests for sslv2 header parsing and fragmented sslv2 messages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
