### PR TITLE
feat[bindings]: fips feature flag

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -187,17 +187,6 @@ jobs:
         run: |
           cargo test --features fips
 
-      # Explicitly test without the `fips` feature flag.
-      #
-      # The `fips` feature flag results in building s2n-tls with `aws-lc-fips-sys`
-      # instead of `aws-lc-sys`. Since other tasks use `--all-features` and automatically
-      # enable `fips`, testing with `aws-lc-sys` (non-fips) is missing without this step.
-      - name: Test non-fips
-        working-directory: ${{env.ROOT_PATH}}
-        run: |
-          cargo test
-
-
   rustfmt:
     runs-on: ubuntu-latest
     steps:
@@ -216,7 +205,7 @@ jobs:
       # We don't need to format the generated files,
       # but if they don't exist other code breaks.
       - name: Generate
-        run: ./${{env.ROOT_PATH}}/generate.sh
+        run: ./${{env.ROOT_PATH}}/generate.sh --skip-tests
 
       - name: Run cargo fmt
         run: |

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -31,6 +31,13 @@ jobs:
           rustup toolchain install stable
           rustup override set stable
 
+      # https://github.com/aws/aws-lc-rs/blob/main/aws-lc-fips-sys/README.md#build-prerequisites
+      # go required to build aws-lc-rs in FIPS mode
+      - name: Install go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.18'
+
       - uses: camshaft/rust-cache@v1
 
       - name: Generate
@@ -163,21 +170,30 @@ jobs:
           rustup toolchain install stable
           rustup override set stable
 
+      # https://github.com/aws/aws-lc-rs/blob/main/aws-lc-fips-sys/README.md#build-prerequisites
+      # go required to build aws-lc-rs in FIPS mode
+      - name: Install go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.18'
+
       - uses: camshaft/rust-cache@v1
 
       - name: Generate
         run: ./${{env.ROOT_PATH}}/generate.sh
 
       - name: Test fips
+        working-directory: ${{env.ROOT_PATH}}
         run: |
           cargo test --features fips
 
       # Explicitly test without the `fips` feature flag.
       #
       # The `fips` feature flag results in building s2n-tls with `aws-lc-fips-sys`
-      # instead of `aws-lc-sys`. Since other tasks use `--all-features` for testing,
-      # we don't currently test building s2n-tls with `aws-lc-sys` (non-fips).
+      # instead of `aws-lc-sys`. Since other tasks use `--all-features` and automatically
+      # enable `fips`, testing with `aws-lc-sys` (non-fips) is missing without this step.
       - name: Test non-fips
+        working-directory: ${{env.ROOT_PATH}}
         run: |
           cargo test
 

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -84,7 +84,7 @@ jobs:
       - name: bench tests
         working-directory: ${{env.ROOT_PATH}}/bench
         run: cargo test
-  
+
   s2n-tls-binding-examples:
     runs-on: ubuntu-latest
     steps:
@@ -95,7 +95,7 @@ jobs:
         run: |
           rustup toolchain install stable
           rustup override set stable
-      
+
       - name: generate bindings
         run: ${{env.ROOT_PATH}}/generate.sh --skip-tests
 
@@ -149,6 +149,38 @@ jobs:
       - name: Tests
         working-directory: ${{env.ROOT_PATH}}
         run: cargo test --all-features
+
+  fips:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Install Rust toolchain
+        id: toolchain
+        run: |
+          rustup toolchain install stable
+          rustup override set stable
+
+      - uses: camshaft/rust-cache@v1
+
+      - name: Generate
+        run: ./${{env.ROOT_PATH}}/generate.sh
+
+      - name: Test fips
+        run: |
+          cargo test --features fips
+
+      # Explicitly test without the `fips` feature flag.
+      #
+      # The `fips` feature flag results in building s2n-tls with `aws-lc-fips-sys`
+      # instead of `aws-lc-sys`. Since other tasks use `--all-features` for testing,
+      # we don't currently test building s2n-tls with `aws-lc-sys` (non-fips).
+      - name: Test non-fips
+        run: |
+          cargo test
+
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/bindings/rust/s2n-tls-sys/templates/Cargo.template
+++ b/bindings/rust/s2n-tls-sys/templates/Cargo.template
@@ -27,6 +27,7 @@ default = []
 # preserve the cmake feature in case any consumers had it enabled before
 cmake = []
 quic = []
+fips = ["aws-lc-rs/fips"]
 pq = []
 internal = []
 stacktrace = []

--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -13,6 +13,7 @@ default = []
 unstable-fingerprint = ["s2n-tls-sys/unstable-fingerprint"]
 unstable-ktls = ["s2n-tls-sys/unstable-ktls"]
 quic = ["s2n-tls-sys/quic"]
+fips = ["s2n-tls-sys/fips"]
 pq = ["s2n-tls-sys/pq"]
 testing = ["bytes"]
 

--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -36,4 +36,3 @@ checkers = "0.6"
 # cargo package / cargo publish, as those commands do not respect the version pin
 # in downstream dev-dependencies (in s2n-tls-sys, in this case)
 jobserver = "=0.1.26"
-cfg-if = "1"

--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -36,3 +36,4 @@ checkers = "0.6"
 # cargo package / cargo publish, as those commands do not respect the version pin
 # in downstream dev-dependencies (in s2n-tls-sys, in this case)
 jobserver = "=0.1.26"
+cfg-if = "1"

--- a/bindings/rust/s2n-tls/src/enums.rs
+++ b/bindings/rust/s2n-tls/src/enums.rs
@@ -32,6 +32,26 @@ impl<T, E> From<Result<T, E>> for CallbackResult {
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]
+pub enum FipsMode {
+    Disabled,
+    Enabled,
+}
+
+impl TryFrom<s2n_fips_mode::Type> for FipsMode {
+    type Error = Error;
+
+    fn try_from(input: s2n_fips_mode::Type) -> Result<Self, Self::Error> {
+        let mode = match input {
+            s2n_fips_mode::FIPS_MODE_DISABLED => FipsMode::Disabled,
+            s2n_fips_mode::FIPS_MODE_ENABLED => FipsMode::Enabled,
+            _ => return Err(Error::INVALID_INPUT),
+        };
+
+        Ok(mode)
+    }
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum Mode {
     Server,
     Client,

--- a/bindings/rust/s2n-tls/src/enums.rs
+++ b/bindings/rust/s2n-tls/src/enums.rs
@@ -31,23 +31,26 @@ impl<T, E> From<Result<T, E>> for CallbackResult {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum FipsMode {
     Disabled,
     Enabled,
 }
 
-impl TryFrom<s2n_fips_mode::Type> for FipsMode {
-    type Error = Error;
+impl FipsMode {
+    pub fn is_enabled(&self) -> bool {
+        matches!(self, FipsMode::Enabled)
+    }
+}
 
-    fn try_from(input: s2n_fips_mode::Type) -> Result<Self, Self::Error> {
-        let mode = match input {
+impl From<s2n_fips_mode::Type> for FipsMode {
+    fn from(input: s2n_fips_mode::Type) -> Self {
+        match input {
             s2n_fips_mode::FIPS_MODE_DISABLED => FipsMode::Disabled,
             s2n_fips_mode::FIPS_MODE_ENABLED => FipsMode::Enabled,
-            _ => return Err(Error::INVALID_INPUT),
-        };
-
-        Ok(mode)
+            _ => unreachable!(),
+        }
     }
 }
 

--- a/bindings/rust/s2n-tls/src/enums.rs
+++ b/bindings/rust/s2n-tls/src/enums.rs
@@ -44,13 +44,17 @@ impl FipsMode {
     }
 }
 
-impl From<s2n_fips_mode::Type> for FipsMode {
-    fn from(input: s2n_fips_mode::Type) -> Self {
-        match input {
+impl TryFrom<s2n_fips_mode::Type> for FipsMode {
+    type Error = Error;
+
+    fn try_from(input: s2n_fips_mode::Type) -> Result<Self, Self::Error> {
+        let mode = match input {
             s2n_fips_mode::FIPS_MODE_DISABLED => FipsMode::Disabled,
             s2n_fips_mode::FIPS_MODE_ENABLED => FipsMode::Enabled,
-            _ => unreachable!(),
-        }
+            _ => return Err(Error::INVALID_INPUT),
+        };
+
+        Ok(mode)
     }
 }
 

--- a/bindings/rust/s2n-tls/src/init.rs
+++ b/bindings/rust/s2n-tls/src/init.rs
@@ -55,7 +55,7 @@ pub fn fips_mode() -> Result<FipsMode, Error> {
     unsafe {
         s2n_get_fips_mode(&mut fips_mode as *mut _).into_result()?;
     }
-    fips_mode.try_into()
+    Ok(fips_mode.into())
 }
 
 mod mem {

--- a/bindings/rust/s2n-tls/src/init.rs
+++ b/bindings/rust/s2n-tls/src/init.rs
@@ -55,7 +55,7 @@ pub fn fips_mode() -> Result<FipsMode, Error> {
     unsafe {
         s2n_get_fips_mode(&mut fips_mode as *mut _).into_result()?;
     }
-    Ok(fips_mode.into())
+    fips_mode.try_into()
 }
 
 mod mem {

--- a/bindings/rust/s2n-tls/src/init.rs
+++ b/bindings/rust/s2n-tls/src/init.rs
@@ -51,9 +51,9 @@ pub fn init() {
 /// FIPS requirements. Applications desiring FIPS compliance should use this API to ensure that
 /// s2n-tls has been properly linked with a FIPS libcrypto and has successfully entered FIPS mode.
 pub fn fips_mode() -> Result<FipsMode, Error> {
-    let fips_mode = s2n_fips_mode::FIPS_MODE_DISABLED;
+    let mut fips_mode = s2n_fips_mode::FIPS_MODE_DISABLED;
     unsafe {
-        s2n_get_fips_mode(fips_mode as _).into_result()?;
+        s2n_get_fips_mode(&mut fips_mode as *mut _).into_result()?;
     }
     fips_mode.try_into()
 }

--- a/bindings/rust/s2n-tls/src/init.rs
+++ b/bindings/rust/s2n-tls/src/init.rs
@@ -1,7 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::error::{Error, Fallible};
+use crate::{
+    enums::FipsMode,
+    error::{Error, Fallible},
+};
 use s2n_tls_sys::*;
 use std::sync::Once;
 
@@ -38,6 +41,21 @@ impl Drop for Thread {
 
 pub fn init() {
     S2N_THREAD.with(|_| ());
+}
+
+/// Determines whether s2n-tls is operating in FIPS mode.
+///
+/// It is possible to enable FIPS mode by enabling the `fips` feature flag.
+///
+/// s2n-tls MUST be linked to a FIPS libcrypto and MUST be in FIPS mode in order to comply with
+/// FIPS requirements. Applications desiring FIPS compliance should use this API to ensure that
+/// s2n-tls has been properly linked with a FIPS libcrypto and has successfully entered FIPS mode.
+pub fn fips_mode() -> Result<FipsMode, Error> {
+    let fips_mode = s2n_fips_mode::FIPS_MODE_DISABLED;
+    unsafe {
+        s2n_get_fips_mode(fips_mode as _).into_result()?;
+    }
+    fips_mode.try_into()
 }
 
 mod mem {

--- a/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
+++ b/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
@@ -965,9 +965,9 @@ mod tests {
     #[cfg(feature = "fips")]
     #[test]
     fn test_fips_mode() {
-        use crate::{enums::FipsMode, init};
+        use crate::init;
 
         init::init();
-        assert_eq!(init::fips_mode().unwrap(), FipsMode::Enabled);
+        assert!(init::fips_mode().unwrap().is_enabled());
     }
 }

--- a/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
+++ b/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
@@ -963,7 +963,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fips_mod() -> Result<(), Error> {
+    fn test_fips_mode() -> Result<(), Error> {
         use crate::{enums::FipsMode, init};
 
         init::init();

--- a/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
+++ b/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
@@ -962,20 +962,12 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "fips")]
     #[test]
-    fn test_fips_mode() -> Result<(), Error> {
+    fn test_fips_mode() {
         use crate::{enums::FipsMode, init};
 
         init::init();
-
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "fips")] {
-                assert_eq!(init::fips_mode().unwrap(), FipsMode::Enabled);
-            } else {
-                assert_eq!(init::fips_mode().unwrap(), FipsMode::Disabled);
-            }
-        }
-
-        Ok(())
+        assert_eq!(init::fips_mode().unwrap(), FipsMode::Enabled);
     }
 }

--- a/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
+++ b/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
@@ -961,4 +961,21 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_fips_mod() -> Result<(), Error> {
+        use crate::{enums::FipsMode, init};
+
+        init::init();
+
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "fips")] {
+                assert_eq!(init::fips_mode().unwrap(), FipsMode::Enabled);
+            } else {
+                assert_eq!(init::fips_mode().unwrap(), FipsMode::Disabled);
+            }
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
### Description of changes: 
This PR adds a new `fips` feature flag which builds the bindings in FIPS mode. We also exposes the underlying C function to retrieve the `fips_mode()` so Applications can check their FIPS status at runtime.

aws-lc-rs exposes a [`fips` feature flag](https://docs.rs/crate/aws-lc-rs/latest/features#fips), which can be set to use aws-lc in FIPS mode. The changes in this PR simply propagate the fips flag down to aws-lc-rs so that s2n-tls is built with a FIPS compliant libcrypto.

### Testing:
Added testing to ensure s2n-tls correctly enters FIPS mode when built with aws-lc-rs with fips enabled

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
