### PR TITLE
Allow OpenSSL 3.0 as an OpenSSL provider.

### DIFF
--- a/tests/integrationv2/conftest.py
+++ b/tests/integrationv2/conftest.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 import pytest
+import subprocess
 from global_flags import set_flag, S2N_PROVIDER_VERSION, S2N_FIPS_MODE
-from providers import S2N, JavaSSL
+from providers import S2N, JavaSSL, OpenSSL
 
 PATH_CONFIGURATION_KEY = pytest.StashKey()
 
@@ -29,6 +30,15 @@ def available_providers():
 
     if os.path.exists("./bin/SSLSocketClient.class"):
         providers.add(JavaSSL)
+        
+    result = subprocess.run(
+        ["openssl", "version"], shell=False, capture_output=True, text=True
+    )
+    version_str = result.stdout.split(" ")
+    project = version_str[0]
+    version = version_str[1]
+    if project == "OpenSSL" and version[0:3] == "3.0":
+        providers.add(OpenSSL)
 
     return providers
 

--- a/tests/integrationv2/processes.py
+++ b/tests/integrationv2/processes.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+import time
 import os
 import select
 import selectors
@@ -90,13 +91,23 @@ class _processCommunicator(object):
 
         return (stdout, stderr)
 
+    # Helper function to print out debugging statements
+    def get_fd_name(self, proc, fileobj):
+        if fileobj == proc.stdout:
+            return "stdout"
+        elif fileobj == proc.stderr:
+            return "stderr"
+        elif fileobj == proc.stdin:
+            return "stdin"
+        return "fileobj is not stdout, stderr nor stdin"
+
     def _communicate(self, input_data=None, send_marker_list=None, close_marker=None, kill_marker=None,
                      send_with_newline=False, timeout=None):
         """
         This method will read and write data to a subprocess in a non-blocking manner.
         The code is heavily based on Popen.communicate. There are a couple differences:
 
-            * STDIN is not registered for events until the read_to_send marker is found
+            * STDIN is not registered for events until the ready_to_send marker is found
             * STDIN is only closed after all registered events have been processed (including
               pending stdout/stderr events, allowing more data to be stored).
         """
@@ -144,6 +155,7 @@ class _processCommunicator(object):
             if self.proc.stderr and not self.proc.stderr.closed:
                 selector.register(self.proc.stderr, selectors.EVENT_READ)
 
+            # Keep iterating until we unregister stdin, stdout and stderr
             while selector.get_map():
                 timeout = self._remaining_time(endtime)
                 if timeout is not None and timeout < 0:
@@ -164,26 +176,35 @@ class _processCommunicator(object):
                         print(f'{self.name}: stdin available')
                         chunk = input_view[input_data_offset:
                                            input_data_offset + _PIPE_BUF]
+                        
+                        # will run try block and then else (if no exception was found)
                         try:
                             input_data_offset += os.write(key.fd, chunk)
                             print(f'{self.name}: sent')
                         except BrokenPipeError:
-                            selector.unregister(key.fileobj)
+                            print(f"{self.name}: Unregistering (stdin) BrokenPipeError")
+                            selector.unregister(self.proc.stdin)
                         else:
                             if input_data_offset >= input_data_len:
-                                selector.unregister(key.fileobj)
+                                print(f"{self.name}: Unregistering (stdin) Input_data_offset >= input_data_len")
+                                selector.unregister(self.proc.stdin)
                                 input_data_sent = True
                                 input_data_offset = 0
                                 if send_marker_list:
                                     send_marker = send_marker_list.pop(0)
                                     print(f'{self.name}: next send_marker is {send_marker}')
                     elif key.fileobj in (self.proc.stdout, self.proc.stderr):
-                        print(f'{self.name}: stdout available')
+                        fd_name = self.get_fd_name(self.proc, key.fileobj)
+                        print(f'{self.name}: {fd_name} available')
                         # 32 KB (32 × 1024 = 32,768 bytes), read 32KB from the file descriptor
                         data = os.read(key.fd, 32768)
                         if not data:
+                            
+                            print(f"{self.name}:  Unregistering: {fd_name} No Data")
                             selector.unregister(key.fileobj)
+
                         data_str = str(data)
+                        print(f"data is : {data_str}\n")
 
                         # Prepends n - 1 bytes of previously-seen stdout to the chunk we'll be searching
                         # through, where n is the size of the send_marker we're currently looking for.
@@ -228,6 +249,7 @@ class _processCommunicator(object):
                         if self.wait_for_marker:
                             print(f'{self.name}: looking for wait_for_marker {self.wait_for_marker} in {data_debug}')
                         if self.wait_for_marker is not None and self.wait_for_marker in data_str:
+                            print(f"{self.name}: Unregistering (stdout + stderr), found wait_for_marker")
                             selector.unregister(self.proc.stdout)
                             selector.unregister(self.proc.stderr)
                             return None, None
@@ -235,20 +257,19 @@ class _processCommunicator(object):
                         if kill_marker:
                             print(f'{self.name}: looking for kill_marker {kill_marker} in {data}')
                         if kill_marker is not None and kill_marker in data:
+                            print(f"{self.name}: Unregistering (stdout + stderr), found kill_marker")
                             selector.unregister(self.proc.stdout)
                             selector.unregister(self.proc.stderr)
                             self.proc.kill()
 
-                # If we have finished sending all our input, and have received the
-                # ready-to-send marker, we can close out stdin.
-                if self.proc.stdin and input_data_sent and not input_data:
-                    print(f'{self.name}: finished sending')
-                    if close_marker:
-                        print(f'{self.name}: looking for close_marker {close_marker} in {data_debug}')
-                    if close_marker is None or (close_marker and close_marker in data_str):
-                        print(f'{self.name}: closing stdin')
-                        input_data_sent = None
-                        self.proc.stdin.close()
+                        if self.proc.stdin and input_data_sent and not input_data:
+                            print(f'{self.name}: finished sending')
+                            if close_marker:
+                                print(f'{self.name}: looking for close_marker {close_marker} in {data_debug}\n')
+                            if close_marker is None or (close_marker and close_marker in data_str):
+                                print(f'{self.name} Found close marker: closing stdin')
+                                input_data_sent = None
+                                self.proc.stdin.close()
 
         self.proc.wait(timeout=self._remaining_time(endtime))
 
@@ -391,7 +412,7 @@ class ManagedProcess(threading.Thread):
             finally:
                 # This data is dumped to stdout so we capture this
                 # information no matter where a test fails.
-                print("###############################################################")
+                print("###############################################################")   
                 print(f"#######################   {self.cmd_line[0]}   #######################")
                 print("###############################################################")
 


### PR DESCRIPTION
### Resolved issues:

Resolves : allow OpenSSL 3.0 as an OpenSSL provider.
https://github.com/aws/s2n-tls/issues/5027

### Description of changes: 

-Add openssl 3.0 as a provider
-Remove v1.1.1 as a constraint
-Remove support for TLSv1.0 and TLSv1.1 (for openssl)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
