### PR TITLE
api: add key update request functionality

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1883,26 +1883,17 @@ S2N_API extern uint64_t s2n_connection_get_delay(struct s2n_connection *conn);
 S2N_API extern int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);
 
 /**
- * This enums defines the available key update types. For additional information see the documentation for
- * `s2n_connection_request_key_update`.
- */
-typedef enum {
-    S2N_UPDATE_NOT_REQUESTED,
-    S2N_UPDATE_REQUESTED,
-} s2n_peer_key_update;
-
-/**
  * Signals the connection to do a key_update at the next possible opportunity.
  * 
- * @param conn The connection object to trigger the key update on
- * @param update The type of key update. `S2N_UPDATE_REQUESTED` will update the 
- * sending key of `conn` and will also request that the peer update their sending
- * key. `S2N_UPDATE_NOT_REQUESTED` will update the sending key of `conn` and inform
- * the peer of the update, but does not request that the peer update their sending 
- * keys. Only `S2N_UPDATE_NOT_REQUESTED` is currently supported.
+ * @param conn The connection object to trigger the key update on.
+ * @param peer_update_requested Indicates if a key update should also be requested 
+ * of the peer. If false, then only the sending keys of `conn` will be updated. If
+ * true, then the sending keys of conn will be updated AND the peer will be requested
+ * to update their sending key. Note that s2n-tls currently only supports 
+ * `peer_update_requested` being set to `false`.
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
 */
-S2N_API extern int s2n_connection_request_key_update(struct s2n_connection *conn, s2n_peer_key_update update);
+S2N_API extern int s2n_connection_request_key_update(struct s2n_connection *conn, bool peer_update_requested);
 /**
  * Appends the provided application protocol to the preference list
  *

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1895,10 +1895,11 @@ typedef enum {
  * Signals the connection to do a key_update at the next possible opportunity.
  * 
  * @param conn The connection object to trigger the key update on
- * @param update The type of key update. `S2N_UPDATE_REQUESTED` will update the sending key of `conn` and will also
- * request that the peer update their sending key. `S2N_UPDATE_NOT_REQUESTED` will update the sending key of `conn`
- * and inform the peer of the update, but does not request that the peer update their sending keys. Only 
- * `S2N_UPDATE_NOT_REQUESTED` is currently supported.
+ * @param update The type of key update. `S2N_UPDATE_REQUESTED` will update the 
+ * sending key of `conn` and will also request that the peer update their sending
+ * key. `S2N_UPDATE_NOT_REQUESTED` will update the sending key of `conn` and inform
+ * the peer of the update, but does not request that the peer update their sending 
+ * keys. Only `S2N_UPDATE_NOT_REQUESTED` is currently supported.
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
 */
 S2N_API extern int s2n_connection_request_key_update(struct s2n_connection *conn, s2n_peer_key_update update);

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1898,8 +1898,8 @@ typedef enum {
  * @param conn The connection object to trigger the key update on.
  * @param peer_request Indicates if a key update should also be requested 
  * of the peer. When set to `S2N_KEY_UPDATE_NOT_REQUESTED`, then only the sending
- * keys of `conn` will be updated. If set to `S2N_KEY_UPDATE_REQUESTED`, then 
- * the sending keys of conn will be updated AND the peer will be requested to 
+ * key of `conn` will be updated. If set to `S2N_KEY_UPDATE_REQUESTED`, then 
+ * the sending key of conn will be updated AND the peer will be requested to 
  * update their sending key. Note that s2n-tls currently only supports 
  * `peer_request` being set to `S2N_KEY_UPDATE_NOT_REQUESTED` and will return
  *  S2N_FAILURE if any other value is used.

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1883,19 +1883,29 @@ S2N_API extern uint64_t s2n_connection_get_delay(struct s2n_connection *conn);
 S2N_API extern int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);
 
 /**
+ * Used to indicate the type of key update that is being requested. For further 
+ * information refer to `s2n_connection_request_key_update`.
+*/
+typedef enum {
+    S2N_KEY_UPDATE_NOT_REQUESTED = 0,
+    S2N_KEY_UPDATE_REQUESTED
+} s2n_peer_key_update;
+
+/**
  * Signals the connection to do a key_update at the next possible opportunity. Note that the resulting key update message
  * will not be sent until `s2n_send` is called.
  * 
  * @param conn The connection object to trigger the key update on.
- * @param peer_update_requested Indicates if a key update should also be requested 
- * of the peer. If `0`, then only the sending keys of `conn` will be updated. If
- * non-zero, then the sending keys of conn will be updated AND the peer will be requested
- * to update their sending key. Note that s2n-tls currently only supports 
- * `peer_update_requested` being set to `0` and will return an S2N_FAILURE if
- * `peer_update_requested` is non-zero.
+ * @param peer_request Indicates if a key update should also be requested 
+ * of the peer. When set to `S2N_KEY_UPDATE_NOT_REQUESTED`, then only the sending
+ * keys of `conn` will be updated. If set to `S2N_KEY_UPDATE_REQUESTED`, then 
+ * the sending keys of conn will be updated AND the peer will be requested to 
+ * update their sending key. Note that s2n-tls currently only supports 
+ * `peer_request` being set to `S2N_KEY_UPDATE_NOT_REQUESTED` and will return
+ *  S2N_FAILURE if any other value is used.
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
 */
-S2N_API extern int s2n_connection_request_key_update(struct s2n_connection *conn, uint8_t peer_update_requested);
+S2N_API extern int s2n_connection_request_key_update(struct s2n_connection *conn, s2n_peer_key_update peer_request);
 /**
  * Appends the provided application protocol to the preference list
  *

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1888,14 +1888,14 @@ S2N_API extern int s2n_connection_set_cipher_preferences(struct s2n_connection *
  * 
  * @param conn The connection object to trigger the key update on.
  * @param peer_update_requested Indicates if a key update should also be requested 
- * of the peer. If false, then only the sending keys of `conn` will be updated. If
- * true, then the sending keys of conn will be updated AND the peer will be requested
+ * of the peer. If `0`, then only the sending keys of `conn` will be updated. If
+ * non-zero, then the sending keys of conn will be updated AND the peer will be requested
  * to update their sending key. Note that s2n-tls currently only supports 
- * `peer_update_requested` being set to `false` and will return an S2N_FAILURE if
- * `peer_update_requested` is `true`.
+ * `peer_update_requested` being set to `0` and will return an S2N_FAILURE if
+ * `peer_update_requested` is non-zero.
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
 */
-S2N_API extern int s2n_connection_request_key_update(struct s2n_connection *conn, bool peer_update_requested);
+S2N_API extern int s2n_connection_request_key_update(struct s2n_connection *conn, uint8_t peer_update_requested);
 /**
  * Appends the provided application protocol to the preference list
  *

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1883,14 +1883,16 @@ S2N_API extern uint64_t s2n_connection_get_delay(struct s2n_connection *conn);
 S2N_API extern int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);
 
 /**
- * Signals the connection to do a key_update at the next possible opportunity.
+ * Signals the connection to do a key_update at the next possible opportunity. Note that the resulting key update message
+ * will not be sent until `s2n_send` is called.
  * 
  * @param conn The connection object to trigger the key update on.
  * @param peer_update_requested Indicates if a key update should also be requested 
  * of the peer. If false, then only the sending keys of `conn` will be updated. If
  * true, then the sending keys of conn will be updated AND the peer will be requested
  * to update their sending key. Note that s2n-tls currently only supports 
- * `peer_update_requested` being set to `false`.
+ * `peer_update_requested` being set to `false` and will return an S2N_FAILURE if
+ * `peer_update_requested` is `true`.
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
 */
 S2N_API extern int s2n_connection_request_key_update(struct s2n_connection *conn, bool peer_update_requested);

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1883,6 +1883,26 @@ S2N_API extern uint64_t s2n_connection_get_delay(struct s2n_connection *conn);
 S2N_API extern int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const char *version);
 
 /**
+ * This enums defines the available key update types. For additional information see the documentation for
+ * `s2n_connection_request_key_update`.
+ */
+typedef enum {
+    S2N_UPDATE_NOT_REQUESTED,
+    S2N_UPDATE_REQUESTED,
+} s2n_peer_key_update;
+
+/**
+ * Signals the connection to do a key_update at the next possible opportunity.
+ * 
+ * @param conn The connection object to trigger the key update on
+ * @param update The type of key update. `S2N_UPDATE_REQUESTED` will update the sending key of `conn` and will also
+ * request that the peer update their sending key. `S2N_UPDATE_NOT_REQUESTED` will update the sending key of `conn`
+ * and inform the peer of the update, but does not request that the peer update their sending keys. Only 
+ * `S2N_UPDATE_NOT_REQUESTED` is currently supported.
+ * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
+*/
+S2N_API extern int s2n_connection_request_key_update(struct s2n_connection *conn, s2n_peer_key_update update);
+/**
  * Appends the provided application protocol to the preference list
  *
  * The data provided in `protocol` parameter will be copied into an internal buffer

--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -687,7 +687,7 @@ int main(int argc, char **argv)
         /* usage */
         {
             DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_request_key_update(conn, true), S2N_ERR_T_USAGE);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_request_key_update(conn, true), S2N_ERR_UNIMPLEMENTED);
         };
 
         /* happy path */

--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -333,7 +333,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, client_conn));
 
-            EXPECT_SUCCESS(s2n_connection_request_key_update(client_conn, S2N_UPDATE_NOT_REQUESTED));
+            EXPECT_SUCCESS(s2n_connection_request_key_update(client_conn, false));
 
             s2n_blocked_status blocked = 0;
             EXPECT_SUCCESS(s2n_key_update_send(client_conn, &blocked));
@@ -681,20 +681,20 @@ int main(int argc, char **argv)
     {
         /* null safety */
         {
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_request_key_update(NULL, S2N_UPDATE_NOT_REQUESTED), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_request_key_update(NULL, false), S2N_ERR_NULL);
         };
 
         /* usage */
         {
             DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_request_key_update(conn, S2N_UPDATE_REQUESTED), S2N_ERR_T_USAGE);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_request_key_update(conn, true), S2N_ERR_T_USAGE);
         };
 
         /* happy path */
         {
             DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
             EXPECT_FALSE(s2n_atomic_flag_test(&conn->key_update_pending));
-            EXPECT_SUCCESS(s2n_connection_request_key_update(conn, S2N_UPDATE_NOT_REQUESTED));
+            EXPECT_SUCCESS(s2n_connection_request_key_update(conn, false));
             EXPECT_TRUE(s2n_atomic_flag_test(&conn->key_update_pending));
         };
     };

--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -687,7 +687,7 @@ int main(int argc, char **argv)
         /* usage */
         {
             DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_request_key_update(conn, true), S2N_ERR_UNIMPLEMENTED);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_request_key_update(conn, true), S2N_ERR_INVALID_ARGUMENT);
         };
 
         /* happy path */

--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -333,7 +333,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, client_conn));
 
-            EXPECT_SUCCESS(s2n_connection_request_key_update(client_conn, false));
+            EXPECT_SUCCESS(s2n_connection_request_key_update(client_conn, S2N_KEY_UPDATE_NOT_REQUESTED));
 
             s2n_blocked_status blocked = 0;
             EXPECT_SUCCESS(s2n_key_update_send(client_conn, &blocked));
@@ -681,20 +681,20 @@ int main(int argc, char **argv)
     {
         /* null safety */
         {
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_request_key_update(NULL, false), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_request_key_update(NULL, S2N_KEY_UPDATE_NOT_REQUESTED), S2N_ERR_NULL);
         };
 
         /* usage */
         {
             DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_request_key_update(conn, true), S2N_ERR_INVALID_ARGUMENT);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_request_key_update(conn, S2N_KEY_UPDATE_REQUESTED), S2N_ERR_INVALID_ARGUMENT);
         };
 
         /* happy path */
         {
             DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
             EXPECT_FALSE(s2n_atomic_flag_test(&conn->key_update_pending));
-            EXPECT_SUCCESS(s2n_connection_request_key_update(conn, false));
+            EXPECT_SUCCESS(s2n_connection_request_key_update(conn, S2N_KEY_UPDATE_NOT_REQUESTED));
             EXPECT_TRUE(s2n_atomic_flag_test(&conn->key_update_pending));
         };
     };

--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -333,8 +333,6 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, client_conn));
 
-            EXPECT_FALSE(s2n_atomic_flag_test(&client_conn->key_update_pending));
-
             EXPECT_SUCCESS(s2n_connection_request_key_update(client_conn, S2N_UPDATE_NOT_REQUESTED));
 
             s2n_blocked_status blocked = 0;

--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -333,7 +333,9 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&stuffer, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&stuffer, &stuffer, client_conn));
 
-            s2n_atomic_flag_set(&client_conn->key_update_pending);
+            EXPECT_FALSE(s2n_atomic_flag_test(&client_conn->key_update_pending));
+
+            EXPECT_SUCCESS(s2n_connection_request_key_update(client_conn, S2N_UPDATE_NOT_REQUESTED));
 
             s2n_blocked_status blocked = 0;
             EXPECT_SUCCESS(s2n_key_update_send(client_conn, &blocked));
@@ -676,6 +678,28 @@ int main(int argc, char **argv)
             EXPECT_TRUE(cipher_suite->record_alg->encryption_limit > 0);
         }
     }
+
+    /* s2n_connection_key_update_requested */
+    {
+        /* null safety */
+        {
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_request_key_update(NULL, S2N_UPDATE_NOT_REQUESTED), S2N_ERR_NULL);
+        };
+
+        /* usage */
+        {
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_request_key_update(conn, S2N_UPDATE_REQUESTED), S2N_ERR_T_USAGE);
+        };
+
+        /* happy path */
+        {
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+            EXPECT_FALSE(s2n_atomic_flag_test(&conn->key_update_pending));
+            EXPECT_SUCCESS(s2n_connection_request_key_update(conn, S2N_UPDATE_NOT_REQUESTED));
+            EXPECT_TRUE(s2n_atomic_flag_test(&conn->key_update_pending));
+        };
+    };
 
     END_TEST();
 }

--- a/tests/unit/s2n_key_update_threads_test.c
+++ b/tests/unit/s2n_key_update_threads_test.c
@@ -35,7 +35,7 @@
     _##name##_record_alg.encryption_limit = limit;                       \
     name.record_alg = &_##name##_record_alg;
 
-S2N_RESULT s2n_set_key_update_request_for_testing(keyupdate_request request);
+S2N_RESULT s2n_set_key_update_request_for_testing(s2n_peer_key_update request);
 
 static void *s2n_send_random_data(void *arg)
 {

--- a/tls/s2n_key_update.c
+++ b/tls/s2n_key_update.c
@@ -147,11 +147,11 @@ int s2n_check_record_limit(struct s2n_connection *conn, struct s2n_blob *sequenc
     return S2N_SUCCESS;
 }
 
-int s2n_connection_request_key_update(struct s2n_connection *conn, bool peer_update_requested)
+int s2n_connection_request_key_update(struct s2n_connection *conn, uint8_t peer_update_requested)
 {
     POSIX_ENSURE_REF(conn);
     /* s2n-tls does not currently support requesting key updates from peers */
-    POSIX_ENSURE(!peer_update_requested, S2N_ERR_UNIMPLEMENTED);
+    POSIX_ENSURE(peer_update_requested == 0, S2N_ERR_INVALID_ARGUMENT);
     s2n_atomic_flag_set(&conn->key_update_pending);
     return S2N_SUCCESS;
 }

--- a/tls/s2n_key_update.c
+++ b/tls/s2n_key_update.c
@@ -146,3 +146,11 @@ int s2n_check_record_limit(struct s2n_connection *conn, struct s2n_blob *sequenc
 
     return S2N_SUCCESS;
 }
+
+int s2n_connection_request_key_update(struct s2n_connection *conn, s2n_peer_key_update update)
+{
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE(update == S2N_UPDATE_NOT_REQUESTED, S2N_ERR_T_USAGE);
+    s2n_atomic_flag_set(&conn->key_update_pending);
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_key_update.c
+++ b/tls/s2n_key_update.c
@@ -151,7 +151,7 @@ int s2n_connection_request_key_update(struct s2n_connection *conn, bool peer_upd
 {
     POSIX_ENSURE_REF(conn);
     /* s2n-tls does not currently support requesting key updates from peers */
-    POSIX_ENSURE(!peer_update_requested, S2N_ERR_T_USAGE);
+    POSIX_ENSURE(!peer_update_requested, S2N_ERR_UNIMPLEMENTED);
     s2n_atomic_flag_set(&conn->key_update_pending);
     return S2N_SUCCESS;
 }

--- a/tls/s2n_key_update.c
+++ b/tls/s2n_key_update.c
@@ -147,10 +147,11 @@ int s2n_check_record_limit(struct s2n_connection *conn, struct s2n_blob *sequenc
     return S2N_SUCCESS;
 }
 
-int s2n_connection_request_key_update(struct s2n_connection *conn, s2n_peer_key_update update)
+int s2n_connection_request_key_update(struct s2n_connection *conn, bool peer_update_requested)
 {
     POSIX_ENSURE_REF(conn);
-    POSIX_ENSURE(update == S2N_UPDATE_NOT_REQUESTED, S2N_ERR_T_USAGE);
+    /* s2n-tls does not currently support requesting key updates from peers */
+    POSIX_ENSURE(!peer_update_requested, S2N_ERR_T_USAGE);
     s2n_atomic_flag_set(&conn->key_update_pending);
     return S2N_SUCCESS;
 }

--- a/tls/s2n_key_update.c
+++ b/tls/s2n_key_update.c
@@ -24,12 +24,12 @@
 #include "utils/s2n_atomic.h"
 #include "utils/s2n_safety.h"
 
-static keyupdate_request key_update_request_val = S2N_KEY_UPDATE_NOT_REQUESTED;
+static s2n_peer_key_update key_update_request_val = S2N_KEY_UPDATE_NOT_REQUESTED;
 
 int s2n_key_update_write(struct s2n_blob *out);
 int s2n_check_record_limit(struct s2n_connection *conn, struct s2n_blob *sequence_number);
 
-S2N_RESULT s2n_set_key_update_request_for_testing(keyupdate_request request)
+S2N_RESULT s2n_set_key_update_request_for_testing(s2n_peer_key_update request)
 {
     RESULT_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
     key_update_request_val = request;
@@ -147,11 +147,11 @@ int s2n_check_record_limit(struct s2n_connection *conn, struct s2n_blob *sequenc
     return S2N_SUCCESS;
 }
 
-int s2n_connection_request_key_update(struct s2n_connection *conn, uint8_t peer_update_requested)
+int s2n_connection_request_key_update(struct s2n_connection *conn, s2n_peer_key_update peer_request)
 {
     POSIX_ENSURE_REF(conn);
     /* s2n-tls does not currently support requesting key updates from peers */
-    POSIX_ENSURE(peer_update_requested == 0, S2N_ERR_INVALID_ARGUMENT);
+    POSIX_ENSURE(peer_request == S2N_KEY_UPDATE_NOT_REQUESTED, S2N_ERR_INVALID_ARGUMENT);
     s2n_atomic_flag_set(&conn->key_update_pending);
     return S2N_SUCCESS;
 }

--- a/tls/s2n_key_update.h
+++ b/tls/s2n_key_update.h
@@ -25,10 +25,5 @@ typedef enum {
     RECEIVING
 } keyupdate_status;
 
-typedef enum {
-    S2N_KEY_UPDATE_NOT_REQUESTED = 0,
-    S2N_KEY_UPDATE_REQUESTED
-} keyupdate_request;
-
 int s2n_key_update_recv(struct s2n_connection *conn, struct s2n_stuffer *request);
 int s2n_key_update_send(struct s2n_connection *conn, s2n_blocked_status *blocked);


### PR DESCRIPTION
### Description of changes: 

This commit adds a new API which allows a customer to signal their desire for a key update.

### Testing:

Unit tests were added to cover new functionality.

Testing was done locally with other implementations to confirm that they receive the new key update. at the signaled time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
