### PR TITLE
fix: zip corpus files before uploading to s3

### DIFF
--- a/tests/fuzz/runFuzzTest.sh
+++ b/tests/fuzz/runFuzzTest.sh
@@ -84,8 +84,12 @@ if [ "$CORPUS_UPLOAD_LOC" != "none" ]; then
         # The LD variables interferes with certificate validation when communicating with AWS S3.
         unset LD_PRELOAD
         unset LD_LIBRARY_PATH
-        printf "Copying corpus files from S3 bucket...\n"
-        aws s3 sync $CORPUS_UPLOAD_LOC/${TEST_NAME}/ "${TEMP_CORPUS_DIR}"
+        if aws s3 ls "${CORPUS_UPLOAD_LOC}/${TEST_NAME}/corpus.zip" > /dev/null 2>&1; then
+            echo "corpus.zip found, downloading from S3 bucket and unzipping..."
+            # Download corpus.zip
+            aws s3 cp "${CORPUS_UPLOAD_LOC}/${TEST_NAME}/corpus.zip" "${TEMP_CORPUS_DIR}/corpus.zip"
+            # Unzip the file
+            unzip -o "${TEMP_CORPUS_DIR}/corpus.zip" -d "${TEMP_CORPUS_DIR}"
     )
 else
     cp -r ./corpus/${TEST_NAME}/. "${TEMP_CORPUS_DIR}"
@@ -225,8 +229,11 @@ then
         unset LD_PRELOAD
         unset LD_LIBRARY_PATH
         if [ "$CORPUS_UPLOAD_LOC" != "none" ]; then
-            printf "Uploading corpus files to S3 bucket...\n"
-            aws s3 sync ./corpus/${TEST_NAME}/ $CORPUS_UPLOAD_LOC/${TEST_NAME}/
+            printf "Zipping corpus files...\n"
+            zip -r ./corpus/${TEST_NAME}.zip ./corpus/${TEST_NAME}/
+            
+            printf "Uploading zipped corpus file to S3 bucket...\n"
+            aws s3 cp ./corpus/${TEST_NAME}.zip $CORPUS_UPLOAD_LOC/${TEST_NAME}/corpus.zip
         fi
     fi
 

--- a/tests/fuzz/runFuzzTest.sh
+++ b/tests/fuzz/runFuzzTest.sh
@@ -84,6 +84,10 @@ if [ "$CORPUS_UPLOAD_LOC" != "none" ]; then
         # The LD variables interferes with certificate validation when communicating with AWS S3.
         unset LD_PRELOAD
         unset LD_LIBRARY_PATH
+
+        # Check if corpus.zip exists in the specified S3 location.
+        # `> /dev/null 2>&1` redirects output to /dev/null.
+        # If the file is not found, `aws s3 ls` returns a non-zero exit code.
         if aws s3 ls "${CORPUS_UPLOAD_LOC}/${TEST_NAME}/corpus.zip" > /dev/null 2>&1; then
             printf "corpus.zip found, downloading from S3 bucket and unzipping...\n"
             aws s3 cp "${CORPUS_UPLOAD_LOC}/${TEST_NAME}/corpus.zip" "${TEMP_CORPUS_DIR}/corpus.zip"

--- a/tests/fuzz/runFuzzTest.sh
+++ b/tests/fuzz/runFuzzTest.sh
@@ -85,11 +85,9 @@ if [ "$CORPUS_UPLOAD_LOC" != "none" ]; then
         unset LD_PRELOAD
         unset LD_LIBRARY_PATH
         if aws s3 ls "${CORPUS_UPLOAD_LOC}/${TEST_NAME}/corpus.zip" > /dev/null 2>&1; then
-            echo "corpus.zip found, downloading from S3 bucket and unzipping..."
+            printf "corpus.zip found, downloading from S3 bucket and unzipping...\n"
             aws s3 cp "${CORPUS_UPLOAD_LOC}/${TEST_NAME}/corpus.zip" "${TEMP_CORPUS_DIR}/corpus.zip"
             unzip -o "${TEMP_CORPUS_DIR}/corpus.zip" -d "${TEMP_CORPUS_DIR}"
-        else 
-            cp -r ./corpus/${TEST_NAME}/. "${TEMP_CORPUS_DIR}"
         fi
     )
 else

--- a/tests/fuzz/runFuzzTest.sh
+++ b/tests/fuzz/runFuzzTest.sh
@@ -86,10 +86,11 @@ if [ "$CORPUS_UPLOAD_LOC" != "none" ]; then
         unset LD_LIBRARY_PATH
         if aws s3 ls "${CORPUS_UPLOAD_LOC}/${TEST_NAME}/corpus.zip" > /dev/null 2>&1; then
             echo "corpus.zip found, downloading from S3 bucket and unzipping..."
-            # Download corpus.zip
             aws s3 cp "${CORPUS_UPLOAD_LOC}/${TEST_NAME}/corpus.zip" "${TEMP_CORPUS_DIR}/corpus.zip"
-            # Unzip the file
             unzip -o "${TEMP_CORPUS_DIR}/corpus.zip" -d "${TEMP_CORPUS_DIR}"
+        else 
+            cp -r ./corpus/${TEST_NAME}/. "${TEMP_CORPUS_DIR}"
+        fi
     )
 else
     cp -r ./corpus/${TEST_NAME}/. "${TEMP_CORPUS_DIR}"


### PR DESCRIPTION
### Resolved issues:

Currently corpus files are downloaded/uploaded individually from/to S3 bucket. Since number of requests can factor into S3 pricing, we should minimize it by zipping the corpus before uploading them to S3.

### Description of changes: 

- Instead of downloading individual corpus files, downloads a zipped version and unzip
- Instead of uploading individual corpus files, uploads a zipped version to S3

### Call-outs:

### Testing:

- Test running s2nFuzzBatch with this PR as source: [link to CodeBuild job](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nFuzzBatch/build/s2nFuzzBatch%3A2778dd39-f9f0-4501-98c8-7eafa9211ca9?region=us-west-2)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
