### PR TITLE
test: refactor pcap test to use version from rtshark

### DIFF
--- a/tests/pcap/Cargo.toml
+++ b/tests/pcap/Cargo.toml
@@ -14,11 +14,12 @@ bytes = "1.7.1"
 hex = "0.4.3"
 reqwest = { version = "0.12.7", features = ["blocking"] }
 semver = "1.0.23"
+rtshark = "2.9.0"
 
 [dependencies]
 anyhow = "1.0.86"
 hex = "0.4.3"
-rtshark = "2.7.1"
+rtshark = "2.9.0"
 
 [dev-dependencies]
 # We want to test against the latest, local version of s2n

--- a/tests/pcap/build.rs
+++ b/tests/pcap/build.rs
@@ -4,12 +4,12 @@
 use anyhow::*;
 use bytes::Buf;
 use bytes::Bytes;
+use rtshark::RTSharkBuilder;
 use semver::Version;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::copy;
 use std::path::Path;
-use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
@@ -101,12 +101,8 @@ fn download(url: &str) -> Result<Bytes> {
 }
 
 fn assert_tshark_version() -> Result<()> {
-    let output = Command::new("tshark").args(["--version"]).output();
-    let version = output.ok().and_then(|output| {
-        let message = std::str::from_utf8(&output.stdout).ok();
-        message.and_then(|msg| msg.split_whitespace().find_map(|s| Version::parse(s).ok()))
-    });
-
+    let version_info = RTSharkBuilder::builder().version()?;
+    let version = version_info.version();
     // Version requirements:
     // 1. tshark >= 3.7.0 is required for JA3 support
     //    JA3 support was added to earlier versions, but did not correctly ignore grease values.
@@ -117,17 +113,13 @@ fn assert_tshark_version() -> Result<()> {
     // 3. tshark >= 4.2.0 is required for JA4 support.
     //    See https://gitlab.com/wireshark/wireshark/-/commit/fd19f0d06f96b9934e3cd5b9889b2f83d3567fce
     let min_version = Version::new(4, 2, 0);
-    if let Some(version) = version {
-        assert!(
-            version >= min_version,
-            "tshark {} required. tshark {} found",
-            min_version,
-            version
-        );
-        println!("tshark version: {}", version);
-    } else {
-        println!("cargo:warning=Unable to determine tshark version");
-    }
+    assert!(
+        version >= &min_version,
+        "tshark {} required. tshark {} found.",
+        min_version,
+        version
+    );
+    println!("tshark version: {}", version);
     Ok(())
 }
 


### PR DESCRIPTION
### Description of changes: 

I didn't like that we had to call tshark directly in the pcap test build script, so I moved that logic into rtshark: https://github.com/CrabeDeFrance/rtshark/commit/1e9b7eb8b0f21115d403248adb45c5642ca2e513 Now we can just get the version from rtshark.

### Testing:
The test correctly still can't run on Ubuntu18 😔
```
error: failed to run custom build command for `pcap v0.1.0 (/home/ubuntu/s2n-tls/tests/pcap)`

Caused by:
  process didn't exit successfully: `/home/ubuntu/s2n-tls/tests/pcap/target/debug/build/pcap-a2228bd6ce729e8c/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at build.rs:116:5:
  tshark 4.2.0 required. tshark 3.6.2 found.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
