### PR TITLE
ci: Add ubuntu24 with a new cmake buildspec

### DIFF
--- a/codebuild/spec/buildspec_generalbatch.yml
+++ b/codebuild/spec/buildspec_generalbatch.yml
@@ -187,6 +187,26 @@ batch:
           S2N_LIBCRYPTO: openssl-3.0
           TESTS: unit
       identifier: s2nUnitOpenssl3Gcc9
+    - env:
+        compute-type: BUILD_GENERAL1_SMALL
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu24codebuild
+        privileged-mode: true
+        variables:
+          BUILD_S2N: 'true'
+          GCC_VERSION: '13'
+          S2N_LIBCRYPTO: 'openssl-3.0'
+          TESTS: unit
+      identifier: s2nUnitOpenss3Gcc13
+    - env:
+        compute-type: BUILD_GENERAL1_SMALL
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu24codebuild
+        privileged-mode: true
+        variables:
+          BUILD_S2N: 'true'
+          GCC_VERSION: '13'
+          S2N_LIBCRYPTO: 'awslc'
+          TESTS: unit
+      identifier: s2nUnitAwslcGcc13
     - buildspec: codebuild/spec/buildspec_amazonlinux.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE

--- a/codebuild/spec/buildspec_ubuntu_cmake.yml
+++ b/codebuild/spec/buildspec_ubuntu_cmake.yml
@@ -1,0 +1,29 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+version: 0.2
+
+phases:
+  build:
+    on-failure: ABORT
+    commands:
+      - |
+        cmake . -Bbuild \
+          -DCMAKE_C_COMPILER=/usr/bin/$COMPILER \
+          -DCMAKE_PREFIX_PATH=/usr/local/$S2N_LIBCRYPTO \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - cmake --build ./build -- -j $(nproc)
+  post_build:
+    on-failure: ABORT
+    commands:
+      - CTEST_OUTPUT_ON_FAILURE=1 CTEST_PARALLEL_LEVEL=$(nproc) make -C build test


### PR DESCRIPTION
### Description of changes: 

Add an Ubuntu24 unit test for awslc and openssl3. To diverge from the historical scripts, which modify PATH, I'm introducing a new simpler CMake buildspec, modeled on the [sanitizer](https://github.com/aws/s2n-tls/blob/main/codebuild/spec/buildspec_sanitizer.yml).

### Call-outs:

CI won't run with these changes.  Manual job: https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nGeneralBatch/batch/s2nGeneralBatch%3A86306335-4d9a-48f8-be93-11254cdf7ee5?region=us-west-2#

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? Locally, ad-hoc CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
