### PR TITLE
refactor: switch s2n_blob to use S2N_RESULT

### DIFF
--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -422,7 +422,7 @@ static S2N_RESULT s2n_tls12_aead_cipher_aes128_gcm_set_ktls_info(
     RESULT_ENSURE_LTE(sizeof(crypto_info->iv), in->seq.size);
     RESULT_CHECKED_MEMCPY(crypto_info->iv, in->seq.data, sizeof(crypto_info->iv));
 
-    RESULT_GUARD_POSIX(s2n_blob_init(&out->value, (uint8_t *) (void *) crypto_info,
+    RESULT_GUARD(s2n_blob_init(&out->value, (uint8_t *) (void *) crypto_info,
             sizeof(s2n_ktls_crypto_info_tls12_aes_gcm_128)));
     return S2N_RESULT_OK;
 }
@@ -449,7 +449,7 @@ static S2N_RESULT s2n_tls12_aead_cipher_aes256_gcm_set_ktls_info(
     RESULT_ENSURE_LTE(sizeof(crypto_info->iv), in->seq.size);
     RESULT_CHECKED_MEMCPY(crypto_info->iv, in->seq.data, sizeof(crypto_info->iv));
 
-    RESULT_GUARD_POSIX(s2n_blob_init(&out->value, (uint8_t *) (void *) crypto_info,
+    RESULT_GUARD(s2n_blob_init(&out->value, (uint8_t *) (void *) crypto_info,
             sizeof(s2n_ktls_crypto_info_tls12_aes_gcm_256)));
     return S2N_RESULT_OK;
 }
@@ -485,7 +485,7 @@ static S2N_RESULT s2n_tls13_aead_cipher_aes128_gcm_set_ktls_info(
     RESULT_ENSURE_LTE(sizeof(crypto_info->iv), iv_remainder);
     RESULT_CHECKED_MEMCPY(crypto_info->iv, in->iv.data + salt_size, sizeof(crypto_info->iv));
 
-    RESULT_GUARD_POSIX(s2n_blob_init(&out->value, (uint8_t *) (void *) crypto_info,
+    RESULT_GUARD(s2n_blob_init(&out->value, (uint8_t *) (void *) crypto_info,
             sizeof(s2n_ktls_crypto_info_tls12_aes_gcm_128)));
     return S2N_RESULT_OK;
 }
@@ -515,7 +515,7 @@ static S2N_RESULT s2n_tls13_aead_cipher_aes256_gcm_set_ktls_info(
     RESULT_ENSURE_LTE(sizeof(crypto_info->iv), iv_remainder);
     RESULT_CHECKED_MEMCPY(crypto_info->iv, in->iv.data + salt_size, sizeof(crypto_info->iv));
 
-    RESULT_GUARD_POSIX(s2n_blob_init(&out->value, (uint8_t *) (void *) crypto_info,
+    RESULT_GUARD(s2n_blob_init(&out->value, (uint8_t *) (void *) crypto_info,
             sizeof(s2n_ktls_crypto_info_tls12_aes_gcm_256)));
     return S2N_RESULT_OK;
 }

--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -58,7 +58,7 @@ int s2n_create_cert_chain_from_stuffer(struct s2n_cert_chain *cert_chain_out, st
         }
         struct s2n_blob mem = { 0 };
         POSIX_GUARD(s2n_alloc(&mem, sizeof(struct s2n_cert)));
-        POSIX_GUARD(s2n_blob_zero(&mem));
+        POSIX_GUARD_RESULT(s2n_blob_zero(&mem));
         new_node = (struct s2n_cert *) (void *) mem.data;
 
         if (s2n_alloc(&new_node->raw, s2n_stuffer_data_available(&cert_out_stuffer)) != S2N_SUCCESS) {
@@ -188,15 +188,15 @@ struct s2n_cert_chain_and_key *s2n_cert_chain_and_key_new(void)
 {
     DEFER_CLEANUP(struct s2n_blob chain_and_key_mem = { 0 }, s2n_free);
     PTR_GUARD_POSIX(s2n_alloc(&chain_and_key_mem, sizeof(struct s2n_cert_chain_and_key)));
-    PTR_GUARD_POSIX(s2n_blob_zero(&chain_and_key_mem));
+    PTR_GUARD_RESULT(s2n_blob_zero(&chain_and_key_mem));
 
     DEFER_CLEANUP(struct s2n_blob cert_chain_mem = { 0 }, s2n_free);
     PTR_GUARD_POSIX(s2n_alloc(&cert_chain_mem, sizeof(struct s2n_cert_chain)));
-    PTR_GUARD_POSIX(s2n_blob_zero(&cert_chain_mem));
+    PTR_GUARD_RESULT(s2n_blob_zero(&cert_chain_mem));
 
     DEFER_CLEANUP(struct s2n_blob pkey_mem = { 0 }, s2n_free);
     PTR_GUARD_POSIX(s2n_alloc(&pkey_mem, sizeof(s2n_cert_private_key)));
-    PTR_GUARD_POSIX(s2n_blob_zero(&pkey_mem));
+    PTR_GUARD_RESULT(s2n_blob_zero(&pkey_mem));
 
     DEFER_CLEANUP(struct s2n_array *cn_names = NULL, s2n_array_free_p);
     cn_names = s2n_array_new(sizeof(struct s2n_blob));
@@ -257,7 +257,7 @@ int s2n_cert_chain_and_key_load_sans(struct s2n_cert_chain_and_key *chain_and_ke
             POSIX_CHECKED_MEMCPY(san_blob->data, san_str, san_str_len);
             san_blob->size = san_str_len;
             /* normalize san_blob to lowercase */
-            POSIX_GUARD(s2n_blob_char_to_lower(san_blob));
+            POSIX_GUARD_RESULT(s2n_blob_char_to_lower(san_blob));
         }
     }
 
@@ -330,7 +330,7 @@ int s2n_cert_chain_and_key_load_cns(struct s2n_cert_chain_and_key *chain_and_key
             POSIX_CHECKED_MEMCPY(cn_name->data, utf8_str, utf8_out_len);
             cn_name->size = utf8_out_len;
             /* normalize cn_name to lowercase */
-            POSIX_GUARD(s2n_blob_char_to_lower(cn_name));
+            POSIX_GUARD_RESULT(s2n_blob_char_to_lower(cn_name));
         }
     }
 

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -137,7 +137,7 @@ static int s2n_composite_cipher_aes_sha_initial_hmac(struct s2n_session_key *key
 #else
     uint8_t ctrl_buf[S2N_TLS12_AAD_LEN];
     struct s2n_blob ctrl_blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&ctrl_blob, ctrl_buf, S2N_TLS12_AAD_LEN));
+    POSIX_GUARD_RESULT(s2n_blob_init(&ctrl_blob, ctrl_buf, S2N_TLS12_AAD_LEN));
     struct s2n_stuffer ctrl_stuffer = { 0 };
     POSIX_GUARD(s2n_stuffer_init(&ctrl_stuffer, &ctrl_blob));
 

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -62,7 +62,7 @@ static S2N_RESULT s2n_drbg_bits(struct s2n_drbg *drbg, struct s2n_blob *out)
     RESULT_ENSURE_REF(out);
 
     struct s2n_blob value = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&value, drbg->v, sizeof(drbg->v)));
+    RESULT_GUARD(s2n_blob_init(&value, drbg->v, sizeof(drbg->v)));
     uint32_t block_aligned_size = out->size - (out->size % S2N_DRBG_BLOCK_SIZE);
 
     /* Per NIST SP800-90A 10.2.1.2: */
@@ -189,7 +189,7 @@ S2N_RESULT s2n_drbg_instantiate(struct s2n_drbg *drbg, struct s2n_blob *personal
 
     /* Copy the personalization string */
     RESULT_STACK_BLOB(ps, s2n_drbg_seed_size(drbg), S2N_DRBG_MAX_SEED_SIZE);
-    RESULT_GUARD_POSIX(s2n_blob_zero(&ps));
+    RESULT_GUARD(s2n_blob_zero(&ps));
 
     RESULT_CHECKED_MEMCPY(ps.data, personalization_string->data, MIN(ps.size, personalization_string->size));
 

--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -102,7 +102,7 @@ static int s2n_ecdsa_sign(const struct s2n_pkey *priv, s2n_signature_algorithm s
     POSIX_GUARD(s2n_hash_digest(digest, digest_out, digest_length));
 
     struct s2n_blob digest_blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&digest_blob, digest_out, digest_length));
+    POSIX_GUARD_RESULT(s2n_blob_init(&digest_blob, digest_out, digest_length));
     POSIX_GUARD(s2n_ecdsa_sign_digest(priv, &digest_blob, signature));
 
     POSIX_GUARD(s2n_hash_reset(digest));

--- a/crypto/s2n_hkdf.c
+++ b/crypto/s2n_hkdf.c
@@ -105,7 +105,7 @@ static int s2n_custom_hkdf(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, 
 {
     uint8_t prk_pad[MAX_DIGEST_SIZE] = { 0 };
     struct s2n_blob pseudo_rand_key = { 0 };
-    POSIX_GUARD(s2n_blob_init(&pseudo_rand_key, prk_pad, sizeof(prk_pad)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&pseudo_rand_key, prk_pad, sizeof(prk_pad)));
 
     POSIX_GUARD(s2n_custom_hkdf_extract(hmac, alg, salt, key, &pseudo_rand_key));
     POSIX_GUARD(s2n_custom_hkdf_expand(hmac, alg, &pseudo_rand_key, info, output));
@@ -259,7 +259,7 @@ int s2n_hkdf_expand_label(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, c
 
     POSIX_ENSURE_LTE(label->size, S2N_MAX_HKDF_EXPAND_LABEL_LENGTH);
 
-    POSIX_GUARD(s2n_blob_init(&hkdf_label_blob, hkdf_label_buf, sizeof(hkdf_label_buf)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&hkdf_label_blob, hkdf_label_buf, sizeof(hkdf_label_buf)));
     POSIX_GUARD(s2n_stuffer_init(&hkdf_label, &hkdf_label_blob));
     POSIX_GUARD(s2n_stuffer_write_uint16(&hkdf_label, output->size));
     POSIX_GUARD(s2n_stuffer_write_uint8(&hkdf_label, label->size + sizeof("tls13 ") - 1));

--- a/crypto/s2n_rsa_signing.c
+++ b/crypto/s2n_rsa_signing.c
@@ -88,7 +88,7 @@ int s2n_rsa_pkcs1v15_sign(const struct s2n_pkey *priv, struct s2n_hash_state *di
     POSIX_GUARD(s2n_hash_digest(digest, digest_out, digest_length));
 
     struct s2n_blob digest_blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&digest_blob, digest_out, digest_length));
+    POSIX_GUARD_RESULT(s2n_blob_init(&digest_blob, digest_out, digest_length));
     POSIX_GUARD(s2n_rsa_pkcs1v15_sign_digest(priv, digest->alg, &digest_blob, signature));
 
     return S2N_SUCCESS;
@@ -176,7 +176,7 @@ int s2n_rsa_pss_sign(const struct s2n_pkey *priv, struct s2n_hash_state *digest,
     POSIX_GUARD(s2n_hash_digest(digest, digest_data, digest_length));
 
     struct s2n_blob digest_blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&digest_blob, digest_data, digest_length));
+    POSIX_GUARD_RESULT(s2n_blob_init(&digest_blob, digest_data, digest_length));
     POSIX_GUARD(s2n_rsa_pss_sign_digest(priv, digest->alg, &digest_blob, signature_out));
 
     return S2N_SUCCESS;

--- a/crypto/s2n_tls13_keys.c
+++ b/crypto/s2n_tls13_keys.c
@@ -106,8 +106,8 @@ int s2n_tls13_keys_init(struct s2n_tls13_keys *keys, s2n_hmac_algorithm alg)
     keys->hmac_algorithm = alg;
     POSIX_GUARD(s2n_hmac_hash_alg(alg, &keys->hash_algorithm));
     POSIX_GUARD(s2n_hash_digest_size(keys->hash_algorithm, &keys->size));
-    POSIX_GUARD(s2n_blob_init(&keys->extract_secret, keys->extract_secret_bytes, keys->size));
-    POSIX_GUARD(s2n_blob_init(&keys->derive_secret, keys->derive_secret_bytes, keys->size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&keys->extract_secret, keys->extract_secret_bytes, keys->size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&keys->derive_secret, keys->derive_secret_bytes, keys->size));
     POSIX_GUARD(s2n_hmac_new(&keys->hmac));
 
     return 0;

--- a/stuffer/s2n_stuffer_file.c
+++ b/stuffer/s2n_stuffer_file.c
@@ -86,7 +86,7 @@ int s2n_stuffer_alloc_ro_from_fd(struct s2n_stuffer *stuffer, int rfd)
     POSIX_ENSURE(map != MAP_FAILED, S2N_ERR_MMAP);
 
     struct s2n_blob b = { 0 };
-    POSIX_GUARD(s2n_blob_init(&b, map, (uint32_t) st.st_size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&b, map, (uint32_t) st.st_size));
     return s2n_stuffer_init(stuffer, &b);
 }
 

--- a/stuffer/s2n_stuffer_text.c
+++ b/stuffer/s2n_stuffer_text.c
@@ -200,7 +200,7 @@ int s2n_stuffer_init_ro_from_string(struct s2n_stuffer *stuffer, uint8_t *data, 
     POSIX_ENSURE_REF(data);
 
     struct s2n_blob data_blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&data_blob, data, length));
+    POSIX_GUARD_RESULT(s2n_blob_init(&data_blob, data, length));
 
     POSIX_GUARD(s2n_stuffer_init(stuffer, &data_blob));
     POSIX_GUARD(s2n_stuffer_skip_write(stuffer, length));

--- a/tests/fuzz/s2n_deserialize_resumption_state_test.c
+++ b/tests/fuzz/s2n_deserialize_resumption_state_test.c
@@ -56,7 +56,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     uint8_t test_data[] = "test psk identity";
     struct s2n_blob test_blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&test_blob, test_data, sizeof(test_data)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&test_blob, test_data, sizeof(test_data)));
 
     /* Ignore the result of this function */
     s2n_result_ignore(s2n_deserialize_resumption_state(server_conn, &test_blob, &fuzzed_ticket));

--- a/tests/testlib/s2n_connection_test_utils.c
+++ b/tests/testlib/s2n_connection_test_utils.c
@@ -295,13 +295,13 @@ S2N_RESULT s2n_connection_set_secrets(struct s2n_connection *conn)
 
     uint8_t client_key_bytes[S2N_TLS13_SECRET_MAX_LEN] = "client key";
     struct s2n_blob client_key = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&client_key, client_key_bytes, cipher->key_material_size));
+    RESULT_GUARD(s2n_blob_init(&client_key, client_key_bytes, cipher->key_material_size));
     RESULT_GUARD_POSIX(cipher->init(&conn->secure->client_key));
     RESULT_GUARD_POSIX(cipher->set_encryption_key(&conn->secure->client_key, &client_key));
 
     uint8_t server_key_bytes[S2N_TLS13_SECRET_MAX_LEN] = "server key";
     struct s2n_blob server_key = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&server_key, server_key_bytes, cipher->key_material_size));
+    RESULT_GUARD(s2n_blob_init(&server_key, server_key_bytes, cipher->key_material_size));
     RESULT_GUARD_POSIX(cipher->init(&conn->secure->server_key));
     RESULT_GUARD_POSIX(cipher->set_encryption_key(&conn->secure->server_key, &server_key));
 

--- a/tests/testlib/s2n_io_testlib.c
+++ b/tests/testlib/s2n_io_testlib.c
@@ -68,7 +68,7 @@ S2N_RESULT s2n_test_new_iovecs(struct s2n_test_iovecs *iovecs,
 
     struct s2n_blob iovecs_mem = { 0 };
     RESULT_GUARD_POSIX(s2n_alloc(&iovecs_mem, sizeof(struct iovec) * iovecs_count));
-    RESULT_GUARD_POSIX(s2n_blob_zero(&iovecs_mem));
+    RESULT_GUARD(s2n_blob_zero(&iovecs_mem));
     iovecs->iovecs = (struct iovec *) (void *) iovecs_mem.data;
     iovecs->iovecs_count = iovecs_count;
 

--- a/tests/testlib/s2n_pq_kat_test_utils.c
+++ b/tests/testlib/s2n_pq_kat_test_utils.c
@@ -62,7 +62,7 @@ static S2N_RESULT s2n_drbg_generate_for_pq_kat_tests(struct s2n_drbg *drbg, stru
     RESULT_ENSURE_REF(drbg->ctx);
     uint8_t zeros_buffer[S2N_DRBG_MAX_SEED_SIZE] = { 0 };
     struct s2n_blob zeros = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&zeros, zeros_buffer, s2n_drbg_seed_size(drbg)));
+    RESULT_GUARD(s2n_blob_init(&zeros, zeros_buffer, s2n_drbg_seed_size(drbg)));
 
     RESULT_ENSURE(blob->size <= S2N_DRBG_GENERATE_LIMIT, S2N_ERR_DRBG_REQUEST_SIZE);
 
@@ -83,7 +83,7 @@ static S2N_RESULT s2n_get_random_data_for_pq_kat_tests(struct s2n_blob *blob)
     while (remaining) {
         struct s2n_blob slice = { 0 };
 
-        RESULT_GUARD_POSIX(s2n_blob_slice(blob, &slice, offset, MIN(remaining, S2N_DRBG_GENERATE_LIMIT)));
+        RESULT_GUARD(s2n_blob_slice(blob, &slice, offset, MIN(remaining, S2N_DRBG_GENERATE_LIMIT)));
         RESULT_GUARD(s2n_drbg_generate_for_pq_kat_tests(&drbg_for_pq_kats, &slice));
 
         remaining -= slice.size;
@@ -97,7 +97,7 @@ S2N_RESULT s2n_get_random_bytes_for_pq_kat_tests(uint8_t *buffer, uint32_t num_b
 {
     RESULT_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
     struct s2n_blob out = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&out, buffer, num_bytes));
+    RESULT_GUARD(s2n_blob_init(&out, buffer, num_bytes));
 
     RESULT_GUARD(s2n_get_random_data_for_pq_kat_tests(&out));
 

--- a/tests/testlib/s2n_stuffer_hex.c
+++ b/tests/testlib/s2n_stuffer_hex.c
@@ -31,7 +31,7 @@ static int s2n_stuffer_read_n_bits_hex(struct s2n_stuffer *stuffer, uint8_t n, u
 {
     uint8_t hex_data[16] = { 0 };
     struct s2n_blob b = { 0 };
-    POSIX_GUARD(s2n_blob_init(&b, hex_data, n / 4));
+    POSIX_GUARD_RESULT(s2n_blob_init(&b, hex_data, n / 4));
 
     POSIX_GUARD(s2n_stuffer_read(stuffer, &b));
 
@@ -125,7 +125,7 @@ static int s2n_stuffer_write_n_bits_hex(struct s2n_stuffer *stuffer, uint8_t n, 
 {
     uint8_t hex_data[16] = { 0 };
     struct s2n_blob b = { 0 };
-    POSIX_GUARD(s2n_blob_init(&b, hex_data, n / 4));
+    POSIX_GUARD_RESULT(s2n_blob_init(&b, hex_data, n / 4));
 
     POSIX_ENSURE_LTE(n, 64);
 

--- a/tests/unit/s2n_3des_test.c
+++ b/tests/unit/s2n_3des_test.c
@@ -33,10 +33,10 @@ int main(int argc, char **argv)
     uint8_t mac_key[] = "sample mac key";
     uint8_t des3_key[] = "12345678901234567890123";
     struct s2n_blob des3 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&des3, des3_key, sizeof(des3_key)));
+    EXPECT_OK(s2n_blob_init(&des3, des3_key, sizeof(des3_key)));
     uint8_t random_data[S2N_DEFAULT_FRAGMENT_LENGTH + 1];
     struct s2n_blob r = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&r, random_data, sizeof(random_data)));
+    EXPECT_OK(s2n_blob_init(&r, random_data, sizeof(random_data)));
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -60,7 +60,7 @@ int main(int argc, char **argv)
 
     for (int i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
+        EXPECT_OK(s2n_blob_init(&in, random_data, i));
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));

--- a/tests/unit/s2n_aead_aes_test.c
+++ b/tests/unit/s2n_aead_aes_test.c
@@ -52,11 +52,11 @@ int main(int argc, char **argv)
     uint8_t aes128_key[] = "123456789012345";
     uint8_t aes256_key[] = "1234567890123456789012345678901";
     struct s2n_blob aes128 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&aes128, aes128_key, sizeof(aes128_key)));
+    EXPECT_OK(s2n_blob_init(&aes128, aes128_key, sizeof(aes128_key)));
     struct s2n_blob aes256 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&aes256, aes256_key, sizeof(aes256_key)));
+    EXPECT_OK(s2n_blob_init(&aes256, aes256_key, sizeof(aes256_key)));
     struct s2n_blob r = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&r, random_data, sizeof(random_data)));
+    EXPECT_OK(s2n_blob_init(&r, random_data, sizeof(random_data)));
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
     int max_fragment = S2N_SMALL_FRAGMENT_LENGTH;
     for (size_t i = 0; i <= max_fragment + 1; i++) {
         struct s2n_blob in = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
+        EXPECT_OK(s2n_blob_init(&in, random_data, i));
         int bytes_written;
 
         /* TLS packet on the wire using AES-GCM:
@@ -273,7 +273,7 @@ int main(int argc, char **argv)
 
     for (size_t i = 0; i <= max_fragment + 1; i++) {
         struct s2n_blob in = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
+        EXPECT_OK(s2n_blob_init(&in, random_data, i));
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_connection_wipe(conn));

--- a/tests/unit/s2n_aead_chacha20_poly1305_test.c
+++ b/tests/unit/s2n_aead_chacha20_poly1305_test.c
@@ -52,9 +52,9 @@ int main(int argc, char **argv)
     uint8_t random_data[S2N_SMALL_FRAGMENT_LENGTH + 1];
     uint8_t chacha20_poly1305_key_data[] = "1234567890123456789012345678901";
     struct s2n_blob chacha20_poly1305_key = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&chacha20_poly1305_key, chacha20_poly1305_key_data, sizeof(chacha20_poly1305_key_data)));
+    EXPECT_OK(s2n_blob_init(&chacha20_poly1305_key, chacha20_poly1305_key_data, sizeof(chacha20_poly1305_key_data)));
     struct s2n_blob r = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&r, random_data, sizeof(random_data)));
+    EXPECT_OK(s2n_blob_init(&r, random_data, sizeof(random_data)));
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
     int max_fragment = S2N_SMALL_FRAGMENT_LENGTH;
     for (size_t i = 0; i <= max_fragment + 1; i++) {
         struct s2n_blob in = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
+        EXPECT_OK(s2n_blob_init(&in, random_data, i));
         int bytes_written;
 
         /* TLS packet on the wire using ChaCha20-Poly1305:

--- a/tests/unit/s2n_aes_sha_composite_test.c
+++ b/tests/unit/s2n_aes_sha_composite_test.c
@@ -54,11 +54,11 @@ int main(int argc, char **argv)
     uint8_t aes128_key[] = "123456789012345";
     uint8_t aes256_key[] = "1234567890123456789012345678901";
     struct s2n_blob aes128 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&aes128, aes128_key, sizeof(aes128_key)));
+    EXPECT_OK(s2n_blob_init(&aes128, aes128_key, sizeof(aes128_key)));
     struct s2n_blob aes256 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&aes256, aes256_key, sizeof(aes256_key)));
+    EXPECT_OK(s2n_blob_init(&aes256, aes256_key, sizeof(aes256_key)));
     struct s2n_blob r = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&r, random_data, sizeof(random_data)));
+    EXPECT_OK(s2n_blob_init(&r, random_data, sizeof(random_data)));
     /* Stores explicit IVs used in each test case to validate uniqueness. */
     uint8_t existing_explicit_ivs[S2N_DEFAULT_FRAGMENT_LENGTH + 2][S2N_TLS_MAX_IV_LEN];
 
@@ -92,7 +92,7 @@ int main(int argc, char **argv)
     for (int j = 0; j < 3; j++) {
         for (size_t i = 0; i <= max_aligned_fragment + 1; i++) {
             struct s2n_blob in = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
+            EXPECT_OK(s2n_blob_init(&in, random_data, i));
             int bytes_written;
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
@@ -168,7 +168,7 @@ int main(int argc, char **argv)
     for (int j = 0; j < 3; j++) {
         for (int i = 0; i <= max_aligned_fragment + 1; i++) {
             struct s2n_blob in = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
+            EXPECT_OK(s2n_blob_init(&in, random_data, i));
             int bytes_written;
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
@@ -244,7 +244,7 @@ int main(int argc, char **argv)
     for (int j = 0; j < 3; j++) {
         for (int i = 0; i < max_aligned_fragment + 1; i++) {
             struct s2n_blob in = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
+            EXPECT_OK(s2n_blob_init(&in, random_data, i));
             int bytes_written;
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
@@ -320,7 +320,7 @@ int main(int argc, char **argv)
     for (int j = 0; j < 3; j++) {
         for (int i = 0; i <= max_aligned_fragment + 1; i++) {
             struct s2n_blob in = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
+            EXPECT_OK(s2n_blob_init(&in, random_data, i));
             int bytes_written;
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));

--- a/tests/unit/s2n_aes_test.c
+++ b/tests/unit/s2n_aes_test.c
@@ -34,12 +34,12 @@ int main(int argc, char **argv)
     uint8_t aes128_key[] = "123456789012345";
     uint8_t aes256_key[] = "1234567890123456789012345678901";
     struct s2n_blob aes128 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&aes128, aes128_key, sizeof(aes128_key)));
+    EXPECT_OK(s2n_blob_init(&aes128, aes128_key, sizeof(aes128_key)));
     struct s2n_blob aes256 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&aes256, aes256_key, sizeof(aes256_key)));
+    EXPECT_OK(s2n_blob_init(&aes256, aes256_key, sizeof(aes256_key)));
     uint8_t random_data[S2N_DEFAULT_FRAGMENT_LENGTH + 1];
     struct s2n_blob r = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&r, random_data, sizeof(random_data)));
+    EXPECT_OK(s2n_blob_init(&r, random_data, sizeof(random_data)));
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
 
     for (size_t i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
+        EXPECT_OK(s2n_blob_init(&in, random_data, i));
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
@@ -129,7 +129,7 @@ int main(int argc, char **argv)
 
     for (size_t i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
+        EXPECT_OK(s2n_blob_init(&in, random_data, i));
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));

--- a/tests/unit/s2n_alerts_protocol_test.c
+++ b/tests/unit/s2n_alerts_protocol_test.c
@@ -148,7 +148,7 @@ int main(int argc, char **argv)
                 /* Send alert */
                 struct s2n_blob alert = { 0 };
                 s2n_blocked_status blocked = S2N_NOT_BLOCKED;
-                EXPECT_SUCCESS(s2n_blob_init(&alert, error_alerts[i], sizeof(error_alerts[0])));
+                EXPECT_OK(s2n_blob_init(&alert, error_alerts[i], sizeof(error_alerts[0])));
                 EXPECT_OK(s2n_record_write(sender, TLS_ALERT, &alert));
                 EXPECT_SUCCESS(s2n_flush(sender, &blocked));
 

--- a/tests/unit/s2n_async_pkey_test.c
+++ b/tests/unit/s2n_async_pkey_test.c
@@ -357,7 +357,7 @@ static int s2n_test_bad_sign(const struct s2n_pkey *pub_key, s2n_signature_algor
     /* Just write all zeroes.
      * This could accidentally be the correct signature, but it's very unlikely.
      */
-    POSIX_GUARD(s2n_blob_zero(signature));
+    POSIX_GUARD_RESULT(s2n_blob_zero(signature));
     return S2N_SUCCESS;
 }
 
@@ -639,12 +639,12 @@ int main(int argc, char **argv)
         conn->config->async_pkey_cb = async_pkey_decrypt_callback;
 
         struct s2n_blob encrypted_data = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&encrypted_data, test_encrypted_data, test_encrypted_size));
+        EXPECT_OK(s2n_blob_init(&encrypted_data, test_encrypted_data, test_encrypted_size));
 
         struct s2n_blob decrypted_data = { 0 };
         /* Re-use the encrypted data buffer to make sure that the data was actually transformed in the callback. 
          * If we filled this with the decrypted data, we would not know if the decryption happened in the callback. */
-        EXPECT_SUCCESS(s2n_blob_init(&decrypted_data, test_encrypted_data, test_encrypted_size));
+        EXPECT_OK(s2n_blob_init(&decrypted_data, test_encrypted_data, test_encrypted_size));
 
         EXPECT_FALSE(s2n_result_is_ok(s2n_async_pkey_decrypt(conn, &encrypted_data, &decrypted_data, s2n_async_decrypt_complete)));
         EXPECT_TRUE(s2n_errno == S2N_ERR_ASYNC_BLOCKED);

--- a/tests/unit/s2n_blob_test.c
+++ b/tests/unit/s2n_blob_test.c
@@ -35,13 +35,13 @@ int main(int argc, char **argv)
 
     /* Size of 0 is OK if data is null */
     struct s2n_blob b2 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&b2, 0, 0));
+    EXPECT_OK(s2n_blob_init(&b2, 0, 0));
     EXPECT_OK(s2n_blob_validate(&b2));
 
     /* Valid blob is valid */
     uint8_t array[12];
     struct s2n_blob b3 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&b3, array, sizeof(array)));
+    EXPECT_OK(s2n_blob_init(&b3, array, sizeof(array)));
     EXPECT_OK(s2n_blob_validate(&b3));
 
     /* Null blob is not growable */
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
 
     /* Static blob is not growable or freeable */
     struct s2n_blob g1 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&g1, array, 12));
+    EXPECT_OK(s2n_blob_init(&g1, array, 12));
     EXPECT_FALSE(s2n_blob_is_growable(&g1));
     EXPECT_FAILURE(s2n_realloc(&g1, 24));
     EXPECT_FAILURE(s2n_free(&g1));
@@ -92,15 +92,15 @@ int main(int argc, char **argv)
 
     /* Down-casing works */
     struct s2n_blob g7 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&g7, hello_world, sizeof(hello_world)));
-    EXPECT_SUCCESS(s2n_blob_char_to_lower(&g7));
+    EXPECT_OK(s2n_blob_init(&g7, hello_world, sizeof(hello_world)));
+    EXPECT_OK(s2n_blob_char_to_lower(&g7));
     EXPECT_SUCCESS(memcmp(g7.data, "hello world", sizeof(hello_world)));
 
     /* Slicing works */
     struct s2n_blob g8 = { 0 };
     uint8_t hello[] = "hello ";
     uint8_t world[] = "world";
-    EXPECT_SUCCESS(s2n_blob_slice(&g7, &g8, strlen((char *) hello), sizeof(world)));
+    EXPECT_OK(s2n_blob_slice(&g7, &g8, strlen((char *) hello), sizeof(world)));
     EXPECT_EQUAL(memcmp(g8.data, world, sizeof(world)), 0);
     EXPECT_EQUAL(g8.size, sizeof(world));
 
@@ -114,11 +114,11 @@ int main(int argc, char **argv)
             struct s2n_blob output_blob = { 0 };
 
             /* Succeeds with output blob of the right size */
-            EXPECT_SUCCESS(s2n_blob_init(&output_blob, test_mem, sizeof(long_input_str) / 2));
+            EXPECT_OK(s2n_blob_init(&output_blob, test_mem, sizeof(long_input_str) / 2));
             EXPECT_SUCCESS(s2n_hex_string_to_bytes(long_input_str, &output_blob));
 
             /* Fails with output blob that's too small */
-            EXPECT_SUCCESS(s2n_blob_init(&output_blob, test_mem, 1));
+            EXPECT_OK(s2n_blob_init(&output_blob, test_mem, 1));
             EXPECT_FAILURE_WITH_ERRNO(s2n_hex_string_to_bytes(long_input_str, &output_blob),
                     S2N_ERR_INVALID_HEX);
         };
@@ -126,7 +126,7 @@ int main(int argc, char **argv)
         /* Test with invalid characters */
         {
             struct s2n_blob output_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&output_blob, test_mem, sizeof(test_mem)));
+            EXPECT_OK(s2n_blob_init(&output_blob, test_mem, sizeof(test_mem)));
 
             EXPECT_SUCCESS(s2n_hex_string_to_bytes((const uint8_t *) "12", &output_blob));
             EXPECT_FAILURE_WITH_ERRNO(s2n_hex_string_to_bytes((const uint8_t *) "#2", &output_blob),
@@ -152,7 +152,7 @@ int main(int argc, char **argv)
         };
         for (size_t i = 0; i < s2n_array_len(test_cases); i++) {
             struct s2n_blob actual_output = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&actual_output, test_mem, sizeof(test_mem)));
+            EXPECT_OK(s2n_blob_init(&actual_output, test_mem, sizeof(test_mem)));
 
             EXPECT_SUCCESS(s2n_hex_string_to_bytes((const uint8_t *) test_cases[i].input, &actual_output));
             EXPECT_BYTEARRAY_EQUAL(actual_output.data, test_cases[i].expected_output, test_cases[i].expected_output_size);

--- a/tests/unit/s2n_client_early_data_indication_test.c
+++ b/tests/unit/s2n_client_early_data_indication_test.c
@@ -190,7 +190,7 @@ int main(int argc, char **argv)
             uint8_t app_protocol_data[] = "protocol preference";
             uint8_t other_app_protocol_data[] = "different protocol";
             struct s2n_blob app_protocol = { 0 }, empty_app_protocol = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&app_protocol, app_protocol_data, sizeof(app_protocol_data)));
+            EXPECT_OK(s2n_blob_init(&app_protocol, app_protocol_data, sizeof(app_protocol_data)));
 
             /* No early data alp, empty alpn preferences: send */
             EXPECT_OK(s2n_set_early_data_app_protocol(conn, &empty_app_protocol));

--- a/tests/unit/s2n_client_hello_get_supported_groups_test.c
+++ b/tests/unit/s2n_client_hello_get_supported_groups_test.c
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
 
         uint8_t extension_data[S2N_TEST_SUPPORTED_GROUPS_EXTENSION_SIZE] = { 0 };
         struct s2n_blob extension_blob = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&extension_blob, extension_data, sizeof(extension_data)));
+        EXPECT_OK(s2n_blob_init(&extension_blob, extension_data, sizeof(extension_data)));
 
         s2n_parsed_extension *supported_groups_extension = &client_hello.extensions.parsed_extensions[supported_groups_id];
         supported_groups_extension->extension_type = S2N_EXTENSION_SUPPORTED_GROUPS;
@@ -210,7 +210,7 @@ int main(int argc, char **argv)
         {
             uint8_t extension_data[S2N_TEST_SUPPORTED_GROUPS_EXTENSION_SIZE] = { 0 };
             struct s2n_blob extension_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&extension_blob, extension_data, sizeof(extension_data)));
+            EXPECT_OK(s2n_blob_init(&extension_blob, extension_data, sizeof(extension_data)));
             supported_groups_extension->extension = extension_blob;
 
             struct s2n_stuffer extension_stuffer = { 0 };
@@ -231,7 +231,7 @@ int main(int argc, char **argv)
             uint8_t extension_data[S2N_TEST_SUPPORTED_GROUPS_EXTENSION_SIZE] = { 0 };
             struct s2n_blob extension_blob = { 0 };
             uint32_t extension_too_small_size = S2N_TEST_SUPPORTED_GROUPS_EXTENSION_SIZE - 2;
-            EXPECT_SUCCESS(s2n_blob_init(&extension_blob, extension_data, extension_too_small_size));
+            EXPECT_OK(s2n_blob_init(&extension_blob, extension_data, extension_too_small_size));
             supported_groups_extension->extension = extension_blob;
 
             struct s2n_stuffer extension_stuffer = { 0 };
@@ -251,7 +251,7 @@ int main(int argc, char **argv)
         {
             uint8_t extension_data[S2N_TEST_SUPPORTED_GROUPS_EXTENSION_SIZE] = { 0 };
             struct s2n_blob extension_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&extension_blob, extension_data, sizeof(extension_data)));
+            EXPECT_OK(s2n_blob_init(&extension_blob, extension_data, sizeof(extension_data)));
             supported_groups_extension->extension = extension_blob;
 
             struct s2n_stuffer extension_stuffer = { 0 };
@@ -282,12 +282,12 @@ int main(int argc, char **argv)
 
             uint8_t test_groups_list_data[S2N_TEST_SUPPORTED_GROUPS_LIST_SIZE] = { 0 };
             struct s2n_blob test_groups_list_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&test_groups_list_blob, test_groups_list_data, test_groups_list_size));
+            EXPECT_OK(s2n_blob_init(&test_groups_list_blob, test_groups_list_data, test_groups_list_size));
             EXPECT_OK(s2n_get_public_random_data(&test_groups_list_blob));
 
             uint8_t extension_data[S2N_TEST_SUPPORTED_GROUPS_EXTENSION_SIZE] = { 0 };
             struct s2n_blob extension_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&extension_blob, extension_data, sizeof(extension_data)));
+            EXPECT_OK(s2n_blob_init(&extension_blob, extension_data, sizeof(extension_data)));
             supported_groups_extension->extension = extension_blob;
 
             struct s2n_stuffer extension_stuffer = { 0 };
@@ -370,7 +370,7 @@ int main(int argc, char **argv)
 
             uint8_t sent_supported_groups_data[S2N_TEST_SUPPORTED_GROUPS_EXTENSION_SIZE];
             struct s2n_blob sent_supported_groups_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&sent_supported_groups_blob, sent_supported_groups_data,
+            EXPECT_OK(s2n_blob_init(&sent_supported_groups_blob, sent_supported_groups_data,
                     s2n_array_len(sent_supported_groups_data)));
 
             struct s2n_stuffer sent_supported_groups_stuffer = { 0 };

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -527,7 +527,7 @@ int main(int argc, char **argv)
             SSLv2_CLIENT_HELLO_CIPHER_SUITES,
             SSLv2_CLIENT_HELLO_CHALLENGE,
         };
-        EXPECT_SUCCESS(s2n_blob_init(&server_in.blob,
+        EXPECT_OK(s2n_blob_init(&server_in.blob,
                 sslv2_client_hello, sizeof(sslv2_client_hello)));
         EXPECT_SUCCESS(s2n_connection_set_recv_io_stuffer(&server_in, server));
 

--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -367,7 +367,7 @@ int main(int argc, char **argv)
         POSIX_GUARD(s2n_hash_digest(&server_hash, server_digest_out, hash_digest_length));
 
         struct s2n_blob server_blob = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&server_blob, server_digest_out, hash_digest_length));
+        EXPECT_OK(s2n_blob_init(&server_blob, server_digest_out, hash_digest_length));
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&client_conn->handshake.io));
         EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io,
@@ -388,7 +388,7 @@ int main(int argc, char **argv)
         POSIX_GUARD(s2n_hash_digest(&client_hash, client_digest_out, hash_digest_length));
 
         struct s2n_blob client_blob = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&client_blob, client_digest_out, hash_digest_length));
+        EXPECT_OK(s2n_blob_init(&client_blob, client_digest_out, hash_digest_length));
 
         /* Test that the transcript hash recreated MUST be the same on the server and client side */
         S2N_BLOB_EXPECT_EQUAL(client_blob, server_blob);
@@ -1144,7 +1144,7 @@ int main(int argc, char **argv)
 
             uint8_t extension_data[3] = { 0 };
             struct s2n_blob extension_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&extension_blob, extension_data, sizeof(extension_data)));
+            EXPECT_OK(s2n_blob_init(&extension_blob, extension_data, sizeof(extension_data)));
             struct s2n_stuffer extension_stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_init(&extension_stuffer, &extension_blob));
 

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -1704,7 +1704,7 @@ int main(int argc, char **argv)
 
             /* User did not provide a large enough buffer to write the compression methods */
             uint8_t data[] = { 1, 2, 3, 4, 5 };
-            EXPECT_SUCCESS(s2n_blob_init(&client_hello.compression_methods, data, sizeof(data)));
+            EXPECT_OK(s2n_blob_init(&client_hello.compression_methods, data, sizeof(data)));
             EXPECT_FAILURE_WITH_ERRNO(s2n_client_hello_get_compression_methods(&client_hello, &list, list_length, &out_length),
                     S2N_ERR_INSUFFICIENT_MEM_SIZE);
         };

--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -569,11 +569,11 @@ int main(int argc, char **argv)
         };
 
         struct s2n_blob identity_1 = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&identity_1, test_identity, sizeof(test_identity)));
+        EXPECT_OK(s2n_blob_init(&identity_1, test_identity, sizeof(test_identity)));
         struct s2n_blob identity_2 = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&identity_2, test_identity_2, sizeof(test_identity_2)));
+        EXPECT_OK(s2n_blob_init(&identity_2, test_identity_2, sizeof(test_identity_2)));
         struct s2n_blob identity_3 = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&identity_3, test_identity_3, sizeof(test_identity_3)));
+        EXPECT_OK(s2n_blob_init(&identity_3, test_identity_3, sizeof(test_identity_3)));
 
         struct s2n_blob *all_psks_list[] = { &identity_1, &identity_2, &identity_3 };
         struct s2n_blob *reverse_order_list[] = { &identity_3, &identity_2, &identity_1 };
@@ -752,7 +752,7 @@ int main(int argc, char **argv)
             /* Write invalid resumption psk */
             uint8_t bad_identity_data[] = "hello";
             struct s2n_blob bad_identity = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&bad_identity, bad_identity_data, sizeof(bad_identity_data)));
+            EXPECT_OK(s2n_blob_init(&bad_identity, bad_identity_data, sizeof(bad_identity_data)));
 
             uint8_t psk_idx = MAX_REJECTED_TICKETS - 1;
             for (size_t i = 0; i < psk_idx; i++) {
@@ -792,7 +792,7 @@ int main(int argc, char **argv)
             /* Write invalid resumption psk */
             uint8_t bad_identity_data[] = "hello";
             struct s2n_blob bad_identity = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&bad_identity, bad_identity_data, sizeof(bad_identity_data)));
+            EXPECT_OK(s2n_blob_init(&bad_identity, bad_identity_data, sizeof(bad_identity_data)));
             EXPECT_OK(s2n_write_test_identity(&identity_list.wire_data, &bad_identity));
 
             EXPECT_ERROR_WITH_ERRNO(s2n_select_resumption_psk(conn, &identity_list), S2N_ERR_INVALID_SESSION_TICKET);
@@ -822,7 +822,7 @@ int main(int argc, char **argv)
             /* "hello" is mysteriously not a valid session ticket */
             uint8_t bad_identity_data[] = "hello";
             struct s2n_blob bad_identity = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&bad_identity, bad_identity_data, sizeof(bad_identity_data)));
+            EXPECT_OK(s2n_blob_init(&bad_identity, bad_identity_data, sizeof(bad_identity_data)));
 
             struct s2n_offered_psk_list identity_list = { .conn = conn };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&identity_list.wire_data, 0));
@@ -1017,7 +1017,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_psk_set_identity(local_psk, test_bytes_data, sizeof(test_bytes_data)));
 
             struct s2n_blob wire_identity = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&wire_identity, test_bytes_data_2, sizeof(test_bytes_data_2)));
+            EXPECT_OK(s2n_blob_init(&wire_identity, test_bytes_data_2, sizeof(test_bytes_data_2)));
 
             struct s2n_stuffer wire_identities_in = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&wire_identities_in, 0));
@@ -1063,7 +1063,7 @@ int main(int argc, char **argv)
             {
                 /* Write invalid resumption PSK */
                 struct s2n_blob wire_identity = { 0 };
-                EXPECT_SUCCESS(s2n_blob_init(&wire_identity, test_bytes_data_2, sizeof(test_bytes_data_2)));
+                EXPECT_OK(s2n_blob_init(&wire_identity, test_bytes_data_2, sizeof(test_bytes_data_2)));
                 EXPECT_OK(s2n_write_test_identity(&wire_identities_in, &wire_identity));
 
                 /* Write valid resumption PSK */
@@ -1095,7 +1095,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_connection_set_config(conn, config_with_cb));
 
                 struct s2n_blob wire_identity = { 0 };
-                EXPECT_SUCCESS(s2n_blob_init(&wire_identity, test_bytes_data_2, sizeof(test_bytes_data_2)));
+                EXPECT_OK(s2n_blob_init(&wire_identity, test_bytes_data_2, sizeof(test_bytes_data_2)));
                 EXPECT_OK(s2n_write_test_identity(&wire_identities_in, &wire_identity));
 
                 EXPECT_ERROR(s2n_client_psk_recv_identity_list(conn, &wire_identities_in));
@@ -1127,14 +1127,14 @@ int main(int argc, char **argv)
         uint8_t valid_binder_data[SHA256_DIGEST_LENGTH] = { 0 };
 
         struct s2n_blob partial_client_hello = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&partial_client_hello,
+        EXPECT_OK(s2n_blob_init(&partial_client_hello,
                 partial_client_hello_data, sizeof(partial_client_hello_data)));
 
         struct s2n_blob binder_hash = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&binder_hash, binder_hash_data, sizeof(binder_hash_data)));
+        EXPECT_OK(s2n_blob_init(&binder_hash, binder_hash_data, sizeof(binder_hash_data)));
 
         struct s2n_blob valid_binder = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&valid_binder, valid_binder_data, sizeof(valid_binder_data)));
+        EXPECT_OK(s2n_blob_init(&valid_binder, valid_binder_data, sizeof(valid_binder_data)));
 
         struct s2n_connection *conn;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));

--- a/tests/unit/s2n_connection_protocol_versions_test.c
+++ b/tests/unit/s2n_connection_protocol_versions_test.c
@@ -54,7 +54,7 @@ static int s2n_overwrite_client_hello_cb(struct s2n_connection *conn, void *ctx)
 
     if (context->extension_length) {
         struct s2n_blob supported_versions_blob = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&supported_versions_blob, context->supported_versions_data,
+        EXPECT_OK(s2n_blob_init(&supported_versions_blob, context->supported_versions_data,
                 sizeof(context->supported_versions_data)));
 
         struct s2n_client_hello *client_hello = s2n_connection_get_client_hello(conn);

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -745,7 +745,7 @@ int main(int argc, char **argv)
             /* Test with static buffer */
             for (size_t i = 0; i < 3; i++) {
                 struct s2n_blob static_blob = { 0 };
-                EXPECT_SUCCESS(s2n_blob_init(&static_blob, conn->post_handshake.header_in,
+                EXPECT_OK(s2n_blob_init(&static_blob, conn->post_handshake.header_in,
                         sizeof(conn->post_handshake.header_in)));
                 EXPECT_SUCCESS(s2n_stuffer_init(&conn->post_handshake.in, &static_blob));
                 EXPECT_FALSE(conn->post_handshake.in.growable);
@@ -787,7 +787,7 @@ int main(int argc, char **argv)
             /* Test with static memory */
             for (size_t i = 0; i < 3; i++) {
                 struct s2n_blob static_blob = { 0 };
-                EXPECT_SUCCESS(s2n_blob_init(&static_blob, conn->post_handshake.header_in,
+                EXPECT_OK(s2n_blob_init(&static_blob, conn->post_handshake.header_in,
                         sizeof(conn->post_handshake.header_in)));
                 EXPECT_SUCCESS(s2n_stuffer_init(&conn->post_handshake.in, &static_blob));
                 EXPECT_FALSE(conn->post_handshake.in.growable);

--- a/tests/unit/s2n_drbg_test.c
+++ b/tests/unit/s2n_drbg_test.c
@@ -259,7 +259,7 @@ int nist_fake_entropy_init_cleanup(void)
 int nist_fake_128_entropy_data(void *data, uint32_t size)
 {
     struct s2n_blob blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&blob, data, size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&blob, data, size));
 
     POSIX_GUARD(s2n_stuffer_read(&nist_aes128_reference_entropy, &blob));
 
@@ -269,7 +269,7 @@ int nist_fake_128_entropy_data(void *data, uint32_t size)
 int nist_fake_256_entropy_data(void *data, uint32_t size)
 {
     struct s2n_blob blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&blob, data, size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&blob, data, size));
 
     POSIX_GUARD(s2n_stuffer_read(&nist_aes256_reference_entropy, &blob));
 
@@ -290,7 +290,7 @@ int check_drgb_version(s2n_drbg_mode mode, int (*generator)(void *, uint32_t), i
         uint8_t ps[S2N_DRBG_MAX_SEED_SIZE] = { 0 };
         struct s2n_drbg nist_drbg = { 0 };
         struct s2n_blob personalization_string = { 0 };
-        POSIX_GUARD(s2n_blob_init(&personalization_string, ps, personalization_size));
+        POSIX_GUARD_RESULT(s2n_blob_init(&personalization_string, ps, personalization_size));
 
         /* Read the next personalization string */
         POSIX_GUARD(s2n_stuffer_read(&personalization, &personalization_string));
@@ -309,7 +309,7 @@ int check_drgb_version(s2n_drbg_mode mode, int (*generator)(void *, uint32_t), i
         /* Generate 512 bits (FIRST CALL) */
         uint8_t out[64];
         struct s2n_blob generated = { 0 };
-        POSIX_GUARD(s2n_blob_init(&generated, out, 64));
+        POSIX_GUARD_RESULT(s2n_blob_init(&generated, out, 64));
         POSIX_GUARD_RESULT(s2n_drbg_generate(&nist_drbg, &generated));
 
         POSIX_GUARD(s2n_stuffer_read_bytes(&reference_values, nist_v, sizeof(nist_v)));
@@ -346,7 +346,7 @@ int main(int argc, char **argv)
     struct s2n_drbg aes128_drbg = { 0 };
     struct s2n_drbg aes256_pr_drbg = { 0 };
     struct s2n_blob blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&blob, data, 64));
+    EXPECT_OK(s2n_blob_init(&blob, data, 64));
 
     EXPECT_OK(s2n_drbg_instantiate(&aes128_drbg, &blob, S2N_AES_128_CTR_NO_DF_PR));
     EXPECT_OK(s2n_drbg_instantiate(&aes256_pr_drbg, &blob, S2N_AES_256_CTR_NO_DF_PR));

--- a/tests/unit/s2n_early_data_io_api_test.c
+++ b/tests/unit/s2n_early_data_io_api_test.c
@@ -454,7 +454,7 @@ int main(int argc, char **argv)
 
             struct s2n_blob payload_blob = { 0 };
             struct s2n_stuffer payload_stuffer = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&payload_blob, actual_payload, sizeof(actual_payload)));
+            EXPECT_OK(s2n_blob_init(&payload_blob, actual_payload, sizeof(actual_payload)));
             EXPECT_SUCCESS(s2n_stuffer_init(&payload_stuffer, &payload_blob));
             EXPECT_SUCCESS(s2n_stuffer_skip_write(&payload_stuffer, data_size));
 

--- a/tests/unit/s2n_ecdsa_test.c
+++ b/tests/unit/s2n_ecdsa_test.c
@@ -103,13 +103,13 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
 
-    EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
+    EXPECT_OK(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
     EXPECT_SUCCESS(s2n_stuffer_write(&certificate_in, &b));
 
-    EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) private_key_pem, strlen(private_key_pem) + 1));
+    EXPECT_OK(s2n_blob_init(&b, (uint8_t *) private_key_pem, strlen(private_key_pem) + 1));
     EXPECT_SUCCESS(s2n_stuffer_write(&ecdsa_key_in, &b));
 
-    EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) unmatched_private_key, sizeof(unmatched_private_key)));
+    EXPECT_OK(s2n_blob_init(&b, (uint8_t *) unmatched_private_key, sizeof(unmatched_private_key)));
     EXPECT_SUCCESS(s2n_stuffer_write(&unmatched_ecdsa_key_in, &b));
 
     int type = 0;
@@ -126,7 +126,7 @@ int main(int argc, char **argv)
     uint32_t available_size = 0;
 
     available_size = s2n_stuffer_data_available(&certificate_out);
-    EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
+    EXPECT_OK(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
     EXPECT_OK(s2n_asn1der_to_public_key_and_type(&pub_key, &pkey_type, &b));
 
     /* Test without a type hint */
@@ -134,11 +134,11 @@ int main(int argc, char **argv)
     EXPECT_NOT_EQUAL(wrong_type, EVP_PKEY_EC);
 
     available_size = s2n_stuffer_data_available(&ecdsa_key_out);
-    EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&ecdsa_key_out, available_size), available_size));
+    EXPECT_OK(s2n_blob_init(&b, s2n_stuffer_raw_read(&ecdsa_key_out, available_size), available_size));
     EXPECT_OK(s2n_asn1der_to_private_key(&priv_key, &b, wrong_type));
 
     available_size = s2n_stuffer_data_available(&unmatched_ecdsa_key_out);
-    EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&unmatched_ecdsa_key_out, available_size), available_size));
+    EXPECT_OK(s2n_blob_init(&b, s2n_stuffer_raw_read(&unmatched_ecdsa_key_out, available_size), available_size));
     EXPECT_OK(s2n_asn1der_to_private_key(&unmatched_priv_key, &b, wrong_type));
 
     /* Verify that the public/private key pair match */

--- a/tests/unit/s2n_extended_master_secret_test.c
+++ b/tests/unit/s2n_extended_master_secret_test.c
@@ -59,7 +59,7 @@ int main(int argc, char **argv)
             struct s2n_stuffer ticket = { 0 };
             struct s2n_blob ticket_blob = { 0 };
             uint8_t ticket_data[S2N_TLS12_TICKET_SIZE_IN_BYTES] = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, ticket_data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
+            EXPECT_OK(s2n_blob_init(&ticket_blob, ticket_data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
             EXPECT_SUCCESS(s2n_stuffer_init(&ticket, &ticket_blob));
 
             /* Encrypt the ticket with EMS data */
@@ -98,7 +98,7 @@ int main(int argc, char **argv)
             struct s2n_stuffer ticket = { 0 };
             struct s2n_blob ticket_blob = { 0 };
             uint8_t ticket_data[S2N_TLS12_TICKET_SIZE_IN_BYTES] = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, ticket_data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
+            EXPECT_OK(s2n_blob_init(&ticket_blob, ticket_data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
             EXPECT_SUCCESS(s2n_stuffer_init(&ticket, &ticket_blob));
 
             /* Encrypt the ticket without EMS data */
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
             struct s2n_stuffer ticket = { 0 };
             struct s2n_blob ticket_blob = { 0 };
             uint8_t ticket_data[S2N_TLS12_TICKET_SIZE_IN_BYTES] = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, ticket_data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
+            EXPECT_OK(s2n_blob_init(&ticket_blob, ticket_data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
             EXPECT_SUCCESS(s2n_stuffer_init(&ticket, &ticket_blob));
 
             /* Encrypt the ticket with EMS data */

--- a/tests/unit/s2n_extension_list_process_test.c
+++ b/tests/unit/s2n_extension_list_process_test.c
@@ -45,7 +45,7 @@ static int s2n_setup_test_parsed_extension(const s2n_extension_type *extension_t
 
     POSIX_GUARD(extension_type->send(conn, stuffer));
     uint16_t extension_size = s2n_stuffer_data_available(stuffer);
-    POSIX_GUARD(s2n_blob_init(&parsed_extension->extension, s2n_stuffer_raw_read(stuffer, extension_size), extension_size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&parsed_extension->extension, s2n_stuffer_raw_read(stuffer, extension_size), extension_size));
 
     return S2N_SUCCESS;
 }
@@ -67,7 +67,7 @@ int main()
     {
         uint8_t extension_data[] = "data";
         struct s2n_blob extension_blob = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&extension_blob, extension_data, sizeof(extension_data)));
+        EXPECT_OK(s2n_blob_init(&extension_blob, extension_data, sizeof(extension_data)));
 
         const s2n_extension_type test_extension_type = {
             .iana_value = TLS_EXTENSION_SUPPORTED_VERSIONS,

--- a/tests/unit/s2n_fingerprint_ja3_test.c
+++ b/tests/unit/s2n_fingerprint_ja3_test.c
@@ -75,7 +75,7 @@ static S2N_RESULT s2n_validate_ja3_str(uint8_t *ja3, uint32_t ja3_size,
 {
     struct s2n_blob input_blob = { 0 };
     struct s2n_stuffer input = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&input_blob, ja3, ja3_size));
+    RESULT_GUARD(s2n_blob_init(&input_blob, ja3, ja3_size));
     RESULT_GUARD_POSIX(s2n_stuffer_init(&input, &input_blob));
     RESULT_GUARD_POSIX(s2n_stuffer_skip_write(&input, ja3_size));
 

--- a/tests/unit/s2n_handshake_fragment_test.c
+++ b/tests/unit/s2n_handshake_fragment_test.c
@@ -323,7 +323,7 @@ int main(int argc, char **argv)
         if (s2n_is_tls13_fully_supported()) {
             uint8_t early_data_bytes[] = "hello world";
             struct s2n_blob early_data = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&early_data, early_data_bytes, sizeof(early_data_bytes)));
+            EXPECT_OK(s2n_blob_init(&early_data, early_data_bytes, sizeof(early_data_bytes)));
 
             DEFER_CLEANUP(struct s2n_config *config = s2n_test_config_new(chain_and_key),
                     s2n_config_ptr_free);
@@ -346,7 +346,7 @@ int main(int argc, char **argv)
 
             uint8_t recv_buffer[sizeof(early_data_bytes)] = { 0 };
             struct s2n_blob early_data_received = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&early_data_received, recv_buffer, sizeof(recv_buffer)));
+            EXPECT_OK(s2n_blob_init(&early_data_received, recv_buffer, sizeof(recv_buffer)));
 
             EXPECT_ERROR_WITH_ERRNO(s2n_negotiate_test_server_and_client_with_early_data(server_conn, client_conn,
                                             &early_data, &early_data_received),

--- a/tests/unit/s2n_handshake_io_early_data_test.c
+++ b/tests/unit/s2n_handshake_io_early_data_test.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
     struct s2n_cipher_suite *test_cipher_suite = &s2n_tls13_aes_256_gcm_sha384;
     uint8_t test_key_bytes[S2N_TLS13_SECRET_MAX_LEN] = "gibberish key";
     struct s2n_blob test_key = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&test_key, test_key_bytes,
+    EXPECT_OK(s2n_blob_init(&test_key, test_key_bytes,
             test_cipher_suite->record_alg->cipher->key_material_size));
 
     /**

--- a/tests/unit/s2n_hash_all_algs_test.c
+++ b/tests/unit/s2n_hash_all_algs_test.c
@@ -65,7 +65,7 @@ S2N_RESULT s2n_hash_test_state(struct s2n_hash_state *hash_state, s2n_hash_algor
     {
         struct s2n_blob result = { 0 };
         uint8_t result_data[OUTPUT_DATA_SIZE] = { 0 };
-        RESULT_GUARD_POSIX(s2n_blob_init(&result, result_data, OUTPUT_DATA_SIZE));
+        RESULT_GUARD(s2n_blob_init(&result, result_data, OUTPUT_DATA_SIZE));
 
         RESULT_GUARD_POSIX(s2n_hash_new(&hash_copy));
         RESULT_GUARD_POSIX(s2n_hash_copy(&hash_copy, hash_state));
@@ -120,7 +120,7 @@ S2N_RESULT s2n_hash_test(s2n_hash_algorithm hash_alg, struct s2n_blob *digest)
     {
         struct s2n_blob result = { 0 };
         uint8_t result_data[OUTPUT_DATA_SIZE] = { 0 };
-        RESULT_GUARD_POSIX(s2n_blob_init(&result, result_data, OUTPUT_DATA_SIZE));
+        RESULT_GUARD(s2n_blob_init(&result, result_data, OUTPUT_DATA_SIZE));
 
         RESULT_GUARD_POSIX(s2n_hash_reset(&hash_state));
         RESULT_ENSURE_EQ(hash_state.currently_in_hash, 0);
@@ -143,11 +143,11 @@ int main(int argc, char **argv)
     for (s2n_hash_algorithm hash_alg = 0; hash_alg < S2N_HASH_SENTINEL; hash_alg++) {
         struct s2n_blob actual_result = { 0 };
         uint8_t actual_result_data[OUTPUT_DATA_SIZE] = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&actual_result, actual_result_data, OUTPUT_DATA_SIZE));
+        EXPECT_OK(s2n_blob_init(&actual_result, actual_result_data, OUTPUT_DATA_SIZE));
 
         struct s2n_blob expected_result = { 0 };
         uint8_t expected_result_data[OUTPUT_DATA_SIZE] = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&expected_result, expected_result_data, OUTPUT_DATA_SIZE));
+        EXPECT_OK(s2n_blob_init(&expected_result, expected_result_data, OUTPUT_DATA_SIZE));
         EXPECT_SUCCESS(s2n_hex_string_to_bytes((const uint8_t *) expected_result_hex[hash_alg], &expected_result));
 
         EXPECT_OK(s2n_hash_test(hash_alg, &actual_result));

--- a/tests/unit/s2n_hash_test.c
+++ b/tests/unit/s2n_hash_test.c
@@ -34,7 +34,7 @@ int main(int argc, char **argv)
     struct s2n_stuffer output = { 0 };
     struct s2n_hash_state hash, copy;
     struct s2n_blob out = { 0 };
-    POSIX_GUARD(s2n_blob_init(&out, output_pad, sizeof(output_pad)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&out, output_pad, sizeof(output_pad)));
     uint64_t bytes_in_hash;
 
     BEGIN_TEST();

--- a/tests/unit/s2n_hkdf_test.c
+++ b/tests/unit/s2n_hkdf_test.c
@@ -421,13 +421,13 @@ int main(int argc, char **argv)
     for (uint8_t i = 0; i < NUM_TESTS; i++) {
         struct hkdf_test_vector *test = &tests[i];
 
-        EXPECT_SUCCESS(s2n_blob_init(&in_key_blob, test->in_key, test->in_key_len));
-        EXPECT_SUCCESS(s2n_blob_init(&salt_blob, test->salt, test->salt_len));
-        EXPECT_SUCCESS(s2n_blob_init(&info_blob, test->info, test->info_len));
-        EXPECT_SUCCESS(s2n_blob_init(&actual_prk_blob, test->pseudo_rand_key, test->prk_len));
-        EXPECT_SUCCESS(s2n_blob_init(&actual_output_blob, test->output, test->output_len));
-        EXPECT_SUCCESS(s2n_blob_init(&prk_result, prk_pad, sizeof(prk_pad)));
-        EXPECT_SUCCESS(s2n_blob_init(&out_result, output_pad, sizeof(output_pad)));
+        EXPECT_OK(s2n_blob_init(&in_key_blob, test->in_key, test->in_key_len));
+        EXPECT_OK(s2n_blob_init(&salt_blob, test->salt, test->salt_len));
+        EXPECT_OK(s2n_blob_init(&info_blob, test->info, test->info_len));
+        EXPECT_OK(s2n_blob_init(&actual_prk_blob, test->pseudo_rand_key, test->prk_len));
+        EXPECT_OK(s2n_blob_init(&actual_output_blob, test->output, test->output_len));
+        EXPECT_OK(s2n_blob_init(&prk_result, prk_pad, sizeof(prk_pad)));
+        EXPECT_OK(s2n_blob_init(&out_result, output_pad, sizeof(output_pad)));
 
         EXPECT_SUCCESS(s2n_hkdf_extract(&hmac, test->alg, &salt_blob, &in_key_blob, &prk_result));
         EXPECT_EQUAL(memcmp(prk_pad, actual_prk_blob.data, actual_prk_blob.size), 0);
@@ -463,9 +463,9 @@ int main(int argc, char **argv)
      */
     uint8_t error_out_pad[5101];
     struct s2n_blob error_out = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&error_out, error_out_pad, sizeof(error_out_pad)));
+    EXPECT_OK(s2n_blob_init(&error_out, error_out_pad, sizeof(error_out_pad)));
     struct s2n_blob zero_out = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&zero_out, output_pad, 0));
+    EXPECT_OK(s2n_blob_init(&zero_out, output_pad, 0));
 
     s2n_hmac_algorithm alg = S2N_HMAC_SHA1;
 

--- a/tests/unit/s2n_hmac_test.c
+++ b/tests/unit/s2n_hmac_test.c
@@ -38,7 +38,7 @@ int main(int argc, char **argv)
     struct s2n_hmac_state hmac, copy, cmac;
 
     struct s2n_blob out = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&out, output_pad, sizeof(output_pad)));
+    EXPECT_OK(s2n_blob_init(&out, output_pad, sizeof(output_pad)));
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());

--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -35,7 +35,7 @@ static S2N_RESULT s2n_write_uint64(uint64_t input, uint8_t *output)
 {
     struct s2n_blob blob = { 0 };
     struct s2n_stuffer stuffer = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&blob, output, S2N_TLS_SEQUENCE_NUM_LEN));
+    EXPECT_OK(s2n_blob_init(&blob, output, S2N_TLS_SEQUENCE_NUM_LEN));
     EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &blob));
     EXPECT_SUCCESS(s2n_stuffer_write_uint64(&stuffer, input));
     return S2N_RESULT_OK;
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
             uint8_t key_update_data[S2N_KEY_UPDATE_MESSAGE_SIZE];
             struct s2n_blob key_update_blob = { 0 };
             struct s2n_stuffer key_update_stuffer = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&key_update_blob, key_update_data, sizeof(key_update_data)));
+            EXPECT_OK(s2n_blob_init(&key_update_blob, key_update_data, sizeof(key_update_data)));
             EXPECT_SUCCESS(s2n_stuffer_init(&key_update_stuffer, &key_update_blob));
 
             /* Write key update message */
@@ -449,7 +449,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, client_conn));
 
             struct s2n_blob sequence_number = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&sequence_number,
+            EXPECT_OK(s2n_blob_init(&sequence_number,
                     client_conn->secure->client_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
             EXPECT_OK(s2n_write_uint64(start, client_conn->secure->client_sequence_number));
 
@@ -487,7 +487,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, client_conn));
 
             struct s2n_blob sequence_number = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&sequence_number,
+            EXPECT_OK(s2n_blob_init(&sequence_number,
                     client_conn->secure->client_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
             EXPECT_OK(s2n_write_uint64(start, client_conn->secure->client_sequence_number));
 
@@ -538,7 +538,7 @@ int main(int argc, char **argv)
         {
             struct s2n_blob sequence_number = { 0 };
             uint8_t sequence_number_bytes[S2N_TLS_SEQUENCE_NUM_LEN] = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&sequence_number, sequence_number_bytes, sizeof(sequence_number_bytes)));
+            EXPECT_OK(s2n_blob_init(&sequence_number, sequence_number_bytes, sizeof(sequence_number_bytes)));
 
             DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
             EXPECT_NOT_NULL(conn);
@@ -584,7 +584,7 @@ int main(int argc, char **argv)
         {
             struct s2n_blob sequence_number = { 0 };
             uint8_t sequence_number_bytes[S2N_TLS_SEQUENCE_NUM_LEN] = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&sequence_number, sequence_number_bytes, sizeof(sequence_number_bytes)));
+            EXPECT_OK(s2n_blob_init(&sequence_number, sequence_number_bytes, sizeof(sequence_number_bytes)));
 
             DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
             EXPECT_NOT_NULL(conn);

--- a/tests/unit/s2n_ktls_io_test.c
+++ b/tests/unit/s2n_ktls_io_test.c
@@ -100,7 +100,7 @@ int main(int argc, char **argv)
     /* test data */
     uint8_t test_data[S2N_TLS_MAXIMUM_FRAGMENT_LENGTH] = { 0 };
     struct s2n_blob test_data_blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&test_data_blob, test_data, sizeof(test_data)));
+    EXPECT_OK(s2n_blob_init(&test_data_blob, test_data, sizeof(test_data)));
     EXPECT_OK(s2n_get_public_random_data(&test_data_blob));
 
     /* Test s2n_ktls_set_control_data and s2n_ktls_get_control_data */

--- a/tests/unit/s2n_ktls_test.c
+++ b/tests/unit/s2n_ktls_test.c
@@ -105,7 +105,7 @@ static S2N_RESULT s2n_test_setsockopt_set_ktls_info(struct s2n_ktls_crypto_info_
     S2N_BLOB_EXPECT_EQUAL(inputs->iv, s2n_test_setsockopt_expected.crypto_info_inputs.iv);
     S2N_BLOB_EXPECT_EQUAL(inputs->key, s2n_test_setsockopt_expected.crypto_info_inputs.key);
     S2N_BLOB_EXPECT_EQUAL(inputs->seq, s2n_test_setsockopt_expected.crypto_info_inputs.seq);
-    RESULT_GUARD_POSIX(s2n_blob_init(&crypto_info->value,
+    RESULT_GUARD(s2n_blob_init(&crypto_info->value,
             (void *) &s2n_test_setsockopt_expected.crypto_info_inputs,
             sizeof(s2n_test_setsockopt_expected.crypto_info_inputs)));
     return S2N_RESULT_OK;
@@ -158,12 +158,12 @@ int main(int argc, char **argv)
         struct s2n_crypto_parameters crypto_params = { 0 };
 
         struct s2n_blob test_iv = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&test_iv, crypto_params.client_implicit_iv,
+        EXPECT_OK(s2n_blob_init(&test_iv, crypto_params.client_implicit_iv,
                 sizeof(crypto_params.client_implicit_iv)));
         EXPECT_OK(s2n_get_public_random_data(&test_iv));
 
         struct s2n_blob test_seq = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&test_seq, crypto_params.client_sequence_number,
+        EXPECT_OK(s2n_blob_init(&test_seq, crypto_params.client_sequence_number,
                 sizeof(crypto_params.client_sequence_number)));
         EXPECT_OK(s2n_get_public_random_data(&test_seq));
 
@@ -449,17 +449,17 @@ int main(int argc, char **argv)
             crypto_params.cipher_suite = &test_cipher_suite;
 
             struct s2n_blob server_iv = { 0 }, client_iv = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&server_iv, crypto_params.server_implicit_iv,
+            EXPECT_OK(s2n_blob_init(&server_iv, crypto_params.server_implicit_iv,
                     sizeof(crypto_params.server_implicit_iv)));
-            EXPECT_SUCCESS(s2n_blob_init(&client_iv, crypto_params.client_implicit_iv,
+            EXPECT_OK(s2n_blob_init(&client_iv, crypto_params.client_implicit_iv,
                     sizeof(crypto_params.client_implicit_iv)));
             EXPECT_OK(s2n_get_public_random_data(&server_iv));
             EXPECT_OK(s2n_get_public_random_data(&client_iv));
 
             struct s2n_blob server_seq = { 0 }, client_seq = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&server_seq, crypto_params.server_sequence_number,
+            EXPECT_OK(s2n_blob_init(&server_seq, crypto_params.server_sequence_number,
                     sizeof(crypto_params.server_sequence_number)));
-            EXPECT_SUCCESS(s2n_blob_init(&client_seq, crypto_params.client_sequence_number,
+            EXPECT_OK(s2n_blob_init(&client_seq, crypto_params.client_sequence_number,
                     sizeof(crypto_params.client_sequence_number)));
             EXPECT_OK(s2n_get_public_random_data(&server_seq));
             EXPECT_OK(s2n_get_public_random_data(&client_seq));

--- a/tests/unit/s2n_ktls_test_utils_test.c
+++ b/tests/unit/s2n_ktls_test_utils_test.c
@@ -35,7 +35,7 @@ int main(int argc, char **argv)
     /* test data */
     uint8_t test_data[S2N_TLS_MAXIMUM_FRAGMENT_LENGTH] = { 0 };
     struct s2n_blob test_data_blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&test_data_blob, test_data, sizeof(test_data)));
+    EXPECT_OK(s2n_blob_init(&test_data_blob, test_data, sizeof(test_data)));
     EXPECT_OK(s2n_get_public_random_data(&test_data_blob));
 
     /* Test the sendmsg mock IO stuffer implementation */

--- a/tests/unit/s2n_openssl_x509_test.c
+++ b/tests/unit/s2n_openssl_x509_test.c
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
                 &cert_chain_len, S2N_MAX_TEST_PEM_SIZE));
 
         struct s2n_blob cert_chain_blob = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&cert_chain_blob, cert_chain_data, cert_chain_len));
+        EXPECT_OK(s2n_blob_init(&cert_chain_blob, cert_chain_data, cert_chain_len));
 
         DEFER_CLEANUP(struct s2n_stuffer cert_chain_stuffer = { 0 }, s2n_stuffer_free);
         EXPECT_SUCCESS(s2n_stuffer_init_written(&cert_chain_stuffer, &cert_chain_blob));
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
                 &cert_chain_len, S2N_MAX_TEST_PEM_SIZE));
 
         struct s2n_blob cert_chain_blob = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&cert_chain_blob, cert_chain_data, cert_chain_len));
+        EXPECT_OK(s2n_blob_init(&cert_chain_blob, cert_chain_data, cert_chain_len));
 
         DEFER_CLEANUP(struct s2n_stuffer cert_chain_stuffer = { 0 }, s2n_stuffer_free);
         EXPECT_SUCCESS(s2n_stuffer_init_written(&cert_chain_stuffer, &cert_chain_blob));

--- a/tests/unit/s2n_override_openssl_random_test.c
+++ b/tests/unit/s2n_override_openssl_random_test.c
@@ -51,7 +51,7 @@ struct s2n_stuffer test_entropy = { 0 };
 int s2n_entropy_generator(void *data, uint32_t size)
 {
     struct s2n_blob blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&blob, data, size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&blob, data, size));
     POSIX_GUARD(s2n_stuffer_read(&test_entropy, &blob));
     return 0;
 }
@@ -78,13 +78,13 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(bytes_used, 0);
 
     /* Parse the DH params */
-    EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) dhparams_pem, strlen(dhparams_pem) + 1));
+    EXPECT_OK(s2n_blob_init(&b, (uint8_t *) dhparams_pem, strlen(dhparams_pem) + 1));
     EXPECT_SUCCESS(s2n_stuffer_alloc(&dhparams_in, b.size));
     EXPECT_SUCCESS(s2n_stuffer_alloc(&dhparams_out, b.size));
     EXPECT_SUCCESS(s2n_stuffer_write(&dhparams_in, &b));
     EXPECT_SUCCESS(s2n_stuffer_dhparams_from_pem(&dhparams_in, &dhparams_out));
     uint32_t available_size = s2n_stuffer_data_available(&dhparams_out);
-    EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&dhparams_out, available_size), available_size));
+    EXPECT_OK(s2n_blob_init(&b, s2n_stuffer_raw_read(&dhparams_out, available_size), available_size));
     EXPECT_SUCCESS(s2n_pkcs3_to_dh_params(&dh_params, &b));
 
     EXPECT_SUCCESS(s2n_dh_generate_ephemeral_key(&dh_params));

--- a/tests/unit/s2n_pem_rsa_dhe_test.c
+++ b/tests/unit/s2n_pem_rsa_dhe_test.c
@@ -87,13 +87,13 @@ int main(int argc, char **argv)
     EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
     EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
 
-    EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) leaf_cert_pem, strlen(leaf_cert_pem) + 1));
+    EXPECT_OK(s2n_blob_init(&b, (uint8_t *) leaf_cert_pem, strlen(leaf_cert_pem) + 1));
     EXPECT_SUCCESS(s2n_stuffer_write(&certificate_in, &b));
 
-    EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) private_key_pem, strlen(private_key_pem) + 1));
+    EXPECT_OK(s2n_blob_init(&b, (uint8_t *) private_key_pem, strlen(private_key_pem) + 1));
     EXPECT_SUCCESS(s2n_stuffer_write(&rsa_key_in, &b));
 
-    EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) dhparams_pem, strlen(dhparams_pem) + 1));
+    EXPECT_OK(s2n_blob_init(&b, (uint8_t *) dhparams_pem, strlen(dhparams_pem) + 1));
     EXPECT_SUCCESS(s2n_stuffer_write(&dhparams_in, &b));
 
     int type = 0;
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
 
     uint32_t available_size = 0;
     available_size = s2n_stuffer_data_available(&certificate_out);
-    EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
+    EXPECT_OK(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
     EXPECT_OK(s2n_asn1der_to_public_key_and_type(&pub_key, &pkey_type, &b));
 
     /* Test without a type hint */
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
     EXPECT_NOT_EQUAL(wrong_type, EVP_PKEY_RSA);
 
     available_size = s2n_stuffer_data_available(&rsa_key_out);
-    EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&rsa_key_out, available_size), available_size));
+    EXPECT_OK(s2n_blob_init(&b, s2n_stuffer_raw_read(&rsa_key_out, available_size), available_size));
     EXPECT_OK(s2n_asn1der_to_private_key(&priv_key, &b, wrong_type));
 
     EXPECT_SUCCESS(s2n_pkey_match(&pub_key, &priv_key));
@@ -127,7 +127,7 @@ int main(int argc, char **argv)
 
     struct s2n_dh_params dh_params = { 0 };
     available_size = s2n_stuffer_data_available(&dhparams_out);
-    EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&dhparams_out, available_size), available_size));
+    EXPECT_OK(s2n_blob_init(&b, s2n_stuffer_raw_read(&dhparams_out, available_size), available_size));
     EXPECT_SUCCESS(s2n_pkcs3_to_dh_params(&dh_params, &b));
 
     EXPECT_SUCCESS(s2n_config_add_dhparams(config, dhparams_pem));

--- a/tests/unit/s2n_post_handshake_send_test.c
+++ b/tests/unit/s2n_post_handshake_send_test.c
@@ -42,7 +42,7 @@ static S2N_RESULT s2n_get_actual_record_count(uint8_t *cur_seq_num_bytes,
     uint64_t cur_seq_num = 0;
     struct s2n_blob blob = { 0 };
     struct s2n_stuffer stuffer = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&blob, cur_seq_num_bytes, S2N_TLS_SEQUENCE_NUM_LEN));
+    RESULT_GUARD(s2n_blob_init(&blob, cur_seq_num_bytes, S2N_TLS_SEQUENCE_NUM_LEN));
     RESULT_GUARD_POSIX(s2n_stuffer_init(&stuffer, &blob));
     RESULT_GUARD_POSIX(s2n_stuffer_skip_write(&stuffer, S2N_TLS_SEQUENCE_NUM_LEN));
     RESULT_GUARD_POSIX(s2n_stuffer_read_uint64(&stuffer, &cur_seq_num));

--- a/tests/unit/s2n_post_handshake_test.c
+++ b/tests/unit/s2n_post_handshake_test.c
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
             for (size_t i = 0; i < num_key_updates; i++) {
                 uint8_t data[KEY_UPDATE_MESSAGE_SIZE] = { 0 };
                 struct s2n_blob key_update_message = { 0 };
-                EXPECT_SUCCESS(s2n_blob_init(&key_update_message, data, sizeof(data)));
+                EXPECT_OK(s2n_blob_init(&key_update_message, data, sizeof(data)));
                 EXPECT_SUCCESS(s2n_key_update_write(&key_update_message));
                 EXPECT_SUCCESS(s2n_stuffer_write_bytes(&conn->in, key_update_message.data, key_update_message.size));
             }

--- a/tests/unit/s2n_prf_key_material_test.c
+++ b/tests/unit/s2n_prf_key_material_test.c
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
     /* prepare test data */
     uint8_t test_data[S2N_MAX_KEY_BLOCK_LEN] = { 0 };
     struct s2n_blob test_data_blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&test_data_blob, test_data, sizeof(test_data)));
+    EXPECT_OK(s2n_blob_init(&test_data_blob, test_data, sizeof(test_data)));
     EXPECT_OK(s2n_get_public_random_data(&test_data_blob));
 
     /* fuzz s2n_key_material_init with different mac, key, iv sizes */

--- a/tests/unit/s2n_protocol_preferences_test.c
+++ b/tests/unit/s2n_protocol_preferences_test.c
@@ -224,7 +224,7 @@ int main(int argc, char **argv)
     {
         uint8_t protocol3[] = "protocol3";
         struct s2n_blob protocol3_blob = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&protocol3_blob, protocol3, sizeof(protocol3)));
+        EXPECT_OK(s2n_blob_init(&protocol3_blob, protocol3, sizeof(protocol3)));
 
         /* Safety checks */
         {

--- a/tests/unit/s2n_psk_offered_test.c
+++ b/tests/unit/s2n_psk_offered_test.c
@@ -358,7 +358,7 @@ int main(int argc, char **argv)
         {
             uint8_t wire_identity[] = "identity";
             DEFER_CLEANUP(struct s2n_offered_psk *psk = s2n_offered_psk_new(), s2n_offered_psk_free);
-            EXPECT_SUCCESS(s2n_blob_init(&psk->identity, wire_identity, sizeof(wire_identity)));
+            EXPECT_OK(s2n_blob_init(&psk->identity, wire_identity, sizeof(wire_identity)));
 
             uint8_t *data = NULL;
             uint16_t size = 0;
@@ -404,7 +404,7 @@ int main(int argc, char **argv)
         const uint16_t wire_index = 5;
         uint8_t wire_identity_bytes[] = "wire_identity_bytes";
         struct s2n_blob wire_identity = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&wire_identity, wire_identity_bytes, sizeof(wire_identity_bytes)));
+        EXPECT_OK(s2n_blob_init(&wire_identity, wire_identity_bytes, sizeof(wire_identity_bytes)));
         struct s2n_offered_psk offered_psk = { .identity = wire_identity, .wire_index = wire_index };
 
         struct s2n_offered_psk_list offered_psk_list = { .conn = conn };

--- a/tests/unit/s2n_psk_test.c
+++ b/tests/unit/s2n_psk_test.c
@@ -332,7 +332,7 @@ int main(int argc, char **argv)
         uint8_t test_value[] = TEST_VALUE_1;
 
         struct s2n_blob client_hello_prefix = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&client_hello_prefix, test_value, sizeof(test_value)));
+        EXPECT_OK(s2n_blob_init(&client_hello_prefix, test_value, sizeof(test_value)));
 
         /* Write two binders.
          * There are no available test vectors for multiple PSKs, but we should at least
@@ -484,7 +484,7 @@ int main(int argc, char **argv)
 
             struct s2n_blob hash_value = { 0 };
             uint8_t hash_value_data[SHA256_DIGEST_LENGTH];
-            EXPECT_SUCCESS(s2n_blob_init(&hash_value, hash_value_data, sizeof(hash_value_data)));
+            EXPECT_OK(s2n_blob_init(&hash_value, hash_value_data, sizeof(hash_value_data)));
 
             EXPECT_SUCCESS(s2n_psk_calculate_binder_hash(conn, S2N_HMAC_SHA256, &client_hello_prefix, &hash_value));
             S2N_BLOB_EXPECT_EQUAL(hash_value, binder_hash);
@@ -500,7 +500,7 @@ int main(int argc, char **argv)
 
             struct s2n_blob binder_value = { 0 };
             uint8_t binder_value_data[SHA256_DIGEST_LENGTH];
-            EXPECT_SUCCESS(s2n_blob_init(&binder_value, binder_value_data, sizeof(binder_value_data)));
+            EXPECT_OK(s2n_blob_init(&binder_value, binder_value_data, sizeof(binder_value_data)));
 
             EXPECT_SUCCESS(s2n_psk_calculate_binder(&test_psk, &binder_hash, &binder_value));
             S2N_BLOB_EXPECT_EQUAL(test_psk.early_secret, early_secret);
@@ -518,7 +518,7 @@ int main(int argc, char **argv)
 
             struct s2n_blob binder_value = { 0 };
             uint8_t binder_value_data[SHA256_DIGEST_LENGTH];
-            EXPECT_SUCCESS(s2n_blob_init(&binder_value, binder_value_data, sizeof(binder_value_data)));
+            EXPECT_OK(s2n_blob_init(&binder_value, binder_value_data, sizeof(binder_value_data)));
 
             EXPECT_SUCCESS(s2n_psk_verify_binder(conn, &test_psk, &client_hello_prefix, &finished_binder));
             S2N_BLOB_EXPECT_EQUAL(test_psk.early_secret, early_secret);
@@ -539,7 +539,7 @@ int main(int argc, char **argv)
 
             struct s2n_blob binder_value = { 0 };
             uint8_t binder_value_data[SHA256_DIGEST_LENGTH];
-            EXPECT_SUCCESS(s2n_blob_init(&binder_value, binder_value_data, sizeof(binder_value_data)));
+            EXPECT_OK(s2n_blob_init(&binder_value, binder_value_data, sizeof(binder_value_data)));
 
             EXPECT_FAILURE(s2n_psk_verify_binder(conn, &test_psk, &client_hello_prefix, incorrect_binder_value));
             S2N_BLOB_EXPECT_EQUAL(test_psk.early_secret, early_secret);

--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -109,7 +109,7 @@ static S2N_RESULT s2n_basic_pattern_tests(S2N_RESULT (*s2n_get_random_data_cb)(s
     uint8_t bit_set_run[8];
     uint8_t data[MAX_RANDOM_GENERATE_DATA_SIZE];
     struct s2n_blob blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&blob, data, 0));
+    EXPECT_OK(s2n_blob_init(&blob, data, 0));
     int trailing_zeros[8] = { 0 };
 
     for (int size = 0; size < MAX_RANDOM_GENERATE_DATA_SIZE; size++) {
@@ -180,7 +180,7 @@ static S2N_RESULT s2n_tests_get_range(void)
     /* The type of the `bound` parameter in s2n_public_random() is signed */
     int64_t chosen_upper_bound = 0;
     struct s2n_blob upper_bound_blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&upper_bound_blob, (void *) &chosen_upper_bound, sizeof(chosen_upper_bound)));
+    EXPECT_OK(s2n_blob_init(&upper_bound_blob, (void *) &chosen_upper_bound, sizeof(chosen_upper_bound)));
 
     /* 0 is not a legal upper bound */
     chosen_upper_bound = 0;
@@ -272,7 +272,7 @@ void *s2n_thread_test_cb(void *thread_comms)
     struct random_communication *thread_comms_ptr = (struct random_communication *) thread_comms;
 
     struct s2n_blob thread_blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&thread_blob, thread_comms_ptr->thread_data, RANDOM_GENERATE_DATA_SIZE));
+    EXPECT_OK(s2n_blob_init(&thread_blob, thread_comms_ptr->thread_data, RANDOM_GENERATE_DATA_SIZE));
 
     EXPECT_NOT_NULL(thread_comms_ptr->s2n_get_random_data_cb_1);
     EXPECT_OK(thread_comms_ptr->s2n_get_random_data_cb_1(&thread_blob));
@@ -292,7 +292,7 @@ static S2N_RESULT s2n_thread_test(
 {
     uint8_t data[RANDOM_GENERATE_DATA_SIZE];
     struct s2n_blob blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&blob, data, 0));
+    EXPECT_OK(s2n_blob_init(&blob, data, 0));
     pthread_t threads[MAX_NUMBER_OF_TEST_THREADS];
 
     struct random_communication thread_communication_0 = { .s2n_get_random_data_cb_1 = s2n_get_random_data_cb_thread };
@@ -325,7 +325,7 @@ static void s2n_fork_test_generate_randomness(int write_fd, S2N_RESULT (*s2n_get
     uint8_t data[RANDOM_GENERATE_DATA_SIZE];
 
     struct s2n_blob blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&blob, data, RANDOM_GENERATE_DATA_SIZE));
+    EXPECT_OK(s2n_blob_init(&blob, data, RANDOM_GENERATE_DATA_SIZE));
     EXPECT_OK(s2n_get_random_data_cb(&blob));
 
     /* Write the data we got to our pipe */
@@ -343,7 +343,7 @@ static S2N_RESULT s2n_fork_test_verify_result(int *pipes, int proc_id, S2N_RESUL
     uint8_t child_data[RANDOM_GENERATE_DATA_SIZE];
     uint8_t parent_data[RANDOM_GENERATE_DATA_SIZE];
     struct s2n_blob parent_blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&parent_blob, parent_data, RANDOM_GENERATE_DATA_SIZE));
+    EXPECT_OK(s2n_blob_init(&parent_blob, parent_data, RANDOM_GENERATE_DATA_SIZE));
 
     /* Quickly verify we are in the parent process and not the child */
     EXPECT_NOT_EQUAL(proc_id, 0);
@@ -509,9 +509,9 @@ static S2N_RESULT s2n_basic_generate_tests(void)
     uint8_t data1[RANDOM_GENERATE_DATA_SIZE];
     uint8_t data2[RANDOM_GENERATE_DATA_SIZE];
     struct s2n_blob blob1 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&blob1, data1, 0));
+    EXPECT_OK(s2n_blob_init(&blob1, data1, 0));
     struct s2n_blob blob2 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&blob2, data2, 0));
+    EXPECT_OK(s2n_blob_init(&blob2, data2, 0));
 
     /* Generate two random data blobs and confirm that they are unique */
     blob1.size = RANDOM_GENERATE_DATA_SIZE;
@@ -531,7 +531,7 @@ static S2N_RESULT s2n_random_implementation_test(void)
 {
     uint8_t random_data[RANDOM_GENERATE_DATA_SIZE] = { 0 };
     struct s2n_blob blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&blob, random_data, sizeof(random_data)));
+    EXPECT_OK(s2n_blob_init(&blob, random_data, sizeof(random_data)));
 
     uint64_t previous_public_bytes_used = 0;
     EXPECT_OK(s2n_get_public_random_bytes_used(&previous_public_bytes_used));
@@ -566,9 +566,9 @@ static int s2n_common_tests(struct random_test_case *test_case)
     uint8_t data1[RANDOM_GENERATE_DATA_SIZE];
     uint8_t data2[RANDOM_GENERATE_DATA_SIZE];
     struct s2n_blob blob1 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&blob1, data1, 0));
+    EXPECT_OK(s2n_blob_init(&blob1, data1, 0));
     struct s2n_blob blob2 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&blob2, data2, 0));
+    EXPECT_OK(s2n_blob_init(&blob2, data2, 0));
     int64_t bound = 0;
     uint64_t output = 0;
 

--- a/tests/unit/s2n_rc4_test.c
+++ b/tests/unit/s2n_rc4_test.c
@@ -47,10 +47,10 @@ int main(int argc, char **argv)
     uint8_t mac_key[] = "sample mac key";
     uint8_t rc4_key[] = "123456789012345";
     struct s2n_blob key_iv = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&key_iv, rc4_key, sizeof(rc4_key)));
+    EXPECT_OK(s2n_blob_init(&key_iv, rc4_key, sizeof(rc4_key)));
     uint8_t random_data[S2N_DEFAULT_FRAGMENT_LENGTH + 1];
     struct s2n_blob r = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&r, random_data, sizeof(random_data)));
+    EXPECT_OK(s2n_blob_init(&r, random_data, sizeof(random_data)));
 
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
 
         for (size_t i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
             struct s2n_blob in = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
+            EXPECT_OK(s2n_blob_init(&in, random_data, i));
             int bytes_written;
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));

--- a/tests/unit/s2n_record_size_test.c
+++ b/tests/unit/s2n_record_size_test.c
@@ -63,12 +63,12 @@ int main(int argc, char **argv)
 
     uint8_t random_data[S2N_LARGE_RECORD_LENGTH + 1];
     struct s2n_blob r = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&r, random_data, sizeof(random_data)));
+    EXPECT_OK(s2n_blob_init(&r, random_data, sizeof(random_data)));
     EXPECT_OK(s2n_get_public_random_data(&r));
 
     uint8_t aes128_key[] = "123456789012345";
     struct s2n_blob aes128 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&aes128, aes128_key, sizeof(aes128_key)));
+    EXPECT_OK(s2n_blob_init(&aes128, aes128_key, sizeof(aes128_key)));
 
     /* Test record sizes with s2n_record_write */
     {
@@ -250,7 +250,7 @@ int main(int argc, char **argv)
             server_conn->initial->cipher_suite->record_alg = &s2n_record_alg_3des_sha;
             uint8_t des3_key[] = "12345678901234567890123";
             struct s2n_blob des3 = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&des3, des3_key, sizeof(des3_key)));
+            EXPECT_OK(s2n_blob_init(&des3, des3_key, sizeof(des3_key)));
             server_conn->server = server_conn->secure;
             EXPECT_SUCCESS(server_conn->secure->cipher_suite->record_alg->cipher->init(&server_conn->secure->server_key));
             EXPECT_SUCCESS(server_conn->secure->cipher_suite->record_alg->cipher->init(&server_conn->secure->client_key));
@@ -322,7 +322,7 @@ int main(int argc, char **argv)
             server_conn->initial->cipher_suite->record_alg = &s2n_record_alg_chacha20_poly1305;
             uint8_t chacha20_poly1305_key_data[] = "1234567890123456789012345678901";
             struct s2n_blob chacha20_poly1305_key = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&chacha20_poly1305_key, chacha20_poly1305_key_data, sizeof(chacha20_poly1305_key_data)));
+            EXPECT_OK(s2n_blob_init(&chacha20_poly1305_key, chacha20_poly1305_key_data, sizeof(chacha20_poly1305_key_data)));
 
             EXPECT_SUCCESS(setup_server_keys(server_conn, &chacha20_poly1305_key));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&server_conn->out));
@@ -346,7 +346,7 @@ int main(int argc, char **argv)
             server_conn->initial->cipher_suite->record_alg = &s2n_tls13_record_alg_chacha20_poly1305;
             uint8_t chacha20_poly1305_key_data[] = "1234567890123456789012345678901";
             struct s2n_blob chacha20_poly1305_key = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&chacha20_poly1305_key, chacha20_poly1305_key_data, sizeof(chacha20_poly1305_key_data)));
+            EXPECT_OK(s2n_blob_init(&chacha20_poly1305_key, chacha20_poly1305_key_data, sizeof(chacha20_poly1305_key_data)));
 
             EXPECT_SUCCESS(setup_server_keys(server_conn, &chacha20_poly1305_key));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&server_conn->out));

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -71,11 +71,11 @@ int main(int argc, char **argv)
     struct s2n_connection *conn;
     uint8_t mac_key[] = "sample mac key";
     struct s2n_blob fixed_iv = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&fixed_iv, mac_key, sizeof(mac_key)));
+    EXPECT_OK(s2n_blob_init(&fixed_iv, mac_key, sizeof(mac_key)));
     struct s2n_hmac_state check_mac;
     uint8_t random_data[S2N_DEFAULT_FRAGMENT_LENGTH + 1];
     struct s2n_blob r = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&r, random_data, sizeof(random_data)));
+    EXPECT_OK(s2n_blob_init(&r, random_data, sizeof(random_data)));
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
 
     for (size_t i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
+        EXPECT_OK(s2n_blob_init(&in, random_data, i));
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->out));
@@ -140,7 +140,7 @@ int main(int argc, char **argv)
 
     for (size_t i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
+        EXPECT_OK(s2n_blob_init(&in, random_data, i));
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_hmac_reset(&check_mac));
@@ -224,7 +224,7 @@ int main(int argc, char **argv)
 
     for (size_t i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
+        EXPECT_OK(s2n_blob_init(&in, random_data, i));
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_hmac_reset(&check_mac));
@@ -294,7 +294,7 @@ int main(int argc, char **argv)
 
     for (int i = 0; i <= S2N_DEFAULT_FRAGMENT_LENGTH + 1; i++) {
         struct s2n_blob in = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
+        EXPECT_OK(s2n_blob_init(&in, random_data, i));
         int bytes_written;
 
         EXPECT_SUCCESS(s2n_hmac_reset(&check_mac));
@@ -356,7 +356,7 @@ int main(int argc, char **argv)
 
     /* Test TLS record limit */
     struct s2n_blob empty_blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&empty_blob, NULL, 0));
+    EXPECT_OK(s2n_blob_init(&empty_blob, NULL, 0));
     conn->initial->cipher_suite = &s2n_null_cipher_suite;
 
     /* Fast forward the sequence number */

--- a/tests/unit/s2n_recv_test.c
+++ b/tests/unit/s2n_recv_test.c
@@ -365,7 +365,7 @@ int main(int argc, char **argv)
     {
         uint8_t test_data[100] = { 0 };
         struct s2n_blob test_data_blob = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&test_data_blob, test_data, sizeof(test_data)));
+        EXPECT_OK(s2n_blob_init(&test_data_blob, test_data, sizeof(test_data)));
         EXPECT_OK(s2n_get_public_random_data(&test_data_blob));
 
         const struct iovec test_iovec = {

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -399,7 +399,7 @@ int main(int argc, char **argv)
 
         struct s2n_blob blob = { 0 };
         struct s2n_stuffer stuffer = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN));
+        EXPECT_OK(s2n_blob_init(&blob, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN));
         EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &blob));
         EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
         conn->secure->cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
@@ -411,7 +411,7 @@ int main(int argc, char **argv)
 
             uint8_t s_data[S2N_TLS12_STATE_SIZE_IN_BYTES] = { 0 };
             struct s2n_blob state_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
+            EXPECT_OK(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
             struct s2n_stuffer output = { 0 };
 
             EXPECT_SUCCESS(s2n_stuffer_init(&output, &state_blob));
@@ -705,7 +705,7 @@ int main(int argc, char **argv)
         /* Deserialize ticket with incorrect format errors */
         {
             struct s2n_blob ticket_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, faulty_format_ticket, sizeof(faulty_format_ticket)));
+            EXPECT_OK(s2n_blob_init(&ticket_blob, faulty_format_ticket, sizeof(faulty_format_ticket)));
             struct s2n_stuffer ticket_stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_init(&ticket_stuffer, &ticket_blob));
             EXPECT_SUCCESS(s2n_stuffer_skip_write(&ticket_stuffer, sizeof(faulty_format_ticket)));
@@ -722,7 +722,7 @@ int main(int argc, char **argv)
         /* Deserialized ticket without EMS data errors */
         {
             struct s2n_blob ticket_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, tls12_ticket, sizeof(tls12_ticket)));
+            EXPECT_OK(s2n_blob_init(&ticket_blob, tls12_ticket, sizeof(tls12_ticket)));
             struct s2n_stuffer ticket_stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_init(&ticket_stuffer, &ticket_blob));
             EXPECT_SUCCESS(s2n_stuffer_skip_write(&ticket_stuffer, sizeof(tls12_ticket) - S2N_TLS_SECRET_LEN));
@@ -742,7 +742,7 @@ int main(int argc, char **argv)
         /* Client processes hardcoded TLS1.2 ticket with EMS data correctly */
         {
             struct s2n_blob ticket_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, tls12_ticket_with_ems, sizeof(tls12_ticket_with_ems)));
+            EXPECT_OK(s2n_blob_init(&ticket_blob, tls12_ticket_with_ems, sizeof(tls12_ticket_with_ems)));
             struct s2n_stuffer ticket_stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_init(&ticket_stuffer, &ticket_blob));
             EXPECT_SUCCESS(s2n_stuffer_skip_write(&ticket_stuffer, sizeof(tls12_ticket_with_ems) - S2N_TLS_SECRET_LEN - 1));
@@ -778,7 +778,7 @@ int main(int argc, char **argv)
 
             struct s2n_blob blob = { 0 };
             struct s2n_stuffer stuffer = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN));
+            EXPECT_OK(s2n_blob_init(&blob, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN));
             EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &blob));
             EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
             conn->secure->cipher_suite = &s2n_rsa_with_aes_128_gcm_sha256;
@@ -786,7 +786,7 @@ int main(int argc, char **argv)
 
             uint8_t s_data[S2N_TLS12_STATE_SIZE_IN_BYTES] = { 0 };
             struct s2n_blob state_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
+            EXPECT_OK(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
             struct s2n_stuffer output = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_init(&output, &state_blob));
 
@@ -810,7 +810,7 @@ int main(int argc, char **argv)
 
             struct s2n_blob blob = { 0 };
             struct s2n_stuffer stuffer = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&blob, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN));
+            EXPECT_OK(s2n_blob_init(&blob, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN));
             EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &blob));
             EXPECT_SUCCESS(s2n_stuffer_write_bytes(&stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
             conn->secure->cipher_suite = &s2n_rsa_with_aes_128_gcm_sha256;
@@ -818,7 +818,7 @@ int main(int argc, char **argv)
 
             uint8_t s_data[S2N_TLS12_STATE_SIZE_IN_BYTES] = { 0 };
             struct s2n_blob state_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
+            EXPECT_OK(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
             struct s2n_stuffer output = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_init(&output, &state_blob));
 
@@ -865,7 +865,7 @@ int main(int argc, char **argv)
         /* Deserialized ticket sets correct PSK values for session resumption in TLS1.3 */
         {
             struct s2n_blob ticket_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, tls13_ticket, sizeof(tls13_ticket)));
+            EXPECT_OK(s2n_blob_init(&ticket_blob, tls13_ticket, sizeof(tls13_ticket)));
             struct s2n_stuffer ticket_stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_init(&ticket_stuffer, &ticket_blob));
             EXPECT_SUCCESS(s2n_stuffer_skip_write(&ticket_stuffer, sizeof(tls13_ticket)));
@@ -908,7 +908,7 @@ int main(int argc, char **argv)
         /* Deserialized TLS1.3 server ticket sets correct keying material value */
         {
             struct s2n_blob ticket_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, tls13_server_ticket, sizeof(tls13_server_ticket)));
+            EXPECT_OK(s2n_blob_init(&ticket_blob, tls13_server_ticket, sizeof(tls13_server_ticket)));
             struct s2n_stuffer ticket_stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_init(&ticket_stuffer, &ticket_blob));
             EXPECT_SUCCESS(s2n_stuffer_skip_write(&ticket_stuffer, ticket_blob.size));
@@ -942,7 +942,7 @@ int main(int argc, char **argv)
         /* Deserializing TLS1.3 server ticket fails for expired keying material */
         {
             struct s2n_blob ticket_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, tls13_server_ticket, sizeof(tls13_server_ticket)));
+            EXPECT_OK(s2n_blob_init(&ticket_blob, tls13_server_ticket, sizeof(tls13_server_ticket)));
             struct s2n_stuffer ticket_stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_init(&ticket_stuffer, &ticket_blob));
             EXPECT_SUCCESS(s2n_stuffer_skip_write(&ticket_stuffer, ticket_blob.size));
@@ -974,7 +974,7 @@ int main(int argc, char **argv)
             const uint8_t expected_context[] = { EARLY_DATA_CONTEXT };
 
             struct s2n_blob ticket_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, tls13_ticket_with_early_data, sizeof(tls13_ticket_with_early_data)));
+            EXPECT_OK(s2n_blob_init(&ticket_blob, tls13_ticket_with_early_data, sizeof(tls13_ticket_with_early_data)));
             struct s2n_stuffer ticket_stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_init(&ticket_stuffer, &ticket_blob));
             EXPECT_SUCCESS(s2n_stuffer_skip_write(&ticket_stuffer, ticket_blob.size));
@@ -1047,7 +1047,7 @@ int main(int argc, char **argv)
         /* Any existing psks are removed when creating a new resumption psk */
         {
             struct s2n_blob ticket_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, tls13_ticket, sizeof(tls13_ticket)));
+            EXPECT_OK(s2n_blob_init(&ticket_blob, tls13_ticket, sizeof(tls13_ticket)));
             struct s2n_stuffer ticket_stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_init(&ticket_stuffer, &ticket_blob));
             EXPECT_SUCCESS(s2n_stuffer_skip_write(&ticket_stuffer, sizeof(tls13_ticket)));
@@ -1090,7 +1090,7 @@ int main(int argc, char **argv)
         /* Fails if external PSKs already set */
         {
             struct s2n_blob ticket_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, tls13_ticket, sizeof(tls13_ticket)));
+            EXPECT_OK(s2n_blob_init(&ticket_blob, tls13_ticket, sizeof(tls13_ticket)));
             struct s2n_stuffer ticket_stuffer = { 0 };
             EXPECT_SUCCESS(s2n_stuffer_init(&ticket_stuffer, &ticket_blob));
             EXPECT_SUCCESS(s2n_stuffer_skip_write(&ticket_stuffer, sizeof(tls13_ticket)));
@@ -1236,7 +1236,7 @@ int main(int argc, char **argv)
 
                 uint8_t s_data[S2N_TLS12_STATE_SIZE_IN_BYTES] = { 0 };
                 struct s2n_blob state_blob = { 0 };
-                EXPECT_SUCCESS(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
+                EXPECT_OK(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
                 struct s2n_stuffer stuffer = { 0 };
 
                 EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &state_blob));
@@ -1307,7 +1307,7 @@ int main(int argc, char **argv)
 
             struct s2n_blob secret = { 0 };
             struct s2n_stuffer secret_stuffer = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&secret, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN));
+            EXPECT_OK(s2n_blob_init(&secret, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN));
             EXPECT_SUCCESS(s2n_stuffer_init(&secret_stuffer, &secret));
             EXPECT_SUCCESS(s2n_stuffer_write_bytes(&secret_stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
             conn->secure->cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
@@ -1566,7 +1566,7 @@ int main(int argc, char **argv)
         {
             uint8_t ticket_data[] = "session ticket data";
             struct s2n_blob ticket_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, ticket_data, sizeof(ticket_data)));
+            EXPECT_OK(s2n_blob_init(&ticket_blob, ticket_data, sizeof(ticket_data)));
             struct s2n_session_ticket session_ticket = { .ticket_data = ticket_blob };
 
             size_t data_len = 0;
@@ -1590,7 +1590,7 @@ int main(int argc, char **argv)
         {
             uint8_t ticket_data[] = "session ticket data";
             struct s2n_blob ticket_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, ticket_data, sizeof(ticket_data)));
+            EXPECT_OK(s2n_blob_init(&ticket_blob, ticket_data, sizeof(ticket_data)));
             struct s2n_session_ticket session_ticket = { .ticket_data = ticket_blob };
 
             uint8_t data[sizeof(ticket_data)];
@@ -1603,7 +1603,7 @@ int main(int argc, char **argv)
         {
             uint8_t ticket_data[] = "session ticket data";
             struct s2n_blob ticket_blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&ticket_blob, ticket_data, sizeof(ticket_data)));
+            EXPECT_OK(s2n_blob_init(&ticket_blob, ticket_data, sizeof(ticket_data)));
             struct s2n_session_ticket session_ticket = { .ticket_data = ticket_blob };
 
             uint8_t data[sizeof(ticket_data) - 1];

--- a/tests/unit/s2n_rfc5952_test.c
+++ b/tests/unit/s2n_rfc5952_test.c
@@ -37,9 +37,9 @@ int main(int argc, char **argv)
     uint8_t ipv6_buf[sizeof("1111:2222:3333:4444:5555:6666:7777:8888")];
 
     struct s2n_blob ipv4_blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&ipv4_blob, ipv4_buf, sizeof(ipv4_buf)));
+    EXPECT_OK(s2n_blob_init(&ipv4_blob, ipv4_buf, sizeof(ipv4_buf)));
     struct s2n_blob ipv6_blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&ipv6_blob, ipv6_buf, sizeof(ipv6_buf)));
+    EXPECT_OK(s2n_blob_init(&ipv6_blob, ipv6_buf, sizeof(ipv6_buf)));
 
     EXPECT_SUCCESS(inet_pton(AF_INET, "111.222.111.111", ipv4));
     EXPECT_OK(s2n_inet_ntop(AF_INET, ipv4, &ipv4_blob));

--- a/tests/unit/s2n_self_talk_ktls_test.c
+++ b/tests/unit/s2n_self_talk_ktls_test.c
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
 
     uint8_t test_data[100] = { 0 };
     struct s2n_blob test_data_blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&test_data_blob, test_data, sizeof(test_data)));
+    EXPECT_OK(s2n_blob_init(&test_data_blob, test_data, sizeof(test_data)));
     EXPECT_OK(s2n_get_public_random_data(&test_data_blob));
 
     DEFER_CLEANUP(struct s2n_test_iovecs test_iovecs = { 0 }, s2n_test_iovecs_free);
@@ -354,7 +354,7 @@ int main(int argc, char **argv)
             const uint8_t test_record_type = TLS_CHANGE_CIPHER_SPEC;
             uint8_t control_record_data[] = "control record data";
             struct s2n_blob control_record = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&control_record, control_record_data,
+            EXPECT_OK(s2n_blob_init(&control_record, control_record_data,
                     sizeof(control_record_data)));
 
             for (size_t i = 0; i < 5; i++) {
@@ -442,7 +442,7 @@ int main(int argc, char **argv)
                 10,
             };
             struct s2n_blob control_record = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&control_record, control_record_data,
+            EXPECT_OK(s2n_blob_init(&control_record, control_record_data,
                     sizeof(control_record_data)));
 
             for (size_t i = 0; i < 5; i++) {

--- a/tests/unit/s2n_self_talk_npn_test.c
+++ b/tests/unit/s2n_self_talk_npn_test.c
@@ -28,7 +28,7 @@ static int s2n_wipe_alpn_ext(struct s2n_connection *conn, void *ctx)
     s2n_parsed_extension *parsed_extension = NULL;
     POSIX_GUARD(s2n_client_hello_get_parsed_extension(S2N_EXTENSION_ALPN, &client_hello->extensions, &parsed_extension));
     POSIX_ENSURE_REF(parsed_extension);
-    POSIX_GUARD(s2n_blob_zero(&parsed_extension->extension));
+    POSIX_GUARD_RESULT(s2n_blob_zero(&parsed_extension->extension));
 
     return S2N_SUCCESS;
 }

--- a/tests/unit/s2n_self_talk_session_resumption_test.c
+++ b/tests/unit/s2n_self_talk_session_resumption_test.c
@@ -149,7 +149,7 @@ static S2N_RESULT s2n_test_negotiate(struct s2n_connection *server_conn, struct 
 
     uint8_t early_data_recv_data[sizeof(early_data)] = { 0 };
     struct s2n_blob early_data_recv = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&early_data_recv, early_data_recv_data, sizeof(early_data_recv_data)));
+    RESULT_GUARD(s2n_blob_init(&early_data_recv, early_data_recv_data, sizeof(early_data_recv_data)));
 
     if (early_data_case->server_supported) {
         RESULT_GUARD_POSIX(s2n_connection_set_server_max_early_data_size(server_conn, UINT16_MAX));
@@ -159,7 +159,7 @@ static S2N_RESULT s2n_test_negotiate(struct s2n_connection *server_conn, struct 
 
     struct s2n_blob early_data_send = { 0 };
     if (early_data_case->client_supported) {
-        RESULT_GUARD_POSIX(s2n_blob_init(&early_data_send, early_data, sizeof(early_data)));
+        RESULT_GUARD(s2n_blob_init(&early_data_send, early_data, sizeof(early_data)));
     }
 
     RESULT_GUARD(s2n_negotiate_test_server_and_client_with_early_data(server_conn, client_conn,
@@ -183,7 +183,7 @@ static int s2n_wipe_psk_ke_ext(struct s2n_connection *conn, void *ctx)
     s2n_parsed_extension *parsed_extension = NULL;
     POSIX_GUARD(s2n_client_hello_get_parsed_extension(TLS_EXTENSION_PSK_KEY_EXCHANGE_MODES, &client_hello->extensions, &parsed_extension));
     POSIX_ENSURE_REF(parsed_extension);
-    POSIX_GUARD(s2n_blob_zero(&parsed_extension->extension));
+    POSIX_GUARD_RESULT(s2n_blob_zero(&parsed_extension->extension));
 
     return S2N_SUCCESS;
 }

--- a/tests/unit/s2n_send_key_update_test.c
+++ b/tests/unit/s2n_send_key_update_test.c
@@ -171,7 +171,7 @@ int main(int argc, char **argv)
         /* Force Client to send a TLS 1.3 KeyUpdate Message over TLS 1.2 connection */
         uint8_t key_update_data[S2N_KEY_UPDATE_MESSAGE_SIZE] = { 0 };
         struct s2n_blob key_update_blob = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&key_update_blob, key_update_data, sizeof(key_update_data)));
+        EXPECT_OK(s2n_blob_init(&key_update_blob, key_update_data, sizeof(key_update_data)));
         EXPECT_SUCCESS(s2n_key_update_write(&key_update_blob));
         EXPECT_OK(s2n_record_write(client_conn, TLS_HANDSHAKE, &key_update_blob));
         EXPECT_SUCCESS(s2n_flush(client_conn, &blocked));

--- a/tests/unit/s2n_send_multirecord_test.c
+++ b/tests/unit/s2n_send_multirecord_test.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
 
     uint8_t large_test_data[S2N_TLS_MAXIMUM_FRAGMENT_LENGTH + 10] = { 0 };
     struct s2n_blob large_data_blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&large_data_blob, large_test_data, sizeof(large_test_data)));
+    EXPECT_OK(s2n_blob_init(&large_data_blob, large_test_data, sizeof(large_test_data)));
     EXPECT_OK(s2n_get_public_random_data(&large_data_blob));
 
     /* Small record sizes will require a LOT of calls to s2n_send.
@@ -426,7 +426,7 @@ int main(int argc, char **argv)
         /* Initialize sequence number */
         struct s2n_blob seq_num_blob = { 0 };
         struct s2n_stuffer seq_num_stuffer = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&seq_num_blob, conn->secure->client_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
+        EXPECT_OK(s2n_blob_init(&seq_num_blob, conn->secure->client_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
         EXPECT_SUCCESS(s2n_stuffer_init(&seq_num_stuffer, &seq_num_blob));
 
         /* Set the sequence number so that a KeyUpdate triggers after one more record. */
@@ -544,7 +544,7 @@ int main(int argc, char **argv)
         /* Initialize sequence number */
         struct s2n_blob seq_num_blob = { 0 };
         struct s2n_stuffer seq_num_stuffer = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&seq_num_blob, conn->secure->client_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
+        EXPECT_OK(s2n_blob_init(&seq_num_blob, conn->secure->client_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
         EXPECT_SUCCESS(s2n_stuffer_init(&seq_num_stuffer, &seq_num_blob));
 
         /* Set the sequence number so that a KeyUpdate triggers after one more record. */

--- a/tests/unit/s2n_send_test.c
+++ b/tests/unit/s2n_send_test.c
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
 
     uint8_t large_test_data[S2N_TLS_MAXIMUM_FRAGMENT_LENGTH + 10] = { 0 };
     struct s2n_blob large_data_blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&large_data_blob, large_test_data, sizeof(large_test_data)));
+    EXPECT_OK(s2n_blob_init(&large_data_blob, large_test_data, sizeof(large_test_data)));
     EXPECT_OK(s2n_get_public_random_data(&large_data_blob));
 
     /* Small record sizes will require a LOT of calls to s2n_send.

--- a/tests/unit/s2n_sequence_number_test.c
+++ b/tests/unit/s2n_sequence_number_test.c
@@ -31,7 +31,7 @@ int main(int argc, char **argv)
             uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN] = { 0 };
             struct s2n_blob sequence_number = { 0 };
 
-            EXPECT_SUCCESS(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
+            EXPECT_OK(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
 
             EXPECT_SUCCESS(s2n_sequence_number_to_uint64(&sequence_number, &output));
 
@@ -45,7 +45,7 @@ int main(int argc, char **argv)
             data[S2N_TLS_SEQUENCE_NUM_LEN - 1] = 1;
             struct s2n_blob sequence_number = { 0 };
 
-            EXPECT_SUCCESS(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
+            EXPECT_OK(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
 
             EXPECT_SUCCESS(s2n_sequence_number_to_uint64(&sequence_number, &output));
 
@@ -58,8 +58,8 @@ int main(int argc, char **argv)
             uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN] = { 0 };
             struct s2n_blob sequence_number = { 0 };
 
-            EXPECT_SUCCESS(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
-            EXPECT_SUCCESS(s2n_blob_zero(&sequence_number));
+            EXPECT_OK(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
+            EXPECT_OK(s2n_blob_zero(&sequence_number));
 
             for (size_t i = 0; i < S2N_TLS_SEQUENCE_NUM_LEN; i++) {
                 sequence_number.data[i] = UINT8_MAX;
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
             uint8_t data[S2N_TLS_SEQUENCE_NUM_LEN] = { 0, 0, 0, 0, 1, 106, 9, 229 };
             struct s2n_blob sequence_number = { 0 };
 
-            EXPECT_SUCCESS(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
+            EXPECT_OK(s2n_blob_init(&sequence_number, data, S2N_TLS_SEQUENCE_NUM_LEN));
 
             EXPECT_SUCCESS(s2n_sequence_number_to_uint64(&sequence_number, &output));
 
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
             uint8_t stuffer_bytes[S2N_TLS_SEQUENCE_NUM_LEN] = { 0 };
             struct s2n_blob stuffer_blob = { 0 };
             struct s2n_stuffer stuffer = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&stuffer_blob, stuffer_bytes, sizeof(stuffer_bytes)));
+            EXPECT_OK(s2n_blob_init(&stuffer_blob, stuffer_bytes, sizeof(stuffer_bytes)));
             EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &stuffer_blob));
             EXPECT_SUCCESS(s2n_stuffer_write_uint64(&stuffer, input));
 

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -191,7 +191,7 @@ int main(int argc, char **argv)
 
             struct s2n_cert_chain_and_key fake_chain_and_key = { 0 };
             static uint8_t sct_list[] = { 0xff, 0xff, 0xff };
-            EXPECT_SUCCESS(s2n_blob_init(&fake_chain_and_key.sct_list, sct_list, sizeof(sct_list)));
+            EXPECT_OK(s2n_blob_init(&fake_chain_and_key.sct_list, sct_list, sizeof(sct_list)));
 
             conn->ct_level_requested = S2N_CT_SUPPORT_REQUEST;
             conn->handshake_params.our_chain_and_key = &fake_chain_and_key;
@@ -221,7 +221,7 @@ int main(int argc, char **argv)
 
             struct s2n_cert_chain_and_key fake_chain_and_key = { 0 };
             static uint8_t fake_ocsp[] = { 0xff, 0xff, 0xff };
-            EXPECT_SUCCESS(s2n_blob_init(&fake_chain_and_key.ocsp_status, fake_ocsp, sizeof(fake_ocsp)));
+            EXPECT_OK(s2n_blob_init(&fake_chain_and_key.ocsp_status, fake_ocsp, sizeof(fake_ocsp)));
 
             conn->status_type = S2N_STATUS_REQUEST_OCSP;
             conn->handshake_params.our_chain_and_key = &fake_chain_and_key;
@@ -549,7 +549,7 @@ int main(int argc, char **argv)
 
         struct s2n_cert_chain_and_key fake_chain_and_key = { 0 };
         static uint8_t fake_ocsp[] = { 0xff, 0xff, 0xff };
-        EXPECT_SUCCESS(s2n_blob_init(&fake_chain_and_key.ocsp_status, fake_ocsp, sizeof(fake_ocsp)));
+        EXPECT_OK(s2n_blob_init(&fake_chain_and_key.ocsp_status, fake_ocsp, sizeof(fake_ocsp)));
 
         /* For our test status_request extension */
         server_conn->status_type = S2N_STATUS_REQUEST_OCSP;

--- a/tests/unit/s2n_server_hello_retry_test.c
+++ b/tests/unit/s2n_server_hello_retry_test.c
@@ -365,7 +365,7 @@ int main(int argc, char **argv)
         uint8_t client_hello1_digest_out[S2N_MAX_DIGEST_LEN] = { 0 };
         EXPECT_SUCCESS(s2n_hash_digest(&client_hello1_hash, client_hello1_digest_out, hash_digest_length));
 
-        EXPECT_SUCCESS(s2n_blob_init(&compare_blob, client_hello1_digest_out, hash_digest_length));
+        EXPECT_OK(s2n_blob_init(&compare_blob, client_hello1_digest_out, hash_digest_length));
         S2N_BLOB_EXPECT_EQUAL(client_hello1_expected_hash, compare_blob);
 
         EXPECT_SUCCESS(s2n_server_hello_retry_recreate_transcript(conn));
@@ -376,7 +376,7 @@ int main(int argc, char **argv)
         POSIX_GUARD_RESULT(s2n_handshake_copy_hash_state(conn, keys.hash_algorithm, &recreated_hash));
         EXPECT_SUCCESS(s2n_hash_digest(&recreated_hash, recreated_transcript_digest_out, hash_digest_length));
 
-        EXPECT_SUCCESS(s2n_blob_init(&compare_blob, recreated_transcript_digest_out, hash_digest_length));
+        EXPECT_OK(s2n_blob_init(&compare_blob, recreated_transcript_digest_out, hash_digest_length));
         S2N_BLOB_EXPECT_EQUAL(synthetic_message_with_ch1_expected_hash, compare_blob);
 
         EXPECT_SUCCESS(s2n_config_free(conf));

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -563,7 +563,7 @@ int main(int argc, char **argv)
                 uint8_t iana_buffer[2];
                 struct s2n_blob iana_blob = { 0 };
                 struct s2n_stuffer iana_stuffer = { 0 };
-                EXPECT_SUCCESS(s2n_blob_init(&iana_blob, iana_buffer, 2));
+                EXPECT_OK(s2n_blob_init(&iana_blob, iana_buffer, 2));
                 EXPECT_SUCCESS(s2n_stuffer_init(&iana_stuffer, &iana_blob));
                 EXPECT_SUCCESS(s2n_stuffer_write_uint16(&iana_stuffer, test_security_policy.kem_preferences->tls13_kem_groups[0]->iana_id));
 
@@ -727,7 +727,7 @@ int main(int argc, char **argv)
                         uint8_t truncated_extension[10];
                         EXPECT_MEMCPY_SUCCESS(truncated_extension, key_share_payload.blob.data, 10);
                         struct s2n_blob trunc_ext_blob = { 0 };
-                        EXPECT_SUCCESS(s2n_blob_init(&trunc_ext_blob, truncated_extension, 10));
+                        EXPECT_OK(s2n_blob_init(&trunc_ext_blob, truncated_extension, 10));
                         struct s2n_stuffer trunc_ext_stuffer = { 0 };
                         EXPECT_SUCCESS(s2n_stuffer_init(&trunc_ext_stuffer, &trunc_ext_blob));
                         EXPECT_FAILURE_WITH_ERRNO(s2n_server_key_share_extension.recv(client_conn, &trunc_ext_stuffer),

--- a/tests/unit/s2n_server_new_session_ticket_test.c
+++ b/tests/unit/s2n_server_new_session_ticket_test.c
@@ -97,7 +97,7 @@ static int s2n_setup_test_resumption_secret(struct s2n_connection *conn)
     /* Set up resumption secret */
     struct s2n_blob secret = { 0 };
     struct s2n_stuffer secret_stuffer = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&secret, conn->secrets.version.tls13.resumption_master_secret, S2N_TLS_SECRET_LEN));
+    EXPECT_OK(s2n_blob_init(&secret, conn->secrets.version.tls13.resumption_master_secret, S2N_TLS_SECRET_LEN));
     EXPECT_SUCCESS(s2n_stuffer_init(&secret_stuffer, &secret));
     EXPECT_SUCCESS(s2n_stuffer_write_bytes(&secret_stuffer, test_resumption_secret.data, test_resumption_secret.size));
 
@@ -157,7 +157,7 @@ int main(int argc, char **argv)
 
             uint8_t tickets_sent_array[sizeof(uint16_t)] = { 0 };
             struct s2n_blob blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&blob, tickets_sent_array, sizeof(uint16_t)));
+            EXPECT_OK(s2n_blob_init(&blob, tickets_sent_array, sizeof(uint16_t)));
             EXPECT_OK(s2n_generate_ticket_nonce(test_tickets_sent, &blob));
             EXPECT_BYTEARRAY_EQUAL(ticket_nonce, blob.data, ticket_nonce_len);
 
@@ -386,7 +386,7 @@ int main(int argc, char **argv)
         for (size_t i = 0; i < s2n_array_len(test_cases); i++) {
             uint8_t data[sizeof(uint16_t)] = { 0 };
             struct s2n_blob blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&blob, data, sizeof(data)));
+            EXPECT_OK(s2n_blob_init(&blob, data, sizeof(data)));
 
             EXPECT_OK(s2n_generate_ticket_nonce(test_cases[i].value, &blob));
 
@@ -414,7 +414,7 @@ int main(int argc, char **argv)
         for (size_t i = 0; i < s2n_array_len(test_cases); i++) {
             uint32_t output = 0;
             struct s2n_blob blob = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&blob, test_cases[i].value, sizeof(test_cases[i].value)));
+            EXPECT_OK(s2n_blob_init(&blob, test_cases[i].value, sizeof(test_cases[i].value)));
             EXPECT_OK(s2n_generate_ticket_age_add(&blob, &output));
 
             EXPECT_EQUAL(output, test_cases[i].expected_output);
@@ -442,7 +442,7 @@ int main(int argc, char **argv)
 
         uint8_t nonce_data[sizeof(uint16_t)] = { 0 };
         struct s2n_blob nonce = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&nonce, nonce_data, sizeof(nonce_data)));
+        EXPECT_OK(s2n_blob_init(&nonce, nonce_data, sizeof(nonce_data)));
 
         struct s2n_blob *output = &conn->tls13_ticket_fields.session_secret;
         EXPECT_SUCCESS(s2n_generate_session_secret(conn, &nonce, output));
@@ -479,7 +479,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
 
             struct s2n_blob nst_message = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&nst_message, nst_data, sizeof(nst_data)));
+            EXPECT_OK(s2n_blob_init(&nst_message, nst_data, sizeof(nst_data)));
             EXPECT_SUCCESS(s2n_stuffer_write(&input, &nst_message));
 
             EXPECT_OK(s2n_tls13_server_nst_recv(conn, &input));
@@ -502,7 +502,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
 
             struct s2n_blob nst_message = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&nst_message, nst_data, sizeof(nst_data)));
+            EXPECT_OK(s2n_blob_init(&nst_message, nst_data, sizeof(nst_data)));
             EXPECT_SUCCESS(s2n_stuffer_write(&input, &nst_message));
 
             EXPECT_ERROR_WITH_ERRNO(s2n_tls13_server_nst_recv(conn, &input), S2N_ERR_BAD_MESSAGE);
@@ -532,7 +532,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
 
             struct s2n_blob nst_message = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&nst_message, nst_data, sizeof(nst_data)));
+            EXPECT_OK(s2n_blob_init(&nst_message, nst_data, sizeof(nst_data)));
             EXPECT_SUCCESS(s2n_stuffer_write(&input, &nst_message));
 
             EXPECT_OK(s2n_tls13_server_nst_recv(conn, &input));
@@ -542,7 +542,7 @@ int main(int argc, char **argv)
             /* Initialize a stuffer to examine the serialized data returned in the session ticket callback */
             struct s2n_blob session_blob = { 0 };
             struct s2n_stuffer session_stuffer = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&session_blob, cb_session_data, cb_session_data_len));
+            EXPECT_OK(s2n_blob_init(&session_blob, cb_session_data, cb_session_data_len));
             EXPECT_SUCCESS(s2n_stuffer_init(&session_stuffer, &session_blob));
             EXPECT_SUCCESS(s2n_stuffer_skip_write(&session_stuffer, cb_session_data_len));
 

--- a/tests/unit/s2n_ssl_prf_test.c
+++ b/tests/unit/s2n_ssl_prf_test.c
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
     struct s2n_stuffer premaster_secret_in = { 0 };
     struct s2n_stuffer master_secret_hex_out = { 0 };
     struct s2n_blob master_secret = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&master_secret, master_secret_hex_pad, sizeof(master_secret_hex_pad)));
+    EXPECT_OK(s2n_blob_init(&master_secret, master_secret_hex_pad, sizeof(master_secret_hex_pad)));
     struct s2n_blob pms = { 0 };
 
     struct s2n_connection *conn = NULL;

--- a/tests/unit/s2n_sslv3_test.c
+++ b/tests/unit/s2n_sslv3_test.c
@@ -23,7 +23,7 @@ S2N_RESULT s2n_test_send_receive_data(struct s2n_connection *sender, struct s2n_
 {
     uint8_t test_data[S2N_TEST_DATA_SIZE] = { 0 };
     struct s2n_blob test_data_blob = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&test_data_blob, test_data, sizeof(test_data)));
+    EXPECT_OK(s2n_blob_init(&test_data_blob, test_data, sizeof(test_data)));
     EXPECT_OK(s2n_get_public_random_data(&test_data_blob));
 
     /* Send data */

--- a/tests/unit/s2n_stream_cipher_null_test.c
+++ b/tests/unit/s2n_stream_cipher_null_test.c
@@ -27,9 +27,9 @@ int main(int argc, char **argv)
     {
         uint8_t array[9] = { 0 };
         struct s2n_blob in = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&in, array, 9));
+        EXPECT_OK(s2n_blob_init(&in, array, 9));
         struct s2n_blob out = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&out, array, 9));
+        EXPECT_OK(s2n_blob_init(&out, array, 9));
         EXPECT_SUCCESS(s2n_stream_cipher_null_endecrypt(NULL, &in, &out));
     };
 
@@ -37,9 +37,9 @@ int main(int argc, char **argv)
     {
         uint8_t array[9] = { 0 };
         struct s2n_blob in = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&in, array, 9));
+        EXPECT_OK(s2n_blob_init(&in, array, 9));
         struct s2n_blob out = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&out, array, 8));
+        EXPECT_OK(s2n_blob_init(&out, array, 8));
         EXPECT_FAILURE(s2n_stream_cipher_null_endecrypt(NULL, &in, &out));
     };
 
@@ -48,9 +48,9 @@ int main(int argc, char **argv)
         uint8_t in_array[9] = { 0, 1, 2, 3, 4, 5, 6, 7, 8 };
         uint8_t out_array[9] = { 0 };
         struct s2n_blob in = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&in, in_array, 9));
+        EXPECT_OK(s2n_blob_init(&in, in_array, 9));
         struct s2n_blob out = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&out, out_array, 9));
+        EXPECT_OK(s2n_blob_init(&out, out_array, 9));
         EXPECT_BYTEARRAY_NOT_EQUAL(in_array, out_array, out.size);
         EXPECT_SUCCESS(s2n_stream_cipher_null_endecrypt(NULL, &in, &out));
         EXPECT_BYTEARRAY_EQUAL(in_array, out_array, out.size);

--- a/tests/unit/s2n_stuffer_base64_test.c
+++ b/tests/unit/s2n_stuffer_base64_test.c
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
     struct s2n_stuffer stuffer = { 0 }, known_data = { 0 }, scratch = { 0 }, entropy = { 0 }, mirror = { 0 };
     uint8_t pad[50];
     struct s2n_blob r = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&r, pad, sizeof(pad)));
+    EXPECT_OK(s2n_blob_init(&r, pad, sizeof(pad)));
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());

--- a/tests/unit/s2n_stuffer_hex_test.c
+++ b/tests/unit/s2n_stuffer_hex_test.c
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
 {
     uint8_t pad[100];
     struct s2n_blob b = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&b, pad, sizeof(pad)));
+    EXPECT_OK(s2n_blob_init(&b, pad, sizeof(pad)));
     struct s2n_stuffer stuffer = { 0 };
     uint8_t u8;
     uint16_t u16;
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_stuffer_wipe(&stuffer));
     uint8_t hex[] = "f0F0Zz";
     struct s2n_blob text = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&text, hex, strlen((char *) hex)));
+    EXPECT_OK(s2n_blob_init(&text, hex, strlen((char *) hex)));
     EXPECT_SUCCESS(s2n_stuffer_write(&stuffer, &text));
 
     EXPECT_SUCCESS(s2n_stuffer_read_uint8_hex(&stuffer, &u8));

--- a/tests/unit/s2n_stuffer_test.c
+++ b/tests/unit/s2n_stuffer_test.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
 
     /* Try to write 101 bytes */
     struct s2n_blob in = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&in, entropy, 101));
+    EXPECT_OK(s2n_blob_init(&in, entropy, 101));
     EXPECT_FAILURE(s2n_stuffer_write(&stuffer, &in));
 
     /* Try to write 101 1-byte ints bytes */
@@ -148,14 +148,14 @@ int main(int argc, char **argv)
     /* Valid empty blob should succeed init */
     struct s2n_stuffer s2 = { 0 };
     struct s2n_blob b2 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&b2, 0, 0));
+    EXPECT_OK(s2n_blob_init(&b2, 0, 0));
     EXPECT_SUCCESS(s2n_stuffer_init(&s2, &b2));
 
     /* Valid blob should succeed init */
     struct s2n_stuffer s3 = { 0 };
     uint8_t a3[12];
     struct s2n_blob b3 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&b3, a3, sizeof(a3)));
+    EXPECT_OK(s2n_blob_init(&b3, a3, sizeof(a3)));
     EXPECT_SUCCESS(s2n_stuffer_init(&s3, &b3));
 
     /* Null blob should fail init */
@@ -164,14 +164,14 @@ int main(int argc, char **argv)
 
     /* Null stuffer should fail init */
     struct s2n_blob b5 = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&b5, 0, 0));
+    EXPECT_OK(s2n_blob_init(&b5, 0, 0));
     EXPECT_FAILURE(s2n_stuffer_init(NULL, &b5));
 
     /* Check s2n_stuffer_validate() function */
     EXPECT_ERROR(s2n_stuffer_validate(NULL));
     uint8_t valid_blob_array[12];
     struct s2n_blob blob_valid = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&blob_valid, valid_blob_array, sizeof(valid_blob_array)));
+    EXPECT_OK(s2n_blob_init(&blob_valid, valid_blob_array, sizeof(valid_blob_array)));
 
     struct s2n_stuffer stuffer_valid = { 0 };
     EXPECT_SUCCESS(s2n_stuffer_init(&stuffer_valid, &blob_valid));
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
         uint8_t output[sizeof(data)] = { 0 };
 
         struct s2n_blob blob = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&blob, input, sizeof(input)));
+        EXPECT_OK(s2n_blob_init(&blob, input, sizeof(input)));
 
         /* Repeat control to show behavior is consistent */
         for (size_t i = 0; i < 3; i++) {

--- a/tests/unit/s2n_stuffer_text_test.c
+++ b/tests/unit/s2n_stuffer_text_test.c
@@ -38,9 +38,9 @@ int main(int argc, char **argv)
     /* Check whitespace reading */
     {
         /* Create a stuffer */
-        EXPECT_SUCCESS(s2n_blob_init(&token_blob, (uint8_t *) tokenpad, sizeof(tokenpad)));
+        EXPECT_OK(s2n_blob_init(&token_blob, (uint8_t *) tokenpad, sizeof(tokenpad)));
         EXPECT_SUCCESS(s2n_stuffer_init(&token, &token_blob));
-        EXPECT_SUCCESS(s2n_blob_init(&pad_blob, (uint8_t *) pad, sizeof(pad)));
+        EXPECT_OK(s2n_blob_init(&pad_blob, (uint8_t *) pad, sizeof(pad)));
         EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &pad_blob));
         EXPECT_SUCCESS(s2n_stuffer_write_text(&stuffer, text, sizeof(text)));
 
@@ -71,9 +71,9 @@ int main(int argc, char **argv)
     /* Check read_until, rewinding, and expecting */
     {
         /* Create a stuffer */
-        EXPECT_SUCCESS(s2n_blob_init(&token_blob, (uint8_t *) tokenpad, sizeof(tokenpad)));
+        EXPECT_OK(s2n_blob_init(&token_blob, (uint8_t *) tokenpad, sizeof(tokenpad)));
         EXPECT_SUCCESS(s2n_stuffer_init(&token, &token_blob));
-        EXPECT_SUCCESS(s2n_blob_init(&pad_blob, (uint8_t *) pad, sizeof(pad)));
+        EXPECT_OK(s2n_blob_init(&pad_blob, (uint8_t *) pad, sizeof(pad)));
         EXPECT_SUCCESS(s2n_stuffer_init(&stuffer, &pad_blob));
         EXPECT_SUCCESS(s2n_stuffer_write_text(&stuffer, text, sizeof(text)));
 
@@ -121,41 +121,41 @@ int main(int argc, char **argv)
         char lf_line_trailing_cr[] = "a LF terminated line with trailing CR\n\r\r\r\r\r\r";
         char not_a_line[] = "not a line";
 
-        EXPECT_SUCCESS(s2n_blob_init(&line_blob, (uint8_t *) lf_line, sizeof(lf_line)));
+        EXPECT_OK(s2n_blob_init(&line_blob, (uint8_t *) lf_line, sizeof(lf_line)));
         EXPECT_SUCCESS(s2n_stuffer_init(&lstuffer, &line_blob));
         EXPECT_SUCCESS(s2n_stuffer_write(&lstuffer, &line_blob));
         memset(pad, 0, sizeof(pad));
-        EXPECT_SUCCESS(s2n_blob_init(&pad_blob, pad, sizeof(pad)));
+        EXPECT_OK(s2n_blob_init(&pad_blob, pad, sizeof(pad)));
         EXPECT_SUCCESS(s2n_stuffer_init(&token, &pad_blob));
         EXPECT_SUCCESS(s2n_stuffer_read_line(&lstuffer, &token));
         EXPECT_EQUAL(strlen("a LF terminated line"), s2n_stuffer_data_available(&token));
         EXPECT_SUCCESS(memcmp("a LF terminated line", token.blob.data, s2n_stuffer_data_available(&token)));
 
-        EXPECT_SUCCESS(s2n_blob_init(&line_blob, (uint8_t *) crlf_line, sizeof(crlf_line)));
+        EXPECT_OK(s2n_blob_init(&line_blob, (uint8_t *) crlf_line, sizeof(crlf_line)));
         EXPECT_SUCCESS(s2n_stuffer_init(&lstuffer, &line_blob));
         EXPECT_SUCCESS(s2n_stuffer_write(&lstuffer, &line_blob));
         memset(pad, 0, sizeof(pad));
-        EXPECT_SUCCESS(s2n_blob_init(&pad_blob, pad, sizeof(pad)));
+        EXPECT_OK(s2n_blob_init(&pad_blob, pad, sizeof(pad)));
         EXPECT_SUCCESS(s2n_stuffer_init(&token, &pad_blob));
         EXPECT_SUCCESS(s2n_stuffer_read_line(&lstuffer, &token));
         EXPECT_EQUAL(strlen("a CRLF terminated line"), s2n_stuffer_data_available(&token));
         EXPECT_SUCCESS(memcmp("a CRLF terminated line", token.blob.data, s2n_stuffer_data_available(&token)));
 
-        EXPECT_SUCCESS(s2n_blob_init(&line_blob, (uint8_t *) lf_line_trailing_cr, sizeof(lf_line_trailing_cr)));
+        EXPECT_OK(s2n_blob_init(&line_blob, (uint8_t *) lf_line_trailing_cr, sizeof(lf_line_trailing_cr)));
         EXPECT_SUCCESS(s2n_stuffer_init(&lstuffer, &line_blob));
         EXPECT_SUCCESS(s2n_stuffer_write(&lstuffer, &line_blob));
         memset(pad, 0, sizeof(pad));
-        EXPECT_SUCCESS(s2n_blob_init(&pad_blob, pad, sizeof(pad)));
+        EXPECT_OK(s2n_blob_init(&pad_blob, pad, sizeof(pad)));
         EXPECT_SUCCESS(s2n_stuffer_init(&token, &pad_blob));
         EXPECT_SUCCESS(s2n_stuffer_read_line(&lstuffer, &token));
         EXPECT_EQUAL(strlen("a LF terminated line with trailing CR"), s2n_stuffer_data_available(&token));
         EXPECT_SUCCESS(memcmp("a LF terminated line with trailing CR", token.blob.data, s2n_stuffer_data_available(&token)));
 
-        EXPECT_SUCCESS(s2n_blob_init(&line_blob, (uint8_t *) not_a_line, sizeof(not_a_line)));
+        EXPECT_OK(s2n_blob_init(&line_blob, (uint8_t *) not_a_line, sizeof(not_a_line)));
         EXPECT_SUCCESS(s2n_stuffer_init(&lstuffer, &line_blob));
         EXPECT_SUCCESS(s2n_stuffer_write(&lstuffer, &line_blob));
         memset(pad, 0, sizeof(pad));
-        EXPECT_SUCCESS(s2n_blob_init(&pad_blob, pad, sizeof(pad)));
+        EXPECT_OK(s2n_blob_init(&pad_blob, pad, sizeof(pad)));
         EXPECT_SUCCESS(s2n_stuffer_init(&token, &pad_blob));
         EXPECT_SUCCESS(s2n_stuffer_read_line(&lstuffer, &token));
         EXPECT_EQUAL(sizeof(not_a_line), s2n_stuffer_data_available(&token));

--- a/tests/unit/s2n_tls13_cert_verify_test.c
+++ b/tests/unit/s2n_tls13_cert_verify_test.c
@@ -88,13 +88,13 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         EXPECT_SUCCESS(s2n_connection_set_config(verifying_conn, config));
         verifying_conn->secure->cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
-        EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
+        EXPECT_OK(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
         EXPECT_SUCCESS(s2n_stuffer_write(&certificate_in, &b));
         EXPECT_SUCCESS(s2n_stuffer_certificate_from_pem(&certificate_in, &certificate_out));
 
         /* Extract public key from certificate and set it for verifying connection */
         uint32_t available_size = s2n_stuffer_data_available(&certificate_out);
-        EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
+        EXPECT_OK(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
         if (verifying_conn->mode == S2N_CLIENT) {
             EXPECT_OK(s2n_asn1der_to_public_key_and_type(&verifying_conn->handshake_params.server_public_key, &pkey_type, &b));
             EXPECT_SUCCESS(s2n_pkey_match(&verifying_conn->handshake_params.server_public_key, sending_conn->handshake_params.our_chain_and_key->private_key));
@@ -154,12 +154,12 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         verifying_conn->handshake_params.client_cert_sig_scheme = &sig_scheme;
         verifying_conn->secure->cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
-        EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
+        EXPECT_OK(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
         EXPECT_SUCCESS(s2n_stuffer_write(&certificate_in, &b));
         EXPECT_SUCCESS(s2n_stuffer_certificate_from_pem(&certificate_in, &certificate_out));
 
         uint32_t available_size = s2n_stuffer_data_available(&certificate_out);
-        EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
+        EXPECT_OK(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
         if (verifying_conn->mode == S2N_CLIENT) {
             EXPECT_OK(s2n_asn1der_to_public_key_and_type(&verifying_conn->handshake_params.server_public_key, &pkey_type, &b));
             EXPECT_SUCCESS(s2n_pkey_match(&verifying_conn->handshake_params.server_public_key, verifying_conn->handshake_params.our_chain_and_key->private_key));
@@ -210,12 +210,12 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         verifying_conn->handshake_params.client_cert_sig_scheme = &sig_scheme;
         verifying_conn->secure->cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
 
-        EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
+        EXPECT_OK(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
         EXPECT_SUCCESS(s2n_stuffer_write(&certificate_in, &b));
         EXPECT_SUCCESS(s2n_stuffer_certificate_from_pem(&certificate_in, &certificate_out));
 
         uint32_t available_size = s2n_stuffer_data_available(&certificate_out);
-        EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
+        EXPECT_OK(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
         if (verifying_conn->mode == S2N_CLIENT) {
             EXPECT_OK(s2n_asn1der_to_public_key_and_type(&verifying_conn->handshake_params.server_public_key, &pkey_type, &b));
         } else {
@@ -268,13 +268,13 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         verifying_conn->secure->cipher_suite = &s2n_tls13_aes_128_gcm_sha256;
         verifying_conn->actual_protocol_version = S2N_TLS13;
 
-        EXPECT_SUCCESS(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
+        EXPECT_OK(s2n_blob_init(&b, (uint8_t *) cert_chain_pem, strlen(cert_chain_pem) + 1));
         EXPECT_SUCCESS(s2n_stuffer_write(&certificate_in, &b));
 
         EXPECT_SUCCESS(s2n_stuffer_certificate_from_pem(&certificate_in, &certificate_out));
 
         uint32_t available_size = s2n_stuffer_data_available(&certificate_out);
-        EXPECT_SUCCESS(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
+        EXPECT_OK(s2n_blob_init(&b, s2n_stuffer_raw_read(&certificate_out, available_size), available_size));
         if (verifying_conn->mode == S2N_CLIENT) {
             EXPECT_OK(s2n_asn1der_to_public_key_and_type(&verifying_conn->handshake_params.server_public_key, &pkey_type, &b));
         } else {

--- a/tests/unit/s2n_tls13_key_schedule_test.c
+++ b/tests/unit/s2n_tls13_key_schedule_test.c
@@ -49,7 +49,7 @@ static int s2n_test_secret_cb(void *context, struct s2n_connection *conn,
     POSIX_ENSURE_GTE(secret_type, 0);
     POSIX_ENSURE_LT(secret_type, TRAFFIC_SECRET_COUNT);
     POSIX_ENSURE_EQ(secrets->blobs[secret_type].size, 0);
-    POSIX_GUARD(s2n_blob_init(&secrets->blobs[secret_type],
+    POSIX_GUARD_RESULT(s2n_blob_init(&secrets->blobs[secret_type],
             secrets->bytes[secret_type], secret_size));
     POSIX_CHECKED_MEMCPY(secrets->bytes[secret_type], secret_bytes, secret_size);
     return S2N_SUCCESS;
@@ -86,7 +86,7 @@ static S2N_RESULT s2n_mock_derive_method(struct s2n_connection *conn, struct s2n
     uint8_t size = 0;
     s2n_hmac_algorithm hmac_alg = conn->secure->cipher_suite->prf_alg;
     RESULT_GUARD_POSIX(s2n_hmac_digest_size(hmac_alg, &size));
-    RESULT_GUARD_POSIX(s2n_blob_init(secret, empty_secret, size));
+    RESULT_GUARD(s2n_blob_init(secret, empty_secret, size));
     return S2N_RESULT_OK;
 }
 

--- a/tests/unit/s2n_tls13_prf_test.c
+++ b/tests/unit/s2n_tls13_prf_test.c
@@ -113,11 +113,11 @@ int main(int argc, char **argv)
     uint8_t output_buf[SHA256_DIGEST_LENGTH] = { 0 };
     struct s2n_blob output = { 0 };
 
-    EXPECT_SUCCESS(s2n_blob_init(&salt, salt_buf, sizeof(salt_buf)));
-    EXPECT_SUCCESS(s2n_blob_init(&ikm, ikm_buf, sizeof(ikm_buf)));
-    EXPECT_SUCCESS(s2n_blob_init(&digest, digest_buf, sizeof(digest_buf)));
-    EXPECT_SUCCESS(s2n_blob_init(&secret, secret_buf, sizeof(secret_buf)));
-    EXPECT_SUCCESS(s2n_blob_init(&output, output_buf, sizeof(output_buf)));
+    EXPECT_OK(s2n_blob_init(&salt, salt_buf, sizeof(salt_buf)));
+    EXPECT_OK(s2n_blob_init(&ikm, ikm_buf, sizeof(ikm_buf)));
+    EXPECT_OK(s2n_blob_init(&digest, digest_buf, sizeof(digest_buf)));
+    EXPECT_OK(s2n_blob_init(&secret, secret_buf, sizeof(secret_buf)));
+    EXPECT_OK(s2n_blob_init(&output, output_buf, sizeof(output_buf)));
 
     struct s2n_hmac_state throwaway;
     EXPECT_SUCCESS(s2n_hmac_new(&throwaway));

--- a/tests/unit/s2n_tls13_record_aead_test.c
+++ b/tests/unit/s2n_tls13_record_aead_test.c
@@ -106,19 +106,19 @@ int main(int argc, char **argv)
         S2N_BLOB_EXPECT_EQUAL(expected_aad, aad);
 
         /* record length 16640 should be valid */
-        EXPECT_SUCCESS(s2n_blob_zero(&aad));
+        EXPECT_OK(s2n_blob_zero(&aad));
         EXPECT_OK(s2n_tls13_aead_aad_init(16628, 12, &aad));
 
         /* record length 16641 should be invalid */
-        EXPECT_SUCCESS(s2n_blob_zero(&aad));
+        EXPECT_OK(s2n_blob_zero(&aad));
         EXPECT_ERROR_WITH_ERRNO(s2n_tls13_aead_aad_init(16629, 12, &aad), S2N_ERR_RECORD_LIMIT);
 
         /* Test failure case: No AAD should be invalid */
-        EXPECT_SUCCESS(s2n_blob_zero(&aad));
+        EXPECT_OK(s2n_blob_zero(&aad));
         EXPECT_ERROR(s2n_tls13_aead_aad_init(16629, 12, NULL));
 
         /* Test failure case: 0-length tag should be invalid */
-        EXPECT_SUCCESS(s2n_blob_zero(&aad));
+        EXPECT_OK(s2n_blob_zero(&aad));
         EXPECT_ERROR(s2n_tls13_aead_aad_init(16628, 0, &aad));
 
         /* Test failure case: invalid record length (-1) should be invalid */
@@ -296,7 +296,7 @@ int main(int argc, char **argv)
 
         static uint8_t hello_data[] = "Hello world";
         struct s2n_blob plaintext = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&plaintext, hello_data, sizeof(hello_data) - 1));
+        EXPECT_OK(s2n_blob_init(&plaintext, hello_data, sizeof(hello_data) - 1));
 
         /* Takes an input blob and writes to out stuffer then encrypt the payload */
         EXPECT_OK(s2n_record_write(conn, TLS_HANDSHAKE, &plaintext));

--- a/tests/unit/s2n_tls13_secrets_rfc8448_test.c
+++ b/tests/unit/s2n_tls13_secrets_rfc8448_test.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
 
     struct s2n_blob derived_secret = { 0 };
     uint8_t derived_secret_bytes[S2N_TLS13_SECRET_MAX_LEN] = { 0 };
-    EXPECT_SUCCESS(s2n_blob_init(&derived_secret,
+    EXPECT_OK(s2n_blob_init(&derived_secret,
             derived_secret_bytes, S2N_TLS13_SECRET_MAX_LEN));
 
     /*

--- a/tests/unit/s2n_tls13_secrets_test.c
+++ b/tests/unit/s2n_tls13_secrets_test.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
 
     struct s2n_blob test_secret = { 0 };
     uint8_t test_secret_bytes[S2N_TLS13_SECRET_MAX_LEN] = "hello world";
-    EXPECT_SUCCESS(s2n_blob_init(&test_secret, test_secret_bytes, sizeof(test_secret_bytes)));
+    EXPECT_OK(s2n_blob_init(&test_secret, test_secret_bytes, sizeof(test_secret_bytes)));
 
     struct s2n_tls13_secrets_test_case test_cases[1000] = { 0 };
     size_t test_cases_count = 0;
@@ -186,7 +186,7 @@ int main(int argc, char **argv)
         {
             uint8_t output_bytes[S2N_TLS13_SECRET_MAX_LEN] = { 0 };
             struct s2n_blob output = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&output, output_bytes, sizeof(output_bytes)));
+            EXPECT_OK(s2n_blob_init(&output, output_bytes, sizeof(output_bytes)));
 
             DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
                     s2n_connection_ptr_free);
@@ -201,7 +201,7 @@ int main(int argc, char **argv)
         {
             uint8_t output_bytes[S2N_TLS13_SECRET_MAX_LEN] = { 0 };
             struct s2n_blob output = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&output, output_bytes, sizeof(output_bytes)));
+            EXPECT_OK(s2n_blob_init(&output, output_bytes, sizeof(output_bytes)));
 
             DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
                     s2n_connection_ptr_free);
@@ -225,7 +225,7 @@ int main(int argc, char **argv)
         {
             uint8_t output_bytes[S2N_TLS13_SECRET_MAX_LEN] = { 0 };
             struct s2n_blob output = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&output, output_bytes, sizeof(output_bytes)));
+            EXPECT_OK(s2n_blob_init(&output, output_bytes, sizeof(output_bytes)));
 
             DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
                     s2n_connection_ptr_free);
@@ -247,7 +247,7 @@ int main(int argc, char **argv)
         for (size_t i = 0; i < test_cases_count; i++) {
             uint8_t output_bytes[S2N_TLS13_SECRET_MAX_LEN] = { 0 };
             struct s2n_blob output = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&output, output_bytes, sizeof(output_bytes)));
+            EXPECT_OK(s2n_blob_init(&output, output_bytes, sizeof(output_bytes)));
 
             DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(test_cases[i].conn_mode),
                     s2n_connection_ptr_free);
@@ -346,7 +346,7 @@ int main(int argc, char **argv)
 
             struct s2n_blob result = { 0 };
             uint8_t result_bytes[S2N_TLS13_SECRET_MAX_LEN] = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&result, result_bytes, sizeof(result_bytes)));
+            EXPECT_OK(s2n_blob_init(&result, result_bytes, sizeof(result_bytes)));
             EXPECT_OK(s2n_tls13_secrets_get(conn, S2N_HANDSHAKE_SECRET, S2N_CLIENT, &result));
 
             EXPECT_TRUE(result.size > 0);

--- a/tests/unit/s2n_tls_hybrid_prf_test.c
+++ b/tests/unit/s2n_tls_hybrid_prf_test.c
@@ -87,9 +87,9 @@ int main(int argc, char **argv)
         POSIX_GUARD(ReadHex(kat_file, expected_master_secret, MASTER_SECRET_LENGTH, "master_secret = "));
 
         struct s2n_blob classic_pms = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&classic_pms, premaster_classic_secret, PREMASTER_CLASSIC_SECRET_LENGTH));
+        EXPECT_OK(s2n_blob_init(&classic_pms, premaster_classic_secret, PREMASTER_CLASSIC_SECRET_LENGTH));
         struct s2n_blob kem_pms = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&kem_pms, premaster_kem_secret, premaster_kem_secret_length));
+        EXPECT_OK(s2n_blob_init(&kem_pms, premaster_kem_secret, premaster_kem_secret_length));
 
         /* In the future the hybrid_kex client_key_send (client side) and client_key_receive (server side) will concatenate the two parts */
         DEFER_CLEANUP(struct s2n_blob combined_pms = { 0 }, s2n_free);

--- a/tests/unit/s2n_tls_prf_test.c
+++ b/tests/unit/s2n_tls_prf_test.c
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
         EXPECT_MEMCPY_SUCCESS(conn->handshake_params.server_random, server_random_in.data, server_random_in.size);
 
         struct s2n_blob pms = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&pms, conn->secrets.version.tls12.rsa_premaster_secret, sizeof(conn->secrets.version.tls12.rsa_premaster_secret)));
+        EXPECT_OK(s2n_blob_init(&pms, conn->secrets.version.tls12.rsa_premaster_secret, sizeof(conn->secrets.version.tls12.rsa_premaster_secret)));
         EXPECT_SUCCESS(s2n_tls_prf_master_secret(conn, &pms));
         EXPECT_EQUAL(memcmp(conn->secrets.version.tls12.master_secret, master_secret_in.data, master_secret_in.size), 0);
 
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
         EXPECT_MEMCPY_SUCCESS(conn->handshake_params.server_random, server_random_in.data, server_random_in.size);
 
         struct s2n_blob pms = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&pms, conn->secrets.version.tls12.rsa_premaster_secret, sizeof(conn->secrets.version.tls12.rsa_premaster_secret)));
+        EXPECT_OK(s2n_blob_init(&pms, conn->secrets.version.tls12.rsa_premaster_secret, sizeof(conn->secrets.version.tls12.rsa_premaster_secret)));
 
         /* Errors when handshake is not at the Client Key Exchange message */
         EXPECT_FAILURE_WITH_ERRNO(s2n_prf_calculate_master_secret(conn, &pms), S2N_ERR_SAFETY);
@@ -193,14 +193,14 @@ int main(int argc, char **argv)
 
         uint8_t data[S2N_MAX_DIGEST_LEN] = { 0 };
         struct s2n_blob digest_for_ems = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&digest_for_ems, data, sizeof(data)));
+        EXPECT_OK(s2n_blob_init(&digest_for_ems, data, sizeof(data)));
 
         /* Get the Client Key transcript */
         EXPECT_SUCCESS(s2n_stuffer_skip_read(&client_to_server, S2N_TLS_RECORD_HEADER_LENGTH));
         uint8_t client_key_message_length = s2n_stuffer_data_available(&client_to_server);
         uint8_t *client_key_message = s2n_stuffer_raw_read(&client_to_server, client_key_message_length);
         struct s2n_blob message = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&message, client_key_message, client_key_message_length));
+        EXPECT_OK(s2n_blob_init(&message, client_key_message, client_key_message_length));
 
         s2n_hmac_algorithm prf_alg = server_conn->secure->cipher_suite->prf_alg;
         s2n_hash_algorithm hash_alg = 0;
@@ -287,7 +287,7 @@ int main(int argc, char **argv)
         /* PRF usable throughout connection lifecycle */
         {
             struct s2n_blob pms = { 0 };
-            EXPECT_SUCCESS(s2n_blob_init(&pms, premaster_secret_in.data, premaster_secret_in.size));
+            EXPECT_OK(s2n_blob_init(&pms, premaster_secret_in.data, premaster_secret_in.size));
 
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
             EXPECT_MEMCPY_SUCCESS(conn->secrets.version.tls12.rsa_premaster_secret, premaster_secret_in.data, premaster_secret_in.size);

--- a/tests/unit/s2n_wildcard_hostname_test.c
+++ b/tests/unit/s2n_wildcard_hostname_test.c
@@ -47,10 +47,10 @@ int main(int argc, char **argv)
     for (size_t i = 0; i < num_wildcardify_tests; i++) {
         const char *hostname = wildcardify_test_cases[i].hostname;
         struct s2n_blob hostname_blob = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&hostname_blob, (uint8_t *) (uintptr_t) hostname, strlen(hostname)));
+        EXPECT_OK(s2n_blob_init(&hostname_blob, (uint8_t *) (uintptr_t) hostname, strlen(hostname)));
         uint8_t output[S2N_MAX_SERVER_NAME] = { 0 };
         struct s2n_blob output_blob = { 0 };
-        EXPECT_SUCCESS(s2n_blob_init(&output_blob, (uint8_t *) (uintptr_t) output, sizeof(output)));
+        EXPECT_OK(s2n_blob_init(&output_blob, (uint8_t *) (uintptr_t) output, sizeof(output)));
         struct s2n_stuffer hostname_stuffer = { 0 };
         struct s2n_stuffer output_stuffer = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_init(&hostname_stuffer, &hostname_blob));

--- a/tls/extensions/s2n_client_alpn.c
+++ b/tls/extensions/s2n_client_alpn.c
@@ -76,7 +76,7 @@ static int s2n_client_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer 
     }
 
     struct s2n_blob client_protocols = { 0 };
-    POSIX_GUARD(s2n_blob_init(&client_protocols, s2n_stuffer_raw_read(extension, wire_size), wire_size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&client_protocols, s2n_stuffer_raw_read(extension, wire_size), wire_size));
 
     struct s2n_stuffer server_protocols = { 0 };
     POSIX_GUARD(s2n_stuffer_init(&server_protocols, supported_protocols));

--- a/tls/extensions/s2n_client_key_share.c
+++ b/tls/extensions/s2n_client_key_share.c
@@ -424,7 +424,7 @@ static int s2n_client_key_share_recv(struct s2n_connection *conn, struct s2n_stu
         POSIX_GUARD(s2n_stuffer_read_uint16(extension, &share_size));
         POSIX_ENSURE(s2n_stuffer_data_available(extension) >= share_size, S2N_ERR_BAD_MESSAGE);
 
-        POSIX_GUARD(s2n_blob_init(&key_share_blob,
+        POSIX_GUARD_RESULT(s2n_blob_init(&key_share_blob,
                 s2n_stuffer_raw_read(extension, share_size), share_size));
         POSIX_GUARD(s2n_stuffer_init(&key_share, &key_share_blob));
         POSIX_GUARD(s2n_stuffer_skip_write(&key_share, share_size));

--- a/tls/extensions/s2n_client_psk.c
+++ b/tls/extensions/s2n_client_psk.c
@@ -292,7 +292,7 @@ static S2N_RESULT s2n_client_psk_recv_binder_list(struct s2n_connection *conn, s
         RESULT_ENSURE_REF(wire_binder_data = s2n_stuffer_raw_read(wire_binders_in, wire_binder_size));
 
         struct s2n_blob wire_binder = { 0 };
-        RESULT_GUARD_POSIX(s2n_blob_init(&wire_binder, wire_binder_data, wire_binder_size));
+        RESULT_GUARD(s2n_blob_init(&wire_binder, wire_binder_data, wire_binder_size));
 
         if (wire_index == conn->psk_params.chosen_psk_wire_index) {
             RESULT_GUARD_POSIX(s2n_psk_verify_binder(conn, conn->psk_params.chosen_psk,
@@ -315,7 +315,7 @@ static S2N_RESULT s2n_client_psk_recv_identities(struct s2n_connection *conn, st
     RESULT_ENSURE_REF(identity_list_data = s2n_stuffer_raw_read(extension, identity_list_size));
 
     struct s2n_blob identity_list_blob = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&identity_list_blob, identity_list_data, identity_list_size));
+    RESULT_GUARD(s2n_blob_init(&identity_list_blob, identity_list_data, identity_list_size));
 
     struct s2n_stuffer identity_list = { 0 };
     RESULT_GUARD_POSIX(s2n_stuffer_init(&identity_list, &identity_list_blob));
@@ -335,7 +335,7 @@ static S2N_RESULT s2n_client_psk_recv_binders(struct s2n_connection *conn, struc
     RESULT_ENSURE_REF(binder_list_data = s2n_stuffer_raw_read(extension, binder_list_size));
 
     struct s2n_blob binder_list_blob = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&binder_list_blob, binder_list_data, binder_list_size));
+    RESULT_GUARD(s2n_blob_init(&binder_list_blob, binder_list_data, binder_list_size));
 
     struct s2n_stuffer binder_list = { 0 };
     RESULT_GUARD_POSIX(s2n_stuffer_init(&binder_list, &binder_list_blob));
@@ -348,7 +348,7 @@ static S2N_RESULT s2n_client_psk_recv_binders(struct s2n_connection *conn, struc
     uint32_t binders_size = binder_list_blob.size + SIZE_OF_BINDER_LIST_SIZE;
     RESULT_ENSURE_GTE(client_hello->write_cursor, binders_size);
     uint16_t partial_client_hello_size = client_hello->write_cursor - binders_size;
-    RESULT_GUARD_POSIX(s2n_blob_slice(&client_hello->blob, &partial_client_hello, 0, partial_client_hello_size));
+    RESULT_GUARD(s2n_blob_slice(&client_hello->blob, &partial_client_hello, 0, partial_client_hello_size));
 
     return s2n_client_psk_recv_binder_list(conn, &partial_client_hello, &binder_list);
 }

--- a/tls/extensions/s2n_client_server_name.c
+++ b/tls/extensions/s2n_client_server_name.c
@@ -77,7 +77,7 @@ S2N_RESULT s2n_client_server_name_parse(struct s2n_stuffer *extension, struct s2
 
     uint8_t *data = s2n_stuffer_raw_read(extension, length);
     RESULT_ENSURE_REF(data);
-    RESULT_GUARD_POSIX(s2n_blob_init(server_name, data, length));
+    RESULT_GUARD(s2n_blob_init(server_name, data, length));
 
     return S2N_RESULT_OK;
 }

--- a/tls/extensions/s2n_extension_list.c
+++ b/tls/extensions/s2n_extension_list.c
@@ -149,7 +149,7 @@ static int s2n_extension_parse(struct s2n_stuffer *in, s2n_parsed_extension *par
     /* Fill in parsed extension */
     parsed_extension->extension_type = extension_type;
     parsed_extension->wire_index = *wire_index;
-    POSIX_GUARD(s2n_blob_init(&parsed_extension->extension, extension_data, extension_size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&parsed_extension->extension, extension_data, extension_size));
     (*wire_index)++;
 
     return S2N_SUCCESS;
@@ -171,7 +171,7 @@ int s2n_extension_list_parse(struct s2n_stuffer *in, s2n_parsed_extensions_list 
     uint8_t *extensions_data = s2n_stuffer_raw_read(in, total_extensions_size);
     POSIX_ENSURE(extensions_data != NULL, S2N_ERR_BAD_MESSAGE);
 
-    POSIX_GUARD(s2n_blob_init(&parsed_extension_list->raw, extensions_data, total_extensions_size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&parsed_extension_list->raw, extensions_data, total_extensions_size));
 
     struct s2n_stuffer extensions_stuffer = { 0 };
     POSIX_GUARD(s2n_stuffer_init(&extensions_stuffer, &parsed_extension_list->raw));

--- a/tls/extensions/s2n_server_sct_list.c
+++ b/tls/extensions/s2n_server_sct_list.c
@@ -56,7 +56,7 @@ int s2n_server_sct_list_recv(struct s2n_connection *conn, struct s2n_stuffer *ex
 
     struct s2n_blob sct_list = { 0 };
     size_t data_available = s2n_stuffer_data_available(extension);
-    POSIX_GUARD(s2n_blob_init(&sct_list,
+    POSIX_GUARD_RESULT(s2n_blob_init(&sct_list,
             s2n_stuffer_raw_read(extension, data_available),
             data_available));
     POSIX_ENSURE_REF(sct_list.data);

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -322,7 +322,7 @@ S2N_RESULT s2n_alerts_write_error_or_close_notify(struct s2n_connection *conn)
 
     struct s2n_blob alert = { 0 };
     uint8_t alert_bytes[] = { level, code };
-    RESULT_GUARD_POSIX(s2n_blob_init(&alert, alert_bytes, sizeof(alert_bytes)));
+    RESULT_GUARD(s2n_blob_init(&alert, alert_bytes, sizeof(alert_bytes)));
 
     RESULT_GUARD(s2n_record_write(conn, TLS_ALERT, &alert));
     conn->alert_sent = true;
@@ -340,7 +340,7 @@ S2N_RESULT s2n_alerts_write_warning(struct s2n_connection *conn)
 
     struct s2n_blob alert = { 0 };
     uint8_t alert_bytes[] = { level, code };
-    RESULT_GUARD_POSIX(s2n_blob_init(&alert, alert_bytes, sizeof(alert_bytes)));
+    RESULT_GUARD(s2n_blob_init(&alert, alert_bytes, sizeof(alert_bytes)));
 
     RESULT_GUARD(s2n_record_write(conn, TLS_ALERT, &alert));
     return S2N_RESULT_OK;

--- a/tls/s2n_async_pkey.c
+++ b/tls/s2n_async_pkey.c
@@ -135,10 +135,10 @@ static S2N_RESULT s2n_async_pkey_op_allocate(struct s2n_async_pkey_op **op)
     /* allocate memory */
     DEFER_CLEANUP(struct s2n_blob mem = { 0 }, s2n_free);
     RESULT_GUARD_POSIX(s2n_alloc(&mem, sizeof(struct s2n_async_pkey_op)));
-    RESULT_GUARD_POSIX(s2n_blob_zero(&mem));
+    RESULT_GUARD(s2n_blob_zero(&mem));
 
     *op = (void *) mem.data;
-    if (s2n_blob_init(&mem, NULL, 0) != S2N_SUCCESS) {
+    if (s2n_result_is_error(s2n_blob_init(&mem, NULL, 0))) {
         *op = NULL;
         return S2N_RESULT_ERROR;
     }
@@ -394,8 +394,8 @@ S2N_RESULT s2n_async_pkey_decrypt_free(struct s2n_async_pkey_op *op)
 
     struct s2n_async_pkey_decrypt_data *decrypt = &op->op.decrypt;
 
-    RESULT_GUARD_POSIX(s2n_blob_zero(&decrypt->decrypted));
-    RESULT_GUARD_POSIX(s2n_blob_zero(&decrypt->encrypted));
+    RESULT_GUARD(s2n_blob_zero(&decrypt->decrypted));
+    RESULT_GUARD(s2n_blob_zero(&decrypt->encrypted));
     RESULT_GUARD_POSIX(s2n_free(&decrypt->decrypted));
     RESULT_GUARD_POSIX(s2n_free(&decrypt->encrypted));
 

--- a/tls/s2n_change_cipher_spec.c
+++ b/tls/s2n_change_cipher_spec.c
@@ -44,8 +44,8 @@ int s2n_client_ccs_recv(struct s2n_connection *conn)
 
     /* Zero the sequence number */
     struct s2n_blob seq = { 0 };
-    POSIX_GUARD(s2n_blob_init(&seq, conn->secure->client_sequence_number, sizeof(conn->secure->client_sequence_number)));
-    POSIX_GUARD(s2n_blob_zero(&seq));
+    POSIX_GUARD_RESULT(s2n_blob_init(&seq, conn->secure->client_sequence_number, sizeof(conn->secure->client_sequence_number)));
+    POSIX_GUARD_RESULT(s2n_blob_zero(&seq));
 
     /* Update the client to use the cipher-suite */
     conn->client = conn->secure;
@@ -67,8 +67,8 @@ int s2n_server_ccs_recv(struct s2n_connection *conn)
 
     /* Zero the sequence number */
     struct s2n_blob seq = { 0 };
-    POSIX_GUARD(s2n_blob_init(&seq, conn->secure->server_sequence_number, sizeof(conn->secure->server_sequence_number)));
-    POSIX_GUARD(s2n_blob_zero(&seq));
+    POSIX_GUARD_RESULT(s2n_blob_init(&seq, conn->secure->server_sequence_number, sizeof(conn->secure->server_sequence_number)));
+    POSIX_GUARD_RESULT(s2n_blob_zero(&seq));
 
     /* Compute the finished message */
     POSIX_GUARD(s2n_prf_server_finished(conn));

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1000,7 +1000,7 @@ int s2n_cipher_suites_init(void)
         /* Initialize SSLv3 cipher suite if SSLv3 utilizes a different record algorithm */
         if (cur_suite->sslv3_record_alg && cur_suite->sslv3_record_alg->cipher->is_available()) {
             struct s2n_blob cur_suite_mem = { 0 };
-            POSIX_GUARD(s2n_blob_init(&cur_suite_mem, (uint8_t *) cur_suite, sizeof(struct s2n_cipher_suite)));
+            POSIX_GUARD_RESULT(s2n_blob_init(&cur_suite_mem, (uint8_t *) cur_suite, sizeof(struct s2n_cipher_suite)));
             struct s2n_blob new_suite_mem = { 0 };
             POSIX_GUARD(s2n_dup(&cur_suite_mem, &new_suite_mem));
 

--- a/tls/s2n_client_cert.c
+++ b/tls/s2n_client_cert.c
@@ -121,7 +121,7 @@ int s2n_client_cert_recv(struct s2n_connection *conn)
     POSIX_ENSURE_REF(cert_chain_data);
 
     struct s2n_blob cert_chain = { 0 };
-    POSIX_GUARD(s2n_blob_init(&cert_chain, cert_chain_data, cert_chain_size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&cert_chain, cert_chain_data, cert_chain_size));
     POSIX_ENSURE(s2n_result_is_ok(s2n_client_cert_chain_store(conn, &cert_chain)),
             S2N_ERR_BAD_MESSAGE);
 

--- a/tls/s2n_client_finished.c
+++ b/tls/s2n_client_finished.c
@@ -57,7 +57,7 @@ int s2n_tls13_client_finished_recv(struct s2n_connection *conn)
 
     /* read finished mac from handshake */
     struct s2n_blob wire_finished_mac = { 0 };
-    POSIX_GUARD(s2n_blob_init(&wire_finished_mac, s2n_stuffer_raw_read(&conn->handshake.io, length), length));
+    POSIX_GUARD_RESULT(s2n_blob_init(&wire_finished_mac, s2n_stuffer_raw_read(&conn->handshake.io, length), length));
 
     /* get tls13 keys */
     s2n_tls13_connection_keys(keys, conn);
@@ -68,7 +68,7 @@ int s2n_tls13_client_finished_recv(struct s2n_connection *conn)
     POSIX_GUARD_RESULT(s2n_handshake_copy_hash_state(conn, keys.hash_algorithm, hash_state));
 
     struct s2n_blob finished_key = { 0 };
-    POSIX_GUARD(s2n_blob_init(&finished_key, conn->handshake.client_finished, keys.size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&finished_key, conn->handshake.client_finished, keys.size));
 
     s2n_tls13_key_blob(client_finished_mac, keys.size);
     POSIX_GUARD(s2n_tls13_calculate_finished_mac(&keys, &finished_key, hash_state, &client_finished_mac));
@@ -92,7 +92,7 @@ int s2n_tls13_client_finished_send(struct s2n_connection *conn)
 
     /* look up finished secret key */
     struct s2n_blob finished_key = { 0 };
-    POSIX_GUARD(s2n_blob_init(&finished_key, conn->handshake.client_finished, keys.size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&finished_key, conn->handshake.client_finished, keys.size));
 
     /* generate the hashed message authenticated code */
     s2n_stack_blob(client_finished_mac, keys.size, S2N_TLS13_SECRET_MAX_LEN);

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -92,7 +92,7 @@ static S2N_RESULT s2n_generate_client_session_id(struct s2n_connection *conn)
     RESULT_ENSURE(!conn->quic_enabled, S2N_ERR_UNSUPPORTED_WITH_QUIC);
 
     struct s2n_blob session_id = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&session_id, conn->session_id, S2N_TLS_SESSION_ID_MAX_LEN));
+    RESULT_GUARD(s2n_blob_init(&session_id, conn->session_id, S2N_TLS_SESSION_ID_MAX_LEN));
     RESULT_GUARD(s2n_get_public_random_data(&session_id));
     conn->session_id_len = S2N_TLS_SESSION_ID_MAX_LEN;
     return S2N_RESULT_OK;
@@ -401,7 +401,7 @@ S2N_RESULT s2n_client_hello_parse_raw(struct s2n_client_hello *client_hello,
     RESULT_ENSURE(session_id_len <= S2N_TLS_SESSION_ID_MAX_LEN, S2N_ERR_BAD_MESSAGE);
     uint8_t *session_id = s2n_stuffer_raw_read(in, session_id_len);
     RESULT_ENSURE(session_id != NULL, S2N_ERR_BAD_MESSAGE);
-    RESULT_GUARD_POSIX(s2n_blob_init(&client_hello->session_id, session_id, session_id_len));
+    RESULT_GUARD(s2n_blob_init(&client_hello->session_id, session_id, session_id_len));
 
     /* cipher suites */
     uint16_t cipher_suites_length = 0;
@@ -410,14 +410,14 @@ S2N_RESULT s2n_client_hello_parse_raw(struct s2n_client_hello *client_hello,
     RESULT_ENSURE(cipher_suites_length % S2N_TLS_CIPHER_SUITE_LEN == 0, S2N_ERR_BAD_MESSAGE);
     uint8_t *cipher_suites = s2n_stuffer_raw_read(in, cipher_suites_length);
     RESULT_ENSURE(cipher_suites != NULL, S2N_ERR_BAD_MESSAGE);
-    RESULT_GUARD_POSIX(s2n_blob_init(&client_hello->cipher_suites, cipher_suites, cipher_suites_length));
+    RESULT_GUARD(s2n_blob_init(&client_hello->cipher_suites, cipher_suites, cipher_suites_length));
 
     /* legacy_compression_methods */
     uint8_t compression_methods_len = 0;
     RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(in, &compression_methods_len));
     uint8_t *compression_methods = s2n_stuffer_raw_read(in, compression_methods_len);
     RESULT_ENSURE(compression_methods != NULL, S2N_ERR_BAD_MESSAGE);
-    RESULT_GUARD_POSIX(s2n_blob_init(&client_hello->compression_methods, compression_methods, compression_methods_len));
+    RESULT_GUARD(s2n_blob_init(&client_hello->compression_methods, compression_methods, compression_methods_len));
 
     /* extensions */
     RESULT_GUARD_POSIX(s2n_extension_list_parse(in, &client_hello->extensions));
@@ -511,7 +511,7 @@ static S2N_RESULT s2n_client_hello_parse_message_impl(struct s2n_client_hello **
 
     DEFER_CLEANUP(struct s2n_blob mem = { 0 }, s2n_free);
     RESULT_GUARD_POSIX(s2n_alloc(&mem, sizeof(struct s2n_client_hello)));
-    RESULT_GUARD_POSIX(s2n_blob_zero(&mem));
+    RESULT_GUARD(s2n_blob_zero(&mem));
 
     DEFER_CLEANUP(struct s2n_client_hello *client_hello = NULL, s2n_client_hello_free);
     client_hello = (struct s2n_client_hello *) (void *) mem.data;
@@ -722,7 +722,7 @@ int s2n_client_hello_send(struct s2n_connection *conn)
     POSIX_GUARD(s2n_stuffer_write_bytes(out, client_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
 
     struct s2n_blob client_random = { 0 };
-    POSIX_GUARD(s2n_blob_init(&client_random, conn->handshake_params.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD_RESULT(s2n_blob_init(&client_random, conn->handshake_params.client_random, S2N_TLS_RANDOM_DATA_LEN));
     if (!s2n_is_hello_retry_handshake(conn)) {
         /* Only generate the random data for our first client hello.
          * If we retry, we'll reuse the value. */
@@ -856,14 +856,14 @@ int s2n_sslv2_client_hello_recv(struct s2n_connection *conn)
     POSIX_GUARD(s2n_select_certs_for_server_auth(conn, &conn->handshake_params.our_chain_and_key));
 
     S2N_ERROR_IF(session_id_length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
-    POSIX_GUARD(s2n_blob_init(&client_hello->session_id, s2n_stuffer_raw_read(in, session_id_length), session_id_length));
+    POSIX_GUARD_RESULT(s2n_blob_init(&client_hello->session_id, s2n_stuffer_raw_read(in, session_id_length), session_id_length));
     if (session_id_length > 0 && session_id_length <= S2N_TLS_SESSION_ID_MAX_LEN) {
         POSIX_CHECKED_MEMCPY(conn->session_id, client_hello->session_id.data, session_id_length);
         conn->session_id_len = (uint8_t) session_id_length;
     }
 
     struct s2n_blob b = { 0 };
-    POSIX_GUARD(s2n_blob_init(&b, conn->handshake_params.client_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD_RESULT(s2n_blob_init(&b, conn->handshake_params.client_random, S2N_TLS_RANDOM_DATA_LEN));
 
     b.data += S2N_TLS_RANDOM_DATA_LEN - challenge_length;
     b.size -= S2N_TLS_RANDOM_DATA_LEN - challenge_length;
@@ -998,7 +998,7 @@ S2N_RESULT s2n_client_hello_get_raw_extension(uint16_t extension_iana,
         RESULT_ENSURE_REF(extension_data);
 
         if (extension_iana == extension_type) {
-            RESULT_GUARD_POSIX(s2n_blob_init(extension, extension_data, extension_size));
+            RESULT_GUARD(s2n_blob_init(extension, extension_data, extension_size));
             return S2N_RESULT_OK;
         }
     }

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -131,7 +131,7 @@ int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared
 
     /* Decrypt the pre-master secret */
     struct s2n_blob encrypted = { 0 };
-    POSIX_GUARD(s2n_blob_init(&encrypted, s2n_stuffer_raw_read(in, length), length));
+    POSIX_GUARD_RESULT(s2n_blob_init(&encrypted, s2n_stuffer_raw_read(in, length), length));
     POSIX_ENSURE_REF(encrypted.data);
     POSIX_ENSURE_GT(encrypted.size, 0);
 

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -291,7 +291,7 @@ struct s2n_config *s2n_config_new_minimal(void)
     struct s2n_config *new_config;
 
     PTR_GUARD_POSIX(s2n_alloc(&allocator, sizeof(struct s2n_config)));
-    PTR_GUARD_POSIX(s2n_blob_zero(&allocator));
+    PTR_GUARD_RESULT(s2n_blob_zero(&allocator));
 
     new_config = (struct s2n_config *) (void *) allocator.data;
     if (s2n_config_init(new_config) != S2N_SUCCESS) {
@@ -956,13 +956,13 @@ int s2n_config_add_ticket_crypto_key(struct s2n_config *config,
 
     uint8_t output_pad[S2N_AES256_KEY_LEN + S2N_TICKET_AAD_IMPLICIT_LEN] = { 0 };
     struct s2n_blob out_key = { 0 };
-    POSIX_GUARD(s2n_blob_init(&out_key, output_pad, s2n_array_len(output_pad)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&out_key, output_pad, s2n_array_len(output_pad)));
     struct s2n_blob in_key = { 0 };
-    POSIX_GUARD(s2n_blob_init(&in_key, key, key_len));
+    POSIX_GUARD_RESULT(s2n_blob_init(&in_key, key, key_len));
     struct s2n_blob salt = { 0 };
-    POSIX_GUARD(s2n_blob_init(&salt, NULL, 0));
+    POSIX_GUARD_RESULT(s2n_blob_init(&salt, NULL, 0));
     struct s2n_blob info = { 0 };
-    POSIX_GUARD(s2n_blob_init(&info, NULL, 0));
+    POSIX_GUARD_RESULT(s2n_blob_init(&info, NULL, 0));
 
     struct s2n_ticket_key *session_ticket_key = { 0 };
     DEFER_CLEANUP(struct s2n_blob allocator = { 0 }, s2n_free);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -67,7 +67,7 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
 {
     struct s2n_blob blob = { 0 };
     PTR_GUARD_POSIX(s2n_alloc(&blob, sizeof(struct s2n_connection)));
-    PTR_GUARD_POSIX(s2n_blob_zero(&blob));
+    PTR_GUARD_RESULT(s2n_blob_zero(&blob));
 
     /* Cast 'through' void to acknowledge that we are changing alignment,
      * which is ok, as blob.data is always aligned.
@@ -81,11 +81,11 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
 
     /* Allocate the fixed-size stuffers */
     blob = (struct s2n_blob){ 0 };
-    PTR_GUARD_POSIX(s2n_blob_init(&blob, conn->alert_in_data, S2N_ALERT_LENGTH));
+    PTR_GUARD_RESULT(s2n_blob_init(&blob, conn->alert_in_data, S2N_ALERT_LENGTH));
     PTR_GUARD_POSIX(s2n_stuffer_init(&conn->alert_in, &blob));
 
     blob = (struct s2n_blob){ 0 };
-    PTR_GUARD_POSIX(s2n_blob_init(&blob, conn->ticket_ext_data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
+    PTR_GUARD_RESULT(s2n_blob_init(&blob, conn->ticket_ext_data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
     PTR_GUARD_POSIX(s2n_stuffer_init(&conn->client_ticket_to_decrypt, &blob));
 
     /* Allocate long term hash and HMAC memory */
@@ -96,7 +96,7 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
      * in _wipe will fix that
      */
     blob = (struct s2n_blob){ 0 };
-    PTR_GUARD_POSIX(s2n_blob_init(&blob, conn->header_in_data, S2N_TLS_RECORD_HEADER_LENGTH));
+    PTR_GUARD_RESULT(s2n_blob_init(&blob, conn->header_in_data, S2N_TLS_RECORD_HEADER_LENGTH));
     PTR_GUARD_POSIX(s2n_stuffer_init(&conn->header_in, &blob));
     PTR_GUARD_POSIX(s2n_stuffer_growable_alloc(&conn->out, 0));
     PTR_GUARD_POSIX(s2n_stuffer_growable_alloc(&conn->in, 0));
@@ -433,7 +433,7 @@ int s2n_connection_free_handshake(struct s2n_connection *conn)
 
     /* Wipe the buffers we are going to free */
     POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
-    POSIX_GUARD(s2n_blob_zero(&conn->client_hello.raw_message));
+    POSIX_GUARD_RESULT(s2n_blob_zero(&conn->client_hello.raw_message));
 
     /* Truncate buffers to save memory, we are done with the handshake */
     POSIX_GUARD(s2n_stuffer_resize(&conn->handshake.io, 0));
@@ -499,7 +499,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     POSIX_GUARD(s2n_stuffer_wipe(&conn->client_ticket_to_decrypt));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->post_handshake.in));
-    POSIX_GUARD(s2n_blob_zero(&conn->client_hello.raw_message));
+    POSIX_GUARD_RESULT(s2n_blob_zero(&conn->client_hello.raw_message));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->in));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->out));
@@ -777,7 +777,7 @@ int s2n_connection_set_read_fd(struct s2n_connection *conn, int rfd)
 
     POSIX_ENSURE_REF(conn);
     POSIX_GUARD(s2n_alloc(&ctx_mem, sizeof(struct s2n_socket_read_io_context)));
-    POSIX_GUARD(s2n_blob_zero(&ctx_mem));
+    POSIX_GUARD_RESULT(s2n_blob_zero(&ctx_mem));
 
     peer_socket_ctx = (struct s2n_socket_read_io_context *) (void *) ctx_mem.data;
     peer_socket_ctx->fd = rfd;
@@ -1684,11 +1684,11 @@ S2N_RESULT s2n_connection_get_sequence_number(struct s2n_connection *conn,
 
     switch (mode) {
         case S2N_CLIENT:
-            RESULT_GUARD_POSIX(s2n_blob_init(seq_num, conn->secure->client_sequence_number,
+            RESULT_GUARD(s2n_blob_init(seq_num, conn->secure->client_sequence_number,
                     sizeof(conn->secure->client_sequence_number)));
             break;
         case S2N_SERVER:
-            RESULT_GUARD_POSIX(s2n_blob_init(seq_num, conn->secure->server_sequence_number,
+            RESULT_GUARD(s2n_blob_init(seq_num, conn->secure->server_sequence_number,
                     sizeof(conn->secure->server_sequence_number)));
             break;
         default:

--- a/tls/s2n_crl.c
+++ b/tls/s2n_crl.c
@@ -21,7 +21,7 @@ struct s2n_crl *s2n_crl_new(void)
 {
     DEFER_CLEANUP(struct s2n_blob mem = { 0 }, s2n_free);
     PTR_GUARD_POSIX(s2n_alloc(&mem, sizeof(struct s2n_crl)));
-    PTR_GUARD_POSIX(s2n_blob_zero(&mem));
+    PTR_GUARD_RESULT(s2n_blob_zero(&mem));
 
     struct s2n_crl *crl = (struct s2n_crl *) (void *) mem.data;
 
@@ -35,7 +35,7 @@ int s2n_crl_load_pem(struct s2n_crl *crl, uint8_t *pem, size_t len)
     POSIX_ENSURE(crl->crl == NULL, S2N_ERR_INVALID_ARGUMENT);
 
     struct s2n_blob pem_blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&pem_blob, pem, len));
+    POSIX_GUARD_RESULT(s2n_blob_init(&pem_blob, pem, len));
 
     struct s2n_stuffer pem_stuffer = { 0 };
     POSIX_GUARD(s2n_stuffer_init(&pem_stuffer, &pem_blob));

--- a/tls/s2n_crypto.c
+++ b/tls/s2n_crypto.c
@@ -27,7 +27,7 @@ S2N_RESULT s2n_crypto_parameters_new(struct s2n_crypto_parameters **new_params)
 
     DEFER_CLEANUP(struct s2n_blob mem = { 0 }, s2n_free);
     RESULT_GUARD_POSIX(s2n_alloc(&mem, sizeof(struct s2n_crypto_parameters)));
-    RESULT_GUARD_POSIX(s2n_blob_zero(&mem));
+    RESULT_GUARD(s2n_blob_zero(&mem));
 
     DEFER_CLEANUP(struct s2n_crypto_parameters *params = (struct s2n_crypto_parameters *) (void *) mem.data,
             s2n_crypto_parameters_free);
@@ -107,13 +107,13 @@ S2N_RESULT s2n_crypto_parameters_switch(struct s2n_connection *conn)
     /* Only start encryption if we have not already switched to secure parameters */
     if (conn->mode == S2N_CLIENT && conn->client == conn->initial) {
         struct s2n_blob seq = { 0 };
-        RESULT_GUARD_POSIX(s2n_blob_init(&seq, conn->secure->client_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
-        RESULT_GUARD_POSIX(s2n_blob_zero(&seq));
+        RESULT_GUARD(s2n_blob_init(&seq, conn->secure->client_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
+        RESULT_GUARD(s2n_blob_zero(&seq));
         conn->client = conn->secure;
     } else if (conn->mode == S2N_SERVER && conn->server == conn->initial) {
         struct s2n_blob seq = { 0 };
-        RESULT_GUARD_POSIX(s2n_blob_init(&seq, conn->secure->server_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
-        RESULT_GUARD_POSIX(s2n_blob_zero(&seq));
+        RESULT_GUARD(s2n_blob_init(&seq, conn->secure->server_sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
+        RESULT_GUARD(s2n_blob_zero(&seq));
         conn->server = conn->secure;
     }
 

--- a/tls/s2n_fingerprint.c
+++ b/tls/s2n_fingerprint.c
@@ -273,7 +273,7 @@ int s2n_client_hello_get_fingerprint_hash(struct s2n_client_hello *ch, s2n_finge
     uint8_t string_mem[50] = { 0 };
     struct s2n_blob string_blob = { 0 };
     struct s2n_stuffer string_stuffer = { 0 };
-    POSIX_GUARD(s2n_blob_init(&string_blob, string_mem, sizeof(string_mem)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&string_blob, string_mem, sizeof(string_mem)));
     POSIX_GUARD(s2n_stuffer_init(&string_stuffer, &string_blob));
 
     /* JA3 uses an MD5 hash.
@@ -312,7 +312,7 @@ int s2n_client_hello_get_fingerprint_string(struct s2n_client_hello *ch, s2n_fin
 
     struct s2n_blob output_blob = { 0 };
     struct s2n_stuffer output_stuffer = { 0 };
-    POSIX_GUARD(s2n_blob_init(&output_blob, output, max_size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&output_blob, output, max_size));
     POSIX_GUARD(s2n_stuffer_init(&output_stuffer, &output_blob));
 
     POSIX_GUARD_RESULT(s2n_fingerprint_ja3(ch, &output_stuffer, output_size, NULL));

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -252,14 +252,14 @@ int s2n_conn_find_name_matching_certs(struct s2n_connection *conn)
     }
     const char *name = conn->server_name;
     struct s2n_blob hostname_blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&hostname_blob, (uint8_t *) (uintptr_t) name, strlen(name)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&hostname_blob, (uint8_t *) (uintptr_t) name, strlen(name)));
     POSIX_ENSURE_LTE(hostname_blob.size, S2N_MAX_SERVER_NAME);
     char normalized_hostname[S2N_MAX_SERVER_NAME + 1] = { 0 };
     POSIX_CHECKED_MEMCPY(normalized_hostname, hostname_blob.data, hostname_blob.size);
     struct s2n_blob normalized_name = { 0 };
-    POSIX_GUARD(s2n_blob_init(&normalized_name, (uint8_t *) normalized_hostname, hostname_blob.size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&normalized_name, (uint8_t *) normalized_hostname, hostname_blob.size));
 
-    POSIX_GUARD(s2n_blob_char_to_lower(&normalized_name));
+    POSIX_GUARD_RESULT(s2n_blob_char_to_lower(&normalized_name));
     struct s2n_stuffer normalized_hostname_stuffer = { 0 };
     POSIX_GUARD(s2n_stuffer_init(&normalized_hostname_stuffer, &normalized_name));
     POSIX_GUARD(s2n_stuffer_skip_write(&normalized_hostname_stuffer, normalized_name.size));
@@ -274,7 +274,7 @@ int s2n_conn_find_name_matching_certs(struct s2n_connection *conn)
         /* We have not yet found an exact domain match. Try to find wildcard matches. */
         char wildcard_hostname[S2N_MAX_SERVER_NAME + 1] = { 0 };
         struct s2n_blob wildcard_blob = { 0 };
-        POSIX_GUARD(s2n_blob_init(&wildcard_blob, (uint8_t *) wildcard_hostname, sizeof(wildcard_hostname)));
+        POSIX_GUARD_RESULT(s2n_blob_init(&wildcard_blob, (uint8_t *) wildcard_hostname, sizeof(wildcard_hostname)));
         struct s2n_stuffer wildcard_stuffer = { 0 };
         POSIX_GUARD(s2n_stuffer_init(&wildcard_stuffer, &wildcard_blob));
         POSIX_GUARD(s2n_create_wildcard_hostname(&normalized_hostname_stuffer, &wildcard_stuffer));

--- a/tls/s2n_handshake_hashes.c
+++ b/tls/s2n_handshake_hashes.c
@@ -100,7 +100,7 @@ S2N_RESULT s2n_handshake_hashes_new(struct s2n_handshake_hashes **hashes)
 
     DEFER_CLEANUP(struct s2n_blob data = { 0 }, s2n_free);
     RESULT_GUARD_POSIX(s2n_realloc(&data, sizeof(struct s2n_handshake_hashes)));
-    RESULT_GUARD_POSIX(s2n_blob_zero(&data));
+    RESULT_GUARD(s2n_blob_zero(&data));
     *hashes = (struct s2n_handshake_hashes *) (void *) data.data;
     ZERO_TO_DISABLE_DEFER_CLEANUP(data);
 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -901,7 +901,7 @@ int s2n_generate_new_client_session_id(struct s2n_connection *conn)
 {
     if (conn->mode == S2N_SERVER) {
         struct s2n_blob session_id = { 0 };
-        POSIX_GUARD(s2n_blob_init(&session_id, conn->session_id, S2N_TLS_SESSION_ID_MAX_LEN));
+        POSIX_GUARD_RESULT(s2n_blob_init(&session_id, conn->session_id, S2N_TLS_SESSION_ID_MAX_LEN));
 
         /* Generate a new session id */
         POSIX_GUARD_RESULT(s2n_get_public_random_data(&session_id));
@@ -1320,7 +1320,7 @@ static int s2n_handshake_handle_sslv2(struct s2n_connection *conn)
 
     /* Add the message to our handshake hashes */
     struct s2n_blob hashed = { 0 };
-    POSIX_GUARD(s2n_blob_init(&hashed, conn->header_in.blob.data + 2, 3));
+    POSIX_GUARD_RESULT(s2n_blob_init(&hashed, conn->header_in.blob.data + 2, 3));
     POSIX_GUARD(s2n_conn_update_handshake_hashes(conn, &hashed));
 
     hashed.data = conn->in.blob.data;

--- a/tls/s2n_handshake_transcript.c
+++ b/tls/s2n_handshake_transcript.c
@@ -33,7 +33,7 @@ S2N_RESULT s2n_handshake_transcript_update(struct s2n_connection *conn)
     uint32_t len = s2n_stuffer_data_available(&message);
     uint8_t *bytes = s2n_stuffer_raw_read(&message, len);
     RESULT_ENSURE_REF(bytes);
-    RESULT_GUARD_POSIX(s2n_blob_init(&data, bytes, len));
+    RESULT_GUARD(s2n_blob_init(&data, bytes, len));
 
     RESULT_GUARD_POSIX(s2n_conn_update_handshake_hashes(conn, &data));
     return S2N_RESULT_OK;
@@ -122,11 +122,11 @@ int s2n_server_hello_retry_recreate_transcript(struct s2n_connection *conn)
 
     /* Step 2: Update the transcript with the synthetic message */
     struct s2n_blob msg_blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&msg_blob, msghdr, MESSAGE_HASH_HEADER_LENGTH));
+    POSIX_GUARD_RESULT(s2n_blob_init(&msg_blob, msghdr, MESSAGE_HASH_HEADER_LENGTH));
     POSIX_GUARD(s2n_conn_update_handshake_hashes(conn, &msg_blob));
 
     /* Step 3: Update the transcript with the ClientHello1 hash */
-    POSIX_GUARD(s2n_blob_init(&msg_blob, client_hello1_digest_out, hash_digest_length));
+    POSIX_GUARD_RESULT(s2n_blob_init(&msg_blob, client_hello1_digest_out, hash_digest_length));
     POSIX_GUARD(s2n_conn_update_handshake_hashes(conn, &msg_blob));
 
     return S2N_SUCCESS;

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -389,7 +389,7 @@ int s2n_kem_send_ciphertext(struct s2n_stuffer *out, struct s2n_kem_params *kem_
 
     /* Ciphertext will get written to *out */
     struct s2n_blob ciphertext = { 0 };
-    POSIX_GUARD(s2n_blob_init(&ciphertext, s2n_stuffer_raw_write(out, kem->ciphertext_length), kem->ciphertext_length));
+    POSIX_GUARD_RESULT(s2n_blob_init(&ciphertext, s2n_stuffer_raw_write(out, kem->ciphertext_length), kem->ciphertext_length));
     POSIX_ENSURE_REF(ciphertext.data);
 
     /* Saves the shared secret in kem_params */

--- a/tls/s2n_key_update.c
+++ b/tls/s2n_key_update.c
@@ -86,7 +86,7 @@ int s2n_key_update_send(struct s2n_connection *conn, s2n_blocked_status *blocked
 
         uint8_t key_update_data[S2N_KEY_UPDATE_MESSAGE_SIZE];
         struct s2n_blob key_update_blob = { 0 };
-        POSIX_GUARD(s2n_blob_init(&key_update_blob, key_update_data, sizeof(key_update_data)));
+        POSIX_GUARD_RESULT(s2n_blob_init(&key_update_blob, key_update_data, sizeof(key_update_data)));
 
         /* Write key update message */
         POSIX_GUARD(s2n_key_update_write(&key_update_blob));

--- a/tls/s2n_ktls.c
+++ b/tls/s2n_ktls.c
@@ -180,11 +180,11 @@ static S2N_RESULT s2n_ktls_crypto_info_init(struct s2n_connection *conn, s2n_ktl
     struct s2n_ktls_crypto_info_inputs inputs = { 0 };
     if (key_mode == S2N_CLIENT) {
         inputs.key = key_material.client_key;
-        RESULT_GUARD_POSIX(s2n_blob_init(&inputs.iv,
+        RESULT_GUARD(s2n_blob_init(&inputs.iv,
                 secure->client_implicit_iv, sizeof(secure->client_implicit_iv)));
     } else {
         inputs.key = key_material.server_key;
-        RESULT_GUARD_POSIX(s2n_blob_init(&inputs.iv,
+        RESULT_GUARD(s2n_blob_init(&inputs.iv,
                 secure->server_implicit_iv, sizeof(secure->server_implicit_iv)));
     }
     RESULT_GUARD(s2n_connection_get_sequence_number(conn, key_mode, &inputs.seq));

--- a/tls/s2n_ktls_io.c
+++ b/tls/s2n_ktls_io.c
@@ -426,7 +426,7 @@ ssize_t s2n_ktls_sendv_with_offset(struct s2n_connection *conn, const struct iov
     /* The order of new_bufs and new_bufs_mem matters. See https://github.com/aws/s2n-tls/issues/4354 */
     uint8_t new_bufs_mem[S2N_MAX_STACK_IOVECS_MEM] = { 0 };
     DEFER_CLEANUP(struct s2n_blob new_bufs = { 0 }, s2n_free_or_wipe);
-    POSIX_GUARD(s2n_blob_init(&new_bufs, new_bufs_mem, sizeof(new_bufs_mem)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&new_bufs, new_bufs_mem, sizeof(new_bufs_mem)));
     if (offs > 0) {
         POSIX_GUARD_RESULT(s2n_ktls_update_bufs_with_offset(&bufs, &count, offs, &new_bufs));
     }

--- a/tls/s2n_post_handshake.c
+++ b/tls/s2n_post_handshake.c
@@ -82,7 +82,7 @@ S2N_RESULT s2n_post_handshake_message_recv(struct s2n_connection *conn)
      */
     if (s2n_stuffer_is_freed(message)) {
         struct s2n_blob b = { 0 };
-        RESULT_GUARD_POSIX(s2n_blob_init(&b, conn->post_handshake.header_in,
+        RESULT_GUARD(s2n_blob_init(&b, conn->post_handshake.header_in,
                 sizeof(conn->post_handshake.header_in)));
         RESULT_GUARD_POSIX(s2n_stuffer_init(message, &b));
     }
@@ -109,7 +109,7 @@ S2N_RESULT s2n_post_handshake_message_recv(struct s2n_connection *conn)
     if (s2n_stuffer_data_available(message) == 0 && s2n_stuffer_data_available(in) >= message_len) {
         struct s2n_stuffer full_message = { 0 };
         struct s2n_blob full_message_blob = { 0 };
-        RESULT_GUARD_POSIX(s2n_blob_init(&full_message_blob, s2n_stuffer_raw_read(in, message_len), message_len));
+        RESULT_GUARD(s2n_blob_init(&full_message_blob, s2n_stuffer_raw_read(in, message_len), message_len));
         RESULT_GUARD_POSIX(s2n_stuffer_init(&full_message, &full_message_blob));
         RESULT_GUARD_POSIX(s2n_stuffer_skip_write(&full_message, message_len));
         RESULT_GUARD(s2n_post_handshake_process(conn, &full_message, message_type));

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -80,7 +80,7 @@ S2N_RESULT s2n_key_material_init(struct s2n_key_material *key_material, struct s
 
     struct s2n_stuffer key_material_stuffer = { 0 };
     struct s2n_blob key_material_blob = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&key_material_blob, key_material->key_block, sizeof(key_material->key_block)));
+    RESULT_GUARD(s2n_blob_init(&key_material_blob, key_material->key_block, sizeof(key_material->key_block)));
     RESULT_GUARD_POSIX(s2n_stuffer_init_written(&key_material_stuffer, &key_material_blob));
 
     /* initialize key_material blobs; incrementing ptr to point to the next slice of memory */
@@ -88,29 +88,29 @@ S2N_RESULT s2n_key_material_init(struct s2n_key_material *key_material, struct s
     /* MAC */
     ptr = s2n_stuffer_raw_read(&key_material_stuffer, mac_size);
     RESULT_ENSURE_REF(ptr);
-    RESULT_GUARD_POSIX(s2n_blob_init(&key_material->client_mac, ptr, mac_size));
+    RESULT_GUARD(s2n_blob_init(&key_material->client_mac, ptr, mac_size));
 
     ptr = s2n_stuffer_raw_read(&key_material_stuffer, mac_size);
     RESULT_ENSURE_REF(ptr);
-    RESULT_GUARD_POSIX(s2n_blob_init(&key_material->server_mac, ptr, mac_size));
+    RESULT_GUARD(s2n_blob_init(&key_material->server_mac, ptr, mac_size));
 
     /* KEY */
     ptr = s2n_stuffer_raw_read(&key_material_stuffer, key_size);
     RESULT_ENSURE_REF(ptr);
-    RESULT_GUARD_POSIX(s2n_blob_init(&key_material->client_key, ptr, key_size));
+    RESULT_GUARD(s2n_blob_init(&key_material->client_key, ptr, key_size));
 
     ptr = s2n_stuffer_raw_read(&key_material_stuffer, key_size);
     RESULT_ENSURE_REF(ptr);
-    RESULT_GUARD_POSIX(s2n_blob_init(&key_material->server_key, ptr, key_size));
+    RESULT_GUARD(s2n_blob_init(&key_material->server_key, ptr, key_size));
 
     /* IV */
     ptr = s2n_stuffer_raw_read(&key_material_stuffer, iv_size);
     RESULT_ENSURE_REF(ptr);
-    RESULT_GUARD_POSIX(s2n_blob_init(&key_material->client_iv, ptr, iv_size));
+    RESULT_GUARD(s2n_blob_init(&key_material->client_iv, ptr, iv_size));
 
     ptr = s2n_stuffer_raw_read(&key_material_stuffer, iv_size);
     RESULT_ENSURE_REF(ptr);
-    RESULT_GUARD_POSIX(s2n_blob_init(&key_material->server_iv, ptr, iv_size));
+    RESULT_GUARD(s2n_blob_init(&key_material->server_iv, ptr, iv_size));
 
     return S2N_RESULT_OK;
 }
@@ -476,7 +476,7 @@ S2N_RESULT s2n_prf_new(struct s2n_connection *conn)
 
     DEFER_CLEANUP(struct s2n_blob mem = { 0 }, s2n_free);
     RESULT_GUARD_POSIX(s2n_realloc(&mem, sizeof(struct s2n_prf_working_space)));
-    RESULT_GUARD_POSIX(s2n_blob_zero(&mem));
+    RESULT_GUARD(s2n_blob_zero(&mem));
     conn->prf_space = (struct s2n_prf_working_space *) (void *) mem.data;
     ZERO_TO_DISABLE_DEFER_CLEANUP(mem);
 
@@ -529,7 +529,7 @@ S2N_RESULT s2n_custom_prf(struct s2n_connection *conn, struct s2n_blob *secret, 
      * the right values. When we call it twice in the regular case, the two
      * outputs will be XORd just ass the TLS 1.0 and 1.1 RFCs require.
      */
-    RESULT_GUARD_POSIX(s2n_blob_zero(out));
+    RESULT_GUARD(s2n_blob_zero(out));
 
     if (conn->actual_protocol_version == S2N_TLS12) {
         RESULT_GUARD_POSIX(s2n_p_hash(conn->prf_space, conn->secure->cipher_suite->prf_alg, secret, label, seed_a,
@@ -538,7 +538,7 @@ S2N_RESULT s2n_custom_prf(struct s2n_connection *conn, struct s2n_blob *secret, 
     }
 
     struct s2n_blob half_secret = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&half_secret, secret->data, (secret->size + 1) / 2));
+    RESULT_GUARD(s2n_blob_init(&half_secret, secret->data, (secret->size + 1) / 2));
 
     RESULT_GUARD_POSIX(s2n_p_hash(conn->prf_space, S2N_HMAC_MD5, &half_secret, label, seed_a, seed_b, seed_c, out));
     half_secret.data += secret->size - half_secret.size;
@@ -584,7 +584,7 @@ S2N_RESULT s2n_libcrypto_prf(struct s2n_connection *conn, struct s2n_blob *secre
 
     if (seed_b != NULL) {
         struct s2n_blob seed_b_blob = { 0 };
-        RESULT_GUARD_POSIX(s2n_blob_init(&seed_b_blob, seed_b->data, seed_b->size));
+        RESULT_GUARD(s2n_blob_init(&seed_b_blob, seed_b->data, seed_b->size));
         RESULT_GUARD_POSIX(s2n_stuffer_init_written(&seed_b_stuffer, &seed_b_blob));
 
         if (seed_c != NULL) {
@@ -657,15 +657,15 @@ int s2n_tls_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *prem
     POSIX_ENSURE_REF(conn);
 
     struct s2n_blob client_random = { 0 };
-    POSIX_GUARD(s2n_blob_init(&client_random, conn->handshake_params.client_random, sizeof(conn->handshake_params.client_random)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&client_random, conn->handshake_params.client_random, sizeof(conn->handshake_params.client_random)));
     struct s2n_blob server_random = { 0 };
-    POSIX_GUARD(s2n_blob_init(&server_random, conn->handshake_params.server_random, sizeof(conn->handshake_params.server_random)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&server_random, conn->handshake_params.server_random, sizeof(conn->handshake_params.server_random)));
     struct s2n_blob master_secret = { 0 };
-    POSIX_GUARD(s2n_blob_init(&master_secret, conn->secrets.version.tls12.master_secret, sizeof(conn->secrets.version.tls12.master_secret)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&master_secret, conn->secrets.version.tls12.master_secret, sizeof(conn->secrets.version.tls12.master_secret)));
 
     uint8_t master_secret_label[] = "master secret";
     struct s2n_blob label = { 0 };
-    POSIX_GUARD(s2n_blob_init(&label, master_secret_label, sizeof(master_secret_label) - 1));
+    POSIX_GUARD_RESULT(s2n_blob_init(&label, master_secret_label, sizeof(master_secret_label) - 1));
 
     return s2n_prf(conn, premaster_secret, &label, &client_random, &server_random, NULL, &master_secret);
 }
@@ -675,15 +675,15 @@ int s2n_hybrid_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *p
     POSIX_ENSURE_REF(conn);
 
     struct s2n_blob client_random = { 0 };
-    POSIX_GUARD(s2n_blob_init(&client_random, conn->handshake_params.client_random, sizeof(conn->handshake_params.client_random)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&client_random, conn->handshake_params.client_random, sizeof(conn->handshake_params.client_random)));
     struct s2n_blob server_random = { 0 };
-    POSIX_GUARD(s2n_blob_init(&server_random, conn->handshake_params.server_random, sizeof(conn->handshake_params.server_random)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&server_random, conn->handshake_params.server_random, sizeof(conn->handshake_params.server_random)));
     struct s2n_blob master_secret = { 0 };
-    POSIX_GUARD(s2n_blob_init(&master_secret, conn->secrets.version.tls12.master_secret, sizeof(conn->secrets.version.tls12.master_secret)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&master_secret, conn->secrets.version.tls12.master_secret, sizeof(conn->secrets.version.tls12.master_secret)));
 
     uint8_t master_secret_label[] = "hybrid master secret";
     struct s2n_blob label = { 0 };
-    POSIX_GUARD(s2n_blob_init(&label, master_secret_label, sizeof(master_secret_label) - 1));
+    POSIX_GUARD_RESULT(s2n_blob_init(&label, master_secret_label, sizeof(master_secret_label) - 1));
 
     return s2n_prf(conn, premaster_secret, &label, &client_random, &server_random, &conn->kex_params.client_key_exchange_message, &master_secret);
 }
@@ -708,15 +708,15 @@ int s2n_prf_calculate_master_secret(struct s2n_connection *conn, struct s2n_blob
     POSIX_GUARD(s2n_stuffer_reread(&client_key_message));
     uint32_t client_key_message_size = s2n_stuffer_data_available(&client_key_message);
     struct s2n_blob client_key_blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&client_key_blob, client_key_message.blob.data, client_key_message_size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&client_key_blob, client_key_message.blob.data, client_key_message_size));
 
     uint8_t data[S2N_MAX_DIGEST_LEN] = { 0 };
     struct s2n_blob digest = { 0 };
-    POSIX_GUARD(s2n_blob_init(&digest, data, sizeof(data)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&digest, data, sizeof(data)));
     if (conn->actual_protocol_version < S2N_TLS12) {
         uint8_t sha1_data[S2N_MAX_DIGEST_LEN] = { 0 };
         struct s2n_blob sha1_digest = { 0 };
-        POSIX_GUARD(s2n_blob_init(&sha1_digest, sha1_data, sizeof(sha1_data)));
+        POSIX_GUARD_RESULT(s2n_blob_init(&sha1_digest, sha1_data, sizeof(sha1_data)));
         POSIX_GUARD_RESULT(s2n_prf_get_digest_for_ems(conn, &client_key_blob, S2N_HASH_MD5, &digest));
         POSIX_GUARD_RESULT(s2n_prf_get_digest_for_ems(conn, &client_key_blob, S2N_HASH_SHA1, &sha1_digest));
         POSIX_GUARD_RESULT(s2n_tls_prf_extended_master_secret(conn, premaster_secret, &digest, &sha1_digest));
@@ -744,12 +744,12 @@ S2N_RESULT s2n_tls_prf_extended_master_secret(struct s2n_connection *conn, struc
     RESULT_ENSURE_REF(conn);
 
     struct s2n_blob extended_master_secret = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&extended_master_secret, conn->secrets.version.tls12.master_secret, sizeof(conn->secrets.version.tls12.master_secret)));
+    RESULT_GUARD(s2n_blob_init(&extended_master_secret, conn->secrets.version.tls12.master_secret, sizeof(conn->secrets.version.tls12.master_secret)));
 
     uint8_t extended_master_secret_label[] = "extended master secret";
     /* Subtract one from the label size to remove the "\0" */
     struct s2n_blob label = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&label, extended_master_secret_label, sizeof(extended_master_secret_label) - 1));
+    RESULT_GUARD(s2n_blob_init(&label, extended_master_secret_label, sizeof(extended_master_secret_label) - 1));
 
     RESULT_GUARD_POSIX(s2n_prf(conn, premaster_secret, &label, session_hash, sha1_hash, NULL, &extended_master_secret));
 
@@ -1001,19 +1001,19 @@ S2N_RESULT s2n_prf_generate_key_material(struct s2n_connection *conn, struct s2n
     RESULT_ENSURE_REF(key_material);
 
     struct s2n_blob client_random = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&client_random, conn->handshake_params.client_random, sizeof(conn->handshake_params.client_random)));
+    RESULT_GUARD(s2n_blob_init(&client_random, conn->handshake_params.client_random, sizeof(conn->handshake_params.client_random)));
     struct s2n_blob server_random = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&server_random, conn->handshake_params.server_random, sizeof(conn->handshake_params.server_random)));
+    RESULT_GUARD(s2n_blob_init(&server_random, conn->handshake_params.server_random, sizeof(conn->handshake_params.server_random)));
     struct s2n_blob master_secret = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&master_secret, conn->secrets.version.tls12.master_secret, sizeof(conn->secrets.version.tls12.master_secret)));
+    RESULT_GUARD(s2n_blob_init(&master_secret, conn->secrets.version.tls12.master_secret, sizeof(conn->secrets.version.tls12.master_secret)));
 
     struct s2n_blob label = { 0 };
     uint8_t key_expansion_label[] = "key expansion";
-    RESULT_GUARD_POSIX(s2n_blob_init(&label, key_expansion_label, sizeof(key_expansion_label) - 1));
+    RESULT_GUARD(s2n_blob_init(&label, key_expansion_label, sizeof(key_expansion_label) - 1));
 
     RESULT_GUARD(s2n_key_material_init(key_material, conn));
     struct s2n_blob prf_out = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&prf_out, key_material->key_block, sizeof(key_material->key_block)));
+    RESULT_GUARD(s2n_blob_init(&prf_out, key_material->key_block, sizeof(key_material->key_block)));
     RESULT_GUARD_POSIX(s2n_prf(conn, &master_secret, &label, &server_random, &client_random, NULL, &prf_out));
 
     return S2N_RESULT_OK;

--- a/tls/s2n_protocol_preferences.c
+++ b/tls/s2n_protocol_preferences.c
@@ -29,7 +29,7 @@ S2N_RESULT s2n_protocol_preferences_read(struct s2n_stuffer *protocol_preference
     uint8_t *data = s2n_stuffer_raw_read(protocol_preferences, length);
     RESULT_ENSURE_REF(data);
 
-    RESULT_GUARD_POSIX(s2n_blob_init(protocol, data, length));
+    RESULT_GUARD(s2n_blob_init(protocol, data, length));
     return S2N_RESULT_OK;
 }
 

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -226,7 +226,7 @@ S2N_RESULT s2n_offered_psk_list_read_next(struct s2n_offered_psk_list *psk_list,
         RESULT_GUARD_POSIX(s2n_stuffer_read_uint32(&psk_list->wire_data, &psk->obfuscated_ticket_age));
     }
 
-    RESULT_GUARD_POSIX(s2n_blob_init(&psk->identity, identity_data, identity_size));
+    RESULT_GUARD(s2n_blob_init(&psk->identity, identity_data, identity_size));
     psk->wire_index = psk_list->wire_index;
 
     RESULT_ENSURE(psk_list->wire_index < UINT16_MAX, S2N_ERR_INTEGER_OVERFLOW);
@@ -344,7 +344,7 @@ struct s2n_offered_psk *s2n_offered_psk_new()
 {
     DEFER_CLEANUP(struct s2n_blob mem = { 0 }, s2n_free);
     PTR_GUARD_POSIX(s2n_alloc(&mem, sizeof(struct s2n_offered_psk)));
-    PTR_GUARD_POSIX(s2n_blob_zero(&mem));
+    PTR_GUARD_RESULT(s2n_blob_zero(&mem));
 
     struct s2n_offered_psk *psk = (struct s2n_offered_psk *) (void *) mem.data;
 
@@ -417,7 +417,7 @@ int s2n_psk_calculate_binder(struct s2n_psk *psk, const struct s2n_blob *binder_
 
     /* Derive the binder key */
     POSIX_GUARD_RESULT(s2n_derive_binder_key(psk, &psk_keys.derive_secret));
-    POSIX_GUARD(s2n_blob_init(&psk_keys.extract_secret, psk->early_secret.data, psk_keys.size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&psk_keys.extract_secret, psk->early_secret.data, psk_keys.size));
     struct s2n_blob *binder_key = &psk_keys.derive_secret;
 
     /* Expand the binder key into the finished key */
@@ -462,7 +462,7 @@ static S2N_RESULT s2n_psk_write_binder(struct s2n_connection *conn, struct s2n_p
 
     struct s2n_blob binder = { 0 };
     uint8_t binder_data[S2N_TLS13_SECRET_MAX_LEN] = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&binder, binder_data, binder_hash->size));
+    RESULT_GUARD(s2n_blob_init(&binder, binder_data, binder_hash->size));
 
     RESULT_GUARD_POSIX(s2n_psk_calculate_binder(psk, binder_hash, &binder));
     RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(out, binder.size));
@@ -512,7 +512,7 @@ static S2N_RESULT s2n_psk_write_binder_list(struct s2n_connection *conn, const s
         if (binder_hash->size == 0) {
             uint8_t hash_size = 0;
             RESULT_GUARD_POSIX(s2n_hmac_digest_size(psk->hmac_alg, &hash_size));
-            RESULT_GUARD_POSIX(s2n_blob_init(binder_hash, binder_hashes_data[psk->hmac_alg], hash_size));
+            RESULT_GUARD(s2n_blob_init(binder_hash, binder_hashes_data[psk->hmac_alg], hash_size));
             RESULT_GUARD_POSIX(s2n_psk_calculate_binder_hash(conn, psk->hmac_alg, partial_client_hello, binder_hash));
         }
 
@@ -544,7 +544,7 @@ S2N_RESULT s2n_finish_psk_extension(struct s2n_connection *conn)
 
     /* Store the partial client hello for use in calculating the binder hash. */
     struct s2n_blob partial_client_hello = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&partial_client_hello, client_hello->blob.data,
+    RESULT_GUARD(s2n_blob_init(&partial_client_hello, client_hello->blob.data,
             s2n_stuffer_data_available(client_hello)));
 
     RESULT_GUARD(s2n_psk_write_binder_list(conn, &partial_client_hello, client_hello));

--- a/tls/s2n_record_read_aead.c
+++ b/tls/s2n_record_read_aead.c
@@ -42,14 +42,14 @@ int s2n_record_parse_aead(
     s2n_stack_blob(aad, is_tls13_record ? S2N_TLS13_AAD_LEN : S2N_TLS_MAX_AAD_LEN, S2N_TLS_MAX_AAD_LEN);
 
     struct s2n_blob en = { 0 };
-    POSIX_GUARD(s2n_blob_init(&en, s2n_stuffer_raw_read(&conn->in, encrypted_length), encrypted_length));
+    POSIX_GUARD_RESULT(s2n_blob_init(&en, s2n_stuffer_raw_read(&conn->in, encrypted_length), encrypted_length));
     POSIX_ENSURE_REF(en.data);
     /* In AEAD mode, the explicit IV is in the record */
     POSIX_ENSURE_GTE(en.size, cipher_suite->record_alg->cipher->io.aead.record_iv_size);
 
     uint8_t aad_iv[S2N_TLS_MAX_IV_LEN] = { 0 };
     struct s2n_blob iv = { 0 };
-    POSIX_GUARD(s2n_blob_init(&iv, aad_iv, sizeof(aad_iv)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&iv, aad_iv, sizeof(aad_iv)));
     struct s2n_stuffer iv_stuffer = { 0 };
     POSIX_GUARD(s2n_stuffer_init(&iv_stuffer, &iv));
 
@@ -101,7 +101,7 @@ int s2n_record_parse_aead(
 
     POSIX_GUARD(cipher_suite->record_alg->cipher->io.aead.decrypt(session_key, &iv, &aad, &en, &en));
     struct s2n_blob seq = { 0 };
-    POSIX_GUARD(s2n_blob_init(&seq, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
+    POSIX_GUARD_RESULT(s2n_blob_init(&seq, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
     POSIX_GUARD(s2n_increment_sequence_number(&seq));
 
     /* O.k., we've successfully read and decrypted the record, now we need to align the stuffer

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -346,7 +346,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
      */
     struct s2n_blob record_blob = { 0 };
     struct s2n_stuffer record_stuffer = { 0 };
-    POSIX_GUARD(s2n_blob_init(&record_blob,
+    POSIX_GUARD_RESULT(s2n_blob_init(&record_blob,
             conn->out.blob.data + conn->out.write_cursor,
             s2n_stuffer_space_remaining(&conn->out)));
     POSIX_GUARD(s2n_stuffer_init(&record_stuffer, &record_blob));
@@ -401,7 +401,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
     /* If we're AEAD, write the sequence number as an IV, and generate the AAD */
     if (cipher_suite->record_alg->cipher->type == S2N_AEAD) {
         struct s2n_stuffer iv_stuffer = { 0 };
-        POSIX_GUARD(s2n_blob_init(&iv, aad_iv, sizeof(aad_iv)));
+        POSIX_GUARD_RESULT(s2n_blob_init(&iv, aad_iv, sizeof(aad_iv)));
         POSIX_GUARD(s2n_stuffer_init(&iv_stuffer, &iv));
 
         if (cipher_suite->record_alg->flags & S2N_TLS12_AES_GCM_AEAD_NONCE) {
@@ -429,7 +429,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
             POSIX_GUARD_RESULT(s2n_aead_aad_init(conn, sequence_number, content_type, data_bytes_to_take, &aad));
         }
     } else if (cipher_suite->record_alg->cipher->type == S2N_CBC || cipher_suite->record_alg->cipher->type == S2N_COMPOSITE) {
-        POSIX_GUARD(s2n_blob_init(&iv, implicit_iv, block_size));
+        POSIX_GUARD_RESULT(s2n_blob_init(&iv, implicit_iv, block_size));
 
         /* For TLS1.1/1.2; write the IV with random data */
         if (conn->actual_protocol_version > S2N_TLS10) {
@@ -450,7 +450,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
                  */
                 struct s2n_blob explicit_iv_placeholder = { 0 };
                 uint8_t zero_block[S2N_TLS_MAX_IV_LEN] = { 0 };
-                POSIX_GUARD(s2n_blob_init(&explicit_iv_placeholder, zero_block, block_size));
+                POSIX_GUARD_RESULT(s2n_blob_init(&explicit_iv_placeholder, zero_block, block_size));
                 POSIX_GUARD_RESULT(s2n_get_public_random_data(&explicit_iv_placeholder));
                 POSIX_GUARD(s2n_stuffer_write(&record_stuffer, &explicit_iv_placeholder));
             } else {
@@ -464,7 +464,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
 
     /* We are done with this sequence number, so we can increment it */
     struct s2n_blob seq = { 0 };
-    POSIX_GUARD(s2n_blob_init(&seq, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
+    POSIX_GUARD_RESULT(s2n_blob_init(&seq, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
     POSIX_GUARD(s2n_increment_sequence_number(&seq));
 
     /* Write the plaintext data */

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -114,7 +114,7 @@ ssize_t s2n_recv_impl(struct s2n_connection *conn, void *buf, ssize_t size_signe
     size_t size = size_signed;
     ssize_t bytes_read = 0;
     struct s2n_blob out = { 0 };
-    POSIX_GUARD(s2n_blob_init(&out, (uint8_t *) buf, 0));
+    POSIX_GUARD_RESULT(s2n_blob_init(&out, (uint8_t *) buf, 0));
 
     /*
      * Set the `blocked` status to BLOCKED_ON_READ by default

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -417,7 +417,7 @@ static int s2n_client_deserialize_with_session_ticket(struct s2n_connection *con
     struct s2n_blob session_ticket = { 0 };
     uint8_t *session_ticket_bytes = s2n_stuffer_raw_read(from, session_ticket_len);
     POSIX_ENSURE_REF(session_ticket_bytes);
-    POSIX_GUARD(s2n_blob_init(&session_ticket, session_ticket_bytes, session_ticket_len));
+    POSIX_GUARD_RESULT(s2n_blob_init(&session_ticket, session_ticket_bytes, session_ticket_len));
 
     POSIX_GUARD_RESULT(s2n_deserialize_resumption_state(conn, &session_ticket, from));
     return 0;
@@ -449,7 +449,7 @@ int s2n_resume_from_cache(struct s2n_connection *conn)
 
     uint8_t data[S2N_TLS12_TICKET_SIZE_IN_BYTES] = { 0 };
     struct s2n_blob entry = { 0 };
-    POSIX_GUARD(s2n_blob_init(&entry, data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
+    POSIX_GUARD_RESULT(s2n_blob_init(&entry, data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
     uint64_t size = entry.size;
     int result = conn->config->cache_retrieve(conn, conn->config->cache_retrieve_data, conn->session_id, conn->session_id_len, entry.data, &size);
     if (result == S2N_CALLBACK_BLOCKED) {
@@ -471,7 +471,7 @@ S2N_RESULT s2n_store_to_cache(struct s2n_connection *conn)
 {
     uint8_t data[S2N_TLS12_TICKET_SIZE_IN_BYTES] = { 0 };
     struct s2n_blob entry = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&entry, data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
+    RESULT_GUARD(s2n_blob_init(&entry, data, S2N_TLS12_TICKET_SIZE_IN_BYTES));
     struct s2n_stuffer to = { 0 };
 
     /* session_id_len should always be >0 since either the Client provided a SessionId or the Server generated a new
@@ -519,8 +519,8 @@ int s2n_connection_get_session(struct s2n_connection *conn, uint8_t *session, si
     POSIX_ENSURE((size_t) len <= max_length, S2N_ERR_SERIALIZED_SESSION_STATE_TOO_LONG);
 
     struct s2n_blob serialized_data = { 0 };
-    POSIX_GUARD(s2n_blob_init(&serialized_data, session, len));
-    POSIX_GUARD(s2n_blob_zero(&serialized_data));
+    POSIX_GUARD_RESULT(s2n_blob_init(&serialized_data, session, len));
+    POSIX_GUARD_RESULT(s2n_blob_zero(&serialized_data));
 
     struct s2n_stuffer to = { 0 };
     POSIX_GUARD(s2n_stuffer_init(&to, &serialized_data));
@@ -772,11 +772,11 @@ int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *
 
     uint8_t iv_data[S2N_TLS_GCM_IV_LEN] = { 0 };
     struct s2n_blob iv = { 0 };
-    POSIX_GUARD(s2n_blob_init(&iv, iv_data, sizeof(iv_data)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&iv, iv_data, sizeof(iv_data)));
 
     uint8_t aad_data[S2N_TICKET_AAD_LEN] = { 0 };
     struct s2n_blob aad_blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&aad_blob, aad_data, sizeof(aad_data)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&aad_blob, aad_data, sizeof(aad_data)));
     struct s2n_stuffer aad = { 0 };
 
     key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
@@ -789,7 +789,7 @@ int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *
     POSIX_GUARD_RESULT(s2n_get_public_random_data(&iv));
     POSIX_GUARD(s2n_stuffer_write(to, &iv));
 
-    POSIX_GUARD(s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN));
+    POSIX_GUARD_RESULT(s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN));
     POSIX_GUARD(s2n_session_key_alloc(&aes_ticket_key));
     POSIX_GUARD(s2n_aes256_gcm.init(&aes_ticket_key));
     POSIX_GUARD(s2n_aes256_gcm.set_encryption_key(&aes_ticket_key, &aes_key_blob));
@@ -808,7 +808,7 @@ int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *
     uint32_t state_blob_size = s2n_stuffer_data_available(&copy_for_encryption);
     uint8_t *state_blob_data = s2n_stuffer_raw_read(&copy_for_encryption, state_blob_size);
     POSIX_ENSURE_REF(state_blob_data);
-    POSIX_GUARD(s2n_blob_init(&state_blob, state_blob_data, state_blob_size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&state_blob, state_blob_data, state_blob_size));
 
     POSIX_GUARD(s2n_aes256_gcm.io.aead.encrypt(&aes_ticket_key, &iv, &aad_blob, &state_blob, &state_blob));
 
@@ -828,11 +828,11 @@ int s2n_decrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *
 
     uint8_t iv_data[S2N_TLS_GCM_IV_LEN] = { 0 };
     struct s2n_blob iv = { 0 };
-    POSIX_GUARD(s2n_blob_init(&iv, iv_data, sizeof(iv_data)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&iv, iv_data, sizeof(iv_data)));
 
     uint8_t aad_data[S2N_TICKET_AAD_LEN] = { 0 };
     struct s2n_blob aad_blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&aad_blob, aad_data, sizeof(aad_data)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&aad_blob, aad_data, sizeof(aad_data)));
     struct s2n_stuffer aad = { 0 };
 
     POSIX_GUARD(s2n_stuffer_read_bytes(from, key_name, s2n_array_len(key_name)));
@@ -844,7 +844,7 @@ int s2n_decrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *
 
     POSIX_GUARD(s2n_stuffer_read(from, &iv));
 
-    POSIX_GUARD(s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN));
+    POSIX_GUARD_RESULT(s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN));
     POSIX_GUARD(s2n_session_key_alloc(&aes_ticket_key));
     POSIX_GUARD(s2n_aes256_gcm.init(&aes_ticket_key));
     POSIX_GUARD(s2n_aes256_gcm.set_decryption_key(&aes_ticket_key, &aes_key_blob));
@@ -857,12 +857,12 @@ int s2n_decrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *
     uint32_t en_blob_size = s2n_stuffer_data_available(from);
     uint8_t *en_blob_data = s2n_stuffer_raw_read(from, en_blob_size);
     POSIX_ENSURE_REF(en_blob_data);
-    POSIX_GUARD(s2n_blob_init(&en_blob, en_blob_data, en_blob_size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&en_blob, en_blob_data, en_blob_size));
     POSIX_GUARD(s2n_aes256_gcm.io.aead.decrypt(&aes_ticket_key, &iv, &aad_blob, &en_blob, &en_blob));
 
     struct s2n_blob state_blob = { 0 };
     uint32_t state_blob_size = en_blob_size - S2N_TLS_GCM_TAG_LEN;
-    POSIX_GUARD(s2n_blob_init(&state_blob, en_blob.data, state_blob_size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&state_blob, en_blob.data, state_blob_size));
     struct s2n_stuffer state_stuffer = { 0 };
     POSIX_GUARD(s2n_stuffer_init(&state_stuffer, &state_blob));
     POSIX_GUARD(s2n_stuffer_skip_write(&state_stuffer, state_blob_size));
@@ -900,21 +900,21 @@ int s2n_decrypt_session_cache(struct s2n_connection *conn, struct s2n_stuffer *f
 
     uint8_t iv_data[S2N_TLS_GCM_IV_LEN] = { 0 };
     struct s2n_blob iv = { 0 };
-    POSIX_GUARD(s2n_blob_init(&iv, iv_data, sizeof(iv_data)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&iv, iv_data, sizeof(iv_data)));
 
     uint8_t aad_data[S2N_TICKET_AAD_LEN] = { 0 };
     struct s2n_blob aad_blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&aad_blob, aad_data, sizeof(aad_data)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&aad_blob, aad_data, sizeof(aad_data)));
     struct s2n_stuffer aad = { 0 };
 
     uint8_t s_data[S2N_TLS12_STATE_SIZE_IN_BYTES] = { 0 };
     struct s2n_blob state_blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&state_blob, s_data, sizeof(s_data)));
     struct s2n_stuffer state = { 0 };
 
     uint8_t en_data[S2N_TLS12_STATE_SIZE_IN_BYTES + S2N_TLS_GCM_TAG_LEN] = { 0 };
     struct s2n_blob en_blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&en_blob, en_data, sizeof(en_data)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&en_blob, en_data, sizeof(en_data)));
 
     POSIX_GUARD(s2n_stuffer_read_bytes(from, key_name, s2n_array_len(key_name)));
 
@@ -925,7 +925,7 @@ int s2n_decrypt_session_cache(struct s2n_connection *conn, struct s2n_stuffer *f
 
     POSIX_GUARD(s2n_stuffer_read(from, &iv));
 
-    POSIX_GUARD(s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN));
+    POSIX_GUARD_RESULT(s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN));
     POSIX_GUARD(s2n_session_key_alloc(&aes_ticket_key));
     POSIX_GUARD(s2n_aes256_gcm.init(&aes_ticket_key));
     POSIX_GUARD(s2n_aes256_gcm.set_decryption_key(&aes_ticket_key, &aes_key_blob));

--- a/tls/s2n_server_finished.c
+++ b/tls/s2n_server_finished.c
@@ -86,7 +86,7 @@ int s2n_tls13_server_finished_recv(struct s2n_connection *conn)
 
     /* read finished mac from handshake */
     struct s2n_blob wire_finished_mac = { 0 };
-    POSIX_GUARD(s2n_blob_init(&wire_finished_mac, s2n_stuffer_raw_read(&conn->handshake.io, length), length));
+    POSIX_GUARD_RESULT(s2n_blob_init(&wire_finished_mac, s2n_stuffer_raw_read(&conn->handshake.io, length), length));
 
     /* get tls13 keys */
     s2n_tls13_connection_keys(keys, conn);
@@ -98,7 +98,7 @@ int s2n_tls13_server_finished_recv(struct s2n_connection *conn)
 
     /* look up finished secret key */
     struct s2n_blob finished_key = { 0 };
-    POSIX_GUARD(s2n_blob_init(&finished_key, conn->handshake.server_finished, keys.size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&finished_key, conn->handshake.server_finished, keys.size));
 
     /* generate the hashed message authenticated code */
     s2n_tls13_key_blob(server_finished_mac, keys.size);
@@ -124,7 +124,7 @@ int s2n_tls13_server_finished_send(struct s2n_connection *conn)
 
     /* look up finished secret key */
     struct s2n_blob finished_key = { 0 };
-    POSIX_GUARD(s2n_blob_init(&finished_key, conn->handshake.server_finished, keys.size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&finished_key, conn->handshake.server_finished, keys.size));
 
     /* generate the hashed message authenticated code */
     s2n_tls13_key_blob(server_finished_mac, keys.size);

--- a/tls/s2n_server_hello.c
+++ b/tls/s2n_server_hello.c
@@ -321,13 +321,13 @@ int s2n_server_hello_send(struct s2n_connection *conn)
 
     struct s2n_stuffer server_random = { 0 };
     struct s2n_blob b = { 0 };
-    POSIX_GUARD(s2n_blob_init(&b, conn->handshake_params.server_random, S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD_RESULT(s2n_blob_init(&b, conn->handshake_params.server_random, S2N_TLS_RANDOM_DATA_LEN));
 
     /* Create the server random data */
     POSIX_GUARD(s2n_stuffer_init(&server_random, &b));
 
     struct s2n_blob rand_data = { 0 };
-    POSIX_GUARD(s2n_blob_init(&rand_data, s2n_stuffer_raw_write(&server_random, S2N_TLS_RANDOM_DATA_LEN), S2N_TLS_RANDOM_DATA_LEN));
+    POSIX_GUARD_RESULT(s2n_blob_init(&rand_data, s2n_stuffer_raw_write(&server_random, S2N_TLS_RANDOM_DATA_LEN), S2N_TLS_RANDOM_DATA_LEN));
     POSIX_ENSURE_REF(rand_data.data);
     POSIX_GUARD_RESULT(s2n_get_public_random_data(&rand_data));
 

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -69,7 +69,7 @@ int s2n_server_key_recv(struct s2n_connection *conn)
     POSIX_GUARD(s2n_stuffer_read_uint16(in, &signature_length));
 
     struct s2n_blob signature = { 0 };
-    POSIX_GUARD(s2n_blob_init(&signature, s2n_stuffer_raw_read(in, signature_length), signature_length));
+    POSIX_GUARD_RESULT(s2n_blob_init(&signature, s2n_stuffer_raw_read(in, signature_length), signature_length));
 
     POSIX_ENSURE_REF(signature.data);
     POSIX_ENSURE_GT(signature_length, 0);
@@ -164,7 +164,7 @@ int s2n_kem_server_key_recv_read_data(struct s2n_connection *conn, struct s2n_bl
     uint8_t kem_id_arr[2];
     kem_extension_size kem_id;
     struct s2n_blob kem_id_blob = { 0 };
-    POSIX_GUARD(s2n_blob_init(&kem_id_blob, kem_id_arr, s2n_array_len(kem_id_arr)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&kem_id_blob, kem_id_arr, s2n_array_len(kem_id_arr)));
     POSIX_GUARD(s2n_stuffer_init(&kem_id_stuffer, &kem_id_blob));
     POSIX_GUARD(s2n_stuffer_write(&kem_id_stuffer, &(kem_data->kem_name)));
     POSIX_GUARD(s2n_stuffer_read_uint16(&kem_id_stuffer, &kem_id));

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -77,7 +77,7 @@ int s2n_server_nst_send(struct s2n_connection *conn)
     uint16_t session_ticket_len = S2N_TLS12_TICKET_SIZE_IN_BYTES;
     uint8_t data[S2N_TLS12_TICKET_SIZE_IN_BYTES] = { 0 };
     struct s2n_blob entry = { 0 };
-    POSIX_GUARD(s2n_blob_init(&entry, data, sizeof(data)));
+    POSIX_GUARD_RESULT(s2n_blob_init(&entry, data, sizeof(data)));
     struct s2n_stuffer to = { 0 };
     uint32_t lifetime_hint_in_secs =
             (conn->config->encrypt_decrypt_key_lifetime_in_nanos + conn->config->decrypt_key_lifetime_in_nanos) / ONE_SEC_IN_NANOS;
@@ -252,7 +252,7 @@ static int s2n_generate_session_secret(struct s2n_connection *conn, struct s2n_b
 
     s2n_tls13_connection_keys(secrets, conn);
     struct s2n_blob master_secret = { 0 };
-    POSIX_GUARD(s2n_blob_init(&master_secret, conn->secrets.version.tls13.resumption_master_secret, secrets.size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&master_secret, conn->secrets.version.tls13.resumption_master_secret, secrets.size));
     POSIX_GUARD(s2n_realloc(output, secrets.size));
     POSIX_GUARD_RESULT(s2n_tls13_derive_session_ticket_secret(&secrets, &master_secret, nonce, output));
 
@@ -279,7 +279,7 @@ S2N_RESULT s2n_tls13_server_nst_write(struct s2n_connection *conn, struct s2n_st
     /* Get random data to use as ticket_age_add value */
     uint8_t data[sizeof(uint32_t)] = { 0 };
     struct s2n_blob random_data = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&random_data, data, sizeof(data)));
+    RESULT_GUARD(s2n_blob_init(&random_data, data, sizeof(data)));
     /** 
      *= https://tools.ietf.org/rfc/rfc8446#section-4.6.1
      *#  The server MUST generate a fresh value
@@ -292,7 +292,7 @@ S2N_RESULT s2n_tls13_server_nst_write(struct s2n_connection *conn, struct s2n_st
     /* Write ticket nonce */
     uint8_t nonce_data[sizeof(uint16_t)] = { 0 };
     struct s2n_blob nonce = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&nonce, nonce_data, sizeof(nonce_data)));
+    RESULT_GUARD(s2n_blob_init(&nonce, nonce_data, sizeof(nonce_data)));
     RESULT_GUARD(s2n_generate_ticket_nonce(conn->tickets_sent, &nonce));
     RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(output, nonce.size));
     RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(output, nonce.data, nonce.size));
@@ -367,7 +367,7 @@ S2N_RESULT s2n_tls13_server_nst_recv(struct s2n_connection *conn, struct s2n_stu
     RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(input, &ticket_nonce_len));
     uint8_t nonce_data[UINT8_MAX] = { 0 };
     struct s2n_blob nonce = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&nonce, nonce_data, ticket_nonce_len));
+    RESULT_GUARD(s2n_blob_init(&nonce, nonce_data, ticket_nonce_len));
     RESULT_GUARD_POSIX(s2n_stuffer_read_bytes(input, nonce.data, ticket_nonce_len));
     RESULT_GUARD_POSIX(s2n_generate_session_secret(conn, &nonce, &ticket_fields->session_secret));
 

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -25,7 +25,7 @@ static int s2n_zero_sequence_number(struct s2n_connection *conn, s2n_mode mode)
     POSIX_ENSURE_REF(conn->secure);
     struct s2n_blob sequence_number = { 0 };
     POSIX_GUARD_RESULT(s2n_connection_get_sequence_number(conn, mode, &sequence_number));
-    POSIX_GUARD(s2n_blob_zero(&sequence_number));
+    POSIX_GUARD_RESULT(s2n_blob_zero(&sequence_number));
     return S2N_SUCCESS;
 }
 
@@ -165,12 +165,12 @@ int s2n_update_application_traffic_keys(struct s2n_connection *conn, s2n_mode mo
 
     if (mode == S2N_CLIENT) {
         old_key = &conn->secure->client_key;
-        POSIX_GUARD(s2n_blob_init(&old_app_secret, conn->secrets.version.tls13.client_app_secret, keys.size));
-        POSIX_GUARD(s2n_blob_init(&app_iv, conn->secure->client_implicit_iv, S2N_TLS13_FIXED_IV_LEN));
+        POSIX_GUARD_RESULT(s2n_blob_init(&old_app_secret, conn->secrets.version.tls13.client_app_secret, keys.size));
+        POSIX_GUARD_RESULT(s2n_blob_init(&app_iv, conn->secure->client_implicit_iv, S2N_TLS13_FIXED_IV_LEN));
     } else {
         old_key = &conn->secure->server_key;
-        POSIX_GUARD(s2n_blob_init(&old_app_secret, conn->secrets.version.tls13.server_app_secret, keys.size));
-        POSIX_GUARD(s2n_blob_init(&app_iv, conn->secure->server_implicit_iv, S2N_TLS13_FIXED_IV_LEN));
+        POSIX_GUARD_RESULT(s2n_blob_init(&old_app_secret, conn->secrets.version.tls13.server_app_secret, keys.size));
+        POSIX_GUARD_RESULT(s2n_blob_init(&app_iv, conn->secure->server_implicit_iv, S2N_TLS13_FIXED_IV_LEN));
     }
 
     /* Produce new application secret */

--- a/tls/s2n_tls13_key_schedule.c
+++ b/tls/s2n_tls13_key_schedule.c
@@ -38,7 +38,7 @@ static S2N_RESULT s2n_zero_sequence_number(struct s2n_connection *conn, s2n_mode
     RESULT_ENSURE_REF(conn->secure);
     struct s2n_blob sequence_number = { 0 };
     RESULT_GUARD(s2n_connection_get_sequence_number(conn, mode, &sequence_number));
-    RESULT_GUARD_POSIX(s2n_blob_zero(&sequence_number));
+    RESULT_GUARD(s2n_blob_zero(&sequence_number));
     return S2N_RESULT_OK;
 }
 
@@ -67,7 +67,7 @@ static S2N_RESULT s2n_tls13_key_schedule_get_keying_material(
      **/
     struct s2n_blob secret = { 0 };
     uint8_t secret_bytes[S2N_TLS13_SECRET_MAX_LEN] = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&secret, secret_bytes, S2N_TLS13_SECRET_MAX_LEN));
+    RESULT_GUARD(s2n_blob_init(&secret, secret_bytes, S2N_TLS13_SECRET_MAX_LEN));
     RESULT_GUARD(s2n_tls13_secrets_get(conn, secret_type, mode, &secret));
 
     /**
@@ -139,8 +139,8 @@ static S2N_RESULT s2n_set_key(struct s2n_connection *conn, s2n_extract_secret_ty
 
     struct s2n_blob iv = { 0 };
     struct s2n_blob key = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&iv, implicit_iv_data, S2N_TLS13_FIXED_IV_LEN));
-    RESULT_GUARD_POSIX(s2n_blob_init(&key, key_bytes, sizeof(key_bytes)));
+    RESULT_GUARD(s2n_blob_init(&iv, implicit_iv_data, S2N_TLS13_FIXED_IV_LEN));
+    RESULT_GUARD(s2n_blob_init(&key, key_bytes, sizeof(key_bytes)));
     RESULT_GUARD(s2n_tls13_key_schedule_get_keying_material(
             conn, secret_type, mode, &iv, &key));
 

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -495,7 +495,7 @@ static S2N_RESULT s2n_x509_validator_read_cert_chain(struct s2n_x509_validator *
     RESULT_ENSURE(validator->state == INIT, S2N_ERR_INVALID_CERT_STATE);
 
     struct s2n_blob cert_chain_blob = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&cert_chain_blob, cert_chain_in, cert_chain_len));
+    RESULT_GUARD(s2n_blob_init(&cert_chain_blob, cert_chain_in, cert_chain_len));
     DEFER_CLEANUP(struct s2n_stuffer cert_chain_in_stuffer = { 0 }, s2n_stuffer_free);
 
     RESULT_GUARD_POSIX(s2n_stuffer_init(&cert_chain_in_stuffer, &cert_chain_blob));
@@ -735,7 +735,7 @@ static S2N_RESULT s2n_x509_validator_parse_leaf_certificate_extensions(struct s2
     RESULT_ENSURE_GTE(conn->actual_protocol_version, S2N_TLS13);
 
     struct s2n_blob cert_chain_blob = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&cert_chain_blob, cert_chain_in, cert_chain_len));
+    RESULT_GUARD(s2n_blob_init(&cert_chain_blob, cert_chain_in, cert_chain_len));
     DEFER_CLEANUP(struct s2n_stuffer cert_chain_in_stuffer = { 0 }, s2n_stuffer_free);
 
     RESULT_GUARD_POSIX(s2n_stuffer_init(&cert_chain_in_stuffer, &cert_chain_blob));

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -35,48 +35,48 @@ S2N_RESULT s2n_blob_validate(const struct s2n_blob *b)
     return S2N_RESULT_OK;
 }
 
-int s2n_blob_init(struct s2n_blob *b, uint8_t *data, uint32_t size)
+S2N_RESULT s2n_blob_init(struct s2n_blob *b, uint8_t *data, uint32_t size)
 {
-    POSIX_ENSURE_REF(b);
-    POSIX_ENSURE(S2N_MEM_IS_READABLE(data, size), S2N_ERR_SAFETY);
+    RESULT_ENSURE_REF(b);
+    RESULT_ENSURE(S2N_MEM_IS_READABLE(data, size), S2N_ERR_SAFETY);
     *b = (struct s2n_blob){ .data = data, .size = size, .allocated = 0, .growable = 0 };
-    POSIX_POSTCONDITION(s2n_blob_validate(b));
-    return S2N_SUCCESS;
+    RESULT_POSTCONDITION(s2n_blob_validate(b));
+    return S2N_RESULT_OK;
 }
 
-int s2n_blob_zero(struct s2n_blob *b)
+S2N_RESULT s2n_blob_zero(struct s2n_blob *b)
 {
-    POSIX_PRECONDITION(s2n_blob_validate(b));
-    POSIX_CHECKED_MEMSET(b->data, 0, MAX(b->allocated, b->size));
-    POSIX_POSTCONDITION(s2n_blob_validate(b));
-    return S2N_SUCCESS;
+    RESULT_PRECONDITION(s2n_blob_validate(b));
+    RESULT_CHECKED_MEMSET(b->data, 0, MAX(b->allocated, b->size));
+    RESULT_POSTCONDITION(s2n_blob_validate(b));
+    return S2N_RESULT_OK;
 }
 
-int s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint32_t offset, uint32_t size)
+S2N_RESULT s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint32_t offset, uint32_t size)
 {
-    POSIX_PRECONDITION(s2n_blob_validate(b));
-    POSIX_PRECONDITION(s2n_blob_validate(slice));
+    RESULT_PRECONDITION(s2n_blob_validate(b));
+    RESULT_PRECONDITION(s2n_blob_validate(slice));
 
     uint32_t slice_size = 0;
-    POSIX_GUARD(s2n_add_overflow(offset, size, &slice_size));
-    POSIX_ENSURE(b->size >= slice_size, S2N_ERR_SIZE_MISMATCH);
+    RESULT_GUARD_POSIX(s2n_add_overflow(offset, size, &slice_size));
+    RESULT_ENSURE(b->size >= slice_size, S2N_ERR_SIZE_MISMATCH);
     slice->data = (b->data) ? (b->data + offset) : NULL;
     slice->size = size;
     slice->growable = 0;
     slice->allocated = 0;
 
-    POSIX_POSTCONDITION(s2n_blob_validate(slice));
-    return S2N_SUCCESS;
+    RESULT_POSTCONDITION(s2n_blob_validate(slice));
+    return S2N_RESULT_OK;
 }
 
-int s2n_blob_char_to_lower(struct s2n_blob *b)
+S2N_RESULT s2n_blob_char_to_lower(struct s2n_blob *b)
 {
-    POSIX_PRECONDITION(s2n_blob_validate(b));
+    RESULT_PRECONDITION(s2n_blob_validate(b));
     for (size_t i = 0; i < b->size; i++) {
         b->data[i] = tolower(b->data[i]);
     }
-    POSIX_POSTCONDITION(s2n_blob_validate(b));
-    return S2N_SUCCESS;
+    RESULT_POSTCONDITION(s2n_blob_validate(b));
+    return S2N_RESULT_OK;
 }
 
 /* An inverse map from an ascii value to a hexidecimal nibble value

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -40,25 +40,25 @@ struct s2n_blob {
 
 bool s2n_blob_is_growable(const struct s2n_blob *b);
 S2N_RESULT s2n_blob_validate(const struct s2n_blob *b);
-int S2N_RESULT_MUST_USE s2n_blob_init(struct s2n_blob *b, uint8_t *data, uint32_t size);
-int s2n_blob_zero(struct s2n_blob *b);
-int S2N_RESULT_MUST_USE s2n_blob_char_to_lower(struct s2n_blob *b);
+S2N_RESULT s2n_blob_init(struct s2n_blob *b, uint8_t *data, uint32_t size);
+S2N_CLEANUP_RESULT s2n_blob_zero(struct s2n_blob *b);
+S2N_RESULT s2n_blob_char_to_lower(struct s2n_blob *b);
 int S2N_RESULT_MUST_USE s2n_hex_string_to_bytes(const uint8_t *str, struct s2n_blob *blob);
-int S2N_RESULT_MUST_USE s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint32_t offset, uint32_t size);
+S2N_RESULT s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint32_t offset, uint32_t size);
 
 #define s2n_stack_blob(name, requested_size, maximum)   \
     size_t name##_requested_size = (requested_size);    \
     uint8_t name##_buf[(maximum)] = { 0 };              \
     POSIX_ENSURE_LTE(name##_requested_size, (maximum)); \
     struct s2n_blob name = { 0 };                       \
-    POSIX_GUARD(s2n_blob_init(&name, name##_buf, name##_requested_size))
+    POSIX_GUARD_RESULT(s2n_blob_init(&name, name##_buf, name##_requested_size))
 
 #define RESULT_STACK_BLOB(name, requested_size, maximum) \
     size_t name##_requested_size = (requested_size);     \
     uint8_t name##_buf[(maximum)] = { 0 };               \
     RESULT_ENSURE_LTE(name##_requested_size, (maximum)); \
     struct s2n_blob name = { 0 };                        \
-    RESULT_GUARD_POSIX(s2n_blob_init(&name, name##_buf, name##_requested_size))
+    RESULT_GUARD(s2n_blob_init(&name, name##_buf, name##_requested_size))
 
 #define S2N_BLOB_LABEL(name, str)       \
     static uint8_t name##_data[] = str; \

--- a/utils/s2n_map.c
+++ b/utils/s2n_map.c
@@ -56,7 +56,7 @@ static S2N_RESULT s2n_map_embiggen(struct s2n_map *map, uint32_t capacity)
     RESULT_ENSURE(!map->immutable, S2N_ERR_MAP_IMMUTABLE);
 
     RESULT_GUARD_POSIX(s2n_alloc(&mem, (capacity * sizeof(struct s2n_map_entry))));
-    RESULT_GUARD_POSIX(s2n_blob_zero(&mem));
+    RESULT_GUARD(s2n_blob_zero(&mem));
 
     tmp.capacity = capacity;
     tmp.size = 0;
@@ -210,7 +210,7 @@ S2N_RESULT s2n_map_lookup(const struct s2n_map *map, struct s2n_blob *key, struc
 
         /* We found a match */
         struct s2n_blob entry_value = map->table[slot].value;
-        RESULT_GUARD_POSIX(s2n_blob_init(value, entry_value.data, entry_value.size));
+        RESULT_GUARD(s2n_blob_init(value, entry_value.data, entry_value.size));
 
         *key_found = true;
 
@@ -305,7 +305,7 @@ S2N_RESULT s2n_map_iterator_next(struct s2n_map_iterator *iter, struct s2n_blob 
 
     RESULT_ENSURE(iter->current_index < iter->map->capacity, S2N_ERR_ARRAY_INDEX_OOB);
     struct s2n_blob entry_value = iter->map->table[iter->current_index].value;
-    RESULT_GUARD_POSIX(s2n_blob_init(value, entry_value.data, entry_value.size));
+    RESULT_GUARD(s2n_blob_init(value, entry_value.data, entry_value.size));
 
     RESULT_GUARD(s2n_map_iterator_advance(iter));
 

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -206,8 +206,8 @@ int s2n_realloc(struct s2n_blob *b, uint32_t size)
         if (size < b->size) {
             /* Zero the existing blob memory before the we release it */
             struct s2n_blob slice = { 0 };
-            POSIX_GUARD(s2n_blob_slice(b, &slice, size, b->size - size));
-            POSIX_GUARD(s2n_blob_zero(&slice));
+            POSIX_GUARD_RESULT(s2n_blob_slice(b, &slice, size, b->size - size));
+            POSIX_GUARD_RESULT(s2n_blob_zero(&slice));
         }
 
         b->size = size;
@@ -302,9 +302,9 @@ int s2n_free(struct s2n_blob *b)
 {
     /* To avoid memory leaks, don't exit the function until the memory
        has been freed */
-    int zero_rc = s2n_blob_zero(b);
+    s2n_result zero_rc = s2n_blob_zero(b);
     POSIX_GUARD(s2n_free_without_wipe(b));
-    return zero_rc;
+    return s2n_result_is_ok(zero_rc) ? S2N_SUCCESS : S2N_FAILURE;
 }
 
 int s2n_free_without_wipe(struct s2n_blob *b)
@@ -326,9 +326,9 @@ int s2n_free_without_wipe(struct s2n_blob *b)
 int s2n_free_or_wipe(struct s2n_blob *b)
 {
     POSIX_ENSURE_REF(b);
-    int zero_rc = s2n_blob_zero(b);
+    s2n_result zero_rc = s2n_blob_zero(b);
     if (b->allocated) {
         POSIX_GUARD(s2n_free_without_wipe(b));
     }
-    return zero_rc;
+    return s2n_result_is_ok(zero_rc) ? S2N_SUCCESS : S2N_FAILURE;
 }

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -213,9 +213,9 @@ static S2N_RESULT s2n_init_drbgs(void)
     uint8_t s2n_public_drbg[] = "s2n public drbg";
     uint8_t s2n_private_drbg[] = "s2n private drbg";
     struct s2n_blob public = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&public, s2n_public_drbg, sizeof(s2n_public_drbg)));
+    RESULT_GUARD(s2n_blob_init(&public, s2n_public_drbg, sizeof(s2n_public_drbg)));
     struct s2n_blob private = { 0 };
-    RESULT_GUARD_POSIX(s2n_blob_init(&private, s2n_private_drbg, sizeof(s2n_private_drbg)));
+    RESULT_GUARD(s2n_blob_init(&private, s2n_private_drbg, sizeof(s2n_private_drbg)));
 
     RESULT_ENSURE(pthread_once(&s2n_per_thread_rand_state_key_once, s2n_drbg_make_rand_state_key) == 0, S2N_ERR_DRBG);
     RESULT_ENSURE_EQ(pthread_key_create_result, 0);
@@ -290,7 +290,7 @@ static S2N_RESULT s2n_get_custom_random_data(struct s2n_blob *out_blob, struct s
     while (remaining) {
         struct s2n_blob slice = { 0 };
 
-        RESULT_GUARD_POSIX(s2n_blob_slice(out_blob, &slice, offset, MIN(remaining, S2N_DRBG_GENERATE_LIMIT)));
+        RESULT_GUARD(s2n_blob_slice(out_blob, &slice, offset, MIN(remaining, S2N_DRBG_GENERATE_LIMIT)));
         RESULT_GUARD(s2n_drbg_generate(drbg_state, &slice));
 
         remaining -= slice.size;
@@ -469,7 +469,7 @@ S2N_RESULT s2n_public_random(int64_t bound, uint64_t *output)
 
     while (1) {
         struct s2n_blob blob = { 0 };
-        RESULT_GUARD_POSIX(s2n_blob_init(&blob, (void *) &r, sizeof(r)));
+        RESULT_GUARD(s2n_blob_init(&blob, (void *) &r, sizeof(r)));
         RESULT_GUARD(s2n_get_public_random_data(&blob));
 
         /* Imagine an int was one byte and UINT_MAX was 256. If the
@@ -499,7 +499,7 @@ S2N_RESULT s2n_public_random(int64_t bound, uint64_t *output)
 int s2n_openssl_compat_rand(unsigned char *buf, int num)
 {
     struct s2n_blob out = { 0 };
-    POSIX_GUARD(s2n_blob_init(&out, buf, num));
+    POSIX_GUARD_RESULT(s2n_blob_init(&out, buf, num));
 
     if (s2n_result_is_error(s2n_get_private_random_data(&out))) {
         return 0;
@@ -665,7 +665,7 @@ static int s2n_rand_get_entropy_from_rdrand(void *data, uint32_t size)
 {
 #if defined(__x86_64__) || defined(__i386__)
     struct s2n_blob out = { 0 };
-    POSIX_GUARD(s2n_blob_init(&out, data, size));
+    POSIX_GUARD_RESULT(s2n_blob_init(&out, data, size));
     size_t space_remaining = 0;
     struct s2n_stuffer stuffer = { 0 };
     union {


### PR DESCRIPTION
### Resolved issues:

chips away at #2425 

### Description of changes: 
This PR switches `s2n_blob` methods to use `s2n_result`.

There are 5 manual changes

- `utils/s2n_blob.c`: switch all implementations to use `s2n_result` with the appropriate guard changes
- `utils/s2n_blob.h`: switch the header to match the implementation
- `tls/s2n_async_pkey.c:141`: There was a manual comparison with `S2N_SUCCESS`, switched to use `s2n_result_is_error`
- `utils/s2n_mem.c:s2n_free(305)`: the return type is stored, so the type of that variable had to be changed
- `utils/s2n_mem.c:s2n_free_or_wipe(333)`: the return type is stored, so the type of that variable had to be change.

All other changes were made with the following `sed` commands.
```
find . -type f -exec sed -i 's/POSIX_GUARD(s2n_blob/POSIX_GUARD_RESULT(s2n_blob/g' {} +
find . -type f -exec sed -i 's/PTR_GUARD_POSIX(s2n_blob/PTR_GUARD_RESULT(s2n_blob/g' {} +
find . -type f -exec sed -i 's/RESULT_GUARD(s2n_blob/RESULT_GUARD(s2n_blob/g' {} +
find . -type f -exec sed -i 's/EXPECT_SUCCESS(s2n_blob/EXPECT_OK(s2n_blob/g' {} +
```

### Call-outs:
Draft note: It would be lovely to make this a completely automated PR, but I don't see an easy way to do that and keep things compiling. ☹️ 

### Testing:
All existing tests should pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
