### PR TITLE
ci: add script to help launch stuck codebuild jobs

### DIFF
--- a/codebuild/bin/start_codebuild.sh
+++ b/codebuild/bin/start_codebuild.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# Codebuild does not run in the Github CI if certain files are modified.
+# Launching each individual build from the Codebuild UI is slow and tedious.
+# Instead, this script will launch all the Codebuild builds at once.
+# You will need to setup the AWS CLI with the proper authentication.
+
+set -e
+
+BUILDS=(
+    "AddressSanitizer"
+    "S2nIntegrationV2SmallBatch"
+    "Valgrind"
+    "s2nFuzzBatch"
+    "s2nGeneralBatch"
+    "s2nUnitNix"
+    "Integv2NixBatchBF1FB83F-7tcZOiMDWPH0 us-east-2 batch"
+    "kTLS us-west-2 no-batch"
+)
+
+usage() {
+    echo "start_codebuild.sh <source_version>"
+    echo "    example: start_codebuild.sh pr/1111"
+    echo "    example: start_codebuild.sh test_branch"
+    echo "    example: start_codebuild.sh 1234abcd"
+    exit 1
+}
+
+if [ "$#" -ne "1" ]; then
+    usage
+fi
+SOURCE_VERSION=$1
+
+add_command() {
+    NAME=$1
+    REGION=${2:-"us-west-2"}
+    BATCH=${3:-"batch"}
+    
+    START_COMMAND="start-build-batch"
+    if [ "$BATCH" = "no-batch" ]; then
+        START_COMMAND="start-build"
+    fi
+    COMMANDS+=("aws --region $REGION codebuild $START_COMMAND --source-version $SOURCE_VERSION
+        --project-name $NAME")
+}
+
+for args in "${BUILDS[@]}"; do
+    add_command $args
+done
+
+echo "Builds:"
+for command in "${COMMANDS[@]}"; do
+    echo "$command"
+done
+
+select yn in "Start ${#COMMANDS[@]} builds" "Exit"; do
+    case $REPLY in
+        "1" ) echo "Starting builds..."; break;;
+        "2" ) echo "No builds started."; exit;;
+    esac
+done
+
+for command in "${COMMANDS[@]}"; do
+    $command | grep '"id":'
+done
+
+echo "All builds successfully launched."


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

We have enough codebuild jobs now that manually launching them, like we have to do when we modify a buildpsec, is very slow and tedious. I was very annoyed trying to get https://github.com/aws/s2n-tls/commit/7220e239b10d1c8feeef8a6b89452b1f77b8fc3f merged.

This just adds a simple script that will launch all the codebuild jobs for you, as long as you have the aws cli setup right. I could put this script somewhere else, but committing it seems like our best bet to keep it up to date.

### Call-outs:

I'd love a way to enforce that the script is always up-to-date with all our Codebuild jobs, but I'm not sure how to do that easily :thinking: Edit: I have an abomination of an idea: https://github.com/aws/s2n-tls/commit/eec5b09fd7b97e1588c56ab0f12c5cb0a71fcc86

### Testing:
I ran it locally and verified that the builds were successfully launched. Anyone with access to the Codebuild jobs can too, to verify. This is the output of a run:
```
%  ./codebuild/bin/start_codebuild.sh pr/5004
Builds:
aws --region us-west-2 codebuild start-build-batch --source-version pr/5004
        --project-name AddressSanitizer
aws --region us-west-2 codebuild start-build-batch --source-version pr/5004
        --project-name S2nIntegrationV2SmallBatch
aws --region us-west-2 codebuild start-build-batch --source-version pr/5004
        --project-name Valgrind
aws --region us-west-2 codebuild start-build-batch --source-version pr/5004
        --project-name s2nFuzzBatch
aws --region us-west-2 codebuild start-build-batch --source-version pr/5004
        --project-name s2nGeneralBatch
aws --region us-west-2 codebuild start-build-batch --source-version pr/5004
        --project-name s2nUnitNix
aws --region us-east-2 codebuild start-build-batch --source-version pr/5004
        --project-name Integv2NixBatchBF1FB83F-7tcZOiMDWPH0
aws --region us-west-2 codebuild start-build --source-version pr/5004
        --project-name kTLS
1) Start 8 builds
2) Exit
#? 1
Starting builds...
        "id": "AddressSanitizer:d8ee382f-c514-49c7-bf7c-6e7f85f97c3f",
        "id": "S2nIntegrationV2SmallBatch:03004132-4aa8-49cf-9c8f-409e4513fb94",
        "id": "Valgrind:61ce8e36-5d64-42b3-be2b-eaa2c7b74b70",
        "id": "s2nFuzzBatch:181468d7-ce88-42e2-af70-105871a3d900",
        "id": "s2nGeneralBatch:b85fbb1c-a2eb-4243-97af-892cd5f21c4f",
        "id": "s2nUnitNix:98accd76-0fe3-4cb6-a5ac-d8abb413df5d",
        "id": "Integv2NixBatchBF1FB83F-7tcZOiMDWPH0:1bd41ce3-ac35-4782-a02b-fc53e2eea0d6",
        "id": "kTLS:835eacfc-9ba2-49b6-bba0-65141f4b01f3",
All builds successfully launched.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
