### PR TITLE
test: remove load system certs functionality for s2n_default_tls13_config

### DIFF
--- a/tests/fuzz/s2n_certificate_extensions_parse_test.c
+++ b/tests/fuzz/s2n_certificate_extensions_parse_test.c
@@ -65,6 +65,7 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     POSIX_GUARD(s2n_stuffer_write_bytes(&fuzz_stuffer, buf, len));
 
     DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+    EXPECT_NOT_NULL(config);
     POSIX_GUARD(s2n_config_set_cipher_preferences(config, "20240503"));
 
     struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);

--- a/tests/fuzz/s2n_certificate_extensions_parse_test.c
+++ b/tests/fuzz/s2n_certificate_extensions_parse_test.c
@@ -49,11 +49,6 @@ static uint8_t verify_host_accept_everything(const char *host_name, size_t host_
 /* This test is for TLS versions 1.3 and up only */
 static const uint8_t TLS_VERSIONS[] = {S2N_TLS13};
 
-int s2n_fuzz_init(int *argc, char **argv[])
-{
-    return S2N_SUCCESS;
-}
-
 int s2n_fuzz_test(const uint8_t *buf, size_t len)
 {
     /* We need at least one byte of input to set parameters */
@@ -117,4 +112,4 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     return S2N_SUCCESS;
 }
 
-S2N_FUZZ_TARGET(s2n_fuzz_init, s2n_fuzz_test, NULL)
+S2N_FUZZ_TARGET(NULL, s2n_fuzz_test, NULL)

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -251,12 +251,6 @@ int s2n_config_defaults_init(void)
     return S2N_SUCCESS;
 }
 
-S2N_RESULT s2n_config_testing_defaults_init_tls13_certs(void)
-{
-    RESULT_GUARD_POSIX(s2n_config_load_system_certs(&s2n_default_tls13_config));
-    return S2N_RESULT_OK;
-}
-
 void s2n_wipe_static_configs(void)
 {
     s2n_config_cleanup(&s2n_default_fips_config);

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -239,7 +239,6 @@ struct s2n_config {
 S2N_CLEANUP_RESULT s2n_config_ptr_free(struct s2n_config **config);
 
 int s2n_config_defaults_init(void);
-S2N_RESULT s2n_config_testing_defaults_init_tls13_certs(void);
 struct s2n_config *s2n_fetch_default_config(void);
 int s2n_config_set_unsafe_for_testing(struct s2n_config *config);
 


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes:
I noticed that `s2n_config_testing_defaults_init_tls13_certs` was only being called from a single fuzz test and could be deleted if we pinned the test to use a new config with the same security policy (`20240503` is the current `default_tls13`).

### Testing:
This PR refactors the fuzz test, which should continue to pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
