### PR TITLE
chore(s2n-tls-hyper): Publish s2n-tls-hyper

### DIFF
--- a/bindings/rust/standard/s2n-tls-hyper/Cargo.toml
+++ b/bindings/rust/standard/s2n-tls-hyper/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "s2n-tls-hyper"
 description = "A compatbility crate allowing s2n-tls to be used with the hyper HTTP library"
-version = "0.0.1"
+version = "0.3.9"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.74.0"
 repository = "https://github.com/aws/s2n-tls"
 license = "Apache-2.0"
-publish = false
 
 [features]
 default = []

--- a/bindings/rust/standard/s2n-tls-hyper/Cargo.toml
+++ b/bindings/rust/standard/s2n-tls-hyper/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-hyper"
 description = "A compatbility crate allowing s2n-tls to be used with the hyper HTTP library"
-version = "0.3.9"
+version = "0.0.1"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.74.0"

--- a/bindings/rust/standard/s2n-tls-hyper/README.md
+++ b/bindings/rust/standard/s2n-tls-hyper/README.md
@@ -1,3 +1,1 @@
 `s2n-tls-hyper` provides compatibility structs for [hyper](https://hyper.rs/), allowing s2n-tls to be used as the underlying TLS implementation with hyper clients.
-
-This crate is currently being developed and is unstable.

--- a/bindings/rust/standard/s2n-tls-hyper/README.md
+++ b/bindings/rust/standard/s2n-tls-hyper/README.md
@@ -1,1 +1,3 @@
 `s2n-tls-hyper` provides compatibility structs for [hyper](https://hyper.rs/), allowing s2n-tls to be used as the underlying TLS implementation with hyper clients.
+
+This crate is currently being developed and is unstable.


### PR DESCRIPTION
### Description of changes: 

Allows the s2n-tls-hyper crate to be published to crates.io.

I left the version as 0.0.1 to indicate that the crate is unstable. This will allow at least one customer to fully integrate successfully before we stabilize.

### Call-outs:

Is there anything we should do before publishing/stabilizing s2n-tls-hyper? The 0.0.1 version allows us to introduce breaking changes if necessary, but ideally we wouldn't have to.

### Testing:

No code changes made. Existing tests should pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
