### PR TITLE
refactor: make s2n_array_len constant

### DIFF
--- a/tls/extensions/s2n_server_alpn.c
+++ b/tls/extensions/s2n_server_alpn.c
@@ -66,7 +66,6 @@ static int s2n_alpn_recv(struct s2n_connection *conn, struct s2n_stuffer *extens
 
     uint8_t protocol_len = 0;
     POSIX_GUARD(s2n_stuffer_read_uint8(extension, &protocol_len));
-    POSIX_ENSURE_LT(protocol_len, s2n_array_len(conn->application_protocol));
 
     uint8_t *protocol = s2n_stuffer_raw_read(extension, protocol_len);
     POSIX_ENSURE_REF(protocol);

--- a/utils/s2n_safety.h
+++ b/utils/s2n_safety.h
@@ -97,7 +97,13 @@ S2N_CLEANUP_RESULT s2n_connection_apply_error_blinding(struct s2n_connection** c
     }                                           \
     struct __useless_struct_to_allow_trailing_semicolon__
 
-#define s2n_array_len(array) ((array != NULL) ? (sizeof(array) / sizeof(array[0])) : 0)
+/* CAREFUL: this method works for ARRAYS, not for POINTERS.
+ * Calling sizeof on an array declared in the current function correctly returns
+ * the total size of the array. But once the array is passed to another function,
+ * it behaves like a pointer. Calling sizeof on a pointer only returns the size
+ * of the pointer address itself (so usually 8).
+ */
+#define s2n_array_len(array) (sizeof(array) / sizeof(array[0]))
 
 int s2n_mul_overflow(uint32_t a, uint32_t b, uint32_t* out);
 


### PR DESCRIPTION
### Description of changes: 

Our grep_simple_mistakes script requires that we use s2n_array_len everywhere instead of `(sizeof(array) / sizeof(array[0]))`, but s2n_array_len is no longer defined as `(sizeof(array) / sizeof(array[0]))`, so it's no longer constant. That means that you can't do like:
```
struct s2n_blob array1[100] = { 0 };
struct s2n_blob array2[s2n_array_len(array1)] = { 0 };
```
You could do `(sizeof(array) / sizeof(struct s2n_blob))` as a workaround, but that's unnecessary and more brittle.

The null check is also unnecessary because arrays can't be null. Only pointers can be null, and s2n_array_len doesn't work on pointers anyway. You could argue that we need a `sizeof(array) > 0` check instead, but funnily enough `array[0]` actually doesn't seg fault for an empty array: https://godbolt.org/z/s4vcrr6fP. I guess that makes sense, since you don't have to dereference anything. I'd hope at least some compilers or static analyzers would yell at you though.

### Testing:
I'm just removing an unnecessary null check from a macro. I'm not sure how I'd test this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
