### PR TITLE
fix(integrationv2): Skip unsupported client auth tests

### DIFF
--- a/codebuild/spec/buildspec_ubuntu_integrationv2.yml
+++ b/codebuild/spec/buildspec_ubuntu_integrationv2.yml
@@ -36,7 +36,7 @@ batch:
             - openssl-1.1.1_gcc9
             - openssl-3.0
           INTEGV2_TEST:
-            - "test_dynamic_record_sizes test_sslyze test_sslv2_client_hello"
+            - "test_client_authentication test_dynamic_record_sizes test_sslyze test_sslv2_client_hello"
             - "test_happy_path"
             - "test_cross_compatibility"
             - "test_early_data test_well_known_endpoints test_hello_retry_requests test_sni_match test_pq_handshake test_fragmentation test_key_update"

--- a/tests/integrationv2/utils.py
+++ b/tests/integrationv2/utils.py
@@ -72,7 +72,7 @@ def invalid_test_parameters(*args, **kwargs):
     # Always consider S2N
     providers.append(S2N)
 
-    certificates = [certificate_ for certificate_ in [certificate, client_certificate] if certificate_]
+    certificates = [cert for cert in [certificate, client_certificate] if cert]
 
     # Older versions do not support RSA-PSS-PSS certificates
     if protocol and protocol < Protocols.TLS12:

--- a/tests/integrationv2/utils.py
+++ b/tests/integrationv2/utils.py
@@ -72,6 +72,8 @@ def invalid_test_parameters(*args, **kwargs):
     # Always consider S2N
     providers.append(S2N)
 
+    certificates = [certificate_ for certificate_ in [certificate, client_certificate] if certificate_]
+
     # Older versions do not support RSA-PSS-PSS certificates
     if protocol and protocol < Protocols.TLS12:
         if client_certificate and client_certificate.algorithm == 'RSAPSS':
@@ -82,6 +84,10 @@ def invalid_test_parameters(*args, **kwargs):
     for provider_ in providers:
         if not provider_.supports_protocol(protocol):
             return True
+
+        for certificate_ in certificates:
+            if not provider_.supports_certificate(certificate_):
+                return True
 
     if cipher is not None:
         # If the selected protocol doesn't allow the cipher, don't test
@@ -105,10 +111,6 @@ def invalid_test_parameters(*args, **kwargs):
     # If we are using a cipher that depends on a specific certificate algorithm
     # deselect the test if the wrong certificate is used.
     if certificate is not None:
-        if protocol is not None:
-            for provider_ in providers:
-                if provider_.supports_protocol(protocol, with_cert=certificate) is False:
-                    return True
         if cipher is not None and certificate.compatible_with_cipher(cipher) is False:
             return True
 


### PR DESCRIPTION
### Description of changes: 

The client auth integration test is not currently running on PRs, and it fails when I run it. This PR fixes this test and adds it to the integrationv2 buildspec so it will run on PRs.

I _think_ this test would have started failing after https://github.com/aws/s2n-tls/pull/4949, which started allowing RSA PSS certificates to be used with TLS 1.2 in the integration tests. I think this change broke the client auth test because there's currently no logic to prevent an RSA PSS cert from being tested in a scenario in which one peer supports RSA PSS signing and the other doesn't.

This worked before when RSA PSS certificates were only tested in TLS 1.3 since TLS 1.3 tests are skipped if either provider doesn't support TLS 1.3:
https://github.com/aws/s2n-tls/blob/806830de6a3b98d0bdead01f8408ecb5a6f58723/tests/integrationv2/utils.py#L82-L84

This PR updates the test skipping logic to skip testing RSA PSS certificates if _either_ of the two providers don't support RSA PSS signing.

<details>
<summary>Test failure investigation</summary>
<br>

The test fails with the following error:
```
Stderr: Failed to negotiate: 'Server requires client certificate'. Error encountered in /codebuild/output/src2447279014/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/s2n_replica/third-party-src/tls/s2n_handshake_io.c:1108
```

I think this error is caused by an s2n-tls server that doesn't support RSA PSS signing, and an OpenSSL 1.1.1 client that does support RSA PSS signing. The test certs are being correctly filtered for the server, so s2n-tls is given a normal RSA cert. But the client certificate isn't filtered, so OpenSSL 1.1.1 is given an RSA PSS certificate. I think since OpenSSL 1.1.1 supports RSA PSS certificates, the failure isn't observed until later when OpenSSL doesn't send any client certificate to s2n-tls, likely because s2n-tls isn't negotiating RSA PSS as the signature algorithm.

</details>

### Call-outs:

It seemed weird that the logic for skipping certificates is in `supports_protocol()`, so I moved this to a separate `supports_certificate()` function.

### Testing:

The client auth test was re-added to the integrationv2 buildspec for PRs, and should now succeed in this PR. I confirmed that it's now running: 
```
    Start 276: integrationv2_client_authentication
```

I double checked that we're still testing RSA PSS certificates when s2n-tls is linked to a libcrypto that supports RSA PSS signing. Examples from the [aws-lc log](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiQzJvYzVDcjhhQ21KZzJCbzN5eDVEV2pOcGNaTlhpSzIvNm5ESktJT01mMS9NZ0FtMjUzV1htd0NoeEJNTGRqTG10NWkzeUt1djR2QjFHc3RraG1wWmhSUHNjbHdxZ1pSMHVMRlZ0MitQKzBUSUJPVkJKNTFtY3Q4Wnc9PSIsIml2UGFyYW1ldGVyU3BlYyI6IjF3VDZIVTFhaDJsMlhzSy8iLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D/build/543c0043-04cf-4b67-bfe2-9fac4f0c443f):
```
276: [gw1] [  0%] PASSED test_client_authentication.py::test_client_auth_with_s2n_server[RSA_4096_SHA512-RSA_PSS_2048_SHA256-DHE-RSA-AES256-GCM-SHA384-TLS1.2-S2N-OpenSSL] 
276: [gw1] [  1%] PASSED test_client_authentication.py::test_client_auth_with_s2n_server[RSA_4096_SHA512-RSA_PSS_2048_SHA256-TLS_CHACHA20_POLY1305_SHA256-TLS1.3-S2N-OpenSSL] 
276: [gw1] [ 28%] PASSED test_client_authentication.py::test_client_auth_with_s2n_server[RSA_PSS_2048_SHA256-RSA_1024_SHA256-DHE-RSA-AES128-SHA-TLS1.2-S2N-OpenSSL] 
276: [gw1] [ 29%] PASSED test_client_authentication.py::test_client_auth_with_s2n_server[RSA_PSS_2048_SHA256-RSA_1024_SHA256-TLS_AES_128_GCM_SHA256-TLS1.3-S2N-OpenSSL] 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
