### PR TITLE
docs: update fips documentation to specify supported libcrypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ s2n-tls avoids implementing rarely used options and extensions, as well as featu
 The security of TLS and its associated encryption algorithms depends upon secure random number generation. s2n-tls provides every thread with two separate random number generators. One for "public" randomly generated data that may appear in the clear, and one for "private" data that should remain secret. This approach lessens the risk of potential predictability weaknesses in random number generation algorithms from leaking information across contexts.
 
 ##### Modularized encryption
-s2n-tls has been structured so that different encryption libraries may be used. Today s2n-tls supports OpenSSL (versions 1.0.2, 1.1.1 and 3.0.x), LibreSSL, BoringSSL, AWS-LC, and the Apple Common Crypto framework to perform the underlying cryptographic operations.
+s2n-tls has been structured so that different encryption libraries may be used. Today s2n-tls supports OpenSSL (versions 1.0.2, 1.1.1 and 3.0.x), LibreSSL, BoringSSL, AWS-LC, and the Apple Common Crypto framework to perform the underlying cryptographic operations. s2n-tls only supports FIPS mode when built with AWS-LC-FIPS.
 
 ##### Timing blinding
 s2n-tls includes structured support for blinding time-based side-channels that may leak sensitive data. For example, if s2n-tls fails to parse a TLS record or handshake message, s2n-tls will add a randomized delay of between 10 and 30 seconds, granular to nanoseconds, before responding. This raises the complexity of real-world timing side-channel attacks by a factor of at least tens of trillions.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ s2n-tls avoids implementing rarely used options and extensions, as well as featu
 The security of TLS and its associated encryption algorithms depends upon secure random number generation. s2n-tls provides every thread with two separate random number generators. One for "public" randomly generated data that may appear in the clear, and one for "private" data that should remain secret. This approach lessens the risk of potential predictability weaknesses in random number generation algorithms from leaking information across contexts.
 
 ##### Modularized encryption
-s2n-tls has been structured so that different encryption libraries may be used. Today s2n-tls supports OpenSSL (versions 1.0.2, 1.1.1 and 3.0.x), LibreSSL, BoringSSL, AWS-LC, and the Apple Common Crypto framework to perform the underlying cryptographic operations. s2n-tls only supports FIPS mode when built with AWS-LC-FIPS.
+s2n-tls has been structured so that different encryption libraries may be used. Today s2n-tls supports AWS-LC, OpenSSL (versions 1.0.2, 1.1.1 and 3.0.x), LibreSSL, and BoringSSL to perform the underlying cryptographic operations. Check the [libcrypto build documentation](docs/BUILD.md#building-with-a-specific-libcrypto) for a list of libcrypto-specific features.
 
 ##### Timing blinding
 s2n-tls includes structured support for blinding time-based side-channels that may leak sensitive data. For example, if s2n-tls fails to parse a TLS record or handshake message, s2n-tls will add a randomized delay of between 10 and 30 seconds, granular to nanoseconds, before responding. This raises the complexity of real-world timing side-channel attacks by a factor of at least tens of trillions.

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -262,9 +262,9 @@ typedef enum {
 /**
  * Determines whether s2n-tls is operating in FIPS mode.
  *
- * s2n-tls enters FIPS mode on initialization when the linked libcrypto has FIPS mode enabled. Some
- * libcryptos, such as AWS-LC-FIPS, have FIPS mode enabled by default. With other libcryptos, such
- * as OpenSSL, FIPS mode must be enabled before initialization by calling `FIPS_mode_set()`.
+ * s2n-tls enters FIPS mode on initialization when the linked libcrypto has FIPS mode enabled.
+ * s2n-tls only supports FIPS mode when built with AWS-LC-FIPS or AWS-LC-FIPS-2022. AWS-LC-FIPS
+ * and AWS-LC-FIPS-2022 have FIPS mode enabled by default.
  *
  * s2n-tls MUST be linked to a FIPS libcrypto and MUST be in FIPS mode in order to comply with FIPS
  * requirements. Applications desiring FIPS compliance should use this API to ensure that s2n-tls

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -262,13 +262,11 @@ typedef enum {
 /**
  * Determines whether s2n-tls is operating in FIPS mode.
  *
- * s2n-tls enters FIPS mode on initialization when the linked libcrypto has FIPS mode enabled.
- * s2n-tls only supports FIPS mode when built with AWS-LC-FIPS or AWS-LC-FIPS-2022. AWS-LC-FIPS
- * and AWS-LC-FIPS-2022 have FIPS mode enabled by default.
+ * s2n-tls enters FIPS mode on initialization when linked with a FIPS validated version of AWS-LC.
  *
- * s2n-tls MUST be linked to a FIPS libcrypto and MUST be in FIPS mode in order to comply with FIPS
- * requirements. Applications desiring FIPS compliance should use this API to ensure that s2n-tls
- * has been properly linked with a FIPS libcrypto and has successfully entered FIPS mode.
+ * s2n-tls MUST be linked to a FIPS validated libcrypto and MUST be in FIPS mode in order to comply
+ * with FIPS requirements. Applications desiring FIPS compliance should use this API to ensure that
+ * s2n-tls has been properly linked with a FIPS libcrypto and has successfully entered FIPS mode.
  *
  * @param fips_mode Set to the FIPS mode of s2n-tls.
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure.

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -262,11 +262,13 @@ typedef enum {
 /**
  * Determines whether s2n-tls is operating in FIPS mode.
  *
- * s2n-tls enters FIPS mode on initialization when linked with a FIPS validated version of AWS-LC.
+ * s2n-tls enters FIPS mode on initialization when built with a version of AWS-LC that supports
+ * FIPS (https://github.com/aws/aws-lc/blob/main/crypto/fipsmodule/FIPS.md). FIPS mode controls
+ * some internal configuration related to FIPS support, like which random number generator is used.
  *
- * s2n-tls MUST be linked to a FIPS validated libcrypto and MUST be in FIPS mode in order to comply
- * with FIPS requirements. Applications desiring FIPS compliance should use this API to ensure that
- * s2n-tls has been properly linked with a FIPS libcrypto and has successfully entered FIPS mode.
+ * FIPS mode does not enforce the use of FIPS-approved cryptography. Applications attempting to use
+ * only FIPS-approved cryptography should also ensure that s2n-tls is configured to use a security
+ * policy that only supports FIPS-approved cryptography.
  *
  * @param fips_mode Set to the FIPS mode of s2n-tls.
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure.

--- a/codebuild/bin/install_awslc_fips_2022.sh
+++ b/codebuild/bin/install_awslc_fips_2022.sh
@@ -32,16 +32,13 @@ if [[ ! -f "$(which clang)" ]]; then
   exit 1
 fi
 
-# There are currently no AWSLC release tags for the 2022 FIPS branch. The
-# following is the latest commit in this branch as of 8/19/24:
-# https://github.com/aws/aws-lc/commits/fips-2022-11-02
-AWSLC_VERSION=ec94d74a19b5a0aa738b436a95bb06ff87fc7ba9
+AWSLC_VERSION=AWS-LC-FIPS-2.0.17
 
 mkdir -p "$BUILD_DIR" || true
 cd "$BUILD_DIR"
-git clone https://github.com/aws/aws-lc.git
-cd aws-lc
-git checkout "${AWSLC_VERSION}"
+# --branch can also take tags and detaches the HEAD at that commit in the resulting repository
+# --depth 1 Create a shallow clone with a history truncated to 1 commit
+git clone https://github.com/awslabs/aws-lc.git --branch "$AWSLC_VERSION" --depth 1
 
 build() {
     shared=$1

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -112,6 +112,8 @@ s2n-tls has a dependency on a libcrypto library. A supported libcrypto must be l
 - [AWS-LC](https://github.com/aws/aws-lc)
   - Limited ["Sandboxing"](https://github.com/aws/aws-lc/blob/main/SANDBOXING.md) is only supported and tested with AWS-LC.
   - [PQ key exchange](https://aws.github.io/s2n-tls/usage-guide/ch15-post-quantum.html) is only supported with AWS-LC.
+  - s2n-tls enters FIPS mode when linked to AWS-LC-FIPS. AWS-LC-FIPS can be built by first checking out the FIPS tagged
+    commit from the official AWS-LC repo (eg. [AWS-LC-FIPS-2.0.17](https://github.com/aws/aws-lc/tree/AWS-LC-FIPS-2.0.17))
 - [OpenSSL](https://www.openssl.org/) (versions 1.0.2 - 3.0)
   - ChaChaPoly is not supported before Openssl-1.1.1.
   - RSA-PSS is not supported before Openssl-1.1.1.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -122,7 +122,6 @@ s2n-tls has a dependency on a libcrypto library. A supported libcrypto must be l
   - OCSP features are not supported with BoringSSL.
   - FIPS mode is not supported with BoringSSL.
 - [LibreSSL](https://www.libressl.org/)
-  - FIPS mode is not supported with LibreSSL.
 
 By default, s2n-tls will attempt to find a system libcrypto to link with when building. However, this search can be overridden to any of the above libcryptos by specifying the install directory with the `CMAKE_PREFIX_PATH` flag.
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -117,7 +117,7 @@ s2n-tls has a dependency on a libcrypto library. A supported libcrypto must be l
   - ChaChaPoly is not supported before Openssl-1.1.1.
   - RSA-PSS is not supported before Openssl-1.1.1.
   - RC4 is not supported with Openssl-3.0 or later.
-  - FIPS mode is not supported with Openssl.
+  - FIPS mode is not supported with Openssl-3.0 or later.
 - [BoringSSL](https://boringssl.googlesource.com/boringssl)
   - OCSP features are not supported with BoringSSL.
   - FIPS mode is not supported with BoringSSL.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -112,7 +112,8 @@ s2n-tls has a dependency on a libcrypto library. A supported libcrypto must be l
 - [AWS-LC](https://github.com/aws/aws-lc)
   - Limited ["Sandboxing"](https://github.com/aws/aws-lc/blob/main/SANDBOXING.md) is only supported and tested with AWS-LC.
   - [PQ key exchange](https://aws.github.io/s2n-tls/usage-guide/ch15-post-quantum.html) is only supported with AWS-LC.
-  - FIPS mode is supported when s2n-tls is linked with a FIPS validated version of [AWS-LC](https://github.com/aws/aws-lc/blob/main/crypto/fipsmodule/FIPS.md).
+  - FIPS mode is supported with versions of AWS-LC [that support
+    FIPS](https://github.com/aws/aws-lc/blob/main/crypto/fipsmodule/FIPS.md).
 - [OpenSSL](https://www.openssl.org/) (versions 1.0.2 - 3.0)
   - ChaChaPoly is not supported before Openssl-1.1.1.
   - RSA-PSS is not supported before Openssl-1.1.1.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -112,15 +112,17 @@ s2n-tls has a dependency on a libcrypto library. A supported libcrypto must be l
 - [AWS-LC](https://github.com/aws/aws-lc)
   - Limited ["Sandboxing"](https://github.com/aws/aws-lc/blob/main/SANDBOXING.md) is only supported and tested with AWS-LC.
   - [PQ key exchange](https://aws.github.io/s2n-tls/usage-guide/ch15-post-quantum.html) is only supported with AWS-LC.
-  - s2n-tls enters FIPS mode when linked to AWS-LC-FIPS. AWS-LC-FIPS can be built by first checking out the FIPS tagged
-    commit from the official AWS-LC repo (eg. [AWS-LC-FIPS-2.0.17](https://github.com/aws/aws-lc/tree/AWS-LC-FIPS-2.0.17))
+  - FIPS mode is supported when s2n-tls is linked with a FIPS validated version of [AWS-LC](https://github.com/aws/aws-lc/blob/main/crypto/fipsmodule/FIPS.md).
 - [OpenSSL](https://www.openssl.org/) (versions 1.0.2 - 3.0)
   - ChaChaPoly is not supported before Openssl-1.1.1.
   - RSA-PSS is not supported before Openssl-1.1.1.
   - RC4 is not supported with Openssl-3.0 or later.
+  - FIPS mode is not supported with Openssl.
 - [BoringSSL](https://boringssl.googlesource.com/boringssl)
   - OCSP features are not supported with BoringSSL.
+  - FIPS mode is not supported with BoringSSL.
 - [LibreSSL](https://www.libressl.org/)
+  - FIPS mode is not supported with LibreSSL.
 
 By default, s2n-tls will attempt to find a system libcrypto to link with when building. However, this search can be overridden to any of the above libcryptos by specifying the install directory with the `CMAKE_PREFIX_PATH` flag.
 


### PR DESCRIPTION
### Description of changes: 
This PR updates our documentation to specify the libcryptos (AWS-LC-FIPS or AWS-LC-FIPS-2022) with which s2n-tls offers FIPS mode.

I also updated our CI test to use a tagged version of AWS-LC-FIPS-2022.

### Testing:
Tests should continue to pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
