### PR TITLE
Add new MLKEM TLS Policies

### DIFF
--- a/tests/unit/s2n_pq_mlkem_policies_test.c
+++ b/tests/unit/s2n_pq_mlkem_policies_test.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "crypto/s2n_pq.h"
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+#include "tls/s2n_kem.h"
+#include "tls/s2n_security_policies.h"
+#include "tls/s2n_tls.h"
+
+static S2N_RESULT s2n_policy_has_cipher(const struct s2n_security_policy *security_policy, const struct s2n_cipher_suite *needle, bool *val)
+{
+    RESULT_ENSURE_REF(security_policy);
+    RESULT_ENSURE_REF(security_policy->cipher_preferences);
+    RESULT_ENSURE_REF(security_policy->cipher_preferences->suites);
+
+    for (size_t i = 0; i < security_policy->cipher_preferences->count; i++) {
+        const struct s2n_cipher_suite *hay = security_policy->cipher_preferences->suites[i];
+        if (hay == needle) {
+            *val = true;
+            return S2N_RESULT_OK;
+        }
+    }
+
+    *val = false;
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_policy_has_kem(const struct s2n_security_policy *security_policy, const struct s2n_kem **kem_list, size_t kem_list_count, bool *val)
+{
+    RESULT_ENSURE_REF(security_policy);
+    RESULT_ENSURE_REF(security_policy->kem_preferences);
+
+    if (security_policy->kem_preferences->tls13_kem_groups == NULL || security_policy->kem_preferences->tls13_kem_group_count == 0) {
+        *val = false;
+        return S2N_RESULT_OK;
+    }
+
+    for (size_t i = 0; i < security_policy->kem_preferences->tls13_kem_group_count; i++) {
+        const struct s2n_kem_group *supported_kem_group = security_policy->kem_preferences->tls13_kem_groups[i];
+        RESULT_ENSURE_REF(supported_kem_group);
+        for (int j = 0; j < kem_list_count; j++) {
+            const struct s2n_kem *banned_kem = kem_list[j];
+            RESULT_ENSURE_REF(banned_kem);
+            if (supported_kem_group->kem == banned_kem) {
+                *val = true;
+                return S2N_RESULT_OK;
+            }
+        }
+    }
+
+    *val = false;
+    return S2N_RESULT_OK;
+}
+
+static S2N_RESULT s2n_policy_in_list(const char *policy_name, const char **exception_list, size_t list_count, bool *val)
+{
+    RESULT_ENSURE_REF(policy_name);
+
+    for (size_t i = 0; i < list_count; i++) {
+        const char *exception = exception_list[i];
+        RESULT_ENSURE_REF(exception);
+
+        if (strlen(policy_name) != strlen(exception)) {
+            continue;
+        }
+
+        if (memcmp(policy_name, exception, strlen(policy_name)) == 0) {
+            *val = true;
+            return S2N_RESULT_OK;
+        }
+    }
+
+    *val = false;
+    return S2N_RESULT_OK;
+}
+
+/* List of all ML-KEM Parameter sizes */
+const struct s2n_kem *mlkem_list[] = {
+    &s2n_mlkem_768
+};
+
+/* Ciphers that should not be present in TLS Policies that have ML-KEM */
+const struct s2n_cipher_suite *legacy_cipher_suites[] = {
+    &s2n_ecdhe_kyber_rsa_with_aes_256_gcm_sha384, /* Draft cipher for negotiating Kyber in TLS 1.2. */
+    &s2n_rsa_with_3des_ede_cbc_sha,
+    &s2n_dhe_rsa_with_3des_ede_cbc_sha,
+    &s2n_ecdhe_rsa_with_3des_ede_cbc_sha,
+    &s2n_ecdhe_rsa_with_rc4_128_sha,
+    &s2n_rsa_with_rc4_128_sha,
+    &s2n_rsa_with_rc4_128_md5,
+    &s2n_null_cipher_suite,
+};
+
+/* List of s2n TLS Security Policies that are allowed to have legacy TLS Ciphers and support ML-KEM */
+const char *cipher_exceptions[] = {
+    "test_all",
+};
+
+/* List of s2n TLS Security Policies that are allowed to have a minimum TLS Version below TLS 1.2 and support ML-KEM */
+const char *tls_version_exceptions[] = {
+    "test_all",
+};
+
+const size_t mlkem_list_size = s2n_array_len(mlkem_list);
+const size_t cipher_exceptions_size = s2n_array_len(cipher_exceptions);
+const size_t tls_version_exceptions_size = s2n_array_len(tls_version_exceptions);
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Enforce minimum requirements on all security policies that support ML-KEM */
+    for (size_t policy_index = 0; security_policy_selection[policy_index].version != NULL; policy_index++) {
+        const struct s2n_security_policy_selection selection = security_policy_selection[policy_index];
+        const char *policy_name = selection.version;
+        const struct s2n_security_policy *security_policy = selection.security_policy;
+        POSIX_ENSURE_REF(security_policy);
+
+        bool has_mlkem = false;
+        EXPECT_OK(s2n_policy_has_kem(security_policy, mlkem_list, mlkem_list_size, &has_mlkem));
+
+        if (!has_mlkem) {
+            continue;
+        }
+
+        /* ML-KEM requires TLS 1.3 in order to be negotiated. Ensure that Policies with ML-KEM also support TLS 1.3 */
+        bool has_tls_13_cipher = false;
+        for (size_t i = 0; i < security_policy->cipher_preferences->count; i++) {
+            if (security_policy->cipher_preferences->suites[i]->minimum_required_tls_version == S2N_TLS13) {
+                has_tls_13_cipher = true;
+                break;
+            }
+        }
+        EXPECT_TRUE(has_tls_13_cipher);
+
+        /* Ensure all security policies that have ML-KEM support do not use previous draft wire-format
+         * for Hybrid KeyShares with length prefixing. */
+        const struct s2n_kem_preferences *kem_preferences = security_policy->kem_preferences;
+        POSIX_ENSURE_REF(kem_preferences);
+        EXPECT_FALSE(s2n_tls13_client_must_use_hybrid_kem_length_prefix(kem_preferences));
+
+        /* All security policies that have ML-KEM should have TLS 1.2 as their minimum supported TLS Version */
+        if (security_policy->minimum_protocol_version < S2N_TLS12) {
+            bool has_exception = false;
+            EXPECT_OK(s2n_policy_in_list(policy_name, tls_version_exceptions, tls_version_exceptions_size, &has_exception));
+
+            if (!has_exception) {
+                fprintf(stdout, "Security Policy: %s has ML-KEM and uses a legacy TLS Version: %d\n",
+                        policy_name, security_policy->minimum_protocol_version);
+                FAIL_MSG("ML-KEM policies should not contain legacy TLS Versions.");
+            }
+        }
+
+        /* Policies that have ML-KEM should not have 3DES, RC4, or (abandoned/deprecated) draft TLS 1.2 Kyber support */
+        for (int j = 0; j < s2n_array_len(legacy_cipher_suites); j++) {
+            bool has_cipher = false;
+            EXPECT_OK(s2n_policy_has_cipher(security_policy, legacy_cipher_suites[j], &has_cipher));
+
+            if (has_cipher) {
+                bool has_exception = false;
+                EXPECT_OK(s2n_policy_in_list(policy_name, cipher_exceptions, cipher_exceptions_size, &has_exception));
+
+                if (!has_exception) {
+                    fprintf(stdout, "Security Policy: %s has ML-KEM and legacy cipher: %s\n",
+                            policy_name, legacy_cipher_suites[j]->name);
+                    FAIL_MSG("ML-KEM policies should not contain legacy ciphers.");
+                }
+            }
+        }
+    }
+
+    END_TEST();
+}

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -541,6 +541,96 @@ const struct s2n_cipher_preferences cipher_preferences_20210825_gcm = {
     .allow_chacha20_boosting = false,
 };
 
+/* Same as cipher_suites_20210825, but with 3DES removed */
+struct s2n_cipher_suite *cipher_suites_20241008[] = {
+    S2N_TLS13_CLOUDFRONT_CIPHER_SUITES_20200716,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_rsa_with_aes_128_cbc_sha,
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_128_cbc_sha256,
+    &s2n_rsa_with_aes_256_cbc_sha,
+    &s2n_rsa_with_aes_256_cbc_sha256,
+    &s2n_dhe_rsa_with_aes_128_cbc_sha,
+    &s2n_dhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_dhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_dhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_dhe_rsa_with_aes_256_cbc_sha,
+    &s2n_dhe_rsa_with_aes_256_cbc_sha256,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_20241008 = {
+    .count = s2n_array_len(cipher_suites_20241008),
+    .suites = cipher_suites_20241008,
+    .allow_chacha20_boosting = false,
+};
+
+/* Same as cipher_suites_20210825_gcm and cipher_suites_pq_tls_1_0_2021_05_26, but with 3DES and Kyber (for TLS 1.2) removed */
+struct s2n_cipher_suite *cipher_suites_20241008_gcm[] = {
+    S2N_TLS13_CLOUDFRONT_CIPHER_SUITES_20200716,
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_128_cbc_sha,
+    &s2n_rsa_with_aes_128_cbc_sha256,
+    &s2n_rsa_with_aes_256_cbc_sha,
+    &s2n_rsa_with_aes_256_cbc_sha256,
+    &s2n_dhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_dhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_dhe_rsa_with_aes_128_cbc_sha,
+    &s2n_dhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_dhe_rsa_with_aes_256_cbc_sha,
+    &s2n_dhe_rsa_with_aes_256_cbc_sha256,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_20241008_gcm = {
+    .count = s2n_array_len(cipher_suites_20241008_gcm),
+    .suites = cipher_suites_20241008_gcm,
+    .allow_chacha20_boosting = false,
+};
+
+/* Same as cipher_preferences_pq_tls_1_0_2021_05_24, but with 3DES and Kyber (for TLS 1.2) removed */
+struct s2n_cipher_suite *cipher_suites_20241009[] = {
+    S2N_TLS13_CIPHER_SUITES_20190801,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_dhe_rsa_with_aes_256_cbc_sha256,
+    &s2n_dhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_dhe_rsa_with_aes_256_cbc_sha,
+    &s2n_dhe_rsa_with_aes_128_cbc_sha,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_20241009 = {
+    .count = s2n_array_len(cipher_suites_20241009),
+    .suites = cipher_suites_20241009,
+    .allow_chacha20_boosting = false,
+};
+
 struct s2n_cipher_suite *cipher_suites_null[] = {
     &s2n_null_cipher_suite
 };
@@ -904,6 +994,36 @@ const struct s2n_cipher_preferences elb_security_policy_fs_1_2_Res_2019_08 = {
     .count = s2n_array_len(cipher_suites_elb_security_policy_fs_1_2_Res_2019_08),
     .suites = cipher_suites_elb_security_policy_fs_1_2_Res_2019_08,
     .allow_chacha20_boosting = false,
+};
+
+/*
+ * S2N_TLS13_CLOUDFRONT_CIPHER_SUITES_20200716 on top of cipher_suites_elb_security_policy_tls_1_2_ext_2018_06
+*/
+struct s2n_cipher_suite *cipher_suites_elb_security_policy_tls13_1_2_Ext2_2021_06[] = {
+    S2N_TLS13_CLOUDFRONT_CIPHER_SUITES_20200716,
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha,
+    &s2n_rsa_with_aes_128_gcm_sha256,
+    &s2n_rsa_with_aes_128_cbc_sha256,
+    &s2n_rsa_with_aes_128_cbc_sha,
+    &s2n_rsa_with_aes_256_gcm_sha384,
+    &s2n_rsa_with_aes_256_cbc_sha256,
+    &s2n_rsa_with_aes_256_cbc_sha,
+};
+
+const struct s2n_cipher_preferences elb_security_policy_tls13_1_2_Ext2_2021_06 = {
+    .count = s2n_array_len(cipher_suites_elb_security_policy_tls13_1_2_Ext2_2021_06),
+    .suites = cipher_suites_elb_security_policy_tls13_1_2_Ext2_2021_06,
 };
 
 struct s2n_cipher_suite *cipher_suites_cloudfront_upstream[] = {

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -59,6 +59,9 @@ extern const struct s2n_cipher_preferences cipher_preferences_20210831;
 extern const struct s2n_cipher_preferences cipher_preferences_20231213;
 extern const struct s2n_cipher_preferences cipher_preferences_20231214;
 extern const struct s2n_cipher_preferences cipher_preferences_20240603;
+extern const struct s2n_cipher_preferences cipher_preferences_20241008;
+extern const struct s2n_cipher_preferences cipher_preferences_20241008_gcm;
+extern const struct s2n_cipher_preferences cipher_preferences_20241009;
 
 extern const struct s2n_cipher_preferences cipher_preferences_default_fips;
 
@@ -83,6 +86,7 @@ extern const struct s2n_cipher_preferences elb_security_policy_fs_2018_06;
 extern const struct s2n_cipher_preferences elb_security_policy_fs_1_2_2019_08;
 extern const struct s2n_cipher_preferences elb_security_policy_fs_1_1_2019_08;
 extern const struct s2n_cipher_preferences elb_security_policy_fs_1_2_Res_2019_08;
+extern const struct s2n_cipher_preferences elb_security_policy_tls13_1_2_Ext2_2021_06;
 
 /* CloudFront upstream */
 extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_upstream;

--- a/tls/s2n_kem_preferences.c
+++ b/tls/s2n_kem_preferences.c
@@ -43,6 +43,24 @@ const struct s2n_kem_group *pq_kem_groups_r3_2023_12[] = {
     &s2n_secp256r1_kyber_512_r3,
 };
 
+/* Includes only IETF standard KEM Groups. */
+const struct s2n_kem_group *pq_kem_groups_ietf_2024_10[] = {
+    &s2n_x25519_mlkem_768,
+    &s2n_secp256r1_mlkem_768,
+};
+
+/* Includes both IETF standard KEM Groups, and earlier draft standards with Kyber. */
+const struct s2n_kem_group *pq_kem_groups_mixed_2024_10[] = {
+    &s2n_x25519_mlkem_768,
+    &s2n_secp256r1_mlkem_768,
+    &s2n_secp256r1_kyber_768_r3,
+    &s2n_x25519_kyber_768_r3,
+    &s2n_secp384r1_kyber_768_r3,
+    &s2n_secp521r1_kyber_1024_r3,
+    &s2n_secp256r1_kyber_512_r3,
+    &s2n_x25519_kyber_512_r3,
+};
+
 const struct s2n_kem_preferences kem_preferences_pq_tls_1_0_2021_05 = {
     .kem_count = s2n_array_len(pq_kems_r3_2021_05),
     .kems = pq_kems_r3_2021_05,
@@ -74,6 +92,22 @@ const struct s2n_kem_preferences kem_preferences_pq_tls_1_3_2023_12 = {
     .kems = NULL,
     .tls13_kem_group_count = s2n_array_len(pq_kem_groups_r3_2023_12),
     .tls13_kem_groups = pq_kem_groups_r3_2023_12,
+    .tls13_pq_hybrid_draft_revision = 5
+};
+
+const struct s2n_kem_preferences kem_preferences_pq_tls_1_3_ietf_2024_10 = {
+    .kem_count = 0,
+    .kems = NULL,
+    .tls13_kem_group_count = s2n_array_len(pq_kem_groups_ietf_2024_10),
+    .tls13_kem_groups = pq_kem_groups_ietf_2024_10,
+    .tls13_pq_hybrid_draft_revision = 5
+};
+
+const struct s2n_kem_preferences kem_preferences_pq_tls_1_3_mixed_2024_10 = {
+    .kem_count = 0,
+    .kems = NULL,
+    .tls13_kem_group_count = s2n_array_len(pq_kem_groups_mixed_2024_10),
+    .tls13_kem_groups = pq_kem_groups_mixed_2024_10,
     .tls13_pq_hybrid_draft_revision = 5
 };
 

--- a/tls/s2n_kem_preferences.h
+++ b/tls/s2n_kem_preferences.h
@@ -48,6 +48,8 @@ extern const struct s2n_kem_preferences kem_preferences_pq_tls_1_0_2021_05;
 extern const struct s2n_kem_preferences kem_preferences_pq_tls_1_0_2023_01;
 extern const struct s2n_kem_preferences kem_preferences_pq_tls_1_3_2023_06;
 extern const struct s2n_kem_preferences kem_preferences_pq_tls_1_3_2023_12;
+extern const struct s2n_kem_preferences kem_preferences_pq_tls_1_3_ietf_2024_10;
+extern const struct s2n_kem_preferences kem_preferences_pq_tls_1_3_mixed_2024_10;
 extern const struct s2n_kem_preferences kem_preferences_all;
 extern const struct s2n_kem_preferences kem_preferences_null;
 

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -881,7 +881,7 @@ const struct s2n_security_policy security_policy_pq_tls_1_2_2024_10_07 = {
     .ecc_preferences = &s2n_ecc_preferences_20200310,
 };
 
-/* Same as security_policy_pq_tls_1_2_2024_10_08, but with 3DES and Kyber (for TLS 1.2) removed, and added ML-KEM support */
+/* Same as security_policy_pq_tls_1_2_2023_10_08, but with 3DES and Kyber (for TLS 1.2) removed, and added ML-KEM support */
 const struct s2n_security_policy security_policy_pq_tls_1_2_2024_10_08 = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_20241008,
@@ -890,7 +890,7 @@ const struct s2n_security_policy security_policy_pq_tls_1_2_2024_10_08 = {
     .ecc_preferences = &s2n_ecc_preferences_20200310,
 };
 
-/* Same as security_policy_pq_tls_1_2_2023_04_10, but with 3DES and Kyber (for TLS 1.2) removed, and added ML-KEM support */
+/* Same as security_policy_pq_tls_1_2_2023_10_10, but with 3DES and Kyber (for TLS 1.2) removed, and added ML-KEM support */
 const struct s2n_security_policy security_policy_pq_tls_1_2_2024_10_08_gcm = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_20241008_gcm,

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -72,6 +72,30 @@ const struct s2n_security_policy security_policy_20240730 = {
     },
 };
 
+const struct s2n_security_policy security_policy_20241001 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_cloudfront_tls_1_2_2019,
+    .kem_preferences = &kem_preferences_pq_tls_1_3_ietf_2024_10,
+    .signature_preferences = &s2n_signature_preferences_20240501,
+    .certificate_signature_preferences = &s2n_certificate_signature_preferences_20201110,
+    .ecc_preferences = &s2n_ecc_preferences_20240501,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
+};
+
+const struct s2n_security_policy security_policy_20241001_pq_mixed = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_cloudfront_tls_1_2_2019,
+    .kem_preferences = &kem_preferences_pq_tls_1_3_mixed_2024_10,
+    .signature_preferences = &s2n_signature_preferences_20240501,
+    .certificate_signature_preferences = &s2n_certificate_signature_preferences_20201110,
+    .ecc_preferences = &s2n_ecc_preferences_20240501,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
+};
+
 const struct s2n_security_policy security_policy_20240603 = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_20240603,
@@ -839,6 +863,53 @@ const struct s2n_security_policy security_policy_pq_20231215 = {
     },
 };
 
+/* Same as security_policy_aws_crt_sdk_tls_12_06_23 but with ML-KEM Support */
+const struct s2n_security_policy security_policy_aws_crt_sdk_tls_12_06_23_pq = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_aws_crt_sdk_default,
+    .kem_preferences = &kem_preferences_pq_tls_1_3_mixed_2024_10,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20230623,
+};
+
+/* Same as security_policy_pq_tls_1_2_2023_10_07, but with TLS 1.2 Kyber removed, and added ML-KEM support */
+const struct s2n_security_policy security_policy_pq_tls_1_2_2024_10_07 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &elb_security_policy_tls13_1_2_Ext2_2021_06,
+    .kem_preferences = &kem_preferences_pq_tls_1_3_mixed_2024_10,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20200310,
+};
+
+/* Same as security_policy_pq_tls_1_2_2024_10_08, but with 3DES and Kyber (for TLS 1.2) removed, and added ML-KEM support */
+const struct s2n_security_policy security_policy_pq_tls_1_2_2024_10_08 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_20241008,
+    .kem_preferences = &kem_preferences_pq_tls_1_3_mixed_2024_10,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20200310,
+};
+
+/* Same as security_policy_pq_tls_1_2_2023_04_10, but with 3DES and Kyber (for TLS 1.2) removed, and added ML-KEM support */
+const struct s2n_security_policy security_policy_pq_tls_1_2_2024_10_08_gcm = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_20241008_gcm,
+    .kem_preferences = &kem_preferences_pq_tls_1_3_mixed_2024_10,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20200310,
+};
+
+/* Same as security_policy_pq_tls_1_2_2023_10_09 but with 3DES and Kyber (for TLS 1.2) removed, and added ML-KEM support */
+const struct s2n_security_policy security_policy_pq_tls_1_2_2024_10_09 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_20241009,
+    .kem_preferences = &kem_preferences_pq_tls_1_3_mixed_2024_10,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20200310,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
+};
 const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2018_10 = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_kms_fips_tls_1_2_2018_10,
@@ -858,6 +929,19 @@ const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2021_08 = {
     .ecc_preferences = &s2n_ecc_preferences_20140601,
     .rules = {
             [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
+};
+
+/* Same as security_policy_pq_20231215, but with only ML-KEM Support */
+const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2024_10 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_kms_fips_tls_1_2_2021_08,
+    .kem_preferences = &kem_preferences_pq_tls_1_3_ietf_2024_10,
+    .signature_preferences = &s2n_signature_preferences_20230317,
+    .ecc_preferences = &s2n_ecc_preferences_20201021,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+            [S2N_FIPS_140_3] = true,
     },
 };
 
@@ -1137,7 +1221,7 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "default", .security_policy = &security_policy_20240501, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "default_tls13", .security_policy = &security_policy_20240503, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "default_fips", .security_policy = &security_policy_20240502, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
-    { .version = "default_pq", .security_policy = &security_policy_20240730, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "default_pq", .security_policy = &security_policy_20241001, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20240501", .security_policy = &security_policy_20240501, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20240502", .security_policy = &security_policy_20240502, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20240503", .security_policy = &security_policy_20240503, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
@@ -1146,6 +1230,8 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "20240417", .security_policy = &security_policy_20240417, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20240416", .security_policy = &security_policy_20240416, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20240730", .security_policy = &security_policy_20240730, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "20241001", .security_policy = &security_policy_20241001, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "20241001_pq_mixed", .security_policy = &security_policy_20241001_pq_mixed, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "ELBSecurityPolicy-TLS-1-0-2015-04", .security_policy = &security_policy_elb_2015_04, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     /* Not a mistake. TLS-1-0-2015-05 and 2016-08 are equivalent */
     { .version = "ELBSecurityPolicy-TLS-1-0-2015-05", .security_policy = &security_policy_elb_2016_08, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
@@ -1188,6 +1274,7 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "AWS-CRT-SDK-TLSv1.0-2023", .security_policy = &security_policy_aws_crt_sdk_tls_10_06_23, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "AWS-CRT-SDK-TLSv1.1-2023", .security_policy = &security_policy_aws_crt_sdk_tls_11_06_23, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "AWS-CRT-SDK-TLSv1.2-2023", .security_policy = &security_policy_aws_crt_sdk_tls_12_06_23, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "AWS-CRT-SDK-TLSv1.2-2023-PQ", .security_policy = &security_policy_aws_crt_sdk_tls_12_06_23_pq, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "AWS-CRT-SDK-TLSv1.3-2023", .security_policy = &security_policy_aws_crt_sdk_tls_13_06_23, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     /* KMS TLS Policies*/
     { .version = "KMS-TLS-1-0-2018-10", .security_policy = &security_policy_kms_tls_1_0_2018_10, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
@@ -1195,6 +1282,7 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "KMS-TLS-1-2-2023-06", .security_policy = &security_policy_kms_tls_1_2_2023_06, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "KMS-FIPS-TLS-1-2-2018-10", .security_policy = &security_policy_kms_fips_tls_1_2_2018_10, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "KMS-FIPS-TLS-1-2-2021-08", .security_policy = &security_policy_kms_fips_tls_1_2_2021_08, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "KMS-FIPS-TLS-1-2-2024-10", .security_policy = &security_policy_kms_fips_tls_1_2_2024_10, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "KMS-PQ-TLS-1-0-2019-06", .security_policy = &security_policy_kms_pq_tls_1_0_2019_06, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "KMS-PQ-TLS-1-0-2020-02", .security_policy = &security_policy_kms_pq_tls_1_0_2020_02, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "KMS-PQ-TLS-1-0-2020-07", .security_policy = &security_policy_kms_pq_tls_1_0_2020_07, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
@@ -1224,6 +1312,10 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "PQ-TLS-1-2-2023-12-13", .security_policy = &security_policy_pq_20231213, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "PQ-TLS-1-2-2023-12-14", .security_policy = &security_policy_pq_20231214, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "PQ-TLS-1-2-2023-12-15", .security_policy = &security_policy_pq_20231215, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "PQ-TLS-1-2-2024-10-07", .security_policy = &security_policy_pq_tls_1_2_2024_10_07, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "PQ-TLS-1-2-2024-10-08", .security_policy = &security_policy_pq_tls_1_2_2024_10_08, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "PQ-TLS-1-2-2024-10-08_gcm", .security_policy = &security_policy_pq_tls_1_2_2024_10_08_gcm, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "PQ-TLS-1-2-2024-10-09", .security_policy = &security_policy_pq_tls_1_2_2024_10_09, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20140601", .security_policy = &security_policy_20140601, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20141001", .security_policy = &security_policy_20141001, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20150202", .security_policy = &security_policy_20150202, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -123,6 +123,9 @@ extern const struct s2n_security_policy security_policy_20240331;
 extern const struct s2n_security_policy security_policy_20240417;
 extern const struct s2n_security_policy security_policy_20240416;
 extern const struct s2n_security_policy security_policy_20240603;
+extern const struct s2n_security_policy security_policy_20240730;
+extern const struct s2n_security_policy security_policy_20241001;
+extern const struct s2n_security_policy security_policy_20241001_pq_mixed;
 
 extern const struct s2n_security_policy security_policy_rfc9151;
 extern const struct s2n_security_policy security_policy_test_all;
@@ -149,6 +152,8 @@ extern const struct s2n_security_policy security_policy_aws_crt_sdk_ssl_v3;
 extern const struct s2n_security_policy security_policy_aws_crt_sdk_tls_10;
 extern const struct s2n_security_policy security_policy_aws_crt_sdk_tls_11;
 extern const struct s2n_security_policy security_policy_aws_crt_sdk_tls_12;
+extern const struct s2n_security_policy security_policy_aws_crt_sdk_tls_12_06_23;
+extern const struct s2n_security_policy security_policy_aws_crt_sdk_tls_12_06_23_pq;
 extern const struct s2n_security_policy security_policy_aws_crt_sdk_tls_13;
 
 extern const struct s2n_security_policy security_policy_kms_pq_tls_1_0_2019_06;
@@ -177,6 +182,10 @@ extern const struct s2n_security_policy security_policy_pq_tls_1_2_2023_10_07;
 extern const struct s2n_security_policy security_policy_pq_tls_1_2_2023_10_08;
 extern const struct s2n_security_policy security_policy_pq_tls_1_2_2023_10_09;
 extern const struct s2n_security_policy security_policy_pq_tls_1_2_2023_10_10;
+extern const struct s2n_security_policy security_policy_pq_tls_1_2_2024_10_07;
+extern const struct s2n_security_policy security_policy_pq_tls_1_2_2024_10_08;
+extern const struct s2n_security_policy security_policy_pq_tls_1_2_2024_10_08_gcm;
+extern const struct s2n_security_policy security_policy_pq_tls_1_2_2024_10_09;
 
 extern const struct s2n_security_policy security_policy_cloudfront_upstream;
 extern const struct s2n_security_policy security_policy_cloudfront_upstream_tls10;
@@ -194,6 +203,7 @@ extern const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2021_
 extern const struct s2n_security_policy security_policy_kms_tls_1_0_2018_10;
 extern const struct s2n_security_policy security_policy_kms_tls_1_2_2023_06;
 extern const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2018_10;
+extern const struct s2n_security_policy security_policy_kms_fips_tls_1_2_2024_10;
 
 extern const struct s2n_security_policy security_policy_20190120;
 extern const struct s2n_security_policy security_policy_20190121;


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 
Part 5 in a multi-part series to add ML-KEM support to s2n. 

### Call-outs:

This PR is only one of a multi-part series of ML-KEM related PR's:
 - Part 1: https://github.com/aws/s2n-tls/pull/4810
 - Part 2: https://github.com/aws/s2n-tls/pull/4823
 - Part 3: https://github.com/aws/s2n-tls/pull/4816
 - Part 4: https://github.com/aws/s2n-tls/pull/4829
 - Part 5: https://github.com/aws/s2n-tls/pull/4830
 

### Testing:
Unit Tests. Manually confirmed interoperability with AWS-LC and BoringSSL for X25519MLKEM768 using s2nc and s2nd. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
