### PR TITLE
test: prepare for auto amending implicit use of "default" security policy

### DIFF
--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -29,6 +29,7 @@
 #include "tls/s2n_tls13.h"
 
 int test_count;
+const char *s2n_auto_gen_old_default_security_policy();
 
 bool s2n_use_color_in_output = true;
 

--- a/tests/testlib/s2n_security_policy_testlib.c
+++ b/tests/testlib/s2n_security_policy_testlib.c
@@ -13,12 +13,13 @@
  * permissions and limitations under the License.
  */
 
+#include "crypto/s2n_fips.h"
 #include "s2n_testlib.h"
 #include "utils/s2n_safety.h"
 
 extern const struct s2n_ecc_named_curve s2n_unsupported_curve;
 
-const struct s2n_ecc_named_curve *const ecc_pref_list_for_retry[] = {
+const struct s2n_ecc_named_curve* const ecc_pref_list_for_retry[] = {
     &s2n_unsupported_curve,
 #if EVP_APIS_SUPPORTED
     &s2n_ecc_curve_x25519,
@@ -40,3 +41,23 @@ const struct s2n_security_policy security_policy_test_tls13_retry = {
     .certificate_signature_preferences = &s2n_certificate_signature_preferences_20201110,
     .ecc_preferences = &ecc_preferences_for_retry,
 };
+
+/* https://github.com/aws/s2n-tls/issues/4765
+ *
+ * These represent the old 'pinned' versions of the "default", "default_fips",
+ * and "default_tls13" policies.
+ *
+ * Motivated when TLS 1.3 support was added to "default" and "default_fips";
+ * this is used to pin old tests to the equivalent numbered policy and avoid
+ * changes in testing behavior.
+ */
+const char* s2n_auto_gen_old_default_security_policy()
+{
+    if (s2n_use_default_tls13_config()) {
+        return "20240503";
+    } else if (s2n_is_in_fips_mode()) {
+        return "20240502";
+    } else {
+        return "20240501";
+    }
+}

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(config = s2n_config_new());
         EXPECT_NOT_NULL(default_config = s2n_fetch_default_config());
 
-        /* s2n_config_new() matches s2n_fetch_default_config() */
+        /* s2n_config_new matches s2n_fetch_default_config() */
         EXPECT_EQUAL(default_config->security_policy, config->security_policy);
         EXPECT_EQUAL(default_config->security_policy->signature_preferences, config->security_policy->signature_preferences);
         EXPECT_EQUAL(default_config->client_cert_auth_type, config->client_cert_auth_type);
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
         }
     };
 
-    /* Test for s2n_config_new() and tls 1.3 behavior */
+    /* Test for s2n_config_new and tls 1.3 behavior */
     {
         if (!s2n_is_in_fips_mode()) {
             struct s2n_config *config = NULL;


### PR DESCRIPTION
### Description of changes: 
This PR includes the manual changes needed before running the auto-generate script in https://github.com/aws/s2n-tls/pull/4778

Changes include:
- adding `s2n_auto_gen_old_default_security_policy` which captures the current numbered equivalent of the default policies.
- changing comments from `s2n_config_new()` -> `s2n_config_new` so that the auto script can match on that string

### Testing:
Only test files were changed and current tests should continue to pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
