### PR TITLE
ci: update CRT test ubuntu version to ubuntu24

### DIFF
--- a/codebuild/spec/buildspec_generalbatch.yml
+++ b/codebuild/spec/buildspec_generalbatch.yml
@@ -177,10 +177,10 @@ batch:
     - buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE
-        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu24
         privileged-mode: true
         variables:
-          GCC_VERSION: '6'
+          GCC_VERSION: '13'
           TESTS: crt
       identifier: s2nUnitCRT
     - buildspec: codebuild/spec/buildspec_ubuntu.yml


### PR DESCRIPTION
### Description of changes: 

Our CI is blocked by CRT. Currently, CRT-CPP can't properly prebuild AWSLC on Ubuntu 18. Hence, I tried to update the Ubuntu version to 24, and it successfully build AWSLC on a newer platform. I have already created an issue for the CRT team to ask questions: https://github.com/awslabs/aws-crt-cpp/issues/691.

### Call-outs:

* Update the CRT test's Ubuntu version to Ubuntu 24 is a step that we want to take to upgrade our CI to use newer versions of Ubuntu in general. https://github.com/aws/s2n-tls/issues/4537

### Testing:

This PR will be tested by the CI. I have already verified that CRT test will pass on this PR.
Refer to the [result of `s2nGeneralBatch`](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/s2nGeneralBatch/batch/s2nGeneralBatch%3A18c830fd-9c74-4b96-a21e-a3d9e157df07?region=us-west-2) for further testing details.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
