### PR TITLE
Fix build of s2n_random.c if OPENSSL_NO_ENGINE

### DIFF
--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -47,7 +47,6 @@
 #endif
 #include <errno.h>
 #include <limits.h>
-#include <openssl/engine.h>
 #include <openssl/rand.h>
 #include <pthread.h>
 #include <stdint.h>
@@ -75,6 +74,11 @@
 #include "utils/s2n_random.h"
 #include "utils/s2n_result.h"
 #include "utils/s2n_safety.h"
+
+#if S2N_LIBCRYPTO_SUPPORTS_CUSTOM_RAND
+    /* This header may not be available if OpenSSL is compiled with no-engine. */
+    #include <openssl/engine.h>
+#endif
 
 #if defined(O_CLOEXEC)
     #define ENTROPY_FLAGS O_RDONLY | O_CLOEXEC


### PR DESCRIPTION
### Resolved issues:

Resolves awslabs/aws-crt-python#583

### Description of changes: 

OpenSSL does not create the `openssl/engine.h` header when compiled with the `no-engine` option, which creates the `OPENSSL_NO_ENGINE` preprocessor symbol.

### Call-outs:

I have not tested this.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
