### PR TITLE
build(deps): update rand requirement

### DIFF
--- a/bindings/rust/extended/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls-tokio/Cargo.toml
@@ -21,6 +21,6 @@ tokio = { version = "1", features = ["net", "time"] }
 
 [dev-dependencies]
 s2n-tls = { path = "../s2n-tls", features = ["unstable-testing"] }
-rand = { version = "0.8" }
+rand = { version = "0.9" }
 tokio = { version = "1", features = [ "io-std", "io-util", "macros", "net", "rt-multi-thread", "test-util", "time"] }
 tokio-macros = "=2.3.0"

--- a/bindings/rust/extended/s2n-tls-tokio/tests/handshake.rs
+++ b/bindings/rust/extended/s2n-tls-tokio/tests/handshake.rs
@@ -62,7 +62,7 @@ async fn handshake_with_pool_multithread() -> Result<(), Box<dyn std::error::Err
         let server = server.clone();
         tasks.push_back(tokio::spawn(async move {
             // Start each handshake at a randomly determined time
-            let rand = rand::thread_rng().gen_range(0..50);
+            let rand = rand::rng().random_range(0..50);
             time::sleep(Duration::from_millis(rand)).await;
 
             let (server_stream, client_stream) = common::get_streams().await.unwrap();


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

This PR fixes breaking changes that were introduced by `rand v0.9.0`. This PR fixes [the dependabot PR](https://github.com/aws/s2n-tls/pull/5092).

According to the [release announcement](https://github.com/rust-random/rand/releases/tag/0.9.0), `thread_rng` is renamed to `rng` and `gen_range()` is renamed to `random_range()`.

### Call-outs:

### Testing:

CI test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
