### PR TITLE
test(s2n-tls-hyper): matching on s2n-tls error

### DIFF
--- a/bindings/rust/s2n-tls-hyper/tests/common/echo.rs
+++ b/bindings/rust/s2n-tls-hyper/tests/common/echo.rs
@@ -17,7 +17,7 @@ async fn echo(
     Ok(Response::new(req.into_body().boxed()))
 }
 
-async fn serve_echo<B>(
+pub async fn serve_echo<B>(
     tcp_listener: TcpListener,
     builder: B,
 ) -> Result<(), Box<dyn Error + Send + Sync>>

--- a/bindings/rust/s2n-tls-hyper/tests/common/mod.rs
+++ b/bindings/rust/s2n-tls-hyper/tests/common/mod.rs
@@ -6,10 +6,9 @@ use s2n_tls::{callbacks::VerifyHostNameCallback, config, error::Error, security:
 pub mod echo;
 
 /// NOTE: this certificate and key are used for testing purposes only!
-pub static CERT_PEM: &[u8] =
+pub const CERT_PEM: &[u8] =
     include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/../certs/cert.pem"));
-pub static KEY_PEM: &[u8] =
-    include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/../certs/key.pem"));
+pub const KEY_PEM: &[u8] = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/../certs/key.pem"));
 
 pub fn config() -> Result<config::Builder, Error> {
     let mut builder = config::Config::builder();

--- a/bindings/rust/s2n-tls-hyper/tests/http.rs
+++ b/bindings/rust/s2n-tls-hyper/tests/http.rs
@@ -3,15 +3,19 @@
 
 use crate::common::InsecureAcceptAllCertificatesHandler;
 use bytes::Bytes;
+use common::echo::serve_echo;
 use http::{Method, Request, Uri};
 use http_body_util::{BodyExt, Empty, Full};
 use hyper_util::{client::legacy::Client, rt::TokioExecutor};
 use s2n_tls::{
     callbacks::{ClientHelloCallback, ConnectionFuture},
+    config,
     connection::Connection,
+    security::DEFAULT_TLS13,
 };
 use s2n_tls_hyper::connector::HttpsConnector;
 use std::{error::Error, pin::Pin, str::FromStr};
+use tokio::{net::TcpListener, task::JoinHandle};
 
 pub mod common;
 
@@ -136,5 +140,78 @@ async fn test_sni() -> Result<(), Box<dyn Error + Send + Sync>> {
         .await?;
     }
 
+    Ok(())
+}
+
+/// This test covers the general customer TLS Error experience. We want to
+/// confirm that s2n-tls errors are correctly bubbled up and that details can be
+/// extracted/matched on.
+#[tokio::test]
+async fn error_matching() -> Result<(), Box<dyn Error + Send + Sync>> {
+    let (server_task, addr) = {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let server_task = tokio::spawn(serve_echo(listener, common::config()?.build()?));
+        (server_task, addr)
+    };
+
+    let client_task: JoinHandle<Result<(), Box<dyn Error + Send + Sync>>> =
+        tokio::spawn(async move {
+            // the client config won't trust the self-signed cert that the server
+            // uses.
+            let client_config = {
+                let mut builder = config::Config::builder();
+                builder.set_security_policy(&DEFAULT_TLS13)?;
+                builder.set_max_blinding_delay(0)?;
+                builder.build()?
+            };
+
+            let connector = HttpsConnector::new(client_config);
+            let client: Client<_, Empty<Bytes>> =
+                Client::builder(TokioExecutor::new()).build(connector);
+
+            let uri = Uri::from_str(format!("https://localhost:{}", addr.port()).as_str())?;
+            client.get(uri).await?;
+
+            panic!("the client request should fail");
+        });
+
+    // expected error:
+    // hyper_util::client::legacy::Error(
+    //     Connect,
+    //     TlsError(
+    //         Error {
+    //             code: 335544366,
+    //             name: "S2N_ERR_CERT_UNTRUSTED",
+    //             message: "Certificate is untrusted",
+    //             kind: ProtocolError,
+    //             source: Library,
+    //             debug: "Error encountered in lib/tls/s2n_x509_validator.c:721",
+    //             errno: "No such file or directory",
+    //         },
+    //     ),
+    // )
+    let client_response = client_task.await?;
+    let client_error = client_response.unwrap_err();
+    let hyper_error: &hyper_util::client::legacy::Error = client_error.downcast_ref().unwrap();
+
+    // the error happened when attempting to connect to the endpoint.
+    assert!(hyper_error.is_connect());
+
+    let error_source = hyper_error.source().unwrap();
+    let s2n_tls_hyper_error: &s2n_tls_hyper::error::Error = error_source.downcast_ref().unwrap();
+
+    let s2n_tls_error = match s2n_tls_hyper_error {
+        s2n_tls_hyper::error::Error::TlsError(s2n_tls_error) => s2n_tls_error,
+        _ => panic!("unexpected error type"),
+    };
+
+    assert_eq!(
+        s2n_tls_error.kind(),
+        s2n_tls::error::ErrorType::ProtocolError
+    );
+    assert_eq!(s2n_tls_error.name(), "S2N_ERR_CERT_UNTRUSTED");
+
+    server_task.abort();
     Ok(())
 }


### PR DESCRIPTION
### Resolved issues:

Prompted by [discussion](https://github.com/aws/s2n-tls/pull/4884#discussion_r1838883736) in #4884 

### Description of changes: 
The PR adds a "sanity check" test covering customer interactions with hyper and s2n-tls errors. This confirms that hyper isn't doing anything tricky (like converting TLS errors to HTTP errors) and that the original s2n-tls error descriptions can still be inspected.

### Testing:

No functional changes, this just tests existing behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
