### PR TITLE
style(bindings): fix new clippy lint

### DIFF
--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -714,7 +714,7 @@ impl Connection {
             if let Some(prev_waker) = ctx.waker.as_mut() {
                 // only replace the Waker if they dont reference the same task
                 if !prev_waker.will_wake(waker) {
-                    *prev_waker = waker.clone();
+                    prev_waker.clone_from(waker);
                 }
             } else {
                 ctx.waker = Some(waker.clone());


### PR DESCRIPTION
### Description of changes: 
Address the new clippy lint

```
    Checking s2n-tls v0.2.4 (/home/runner/work/s2n-tls/s2n-tls/bindings/rust/s2n-tls)
error: assigning the result of `Clone::clone()` may be inefficient
   --> s2n-tls/src/connection.rs:717:21
    |
717 |                     *prev_waker = waker.clone();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `prev_waker.clone_from(waker)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
    = note: `-D clippy::assigning-clones` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::assigning_clones)]`
```

### Testing:

CI should pass
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
