### PR TITLE
fix: don't prefix empty string when interning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,7 +402,8 @@ if (S2N_INTERN_LIBCRYPTO)
           # copy the static version of libcrypto
           cp ${crypto_STATIC_LIBRARY} s2n_libcrypto.a &&
           # dump all of the symbols and prefix them with `s2n$`
-          bash -c "${CMAKE_NM} s2n_libcrypto.a | awk '/ [A-Z] /{print $3\" s2n$\"$3}' | sort | uniq > libcrypto.symbols" &&
+          bash -c "${CMAKE_NM} s2n_libcrypto.a | awk '/ [A-Z] /{if ($3) print $3\" s2n$\"$3}' | sort | uniq > libcrypto.symbols" &&
+          cp libcrypto.symbols my_analysis.symbols &&
           # redefine the libcrypto libary symbols
           ${CMAKE_OBJCOPY} --redefine-syms libcrypto.symbols s2n_libcrypto.a &&
           rm -rf s2n_libcrypto &&


### PR DESCRIPTION
### Description of changes: 

Interning is broken on my platform, ubuntu24, ARM.

When trying to the following build
```
cmake . \
    -B build \
    -D CMAKE_C_COMPILER=clang \
    -D CMAKE_BUILD_TYPE=RelWithDebInfo \
    -D S2N_INTERN_LIBCRYPTO=ON
```

The actual build invocation will fail
```
[  0%] Generating libcrypto.symbols
/usr/bin/llvm-objcopy: error: libcrypto.symbols:1: missing new symbol name
gmake[2]: *** [CMakeFiles/s2n_libcrypto.dir/build.make:73: libcrypto.symbols] Error 1
gmake[2]: *** Deleting file 'libcrypto.symbols'
gmake[1]: *** [CMakeFiles/Makefile2:695: CMakeFiles/s2n_libcrypto.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```

objcopy expects every line to have `<old token> <new token>`, but it says that there is a line with only a single token. To debug this we dump a temporary copy of the `libcrypto.symbols` that is generated for prefixing.

```
ubuntu@ip-172-31-49-198:~/workspace/s2n-tls$ head build/my_analysis.symbols 
 s2n$
ACCESS_DESCRIPTION_free s2n$ACCESS_DESCRIPTION_free
ACCESS_DESCRIPTION_it s2n$ACCESS_DESCRIPTION_it
ACCESS_DESCRIPTION_new s2n$ACCESS_DESCRIPTION_new
ADMISSIONS_free s2n$ADMISSIONS_free
ADMISSIONS_get0_admissionAuthority s2n$ADMISSIONS_get0_admissionAuthority
ADMISSIONS_get0_namingAuthority s2n$ADMISSIONS_get0_namingAuthority
ADMISSIONS_get0_professionInfos s2n$ADMISSIONS_get0_professionInfos
ADMISSIONS_it s2n$ADMISSIONS_it
ADMISSIONS_new s2n$ADMISSIONS_new
```

We see that there is indeed an empty symbol. Why?

libcrypto.symbols is generated with this line
```
bash -c "${CMAKE_NM} s2n_libcrypto.a | awk '/ [A-Z] /{print $3\" s2n$\"$3}' | sort | uniq > libcrypto.symbols" &&
```

Which will match all lines that contain at least one upper case character, and then print out `<token 3> s2n<token 3>

With the following script, we can check that lines that result in an empty token
```
ubuntu@ip-172-31-49-198:~/workspace/s2n-tls$ nm /usr/lib/aarch64-linux-gnu/libcrypto.a | awk '/ [A-Z] / && !$3 { print }' | head
                 U AES_decrypt
                 U AES_encrypt
                 U CRYPTO_cbc128_decrypt
                 U CRYPTO_cbc128_encrypt
                 U AES_encrypt
                 U CRYPTO_cfb128_1_encrypt
                 U CRYPTO_cfb128_8_encrypt
                 U CRYPTO_cfb128_encrypt
                 U AES_decrypt
                 U AES_encrypt
```

So the problem is the undefined tokens.

### Call-outs:
I don't understand why this isn't currently failing in our CI ...

### Testing:
It now works on my platform, and existing CI should pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
