### PR TITLE
fix: Removing new usage of memcmp

### DIFF
--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -800,7 +800,7 @@ int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *
     /* Ensure we never encrypt with a zero-filled key */
     uint8_t zero_block[S2N_AES256_KEY_LEN] = { 0 };
     POSIX_ENSURE(s2n_constant_time_equals(key->aes_key, zero_block, S2N_AES256_KEY_LEN) != 1,
-        S2N_ERR_KEY_CHECK);
+            S2N_ERR_KEY_CHECK);
     POSIX_GUARD(s2n_stuffer_init(&aad, &aad_blob));
     POSIX_GUARD(s2n_stuffer_write_bytes(&aad, key->implicit_aad, S2N_TICKET_AAD_IMPLICIT_LEN));
     POSIX_GUARD(s2n_stuffer_write_bytes(&aad, key->key_name, S2N_TICKET_KEY_NAME_LEN));

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -799,8 +799,8 @@ int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *
 
     /* Ensure we never encrypt with a zero-filled key */
     uint8_t zero_block[S2N_AES256_KEY_LEN] = { 0 };
-    POSIX_ENSURE(memcmp(key->aes_key, zero_block, S2N_AES256_KEY_LEN) != 0, S2N_ERR_KEY_CHECK);
-
+    POSIX_ENSURE(s2n_constant_time_equals(key->aes_key, zero_block, S2N_AES256_KEY_LEN) != 1,
+        S2N_ERR_KEY_CHECK);
     POSIX_GUARD(s2n_stuffer_init(&aad, &aad_blob));
     POSIX_GUARD(s2n_stuffer_write_bytes(&aad, key->implicit_aad, S2N_TICKET_AAD_IMPLICIT_LEN));
     POSIX_GUARD(s2n_stuffer_write_bytes(&aad, key->key_name, S2N_TICKET_KEY_NAME_LEN));

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -799,7 +799,7 @@ int s2n_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *
 
     /* Ensure we never encrypt with a zero-filled key */
     uint8_t zero_block[S2N_AES256_KEY_LEN] = { 0 };
-    POSIX_ENSURE(s2n_constant_time_equals(key->aes_key, zero_block, S2N_AES256_KEY_LEN) != 1,
+    POSIX_ENSURE(!s2n_constant_time_equals(key->aes_key, zero_block, S2N_AES256_KEY_LEN),
             S2N_ERR_KEY_CHECK);
     POSIX_GUARD(s2n_stuffer_init(&aad, &aad_blob));
     POSIX_GUARD(s2n_stuffer_write_bytes(&aad, key->implicit_aad, S2N_TICKET_AAD_IMPLICIT_LEN));

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -44,7 +44,7 @@ int s2n_in_integ_test_set(bool is_integ);
 bool s2n_in_unit_test();
 bool s2n_in_test();
 
-/* Returns 1 if a and b are equal, in constant time */
+/* Returns true if a and b are equal, in constant time */
 bool s2n_constant_time_equals(const uint8_t* a, const uint8_t* b, const uint32_t len);
 
 /* Copy src to dst, or don't copy it, in constant time */


### PR DESCRIPTION
### Resolved issues:

Fixes CI
### Description of changes: 

Replaces the memcmp with s2n_constant_time_equals.


### Testing:

All tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
