### PR TITLE
ci: keep start_codebuild.sh up-to-date

### DIFF
--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -128,3 +128,38 @@ jobs:
           exit 1
       - name: Success
         run: echo "All nix files passed format check"
+        
+  validate_start_codebuild_script:
+    name: validate start_codebuild.sh
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: pause
+        run: "sleep 120"
+      - name: retrieve statuses
+        id: get_statuses
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/{repo}/commits/{ref}/statuses?per_page=100
+          repo: ${{ github.repository }}
+          ref: ${{ github.event.merge_group.head_sha || github.event.pull_request.head.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: check start_codebuild.sh against statuses
+        id: github_builds
+        run: |
+            from_github=$(
+                jq '.[] | .description' <<< '${{ steps.get_statuses.outputs.data }}' \
+                    | grep "for project" \
+                    | sed -r "s/^.*?for project (.*?)\"$/\1/" \
+                    | sort -u
+            )
+            echo builds from github statuses:
+            echo "$from_github"
+            from_file=$(
+                source codebuild/bin/start_codebuild.sh > /dev/null \
+                || printf "%s\n" "${BUILDS[@]}" | cut -d" " -f1 | sort -u
+            )
+            echo builds from start_codebuild.sh:
+            echo "$from_file"
+            diff <(echo "$from_github") <(echo "$from_file")

--- a/codebuild/bin/start_codebuild.sh
+++ b/codebuild/bin/start_codebuild.sh
@@ -35,11 +35,13 @@ usage() {
     echo "    example: start_codebuild.sh pr/1111"
     echo "    example: start_codebuild.sh test_branch"
     echo "    example: start_codebuild.sh 1234abcd"
-    exit 1
 }
 
 if [ "$#" -ne "1" ]; then
     usage
+    # Return instead of exit so we can `source` this script
+    # in order to get access to BUILDS.
+    return 1
 fi
 SOURCE_VERSION=$1
 


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

Add an action to make sure start_codebuild.sh from https://github.com/aws/s2n-tls/commit/b4a4e0915b73aebd0cf16753a11b6f4d3ee71520 stays up-to-date with changes to our Codebuild jobs. This might be unnecessary overkill / too much complication for the small benefit / a waste of a github action-- interested in opinions.

### Testing:
The test fails if I remove a job from the list in start_codebuild.sh. See https://github.com/aws/s2n-tls/actions/runs/12705769604/job/35417420123?pr=5024


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
