### PR TITLE
chore: fix a typo in API comments

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1774,7 +1774,7 @@ S2N_API extern int s2n_connection_get_write_fd(struct s2n_connection *conn, int 
 S2N_API extern int s2n_connection_use_corked_io(struct s2n_connection *conn);
 
 /**
- * Function pointer for a user provided send callback.
+ * Function pointer for a user provided recv callback.
  */
 typedef int s2n_recv_fn(void *io_context, uint8_t *buf, uint32_t len);
 


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves #5115 

### Description of changes: 

A customer found a typo in our API comments. The comment should indicate that `s2n_recv_fn` should be a recv callback instead of a send callback.

### Call-outs:

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
