### PR TITLE
chore: improve test coverage for rc4.is_available()

### DIFF
--- a/tests/unit/s2n_rc4_test.c
+++ b/tests/unit/s2n_rc4_test.c
@@ -36,6 +36,8 @@ int main(int argc, char **argv)
     /* Test Openssl-3.0 does not support RC4 */
     if (S2N_OPENSSL_VERSION_AT_LEAST(3, 0, 0)) {
         EXPECT_FALSE(s2n_rc4.is_available());
+    } else {
+        EXPECT_TRUE(s2n_rc4.is_available());
     }
 
     /* Test FIPS does not support RC4 */


### PR DESCRIPTION
### Description of changes: 

#4438 was a little tedious to reproduce because the problematic method wasn't getting called with the newer libcrypto that I have on my dev instance.

This change ensure that the `rc4.is_available` method will have test coverage regardless of libcrypto version.

### Testing:
All CI should pass
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
