### PR TITLE
fix: error rather than empty cipher suites

### DIFF
--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -51,8 +51,9 @@ S2N_RESULT s2n_stuffer_reservation_validate(const struct s2n_stuffer_reservation
     RESULT_GUARD(s2n_stuffer_validate(reserve_obj.stuffer));
     const struct s2n_stuffer stuffer_obj = *(reserve_obj.stuffer);
 
-    /* The entire reservation must fit between the read and write cursors */
+    /* Verify that write_cursor + length can be represented as a uint32_t without overflow */
     RESULT_ENSURE_LTE(reserve_obj.write_cursor, UINT32_MAX - reserve_obj.length);
+    /* The entire reservation must fit between the stuffer read and write cursors */
     RESULT_ENSURE_LTE(reserve_obj.write_cursor + reserve_obj.length, stuffer_obj.write_cursor);
     RESULT_ENSURE_GTE(reserve_obj.write_cursor, stuffer_obj.read_cursor);
 

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -50,13 +50,11 @@ S2N_RESULT s2n_stuffer_reservation_validate(const struct s2n_stuffer_reservation
     const struct s2n_stuffer_reservation reserve_obj = *reservation;
     RESULT_GUARD(s2n_stuffer_validate(reserve_obj.stuffer));
     const struct s2n_stuffer stuffer_obj = *(reserve_obj.stuffer);
-    RESULT_ENSURE(stuffer_obj.blob.size >= reserve_obj.length, S2N_ERR_SAFETY);
 
-    if (reserve_obj.length > 0) {
-        RESULT_ENSURE(reserve_obj.write_cursor < stuffer_obj.write_cursor, S2N_ERR_SAFETY);
-        RESULT_ENSURE(S2N_MEM_IS_WRITABLE(stuffer_obj.blob.data + reserve_obj.write_cursor, reserve_obj.length),
-                S2N_ERR_SAFETY);
-    }
+    /* The entire reservation must fit between the read and write cursors */
+    RESULT_ENSURE_LTE(reserve_obj.write_cursor, UINT32_MAX - reserve_obj.length);
+    RESULT_ENSURE_LTE(reserve_obj.write_cursor + reserve_obj.length, stuffer_obj.write_cursor);
+    RESULT_ENSURE_GTE(reserve_obj.write_cursor, stuffer_obj.read_cursor);
 
     return S2N_RESULT_OK;
 }

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -140,6 +140,14 @@ int S2N_RESULT_MUST_USE s2n_stuffer_reserve_uint8(struct s2n_stuffer *stuffer, s
 int S2N_RESULT_MUST_USE s2n_stuffer_reserve_uint16(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservation *reservation);
 int S2N_RESULT_MUST_USE s2n_stuffer_reserve_uint24(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservation *reservation);
 int S2N_RESULT_MUST_USE s2n_stuffer_write_reservation(struct s2n_stuffer_reservation *reservation, const uint32_t value);
+/* Reservations are primarily intended to handle the variable-length vector type
+ * defined in the RFC: https://tools.ietf.org/html/rfc8446#section-3.4
+ * Variable-length vectors are preceded by the total size of the vector in bytes
+ * (not to be confused with the number of elements in the vector).
+ *
+ * These methods calculate the size of the vector just written to a stuffer based
+ * on the stuffer's current write cursor.
+ */
 int S2N_RESULT_MUST_USE s2n_stuffer_get_vector_size(const struct s2n_stuffer_reservation *reservation, uint32_t *size);
 int S2N_RESULT_MUST_USE s2n_stuffer_write_vector_size(struct s2n_stuffer_reservation *reservation);
 

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -139,6 +139,8 @@ S2N_RESULT s2n_stuffer_reservation_validate(const struct s2n_stuffer_reservation
 int S2N_RESULT_MUST_USE s2n_stuffer_reserve_uint8(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservation *reservation);
 int S2N_RESULT_MUST_USE s2n_stuffer_reserve_uint16(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservation *reservation);
 int S2N_RESULT_MUST_USE s2n_stuffer_reserve_uint24(struct s2n_stuffer *stuffer, struct s2n_stuffer_reservation *reservation);
+int S2N_RESULT_MUST_USE s2n_stuffer_write_reservation(struct s2n_stuffer_reservation *reservation, const uint32_t value);
+int S2N_RESULT_MUST_USE s2n_stuffer_get_vector_size(const struct s2n_stuffer_reservation *reservation, uint32_t *size);
 int S2N_RESULT_MUST_USE s2n_stuffer_write_vector_size(struct s2n_stuffer_reservation *reservation);
 
 /* Copy one stuffer to another */

--- a/stuffer/s2n_stuffer_network_order.c
+++ b/stuffer/s2n_stuffer_network_order.c
@@ -197,11 +197,18 @@ int s2n_stuffer_write_reservation(struct s2n_stuffer_reservation *reservation, c
     return result;
 }
 
-int s2n_stuffer_write_vector_size(struct s2n_stuffer_reservation *reservation)
+int s2n_stuffer_get_vector_size(const struct s2n_stuffer_reservation *reservation, uint32_t *size)
 {
     POSIX_PRECONDITION(s2n_stuffer_reservation_validate(reservation));
+    POSIX_ENSURE_REF(size);
+    *size = reservation->stuffer->write_cursor - (reservation->write_cursor + reservation->length);
+    return S2N_SUCCESS;
+}
+
+int s2n_stuffer_write_vector_size(struct s2n_stuffer_reservation *reservation)
+{
     uint32_t size = 0;
-    POSIX_GUARD(s2n_sub_overflow(reservation->stuffer->write_cursor, reservation->write_cursor, &size));
-    POSIX_GUARD(s2n_sub_overflow(size, reservation->length, &size));
-    return s2n_stuffer_write_reservation(reservation, size);
+    POSIX_GUARD(s2n_stuffer_get_vector_size(reservation, &size));
+    POSIX_GUARD(s2n_stuffer_write_reservation(reservation, size));
+    return S2N_SUCCESS;
 }

--- a/tests/cbmc/proofs/s2n_stuffer_get_vector_size/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_get_vector_size/Makefile
@@ -1,0 +1,34 @@
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+CBMCFLAGS +=
+
+PROOF_UID = s2n_stuffer_get_vector_size
+HARNESS_ENTRY = $(PROOF_UID)_harness
+HARNESS_FILE = $(HARNESS_ENTRY).c
+
+PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
+PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
+PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/sysconf.c
+
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer.c
+PROJECT_SOURCES += $(SRCDIR)/stuffer/s2n_stuffer_network_order.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_blob.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_mem.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c
+PROJECT_SOURCES += $(SRCDIR)/utils/s2n_result.c
+
+include ../Makefile.common

--- a/tests/cbmc/proofs/s2n_stuffer_get_vector_size/cbmc-proof.txt
+++ b/tests/cbmc/proofs/s2n_stuffer_get_vector_size/cbmc-proof.txt
@@ -1,0 +1,1 @@
+# This file marks this directory as containing a CBMC proof.

--- a/tests/cbmc/proofs/s2n_stuffer_get_vector_size/s2n_stuffer_get_vector_size_harness.c
+++ b/tests/cbmc/proofs/s2n_stuffer_get_vector_size/s2n_stuffer_get_vector_size_harness.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <assert.h>
+#include <cbmc_proof/cbmc_utils.h>
+#include <cbmc_proof/make_common_datastructures.h>
+#include <cbmc_proof/nondet.h>
+
+#include "api/s2n.h"
+#include "stuffer/s2n_stuffer.h"
+
+void s2n_stuffer_get_vector_size_harness()
+{
+    nondet_s2n_mem_init();
+
+    struct s2n_stuffer_reservation *reservation = cbmc_allocate_s2n_stuffer_reservation();
+    __CPROVER_assume(s2n_result_is_ok(s2n_stuffer_reservation_validate(reservation)));
+
+    uint32_t output = 0;
+    assert(s2n_stuffer_get_vector_size(reservation, &output) == S2N_SUCCESS);
+
+    assert(s2n_result_is_ok(s2n_stuffer_reservation_validate(reservation)));
+    uint32_t expected_output = reservation->stuffer->write_cursor -
+            (reservation->write_cursor + reservation->length);
+    assert(expected_output == output);
+}

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -669,6 +669,7 @@ int main(int argc, char **argv)
                     S2N_ERR_INVALID_CIPHER_PREFERENCES);
 
             /* Succeeds with one cipher suite available / written */
+            /* cppcheck-suppress redundantAssignment */
             cipher_suite.available = true;
             EXPECT_SUCCESS(s2n_client_hello_send(conn));
         };

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -646,6 +646,32 @@ int main(int argc, char **argv)
 
             EXPECT_SUCCESS(s2n_config_free(config));
         };
+
+        /* Error if no cipher suites written. */
+        {
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(conn);
+
+            struct s2n_cipher_suite cipher_suite = s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
+            struct s2n_cipher_suite *cipher_suites = &cipher_suite;
+            struct s2n_cipher_preferences cipher_preferences = {
+                .suites = &cipher_suites,
+                .count = 1,
+            };
+            struct s2n_security_policy policy = *conn->config->security_policy;
+            policy.cipher_preferences = &cipher_preferences;
+            conn->security_policy_override = &policy;
+
+            /* Fails with no cipher suites available / written */
+            cipher_suite.available = false;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_client_hello_send(conn),
+                    S2N_ERR_INVALID_CIPHER_PREFERENCES);
+
+            /* Succeeds with one cipher suite available / written */
+            cipher_suite.available = true;
+            EXPECT_SUCCESS(s2n_client_hello_send(conn));
+        };
     };
 
     /* Test that negotiating TLS1.2 with QUIC-enabled server fails */

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -774,7 +774,10 @@ int s2n_client_hello_send(struct s2n_connection *conn)
     }
 
     /* Write size of the list of available ciphers */
-    POSIX_GUARD(s2n_stuffer_write_vector_size(&available_cipher_suites_size));
+    uint32_t ciphers_size = 0;
+    POSIX_GUARD(s2n_stuffer_get_vector_size(&available_cipher_suites_size, &ciphers_size));
+    POSIX_ENSURE(ciphers_size > 0, S2N_ERR_INVALID_CIPHER_PREFERENCES);
+    POSIX_GUARD(s2n_stuffer_write_reservation(&available_cipher_suites_size, ciphers_size));
 
     /* Zero compression methods */
     POSIX_GUARD(s2n_stuffer_write_uint8(out, 1));


### PR DESCRIPTION
### Resolved issues:
Related to https://github.com/aws/s2n-tls/issues/4594

### Description of changes: 
We should never send a ClientHello without any cipher suites, even if none of the cipher suites in our security policy are usable. Currently that can probably only happen if you try to use a TLS1.2-only policy with s2n-quic, but this change minimally means that we'll get better visibility if another issue causes the same problem.

This change also turned into a bit of a s2n_stuffer_reservation proof cleanup. I had to add a new proof for my new stuffer reservation method. While debugging it, I realized that s2n_stuffer_reservation_validate really wasn't enforcing the invariants that it should be, so I fixed that. The properly written s2n_stuffer_reservation_validate also means that technically we can assume that the vector size is safe to calculate without s2n_sub_overflow, but I'm not sure if that's a dangerous assumption to make or not :/

### Call-outs:
This only addresses part of the linked issue. It is not intended as a complete solution. We should still try to prevent an application from setting a security policy that will result in no cipher suites, if possible.

### Testing:
- New unit test for sending a client hello with no available cipher suites
- New CBMC proof for s2n_stuffer_get_vector_size
- A CBMC proof already exists for s2n_stuffer_write_reservation, even though the method wasn't in s2n_stuffer.h before

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
