### PR TITLE
feat: update scripts to use OpenSSL 3

### DIFF
--- a/.github/install_osx_dependencies.sh
+++ b/.github/install_osx_dependencies.sh
@@ -26,4 +26,4 @@ brew_install_if_not_installed coreutils
 brew_install_if_not_installed cppcheck
 brew_install_if_not_installed pkg-config  # for gnutls compilation
 brew_install_if_not_installed ninja
-brew_install_if_not_installed openssl@1.1 # for libcrypto
+brew_install_if_not_installed openssl@3 # for libcrypto

--- a/.github/s2n_osx.sh
+++ b/.github/s2n_osx.sh
@@ -17,14 +17,14 @@ set -eu
 source codebuild/bin/s2n_setup_env.sh
 
 export CTEST_OUTPUT_ON_FAILURE=1
-BREWINSTLLPATH=$(brew --prefix openssl@1.1)
-OPENSSL_1_1_1_INSTALL_DIR="${BREWINSTLLPATH:-"/usr/local/Cellar/openssl@1.1/1.1.1?"}"
+BREWINSTLLPATH=$(brew --prefix openssl@3)
+OPENSSL_3_INSTALL_DIR="${BREWINSTLLPATH:-"/usr/local/Cellar/openssl@3/3.0.0?"}"
 
-echo "Using OpenSSL at $OPENSSL_1_1_1_INSTALL_DIR"
+echo "Using OpenSSL at $OPENSSL_3_INSTALL_DIR"
 # Build with debug symbols and a specific OpenSSL version
 cmake . -Bbuild -GNinja \
 -DCMAKE_BUILD_TYPE=Debug \
--DCMAKE_PREFIX_PATH=${OPENSSL_1_1_1_INSTALL_DIR} ..
+-DCMAKE_PREFIX_PATH=${OPENSSL_3_INSTALL_DIR} ..
 
 cmake --build ./build -j $(nproc)
 time CTEST_PARALLEL_LEVEL=$(nproc) ninja -C build test
@@ -32,7 +32,7 @@ time CTEST_PARALLEL_LEVEL=$(nproc) ninja -C build test
 # Build shared library
 cmake . -Bbuild -GNinja \
 -DCMAKE_BUILD_TYPE=Debug \
--DCMAKE_PREFIX_PATH=${OPENSSL_1_1_1_INSTALL_DIR} .. \
+-DCMAKE_PREFIX_PATH=${OPENSSL_3_INSTALL_DIR} .. \
 -DBUILD_SHARED_LIBS=ON
 
 cmake --build ./build -j $(nproc)


### PR DESCRIPTION
### Description of changes: 

since [1.3.22 release](https://github.com/Homebrew/homebrew-core/pull/111633), homebrew has switched to use openssl@3, also openssl@1.1 has been [disabled on the homebrew side](https://github.com/Homebrew/homebrew-core/pull/193232) for quite some time.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
