### PR TITLE
fix(ci): partially revert checking out head from current clone.

### DIFF
--- a/codebuild/bin/install_s2n_head.sh
+++ b/codebuild/bin/install_s2n_head.sh
@@ -27,7 +27,8 @@ if [ "$#" -ne "1" ]; then
 fi
 
 clone(){
-    git clone --branch main --single-branch . "$SRC_ROOT"/s2n_head
+    # Path differences for internal builds mean we always need to go back to GitHub for head.
+    git clone --branch main --single-branch https://github.com/aws/s2n-tls "$SRC_ROOT"/s2n_head
 }
 
 # CMake(nix) and Make are using different directory structures.

--- a/codebuild/bin/install_s2n_head.sh
+++ b/codebuild/bin/install_s2n_head.sh
@@ -28,7 +28,7 @@ fi
 
 clone(){
     # Path differences for internal builds mean we always need to go back to GitHub for head.
-    git clone --branch main --single-branch https://github.com/aws/s2n-tls "$SRC_ROOT"/s2n_head
+    git clone --branch main --single-branch "$CLONE_SRC" "$SRC_ROOT"/s2n_head
 }
 
 # CMake(nix) and Make are using different directory structures.
@@ -36,9 +36,13 @@ set +u
 if [[ "$IN_NIX_SHELL" ]]; then
     export DEST_DIR="$SRC_ROOT"/build/bin
     export EXTRA_BUILD_FLAGS=""
+    # Work around issue cloning inside a nix devshell https://github.com/NixOS/nixpkgs/issues/299949 
+    export CLONE_SRC="."
 else
     export DEST_DIR="$SRC_ROOT"/bin
     export EXTRA_BUILD_FLAGS="-DCMAKE_PREFIX_PATH=$LIBCRYPTO_ROOT"
+    # Work around different pathing issues for internal rel.
+    export CLONE_SRC="https://github.com/aws/s2n-tls"
 fi
 set -u
 


### PR DESCRIPTION
### Resolved issues:

none

### Description of changes: 

To check against ^HEAD, we were cloning from the existing filesystem's clone.  This breaks under certain internal build scenarios where our .git folder is in a different place. Go back to cloning from GitHub for non Nix use, but leave the current behavior inside a Nix shell.

### Call-outs:

Cloning inside a nix devshell is throwing an error, appears to be related to https://github.com/NixOS/nixpkgs/issues/299949 .

[ad-hoc](https://us-east-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/Integv2NixBatchBF1FB83F-7tcZOiMDWPH0/build/Integv2NixBatchBF1FB83F-7tcZOiMDWPH0%3Af8a2234f-b68b-4768-9d01-05fa18f8fc85?region=us-east-2) test run of the cross_compat test with these changes

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? CI, ad-hoc

Is this a refactor change? no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
