### PR TITLE
tests: add sslv2 client hello test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -590,6 +590,37 @@ if (BUILD_TESTING)
     endforeach(test_case)
 
     ############################################################################
+    #################   sslv2 formatted client hello test    ###################
+    ############################################################################
+
+    add_executable(s2n_sslv2_client_hello_handshake tests/integration_c/test_sslv2_handshake.c)
+    
+    find_package(OpenSSL REQUIRED)
+    if(OpenSSL_VERSION VERSION_GREATER "1.0.2")
+        message(FATAL_ERROR "OpenSSL version must not exceed 1.0.2. Found version: ${OpenSSL_VERSION}")
+    endif()
+    
+    # There are two libcryptos (and two headers) in the build tree. We need the sslv2
+    # test to use the <openssl_1_0_2>/openssl/ssl.h header. However the <awslc>/openssl/ssh.h
+    # header is universally preferred because it was added through the global include_directories
+    # command. Therefore we first have to "clear" that global setting, allowing 
+    # openssl_1_0_2 header to be found before the aws lc header.
+    set_target_properties(s2n_sslv2_client_hello_handshake PROPERTIES INCLUDE_DIRECTORIES "")
+
+    target_link_libraries(s2n_sslv2_client_hello_handshake 
+        OpenSSL::SSL 
+        OpenSSL::Crypto
+        ${PROJECT_NAME}
+        testss2n
+    )
+
+    add_test(
+        NAME s2n_sslv2_client_hello_handshake
+        COMMAND s2n_sslv2_client_hello_handshake 
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/integration_c
+    )
+
+    ############################################################################
     ######################### build utility binaries ###########################
     ############################################################################
 

--- a/codebuild/spec/buildspec_generalbatch.yml
+++ b/codebuild/spec/buildspec_generalbatch.yml
@@ -99,6 +99,14 @@ batch:
           COMPILER: 'clang-18'
           S2N_LIBCRYPTO: 'awslc'
       identifier: s2nUnitAwslcClang18
+    - identifier: sslv2_client_hello_test
+      buildspec: codebuild/spec/buildspec_sslv2_client_hello.yml
+      env:
+        compute-type: BUILD_GENERAL1_MEDIUM
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu24
+        privileged-mode: true
+        variables:
+          S2N_LIBCRYPTO: 'awslc'
     - buildspec: codebuild/spec/buildspec_amazonlinux.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE

--- a/codebuild/spec/buildspec_sslv2_client_hello.yml
+++ b/codebuild/spec/buildspec_sslv2_client_hello.yml
@@ -1,0 +1,27 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+version: 0.2
+
+# CMAKE_PREFIX_PATH: specifies the libcrypto that will be interned and linked with libs2n
+# OPENSSL_ROOT_DIR: specifies the libcrypto that will be used as the openssl client
+#                   for the sslv2 client hello test.
+
+phases:
+  build:
+    on-failure: ABORT
+    commands:
+      - |
+        cmake . \
+          -B build \
+          -D CMAKE_C_COMPILER=clang \
+          -D CMAKE_PREFIX_PATH=$LIBCRYPTO_ROOT \
+          -D S2N_INTERN_LIBCRYPTO=ON \
+          -D OPENSSL_ROOT_DIR=/home/ubuntu/workspace/ossl-1-0-2-install
+      - cmake --build ./build -- -j $(nproc)
+  post_build:
+    on-failure: ABORT
+    commands:
+      # make sure that sslv2 client hello test was built and discovered by ctest
+      - ctest --test-dir build -N | grep s2n_sslv2_client_hello_handshake
+      - CTEST_PARALLEL_LEVEL=$(nproc) cmake --build ./build --target test ARGS="--output-on-failure"

--- a/tests/integration_c/README.md
+++ b/tests/integration_c/README.md
@@ -1,0 +1,60 @@
+# Overview
+This folder contains an SSLv2-formatted ClientHello integration test.
+
+s2n-tls does not support SSLv2, but it does support SSLv2 formatted Client Hellos. This enables old clients (which might still support SSLv2) to negotiate newer protocols like TLS 1.2. s2n-tls will never send an SSLv2 formatted client hello, so we use an external TLS implementation to test this functionality.
+
+## OpenSSL 1.0.2 Install
+SSLv2 ClientHellos are not supported my most TLS implementation. The last version of OpenSSL to support SSLv2 ClientHellos was OpenSSL 1.0.2, and the `enable-ssl2` option must be explicitly enabled at compile time.
+
+```
+git clone https://github.com/openssl/openssl
+cd openssl
+git checkout OpenSSL_1_0_2-stable
+./config enable-weak-ssl-ciphers enable-ssl2 --prefix=/home/ubuntu/workspace/ossl-1-0-2-install
+make
+make install
+```
+
+## Build Setup
+This integration tests requires two separate libcrypto's to be included in the same build tree. We achieve this using s2n-tls's "interning" feature. The main libcrypto e.g. awslc, has all of it's symbols prefixed by the s2n-tls project CMake build. This allows the sslv2 test to link against a standard OpenSSL 1.0.2 libcrypto.
+```
+                 ┌──────────┐                 
+                 │sslv2 test│                 
+            ┌────┴──────────┴───┐             
+            │                   │             
+            │                   │             
+            ▼                   ▼             
+        ┌──────┐          ┌──────────────┐    
+        │libs2n│          │libssl (1.0.2)│    
+        └──┬───┘          └─────┬────────┘    
+           │                    │             
+           │                    │             
+           ▼                    ▼             
+┌─────────────────────┐   ┌─────────────────┐ 
+│s2n_libcrypto (awslc)│   │libcrypto (1.0.2)│ 
+└─────────────────────┘   └─────────────────┘ 
+           ▲                                  
+           │                                  
+  interned/prefixed                           
+           │                                  
+           │                                  
+  ┌────────┼────────┐                         
+  │libcrypto (awslc)│                         
+  └─────────────────┘                         
+```
+
+
+## Building the test
+Because of the multiple libcryptos, this test can only be used with an _interned_ libcrypto. In the example build script below, observe that the libcrypto that s2n-tls links with is specified using `CMAKE_PREFIX_PATH`, and then the separate libcrypto used as a client is specified with `OPENSS_ROOT_DIR`.
+```
+rm -rf build
+cmake . \
+    -B build \
+    -D CMAKE_C_COMPILER=clang \
+    -D CMAKE_BUILD_TYPE=RelWithDebInfo \
+    -D CMAKE_PREFIX_PATH=/home/ubuntu/workspace/aws-lc-install \
+    -D S2N_INTERN_LIBCRYPTO=ON \
+    -D OPENSSL_ROOT_DIR=/home/ubuntu/workspace/ossl-1-0-2-install
+cmake --build ./build -j $(nproc)
+CTEST_PARALLEL_LEVEL=$(nproc) make -C build test ARGS="--output-on-failure"
+```

--- a/tests/integration_c/test_sslv2_handshake.c
+++ b/tests/integration_c/test_sslv2_handshake.c
@@ -1,0 +1,145 @@
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "testlib/s2n_testlib.h"
+#include "tests/s2n_test.h"
+#include "utils/s2n_safety.h"
+
+#define SERVER_CHAIN       "/home/ubuntu/workspace/s2n-tls/tests/pems/permutations/rsae_pkcs_2048_sha256/server-chain.pem"
+#define SERVER_KEY         "/home/ubuntu/workspace/s2n-tls/tests/pems/permutations/rsae_pkcs_2048_sha256/server-key.pem"
+#define OPENSSL_1_0_2_MASK 0x10002000L
+
+#define EXPECT_OSSL_SUCCESS(e1) EXPECT_TRUE(e1 > -1)
+
+struct s2n_client_hello_version_detector {
+    uint8_t invoked;
+};
+
+int sslv2_assertion_cb(struct s2n_connection *conn, void *ctx)
+{
+    EXPECT_EQUAL(s2n_connection_get_client_hello_version(conn), S2N_SSLv2);
+
+    struct s2n_client_hello_version_detector *detector = ctx;
+    detector->invoked += 1;
+
+    return 0;
+}
+
+/* s2n-tls io recv callback that operates on an OpenSSL BIO. */
+int s2n_bio_read(void *io_context, uint8_t *buf, uint32_t len)
+{
+    int bytes_read = BIO_read(io_context, buf, len);
+    if (bytes_read == -1) {
+        errno = EWOULDBLOCK;
+    }
+    return bytes_read;
+}
+
+/* s2n-tls io send callback that operates on an OpenSSL BIO. */
+int s2n_bio_write(void *io_context, const uint8_t *buf, uint32_t len)
+{
+    return BIO_write(io_context, buf, len);
+}
+
+
+S2N_RESULT s2n_negotiate_s2n_and_ossl(SSL *client, struct s2n_connection *server)
+{
+    bool server_done = false, client_done = false;
+    s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+
+    do {
+        int ret = SSL_do_handshake(client);
+        if (ret == 1) {
+            client_done = true;
+        } else {
+            /* if error not caused by blocked io, fail */
+            int err = SSL_get_error(client, ret);
+            RESULT_ENSURE(err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE, S2N_ERR_IO);
+        }
+
+        server_done = (s2n_negotiate(server, &blocked) >= S2N_SUCCESS);
+        if (!server_done) {
+            /* if error not caused by blocked io, fail */
+            RESULT_ENSURE_EQ(s2n_error_get_type(s2n_errno), S2N_ERR_T_BLOCKED);
+        }
+
+    } while (!client_done || !server_done);
+
+    return S2N_RESULT_OK;
+}
+
+int main()
+{
+    // Assert that we are pulling in the correct openssl header.
+    EXPECT_EQUAL(OPENSSL_VERSION_NUMBER & OPENSSL_1_0_2_MASK, OPENSSL_1_0_2_MASK);
+
+    EXPECT_OSSL_SUCCESS(SSL_library_init());
+    SSL_load_error_strings();
+    EXPECT_SUCCESS(s2n_init());
+
+    /* s2n-tls client w/ openssl server */
+    {
+        /* s2n-tls server config */
+        DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = NULL,
+                s2n_cert_chain_and_key_ptr_free);
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_and_key,
+                SERVER_CHAIN, SERVER_KEY));
+
+        struct s2n_client_hello_version_detector client_hello_detector = { 0 };
+
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(),
+                s2n_config_ptr_free);
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "PQ-TLS-1-2-2023-12-13"));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+        EXPECT_SUCCESS(s2n_config_wipe_trust_store(config));
+        EXPECT_SUCCESS(s2n_config_set_client_hello_cb(config, sslv2_assertion_cb, &client_hello_detector));
+
+        /* OpenSSL client config */
+        SSL_CTX *client_ctx = SSL_CTX_new(SSLv23_client_method());
+        EXPECT_NOT_NULL(client_ctx);
+        /* SSLv2 is disabled by default, so we must explicitly clear the setting.
+         * https://github.com/openssl/openssl/blob/master/CHANGES.md#changes-between-102f-and-102g-1-mar-2016
+         */
+        EXPECT_OSSL_SUCCESS(SSL_CTX_clear_options(client_ctx, SSL_OP_NO_SSLv2));
+        /* Explicitly enable SSLv2 cipher suites to force OpenSSL to send an SSLv2
+         * ClientHello. Also enable modern cipher suites to allow us to actually
+         * negotiate TLS 1.2.
+         */
+        EXPECT_OSSL_SUCCESS(SSL_CTX_set_cipher_list(client_ctx, "SSLv2:RSA"));
+
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+
+        SSL *client_conn = SSL_new(client_ctx);
+        EXPECT_NOT_NULL(client_conn);
+
+        /* setup io for the connections */
+        BIO *server_to_client = BIO_new(BIO_s_mem());
+        BIO *client_to_server = BIO_new(BIO_s_mem());
+        EXPECT_NOT_NULL(server_to_client);
+        EXPECT_NOT_NULL(client_to_server);
+
+        EXPECT_SUCCESS(s2n_connection_set_recv_cb(server_conn, s2n_bio_read));
+        EXPECT_SUCCESS(s2n_connection_set_recv_ctx(server_conn, client_to_server));
+        EXPECT_SUCCESS(s2n_connection_set_send_cb(server_conn, s2n_bio_write));
+        EXPECT_SUCCESS(s2n_connection_set_send_ctx(server_conn, server_to_client));
+
+        SSL_set_bio(client_conn, server_to_client, client_to_server);
+        SSL_set_connect_state(client_conn);
+
+        EXPECT_OK(s2n_negotiate_s2n_and_ossl(client_conn, server_conn));
+
+        EXPECT_EQUAL(s2n_connection_get_actual_protocol_version(server_conn), S2N_TLS12);
+        EXPECT_EQUAL(client_hello_detector.invoked, 1);
+
+        // Cleanup
+        SSL_free(client_conn);
+        SSL_CTX_free(client_ctx);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Resolved issues:

Part of #4585 

### Description of changes: 

s2n-tls doesn't currently have any integration tests that do a full handshake with an SSLv2 formatted client hello. This PR adds a test.

This is done using an in-process test that handshakes over shared memory. This allows the test to run quickly, and also allows a high degree of observability (assertions can be fine grained). This is also useful because we need access to very specific configuration that would be painful to specify through the command line.

### Testing:

New test. We confirm that the ClientHello is actually an SSLv2 client hello in the ClientHello callback.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
