### PR TITLE
ci: add change directory to third-party-src logic

### DIFF
--- a/codebuild/spec/buildspec_32bit_cross_compile.yml
+++ b/codebuild/spec/buildspec_32bit_cross_compile.yml
@@ -14,6 +14,12 @@
 version: 0.2
 
 phases:
+  pre_build:
+    commands:
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
   build:
     on-failure: ABORT
     commands:

--- a/codebuild/spec/buildspec_musl.yml
+++ b/codebuild/spec/buildspec_musl.yml
@@ -22,10 +22,6 @@ phases:
   pre_build:
     on-failure: ABORT
     commands:
-      - |
-        if [ -d "third-party-src" ]; then
-          cd third-party-src;
-        fi
       # Install musl libc
       - git clone --depth=1 https://git.musl-libc.org/git/musl $MUSL_DIR
       - echo "Installing musl to $CODEBUILD_SRC_DIR/$MUSL_DIR"

--- a/codebuild/spec/buildspec_musl.yml
+++ b/codebuild/spec/buildspec_musl.yml
@@ -22,6 +22,10 @@ phases:
   pre_build:
     on-failure: ABORT
     commands:
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
       # Install musl libc
       - git clone --depth=1 https://git.musl-libc.org/git/musl $MUSL_DIR
       - echo "Installing musl to $CODEBUILD_SRC_DIR/$MUSL_DIR"

--- a/codebuild/spec/buildspec_tsan.yml
+++ b/codebuild/spec/buildspec_tsan.yml
@@ -14,6 +14,12 @@
 version: 0.2
 
 phases:
+  pre_build:
+    commands:
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
   build:
     on-failure: ABORT
     commands:

--- a/codebuild/spec/buildspec_ubuntu_cmake.yml
+++ b/codebuild/spec/buildspec_ubuntu_cmake.yml
@@ -14,6 +14,12 @@
 version: 0.2
 
 phases:
+  pre_build:
+    commands:
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
   build:
     on-failure: ABORT
     commands:


### PR DESCRIPTION
### Description of changes: 

We want to use `GeneralBatch` to replace `Omnibus`. After PR https://github.com/aws/s2n-tls/pull/4913, PR https://github.com/aws/s2n-tls/pull/4945, and PR https://github.com/aws/s2n-tls/pull/4946 are merged, `GeneralBatch` provides more coverage than `Omnibus`, so we can use `GeneralBatch` to deprecate the rest of `Omnibus`. However, there are four buildspec files in `GeneralBatch` that are lacking the logic to cd into the `third-party-src` directory during the release process. Hence, this PR will add those logics for the release process to run properly.

### Call-outs:

Another way to resolve such problem is to remove the `third-party-src` directory. However, that would present risks for users who build s2n-tls with their own scripts. Some of their directories might conflict with ours.

### Testing:

`GeneralBatch` will be triggered by the Lambda function. Testing results is attached to this PR:
[`s2nGeneralBatch`](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nGeneralBatch/batch/s2nGeneralBatch%3A70e54f67-41bb-44cf-b040-332e3a7f7f40?region=us-west-2).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
