### PR TITLE
fix: remove S2N_NO_PQ option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -584,7 +584,7 @@ if (BUILD_TESTING)
                         pytest
                         -x -n=${N} --reruns=2 --durations=10 --cache-clear -rpfsq
                         -o log_cli=true --log-cli-level=DEBUG --provider-version=$ENV{S2N_LIBCRYPTO}
-                        --provider-criterion=off --fips-mode=0 --no-pq=0 ${test_file_path}
+                        --provider-criterion=off --fips-mode=0 ${test_file_path}
                         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/integrationv2
                 )
             else()

--- a/codebuild/bin/criterion_baseline.sh
+++ b/codebuild/bin/criterion_baseline.sh
@@ -16,8 +16,6 @@ set -eu
 source codebuild/bin/s2n_setup_env.sh
 source codebuild/bin/utils.sh
 
-# Disable PQ
-export S2N_NO_PQ=1
 # Limit the number of child processes in the test run
 export RUST_BACKTRACE=1
 export TOX_TEST_NAME="$INTEGV2_TEST"

--- a/codebuild/bin/criterion_delta.sh
+++ b/codebuild/bin/criterion_delta.sh
@@ -13,8 +13,6 @@
 # permissions and limitations under the License.
 set -eu
 source ./codebuild/bin/utils.sh
-# Disable PQ
-export S2N_NO_PQ=1
 export AWS_S3_BUCKET="s3://s2n-tls-logs/"
 # Limit the number of child processes in the test run
 export RUST_BACKTRACE=1

--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -61,11 +61,6 @@ if [[ "$OS_NAME" == "linux" && "$TESTS" == "valgrind" ]]; then
     kill %1
 fi
 
-CMAKE_PQ_OPTION="S2N_NO_PQ=False"
-if [[ -n "$S2N_NO_PQ" ]]; then
-    CMAKE_PQ_OPTION="S2N_NO_PQ=True"
-fi
-
 test_linked_libcrypto() {
     s2n_executable="$1"
     so_path="${LIBCRYPTO_ROOT}/lib/libcrypto.so"
@@ -93,7 +88,6 @@ run_integration_v2_tests() {
     "$CB_BIN_DIR/install_s2n_head.sh" "$(mktemp -d)"
     cmake . -Bbuild \
             -DCMAKE_PREFIX_PATH=$LIBCRYPTO_ROOT \
-            -D${CMAKE_PQ_OPTION} \
             -DS2N_BLOCK_NONPORTABLE_OPTIMIZATIONS=True \
             -DBUILD_SHARED_LIBS=on \
             -DS2N_INTEG_TESTS=on \
@@ -114,7 +108,6 @@ run_integration_v2_tests() {
 run_unit_tests() {
     cmake . -Bbuild \
             -DCMAKE_PREFIX_PATH=$LIBCRYPTO_ROOT \
-            -D${CMAKE_PQ_OPTION} \
             -DS2N_BLOCK_NONPORTABLE_OPTIMIZATIONS=True \
             -DBUILD_SHARED_LIBS=on
     cmake --build ./build -- -j $(nproc)

--- a/codebuild/bin/s2n_codebuild_al2.sh
+++ b/codebuild/bin/s2n_codebuild_al2.sh
@@ -24,16 +24,11 @@ if [[ "$OS_NAME" == "linux" && -n "$CODEBUILD_BUILD_ARN" ]]; then
     sudo -E ${PRLIMIT_LOCATION} --pid "$$" --memlock=unlimited:unlimited;
 fi
 
-CMAKE_PQ_OPTION="S2N_NO_PQ=False"
-if [[ -n "$S2N_NO_PQ" ]]; then
-    CMAKE_PQ_OPTION="S2N_NO_PQ=True"
-fi
-
 # Linker flags are a workaround for openssl
 case "$TESTS" in
   "unit")
     cmake . -Bbuild -DCMAKE_EXE_LINKER_FLAGS="-lcrypto -lz" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-      -D${CMAKE_PQ_OPTION} -DS2N_BLOCK_NONPORTABLE_OPTIMIZATIONS=True
+      -DS2N_BLOCK_NONPORTABLE_OPTIMIZATIONS=True
     cmake --build ./build -j $(nproc)
     cmake --build ./build --target test -- ARGS="-L unit --output-on-failure"
     ;;

--- a/codebuild/bin/s2n_setup_env.sh
+++ b/codebuild/bin/s2n_setup_env.sh
@@ -114,7 +114,6 @@ export FUZZ_TIMEOUT_SEC
 export GB_INSTALL_DIR
 export OS_NAME
 export S2N_CORKED_IO
-export S2N_NO_PQ
 # For use by criterion/ci run reports
 export AWS_S3_URL="s3://s2n-tls-logs/release/"
 

--- a/codebuild/spec/buildspec_generalbatch.yml
+++ b/codebuild/spec/buildspec_generalbatch.yml
@@ -173,9 +173,8 @@ batch:
           BUILD_S2N: 'true'
           GCC_VERSION: '9'
           S2N_LIBCRYPTO: 'openssl-1.1.1'
-          S2N_NO_PQ: 1
           TESTS: unit
-      identifier: s2nUnitNoPQ
+      identifier: s2nUnitOpenssl111Gcc9
     - buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
@@ -195,7 +194,6 @@ batch:
         privileged-mode: true
         type: ARM_CONTAINER
         variables:
-          S2N_NO_PQ: 1
           TESTS: unit
       identifier: s2nUnitAl2Arm
     - buildspec: codebuild/spec/buildspec_amazonlinux2.yml
@@ -204,7 +202,6 @@ batch:
         image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
         privileged-mode: true
         variables:
-          S2N_NO_PQ: 1
           TESTS: unit
           S2N_LIBCRYPTO: default
       identifier: s2nUnitAL2
@@ -214,7 +211,6 @@ batch:
         image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
         privileged-mode: true
         variables:
-          S2N_NO_PQ: 1
           TESTS: unit
           S2N_LIBCRYPTO: openssl-1.1.1
       identifier: s2nUnitAl2Openssl111
@@ -296,7 +292,6 @@ batch:
           BUILD_S2N: 'true'
           GCC_VERSION: '6'
           S2N_LIBCRYPTO: 'libressl'
-          S2N_NO_PQ: 1
           TESTS: unit
       identifier: s2nUnitLibressl
     - buildspec: codebuild/spec/buildspec_ubuntu.yml
@@ -308,7 +303,6 @@ batch:
           BUILD_S2N: 'true'
           GCC_VERSION: '9'
           S2N_LIBCRYPTO: 'boringssl'
-          S2N_NO_PQ: 1
           TESTS: unit
       identifier: s2nUnitBoringssl
     - buildspec: codebuild/spec/buildspec_ubuntu.yml
@@ -332,7 +326,6 @@ batch:
           CC: '/usr/bin/clang'
           CXX: '/usr/bin/clang++'
           S2N_LIBCRYPTO: 'awslc'
-          S2N_NO_PQ: 1
           TESTS: unit
       identifier: s2nUnitClang15
     - identifier: 32BitBuildAndUnit

--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -157,7 +157,7 @@ batch:
           S2N_LIBCRYPTO: 'openssl-1.0.2'
           BUILD_S2N: 'true'
 
-    - identifier: s2nUnitNoPQ
+    - identifier: s2nUnitOpenssl111Gcc9
       buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         privileged-mode: true
@@ -167,7 +167,6 @@ batch:
           TESTS: unit
           GCC_VERSION: '9'
           S2N_LIBCRYPTO: 'openssl-1.1.1'
-          S2N_NO_PQ: 1
           BUILD_S2N: 'true'
 
     - identifier: s2nUnitAl2Arm
@@ -178,7 +177,6 @@ batch:
         image: aws/codebuild/amazonlinux2-aarch64-standard:2.0
         privileged-mode: true
         variables:
-          S2N_NO_PQ: 1
           TESTS: unit
 
     - identifier: s2nUnitAl2
@@ -189,7 +187,6 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           TESTS: unit
-          S2N_NO_PQ: 1
 
     - identifier: s2nLibcryptoInterningOpenSSL
       buildspec: codebuild/spec/buildspec_ubuntu.yml
@@ -280,7 +277,6 @@ batch:
           BUILD_S2N: 'true'
           GCC_VERSION: '6'
           S2N_LIBCRYPTO: 'libressl'
-          S2N_NO_PQ: 1
           TESTS: unit
       identifier: s2nUnitLibressl
 
@@ -293,7 +289,6 @@ batch:
           BUILD_S2N: 'true'
           GCC_VERSION: '9'
           S2N_LIBCRYPTO: 'boringssl'
-          S2N_NO_PQ: 1
           TESTS: unit
       identifier: s2nUnitBoringssl
 

--- a/codebuild/spec/buildspec_ubuntu_integv2criterion.yml
+++ b/codebuild/spec/buildspec_ubuntu_integv2criterion.yml
@@ -17,7 +17,6 @@ batch:
         variables:
           INTEGV2_TEST: test_well_known_endpoints
           S2N_USE_CRITERION: 2
-          S2N_NO_PQ: 1
           TESTS: integrationv2crit
           GCC_VERSION: 6
           RUST_BACKTRACE: 1
@@ -29,7 +28,6 @@ batch:
         variables:
           INTEGV2_TEST: test_well_known_endpoints
           S2N_USE_CRITERION: 1
-          S2N_NO_PQ: 1
           TESTS: integrationv2crit
           GCC_VERSION: 6
           ARTIFACT_BUCKET: s3://s2n-tls-logs/release

--- a/flake.nix
+++ b/flake.nix
@@ -68,8 +68,7 @@
           configurePhase = ''
             cmake -S . -B./build \
                   -DBUILD_SHARED_LIBS=ON \
-                  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-                  -DS2N_NO_PQ=0
+                  -DCMAKE_BUILD_TYPE=RelWithDebInfo
           ''; # TODO: set when system like aarch64/mips,etc
 
           buildPhase = ''

--- a/tests/integrationv2/conftest.py
+++ b/tests/integrationv2/conftest.py
@@ -1,4 +1,4 @@
-from global_flags import set_flag, S2N_PROVIDER_VERSION, S2N_FIPS_MODE, S2N_NO_PQ, S2N_USE_CRITERION
+from global_flags import set_flag, S2N_PROVIDER_VERSION, S2N_FIPS_MODE, S2N_USE_CRITERION
 
 
 def pytest_addoption(parser):
@@ -6,8 +6,6 @@ def pytest_addoption(parser):
                      default=None, type=str, help="Set the version of the TLS provider")
     parser.addoption("--fips-mode", action="store", dest="fips-mode",
                      default=False, type=int, help="S2N is running in FIPS mode")
-    parser.addoption("--no-pq", action="store", dest="no-pq",
-                     default=False, type=int, help="Turn off PQ support")
     parser.addoption("--provider-criterion", action="store", dest="provider-criterion",
                      default="off", type=str, choices=['off', 'baseline', 'delta'], help="Use Criterion provider in one of 3 modes: [off,baseline,delta]")
 
@@ -21,10 +19,7 @@ def pytest_configure(config):
         "markers", "uncollect_if(*, func): function to unselect tests from parametrization"
     )
 
-    no_pq = config.getoption('no-pq', 0)
     fips_mode = config.getoption('fips-mode', 0)
-    if no_pq == 1:
-        set_flag(S2N_NO_PQ, True)
     if fips_mode == 1:
         set_flag(S2N_FIPS_MODE, True)
 

--- a/tests/integrationv2/global_flags.py
+++ b/tests/integrationv2/global_flags.py
@@ -2,9 +2,6 @@
 # These flags enable Providers and Tests to determine how to behave
 # based on the environment.
 
-# If PQ support was not compiled in to S2N
-S2N_NO_PQ = 's2n_no_pq'
-
 # If S2N is operating in FIPS mode
 S2N_FIPS_MODE = 's2n_fips_mode'
 

--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -27,5 +27,4 @@ commands =
         --provider-version={env:S2N_LIBCRYPTO} \
         --provider-criterion={env:S2N_USE_CRITERION:"off"} \
         --fips-mode={env:S2N_TEST_IN_FIPS_MODE:"0"} \
-        --no-pq={env:S2N_NO_PQ:"0"} \
         {env:TOX_TEST_NAME:""}


### PR DESCRIPTION
### Resolved issues:

Resolves #4349

### Description of changes: 

Removed references to S2N_NO_PQ option and related codes.

### Call-outs:


### Testing:

I tested with the following commands.

```
cmake . -Bbuild \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_PREFIX_PATH=$(dirname $(dirname $(brew list openssl@3|grep libcrypto.dylib))) \
    -DCMAKE_INSTALL_PREFIX=./s2n-tls-install
cmake --build build -j $(sysctl -n hw.ncpu)
CTEST_PARALLEL_LEVEL=$(sysctl -n hw.ncpu) ctest --test-dir build
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
