### PR TITLE
fix: pedantic memory leak in handshake test

### DIFF
--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -448,7 +448,7 @@ int main(int argc, char **argv)
                 close((int) fd);
             }
 
-            /* use an nested scope to force the DEFER_CLEANUP statements to 
+            /* use a nested scope to force the DEFER_CLEANUP statements to 
              * execute before the exit() call. 
              */
             {

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -462,8 +462,8 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(test_cipher_preferences(config, config, chain_and_key, S2N_SIGNATURE_RSA));
 
-            s2n_cert_chain_and_key_free(chain_and_key);
-            s2n_config_free(config);
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+            EXPECT_SUCCESS(s2n_config_free(config));
             exit(EXIT_SUCCESS);
         }
 

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -448,22 +448,25 @@ int main(int argc, char **argv)
                 close((int) fd);
             }
 
-            struct s2n_cert_chain_and_key *chain_and_key = NULL;
-            EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
-                    S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
-            EXPECT_NOT_NULL(chain_and_key);
+            /* use an nested scope to force the DEFER_CLEANUP statements to 
+             * execute before the exit() call. 
+             */
+            {
+                DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = NULL, s2n_cert_chain_and_key_ptr_free);
+                EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+                        S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+                EXPECT_NOT_NULL(chain_and_key);
 
-            struct s2n_config *config = s2n_config_new();
-            EXPECT_NOT_NULL(config);
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
-            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-            EXPECT_SUCCESS(s2n_config_set_verification_ca_location(config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
-            EXPECT_SUCCESS(s2n_config_disable_x509_verification(config));
+                DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+                EXPECT_NOT_NULL(config);
+                EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+                EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+                EXPECT_SUCCESS(s2n_config_set_verification_ca_location(config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
+                EXPECT_SUCCESS(s2n_config_disable_x509_verification(config));
 
-            EXPECT_SUCCESS(test_cipher_preferences(config, config, chain_and_key, S2N_SIGNATURE_RSA));
+                EXPECT_SUCCESS(test_cipher_preferences(config, config, chain_and_key, S2N_SIGNATURE_RSA));
+            }
 
-            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
-            EXPECT_SUCCESS(s2n_config_free(config));
             exit(EXIT_SUCCESS);
         }
 

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -448,12 +448,12 @@ int main(int argc, char **argv)
                 close((int) fd);
             }
 
-            DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = NULL, s2n_cert_chain_and_key_ptr_free);
+            struct s2n_cert_chain_and_key *chain_and_key = NULL;
             EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
                     S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
             EXPECT_NOT_NULL(chain_and_key);
 
-            DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+            struct s2n_config *config = s2n_config_new();
             EXPECT_NOT_NULL(config);
             EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
@@ -462,6 +462,8 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(test_cipher_preferences(config, config, chain_and_key, S2N_SIGNATURE_RSA));
 
+            s2n_cert_chain_and_key_free(chain_and_key);
+            s2n_config_free(config);
             exit(EXIT_SUCCESS);
         }
 


### PR DESCRIPTION
We run valgrind with "pedantic" settings, which requires that memory in child processes is explicitly freed before the process exits. This is commonly an issue when defer cleanup is used, because defer cleanup statements are not invoked when the "exit" system call is used.


### Description of changes: 


#4369 merges in CI changes to catch these errors, but `s2n_handshake_test` was modified in between when I opened the PR and when I tried to merge the PR. After rebasing on main, this is now causing failures for my PR.

This PR fixes the new failures in `s2n_handshake_test` separately from #4369 to make review easier.

### Testing:

failing run for current mainline build with my valgrind changes:[here](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoidUpNb2QzNjZzQ3lrWm1UQ2xzdFZMN1ZGYWE5dVlSQ1ZKd1BnZzZ6aXN1dlZXTmFuZWdvNnR0SitPaFlIcUdjaDZ6RU9KemY2Mi9ybXVBajF0RXo4NmZ1Rnl4dkZrT241UUY4MTVQMkRuNTQ9IiwiaXZQYXJhbWV0ZXJTcGVjIjoiemFRUDgvZUMreVhER0RKaiIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D/build/ca5fefe2-cfee-4af3-a9a0-921d37a47b0e)

(Initial draft): passing run of this change with my valgrind changes rebased on top of it: [here](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoidUpNb2QzNjZzQ3lrWm1UQ2xzdFZMN1ZGYWE5dVlSQ1ZKd1BnZzZ6aXN1dlZXTmFuZWdvNnR0SitPaFlIcUdjaDZ6RU9KemY2Mi9ybXVBajF0RXo4NmZ1Rnl4dkZrT241UUY4MTVQMkRuNTQ9IiwiaXZQYXJhbWV0ZXJTcGVjIjoiemFRUDgvZUMreVhER0RKaiIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D/batch/7b864520-3e87-4182-a54a-a5ac2b49eb18)

(nested scope): [here](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoidUpNb2QzNjZzQ3lrWm1UQ2xzdFZMN1ZGYWE5dVlSQ1ZKd1BnZzZ6aXN1dlZXTmFuZWdvNnR0SitPaFlIcUdjaDZ6RU9KemY2Mi9ybXVBajF0RXo4NmZ1Rnl4dkZrT241UUY4MTVQMkRuNTQ9IiwiaXZQYXJhbWV0ZXJTcGVjIjoiemFRUDgvZUMreVhER0RKaiIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D/batch/7ee55ad0-43ed-49fe-8cf9-4ae6a168dd7b)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
