### PR TITLE
fix: Validate received signature algorithm in EVP verify

### DIFF
--- a/crypto/s2n_evp_signing.c
+++ b/crypto/s2n_evp_signing.c
@@ -104,7 +104,7 @@ static S2N_RESULT s2n_evp_signing_validate_sig_alg(const struct s2n_pkey *key, s
 
     /* Ensure that the signature algorithm type matches the key type. */
     s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
-    RESULT_GUARD(s2n_pkey_get_pkey_type(key->pkey, &pkey_type));
+    RESULT_GUARD(s2n_pkey_get_type(key->pkey, &pkey_type));
     s2n_pkey_type sig_alg_type = S2N_PKEY_TYPE_UNKNOWN;
     RESULT_GUARD(s2n_signature_algorithm_get_pkey_type(sig_alg, &sig_alg_type));
     RESULT_ENSURE(pkey_type == sig_alg_type, S2N_ERR_INVALID_SIGNATURE_ALGORITHM);

--- a/crypto/s2n_pkey.c
+++ b/crypto/s2n_pkey.c
@@ -194,7 +194,7 @@ S2N_RESULT s2n_asn1der_to_public_key_and_type(struct s2n_pkey *pub_key,
     return S2N_RESULT_OK;
 }
 
-S2N_RESULT s2n_pkey_get_pkey_type(EVP_PKEY *evp_pkey, s2n_pkey_type *pkey_type)
+S2N_RESULT s2n_pkey_get_type(EVP_PKEY *evp_pkey, s2n_pkey_type *pkey_type)
 {
     RESULT_ENSURE_REF(evp_pkey);
     RESULT_ENSURE_REF(pkey_type);
@@ -228,7 +228,7 @@ S2N_RESULT s2n_pkey_from_x509(X509 *cert, struct s2n_pkey *pub_key_out,
     DEFER_CLEANUP(EVP_PKEY *evp_public_key = X509_get_pubkey(cert), EVP_PKEY_free_pointer);
     RESULT_ENSURE(evp_public_key != NULL, S2N_ERR_DECODE_CERTIFICATE);
 
-    RESULT_GUARD(s2n_pkey_get_pkey_type(evp_public_key, pkey_type_out));
+    RESULT_GUARD(s2n_pkey_get_type(evp_public_key, pkey_type_out));
     switch (*pkey_type_out) {
         case S2N_PKEY_TYPE_RSA:
             RESULT_GUARD(s2n_rsa_pkey_init(pub_key_out));

--- a/crypto/s2n_pkey.c
+++ b/crypto/s2n_pkey.c
@@ -194,6 +194,30 @@ S2N_RESULT s2n_asn1der_to_public_key_and_type(struct s2n_pkey *pub_key,
     return S2N_RESULT_OK;
 }
 
+S2N_RESULT s2n_pkey_get_pkey_type(EVP_PKEY *evp_pkey, s2n_pkey_type *pkey_type)
+{
+    RESULT_ENSURE_REF(evp_pkey);
+    RESULT_ENSURE_REF(pkey_type);
+    *pkey_type = S2N_PKEY_TYPE_UNKNOWN;
+
+    int type = EVP_PKEY_base_id(evp_pkey);
+    switch (type) {
+        case EVP_PKEY_RSA:
+            *pkey_type = S2N_PKEY_TYPE_RSA;
+            break;
+        case EVP_PKEY_RSA_PSS:
+            *pkey_type = S2N_PKEY_TYPE_RSA_PSS;
+            break;
+        case EVP_PKEY_EC:
+            *pkey_type = S2N_PKEY_TYPE_ECDSA;
+            break;
+        default:
+            RESULT_BAIL(S2N_ERR_DECODE_CERTIFICATE);
+    }
+
+    return S2N_RESULT_OK;
+}
+
 S2N_RESULT s2n_pkey_from_x509(X509 *cert, struct s2n_pkey *pub_key_out,
         s2n_pkey_type *pkey_type_out)
 {
@@ -204,23 +228,19 @@ S2N_RESULT s2n_pkey_from_x509(X509 *cert, struct s2n_pkey *pub_key_out,
     DEFER_CLEANUP(EVP_PKEY *evp_public_key = X509_get_pubkey(cert), EVP_PKEY_free_pointer);
     RESULT_ENSURE(evp_public_key != NULL, S2N_ERR_DECODE_CERTIFICATE);
 
-    /* Check for success in decoding certificate according to type */
-    int type = EVP_PKEY_base_id(evp_public_key);
-    switch (type) {
-        case EVP_PKEY_RSA:
+    RESULT_GUARD(s2n_pkey_get_pkey_type(evp_public_key, pkey_type_out));
+    switch (*pkey_type_out) {
+        case S2N_PKEY_TYPE_RSA:
             RESULT_GUARD(s2n_rsa_pkey_init(pub_key_out));
             RESULT_GUARD(s2n_evp_pkey_to_rsa_public_key(&pub_key_out->key.rsa_key, evp_public_key));
-            *pkey_type_out = S2N_PKEY_TYPE_RSA;
             break;
-        case EVP_PKEY_RSA_PSS:
+        case S2N_PKEY_TYPE_RSA_PSS:
             RESULT_GUARD(s2n_rsa_pss_pkey_init(pub_key_out));
             RESULT_GUARD(s2n_evp_pkey_to_rsa_pss_public_key(&pub_key_out->key.rsa_key, evp_public_key));
-            *pkey_type_out = S2N_PKEY_TYPE_RSA_PSS;
             break;
-        case EVP_PKEY_EC:
+        case S2N_PKEY_TYPE_ECDSA:
             RESULT_GUARD(s2n_ecdsa_pkey_init(pub_key_out));
             RESULT_GUARD(s2n_evp_pkey_to_ecdsa_public_key(&pub_key_out->key.ecdsa_key, evp_public_key));
-            *pkey_type_out = S2N_PKEY_TYPE_ECDSA;
             break;
         default:
             RESULT_BAIL(S2N_ERR_DECODE_CERTIFICATE);

--- a/crypto/s2n_pkey.h
+++ b/crypto/s2n_pkey.h
@@ -71,6 +71,6 @@ int s2n_pkey_free(struct s2n_pkey *pkey);
 
 S2N_RESULT s2n_asn1der_to_private_key(struct s2n_pkey *priv_key, struct s2n_blob *asn1der, int type_hint);
 S2N_RESULT s2n_asn1der_to_public_key_and_type(struct s2n_pkey *pub_key, s2n_pkey_type *pkey_type, struct s2n_blob *asn1der);
-S2N_RESULT s2n_pkey_get_pkey_type(EVP_PKEY *evp_pkey, s2n_pkey_type *pkey_type);
+S2N_RESULT s2n_pkey_get_type(EVP_PKEY *evp_pkey, s2n_pkey_type *pkey_type);
 S2N_RESULT s2n_pkey_from_x509(X509 *cert, struct s2n_pkey *pub_key_out,
         s2n_pkey_type *pkey_type_out);

--- a/crypto/s2n_pkey.h
+++ b/crypto/s2n_pkey.h
@@ -71,5 +71,6 @@ int s2n_pkey_free(struct s2n_pkey *pkey);
 
 S2N_RESULT s2n_asn1der_to_private_key(struct s2n_pkey *priv_key, struct s2n_blob *asn1der, int type_hint);
 S2N_RESULT s2n_asn1der_to_public_key_and_type(struct s2n_pkey *pub_key, s2n_pkey_type *pkey_type, struct s2n_blob *asn1der);
+S2N_RESULT s2n_pkey_get_pkey_type(EVP_PKEY *evp_pkey, s2n_pkey_type *pkey_type);
 S2N_RESULT s2n_pkey_from_x509(X509 *cert, struct s2n_pkey *pub_key_out,
         s2n_pkey_type *pkey_type_out);

--- a/tests/unit/s2n_rsa_pss_rsae_test.c
+++ b/tests/unit/s2n_rsa_pss_rsae_test.c
@@ -241,11 +241,11 @@ int main(int argc, char **argv)
         /* Test: If they share the same RSA key,
          * an RSA cert and an RSA_PSS cert are equivalent for PSS signatures. */
         {
-            DEFER_CLEANUP(struct s2n_pkey rsa_public_key_shared = { 0 }, s2n_pkey_free);
-            s2n_pkey_type rsa_public_key_shared_type = S2N_PKEY_TYPE_UNKNOWN;
-            EXPECT_OK(s2n_asn1der_to_public_key_and_type(&rsa_public_key_shared, &rsa_public_key_shared_type,
+            DEFER_CLEANUP(struct s2n_pkey rsa_public_key_as_pss = { 0 }, s2n_pkey_free);
+            s2n_pkey_type rsa_public_key_as_pss_type = S2N_PKEY_TYPE_UNKNOWN;
+            EXPECT_OK(s2n_asn1der_to_public_key_and_type(&rsa_public_key_as_pss, &rsa_public_key_as_pss_type,
                     &rsa_cert_chain->cert_chain->head->raw));
-            EXPECT_EQUAL(rsa_public_key_shared_type, S2N_PKEY_TYPE_RSA);
+            EXPECT_EQUAL(rsa_public_key_as_pss_type, S2N_PKEY_TYPE_RSA);
 
             DEFER_CLEANUP(struct s2n_pkey rsa_pss_public_key_shared = { 0 }, s2n_pkey_free);
             s2n_pkey_type rsa_pss_pkey_type_shared = S2N_PKEY_TYPE_UNKNOWN;
@@ -255,12 +255,16 @@ int main(int argc, char **argv)
 
             /* Set the keys equal.
              *
-             * EVP_PKEY_set1_RSA sets the EVP key type to RSA, even if the set key is RSA_PSS. To
-             * ensure that the RSA_PSS EVP key type remains set to RSA_PSS, the RSA key is
-             * overridden instead of the RSA_PSS key, since its key type is RSA anyway.
+             * When EVP signing APIs are enabled, s2n-tls validates the signature algorithm type
+             * against the EVP pkey type, so the EVP pkey type must be RSA_PSS in order to use the
+             * RSA_PSS signature algorithm. However, EVP_PKEY_set1_RSA sets the EVP pkey type to
+             * RSA, even if the EVP pkey type was RSA_PSS (there is no EVP_PKEY_set1_RSA_PSS API).
+             *
+             * To ensure that the RSA_PSS EVP pkey type remains set to RSA_PSS, the RSA key is
+             * overridden instead of the RSA_PSS key, since its pkey type is RSA anyway.
              */
             RSA *rsa_key_copy = EVP_PKEY_get1_RSA(rsa_pss_public_key_shared.pkey);
-            POSIX_GUARD_OSSL(EVP_PKEY_set1_RSA(rsa_public_key_shared.pkey, rsa_key_copy), S2N_ERR_KEY_INIT);
+            POSIX_GUARD_OSSL(EVP_PKEY_set1_RSA(rsa_public_key_as_pss.pkey, rsa_key_copy), S2N_ERR_KEY_INIT);
             RSA_free(rsa_key_copy);
 
             /* RSA signed with PSS, RSA_PSS verified with PSS */
@@ -268,7 +272,7 @@ int main(int argc, char **argv)
                 hash_state_new(sign_hash, random_msg);
                 hash_state_new(verify_hash, random_msg);
 
-                EXPECT_SUCCESS(rsa_public_key_shared.sign(rsa_pss_cert_chain->private_key, S2N_SIGNATURE_RSA_PSS_RSAE,
+                EXPECT_SUCCESS(rsa_public_key_as_pss.sign(rsa_pss_cert_chain->private_key, S2N_SIGNATURE_RSA_PSS_RSAE,
                         &sign_hash, &result));
                 EXPECT_SUCCESS(rsa_pss_public_key_shared.verify(&rsa_pss_public_key_shared, S2N_SIGNATURE_RSA_PSS_PSS,
                         &verify_hash, &result));
@@ -281,7 +285,7 @@ int main(int argc, char **argv)
 
                 EXPECT_SUCCESS(rsa_pss_public_key_shared.sign(rsa_pss_cert_chain->private_key, S2N_SIGNATURE_RSA_PSS_PSS,
                         &sign_hash, &result));
-                EXPECT_SUCCESS(rsa_public_key_shared.verify(&rsa_public_key_shared, S2N_SIGNATURE_RSA_PSS_RSAE,
+                EXPECT_SUCCESS(rsa_public_key_as_pss.verify(&rsa_public_key_as_pss, S2N_SIGNATURE_RSA_PSS_RSAE,
                         &verify_hash, &result));
             };
         };

--- a/tests/unit/s2n_rsa_pss_rsae_test.c
+++ b/tests/unit/s2n_rsa_pss_rsae_test.c
@@ -247,9 +247,9 @@ int main(int argc, char **argv)
                     &rsa_cert_chain->cert_chain->head->raw));
             EXPECT_EQUAL(rsa_public_key_as_pss_type, S2N_PKEY_TYPE_RSA);
 
-            DEFER_CLEANUP(struct s2n_pkey rsa_pss_public_key_shared = { 0 }, s2n_pkey_free);
+            DEFER_CLEANUP(struct s2n_pkey rsa_pss_public_key = { 0 }, s2n_pkey_free);
             s2n_pkey_type rsa_pss_pkey_type_shared = S2N_PKEY_TYPE_UNKNOWN;
-            EXPECT_OK(s2n_asn1der_to_public_key_and_type(&rsa_pss_public_key_shared, &rsa_pss_pkey_type_shared,
+            EXPECT_OK(s2n_asn1der_to_public_key_and_type(&rsa_pss_public_key, &rsa_pss_pkey_type_shared,
                     &rsa_pss_cert_chain->cert_chain->head->raw));
             EXPECT_EQUAL(rsa_pss_pkey_type_shared, S2N_PKEY_TYPE_RSA_PSS);
 
@@ -263,7 +263,7 @@ int main(int argc, char **argv)
              * To ensure that the RSA_PSS EVP pkey type remains set to RSA_PSS, the RSA key is
              * overridden instead of the RSA_PSS key, since its pkey type is RSA anyway.
              */
-            RSA *rsa_key_copy = EVP_PKEY_get1_RSA(rsa_pss_public_key_shared.pkey);
+            RSA *rsa_key_copy = EVP_PKEY_get1_RSA(rsa_pss_public_key.pkey);
             POSIX_GUARD_OSSL(EVP_PKEY_set1_RSA(rsa_public_key_as_pss.pkey, rsa_key_copy), S2N_ERR_KEY_INIT);
             RSA_free(rsa_key_copy);
 
@@ -274,7 +274,7 @@ int main(int argc, char **argv)
 
                 EXPECT_SUCCESS(rsa_public_key_as_pss.sign(rsa_pss_cert_chain->private_key, S2N_SIGNATURE_RSA_PSS_RSAE,
                         &sign_hash, &result));
-                EXPECT_SUCCESS(rsa_pss_public_key_shared.verify(&rsa_pss_public_key_shared, S2N_SIGNATURE_RSA_PSS_PSS,
+                EXPECT_SUCCESS(rsa_pss_public_key.verify(&rsa_pss_public_key, S2N_SIGNATURE_RSA_PSS_PSS,
                         &verify_hash, &result));
             };
 
@@ -283,7 +283,7 @@ int main(int argc, char **argv)
                 hash_state_new(sign_hash, random_msg);
                 hash_state_new(verify_hash, random_msg);
 
-                EXPECT_SUCCESS(rsa_pss_public_key_shared.sign(rsa_pss_cert_chain->private_key, S2N_SIGNATURE_RSA_PSS_PSS,
+                EXPECT_SUCCESS(rsa_pss_public_key.sign(rsa_pss_cert_chain->private_key, S2N_SIGNATURE_RSA_PSS_PSS,
                         &sign_hash, &result));
                 EXPECT_SUCCESS(rsa_public_key_as_pss.verify(&rsa_public_key_as_pss, S2N_SIGNATURE_RSA_PSS_RSAE,
                         &verify_hash, &result));

--- a/tests/unit/s2n_tls13_cert_verify_test.c
+++ b/tests/unit/s2n_tls13_cert_verify_test.c
@@ -274,9 +274,10 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all_tls13"));
             EXPECT_SUCCESS(s2n_config_disable_x509_verification(config));
 
-            /* The server only supports the single test certificate, and will only use the
-             * corresponding signature algorithm to sign the CertificateVerify message, regardless
-             * of the client's advertised signature schemes.
+            /* The server only supports the single test certificate. Due to the fallback logic in
+             * the s2n-tls server, the signature algorithm corresponding with the test certificate
+             * will always be used to sign the CertificateVerify message, regardless of the
+             * client's advertised signature schemes.
              */
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
 

--- a/tests/unit/s2n_tls13_cert_verify_test.c
+++ b/tests/unit/s2n_tls13_cert_verify_test.c
@@ -32,7 +32,6 @@ struct s2n_tls13_cert_verify_test {
     const char *const key_file;
     const struct s2n_signature_scheme *sig_scheme;
     const struct s2n_signature_scheme *with_wrong_hash;
-    const struct s2n_signature_scheme *with_wrong_sig_alg;
 };
 
 const struct s2n_tls13_cert_verify_test test_cases[] = {
@@ -41,7 +40,6 @@ const struct s2n_tls13_cert_verify_test test_cases[] = {
             .key_file = S2N_ECDSA_P256_PKCS1_KEY,
             .sig_scheme = &s2n_ecdsa_sha256,
             .with_wrong_hash = &s2n_ecdsa_sha384,
-            .with_wrong_sig_alg = &s2n_rsa_pss_pss_sha256,
     },
 #if RSA_PSS_CERTS_SUPPORTED
     {
@@ -49,7 +47,6 @@ const struct s2n_tls13_cert_verify_test test_cases[] = {
             .key_file = S2N_RSA_PSS_2048_SHA256_LEAF_KEY,
             .sig_scheme = &s2n_rsa_pss_pss_sha256,
             .with_wrong_hash = &s2n_rsa_pss_pss_sha384,
-            .with_wrong_sig_alg = &s2n_ecdsa_sha256,
     },
 #endif
 };
@@ -114,7 +111,6 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
     EXPECT_NOT_NULL(config);
     EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20200207"));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
-    EXPECT_SUCCESS(s2n_config_disable_x509_verification(config));
 
     /* Initialize a certificate */
     DEFER_CLEANUP(struct s2n_stuffer certificate_in = { 0 }, s2n_stuffer_free);
@@ -221,86 +217,6 @@ int run_tests(const struct s2n_tls13_cert_verify_test *test_case, s2n_mode verif
         EXPECT_FAILURE_WITH_ERRNO(s2n_tls13_cert_verify_recv(verifying_conn), S2N_ERR_VERIFY_SIGNATURE);
     };
 
-    /* Self-talk: Ensure that the signature algorithm used to sign the CertificateVerify message
-     * is validated against the certificate type
-     */
-    if (verifier_mode == S2N_CLIENT) {
-        const struct s2n_signature_scheme *test_sig_schemes[] = {
-            test_case->sig_scheme,
-            test_case->with_wrong_sig_alg,
-        };
-
-        for (size_t sig_idx = 0; sig_idx < s2n_array_len(test_sig_schemes); sig_idx++) {
-            DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
-                    s2n_connection_ptr_free);
-            EXPECT_NOT_NULL(server_conn);
-            EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
-            EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-
-            DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
-                    s2n_connection_ptr_free);
-            EXPECT_NOT_NULL(client_conn);
-            EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
-            EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
-
-            /* The server will sign the CertificateVerify message with the signature and hash
-             * algorithms corresponding with its certificate, regardless of the client's
-             * supported signature algorithms.
-             *
-             * The client only supports the single test signature scheme, which allows for the
-             * server to sign the CertificateVerify message with a signature algorithm that isn't
-             * supported by the client.
-             */
-            const struct s2n_signature_scheme *client_advertised_sig_scheme = test_sig_schemes[sig_idx];
-            struct s2n_signature_preferences test_sig_preferences = {
-                .count = 1,
-                .signature_schemes = &client_advertised_sig_scheme,
-            };
-            struct s2n_security_policy client_policy = security_policy_test_all_tls13;
-            client_policy.signature_preferences = &test_sig_preferences;
-            client_conn->security_policy_override = &client_policy;
-
-            struct s2n_test_io_pair io_pair = { 0 };
-            EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
-            EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
-
-            /* Send the CertificateVerify message. */
-            EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn, SERVER_CERT_VERIFY));
-            EXPECT_SUCCESS(s2n_stuffer_rewrite(&server_conn->handshake.io));
-            EXPECT_SUCCESS(s2n_tls13_cert_verify_send(server_conn));
-
-            /* Check that the expected signature algorithm was used by the server. */
-            EXPECT_EQUAL(server_conn->handshake_params.server_cert_sig_scheme, test_case->sig_scheme);
-
-            /* Overwrite the SignatureScheme field of the CertificateVerify message to lie to the
-             * client about which signature algorithm was used to sign the signature content. This
-             * will trick the client into always thinking its advertised signature algorithm was
-             * used.
-             */
-            struct s2n_stuffer cert_verify_stuffer = server_conn->handshake.io;
-            EXPECT_SUCCESS(s2n_stuffer_rewrite(&cert_verify_stuffer));
-            EXPECT_SUCCESS(s2n_stuffer_write_uint16(&cert_verify_stuffer, client_advertised_sig_scheme->iana_value));
-
-            EXPECT_SUCCESS(s2n_stuffer_wipe(&client_conn->handshake.io));
-            EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io,
-                    s2n_stuffer_data_available(&server_conn->handshake.io)));
-
-            int ret = s2n_tls13_cert_verify_recv(client_conn);
-
-            if (client_advertised_sig_scheme == test_case->sig_scheme) {
-                /* If the client's advertised signature scheme matches what the server actually
-                 * used to sign the CertificateVerify message, validation should succeed.
-                 */
-                EXPECT_SUCCESS(ret);
-            } else {
-                /* Otherwise, the client should observe that the indicated signature algorithm from
-                 * the server doesn't match the certificate type, and the connection should fail.
-                 */
-                EXPECT_FAILURE_WITH_ERRNO(ret, S2N_ERR_INVALID_SIGNATURE_ALGORITHM);
-            }
-        }
-    }
-
     return 0;
 }
 
@@ -316,6 +232,122 @@ int main(int argc, char **argv)
 
         /* Run all tests for client sending and server receiving/verifying cert_verify message */
         run_tests(&test_cases[i], S2N_SERVER);
+    }
+
+    /* Self-talk: Ensure that the signature algorithm used to sign the CertificateVerify message
+     * is validated against the certificate type
+     */
+    if (s2n_is_tls13_fully_supported()) {
+        struct s2n_tls13_cert_verify_test sha256_test_cases[] = {
+            {
+                    .cert_file = S2N_RSA_2048_PKCS1_CERT_CHAIN,
+                    .key_file = S2N_RSA_2048_PKCS1_KEY,
+                    .sig_scheme = &s2n_rsa_pss_rsae_sha256,
+            },
+            {
+                    .cert_file = S2N_RSA_PSS_2048_SHA256_LEAF_CERT,
+                    .key_file = S2N_RSA_PSS_2048_SHA256_LEAF_KEY,
+                    .sig_scheme = &s2n_rsa_pss_pss_sha256,
+            },
+            {
+                    .cert_file = S2N_ECDSA_P256_PKCS1_CERT_CHAIN,
+                    .key_file = S2N_ECDSA_P256_PKCS1_KEY,
+                    .sig_scheme = &s2n_ecdsa_sha256,
+            }
+        };
+
+        const struct s2n_signature_scheme *test_sha256_sig_algs[] = {
+            &s2n_rsa_pss_rsae_sha256,
+            &s2n_rsa_pss_pss_sha256,
+            &s2n_ecdsa_sha256,
+        };
+
+        for (size_t test_idx = 0; test_idx < s2n_array_len(sha256_test_cases); test_idx++) {
+            struct s2n_tls13_cert_verify_test test_case = sha256_test_cases[test_idx];
+
+            DEFER_CLEANUP(struct s2n_cert_chain_and_key *cert_chain = NULL, s2n_cert_chain_and_key_ptr_free);
+            EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&cert_chain, test_case.cert_file, test_case.key_file));
+
+            DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+            EXPECT_NOT_NULL(config);
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all_tls13"));
+            EXPECT_SUCCESS(s2n_config_disable_x509_verification(config));
+
+            /* The server only supports the single test certificate, and will only use the
+             * corresponding signature algorithm to sign the CertificateVerify message, regardless
+             * of the client's advertised signature schemes.
+             */
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, cert_chain));
+
+            for (size_t sig_alg_idx = 0; sig_alg_idx < s2n_array_len(test_sha256_sig_algs); sig_alg_idx++) {
+                DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                        s2n_connection_ptr_free);
+                EXPECT_NOT_NULL(server_conn);
+                EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
+                EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+                DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                        s2n_connection_ptr_free);
+                EXPECT_NOT_NULL(client_conn);
+                EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
+                EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+                /* The client only supports the single test signature scheme, which allows for the
+                 * server to sign the CertificateVerify message with a signature algorithm that
+                 * isn't supported by the client.
+                 */
+                const struct s2n_signature_scheme *client_advertised_sig_scheme = test_sha256_sig_algs[sig_alg_idx];
+                struct s2n_signature_preferences test_sig_preferences = {
+                    .count = 1,
+                    .signature_schemes = &client_advertised_sig_scheme,
+                };
+                struct s2n_security_policy client_policy = security_policy_test_all_tls13;
+                client_policy.signature_preferences = &test_sig_preferences;
+                client_conn->security_policy_override = &client_policy;
+
+                struct s2n_test_io_pair io_pair = { 0 };
+                EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+                EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+                /* Send the CertificateVerify message. */
+                EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
+                        SERVER_CERT_VERIFY));
+                EXPECT_SUCCESS(s2n_stuffer_rewrite(&server_conn->handshake.io));
+                EXPECT_SUCCESS(s2n_tls13_cert_verify_send(server_conn));
+
+                /* Check that the expected signature algorithm was used by the server. */
+                EXPECT_EQUAL(server_conn->handshake_params.server_cert_sig_scheme, test_case.sig_scheme);
+
+                /* Overwrite the SignatureScheme field of the CertificateVerify message to lie to the
+                 * client about which signature algorithm was used to sign the signature content. This
+                 * will trick the client into always thinking its advertised signature algorithm was
+                 * used.
+                 */
+                struct s2n_stuffer cert_verify_stuffer = server_conn->handshake.io;
+                EXPECT_SUCCESS(s2n_stuffer_rewrite(&cert_verify_stuffer));
+                EXPECT_SUCCESS(s2n_stuffer_write_uint16(&cert_verify_stuffer,
+                        client_advertised_sig_scheme->iana_value));
+
+                EXPECT_SUCCESS(s2n_stuffer_wipe(&client_conn->handshake.io));
+                EXPECT_SUCCESS(s2n_stuffer_copy(&server_conn->handshake.io, &client_conn->handshake.io,
+                        s2n_stuffer_data_available(&server_conn->handshake.io)));
+
+                int ret = s2n_tls13_cert_verify_recv(client_conn);
+
+                if (client_advertised_sig_scheme == test_case.sig_scheme) {
+                    /* If the client's advertised signature scheme matches what the server actually
+                     * used to sign the CertificateVerify message, validation should succeed.
+                     */
+                    EXPECT_SUCCESS(ret);
+                } else {
+                    /* Otherwise, the client should observe that the indicated signature algorithm
+                     * from the server doesn't match the certificate type, and the connection
+                     * should fail.
+                     */
+                    EXPECT_FAILURE_WITH_ERRNO(ret, S2N_ERR_INVALID_SIGNATURE_ALGORITHM);
+                }
+            }
+        }
     }
 
     END_TEST();

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -373,3 +373,26 @@ int s2n_recv_supported_sig_scheme_list(struct s2n_stuffer *in, struct s2n_sig_sc
 
     return 0;
 }
+
+S2N_RESULT s2n_signature_algorithm_get_pkey_type(s2n_signature_algorithm sig_alg, s2n_pkey_type *pkey_type)
+{
+    RESULT_ENSURE_REF(pkey_type);
+    *pkey_type = S2N_PKEY_TYPE_UNKNOWN;
+
+    switch (sig_alg) {
+        case S2N_SIGNATURE_RSA:
+        case S2N_SIGNATURE_RSA_PSS_RSAE:
+            *pkey_type = S2N_PKEY_TYPE_RSA;
+            break;
+        case S2N_SIGNATURE_RSA_PSS_PSS:
+            *pkey_type = S2N_PKEY_TYPE_RSA_PSS;
+            break;
+        case S2N_SIGNATURE_ECDSA:
+            *pkey_type = S2N_PKEY_TYPE_ECDSA;
+            break;
+        default:
+            RESULT_BAIL(S2N_ERR_INVALID_SIGNATURE_ALGORITHM);
+    }
+
+    return S2N_RESULT_OK;
+}

--- a/tls/s2n_signature_algorithms.h
+++ b/tls/s2n_signature_algorithms.h
@@ -17,6 +17,7 @@
 
 #include "api/s2n.h"
 #include "crypto/s2n_hash.h"
+#include "crypto/s2n_pkey.h"
 #include "crypto/s2n_signature.h"
 #include "stuffer/s2n_stuffer.h"
 #include "tls/s2n_signature_scheme.h"
@@ -35,3 +36,5 @@ S2N_RESULT s2n_signature_algorithm_select(struct s2n_connection *conn);
 int s2n_recv_supported_sig_scheme_list(struct s2n_stuffer *in, struct s2n_sig_scheme_list *sig_hash_algs);
 S2N_RESULT s2n_signature_algorithms_supported_list_send(struct s2n_connection *conn,
         struct s2n_stuffer *out);
+
+S2N_RESULT s2n_signature_algorithm_get_pkey_type(s2n_signature_algorithm sig_alg, s2n_pkey_type *pkey_type);


### PR DESCRIPTION
### Description of changes: 

It was discovered in https://github.com/aws/s2n-tls/pull/4545 that it's possible for a signature algorithm type to be disallowed in a security policy, yet still be accepted when verifying the signature content of the CertificateVerify message when the EVP signing APIs are enabled (when s2n-tls is in FIPS mode and is linked with an EVP-compatible libcrypto). However, no security policies currently disallow all signature algorithms of one type (i.e. removing ALL RSA signature algorithms or ALL ECDSA signature algorithms), so this isn't currently an issue.

This PR adds a check to the EVP verify path to ensure that the certificate matches the received signature scheme, similar to how the non-EVP verify code currently works.

#### Further description:

The first two bytes of the CertificateVerify message contain the signature scheme used to sign the subsequent signature content in the CertificateVerify message. When s2n-tls receives a CertificateVerify message, the indicated signature scheme is validated against the set security policy:
https://github.com/aws/s2n-tls/blob/6f7058fd9fa46eff73d3a047d79022a403d43e16/tls/s2n_tls13_certificate_verify.c#L148

Normally, s2n-tls then validates that the signature algorithm in the received signature scheme matches the certificate type. For example, if an RSA_PSS certificate is received, s2n-tls validates that the signature algorithm is RSA_PSS:
https://github.com/aws/s2n-tls/blob/6f7058fd9fa46eff73d3a047d79022a403d43e16/crypto/s2n_rsa_pss.c#L79-L83

s2n-tls similarly validates an ECDSA signature algorithm against the certificate type:
https://github.com/aws/s2n-tls/blob/6f7058fd9fa46eff73d3a047d79022a403d43e16/crypto/s2n_ecdsa.c#L113-L116

However, when s2n-tls is operating in FIPS mode with an EVP-compatible libcrypto, all pkey verify operations route to the same [s2n_evp_verify()](https://github.com/aws/s2n-tls/blob/6f7058fd9fa46eff73d3a047d79022a403d43e16/crypto/s2n_evp_signing.c#L131) function, which currently doesn't validate the signature algorithm against the certificate type. Additionally, `s2n_evp_verify()` doesn't use the signature algorithm in the received signature scheme to actually perform the verify operation. Rather, the certificate public key type is used.

This allows for a scenario in which the server signs the CertificateVerify signature content with one signature algorithm, and lies about the signature algorithm used in the first two bytes of the CertificateVerify message. s2n-tls would successfully validate the incorrect signature scheme against the security policy, and then proceed use another, potentially disallowed signature algorithm in the verify operation.

The following example demonstrates the issue:
- The client sets a security policy that only contains ECDSA signature schemes, indicating that any RSA signature scheme used in the CertificateVerify message should fail. This client advertises its ECDSA signature scheme list in the ClientHello.
- The server doesn't care about the client's ECDSA signature scheme list, and sends an RSA certificate to the client, and uses an RSA signature algorithm to sign the signature content of the CertificateVerify message.
- However, to trick s2n-tls into verifying the CertificateVerify message anyway, the server lies about the signature algorithm in the first two bytes of the CertificateVerify message. The server writes ones of the client's ECDSA signature schemes here, even though it wasn't actually used to sign the signature content.
- The client receives the CertificateVerify message, parses the signature scheme, and successfully validates it against its security policy, since the server lied.
- The client verifies the CertificateMessage by calling [s2n_evp_verify()](https://github.com/aws/s2n-tls/blob/6f7058fd9fa46eff73d3a047d79022a403d43e16/crypto/s2n_evp_signing.c#L131), which sees that the server sent an RSA certificate, and successfully verifies the signature content with an RSA signature algorithm, even though the client didn't permit it as an acceptable signature algorithm.

Note that this issue doesn't impact the hash algorithm restrictions in security policies, since the indicated hash algorithm is used by s2n-tls to generate the content to sign. So, if the server lies about the hash algorithm, the received signature content won't match the content generated by s2n-tls. A test for this [already exists](https://github.com/aws/s2n-tls/blob/6ea240a6c8b86241c75f50162742a145b7bd1b83/tests/unit/s2n_tls13_cert_verify_test.c#L200-L218).

### Call-outs:

None

### Testing:

A new unit test was added to test the new signature algorithm check, and ensure that the behavior is the same between the EVP and non-EVP code paths.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
