### PR TITLE
Dup of #4992

### DIFF
--- a/.github/install_osx_dependencies.sh
+++ b/.github/install_osx_dependencies.sh
@@ -26,4 +26,4 @@ brew_install_if_not_installed coreutils
 brew_install_if_not_installed cppcheck
 brew_install_if_not_installed pkg-config  # for gnutls compilation
 brew_install_if_not_installed ninja
-brew_install_if_not_installed openssl@1.1 # for libcrypto
+brew_install_if_not_installed openssl@3 # for libcrypto

--- a/.github/s2n_osx.sh
+++ b/.github/s2n_osx.sh
@@ -14,11 +14,11 @@
 # permissions and limitations under the License.
 #
 set -eu
-source codebuild/bin/s2n_setup_env.sh
 
 export CTEST_OUTPUT_ON_FAILURE=1
+export S2N_LIBCRYPTO=openssl-3.4
 BREWINSTLLPATH=$(brew --prefix openssl@3)
-OPENSSL_3_INSTALL_DIR="${BREWINSTLLPATH:-"/usr/local/Cellar/openssl@3/3.0.0?"}"
+OPENSSL_3_INSTALL_DIR="${BREWINSTLLPATH:-"/opt/homebrew/Cellar/openssl@3/3?"}"
 
 echo "Using OpenSSL at $OPENSSL_3_INSTALL_DIR"
 # Build with debug symbols and a specific OpenSSL version

--- a/.github/s2n_osx.sh
+++ b/.github/s2n_osx.sh
@@ -17,14 +17,14 @@ set -eu
 source codebuild/bin/s2n_setup_env.sh
 
 export CTEST_OUTPUT_ON_FAILURE=1
-BREWINSTLLPATH=$(brew --prefix openssl@1.1)
-OPENSSL_1_1_1_INSTALL_DIR="${BREWINSTLLPATH:-"/usr/local/Cellar/openssl@1.1/1.1.1?"}"
+BREWINSTLLPATH=$(brew --prefix openssl@3)
+OPENSSL_3_INSTALL_DIR="${BREWINSTLLPATH:-"/usr/local/Cellar/openssl@3/3.0.0?"}"
 
-echo "Using OpenSSL at $OPENSSL_1_1_1_INSTALL_DIR"
+echo "Using OpenSSL at $OPENSSL_3_INSTALL_DIR"
 # Build with debug symbols and a specific OpenSSL version
 cmake . -Bbuild -GNinja \
 -DCMAKE_BUILD_TYPE=Debug \
--DCMAKE_PREFIX_PATH=${OPENSSL_1_1_1_INSTALL_DIR} ..
+-DCMAKE_PREFIX_PATH=${OPENSSL_3_INSTALL_DIR} ..
 
 cmake --build ./build -j $(nproc)
 time CTEST_PARALLEL_LEVEL=$(nproc) ninja -C build test
@@ -32,7 +32,7 @@ time CTEST_PARALLEL_LEVEL=$(nproc) ninja -C build test
 # Build shared library
 cmake . -Bbuild -GNinja \
 -DCMAKE_BUILD_TYPE=Debug \
--DCMAKE_PREFIX_PATH=${OPENSSL_1_1_1_INSTALL_DIR} .. \
+-DCMAKE_PREFIX_PATH=${OPENSSL_3_INSTALL_DIR} .. \
 -DBUILD_SHARED_LIBS=ON
 
 cmake --build ./build -j $(nproc)

--- a/tests/unit/s2n_build_test.c
+++ b/tests/unit/s2n_build_test.c
@@ -83,6 +83,10 @@ S2N_RESULT s2n_check_supported_libcrypto(const char *s2n_libcrypto)
         { .libcrypto = "openssl-1.0.2-fips", .is_openssl = true },
         { .libcrypto = "openssl-1.1.1", .is_openssl = true },
         { .libcrypto = "openssl-3.0", .is_openssl = true },
+        { .libcrypto = "openssl-3.1", .is_openssl = true },
+        { .libcrypto = "openssl-3.2", .is_openssl = true },
+        { .libcrypto = "openssl-3.3", .is_openssl = true },
+        { .libcrypto = "openssl-3.4", .is_openssl = true },
     };
 
     for (size_t i = 0; i < s2n_array_len(supported_libcrypto); i++) {


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

n/a

### Description of changes: 

The historical script that sets a bunch of default env. vars, `./codebuild/bin/s2n_setup_env.sh`, is defaulting to openssl-1.1.1, these changes explicitly set S2N_LIBCRYPTO and do away with setup_env script, which really should be deprecated.

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? What manual testing was performed? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

Remember:
* Any change to the library source code should at least include unit tests.
* Any change to the core stuffer or blob methods should include [CBMC proofs](https://github.com/aws/s2n-tls/tree/main/tests/cbmc).
* Any change to the CI or tests should:
   1. prove that the test succeeds for good input
   2. prove that the test fails for bad input (eg, a test for memory leaks fails when a memory leak is committed)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
