### PR TITLE
ci: correctly read environment variable from CodeBuild configuration for scheduled fuzz test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -678,8 +678,10 @@ if (BUILD_TESTING)
         target_include_directories(fuzztest PUBLIC tests)
         target_link_libraries(fuzztest PUBLIC ${PROJECT_NAME})
 
-        # Set default values for fuzzing if not defined
-        if(NOT DEFINED FUZZ_TIMEOUT_SEC)
+        # Set default values for fuzzing
+        if(DEFINED ENV{FUZZ_TIMEOUT_SEC})
+            set(FUZZ_TIMEOUT_SEC $ENV{FUZZ_TIMEOUT_SEC})    
+        else()
             set(FUZZ_TIMEOUT_SEC 60)
         endif()
 


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

Currently scheduled fuzz test only runs for 60 seconds, even though we set FUZZ_TIMEOUT_SEC environment variable to a longer duration on CodeBuild project configuration. This PR fixes it by correctly reading the value from system environment.

### Description of changes: 

Updated to use `ENV` keyword for reading timeout values from CodeBuild's system environment variables, replacing the previous approach of passing timeout via -D argument, which was removed in PR #4960.

### Call-outs:

### Testing:

Overridden scheduled fuzz test with 300 seconds timeout. Default is 60 seconds: [Link to CodeBuild job](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/FuzzScheduled/build/FuzzScheduled%3A82148a33-0ad2-4710-8ba3-44645a5a3b3e?region=us-west-2)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
