### PR TITLE
chore(bindings): pin unicode-width

### DIFF
--- a/bindings/rust/integration/Cargo.toml
+++ b/bindings/rust/integration/Cargo.toml
@@ -10,6 +10,7 @@ s2n-tls = { path = "../s2n-tls"}
 s2n-tls-sys = { path = "../s2n-tls-sys" }
 criterion = { version = "0.3", features = ["html_reports"] }
 anyhow = "1"
+unicode-width = "=0.1.13" # newer versions require newer rust, see https://github.com/aws/s2n-tls/issues/4786
 
 [[bench]]
 name = "s2nc"


### PR DESCRIPTION
### Description of changes: 

Fix broken CI by pinning unicode-width:
```
error[E0658]: use of unstable library feature 'mixed_integer_ops'
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/unicode-width-0.1.14/src/tables.rs:407:22
    |
407 |                 (sum.wrapping_add_signed(isize::from(add)), info)
    |                      ^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #87840 <https://github.com/rust-lang/rust/issues/87840> for more information

error[E0658]: use of unstable library feature 'mixed_integer_ops'
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/unicode-width-0.1.14/src/tables.rs:702:22
    |
702 |                 (sum.wrapping_add_signed(isize::from(add)), info)
    |                      ^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #87840 <https://github.com/rust-lang/rust/issues/87840> for more information

For more information about this error, try `rustc --explain E0658`.
error: could not compile `unicode-width` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
```

wrapping_add_signed became stable in 1.66.0: https://doc.rust-lang.org/core/primitive.isize.html#method.wrapping_add_unsigned


### Testing:
CI passes again

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
