### PR TITLE
ci: add timeout for cbmc proof

### DIFF
--- a/.github/workflows/proof_ci.yaml
+++ b/.github/workflows/proof_ci.yaml
@@ -26,6 +26,8 @@ jobs:
   run_cbmc_proofs:
     runs-on: cbmc_ubuntu-latest_64-core
     name: run_cbmc_proofs
+    # The default timeout is 360 minutes
+    timeout-minutes: 60
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
### Release Summary:

### Resolved issues:


### Description of changes: 

We noticed that Run CBMC Proofs Workflow sometimes hang for six hours and then Github terminates the workflow. Here is an [example](https://github.com/aws/s2n-tls/actions/runs/12785232895/job/35639810898). We want to lower the timeout limit to 60 minutes. [Run CBMC Proofs Workflow](https://github.com/aws/s2n-tls/actions/workflows/proof_ci.yaml) typically only takes 30 minutes to finish. To set the timeout, refer to the [Github Action Page](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes).

For this CBMC workflow hanging, we suspect the problem happens in:
https://github.com/aws/s2n-tls/blob/6cc9f53d7ab5f0427ae5f838891fff57844a9e3f/.github/workflows/proof_ci.yaml#L120-L121


### Call-outs:

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
