### PR TITLE
ci(refactor): remove ASAN from Omnibus and GeneralBatch

### DIFF
--- a/codebuild/bin/s2n_codebuild.sh
+++ b/codebuild/bin/s2n_codebuild.sh
@@ -102,7 +102,6 @@ if [[ "$TESTS" == "ALL" || "$TESTS" == "sawHMACPlus" ]] && [[ "$OS_NAME" == "lin
 if [[ "$TESTS" == "ALL" || "$TESTS" == "unit" ]]; then run_unit_tests; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "interning" ]]; then ./codebuild/bin/test_libcrypto_interning.sh; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "exec_leak" ]]; then ./codebuild/bin/test_exec_leak.sh; fi
-if [[ "$TESTS" == "ALL" || "$TESTS" == "asan" ]]; then make clean; S2N_ADDRESS_SANITIZER=1 make -j $JOBS ; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "integrationv2" ]]; then run_integration_v2_tests; fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "crt" ]]; then ./codebuild/bin/build_aws_crt_cpp.sh $(mktemp -d) $(mktemp -d); fi
 if [[ "$TESTS" == "ALL" || "$TESTS" == "sharedandstatic" ]]; then ./codebuild/bin/test_install_shared_and_static.sh $(mktemp -d); fi

--- a/codebuild/spec/buildspec_generalbatch.yml
+++ b/codebuild/spec/buildspec_generalbatch.yml
@@ -53,51 +53,6 @@ batch:
           BUILD_S2N: 'true'
           TESTS: exec_leak
       identifier: s2nExecLeak
-    - identifier: s2nAsanOpenSSL111Coverage
-      buildspec: codebuild/spec/buildspec_ubuntu.yml
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
-        privileged-mode: true
-        variables:
-          BUILD_S2N: 'true'
-          GCC_VERSION: '9'
-          S2N_COVERAGE: 'true'
-          S2N_LIBCRYPTO: 'openssl-1.1.1'
-          TESTS: asan
-    - identifier: s2nAsanAwslc
-      buildspec: codebuild/spec/buildspec_ubuntu.yml
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
-        privileged-mode: true
-        variables:
-          BUILD_S2N: 'true'
-          GCC_VERSION: '9'
-          S2N_LIBCRYPTO: 'awslc'
-          TESTS: asan
-    - identifier: s2nAsanOpenssl3
-      buildspec: codebuild/spec/buildspec_ubuntu.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
-        variables:
-          TESTS: asan
-          GCC_VERSION: '9'
-          S2N_LIBCRYPTO: 'openssl-3.0'
-          BUILD_S2N: 'true'
-    - identifier: s2nAsanOpenssl102
-      buildspec: codebuild/spec/buildspec_ubuntu.yml
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
-        privileged-mode: true
-        variables:
-          BUILD_S2N: 'true'
-          GCC_VERSION: '9'
-          S2N_LIBCRYPTO: 'openssl-1.0.2'
-          TESTS: asan
     - buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL

--- a/codebuild/spec/buildspec_omnibus.yml
+++ b/codebuild/spec/buildspec_omnibus.yml
@@ -48,31 +48,6 @@ batch:
         variables:
           TESTS: sidetrail
 
-    - identifier: s2nAsanOpenSSL111Coverage
-      buildspec: codebuild/spec/buildspec_ubuntu.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
-        variables:
-          TESTS: asan
-          GCC_VERSION: '6'
-          S2N_LIBCRYPTO: 'openssl-1.1.1'
-          BUILD_S2N: 'true'
-          S2N_COVERAGE: 'true'
-
-    - identifier: s2nAsanOpenssl102
-      buildspec: codebuild/spec/buildspec_ubuntu.yml
-      env:
-        privileged-mode: true
-        compute-type: BUILD_GENERAL1_LARGE
-        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
-        variables:
-          TESTS: asan
-          GCC_VERSION: '6'
-          S2N_LIBCRYPTO: 'openssl-1.0.2'
-          BUILD_S2N: 'true'
-
     - identifier: s2nUnitNoPQ
       buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:


### PR DESCRIPTION
### Description of changes: 

[`buildspec_sanitizer.yml`](https://github.com/aws/s2n-tls/blob/main/codebuild/spec/buildspec_sanitizer.yml) has coverages for both ASAN and UBSAN, while the current Omnibus only has ASAN coverage for two libcryptos. We want to drop those two coverages in Omnibus and run our `AddressSanitizer` job instead. Hence, this PR drop the buildspec for those two jobs. We also remove the ASAN parts in `s2nGeneralBatch`, since `AddressSanitizer` already provides coverages for those tests.

### Testing:

The results for the triggered [Omnibus job](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nOmnibus/batch/s2nOmnibus%3A4c0d8b5e-d36a-4aa0-8b22-782309b4a226?region=us-west-2), [S2nIntegrationV2Batch2 job](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/S2nIntegrationV2Batch2/batch/S2nIntegrationV2Batch2%3Abb221703-cdb5-4f0f-9207-01cc1f3b5489?region=us-west-2), [Valgrind job](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/Valgrind/batch/Valgrind%3A9be739fe-b145-4a78-bed1-d9bf97ea4899?region=us-west-2), [s2nFuzzBatch job](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nFuzzBatch/batch/s2nFuzzBatch%3A2c633087-48a5-40d0-abf8-ecdeaa0fc862?region=us-west-2), and [AddressSanitizer job](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/AddressSanitizer/batch/AddressSanitizer%3A333c8f57-6f1f-4ec4-87d0-65a0c2b25abf?region=us-west-2) are linked to this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
