### PR TITLE
bug(nix:corretto): use autoPatchelfHook on all systems and ignore als…

### DIFF
--- a/nix/amazon-corretto-17.nix
+++ b/nix/amazon-corretto-17.nix
@@ -34,13 +34,8 @@ pkgs.stdenv.mkDerivation rec {
   # See: https://github.com/NixOS/patchelf/issues/10
   dontStrip = 1;
 
-  nativeBuildInputs = if (pkgs.stdenv.system == "x86_64-linux") then [
-    pkgs.autoPatchelfHook
-    pkgs.alsa-lib
-  ] else
-    [ ];
-
   buildInputs = with pkgs; [
+    autoPatchelfHook
     cpio
     cups
     file
@@ -68,6 +63,12 @@ pkgs.stdenv.mkDerivation rec {
     xorg.libXxf86vm
     zip
     zlib
+  ];
+
+  # Arm doesn't have this, and because Corretto was built elsewhere, we need
+  # to change the interpreter: https://github.com/NixOS/patchelf
+  autoPatchelfIgnoreMissingDeps = [
+    "libasound.so.2"
   ];
 
   buildPhase = ''

--- a/nix/amazon-corretto-17.nix
+++ b/nix/amazon-corretto-17.nix
@@ -67,9 +67,7 @@ pkgs.stdenv.mkDerivation rec {
 
   # Arm doesn't have this, and because Corretto was built elsewhere, we need
   # to change the interpreter: https://github.com/NixOS/patchelf
-  autoPatchelfIgnoreMissingDeps = [
-    "libasound.so.2"
-  ];
+  autoPatchelfIgnoreMissingDeps = [ "libasound.so.2" ];
 
   buildPhase = ''
     echo "Corretto is already built"


### PR DESCRIPTION
### Resolved issues:

Resolves #4560

### Description of changes: 

Revert my previous naive approach to getting Corretto installed on arm and instead tell autoPatchelf to ignore the sound library dependency.

### Call-outs:

This only affects arm, which isn't running tests using Corretto in CI, yet.

An ad-hoc example of the happy_path test on arm is [here](https://us-east-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/Integv2NixBatchBF1FB83F-7tcZOiMDWPH0/build/Integv2NixBatchBF1FB83F-7tcZOiMDWPH0%3A4ca72a8a-c74c-4358-a6d7-748c0f733bf2?region=us-east-2) and while it should fail due to no retries, you can see a few java providers passing in the first few screens of test output.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? locally

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
