### PR TITLE
Update to CBMC 6.2.0

### DIFF
--- a/.github/workflows/proof_ci_resources/config.yaml
+++ b/.github/workflows/proof_ci_resources/config.yaml
@@ -1,5 +1,5 @@
 cadical-tag: latest
-cbmc-version: "6.1.0"
+cbmc-version: "6.2.0"
 cbmc-viewer-version: latest
 kissat-tag: latest
 litani-version: latest


### PR DESCRIPTION
### Resolved issues:

Resolves #4745 

### Description of changes: 

Updates CBMC in CI runners to use version 6.2.0

### Call-outs:

None

### Testing:
All proofs re-run locally on HEAD of "main" branch, using EC2/Ubuntu 20.04, and again on macOS. All fine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
