### PR TITLE
(chore): Fixes team-label github action

### DIFF
--- a/.github/workflows/team_label.yml
+++ b/.github/workflows/team_label.yml
@@ -11,7 +11,7 @@ jobs:
   team-labeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: JulienKode/team-labeler-action@v1.3
+      - uses: JulienKode/team-labeler-action@v1.3.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
### Release Summary:
N/A

### Resolved issues:

N/A
### Description of changes: 

We need to use actual tags in our versions for various github actions. The parser is unfortunately not very sophisticated and doesn't know what v1.3 means since the maintainer only has a v1.3.0 tag.
See: https://github.com/orgs/community/discussions/48058
### Call-outs:

N/A

### Testing:

Note that the CI still fails because (confusingly) it isn't using my change yet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
