### PR TITLE
bindings: ensure CFLAGS includes come after build script includes

### DIFF
--- a/bindings/rust/s2n-tls-sys/build.rs
+++ b/bindings/rust/s2n-tls-sys/build.rs
@@ -154,20 +154,19 @@ fn build_vendored() {
 fn builder(libcrypto: &Libcrypto) -> cc::Build {
     let mut build = cc::Build::new();
 
+    let includes = [&libcrypto.include, "lib", "lib/api"];
     if let Ok(cflags) = std::env::var("CFLAGS") {
         // cc will read the CFLAGS env variable and prepend the compiler
         // command with all flags and includes from it, which may conflict
         // with the libcrypto includes we specify. To ensure the libcrypto
         // includes show up first in the compiler command, we prepend our
         // includes to CFLAGS.
-        std::env::set_var("CFLAGS", format!("-I {} {}", libcrypto.include, cflags));
+        std::env::set_var("CFLAGS", format!("-I {} {}", includes.join(" -I "), cflags));
     } else {
-        build.include(&libcrypto.include);
+        build.includes(includes);
     };
 
     build
-        .include("lib")
-        .include("lib/api")
         .flag("-std=c11")
         .flag("-fgnu89-inline")
         // make sure the stack is non-executable

--- a/bindings/rust/s2n-tls-sys/build.rs
+++ b/bindings/rust/s2n-tls-sys/build.rs
@@ -158,9 +158,8 @@ fn builder(libcrypto: &Libcrypto) -> cc::Build {
     if let Ok(cflags) = std::env::var("CFLAGS") {
         // cc will read the CFLAGS env variable and prepend the compiler
         // command with all flags and includes from it, which may conflict
-        // with the libcrypto includes we specify. To ensure the libcrypto
-        // includes show up first in the compiler command, we prepend our
-        // includes to CFLAGS.
+        // with the includes we specify. To ensure that our includes show
+        // up first in the compiler command, we prepend them to CFLAGS.
         std::env::set_var("CFLAGS", format!("-I {} {}", includes.join(" -I "), cflags));
     } else {
         build.includes(includes);


### PR DESCRIPTION
### Description of changes: 
In https://github.com/aws/s2n-tls/pull/4338, Wesley fixed an issue where includes set in CFLAGS conflicted with includes we set for our libcrypto. I've run into the same problem, but with our library headers.

It seems like the simplest solution is just to prepend all of our includes onto the CFLAGS, so that they always take priority. We don't always control our build environment and there shouldn't be a reason for any headers to take priority over "lib" and "lib/api" during our build.

### Testing:
I set my CFLAGS to include a copy of s2n.h in a directory I named "bad_src": 
```
$ export CFLAGS="-I bad_src"
$ echo $CFLAGS
-I bad_src
```

When I ran the build without this fix, it failed with many errors like:
```
  cargo:warning=bad_src/s2n.h:1911:5: error: redeclaration of enumerator ‘S2N_KEY_UPDATE_NOT_REQUESTED’
  cargo:warning= 1911 |     S2N_KEY_UPDATE_NOT_REQUESTED = 0,
  cargo:warning=      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
  cargo:warning=lib/api/s2n.h:1911:5: note: previous definition of ‘S2N_KEY_UPDATE_NOT_REQUESTED’ with type ‘enum <anonymous>’
  cargo:warning= 1911 |     S2N_KEY_UPDATE_NOT_REQUESTED = 0,
```
When I ran the build with this fix, it succeeded.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
