### PR TITLE
fix: add coverage for all ticket formats

### DIFF
--- a/tests/fuzz/Readme.md
+++ b/tests/fuzz/Readme.md
@@ -61,7 +61,7 @@ The `.info` files contain raw coverage data.  To convert them into HTML format, 
 ```
 
 You will see coverage reports placed in the following directory:
-> s2n-tls/tests/fuzz/coverage
+> s2n-tls/coverage/fuzz/total_fuzz_coverage
 
 ## Fuzz Test Directory Structure
 For a test with name `$TEST_NAME`, its files should be laid out with the following structure:

--- a/tests/fuzz/s2n_deserialize_resumption_state_test.c
+++ b/tests/fuzz/s2n_deserialize_resumption_state_test.c
@@ -44,7 +44,6 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     /* There are only a few valid formats for session tickets; this ensures the
      * format version is at or below S2N_SERIALIZED_FORMAT_TLS12_V3, which will
      * keep the test checking mostly valid paths. */
-    randval = randval % S2N_SERIALIZED_FORMAT_TLS12_V3;
     POSIX_GUARD(s2n_stuffer_write_uint8(&fuzzed_ticket, randval));
     /* We have to put the write cursor back */
     POSIX_GUARD(s2n_stuffer_skip_write(&fuzzed_ticket, len - 1));

--- a/tests/fuzz/s2n_deserialize_resumption_state_test.c
+++ b/tests/fuzz/s2n_deserialize_resumption_state_test.c
@@ -35,19 +35,6 @@ int s2n_fuzz_test(const uint8_t *buf, size_t len)
     POSIX_GUARD(s2n_stuffer_alloc(&fuzzed_ticket, len));
     POSIX_GUARD(s2n_stuffer_write_bytes(&fuzzed_ticket, buf, len));
 
-    /* Pull a byte off the libfuzzer input and use it to set parameters */
-    uint8_t randval = 0;
-    POSIX_GUARD(s2n_stuffer_read_uint8(&fuzzed_ticket, &randval));
-    POSIX_GUARD(s2n_stuffer_reread(&fuzzed_ticket));
-    POSIX_GUARD(s2n_stuffer_rewrite(&fuzzed_ticket));
-
-    /* There are only a few valid formats for session tickets; this ensures the
-     * format version is at or below S2N_SERIALIZED_FORMAT_TLS12_V3, which will
-     * keep the test checking mostly valid paths. */
-    POSIX_GUARD(s2n_stuffer_write_uint8(&fuzzed_ticket, randval));
-    /* We have to put the write cursor back */
-    POSIX_GUARD(s2n_stuffer_skip_write(&fuzzed_ticket, len - 1));
-
     /* A session ticket is sent along with the Client Hello, so there's not much set up needed for the server */
     DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
     POSIX_ENSURE_REF(server_conn);


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

resolves #4965

### Description of changes: 

There are two changes in this PR:

1. Remove the manual setting of session ticket formats in `s2n_deserialize_resumption_state_test.c`. We no longer make assumptions about the possible format versions

2. Update the path to coverage reports in `Readme`

### Call-outs:

N/A

### Testing:

Generated fuzz coverage reports locally and confirmed that `S2N_SERIALIZED_FORMAT_TLS12_V3` is covered

<img width="1002" alt="Fuzz_coverage" src="https://github.com/user-attachments/assets/7341e9f6-3772-4702-a75a-235b3c8c064a" />


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
