### PR TITLE
refactor(api): make psk apis const

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2836,7 +2836,7 @@ S2N_API int s2n_psk_set_hmac(struct s2n_psk *psk, s2n_psk_hmac hmac);
  * @param conn A pointer to the s2n_connection object that contains the list of PSKs supported.
  * @param psk A pointer to the `s2n_psk` object to be appended to the list of PSKs on the s2n connection.
  */
-S2N_API int s2n_connection_append_psk(struct s2n_connection *conn, struct s2n_psk *psk);
+S2N_API int s2n_connection_append_psk(struct s2n_connection *conn, const struct s2n_psk *psk);
 
 /**
  * The list of PSK modes supported by s2n-tls for TLS versions >= TLS1.3.
@@ -2879,7 +2879,7 @@ S2N_API int s2n_connection_set_psk_mode(struct s2n_connection *conn, s2n_psk_mod
  * @param conn A pointer to the s2n_connection object that successfully negotiated a PSK connection.
  * @param identity_length The length of the negotiated PSK identity. 
  */
-S2N_API int s2n_connection_get_negotiated_psk_identity_length(struct s2n_connection *conn, uint16_t *identity_length);
+S2N_API int s2n_connection_get_negotiated_psk_identity_length(const struct s2n_connection *conn, uint16_t *identity_length);
 
 /**
  * Gets the negotiated PSK identity from the s2n connection object. 
@@ -2897,7 +2897,7 @@ S2N_API int s2n_connection_get_negotiated_psk_identity_length(struct s2n_connect
  * @param max_identity_length The maximum length for the PSK identity. If the negotiated psk_identity length is 
  * greater than this `max_identity_length` value an error will be returned.
  */
-S2N_API int s2n_connection_get_negotiated_psk_identity(struct s2n_connection *conn, uint8_t *identity, uint16_t max_identity_length);
+S2N_API int s2n_connection_get_negotiated_psk_identity(const struct s2n_connection *conn, uint8_t *identity, uint16_t max_identity_length);
 
 struct s2n_offered_psk;
 
@@ -2927,7 +2927,7 @@ S2N_API int s2n_offered_psk_free(struct s2n_offered_psk **psk);
  * @param identity The PSK identity being obtained.
  * @param size The length of the PSK identity being obtained.
  */
-S2N_API int s2n_offered_psk_get_identity(struct s2n_offered_psk *psk, uint8_t **identity, uint16_t *size);
+S2N_API int s2n_offered_psk_get_identity(const struct s2n_offered_psk *psk, uint8_t **identity, uint16_t *size);
 
 struct s2n_offered_psk_list;
 
@@ -2943,7 +2943,7 @@ struct s2n_offered_psk_list;
  * @param psk_list A pointer to the offered PSK list being read.
  * @returns bool A boolean value representing whether an offered psk object is present next in line in the offered PSK list.
  */
-S2N_API bool s2n_offered_psk_list_has_next(struct s2n_offered_psk_list *psk_list);
+S2N_API bool s2n_offered_psk_list_has_next(const struct s2n_offered_psk_list *psk_list);
 
 /**
  * Obtains the next offered PSK object from the list of offered PSKs. Use `s2n_offered_psk_list_has_next` 

--- a/tls/s2n_early_data.c
+++ b/tls/s2n_early_data.c
@@ -251,7 +251,7 @@ int s2n_psk_set_early_data_context(struct s2n_psk *psk, const uint8_t *context, 
     return S2N_SUCCESS;
 }
 
-S2N_RESULT s2n_early_data_config_clone(struct s2n_psk *new_psk, struct s2n_early_data_config *old_config)
+S2N_RESULT s2n_early_data_config_clone(struct s2n_psk *new_psk, const struct s2n_early_data_config *old_config)
 {
     RESULT_ENSURE_REF(old_config);
     RESULT_ENSURE_REF(new_psk);

--- a/tls/s2n_early_data.h
+++ b/tls/s2n_early_data.h
@@ -42,7 +42,7 @@ struct s2n_early_data_config {
     struct s2n_blob context;
 };
 S2N_CLEANUP_RESULT s2n_early_data_config_free(struct s2n_early_data_config *config);
-S2N_RESULT s2n_early_data_config_clone(struct s2n_psk *new_psk, struct s2n_early_data_config *old_config);
+S2N_RESULT s2n_early_data_config_clone(struct s2n_psk *new_psk, const struct s2n_early_data_config *old_config);
 
 struct s2n_offered_early_data {
     struct s2n_connection *conn;

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -74,7 +74,7 @@ int s2n_psk_set_secret(struct s2n_psk *psk, const uint8_t *secret, uint16_t secr
     return S2N_SUCCESS;
 }
 
-S2N_RESULT s2n_psk_clone(struct s2n_psk *new_psk, struct s2n_psk *original_psk)
+S2N_RESULT s2n_psk_clone(struct s2n_psk *new_psk, const struct s2n_psk *original_psk)
 {
     if (original_psk == NULL) {
         return S2N_RESULT_OK;
@@ -131,7 +131,7 @@ S2N_RESULT s2n_psk_parameters_init(struct s2n_psk_parameters *params)
     return S2N_RESULT_OK;
 }
 
-static S2N_RESULT s2n_psk_offered_psk_size(struct s2n_psk *psk, uint32_t *size)
+static S2N_RESULT s2n_psk_offered_psk_size(const struct s2n_psk *psk, uint32_t *size)
 {
     *size = sizeof(uint16_t)   /* identity size */
             + sizeof(uint32_t) /* obfuscated ticket age */
@@ -196,7 +196,7 @@ S2N_CLEANUP_RESULT s2n_psk_parameters_wipe_secrets(struct s2n_psk_parameters *pa
     return S2N_RESULT_OK;
 }
 
-bool s2n_offered_psk_list_has_next(struct s2n_offered_psk_list *psk_list)
+bool s2n_offered_psk_list_has_next(const struct s2n_offered_psk_list *psk_list)
 {
     return psk_list != NULL && s2n_stuffer_data_available(&psk_list->wire_data) > 0;
 }
@@ -360,7 +360,7 @@ int s2n_offered_psk_free(struct s2n_offered_psk **psk)
     return s2n_free_object((uint8_t **) psk, sizeof(struct s2n_offered_psk));
 }
 
-int s2n_offered_psk_get_identity(struct s2n_offered_psk *psk, uint8_t **identity, uint16_t *size)
+int s2n_offered_psk_get_identity(const struct s2n_offered_psk *psk, uint8_t **identity, uint16_t *size)
 {
     POSIX_ENSURE_REF(psk);
     POSIX_ENSURE_REF(identity);
@@ -583,7 +583,7 @@ S2N_RESULT s2n_connection_set_psk_type(struct s2n_connection *conn, s2n_psk_type
     return S2N_RESULT_OK;
 }
 
-int s2n_connection_append_psk(struct s2n_connection *conn, struct s2n_psk *input_psk)
+int s2n_connection_append_psk(struct s2n_connection *conn, const struct s2n_psk *input_psk)
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(input_psk);
@@ -648,7 +648,7 @@ int s2n_connection_set_psk_mode(struct s2n_connection *conn, s2n_psk_mode mode)
     return S2N_SUCCESS;
 }
 
-int s2n_connection_get_negotiated_psk_identity_length(struct s2n_connection *conn, uint16_t *identity_length)
+int s2n_connection_get_negotiated_psk_identity_length(const struct s2n_connection *conn, uint16_t *identity_length)
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(identity_length);
@@ -664,7 +664,7 @@ int s2n_connection_get_negotiated_psk_identity_length(struct s2n_connection *con
     return S2N_SUCCESS;
 }
 
-int s2n_connection_get_negotiated_psk_identity(struct s2n_connection *conn, uint8_t *identity,
+int s2n_connection_get_negotiated_psk_identity(const struct s2n_connection *conn, uint8_t *identity,
         uint16_t max_identity_length)
 {
     POSIX_ENSURE_REF(conn);

--- a/tls/s2n_psk.h
+++ b/tls/s2n_psk.h
@@ -52,7 +52,7 @@ struct s2n_psk {
 };
 S2N_RESULT s2n_psk_init(struct s2n_psk *psk, s2n_psk_type type);
 S2N_CLEANUP_RESULT s2n_psk_wipe(struct s2n_psk *psk);
-S2N_RESULT s2n_psk_clone(struct s2n_psk *new_psk, struct s2n_psk *original_psk);
+S2N_RESULT s2n_psk_clone(struct s2n_psk *new_psk, const struct s2n_psk *original_psk);
 
 struct s2n_psk_parameters {
     s2n_psk_type type;


### PR DESCRIPTION
### Resolved issues:

Relevant to #4140 

### Description of changes: 
When sketching out PSK bindings for Rust, there were a number of dangerous "The API takes in `*mut` but I'm going to assume that we really meant `*const`" assumptions.

This PR updates the APIs to be actually const where possible. Some of them were not simply fixable due to interactions with stuffers.

### Call-outs:

This is not expected to be a breaking change, because it is valid to treat a mutable pointer as a const pointer. However to my knowledge we haven't made this kind of change before, and it's unclear if customer might be doing particularly odd things that would get broken by this.

### Testing:

All tests should continue to pass. There is no semantic changes, only changes to function definitions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
