### PR TITLE
Added cloudfront viewer security policies

### DIFF
--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -532,6 +532,8 @@ int main(int argc, char **argv)
             "CloudFront-TLS-1-2-2019",
             "CloudFront-TLS-1-2-2021",
             "CloudFront-TLS-1-2-2021-ChaCha20-Boosted",
+            "CloudFront-TLS-1-2-2025",
+            "CloudFront-TLS-1-3-2025",
             /* AWS Common Runtime SDK */
             "AWS-CRT-SDK-SSLv3.0",
             "AWS-CRT-SDK-TLSv1.0",
@@ -559,6 +561,26 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_find_security_policy_from_version(tls13_security_policy_strings[i], &security_policy));
             EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
         }
+    }
+
+    /* Test CloudFront security policies */
+    {
+        security_policy = NULL;
+        EXPECT_SUCCESS(s2n_find_security_policy_from_version("CloudFront-TLS-1-2-2025", &security_policy));
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
+        EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
+        EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
+        EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
+        EXPECT_OK(s2n_test_security_policies_compatible(security_policy, "default_fips", rsa_chain_and_key));
+        EXPECT_OK(s2n_test_security_policies_compatible(security_policy, "default_fips", ecdsa_chain_and_key));
+
+        security_policy = NULL;
+        EXPECT_SUCCESS(s2n_find_security_policy_from_version("CloudFront-TLS-1-3-2025", &security_policy));
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
+        EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
+        EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
+        EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
+        EXPECT_EQUAL(security_policy->minimum_protocol_version, S2N_TLS13);
     }
 
     /* Test that null fails */

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -1490,6 +1490,32 @@ const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2021_c
     .allow_chacha20_boosting = true,
 };
 
+/* FIPS 140-3 compliant version of cipher_preferences_cloudfront_tls_1_2_2021 */
+struct s2n_cipher_suite *cipher_suites_cloudfront_tls_1_2_2025[] = {
+    &s2n_tls13_aes_128_gcm_sha256,
+    &s2n_tls13_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384
+};
+
+const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2025 = {
+    .count = s2n_array_len(cipher_suites_cloudfront_tls_1_2_2025),
+    .suites = cipher_suites_cloudfront_tls_1_2_2025,
+    .allow_chacha20_boosting = false,
+};
+
+struct s2n_cipher_suite *cipher_suites_cloudfront_tls_1_3_2025[] = {
+    S2N_TLS13_CLOUDFRONT_CIPHER_SUITES_20200716
+};
+
+const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_3_2025 = {
+    .count = s2n_array_len(cipher_suites_cloudfront_tls_1_3_2025),
+    .suites = cipher_suites_cloudfront_tls_1_3_2025,
+    .allow_chacha20_boosting = false,
+};
+
 /* Based on cipher_preferences_cloudfront_tls_1_0_2016, but with ordering changed and AES256-SHA256, DES-CBC3-SHA, and
  * RC4-MD5 added for compatibility. */
 struct s2n_cipher_suite *cipher_suites_aws_crt_sdk_ssl_v3[] = {

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -103,6 +103,8 @@ extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2
 extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2019;
 extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2021;
 extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2021_chacha20_boosted;
+extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2_2025;
+extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_3_2025;
 
 /* CloudFront viewer facing legacy TLS 1.2 policies */
 extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_ssl_v_3_legacy;

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -417,6 +417,30 @@ const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2021_chacha2
     },
 };
 
+/* FIPS 140-3 compliant version of security_policy_cloudfront_tls_1_2_2021 */
+const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2025 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_cloudfront_tls_1_2_2025,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20230317,
+    .ecc_preferences = &s2n_ecc_preferences_20201021,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+            [S2N_FIPS_140_3] = true,
+    },
+};
+
+const struct s2n_security_policy security_policy_cloudfront_tls_1_3_2025 = {
+    .minimum_protocol_version = S2N_TLS13,
+    .cipher_preferences = &cipher_preferences_cloudfront_tls_1_3_2025,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20200207,
+    .ecc_preferences = &s2n_ecc_preferences_20200310,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
+};
+
 /* CloudFront viewer facing legacy TLS 1.2 policies */
 const struct s2n_security_policy security_policy_cloudfront_ssl_v_3_legacy = {
     .minimum_protocol_version = S2N_SSLv3,
@@ -1267,6 +1291,8 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "CloudFront-TLS-1-2-2019", .security_policy = &security_policy_cloudfront_tls_1_2_2019, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "CloudFront-TLS-1-2-2021", .security_policy = &security_policy_cloudfront_tls_1_2_2021, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "CloudFront-TLS-1-2-2021-Chacha20-Boosted", .security_policy = &security_policy_cloudfront_tls_1_2_2021_chacha20_boosted, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "CloudFront-TLS-1-2-2025", .security_policy = &security_policy_cloudfront_tls_1_2_2025, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "CloudFront-TLS-1-3-2025", .security_policy = &security_policy_cloudfront_tls_1_3_2025, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     /* CloudFront Legacy (TLS 1.2) policies */
     { .version = "CloudFront-SSL-v-3-Legacy", .security_policy = &security_policy_cloudfront_ssl_v_3_legacy, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "CloudFront-TLS-1-0-2014-Legacy", .security_policy = &security_policy_cloudfront_tls_1_0_2014_legacy, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -200,6 +200,8 @@ extern const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2018;
 extern const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2019;
 extern const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2021;
 extern const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2021_chacha20_boosted;
+extern const struct s2n_security_policy security_policy_cloudfront_tls_1_2_2025;
+extern const struct s2n_security_policy security_policy_cloudfront_tls_1_3_2025;
 
 extern const struct s2n_security_policy security_policy_kms_tls_1_0_2018_10;
 extern const struct s2n_security_policy security_policy_kms_tls_1_2_2023_06;


### PR DESCRIPTION
### Release Summary:
Added two CloudFront viewer security policies: one that's a FIPS-compliant version of 2021 policy, and the other is a TLS1.3 only policy.

### Resolved issues:

N/A

### Description of changes: 

Added two CloudFront viewer security policies.

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? What manual testing was performed? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

Remember:
* Any change to the library source code should at least include unit tests.
* Any change to the core stuffer or blob methods should include [CBMC proofs](https://github.com/aws/s2n-tls/tree/main/tests/cbmc).
* Any change to the CI or tests should:
   1. prove that the test succeeds for good input
   2. prove that the test fails for bad input (eg, a test for memory leaks fails when a memory leak is committed)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
