### PR TITLE
Add support for recovering underlying stream from s2n-tls-tokio handshake

### DIFF
--- a/bindings/rust/s2n-tls-tokio/src/lib.rs
+++ b/bindings/rust/s2n-tls-tokio/src/lib.rs
@@ -145,6 +145,15 @@ where
         &mut self.stream
     }
 
+    /// Deconstructs the TlsStream into the underlying IO stream.
+    ///
+    /// This ignores any ongoing TLS state and returns the raw IO stream. Similar to the stream
+    /// returned by [`open`], it is in an indeterminate state (e.g., buffer contents may or may not
+    /// contain TLS data).
+    pub fn unwrap_into_stream(self) -> S {
+        self.stream
+    }
+
     /// Establish a TLS stream with the peer. This performs a TLS handshake.
     ///
     /// On failures, it returns the stream back to the caller. No guarantees are made by this

--- a/bindings/rust/s2n-tls-tokio/tests/handshake.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/handshake.rs
@@ -257,5 +257,11 @@ async fn io_stream_access() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(client_result.get_ref().local_addr().unwrap(), client_addr);
     assert_eq!(client_result.get_mut().local_addr().unwrap(), client_addr);
 
+    // This is a terminal operation but still makes sense to check it.
+    assert_eq!(
+        client_result.unwrap_into_stream().local_addr().unwrap(),
+        client_addr
+    );
+
     Ok(())
 }


### PR DESCRIPTION
### Description of changes: 

Some callers may need to continue using the underlying transport after handshake failure. This exposes a low-level interface which returns the stream alongside the error payload in the Rust interface. The TLS stream is still shutdown & blinding applied (if it would have been in the high level APIs).

### Call-outs:

This intentionally does not propagate the availability of the low-level bindings to the TlsConnector/TlsAcceptor. We may want to do that, but it seems to me that those add relatively little value for this kind of consumer and the simpler, easier to get correct API that doesn't expose the stream back is probably better for those. This also avoids adding new APIs or making a breaking change on that struct.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

A new test is added to the handshake harness, which uses the newly added API on a failed handshake, and then checks that it can still send traffic in both directions in plaintext on the underlying TcpStream.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
