### PR TITLE
chore: bump awslc(non FIPS) to 1.36.0

### DIFF
--- a/codebuild/bin/install_awslc.sh
+++ b/codebuild/bin/install_awslc.sh
@@ -39,7 +39,7 @@ fi
 if [ "$IS_FIPS" == "1" ]; then
   AWSLC_VERSION=AWS-LC-FIPS-1.0.3
 else
-  AWSLC_VERSION=v1.33.0
+  AWSLC_VERSION=v1.36.0
 fi
 mkdir -p "$BUILD_DIR"||true
 cd "$BUILD_DIR"

--- a/flake.lock
+++ b/flake.lock
@@ -7,16 +7,16 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1724112161,
-        "narHash": "sha256-nvnsCjeP6u5azEIg5dvW3v95mMa8sAwqUKSUwFdplaE=",
+        "lastModified": 1728071784,
+        "narHash": "sha256-Nuxw5kmd9ISY9v/0OpGtJEdRTCwNKW4LMRwN7XAiwBk=",
         "owner": "dougch",
         "repo": "aws-lc",
-        "rev": "645150320c75c672ac286816eb971bb44f97cc23",
+        "rev": "dca587a40ed9942be40a7d9e1a196be41173d3cf",
         "type": "github"
       },
       "original": {
         "owner": "dougch",
-        "ref": "nixv1.33.0",
+        "ref": "nixv1.36.0",
         "repo": "aws-lc",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
   # TODO: https://github.com/aws/aws-lc/pull/830
-  inputs.awslc.url = "github:dougch/aws-lc?ref=nixv1.33.0";
+  inputs.awslc.url = "github:dougch/aws-lc?ref=nixv1.36.0";
 
   outputs = { self, nix, nixpkgs, awslc, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:


### PR DESCRIPTION
### Description of changes: 

We pin the aws-lc version in two places; bump it to almost latest.

### Call-outs:

The [1.36.1](https://github.com/aws/aws-lc/releases/tag/v1.36.1) release contains a [pkg-config change](https://github.com/aws/aws-lc/pull/1890/files) that breaks nix. 

There is a small write-up about how to handle path concatenation: https://github.com/jtojnar/cmake-snips/#concatenating-paths-when-building-pkg-config-files , I'll cut an aws-lc issue when I better understand this.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)?  localy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
