### PR TITLE
New TLS1.2-only variant of 20230317 policy

### DIFF
--- a/docs/usage-guide/topics/ch06-security-policies.md
+++ b/docs/usage-guide/topics/ch06-security-policies.md
@@ -43,7 +43,7 @@ The following chart maps the security policy version to protocol version and cip
 The "default", "default_tls13", and "default_fips" versions are special in that they will be updated with future s2n-tls changes and ciphersuites and protocol versions may be added and removed, or their internal order of preference might change. Numbered versions are fixed and will never change.
 In general, customers prefer to use numbered versions for production use cases to prevent impact from library updates.
 
-"20230317" offers more limited but more secure options than the default policies. Consider it if you don't need or want to support less secure legacy options like TLS1.1 or SHA1. It is also FIPS compliant and supports TLS1.3. If you need a policy that doesn't support TLS1.3, choose "20240331" instead.
+"20230317" offers more limited but more secure options than the default policies. Consider it if you don't need or want to support less secure legacy options like TLS1.1 or SHA1. It is also FIPS compliant and supports TLS1.3. If you need a version of this policy that doesn't support TLS1.3, choose "20240331" instead.
 
 "20160411" follows the same general preference order as "default". The main difference is it has a CBC cipher suite at the top. This is to accommodate certain Java clients that have poor GCM implementations. Users of s2n-tls who have found GCM to be hurting performance for their clients should consider this version.
 

--- a/docs/usage-guide/topics/ch06-security-policies.md
+++ b/docs/usage-guide/topics/ch06-security-policies.md
@@ -16,6 +16,7 @@ The following chart maps the security policy version to protocol version and cip
 |    version    | TLS1.0 | TLS1.1 | TLS1.2 | TLS1.3 | AES-CBC | AES-GCM | CHACHAPOLY | 3DES | RC4 | DHE | ECDHE | RSA kx |
 |---------------|--------|--------|--------|--------|---------|---------|------------|------|-----|-----|-------|--------|
 |   20230317    |        |        |    X   |    X   |    X    |    X    |            |      |     |     |   X   |        |
+| 20230317_12   |        |        |    X   |        |    X    |    X    |            |      |     |     |   X   |        |
 |    default    |    X   |    X   |    X   |        |    X    |    X    |      X     |      |     |     |   X   |    X   |
 | default_tls13 |    X   |    X   |    X   |    X   |    X    |    X    |      X     |      |     |     |   X   |    X   |
 | default_fips  |        |        |    X   |        |    X    |    X    |            |      |     |  X  |   X   |        |
@@ -42,7 +43,10 @@ The following chart maps the security policy version to protocol version and cip
 The "default", "default_tls13", and "default_fips" versions are special in that they will be updated with future s2n-tls changes and ciphersuites and protocol versions may be added and removed, or their internal order of preference might change. Numbered versions are fixed and will never change.
 In general, customers prefer to use numbered versions for production use cases to prevent impact from library updates.
 
-"20230317" is a FIPS compliant policy. It offers more limited but more secure options than "default". It only supports TLS1.2 and TLS1.3. Consider this policy if you plan to enable FIPS mode or don't need or want to support less secure legacy options like TLS1.1 or SHA1.
+"20230317" offers more limited but more secure options than the default policies.
+Consider it if you don't need or want to support less secure legacy options like
+TLS1.1 or SHA1. It is also FIPS compliant and supports TLS1.3. If you need a policy
+that doesn't support TLS1.3, choose "20230317_12" instead.
 
 "20160411" follows the same general preference order as "default". The main difference is it has a CBC cipher suite at the top. This is to accommodate certain Java clients that have poor GCM implementations. Users of s2n-tls who have found GCM to be hurting performance for their clients should consider this version.
 

--- a/docs/usage-guide/topics/ch06-security-policies.md
+++ b/docs/usage-guide/topics/ch06-security-policies.md
@@ -16,7 +16,7 @@ The following chart maps the security policy version to protocol version and cip
 |    version    | TLS1.0 | TLS1.1 | TLS1.2 | TLS1.3 | AES-CBC | AES-GCM | CHACHAPOLY | 3DES | RC4 | DHE | ECDHE | RSA kx |
 |---------------|--------|--------|--------|--------|---------|---------|------------|------|-----|-----|-------|--------|
 |   20230317    |        |        |    X   |    X   |    X    |    X    |            |      |     |     |   X   |        |
-| 20230317_12   |        |        |    X   |        |    X    |    X    |            |      |     |     |   X   |        |
+|   20240331    |        |        |    X   |        |    X    |    X    |            |      |     |     |   X   |        |
 |    default    |    X   |    X   |    X   |        |    X    |    X    |      X     |      |     |     |   X   |    X   |
 | default_tls13 |    X   |    X   |    X   |    X   |    X    |    X    |      X     |      |     |     |   X   |    X   |
 | default_fips  |        |        |    X   |        |    X    |    X    |            |      |     |  X  |   X   |        |
@@ -43,10 +43,7 @@ The following chart maps the security policy version to protocol version and cip
 The "default", "default_tls13", and "default_fips" versions are special in that they will be updated with future s2n-tls changes and ciphersuites and protocol versions may be added and removed, or their internal order of preference might change. Numbered versions are fixed and will never change.
 In general, customers prefer to use numbered versions for production use cases to prevent impact from library updates.
 
-"20230317" offers more limited but more secure options than the default policies.
-Consider it if you don't need or want to support less secure legacy options like
-TLS1.1 or SHA1. It is also FIPS compliant and supports TLS1.3. If you need a policy
-that doesn't support TLS1.3, choose "20230317_12" instead.
+"20230317" offers more limited but more secure options than the default policies. Consider it if you don't need or want to support less secure legacy options like TLS1.1 or SHA1. It is also FIPS compliant and supports TLS1.3. If you need a policy that doesn't support TLS1.3, choose "20240331" instead.
 
 "20160411" follows the same general preference order as "default". The main difference is it has a CBC cipher suite at the top. This is to accommodate certain Java clients that have poor GCM implementations. Users of s2n-tls who have found GCM to be hurting performance for their clients should consider this version.
 

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -460,7 +460,7 @@ int main(int argc, char **argv)
             "20190121",
             "20190122",
             "20201021",
-            "20230317_12",
+            "20240331",
             "test_all_ecdsa",
             "test_ecdsa_priority",
             "test_all_tls12",
@@ -986,35 +986,35 @@ int main(int argc, char **argv)
             }
         };
 
-        /* 20230317_12 */
+        /* 20240331 */
         {
-            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20240331,
                     "default", rsa_chain_and_key));
-            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20240331,
                     "default_tls13", rsa_chain_and_key));
-            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20240331,
                     "default_fips", rsa_chain_and_key));
-            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20240331,
                     "20230317", rsa_chain_and_key));
-            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
-                    "20230317_12", rsa_chain_and_key));
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20240331,
+                    "20240331", rsa_chain_and_key));
 
-            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20240331,
                     "default_tls13", ecdsa_chain_and_key));
-            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20240331,
                     "default_fips", ecdsa_chain_and_key));
-            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20240331,
                     "20230317", ecdsa_chain_and_key));
-            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
-                    "20230317_12", ecdsa_chain_and_key));
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20240331,
+                    "20240331", ecdsa_chain_and_key));
 
             /* Can't negotiate TLS1.3 */
             EXPECT_ERROR_WITH_ERRNO(
-                    s2n_test_security_policies_compatible(&security_policy_20230317_12,
+                    s2n_test_security_policies_compatible(&security_policy_20240331,
                             "test_all_tls13", rsa_chain_and_key),
                     S2N_ERR_CIPHER_NOT_SUPPORTED);
             EXPECT_ERROR_WITH_ERRNO(
-                    s2n_test_security_policies_compatible(&security_policy_20230317_12,
+                    s2n_test_security_policies_compatible(&security_policy_20240331,
                             "test_all_tls13", ecdsa_chain_and_key),
                     S2N_ERR_CIPHER_NOT_SUPPORTED);
         };

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -460,6 +460,7 @@ int main(int argc, char **argv)
             "20190121",
             "20190122",
             "20201021",
+            "20230317_12",
             "test_all_ecdsa",
             "test_ecdsa_priority",
             "test_all_tls12",
@@ -478,6 +479,7 @@ int main(int argc, char **argv)
             "20190801",
             "20190802",
             "KMS-TLS-1-2-2023-06",
+            "20230317",
             /* CloudFront viewer facing */
             "CloudFront-SSL-v-3",
             "CloudFront-TLS-1-0-2014",
@@ -973,6 +975,48 @@ int main(int argc, char **argv)
                 EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317, "default_tls13", rsa_pss_chain_and_key));
                 EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317, "20230317", rsa_pss_chain_and_key));
             }
+
+            if (s2n_is_tls13_fully_supported()) {
+                EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317,
+                        "test_all_tls13", rsa_chain_and_key));
+                EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317,
+                        "test_all_tls13", rsa_pss_chain_and_key));
+                EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317,
+                        "test_all_tls13", ecdsa_chain_and_key));
+            }
+        };
+
+        /* 20230317_12 */
+        {
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
+                    "default", rsa_chain_and_key));
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
+                    "default_tls13", rsa_chain_and_key));
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
+                    "default_fips", rsa_chain_and_key));
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
+                    "20230317", rsa_chain_and_key));
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
+                    "20230317_12", rsa_chain_and_key));
+
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
+                    "default_tls13", ecdsa_chain_and_key));
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
+                    "default_fips", ecdsa_chain_and_key));
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
+                    "20230317", ecdsa_chain_and_key));
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20230317_12,
+                    "20230317_12", ecdsa_chain_and_key));
+
+            /* Can't negotiate TLS1.3 */
+            EXPECT_ERROR_WITH_ERRNO(
+                    s2n_test_security_policies_compatible(&security_policy_20230317_12,
+                            "test_all_tls13", rsa_chain_and_key),
+                    S2N_ERR_CIPHER_NOT_SUPPORTED);
+            EXPECT_ERROR_WITH_ERRNO(
+                    s2n_test_security_policies_compatible(&security_policy_20230317_12,
+                            "test_all_tls13", ecdsa_chain_and_key),
+                    S2N_ERR_CIPHER_NOT_SUPPORTED);
         };
     };
 

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -302,6 +302,31 @@ const struct s2n_cipher_preferences cipher_preferences_20230317 = {
     .allow_chacha20_boosting = false,
 };
 
+/*
+ * No TLS1.3 support.
+ * FIPS compliant.
+ * No DHE (would require extra setup with s2n_config_add_dhparams)
+ */
+struct s2n_cipher_suite *cipher_suites_20230317_12[] = {
+    /* TLS1.2 with ECDSA */
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+
+    /* TLS1.2 with RSA */
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_20230317_12 = {
+    .count = s2n_array_len(cipher_suites_20230317_12),
+    .suites = cipher_suites_20230317_12,
+    .allow_chacha20_boosting = false,
+};
+
 /* Same as 20160411, but with ChaCha20 added as 1st in Preference List */
 struct s2n_cipher_suite *cipher_suites_20190122[] = {
     &s2n_ecdhe_rsa_with_chacha20_poly1305_sha256,

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -307,7 +307,7 @@ const struct s2n_cipher_preferences cipher_preferences_20230317 = {
  * FIPS compliant.
  * No DHE (would require extra setup with s2n_config_add_dhparams)
  */
-struct s2n_cipher_suite *cipher_suites_20230317_12[] = {
+struct s2n_cipher_suite *cipher_suites_20240331[] = {
     /* TLS1.2 with ECDSA */
     &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
     &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
@@ -321,9 +321,9 @@ struct s2n_cipher_suite *cipher_suites_20230317_12[] = {
     &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
 };
 
-const struct s2n_cipher_preferences cipher_preferences_20230317_12 = {
-    .count = s2n_array_len(cipher_suites_20230317_12),
-    .suites = cipher_suites_20230317_12,
+const struct s2n_cipher_preferences cipher_preferences_20240331 = {
+    .count = s2n_array_len(cipher_suites_20240331),
+    .suites = cipher_suites_20240331,
     .allow_chacha20_boosting = false,
 };
 

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -28,7 +28,7 @@ struct s2n_cipher_preferences {
 };
 
 extern const struct s2n_cipher_preferences cipher_preferences_20230317;
-extern const struct s2n_cipher_preferences cipher_preferences_20230317_12;
+extern const struct s2n_cipher_preferences cipher_preferences_20240331;
 extern const struct s2n_cipher_preferences cipher_preferences_20140601;
 extern const struct s2n_cipher_preferences cipher_preferences_20141001;
 extern const struct s2n_cipher_preferences cipher_preferences_20150202;

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -28,6 +28,7 @@ struct s2n_cipher_preferences {
 };
 
 extern const struct s2n_cipher_preferences cipher_preferences_20230317;
+extern const struct s2n_cipher_preferences cipher_preferences_20230317_12;
 extern const struct s2n_cipher_preferences cipher_preferences_20140601;
 extern const struct s2n_cipher_preferences cipher_preferences_20141001;
 extern const struct s2n_cipher_preferences cipher_preferences_20150202;

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -69,9 +69,9 @@ const struct s2n_security_policy security_policy_20230317 = {
     },
 };
 
-const struct s2n_security_policy security_policy_20230317_12 = {
+const struct s2n_security_policy security_policy_20240331 = {
     .minimum_protocol_version = S2N_TLS12,
-    .cipher_preferences = &cipher_preferences_20230317_12,
+    .cipher_preferences = &cipher_preferences_20240331,
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20230317,
     .certificate_signature_preferences = &s2n_signature_preferences_20230317,
@@ -1075,7 +1075,7 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "default_tls13", .security_policy = &security_policy_default_tls13, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "default_fips", .security_policy = &security_policy_default_fips, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20230317", .security_policy = &security_policy_20230317, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
-    { .version = "20230317_12", .security_policy = &security_policy_20230317_12, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "20240331", .security_policy = &security_policy_20240331, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "ELBSecurityPolicy-TLS-1-0-2015-04", .security_policy = &security_policy_elb_2015_04, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     /* Not a mistake. TLS-1-0-2015-05 and 2016-08 are equivalent */
     { .version = "ELBSecurityPolicy-TLS-1-0-2015-05", .security_policy = &security_policy_elb_2016_08, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -69,6 +69,19 @@ const struct s2n_security_policy security_policy_20230317 = {
     },
 };
 
+const struct s2n_security_policy security_policy_20230317_12 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_20230317_12,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20230317,
+    .certificate_signature_preferences = &s2n_signature_preferences_20230317,
+    .ecc_preferences = &s2n_ecc_preferences_20201021,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+            [S2N_FIPS_140_3] = true,
+    },
+};
+
 const struct s2n_security_policy security_policy_20190801 = {
     .minimum_protocol_version = S2N_TLS10,
     .cipher_preferences = &cipher_preferences_20190801,
@@ -1062,6 +1075,7 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "default_tls13", .security_policy = &security_policy_default_tls13, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "default_fips", .security_policy = &security_policy_default_fips, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20230317", .security_policy = &security_policy_20230317, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "20230317_12", .security_policy = &security_policy_20230317_12, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "ELBSecurityPolicy-TLS-1-0-2015-04", .security_policy = &security_policy_elb_2015_04, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     /* Not a mistake. TLS-1-0-2015-05 and 2016-08 are equivalent */
     { .version = "ELBSecurityPolicy-TLS-1-0-2015-05", .security_policy = &security_policy_elb_2016_08, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -113,6 +113,7 @@ extern const struct s2n_security_policy security_policy_20190214_gcm;
 extern const struct s2n_security_policy security_policy_20190801;
 extern const struct s2n_security_policy security_policy_20190802;
 extern const struct s2n_security_policy security_policy_20230317;
+extern const struct s2n_security_policy security_policy_20230317_12;
 extern const struct s2n_security_policy security_policy_default_tls13;
 extern const struct s2n_security_policy security_policy_default_fips;
 extern const struct s2n_security_policy security_policy_rfc9151;

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -113,7 +113,7 @@ extern const struct s2n_security_policy security_policy_20190214_gcm;
 extern const struct s2n_security_policy security_policy_20190801;
 extern const struct s2n_security_policy security_policy_20190802;
 extern const struct s2n_security_policy security_policy_20230317;
-extern const struct s2n_security_policy security_policy_20230317_12;
+extern const struct s2n_security_policy security_policy_20240331;
 extern const struct s2n_security_policy security_policy_default_tls13;
 extern const struct s2n_security_policy security_policy_default_fips;
 extern const struct s2n_security_policy security_policy_rfc9151;


### PR DESCRIPTION
### Description of changes: 

For backwards compatibility reasons, customers may want a modern, secure policy that won't negotiate TLS1.3. Adding a variant of our suggested policy that won't negotiate TLS1.3.

### Testing:
Added some compatibility tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
