### PR TITLE
chore(integration): update well-known-endpoints

### DIFF
--- a/bindings/rust/integration/src/network/https_client.rs
+++ b/bindings/rust/integration/src/network/https_client.rs
@@ -51,7 +51,6 @@ const TEST_CASES: &[TestCase] = &[
     TestCase::new("https://www.samsung.com", 301),
     TestCase::new("https://www.twitter.com", 301),
     TestCase::new("https://www.facebook.com", 302),
-    TestCase::new("https://www.microsoft.com", 302),
     TestCase::new("https://www.ibm.com", 303),
     TestCase::new("https://www.f5.com", 403),
 ];

--- a/bindings/rust/integration/src/network/tls_client.rs
+++ b/bindings/rust/integration/src/network/tls_client.rs
@@ -76,10 +76,16 @@ mod kms_pq {
 
 #[test_log::test(tokio::test)]
 async fn tls_client() -> Result<(), Box<dyn std::error::Error>> {
-    // The akamai request should be in internet_https_client.rs but Akamai
-    // http requests hang indefinitely. This behavior is also observed with
-    // curl and chrome. https://github.com/aws/s2n-tls/issues/4883
-    const DOMAINS: &[&str] = &["www.akamai.com"];
+    const DOMAINS: &[&str] = &[
+        // The akamai request should be in internet_https_client.rs but Akamai
+        // http requests hang indefinitely. This behavior is also observed with
+        // curl and chrome. https://github.com/aws/s2n-tls/issues/4883
+        "www.akamai.com",
+        // microsoft.com started returning 403 HTTP status codes in CI, but returned 200 locally.
+        // This domain may be throttling HTTP requests from CI, so a plain TLS connection is tested
+        // instead.
+        "www.microsoft.com",
+    ];
 
     for domain in DOMAINS {
         tracing::info!("querying {domain}");


### PR DESCRIPTION
### Description of changes: 

`www.microsoft.com` started returning 403 status codes in the rust well-known-endpoints test:
https://github.com/aws/s2n-tls/actions/runs/11966043763/job/33361030837?pr=4926

However, when I run this test locally I get a 200 response. I think this may mean that this endpoint is throttling the HTTP requests from CI?

### Call-outs:

Changing the expected status code to 403 causes the test to fail locally, since a 200 code is returned. So I instead opted to just test TLS with this endpoint rather than HTTPS.

### Testing:

The rust network integration test should now succeed in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
