### PR TITLE
ci: add more awslc-fips-2022 testing

### DIFF
--- a/codebuild/spec/buildspec_fuzz_batch.yml
+++ b/codebuild/spec/buildspec_fuzz_batch.yml
@@ -39,6 +39,16 @@ batch:
         variables:
           S2N_LIBCRYPTO: awslc
           COMPILER: clang
+    - identifier: clang_awslc_fips_2022
+      buildspec: codebuild/spec/buildspec_fuzz.yml
+      debug-session: true
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
+        privileged-mode: true
+        variables:
+          S2N_LIBCRYPTO: awslc-fips-2022
+          COMPILER: clang
     - identifier: clang_openssl_1_0_2
       buildspec: codebuild/spec/buildspec_fuzz.yml
       debug-session: true

--- a/codebuild/spec/buildspec_sanitizer.yml
+++ b/codebuild/spec/buildspec_sanitizer.yml
@@ -45,6 +45,12 @@ batch:
         variables:
           S2N_LIBCRYPTO: awslc
           COMPILER: clang
+    - identifier: clang_awslc_fips_2022
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          S2N_LIBCRYPTO: awslc-fips-2022
+          COMPILER: clang
     - identifier: clang_openssl_3_0
       env:
         compute-type: BUILD_GENERAL1_LARGE
@@ -68,6 +74,12 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           S2N_LIBCRYPTO: awslc
+          COMPILER: gcc
+    - identifier: gcc_awslc_fips_2022
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          S2N_LIBCRYPTO: awslc-fips-2022
           COMPILER: gcc
     - identifier: gcc_openssl_3_0
       env:

--- a/codebuild/spec/buildspec_valgrind.yml
+++ b/codebuild/spec/buildspec_valgrind.yml
@@ -29,6 +29,13 @@ batch:
         variables:
           S2N_LIBCRYPTO: awslc-fips
           COMPILER: gcc
+    - identifier: gcc_awslc_fips_2022
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu24
+        variables:
+          S2N_LIBCRYPTO: awslc-fips-2022
+          COMPILER: gcc
     - identifier: gcc_openssl_3_0
       env:
         compute-type: BUILD_GENERAL1_LARGE


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

I noticed while messing with the fips logic for the openssl-3-fips work that we're missing some awslc-fips testing:
* fuzz_batch tests awslc, but not awslc-fips or awslc-fips-2022
* sanitizer tests awslc, but not awslc-fips or awslc-fips-2022
* valgrind tests awslc and awslc-fips, but not awslc-fips-2022 (the newer version)

awslc is an important libcrypto and fips is a common use case, so we need to make sure we thoroughly test the latest fips version of awslc. Wherever we test with different libcryptos, we should be testing with awslc-fips-2022.

I searched our buildspecs for "S2N_LIBCRYPTO:" to get an idea of which specs used which libcryptos. I added awslc-fips-2022 anywhere it was missing.

### Testing:
This adds more testing, which should pass in the CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
