### PR TITLE
chore: bump versions of aws-lc and aws-lc-fips

### DIFF
--- a/codebuild/bin/install_awslc.sh
+++ b/codebuild/bin/install_awslc.sh
@@ -36,7 +36,7 @@ source codebuild/bin/jobs.sh
 if [ "$IS_FIPS" == "1" ]; then
   AWSLC_VERSION=AWS-LC-FIPS-1.0.3
 else
-  AWSLC_VERSION=v1.17.4
+  AWSLC_VERSION=v1.33.0
 fi
 mkdir -p "$BUILD_DIR"||true
 cd "$BUILD_DIR"

--- a/codebuild/bin/install_awslc_fips_2022.sh
+++ b/codebuild/bin/install_awslc_fips_2022.sh
@@ -30,9 +30,9 @@ INSTALL_DIR=$2
 source codebuild/bin/jobs.sh
 
 # There are currently no AWSLC release tags for the 2022 FIPS branch. The
-# following is the latest commit in this branch as of 4/5/23:
+# following is the latest commit in this branch as of 8/19/24:
 # https://github.com/aws/aws-lc/commits/fips-2022-11-02
-AWSLC_VERSION=03ea7816359a3e1babdf9f2cd0e694977c36ebbc
+AWSLC_VERSION=ec94d74a19b5a0aa738b436a95bb06ff87fc7ba9
 
 mkdir -p "$BUILD_DIR" || true
 cd "$BUILD_DIR"

--- a/flake.lock
+++ b/flake.lock
@@ -7,16 +7,16 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1717024791,
-        "narHash": "sha256-iexbdh5oFLyqORor19II03e34SCH1LtR0po8oTB4zJM=",
+        "lastModified": 1724112161,
+        "narHash": "sha256-nvnsCjeP6u5azEIg5dvW3v95mMa8sAwqUKSUwFdplaE=",
         "owner": "dougch",
         "repo": "aws-lc",
-        "rev": "f0ff570c1d098f94155ff14465be0212d4153369",
+        "rev": "645150320c75c672ac286816eb971bb44f97cc23",
         "type": "github"
       },
       "original": {
         "owner": "dougch",
-        "ref": "nixv1.17.4",
+        "ref": "nixv1.33.0",
         "repo": "aws-lc",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
   # TODO: https://github.com/aws/aws-lc/pull/830
-  inputs.awslc.url = "github:dougch/aws-lc?ref=nixv1.17.4";
+  inputs.awslc.url = "github:dougch/aws-lc?ref=nixv1.33.0";
 
   outputs = { self, nix, nixpkgs, awslc, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -56,7 +56,7 @@
 #elif defined(__OpenBSD__)
     #define MEM_PER_CONNECTION 61
 #else
-    #define MEM_PER_CONNECTION 50
+    #define MEM_PER_CONNECTION 51
 #endif
 
 /* This is the maximum memory per connection including 4KB of slack */


### PR DESCRIPTION
### Resolved issues:

Partial for #4710 

### Description of changes: 

We're pinning the versions of aws-lc and aws-lc-fips in CI, nix and our docker containers.

### Call-outs:

- Because the flake is updated, the nix CI jobs are _actually_ testing the new version of aws-lc
- This change won't make it into the regular CI jobs until the custom CodeBuild Docker containers are rebuilt (quick followup to this PR).
- The s2n_mem_usage_test was failing with 50KB/connection when awslc was built with musl; bumping to 51 resolves this in ad-hoc testing.

### Testing:

How is this change tested: locally, unit tests pass

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
