### PR TITLE
ci: always set values for command line defines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,7 @@ endif()
 
 if (NOT S2N_OVERRIDE_LIBCRYPTO_RAND_ENGINE)
     message(STATUS "Disabling libcrypto RAND engine override")
-    add_definitions(-DS2N_DISABLE_RAND_ENGINE_OVERRIDE)
+    add_definitions(-DS2N_DISABLE_RAND_ENGINE_OVERRIDE=1)
 endif()
 
 # For interning, we need to find the static libcrypto library. Cmake configs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,7 @@ endif ()
 if(BUILD_TESTING AND BUILD_SHARED_LIBS OR S2N_FUZZ_TEST)
     target_compile_options(${PROJECT_NAME} PRIVATE -fvisibility=default)
 else()
-    target_compile_options(${PROJECT_NAME} PRIVATE -fvisibility=hidden -DS2N_EXPORTS)
+    target_compile_options(${PROJECT_NAME} PRIVATE -fvisibility=hidden -DS2N_EXPORTS=1)
 endif()
 
 if(S2N_LTO)
@@ -197,7 +197,7 @@ target_compile_options(${PROJECT_NAME} PRIVATE -include "${S2N_PRELUDE}")
 # Match on Release, RelWithDebInfo and MinSizeRel
 # See: https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html#variable:CMAKE_BUILD_TYPE
 if(CMAKE_BUILD_TYPE MATCHES Rel)
-    add_definitions(-DS2N_BUILD_RELEASE)
+    add_definitions(-DS2N_BUILD_RELEASE=1)
 endif()
 
 if(NO_STACK_PROTECTOR)
@@ -316,7 +316,7 @@ function(feature_probe_result PROBE_NAME IS_AVAILABLE)
 
     # define the probe if available
     if(NORMALIZED)
-        add_definitions(-D${PROBE_NAME})
+        add_definitions(-D${PROBE_NAME}=1)
     endif()
 endfunction()
 
@@ -426,7 +426,7 @@ if (S2N_INTERN_LIBCRYPTO)
       DEPENDS libcrypto.symbols
     )
     add_dependencies(${PROJECT_NAME} s2n_libcrypto)
-    add_definitions(-DS2N_INTERN_LIBCRYPTO)
+    add_definitions(-DS2N_INTERN_LIBCRYPTO=1)
 
     if ((BUILD_SHARED_LIBS AND BUILD_TESTING) OR NOT BUILD_SHARED_LIBS)
         # if libcrypto needs to be interned, rewrite libcrypto references so use of internal functions will link correctly

--- a/codebuild/bin/grep_simple_mistakes.sh
+++ b/codebuild/bin/grep_simple_mistakes.sh
@@ -15,6 +15,20 @@
 FAILED=0
 
 #############################################
+# Grep for command line defines without values
+#############################################
+EMPTY_DEFINES=$(grep -Eon "\-D[^=]+=?" CMakeLists.txt | grep -v =)
+if [ ! -z "${EMPTY_DEFINES}" ]; then
+    FAILED=1
+    printf "\e[1;34mCommand line define is missing value:\e[0m "
+    printf "Compilers SHOULD set a default value of 1 when no default is given, "
+    printf "but that behavior is not required by any official spec. Set a value just in case. "
+    printf "For example: -DS2N_FOO=1 instead of -DS2N_FOO.\n"
+    printf "Found: \n"
+    echo "$EMPTY_DEFINES"
+fi
+
+#############################################
 # Grep for bindings methods without C documentation links.
 #############################################
 BINDINGS="bindings/rust/extended/s2n-tls/src"

--- a/s2n.mk
+++ b/s2n.mk
@@ -134,7 +134,7 @@ bindir ?= $(exec_prefix)/bin
 libdir ?= $(exec_prefix)/lib64
 includedir ?= $(exec_prefix)/include
 
-feature_probe = $(shell $(CC) $(CFLAGS) $(shell cat $(S2N_ROOT)/tests/features/GLOBAL.flags) $(shell cat $(S2N_ROOT)/tests/features/$(1).flags) -c -o tmp.o $(S2N_ROOT)/tests/features/$(1).c > /dev/null 2>&1 && echo "-D$(1)"; rm tmp.o > /dev/null 2>&1)
+feature_probe = $(shell $(CC) $(CFLAGS) $(shell cat $(S2N_ROOT)/tests/features/GLOBAL.flags) $(shell cat $(S2N_ROOT)/tests/features/$(1).flags) -c -o tmp.o $(S2N_ROOT)/tests/features/$(1).c > /dev/null 2>&1 && echo "-D$(1)=1"; rm tmp.o > /dev/null 2>&1)
 
 FEATURES := $(notdir $(patsubst %.c,%,$(wildcard $(S2N_ROOT)/tests/features/*.c)))
 SUPPORTED_FEATURES := $(foreach feature,$(FEATURES),$(call feature_probe,$(feature)))


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

resolves https://github.com/aws/s2n-tls/pull/5116#discussion_r1960606451

### Description of changes: 

gcc, clang, and [every compiler on godbolt that I could test with](https://godbolt.org/z/8PTaP14sa) set any command-line define to 1 by default. But that's apparently not part of any spec, so a compiler could theoretically do something different. It's also arguably "magical" behavior: without reading the right clang or gcc documentation, it's unclear that it's happening.

I'm thinking that it would be clearer to just explicitly set defines to 1.

It's also technically safer, but honestly probably not that much safer.  While I was trying to find any sort of spec, I found [this](https://stackoverflow.com/questions/69083896/gcc-whats-the-default-value-when-a-symbol-is-defined-on-command-line) memorable quote: "The C Standard does not mandate this behavior but it would take a perverse compiler to not mimic the original pcc as all others have for 40 years including gcc and clang." The "perverse" compiler would also have to specifically use "0" as its default, because any non-0 value would work just fine in any #ifs and just not setting any value at all would cause compilation of any #ifs to fail.

### Testing:
The script passes for the updated CMakeLists.txt.
The script fails for the old CMakeLists.txt with: https://github.com/lrstewart/s2n/actions/runs/13402258346/job/37435368302?pr=61
```
Command line define is missing value: Compilers SHOULD set a default value of 1 when no default is given, but that behavior is not required by any official spec. Set a value just in case. For example: -DS2N_FOO=1 instead of -DS2N_FOO.
Found: 
166:-DS2N_EXPORTS)
198:-DS2N_BUILD_RELEASE)
312:-D${PROBE_NAME})
422:-DS2N_INTERN_LIBCRYPTO)
FAILED Grep For Simple Mistakes check
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
