### PR TITLE
fix: memory leak during STEK rotation

### DIFF
--- a/codebuild/bin/grep_simple_mistakes.sh
+++ b/codebuild/bin/grep_simple_mistakes.sh
@@ -88,7 +88,6 @@ KNOWN_MEMCMP_USAGE["$PWD/stuffer/s2n_stuffer_text.c"]=1
 KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_psk.c"]=1
 KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_protocol_preferences.c"]=1
 KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_cipher_suites.c"]=1
-KNOWN_MEMCMP_USAGE["$PWD/tls/s2n_config.c"]=1
 KNOWN_MEMCMP_USAGE["$PWD/utils/s2n_map.c"]=3
 
 for file in $S2N_FILES_ASSERT_NOT_USING_MEMCMP; do

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -396,8 +396,7 @@ struct s2n_config *cbmc_allocate_s2n_config()
     s2n_config->monotonic_clock_ctx  = malloc(sizeof(*(s2n_config->monotonic_clock_ctx)));
     s2n_config->client_hello_cb      = malloc(sizeof(*(s2n_config->client_hello_cb))); /* Function pointer. */
     s2n_config->client_hello_cb_ctx  = malloc(sizeof(*(s2n_config->client_hello_cb_ctx)));
-    s2n_config->ticket_keys          = cbmc_allocate_s2n_set();
-    s2n_config->ticket_key_hashes    = cbmc_allocate_s2n_set();
+    s2n_config->ticket_keys          = cbmc_allocate_s2n_array();
     s2n_config->cache_store_data     = malloc(sizeof(*(s2n_config->cache_store_data)));
     s2n_config->cache_retrieve_data  = malloc(sizeof(*(s2n_config->cache_retrieve_data)));
     s2n_config->cache_delete_data    = malloc(sizeof(*(s2n_config->cache_delete_data)));

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -1532,7 +1532,7 @@ int main(int argc, char **argv)
 
             /* Manually zero out key bytes */
             struct s2n_ticket_key *key = NULL;
-            EXPECT_OK(s2n_set_get(config->ticket_keys, 0, (void **) &key));
+            EXPECT_OK(s2n_array_get(config->ticket_keys, 0, (void **) &key));
             EXPECT_NOT_NULL(key);
             POSIX_CHECKED_MEMSET((uint8_t *) key->aes_key, 0, S2N_AES256_KEY_LEN);
 

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -780,9 +780,9 @@ int main(int argc, char **argv)
 
     /* Attempting to add more than S2N_MAX_TICKET_KEYS causes failures. */
     {
-        DEFER_CLEANUP(struct s2n_config *server_config = s2n_config_new(), s2n_config_ptr_free);
-        EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(config, 1));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
 
         uint8_t id = 0;
         uint8_t ticket_key_buf[32] = { 0 };
@@ -790,14 +790,14 @@ int main(int argc, char **argv)
         for (uint8_t i = 0; i < S2N_MAX_TICKET_KEYS; i++) {
             id = i;
             ticket_key_buf[0] = i;
-            EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(server_config,
+            EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(config,
                     &id, sizeof(id), ticket_key_buf, s2n_array_len(ticket_key_buf), 0));
         }
 
         id = S2N_MAX_TICKET_KEYS;
         ticket_key_buf[0] = S2N_MAX_TICKET_KEYS;
-        EXPECT_FAILURE(s2n_config_add_ticket_crypto_key(server_config,
-                &id, sizeof(id), ticket_key_buf, s2n_array_len(ticket_key_buf), 0));
+        EXPECT_FAILURE(s2n_config_add_ticket_crypto_key(config, &id, sizeof(id),
+                ticket_key_buf, s2n_array_len(ticket_key_buf), 0));
     };
 
     /* Scenario 1: Client sends empty ST and server has multiple encrypt-decrypt keys to choose from for encrypting NST. */

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -577,9 +577,9 @@ int main(int argc, char **argv)
         EXPECT_TRUE(IS_ISSUING_NEW_SESSION_TICKET(server_conn));
 
         /* Verify that the server has only the unexpired key */
-        EXPECT_OK(s2n_set_get(server_config->ticket_keys, 0, (void **) &ticket_key));
+        EXPECT_OK(s2n_array_get(server_config->ticket_keys, 0, (void **) &ticket_key));
         EXPECT_BYTEARRAY_EQUAL(ticket_key->key_name, ticket_key_name2, s2n_array_len(ticket_key_name2));
-        EXPECT_OK(s2n_set_len(server_config->ticket_keys, &ticket_keys_len));
+        EXPECT_OK(s2n_array_num_elements(server_config->ticket_keys, &ticket_keys_len));
         EXPECT_EQUAL(ticket_keys_len, 1);
 
         /* Verify that the client received NST */
@@ -765,20 +765,39 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(server_config, ticket_key_name3, s2n_array_len(ticket_key_name3), ticket_key3, s2n_array_len(ticket_key3), 0));
 
         /* Try adding the expired keys */
-        EXPECT_EQUAL(s2n_config_add_ticket_crypto_key(server_config, ticket_key_name2, s2n_array_len(ticket_key_name2), ticket_key2, s2n_array_len(ticket_key2), 0), -1);
-        EXPECT_EQUAL(s2n_config_add_ticket_crypto_key(server_config, ticket_key_name1, s2n_array_len(ticket_key_name1), ticket_key1, s2n_array_len(ticket_key1), 0), -1);
+        EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(server_config, ticket_key_name2, s2n_array_len(ticket_key_name2), ticket_key2, s2n_array_len(ticket_key2), 0));
+        EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(server_config, ticket_key_name1, s2n_array_len(ticket_key_name1), ticket_key1, s2n_array_len(ticket_key1), 0));
 
-        /* Verify that the config has only one unexpired key */
-        EXPECT_OK(s2n_set_get(server_config->ticket_keys, 0, (void **) &ticket_key));
+        /* Verify that the config has three unexpired keys */
+        EXPECT_OK(s2n_array_get(server_config->ticket_keys, 0, (void **) &ticket_key));
+        /* ticket_key3 should have "rotated" to the first index as other keys expired */
         EXPECT_BYTEARRAY_EQUAL(ticket_key->key_name, ticket_key_name3, s2n_array_len(ticket_key_name3));
-        EXPECT_OK(s2n_set_len(server_config->ticket_keys, &ticket_keys_len));
-        EXPECT_EQUAL(ticket_keys_len, 1);
-
-        /* Verify that the total number of key hashes is three */
-        EXPECT_OK(s2n_set_len(server_config->ticket_key_hashes, &ticket_keys_len));
+        EXPECT_OK(s2n_array_num_elements(server_config->ticket_keys, &ticket_keys_len));
         EXPECT_EQUAL(ticket_keys_len, 3);
 
         EXPECT_SUCCESS(s2n_config_free(server_config));
+    };
+
+    /* Attempting to add more than S2N_MAX_TICKET_KEYS causes failures. */
+    {
+        DEFER_CLEANUP(struct s2n_config *server_config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_SUCCESS(s2n_config_set_session_tickets_onoff(server_config, 1));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+
+        uint8_t id = 0;
+        uint8_t ticket_key_buf[32] = { 0 };
+
+        for (uint8_t i = 0; i < S2N_MAX_TICKET_KEYS; i++) {
+            id = i;
+            ticket_key_buf[0] = i;
+            EXPECT_SUCCESS(s2n_config_add_ticket_crypto_key(server_config,
+                    &id, sizeof(id), ticket_key_buf, s2n_array_len(ticket_key_buf), 0));
+        }
+
+        id = S2N_MAX_TICKET_KEYS;
+        ticket_key_buf[0] = S2N_MAX_TICKET_KEYS;
+        EXPECT_FAILURE(s2n_config_add_ticket_crypto_key(server_config,
+                &id, sizeof(id), ticket_key_buf, s2n_array_len(ticket_key_buf), 0));
     };
 
     /* Scenario 1: Client sends empty ST and server has multiple encrypt-decrypt keys to choose from for encrypting NST. */
@@ -1057,14 +1076,6 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(s2n_connection_get_session(client_conn, serialized_session_state, serialized_session_state_length), serialized_session_state_length);
         EXPECT_BYTEARRAY_EQUAL(serialized_session_state + S2N_TICKET_KEY_NAME_LOCATION,
                 ticket_key_name2, s2n_array_len(ticket_key_name2));
-
-        /* Verify that the keys are stored from oldest to newest */
-        EXPECT_OK(s2n_set_get(server_config->ticket_keys, 0, (void **) &ticket_key));
-        EXPECT_BYTEARRAY_EQUAL(ticket_key->key_name, ticket_key_name2, s2n_array_len(ticket_key_name2));
-        EXPECT_OK(s2n_set_get(server_config->ticket_keys, 1, (void **) &ticket_key));
-        EXPECT_BYTEARRAY_EQUAL(ticket_key->key_name, ticket_key_name1, s2n_array_len(ticket_key_name1));
-        EXPECT_OK(s2n_set_get(server_config->ticket_keys, 2, (void **) &ticket_key));
-        EXPECT_BYTEARRAY_EQUAL(ticket_key->key_name, ticket_key_name3, s2n_array_len(ticket_key_name3));
 
         EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -308,28 +308,10 @@ struct s2n_config *s2n_config_new(void)
     return new_config;
 }
 
-static int s2n_config_store_ticket_key_comparator(const void *a, const void *b)
-{
-    if (((const struct s2n_ticket_key *) a)->intro_timestamp >= ((const struct s2n_ticket_key *) b)->intro_timestamp) {
-        return S2N_GREATER_OR_EQUAL;
-    } else {
-        return S2N_LESS_THAN;
-    }
-}
-
-static int s2n_verify_unique_ticket_key_comparator(const void *a, const void *b)
-{
-    return memcmp(a, b, SHA_DIGEST_LENGTH);
-}
-
 int s2n_config_init_session_ticket_keys(struct s2n_config *config)
 {
     if (config->ticket_keys == NULL) {
-        POSIX_ENSURE_REF(config->ticket_keys = s2n_set_new(sizeof(struct s2n_ticket_key), s2n_config_store_ticket_key_comparator));
-    }
-
-    if (config->ticket_key_hashes == NULL) {
-        POSIX_ENSURE_REF(config->ticket_key_hashes = s2n_set_new(SHA_DIGEST_LENGTH, s2n_verify_unique_ticket_key_comparator));
+        POSIX_ENSURE_REF(config->ticket_keys = s2n_array_new_with_capacity(sizeof(struct s2n_ticket_key), S2N_MAX_TICKET_KEYS));
     }
 
     return 0;
@@ -338,11 +320,7 @@ int s2n_config_init_session_ticket_keys(struct s2n_config *config)
 int s2n_config_free_session_ticket_keys(struct s2n_config *config)
 {
     if (config->ticket_keys != NULL) {
-        POSIX_GUARD_RESULT(s2n_set_free_p(&config->ticket_keys));
-    }
-
-    if (config->ticket_key_hashes != NULL) {
-        POSIX_GUARD_RESULT(s2n_set_free_p(&config->ticket_key_hashes));
+        POSIX_GUARD_RESULT(s2n_array_free_p(&config->ticket_keys));
     }
 
     return 0;
@@ -956,7 +934,7 @@ int s2n_config_add_ticket_crypto_key(struct s2n_config *config,
     POSIX_ENSURE(key_len != 0, S2N_ERR_INVALID_TICKET_KEY_LENGTH);
 
     uint32_t ticket_keys_len = 0;
-    POSIX_GUARD_RESULT(s2n_set_len(config->ticket_keys, &ticket_keys_len));
+    POSIX_GUARD_RESULT(s2n_array_num_elements(config->ticket_keys, &ticket_keys_len));
     POSIX_ENSURE(ticket_keys_len < S2N_MAX_TICKET_KEYS, S2N_ERR_TICKET_KEY_LIMIT);
 
     POSIX_ENSURE(name_len != 0, S2N_ERR_INVALID_TICKET_KEY_NAME_OR_NAME_LENGTH);
@@ -989,23 +967,6 @@ int s2n_config_add_ticket_crypto_key(struct s2n_config *config,
 
     POSIX_GUARD(s2n_hmac_new(&hmac));
     POSIX_GUARD(s2n_hkdf(&hmac, S2N_HMAC_SHA256, &salt, &in_key, &info, &out_key));
-
-    DEFER_CLEANUP(struct s2n_hash_state hash = { 0 }, s2n_hash_free);
-    uint8_t hash_output[SHA_DIGEST_LENGTH] = { 0 };
-
-    POSIX_GUARD(s2n_hash_new(&hash));
-    POSIX_GUARD(s2n_hash_init(&hash, S2N_HASH_SHA1));
-    POSIX_GUARD(s2n_hash_update(&hash, out_key.data, out_key.size));
-    POSIX_GUARD(s2n_hash_digest(&hash, hash_output, SHA_DIGEST_LENGTH));
-
-    POSIX_GUARD_RESULT(s2n_set_len(config->ticket_keys, &ticket_keys_len));
-    if (ticket_keys_len >= S2N_MAX_TICKET_KEY_HASHES) {
-        POSIX_GUARD_RESULT(s2n_set_free_p(&config->ticket_key_hashes));
-        POSIX_ENSURE_REF(config->ticket_key_hashes = s2n_set_new(SHA_DIGEST_LENGTH, s2n_verify_unique_ticket_key_comparator));
-    }
-
-    /* Insert hash key into a sorted array at known index */
-    POSIX_GUARD_RESULT(s2n_set_add(config->ticket_key_hashes, hash_output));
 
     POSIX_CHECKED_MEMCPY(session_ticket_key->key_name, name_data, s2n_array_len(name_data));
     POSIX_CHECKED_MEMCPY(session_ticket_key->aes_key, out_key.data, S2N_AES256_KEY_LEN);

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -945,9 +945,6 @@ int s2n_config_add_ticket_crypto_key(struct s2n_config *config,
     uint8_t name_data[S2N_TICKET_KEY_NAME_LEN] = { 0 };
     POSIX_CHECKED_MEMCPY(name_data, name, name_len);
 
-    /* ensure the ticket name is not already present */
-    POSIX_ENSURE(s2n_find_ticket_key(config, name_data) == NULL, S2N_ERR_INVALID_TICKET_KEY_NAME_OR_NAME_LENGTH);
-
     uint8_t output_pad[S2N_AES256_KEY_LEN + S2N_TICKET_AAD_IMPLICIT_LEN] = { 0 };
     struct s2n_blob out_key = { 0 };
     POSIX_GUARD(s2n_blob_init(&out_key, output_pad, s2n_array_len(output_pad)));

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -31,7 +31,7 @@
 #include "utils/s2n_blob.h"
 #include "utils/s2n_set.h"
 
-#define S2N_MAX_TICKET_KEYS       48
+#define S2N_MAX_TICKET_KEYS 48
 
 /*
  * TLS1.3 does not allow alert messages to be fragmented, and some TLS

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -32,7 +32,6 @@
 #include "utils/s2n_set.h"
 
 #define S2N_MAX_TICKET_KEYS       48
-#define S2N_MAX_TICKET_KEY_HASHES 500 /* 10KB */
 
 /*
  * TLS1.3 does not allow alert messages to be fragmented, and some TLS
@@ -133,8 +132,7 @@ struct s2n_config {
 
     uint64_t session_state_lifetime_in_nanos;
 
-    struct s2n_set *ticket_keys;
-    struct s2n_set *ticket_key_hashes;
+    struct s2n_array *ticket_keys;
     uint64_t encrypt_decrypt_key_lifetime_in_nanos;
     uint64_t decrypt_key_lifetime_in_nanos;
 

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -1037,10 +1037,12 @@ int s2n_config_store_ticket_key(struct s2n_config *config, struct s2n_ticket_key
     uint32_t ticket_keys_len = 0;
     POSIX_GUARD_RESULT(s2n_array_num_elements(config->ticket_keys, &ticket_keys_len));
 
-    /* The ticket key secret must be unique. */
+    /* The ticket key name and secret must both be unique. */
     for (uint32_t i = 0; i < ticket_keys_len; i++) {
         struct s2n_ticket_key *other_key = NULL;
         POSIX_GUARD_RESULT(s2n_array_get(config->ticket_keys, i, (void **) &other_key));
+        POSIX_ENSURE(!s2n_constant_time_equals(key->key_name, other_key->key_name, s2n_array_len(key->key_name)),
+                S2N_ERR_INVALID_TICKET_KEY_NAME_OR_NAME_LENGTH);
         POSIX_ENSURE(!s2n_constant_time_equals(key->aes_key, other_key->aes_key, s2n_array_len(key->aes_key)),
                 S2N_ERR_TICKET_KEY_NOT_UNIQUE);
     }


### PR DESCRIPTION
## Release Summary:
A small memory leak related to session resumption was resolved. Long lived applications with session resumption enabled will see a reduction in the memory footprint of `s2n_config`.

## Description of changes: 

For each STEK that was added to a config, we hashed it and stored the hash in `config->ticket_key_hashes`. This was intended to have a maximum size of 500, but a typo in the length check resulted in us checking the length of `ticket_keys` instead of `ticket_key_hashes`. Therefore `ticket_key_hashes` would continue to grow as new STEKs were added to the config.

This PR totally removes the ticket key hashes set. Instead we enforce secret uniqueness through a linear scan of the existing keys. Performance wise, this is acceptable because `S2N_MAX_TICKET_KEYS` is `48`.


### external behavior changes
- previous: STEK secret material must be unique across all STEKs that have ever been set on the config
- proposed: STEK secret material must be unique across all unexpired STEKs currently on the config

### internal behavior changes
- previous: STEKs in `config->ticket_keys` are sorted based on the `intro_time` parameter
- proposed: STEKs in `config->tickets_keys` are not sorted. They happen to be in "most recently added" order.

I was suspicious that this internal behavior change wouldn't break things in odd ways, so here is the little audit I did

**removing steks**: `s2n_config_wipe_expired_ticket_crypto_keys` does not short circuit, but iterates through all keys selecting the ones that are no longer valid. So this behavior doesn't break.
**selecting stek for encryption**: `s2n_get_ticket_encrypt_decrypt_key` does not short circuit when gathering the indices of the steks available for encryption. So this behavior doesn't break.
**selecting stek for decryption**: This is done by key name, so it makes sense that we aren't relying on the order of the ticket keys.

## Call-outs:
This PR will remove the only usages of `s2n_set` in the codebase, so we can rip out s2n_set after this is merged in.

## Testing:

I had to modify some unit tests that were asserting on old behaviors.

Technically this should all be covered by existing unit tests, but I couldn't find a unit test enforcing that adding more than `S2N_MAX_TICKET_KEYS` fails, so I added one.

I also had added a test confirming the memory leak, which showed that more than 500 ticket hashes can be found on a config. That is not included in the PR since we no longer store ticket hashes at all 🙂 

### Benchmarks
This PR actually makes it less expensive to add STEKs to config despite the new linear scan. Hypothesis: the simple comparison is relatively inexpensive relative to key derivation/hashing. 
```
Stek Addition/config add 1 key to 0 keys
                        time:   [1.4064 µs 1.4077 µs 1.4091 µs]
                        change: [-9.5961% -9.1370% -8.6922%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking Stek Addition/config add 1 key to 47 keys: Collecting 100 samples in es
Stek Addition/config add 1 key to 47 keys
                        time:   [2.0392 µs 2.0409 µs 2.0425 µs]
                        change: [-8.4058% -8.1100% -7.7137%] (p = 0.00 < 0.05)
                        Performance has improved.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.