### PR TITLE
fix(integration): Update PQ integration test expectations

### DIFF
--- a/bindings/rust/standard/integration/src/network/tls_client.rs
+++ b/bindings/rust/standard/integration/src/network/tls_client.rs
@@ -53,7 +53,7 @@ mod kms_pq {
             tls.as_ref().cipher_suite()?,
             "TLS_AES_256_GCM_SHA384"
         );
-        assert_eq!(tls.as_ref().kem_group_name(), Some("x25519_kyber-512-r3"));
+        assert!(tls.as_ref().kem_group_name().unwrap().to_lowercase().contains("kyber"));
 
         Ok(())
     }

--- a/bindings/rust/standard/integration/src/network/tls_client.rs
+++ b/bindings/rust/standard/integration/src/network/tls_client.rs
@@ -40,20 +40,16 @@ mod kms_pq {
     const DOMAIN: &str = "kms.us-east-1.amazonaws.com";
 
     // confirm that we successfully negotiate a supported PQ key exchange.
-    //
-    // Note: In the future KMS will deprecate kyber_r3 in favor of ML-KEM.
-    // At that point this test should be updated with a security policy that
-    // supports ML-KEM.
     #[test_log::test(tokio::test)]
     async fn pq_handshake() -> Result<(), Box<dyn std::error::Error>> {
-        let policy = Policy::from_version("PQ-TLS-1-2-2023-10-09")?;
+        let policy = Policy::from_version("20241001")?;
         let tls = handshake_with_domain(DOMAIN, &policy).await?;
 
         assert_eq!(
             tls.as_ref().cipher_suite()?,
             "TLS_AES_256_GCM_SHA384"
         );
-        assert!(tls.as_ref().kem_group_name().unwrap().to_lowercase().contains("kyber"));
+        assert_eq!(tls.as_ref().kem_group_name(), Some("X25519MLKEM768"));
 
         Ok(())
     }


### PR DESCRIPTION
### Description of changes: 

The [KMS PQ network integration test](https://github.com/aws/s2n-tls/blob/c6b41ef06d539d040315208fd9edeba221093fa7/bindings/rust/standard/integration/src/network/tls_client.rs#L42-L60) recently [started failing in CI](https://github.com/aws/s2n-tls/actions/runs/13143879237/job/36680079905?pr=5080#step:11:41) because KMS started negotiating a different KEM group:
```
assertion `left == right` failed
  left: Some("SecP256r1Kyber768Draft00")
 right: Some("x25519_kyber-512-r3")
```

We're currently expecting `x25519_kyber-512-r3` to be negotiated, but KMS is now negotiating `SecP256r1Kyber768Draft00`.

I don't believe this to be indicative of any regression on our side, since this failure wasn't caused by any specific PR. Also, `SecP256r1Kyber768Draft00` is actually a more preferred KEM group in the test security policy (`PQ-TLS-1-2-2023-10-09`):
https://github.com/aws/s2n-tls/blob/c6b41ef06d539d040315208fd9edeba221093fa7/tls/s2n_kem_preferences.c#L30-L32

This PR updates the expectations of this test.

### Call-outs:

The purpose of this test is simply to verify that we can successfully perform a PQ handshake. The specific KEM group seems less important. So I updated this test to just check that any kyber KEM group was negotiated. We could instead update this test to check for the new KEM group specifically, if this seems preferable.

### Testing:

The PQ integration test should now succeed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
