### PR TITLE
upgrade cmake version to 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.9)
 project (s2n C)
 
 if(POLICY CMP0077)


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

Updated CMake version from 3.0 to 3.9.

### Resolved issues:

resolves #4899 

### Description of changes: 

Updated the `cmake_minimum_required` version from 3.0 to 3.9.

### Call-outs:

### Testing:
Before this change, you'd see following warning when you build s2n-tls:
```
~/s2n-tls$ cmake . -Bbuild     -DCMAKE_BUILD_TYPE=Release     -DCMAKE_INSTALL_PREFIX=./s2n-tls-install
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Detected CMAKE_SYSTEM_PROCESSOR as x86_64
-- Detected 64-Bit system
-- LibCrypto Include Dir: /usr/include
...
```

After this change, the warning message is gone:
```
~/s2n-tls$ cmake . -Bbuild     -DCMAKE_BUILD_TYPE=Release     -DCMAKE_INSTALL_PREFIX=./s2n-tls-install
-- Detected CMAKE_SYSTEM_PROCESSOR as x86_64
-- Detected 64-Bit system
-- LibCrypto Include Dir: /usr/include
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
