### PR TITLE
bindings: unpin openssl crate from a specific patch version

### DIFF
--- a/bindings/rust/extended/s2n-tls/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls/Cargo.toml
@@ -28,9 +28,7 @@ hex = "0.4"
 
 [dev-dependencies]
 futures-test = "0.3"
-# The openssl crate broke MSRV with 0.10.67
-# TODO unpin this once fixed - https://github.com/sfackler/rust-openssl/issues/2317
-openssl = "<0.10.67"
+openssl = "0.10"
 openssl-sys = "0.9"
 foreign-types = "0.3"
 temp-env = "0.3"


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

[PR to the rust openssl crate](https://github.com/sfackler/rust-openssl/issues/2317) has been merged. Hence, we should unpin our openssl crate dependency according to [PR#4849](https://github.com/aws/s2n-tls/pull/4849).

### Call-outs:

[PR#5119](https://github.com/aws/s2n-tls/pull/5119) should be closed once this PR is merged.

### Testing:

CI tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
