### PR TITLE
ci: Update bench action with new bindings paths

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,11 +29,11 @@ jobs:
           pip3 install "boto3[crt]"
 
       - name: Generate
-        working-directory: bindings/rust
+        working-directory: bindings/rust/extended
         run: ./generate.sh --skip-tests
 
       - name: Benchmark
-        working-directory: bindings/rust/bench
+        working-directory: bindings/rust/standard/bench
         run: cargo criterion --message-format json > criterion_output.log
 
       - name: Configure AWS Credentials
@@ -46,6 +46,6 @@ jobs:
       - name: Emit CloudWatch metrics
         run: |
           python3 .github/bin/criterion_to_cloudwatch.py \
-            --criterion_output_path bindings/rust/bench/criterion_output.log \
+            --criterion_output_path bindings/rust/standard/bench/criterion_output.log \
             --namespace s2n-tls-bench \
             --platform ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,6 +1,8 @@
 name: Benchmarking
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
   schedule:


### PR DESCRIPTION
### Description of changes: 

The bench github action paths to the rust bindings directories to run the bench program. These paths were modified in https://github.com/aws/s2n-tls/pull/4983, which broke this action. This PR updates these paths so the bench action can publish metrics again.

### Call-outs:

None

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
