### PR TITLE
feat(bindings): add set receive buffering to the rust bindings

### DIFF
--- a/bindings/rust/s2n-tls/src/connection.rs
+++ b/bindings/rust/s2n-tls/src/connection.rs
@@ -451,6 +451,18 @@ impl Connection {
         Ok(self)
     }
 
+    /// Configure the connection to reduce potentially expensive calls to recv.
+    ///
+    /// Refer to the corresponding C API
+    /// [s2n_connection_set_recv_buffering](https://aws.github.io/s2n-tls/doxygen/s2n_8h.html)
+    /// for more information.
+    pub fn set_receive_buffering(&mut self, enabled: bool) -> Result<&mut Self, Error> {
+        unsafe {
+            s2n_connection_set_recv_buffering(self.connection.as_ptr(), enabled).into_result()
+        }?;
+        Ok(self)
+    }
+
     /// wipes and free the in and out buffers associated with a connection.
     ///
     /// This function may be called when a connection is in keep-alive or idle state to


### PR DESCRIPTION
### Description of changes: 

Add rust bindings `connection.set_receive_buffering(enabled)`  which correspond to `s2n_connection_set_recv_buffering`.

The C api was added in https://github.com/aws/s2n-tls/pull/4485 that provides performance by reducing recv syscalls eariler, this change updates the `s2n-tls` rust api to enable this feature.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
