### PR TITLE
feat: add TLS1.3 support to "default" and "default_fips" policies

### DIFF
--- a/tests/unit/s2n_connection_preferences_test.c
+++ b/tests/unit/s2n_connection_preferences_test.c
@@ -28,8 +28,7 @@ int main(int argc, char **argv)
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    const struct s2n_security_policy *default_security_policy = NULL, *tls13_security_policy = NULL, *fips_security_policy = NULL;
-    EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_tls13", &tls13_security_policy));
+    const struct s2n_security_policy *default_security_policy = NULL, *fips_security_policy = NULL;
     EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_fips", &fips_security_policy));
     EXPECT_SUCCESS(s2n_find_security_policy_from_version("default", &default_security_policy));
 

--- a/tests/unit/s2n_connection_preferences_test.c
+++ b/tests/unit/s2n_connection_preferences_test.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_fips", &fips_security_policy));
     EXPECT_SUCCESS(s2n_find_security_policy_from_version("default", &default_security_policy));
 
-    /* Test default TLS1.2 */
+    /* Test default TLS 1.3 */
     if (!s2n_is_in_fips_mode()) {
         struct s2n_connection *conn = NULL;
         const struct s2n_cipher_preferences *cipher_preferences = NULL;
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
-    /* Test TLS1.3 */
+    /* Test TLS1.3 and s2n_enable_tls13_in_test behavior */
     {
         EXPECT_SUCCESS(s2n_enable_tls13_in_test());
         struct s2n_connection *conn = NULL;
@@ -100,19 +100,19 @@ int main(int argc, char **argv)
         EXPECT_NULL(conn->security_policy_override);
 
         EXPECT_SUCCESS(s2n_connection_get_cipher_preferences(conn, &cipher_preferences));
-        EXPECT_EQUAL(cipher_preferences, tls13_security_policy->cipher_preferences);
+        EXPECT_EQUAL(cipher_preferences, default_security_policy->cipher_preferences);
 
         EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
-        EXPECT_EQUAL(security_policy, tls13_security_policy);
+        EXPECT_EQUAL(security_policy, default_security_policy);
 
         EXPECT_SUCCESS(s2n_connection_get_kem_preferences(conn, &kem_preferences));
-        EXPECT_EQUAL(kem_preferences, tls13_security_policy->kem_preferences);
+        EXPECT_EQUAL(kem_preferences, default_security_policy->kem_preferences);
 
         EXPECT_SUCCESS(s2n_connection_get_signature_preferences(conn, &signature_preferences));
-        EXPECT_EQUAL(signature_preferences, tls13_security_policy->signature_preferences);
+        EXPECT_EQUAL(signature_preferences, default_security_policy->signature_preferences);
 
         EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));
-        EXPECT_EQUAL(ecc_preferences, tls13_security_policy->ecc_preferences);
+        EXPECT_EQUAL(ecc_preferences, default_security_policy->ecc_preferences);
 
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all_tls13"));
         EXPECT_NOT_NULL(conn->security_policy_override);

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -178,7 +178,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
         EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
         EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
-        EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
+        EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
 
         security_policy = NULL;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_tls13", &security_policy));
@@ -452,8 +452,6 @@ int main(int argc, char **argv)
 
     {
         char tls12_only_security_policy_strings[][255] = {
-            "default",
-            "default_fips",
             "ELBSecurityPolicy-TLS-1-0-2015-04",
             "ELBSecurityPolicy-TLS-1-0-2015-05",
             "ELBSecurityPolicy-2016-08",
@@ -512,6 +510,8 @@ int main(int argc, char **argv)
         }
 
         char tls13_security_policy_strings[][255] = {
+            "default",
+            "default_fips",
             "default_tls13",
             "test_all",
             "test_all_tls13",
@@ -1042,6 +1042,7 @@ int main(int argc, char **argv)
             const struct s2n_security_policy *versioned_policies[] = {
                 &security_policy_20170210,
                 &security_policy_20240501,
+                &security_policy_20240701,
             };
 
             const struct s2n_supported_cert supported_certs[] = {
@@ -1077,6 +1078,7 @@ int main(int argc, char **argv)
             const struct s2n_security_policy *versioned_policies[] = {
                 &security_policy_20240416,
                 &security_policy_20240502,
+                &security_policy_20240702,
             };
 
             const struct s2n_supported_cert supported_certs[] = {

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -28,14 +28,18 @@
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
+
+    /* TLS 1.3 is used by default */
+    EXPECT_EQUAL(s2n_highest_protocol_version, S2N_TLS13);
+
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    /* TLS 1.3 is not used by default */
-    EXPECT_FALSE(s2n_use_default_tls13_config());
+    /* `s2n_disable_tls13_in_test` disables TLS 1.3 */
+    EXPECT_EQUAL(s2n_highest_protocol_version, S2N_TLS12);
 
-    /* TLS1.3 is not supported or configured by default */
+    /* TLS1.3 is supported and configured by default */
     {
-        /* Client does not support or configure TLS 1.3 */
+        /* Client does support and configure TLS 1.3 */
         {
             struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
@@ -44,12 +48,12 @@ int main(int argc, char **argv)
 
             const struct s2n_security_policy *security_policy = NULL;
             EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
-            EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
+            EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         };
 
-        /* Server does not support or configure TLS 1.3 */
+        /* Server does support and configure TLS 1.3 */
         {
             struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
@@ -58,18 +62,18 @@ int main(int argc, char **argv)
 
             const struct s2n_security_policy *security_policy = NULL;
             EXPECT_SUCCESS(s2n_connection_get_security_policy(conn, &security_policy));
-            EXPECT_FALSE(s2n_security_policy_supports_tls13(security_policy));
+            EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         };
     };
 
     EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-    EXPECT_TRUE(s2n_use_default_tls13_config());
+    EXPECT_EQUAL(s2n_highest_protocol_version, S2N_TLS13);
 
     /* Re-enabling has no effect */
     EXPECT_SUCCESS(s2n_enable_tls13_in_test());
-    EXPECT_TRUE(s2n_use_default_tls13_config());
+    EXPECT_EQUAL(s2n_highest_protocol_version, S2N_TLS13);
 
     /* If "enabled", TLS1.3 is supported and configured */
     {
@@ -103,11 +107,11 @@ int main(int argc, char **argv)
     };
 
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
-    EXPECT_FALSE(s2n_use_default_tls13_config());
+    EXPECT_EQUAL(s2n_highest_protocol_version, S2N_TLS12);
 
     /* Re-disabling has no effect */
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
-    EXPECT_FALSE(s2n_use_default_tls13_config());
+    EXPECT_EQUAL(s2n_highest_protocol_version, S2N_TLS12);
 
     /* Test s2n_is_valid_tls13_cipher() */
     {

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -327,6 +327,32 @@ const struct s2n_cipher_preferences cipher_preferences_20240331 = {
     .allow_chacha20_boosting = false,
 };
 
+/*
+ * TLS1.3 support.
+ * FIPS compliant.
+ * No DHE (would require extra setup with s2n_config_add_dhparams)
+ */
+struct s2n_cipher_suite *cipher_suites_20240701[] = {
+    &s2n_tls13_aes_256_gcm_sha384,
+    &s2n_tls13_aes_128_gcm_sha256,
+    /* TLS1.2 with ECDSA */
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+    /* TLS1.2 with RSA */
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_128_cbc_sha256,
+    &s2n_ecdhe_rsa_with_aes_256_cbc_sha384,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_20240701 = {
+    .count = s2n_array_len(cipher_suites_20240701),
+    .suites = cipher_suites_20240701,
+    .allow_chacha20_boosting = false,
+};
+
 /* Same as 20160411, but with ChaCha20 added as 1st in Preference List */
 struct s2n_cipher_suite *cipher_suites_20190122[] = {
     &s2n_ecdhe_rsa_with_chacha20_poly1305_sha256,

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -27,6 +27,7 @@ struct s2n_cipher_preferences {
     bool allow_chacha20_boosting;
 };
 
+extern const struct s2n_cipher_preferences cipher_preferences_20240701;
 extern const struct s2n_cipher_preferences cipher_preferences_20230317;
 extern const struct s2n_cipher_preferences cipher_preferences_20240331;
 extern const struct s2n_cipher_preferences cipher_preferences_20140601;

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -70,17 +70,10 @@ static int wall_clock(void *data, uint64_t *nanoseconds)
 
 static struct s2n_config s2n_default_config = { 0 };
 static struct s2n_config s2n_default_fips_config = { 0 };
-static struct s2n_config s2n_default_tls13_config = { 0 };
 
 static int s2n_config_setup_default(struct s2n_config *config)
 {
     POSIX_GUARD(s2n_config_set_cipher_preferences(config, "default"));
-    return S2N_SUCCESS;
-}
-
-static int s2n_config_setup_tls13(struct s2n_config *config)
-{
-    POSIX_GUARD(s2n_config_set_cipher_preferences(config, "default_tls13"));
     return S2N_SUCCESS;
 }
 
@@ -105,11 +98,10 @@ static int s2n_config_init(struct s2n_config *config)
 
     config->client_hello_cb_mode = S2N_CLIENT_HELLO_CB_BLOCKING;
 
-    POSIX_GUARD(s2n_config_setup_default(config));
-    if (s2n_use_default_tls13_config()) {
-        POSIX_GUARD(s2n_config_setup_tls13(config));
-    } else if (s2n_is_in_fips_mode()) {
+    if (s2n_is_in_fips_mode()) {
         POSIX_GUARD(s2n_config_setup_fips(config));
+    } else {
+        POSIX_GUARD(s2n_config_setup_default(config));
     }
 
     POSIX_GUARD_PTR(config->domain_name_to_cert_map = s2n_map_new_with_initial_capacity(1));
@@ -212,9 +204,6 @@ int s2n_config_build_domain_name_to_cert_map(struct s2n_config *config, struct s
 
 struct s2n_config *s2n_fetch_default_config(void)
 {
-    if (s2n_use_default_tls13_config()) {
-        return &s2n_default_tls13_config;
-    }
     if (s2n_is_in_fips_mode()) {
         return &s2n_default_fips_config;
     }
@@ -244,10 +233,6 @@ int s2n_config_defaults_init(void)
         POSIX_GUARD(s2n_config_load_system_certs(&s2n_default_config));
     }
 
-    /* TLS 1.3 default config is only used in tests so avoid initialization costs in applications */
-    POSIX_GUARD(s2n_config_init(&s2n_default_tls13_config));
-    POSIX_GUARD(s2n_config_setup_tls13(&s2n_default_tls13_config));
-
     return S2N_SUCCESS;
 }
 
@@ -255,7 +240,6 @@ void s2n_wipe_static_configs(void)
 {
     s2n_config_cleanup(&s2n_default_fips_config);
     s2n_config_cleanup(&s2n_default_config);
-    s2n_config_cleanup(&s2n_default_tls13_config);
 }
 
 int s2n_config_load_system_certs(struct s2n_config *config)

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -20,7 +20,6 @@
 #include "tls/s2n_connection.h"
 #include "utils/s2n_safety.h"
 
-
 /* TODO update the date before merge */
 /* default as of 07/01. Supports TLS 1.3 */
 const struct s2n_security_policy security_policy_20240701 = {

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -20,10 +20,12 @@
 #include "tls/s2n_connection.h"
 #include "utils/s2n_safety.h"
 
-/* TLS1.2 default as of 05/24 */
-const struct s2n_security_policy security_policy_20240501 = {
+
+/* TODO update the date before merge */
+/* default as of 07/01. Supports TLS 1.3 */
+const struct s2n_security_policy security_policy_20240701 = {
     .minimum_protocol_version = S2N_TLS12,
-    .cipher_preferences = &cipher_preferences_20240331,
+    .cipher_preferences = &cipher_preferences_20240701,
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20240501,
     .ecc_preferences = &s2n_ecc_preferences_20240501,
@@ -32,10 +34,11 @@ const struct s2n_security_policy security_policy_20240501 = {
     },
 };
 
-/* FIPS default as of 05/24 */
-const struct s2n_security_policy security_policy_20240502 = {
+/* TODO update the date before merge */
+/* FIPS default as of 07/01. Supports TLS 1.3 */
+const struct s2n_security_policy security_policy_20240702 = {
     .minimum_protocol_version = S2N_TLS12,
-    .cipher_preferences = &cipher_preferences_20240331,
+    .cipher_preferences = &cipher_preferences_20240701,
     .kem_preferences = &kem_preferences_null,
     .signature_preferences = &s2n_signature_preferences_20240501,
     .certificate_signature_preferences = &s2n_certificate_signature_preferences_20201110,
@@ -69,6 +72,30 @@ const struct s2n_security_policy security_policy_20240730 = {
     .ecc_preferences = &s2n_ecc_preferences_20240501,
     .rules = {
             [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
+};
+
+const struct s2n_security_policy security_policy_20240501 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_20240331,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20240501,
+    .ecc_preferences = &s2n_ecc_preferences_20240501,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
+};
+
+const struct s2n_security_policy security_policy_20240502 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_20240331,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20240501,
+    .certificate_signature_preferences = &s2n_certificate_signature_preferences_20201110,
+    .ecc_preferences = &s2n_ecc_preferences_20201021,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+            [S2N_FIPS_140_3] = true,
     },
 };
 
@@ -1227,10 +1254,12 @@ const struct s2n_security_policy security_policy_null = {
 };
 
 struct s2n_security_policy_selection security_policy_selection[] = {
-    { .version = "default", .security_policy = &security_policy_20240501, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "default", .security_policy = &security_policy_20240701, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "default_tls13", .security_policy = &security_policy_20240503, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
-    { .version = "default_fips", .security_policy = &security_policy_20240502, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "default_fips", .security_policy = &security_policy_20240702, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "default_pq", .security_policy = &security_policy_20241001, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "20240701", .security_policy = &security_policy_20240701, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "20240702", .security_policy = &security_policy_20240702, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20241106", .security_policy = &security_policy_20241106, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20240501", .security_policy = &security_policy_20240501, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20240502", .security_policy = &security_policy_20240502, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -94,11 +94,14 @@ struct s2n_security_policy_selection {
 
 extern struct s2n_security_policy_selection security_policy_selection[];
 
-/* Defaults as of 05/24 */
-extern const struct s2n_security_policy security_policy_20240501;
-extern const struct s2n_security_policy security_policy_20240502;
+/* Defaults as of 05/24
+ * TODO updated date*/
+extern const struct s2n_security_policy security_policy_20240701;
+extern const struct s2n_security_policy security_policy_20240702;
 extern const struct s2n_security_policy security_policy_20240503;
 
+extern const struct s2n_security_policy security_policy_20240501;
+extern const struct s2n_security_policy security_policy_20240502;
 extern const struct s2n_security_policy security_policy_20241106;
 extern const struct s2n_security_policy security_policy_20140601;
 extern const struct s2n_security_policy security_policy_20141001;

--- a/tls/s2n_tls13.c
+++ b/tls/s2n_tls13.c
@@ -20,13 +20,6 @@
 #include "crypto/s2n_rsa_signing.h"
 #include "tls/s2n_tls.h"
 
-bool s2n_use_default_tls13_config_flag = false;
-
-bool s2n_use_default_tls13_config()
-{
-    return s2n_use_default_tls13_config_flag;
-}
-
 bool s2n_is_tls13_fully_supported()
 {
     /* Older versions of Openssl (eg 1.0.2) do not support RSA PSS, which is required for TLS 1.3. */
@@ -58,7 +51,6 @@ int s2n_enable_tls13()
 int s2n_enable_tls13_in_test()
 {
     s2n_highest_protocol_version = S2N_TLS13;
-    s2n_use_default_tls13_config_flag = true;
     return S2N_SUCCESS;
 }
 
@@ -72,7 +64,6 @@ int s2n_disable_tls13_in_test()
 {
     POSIX_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
     s2n_highest_protocol_version = S2N_TLS12;
-    s2n_use_default_tls13_config_flag = false;
     return S2N_SUCCESS;
 }
 
@@ -85,7 +76,6 @@ int s2n_reset_tls13_in_test()
 {
     POSIX_ENSURE(s2n_in_unit_test(), S2N_ERR_NOT_IN_UNIT_TEST);
     s2n_highest_protocol_version = S2N_TLS13;
-    s2n_use_default_tls13_config_flag = false;
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_tls13.h
+++ b/tls/s2n_tls13.h
@@ -36,7 +36,6 @@ S2N_API __attribute__((deprecated)) int s2n_enable_tls13();
 /* from RFC: https://tools.ietf.org/html/rfc8446#section-4.1.3*/
 extern uint8_t hello_retry_req_random[S2N_TLS_RANDOM_DATA_LEN];
 
-bool s2n_use_default_tls13_config();
 bool s2n_is_tls13_fully_supported();
 int s2n_get_highest_fully_supported_tls_version();
 int s2n_enable_tls13_in_test();


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.

### Description of changes: 

Describe s2n’s current behavior and how your code changes that behavior. If there are no issues this PR is resolving, explain why this change is necessary.

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? What manual testing was performed? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

Remember:
* Any change to the library source code should at least include unit tests.
* Any change to the core stuffer or blob methods should include [CBMC proofs](https://github.com/aws/s2n-tls/tree/main/tests/cbmc).
* Any change to the CI or tests should:
   1. prove that the test succeeds for good input
   2. prove that the test fails for bad input (eg, a test for memory leaks fails when a memory leak is committed)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
