### PR TITLE
fix(bindings): unpin jobserver

### DIFF
--- a/bindings/rust/s2n-tls-sys/templates/Cargo.template
+++ b/bindings/rust/s2n-tls-sys/templates/Cargo.template
@@ -36,7 +36,7 @@ stacktrace = []
 # unstable-foo = []
 
 [dependencies]
-
+# https://github.com/aws/s2n-tls/issues/4757
 aws-lc-rs = { version = "=1.8.1" }
 libc = "0.2"
 

--- a/bindings/rust/s2n-tls-sys/templates/Cargo.template
+++ b/bindings/rust/s2n-tls-sys/templates/Cargo.template
@@ -36,11 +36,12 @@ stacktrace = []
 # unstable-foo = []
 
 [dependencies]
-aws-lc-rs = { version = "1.6.2" }
+
+aws-lc-rs = { version = "=1.8.1" }
 libc = "0.2"
 
 [build-dependencies]
-cc = { version = "1.0", features = ["parallel"] }
+cc = { version = "1", features = ["parallel"] }
 
 [dev-dependencies]
 jobserver = "=0.1.26" # newer versions require rust 1.66, see https://github.com/aws/s2n-tls/issues/4241

--- a/bindings/rust/s2n-tls-sys/templates/Cargo.template
+++ b/bindings/rust/s2n-tls-sys/templates/Cargo.template
@@ -36,15 +36,13 @@ stacktrace = []
 # unstable-foo = []
 
 [dependencies]
-# https://github.com/aws/s2n-tls/issues/4757
-aws-lc-rs = { version = "=1.8.1" }
+aws-lc-rs = { version = "1" }
 libc = "0.2"
 
 [build-dependencies]
-cc = { version = "1", features = ["parallel"] }
+cc = { version = "1.0.100", features = ["parallel"] }
 
 [dev-dependencies]
-jobserver = "=0.1.26" # newer versions require rust 1.66, see https://github.com/aws/s2n-tls/issues/4241
 home = "=0.5.5" # newer versions require rust 1.70, see https://github.com/aws/s2n-tls/issues/4395
 regex = "=1.9.6" # newer versions require rust 1.65, see https://github.com/aws/s2n-tls/issues/4242
 zeroize = "=1.7.0" # newer versions require rust 1.72, see https://github.com/aws/s2n-tls/issues/4518

--- a/bindings/rust/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/s2n-tls-tokio/Cargo.toml
@@ -22,10 +22,4 @@ tokio = { version = "1", features = ["net", "time"] }
 clap = { version = "3", features = ["derive"] }
 rand = { version = "0.8" }
 tokio = { version = "1", features = [ "io-std", "io-util", "macros", "net", "rt-multi-thread", "test-util", "time"] }
-# newer versions require rust 1.66, see https://github.com/aws/s2n-tls/issues/4241
-# this version pin is only needed to prevent verification failures when using
-# cargo package / cargo publish, as those commands do not respect the version pin
-# in downstream dev-dependencies (in s2n-tls-sys, in this case)
-jobserver = "=0.1.26"
-# newer versions require rust 1.70
 tokio-macros = "=2.3.0"

--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -32,8 +32,3 @@ openssl-sys = "0.9"
 foreign-types = "0.3"
 temp-env = "0.3"
 checkers = "0.6"
-# newer versions require rust 1.66, see https://github.com/aws/s2n-tls/issues/4241
-# this version pin is only needed to prevent verification failures when using
-# cargo package / cargo publish, as those commands do not respect the version pin
-# in downstream dev-dependencies (in s2n-tls-sys, in this case)
-jobserver = "=0.1.26"


### PR DESCRIPTION
### Resolves:
https://github.com/aws/s2n-tls/issues/4241

### Description of changes:
Our CI is failing due an api change in the `cc` crate. This PR updates the minimum dependencies to require a higher minimum-version of `cc = "1.0.100"`. It also unpins `jobserver` since it looks like they fixed their [MSRV to 1.63](https://github.com/rust-lang/jobserver-rs/blob/main/Cargo.toml#L13).

### Testing:
All tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
