### PR TITLE
fix(bindings): print cargo commands to stdout

### DIFF
--- a/bindings/rust/s2n-tls-sys/build.rs
+++ b/bindings/rust/s2n-tls-sys/build.rs
@@ -19,7 +19,7 @@ fn env<N: AsRef<str>>(name: N) -> String {
 
 fn option_env<N: AsRef<str>>(name: N) -> Option<String> {
     let name = name.as_ref();
-    eprintln!("cargo:rerun-if-env-changed={}", name);
+    println!("cargo:rerun-if-env-changed={}", name);
     std::env::var(name).ok()
 }
 
@@ -194,7 +194,7 @@ impl Default for Libcrypto {
                 if let Some(version) = version.strip_suffix("_INCLUDE") {
                     let version = version.to_string();
 
-                    eprintln!("cargo:rerun-if-env-changed={}", name);
+                    println!("cargo:rerun-if-env-changed={}", name);
 
                     let include = value;
                     let root = env(format!("DEP_AWS_LC_{version}_ROOT"));


### PR DESCRIPTION
### Description of changes: 

As highlighted in https://github.com/aws/aws-lc-rs/pull/378, cargo commands need to be stdout, not stderr.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
