### PR TITLE
Add unit test for setting server cipher preferences in the CH callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ build/
 result
 result-*
 *.class
+Session.vim

--- a/tests/unit/s2n_self_talk_client_hello_cb_test.c
+++ b/tests/unit/s2n_self_talk_client_hello_cb_test.c
@@ -470,12 +470,12 @@ int run_test_reject_handshake_ch_cb(s2n_client_hello_cb_mode cb_mode, struct cli
 
 int run_test_set_cipher_preferences_ch_cb(s2n_client_hello_cb_mode cb_mode, struct client_hello_context *ch_ctx)
 {
-    struct s2n_test_io_pair io_pair;
+    struct s2n_test_io_pair io_pair = { 0 };
     struct s2n_config *config = NULL;
     struct s2n_connection *conn = NULL;
     pid_t pid = 0;
     struct s2n_cert_chain_and_key *chain_and_key = NULL;
-    uint8_t negotiated_cipher_actual_iana[S2N_TLS_CIPHER_SUITE_LEN];
+    uint8_t negotiated_cipher_actual_iana[S2N_TLS_CIPHER_SUITE_LEN] = { 0 };
 
     EXPECT_SUCCESS(start_client_conn(&io_pair, &pid, 0, 0));
 


### PR DESCRIPTION
### Description of changes: 

This adds a new unit test for changing server cipher preferences in the ClientHello callback

From the documentation of [s2n_client_hello_fn](https://aws.github.io/s2n-tls/doxygen/s2n_8h.html#a0451dcbf88fdf09f36a82cab4d25d44e):
>The callback function takes a s2n-tls connection as input, which receives the ClientHello and the context previously provided in s2n_config_set_client_hello_cb. The callback can access any ClientHello information from the connection and use the s2n_connection_set_config call to change the config of the connection.

Within this callback, are calls to `s2n_connection_set_cipher_preferences` also valid? I found no documentation or unit test that confirms this, so I'm contributing one under the premise that this is the case.

### Testing

I confirmed that removing the `s2n_connection_set_cipher_preferences()` call from the test callback fails the new unit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.