### PR TITLE
refactor: add key as a parameter for s2n_resume_encrypt_session_ticket

### DIFF
--- a/tests/unit/s2n_client_psk_extension_test.c
+++ b/tests/unit/s2n_client_psk_extension_test.c
@@ -82,7 +82,8 @@ static S2N_RESULT s2n_setup_encrypted_ticket(struct s2n_connection *conn, struct
     RESULT_CHECKED_MEMCPY(conn->tls13_ticket_fields.session_secret.data, test_secret_data, sizeof(test_secret_data));
 
     /* Create a valid resumption psk identity */
-    RESULT_GUARD(s2n_resume_encrypt_session_ticket(conn, output));
+    struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+    RESULT_GUARD(s2n_resume_encrypt_session_ticket(conn, key, output));
     output->blob.size = s2n_stuffer_data_available(output);
 
     return S2N_RESULT_OK;

--- a/tests/unit/s2n_extended_master_secret_test.c
+++ b/tests/unit/s2n_extended_master_secret_test.c
@@ -50,7 +50,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_init(&ticket, &ticket_blob));
 
             /* Encrypt the ticket with EMS data */
-            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, &ticket));
+            struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, key, &ticket));
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -89,7 +90,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_init(&ticket, &ticket_blob));
 
             /* Encrypt the ticket without EMS data */
-            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, &ticket));
+            struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, key, &ticket));
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
@@ -126,7 +128,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_init(&ticket, &ticket_blob));
 
             /* Encrypt the ticket with EMS data */
-            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, &ticket));
+            struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, key, &ticket));
 
             EXPECT_SUCCESS(s2n_connection_wipe(conn));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));

--- a/tests/unit/s2n_psk_offered_test.c
+++ b/tests/unit/s2n_psk_offered_test.c
@@ -30,7 +30,8 @@ static S2N_RESULT s2n_setup_encrypted_ticket(struct s2n_connection *conn, struct
     RESULT_CHECKED_MEMCPY(conn->tls13_ticket_fields.session_secret.data, test_secret_data, sizeof(test_secret_data));
 
     /* Create a valid resumption psk identity */
-    RESULT_GUARD(s2n_resume_encrypt_session_ticket(conn, output));
+    struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+    RESULT_GUARD(s2n_resume_encrypt_session_ticket(conn, key, output));
     output->blob.size = s2n_stuffer_data_available(output);
 
     return S2N_RESULT_OK;

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -1297,8 +1297,8 @@ int main(int argc, char **argv)
         {
             DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
                     s2n_connection_ptr_free);
-            EXPECT_NOT_NULL(conn);
-            EXPECT_ERROR_WITH_ERRNO(s2n_resume_encrypt_session_ticket(conn, &conn->client_ticket_to_decrypt),
+            struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+            EXPECT_ERROR_WITH_ERRNO(s2n_resume_encrypt_session_ticket(conn, key, &conn->client_ticket_to_decrypt),
                     S2N_ERR_NO_TICKET_ENCRYPT_DECRYPT_KEY);
         }
 
@@ -1315,7 +1315,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
             struct s2n_stuffer output = { 0 };
-            EXPECT_ERROR_WITH_ERRNO(s2n_resume_encrypt_session_ticket(conn, &output), S2N_ERR_STUFFER_IS_FULL);
+            struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+            EXPECT_ERROR_WITH_ERRNO(s2n_resume_encrypt_session_ticket(conn, key, &output), S2N_ERR_STUFFER_IS_FULL);
         }
 
         /* Check encrypted data can be decrypted correctly for TLS12 */
@@ -1337,7 +1338,8 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_write_bytes(&secret_stuffer, test_master_secret.data, S2N_TLS_SECRET_LEN));
             conn->secure->cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
 
-            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, &conn->client_ticket_to_decrypt));
+            struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, key, &conn->client_ticket_to_decrypt));
             EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&conn->client_ticket_to_decrypt), 0);
 
             /* Wiping the master secret to prove that the decryption function actually writes the master secret */
@@ -1374,7 +1376,8 @@ int main(int argc, char **argv)
             /* This secret is smaller than the maximum secret length */
             EXPECT_TRUE(conn->tls13_ticket_fields.session_secret.size < S2N_TLS_SECRET_LEN);
 
-            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, &output));
+            struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, key, &output));
             EXPECT_OK(s2n_resume_decrypt_session_ticket(conn, &output));
 
             EXPECT_EQUAL(s2n_stuffer_data_available(&output), 0);
@@ -1410,7 +1413,8 @@ int main(int argc, char **argv)
             /* This secret is equal to the maximum secret length */
             EXPECT_EQUAL(conn->tls13_ticket_fields.session_secret.size, S2N_TLS_SECRET_LEN);
 
-            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, &output));
+            struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, key, &output));
             EXPECT_OK(s2n_resume_decrypt_session_ticket(conn, &output));
 
             EXPECT_EQUAL(s2n_stuffer_data_available(&output), 0);
@@ -1438,7 +1442,8 @@ int main(int argc, char **argv)
             conn->actual_protocol_version = S2N_TLS12;
             conn->handshake.handshake_type = NEGOTIATED;
 
-            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, &conn->client_ticket_to_decrypt));
+            struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, key, &conn->client_ticket_to_decrypt));
             EXPECT_NOT_EQUAL(s2n_stuffer_data_available(&conn->client_ticket_to_decrypt), 0);
 
             /* Modify the version number of the ticket */
@@ -1470,7 +1475,8 @@ int main(int argc, char **argv)
 
             DEFER_CLEANUP(struct s2n_stuffer valid_ticket = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&valid_ticket, 0));
-            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, &valid_ticket));
+            struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, key, &valid_ticket));
             uint32_t ticket_size = s2n_stuffer_data_available(&valid_ticket);
 
             /* Copy ticket so that we don't modify the original ticket */
@@ -1521,7 +1527,8 @@ int main(int argc, char **argv)
             DEFER_CLEANUP(struct s2n_stuffer output = { 0 }, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&output, 0));
 
-            EXPECT_ERROR_WITH_ERRNO(s2n_resume_encrypt_session_ticket(conn, &output), S2N_ERR_KEY_CHECK);
+            struct s2n_ticket_key *zeroed_key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+            EXPECT_ERROR_WITH_ERRNO(s2n_resume_encrypt_session_ticket(conn, zeroed_key, &output), S2N_ERR_KEY_CHECK);
         };
 
         /* Check session ticket is correct when using early data with TLS1.3. */
@@ -1548,7 +1555,8 @@ int main(int argc, char **argv)
             conn->tls13_ticket_fields = (struct s2n_ticket_fields){ .ticket_age_add = 1 };
             EXPECT_SUCCESS(s2n_dup(&test_master_secret, &conn->tls13_ticket_fields.session_secret));
 
-            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, &output));
+            struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+            EXPECT_OK(s2n_resume_encrypt_session_ticket(conn, key, &output));
             EXPECT_OK(s2n_resume_decrypt_session_ticket(conn, &output));
 
             EXPECT_EQUAL(s2n_stuffer_data_available(&output), 0);

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -495,7 +495,10 @@ S2N_RESULT s2n_store_to_cache(struct s2n_connection *conn)
     RESULT_ENSURE(conn->session_id_len <= S2N_TLS_SESSION_ID_MAX_LEN, S2N_ERR_SESSION_ID_TOO_LONG);
 
     RESULT_GUARD_POSIX(s2n_stuffer_init(&to, &entry));
-    RESULT_GUARD(s2n_resume_encrypt_session_ticket(conn, &to));
+    struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+    /* No keys loaded by the user or the keys are either in decrypt-only or expired state */
+    RESULT_ENSURE(key != NULL, S2N_ERR_NO_TICKET_ENCRYPT_DECRYPT_KEY);
+    RESULT_GUARD(s2n_resume_encrypt_session_ticket(conn, key, &to));
 
     /* Store to the cache */
     conn->config->cache_store(conn, conn->config->cache_store_data, S2N_TLS_SESSION_CACHE_TTL, conn->session_id, conn->session_id_len, entry.data, entry.size);
@@ -815,12 +818,11 @@ static S2N_RESULT s2n_resume_generate_unique_ticket_key(struct s2n_unique_ticket
     return S2N_RESULT_OK;
 }
 
-S2N_RESULT s2n_resume_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *to)
+S2N_RESULT s2n_resume_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_ticket_key *key, struct s2n_stuffer *to)
 {
     RESULT_ENSURE_REF(conn);
     RESULT_ENSURE_REF(to);
 
-    struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
     /* No keys loaded by the user or the keys are either in decrypt-only or expired state */
     RESULT_ENSURE(key != NULL, S2N_ERR_NO_TICKET_ENCRYPT_DECRYPT_KEY);
 

--- a/tls/s2n_resume.h
+++ b/tls/s2n_resume.h
@@ -77,7 +77,8 @@ struct s2n_session_ticket {
 };
 
 struct s2n_ticket_key *s2n_find_ticket_key(struct s2n_config *config, const uint8_t name[S2N_TICKET_KEY_NAME_LEN]);
-S2N_RESULT s2n_resume_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *to);
+struct s2n_ticket_key *s2n_get_ticket_encrypt_decrypt_key(struct s2n_config *config);
+S2N_RESULT s2n_resume_encrypt_session_ticket(struct s2n_connection *conn, struct s2n_ticket_key *key, struct s2n_stuffer *to);
 S2N_RESULT s2n_resume_decrypt_session_ticket(struct s2n_connection *conn, struct s2n_stuffer *from);
 S2N_RESULT s2n_resume_decrypt_session_cache(struct s2n_connection *conn, struct s2n_stuffer *from);
 S2N_RESULT s2n_config_is_encrypt_key_available(struct s2n_config *config);

--- a/tls/s2n_server_new_session_ticket.c
+++ b/tls/s2n_server_new_session_ticket.c
@@ -92,7 +92,8 @@ int s2n_server_nst_send(struct s2n_connection *conn)
      *# NewSessionTicket handshake message.
      **/
     POSIX_GUARD(s2n_stuffer_init(&to, &entry));
-    if (!conn->config->use_tickets || s2n_result_is_error(s2n_resume_encrypt_session_ticket(conn, &to))) {
+    struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+    if (!conn->config->use_tickets || s2n_result_is_error(s2n_resume_encrypt_session_ticket(conn, key, &to))) {
         POSIX_GUARD(s2n_stuffer_write_uint32(&conn->handshake.io, 0));
         POSIX_GUARD(s2n_stuffer_write_uint16(&conn->handshake.io, 0));
 
@@ -272,6 +273,9 @@ S2N_RESULT s2n_tls13_server_nst_write(struct s2n_connection *conn, struct s2n_st
     RESULT_ENSURE_REF(output);
 
     struct s2n_ticket_fields *ticket_fields = &conn->tls13_ticket_fields;
+    struct s2n_ticket_key *key = s2n_get_ticket_encrypt_decrypt_key(conn->config);
+    /* No keys loaded by the user or the keys are either in decrypt-only or expired state */
+    RESULT_ENSURE(key != NULL, S2N_ERR_NO_TICKET_ENCRYPT_DECRYPT_KEY);
 
     /* Write message type because session resumption in TLS13 is a post-handshake message */
     RESULT_GUARD_POSIX(s2n_stuffer_write_uint8(output, TLS_SERVER_NEW_SESSION_TICKET));
@@ -310,7 +314,7 @@ S2N_RESULT s2n_tls13_server_nst_write(struct s2n_connection *conn, struct s2n_st
     /* Write ticket */
     struct s2n_stuffer_reservation ticket_size = { 0 };
     RESULT_GUARD_POSIX(s2n_stuffer_reserve_uint16(output, &ticket_size));
-    RESULT_GUARD(s2n_resume_encrypt_session_ticket(conn, output));
+    RESULT_GUARD(s2n_resume_encrypt_session_ticket(conn, key, output));
     RESULT_GUARD_POSIX(s2n_stuffer_write_vector_size(&ticket_size));
 
     RESULT_GUARD_POSIX(s2n_extension_list_send(S2N_EXTENSION_LIST_NST, conn, output));


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

Partial for issue #4583 and #2756.

### Description of changes: 

This PR is to address [a comment](https://github.com/aws/s2n-tls/pull/5001#discussion_r1906078646) in [PR#5001](https://github.com/aws/s2n-tls/pull/5001). Currently `s2n_resume_encrypt_session_ticket()` picks a session ticket key inside the function:
https://github.com/aws/s2n-tls/blob/edf68e0e778651c2d4cef9920b16f165814ca1ab/tls/s2n_resume.c#L818-L825
The `s2n_get_ticket_encrypt_decrypt_key()` function is non-deterministic, so we might end up with different session ticket keys if we call them multiple times. We need to specify the session ticket key outside of the function, so that when we are calculating the session ticket lifetime, S2N will use the same session ticket key for both lifetime calculation and session ticket encryption.

Hence, this PR adds `struct s2n_ticket_key *key` as an additional parameter in `s2n_resume_encrypt_session_ticket()`, and chooses the key before calling `s2n_resume_encrypt_session_ticket()` every where in the codebase.

### Call-outs:

* I made `s2n_get_ticket_encrypt_decrypt_key()` function available in `s2n_resume.h`, because this function needs to be called in `s2n_server_nst_send()` and `s2n_tls13_server_nst_write()` functions.
* I will need to merge this PR first before continue to work on PR #5001. That PR should serve for fixing the calculation only.

### Testing:

This PR is tested locally and by the CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
