### PR TITLE
fix(bindings): handle failures from wipe

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Tests
         working-directory: ${{env.ROOT_PATH}}
         # Test all features except for FIPS, which is tested separately.
-        run: cargo test --features unstable-fingerprint,unstable-ktls,quic,pq
+        run: cargo test --features unstable-renegotiate,unstable-fingerprint,unstable-ktls,quic,pq
 
       # Ensure that all tests pass with the default feature set
       - name: Default Tests

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -802,7 +802,7 @@ impl Connection {
     unsafe fn drop_context(&mut self) -> Result<(), Error> {
         let ctx = s2n_connection_get_ctx(self.connection.as_ptr()).into_result();
         if let Ok(ctx) = ctx {
-            drop(Box::from_raw(ctx.as_ptr()));
+            drop(Box::from_raw(ctx.as_ptr() as *mut Context));
         }
         // Setting a NULL context is important: if we don't also remove the context
         // from the connection, then the invalid memory is still accessible and

--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -805,7 +805,7 @@ impl Connection {
             drop(Box::from_raw(ctx.as_ptr()));
         }
         // Setting a NULL context is important: if we don't also remove the context
-        // from the connection, than the invalid memory is still accessible and
+        // from the connection, then the invalid memory is still accessible and
         // may even be double-freed.
         s2n_connection_set_ctx(self.connection.as_ptr(), core::ptr::null_mut()).into_result()?;
         Ok(())

--- a/bindings/rust/s2n-tls/src/renegotiate.rs
+++ b/bindings/rust/s2n-tls/src/renegotiate.rs
@@ -148,6 +148,7 @@ mod tests {
             ConnectionFuture, ConnectionFutureResult, PrivateKeyCallback, PrivateKeyOperation,
         },
         config::ConnectionInitializer,
+        error::ErrorSource,
         testing::{CertKeyPair, InsecureAcceptAllCertificatesHandler, TestPair, TestPairIO},
     };
     use foreign_types::ForeignTypeRef;
@@ -613,6 +614,16 @@ mod tests {
         let server_name = pair.server.ssl().servername(NameType::HOST_NAME);
         assert_eq!(Some(expected_server_name), server_name);
 
+        Ok(())
+    }
+
+    #[test]
+    fn wipe_for_renegotiate_failure() -> Result<(), Box<dyn Error>> {
+        let mut connection = Connection::new_server();
+        // Servers can't renegotiate
+        let error = connection.wipe_for_renegotiate().unwrap_err();
+        assert_eq!(error.source(), ErrorSource::Library);
+        assert_eq!(error.name(), "S2N_ERR_NO_RENEGOTIATION");
         Ok(())
     }
 }


### PR DESCRIPTION
### Description of changes: 

s2n_renegotiate_wipe is fairly likely to fail, so we should handle those failures.

### Testing:

Added a new test that hits the failure path.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
