### PR TITLE
ci: grep for S2N_RESULT_ERR without setting s2n_errno

### DIFF
--- a/codebuild/bin/grep_simple_mistakes.sh
+++ b/codebuild/bin/grep_simple_mistakes.sh
@@ -75,6 +75,7 @@ for file in $S2N_FILES_ASSERT_RETURN; do
   RESULT_NEGATIVE_ONE=`grep -rn 'return -1;' $file`
   RESULT_S2N_ERR=`grep -rn 'return S2N_ERR*' $file`
   RESULT_S2N_FAIL=`grep -rn 'return S2N_FAIL*' $file`
+  RESULT_S2N_RESULT_ERR=`grep -rn 'return S2N_RESULT_ERR*' $file`
 
   if [ "${#RESULT_NEGATIVE_ONE}" != "0" ]; then
     FAILED=1
@@ -87,6 +88,10 @@ for file in $S2N_FILES_ASSERT_RETURN; do
   if [ "${#RESULT_S2N_FAIL}" != "0" ]; then
     FAILED=1
     printf "\e[1;34mGrep for 'return S2N_FAIL*' check failed in $file:\e[0m\n$RESULT_S2N_FAIL\n\n"
+  fi
+  if [ "${#RESULT_S2N_RESULT_ERR}" != "0" ]; then
+    FAILED=1
+    printf "\e[1;34mGrep for 'return S2N_RESULT_ERR*' check failed in $file:\e[0m\n$RESULT_S2N_RESULT_ERR\n\n"
   fi
 done
 

--- a/tls/s2n_async_pkey.c
+++ b/tls/s2n_async_pkey.c
@@ -124,7 +124,7 @@ static S2N_RESULT s2n_async_get_actions(s2n_async_pkey_op_type type, const struc
             /* No default for compiler warnings */
     }
 
-    return S2N_RESULT_ERROR;
+    RESULT_BAIL(S2N_ERR_SAFETY);
 }
 
 static S2N_RESULT s2n_async_pkey_op_allocate(struct s2n_async_pkey_op **op)
@@ -138,10 +138,7 @@ static S2N_RESULT s2n_async_pkey_op_allocate(struct s2n_async_pkey_op **op)
     RESULT_GUARD_POSIX(s2n_blob_zero(&mem));
 
     *op = (void *) mem.data;
-    if (s2n_blob_init(&mem, NULL, 0) != S2N_SUCCESS) {
-        *op = NULL;
-        return S2N_RESULT_ERROR;
-    }
+    ZERO_TO_DISABLE_DEFER_CLEANUP(mem);
     return S2N_RESULT_OK;
 }
 

--- a/tls/s2n_early_data_io.c
+++ b/tls/s2n_early_data_io.c
@@ -169,9 +169,9 @@ S2N_RESULT s2n_send_early_data_impl(struct s2n_connection *conn, const uint8_t *
     int negotiate_result = s2n_negotiate(conn, blocked);
     if (negotiate_result < S2N_SUCCESS) {
         if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
-            return S2N_RESULT_ERROR;
+            RESULT_GUARD_POSIX(negotiate_result);
         } else if (*blocked != S2N_BLOCKED_ON_EARLY_DATA && *blocked != S2N_BLOCKED_ON_READ) {
-            return S2N_RESULT_ERROR;
+            RESULT_GUARD_POSIX(negotiate_result);
         }
     }
     /* Save the error status for later */
@@ -239,14 +239,15 @@ S2N_RESULT s2n_recv_early_data_impl(struct s2n_connection *conn, uint8_t *data, 
         return S2N_RESULT_OK;
     }
 
-    while (s2n_negotiate(conn, blocked) < S2N_SUCCESS) {
+    int negotiate_result = S2N_SUCCESS;
+    while ((negotiate_result = s2n_negotiate(conn, blocked)) != S2N_SUCCESS) {
         if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED) {
-            return S2N_RESULT_ERROR;
+            RESULT_GUARD_POSIX(negotiate_result);
         } else if (max_data_len <= *data_received) {
-            return S2N_RESULT_ERROR;
+            RESULT_GUARD_POSIX(negotiate_result);
         } else if (*blocked != S2N_BLOCKED_ON_EARLY_DATA) {
             if (s2n_early_data_can_continue(conn)) {
-                return S2N_RESULT_ERROR;
+                RESULT_GUARD_POSIX(negotiate_result);
             } else {
                 *blocked = S2N_NOT_BLOCKED;
                 return S2N_RESULT_OK;


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/aws/s2n-tls/pull/4513#discussion_r1587978354

### Description of changes: 
Our existing grep checks for posix return types, but not S2N_RESULT return types. So it misses `return S2N_RESULT_ERROR` mistakes.

### Testing:
The updated script found a couple existing mistakes, which I fixed. The only actual problem was `s2n_async_get_actions`. The other instances didn't set s2n_errno, but relied on a previous call having just failed and kept the error code from that failure. RESULT_GUARD does the same thing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
