### PR TITLE
fix(bindings): remove mutation behind Arc

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/cert_chain.rs
+++ b/bindings/rust/extended/s2n-tls/src/cert_chain.rs
@@ -26,6 +26,9 @@ unsafe impl Send for CertificateChainHandle<'_> {}
 unsafe impl Sync for CertificateChainHandle<'_> {}
 
 impl CertificateChainHandle<'_> {
+    /// Allocate an uninitialized CertificateChainHandle.
+    ///
+    /// Corresponds to [s2n_cert_chain_and_key_new].
     pub(crate) fn allocate() -> Result<CertificateChainHandle<'static>, crate::error::Error> {
         crate::init::init();
         Ok(CertificateChainHandle {
@@ -57,13 +60,13 @@ impl Drop for CertificateChainHandle<'_> {
 }
 
 pub struct Builder {
-    cert: CertificateChainHandle<'static>,
+    cert_handle: CertificateChainHandle<'static>,
 }
 
 impl Builder {
     pub fn new() -> Result<Self, Error> {
         Ok(Self {
-            cert: CertificateChainHandle::allocate()?,
+            cert_handle: CertificateChainHandle::allocate()?,
         })
     }
 
@@ -77,7 +80,7 @@ impl Builder {
             // `private_key_pem` are not modified.
             // https://github.com/aws/s2n-tls/issues/4140
             s2n_cert_chain_and_key_load_pem_bytes(
-                self.cert.cert.as_ptr(),
+                self.cert_handle.cert.as_ptr(),
                 chain.as_ptr() as *mut _,
                 chain.len() as u32,
                 key.as_ptr() as *mut _,
@@ -99,7 +102,7 @@ impl Builder {
             // is not modified
             // https://github.com/aws/s2n-tls/issues/4140
             s2n_cert_chain_and_key_load_public_pem_bytes(
-                self.cert.cert.as_ptr(),
+                self.cert_handle.cert.as_ptr(),
                 chain.as_ptr() as *mut _,
                 chain.len() as u32,
             )
@@ -113,7 +116,7 @@ impl Builder {
     pub fn set_ocsp_data(&mut self, data: &[u8]) -> Result<&mut Self, Error> {
         unsafe {
             s2n_cert_chain_and_key_set_ocsp_data(
-                self.cert.cert.as_ptr(),
+                self.cert_handle.cert.as_ptr(),
                 data.as_ptr(),
                 data.len() as u32,
             )
@@ -126,7 +129,7 @@ impl Builder {
     pub fn build(self) -> Result<CertificateChain<'static>, Error> {
         // This method is currently infallible, but returning a result allows
         // us to add validation in the future.
-        Ok(CertificateChain::from_allocated(self.cert))
+        Ok(CertificateChain::from_allocated(self.cert_handle))
     }
 }
 
@@ -139,18 +142,16 @@ impl Builder {
 // safe to mutate CertificateChains.
 #[derive(Clone)]
 pub struct CertificateChain<'a> {
-    ptr: Arc<CertificateChainHandle<'a>>,
+    cert_handle: Arc<CertificateChainHandle<'a>>,
 }
 
 impl CertificateChain<'_> {
-    /// This allocates a new certificate chain from s2n.
-    ///
-    /// Corresponds to [s2n_cert_chain_and_key_new].
+    /// Construct a CertificateChain from an allocated [CertificateChainHandle].
     pub(crate) fn from_allocated(
         handle: CertificateChainHandle<'static>,
     ) -> CertificateChain<'static> {
         CertificateChain {
-            ptr: Arc::new(handle),
+            cert_handle: Arc::new(handle),
         }
     }
 
@@ -161,7 +162,9 @@ impl CertificateChain<'_> {
     ) -> CertificateChain<'a> {
         let handle = Arc::new(CertificateChainHandle::from_reference(ptr));
 
-        CertificateChain { ptr: handle }
+        CertificateChain {
+            cert_handle: handle,
+        }
     }
 
     pub fn iter(&self) -> CertificateChainIter<'_> {
@@ -200,7 +203,7 @@ impl CertificateChain<'_> {
     }
 
     pub(crate) fn as_ptr(&self) -> *const s2n_cert_chain_and_key {
-        self.ptr.cert.as_ptr() as *const _
+        self.cert_handle.cert.as_ptr() as *const _
     }
 }
 
@@ -328,19 +331,19 @@ mod tests {
     #[test]
     fn reference_count_increment() -> Result<(), crate::error::Error> {
         let cert = SniTestCerts::AlligatorRsa.get().into_certificate_chain();
-        assert_eq!(Arc::strong_count(&cert.ptr), 1);
+        assert_eq!(Arc::strong_count(&cert.cert_handle), 1);
 
         {
             let mut server = config::Builder::new();
             server.load_chain(cert.clone())?;
 
             // after being added, the reference count should have increased
-            assert_eq!(Arc::strong_count(&cert.ptr), 2);
+            assert_eq!(Arc::strong_count(&cert.cert_handle), 2);
         }
 
         // after the config goes out of scope and is dropped, the ref count should
         // decrement
-        assert_eq!(Arc::strong_count(&cert.ptr), 1);
+        assert_eq!(Arc::strong_count(&cert.cert_handle), 1);
         Ok(())
     }
 
@@ -348,8 +351,8 @@ mod tests {
     fn cert_is_dropped() {
         let weak_ref = {
             let cert = SniTestCerts::AlligatorEcdsa.get().into_certificate_chain();
-            assert_eq!(Arc::strong_count(&cert.ptr), 1);
-            Arc::downgrade(&cert.ptr)
+            assert_eq!(Arc::strong_count(&cert.cert_handle), 1);
+            Arc::downgrade(&cert.cert_handle)
         };
         assert_eq!(weak_ref.strong_count(), 0);
         assert!(weak_ref.upgrade().is_none());
@@ -366,17 +369,17 @@ mod tests {
         let mut test_pair_2 =
             sni_test_pair(vec![cert.clone()], None, &[SniTestCerts::AlligatorRsa])?;
 
-        assert_eq!(Arc::strong_count(&cert.ptr), 3);
+        assert_eq!(Arc::strong_count(&cert.cert_handle), 3);
 
         assert!(test_pair_1.handshake().is_ok());
         assert!(test_pair_2.handshake().is_ok());
 
-        assert_eq!(Arc::strong_count(&cert.ptr), 3);
+        assert_eq!(Arc::strong_count(&cert.cert_handle), 3);
 
         drop(test_pair_1);
-        assert_eq!(Arc::strong_count(&cert.ptr), 2);
+        assert_eq!(Arc::strong_count(&cert.cert_handle), 2);
         drop(test_pair_2);
-        assert_eq!(Arc::strong_count(&cert.ptr), 1);
+        assert_eq!(Arc::strong_count(&cert.cert_handle), 1);
         Ok(())
     }
 
@@ -385,7 +388,7 @@ mod tests {
         // 5 certs in the maximum allowed, 6 should error.
         const FAILING_NUMBER: usize = 6;
         let certs = vec![SniTestCerts::AlligatorRsa.get().into_certificate_chain(); FAILING_NUMBER];
-        assert_eq!(Arc::strong_count(&certs[0].ptr), FAILING_NUMBER);
+        assert_eq!(Arc::strong_count(&certs[0].cert_handle), FAILING_NUMBER);
 
         let mut config = config::Builder::new();
         let err = config.set_default_chains(certs.clone()).err().unwrap();
@@ -394,7 +397,7 @@ mod tests {
 
         // The config should not hold a reference when the error was detected
         // in the bindings
-        assert_eq!(Arc::strong_count(&certs[0].ptr), FAILING_NUMBER);
+        assert_eq!(Arc::strong_count(&certs[0].cert_handle), FAILING_NUMBER);
 
         Ok(())
     }
@@ -419,8 +422,8 @@ mod tests {
                 &test_pair.client.peer_cert_chain().unwrap()
             ));
 
-            assert_eq!(Arc::strong_count(&alligator_cert.ptr), 2);
-            assert_eq!(Arc::strong_count(&beaver_cert.ptr), 2);
+            assert_eq!(Arc::strong_count(&alligator_cert.cert_handle), 2);
+            assert_eq!(Arc::strong_count(&beaver_cert.cert_handle), 2);
         }
 
         // set an explicit default
@@ -438,10 +441,10 @@ mod tests {
                 &test_pair.client.peer_cert_chain().unwrap()
             ));
 
-            assert_eq!(Arc::strong_count(&alligator_cert.ptr), 2);
+            assert_eq!(Arc::strong_count(&alligator_cert.cert_handle), 2);
             // beaver has an additional reference because it was used in multiple
             // calls
-            assert_eq!(Arc::strong_count(&beaver_cert.ptr), 3);
+            assert_eq!(Arc::strong_count(&beaver_cert.cert_handle), 3);
         }
 
         // set a default without adding it to the store
@@ -459,8 +462,8 @@ mod tests {
                 &test_pair.client.peer_cert_chain().unwrap()
             ));
 
-            assert_eq!(Arc::strong_count(&alligator_cert.ptr), 2);
-            assert_eq!(Arc::strong_count(&beaver_cert.ptr), 2);
+            assert_eq!(Arc::strong_count(&alligator_cert.cert_handle), 2);
+            assert_eq!(Arc::strong_count(&beaver_cert.cert_handle), 2);
         }
 
         Ok(())


### PR DESCRIPTION
### Description of changes: 

- don't mutate item behind immutable ref
- tie lifetime to `CertificateChainHandle`

In `connection.rs`, we essentially mutate a `CertificateChainHandle` which is behind `Arc<CertificateChainHandle>`. This does not seem correct.

> If you have a reference `&T`, then normally in Rust the compiler performs optimizations based on the knowledge that &T points to immutable data. Mutating that data, for example through an alias or by transmuting a `&T` into a `&mut T`, is considered undefined behavior.
> [UnsafeCell docs](https://doc.rust-lang.org/std/cell/struct.UnsafeCell.html)

Additionally, the most accurate place to tag the lifetime is on the underlying `CertificateChainHandle`, which already has the `is_owned` field.

### Call-outs:
This refactor is being done to simplify the addition of an application-level CertificateChainContext. 

### Testing:
This is a refactor. All existing tests should continue to pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
