### PR TITLE
refactor: use EVP_MD_fetch() if available

### DIFF
--- a/codebuild/spec/buildspec_openssl3fips.yml
+++ b/codebuild/spec/buildspec_openssl3fips.yml
@@ -32,3 +32,4 @@ phases:
       - export CTEST_PARALLEL_LEVEL=$(nproc)
       # openssl3fips is still a work-in-progress. Not all tests pass.
       - make -C build test -- ARGS="-R 's2n_build_test|s2n_fips_test'"
+      - make -C build test -- ARGS="-R 's2n_hash_test|s2n_hash_all_algs_test|s2n_openssl_test|s2n_init_test'"

--- a/codebuild/spec/buildspec_openssl3fips.yml
+++ b/codebuild/spec/buildspec_openssl3fips.yml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 version: 0.2
+
+env:
+  variables:
+    S2N_LIBCRYPTO: "openssl-3.0-fips"
+    CTEST_OUTPUT_ON_FAILURE: 1
       
 phases:
   build:
@@ -28,7 +33,6 @@ phases:
   post_build:
     on-failure: ABORT
     commands:
-      - export CTEST_OUTPUT_ON_FAILURE=1
       - export CTEST_PARALLEL_LEVEL=$(nproc)
       # openssl3fips is still a work-in-progress. Not all tests pass.
       - make -C build test -- ARGS="-R 's2n_build_test|s2n_fips_test'"

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -356,10 +356,10 @@ static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm al
     if (alg == S2N_HASH_MD5_SHA1 && s2n_use_custom_md5_sha1()) {
         POSIX_ENSURE_REF(state->digest.high_level.evp_md5_secondary.ctx);
         POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx,
-                s2n_hash_alg_to_evp_md(S2N_HASH_SHA1), NULL),
+                                 s2n_hash_alg_to_evp_md(S2N_HASH_SHA1), NULL),
                 S2N_ERR_HASH_INIT_FAILED);
         POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp_md5_secondary.ctx,
-                s2n_hash_alg_to_evp_md(S2N_HASH_MD5), NULL),
+                                 s2n_hash_alg_to_evp_md(S2N_HASH_MD5), NULL),
                 S2N_ERR_HASH_INIT_FAILED);
         return S2N_SUCCESS;
     }

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -20,6 +20,12 @@
 #include "error/s2n_errno.h"
 #include "utils/s2n_safety.h"
 
+#if S2N_LIBCRYPTO_SUPPORTS_PROVIDERS
+static EVP_MD *evp_mds[S2N_HASH_ALGS_COUNT] = { 0 };
+#else
+static const EVP_MD *evp_mds[S2N_HASH_ALGS_COUNT] = { 0 };
+#endif
+
 static bool s2n_use_custom_md5_sha1()
 {
 #if defined(S2N_LIBCRYPTO_SUPPORTS_EVP_MD5_SHA1_HASH)
@@ -39,28 +45,65 @@ bool s2n_hash_evp_fully_supported()
     return s2n_use_evp_impl() && !s2n_use_custom_md5_sha1();
 }
 
+S2N_RESULT s2n_hash_algorithms_init()
+{
+#if S2N_LIBCRYPTO_SUPPORTS_PROVIDERS
+    /* openssl-3.0 introduced the concept of providers.
+     * After openssl-3.0, the old EVP_sha256()-style methods will still work,
+     * but may be inefficient. See
+     * https://docs.openssl.org/3.4/man7/ossl-guide-libcrypto-introduction/#performance
+     *
+     * Additionally, the old style methods do not support property query strings
+     * to guide which provider to fetch from. This is important for FIPS, where
+     * the default query string of "fips=yes" will need to be overridden for
+     * legacy algorithms.
+     */
+    evp_mds[S2N_HASH_MD5] = EVP_MD_fetch(NULL, "MD5", "-fips");
+    evp_mds[S2N_HASH_MD5_SHA1] = EVP_MD_fetch(NULL, "MD5-SHA1", "-fips");
+    evp_mds[S2N_HASH_SHA1] = EVP_MD_fetch(NULL, "SHA1", NULL);
+    evp_mds[S2N_HASH_SHA224] = EVP_MD_fetch(NULL, "SHA224", NULL);
+    evp_mds[S2N_HASH_SHA256] = EVP_MD_fetch(NULL, "SHA256", NULL);
+    evp_mds[S2N_HASH_SHA384] = EVP_MD_fetch(NULL, "SHA384", NULL);
+    evp_mds[S2N_HASH_SHA512] = EVP_MD_fetch(NULL, "SHA512", NULL);
+#else
+    evp_mds[S2N_HASH_MD5] = EVP_md5();
+    evp_mds[S2N_HASH_SHA1] = EVP_sha1();
+    evp_mds[S2N_HASH_SHA224] = EVP_sha224();
+    evp_mds[S2N_HASH_SHA256] = EVP_sha256();
+    evp_mds[S2N_HASH_SHA384] = EVP_sha384();
+    evp_mds[S2N_HASH_SHA512] = EVP_sha512();
+    /* Very old libcryptos like openssl-1.0.2 do not support EVP_MD_md5_sha1().
+     * We work around that by manually combining MD5 and SHA1, rather than
+     * using the composite algorithm.
+     */
+    #if defined(S2N_LIBCRYPTO_SUPPORTS_EVP_MD5_SHA1_HASH)
+    evp_mds[S2N_HASH_MD5_SHA1] = EVP_md5_sha1();
+    #endif
+#endif
+    return S2N_RESULT_OK;
+}
+
+S2N_RESULT s2n_hash_algorithms_cleanup()
+{
+#if S2N_LIBCRYPTO_SUPPORTS_PROVIDERS
+    for (size_t i = 0; i < S2N_HASH_ALGS_COUNT; i++) {
+        /* https://docs.openssl.org/3.4/man3/EVP_DigestInit/
+         * > Decrements the reference count for the fetched EVP_MD structure.
+         * > If the reference count drops to 0 then the structure is freed.
+         * > If the argument is NULL, nothing is done.
+         */
+        EVP_MD_free(evp_mds[i]);
+        evp_mds[i] = NULL;
+    }
+#endif
+    return S2N_RESULT_OK;
+}
+
 const EVP_MD *s2n_hash_alg_to_evp_md(s2n_hash_algorithm alg)
 {
-    switch (alg) {
-        case S2N_HASH_MD5:
-            return EVP_md5();
-        case S2N_HASH_SHA1:
-            return EVP_sha1();
-        case S2N_HASH_SHA224:
-            return EVP_sha224();
-        case S2N_HASH_SHA256:
-            return EVP_sha256();
-        case S2N_HASH_SHA384:
-            return EVP_sha384();
-        case S2N_HASH_SHA512:
-            return EVP_sha512();
-#if defined(S2N_LIBCRYPTO_SUPPORTS_EVP_MD5_SHA1_HASH)
-        case S2N_HASH_MD5_SHA1:
-            return EVP_md5_sha1();
-#endif
-        default:
-            return NULL;
-    }
+    PTR_ENSURE_GTE(alg, 0);
+    PTR_ENSURE_LT(alg, S2N_HASH_ALGS_COUNT);
+    return evp_mds[alg];
 }
 
 int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out)
@@ -119,7 +162,7 @@ bool s2n_hash_is_available(s2n_hash_algorithm alg)
         case S2N_HASH_SHA384:
         case S2N_HASH_SHA512:
             return true;
-        case S2N_HASH_SENTINEL:
+        case S2N_HASH_ALGS_COUNT:
             return false;
     }
     return false;
@@ -312,13 +355,20 @@ static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm al
 
     if (alg == S2N_HASH_MD5_SHA1 && s2n_use_custom_md5_sha1()) {
         POSIX_ENSURE_REF(state->digest.high_level.evp_md5_secondary.ctx);
-        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, EVP_sha1(), NULL), S2N_ERR_HASH_INIT_FAILED);
-        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp_md5_secondary.ctx, EVP_md5(), NULL), S2N_ERR_HASH_INIT_FAILED);
+        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx,
+                s2n_hash_alg_to_evp_md(S2N_HASH_SHA1), NULL),
+                S2N_ERR_HASH_INIT_FAILED);
+        POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp_md5_secondary.ctx,
+                s2n_hash_alg_to_evp_md(S2N_HASH_MD5), NULL),
+                S2N_ERR_HASH_INIT_FAILED);
         return S2N_SUCCESS;
     }
 
-    POSIX_ENSURE_REF(s2n_hash_alg_to_evp_md(alg));
-    POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, s2n_hash_alg_to_evp_md(alg), NULL), S2N_ERR_HASH_INIT_FAILED);
+    const EVP_MD *md = s2n_hash_alg_to_evp_md(alg);
+    POSIX_ENSURE(md, S2N_ERR_HASH_INVALID_ALGORITHM);
+    POSIX_GUARD_OSSL(EVP_DigestInit_ex(state->digest.high_level.evp.ctx, md, NULL),
+            S2N_ERR_HASH_INIT_FAILED);
+
     return S2N_SUCCESS;
 }
 

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -21,9 +21,9 @@
 #include "utils/s2n_safety.h"
 
 #if S2N_LIBCRYPTO_SUPPORTS_PROVIDERS
-static EVP_MD *evp_mds[S2N_HASH_ALGS_COUNT] = { 0 };
+static EVP_MD *s2n_evp_mds[S2N_HASH_ALGS_COUNT] = { 0 };
 #else
-static const EVP_MD *evp_mds[S2N_HASH_ALGS_COUNT] = { 0 };
+static const EVP_MD *s2n_evp_mds[S2N_HASH_ALGS_COUNT] = { 0 };
 #endif
 
 static bool s2n_use_custom_md5_sha1()
@@ -58,26 +58,26 @@ S2N_RESULT s2n_hash_algorithms_init()
      * the default query string of "fips=yes" will need to be overridden for
      * legacy algorithms.
      */
-    evp_mds[S2N_HASH_MD5] = EVP_MD_fetch(NULL, "MD5", "-fips");
-    evp_mds[S2N_HASH_MD5_SHA1] = EVP_MD_fetch(NULL, "MD5-SHA1", "-fips");
-    evp_mds[S2N_HASH_SHA1] = EVP_MD_fetch(NULL, "SHA1", NULL);
-    evp_mds[S2N_HASH_SHA224] = EVP_MD_fetch(NULL, "SHA224", NULL);
-    evp_mds[S2N_HASH_SHA256] = EVP_MD_fetch(NULL, "SHA256", NULL);
-    evp_mds[S2N_HASH_SHA384] = EVP_MD_fetch(NULL, "SHA384", NULL);
-    evp_mds[S2N_HASH_SHA512] = EVP_MD_fetch(NULL, "SHA512", NULL);
+    s2n_evp_mds[S2N_HASH_MD5] = EVP_MD_fetch(NULL, "MD5", "-fips");
+    s2n_evp_mds[S2N_HASH_MD5_SHA1] = EVP_MD_fetch(NULL, "MD5-SHA1", "-fips");
+    s2n_evp_mds[S2N_HASH_SHA1] = EVP_MD_fetch(NULL, "SHA1", NULL);
+    s2n_evp_mds[S2N_HASH_SHA224] = EVP_MD_fetch(NULL, "SHA224", NULL);
+    s2n_evp_mds[S2N_HASH_SHA256] = EVP_MD_fetch(NULL, "SHA256", NULL);
+    s2n_evp_mds[S2N_HASH_SHA384] = EVP_MD_fetch(NULL, "SHA384", NULL);
+    s2n_evp_mds[S2N_HASH_SHA512] = EVP_MD_fetch(NULL, "SHA512", NULL);
 #else
-    evp_mds[S2N_HASH_MD5] = EVP_md5();
-    evp_mds[S2N_HASH_SHA1] = EVP_sha1();
-    evp_mds[S2N_HASH_SHA224] = EVP_sha224();
-    evp_mds[S2N_HASH_SHA256] = EVP_sha256();
-    evp_mds[S2N_HASH_SHA384] = EVP_sha384();
-    evp_mds[S2N_HASH_SHA512] = EVP_sha512();
+    s2n_evp_mds[S2N_HASH_MD5] = EVP_md5();
+    s2n_evp_mds[S2N_HASH_SHA1] = EVP_sha1();
+    s2n_evp_mds[S2N_HASH_SHA224] = EVP_sha224();
+    s2n_evp_mds[S2N_HASH_SHA256] = EVP_sha256();
+    s2n_evp_mds[S2N_HASH_SHA384] = EVP_sha384();
+    s2n_evp_mds[S2N_HASH_SHA512] = EVP_sha512();
     /* Very old libcryptos like openssl-1.0.2 do not support EVP_MD_md5_sha1().
      * We work around that by manually combining MD5 and SHA1, rather than
      * using the composite algorithm.
      */
     #if defined(S2N_LIBCRYPTO_SUPPORTS_EVP_MD5_SHA1_HASH)
-    evp_mds[S2N_HASH_MD5_SHA1] = EVP_md5_sha1();
+    s2n_evp_mds[S2N_HASH_MD5_SHA1] = EVP_md5_sha1();
     #endif
 #endif
     return S2N_RESULT_OK;
@@ -92,8 +92,8 @@ S2N_RESULT s2n_hash_algorithms_cleanup()
          * > If the reference count drops to 0 then the structure is freed.
          * > If the argument is NULL, nothing is done.
          */
-        EVP_MD_free(evp_mds[i]);
-        evp_mds[i] = NULL;
+        EVP_MD_free(s2n_evp_mds[i]);
+        s2n_evp_mds[i] = NULL;
     }
 #endif
     return S2N_RESULT_OK;
@@ -103,7 +103,7 @@ const EVP_MD *s2n_hash_alg_to_evp_md(s2n_hash_algorithm alg)
 {
     PTR_ENSURE_GTE(alg, 0);
     PTR_ENSURE_LT(alg, S2N_HASH_ALGS_COUNT);
-    return evp_mds[alg];
+    return s2n_evp_mds[alg];
 }
 
 int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out)

--- a/crypto/s2n_hash.h
+++ b/crypto/s2n_hash.h
@@ -33,8 +33,8 @@ typedef enum {
     S2N_HASH_SHA384,
     S2N_HASH_SHA512,
     S2N_HASH_MD5_SHA1,
-    /* Don't add any hash algorithms below S2N_HASH_SENTINEL */
-    S2N_HASH_SENTINEL
+    /* Don't add any hash algorithms below S2N_HASH_ALGS_COUNT */
+    S2N_HASH_ALGS_COUNT
 } s2n_hash_algorithm;
 
 /* The low_level_digest stores all OpenSSL structs that are alg-specific to be used with OpenSSL's low-level hash API's. */
@@ -85,6 +85,8 @@ struct s2n_hash {
     int (*free)(struct s2n_hash_state *state);
 };
 
+S2N_RESULT s2n_hash_algorithms_init();
+S2N_RESULT s2n_hash_algorithms_cleanup();
 bool s2n_hash_evp_fully_supported();
 const EVP_MD *s2n_hash_alg_to_evp_md(s2n_hash_algorithm alg);
 int s2n_hash_digest_size(s2n_hash_algorithm alg, uint8_t *out);

--- a/crypto/s2n_libcrypto.c
+++ b/crypto/s2n_libcrypto.c
@@ -229,7 +229,7 @@ bool s2n_libcrypto_supports_flag_no_check_time()
 
 bool s2n_libcrypto_supports_providers(void)
 {
-#ifdef S2N_LIBCRYPTO_SUPPORTS_PROVIDERS
+#if S2N_LIBCRYPTO_SUPPORTS_PROVIDERS
     return true;
 #else
     return false;

--- a/crypto/s2n_libcrypto.c
+++ b/crypto/s2n_libcrypto.c
@@ -226,3 +226,12 @@ bool s2n_libcrypto_supports_flag_no_check_time()
     return false;
 #endif
 }
+
+bool s2n_libcrypto_supports_providers(void)
+{
+#ifdef S2N_LIBCRYPTO_SUPPORTS_PROVIDERS
+    return true;
+#else
+    return false;
+#endif
+}

--- a/tests/cbmc/proofs/s2n_hash_init/s2n_hash_init_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_init/s2n_hash_init_harness.c
@@ -25,6 +25,8 @@ void s2n_hash_init_harness()
     struct s2n_hash_state *state = cbmc_allocate_s2n_hash_state();
     s2n_hash_algorithm alg;
 
+    assert(s2n_result_is_ok(s2n_hash_algorithms_init()));
+
     /* Operation under verification. */
     if (s2n_hash_init(state, alg) == S2N_SUCCESS) {
         /* Post-conditions. */

--- a/tests/cbmc/proofs/s2n_hash_is_available/s2n_hash_is_available_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_is_available/s2n_hash_is_available_harness.c
@@ -39,8 +39,6 @@ void s2n_hash_is_available_harness()
         case S2N_HASH_SHA384:
         case S2N_HASH_SHA512:
             assert(is_available); break;
-        case S2N_HASH_SENTINEL:
-            assert(!is_available); break;
         default:
             __CPROVER_assert(!is_available, "Unsupported algorithm.");
     }

--- a/tests/cbmc/proofs/s2n_hash_reset/s2n_hash_reset_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_reset/s2n_hash_reset_harness.c
@@ -24,6 +24,8 @@ void s2n_hash_reset_harness()
     /* Non-deterministic inputs. */
     struct s2n_hash_state *state = cbmc_allocate_s2n_hash_state();
 
+    assert(s2n_result_is_ok(s2n_hash_algorithms_init()));
+
     /* Operation under verification. */
     if (s2n_hash_reset(state) == S2N_SUCCESS)
     {

--- a/tests/features/S2N_LIBCRYPTO_SUPPORTS_PROVIDERS.c
+++ b/tests/features/S2N_LIBCRYPTO_SUPPORTS_PROVIDERS.c
@@ -13,19 +13,20 @@
  * permissions and limitations under the License.
  */
 
-#pragma once
+/*
+ * This feature probe checks if the linked libcrypto has "provider" support:
+ * https://docs.openssl.org/3.4/man7/provider/
+ * Fetching algorithms from providers:
+ * https://docs.openssl.org/3.4/man7/ossl-guide-libcrypto-introduction/#algorithm-fetching
+ */
 
-#include "utils/s2n_result.h"
+#include <openssl/evp.h>
 
-bool s2n_libcrypto_is_openssl(void);
-bool s2n_libcrypto_is_openssl_fips(void);
-bool s2n_libcrypto_is_awslc(void);
-bool s2n_libcrypto_is_awslc_fips(void);
-bool s2n_libcrypto_is_boringssl(void);
-bool s2n_libcrypto_is_libressl(void);
+int main()
+{
+    /* Supports fetching hash algorithms */
+    EVP_MD *md = EVP_MD_fetch(NULL, NULL, NULL);
+    EVP_MD_free(md);
 
-uint64_t s2n_libcrypto_awslc_api_version(void);
-S2N_RESULT s2n_libcrypto_validate_runtime(void);
-const char *s2n_libcrypto_get_version_name(void);
-bool s2n_libcrypto_supports_flag_no_check_time(void);
-bool s2n_libcrypto_supports_providers(void);
+    return 0;
+}

--- a/tests/sidetrail/working/s2n-cbc/stubs/s2n_hash.h
+++ b/tests/sidetrail/working/s2n-cbc/stubs/s2n_hash.h
@@ -32,8 +32,8 @@ typedef enum {
     S2N_HASH_SHA384,
     S2N_HASH_SHA512,
     S2N_HASH_MD5_SHA1,
-    /* Don't add any hash algorithms below S2N_HASH_SENTINEL */
-    S2N_HASH_SENTINEL
+    /* Don't add any hash algorithms below S2N_HASH_ALGS_COUNT */
+    S2N_HASH_ALGS_COUNT
 } s2n_hash_algorithm;
 
 struct s2n_hash_state {

--- a/tests/sidetrail/working/stubs/s2n_hash.h
+++ b/tests/sidetrail/working/stubs/s2n_hash.h
@@ -32,8 +32,8 @@ typedef enum {
     S2N_HASH_SHA384,
     S2N_HASH_SHA512,
     S2N_HASH_MD5_SHA1,
-    /* Don't add any hash algorithms below S2N_HASH_SENTINEL */
-    S2N_HASH_SENTINEL
+    /* Don't add any hash algorithms below S2N_HASH_ALGS_COUNT */
+    S2N_HASH_ALGS_COUNT
 } s2n_hash_algorithm;
 
 struct s2n_hash_state {

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -258,7 +258,7 @@ int main(int argc, char **argv)
             test_scheme.hash_alg = i;
             conn->handshake_params.client_cert_sig_scheme = &test_scheme;
             conn->handshake_params.server_cert_sig_scheme = &test_scheme;
-            if (i <= S2N_HASH_SENTINEL) {
+            if (i <= S2N_HASH_ALGS_COUNT) {
                 EXPECT_SUCCESS(s2n_connection_get_selected_client_cert_digest_algorithm(conn, &output));
                 EXPECT_EQUAL(expected_output[i], output);
 

--- a/tests/unit/s2n_evp_signing_test.c
+++ b/tests/unit/s2n_evp_signing_test.c
@@ -119,7 +119,7 @@ int main(int argc, char **argv)
         struct s2n_pkey *pkey = rsa_cert_chain->private_key;
 
         for (s2n_signature_algorithm sig_alg = 0; sig_alg <= UINT8_MAX; sig_alg++) {
-            for (s2n_hash_algorithm hash_alg = 0; hash_alg < S2N_HASH_SENTINEL; hash_alg++) {
+            for (s2n_hash_algorithm hash_alg = 0; hash_alg < S2N_HASH_ALGS_COUNT; hash_alg++) {
                 if (s2n_hash_alg_is_supported(sig_alg, hash_alg)) {
                     continue;
                 }
@@ -145,7 +145,7 @@ int main(int argc, char **argv)
         EXPECT_PKEY_USES_EVP_SIGNING(private_key);
         EXPECT_PKEY_USES_EVP_SIGNING(public_key);
 
-        for (s2n_hash_algorithm hash_alg = 0; hash_alg < S2N_HASH_SENTINEL; hash_alg++) {
+        for (s2n_hash_algorithm hash_alg = 0; hash_alg < S2N_HASH_ALGS_COUNT; hash_alg++) {
             if (!s2n_hash_alg_is_supported(sig_alg, hash_alg)) {
                 continue;
             }
@@ -183,7 +183,7 @@ int main(int argc, char **argv)
         EXPECT_PKEY_USES_EVP_SIGNING(private_key);
         EXPECT_PKEY_USES_EVP_SIGNING(public_key);
 
-        for (s2n_hash_algorithm hash_alg = 0; hash_alg < S2N_HASH_SENTINEL; hash_alg++) {
+        for (s2n_hash_algorithm hash_alg = 0; hash_alg < S2N_HASH_ALGS_COUNT; hash_alg++) {
             if (!s2n_hash_alg_is_supported(sig_alg, hash_alg)) {
                 continue;
             }
@@ -220,7 +220,7 @@ int main(int argc, char **argv)
         EXPECT_PKEY_USES_EVP_SIGNING(private_key);
         EXPECT_PKEY_USES_EVP_SIGNING(public_key);
 
-        for (s2n_hash_algorithm hash_alg = 0; hash_alg < S2N_HASH_SENTINEL; hash_alg++) {
+        for (s2n_hash_algorithm hash_alg = 0; hash_alg < S2N_HASH_ALGS_COUNT; hash_alg++) {
             if (!s2n_hash_alg_is_supported(sig_alg, hash_alg)) {
                 continue;
             }
@@ -258,7 +258,7 @@ int main(int argc, char **argv)
         EXPECT_PKEY_USES_EVP_SIGNING(private_key);
         EXPECT_PKEY_USES_EVP_SIGNING(public_key);
 
-        for (s2n_hash_algorithm hash_alg = 0; hash_alg < S2N_HASH_SENTINEL; hash_alg++) {
+        for (s2n_hash_algorithm hash_alg = 0; hash_alg < S2N_HASH_ALGS_COUNT; hash_alg++) {
             if (!s2n_hash_alg_is_supported(sig_alg, hash_alg)) {
                 continue;
             }

--- a/tests/unit/s2n_handshake_hashes_test.c
+++ b/tests/unit/s2n_handshake_hashes_test.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
             uint8_t data[100] = { 0 };
 
             /* Allocates all hashes */
-            for (s2n_hash_algorithm alg = 0; alg < S2N_HASH_SENTINEL; alg++) {
+            for (s2n_hash_algorithm alg = 0; alg < S2N_HASH_ALGS_COUNT; alg++) {
                 if (alg == S2N_HASH_NONE) {
                     continue;
                 }
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
 
             uint8_t data[100] = { 0 };
 
-            for (s2n_hash_algorithm alg = 0; alg < S2N_HASH_SENTINEL; alg++) {
+            for (s2n_hash_algorithm alg = 0; alg < S2N_HASH_ALGS_COUNT; alg++) {
                 if (alg == S2N_HASH_NONE) {
                     continue;
                 }

--- a/tests/unit/s2n_hash_all_algs_test.c
+++ b/tests/unit/s2n_hash_all_algs_test.c
@@ -28,7 +28,7 @@ const uint8_t input_data[INPUT_DATA_SIZE] = "hello hash";
  * They are useful to validate that the results of the low level implementation
  * never change and match the results of the EVP implementation.
  */
-const char *expected_result_hex[S2N_HASH_SENTINEL] = {
+const char *expected_result_hex[S2N_HASH_ALGS_COUNT] = {
     [S2N_HASH_NONE] = "",
     [S2N_HASH_MD5] = "f5d589043253ca6ae54124c31be43701",
     [S2N_HASH_SHA1] = "ccf8abd6b03ef5054a4f257e7c712e17f965272d",
@@ -134,8 +134,7 @@ int main(int argc, char **argv)
 {
     BEGIN_TEST();
 
-    /* Calculate digests when not in FIPS mode. They must match. */
-    for (s2n_hash_algorithm hash_alg = 0; hash_alg < S2N_HASH_SENTINEL; hash_alg++) {
+    for (s2n_hash_algorithm hash_alg = 0; hash_alg < S2N_HASH_ALGS_COUNT; hash_alg++) {
         struct s2n_blob actual_result = { 0 };
         uint8_t actual_result_data[OUTPUT_DATA_SIZE] = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&actual_result, actual_result_data, OUTPUT_DATA_SIZE));

--- a/tests/unit/s2n_libcrypto_test.c
+++ b/tests/unit/s2n_libcrypto_test.c
@@ -15,7 +15,6 @@
 
 #include "crypto/s2n_libcrypto.h"
 
-#include "crypto/s2n_libcrypto.h"
 #include "s2n_test.h"
 #include "utils/s2n_random.h"
 

--- a/tests/unit/s2n_libcrypto_test.c
+++ b/tests/unit/s2n_libcrypto_test.c
@@ -15,6 +15,7 @@
 
 #include "crypto/s2n_libcrypto.h"
 
+#include "crypto/s2n_libcrypto.h"
 #include "s2n_test.h"
 #include "utils/s2n_random.h"
 
@@ -59,6 +60,11 @@ int main(int argc, char** argv)
      */
     if (strcmp("openssl-1.0.2-fips", env_libcrypto) == 0) {
         EXPECT_FALSE(s2n_supports_custom_rand());
+    }
+
+    /* We expect openssl-3.0 to support providers */
+    if (strstr(env_libcrypto, "openssl") && strstr(env_libcrypto, "3")) {
+        EXPECT_TRUE(s2n_libcrypto_supports_providers());
     }
 
     END_TEST();

--- a/tls/s2n_handshake.h
+++ b/tls/s2n_handshake.h
@@ -158,7 +158,7 @@ struct s2n_handshake {
     /* Hash algorithms required for this handshake. The set of required hashes can be reduced as session parameters are
      * negotiated, i.e. cipher suite and protocol version.
      */
-    uint8_t required_hash_algs[S2N_HASH_SENTINEL];
+    uint8_t required_hash_algs[S2N_HASH_ALGS_COUNT];
 
     /*
      * Data required by the Finished messages.

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -25,8 +25,6 @@
 #include "utils/s2n_mem.h"
 #include "utils/s2n_safety.h"
 
-#define S2N_HASH_ALG_COUNT S2N_HASH_SENTINEL
-
 S2N_RESULT s2n_psk_init(struct s2n_psk *psk, s2n_psk_type type)
 {
     RESULT_ENSURE_MUT(psk);
@@ -493,8 +491,8 @@ static S2N_RESULT s2n_psk_write_binder_list(struct s2n_connection *conn, const s
 
     /* Setup memory to hold the binder hashes. We potentially need one for
      * every hash algorithm. */
-    uint8_t binder_hashes_data[S2N_HASH_ALG_COUNT][S2N_TLS13_SECRET_MAX_LEN] = { 0 };
-    struct s2n_blob binder_hashes[S2N_HASH_ALG_COUNT] = { 0 };
+    uint8_t binder_hashes_data[S2N_HASH_ALGS_COUNT][S2N_TLS13_SECRET_MAX_LEN] = { 0 };
+    struct s2n_blob binder_hashes[S2N_HASH_ALGS_COUNT] = { 0 };
 
     struct s2n_stuffer_reservation binder_list_size = { 0 };
     RESULT_GUARD_POSIX(s2n_stuffer_reserve_uint16(out, &binder_list_size));

--- a/utils/s2n_init.c
+++ b/utils/s2n_init.c
@@ -76,6 +76,7 @@ int s2n_init(void)
     POSIX_GUARD_RESULT(s2n_locking_init());
     POSIX_GUARD(s2n_fips_init());
     POSIX_GUARD_RESULT(s2n_rand_init());
+    POSIX_GUARD_RESULT(s2n_hash_algorithms_init());
     POSIX_GUARD(s2n_cipher_suites_init());
     POSIX_GUARD(s2n_security_policies_init());
     POSIX_GUARD(s2n_config_defaults_init());
@@ -109,6 +110,7 @@ static bool s2n_cleanup_atexit_impl(void)
     s2n_wipe_static_configs();
 
     bool cleaned_up = s2n_result_is_ok(s2n_cipher_suites_cleanup())
+            && s2n_result_is_ok(s2n_hash_algorithms_cleanup())
             && s2n_result_is_ok(s2n_rand_cleanup_thread())
             && s2n_result_is_ok(s2n_rand_cleanup())
             && s2n_result_is_ok(s2n_locking_cleanup())


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:
related to aws/s2n-tls#5105

### Description of changes: 
openssl-3.0 "fetches" implementations of algorithms from "providers". To make that more efficient, you're encouraged to "pre-fetch" and store the implementations you use frequently. Additionally, if we want to influence which provider is chosen for the algorithm, we have to provide a "property query string". Here, we're using a string that tells openssl to ignore any default query for fips that was set for MD5.

Basically, this PR should just be a performance improvement for openssl-3.0 (although I didn't actually test that) and is required for openssl-3.0-fips.

I also felt very silly writing EVP_MD *evp_mds[S2N_HASH_SENTINEL], so I renamed S2N_HASH_SENTINEL to S2N_HASH_ALGS_COUNT. That's how it's used almost everywhere in the code, except for like one very old test (s2n_connection_test.c) that really treats it as a sentinel. If that complicates the PR too much, I can revert the rename.

### Testing:
We have existing tests for s2n_hash. I added them to the openssl build job.
I also added s2n_openssl_test and s2n_init_test to the openssl build job. I *think* that's all the really relevant tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
