### PR TITLE
docs: document s2n_cert_auth_type behavior

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2296,10 +2296,10 @@ S2N_API extern int s2n_shutdown_send(struct s2n_connection *conn, s2n_blocked_st
  *
  * Server behavior:
  * - None(default): Will not request client authentication.
- * - Optional: Request the client's certificate and validate it. If no certificate is sent then
+ * - Optional: Request the client's certificate and validate it. If no certificate is received then
  *      no validation is performed.
- * - Required: Request the client's certificate and validate it. Abort the handshake if the
- *   client doesn't send its certificate.
+ * - Required: Request the client's certificate and validate it. Abort the handshake if a client
+ *   certificate not recieved.
  *
  * Client behavior:
  * - None: Abort the handshake if the server requests client authentication.

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2291,31 +2291,31 @@ S2N_API extern int s2n_shutdown_send(struct s2n_connection *conn, s2n_blocked_st
 /**
  * Used to declare what type of client certificate authentication to use.
  *
- * Currently the default for s2n-tls is for neither the server side or the client side to use
- * Client (aka Mutual) authentication.
- *
  * A s2n_connection will enforce client certificate authentication (mTLS) differently based on
- * the s2n_cert_auth_type and s2n_mode of the connection.
+ * the s2n_cert_auth_type and s2n_mode(client/server) of the connection, as described below. The
+ * **default** behavior is used if the application hasn't set an override via
+ * `s2n_config_set_client_auth_type()` or `s2n_connection_set_client_auth_type()`.
  *
- * Server connection behavior:
- * - None: don't send CLIENT_CERT_REQ and therefore don't perform client authentication.
+ * Client authentication involves the following TLS messages:
+ * - 'CLIENT_CERT_REQ': represents the CertificateRequest message sent by the server to request
+ *   client certificate authentication.
+ * - 'CLIENT_CERT': upon receiving a CLIENT_CERT_REQ, the client should respond with its certificate
+ *   in a CLIENT_CERT message.
+ *
+ * **Server connection behavior:**
+ * - None(**default**): don't send CLIENT_CERT_REQ and therefore don't perform client authentication.
  * - Optional: send CLIENT_CERT_REQ and expect a CLIENT_CERT message. Validate the client
  *   certificate or simply continue with the handshake if CLIENT_CERT is empty.
  * - Required: send CLIENT_CERT_REQ and expect a CLIENT_CERT message. Validate the client
  *   certificate or abort the handshake if CLIENT_CERT is empty.
  *
- * Client connection behavior:
- * - None: if a CLIENT_CERT_REQ is received: abort the handshake.
- * - Optional: if a CLIENT_CERT_REQ is received: send a CLIENT_CERT with the client's
- *   certificate. CLIENT_CERT is empty if no client certificate have been set.
- * - Required: expect to receive a CLIENT_CERT_REQ. If no CLIENT_CERT_REQ is received then
- *   abort the handshake. Send a CLIENT_CERT with the client's certificate. Abort the handshake
- *   if no client certificate have been set.
- *
- * - 'CLIENT_CERT_REQ': represents the CertificateRequest message sent by the server to request
- *   client certificate authentication.
- * - 'CLIENT_CERT': upon receiving a CLIENT_CERT_REQ, the client will respond with its certificate
- *   in a CLIENT_CERT message.
+ * **Client connection behavior:**
+ * - None: if a CLIENT_CERT_REQ is received abort the handshake.
+ * - Optional(**default**): if a CLIENT_CERT_REQ is received, send a CLIENT_CERT with the client's
+ *   certificate. The CLIENT_CERT will be empty if no client certificate have been set.
+ * - Required: expect to receive a CLIENT_CERT_REQ, aborting the handshake if it is not received.
+ *   Send a CLIENT_CERT with the client's certificate, aborting the handshake if no client
+ *   certificate have been set.
  */
 typedef enum {
     S2N_CERT_AUTH_NONE,

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2303,8 +2303,8 @@ S2N_API extern int s2n_shutdown_send(struct s2n_connection *conn, s2n_blocked_st
  *
  * Client behavior:
  * - None: Abort the handshake if the server requests client authentication.
- * - Optional (default): Sends the application provided client certificate if the server
- *     requests client authentication.
+ * - Optional (default): Sends the client certificate if the server requests client
+ *     authentication. No certificate is sent if the application hasn't provided a certificate.
  * - Required: Send the client certificate. Abort the handshake if the server doesn't request
  *     client authentication or if the application hasn't provided a client certificate.
  */

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2295,18 +2295,18 @@ S2N_API extern int s2n_shutdown_send(struct s2n_connection *conn, s2n_blocked_st
  * the `s2n_cert_auth_type` and `s2n_mode` (client/server) of the connection, as described below.
  *
  * Server behavior:
- * - None(default): Will not request client authentication.
+ * - None (default): Will not request client authentication.
  * - Optional: Request the client's certificate and validate it. If no certificate is received then
- *      no validation is performed.
+ *     no validation is performed.
  * - Required: Request the client's certificate and validate it. Abort the handshake if a client
- *   certificate not recieved.
+ *   certificate is not received.
  *
  * Client behavior:
  * - None: Abort the handshake if the server requests client authentication.
- * - Optional(default): Sends the application provided client certificate if the server
- *      requests client authentication.
+ * - Optional (default): Sends the application provided client certificate if the server
+ *     requests client authentication.
  * - Required: Send the client certificate. Abort the handshake if the server doesn't request
- *      client authentication or if the application hasn't provided a client certificate.
+ *     client authentication or if the application hasn't provided a client certificate.
  */
 typedef enum {
     S2N_CERT_AUTH_NONE,

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2306,7 +2306,7 @@ S2N_API extern int s2n_shutdown_send(struct s2n_connection *conn, s2n_blocked_st
  * - Optional (default): Sends the client certificate if the server requests client
  *     authentication. No certificate is sent if the application hasn't provided a certificate.
  * - Required: Send the client certificate. Abort the handshake if the server doesn't request
- *     client authentication or if the application hasn't provided a client certificate.
+ *     client authentication or if the application hasn't provided a certificate.
  */
 typedef enum {
     S2N_CERT_AUTH_NONE,

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2291,7 +2291,31 @@ S2N_API extern int s2n_shutdown_send(struct s2n_connection *conn, s2n_blocked_st
 /**
  * Used to declare what type of client certificate authentication to use.
  *
- * Currently the default for s2n-tls is for neither the server side or the client side to use Client (aka Mutual) authentication.
+ * Currently the default for s2n-tls is for neither the server side or the client side to use
+ * Client (aka Mutual) authentication.
+ *
+ * A s2n_connection will enforce client certificate authentication (mTLS) differently based on
+ * the s2n_cert_auth_type and s2n_mode of the connection.
+ *
+ * Server connection behavior:
+ * - None: don't send CLIENT_CERT_REQ and therefore don't perform client authentication.
+ * - Optional: send CLIENT_CERT_REQ and expect a CLIENT_CERT message. Validate the client
+ *   certificate or simply continue with the handshake if CLIENT_CERT is empty.
+ * - Required: send CLIENT_CERT_REQ and expect a CLIENT_CERT message. Validate the client
+ *   certificate or abort the handshake if CLIENT_CERT is empty.
+ *
+ * Client connection behavior:
+ * - None: if a CLIENT_CERT_REQ is received: abort the handshake.
+ * - Optional: if a CLIENT_CERT_REQ is received: send a CLIENT_CERT with the client's
+ *   certificate. CLIENT_CERT is empty if no client certificate have been set.
+ * - Required: expect to receive a CLIENT_CERT_REQ. If no CLIENT_CERT_REQ is received then
+ *   abort the handshake. Send a CLIENT_CERT with the client's certificate. Abort the handshake
+ *   if no client certificate have been set.
+ *
+ * - 'CLIENT_CERT_REQ': represents the CertificateRequest message sent by the server to request
+ *   client certificate authentication.
+ * - 'CLIENT_CERT': upon receiving a CLIENT_CERT_REQ, the client will respond with its certificate
+ *   in a CLIENT_CERT message.
  */
 typedef enum {
     S2N_CERT_AUTH_NONE,

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2299,7 +2299,7 @@ S2N_API extern int s2n_shutdown_send(struct s2n_connection *conn, s2n_blocked_st
  * - Optional: Request the client's certificate and validate it. If no certificate is received then
  *     no validation is performed.
  * - Required: Request the client's certificate and validate it. Abort the handshake if a client
- *   certificate is not received.
+ *     certificate is not received.
  *
  * Client behavior:
  * - None: Abort the handshake if the server requests client authentication.

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2296,27 +2296,18 @@ S2N_API extern int s2n_shutdown_send(struct s2n_connection *conn, s2n_blocked_st
  * **default** behavior is used if the application hasn't set an override via
  * `s2n_config_set_client_auth_type()` or `s2n_connection_set_client_auth_type()`.
  *
- * Client authentication involves the following TLS messages:
- * - 'CLIENT_CERT_REQ': represents the CertificateRequest message sent by the server to request
- *   client certificate authentication.
- * - 'CLIENT_CERT': upon receiving a CLIENT_CERT_REQ, the client should respond with its certificate
- *   in a CLIENT_CERT message.
+ * **Server behavior:**
+ * - None(**default**): don't request client authentication.
+ * - Optional: request the client's certificate and validate if it's non-empty.
+ * - Required: request the client's certificate and validate it.
  *
- * **Server connection behavior:**
- * - None(**default**): don't send CLIENT_CERT_REQ and therefore don't perform client authentication.
- * - Optional: send CLIENT_CERT_REQ and expect a CLIENT_CERT message. Validate the client
- *   certificate or simply continue with the handshake if CLIENT_CERT is empty.
- * - Required: send CLIENT_CERT_REQ and expect a CLIENT_CERT message. Validate the client
- *   certificate or abort the handshake if CLIENT_CERT is empty.
- *
- * **Client connection behavior:**
- * - None: if a CLIENT_CERT_REQ is received abort the handshake.
- * - Optional(**default**): if a CLIENT_CERT_REQ is received, send a CLIENT_CERT with the client's
- *   certificate. The CLIENT_CERT will be empty if no client certificate have been set.
- * - Required: expect to receive a CLIENT_CERT_REQ, aborting the handshake if it is not received.
- *   Send a CLIENT_CERT with the client's certificate, aborting the handshake if no client
- *   certificate have been set.
- */
+ * **Client behavior:**
+ * - None: abort the handshake if the server requests client authentication.
+ * - Optional(**default**): send the client's certificate (can be empty if not set) if the
+ *      server requested client authentication.
+ * - Required: send the client's certificate. Terminate the handshake if the server doesn't request
+ *      client authentication or if the application hasn't specified a client certificate.
+ 
 typedef enum {
     S2N_CERT_AUTH_NONE,
     S2N_CERT_AUTH_REQUIRED,

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2297,7 +2297,7 @@ S2N_API extern int s2n_shutdown_send(struct s2n_connection *conn, s2n_blocked_st
  * `s2n_config_set_client_auth_type()` or `s2n_connection_set_client_auth_type()`.
  *
  * **Server behavior:**
- * - None(**default**): don't request client authentication. Abort the handshake if the client
+ * - None(default): don't request client authentication. Abort the handshake if the client
  *      sends its certificate.
  * - Optional: request the client's certificate and validate if it's non-empty. Abort the
  *      handshake if the client doesn't send its certificate (can be empty).
@@ -2306,7 +2306,7 @@ S2N_API extern int s2n_shutdown_send(struct s2n_connection *conn, s2n_blocked_st
  *
  * **Client behavior:**
  * - None: abort the handshake if the server requests client authentication.
- * - Optional(**default**): send the client's certificate if the server requested client
+ * - Optional(default): send the client's certificate if the server requested client
  *      authentication. An empty certificate will be sent if the application hasn't provided a
  *      client certificate.
  * - Required: send the client's certificate. Abort the handshake if the server doesn't request

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2292,24 +2292,20 @@ S2N_API extern int s2n_shutdown_send(struct s2n_connection *conn, s2n_blocked_st
  * Used to declare what type of client certificate authentication to use.
  *
  * A s2n_connection will enforce client certificate authentication (mTLS) differently based on
- * the s2n_cert_auth_type and s2n_mode(client/server) of the connection, as described below. The
- * default behavior is used if the application hasn't set an override via
- * `s2n_config_set_client_auth_type()` or `s2n_connection_set_client_auth_type()`.
+ * the `s2n_cert_auth_type` and `s2n_mode` (client/server) of the connection, as described below.
  *
- * **Server behavior:**
- * - None(default): don't request client authentication. Abort the handshake if the client
- *      sends its certificate.
- * - Optional: request the client's certificate and validate if it's non-empty. Abort the
- *      handshake if the client doesn't send its certificate (can be empty).
- * - Required: request the client's certificate and validate it. Abort the handshake if the
- *   client doesn't send its certificate or sends an empty certificate.
+ * Server behavior:
+ * - None(default): Will not request client authentication.
+ * - Optional: Request the client's certificate and validate it. If no certificate is sent then
+ *      no validation is performed.
+ * - Required: Request the client's certificate and validate it. Abort the handshake if the
+ *   client doesn't send its certificate.
  *
- * **Client behavior:**
- * - None: abort the handshake if the server requests client authentication.
- * - Optional(default): send the client's certificate if the server requested client
- *      authentication. An empty certificate will be sent if the application hasn't provided a
- *      client certificate.
- * - Required: send the client's certificate. Abort the handshake if the server doesn't request
+ * Client behavior:
+ * - None: Abort the handshake if the server requests client authentication.
+ * - Optional(default): Sends the application provided client certificate if the server
+ *      requests client authentication.
+ * - Required: Send the client certificate. Abort the handshake if the server doesn't request
  *      client authentication or if the application hasn't provided a client certificate.
  */
 typedef enum {

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2293,21 +2293,25 @@ S2N_API extern int s2n_shutdown_send(struct s2n_connection *conn, s2n_blocked_st
  *
  * A s2n_connection will enforce client certificate authentication (mTLS) differently based on
  * the s2n_cert_auth_type and s2n_mode(client/server) of the connection, as described below. The
- * **default** behavior is used if the application hasn't set an override via
+ * default behavior is used if the application hasn't set an override via
  * `s2n_config_set_client_auth_type()` or `s2n_connection_set_client_auth_type()`.
  *
  * **Server behavior:**
- * - None(**default**): don't request client authentication.
- * - Optional: request the client's certificate and validate if it's non-empty.
- * - Required: request the client's certificate and validate it.
+ * - None(**default**): don't request client authentication. Abort the handshake if the client
+ *      sends its certificate.
+ * - Optional: request the client's certificate and validate if it's non-empty. Abort the
+ *      handshake if the client doesn't send its certificate (can be empty).
+ * - Required: request the client's certificate and validate it. Abort the handshake if the
+ *   client doesn't send its certificate or sends an empty certificate.
  *
  * **Client behavior:**
  * - None: abort the handshake if the server requests client authentication.
- * - Optional(**default**): send the client's certificate (can be empty if not set) if the
- *      server requested client authentication.
- * - Required: send the client's certificate. Terminate the handshake if the server doesn't request
- *      client authentication or if the application hasn't specified a client certificate.
- 
+ * - Optional(**default**): send the client's certificate if the server requested client
+ *      authentication. An empty certificate will be sent if the application hasn't provided a
+ *      client certificate.
+ * - Required: send the client's certificate. Abort the handshake if the server doesn't request
+ *      client authentication or if the application hasn't provided a client certificate.
+ */
 typedef enum {
     S2N_CERT_AUTH_NONE,
     S2N_CERT_AUTH_REQUIRED,


### PR DESCRIPTION
### Description of changes: 
s2n-tls has a concept of `s2n_cert_auth_type` which controls handshake behavior depending on the type of connection (server vs client). This behavior is complex and undocumented. This PR attempts to document the behavior.

### Callout:
The default behavior was recently changed in https://github.com/aws/s2n-tls/pull/4390

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
