### PR TITLE
refactor(bin): remove references to FIPS_mode_set

### DIFF
--- a/crypto/s2n_fips.c
+++ b/crypto/s2n_fips.c
@@ -30,19 +30,14 @@ static bool s2n_fips_mode_enabled = false;
  *
  * This method indicates the state of the libcrypto, NOT the state
  * of s2n-tls and should ONLY be called during library initialization (i.e.
- * s2n_init()). For example, if s2n-tls is using Openssl and FIPS_mode_set(1)
- * is called after s2n_init() is called, then this method will return true
- * while s2n_is_in_fips_mode() will return false and s2n-tls will not operate
+ * s2n_init()). This distinction is important because in the past,
+ * if s2n-tls was using Openssl-1.0.2-fips and FIPS_mode_set(1)
+ * was called after s2n_init() was called, then this method would return true
+ * while s2n_is_in_fips_mode() would return false and s2n-tls would not operate
  * in FIPS mode.
  *
  * For AWS-LC, the FIPS_mode() method is always defined. If AWS-LC was built to
  * support FIPS, FIPS_mode() always returns 1.
- *
- * For OpenSSL, OPENSSL_FIPS is defined if the libcrypto was built to support
- * FIPS. The FIPS_mode() method is only present if OPENSSL_FIPS is defined, and
- * only returns 1 if FIPS_mode_set(1) was used to enable FIPS mode.
- * Applications wanting to enable FIPS mode with OpenSSL must call
- * FIPS_mode_set(1) prior to calling s2n_init().
  */
 bool s2n_libcrypto_is_fips(void)
 {

--- a/docs/usage-guide/topics/ch02-initialization.md
+++ b/docs/usage-guide/topics/ch02-initialization.md
@@ -7,8 +7,6 @@ Initialization can be modified by calling `s2n_crypto_disable_init()` or `s2n_di
 
 An application can override s2n-tls’s internal memory management by calling `s2n_mem_set_callbacks()` before calling `s2n_init()`.
 
-If you are trying to use FIPS mode, you must enable FIPS in your libcrypto library (probably by calling `FIPS_mode_set(1)`) before calling `s2n_init()`.
-
 ## Teardown
 ### Thread-local Memory
 We recommend calling `s2n_cleanup()` from every thread created after `s2n_init()` to ensure there are no memory leaks. s2n-tls has thread-local memory that it attempts to clean up automatically at thread-exit. However, this is done using pthread destructors and may not work if you are using a threads library other than pthreads.


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

Hopefully last of the openssl-1.0.2-fips cleanup. FIPS_mode_set was only required for openssl-1.0.2-fips, not for awslc or openssl3.

### Testing:

I verified with a search that the only remaining references to FIPS_mode_set are in the s2n_fips.c comment discussing past behavior.

s2nd when built with awslc-fips:
```
./build/bin/s2nd --enter-fips-mode localhost 8888
libcrypto: AWS-LC FIPS 2.0.17
s2nd entered FIPS mode
```

s2nd when built with openss-1.1.1:
```
./build/bin/s2nd --enter-fips-mode localhost 8888
libcrypto: OpenSSL 1.1.1x-dev  xx XXX xxxx
FIPS mode not enabled: libcrypto does not support FIPS
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
