### PR TITLE
s2n-tls-tokio: allow to set application context when accept

### DIFF
--- a/bindings/rust/s2n-tls-tokio/src/lib.rs
+++ b/bindings/rust/s2n-tls-tokio/src/lib.rs
@@ -56,6 +56,20 @@ where
         let conn = self.builder.build_connection(Mode::Server)?;
         TlsStream::open(conn, stream).await
     }
+
+    pub async fn accept_with_application_context<S, T>(
+        &self,
+        stream: S,
+        app_context: T,
+    ) -> Result<TlsStream<S, B::Output>, Error>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+        T: Send + Sync + 'static,
+    {
+        let mut conn = self.builder.build_connection(Mode::Server)?;
+        conn.as_mut().set_application_context(app_context);
+        TlsStream::open(conn, stream).await
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
### Description of changes: 

Add a TlsAcceptor::accept_with_application_context method to set an application context early, which may be used in client hello callbacks.

The other way is to add a application context to TlsAcceptor, with also a TlsAcceptor::new_with_application_context method.

### Testing:

Will add one later after the API is sure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
