### PR TITLE
ci: Emit benchmark metrics from scheduled runs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -39,7 +39,8 @@ jobs:
         run: cargo criterion --message-format json > criterion_output.log
 
       - name: Configure AWS Credentials
-        if: github.event_name == 'push'
+        # Only continue with the workflow to emit metrics on code that has been merged to main.
+        if: github.event_name != 'pull_request'
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
@@ -47,7 +48,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Emit CloudWatch metrics
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         run: |
           python3 .github/bin/criterion_to_cloudwatch.py \
             --criterion_output_path bindings/rust/standard/bench/criterion_output.log \


### PR DESCRIPTION
### Description of changes: 

https://github.com/aws/s2n-tls/pull/5007 updated the bench github action to build and run the benchmarks on PRs, but not publish any metrics. The condition I used to skip this step in the workflow was `if: github.event_name == 'push'`. This did succeed in preventing the metrics from emitting on PRs, but also [prevented the metrics from emitting on scheduled runs](https://github.com/aws/s2n-tls/actions/runs/12979701608/job/36195758341).

This PR updates the metric emit condition to anything but PRs, so it will run on both pushes to main and on scheduled runs.

### Call-outs:

None

### Testing:

The bench action on this PR skips the emit steps:
https://github.com/aws/s2n-tls/actions/runs/13014897818/job/36301511926?pr=5064

This indicates that it will emit in all other circumstances.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
