### PR TITLE
refactor: Change signature of s2n_is_in_fips_mode to support errors

### DIFF
--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -88,6 +88,11 @@ static const EVP_CIPHER *s2n_evp_aes_256_cbc_hmac_sha256(void)
 
 static uint8_t s2n_composite_cipher_aes128_sha_available(void)
 {
+    bool fips_mode = false;
+    if (s2n_is_in_fips_mode(&fips_mode) != S2N_SUCCESS) {
+        return 0;
+    }
+
     /* EVP_aes_128_cbc_hmac_sha1() returns NULL if the implementations aren't available.
      * See https://github.com/openssl/openssl/blob/master/crypto/evp/e_aes_cbc_hmac_sha1.c#L952
      *
@@ -95,34 +100,49 @@ static uint8_t s2n_composite_cipher_aes128_sha_available(void)
      * EVP_CIPH_FLAG_FIPS OpenSSL flag to be set for use when in FIPS mode, and composite
      * ciphers cause OpenSSL errors due to the lack of the flag.
      */
-    return (!s2n_is_in_fips_mode() && s2n_evp_aes_128_cbc_hmac_sha1() ? 1 : 0);
+    return (!fips_mode && s2n_evp_aes_128_cbc_hmac_sha1() ? 1 : 0);
 }
 
 static uint8_t s2n_composite_cipher_aes256_sha_available(void)
 {
+    bool fips_mode = false;
+    if (s2n_is_in_fips_mode(&fips_mode) != S2N_SUCCESS) {
+        return 0;
+    }
+
     /* Composite ciphers cannot be used when FIPS mode is set. Ciphers require the
      * EVP_CIPH_FLAG_FIPS OpenSSL flag to be set for use when in FIPS mode, and composite
      * ciphers cause OpenSSL errors due to the lack of the flag.
      */
-    return (!s2n_is_in_fips_mode() && s2n_evp_aes_256_cbc_hmac_sha1() ? 1 : 0);
+    return (!fips_mode && s2n_evp_aes_256_cbc_hmac_sha1() ? 1 : 0);
 }
 
 static uint8_t s2n_composite_cipher_aes128_sha256_available(void)
 {
+    bool fips_mode = false;
+    if (s2n_is_in_fips_mode(&fips_mode) != S2N_SUCCESS) {
+        return 0;
+    }
+
     /* Composite ciphers cannot be used when FIPS mode is set. Ciphers require the
      * EVP_CIPH_FLAG_FIPS OpenSSL flag to be set for use when in FIPS mode, and composite
      * ciphers cause OpenSSL errors due to the lack of the flag.
      */
-    return (!s2n_is_in_fips_mode() && s2n_evp_aes_128_cbc_hmac_sha256() ? 1 : 0);
+    return (!fips_mode && s2n_evp_aes_128_cbc_hmac_sha256() ? 1 : 0);
 }
 
 static uint8_t s2n_composite_cipher_aes256_sha256_available(void)
 {
+    bool fips_mode = false;
+    if (s2n_is_in_fips_mode(&fips_mode) != S2N_SUCCESS) {
+        return 0;
+    }
+
     /* Composite ciphers cannot be used when FIPS mode is set. Ciphers require the
      * EVP_CIPH_FLAG_FIPS OpenSSL flag to be set for use when in FIPS mode, and composite
      * ciphers cause OpenSSL errors due to the lack of the flag.
      */
-    return (!s2n_is_in_fips_mode() && s2n_evp_aes_256_cbc_hmac_sha256() ? 1 : 0);
+    return (!fips_mode && s2n_evp_aes_256_cbc_hmac_sha256() ? 1 : 0);
 }
 
 static int s2n_composite_cipher_aes_sha_initial_hmac(struct s2n_session_key *key, uint8_t *sequence_number, uint8_t content_type,

--- a/crypto/s2n_evp.c
+++ b/crypto/s2n_evp.c
@@ -22,11 +22,15 @@
 int s2n_digest_allow_md5_for_fips(struct s2n_evp_digest *evp_digest)
 {
     POSIX_ENSURE_REF(evp_digest);
+
+    bool fips_mode = false;
+    POSIX_GUARD(s2n_is_in_fips_mode(&fips_mode));
+
     /* This is only to be used for EVP digests that will require MD5 to be used
      * to comply with the TLS 1.0 and 1.1 RFC's for the PRF. MD5 cannot be used
      * outside of the TLS 1.0 and 1.1 PRF when in FIPS mode.
      */
-    S2N_ERROR_IF(!s2n_is_in_fips_mode() || (evp_digest->ctx == NULL), S2N_ERR_ALLOW_MD5_FOR_FIPS_FAILED);
+    S2N_ERROR_IF(!fips_mode || (evp_digest->ctx == NULL), S2N_ERR_ALLOW_MD5_FOR_FIPS_FAILED);
 
 #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
     EVP_MD_CTX_set_flags(evp_digest->ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
@@ -38,13 +42,17 @@ S2N_RESULT s2n_digest_is_md5_allowed_for_fips(struct s2n_evp_digest *evp_digest,
 {
     RESULT_ENSURE_REF(out);
     *out = false;
+
+    bool fips_mode = false;
+    RESULT_GUARD_POSIX(s2n_is_in_fips_mode(&fips_mode));
+
 #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
-    if (s2n_is_in_fips_mode() && evp_digest && evp_digest->ctx && EVP_MD_CTX_test_flags(evp_digest->ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW)) {
+    if (fips_mode && evp_digest && evp_digest->ctx && EVP_MD_CTX_test_flags(evp_digest->ctx, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW)) {
         /* s2n is in FIPS mode and the EVP digest allows MD5. */
         *out = true;
     }
 #else
-    if (s2n_is_in_fips_mode()) {
+    if (fips_mode) {
         /* If s2n is in FIPS mode and built with AWS-LC or BoringSSL, there are no flags to check in the EVP digest to allow MD5. */
         *out = true;
     }

--- a/crypto/s2n_fips.c
+++ b/crypto/s2n_fips.c
@@ -17,6 +17,8 @@
 
 #include <openssl/crypto.h>
 
+#include "utils/s2n_safety.h"
+
 #if defined(S2N_INTERN_LIBCRYPTO) && defined(OPENSSL_FIPS)
     #error "Interning with OpenSSL fips-validated libcrypto is not currently supported. See https://github.com/aws/s2n-tls/issues/2741"
 #endif
@@ -56,7 +58,14 @@ int s2n_fips_init(void)
 }
 
 /* Return 1 if FIPS mode is enabled, 0 otherwise. FIPS mode must be enabled prior to calling s2n_init(). */
-int s2n_is_in_fips_mode(void)
+int s2n_is_in_fips_mode(bool *fips_mode)
 {
-    return s2n_fips_mode;
+    POSIX_ENSURE_REF(fips_mode);
+    *fips_mode = false;
+
+    if (s2n_fips_mode) {
+        *fips_mode = true;
+    }
+
+    return S2N_SUCCESS;
 }

--- a/crypto/s2n_fips.h
+++ b/crypto/s2n_fips.h
@@ -21,7 +21,7 @@
 #pragma once
 
 int s2n_fips_init(void);
-int s2n_is_in_fips_mode(void);
+int s2n_is_in_fips_mode(bool *fips_mode);
 bool s2n_libcrypto_is_fips(void);
 
 struct s2n_cipher_suite;

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -32,7 +32,11 @@ static bool s2n_use_custom_md5_sha1()
 
 static bool s2n_use_evp_impl()
 {
-    return s2n_is_in_fips_mode();
+    bool fips_mode = false;
+    if (s2n_is_in_fips_mode(&fips_mode) != S2N_SUCCESS) {
+        return false;
+    }
+    return fips_mode;
 }
 
 bool s2n_hash_evp_fully_supported()
@@ -110,11 +114,16 @@ int s2n_hash_block_size(s2n_hash_algorithm alg, uint64_t *block_size)
 /* Return true if hash algorithm is available, false otherwise. */
 bool s2n_hash_is_available(s2n_hash_algorithm alg)
 {
+    bool fips_mode = false;
+    if (s2n_is_in_fips_mode(&fips_mode) != S2N_SUCCESS) {
+        return false;
+    }
+
     switch (alg) {
         case S2N_HASH_MD5:
         case S2N_HASH_MD5_SHA1:
             /* return false if in FIPS mode, as MD5 algs are not available in FIPS mode. */
-            return !s2n_is_in_fips_mode();
+            return !fips_mode;
         case S2N_HASH_NONE:
         case S2N_HASH_SHA1:
         case S2N_HASH_SHA224:

--- a/crypto/s2n_hkdf.c
+++ b/crypto/s2n_hkdf.c
@@ -203,10 +203,13 @@ const struct s2n_hkdf_impl s2n_libcrypto_hkdf_impl = {
 
 static const struct s2n_hkdf_impl *s2n_get_hkdf_implementation()
 {
+    bool fips_mode = false;
+    PTR_GUARD_POSIX(s2n_is_in_fips_mode(&fips_mode));
+
     /* By default, s2n-tls uses a custom HKDF implementation. When operating in FIPS mode, the
      * FIPS-validated libcrypto implementation is used instead, if an implementation is provided.
      */
-    if (s2n_is_in_fips_mode() && s2n_libcrypto_supports_hkdf()) {
+    if (fips_mode && s2n_libcrypto_supports_hkdf()) {
         return &s2n_libcrypto_hkdf_impl;
     }
 

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -78,6 +78,11 @@ int s2n_hmac_digest_size(s2n_hmac_algorithm hmac_alg, uint8_t *out)
 /* Return 1 if hmac algorithm is available, 0 otherwise. */
 bool s2n_hmac_is_available(s2n_hmac_algorithm hmac_alg)
 {
+    bool fips_mode = false;
+    if (s2n_is_in_fips_mode(&fips_mode) != S2N_SUCCESS) {
+        return false;
+    }
+
     switch(hmac_alg) {
     case S2N_HMAC_MD5:
     case S2N_HMAC_SSLv3_MD5:
@@ -85,7 +90,7 @@ bool s2n_hmac_is_available(s2n_hmac_algorithm hmac_alg)
         /* Some libcryptos, such as OpenSSL, disable MD5 by default when in FIPS mode, which is
          * required in order to negotiate SSLv3. However, this is supported in AWS-LC.
          */
-        return !s2n_is_in_fips_mode() || s2n_libcrypto_is_awslc();
+        return !fips_mode || s2n_libcrypto_is_awslc();
     case S2N_HMAC_NONE:
     case S2N_HMAC_SHA1:
     case S2N_HMAC_SHA224:

--- a/crypto/s2n_stream_cipher_rc4.c
+++ b/crypto/s2n_stream_cipher_rc4.c
@@ -32,7 +32,12 @@ static const EVP_CIPHER *s2n_evp_rc4()
 
 static uint8_t s2n_stream_cipher_rc4_available()
 {
-    if (s2n_is_in_fips_mode()) {
+    bool fips_mode = false;
+    if (s2n_is_in_fips_mode(&fips_mode) != S2N_SUCCESS) {
+        return 0;
+    }
+
+    if (fips_mode) {
         return 0;
     }
     /* RC4 MIGHT be available in Openssl-3.0, depending on whether or not the

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -67,6 +67,9 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
+    bool fips_mode = false;
+    EXPECT_SUCCESS(s2n_is_in_fips_mode(&fips_mode));
+
     const s2n_mode modes[] = { S2N_CLIENT, S2N_SERVER };
 
     const struct s2n_security_policy *default_security_policy, *tls13_security_policy, *fips_security_policy;
@@ -105,7 +108,7 @@ int main(int argc, char **argv)
     /* Connections created with default configs */
     {
         /* For TLS1.2 */
-        if (!s2n_is_in_fips_mode()) {
+        if (!fips_mode) {
             struct s2n_connection *conn;
             const struct s2n_security_policy *security_policy;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
@@ -135,7 +138,7 @@ int main(int argc, char **argv)
         };
 
         /* For fips */
-        if (s2n_is_in_fips_mode()) {
+        if (fips_mode) {
             struct s2n_connection *conn;
             const struct s2n_security_policy *security_policy;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
@@ -152,7 +155,7 @@ int main(int argc, char **argv)
 
     /* Test for s2n_config_new() and tls 1.3 behavior */
     {
-        if (!s2n_is_in_fips_mode()) {
+        if (!fips_mode) {
             struct s2n_config *config;
             EXPECT_NOT_NULL(config = s2n_config_new());
             EXPECT_EQUAL(config->security_policy, default_security_policy);

--- a/tests/unit/s2n_connection_preferences_test.c
+++ b/tests/unit/s2n_connection_preferences_test.c
@@ -28,13 +28,16 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
+    bool fips_mode = false;
+    EXPECT_SUCCESS(s2n_is_in_fips_mode(&fips_mode));
+
     const struct s2n_security_policy *default_security_policy, *tls13_security_policy, *fips_security_policy;
     EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_tls13", &tls13_security_policy));
     EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_fips", &fips_security_policy));
     EXPECT_SUCCESS(s2n_find_security_policy_from_version("default", &default_security_policy));
 
     /* Test default TLS1.2 */
-    if (!s2n_is_in_fips_mode()) {
+    if (!fips_mode) {
         struct s2n_connection *conn = NULL;
         const struct s2n_cipher_preferences *cipher_preferences = NULL;
         const struct s2n_security_policy *security_policy = NULL;
@@ -143,7 +146,7 @@ int main(int argc, char **argv)
 
     /* Test default fips */
 
-    if (s2n_is_in_fips_mode()) {
+    if (fips_mode) {
         struct s2n_connection *conn = NULL;
         const struct s2n_cipher_preferences *cipher_preferences = NULL;
         const struct s2n_security_policy *security_policy = NULL;

--- a/tests/unit/s2n_evp_signing_test.c
+++ b/tests/unit/s2n_evp_signing_test.c
@@ -94,10 +94,13 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
+    bool fips_mode = false;
+    EXPECT_SUCCESS(s2n_is_in_fips_mode(&fips_mode));
+
     /* Sanity check that we're enabling evp signing properly.
      * awslc-fips is known to require evp signing.
      */
-    if (s2n_is_in_fips_mode() && s2n_libcrypto_is_awslc()) {
+    if (fips_mode && s2n_libcrypto_is_awslc()) {
         EXPECT_TRUE(s2n_evp_signing_supported());
     }
 

--- a/tests/unit/s2n_fingerprint_ja3_test.c
+++ b/tests/unit/s2n_fingerprint_ja3_test.c
@@ -129,6 +129,9 @@ int main(int argc, char **argv)
         S2N_CH_FROM_RAW,
     };
 
+    bool fips_mode = false;
+    EXPECT_SUCCESS(s2n_is_in_fips_mode(&fips_mode));
+
     DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = NULL,
             s2n_cert_chain_and_key_ptr_free);
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
@@ -142,7 +145,7 @@ int main(int argc, char **argv)
     uint8_t empty_md5_hash[MD5_DIGEST_LENGTH] = { 0 };
     DEFER_CLEANUP(struct s2n_hash_state md5_hash = { 0 }, s2n_hash_free);
     EXPECT_SUCCESS(s2n_hash_new(&md5_hash));
-    if (s2n_is_in_fips_mode()) {
+    if (fips_mode) {
         EXPECT_SUCCESS(s2n_hash_allow_md5_for_fips(&md5_hash));
     }
     EXPECT_SUCCESS(s2n_hash_init(&md5_hash, S2N_HASH_MD5));

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -128,7 +128,10 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
     const struct s2n_security_policy *security_policy = server_config->security_policy;
     EXPECT_NOT_NULL(security_policy);
 
-    if (s2n_is_in_fips_mode()) {
+    bool fips_mode = false;
+    EXPECT_SUCCESS(s2n_is_in_fips_mode(&fips_mode));
+
+    if (fips_mode) {
         /* Override default client config ciphers when in FIPS mode to ensure all FIPS
          * default ciphers are tested.
          */
@@ -275,7 +278,10 @@ int main(int argc, char **argv)
 
         /*  Test: RSA (TLS 1.2) key exchanges with TLS 1.3 client */
         {
-            if (!s2n_is_in_fips_mode()) {
+            bool fips_mode = false;
+            EXPECT_SUCCESS(s2n_is_in_fips_mode(&fips_mode));
+
+            if (!fips_mode) {
                 /* Enable TLS 1.3 for the client */
                 EXPECT_SUCCESS(s2n_enable_tls13_in_test());
                 struct s2n_config *server_config, *client_config;

--- a/tests/unit/s2n_hash_all_algs_test.c
+++ b/tests/unit/s2n_hash_all_algs_test.c
@@ -104,8 +104,11 @@ S2N_RESULT s2n_hash_test(s2n_hash_algorithm hash_alg, struct s2n_blob *digest)
         RESULT_ENSURE_EQ(hash_state.currently_in_hash, 0);
         RESULT_ENSURE_EQ(hash_state.is_ready_for_input, false);
 
+        bool fips_mode = false;
+        RESULT_GUARD_POSIX(s2n_is_in_fips_mode(&fips_mode));
+
         /* Allow MD5 when necessary */
-        if (s2n_is_in_fips_mode() && (hash_alg == S2N_HASH_MD5 || hash_alg == S2N_HASH_MD5_SHA1)) {
+        if (fips_mode && (hash_alg == S2N_HASH_MD5 || hash_alg == S2N_HASH_MD5_SHA1)) {
             RESULT_GUARD_POSIX(s2n_hash_allow_md5_for_fips(&hash_state));
         }
 

--- a/tests/unit/s2n_hkdf_test.c
+++ b/tests/unit/s2n_hkdf_test.c
@@ -416,6 +416,9 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
+    bool fips_mode = false;
+    EXPECT_SUCCESS(s2n_is_in_fips_mode(&fips_mode));
+
     EXPECT_SUCCESS(s2n_hmac_new(&hmac));
 
     for (uint8_t i = 0; i < NUM_TESTS; i++) {
@@ -453,7 +456,7 @@ int main(int argc, char **argv)
     }
 
     /* Ensure that the libcrypto HKDF implementation is supported when s2n-tls is linked with AWSLC-FIPS */
-    if (s2n_libcrypto_is_awslc() && s2n_is_in_fips_mode()) {
+    if (s2n_libcrypto_is_awslc() && fips_mode) {
         EXPECT_TRUE(s2n_libcrypto_supports_hkdf());
     }
 

--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -546,7 +546,10 @@ static S2N_RESULT s2n_random_implementation_test(void)
     uint64_t private_bytes_used = 0;
     EXPECT_OK(s2n_get_private_random_bytes_used(&private_bytes_used));
 
-    if (s2n_is_in_fips_mode()) {
+    bool fips_mode = false;
+    EXPECT_SUCCESS(s2n_is_in_fips_mode(&fips_mode));
+
+    if (fips_mode) {
         /* The libcrypto random implementation should be used when operating in FIPS mode, so
          * the bytes used in the custom DRBG state should not have changed.
          */
@@ -856,7 +859,10 @@ static int s2n_random_invalid_urandom_fd_cb(struct random_test_case *test_case)
         uint64_t public_bytes_used = 0;
         EXPECT_OK(s2n_get_public_random_bytes_used(&public_bytes_used));
 
-        if (s2n_is_in_fips_mode()) {
+        bool fips_mode = false;
+        EXPECT_SUCCESS(s2n_is_in_fips_mode(&fips_mode));
+
+        if (fips_mode) {
             /* The urandom implementation should not be in use when s2n-tls is in FIPS mode. */
             EXPECT_EQUAL(public_bytes_used, 0);
         } else {

--- a/tests/unit/s2n_rc4_test.c
+++ b/tests/unit/s2n_rc4_test.c
@@ -38,8 +38,11 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_rc4.is_available());
     }
 
+    bool fips_mode = false;
+    EXPECT_SUCCESS(s2n_is_in_fips_mode(&fips_mode));
+
     /* Test FIPS does not support RC4 */
-    if (s2n_is_in_fips_mode()) {
+    if (fips_mode) {
         EXPECT_FALSE(s2n_rc4.is_available());
     }
 
@@ -54,7 +57,7 @@ int main(int argc, char **argv)
 
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    if (s2n_is_in_fips_mode()) {
+    if (fips_mode) {
         /* Skip when FIPS mode is set as FIPS mode does not support RC4 */
         END_TEST();
     }

--- a/tests/unit/s2n_signature_algorithms_test.c
+++ b/tests/unit/s2n_signature_algorithms_test.c
@@ -97,7 +97,9 @@ int main(int argc, char **argv)
 
     /* s2n_signature_algorithms_supported_list_send */
     {
-        struct s2n_security_policy test_security_policy = *s2n_fetch_default_config()->security_policy;
+        struct s2n_config *default_config = s2n_fetch_default_config();
+        EXPECT_NOT_NULL(default_config);
+        struct s2n_security_policy test_security_policy = *default_config->security_policy;
         test_security_policy.signature_preferences = &test_preferences;
 
         /* Test: if all signatures supported, send all signatures */
@@ -889,7 +891,9 @@ int main(int argc, char **argv)
 
     /* s2n_signature_algorithm_recv */
     {
-        struct s2n_security_policy test_security_policy = *s2n_fetch_default_config()->security_policy;
+        struct s2n_config *default_config = s2n_fetch_default_config();
+        EXPECT_NOT_NULL(default_config);
+        struct s2n_security_policy test_security_policy = *default_config->security_policy;
         test_security_policy.signature_preferences = &test_preferences;
 
         /* Test: successfully choose valid server signature */
@@ -1124,7 +1128,9 @@ int main(int argc, char **argv)
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, rsa_cert_chain));
 
-        struct s2n_security_policy test_security_policy = *s2n_fetch_default_config()->security_policy;
+        struct s2n_config *default_config = s2n_fetch_default_config();
+        EXPECT_NOT_NULL(default_config);
+        struct s2n_security_policy test_security_policy = *default_config->security_policy;
         test_security_policy.signature_preferences = &pss_test_preferences,
         config->security_policy = &test_security_policy;
 

--- a/tests/unit/s2n_ssl_prf_test.c
+++ b/tests/unit/s2n_ssl_prf_test.c
@@ -52,7 +52,10 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    if (s2n_is_in_fips_mode()) {
+    bool fips_mode = false;
+    EXPECT_SUCCESS(s2n_is_in_fips_mode(&fips_mode));
+
+    if (fips_mode) {
         /* Skip when FIPS mode is set as FIPS mode does not support SSLv3 */
         END_TEST();
     }

--- a/tests/unit/s2n_tls_prf_test.c
+++ b/tests/unit/s2n_tls_prf_test.c
@@ -329,6 +329,9 @@ int main(int argc, char **argv)
         s2n_stack_blob(seed_c, TEST_BLOB_SIZE, TEST_BLOB_SIZE);
         s2n_stack_blob(out, TEST_BLOB_SIZE, TEST_BLOB_SIZE);
 
+        bool fips_mode = false;
+        EXPECT_SUCCESS(s2n_is_in_fips_mode(&fips_mode));
+
         /* Safety */
         {
             DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
@@ -358,7 +361,7 @@ int main(int argc, char **argv)
         }
 
         /* The custom PRF implementation is used when s2n-tls is not operating in FIPS mode */
-        if (!s2n_is_in_fips_mode()) {
+        if (!fips_mode) {
             DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
 
             uint8_t zeros[S2N_MAX_DIGEST_LEN] = { 0 };
@@ -371,7 +374,7 @@ int main(int argc, char **argv)
         }
 
         /* The libcrypto PRF implementation is used when s2n-tls is linked with AWSLC-FIPS */
-        if (s2n_libcrypto_is_awslc() && s2n_is_in_fips_mode()) {
+        if (s2n_libcrypto_is_awslc() && fips_mode) {
             DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
 
             uint8_t zeros[S2N_MAX_DIGEST_LEN] = { 0 };

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -104,10 +104,13 @@ static int s2n_config_init(struct s2n_config *config)
 
     config->client_hello_cb_mode = S2N_CLIENT_HELLO_CB_BLOCKING;
 
+    bool fips_mode = false;
+    POSIX_GUARD(s2n_is_in_fips_mode(&fips_mode));
+
     POSIX_GUARD(s2n_config_setup_default(config));
     if (s2n_use_default_tls13_config()) {
         POSIX_GUARD(s2n_config_setup_tls13(config));
-    } else if (s2n_is_in_fips_mode()) {
+    } else if (fips_mode) {
         POSIX_GUARD(s2n_config_setup_fips(config));
     }
 
@@ -210,10 +213,13 @@ int s2n_config_build_domain_name_to_cert_map(struct s2n_config *config, struct s
 
 struct s2n_config *s2n_fetch_default_config(void)
 {
+    bool fips_mode = false;
+    PTR_GUARD_POSIX(s2n_is_in_fips_mode(&fips_mode));
+
     if (s2n_use_default_tls13_config()) {
         return &s2n_default_tls13_config;
     }
-    if (s2n_is_in_fips_mode()) {
+    if (fips_mode) {
         return &s2n_default_fips_config;
     }
     return &s2n_default_config;
@@ -231,8 +237,11 @@ int s2n_config_set_unsafe_for_testing(struct s2n_config *config)
 
 int s2n_config_defaults_init(void)
 {
+    bool fips_mode = false;
+    POSIX_GUARD(s2n_is_in_fips_mode(&fips_mode));
+
     /* Set up fips defaults */
-    if (s2n_is_in_fips_mode()) {
+    if (fips_mode) {
         POSIX_GUARD(s2n_config_init(&s2n_default_fips_config));
         POSIX_GUARD(s2n_config_setup_fips(&s2n_default_fips_config));
         POSIX_GUARD(s2n_config_load_system_certs(&s2n_default_fips_config));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -74,7 +74,9 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
      */
     struct s2n_connection *conn = (struct s2n_connection *) (void *) blob.data;
 
-    PTR_GUARD_POSIX(s2n_connection_set_config(conn, s2n_fetch_default_config()));
+    struct s2n_config *default_config = s2n_fetch_default_config();
+    PTR_ENSURE_REF(default_config);
+    PTR_GUARD_POSIX(s2n_connection_set_config(conn, default_config));
 
     /* `mode` is initialized here since it's passed in as a parameter. */
     conn->mode = mode;

--- a/tls/s2n_fingerprint.c
+++ b/tls/s2n_fingerprint.c
@@ -276,13 +276,16 @@ int s2n_client_hello_get_fingerprint_hash(struct s2n_client_hello *ch, s2n_finge
     POSIX_GUARD(s2n_blob_init(&string_blob, string_mem, sizeof(string_mem)));
     POSIX_GUARD(s2n_stuffer_init(&string_stuffer, &string_blob));
 
+    bool fips_mode = false;
+    POSIX_GUARD(s2n_is_in_fips_mode(&fips_mode));
+
     /* JA3 uses an MD5 hash.
      * The hash doesn't have to be cryptographically secure,
      * so the weakness of MD5 shouldn't be a problem.
      */
     DEFER_CLEANUP(struct s2n_hash_state md5_hash = { 0 }, s2n_hash_free);
     POSIX_GUARD(s2n_hash_new(&md5_hash));
-    if (s2n_is_in_fips_mode()) {
+    if (fips_mode) {
         /* This hash is unrelated to TLS and does not affect FIPS */
         POSIX_GUARD(s2n_hash_allow_md5_for_fips(&md5_hash));
     }

--- a/tls/s2n_handshake_hashes.c
+++ b/tls/s2n_handshake_hashes.c
@@ -67,11 +67,14 @@ static S2N_RESULT s2n_handshake_hashes_free_hashes(struct s2n_handshake_hashes *
 
 static S2N_RESULT s2n_handshake_hashes_init_hashes(struct s2n_handshake_hashes *hashes)
 {
+    bool fips_mode = false;
+    RESULT_GUARD_POSIX(s2n_is_in_fips_mode(&fips_mode));
+
     /* Allow MD5 for hash states that are used by the PRF. This is required
      * to comply with the TLS 1.0 and 1.1 RFCs and is approved as per
      * NIST Special Publication 800-52 Revision 1.
      */
-    if (s2n_is_in_fips_mode()) {
+    if (fips_mode) {
         RESULT_GUARD_POSIX(s2n_hash_allow_md5_for_fips(&hashes->md5));
 
         /* Do not check s2n_hash_is_available before initialization. Allow MD5 and

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -52,8 +52,11 @@ int s2n_server_key_recv(struct s2n_connection *conn)
     const struct s2n_signature_scheme *active_sig_scheme = conn->handshake_params.server_cert_sig_scheme;
     POSIX_ENSURE_REF(active_sig_scheme);
 
+    bool fips_mode = false;
+    POSIX_GUARD(s2n_is_in_fips_mode(&fips_mode));
+
     /* FIPS specifically allows MD5 for <TLS1.2 */
-    if (s2n_is_in_fips_mode() && conn->actual_protocol_version < S2N_TLS12) {
+    if (fips_mode && conn->actual_protocol_version < S2N_TLS12) {
         POSIX_GUARD(s2n_hash_allow_md5_for_fips(signature_hash));
     }
 
@@ -267,8 +270,11 @@ int s2n_server_key_send(struct s2n_connection *conn)
         POSIX_GUARD(s2n_stuffer_write_uint16(out, sig_scheme->iana_value));
     }
 
+    bool fips_mode = false;
+    POSIX_GUARD(s2n_is_in_fips_mode(&fips_mode));
+
     /* FIPS specifically allows MD5 for <TLS1.2 */
-    if (s2n_is_in_fips_mode() && conn->actual_protocol_version < S2N_TLS12) {
+    if (fips_mode && conn->actual_protocol_version < S2N_TLS12) {
         POSIX_GUARD(s2n_hash_allow_md5_for_fips(signature_hash));
     }
 

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -280,7 +280,10 @@ static S2N_RESULT s2n_get_custom_random_data(struct s2n_blob *out_blob, struct s
     RESULT_GUARD_PTR(out_blob);
     RESULT_GUARD_PTR(drbg_state);
 
-    RESULT_ENSURE(!s2n_is_in_fips_mode(), S2N_ERR_DRBG);
+    bool fips_mode = false;
+    RESULT_GUARD_POSIX(s2n_is_in_fips_mode(&fips_mode));
+
+    RESULT_ENSURE(!fips_mode, S2N_ERR_DRBG);
     RESULT_GUARD(s2n_ensure_initialized_drbgs());
     RESULT_GUARD(s2n_ensure_uniqueness());
 
@@ -302,11 +305,14 @@ static S2N_RESULT s2n_get_custom_random_data(struct s2n_blob *out_blob, struct s
 
 static S2N_RESULT s2n_get_random_data(struct s2n_blob *blob, struct s2n_drbg *drbg_state)
 {
+    bool fips_mode = false;
+    RESULT_GUARD_POSIX(s2n_is_in_fips_mode(&fips_mode));
+
     /* By default, s2n-tls uses a custom random implementation to generate random data for the TLS
      * handshake. When operating in FIPS mode, the FIPS-validated libcrypto implementation is used
      * instead.
      */
-    if (s2n_is_in_fips_mode()) {
+    if (fips_mode) {
         RESULT_GUARD(s2n_get_libcrypto_random_data(blob));
         return S2N_RESULT_OK;
     }
@@ -549,7 +555,10 @@ S2N_RESULT s2n_rand_init(void)
     RESULT_GUARD(s2n_ensure_initialized_drbgs());
 
 #if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
-    if (s2n_is_in_fips_mode()) {
+    bool fips_mode = false;
+    RESULT_GUARD_POSIX(s2n_is_in_fips_mode(&fips_mode));
+
+    if (fips_mode) {
         return S2N_RESULT_OK;
     }
 


### PR DESCRIPTION
### Description of changes: 

`s2n_is_in_fips_mode()` is used internally to determine whether s2n-tls should operate in a FIPS-compliant manner. For example, the FIPS mode is checked to determine which cryptographic algorithm implementations should be selected. 

Currently, this function returns a bool, meaning it's not possible to indicate that an error occurred while getting the FIPS mode. This PR adds a new bool field that's set with the FIPS mode, allowing the function to return an error.

While this PR doesn't add it, one use for returning an error might be to indicate that `s2n_init()` hasn't been called yet, since the FIPS mode is unknown before initialization.

### Testing:

No new tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
