### PR TITLE
binding: Add s2n_connection_get_session on the Connection

### DIFF
--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -683,7 +683,7 @@ impl Connection {
     pub fn session_ticket_length(&mut self) -> Result<usize, Error> {
         let len =
             unsafe { s2n_connection_get_session_length(self.connection.as_ptr()).into_result()? };
-        Ok(len.try_into().expect("into_result cannot be < 0"))
+        Ok(len.try_into().unwrap())
     }
 
     /// Serializes the session state from the connection into `output` and returns
@@ -703,7 +703,7 @@ impl Connection {
             s2n_connection_get_session(self.connection.as_ptr(), output.as_mut_ptr(), output.len())
                 .into_result()?
         };
-        Ok(written.try_into().expect("into_result < 0"))
+        Ok(written.try_into().unwrap())
     }
 
     /// Sets a Waker on the connection context or clears it if `None` is passed.

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -689,7 +689,7 @@ impl Connection {
     pub fn session(&mut self) -> Result<Vec<u8>, Error> {
         let size;
         unsafe {
-            size = dbg!(s2n_connection_get_session_length(self.connection.as_ptr()));
+            size = s2n_connection_get_session_length(self.connection.as_ptr());
         }
         if size <= 0 {
             return Ok(Vec::default());

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -680,7 +680,7 @@ impl Connection {
     }
 
     /// Retrieves the size of the session ticket.
-    pub fn session_ticket_length(&mut self) -> Result<usize, Error> {
+    pub fn session_ticket_length(&self) -> Result<usize, Error> {
         let len =
             unsafe { s2n_connection_get_session_length(self.connection.as_ptr()).into_result()? };
         Ok(len.try_into().unwrap())
@@ -695,7 +695,7 @@ impl Connection {
     /// Note: This function is not recommended for > TLS1.2 because in TLS1.3
     /// servers can send multiple session tickets and this will return only
     /// the most recently received ticket.
-    pub fn session_ticket(&mut self, output: &mut [u8]) -> Result<usize, Error> {
+    pub fn session_ticket(&self, output: &mut [u8]) -> Result<usize, Error> {
         if output.len() < self.session_ticket_length()? {
             return Err(Error::INVALID_INPUT);
         }

--- a/bindings/rust/s2n-tls/src/testing/resumption.rs
+++ b/bindings/rust/s2n-tls/src/testing/resumption.rs
@@ -50,7 +50,7 @@ mod tests {
     const KEY: [u8; 16] = [0; 16];
     const KEYNAME: [u8; 3] = [1, 3, 4];
 
-    fn validate_session_ticket(conn: &mut Connection) -> Result<(), Box<dyn Error>> {
+    fn validate_session_ticket(conn: &Connection) -> Result<(), Box<dyn Error>> {
         assert!(conn.session_ticket_length()? > 0);
         let mut session = vec![0; conn.session_ticket_length()?];
         //load the ticket and make sure session is no longer empty
@@ -104,9 +104,9 @@ mod tests {
         let server = Harness::new(server);
         let client = Harness::new(client);
         let pair = Pair::new(server, client);
-        let mut pair = poll_tls_pair(pair);
+        let pair = poll_tls_pair(pair);
 
-        let client = pair.client.0.connection_mut();
+        let client = pair.client.0.connection();
 
         // Check connection was full handshake and a session ticket was included
         assert_eq!(
@@ -132,10 +132,10 @@ mod tests {
         let server = Harness::new(server);
         let client = Harness::new(client);
         let pair = Pair::new(server, client);
-        let mut pair = poll_tls_pair(pair);
+        let pair = poll_tls_pair(pair);
 
-        let client = pair.client.0.connection_mut();
-        let server = pair.server.0.connection_mut();
+        let client = pair.client.0.connection();
+        let server = pair.server.0.connection();
 
         // Check new connection was resumed
         assert_eq!(client.handshake_type()?, "NEGOTIATED");
@@ -193,7 +193,7 @@ mod tests {
         // to collect the session ticket.
         assert!(pair.poll_recv(Mode::Client, &mut [0]).is_pending());
 
-        let client = pair.client.0.connection_mut();
+        let client = pair.client.0.connection();
         // Check connection was full handshake
         assert_eq!(
             client.handshake_type()?,
@@ -225,7 +225,7 @@ mod tests {
         // to collect the session ticket.
         assert!(pair.poll_recv(Mode::Client, &mut [0]).is_pending());
 
-        let client = pair.client.0.connection_mut();
+        let client = pair.client.0.connection();
         // Check new connection was resumed
         assert_eq!(client.handshake_type()?, "NEGOTIATED|MIDDLEBOX_COMPAT");
         // validate that a ticket is available

--- a/bindings/rust/s2n-tls/src/testing/resumption.rs
+++ b/bindings/rust/s2n-tls/src/testing/resumption.rs
@@ -50,12 +50,15 @@ mod tests {
     const KEY: [u8; 16] = [0; 16];
     const KEYNAME: [u8; 3] = [1, 3, 4];
 
-    fn validate_session_ticket(c: &mut Connection) -> Result<(), Box<dyn Error>> {
-        assert!(c.session_ticket_length()? > 0);
-        let mut session = vec![0; c.session_ticket_length()?];
+    fn validate_session_ticket(conn: &mut Connection) -> Result<(), Box<dyn Error>> {
+        assert!(conn.session_ticket_length()? > 0);
+        let mut session = vec![0; conn.session_ticket_length()?];
         //load the ticket and make sure session is no longer empty
-        assert_eq!(c.session_ticket(&mut session)?, c.session_ticket_length()?);
-        assert_ne!(session, vec![0; c.session_ticket_length()?]);
+        assert_eq!(
+            conn.session_ticket(&mut session)?,
+            conn.session_ticket_length()?
+        );
+        assert_ne!(session, vec![0; conn.session_ticket_length()?]);
         Ok(())
     }
 
@@ -188,8 +191,7 @@ mod tests {
         // Do a recv call on the client side to read a session ticket. Poll function
         // returns pending since no application data was read, however it is enough
         // to collect the session ticket.
-        let mut recv_buffer: [u8; 10] = [0; 10];
-        assert!(pair.poll_recv(Mode::Client, &mut recv_buffer).is_pending());
+        assert!(pair.poll_recv(Mode::Client, &mut [0]).is_pending());
 
         let client = pair.client.0.connection_mut();
         // Check connection was full handshake
@@ -221,8 +223,7 @@ mod tests {
         // Do a recv call on the client side to read a session ticket. Poll function
         // returns pending since no application data was read, however it is enough
         // to collect the session ticket.
-        let mut recv_buffer: [u8; 10] = [0; 10];
-        assert!(pair.poll_recv(Mode::Client, &mut recv_buffer).is_pending());
+        assert!(pair.poll_recv(Mode::Client, &mut [0]).is_pending());
 
         let client = pair.client.0.connection_mut();
         // Check new connection was resumed


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

The change adds a new method in the `Connection` for the rust bindings to expose the session state. This allows clients/servers to capture the most recent session outside of the `SessionTicketCallback` callback.

Until #4264 is addressed, this allows sessions for TLS1.2 or lower to be cached with data other than a servername.

### Call-outs:

The C api requires an allocation for writing the session, In order to provide a simpler rust API, and be consistent with some of the other apis in Connection, the buffer allocation is performed within the `connection::session` method itself.

### Testing:
Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
