### PR TITLE
docs: add more warnings about security policy defaults

### DIFF
--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -40,7 +40,7 @@ impl Config {
     /// # Warning
     ///
     /// The newly created Config will use the default security policy.
-    /// Consider changing this depending on your security and availability requirements
+    /// Consider changing this depending on your security and compatibility requirements
     /// by using [`Builder`] and [`Builder::set_security_policy`].
     /// See the s2n-tls usage guide:
     /// <https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html>
@@ -169,7 +169,7 @@ impl Builder {
     /// # Warning
     ///
     /// The newly created Builder will create Configs that use the default security policy.
-    /// Consider changing this depending on your security and availability requirements
+    /// Consider changing this depending on your security and compatibility requirements
     /// by calling [`Builder::set_security_policy`].
     /// See the s2n-tls usage guide:
     /// <https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html>
@@ -772,7 +772,7 @@ impl Builder {
 /// # Warning
 ///
 /// The newly created Builder uses the default security policy.
-/// Consider changing this depending on your security and availability requirements
+/// Consider changing this depending on your security and compatibility requirements
 /// by using [`Builder::new`] instead and calling [`Builder::set_security_policy`].
 /// See the s2n-tls usage guide:
 /// <https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html>

--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -39,7 +39,7 @@ impl Config {
     ///
     /// # Warning
     ///
-    /// By default, the newly created Config uses the default security policy.
+    /// The newly created Config will use the default security policy.
     /// Consider changing this depending on your security and availability requirements
     /// by using [`Builder`] and [`Builder::set_security_policy`].
     /// See the s2n-tls usage guide:
@@ -168,7 +168,7 @@ pub struct Builder {
 impl Builder {
     /// # Warning
     ///
-    /// By default, the newly created Builder uses the default security policy.
+    /// The newly created Builder will create Configs that use the default security policy.
     /// Consider changing this depending on your security and availability requirements
     /// by calling [`Builder::set_security_policy`].
     /// See the s2n-tls usage guide:

--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -36,6 +36,14 @@ impl Config {
     /// Returns a Config object with pre-defined defaults.
     ///
     /// Use the [`Builder`] if custom configuration is desired.
+    ///
+    /// # Safety:
+    ///
+    /// By default, the newly created Config uses the default security policy.
+    /// Consider changing this depending on your security and availability requirements
+    /// by using [`Builder`] and [`Builder::set_security_policy`].
+    /// See the s2n-tls usage guide:
+    /// <https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html>
     pub fn new() -> Self {
         Self::default()
     }
@@ -158,6 +166,13 @@ pub struct Builder {
 }
 
 impl Builder {
+    /// # Safety
+    ///
+    /// By default, the newly created Builder uses the default security policy.
+    /// Consider changing this depending on your security and availability requirements
+    /// by calling [`Builder::set_security_policy`].
+    /// See the s2n-tls usage guide:
+    /// <https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html>
     pub fn new() -> Self {
         crate::init::init();
         let config = unsafe { s2n_config_new_minimal().into_result() }.unwrap();
@@ -754,6 +769,13 @@ impl Builder {
     }
 }
 
+/// # Safety
+///
+/// The newly created Builder uses the default security policy.
+/// Consider changing this depending on your security and availability requirements
+/// by using [`Builder::new`] instead and calling [`Builder::set_security_policy`].
+/// See the s2n-tls usage guide:
+/// <https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html>
 impl Default for Builder {
     fn default() -> Self {
         Self::new()

--- a/bindings/rust/s2n-tls/src/config.rs
+++ b/bindings/rust/s2n-tls/src/config.rs
@@ -37,7 +37,7 @@ impl Config {
     ///
     /// Use the [`Builder`] if custom configuration is desired.
     ///
-    /// # Safety:
+    /// # Warning
     ///
     /// By default, the newly created Config uses the default security policy.
     /// Consider changing this depending on your security and availability requirements
@@ -166,7 +166,7 @@ pub struct Builder {
 }
 
 impl Builder {
-    /// # Safety
+    /// # Warning
     ///
     /// By default, the newly created Builder uses the default security policy.
     /// Consider changing this depending on your security and availability requirements
@@ -769,7 +769,7 @@ impl Builder {
     }
 }
 
-/// # Safety
+/// # Warning
 ///
 /// The newly created Builder uses the default security policy.
 /// Consider changing this depending on your security and availability requirements

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -89,6 +89,15 @@ unsafe impl Send for Connection {}
 unsafe impl Sync for Connection {}
 
 impl Connection {
+    /// # Safety
+    ///
+    /// The newly created connection uses the default security policy.
+    /// Consider changing this depending on your security and availability requirements
+    /// by calling [`Connection::set_security_policy`].
+    /// Alternatively, you can use [`crate::config::Builder`], [`crate::config::Builder::set_security_policy`],
+    /// and [`Connection::set_config`] to set the policy on the Config instead of on the Connection.
+    /// See the s2n-tls usage guide:
+    /// <https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html>
     pub fn new(mode: Mode) -> Self {
         crate::init::init();
 

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -89,7 +89,7 @@ unsafe impl Send for Connection {}
 unsafe impl Sync for Connection {}
 
 impl Connection {
-    /// # Safety
+    /// # Warning
     ///
     /// The newly created connection uses the default security policy.
     /// Consider changing this depending on your security and availability requirements

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -92,7 +92,7 @@ impl Connection {
     /// # Warning
     ///
     /// The newly created connection uses the default security policy.
-    /// Consider changing this depending on your security and availability requirements
+    /// Consider changing this depending on your security and compatibility requirements
     /// by calling [`Connection::set_security_policy`].
     /// Alternatively, you can use [`crate::config::Builder`], [`crate::config::Builder::set_security_policy`],
     /// and [`Connection::set_config`] to set the policy on the Config instead of on the Connection.

--- a/bindings/rust/s2n-tls/src/security.rs
+++ b/bindings/rust/s2n-tls/src/security.rs
@@ -1,6 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Security options like cipher suites, signature algorithms, versions, etc.
+//!
+//! See <https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html>
+
 use crate::error::Error;
 use core::fmt;
 use std::ffi::{CStr, CString};
@@ -25,6 +29,8 @@ impl Policy {
         }
     }
 
+    /// See the s2n-tls usage guide for details on available policies:
+    /// <https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html>
     pub fn from_version(version: &str) -> Result<Policy, Error> {
         let cstr = CString::new(version).map_err(|_| Error::INVALID_INPUT)?;
         let context = Context::Owned(cstr);
@@ -37,18 +43,48 @@ impl fmt::Debug for Policy {
         f.debug_tuple("Policy").field(&self.as_cstr()).finish()
     }
 }
-
 macro_rules! policy {
-    ($name:ident, $version:expr) => {
-        pub const $name: Policy = Policy(Context::Static(concat!($version, "\0").as_bytes()));
+    ($version:expr) => {
+        Policy(Context::Static(concat!($version, "\0").as_bytes()));
     };
 }
 
-policy!(DEFAULT, "default");
-policy!(DEFAULT_TLS13, "default_tls13");
+/// Default policy
+///
+/// # Safety
+///
+/// Cipher suites, curves, signature algorithms, or other security policy options
+/// may be added or removed from "default" in order to keep it up to date with
+/// current security best practices.
+///
+/// That means that updating the library may cause the policy to change. If peers
+/// are expected to be reasonably modern and support standard options, then this
+/// should not be a problem. But if peers rely on a deprecated option that is removed,
+/// they may be unable to connect.
+///
+/// If you instead need a static, versioned policy, choose one according to the s2n-tls usage guide:
+/// <https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html>
+pub const DEFAULT: Policy = policy!("default");
+
+/// Default policy supporting TLS1.3
+///
+/// # Safety
+///
+/// Cipher suites, curves, signature algorithms, or other security policy options
+/// may be added or removed from "default_tls13" in order to keep it up to date with
+/// current security best practices.
+///
+/// That means that updating the library may cause the policy to change. If peers
+/// are expected to be reasonably modern and support standard options, then this
+/// should not be a problem. But if peers rely on a deprecated option that is removed,
+/// they may be unable to connect.
+///
+/// If you instead need a static, versioned policy, choose one according to the s2n-tls usage guide:
+/// <https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html>
+pub const DEFAULT_TLS13: Policy = policy!("default_tls13");
 
 #[cfg(feature = "pq")]
-policy!(TESTING_PQ, "PQ-TLS-1-0-2021-05-26");
+pub const TESTING_PQ: Policy = policy!("PQ-TLS-1-0-2021-05-26");
 
 pub const ALL_POLICIES: &[Policy] = &[
     DEFAULT,

--- a/bindings/rust/s2n-tls/src/security.rs
+++ b/bindings/rust/s2n-tls/src/security.rs
@@ -43,9 +43,10 @@ impl fmt::Debug for Policy {
         f.debug_tuple("Policy").field(&self.as_cstr()).finish()
     }
 }
+
 macro_rules! policy {
     ($version:expr) => {
-        Policy(Context::Static(concat!($version, "\0").as_bytes()));
+        Policy(Context::Static(concat!($version, "\0").as_bytes()))
     };
 }
 

--- a/bindings/rust/s2n-tls/src/security.rs
+++ b/bindings/rust/s2n-tls/src/security.rs
@@ -51,7 +51,7 @@ macro_rules! policy {
 
 /// Default policy
 ///
-/// # Safety
+/// # Warning
 ///
 /// Cipher suites, curves, signature algorithms, or other security policy options
 /// may be added or removed from "default" in order to keep it up to date with
@@ -68,7 +68,7 @@ pub const DEFAULT: Policy = policy!("default");
 
 /// Default policy supporting TLS1.3
 ///
-/// # Safety
+/// # Warning
 ///
 /// Cipher suites, curves, signature algorithms, or other security policy options
 /// may be added or removed from "default_tls13" in order to keep it up to date with

--- a/docs/usage-guide/topics/ch06-security-policies.md
+++ b/docs/usage-guide/topics/ch06-security-policies.md
@@ -40,23 +40,25 @@ The following chart maps the security policy version to protocol version and cip
 |   20200207    |        |        |        |    X   |         |    X    |      X     |      |     |     |   X   |        |
 |    rfc9151    |        |        |    X   |    X   |         |    X    |            |      |     |  X  |   X   |    X   |
 
-The "default", "default_tls13", and "default_fips" versions are special in that they will be updated with future s2n-tls changes and ciphersuites and protocol versions may be added and removed, or their internal order of preference might change. Numbered versions are fixed and will never change.
-In general, customers prefer to use numbered versions for production use cases to prevent impact from library updates.
+The "default", "default_tls13", and "default_fips" versions are special in that they will be updated with future s2n-tls changes to keep up-to-date with current security best practices. Ciphersuites, protocol versions, and other options may be added or removed, or their internal order of preference might change. **Warning**: this means that the default policies may change as a result of library updates, which could break peers that rely on legacy options.
+
+In contrast, numbered or dated versions are fixed and will never change.
 
 "20230317" offers more limited but more secure options than the default policies. Consider it if you don't need or want to support less secure legacy options like TLS1.1 or SHA1. It is also FIPS compliant and supports TLS1.3. If you need a version of this policy that doesn't support TLS1.3, choose "20240331" instead.
 
 "20160411" follows the same general preference order as "default". The main difference is it has a CBC cipher suite at the top. This is to accommodate certain Java clients that have poor GCM implementations. Users of s2n-tls who have found GCM to be hurting performance for their clients should consider this version.
 
 "rfc9151" is derived from [Commercial National Security Algorithm (CNSA) Suite Profile for TLS and DTLS 1.2 and 1.3](https://datatracker.ietf.org/doc/html/rfc9151). This policy restricts the algorithms allowed for signatures on certificates in the certificate chain to RSA or ECDSA with sha384, which may require you to update your certificates.
+Like the default policies, this policy may also change if the source RFC definition changes.
 
 s2n-tls does not expose an API to control the order of preference for each ciphersuite or protocol version. s2n-tls follows the following order:
-
-*NOTE*: All ChaCha20-Poly1305 cipher suites will not be available if s2n-tls is not built with an Openssl 1.1.1 libcrypto. The underlying encrypt/decrypt functions are not available in older versions.
 
 1. Always prefer the highest protocol version supported
 2. Always use forward secrecy where possible. Prefer ECDHE over DHE.
 3. Prefer encryption ciphers in the following order: AES128, AES256, ChaCha20, 3DES, RC4.
 4. Prefer record authentication modes in the following order: GCM, Poly1305, SHA256, SHA1, MD5.
+
+*NOTE*: ChaCha20-Poly1305 cipher suites will not be available if s2n-tls is built with an older libcrypto like openssl-1.0.2. The underlying encrypt/decrypt functions are not available in older versions.
 
 #### ChaCha20 Boosting
 
@@ -90,7 +92,9 @@ s2n-tls usually prefers AES over ChaCha20. However, some clients-- particularly 
 |   20200207    |           |   X   |              |    X    |
 |    rfc9151    |     X     |   X   |              |    X    |
 
-Note that legacy SHA-1 algorithms are not supported in TLS1.3. Legacy SHA-1 algorithms will be supported only if TLS1.2 has been negotiated and the security policy allows them.
+*NOTE*: Legacy SHA-1 algorithms are not supported in TLS1.3. Legacy SHA-1 algorithms will be supported only if TLS1.2 has been negotiated and the security policy allows them.
+
+*NOTE*: RSA-PSS certificates will not be available if s2n-tls is built with an older libcrypto like openssl-1.0.2. RSA certificate signatures with PSS padding (RSA-PSS-RSAE) will still be available, but RSA-PSS certificate signatures with PSS padding (RSA-PSS-PSS) will not be available.
 
 ### Chart: Security policy version to supported curves/groups
 


### PR DESCRIPTION
### Description of changes: 

Users of the Rust bindings don't necessarily read our usage guide, which is primarily focused on the C library.
I added safety notes about security policies to the Rust bindings so that users are at least aware that security policies exist.
I also tried to make the existing usage guide information on default policies clearer.

### Callouts
Anywhere else I should put the warning?

### Testing:
I ran cargo doc. We have existing warnings, but none about my new comments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
