### PR TITLE
refactor(binding): more accurate naming for const str helper

### DIFF
--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -868,28 +868,34 @@ impl Connection {
         let handshake = unsafe {
             s2n_connection_get_handshake_type_name(self.connection.as_ptr()).into_result()?
         };
-        // SAFETY: constructed strings have a null byte appended to them
-        // SAFETY: the data has a 'static lifetime, because it resides in a static
-        // char array, and is never modified after its initial creation
-        unsafe { const_str!(handshake) }
+        unsafe {
+            // SAFETY: constructed strings have a null byte appended to them
+            // SAFETY: the data has a 'static lifetime, because it resides in a static
+            // char array, and is never modified after its initial creation
+            const_str!(handshake)
+        }
     }
 
     pub fn cipher_suite(&self) -> Result<&str, Error> {
         let cipher = unsafe { s2n_connection_get_cipher(self.connection.as_ptr()).into_result()? };
-        // SAFETY: The data is null terminated because it is declared as a C string literal.
-        // SAFETY: cipher has a static lifetime because it lives on s2n_cipher_suite, a static struct.
-        // a static const struct, and therefore outlives the surrounding scope
-        // (which is the lifetime of the connection)
-        unsafe { const_str!(cipher) }
+        unsafe {
+            // SAFETY: The data is null terminated because it is declared as a C string literal.
+            // SAFETY: cipher has a static lifetime because it lives on s2n_cipher_suite, a static struct.
+            // a static const struct, and therefore outlives the surrounding scope
+            // (which is the lifetime of the connection)
+            const_str!(cipher)
+        }
     }
 
     pub fn selected_curve(&self) -> Result<&str, Error> {
         let curve = unsafe { s2n_connection_get_curve(self.connection.as_ptr()).into_result()? };
-        // SAFETY: The data is null terminated because it is declared as a C string literal.
-        // SAFETY: curve has a static lifetime because it lives on s2n_ecc_named_curve, which is a static const struct.
-        // a static const struct, and therefore outlives the surrounding scope
-        // (which is the lifetime of the connection)
-        unsafe { const_str!(curve) }
+        unsafe {
+            // SAFETY: The data is null terminated because it is declared as a C string literal.
+            // SAFETY: curve has a static lifetime because it lives on s2n_ecc_named_curve, which is a static const struct.
+            // a static const struct, and therefore outlives the surrounding scope
+            // (which is the lifetime of the connection)
+            const_str!(curve)
+        }
     }
 
     pub fn selected_signature_algorithm(&self) -> Result<SignatureAlgorithm, Error> {

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -869,9 +869,10 @@ impl Connection {
             s2n_connection_get_handshake_type_name(self.connection.as_ptr()).into_result()?
         };
         unsafe {
-            // SAFETY: constructed strings have a null byte appended to them
-            // SAFETY: the data has a 'static lifetime, because it resides in a static
-            // char array, and is never modified after its initial creation
+            // SAFETY: Constructed strings have a null byte appended to them.
+            // SAFETY: The data has a 'static lifetime, because it resides in a 
+            //         static char array, and is never modified after its initial
+            //         creation.
             const_str!(handshake)
         }
     }
@@ -879,10 +880,10 @@ impl Connection {
     pub fn cipher_suite(&self) -> Result<&str, Error> {
         let cipher = unsafe { s2n_connection_get_cipher(self.connection.as_ptr()).into_result()? };
         unsafe {
-            // SAFETY: The data is null terminated because it is declared as a C string literal.
-            // SAFETY: cipher has a static lifetime because it lives on s2n_cipher_suite, a static struct.
-            // a static const struct, and therefore outlives the surrounding scope
-            // (which is the lifetime of the connection)
+            // SAFETY: The data is null terminated because it is declared as a C
+            //         string literal.
+            // SAFETY: cipher has a static lifetime because it lives on s2n_cipher_suite,
+            //         a static struct.
             const_str!(cipher)
         }
     }
@@ -890,10 +891,10 @@ impl Connection {
     pub fn selected_curve(&self) -> Result<&str, Error> {
         let curve = unsafe { s2n_connection_get_curve(self.connection.as_ptr()).into_result()? };
         unsafe {
-            // SAFETY: The data is null terminated because it is declared as a C string literal.
-            // SAFETY: curve has a static lifetime because it lives on s2n_ecc_named_curve, which is a static const struct.
-            // a static const struct, and therefore outlives the surrounding scope
-            // (which is the lifetime of the connection)
+            // SAFETY: The data is null terminated because it is declared as a C
+            //         string literal.
+            // SAFETY: curve has a static lifetime because it lives on s2n_ecc_named_curve,
+            //         which is a static const struct.
             const_str!(curve)
         }
     }

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -870,7 +870,7 @@ impl Connection {
         };
         unsafe {
             // SAFETY: Constructed strings have a null byte appended to them.
-            // SAFETY: The data has a 'static lifetime, because it resides in a 
+            // SAFETY: The data has a 'static lifetime, because it resides in a
             //         static char array, and is never modified after its initial
             //         creation.
             const_str!(handshake)

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -29,9 +29,9 @@ mod builder;
 pub use builder::*;
 
 /// return a &str scoped to the lifetime of the surrounding function
-/// 
+///
 /// SAFETY: must be called on a null terminated string
-/// 
+///
 /// SAFETY: the underlying data must live at least as long as the surrounding scope
 // We use a macro instead of a function so that the lifetime of the output is
 // automatically inferred to match the surrounding scope.
@@ -878,7 +878,7 @@ impl Connection {
         let cipher = unsafe { s2n_connection_get_cipher(self.connection.as_ptr()).into_result()? };
         // SAFETY: The data is null terminated because it is declared as a C string literal.
         // SAFETY: cipher has a static lifetime because it lives on s2n_cipher_suite, a static struct.
-        // a static const struct, and therefore outlives the surrounding scope 
+        // a static const struct, and therefore outlives the surrounding scope
         // (which is the lifetime of the connection)
         unsafe { const_str!(cipher) }
     }
@@ -887,7 +887,7 @@ impl Connection {
         let curve = unsafe { s2n_connection_get_curve(self.connection.as_ptr()).into_result()? };
         // SAFETY: The data is null terminated because it is declared as a C string literal.
         // SAFETY: curve has a static lifetime because it lives on s2n_ecc_named_curve, which is a static const struct.
-        // a static const struct, and therefore outlives the surrounding scope 
+        // a static const struct, and therefore outlives the surrounding scope
         // (which is the lifetime of the connection)
         unsafe { const_str!(curve) }
     }

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -870,14 +870,14 @@ impl Connection {
         };
         // SAFETY: constructed strings have a null byte appended to them
         // SAFETY: the data has a 'static lifetime, because it resides in a static
-        // char array, and is never modified after it's initial creation
+        // char array, and is never modified after its initial creation
         unsafe { const_str!(handshake) }
     }
 
     pub fn cipher_suite(&self) -> Result<&str, Error> {
         let cipher = unsafe { s2n_connection_get_cipher(self.connection.as_ptr()).into_result()? };
         // SAFETY: The data is null terminated because it is declared as a C string literal.
-        // SAFETY: The data has a static lifetime because it is associated with 
+        // SAFETY: cipher has a static lifetime because it lives on s2n_cipher_suite, a static struct.
         // a static const struct, and therefore outlives the surrounding scope 
         // (which is the lifetime of the connection)
         unsafe { const_str!(cipher) }
@@ -886,7 +886,7 @@ impl Connection {
     pub fn selected_curve(&self) -> Result<&str, Error> {
         let curve = unsafe { s2n_connection_get_curve(self.connection.as_ptr()).into_result()? };
         // SAFETY: The data is null terminated because it is declared as a C string literal.
-        // SAFETY: The data has a static lifetime because it is associated with 
+        // SAFETY: curve has a static lifetime because it lives on s2n_ecc_named_curve, which is a static const struct.
         // a static const struct, and therefore outlives the surrounding scope 
         // (which is the lifetime of the connection)
         unsafe { const_str!(curve) }

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -28,9 +28,16 @@ use std::{any::Any, ffi::CStr};
 mod builder;
 pub use builder::*;
 
-macro_rules! static_const_str {
+/// return a &str scoped to the lifetime of the surrounding function
+/// 
+/// SAFETY: must be called on a null terminated string
+/// 
+/// SAFETY: the underlying data must live at least as long as the surrounding scope
+// We use a macro instead of a function so that the lifetime of the output is
+// automatically inferred to match the surrounding scope.
+macro_rules! const_str {
     ($c_chars:expr) => {
-        unsafe { CStr::from_ptr($c_chars) }
+        CStr::from_ptr($c_chars)
             .to_str()
             .map_err(|_| Error::INVALID_INPUT)
     };
@@ -861,21 +868,28 @@ impl Connection {
         let handshake = unsafe {
             s2n_connection_get_handshake_type_name(self.connection.as_ptr()).into_result()?
         };
-        // The strings returned by s2n_connection_get_handshake_type_name
-        // are static and immutable after they are first calculated
-        static_const_str!(handshake)
+        // SAFETY: constructed strings have a null byte appended to them
+        // SAFETY: the data has a 'static lifetime, because it resides in a static
+        // char array, and is never modified after it's initial creation
+        unsafe { const_str!(handshake) }
     }
 
     pub fn cipher_suite(&self) -> Result<&str, Error> {
         let cipher = unsafe { s2n_connection_get_cipher(self.connection.as_ptr()).into_result()? };
-        // The strings returned by s2n_connection_get_cipher
-        // are static and immutable since they are const fields on static const structs
-        static_const_str!(cipher)
+        // SAFETY: The data is null terminated because it is declared as a C string literal.
+        // SAFETY: The data has a static lifetime because it is associated with 
+        // a static const struct, and therefore outlives the surrounding scope 
+        // (which is the lifetime of the connection)
+        unsafe { const_str!(cipher) }
     }
 
     pub fn selected_curve(&self) -> Result<&str, Error> {
         let curve = unsafe { s2n_connection_get_curve(self.connection.as_ptr()).into_result()? };
-        static_const_str!(curve)
+        // SAFETY: The data is null terminated because it is declared as a C string literal.
+        // SAFETY: The data has a static lifetime because it is associated with 
+        // a static const struct, and therefore outlives the surrounding scope 
+        // (which is the lifetime of the connection)
+        unsafe { const_str!(curve) }
     }
 
     pub fn selected_signature_algorithm(&self) -> Result<SignatureAlgorithm, Error> {


### PR DESCRIPTION
### Description of changes: 

- remove the `unsafe` block from the macro, forcing callers to explicitly mark the macro as unsafe.
- rename the macro to `const_str`, since no static lifetimes were being used
- explicitly spell out the safety conditions

### Testing:

This does not change any of the functionality of the underlying code, just the way it must be called.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
