### PR TITLE
fix(bindings/bench): Prevent IO from going out of scope

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -39,6 +39,7 @@ jobs:
         run: cargo criterion --message-format json > criterion_output.log
 
       - name: Configure AWS Credentials
+        if: github.event_name == 'push'
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
@@ -46,6 +47,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Emit CloudWatch metrics
+        if: github.event_name == 'push'
         run: |
           python3 .github/bin/criterion_to_cloudwatch.py \
             --criterion_output_path bindings/rust/standard/bench/criterion_output.log \

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,6 +1,8 @@
 name: Benchmarking
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
   schedule:
@@ -29,14 +31,15 @@ jobs:
           pip3 install "boto3[crt]"
 
       - name: Generate
-        working-directory: bindings/rust
+        working-directory: bindings/rust/extended
         run: ./generate.sh --skip-tests
 
       - name: Benchmark
-        working-directory: bindings/rust/bench
+        working-directory: bindings/rust/standard/bench
         run: cargo criterion --message-format json > criterion_output.log
 
       - name: Configure AWS Credentials
+        if: github.event_name == 'push'
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
@@ -44,8 +47,9 @@ jobs:
           aws-region: us-west-2
 
       - name: Emit CloudWatch metrics
+        if: github.event_name == 'push'
         run: |
           python3 .github/bin/criterion_to_cloudwatch.py \
-            --criterion_output_path bindings/rust/bench/criterion_output.log \
+            --criterion_output_path bindings/rust/standard/bench/criterion_output.log \
             --namespace s2n-tls-bench \
             --platform ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -39,7 +39,6 @@ jobs:
         run: cargo criterion --message-format json > criterion_output.log
 
       - name: Configure AWS Credentials
-        if: github.event_name == 'push'
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
@@ -47,7 +46,6 @@ jobs:
           aws-region: us-west-2
 
       - name: Emit CloudWatch metrics
-        if: github.event_name == 'push'
         run: |
           python3 .github/bin/criterion_to_cloudwatch.py \
             --criterion_output_path bindings/rust/standard/bench/criterion_output.log \

--- a/bindings/rust/standard/bench/benches/resumption.rs
+++ b/bindings/rust/standard/bench/benches/resumption.rs
@@ -45,19 +45,18 @@ where
         bench_group.bench_function(format!("{:?}-{}", handshake, T::name()), |b| {
             b.iter_batched_ref(
                 || {
-                    let pair = TlsConnPair::<T, T>::new_bench_pair(
+                    let mut pair = TlsConnPair::<T, T>::new_bench_pair(
                         CryptoConfig::new(CipherSuite::default(), KXGroup::default(), sig_type),
                         handshake,
                     )
                     .unwrap();
-                    let (mut c, s) = pair.split();
-                    c.handshake().unwrap();
-                    s
+                    pair.client_mut().handshake().unwrap();
+                    pair
                 },
-                |server| {
+                |pair| {
                     // this represents the work that the server does during the
                     // first RTT
-                    server.handshake().unwrap()
+                    pair.server_mut().handshake().unwrap();
                 },
                 BatchSize::SmallInput,
             )

--- a/bindings/rust/standard/bench/src/harness/mod.rs
+++ b/bindings/rust/standard/bench/src/harness/mod.rs
@@ -260,9 +260,20 @@ where
         Self { client, server, io }
     }
 
-    /// Take back ownership of individual connections in the TlsConnPair
-    pub fn split(self) -> (C, S) {
-        (self.client, self.server)
+    pub fn client(&self) -> &C {
+        &self.client
+    }
+
+    pub fn client_mut(&mut self) -> &mut C {
+        &mut self.client
+    }
+
+    pub fn server(&self) -> &S {
+        &self.server
+    }
+
+    pub fn server_mut(&mut self) -> &mut S {
+        &mut self.server
     }
 
     /// Run handshake on connections
@@ -386,8 +397,7 @@ mod tests {
             TlsConnPair::<C, S>::new_bench_pair(CryptoConfig::default(), HandshakeType::Resumption)
                 .unwrap();
         conn_pair.handshake().unwrap();
-        let (_, server) = conn_pair.split();
-        assert!(server.resumed_connection());
+        assert!(conn_pair.server().resumed_connection());
     }
 
     #[test]


### PR DESCRIPTION
### Description of changes: 

https://github.com/aws/s2n-tls/pull/4847 moved the ownership of the IO streams into `TlsConnPair`. After this change, [the resumption benchmark started failing](https://github.com/aws/s2n-tls/actions/runs/12363329121/job/34504430161). I think this change affected the `TlsConnPair::split` API, which consumed the `TlsConnPair` and returned the underlying client and server `TlsConnection`s. However, now that the `TlsConnPair` also owns the IO streams, I think this caused the streams to be dropped, which caused the s2n-tls send/recv callbacks to access invalid memory after `split` was called.

This PR removes the `TlsConnPair::split` API to prevent the IO streams from being dropped, and instead provides references to the underlying client and server.

The benchmarks were further broken by https://github.com/aws/s2n-tls/pull/4983, which changed the paths to the bench crate. This PR also updates these paths.

Both of these issues were not caught at PR-time since the bench action currently only runs on pushes to main. To catch similar issues in the future, this PR updates the bench action to build and run on PRs (but not publish any metrics until it's merged).

### Call-outs:

None

### Testing:

The bench action will now run on all PRs, with the authenticate/publish steps skipped. So the bench action on this PR should build and run successfully: https://github.com/aws/s2n-tls/actions/runs/12677767236/job/35333826698?pr=5007

I temporarily allowed the metrics to be published on PRs in https://github.com/aws/s2n-tls/pull/5007/commits/c84990c59718b2fc1fdb7586e4c9bd4700b44735 in order to test this step: https://github.com/aws/s2n-tls/actions/runs/12677418611/job/35332715910?pr=5007


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
