### PR TITLE
fix: fix opened AF_UNIX sockets that didn't call s2n_io_pair_close

### DIFF
--- a/tests/unit/s2n_alerts_protocol_test.c
+++ b/tests/unit/s2n_alerts_protocol_test.c
@@ -551,7 +551,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_blinding(client, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_config(client, config));
 
-            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            struct s2n_test_io_pair io_pair = { 0 };
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client, server, &io_pair));
 
@@ -573,6 +573,8 @@ int main(int argc, char **argv)
                         S2N_ERR_CLOSED);
                 EXPECT_FALSE(s2n_connection_check_io_status(receiver, S2N_IO_READABLE));
             }
+            /* Close the other end of pipe */
+            EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, 1 - mode));
         };
 
         /* Test: With partial read */
@@ -594,7 +596,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_blinding(client, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_config(client, &partial_write_config_copy));
 
-            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            struct s2n_test_io_pair io_pair = { 0 };
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client, server, &io_pair));
 
@@ -629,6 +631,8 @@ int main(int argc, char **argv)
                 EXPECT_FAILURE_WITH_ERRNO(s2n_recv(receiver, data, sizeof(data), &blocked),
                         S2N_ERR_CLOSED);
             }
+            /* Close the other end of pipe */
+            EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, 1 - mode));
         };
     };
 

--- a/tests/unit/s2n_alerts_protocol_test.c
+++ b/tests/unit/s2n_alerts_protocol_test.c
@@ -551,7 +551,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_blinding(client, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_config(client, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client, server, &io_pair));
 
@@ -573,8 +573,6 @@ int main(int argc, char **argv)
                         S2N_ERR_CLOSED);
                 EXPECT_FALSE(s2n_connection_check_io_status(receiver, S2N_IO_READABLE));
             }
-            /* Close the other end of pipe */
-            EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, 1 - mode));
         };
 
         /* Test: With partial read */
@@ -596,7 +594,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_blinding(client, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_config(client, &partial_write_config_copy));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client, server, &io_pair));
 
@@ -631,8 +629,6 @@ int main(int argc, char **argv)
                 EXPECT_FAILURE_WITH_ERRNO(s2n_recv(receiver, data, sizeof(data), &blocked),
                         S2N_ERR_CLOSED);
             }
-            /* Close the other end of pipe */
-            EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, 1 - mode));
         };
     };
 

--- a/tests/unit/s2n_certificate_test.c
+++ b/tests/unit/s2n_certificate_test.c
@@ -698,7 +698,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(tls12_client_conn, "test_all_tls12"));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(tls12_server_conn, "test_all_tls12"));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(tls12_client_conn, tls12_server_conn, &io_pair));
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(tls12_server_conn, tls12_client_conn));
@@ -719,7 +719,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(tls13_client_conn, "default_tls13"));
             EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(tls13_server_conn, "default_tls13"));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(tls13_client_conn, tls13_server_conn, &io_pair));
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(tls13_server_conn, tls13_client_conn));

--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -712,7 +712,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn);
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -741,7 +741,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -777,7 +777,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -810,7 +810,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -844,7 +844,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -886,7 +886,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -948,7 +948,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1001,7 +1001,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1067,7 +1067,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1118,7 +1118,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1185,7 +1185,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
             EXPECT_SUCCESS(s2n_set_server_name(client_conn, "localhost"));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1219,7 +1219,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
             EXPECT_SUCCESS(s2n_set_server_name(client_conn, "localhost"));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1253,7 +1253,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1301,7 +1301,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn);
             EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1425,7 +1425,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config_with_cb));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1509,7 +1509,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn);
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1553,7 +1553,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn);
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1606,7 +1606,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn);
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1643,7 +1643,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(client_conn);
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1709,7 +1709,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn);
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-        struct s2n_test_io_pair io_pair = { 0 };
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1792,7 +1792,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-        struct s2n_test_io_pair io_pair = { 0 };
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1845,7 +1845,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-        struct s2n_test_io_pair io_pair = { 0 };
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1920,7 +1920,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn);
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-        struct s2n_test_io_pair io_pair = { 0 };
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -1986,7 +1986,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
         EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
 
-        struct s2n_test_io_pair io_pair = { 0 };
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 

--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -500,7 +500,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(server_conn);
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 

--- a/tests/unit/s2n_client_supported_versions_extension_test.c
+++ b/tests/unit/s2n_client_supported_versions_extension_test.c
@@ -418,7 +418,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(client_conn);
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config_with_cert));
 
-        struct s2n_test_io_pair io_pair = { 0 };
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -910,7 +910,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
                 EXPECT_SUCCESS(s2n_set_server_name(client_conn, "localhost"));
 
-                struct s2n_test_io_pair io_pair = { 0 };
+                DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
                 EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
                 EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -945,7 +945,7 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
                 EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));
 
-                struct s2n_test_io_pair io_pair = { 0 };
+                DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
                 EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
                 EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 

--- a/tests/unit/s2n_crypto_test.c
+++ b/tests/unit/s2n_crypto_test.c
@@ -142,7 +142,7 @@ int main()
             /* Set server master secret to known value to ensure overridden later */
             memset(server->secrets.version.tls12.master_secret, 1, S2N_TLS_SECRET_LEN);
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client, server, &io_pair));
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server, client));

--- a/tests/unit/s2n_early_data_io_api_test.c
+++ b/tests/unit/s2n_early_data_io_api_test.c
@@ -28,7 +28,8 @@
     EXPECT_EQUAL((blocked), (expected_blocked));                         \
     EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), (expected_msg))
 
-static S2N_RESULT s2n_test_client_and_server_new(struct s2n_connection **client_conn, struct s2n_connection **server_conn)
+static S2N_RESULT s2n_test_client_and_server_new(struct s2n_connection **client_conn, struct s2n_connection **server_conn,
+        struct s2n_test_io_pair *io_pair)
 {
     *client_conn = s2n_connection_new(S2N_CLIENT);
     EXPECT_NOT_NULL(*client_conn);
@@ -39,9 +40,8 @@ static S2N_RESULT s2n_test_client_and_server_new(struct s2n_connection **client_
     EXPECT_SUCCESS(s2n_connection_set_blinding(*server_conn, S2N_SELF_SERVICE_BLINDING));
     EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(*server_conn, "default_tls13"));
 
-    struct s2n_test_io_pair io_pair = { 0 };
-    EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
-    EXPECT_SUCCESS(s2n_connections_set_io_pair(*client_conn, *server_conn, &io_pair));
+    EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(io_pair));
+    EXPECT_SUCCESS(s2n_connections_set_io_pair(*client_conn, *server_conn, io_pair));
 
     return S2N_RESULT_OK;
 }
@@ -247,7 +247,8 @@ int main(int argc, char **argv)
         /* Propagate errors from s2n_recv */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
 
@@ -276,7 +277,8 @@ int main(int argc, char **argv)
         /* Send zero-length early data */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
@@ -308,7 +310,8 @@ int main(int argc, char **argv)
         /* Send early data once */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
@@ -342,7 +345,8 @@ int main(int argc, char **argv)
         /* Receive early data too large for buffer */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
@@ -393,7 +397,8 @@ int main(int argc, char **argv)
         /* Send multiple early data messages */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
@@ -432,7 +437,8 @@ int main(int argc, char **argv)
         /* Receive and combine multiple early data records */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
@@ -474,7 +480,8 @@ int main(int argc, char **argv)
         /* Early data not requested */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk_with_wrong_early_data));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
@@ -509,7 +516,8 @@ int main(int argc, char **argv)
         /* Early data rejected */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk_with_wrong_early_data));

--- a/tests/unit/s2n_early_data_io_test.c
+++ b/tests/unit/s2n_early_data_io_test.c
@@ -25,7 +25,8 @@
     EXPECT_EQUAL(s2n_recv(conn, data_buffer, data_buffer_size, blocked), data_len);           \
     EXPECT_BYTEARRAY_EQUAL(data_buffer, data, data_len)
 
-static S2N_RESULT s2n_test_client_and_server_new(struct s2n_connection **client_conn, struct s2n_connection **server_conn)
+static S2N_RESULT s2n_test_client_and_server_new(struct s2n_connection **client_conn, struct s2n_connection **server_conn,
+        struct s2n_test_io_pair *io_pair)
 {
     *client_conn = s2n_connection_new(S2N_CLIENT);
     EXPECT_NOT_NULL(*client_conn);
@@ -36,9 +37,8 @@ static S2N_RESULT s2n_test_client_and_server_new(struct s2n_connection **client_
     EXPECT_SUCCESS(s2n_connection_set_blinding(*server_conn, S2N_SELF_SERVICE_BLINDING));
     EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(*server_conn, "default_tls13"));
 
-    struct s2n_test_io_pair io_pair = { 0 };
-    EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
-    EXPECT_SUCCESS(s2n_connections_set_io_pair(*client_conn, *server_conn, &io_pair));
+    EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(io_pair));
+    EXPECT_SUCCESS(s2n_connections_set_io_pair(*client_conn, *server_conn, io_pair));
 
     return S2N_RESULT_OK;
 }
@@ -88,7 +88,8 @@ int main(int argc, char **argv)
         /* Early data not supported by server */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
@@ -115,7 +116,8 @@ int main(int argc, char **argv)
         /* Early data not supported by client */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
@@ -142,7 +144,8 @@ int main(int argc, char **argv)
         /* Server does not support TLS1.3 */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_set_early_data_expected(client_conn));
@@ -166,7 +169,8 @@ int main(int argc, char **argv)
         /* Early data accepted */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
@@ -212,7 +216,8 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(config);
 
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
             EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
@@ -255,7 +260,8 @@ int main(int argc, char **argv)
         /* Early data rejected */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk_without_early_data));
@@ -289,7 +295,8 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(config);
 
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
             EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
@@ -327,7 +334,8 @@ int main(int argc, char **argv)
         /* Early data rejected and ignored */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk_to_reject));
@@ -364,7 +372,8 @@ int main(int argc, char **argv)
         /* Early data rejected, but too much early data received */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk_to_reject));
@@ -403,7 +412,8 @@ int main(int argc, char **argv)
         /* Early data rejected due to HRR */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
@@ -494,7 +504,8 @@ int main(int argc, char **argv)
         /* PSK rejected altogether */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config_with_cert));
             EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config_with_cert));
@@ -526,7 +537,8 @@ int main(int argc, char **argv)
         /* End early data after the server accepts the early data request */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
@@ -589,7 +601,8 @@ int main(int argc, char **argv)
         /* End early data before the server accepts the early data request. */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
@@ -626,7 +639,8 @@ int main(int argc, char **argv)
         {
             DEFER_CLEANUP(struct s2n_connection *client_conn = NULL, s2n_connection_ptr_free);
             DEFER_CLEANUP(struct s2n_connection *server_conn = NULL, s2n_connection_ptr_free);
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
@@ -675,7 +689,8 @@ int main(int argc, char **argv)
         /* s2n_recv can read early data sent with s2n_send */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
@@ -742,7 +757,8 @@ int main(int argc, char **argv)
         /* s2n_recv fails if it encounters a handshake message instead of early data. */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));
@@ -774,7 +790,8 @@ int main(int argc, char **argv)
         /* s2n_recv fails on too much early data */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_test_client_and_server_new(&client_conn, &server_conn, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));

--- a/tests/unit/s2n_extension_type_test.c
+++ b/tests/unit/s2n_extension_type_test.c
@@ -487,7 +487,7 @@ int main()
                 EXPECT_NOT_NULL(server_conn);
                 EXPECT_SUCCESS(s2n_connection_set_config(server_conn, test_all_config));
 
-                struct s2n_test_io_pair io_pair = { 0 };
+                DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
                 EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
                 EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -515,7 +515,7 @@ int main()
                 EXPECT_NOT_NULL(server_conn);
                 EXPECT_SUCCESS(s2n_connection_set_config(server_conn, test_all_config));
 
-                struct s2n_test_io_pair io_pair = { 0 };
+                DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
                 EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
                 EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 
@@ -544,7 +544,7 @@ int main()
                 EXPECT_SUCCESS(s2n_connection_set_config(server_conn, test_all_config));
                 EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "test_all_tls12"));
 
-                struct s2n_test_io_pair io_pair = { 0 };
+                DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
                 EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
                 EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 

--- a/tests/unit/s2n_handshake_partial_test.c
+++ b/tests/unit/s2n_handshake_partial_test.c
@@ -20,7 +20,7 @@
 #include "tls/s2n_tls.h"
 
 static S2N_RESULT s2n_get_test_client_and_server(struct s2n_connection **client_conn, struct s2n_connection **server_conn,
-        struct s2n_config *config, struct s2n_test_io_pair *io_pair)
+        struct s2n_test_io_pair *io_pair, struct s2n_config *config)
 {
     *client_conn = s2n_connection_new(S2N_CLIENT);
     RESULT_ENSURE_REF(*client_conn);
@@ -75,7 +75,7 @@ int main()
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
             DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
-            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config, &io_pair));
+            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, &io_pair, config));
 
             EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
                     SERVER_KEY));
@@ -90,7 +90,7 @@ int main()
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
             DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
-            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config, &io_pair));
+            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, &io_pair, config));
 
             EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
                     SERVER_CERT_VERIFY));
@@ -105,7 +105,7 @@ int main()
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
             DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
-            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config, &io_pair));
+            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, &io_pair, config));
 
             EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
                     CLIENT_HELLO));
@@ -145,7 +145,7 @@ int main()
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
             DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
-            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config, &io_pair));
+            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, &io_pair, config));
 
             EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
                     CLIENT_FINISHED));
@@ -165,7 +165,7 @@ int main()
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
             DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
-            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config, &io_pair));
+            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, &io_pair, config));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));

--- a/tests/unit/s2n_handshake_partial_test.c
+++ b/tests/unit/s2n_handshake_partial_test.c
@@ -20,7 +20,7 @@
 #include "tls/s2n_tls.h"
 
 static S2N_RESULT s2n_get_test_client_and_server(struct s2n_connection **client_conn, struct s2n_connection **server_conn,
-        struct s2n_config *config)
+        struct s2n_config *config, struct s2n_test_io_pair *io_pair)
 {
     *client_conn = s2n_connection_new(S2N_CLIENT);
     RESULT_ENSURE_REF(*client_conn);
@@ -32,9 +32,8 @@ static S2N_RESULT s2n_get_test_client_and_server(struct s2n_connection **client_
     RESULT_GUARD_POSIX(s2n_connection_set_config(*client_conn, config));
     RESULT_GUARD_POSIX(s2n_connection_set_config(*server_conn, config));
 
-    struct s2n_test_io_pair io_pair = { 0 };
-    RESULT_GUARD_POSIX(s2n_io_pair_init_non_blocking(&io_pair));
-    RESULT_GUARD_POSIX(s2n_connections_set_io_pair(*client_conn, *server_conn, &io_pair));
+    RESULT_GUARD_POSIX(s2n_io_pair_init_non_blocking(io_pair));
+    RESULT_GUARD_POSIX(s2n_connections_set_io_pair(*client_conn, *server_conn, io_pair));
 
     return S2N_RESULT_OK;
 }
@@ -75,7 +74,8 @@ int main()
         /* If message is never encountered, complete the handshake */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config, &io_pair));
 
             EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
                     SERVER_KEY));
@@ -89,7 +89,8 @@ int main()
         /* Can stop on a given message */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config, &io_pair));
 
             EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
                     SERVER_CERT_VERIFY));
@@ -103,7 +104,8 @@ int main()
         /* Can be called repeatedly */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config, &io_pair));
 
             EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
                     CLIENT_HELLO));
@@ -142,7 +144,8 @@ int main()
         /* Can continue as normal after stopping */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config, &io_pair));
 
             EXPECT_OK(s2n_negotiate_test_server_and_client_until_message(server_conn, client_conn,
                     CLIENT_FINISHED));
@@ -161,7 +164,8 @@ int main()
          * (This is the non-test use case for this feature) */
         {
             struct s2n_connection *client_conn = NULL, *server_conn = NULL;
-            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config));
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+            EXPECT_OK(s2n_get_test_client_and_server(&client_conn, &server_conn, config, &io_pair));
 
             EXPECT_SUCCESS(s2n_connection_append_psk(client_conn, test_psk));
             EXPECT_SUCCESS(s2n_connection_append_psk(server_conn, test_psk));

--- a/tests/unit/s2n_io_test.c
+++ b/tests/unit/s2n_io_test.c
@@ -102,6 +102,8 @@ int main(int argc, char **argv)
                         s2n_test_real_interrupt(io_pair.client, n_times, &counter));
                 EXPECT_EQUAL(result, S2N_TEST_SUCCESS);
                 EXPECT_EQUAL(counter, n_times);
+                /* Child process exit don't close io_pair properly, so manually close it*/
+                EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
                 exit(0);
             }
 

--- a/tests/unit/s2n_io_test.c
+++ b/tests/unit/s2n_io_test.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
                         s2n_test_real_interrupt(io_pair.client, n_times, &counter));
                 EXPECT_EQUAL(result, S2N_TEST_SUCCESS);
                 EXPECT_EQUAL(counter, n_times);
-                /* Child process exit don't close io_pair properly, so manually close it*/
+                /* Child process exit doesn't close io_pair properly, so manually close it*/
                 EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
                 exit(0);
             }

--- a/tests/unit/s2n_key_update_threads_test.c
+++ b/tests/unit/s2n_key_update_threads_test.c
@@ -208,6 +208,7 @@ static S2N_RESULT s2n_run_self_talk_test(s2n_test_scenario scenario_fn)
         EXPECT_SUCCESS(s2n_connection_free(client));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
         EXPECT_SUCCESS(s2n_config_free(config));
+        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));
 
         exit(EXIT_SUCCESS);
     }
@@ -231,6 +232,7 @@ static S2N_RESULT s2n_run_self_talk_test(s2n_test_scenario scenario_fn)
         EXPECT_SUCCESS(s2n_connection_free(server));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
         EXPECT_SUCCESS(s2n_config_free(config));
+        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
 
         exit(EXIT_SUCCESS);
     }

--- a/tests/unit/s2n_ktls_io_sendfile_test.c
+++ b/tests/unit/s2n_ktls_io_sendfile_test.c
@@ -139,7 +139,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_write_fd(conn, write_fd));
 
         /* Close one side of the stream to make the fds invalid */
-        s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT);
+        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));
 
         s2n_blocked_status blocked = S2N_NOT_BLOCKED;
         size_t bytes_written = 0;

--- a/tests/unit/s2n_ktls_io_sendfile_test.c
+++ b/tests/unit/s2n_ktls_io_sendfile_test.c
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn);
         conn->ktls_send_enabled = true;
 
-        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+        struct s2n_test_io_pair io_pair = { 0 };
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         int write_fd = io_pair.server;
         int read_fd = io_pair.client;
@@ -149,6 +149,7 @@ int main(int argc, char **argv)
         EXPECT_FAILURE_WITH_ERRNO(ret, S2N_ERR_IO);
         EXPECT_EQUAL(bytes_written, 0);
         EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_WRITE);
+        close(write_fd);
     };
 
     /* Test: send blocks */

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -66,7 +66,7 @@
 
 /* This is the total maximum memory allowed */
 #define MAX_MEM_ALLOWED(num_connections) \
-    (2 * (num_connections) * MAX_MEM_PER_CONNECTION)
+    (2 * (num_connections) *MAX_MEM_PER_CONNECTION)
 
 /* This is the correct value of MEM_PER_CONNECTION based on test results.
  * Basically, this calculation should reverse MAX_MEM_ALLOWED */

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -17,7 +17,7 @@
     /* FreeBSD requires POSIX compatibility off for its syscalls (enables __BSD_VISIBLE)
      * Without the below line, <sys/user.h> cannot be imported (it requires __BSD_VISIBLE) */
     #undef _POSIX_C_SOURCE
-    /* clang-format off */
+/* clang-format off */
     #include <sys/types.h>
     #include <sys/sysctl.h>
     /* clang-format on */
@@ -25,7 +25,7 @@
 #elif defined(__OpenBSD__)
     #undef _POSIX_C_SOURCE
     #include <kvm.h>
-    /* clang-format off */
+/* clang-format off */
     #include <sys/types.h>
     #include <sys/sysctl.h>
     /* clang-format on */
@@ -155,7 +155,7 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    DEFER_CLEANUP(struct s2n_test_io_pair io_pair, s2n_io_pair_close);
+    DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
     EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
 
     /* Skip the test when running under valgrind or address sanitizer, as those tools
@@ -244,7 +244,6 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(servers[i]));
     }
 
-    EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
     EXPECT_SUCCESS(s2n_config_free(server_config));
     EXPECT_SUCCESS(s2n_config_free(client_config));

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -66,7 +66,7 @@
 
 /* This is the total maximum memory allowed */
 #define MAX_MEM_ALLOWED(num_connections) \
-    (2 * (num_connections) *MAX_MEM_PER_CONNECTION)
+    (2 * (num_connections) * MAX_MEM_PER_CONNECTION)
 
 /* This is the correct value of MEM_PER_CONNECTION based on test results.
  * Basically, this calculation should reverse MAX_MEM_ALLOWED */

--- a/tests/unit/s2n_mem_usage_test.c
+++ b/tests/unit/s2n_mem_usage_test.c
@@ -155,7 +155,7 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    struct s2n_test_io_pair io_pair;
+    DEFER_CLEANUP(struct s2n_test_io_pair io_pair, s2n_io_pair_close);
     EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
 
     /* Skip the test when running under valgrind or address sanitizer, as those tools

--- a/tests/unit/s2n_recv_test.c
+++ b/tests/unit/s2n_recv_test.c
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
                     s2n_connection_ptr_free);
             EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
@@ -234,7 +234,7 @@ int main(int argc, char **argv)
                     s2n_connection_ptr_free);
             EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
-            struct s2n_test_io_pair io_pair = { 0 };
+            DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
@@ -280,7 +280,7 @@ int main(int argc, char **argv)
                 s2n_connection_ptr_free);
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
-        struct s2n_test_io_pair io_pair = { 0 };
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));

--- a/tests/unit/s2n_release_non_empty_buffers_test.c
+++ b/tests/unit/s2n_release_non_empty_buffers_test.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
     /* Create a pipe */
-    struct s2n_test_io_pair io_pair;
+    DEFER_CLEANUP(struct s2n_test_io_pair io_pair, s2n_io_pair_close);
     EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
 
     /* Create a child process */

--- a/tests/unit/s2n_release_non_empty_buffers_test.c
+++ b/tests/unit/s2n_release_non_empty_buffers_test.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
     /* Create a pipe */
-    DEFER_CLEANUP(struct s2n_test_io_pair io_pair, s2n_io_pair_close);
+    DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
     EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
 
     /* Create a child process */

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
         struct s2n_cert_chain_and_key *chain_and_keys[SUPPORTED_CERTIFICATE_FORMATS];
 
         /* Create a pipe */
-        DEFER_CLEANUP(struct s2n_test_io_pair io_pair, s2n_io_pair_close);
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
 
         /* Create a child process */

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
         struct s2n_cert_chain_and_key *chain_and_keys[SUPPORTED_CERTIFICATE_FORMATS];
 
         /* Create a pipe */
-        struct s2n_test_io_pair io_pair;
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
 
         /* Create a child process */

--- a/tests/unit/s2n_self_talk_io_mem_test.c
+++ b/tests/unit/s2n_self_talk_io_mem_test.c
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
         /* Create nonblocking pipes */
-        struct s2n_test_io_pair io_pair;
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
@@ -89,7 +89,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
         /* Create nonblocking pipes */
-        struct s2n_test_io_pair io_pair;
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config_for_mfl));
 
         /* Create nonblocking pipes */
-        struct s2n_test_io_pair io_pair;
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
@@ -190,7 +190,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_conn->out.blob.size, 0);
 
         /* Create nonblocking pipes */
-        struct s2n_test_io_pair io_pair;
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));

--- a/tests/unit/s2n_self_talk_io_mem_test.c
+++ b/tests/unit/s2n_self_talk_io_mem_test.c
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
         /* Create nonblocking pipes */
-        DEFER_CLEANUP(struct s2n_test_io_pair io_pair, s2n_io_pair_close);
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
@@ -89,7 +89,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
 
         /* Create nonblocking pipes */
-        DEFER_CLEANUP(struct s2n_test_io_pair io_pair, s2n_io_pair_close);
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config_for_mfl));
 
         /* Create nonblocking pipes */
-        DEFER_CLEANUP(struct s2n_test_io_pair io_pair, s2n_io_pair_close);
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
@@ -190,7 +190,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_conn->out.blob.size, 0);
 
         /* Create nonblocking pipes */
-        DEFER_CLEANUP(struct s2n_test_io_pair io_pair, s2n_io_pair_close);
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
         EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
         EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));

--- a/tests/unit/s2n_self_talk_session_id_test.c
+++ b/tests/unit/s2n_self_talk_session_id_test.c
@@ -578,6 +578,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(client_conn));
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
+        EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
     };
 
     /**

--- a/tests/unit/s2n_testlib_test.c
+++ b/tests/unit/s2n_testlib_test.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
         /* Create nonblocking pipes */
-        DEFER_CLEANUP(struct s2n_test_io_pair io_pair, s2n_io_pair_close);
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
         POSIX_GUARD(s2n_io_pair_init_non_blocking(&io_pair));
         POSIX_GUARD(s2n_connection_set_io_pair(server_conn, &io_pair));
 

--- a/tests/unit/s2n_testlib_test.c
+++ b/tests/unit/s2n_testlib_test.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
 
         /* Create nonblocking pipes */
-        struct s2n_test_io_pair io_pair;
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair, s2n_io_pair_close);
         POSIX_GUARD(s2n_io_pair_init_non_blocking(&io_pair));
         POSIX_GUARD(s2n_connection_set_io_pair(server_conn, &io_pair));
 

--- a/tests/unit/s2n_tls13_cert_verify_test.c
+++ b/tests/unit/s2n_tls13_cert_verify_test.c
@@ -307,7 +307,7 @@ int main(int argc, char **argv)
                 client_policy.signature_preferences = &test_sig_preferences;
                 client_conn->security_policy_override = &client_policy;
 
-                struct s2n_test_io_pair io_pair = { 0 };
+                DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
                 EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
                 EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
 


### PR DESCRIPTION
### Resolved issues:

Partially solve #4005

### Description of changes: 

* Use s2n_io_pair_close and s2n_io_pair_close_one_end to close most AF_UNIX sockets.
    * Fix those tests that forgot to add s2n_io_pair_close().

### Call-outs:

* See [PR#4834](https://github.com/aws/s2n-tls/pull/4834) and [PR#4835](https://github.com/aws/s2n-tls/pull/4835) for fixes of other open fds.
* I didn't add a test in this PR. The test to detect all opened fds will be in a separate PR.
* Address this [comment](https://github.com/aws/s2n-tls/pull/4833#discussion_r1796098930) in [PR#4841](https://github.com/aws/s2n-tls/pull/4841).

### Testing:

* Test locally. 
    * Add `--track-fds=yes` to CTest memcheck and direct all Valgrind output to `MemoryTester.log` files.
    * Search in VS Code for Open File Descriptors of `AF_UNIX`.
        * Previously opened `AF_UNIX` sockets in tests that are fixed are gone.
    * This is similar to the check in `./codebuild/bin/test_exec_leak.sh`.
  https://github.com/aws/s2n-tls/blob/6bb195c23fd1ecf623dece3b43644e7c9a9e0e20/codebuild/bin/test_exec_leak.sh#L82-L97

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
