### PR TITLE
fix(bindings): prevent temp connection free after panic

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/callbacks.rs
+++ b/bindings/rust/extended/s2n-tls/src/callbacks.rs
@@ -48,7 +48,7 @@ pub use pkey::*;
 /// callbacks were configured through the Rust bindings.
 pub(crate) unsafe fn with_context<F, T>(conn_ptr: *mut s2n_connection, action: F) -> T
 where
-    F: FnOnce(&mut Connection, &Context) -> T,
+    F: FnOnce(&mut Connection, &mut Context) -> T,
 {
     let raw = NonNull::new(conn_ptr).expect("connection should not be null");
     // Since this is a callback, it receives a pointer to the connection
@@ -57,8 +57,8 @@ where
     // We must make the connection `ManuallyDrop` before `action`, otherwise a panic
     // in `action` would cause the unwind mechanism to drop the connection.
     let mut conn = ManuallyDrop::new(Connection::from_raw(raw));
-    let config = conn.config().expect("config should not be null");
-    let context = config.context();
+    let mut config = conn.config().expect("config should not be null");
+    let context = config.context_mut();
     action(&mut conn, context)
 }
 

--- a/bindings/rust/extended/s2n-tls/src/callbacks.rs
+++ b/bindings/rust/extended/s2n-tls/src/callbacks.rs
@@ -59,8 +59,7 @@ where
     let mut conn = ManuallyDrop::new(Connection::from_raw(raw));
     let config = conn.config().expect("config should not be null");
     let context = config.context();
-    let r = action(&mut conn, context);
-    r
+    action(&mut conn, context)
 }
 
 /// A trait for the callback used to verify host name(s) during X509
@@ -104,12 +103,7 @@ pub(crate) unsafe fn verify_host(
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        callbacks::with_context,
-        config::{Config, Context},
-        connection::{Builder, Connection},
-        enums::Mode,
-    };
+    use crate::{callbacks::with_context, config::Config, connection::Builder, enums::Mode};
 
     // The temporary connection created in `with_context` should never be freed,
     // even if customer code panics.


### PR DESCRIPTION
### Description of changes: 

We should never be freeing the temporary connection in `with_context`, even during an unwind. To prevent this make the connection `ManuallyDrop` during initialization.

~~Secondly, `with_context` may be invoked concurrently, so we should use `context` not `context_mut`.~~
Moved to #5701

### Testing:

I added a unit test which confirms that the connection is not freed during a panic. I confirmed that the old behavior causes this test to fail.

```
~/workspace/s2n-tls/bindings/rust/extended$ cargo test panic_does_not_free_connection -- --nocapture

running 1 test
thread 'callbacks::tests::panic_does_not_free_connection' panicked at 'a panic in customer code', s2n-tls/src/callbacks.rs:121:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'callbacks::tests::panic_does_not_free_connection' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `2`', s2n-tls/src/callbacks.rs:141:9
error: test failed, to rerun pass '-p s2n-tls --lib'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
