### PR TITLE
ci: Move kTLS test out of GeneralBatch

### DIFF
--- a/codebuild/spec/buildspec_al2023_ktls.yml
+++ b/codebuild/spec/buildspec_al2023_ktls.yml
@@ -1,0 +1,26 @@
+---
+# This is designed to work with CodeBuild's reserved instances fleet and curated Ec2 AMI for AL2023.
+version: 0.2
+env:
+  variables:
+    NIX_CACHE_BUCKET: "s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2"
+    S2N_KTLS_TESTING_EXPECTED: 1
+phases:
+  install:
+    commands:
+      - yum update -y; yum upgrade -y
+  pre_build:
+    commands:
+      # Nix is installed, but intentionally not setup for root, fix that
+      - cp -aR /home/nix/.nix-profile ~/; chown -R root /root/.nix-profile; export PATH=$HOME/.nix-profile/bin:$PATH
+      # Turn on flakes
+      - mkdir -p ~/.config/nix; echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+      # Populate the store from the nix cache
+      - nix copy --from $NIX_CACHE_BUCKET --all  --no-check-sigs
+      # Load the TLS kernel module
+      - sudo modprobe tls
+      - echo "Checking that the TLS kernel mod loaded..."; test $(sudo lsmod|grep -c tls) = 1
+  build:
+    commands:
+      - nix develop .#openssl111 --command bash -c  'source ./nix/shell.sh && clean && configure && unit'
+      - S2N_CMAKE_OPTIONS="-DASAN=ON" nix develop .#openssl111 --command bash -c  'source ./nix/shell.sh && clean && configure && unit'

--- a/codebuild/spec/buildspec_generalbatch.yml
+++ b/codebuild/spec/buildspec_generalbatch.yml
@@ -388,17 +388,3 @@ batch:
         privileged-mode: true
         compute-type: BUILD_GENERAL1_LARGE
         image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
-    - identifier: ktls
-      buildspec: codebuild/spec/buildspec_ktls.yml
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        image: aws/codebuild/standard:7.0
-        privileged-mode: true
-    - identifier: ktlsASAN
-      buildspec: codebuild/spec/buildspec_ktls.yml
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        image: aws/codebuild/standard:7.0
-        privileged-mode: true
-        variables:
-            S2N_CMAKE_OPTIONS: "-DASAN=ON"


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

n/a

### Description of changes: 

Replaces #4886.  CodeBuild now supports [ec2 instance types](https://aws.amazon.com/about-aws/whats-new/2024/11/aws-codebuild-windows-docker-reserved-capacity-fleets/), move kTLS out of general batch and onto this new setup.  Example run: [here](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/AMI_tester/build/AMI_tester%3A6561c884-6ce7-489c-a90a-d90cafb14fca/?region=us-west-2)

Because this new CodeBuild feature does not support batch builds, I've added the kTLS ASAN job to the new kTLS buildspec serially. On the 8vcpu instance, total runtime is ~8 minutes, end to end.

### Call-outs:

This moves us away from hand rolled QEMU VM images and onto a vended AL2023 AMI.

This change also directly uses the Nix s3 cache to speed up builds. 

Release steps:
- While this is in review, I'll finalize the CodeBuild job
- Just prior to merging, the webhook will be turned on in "not required" mode.
- After some soak time, we'll mark it required

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)?  On a new job called AMI Tester, see the linked run above
How can you convince your reviewers that this PR is safe and effective? ad-hoc test run, you can duplicate in [AMI tester](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/AMI_tester?region=us-west-2&builds-meta=eyJmIjp7InRleHQiOiIiLCJzdGF0dXMiOiIifSwicyI6e30sIm4iOjIwLCJpIjowfQ)
Is this a refactor change? of s2n code, no, of CI, yes. No more Qemu or AL2 qcow images.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
