### PR TITLE
test: pin static testing policies to numbered versions

### DIFF
--- a/tests/fuzz/s2n_certificate_extensions_parse_test.c
+++ b/tests/fuzz/s2n_certificate_extensions_parse_test.c
@@ -52,7 +52,6 @@ static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
 int s2n_fuzz_init(int *argc, char **argv[])
 {
     /* Initialize the trust store */
-    POSIX_GUARD_RESULT(s2n_config_testing_defaults_init_tls13_certs());
     POSIX_GUARD(s2n_enable_tls13_in_test());
     return S2N_SUCCESS;
 }
@@ -69,6 +68,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
 
     struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
     POSIX_ENSURE_REF(client_conn);
+    POSIX_GUARD(s2n_connection_set_cipher_preferences(client_conn, "20240503"));
 
     /* Pull a byte off the libfuzzer input and use it to set parameters */
     uint8_t randval = 0;

--- a/tests/unit/s2n_connection_preferences_test.c
+++ b/tests/unit/s2n_connection_preferences_test.c
@@ -23,176 +23,122 @@
 #include "tls/s2n_security_policies.h"
 #include "tls/s2n_tls13.h"
 
+S2N_RESULT test_policy_behavior(const struct s2n_security_policy *policy,
+        const struct s2n_security_policy *compare_policy, const char *compare_policy_name)
+{
+    RESULT_ENSURE_REF(policy);
+
+    struct s2n_connection *conn = NULL;
+    const struct s2n_cipher_preferences *cipher_preferences = NULL;
+    const struct s2n_security_policy *security_policy = NULL;
+    const struct s2n_kem_preferences *kem_preferences = NULL;
+    const struct s2n_signature_preferences *signature_preferences = NULL;
+    const struct s2n_ecc_preferences *ecc_preferences = NULL;
+
+    EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+    EXPECT_NULL(conn->security_policy_override);
+
+    EXPECT_SUCCESS(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+    EXPECT_EQUAL(cipher_preferences, policy->cipher_preferences);
+
+    EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
+    EXPECT_EQUAL(security_policy, policy);
+
+    EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_preferences));
+    EXPECT_EQUAL(kem_preferences, policy->kem_preferences);
+
+    EXPECT_SUCCESS(s2n_connection_get_signature_preferences(conn, &signature_preferences));
+    EXPECT_EQUAL(signature_preferences, policy->signature_preferences);
+
+    EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
+    EXPECT_EQUAL(ecc_preferences, policy->ecc_preferences);
+
+    /* Load a security_policy with the `compare_policy_name` and confirm it is equal
+     * to the `compare_policy`.
+     */
+    EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, compare_policy_name));
+    EXPECT_NOT_NULL(conn->security_policy_override);
+
+    cipher_preferences = NULL;
+    EXPECT_SUCCESS(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
+    EXPECT_EQUAL(cipher_preferences, compare_policy->cipher_preferences);
+
+    security_policy = NULL;
+    EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
+    EXPECT_EQUAL(security_policy, compare_policy);
+
+    kem_preferences = NULL;
+    EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_preferences));
+    EXPECT_EQUAL(kem_preferences, compare_policy->kem_preferences);
+
+    signature_preferences = NULL;
+    EXPECT_SUCCESS(s2n_connection_get_signature_preferences(conn, &signature_preferences));
+    EXPECT_EQUAL(signature_preferences, compare_policy->signature_preferences);
+
+    ecc_preferences = NULL;
+    EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
+    EXPECT_EQUAL(ecc_preferences, compare_policy->ecc_preferences);
+
+    EXPECT_SUCCESS(s2n_connection_free(conn));
+
+    return S2N_RESULT_OK;
+}
+
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    const struct s2n_security_policy *default_security_policy = NULL, *tls13_security_policy = NULL, *fips_security_policy = NULL;
-    EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_tls13", &tls13_security_policy));
+    const struct s2n_security_policy *default_security_policy = NULL, *fips_security_policy = NULL,
+                                     *tls12_security_policy = NULL, *tls12_fips_security_policy = NULL,
+                                     *tls13_security_policy = NULL;
     EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_fips", &fips_security_policy));
     EXPECT_SUCCESS(s2n_find_security_policy_from_version("default", &default_security_policy));
+    EXPECT_SUCCESS(s2n_find_security_policy_from_version("20240501", &tls12_security_policy));
+    EXPECT_SUCCESS(s2n_find_security_policy_from_version("20240502", &tls12_fips_security_policy));
+    EXPECT_SUCCESS(s2n_find_security_policy_from_version("20240503", &tls13_security_policy));
 
-    /* Test default TLS1.2 */
-    if (!s2n_is_in_fips_mode()) {
-        struct s2n_connection *conn = NULL;
-        const struct s2n_cipher_preferences *cipher_preferences = NULL;
-        const struct s2n_security_policy *security_policy = NULL;
-        const struct s2n_kem_preferences *kem_preferences = NULL;
-        const struct s2n_signature_preferences *signature_preferences = NULL;
-        const struct s2n_ecc_preferences *ecc_preferences = NULL;
+    /* Test default */
+    {
+        EXPECT_SUCCESS(s2n_reset_tls13_in_test());
 
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_NULL(conn->security_policy_override);
+        /* TLS 1.2 */
+        if (!s2n_is_in_fips_mode()) {
+            EXPECT_OK(test_policy_behavior(default_security_policy, &security_policy_20240501, "20240501"));
+        }
 
-        EXPECT_SUCCESS(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
-        EXPECT_EQUAL(cipher_preferences, default_security_policy->cipher_preferences);
+        /* TLS 1.2 FIPS */
+        if (s2n_is_in_fips_mode()) {
+            EXPECT_OK(test_policy_behavior(fips_security_policy, &security_policy_20240502, "20240502"));
+        }
 
-        EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
-        EXPECT_EQUAL(security_policy, default_security_policy);
-
-        EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_preferences));
-        EXPECT_EQUAL(kem_preferences, default_security_policy->kem_preferences);
-
-        EXPECT_SUCCESS(s2n_connection_get_signature_preferences(conn, &signature_preferences));
-        EXPECT_EQUAL(signature_preferences, default_security_policy->signature_preferences);
-
-        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
-        EXPECT_EQUAL(ecc_preferences, default_security_policy->ecc_preferences);
-
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20170328"));
-        EXPECT_NOT_NULL(conn->security_policy_override);
-
-        cipher_preferences = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
-        EXPECT_EQUAL(cipher_preferences, security_policy_20170328.cipher_preferences);
-
-        security_policy = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
-        EXPECT_EQUAL(security_policy, &security_policy_20170328);
-
-        kem_preferences = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_preferences));
-        EXPECT_EQUAL(kem_preferences, security_policy_20170328.kem_preferences);
-
-        signature_preferences = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_signature_preferences(conn, &signature_preferences));
-        EXPECT_EQUAL(signature_preferences, security_policy_20170328.signature_preferences);
-
-        ecc_preferences = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
-        EXPECT_EQUAL(ecc_preferences, security_policy_20170328.ecc_preferences);
-
-        EXPECT_SUCCESS(s2n_connection_free(conn));
+        EXPECT_SUCCESS(s2n_disable_tls13_in_test());
     }
 
-    /* Test TLS1.3 */
+    /* Test override */
     {
-        EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-        struct s2n_connection *conn = NULL;
-        const struct s2n_cipher_preferences *cipher_preferences = NULL;
-        const struct s2n_security_policy *security_policy = NULL;
-        const struct s2n_kem_preferences *kem_preferences = NULL;
-        const struct s2n_signature_preferences *signature_preferences = NULL;
-        const struct s2n_ecc_preferences *ecc_preferences = NULL;
+        /* Test override TLS1.2 */
+        if (!s2n_is_in_fips_mode()) {
+            EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_NULL(conn->security_policy_override);
+            EXPECT_OK(test_policy_behavior(tls12_security_policy, &security_policy_20170328, "20170328"));
+        }
 
-        EXPECT_SUCCESS(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
-        EXPECT_EQUAL(cipher_preferences, tls13_security_policy->cipher_preferences);
+        /* Test override TLS1.3 */
+        {
+            EXPECT_SUCCESS(s2n_enable_tls13_in_test());
 
-        EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
-        EXPECT_EQUAL(security_policy, tls13_security_policy);
+            EXPECT_OK(test_policy_behavior(tls13_security_policy, &security_policy_test_all_tls13, "test_all_tls13"));
+        };
 
-        EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_preferences));
-        EXPECT_EQUAL(kem_preferences, tls13_security_policy->kem_preferences);
+        /* Test override default fips */
+        if (s2n_is_in_fips_mode()) {
+            EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-        EXPECT_SUCCESS(s2n_connection_get_signature_preferences(conn, &signature_preferences));
-        EXPECT_EQUAL(signature_preferences, tls13_security_policy->signature_preferences);
+            EXPECT_OK(test_policy_behavior(fips_security_policy, &security_policy_test_all_fips, "test_all_fips"));
+        }
 
-        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
-        EXPECT_EQUAL(ecc_preferences, tls13_security_policy->ecc_preferences);
-
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all_tls13"));
-        EXPECT_NOT_NULL(conn->security_policy_override);
-
-        cipher_preferences = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
-        EXPECT_EQUAL(cipher_preferences, security_policy_test_all_tls13.cipher_preferences);
-
-        security_policy = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
-        EXPECT_EQUAL(security_policy, &security_policy_test_all_tls13);
-
-        kem_preferences = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_preferences));
-        EXPECT_EQUAL(kem_preferences, security_policy_test_all_tls13.kem_preferences);
-
-        signature_preferences = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_signature_preferences(conn, &signature_preferences));
-        EXPECT_EQUAL(signature_preferences, security_policy_test_all_tls13.signature_preferences);
-
-        ecc_preferences = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
-        EXPECT_EQUAL(ecc_preferences, security_policy_test_all_tls13.ecc_preferences);
-
-        EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_disable_tls13_in_test());
-    };
-
-    /* Test default fips */
-
-    if (s2n_is_in_fips_mode()) {
-        struct s2n_connection *conn = NULL;
-        const struct s2n_cipher_preferences *cipher_preferences = NULL;
-        const struct s2n_security_policy *security_policy = NULL;
-        const struct s2n_kem_preferences *kem_preferences = NULL;
-        const struct s2n_signature_preferences *signature_preferences = NULL;
-        const struct s2n_ecc_preferences *ecc_preferences = NULL;
-
-        EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-        EXPECT_NULL(conn->security_policy_override);
-
-        EXPECT_SUCCESS(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
-        EXPECT_EQUAL(cipher_preferences, fips_security_policy->cipher_preferences);
-
-        EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
-        EXPECT_EQUAL(security_policy, fips_security_policy);
-
-        EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_preferences));
-        EXPECT_EQUAL(kem_preferences, fips_security_policy->kem_preferences);
-
-        EXPECT_SUCCESS(s2n_connection_get_signature_preferences(conn, &signature_preferences));
-        EXPECT_EQUAL(signature_preferences, fips_security_policy->signature_preferences);
-
-        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
-        EXPECT_EQUAL(ecc_preferences, fips_security_policy->ecc_preferences);
-
-        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all_fips"));
-        EXPECT_NOT_NULL(conn->security_policy_override);
-
-        cipher_preferences = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
-        EXPECT_EQUAL(cipher_preferences, security_policy_test_all_fips.cipher_preferences);
-
-        security_policy = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
-        EXPECT_EQUAL(security_policy, &security_policy_test_all_fips);
-
-        kem_preferences = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_preferences));
-        EXPECT_EQUAL(kem_preferences, security_policy_test_all_fips.kem_preferences);
-
-        signature_preferences = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_signature_preferences(conn, &signature_preferences));
-        EXPECT_EQUAL(signature_preferences, security_policy_test_all_fips.signature_preferences);
-
-        ecc_preferences = NULL;
-        EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
-        EXPECT_EQUAL(ecc_preferences, security_policy_test_all_fips.ecc_preferences);
-
-        EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
     /* Test for NULL */

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -48,6 +48,20 @@
 
 struct s2n_cipher_preferences;
 
+/* The default security policy when creating a new config. */
+typedef enum {
+    /* Use the "default" security policy */
+    S2N_SELECT_DEFAULT_POLICY = 0,
+
+    /* Use the "default_fips" security policy */
+    S2N_SELECT_DEFAULT_FIPS_POLICY,
+
+    /* Support overriding the security policies in tests */
+    S2N_SELECT_TEST_OVERRIDE_POLICY_TLS12,
+    S2N_SELECT_TEST_OVERRIDE_POLICY_TLS12_FIPS,
+    S2N_SELECT_TEST_OVERRIDE_POLICY_TLS13,
+} s2n_default_security_policy_selection;
+
 typedef enum {
     S2N_NOT_OWNED = 0,
     S2N_APP_OWNED,
@@ -239,7 +253,6 @@ struct s2n_config {
 S2N_CLEANUP_RESULT s2n_config_ptr_free(struct s2n_config **config);
 
 int s2n_config_defaults_init(void);
-S2N_RESULT s2n_config_testing_defaults_init_tls13_certs(void);
 struct s2n_config *s2n_fetch_default_config(void);
 int s2n_config_set_unsafe_for_testing(struct s2n_config *config);
 

--- a/tls/s2n_tls13.h
+++ b/tls/s2n_tls13.h
@@ -36,6 +36,14 @@ S2N_API __attribute__((deprecated)) int s2n_enable_tls13();
 /* from RFC: https://tools.ietf.org/html/rfc8446#section-4.1.3*/
 extern uint8_t hello_retry_req_random[S2N_TLS_RANDOM_DATA_LEN];
 
+/* Determine the protocol override intent in tests. */
+typedef enum {
+    S2N_TESTING_POLICY_OVERRIDE_TLS12 = 0,
+    S2N_TESTING_POLICY_OVERRIDE_TLS13,
+    S2N_TESTING_POLICY_NO_OVERRIDE,
+} s2n_testing_security_policy_override;
+
+S2N_RESULT s2n_get_testing_security_policy_override(s2n_testing_security_policy_override *override);
 bool s2n_use_default_tls13_config();
 bool s2n_is_tls13_fully_supported();
 int s2n_get_highest_fully_supported_tls_version();


### PR DESCRIPTION
### Problem:
Currently, a new s2n_config object is configured with one of three static configs based on [runtime settings and testing overrides](https://github.com/aws/s2n-tls/blob/main/tls/s2n_config.c#L102-L108).

The security policy selection depends on testing override function calls and makes use of the "default" and "default_fips" policies.

```
enable_tls13_int_test()       // 13 not-fips    "default_tls13"
disable_tls13_int_test()
  in_fips_mode                // 12 fips        "default_fips"
  else                        // 12 not-fips    "default"
else //reset_tls13_in_test()
  in_fips_mode                // 12 fips        "default_fips"
  else                        // 12 not-fips    "default"
```

As we attempt to evolve the default* policies, maintaining the current behavior becomes cumbersome. Specifically, along with adding TLS1.3 support to the "default" policy, we will also add a new test which temporarily set the "default" to TLS1.2. This "toggling" of the "default" policy will make the current config selection very complicated.


### Description of changes: 
To solve this issue, this PR creates dedicated static configs for testing override and **pins** them to numbered policies rather than rely on the "default" policy.

```
// Current ==========
static struct s2n_config s2n_default_config = { 0 };
static struct s2n_config s2n_default_fips_config = { 0 };
static struct s2n_config s2n_default_tls13_config = { 0 };

// Proposed changes ==========
static struct s2n_config s2n_default_config = { 0 };
static struct s2n_config s2n_default_fips_config = { 0 };
/* Dedicated configs for testing different protocols since test can override the
 * default security policy behavior.
 */
static struct s2n_config s2n_testing_default_tls12_config = { 0 }; // pinned to "20240501"
static struct s2n_config s2n_testing_default_tls12_fips_config = { 0 }; // pinned to "20240502"
static struct s2n_config s2n_testing_default_tls13_config = { 0 }; // pinned to "20240503"
```

The cost of this strategy is 2 additional static configs, however, since these are only used in testing, we are able to avoid extra costs of the `s2n_config_load_system_certs` by gating initialization of test configs behind a `s2n_in_unit_test` check.

### Callout:
I have made other refactor changes to make reasoning about testing overrides and policy selection easier to reason about:
- capture policy override and cofig selection behavior as enum: `s2n_default_security_policy_selection` and `s2n_testing_security_policy_override`
- remove function `s2n_config_testing_defaults_init_tls13_certs`: was used to avoid the costs of `s2n_config_load_system_certs`, however we can fully avoid the costs by gating initialization to unit tests.


### Testing:
Added unit testing with and without the testing overrides.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
