### PR TITLE
fix: fix s2n_io_pair_close_one_end

### DIFF
--- a/tests/testlib/s2n_connection_test_utils.c
+++ b/tests/testlib/s2n_connection_test_utils.c
@@ -187,10 +187,12 @@ int s2n_io_pair_close(struct s2n_test_io_pair *io_pair)
 
 int s2n_io_pair_close_one_end(struct s2n_test_io_pair *io_pair, int mode_to_close)
 {
-    if (mode_to_close == S2N_CLIENT) {
+    if (mode_to_close == S2N_CLIENT && io_pair->client != S2N_CLOSED_FD) {
         POSIX_GUARD(close(io_pair->client));
-    } else if (mode_to_close == S2N_SERVER) {
+        io_pair->client = S2N_CLOSED_FD;
+    } else if (mode_to_close == S2N_SERVER && io_pair->server != S2N_CLOSED_FD) {
         POSIX_GUARD(close(io_pair->server));
+        io_pair->server = S2N_CLOSED_FD;
     }
     return 0;
 }

--- a/tests/testlib/s2n_testlib.h
+++ b/tests/testlib/s2n_testlib.h
@@ -20,6 +20,8 @@
 #include "stuffer/s2n_stuffer.h"
 #include "tls/s2n_connection.h"
 
+#define S2N_CLOSED_FD -1
+
 extern const struct s2n_ecc_preferences ecc_preferences_for_retry;
 extern const struct s2n_security_policy security_policy_test_tls13_retry;
 


### PR DESCRIPTION
### Resolved issues:

Partially Solve #4005.

Our current implementation for `s2n_io_pair_close_one_end` has problems:
* It might attempt to close a already closed fd, and failed the `s2n_io_pair_close` function.
* It might accidentally close a valid fd, that is reused by one closed end of `io_pair`.

### Description of changes: 

* Add checking logics for s2n_io_pair_close_one_end().
    * Only proceed to close a fd if the fd is not previously closed.
    * Define `S2N_CLOSED_FD` to be -1.
    * Set closed fd to `S2N_CLOSED_FD`.

### Call-outs:

* This PR is related to [PR4833](https://github.com/aws/s2n-tls/pull/4833). It is to solve this [comment](https://github.com/aws/s2n-tls/pull/4833#discussion_r1796098930).

### Testing:

* It passes all unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
