### PR TITLE
refactor: separate out ja3 specific logic

### DIFF
--- a/tests/unit/s2n_fingerprint_test.c
+++ b/tests/unit/s2n_fingerprint_test.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_stuffer_read_char(&output, &actual_value));
                 EXPECT_EQUAL(actual_value, test_char);
             }
-        }
+        };
 
         /* Add to hash */
         {
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
                 EXPECT_OK(s2n_fingerprint_hash_add_char(&hash, test_char));
                 EXPECT_EQUAL(hash.hash->currently_in_hash, i);
             }
-        }
+        };
 
         /* Error due to insufficient space */
         {
@@ -89,8 +89,8 @@ int main(int argc, char **argv)
             EXPECT_OK(s2n_fingerprint_hash_add_char(&hash, test_char));
             EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_char(&hash, test_char),
                     S2N_ERR_INSUFFICIENT_MEM_SIZE);
-        }
-    }
+        };
+    };
 
     /* Test s2n_fingerprint_hash_add_str */
     {
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
                 EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_str(&hash, NULL, 10),
                         S2N_ERR_NULL);
                 EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, NULL, 0));
-            }
+            };
 
             /* Null str with hash */
             {
@@ -118,8 +118,8 @@ int main(int argc, char **argv)
                 EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_str(&hash, NULL, 10),
                         S2N_ERR_NULL);
                 EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, NULL, 0));
-            }
-        }
+            };
+        };
 
         /* Add to stuffer */
         {
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, actual_value, test_str_len));
                 EXPECT_BYTEARRAY_EQUAL(actual_value, test_str, test_str_len);
             }
-        }
+        };
 
         /* Add to hash */
         {
@@ -147,7 +147,7 @@ int main(int argc, char **argv)
                 EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, test_str, test_str_len));
                 EXPECT_EQUAL(hash.hash->currently_in_hash, test_str_len * i);
             }
-        }
+        };
 
         /* Error due to insufficient space */
         {
@@ -175,8 +175,8 @@ int main(int argc, char **argv)
                     s2n_fingerprint_hash_add_str(&hash, test_str, test_str_len),
                     S2N_ERR_INSUFFICIENT_MEM_SIZE);
             EXPECT_SUCCESS(s2n_stuffer_free(&output));
-        }
-    }
+        };
+    };
 
     /* Test s2n_fingerprint_hash_digest */
     {
@@ -186,7 +186,7 @@ int main(int argc, char **argv)
             EXPECT_ERROR_WITH_ERRNO(
                     s2n_fingerprint_hash_digest(NULL, output_value, sizeof(output_value)),
                     S2N_ERR_NULL);
-        }
+        };
 
         /* Digest successfully calculated */
         {
@@ -201,7 +201,7 @@ int main(int argc, char **argv)
             EXPECT_OK(s2n_fingerprint_hash_digest(&hash, actual_digest, sizeof(actual_digest)));
             EXPECT_BYTEARRAY_EQUAL(actual_digest, test_str_digest, sizeof(test_str_digest));
             EXPECT_EQUAL(hash.bytes_digested, test_str_len);
-        }
+        };
 
         /* Hash can be reused after digest */
         {
@@ -217,8 +217,8 @@ int main(int argc, char **argv)
                 EXPECT_BYTEARRAY_EQUAL(actual_digest, test_str_digest, sizeof(test_str_digest));
             }
             EXPECT_EQUAL(hash.bytes_digested, test_str_len * count);
-        }
-    }
+        };
+    };
 
     /* Test s2n_fingerprint_hash_do_digest */
     {
@@ -235,7 +235,7 @@ int main(int argc, char **argv)
         struct s2n_hash_state hash_state = { 0 };
         hash.hash = &hash_state;
         EXPECT_TRUE(s2n_fingerprint_hash_do_digest(&hash));
-    }
+    };
 
     /* Test s2n_assert_grease_value */
     {
@@ -243,7 +243,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE(s2n_is_grease_value(0xFAFA));
         EXPECT_FALSE(s2n_is_grease_value(0x0000));
         EXPECT_FALSE(s2n_is_grease_value(0x0001));
-    }
+    };
 
     END_TEST();
 }

--- a/tests/unit/s2n_fingerprint_test.c
+++ b/tests/unit/s2n_fingerprint_test.c
@@ -22,11 +22,8 @@
 #define S2N_TEST_HASH S2N_HASH_SHA256
 #define TEST_COUNT    10
 
-static S2N_RESULT s2n_test_hash_new(struct s2n_fingerprint_hash *hash,
-        struct s2n_hash_state *hash_state)
+static S2N_RESULT s2n_test_hash_state_new(struct s2n_hash_state *hash_state)
 {
-    hash->hash = hash_state;
-    hash->do_digest = true;
     EXPECT_SUCCESS(s2n_hash_new(hash_state));
     EXPECT_SUCCESS(s2n_hash_init(hash_state, S2N_TEST_HASH));
     return S2N_RESULT_OK;
@@ -40,6 +37,12 @@ int main(int argc, char **argv)
     const char test_str[] = "hello";
     const size_t test_str_len = strlen(test_str);
     EXPECT_NOT_EQUAL(test_char, test_str[0]);
+
+    const uint8_t test_str_digest[] = {
+        0x2c, 0xf2, 0x4d, 0xba, 0x5f, 0xb0, 0xa3, 0xe, 0x26, 0xe8, 0x3b,
+        0x2a, 0xc5, 0xb9, 0xe2, 0x9e, 0x1b, 0x16, 0x1e, 0x5c, 0x1f, 0xa7,
+        0x42, 0x5e, 0x73, 0x4, 0x33, 0x62, 0x93, 0x8b, 0x98, 0x24
+    };
 
     /* Test s2n_fingerprint_hash_add_char */
     {
@@ -66,8 +69,8 @@ int main(int argc, char **argv)
         /* Add to hash */
         {
             DEFER_CLEANUP(struct s2n_hash_state hash_state = { 0 }, s2n_hash_free);
-            struct s2n_fingerprint_hash hash = { 0 };
-            EXPECT_OK(s2n_test_hash_new(&hash, &hash_state));
+            EXPECT_OK(s2n_test_hash_state_new(&hash_state));
+            struct s2n_fingerprint_hash hash = { .hash = &hash_state };
 
             for (size_t i = 1; i <= TEST_COUNT; i++) {
                 EXPECT_OK(s2n_fingerprint_hash_add_char(&hash, test_char));
@@ -92,8 +95,31 @@ int main(int argc, char **argv)
     /* Test s2n_fingerprint_hash_add_str */
     {
         /* Safety */
-        EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_str(NULL, test_str),
-                S2N_ERR_NULL);
+        {
+            /* Null hash */
+            EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_str(NULL, test_str, 0),
+                    S2N_ERR_NULL);
+
+            /* Null str with stuffer */
+            {
+                DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+                EXPECT_SUCCESS(s2n_stuffer_alloc(&output, 100));
+                struct s2n_fingerprint_hash hash = { .buffer = &output };
+                EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_str(&hash, NULL, 10),
+                        S2N_ERR_NULL);
+                EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, NULL, 0));
+            }
+
+            /* Null str with hash */
+            {
+                DEFER_CLEANUP(struct s2n_hash_state hash_state = { 0 }, s2n_hash_free);
+                EXPECT_OK(s2n_test_hash_state_new(&hash_state));
+                struct s2n_fingerprint_hash hash = { .hash = &hash_state };
+                EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_str(&hash, NULL, 10),
+                        S2N_ERR_NULL);
+                EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, NULL, 0));
+            }
+        }
 
         /* Add to stuffer */
         {
@@ -102,7 +128,7 @@ int main(int argc, char **argv)
             struct s2n_fingerprint_hash hash = { .buffer = &output };
 
             for (size_t i = 1; i <= TEST_COUNT; i++) {
-                EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, test_str));
+                EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, test_str, test_str_len));
                 EXPECT_EQUAL(s2n_stuffer_data_available(&output), test_str_len);
 
                 uint8_t actual_value[sizeof(test_str)] = { 0 };
@@ -114,11 +140,11 @@ int main(int argc, char **argv)
         /* Add to hash */
         {
             DEFER_CLEANUP(struct s2n_hash_state hash_state = { 0 }, s2n_hash_free);
-            struct s2n_fingerprint_hash hash = { 0 };
-            EXPECT_OK(s2n_test_hash_new(&hash, &hash_state));
+            EXPECT_OK(s2n_test_hash_state_new(&hash_state));
+            struct s2n_fingerprint_hash hash = { .hash = &hash_state };
 
             for (size_t i = 1; i <= TEST_COUNT; i++) {
-                EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, test_str));
+                EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, test_str, test_str_len));
                 EXPECT_EQUAL(hash.hash->currently_in_hash, test_str_len * i);
             }
         }
@@ -127,22 +153,26 @@ int main(int argc, char **argv)
         {
             struct s2n_stuffer output = { 0 };
             struct s2n_fingerprint_hash hash = { .buffer = &output };
-            EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_str(&hash, test_str),
+            EXPECT_ERROR_WITH_ERRNO(
+                    s2n_fingerprint_hash_add_str(&hash, test_str, test_str_len),
                     S2N_ERR_INSUFFICIENT_MEM_SIZE);
 
             EXPECT_SUCCESS(s2n_stuffer_alloc(&output, 1));
-            EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_str(&hash, test_str),
+            EXPECT_ERROR_WITH_ERRNO(
+                    s2n_fingerprint_hash_add_str(&hash, test_str, test_str_len),
                     S2N_ERR_INSUFFICIENT_MEM_SIZE);
             EXPECT_SUCCESS(s2n_stuffer_free(&output));
 
             EXPECT_SUCCESS(s2n_stuffer_alloc(&output, test_str_len - 1));
-            EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_str(&hash, test_str),
+            EXPECT_ERROR_WITH_ERRNO(
+                    s2n_fingerprint_hash_add_str(&hash, test_str, test_str_len),
                     S2N_ERR_INSUFFICIENT_MEM_SIZE);
             EXPECT_SUCCESS(s2n_stuffer_free(&output));
 
             EXPECT_SUCCESS(s2n_stuffer_alloc(&output, test_str_len));
             EXPECT_OK(s2n_fingerprint_hash_add_char(&hash, test_char));
-            EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_str(&hash, test_str),
+            EXPECT_ERROR_WITH_ERRNO(
+                    s2n_fingerprint_hash_add_str(&hash, test_str, test_str_len),
                     S2N_ERR_INSUFFICIENT_MEM_SIZE);
             EXPECT_SUCCESS(s2n_stuffer_free(&output));
         }
@@ -150,13 +180,6 @@ int main(int argc, char **argv)
 
     /* Test s2n_fingerprint_hash_digest */
     {
-        const char test_value[] = "hello";
-        const uint8_t digest_value[] = {
-            0x2c, 0xf2, 0x4d, 0xba, 0x5f, 0xb0, 0xa3, 0xe, 0x26, 0xe8, 0x3b,
-            0x2a, 0xc5, 0xb9, 0xe2, 0x9e, 0x1b, 0x16, 0x1e, 0x5c, 0x1f, 0xa7,
-            0x42, 0x5e, 0x73, 0x4, 0x33, 0x62, 0x93, 0x8b, 0x98, 0x24
-        };
-
         /* Safety */
         {
             uint8_t output_value[1] = { 0 };
@@ -168,33 +191,50 @@ int main(int argc, char **argv)
         /* Digest successfully calculated */
         {
             DEFER_CLEANUP(struct s2n_hash_state hash_state = { 0 }, s2n_hash_free);
-            struct s2n_fingerprint_hash hash = { 0 };
-            EXPECT_OK(s2n_test_hash_new(&hash, &hash_state));
+            EXPECT_OK(s2n_test_hash_state_new(&hash_state));
+            struct s2n_fingerprint_hash hash = { .hash = &hash_state };
 
-            EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, test_value));
+            EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, test_str, test_str_len));
             EXPECT_EQUAL(hash.hash->currently_in_hash, test_str_len);
 
-            uint8_t actual_digest[sizeof(digest_value)] = { 0 };
+            uint8_t actual_digest[sizeof(test_str_digest)] = { 0 };
             EXPECT_OK(s2n_fingerprint_hash_digest(&hash, actual_digest, sizeof(actual_digest)));
-            EXPECT_BYTEARRAY_EQUAL(actual_digest, digest_value, sizeof(digest_value));
+            EXPECT_BYTEARRAY_EQUAL(actual_digest, test_str_digest, sizeof(test_str_digest));
             EXPECT_EQUAL(hash.bytes_digested, test_str_len);
         }
 
         /* Hash can be reused after digest */
         {
             DEFER_CLEANUP(struct s2n_hash_state hash_state = { 0 }, s2n_hash_free);
-            struct s2n_fingerprint_hash hash = { 0 };
-            EXPECT_OK(s2n_test_hash_new(&hash, &hash_state));
+            EXPECT_OK(s2n_test_hash_state_new(&hash_state));
+            struct s2n_fingerprint_hash hash = { .hash = &hash_state };
 
             const size_t count = 10;
             for (size_t i = 0; i < count; i++) {
-                uint8_t actual_digest[sizeof(digest_value)] = { 0 };
-                EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, test_value));
+                uint8_t actual_digest[sizeof(test_str_digest)] = { 0 };
+                EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, test_str, test_str_len));
                 EXPECT_OK(s2n_fingerprint_hash_digest(&hash, actual_digest, sizeof(actual_digest)));
-                EXPECT_BYTEARRAY_EQUAL(actual_digest, digest_value, sizeof(digest_value));
+                EXPECT_BYTEARRAY_EQUAL(actual_digest, test_str_digest, sizeof(test_str_digest));
             }
             EXPECT_EQUAL(hash.bytes_digested, test_str_len * count);
         }
+    }
+
+    /* Test s2n_fingerprint_hash_supports_digest */
+    {
+        /* Safety */
+        EXPECT_FALSE(s2n_fingerprint_hash_supports_digest(NULL));
+
+        struct s2n_fingerprint_hash hash = { 0 };
+        EXPECT_FALSE(s2n_fingerprint_hash_supports_digest(&hash));
+
+        struct s2n_stuffer output = { 0 };
+        hash.buffer = &output;
+        EXPECT_FALSE(s2n_fingerprint_hash_supports_digest(&hash));
+
+        struct s2n_hash_state hash_state = { 0 };
+        hash.hash = &hash_state;
+        EXPECT_TRUE(s2n_fingerprint_hash_supports_digest(&hash));
     }
 
     /* Test s2n_assert_grease_value */

--- a/tests/unit/s2n_fingerprint_test.c
+++ b/tests/unit/s2n_fingerprint_test.c
@@ -29,7 +29,7 @@ static S2N_RESULT s2n_test_fingerprint_hash(struct s2n_fingerprint_hash *hash,
     hash->hash = hash_state;
     hash->do_digest = true;
     EXPECT_SUCCESS(s2n_hash_new(hash_state));
-    EXPECT_OK(s2n_fingerprint_hash_init(hash, S2N_TEST_HASH));
+    EXPECT_SUCCESS(s2n_hash_init(hash_state, S2N_TEST_HASH));
     EXPECT_SUCCESS(s2n_stuffer_alloc(hash_output, hash_buffer_size));
     return S2N_RESULT_OK;
 }
@@ -42,34 +42,6 @@ int main(int argc, char **argv)
     const char test_str[] = "hello";
     const size_t test_str_len = strlen(test_str);
     EXPECT_NOT_EQUAL(test_char, test_str[0]);
-
-    /* Test s2n_fingerprint_hash_init */
-    {
-        /* Safety */
-        EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_init(NULL, S2N_TEST_HASH),
-                S2N_ERR_NULL);
-
-        /* With hash */
-        {
-            DEFER_CLEANUP(struct s2n_hash_state hash_state = { 0 }, s2n_hash_free);
-            EXPECT_SUCCESS(s2n_hash_new(&hash_state));
-            struct s2n_fingerprint_hash hash = { .hash = &hash_state };
-            EXPECT_OK(s2n_fingerprint_hash_init(&hash, S2N_TEST_HASH));
-        }
-
-        /* Without hash */
-        {
-            struct s2n_fingerprint_hash hash = { 0 };
-            EXPECT_OK(s2n_fingerprint_hash_init(&hash, S2N_TEST_HASH));
-        }
-
-        /* Without hash, but needs hash */
-        {
-            struct s2n_fingerprint_hash hash = { .do_digest = true };
-            EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_init(&hash, S2N_TEST_HASH),
-                    S2N_ERR_INVALID_STATE);
-        }
-    }
 
     /* Test s2n_fingerprint_hash_add_char */
     {

--- a/tests/unit/s2n_fingerprint_test.c
+++ b/tests/unit/s2n_fingerprint_test.c
@@ -220,21 +220,21 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Test s2n_fingerprint_hash_supports_digest */
+    /* Test s2n_fingerprint_hash_do_digest */
     {
         /* Safety */
-        EXPECT_FALSE(s2n_fingerprint_hash_supports_digest(NULL));
+        EXPECT_FALSE(s2n_fingerprint_hash_do_digest(NULL));
 
         struct s2n_fingerprint_hash hash = { 0 };
-        EXPECT_FALSE(s2n_fingerprint_hash_supports_digest(&hash));
+        EXPECT_FALSE(s2n_fingerprint_hash_do_digest(&hash));
 
         struct s2n_stuffer output = { 0 };
         hash.buffer = &output;
-        EXPECT_FALSE(s2n_fingerprint_hash_supports_digest(&hash));
+        EXPECT_FALSE(s2n_fingerprint_hash_do_digest(&hash));
 
         struct s2n_hash_state hash_state = { 0 };
         hash.hash = &hash_state;
-        EXPECT_TRUE(s2n_fingerprint_hash_supports_digest(&hash));
+        EXPECT_TRUE(s2n_fingerprint_hash_do_digest(&hash));
     }
 
     /* Test s2n_assert_grease_value */

--- a/tests/unit/s2n_fingerprint_test.c
+++ b/tests/unit/s2n_fingerprint_test.c
@@ -1,0 +1,264 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tls/s2n_fingerprint.h"
+
+#include "crypto/s2n_hash.h"
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+#define S2N_TEST_HASH S2N_HASH_SHA256
+
+static S2N_RESULT s2n_test_fingerprint_hash(struct s2n_fingerprint_hash *hash,
+        struct s2n_stuffer *hash_output, struct s2n_hash_state *hash_state,
+        size_t hash_buffer_size)
+{
+    hash->buffer = hash_output;
+    hash->hash = hash_state;
+    hash->do_digest = true;
+    EXPECT_SUCCESS(s2n_hash_new(hash_state));
+    EXPECT_OK(s2n_fingerprint_hash_init(hash, S2N_TEST_HASH));
+    EXPECT_SUCCESS(s2n_stuffer_alloc(hash_output, hash_buffer_size));
+    return S2N_RESULT_OK;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    const char test_char = '!';
+    const char test_str[] = "hello";
+    const size_t test_str_len = strlen(test_str);
+    EXPECT_NOT_EQUAL(test_char, test_str[0]);
+
+    /* Test s2n_fingerprint_hash_init */
+    {
+        /* Safety */
+        EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_init(NULL, S2N_TEST_HASH),
+                S2N_ERR_NULL);
+
+        /* With hash */
+        {
+            DEFER_CLEANUP(struct s2n_hash_state hash_state = { 0 }, s2n_hash_free);
+            EXPECT_SUCCESS(s2n_hash_new(&hash_state));
+            struct s2n_fingerprint_hash hash = { .hash = &hash_state };
+            EXPECT_OK(s2n_fingerprint_hash_init(&hash, S2N_TEST_HASH));
+        }
+
+        /* Without hash */
+        {
+            struct s2n_fingerprint_hash hash = { 0 };
+            EXPECT_OK(s2n_fingerprint_hash_init(&hash, S2N_TEST_HASH));
+        }
+
+        /* Without hash, but needs hash */
+        {
+            struct s2n_fingerprint_hash hash = { .do_digest = true };
+            EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_init(&hash, S2N_TEST_HASH),
+                    S2N_ERR_INVALID_STATE);
+        }
+    }
+
+    /* Test s2n_fingerprint_hash_add_char */
+    {
+        /* Safety */
+        EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_char(NULL, test_char),
+                S2N_ERR_NULL);
+
+        /* Successfully added */
+        {
+            DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&output, 1));
+            struct s2n_fingerprint_hash hash = { .buffer = &output };
+
+            EXPECT_OK(s2n_fingerprint_hash_add_char(&hash, test_char));
+            EXPECT_EQUAL(s2n_stuffer_data_available(&output), 1);
+            EXPECT_EQUAL(s2n_stuffer_space_remaining(&output), 0);
+
+            char actual_value = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_char(&output, &actual_value));
+            EXPECT_EQUAL(actual_value, test_char);
+        }
+
+        /* Error due to insufficient space */
+        {
+            DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+            struct s2n_fingerprint_hash hash = { .buffer = &output };
+            EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_char(&hash, test_char),
+                    S2N_ERR_INSUFFICIENT_MEM_SIZE);
+
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&output, 1));
+            EXPECT_OK(s2n_fingerprint_hash_add_char(&hash, test_char));
+            EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_char(&hash, test_char),
+                    S2N_ERR_INSUFFICIENT_MEM_SIZE);
+        }
+
+        /* Flushed due to insufficient space */
+        {
+            DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+            DEFER_CLEANUP(struct s2n_hash_state hash_state = { 0 }, s2n_hash_free);
+            struct s2n_fingerprint_hash hash = { 0 };
+            EXPECT_OK(s2n_test_fingerprint_hash(&hash, &output, &hash_state, 1));
+
+            EXPECT_OK(s2n_fingerprint_hash_add_char(&hash, test_str[0]));
+            EXPECT_EQUAL(s2n_stuffer_data_available(&output), 1);
+            EXPECT_EQUAL(s2n_stuffer_space_remaining(&output), 0);
+            EXPECT_EQUAL(hash.hash->currently_in_hash, 0);
+
+            EXPECT_OK(s2n_fingerprint_hash_add_char(&hash, test_char));
+            EXPECT_EQUAL(s2n_stuffer_data_available(&output), 1);
+            EXPECT_EQUAL(s2n_stuffer_space_remaining(&output), 0);
+            EXPECT_EQUAL(hash.hash->currently_in_hash, 1);
+
+            char actual_value = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_char(&output, &actual_value));
+            EXPECT_EQUAL(actual_value, test_char);
+        }
+    }
+
+    /* Test s2n_fingerprint_hash_add_str */
+    {
+        /* Safety */
+        EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_str(NULL, test_str),
+                S2N_ERR_NULL);
+
+        /* Successfully added */
+        {
+            DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&output, test_str_len));
+            struct s2n_fingerprint_hash hash = { .buffer = &output };
+
+            EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, test_str));
+            EXPECT_EQUAL(s2n_stuffer_data_available(&output), test_str_len);
+            EXPECT_EQUAL(s2n_stuffer_space_remaining(&output), 0);
+
+            uint8_t actual_value[sizeof(test_str)] = { 0 };
+            EXPECT_SUCCESS(s2n_stuffer_read_bytes(&output, actual_value, test_str_len));
+            EXPECT_BYTEARRAY_EQUAL(actual_value, test_str, test_str_len);
+        }
+
+        /* Error due to insufficient space */
+        {
+            struct s2n_stuffer output = { 0 };
+            struct s2n_fingerprint_hash hash = { .buffer = &output };
+            EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_str(&hash, test_str),
+                    S2N_ERR_INSUFFICIENT_MEM_SIZE);
+
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&output, 1));
+            EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_str(&hash, test_str),
+                    S2N_ERR_INSUFFICIENT_MEM_SIZE);
+            EXPECT_SUCCESS(s2n_stuffer_free(&output));
+
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&output, test_str_len - 1));
+            EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_str(&hash, test_str),
+                    S2N_ERR_INSUFFICIENT_MEM_SIZE);
+            EXPECT_SUCCESS(s2n_stuffer_free(&output));
+
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&output, test_str_len));
+            EXPECT_OK(s2n_fingerprint_hash_add_char(&hash, test_char));
+            EXPECT_ERROR_WITH_ERRNO(s2n_fingerprint_hash_add_str(&hash, test_str),
+                    S2N_ERR_INSUFFICIENT_MEM_SIZE);
+            EXPECT_SUCCESS(s2n_stuffer_free(&output));
+        }
+
+        /* Flushed due to insufficient space */
+        {
+            DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+            DEFER_CLEANUP(struct s2n_hash_state hash_state = { 0 }, s2n_hash_free);
+            struct s2n_fingerprint_hash hash = { 0 };
+            EXPECT_OK(s2n_test_fingerprint_hash(&hash, &output, &hash_state, test_str_len));
+
+            EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, test_str));
+            EXPECT_EQUAL(s2n_stuffer_data_available(&output), test_str_len);
+            EXPECT_EQUAL(s2n_stuffer_space_remaining(&output), 0);
+            EXPECT_EQUAL(hash.hash->currently_in_hash, 0);
+
+            EXPECT_OK(s2n_fingerprint_hash_add_char(&hash, test_char));
+            EXPECT_EQUAL(s2n_stuffer_data_available(&output), 1);
+            EXPECT_EQUAL(s2n_stuffer_space_remaining(&output), test_str_len - 1);
+            EXPECT_EQUAL(hash.hash->currently_in_hash, test_str_len);
+
+            char actual_value = 0;
+            EXPECT_SUCCESS(s2n_stuffer_read_char(&output, &actual_value));
+            EXPECT_EQUAL(actual_value, test_char);
+        }
+    }
+
+    /* Test s2n_fingerprint_hash_digest */
+    {
+        const char test_value[] = "hello";
+        const uint8_t digest_value[] = {
+            0x2c, 0xf2, 0x4d, 0xba, 0x5f, 0xb0, 0xa3, 0xe, 0x26, 0xe8, 0x3b,
+            0x2a, 0xc5, 0xb9, 0xe2, 0x9e, 0x1b, 0x16, 0x1e, 0x5c, 0x1f, 0xa7,
+            0x42, 0x5e, 0x73, 0x4, 0x33, 0x62, 0x93, 0x8b, 0x98, 0x24
+        };
+
+        /* Safety */
+        {
+            uint8_t output_value[1] = { 0 };
+            EXPECT_ERROR_WITH_ERRNO(
+                    s2n_fingerprint_hash_digest(NULL, output_value, sizeof(output_value)),
+                    S2N_ERR_NULL);
+        }
+
+        /* Digest successfully calculated */
+        {
+            DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+            DEFER_CLEANUP(struct s2n_hash_state hash_state = { 0 }, s2n_hash_free);
+            struct s2n_fingerprint_hash hash = { 0 };
+            EXPECT_OK(s2n_test_fingerprint_hash(&hash, &output, &hash_state, test_str_len));
+
+            EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, test_value));
+            EXPECT_EQUAL(s2n_stuffer_data_available(&output), test_str_len);
+            EXPECT_EQUAL(s2n_stuffer_space_remaining(&output), 0);
+            EXPECT_EQUAL(hash.hash->currently_in_hash, 0);
+
+            uint8_t actual_digest[sizeof(digest_value)] = { 0 };
+            EXPECT_OK(s2n_fingerprint_hash_digest(&hash, actual_digest, sizeof(actual_digest)));
+            EXPECT_BYTEARRAY_EQUAL(actual_digest, digest_value, sizeof(digest_value));
+
+            EXPECT_EQUAL(s2n_stuffer_data_available(&output), 0);
+            EXPECT_EQUAL(s2n_stuffer_space_remaining(&output), test_str_len);
+            EXPECT_EQUAL(hash.bytes_digested, test_str_len);
+        }
+
+        /* Hash can be reused after digest */
+        {
+            DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
+            DEFER_CLEANUP(struct s2n_hash_state hash_state = { 0 }, s2n_hash_free);
+            struct s2n_fingerprint_hash hash = { 0 };
+            EXPECT_OK(s2n_test_fingerprint_hash(&hash, &output, &hash_state, test_str_len));
+
+            const size_t count = 10;
+            for (size_t i = 0; i < count; i++) {
+                uint8_t actual_digest[sizeof(digest_value)] = { 0 };
+                EXPECT_OK(s2n_fingerprint_hash_add_str(&hash, test_value));
+                EXPECT_OK(s2n_fingerprint_hash_digest(&hash, actual_digest, sizeof(actual_digest)));
+                EXPECT_BYTEARRAY_EQUAL(actual_digest, digest_value, sizeof(digest_value));
+            }
+            EXPECT_EQUAL(hash.bytes_digested, test_str_len * count);
+        }
+    }
+
+    /* Test s2n_assert_grease_value */
+    {
+        EXPECT_TRUE(s2n_is_grease_value(0x0A0A));
+        EXPECT_TRUE(s2n_is_grease_value(0xFAFA));
+        EXPECT_FALSE(s2n_is_grease_value(0x0000));
+        EXPECT_FALSE(s2n_is_grease_value(0x0001));
+    }
+
+    END_TEST();
+}

--- a/tls/s2n_fingerprint.c
+++ b/tls/s2n_fingerprint.c
@@ -83,7 +83,7 @@ S2N_RESULT s2n_fingerprint_hash_digest(struct s2n_fingerprint_hash *hash, uint8_
     return S2N_RESULT_OK;
 }
 
-bool s2n_fingerprint_hash_supports_digest(struct s2n_fingerprint_hash *hash)
+bool s2n_fingerprint_hash_do_digest(struct s2n_fingerprint_hash *hash)
 {
     return hash && hash->hash;
 }

--- a/tls/s2n_fingerprint.c
+++ b/tls/s2n_fingerprint.c
@@ -13,22 +13,11 @@
  * permissions and limitations under the License.
  */
 
-#include "api/unstable/fingerprint.h"
-#include "crypto/s2n_fips.h"
-#include "crypto/s2n_hash.h"
-#include "stuffer/s2n_stuffer.h"
-#include "tls/extensions/s2n_extension_list.h"
-#include "tls/s2n_client_hello.h"
-#include "tls/s2n_crypto_constants.h"
+#include "tls/s2n_fingerprint.h"
+
 #include "utils/s2n_blob.h"
-#include "utils/s2n_result.h"
+#include "utils/s2n_mem.h"
 #include "utils/s2n_safety.h"
-
-#define S2N_JA3_FIELD_DIV ','
-#define S2N_JA3_LIST_DIV  '-'
-
-/* UINT16_MAX == 65535 */
-#define S2N_UINT16_STR_MAX_SIZE 5
 
 /* See https://datatracker.ietf.org/doc/html/rfc8701
  * for an explanation of GREASE and lists of the GREASE values.
@@ -45,278 +34,142 @@ static S2N_RESULT s2n_assert_grease_value(uint16_t val)
     return S2N_RESULT_OK;
 }
 
-static bool s2n_is_grease_value(uint16_t val)
+bool s2n_is_grease_value(uint16_t val)
 {
     return s2n_result_is_ok(s2n_assert_grease_value(val));
 }
 
-static S2N_RESULT s2n_fingerprint_hash_flush(struct s2n_hash_state *hash, struct s2n_stuffer *in)
+S2N_RESULT s2n_fingerprint_hash_init(struct s2n_fingerprint_hash *hash, s2n_hash_algorithm hash_alg)
 {
-    if (hash == NULL) {
-        /* If the buffer is full and needs to be flushed, but no hash was provided,
-         * then we have insufficient memory to complete the fingerprint.
-         *
-         * The application will need to provide a larger buffer.
-         */
-        RESULT_BAIL(S2N_ERR_INSUFFICIENT_MEM_SIZE);
+    RESULT_ENSURE_REF(hash);
+    if (hash->hash) {
+        RESULT_GUARD_POSIX(s2n_hash_init(hash->hash, hash_alg));
+    } else {
+        RESULT_ENSURE(!hash->do_digest, S2N_ERR_INVALID_STATE);
     }
+    return S2N_RESULT_OK;
+}
 
-    uint32_t hash_data_len = s2n_stuffer_data_available(in);
-    uint8_t *hash_data = s2n_stuffer_raw_read(in, hash_data_len);
+static S2N_RESULT s2n_fingerprint_hash_flush(struct s2n_fingerprint_hash *hash)
+{
+    RESULT_ENSURE_REF(hash);
+
+    uint32_t hash_data_len = s2n_stuffer_data_available(hash->buffer);
+    uint8_t *hash_data = s2n_stuffer_raw_read(hash->buffer, hash_data_len);
     RESULT_ENSURE_REF(hash_data);
-    RESULT_GUARD_POSIX(s2n_hash_update(hash, hash_data, hash_data_len));
-    RESULT_GUARD_POSIX(s2n_stuffer_wipe(in));
+
+    RESULT_GUARD_POSIX(s2n_hash_update(hash->hash, hash_data, hash_data_len));
+    RESULT_GUARD_POSIX(s2n_stuffer_wipe(hash->buffer));
     return S2N_RESULT_OK;
 }
 
-static S2N_RESULT s2n_fingerprint_write_char(struct s2n_stuffer *stuffer,
-        char c, struct s2n_hash_state *hash)
+static S2N_RESULT s2n_fingerprint_hash_reserve_space(struct s2n_fingerprint_hash *hash, size_t size)
 {
-    if (s2n_stuffer_space_remaining(stuffer) < 1) {
-        RESULT_GUARD(s2n_fingerprint_hash_flush(hash, stuffer));
-    }
-    RESULT_GUARD_POSIX(s2n_stuffer_write_char(stuffer, c));
-    return S2N_RESULT_OK;
-}
-
-static S2N_RESULT s2n_fingerprint_write_entry(struct s2n_stuffer *stuffer,
-        bool *is_list, uint16_t value, struct s2n_hash_state *hash)
-{
-    /* If we have already written at least one value for this field,
-     * then we are writing a list and need to prepend a list divider before
-     * writing the next value.
-     */
-    RESULT_ENSURE_REF(is_list);
-    if (*is_list) {
-        RESULT_GUARD(s2n_fingerprint_write_char(stuffer, S2N_JA3_LIST_DIV, hash));
-    }
-    *is_list = true;
-
-    /* snprintf always appends a '\0' to the output,
-     * but that extra '\0' is not included in the return value */
-    uint8_t entry[S2N_UINT16_STR_MAX_SIZE + 1] = { 0 };
-    int written = snprintf((char *) entry, sizeof(entry), "%u", value);
-    RESULT_ENSURE_GT(written, 0);
-    RESULT_ENSURE_LTE(written, S2N_UINT16_STR_MAX_SIZE);
-
-    if (s2n_stuffer_space_remaining(stuffer) < (uint64_t) written) {
-        RESULT_GUARD(s2n_fingerprint_hash_flush(hash, stuffer));
-    }
-    RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(stuffer, entry, written));
-
-    return S2N_RESULT_OK;
-}
-
-static S2N_RESULT s2n_fingerprint_write_version(struct s2n_client_hello *ch,
-        struct s2n_stuffer *output, struct s2n_hash_state *hash)
-{
-    RESULT_ENSURE_REF(ch);
-    bool is_list = false;
-    uint16_t version = 0;
-    struct s2n_stuffer message = { 0 };
-    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&message, &ch->raw_message));
-    RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&message, &version));
-    RESULT_GUARD(s2n_fingerprint_write_entry(output, &is_list, version, hash));
-    return S2N_RESULT_OK;
-}
-
-static S2N_RESULT s2n_fingerprint_write_ciphers(struct s2n_client_hello *ch,
-        struct s2n_stuffer *output, struct s2n_hash_state *hash)
-{
-    RESULT_ENSURE_REF(ch);
-
-    bool cipher_found = false;
-    struct s2n_stuffer ciphers = { 0 };
-    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&ciphers, &ch->cipher_suites));
-    while (s2n_stuffer_data_available(&ciphers)) {
-        uint16_t cipher = 0;
-        RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&ciphers, &cipher));
-        if (s2n_is_grease_value(cipher)) {
-            continue;
-        }
-        RESULT_GUARD(s2n_fingerprint_write_entry(output, &cipher_found, cipher, hash));
+    RESULT_ENSURE_REF(hash);
+    if (s2n_stuffer_space_remaining(hash->buffer) < size) {
+        RESULT_ENSURE(hash->hash, S2N_ERR_INSUFFICIENT_MEM_SIZE);
+        RESULT_GUARD(s2n_fingerprint_hash_flush(hash));
     }
     return S2N_RESULT_OK;
 }
 
-static S2N_RESULT s2n_fingerprint_write_extensions(struct s2n_client_hello *ch,
-        struct s2n_stuffer *output, struct s2n_hash_state *hash)
+S2N_RESULT s2n_fingerprint_hash_add_char(struct s2n_fingerprint_hash *hash, char c)
 {
-    RESULT_ENSURE_REF(ch);
-
-    /* We have to use the raw extensions instead of the parsed extensions
-     * because s2n-tls both intentionally ignores any unknown extensions
-     * and reorders the extensions when parsing the list.
-     */
-    struct s2n_stuffer extensions = { 0 };
-    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&extensions, &ch->extensions.raw));
-
-    bool extension_found = false;
-    while (s2n_stuffer_data_available(&extensions)) {
-        uint16_t extension = 0, extension_size = 0;
-        RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&extensions, &extension));
-        RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&extensions, &extension_size));
-        RESULT_GUARD_POSIX(s2n_stuffer_skip_read(&extensions, extension_size));
-        if (s2n_is_grease_value(extension)) {
-            continue;
-        }
-        RESULT_GUARD(s2n_fingerprint_write_entry(output, &extension_found, extension, hash));
-    }
+    RESULT_GUARD(s2n_fingerprint_hash_reserve_space(hash, 1));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_char(hash->buffer, c));
     return S2N_RESULT_OK;
 }
 
-static S2N_RESULT s2n_fingerprint_write_elliptic_curves(struct s2n_client_hello *ch,
-        struct s2n_stuffer *output, struct s2n_hash_state *hash)
+S2N_RESULT s2n_fingerprint_hash_add_str(struct s2n_fingerprint_hash *hash, const char *str)
 {
-    RESULT_ENSURE_REF(ch);
-
-    s2n_parsed_extension *elliptic_curves_extension = NULL;
-    int result = s2n_client_hello_get_parsed_extension(S2N_EXTENSION_SUPPORTED_GROUPS,
-            &ch->extensions, &elliptic_curves_extension);
-    if (result != S2N_SUCCESS) {
-        return S2N_RESULT_OK;
-    }
-
-    struct s2n_stuffer elliptic_curves = { 0 };
-    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&elliptic_curves,
-            &elliptic_curves_extension->extension));
-
-    uint16_t count = 0;
-    RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&elliptic_curves, &count));
-
-    bool curve_found = false;
-    while (s2n_stuffer_data_available(&elliptic_curves)) {
-        uint16_t curve = 0;
-        RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&elliptic_curves, &curve));
-        if (s2n_is_grease_value(curve)) {
-            continue;
-        }
-        RESULT_GUARD(s2n_fingerprint_write_entry(output, &curve_found, curve, hash));
-    }
+    RESULT_GUARD(s2n_fingerprint_hash_reserve_space(hash, strlen(str)));
+    RESULT_GUARD_POSIX(s2n_stuffer_write_str(hash->buffer, str));
     return S2N_RESULT_OK;
 }
 
-static S2N_RESULT s2n_fingerprint_write_point_formats(struct s2n_client_hello *ch,
-        struct s2n_stuffer *output, struct s2n_hash_state *hash)
+S2N_RESULT s2n_fingerprint_hash_digest(struct s2n_fingerprint_hash *hash, uint8_t *out, size_t out_size)
 {
-    RESULT_ENSURE_REF(ch);
+    RESULT_GUARD(s2n_fingerprint_hash_flush(hash));
 
-    s2n_parsed_extension *point_formats_extension = NULL;
-    int result = s2n_client_hello_get_parsed_extension(S2N_EXTENSION_EC_POINT_FORMATS,
-            &ch->extensions, &point_formats_extension);
-    if (result != S2N_SUCCESS) {
-        return S2N_RESULT_OK;
-    }
+    RESULT_ENSURE_REF(hash);
+    RESULT_ENSURE_REF(hash->hash);
+    hash->bytes_digested += hash->hash->currently_in_hash;
 
-    struct s2n_stuffer point_formats = { 0 };
-    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&point_formats,
-            &point_formats_extension->extension));
-
-    uint8_t count = 0;
-    RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(&point_formats, &count));
-
-    bool format_found = false;
-    while (s2n_stuffer_data_available(&point_formats)) {
-        uint8_t format = 0;
-        RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(&point_formats, &format));
-        RESULT_GUARD(s2n_fingerprint_write_entry(output, &format_found, format, hash));
-    }
-    return S2N_RESULT_OK;
-}
-
-/* JA3 involves concatenating a set of fields from the ClientHello:
- *      SSLVersion,Cipher,SSLExtension,EllipticCurve,EllipticCurvePointFormat
- * For example:
- *      "769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0"
- * See https://github.com/salesforce/ja3
- */
-static S2N_RESULT s2n_fingerprint_ja3(struct s2n_client_hello *ch,
-        struct s2n_stuffer *output, uint32_t *output_size, struct s2n_hash_state *hash)
-{
-    RESULT_ENSURE_REF(ch);
-    RESULT_ENSURE(!ch->sslv2, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
-
-    RESULT_GUARD(s2n_fingerprint_write_version(ch, output, hash));
-    RESULT_GUARD(s2n_fingerprint_write_char(output, S2N_JA3_FIELD_DIV, hash));
-    RESULT_GUARD(s2n_fingerprint_write_ciphers(ch, output, hash));
-    RESULT_GUARD(s2n_fingerprint_write_char(output, S2N_JA3_FIELD_DIV, hash));
-    RESULT_GUARD(s2n_fingerprint_write_extensions(ch, output, hash));
-    RESULT_GUARD(s2n_fingerprint_write_char(output, S2N_JA3_FIELD_DIV, hash));
-    RESULT_GUARD(s2n_fingerprint_write_elliptic_curves(ch, output, hash));
-    RESULT_GUARD(s2n_fingerprint_write_char(output, S2N_JA3_FIELD_DIV, hash));
-    RESULT_GUARD(s2n_fingerprint_write_point_formats(ch, output, hash));
-
+    RESULT_GUARD_POSIX(s2n_hash_digest(hash->hash, out, out_size));
+    RESULT_GUARD_POSIX(s2n_hash_reset(hash->hash));
     return S2N_RESULT_OK;
 }
 
 int s2n_client_hello_get_fingerprint_hash(struct s2n_client_hello *ch, s2n_fingerprint_type type,
-        uint32_t max_hash_size, uint8_t *hash, uint32_t *hash_size, uint32_t *str_size)
+        uint32_t max_output_size, uint8_t *output, uint32_t *output_size, uint32_t *str_size)
 {
     POSIX_ENSURE(type == S2N_FINGERPRINT_JA3, S2N_ERR_INVALID_ARGUMENT);
-    POSIX_ENSURE(max_hash_size >= MD5_DIGEST_LENGTH, S2N_ERR_INSUFFICIENT_MEM_SIZE);
-    POSIX_ENSURE_REF(hash);
-    POSIX_ENSURE_REF(hash_size);
+    const struct s2n_fingerprint_method *method = &ja3_fingerprint;
+    POSIX_ENSURE(max_output_size >= method->hash_size, S2N_ERR_INSUFFICIENT_MEM_SIZE);
+
+    POSIX_ENSURE_REF(ch);
+    POSIX_ENSURE(!ch->sslv2, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
+    POSIX_ENSURE_REF(output);
+    POSIX_ENSURE_REF(output_size);
     POSIX_ENSURE_REF(str_size);
-    *hash_size = 0;
+    *output_size = 0;
     *str_size = 0;
 
-    /* The maximum size of the JA3 string is variable and could theoretically
-     * be extremely large. However, we don't need enough memory to hold the full
-     * string when calculating a hash. We can calculate and add the JA3 string
-     * to the hash in chunks, similarly to how the TLS transcript hash is
-     * calculated by adding handshake messages to the hash as they become
-     * available. After a chunk is added to the hash, the string buffer can be
-     * wiped and reused for the next chunk.
+    struct s2n_stuffer output_stuffer = { 0 };
+    POSIX_GUARD(s2n_blob_init(&output_stuffer.blob, output, max_output_size));
+
+    /* The maximum size of the hash input string is variable and could theoretically
+     * be extremely large. However, we don't need enough memory to hold the full string
+     * when calculating a hash. We can calculate and add the string to the hash in chunks,
+     * similarly to how the TLS transcript hash is calculated by adding handshake
+     * messages to the hash as they become available. After a chunk is added to the hash,
+     * the buffer can be wiped and reused for the next chunk.
      *
-     * The size of this buffer was chosen fairly arbitrarily.
+     * This ensures that our calculation requires a constant amount of memory.
+     *
+     * The size of the buffer is chosen to be the block size of most hashes.
      */
-    uint8_t string_mem[50] = { 0 };
-    struct s2n_blob string_blob = { 0 };
-    struct s2n_stuffer string_stuffer = { 0 };
-    POSIX_GUARD(s2n_blob_init(&string_blob, string_mem, sizeof(string_mem)));
-    POSIX_GUARD(s2n_stuffer_init(&string_stuffer, &string_blob));
+    uint8_t hash_mem[64] = { 0 };
+    struct s2n_stuffer hash_stuffer = { 0 };
+    POSIX_GUARD(s2n_blob_init(&hash_stuffer.blob, hash_mem, sizeof(hash_mem)));
 
-    /* JA3 uses an MD5 hash.
-     * The hash doesn't have to be cryptographically secure,
-     * so the weakness of MD5 shouldn't be a problem.
-     */
-    DEFER_CLEANUP(struct s2n_hash_state md5_hash = { 0 }, s2n_hash_free);
-    POSIX_GUARD(s2n_hash_new(&md5_hash));
-    if (s2n_is_in_fips_mode()) {
-        /* This hash is unrelated to TLS and does not affect FIPS */
-        POSIX_GUARD(s2n_hash_allow_md5_for_fips(&md5_hash));
-    }
-    POSIX_GUARD(s2n_hash_init(&md5_hash, S2N_HASH_MD5));
+    DEFER_CLEANUP(struct s2n_hash_state hash_state = { 0 }, s2n_hash_free);
+    POSIX_GUARD(s2n_hash_new(&hash_state));
+    s2n_hash_allow_md5_for_fips(&hash_state);
 
-    POSIX_GUARD_RESULT(s2n_fingerprint_ja3(ch, &string_stuffer, hash_size, &md5_hash));
-    POSIX_GUARD_RESULT(s2n_fingerprint_hash_flush(&md5_hash, &string_stuffer));
+    struct s2n_fingerprint_hash hash = {
+        .buffer = &hash_stuffer,
+        .hash = &hash_state,
+        .do_digest = true,
+    };
 
-    uint64_t in_hash = 0;
-    POSIX_GUARD(s2n_hash_get_currently_in_hash_total(&md5_hash, &in_hash));
-    POSIX_ENSURE_LTE(in_hash, UINT32_MAX);
-    *str_size = in_hash;
-
-    POSIX_GUARD(s2n_hash_digest(&md5_hash, hash, MD5_DIGEST_LENGTH));
-    *hash_size = MD5_DIGEST_LENGTH;
+    POSIX_GUARD_RESULT(method->fingerprint(ch, &hash, &output_stuffer));
+    *output_size = s2n_stuffer_data_available(&output_stuffer);
+    *str_size = hash.bytes_digested;
     return S2N_SUCCESS;
 }
 
 int s2n_client_hello_get_fingerprint_string(struct s2n_client_hello *ch, s2n_fingerprint_type type,
-        uint32_t max_size, uint8_t *output, uint32_t *output_size)
+        uint32_t max_output_size, uint8_t *output, uint32_t *output_size)
 {
     POSIX_ENSURE(type == S2N_FINGERPRINT_JA3, S2N_ERR_INVALID_ARGUMENT);
-    POSIX_ENSURE(max_size > 0, S2N_ERR_INSUFFICIENT_MEM_SIZE);
+    const struct s2n_fingerprint_method *method = &ja3_fingerprint;
+    POSIX_ENSURE(max_output_size > 0, S2N_ERR_INSUFFICIENT_MEM_SIZE);
+
+    POSIX_ENSURE_REF(ch);
+    POSIX_ENSURE(!ch->sslv2, S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
     POSIX_ENSURE_REF(output);
     POSIX_ENSURE_REF(output_size);
     *output_size = 0;
 
-    struct s2n_blob output_blob = { 0 };
     struct s2n_stuffer output_stuffer = { 0 };
-    POSIX_GUARD(s2n_blob_init(&output_blob, output, max_size));
-    POSIX_GUARD(s2n_stuffer_init(&output_stuffer, &output_blob));
+    POSIX_GUARD(s2n_blob_init(&output_stuffer.blob, output, max_output_size));
 
-    POSIX_GUARD_RESULT(s2n_fingerprint_ja3(ch, &output_stuffer, output_size, NULL));
+    struct s2n_fingerprint_hash hash = {
+        .buffer = &output_stuffer,
+    };
+
+    POSIX_GUARD_RESULT(method->fingerprint(ch, &hash, &output_stuffer));
     *output_size = s2n_stuffer_data_available(&output_stuffer);
-
     return S2N_SUCCESS;
 }

--- a/tls/s2n_fingerprint.h
+++ b/tls/s2n_fingerprint.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include "api/s2n.h"
+#include "api/unstable/fingerprint.h"
+#include "crypto/s2n_hash.h"
+#include "stuffer/s2n_stuffer.h"
+#include "tls/s2n_client_hello.h"
+#include "utils/s2n_result.h"
+
+struct s2n_fingerprint_hash {
+    uint32_t bytes_digested;
+    struct s2n_stuffer *buffer;
+    struct s2n_hash_state *hash;
+    unsigned int do_digest : 1;
+};
+S2N_RESULT s2n_fingerprint_hash_init(struct s2n_fingerprint_hash *hash, s2n_hash_algorithm hash_alg);
+S2N_RESULT s2n_fingerprint_hash_add_char(struct s2n_fingerprint_hash *hash, char c);
+S2N_RESULT s2n_fingerprint_hash_add_str(struct s2n_fingerprint_hash *hash, const char *str);
+S2N_RESULT s2n_fingerprint_hash_digest(struct s2n_fingerprint_hash *hash, uint8_t *out, size_t out_size);
+
+struct s2n_fingerprint_method {
+    uint32_t hash_size;
+    S2N_RESULT (*fingerprint)(struct s2n_client_hello *ch,
+            struct s2n_fingerprint_hash *hash, struct s2n_stuffer *output);
+};
+extern struct s2n_fingerprint_method ja3_fingerprint;
+
+bool s2n_is_grease_value(uint16_t val);

--- a/tls/s2n_fingerprint.h
+++ b/tls/s2n_fingerprint.h
@@ -30,7 +30,7 @@ struct s2n_fingerprint_hash {
 S2N_RESULT s2n_fingerprint_hash_add_char(struct s2n_fingerprint_hash *hash, char c);
 S2N_RESULT s2n_fingerprint_hash_add_str(struct s2n_fingerprint_hash *hash, const char *str, size_t str_size);
 S2N_RESULT s2n_fingerprint_hash_digest(struct s2n_fingerprint_hash *hash, uint8_t *out, size_t out_size);
-bool s2n_fingerprint_hash_supports_digest(struct s2n_fingerprint_hash *hash);
+bool s2n_fingerprint_hash_do_digest(struct s2n_fingerprint_hash *hash);
 
 struct s2n_fingerprint_method {
     s2n_hash_algorithm hash;

--- a/tls/s2n_fingerprint.h
+++ b/tls/s2n_fingerprint.h
@@ -26,11 +26,11 @@ struct s2n_fingerprint_hash {
     uint32_t bytes_digested;
     struct s2n_stuffer *buffer;
     struct s2n_hash_state *hash;
-    unsigned int do_digest : 1;
 };
 S2N_RESULT s2n_fingerprint_hash_add_char(struct s2n_fingerprint_hash *hash, char c);
-S2N_RESULT s2n_fingerprint_hash_add_str(struct s2n_fingerprint_hash *hash, const char *str);
+S2N_RESULT s2n_fingerprint_hash_add_str(struct s2n_fingerprint_hash *hash, const char *str, size_t str_size);
 S2N_RESULT s2n_fingerprint_hash_digest(struct s2n_fingerprint_hash *hash, uint8_t *out, size_t out_size);
+bool s2n_fingerprint_hash_supports_digest(struct s2n_fingerprint_hash *hash);
 
 struct s2n_fingerprint_method {
     s2n_hash_algorithm hash;

--- a/tls/s2n_fingerprint.h
+++ b/tls/s2n_fingerprint.h
@@ -28,13 +28,12 @@ struct s2n_fingerprint_hash {
     struct s2n_hash_state *hash;
     unsigned int do_digest : 1;
 };
-S2N_RESULT s2n_fingerprint_hash_init(struct s2n_fingerprint_hash *hash, s2n_hash_algorithm hash_alg);
 S2N_RESULT s2n_fingerprint_hash_add_char(struct s2n_fingerprint_hash *hash, char c);
 S2N_RESULT s2n_fingerprint_hash_add_str(struct s2n_fingerprint_hash *hash, const char *str);
 S2N_RESULT s2n_fingerprint_hash_digest(struct s2n_fingerprint_hash *hash, uint8_t *out, size_t out_size);
 
 struct s2n_fingerprint_method {
-    uint32_t hash_size;
+    s2n_hash_algorithm hash;
     S2N_RESULT (*fingerprint)(struct s2n_client_hello *ch,
             struct s2n_fingerprint_hash *hash, struct s2n_stuffer *output);
 };

--- a/tls/s2n_fingerprint_ja3.c
+++ b/tls/s2n_fingerprint_ja3.c
@@ -1,0 +1,201 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "tls/extensions/s2n_extension_list.h"
+#include "tls/s2n_fingerprint.h"
+#include "utils/s2n_blob.h"
+#include "utils/s2n_safety.h"
+
+#define S2N_JA3_FIELD_DIV ','
+#define S2N_JA3_LIST_DIV  '-'
+
+/* UINT16_MAX == 65535 */
+#define S2N_UINT16_STR_MAX_SIZE 5
+
+static S2N_RESULT s2n_fingerprint_ja3_digest(struct s2n_fingerprint_hash *hash,
+        struct s2n_stuffer *out)
+{
+    if (!hash->do_digest) {
+        return S2N_RESULT_OK;
+    }
+
+    uint8_t *digest = s2n_stuffer_raw_write(out, MD5_DIGEST_LENGTH);
+    RESULT_GUARD_PTR(digest);
+    RESULT_GUARD(s2n_fingerprint_hash_digest(hash, digest, MD5_DIGEST_LENGTH));
+
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_fingerprint_ja3_iana(struct s2n_fingerprint_hash *hash,
+        bool *is_list, uint16_t iana)
+{
+    if (s2n_is_grease_value(iana)) {
+        return S2N_RESULT_OK;
+    }
+
+    if (*is_list) {
+        RESULT_GUARD(s2n_fingerprint_hash_add_char(hash, S2N_JA3_LIST_DIV));
+    } else {
+        *is_list = true;
+    }
+
+    char str[S2N_UINT16_STR_MAX_SIZE + 1] = { 0 };
+    int written = snprintf(str, sizeof(str), "%u", iana);
+    RESULT_ENSURE_GT(written, 0);
+    RESULT_ENSURE_LTE(written, S2N_UINT16_STR_MAX_SIZE);
+
+    RESULT_GUARD(s2n_fingerprint_hash_add_str(hash, str));
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_fingerprint_ja3_version(struct s2n_fingerprint_hash *hash,
+        struct s2n_client_hello *ch)
+{
+    struct s2n_stuffer message = { 0 };
+    RESULT_ENSURE_REF(ch);
+    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&message, &ch->raw_message));
+
+    uint16_t version = 0;
+    RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&message, &version));
+
+    bool is_list = false;
+    RESULT_GUARD(s2n_fingerprint_ja3_iana(hash, &is_list, version));
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_fingerprint_ja3_cipher_suites(struct s2n_fingerprint_hash *hash,
+        struct s2n_client_hello *ch)
+{
+    RESULT_ENSURE_REF(ch);
+
+    struct s2n_stuffer ciphers = { 0 };
+    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&ciphers, &ch->cipher_suites));
+
+    bool found = false;
+    while (s2n_stuffer_data_available(&ciphers)) {
+        uint16_t iana = 0;
+        RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&ciphers, &iana));
+        RESULT_GUARD(s2n_fingerprint_ja3_iana(hash, &found, iana));
+    }
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_fingerprint_ja3_extensions(struct s2n_fingerprint_hash *hash,
+        struct s2n_client_hello *ch)
+{
+    RESULT_ENSURE_REF(ch);
+
+    /* We have to use the raw extensions instead of the parsed extensions
+     * because s2n-tls both intentionally ignores any unknown extensions
+     * and reorders the extensions when parsing the list.
+     */
+    struct s2n_stuffer extensions = { 0 };
+    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&extensions, &ch->extensions.raw));
+
+    bool found = false;
+    while (s2n_stuffer_data_available(&extensions)) {
+        uint16_t iana = 0, size = 0;
+        RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&extensions, &iana));
+        RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&extensions, &size));
+        RESULT_GUARD_POSIX(s2n_stuffer_skip_read(&extensions, size));
+        RESULT_GUARD(s2n_fingerprint_ja3_iana(hash, &found, iana));
+    }
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_fingerprint_ja3_elliptic_curves(struct s2n_fingerprint_hash *hash,
+        struct s2n_client_hello *ch)
+{
+    RESULT_ENSURE_REF(ch);
+
+    s2n_parsed_extension *extension = NULL;
+    int result = s2n_client_hello_get_parsed_extension(S2N_EXTENSION_SUPPORTED_GROUPS,
+            &ch->extensions, &extension);
+    if (result != S2N_SUCCESS) {
+        return S2N_RESULT_OK;
+    }
+
+    struct s2n_stuffer elliptic_curves = { 0 };
+    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&elliptic_curves, &extension->extension));
+    RESULT_GUARD_POSIX(s2n_stuffer_skip_read(&elliptic_curves, sizeof(uint16_t)));
+
+    bool found = false;
+    while (s2n_stuffer_data_available(&elliptic_curves)) {
+        uint16_t iana = 0;
+        RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&elliptic_curves, &iana));
+        RESULT_GUARD(s2n_fingerprint_ja3_iana(hash, &found, iana));
+    }
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_fingerprint_ja3_point_formats(struct s2n_fingerprint_hash *hash,
+        struct s2n_client_hello *ch)
+{
+    RESULT_ENSURE_REF(ch);
+
+    s2n_parsed_extension *extension = NULL;
+    int result = s2n_client_hello_get_parsed_extension(S2N_EXTENSION_EC_POINT_FORMATS,
+            &ch->extensions, &extension);
+    if (result != S2N_SUCCESS) {
+        return S2N_RESULT_OK;
+    }
+
+    struct s2n_stuffer point_formats = { 0 };
+    RESULT_GUARD_POSIX(s2n_stuffer_init_written(&point_formats, &extension->extension));
+    RESULT_GUARD_POSIX(s2n_stuffer_skip_read(&point_formats, sizeof(uint8_t)));
+
+    bool found = false;
+    while (s2n_stuffer_data_available(&point_formats)) {
+        uint8_t iana = 0;
+        RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(&point_formats, &iana));
+        RESULT_GUARD(s2n_fingerprint_ja3_iana(hash, &found, iana));
+    }
+    return S2N_RESULT_OK;
+}
+
+/* JA3 involves concatenating a set of fields from the ClientHello:
+ *      SSLVersion,Cipher,SSLExtension,EllipticCurve,EllipticCurvePointFormat
+ * For example:
+ *      "769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0"
+ * See https://github.com/salesforce/ja3
+ */
+static S2N_RESULT s2n_fingerprint_ja3_write(struct s2n_fingerprint_hash *hash,
+        struct s2n_client_hello *ch)
+{
+    RESULT_GUARD(s2n_fingerprint_ja3_version(hash, ch));
+    RESULT_GUARD(s2n_fingerprint_hash_add_char(hash, S2N_JA3_FIELD_DIV));
+    RESULT_GUARD(s2n_fingerprint_ja3_cipher_suites(hash, ch));
+    RESULT_GUARD(s2n_fingerprint_hash_add_char(hash, S2N_JA3_FIELD_DIV));
+    RESULT_GUARD(s2n_fingerprint_ja3_extensions(hash, ch));
+    RESULT_GUARD(s2n_fingerprint_hash_add_char(hash, S2N_JA3_FIELD_DIV));
+    RESULT_GUARD(s2n_fingerprint_ja3_elliptic_curves(hash, ch));
+    RESULT_GUARD(s2n_fingerprint_hash_add_char(hash, S2N_JA3_FIELD_DIV));
+    RESULT_GUARD(s2n_fingerprint_ja3_point_formats(hash, ch));
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_fingerprint_ja3(struct s2n_client_hello *client_hello,
+        struct s2n_fingerprint_hash *hash, struct s2n_stuffer *output)
+{
+    RESULT_GUARD(s2n_fingerprint_hash_init(hash, S2N_HASH_MD5));
+    RESULT_GUARD(s2n_fingerprint_ja3_write(hash, client_hello));
+    RESULT_GUARD(s2n_fingerprint_ja3_digest(hash, output));
+    return S2N_RESULT_OK;
+}
+
+struct s2n_fingerprint_method ja3_fingerprint = {
+    .hash_size = MD5_DIGEST_LENGTH,
+    .fingerprint = s2n_fingerprint_ja3,
+};

--- a/tls/s2n_fingerprint_ja3.c
+++ b/tls/s2n_fingerprint_ja3.c
@@ -189,13 +189,12 @@ static S2N_RESULT s2n_fingerprint_ja3_write(struct s2n_fingerprint_hash *hash,
 S2N_RESULT s2n_fingerprint_ja3(struct s2n_client_hello *client_hello,
         struct s2n_fingerprint_hash *hash, struct s2n_stuffer *output)
 {
-    RESULT_GUARD(s2n_fingerprint_hash_init(hash, S2N_HASH_MD5));
     RESULT_GUARD(s2n_fingerprint_ja3_write(hash, client_hello));
     RESULT_GUARD(s2n_fingerprint_ja3_digest(hash, output));
     return S2N_RESULT_OK;
 }
 
 struct s2n_fingerprint_method ja3_fingerprint = {
-    .hash_size = MD5_DIGEST_LENGTH,
+    .hash = S2N_HASH_MD5,
     .fingerprint = s2n_fingerprint_ja3,
 };

--- a/tls/s2n_fingerprint_ja3.c
+++ b/tls/s2n_fingerprint_ja3.c
@@ -27,7 +27,7 @@
 static S2N_RESULT s2n_fingerprint_ja3_digest(struct s2n_fingerprint_hash *hash,
         struct s2n_stuffer *out)
 {
-    if (!hash->do_digest) {
+    if (!s2n_fingerprint_hash_supports_digest(hash)) {
         return S2N_RESULT_OK;
     }
 
@@ -56,7 +56,7 @@ static S2N_RESULT s2n_fingerprint_ja3_iana(struct s2n_fingerprint_hash *hash,
     RESULT_ENSURE_GT(written, 0);
     RESULT_ENSURE_LTE(written, S2N_UINT16_STR_MAX_SIZE);
 
-    RESULT_GUARD(s2n_fingerprint_hash_add_str(hash, str));
+    RESULT_GUARD(s2n_fingerprint_hash_add_str(hash, str, written));
     return S2N_RESULT_OK;
 }
 


### PR DESCRIPTION
### Description of changes: 

Moving towards adding JA4 support.

I split the JA3-specific logic into a separate file. As part of that, I also better encapsulated the logic that calculates either a digest or a full string for a given hash, because JA4 will need to reuse that logic (JA4 includes two different digests, concatenated).

Other than the hashing, JA3 and JA4 share very little. JA3 uses decimal, JA4 uses hex. The separators are also different.

This is an example JA3 fingerprint:
```
769,47-53-5-10-49161-49162-49171-49172-50-56-19-4,0-10-11,23-24-25,0
```
While this is an example JA4 fingerprint:
```
t13d1516h2_002f,0035,009c,009d,1301,1302,1303_0005,000a,000b,000d,0012,0015,0017_0403,0804,0401,0503,0805,0501
```

### Callouts
The diff is really not good, but I can't figure out how to improve it. If it's completely unreadable,  I could just rename "s2n_fingerprint.c" to "s2n_fingerprint_common.c" to avoid the messy diff. I could then rename it back in a later PR.

### Testing:
The existing "s2n_fingerprint_ja3_test" tests continue to pass with the refactor. I also added some "s2n_fingerprint_test" tests for the hashing + grease value detection.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
