### PR TITLE
feat: pytest marks to selectively skip some tests

### DIFF
--- a/tests/integrationv2/conftest.py
+++ b/tests/integrationv2/conftest.py
@@ -4,7 +4,7 @@ from global_flags import set_flag, S2N_PROVIDER_VERSION, S2N_FIPS_MODE, S2N_NO_P
 from platform import machine
 
 ALLPLATFORMS = set(["aarch64", "x86_64"])
-NOTNIXMARKS = set(["fix4nix"])
+FIXNIXMARK = set(["fix4nix"])
 
 
 def pytest_addoption(parser):
@@ -72,6 +72,6 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
         pytest.skip(f"Platform specific test; not running on {platform}")
 
     # Look for a not-in-nix mark, and check for a Nix defined env. var to skip the test.
-    not_nix_mark = NOTNIXMARKS.intersection(mark.name for mark in item.iter_markers())
+    not_nix_mark = FIXNIXMARK.intersection(mark.name for mark in item.iter_markers())
     if getenv("IN_NIX_SHELL", None) and not_nix_mark:
         pytest.skip(f"Nix detected; skipping this test")

--- a/tests/integrationv2/conftest.py
+++ b/tests/integrationv2/conftest.py
@@ -6,6 +6,7 @@ from platform import machine
 ALLPLATFORMS = set(["aarch64", "x86_64"])
 NOTNIXMARKS = set(["fix4nix"])
 
+
 def pytest_addoption(parser):
     parser.addoption("--provider-version", action="store", dest="provider-version",
                      default=None, type=str, help="Set the version of the TLS provider")
@@ -64,7 +65,7 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
     # Find the intersection of all pytest.marks and ALLPLATFORMS.
     # By default, with no platform marks, this set will be empty.
     marked_platform = ALLPLATFORMS.intersection(mark.name for mark in item.iter_markers())
-    #Get the current runtime platform
+    # Get the current runtime platform.
     platform = machine()
     # Skip this test if a platform mark was defined but doesn't match the current platform.
     if platform is not None and marked_platform and platform not in marked_platform:

--- a/tests/integrationv2/global_flags.py
+++ b/tests/integrationv2/global_flags.py
@@ -32,4 +32,7 @@ def get_flag(name, default=None):
 
 def set_flag(name, value):
     """Set the value of a flag"""
-    _flags[name] = value
+    if value is None:
+        raise TypeError(f"Value for {name} can not be None")
+    else:
+        _flags[name] = value

--- a/tests/integrationv2/pytest.ini
+++ b/tests/integrationv2/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+minversion = 7.0
+python_files = test_*.py
+markers =
+  uncollect_if(*, func): function to unselect tests from parametrization
+  aarch64: tests that should only run on aarch64
+  x86_64: tests that should only run on x86_64
+  fast: tests complete in 120 seconds or less. Future use
+  slow: tests complete in more than 120 seconds Future use
+  fix4nix: tests excluded on nix

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -66,6 +66,7 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
                 cipher.name)) in server_results.stdout
 
 
+@pytest.mark.x86_64
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [S2N, OpenSSL, GnuTLS, SSLv3Provider])

--- a/tests/integrationv2/test_ocsp.py
+++ b/tests/integrationv2/test_ocsp.py
@@ -12,6 +12,7 @@ from global_flags import get_flag, S2N_PROVIDER_VERSION
 OCSP_CERTS = [Certificates.OCSP, Certificates.OCSP_ECDSA]
 
 
+@pytest.mark.x86_64
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [S2N, OpenSSL, GnuTLS], ids=get_parameter_name)
@@ -74,6 +75,7 @@ def test_s2n_client_ocsp_response(managed_process, cipher, provider, other_provi
         assert random_bytes[1:] in server_results.stdout or random_bytes[1:] in server_results.stderr
 
 
+@pytest.mark.x86_64
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [GnuTLS, OpenSSL], ids=get_parameter_name)

--- a/tests/integrationv2/test_record_padding.py
+++ b/tests/integrationv2/test_record_padding.py
@@ -70,6 +70,7 @@ def test_nothing():
     assert True
 
 
+@pytest.mark.fix4nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL])
@@ -123,6 +124,7 @@ def test_s2n_server_handles_padded_records(managed_process, cipher, provider, cu
             cipher.name)) in server_results.stdout
 
 
+@pytest.mark.fix4nix
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL])

--- a/tests/integrationv2/test_renegotiate.py
+++ b/tests/integrationv2/test_renegotiate.py
@@ -207,6 +207,7 @@ This tests the default behavior for customers who do not enable renegotiation.
 """
 
 
+@pytest.mark.x86_64
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -235,6 +236,7 @@ Renegotiation request rejected by s2n-tls client.
 """
 
 
+@pytest.mark.x86_64
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -260,6 +262,7 @@ Renegotiation request accepted by s2n-tls client.
 """
 
 
+@pytest.mark.x86_64
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -292,6 +295,7 @@ but does require client auth during the second handshake.
 """
 
 
+@pytest.mark.x86_64
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -341,6 +345,7 @@ The s2n-tls client successfully reads ApplicationData during the renegotiation h
 """
 
 
+@pytest.mark.x86_64
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)

--- a/tests/integrationv2/test_signature_algorithms.py
+++ b/tests/integrationv2/test_signature_algorithms.py
@@ -68,6 +68,7 @@ def skip_ciphers(*args, **kwargs):
     return invalid_test_parameters(*args, **kwargs)
 
 
+@pytest.mark.fix4nix
 @pytest.mark.uncollect_if(func=skip_ciphers)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL, GnuTLS])
@@ -124,6 +125,7 @@ def test_s2n_server_signature_algorithms(managed_process, cipher, provider, othe
         assert random_bytes in results.stdout
 
 
+@pytest.mark.fix4nix
 @pytest.mark.uncollect_if(func=skip_ciphers)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL, GnuTLS])

--- a/tests/integrationv2/test_version_negotiation.py
+++ b/tests/integrationv2/test_version_negotiation.py
@@ -29,6 +29,7 @@ def invalid_version_negotiation_test_parameters(*args, **kwargs):
     return invalid_test_parameters(*args, **kwargs)
 
 
+@pytest.mark.x86_64
 @pytest.mark.uncollect_if(func=invalid_version_negotiation_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -92,6 +93,7 @@ def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, certificate
         ])
 
 
+@pytest.mark.x86_64
 @pytest.mark.uncollect_if(func=invalid_version_negotiation_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)


### PR DESCRIPTION
### Resolved issues:

Partial for https://github.com/aws/s2n-tls/issues/3841

### Description of changes: 

Adds a pytest mark to allow skipping tests based on current platform (x86 or arm) and if we detect a `nix devshell`.

Marks added to skip certain tests based on local testing.

### Call-outs:

The mark `uncollect_if()` was moved from conftest.py to the pytest.ini.

While pytest.ini is normally at the root of the project, we've historically passed all of the arguments into pytest instead of using a configuration file.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? Locally.

Is this a refactor change? No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
