### PR TITLE
chore: grant duvet more permissions

### DIFF
--- a/.github/workflows/ci_compliance.yml
+++ b/.github/workflows/ci_compliance.yml
@@ -9,6 +9,10 @@ on:
     types: [checks_requested]
     branches: [main]
 
+permissions:
+  contents: read  # This is required for actions/checkout
+  id-token: write # This is required for requesting the JWT/OIDC
+
 jobs:
   duvet:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description of changes: 

The id-token permissions are needed to save the short-term creds.  This was missed in #4850

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)?  https://github.com/aws/s2n-quic/pull/2350

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
