### PR TITLE
ci: use newer version of libFuzzer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,8 +184,8 @@ if(NO_STACK_PROTECTOR)
 endif()
 
 if(S2N_FUZZ_TEST)
-    target_compile_options(${PROJECT_NAME} PUBLIC -fsanitize-coverage=trace-pc-guard -fsanitize=leak)
-    target_link_libraries(${PROJECT_NAME} PUBLIC -fsanitize-coverage=trace-pc-guard -fsanitize=leak)
+    target_compile_options(${PROJECT_NAME} PUBLIC -fsanitize=fuzzer-no-link,leak)
+    target_link_libraries(${PROJECT_NAME} PUBLIC -fsanitize=fuzzer-no-link,leak)
 endif()
 
 if(TSAN)
@@ -602,10 +602,6 @@ if (BUILD_TESTING)
         target_link_libraries(fuzztest PUBLIC ${PROJECT_NAME})
 
         # Set default values for fuzzing if not defined
-        if(NOT DEFINED LIBFUZZER_LIB)
-            message(FATAL_ERROR "LIBFUZZER_LIB is not defined. Please set it to the path of your libFuzzer.a.")
-        endif()
-        
         if(NOT DEFINED FUZZ_TIMEOUT_SEC)
             set(FUZZ_TIMEOUT_SEC 60)
         endif()
@@ -655,8 +651,7 @@ if (BUILD_TESTING)
             )
             target_link_libraries(${TEST_NAME} PRIVATE 
                 fuzztest
-                ${LIBFUZZER_LIB}  # Manually link old libFuzzer.a
-                -lstdc++
+                -fsanitize=fuzzer -lstdc++
             )
 
             # Set the output directory for the fuzzing binaries

--- a/codebuild/spec/buildspec_fuzz.yml
+++ b/codebuild/spec/buildspec_fuzz.yml
@@ -61,8 +61,7 @@ phases:
       - |
         cmake . -Bbuild \
         -DCMAKE_PREFIX_PATH=$LIBCRYPTO_ROOT \
-        -DS2N_FUZZ_TEST=on \
-        -DLIBFUZZER_LIB=/usr/local/libfuzzer/lib/libFuzzer.a
+        -DS2N_FUZZ_TEST=on
       - cmake --build ./build -- -j $(nproc)
   post_build:
     on-failure: ABORT


### PR DESCRIPTION
### Resolved issues:

Part of #4748

We are currently manually linking a specific version of libFuzzer that is 7 years old. 
https://github.com/aws/s2n-tls/blob/7ba4a2f2813cb9225de5dfc8ae5d79c3487aa128/codebuild/bin/install_libFuzzer.sh#L33-L35
Instead, we should use the newer version of libFuzzer that comes with clang.

### Description of changes: 

By using `-fsanitize=fuzzer`, we automatically link the libFuzzer that comes with clang. This change removes the need to manually install or link the old library against our test executables. This will also make it easier to run fuzz tests locally since we no longer need to install libFuzzer.

### Testing:

Running FuzzBatch passed all test cases. [Link to CodeBuild job](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nFuzzBatch/batch/s2nFuzzBatch%3A1d57785e-e1c3-4f9e-be8f-c6c928b9f2ce?region=us-west-2)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
