### PR TITLE
feat(s2n-tls-hyper): Allow plain HTTP connections

### DIFF
--- a/bindings/rust/s2n-tls-hyper/src/connector.rs
+++ b/bindings/rust/s2n-tls-hyper/src/connector.rs
@@ -119,7 +119,7 @@ pub struct Builder<Http, ConnBuilder> {
 }
 
 impl<Http, ConnBuilder> Builder<Http, ConnBuilder> {
-    /// Allows communication with insecure HTTP endpoints in addition to secure HTTPS endpoints.
+    /// If enabled, allows communication with insecure HTTP endpoints in addition to secure HTTPS endpoints (default: false).
     pub fn with_insecure_http(&mut self, enabled: bool) -> &mut Self {
         self.insecure_http = enabled;
         self

--- a/bindings/rust/s2n-tls-hyper/src/connector.rs
+++ b/bindings/rust/s2n-tls-hyper/src/connector.rs
@@ -120,8 +120,8 @@ pub struct Builder<Http, ConnBuilder> {
 
 impl<Http, ConnBuilder> Builder<Http, ConnBuilder> {
     /// Allows communication with insecure HTTP endpoints in addition to secure HTTPS endpoints.
-    pub fn with_insecure_http(&mut self) -> &mut Self {
-        self.insecure_http = true;
+    pub fn with_insecure_http(&mut self, enabled: bool) -> &mut Self {
+        self.insecure_http = enabled;
         self
     }
 
@@ -271,6 +271,15 @@ mod tests {
 
         // Ensure that the error can produce a valid message
         assert!(!error.to_string().is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn default_builder() -> Result<(), Box<dyn StdError>> {
+        // Ensure that insecure HTTP is disabled by default.
+        let connector = HttpsConnector::builder(Config::default()).build();
+        assert!(!connector.insecure_http);
 
         Ok(())
     }

--- a/bindings/rust/s2n-tls-hyper/src/connector.rs
+++ b/bindings/rust/s2n-tls-hyper/src/connector.rs
@@ -27,6 +27,7 @@ use tower_service::Service;
 pub struct HttpsConnector<Http, ConnBuilder = Config> {
     http: Http,
     conn_builder: ConnBuilder,
+    insecure_http: bool,
 }
 
 impl<ConnBuilder> HttpsConnector<HttpConnector, ConnBuilder>
@@ -101,7 +102,11 @@ where
     /// configured on `conn_builder` with APIs like
     /// `s2n_tls::config::Builder::set_application_protocol_preference()` will be ignored.
     pub fn builder_with_http(http: Http, conn_builder: ConnBuilder) -> Builder<Http, ConnBuilder> {
-        Builder { http, conn_builder }
+        Builder {
+            http,
+            conn_builder,
+            insecure_http: false,
+        }
     }
 }
 
@@ -110,14 +115,22 @@ where
 pub struct Builder<Http, ConnBuilder> {
     http: Http,
     conn_builder: ConnBuilder,
+    insecure_http: bool,
 }
 
 impl<Http, ConnBuilder> Builder<Http, ConnBuilder> {
+    /// Allows communication with insecure HTTP endpoints in addition to secure HTTPS endpoints.
+    pub fn with_insecure_http(&mut self) -> &mut Self {
+        self.insecure_http = true;
+        self
+    }
+
     /// Builds a new `HttpsConnector`.
     pub fn build(self) -> HttpsConnector<Http, ConnBuilder> {
         HttpsConnector {
             http: self.http,
             conn_builder: self.conn_builder,
+            insecure_http: self.insecure_http,
         }
     }
 }
@@ -155,10 +168,18 @@ where
     }
 
     fn call(&mut self, req: Uri) -> Self::Future {
-        // Currently, the only supported stream type is TLS. If the application attempts to
-        // negotiate HTTP over plain TCP, return an error.
-        if req.scheme() == Some(&http::uri::Scheme::HTTP) {
-            return Box::pin(async move { Err(Error::InvalidScheme) });
+        match req.scheme() {
+            Some(scheme) if scheme == &http::uri::Scheme::HTTPS => (),
+            Some(scheme) if scheme == &http::uri::Scheme::HTTP && self.insecure_http => {
+                let call = self.http.call(req);
+                return Box::pin(async move {
+                    let tcp = call.await.map_err(|e| Error::HttpError(e.into()))?;
+                    Ok(MaybeHttpsStream::Http(tcp))
+                });
+            }
+            _ => {
+                return Box::pin(async move { Err(Error::InvalidScheme) });
+            }
         }
 
         // Attempt to negotiate HTTP/2 by including it in the ALPN extension. Other supported HTTP
@@ -235,15 +256,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_unsecure_http() -> Result<(), Box<dyn StdError>> {
+    async fn test_invalid_scheme() -> Result<(), Box<dyn StdError>> {
         let connector = HttpsConnector::new(Config::default());
         let client: Client<_, Empty<Bytes>> =
             Client::builder(TokioExecutor::new()).build(connector);
 
-        let uri = Uri::from_str("http://www.amazon.com")?;
+        // Attempt to make a request with an arbitrary invalid scheme.
+        let uri = Uri::from_str("notascheme://www.amazon.com")?;
         let error = client.get(uri).await.unwrap_err();
 
-        // Ensure that an InvalidScheme error is returned when HTTP over TCP is attempted.
+        // Ensure that an InvalidScheme error is returned.
         let error = error.source().unwrap().downcast_ref::<Error>().unwrap();
         assert!(matches!(error, Error::InvalidScheme));
 

--- a/bindings/rust/s2n-tls-hyper/src/stream.rs
+++ b/bindings/rust/s2n-tls-hyper/src/stream.rs
@@ -15,11 +15,8 @@ use std::{
 };
 
 /// `MaybeHttpsStream` is a wrapper over a hyper TCP stream, `Transport`, allowing for TLS to be
-/// negotiated over the TCP stream.
-///
-/// While not currently implemented, the `MaybeHttpsStream` enum will provide an `Http` type
-/// corresponding to the plain TCP stream, allowing for HTTP to be negotiated in addition to HTTPS
-/// when the HTTP scheme is used.
+/// negotiated over the TCP stream via the `Https` type. The `Http` type bypasses TLS to optionally
+/// allow for communication with HTTP endpoints over plain TCP.
 ///
 /// This struct is used to implement `tower_service::Service` for `HttpsConnector`, and shouldn't
 /// need to be used directly.
@@ -38,6 +35,7 @@ where
     // traits to tokio's. This allows the `Read` and `Write` implementations for `MaybeHttpsStream`
     // to simply call the `TokioIo` `poll` functions.
     Https(TokioIo<TlsStream<TokioIo<Transport>, Builder::Output>>),
+    Http(Transport),
 }
 
 impl<Transport, Builder> HyperConnection for MaybeHttpsStream<Transport, Builder>
@@ -48,7 +46,7 @@ where
 {
     fn connected(&self) -> Connected {
         match self {
-            MaybeHttpsStream::Https(stream) => {
+            Self::Https(stream) => {
                 let connected = stream.inner().get_ref().connected();
                 let conn = stream.inner().as_ref();
                 match conn.application_protocol() {
@@ -57,6 +55,7 @@ where
                     _ => connected,
                 }
             }
+            Self::Http(stream) => stream.connected(),
         }
     }
 }
@@ -74,6 +73,7 @@ where
     ) -> Poll<Result<(), Error>> {
         match Pin::get_mut(self) {
             Self::Https(stream) => Pin::new(stream).poll_read(cx, buf),
+            Self::Http(stream) => Pin::new(stream).poll_read(cx, buf),
         }
     }
 }
@@ -91,18 +91,21 @@ where
     ) -> Poll<Result<usize, Error>> {
         match Pin::get_mut(self) {
             Self::Https(stream) => Pin::new(stream).poll_write(cx, buf),
+            Self::Http(stream) => Pin::new(stream).poll_write(cx, buf),
         }
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
         match Pin::get_mut(self) {
-            MaybeHttpsStream::Https(stream) => Pin::new(stream).poll_flush(cx),
+            Self::Https(stream) => Pin::new(stream).poll_flush(cx),
+            Self::Http(stream) => Pin::new(stream).poll_flush(cx),
         }
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
         match Pin::get_mut(self) {
-            MaybeHttpsStream::Https(stream) => Pin::new(stream).poll_shutdown(cx),
+            Self::Https(stream) => Pin::new(stream).poll_shutdown(cx),
+            Self::Http(stream) => Pin::new(stream).poll_shutdown(cx),
         }
     }
 }

--- a/bindings/rust/s2n-tls-hyper/tests/common/echo.rs
+++ b/bindings/rust/s2n-tls-hyper/tests/common/echo.rs
@@ -11,7 +11,7 @@ use s2n_tls_tokio::TlsAcceptor;
 use std::{error::Error, future::Future};
 use tokio::net::TcpListener;
 
-async fn echo(
+pub async fn echo(
     req: Request<hyper::body::Incoming>,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
     Ok(Response::new(req.into_body().boxed()))

--- a/bindings/rust/s2n-tls-hyper/tests/http.rs
+++ b/bindings/rust/s2n-tls-hyper/tests/http.rs
@@ -360,9 +360,7 @@ async fn insecure_http() -> Result<(), Box<dyn Error + Send + Sync>> {
             let connector = {
                 let config = common::config()?.build()?;
                 let mut builder = HttpsConnector::builder(config);
-                if enable_insecure_http {
-                    builder.with_insecure_http();
-                }
+                builder.with_insecure_http(enable_insecure_http);
                 builder.build()
             };
 
@@ -376,7 +374,7 @@ async fn insecure_http() -> Result<(), Box<dyn Error + Send + Sync>> {
                 let response = response.unwrap();
                 assert_eq!(response.status(), 200);
             } else {
-                // By default, insecure HTTP is disabled, and the request should error.
+                // If insecure HTTP is disabled, the request should error.
                 let error = response.unwrap_err();
 
                 // Ensure an InvalidScheme error is produced.

--- a/bindings/rust/s2n-tls-hyper/tests/http.rs
+++ b/bindings/rust/s2n-tls-hyper/tests/http.rs
@@ -339,7 +339,7 @@ async fn config_alpn_ignored() -> Result<(), Box<dyn Error + Send + Sync>> {
 }
 
 #[tokio::test]
-async fn insecure_http() -> Result<(), Box<dyn Error + Send + Sync>> {
+async fn plaintext_http() -> Result<(), Box<dyn Error + Send + Sync>> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
 
@@ -356,11 +356,11 @@ async fn insecure_http() -> Result<(), Box<dyn Error + Send + Sync>> {
     });
 
     tasks.spawn(async move {
-        for enable_insecure_http in [false, true] {
+        for enable_plaintext_http in [false, true] {
             let connector = {
                 let config = common::config()?.build()?;
                 let mut builder = HttpsConnector::builder(config);
-                builder.with_insecure_http(enable_insecure_http);
+                builder.with_plaintext_http(enable_plaintext_http);
                 builder.build()
             };
 
@@ -369,12 +369,12 @@ async fn insecure_http() -> Result<(), Box<dyn Error + Send + Sync>> {
             let uri = Uri::from_str(format!("http://127.0.0.1:{}", addr.port()).as_str())?;
             let response = client.get(uri).await;
 
-            if enable_insecure_http {
-                // If insecure HTTP is enabled, the request should succeed.
+            if enable_plaintext_http {
+                // If plaintext HTTP is enabled, the request should succeed.
                 let response = response.unwrap();
                 assert_eq!(response.status(), 200);
             } else {
-                // If insecure HTTP is disabled, the request should error.
+                // If plaintext HTTP is disabled, the request should error.
                 let error = response.unwrap_err();
 
                 // Ensure an InvalidScheme error is produced.


### PR DESCRIPTION
### Description of changes: 

Currently, an `HttpsConnector` can only be used to make secure HTTPS requests over TLS. If communication with an insecure HTTP endpoint is attempted, an `InvalidScheme` error is returned. This behavior prevents accidentally bypassing TLS if an insecure endpoint is provided.

However, this behavior may be desirable in some circumstances, if communication with both HTTPS and HTTP endpoints is required. This PR allows an `HttpsConnector` to be constructed with an `insecure_http` option, allowing for HTTP over plain TCP to be communicated if an HTTP route is provided. 

### Call-outs:

Previously we were erroring for HTTP schemes but permitting _all_ other schemes (not just HTTPS). This was changed to now error for all unexpected schemes.

Is `with_insecure_http` a good name for the API? Other possible options:
- `with_https_or_http` ([the equivalent hyper-rustls API](https://github.com/rustls/hyper-rustls/blob/cbf6c967cc7f59bf4cd28d507ddc15294771f719/src/connector/builder.rs#L193))
- `with_http`

### Testing:

Added a new localhost plain TCP HTTP test, which ensures that TLS is successfully bypassed, and that the plain HTTP option is disabled by default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
