### PR TITLE
Extend license check to .rs files

### DIFF
--- a/bindings/rust/bench/benches/resumption.rs
+++ b/bindings/rust/bench/benches/resumption.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use bench::{
     harness::TlsBenchConfig, CipherSuite, CryptoConfig, HandshakeType, KXGroup, S2NConnection,
     SigType, TlsConnPair, TlsConnection,

--- a/bindings/rust/bench/src/bin/graph_memory.rs
+++ b/bindings/rust/bench/src/bin/graph_memory.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use plotters::{
     prelude::{
         ChartBuilder, IntoDrawingArea, IntoSegmentedCoord, LabelAreaPosition, Rectangle,

--- a/codebuild/bin/copyright_mistake_scanner.sh
+++ b/codebuild/bin/copyright_mistake_scanner.sh
@@ -20,12 +20,14 @@ S2N_FILES+=" "
 S2N_FILES+=$(find "$PWD"/codebuild/ -type f -name "*.sh")
 S2N_FILES+=" "
 S2N_FILES+=$(find "$PWD"/tests/ -type f -name "*.sh")
+S2N_FILES+=" "
+S2N_FILES+=$(find "$PWD" -type f -name "*.rs" | grep -v target)
 
 FAILED=0
 
 for file in $S2N_FILES; do
-    # The word "Copyright" should appear at least once in the first 3 lines of every file
-    COUNT=`head -3 $file | grep "Copyright" | wc -l`;
+    # The word "Copyright" should appear at least once in the first 4 lines of every file
+    COUNT=`head -4 $file | grep "Copyright" | wc -l`;
     if [ "$COUNT" == "0" ];
     then
         FAILED=1;


### PR DESCRIPTION
### Resolved issues:

n/a

### Description of changes: 

This excludes the target directory (which isn't source code). We modify the number of lines checked for Copyright to 4, so that the bindgen-generated header in generated feature files doesn't push the license header out of the check window.

### Call-outs:

This only checks .rs files, not e.g. Cargo.toml. That seems reasonable to me, but happy to try extending it further; it would likely mean some filtering to avoid picking up the large amount of RFC toml files.

### Testing:

Ran the checker successfully locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
