### PR TITLE
feat(bindings): Add API to check for resumption

### DIFF
--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -1046,7 +1046,7 @@ impl Connection {
     }
 
     /// Determines whether the connection was resumed from an earlier handshake.
-    pub fn was_resumed(&self) -> bool {
+    pub fn resumed(&self) -> bool {
         unsafe { s2n_connection_is_session_resumed(self.connection.as_ptr()) == 1 }
     }
 }

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -1044,6 +1044,11 @@ impl Connection {
             Ok(())
         }
     }
+
+    /// Determines whether the connection was resumed from an earlier handshake.
+    pub fn was_resumed(&self) -> bool {
+        unsafe { s2n_connection_is_session_resumed(self.connection.as_ptr()) == 1 }
+    }
 }
 
 struct Context {

--- a/bindings/rust/s2n-tls/src/testing/resumption.rs
+++ b/bindings/rust/s2n-tls/src/testing/resumption.rs
@@ -109,7 +109,7 @@ mod tests {
         let client = pair.client.0.connection();
 
         // Check connection was full handshake and a session ticket was included
-        assert!(!client.was_resumed());
+        assert!(!client.resumed());
         validate_session_ticket(client)?;
 
         // create and configure a client/server connection again
@@ -135,7 +135,7 @@ mod tests {
         let server = pair.server.0.connection();
 
         // Check new connection was resumed
-        assert!(client.was_resumed());
+        assert!(client.resumed());
         // validate that a ticket is available
         validate_session_ticket(client)?;
         validate_session_ticket(server)?;
@@ -192,7 +192,7 @@ mod tests {
 
         let client = pair.client.0.connection();
         // Check connection was full handshake
-        assert!(!client.was_resumed());
+        assert!(!client.resumed());
         // validate that a ticket is available
         validate_session_ticket(client)?;
 
@@ -221,7 +221,7 @@ mod tests {
 
         let client = pair.client.0.connection();
         // Check new connection was resumed
-        assert!(client.was_resumed());
+        assert!(client.resumed());
         // validate that a ticket is available
         validate_session_ticket(client)?;
         Ok(())

--- a/bindings/rust/s2n-tls/src/testing/resumption.rs
+++ b/bindings/rust/s2n-tls/src/testing/resumption.rs
@@ -109,10 +109,7 @@ mod tests {
         let client = pair.client.0.connection();
 
         // Check connection was full handshake and a session ticket was included
-        assert_eq!(
-            client.handshake_type()?,
-            "NEGOTIATED|FULL_HANDSHAKE|TLS12_PERFECT_FORWARD_SECRECY|WITH_SESSION_TICKET"
-        );
+        assert!(!client.was_resumed());
         validate_session_ticket(client)?;
 
         // create and configure a client/server connection again
@@ -138,7 +135,7 @@ mod tests {
         let server = pair.server.0.connection();
 
         // Check new connection was resumed
-        assert_eq!(client.handshake_type()?, "NEGOTIATED");
+        assert!(client.was_resumed());
         // validate that a ticket is available
         validate_session_ticket(client)?;
         validate_session_ticket(server)?;
@@ -195,10 +192,7 @@ mod tests {
 
         let client = pair.client.0.connection();
         // Check connection was full handshake
-        assert_eq!(
-            client.handshake_type()?,
-            "NEGOTIATED|FULL_HANDSHAKE|MIDDLEBOX_COMPAT"
-        );
+        assert!(!client.was_resumed());
         // validate that a ticket is available
         validate_session_ticket(client)?;
 
@@ -227,7 +221,7 @@ mod tests {
 
         let client = pair.client.0.connection();
         // Check new connection was resumed
-        assert_eq!(client.handshake_type()?, "NEGOTIATED|MIDDLEBOX_COMPAT");
+        assert!(client.was_resumed());
         // validate that a ticket is available
         validate_session_ticket(client)?;
         Ok(())


### PR DESCRIPTION
### Resolved issues:

Resolves https://github.com/aws/s2n-tls/issues/4263

### Description of changes: 

Adds a new API to the rust bindings that corresponds to `s2n_connection_is_session_resumed()`, which determines whether the connection was resumed.

### Call-outs:

I changed the API name to be past tense, since the handshake would have already occurred when this API is called. But let me know if you think `is_resumed()` would be better, or if there's another name that would be better.

### Testing:

I updated the session resumption tests to use this API to check for resumption and the absence of resumption, and the tests succeed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
