### PR TITLE
chore: update s2n_stuffer_printf CBMC harness

### DIFF
--- a/tests/cbmc/proofs/s2n_stuffer_printf/s2n_stuffer_printf_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_printf/s2n_stuffer_printf_harness.c
@@ -21,6 +21,17 @@
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_mem.h"
 
+int nondet_int(void);
+
+int vsnprintf(char *str, size_t size, const char *fmt, va_list ap)
+{
+  if(size > 0)
+    __CPROVER_havoc_slice(str, size);
+  (void)*fmt;
+  (void)*(char **)ap;
+  return nondet_int();
+}
+
 void s2n_stuffer_printf_harness()
 {
     nondet_s2n_mem_init();
@@ -34,7 +45,10 @@ void s2n_stuffer_printf_harness()
     /* CBMC defines va_list as void** */
     size_t va_list_size;
     __CPROVER_assume(va_list_size % sizeof(void*) == 0);
+    __CPROVER_assume(va_list_size > 0);
     void** va_list_mem = malloc(va_list_size);
+    __CPROVER_assume(va_list_mem != NULL);
+    va_list_mem[va_list_size / sizeof(void*) - 1] = NULL;
 
     /* Store the stuffer to compare after the write */
     struct s2n_stuffer            old_stuffer = *stuffer;


### PR DESCRIPTION
### Description of changes: 

Newer CBMC versions ship a model of vsnprintf. We don't want to use this model for it contains loops, but still this highlighted a number of missing constraints in our existing harness.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
