### PR TITLE
fix(bindings): Increase aws-lc-rs minimum version

### DIFF
--- a/bindings/rust/extended/s2n-tls-sys/templates/Cargo.template
+++ b/bindings/rust/extended/s2n-tls-sys/templates/Cargo.template
@@ -36,12 +36,13 @@ stacktrace = []
 # unstable-foo = []
 
 [dependencies]
-# aws-lc-rs 1.6.4 adds DEP_AWS_LC environment variables which are required to build s2n-tls-sys:
+# aws-lc-rs 1.12.0 specifies a minimum version for aws-lc-sys and aws-lc-fips-sys that include
+# DEP_AWS_LC environment variables, which are required to build s2n-tls-sys:
 # https://github.com/aws/aws-lc-rs/pull/335
-aws-lc-rs = { version = "1.6.4" }
-# aws-lc-rs 1.6.4 depends on aws-lc-sys 0.14.0, which requires libc 0.2.121:
-# https://github.com/aws/aws-lc-rs/blob/2298ca861234d4f43aecef2c7d7e822c60bc488a/aws-lc-sys/Cargo.toml#L65
-libc = "0.2.121"
+aws-lc-rs = { version = "1.12.0" }
+# cc 1.0.100 depends on jobserver 0.1.30, which requires libc 0.2.87:
+# https://github.com/rust-lang/jobserver-rs/blob/4ac8212169e06f427ccd4da985cf023a483fc6a6/Cargo.toml#L16
+libc = "0.2.87"
 
 [build-dependencies]
 cc = { version = "1.0.100", features = ["parallel"] }

--- a/bindings/rust/extended/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls-tokio/Cargo.toml
@@ -13,8 +13,8 @@ default = []
 
 [dependencies]
 errno = { version = "0.3" }
-# A minimum libc version of 0.2.121 is required by aws-lc-sys 0.14.0.
-libc = { version = "0.2.121" }
+# A minimum libc version of 0.2.87 is required by jobserver 0.1.30.
+libc = { version = "0.2.87" }
 pin-project-lite = { version = "0.2" }
 s2n-tls = { version = "=0.3.9", path = "../s2n-tls" }
 tokio = { version = "1", features = ["net", "time"] }

--- a/bindings/rust/extended/s2n-tls/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls/Cargo.toml
@@ -20,8 +20,8 @@ unstable-testing = []
 
 [dependencies]
 errno = { version = "0.3" }
-# A minimum libc version of 0.2.121 is required by aws-lc-sys 0.14.0.
-libc = "0.2.121"
+# A minimum libc version of 0.2.87 is required by jobserver 0.1.30.
+libc = { version = "0.2.87" }
 s2n-tls-sys = { version = "=0.3.9", path = "../s2n-tls-sys", features = ["internal"] }
 pin-project-lite = "0.2"
 hex = "0.4"


### PR DESCRIPTION
### Description of changes: 

https://github.com/aws/s2n-tls/pull/5028 updated the minimum supported version of aws-lc-rs to 1.6.4, because https://github.com/aws/aws-lc-rs/pull/335 is required in order to build s2n-tls-sys. However, https://github.com/aws/aws-lc-rs/pull/335 modifies three crates: aws-lc-rs, aws-lc-sys, and aws-lc-fips-sys. In order to build s2n-tls, the changes are required in aws-lc-rs and aws-lc-sys for non-FIPS builds, and aws-lc-rs and aws-lc-fips-sys for FIPS builds.

- https://github.com/aws/aws-lc-rs/pull/335 was added to aws-lc-rs in version 1.6.2.
- https://github.com/aws/aws-lc-rs/pull/335 was added to aws-lc-sys in version 0.13.1.
- https://github.com/aws/aws-lc-rs/pull/335 was added to aws-lc-fips-sys in version 0.12.2.

aws-lc-rs 1.6.4 is the first aws-lc-rs version to enforce that https://github.com/aws/aws-lc-rs/pull/335 is included in aws-lc-sys, since it [depends on aws-lc-sys 0.14.0](https://github.com/aws/aws-lc-rs/blob/ccb2a90c5b04ce7c792289840e299cdaf9f47beb/aws-lc-rs/Cargo.toml#L49).

However, aws-lc-rs 1.12.0 (released ~1 month ago) is the first aws-lc-rs version to enforce that https://github.com/aws/aws-lc-rs/pull/335 is included in aws-lc-fips-sys, since it [started depending on aws-lc-fips-sys 0.13.0](https://github.com/aws/aws-lc-rs/blob/809cd7de7cfa8975144e00ef0b5a4e04351bc330/aws-lc-rs/Cargo.toml#L51). All versions before that [only depended on 0.12.0](https://github.com/aws/aws-lc-rs/blob/7d59a1239f551d7f4312e8cf3185959017f2e725/aws-lc-rs/Cargo.toml#L51)

It's therefore currently possible for a dependency closure to include s2n-tls, aws-lc-rs 1.6.4, and aws-lc-fips-sys 1.12.0, which doesn't include https://github.com/aws/aws-lc-rs/pull/335. This causes the s2n-tls build to fail. To ensure that https://github.com/aws/aws-lc-rs/pull/335 is included in the build, we need aws-lc-fips-sys to be at least 0.12.2, which is only enforced in aws-lc-rs 1.12.0, so this PR updates the aws-lc-rs minimum version to 1.12.0.


### Call-outs:

Alternative solutions:
- We could decide that specifying proper minimum versions is not worth requiring such a strict aws-lc-rs version.
- We could maybe specify the minimum aws-lc-fips-sys version as an optional dependency in s2n-tls-sys, which gets enabled when the fips feature is enabled. This would prevent us from requiring such a strict aws-lc-rs minimum version for non-FIPS builds. However, aws-lc-fips-sys can be included in a dependency closure as a result of another crate enabling fips in aws-lc-rs, so this would not resolve the minimum version issue in this case.

Note that this was not caught by the new minimum versions test added in https://github.com/aws/s2n-tls/pull/5028 because it currently only tests minimum versions of direct dependencies (aws-lc-rs). For indirect dependencies (aws-lc-fips-sys), the highest supported versions are tested.

### Testing:

I ran the minimal-versions test on my smithy-rs PR locally:
```
❯ cargo minimal-versions check --all-features
...
info: running `cargo hack check --all-features`
info: running `cargo check --all-features` on aws-smithy-http-client (1/1)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.68s
```

I _didn't_ update the minimum test to include transitive dependencies, as this is [not recommended in the Rust documentation](https://doc.rust-lang.org/cargo/reference/unstable.html#minimal-versions). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
