### PR TITLE
Ak WIP - adding tls13 to default security policies

### DIFF
--- a/bindings/rust/s2n-tls-tokio/tests/common/mod.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/common/mod.rs
@@ -5,7 +5,7 @@ use s2n_tls::{
     config,
     connection::Builder,
     error::Error,
-    security::{DEFAULT, DEFAULT_TLS13},
+    security::{self, DEFAULT_TLS13},
 };
 use s2n_tls_tokio::{TlsAcceptor, TlsConnector, TlsStream};
 use std::time::Duration;
@@ -67,14 +67,14 @@ pub fn server_config() -> Result<config::Builder, Error> {
 
 pub fn client_config_tls12() -> Result<config::Builder, Error> {
     let mut builder = config::Config::builder();
-    builder.set_security_policy(&DEFAULT)?;
+    builder.set_security_policy(&security::Policy::from_version("20240502")?)?;
     builder.trust_pem(RSA_CERT_PEM)?;
     Ok(builder)
 }
 
 pub fn server_config_tls12() -> Result<config::Builder, Error> {
     let mut builder = config::Config::builder();
-    builder.set_security_policy(&DEFAULT)?;
+    builder.set_security_policy(&security::Policy::from_version("20240502")?)?;
     builder.load_pem(RSA_CERT_PEM, RSA_KEY_PEM)?;
     Ok(builder)
 }

--- a/default.diff
+++ b/default.diff
@@ -1,0 +1,17 @@
+diff --git a/default.old b/default.new
+index 5e6a085f9..90fc3254a 100644
+--- a/default.old
++++ b/default.new
+@@ -1,9 +1,11 @@
+-name: 20240501
++name: default
+ min version: TLS1.2
+ rules:
+ - Perfect Forward Secrecy: yes
+ - FIPS 140-3 (2019): no
+ cipher suites:
++- TLS_AES_256_GCM_SHA384
++- TLS_AES_128_GCM_SHA256
+ - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+ - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+ - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256

--- a/default.new
+++ b/default.new
@@ -1,0 +1,34 @@
+name: default
+min version: TLS1.2
+rules:
+- Perfect Forward Secrecy: yes
+- FIPS 140-3 (2019): no
+cipher suites:
+- TLS_AES_256_GCM_SHA384
+- TLS_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+- TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+- TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+signature schemes:
+- ecdsa_sha256
+- ecdsa_sha384
+- ecdsa_sha512
+- rsa_pss_pss_sha256
+- rsa_pss_pss_sha384
+- rsa_pss_pss_sha512
+- rsa_pss_rsae_sha256
+- rsa_pss_rsae_sha384
+- rsa_pss_rsae_sha512
+- rsa_pkcs1_sha256
+- rsa_pkcs1_sha384
+- rsa_pkcs1_sha512
+curves:
+- secp256r1
+- x25519
+- secp384r1
+- secp521r1

--- a/default.old
+++ b/default.old
@@ -1,0 +1,32 @@
+name: 20240501
+min version: TLS1.2
+rules:
+- Perfect Forward Secrecy: yes
+- FIPS 140-3 (2019): no
+cipher suites:
+- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+- TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+- TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+signature schemes:
+- ecdsa_sha256
+- ecdsa_sha384
+- ecdsa_sha512
+- rsa_pss_pss_sha256
+- rsa_pss_pss_sha384
+- rsa_pss_pss_sha512
+- rsa_pss_rsae_sha256
+- rsa_pss_rsae_sha384
+- rsa_pss_rsae_sha512
+- rsa_pkcs1_sha256
+- rsa_pkcs1_sha384
+- rsa_pkcs1_sha512
+curves:
+- secp256r1
+- x25519
+- secp384r1
+- secp521r1

--- a/default_fips.diff
+++ b/default_fips.diff
@@ -1,0 +1,17 @@
+diff --git a/default_fips.old b/default_fips.new
+index a06198b37..cbfab484f 100644
+--- a/default_fips.old
++++ b/default_fips.new
+@@ -1,9 +1,11 @@
+-name: 20240502
++name: default_fips
+ min version: TLS1.2
+ rules:
+ - Perfect Forward Secrecy: yes
+ - FIPS 140-3 (2019): yes
+ cipher suites:
++- TLS_AES_256_GCM_SHA384
++- TLS_AES_128_GCM_SHA256
+ - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+ - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+ - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256

--- a/default_fips.new
+++ b/default_fips.new
@@ -1,0 +1,48 @@
+name: default_fips
+min version: TLS1.2
+rules:
+- Perfect Forward Secrecy: yes
+- FIPS 140-3 (2019): yes
+cipher suites:
+- TLS_AES_256_GCM_SHA384
+- TLS_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+- TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+- TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+signature schemes:
+- ecdsa_sha256
+- ecdsa_sha384
+- ecdsa_sha512
+- rsa_pss_pss_sha256
+- rsa_pss_pss_sha384
+- rsa_pss_pss_sha512
+- rsa_pss_rsae_sha256
+- rsa_pss_rsae_sha384
+- rsa_pss_rsae_sha512
+- rsa_pkcs1_sha256
+- rsa_pkcs1_sha384
+- rsa_pkcs1_sha512
+curves:
+- secp256r1
+- secp384r1
+- secp521r1
+certificate signature schemes:
+- rsa_pss_pss_sha256
+- rsa_pss_pss_sha384
+- rsa_pss_pss_sha512
+- rsa_pss_rsae_sha256
+- rsa_pss_rsae_sha384
+- rsa_pss_rsae_sha512
+- rsa_pkcs1_sha256
+- rsa_pkcs1_sha384
+- rsa_pkcs1_sha512
+- legacy_rsa_pkcs1_sha224
+- ecdsa_sha256
+- ecdsa_sha384
+- ecdsa_sha512
+- legacy_ecdsa_sha224

--- a/default_fips.old
+++ b/default_fips.old
@@ -1,0 +1,46 @@
+name: 20240502
+min version: TLS1.2
+rules:
+- Perfect Forward Secrecy: yes
+- FIPS 140-3 (2019): yes
+cipher suites:
+- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+- TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+- TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+signature schemes:
+- ecdsa_sha256
+- ecdsa_sha384
+- ecdsa_sha512
+- rsa_pss_pss_sha256
+- rsa_pss_pss_sha384
+- rsa_pss_pss_sha512
+- rsa_pss_rsae_sha256
+- rsa_pss_rsae_sha384
+- rsa_pss_rsae_sha512
+- rsa_pkcs1_sha256
+- rsa_pkcs1_sha384
+- rsa_pkcs1_sha512
+curves:
+- secp256r1
+- secp384r1
+- secp521r1
+certificate signature schemes:
+- rsa_pss_pss_sha256
+- rsa_pss_pss_sha384
+- rsa_pss_pss_sha512
+- rsa_pss_rsae_sha256
+- rsa_pss_rsae_sha384
+- rsa_pss_rsae_sha512
+- rsa_pkcs1_sha256
+- rsa_pkcs1_sha384
+- rsa_pkcs1_sha512
+- legacy_rsa_pkcs1_sha224
+- ecdsa_sha256
+- ecdsa_sha384
+- ecdsa_sha512
+- legacy_ecdsa_sha224

--- a/docs/usage-guide/topics/ch06-security-policies.md
+++ b/docs/usage-guide/topics/ch06-security-policies.md
@@ -6,7 +6,7 @@ s2n-tls uses pre-made security policies to help avoid common misconfiguration mi
 
 ## Supported TLS Versions
 
-Currently TLS 1.2 is our default version, but we recommend TLS 1.3 where possible. To use TLS 1.3 you need a security policy that supports TLS 1.3.
+TLS 1.3 support is enabled by default.
 
 ### SSL 3.0, TLS 1.0, and TLS 1.1
 s2n-tls supports older versions, but their use is not recommended.
@@ -17,6 +17,9 @@ Compatibility with older versions of TLS may also require support for older ciph
 s2n-tls will not negotiate SSL 2.0, but will accept SSLv2 ClientHellos advertising a higher protocol version like TLS1.2. See the ["Compatibility with SSL 2.0"](https://datatracker.ietf.org/doc/html/rfc5246#appendix-E.2) section in the TLS 1.2 RFC.
 
 Compatibility with SSLv2 ClientHellos advertising TLS1.2 may require similar support for older ciphersuites as compatibility with older versions of TLS does. In particular, SSLv2 ClientHellos are likely to require support for SHA1 and either RSA or DHE key exchange. This is due to technical limitations of the SSLv2 ClientHello, which does not include TLS extensions.
+||||||| parent of 36abc9eef (wip: add tls13 to default)
+Currently TLS 1.2 is our default version, but we recommend TLS 1.3 where possible. To use TLS 1.3 you need a security policy that supports TLS 1.3.
+**Note:** s2n-tls does not support SSL2.0 for sending and receiving encrypted data, but does accept SSL2.0 hello messages.
 
 ### Chart: Security Policy Version To Protocol Version And Ciphersuites
 
@@ -24,9 +27,11 @@ The following chart maps the security policy version to protocol version and cip
 
 |    version    | TLS1.0 | TLS1.1 | TLS1.2 | TLS1.3 | AES-CBC | AES-GCM | CHACHAPOLY | 3DES | RC4 | DHE | ECDHE | RSA kx |
 |---------------|--------|--------|--------|--------|---------|---------|------------|------|-----|-----|-------|--------|
-|    default    |        |        |    X   |        |    X    |    X    |            |      |     |     |   X   |        |
-| default_fips  |        |        |    X   |        |    X    |    X    |            |      |     |     |   X   |        |
+|    default    |        |        |    X   |    X   |    X    |    X    |            |      |     |     |   X   |        |
+| default_fips  |        |        |    X   |    X   |    X    |    X    |            |      |     |     |   X   |        |
 | default_tls13 |        |        |    X   |    X   |    X    |    X    |      X     |      |     |     |   X   |        |
+|   20240701    |        |        |    X   |    X   |    X    |    X    |      X     |      |     |     |   X   |        |
+|   20240702    |        |        |    X   |    X   |    X    |    X    |            |      |     |     |   X   |        |
 |   20240501    |        |        |    X   |        |    X    |    X    |            |      |     |     |   X   |        |
 |   20240502    |        |        |    X   |        |    X    |    X    |            |      |     |     |   X   |        |
 |   20240503    |        |        |    X   |    X   |    X    |    X    |            |      |     |     |   X   |        |
@@ -55,12 +60,11 @@ The following chart maps the security policy version to protocol version and cip
 The "default", "default_tls13", and "default_fips" versions are special in that they will be updated with future s2n-tls changes to keep up-to-date with current security best practices. Ciphersuites, protocol versions, and other options may be added or removed, or their internal order of preference might change. **Warning**: this means that the default policies may change as a result of library updates, which could break peers that rely on legacy options.
 
 In contrast, numbered or dated versions are fixed and will never change. The numbered equivalents of the default policies are currently:
-* "default": "20240501"
-* "default_fips": "20240502"
+* "default": "20240701"
+* "default_fips": "20240702"
 * "default_tls13": "20240503"
-For previous defaults, see the "Default Policy History" section below.
 
-"default_fips" does not currently support TLS1.3. If you need a policy that supports both FIPS and TLS1.3, choose "20230317". We plan to add TLS1.3 support to both "default" and "default_fips" in the future.
+For previous defaults versions, see the "Default Policy History" section below.
 
 "rfc9151" is derived from [Commercial National Security Algorithm (CNSA) Suite Profile for TLS and DTLS 1.2 and 1.3](https://datatracker.ietf.org/doc/html/rfc9151). This policy restricts the algorithms allowed for signatures on certificates in the certificate chain to RSA or ECDSA with sha384, which may require you to update your certificates.
 Like the default policies, this policy may also change if the source RFC definition changes.
@@ -85,6 +89,8 @@ s2n-tls usually prefers AES over ChaCha20. However, some clients-- particularly 
 |    default    |     X     |   X   |              |    X    |
 | default_fips  |     X     |   X   |              |    X    |
 | default_tls13 |     X     |   X   |              |    X    |
+|   20240701    |     X     |   X   |              |    X    |
+|   20240701    |     X     |   X   |              |    X    |
 |   20240501    |     X     |   X   |              |    X    |
 |   20240502    |     X     |   X   |              |    X    |
 |   20240503    |     X     |   X   |              |    X    |
@@ -120,6 +126,8 @@ s2n-tls usually prefers AES over ChaCha20. However, some clients-- particularly 
 |    default    |     X     |     X     |    X   |
 | default_fips  |     X     |     X     |        |
 | default_tls13 |     X     |     X     |    X   |
+|   20240701    |     X     |     X     |    X   |
+|   20240702    |     X     |     X     |        |
 |   20240501    |     X     |     X     |    X   |
 |   20240502    |     X     |     X     |        |
 |   20240503    |     X     |     X     |    X   |
@@ -147,5 +155,6 @@ s2n-tls usually prefers AES over ChaCha20. However, some clients-- particularly 
 ### Default Policy History
 |  Version   | "default" | "default_fips" | "default_tls13" |
 |------------|-----------|----------------|-----------------|
+|  v1.4.TODO   | 20240701  |   20247502     |    20240503     |
 |  v1.4.16   | 20240501  |   20240502     |    20240503     |
 |   Older    | 20170210  |   20240416     |    20240417     |

--- a/policy.new
+++ b/policy.new
@@ -1,0 +1,15 @@
+NEW
+
+                                   protocol                        security_policy
+
+                                | tls12  tls13  |  default  default_fips  default_tls13  default_tls12
+                                |               |
+ * non_fips:                    |               |
+ *   no_call:                   |          N    |     x
+ *   s2n_enable_tls13_in_test:  |          x    |     N
+ *   s2n_disable_tls13_in_test: |   x           |                                            N
+ *                              |               |
+ * fips:                        |               |
+ *   no_call:                   |          N    |               x
+ *   s2n_enable_tls13_in_test:  |          x    |               N
+ *   s2n_disable_tls13_in_test: |   x           |                                            N

--- a/policy.old
+++ b/policy.old
@@ -1,0 +1,16 @@
+OLD
+
+                                   protocol                        security_policy
+
+                                | tls12  tls13  |  default  default_fips  default_tls13  default_tls12
+                                |               |
+ * non_fips:                    |               |
+ *   no_call:                   |   x           |     x
+ *   s2n_enable_tls13_in_test:  |          x    |                             x
+ *   s2n_disable_tls13_in_test: |   x           |     x
+ *                              |               |
+ * fips:                        |               |
+ *   no_call:                   |   x           |               x
+ *   s2n_enable_tls13_in_test:  |          x    |                             x
+ *   s2n_disable_tls13_in_test: |   x           |               x
+

--- a/tests/fuzz/s2n_certificate_extensions_parse_test.c
+++ b/tests/fuzz/s2n_certificate_extensions_parse_test.c
@@ -17,21 +17,20 @@
                      s2n_recv_server_sct_list s2n_server_certificate_status_recv
                      s2n_x509_validator_validate_cert_stapled_ocsp_response */
 
-#include <stdint.h>
-
 #include <openssl/crypto.h>
 #include <openssl/err.h>
+#include <stdint.h>
 
 #include "api/s2n.h"
+#include "s2n_test.h"
 #include "stuffer/s2n_stuffer.h"
+#include "testlib/s2n_testlib.h"
 #include "tls/extensions/s2n_extension_list.h"
 #include "tls/s2n_config.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_tls.h"
-#include "utils/s2n_safety.h"
-#include "s2n_test.h"
-#include "testlib/s2n_testlib.h"
 #include "tls/s2n_tls13.h"
+#include "utils/s2n_safety.h"
 
 struct host_verify_data {
     const char *name;
@@ -47,12 +46,11 @@ static uint8_t verify_host_accept_everything(const char *host_name, size_t host_
 }
 
 /* This test is for TLS versions 1.3 and up only */
-static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
+static const uint8_t TLS_VERSIONS[] = { S2N_TLS13 };
 
 int s2n_fuzz_init(int *argc, char **argv[])
 {
     /* Initialize the trust store */
-    POSIX_GUARD_RESULT(s2n_config_testing_defaults_init_tls13_certs());
     POSIX_GUARD(s2n_enable_tls13_in_test());
     return S2N_SUCCESS;
 }
@@ -63,7 +61,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     S2N_FUZZ_ENSURE_MIN_LEN(len, 1);
 
     /* Setup */
-    struct s2n_stuffer fuzz_stuffer = {0};
+    struct s2n_stuffer fuzz_stuffer = { 0 };
     POSIX_GUARD(s2n_stuffer_alloc(&fuzz_stuffer, len));
     POSIX_GUARD(s2n_stuffer_write_bytes(&fuzz_stuffer, buf, len));
 

--- a/tests/unit/s2n_alerts_protocol_test.c
+++ b/tests/unit/s2n_alerts_protocol_test.c
@@ -479,13 +479,13 @@ int main(int argc, char **argv)
                 s2n_connection_ptr_free);
         EXPECT_SUCCESS(s2n_connection_set_blinding(server, S2N_SELF_SERVICE_BLINDING));
         EXPECT_SUCCESS(s2n_connection_set_config(server, config));
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server, "default"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server, "20240501"));
 
         DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
                 s2n_connection_ptr_free);
         EXPECT_SUCCESS(s2n_connection_set_blinding(client, S2N_SELF_SERVICE_BLINDING));
         EXPECT_SUCCESS(s2n_connection_set_config(client, config));
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client, "default"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client, "20240501"));
 
         DEFER_CLEANUP(struct s2n_test_io_stuffer_pair io_pair = { 0 }, s2n_io_stuffer_pair_free);
         EXPECT_OK(s2n_io_stuffer_pair_init(&io_pair));

--- a/tests/unit/s2n_client_hello_request_test.c
+++ b/tests/unit/s2n_client_hello_request_test.c
@@ -76,13 +76,13 @@ int main(int argc, char **argv)
 
     DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
     EXPECT_NOT_NULL(config);
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
 
     DEFER_CLEANUP(struct s2n_config *config_with_reneg_cb = s2n_config_new(), s2n_config_ptr_free);
     EXPECT_NOT_NULL(config_with_reneg_cb);
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config_with_reneg_cb, "default"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config_with_reneg_cb, "20240501"));
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config_with_reneg_cb));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config_with_reneg_cb, chain_and_key));
     EXPECT_SUCCESS(s2n_config_set_renegotiate_request_cb(config_with_reneg_cb, s2n_test_reneg_req_cb, NULL));
@@ -167,7 +167,7 @@ int main(int argc, char **argv)
     {
         DEFER_CLEANUP(struct s2n_config *config_with_warns = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config_with_warns);
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config_with_warns, "default"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config_with_warns, "20240501"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config_with_warns));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config_with_warns, chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_alert_behavior(config_with_warns, S2N_ALERT_IGNORE_WARNINGS));

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -759,7 +759,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
-            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default"));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20240501"));
 
             const struct s2n_security_policy *security_policy = NULL;
             POSIX_GUARD(s2n_connection_get_security_policy(conn, &security_policy));

--- a/tests/unit/s2n_client_supported_groups_extension_test.c
+++ b/tests/unit/s2n_client_supported_groups_extension_test.c
@@ -259,13 +259,19 @@ int main()
             };
 
             for (size_t i = 0; i < NUM_MISMATCH_PQ_TEST_POLICY_OVERRIDES; i++) {
-                EXPECT_SUCCESS(s2n_enable_tls13_in_test());
+                DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(),
+                        s2n_config_ptr_free);
+                EXPECT_NOT_NULL(config);
+                EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+
                 struct s2n_connection *client_conn = NULL;
                 EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+                EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
                 client_conn->security_policy_override = test_policy_overrides[i][0];
 
                 struct s2n_connection *server_conn = NULL;
                 EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_CLIENT));
+                EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
                 server_conn->security_policy_override = test_policy_overrides[i][1];
 
                 const struct s2n_ecc_preferences *server_ecc_pref = NULL;
@@ -291,7 +297,6 @@ int main()
 
                 EXPECT_SUCCESS(s2n_connection_free(client_conn));
                 EXPECT_SUCCESS(s2n_connection_free(server_conn));
-                EXPECT_SUCCESS(s2n_disable_tls13_in_test());
             }
         }
 

--- a/tests/unit/s2n_connection_serialize_test.c
+++ b/tests/unit/s2n_connection_serialize_test.c
@@ -78,6 +78,7 @@ int main(int argc, char **argv)
             S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
 
     DEFER_CLEANUP(struct s2n_config *tls12_config = s2n_config_new(), s2n_config_ptr_free);
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(tls12_config, "20240501"));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(tls12_config, chain_and_key));
     EXPECT_SUCCESS(s2n_config_disable_x509_verification(tls12_config));
     EXPECT_SUCCESS(s2n_config_set_serialization_version(tls12_config, S2N_SERIALIZED_CONN_V1));
@@ -594,6 +595,7 @@ int main(int argc, char **argv)
     /* Self-talk: Test interaction between TLS1.2 session resumption and serialization */
     {
         DEFER_CLEANUP(struct s2n_config *resumption_config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(resumption_config, "20240501"));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(resumption_config, chain_and_key));
         EXPECT_SUCCESS(s2n_config_disable_x509_verification(resumption_config));
         EXPECT_SUCCESS(s2n_config_set_serialization_version(resumption_config, S2N_SERIALIZED_CONN_V1));
@@ -921,7 +923,7 @@ int main(int argc, char **argv)
      * The information needed to perform renegotiation (i.e. client/server finished verify data
      * and secure renegotiation flag) isn't stored during the serialization process and therefore
      * isn't available post-deserialization.
-     * 
+     *
      * We could add that data to the serialized struct in the future, but for now, the user will get
      * an error if they attempt to configure renegotiation after serialization, and vice versa.
      */

--- a/tests/unit/s2n_extended_master_secret_test.c
+++ b/tests/unit/s2n_extended_master_secret_test.c
@@ -157,7 +157,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(config);
 
         /* TLS1.2 cipher preferences */
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
         struct s2n_cert_chain_and_key *chain_and_key = NULL;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
@@ -208,7 +208,7 @@ int main(int argc, char **argv)
         struct s2n_config *config = s2n_config_new();
         EXPECT_NOT_NULL(config);
 
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
         struct s2n_cert_chain_and_key *chain_and_key = NULL;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
@@ -228,7 +228,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
-        /* s2n clients support EMS by default. To manually prevent them from sending the EMS extension, add a 
+        /* s2n clients support EMS by default. To manually prevent them from sending the EMS extension, add a
          * resumption ticket to the connection, which indicates the previous session did not negotiate
          * EMS and therefore this session shouldn't either. The resumption ticket does not have to be valid
          * as this test is only interested in EMS. */
@@ -253,7 +253,7 @@ int main(int argc, char **argv)
         struct s2n_config *config = s2n_config_new();
         EXPECT_NOT_NULL(config);
 
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
         struct s2n_cert_chain_and_key *chain_and_key = NULL;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,

--- a/tests/unit/s2n_renegotiate_io_test.c
+++ b/tests/unit/s2n_renegotiate_io_test.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     EXPECT_NOT_NULL(config);
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
 
     uint8_t app_data[] = "test application data";
 

--- a/tests/unit/s2n_renegotiate_test.c
+++ b/tests/unit/s2n_renegotiate_test.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
     EXPECT_NOT_NULL(config);
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
 
     uint8_t app_data[] = "smaller hello world";
     uint8_t large_app_data[S2N_TLS_MAXIMUM_FRAGMENT_LENGTH] = "hello world and a lot of zeroes";
@@ -275,7 +275,7 @@ int main(int argc, char *argv[])
             EXPECT_NOT_NULL(small_frag_config);
             EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(small_frag_config));
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(small_frag_config, chain_and_key));
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(small_frag_config, "default"));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(small_frag_config, "20240501"));
             EXPECT_SUCCESS(s2n_config_accept_max_fragment_length(small_frag_config));
             EXPECT_SUCCESS(s2n_config_send_max_fragment_length(small_frag_config, S2N_TLS_MAX_FRAG_LEN_512));
 
@@ -283,7 +283,7 @@ int main(int argc, char *argv[])
             EXPECT_NOT_NULL(larger_frag_config);
             EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(larger_frag_config));
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(larger_frag_config, chain_and_key));
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(larger_frag_config, "default"));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(larger_frag_config, "20240501"));
             EXPECT_SUCCESS(s2n_config_accept_max_fragment_length(larger_frag_config));
             EXPECT_SUCCESS(s2n_config_send_max_fragment_length(larger_frag_config, S2N_TLS_MAX_FRAG_LEN_4096));
 

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -178,7 +178,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
         EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
         EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
-        EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
+        /* EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy)); */
+        EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
 
         security_policy = NULL;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_tls13", &security_policy));
@@ -461,6 +462,7 @@ int main(int argc, char **argv)
 
     {
         char tls12_only_security_policy_strings[][255] = {
+            "default",
             "ELBSecurityPolicy-TLS-1-0-2015-04",
             "ELBSecurityPolicy-TLS-1-0-2015-05",
             "ELBSecurityPolicy-2016-08",
@@ -519,7 +521,6 @@ int main(int argc, char **argv)
         }
 
         char tls13_security_policy_strings[][255] = {
-            "default",
             "default_fips",
             "default_tls13",
             "test_all",
@@ -1050,8 +1051,8 @@ int main(int argc, char **argv)
         {
             const struct s2n_security_policy *versioned_policies[] = {
                 &security_policy_20170210,
-                &security_policy_20240701,
                 &security_policy_20240501,
+                /* &security_policy_20240701, */
             };
 
             const struct s2n_supported_cert supported_certs[] = {

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -178,17 +178,26 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
         EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
         EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
-        EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
+        EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
 
         security_policy = NULL;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_tls13", &security_policy));
         EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
-        EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
         EXPECT_EQUAL(0, security_policy->kem_preferences->kems);
         EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
         EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
         EXPECT_NULL(security_policy->kem_preferences->kems);
+        EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
+
+        EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_fips", &security_policy));
+        EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
+        EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
+        EXPECT_NULL(security_policy->kem_preferences->kems);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
+        EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
+        EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
 
         /* The "all" security policy contains both TLS 1.2 KEM extension and TLS 1.3 KEM SupportedGroup entries*/
         security_policy = NULL;
@@ -452,8 +461,6 @@ int main(int argc, char **argv)
 
     {
         char tls12_only_security_policy_strings[][255] = {
-            "default",
-            "default_fips",
             "ELBSecurityPolicy-TLS-1-0-2015-04",
             "ELBSecurityPolicy-TLS-1-0-2015-05",
             "ELBSecurityPolicy-2016-08",
@@ -512,6 +519,8 @@ int main(int argc, char **argv)
         }
 
         char tls13_security_policy_strings[][255] = {
+            "default",
+            "default_fips",
             "default_tls13",
             "test_all",
             "test_all_tls13",
@@ -1041,6 +1050,7 @@ int main(int argc, char **argv)
         {
             const struct s2n_security_policy *versioned_policies[] = {
                 &security_policy_20170210,
+                &security_policy_20240701,
                 &security_policy_20240501,
             };
 
@@ -1077,6 +1087,7 @@ int main(int argc, char **argv)
             const struct s2n_security_policy *versioned_policies[] = {
                 &security_policy_20240416,
                 &security_policy_20240502,
+                &security_policy_20240702,
             };
 
             const struct s2n_supported_cert supported_certs[] = {

--- a/tests/unit/s2n_self_talk_alerts_test.c
+++ b/tests/unit/s2n_self_talk_alerts_test.c
@@ -55,6 +55,7 @@ int mock_client(struct s2n_test_io_pair *io_pair, s2n_alert_behavior alert_behav
 
     conn = s2n_connection_new(S2N_CLIENT);
     config = s2n_config_new();
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
     s2n_config_disable_x509_verification(config);
     s2n_config_set_alert_behavior(config, alert_behavior);
     s2n_connection_set_config(conn, config);
@@ -177,7 +178,7 @@ int main(int argc, char **argv)
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(),
                 s2n_config_ptr_free);
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
 
         /* Set up the callback to send an alert after receiving ClientHello */
         struct alert_ctx warning_alert = { .write_fd = io_pair.server, .invoked = 0, .count = 2, .level = TLS_ALERT_LEVEL_WARNING, .code = TLS_ALERT_UNRECOGNIZED_NAME };

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
         for (int cert = 0; cert < SUPPORTED_CERTIFICATE_FORMATS; cert++) {
             EXPECT_SUCCESS(s2n_read_test_pem(certificate_paths[cert], cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
             EXPECT_SUCCESS(s2n_read_test_pem(private_key_paths[cert], private_key_pem, S2N_MAX_TEST_PEM_SIZE));

--- a/tests/unit/s2n_self_talk_key_log_test.c
+++ b/tests/unit/s2n_self_talk_key_log_test.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
                 S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
         struct s2n_config *client_config = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "default"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "20240501"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(client_config));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(client_config, chain_and_key));
         DEFER_CLEANUP(struct s2n_stuffer client_key_log, s2n_stuffer_free);
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
 
         struct s2n_config *server_config = NULL;
         EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "default"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "20240501"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(server_config));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
         DEFER_CLEANUP(struct s2n_stuffer server_key_log, s2n_stuffer_free);

--- a/tests/unit/s2n_self_talk_ktls_test.c
+++ b/tests/unit/s2n_self_talk_ktls_test.c
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
     DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240502"));
     EXPECT_SUCCESS(s2n_config_ktls_enable_unsafe_tls13(config));
 
     /* Even if we detected ktls support at compile time, enabling ktls

--- a/tests/unit/s2n_self_talk_npn_test.c
+++ b/tests/unit/s2n_self_talk_npn_test.c
@@ -17,9 +17,9 @@
 #include "testlib/s2n_testlib.h"
 #include "tls/s2n_client_hello.c"
 
-/* The server will always prefer to negotiate an application protocol with 
+/* The server will always prefer to negotiate an application protocol with
  * the ALPN extension. This callback wipes the ALPN extension from the client
- * hello and forces the server to negotiate a protocol using the NPN extension 
+ * hello and forces the server to negotiate a protocol using the NPN extension
  * instead. */
 static int s2n_wipe_alpn_ext(struct s2n_connection *conn, void *ctx)
 {
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
     DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
     EXPECT_NOT_NULL(config);
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
     struct s2n_cert_chain_and_key *chain_and_key = NULL;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key, S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
     DEFER_CLEANUP(struct s2n_config *npn_config = s2n_config_new(), s2n_config_ptr_free);
     EXPECT_NOT_NULL(npn_config);
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(npn_config));
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(npn_config, "default"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(npn_config, "20240501"));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(npn_config, chain_and_key));
     EXPECT_SUCCESS(s2n_config_set_protocol_preferences(npn_config, protocols, protocols_count));
     EXPECT_SUCCESS(s2n_config_set_client_hello_cb(npn_config, s2n_wipe_alpn_ext, NULL));
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
         DEFER_CLEANUP(struct s2n_config *different_config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(different_config);
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(different_config));
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(different_config, "default"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(different_config, "20240501"));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(different_config, chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_protocol_preferences(different_config, server_protocols, server_protocols_count));
         EXPECT_SUCCESS(s2n_config_set_client_hello_cb(different_config, s2n_wipe_alpn_ext, NULL));

--- a/tests/unit/s2n_self_talk_session_id_test.c
+++ b/tests/unit/s2n_self_talk_session_id_test.c
@@ -338,7 +338,7 @@ int main(int argc, char **argv)
         initialize_cache();
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
 
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -251,6 +251,7 @@ int main(int argc, char **argv)
                 struct s2n_connection *client_conn = NULL;
 
                 EXPECT_NOT_NULL(client_conn = s2n_connection_new(S2N_CLIENT));
+                EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_conn->config, "default_tls13"));
 
                 const struct s2n_ecc_preferences *ecc_pref = NULL;
                 EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(client_conn, &ecc_pref));

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -1342,7 +1342,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "20240501"));
 
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
@@ -1387,8 +1387,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_configuration,
                 chain_and_key));
 
-        /* Add the key that encrypted the session ticket so that the server will be able to decrypt 
-         * the ticket successfully. 
+        /* Add the key that encrypted the session ticket so that the server will be able to decrypt
+         * the ticket successfully.
          */
         EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(server_configuration, ticket_key_name1,
                 s2n_array_len(ticket_key_name1), ticket_key1, s2n_array_len(ticket_key1), 0));
@@ -1446,6 +1446,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_configuration);
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(client_configuration, 1));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(client_configuration));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_configuration, "20240501"));
 
         DEFER_CLEANUP(struct s2n_config *server_configuration = s2n_config_new(),
                 s2n_config_ptr_free);
@@ -1453,6 +1454,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_configuration, 1));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_configuration,
                 chain_and_key));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_configuration, "20240501"));
 
         EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(server_configuration, ticket_key_name1,
                 s2n_array_len(ticket_key_name1), ticket_key1, s2n_array_len(ticket_key1), 0));
@@ -1472,8 +1474,8 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_io_stuffer_pair_init(&test_io));
         EXPECT_OK(s2n_connections_set_io_stuffer_pair(client, server, &test_io));
 
-        /* Stop the handshake after the peers have established that a ticket 
-         * will be sent in this handshake. 
+        /* Stop the handshake after the peers have established that a ticket
+         * will be sent in this handshake.
          */
         EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server, client,
                 CLIENT_FINISHED));

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -28,37 +28,50 @@
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
-    EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    /* TLS 1.3 is not used by default */
+    /* Test default override behavior */
+    {
+        /* By default there should be no testing override */
+        EXPECT_FALSE(s2n_use_default_tls13_config());
+
+        EXPECT_SUCCESS(s2n_disable_tls13_in_test());
+        EXPECT_FALSE(s2n_use_default_tls13_config());
+
+        EXPECT_SUCCESS(s2n_enable_tls13_in_test());
+        EXPECT_TRUE(s2n_use_default_tls13_config());
+
+        EXPECT_SUCCESS(s2n_reset_tls13_in_test());
+        EXPECT_FALSE(s2n_use_default_tls13_config());
+    }
+
     EXPECT_FALSE(s2n_use_default_tls13_config());
 
-    /* TLS1.3 is not supported or configured by default */
+    /* TLS1.3 is supported and configured by default */
     {
-        /* Client does not support or configure TLS 1.3 */
+        /* Client supports and configures TLS 1.3 */
         {
             struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
 
-            EXPECT_NOT_EQUAL(conn->client_protocol_version, S2N_TLS13);
+            EXPECT_EQUAL(conn->client_protocol_version, S2N_TLS13);
 
             const struct s2n_security_policy *security_policy = NULL;
             EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
-            EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
+            EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         };
 
-        /* Server does not support or configure TLS 1.3 */
+        /* Server supports and configures TLS 1.3 */
         {
             struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
-            EXPECT_NOT_EQUAL(conn->server_protocol_version, S2N_TLS13);
+            EXPECT_EQUAL(conn->server_protocol_version, S2N_TLS13);
 
             const struct s2n_security_policy *security_policy = NULL;
             EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
-            EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
+            EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         };

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -57,7 +57,8 @@ int main(int argc, char **argv)
 
             const struct s2n_security_policy *security_policy = NULL;
             EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
-            EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
+            /* EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy)); */
+            EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         };
@@ -71,7 +72,8 @@ int main(int argc, char **argv)
 
             const struct s2n_security_policy *security_policy = NULL;
             EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
-            EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
+            /* EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy)); */
+            EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         };

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -327,6 +327,33 @@ const struct s2n_cipher_preferences cipher_preferences_20240331 = {
     .allow_chacha20_boosting = false,
 };
 
+/*
+ * TLS1.3 support.
+ * FIPS compliant.
+ * No DHE (would require extra setup with s2n_config_add_dhparams)
+ */
+struct s2n_cipher_suite *cipher_suites_20240701[] = {
+    &s2n_tls13_aes_256_gcm_sha384,
+    &s2n_tls13_aes_128_gcm_sha256,
+    /* TLS1.2 with ECDSA */
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+
+    /* TLS1.2 with RSA */
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_20240701 = {
+    .count = s2n_array_len(cipher_suites_20240701),
+    .suites = cipher_suites_20240701,
+    .allow_chacha20_boosting = false,
+};
+
 /* Same as 20160411, but with ChaCha20 added as 1st in Preference List */
 struct s2n_cipher_suite *cipher_suites_20190122[] = {
     &s2n_ecdhe_rsa_with_chacha20_poly1305_sha256,

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -27,6 +27,7 @@ struct s2n_cipher_preferences {
     bool allow_chacha20_boosting;
 };
 
+extern const struct s2n_cipher_preferences cipher_preferences_20240701;
 extern const struct s2n_cipher_preferences cipher_preferences_20230317;
 extern const struct s2n_cipher_preferences cipher_preferences_20240331;
 extern const struct s2n_cipher_preferences cipher_preferences_20140601;

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -48,6 +48,19 @@
 
 struct s2n_cipher_preferences;
 
+/* Determine the default security policy when creating a new config. */
+typedef enum {
+    /* Use the "default" security policy */
+    S2N_DEFAULT_POLICY_SETTING_DEFAULT = 0,
+
+    /* Use the "default_fips" security policy */
+    S2N_DEFAULT_POLICY_SETTING_FIPS,
+
+    /* Support overriding the security policies in testing */
+    S2N_DEFAULT_POLICY_SETTING_TSL12,
+    S2N_DEFAULT_POLICY_SETTING_TSL13,
+} s2n_default_security_policy_setting;
+
 typedef enum {
     S2N_NOT_OWNED = 0,
     S2N_APP_OWNED,
@@ -239,7 +252,7 @@ struct s2n_config {
 S2N_CLEANUP_RESULT s2n_config_ptr_free(struct s2n_config **config);
 
 int s2n_config_defaults_init(void);
-S2N_RESULT s2n_config_testing_defaults_init_tls13_certs(void);
+S2N_RESULT s2n_config_testing_default_init_certs(void);
 struct s2n_config *s2n_fetch_default_config(void);
 int s2n_config_set_unsafe_for_testing(struct s2n_config *config);
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -366,7 +366,7 @@ int s2n_connection_set_config(struct s2n_connection *conn, struct s2n_config *co
      * However, the s2n_config_set_verification_ca_location behavior predates client authentication
      * support for OCSP stapling, so could only affect whether clients requested OCSP stapling. We
      * therefore only have to maintain the legacy behavior for clients, not servers.
-     * 
+     *
      * Note: The Rust bindings do not maintain the legacy behavior.
      */
     conn->request_ocsp_status = config->ocsp_status_requested_by_user;
@@ -1197,11 +1197,11 @@ uint64_t s2n_connection_get_delay(struct s2n_connection *conn)
 
 /* s2n-tls has a random delay that will trigger for sensitive errors. This is a mitigation
  * for possible timing sidechannels.
- * 
+ *
  * The historical sidechannel that inspired s2n-tls blinding was the Lucky 13 attack, which takes
  * advantage of potential timing differences when removing padding from a record encrypted in CBC mode.
- * The attack is only theoretical in TLS; the attack criteria is unlikely to ever occur 
- * (See: Fardan, N. J. A., & Paterson, K. G. (2013, May 1). Lucky Thirteen: Breaking the TLS and 
+ * The attack is only theoretical in TLS; the attack criteria is unlikely to ever occur
+ * (See: Fardan, N. J. A., & Paterson, K. G. (2013, May 1). Lucky Thirteen: Breaking the TLS and
  * DTLS Record Protocols.) However, we still include blinding to provide a defense in depth mitigation.
  */
 S2N_RESULT s2n_connection_calculate_blinding(struct s2n_connection *conn, int64_t *min, int64_t *max)

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -1160,7 +1160,8 @@ const struct s2n_security_policy security_policy_null = {
 };
 
 struct s2n_security_policy_selection security_policy_selection[] = {
-    { .version = "default", .security_policy = &security_policy_20240701, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    /* { .version = "default", .security_policy = &security_policy_20240701, .ecc_extension_required = 0, .pq_kem_extension_required = 0 }, */
+    { .version = "default", .security_policy = &security_policy_20240501, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "default_fips", .security_policy = &security_policy_20240702, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "default_tls13", .security_policy = &security_policy_20240503, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "default_pq", .security_policy = &security_policy_20240730, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -20,10 +20,11 @@
 #include "tls/s2n_connection.h"
 #include "utils/s2n_safety.h"
 
-/* TLS1.2 default as of 05/24 */
-const struct s2n_security_policy security_policy_20240501 = {
+/* TODO update the date before merge */
+/* default as of 07/01. Supports TLS 1.3 */
+const struct s2n_security_policy security_policy_20240701 = {
     .minimum_protocol_version = S2N_TLS12,
-    .cipher_preferences = &cipher_preferences_20240331,
+    .cipher_preferences = &cipher_preferences_20240701,
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20240501,
     .ecc_preferences = &s2n_ecc_preferences_20240501,
@@ -32,10 +33,11 @@ const struct s2n_security_policy security_policy_20240501 = {
     },
 };
 
-/* FIPS default as of 05/24 */
-const struct s2n_security_policy security_policy_20240502 = {
+/* TODO update the date before merge */
+/* FIPS default as of 07/01. Supports TLS 1.3 */
+const struct s2n_security_policy security_policy_20240702 = {
     .minimum_protocol_version = S2N_TLS12,
-    .cipher_preferences = &cipher_preferences_20240331,
+    .cipher_preferences = &cipher_preferences_20240701,
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20240501,
     .certificate_signature_preferences = &s2n_certificate_signature_preferences_20201110,
@@ -69,6 +71,30 @@ const struct s2n_security_policy security_policy_20240730 = {
     .ecc_preferences = &s2n_ecc_preferences_20240501,
     .rules = {
             [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
+};
+
+const struct s2n_security_policy security_policy_20240501 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_20240331,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20240501,
+    .ecc_preferences = &s2n_ecc_preferences_20240501,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
+};
+
+const struct s2n_security_policy security_policy_20240502 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_20240331,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20240501,
+    .certificate_signature_preferences = &s2n_certificate_signature_preferences_20201110,
+    .ecc_preferences = &s2n_ecc_preferences_20201021,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+            [S2N_FIPS_140_3] = true,
     },
 };
 
@@ -1134,10 +1160,12 @@ const struct s2n_security_policy security_policy_null = {
 };
 
 struct s2n_security_policy_selection security_policy_selection[] = {
-    { .version = "default", .security_policy = &security_policy_20240501, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "default", .security_policy = &security_policy_20240701, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "default_fips", .security_policy = &security_policy_20240702, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "default_tls13", .security_policy = &security_policy_20240503, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
-    { .version = "default_fips", .security_policy = &security_policy_20240502, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "default_pq", .security_policy = &security_policy_20240730, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "20240701", .security_policy = &security_policy_20240701, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "20240702", .security_policy = &security_policy_20240702, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20240501", .security_policy = &security_policy_20240501, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20240502", .security_policy = &security_policy_20240502, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20240503", .security_policy = &security_policy_20240503, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
@@ -1313,7 +1341,7 @@ int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const cha
     /* If the security policy's minimum version is higher than what libcrypto supports, return an error. */
     POSIX_ENSURE((security_policy->minimum_protocol_version <= s2n_get_highest_fully_supported_tls_version()), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 
-    /* If the certificates loaded in the config are incompatible with the security 
+    /* If the certificates loaded in the config are incompatible with the security
      * policy's certificate preferences, return an error. */
     POSIX_GUARD_RESULT(s2n_config_validate_loaded_certificates(conn->config, security_policy));
 

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -94,11 +94,15 @@ struct s2n_security_policy_selection {
 
 extern struct s2n_security_policy_selection security_policy_selection[];
 
+/* TODO update the date before merge */
+/* Defaults as of 07/01 */
+extern const struct s2n_security_policy security_policy_20240701;
+extern const struct s2n_security_policy security_policy_20240702;
 /* Defaults as of 05/24 */
-extern const struct s2n_security_policy security_policy_20240501;
-extern const struct s2n_security_policy security_policy_20240502;
 extern const struct s2n_security_policy security_policy_20240503;
 
+extern const struct s2n_security_policy security_policy_20240501;
+extern const struct s2n_security_policy security_policy_20240502;
 extern const struct s2n_security_policy security_policy_20140601;
 extern const struct s2n_security_policy security_policy_20141001;
 extern const struct s2n_security_policy security_policy_20150202;

--- a/tls/s2n_tls13.h
+++ b/tls/s2n_tls13.h
@@ -36,6 +36,19 @@ S2N_API __attribute__((deprecated)) int s2n_enable_tls13();
 /* from RFC: https://tools.ietf.org/html/rfc8446#section-4.1.3*/
 extern uint8_t hello_retry_req_random[S2N_TLS_RANDOM_DATA_LEN];
 
+/* Determine the protocol override intent in tests.
+ *
+ * As we continue to evolve the default policies, we need to explicitly track
+ * the original intent of tests (negotiate TLS 1.2 vs TLS 1.3) rather than rely
+ * on the "default" security policy behavior.
+ */
+typedef enum {
+    S2N_SECURITY_POLICY_OVERRIDE_TLS12 = 0,
+    S2N_SECURITY_POLICY_OVERRIDE_TLS13,
+    S2N_SECURITY_POLICY_NO_OVERRIDE,
+} s2n_testing_security_policy_override;
+
+S2N_RESULT s2n_get_testing_security_policy_override(s2n_testing_security_policy_override *override);
 bool s2n_use_default_tls13_config();
 bool s2n_is_tls13_fully_supported();
 int s2n_get_highest_fully_supported_tls_version();


### PR DESCRIPTION
WIP: adding TLS1.3 support to default/default_fips means switching tests which use those policies to TLS1.2 rather than TLS1.3.

This change is not safe since tests can be protocol specific and could have been written to assume TLS1.2. Therefore prior to making this change we must first assert that all tests that are using the "default" policy continue to do so after the change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
