### PR TITLE
Migrate PQ Rust code to TLS 1.3

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -972,6 +972,7 @@ impl Connection {
         }
     }
 
+    #[deprecated = "PQ TLS 1.2 KEM Names are no longer supported. Use kem_group_name() to retrieve PQ TLS 1.3 Group name."]
     pub fn kem_name(&self) -> Option<&str> {
         let name_bytes = {
             let name = unsafe { s2n_connection_get_kem_name(self.connection.as_ptr()) };

--- a/bindings/rust/extended/s2n-tls/src/testing/s2n_tls.rs
+++ b/bindings/rust/extended/s2n-tls/src/testing/s2n_tls.rs
@@ -44,12 +44,12 @@ mod tests {
 
         // PQ is supported
         {
-            let policy = Policy::from_version("KMS-PQ-TLS-1-0-2020-07")?;
+            let policy = Policy::from_version("default_pq")?;
             let config = build_config(&policy)?;
             let mut pair = TestPair::from_config(&config);
 
             pair.handshake().unwrap();
-            assert_eq!(pair.client.kem_name(), Some("kyber512r3"));
+            assert_eq!(pair.client.kem_group_name(), Some("X25519MLKEM768"));
         }
 
         Ok(())

--- a/bindings/rust/extended/s2n-tls/src/testing/s2n_tls.rs
+++ b/bindings/rust/extended/s2n-tls/src/testing/s2n_tls.rs
@@ -28,18 +28,18 @@ mod tests {
     }
 
     #[test]
-    fn kem_name_retrieval() -> Result<(), Error> {
+    fn kem_group_name_retrieval() -> Result<(), Error> {
         // PQ isn't supported
         {
             let policy = Policy::from_version("20240501")?;
             let config = build_config(&policy)?;
             let mut pair = TestPair::from_config(&config);
 
-            // before negotiation, kem_name is none
-            assert!(pair.client.kem_name().is_none());
+            // before negotiation, kem_group_name is none
+            assert!(pair.client.kem_group_name().is_none());
 
             pair.handshake().unwrap();
-            assert!(pair.client.kem_name().is_none());
+            assert!(pair.client.kem_group_name().is_none());
         }
 
         // PQ is supported

--- a/bindings/rust/standard/integration/src/lib.rs
+++ b/bindings/rust/standard/integration/src/lib.rs
@@ -16,11 +16,11 @@ mod tests {
     #[cfg(feature = "pq")]
     #[test]
     fn pq_sanity_check() -> Result<(), Box<dyn std::error::Error>> {
-        let config = testing::build_config(&Policy::from_version("KMS-PQ-TLS-1-0-2020-07")?)?;
+        let config = testing::build_config(&Policy::from_version("default_pq")?)?;
         let mut pair = TestPair::from_config(&config);
         pair.handshake()?;
 
-        if pair.client.kem_name().is_none() {
+        if pair.client.kem_group_name().is_none() {
             panic!(
                 "PQ tests are enabled, but PQ functionality is unavailable. \
                 Are you sure that the libcrypto supports PQ?"

--- a/bindings/rust/standard/integration/src/network/tls_client.rs
+++ b/bindings/rust/standard/integration/src/network/tls_client.rs
@@ -46,36 +46,15 @@ mod kms_pq {
     // supports ML-KEM.
     #[test_log::test(tokio::test)]
     async fn pq_handshake() -> Result<(), Box<dyn std::error::Error>> {
-        let policy = Policy::from_version("KMS-PQ-TLS-1-0-2020-07")?;
+        let policy = Policy::from_version("PQ-TLS-1-2-2023-10-09")?;
         let tls = handshake_with_domain(DOMAIN, &policy).await?;
 
         assert_eq!(
             tls.as_ref().cipher_suite()?,
-            "ECDHE-KYBER-RSA-AES256-GCM-SHA384"
+            "TLS_AES_256_GCM_SHA384"
         );
-        assert_eq!(tls.as_ref().kem_name(), Some("kyber512r3"));
+        assert_eq!(tls.as_ref().kem_group_name(), Some("x25519_kyber-512-r3"));
 
-        Ok(())
-    }
-
-    // We want to confirm that non-supported kyber drafts successfully fall
-    // back to a full handshake.
-    #[test_log::test(tokio::test)]
-    async fn early_draft_falls_back_to_classical() -> Result<(), Box<dyn std::error::Error>> {
-        const EARLY_DRAFT_PQ_POLICIES: &[&str] = &[
-            "KMS-PQ-TLS-1-0-2019-06",
-            "PQ-SIKE-TEST-TLS-1-0-2019-11",
-            "KMS-PQ-TLS-1-0-2020-02",
-            "PQ-SIKE-TEST-TLS-1-0-2020-02",
-        ];
-
-        for security_policy in EARLY_DRAFT_PQ_POLICIES {
-            let policy = Policy::from_version(security_policy)?;
-            let tls = handshake_with_domain(DOMAIN, &policy).await?;
-
-            assert_eq!(tls.as_ref().cipher_suite()?, "ECDHE-RSA-AES256-GCM-SHA384");
-            assert_eq!(tls.as_ref().kem_name(), None);
-        }
         Ok(())
     }
 }


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

None

### Description of changes: 
Migrates all Rust binding code to use PQ TLS 1.3 in preparation of the removal of PQ TLS 1.2 in s2n.

### Call-outs:

None.

### Testing:

Existing Rust binding tests are updated to use PQ TLS 1.3 enabled security policies. 

Remember:
* Any change to the library source code should at least include unit tests.
* Any change to the core stuffer or blob methods should include [CBMC proofs](https://github.com/aws/s2n-tls/tree/main/tests/cbmc).
* Any change to the CI or tests should:
   1. prove that the test succeeds for good input
   2. prove that the test fails for bad input (eg, a test for memory leaks fails when a memory leak is committed)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
