### PR TITLE
bindings: pin openssl crate to 0.10.66

### DIFF
--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -27,7 +27,9 @@ hex = "0.4"
 
 [dev-dependencies]
 futures-test = "0.3"
-openssl = "0.10"
+# The openssl crate broke MSRV with 0.10.67
+# TODO unpin this once fixed - https://github.com/sfackler/rust-openssl/issues/2317
+openssl = "<0.10.67"
 openssl-sys = "0.9"
 foreign-types = "0.3"
 temp-env = "0.3"


### PR DESCRIPTION
### Description of changes: 

The `openssl` crate broke 1.63 MSRV. This change pins it to `0.10.66` until it's resolved.

See https://github.com/sfackler/rust-openssl/issues/2317.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
