### PR TITLE
ci: fix macos rust bindings generate action

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -25,6 +25,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Fix xcode on macos
+        if: ${{ matrix.os == 'macOS-latest' }}
+        run: |
+          sudo xcode-select --switch /Library/Developer/CommandLineTools
+          xcrun --show-sdk-path
+
       - name: Install Rust toolchain
         id: toolchain
         run: |


### PR DESCRIPTION
### Resolved issues:

Resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.

### Description of changes: 

The macos bindings generate action is currently failing with:
```
     Running `target/debug/generate ../s2n-tls-sys`
../s2n-tls-sys/lib/api/s2n.h:43:10: fatal error: 'stdio.h' file not found
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ClangDiagnostic("../s2n-tls-sys/lib/api/s2n.h:43:10: fatal error: 'stdio.h' file not found\n")', src/main.rs:39:6
```

My vague understanding of how macos works: the standard c library, including stdio.h, is coming from xcode. After the last update to our macos image (which did include [an update to xcode](https://github.com/actions/runner-images/commit/9d5d1be4828f3f7e54796a46d60afd0a2f9e05b0)) we weren't able to get "stdio.h" from xcode anymore.

But there are two versions of xcode: Xcode and Xcode CommandLineTools. Since we're doing command line development here, we should probably be using the CommandLineTools version.

When I ran `mdfind -name stdio.h`, I got:
```
/Users/runner/Library/Android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/bits/fortify/stdio.h
/Users/runner/Library/Android/sdk/ndk/25.2.9519653/sources/cxx-stl/llvm-libc++/include/stdio.h
/Users/runner/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/bits/fortify/stdio.h
/Users/runner/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/c++/v1/stdio.h
/Users/runner/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/stdio.h
/Users/runner/Library/Android/sdk/ndk/26.3.11579264/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/c++/v1/stdio.h
/Users/runner/Library/Android/sdk/ndk/26.3.11579264/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/bits/fortify/stdio.h
/Users/runner/Library/Android/sdk/ndk/26.3.11579264/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/stdio.h
/Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/System/Library/Frameworks/Kernel.framework/Versions/A/Headers/sys/stdio.h
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/System/Library/Frameworks/Kernel.framework/Versions/A/Headers/sys/stdio.h
/Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/include/xlocale/_stdio.h
/Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/include/c++/v1/stdio.h
/Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/include/_stdio.h
/Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/include/secure/_stdio.h
/Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/include/sys/stdio.h
/Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk/usr/include/stdio.h
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/xlocale/_stdio.h
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/_stdio.h
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/stdio.h
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/secure/_stdio.h
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/sys/stdio.h
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/stdio.h
/Users/runner/Library/Android/sdk/ndk/24.0.8215888/sources/cxx-stl/llvm-libc++/include/stdio.h
/Users/runner/Library/Android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/c++/v1/stdio.h
/Users/runner/Library/Android/sdk/ndk/24.0.8215888/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/stdio.h
```
Notice that unless we want to do Android development, it looks like we need to get the header from CommandLineTools.

But when I ran `xcrun --show-sdk-path` I got:
```
/Applications/Xcode_15.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
```
So that is using Xcode, not CommandLineTools.

### Testing:

After this change, running  `xcrun --show-sdk-path` gives:
```
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
