### PR TITLE
Reorder PR and Mainline in Regression Test Runner

### DIFF
--- a/.github/workflows/regression_ci.yml
+++ b/.github/workflows/regression_ci.yml
@@ -84,4 +84,3 @@ jobs:
         with:
           name: regression_artifacts
           path: tests/regression/target/regression_artifacts
-          

--- a/.github/workflows/regression_ci.yml
+++ b/.github/workflows/regression_ci.yml
@@ -41,36 +41,35 @@ jobs:
           make
           sudo make install
 
-      # Generate the necessary bindings
-      - name: Generate
-        run: ${{env.ROOT_PATH}}bindings/rust/generate.sh --skip-tests
-
-      # Run performance tests using Valgrind for current branch
-      - name: Run scalar performance test (curr)
-        env:
-          PERF_MODE: valgrind
-        run: cargo test --release --manifest-path=tests/regression/Cargo.toml
-
       # Switch to the main branch
       - name: Switch to mainline
         run: |
           git fetch origin main
           git switch main
 
-      # Regenerate bindings for main branch
-      - name: Generate
+      # Generate bindings for main branch
+      - name: Generate bindings (mainline)
         run: ${{env.ROOT_PATH}}bindings/rust/generate.sh --skip-tests
 
       # Run performance tests using Valgrind for main branch
-      - name: Run scalar performance test (prev)
+      - name: Run scalar performance test (mainline)
         env:
           PERF_MODE: valgrind
         run: cargo test --release --manifest-path=tests/regression/Cargo.toml
 
-      # Checkout pull request branch again
-      # This is required for cg_annotate diff to locate the changes in the PR to properly annotate the output diff file
+      # Checkout pull request branch
       - name: Checkout pull request branch
         run: git checkout ${{ github.event.pull_request.head.sha }}
+
+      # Generate bindings for PR branch
+      - name: Generate bindings (PR branch)
+        run: ${{env.ROOT_PATH}}bindings/rust/generate.sh --skip-tests
+
+      # Run performance tests using Valgrind for PR branch
+      - name: Run scalar performance test (PR branch)
+        env:
+          PERF_MODE: valgrind
+        run: cargo test --release --manifest-path=tests/regression/Cargo.toml
 
       # Run the differential performance test
       - name: Run diff test
@@ -80,8 +79,9 @@ jobs:
 
       # Upload the performance output artifacts. This runs even if run diff test fails so debug files can be accessed
       - name: Upload artifacts
-        if: ${{ always() }}  
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: regression_artifacts
           path: tests/regression/target/regression_artifacts
+          


### PR DESCRIPTION
### Resolved issues:

This PR resolves an issue with the regression test failing in the rust bindings bump: https://github.com/aws/s2n-tls/actions/runs/10476995419/job/29017133119?pr=4719. 

### Description of changes: 

Currently, the CI workflow runs performance tests on the pull request branch before running them on the mainline branch, which might lead to potential inconsistencies in the test results, especially when generating diffs. There was an issue with the version mismatch for the s2n-tls-sys dependency, where the required version 0.3.1 was not available, causing the build to fail. This was because the bindings are not regenerated after switching back to the PR branch from mainline. To avoid this issue from recurring on this bindings bump and future ones, this PR reorders the operations.

This PR addresses these issues by:

1. Reordering the workflow steps to first switch to the main branch, generate bindings, and run the performance tests on the mainline branch.

2. After completing the mainline tests, the workflow checks out the PR branch, regenerates bindings, and runs the performance tests on the PR branch.

3. Finally, it runs the differential performance test between the mainline and PR branch results.

### Call-outs:

Instead of regenerating the bindings for the differential performance test, I reordered the mainline profiling and pull request profiling so that we only have to generate bindings once. The first git checkout step in the original workflow is used to ensure that the workflow starts by working with the code from the pull request branch. This is necessary because the GitHub Actions runner starts in a detached state, and the workflow needs to explicitly check out the pull request's code to work with it.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
