### PR TITLE
bug: Fixing bash error

### DIFF
--- a/tests/fuzz/runFuzzTest.sh
+++ b/tests/fuzz/runFuzzTest.sh
@@ -203,7 +203,7 @@ then
             COVERAGE_FAILURE_ALLOWED=1
         fi
 
-        if [ "$FEATURE_COVERAGE" -lt $MIN_FEATURES_COVERED && COVERAGE_FAILURE_ALLOWED -eq 0 ]; then
+        if [[ "$FEATURE_COVERAGE" -lt $MIN_FEATURES_COVERED && COVERAGE_FAILURE_ALLOWED -eq 0 ]]; then
             printf "\033[31;1mERROR!\033[0m ${TEST_NAME} only covers ${FEATURE_COVERAGE} features, which is below ${MIN_FEATURES_COVERED}! This may be due to missing corpus files or a bug.\n"
             exit -1;
         fi


### PR DESCRIPTION
### Resolved issues:

N/A
### Description of changes: 

Fixes `./runFuzzTest.sh: line 206: [: missing `]'` error you get from running the fuzz tests. Apparently if you use a logical 'and' in a bash script it needs to be in double brackets.

See: https://stackoverflow.com/questions/35281797/missing-in-bash-script

### Call-outs:

### Testing:

I didn't test this by running the script, but if you try this out in a bash script you can see that using the && operator without double brackets gives you get this error.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
