### PR TITLE
Refactor: change init and destroy_key return type to S2N_RESULT in s2n_cipher struct

### DIFF
--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -361,11 +361,11 @@ static int s2n_aead_cipher_aes256_gcm_set_decryption_key_tls13(struct s2n_sessio
     return S2N_SUCCESS;
 }
 
-static int s2n_aead_cipher_aes_gcm_init(struct s2n_session_key *key)
+static S2N_RESULT s2n_aead_cipher_aes_gcm_init(struct s2n_session_key *key)
 {
-    s2n_evp_ctx_init(key->evp_cipher_ctx);
+    RESULT_EVP_CTX_INIT(key->evp_cipher_ctx);
 
-    return S2N_SUCCESS;
+    return S2N_RESULT_OK;
 }
 
 static int s2n_aead_cipher_aes_gcm_destroy_key(struct s2n_session_key *key)

--- a/crypto/s2n_aead_cipher_chacha20_poly1305.c
+++ b/crypto/s2n_aead_cipher_chacha20_poly1305.c
@@ -143,11 +143,11 @@ static int s2n_aead_chacha20_poly1305_set_decryption_key(struct s2n_session_key 
     return 0;
 }
 
-static int s2n_aead_chacha20_poly1305_init(struct s2n_session_key *key)
+static S2N_RESULT s2n_aead_chacha20_poly1305_init(struct s2n_session_key *key)
 {
-    s2n_evp_ctx_init(key->evp_cipher_ctx);
+    RESULT_EVP_CTX_INIT(key->evp_cipher_ctx);
 
-    return 0;
+    return S2N_RESULT_OK;
 }
 
 static int s2n_aead_chacha20_poly1305_destroy_key(struct s2n_session_key *key)

--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -74,11 +74,11 @@ static int s2n_cbc_cipher_3des_set_encryption_key(struct s2n_session_key *key, s
     return 0;
 }
 
-static int s2n_cbc_cipher_3des_init(struct s2n_session_key *key)
+static S2N_RESULT s2n_cbc_cipher_3des_init(struct s2n_session_key *key)
 {
-    s2n_evp_ctx_init(key->evp_cipher_ctx);
+    RESULT_EVP_CTX_INIT(key->evp_cipher_ctx);
 
-    return 0;
+    return S2N_RESULT_OK;
 }
 
 static int s2n_cbc_cipher_3des_destroy_key(struct s2n_session_key *key)

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -100,11 +100,11 @@ int s2n_cbc_cipher_aes256_set_encryption_key(struct s2n_session_key *key, struct
     return 0;
 }
 
-static int s2n_cbc_cipher_aes_init(struct s2n_session_key *key)
+static S2N_RESULT s2n_cbc_cipher_aes_init(struct s2n_session_key *key)
 {
-    s2n_evp_ctx_init(key->evp_cipher_ctx);
+    RESULT_EVP_CTX_INIT(key->evp_cipher_ctx);
 
-    return 0;
+    return S2N_RESULT_OK;
 }
 
 static int s2n_cbc_cipher_aes_destroy_key(struct s2n_session_key *key)

--- a/crypto/s2n_cipher.h
+++ b/crypto/s2n_cipher.h
@@ -83,7 +83,7 @@ struct s2n_cipher {
     } io;
     uint8_t key_material_size;
     uint8_t (*is_available)(void);
-    int (*init)(struct s2n_session_key *key);
+    S2N_RESULT (*init)(struct s2n_session_key *key);
     int (*set_decryption_key)(struct s2n_session_key *key, struct s2n_blob *in);
     int (*set_encryption_key)(struct s2n_session_key *key, struct s2n_blob *in);
     int (*destroy_key)(struct s2n_session_key *key);

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -287,11 +287,11 @@ static int s2n_composite_cipher_aes256_sha256_set_decryption_key(struct s2n_sess
     return 0;
 }
 
-static int s2n_composite_cipher_aes_sha_init(struct s2n_session_key *key)
+static S2N_RESULT s2n_composite_cipher_aes_sha_init(struct s2n_session_key *key)
 {
-    s2n_evp_ctx_init(key->evp_cipher_ctx);
+    RESULT_EVP_CTX_INIT(key->evp_cipher_ctx);
 
-    return 0;
+    return S2N_RESULT_OK;
 }
 
 static int s2n_composite_cipher_aes_sha_destroy_key(struct s2n_session_key *key)

--- a/crypto/s2n_stream_cipher_null.c
+++ b/crypto/s2n_stream_cipher_null.c
@@ -43,9 +43,9 @@ static int s2n_stream_cipher_null_destroy_key(struct s2n_session_key *key)
     return 0;
 }
 
-static int s2n_stream_cipher_null_init(struct s2n_session_key *key)
+static S2N_RESULT s2n_stream_cipher_null_init(struct s2n_session_key *key)
 {
-    return 0;
+    return S2N_RESULT_OK;
 }
 
 const struct s2n_cipher s2n_null_cipher = {

--- a/crypto/s2n_stream_cipher_rc4.c
+++ b/crypto/s2n_stream_cipher_rc4.c
@@ -87,11 +87,11 @@ static int s2n_stream_cipher_rc4_set_decryption_key(struct s2n_session_key *key,
     return S2N_SUCCESS;
 }
 
-static int s2n_stream_cipher_rc4_init(struct s2n_session_key *key)
+static S2N_RESULT s2n_stream_cipher_rc4_init(struct s2n_session_key *key)
 {
-    s2n_evp_ctx_init(key->evp_cipher_ctx);
+    RESULT_EVP_CTX_INIT(key->evp_cipher_ctx);
 
-    return 0;
+    return S2N_RESULT_OK;
 }
 
 static int s2n_stream_cipher_rc4_destroy_key(struct s2n_session_key *key)

--- a/tests/testlib/s2n_connection_test_utils.c
+++ b/tests/testlib/s2n_connection_test_utils.c
@@ -296,13 +296,13 @@ S2N_RESULT s2n_connection_set_secrets(struct s2n_connection *conn)
     uint8_t client_key_bytes[S2N_TLS13_SECRET_MAX_LEN] = "client key";
     struct s2n_blob client_key = { 0 };
     RESULT_GUARD_POSIX(s2n_blob_init(&client_key, client_key_bytes, cipher->key_material_size));
-    RESULT_GUARD_POSIX(cipher->init(&conn->secure->client_key));
+    RESULT_GUARD(cipher->init(&conn->secure->client_key));
     RESULT_GUARD_POSIX(cipher->set_encryption_key(&conn->secure->client_key, &client_key));
 
     uint8_t server_key_bytes[S2N_TLS13_SECRET_MAX_LEN] = "server key";
     struct s2n_blob server_key = { 0 };
     RESULT_GUARD_POSIX(s2n_blob_init(&server_key, server_key_bytes, cipher->key_material_size));
-    RESULT_GUARD_POSIX(cipher->init(&conn->secure->server_key));
+    RESULT_GUARD(cipher->init(&conn->secure->server_key));
     RESULT_GUARD_POSIX(cipher->set_encryption_key(&conn->secure->server_key, &server_key));
 
     conn->client = conn->secure;

--- a/tests/unit/s2n_3des_test.c
+++ b/tests/unit/s2n_3des_test.c
@@ -50,8 +50,8 @@ int main(int argc, char **argv)
 
     /* test the 3des cipher with a SHA1 hash */
     conn->secure->cipher_suite->record_alg = &s2n_record_alg_3des_sha;
-    EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->server_key));
-    EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->client_key));
+    EXPECT_OK(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->server_key));
+    EXPECT_OK(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->client_key));
     EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure->server_key, &des3));
     EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure->client_key, &des3));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure->client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));

--- a/tests/unit/s2n_aead_aes_test.c
+++ b/tests/unit/s2n_aead_aes_test.c
@@ -37,8 +37,8 @@ static int destroy_server_keys(struct s2n_connection *server_conn)
 
 static int setup_server_keys(struct s2n_connection *server_conn, struct s2n_blob *key)
 {
-    POSIX_GUARD(server_conn->initial->cipher_suite->record_alg->cipher->init(&server_conn->initial->server_key));
-    POSIX_GUARD(server_conn->initial->cipher_suite->record_alg->cipher->init(&server_conn->initial->client_key));
+    POSIX_GUARD_RESULT(server_conn->initial->cipher_suite->record_alg->cipher->init(&server_conn->initial->server_key));
+    POSIX_GUARD_RESULT(server_conn->initial->cipher_suite->record_alg->cipher->init(&server_conn->initial->client_key));
     POSIX_GUARD(server_conn->initial->cipher_suite->record_alg->cipher->set_encryption_key(&server_conn->initial->server_key, key));
     POSIX_GUARD(server_conn->initial->cipher_suite->record_alg->cipher->set_decryption_key(&server_conn->initial->client_key, key));
 

--- a/tests/unit/s2n_aead_chacha20_poly1305_test.c
+++ b/tests/unit/s2n_aead_chacha20_poly1305_test.c
@@ -38,8 +38,8 @@ static int destroy_server_keys(struct s2n_connection *server_conn)
 
 static int setup_server_keys(struct s2n_connection *server_conn, struct s2n_blob *key)
 {
-    POSIX_GUARD(server_conn->initial->cipher_suite->record_alg->cipher->init(&server_conn->initial->server_key));
-    POSIX_GUARD(server_conn->initial->cipher_suite->record_alg->cipher->init(&server_conn->initial->client_key));
+    POSIX_GUARD_RESULT(server_conn->initial->cipher_suite->record_alg->cipher->init(&server_conn->initial->server_key));
+    POSIX_GUARD_RESULT(server_conn->initial->cipher_suite->record_alg->cipher->init(&server_conn->initial->client_key));
     POSIX_GUARD(server_conn->initial->cipher_suite->record_alg->cipher->set_encryption_key(&server_conn->initial->server_key, key));
     POSIX_GUARD(server_conn->initial->cipher_suite->record_alg->cipher->set_decryption_key(&server_conn->initial->client_key, key));
 

--- a/tests/unit/s2n_aes_test.c
+++ b/tests/unit/s2n_aes_test.c
@@ -53,8 +53,8 @@ int main(int argc, char **argv)
 
     /* test the AES128 cipher with a SHA1 hash */
     conn->secure->cipher_suite->record_alg = &s2n_record_alg_aes128_sha;
-    EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->server_key));
-    EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->client_key));
+    EXPECT_OK(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->server_key));
+    EXPECT_OK(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->client_key));
     EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure->server_key, &aes128));
     EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure->client_key, &aes128));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure->client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
@@ -119,8 +119,8 @@ int main(int argc, char **argv)
     conn->server = conn->secure;
     conn->client = conn->secure;
     conn->secure->cipher_suite->record_alg = &s2n_record_alg_aes256_sha;
-    EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->server_key));
-    EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->client_key));
+    EXPECT_OK(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->server_key));
+    EXPECT_OK(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->client_key));
     EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure->server_key, &aes256));
     EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure->client_key, &aes256));
     EXPECT_SUCCESS(s2n_hmac_init(&conn->secure->client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));

--- a/tests/unit/s2n_handshake_io_early_data_test.c
+++ b/tests/unit/s2n_handshake_io_early_data_test.c
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
 
             server_conn->secure->cipher_suite = test_cipher_suite;
-            POSIX_GUARD(server_conn->secure->cipher_suite->record_alg->cipher->init(&server_conn->secure->client_key));
+            POSIX_GUARD_RESULT(server_conn->secure->cipher_suite->record_alg->cipher->init(&server_conn->secure->client_key));
             POSIX_GUARD(server_conn->secure->cipher_suite->record_alg->cipher->set_decryption_key(&server_conn->secure->client_key, &test_key));
             server_conn->client = server_conn->secure;
 
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
 
                 client_conn->secure->cipher_suite = test_cipher_suite;
-                POSIX_GUARD(client_conn->secure->cipher_suite->record_alg->cipher->init(&client_conn->secure->server_key));
+                POSIX_GUARD_RESULT(client_conn->secure->cipher_suite->record_alg->cipher->init(&client_conn->secure->server_key));
                 POSIX_GUARD(client_conn->secure->cipher_suite->record_alg->cipher->set_decryption_key(&client_conn->secure->server_key, &test_key));
                 client_conn->server = client_conn->secure;
 

--- a/tests/unit/s2n_rc4_test.c
+++ b/tests/unit/s2n_rc4_test.c
@@ -68,8 +68,8 @@ int main(int argc, char **argv)
 
     /* test the RC4 cipher with a SHA1 hash */
     conn->secure->cipher_suite->record_alg = &s2n_record_alg_rc4_sha;
-    EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->server_key));
-    EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->client_key));
+    EXPECT_OK(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->server_key));
+    EXPECT_OK(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->client_key));
     if (conn->secure->cipher_suite->record_alg->cipher->is_available()) {
         EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure->client_key, &key_iv));
         EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure->server_key, &key_iv));

--- a/tests/unit/s2n_record_size_test.c
+++ b/tests/unit/s2n_record_size_test.c
@@ -46,8 +46,8 @@ static int destroy_server_keys(struct s2n_connection *server_conn)
 
 static int setup_server_keys(struct s2n_connection *server_conn, struct s2n_blob *key)
 {
-    POSIX_GUARD(server_conn->initial->cipher_suite->record_alg->cipher->init(&server_conn->initial->server_key));
-    POSIX_GUARD(server_conn->initial->cipher_suite->record_alg->cipher->init(&server_conn->initial->client_key));
+    POSIX_GUARD_RESULT(server_conn->initial->cipher_suite->record_alg->cipher->init(&server_conn->initial->server_key));
+    POSIX_GUARD_RESULT(server_conn->initial->cipher_suite->record_alg->cipher->init(&server_conn->initial->client_key));
     POSIX_GUARD(server_conn->initial->cipher_suite->record_alg->cipher->set_encryption_key(&server_conn->initial->server_key, key));
     POSIX_GUARD(server_conn->initial->cipher_suite->record_alg->cipher->set_decryption_key(&server_conn->initial->client_key, key));
 
@@ -82,8 +82,8 @@ int main(int argc, char **argv)
 
         /* test the AES128 cipher with a SHA1 hash */
         conn->secure->cipher_suite->record_alg = &s2n_record_alg_aes128_sha;
-        EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->server_key));
-        EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->client_key));
+        EXPECT_OK(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->server_key));
+        EXPECT_OK(conn->secure->cipher_suite->record_alg->cipher->init(&conn->secure->client_key));
         EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure->server_key, &aes128));
         EXPECT_SUCCESS(conn->secure->cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure->client_key, &aes128));
         EXPECT_SUCCESS(s2n_hmac_init(&conn->secure->client_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
@@ -252,8 +252,8 @@ int main(int argc, char **argv)
             struct s2n_blob des3 = { 0 };
             EXPECT_SUCCESS(s2n_blob_init(&des3, des3_key, sizeof(des3_key)));
             server_conn->server = server_conn->secure;
-            EXPECT_SUCCESS(server_conn->secure->cipher_suite->record_alg->cipher->init(&server_conn->secure->server_key));
-            EXPECT_SUCCESS(server_conn->secure->cipher_suite->record_alg->cipher->init(&server_conn->secure->client_key));
+            EXPECT_OK(server_conn->secure->cipher_suite->record_alg->cipher->init(&server_conn->secure->server_key));
+            EXPECT_OK(server_conn->secure->cipher_suite->record_alg->cipher->init(&server_conn->secure->client_key));
             EXPECT_SUCCESS(server_conn->secure->cipher_suite->record_alg->cipher->set_encryption_key(&server_conn->secure->server_key, &des3));
             EXPECT_SUCCESS(server_conn->secure->cipher_suite->record_alg->cipher->set_decryption_key(&server_conn->secure->client_key, &des3));
             EXPECT_SUCCESS(s2n_hmac_init(&server_conn->secure->server_record_mac, S2N_HMAC_SHA1, mac_key, sizeof(mac_key)));
@@ -407,7 +407,7 @@ int main(int argc, char **argv)
         uint8_t *implicit_iv = server_conn->server->server_implicit_iv;
 
         /* init record algorithm */
-        EXPECT_SUCCESS(cipher_suite->record_alg->cipher->init(session_key));
+        EXPECT_OK(cipher_suite->record_alg->cipher->init(session_key));
         S2N_BLOB_FROM_HEX(key, "0123456789abcdef0123456789abcdef");
         EXPECT_SUCCESS(cipher_suite->record_alg->cipher->set_encryption_key(session_key, &key));
         EXPECT_SUCCESS(cipher_suite->record_alg->cipher->set_decryption_key(session_key, &key));

--- a/tests/unit/s2n_send_key_update_test.c
+++ b/tests/unit/s2n_send_key_update_test.c
@@ -50,8 +50,8 @@ static int s2n_test_init_encryption(struct s2n_connection *conn)
     uint8_t *client_implicit_iv = conn->client->client_implicit_iv;
 
     /* Initialize record algorithm */
-    POSIX_GUARD(cipher_suite->record_alg->cipher->init(server_session_key));
-    POSIX_GUARD(cipher_suite->record_alg->cipher->init(client_session_key));
+    POSIX_GUARD_RESULT(cipher_suite->record_alg->cipher->init(server_session_key));
+    POSIX_GUARD_RESULT(cipher_suite->record_alg->cipher->init(client_session_key));
     POSIX_GUARD(cipher_suite->record_alg->cipher->set_encryption_key(server_session_key, &key));
     POSIX_GUARD(cipher_suite->record_alg->cipher->set_encryption_key(client_session_key, &key));
     POSIX_GUARD(cipher_suite->record_alg->cipher->set_decryption_key(server_session_key, &key));

--- a/tests/unit/s2n_tls13_record_aead_test.c
+++ b/tests/unit/s2n_tls13_record_aead_test.c
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
         conn->actual_protocol_version = S2N_TLS13;
 
         /* init record algorithm */
-        EXPECT_SUCCESS(cipher_suite->record_alg->cipher->init(&session_key));
+        EXPECT_OK(cipher_suite->record_alg->cipher->init(&session_key));
         S2N_BLOB_FROM_HEX(key, "3fce516009c21727d0f2e4e86ee403bc");
         EXPECT_SUCCESS(cipher_suite->record_alg->cipher->set_decryption_key(&session_key, &key));
 
@@ -222,7 +222,7 @@ int main(int argc, char **argv)
         uint8_t *implicit_iv = conn->server->server_implicit_iv;
 
         /* init record algorithm */
-        EXPECT_SUCCESS(cipher_suite->record_alg->cipher->init(session_key));
+        EXPECT_OK(cipher_suite->record_alg->cipher->init(session_key));
         S2N_BLOB_FROM_HEX(key, "3fce516009c21727d0f2e4e86ee403bc");
         EXPECT_SUCCESS(cipher_suite->record_alg->cipher->set_encryption_key(session_key, &key));
 
@@ -279,7 +279,7 @@ int main(int argc, char **argv)
         uint8_t *implicit_iv = conn->server->server_implicit_iv;
 
         /* init record algorithm */
-        EXPECT_SUCCESS(cipher_suite->record_alg->cipher->init(session_key));
+        EXPECT_OK(cipher_suite->record_alg->cipher->init(session_key));
         S2N_BLOB_FROM_HEX(key, "3fce516009c21727d0f2e4e86ee403bc");
         EXPECT_SUCCESS(cipher_suite->record_alg->cipher->set_encryption_key(session_key, &key));
         EXPECT_SUCCESS(cipher_suite->record_alg->cipher->set_decryption_key(session_key, &key));
@@ -348,8 +348,8 @@ int main(int argc, char **argv)
             conn->client = conn->secure;
 
             /* init record algorithm */
-            EXPECT_SUCCESS(cipher_suite->record_alg->cipher->init(&conn->secure->server_key));
-            EXPECT_SUCCESS(cipher_suite->record_alg->cipher->init(&conn->secure->client_key));
+            EXPECT_OK(cipher_suite->record_alg->cipher->init(&conn->secure->server_key));
+            EXPECT_OK(cipher_suite->record_alg->cipher->init(&conn->secure->client_key));
             S2N_BLOB_FROM_HEX(key, "3fce516009c21727d0f2e4e86ee403bc");
             EXPECT_SUCCESS(cipher_suite->record_alg->cipher->set_encryption_key(&conn->secure->server_key, &key));
             EXPECT_SUCCESS(cipher_suite->record_alg->cipher->set_decryption_key(&conn->secure->client_key, &key));

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -1033,8 +1033,8 @@ int s2n_prf_key_expansion(struct s2n_connection *conn)
     POSIX_GUARD_RESULT(s2n_prf_generate_key_material(conn, &key_material));
 
     POSIX_ENSURE(cipher_suite->available, S2N_ERR_PRF_INVALID_ALGORITHM);
-    POSIX_GUARD(cipher->init(&conn->secure->client_key));
-    POSIX_GUARD(cipher->init(&conn->secure->server_key));
+    POSIX_GUARD_RESULT(cipher->init(&conn->secure->client_key));
+    POSIX_GUARD_RESULT(cipher->init(&conn->secure->server_key));
 
     /* Seed the client MAC */
     POSIX_GUARD(s2n_hmac_reset(&conn->secure->client_record_mac));

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -796,7 +796,7 @@ int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *
 
     POSIX_GUARD(s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN));
     POSIX_GUARD(s2n_session_key_alloc(&aes_ticket_key));
-    POSIX_GUARD(s2n_aes256_gcm.init(&aes_ticket_key));
+    POSIX_GUARD_RESULT(s2n_aes256_gcm.init(&aes_ticket_key));
     POSIX_GUARD(s2n_aes256_gcm.set_encryption_key(&aes_ticket_key, &aes_key_blob));
 
     POSIX_GUARD(s2n_stuffer_init(&aad, &aad_blob));
@@ -851,7 +851,7 @@ int s2n_decrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *
 
     POSIX_GUARD(s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN));
     POSIX_GUARD(s2n_session_key_alloc(&aes_ticket_key));
-    POSIX_GUARD(s2n_aes256_gcm.init(&aes_ticket_key));
+    POSIX_GUARD_RESULT(s2n_aes256_gcm.init(&aes_ticket_key));
     POSIX_GUARD(s2n_aes256_gcm.set_decryption_key(&aes_ticket_key, &aes_key_blob));
 
     POSIX_GUARD(s2n_stuffer_init(&aad, &aad_blob));
@@ -931,7 +931,7 @@ int s2n_decrypt_session_cache(struct s2n_connection *conn, struct s2n_stuffer *f
 
     POSIX_GUARD(s2n_blob_init(&aes_key_blob, key->aes_key, S2N_AES256_KEY_LEN));
     POSIX_GUARD(s2n_session_key_alloc(&aes_ticket_key));
-    POSIX_GUARD(s2n_aes256_gcm.init(&aes_ticket_key));
+    POSIX_GUARD_RESULT(s2n_aes256_gcm.init(&aes_ticket_key));
     POSIX_GUARD(s2n_aes256_gcm.set_decryption_key(&aes_ticket_key, &aes_key_blob));
 
     POSIX_GUARD(s2n_stuffer_init(&aad, &aad_blob));


### PR DESCRIPTION
### Resolved issues:

Part of #3983 

### Description of changes: 

- Change return type of `init` and `destroy_key` from int to S2N_RESULT
https://github.com/aws/s2n-tls/blob/d538d0a7031f01a692c7f0dd76fbe08110b509cd/crypto/s2n_cipher.h#L86
https://github.com/aws/s2n-tls/blob/d538d0a7031f01a692c7f0dd76fbe08110b509cd/crypto/s2n_cipher.h#L89 
- Majority of changes are to adapt to correct return types, like converting S2N_SUCCESS to S2N_OK, POSIX_GUARD to POSIX_GUARD_RESULT, and etc.

### Call-outs:

### Testing:

- Confirmed all unit tests pass. Will address any CI failures

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
