### PR TITLE
chore: separate build from test

### DIFF
--- a/codebuild/spec/buildspec_ktls.yml
+++ b/codebuild/spec/buildspec_ktls.yml
@@ -45,6 +45,8 @@ phases:
       - echo "Checking that the TLS kernel mod loaded..."; test $(sudo lsmod|grep -c tls) = 1
   build:
     commands:
-      - nix develop .#awslc --command bash -c  'source ./nix/shell.sh && clean && configure && unit'
+      - nix develop .#awslc --command bash -c  'source ./nix/shell.sh && clean && configure && build'
+  post_build:
+    commands:
+      - nix develop .#awslc --command bash -c  'source ./nix/shell.sh && unit'
       - S2N_CMAKE_OPTIONS="-DASAN=ON" nix develop .#awslc --command bash -c  'source ./nix/shell.sh && clean && configure && unit'
-


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

none

### Description of changes: 

Codebuild emits timing metrics to CloudWatch per phase. To capture just the build timing, I need a singleton job (not batch) where build and test can be separated. The recent kTLS job is a good candidate.

### Call-outs:

There is only one phase after build, so the ASAN build/test is running with the regular tests.

### Testing:

locally- this buildspec change should run in CI as well.

Remember:
* Any change to the library source code should at least include unit tests.
* Any change to the core stuffer or blob methods should include [CBMC proofs](https://github.com/aws/s2n-tls/tree/main/tests/cbmc).
* Any change to the CI or tests should:
   1. prove that the test succeeds for good input
   2. prove that the test fails for bad input (eg, a test for memory leaks fails when a memory leak is committed)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
