### PR TITLE
style: manual initial value fix

### DIFF
--- a/tests/sidetrail/working/patches/cbc.patch
+++ b/tests/sidetrail/working/patches/cbc.patch
@@ -35,7 +35,7 @@ index 401ab760..f39cc7e2 100644
   */
  int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, struct s2n_blob *decrypted)
  {
--    uint8_t mac_digest_size;
+-    uint8_t mac_digest_size = 0;
 -    POSIX_GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));
 +    uint8_t mac_digest_size = DIGEST_SIZE;
 +    //POSIX_GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));

--- a/tls/s2n_cbc.c
+++ b/tls/s2n_cbc.c
@@ -45,7 +45,7 @@
  */
 int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, struct s2n_blob *decrypted)
 {
-    uint8_t mac_digest_size;
+    uint8_t mac_digest_size = 0;
     POSIX_GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));
 
     /* The record has to be at least big enough to contain the MAC,


### PR DESCRIPTION
We wish to keep the main switch to initial value declarations entirely automated. Entirely automated approaches were failing because the patch wasn't also getting linted. This commit breaks that out into a separate PR.

### Description of changes: 

Related to #4404 

### Testing:

All existing CI should pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
