### PR TITLE
ci: refactor fuzz buildspec

### DIFF
--- a/codebuild/spec/buildspec_fuzz.yml
+++ b/codebuild/spec/buildspec_fuzz.yml
@@ -13,40 +13,6 @@
 # limitations under the License.
 version: 0.2
 
-# This buildspec runs on an Ubuntu22 image. That configuration is a property of
-# the codebuild job itself.
-
-# Codebuild's matrix jobs have non-differentiated names so use batch-list
-# instead.
-
-# Parameter motivation
-
-# LIBCRYPTOS
-# awslc: happy path libcrypto for s2n-tls
-# openssl 3: s2n-tls takes different code paths for ossl3, so make sure we run 
-#            asan on it. See pr 4033 for a historical motivating example.
-
-batch:
-  build-list:
-    - identifier: clang_awslc
-      debug-session: true
-      env:
-        compute-type: BUILD_GENERAL1_XLARGE
-        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
-        privileged-mode: true
-        variables:
-          S2N_LIBCRYPTO: awslc
-          COMPILER: clang
-    - identifier: clang_openssl_3_0
-      debug-session: true
-      env:
-        compute-type: BUILD_GENERAL1_XLARGE
-        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
-        privileged-mode: true
-        variables:
-          S2N_LIBCRYPTO: openssl-3.0
-          COMPILER: clang
-
 phases:
   pre_build:
     commands:
@@ -60,7 +26,7 @@ phases:
     commands:
       - |
         cmake . -Bbuild \
-        -DCMAKE_PREFIX_PATH=$LIBCRYPTO_ROOT \
+        -DCMAKE_PREFIX_PATH=/usr/local/$S2N_LIBCRYPTO \
         -DS2N_FUZZ_TEST=on
       - cmake --build ./build -- -j $(nproc)
   post_build:

--- a/codebuild/spec/buildspec_fuzz_batch.yml
+++ b/codebuild/spec/buildspec_fuzz_batch.yml
@@ -23,12 +23,11 @@ version: 0.2
 
 # LIBCRYPTOS
 # awslc: happy path libcrypto for s2n-tls
-# openssl 3: s2n-tls takes different code paths for ossl3, so make sure we run 
-#            asan on it. See pr 4033 for a historical motivating example.
+# openssl 3: libcrypto that is widely used
 
 batch:
   build-list:
-    - identifier: s2nFuzzerAWSLC
+    - identifier: clang_awslc
       buildspec: codebuild/spec/buildspec_fuzz.yml
       debug-session: true
       env:
@@ -38,7 +37,7 @@ batch:
         variables:
           S2N_LIBCRYPTO: awslc
           COMPILER: clang
-    - identifier: s2nFuzzerOSSL_3_0
+    - identifier: clang_openssl_3_0
       buildspec: codebuild/spec/buildspec_fuzz.yml
       debug-session: true
       env:

--- a/codebuild/spec/buildspec_fuzz_batch.yml
+++ b/codebuild/spec/buildspec_fuzz_batch.yml
@@ -1,0 +1,50 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+version: 0.2
+
+# This buildspec runs on an Ubuntu22 image. That configuration is a property of
+# the codebuild job itself.
+
+# Codebuild's matrix jobs have non-differentiated names so use batch-list
+# instead.
+
+# Parameter motivation
+
+# LIBCRYPTOS
+# awslc: happy path libcrypto for s2n-tls
+# openssl 3: s2n-tls takes different code paths for ossl3, so make sure we run 
+#            asan on it. See pr 4033 for a historical motivating example.
+
+batch:
+  build-list:
+    - identifier: s2nFuzzerAWSLC
+      buildspec: codebuild/spec/buildspec_fuzz.yml
+      debug-session: true
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
+        privileged-mode: true
+        variables:
+          S2N_LIBCRYPTO: awslc
+          COMPILER: clang
+    - identifier: s2nFuzzerOSSL_3_0
+      buildspec: codebuild/spec/buildspec_fuzz.yml
+      debug-session: true
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
+        privileged-mode: true
+        variables:
+          S2N_LIBCRYPTO: openssl-3.0
+          COMPILER: clang


### PR DESCRIPTION
### Resolved issues:

The s2n-tls release is currently blocked due to a fuzz test failure. This is likely caused by recent changes to [runFuzzTest.sh](https://github.com/aws/s2n-tls/blob/main/tests/fuzz/runFuzzTest.sh), which introduced incompatibilities with the Make build in the Omnibus job.

Failed job: [Link to CodeBuild](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nOmnibus/batch/s2nOmnibus%3A65bdfcd1-5f18-47cb-85ed-f14489d1f2fc?region=us-west-2)

Instead of fixing the Make build, we can replace it with a CMake-based fuzz build, as introduced in #4743

### Description of changes: 

- The Omnibus job runs a batch with a list of identifiers and their associated buildspec files. The fuzz test currently uses a buildspec that runs a batch job, but running a batch job within another batch job can cause issues. Therefore, this PR splits the logic from `buildspec_fuzz.yml` into two files:
   - `buildspec_fuzz_batch.yml` to manage the batch job with environment variables for each job.
   - `buildspec_fuzz.yml` to handle the actual CMake build commands.
- The `-DCMAKE_PREFIX_PATH=$LIBCRYPTO_ROOT` flag was not loading the intended libcrypto correctly, and this PR addresses that issue.

### Call-outs:

This PR requires changes to both the `s2nFuzzBatch` and `s2nOmnibus` jobs:

`s2nFuzzBatch`: Update the buildspec file from `codebuild/spec/buildspec_fuzz.yml` to `codebuild/spec/buildspec_fuzz_batch.yml`.

`s2nOmnibus`: In the buildspec, replace the following:

```
    - identifier: s2nFuzzerOpenSSL111Coverage
      buildspec: codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
      env:
        privileged-mode: true
        compute-type: BUILD_GENERAL1_LARGE
        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
        variables:
          S2N_LIBCRYPTO: openssl-1.1.1
          LATEST_CLANG: true
          TESTS: fuzz
          FUZZ_TIMEOUT_SEC: 60
          FUZZ_COVERAGE: true

    - identifier: s2nFuzzerOpenSSL102FIPS
      buildspec: codebuild/spec/buildspec_ubuntu_fuzz_artifacts.yml
      env:
        privileged-mode: true
        compute-type: BUILD_GENERAL1_LARGE
        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
        variables:
          S2N_LIBCRYPTO: openssl-1.0.2-fips
          LATEST_CLANG: true
          TESTS: fuzz
          FUZZ_TIMEOUT_SEC: 60
```

with:

```
  - identifier: s2nFuzzerAWSLC
    buildspec: codebuild/spec/buildspec_omnibus_fuzz.yml
    debug-session: true
    env:
      compute-type: BUILD_GENERAL1_XLARGE
      image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
      privileged-mode: true
      variables:
        S2N_LIBCRYPTO: awslc
        COMPILER: clang

  - identifier: s2nFuzzerOSSL_3_0
    buildspec: codebuild/spec/buildspec_omnibus_fuzz.yml
    debug-session: true
    env:
      compute-type: BUILD_GENERAL1_XLARGE
      image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
      privileged-mode: true
      variables:
        S2N_LIBCRYPTO: openssl-3.0
        COMPILER: clang
```

### Testing:

Tested changes in this PR by overriding CodeBuild jobs:

Omnibus job ran with the modified buildspec definition: [Link to CodeBuild](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nOmnibus/batch/s2nOmnibus%3A70f54f10-dc4a-41f5-be21-71003d527fa6/builds?region=us-west-2) 
(Note that the old fuzz tests have been removed, and the new `s2nFuzzerAWSLC` and `s2nFuzzerOSSL_3_0` jobs have been added to the batch list.)

s2nFuzzBatch job using `buildspec_fuzz_batch.yml`: [Link to CodeBuild](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nFuzzBatch/batch/s2nFuzzBatch%3Ae2e91d93-48d9-4125-b677-49e5ea6e2ea8?region=us-west-2)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
