### PR TITLE
ci: improve fips mode coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,11 +101,6 @@ else()
     set(OS_LIBS Threads::Threads dl rt)
 endif()
 
-# Compiling the unit tests rely on S2N_TEST_IN_FIPS_MODE to be set correctly
-if(S2N_FIPS)
-    add_definitions(-DS2N_TEST_IN_FIPS_MODE)
-endif()
-
 file(GLOB S2N_HEADERS
     ${API_HEADERS}
     ${API_UNSTABLE_HEADERS}
@@ -469,6 +464,14 @@ target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURR
 if (BUILD_TESTING)
     enable_testing()
 
+    # FIPS mode is optional for Openssl and must be deliberately configured
+    if ($ENV{S2N_LIBCRYPTO} MATCHES "openssl" AND $ENV{S2N_LIBCRYPTO} MATCHES "fips")
+        set(TEST_FIPS_MODES true false)
+        message(STATUS "Building against $ENV{S2N_LIBCRYPTO}: will test FIPS modes")
+    else()
+        set(TEST_FIPS_MODES false)
+    endif()
+
     ############################################################################
     ################### build testlib (utility library) ########################
     ############################################################################
@@ -562,8 +565,14 @@ if (BUILD_TESTING)
 
     file(GLOB UNITTESTS_SRC "tests/unit/*.c")
     foreach(test_case ${UNITTESTS_SRC})
+    foreach(fips_mode ${TEST_FIPS_MODES})
         # NAME_WE: name without extension
         get_filename_component(test_case_name ${test_case} NAME_WE)
+
+        if(fips_mode)
+            set(test_case_name ${test_case_name}+fips)
+            set(target_compile_definitions(${test_case_name} PRIVATE S2N_TEST_IN_FIPS_MODE))
+        endif()
 
         add_executable(${test_case_name} ${test_case})
         target_link_libraries(${test_case_name} PRIVATE testss2n)
@@ -592,6 +601,7 @@ if (BUILD_TESTING)
         set_property(TEST ${test_case_name} PROPERTY LABELS "unit")
         set_property(TEST ${test_case_name} PROPERTY ENVIRONMENT ${UNIT_TEST_ENVS})
 
+    endforeach(fips_mode)
     endforeach(test_case)
 
     ############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,7 +465,7 @@ if (BUILD_TESTING)
     enable_testing()
 
     # FIPS mode is optional for Openssl and must be deliberately configured
-    if ($ENV{S2N_LIBCRYPTO} MATCHES "openssl" AND $ENV{S2N_LIBCRYPTO} MATCHES "fips")
+    if ("$ENV{S2N_LIBCRYPTO}" MATCHES "openssl" AND "$ENV{S2N_LIBCRYPTO}" MATCHES "fips")
         set(TEST_FIPS_MODES true false)
         message(STATUS "Building against $ENV{S2N_LIBCRYPTO}: will test FIPS modes")
     else()

--- a/codebuild/spec/buildspec_sanitizer.yml
+++ b/codebuild/spec/buildspec_sanitizer.yml
@@ -63,7 +63,7 @@ batch:
         variables:
           S2N_LIBCRYPTO: openssl-1.0.2
           COMPILER: clang
-    - identifier: clang_openssl_1_0_2-fips
+    - identifier: clang_openssl_1_0_2_fips
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
@@ -93,7 +93,7 @@ batch:
         variables:
           S2N_LIBCRYPTO: openssl-1.0.2
           COMPILER: gcc
-    - identifier: gcc_openssl_1_0_2-fips
+    - identifier: gcc_openssl_1_0_2_fips
       env:
         compute-type: BUILD_GENERAL1_LARGE
         variables:

--- a/codebuild/spec/buildspec_sanitizer.yml
+++ b/codebuild/spec/buildspec_sanitizer.yml
@@ -63,6 +63,12 @@ batch:
         variables:
           S2N_LIBCRYPTO: openssl-1.0.2
           COMPILER: clang
+    - identifier: clang_openssl_1_0_2-fips
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          S2N_LIBCRYPTO: openssl-1.0.2-fips
+          COMPILER: clang
     - identifier: gcc_awslc
       env:
         compute-type: BUILD_GENERAL1_LARGE
@@ -86,6 +92,12 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           S2N_LIBCRYPTO: openssl-1.0.2
+          COMPILER: gcc
+    - identifier: gcc_openssl_1_0_2-fips
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          S2N_LIBCRYPTO: openssl-1.0.2-fips
           COMPILER: gcc
 
 phases:


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

Improve fips mode coverage. Unit tests enable fips mode when S2N_TEST_IN_FIPS_MODE is defined: [see code](https://github.com/aws/s2n-tls/blob/76cba020c2b3473b6b630db1ca30b34eb85e5f35/tests/s2n_test.h#L218-L234).

When testing an openssl version that supports fips, this change causes the unit tests to test both fips and non-fips modes. Alternatively, we could just always test fips mode. Since we also test versions of openssl that don't support fips, that arguably wouldn't lose much coverage (although the exact version tested will always be different due to fips lagging behind). I'm curious for other opinions on what testing is sufficient.

### Testing:

Existing tests pass. If you examine the output of one of the openssl-1.0.2-fips builds, you can now see both normal and "+fips" versions of each unit test.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
