### PR TITLE
fix: don't use DEPENDS with add_custom_command(TARGET)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,7 +445,6 @@ if (S2N_INTERN_LIBCRYPTO)
         # add all of the prefixed symbols to the archive
         add_custom_command(
             TARGET ${PROJECT_NAME} POST_BUILD
-            DEPENDS libcrypto.symbols
             COMMAND
                 bash -c "${CMAKE_AR} -r lib/libs2n.a s2n_libcrypto/*.o"
             VERBATIM


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves #5073

### Description of changes: 

We can use `DEPENDS` for `add_custom_command(OUTPUT)` but can't use `DEPENDS` for `add_custom_command(TARGET)`.

See also the `add_custom_command(TARGET)` document:
https://cmake.org/cmake/help/latest/command/add_custom_command.html#build-events

If we use `DEPENDS` for `add_custom_command(TARGET)`, the following warning is reported:

    The following keywords are not supported when using
    add_custom_command(TARGET): DEPENDS.

We can just remove `DEPENDS` to suppress the warning.

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? What manual testing was performed? Are there any testing steps to be verified by the reviewer?

`cmake -DS2N_INTERN_LIBCRYPTO=ON` doesn't report the warning with this.

How can you convince your reviewers that this PR is safe and effective?

This just removes the warned and ignored argument.

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

No.

Remember:
* Any change to the library source code should at least include unit tests.
* Any change to the core stuffer or blob methods should include [CBMC proofs](https://github.com/aws/s2n-tls/tree/main/tests/cbmc).
* Any change to the CI or tests should:
   1. prove that the test succeeds for good input
   2. prove that the test fails for bad input (eg, a test for memory leaks fails when a memory leak is committed)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
