### PR TITLE
feature: bump cert authorities max size to 20kb

### DIFF
--- a/tls/extensions/s2n_cert_authorities.h
+++ b/tls/extensions/s2n_cert_authorities.h
@@ -28,7 +28,7 @@
  * To keep the limit predictable and avoid surprise errors during negotiation,
  * set a reasonable fixed limit.
  */
-#define S2N_CERT_AUTHORITIES_MAX_SIZE (10000)
+#define S2N_CERT_AUTHORITIES_MAX_SIZE (20000)
 
 extern const s2n_extension_type s2n_cert_authorities_extension;
 


### PR DESCRIPTION
### Description of changes: 

Bumping the cert authorities limit for a customer.

### Call-outs:

The extensions are limited to a size of UINT16_MAX, so about 65K. The cert authorities have to share that size with the other extensions, so this max size leaves about 45K for other extensions. We currently only support the cert authorities extension on the certificate request message, which only also supports the signature algorithms and certificate status extensions, but could support more extensions in the future.

### Testing:
Existing tests pass, including the test that verifies we can't load the default AL2012 trust store due to its size: https://github.com/aws/s2n-tls/blob/4a1bfeed574b7ed77a7562e24963ea94a4e9792c/tests/unit/s2n_cert_authorities_test.c#L99-L110

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
