### PR TITLE
Simplify git logic in regression tests

### DIFF
--- a/.github/workflows/regression_ci.yml
+++ b/.github/workflows/regression_ci.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Run scalar performance test (mainline)
         env:
           PERF_MODE: valgrind
+          COMMIT_TYPE: baseline
         run: cargo test --release --manifest-path=tests/regression/Cargo.toml
 
       # Checkout pull request branch
@@ -69,6 +70,7 @@ jobs:
       - name: Run scalar performance test (PR branch)
         env:
           PERF_MODE: valgrind
+          COMMIT_TYPE: altered
         run: cargo test --release --manifest-path=tests/regression/Cargo.toml
 
       # Run the differential performance test

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -49,8 +49,8 @@ PERF_MODE=valgrind COMMIT_TYPE=baseline cargo test
 ```
 PERF_MODE=diff cargo test
 ```
-This will assert on the performance difference of the current version minus the previous. If the regression exceeds the const `MAX_DIFF`, the test fails. Performance output profiles are stored by their commit id in `/target/baseline` or target/altered:
-- `.raw_profile` for the unannotated cachegrind output result
+This will assert on the performance difference of the current version minus the previous. If the regression exceeds the const `MAX_DIFF`, the test fails. Performance output profiles are stored by their commit id in `/target/baseline` or `target/altered`:
+- `raw_profile` for the unannotated cachegrind output result
 - `annotated_profile` for the annotated cachegrind output (scalar)
 - `target/diff` contains the annotated differential profile between two commits
 

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -39,18 +39,18 @@ This will recursively call all tests with valgrind enabled so the performance ou
 ## Running the Harnesses between versions (differential performance)
 Run the scalar performance for all harnesses on the current branch version of s2n-tls
 ```
-PERF_MODE=valgrind cargo test
+PERF_MODE=valgrind COMMIT_TYPE=altered cargo test
 ```
 `git checkout` or `git switch` to mainline/version being compared to. Make sure you have stashed or committed any changes.
 ```
-PERF_MODE=valgrind cargo test
+PERF_MODE=valgrind COMMIT_TYPE=baseline cargo test
 ```
 `git checkout` or `git switch` back to the original version. At this point you should have two annotated performance outputs for each test. If you have more, the diff test will not be able to recognize the versions being compared.
 ```
 PERF_MODE=diff cargo test
 ```
-This will assert on the performance difference of the current version minus the previous. If the regression exceeds the const `MAX_DIFF`, the test fails. Performance output profiles are stored by their commit id in `/target/commit_id`:
-- `raw_profile` for the unannotated cachegrind output result
+This will assert on the performance difference of the current version minus the previous. If the regression exceeds the const `MAX_DIFF`, the test fails. Performance output profiles are stored by their commit id in `/target/baseline` or target/altered:
+- `.raw_profile` for the unannotated cachegrind output result
 - `annotated_profile` for the annotated cachegrind output (scalar)
 - `target/diff` contains the annotated differential profile between two commits
 
@@ -63,9 +63,9 @@ cargo test
 This will run the tests without valgrind to test if the harnesses complete as expected
 
 ## Output Files
-- `target/$commit_id/test_name.raw`: Contains the raw cachegrind profile. On its own, the file is pretty much unreadable but is useful for the cg_annotate --diff functionality or to visualize the profile via tools like [KCachegrind](https://kcachegrind.github.io/html/Home.html).
-- `target/$commit_id/test_name.annotated`: The scalar annotated profile associated with that particular commit id. This file contains detailed information on the contribution of functions, files, and lines of code to the overall scalar performance count.
-- `target/diff/test_name.diff`: The annotated performance difference between two commits. This file contains the overall performance difference and also details the instruction counts, how many instructions a particular file/function account for, and the contribution of individual lines of code to the overall instruction count difference.
+- `target/regression_artifact/$commit_type/$commit_id_test_name.raw`: Contains the raw cachegrind profile. On its own, the file is pretty much unreadable but is useful for the cg_annotate --diff functionality or to visualize the profile via tools like [KCachegrind](https://kcachegrind.github.io/html/Home.html).
+- `target/regression_artifacts/$commit_type/$commit_id_test_name.annotated`: The scalar annotated profile associated with that particular commit id. This file contains detailed information on the contribution of functions, files, and lines of code to the overall scalar performance count.
+- `target/regression_artifacts/diff/test_name.diff`: The annotated performance difference between two commits. This file contains the overall performance difference and also details the instruction counts, how many instructions a particular file/function account for, and the contribution of individual lines of code to the overall instruction count difference.
 
 ## Sample Output for Valgrind test (differential)
 

--- a/tests/regression/src/lib.rs
+++ b/tests/regression/src/lib.rs
@@ -112,6 +112,7 @@ mod tests {
 
     impl RawProfile {
         fn new(test_name: &str) -> Self {
+            // For filename readability, the first 7 digits of the commit hash are the typical standard to ensure a unique git SHA
             let commit_hash = git::get_current_commit_hash()[..7].to_string();
             let commit_type = env::var("COMMIT_TYPE")
                 .expect("COMMIT_TYPE environment variable must be set to 'baseline' or 'altered'");
@@ -182,6 +183,7 @@ mod tests {
 
             let baseline_profile = RawProfile {
                 test_name: test_name.to_string(),
+                //file names stored an OsString could be invalid UTF-8 so to_string_lossy is used
                 commit_hash: git::extract_commit_hash(&baseline_file.to_string_lossy()),
                 commit_type: "baseline".to_string(),
             };


### PR DESCRIPTION
### Resolved issues:

This PR addresses a discussion in #4701: https://github.com/aws/s2n-tls/pull/4701#discussion_r1715876391 to simplify the git logic in the regression tests.

### Description of changes: 

This change removes the `is_older_commit` and `is_mainline` functions of the git module to allow more flexibility in how the tests are run. Previously, two commits being compared would either have to be on the same log or one of them would have to be mainline for the auto-detection to work. This change introduces environment variables which the user can invoke to identify which commit is the "baseline" and which commit is the "altered" code. 

These changes also modify the test storage scheme to still include a git commit identifier so build artifacts for a baseline commit are now stored by `tests/regression_artifacts/baseline/$commit_id_$test_name`. This enables the DiffProfile to access old and new commits in a simpler fashion than the previous git logic while also providing the commit id in the filename which could be useful as a reference to the change that the profile is associated with.

Additionally, the github actions workflow is updated to reflect these changes when invoking the test through CI, so that mainline sets the environment variable to baseline and the PR branch is set to altered.

### Call-outs:

Since these changes modify the regression test along with the workflow, the workflow will run on this PR and fail. This is because the mainline run through the regression tests in CI will not store files in the same way that the revised approach to the tests does. 
### Testing:

I have run the CI workflow locally and it works as intended.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
