### PR TITLE
feat: add missing numbered security policies

### DIFF
--- a/docs/usage-guide/topics/ch06-security-policies.md
+++ b/docs/usage-guide/topics/ch06-security-policies.md
@@ -42,7 +42,10 @@ The following chart maps the security policy version to protocol version and cip
 
 The "default", "default_tls13", and "default_fips" versions are special in that they will be updated with future s2n-tls changes to keep up-to-date with current security best practices. Ciphersuites, protocol versions, and other options may be added or removed, or their internal order of preference might change. **Warning**: this means that the default policies may change as a result of library updates, which could break peers that rely on legacy options.
 
-In contrast, numbered or dated versions are fixed and will never change.
+In contrast, numbered or dated versions are fixed and will never change. The numbered equivalents of the default policies are currently:
+* "default": "20170210"
+* "default_tls13": "20240417"
+* "default_fips": "20240416"
 
 "20230317" offers more limited but more secure options than the default policies. Consider it if you don't need or want to support less secure legacy options like TLS1.1 or SHA1. It is also FIPS compliant and supports TLS1.3. If you need a version of this policy that doesn't support TLS1.3, choose "20240331" instead.
 

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -605,7 +605,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_20140601);
 
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
-        EXPECT_EQUAL(config->security_policy, &security_policy_default_tls13);
+        EXPECT_EQUAL(config->security_policy, &security_policy_20240417);
         EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_20210831);
         EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_null);
         EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20200207);
@@ -731,7 +731,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default_tls13"));
         EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
-        EXPECT_EQUAL(security_policy, &security_policy_default_tls13);
+        EXPECT_EQUAL(security_policy, &security_policy_20240417);
         EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_20210831);
         EXPECT_EQUAL(security_policy->kem_preferences, &kem_preferences_null);
         EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20200207);

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -28,7 +28,7 @@ const struct s2n_security_policy security_policy_20170210 = {
     .ecc_preferences = &s2n_ecc_preferences_20140601,
 };
 
-const struct s2n_security_policy security_policy_default_tls13 = {
+const struct s2n_security_policy security_policy_20240417 = {
     .minimum_protocol_version = S2N_TLS10,
     .cipher_preferences = &cipher_preferences_20210831,
     .kem_preferences = &kem_preferences_null,
@@ -43,7 +43,7 @@ const struct s2n_security_policy security_policy_default_tls13 = {
  *
  * Supports TLS1.2
  */
-const struct s2n_security_policy security_policy_default_fips = {
+const struct s2n_security_policy security_policy_20240416 = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_default_fips,
     .kem_preferences = &kem_preferences_null,
@@ -1072,10 +1072,12 @@ const struct s2n_security_policy security_policy_null = {
 
 struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "default", .security_policy = &security_policy_20170210, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
-    { .version = "default_tls13", .security_policy = &security_policy_default_tls13, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
-    { .version = "default_fips", .security_policy = &security_policy_default_fips, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "default_tls13", .security_policy = &security_policy_20240417, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "default_fips", .security_policy = &security_policy_20240416, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20230317", .security_policy = &security_policy_20230317, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20240331", .security_policy = &security_policy_20240331, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "20240417", .security_policy = &security_policy_20240417, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "20240416", .security_policy = &security_policy_20240416, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "ELBSecurityPolicy-TLS-1-0-2015-04", .security_policy = &security_policy_elb_2015_04, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     /* Not a mistake. TLS-1-0-2015-05 and 2016-08 are equivalent */
     { .version = "ELBSecurityPolicy-TLS-1-0-2015-05", .security_policy = &security_policy_elb_2016_08, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -114,8 +114,8 @@ extern const struct s2n_security_policy security_policy_20190801;
 extern const struct s2n_security_policy security_policy_20190802;
 extern const struct s2n_security_policy security_policy_20230317;
 extern const struct s2n_security_policy security_policy_20240331;
-extern const struct s2n_security_policy security_policy_default_tls13;
-extern const struct s2n_security_policy security_policy_default_fips;
+extern const struct s2n_security_policy security_policy_20240417;
+extern const struct s2n_security_policy security_policy_20240416;
 extern const struct s2n_security_policy security_policy_rfc9151;
 extern const struct s2n_security_policy security_policy_test_all;
 


### PR DESCRIPTION
### Description of changes: 
We currently don't have versioned equivalents to "default_tls13" or "default_fips", so customers who want a fixed version of the defaults don't have obvious migration options. This PR adds those versioned copies and updates the documentation.

### Testing:
No tests. This is really just a rename + adding two new policy mappings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
