### PR TITLE
Update s2n_connection_get_kem_group_name() to work with ClientHelloRe…

### DIFF
--- a/tests/unit/s2n_tls13_pq_handshake_test.c
+++ b/tests/unit/s2n_tls13_pq_handshake_test.c
@@ -237,6 +237,12 @@ int s2n_test_tls13_pq_handshake(const struct s2n_security_policy *client_sec_pol
         POSIX_ENSURE_EQ(expected_kem_group->kem, server_conn->kex_params.server_kem_group_params.kem_params.kem);
         POSIX_ENSURE_EQ(expected_kem_group->curve, server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
         POSIX_ENSURE_EQ(NULL, server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+
+        /* Ensure s2n_connection_get_kem_group_name() gives the correct answer for both client and server */
+        POSIX_ENSURE_EQ(strlen(expected_kem_group->name), strlen(s2n_connection_get_kem_group_name(server_conn)));
+        POSIX_ENSURE_EQ(memcmp(expected_kem_group->name, s2n_connection_get_kem_group_name(server_conn), strlen(expected_kem_group->name)), 0);
+        POSIX_ENSURE_EQ(strlen(expected_kem_group->name), strlen(s2n_connection_get_kem_group_name(client_conn)));
+        POSIX_ENSURE_EQ(memcmp(expected_kem_group->name, s2n_connection_get_kem_group_name(client_conn), strlen(expected_kem_group->name)), 0);
     } else {
         POSIX_ENSURE_EQ(NULL, client_conn->kex_params.server_kem_group_params.kem_group);
         POSIX_ENSURE_EQ(NULL, client_conn->kex_params.server_kem_group_params.kem_params.kem);
@@ -247,6 +253,12 @@ int s2n_test_tls13_pq_handshake(const struct s2n_security_policy *client_sec_pol
         POSIX_ENSURE_EQ(NULL, server_conn->kex_params.server_kem_group_params.kem_params.kem);
         POSIX_ENSURE_EQ(NULL, server_conn->kex_params.server_kem_group_params.ecc_params.negotiated_curve);
         POSIX_ENSURE_EQ(expected_curve, server_conn->kex_params.server_ecc_evp_params.negotiated_curve);
+
+        /* Ensure s2n_connection_get_curve() gives the correct answer for both client and server */
+        POSIX_ENSURE_EQ(strlen(expected_curve->name), strlen(s2n_connection_get_curve(server_conn)));
+        POSIX_ENSURE_EQ(memcmp(expected_curve->name, s2n_connection_get_curve(server_conn), strlen(expected_curve->name)), 0);
+        POSIX_ENSURE_EQ(strlen(expected_curve->name), strlen(s2n_connection_get_curve(client_conn)));
+        POSIX_ENSURE_EQ(memcmp(expected_curve->name, s2n_connection_get_curve(client_conn), strlen(expected_curve->name)), 0);
     }
 
     /* Verify basic properties of secrets */

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -970,11 +970,11 @@ const char *s2n_connection_get_kem_group_name(struct s2n_connection *conn)
 {
     PTR_ENSURE_REF(conn);
 
-    if (conn->actual_protocol_version < S2N_TLS13 || !conn->kex_params.client_kem_group_params.kem_group) {
+    if (conn->actual_protocol_version < S2N_TLS13 || !conn->kex_params.server_kem_group_params.kem_group) {
         return "NONE";
     }
 
-    return conn->kex_params.client_kem_group_params.kem_group->name;
+    return conn->kex_params.server_kem_group_params.kem_group->name;
 }
 
 static S2N_RESULT s2n_connection_get_client_supported_version(struct s2n_connection *conn,


### PR DESCRIPTION
…tries

### Resolved issues:

N/A

### Description of changes: 

Updates `s2n_connection_get_kem_group_name()` to return the Hybrid PQ KemGroup that the server negotiated (not the one that the client preferred and sent in it's ClientHello) in the event that a 2-RTT PQ Handshake occurs. 

Before https://github.com/aws/s2n-tls/pull/4526 these two values would have always been the same, but after this change (if a 2-RTT occurs where the server selects a PQ KemGroup that the Client didn't include a KeyShare for in the ClientHello) these values could differ.

### Call-outs:

None

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

New unit tests added to check for this case. 

Is this a refactor change? No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
