### PR TITLE
ci: add check for third-party-src in disable rand override buildspec

### DIFF
--- a/codebuild/spec/buildspec_disable_rand_override.yml
+++ b/codebuild/spec/buildspec_disable_rand_override.yml
@@ -21,6 +21,12 @@ env:
     CTEST_OUTPUT_ON_FAILURE: 1
 
 phases:
+  pre_build:
+    commands:
+      - |
+        if [ -d "third-party-src" ]; then
+          cd third-party-src;
+        fi
   build:
     on-failure: ABORT
     commands:


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

The `buildspec_disable_rand_override.yml` is lacking the check for `third-party-src` which is causing our release to fail. I am adding this test to fix the directory entry.

### Call-outs:

### Testing:

This will be tested in the CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
