### PR TITLE
Revert "ci: remove openssl-1.0.2-fips builds (#4995)"

### DIFF
--- a/codebuild/bin/install_default_dependencies.sh
+++ b/codebuild/bin/install_default_dependencies.sh
@@ -43,6 +43,10 @@ if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2" && ! -d "$OPENSSL_1_0_2_INSTALL_DIR" ]
     codebuild/bin/install_openssl_1_0_2.sh "$(mktemp -d)" "$OPENSSL_1_0_2_INSTALL_DIR" "$OS_NAME" > /dev/null ;
 fi
 
+# Download and Install the Openssl FIPS module and Openssl 1.0.2-fips
+if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2-fips" ]] && [[ ! -d "$OPENSSL_1_0_2_FIPS_INSTALL_DIR" ]]; then
+    codebuild/bin/install_openssl_1_0_2_fips.sh "$(mktemp -d)" "$OPENSSL_1_0_2_FIPS_INSTALL_DIR" "$OS_NAME" ; fi
+
 # Download and Install LibreSSL
 if [[ "$S2N_LIBCRYPTO" == "libressl" && ! -d "$LIBRESSL_INSTALL_DIR" ]]; then
     mkdir -p "$LIBRESSL_INSTALL_DIR"||true

--- a/codebuild/bin/install_openssl_1_0_2_fips.sh
+++ b/codebuild/bin/install_openssl_1_0_2_fips.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+#
+
+set -ex
+pushd "$(pwd)"
+
+usage() {
+    echo "install_openssl_1_0_2_fips.sh build_dir install_dir os_name"
+    exit 1
+}
+
+if [ "$#" -ne "3" ]; then
+    usage
+fi
+
+BUILD_DIR=$1
+INSTALL_DIR=$2
+OS_NAME=$3
+
+if [ "$OS_NAME" == "linux" ]; then
+    CONFIGURE="./config -d"
+elif [ "$OS_NAME" == "osx" ]; then
+    echo "WARNING: FIPS and MacOS is not officially supported. This build should only be used for local debugging."
+    echo "See: http://openssl.6102.n7.nabble.com/Openssl-Fips-build-for-Mac-OSX-64-bit-td44716.html"
+    CONFIGURE="./Configure darwin64-x86_64-cc"
+else
+    echo "Invalid platform! $OS_NAME"
+    usage
+fi
+
+# Install the FIPS object module in accordance with OpenSSL FIPS 140-2 Security Policy Annex A.
+#     https://www.openssl.org/docs/fips/SecurityPolicy-2.0.pdf
+# This installation is not FIPS compliant as we do not own the build system architecture.
+# It may only be used for testing purposes.
+#
+# There is no 'latest' download URL for the FIPS object modules
+cd "$BUILD_DIR"
+# Originally from: http://www.openssl.org/source/openssl-fips-2.0.13.tar.gz
+curl --retry 3 https://s3-us-west-2.amazonaws.com/s2n-public-test-dependencies/2017-08-31_openssl-fips-2.0.13.tar.gz --output openssl-fips-2.0.13.tar.gz
+gunzip -c openssl-fips-2.0.13.tar.gz | tar xf -
+rm openssl-fips-2.0.13.tar.gz
+cd openssl-fips-2.0.13
+mkdir ../OpensslFipsModule
+FIPSDIR="$(pwd)/../OpensslFipsModule"
+export FIPSDIR
+chmod +x ./Configure
+$CONFIGURE
+make
+make install
+
+cd "$BUILD_DIR"
+curl --retry 3 -L https://github.com/openssl/openssl/archive/OpenSSL_1_0_2-stable.zip --output openssl-OpenSSL_1_0_2-stable.zip
+unzip openssl-OpenSSL_1_0_2-stable.zip
+cd openssl-OpenSSL_1_0_2-stable
+
+FIPS_OPTIONS="fips --with-fipsdir=$FIPSDIR shared"
+
+$CONFIGURE $FIPS_OPTIONS -g3 -fPIC no-libunbound no-gmp no-jpake no-krb5 no-md2 no-rc5 \
+         no-rfc3779 no-sctp no-ssl-trace no-store no-zlib no-hw no-mdc2 no-seed no-idea \
+         enable-ec_nistp_64_gcc_128 no-camellia no-bf no-ripemd no-dsa no-ssl2 no-capieng -DSSL_FORBID_ENULL \
+         -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS --prefix="$INSTALL_DIR"
+
+make depend
+make
+make install_sw
+
+popd
+
+exit 0
+

--- a/codebuild/bin/s2n_set_build_preset.sh
+++ b/codebuild/bin/s2n_set_build_preset.sh
@@ -49,6 +49,10 @@ case "${S2N_BUILD_PRESET-default}" in
         : "${S2N_LIBCRYPTO:=openssl-1.0.2}"
         : "${GCC_VERSION:=6}"
         ;;
+    "openssl-1.0.2-fips")
+        : "${S2N_LIBCRYPTO:=openssl-1.0.2-fips}"
+        : "${GCC_VERSION:=6}"
+        ;;
     "openssl-1.1.1_gcc4-8")
         : "${S2N_LIBCRYPTO:=openssl-1.1.1}"
         : "${GCC_VERSION:=4.8}"

--- a/codebuild/bin/s2n_setup_env.sh
+++ b/codebuild/bin/s2n_setup_env.sh
@@ -42,6 +42,7 @@ source codebuild/bin/s2n_set_build_preset.sh
 : "${OPENSSL_3_0_INSTALL_DIR:=$TEST_DEPS_DIR/openssl-3.0}"
 : "${OPENSSL_1_0_2_INSTALL_DIR:=$TEST_DEPS_DIR/openssl-1.0.2}"
 : "${OQS_OPENSSL_1_1_1_INSTALL_DIR:=$TEST_DEPS_DIR/oqs_openssl-1.1.1}"
+: "${OPENSSL_1_0_2_FIPS_INSTALL_DIR:=$TEST_DEPS_DIR/openssl-1.0.2-fips}"
 : "${BORINGSSL_INSTALL_DIR:=$TEST_DEPS_DIR/boringssl}"
 : "${AWSLC_INSTALL_DIR:=$TEST_DEPS_DIR/awslc}"
 : "${AWSLC_FIPS_INSTALL_DIR:=$TEST_DEPS_DIR/awslc-fips}"
@@ -98,6 +99,7 @@ export SCAN_BUILD_INSTALL_DIR
 export OPENSSL_1_1_1_INSTALL_DIR
 export OPENSSL_3_0_INSTALL_DIR
 export OPENSSL_1_0_2_INSTALL_DIR
+export OPENSSL_1_0_2_FIPS_INSTALL_DIR
 export OQS_OPENSSL_1_1_1_INSTALL_DIR
 export BORINGSSL_INSTALL_DIR
 export AWSLC_INSTALL_DIR
@@ -126,6 +128,10 @@ if [[ -z $S2N_LIBCRYPTO ]]; then export LIBCRYPTO_ROOT=$OPENSSL_1_1_1_INSTALL_DI
 if [[ "$S2N_LIBCRYPTO" == "openssl-1.1.1" ]]; then export LIBCRYPTO_ROOT=$OPENSSL_1_1_1_INSTALL_DIR ; fi
 if [[ "$S2N_LIBCRYPTO" == "openssl-3.0" ]]; then export LIBCRYPTO_ROOT=$OPENSSL_3_0_INSTALL_DIR ; fi
 if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2" ]]; then export LIBCRYPTO_ROOT=$OPENSSL_1_0_2_INSTALL_DIR ; fi
+if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2-fips" ]]; then
+    export LIBCRYPTO_ROOT=$OPENSSL_1_0_2_FIPS_INSTALL_DIR ;
+    export S2N_TEST_IN_FIPS_MODE=1 ;
+fi
 if [[ "$S2N_LIBCRYPTO" == "boringssl" ]]; then export LIBCRYPTO_ROOT=$BORINGSSL_INSTALL_DIR ; fi
 if [[ "$S2N_LIBCRYPTO" == "awslc" ]]; then export LIBCRYPTO_ROOT=$AWSLC_INSTALL_DIR ; fi
 if [[ "$S2N_LIBCRYPTO" == "awslc-fips" ]]; then export LIBCRYPTO_ROOT=$AWSLC_FIPS_INSTALL_DIR ; fi

--- a/codebuild/spec/buildspec_fuzz_batch.yml
+++ b/codebuild/spec/buildspec_fuzz_batch.yml
@@ -68,4 +68,14 @@ batch:
         privileged-mode: true
         variables:
           S2N_LIBCRYPTO: openssl-3.0
-          COMPILER: clang    
+          COMPILER: clang
+    - identifier: clang_openssl_1_0_2_fips
+      buildspec: codebuild/spec/buildspec_fuzz.yml
+      debug-session: true
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
+        privileged-mode: true
+        variables:
+          S2N_LIBCRYPTO: openssl-1.0.2-fips
+          COMPILER: clang          

--- a/codebuild/spec/buildspec_valgrind.yml
+++ b/codebuild/spec/buildspec_valgrind.yml
@@ -50,6 +50,13 @@ batch:
         variables:
           S2N_LIBCRYPTO: openssl-1.0.2
           COMPILER: gcc
+    - identifier: gcc_openssl_1_0_2_fips
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
+        variables:
+          S2N_LIBCRYPTO: openssl-1.0.2-fips
+          COMPILER: gcc
 
 phases:
   pre_build:

--- a/tests/integrationv2/conftest.py
+++ b/tests/integrationv2/conftest.py
@@ -61,7 +61,9 @@ def pytest_configure(config: pytest.Config):
         config.stash[PATH_CONFIGURATION_KEY] = available_providers()
 
     provider_version = config.getoption('provider-version', None)
-    if "fips" in provider_version:
+    # By default, any libcrypto with "fips" in its name should be in fips mode.
+    # However, s2n-tls no longer supports fips mode with openssl-1.0.2-fips.
+    if "fips" in provider_version and "openssl-1.0.2-fips" not in provider_version:
         set_flag(S2N_FIPS_MODE, True)
     set_flag(S2N_PROVIDER_VERSION, provider_version)
 

--- a/tests/integrationv2/test_sslyze.py
+++ b/tests/integrationv2/test_sslyze.py
@@ -227,6 +227,11 @@ def invalid_sslyze_scan_parameters(*args, **kwargs):
             sslyze.ScanCommand.SESSION_RENEGOTIATION
         ]:
             return True
+    # BUG_IN_SSLYZE error for session resumption scan with openssl 1.0.2 fips
+    if "openssl-1.0.2-fips" in get_flag(S2N_PROVIDER_VERSION):
+        if scan_command == sslyze.ScanCommand.SESSION_RESUMPTION:
+            return True
+
     return invalid_test_parameters(*args, **kwargs)
 
 
@@ -308,6 +313,11 @@ def invalid_certificate_scans_parameters(*args, **kwargs):
         # SSLyze curves scan errors when given ECDSA certs
         if "ECDSA" in certificate.name:
             return True
+
+        # SSLyze curves scan fails to validate with openssl 1.0.2 fips
+        if "openssl-1.0.2-fips" in get_flag(S2N_PROVIDER_VERSION):
+            return True
+
     return invalid_test_parameters(*args, **kwargs)
 
 

--- a/tests/unit/s2n_build_test.c
+++ b/tests/unit/s2n_build_test.c
@@ -80,6 +80,7 @@ S2N_RESULT s2n_check_supported_libcrypto(const char *s2n_libcrypto)
         { .libcrypto = "boringssl", .is_openssl = false },
         { .libcrypto = "libressl", .is_openssl = false },
         { .libcrypto = "openssl-1.0.2", .is_openssl = true },
+        { .libcrypto = "openssl-1.0.2-fips", .is_openssl = true },
         { .libcrypto = "openssl-1.1.1", .is_openssl = true },
         { .libcrypto = "openssl-3.0", .is_openssl = true },
         { .libcrypto = "openssl-3.4", .is_openssl = true },


### PR DESCRIPTION
This reverts commit 7220e239b10d1c8feeef8a6b89452b1f77b8fc3f.

### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 
I'm thinking this was actually a mistake, so I'm reverting it and restoring coverage. We may not support openssl-1.0.2-fips in fips mode, but we should still make sure we can build and run with openssl-1.0.2-fips. In 1.0.2, you have to call a specific method to enable fips mode, and our tests don't do that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
