### PR TITLE
feat(bindings): add psk selection api

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/callbacks.rs
+++ b/bindings/rust/extended/s2n-tls/src/callbacks.rs
@@ -32,6 +32,9 @@ pub use async_cb::*;
 mod client_hello;
 pub use client_hello::*;
 
+pub(crate) mod psk_selection;
+pub use psk_selection::PskSelectionCallback;
+
 mod session_ticket;
 pub use session_ticket::*;
 

--- a/bindings/rust/extended/s2n-tls/src/callbacks/psk_selection.rs
+++ b/bindings/rust/extended/s2n-tls/src/callbacks/psk_selection.rs
@@ -1,0 +1,445 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    marker::PhantomData,
+    ptr::{self, NonNull},
+};
+
+use s2n_tls_sys::*;
+
+use crate::{
+    connection::Connection,
+    error::Fallible,
+    foreign_types::{Opaque, S2NRef},
+};
+
+struct OfferedPsk<'callback> {
+    ptr: NonNull<s2n_offered_psk>,
+    // The `&[u8]` returned from `OfferedPsk::identity` is not owned by the OfferedPsk
+    // struct, but instead is a reference to the wire_input stuffer of the s2n_offered_psk
+    wire_input: PhantomData<&'callback [u8]>,
+}
+
+impl<'callback> OfferedPsk<'callback> {
+    fn allocate() -> Result<Self, crate::error::Error> {
+        let ptr = unsafe { s2n_offered_psk_new().into_result() }?;
+        Ok(Self {
+            ptr,
+            wire_input: PhantomData,
+        })
+    }
+
+    /// Return the identity associated with an offered PSK.
+    pub fn identity(&self) -> Result<&'callback [u8], crate::error::Error> {
+        let mut identity_buffer = ptr::null_mut::<u8>();
+        let mut size = 0;
+        unsafe {
+            s2n_offered_psk_get_identity(self.ptr.as_ptr(), &mut identity_buffer, &mut size)
+                .into_result()?
+        };
+
+        Ok(unsafe {
+            // SAFETY: valid, aligned, non-null -> If the s2n-tls API didn't fail
+            //         (which we check for) then data will be non-null, valid for
+            //         reads, and aligned.
+            // SAFETY: the memory is not mutated -> For the life of the PSK Selection
+            //         callback, nothing else is mutating the wire buffer which
+            //         is the backing memory of the identities.
+            std::slice::from_raw_parts(identity_buffer, size as usize)
+        })
+    }
+}
+
+impl Drop for OfferedPsk<'_> {
+    fn drop(&mut self) {
+        let mut s2n_ptr = self.ptr.as_ptr();
+        // ignore failures. There isn't anything to be done to handle them, but
+        // allowing the program to continue is preferable to crashing.
+        let _ = unsafe { s2n_offered_psk_free(&mut s2n_ptr).into_result() };
+    }
+}
+
+pub struct OfferedPskListRef<'callback> {
+    _ptr: Opaque,
+    // s2n_offered_psk_list has a stuffer that refers to the wire_input from
+    // the connection. This stuffer is valid for the lifetime of the callback.
+    wire_input: PhantomData<&'callback [u8]>,
+}
+
+impl S2NRef for OfferedPskListRef<'_> {
+    type ForeignType = s2n_offered_psk_list;
+}
+
+impl<'callback> OfferedPskListRef<'callback> {
+    /// Return an iterator over the PSK identities offered by the client.
+    //
+    // Given an &OfferedPskListRef of some lifetime '_ which holds wire_input that
+    // is valid for 'callback, return an IdentitySelector which borrows list for
+    // the lifetime of the selector, but which can return identities valid for
+    // the lifetime of 'callback.
+    pub fn identities(&mut self) -> Result<IdentitySelector<'_, 'callback>, crate::error::Error> {
+        self.reread()?;
+        Ok(IdentitySelector {
+            psk: OfferedPsk::allocate()?,
+            list: self,
+        })
+    }
+
+    // Return a selector over the OfferedPsks that the client has
+    // sent.
+    // We write tests for this workflow to ensure that it could be made public
+    // in the future if additional fields of OfferedPsk are exposed.
+    #[cfg(test)]
+    fn offered_psks(&mut self) -> Result<OfferedPskSelector<'_, 'callback>, crate::error::Error> {
+        self.reread()?;
+        Ok(OfferedPskSelector {
+            psk: OfferedPsk::allocate()?,
+            list: self,
+        })
+    }
+
+    fn has_next(&self) -> bool {
+        // SAFETY: *mut cast - s2n-tls does not treat the pointer as mutable.
+        unsafe { s2n_offered_psk_list_has_next(self.as_s2n_ptr() as *mut _) }
+    }
+
+    fn next(&mut self, psk: &mut OfferedPsk) -> Result<(), crate::error::Error> {
+        let psk_ptr = psk.ptr.as_ptr();
+        unsafe { s2n_offered_psk_list_next(self.as_s2n_ptr_mut(), psk_ptr).into_result() }?;
+        Ok(())
+    }
+
+    fn choose_psk(&mut self, psk: &OfferedPsk) -> Result<(), crate::error::Error> {
+        let mut_psk = psk.ptr.as_ptr();
+        unsafe { s2n_offered_psk_list_choose_psk(self.as_s2n_ptr_mut(), mut_psk).into_result()? };
+        Ok(())
+    }
+
+    fn reread(&mut self) -> Result<(), crate::error::Error> {
+        unsafe { s2n_offered_psk_list_reread(self.as_s2n_ptr_mut()).into_result() }?;
+        Ok(())
+    }
+}
+
+pub struct IdentitySelector<'selector, 'callback> {
+    psk: OfferedPsk<'callback>,
+    // it is necessary for 'callback to outlive 'selector, because we want to be able
+    // to create multiple 'selector within the scope of a single 'callback.
+    list: &'selector mut OfferedPskListRef<'callback>,
+}
+
+impl IdentitySelector<'_, '_> {
+    /// Choose the PSK returned from the last call to `next()` to negotiate with.
+    ///
+    /// If no offered PSK is acceptable, implementors can return from the callback
+    /// without calling this function to reject the connection.
+    pub fn choose_current_psk(&mut self) -> Result<(), crate::error::Error> {
+        self.list.choose_psk(&self.psk)
+    }
+}
+
+impl<'callback> Iterator for IdentitySelector<'_, 'callback> {
+    type Item = Result<&'callback [u8], crate::error::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.list.has_next() {
+            if let Err(e) = self.list.next(&mut self.psk) {
+                return Some(Err(e));
+            }
+            Some(self.psk.identity())
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+struct OfferedPskSelector<'selector, 'callback> {
+    psk: OfferedPsk<'callback>,
+    list: &'selector mut OfferedPskListRef<'callback>,
+}
+
+#[cfg(test)]
+impl OfferedPskSelector<'_, '_> {
+    /// Advance the cursor, returning the currently selected PSK.
+    fn advance(&mut self) -> Result<Option<&OfferedPsk>, crate::error::Error> {
+        if !self.list.has_next() {
+            Ok(None)
+        } else {
+            self.list.next(&mut self.psk)?;
+            Ok(Some(&self.psk))
+        }
+    }
+
+    /// Choose the currently selected PSK to negotiate with.
+    ///
+    /// If no offered PSK is acceptable, implementors can return from the callback
+    /// without calling this function to reject the connection.
+    fn choose_current_psk(&mut self) -> Result<(), crate::error::Error> {
+        self.list.choose_psk(&self.psk)
+    }
+
+    /// Reset the cursor, allowing the list to be reread.
+    fn reset(&mut self) -> Result<(), crate::error::Error> {
+        self.list.reread()?;
+        Ok(())
+    }
+}
+
+/// A trait used by the server to select an external PSK given a client's offered
+/// list of PSKs.
+///
+/// If working with small numbers of PSKs, consider just directly using [Connection::append_psk].
+///
+/// Used in conjunction with [crate::config::Builder::set_psk_selection_callback].
+pub trait PskSelectionCallback: 'static + Send + Sync {
+    /// Select a psk using the [OfferedPskListRef].
+    ///
+    /// Use [`OfferedPskListRef::identities`] to retrieve an iterator over the
+    /// identities that the client has offered.
+    ///
+    /// Before calling [`IdentitySelector::choose_current_psk`], implementors must
+    /// first append the corresponding [`crate::psk::Psk`] to the
+    /// connection using [`Connection::append_psk`].
+    fn select_psk(&self, connection: &mut Connection, psk_list: &mut OfferedPskListRef);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        ops::Deref,
+        sync::{
+            atomic::{self, AtomicBool},
+            Arc,
+        },
+    };
+
+    use crate::error::Error as S2NError;
+
+    use crate::{
+        config::Config,
+        error::{ErrorSource, ErrorType},
+        psk::Psk,
+        security::DEFAULT_TLS13,
+        testing::TestPair,
+    };
+
+    use super::*;
+
+    type Identity = [u8; 8];
+
+    #[derive(Clone)]
+    struct TestPskStore {
+        store: Arc<Vec<Psk>>,
+        invoked: Arc<AtomicBool>,
+    }
+
+    impl TestPskStore {
+        const SIZE: u8 = 200;
+        const ID_LEN: usize = 8;
+
+        fn psk_identity(id: u8) -> Identity {
+            [id; Self::ID_LEN]
+        }
+
+        fn test_psk(id: u8) -> Result<Psk, S2NError> {
+            let mut psk = Psk::builder()?;
+            psk.set_identity(&Self::psk_identity(id))?
+                .set_secret(&[id + 1; 16])?
+                .set_hmac(crate::enums::PskHmac::SHA384)?;
+            psk.build()
+        }
+
+        pub fn new() -> Result<Self, S2NError> {
+            let store = (0..Self::SIZE)
+                .map(Self::test_psk)
+                .filter_map(Result::ok)
+                .collect();
+            Ok(Self {
+                store: Arc::new(store),
+                invoked: Arc::new(AtomicBool::new(false)),
+            })
+        }
+
+        pub fn get_by_identity(&self, identity: &[u8]) -> Option<&Psk> {
+            let index = identity[0];
+            self.store.get(index as usize)
+        }
+    }
+
+    impl PskSelectionCallback for TestPskStore {
+        fn select_psk(&self, connection: &mut Connection, psk_list: &mut OfferedPskListRef) {
+            self.invoked.store(true, atomic::Ordering::Relaxed);
+
+            let identities: Vec<&[u8]> = psk_list
+                .identities()
+                .unwrap()
+                .map(|psk| psk.unwrap())
+                .collect();
+
+            // identities are successfully read
+            for (i, identity) in identities.iter().enumerate() {
+                assert_eq!(&[i as u8; TestPskStore::ID_LEN], *identity);
+            }
+
+            // reset (called internally by OfferedPskListRef::identities) yields
+            // the same identities again
+            let identities_again: Vec<&[u8]> = psk_list
+                .identities()
+                .unwrap()
+                .map(|psk| psk.unwrap())
+                .collect();
+
+            assert_eq!(identities.len(), Self::SIZE as usize);
+            assert_eq!(identities, identities_again);
+
+            let mut identity_selector = psk_list.identities().unwrap();
+            let chosen = identity_selector.next().unwrap().unwrap();
+
+            let chosen_external = self.get_by_identity(chosen).unwrap();
+            connection.append_psk(chosen_external).unwrap();
+            identity_selector.choose_current_psk().unwrap();
+        }
+    }
+
+    #[test]
+    fn psk_handshake_with_callback() -> Result<(), S2NError> {
+        let psk_store = TestPskStore::new()?;
+        let client_psks = psk_store.clone();
+
+        let mut config = Config::builder();
+        config.set_security_policy(&DEFAULT_TLS13)?;
+        config.set_psk_selection_callback(psk_store)?;
+
+        let config = config.build()?;
+        let mut test_pair = TestPair::from_config(&config);
+        for psk in client_psks.store.iter() {
+            test_pair.client.append_psk(psk)?;
+        }
+        assert!(test_pair.handshake().is_ok());
+        assert!(client_psks.invoked.load(atomic::Ordering::Relaxed));
+        Ok(())
+    }
+
+    #[test]
+    // If choose_current_psk is called when there isn't a current psk, s2n-tls
+    // should return a well formed error.
+    fn choose_without_current_psk() -> Result<(), crate::error::Error> {
+        #[derive(Clone, Default)]
+        struct ImmediateSelect {
+            invoked: Arc<AtomicBool>,
+        }
+
+        impl PskSelectionCallback for ImmediateSelect {
+            fn select_psk(&self, _connection: &mut Connection, psk_list: &mut OfferedPskListRef) {
+                self.invoked.store(true, atomic::Ordering::Relaxed);
+
+                let err = psk_list
+                    .identities()
+                    .unwrap()
+                    .choose_current_psk()
+                    .unwrap_err();
+                assert_eq!(err.kind(), ErrorType::InternalError);
+                assert_eq!(err.source(), ErrorSource::Library);
+            }
+        }
+
+        let selector = ImmediateSelect::default();
+        let selector_handle = selector.clone();
+        let mut config = Config::builder();
+        config.set_security_policy(&DEFAULT_TLS13)?;
+        config.set_psk_selection_callback(selector)?;
+
+        let mut test_pair = TestPair::from_config(&config.build()?);
+        test_pair.client.append_psk(&TestPskStore::test_psk(1)?)?;
+        assert!(test_pair.handshake().is_err());
+        assert!(selector_handle.invoked.load(atomic::Ordering::Relaxed));
+        Ok(())
+    }
+
+    #[test]
+    // If choose_current_psk isn't called, then the handshake should fail gracefully.
+    fn no_chosen_psk() -> Result<(), crate::error::Error> {
+        #[derive(Clone, Default)]
+        struct NeverSelect(Arc<AtomicBool>);
+
+        impl PskSelectionCallback for NeverSelect {
+            fn select_psk(
+                &self,
+                _connection: &mut Connection,
+                _psk_cursor: &mut OfferedPskListRef,
+            ) {
+                self.0.store(true, atomic::Ordering::Relaxed);
+                // return without calling cursor.choose_current_psk
+            }
+        }
+
+        let selector = NeverSelect::default();
+        let selector_handle = selector.clone();
+        let mut config = Config::builder();
+        config.set_security_policy(&DEFAULT_TLS13)?;
+        config.set_psk_selection_callback(selector)?;
+
+        let mut test_pair = TestPair::from_config(&config.build()?);
+        test_pair.client.append_psk(&TestPskStore::test_psk(1)?)?;
+
+        let err = test_pair.handshake().unwrap_err();
+        assert_eq!(err.kind(), ErrorType::ProtocolError);
+        assert_eq!(err.source(), ErrorSource::Library);
+        assert!(selector_handle.0.load(atomic::Ordering::Relaxed));
+        Ok(())
+    }
+
+    #[test]
+    fn offered_psk_selector_workflow() -> Result<(), S2NError> {
+        struct UseOfferedPskSelector(TestPskStore);
+        impl Deref for UseOfferedPskSelector {
+            type Target = TestPskStore;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl PskSelectionCallback for UseOfferedPskSelector {
+            fn select_psk(&self, connection: &mut Connection, psk_list: &mut OfferedPskListRef) {
+                self.invoked.store(true, atomic::Ordering::Relaxed);
+
+                let identities: Vec<&[u8]> = psk_list
+                    .identities()
+                    .unwrap()
+                    .map(|psk| psk.unwrap())
+                    .collect();
+
+                let mut identities_from_offered_psk = Vec::new();
+                let mut offered_psks = psk_list.offered_psks().unwrap();
+                while let Some(psk) = offered_psks.advance().unwrap() {
+                    // `psk.identity()` can not outlive `psk`, so use to_owned()
+                    identities_from_offered_psk.push(psk.identity().unwrap().to_owned());
+                }
+
+                // the identities from the iterators should be the same
+                assert_eq!(identities, identities_from_offered_psk);
+
+                offered_psks.reset().unwrap();
+                let psk = offered_psks.advance().unwrap().unwrap();
+                let identity = psk.identity().unwrap();
+                let psk = self.get_by_identity(identity).unwrap();
+                connection.append_psk(psk).unwrap();
+                offered_psks.choose_current_psk().unwrap();
+            }
+        }
+
+        let selector = UseOfferedPskSelector(TestPskStore::new()?);
+        let mut config = Config::builder();
+        config.set_security_policy(&DEFAULT_TLS13)?;
+        config.set_psk_selection_callback(selector)?;
+
+        let mut test_pair = TestPair::from_config(&config.build()?);
+        test_pair.client.append_psk(&TestPskStore::test_psk(1)?)?;
+        assert!(test_pair.handshake().is_ok());
+
+        Ok(())
+    }
+}

--- a/bindings/rust/extended/s2n-tls/src/config.rs
+++ b/bindings/rust/extended/s2n-tls/src/config.rs
@@ -4,10 +4,11 @@
 #[cfg(feature = "unstable-renegotiate")]
 use crate::renegotiate::RenegotiateCallback;
 use crate::{
-    callbacks::*,
+    callbacks::{psk_selection::OfferedPskListRef, *},
     cert_chain::CertificateChain,
     enums::*,
     error::{Error, ErrorType, Fallible},
+    foreign_types::S2NRef,
     security,
 };
 use core::{convert::TryInto, ptr::NonNull};
@@ -673,6 +674,38 @@ impl Builder {
         Ok(self)
     }
 
+    pub fn set_psk_selection_callback<T: PskSelectionCallback>(
+        &mut self,
+        handler: T,
+    ) -> Result<&mut Self, Error> {
+        unsafe extern "C" fn psk_selection_cb(
+            conn_ptr: *mut s2n_connection,
+            _context: *mut ::libc::c_void,
+            psk_list_ptr: *mut s2n_offered_psk_list,
+        ) -> libc::c_int {
+            let psk_list = OfferedPskListRef::from_s2n_ptr_mut(psk_list_ptr);
+            with_context(conn_ptr, |conn, context| {
+                let callback = context.psk_selection_callback.as_ref();
+                callback.map(|c| c.select_psk(conn, psk_list))
+            });
+            CallbackResult::Success.into()
+        }
+
+        let handler = Box::new(handler);
+        let context = self.config.context_mut();
+        context.psk_selection_callback = Some(handler);
+
+        unsafe {
+            s2n_config_set_psk_selection_callback(
+                self.as_mut_ptr(),
+                Some(psk_selection_cb),
+                self.config.context() as *const Context as *mut c_void,
+            )
+            .into_result()?
+        };
+        Ok(self)
+    }
+
     /// Set a callback function triggered by operations requiring the private key.
     ///
     /// See https://github.com/aws/s2n-tls/blob/main/docs/USAGE-GUIDE.md#private-key-operation-related-calls
@@ -882,6 +915,12 @@ impl Builder {
         Ok(self)
     }
 
+    /// Corresponds to [`s2n_config_set_psk_mode`].
+    pub fn set_psk_mode(&mut self, mode: PskMode) -> Result<&mut Self, Error> {
+        unsafe { s2n_config_set_psk_mode(self.as_mut_ptr(), mode.into()).into_result()? };
+        Ok(self)
+    }
+
     /// Sets a configurable blinding delay instead of the default
     ///
     /// Corresponds to [s2n_config_set_max_blinding_delay].
@@ -964,6 +1003,7 @@ pub(crate) struct Context {
     pub(crate) private_key_callback: Option<Box<dyn PrivateKeyCallback>>,
     pub(crate) verify_host_callback: Option<Box<dyn VerifyHostNameCallback>>,
     pub(crate) session_ticket_callback: Option<Box<dyn SessionTicketCallback>>,
+    pub(crate) psk_selection_callback: Option<Box<dyn PskSelectionCallback>>,
     pub(crate) connection_initializer: Option<Box<dyn ConnectionInitializer>>,
     pub(crate) wall_clock: Option<Box<dyn WallClock>>,
     pub(crate) monotonic_clock: Option<Box<dyn MonotonicClock>>,
@@ -984,6 +1024,7 @@ impl Default for Context {
             private_key_callback: None,
             verify_host_callback: None,
             session_ticket_callback: None,
+            psk_selection_callback: None,
             connection_initializer: None,
             wall_clock: None,
             monotonic_clock: None,

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -1322,7 +1322,8 @@ impl Connection {
 
     /// Append an external psk to a connection.
     ///
-    /// This may be called repeatedly to support multiple PSKs.
+    /// This may be called repeatedly to support multiple PSKs. If working with
+    /// large numbers of PSKs, consider using a [`PskSelectionCallback`].
     ///
     /// Corresponds to [s2n_connection_append_psk].
     pub fn append_psk(&mut self, psk: &Psk) -> Result<(), Error> {

--- a/bindings/rust/extended/s2n-tls/src/foreign_types.rs
+++ b/bindings/rust/extended/s2n-tls/src/foreign_types.rs
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! s2n-tls uses a dual-type approach to represent ownership. One type represents
+//! owned values, and the other type represents borrowed values. This is the same
+//! approach used by the OpenSSL/[ForeignTypes](https://docs.rs/foreign-types/latest/foreign_types/)
+//! crate.
+//!
+//! We don't directly use the `ForeignTypes` trait for this functionality because
+//! we don't want consumers of the [s2n-tls] crate to be able to easily retrieve
+//! the underlying pointers to s2n-tls-sys types.
+//!
+//! When using this pattern, prefer to implement functionality on the most general
+//! type (the Ref type) and then add a `Deref` impl from the owned type to the ref
+//! type.
+//! ```no_compile
+//! struct Dog {
+//!     ptr: NonNull<s2n_dog>
+//! }
+//!
+//! impl Deref for Dog {
+//!     type Target = DogRef;
+//!
+//!     fn deref(&self) -> &Self::Target {
+//!         ...
+//!     }
+//! }
+//!
+//! struct DogRef(Opaque);
+//!
+//! impl S2NRef for DogRef {
+//!     type ForeignType = s2n_dog;
+//! }
+//!
+//! impl DogRef {
+//!     fn bark(&self);
+//! }
+//! ```
+//! In the above example, `bark` can be done by both `Dog` and `DogRef`, so we
+//! prefer to implement the functionality on DogRef.
+
+use std::{ffi::c_void, marker::PhantomData};
+
+// This opaque approach is largely borrowed from the foreign-types crate
+// https://github.com/sfackler/foreign-types/blob/393f6ab5a5dc66b8a8e2d6d880b1ff80b6a7edc2/foreign-types-shared/src/lib.rs#L14
+// This type acts as if it owns a mutable pointer to some void type.
+#[derive(Debug)]
+pub(crate) struct Opaque(PhantomData<*mut c_void>);
+
+/// This trait is used for structs implementing the RefType pattern.
+///
+/// It allows s2n-tls pointers to be easily retrieved from the reference to the type.
+/// ```no_compile
+/// struct ClientHelloRef(Opaque);
+///
+/// impl S2NRef for ClientHelloRef {
+///     type ForeignType: Size = s2n_tls_sys::s2n_client_hello;
+/// };
+/// ```
+/// SAFETY: both Self and Self::ForeignType must be zero sized.
+pub(crate) trait S2NRef: Sized {
+    type ForeignType: Sized;
+
+    fn from_s2n_ptr_mut<'a>(ptr: *mut Self::ForeignType) -> &'a mut Self {
+        debug_assert_eq!(std::mem::size_of::<Self>(), 0);
+        debug_assert_eq!(std::mem::size_of::<Self::ForeignType>(), 0);
+        unsafe { &mut *(ptr as *mut Self) }
+    }
+
+    fn as_s2n_ptr_mut(&mut self) -> *mut Self::ForeignType {
+        self.as_s2n_ptr() as *mut Self::ForeignType
+    }
+
+    fn as_s2n_ptr(&self) -> *const Self::ForeignType {
+        self as *const Self as *const Self::ForeignType
+    }
+}

--- a/bindings/rust/extended/s2n-tls/src/lib.rs
+++ b/bindings/rust/extended/s2n-tls/src/lib.rs
@@ -21,6 +21,7 @@ pub mod connection;
 pub mod enums;
 #[cfg(feature = "unstable-fingerprint")]
 pub mod fingerprint;
+pub(crate) mod foreign_types;
 pub mod init;
 pub mod pool;
 pub mod psk;


### PR DESCRIPTION
### Description of changes: 

Add PSK Selection API

All known use cases for the Psk Callback are mut by just iterating over the identities. This functionality is exposed through the IdentitySelector.

If we were to add additional functionality to the OfferedPsk in the future, we might also want to expose that. So I added that workflow as well, through the OfferedPskSelector (gated behind `#(cfg(test))`)

### Call-outs:
The lifetime stuff is rather dense internally, but the actual trait definition/implementors of the trait don't really have to directly deal with any of the complexity.

### Testing:

Unit tests were added for the PSK callbacks

I also did some quite sanity checks to ensure that the lifetime stuff was preventing bad scenarios.

multiple selectors:
```rust
            let mut more_ids = psk_list.identities().unwrap();
            let mut offered_psks = psk_list.offered_psks().unwrap();
            let thing = more_ids.next();
            let psk = offered_psks.advance();
```
results in
```
error[E0499]: cannot borrow `*psk_list` as mutable more than once at a time
   --> s2n-tls/src/callbacks/psk_selection.rs:409:36
    |
408 |             let mut more_ids = psk_list.identities().unwrap();
    |                                -------- first mutable borrow occurs here
409 |             let mut offered_psks = psk_list.offered_psks().unwrap();
    |                                    ^^^^^^^^ second mutable borrow occurs here
410 |             let thing = more_ids.next();
    |                         -------- first borrow later used here
```

Repeated borrow from offered psk selector:
```rust
            let mut offered_psks = psk_list.offered_psks().unwrap();
            let psk = offered_psks.advance().unwrap().unwrap();
            let psk2 = offered_psks.advance().unwrap().unwrap();
            psk.identity();
```
results in 
```
error[E0499]: cannot borrow `offered_psks` as mutable more than once at a time
   --> s2n-tls/src/callbacks/psk_selection.rs:410:24
    |
409 |             let psk = offered_psks.advance().unwrap().unwrap();
    |                       ------------ first mutable borrow occurs here
410 |             let psk2 = offered_psks.advance().unwrap().unwrap();
    |                        ^^^^^^^^^^^^ second mutable borrow occurs here
411 |             psk.identity();
    |             --- first borrow later used here
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
