### PR TITLE
ci: update 2 GHAs with merge_queue branch filter

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,9 @@ name: "CodeQL - Python"
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - 'main'
+      - 'gh-readonly-queue/main/*'
     paths-ignore:
       - '**/tests/integration/*'
   pull_request:
@@ -11,9 +13,6 @@ on:
       - '**/tests/integration/*'
   schedule:
     - cron: "1 18 * * 0"
-  merge_group:
-    types: [checks_requested]
-    branches: [main]
 
 jobs:
   analyze:

--- a/.github/workflows/usage_guide.yml
+++ b/.github/workflows/usage_guide.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'gh-readonly-queue/main/*'
   pull_request:
     branches:
       - main
@@ -39,14 +40,14 @@ jobs:
         run: |
           cd docs/usage-guide
           mdbook build
-      
+
       - name: Deploy documentation to gh-pages
         uses: JamesIves/github-pages-deploy-action@v4.5.0
         if: github.event_name == 'push'
         with:
           target-folder: usage-guide
           folder: docs/usage-guide/book
-  
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4.0.1
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -54,7 +55,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
-      
+
       - name: Upload to S3
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
@@ -63,8 +64,8 @@ jobs:
           aws s3 sync docs/usage-guide/book "s3://s2n-tls-ci-artifacts/$TARGET" --acl private --follow-symlinks
           URL="$CDN/$TARGET/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
-      
-      - name: Output mdbook url 
+
+      - name: Output mdbook url
         uses: ouzi-dev/commit-status-updater@v2.0.1
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:


### PR DESCRIPTION
### Resolved issues:

[#4619](https://github.com/aws/s2n-tls/issues/4619)

### Description of changes: 

Update two of our actions to start on merge queue pushes, instead of merge_group events.

Based on the [branch filter](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) docs.

### Call outs

Fixed the yamllint trailing spaces.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? CI 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
