### PR TITLE
ci: add default provider to openssl-3.0-fips

### DIFF
--- a/codebuild/bin/s2n_fips_openssl.cnf
+++ b/codebuild/bin/s2n_fips_openssl.cnf
@@ -56,10 +56,10 @@ alg_section = algorithm_sect
 
 # List of providers to load
 [provider_sect]
-base = base_sect
+default = default_sect
 fips = fips_sect
 
-[base_sect]
+[default_sect]
 activate = 1
 
 [algorithm_sect]

--- a/codebuild/bin/start_codebuild.sh
+++ b/codebuild/bin/start_codebuild.sh
@@ -28,6 +28,7 @@ BUILDS=(
     "s2nUnitNix"
     "Integv2NixBatchBF1FB83F-7tcZOiMDWPH0 us-east-2 batch"
     "kTLS us-west-2 no-batch"
+    "Openssl3fipsWIP us-west-2 no-batch"
 )
 
 usage() {


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:
Related to getting https://github.com/aws/s2n-tls/pull/5112 to pass the CI

### Description of changes: 
I thought I could work around the limitations of the fips provider, but I was wrong. Unless we want to rewrite like every test and a bunch of the pre-protocol-selection logic.

Instead, just also require a provider that supports non-fips algorithms. Here we add the default provider to our openssl-3.0-fips build.

### Call-outs:

The specific problem I couldn't otherwise work around was that EVP_PKEY_CTX_set_signature_md is required for RSA with PKCS1 padding. Otherwise, the padding on the signature calculated by EVP_PKEY_sign will be wrong. See https://docs.openssl.org/3.1/man3/EVP_PKEY_CTX_ctrl/#rsa-parameters:
> Two RSA padding modes behave differently if EVP_PKEY_CTX_set_signature_md() is used. If this function is called for PKCS#1 padding the plaintext buffer is an actual digest value and is encapsulated in a DigestInfo structure according to PKCS#1 when signing and this structure is expected (and stripped off) when verifying. If this control is not used with RSA and PKCS#1 padding then the supplied data is used directly and not encapsulated.
It's an annoyingly subtle problem. I didn't notice until running the test on openssl-3.0 (non-fips), which is capable of running both the EVP and legacy signing methods so could compare the results.

I couldn't figure out any way to work around that problem, and I'm skeptical a way exists. PKCS1 padding needs to know the hash algorithm, and openssl-3.0-fips will refuse to accept some hash algorithms. As far as I can tell, the problem algorithms are MD5 (of course) and SHA1, but SHA1 is only rejected when signing? Verifying is fine?

We could someday try to remove the requirement for MD5 and SHA1, since they're not allowed by FIPS, but when I attempted that like ALL the tests failed. A lot of our code just assumes SHA1 is available.

### Testing:

Locally, I could get the s2n_evp_signing_test to pass with this update + some additional code changes to use SHA1 from a provider other than FIPS.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
