### PR TITLE
test(bindings): run unit tests under asan

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -226,17 +226,21 @@ jobs:
       - name: Install Rust toolchain
         id: toolchain
         run: |
-          rustup toolchain install ${{env.RUST_NIGHTLY_TOOLCHAIN }} \
+          rustup toolchain install nightly \
             --profile minimal \
             --component rust-src \
             --target x86_64-unknown-linux-gnu
-          rustup override set ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
       
       - name: Generate
         run: ./${{env.ROOT_PATH}}/generate.sh --skip-tests
 
       - name: Run Unit Tests under ASAN
-        run: RUSTFLAGS=-Zsanitizer=address cargo test -Zbuild-std --manifest-path ${{ env.ROOT_PATH}}/Cargo.toml --target x86_64-unknown-linux-gnu
+        run: |
+          RUSTFLAGS=-Zsanitizer=address \
+            cargo +nightly test \
+            -Zbuild-std \
+            --manifest-path ${{ env.ROOT_PATH}}/Cargo.toml \
+            --target x86_64-unknown-linux-gnu
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -236,6 +236,7 @@ jobs:
         run: ./${{env.ROOT_PATH}}/generate.sh --skip-tests
 
       - name: Run Unit Tests under ASAN
+        working-directory: ${{env.ROOT_PATH}}
         run: RUSTFLAGS=-Zsanitizer=address cargo test -Zbuild-std --target x86_64-unknown-linux-gnu
 
   rustfmt:

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -235,6 +235,9 @@ jobs:
       - name: Generate
         run: ./${{env.ROOT_PATH}}/generate.sh --skip-tests
 
+      - name: check llvm symbolizer
+        run: find / -name llvm-symbolizer*
+
       - name: Run Unit Tests under ASAN
         run: |
           RUSTDOCFLAGS=-Zsanitizer=address \

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -246,9 +246,10 @@ jobs:
           sudo ln -s $(find /usr/bin/ -maxdepth 1 -name "llvm-symbolizer-*" | sort -V | tail -n 1) /usr/bin/llvm-symbolizer
 
       - name: Run Unit Tests under ASAN
+        env:
+          RUSTDOCFLAGS: -Zsanitizer=address
+          RUSTFLAGS: -Zsanitizer=address
         run: |
-          RUSTDOCFLAGS=-Zsanitizer=address \
-          RUSTFLAGS=-Zsanitizer=address \
           cargo test \
             -Zbuild-std \
             --manifest-path ${{ env.ROOT_PATH}}/Cargo.toml \

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -236,11 +236,7 @@ jobs:
         run: ./${{env.ROOT_PATH}}/generate.sh --skip-tests
 
       - name: Run Unit Tests under ASAN
-        run: RUSTFLAGS=-Zsanitizer=address \
-          cargo test \
-          -Zbuild-std \
-          --manifest-path ${{ env.ROOT_PATH}}/Cargo.toml \
-          --target x86_64-unknown-linux-gnu
+        run: RUSTFLAGS=-Zsanitizer=address cargo test -Zbuild-std --manifest-path ${{ env.ROOT_PATH}}/Cargo.toml --target x86_64-unknown-linux-gnu
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -11,7 +11,7 @@ on:
 env:
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2024-01-01
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2024-12-01
   ROOT_PATH: bindings/rust
   EXAMPLE_WORKSPACE: bindings/rust-examples
   PCAP_TEST_PATH: tests/pcap
@@ -212,6 +212,33 @@ jobs:
         working-directory: ${{env.ROOT_PATH}}
         run: |
           cargo test --tests --all-features
+
+  # Run the rust unit tests under address sanitizer.
+  #
+  # Rust is generally memory safe, but our bindings contain a large amount of unsafe
+  # code. Additionally, "safe" code doesn't guarentee that the code is free of 
+  # memory leaks.
+  asan-unit-tests:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -Zsanitizer=address
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        id: toolchain
+        run: |
+          rustup toolchain install ${{env.RUST_NIGHTLY_TOOLCHAIN }} \
+            --profile minimal \
+            --component rust-src \
+            --target x86_64-unknown-linux-gnu
+          rustup override set ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
+      
+      - name: Generate
+        run: ./${{env.ROOT_PATH}}/generate.sh --skip-tests
+
+      - name: Run Unit Tests under ASAN
+        run: cargo test -Zbuild-std --target x86_64-unknown-linux-gnu
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -220,8 +220,6 @@ jobs:
   # memory leaks.
   asan-unit-tests:
     runs-on: ubuntu-latest
-    env:
-      RUSTUP_TOOLCHAIN: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -232,13 +230,17 @@ jobs:
             --profile minimal \
             --component rust-src \
             --target x86_64-unknown-linux-gnu
+          rustup override set ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
       
       - name: Generate
         run: ./${{env.ROOT_PATH}}/generate.sh --skip-tests
 
       - name: Run Unit Tests under ASAN
-        working-directory: ${{env.ROOT_PATH}}
-        run: RUSTFLAGS=-Zsanitizer=address cargo test -Zbuild-std --target x86_64-unknown-linux-gnu
+        run: RUSTFLAGS=-Zsanitizer=address \
+          cargo test \
+          -Zbuild-std \
+          --manifest-path ${{ env.ROOT_PATH}}/Cargo.toml \
+          --target x86_64-unknown-linux-gnu
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -220,8 +220,6 @@ jobs:
   # memory leaks.
   asan-unit-tests:
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: -Zsanitizer=address
     steps:
       - uses: actions/checkout@v4
 
@@ -238,7 +236,7 @@ jobs:
         run: ./${{env.ROOT_PATH}}/generate.sh --skip-tests
 
       - name: Run Unit Tests under ASAN
-        run: cargo test -Zbuild-std --target x86_64-unknown-linux-gnu
+        run: RUSTFLAGS=-Zsanitizer=address cargo test -Zbuild-std --target x86_64-unknown-linux-gnu
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -226,18 +226,20 @@ jobs:
       - name: Install Rust toolchain
         id: toolchain
         run: |
-          rustup toolchain install nightly \
+          rustup toolchain install ${{env.RUST_NIGHTLY_TOOLCHAIN }} \
             --profile minimal \
             --component rust-src \
             --target x86_64-unknown-linux-gnu
+          rustup override set ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
       
       - name: Generate
         run: ./${{env.ROOT_PATH}}/generate.sh --skip-tests
 
       - name: Run Unit Tests under ASAN
         run: |
+          RUSTDOCFLAGS=-Zsanitizer=address \
           RUSTFLAGS=-Zsanitizer=address \
-            cargo +nightly test \
+            cargo test \
             -Zbuild-std \
             --manifest-path ${{ env.ROOT_PATH}}/Cargo.toml \
             --target x86_64-unknown-linux-gnu

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -220,6 +220,8 @@ jobs:
   # memory leaks.
   asan-unit-tests:
     runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -230,7 +232,6 @@ jobs:
             --profile minimal \
             --component rust-src \
             --target x86_64-unknown-linux-gnu
-          rustup override set ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
       
       - name: Generate
         run: ./${{env.ROOT_PATH}}/generate.sh --skip-tests

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -235,8 +235,13 @@ jobs:
       - name: Generate
         run: ./${{env.ROOT_PATH}}/generate.sh --skip-tests
 
-      - name: check llvm symbolizer
-        run: find / -name llvm-symbolizer*
+      # asan expects a binary at /usr/bin/llvm-symbolizer but GHA runners include
+      # multiple explicit binaries. /usr/bin/llvm-symbolizer-13, etc
+      # This script will find the latest symbolizer and use it as the "base"
+      # llvm-symbolizer binary.
+      - name: set llvm symbolizer
+        run: |
+          sudo ln -s $(find /usr/bin/ -maxdepth 1 -name "llvm-symbolizer-*" | sort -V | tail -n 1) /usr/bin/llvm-symbolizer
 
       - name: Run Unit Tests under ASAN
         run: |

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -236,9 +236,11 @@ jobs:
         run: ./${{env.ROOT_PATH}}/generate.sh --skip-tests
 
       # asan expects a binary at /usr/bin/llvm-symbolizer but GHA runners include
-      # multiple explicit binaries. /usr/bin/llvm-symbolizer-13, etc
-      # This script will find the latest symbolizer and use it as the "base"
-      # llvm-symbolizer binary.
+      # multiple versioned binaries, like /usr/bin/llvm-symbolizer-13. This step
+      # finds the latest symbolizer and use it as the "base" llvm-symbolizer binary.
+      #
+      # llvm-symbolizer is necessary to get nice stack traces from asan errors. 
+      # Otherwise the stack trace just contains a hex address like "0x55bc6a28a9b6"
       - name: set llvm symbolizer
         run: |
           sudo ln -s $(find /usr/bin/ -maxdepth 1 -name "llvm-symbolizer-*" | sort -V | tail -n 1) /usr/bin/llvm-symbolizer

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -239,7 +239,7 @@ jobs:
         run: |
           RUSTDOCFLAGS=-Zsanitizer=address \
           RUSTFLAGS=-Zsanitizer=address \
-            cargo test \
+          cargo test \
             -Zbuild-std \
             --manifest-path ${{ env.ROOT_PATH}}/Cargo.toml \
             --target x86_64-unknown-linux-gnu

--- a/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
+++ b/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
@@ -23,8 +23,6 @@ mod tests {
 
     #[test]
     fn handshake_default_tls13() {
-        let arced = Arc::new(5);
-        std::mem::forget(arced);
         let config = build_config(&security::DEFAULT_TLS13).unwrap();
         assert!(TestPair::handshake_with_config(&config).is_ok());
     }

--- a/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
+++ b/bindings/rust/s2n-tls/src/testing/s2n_tls.rs
@@ -23,6 +23,8 @@ mod tests {
 
     #[test]
     fn handshake_default_tls13() {
+        let arced = Arc::new(5);
+        std::mem::forget(arced);
         let config = build_config(&security::DEFAULT_TLS13).unwrap();
         assert!(TestPair::handshake_with_config(&config).is_ok());
     }


### PR DESCRIPTION
### Description of changes: 

We want to ensure that _none_ of our unit tests are leaking memory.

We currently use "checkers" for some of our tests, but this requires us to manually annotate each test with the `checkers::test` macro.

Instead of doing that, we can just use Rust's existing [address sanitizer](https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html#addresssanitizer) support to check for memory leaks in all of the tests.

### Testing:

All existing tests should pass.

Additionally, I pushed a commit containing a memory leak [here](https://github.com/aws/s2n-tls/pull/4948/commits/4128517ba060c7cb4715c4e6ae1d1e19b7b6eedd). You can see the failed asan job for that commit [here](https://github.com/aws/s2n-tls/actions/runs/12151988381/job/33887560249?pr=4948)
```
 =================================================================
==8298==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x55c17b9a2eaf in malloc /rustc/llvm/src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x55c17ba2ce2b in std::sys::alloc::unix::_$LT$impl$u20$core..alloc..global..GlobalAlloc$u20$for$u20$std..alloc..System$GT$::alloc::h3cfff84b03a4b754 /home/runner/.rustup/toolchains/nightly-2024-12-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/alloc/unix.rs:14:22
    #2 0x55c17ba22589 in _$LT$checkers..allocator..Allocator$LT$T$GT$$u20$as$u20$core..alloc..global..GlobalAlloc$GT$::alloc::h457eba1cc841aa88 /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/checkers-0.6.3/src/allocator.rs:54:19
    #3 0x55c17ba67a91 in __rust_alloc /home/runner/work/s2n-tls/s2n-tls/bindings/rust/s2n-tls/src/lib.rs:11:19
    #4 0x55c17ba78fd4 in alloc::alloc::Global::alloc_impl::h3f5294fc6a51959a /home/runner/.rustup/toolchains/nightly-2024-12-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:195:73
    #5 0x55c17ba79388 in _$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$::allocate::h5d31da0bd5bc3bca /home/runner/.rustup/toolchains/nightly-2024-12-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:257:9
    #6 0x55c17ba689b6 in s2n_tls::testing::s2n_tls::tests::handshake_default_tls13::_$u7b$$u7b$closure$u7d$$u7d$::h335262bad34403ec /home/runner/work/s2n-tls/s2n-tls/bindings/rust/s2n-tls/src/testing/s2n_tls.rs:25:33
    #7 0x55c17bb4d6aa in test::types::RunnableTest::run::h5819b201521a79fb /home/runner/.rustup/toolchains/nightly-2024-12-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/test/src/types.rs:145:40
    <SNIP>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
