### PR TITLE
feat(bindings): expose default fips security policy

### DIFF
--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -714,7 +714,7 @@ impl Connection {
             if let Some(prev_waker) = ctx.waker.as_mut() {
                 // only replace the Waker if they dont reference the same task
                 if !prev_waker.will_wake(waker) {
-                    *prev_waker = waker.clone();
+                    prev_waker.clone_from(waker);
                 }
             } else {
                 ctx.waker = Some(waker.clone());

--- a/bindings/rust/s2n-tls/src/security.rs
+++ b/bindings/rust/s2n-tls/src/security.rs
@@ -99,6 +99,7 @@ pub const DEFAULT_TLS13: Policy = policy!("default_tls13");
 ///
 /// If you instead need a static, versioned policy, choose one according to the s2n-tls usage guide:
 /// <https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html>
+#[cfg(feature = "fips")]
 pub const DEFAULT_FIPS: Policy = policy!("default_fips");
 
 #[cfg(feature = "pq")]
@@ -107,6 +108,7 @@ pub const TESTING_PQ: Policy = policy!("PQ-TLS-1-0-2021-05-26");
 pub const ALL_POLICIES: &[Policy] = &[
     DEFAULT,
     DEFAULT_TLS13,
+    #[cfg(feature = "fips")]
     DEFAULT_FIPS,
     #[cfg(feature = "pq")]
     TESTING_PQ,

--- a/bindings/rust/s2n-tls/src/security.rs
+++ b/bindings/rust/s2n-tls/src/security.rs
@@ -84,12 +84,30 @@ pub const DEFAULT: Policy = policy!("default");
 /// <https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html>
 pub const DEFAULT_TLS13: Policy = policy!("default_tls13");
 
+/// Default FIPS compliant policy
+///
+/// # Warning
+///
+/// Cipher suites, curves, signature algorithms, or other security policy options
+/// may be added or removed from "default_fips" in order to keep it up to date with
+/// current security best practices.
+///
+/// That means that updating the library may cause the policy to change. If peers
+/// are expected to be reasonably modern and support standard options, then this
+/// should not be a problem. But if peers rely on a deprecated option that is removed,
+/// they may be unable to connect.
+///
+/// If you instead need a static, versioned policy, choose one according to the s2n-tls usage guide:
+/// <https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html>
+pub const DEFAULT_FIPS: Policy = policy!("default_fips");
+
 #[cfg(feature = "pq")]
 pub const TESTING_PQ: Policy = policy!("PQ-TLS-1-0-2021-05-26");
 
 pub const ALL_POLICIES: &[Policy] = &[
     DEFAULT,
     DEFAULT_TLS13,
+    DEFAULT_FIPS,
     #[cfg(feature = "pq")]
     TESTING_PQ,
 ];


### PR DESCRIPTION
### Description of changes: 
This PR exposes the `default_fips` from the rust bindings. This is specifically needed so that s2n-quic can set a fips compliant policy when trying to operate in FIPS mode. I have gated this policy behind the `fips` feature flag, which while not necessary (someone could want to use the default_fips policy even when not in fips mode), seems cleaner.

### Testing:
Existing CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
