### PR TITLE
fix: add missing null-checks in s2n_connection.c

### DIFF
--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -198,8 +198,6 @@ static int s2n_connection_free_managed_io(struct s2n_connection *conn)
 
 static int s2n_connection_wipe_io(struct s2n_connection *conn)
 {
-    POSIX_ENSURE_REF(conn);
-
     if (s2n_connection_is_managed_corked(conn) && conn->recv) {
         POSIX_GUARD(s2n_socket_read_restore(conn));
     }

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -118,6 +118,9 @@ struct s2n_connection *s2n_connection_new(s2n_mode mode)
 
 static int s2n_connection_zero(struct s2n_connection *conn, int mode, struct s2n_config *config)
 {
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(config);
+
     /* Zero the whole connection structure */
     POSIX_CHECKED_MEMSET(conn, 0, sizeof(struct s2n_connection));
 
@@ -144,6 +147,8 @@ S2N_RESULT s2n_connection_wipe_all_keyshares(struct s2n_connection *conn)
 
 static int s2n_connection_wipe_keys(struct s2n_connection *conn)
 {
+    POSIX_ENSURE_REF(conn);
+
     /* Free any server key received (we may not have completed a
      * handshake, so this may not have been free'd yet) */
     POSIX_GUARD(s2n_pkey_free(&conn->handshake_params.server_public_key));
@@ -193,6 +198,8 @@ static int s2n_connection_free_managed_io(struct s2n_connection *conn)
 
 static int s2n_connection_wipe_io(struct s2n_connection *conn)
 {
+    POSIX_ENSURE_REF(conn);
+
     if (s2n_connection_is_managed_corked(conn) && conn->recv) {
         POSIX_GUARD(s2n_socket_read_restore(conn));
     }
@@ -420,6 +427,8 @@ int s2n_connection_release_buffers(struct s2n_connection *conn)
 
 int s2n_connection_free_handshake(struct s2n_connection *conn)
 {
+    POSIX_ENSURE_REF(conn);
+
     /* We are done with the handshake */
     POSIX_GUARD_RESULT(s2n_handshake_hashes_free(&conn->handshake.hashes));
     POSIX_GUARD_RESULT(s2n_prf_free(conn));
@@ -458,6 +467,8 @@ int s2n_connection_free_handshake(struct s2n_connection *conn)
  */
 int s2n_connection_wipe(struct s2n_connection *conn)
 {
+    POSIX_ENSURE_REF(conn);
+
     /* First make a copy of everything we'd like to save, which isn't very much. */
     int mode = conn->mode;
     struct s2n_config *config = conn->config;
@@ -790,6 +801,8 @@ int s2n_connection_get_client_auth_type(struct s2n_connection *conn,
 
 int s2n_connection_set_client_auth_type(struct s2n_connection *conn, s2n_cert_auth_type client_cert_auth_type)
 {
+    POSIX_ENSURE_REF(conn);
+
     conn->client_cert_auth_type_overridden = 1;
     conn->client_cert_auth_type = client_cert_auth_type;
     return 0;


### PR DESCRIPTION
### Resolved issues:

Resolves #4752 

### Description of changes: 

I initially planned to fix the missing null-check for `s2n_connection_wipe_keys`, but while reviewing the file, I found other functions missing null-checks, which could potentially lead to null-pointer errors.

I added null-checks to functions that didn't perform them. For cases where a function calls another function that already performs a null-check, I did not add additional checks.

### Testing:

Unit tests passed. Will address CI failures if any.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
