### PR TITLE
chore(bindings): Pin `zeroize` to avoid MSRV increase

### DIFF
--- a/bindings/rust/s2n-tls-sys/templates/Cargo.template
+++ b/bindings/rust/s2n-tls-sys/templates/Cargo.template
@@ -45,3 +45,4 @@ cc = { version = "1.0", features = ["parallel"] }
 jobserver = "=0.1.26" # newer versions require rust 1.66, see https://github.com/aws/s2n-tls/issues/4241
 home = "=0.5.5" # newer versions require rust 1.70, see https://github.com/aws/s2n-tls/issues/4395
 regex = "=1.9.6" # newer versions require rust 1.65, see https://github.com/aws/s2n-tls/issues/4242
+zeroize = "=1.7.0" # newer versions require rust 1.72, see https://github.com/aws/s2n-tls/issues/4518


### PR DESCRIPTION
### Description of changes: 

The `zeroize` crate has updated their MSRV to 1.72 which [causes the rust bindings build to fail](https://github.com/aws/s2n-tls/actions/runs/8823035714/job/24222571418?pr=4512), see https://github.com/aws/s2n-tls/issues/4518. This PR pins `zeroize` to the previous version in order to avoid the MSRV increase.

### Testing:

The CI should build the rust bindings successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
