### PR TITLE
chore(ci): Give OpenBSD CI job a performance boost

### DIFF
--- a/.github/workflows/ci_openbsd.yml
+++ b/.github/workflows/ci_openbsd.yml
@@ -9,17 +9,18 @@ on:
 
 jobs:
   testopenbsd:
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     name: CI OpenBSD
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build and test in OpenBSD
         id: test
-        uses: cross-platform-actions/action@v0.21.1
+        uses: cross-platform-actions/action@v0.23.0
         with:
           operating_system: openbsd
           architecture: x86-64
-          version: '7.2'
+          version: '7.4'
+          cpu_count: 4
           shell: bash
           run: |
             sudo pkg_add ninja cmake


### PR DESCRIPTION
This bumps the cross-platform-action to the latest version which enables hardware acceleration on Ubuntu runners. Job time drops from ~45 minutes to ~8 minutes.

While here, bump OpenBSD version to 7.4.

### Testing:

I triggered the action a few times in a forked repo (https://github.com/knightjoel/s2n-tls/actions/workflows/ci_openbsd.yml). All runs were successful.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
