### PR TITLE
feat(bindings): enable multiple cert chains on config

### DIFF
--- a/bindings/rust/s2n-tls/src/cert_chain.rs
+++ b/bindings/rust/s2n-tls/src/cert_chain.rs
@@ -309,7 +309,7 @@ mod tests {
         assert_eq!(original_cert.context().refcount.load(Ordering::Relaxed), 1);
     }
 
-    // ensure the config context is send and sync
+    // ensure the CertificateChainContext is send and sync
     #[test]
     fn context_send_sync_test() {
         fn assert_send_sync<T: 'static + Send + Sync>() {}

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -763,6 +763,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
     };
 
+    // TODO: add Test s2n_config_get_cert_chains
+
     /* Test loading system certs */
     {
         /* s2n_config_load_system_certs safety */

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -776,6 +776,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_get_cert_chains(config, &cert_chains, &chain_count));
         EXPECT_NULL(cert_chains);
         EXPECT_EQUAL(chain_count, 0);
+        EXPECT_SUCCESS(s2n_free_config_cert_chains(&cert_chains, chain_count));
 
         EXPECT_SUCCESS(s2n_config_free(config));
     };
@@ -797,7 +798,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(chain_count, 1);
         EXPECT_EQUAL(cert_chains[0], chain_and_key);
 
-        EXPECT_SUCCESS(s2n_free_object((uint8_t **)&cert_chains, sizeof(struct s2n_cert_chain_and_key *) * chain_count));
+        EXPECT_SUCCESS(s2n_free_config_cert_chains(&cert_chains, chain_count));
         EXPECT_SUCCESS(s2n_config_free(config));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
     };
@@ -823,7 +824,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE((cert_chains[0] == chain1 && cert_chains[1] == chain2) ||
                     (cert_chains[0] == chain2 && cert_chains[1] == chain1));
 
-        EXPECT_SUCCESS(s2n_free_object((uint8_t **)&cert_chains, sizeof(struct s2n_cert_chain_and_key *) * chain_count));
+        EXPECT_SUCCESS(s2n_free_config_cert_chains(&cert_chains, chain_count));
         EXPECT_SUCCESS(s2n_config_free(config));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain1));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain2));
@@ -850,7 +851,7 @@ int main(int argc, char **argv)
         EXPECT_TRUE((cert_chains[0] == chain1 && cert_chains[1] == chain2) ||
                     (cert_chains[0] == chain2 && cert_chains[1] == chain1));
 
-        EXPECT_SUCCESS(s2n_free_object((uint8_t **)&cert_chains, sizeof(struct s2n_cert_chain_and_key *) * chain_count));
+        EXPECT_SUCCESS(s2n_free_config_cert_chains(&cert_chains, chain_count));
         EXPECT_SUCCESS(s2n_config_free(config));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain1));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain2));

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -811,6 +811,17 @@ int s2n_config_get_cert_chains(struct s2n_config *config,
     return S2N_SUCCESS;
 }
 
+int s2n_free_config_cert_chains(struct s2n_cert_chain_and_key ***cert_chains, uint32_t chain_count)
+{
+    POSIX_ENSURE_REF(cert_chains);
+    if (*cert_chains != NULL) {
+        POSIX_GUARD(s2n_free_object((uint8_t **)cert_chains, sizeof(struct s2n_cert_chain_and_key *) * chain_count));
+        *cert_chains = NULL;
+    }
+
+    return S2N_SUCCESS;
+}
+
 int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem)
 {
     DEFER_CLEANUP(struct s2n_stuffer dhparams_in_stuffer = { 0 }, s2n_stuffer_free);

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -729,6 +729,96 @@ int s2n_config_set_cert_chain_and_key_defaults(struct s2n_config *config,
     return 0;
 }
 
+/* Only used in the Rust bindings for cleanup */
+int s2n_config_get_cert_chains(struct s2n_config *config,
+        struct s2n_cert_chain_and_key ***cert_chains,
+        uint32_t *chain_count) 
+{
+    POSIX_ENSURE_REF(config);
+    POSIX_ENSURE_REF(cert_chains);
+    POSIX_ENSURE_REF(chain_count);
+    *chain_count = 0;
+    *cert_chains = NULL;
+    uint32_t total_possible_chains = 0;
+    
+    /* Count all the certs to know how much max memory to allocate */ 
+    for (int i = 0; i < S2N_CERT_TYPE_COUNT; i++) {
+        if (config->default_certs_by_type.certs[i] != NULL) {
+            total_possible_chains++;
+        }
+    }
+    if (config->domain_name_to_cert_map != NULL) {
+        uint32_t domain_count = 0;
+        POSIX_GUARD_RESULT(s2n_map_size(config->domain_name_to_cert_map, &domain_count));
+        total_possible_chains += (domain_count * S2N_CERT_TYPE_COUNT);
+    }
+
+    if (total_possible_chains == 0) {
+        return S2N_SUCCESS;
+    }
+    DEFER_CLEANUP(struct s2n_blob allocator = {0}, s2n_free);
+    POSIX_GUARD(s2n_alloc(&allocator, sizeof(struct s2n_cert_chain_and_key*) * total_possible_chains));
+    // These two lines to try and fix cast from 'uint8_t *' (aka 'unsigned char *') to 'struct s2n_cert_chain_and_key **' increases required alignment from 1 to 8 [-Werror,-Wcast-align]GCC
+    POSIX_GUARD(s2n_blob_init(&allocator, allocator.data, sizeof(struct s2n_cert_chain_and_key*) * total_possible_chains));
+    POSIX_GUARD(s2n_blob_zero(&allocator));
+    *cert_chains = (struct s2n_cert_chain_and_key**)allocator.data;
+
+
+    for (int i = 0; i < S2N_CERT_TYPE_COUNT; i++) {
+        if (config->default_certs_by_type.certs[i] != NULL) {
+            (*cert_chains)[*chain_count] = config->default_certs_by_type.certs[i];
+            (*chain_count)++;
+        }
+    }
+    if (config->domain_name_to_cert_map != NULL) {
+        struct s2n_map_iterator iter = {0};
+        POSIX_GUARD_RESULT(s2n_map_iterator_init(&iter, config->domain_name_to_cert_map));
+
+        while (s2n_map_iterator_has_next(&iter)) {
+            struct s2n_blob value = {0};
+            POSIX_GUARD_RESULT(s2n_map_iterator_next(&iter, &value));
+            
+            struct certs_by_type *domain_certs = (void *)value.data;
+            for (int i = 0; i < S2N_CERT_TYPE_COUNT; i++) {
+                if (domain_certs->certs[i] != NULL) {
+                    bool duplicate = false;
+                    for (uint32_t j = 0; j < *chain_count; j++) {
+                        if ((*cert_chains)[j] == domain_certs->certs[i]) {
+                            duplicate = true;
+                            break;
+                        }
+                    }
+
+                    if (!duplicate) {
+                        (*cert_chains)[*chain_count] = domain_certs->certs[i];
+                        (*chain_count)++;
+                    }
+                }
+            }
+        }
+    }
+
+    /* If we found fewer chains than allocated, reallocate to the exact size */
+    if (*chain_count < total_possible_chains) {
+        DEFER_CLEANUP(struct s2n_blob right_sized_allocator = {0}, s2n_free);
+        POSIX_GUARD(s2n_alloc(&right_sized_allocator, sizeof(struct s2n_cert_chain_and_key*) * (*chain_count)));
+        POSIX_GUARD(s2n_blob_init(&right_sized_allocator, right_sized_allocator.data, 
+            sizeof(struct s2n_cert_chain_and_key*) * (*chain_count)));
+        struct s2n_cert_chain_and_key **right_sized_chains = (struct s2n_cert_chain_and_key**)right_sized_allocator.data;
+        
+        POSIX_CHECKED_MEMCPY(right_sized_chains, *cert_chains, sizeof(struct s2n_cert_chain_and_key*) * (*chain_count));
+        *cert_chains = right_sized_chains;
+        
+        /* Prevent double free of the memory */
+        right_sized_allocator.data = NULL;
+    }
+
+    /* Prevent double free of the memory */
+    allocator.data = NULL;
+
+    return S2N_SUCCESS;
+}
+
 int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem)
 {
     DEFER_CLEANUP(struct s2n_stuffer dhparams_in_stuffer = { 0 }, s2n_stuffer_free);

--- a/tls/s2n_internal.h
+++ b/tls/s2n_internal.h
@@ -59,3 +59,12 @@ S2N_PRIVATE_API int s2n_config_add_cert_chain(struct s2n_config *config,
  * is still waiting for encryption.
  */
 S2N_PRIVATE_API int s2n_flush(struct s2n_connection *conn, s2n_blocked_status *blocked);
+
+/*
+ * Gets all the s2n_cert_chain_and_key set on the config
+ * 
+ * This method is only useful for the Rust bindings that need to iterate over
+ * the 
+ */
+S2N_PRIVATE_API int s2n_config_get_cert_chains(struct s2n_config *config,
+        struct s2n_cert_chain_and_key ***cert_chains, uint32_t *chain_count);

--- a/tls/s2n_internal.h
+++ b/tls/s2n_internal.h
@@ -64,7 +64,14 @@ S2N_PRIVATE_API int s2n_flush(struct s2n_connection *conn, s2n_blocked_status *b
  * Gets all the s2n_cert_chain_and_key set on the config
  * 
  * This method is only useful for the Rust bindings that need to iterate over
- * the 
+ * the cert chains for cleanup
  */
 S2N_PRIVATE_API int s2n_config_get_cert_chains(struct s2n_config *config,
         struct s2n_cert_chain_and_key ***cert_chains, uint32_t *chain_count);
+
+/*
+ * Cleanup for memory needed for s2n_config_get_cert_chains
+ *
+ * This method is only used by the Rust bindings
+ */
+S2N_PRIVATE_API int s2n_free_config_cert_chains(struct s2n_cert_chain_and_key ***cert_chains, uint32_t chain_count);


### PR DESCRIPTION
### Release Summary:

- Adds `add_cert_chain` to allow more than one CertificateChain (s2n_cert_chain_and_key in C)
- Adds `clone` to CertificateChain to allow multiple configs to share CertificateChains 

### Resolved issues:
N/A did not see any issues for this

### Description of changes: 
Prior to this change the only way of using the bindings was to use the older `s2n_config_add_cert_chain_and_key` C code that sets S2N ownership. This change is to allow use of the newer `s2n_config_add_cert_chain` which does not set S2N ownership of the cert. This PR does not change any existing C functionality and the older rust functions are still usable. The C code added is to implement drop on config and CertificateChain.

This change is needed to support more than one cert chain while using Rust.

### Call-outs:

`load_public_pem` was not added on CertificateChain but would likely need to be implemented in the future. I left it out as it would need more C code and can be added independently of this PR.

I went with documentation about which Config Builder functions can be used together. The setters will fail due to the C code checking the condition. LMK if you think there is a better way to communicate when to pick one function over the other.

`from_owned_ptr_reference` vs `from_ptr_reference` requires knowing the implementation details of the ownership. Not sure how to get around that and still keep backwards compatibility.

I did not create a builder for CertificateChain as it seemed a bit superfluous since the build would not be able to validate anything. 

### Testing:

Used the following to execute the tests

```
cmake3 . -Bbuild \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_INSTALL_PREFIX=./s2n-tls-install \
    -DCMAKE_EXE_LINKER_FLAGS="-lcrypto -lz"
cmake3 --build build -j $(nproc)
cd build
CTEST_PARALLEL_LEVEL=$(nproc) ctest3
cd ..
cmake3 --install build


./bindings/rust/generate.sh
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
