### PR TITLE
refactor: move "s2n_libcrypto_is" methods into s2n_libcrypto.h

### DIFF
--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -18,6 +18,7 @@
 #include <openssl/evp.h>
 #include <sys/param.h>
 
+#include "crypto/s2n_openssl.h"
 #include "utils/s2n_blob.h"
 #include "utils/s2n_random.h"
 #include "utils/s2n_safety.h"

--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -22,7 +22,6 @@
 #include "crypto/s2n_ecc_evp.h"
 #include "crypto/s2n_evp_signing.h"
 #include "crypto/s2n_hash.h"
-#include "crypto/s2n_openssl.h"
 #include "crypto/s2n_pkey.h"
 #include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"

--- a/crypto/s2n_fips.c
+++ b/crypto/s2n_fips.c
@@ -17,6 +17,8 @@
 
 #include <openssl/crypto.h>
 
+#include "crypto/s2n_libcrypto.h"
+#include "crypto/s2n_openssl.h"
 #include "utils/s2n_init.h"
 #include "utils/s2n_safety.h"
 

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -17,7 +17,6 @@
 
 #include "crypto/s2n_evp_signing.h"
 #include "crypto/s2n_hmac.h"
-#include "crypto/s2n_openssl.h"
 #include "error/s2n_errno.h"
 #include "utils/s2n_safety.h"
 

--- a/crypto/s2n_libcrypto.h
+++ b/crypto/s2n_libcrypto.h
@@ -17,7 +17,14 @@
 
 #include "utils/s2n_result.h"
 
+bool s2n_libcrypto_is_openssl(void);
+bool s2n_libcrypto_is_openssl_fips(void);
+bool s2n_libcrypto_is_awslc(void);
+bool s2n_libcrypto_is_awslc_fips(void);
+bool s2n_libcrypto_is_boringssl(void);
+bool s2n_libcrypto_is_libressl(void);
+
 uint64_t s2n_libcrypto_awslc_api_version(void);
 S2N_RESULT s2n_libcrypto_validate_runtime(void);
 const char *s2n_libcrypto_get_version_name(void);
-bool s2n_libcrypto_supports_flag_no_check_time();
+bool s2n_libcrypto_supports_flag_no_check_time(void);

--- a/crypto/s2n_openssl.h
+++ b/crypto/s2n_openssl.h
@@ -15,8 +15,6 @@
 
 #pragma once
 
-#include <stdbool.h>
-
 /**
  * openssl with OPENSSL_VERSION_NUMBER < 0x10100003L made data type details unavailable
  * libressl use openssl with data type details available, but mandatorily set
@@ -49,10 +47,3 @@
     #define s2n_evp_ctx_init(ctx)    EVP_CIPHER_CTX_init(ctx)
     #define RESULT_EVP_CTX_INIT(ctx) EVP_CIPHER_CTX_init(ctx)
 #endif
-
-bool s2n_libcrypto_is_openssl(void);
-bool s2n_libcrypto_is_openssl_fips(void);
-bool s2n_libcrypto_is_awslc();
-bool s2n_libcrypto_is_awslc_fips(void);
-bool s2n_libcrypto_is_boringssl();
-bool s2n_libcrypto_is_libressl();

--- a/crypto/s2n_pq.c
+++ b/crypto/s2n_pq.c
@@ -15,8 +15,6 @@
 
 #include "s2n_pq.h"
 
-#include "crypto/s2n_openssl.h"
-
 bool s2n_libcrypto_supports_evp_kem()
 {
     /* S2N_LIBCRYPTO_SUPPORTS_EVP_KEM will be auto-detected and #defined if

--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -22,6 +22,7 @@
 #include "crypto/s2n_drbg.h"
 #include "crypto/s2n_evp_signing.h"
 #include "crypto/s2n_hash.h"
+#include "crypto/s2n_openssl.h"
 #include "crypto/s2n_pkey.h"
 #include "crypto/s2n_rsa_signing.h"
 #include "error/s2n_errno.h"

--- a/crypto/s2n_rsa_pss.c
+++ b/crypto/s2n_rsa_pss.c
@@ -21,7 +21,6 @@
 
 #include "crypto/s2n_evp_signing.h"
 #include "crypto/s2n_hash.h"
-#include "crypto/s2n_openssl.h"
 #include "crypto/s2n_pkey.h"
 #include "crypto/s2n_rsa.h"
 #include "crypto/s2n_rsa_signing.h"

--- a/crypto/s2n_rsa_signing.h
+++ b/crypto/s2n_rsa_signing.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include "api/s2n.h"
-#include "crypto/s2n_openssl.h"
 #include "crypto/s2n_rsa.h"
 #include "utils/s2n_blob.h"
 

--- a/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
+++ b/tests/cbmc/include/cbmc_proof/make_common_datastructures.h
@@ -23,6 +23,7 @@
 #include "crypto/s2n_evp.h"
 #include "crypto/s2n_hash.h"
 #include "crypto/s2n_hmac.h"
+#include "crypto/s2n_libcrypto.h"
 #include "stuffer/s2n_stuffer.h"
 #include "tls/s2n_config.h"
 #include "tls/s2n_connection.h"

--- a/tests/cbmc/stubs/s2n_libcrypto_is_awslc.c
+++ b/tests/cbmc/stubs/s2n_libcrypto_is_awslc.c
@@ -16,7 +16,6 @@
 #include <cbmc_proof/nondet.h>
 
 #include <stdbool.h>
-#include "crypto/s2n_openssl.h"
 
 static int flag = 0;
 static bool s2n_awslc_flag = 0;

--- a/tests/unit/s2n_build_test.c
+++ b/tests/unit/s2n_build_test.c
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "crypto/s2n_openssl.h"
+#include "crypto/s2n_libcrypto.h"
 #include "s2n_test.h"
 
 #define MAX_LIBCRYPTO_NAME_LEN 100

--- a/tests/unit/s2n_cert_authorities_test.c
+++ b/tests/unit/s2n_cert_authorities_test.c
@@ -15,6 +15,7 @@
 
 #include "tls/extensions/s2n_cert_authorities.h"
 
+#include "crypto/s2n_libcrypto.h"
 #include "crypto/s2n_rsa_pss.h"
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -20,6 +20,8 @@
 
 #include "api/s2n.h"
 #include "crypto/s2n_fips.h"
+#include "crypto/s2n_libcrypto.h"
+#include "crypto/s2n_openssl.h"
 #include "crypto/s2n_pq.h"
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"

--- a/tests/unit/s2n_evp_signing_test.c
+++ b/tests/unit/s2n_evp_signing_test.c
@@ -17,6 +17,7 @@
 
 #include "crypto/s2n_ecdsa.h"
 #include "crypto/s2n_fips.h"
+#include "crypto/s2n_libcrypto.h"
 #include "crypto/s2n_rsa_pss.h"
 #include "crypto/s2n_rsa_signing.h"
 #include "s2n_test.h"

--- a/tests/unit/s2n_fips_test.c
+++ b/tests/unit/s2n_fips_test.c
@@ -16,6 +16,7 @@
 #include "crypto/s2n_fips.h"
 
 #include "api/s2n.h"
+#include "crypto/s2n_libcrypto.h"
 #include "s2n_test.h"
 
 int main()

--- a/tests/unit/s2n_hash_test.c
+++ b/tests/unit/s2n_hash_test.c
@@ -18,6 +18,7 @@
 #include <string.h>
 
 #include "crypto/s2n_fips.h"
+#include "crypto/s2n_libcrypto.h"
 #include "s2n_test.h"
 #include "stuffer/s2n_stuffer.h"
 #include "testlib/s2n_testlib.h"

--- a/tests/unit/s2n_hkdf_test.c
+++ b/tests/unit/s2n_hkdf_test.c
@@ -19,6 +19,7 @@
 
 #include "crypto/s2n_fips.h"
 #include "crypto/s2n_hmac.h"
+#include "crypto/s2n_libcrypto.h"
 #include "s2n_test.h"
 #include "stuffer/s2n_stuffer.h"
 #include "testlib/s2n_testlib.h"

--- a/tests/unit/s2n_libcrypto_test.c
+++ b/tests/unit/s2n_libcrypto_test.c
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-#include "crypto/s2n_openssl.h"
+#include "crypto/s2n_libcrypto.h"
 
 #include "s2n_test.h"
 #include "utils/s2n_random.h"

--- a/tests/unit/s2n_locking_test.c
+++ b/tests/unit/s2n_locking_test.c
@@ -17,6 +17,7 @@
 
 #include <pthread.h>
 
+#include "crypto/s2n_openssl.h"
 #include "s2n_test.h"
 
 #define LOCK_N 1

--- a/tests/unit/s2n_pq_mlkem_test.c
+++ b/tests/unit/s2n_pq_mlkem_test.c
@@ -15,7 +15,6 @@
 
 #include "api/s2n.h"
 #include "crypto/s2n_libcrypto.h"
-#include "crypto/s2n_openssl.h"
 #include "crypto/s2n_pq.h"
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"

--- a/tests/unit/s2n_random_test.c
+++ b/tests/unit/s2n_random_test.c
@@ -32,6 +32,7 @@
 
 #include "api/s2n.h"
 #include "crypto/s2n_fips.h"
+#include "crypto/s2n_libcrypto.h"
 #include "s2n_test.h"
 #include "utils/s2n_fork_detection.h"
 

--- a/tests/unit/s2n_tls13_secrets_rfc8448_test.c
+++ b/tests/unit/s2n_tls13_secrets_rfc8448_test.c
@@ -16,6 +16,7 @@
 /* Needed to set up X25519 key shares */
 #include <openssl/evp.h>
 
+#include "crypto/s2n_openssl.h"
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 #include "tls/s2n_cipher_suites.h"

--- a/tests/unit/s2n_tls_prf_test.c
+++ b/tests/unit/s2n_tls_prf_test.c
@@ -17,7 +17,7 @@
 #include <string.h>
 
 #include "api/s2n.h"
-#include "crypto/s2n_openssl.h"
+#include "crypto/s2n_libcrypto.h"
 #include "s2n_test.h"
 #include "stuffer/s2n_stuffer.h"
 #include "testlib/s2n_testlib.h"

--- a/tests/unit/s2n_x509_validator_certificate_signatures_test.c
+++ b/tests/unit/s2n_x509_validator_certificate_signatures_test.c
@@ -19,7 +19,6 @@
 #include <string.h>
 
 #include "api/s2n.h"
-#include "crypto/s2n_openssl.h"
 #include "crypto/s2n_openssl_x509.h"
 #include "error/s2n_errno.h"
 #include "s2n_test.h"

--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -13,6 +13,8 @@
  * permissions and limitations under the License.
  */
 
+#include "crypto/s2n_libcrypto.h"
+#include "crypto/s2n_openssl.h"
 #include "crypto/s2n_openssl_x509.h"
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"

--- a/tests/unit/s2n_x509_validator_time_verification_test.c
+++ b/tests/unit/s2n_x509_validator_time_verification_test.c
@@ -13,6 +13,7 @@
 * permissions and limitations under the License.
 */
 
+#include "crypto/s2n_libcrypto.h"
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 

--- a/tls/s2n_prf.c
+++ b/tls/s2n_prf.c
@@ -24,7 +24,6 @@
 #include "crypto/s2n_fips.h"
 #include "crypto/s2n_hash.h"
 #include "crypto/s2n_hmac.h"
-#include "crypto/s2n_openssl.h"
 #include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"
 #include "tls/s2n_cipher_suites.h"

--- a/tls/s2n_prf.h
+++ b/tls/s2n_prf.h
@@ -19,7 +19,6 @@
 
 #include "crypto/s2n_hash.h"
 #include "crypto/s2n_hmac.h"
-#include "crypto/s2n_openssl.h"
 #include "utils/s2n_blob.h"
 
 /* Enough to support TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, 2*SHA384_DIGEST_LEN + 2*AES256_KEY_SIZE */

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -20,7 +20,6 @@
 #include <sys/socket.h>
 
 #include "crypto/s2n_libcrypto.h"
-#include "crypto/s2n_openssl.h"
 #include "crypto/s2n_openssl_x509.h"
 #include "crypto/s2n_pkey.h"
 #include "tls/extensions/s2n_extension_list.h"

--- a/utils/s2n_random.c
+++ b/utils/s2n_random.c
@@ -71,6 +71,7 @@
 #include "api/s2n.h"
 #include "crypto/s2n_drbg.h"
 #include "crypto/s2n_fips.h"
+#include "crypto/s2n_libcrypto.h"
 #include "error/s2n_errno.h"
 #include "s2n_io.h"
 #include "stuffer/s2n_stuffer.h"


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

This change should not change any code behavior.

It bothers me that we have a bunch of methods with the prefix "s2n_libcrypto", implemented in "s2n_libcrypto.c", but declared in "s2n_openssl.h". This PR moves them to s2n_libcrypto.h, where you'd expect to find them. It also renames the s2n_openssl_test to the s2n_libcrypto_test, because it was only testing the "s2n_libcrypto" methods.

As part of that move, I also tried to update our s2n_openssl.h includes. Mostly if s2n_openssl.h isn't included somewhere, you'll get an error because a symbol it declares is missing. EXCEPT for OPENSSL_VERSION_NUMBER: it redefines OPENSSL_VERSION_NUMBER for libressl https://github.com/aws/s2n-tls/blob/82012056bb47dd710edb06324f8605969d5fa293/crypto/s2n_openssl.h#L26-L33
There's probably a less error prone way to handle that, but I'm just here about the names :)

So to cleanup the includes I:
- removed s2n_openssl.h as an include everywhere.
- added it back to [files that reference OPENSSL_VERSION_NUMBER](https://github.com/search?q=repo%3Aaws%2Fs2n-tls%20OPENSSL_VERSION_NUMBER&type=code)
- added it back to files that failed to compile due to missing symbols.
I also added s2n_libcrypto.h as an include to files that failed to compile due to missing "s2n_libcrypto_is" symbols.

We definitely need a more comprehensive include cleanup, but I just didn't want to make the situation worse with this move.

### Testing:
Existing tests pass. This should just be moving files around.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
