### PR TITLE
Ruff Formatting and add to CI

### DIFF
--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -83,6 +83,10 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
 
+      - name: Install dependencies
+        working-directory: tests/integrationv2  # Set the working directory
+        run: uv install  # Use uv to install dependencies from pyproject.toml
+
       - name: Run Ruff formatting check
         working-directory: tests/integrationv2  # Set the working directory
         id: ruff_format

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -79,13 +79,16 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
+
       - name: Run Ruff formatting check
+        working-directory: tests/integrationv2  # Set the working directory
         id: ruff_format
         run: ruff format --check .
-        working-directory: tests/integrationv2  # Set the working directory
         continue-on-error: true
+
       - name: Check exit code
         if: steps.ruff_format.outcome == 'failure'
         run: |

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -81,12 +81,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
-      - name: Install dependencies
-        run: pip install tests/integrationv2
       - name: Run Ruff formatting check
         id: ruff_format
-        run: ruff format --check tests/integrationv2
-      continue-on-error: true
+        run: ruff format --check .
+        working-directory: tests/integrationv2  # Set the working directory
         continue-on-error: true
       - name: Check exit code
         if: steps.ruff_format.outcome == 'failure'

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -83,10 +83,14 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
 
+      - name: Install Ruff in tests/integrationv2
+        working-directory: tests/integrationv2
+        run: uv add ruff
+
       - name: Run Ruff formatting check
-        working-directory: tests/integrationv2  # Set the working directory
+        working-directory: tests/integrationv2
         id: ruff_format
-        run: uvx ruff format --check .  # Use uvx to run ruff
+        run: uv run ruff format --check .
         continue-on-error: true
 
       - name: Check exit code

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -81,10 +81,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
-      - name: Install dependencies
-        run: |
-          cd tests/integrationv2  # Change to the directory containing pyproject.toml
-          pip install .           # Install dependencies from pyproject.toml
       - name: Run Ruff formatting check
         id: ruff_format
         run: |

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -77,17 +77,16 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: checkout
         uses: actions/checkout@v4
-
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
       - name: Install Ruff
-        run: pip install ruff
-
+        run: uv pip install ruff
       - name: Run Ruff formatting check
         id: ruff_format
         run: ruff format --check .
         continue-on-error: true
-
       - name: Check exit code
         if: steps.ruff_format.outcome == 'failure'
         run: |

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -83,7 +83,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
       - name: Run Ruff formatting check
         id: ruff_format
-        run: uv run ruff format --check .
+        run: uv run ruff format --check tests/integrationv2
         continue-on-error: true
       - name: Check exit code
         if: steps.ruff_format.outcome == 'failure'

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: tests/integrationv2  # Set the working directory
-        run: uv install  # Use uv to install dependencies from pyproject.toml
+        run: uv add  # Use uv to add dependencies defined in pyproject.toml
 
       - name: Run Ruff formatting check
         working-directory: tests/integrationv2  # Set the working directory

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -83,10 +83,6 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Install Ruff in tests/integrationv2
-        working-directory: tests/integrationv2
-        run: uv add ruff
-
       - name: Run Ruff formatting check
         working-directory: tests/integrationv2
         id: ruff_format

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: tests/integrationv2  # Set the working directory
-        run: uv add  # Use uv to add dependencies defined in pyproject.toml
+        run: uv add --requirements pyproject.toml  # Use uv to add dependencies from pyproject.toml
 
       - name: Run Ruff formatting check
         working-directory: tests/integrationv2  # Set the working directory

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -74,20 +74,24 @@ jobs:
         run: |
           ./codebuild/bin/run_kwstyle.sh
           ./codebuild/bin/cpp_style_comment_linter.sh
-  pepeight:
+  ruff:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Run autopep8
-        id: autopep8
-        uses: peter-evans/autopep8@v2
-        with:
-          args: --diff --exit-code .
+
+      - name: Install Ruff
+        run: pip install ruff
+
+      - name: Run Ruff formatting check
+        id: ruff_format
+        run: ruff format --check .
+        continue-on-error: true
+
       - name: Check exit code
-        if: steps.autopep8.outputs.exit-code != 0
+        if: steps.ruff_format.outcome == 'failure'
         run: |
-            echo "Run 'autopep8 --in-place .' to fix"
+            echo "Run 'ruff format .' to fix formatting issues"
             exit 1
   clang-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -83,14 +83,10 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Install dependencies
-        working-directory: tests/integrationv2  # Set the working directory
-        run: uv add --requirements pyproject.toml  # Use uv to add dependencies from pyproject.toml
-
       - name: Run Ruff formatting check
         working-directory: tests/integrationv2  # Set the working directory
         id: ruff_format
-        run: ruff format --check .
+        run: uvx ruff format --check .  # Use uvx to run ruff
         continue-on-error: true
 
       - name: Check exit code

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -81,11 +81,15 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
+      - name: Install dependencies
+        run: |
+          cd tests/integrationv2
+          pip install .
       - name: Run Ruff formatting check
         id: ruff_format
         run: |
-          cd tests/integrationv2  # Change to the directory again
-          ruff format --check .    # Run Ruff to check formatting
+          cd tests/integrationv2
+          ruff format --check .
         continue-on-error: true
       - name: Check exit code
         if: steps.ruff_format.outcome == 'failure'

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -81,11 +81,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
-      - name: Install Ruff
-        run: uv pip install ruff
       - name: Run Ruff formatting check
         id: ruff_format
-        run: ruff format --check .
+        run: uv run ruff format --check .
         continue-on-error: true
       - name: Check exit code
         if: steps.ruff_format.outcome == 'failure'

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -82,14 +82,11 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
       - name: Install dependencies
-        run: |
-          cd tests/integrationv2
-          pip install .
+        run: pip install tests/integrationv2
       - name: Run Ruff formatting check
         id: ruff_format
-        run: |
-          cd tests/integrationv2
-          ruff format --check .
+        run: ruff format --check tests/integrationv2
+      continue-on-error: true
         continue-on-error: true
       - name: Check exit code
         if: steps.ruff_format.outcome == 'failure'

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -81,6 +81,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
+      - name: Install dependencies
+        run: pip install .
       - name: Run Ruff formatting check
         id: ruff_format
         run: uv run ruff format --check tests/integrationv2

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -82,10 +82,14 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
       - name: Install dependencies
-        run: pip install .
+        run: |
+          cd tests/integrationv2  # Change to the directory containing pyproject.toml
+          pip install .           # Install dependencies from pyproject.toml
       - name: Run Ruff formatting check
         id: ruff_format
-        run: uv run ruff format --check tests/integrationv2
+        run: |
+          cd tests/integrationv2  # Change to the directory again
+          ruff format --check .    # Run Ruff to check formatting
         continue-on-error: true
       - name: Check exit code
         if: steps.ruff_format.outcome == 'failure'

--- a/.pep8
+++ b/.pep8
@@ -1,3 +1,0 @@
-[pep8]
-max_line_length = 120
-recursive = true

--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -31,12 +31,7 @@ TLS13 = [True, False]
 
 
 # List of all curves that will be tested.
-ALL_TEST_CURVES = [
-    Curves.X25519,
-    Curves.P256,
-    Curves.P384,
-    Curves.P521
-]
+ALL_TEST_CURVES = [Curves.X25519, Curves.P256, Curves.P384, Curves.P521]
 
 
 # List of all certificates that will be tested.
@@ -66,7 +61,7 @@ MINIMAL_TEST_CERTS = [
     Certificates.RSA_4096_SHA256,
     Certificates.ECDSA_256,
     Certificates.ECDSA_384,
-    Certificates.RSA_PSS_2048_SHA256
+    Certificates.RSA_PSS_2048_SHA256,
 ]
 
 
@@ -79,14 +74,12 @@ ALL_TEST_CIPHERS = [
     Ciphers.DHE_RSA_AES128_GCM_SHA256,
     Ciphers.DHE_RSA_AES256_GCM_SHA384,
     Ciphers.DHE_RSA_CHACHA20_POLY1305,
-
     Ciphers.AES128_SHA,
     Ciphers.AES256_SHA,
     Ciphers.AES128_SHA256,
     Ciphers.AES256_SHA256,
     Ciphers.AES128_GCM_SHA256,
     Ciphers.AES256_GCM_SHA384,
-
     Ciphers.ECDHE_ECDSA_AES128_GCM_SHA256,
     Ciphers.ECDHE_ECDSA_AES256_GCM_SHA384,
     Ciphers.ECDHE_ECDSA_AES128_SHA256,
@@ -94,7 +87,6 @@ ALL_TEST_CIPHERS = [
     Ciphers.ECDHE_ECDSA_AES128_SHA,
     Ciphers.ECDHE_ECDSA_AES256_SHA,
     Ciphers.ECDHE_ECDSA_CHACHA20_POLY1305,
-
     Ciphers.ECDHE_RSA_AES128_SHA,
     Ciphers.ECDHE_RSA_AES256_SHA,
     Ciphers.ECDHE_RSA_AES128_SHA256,
@@ -102,7 +94,6 @@ ALL_TEST_CIPHERS = [
     Ciphers.ECDHE_RSA_AES128_GCM_SHA256,
     Ciphers.ECDHE_RSA_AES256_GCM_SHA384,
     Ciphers.ECDHE_RSA_CHACHA20_POLY1305,
-
     Ciphers.CHACHA20_POLY1305_SHA256,
 ]
 
@@ -124,103 +115,109 @@ SNI_CERTS = {
     "alligator": (
         TEST_SNI_CERT_DIRECTORY + "alligator_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "alligator_key.pem",
-        ["www.alligator.com"]
+        ["www.alligator.com"],
     ),
     "second_alligator_rsa": (
         TEST_SNI_CERT_DIRECTORY + "second_alligator_rsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "second_alligator_rsa_key.pem",
-        ["www.alligator.com"]
+        ["www.alligator.com"],
     ),
     "alligator_ecdsa": (
         TEST_SNI_CERT_DIRECTORY + "alligator_ecdsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "alligator_ecdsa_key.pem",
-        ["www.alligator.com"]
+        ["www.alligator.com"],
     ),
     "beaver": (
         TEST_SNI_CERT_DIRECTORY + "beaver_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "beaver_key.pem",
-        ["www.beaver.com"]
+        ["www.beaver.com"],
     ),
     "many_animals": (
         TEST_SNI_CERT_DIRECTORY + "many_animal_sans_rsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "many_animal_sans_rsa_key.pem",
-        ["www.catfish.com",
-         "www.dolphin.com",
-         "www.elephant.com",
-         "www.falcon.com",
-         "www.gorilla.com",
-         "www.horse.com",
-         "www.impala.com",
-         # "Simple hostname"
-         "Jackal",
-         "k.e.e.l.b.i.l.l.e.d.t.o.u.c.a.n",
-         # SAN on this cert is actually "ladybug.ladybug"
-         # Verify case insensitivity works as expected.
-         "LADYBUG.LADYBUG",
-         "com.penguin.macaroni"]
+        [
+            "www.catfish.com",
+            "www.dolphin.com",
+            "www.elephant.com",
+            "www.falcon.com",
+            "www.gorilla.com",
+            "www.horse.com",
+            "www.impala.com",
+            # "Simple hostname"
+            "Jackal",
+            "k.e.e.l.b.i.l.l.e.d.t.o.u.c.a.n",
+            # SAN on this cert is actually "ladybug.ladybug"
+            # Verify case insensitivity works as expected.
+            "LADYBUG.LADYBUG",
+            "com.penguin.macaroni",
+        ],
     ),
     "narwhal_cn": (
         TEST_SNI_CERT_DIRECTORY + "narwhal_cn_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "narwhal_cn_key.pem",
-        ["www.narwhal.com"]
+        ["www.narwhal.com"],
     ),
     "octopus_cn_platypus_san": (
         TEST_SNI_CERT_DIRECTORY + "octopus_cn_platypus_san_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "octopus_cn_platypus_san_key.pem",
-        ["www.platypus.com"]
+        ["www.platypus.com"],
     ),
     "quail_cn_rattlesnake_cn": (
         TEST_SNI_CERT_DIRECTORY + "quail_cn_rattlesnake_cn_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "quail_cn_rattlesnake_cn_key.pem",
-        ["www.quail.com", "www.rattlesnake.com"]
+        ["www.quail.com", "www.rattlesnake.com"],
     ),
     "many_animals_mixed_case": (
         TEST_SNI_CERT_DIRECTORY + "many_animal_sans_mixed_case_rsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "many_animal_sans_mixed_case_rsa_key.pem",
-        ["alligator.com",
-         "beaver.com",
-         "catFish.com",
-         "WWW.dolphin.COM",
-         "www.ELEPHANT.com",
-         "www.Falcon.Com",
-         "WWW.gorilla.COM",
-         "www.horse.com",
-         "WWW.IMPALA.COM",
-         "WwW.jAcKaL.cOm"]
+        [
+            "alligator.com",
+            "beaver.com",
+            "catFish.com",
+            "WWW.dolphin.COM",
+            "www.ELEPHANT.com",
+            "www.Falcon.Com",
+            "WWW.gorilla.COM",
+            "www.horse.com",
+            "WWW.IMPALA.COM",
+            "WwW.jAcKaL.cOm",
+        ],
     ),
     "embedded_wildcard": (
         TEST_SNI_CERT_DIRECTORY + "embedded_wildcard_rsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "embedded_wildcard_rsa_key.pem",
-        ["www.labelstart*labelend.com"]
+        ["www.labelstart*labelend.com"],
     ),
     "non_empty_label_wildcard": (
         TEST_SNI_CERT_DIRECTORY + "non_empty_label_wildcard_rsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "non_empty_label_wildcard_rsa_key.pem",
-        ["WILD*.middle.end"]
+        ["WILD*.middle.end"],
     ),
     "trailing_wildcard": (
         TEST_SNI_CERT_DIRECTORY + "trailing_wildcard_rsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "trailing_wildcard_rsa_key.pem",
-        ["the.prefix.*"]
+        ["the.prefix.*"],
     ),
     "wildcard_insect": (
         TEST_SNI_CERT_DIRECTORY + "wildcard_insect_rsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "wildcard_insect_rsa_key.pem",
-        ["ant.insect.hexapod",
-         "BEE.insect.hexapod",
-         "wasp.INSECT.hexapod",
-         "butterfly.insect.hexapod"]
+        [
+            "ant.insect.hexapod",
+            "BEE.insect.hexapod",
+            "wasp.INSECT.hexapod",
+            "butterfly.insect.hexapod",
+        ],
     ),
     "termite": (
         TEST_SNI_CERT_DIRECTORY + "termite_rsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "termite_rsa_key.pem",
-        ["termite.insect.hexapod"]
+        ["termite.insect.hexapod"],
     ),
     "underwing": (
         TEST_SNI_CERT_DIRECTORY + "underwing_ecdsa_cert.pem",
         TEST_SNI_CERT_DIRECTORY + "underwing_ecdsa_key.pem",
-        ["underwing.insect.hexapod"]
-    )
+        ["underwing.insect.hexapod"],
+    ),
 }
 
 
@@ -228,74 +225,103 @@ SNI_CERTS = {
 # Test inputs: server certificates to load into s2nd, client SNI and capabilities, outputs are selected server cert
 # and negotiated cipher.
 MultiCertTest = collections.namedtuple(
-    'MultiCertTest', 'description server_certs client_sni client_ciphers expected_cert expect_matching_hostname')
+    "MultiCertTest",
+    "description server_certs client_sni client_ciphers expected_cert expect_matching_hostname",
+)
 MULTI_CERT_TEST_CASES = [
     MultiCertTest(
         description="Test basic SNI match for default cert.",
-        server_certs=[SNI_CERTS["alligator"],
-                      SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        server_certs=[
+            SNI_CERTS["alligator"],
+            SNI_CERTS["beaver"],
+            SNI_CERTS["alligator_ecdsa"],
+        ],
         client_sni="www.alligator.com",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator"],
-        expect_matching_hostname=True),
+        expect_matching_hostname=True,
+    ),
     MultiCertTest(
         description="Test basic SNI matches for non-default cert.",
-        server_certs=[SNI_CERTS["alligator"],
-                      SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        server_certs=[
+            SNI_CERTS["alligator"],
+            SNI_CERTS["beaver"],
+            SNI_CERTS["alligator_ecdsa"],
+        ],
         client_sni="www.beaver.com",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["beaver"],
-        expect_matching_hostname=True),
+        expect_matching_hostname=True,
+    ),
     MultiCertTest(
         description="Test default cert is selected when there are no SNI matches.",
-        server_certs=[SNI_CERTS["alligator"],
-                      SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        server_certs=[
+            SNI_CERTS["alligator"],
+            SNI_CERTS["beaver"],
+            SNI_CERTS["alligator_ecdsa"],
+        ],
         client_sni="not.a.match",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator"],
-        expect_matching_hostname=False),
+        expect_matching_hostname=False,
+    ),
     MultiCertTest(
         description="Test default cert is selected when no SNI is sent.",
-        server_certs=[SNI_CERTS["alligator"],
-                      SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        server_certs=[
+            SNI_CERTS["alligator"],
+            SNI_CERTS["beaver"],
+            SNI_CERTS["alligator_ecdsa"],
+        ],
         client_sni=None,
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator"],
-        expect_matching_hostname=False),
+        expect_matching_hostname=False,
+    ),
     MultiCertTest(
         description="Test ECDSA cert is selected with matching domain and client only supports ECDSA.",
-        server_certs=[SNI_CERTS["alligator"],
-                      SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        server_certs=[
+            SNI_CERTS["alligator"],
+            SNI_CERTS["beaver"],
+            SNI_CERTS["alligator_ecdsa"],
+        ],
         client_sni="www.alligator.com",
         client_ciphers=[Ciphers.ECDHE_ECDSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator_ecdsa"],
-        expect_matching_hostname=True),
+        expect_matching_hostname=True,
+    ),
     MultiCertTest(
         description="Test ECDSA cert selected when: domain matches for both ECDSA+RSA, client supports ECDSA+RSA "
-                    " ciphers, ECDSA is higher priority on server side.",
-        server_certs=[SNI_CERTS["alligator"],
-                      SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
+        " ciphers, ECDSA is higher priority on server side.",
+        server_certs=[
+            SNI_CERTS["alligator"],
+            SNI_CERTS["beaver"],
+            SNI_CERTS["alligator_ecdsa"],
+        ],
         client_sni="www.alligator.com",
-        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA,
-                        Ciphers.ECDHE_ECDSA_AES128_SHA],
+        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA, Ciphers.ECDHE_ECDSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator_ecdsa"],
-        expect_matching_hostname=True),
+        expect_matching_hostname=True,
+    ),
     MultiCertTest(
         description="Test domain match is highest priority. Domain matching ECDSA certificate should be selected"
-                    " even if domain mismatched RSA certificate is available and RSA cipher is higher priority.",
+        " even if domain mismatched RSA certificate is available and RSA cipher is higher priority.",
         server_certs=[SNI_CERTS["beaver"], SNI_CERTS["alligator_ecdsa"]],
         client_sni="www.alligator.com",
-        client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA256,
-                        Ciphers.ECDHE_ECDSA_AES128_SHA256],
+        client_ciphers=[
+            Ciphers.ECDHE_RSA_AES128_SHA256,
+            Ciphers.ECDHE_ECDSA_AES128_SHA256,
+        ],
         expected_cert=SNI_CERTS["alligator_ecdsa"],
-        expect_matching_hostname=True),
+        expect_matching_hostname=True,
+    ),
     MultiCertTest(
         description="Test certificate with single SAN entry matching is selected before mismatched multi SAN cert",
         server_certs=[SNI_CERTS["many_animals"], SNI_CERTS["alligator"]],
         client_sni="www.alligator.com",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator"],
-        expect_matching_hostname=True),
+        expect_matching_hostname=True,
+    ),
     # many_animals was the first cert added
     MultiCertTest(
         description="Test default cert with multiple sans and no SNI sent.",
@@ -303,119 +329,157 @@ MULTI_CERT_TEST_CASES = [
         client_sni=None,
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["many_animals"],
-        expect_matching_hostname=False),
+        expect_matching_hostname=False,
+    ),
     MultiCertTest(
         description="Test certificate match with CN",
         server_certs=[SNI_CERTS["alligator"], SNI_CERTS["narwhal_cn"]],
         client_sni="www.narwhal.com",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["narwhal_cn"],
-        expect_matching_hostname=True),
+        expect_matching_hostname=True,
+    ),
     MultiCertTest(
         description="Test SAN+CN cert can match using SAN.",
-        server_certs=[SNI_CERTS["alligator"],
-                      SNI_CERTS["octopus_cn_platypus_san"]],
+        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["octopus_cn_platypus_san"]],
         client_sni="www.platypus.com",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["octopus_cn_platypus_san"],
-        expect_matching_hostname=True),
+        expect_matching_hostname=True,
+    ),
     MultiCertTest(
         description="Test that CN is not considered for matching if the certificate contains SANs.",
-        server_certs=[SNI_CERTS["alligator"],
-                      SNI_CERTS["octopus_cn_platypus_san"]],
+        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["octopus_cn_platypus_san"]],
         client_sni="www.octopus.com",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator"],
-        expect_matching_hostname=False),
+        expect_matching_hostname=False,
+    ),
     MultiCertTest(
         description="Test certificate with multiple CNs can match.",
-        server_certs=[SNI_CERTS["alligator"],
-                      SNI_CERTS["quail_cn_rattlesnake_cn"]],
+        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["quail_cn_rattlesnake_cn"]],
         client_sni="www.rattlesnake.com",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["quail_cn_rattlesnake_cn"],
-        expect_matching_hostname=False),
+        expect_matching_hostname=False,
+    ),
     MultiCertTest(
         description="Test cert with embedded wildcard is not treated as a wildcard.",
         server_certs=[SNI_CERTS["alligator"], SNI_CERTS["embedded_wildcard"]],
         client_sni="www.labelstartWILDCARDlabelend.com",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator"],
-        expect_matching_hostname=False),
+        expect_matching_hostname=False,
+    ),
     MultiCertTest(
-        description="Test non empty left label wildcard cert is not treated as a wildcard."\
-                    " s2n only supports wildcards with a single * as the left label",
-        server_certs=[SNI_CERTS["alligator"],
-                      SNI_CERTS["non_empty_label_wildcard"]],
+        description="Test non empty left label wildcard cert is not treated as a wildcard."
+        " s2n only supports wildcards with a single * as the left label",
+        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["non_empty_label_wildcard"]],
         client_sni="WILDCARD.middle.end",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator"],
-        expect_matching_hostname=False),
+        expect_matching_hostname=False,
+    ),
     MultiCertTest(
         description="Test cert with trailing * is not treated as wildcard.",
         server_certs=[SNI_CERTS["alligator"], SNI_CERTS["trailing_wildcard"]],
         client_sni="the.prefix.WILDCARD",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["alligator"],
-        expect_matching_hostname=False),
+        expect_matching_hostname=False,
+    ),
     MultiCertTest(
-        description="Certificate with exact sni match(termite.insect.hexapod) is preferred over wildcard"\
-                    " *.insect.hexapod",
-        server_certs=[SNI_CERTS["wildcard_insect"],
-                      SNI_CERTS["alligator"], SNI_CERTS["termite"]],
+        description="Certificate with exact sni match(termite.insect.hexapod) is preferred over wildcard"
+        " *.insect.hexapod",
+        server_certs=[
+            SNI_CERTS["wildcard_insect"],
+            SNI_CERTS["alligator"],
+            SNI_CERTS["termite"],
+        ],
         client_sni="termite.insect.hexapod",
         client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
         expected_cert=SNI_CERTS["termite"],
-        expect_matching_hostname=True),
+        expect_matching_hostname=True,
+    ),
     MultiCertTest(
-        description="ECDSA Certificate with exact sni match(underwing.insect.hexapod) is preferred over RSA wildcard"\
-                    " *.insect.hexapod when RSA ciphers are higher priority than ECDSA in server preferences.",
-        server_certs=[SNI_CERTS["wildcard_insect"],
-                      SNI_CERTS["alligator"], SNI_CERTS["underwing"]],
+        description="ECDSA Certificate with exact sni match(underwing.insect.hexapod) is preferred over RSA wildcard"
+        " *.insect.hexapod when RSA ciphers are higher priority than ECDSA in server preferences.",
+        server_certs=[
+            SNI_CERTS["wildcard_insect"],
+            SNI_CERTS["alligator"],
+            SNI_CERTS["underwing"],
+        ],
         client_sni="underwing.insect.hexapod",
-        client_ciphers=[Ciphers.ECDHE_RSA_AES128_GCM_SHA256,
-                        Ciphers.ECDHE_ECDSA_AES128_GCM_SHA256],
+        client_ciphers=[
+            Ciphers.ECDHE_RSA_AES128_GCM_SHA256,
+            Ciphers.ECDHE_ECDSA_AES128_GCM_SHA256,
+        ],
         expected_cert=SNI_CERTS["underwing"],
-        expect_matching_hostname=True),
+        expect_matching_hostname=True,
+    ),
     MultiCertTest(
         description="Firstly loaded matching certificate should be selected among certificates with the same domain names",
-        server_certs=[SNI_CERTS["alligator"],
-                      SNI_CERTS["second_alligator_rsa"]],
+        server_certs=[SNI_CERTS["alligator"], SNI_CERTS["second_alligator_rsa"]],
         client_sni="www.alligator.com",
         client_ciphers=[Ciphers.AES128_GCM_SHA256],
         expected_cert=SNI_CERTS["alligator"],
-        expect_matching_hostname=True),
+        expect_matching_hostname=True,
+    ),
     MultiCertTest(
         description="Firstly loaded matching certificate should be selected among matching+non-matching certificates",
-        server_certs=[SNI_CERTS["beaver"], SNI_CERTS["alligator"],
-                      SNI_CERTS["second_alligator_rsa"]],
+        server_certs=[
+            SNI_CERTS["beaver"],
+            SNI_CERTS["alligator"],
+            SNI_CERTS["second_alligator_rsa"],
+        ],
         client_sni="www.alligator.com",
         client_ciphers=[Ciphers.AES128_GCM_SHA256],
         expected_cert=SNI_CERTS["alligator"],
-        expect_matching_hostname=True)]
+        expect_matching_hostname=True,
+    ),
+]
 # Positive test for wildcard matches
-MULTI_CERT_TEST_CASES.extend([MultiCertTest(
-    description="Test wildcard *.insect.hexapod matches subdomain " + specific_insect_domain,
-    server_certs=[SNI_CERTS["alligator"], SNI_CERTS["wildcard_insect"]],
-    client_sni=specific_insect_domain,
-    client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
-    expected_cert=SNI_CERTS["wildcard_insect"],
-    expect_matching_hostname=True) for specific_insect_domain in SNI_CERTS["wildcard_insect"][2]])
+MULTI_CERT_TEST_CASES.extend(
+    [
+        MultiCertTest(
+            description="Test wildcard *.insect.hexapod matches subdomain "
+            + specific_insect_domain,
+            server_certs=[SNI_CERTS["alligator"], SNI_CERTS["wildcard_insect"]],
+            client_sni=specific_insect_domain,
+            client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+            expected_cert=SNI_CERTS["wildcard_insect"],
+            expect_matching_hostname=True,
+        )
+        for specific_insect_domain in SNI_CERTS["wildcard_insect"][2]
+    ]
+)
 # Positive test for basic SAN matches
-MULTI_CERT_TEST_CASES.extend([MultiCertTest(
-    description="Match SAN " + many_animal_domain + " in many_animals cert",
-    server_certs=[SNI_CERTS["alligator"], SNI_CERTS["many_animals"]],
-    client_sni=many_animal_domain,
-    client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
-    expected_cert=SNI_CERTS["many_animals"],
-    expect_matching_hostname=True) for many_animal_domain in SNI_CERTS["many_animals"][2]])
+MULTI_CERT_TEST_CASES.extend(
+    [
+        MultiCertTest(
+            description="Match SAN " + many_animal_domain + " in many_animals cert",
+            server_certs=[SNI_CERTS["alligator"], SNI_CERTS["many_animals"]],
+            client_sni=many_animal_domain,
+            client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+            expected_cert=SNI_CERTS["many_animals"],
+            expect_matching_hostname=True,
+        )
+        for many_animal_domain in SNI_CERTS["many_animals"][2]
+    ]
+)
 # Positive test for mixed cased SAN matches
-MULTI_CERT_TEST_CASES.extend([MultiCertTest(
-    description="Match SAN " + many_animal_domain +
-    " in many_animals_mixed_case cert",
-    server_certs=[SNI_CERTS["alligator"],
-                  SNI_CERTS["many_animals_mixed_case"]],
-    client_sni=many_animal_domain,
-    client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
-    expected_cert=SNI_CERTS["many_animals_mixed_case"],
-    expect_matching_hostname=True) for many_animal_domain in SNI_CERTS["many_animals_mixed_case"][2]])
+MULTI_CERT_TEST_CASES.extend(
+    [
+        MultiCertTest(
+            description="Match SAN "
+            + many_animal_domain
+            + " in many_animals_mixed_case cert",
+            server_certs=[SNI_CERTS["alligator"], SNI_CERTS["many_animals_mixed_case"]],
+            client_sni=many_animal_domain,
+            client_ciphers=[Ciphers.ECDHE_RSA_AES128_SHA],
+            expected_cert=SNI_CERTS["many_animals_mixed_case"],
+            expect_matching_hostname=True,
+        )
+        for many_animal_domain in SNI_CERTS["many_animals_mixed_case"][2]
+    ]
+)

--- a/tests/integrationv2/conftest.py
+++ b/tests/integrationv2/conftest.py
@@ -24,7 +24,7 @@ def available_providers():
         bin_path = f"{expected_location}/{binary}"
         if not os.path.exists(bin_path):
             pytest.fail(f"unable to locate {binary}")
-    os.environ['PATH'] += os.pathsep + expected_location
+    os.environ["PATH"] += os.pathsep + expected_location
     providers.add(S2N)
 
     if os.path.exists("./bin/SSLSocketClient.class"):
@@ -34,8 +34,14 @@ def available_providers():
 
 
 def pytest_addoption(parser: pytest.Parser):
-    parser.addoption("--provider-version", action="store", dest="provider-version",
-                     default=None, type=str, help="Set the version of the TLS provider")
+    parser.addoption(
+        "--provider-version",
+        action="store",
+        dest="provider-version",
+        default=None,
+        type=str,
+        help="Set the version of the TLS provider",
+    )
     parser.addoption(
         "--best-effort-NOT-FOR-CI",
         action="store_true",
@@ -54,13 +60,14 @@ def pytest_configure(config: pytest.Config):
     This is executed once per pytest session on process startup.
     """
     config.addinivalue_line(
-        "markers", "uncollect_if(*, func): function to unselect tests from parametrization"
+        "markers",
+        "uncollect_if(*, func): function to unselect tests from parametrization",
     )
 
     if config.getoption("--best-effort-NOT-FOR-CI"):
         config.stash[PATH_CONFIGURATION_KEY] = available_providers()
 
-    provider_version = config.getoption('provider-version', None)
+    provider_version = config.getoption("provider-version", None)
     # By default, any libcrypto with "fips" in its name should be in fips mode.
     # However, s2n-tls no longer supports fips mode with openssl-1.0.2-fips.
     if "fips" in provider_version and "openssl-1.0.2-fips" not in provider_version:
@@ -75,9 +82,9 @@ def pytest_collection_modifyitems(config, items):
     removed = []
     kept = []
     for item in items:
-        m = item.get_closest_marker('uncollect_if')
+        m = item.get_closest_marker("uncollect_if")
         if m:
-            func = m.kwargs['func']
+            func = m.kwargs["func"]
             if func(**item.callspec.params):
                 removed.append(item)
                 continue

--- a/tests/integrationv2/constants.py
+++ b/tests/integrationv2/constants.py
@@ -4,6 +4,5 @@ TEST_CERT_DIRECTORY = "../pems/"
 TEST_SNI_CERT_DIRECTORY = "../pems/sni/"
 TEST_OCSP_DIRECTORY = "../pems/ocsp/"
 
-TRUST_STORE_BUNDLE = TEST_CERT_DIRECTORY + 'trust-store/ca-bundle.crt'
-TRUST_STORE_TRUSTED_BUNDLE = TEST_CERT_DIRECTORY + \
-    'trust-store/ca-bundle.trust.crt'
+TRUST_STORE_BUNDLE = TEST_CERT_DIRECTORY + "trust-store/ca-bundle.crt"
+TRUST_STORE_TRUSTED_BUNDLE = TEST_CERT_DIRECTORY + "trust-store/ca-bundle.trust.crt"

--- a/tests/integrationv2/global_flags.py
+++ b/tests/integrationv2/global_flags.py
@@ -5,11 +5,11 @@
 # based on the environment.
 
 # If S2N is operating in FIPS mode
-S2N_FIPS_MODE = 's2n_fips_mode'
+S2N_FIPS_MODE = "s2n_fips_mode"
 
 # The version of provider being used
 # (set from the S2N_LIBCRYPTO env var, which is how the original integration test works)
-S2N_PROVIDER_VERSION = 's2n_provider_version'
+S2N_PROVIDER_VERSION = "s2n_provider_version"
 
 _flags = {}
 

--- a/tests/integrationv2/processes.py
+++ b/tests/integrationv2/processes.py
@@ -11,7 +11,7 @@ from time import monotonic as _time
 
 
 _PopenSelector = selectors.PollSelector
-_PIPE_BUF = getattr(select, 'PIPE_BUF', 512)
+_PIPE_BUF = getattr(select, "PIPE_BUF", 512)
 _DEBUG_LEN = 80
 
 
@@ -63,8 +63,15 @@ class _processCommunicator(object):
 
         return (stdout, stderr)
 
-    def communicate(self, input_data=None, send_marker_list=None, close_marker=None, kill_marker=None,
-                    send_with_newline=False, timeout=None):
+    def communicate(
+        self,
+        input_data=None,
+        send_marker_list=None,
+        close_marker=None,
+        kill_marker=None,
+        send_with_newline=False,
+        timeout=None,
+    ):
         """
         Communicates with the managed process. If send_marker_list is set, input_data will not be sent
         until the marker is seen.
@@ -83,15 +90,22 @@ class _processCommunicator(object):
                 close_marker,
                 kill_marker,
                 send_with_newline,
-                timeout
+                timeout,
             )
         finally:
             self._communication_started = True
 
         return (stdout, stderr)
 
-    def _communicate(self, input_data=None, send_marker_list=None, close_marker=None, kill_marker=None,
-                     send_with_newline=False, timeout=None):
+    def _communicate(
+        self,
+        input_data=None,
+        send_marker_list=None,
+        close_marker=None,
+        kill_marker=None,
+        send_with_newline=False,
+        timeout=None,
+    ):
         """
         This method will read and write data to a subprocess in a non-blocking manner.
         The code is heavily based on Popen.communicate. There are a couple differences:
@@ -147,12 +161,13 @@ class _processCommunicator(object):
             while selector.get_map():
                 timeout = self._remaining_time(endtime)
                 if timeout is not None and timeout < 0:
-                    self._check_timeout(endtime, orig_timeout,
-                                        stdout, stderr,
-                                        skip_check_and_raise=True)
+                    self._check_timeout(
+                        endtime, orig_timeout, stdout, stderr, skip_check_and_raise=True
+                    )
                     raise RuntimeError(  # Impossible :)
-                        '_check_timeout(..., skip_check_and_raise=True) '
-                        'failed to raise TimeoutExpired.')
+                        "_check_timeout(..., skip_check_and_raise=True) "
+                        "failed to raise TimeoutExpired."
+                    )
 
                 ready = selector.select(timeout)
                 self._check_timeout(endtime, orig_timeout, stdout, stderr)
@@ -161,12 +176,13 @@ class _processCommunicator(object):
                 for key, events in ready:
                     # STDIN is only registered to receive events after the send_marker is found.
                     if key.fileobj is self.proc.stdin:
-                        print(f'{self.name}: stdin available')
-                        chunk = input_view[input_data_offset:
-                                           input_data_offset + _PIPE_BUF]
+                        print(f"{self.name}: stdin available")
+                        chunk = input_view[
+                            input_data_offset : input_data_offset + _PIPE_BUF
+                        ]
                         try:
                             input_data_offset += os.write(key.fd, chunk)
-                            print(f'{self.name}: sent')
+                            print(f"{self.name}: sent")
                         except BrokenPipeError:
                             selector.unregister(key.fileobj)
                         else:
@@ -176,9 +192,11 @@ class _processCommunicator(object):
                                 input_data_offset = 0
                                 if send_marker_list:
                                     send_marker = send_marker_list.pop(0)
-                                    print(f'{self.name}: next send_marker is {send_marker}')
+                                    print(
+                                        f"{self.name}: next send_marker is {send_marker}"
+                                    )
                     elif key.fileobj in (self.proc.stdout, self.proc.stderr):
-                        print(f'{self.name}: stdout available')
+                        print(f"{self.name}: stdout available")
                         # 32 KB (32 × 1024 = 32,768 bytes), read 32KB from the file descriptor
                         data = os.read(key.fd, 32768)
                         if not data:
@@ -192,11 +210,15 @@ class _processCommunicator(object):
                             stored_stdout_list = self._fileobj2output[key.fileobj]
                             send_marker_len = len(send_marker) - 1
                             if len(stored_stdout_list) > 0:
-                                data_str = str(stored_stdout_list[-1][-send_marker_len:] + data)
+                                data_str = str(
+                                    stored_stdout_list[-1][-send_marker_len:] + data
+                                )
 
                         data_debug = data_str[:_DEBUG_LEN]
                         if len(data_str) > _DEBUG_LEN:
-                            data_debug += f' ...({len(data_str) - _DEBUG_LEN} more bytes)'
+                            data_debug += (
+                                f" ...({len(data_str) - _DEBUG_LEN} more bytes)"
+                            )
 
                         # fileobj2output[key.fileobj] is a list of data chunks
                         # that get joined later
@@ -206,34 +228,44 @@ class _processCommunicator(object):
                         # register STDIN to receive events. If there is no data to send,
                         # just mark input_send as true so we can close out STDIN.
                         if send_marker:
-                            print(f'{self.name}: looking for send_marker {send_marker} in {data_debug}')
+                            print(
+                                f"{self.name}: looking for send_marker {send_marker} in {data_debug}"
+                            )
                         if send_marker is not None and send_marker in data_str:
-                            print(f'{self.name}: found {send_marker}')
+                            print(f"{self.name}: found {send_marker}")
                             send_marker = None
                             if self.proc.stdin and input_data:
                                 selector.register(
-                                    self.proc.stdin, selectors.EVENT_WRITE)
+                                    self.proc.stdin, selectors.EVENT_WRITE
+                                )
                                 message = input_data.pop(0)
                                 if send_with_newline:
-                                    message += b'\n'
+                                    message += b"\n"
                                 # Data destined for stdin is stored in a memoryview
                                 input_view = memoryview(message)
                                 input_data_len = len(message)
                                 input_data_sent = False
-                                print(f'{self.name}: will send {message}')
+                                print(f"{self.name}: will send {message}")
                             else:
                                 input_data_sent = True
-                                print(f'{self.name}: will send nothing')
+                                print(f"{self.name}: will send nothing")
 
                         if self.wait_for_marker:
-                            print(f'{self.name}: looking for wait_for_marker {self.wait_for_marker} in {data_debug}')
-                        if self.wait_for_marker is not None and self.wait_for_marker in data_str:
+                            print(
+                                f"{self.name}: looking for wait_for_marker {self.wait_for_marker} in {data_debug}"
+                            )
+                        if (
+                            self.wait_for_marker is not None
+                            and self.wait_for_marker in data_str
+                        ):
                             selector.unregister(self.proc.stdout)
                             selector.unregister(self.proc.stderr)
                             return None, None
 
                         if kill_marker:
-                            print(f'{self.name}: looking for kill_marker {kill_marker} in {data}')
+                            print(
+                                f"{self.name}: looking for kill_marker {kill_marker} in {data}"
+                            )
                         if kill_marker is not None and kill_marker in data:
                             selector.unregister(self.proc.stdout)
                             selector.unregister(self.proc.stderr)
@@ -242,11 +274,15 @@ class _processCommunicator(object):
                 # If we have finished sending all our input, and have received the
                 # ready-to-send marker, we can close out stdin.
                 if self.proc.stdin and input_data_sent and not input_data:
-                    print(f'{self.name}: finished sending')
+                    print(f"{self.name}: finished sending")
                     if close_marker:
-                        print(f'{self.name}: looking for close_marker {close_marker} in {data_debug}')
-                    if close_marker is None or (close_marker and close_marker in data_str):
-                        print(f'{self.name}: closing stdin')
+                        print(
+                            f"{self.name}: looking for close_marker {close_marker} in {data_debug}"
+                        )
+                    if close_marker is None or (
+                        close_marker and close_marker in data_str
+                    ):
+                        print(f"{self.name}: closing stdin")
                         input_data_sent = None
                         self.proc.stdin.close()
 
@@ -254,9 +290,9 @@ class _processCommunicator(object):
 
         # All data exchanged.  Translate lists into strings.
         if stdout is not None:
-            stdout = b''.join(stdout)
+            stdout = b"".join(stdout)
         if stderr is not None:
-            stderr = b''.join(stderr)
+            stderr = b"".join(stderr)
 
         return (stdout, stderr)
 
@@ -267,8 +303,9 @@ class _processCommunicator(object):
         else:
             return endtime - _time()
 
-    def _check_timeout(self, endtime, orig_timeout, stdout_seq, stderr_seq,
-                       skip_check_and_raise=False):
+    def _check_timeout(
+        self, endtime, orig_timeout, stdout_seq, stderr_seq, skip_check_and_raise=False
+    ):
         """
         Convenience for checking if a timeout has expired.
 
@@ -279,9 +316,11 @@ class _processCommunicator(object):
             return
         if skip_check_and_raise or _time() > endtime:
             raise subprocess.TimeoutExpired(
-                self.proc.args, orig_timeout,
-                output=b''.join(stdout_seq) if stdout_seq else None,
-                stderr=b''.join(stderr_seq) if stderr_seq else None)
+                self.proc.args,
+                orig_timeout,
+                output=b"".join(stdout_seq) if stdout_seq else None,
+                stderr=b"".join(stderr_seq) if stderr_seq else None,
+            )
 
 
 class ManagedProcess(threading.Thread):
@@ -293,9 +332,20 @@ class ManagedProcess(threading.Thread):
     are made available to the caller.
     """
 
-    def __init__(self, cmd_line, provider_set_ready_condition, wait_for_marker=None, send_marker_list=None,
-                 close_marker=None, timeout=5, data_source=None, env_overrides=dict(), expect_stderr=False,
-                 kill_marker=None, send_with_newline=False):
+    def __init__(
+        self,
+        cmd_line,
+        provider_set_ready_condition,
+        wait_for_marker=None,
+        send_marker_list=None,
+        close_marker=None,
+        timeout=5,
+        data_source=None,
+        env_overrides=dict(),
+        expect_stderr=False,
+        kill_marker=None,
+        send_with_newline=False,
+    ):
         threading.Thread.__init__(self)
 
         proc_env = os.environ.copy()
@@ -341,12 +391,17 @@ class ManagedProcess(threading.Thread):
     def run(self):
         with self.results_condition:
             try:
-                proc = subprocess.Popen(self.cmd_line, env=self.proc_env, stdin=subprocess.PIPE,
-                                        stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
+                proc = subprocess.Popen(
+                    self.cmd_line,
+                    env=self.proc_env,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    close_fds=True,
+                )
                 self.proc = proc
             except Exception as ex:
-                self.results = Results(
-                    None, None, None, ex, self.expect_stderr)
+                self.results = Results(None, None, None, ex, self.expect_stderr)
                 raise ex
 
             communicator = _processCommunicator(proc, self.cmd_line[0])
@@ -374,7 +429,7 @@ class ManagedProcess(threading.Thread):
                     proc.returncode,
                     None,
                     expect_stderr=self.expect_stderr,
-                    expect_nonzero_exit=self.kill_marker is not None
+                    expect_nonzero_exit=self.kill_marker is not None,
                 )
             except subprocess.TimeoutExpired as ex:
                 proc.kill()
@@ -383,16 +438,28 @@ class ManagedProcess(threading.Thread):
                 # Read any remaining output
                 proc_results = communicator.communicate()
                 self.results = Results(
-                    proc_results[0], proc_results[1], proc.returncode, wrapped_ex, self.expect_stderr)
+                    proc_results[0],
+                    proc_results[1],
+                    proc.returncode,
+                    wrapped_ex,
+                    self.expect_stderr,
+                )
             except Exception as ex:
                 self.results = Results(
-                    proc_results[0], proc_results[1], proc.returncode, ex, self.expect_stderr)
+                    proc_results[0],
+                    proc_results[1],
+                    proc.returncode,
+                    ex,
+                    self.expect_stderr,
+                )
                 raise ex
             finally:
                 # This data is dumped to stdout so we capture this
                 # information no matter where a test fails.
                 print("###############################################################")
-                print(f"#######################   {self.cmd_line[0]}   #######################")
+                print(
+                    f"#######################   {self.cmd_line[0]}   #######################"
+                )
                 print("###############################################################")
 
                 print(f"Command line:\n\t{' '.join(self.cmd_line)}")
@@ -436,7 +503,8 @@ class ManagedProcess(threading.Thread):
         """
         with self.results_condition:
             result = self.results_condition.wait_for(
-                self._results_ready, timeout=self.timeout)
+                self._results_ready, timeout=self.timeout
+            )
 
             if result is False:
                 raise Exception("Timeout")

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -112,26 +112,27 @@ class Tcpdump(Provider):
         Provider.__init__(self, options)
 
     def setup_client(self):
-        self.ready_to_test_marker = 'listening on lo'
+        self.ready_to_test_marker = "listening on lo"
         tcpdump_filter = "dst port {}".format(self.options.port)
 
-        cmd_line = ["tcpdump",
-                    # Line buffer the output
-                    "-l",
-
-                    # Only read 10 packets before exiting. This is enough to find a large
-                    # packet, and still exit before the timeout.
-                    "-c", "10",
-
-                    # Watch the loopback device
-                    "-i", "lo",
-
-                    # Don't resolve IP addresses
-                    "-nn",
-
-                    # Set the buffer size to 1k
-                    "-B", "1024",
-                    tcpdump_filter]
+        cmd_line = [
+            "tcpdump",
+            # Line buffer the output
+            "-l",
+            # Only read 10 packets before exiting. This is enough to find a large
+            # packet, and still exit before the timeout.
+            "-c",
+            "10",
+            # Watch the loopback device
+            "-i",
+            "lo",
+            # Don't resolve IP addresses
+            "-nn",
+            # Set the buffer size to 1k
+            "-B",
+            "1024",
+            tcpdump_filter,
+        ]
 
         return cmd_line
 
@@ -148,18 +149,14 @@ class S2N(Provider):
 
     @classmethod
     def get_send_marker(cls):
-        return 's2n is ready'
+        return "s2n is ready"
 
     @classmethod
     def _pss_supported(cls):
         # RSA-PSS is unsupported for openssl-1.0
         # libressl and boringssl are disabled because of configuration issues
         # see https://github.com/aws/s2n-tls/issues/3250
-        PSS_UNSUPPORTED_LIBCRYPTOS = {
-            "libressl",
-            "boringssl",
-            "openssl-1.0"
-        }
+        PSS_UNSUPPORTED_LIBCRYPTOS = {"libressl", "boringssl", "openssl-1.0"}
         for libcrypto in PSS_UNSUPPORTED_LIBCRYPTOS:
             # e.g. "openssl-1.0" in "openssl-1.0.2-fips"
             if libcrypto in get_flag(S2N_PROVIDER_VERSION):
@@ -168,7 +165,7 @@ class S2N(Provider):
 
     @classmethod
     def supports_certificate(cls, cert: Cert):
-        if not cls._pss_supported() and cert.algorithm == 'RSAPSS':
+        if not cls._pss_supported() and cert.algorithm == "RSAPSS":
             return False
         return True
 
@@ -178,11 +175,13 @@ class S2N(Provider):
             return False
 
         # SSLv3 cannot be negotiated in FIPS mode with libcryptos other than AWS-LC.
-        if all([
-            protocol == Protocols.SSLv3,
-            get_flag(S2N_FIPS_MODE),
-            "awslc" not in get_flag(S2N_PROVIDER_VERSION)
-        ]):
+        if all(
+            [
+                protocol == Protocols.SSLv3,
+                get_flag(S2N_FIPS_MODE),
+                "awslc" not in get_flag(S2N_PROVIDER_VERSION),
+            ]
+        ):
             return False
 
         return True
@@ -196,7 +195,10 @@ class S2N(Provider):
             "RC4": ["openssl-3"],
         }
 
-        for unsupported_cipher, unsupported_libcryptos in unsupported_configurations.items():
+        for (
+            unsupported_cipher,
+            unsupported_libcryptos,
+        ) in unsupported_configurations.items():
             # the queried cipher has some libcrypto's that don't support it
             # e.g. "RC4" in "TLS_ECDHE_RSA_WITH_RC4_128_SHA"
             if unsupported_cipher in cipher.name:
@@ -210,14 +212,15 @@ class S2N(Provider):
     @classmethod
     def supports_signature(cls, signature):
         # Disable RSA_PSS_RSAE_SHA256 in unsupported libcryptos
-        if any([
-            libcrypto in get_flag(S2N_PROVIDER_VERSION)
-            for libcrypto in [
-                "openssl-1.0.2",
-                "libressl",
-                "boringssl"
-            ]
-        ]) and signature == Signatures.RSA_PSS_RSAE_SHA256:
+        if (
+            any(
+                [
+                    libcrypto in get_flag(S2N_PROVIDER_VERSION)
+                    for libcrypto in ["openssl-1.0.2", "libressl", "boringssl"]
+                ]
+            )
+            and signature == Signatures.RSA_PSS_RSAE_SHA256
+        ):
             return False
 
         return True
@@ -228,44 +231,44 @@ class S2N(Provider):
         """
         cmd_line = []
         if self.options.use_mainline_version is True:
-            cmd_line.append('s2nc_head')
+            cmd_line.append("s2nc_head")
         else:
-            cmd_line.append('s2nc')
-        cmd_line.append('--non-blocking')
+            cmd_line.append("s2nc")
+        cmd_line.append("--non-blocking")
 
         # Tests requiring reconnects can't wait on echo data,
         # but all other tests can.
         if self.options.reconnect is not True:
-            cmd_line.append('-e')
+            cmd_line.append("-e")
 
         if self.options.use_session_ticket is False:
-            cmd_line.append('-T')
+            cmd_line.append("-T")
 
         if self.options.insecure is True:
-            cmd_line.append('--insecure')
+            cmd_line.append("--insecure")
         elif self.options.trust_store:
-            cmd_line.extend(['-f', self.options.trust_store])
+            cmd_line.extend(["-f", self.options.trust_store])
         elif self.options.cert:
-            cmd_line.extend(['-f', self.options.cert])
+            cmd_line.extend(["-f", self.options.cert])
 
         if self.options.reconnect is True:
-            cmd_line.append('-r')
+            cmd_line.append("-r")
 
         # If the test provided a cipher (security policy) that is compatible with
         # s2n, we'll use it. Otherwise, default to the appropriate `test_all` policy.
-        cipher_prefs = 'test_all_tls12'
+        cipher_prefs = "test_all_tls12"
         if self.options.protocol is Protocols.TLS13:
-            cipher_prefs = 'test_all'
+            cipher_prefs = "test_all"
         if self.options.cipher and self.options.cipher.s2n:
             cipher_prefs = self.options.cipher.name
 
-        cmd_line.extend(['-c', cipher_prefs])
+        cmd_line.extend(["-c", cipher_prefs])
 
         if self.options.use_client_auth:
             if self.options.key:
-                cmd_line.extend(['--key', self.options.key])
+                cmd_line.extend(["--key", self.options.key])
             if self.options.cert:
-                cmd_line.extend(['--cert', self.options.cert])
+                cmd_line.extend(["--cert", self.options.cert])
 
         if get_flag(S2N_FIPS_MODE):
             cmd_line.append("--enter-fips-mode")
@@ -285,49 +288,50 @@ class S2N(Provider):
 
     def setup_server(self):
         # s2nd prints this message after it begins listening for connections
-        self.ready_to_test_marker = 'Listening on'
+        self.ready_to_test_marker = "Listening on"
 
         """
         Using the passed ProviderOptions, create a command line.
         """
         cmd_line = []
         if self.options.use_mainline_version is True:
-            cmd_line.append('s2nd_head')
+            cmd_line.append("s2nd_head")
         else:
-            cmd_line.append('s2nd')
-        cmd_line.extend(['-X', '--self-service-blinding', '--non-blocking'])
+            cmd_line.append("s2nd")
+        cmd_line.extend(["-X", "--self-service-blinding", "--non-blocking"])
 
         if self.options.key is not None:
-            cmd_line.extend(['--key', self.options.key])
+            cmd_line.extend(["--key", self.options.key])
         if self.options.cert is not None:
-            cmd_line.extend(['--cert', self.options.cert])
+            cmd_line.extend(["--cert", self.options.cert])
 
         if self.options.insecure is True:
-            cmd_line.append('--insecure')
+            cmd_line.append("--insecure")
         elif self.options.trust_store:
-            cmd_line.extend(['-t', self.options.trust_store])
+            cmd_line.extend(["-t", self.options.trust_store])
         elif self.options.cert:
-            cmd_line.extend(['-t', self.options.cert])
+            cmd_line.extend(["-t", self.options.cert])
 
         # If the test provided a cipher (security policy) that is compatible with
         # s2n, we'll use it. Otherwise, default to the appropriate `test_all` policy.
-        cipher_prefs = 'test_all_tls12'
+        cipher_prefs = "test_all_tls12"
         if self.options.protocol is Protocols.TLS13:
-            cipher_prefs = 'test_all'
+            cipher_prefs = "test_all"
         if self.options.cipher and self.options.cipher.s2n:
             cipher_prefs = self.options.cipher.name
 
-        cmd_line.extend(['-c', cipher_prefs])
+        cmd_line.extend(["-c", cipher_prefs])
 
         if self.options.use_client_auth is True:
-            cmd_line.append('-m')
+            cmd_line.append("-m")
 
         if self.options.use_session_ticket is False:
-            cmd_line.append('-T')
+            cmd_line.append("-T")
 
         if self.options.reconnects_before_exit is not None:
             cmd_line.append(
-                '--max-conns={}'.format(self.options.reconnects_before_exit))
+                "--max-conns={}".format(self.options.reconnects_before_exit)
+            )
 
         if get_flag(S2N_FIPS_MODE):
             cmd_line.append("--enter-fips-mode")
@@ -353,7 +357,7 @@ class OpenSSL(Provider):
 
     @classmethod
     def get_send_marker(cls):
-        return 'Verify return code'
+        return "Verify return code"
 
     def _join_ciphers(self, ciphers):
         """
@@ -365,7 +369,7 @@ class OpenSSL(Provider):
         for c in ciphers:
             cipher_list.append(c.name)
 
-        ciphers = ':'.join(cipher_list)
+        ciphers = ":".join(cipher_list)
 
         return ciphers
 
@@ -376,23 +380,29 @@ class OpenSSL(Provider):
         if type(cipher) is list:
             # In the case of a cipher list we need to be sure TLS13 specific ciphers aren't
             # mixed with ciphers from previous versions
-            is_tls13_or_above = (cipher[0].min_version >= Protocols.TLS13)
-            mismatch = [c for c in cipher if (
-                c.min_version >= Protocols.TLS13) != is_tls13_or_above]
+            is_tls13_or_above = cipher[0].min_version >= Protocols.TLS13
+            mismatch = [
+                c
+                for c in cipher
+                if (c.min_version >= Protocols.TLS13) != is_tls13_or_above
+            ]
 
             if len(mismatch) > 0:
-                raise Exception("Cannot combine ciphers for TLS1.3 or above with older ciphers: {}".format(
-                    [c.name for c in cipher]))
+                raise Exception(
+                    "Cannot combine ciphers for TLS1.3 or above with older ciphers: {}".format(
+                        [c.name for c in cipher]
+                    )
+                )
 
             ciphers.append(self._join_ciphers(cipher))
         else:
-            is_tls13_or_above = (cipher.min_version >= Protocols.TLS13)
+            is_tls13_or_above = cipher.min_version >= Protocols.TLS13
             ciphers.append(cipher.name)
 
         if is_tls13_or_above:
-            cmdline.append('-ciphersuites')
+            cmdline.append("-ciphersuites")
         else:
-            cmdline.append('-cipher')
+            cmdline.append("-cipher")
 
         return cmdline + ciphers
 
@@ -412,70 +422,74 @@ class OpenSSL(Provider):
         return True
 
     def _is_openssl_11(self) -> None:
-        result = subprocess.run(["openssl", "version"], shell=False, capture_output=True, text=True)
+        result = subprocess.run(
+            ["openssl", "version"], shell=False, capture_output=True, text=True
+        )
         version_str = result.stdout.split(" ")
         project = version_str[0]
         version = version_str[1]
         print(f"openssl version: {project} version: {version}")
-        if (project != "OpenSSL" or version[0:3] != "1.1"):
-            raise FileNotFoundError(f"Openssl version returned {version}, expected 1.1.x.")
+        if project != "OpenSSL" or version[0:3] != "1.1":
+            raise FileNotFoundError(
+                f"Openssl version returned {version}, expected 1.1.x."
+            )
 
     def setup_client(self):
-        cmd_line = ['openssl', 's_client']
+        cmd_line = ["openssl", "s_client"]
         cmd_line.extend(
-            ['-connect', '{}:{}'.format(self.options.host, self.options.port)])
+            ["-connect", "{}:{}".format(self.options.host, self.options.port)]
+        )
 
         # Additional debugging that will be captured incase of failure
         if self.options.verbose:
-            cmd_line.append('-debug')
+            cmd_line.append("-debug")
 
-        cmd_line.extend(['-tlsextdebug', '-state'])
+        cmd_line.extend(["-tlsextdebug", "-state"])
 
         if self.options.key is not None:
-            cmd_line.extend(['-key', self.options.key])
+            cmd_line.extend(["-key", self.options.key])
 
         # Unlike s2n, OpenSSL allows us to be much more specific about which TLS
         # protocol to use.
         if self.options.protocol == Protocols.TLS13:
-            cmd_line.append('-tls1_3')
+            cmd_line.append("-tls1_3")
         elif self.options.protocol == Protocols.TLS12:
-            cmd_line.append('-tls1_2')
+            cmd_line.append("-tls1_2")
         elif self.options.protocol == Protocols.TLS11:
-            cmd_line.append('-tls1_1')
+            cmd_line.append("-tls1_1")
         elif self.options.protocol == Protocols.TLS10:
-            cmd_line.append('-tls1')
+            cmd_line.append("-tls1")
         elif self.options.protocol == Protocols.SSLv3:
-            cmd_line.append('-ssl3')
+            cmd_line.append("-ssl3")
 
         if self.options.cipher is not None:
             cmd_line.extend(self._cipher_to_cmdline(self.options.cipher))
 
         if self.options.curve is not None:
-            cmd_line.extend(['-curves', str(self.options.curve)])
+            cmd_line.extend(["-curves", str(self.options.curve)])
 
         if self.options.use_client_auth:
             if self.options.key:
-                cmd_line.extend(['-key', self.options.key])
+                cmd_line.extend(["-key", self.options.key])
             if self.options.cert:
-                cmd_line.extend(['-cert', self.options.cert])
+                cmd_line.extend(["-cert", self.options.cert])
 
         if self.options.reconnect is True:
-            cmd_line.append('-reconnect')
+            cmd_line.append("-reconnect")
 
         if self.options.extra_flags is not None:
             cmd_line.extend(self.options.extra_flags)
 
         if self.options.server_name is not None:
-            cmd_line.extend(['-servername', self.options.server_name])
+            cmd_line.extend(["-servername", self.options.server_name])
             if self.options.verify_hostname is not None:
-                cmd_line.extend(['-verify_hostname', self.options.server_name])
+                cmd_line.extend(["-verify_hostname", self.options.server_name])
 
         if self.options.enable_client_ocsp:
             cmd_line.append("-status")
 
         if self.options.signature_algorithm is not None:
-            cmd_line.extend(
-                ["-sigalgs", self.options.signature_algorithm.name])
+            cmd_line.extend(["-sigalgs", self.options.signature_algorithm.name])
 
         if self.options.record_size is not None:
             cmd_line.extend(["-max_send_frag", str(self.options.record_size)])
@@ -487,60 +501,58 @@ class OpenSSL(Provider):
 
     def setup_server(self):
         # s_server prints this message before it is ready to send/receive data
-        self.ready_to_test_marker = 'ACCEPT'
+        self.ready_to_test_marker = "ACCEPT"
 
-        cmd_line = ['openssl', 's_server']
-        cmd_line.extend(['-accept', '{}'.format(self.options.port)])
+        cmd_line = ["openssl", "s_server"]
+        cmd_line.extend(["-accept", "{}".format(self.options.port)])
 
         if self.options.reconnects_before_exit is not None:
             # If the user request a specific reconnection count, set it here
-            cmd_line.extend(
-                ['-naccept', str(self.options.reconnects_before_exit)])
+            cmd_line.extend(["-naccept", str(self.options.reconnects_before_exit)])
         else:
             # Exit after the first connection by default
-            cmd_line.extend(['-naccept', '1'])
+            cmd_line.extend(["-naccept", "1"])
 
         # Additional debugging that will be captured incase of failure
         if self.options.verbose:
-            cmd_line.append('-debug')
+            cmd_line.append("-debug")
 
-        cmd_line.extend(['-tlsextdebug', '-state'])
+        cmd_line.extend(["-tlsextdebug", "-state"])
 
         if self.options.cert is not None:
-            cmd_line.extend(['-cert', self.options.cert])
+            cmd_line.extend(["-cert", self.options.cert])
         if self.options.key is not None:
-            cmd_line.extend(['-key', self.options.key])
+            cmd_line.extend(["-key", self.options.key])
 
         # Unlike s2n, OpenSSL allows us to be much more specific about which TLS
         # protocol to use.
         if self.options.protocol == Protocols.TLS13:
-            cmd_line.append('-tls1_3')
+            cmd_line.append("-tls1_3")
         elif self.options.protocol == Protocols.TLS12:
-            cmd_line.append('-tls1_2')
+            cmd_line.append("-tls1_2")
         elif self.options.protocol == Protocols.TLS11:
-            cmd_line.append('-tls1_1')
+            cmd_line.append("-tls1_1")
         elif self.options.protocol == Protocols.TLS10:
-            cmd_line.append('-tls1')
+            cmd_line.append("-tls1")
         elif self.options.protocol == Protocols.SSLv3:
-            cmd_line.append('-ssl3')
+            cmd_line.append("-ssl3")
 
         if self.options.cipher is not None:
             cmd_line.extend(self._cipher_to_cmdline(self.options.cipher))
             if self.options.cipher.parameters is not None:
-                cmd_line.extend(['-dhparam', self.options.cipher.parameters])
+                cmd_line.extend(["-dhparam", self.options.cipher.parameters])
 
         if self.options.curve is not None:
-            cmd_line.extend(['-curves', str(self.options.curve)])
+            cmd_line.extend(["-curves", str(self.options.curve)])
         if self.options.use_client_auth is True:
             # We use "Verify" instead of "verify" to require a client cert
-            cmd_line.extend(['-Verify', '1'])
+            cmd_line.extend(["-Verify", "1"])
 
         if self.options.ocsp_response is not None:
             cmd_line.extend(["-status_file", self.options.ocsp_response])
 
         if self.options.signature_algorithm is not None:
-            cmd_line.extend(
-                ["-sigalgs", self.options.signature_algorithm.name])
+            cmd_line.extend(["-sigalgs", self.options.signature_algorithm.name])
 
         if self.options.extra_flags is not None:
             cmd_line.extend(self.options.extra_flags)
@@ -584,7 +596,11 @@ class JavaSSL(Provider):
     @classmethod
     def supports_protocol(cls, protocol):
         # https://aws.amazon.com/blogs/opensource/tls-1-0-1-1-changes-in-openjdk-and-amazon-corretto/
-        if protocol is Protocols.SSLv3 or protocol is Protocols.TLS10 or protocol is Protocols.TLS11:
+        if (
+            protocol is Protocols.SSLv3
+            or protocol is Protocols.TLS10
+            or protocol is Protocols.TLS11
+        ):
             return False
 
         return True
@@ -592,16 +608,16 @@ class JavaSSL(Provider):
     @classmethod
     def supports_cipher(cls, cipher, with_curve=None):
         # Java SSL does not support CHACHA20
-        if 'CHACHA20' in cipher.name:
+        if "CHACHA20" in cipher.name:
             return False
 
         return True
 
     def setup_server(self):
-        pytest.skip('JavaSSL does not support server mode at this time')
+        pytest.skip("JavaSSL does not support server mode at this time")
 
     def setup_client(self):
-        cmd_line = ['java', "-classpath", "bin", "SSLSocketClient"]
+        cmd_line = ["java", "-classpath", "bin", "SSLSocketClient"]
 
         if self.options.port is not None:
             cmd_line.extend([self.options.port])
@@ -638,29 +654,30 @@ class BoringSSL(Provider):
 
     @classmethod
     def get_send_marker(cls):
-        return 'Cert issuer:'
+        return "Cert issuer:"
 
     def setup_server(self):
-        cmd_line = ['bssl', 's_server']
-        cmd_line.extend(['-accept', self.options.port])
+        cmd_line = ["bssl", "s_server"]
+        cmd_line.extend(["-accept", self.options.port])
         if self.options.cert is not None:
-            cmd_line.extend(['-cert', self.options.cert])
+            cmd_line.extend(["-cert", self.options.cert])
         if self.options.key is not None:
-            cmd_line.extend(['-key', self.options.key])
+            cmd_line.extend(["-key", self.options.key])
         if self.options.curve is not None:
             if self.options.curve == Curves.P256:
-                cmd_line.extend(['-curves', 'P-256'])
+                cmd_line.extend(["-curves", "P-256"])
             elif self.options.curve == Curves.P384:
-                cmd_line.extend(['-curves', 'P-384'])
+                cmd_line.extend(["-curves", "P-384"])
             elif self.options.curve == Curves.P521:
-                cmd_line.extend(['-curves', 'P-521'])
+                cmd_line.extend(["-curves", "P-521"])
             elif self.options.curve == Curves.SecP256r1Kyber768Draft00:
-                cmd_line.extend(['-curves', 'SecP256r1Kyber768Draft00'])
+                cmd_line.extend(["-curves", "SecP256r1Kyber768Draft00"])
             elif self.options.curve == Curves.X25519Kyber768Draft00:
-                cmd_line.extend(['-curves', 'X25519Kyber768Draft00'])
+                cmd_line.extend(["-curves", "X25519Kyber768Draft00"])
             elif self.options.curve == Curves.X25519:
-                pytest.skip('BoringSSL does not support curve {}'.format(
-                    self.options.curve))
+                pytest.skip(
+                    "BoringSSL does not support curve {}".format(self.options.curve)
+                )
 
         if self.options.extra_flags is not None:
             cmd_line.extend(self.options.extra_flags)
@@ -668,37 +685,42 @@ class BoringSSL(Provider):
         return cmd_line
 
     def setup_client(self):
-        cmd_line = ['bssl', 's_client']
+        cmd_line = ["bssl", "s_client"]
         cmd_line.extend(
-            ['-connect', '{}:{}'.format(self.options.host, self.options.port)])
+            ["-connect", "{}:{}".format(self.options.host, self.options.port)]
+        )
         if self.options.cert is not None:
-            cmd_line.extend(['-cert', self.options.cert])
+            cmd_line.extend(["-cert", self.options.cert])
         if self.options.key is not None:
-            cmd_line.extend(['-key', self.options.key])
+            cmd_line.extend(["-key", self.options.key])
         if self.options.cipher is not None:
             if self.options.cipher == Ciphersuites.TLS_CHACHA20_POLY1305_SHA256:
                 cmd_line.extend(
-                    ['-cipher', 'TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256'])
+                    ["-cipher", "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"]
+                )
             elif self.options.cipher == Ciphersuites.TLS_AES_128_GCM_256:
-                pytest.skip('BoringSSL does not support Cipher {}'.format(
-                    self.options.cipher))
+                pytest.skip(
+                    "BoringSSL does not support Cipher {}".format(self.options.cipher)
+                )
             elif self.options.cipher == Ciphersuites.TLS_AES_256_GCM_384:
-                pytest.skip('BoringSSL does not support Cipher {}'.format(
-                    self.options.cipher))
+                pytest.skip(
+                    "BoringSSL does not support Cipher {}".format(self.options.cipher)
+                )
         if self.options.curve is not None:
             if self.options.curve == Curves.P256:
-                cmd_line.extend(['-curves', 'P-256'])
+                cmd_line.extend(["-curves", "P-256"])
             elif self.options.curve == Curves.P384:
-                cmd_line.extend(['-curves', 'P-384'])
+                cmd_line.extend(["-curves", "P-384"])
             elif self.options.curve == Curves.P521:
-                cmd_line.extend(['-curves', 'P-521'])
+                cmd_line.extend(["-curves", "P-521"])
             elif self.options.curve == Curves.SecP256r1Kyber768Draft00:
-                cmd_line.extend(['-curves', 'SecP256r1Kyber768Draft00'])
+                cmd_line.extend(["-curves", "SecP256r1Kyber768Draft00"])
             elif self.options.curve == Curves.X25519Kyber768Draft00:
-                cmd_line.extend(['-curves', 'X25519Kyber768Draft00'])
+                cmd_line.extend(["-curves", "X25519Kyber768Draft00"])
             elif self.options.curve == Curves.X25519:
-                pytest.skip('BoringSSL does not support curve {}'.format(
-                    self.options.curve))
+                pytest.skip(
+                    "BoringSSL does not support curve {}".format(self.options.curve)
+                )
 
         if self.options.extra_flags is not None:
             cmd_line.extend(self.options.extra_flags)
@@ -719,35 +741,32 @@ class GnuTLS(Provider):
     @staticmethod
     def cipher_to_priority_str(cipher):
         return {
-            Ciphers.DHE_RSA_AES128_SHA:         "DHE-RSA:+AES-128-CBC:+SHA1",
-            Ciphers.DHE_RSA_AES256_SHA:         "DHE-RSA:+AES-256-CBC:+SHA1",
-            Ciphers.DHE_RSA_AES128_SHA256:      "DHE-RSA:+AES-128-CBC:+SHA256",
-            Ciphers.DHE_RSA_AES256_SHA256:      "DHE-RSA:+AES-256-CBC:+SHA256",
-            Ciphers.DHE_RSA_AES128_GCM_SHA256:  "DHE-RSA:+AES-128-GCM:+AEAD",
-            Ciphers.DHE_RSA_AES256_GCM_SHA384:  "DHE-RSA:+AES-256-GCM:+AEAD",
-            Ciphers.DHE_RSA_CHACHA20_POLY1305:  "DHE-RSA:+CHACHA20-POLY1305:+AEAD",
-
-            Ciphers.AES128_SHA:         "RSA:+AES-128-CBC:+SHA1",
-            Ciphers.AES256_SHA:         "RSA:+AES-256-CBC:+SHA1",
-            Ciphers.AES128_SHA256:      "RSA:+AES-128-CBC:+SHA256",
-            Ciphers.AES256_SHA256:      "RSA:+AES-256-CBC:+SHA256",
-            Ciphers.AES128_GCM_SHA256:  "RSA:+AES-128-GCM:+AEAD",
-            Ciphers.AES256_GCM_SHA384:  "RSA:+AES-256-GCM:+AEAD",
-
-            Ciphers.ECDHE_ECDSA_AES128_SHA:         "ECDHE-ECDSA:+AES-128-CBC:+SHA1",
-            Ciphers.ECDHE_ECDSA_AES256_SHA:         "ECDHE-ECDSA:+AES-256-CBC:+SHA1",
-            Ciphers.ECDHE_ECDSA_AES128_SHA256:      "ECDHE-ECDSA:+AES-128-CBC:+SHA256",
-            Ciphers.ECDHE_ECDSA_AES256_SHA384:      "ECDHE-ECDSA:+AES-256-CBC:+SHA384",
-            Ciphers.ECDHE_ECDSA_AES128_GCM_SHA256:  "ECDHE-ECDSA:+AES-128-GCM:+AEAD",
-            Ciphers.ECDHE_ECDSA_AES256_GCM_SHA384:  "ECDHE-ECDSA:+AES-256-GCM:+AEAD",
-
-            Ciphers.ECDHE_RSA_AES128_SHA:           "ECDHE-RSA:+AES-128-CBC:+SHA1",
-            Ciphers.ECDHE_RSA_AES256_SHA:           "ECDHE-RSA:+AES-256-CBC:+SHA1",
-            Ciphers.ECDHE_RSA_AES128_SHA256:        "ECDHE-RSA:+AES-128-CBC:+SHA256",
-            Ciphers.ECDHE_RSA_AES256_SHA384:        "ECDHE-RSA:+AES-256-CBC:+SHA384",
-            Ciphers.ECDHE_RSA_AES128_GCM_SHA256:    "ECDHE-RSA:+AES-128-GCM:+AEAD",
-            Ciphers.ECDHE_RSA_AES256_GCM_SHA384:    "ECDHE-RSA:+AES-256-GCM:+AEAD",
-            Ciphers.ECDHE_RSA_CHACHA20_POLY1305:    "ECDHE-RSA:+CHACHA20-POLY1305:+AEAD"
+            Ciphers.DHE_RSA_AES128_SHA: "DHE-RSA:+AES-128-CBC:+SHA1",
+            Ciphers.DHE_RSA_AES256_SHA: "DHE-RSA:+AES-256-CBC:+SHA1",
+            Ciphers.DHE_RSA_AES128_SHA256: "DHE-RSA:+AES-128-CBC:+SHA256",
+            Ciphers.DHE_RSA_AES256_SHA256: "DHE-RSA:+AES-256-CBC:+SHA256",
+            Ciphers.DHE_RSA_AES128_GCM_SHA256: "DHE-RSA:+AES-128-GCM:+AEAD",
+            Ciphers.DHE_RSA_AES256_GCM_SHA384: "DHE-RSA:+AES-256-GCM:+AEAD",
+            Ciphers.DHE_RSA_CHACHA20_POLY1305: "DHE-RSA:+CHACHA20-POLY1305:+AEAD",
+            Ciphers.AES128_SHA: "RSA:+AES-128-CBC:+SHA1",
+            Ciphers.AES256_SHA: "RSA:+AES-256-CBC:+SHA1",
+            Ciphers.AES128_SHA256: "RSA:+AES-128-CBC:+SHA256",
+            Ciphers.AES256_SHA256: "RSA:+AES-256-CBC:+SHA256",
+            Ciphers.AES128_GCM_SHA256: "RSA:+AES-128-GCM:+AEAD",
+            Ciphers.AES256_GCM_SHA384: "RSA:+AES-256-GCM:+AEAD",
+            Ciphers.ECDHE_ECDSA_AES128_SHA: "ECDHE-ECDSA:+AES-128-CBC:+SHA1",
+            Ciphers.ECDHE_ECDSA_AES256_SHA: "ECDHE-ECDSA:+AES-256-CBC:+SHA1",
+            Ciphers.ECDHE_ECDSA_AES128_SHA256: "ECDHE-ECDSA:+AES-128-CBC:+SHA256",
+            Ciphers.ECDHE_ECDSA_AES256_SHA384: "ECDHE-ECDSA:+AES-256-CBC:+SHA384",
+            Ciphers.ECDHE_ECDSA_AES128_GCM_SHA256: "ECDHE-ECDSA:+AES-128-GCM:+AEAD",
+            Ciphers.ECDHE_ECDSA_AES256_GCM_SHA384: "ECDHE-ECDSA:+AES-256-GCM:+AEAD",
+            Ciphers.ECDHE_RSA_AES128_SHA: "ECDHE-RSA:+AES-128-CBC:+SHA1",
+            Ciphers.ECDHE_RSA_AES256_SHA: "ECDHE-RSA:+AES-256-CBC:+SHA1",
+            Ciphers.ECDHE_RSA_AES128_SHA256: "ECDHE-RSA:+AES-128-CBC:+SHA256",
+            Ciphers.ECDHE_RSA_AES256_SHA384: "ECDHE-RSA:+AES-256-CBC:+SHA384",
+            Ciphers.ECDHE_RSA_AES128_GCM_SHA256: "ECDHE-RSA:+AES-128-GCM:+AEAD",
+            Ciphers.ECDHE_RSA_AES256_GCM_SHA384: "ECDHE-RSA:+AES-256-GCM:+AEAD",
+            Ciphers.ECDHE_RSA_CHACHA20_POLY1305: "ECDHE-RSA:+CHACHA20-POLY1305:+AEAD",
         }.get(cipher)
 
     @staticmethod
@@ -758,25 +777,25 @@ class GnuTLS(Provider):
             Protocols.TLS10.value: "VERS-TLS1.0",
             Protocols.TLS11.value: "VERS-TLS1.1",
             Protocols.TLS12.value: "VERS-TLS1.2",
-            Protocols.TLS13.value: "VERS-TLS1.3"
+            Protocols.TLS13.value: "VERS-TLS1.3",
         }.get(protocol.value)
 
     @staticmethod
     def curve_to_priority_str(curve):
         return {
-            Curves.P256:    "CURVE-SECP256R1",
-            Curves.P384:    "CURVE-SECP384R1",
-            Curves.P521:    "CURVE-SECP521R1",
-            Curves.X25519:  "CURVE-X25519"
+            Curves.P256: "CURVE-SECP256R1",
+            Curves.P384: "CURVE-SECP384R1",
+            Curves.P521: "CURVE-SECP521R1",
+            Curves.X25519: "CURVE-X25519",
         }.get(curve)
 
     @staticmethod
     def sigalg_to_priority_str(sigalg):
         return {
-            Signatures.RSA_SHA1:    "SIGN-RSA-SHA1",
-            Signatures.RSA_SHA256:  "SIGN-RSA-SHA256",
-            Signatures.RSA_SHA384:  "SIGN-RSA-SHA384",
-            Signatures.RSA_SHA512:  "SIGN-RSA-SHA512",
+            Signatures.RSA_SHA1: "SIGN-RSA-SHA1",
+            Signatures.RSA_SHA256: "SIGN-RSA-SHA256",
+            Signatures.RSA_SHA384: "SIGN-RSA-SHA384",
+            Signatures.RSA_SHA512: "SIGN-RSA-SHA512",
         }.get(sigalg)
 
     @classmethod
@@ -804,7 +823,9 @@ class GnuTLS(Provider):
         else:
             priority_str += ":+GROUP-ALL"
 
-        sigalg_to_priority_str = self.sigalg_to_priority_str(self.options.signature_algorithm)
+        sigalg_to_priority_str = self.sigalg_to_priority_str(
+            self.options.signature_algorithm
+        )
         if sigalg_to_priority_str:
             priority_str += ":+" + sigalg_to_priority_str
         else:
@@ -826,9 +847,11 @@ class GnuTLS(Provider):
 
         cmd_line = [
             "gnutls-cli",
-            "--port", str(self.options.port),
+            "--port",
+            str(self.options.port),
             self.options.host,
-            "--debug", "9999"
+            "--debug",
+            "9999",
         ]
 
         if self.options.verbose:
@@ -862,7 +885,7 @@ class GnuTLS(Provider):
             "gnutls-serv",
             f"--port={self.options.port}",
             "--echo",
-            "--debug=9999"
+            "--debug=9999",
         ]
 
         if self.options.cert is not None:

--- a/tests/integrationv2/pyproject.toml
+++ b/tests/integrationv2/pyproject.toml
@@ -9,5 +9,6 @@ dependencies = [
     "pytest>=8.3.4",
     "pytest-rerunfailures>=15.0",
     "pytest-xdist>=3.6.1",
+    "ruff>=0.9.7",
     "sslyze>=6.1.0",
 ]

--- a/tests/integrationv2/pyproject.toml
+++ b/tests/integrationv2/pyproject.toml
@@ -9,6 +9,5 @@ dependencies = [
     "pytest>=8.3.4",
     "pytest-rerunfailures>=15.0",
     "pytest-xdist>=3.6.1",
-    "ruff>=0.9.7",
     "sslyze>=6.1.0",
 ]

--- a/tests/integrationv2/test_buffered_send.py
+++ b/tests/integrationv2/test_buffered_send.py
@@ -2,13 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
-from configuration import available_ports, PROTOCOLS, ALL_TEST_CIPHERS, MINIMAL_TEST_CERTS
+from configuration import (
+    available_ports,
+    PROTOCOLS,
+    ALL_TEST_CIPHERS,
+    MINIMAL_TEST_CERTS,
+)
 from common import ProviderOptions, data_bytes
 from fixtures import managed_process  # lgtm [py/unused-import]
 from providers import Provider, S2N, OpenSSL, GnuTLS
 from utils import invalid_test_parameters, get_parameter_name, to_bytes, to_string
 
-SEND_DATA_SIZE = 2 ** 14
+SEND_DATA_SIZE = 2**14
 
 # CLOSE_MARKER must a substring of SEND_DATA exactly once, and must be its suffix
 CLOSE_MARKER = "unique-suffix-close-marker"
@@ -28,28 +33,26 @@ SEND_BUFFER_SIZES = [
     SEND_BUFFER_SIZE_MIN_RECOMMENDED,
     SEND_BUFFER_SIZE_MULTI_RECORD,
     SEND_BUFFER_SIZE_PREFER_THROUGHPUT,
-    SEND_BUFFER_SIZE_HUGE
+    SEND_BUFFER_SIZE_HUGE,
 ]
 
-FRAGMENT_PREFERENCE = [
-    None,
-    "--prefer-low-latency",
-    "--prefer-throughput"
-]
+FRAGMENT_PREFERENCE = [None, "--prefer-low-latency", "--prefer-throughput"]
 
 
 def test_SEND_BUFFER_SIZE_MIN_is_s2ns_min_buffer_size(managed_process):
     port = next(available_ports)
 
-    s2n_options = ProviderOptions(mode=Provider.ServerMode,
-                                  port=port,
-                                  data_to_send="test",
-                                  extra_flags=['--buffered-send', SEND_BUFFER_SIZE_MIN])
+    s2n_options = ProviderOptions(
+        mode=Provider.ServerMode,
+        port=port,
+        data_to_send="test",
+        extra_flags=["--buffered-send", SEND_BUFFER_SIZE_MIN],
+    )
 
     s2nd = managed_process(S2N, s2n_options)
 
     s2n_options.mode = Provider.ClientMode
-    s2n_options.extra_flags = ['--buffered-send', SEND_BUFFER_SIZE_MIN - 1]
+    s2n_options.extra_flags = ["--buffered-send", SEND_BUFFER_SIZE_MIN - 1]
     s2nc = managed_process(S2N, s2n_options)
 
     for results in s2nc.get_results():
@@ -66,9 +69,18 @@ def test_SEND_BUFFER_SIZE_MIN_is_s2ns_min_buffer_size(managed_process):
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("buffer_size", SEND_BUFFER_SIZES, ids=get_parameter_name)
-@pytest.mark.parametrize("fragment_preference", FRAGMENT_PREFERENCE, ids=get_parameter_name)
-def test_s2n_server_buffered_send(managed_process, cipher, provider, protocol, certificate, buffer_size,
-                                  fragment_preference):
+@pytest.mark.parametrize(
+    "fragment_preference", FRAGMENT_PREFERENCE, ids=get_parameter_name
+)
+def test_s2n_server_buffered_send(
+    managed_process,
+    cipher,
+    provider,
+    protocol,
+    certificate,
+    buffer_size,
+    fragment_preference,
+):
     # Communication Timeline
     # Client [S2N|OpenSSL|GnuTLS]  | Server [S2N]
     # Handshake                    | Handshake
@@ -83,9 +95,10 @@ def test_s2n_server_buffered_send(managed_process, cipher, provider, protocol, c
         data_to_send=None,
         insecure=True,
         protocol=protocol,
-        verbose=False)
+        verbose=False,
+    )
 
-    extra_flags = ['--buffered-send', buffer_size]
+    extra_flags = ["--buffered-send", buffer_size]
     if fragment_preference is not None:
         extra_flags.append(fragment_preference)
 
@@ -98,10 +111,15 @@ def test_s2n_server_buffered_send(managed_process, cipher, provider, protocol, c
         protocol=protocol,
         key=certificate.key,
         cert=certificate.cert,
-        extra_flags=extra_flags)
+        extra_flags=extra_flags,
+    )
 
-    server = managed_process(S2N, s2n_server_options, send_marker=[S2N.get_send_marker()])
-    client = managed_process(provider, provider_client_options, close_marker=CLOSE_MARKER)
+    server = managed_process(
+        S2N, s2n_server_options, send_marker=[S2N.get_send_marker()]
+    )
+    client = managed_process(
+        provider, provider_client_options, close_marker=CLOSE_MARKER
+    )
 
     for results in client.get_results():
         assert SEND_DATA_STRING in str(results.stdout)
@@ -119,9 +137,18 @@ def test_s2n_server_buffered_send(managed_process, cipher, provider, protocol, c
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("buffer_size", SEND_BUFFER_SIZES, ids=get_parameter_name)
-@pytest.mark.parametrize("fragment_preference", FRAGMENT_PREFERENCE, ids=get_parameter_name)
-def test_s2n_client_buffered_send(managed_process, cipher, provider, protocol, certificate, buffer_size,
-                                  fragment_preference):
+@pytest.mark.parametrize(
+    "fragment_preference", FRAGMENT_PREFERENCE, ids=get_parameter_name
+)
+def test_s2n_client_buffered_send(
+    managed_process,
+    cipher,
+    provider,
+    protocol,
+    certificate,
+    buffer_size,
+    fragment_preference,
+):
     # Communication Timeline
     # Client [S2N]                       | Server [S2N|OpenSSL]
     # Handshake                          | Handshake
@@ -129,7 +156,7 @@ def test_s2n_client_buffered_send(managed_process, cipher, provider, protocol, c
     # Close                              | Close on CLOSE_MARKER
     port = next(available_ports)
 
-    extra_flags = ['--buffered-send', buffer_size]
+    extra_flags = ["--buffered-send", buffer_size]
     if fragment_preference is not None:
         extra_flags.append(fragment_preference)
 
@@ -140,7 +167,8 @@ def test_s2n_client_buffered_send(managed_process, cipher, provider, protocol, c
         data_to_send=SEND_DATA,
         insecure=True,
         protocol=protocol,
-        extra_flags=extra_flags)
+        extra_flags=extra_flags,
+    )
 
     provider_server_options = ProviderOptions(
         mode=Provider.ServerMode,
@@ -150,10 +178,12 @@ def test_s2n_client_buffered_send(managed_process, cipher, provider, protocol, c
         protocol=protocol,
         key=certificate.key,
         cert=certificate.cert,
-        verbose=False)
+        verbose=False,
+    )
 
-    server = managed_process(provider, provider_server_options,
-                             close_marker=CLOSE_MARKER)
+    server = managed_process(
+        provider, provider_server_options, close_marker=CLOSE_MARKER
+    )
     client = managed_process(S2N, s2n_client_options)
 
     for results in client.get_results():

--- a/tests/integrationv2/test_client_authentication.py
+++ b/tests/integrationv2/test_client_authentication.py
@@ -3,11 +3,16 @@
 import copy
 import pytest
 
-from configuration import (available_ports, ALL_TEST_CIPHERS, PROTOCOLS)
+from configuration import available_ports, ALL_TEST_CIPHERS, PROTOCOLS
 from common import Certificates, ProviderOptions, Protocols, data_bytes, Signatures
 from fixtures import managed_process  # lgtm [py/unused-import]
 from providers import Provider, S2N, GnuTLS, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
+from utils import (
+    invalid_test_parameters,
+    get_parameter_name,
+    get_expected_s2n_version,
+    to_bytes,
+)
 
 # If we test every available cert, the test takes too long.
 # Choose a good representative subset.
@@ -22,20 +27,27 @@ CERTS_TO_TEST = [
 
 def assert_openssl_handshake_complete(results, is_complete=True):
     if is_complete:
-        assert b'read finished' in results.stderr
-        assert b'write finished' in results.stderr
+        assert b"read finished" in results.stderr
+        assert b"write finished" in results.stderr
     else:
-        assert b'read finished' not in results.stderr or b'write finished' not in results.stderr
+        assert (
+            b"read finished" not in results.stderr
+            or b"write finished" not in results.stderr
+        )
 
 
 def assert_s2n_handshake_complete(results, protocol, provider, is_complete=True):
     expected_version = get_expected_s2n_version(protocol, provider)
     if is_complete:
-        assert to_bytes("Actual protocol version: {}".format(
-            expected_version)) in results.stdout
+        assert (
+            to_bytes("Actual protocol version: {}".format(expected_version))
+            in results.stdout
+        )
     else:
-        assert to_bytes("Actual protocol version: {}".format(
-            expected_version)) not in results.stdout
+        assert (
+            to_bytes("Actual protocol version: {}".format(expected_version))
+            not in results.stdout
+        )
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -45,8 +57,15 @@ def assert_s2n_handshake_complete(results, protocol, provider, is_complete=True)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", CERTS_TO_TEST, ids=get_parameter_name)
 @pytest.mark.parametrize("client_certificate", CERTS_TO_TEST, ids=get_parameter_name)
-def test_client_auth_with_s2n_server(managed_process, provider, other_provider, protocol, cipher, certificate,
-                                     client_certificate):
+def test_client_auth_with_s2n_server(
+    managed_process,
+    provider,
+    other_provider,
+    protocol,
+    cipher,
+    certificate,
+    client_certificate,
+):
     port = next(available_ports)
 
     random_bytes = data_bytes(64)
@@ -60,7 +79,8 @@ def test_client_auth_with_s2n_server(managed_process, provider, other_provider, 
         cert=client_certificate.cert,
         trust_store=certificate.cert,
         insecure=False,
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = copy.copy(client_options)
     server_options.data_to_send = None
@@ -75,8 +95,8 @@ def test_client_auth_with_s2n_server(managed_process, provider, other_provider, 
     # Openssl should send a client certificate and complete the handshake
     for results in client.get_results():
         results.assert_success()
-        assert b'write client certificate' in results.stderr
-        assert b'write certificate verify' in results.stderr
+        assert b"write client certificate" in results.stderr
+        assert b"write certificate verify" in results.stderr
         assert_openssl_handshake_complete(results)
 
     # S2N should successfully connect
@@ -93,21 +113,29 @@ def test_client_auth_with_s2n_server(managed_process, provider, other_provider, 
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", CERTS_TO_TEST, ids=get_parameter_name)
 @pytest.mark.parametrize("client_certificate", CERTS_TO_TEST, ids=get_parameter_name)
-def test_client_auth_with_s2n_server_using_nonmatching_certs(managed_process, provider, other_provider, protocol,
-                                                             cipher, certificate, client_certificate):
+def test_client_auth_with_s2n_server_using_nonmatching_certs(
+    managed_process,
+    provider,
+    other_provider,
+    protocol,
+    cipher,
+    certificate,
+    client_certificate,
+):
     port = next(available_ports)
 
     client_options = ProviderOptions(
         mode=Provider.ClientMode,
         port=port,
         cipher=cipher,
-        data_to_send=b'',
+        data_to_send=b"",
         use_client_auth=True,
         key=client_certificate.key,
         cert=client_certificate.cert,
         trust_store=certificate.cert,
         insecure=False,
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = copy.copy(client_options)
     server_options.data_to_send = None
@@ -124,8 +152,8 @@ def test_client_auth_with_s2n_server_using_nonmatching_certs(managed_process, pr
     # Openssl should tell us that a certificate was sent, but the handshake did not complete
     for results in client.get_results():
         assert results.exception is None
-        assert b'write client certificate' in results.stderr
-        assert b'write certificate verify' in results.stderr
+        assert b"write client certificate" in results.stderr
+        assert b"write certificate verify" in results.stderr
         # TLS1.3 OpenSSL fails after the handshake, but pre-TLS1.3 fails during
         if protocol is not Protocols.TLS13:
             assert results.exit_code != 0
@@ -135,8 +163,8 @@ def test_client_auth_with_s2n_server_using_nonmatching_certs(managed_process, pr
     for results in server.get_results():
         assert results.exception is None
         assert results.exit_code != 0
-        assert b'Certificate is untrusted' in results.stderr
-        assert b'Error: Mutual Auth was required, but not negotiated' in results.stderr
+        assert b"Certificate is untrusted" in results.stderr
+        assert b"Error: Mutual Auth was required, but not negotiated" in results.stderr
         assert_s2n_handshake_complete(results, protocol, provider, False)
 
 
@@ -146,7 +174,9 @@ def test_client_auth_with_s2n_server_using_nonmatching_certs(managed_process, pr
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", CERTS_TO_TEST, ids=get_parameter_name)
-def test_client_auth_with_s2n_client_no_cert(managed_process, provider, other_provider, protocol, cipher, certificate):
+def test_client_auth_with_s2n_client_no_cert(
+    managed_process, provider, other_provider, protocol, cipher, certificate
+):
     port = next(available_ports)
 
     random_bytes = data_bytes(64)
@@ -158,7 +188,8 @@ def test_client_auth_with_s2n_client_no_cert(managed_process, provider, other_pr
         use_client_auth=True,
         trust_store=certificate.cert,
         insecure=False,
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = copy.copy(client_options)
     server_options.data_to_send = None
@@ -172,8 +203,8 @@ def test_client_auth_with_s2n_client_no_cert(managed_process, provider, other_pr
     # Openssl should tell us that a cert was requested but not received
     for results in server.get_results():
         results.assert_success()
-        assert b'write certificate request' in results.stderr
-        assert b'read client certificate' not in results.stderr
+        assert b"write certificate request" in results.stderr
+        assert b"read client certificate" not in results.stderr
         assert b"peer did not return a certificate" in results.stderr
         assert_openssl_handshake_complete(results, False)
 
@@ -181,7 +212,7 @@ def test_client_auth_with_s2n_client_no_cert(managed_process, provider, other_pr
         assert results.exception is None
         # TLS1.3 OpenSSL fails after the handshake, but pre-TLS1.3 fails during
         if protocol is not Protocols.TLS13:
-            assert (results.exit_code != 0)
+            assert results.exit_code != 0
             assert b"Failed to negotiate: 'TLS alert received'" in results.stderr
             assert_s2n_handshake_complete(results, protocol, provider, False)
 
@@ -193,8 +224,15 @@ def test_client_auth_with_s2n_client_no_cert(managed_process, provider, other_pr
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", CERTS_TO_TEST, ids=get_parameter_name)
 @pytest.mark.parametrize("client_certificate", CERTS_TO_TEST, ids=get_parameter_name)
-def test_client_auth_with_s2n_client_with_cert(managed_process, provider, other_provider, protocol, cipher, certificate,
-                                               client_certificate):
+def test_client_auth_with_s2n_client_with_cert(
+    managed_process,
+    provider,
+    other_provider,
+    protocol,
+    cipher,
+    certificate,
+    client_certificate,
+):
     port = next(available_ports)
 
     random_bytes = data_bytes(64)
@@ -208,7 +246,8 @@ def test_client_auth_with_s2n_client_with_cert(managed_process, provider, other_
         cert=client_certificate.cert,
         trust_store=certificate.cert,
         insecure=False,
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = copy.copy(client_options)
     server_options.data_to_send = None
@@ -229,8 +268,8 @@ def test_client_auth_with_s2n_client_with_cert(managed_process, provider, other_
     for results in server.get_results():
         results.assert_success()
         assert random_bytes[1:] in results.stdout
-        assert b'read client certificate' in results.stderr
-        assert b'read certificate verify' in results.stderr
+        assert b"read client certificate" in results.stderr
+        assert b"read certificate verify" in results.stderr
         assert_openssl_handshake_complete(results)
 
 
@@ -245,7 +284,11 @@ TLS1.3, even if its security policy would normally allow TLS1.3.
 """
 
 
-@pytest.mark.parametrize("certificate", [Certificates.RSA_2048_PKCS1, Certificates.ECDSA_256], ids=get_parameter_name)
+@pytest.mark.parametrize(
+    "certificate",
+    [Certificates.RSA_2048_PKCS1, Certificates.ECDSA_256],
+    ids=get_parameter_name,
+)
 def test_tls_12_client_auth_downgrade(managed_process, certificate):
     port = next(available_ports)
 
@@ -306,9 +349,11 @@ def test_tls_12_client_auth_downgrade(managed_process, certificate):
 
     for results in server.get_results():
         results.assert_success()
-        assert to_bytes(
-            f"Actual protocol version: {expected_protocol_version}"
-        ) in results.stdout
-        assert to_bytes(
-            f"Client signature negotiated: {expected_signature_type}"
-        ) in results.stdout
+        assert (
+            to_bytes(f"Actual protocol version: {expected_protocol_version}")
+            in results.stdout
+        )
+        assert (
+            to_bytes(f"Client signature negotiated: {expected_signature_type}")
+            in results.stdout
+        )

--- a/tests/integrationv2/test_cross_compatibility.py
+++ b/tests/integrationv2/test_cross_compatibility.py
@@ -4,7 +4,12 @@ import pytest
 import copy
 import os
 
-from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS
+from configuration import (
+    available_ports,
+    ALL_TEST_CIPHERS,
+    ALL_TEST_CURVES,
+    ALL_TEST_CERTS,
+)
 from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process  # lgtm [py/unused-import]
 from providers import Provider, S2N, OpenSSL
@@ -13,7 +18,7 @@ from utils import invalid_test_parameters, get_parameter_name, to_bytes
 S2N_RESUMPTION_MARKER = to_bytes("Resumed session")
 CLOSE_MARKER_BYTES = data_bytes(10)
 
-TICKET_FILE = 'ticket'
+TICKET_FILE = "ticket"
 RESUMPTION_PROTOCOLS = [Protocols.TLS12, Protocols.TLS13]
 
 
@@ -30,8 +35,16 @@ Tests that S2N tickets are backwards-compatible.
 @pytest.mark.parametrize("protocol", RESUMPTION_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-def test_s2n_old_server_new_ticket(managed_process, tmp_path, cipher, curve, certificate, protocol, provider,
-                                   other_provider):
+def test_s2n_old_server_new_ticket(
+    managed_process,
+    tmp_path,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    other_provider,
+):
     ticket_file = str(tmp_path / TICKET_FILE)
     assert not os.path.exists(ticket_file)
 
@@ -46,7 +59,7 @@ def test_s2n_old_server_new_ticket(managed_process, tmp_path, cipher, curve, cer
 
     client_options = copy.copy(options)
     client_options.mode = Provider.ClientMode
-    client_options.extra_flags = ['-sess_out', ticket_file]
+    client_options.extra_flags = ["-sess_out", ticket_file]
 
     server_options = copy.copy(options)
     server_options.mode = Provider.ServerMode
@@ -54,10 +67,10 @@ def test_s2n_old_server_new_ticket(managed_process, tmp_path, cipher, curve, cer
     server_options.cert = certificate.cert
     server_options.data_to_send = CLOSE_MARKER_BYTES
 
-    s2n_server = managed_process(
-        S2N, server_options, send_marker=S2N.get_send_marker())
-    client = managed_process(provider, client_options,
-                             close_marker=str(CLOSE_MARKER_BYTES))
+    s2n_server = managed_process(S2N, server_options, send_marker=S2N.get_send_marker())
+    client = managed_process(
+        provider, client_options, close_marker=str(CLOSE_MARKER_BYTES)
+    )
 
     for results in client.get_results():
         results.assert_success()
@@ -66,13 +79,13 @@ def test_s2n_old_server_new_ticket(managed_process, tmp_path, cipher, curve, cer
         results.assert_success()
 
     assert os.path.exists(ticket_file)
-    client_options.extra_flags = ['-sess_in', ticket_file]
+    client_options.extra_flags = ["-sess_in", ticket_file]
     server_options.use_mainline_version = True
 
-    s2n_server = managed_process(
-        S2N, server_options, send_marker=S2N.get_send_marker())
-    client = managed_process(provider, client_options,
-                             close_marker=str(CLOSE_MARKER_BYTES))
+    s2n_server = managed_process(S2N, server_options, send_marker=S2N.get_send_marker())
+    client = managed_process(
+        provider, client_options, close_marker=str(CLOSE_MARKER_BYTES)
+    )
 
     for results in client.get_results():
         results.assert_success()
@@ -95,8 +108,16 @@ Tests that S2N tickets are forwards-compatible.
 @pytest.mark.parametrize("protocol", RESUMPTION_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-def test_s2n_new_server_old_ticket(managed_process, tmp_path, cipher, curve, certificate, protocol, provider,
-                                   other_provider):
+def test_s2n_new_server_old_ticket(
+    managed_process,
+    tmp_path,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    other_provider,
+):
     ticket_file = str(tmp_path / TICKET_FILE)
     assert not os.path.exists(ticket_file)
 
@@ -111,7 +132,7 @@ def test_s2n_new_server_old_ticket(managed_process, tmp_path, cipher, curve, cer
 
     client_options = copy.copy(options)
     client_options.mode = Provider.ClientMode
-    client_options.extra_flags = ['-sess_out', ticket_file]
+    client_options.extra_flags = ["-sess_out", ticket_file]
 
     server_options = copy.copy(options)
     server_options.mode = Provider.ServerMode
@@ -120,10 +141,10 @@ def test_s2n_new_server_old_ticket(managed_process, tmp_path, cipher, curve, cer
     server_options.cert = certificate.cert
     server_options.data_to_send = CLOSE_MARKER_BYTES
 
-    s2n_server = managed_process(
-        S2N, server_options, send_marker=S2N.get_send_marker())
-    client = managed_process(provider, client_options,
-                             close_marker=str(CLOSE_MARKER_BYTES))
+    s2n_server = managed_process(S2N, server_options, send_marker=S2N.get_send_marker())
+    client = managed_process(
+        provider, client_options, close_marker=str(CLOSE_MARKER_BYTES)
+    )
 
     for results in client.get_results():
         results.assert_success()
@@ -132,13 +153,13 @@ def test_s2n_new_server_old_ticket(managed_process, tmp_path, cipher, curve, cer
         results.assert_success()
 
     assert os.path.exists(ticket_file)
-    client_options.extra_flags = ['-sess_in', ticket_file]
+    client_options.extra_flags = ["-sess_in", ticket_file]
     server_options.use_mainline_version = False
 
-    s2n_server = managed_process(
-        S2N, server_options, send_marker=S2N.get_send_marker())
-    client = managed_process(provider, client_options,
-                             close_marker=str(CLOSE_MARKER_BYTES))
+    s2n_server = managed_process(S2N, server_options, send_marker=S2N.get_send_marker())
+    client = managed_process(
+        provider, client_options, close_marker=str(CLOSE_MARKER_BYTES)
+    )
 
     for results in client.get_results():
         results.assert_success()
@@ -162,8 +183,16 @@ server because the Openssl server uses a different ticket key for each session.
 @pytest.mark.parametrize("protocol", RESUMPTION_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-def test_s2n_old_client_new_ticket(managed_process, tmp_path, cipher, curve, certificate, protocol, provider,
-                                   other_provider):
+def test_s2n_old_client_new_ticket(
+    managed_process,
+    tmp_path,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    other_provider,
+):
     ticket_file = str(tmp_path / TICKET_FILE)
     assert not os.path.exists(ticket_file)
 
@@ -178,7 +207,7 @@ def test_s2n_old_client_new_ticket(managed_process, tmp_path, cipher, curve, cer
 
     client_options = copy.copy(options)
     client_options.mode = Provider.ClientMode
-    client_options.extra_flags = ['--ticket-out', ticket_file]
+    client_options.extra_flags = ["--ticket-out", ticket_file]
 
     server_options = copy.copy(options)
     server_options.mode = Provider.ServerMode
@@ -195,7 +224,7 @@ def test_s2n_old_client_new_ticket(managed_process, tmp_path, cipher, curve, cer
         results.assert_success()
 
     assert os.path.exists(ticket_file)
-    client_options.extra_flags = ['--ticket-in', ticket_file]
+    client_options.extra_flags = ["--ticket-in", ticket_file]
     client_options.use_mainline_version = True
 
     server = managed_process(provider, server_options)
@@ -223,8 +252,16 @@ Tests that S2N tickets are forwards-compatible.
 @pytest.mark.parametrize("protocol", RESUMPTION_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-def test_s2n_new_client_old_ticket(managed_process, tmp_path, cipher, curve, certificate, protocol, provider,
-                                   other_provider):
+def test_s2n_new_client_old_ticket(
+    managed_process,
+    tmp_path,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    other_provider,
+):
     ticket_file = str(tmp_path / TICKET_FILE)
     assert not os.path.exists(ticket_file)
 
@@ -239,7 +276,7 @@ def test_s2n_new_client_old_ticket(managed_process, tmp_path, cipher, curve, cer
 
     client_options = copy.copy(options)
     client_options.mode = Provider.ClientMode
-    client_options.extra_flags = ['--ticket-out', ticket_file]
+    client_options.extra_flags = ["--ticket-out", ticket_file]
     client_options.use_mainline_version = True
 
     server_options = copy.copy(options)
@@ -257,7 +294,7 @@ def test_s2n_new_client_old_ticket(managed_process, tmp_path, cipher, curve, cer
         results.assert_success()
 
     assert os.path.exists(ticket_file)
-    client_options.extra_flags = ['--ticket-in', ticket_file]
+    client_options.extra_flags = ["--ticket-in", ticket_file]
     client_options.use_mainline_version = False
 
     server = managed_process(provider, server_options)

--- a/tests/integrationv2/test_dynamic_record_sizes.py
+++ b/tests/integrationv2/test_dynamic_record_sizes.py
@@ -3,11 +3,22 @@
 import copy
 import pytest
 
-from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS, PROTOCOLS
+from configuration import (
+    available_ports,
+    ALL_TEST_CIPHERS,
+    ALL_TEST_CURVES,
+    ALL_TEST_CERTS,
+    PROTOCOLS,
+)
 from common import ProviderOptions, data_bytes
 from fixtures import custom_mtu, managed_process  # lgtm [py/unused-import]
 from providers import Provider, S2N, OpenSSL, Tcpdump
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
+from utils import (
+    invalid_test_parameters,
+    get_parameter_name,
+    get_expected_s2n_version,
+    to_bytes,
+)
 
 
 def find_fragmented_packet(results):
@@ -19,15 +30,15 @@ def find_fragmented_packet(results):
     to the output line. This happens even when using `-nn` on the command line.
     That is why we need two ways to detect the length of the packet.
     """
-    for line in results.decode('utf-8').split('\n'):
-        pieces = line.split(' ')
+    for line in results.decode("utf-8").split("\n"):
+        pieces = line.split(" ")
         if len(pieces) < 3:
             continue
 
         packet_len = 0
-        if pieces[-2] == 'length':
+        if pieces[-2] == "length":
             packet_len = int(pieces[-1])
-        elif pieces[-3] == 'length':
+        elif pieces[-3] == "length":
             # In this case the length has a colon `1234:`, so we must trim it.
             packet_len = int(pieces[-2][:-1])
 
@@ -44,8 +55,16 @@ def find_fragmented_packet(results):
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
-def test_s2n_client_dynamic_record(custom_mtu, managed_process, cipher, curve, provider, other_provider, protocol,
-                                   certificate):
+def test_s2n_client_dynamic_record(
+    custom_mtu,
+    managed_process,
+    cipher,
+    curve,
+    provider,
+    other_provider,
+    protocol,
+    certificate,
+):
     port = next(available_ports)
 
     # 16384 bytes is enough to reliably get a packet that will exceed the MTU
@@ -56,7 +75,8 @@ def test_s2n_client_dynamic_record(custom_mtu, managed_process, cipher, curve, p
         cipher=cipher,
         data_to_send=bytes_to_send,
         insecure=True,
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = copy.copy(client_options)
     server_options.data_to_send = None
@@ -74,8 +94,10 @@ def test_s2n_client_dynamic_record(custom_mtu, managed_process, cipher, curve, p
 
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes("Actual protocol version: {}".format(
-            expected_version)) in results.stdout
+        assert (
+            to_bytes("Actual protocol version: {}".format(expected_version))
+            in results.stdout
+        )
 
     for results in server.get_results():
         results.assert_success()

--- a/tests/integrationv2/test_early_data.py
+++ b/tests/integrationv2/test_early_data.py
@@ -4,7 +4,12 @@ import copy
 import os
 import pytest
 
-from configuration import available_ports, ALL_TEST_CURVES, ALL_TEST_CERTS, TLS13_CIPHERS
+from configuration import (
+    available_ports,
+    ALL_TEST_CURVES,
+    ALL_TEST_CERTS,
+    TLS13_CIPHERS,
+)
 from common import ProviderOptions, Protocols, Curves, data_bytes
 from fixtures import managed_process  # lgtm [py/unused-import]
 from providers import Provider, S2N as S2NBase, OpenSSL as OpenSSLBase
@@ -12,8 +17,8 @@ from utils import invalid_test_parameters, get_parameter_name, to_bytes
 
 from test_hello_retry_requests import S2N_HRR_MARKER
 
-TICKET_FILE = 'ticket'
-EARLY_DATA_FILE = 'early_data'
+TICKET_FILE = "ticket"
+EARLY_DATA_FILE = "early_data"
 
 MAX_EARLY_DATA = 500  # Arbitrary largish number
 DATA_TO_SEND = data_bytes(500)  # Arbitrary large number
@@ -23,19 +28,17 @@ NUM_CONNECTIONS = NUM_RESUMES + 1  # resumes + initial
 
 S2N_DEFAULT_CURVE = Curves.X25519
 # We have no plans to support this curve any time soon
-S2N_UNSUPPORTED_CURVE = 'X448'
-S2N_HRR_CURVES = list(
-    curve for curve in ALL_TEST_CURVES if curve != S2N_DEFAULT_CURVE)
+S2N_UNSUPPORTED_CURVE = "X448"
+S2N_HRR_CURVES = list(curve for curve in ALL_TEST_CURVES if curve != S2N_DEFAULT_CURVE)
 
 S2N_EARLY_DATA_MARKER = to_bytes("WITH_EARLY_DATA")
 S2N_EARLY_DATA_RECV_MARKER = "Early Data received: "
 S2N_EARLY_DATA_STATUS_MARKER = "Early Data status: {status}"
-S2N_EARLY_DATA_ACCEPTED_MARKER = S2N_EARLY_DATA_STATUS_MARKER.format(
-    status="ACCEPTED")
-S2N_EARLY_DATA_REJECTED_MARKER = S2N_EARLY_DATA_STATUS_MARKER.format(
-    status="REJECTED")
+S2N_EARLY_DATA_ACCEPTED_MARKER = S2N_EARLY_DATA_STATUS_MARKER.format(status="ACCEPTED")
+S2N_EARLY_DATA_REJECTED_MARKER = S2N_EARLY_DATA_STATUS_MARKER.format(status="REJECTED")
 S2N_EARLY_DATA_NOT_REQUESTED_MARKER = S2N_EARLY_DATA_STATUS_MARKER.format(
-    status="NOT REQUESTED")
+    status="NOT REQUESTED"
+)
 
 
 class S2N(S2NBase):
@@ -46,12 +49,12 @@ class S2N(S2NBase):
         cmd_line = S2NBase.setup_client(self)
         early_data_file = self.options.early_data_file
         if early_data_file and os.path.exists(early_data_file):
-            cmd_line.extend(['--early-data', early_data_file])
+            cmd_line.extend(["--early-data", early_data_file])
         return cmd_line
 
     def setup_server(self):
         cmd_line = S2NBase.setup_server(self)
-        cmd_line.extend(['--max-early-data', self.options.max_early_data])
+        cmd_line.extend(["--max-early-data", self.options.max_early_data])
         return cmd_line
 
 
@@ -63,19 +66,19 @@ class OpenSSL(OpenSSLBase):
         cmd_line = OpenSSLBase.setup_client(self)
         early_data_file = self.options.early_data_file
         if early_data_file and os.path.exists(early_data_file):
-            cmd_line.extend(['-early_data', early_data_file])
+            cmd_line.extend(["-early_data", early_data_file])
         ticket_file = self.options.ticket_file
         if ticket_file:
             if os.path.exists(ticket_file):
-                cmd_line.extend(['-sess_in', ticket_file])
+                cmd_line.extend(["-sess_in", ticket_file])
             else:
-                cmd_line.extend(['-sess_out', self.options.ticket_file])
+                cmd_line.extend(["-sess_out", self.options.ticket_file])
         return cmd_line
 
     def setup_server(self):
         cmd_line = OpenSSLBase.setup_server(self)
         if self.options.max_early_data > 0:
-            cmd_line.extend(['-early_data'])
+            cmd_line.extend(["-early_data"])
         return cmd_line
 
 
@@ -89,7 +92,7 @@ SERVER_PROVIDERS = [OpenSSL, S2N]
 
 def get_early_data_bytes(file_path, early_data_size):
     early_data = data_bytes(early_data_size)
-    with open(file_path, 'wb') as fout:
+    with open(file_path, "wb") as fout:
         fout.write(early_data)
     return early_data
 
@@ -118,16 +121,10 @@ def get_ticket_from_s2n_server(options, managed_process, provider, certificate):
     assert not os.path.exists(options.ticket_file)
 
     s2n_server = managed_process(
-        S2N,
-        server_options,
-        send_marker=S2N.get_send_marker(),
-        timeout=10
+        S2N, server_options, send_marker=S2N.get_send_marker(), timeout=10
     )
     client = managed_process(
-        provider,
-        client_options,
-        close_marker=str(close_marker_bytes),
-        timeout=10
+        provider, client_options, close_marker=str(close_marker_bytes), timeout=10
     )
 
     for results in s2n_server.get_results():
@@ -163,9 +160,21 @@ then another resumption connection with early data.
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("provider", CLIENT_PROVIDERS, ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-@pytest.mark.parametrize("early_data_size", [int(MAX_EARLY_DATA/2), int(MAX_EARLY_DATA-1), MAX_EARLY_DATA, 1])
-def test_s2n_server_with_early_data(managed_process, tmp_path, cipher, curve, certificate, protocol, provider,
-                                    other_provider, early_data_size):
+@pytest.mark.parametrize(
+    "early_data_size",
+    [int(MAX_EARLY_DATA / 2), int(MAX_EARLY_DATA - 1), MAX_EARLY_DATA, 1],
+)
+def test_s2n_server_with_early_data(
+    managed_process,
+    tmp_path,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    other_provider,
+    early_data_size,
+):
     ticket_file = str(tmp_path / TICKET_FILE)
     early_data_file = str(tmp_path / EARLY_DATA_FILE)
     early_data = get_early_data_bytes(early_data_file, early_data_size)
@@ -200,8 +209,7 @@ def test_s2n_server_with_early_data(managed_process, tmp_path, cipher, curve, ce
     for results in s2n_server.get_results():
         results.assert_success()
         assert S2N_EARLY_DATA_MARKER in results.stdout
-        assert (to_bytes(S2N_EARLY_DATA_RECV_MARKER) +
-                early_data) in results.stdout
+        assert (to_bytes(S2N_EARLY_DATA_RECV_MARKER) + early_data) in results.stdout
         assert to_bytes(S2N_EARLY_DATA_ACCEPTED_MARKER) in results.stdout
         assert DATA_TO_SEND in results.stdout
 
@@ -220,9 +228,20 @@ That means we don't need to manually perform the initial full connection, and th
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("provider", SERVER_PROVIDERS, ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-@pytest.mark.parametrize("early_data_size", [int(MAX_EARLY_DATA/2), int(MAX_EARLY_DATA-1), MAX_EARLY_DATA, 1])
-def test_s2n_client_with_early_data(managed_process, tmp_path, cipher, certificate, protocol, provider, other_provider,
-                                    early_data_size):
+@pytest.mark.parametrize(
+    "early_data_size",
+    [int(MAX_EARLY_DATA / 2), int(MAX_EARLY_DATA - 1), MAX_EARLY_DATA, 1],
+)
+def test_s2n_client_with_early_data(
+    managed_process,
+    tmp_path,
+    cipher,
+    certificate,
+    protocol,
+    provider,
+    other_provider,
+    early_data_size,
+):
     early_data_file = str(tmp_path / EARLY_DATA_FILE)
     early_data = get_early_data_bytes(early_data_file, early_data_size)
 
@@ -253,8 +272,10 @@ def test_s2n_client_with_early_data(managed_process, tmp_path, cipher, certifica
     for results in s2n_client.get_results():
         results.assert_success()
         assert S2N_EARLY_DATA_MARKER in results.stdout
-        assert results.stdout.count(
-            to_bytes(S2N_EARLY_DATA_ACCEPTED_MARKER)) == NUM_RESUMES
+        assert (
+            results.stdout.count(to_bytes(S2N_EARLY_DATA_ACCEPTED_MARKER))
+            == NUM_RESUMES
+        )
 
     for results in server.get_results():
         results.assert_success()
@@ -275,8 +296,9 @@ test_session_resumption but with validation that no early data is sent.
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("provider", SERVER_PROVIDERS, ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-def test_s2n_client_without_early_data(managed_process, tmp_path, cipher, certificate, protocol, provider,
-                                       other_provider):
+def test_s2n_client_without_early_data(
+    managed_process, tmp_path, cipher, certificate, protocol, provider, other_provider
+):
     early_data_file = str(tmp_path / EARLY_DATA_FILE)
     early_data = get_early_data_bytes(early_data_file, MAX_EARLY_DATA)
 
@@ -311,8 +333,10 @@ def test_s2n_client_without_early_data(managed_process, tmp_path, cipher, certif
     for results in s2n_client.get_results():
         results.assert_success()
         assert S2N_EARLY_DATA_MARKER not in results.stdout
-        assert results.stdout.count(
-            to_bytes(S2N_EARLY_DATA_NOT_REQUESTED_MARKER)) == NUM_CONNECTIONS
+        assert (
+            results.stdout.count(to_bytes(S2N_EARLY_DATA_NOT_REQUESTED_MARKER))
+            == NUM_CONNECTIONS
+        )
 
 
 """
@@ -334,9 +358,21 @@ reconnects automatically, without any mechanism to modify the connection in betw
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("provider", CLIENT_PROVIDERS, ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-@pytest.mark.parametrize("early_data_size", [int(MAX_EARLY_DATA/2), int(MAX_EARLY_DATA-1), MAX_EARLY_DATA, 1])
-def test_s2n_server_with_early_data_rejected(managed_process, tmp_path, cipher, curve, certificate, protocol, provider,
-                                             other_provider, early_data_size):
+@pytest.mark.parametrize(
+    "early_data_size",
+    [int(MAX_EARLY_DATA / 2), int(MAX_EARLY_DATA - 1), MAX_EARLY_DATA, 1],
+)
+def test_s2n_server_with_early_data_rejected(
+    managed_process,
+    tmp_path,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    other_provider,
+    early_data_size,
+):
     ticket_file = str(tmp_path / TICKET_FILE)
     early_data_file = str(tmp_path / EARLY_DATA_FILE)
     get_early_data_bytes(early_data_file, early_data_size)
@@ -393,12 +429,25 @@ does not send key shares for.
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("provider", SERVER_PROVIDERS, ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-@pytest.mark.parametrize("early_data_size", [int(MAX_EARLY_DATA/2), int(MAX_EARLY_DATA-1), MAX_EARLY_DATA, 1])
-def test_s2n_client_with_early_data_rejected_via_hrr(managed_process, tmp_path, cipher, curve, certificate, protocol,
-                                                     provider, other_provider, early_data_size):
+@pytest.mark.parametrize(
+    "early_data_size",
+    [int(MAX_EARLY_DATA / 2), int(MAX_EARLY_DATA - 1), MAX_EARLY_DATA, 1],
+)
+def test_s2n_client_with_early_data_rejected_via_hrr(
+    managed_process,
+    tmp_path,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    other_provider,
+    early_data_size,
+):
     if provider == S2N:
         pytest.skip(
-            "S2N does not respect ProviderOptions.curve, so does not trigger a retry")
+            "S2N does not respect ProviderOptions.curve, so does not trigger a retry"
+        )
 
     early_data_file = str(tmp_path / EARLY_DATA_FILE)
     early_data = get_early_data_bytes(early_data_file, early_data_size)
@@ -432,8 +481,10 @@ def test_s2n_client_with_early_data_rejected_via_hrr(managed_process, tmp_path, 
         results.assert_success()
         assert S2N_EARLY_DATA_MARKER not in results.stdout
         assert S2N_HRR_MARKER in results.stdout
-        assert results.stdout.count(
-            to_bytes(S2N_EARLY_DATA_REJECTED_MARKER)) == NUM_RESUMES
+        assert (
+            results.stdout.count(to_bytes(S2N_EARLY_DATA_REJECTED_MARKER))
+            == NUM_RESUMES
+        )
 
     for results in server.get_results():
         results.assert_success()
@@ -455,9 +506,21 @@ S2N doesn't support while still supporting at least one curve S2N does support.
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("provider", CLIENT_PROVIDERS, ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-@pytest.mark.parametrize("early_data_size", [int(MAX_EARLY_DATA/2), int(MAX_EARLY_DATA-1), MAX_EARLY_DATA, 1])
-def test_s2n_server_with_early_data_rejected_via_hrr(managed_process, tmp_path, cipher, curve, certificate, protocol,
-                                                     provider, other_provider, early_data_size):
+@pytest.mark.parametrize(
+    "early_data_size",
+    [int(MAX_EARLY_DATA / 2), int(MAX_EARLY_DATA - 1), MAX_EARLY_DATA, 1],
+)
+def test_s2n_server_with_early_data_rejected_via_hrr(
+    managed_process,
+    tmp_path,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    other_provider,
+    early_data_size,
+):
     ticket_file = str(tmp_path / TICKET_FILE)
     early_data_file = str(tmp_path / EARLY_DATA_FILE)
     early_data = get_early_data_bytes(early_data_file, early_data_size)
@@ -512,12 +575,22 @@ Test the S2N server fails if it receives too much early data.
 @pytest.mark.parametrize("provider", CLIENT_PROVIDERS, ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("excess_early_data", [1, 10, MAX_EARLY_DATA])
-def test_s2n_server_with_early_data_max_exceeded(managed_process, tmp_path, cipher, curve, certificate, protocol,
-                                                 provider, other_provider, excess_early_data):
+def test_s2n_server_with_early_data_max_exceeded(
+    managed_process,
+    tmp_path,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    other_provider,
+    excess_early_data,
+):
     ticket_file = str(tmp_path / TICKET_FILE)
     early_data_file = str(tmp_path / EARLY_DATA_FILE)
     early_data = get_early_data_bytes(
-        early_data_file, MAX_EARLY_DATA + excess_early_data)
+        early_data_file, MAX_EARLY_DATA + excess_early_data
+    )
 
     options = ProviderOptions(
         port=next(available_ports),
@@ -560,6 +633,7 @@ def test_s2n_server_with_early_data_max_exceeded(managed_process, tmp_path, ciph
         # Full early data should not be reported
         assert early_data not in results.stdout
         # Partial early data should be reported
-        assert (to_bytes(S2N_EARLY_DATA_RECV_MARKER) +
-                early_data[:MAX_EARLY_DATA]) in results.stdout
+        assert (
+            to_bytes(S2N_EARLY_DATA_RECV_MARKER) + early_data[:MAX_EARLY_DATA]
+        ) in results.stdout
         assert to_bytes("Bad message encountered") in results.stderr

--- a/tests/integrationv2/test_external_psk.py
+++ b/tests/integrationv2/test_external_psk.py
@@ -2,7 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
-from configuration import available_ports, TLS13_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS
+from configuration import (
+    available_ports,
+    TLS13_CIPHERS,
+    ALL_TEST_CURVES,
+    ALL_TEST_CERTS,
+)
 from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process  # lgtm [py/unused-import]
 from providers import S2N, OpenSSL
@@ -10,17 +15,19 @@ from utils import invalid_test_parameters, get_parameter_name, to_bytes
 from enum import Enum, auto
 
 # Known value test vectors from https://tools.ietf.org/html/rfc8448#section-4
-known_psk_identity = '2c035d829359ee5ff7af4ec900000000262a6494dc486d2c8a34cb33fa90bf1b00'\
-                     '70ad3c498883c9367c09a2be785abc55cd226097a3a982117283f82a03a143efd3'\
-                     'ff5dd36d64e861be7fd61d2827db279cce145077d454a3664d4e6da4d29ee03725'\
-                     'a6a4dafcd0fc67d2aea70529513e3da2677fa5906c5b3f7d8f92f228bda40dda72'\
-                     '1470f9fbf297b5aea617646fac5c03272e970727c621a79141ef5f7de6505e5bfb'\
-                     'c388e93343694093934ae4d357'
-known_psk_secret = '4ecd0eb6ec3b4d87f5d6028f922ca4c5851a277fd41311c9e62d2c9492e1c4f3'
+known_psk_identity = (
+    "2c035d829359ee5ff7af4ec900000000262a6494dc486d2c8a34cb33fa90bf1b00"
+    "70ad3c498883c9367c09a2be785abc55cd226097a3a982117283f82a03a143efd3"
+    "ff5dd36d64e861be7fd61d2827db279cce145077d454a3664d4e6da4d29ee03725"
+    "a6a4dafcd0fc67d2aea70529513e3da2677fa5906c5b3f7d8f92f228bda40dda72"
+    "1470f9fbf297b5aea617646fac5c03272e970727c621a79141ef5f7de6505e5bfb"
+    "c388e93343694093934ae4d357"
+)
+known_psk_secret = "4ecd0eb6ec3b4d87f5d6028f922ca4c5851a277fd41311c9e62d2c9492e1c4f3"
 
 # Arbitrary test vectors
-PSK_IDENTITY_LIST = [known_psk_identity, 'psk_identity', 'test_psk_identity']
-PSK_SECRET_LIST = [known_psk_secret, 'a6dadae4567876', 'a64dafcd0fc67d2a']
+PSK_IDENTITY_LIST = [known_psk_identity, "psk_identity", "test_psk_identity"]
+PSK_SECRET_LIST = [known_psk_secret, "a6dadae4567876", "a64dafcd0fc67d2a"]
 PSK_IDENTITY_NO_MATCH = "PSK_IDENTITY_NO_MATCH"
 PSK_SECRET_NO_MATCH = "e9492e1c"
 PSK_IDENTITY_NO_MATCH_2 = "PSK_IDENTITY_NO_MATCH_2"
@@ -37,14 +44,16 @@ class Outcome(Enum):
 
 
 def setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg):
-    return ['--psk', psk_identity + ',' + psk_secret + ',' + psk_hash_alg]
+    return ["--psk", psk_identity + "," + psk_secret + "," + psk_hash_alg]
 
 
 def setup_openssl_psk_params(psk_identity, psk_secret):
-    return ['-psk_identity', psk_identity, '--psk', psk_secret]
+    return ["-psk_identity", psk_identity, "--psk", psk_secret]
 
 
-def setup_provider_options(mode, port, cipher, curve, certificate, data_to_send, client_psk_params):
+def setup_provider_options(
+    mode, port, cipher, curve, certificate, data_to_send, client_psk_params
+):
     options = ProviderOptions(
         host="localhost",
         port=port,
@@ -54,7 +63,8 @@ def setup_provider_options(mode, port, cipher, curve, certificate, data_to_send,
         protocol=Protocols.TLS13,
         data_to_send=data_to_send,
         mode=mode,
-        extra_flags=client_psk_params)
+        extra_flags=client_psk_params,
+    )
     if certificate:
         options.key = certificate.key
         options.cert = certificate.cert
@@ -64,10 +74,10 @@ def setup_provider_options(mode, port, cipher, curve, certificate, data_to_send,
 
 def get_psk_hash_alg_from_cipher(cipher):
     # S2N supports only SHA256 and SHA384 PSK Hash Algorithms
-    if 'SHA256' in cipher.name:
-        return 'SHA256'
-    elif 'SHA384' in cipher.name:
-        return 'SHA384'
+    if "SHA256" in cipher.name:
+        return "SHA256"
+    elif "SHA384" in cipher.name:
+        return "SHA384"
     else:
         return None
 
@@ -79,29 +89,33 @@ def skip_invalid_psk_tests(provider, psk_hash_alg):
 
     # In OpenSSL, PSK works only with TLS1.3 ciphersuites based on SHA256 hash algorithm which includes
     # all TLS1.3 ciphersuites supported by S2N except TLS_AES_256_GCM_SHA384.
-    if provider == OpenSSL and psk_hash_alg == 'SHA384':
+    if provider == OpenSSL and psk_hash_alg == "SHA384":
         pytest.skip()
 
 
 def validate_negotiated_psk_s2n(outcome, psk_identity, results):
     if outcome == Outcome.psk_connection:
-        assert to_bytes("Negotiated PSK identity: {}".format(
-            psk_identity)) in results.stdout
+        assert (
+            to_bytes("Negotiated PSK identity: {}".format(psk_identity))
+            in results.stdout
+        )
     elif outcome == Outcome.full_handshake:
-        assert to_bytes("Negotiated PSK identity: {}".format(
-            psk_identity)) not in results.stdout
+        assert (
+            to_bytes("Negotiated PSK identity: {}".format(psk_identity))
+            not in results.stdout
+        )
     else:
         assert results.exit_code != 0
-        assert to_bytes(
-            "Failed to negotiate: 'TLS alert received'") in results.stderr
+        assert to_bytes("Failed to negotiate: 'TLS alert received'") in results.stderr
 
 
 def validate_negotiated_psk_openssl(outcome, results):
     if outcome == Outcome.psk_connection:
-        assert to_bytes("extension \"psk\"") in results.stdout
+        assert to_bytes('extension "psk"') in results.stdout
     elif outcome == Outcome.full_handshake:
-        assert to_bytes(
-            "SSL_connect:SSLv3/TLS read server certificate") in results.stderr
+        assert (
+            to_bytes("SSL_connect:SSLv3/TLS read server certificate") in results.stderr
+        )
     else:
         assert to_bytes("SSL_accept:error in error") in results.stderr
 
@@ -130,42 +144,49 @@ Tests a single psk connection with no fallback option.
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("psk_identity", PSK_IDENTITY_LIST, ids=get_parameter_name)
 @pytest.mark.parametrize("psk_secret", PSK_SECRET_LIST, ids=get_parameter_name)
-def test_s2n_server_psk_connection(managed_process, cipher, curve, protocol, provider, other_provider, psk_identity,
-                                   psk_secret):
+def test_s2n_server_psk_connection(
+    managed_process,
+    cipher,
+    curve,
+    protocol,
+    provider,
+    other_provider,
+    psk_identity,
+    psk_secret,
+):
     port = next(available_ports)
     random_bytes = data_bytes(10)
     psk_hash_alg = get_psk_hash_alg_from_cipher(cipher)
     skip_invalid_psk_tests(provider, psk_hash_alg)
 
     if provider == S2N:
-        client_psk_params = setup_s2n_psk_params(
-            psk_identity, psk_secret, psk_hash_alg)
+        client_psk_params = setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
     else:
         client_psk_params = setup_openssl_psk_params(psk_identity, psk_secret)
     client_options = setup_provider_options(
-        provider.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params)
+        provider.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params
+    )
 
-    server_psk_params = setup_s2n_psk_params(
-        psk_identity, psk_secret, psk_hash_alg)
+    server_psk_params = setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
     server_options = setup_provider_options(
-        S2N.ServerMode, port, cipher, curve, None, None, server_psk_params)
+        S2N.ServerMode, port, cipher, curve, None, None, server_psk_params
+    )
 
     server = managed_process(
-        S2N, server_options, timeout=5, close_marker=str(random_bytes))
+        S2N, server_options, timeout=5, close_marker=str(random_bytes)
+    )
     client = managed_process(provider, client_options, timeout=5)
 
     for results in client.get_results():
         results.assert_success()
         if provider == S2N:
-            validate_negotiated_psk_s2n(
-                Outcome.psk_connection, psk_identity, results)
+            validate_negotiated_psk_s2n(Outcome.psk_connection, psk_identity, results)
         else:
             validate_negotiated_psk_openssl(Outcome.psk_connection, results)
 
     for results in server.get_results():
         results.assert_success()
-        validate_negotiated_psk_s2n(
-            Outcome.psk_connection, psk_identity, results)
+        validate_negotiated_psk_s2n(Outcome.psk_connection, psk_identity, results)
         assert random_bytes in results.stdout
 
 
@@ -184,8 +205,16 @@ Note that OpenSSL does not support multiple PSKs.
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("psk_identity", PSK_IDENTITY_LIST, ids=get_parameter_name)
 @pytest.mark.parametrize("psk_secret", PSK_SECRET_LIST, ids=get_parameter_name)
-def test_s2n_server_multiple_psks(managed_process, cipher, curve, protocol, provider, other_provider, psk_identity,
-                                  psk_secret):
+def test_s2n_server_multiple_psks(
+    managed_process,
+    cipher,
+    curve,
+    protocol,
+    provider,
+    other_provider,
+    psk_identity,
+    psk_secret,
+):
     port = next(available_ports)
     random_bytes = data_bytes(10)
     psk_hash_alg = get_psk_hash_alg_from_cipher(cipher)
@@ -197,41 +226,48 @@ def test_s2n_server_multiple_psks(managed_process, cipher, curve, protocol, prov
         OpenSSL Provider does not support multiple PSKs in the same connection, 
         the last psk parameter is the psk parameter used in the connection. 
         """
-        client_psk_params.extend(setup_openssl_psk_params(
-            PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH))
         client_psk_params.extend(
-            setup_openssl_psk_params(psk_identity, psk_secret))
+            setup_openssl_psk_params(PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH)
+        )
+        client_psk_params.extend(setup_openssl_psk_params(psk_identity, psk_secret))
     else:
-        client_psk_params.extend(setup_s2n_psk_params(
-            PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH, psk_hash_alg))
-        client_psk_params.extend(setup_s2n_psk_params(
-            psk_identity, psk_secret, psk_hash_alg))
+        client_psk_params.extend(
+            setup_s2n_psk_params(
+                PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH, psk_hash_alg
+            )
+        )
+        client_psk_params.extend(
+            setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
+        )
     client_options = setup_provider_options(
-        provider.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params)
+        provider.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params
+    )
 
-    server_psk_params = setup_s2n_psk_params(
-        psk_identity, psk_secret, psk_hash_alg)
-    server_psk_params.extend(setup_s2n_psk_params(
-        PSK_IDENTITY_NO_MATCH_2, PSK_SECRET_NO_MATCH_2, psk_hash_alg))
+    server_psk_params = setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
+    server_psk_params.extend(
+        setup_s2n_psk_params(
+            PSK_IDENTITY_NO_MATCH_2, PSK_SECRET_NO_MATCH_2, psk_hash_alg
+        )
+    )
     server_options = setup_provider_options(
-        S2N.ServerMode, port, cipher, curve, None, None, server_psk_params)
+        S2N.ServerMode, port, cipher, curve, None, None, server_psk_params
+    )
 
     server = managed_process(
-        S2N, server_options, timeout=5, close_marker=str(random_bytes))
+        S2N, server_options, timeout=5, close_marker=str(random_bytes)
+    )
     client = managed_process(provider, client_options, timeout=5)
 
     for results in client.get_results():
         results.assert_success()
         if provider == S2N:
-            validate_negotiated_psk_s2n(
-                Outcome.psk_connection, psk_identity, results)
+            validate_negotiated_psk_s2n(Outcome.psk_connection, psk_identity, results)
         else:
             validate_negotiated_psk_openssl(Outcome.psk_connection, results)
 
     for results in server.get_results():
         results.assert_success()
-        validate_negotiated_psk_s2n(
-            Outcome.psk_connection, psk_identity, results)
+        validate_negotiated_psk_s2n(Outcome.psk_connection, psk_identity, results)
         assert random_bytes in results.stdout
 
 
@@ -254,43 +290,63 @@ as the input.
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("psk_identity", PSK_IDENTITY_LIST, ids=get_parameter_name)
 @pytest.mark.parametrize("psk_secret", PSK_SECRET_LIST, ids=get_parameter_name)
-@pytest.mark.parametrize("certificate", ALL_TEST_CERTS_WITH_EMPTY_CERT, ids=get_parameter_name)
-def test_s2n_server_full_handshake(managed_process, cipher, curve, protocol, provider, other_provider, psk_identity,
-                                   psk_secret, certificate):
+@pytest.mark.parametrize(
+    "certificate", ALL_TEST_CERTS_WITH_EMPTY_CERT, ids=get_parameter_name
+)
+def test_s2n_server_full_handshake(
+    managed_process,
+    cipher,
+    curve,
+    protocol,
+    provider,
+    other_provider,
+    psk_identity,
+    psk_secret,
+    certificate,
+):
     port = next(available_ports)
     random_bytes = data_bytes(10)
     psk_hash_alg = get_psk_hash_alg_from_cipher(cipher)
     skip_invalid_psk_tests(provider, psk_hash_alg)
 
     if provider == S2N:
-        client_psk_params = setup_s2n_psk_params(
-            psk_identity, psk_secret, psk_hash_alg)
+        client_psk_params = setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
     else:
         client_psk_params = setup_openssl_psk_params(psk_identity, psk_secret)
     client_options = setup_provider_options(
-        provider.ClientMode, port, cipher, curve, certificate, random_bytes, client_psk_params)
+        provider.ClientMode,
+        port,
+        cipher,
+        curve,
+        certificate,
+        random_bytes,
+        client_psk_params,
+    )
 
     server_psk_params = setup_s2n_psk_params(
-        PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH, psk_hash_alg)
+        PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH, psk_hash_alg
+    )
     server_options = setup_provider_options(
-        S2N.ServerMode, port, cipher, curve, certificate, None, server_psk_params)
+        S2N.ServerMode, port, cipher, curve, certificate, None, server_psk_params
+    )
 
     server = managed_process(
-        S2N, server_options, timeout=5, close_marker=str(random_bytes))
+        S2N, server_options, timeout=5, close_marker=str(random_bytes)
+    )
     client = managed_process(provider, client_options, timeout=5)
 
     for results in client.get_results():
         results.assert_success()
         if provider == S2N:
-            validate_negotiated_psk_s2n(
-                Outcome.full_handshake, psk_identity, results)
+            validate_negotiated_psk_s2n(Outcome.full_handshake, psk_identity, results)
         else:
             validate_negotiated_psk_openssl(Outcome.full_handshake, results)
 
     for results in server.get_results():
         results.assert_success()
         validate_negotiated_psk_s2n(
-            Outcome.full_handshake, PSK_IDENTITY_NO_MATCH, results)
+            Outcome.full_handshake, PSK_IDENTITY_NO_MATCH, results
+        )
         assert random_bytes in results.stdout
 
 
@@ -309,41 +365,48 @@ Tests a single psk connection with no fallback option.
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("psk_identity", PSK_IDENTITY_LIST, ids=get_parameter_name)
 @pytest.mark.parametrize("psk_secret", PSK_SECRET_LIST, ids=get_parameter_name)
-def test_s2n_client_psk_connection(managed_process, cipher, curve, protocol, provider, other_provider, psk_identity,
-                                   psk_secret):
+def test_s2n_client_psk_connection(
+    managed_process,
+    cipher,
+    curve,
+    protocol,
+    provider,
+    other_provider,
+    psk_identity,
+    psk_secret,
+):
     port = next(available_ports)
     random_bytes = data_bytes(10)
     psk_hash_alg = get_psk_hash_alg_from_cipher(cipher)
     skip_invalid_psk_tests(provider, psk_hash_alg)
 
-    client_psk_params = setup_s2n_psk_params(
-        psk_identity, psk_secret, psk_hash_alg)
+    client_psk_params = setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
     client_options = setup_provider_options(
-        S2N.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params)
+        S2N.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params
+    )
 
     if provider == S2N:
-        server_psk_params = setup_s2n_psk_params(
-            psk_identity, psk_secret, psk_hash_alg)
+        server_psk_params = setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
     else:
         server_psk_params = setup_openssl_psk_params(psk_identity, psk_secret)
-        server_psk_params += ['-nocert']
+        server_psk_params += ["-nocert"]
     server_options = setup_provider_options(
-        provider.ServerMode, port, cipher, curve, None, None, server_psk_params)
+        provider.ServerMode, port, cipher, curve, None, None, server_psk_params
+    )
 
-    server = managed_process(provider, server_options,
-                             timeout=5, close_marker=str(random_bytes))
+    server = managed_process(
+        provider, server_options, timeout=5, close_marker=str(random_bytes)
+    )
     client = managed_process(S2N, client_options, timeout=5)
 
     for results in client.get_results():
         results.assert_success()
-        validate_negotiated_psk_s2n(
-            Outcome.psk_connection, psk_identity, results)
+        validate_negotiated_psk_s2n(Outcome.psk_connection, psk_identity, results)
 
     for results in server.get_results():
         results.assert_success()
         if provider == S2N:
-            validate_negotiated_psk_s2n(
-                Outcome.psk_connection, psk_identity, results)
+            validate_negotiated_psk_s2n(Outcome.psk_connection, psk_identity, results)
         else:
             validate_negotiated_psk_openssl(Outcome.psk_connection, results)
         assert random_bytes in results.stdout
@@ -364,19 +427,28 @@ Note that OpenSSL does not support multiple PSKs.
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("psk_identity", PSK_IDENTITY_LIST, ids=get_parameter_name)
 @pytest.mark.parametrize("psk_secret", PSK_SECRET_LIST, ids=get_parameter_name)
-def test_s2n_client_multiple_psks(managed_process, cipher, curve, protocol, provider, other_provider, psk_identity,
-                                  psk_secret):
+def test_s2n_client_multiple_psks(
+    managed_process,
+    cipher,
+    curve,
+    protocol,
+    provider,
+    other_provider,
+    psk_identity,
+    psk_secret,
+):
     port = next(available_ports)
     random_bytes = data_bytes(10)
     psk_hash_alg = get_psk_hash_alg_from_cipher(cipher)
     skip_invalid_psk_tests(provider, psk_hash_alg)
 
-    client_psk_params = setup_s2n_psk_params(
-        psk_identity, psk_secret, psk_hash_alg)
-    client_psk_params.extend(setup_s2n_psk_params(
-        PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH, psk_hash_alg))
+    client_psk_params = setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
+    client_psk_params.extend(
+        setup_s2n_psk_params(PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH, psk_hash_alg)
+    )
     client_options = setup_provider_options(
-        S2N.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params)
+        S2N.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params
+    )
 
     server_psk_params = []
     if provider == OpenSSL:
@@ -384,33 +456,37 @@ def test_s2n_client_multiple_psks(managed_process, cipher, curve, protocol, prov
         OpenSSL Provider does not support multiple PSKs in the same connection, 
         the last psk params is the final psk used in the connection. 
         """
-        server_psk_params.extend(setup_openssl_psk_params(
-            PSK_IDENTITY_NO_MATCH_2, PSK_SECRET_NO_MATCH_2))
         server_psk_params.extend(
-            setup_openssl_psk_params(psk_identity, psk_secret))
-        server_psk_params += ['-nocert']
+            setup_openssl_psk_params(PSK_IDENTITY_NO_MATCH_2, PSK_SECRET_NO_MATCH_2)
+        )
+        server_psk_params.extend(setup_openssl_psk_params(psk_identity, psk_secret))
+        server_psk_params += ["-nocert"]
     else:
-        server_psk_params.extend(setup_s2n_psk_params(
-            PSK_IDENTITY_NO_MATCH_2, PSK_SECRET_NO_MATCH_2, psk_hash_alg))
-        server_psk_params.extend(setup_s2n_psk_params(
-            psk_identity, psk_secret, psk_hash_alg))
+        server_psk_params.extend(
+            setup_s2n_psk_params(
+                PSK_IDENTITY_NO_MATCH_2, PSK_SECRET_NO_MATCH_2, psk_hash_alg
+            )
+        )
+        server_psk_params.extend(
+            setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
+        )
     server_options = setup_provider_options(
-        provider.ServerMode, port, cipher, curve, None, None, server_psk_params)
+        provider.ServerMode, port, cipher, curve, None, None, server_psk_params
+    )
 
-    server = managed_process(provider, server_options,
-                             timeout=5, close_marker=str(random_bytes))
+    server = managed_process(
+        provider, server_options, timeout=5, close_marker=str(random_bytes)
+    )
     client = managed_process(S2N, client_options, timeout=5)
 
     for results in client.get_results():
         results.assert_success()
-        validate_negotiated_psk_s2n(
-            Outcome.psk_connection, psk_identity, results)
+        validate_negotiated_psk_s2n(Outcome.psk_connection, psk_identity, results)
 
     for results in server.get_results():
         results.assert_success()
         if provider == S2N:
-            validate_negotiated_psk_s2n(
-                Outcome.psk_connection, psk_identity, results)
+            validate_negotiated_psk_s2n(Outcome.psk_connection, psk_identity, results)
         else:
             validate_negotiated_psk_openssl(Outcome.psk_connection, results)
         assert random_bytes in results.stdout
@@ -432,32 +508,35 @@ uses a default certificate if a certificate is not provided as the input.
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("psk_identity", PSK_IDENTITY_LIST, ids=get_parameter_name)
 @pytest.mark.parametrize("psk_secret", PSK_SECRET_LIST, ids=get_parameter_name)
-def test_s2n_client_psk_handshake_failure(managed_process, cipher, curve, protocol, provider, psk_identity, psk_secret):
+def test_s2n_client_psk_handshake_failure(
+    managed_process, cipher, curve, protocol, provider, psk_identity, psk_secret
+):
     port = next(available_ports)
     random_bytes = data_bytes(10)
     psk_hash_alg = get_psk_hash_alg_from_cipher(cipher)
     skip_invalid_psk_tests(provider, psk_hash_alg)
 
-    client_psk_params = setup_s2n_psk_params(
-        psk_identity, psk_secret, psk_hash_alg)
+    client_psk_params = setup_s2n_psk_params(psk_identity, psk_secret, psk_hash_alg)
     client_options = setup_provider_options(
-        S2N.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params)
+        S2N.ClientMode, port, cipher, curve, None, random_bytes, client_psk_params
+    )
 
     server_psk_params = setup_openssl_psk_params(
-        PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH)
-    server_psk_params += ['-nocert']
+        PSK_IDENTITY_NO_MATCH, PSK_SECRET_NO_MATCH
+    )
+    server_psk_params += ["-nocert"]
     server_options = setup_provider_options(
-        provider.ServerMode, port, cipher, curve, None, None, server_psk_params)
+        provider.ServerMode, port, cipher, curve, None, None, server_psk_params
+    )
 
-    server = managed_process(provider, server_options,
-                             timeout=5, close_marker=str(random_bytes))
+    server = managed_process(
+        provider, server_options, timeout=5, close_marker=str(random_bytes)
+    )
     client = managed_process(S2N, client_options, timeout=5)
 
     for results in client.get_results():
-        assert to_bytes(
-            "Failed to negotiate: 'TLS alert received'") in results.stderr
-        validate_negotiated_psk_s2n(
-            Outcome.handshake_failed, psk_identity, results)
+        assert to_bytes("Failed to negotiate: 'TLS alert received'") in results.stderr
+        validate_negotiated_psk_s2n(Outcome.handshake_failed, psk_identity, results)
 
     for results in server.get_results():
         assert to_bytes("SSL_accept:error in error") in results.stderr

--- a/tests/integrationv2/test_fragmentation.py
+++ b/tests/integrationv2/test_fragmentation.py
@@ -7,19 +7,21 @@ from configuration import available_ports, PROTOCOLS
 from common import ProviderOptions, Ciphers, Certificates, data_bytes
 from fixtures import managed_process  # lgtm [py/unused-import]
 from providers import Provider, S2N, OpenSSL, GnuTLS
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
+from utils import (
+    invalid_test_parameters,
+    get_parameter_name,
+    get_expected_s2n_version,
+    to_bytes,
+)
 
 
 CIPHERS_TO_TEST = [
     Ciphers.AES256_SHA,
     Ciphers.ECDHE_ECDSA_AES256_SHA,
-    Ciphers.AES256_GCM_SHA384
+    Ciphers.AES256_GCM_SHA384,
 ]
 
-CERTIFICATES_TO_TEST = [
-    Certificates.RSA_4096_SHA384,
-    Certificates.ECDSA_384
-]
+CERTIFICATES_TO_TEST = [Certificates.RSA_4096_SHA384, Certificates.ECDSA_384]
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -28,10 +30,13 @@ CERTIFICATES_TO_TEST = [
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", CERTIFICATES_TO_TEST, ids=get_parameter_name)
-def test_s2n_server_low_latency(managed_process, cipher, provider, other_provider, protocol, certificate):
-    if provider is OpenSSL and 'openssl-1.0.2' in provider.get_version():
+def test_s2n_server_low_latency(
+    managed_process, cipher, provider, other_provider, protocol, certificate
+):
+    if provider is OpenSSL and "openssl-1.0.2" in provider.get_version():
         pytest.skip(
-            '{} does not allow setting max fragmentation for packets'.format(provider))
+            "{} does not allow setting max fragmentation for packets".format(provider)
+        )
 
     port = next(available_ports)
 
@@ -42,12 +47,13 @@ def test_s2n_server_low_latency(managed_process, cipher, provider, other_provide
         cipher=cipher,
         data_to_send=random_bytes,
         insecure=True,
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = copy.copy(client_options)
     server_options.data_to_send = None
     server_options.mode = Provider.ServerMode
-    server_options.extra_flags = ['--prefer-low-latency']
+    server_options.extra_flags = ["--prefer-low-latency"]
     server_options.key = certificate.key
     server_options.cert = certificate.cert
     server_options.cipher = None
@@ -62,8 +68,10 @@ def test_s2n_server_low_latency(managed_process, cipher, provider, other_provide
 
     for results in server.get_results():
         results.assert_success()
-        assert to_bytes("Actual protocol version: {}".format(
-            expected_version)) in results.stdout
+        assert (
+            to_bytes("Actual protocol version: {}".format(expected_version))
+            in results.stdout
+        )
         assert random_bytes in results.stdout
 
 
@@ -85,12 +93,16 @@ def invalid_test_parameters_frag_len(*args, **kwargs):
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", CERTIFICATES_TO_TEST, ids=get_parameter_name)
-@pytest.mark.parametrize("frag_len", [512, 2048, 8192, 12345, 16384], ids=get_parameter_name)
-def test_s2n_server_framented_data(managed_process, cipher, provider, other_provider, protocol, certificate,
-                                   frag_len):
-    if provider is OpenSSL and 'openssl-1.0.2' in provider.get_version():
+@pytest.mark.parametrize(
+    "frag_len", [512, 2048, 8192, 12345, 16384], ids=get_parameter_name
+)
+def test_s2n_server_framented_data(
+    managed_process, cipher, provider, other_provider, protocol, certificate, frag_len
+):
+    if provider is OpenSSL and "openssl-1.0.2" in provider.get_version():
         pytest.skip(
-            '{} does not allow setting max fragmentation for packets'.format(provider))
+            "{} does not allow setting max fragmentation for packets".format(provider)
+        )
 
     port = next(available_ports)
 
@@ -102,7 +114,7 @@ def test_s2n_server_framented_data(managed_process, cipher, provider, other_prov
         data_to_send=random_bytes,
         insecure=True,
         record_size=frag_len,
-        protocol=protocol
+        protocol=protocol,
     )
 
     server_options = copy.copy(client_options)
@@ -123,8 +135,10 @@ def test_s2n_server_framented_data(managed_process, cipher, provider, other_prov
 
     for server_results in server.get_results():
         server_results.assert_success()
-        assert to_bytes("Actual protocol version: {}".format(
-            expected_version)) in server_results.stdout
+        assert (
+            to_bytes("Actual protocol version: {}".format(expected_version))
+            in server_results.stdout
+        )
 
         if provider == GnuTLS:
             # GnuTLS ignores data sent through stdin past frag_len up to the application data

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -3,11 +3,22 @@
 import copy
 import pytest
 
-from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS, PROTOCOLS
+from configuration import (
+    available_ports,
+    ALL_TEST_CIPHERS,
+    ALL_TEST_CURVES,
+    ALL_TEST_CERTS,
+    PROTOCOLS,
+)
 from common import ProviderOptions, data_bytes
 from fixtures import managed_process  # lgtm [py/unused-import]
 from providers import Provider, S2N, OpenSSL, JavaSSL, GnuTLS, SSLv3Provider
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
+from utils import (
+    invalid_test_parameters,
+    get_parameter_name,
+    get_expected_s2n_version,
+    to_bytes,
+)
 
 
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
@@ -17,7 +28,9 @@ from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
-def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protocol, certificate):
+def test_s2n_server_happy_path(
+    managed_process, cipher, provider, curve, protocol, certificate
+):
     port = next(available_ports)
 
     # s2nd can receive large amounts of data because all the data is
@@ -34,7 +47,7 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
         curve=curve,
         data_to_send=random_bytes,
         insecure=True,
-        protocol=protocol
+        protocol=protocol,
     )
 
     server_options = copy.copy(client_options)
@@ -60,13 +73,17 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
     # the stdout reliably.
     for server_results in server.get_results():
         server_results.assert_success()
-        assert to_bytes("Actual protocol version: {}".format(
-            expected_version)) in server_results.stdout
+        assert (
+            to_bytes("Actual protocol version: {}".format(expected_version))
+            in server_results.stdout
+        )
         assert random_bytes in server_results.stdout
 
         if provider is not S2N:
-            assert to_bytes("Cipher negotiated: {}".format(
-                cipher.name)) in server_results.stdout
+            assert (
+                to_bytes("Cipher negotiated: {}".format(cipher.name))
+                in server_results.stdout
+            )
 
 
 @pytest.mark.flaky(reruns=5, reruns_delay=2)
@@ -76,7 +93,9 @@ def test_s2n_server_happy_path(managed_process, cipher, provider, curve, protoco
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
-def test_s2n_client_happy_path(managed_process, cipher, provider, curve, protocol, certificate):
+def test_s2n_client_happy_path(
+    managed_process, cipher, provider, curve, protocol, certificate
+):
     port = next(available_ports)
 
     # We can only send 4096 - 1 (\n at the end) bytes here because of the
@@ -108,8 +127,9 @@ def test_s2n_client_happy_path(managed_process, cipher, provider, curve, protoco
 
     # Passing the type of client and server as a parameter will
     # allow us to use a fixture to enumerate all possibilities.
-    server = managed_process(provider, server_options,
-                             timeout=5, kill_marker=kill_marker)
+    server = managed_process(
+        provider, server_options, timeout=5, kill_marker=kill_marker
+    )
     client = managed_process(S2N, client_options, timeout=5)
 
     expected_version = get_expected_s2n_version(protocol, provider)
@@ -118,8 +138,10 @@ def test_s2n_client_happy_path(managed_process, cipher, provider, curve, protoco
     # the stdout reliably.
     for client_results in client.get_results():
         client_results.assert_success()
-        assert to_bytes("Actual protocol version: {}".format(
-            expected_version)) in client_results.stdout
+        assert (
+            to_bytes("Actual protocol version: {}".format(expected_version))
+            in client_results.stdout
+        )
 
     # The server will be one of all supported providers. We
     # just want to make sure there was no exception and that
@@ -128,4 +150,5 @@ def test_s2n_client_happy_path(managed_process, cipher, provider, curve, protoco
         server_results.assert_success()
         # Avoid debugging information that sometimes gets inserted after the first character.
         assert any(
-            [random_bytes[1:] in stream for stream in server_results.output_streams()])
+            [random_bytes[1:] in stream for stream in server_results.output_streams()]
+        )

--- a/tests/integrationv2/test_hello_retry_requests.py
+++ b/tests/integrationv2/test_hello_retry_requests.py
@@ -4,7 +4,12 @@ import copy
 import pytest
 import re
 
-from configuration import available_ports, TLS13_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS
+from configuration import (
+    available_ports,
+    TLS13_CIPHERS,
+    ALL_TEST_CURVES,
+    ALL_TEST_CERTS,
+)
 from common import ProviderOptions, Protocols, data_bytes, Curves
 from fixtures import managed_process  # lgtm [py/unused-import]
 from providers import Provider, S2N, OpenSSL
@@ -18,7 +23,7 @@ CURVE_NAMES = {
     "X25519": "x25519",
     "P-256": "secp256r1",
     "P-384": "secp384r1",
-    "P-521": "secp521r1"
+    "P-521": "secp521r1",
 }
 
 
@@ -38,7 +43,9 @@ def test_nothing():
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
-def test_hrr_with_s2n_as_client(managed_process, cipher, provider, other_provider, curve, protocol, certificate):
+def test_hrr_with_s2n_as_client(
+    managed_process, cipher, provider, other_provider, curve, protocol, certificate
+):
     if curve == S2N_DEFAULT_CURVE:
         pytest.skip("No retry if server curve matches client curve")
 
@@ -51,7 +58,8 @@ def test_hrr_with_s2n_as_client(managed_process, cipher, provider, other_provide
         cipher=cipher,
         data_to_send=random_bytes,
         insecure=True,
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = copy.copy(client_options)
     server_options.data_to_send = None
@@ -69,8 +77,7 @@ def test_hrr_with_s2n_as_client(managed_process, cipher, provider, other_provide
     # The client should connect and return without error
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes("Curve: {}".format(
-            CURVE_NAMES[curve.name])) in results.stdout
+        assert to_bytes("Curve: {}".format(CURVE_NAMES[curve.name])) in results.stdout
         assert S2N_HRR_MARKER in results.stdout
 
     marker_part1 = b"cf 21 ad 74 e5"
@@ -80,9 +87,17 @@ def test_hrr_with_s2n_as_client(managed_process, cipher, provider, other_provide
         results.assert_success()
         assert marker_part1 in results.stdout and marker_part2 in results.stdout
         # The "test_all" s2n security policy includes draft Hybrid PQ groups that Openssl server prints as hex values
-        assert re.search(b'Supported Elliptic Groups: [x0-9A-F:]*X25519:P-256:P-384', results.stdout) is not None
-        assert to_bytes("Shared Elliptic groups: {}".format(
-            server_options.curve)) in results.stdout
+        assert (
+            re.search(
+                b"Supported Elliptic Groups: [x0-9A-F:]*X25519:P-256:P-384",
+                results.stdout,
+            )
+            is not None
+        )
+        assert (
+            to_bytes("Shared Elliptic groups: {}".format(server_options.curve))
+            in results.stdout
+        )
         assert random_bytes in results.stdout
 
 
@@ -93,7 +108,9 @@ def test_hrr_with_s2n_as_client(managed_process, cipher, provider, other_provide
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
-def test_hrr_with_s2n_as_server(managed_process, cipher, provider, other_provider, curve, protocol, certificate):
+def test_hrr_with_s2n_as_server(
+    managed_process, cipher, provider, other_provider, curve, protocol, certificate
+):
     port = next(available_ports)
 
     random_bytes = data_bytes(64)
@@ -104,8 +121,9 @@ def test_hrr_with_s2n_as_server(managed_process, cipher, provider, other_provide
         data_to_send=random_bytes,
         insecure=True,
         curve=curve,
-        extra_flags=['-msg', '-curves', 'X448:'+str(curve)],
-        protocol=protocol)
+        extra_flags=["-msg", "-curves", "X448:" + str(curve)],
+        protocol=protocol,
+    )
 
     server_options = copy.copy(client_options)
     server_options.data_to_send = None
@@ -123,8 +141,7 @@ def test_hrr_with_s2n_as_server(managed_process, cipher, provider, other_provide
     for results in server.get_results():
         results.assert_success()
         assert random_bytes in results.stdout
-        assert to_bytes("Curve: {}".format(
-            CURVE_NAMES[curve.name])) in results.stdout
+        assert to_bytes("Curve: {}".format(CURVE_NAMES[curve.name])) in results.stdout
         assert random_bytes in results.stdout
         assert S2N_HRR_MARKER in results.stdout
 
@@ -137,9 +154,9 @@ def test_hrr_with_s2n_as_server(managed_process, cipher, provider, other_provide
     for results in client.get_results():
         results.assert_success()
         assert marker in results.stdout
-        client_hello_count = results.stdout.count(b'ClientHello')
-        server_hello_count = results.stdout.count(b'ServerHello')
-        finished_count = results.stdout.count(b'Finished')
+        client_hello_count = results.stdout.count(b"ClientHello")
+        server_hello_count = results.stdout.count(b"ServerHello")
+        finished_count = results.stdout.count(b"Finished")
 
     assert client_hello_count == 2
     assert server_hello_count == 2
@@ -157,7 +174,9 @@ TEST_CURVES = ALL_TEST_CURVES[1:]
 @pytest.mark.parametrize("curve", TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
-def test_hrr_with_default_keyshare(managed_process, cipher, provider, other_provider, curve, protocol, certificate):
+def test_hrr_with_default_keyshare(
+    managed_process, cipher, provider, other_provider, curve, protocol, certificate
+):
     port = next(available_ports)
 
     random_bytes = data_bytes(64)
@@ -167,7 +186,8 @@ def test_hrr_with_default_keyshare(managed_process, cipher, provider, other_prov
         cipher=cipher,
         data_to_send=random_bytes,
         insecure=True,
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = copy.copy(client_options)
     server_options.data_to_send = None
@@ -185,8 +205,7 @@ def test_hrr_with_default_keyshare(managed_process, cipher, provider, other_prov
     # The client should connect and return without error
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes("Curve: {}".format(
-            CURVE_NAMES[curve.name])) in results.stdout
+        assert to_bytes("Curve: {}".format(CURVE_NAMES[curve.name])) in results.stdout
         assert S2N_HRR_MARKER in results.stdout
 
     marker_part1 = b"cf 21 ad 74 e5"
@@ -196,7 +215,15 @@ def test_hrr_with_default_keyshare(managed_process, cipher, provider, other_prov
         results.assert_success()
         assert marker_part1 in results.stdout and marker_part2 in results.stdout
         # The "test_all" s2n security policy includes draft Hybrid PQ groups that Openssl server prints as hex values
-        assert re.search(b'Supported Elliptic Groups: [x0-9A-F:]*X25519:P-256:P-384', results.stdout) is not None
-        assert to_bytes("Shared Elliptic groups: {}".format(
-            server_options.curve)) in results.stdout
+        assert (
+            re.search(
+                b"Supported Elliptic Groups: [x0-9A-F:]*X25519:P-256:P-384",
+                results.stdout,
+            )
+            is not None
+        )
+        assert (
+            to_bytes("Shared Elliptic groups: {}".format(server_options.curve))
+            in results.stdout
+        )
         assert random_bytes in results.stdout

--- a/tests/integrationv2/test_key_update.py
+++ b/tests/integrationv2/test_key_update.py
@@ -28,7 +28,9 @@ def test_nothing():
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
-def test_s2n_server_key_update(managed_process, cipher, provider, other_provider, protocol):
+def test_s2n_server_key_update(
+    managed_process, cipher, provider, other_provider, protocol
+):
     host = "localhost"
     port = next(available_ports)
 
@@ -55,9 +57,7 @@ def test_s2n_server_key_update(managed_process, cipher, provider, other_provider
     server_options.cert = "../pems/ecdsa_p384_pkcs1_cert.pem"
     server_options.data_to_send = [SERVER_DATA.encode()]
 
-    server = managed_process(
-        S2N, server_options, send_marker=CLIENT_DATA, timeout=30
-    )
+    server = managed_process(S2N, server_options, send_marker=CLIENT_DATA, timeout=30)
     client = managed_process(
         provider,
         client_options,
@@ -82,7 +82,9 @@ def test_s2n_server_key_update(managed_process, cipher, provider, other_provider
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
-def test_s2n_client_key_update(managed_process, cipher, provider, other_provider, protocol):
+def test_s2n_client_key_update(
+    managed_process, cipher, provider, other_provider, protocol
+):
     host = "localhost"
     port = next(available_ports)
 

--- a/tests/integrationv2/test_npn.py
+++ b/tests/integrationv2/test_npn.py
@@ -3,7 +3,13 @@
 import copy
 import pytest
 
-from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, MINIMAL_TEST_CERTS, PROTOCOLS
+from configuration import (
+    available_ports,
+    ALL_TEST_CIPHERS,
+    ALL_TEST_CURVES,
+    MINIMAL_TEST_CERTS,
+    PROTOCOLS,
+)
 from common import ProviderOptions, Protocols
 from fixtures import managed_process  # lgtm [py/unused-import]
 from providers import OpenSSL, S2N, Provider
@@ -24,12 +30,14 @@ OPENSSL_CLIENT_NPN_MARKER = "Next protocol: (1) "
 OPENSSL_CLIENT_NPN_NO_OVERLAP_MARKER = "Next protocol: (2) "
 
 # Test lists
-PROTOCOL_LIST = 'http/1.1,h2,h3'
-PROTOCOL_LIST_ALT_ORDER = 'h2,h3,http/1.1'
-PROTOCOL_LIST_NO_OVERLAP = 'spdy'
+PROTOCOL_LIST = "http/1.1,h2,h3"
+PROTOCOL_LIST_ALT_ORDER = "h2,h3,http/1.1"
+PROTOCOL_LIST_NO_OVERLAP = "spdy"
 
 
-def s2n_client_npn_handshake(managed_process, cipher, curve, certificate, protocol, provider, server_list):
+def s2n_client_npn_handshake(
+    managed_process, cipher, curve, certificate, protocol, provider, server_list
+):
     options = ProviderOptions(
         port=next(available_ports),
         cipher=cipher,
@@ -43,12 +51,12 @@ def s2n_client_npn_handshake(managed_process, cipher, curve, certificate, protoc
     client_options = copy.copy(options)
     client_options.mode = Provider.ClientMode
     # Flags to turn on NPN for s2nc
-    client_options.extra_flags = ['--alpn', PROTOCOL_LIST, '--npn']
+    client_options.extra_flags = ["--alpn", PROTOCOL_LIST, "--npn"]
 
     server_options = copy.copy(options)
     server_options.mode = Provider.ServerMode
     # Flags to turn on NPN for OpenSSL server
-    server_options.extra_flags = ['-nextprotoneg', server_list]
+    server_options.extra_flags = ["-nextprotoneg", server_list]
 
     server = managed_process(provider, server_options, timeout=5)
     s2n_client = managed_process(S2N, client_options, timeout=5)
@@ -67,11 +75,20 @@ The s2n-tls client successfully negotiates an application protocol using NPN.
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
-def test_s2n_client_npn(managed_process, cipher, curve, certificate, protocol, provider):
-    s2n_client, server = s2n_client_npn_handshake(managed_process, cipher, curve, certificate, protocol, provider,
-                                                  server_list=PROTOCOL_LIST)
+def test_s2n_client_npn(
+    managed_process, cipher, curve, certificate, protocol, provider
+):
+    s2n_client, server = s2n_client_npn_handshake(
+        managed_process,
+        cipher,
+        curve,
+        certificate,
+        protocol,
+        provider,
+        server_list=PROTOCOL_LIST,
+    )
 
-    expected_protocol = 'http/1.1'
+    expected_protocol = "http/1.1"
 
     for results in server.get_results():
         results.assert_success()
@@ -94,11 +111,20 @@ The s2n-tls client chooses a server-preferred protocol.
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
-def test_s2n_client_npn_server_preference(managed_process, cipher, curve, certificate, protocol, provider):
-    s2n_client, server = s2n_client_npn_handshake(managed_process, cipher, curve, certificate, protocol, provider,
-                                                  server_list=PROTOCOL_LIST_ALT_ORDER)
+def test_s2n_client_npn_server_preference(
+    managed_process, cipher, curve, certificate, protocol, provider
+):
+    s2n_client, server = s2n_client_npn_handshake(
+        managed_process,
+        cipher,
+        curve,
+        certificate,
+        protocol,
+        provider,
+        server_list=PROTOCOL_LIST_ALT_ORDER,
+    )
 
-    expected_protocol = 'h2'
+    expected_protocol = "h2"
 
     for results in server.get_results():
         results.assert_success()
@@ -121,11 +147,20 @@ The s2n-tls client chooses its preferred protocol since there is no overlap.
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
-def test_s2n_client_npn_no_overlap(managed_process, cipher, curve, certificate, protocol, provider):
-    s2n_client, server = s2n_client_npn_handshake(managed_process, cipher, curve, certificate, protocol, provider,
-                                                  server_list=PROTOCOL_LIST_NO_OVERLAP)
+def test_s2n_client_npn_no_overlap(
+    managed_process, cipher, curve, certificate, protocol, provider
+):
+    s2n_client, server = s2n_client_npn_handshake(
+        managed_process,
+        cipher,
+        curve,
+        certificate,
+        protocol,
+        provider,
+        server_list=PROTOCOL_LIST_NO_OVERLAP,
+    )
 
-    expected_protocol = 'http/1.1'
+    expected_protocol = "http/1.1"
 
     for results in server.get_results():
         results.assert_success()
@@ -137,7 +172,9 @@ def test_s2n_client_npn_no_overlap(managed_process, cipher, curve, certificate, 
         assert to_bytes(S2N_APPLICATION_MARKER + expected_protocol) in results.stdout
 
 
-def s2n_server_npn_handshake(managed_process, cipher, curve, certificate, protocol, provider, server_list):
+def s2n_server_npn_handshake(
+    managed_process, cipher, curve, certificate, protocol, provider, server_list
+):
     options = ProviderOptions(
         port=next(available_ports),
         cipher=cipher,
@@ -151,12 +188,12 @@ def s2n_server_npn_handshake(managed_process, cipher, curve, certificate, protoc
     client_options = copy.copy(options)
     client_options.mode = Provider.ClientMode
     # Flags to turn on NPN for OpenSSL client
-    client_options.extra_flags = ['-nextprotoneg', PROTOCOL_LIST]
+    client_options.extra_flags = ["-nextprotoneg", PROTOCOL_LIST]
 
     server_options = copy.copy(options)
     server_options.mode = Provider.ServerMode
     # Flags to turn on NPN for s2nd.
-    server_options.extra_flags = ['--alpn', server_list, '--npn']
+    server_options.extra_flags = ["--alpn", server_list, "--npn"]
 
     s2n_server = managed_process(S2N, server_options, timeout=5)
     client = managed_process(provider, client_options, timeout=5)
@@ -175,14 +212,23 @@ The s2n-tls server successfully negotiates an application protocol using NPN.
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
-def test_s2n_server_npn(managed_process, cipher, curve, certificate, protocol, provider):
+def test_s2n_server_npn(
+    managed_process, cipher, curve, certificate, protocol, provider
+):
     # We only send one protocol on the s2n server
     # due to the fact that it re-purposes the alpn list(which only sends one protocol)
     # to work for the NPN list.
-    client, s2n_server = s2n_server_npn_handshake(managed_process, cipher, curve, certificate, protocol, provider,
-                                                  server_list='http/1.1')
+    client, s2n_server = s2n_server_npn_handshake(
+        managed_process,
+        cipher,
+        curve,
+        certificate,
+        protocol,
+        provider,
+        server_list="http/1.1",
+    )
 
-    expected_protocol = 'http/1.1'
+    expected_protocol = "http/1.1"
 
     for results in s2n_server.get_results():
         results.assert_success()
@@ -206,11 +252,20 @@ the client chooses its own protocol.
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
-def test_s2n_server_npn_no_overlap(managed_process, cipher, curve, certificate, protocol, provider):
-    client, s2n_server = s2n_server_npn_handshake(managed_process, cipher, curve, certificate, protocol, provider,
-                                                  server_list=PROTOCOL_LIST_NO_OVERLAP)
+def test_s2n_server_npn_no_overlap(
+    managed_process, cipher, curve, certificate, protocol, provider
+):
+    client, s2n_server = s2n_server_npn_handshake(
+        managed_process,
+        cipher,
+        curve,
+        certificate,
+        protocol,
+        provider,
+        server_list=PROTOCOL_LIST_NO_OVERLAP,
+    )
 
-    expected_protocol = 'http/1.1'
+    expected_protocol = "http/1.1"
 
     for results in s2n_server.get_results():
         results.assert_success()
@@ -219,4 +274,7 @@ def test_s2n_server_npn_no_overlap(managed_process, cipher, curve, certificate, 
 
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes(OPENSSL_CLIENT_NPN_NO_OVERLAP_MARKER + expected_protocol) in results.stdout
+        assert (
+            to_bytes(OPENSSL_CLIENT_NPN_NO_OVERLAP_MARKER + expected_protocol)
+            in results.stdout
+        )

--- a/tests/integrationv2/test_ocsp.py
+++ b/tests/integrationv2/test_ocsp.py
@@ -21,7 +21,9 @@ OCSP_CERTS = [Certificates.OCSP, Certificates.OCSP_ECDSA]
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", OCSP_CERTS, ids=get_parameter_name)
-def test_s2n_client_ocsp_response(managed_process, cipher, provider, other_provider, curve, protocol, certificate):
+def test_s2n_client_ocsp_response(
+    managed_process, cipher, provider, other_provider, curve, protocol, certificate
+):
     if "boringssl" in get_flag(S2N_PROVIDER_VERSION):
         pytest.skip("s2n-tls client with boringssl does not support ocsp")
 
@@ -36,7 +38,7 @@ def test_s2n_client_ocsp_response(managed_process, cipher, provider, other_provi
         protocol=protocol,
         insecure=True,
         data_to_send=random_bytes,
-        enable_client_ocsp=True
+        enable_client_ocsp=True,
     )
 
     server_options = ProviderOptions(
@@ -48,8 +50,8 @@ def test_s2n_client_ocsp_response(managed_process, cipher, provider, other_provi
         key=certificate.key,
         cert=certificate.cert,
         ocsp_response={
-            "RSA":  TEST_OCSP_DIRECTORY + "ocsp_response.der",
-            "EC":   TEST_OCSP_DIRECTORY + "ocsp_ecdsa_response.der"
+            "RSA": TEST_OCSP_DIRECTORY + "ocsp_response.der",
+            "EC": TEST_OCSP_DIRECTORY + "ocsp_ecdsa_response.der",
         }.get(certificate.algorithm),
     )
 
@@ -59,10 +61,7 @@ def test_s2n_client_ocsp_response(managed_process, cipher, provider, other_provi
         kill_marker = random_bytes
 
     server = managed_process(
-        provider,
-        server_options,
-        timeout=30,
-        kill_marker=kill_marker
+        provider, server_options, timeout=30, kill_marker=kill_marker
     )
     client = managed_process(S2N, client_options, timeout=30)
 
@@ -73,7 +72,10 @@ def test_s2n_client_ocsp_response(managed_process, cipher, provider, other_provi
     for server_results in server.get_results():
         server_results.assert_success()
         # Avoid debugging information that sometimes gets inserted after the first character.
-        assert random_bytes[1:] in server_results.stdout or random_bytes[1:] in server_results.stderr
+        assert (
+            random_bytes[1:] in server_results.stdout
+            or random_bytes[1:] in server_results.stderr
+        )
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -83,7 +85,9 @@ def test_s2n_client_ocsp_response(managed_process, cipher, provider, other_provi
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", OCSP_CERTS, ids=get_parameter_name)
-def test_s2n_server_ocsp_response(managed_process, cipher, provider, other_provider, curve, protocol, certificate):
+def test_s2n_server_ocsp_response(
+    managed_process, cipher, provider, other_provider, curve, protocol, certificate
+):
     port = next(available_ports)
 
     random_bytes = data_bytes(128)
@@ -95,7 +99,7 @@ def test_s2n_server_ocsp_response(managed_process, cipher, provider, other_provi
         protocol=protocol,
         insecure=True,
         data_to_send=random_bytes,
-        enable_client_ocsp=True
+        enable_client_ocsp=True,
     )
 
     server_options = ProviderOptions(
@@ -108,8 +112,8 @@ def test_s2n_server_ocsp_response(managed_process, cipher, provider, other_provi
         key=certificate.key,
         cert=certificate.cert,
         ocsp_response={
-            "RSA":  TEST_OCSP_DIRECTORY + "ocsp_response.der",
-            "EC":   TEST_OCSP_DIRECTORY + "ocsp_ecdsa_response.der"
+            "RSA": TEST_OCSP_DIRECTORY + "ocsp_response.der",
+            "EC": TEST_OCSP_DIRECTORY + "ocsp_ecdsa_response.der",
         }.get(certificate.algorithm),
     )
 
@@ -120,21 +124,27 @@ def test_s2n_server_ocsp_response(managed_process, cipher, provider, other_provi
         kill_marker = b"Sent: "
 
     server = managed_process(S2N, server_options, timeout=90)
-    client = managed_process(provider, client_options,
-                             timeout=90, kill_marker=kill_marker)
+    client = managed_process(
+        provider, client_options, timeout=90, kill_marker=kill_marker
+    )
 
     for client_results in client.get_results():
         client_results.assert_success()
 
-        assert any([
-            {
-                GnuTLS:  b"OCSP Response Information:\n\tResponse Status: Successful",
-                OpenSSL: b"OCSP Response Status: successful"
-            }.get(provider) in stream for stream in client_results.output_streams()
-        ])
+        assert any(
+            [
+                {
+                    GnuTLS: b"OCSP Response Information:\n\tResponse Status: Successful",
+                    OpenSSL: b"OCSP Response Status: successful",
+                }.get(provider)
+                in stream
+                for stream in client_results.output_streams()
+            ]
+        )
 
     for server_results in server.get_results():
         server_results.assert_success()
         # Avoid debugging information that sometimes gets inserted after the first character.
         assert any(
-            [random_bytes[1:] in stream for stream in server_results.output_streams()])
+            [random_bytes[1:] in stream for stream in server_results.output_streams()]
+        )

--- a/tests/integrationv2/test_pq_handshake.py
+++ b/tests/integrationv2/test_pq_handshake.py
@@ -4,7 +4,15 @@ import pytest
 import os
 
 from configuration import available_ports
-from common import Ciphers, Curves, ProviderOptions, Protocols, KemGroups, Certificates, pq_enabled
+from common import (
+    Ciphers,
+    Curves,
+    ProviderOptions,
+    Protocols,
+    KemGroups,
+    Certificates,
+    pq_enabled,
+)
 from fixtures import managed_process  # lgtm [py/unused-import]
 from providers import Provider, S2N, OpenSSL, BoringSSL
 from utils import invalid_test_parameters, get_parameter_name, to_bytes
@@ -28,33 +36,42 @@ KEM_GROUPS = [
 EXPECTED_RESULTS = {
     # The tuple keys have the form:
     # (client_{cipher, kem_group}, server_{cipher, kem_group}): {"cipher": {expected_cipher}, "kem_group": {expected_kem_group}}
-    (Ciphers.PQ_TLS_1_0_2023_01, Ciphers.PQ_TLS_1_0_2023_01):
-        {"cipher": "TLS_AES_256_GCM_SHA384",
-         "kem_group": "_kyber-512-r3"},
-    (KemGroups.P384_KYBER768R3, Ciphers.PQ_TLS_1_3_2023_06_01):
-        {"cipher": "AES256_GCM_SHA384",
-         "kem_group": "secp384r1_kyber-768-r3"},
-    (KemGroups.P521_KYBER1024R3, Ciphers.PQ_TLS_1_3_2023_06_01):
-        {"cipher": "AES256_GCM_SHA384",
-         "kem_group": "secp521r1_kyber-1024-r3"},
-    (Ciphers.PQ_TLS_1_3_2023_06_01, KemGroups.X25519Kyber768Draft00):
-        {"cipher": "TLS_AES_256_GCM_SHA384",
-         "kem_group": "X25519Kyber768Draft00"},
-    (Ciphers.PQ_TLS_1_3_2023_06_01, KemGroups.SecP256r1Kyber768Draft00):
-        {"cipher": "TLS_AES_256_GCM_SHA384",
-         "kem_group": "SecP256r1Kyber768Draft00"},
-    (Ciphers.PQ_TLS_1_3_2023_06_01, Ciphers.PQ_TLS_1_3_2023_06_01):
-        {"cipher": "TLS_AES_256_GCM_SHA384",
-         "kem_group": "SecP256r1Kyber768Draft00"},
-    (Ciphers.PQ_TLS_1_3_2023_06_01, Ciphers.KMS_TLS_1_0_2018_10):
-        {"cipher": "ECDHE-RSA-AES256-GCM-SHA384",
-         "kem_group": None},
-    (Ciphers.KMS_TLS_1_0_2018_10, Ciphers.PQ_TLS_1_3_2023_06_01):
-        {"cipher": "ECDHE-RSA-AES128-GCM-SHA256",
-         "kem_group": None},
-    (Ciphers.KMS_TLS_1_0_2018_10, Ciphers.KMS_TLS_1_0_2018_10):
-        {"cipher": "ECDHE-RSA-AES256-GCM-SHA384",
-         "kem_group": None},
+    (Ciphers.PQ_TLS_1_0_2023_01, Ciphers.PQ_TLS_1_0_2023_01): {
+        "cipher": "TLS_AES_256_GCM_SHA384",
+        "kem_group": "_kyber-512-r3",
+    },
+    (KemGroups.P384_KYBER768R3, Ciphers.PQ_TLS_1_3_2023_06_01): {
+        "cipher": "AES256_GCM_SHA384",
+        "kem_group": "secp384r1_kyber-768-r3",
+    },
+    (KemGroups.P521_KYBER1024R3, Ciphers.PQ_TLS_1_3_2023_06_01): {
+        "cipher": "AES256_GCM_SHA384",
+        "kem_group": "secp521r1_kyber-1024-r3",
+    },
+    (Ciphers.PQ_TLS_1_3_2023_06_01, KemGroups.X25519Kyber768Draft00): {
+        "cipher": "TLS_AES_256_GCM_SHA384",
+        "kem_group": "X25519Kyber768Draft00",
+    },
+    (Ciphers.PQ_TLS_1_3_2023_06_01, KemGroups.SecP256r1Kyber768Draft00): {
+        "cipher": "TLS_AES_256_GCM_SHA384",
+        "kem_group": "SecP256r1Kyber768Draft00",
+    },
+    (Ciphers.PQ_TLS_1_3_2023_06_01, Ciphers.PQ_TLS_1_3_2023_06_01): {
+        "cipher": "TLS_AES_256_GCM_SHA384",
+        "kem_group": "SecP256r1Kyber768Draft00",
+    },
+    (Ciphers.PQ_TLS_1_3_2023_06_01, Ciphers.KMS_TLS_1_0_2018_10): {
+        "cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+        "kem_group": None,
+    },
+    (Ciphers.KMS_TLS_1_0_2018_10, Ciphers.PQ_TLS_1_3_2023_06_01): {
+        "cipher": "ECDHE-RSA-AES128-GCM-SHA256",
+        "kem_group": None,
+    },
+    (Ciphers.KMS_TLS_1_0_2018_10, Ciphers.KMS_TLS_1_0_2018_10): {
+        "cipher": "ECDHE-RSA-AES256-GCM-SHA384",
+        "kem_group": None,
+    },
 }
 
 """
@@ -73,7 +90,9 @@ def invalid_pq_handshake_test_parameters(*args, **kwargs):
 
     # `or` is correct: invalid_test_parameters() returns True if the parameters are invalid;
     # we want to return True here if either of the sets of parameters are invalid.
-    return invalid_test_parameters(*args, **client_cipher_kwargs) or invalid_test_parameters(*args, **server_cipher_kwargs)
+    return invalid_test_parameters(
+        *args, **client_cipher_kwargs
+    ) or invalid_test_parameters(*args, **server_cipher_kwargs)
 
 
 def get_oqs_openssl_override_env_vars():
@@ -88,14 +107,16 @@ def get_oqs_openssl_override_env_vars():
 
 def assert_s2n_negotiation_parameters(s2n_results, expected_result):
     if expected_result is not None:
-        assert to_bytes(
-            ("Cipher negotiated: " + expected_result['cipher'])) in s2n_results.stdout
-        if expected_result['kem_group']:
+        assert (
+            to_bytes(("Cipher negotiated: " + expected_result["cipher"]))
+            in s2n_results.stdout
+        )
+        if expected_result["kem_group"]:
             # Purposefully leave off the "KEM Group: " prefix in order to perform partial matches
             # without specifying the curve.
-            assert to_bytes(expected_result['kem_group']) in s2n_results.stdout
+            assert to_bytes(expected_result["kem_group"]) in s2n_results.stdout
             assert to_bytes(PQ_ENABLED_FLAG) in s2n_results.stdout
-        if not expected_result['kem_group']:
+        if not expected_result["kem_group"]:
             assert to_bytes(PQ_ENABLED_FLAG) not in s2n_results.stdout
             assert to_bytes("Curve:") in s2n_results.stdout
 
@@ -103,8 +124,8 @@ def assert_s2n_negotiation_parameters(s2n_results, expected_result):
 def assert_awslc_negotiation_parameters(awslc_results, expected_result):
     assert expected_result is not None
     assert awslc_results.exit_code is 0
-    assert to_bytes(("group: " + expected_result['kem_group'])) in awslc_results.stderr
-    assert to_bytes(("Cipher: " + expected_result['cipher'])) in awslc_results.stderr
+    assert to_bytes(("group: " + expected_result["kem_group"])) in awslc_results.stderr
+    assert to_bytes(("Cipher: " + expected_result["cipher"])) in awslc_results.stderr
 
 
 def test_nothing():
@@ -117,14 +138,25 @@ def test_nothing():
 
 
 @pytest.mark.uncollect_if(func=invalid_pq_handshake_test_parameters)
-@pytest.mark.parametrize("protocol", [Protocols.TLS12, Protocols.TLS13], ids=get_parameter_name)
-@pytest.mark.parametrize("certificate", [Certificates.RSA_4096_SHA512], ids=get_parameter_name)
+@pytest.mark.parametrize(
+    "protocol", [Protocols.TLS12, Protocols.TLS13], ids=get_parameter_name
+)
+@pytest.mark.parametrize(
+    "certificate", [Certificates.RSA_4096_SHA512], ids=get_parameter_name
+)
 @pytest.mark.parametrize("client_cipher", CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("server_cipher", CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-def test_s2nc_to_s2nd_pq_handshake(managed_process, protocol, certificate, client_cipher, server_cipher, provider,
-                                   other_provider):
+def test_s2nc_to_s2nd_pq_handshake(
+    managed_process,
+    protocol,
+    certificate,
+    client_cipher,
+    server_cipher,
+    provider,
+    other_provider,
+):
     port = next(available_ports)
 
     client_options = ProviderOptions(
@@ -132,7 +164,8 @@ def test_s2nc_to_s2nd_pq_handshake(managed_process, protocol, certificate, clien
         port=port,
         insecure=True,
         cipher=client_cipher,
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = ProviderOptions(
         mode=Provider.ServerMode,
@@ -140,19 +173,19 @@ def test_s2nc_to_s2nd_pq_handshake(managed_process, protocol, certificate, clien
         protocol=protocol,
         cipher=server_cipher,
         cert=certificate.cert,
-        key=certificate.key)
+        key=certificate.key,
+    )
 
     server = managed_process(S2N, server_options, timeout=5)
     client = managed_process(S2N, client_options, timeout=5)
 
     if pq_enabled():
-        expected_result = EXPECTED_RESULTS.get(
-            (client_cipher, server_cipher), None)
+        expected_result = EXPECTED_RESULTS.get((client_cipher, server_cipher), None)
     else:
         # If PQ is not enabled in s2n, we expect classic handshakes to be negotiated.
         # Leave the expected cipher blank, as there are multiple possibilities - the
         # important thing is that kem and kem_group are NONE.
-        expected_result = {"cipher": "",  "kem_group": None}
+        expected_result = {"cipher": "", "kem_group": None}
 
     # Client and server are both s2n; can make meaningful assertions about negotiation for both
     for results in client.get_results():
@@ -164,18 +197,29 @@ def test_s2nc_to_s2nd_pq_handshake(managed_process, protocol, certificate, clien
         assert_s2n_negotiation_parameters(results, expected_result)
 
 
-@pytest.mark.parametrize("s2n_client_policy", [Ciphers.PQ_TLS_1_3_2023_06_01], ids=get_parameter_name)
-@pytest.mark.parametrize("awslc_server_group", [KemGroups.SecP256r1Kyber768Draft00, KemGroups.X25519Kyber768Draft00], ids=get_parameter_name)
-def test_s2nc_to_awslc_pq_handshake(managed_process, s2n_client_policy, awslc_server_group):
-
+@pytest.mark.parametrize(
+    "s2n_client_policy", [Ciphers.PQ_TLS_1_3_2023_06_01], ids=get_parameter_name
+)
+@pytest.mark.parametrize(
+    "awslc_server_group",
+    [KemGroups.SecP256r1Kyber768Draft00, KemGroups.X25519Kyber768Draft00],
+    ids=get_parameter_name,
+)
+def test_s2nc_to_awslc_pq_handshake(
+    managed_process, s2n_client_policy, awslc_server_group
+):
     if not pq_enabled():
         pytest.skip("PQ not enabled")
 
     if "awslc" not in get_flag(S2N_PROVIDER_VERSION):
-        pytest.skip("s2n must be compiled with awslc libcrypto in order to test PQ TLS compatibility")
+        pytest.skip(
+            "s2n must be compiled with awslc libcrypto in order to test PQ TLS compatibility"
+        )
 
     if "fips" in get_flag(S2N_PROVIDER_VERSION):
-        pytest.skip("No FIPS validated version of AWS-LC has support for negotiating Hybrid PQ TLS yet")
+        pytest.skip(
+            "No FIPS validated version of AWS-LC has support for negotiating Hybrid PQ TLS yet"
+        )
 
     port = next(available_ports)
 
@@ -184,17 +228,21 @@ def test_s2nc_to_awslc_pq_handshake(managed_process, s2n_client_policy, awslc_se
         port=port,
         insecure=True,
         cipher=s2n_client_policy,
-        protocol=Protocols.TLS13)
+        protocol=Protocols.TLS13,
+    )
 
     awslc_server_options = ProviderOptions(
         mode=Provider.ServerMode,
         port=port,
         protocol=Protocols.TLS13,
-        curve=Curves.from_name(awslc_server_group.oqs_name))
+        curve=Curves.from_name(awslc_server_group.oqs_name),
+    )
 
     awslc_server = managed_process(BoringSSL, awslc_server_options, timeout=5)
     s2n_client = managed_process(S2N, s2nc_client_options, timeout=5)
-    expected_result = EXPECTED_RESULTS.get((s2n_client_policy, awslc_server_group), None)
+    expected_result = EXPECTED_RESULTS.get(
+        (s2n_client_policy, awslc_server_group), None
+    )
 
     awslc_result = next(awslc_server.get_results())
     assert_awslc_negotiation_parameters(awslc_result, expected_result)
@@ -203,18 +251,29 @@ def test_s2nc_to_awslc_pq_handshake(managed_process, s2n_client_policy, awslc_se
     assert_s2n_negotiation_parameters(s2nd_result, expected_result)
 
 
-@pytest.mark.parametrize("s2n_server_policy", [Ciphers.PQ_TLS_1_3_2023_06_01], ids=get_parameter_name)
-@pytest.mark.parametrize("awslc_client_group", [KemGroups.SecP256r1Kyber768Draft00, KemGroups.X25519Kyber768Draft00], ids=get_parameter_name)
-def test_s2nd_to_awslc_pq_handshake(managed_process, s2n_server_policy, awslc_client_group):
-
+@pytest.mark.parametrize(
+    "s2n_server_policy", [Ciphers.PQ_TLS_1_3_2023_06_01], ids=get_parameter_name
+)
+@pytest.mark.parametrize(
+    "awslc_client_group",
+    [KemGroups.SecP256r1Kyber768Draft00, KemGroups.X25519Kyber768Draft00],
+    ids=get_parameter_name,
+)
+def test_s2nd_to_awslc_pq_handshake(
+    managed_process, s2n_server_policy, awslc_client_group
+):
     if not pq_enabled():
         pytest.skip("PQ not enabled")
 
     if "awslc" not in get_flag(S2N_PROVIDER_VERSION):
-        pytest.skip("s2n must be compiled with awslc libcrypto in order to test PQ TLS compatibility")
+        pytest.skip(
+            "s2n must be compiled with awslc libcrypto in order to test PQ TLS compatibility"
+        )
 
     if "fips" in get_flag(S2N_PROVIDER_VERSION):
-        pytest.skip("No FIPS validated version of AWS-LC has support for negotiating Hybrid PQ TLS yet")
+        pytest.skip(
+            "No FIPS validated version of AWS-LC has support for negotiating Hybrid PQ TLS yet"
+        )
 
     port = next(available_ports)
 
@@ -223,17 +282,21 @@ def test_s2nd_to_awslc_pq_handshake(managed_process, s2n_server_policy, awslc_cl
         port=port,
         insecure=True,
         cipher=s2n_server_policy,
-        protocol=Protocols.TLS13)
+        protocol=Protocols.TLS13,
+    )
 
     awslc_client_options = ProviderOptions(
         mode=Provider.ClientMode,
         port=port,
         protocol=Protocols.TLS13,
-        curve=Curves.from_name(awslc_client_group.oqs_name))
+        curve=Curves.from_name(awslc_client_group.oqs_name),
+    )
 
     s2nd_server = managed_process(S2N, s2nd_server_options, timeout=5)
     awslc_client = managed_process(BoringSSL, awslc_client_options, timeout=5)
-    expected_result = EXPECTED_RESULTS.get((s2n_server_policy, awslc_client_group), None)
+    expected_result = EXPECTED_RESULTS.get(
+        (s2n_server_policy, awslc_client_group), None
+    )
 
     awslc_result = next(awslc_client.get_results())
     assert_awslc_negotiation_parameters(awslc_result, expected_result)
@@ -244,7 +307,9 @@ def test_s2nd_to_awslc_pq_handshake(managed_process, s2n_server_policy, awslc_cl
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
-@pytest.mark.parametrize("cipher", [Ciphers.PQ_TLS_1_3_2023_06_01], ids=get_parameter_name)
+@pytest.mark.parametrize(
+    "cipher", [Ciphers.PQ_TLS_1_3_2023_06_01], ids=get_parameter_name
+)
 @pytest.mark.parametrize("kem_group", KEM_GROUPS, ids=get_parameter_name)
 def test_s2nc_to_oqs_openssl_pq_handshake(managed_process, protocol, cipher, kem_group):
     # If PQ is not enabled in s2n, there is no reason to test against oqs_openssl
@@ -258,7 +323,8 @@ def test_s2nc_to_oqs_openssl_pq_handshake(managed_process, protocol, cipher, kem
         port=port,
         insecure=True,
         cipher=cipher,
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = ProviderOptions(
         mode=Provider.ServerMode,
@@ -267,7 +333,8 @@ def test_s2nc_to_oqs_openssl_pq_handshake(managed_process, protocol, cipher, kem
         cert=Certificates.RSA_4096_SHA512.cert,
         key=Certificates.RSA_4096_SHA512.key,
         env_overrides=get_oqs_openssl_override_env_vars(),
-        extra_flags=['-groups', kem_group.oqs_name])
+        extra_flags=["-groups", kem_group.oqs_name],
+    )
 
     server = managed_process(OpenSSL, server_options, timeout=5)
     client = managed_process(S2N, client_options, timeout=5)
@@ -286,7 +353,9 @@ def test_s2nc_to_oqs_openssl_pq_handshake(managed_process, protocol, cipher, kem
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
-@pytest.mark.parametrize("cipher", [Ciphers.PQ_TLS_1_3_2023_06_01], ids=get_parameter_name)
+@pytest.mark.parametrize(
+    "cipher", [Ciphers.PQ_TLS_1_3_2023_06_01], ids=get_parameter_name
+)
 @pytest.mark.parametrize("kem_group", KEM_GROUPS, ids=get_parameter_name)
 def test_oqs_openssl_to_s2nd_pq_handshake(managed_process, protocol, cipher, kem_group):
     # If PQ is not enabled in s2n, there is no reason to test against oqs_openssl
@@ -300,7 +369,8 @@ def test_oqs_openssl_to_s2nd_pq_handshake(managed_process, protocol, cipher, kem
         port=port,
         protocol=protocol,
         env_overrides=get_oqs_openssl_override_env_vars(),
-        extra_flags=['-groups', kem_group.oqs_name])
+        extra_flags=["-groups", kem_group.oqs_name],
+    )
 
     server_options = ProviderOptions(
         mode=Provider.ServerMode,
@@ -308,7 +378,8 @@ def test_oqs_openssl_to_s2nd_pq_handshake(managed_process, protocol, cipher, kem
         protocol=protocol,
         cipher=cipher,
         cert=Certificates.RSA_4096_SHA512.cert,
-        key=Certificates.RSA_4096_SHA512.key)
+        key=Certificates.RSA_4096_SHA512.key,
+    )
 
     server = managed_process(S2N, server_options, timeout=5)
     client = managed_process(OpenSSL, client_options, timeout=5)

--- a/tests/integrationv2/test_record_padding.py
+++ b/tests/integrationv2/test_record_padding.py
@@ -5,21 +5,27 @@ import platform
 import pytest
 import re
 
-from configuration import available_ports, TLS13_CIPHERS, ALL_TEST_CURVES, MINIMAL_TEST_CERTS
+from configuration import (
+    available_ports,
+    TLS13_CIPHERS,
+    ALL_TEST_CURVES,
+    MINIMAL_TEST_CERTS,
+)
 from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process  # lgtm [py/unused-import]
 from providers import Provider, S2N, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
+from utils import (
+    invalid_test_parameters,
+    get_parameter_name,
+    get_expected_s2n_version,
+    to_bytes,
+)
 
 PADDING_SIZE_SMALL = 250
 PADDING_SIZE_MEDIUM = 1000
 PADDING_SIZE_MAX = 1 << 14
 
-PADDING_SIZES = [
-    PADDING_SIZE_SMALL,
-    PADDING_SIZE_MEDIUM,
-    PADDING_SIZE_MAX
-]
+PADDING_SIZES = [PADDING_SIZE_SMALL, PADDING_SIZE_MEDIUM, PADDING_SIZE_MAX]
 
 # arbitrarily large payload size
 PAYLOAD_SIZE = 1024
@@ -36,7 +42,7 @@ def strip_string_of_bytes(s: str) -> str:
 
 def get_payload_size_from_openssl_trace(record_size_bytes: str) -> int:
     # record_size_bytes is in the form XX XX where X is a hex digit
-    size_in_hex = record_size_bytes.replace(' ', '')
+    size_in_hex = record_size_bytes.replace(" ", "")
     size = int(size_in_hex, 16)
     # record includes 16 bytes of aead tag
     return size - 16
@@ -45,11 +51,9 @@ def get_payload_size_from_openssl_trace(record_size_bytes: str) -> int:
 def assert_openssl_records_are_padded_correctly(openssl_output: str, padding_size: int):
     number_of_app_data_records = 0
 
-    records_written = re.findall(
-        OPENSSL_RECORD_WRITTEN_PATTERN, openssl_output)
+    records_written = re.findall(OPENSSL_RECORD_WRITTEN_PATTERN, openssl_output)
     for record_prefix in records_written:
-        app_data_header = re.search(
-            OPENSSL_APP_DATA_HEADER_PATTERN, record_prefix)
+        app_data_header = re.search(OPENSSL_APP_DATA_HEADER_PATTERN, record_prefix)
         if app_data_header:
             size_bytes = app_data_header.group(RECORD_SIZE_GROUP)
             size = get_payload_size_from_openssl_trace(size_bytes)
@@ -81,8 +85,9 @@ def test_nothing():
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("padding_size", PADDING_SIZES, ids=get_parameter_name)
-def test_s2n_server_handles_padded_records(managed_process, cipher, provider, curve, protocol, certificate,
-                                           padding_size):
+def test_s2n_server_handles_padded_records(
+    managed_process, cipher, provider, curve, protocol, certificate, padding_size
+):
     port = next(available_ports)
 
     random_bytes = data_bytes(PAYLOAD_SIZE)
@@ -95,7 +100,7 @@ def test_s2n_server_handles_padded_records(managed_process, cipher, provider, cu
         data_to_send=random_bytes,
         insecure=True,
         protocol=protocol,
-        extra_flags=['-record_padding', padding_size]
+        extra_flags=["-record_padding", padding_size],
     )
 
     server_options = copy.copy(client_options)
@@ -110,7 +115,8 @@ def test_s2n_server_handles_padded_records(managed_process, cipher, provider, cu
     for client_results in openssl.get_results():
         client_results.assert_success()
         assert_openssl_records_are_padded_correctly(
-            str(client_results.stdout), padding_size)
+            str(client_results.stdout), padding_size
+        )
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
@@ -119,14 +125,20 @@ def test_s2n_server_handles_padded_records(managed_process, cipher, provider, cu
         # verify that the payload was correctly received by the server
         assert random_bytes in server_results.stdout
         # verify that the version was correctly negotiated
-        assert to_bytes("Actual protocol version: {}".format(
-            expected_version)) in server_results.stdout
+        assert (
+            to_bytes("Actual protocol version: {}".format(expected_version))
+            in server_results.stdout
+        )
         # verify that the cipher was correctly negotiated
-        assert to_bytes("Cipher negotiated: {}".format(
-            cipher.name)) in server_results.stdout
+        assert (
+            to_bytes("Cipher negotiated: {}".format(cipher.name))
+            in server_results.stdout
+        )
 
 
-@pytest.mark.flaky(reruns=5, reruns_delay=2, condition=platform.machine().startswith("aarch"))
+@pytest.mark.flaky(
+    reruns=5, reruns_delay=2, condition=platform.machine().startswith("aarch")
+)
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL])
@@ -135,8 +147,9 @@ def test_s2n_server_handles_padded_records(managed_process, cipher, provider, cu
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("padding_size", PADDING_SIZES, ids=get_parameter_name)
-def test_s2n_client_handles_padded_records(managed_process, cipher, provider, curve, protocol, certificate,
-                                           padding_size):
+def test_s2n_client_handles_padded_records(
+    managed_process, cipher, provider, curve, protocol, certificate, padding_size
+):
     port = next(available_ports)
 
     client_random_bytes = data_bytes(PAYLOAD_SIZE)
@@ -152,7 +165,7 @@ def test_s2n_client_handles_padded_records(managed_process, cipher, provider, cu
         insecure=True,
         protocol=protocol,
         data_to_send=server_random_bytes,
-        extra_flags=['-record_padding', padding_size]
+        extra_flags=["-record_padding", padding_size],
     )
 
     client_options = copy.copy(server_options)
@@ -161,24 +174,37 @@ def test_s2n_client_handles_padded_records(managed_process, cipher, provider, cu
     client_options.data_to_send = client_random_bytes
 
     # openssl will send its response after it has received s2nc's record
-    openssl = managed_process(provider, server_options,
-                              timeout=5, send_marker=strip_string_of_bytes(str(client_random_bytes)))
+    openssl = managed_process(
+        provider,
+        server_options,
+        timeout=5,
+        send_marker=strip_string_of_bytes(str(client_random_bytes)),
+    )
 
     # s2nc will wait until it has received the server's response before closing
-    s2nc = managed_process(S2N, client_options, timeout=5,
-                           close_marker=strip_string_of_bytes(str(server_random_bytes)))
+    s2nc = managed_process(
+        S2N,
+        client_options,
+        timeout=5,
+        close_marker=strip_string_of_bytes(str(server_random_bytes)),
+    )
 
     expected_version = get_expected_s2n_version(protocol, provider)
     for client_results in s2nc.get_results():
         client_results.assert_success()
         # assert that the client has received server's application payload
         assert server_random_bytes in client_results.stdout
-        assert to_bytes("Actual protocol version: {}".format(
-            expected_version)) in client_results.stdout
-        assert to_bytes("Cipher negotiated: {}".format(
-            cipher.name)) in client_results.stdout
+        assert (
+            to_bytes("Actual protocol version: {}".format(expected_version))
+            in client_results.stdout
+        )
+        assert (
+            to_bytes("Cipher negotiated: {}".format(cipher.name))
+            in client_results.stdout
+        )
 
     for server_results in openssl.get_results():
         server_results.assert_success()
         assert_openssl_records_are_padded_correctly(
-            str(server_results.stdout), padding_size)
+            str(server_results.stdout), padding_size
+        )

--- a/tests/integrationv2/test_renegotiate.py
+++ b/tests/integrationv2/test_renegotiate.py
@@ -4,7 +4,13 @@ import copy
 import pytest
 import random
 
-from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, MINIMAL_TEST_CERTS, PROTOCOLS
+from configuration import (
+    available_ports,
+    ALL_TEST_CIPHERS,
+    ALL_TEST_CURVES,
+    MINIMAL_TEST_CERTS,
+    PROTOCOLS,
+)
 from common import ProviderOptions, Protocols
 from fixtures import managed_process  # lgtm [py/unused-import]
 from providers import Provider, S2N, OpenSSL
@@ -20,7 +26,7 @@ S2N_RENEG_OPTION = "--renegotiation"
 S2N_RENEG_ACCEPT = "accept"
 S2N_RENEG_REJECT = "reject"
 S2N_RENEG_WAIT = "wait"
-OPENSSL_RENEG_CTRL_CMD = 'r\n'
+OPENSSL_RENEG_CTRL_CMD = "r\n"
 
 
 # Output indicating renegotiation state
@@ -44,17 +50,19 @@ def renegotiate_was_started(s2n_results):
 
 
 def renegotiate_was_successful(s2n_results):
-    return renegotiate_was_started(s2n_results) and \
-        to_bytes(S2N_RENEG_SUCCESS_MARKER) in s2n_results.stdout
+    return (
+        renegotiate_was_started(s2n_results)
+        and to_bytes(S2N_RENEG_SUCCESS_MARKER) in s2n_results.stdout
+    )
 
 
 # Basic conversion methods
 def to_bytes(val):
-    return str(val).encode('utf-8')
+    return str(val).encode("utf-8")
 
 
 def to_marker(val):
-    return bytes(val).decode('utf-8')
+    return bytes(val).decode("utf-8")
 
 
 """
@@ -101,7 +109,7 @@ class Msg(object):
                 # but our framework is not good at handling non-ASCII characters due
                 # to inconsistent use of bytes vs decode and str vs encode.
                 # As a workaround, just prepend a throwaway non-ASCII utf-8 character.
-                data_bytes.append(bytes([0xc2, 0xbb]) + to_bytes(message.data_str))
+                data_bytes.append(bytes([0xC2, 0xBB]) + to_bytes(message.data_str))
         # We assume that the client will close the connection.
         # Give the server one last message to send without a corresponding send_marker.
         # The message will never be sent, but waiting to send it will prevent the server
@@ -112,7 +120,11 @@ class Msg(object):
 
     @staticmethod
     def expected_output(messages, mode):
-        return [to_bytes(message.data_str) for message in messages if not message.ctrl and message.mode is not mode]
+        return [
+            to_bytes(message.data_str)
+            for message in messages
+            if not message.ctrl and message.mode is not mode
+        ]
 
     @staticmethod
     def send_markers(messages, mode):
@@ -126,27 +138,31 @@ class Msg(object):
                 # Assume that the first sender is s2n
                 send_markers.append(S2N.get_send_marker())
             else:
-                previous = messages[i-1]
-                assert (previous.mode is not mode)
+                previous = messages[i - 1]
+                assert previous.mode is not mode
                 send_markers.append(previous.data_str)
         return send_markers
 
     @staticmethod
     def close_marker(messages):
         # Assume that the last sender is the server
-        assert (messages[-1].mode is Provider.ServerMode)
+        assert messages[-1].mode is Provider.ServerMode
         output = Msg.expected_output(messages, Provider.ClientMode)
         return to_marker(output[-1])
 
     @staticmethod
     def debug(messages):
-        print(f'client data to send: {Msg.data_to_send(messages, Provider.ClientMode)}')
-        print(f'server data to send: {Msg.data_to_send(messages, Provider.ServerMode)}')
-        print(f'client send markers: {Msg.send_markers(messages, Provider.ClientMode)}')
-        print(f'server send markers: {Msg.send_markers(messages, Provider.ServerMode)}')
-        print(f'client close_marker: {Msg.close_marker(messages)}')
-        print(f'client expected output: {Msg.expected_output(messages, Provider.ClientMode)}')
-        print(f'server expected output: {Msg.expected_output(messages, Provider.ServerMode)}')
+        print(f"client data to send: {Msg.data_to_send(messages, Provider.ClientMode)}")
+        print(f"server data to send: {Msg.data_to_send(messages, Provider.ServerMode)}")
+        print(f"client send markers: {Msg.send_markers(messages, Provider.ClientMode)}")
+        print(f"server send markers: {Msg.send_markers(messages, Provider.ServerMode)}")
+        print(f"client close_marker: {Msg.close_marker(messages)}")
+        print(
+            f"client expected output: {Msg.expected_output(messages, Provider.ClientMode)}"
+        )
+        print(
+            f"server expected output: {Msg.expected_output(messages, Provider.ServerMode)}"
+        )
 
 
 # The order of messages that will trigger renegotiation
@@ -166,7 +182,16 @@ RENEG_MESSAGES = [
 ]
 
 
-def basic_reneg_test(managed_process, cipher, curve, certificate, protocol, provider, messages=RENEG_MESSAGES, reneg_option=None):
+def basic_reneg_test(
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    messages=RENEG_MESSAGES,
+    reneg_option=None,
+):
     options = ProviderOptions(
         port=next(available_ports),
         cipher=cipher,
@@ -188,16 +213,20 @@ def basic_reneg_test(managed_process, cipher, curve, certificate, protocol, prov
     server_options.mode = Provider.ServerMode
     server_options.data_to_send = Msg.data_to_send(messages, Provider.ServerMode)
 
-    server = managed_process(provider, server_options,
-                             send_marker=Msg.send_markers(messages, Provider.ServerMode),
-                             timeout=8
-                             )
+    server = managed_process(
+        provider,
+        server_options,
+        send_marker=Msg.send_markers(messages, Provider.ServerMode),
+        timeout=8,
+    )
 
-    s2n_client = managed_process(S2N, client_options,
-                                 send_marker=Msg.send_markers(messages, Provider.ClientMode),
-                                 close_marker=Msg.close_marker(messages),
-                                 timeout=8
-                                 )
+    s2n_client = managed_process(
+        S2N,
+        client_options,
+        send_marker=Msg.send_markers(messages, Provider.ClientMode),
+        close_marker=Msg.close_marker(messages),
+        timeout=8,
+    )
 
     return (s2n_client, server)
 
@@ -215,8 +244,12 @@ This tests the default behavior for customers who do not enable renegotiation.
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
-def test_s2n_client_ignores_openssl_hello_request(managed_process, cipher, curve, certificate, protocol, provider):
-    (s2n_client, server) = basic_reneg_test(managed_process, cipher, curve, certificate, protocol, provider)
+def test_s2n_client_ignores_openssl_hello_request(
+    managed_process, cipher, curve, certificate, protocol, provider
+):
+    (s2n_client, server) = basic_reneg_test(
+        managed_process, cipher, curve, certificate, protocol, provider
+    )
 
     for results in server.get_results():
         results.assert_success()
@@ -243,9 +276,18 @@ Renegotiation request rejected by s2n-tls client.
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
-def test_s2n_client_rejects_openssl_hello_request(managed_process, cipher, curve, certificate, protocol, provider):
-    (s2n_client, server) = basic_reneg_test(managed_process, cipher, curve, certificate, protocol, provider,
-                                            reneg_option=S2N_RENEG_REJECT)
+def test_s2n_client_rejects_openssl_hello_request(
+    managed_process, cipher, curve, certificate, protocol, provider
+):
+    (s2n_client, server) = basic_reneg_test(
+        managed_process,
+        cipher,
+        curve,
+        certificate,
+        protocol,
+        provider,
+        reneg_option=S2N_RENEG_REJECT,
+    )
 
     for results in server.get_results():
         assert renegotiate_was_requested(results)
@@ -268,9 +310,18 @@ Renegotiation request accepted by s2n-tls client.
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
-def test_s2n_client_renegotiate_with_openssl(managed_process, cipher, curve, certificate, protocol, provider):
-    (s2n_client, server) = basic_reneg_test(managed_process, cipher, curve, certificate, protocol, provider,
-                                            reneg_option=S2N_RENEG_ACCEPT)
+def test_s2n_client_renegotiate_with_openssl(
+    managed_process, cipher, curve, certificate, protocol, provider
+):
+    (s2n_client, server) = basic_reneg_test(
+        managed_process,
+        cipher,
+        curve,
+        certificate,
+        protocol,
+        provider,
+        reneg_option=S2N_RENEG_ACCEPT,
+    )
 
     for results in server.get_results():
         results.assert_success()
@@ -301,19 +352,29 @@ but does require client auth during the second handshake.
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
-def test_s2n_client_renegotiate_with_client_auth_with_openssl(managed_process, cipher, curve, certificate, protocol, provider):
+def test_s2n_client_renegotiate_with_client_auth_with_openssl(
+    managed_process, cipher, curve, certificate, protocol, provider
+):
     # We want to use the same messages to test renegotiation,
     # but with 'R' instead of 'r' to trigger the Openssl renegotiate request.
     messages = copy.deepcopy(RENEG_MESSAGES)
     for m in messages:
         if m.ctrl:
-            m.data_str = 'R\n'
+            m.data_str = "R\n"
 
     client_auth_marker = "|CLIENT_AUTH"
     no_client_cert_marker = "|NO_CLIENT_CERT"
 
-    (s2n_client, server) = basic_reneg_test(managed_process, cipher, curve, certificate, protocol, provider,
-                                            messages=messages, reneg_option=S2N_RENEG_WAIT)
+    (s2n_client, server) = basic_reneg_test(
+        managed_process,
+        cipher,
+        curve,
+        certificate,
+        protocol,
+        provider,
+        messages=messages,
+        reneg_option=S2N_RENEG_WAIT,
+    )
 
     for results in server.get_results():
         results.assert_success()
@@ -351,10 +412,19 @@ The s2n-tls client successfully reads ApplicationData during the renegotiation h
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
-def test_s2n_client_renegotiate_with_app_data_with_openssl(managed_process, cipher, curve, certificate, protocol, provider):
+def test_s2n_client_renegotiate_with_app_data_with_openssl(
+    managed_process, cipher, curve, certificate, protocol, provider
+):
     first_server_app_data = Msg.expected_output(RENEG_MESSAGES, Provider.ClientMode)[0]
-    (s2n_client, server) = basic_reneg_test(managed_process, cipher, curve, certificate, protocol, provider,
-                                            reneg_option=S2N_RENEG_WAIT)
+    (s2n_client, server) = basic_reneg_test(
+        managed_process,
+        cipher,
+        curve,
+        certificate,
+        protocol,
+        provider,
+        reneg_option=S2N_RENEG_WAIT,
+    )
 
     for results in server.get_results():
         results.assert_success()

--- a/tests/integrationv2/test_renegotiate_apache.py
+++ b/tests/integrationv2/test_renegotiate_apache.py
@@ -29,7 +29,9 @@ def create_get_request(route):
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
-@pytest.mark.parametrize("endpoint", [CHANGE_CIPHER_SUITE_ENDPOINT, MUTUAL_AUTH_ENDPOINT])
+@pytest.mark.parametrize(
+    "endpoint", [CHANGE_CIPHER_SUITE_ENDPOINT, MUTUAL_AUTH_ENDPOINT]
+)
 def test_apache_endpoints_fail_with_no_reneg(managed_process, protocol, endpoint):
     options = ProviderOptions(
         mode=Provider.ClientMode,
@@ -40,7 +42,7 @@ def test_apache_endpoints_fail_with_no_reneg(managed_process, protocol, endpoint
         trust_store=APACHE_SERVER_CERT,
         cert=APACHE_CLIENT_CERT,
         key=APACHE_CLIENT_KEY,
-        use_client_auth=True
+        use_client_auth=True,
     )
 
     with tempfile.NamedTemporaryFile("w+") as http_request_file:
@@ -48,13 +50,17 @@ def test_apache_endpoints_fail_with_no_reneg(managed_process, protocol, endpoint
         http_request_file.flush()
         options.extra_flags = ["--send-file", http_request_file.name]
 
-        s2n_client = managed_process(S2N, options, timeout=20, close_marker="You don't have permission")
+        s2n_client = managed_process(
+            S2N, options, timeout=20, close_marker="You don't have permission"
+        )
 
         for results in s2n_client.get_results():
             results.assert_success()
 
             assert b"<title>403 Forbidden</title>" in results.stdout
-            assert b"You don't have permission to access this resource." in results.stdout
+            assert (
+                b"You don't have permission to access this resource." in results.stdout
+            )
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -99,7 +105,7 @@ def test_mutual_auth_endpoint(managed_process, curve, protocol):
         trust_store=APACHE_SERVER_CERT,
         cert=APACHE_CLIENT_CERT,
         key=APACHE_CLIENT_KEY,
-        use_client_auth=True
+        use_client_auth=True,
     )
 
     options.extra_flags = [S2N_RENEG_OPTION, S2N_RENEG_ACCEPT]

--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -5,23 +5,45 @@ import os
 import platform
 import pytest
 
-from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS, PROTOCOLS, TLS13_CIPHERS
+from configuration import (
+    available_ports,
+    ALL_TEST_CIPHERS,
+    ALL_TEST_CURVES,
+    ALL_TEST_CERTS,
+    PROTOCOLS,
+    TLS13_CIPHERS,
+)
 from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process  # lgtm [py/unused-import]
 from providers import Provider, S2N, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
+from utils import (
+    invalid_test_parameters,
+    get_parameter_name,
+    get_expected_s2n_version,
+    to_bytes,
+)
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
-@pytest.mark.parametrize("protocol", [p for p in PROTOCOLS if p != Protocols.TLS13], ids=get_parameter_name)
+@pytest.mark.parametrize(
+    "protocol", [p for p in PROTOCOLS if p != Protocols.TLS13], ids=get_parameter_name
+)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("use_ticket", [True, False])
-def test_session_resumption_s2n_server(managed_process, cipher, curve, certificate, protocol, provider, other_provider,
-                                       use_ticket):
+def test_session_resumption_s2n_server(
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    other_provider,
+    use_ticket,
+):
     port = next(available_ports)
 
     client_options = ProviderOptions(
@@ -31,12 +53,13 @@ def test_session_resumption_s2n_server(managed_process, cipher, curve, certifica
         curve=curve,
         insecure=True,
         reconnect=True,
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = copy.copy(client_options)
     server_options.reconnects_before_exit = 6
     server_options.mode = Provider.ServerMode
-    server_options.use_session_ticket = use_ticket,
+    server_options.use_session_ticket = (use_ticket,)
     server_options.key = certificate.key
     server_options.cert = certificate.cert
 
@@ -55,20 +78,34 @@ def test_session_resumption_s2n_server(managed_process, cipher, curve, certifica
     # S2N should indicate the procotol version in a successful connection.
     for results in server.get_results():
         results.assert_success()
-        assert results.stdout.count(
-            to_bytes("Actual protocol version: {}".format(expected_version))) == 6
+        assert (
+            results.stdout.count(
+                to_bytes("Actual protocol version: {}".format(expected_version))
+            )
+            == 6
+        )
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
-@pytest.mark.parametrize("protocol", [p for p in PROTOCOLS if p != Protocols.TLS13], ids=get_parameter_name)
+@pytest.mark.parametrize(
+    "protocol", [p for p in PROTOCOLS if p != Protocols.TLS13], ids=get_parameter_name
+)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("use_ticket", [True, False])
-def test_session_resumption_s2n_client(managed_process, cipher, curve, protocol, provider, other_provider, certificate,
-                                       use_ticket):
+def test_session_resumption_s2n_client(
+    managed_process,
+    cipher,
+    curve,
+    protocol,
+    provider,
+    other_provider,
+    certificate,
+    use_ticket,
+):
     port = next(available_ports)
 
     client_options = ProviderOptions(
@@ -79,7 +116,8 @@ def test_session_resumption_s2n_client(managed_process, cipher, curve, protocol,
         insecure=True,
         reconnect=True,
         use_session_ticket=use_ticket,
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = copy.copy(client_options)
     server_options.reconnects_before_exit = 6
@@ -96,8 +134,12 @@ def test_session_resumption_s2n_client(managed_process, cipher, curve, protocol,
     expected_version = get_expected_s2n_version(protocol, OpenSSL)
     for results in client.get_results():
         results.assert_success()
-        assert results.stdout.count(
-            to_bytes("Actual protocol version: {}".format(expected_version))) == 6
+        assert (
+            results.stdout.count(
+                to_bytes("Actual protocol version: {}".format(expected_version))
+            )
+            == 6
+        )
 
     for results in server.get_results():
         results.assert_success()
@@ -111,12 +153,20 @@ def test_session_resumption_s2n_client(managed_process, cipher, curve, protocol,
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, curve, certificate, protocol, provider,
-                                             other_provider):
+def test_tls13_session_resumption_s2n_server(
+    managed_process,
+    tmp_path,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    other_provider,
+):
     port = str(next(available_ports))
 
     # Use temp directory to store session tickets
-    p = tmp_path / 'ticket.pem'
+    p = tmp_path / "ticket.pem"
     path_to_ticket = str(p)
 
     close_marker_bytes = data_bytes(10)
@@ -128,8 +178,9 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
         curve=curve,
         insecure=True,
         reconnect=False,
-        extra_flags=['-sess_out', path_to_ticket],
-        protocol=protocol)
+        extra_flags=["-sess_out", path_to_ticket],
+        protocol=protocol,
+    )
 
     server_options = copy.copy(client_options)
     server_options.mode = Provider.ServerMode
@@ -140,47 +191,55 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
     server_options.data_to_send = close_marker_bytes
 
     server = managed_process(
-        S2N, server_options, timeout=5, send_marker=S2N.get_send_marker())
-    client = managed_process(provider, client_options,
-                             timeout=5, close_marker=str(close_marker_bytes))
+        S2N, server_options, timeout=5, send_marker=S2N.get_send_marker()
+    )
+    client = managed_process(
+        provider, client_options, timeout=5, close_marker=str(close_marker_bytes)
+    )
 
     # The client should have received a session ticket
     for results in client.get_results():
         results.assert_success()
-        assert b'Post-Handshake New Session Ticket arrived:' in results.stdout
+        assert b"Post-Handshake New Session Ticket arrived:" in results.stdout
 
     for results in server.get_results():
         results.assert_success()
         # The first connection is a full handshake
-        assert b'Resumed session' not in results.stdout
+        assert b"Resumed session" not in results.stdout
 
     # Client inputs received session ticket to resume a session
     assert os.path.exists(path_to_ticket)
-    client_options.extra_flags = ['-sess_in', path_to_ticket]
+    client_options.extra_flags = ["-sess_in", path_to_ticket]
 
     port = str(next(available_ports))
     client_options.port = port
     server_options.port = port
 
     server = managed_process(
-        S2N, server_options, timeout=5, send_marker=S2N.get_send_marker())
-    client = managed_process(provider, client_options,
-                             timeout=5, close_marker=str(close_marker_bytes))
+        S2N, server_options, timeout=5, send_marker=S2N.get_send_marker()
+    )
+    client = managed_process(
+        provider, client_options, timeout=5, close_marker=str(close_marker_bytes)
+    )
 
     s2n_version = get_expected_s2n_version(protocol, provider)
 
     # Client has not read server certificate message as this is a resumed session
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes(
-            "SSL_connect:SSLv3/TLS read server certificate") not in results.stderr
+        assert (
+            to_bytes("SSL_connect:SSLv3/TLS read server certificate")
+            not in results.stderr
+        )
 
     # The server should indicate a session has been resumed
     for results in server.get_results():
         results.assert_success()
-        assert b'Resumed session' in results.stdout
-        assert to_bytes("Actual protocol version: {}".format(
-            s2n_version)) in results.stdout
+        assert b"Resumed session" in results.stdout
+        assert (
+            to_bytes("Actual protocol version: {}".format(s2n_version))
+            in results.stdout
+        )
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
@@ -190,8 +249,9 @@ def test_tls13_session_resumption_s2n_server(managed_process, tmp_path, cipher, 
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL, S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, certificate, protocol, provider,
-                                             other_provider):
+def test_tls13_session_resumption_s2n_client(
+    managed_process, cipher, curve, certificate, protocol, provider, other_provider
+):
     port = str(next(available_ports))
 
     # The reconnect option for s2nc allows the client to reconnect automatically
@@ -208,13 +268,16 @@ def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, cer
         insecure=True,
         use_session_ticket=True,
         reconnect=True,
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = copy.copy(client_options)
     server_options.mode = Provider.ServerMode
     server_options.key = certificate.key
     server_options.cert = certificate.cert
-    server_options.reconnects_before_exit = num_resumed_connections + num_full_connections
+    server_options.reconnects_before_exit = (
+        num_resumed_connections + num_full_connections
+    )
 
     server = managed_process(provider, server_options, timeout=5)
     client = managed_process(S2N, client_options, timeout=5)
@@ -224,29 +287,37 @@ def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, cer
     # s2nc indicates the number of resumed connections in its output
     for results in client.get_results():
         results.assert_success()
-        assert results.stdout.count(
-            b'Resumed session') == num_resumed_connections
-        assert to_bytes("Actual protocol version: {}".format(
-            s2n_version)) in results.stdout
+        assert results.stdout.count(b"Resumed session") == num_resumed_connections
+        assert (
+            to_bytes("Actual protocol version: {}".format(s2n_version))
+            in results.stdout
+        )
 
-    server_accepts_str = str(
-        num_resumed_connections + num_full_connections) + " server accepts that finished"
+    server_accepts_str = (
+        str(num_resumed_connections + num_full_connections)
+        + " server accepts that finished"
+    )
 
     for results in server.get_results():
         results.assert_success()
         if provider is S2N:
-            assert results.stdout.count(
-                b'Resumed session') == num_resumed_connections
-            assert to_bytes("Actual protocol version: {}".format(
-                s2n_version)) in results.stdout
+            assert results.stdout.count(b"Resumed session") == num_resumed_connections
+            assert (
+                to_bytes("Actual protocol version: {}".format(s2n_version))
+                in results.stdout
+            )
         else:
             assert to_bytes(server_accepts_str) in results.stdout
             # s_server only writes one certificate message in all of the connections
-            assert results.stderr.count(
-                b'SSL_accept:SSLv3/TLS write certificate') == num_full_connections
+            assert (
+                results.stderr.count(b"SSL_accept:SSLv3/TLS write certificate")
+                == num_full_connections
+            )
 
 
-@pytest.mark.flaky(reruns=7, reruns_delay=2, condition=platform.machine().startswith("aarch"))
+@pytest.mark.flaky(
+    reruns=7, reruns_delay=2, condition=platform.machine().startswith("aarch")
+)
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", TLS13_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
@@ -254,12 +325,20 @@ def test_tls13_session_resumption_s2n_client(managed_process, cipher, curve, cer
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, curve, certificate, protocol, provider,
-                                            other_provider):
+def test_s2nd_falls_back_to_full_connection(
+    managed_process,
+    tmp_path,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    other_provider,
+):
     port = str(next(available_ports))
 
     # Use temp directory to store session tickets
-    p = tmp_path / 'ticket.pem'
+    p = tmp_path / "ticket.pem"
     path_to_ticket = str(p)
 
     """
@@ -275,9 +354,10 @@ def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, c
         curve=curve,
         insecure=True,
         reconnect=False,
-        extra_flags=['-sess_out', path_to_ticket],
+        extra_flags=["-sess_out", path_to_ticket],
         data_to_send=data_bytes(4069),
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = copy.copy(client_options)
     server_options.mode = Provider.ServerMode
@@ -291,16 +371,16 @@ def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, c
     # The client should have received a session ticket
     for results in client.get_results():
         results.assert_success()
-        assert b'Post-Handshake New Session Ticket arrived:' in results.stdout
+        assert b"Post-Handshake New Session Ticket arrived:" in results.stdout
 
     for results in server.get_results():
         results.assert_success()
         # Server should have sent certificate message as this is a full connection
-        assert b'SSL_accept:SSLv3/TLS write certificate' in results.stderr
+        assert b"SSL_accept:SSLv3/TLS write certificate" in results.stderr
 
     # Client inputs received session ticket to resume a session
     assert os.path.exists(path_to_ticket)
-    client_options.extra_flags = ['-sess_in', path_to_ticket]
+    client_options.extra_flags = ["-sess_in", path_to_ticket]
 
     port = str(next(available_ports))
     client_options.port = port
@@ -315,25 +395,32 @@ def test_s2nd_falls_back_to_full_connection(managed_process, tmp_path, cipher, c
     # Client has read server certificate because this is a full connection
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes(
-            "SSL_connect:SSLv3/TLS read server certificate") in results.stderr
+        assert (
+            to_bytes("SSL_connect:SSLv3/TLS read server certificate") in results.stderr
+        )
 
     # The server should indicate a session has not been resumed
     for results in server.get_results():
         results.assert_success()
-        assert b'Resumed session' not in results.stdout
-        assert to_bytes("Actual protocol version: {}".format(
-            s2n_version)) in results.stdout
+        assert b"Resumed session" not in results.stdout
+        assert (
+            to_bytes("Actual protocol version: {}".format(s2n_version))
+            in results.stdout
+        )
 
 
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
-@pytest.mark.parametrize("protocol", [p for p in PROTOCOLS if p < Protocols.TLS13], ids=get_parameter_name)
+@pytest.mark.parametrize(
+    "protocol", [p for p in PROTOCOLS if p < Protocols.TLS13], ids=get_parameter_name
+)
 @pytest.mark.parametrize("provider", [OpenSSL, S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-def test_session_resumption_s2n_client_tls13_server_not_tls13(managed_process, cipher, curve, protocol, provider, other_provider, certificate):
+def test_session_resumption_s2n_client_tls13_server_not_tls13(
+    managed_process, cipher, curve, protocol, provider, other_provider, certificate
+):
     port = next(available_ports)
 
     # This test verifies that an S2N client that supports TLS1.3 can resume sessions
@@ -353,7 +440,8 @@ def test_session_resumption_s2n_client_tls13_server_not_tls13(managed_process, c
         insecure=True,
         reconnect=True,
         use_session_ticket=True,
-        protocol=Protocols.TLS13)
+        protocol=Protocols.TLS13,
+    )
 
     server_options = ProviderOptions(
         mode=Provider.ServerMode,
@@ -366,7 +454,8 @@ def test_session_resumption_s2n_client_tls13_server_not_tls13(managed_process, c
         protocol=protocol,
         reconnects_before_exit=num_resumed_connections + num_full_connections,
         key=certificate.key,
-        cert=certificate.cert)
+        cert=certificate.cert,
+    )
 
     # Passing the type of client and server as a parameter will
     # allow us to use a fixture to enumerate all possibilities.
@@ -374,22 +463,26 @@ def test_session_resumption_s2n_client_tls13_server_not_tls13(managed_process, c
     client = managed_process(S2N, client_options, timeout=5)
 
     expected_version = get_expected_s2n_version(protocol, provider)
-    server_accepts_str = str(
-        num_resumed_connections + num_full_connections) + " server accepts that finished"
+    server_accepts_str = (
+        str(num_resumed_connections + num_full_connections)
+        + " server accepts that finished"
+    )
 
     for results in client.get_results():
         results.assert_success()
-        assert results.stdout.count(
-            b'Resumed session') == num_resumed_connections
-        assert to_bytes("Actual protocol version: {}".format(
-            expected_version)) in results.stdout
+        assert results.stdout.count(b"Resumed session") == num_resumed_connections
+        assert (
+            to_bytes("Actual protocol version: {}".format(expected_version))
+            in results.stdout
+        )
 
     for results in server.get_results():
         results.assert_success()
         if provider is S2N:
-            assert results.stdout.count(
-                b'Resumed session') == num_resumed_connections
-            assert to_bytes("Actual protocol version: {}".format(
-                expected_version)) in results.stdout
+            assert results.stdout.count(b"Resumed session") == num_resumed_connections
+            assert (
+                to_bytes("Actual protocol version: {}".format(expected_version))
+                in results.stdout
+            )
         else:
             assert to_bytes(server_accepts_str) in results.stdout

--- a/tests/integrationv2/test_signature_algorithms.py
+++ b/tests/integrationv2/test_signature_algorithms.py
@@ -7,7 +7,12 @@ from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CERTS
 from common import ProviderOptions, Protocols, Signatures, data_bytes
 from fixtures import managed_process  # lgtm [py/unused-import]
 from providers import Provider, S2N, OpenSSL, GnuTLS
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
+from utils import (
+    invalid_test_parameters,
+    get_parameter_name,
+    get_expected_s2n_version,
+    to_bytes,
+)
 
 all_sigs = [
     Signatures.RSA_SHA1,
@@ -33,7 +38,7 @@ def expected_signature(protocol, signature):
         # ECDSA by default hashes with SHA-1.
         #
         # This is inferred from extended version of TLS1.1 rfc- https://www.rfc-editor.org/rfc/rfc4492#section-5.10
-        if signature.sig_type == 'ECDSA':
+        if signature.sig_type == "ECDSA":
             signature = Signatures.ECDSA_SHA1
         else:
             signature = Signatures.RSA_MD5_SHA1
@@ -41,16 +46,19 @@ def expected_signature(protocol, signature):
 
 
 def signature_marker(mode, signature):
-    return to_bytes("{mode} signature negotiated: {type}+{digest}"
-                    .format(mode=mode.title(), type=signature.sig_type, digest=signature.sig_digest))
+    return to_bytes(
+        "{mode} signature negotiated: {type}+{digest}".format(
+            mode=mode.title(), type=signature.sig_type, digest=signature.sig_digest
+        )
+    )
 
 
 def skip_ciphers(*args, **kwargs):
-    provider = kwargs.get('provider')
-    cert = kwargs.get('certificate')
-    cipher = kwargs.get('cipher')
-    protocol = kwargs.get('protocol')
-    sigalg = kwargs.get('signature')
+    provider = kwargs.get("provider")
+    cert = kwargs.get("certificate")
+    cipher = kwargs.get("cipher")
+    protocol = kwargs.get("protocol")
+    sigalg = kwargs.get("signature")
 
     if not provider.supports_signature(sigalg):
         return True
@@ -74,12 +82,28 @@ def skip_ciphers(*args, **kwargs):
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL, GnuTLS])
 @pytest.mark.parametrize("other_provider", [S2N])
-@pytest.mark.parametrize("protocol", [Protocols.TLS13, Protocols.TLS12, Protocols.TLS11], ids=get_parameter_name)
+@pytest.mark.parametrize(
+    "protocol",
+    [Protocols.TLS13, Protocols.TLS12, Protocols.TLS11],
+    ids=get_parameter_name,
+)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("signature", all_sigs, ids=get_parameter_name)
-@pytest.mark.parametrize("client_auth", [True, False], ids=lambda val: "client-auth" if val else "no-client-auth")
-def test_s2n_server_signature_algorithms(managed_process, cipher, provider, other_provider, protocol, certificate,
-                                         signature, client_auth):
+@pytest.mark.parametrize(
+    "client_auth",
+    [True, False],
+    ids=lambda val: "client-auth" if val else "no-client-auth",
+)
+def test_s2n_server_signature_algorithms(
+    managed_process,
+    cipher,
+    provider,
+    other_provider,
+    protocol,
+    certificate,
+    signature,
+    client_auth,
+):
     port = next(available_ports)
 
     random_bytes = data_bytes(64)
@@ -93,7 +117,7 @@ def test_s2n_server_signature_algorithms(managed_process, cipher, provider, othe
         key=certificate.key,
         cert=certificate.cert,
         signature_algorithm=signature,
-        protocol=protocol
+        protocol=protocol,
     )
 
     if provider == GnuTLS:
@@ -117,12 +141,22 @@ def test_s2n_server_signature_algorithms(managed_process, cipher, provider, othe
 
     for results in server.get_results():
         results.assert_success()
-        assert to_bytes("Actual protocol version: {}".format(
-            expected_version)) in results.stdout
-        assert signature_marker(Provider.ServerMode,
-                                expected_signature(protocol, signature)) in results.stdout
-        assert (signature_marker(Provider.ClientMode,
-                                 expected_signature(protocol, signature)) in results.stdout) == client_auth
+        assert (
+            to_bytes("Actual protocol version: {}".format(expected_version))
+            in results.stdout
+        )
+        assert (
+            signature_marker(
+                Provider.ServerMode, expected_signature(protocol, signature)
+            )
+            in results.stdout
+        )
+        assert (
+            signature_marker(
+                Provider.ClientMode, expected_signature(protocol, signature)
+            )
+            in results.stdout
+        ) == client_auth
         assert random_bytes in results.stdout
 
 
@@ -130,12 +164,28 @@ def test_s2n_server_signature_algorithms(managed_process, cipher, provider, othe
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL, GnuTLS])
 @pytest.mark.parametrize("other_provider", [S2N])
-@pytest.mark.parametrize("protocol", [Protocols.TLS13, Protocols.TLS12, Protocols.TLS11], ids=get_parameter_name)
+@pytest.mark.parametrize(
+    "protocol",
+    [Protocols.TLS13, Protocols.TLS12, Protocols.TLS11],
+    ids=get_parameter_name,
+)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("signature", all_sigs, ids=get_parameter_name)
-@pytest.mark.parametrize("client_auth", [True, False], ids=lambda val: "client-auth" if val else "no-client-auth")
-def test_s2n_client_signature_algorithms(managed_process, cipher, provider, other_provider, protocol, certificate,
-                                         signature, client_auth):
+@pytest.mark.parametrize(
+    "client_auth",
+    [True, False],
+    ids=lambda val: "client-auth" if val else "no-client-auth",
+)
+def test_s2n_client_signature_algorithms(
+    managed_process,
+    cipher,
+    provider,
+    other_provider,
+    protocol,
+    certificate,
+    signature,
+    client_auth,
+):
     port = next(available_ports)
 
     random_bytes = data_bytes(64)
@@ -148,7 +198,8 @@ def test_s2n_client_signature_algorithms(managed_process, cipher, provider, othe
         use_client_auth=client_auth,
         key=certificate.key,
         cert=certificate.cert,
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = copy.copy(client_options)
     server_options.data_to_send = None
@@ -162,14 +213,14 @@ def test_s2n_client_signature_algorithms(managed_process, cipher, provider, othe
     if provider == GnuTLS:
         kill_marker = random_bytes
 
-    server = managed_process(provider, server_options,
-                             timeout=5, kill_marker=kill_marker)
+    server = managed_process(
+        provider, server_options, timeout=5, kill_marker=kill_marker
+    )
     client = managed_process(S2N, client_options, timeout=5)
 
     for results in server.get_results():
         results.assert_success()
-        assert any(
-            [random_bytes in stream for stream in results.output_streams()])
+        assert any([random_bytes in stream for stream in results.output_streams()])
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
@@ -181,14 +232,24 @@ def test_s2n_client_signature_algorithms(managed_process, cipher, provider, othe
     #
     # This mostly has to be inferred from the RFCs, but this blog post is a pretty good summary
     # of the situation: https://timtaubert.de/blog/2016/07/the-evolution-of-signatures-in-tls/
-    server_sigalg_used = not cipher.iana_standard_name.startswith(
-        "TLS_RSA_WITH_")
+    server_sigalg_used = not cipher.iana_standard_name.startswith("TLS_RSA_WITH_")
 
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes("Actual protocol version: {}".format(
-            expected_version)) in results.stdout
-        assert signature_marker(
-            Provider.ServerMode, expected_signature(protocol, signature)) in results.stdout or not server_sigalg_used
-        assert (signature_marker(Provider.ClientMode, expected_signature(protocol, signature))
-                in results.stdout) == client_auth
+        assert (
+            to_bytes("Actual protocol version: {}".format(expected_version))
+            in results.stdout
+        )
+        assert (
+            signature_marker(
+                Provider.ServerMode, expected_signature(protocol, signature)
+            )
+            in results.stdout
+            or not server_sigalg_used
+        )
+        assert (
+            signature_marker(
+                Provider.ClientMode, expected_signature(protocol, signature)
+            )
+            in results.stdout
+        ) == client_auth

--- a/tests/integrationv2/test_sni_match.py
+++ b/tests/integrationv2/test_sni_match.py
@@ -6,7 +6,12 @@ from configuration import available_ports, MULTI_CERT_TEST_CASES
 from common import ProviderOptions, Protocols
 from fixtures import managed_process  # lgtm [py/unused-import]
 from providers import Provider, S2N, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, to_bytes
+from utils import (
+    invalid_test_parameters,
+    get_parameter_name,
+    get_expected_s2n_version,
+    to_bytes,
+)
 
 
 def filter_cipher_list(*args, **kwargs):
@@ -17,11 +22,12 @@ def filter_cipher_list(*args, **kwargs):
 
     This function handles that unique grouping.
     """
-    protocol = kwargs.get('protocol')
-    cert_test_case = kwargs.get('cert_test_case')
+    protocol = kwargs.get("protocol")
+    cert_test_case = kwargs.get("cert_test_case")
 
     lowest_protocol_cipher = min(
-        cert_test_case.client_ciphers, key=lambda x: x.min_version)
+        cert_test_case.client_ciphers, key=lambda x: x.min_version
+    )
     if protocol < lowest_protocol_cipher.min_version:
         return True
 
@@ -31,7 +37,9 @@ def filter_cipher_list(*args, **kwargs):
 @pytest.mark.uncollect_if(func=filter_cipher_list)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-@pytest.mark.parametrize("protocol", [Protocols.TLS13, Protocols.TLS12], ids=get_parameter_name)
+@pytest.mark.parametrize(
+    "protocol", [Protocols.TLS13, Protocols.TLS12], ids=get_parameter_name
+)
 @pytest.mark.parametrize("cert_test_case", MULTI_CERT_TEST_CASES)
 def test_sni_match(managed_process, provider, other_provider, protocol, cert_test_case):
     port = next(available_ports)
@@ -43,20 +51,18 @@ def test_sni_match(managed_process, provider, other_provider, protocol, cert_tes
         verify_hostname=True,
         server_name=cert_test_case.client_sni,
         cipher=cert_test_case.client_ciphers,
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = ProviderOptions(
-        mode=Provider.ServerMode,
-        port=port,
-        extra_flags=[],
-        protocol=protocol)
+        mode=Provider.ServerMode, port=port, extra_flags=[], protocol=protocol
+    )
 
     # Setup the certificate chain for S2ND based on the multicert test case
-    cert_key_list = [(cert[0], cert[1])
-                     for cert in cert_test_case.server_certs]
+    cert_key_list = [(cert[0], cert[1]) for cert in cert_test_case.server_certs]
     for cert_key_path in cert_key_list:
-        server_options.extra_flags.extend(['--cert', cert_key_path[0]])
-        server_options.extra_flags.extend(['--key', cert_key_path[1]])
+        server_options.extra_flags.extend(["--cert", cert_key_path[0]])
+        server_options.extra_flags.extend(["--key", cert_key_path[1]])
 
     server = managed_process(S2N, server_options, timeout=5)
     client = managed_process(provider, client_options, timeout=5)
@@ -68,8 +74,12 @@ def test_sni_match(managed_process, provider, other_provider, protocol, cert_tes
 
     for results in server.get_results():
         results.assert_success()
-        assert to_bytes("Actual protocol version: {}".format(
-            expected_version)) in results.stdout
+        assert (
+            to_bytes("Actual protocol version: {}".format(expected_version))
+            in results.stdout
+        )
         if cert_test_case.client_sni is not None:
-            assert to_bytes("Server name: {}".format(
-                cert_test_case.client_sni)) in results.stdout
+            assert (
+                to_bytes("Server name: {}".format(cert_test_case.client_sni))
+                in results.stdout
+            )

--- a/tests/integrationv2/test_sslyze.py
+++ b/tests/integrationv2/test_sslyze.py
@@ -19,7 +19,7 @@ PROTOCOLS_TO_TEST = [
     Protocols.TLS10,
     Protocols.TLS11,
     Protocols.TLS12,
-    Protocols.TLS13
+    Protocols.TLS13,
 ]
 
 SSLYZE_SCANS_TO_TEST = [
@@ -30,11 +30,14 @@ SSLYZE_SCANS_TO_TEST = [
     sslyze.ScanCommand.TLS_FALLBACK_SCSV,
     sslyze.ScanCommand.HEARTBLEED,
     sslyze.ScanCommand.OPENSSL_CCS_INJECTION,
-    sslyze.ScanCommand.SESSION_RENEGOTIATION
+    sslyze.ScanCommand.SESSION_RENEGOTIATION,
 ]
 
 CERTS_TO_TEST = [
-    cert for cert in ALL_TEST_CERTS if cert.name not in {
+    cert
+    for cert in ALL_TEST_CERTS
+    if cert.name
+    not in {
         "RSA_PSS_2048_SHA256"  # SSLyze errors when given an RSA PSS cert
     }
 ]
@@ -44,7 +47,7 @@ CIPHER_SUITE_SCANS = {
     Protocols.TLS10.value: sslyze.ScanCommand.TLS_1_0_CIPHER_SUITES,
     Protocols.TLS11.value: sslyze.ScanCommand.TLS_1_1_CIPHER_SUITES,
     Protocols.TLS12.value: sslyze.ScanCommand.TLS_1_2_CIPHER_SUITES,
-    Protocols.TLS13.value: sslyze.ScanCommand.TLS_1_3_CIPHER_SUITES
+    Protocols.TLS13.value: sslyze.ScanCommand.TLS_1_3_CIPHER_SUITES,
 }
 
 
@@ -66,7 +69,8 @@ class CipherSuitesVerifier(ScanVerifier):
         assert self.scan_result.is_tls_version_supported is True
 
         rejected_ciphers = [
-            cipher for rejected_cipher in self.scan_result.rejected_cipher_suites
+            cipher
+            for rejected_cipher in self.scan_result.rejected_cipher_suites
             if (cipher := Ciphers.from_iana(rejected_cipher.cipher_suite.name))
         ]
 
@@ -77,7 +81,7 @@ class CipherSuitesVerifier(ScanVerifier):
                 protocol=self.protocol,
                 provider=S2N,
                 certificate=self.certificate,
-                cipher=cipher
+                cipher=cipher,
             )
 
 
@@ -86,13 +90,16 @@ class EllipticCurveVerifier(ScanVerifier):
         assert self.scan_result.supports_ecdh_key_exchange is True
 
         rejected_curves = [
-            curve for rejected_curve in self.scan_result.rejected_curves
-            if (curve := {
-                "X25519": Curves.X25519,
-                "prime256v1": Curves.P256,
-                "prime384v1": Curves.P384,
-                "prime521v1": Curves.P521
-            }.get(rejected_curve.name))
+            curve
+            for rejected_curve in self.scan_result.rejected_curves
+            if (
+                curve := {
+                    "X25519": Curves.X25519,
+                    "prime256v1": Curves.P256,
+                    "prime384v1": Curves.P384,
+                    "prime521v1": Curves.P521,
+                }.get(rejected_curve.name)
+            )
         ]
 
         for curve in rejected_curves:
@@ -102,16 +109,22 @@ class EllipticCurveVerifier(ScanVerifier):
                 protocol=self.protocol,
                 provider=S2N,
                 certificate=self.certificate,
-                curve=curve
+                curve=curve,
             )
 
 
 class RobotVerifier(ScanVerifier):
     def assert_scan_success(self):
         if self.protocol == Protocols.TLS13:
-            assert self.scan_result.robot_result == sslyze.RobotScanResultEnum.NOT_VULNERABLE_RSA_NOT_SUPPORTED
+            assert (
+                self.scan_result.robot_result
+                == sslyze.RobotScanResultEnum.NOT_VULNERABLE_RSA_NOT_SUPPORTED
+            )
         else:
-            assert self.scan_result.robot_result == sslyze.RobotScanResultEnum.NOT_VULNERABLE_NO_ORACLE
+            assert (
+                self.scan_result.robot_result
+                == sslyze.RobotScanResultEnum.NOT_VULNERABLE_NO_ORACLE
+            )
 
 
 class SessionResumptionVerifier(ScanVerifier):
@@ -119,7 +132,10 @@ class SessionResumptionVerifier(ScanVerifier):
         if self.protocol == Protocols.TLS13:
             pass  # SSLyze does not support session resumption scans for tls 1.3
         else:
-            assert self.scan_result.tls_ticket_resumption_result == sslyze.TlsResumptionSupportEnum.FULLY_SUPPORTED
+            assert (
+                self.scan_result.tls_ticket_resumption_result
+                == sslyze.TlsResumptionSupportEnum.FULLY_SUPPORTED
+            )
 
 
 class CrimeVerifier(ScanVerifier):
@@ -160,16 +176,16 @@ def validate_scan_result(scan_attempt, protocol, certificate=None):
     scan_result = scan_attempt.result
 
     verifier_cls = {
-        sslyze.CipherSuitesScanResult:              CipherSuitesVerifier,
-        sslyze.SupportedEllipticCurvesScanResult:   EllipticCurveVerifier,
-        sslyze.RobotScanResult:                     RobotVerifier,
-        sslyze.SessionResumptionSupportScanResult:  SessionResumptionVerifier,
-        sslyze.CompressionScanResult:               CrimeVerifier,
-        sslyze.EarlyDataScanResult:                 EarlyDataVerifier,
-        sslyze.FallbackScsvScanResult:              DowngradePreventionVerifier,
-        sslyze.HeartbleedScanResult:                HeartbleedVerifier,
-        sslyze.OpenSslCcsInjectionScanResult:       CCSInjectionVerifier,
-        sslyze.SessionRenegotiationScanResult:      InsecureRenegotiationVerifier
+        sslyze.CipherSuitesScanResult: CipherSuitesVerifier,
+        sslyze.SupportedEllipticCurvesScanResult: EllipticCurveVerifier,
+        sslyze.RobotScanResult: RobotVerifier,
+        sslyze.SessionResumptionSupportScanResult: SessionResumptionVerifier,
+        sslyze.CompressionScanResult: CrimeVerifier,
+        sslyze.EarlyDataScanResult: EarlyDataVerifier,
+        sslyze.FallbackScsvScanResult: DowngradePreventionVerifier,
+        sslyze.HeartbleedScanResult: HeartbleedVerifier,
+        sslyze.OpenSslCcsInjectionScanResult: CCSInjectionVerifier,
+        sslyze.SessionRenegotiationScanResult: InsecureRenegotiationVerifier,
     }.get(type(scan_result))
 
     assert verifier_cls is not None, f"unexpected scan: {scan_attempt}"
@@ -181,12 +197,15 @@ def validate_scan_result(scan_attempt, protocol, certificate=None):
 def get_scan_attempts(scan_results):
     # scan_results (sslyze.AllScanCommandsAttempts) is an object containing parameters mapped to scan attempts. convert
     # this to a list containing just scan attempts, and then filter out tests that were not scheduled.
-    scan_attribute_names = [attr_name for attr_name in dir(
-        scan_results) if not attr_name.startswith("__")]
-    scan_attempts = [getattr(scan_results, attr_name)
-                     for attr_name in scan_attribute_names]
+    scan_attribute_names = [
+        attr_name for attr_name in dir(scan_results) if not attr_name.startswith("__")
+    ]
     scan_attempts = [
-        scan_attempt for scan_attempt in scan_attempts
+        getattr(scan_results, attr_name) for attr_name in scan_attribute_names
+    ]
+    scan_attempts = [
+        scan_attempt
+        for scan_attempt in scan_attempts
         if scan_attempt.status != sslyze.ScanCommandAttemptStatusEnum.NOT_SCHEDULED
     ]
     return scan_attempts
@@ -196,19 +215,23 @@ def assert_scan_result_completed(scan_result):
     def get_connectivity_error_str(tb):
         return "\n".join(tb.stack.format())
 
-    assert scan_result.connectivity_status == sslyze.ServerConnectivityStatusEnum.COMPLETED, \
+    assert (
+        scan_result.connectivity_status == sslyze.ServerConnectivityStatusEnum.COMPLETED
+    ), (
         f"sslyze could not connect to server: {get_connectivity_error_str(scan_result.connectivity_error_trace)}"
+    )
 
 
 def assert_scan_attempt_completed(scan_attempt):
-    assert scan_attempt.status == sslyze.ScanCommandAttemptStatusEnum.COMPLETED, \
+    assert scan_attempt.status == sslyze.ScanCommandAttemptStatusEnum.COMPLETED, (
         f"scan attempt ({scan_attempt}) failed: {scan_attempt.status}"
+    )
 
 
 def run_sslyze_scan(host, port, scans):
     scan_request = sslyze.ServerScanRequest(
         server_location=sslyze.ServerNetworkLocation(hostname=host, port=port),
-        scan_commands=scans
+        scan_commands=scans,
     )
     scanner = sslyze.Scanner(per_server_concurrent_connections_limit=1)
     scanner.queue_scans([scan_request])
@@ -224,7 +247,7 @@ def invalid_sslyze_scan_parameters(*args, **kwargs):
     if "fips" in get_flag(S2N_PROVIDER_VERSION) and protocol != Protocols.TLS13:
         if scan_command in [
             sslyze.ScanCommand.TLS_COMPRESSION,
-            sslyze.ScanCommand.SESSION_RENEGOTIATION
+            sslyze.ScanCommand.SESSION_RENEGOTIATION,
         ]:
             return True
     # BUG_IN_SSLYZE error for session resumption scan with openssl 1.0.2 fips
@@ -247,25 +270,29 @@ def test_sslyze_scans(managed_process, protocol, scan_command, provider):
         host=HOST,
         port=port,
         protocol=protocol,
-        extra_flags=["--parallelize"]
+        extra_flags=["--parallelize"],
     )
 
     # Test 1.3 exclusively
     if protocol == Protocols.TLS13:
         server_options.cipher = Cipher(
-            "test_all_tls13", Protocols.TLS13, False, False, s2n=True)
+            "test_all_tls13", Protocols.TLS13, False, False, s2n=True
+        )
 
     if scan_command == sslyze.ScanCommand.SESSION_RESUMPTION:
-        server_options.reconnect = True,
-        server_options.use_session_ticket = True,
+        server_options.reconnect = (True,)
+        server_options.use_session_ticket = (True,)
 
     if scan_command == sslyze.ScanCommand.TLS_1_3_EARLY_DATA:
         server_options.insecure = True
         server_options.use_session_ticket = True
-        server_options.extra_flags.extend([
-            "--max-early-data", "65535",
-            "--https-server"  # Early data scan sends http requests
-        ])
+        server_options.extra_flags.extend(
+            [
+                "--max-early-data",
+                "65535",
+                "--https-server",  # Early data scan sends http requests
+            ]
+        )
 
     server = managed_process(S2N, server_options, timeout=30)
 
@@ -306,7 +333,7 @@ def invalid_certificate_scans_parameters(*args, **kwargs):
             if "RSA" in certificate.name and protocol in [
                 Protocols.SSLv3,
                 Protocols.TLS10,
-                Protocols.TLS11
+                Protocols.TLS11,
             ]:
                 return True
     elif certificate_scan == CertificateScan.ELLIPTIC_CURVE_SCAN:
@@ -325,11 +352,14 @@ def invalid_certificate_scans_parameters(*args, **kwargs):
 @pytest.mark.parametrize("protocol", PROTOCOLS_TO_TEST, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", CERTS_TO_TEST, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [S2N], ids=get_parameter_name)
-@pytest.mark.parametrize("certificate_scan", [
-    CertificateScan.CIPHER_SUITE_SCAN,
-    CertificateScan.ELLIPTIC_CURVE_SCAN
-], ids=lambda certificate_scan: certificate_scan.name)
-def test_sslyze_certificate_scans(managed_process, protocol, certificate, provider, certificate_scan):
+@pytest.mark.parametrize(
+    "certificate_scan",
+    [CertificateScan.CIPHER_SUITE_SCAN, CertificateScan.ELLIPTIC_CURVE_SCAN],
+    ids=lambda certificate_scan: certificate_scan.name,
+)
+def test_sslyze_certificate_scans(
+    managed_process, protocol, certificate, provider, certificate_scan
+):
     port = next(available_ports)
 
     server_options = ProviderOptions(
@@ -340,13 +370,13 @@ def test_sslyze_certificate_scans(managed_process, protocol, certificate, provid
         key=certificate.key,
         cert=certificate.cert,
         insecure=True,
-        extra_flags=["--parallelize"]
+        extra_flags=["--parallelize"],
     )
     server = managed_process(S2N, server_options, timeout=30)
 
     scan = {
         CertificateScan.CIPHER_SUITE_SCAN: CIPHER_SUITE_SCANS.get(protocol.value),
-        CertificateScan.ELLIPTIC_CURVE_SCAN: sslyze.ScanCommand.ELLIPTIC_CURVES
+        CertificateScan.ELLIPTIC_CURVE_SCAN: sslyze.ScanCommand.ELLIPTIC_CURVES,
     }.get(certificate_scan)
 
     scan_attempt_results = run_sslyze_scan(HOST, port, [scan])

--- a/tests/integrationv2/test_version_negotiation.py
+++ b/tests/integrationv2/test_version_negotiation.py
@@ -3,12 +3,23 @@
 import copy
 import pytest
 
-from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, ALL_TEST_CERTS
+from configuration import (
+    available_ports,
+    ALL_TEST_CIPHERS,
+    ALL_TEST_CURVES,
+    ALL_TEST_CERTS,
+)
 from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process  # lgtm [py/unused-import]
 from providers import Provider, S2N, OpenSSL, GnuTLS
-from utils import invalid_test_parameters, get_parameter_name, get_expected_s2n_version, get_expected_openssl_version, \
-    to_bytes, get_expected_gnutls_version
+from utils import (
+    invalid_test_parameters,
+    get_parameter_name,
+    get_expected_s2n_version,
+    get_expected_openssl_version,
+    to_bytes,
+    get_expected_gnutls_version,
+)
 
 
 def test_nothing():
@@ -22,10 +33,7 @@ def test_nothing():
 
 def invalid_version_negotiation_test_parameters(*args, **kwargs):
     # Since s2nd/s2nc will always be using TLS 1.3, make sure the libcrypto is compatible
-    if invalid_test_parameters(**{
-        "provider": S2N,
-        "protocol": Protocols.TLS13
-    }):
+    if invalid_test_parameters(**{"provider": S2N, "protocol": Protocols.TLS13}):
         return True
 
     return invalid_test_parameters(*args, **kwargs)
@@ -35,10 +43,16 @@ def invalid_version_negotiation_test_parameters(*args, **kwargs):
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
-@pytest.mark.parametrize("protocol", [Protocols.TLS12, Protocols.TLS11, Protocols.TLS10], ids=get_parameter_name)
+@pytest.mark.parametrize(
+    "protocol",
+    [Protocols.TLS12, Protocols.TLS11, Protocols.TLS10],
+    ids=get_parameter_name,
+)
 @pytest.mark.parametrize("provider", [S2N, OpenSSL, GnuTLS], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, certificate, protocol, provider, other_provider):
+def test_s2nc_tls13_negotiates_tls12(
+    managed_process, cipher, curve, certificate, protocol, provider, other_provider
+):
     port = next(available_ports)
 
     random_bytes = data_bytes(24)
@@ -49,7 +63,7 @@ def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, certificate
         curve=curve,
         data_to_send=random_bytes,
         insecure=True,
-        protocol=Protocols.TLS13
+        protocol=Protocols.TLS13,
     )
 
     server_options = copy.copy(client_options)
@@ -63,8 +77,9 @@ def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, certificate
     if provider == GnuTLS:
         kill_marker = random_bytes
 
-    server = managed_process(provider, server_options,
-                             timeout=5, kill_marker=kill_marker)
+    server = managed_process(
+        provider, server_options, timeout=5, kill_marker=kill_marker
+    )
     client = managed_process(S2N, client_options, timeout=5)
 
     client_version = get_expected_s2n_version(Protocols.TLS13, provider)
@@ -72,10 +87,14 @@ def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, certificate
 
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes("Client protocol version: {}".format(
-            client_version)) in results.stdout
-        assert to_bytes("Actual protocol version: {}".format(
-            actual_version)) in results.stdout
+        assert (
+            to_bytes("Client protocol version: {}".format(client_version))
+            in results.stdout
+        )
+        assert (
+            to_bytes("Actual protocol version: {}".format(actual_version))
+            in results.stdout
+        )
 
     for results in server.get_results():
         results.assert_success()
@@ -83,25 +102,32 @@ def test_s2nc_tls13_negotiates_tls12(managed_process, cipher, curve, certificate
         # whether the S2N client was able to negotiate a lower TLS version.
         if provider is S2N:
             # The client sends a TLS 1.3 client hello so a client protocol version of TLS 1.3 should always be expected.
-            assert to_bytes("Client protocol version: {}".format(
-                Protocols.TLS13.value)) in results.stdout
-            assert to_bytes("Actual protocol version: {}".format(
-                actual_version)) in results.stdout
+            assert (
+                to_bytes("Client protocol version: {}".format(Protocols.TLS13.value))
+                in results.stdout
+            )
+            assert (
+                to_bytes("Actual protocol version: {}".format(actual_version))
+                in results.stdout
+            )
 
-        assert any([
-            random_bytes[1:] in stream
-            for stream in results.output_streams()
-        ])
+        assert any([random_bytes[1:] in stream for stream in results.output_streams()])
 
 
 @pytest.mark.uncollect_if(func=invalid_version_negotiation_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
-@pytest.mark.parametrize("protocol", [Protocols.TLS12, Protocols.TLS11, Protocols.TLS10], ids=get_parameter_name)
+@pytest.mark.parametrize(
+    "protocol",
+    [Protocols.TLS12, Protocols.TLS11, Protocols.TLS10],
+    ids=get_parameter_name,
+)
 @pytest.mark.parametrize("provider", [S2N, OpenSSL, GnuTLS], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
-def test_s2nd_tls13_negotiates_tls12(managed_process, cipher, curve, certificate, protocol, provider, other_provider):
+def test_s2nd_tls13_negotiates_tls12(
+    managed_process, cipher, curve, certificate, protocol, provider, other_provider
+):
     port = next(available_ports)
 
     random_bytes = data_bytes(24)
@@ -112,7 +138,7 @@ def test_s2nd_tls13_negotiates_tls12(managed_process, cipher, curve, certificate
         curve=curve,
         data_to_send=random_bytes,
         insecure=True,
-        protocol=protocol
+        protocol=protocol,
     )
 
     server_options = copy.copy(client_options)
@@ -134,16 +160,19 @@ def test_s2nd_tls13_negotiates_tls12(managed_process, cipher, curve, certificate
         results.assert_success()
         if provider is S2N:
             # The client will get the server version from the SERVER HELLO, which will be the negotiated version
-            assert to_bytes("Server protocol version: {}".format(
-                actual_version)) in results.stdout
-            assert to_bytes("Actual protocol version: {}".format(
-                actual_version)) in results.stdout
+            assert (
+                to_bytes("Server protocol version: {}".format(actual_version))
+                in results.stdout
+            )
+            assert (
+                to_bytes("Actual protocol version: {}".format(actual_version))
+                in results.stdout
+            )
         elif provider is OpenSSL:
             # This check cares about other providers because we want to know that they did negotiate the version
             # that our S2N server intended to negotiate.
             openssl_version = get_expected_openssl_version(protocol)
-            assert to_bytes("Protocol  : {}".format(
-                openssl_version)) in results.stdout
+            assert to_bytes("Protocol  : {}".format(openssl_version)) in results.stdout
         elif provider is GnuTLS:
             gnutls_version = get_expected_gnutls_version(protocol)
             assert to_bytes(f"Version: {gnutls_version}") in results.stdout

--- a/tests/integrationv2/test_well_known_endpoints.py
+++ b/tests/integrationv2/test_well_known_endpoints.py
@@ -1,13 +1,14 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+
 def test_well_known_endpoints():
-    '''
-    This is a stub test, which allows the existing CI to continue passing while 
+    """
+    This is a stub test, which allows the existing CI to continue passing while
     https://github.com/aws/s2n-tls/pull/4884 is merged in.
 
     Once the PR is merged, the Codebuild spec for NixIntegV2Batch will be updated
     to remove the "well_known_endpoints" argument (manual process) and then this test
     can be fully removed (PR).
-    '''
+    """
     assert 1 == 1

--- a/tests/integrationv2/utils.py
+++ b/tests/integrationv2/utils.py
@@ -6,7 +6,7 @@ from global_flags import get_flag, S2N_FIPS_MODE
 
 
 def to_bytes(val):
-    return bytes(str(val).encode('utf-8'))
+    return bytes(str(val).encode("utf-8"))
 
 
 def to_string(val: bytes):
@@ -22,7 +22,7 @@ def get_expected_s2n_version(protocol, provider):
     protocol is less than tls12.
     """
     if provider == S2N and protocol != Protocols.TLS13:
-        version = '33'
+        version = "33"
     else:
         version = protocol.value
 
@@ -34,7 +34,7 @@ def get_expected_openssl_version(protocol):
         Protocols.TLS10.value: "TLSv1",
         Protocols.TLS11.value: "TLSv1.1",
         Protocols.TLS12.value: "TLSv1.2",
-        Protocols.TLS13.value: "TLSv1.3"
+        Protocols.TLS13.value: "TLSv1.3",
     }.get(protocol.value)
 
 
@@ -43,7 +43,7 @@ def get_expected_gnutls_version(protocol):
         Protocols.TLS10.value: "TLS1.0",
         Protocols.TLS11.value: "TLS1.1",
         Protocols.TLS12.value: "TLS1.2",
-        Protocols.TLS13.value: "TLS1.3"
+        Protocols.TLS13.value: "TLS1.3",
     }.get(protocol.value)
 
 
@@ -59,14 +59,14 @@ def invalid_test_parameters(*args, **kwargs):
     This function returns True or False, indicating whether a
     test should be "deselected" based on the arguments.
     """
-    protocol = kwargs.get('protocol')
-    provider = kwargs.get('provider')
-    other_provider = kwargs.get('other_provider')
-    certificate = kwargs.get('certificate')
-    client_certificate = kwargs.get('client_certificate')
-    cipher = kwargs.get('cipher')
-    curve = kwargs.get('curve')
-    signature = kwargs.get('signature')
+    protocol = kwargs.get("protocol")
+    provider = kwargs.get("provider")
+    other_provider = kwargs.get("other_provider")
+    certificate = kwargs.get("certificate")
+    client_certificate = kwargs.get("client_certificate")
+    cipher = kwargs.get("cipher")
+    curve = kwargs.get("curve")
+    signature = kwargs.get("signature")
 
     providers = [provider_ for provider_ in [provider, other_provider] if provider_]
     # Always consider S2N
@@ -76,9 +76,9 @@ def invalid_test_parameters(*args, **kwargs):
 
     # Older versions do not support RSA-PSS-PSS certificates
     if protocol and protocol < Protocols.TLS12:
-        if client_certificate and client_certificate.algorithm == 'RSAPSS':
+        if client_certificate and client_certificate.algorithm == "RSAPSS":
             return True
-        if certificate and certificate.algorithm == 'RSAPSS':
+        if certificate and certificate.algorithm == "RSAPSS":
             return True
 
     for provider_ in providers:


### PR DESCRIPTION
### Resolved issues:

resolves #5027 

### Description of changes:
* Reformatted all tests/integrationv2 files using ruff
* Replaced autopep8 with ruff as the default formatter in CI (ci_linting.yml).

#### Manual changes:
* Replaced autopep8 with ruff in ci_linting.yml.

#### Automated changes:
* Used `uv run ruff format` to format all files in tests/integrationv2.

#### Why replace autopep8 with ruff?
* Ruff provides a rustfmt-like experience, meaning it enforces a standardized, opinionated code style with minimal configuration. Unlike autopep8, which primarily focuses on fixing formatting issues, ruff operates with a "set it and forget it" approach—developers do not need to fine-tune settings or make repeated manual fixes to satisfy linting rules.
* Unlike autopep8, which only handles formatting, ruff also functions as a linter and static analysis tool, reducing the need for multiple dependencies.
* Ruff is significantly faster than autopep8, improving efficiency in both local development and CI runs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
