### PR TITLE
chore(GHA): Update duvet arguments

### DIFF
--- a/.github/workflows/ci_compliance.yml
+++ b/.github/workflows/ci_compliance.yml
@@ -28,8 +28,8 @@ jobs:
         with:
           s2n-quic-dir: ./s2n-quic
           report-script: compliance/generate_report.sh
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2ntlsGHAS3Session
           aws-s3-bucket-name: s2n-tls-ci-artifacts
           aws-s3-region: us-west-2
           cdn: https://d3fqnyekunr9xg.cloudfront.net


### PR DESCRIPTION
### Description of changes: 

The duvet action is moving to OIDC short term credentials; update s2n-tls action with the new arguments.

### Call-outs:

Duvet updates in https://github.com/aws/s2n-quic/pull/2350 are ready to merge.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? CI in s2n-netbench and s2n-quic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
