### PR TITLE
chore: bindings release 0.3.6

### DIFF
--- a/bindings/rust/s2n-tls-hyper/Cargo.toml
+++ b/bindings/rust/s2n-tls-hyper/Cargo.toml
@@ -13,8 +13,8 @@ publish = false
 default = []
 
 [dependencies]
-s2n-tls = { version = "=0.3.5", path = "../s2n-tls" }
-s2n-tls-tokio = { version = "=0.3.5", path = "../s2n-tls-tokio" }
+s2n-tls = { version = "=0.3.6", path = "../s2n-tls" }
+s2n-tls-tokio = { version = "=0.3.6", path = "../s2n-tls-tokio" }
 hyper = { version = "1" }
 hyper-util = { version = "0.1", features = ["client-legacy", "tokio", "http1"] }
 tower-service = { version = "0.3" }

--- a/bindings/rust/s2n-tls-sys/templates/Cargo.template
+++ b/bindings/rust/s2n-tls-sys/templates/Cargo.template
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-sys"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.63.0"

--- a/bindings/rust/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/s2n-tls-tokio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-tokio"
 description = "An implementation of TLS streams for Tokio built on top of s2n-tls"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.63.0"
@@ -15,7 +15,7 @@ default = []
 errno = { version = "0.3" }
 libc = { version = "0.2" }
 pin-project-lite = { version = "0.2" }
-s2n-tls = { version = "=0.3.5", path = "../s2n-tls" }
+s2n-tls = { version = "=0.3.6", path = "../s2n-tls" }
 tokio = { version = "1", features = ["net", "time"] }
 
 [dev-dependencies]

--- a/bindings/rust/s2n-tls/Cargo.toml
+++ b/bindings/rust/s2n-tls/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.63.0"
@@ -21,7 +21,7 @@ unstable-testing = []
 [dependencies]
 errno = { version = "0.3" }
 libc = "0.2"
-s2n-tls-sys = { version = "=0.3.5", path = "../s2n-tls-sys", features = ["internal"] }
+s2n-tls-sys = { version = "=0.3.6", path = "../s2n-tls-sys", features = ["internal"] }
 pin-project-lite = "0.2"
 hex = "0.4"
 


### PR DESCRIPTION
### Description of changes: 

Bumps the rust bindings versions for a release 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
