### PR TITLE
ci: Adding integ tests back to integv2

### DIFF
--- a/codebuild/spec/buildspec_ubuntu_integrationv2.yml
+++ b/codebuild/spec/buildspec_ubuntu_integrationv2.yml
@@ -38,7 +38,7 @@ batch:
           INTEGV2_TEST:
             - "test_dynamic_record_sizes test_sslyze test_sslv2_client_hello"
             - "test_happy_path"
-            - "test_cross_compatibility test_client_authentication"
+            - "test_cross_compatibility"
             - "test_early_data test_well_known_endpoints test_hello_retry_requests test_sni_match test_pq_handshake test_fragmentation test_key_update"
             - "test_session_resumption test_renegotiate_apache test_buffered_send"
             - "test_npn test_signature_algorithms"

--- a/codebuild/spec/buildspec_ubuntu_integrationv2.yml
+++ b/codebuild/spec/buildspec_ubuntu_integrationv2.yml
@@ -37,6 +37,12 @@ batch:
             - openssl-3.0
           INTEGV2_TEST:
             - "test_dynamic_record_sizes test_sslyze test_sslv2_client_hello"
+            - "test_happy_path"
+            - "test_cross_compatibility test_client_authentication"
+            - "test_early_data test_well_known_endpoints test_hello_retry_requests test_sni_match test_pq_handshake test_fragmentation test_key_update"
+            - "test_session_resumption test_renegotiate_apache test_buffered_send"
+            - "test_npn test_signature_algorithms"
+            - "test_version_negotiation test_external_psk test_ocsp test_renegotiate test_serialization"
 
 env:
   variables:


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

N/A
### Description of changes: 

We need to add all integ tests to this buildspec. Currently nix doesn't work with awslc-fips and without these tests we are missing coverage. 

### Call-outs:

I expect these tests will be removed once nix works with awslc-fips.

### Testing:

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
