### PR TITLE
ci: remove www.mozilla.com from well-known to unblock CI

### DIFF
--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -38,7 +38,8 @@ ENDPOINTS = [
     "www.github.com",
     "www.ibm.com",
     "www.microsoft.com",
-    "www.mozilla.org",
+    # https://github.com/aws/s2n-tls/issues/4879
+    # "www.mozilla.org",
     "www.netflix.com",
     "www.openssl.org",
     "www.samsung.com",


### PR DESCRIPTION
### Description of changes: 
The www.mozilla.org endpoint is flaky. This PR comments out the mozilla endpoint to unblock CI while we work on a long-term fix.

### Callout:
From the test logs we see that we actually do connect to www.mozilla.com (`Connected to www.mozilla.org:443`) and the failure seems to be related to our testing framework.

```
s2nc: stdout available
s2nc: looking for send_marker s2n is ready in b'libcrypto: AWS-LC 1.36.0\nCONNECTED:\nHandshake: NEGOTIATED|FULL_HANDSHAKE|TLS ...(412 more bytes)
s2nc: found s2n is ready
s2nc: will send nothing
s2nc: finished sending
s2nc: closing stdin
s2nc: stdout available
s2nc: stdout available
Command line: s2nc --non-blocking -e -T -f ../pems/trust-store/ca-bundle.crt -c test_all_tls12 www.mozilla.org 443
Exit code: -9
Stdout: libcrypto: AWS-LC 1.36.0
CONNECTED:
Handshake: NEGOTIATED|FULL_HANDSHAKE|TLS12_PERFECT_FORWARD_SECRECY
Client hello version: 33
Client protocol version: 33
Server protocol version: 33
Actual protocol version: 33
Server name: www.mozilla.org
Curve: secp256r1
Cipher negotiated: ECDHE-RSA-AES128-GCM-SHA256
Server signature negotiated: RSA-PSS-RSAE+SHA256
Early Data status: NOT REQUESTED
Wire bytes in: 3072
Wire bytes out: 341
s2n is ready
Connected to www.mozilla.org:443
```

### Testing:
Other well-known endpoints should continue to work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
