### PR TITLE
chore: fix CBMC proof summary count

### DIFF
--- a/tests/cbmc/proofs/lib/summarize.py
+++ b/tests/cbmc/proofs/lib/summarize.py
@@ -86,13 +86,13 @@ def _get_status_and_proof_summaries(run_dict):
     count_statuses = {}
     proofs = [["Proof", "Status"]]
     for proof_pipeline in run_dict["pipelines"]:
+        if proof_pipeline["name"] == "print_tool_versions":
+            continue
         status_pretty_name = proof_pipeline["status"].title().replace("_", " ")
         try:
             count_statuses[status_pretty_name] += 1
         except KeyError:
             count_statuses[status_pretty_name] = 1
-        if proof_pipeline["name"] == "print_tool_versions":
-            continue
         proofs.append([proof_pipeline["name"], status_pretty_name])
     statuses = [["Status", "Count"]]
     for status, count in count_statuses.items():


### PR DESCRIPTION
### Description of changes: 

We had an off-by-one error in the summary of the CBMC job, claiming one proof more as successful than we actually had proofs. Issue found by @rod-chapman.

### Testing:

Tested in CI (the expected number of successful proofs is in s2n-tls 163). See "Summary" page of https://github.com/aws/s2n-tls/actions/runs/9660332387?pr=4627.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
