### PR TITLE
ci: fix regression test paths

### DIFF
--- a/.github/workflows/regression_ci.yml
+++ b/.github/workflows/regression_ci.yml
@@ -8,8 +8,6 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - tests/regression/**
   merge_group:
     types: [checks_requested]
     branches: [main]

--- a/tests/regression/Cargo.toml
+++ b/tests/regression/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-s2n-tls = { version = "=0.3", path = "../../bindings/rust/s2n-tls", features = ["unstable-testing"] }
-s2n-tls-sys = { version = "=0.3", path = "../../bindings/rust/s2n-tls-sys" }
+s2n-tls = { version = "=0.3", path = "../../bindings/rust/extended/s2n-tls", features = ["unstable-testing"] }
+s2n-tls-sys = { version = "=0.3", path = "../../bindings/rust/extended/s2n-tls-sys" }
 bytes = { version = "1", optional = true }
 errno = { version = "0.3" }
 libc = "0.2"


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

The "Performance Regression Test" workflow was not marked required, so https://github.com/aws/s2n-tls/commit/c012d98b7493b9bc3e97a2522af20c853d1acf9e was merged despite breaking the test. This fixes the test.

I also removed the "paths-ignore". It was preventing the test from running and verifying this fix. We definitely need the regression test to run when we modify the regression test-- how else will we know whether changes to the test itself break the test itself?

### Call-outs:
As a follow-up, we need to mark "Performance Regression Test" as required. If it's not marked required because of flakiness, we need to address that flakiness. If it just doesn't provide particularly useful information, we should either remove it or just make it always pass if it successfully runs (even if it detects a problem).

### Testing:
Testing this is a little tricky. The test uses both the PR version of the code and the main branch version, but the main branch version is currently broken. Unless we revert the broken commit, this PR will need to be merged with the test still failing.

I think the best I can do to prove this fix works is to prove that it works if you remove the steps that require the main branch. See this PR on my fork: https://github.com/lrstewart/s2n/pull/57, with a [passing](https://github.com/lrstewart/s2n/actions/runs/12594982840/job/35103389810?pr=57) stripped down version of the test.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
