### PR TITLE
ci: fix cppcheck errors

### DIFF
--- a/tests/unit/s2n_client_key_exchange_test.c
+++ b/tests/unit/s2n_client_key_exchange_test.c
@@ -189,12 +189,12 @@ struct s2n_test_async_pkey_cb_ctx {
     uint32_t offload_invoked_count;
 };
 
-static int s2n_test_async_pkey_decrypt_callback(struct s2n_connection *conn, struct s2n_async_pkey_op *op)
+static int s2n_test_async_pkey_decrypt_callback(struct s2n_connection *conn, struct s2n_async_pkey_op *op_in)
 {
     POSIX_ENSURE_REF(conn);
-    POSIX_ENSURE_REF(op);
+    POSIX_ENSURE_REF(op_in);
 
-    DEFER_CLEANUP(struct s2n_async_pkey_op *op_defer_cleanup = op, s2n_async_pkey_op_free_pointer);
+    DEFER_CLEANUP(struct s2n_async_pkey_op *op = op_in, s2n_async_pkey_op_free_pointer);
 
     struct s2n_test_async_pkey_cb_ctx *ctx = s2n_connection_get_ctx(conn);
     POSIX_ENSURE_REF(ctx);
@@ -215,12 +215,12 @@ static int s2n_test_async_pkey_decrypt_callback(struct s2n_connection *conn, str
     return S2N_SUCCESS;
 }
 
-static int s2n_test_offload_pkey_decrypt_callback(struct s2n_connection *conn, struct s2n_async_pkey_op *op)
+static int s2n_test_offload_pkey_decrypt_callback(struct s2n_connection *conn, struct s2n_async_pkey_op *op_in)
 {
     POSIX_ENSURE_REF(conn);
-    POSIX_ENSURE_REF(op);
+    POSIX_ENSURE_REF(op_in);
 
-    DEFER_CLEANUP(struct s2n_async_pkey_op *op_defer_cleanup = op, s2n_async_pkey_op_free_pointer);
+    DEFER_CLEANUP(struct s2n_async_pkey_op *op = op_in, s2n_async_pkey_op_free_pointer);
 
     struct s2n_test_async_pkey_cb_ctx *ctx = s2n_connection_get_ctx(conn);
     POSIX_ENSURE_REF(ctx);


### PR DESCRIPTION
### Description of changes: 

Fix ci errors due to https://github.com/aws/s2n-tls/commit/114ccab0ff2cde491203ac841837d0d39b767412, because security advisories don't run the CI -_-

### Testing:
cppcheck passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
