### PR TITLE
chore: update boringssl buildspec

### DIFF
--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -283,7 +283,7 @@ batch:
     - buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
-        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
         privileged-mode: true
         variables:
           BUILD_S2N: 'true'


### PR DESCRIPTION
### Description of changes: 
In CI ([GeneralBatch](https://github.com/aws/s2n-tls/blob/main/codebuild/spec/buildspec_generalbatch.yml#L300)) we run BossingSSL unit test on Ubuntu18. This PR updates the Omnispec job (used during release) to do the same.

Reasoning: We should not be testing new things just for release. If it is important enough to warrant running for release then it is important enough to run CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
