### PR TITLE
ci: batch dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,19 +10,27 @@ updates:
     directory: "/.github/workflows"
     schedule:
       interval: "daily"
-    # GHA version updates are relatively safe, so batch them all together into a
-    # single PR.
     groups:
-      gha-updates:
+      all-gha-updates:
         patterns:
           - "*"
 
-  # Maintain dependencies for cargo
+  # restricted-MSRV, so don't do batch updates
   - package-ecosystem: "cargo"
     directories:
       - "/bindings/rust"
+    schedule:
+      interval: "daily"
+
+  # permissive-MSRV, batch updates are acceptable
+  - package-ecosystem: "cargo"
+    directories:
       - "/bindings/rust-examples"
       - "/tests/pcap"
       - "/tests/regression"
     schedule:
       interval: "daily"
+    groups:
+      all-cargo-updates:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
     directory: "/.github/workflows"
     schedule:
       interval: "daily"
+    # GHA version updates are relatively safe, so batch them all together into a
+    # single PR.
+    groups:
+      gha-updates:
+        patterns:
+          - "*"
 
   # Maintain dependencies for cargo
   - package-ecosystem: "cargo"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,13 +15,6 @@ updates:
         patterns:
           - "*"
 
-  # restricted-MSRV, so don't do batch updates
-  - package-ecosystem: "cargo"
-    directories:
-      - "/bindings/rust"
-    schedule:
-      interval: "daily"
-
   # permissive-MSRV, batch updates are acceptable
   - package-ecosystem: "cargo"
     directories:
@@ -34,3 +27,10 @@ updates:
       all-cargo-updates:
         patterns:
           - "*"
+
+  # restricted-MSRV, so don't do batch updates
+  - package-ecosystem: "cargo"
+    directories:
+      - "/bindings/rust"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
### Description of changes: 

Enable batch updates for everything except the MSRV restricted crates (s2n-tls, s2n-tls-tokio, etc)

We don't turn this on for MSRV restricted crates because I expect that most of those are not going to be acceptable, and I want to avoid a ball-of-spaghetti mess.

### Testing:

Very open to testing suggestions. I guess I could set it up on a fork? Although that feels like a lot of toil for a CI change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
