### PR TITLE
fix: some open AF_UNIX sockets in forked child processes

### DIFF
--- a/tests/unit/s2n_examples_test.c
+++ b/tests/unit/s2n_examples_test.c
@@ -250,6 +250,7 @@ static S2N_RESULT s2n_run_self_talk_test(s2n_test_scenario scenario_fn)
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
         EXPECT_SUCCESS(s2n_config_free(config));
         EXPECT_SUCCESS(s2n_free(&input));
+        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));
 
         exit(EXIT_SUCCESS);
     }
@@ -273,6 +274,7 @@ static S2N_RESULT s2n_run_self_talk_test(s2n_test_scenario scenario_fn)
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
         EXPECT_SUCCESS(s2n_config_free(config));
         EXPECT_SUCCESS(s2n_free(&input));
+        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
 
         exit(EXIT_SUCCESS);
     }

--- a/tests/unit/s2n_key_update_threads_test.c
+++ b/tests/unit/s2n_key_update_threads_test.c
@@ -208,6 +208,7 @@ static S2N_RESULT s2n_run_self_talk_test(s2n_test_scenario scenario_fn)
         EXPECT_SUCCESS(s2n_connection_free(client));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
         EXPECT_SUCCESS(s2n_config_free(config));
+        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));
 
         exit(EXIT_SUCCESS);
     }

--- a/tests/unit/s2n_release_non_empty_buffers_test.c
+++ b/tests/unit/s2n_release_non_empty_buffers_test.c
@@ -55,10 +55,10 @@ int mock_client(struct s2n_test_io_pair *io_pair)
         _exit(2);
     }
 
-    EXPECT_SUCCESS(s2n_io_pair_close_one_end(io_pair, S2N_CLIENT));
     s2n_shutdown(conn, &blocked);
     s2n_connection_free(conn);
     s2n_config_free(client_config);
+    EXPECT_SUCCESS(s2n_io_pair_close_one_end(io_pair, S2N_CLIENT));
     s2n_cleanup();
 
     exit(0);

--- a/tests/unit/s2n_release_non_empty_buffers_test.c
+++ b/tests/unit/s2n_release_non_empty_buffers_test.c
@@ -59,6 +59,7 @@ int mock_client(struct s2n_test_io_pair *io_pair)
     s2n_connection_free(conn);
     s2n_config_free(client_config);
     s2n_cleanup();
+    EXPECT_SUCCESS(s2n_io_pair_close_one_end(io_pair, S2N_CLIENT));
 
     exit(0);
 }
@@ -196,6 +197,7 @@ int main(int argc, char **argv)
     free(private_key_pem);
 
     s2n_cleanup();
+    EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
 
     END_TEST();
 

--- a/tests/unit/s2n_release_non_empty_buffers_test.c
+++ b/tests/unit/s2n_release_non_empty_buffers_test.c
@@ -55,11 +55,11 @@ int mock_client(struct s2n_test_io_pair *io_pair)
         _exit(2);
     }
 
+    EXPECT_SUCCESS(s2n_io_pair_close_one_end(io_pair, S2N_CLIENT));
     s2n_shutdown(conn, &blocked);
     s2n_connection_free(conn);
     s2n_config_free(client_config);
     s2n_cleanup();
-    EXPECT_SUCCESS(s2n_io_pair_close_one_end(io_pair, S2N_CLIENT));
 
     exit(0);
 }
@@ -196,8 +196,8 @@ int main(int argc, char **argv)
     free(cert_chain_pem);
     free(private_key_pem);
 
-    s2n_cleanup();
     EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
+    s2n_cleanup();
 
     END_TEST();
 

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -82,6 +82,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
     sleep(1);
 
     s2n_io_pair_shutdown_one_end(io_pair, S2N_CLIENT, SHUT_WR);
+    s2n_io_pair_close_one_end(io_pair, S2N_CLIENT);
 
     exit(0);
 }


### PR DESCRIPTION
### Resolved issues:

Partially solve https://github.com/aws/s2n-tls/issues/4005

### Description of changes: 

* Use s2n_io_pair_close and s2n_io_pair_close_one_end to close AF_UNIX sockets in tests that have fork().
    * Child processes are often forgot to be cleaned up.

### Call-outs:

* See [PR#4833](https://github.com/aws/s2n-tls/pull/4833) and [PR#4835](https://github.com/aws/s2n-tls/pull/4835) for fixing other open fds.
* I didn't add a test in this PR. The test to detect all opened fds will be in a separate PR.

### Testing:

* Test locally. 
    * Add `--track-fds=yes` to CTest memcheck and direct all Valgrind output to `MemoryTester.log` files.
    * Search in VS Code for Open File Descriptors of `AF_UNIX`.
        * Previously opened `AF_UNIX` sockets in tests that are fixed are gone.
    * This is similar to the check in `./codebuild/bin/test_exec_leak.sh`.
  https://github.com/aws/s2n-tls/blob/6bb195c23fd1ecf623dece3b43644e7c9a9e0e20/codebuild/bin/test_exec_leak.sh#L82-L97

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
