### PR TITLE
refactor: remove unused evp support for md5+sha1

### DIFF
--- a/crypto/s2n_evp_signing.c
+++ b/crypto/s2n_evp_signing.c
@@ -16,6 +16,7 @@
 #include "crypto/s2n_evp_signing.h"
 
 #include "crypto/s2n_evp.h"
+#include "crypto/s2n_fips.h"
 #include "crypto/s2n_pkey.h"
 #include "crypto/s2n_rsa_pss.h"
 #include "error/s2n_errno.h"
@@ -50,16 +51,56 @@ static S2N_RESULT s2n_evp_pkey_set_rsa_pss_saltlen(EVP_PKEY_CTX *pctx)
 #endif
 }
 
-bool s2n_evp_signing_supported()
+static bool s2n_evp_md5_sha1_is_supported()
 {
-#ifdef S2N_LIBCRYPTO_SUPPORTS_EVP_MD_CTX_SET_PKEY_CTX
-    /* We can only use EVP signing if the hash state has an EVP_MD_CTX
-     * that we can pass to the EVP signing methods.
-     */
-    return s2n_hash_evp_fully_supported();
+#if defined(S2N_LIBCRYPTO_SUPPORTS_EVP_MD5_SHA1_HASH)
+    return true;
 #else
     return false;
 #endif
+}
+
+static bool s2n_evp_md_ctx_set_pkey_ctx_is_supported()
+{
+#ifdef S2N_LIBCRYPTO_SUPPORTS_EVP_MD_CTX_SET_PKEY_CTX
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool s2n_evp_signing_supported()
+{
+    /* We must use the FIPS-approved EVP APIs in FIPS mode,
+     * but we could also use the EVP APIs outside of FIPS mode.
+     * Only using the EVP APIs in FIPS mode was a choice made to reduce
+     * the impact of adding support for the EVP APIs.
+     * We should consider instead making the EVP APIs the default.
+     */
+    if (!s2n_is_in_fips_mode()) {
+        return false;
+    }
+
+    /* Our EVP signing logic is intended to support FIPS 140-3.
+     * FIPS 140-3 does not allow externally calculated digests (except for
+     * signing, but not verifying, with ECDSA).
+     * See https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/Digital-Signatures,
+     * and note that "component" tests only exist for ECDSA sign.
+     *
+     * We currently work around that restriction by calling EVP_MD_CTX_set_pkey_ctx,
+     * which lets us set a key on an existing hash state. This is important
+     * when we need to handle signing the TLS1.2 client cert verify message,
+     * which requires signing the entire message transcript. If EVP_MD_CTX_set_pkey_ctx
+     * is unavailable (true for openssl-1.0.2), our current EVP logic will not work.
+     *
+     * FIPS 140-3 is also not possible if EVP_md5_sha1() isn't available
+     * (again true for openssl-1.0.2). In that case, we use two separate hash
+     * states to track the md5 and sha1 parts of the hash separately. That means
+     * that we also have to calculate the digests separately, then combine the
+     * result. We therefore only have an externally calculated digest available
+     * for signing or verifying.
+     */
+    return s2n_evp_md_ctx_set_pkey_ctx_is_supported() && s2n_evp_md5_sha1_is_supported();
 }
 
 /* If using EVP signing, override the sign and verify pkey methods.

--- a/crypto/s2n_fips.c
+++ b/crypto/s2n_fips.c
@@ -17,6 +17,7 @@
 
 #include <openssl/crypto.h>
 
+#include "crypto/s2n_evp_signing.h"
 #include "utils/s2n_init.h"
 #include "utils/s2n_safety.h"
 
@@ -64,6 +65,11 @@ int s2n_fips_init(void)
 #if defined(OPENSSL_FIPS) || S2N_OPENSSL_VERSION_AT_LEAST(3, 1, 0)
     POSIX_ENSURE(!s2n_fips_mode_enabled, S2N_ERR_FIPS_MODE_UNSUPPORTED);
 #endif
+
+    /* FIPS requires the use of the FIPS-approved EVP methods */
+    if (s2n_fips_mode_enabled) {
+        POSIX_ENSURE(s2n_evp_signing_supported(), S2N_ERR_FIPS_MODE_UNSUPPORTED);
+    }
 
     /* For now, openssl is only supported for testing */
     if (s2n_libcrypto_is_openssl_fips()) {

--- a/crypto/s2n_fips.c
+++ b/crypto/s2n_fips.c
@@ -17,7 +17,6 @@
 
 #include <openssl/crypto.h>
 
-#include "crypto/s2n_evp_signing.h"
 #include "utils/s2n_init.h"
 #include "utils/s2n_safety.h"
 
@@ -65,11 +64,6 @@ int s2n_fips_init(void)
 #if defined(OPENSSL_FIPS) || S2N_OPENSSL_VERSION_AT_LEAST(3, 1, 0)
     POSIX_ENSURE(!s2n_fips_mode_enabled, S2N_ERR_FIPS_MODE_UNSUPPORTED);
 #endif
-
-    /* FIPS requires the use of the FIPS-approved EVP methods */
-    if (s2n_fips_mode_enabled) {
-        POSIX_ENSURE(s2n_evp_signing_supported(), S2N_ERR_FIPS_MODE_UNSUPPORTED);
-    }
 
     /* For now, openssl is only supported for testing */
     if (s2n_libcrypto_is_openssl_fips()) {

--- a/crypto/s2n_hash.h
+++ b/crypto/s2n_hash.h
@@ -54,8 +54,6 @@ union s2n_hash_low_level_digest {
 /* The evp_digest stores all OpenSSL structs to be used with OpenSSL's EVP hash API's. */
 struct s2n_hash_evp_digest {
     struct s2n_evp_digest evp;
-    /* Always store a secondary evp_digest to allow resetting a hash_state to MD5_SHA1 from another alg. */
-    struct s2n_evp_digest evp_md5_secondary;
 };
 
 /* s2n_hash_state stores the s2n_hash implementation being used (low-level or EVP),

--- a/tests/cbmc/include/cbmc_proof/cbmc_utils.h
+++ b/tests/cbmc/include/cbmc_proof/cbmc_utils.h
@@ -47,13 +47,8 @@ struct rc_keys_from_evp_pkey_ctx {
     int pkey_eckey_refs;
 };
 
-/**
- * In the `rc_keys_from_hash_state`, we store two `rc_keys_from_evp_pkey_ctx` objects:
- * one for the `evp` field and another for `evp_md5_secondary` field.
- */
 struct rc_keys_from_hash_state {
     struct rc_keys_from_evp_pkey_ctx evp;
-    struct rc_keys_from_evp_pkey_ctx evp_md5;
 };
 
 /**

--- a/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/Makefile
@@ -22,7 +22,7 @@ HARNESS_FILE = $(HARNESS_ENTRY).c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
 

--- a/tests/cbmc/proofs/s2n_hash_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_copy/Makefile
@@ -25,7 +25,7 @@ PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_ensure.c

--- a/tests/cbmc/proofs/s2n_hash_digest/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_digest/Makefile
@@ -27,7 +27,7 @@ PROOF_SOURCES += $(OPENSSL_SOURCE)/md5_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/sha_override.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c

--- a/tests/cbmc/proofs/s2n_hash_free/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_free/Makefile
@@ -24,7 +24,7 @@ PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c

--- a/tests/cbmc/proofs/s2n_hash_free/s2n_hash_free_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_free/s2n_hash_free_harness.c
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-#include "crypto/s2n_fips.h"
+#include "crypto/s2n_evp_signing.h"
 #include "crypto/s2n_hash.h"
 
 #include <cbmc_proof/make_common_datastructures.h>
@@ -35,9 +35,8 @@ void s2n_hash_free_harness()
     assert(s2n_hash_free(state) == S2N_SUCCESS);
     if (state != NULL) {
         assert(state->hash_impl->free != NULL);
-        if (s2n_is_in_fips_mode()) {
+        if (s2n_evp_signing_supported()) {
             assert(state->digest.high_level.evp.ctx == NULL);
-            assert(state->digest.high_level.evp_md5_secondary.ctx == NULL);
             assert_rc_decrement_on_hash_state(&saved_hash_state);
         } else {
             assert_rc_unchanged_on_hash_state(&saved_hash_state);
@@ -47,11 +46,10 @@ void s2n_hash_free_harness()
 
     /* Cleanup after expected error cases, for memory leak check. */
     if (state != NULL) {
-        /* 1. `free` leftover EVP_MD_CTX objects if `s2n_is_in_fips_mode`,
+        /* 1. `free` leftover EVP_MD_CTX objects if `s2n_evp_signing_supported`,
               since `s2n_hash_free` is a NO-OP in that case. */
-        if (!s2n_is_in_fips_mode()) {
+        if (!s2n_evp_signing_supported()) {
             S2N_EVP_MD_CTX_FREE(state->digest.high_level.evp.ctx);
-            S2N_EVP_MD_CTX_FREE(state->digest.high_level.evp_md5_secondary.ctx);
         }
 
         /* 2. `free` leftover reference-counted keys (i.e. those with non-zero ref-count),

--- a/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/Makefile
@@ -22,7 +22,7 @@ HARNESS_FILE = $(HARNESS_ENTRY).c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
 

--- a/tests/cbmc/proofs/s2n_hash_init/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_init/Makefile
@@ -24,7 +24,7 @@ PROOF_SOURCES += $(OPENSSL_SOURCE)/md5_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/sha_override.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c

--- a/tests/cbmc/proofs/s2n_hash_new/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_new/Makefile
@@ -22,7 +22,7 @@ HARNESS_FILE = $(HARNESS_ENTRY).c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
 

--- a/tests/cbmc/proofs/s2n_hash_reset/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_reset/Makefile
@@ -27,7 +27,7 @@ PROOF_SOURCES += $(OPENSSL_SOURCE)/md5_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/sha_override.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c

--- a/tests/cbmc/proofs/s2n_hash_update/Makefile
+++ b/tests/cbmc/proofs/s2n_hash_update/Makefile
@@ -27,7 +27,7 @@ PROOF_SOURCES += $(OPENSSL_SOURCE)/md5_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/sha_override.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c
 PROJECT_SOURCES += $(SRCDIR)/utils/s2n_safety.c

--- a/tests/cbmc/proofs/s2n_hmac_copy/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_copy/Makefile
@@ -24,7 +24,7 @@ PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c

--- a/tests/cbmc/proofs/s2n_hmac_digest/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_digest/Makefile
@@ -19,7 +19,7 @@ HARNESS_FILE = $(HARNESS_ENTRY).c
 
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_copy.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_digest.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_update.c

--- a/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/Makefile
@@ -19,7 +19,7 @@ HARNESS_FILE = $(HARNESS_ENTRY).c
 
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_copy.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_digest.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_hash_reset.c

--- a/tests/cbmc/proofs/s2n_hmac_free/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_free/Makefile
@@ -24,7 +24,7 @@ PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_SOURCE)/cbmc_utils.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c

--- a/tests/cbmc/proofs/s2n_hmac_free/s2n_hmac_free_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_free/s2n_hmac_free_harness.c
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-#include "crypto/s2n_fips.h"
+#include "crypto/s2n_evp_signing.h"
 #include "crypto/s2n_hash.h"
 
 #include <cbmc_proof/make_common_datastructures.h>
@@ -44,21 +44,17 @@ void s2n_hmac_free_harness()
         assert(state->outer.hash_impl->free != NULL);
         assert(state->outer_just_key.hash_impl->free != NULL);
 
-        if (s2n_is_in_fips_mode()) {
+        if (s2n_evp_signing_supported()) {
             assert(state->inner.digest.high_level.evp.ctx == NULL);
-            assert(state->inner.digest.high_level.evp_md5_secondary.ctx == NULL);
             assert_rc_decrement_on_hash_state(&saved_inner_hash_state);
 
             assert(state->inner_just_key.digest.high_level.evp.ctx == NULL);
-            assert(state->inner_just_key.digest.high_level.evp_md5_secondary.ctx == NULL);
             assert_rc_decrement_on_hash_state(&saved_inner_just_key_hash_state);
 
             assert(state->outer.digest.high_level.evp.ctx == NULL);
-            assert(state->outer.digest.high_level.evp_md5_secondary.ctx == NULL);
             assert_rc_decrement_on_hash_state(&saved_outer_hash_state);
 
             assert(state->outer_just_key.digest.high_level.evp.ctx == NULL);
-            assert(state->outer_just_key.digest.high_level.evp_md5_secondary.ctx == NULL);
             assert_rc_decrement_on_hash_state(&saved_outer_just_key_hash_state);
         } else {
             assert_rc_unchanged_on_hash_state(&saved_inner_hash_state);
@@ -77,15 +73,11 @@ void s2n_hmac_free_harness()
     if (state != NULL) {
         /* 1. `free` leftover EVP_MD_CTX objects if `s2n_is_in_fips_mode`,
               since `s2n_hash_free` is a NO-OP in that case. */
-        if (!s2n_is_in_fips_mode()) {
+        if (!s2n_evp_signing_supported()) {
             S2N_EVP_MD_CTX_FREE(state->inner.digest.high_level.evp.ctx);
-            S2N_EVP_MD_CTX_FREE(state->inner.digest.high_level.evp_md5_secondary.ctx);
             S2N_EVP_MD_CTX_FREE(state->inner_just_key.digest.high_level.evp.ctx);
-            S2N_EVP_MD_CTX_FREE(state->inner_just_key.digest.high_level.evp_md5_secondary.ctx);
             S2N_EVP_MD_CTX_FREE(state->outer.digest.high_level.evp.ctx);
-            S2N_EVP_MD_CTX_FREE(state->outer.digest.high_level.evp_md5_secondary.ctx);
             S2N_EVP_MD_CTX_FREE(state->outer_just_key.digest.high_level.evp.ctx);
-            S2N_EVP_MD_CTX_FREE(state->outer_just_key.digest.high_level.evp_md5_secondary.ctx);
         }
 
         /* 2. `free` leftover reference-counted keys (i.e. those with non-zero ref-count),

--- a/tests/cbmc/proofs/s2n_hmac_free/s2n_hmac_free_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_free/s2n_hmac_free_harness.c
@@ -71,7 +71,7 @@ void s2n_hmac_free_harness()
 
     /* Cleanup after expected error cases, for memory leak check. */
     if (state != NULL) {
-        /* 1. `free` leftover EVP_MD_CTX objects if `s2n_is_in_fips_mode`,
+        /* 1. `free` leftover EVP_MD_CTX objects if `s2n_evp_signing_supported`,
               since `s2n_hash_free` is a NO-OP in that case. */
         if (!s2n_evp_signing_supported()) {
             S2N_EVP_MD_CTX_FREE(state->inner.digest.high_level.evp.ctx);

--- a/tests/cbmc/proofs/s2n_hmac_init/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_init/Makefile
@@ -24,6 +24,7 @@ PROOF_SOURCES += $(OPENSSL_SOURCE)/md5_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/sha_override.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_libcrypto_is_awslc.c
 PROOF_SOURCES += $(PROOF_STUB)/darwin_check_fd_set_overflow.c

--- a/tests/cbmc/proofs/s2n_hmac_new/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_new/Makefile
@@ -21,7 +21,7 @@ HARNESS_FILE = $(HARNESS_ENTRY).c
 
 PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c

--- a/tests/cbmc/proofs/s2n_hmac_reset/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_reset/Makefile
@@ -24,7 +24,7 @@ PROOF_SOURCES += $(OPENSSL_SOURCE)/ec_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/evp_override.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hash.c

--- a/tests/cbmc/proofs/s2n_hmac_update/Makefile
+++ b/tests/cbmc/proofs/s2n_hmac_update/Makefile
@@ -26,7 +26,7 @@ PROOF_SOURCES += $(OPENSSL_SOURCE)/md5_override.c
 PROOF_SOURCES += $(OPENSSL_SOURCE)/sha_override.c
 PROOF_SOURCES += $(PROOF_SOURCE)/make_common_datastructures.c
 PROOF_SOURCES += $(PROOF_STUB)/s2n_calculate_stacktrace.c
-PROOF_SOURCES += $(PROOF_STUB)/s2n_is_in_fips_mode.c
+PROOF_SOURCES += $(PROOF_STUB)/s2n_evp_signing_supported.c
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE)
 
 PROJECT_SOURCES += $(SRCDIR)/crypto/s2n_hmac.c

--- a/tests/cbmc/sources/cbmc_utils.c
+++ b/tests/cbmc/sources/cbmc_utils.c
@@ -220,13 +220,11 @@ void assert_rc_unchanged_on_evp_pkey_ctx(struct rc_keys_from_evp_pkey_ctx *stora
 void assert_rc_decrement_on_hash_state(struct rc_keys_from_hash_state *storage)
 {
     assert_rc_decrement_on_evp_pkey_ctx(&storage->evp);
-    assert_rc_decrement_on_evp_pkey_ctx(&storage->evp_md5);
 }
 
 void assert_rc_unchanged_on_hash_state(struct rc_keys_from_hash_state *storage)
 {
     assert_rc_unchanged_on_evp_pkey_ctx(&storage->evp);
-    assert_rc_unchanged_on_evp_pkey_ctx(&storage->evp_md5);
 }
 
 void save_abstract_evp_ctx(const EVP_PKEY_CTX *pctx, struct rc_keys_from_evp_pkey_ctx *storage)
@@ -245,20 +243,12 @@ void save_rc_keys_from_hash_state(const struct s2n_hash_state *state, struct rc_
 {
     storage->evp.pkey = NULL;
     storage->evp.pkey_eckey = NULL;
-    storage->evp_md5.pkey = NULL;
-    storage->evp_md5.pkey_eckey = NULL;
-    storage->evp.pkey_refs = storage->evp.pkey_eckey_refs = storage->evp_md5.pkey_refs = storage->evp_md5.pkey_eckey_refs = 0;
+    storage->evp.pkey_refs = storage->evp.pkey_eckey_refs = 0;
 
     if (state) {
         if (state->digest.high_level.evp.ctx) {
             if (state->digest.high_level.evp.ctx->pctx) {
                 save_abstract_evp_ctx(state->digest.high_level.evp.ctx->pctx, &storage->evp);
-            }
-        }
-
-        if (state->digest.high_level.evp_md5_secondary.ctx) {
-            if (state->digest.high_level.evp_md5_secondary.ctx->pctx) {
-                save_abstract_evp_ctx(state->digest.high_level.evp_md5_secondary.ctx->pctx, &storage->evp_md5);
             }
         }
     }
@@ -279,5 +269,4 @@ void free_rc_keys_from_evp_pkey_ctx(struct rc_keys_from_evp_pkey_ctx *pctx)
 void free_rc_keys_from_hash_state(struct rc_keys_from_hash_state *storage)
 {
     free_rc_keys_from_evp_pkey_ctx(&storage->evp);
-    free_rc_keys_from_evp_pkey_ctx(&storage->evp_md5);
 }

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -270,7 +270,6 @@ void cbmc_populate_s2n_hash_state(struct s2n_hash_state* state)
      * If required, this initialization should be done in the validation function.
      */
     cbmc_populate_s2n_evp_digest(&state->digest.high_level.evp);
-    cbmc_populate_s2n_evp_digest(&state->digest.high_level.evp_md5_secondary);
 }
 
 struct s2n_hash_state* cbmc_allocate_s2n_hash_state()
@@ -300,13 +299,9 @@ void cbmc_populate_s2n_hmac_evp_backup(struct s2n_hmac_evp_backup *backup)
 {
     CBMC_ENSURE_REF(backup);
     cbmc_populate_s2n_evp_digest(&backup->inner.evp);
-    cbmc_populate_s2n_evp_digest(&backup->inner.evp_md5_secondary);
     cbmc_populate_s2n_evp_digest(&backup->inner_just_key.evp);
-    cbmc_populate_s2n_evp_digest(&backup->inner_just_key.evp_md5_secondary);
     cbmc_populate_s2n_evp_digest(&backup->outer.evp);
-    cbmc_populate_s2n_evp_digest(&backup->outer.evp_md5_secondary);
     cbmc_populate_s2n_evp_digest(&backup->outer_just_key.evp);
-    cbmc_populate_s2n_evp_digest(&backup->outer_just_key.evp_md5_secondary);
 }
 
 struct s2n_hmac_evp_backup* cbmc_allocate_s2n_hmac_evp_backup()

--- a/tests/cbmc/stubs/s2n_evp_signing_supported.c
+++ b/tests/cbmc/stubs/s2n_evp_signing_supported.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ * this file except in compliance with the License. A copy of the License is
+ * located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cbmc_proof/nondet.h>
+
+static bool is_set = false;
+static bool is_evp_signing_supported = false;
+
+bool s2n_evp_signing_supported()
+{
+    if (!is_set) {
+        is_evp_signing_supported = nondet_bool();
+        is_set = true;
+    }
+    return is_evp_signing_supported;
+}


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

related to https://github.com/aws/s2n-tls/issues/5105

### Description of changes: 

Read https://github.com/aws/s2n-tls/issues/5105 -- this change won't make sense in context without it. After this change:
| Libcrypto    | Hash method | Signing Method
| -------- | ------- |  ------- |
| openssl-1.0.2  | Legacy   | Legacy
| **openssl-1.0.2-fips** | **n/a** | **n/a**
| awslc-fips    |  EVP    | EVP-FIPS-140-3
| openssl-3-fips    | n/a   | n/a
| other    | Legacy   | Legacy

This PR tackles Task 1 from the related issue and cleans up the unused openssl-1.0.2-fips signing logic. This logic was used only for openssl-1.0.2-fips (in fips mode) because that was the only libcrypto:
1. Using "EVP" hashes because s2n_use_evp_impl returned "true" because s2n-tls was in fips mode
2. Using "Legacy" signing because s2n_hash_evp_fully_supported returned "false" because the EVP_MD_CTX_set_pkey_ctx and EVP_md5_sha1 methods are missing

There should be NO practical behavior change from this change.

### Callouts
**But why are we removing the EVP version instead of the legacy version?**
Because MD5 is legacy. Even in our perfect end state where almost everything is using EVP, openssl-3.0-fips will still need to use the legacy methods for MD5. Might as well let openssl-1.0.2 use the same legacy code, rather than complicating the EVP code to support openssl-1.0.2's strange MD5+SHA1 needs.

### Testing:
Unit tests.
Updated the CBMC tests to test with both the EVP and legacy setups.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
