### PR TITLE
style: fix redundant return

### DIFF
--- a/tests/unit/s2n_build_test.c
+++ b/tests/unit/s2n_build_test.c
@@ -122,7 +122,6 @@ int main()
 
     if (s2n_libcrypto == NULL || s2n_libcrypto[0] == '\0') {
         END_TEST();
-        return 0;
     }
 
     if (strcmp(s2n_libcrypto, "default") == 0) {
@@ -178,5 +177,4 @@ int main()
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_cert_chain_and_key_test.c
+++ b/tests/unit/s2n_cert_chain_and_key_test.c
@@ -224,5 +224,4 @@ int main(int argc, char **argv)
     free(alligator_cert);
     free(alligator_key);
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_cert_status_extension_test.c
+++ b/tests/unit/s2n_cert_status_extension_test.c
@@ -393,5 +393,4 @@ int main(int argc, char **argv)
     }
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_cert_status_response_extension_test.c
+++ b/tests/unit/s2n_cert_status_response_extension_test.c
@@ -95,5 +95,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_change_cipher_spec_test.c
+++ b/tests/unit/s2n_change_cipher_spec_test.c
@@ -188,5 +188,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_choose_supported_group_test.c
+++ b/tests/unit/s2n_choose_supported_group_test.c
@@ -319,5 +319,4 @@ int main()
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_client_alpn_extension_test.c
+++ b/tests/unit/s2n_client_alpn_extension_test.c
@@ -122,5 +122,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_client_cert_status_request_extension_test.c
+++ b/tests/unit/s2n_client_cert_status_request_extension_test.c
@@ -141,5 +141,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -1485,5 +1485,4 @@ int main(int argc, char **argv)
     free(cert_chain);
     free(private_key);
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -555,5 +555,4 @@ int main(int argc, char **argv)
     free(tls13_cert_chain);
     free(tls13_private_key);
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -1956,5 +1956,4 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(ecdsa_chain_and_key));
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -1109,7 +1109,6 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }
 
 static int s2n_test_rewrite_length(struct s2n_stuffer *stuffer)

--- a/tests/unit/s2n_client_max_frag_len_extension_test.c
+++ b/tests/unit/s2n_client_max_frag_len_extension_test.c
@@ -155,5 +155,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_client_record_version_test.c
+++ b/tests/unit/s2n_client_record_version_test.c
@@ -312,5 +312,4 @@ int main(int argc, char **argv)
     free(cert_chain);
     free(private_key);
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_client_secure_renegotiation_test.c
+++ b/tests/unit/s2n_client_secure_renegotiation_test.c
@@ -305,5 +305,4 @@ int main(int argc, char **argv)
     free(cert_chain);
     free(private_key);
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_client_server_name_extension_test.c
+++ b/tests/unit/s2n_client_server_name_extension_test.c
@@ -192,5 +192,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_client_session_ticket_extension_test.c
+++ b/tests/unit/s2n_client_session_ticket_extension_test.c
@@ -186,5 +186,4 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_config_free(config));
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_client_signature_algorithms_extension_test.c
+++ b/tests/unit/s2n_client_signature_algorithms_extension_test.c
@@ -103,5 +103,4 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_client_supported_groups_extension_test.c
+++ b/tests/unit/s2n_client_supported_groups_extension_test.c
@@ -544,5 +544,4 @@ int main()
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_client_supported_versions_extension_test.c
+++ b/tests/unit/s2n_client_supported_versions_extension_test.c
@@ -485,5 +485,4 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_config_free(config));
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_connection_blinding_test.c
+++ b/tests/unit/s2n_connection_blinding_test.c
@@ -63,5 +63,4 @@ int main(int argc, char **argv)
     }
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_connection_serialize_test.c
+++ b/tests/unit/s2n_connection_serialize_test.c
@@ -949,5 +949,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_connection_size_test.c
+++ b/tests/unit/s2n_connection_size_test.c
@@ -41,7 +41,6 @@ int main(int argc, char **argv)
     */
     if (is_32_bit_platform()) {
         END_TEST();
-        return 0;
     }
 
     /* Carefully consider any increases to this number. */

--- a/tests/unit/s2n_ecc_point_format_extension_test.c
+++ b/tests/unit/s2n_ecc_point_format_extension_test.c
@@ -102,5 +102,4 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_config_free(config));
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_extensions_server_key_share_select_test.c
+++ b/tests/unit/s2n_extensions_server_key_share_select_test.c
@@ -30,7 +30,6 @@ int main()
     EXPECT_OK(s2n_kem_preferences_groups_available(&kem_preferences_all, &available_groups));
     if (available_groups < 2) {
         END_TEST();
-        return 0;
     }
 
     EXPECT_SUCCESS(s2n_enable_tls13_in_test());
@@ -432,5 +431,4 @@ int main()
         };
     };
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_handshake_invariant_test.c
+++ b/tests/unit/s2n_handshake_invariant_test.c
@@ -85,5 +85,4 @@ int main(int argc, char **argv)
 
     s2n_connection_free(conn);
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -475,5 +475,4 @@ int main(int argc, char **argv)
     }
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_mutual_auth_test.c
+++ b/tests/unit/s2n_mutual_auth_test.c
@@ -390,5 +390,4 @@ int main(int argc, char **argv)
     free(private_key_pem);
     free(dhparams_pem);
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_optional_client_auth_test.c
+++ b/tests/unit/s2n_optional_client_auth_test.c
@@ -475,5 +475,4 @@ int main(int argc, char **argv)
     free(private_key_pem);
     free(dhparams_pem);
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_protocol_preferences_test.c
+++ b/tests/unit/s2n_protocol_preferences_test.c
@@ -280,5 +280,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_safety_test.c
+++ b/tests/unit/s2n_safety_test.c
@@ -458,5 +458,4 @@ int main(int argc, char **argv)
     }
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_self_talk_broken_pipe_test.c
+++ b/tests/unit/s2n_self_talk_broken_pipe_test.c
@@ -175,5 +175,4 @@ int main(int argc, char **argv)
     }
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_self_talk_nonblocking_test.c
+++ b/tests/unit/s2n_self_talk_nonblocking_test.c
@@ -388,5 +388,4 @@ int main(int argc, char **argv)
         }
     }
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_self_talk_session_id_test.c
+++ b/tests/unit/s2n_self_talk_session_id_test.c
@@ -667,5 +667,4 @@ int main(int argc, char **argv)
     free(private_key_pem);
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_self_talk_tls12_test.c
+++ b/tests/unit/s2n_self_talk_tls12_test.c
@@ -201,5 +201,4 @@ int main(int argc, char **argv)
     }
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_self_talk_tls13_test.c
+++ b/tests/unit/s2n_self_talk_tls13_test.c
@@ -181,5 +181,4 @@ int main(int argc, char **argv)
     s2n_disable_tls13_in_test();
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_server_alpn_extension_test.c
+++ b/tests/unit/s2n_server_alpn_extension_test.c
@@ -147,5 +147,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_server_early_data_indication_test.c
+++ b/tests/unit/s2n_server_early_data_indication_test.c
@@ -303,5 +303,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_server_extensions_test.c
+++ b/tests/unit/s2n_server_extensions_test.c
@@ -678,5 +678,4 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_server_key_share_extension_test.c
+++ b/tests/unit/s2n_server_key_share_extension_test.c
@@ -993,7 +993,6 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }
 
 static int s2n_read_server_key_share_hybrid_test_vectors(const struct s2n_kem_group *kem_group, struct s2n_blob *pq_private_key,

--- a/tests/unit/s2n_server_max_frag_len_extension_test.c
+++ b/tests/unit/s2n_server_max_frag_len_extension_test.c
@@ -182,5 +182,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_server_renegotiation_info_test.c
+++ b/tests/unit/s2n_server_renegotiation_info_test.c
@@ -494,5 +494,4 @@ int main(int argc, char **argv)
     }
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_server_sct_list_extension_test.c
+++ b/tests/unit/s2n_server_sct_list_extension_test.c
@@ -116,5 +116,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_server_server_name_extension_test.c
+++ b/tests/unit/s2n_server_server_name_extension_test.c
@@ -77,5 +77,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_server_session_ticket_extension_test.c
+++ b/tests/unit/s2n_server_session_ticket_extension_test.c
@@ -92,5 +92,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_server_supported_versions_extension_test.c
+++ b/tests/unit/s2n_server_supported_versions_extension_test.c
@@ -154,5 +154,4 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_config_free(config));
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_session_ticket_test.c
+++ b/tests/unit/s2n_session_ticket_test.c
@@ -1749,5 +1749,4 @@ int main(int argc, char **argv)
     free(cert_chain);
     free(private_key);
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_stuffer_text_test.c
+++ b/tests/unit/s2n_stuffer_text_test.c
@@ -271,5 +271,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_tls12_handshake_test.c
+++ b/tests/unit/s2n_tls12_handshake_test.c
@@ -521,5 +521,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_tls13_client_finished_test.c
+++ b/tests/unit/s2n_tls13_client_finished_test.c
@@ -174,5 +174,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_tls13_handshake_state_machine_test.c
+++ b/tests/unit/s2n_tls13_handshake_state_machine_test.c
@@ -1004,5 +1004,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_tls13_handshake_test.c
+++ b/tests/unit/s2n_tls13_handshake_test.c
@@ -328,5 +328,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_tls13_server_finished_test.c
+++ b/tests/unit/s2n_tls13_server_finished_test.c
@@ -174,5 +174,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }

--- a/tests/unit/s2n_tls13_support_test.c
+++ b/tests/unit/s2n_tls13_support_test.c
@@ -183,5 +183,4 @@ int main(int argc, char **argv)
     };
 
     END_TEST();
-    return 0;
 }


### PR DESCRIPTION
### Description of changes: 

#1893 

Solved using find and replace

Find 
```
END_TEST\(\);\n.*return 0
```
Replace
```
END_TEST();
```
### Testing:
All tests should pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
