### PR TITLE
Revert "test: disallow explict use of "default" policy in tests (#4750)"

### DIFF
--- a/bindings/rust/s2n-tls-tokio/tests/common/mod.rs
+++ b/bindings/rust/s2n-tls-tokio/tests/common/mod.rs
@@ -5,7 +5,7 @@ use s2n_tls::{
     config,
     connection::Builder,
     error::Error,
-    security::{Policy, DEFAULT_TLS13},
+    security::{DEFAULT, DEFAULT_TLS13},
 };
 use s2n_tls_tokio::{TlsAcceptor, TlsConnector, TlsStream};
 use std::time::Duration;
@@ -67,16 +67,14 @@ pub fn server_config() -> Result<config::Builder, Error> {
 
 pub fn client_config_tls12() -> Result<config::Builder, Error> {
     let mut builder = config::Config::builder();
-    let policy = Policy::from_version("20240501").unwrap();
-    builder.set_security_policy(&policy)?;
+    builder.set_security_policy(&DEFAULT)?;
     builder.trust_pem(RSA_CERT_PEM)?;
     Ok(builder)
 }
 
 pub fn server_config_tls12() -> Result<config::Builder, Error> {
     let mut builder = config::Config::builder();
-    let policy = Policy::from_version("20240501").unwrap();
-    builder.set_security_policy(&policy)?;
+    builder.set_security_policy(&DEFAULT)?;
     builder.load_pem(RSA_CERT_PEM, RSA_KEY_PEM)?;
     Ok(builder)
 }

--- a/codebuild/bin/grep_simple_mistakes.sh
+++ b/codebuild/bin/grep_simple_mistakes.sh
@@ -245,44 +245,6 @@ if [[ -n $S2N_ENSURE_WITH_INVALID_ERROR_CODE ]]; then
 fi
 
 #############################################
-# Assert tests don't specify the "default" security policy.
-#
-# Since the "default" policies are subject to change, tests should instead specify
-# an immutable numbered policy to avoid unwanted testing behavior.
-#############################################
-S2N_DEFAULT_SECURITY_POLICY_USAGE=$(find "$PWD" -type f -name "s2n*.c" -path "*/tests/*" \
-    -not -path "*/bindings/*")
-declare -A KNOWN_DEFAULT_USAGE
-KNOWN_DEFAULT_USAGE["$PWD/tests/unit/s2n_security_policies_test.c"]=5
-KNOWN_DEFAULT_USAGE["$PWD/tests/unit/s2n_client_hello_test.c"]=2
-KNOWN_DEFAULT_USAGE["$PWD/tests/unit/s2n_connection_preferences_test.c"]=1
-KNOWN_DEFAULT_USAGE["$PWD/tests/unit/s2n_config_test.c"]=1
-# "default" string not used for specifying security policy
-#
-# The regex matching results in false positives but is intentionally "loose" to
-# try and catch non-obvious [1] usage of "default". This is acceptable since
-# there are only a few false positives at the moment.
-#
-# [1] https://github.com/aws/s2n-tls/blob/341a69ed6fc4fa8f51c09b9cc477223cec4d8e60/tests/unit/s2n_client_hello_test.c#L580
-KNOWN_DEFAULT_USAGE["$PWD/tests/unit/s2n_build_test.c"]=1
-KNOWN_DEFAULT_USAGE["$PWD/tests/unit/s2n_client_key_share_extension_test.c"]=2
-
-for file in $S2N_DEFAULT_SECURITY_POLICY_USAGE; do
-  RESULT_NUM_LINES=`grep -n '"default"' $file | wc -l`
-
-  # set default KNOWN_DEFAULT_USAGE value
-  [ -z "${KNOWN_DEFAULT_USAGE["$file"]}" ] && KNOWN_DEFAULT_USAGE["$file"]="0"
-
-  # check if "default" usage is 0 or a known value
-  if [ "${RESULT_NUM_LINES}" != "${KNOWN_DEFAULT_USAGE["$file"]}" ]; then
-    FAILED=1
-    KNOWN_USAGE=${KNOWN_DEFAULT_USAGE[$file]}
-    printf "\e[1;34mExpected: ${KNOWN_USAGE} Found: ${RESULT_NUM_LINES} usage of \"default\" in $file\n"
-    printf "\e[1;34mTests should specify a numbered security policy unless specifically testing the \"default\" policy.\n\n"
-  fi
-done
-
-#############################################
 # REPORT FINAL RESULTS
 #############################################
 if [ $FAILED == 1 ]; then

--- a/tests/unit/s2n_alerts_protocol_test.c
+++ b/tests/unit/s2n_alerts_protocol_test.c
@@ -479,13 +479,13 @@ int main(int argc, char **argv)
                 s2n_connection_ptr_free);
         EXPECT_SUCCESS(s2n_connection_set_blinding(server, S2N_SELF_SERVICE_BLINDING));
         EXPECT_SUCCESS(s2n_connection_set_config(server, config));
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server, "default"));
 
         DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
                 s2n_connection_ptr_free);
         EXPECT_SUCCESS(s2n_connection_set_blinding(client, S2N_SELF_SERVICE_BLINDING));
         EXPECT_SUCCESS(s2n_connection_set_config(client, config));
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client, "default"));
 
         DEFER_CLEANUP(struct s2n_test_io_stuffer_pair io_pair = { 0 }, s2n_io_stuffer_pair_free);
         EXPECT_OK(s2n_io_stuffer_pair_init(&io_pair));

--- a/tests/unit/s2n_cert_validation_callback_test.c
+++ b/tests/unit/s2n_cert_validation_callback_test.c
@@ -214,7 +214,7 @@ int main(int argc, char *argv[])
 
             DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
             EXPECT_NOT_NULL(config);
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
 
             struct s2n_cert_validation_data data = test_cases[i].data;
             EXPECT_SUCCESS(s2n_config_set_cert_validation_cb(config, s2n_test_cert_validation_callback, &data));
@@ -262,7 +262,7 @@ int main(int argc, char *argv[])
 
             DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
             EXPECT_NOT_NULL(config);
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
 
             struct s2n_cert_validation_data data = test_cases[i].data;
             EXPECT_SUCCESS(s2n_config_set_cert_validation_cb(config, s2n_test_cert_validation_callback, &data));
@@ -300,7 +300,7 @@ int main(int argc, char *argv[])
             EXPECT_NOT_NULL(config);
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_set_verification_ca_location(config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
 
             struct s2n_cert_validation_data data = test_cases[i].data;
             EXPECT_SUCCESS(s2n_config_set_cert_validation_cb(config, s2n_test_cert_validation_callback_self_talk, &data));
@@ -337,7 +337,7 @@ int main(int argc, char *argv[])
             EXPECT_NOT_NULL(server_config);
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_set_verification_ca_location(server_config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "20240501"));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "default"));
             EXPECT_SUCCESS(s2n_config_set_client_auth_type(server_config, S2N_CERT_AUTH_REQUIRED));
 
             struct s2n_cert_validation_data data = test_cases[i].data;
@@ -353,7 +353,7 @@ int main(int argc, char *argv[])
             EXPECT_NOT_NULL(client_config);
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(client_config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_set_verification_ca_location(client_config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "20240501"));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "default"));
             EXPECT_SUCCESS(s2n_config_set_client_auth_type(client_config, S2N_CERT_AUTH_OPTIONAL));
 
             DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);

--- a/tests/unit/s2n_client_hello_request_test.c
+++ b/tests/unit/s2n_client_hello_request_test.c
@@ -76,13 +76,13 @@ int main(int argc, char **argv)
 
     DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
     EXPECT_NOT_NULL(config);
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
 
     DEFER_CLEANUP(struct s2n_config *config_with_reneg_cb = s2n_config_new(), s2n_config_ptr_free);
     EXPECT_NOT_NULL(config_with_reneg_cb);
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config_with_reneg_cb, "20240501"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config_with_reneg_cb, "default"));
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config_with_reneg_cb));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config_with_reneg_cb, chain_and_key));
     EXPECT_SUCCESS(s2n_config_set_renegotiate_request_cb(config_with_reneg_cb, s2n_test_reneg_req_cb, NULL));
@@ -167,7 +167,7 @@ int main(int argc, char **argv)
     {
         DEFER_CLEANUP(struct s2n_config *config_with_warns = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config_with_warns);
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config_with_warns, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config_with_warns, "default"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config_with_warns));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config_with_warns, chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_alert_behavior(config_with_warns, S2N_ALERT_IGNORE_WARNINGS));

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -759,7 +759,7 @@ int main(int argc, char **argv)
             struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
-            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20240501"));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "default"));
 
             const struct s2n_security_policy *security_policy = NULL;
             POSIX_GUARD(s2n_connection_get_security_policy(conn, &security_policy));

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -891,7 +891,7 @@ int main(int argc, char **argv)
             {
                 DEFER_CLEANUP(struct s2n_config *server_config = s2n_config_new_minimal(), s2n_config_ptr_free);
                 EXPECT_NOT_NULL(server_config);
-                EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "20240501"));
+                EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "default"));
                 EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
 
                 DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
@@ -901,7 +901,7 @@ int main(int argc, char **argv)
 
                 DEFER_CLEANUP(struct s2n_config *client_config = s2n_config_new_minimal(), s2n_config_ptr_free);
                 EXPECT_NOT_NULL(client_config);
-                EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "20240501"));
+                EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "default"));
                 EXPECT_SUCCESS(s2n_config_set_verification_ca_location(client_config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
 
                 DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
@@ -927,7 +927,7 @@ int main(int argc, char **argv)
             {
                 DEFER_CLEANUP(struct s2n_config *server_config = s2n_config_new_minimal(), s2n_config_ptr_free);
                 EXPECT_NOT_NULL(server_config);
-                EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "20240501"));
+                EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "default"));
                 EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
 
                 DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
@@ -936,7 +936,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
                 DEFER_CLEANUP(struct s2n_config *client_config = s2n_config_new_minimal(), s2n_config_ptr_free);
-                EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "20240501"));
+                EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "default"));
                 EXPECT_NOT_NULL(client_config);
 
                 DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
@@ -1092,7 +1092,7 @@ int main(int argc, char **argv)
         struct s2n_security_policy rfc9151_applied_locally = security_policy_rfc9151;
         rfc9151_applied_locally.certificate_preferences_apply_locally = true;
 
-        /* rfc9151 doesn't allow SHA256 signatures, but does allow SHA384 signatures,
+        /* rfc9151 doesn't allow SHA256 signatures, but does allow SHA384 signatures, 
          * so ecdsa_p384_sha256 is invalid and ecdsa_p384_sha384 is valid */
 
         /* valid certs are accepted */
@@ -1119,8 +1119,8 @@ int main(int argc, char **argv)
 
         /* certs in default_certs_by_type are validated */
         {
-            /* s2n_config_set_cert_chain_and_key_defaults populates default_certs_by_type
-             * but doesn't populate domain_name_to_cert_map
+            /* s2n_config_set_cert_chain_and_key_defaults populates default_certs_by_type 
+             * but doesn't populate domain_name_to_cert_map 
              */
             DEFER_CLEANUP(struct s2n_config *config = s2n_config_new_minimal(), s2n_config_ptr_free);
             EXPECT_SUCCESS(s2n_config_set_cert_chain_and_key_defaults(config, &invalid_cert, 1));

--- a/tests/unit/s2n_crl_test.c
+++ b/tests/unit/s2n_crl_test.c
@@ -668,7 +668,7 @@ int main(int argc, char *argv[])
         EXPECT_NOT_NULL(config);
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_verification_ca_location(config, S2N_CRL_ROOT_CERT, NULL));
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
 
         struct crl_lookup_data data = { 0 };
         data.crls[0] = intermediate_crl;
@@ -704,7 +704,7 @@ int main(int argc, char *argv[])
         EXPECT_NOT_NULL(config);
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_verification_ca_location(config, S2N_CRL_ROOT_CERT, NULL));
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
 
         struct crl_lookup_data data = { 0 };
         data.crls[0] = intermediate_crl;
@@ -743,7 +743,7 @@ int main(int argc, char *argv[])
         EXPECT_NOT_NULL(server_config);
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, server_chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_verification_ca_location(server_config, S2N_CRL_ROOT_CERT, NULL));
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "default"));
         EXPECT_SUCCESS(s2n_config_set_client_auth_type(server_config, S2N_CERT_AUTH_REQUIRED));
 
         DEFER_CLEANUP(struct s2n_cert_chain_and_key *client_chain_and_key = NULL, s2n_cert_chain_and_key_ptr_free);
@@ -754,7 +754,7 @@ int main(int argc, char *argv[])
         EXPECT_NOT_NULL(client_config);
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(client_config, client_chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_verification_ca_location(client_config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "default"));
         EXPECT_SUCCESS(s2n_config_set_client_auth_type(client_config, S2N_CERT_AUTH_REQUIRED));
 
         struct crl_lookup_data data = { 0 };
@@ -794,7 +794,7 @@ int main(int argc, char *argv[])
         EXPECT_NOT_NULL(server_config);
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, server_chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_verification_ca_location(server_config, S2N_CRL_ROOT_CERT, NULL));
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "default"));
         EXPECT_SUCCESS(s2n_config_set_client_auth_type(server_config, S2N_CERT_AUTH_REQUIRED));
 
         DEFER_CLEANUP(struct s2n_cert_chain_and_key *client_chain_and_key = NULL, s2n_cert_chain_and_key_ptr_free);
@@ -805,7 +805,7 @@ int main(int argc, char *argv[])
         EXPECT_NOT_NULL(client_config);
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(client_config, client_chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_verification_ca_location(client_config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "default"));
         EXPECT_SUCCESS(s2n_config_set_client_auth_type(client_config, S2N_CERT_AUTH_REQUIRED));
 
         struct crl_lookup_data data = { 0 };

--- a/tests/unit/s2n_extended_master_secret_test.c
+++ b/tests/unit/s2n_extended_master_secret_test.c
@@ -157,7 +157,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(config);
 
         /* TLS1.2 cipher preferences */
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
         struct s2n_cert_chain_and_key *chain_and_key = NULL;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
@@ -208,7 +208,7 @@ int main(int argc, char **argv)
         struct s2n_config *config = s2n_config_new();
         EXPECT_NOT_NULL(config);
 
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
         struct s2n_cert_chain_and_key *chain_and_key = NULL;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
@@ -253,7 +253,7 @@ int main(int argc, char **argv)
         struct s2n_config *config = s2n_config_new();
         EXPECT_NOT_NULL(config);
 
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
         struct s2n_cert_chain_and_key *chain_and_key = NULL;
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,

--- a/tests/unit/s2n_renegotiate_io_test.c
+++ b/tests/unit/s2n_renegotiate_io_test.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     EXPECT_NOT_NULL(config);
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
 
     uint8_t app_data[] = "test application data";
 

--- a/tests/unit/s2n_renegotiate_test.c
+++ b/tests/unit/s2n_renegotiate_test.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
     EXPECT_NOT_NULL(config);
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
 
     uint8_t app_data[] = "smaller hello world";
     uint8_t large_app_data[S2N_TLS_MAXIMUM_FRAGMENT_LENGTH] = "hello world and a lot of zeroes";
@@ -275,7 +275,7 @@ int main(int argc, char *argv[])
             EXPECT_NOT_NULL(small_frag_config);
             EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(small_frag_config));
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(small_frag_config, chain_and_key));
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(small_frag_config, "20240501"));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(small_frag_config, "default"));
             EXPECT_SUCCESS(s2n_config_accept_max_fragment_length(small_frag_config));
             EXPECT_SUCCESS(s2n_config_send_max_fragment_length(small_frag_config, S2N_TLS_MAX_FRAG_LEN_512));
 
@@ -283,7 +283,7 @@ int main(int argc, char *argv[])
             EXPECT_NOT_NULL(larger_frag_config);
             EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(larger_frag_config));
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(larger_frag_config, chain_and_key));
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(larger_frag_config, "20240501"));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(larger_frag_config, "default"));
             EXPECT_SUCCESS(s2n_config_accept_max_fragment_length(larger_frag_config));
             EXPECT_SUCCESS(s2n_config_send_max_fragment_length(larger_frag_config, S2N_TLS_MAX_FRAG_LEN_4096));
 

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -171,7 +171,7 @@ int main(int argc, char **argv)
 
     /* Test common known good cipher suites for expected configuration */
     {
-        EXPECT_SUCCESS(s2n_find_security_policy_from_version("20240501", &security_policy));
+        EXPECT_SUCCESS(s2n_find_security_policy_from_version("default", &security_policy));
         EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
         EXPECT_NULL(security_policy->kem_preferences->kems);

--- a/tests/unit/s2n_self_talk_alerts_test.c
+++ b/tests/unit/s2n_self_talk_alerts_test.c
@@ -177,7 +177,7 @@ int main(int argc, char **argv)
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(),
                 s2n_config_ptr_free);
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
 
         /* Set up the callback to send an alert after receiving ClientHello */
         struct alert_ctx warning_alert = { .write_fd = io_pair.server, .invoked = 0, .count = 2, .level = TLS_ALERT_LEVEL_WARNING, .code = TLS_ALERT_UNRECOGNIZED_NAME };
@@ -245,7 +245,7 @@ int main(int argc, char **argv)
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(),
                 s2n_config_ptr_free);
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
 
         /* Set up the callback to send an alert after receiving ClientHello */
         struct alert_ctx fatal_alert = { .write_fd = io_pair.server, .invoked = 0, .count = 1, .level = TLS_ALERT_LEVEL_FATAL, .code = TLS_ALERT_UNRECOGNIZED_NAME };
@@ -299,7 +299,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, client_hello_send_alerts, &warning_alert));
 
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
 
         /* This is the server process, close the client end of the pipe */
         EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));

--- a/tests/unit/s2n_self_talk_alpn_test.c
+++ b/tests/unit/s2n_self_talk_alpn_test.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv)
     EXPECT_NOT_NULL(server_config);
     EXPECT_SUCCESS(s2n_config_set_protocol_preferences(server_config, protocols,
             s2n_array_len(protocols)));
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "20240501"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "default"));
 
     DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = NULL,
             s2n_cert_chain_and_key_ptr_free);

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -121,7 +121,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
 
         EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
         for (int cert = 0; cert < SUPPORTED_CERTIFICATE_FORMATS; cert++) {
             EXPECT_SUCCESS(s2n_read_test_pem(certificate_paths[cert], cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
             EXPECT_SUCCESS(s2n_read_test_pem(private_key_paths[cert], private_key_pem, S2N_MAX_TEST_PEM_SIZE));

--- a/tests/unit/s2n_self_talk_key_log_test.c
+++ b/tests/unit/s2n_self_talk_key_log_test.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv)
                 S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
         struct s2n_config *client_config = NULL;
         EXPECT_NOT_NULL(client_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "default"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(client_config));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(client_config, chain_and_key));
         DEFER_CLEANUP(struct s2n_stuffer client_key_log, s2n_stuffer_free);
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
 
         struct s2n_config *server_config = NULL;
         EXPECT_NOT_NULL(server_config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "default"));
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(server_config));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
         DEFER_CLEANUP(struct s2n_stuffer server_key_log, s2n_stuffer_free);

--- a/tests/unit/s2n_self_talk_ktls_test.c
+++ b/tests/unit/s2n_self_talk_ktls_test.c
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
     DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
     EXPECT_SUCCESS(s2n_config_ktls_enable_unsafe_tls13(config));
 
     /* Even if we detected ktls support at compile time, enabling ktls

--- a/tests/unit/s2n_self_talk_npn_test.c
+++ b/tests/unit/s2n_self_talk_npn_test.c
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
     DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
     EXPECT_NOT_NULL(config);
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
     struct s2n_cert_chain_and_key *chain_and_key = NULL;
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key, S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
     DEFER_CLEANUP(struct s2n_config *npn_config = s2n_config_new(), s2n_config_ptr_free);
     EXPECT_NOT_NULL(npn_config);
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(npn_config));
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(npn_config, "20240501"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(npn_config, "default"));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(npn_config, chain_and_key));
     EXPECT_SUCCESS(s2n_config_set_protocol_preferences(npn_config, protocols, protocols_count));
     EXPECT_SUCCESS(s2n_config_set_client_hello_cb(npn_config, s2n_wipe_alpn_ext, NULL));
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
         DEFER_CLEANUP(struct s2n_config *different_config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(different_config);
         EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(different_config));
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(different_config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(different_config, "default"));
         EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(different_config, chain_and_key));
         EXPECT_SUCCESS(s2n_config_set_protocol_preferences(different_config, server_protocols, server_protocols_count));
         EXPECT_SUCCESS(s2n_config_set_client_hello_cb(different_config, s2n_wipe_alpn_ext, NULL));

--- a/tests/unit/s2n_self_talk_session_id_test.c
+++ b/tests/unit/s2n_self_talk_session_id_test.c
@@ -338,7 +338,7 @@ int main(int argc, char **argv)
         initialize_cache();
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         EXPECT_NOT_NULL(config = s2n_config_new());
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
 
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));

--- a/tests/unit/s2n_self_talk_shutdown_test.c
+++ b/tests/unit/s2n_self_talk_shutdown_test.c
@@ -30,7 +30,7 @@ int main(int argc, char **argv)
     EXPECT_NOT_NULL(config);
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
 
     /* Self-Talk: shutdown during handshake */
     for (size_t mode_i = 0; mode_i < s2n_array_len(modes); mode_i++) {

--- a/tests/unit/s2n_server_renegotiation_info_test.c
+++ b/tests/unit/s2n_server_renegotiation_info_test.c
@@ -52,7 +52,7 @@ int main(int argc, char **argv)
     EXPECT_NOT_NULL(config);
     EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
     EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+    EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
 
     const uint8_t client_verify_data[] = "client verify data";
     const uint8_t server_verify_data[] = "server verify data";

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -1342,7 +1342,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
         EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default"));
 
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));

--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -212,7 +212,7 @@ int main(int argc, char **argv)
         uint8_t *chain_data = s2n_stuffer_raw_read(&cert_chain_stuffer, chain_len);
         EXPECT_NOT_NULL(chain_data);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
 
         struct s2n_pkey public_key_out;
         EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key_out));
@@ -237,7 +237,7 @@ int main(int argc, char **argv)
         uint8_t *chain_data = s2n_stuffer_raw_read(&cert_chain_stuffer, chain_len);
         EXPECT_NOT_NULL(chain_data);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
 
         EXPECT_SUCCESS(s2n_x509_validator_set_max_chain_depth(&validator, 2));
         struct s2n_pkey public_key_out;
@@ -285,7 +285,7 @@ int main(int argc, char **argv)
         uint8_t *chain_data = s2n_stuffer_raw_read(&cert_chain_stuffer, chain_len);
         EXPECT_NOT_NULL(chain_data);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
 
         struct s2n_pkey public_key_out;
         EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key_out));
@@ -322,7 +322,7 @@ int main(int argc, char **argv)
         uint8_t *chain_data = s2n_stuffer_raw_read(&cert_chain_stuffer, chain_len);
         EXPECT_NOT_NULL(chain_data);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
 
         struct s2n_pkey public_key_out;
         EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key_out));
@@ -402,7 +402,7 @@ int main(int argc, char **argv)
         uint8_t *chain_data = s2n_stuffer_raw_read(&cert_chain_stuffer, chain_len);
         EXPECT_NOT_NULL(chain_data);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
 
         struct s2n_pkey public_key_out;
         EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key_out));
@@ -439,7 +439,7 @@ int main(int argc, char **argv)
         uint8_t *chain_data = s2n_stuffer_raw_read(&cert_chain_stuffer, chain_len);
         EXPECT_NOT_NULL(chain_data);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
 
         EXPECT_SUCCESS(s2n_x509_validator_set_max_chain_depth(&validator, 2));
         struct s2n_pkey public_key_out;
@@ -483,7 +483,7 @@ int main(int argc, char **argv)
         uint8_t *chain_data = s2n_stuffer_raw_read(&cert_chain_stuffer, chain_len);
         EXPECT_NOT_NULL(chain_data);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
 
         s2n_clock_time_nanoseconds old_clock = connection->config->wall_clock;
         s2n_config_set_wall_clock(connection->config, fetch_expired_after_ocsp_timestamp, NULL);
@@ -539,7 +539,7 @@ int main(int argc, char **argv)
         uint8_t *chain_data = s2n_stuffer_raw_read(&cert_chain_stuffer, chain_len);
         EXPECT_NOT_NULL(chain_data);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
 
         s2n_clock_time_nanoseconds old_clock = connection->config->wall_clock;
         EXPECT_SUCCESS(s2n_config_set_wall_clock(connection->config, fetch_early_expired_after_ocsp_timestamp, NULL));
@@ -577,7 +577,7 @@ int main(int argc, char **argv)
         uint8_t *chain_data = s2n_stuffer_raw_read(&cert_chain_stuffer, chain_len);
         EXPECT_NOT_NULL(chain_data);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
 
         /* alter a random byte in the certificate to make it invalid */
         size_t corrupt_index = 200;
@@ -622,7 +622,7 @@ int main(int argc, char **argv)
         uint8_t *chain_data = s2n_stuffer_raw_read(&cert_chain_stuffer, chain_len);
         EXPECT_NOT_NULL(chain_data);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
 
         struct s2n_pkey public_key_out;
         EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key_out));
@@ -669,7 +669,7 @@ int main(int argc, char **argv)
         uint8_t *chain_data = s2n_stuffer_raw_read(&cert_chain_stuffer, chain_len);
         EXPECT_NOT_NULL(chain_data);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
 
         struct s2n_pkey public_key_out;
         EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key_out));
@@ -708,7 +708,7 @@ int main(int argc, char **argv)
         uint8_t *chain_data = s2n_stuffer_raw_read(&cert_chain_stuffer, chain_len);
         EXPECT_NOT_NULL(chain_data);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
 
         struct s2n_pkey public_key_out;
         EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key_out));
@@ -755,7 +755,7 @@ int main(int argc, char **argv)
         uint8_t *chain_data = s2n_stuffer_raw_read(&cert_chain_stuffer, chain_len);
         EXPECT_NOT_NULL(chain_data);
 
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
 
         struct s2n_pkey public_key_out;
         EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key_out));
@@ -1908,7 +1908,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(chain_data);
 
         /* This cert chain includes a SHA1 signature, so the security policy must allow SHA1 cert signatures. */
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
 
         struct s2n_pkey public_key_out;
         EXPECT_SUCCESS(s2n_pkey_zero_init(&public_key_out));
@@ -2099,7 +2099,7 @@ int main(int argc, char **argv)
 
             DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
             EXPECT_NOT_NULL(connection);
-            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
             EXPECT_SUCCESS(s2n_set_server_name(connection, "s2nTestServer"));
 
             DEFER_CLEANUP(struct s2n_stuffer cert_chain_stuffer = { 0 }, s2n_stuffer_free);
@@ -2128,7 +2128,7 @@ int main(int argc, char **argv)
 
             DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
             EXPECT_NOT_NULL(connection);
-            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
             EXPECT_SUCCESS(s2n_set_server_name(connection, "s2nTestServer"));
 
             DEFER_CLEANUP(struct s2n_stuffer cert_chain_stuffer = { 0 }, s2n_stuffer_free);
@@ -2159,7 +2159,7 @@ int main(int argc, char **argv)
 
             DEFER_CLEANUP(struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
             EXPECT_NOT_NULL(connection);
-            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "20240501"));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(connection, "default"));
             EXPECT_SUCCESS(s2n_set_server_name(connection, "s2nTestServer"));
 
             DEFER_CLEANUP(struct s2n_stuffer cert_chain_stuffer = { 0 }, s2n_stuffer_free);

--- a/tests/unit/s2n_x509_validator_time_verification_test.c
+++ b/tests/unit/s2n_x509_validator_time_verification_test.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 
             DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
             EXPECT_NOT_NULL(config);
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
 
             if (test_cases[i].disable_x509_time_validation) {
                 EXPECT_SUCCESS(s2n_config_disable_x509_time_verification(config));
@@ -144,7 +144,7 @@ int main(int argc, char *argv[])
             EXPECT_NOT_NULL(config);
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_set_verification_ca_location(config, test_cases[i].cert_pem_path, NULL));
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
 
             if (test_cases[i].disable_x509_time_validation) {
                 EXPECT_SUCCESS(s2n_config_disable_x509_time_verification(config));
@@ -185,7 +185,7 @@ int main(int argc, char *argv[])
             EXPECT_NOT_NULL(server_config);
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, default_chain_and_key));
             EXPECT_SUCCESS(s2n_config_set_verification_ca_location(server_config, test_cases[i].cert_pem_path, NULL));
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "20240501"));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "default"));
             EXPECT_SUCCESS(s2n_config_set_client_auth_type(server_config, S2N_CERT_AUTH_REQUIRED));
 
             if (test_cases[i].disable_x509_time_validation) {
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
             EXPECT_NOT_NULL(client_config);
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(client_config, chain_and_key));
             EXPECT_SUCCESS(s2n_config_set_verification_ca_location(client_config, S2N_DEFAULT_TEST_CERT_CHAIN, NULL));
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "20240501"));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(client_config, "default"));
             EXPECT_SUCCESS(s2n_config_set_client_auth_type(client_config, S2N_CERT_AUTH_OPTIONAL));
 
             DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
@@ -250,7 +250,7 @@ int main(int argc, char *argv[])
 
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
         EXPECT_NOT_NULL(config);
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240501"));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default"));
         EXPECT_SUCCESS(s2n_config_disable_x509_time_verification(config));
 
         DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -1313,7 +1313,7 @@ int s2n_connection_set_cipher_preferences(struct s2n_connection *conn, const cha
     /* If the security policy's minimum version is higher than what libcrypto supports, return an error. */
     POSIX_ENSURE((security_policy->minimum_protocol_version <= s2n_get_highest_fully_supported_tls_version()), S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED);
 
-    /* If the certificates loaded in the config are incompatible with the security
+    /* If the certificates loaded in the config are incompatible with the security 
      * policy's certificate preferences, return an error. */
     POSIX_GUARD_RESULT(s2n_config_validate_loaded_certificates(conn->config, security_policy));
 


### PR DESCRIPTION
This reverts commit 360feb238fcd2b03efe7a8025708b32890bae811.

### Description of changes: 
While executing the [plan](https://github.com/aws/s2n-tls/issues/4765) to auto-pin config/connection to a numbered policy, we discovered that some tests in-fact do want to test the "default" policy. This means that pinning these policies would result in testing regression.

The same reasoning also applies to the explicit usage in our tests and we need to carefully audit those tests before pinning those policies. This PR reverts the pinning the explicit usage until we have a clear path forward and we can carefully audit those tests.

### Testing:
CI should continue to pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
