### PR TITLE
fix: enable -Wcast-qual flag for libcrypto=awslc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,10 +209,7 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
-if (NOT $ENV{S2N_LIBCRYPTO} MATCHES "awslc")
-    # add cast-qual back in for non AWS-LC
-    target_compile_options(${PROJECT_NAME} PRIVATE -Wcast-qual)
-endif()
+target_compile_options(${PROJECT_NAME} PRIVATE -Wcast-qual)
 
 if (COVERAGE)
     # https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html


### PR DESCRIPTION


### Resolved issues:

Resolve issue #4710 

### Description of changes: 

* Remove the condition which only add -Wcast-qual back for non AWS-lc Libcrypto.

### Call-outs:

* Waiting for `awslc` update for ubuntu18.

### Testing:

* Local testing without specifying `S2N_LIBCRYPTO=openssl`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
