### PR TITLE
fix(test): fix dangling pointers in cert verify test

### DIFF
--- a/tests/unit/s2n_tls13_cert_verify_test.c
+++ b/tests/unit/s2n_tls13_cert_verify_test.c
@@ -23,6 +23,7 @@
 #include "tls/s2n_tls13.h"
 #include "tls/s2n_tls13_certificate_verify.c"
 
+#define TEST_SECURITY_POLICY "20200207"
 uint8_t hello[] = "Hello, World!\n";
 uint8_t goodbye[] = "Goodbye, World!\n";
 
@@ -47,12 +48,12 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
     const char *key_file = test_case->key_file;
     struct s2n_signature_scheme sig_scheme = *test_case->sig_scheme;
 
-    struct s2n_config *config = NULL;
-    EXPECT_NOT_NULL(config = s2n_config_new());
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20200207"));
-
     /* Successfully send and receive certificate verify */
     {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, TEST_SECURITY_POLICY));
+
         /* Derive private/public keys and set connection variables */
         struct s2n_stuffer certificate_in = { 0 }, certificate_out = { 0 };
         struct s2n_blob b = { 0 };
@@ -137,6 +138,10 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
 
     /* Verifying connection errors with incorrect signed content */
     {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, TEST_SECURITY_POLICY));
+
         /* Derive private/public keys and set connection variables */
         struct s2n_stuffer certificate_in = { 0 }, certificate_out = { 0 };
         struct s2n_blob b = { 0 };
@@ -208,6 +213,10 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
 
     /* Verifying connection errors with even 1 bit incorrect */
     {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, TEST_SECURITY_POLICY));
+
         struct s2n_stuffer certificate_in = { 0 }, certificate_out = { 0 };
         struct s2n_blob b = { 0 };
         struct s2n_cert_chain_and_key *cert_chain = NULL;
@@ -278,6 +287,10 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
 
     /* Verifying connection errors with wrong hash/signature algorithms */
     {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, TEST_SECURITY_POLICY));
+
         /* Derive private/public keys and set connection variables */
         struct s2n_stuffer certificate_in = { 0 }, certificate_out = { 0 };
         struct s2n_blob b = { 0 };
@@ -369,8 +382,6 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         EXPECT_SUCCESS(s2n_stuffer_free(&certificate_out));
         EXPECT_SUCCESS(s2n_connection_free(verifying_conn));
     };
-
-    EXPECT_SUCCESS(s2n_config_free(config));
 
     return 0;
 }

--- a/tests/unit/s2n_tls13_cert_verify_test.c
+++ b/tests/unit/s2n_tls13_cert_verify_test.c
@@ -23,7 +23,6 @@
 #include "tls/s2n_tls13.h"
 #include "tls/s2n_tls13_certificate_verify.c"
 
-#define TEST_SECURITY_POLICY "20200207"
 uint8_t hello[] = "Hello, World!\n";
 uint8_t goodbye[] = "Goodbye, World!\n";
 
@@ -48,18 +47,29 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
     const char *key_file = test_case->key_file;
     struct s2n_signature_scheme sig_scheme = *test_case->sig_scheme;
 
+    DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+    EXPECT_NOT_NULL(config);
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20200207"));
+
+    DEFER_CLEANUP(struct s2n_cert_chain_and_key *cert_chain = s2n_cert_chain_and_key_new(), 
+            s2n_cert_chain_and_key_ptr_free);
+    EXPECT_NOT_NULL(cert_chain);
+
+    char cert_chain_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+    char private_key_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+
+    EXPECT_SUCCESS(s2n_read_test_pem(cert_file, &cert_chain_pem[0], S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_read_test_pem(key_file, &private_key_pem[0], S2N_MAX_TEST_PEM_SIZE));
+    EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(cert_chain, cert_chain_pem, private_key_pem));
+
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
+
     /* Successfully send and receive certificate verify */
     {
-        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
-        EXPECT_NOT_NULL(config);
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, TEST_SECURITY_POLICY));
-
         /* Derive private/public keys and set connection variables */
         struct s2n_stuffer certificate_in = { 0 }, certificate_out = { 0 };
         struct s2n_blob b = { 0 };
-        struct s2n_cert_chain_and_key *cert_chain = NULL;
-        char *cert_chain_pem = NULL;
-        char *private_key_pem = NULL;
+
         s2n_pkey_type pkey_type = { 0 };
 
         struct s2n_connection *verifying_conn = NULL, *sending_conn = NULL;
@@ -69,14 +79,7 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
 
         EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_in, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_out, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_NOT_NULL(cert_chain = s2n_cert_chain_and_key_new());
-        EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_read_test_pem(cert_file, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_read_test_pem(key_file, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(cert_chain, cert_chain_pem, private_key_pem));
 
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
         EXPECT_SUCCESS(s2n_connection_set_config(sending_conn, config));
         sending_conn->handshake_params.our_chain_and_key = cert_chain;
         sending_conn->handshake_params.server_cert_sig_scheme = &sig_scheme;
@@ -127,9 +130,6 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         EXPECT_FAILURE(s2n_tls13_cert_verify_recv(verifying_conn));
 
         /* Clean up */
-        free(cert_chain_pem);
-        free(private_key_pem);
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(cert_chain));
         EXPECT_SUCCESS(s2n_stuffer_free(&certificate_in));
         EXPECT_SUCCESS(s2n_stuffer_free(&certificate_out));
         EXPECT_SUCCESS(s2n_connection_free(sending_conn));
@@ -138,32 +138,18 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
 
     /* Verifying connection errors with incorrect signed content */
     {
-        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
-        EXPECT_NOT_NULL(config);
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, TEST_SECURITY_POLICY));
-
         /* Derive private/public keys and set connection variables */
         struct s2n_stuffer certificate_in = { 0 }, certificate_out = { 0 };
         struct s2n_blob b = { 0 };
-        struct s2n_cert_chain_and_key *cert_chain = NULL;
-        char *cert_chain_pem = NULL;
-        char *private_key_pem = NULL;
         uint64_t bytes_in_hash = 0;
         s2n_pkey_type pkey_type = { 0 };
 
         EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_in, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_out, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_NOT_NULL(cert_chain = s2n_cert_chain_and_key_new());
-        EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_read_test_pem(cert_file, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_read_test_pem(key_file, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(cert_chain, cert_chain_pem, private_key_pem));
 
         struct s2n_connection *verifying_conn = NULL;
         EXPECT_NOT_NULL(verifying_conn = s2n_connection_new(verifier_mode));
         verifying_conn->actual_protocol_version = S2N_TLS13;
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
         EXPECT_SUCCESS(s2n_connection_set_config(verifying_conn, config));
         verifying_conn->handshake_params.our_chain_and_key = cert_chain;
         verifying_conn->handshake_params.server_cert_sig_scheme = &sig_scheme;
@@ -203,9 +189,6 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         EXPECT_SUCCESS(s2n_pkey_free(&verifying_conn->handshake_params.client_public_key));
 
         /* Clean up */
-        free(cert_chain_pem);
-        free(private_key_pem);
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(cert_chain));
         EXPECT_SUCCESS(s2n_stuffer_free(&certificate_in));
         EXPECT_SUCCESS(s2n_stuffer_free(&certificate_out));
         EXPECT_SUCCESS(s2n_connection_free(verifying_conn));
@@ -213,30 +196,16 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
 
     /* Verifying connection errors with even 1 bit incorrect */
     {
-        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
-        EXPECT_NOT_NULL(config);
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, TEST_SECURITY_POLICY));
-
         struct s2n_stuffer certificate_in = { 0 }, certificate_out = { 0 };
         struct s2n_blob b = { 0 };
-        struct s2n_cert_chain_and_key *cert_chain = NULL;
-        char *cert_chain_pem = NULL;
-        char *private_key_pem = NULL;
         s2n_pkey_type pkey_type = { 0 };
 
         EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_in, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_out, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_NOT_NULL(cert_chain = s2n_cert_chain_and_key_new());
-        EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_read_test_pem(cert_file, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_read_test_pem(key_file, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(cert_chain, cert_chain_pem, private_key_pem));
 
         struct s2n_connection *verifying_conn = NULL;
         EXPECT_NOT_NULL(verifying_conn = s2n_connection_new(verifier_mode));
         verifying_conn->actual_protocol_version = S2N_TLS13;
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
         EXPECT_SUCCESS(s2n_connection_set_config(verifying_conn, config));
         verifying_conn->handshake_params.our_chain_and_key = cert_chain;
         verifying_conn->handshake_params.server_cert_sig_scheme = &sig_scheme;
@@ -277,9 +246,6 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
             EXPECT_SUCCESS(s2n_pkey_free(&verifying_conn->handshake_params.client_public_key));
         }
 
-        free(cert_chain_pem);
-        free(private_key_pem);
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(cert_chain));
         EXPECT_SUCCESS(s2n_stuffer_free(&certificate_in));
         EXPECT_SUCCESS(s2n_stuffer_free(&certificate_out));
         EXPECT_SUCCESS(s2n_connection_free(verifying_conn));
@@ -287,30 +253,16 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
 
     /* Verifying connection errors with wrong hash/signature algorithms */
     {
-        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
-        EXPECT_NOT_NULL(config);
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, TEST_SECURITY_POLICY));
-
         /* Derive private/public keys and set connection variables */
         struct s2n_stuffer certificate_in = { 0 }, certificate_out = { 0 };
         struct s2n_blob b = { 0 };
-        struct s2n_cert_chain_and_key *cert_chain = NULL;
-        char *cert_chain_pem = NULL;
-        char *private_key_pem = NULL;
         s2n_pkey_type pkey_type = { 0 };
 
         EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_in, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_stuffer_alloc(&certificate_out, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_NOT_NULL(cert_chain = s2n_cert_chain_and_key_new());
-        EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_read_test_pem(cert_file, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_read_test_pem(key_file, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(cert_chain, cert_chain_pem, private_key_pem));
 
         struct s2n_connection *verifying_conn = NULL;
         EXPECT_NOT_NULL(verifying_conn = s2n_connection_new(verifier_mode));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
         EXPECT_SUCCESS(s2n_connection_set_config(verifying_conn, config));
         verifying_conn->handshake_params.our_chain_and_key = cert_chain;
         verifying_conn->handshake_params.server_cert_sig_scheme = &sig_scheme;
@@ -375,14 +327,10 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
             EXPECT_SUCCESS(s2n_pkey_free(&verifying_conn->handshake_params.client_public_key));
         }
 
-        free(cert_chain_pem);
-        free(private_key_pem);
-        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(cert_chain));
         EXPECT_SUCCESS(s2n_stuffer_free(&certificate_in));
         EXPECT_SUCCESS(s2n_stuffer_free(&certificate_out));
         EXPECT_SUCCESS(s2n_connection_free(verifying_conn));
     };
-
     return 0;
 }
 

--- a/tests/unit/s2n_tls13_cert_verify_test.c
+++ b/tests/unit/s2n_tls13_cert_verify_test.c
@@ -14,6 +14,7 @@
  */
 
 #include "crypto/s2n_ecdsa.h"
+#include "crypto/s2n_rsa_pss.h"
 #include "error/s2n_errno.h"
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
@@ -338,18 +339,21 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         /* send and receive with mismatched signature algs */
         verifying_conn->handshake_params.client_cert_sig_scheme = &test_scheme;
         test_scheme.hash_alg = S2N_HASH_SHA256;
-        test_scheme.sig_alg = S2N_SIGNATURE_ECDSA;
+        test_scheme.sig_alg = test_case->sig_scheme->sig_alg;
+        /* 0xFFFF is an invalid iana value */
         test_scheme.iana_value = 0xFFFF;
 
         EXPECT_SUCCESS(s2n_hash_init(&verifying_conn->handshake.hashes->sha256, S2N_HASH_SHA256));
         EXPECT_SUCCESS(s2n_hash_update(&verifying_conn->handshake.hashes->sha256, hello, strlen((char *) hello)));
 
+        /* the iana value is not checked when writing the verify message */
         EXPECT_SUCCESS(s2n_tls13_cert_verify_send(verifying_conn));
 
         EXPECT_SUCCESS(s2n_hash_init(&verifying_conn->handshake.hashes->sha256, S2N_HASH_SHA256));
         EXPECT_SUCCESS(s2n_hash_update(&verifying_conn->handshake.hashes->sha256, hello, strlen((char *) hello)));
 
-        EXPECT_FAILURE(s2n_tls13_cert_verify_recv(verifying_conn));
+        /* the invalid iana value should result in a failure */
+        EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_cert_verify_recv(verifying_conn), S2N_ERR_INVALID_SIGNATURE_SCHEME);
 
         /* Clean up */
         if (verifying_conn->mode == S2N_CLIENT) {

--- a/tests/unit/s2n_tls13_cert_verify_test.c
+++ b/tests/unit/s2n_tls13_cert_verify_test.c
@@ -50,7 +50,7 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
     EXPECT_NOT_NULL(config);
     EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20200207"));
 
-    DEFER_CLEANUP(struct s2n_cert_chain_and_key *cert_chain = s2n_cert_chain_and_key_new(), 
+    DEFER_CLEANUP(struct s2n_cert_chain_and_key *cert_chain = s2n_cert_chain_and_key_new(),
             s2n_cert_chain_and_key_ptr_free);
     EXPECT_NOT_NULL(cert_chain);
 

--- a/tests/unit/s2n_tls13_cert_verify_test.c
+++ b/tests/unit/s2n_tls13_cert_verify_test.c
@@ -68,7 +68,6 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         /* Derive private/public keys and set connection variables */
         struct s2n_stuffer certificate_in = { 0 }, certificate_out = { 0 };
         struct s2n_blob b = { 0 };
-
         s2n_pkey_type pkey_type = { 0 };
 
         struct s2n_connection *verifying_conn = NULL, *sending_conn = NULL;
@@ -300,7 +299,7 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         EXPECT_FAILURE(s2n_tls13_cert_read_and_verify_signature(verifying_conn,
                 verifying_conn->handshake_params.server_cert_sig_scheme));
 
-        /* send with mismatched signature algs */
+        /* send and receive with mismatched signature algs */
         verifying_conn->handshake_params.client_cert_sig_scheme = &test_scheme;
         test_scheme.hash_alg = S2N_HASH_SHA256;
         test_scheme.sig_alg = S2N_SIGNATURE_ECDSA;


### PR DESCRIPTION
### Description of changes: 

This PR switches the config to a smaller scope to prevent the memory abuse that was previously occuring. Currently for each test case a new chain is added to the config and then freed. This means that the cert reference in the config is pointing to freed memory.

### Testing:

I confirmed that after merging in the changes from this pr, 4407 no longer fails under ASAN.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
