### PR TITLE
Update FIPS rules for ML-KEM

### DIFF
--- a/crypto/s2n_fips.h
+++ b/crypto/s2n_fips.h
@@ -16,6 +16,7 @@
 #include <stdbool.h>
 
 #include "api/s2n.h"
+#include "tls/s2n_kem.h"
 #include "utils/s2n_result.h"
 
 #pragma once
@@ -30,4 +31,5 @@ struct s2n_signature_scheme;
 S2N_RESULT s2n_fips_validate_signature_scheme(const struct s2n_signature_scheme *sig_alg, bool *valid);
 struct s2n_ecc_named_curve;
 S2N_RESULT s2n_fips_validate_curve(const struct s2n_ecc_named_curve *curve, bool *valid);
+S2N_RESULT s2n_fips_validate_hybrid_group(const struct s2n_kem_group *hybrid_group, bool *valid);
 S2N_RESULT s2n_fips_validate_version(uint8_t version, bool *valid);

--- a/tests/unit/s2n_security_rules_test.c
+++ b/tests/unit/s2n_security_rules_test.c
@@ -63,6 +63,19 @@ static S2N_RESULT s2n_test_curve_rule(const struct s2n_ecc_named_curve *curve, b
     return S2N_RESULT_OK;
 }
 
+const struct s2n_kem_group *VALID_HYBRID_GROUP = &s2n_secp256r1_mlkem_768;
+const struct s2n_kem_group *EXAMPLE_INVALID_HYBRID_GROUP = &s2n_x25519_kyber_512_r3;
+static S2N_RESULT s2n_test_hybrid_group_rule(const struct s2n_kem_group *hybrid_group, bool *valid)
+{
+    RESULT_ENSURE_REF(valid);
+    if (hybrid_group == VALID_HYBRID_GROUP) {
+        *valid = true;
+    } else {
+        *valid = false;
+    }
+    return S2N_RESULT_OK;
+}
+
 const uint8_t VALID_VERSION = S2N_TLS12;
 const uint8_t EXAMPLE_INVALID_VERSION = S2N_TLS11;
 static S2N_RESULT s2n_test_version(uint8_t version, bool *valid)
@@ -86,6 +99,7 @@ int main(int argc, char **argv)
         .validate_sig_scheme = s2n_test_sig_scheme_rule,
         .validate_cert_sig_scheme = s2n_test_sig_scheme_rule,
         .validate_curve = s2n_test_curve_rule,
+        .validate_hybrid_group = s2n_test_hybrid_group_rule,
         .validate_version = s2n_test_version,
     };
 
@@ -121,20 +135,35 @@ int main(int argc, char **argv)
         .count = 1,
     };
 
+    const struct s2n_kem_preferences valid_kem_preferences = {
+        .kem_count = 0,
+        .kems = NULL,
+        .tls13_kem_groups = &VALID_HYBRID_GROUP,
+        .tls13_kem_group_count = 1,
+    };
+
+    const struct s2n_kem_preferences invalid_kem_preferences = {
+        .kem_count = 0,
+        .kems = NULL,
+        .tls13_kem_groups = &EXAMPLE_INVALID_HYBRID_GROUP,
+        .tls13_kem_group_count = 1,
+    };
+
     const struct s2n_security_policy valid_policy = {
         .cipher_preferences = &valid_cipher_prefs,
         .signature_preferences = &valid_sig_prefs,
         .certificate_signature_preferences = &valid_sig_prefs,
         .ecc_preferences = &valid_ecc_prefs,
-        .kem_preferences = &kem_preferences_null,
+        .kem_preferences = &valid_kem_preferences,
         .minimum_protocol_version = VALID_VERSION,
     };
+
     const struct s2n_security_policy invalid_policy = {
         .cipher_preferences = &invalid_cipher_prefs,
         .signature_preferences = &invalid_sig_prefs,
         .certificate_signature_preferences = &invalid_sig_prefs,
         .ecc_preferences = &invalid_ecc_prefs,
-        .kem_preferences = &kem_preferences_null,
+        .kem_preferences = &invalid_kem_preferences,
         .minimum_protocol_version = EXAMPLE_INVALID_VERSION,
     };
 
@@ -195,6 +224,17 @@ int main(int argc, char **argv)
             {
                 struct s2n_security_policy test_policy = valid_policy;
                 test_policy.ecc_preferences = &invalid_ecc_prefs;
+
+                struct s2n_security_rule_result result = { 0 };
+                EXPECT_OK(s2n_security_rule_validate_policy(
+                        &test_rule, &test_policy, &result));
+                EXPECT_TRUE(result.found_error);
+            };
+
+            /* Test: only hybrid group invalid */
+            {
+                struct s2n_security_policy test_policy = valid_policy;
+                test_policy.kem_preferences = &invalid_kem_preferences;
 
                 struct s2n_security_rule_result result = { 0 };
                 EXPECT_OK(s2n_security_rule_validate_policy(

--- a/tls/s2n_security_rules.h
+++ b/tls/s2n_security_rules.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "stuffer/s2n_stuffer.h"
+#include "tls/s2n_kem.h"
 #include "utils/s2n_result.h"
 
 typedef enum {
@@ -43,6 +44,7 @@ struct s2n_security_rule {
     S2N_RESULT (*validate_sig_scheme)(const struct s2n_signature_scheme *sig_scheme, bool *valid);
     S2N_RESULT (*validate_cert_sig_scheme)(const struct s2n_signature_scheme *sig_scheme, bool *valid);
     S2N_RESULT (*validate_curve)(const struct s2n_ecc_named_curve *curve, bool *valid);
+    S2N_RESULT (*validate_hybrid_group)(const struct s2n_kem_group *hybrid_group, bool *valid);
     S2N_RESULT (*validate_version)(uint8_t version, bool *valid);
 };
 


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Part 4 in a multi-part series to add X25519MLKEM768 support to s2n. This PR updates the FIPS rules checks to correctly handle Hybrid KEMs. 

### Call-outs:
This PR is only one of a multi-part series of ML-KEM related PR's:
 - Part 1: https://github.com/aws/s2n-tls/pull/4810
 - Part 2: https://github.com/aws/s2n-tls/pull/4823
 - Part 3: https://github.com/aws/s2n-tls/pull/4816
 - Part 4: https://github.com/aws/s2n-tls/pull/4829

### Testing:
Unit Tests

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
