### PR TITLE
fix: correct broken early data test

### DIFF
--- a/tests/testlib/s2n_test_server_client.c
+++ b/tests/testlib/s2n_test_server_client.c
@@ -60,7 +60,6 @@ int s2n_negotiate_test_server_and_client(struct s2n_connection *server_conn, str
 S2N_RESULT s2n_negotiate_test_server_and_client_with_early_data(struct s2n_connection *server_conn,
         struct s2n_connection *client_conn, struct s2n_blob *early_data_to_send, struct s2n_blob *early_data_received)
 {
-    bool server_done = false, client_done = false;
     s2n_blocked_status blocked = S2N_NOT_BLOCKED;
     ssize_t total_data_sent = 0, total_data_recv = 0;
     ssize_t data_sent = 0, data_recv = 0;
@@ -74,28 +73,37 @@ S2N_RESULT s2n_negotiate_test_server_and_client_with_early_data(struct s2n_conne
      * server done when it has either read all early data (which may be zero bytes) or has
      * rejected the early data.
      */
+    bool server_done = false, client_done = false;
+    bool server_early_done = false, client_early_done = false;
     do {
-        bool client_success = (s2n_send_early_data(client_conn, early_data_to_send->data + total_data_sent,
-                                       early_data_to_send->size - total_data_sent, &data_sent, &blocked)
-                >= S2N_SUCCESS);
-        total_data_sent += data_sent;
-        RESULT_GUARD(s2n_validate_negotiate_result(client_success, false, &client_done));
+        if (!client_early_done) {
+            bool success = s2n_send_early_data(client_conn,
+                                   early_data_to_send->data + total_data_sent,
+                                   early_data_to_send->size - total_data_sent,
+                                   &data_sent, &blocked)
+                    == S2N_SUCCESS;
+            total_data_sent += data_sent;
+            RESULT_GUARD(s2n_validate_negotiate_result(success, false, &client_early_done));
+        } else {
+            bool success = (s2n_negotiate(client_conn, &blocked) == S2N_SUCCESS);
+            RESULT_GUARD(s2n_validate_negotiate_result(success, server_done, &client_done));
+        }
 
-        bool server_success = (s2n_recv_early_data(server_conn, early_data_received->data + total_data_recv,
-                                       early_data_received->size - total_data_recv, &data_recv, &blocked)
-                >= S2N_SUCCESS);
-        total_data_recv += data_recv;
-        RESULT_GUARD(s2n_validate_negotiate_result(server_success, false, &server_done));
-
-        /* If we expect early data, then we need to keep using the early data APIs
-         * until we have read all the early data.
-         */
-        server_done = (total_data_recv == total_data_sent) || (IS_NEGOTIATED(server_conn) && !WITH_EARLY_DATA(server_conn));
+        if (!server_early_done) {
+            bool success = s2n_recv_early_data(server_conn,
+                                   early_data_received->data + total_data_recv,
+                                   early_data_received->size - total_data_recv,
+                                   &data_recv, &blocked)
+                    == S2N_SUCCESS;
+            total_data_recv += data_recv;
+            RESULT_GUARD(s2n_validate_negotiate_result(success, false, &server_early_done));
+        } else {
+            bool success = (s2n_negotiate(server_conn, &blocked) == S2N_SUCCESS);
+            RESULT_GUARD(s2n_validate_negotiate_result(success, client_done, &server_done));
+        }
     } while (!client_done || !server_done);
 
-    /* Finish the handshake */
-    RESULT_GUARD_POSIX(s2n_negotiate_test_server_and_client(server_conn, client_conn));
-
+    early_data_received->size = total_data_recv;
     return S2N_RESULT_OK;
 }
 

--- a/tests/unit/s2n_client_auth_handshake_test.c
+++ b/tests/unit/s2n_client_auth_handshake_test.c
@@ -467,10 +467,10 @@ int main(int argc, char **argv)
         size_t test_case_count = 0;
 
         for (size_t client_i = 0; client_i < s2n_array_len(all_options); client_i++) {
-            EXPECT_TRUE(test_case_count < s2n_array_len(test_cases));
             for (size_t server_i = 0; server_i < s2n_array_len(all_options); server_i++) {
                 for (size_t cert_i = 0; cert_i <= 1; cert_i++) {
                     for (size_t version = S2N_TLS12; version <= S2N_TLS13; version++) {
+                        EXPECT_TRUE(test_case_count < s2n_array_len(test_cases));
                         test_cases[test_case_count].client_auth_type = all_options[client_i];
                         test_cases[test_case_count].server_auth_type = all_options[server_i];
                         test_cases[test_case_count].client_cert_exists = (cert_i == 1);


### PR DESCRIPTION
### Description of changes: 

While writing the for loops to construct the test cases in https://github.com/aws/s2n-tls/commit/0e57e94efee8e8f28f09a4f44ab7fce7f0a98dfc, I initially made the silly mistake of not setting every field of the test case in the innermost loop. That leads to some test cases being overwritten / skipped. It was a silly mistake, but one I was worried that I'd made in other tests. When I searched for similar loops, I found one in s2n_self_talk_session_resumption_test.c where I made the same mistake :(

When I fixed the test case construction, the tests started hanging indefinitely. The problem was with handling the cases where either the client didn't send any early data, or the server didn't read any early data because it didn't support it. Apparently those cases weren't tested with s2n_negotiate_test_server_and_client_with_early_data anywhere else, and the test "event loop" couldn't handle it.

The problem could be summarized as the client and server not agreeing on whether they should be sending/receiving early data or not, so I changed the logic to allow them to switch between the two states independently rather than only in sync.

I also did some other minor cleanup: I renamed a test variable and made it easier to assert that no early data was received in a test.

### Call-outs:
I'd love to write a grep_simple_mistakes for this, but I'm not sure how. I had a hard enough time doing the search manually where I could filter out all the false positives and try different variations :/ I'm also not sure whether this is actually a common mistake or just a common me mistake.

### Testing:
Is a testing change. I added an assert to verify that the known number of test cases is covered.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
