### PR TITLE
fix: move prelude inclusion as PRIVATE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,10 @@ if(S2N_BLOCK_NONPORTABLE_OPTIMIZATIONS)
     target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_BLOCK_NONPORTABLE_OPTIMIZATIONS=1)
 endif()
 
-target_compile_options(${PROJECT_NAME} PUBLIC -fPIC -include "${CMAKE_CURRENT_LIST_DIR}/utils/s2n_prelude.h")
+target_compile_options(${PROJECT_NAME} PUBLIC -fPIC)
+
+set(S2N_PRELUDE "${CMAKE_CURRENT_LIST_DIR}/utils/s2n_prelude.h")
+target_compile_options(${PROJECT_NAME} PRIVATE -include "${S2N_PRELUDE}")
 
 # Match on Release, RelWithDebInfo and MinSizeRel
 # See: https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html#variable:CMAKE_BUILD_TYPE
@@ -476,6 +479,8 @@ if (BUILD_TESTING)
     add_library(testss2n STATIC ${TESTLIB_SRC} ${EXAMPLES_SRC})
     target_include_directories(testss2n PUBLIC tests)
     target_compile_options(testss2n PRIVATE -std=gnu99)
+    # make sure all linked tests include the prelude
+    target_compile_options(testss2n PUBLIC -include "${S2N_PRELUDE}")
     target_link_libraries(testss2n PUBLIC ${PROJECT_NAME})
     if (SECCOMP)
         message(STATUS "Linking tests with seccomp")


### PR DESCRIPTION
### Description of changes: 

This change moves the s2n_prelude.h as a private compile option, which avoids including the header in any consuming CMake packages.

### Testing:

The tests that are in place to ensure the prelude is linked should show that it still works as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
