### PR TITLE
fix(ci): Allow validate_start_codebuild to run on pushes to main

### DIFF
--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -144,7 +144,7 @@ jobs:
         with:
           route: GET /repos/{repo}/commits/{ref}/statuses?per_page=100
           repo: ${{ github.repository }}
-          ref: ${{ github.event.merge_group.head_sha || github.event.pull_request.head.sha }}
+          ref: ${{ github.event.merge_group.head_sha || github.event.pull_request.head.sha || github.event.after }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: check start_codebuild.sh against statuses


### PR DESCRIPTION
### Description of changes: 

The `validate start_codebuild.sh` workflow [is currently failing on pushes to main](https://github.com/aws/s2n-tls/actions/runs/13081987519/job/36507254713). This is because `ref` is defined for merge group and pull request events, but not the push event:
https://github.com/aws/s2n-tls/blob/c6b41ef06d539d040315208fd9edeba221093fa7/.github/workflows/ci_linting.yml#L147

This PR also defines `ref` for the push to main event, allowing this job to succeed on pushes to main.

### Call-outs:

None

### Testing:

I tested this change by running it on my fork. The codebuild jobs don't actually start on my fork, so  the job still fails, but you can see `ref` is [undefined in the failing job](https://github.com/aws/s2n-tls/actions/runs/13081987519/job/36507254713#step:4:12) and [defined in the job on my fork](https://github.com/goatgoose/s2n-tls/actions/runs/13142410076/job/36672487123#step:5:13).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
