### PR TITLE
fix: typo in comment of s2n_self_talk_tls13_test

### DIFF
--- a/tests/unit/s2n_self_talk_tls13_test.c
+++ b/tests/unit/s2n_self_talk_tls13_test.c
@@ -86,7 +86,7 @@ void mock_client(struct s2n_test_io_pair *io_pair)
     s2n_connection_free(conn);
     s2n_config_free(config);
 
-    /* Give the server a chance to a void a sigpipe */
+    /* Give the server a chance to avoid a sigpipe */
     sleep(1);
 
     s2n_io_pair_close_one_end(io_pair, S2N_CLIENT);


### PR DESCRIPTION
### Resolved issues:

Fix a typo in a comment.

### Description of changes: 

I was studying our self talk tests, and found a typo in `s2n_self_talk_ktls13_test.c`. I believe the comment means to say `avoid`, but it says `a void` instead. I fix that comment to make it more readable.

### Call-outs:

We might have other typos in the codebase, and we should fix them if we find them.

### Testing:

CI and local unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
