### PR TITLE
DRAFT: Trying to repro flaky tests outside of nix

### DIFF
--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -19,7 +19,8 @@ deps =
 commands =
     pytest -x \
         -n=2 \
-        --reruns=2 \
+        --reruns=0 \
+        --maxfail=1 \
         --cache-clear \
         -rpfsq \
         --durations=10 \


### PR DESCRIPTION
### Description of changes: 

The retry flag for pytest allows retries outside of nix; see if bringing the retry count to 0 also causes the integ tests not running under nix to become flaky.

### Call-outs:

Spot checking, pytest isn't printing a retry count, unclear if this is due to an older pytest or something else.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
