### PR TITLE
fix(integV2): remove unused protocol in well-known-endpoints

### DIFF
--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -303,6 +303,12 @@ class Ciphers(object):
     CHACHA20_POLY1305_SHA256 = Cipher("TLS_CHACHA20_POLY1305_SHA256", Protocols.TLS13,
                                       True, False, iana_standard_name="TLS_CHACHA20_POLY1305_SHA256")
 
+
+    # allows all cryptographic parameters and SSLv3 <= protocol <= TLS 1.3
+    TEST_ALL = Cipher("test_all", Protocols.SSLv3, False, False, s2n=True)
+    # allows all cryptographic parameters and SSLv3 <= protocol <= TLS 1.2
+    TEST_ALL_TLS12 = Cipher("test_all_tls12", Protocols.SSLv3, False, False, s2n=True)
+
     KMS_TLS_1_0_2018_10 = Cipher(
         "KMS-TLS-1-0-2018-10", Protocols.TLS10, False, False, s2n=True)
     KMS_PQ_TLS_1_0_2019_06 = Cipher(

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -303,7 +303,6 @@ class Ciphers(object):
     CHACHA20_POLY1305_SHA256 = Cipher("TLS_CHACHA20_POLY1305_SHA256", Protocols.TLS13,
                                       True, False, iana_standard_name="TLS_CHACHA20_POLY1305_SHA256")
 
-
     # allows all cryptographic parameters and SSLv3 <= protocol <= TLS 1.3
     TEST_ALL = Cipher("test_all", Protocols.SSLv3, False, False, s2n=True)
     # allows all cryptographic parameters and SSLv3 <= protocol <= TLS 1.2

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -149,6 +149,10 @@ class S2N(Provider):
 
     @classmethod
     def supports_protocol(cls, protocol, with_cert=None):
+        # the test doesn't care which protocol is used, so we support it
+        if protocol is None:
+            return True
+
         # TLS 1.3 is unsupported for openssl-1.0
         # libressl and boringssl are disabled because of configuration issues
         # see https://github.com/aws/s2n-tls/issues/3250

--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -89,7 +89,6 @@ else:
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
-@pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("endpoint", ENDPOINTS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("cipher", CIPHERS, ids=get_parameter_name)


### PR DESCRIPTION
### Description of changes: 

This test queries each endpoint more than necessary.

The current test runs once for each protocol/cipher tuple. But the protocol has little effect on the security policy selection, so there are lots of duplicate test runs.

https://github.com/aws/s2n-tls/blob/53691f9feba06ca371ea03f371391bbbb7b227d5/tests/integrationv2/providers.py#L243-L251

E.g, all of the following tuples have the same exact configuration, because of the cipher preferences override on line 249.
- sslv3, pq-123,
- tls 1.0, pq-123,
- tls 1.1, pq-123
- tls 1.2, pq-123,
- tls 1.3, pq-123,

So each endpoint was queried 5 * 6 = 30 times, even though most queries were duplicates. After this change, each endpoints will only be queried 6 times.

I think that is still excessive, but this PR keeps coverage _strictly_ the same, and only removes duplicated queries.

### Testing:

Existing CI should pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
