### PR TITLE
refactor: cleanup prf header

### DIFF
--- a/tests/unit/s2n_ssl_prf_test.c
+++ b/tests/unit/s2n_ssl_prf_test.c
@@ -22,8 +22,9 @@
 #include "testlib/s2n_testlib.h"
 #include "tls/s2n_prf.h"
 
-/*
+int s2n_prf_tls_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret);
 
+/*
  * Grabbed from gnutls-cli --insecure -d 9 www.example.com --ciphers AES --macs SHA --protocols SSLv3
  *
  * |<9>| INT: PREMASTER SECRET[48]: 03009e8e006a7f1451d32164088a8cba5077d1b819160662a97e90a765cec244b5f8f98fd50cfe8e4fba97994a7a4843
@@ -86,7 +87,7 @@ int main(int argc, char **argv)
     conn->actual_protocol_version = S2N_SSLv3;
     pms.data = conn->secrets.version.tls12.rsa_premaster_secret;
     pms.size = sizeof(conn->secrets.version.tls12.rsa_premaster_secret);
-    EXPECT_SUCCESS(s2n_tls_prf_master_secret(conn, &pms));
+    EXPECT_SUCCESS(s2n_prf_tls_master_secret(conn, &pms));
 
     /* Convert the master secret to hex */
     for (int i = 0; i < 48; i++) {

--- a/tests/unit/s2n_tls_hybrid_prf_test.c
+++ b/tests/unit/s2n_tls_hybrid_prf_test.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
 
         EXPECT_MEMCPY_SUCCESS(conn->kex_params.client_key_exchange_message.data, client_key_exchange_message, client_key_exchange_message_length);
 
-        EXPECT_SUCCESS(s2n_hybrid_prf_master_secret(conn, &combined_pms));
+        EXPECT_SUCCESS(s2n_prf_hybrid_master_secret(conn, &combined_pms));
         EXPECT_BYTEARRAY_EQUAL(expected_master_secret, conn->secrets.version.tls12.master_secret, S2N_TLS_SECRET_LEN);
         EXPECT_SUCCESS(s2n_free(&conn->kex_params.client_key_exchange_message));
         EXPECT_SUCCESS(s2n_connection_free(conn));

--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -245,7 +245,7 @@ const struct s2n_kex s2n_hybrid_ecdhe_kem = {
     .server_key_send = &s2n_hybrid_server_key_send,
     .client_key_recv = &s2n_hybrid_client_key_recv,
     .client_key_send = &s2n_hybrid_client_key_send,
-    .prf = &s2n_hybrid_prf_master_secret,
+    .prf = &s2n_prf_hybrid_master_secret,
 };
 
 /* TLS1.3 key exchange is implemented differently from previous versions and does

--- a/tls/s2n_prf.h
+++ b/tls/s2n_prf.h
@@ -17,18 +17,12 @@
 
 #include <stdint.h>
 
-#include "crypto/s2n_hash.h"
 #include "crypto/s2n_hmac.h"
+#include "tls/s2n_connection.h"
 #include "utils/s2n_blob.h"
 
 /* Enough to support TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, 2*SHA384_DIGEST_LEN + 2*AES256_KEY_SIZE */
 #define S2N_MAX_KEY_BLOCK_LEN 160
-
-#if defined(OPENSSL_IS_AWSLC)
-    #define S2N_LIBCRYPTO_SUPPORTS_TLS_PRF 1
-#else
-    #define S2N_LIBCRYPTO_SUPPORTS_TLS_PRF 0
-#endif
 
 union p_hash_state {
     struct s2n_hmac_state s2n_hmac;
@@ -39,18 +33,6 @@ struct s2n_prf_working_space {
     union p_hash_state p_hash;
     uint8_t digest0[S2N_MAX_DIGEST_LEN];
     uint8_t digest1[S2N_MAX_DIGEST_LEN];
-};
-
-/* The s2n p_hash implementation is abstracted to allow for separate implementations, using
- * either s2n's formally verified HMAC or OpenSSL's EVP HMAC, for use by the TLS PRF. */
-struct s2n_p_hash_hmac {
-    int (*alloc)(struct s2n_prf_working_space *ws);
-    int (*init)(struct s2n_prf_working_space *ws, s2n_hmac_algorithm alg, struct s2n_blob *secret);
-    int (*update)(struct s2n_prf_working_space *ws, const void *data, uint32_t size);
-    int (*final)(struct s2n_prf_working_space *ws, void *digest, uint32_t size);
-    int (*reset)(struct s2n_prf_working_space *ws);
-    int (*cleanup)(struct s2n_prf_working_space *ws);
-    int (*free)(struct s2n_prf_working_space *ws);
 };
 
 /* TLS key expansion results in an array of contiguous data which is then
@@ -75,27 +57,13 @@ struct s2n_key_material {
 
 S2N_RESULT s2n_key_material_init(struct s2n_key_material *key_material, struct s2n_connection *conn);
 
-#include "tls/s2n_connection.h"
-
 S2N_RESULT s2n_prf_new(struct s2n_connection *conn);
 S2N_RESULT s2n_prf_wipe(struct s2n_connection *conn);
 S2N_RESULT s2n_prf_free(struct s2n_connection *conn);
 
-int s2n_prf(struct s2n_connection *conn, struct s2n_blob *secret, struct s2n_blob *label, struct s2n_blob *seed_a,
-        struct s2n_blob *seed_b, struct s2n_blob *seed_c, struct s2n_blob *out);
 int s2n_prf_calculate_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret);
-int s2n_tls_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret);
-int s2n_hybrid_prf_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret);
-S2N_RESULT s2n_tls_prf_extended_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret, struct s2n_blob *session_hash, struct s2n_blob *sha1_hash);
-S2N_RESULT s2n_prf_get_digest_for_ems(struct s2n_connection *conn, struct s2n_blob *message, s2n_hash_algorithm hash_alg, struct s2n_blob *output);
+int s2n_prf_hybrid_master_secret(struct s2n_connection *conn, struct s2n_blob *premaster_secret);
 S2N_RESULT s2n_prf_generate_key_material(struct s2n_connection *conn, struct s2n_key_material *key_material);
 int s2n_prf_key_expansion(struct s2n_connection *conn);
 int s2n_prf_server_finished(struct s2n_connection *conn);
 int s2n_prf_client_finished(struct s2n_connection *conn);
-
-bool s2n_libcrypto_supports_tls_prf();
-
-S2N_RESULT s2n_custom_prf(struct s2n_connection *conn, struct s2n_blob *secret, struct s2n_blob *label,
-        struct s2n_blob *seed_a, struct s2n_blob *seed_b, struct s2n_blob *seed_c, struct s2n_blob *out);
-S2N_RESULT s2n_libcrypto_prf(struct s2n_connection *conn, struct s2n_blob *secret, struct s2n_blob *label,
-        struct s2n_blob *seed_a, struct s2n_blob *seed_b, struct s2n_blob *seed_c, struct s2n_blob *out);


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:
related to https://github.com/aws/s2n-tls/issues/5143

### Description of changes: 

While poking around in the PRF logic, the mess made understanding the already complicated flow even more complicated. The header contained many internal implementation APIs only required by the tests, which made figuring out how the rest of the code interacted with the PRF more difficult.

This change is purely renames + moving around declarations. The end result is a much simpler s2n_prf.h.

### Call-outs:

I also renamed a couple methods that didn't start with "s2n_prf". The mix of "s2n_tls_prf" and "s2n_prf" made me think there was a meaningful difference. There was not.

### Testing:
No behavior changes, purely cosmetic. Existing tests should continue to pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
