### PR TITLE
fix: update callback return value

### DIFF
--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -818,7 +818,7 @@ S2N_RESULT s2n_x509_validator_validate_cert_chain(struct s2n_x509_validator *val
         RESULT_GUARD(s2n_x509_validator_validate_cert_chain_pre_cb(validator, conn, cert_chain_in, cert_chain_len));
 
         if (conn->config->cert_validation_cb) {
-            RESULT_ENSURE(conn->config->cert_validation_cb(conn, &(validator->cert_validation_info), conn->config->cert_validation_ctx) >= S2N_SUCCESS,
+            RESULT_ENSURE(conn->config->cert_validation_cb(conn, &(validator->cert_validation_info), conn->config->cert_validation_ctx) == S2N_SUCCESS,
                     S2N_ERR_CANCELLED);
             validator->cert_validation_cb_invoked = true;
             RESULT_GUARD(s2n_x509_validator_handle_cert_validation_callback_result(validator));


### PR DESCRIPTION
### Release Summary:
A successful cert validation callback should return only `S2N_SUCCESS`. Previously, both 0 and any positive return value were considered successful.

### Description of changes: 

This is a follow-up change on PR #5110

Per our documentation, `s2n_cert_validation_callback` should return `S2N_SUCCESS` on success. However, the old behavior accepted both 0 and positive values. This PR aims to fix this inconsistency.

### Testing:

Confirmed `s2n_cert_validation_callback_test` passed with this change

```
$ cmake --build build/ --target test -- ARGS="-L unit -R s2n_cert_validation_callback_test --output-on-failure"
Running tests...
Test project /home/ubuntu/s2n-tls/build
    Start 18: s2n_cert_validation_callback_test
1/1 Test #18: s2n_cert_validation_callback_test ...   Passed    0.74 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
unit    =   0.74 sec*proc (1 test)

Total Test time (real) =   0.74 sec
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
