### PR TITLE
tests: use sig schemes as source of truth for valid hash+sig algs

### DIFF
--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -651,7 +651,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(config->security_policy, &security_policy_test_all);
         EXPECT_EQUAL(config->security_policy->cipher_preferences, &cipher_preferences_test_all);
         EXPECT_EQUAL(config->security_policy->kem_preferences, &kem_preferences_all);
-        EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_20201021);
+        EXPECT_EQUAL(config->security_policy->signature_preferences, &s2n_signature_preferences_all);
         EXPECT_EQUAL(config->security_policy->ecc_preferences, &s2n_ecc_preferences_test_all);
 
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all_tls12"));
@@ -755,7 +755,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(security_policy, &security_policy_test_all);
         EXPECT_EQUAL(security_policy->cipher_preferences, &cipher_preferences_test_all);
         EXPECT_EQUAL(security_policy->kem_preferences, &kem_preferences_all);
-        EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_20201021);
+        EXPECT_EQUAL(security_policy->signature_preferences, &s2n_signature_preferences_all);
         EXPECT_EQUAL(security_policy->ecc_preferences, &s2n_ecc_preferences_test_all);
 
         EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "test_all_tls12"));

--- a/tests/unit/s2n_signature_scheme_test.c
+++ b/tests/unit/s2n_signature_scheme_test.c
@@ -28,6 +28,9 @@ int main(int argc, char **argv)
     while (security_policy_selection[policy_i].version != NULL) {
         const struct s2n_signature_preferences *sig_prefs =
                 security_policy_selection[policy_i].security_policy->signature_preferences;
+
+        bool s2n_rsa_pkcs1_md5_sha1_found = false;
+
         for (size_t sig_i = 0; sig_i < sig_prefs->count; sig_i++) {
             const struct s2n_signature_scheme *const sig_scheme = sig_prefs->signature_schemes[sig_i];
 
@@ -53,6 +56,15 @@ int main(int argc, char **argv)
                 EXPECT_NOT_EQUAL(sig_scheme->iana_value, potential_duplicate->iana_value);
             }
 
+            if (sig_scheme == &s2n_rsa_pkcs1_md5_sha1) {
+                s2n_rsa_pkcs1_md5_sha1_found = true;
+            }
+
+            /* s2n_null_sig_scheme is not a real signature scheme and is just a placeholder.
+             * It should not appear in any policy.
+             */
+            EXPECT_NOT_EQUAL(sig_scheme, &s2n_null_sig_scheme);
+
             /* Must be included in s2n_signature_preferences_all */
             bool in_all = false;
             for (size_t all_i = 0; all_i < all_prefs->count; all_i++) {
@@ -62,38 +74,18 @@ int main(int argc, char **argv)
             }
             EXPECT_TRUE(in_all);
         }
+
+        /* Only s2n_signature_preferences_all should include s2n_rsa_pkcs1_md5_sha1
+         *
+         * s2n_rsa_pkcs1_md5_sha1 is the implicit default for pre-TLS1.2 when no signature
+         * schemes are provided. Any code that needs to handle "all signature schemes"
+         * also needs to handle s2n_rsa_pkcs1_md5_sha1. It is not explicitly included
+         * in any real signature preferences, but should still be tracked by
+         * s2n_signature_preferences_all.
+         */
+        EXPECT_EQUAL(s2n_rsa_pkcs1_md5_sha1_found, sig_prefs == all_prefs);
+
         policy_i++;
-    }
-
-    /* Test: s2n_signature_preferences_all should also include s2n_rsa_pkcs1_md5_sha1
-     *
-     * s2n_rsa_pkcs1_md5_sha1 is the implicit default for pre-TLS1.2 when no signature
-     * schemes are provided. Any code that needs to handle "all signature schemes"
-     * also needs to handle s2n_rsa_pkcs1_md5_sha1. It is not explicitly included
-     * in any security policy, but should still be tracked by s2n_signature_preferences_all.
-     */
-    {
-        bool includes_md5_sha1 = false;
-        for (size_t i = 0; i < all_prefs->count; i++) {
-            if (all_prefs->signature_schemes[i] == &s2n_rsa_pkcs1_md5_sha1) {
-                includes_md5_sha1 = true;
-            }
-        }
-        EXPECT_TRUE(includes_md5_sha1);
-    }
-
-    /* Test: s2n_signature_preferences_all should not include s2n_null_sig_scheme.
-     *
-     * s2n_null_sig_scheme is not a real signature scheme and is just a placeholder.
-     */
-    {
-        bool includes_null = false;
-        for (size_t i = 0; i < all_prefs->count; i++) {
-            if (all_prefs->signature_schemes[i] == &s2n_null_sig_scheme) {
-                includes_null = true;
-            }
-        }
-        EXPECT_FALSE(includes_null);
     }
 
     END_TEST();

--- a/tests/unit/s2n_signature_scheme_test.c
+++ b/tests/unit/s2n_signature_scheme_test.c
@@ -13,13 +13,15 @@
  * permissions and limitations under the License.
  */
 
-#include "tls/s2n_signature_scheme.c"
+#include "tls/s2n_signature_scheme.h"
 
 #include "s2n_test.h"
 
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
+
+    const struct s2n_signature_preferences *all_prefs = &s2n_signature_preferences_all;
 
     /* Test all signature schemes */
     size_t policy_i = 0;
@@ -50,8 +52,48 @@ int main(int argc, char **argv)
                         sig_prefs->signature_schemes[dup_i];
                 EXPECT_NOT_EQUAL(sig_scheme->iana_value, potential_duplicate->iana_value);
             }
+
+            /* Must be included in s2n_signature_preferences_all */
+            bool in_all = false;
+            for (size_t all_i = 0; all_i < all_prefs->count; all_i++) {
+                if (sig_scheme == all_prefs->signature_schemes[all_i]) {
+                    in_all = true;
+                }
+            }
+            EXPECT_TRUE(in_all);
         }
         policy_i++;
+    }
+
+    /* Test: s2n_signature_preferences_all should also include s2n_rsa_pkcs1_md5_sha1
+     *
+     * s2n_rsa_pkcs1_md5_sha1 is the implicit default for pre-TLS1.2 when no signature
+     * schemes are provided. Any code that needs to handle "all signature schemes"
+     * also needs to handle s2n_rsa_pkcs1_md5_sha1. It is not explicitly included
+     * in any security policy, but should still be tracked by s2n_signature_preferences_all.
+     */
+    {
+        bool includes_md5_sha1 = false;
+        for (size_t i = 0; i < all_prefs->count; i++) {
+            if (all_prefs->signature_schemes[i] == &s2n_rsa_pkcs1_md5_sha1) {
+                includes_md5_sha1 = true;
+            }
+        }
+        EXPECT_TRUE(includes_md5_sha1);
+    }
+
+    /* Test: s2n_signature_preferences_all should not include s2n_null_sig_scheme.
+     *
+     * s2n_null_sig_scheme is not a real signature scheme and is just a placeholder.
+     */
+    {
+        bool includes_null = false;
+        for (size_t i = 0; i < all_prefs->count; i++) {
+            if (all_prefs->signature_schemes[i] == &s2n_null_sig_scheme) {
+                includes_null = true;
+            }
+        }
+        EXPECT_FALSE(includes_null);
     }
 
     END_TEST();

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -1154,7 +1154,7 @@ const struct s2n_security_policy security_policy_test_all = {
     .minimum_protocol_version = S2N_SSLv3,
     .cipher_preferences = &cipher_preferences_test_all,
     .kem_preferences = &kem_preferences_all,
-    .signature_preferences = &s2n_signature_preferences_20201021,
+    .signature_preferences = &s2n_signature_preferences_all,
     .ecc_preferences = &s2n_ecc_preferences_test_all,
 };
 

--- a/tls/s2n_signature_scheme.c
+++ b/tls/s2n_signature_scheme.c
@@ -204,6 +204,34 @@ const struct s2n_signature_scheme s2n_rsa_pss_pss_sha512 = {
     .minimum_protocol_version = S2N_TLS12,
 };
 
+/* ALL signature schemes, including the legacy default s2n_rsa_pkcs1_md5_sha1 scheme.
+ * New signature schemes must be added to this list.
+ */
+const struct s2n_signature_scheme* const s2n_sig_scheme_pref_list_all[] = {
+    &s2n_rsa_pkcs1_md5_sha1,
+    &s2n_rsa_pkcs1_sha1,
+    &s2n_rsa_pkcs1_sha224,
+    &s2n_rsa_pkcs1_sha256,
+    &s2n_rsa_pkcs1_sha384,
+    &s2n_rsa_pkcs1_sha512,
+    &s2n_ecdsa_sha1,
+    &s2n_ecdsa_sha224,
+    &s2n_ecdsa_sha256,
+    &s2n_ecdsa_sha384,
+    &s2n_ecdsa_sha512,
+    &s2n_rsa_pss_rsae_sha256,
+    &s2n_rsa_pss_rsae_sha384,
+    &s2n_rsa_pss_rsae_sha512,
+    &s2n_rsa_pss_pss_sha256,
+    &s2n_rsa_pss_pss_sha384,
+    &s2n_rsa_pss_pss_sha512,
+};
+
+const struct s2n_signature_preferences s2n_signature_preferences_all = {
+    .count = s2n_array_len(s2n_sig_scheme_pref_list_all),
+    .signature_schemes = s2n_sig_scheme_pref_list_all,
+};
+
 /* Chosen based on AWS server recommendations as of 05/24.
  *
  * The recommendations do not include PKCS1, but we must include it anyway for

--- a/tls/s2n_signature_scheme.h
+++ b/tls/s2n_signature_scheme.h
@@ -82,5 +82,6 @@ extern const struct s2n_signature_preferences s2n_certificate_signature_preferen
 extern const struct s2n_signature_preferences s2n_signature_preferences_default_fips;
 extern const struct s2n_signature_preferences s2n_signature_preferences_null;
 extern const struct s2n_signature_preferences s2n_signature_preferences_test_all_fips;
+extern const struct s2n_signature_preferences s2n_signature_preferences_all;
 
 extern const struct s2n_signature_preferences s2n_certificate_signature_preferences_20201110;


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

related to https://github.com/aws/s2n-tls/issues/5105

### Description of changes: 

Fixing an issue that keeps causing problems in my hash and signing PRs.

It's hard to define "all valid hash algs" in the context of signing. Different libcryptos decide to forbid different combinations, like no MD5 at all or no MD5+SHA1 for ECDSA. We have more than one test trying to define those rules, and the reasoning behind those definitions aren't particularly clear.

Rather than try to separately define all those banned combinations, we should just treat "all valid hash algs" as all the hash algs for which there exists a signature scheme. Signature schemes are the real source of truth for all allowed hash alg + sig scheme combinations. They're the only combinations we'll ever need to care about. 

### Call-outs:
The one "miss" here is that we no longer check that signing methods flag "invalid" algs as invalid. I'm not particularly concerned about that. Without a signature scheme to trigger the signing process, those methods will never get any "invalid" combination in the first place. Also, the libcryptos will happily reject what they define as invalid combos :upside_down_face: 

### Testing:
This is a testing change


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
