### PR TITLE
Add new security policy (20250211)

### DIFF
--- a/tests/pems/gen_self_signed_cert.sh
+++ b/tests/pems/gen_self_signed_cert.sh
@@ -139,7 +139,7 @@ if [ "$KEY_TYPE" == "rsa" ]; then
     openssl req -x509 -config "$cert_conf_path" -newkey rsa:${RSA_KEY_SIZE} -${HASH_ALG} -nodes -keyout ${PREFIX}rsa_key.pem -out ${PREFIX}rsa_cert.pem -days 36500
 elif [ "$KEY_TYPE" == "ecdsa" ]; then
     openssl ecparam -out "${PREFIX}ecdsa_key.pem" -name "$CURVE_NAME" -genkey
-    openssl req -new -config "$cert_conf_path" -days 36500 -nodes -x509 -key "${PREFIX}ecdsa_key.pem" -out "${PREFIX}ecdsa_cert.pem"
+    openssl req -new -config "$cert_conf_path" -${HASH_ALG} -days 36500 -nodes -x509 -key "${PREFIX}ecdsa_key.pem" -out "${PREFIX}ecdsa_cert.pem"
 else
     echo "Incorrect key-type: $KEY_TYPE"
     usage ;

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -105,6 +105,9 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&ecdsa_chain_and_key,
             S2N_DEFAULT_ECDSA_TEST_CERT_CHAIN, S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY));
 
+    DEFER_CLEANUP(struct s2n_cert_chain_and_key *ecdsa_sha384_chain_and_key = NULL, s2n_cert_chain_and_key_ptr_free);
+    EXPECT_SUCCESS(s2n_test_cert_permutation_load_server_chain(&ecdsa_sha384_chain_and_key, "ec", "ecdsa", "p384", "sha384"));
+
     DEFER_CLEANUP(struct s2n_cert_chain_and_key *rsa_pss_chain_and_key = NULL, s2n_cert_chain_and_key_ptr_free);
     if (s2n_is_rsa_pss_certs_supported()) {
         EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&rsa_pss_chain_and_key,
@@ -1018,6 +1021,28 @@ int main(int argc, char **argv)
                     s2n_test_security_policies_compatible(&security_policy_20240331,
                             "test_all_tls13", ecdsa_chain_and_key),
                     S2N_ERR_CIPHER_NOT_SUPPORTED);
+        };
+
+        /* We know of customers that expect to move between the policies in
+         * this section without multi-phased rollouts, so avoid inadvertant
+         * breakage by verifying compatibility.
+         */
+        if (s2n_is_tls13_fully_supported()) {
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_rfc9151, "default_tls13", ecdsa_sha384_chain_and_key));
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_rfc9151, "default_fips", ecdsa_sha384_chain_and_key));
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_rfc9151, "20250211", ecdsa_sha384_chain_and_key));
+
+            /* default_tls13 is currently 20240503 */
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20240503, "rfc9151", ecdsa_sha384_chain_and_key));
+            /* default_fips is currently 20240502 */
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20240502, "rfc9151", ecdsa_sha384_chain_and_key));
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20250211, "rfc9151", ecdsa_sha384_chain_and_key));
+
+            /* default_tls13 > 20250211
+             * note this does not require a sha384 key.
+             */
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20240503, "20250211", ecdsa_chain_and_key));
+            EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20240503, "default_tls13", ecdsa_chain_and_key));
         };
     };
 

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -2180,4 +2180,15 @@ const struct s2n_cipher_preferences cipher_preferences_rfc9151 = {
     .allow_chacha20_boosting = false,
 };
 
+struct s2n_cipher_suite *cipher_suites_20250211[] = {
+    /* TLS1.3 */
+    &s2n_tls13_aes_256_gcm_sha384,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_20250211 = {
+    .count = s2n_array_len(cipher_suites_20250211),
+    .suites = cipher_suites_20250211,
+    .allow_chacha20_boosting = false,
+};
+
 /* clang-format on */

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -62,6 +62,7 @@ extern const struct s2n_cipher_preferences cipher_preferences_20240603;
 extern const struct s2n_cipher_preferences cipher_preferences_20241008;
 extern const struct s2n_cipher_preferences cipher_preferences_20241008_gcm;
 extern const struct s2n_cipher_preferences cipher_preferences_20241009;
+extern const struct s2n_cipher_preferences cipher_preferences_20250211;
 
 extern const struct s2n_cipher_preferences cipher_preferences_default_fips;
 

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -1131,6 +1131,25 @@ const struct s2n_security_policy security_policy_rfc9151 = {
     .certificate_preferences_apply_locally = true,
 };
 
+/*
+ * This security policy is a mix of default_tls13 (20240503) and rfc9151, with
+ * a primary requirement that AES-256 is the ciphersuite chosen. Other
+ * requirements are generally picked to raise minimum thresholds (e.g.,
+ * requiring TLS 1.3) where possible without losing compatibility with modern
+ * default_tls13 clients or servers.
+ */
+const struct s2n_security_policy security_policy_20250211 = {
+    .minimum_protocol_version = S2N_TLS13,
+    .cipher_preferences = &cipher_preferences_20250211,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_rfc9151,
+    .certificate_signature_preferences = &s2n_certificate_signature_preferences_20201110,
+    .ecc_preferences = &s2n_ecc_preferences_20210816,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+    },
+};
+
 const struct s2n_security_policy security_policy_test_all = {
     .minimum_protocol_version = S2N_SSLv3,
     .cipher_preferences = &cipher_preferences_test_all,
@@ -1331,6 +1350,7 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "20210816", .security_policy = &security_policy_20210816, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20210816_GCM", .security_policy = &security_policy_20210816_gcm, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20240603", .security_policy = &security_policy_20240603, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "20250211", .security_policy = &security_policy_20250211, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "rfc9151", .security_policy = &security_policy_rfc9151, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "test_all", .security_policy = &security_policy_test_all, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "test_all_fips", .security_policy = &security_policy_test_all_fips, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -129,6 +129,7 @@ extern const struct s2n_security_policy security_policy_20240603;
 extern const struct s2n_security_policy security_policy_20240730;
 extern const struct s2n_security_policy security_policy_20241001;
 extern const struct s2n_security_policy security_policy_20241001_pq_mixed;
+extern const struct s2n_security_policy security_policy_20250211;
 
 extern const struct s2n_security_policy security_policy_rfc9151;
 extern const struct s2n_security_policy security_policy_test_all;


### PR DESCRIPTION
### Release Summary:

Adds `20250211`, a TLS 1.3-exclusive security policy intended for RFC 9151 migration.

### Resolved issues:

n/a

### Description of changes: 

This PR adds a new security policy that is similar/mix of default_tls13 and rfc9115, but with a minimum protocol support of TLS 1.3. As tested, it is compatible with default_tls13 and rfc9115, making it a middle ground for migration towards rfc9115.

### Call-outs:

n/a

### Testing:

Added a unit test verifying the compatibility -- I'm hoping it runs in CI since locally I think I don't have TLS 1.3 support for it to run successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
