### PR TITLE
chore: add inline noqa suppression directives

### DIFF
--- a/tests/integrationv2/test_buffered_send.py
+++ b/tests/integrationv2/test_buffered_send.py
@@ -9,7 +9,7 @@ from configuration import (
     MINIMAL_TEST_CERTS,
 )
 from common import ProviderOptions, data_bytes
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, OpenSSL, GnuTLS
 from utils import invalid_test_parameters, get_parameter_name, to_bytes, to_string
 
@@ -39,7 +39,7 @@ SEND_BUFFER_SIZES = [
 FRAGMENT_PREFERENCE = [None, "--prefer-low-latency", "--prefer-throughput"]
 
 
-def test_SEND_BUFFER_SIZE_MIN_is_s2ns_min_buffer_size(managed_process):
+def test_SEND_BUFFER_SIZE_MIN_is_s2ns_min_buffer_size(managed_process):  # noqa: F811
     port = next(available_ports)
 
     s2n_options = ProviderOptions(
@@ -73,7 +73,7 @@ def test_SEND_BUFFER_SIZE_MIN_is_s2ns_min_buffer_size(managed_process):
     "fragment_preference", FRAGMENT_PREFERENCE, ids=get_parameter_name
 )
 def test_s2n_server_buffered_send(
-    managed_process,
+    managed_process,  # noqa: F811
     cipher,
     provider,
     protocol,
@@ -141,7 +141,7 @@ def test_s2n_server_buffered_send(
     "fragment_preference", FRAGMENT_PREFERENCE, ids=get_parameter_name
 )
 def test_s2n_client_buffered_send(
-    managed_process,
+    managed_process,  # noqa: F811
     cipher,
     provider,
     protocol,

--- a/tests/integrationv2/test_client_authentication.py
+++ b/tests/integrationv2/test_client_authentication.py
@@ -5,7 +5,7 @@ import pytest
 
 from configuration import available_ports, ALL_TEST_CIPHERS, PROTOCOLS
 from common import Certificates, ProviderOptions, Protocols, data_bytes, Signatures
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, GnuTLS, OpenSSL
 from utils import (
     invalid_test_parameters,
@@ -58,7 +58,7 @@ def assert_s2n_handshake_complete(results, protocol, provider, is_complete=True)
 @pytest.mark.parametrize("certificate", CERTS_TO_TEST, ids=get_parameter_name)
 @pytest.mark.parametrize("client_certificate", CERTS_TO_TEST, ids=get_parameter_name)
 def test_client_auth_with_s2n_server(
-    managed_process,
+    managed_process,  # noqa: F811
     provider,
     other_provider,
     protocol,
@@ -114,7 +114,7 @@ def test_client_auth_with_s2n_server(
 @pytest.mark.parametrize("certificate", CERTS_TO_TEST, ids=get_parameter_name)
 @pytest.mark.parametrize("client_certificate", CERTS_TO_TEST, ids=get_parameter_name)
 def test_client_auth_with_s2n_server_using_nonmatching_certs(
-    managed_process,
+    managed_process,  # noqa: F811
     provider,
     other_provider,
     protocol,
@@ -175,7 +175,7 @@ def test_client_auth_with_s2n_server_using_nonmatching_certs(
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", CERTS_TO_TEST, ids=get_parameter_name)
 def test_client_auth_with_s2n_client_no_cert(
-    managed_process, provider, other_provider, protocol, cipher, certificate
+    managed_process, provider, other_provider, protocol, cipher, certificate  # noqa: F811
 ):
     port = next(available_ports)
 
@@ -225,7 +225,7 @@ def test_client_auth_with_s2n_client_no_cert(
 @pytest.mark.parametrize("certificate", CERTS_TO_TEST, ids=get_parameter_name)
 @pytest.mark.parametrize("client_certificate", CERTS_TO_TEST, ids=get_parameter_name)
 def test_client_auth_with_s2n_client_with_cert(
-    managed_process,
+    managed_process,  # noqa: F811
     provider,
     other_provider,
     protocol,
@@ -289,7 +289,7 @@ TLS1.3, even if its security policy would normally allow TLS1.3.
     [Certificates.RSA_2048_PKCS1, Certificates.ECDSA_256],
     ids=get_parameter_name,
 )
-def test_tls_12_client_auth_downgrade(managed_process, certificate):
+def test_tls_12_client_auth_downgrade(managed_process, certificate):  # noqa: F811
     port = next(available_ports)
 
     random_bytes = data_bytes(64)

--- a/tests/integrationv2/test_client_authentication.py
+++ b/tests/integrationv2/test_client_authentication.py
@@ -175,7 +175,12 @@ def test_client_auth_with_s2n_server_using_nonmatching_certs(
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", CERTS_TO_TEST, ids=get_parameter_name)
 def test_client_auth_with_s2n_client_no_cert(
-    managed_process, provider, other_provider, protocol, cipher, certificate  # noqa: F811
+    managed_process,
+    provider,
+    other_provider,
+    protocol,
+    cipher,
+    certificate,  # noqa: F811
 ):
     port = next(available_ports)
 

--- a/tests/integrationv2/test_cross_compatibility.py
+++ b/tests/integrationv2/test_cross_compatibility.py
@@ -11,7 +11,7 @@ from configuration import (
     ALL_TEST_CERTS,
 )
 from common import ProviderOptions, Protocols, data_bytes
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, OpenSSL
 from utils import invalid_test_parameters, get_parameter_name, to_bytes
 
@@ -36,7 +36,7 @@ Tests that S2N tickets are backwards-compatible.
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_s2n_old_server_new_ticket(
-    managed_process,
+    managed_process,  # noqa: F811
     tmp_path,
     cipher,
     curve,
@@ -109,7 +109,7 @@ Tests that S2N tickets are forwards-compatible.
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_s2n_new_server_old_ticket(
-    managed_process,
+    managed_process,  # noqa: F811
     tmp_path,
     cipher,
     curve,
@@ -184,7 +184,7 @@ server because the Openssl server uses a different ticket key for each session.
 @pytest.mark.parametrize("provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_s2n_old_client_new_ticket(
-    managed_process,
+    managed_process,  # noqa: F811
     tmp_path,
     cipher,
     curve,
@@ -253,7 +253,7 @@ Tests that S2N tickets are forwards-compatible.
 @pytest.mark.parametrize("provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_s2n_new_client_old_ticket(
-    managed_process,
+    managed_process,  # noqa: F811
     tmp_path,
     cipher,
     curve,

--- a/tests/integrationv2/test_dynamic_record_sizes.py
+++ b/tests/integrationv2/test_dynamic_record_sizes.py
@@ -11,7 +11,10 @@ from configuration import (
     PROTOCOLS,
 )
 from common import ProviderOptions, data_bytes
-from fixtures import custom_mtu, managed_process  # lgtm [py/unused-import]  # noqa: F401
+from fixtures import (
+    custom_mtu,
+    managed_process,
+)  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, OpenSSL, Tcpdump
 from utils import (
     invalid_test_parameters,

--- a/tests/integrationv2/test_dynamic_record_sizes.py
+++ b/tests/integrationv2/test_dynamic_record_sizes.py
@@ -11,7 +11,7 @@ from configuration import (
     PROTOCOLS,
 )
 from common import ProviderOptions, data_bytes
-from fixtures import custom_mtu, managed_process  # lgtm [py/unused-import]
+from fixtures import custom_mtu, managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, OpenSSL, Tcpdump
 from utils import (
     invalid_test_parameters,
@@ -56,8 +56,8 @@ def find_fragmented_packet(results):
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 def test_s2n_client_dynamic_record(
-    custom_mtu,
-    managed_process,
+    custom_mtu,  # noqa: F811
+    managed_process,  # noqa: F811
     cipher,
     curve,
     provider,

--- a/tests/integrationv2/test_early_data.py
+++ b/tests/integrationv2/test_early_data.py
@@ -297,7 +297,13 @@ test_session_resumption but with validation that no early data is sent.
 @pytest.mark.parametrize("provider", SERVER_PROVIDERS, ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_s2n_client_without_early_data(
-    managed_process, tmp_path, cipher, certificate, protocol, provider, other_provider  # noqa: F811
+    managed_process,
+    tmp_path,
+    cipher,
+    certificate,
+    protocol,
+    provider,
+    other_provider,  # noqa: F811
 ):
     early_data_file = str(tmp_path / EARLY_DATA_FILE)
     early_data = get_early_data_bytes(early_data_file, MAX_EARLY_DATA)

--- a/tests/integrationv2/test_early_data.py
+++ b/tests/integrationv2/test_early_data.py
@@ -11,7 +11,7 @@ from configuration import (
     TLS13_CIPHERS,
 )
 from common import ProviderOptions, Protocols, Curves, data_bytes
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N as S2NBase, OpenSSL as OpenSSLBase
 from utils import invalid_test_parameters, get_parameter_name, to_bytes
 
@@ -97,7 +97,7 @@ def get_early_data_bytes(file_path, early_data_size):
     return early_data
 
 
-def get_ticket_from_s2n_server(options, managed_process, provider, certificate):
+def get_ticket_from_s2n_server(options, managed_process, provider, certificate):  # noqa: F811
     port = next(available_ports)
 
     """
@@ -165,7 +165,7 @@ then another resumption connection with early data.
     [int(MAX_EARLY_DATA / 2), int(MAX_EARLY_DATA - 1), MAX_EARLY_DATA, 1],
 )
 def test_s2n_server_with_early_data(
-    managed_process,
+    managed_process,  # noqa: F811
     tmp_path,
     cipher,
     curve,
@@ -233,7 +233,7 @@ That means we don't need to manually perform the initial full connection, and th
     [int(MAX_EARLY_DATA / 2), int(MAX_EARLY_DATA - 1), MAX_EARLY_DATA, 1],
 )
 def test_s2n_client_with_early_data(
-    managed_process,
+    managed_process,  # noqa: F811
     tmp_path,
     cipher,
     certificate,
@@ -297,7 +297,7 @@ test_session_resumption but with validation that no early data is sent.
 @pytest.mark.parametrize("provider", SERVER_PROVIDERS, ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_s2n_client_without_early_data(
-    managed_process, tmp_path, cipher, certificate, protocol, provider, other_provider
+    managed_process, tmp_path, cipher, certificate, protocol, provider, other_provider  # noqa: F811
 ):
     early_data_file = str(tmp_path / EARLY_DATA_FILE)
     early_data = get_early_data_bytes(early_data_file, MAX_EARLY_DATA)
@@ -363,7 +363,7 @@ reconnects automatically, without any mechanism to modify the connection in betw
     [int(MAX_EARLY_DATA / 2), int(MAX_EARLY_DATA - 1), MAX_EARLY_DATA, 1],
 )
 def test_s2n_server_with_early_data_rejected(
-    managed_process,
+    managed_process,  # noqa: F811
     tmp_path,
     cipher,
     curve,
@@ -434,7 +434,7 @@ does not send key shares for.
     [int(MAX_EARLY_DATA / 2), int(MAX_EARLY_DATA - 1), MAX_EARLY_DATA, 1],
 )
 def test_s2n_client_with_early_data_rejected_via_hrr(
-    managed_process,
+    managed_process,  # noqa: F811
     tmp_path,
     cipher,
     curve,
@@ -511,7 +511,7 @@ S2N doesn't support while still supporting at least one curve S2N does support.
     [int(MAX_EARLY_DATA / 2), int(MAX_EARLY_DATA - 1), MAX_EARLY_DATA, 1],
 )
 def test_s2n_server_with_early_data_rejected_via_hrr(
-    managed_process,
+    managed_process,  # noqa: F811
     tmp_path,
     cipher,
     curve,
@@ -576,7 +576,7 @@ Test the S2N server fails if it receives too much early data.
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("excess_early_data", [1, 10, MAX_EARLY_DATA])
 def test_s2n_server_with_early_data_max_exceeded(
-    managed_process,
+    managed_process,  # noqa: F811
     tmp_path,
     cipher,
     curve,

--- a/tests/integrationv2/test_external_psk.py
+++ b/tests/integrationv2/test_external_psk.py
@@ -9,7 +9,7 @@ from configuration import (
     ALL_TEST_CERTS,
 )
 from common import ProviderOptions, Protocols, data_bytes
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import S2N, OpenSSL
 from utils import invalid_test_parameters, get_parameter_name, to_bytes
 from enum import Enum, auto
@@ -145,7 +145,7 @@ Tests a single psk connection with no fallback option.
 @pytest.mark.parametrize("psk_identity", PSK_IDENTITY_LIST, ids=get_parameter_name)
 @pytest.mark.parametrize("psk_secret", PSK_SECRET_LIST, ids=get_parameter_name)
 def test_s2n_server_psk_connection(
-    managed_process,
+    managed_process,  # noqa: F811
     cipher,
     curve,
     protocol,
@@ -206,7 +206,7 @@ Note that OpenSSL does not support multiple PSKs.
 @pytest.mark.parametrize("psk_identity", PSK_IDENTITY_LIST, ids=get_parameter_name)
 @pytest.mark.parametrize("psk_secret", PSK_SECRET_LIST, ids=get_parameter_name)
 def test_s2n_server_multiple_psks(
-    managed_process,
+    managed_process,  # noqa: F811
     cipher,
     curve,
     protocol,
@@ -294,7 +294,7 @@ as the input.
     "certificate", ALL_TEST_CERTS_WITH_EMPTY_CERT, ids=get_parameter_name
 )
 def test_s2n_server_full_handshake(
-    managed_process,
+    managed_process,  # noqa: F811
     cipher,
     curve,
     protocol,
@@ -366,7 +366,7 @@ Tests a single psk connection with no fallback option.
 @pytest.mark.parametrize("psk_identity", PSK_IDENTITY_LIST, ids=get_parameter_name)
 @pytest.mark.parametrize("psk_secret", PSK_SECRET_LIST, ids=get_parameter_name)
 def test_s2n_client_psk_connection(
-    managed_process,
+    managed_process,  # noqa: F811
     cipher,
     curve,
     protocol,
@@ -428,7 +428,7 @@ Note that OpenSSL does not support multiple PSKs.
 @pytest.mark.parametrize("psk_identity", PSK_IDENTITY_LIST, ids=get_parameter_name)
 @pytest.mark.parametrize("psk_secret", PSK_SECRET_LIST, ids=get_parameter_name)
 def test_s2n_client_multiple_psks(
-    managed_process,
+    managed_process,  # noqa: F811
     cipher,
     curve,
     protocol,
@@ -509,7 +509,7 @@ uses a default certificate if a certificate is not provided as the input.
 @pytest.mark.parametrize("psk_identity", PSK_IDENTITY_LIST, ids=get_parameter_name)
 @pytest.mark.parametrize("psk_secret", PSK_SECRET_LIST, ids=get_parameter_name)
 def test_s2n_client_psk_handshake_failure(
-    managed_process, cipher, curve, protocol, provider, psk_identity, psk_secret
+    managed_process, cipher, curve, protocol, provider, psk_identity, psk_secret  # noqa: F811
 ):
     port = next(available_ports)
     random_bytes = data_bytes(10)

--- a/tests/integrationv2/test_external_psk.py
+++ b/tests/integrationv2/test_external_psk.py
@@ -509,7 +509,13 @@ uses a default certificate if a certificate is not provided as the input.
 @pytest.mark.parametrize("psk_identity", PSK_IDENTITY_LIST, ids=get_parameter_name)
 @pytest.mark.parametrize("psk_secret", PSK_SECRET_LIST, ids=get_parameter_name)
 def test_s2n_client_psk_handshake_failure(
-    managed_process, cipher, curve, protocol, provider, psk_identity, psk_secret  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    protocol,
+    provider,
+    psk_identity,
+    psk_secret,  # noqa: F811
 ):
     port = next(available_ports)
     random_bytes = data_bytes(10)

--- a/tests/integrationv2/test_fragmentation.py
+++ b/tests/integrationv2/test_fragmentation.py
@@ -31,7 +31,12 @@ CERTIFICATES_TO_TEST = [Certificates.RSA_4096_SHA384, Certificates.ECDSA_384]
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", CERTIFICATES_TO_TEST, ids=get_parameter_name)
 def test_s2n_server_low_latency(
-    managed_process, cipher, provider, other_provider, protocol, certificate  # noqa: F811
+    managed_process,
+    cipher,
+    provider,
+    other_provider,
+    protocol,
+    certificate,  # noqa: F811
 ):
     if provider is OpenSSL and "openssl-1.0.2" in provider.get_version():
         pytest.skip(
@@ -97,7 +102,13 @@ def invalid_test_parameters_frag_len(*args, **kwargs):
     "frag_len", [512, 2048, 8192, 12345, 16384], ids=get_parameter_name
 )
 def test_s2n_server_framented_data(
-    managed_process, cipher, provider, other_provider, protocol, certificate, frag_len  # noqa: F811
+    managed_process,
+    cipher,
+    provider,
+    other_provider,
+    protocol,
+    certificate,
+    frag_len,  # noqa: F811
 ):
     if provider is OpenSSL and "openssl-1.0.2" in provider.get_version():
         pytest.skip(

--- a/tests/integrationv2/test_fragmentation.py
+++ b/tests/integrationv2/test_fragmentation.py
@@ -5,7 +5,7 @@ import pytest
 
 from configuration import available_ports, PROTOCOLS
 from common import ProviderOptions, Ciphers, Certificates, data_bytes
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, OpenSSL, GnuTLS
 from utils import (
     invalid_test_parameters,
@@ -31,7 +31,7 @@ CERTIFICATES_TO_TEST = [Certificates.RSA_4096_SHA384, Certificates.ECDSA_384]
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", CERTIFICATES_TO_TEST, ids=get_parameter_name)
 def test_s2n_server_low_latency(
-    managed_process, cipher, provider, other_provider, protocol, certificate
+    managed_process, cipher, provider, other_provider, protocol, certificate  # noqa: F811
 ):
     if provider is OpenSSL and "openssl-1.0.2" in provider.get_version():
         pytest.skip(
@@ -97,7 +97,7 @@ def invalid_test_parameters_frag_len(*args, **kwargs):
     "frag_len", [512, 2048, 8192, 12345, 16384], ids=get_parameter_name
 )
 def test_s2n_server_framented_data(
-    managed_process, cipher, provider, other_provider, protocol, certificate, frag_len
+    managed_process, cipher, provider, other_provider, protocol, certificate, frag_len  # noqa: F811
 ):
     if provider is OpenSSL and "openssl-1.0.2" in provider.get_version():
         pytest.skip(

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -11,7 +11,7 @@ from configuration import (
     PROTOCOLS,
 )
 from common import ProviderOptions, data_bytes
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, OpenSSL, JavaSSL, GnuTLS, SSLv3Provider
 from utils import (
     invalid_test_parameters,
@@ -29,7 +29,7 @@ from utils import (
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 def test_s2n_server_happy_path(
-    managed_process, cipher, provider, curve, protocol, certificate
+    managed_process, cipher, provider, curve, protocol, certificate  # noqa: F811
 ):
     port = next(available_ports)
 
@@ -94,7 +94,7 @@ def test_s2n_server_happy_path(
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 def test_s2n_client_happy_path(
-    managed_process, cipher, provider, curve, protocol, certificate
+    managed_process, cipher, provider, curve, protocol, certificate  # noqa: F811
 ):
     port = next(available_ports)
 

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -29,7 +29,12 @@ from utils import (
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 def test_s2n_server_happy_path(
-    managed_process, cipher, provider, curve, protocol, certificate  # noqa: F811
+    managed_process,
+    cipher,
+    provider,
+    curve,
+    protocol,
+    certificate,  # noqa: F811
 ):
     port = next(available_ports)
 
@@ -94,7 +99,12 @@ def test_s2n_server_happy_path(
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 def test_s2n_client_happy_path(
-    managed_process, cipher, provider, curve, protocol, certificate  # noqa: F811
+    managed_process,
+    cipher,
+    provider,
+    curve,
+    protocol,
+    certificate,  # noqa: F811
 ):
     port = next(available_ports)
 

--- a/tests/integrationv2/test_hello_retry_requests.py
+++ b/tests/integrationv2/test_hello_retry_requests.py
@@ -11,7 +11,7 @@ from configuration import (
     ALL_TEST_CERTS,
 )
 from common import ProviderOptions, Protocols, data_bytes, Curves
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, OpenSSL
 from utils import invalid_test_parameters, get_parameter_name, to_bytes
 
@@ -44,7 +44,7 @@ def test_nothing():
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 def test_hrr_with_s2n_as_client(
-    managed_process, cipher, provider, other_provider, curve, protocol, certificate
+    managed_process, cipher, provider, other_provider, curve, protocol, certificate  # noqa: F811
 ):
     if curve == S2N_DEFAULT_CURVE:
         pytest.skip("No retry if server curve matches client curve")
@@ -109,7 +109,7 @@ def test_hrr_with_s2n_as_client(
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 def test_hrr_with_s2n_as_server(
-    managed_process, cipher, provider, other_provider, curve, protocol, certificate
+    managed_process, cipher, provider, other_provider, curve, protocol, certificate  # noqa: F811
 ):
     port = next(available_ports)
 
@@ -175,7 +175,7 @@ TEST_CURVES = ALL_TEST_CURVES[1:]
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 def test_hrr_with_default_keyshare(
-    managed_process, cipher, provider, other_provider, curve, protocol, certificate
+    managed_process, cipher, provider, other_provider, curve, protocol, certificate  # noqa: F811
 ):
     port = next(available_ports)
 

--- a/tests/integrationv2/test_hello_retry_requests.py
+++ b/tests/integrationv2/test_hello_retry_requests.py
@@ -44,7 +44,13 @@ def test_nothing():
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 def test_hrr_with_s2n_as_client(
-    managed_process, cipher, provider, other_provider, curve, protocol, certificate  # noqa: F811
+    managed_process,
+    cipher,
+    provider,
+    other_provider,
+    curve,
+    protocol,
+    certificate,  # noqa: F811
 ):
     if curve == S2N_DEFAULT_CURVE:
         pytest.skip("No retry if server curve matches client curve")
@@ -109,7 +115,13 @@ def test_hrr_with_s2n_as_client(
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 def test_hrr_with_s2n_as_server(
-    managed_process, cipher, provider, other_provider, curve, protocol, certificate  # noqa: F811
+    managed_process,
+    cipher,
+    provider,
+    other_provider,
+    curve,
+    protocol,
+    certificate,  # noqa: F811
 ):
     port = next(available_ports)
 
@@ -175,7 +187,13 @@ TEST_CURVES = ALL_TEST_CURVES[1:]
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", ALL_TEST_CERTS, ids=get_parameter_name)
 def test_hrr_with_default_keyshare(
-    managed_process, cipher, provider, other_provider, curve, protocol, certificate  # noqa: F811
+    managed_process,
+    cipher,
+    provider,
+    other_provider,
+    curve,
+    protocol,
+    certificate,  # noqa: F811
 ):
     port = next(available_ports)
 

--- a/tests/integrationv2/test_key_update.py
+++ b/tests/integrationv2/test_key_update.py
@@ -5,7 +5,7 @@ import pytest
 
 from configuration import available_ports, TLS13_CIPHERS
 from common import ProviderOptions, Protocols, random_str
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, OpenSSL
 from utils import invalid_test_parameters, get_parameter_name
 
@@ -29,7 +29,7 @@ def test_nothing():
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 def test_s2n_server_key_update(
-    managed_process, cipher, provider, other_provider, protocol
+    managed_process, cipher, provider, other_provider, protocol  # noqa: F811
 ):
     host = "localhost"
     port = next(available_ports)
@@ -83,7 +83,7 @@ def test_s2n_server_key_update(
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 def test_s2n_client_key_update(
-    managed_process, cipher, provider, other_provider, protocol
+    managed_process, cipher, provider, other_provider, protocol  # noqa: F811
 ):
     host = "localhost"
     port = next(available_ports)

--- a/tests/integrationv2/test_key_update.py
+++ b/tests/integrationv2/test_key_update.py
@@ -29,7 +29,11 @@ def test_nothing():
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 def test_s2n_server_key_update(
-    managed_process, cipher, provider, other_provider, protocol  # noqa: F811
+    managed_process,
+    cipher,
+    provider,
+    other_provider,
+    protocol,  # noqa: F811
 ):
     host = "localhost"
     port = next(available_ports)
@@ -83,7 +87,11 @@ def test_s2n_server_key_update(
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
 def test_s2n_client_key_update(
-    managed_process, cipher, provider, other_provider, protocol  # noqa: F811
+    managed_process,
+    cipher,
+    provider,
+    other_provider,
+    protocol,  # noqa: F811
 ):
     host = "localhost"
     port = next(available_ports)

--- a/tests/integrationv2/test_npn.py
+++ b/tests/integrationv2/test_npn.py
@@ -36,7 +36,13 @@ PROTOCOL_LIST_NO_OVERLAP = "spdy"
 
 
 def s2n_client_npn_handshake(
-    managed_process, cipher, curve, certificate, protocol, provider, server_list  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    server_list,  # noqa: F811
 ):
     options = ProviderOptions(
         port=next(available_ports),
@@ -76,7 +82,12 @@ The s2n-tls client successfully negotiates an application protocol using NPN.
 @pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_npn(
-    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,  # noqa: F811
 ):
     s2n_client, server = s2n_client_npn_handshake(
         managed_process,
@@ -112,7 +123,12 @@ The s2n-tls client chooses a server-preferred protocol.
 @pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_npn_server_preference(
-    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,  # noqa: F811
 ):
     s2n_client, server = s2n_client_npn_handshake(
         managed_process,
@@ -148,7 +164,12 @@ The s2n-tls client chooses its preferred protocol since there is no overlap.
 @pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_npn_no_overlap(
-    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,  # noqa: F811
 ):
     s2n_client, server = s2n_client_npn_handshake(
         managed_process,
@@ -173,7 +194,13 @@ def test_s2n_client_npn_no_overlap(
 
 
 def s2n_server_npn_handshake(
-    managed_process, cipher, curve, certificate, protocol, provider, server_list  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    server_list,  # noqa: F811
 ):
     options = ProviderOptions(
         port=next(available_ports),
@@ -213,7 +240,12 @@ The s2n-tls server successfully negotiates an application protocol using NPN.
 @pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_server_npn(
-    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,  # noqa: F811
 ):
     # We only send one protocol on the s2n server
     # due to the fact that it re-purposes the alpn list(which only sends one protocol)
@@ -253,7 +285,12 @@ the client chooses its own protocol.
 @pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_server_npn_no_overlap(
-    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,  # noqa: F811
 ):
     client, s2n_server = s2n_server_npn_handshake(
         managed_process,

--- a/tests/integrationv2/test_npn.py
+++ b/tests/integrationv2/test_npn.py
@@ -11,7 +11,7 @@ from configuration import (
     PROTOCOLS,
 )
 from common import ProviderOptions, Protocols
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import OpenSSL, S2N, Provider
 from utils import invalid_test_parameters, get_parameter_name, to_bytes
 
@@ -36,7 +36,7 @@ PROTOCOL_LIST_NO_OVERLAP = "spdy"
 
 
 def s2n_client_npn_handshake(
-    managed_process, cipher, curve, certificate, protocol, provider, server_list
+    managed_process, cipher, curve, certificate, protocol, provider, server_list  # noqa: F811
 ):
     options = ProviderOptions(
         port=next(available_ports),
@@ -76,7 +76,7 @@ The s2n-tls client successfully negotiates an application protocol using NPN.
 @pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_npn(
-    managed_process, cipher, curve, certificate, protocol, provider
+    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
 ):
     s2n_client, server = s2n_client_npn_handshake(
         managed_process,
@@ -112,7 +112,7 @@ The s2n-tls client chooses a server-preferred protocol.
 @pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_npn_server_preference(
-    managed_process, cipher, curve, certificate, protocol, provider
+    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
 ):
     s2n_client, server = s2n_client_npn_handshake(
         managed_process,
@@ -148,7 +148,7 @@ The s2n-tls client chooses its preferred protocol since there is no overlap.
 @pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_npn_no_overlap(
-    managed_process, cipher, curve, certificate, protocol, provider
+    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
 ):
     s2n_client, server = s2n_client_npn_handshake(
         managed_process,
@@ -173,7 +173,7 @@ def test_s2n_client_npn_no_overlap(
 
 
 def s2n_server_npn_handshake(
-    managed_process, cipher, curve, certificate, protocol, provider, server_list
+    managed_process, cipher, curve, certificate, protocol, provider, server_list  # noqa: F811
 ):
     options = ProviderOptions(
         port=next(available_ports),
@@ -213,7 +213,7 @@ The s2n-tls server successfully negotiates an application protocol using NPN.
 @pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_server_npn(
-    managed_process, cipher, curve, certificate, protocol, provider
+    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
 ):
     # We only send one protocol on the s2n server
     # due to the fact that it re-purposes the alpn list(which only sends one protocol)
@@ -253,7 +253,7 @@ the client chooses its own protocol.
 @pytest.mark.parametrize("protocol", TLS_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_server_npn_no_overlap(
-    managed_process, cipher, curve, certificate, protocol, provider
+    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
 ):
     client, s2n_server = s2n_server_npn_handshake(
         managed_process,

--- a/tests/integrationv2/test_ocsp.py
+++ b/tests/integrationv2/test_ocsp.py
@@ -4,7 +4,7 @@ import pytest
 
 from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, PROTOCOLS
 from common import ProviderOptions, data_bytes, Certificates
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from constants import TEST_OCSP_DIRECTORY
 from providers import Provider, S2N, OpenSSL, GnuTLS
 from utils import invalid_test_parameters, get_parameter_name
@@ -22,7 +22,7 @@ OCSP_CERTS = [Certificates.OCSP, Certificates.OCSP_ECDSA]
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", OCSP_CERTS, ids=get_parameter_name)
 def test_s2n_client_ocsp_response(
-    managed_process, cipher, provider, other_provider, curve, protocol, certificate
+    managed_process, cipher, provider, other_provider, curve, protocol, certificate  # noqa: F811
 ):
     if "boringssl" in get_flag(S2N_PROVIDER_VERSION):
         pytest.skip("s2n-tls client with boringssl does not support ocsp")
@@ -86,7 +86,7 @@ def test_s2n_client_ocsp_response(
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", OCSP_CERTS, ids=get_parameter_name)
 def test_s2n_server_ocsp_response(
-    managed_process, cipher, provider, other_provider, curve, protocol, certificate
+    managed_process, cipher, provider, other_provider, curve, protocol, certificate  # noqa: F811
 ):
     port = next(available_ports)
 

--- a/tests/integrationv2/test_ocsp.py
+++ b/tests/integrationv2/test_ocsp.py
@@ -22,7 +22,13 @@ OCSP_CERTS = [Certificates.OCSP, Certificates.OCSP_ECDSA]
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", OCSP_CERTS, ids=get_parameter_name)
 def test_s2n_client_ocsp_response(
-    managed_process, cipher, provider, other_provider, curve, protocol, certificate  # noqa: F811
+    managed_process,
+    cipher,
+    provider,
+    other_provider,
+    curve,
+    protocol,
+    certificate,  # noqa: F811
 ):
     if "boringssl" in get_flag(S2N_PROVIDER_VERSION):
         pytest.skip("s2n-tls client with boringssl does not support ocsp")
@@ -86,7 +92,13 @@ def test_s2n_client_ocsp_response(
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", OCSP_CERTS, ids=get_parameter_name)
 def test_s2n_server_ocsp_response(
-    managed_process, cipher, provider, other_provider, curve, protocol, certificate  # noqa: F811
+    managed_process,
+    cipher,
+    provider,
+    other_provider,
+    curve,
+    protocol,
+    certificate,  # noqa: F811
 ):
     port = next(available_ports)
 

--- a/tests/integrationv2/test_pq_handshake.py
+++ b/tests/integrationv2/test_pq_handshake.py
@@ -13,7 +13,7 @@ from common import (
     Certificates,
     pq_enabled,
 )
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, OpenSSL, BoringSSL
 from utils import invalid_test_parameters, get_parameter_name, to_bytes
 from global_flags import get_flag, S2N_PROVIDER_VERSION
@@ -149,7 +149,7 @@ def test_nothing():
 @pytest.mark.parametrize("provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_s2nc_to_s2nd_pq_handshake(
-    managed_process,
+    managed_process,  # noqa: F811
     protocol,
     certificate,
     client_cipher,
@@ -206,7 +206,7 @@ def test_s2nc_to_s2nd_pq_handshake(
     ids=get_parameter_name,
 )
 def test_s2nc_to_awslc_pq_handshake(
-    managed_process, s2n_client_policy, awslc_server_group
+    managed_process, s2n_client_policy, awslc_server_group  # noqa: F811
 ):
     if not pq_enabled():
         pytest.skip("PQ not enabled")
@@ -260,7 +260,7 @@ def test_s2nc_to_awslc_pq_handshake(
     ids=get_parameter_name,
 )
 def test_s2nd_to_awslc_pq_handshake(
-    managed_process, s2n_server_policy, awslc_client_group
+    managed_process, s2n_server_policy, awslc_client_group  # noqa: F811
 ):
     if not pq_enabled():
         pytest.skip("PQ not enabled")
@@ -311,7 +311,7 @@ def test_s2nd_to_awslc_pq_handshake(
     "cipher", [Ciphers.PQ_TLS_1_3_2023_06_01], ids=get_parameter_name
 )
 @pytest.mark.parametrize("kem_group", KEM_GROUPS, ids=get_parameter_name)
-def test_s2nc_to_oqs_openssl_pq_handshake(managed_process, protocol, cipher, kem_group):
+def test_s2nc_to_oqs_openssl_pq_handshake(managed_process, protocol, cipher, kem_group):  # noqa: F811
     # If PQ is not enabled in s2n, there is no reason to test against oqs_openssl
     if not pq_enabled():
         return
@@ -357,7 +357,7 @@ def test_s2nc_to_oqs_openssl_pq_handshake(managed_process, protocol, cipher, kem
     "cipher", [Ciphers.PQ_TLS_1_3_2023_06_01], ids=get_parameter_name
 )
 @pytest.mark.parametrize("kem_group", KEM_GROUPS, ids=get_parameter_name)
-def test_oqs_openssl_to_s2nd_pq_handshake(managed_process, protocol, cipher, kem_group):
+def test_oqs_openssl_to_s2nd_pq_handshake(managed_process, protocol, cipher, kem_group):  # noqa: F811
     # If PQ is not enabled in s2n, there is no reason to test against oqs_openssl
     if not pq_enabled():
         return

--- a/tests/integrationv2/test_pq_handshake.py
+++ b/tests/integrationv2/test_pq_handshake.py
@@ -206,7 +206,9 @@ def test_s2nc_to_s2nd_pq_handshake(
     ids=get_parameter_name,
 )
 def test_s2nc_to_awslc_pq_handshake(
-    managed_process, s2n_client_policy, awslc_server_group  # noqa: F811
+    managed_process,
+    s2n_client_policy,
+    awslc_server_group,  # noqa: F811
 ):
     if not pq_enabled():
         pytest.skip("PQ not enabled")
@@ -260,7 +262,9 @@ def test_s2nc_to_awslc_pq_handshake(
     ids=get_parameter_name,
 )
 def test_s2nd_to_awslc_pq_handshake(
-    managed_process, s2n_server_policy, awslc_client_group  # noqa: F811
+    managed_process,
+    s2n_server_policy,
+    awslc_client_group,  # noqa: F811
 ):
     if not pq_enabled():
         pytest.skip("PQ not enabled")

--- a/tests/integrationv2/test_record_padding.py
+++ b/tests/integrationv2/test_record_padding.py
@@ -12,7 +12,7 @@ from configuration import (
     MINIMAL_TEST_CERTS,
 )
 from common import ProviderOptions, Protocols, data_bytes
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, OpenSSL
 from utils import (
     invalid_test_parameters,
@@ -86,7 +86,7 @@ def test_nothing():
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("padding_size", PADDING_SIZES, ids=get_parameter_name)
 def test_s2n_server_handles_padded_records(
-    managed_process, cipher, provider, curve, protocol, certificate, padding_size
+    managed_process, cipher, provider, curve, protocol, certificate, padding_size  # noqa: F811
 ):
     port = next(available_ports)
 
@@ -148,7 +148,7 @@ def test_s2n_server_handles_padded_records(
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("padding_size", PADDING_SIZES, ids=get_parameter_name)
 def test_s2n_client_handles_padded_records(
-    managed_process, cipher, provider, curve, protocol, certificate, padding_size
+    managed_process, cipher, provider, curve, protocol, certificate, padding_size  # noqa: F811
 ):
     port = next(available_ports)
 

--- a/tests/integrationv2/test_record_padding.py
+++ b/tests/integrationv2/test_record_padding.py
@@ -86,7 +86,13 @@ def test_nothing():
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("padding_size", PADDING_SIZES, ids=get_parameter_name)
 def test_s2n_server_handles_padded_records(
-    managed_process, cipher, provider, curve, protocol, certificate, padding_size  # noqa: F811
+    managed_process,
+    cipher,
+    provider,
+    curve,
+    protocol,
+    certificate,
+    padding_size,  # noqa: F811
 ):
     port = next(available_ports)
 
@@ -148,7 +154,13 @@ def test_s2n_server_handles_padded_records(
 @pytest.mark.parametrize("certificate", MINIMAL_TEST_CERTS, ids=get_parameter_name)
 @pytest.mark.parametrize("padding_size", PADDING_SIZES, ids=get_parameter_name)
 def test_s2n_client_handles_padded_records(
-    managed_process, cipher, provider, curve, protocol, certificate, padding_size  # noqa: F811
+    managed_process,
+    cipher,
+    provider,
+    curve,
+    protocol,
+    certificate,
+    padding_size,  # noqa: F811
 ):
     port = next(available_ports)
 

--- a/tests/integrationv2/test_renegotiate.py
+++ b/tests/integrationv2/test_renegotiate.py
@@ -245,7 +245,12 @@ This tests the default behavior for customers who do not enable renegotiation.
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_ignores_openssl_hello_request(
-    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,  # noqa: F811
 ):
     (s2n_client, server) = basic_reneg_test(
         managed_process, cipher, curve, certificate, protocol, provider
@@ -277,7 +282,12 @@ Renegotiation request rejected by s2n-tls client.
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_rejects_openssl_hello_request(
-    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,  # noqa: F811
 ):
     (s2n_client, server) = basic_reneg_test(
         managed_process,
@@ -311,7 +321,12 @@ Renegotiation request accepted by s2n-tls client.
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_renegotiate_with_openssl(
-    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,  # noqa: F811
 ):
     (s2n_client, server) = basic_reneg_test(
         managed_process,
@@ -353,7 +368,12 @@ but does require client auth during the second handshake.
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_renegotiate_with_client_auth_with_openssl(
-    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,  # noqa: F811
 ):
     # We want to use the same messages to test renegotiation,
     # but with 'R' instead of 'r' to trigger the Openssl renegotiate request.
@@ -413,7 +433,12 @@ The s2n-tls client successfully reads ApplicationData during the renegotiation h
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_renegotiate_with_app_data_with_openssl(
-    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,  # noqa: F811
 ):
     first_server_app_data = Msg.expected_output(RENEG_MESSAGES, Provider.ClientMode)[0]
     (s2n_client, server) = basic_reneg_test(

--- a/tests/integrationv2/test_renegotiate.py
+++ b/tests/integrationv2/test_renegotiate.py
@@ -12,7 +12,7 @@ from configuration import (
     PROTOCOLS,
 )
 from common import ProviderOptions, Protocols
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, OpenSSL
 from utils import invalid_test_parameters, get_parameter_name
 
@@ -183,7 +183,7 @@ RENEG_MESSAGES = [
 
 
 def basic_reneg_test(
-    managed_process,
+    managed_process,  # noqa: F811
     cipher,
     curve,
     certificate,
@@ -245,7 +245,7 @@ This tests the default behavior for customers who do not enable renegotiation.
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_ignores_openssl_hello_request(
-    managed_process, cipher, curve, certificate, protocol, provider
+    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
 ):
     (s2n_client, server) = basic_reneg_test(
         managed_process, cipher, curve, certificate, protocol, provider
@@ -277,7 +277,7 @@ Renegotiation request rejected by s2n-tls client.
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_rejects_openssl_hello_request(
-    managed_process, cipher, curve, certificate, protocol, provider
+    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
 ):
     (s2n_client, server) = basic_reneg_test(
         managed_process,
@@ -311,7 +311,7 @@ Renegotiation request accepted by s2n-tls client.
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_renegotiate_with_openssl(
-    managed_process, cipher, curve, certificate, protocol, provider
+    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
 ):
     (s2n_client, server) = basic_reneg_test(
         managed_process,
@@ -353,7 +353,7 @@ but does require client auth during the second handshake.
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_renegotiate_with_client_auth_with_openssl(
-    managed_process, cipher, curve, certificate, protocol, provider
+    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
 ):
     # We want to use the same messages to test renegotiation,
     # but with 'R' instead of 'r' to trigger the Openssl renegotiate request.
@@ -413,7 +413,7 @@ The s2n-tls client successfully reads ApplicationData during the renegotiation h
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 def test_s2n_client_renegotiate_with_app_data_with_openssl(
-    managed_process, cipher, curve, certificate, protocol, provider
+    managed_process, cipher, curve, certificate, protocol, provider  # noqa: F811
 ):
     first_server_app_data = Msg.expected_output(RENEG_MESSAGES, Provider.ClientMode)[0]
     (s2n_client, server) = basic_reneg_test(

--- a/tests/integrationv2/test_renegotiate_apache.py
+++ b/tests/integrationv2/test_renegotiate_apache.py
@@ -5,7 +5,7 @@ import tempfile
 
 from configuration import ALL_TEST_CURVES
 from common import ProviderOptions
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N
 from utils import invalid_test_parameters, get_parameter_name
 from constants import TEST_CERT_DIRECTORY
@@ -32,7 +32,7 @@ def create_get_request(route):
 @pytest.mark.parametrize(
     "endpoint", [CHANGE_CIPHER_SUITE_ENDPOINT, MUTUAL_AUTH_ENDPOINT]
 )
-def test_apache_endpoints_fail_with_no_reneg(managed_process, protocol, endpoint):
+def test_apache_endpoints_fail_with_no_reneg(managed_process, protocol, endpoint):  # noqa: F811
     options = ProviderOptions(
         mode=Provider.ClientMode,
         host=APACHE_SERVER_IP,
@@ -66,7 +66,7 @@ def test_apache_endpoints_fail_with_no_reneg(managed_process, protocol, endpoint
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
-def test_change_cipher_suite_endpoint(managed_process, curve, protocol):
+def test_change_cipher_suite_endpoint(managed_process, curve, protocol):  # noqa: F811
     options = ProviderOptions(
         mode=Provider.ClientMode,
         host=APACHE_SERVER_IP,
@@ -95,7 +95,7 @@ def test_change_cipher_suite_endpoint(managed_process, curve, protocol):
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
-def test_mutual_auth_endpoint(managed_process, curve, protocol):
+def test_mutual_auth_endpoint(managed_process, curve, protocol):  # noqa: F811
     options = ProviderOptions(
         mode=Provider.ClientMode,
         host=APACHE_SERVER_IP,

--- a/tests/integrationv2/test_serialization.py
+++ b/tests/integrationv2/test_serialization.py
@@ -53,7 +53,11 @@ This prevents one peer from receiving a TCP FIN message and shutting the connect
     "version_change", [Mode.Server, Mode.Client], ids=get_parameter_name
 )
 def test_server_serialization_backwards_compat(
-    managed_process, tmp_path, protocol, mainline_role, version_change  # noqa: F811
+    managed_process,
+    tmp_path,
+    protocol,
+    mainline_role,
+    version_change,  # noqa: F811
 ):
     server_state_file = str(tmp_path / SERVER_STATE_FILE)
     client_state_file = str(tmp_path / CLIENT_STATE_FILE)

--- a/tests/integrationv2/test_serialization.py
+++ b/tests/integrationv2/test_serialization.py
@@ -7,7 +7,7 @@ from enum import Enum, auto
 
 from configuration import available_ports
 from common import ProviderOptions, Protocols, random_str
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N
 from utils import invalid_test_parameters, get_parameter_name, to_bytes
 
@@ -53,7 +53,7 @@ This prevents one peer from receiving a TCP FIN message and shutting the connect
     "version_change", [Mode.Server, Mode.Client], ids=get_parameter_name
 )
 def test_server_serialization_backwards_compat(
-    managed_process, tmp_path, protocol, mainline_role, version_change
+    managed_process, tmp_path, protocol, mainline_role, version_change  # noqa: F811
 ):
     server_state_file = str(tmp_path / SERVER_STATE_FILE)
     client_state_file = str(tmp_path / CLIENT_STATE_FILE)

--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -250,7 +250,13 @@ def test_tls13_session_resumption_s2n_server(
 @pytest.mark.parametrize("provider", [OpenSSL, S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_tls13_session_resumption_s2n_client(
-    managed_process, cipher, curve, certificate, protocol, provider, other_provider  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    other_provider,  # noqa: F811
 ):
     port = str(next(available_ports))
 
@@ -419,7 +425,13 @@ def test_s2nd_falls_back_to_full_connection(
 @pytest.mark.parametrize("provider", [OpenSSL, S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_session_resumption_s2n_client_tls13_server_not_tls13(
-    managed_process, cipher, curve, protocol, provider, other_provider, certificate  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    protocol,
+    provider,
+    other_provider,
+    certificate,  # noqa: F811
 ):
     port = next(available_ports)
 

--- a/tests/integrationv2/test_session_resumption.py
+++ b/tests/integrationv2/test_session_resumption.py
@@ -14,7 +14,7 @@ from configuration import (
     TLS13_CIPHERS,
 )
 from common import ProviderOptions, Protocols, data_bytes
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, OpenSSL
 from utils import (
     invalid_test_parameters,
@@ -35,7 +35,7 @@ from utils import (
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("use_ticket", [True, False])
 def test_session_resumption_s2n_server(
-    managed_process,
+    managed_process,  # noqa: F811
     cipher,
     curve,
     certificate,
@@ -97,7 +97,7 @@ def test_session_resumption_s2n_server(
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("use_ticket", [True, False])
 def test_session_resumption_s2n_client(
-    managed_process,
+    managed_process,  # noqa: F811
     cipher,
     curve,
     protocol,
@@ -154,7 +154,7 @@ def test_session_resumption_s2n_client(
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_tls13_session_resumption_s2n_server(
-    managed_process,
+    managed_process,  # noqa: F811
     tmp_path,
     cipher,
     curve,
@@ -250,7 +250,7 @@ def test_tls13_session_resumption_s2n_server(
 @pytest.mark.parametrize("provider", [OpenSSL, S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_tls13_session_resumption_s2n_client(
-    managed_process, cipher, curve, certificate, protocol, provider, other_provider
+    managed_process, cipher, curve, certificate, protocol, provider, other_provider  # noqa: F811
 ):
     port = str(next(available_ports))
 
@@ -326,7 +326,7 @@ def test_tls13_session_resumption_s2n_client(
 @pytest.mark.parametrize("provider", [OpenSSL], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_s2nd_falls_back_to_full_connection(
-    managed_process,
+    managed_process,  # noqa: F811
     tmp_path,
     cipher,
     curve,
@@ -419,7 +419,7 @@ def test_s2nd_falls_back_to_full_connection(
 @pytest.mark.parametrize("provider", [OpenSSL, S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_session_resumption_s2n_client_tls13_server_not_tls13(
-    managed_process, cipher, curve, protocol, provider, other_provider, certificate
+    managed_process, cipher, curve, protocol, provider, other_provider, certificate  # noqa: F811
 ):
     port = next(available_ports)
 

--- a/tests/integrationv2/test_signature_algorithms.py
+++ b/tests/integrationv2/test_signature_algorithms.py
@@ -5,7 +5,7 @@ import pytest
 
 from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CERTS
 from common import ProviderOptions, Protocols, Signatures, data_bytes
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, OpenSSL, GnuTLS
 from utils import (
     invalid_test_parameters,
@@ -95,7 +95,7 @@ def skip_ciphers(*args, **kwargs):
     ids=lambda val: "client-auth" if val else "no-client-auth",
 )
 def test_s2n_server_signature_algorithms(
-    managed_process,
+    managed_process,  # noqa: F811
     cipher,
     provider,
     other_provider,
@@ -177,7 +177,7 @@ def test_s2n_server_signature_algorithms(
     ids=lambda val: "client-auth" if val else "no-client-auth",
 )
 def test_s2n_client_signature_algorithms(
-    managed_process,
+    managed_process,  # noqa: F811
     cipher,
     provider,
     other_provider,

--- a/tests/integrationv2/test_sni_match.py
+++ b/tests/integrationv2/test_sni_match.py
@@ -4,7 +4,7 @@ import pytest
 
 from configuration import available_ports, MULTI_CERT_TEST_CASES
 from common import ProviderOptions, Protocols
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, OpenSSL
 from utils import (
     invalid_test_parameters,
@@ -41,7 +41,7 @@ def filter_cipher_list(*args, **kwargs):
     "protocol", [Protocols.TLS13, Protocols.TLS12], ids=get_parameter_name
 )
 @pytest.mark.parametrize("cert_test_case", MULTI_CERT_TEST_CASES)
-def test_sni_match(managed_process, provider, other_provider, protocol, cert_test_case):
+def test_sni_match(managed_process, provider, other_provider, protocol, cert_test_case):  # noqa: F811
     port = next(available_ports)
 
     client_options = ProviderOptions(

--- a/tests/integrationv2/test_sslv2_client_hello.py
+++ b/tests/integrationv2/test_sslv2_client_hello.py
@@ -4,14 +4,14 @@ import copy
 
 from configuration import available_ports
 from common import Certificates, Ciphers, Protocols, ProviderOptions, data_bytes
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, JavaSSL
 from utils import (
     to_bytes,
 )
 
 
-def test_s2n_server_sslv2_client_hello(managed_process):
+def test_s2n_server_sslv2_client_hello(managed_process):  # noqa: F811
     # TLS 1.3: not supported by SSLv2 ClientHellos
     # TLS 1.2: supported
     # TLS 1.0 - TLS 1.1: not supported by Java

--- a/tests/integrationv2/test_sslyze.py
+++ b/tests/integrationv2/test_sslyze.py
@@ -7,7 +7,7 @@ from enum import Enum, auto
 
 from configuration import available_ports, ALL_TEST_CERTS
 from common import ProviderOptions, Protocols, Cipher, Ciphers, Curves
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import S2N
 from utils import get_parameter_name, invalid_test_parameters
 from global_flags import get_flag, S2N_PROVIDER_VERSION
@@ -262,7 +262,7 @@ def invalid_sslyze_scan_parameters(*args, **kwargs):
 @pytest.mark.parametrize("protocol", PROTOCOLS_TO_TEST, ids=get_parameter_name)
 @pytest.mark.parametrize("scan_command", SSLYZE_SCANS_TO_TEST, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [S2N], ids=get_parameter_name)
-def test_sslyze_scans(managed_process, protocol, scan_command, provider):
+def test_sslyze_scans(managed_process, protocol, scan_command, provider):  # noqa: F811
     port = next(available_ports)
 
     server_options = ProviderOptions(
@@ -358,7 +358,7 @@ def invalid_certificate_scans_parameters(*args, **kwargs):
     ids=lambda certificate_scan: certificate_scan.name,
 )
 def test_sslyze_certificate_scans(
-    managed_process, protocol, certificate, provider, certificate_scan
+    managed_process, protocol, certificate, provider, certificate_scan  # noqa: F811
 ):
     port = next(available_ports)
 

--- a/tests/integrationv2/test_sslyze.py
+++ b/tests/integrationv2/test_sslyze.py
@@ -358,7 +358,11 @@ def invalid_certificate_scans_parameters(*args, **kwargs):
     ids=lambda certificate_scan: certificate_scan.name,
 )
 def test_sslyze_certificate_scans(
-    managed_process, protocol, certificate, provider, certificate_scan  # noqa: F811
+    managed_process,
+    protocol,
+    certificate,
+    provider,
+    certificate_scan,  # noqa: F811
 ):
     port = next(available_ports)
 

--- a/tests/integrationv2/test_version_negotiation.py
+++ b/tests/integrationv2/test_version_negotiation.py
@@ -10,7 +10,7 @@ from configuration import (
     ALL_TEST_CERTS,
 )
 from common import ProviderOptions, Protocols, data_bytes
-from fixtures import managed_process  # lgtm [py/unused-import]
+from fixtures import managed_process  # lgtm [py/unused-import]  # noqa: F401
 from providers import Provider, S2N, OpenSSL, GnuTLS
 from utils import (
     invalid_test_parameters,
@@ -51,7 +51,7 @@ def invalid_version_negotiation_test_parameters(*args, **kwargs):
 @pytest.mark.parametrize("provider", [S2N, OpenSSL, GnuTLS], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_s2nc_tls13_negotiates_tls12(
-    managed_process, cipher, curve, certificate, protocol, provider, other_provider
+    managed_process, cipher, curve, certificate, protocol, provider, other_provider  # noqa: F811
 ):
     port = next(available_ports)
 
@@ -126,7 +126,7 @@ def test_s2nc_tls13_negotiates_tls12(
 @pytest.mark.parametrize("provider", [S2N, OpenSSL, GnuTLS], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_s2nd_tls13_negotiates_tls12(
-    managed_process, cipher, curve, certificate, protocol, provider, other_provider
+    managed_process, cipher, curve, certificate, protocol, provider, other_provider  # noqa: F811
 ):
     port = next(available_ports)
 

--- a/tests/integrationv2/test_version_negotiation.py
+++ b/tests/integrationv2/test_version_negotiation.py
@@ -51,7 +51,13 @@ def invalid_version_negotiation_test_parameters(*args, **kwargs):
 @pytest.mark.parametrize("provider", [S2N, OpenSSL, GnuTLS], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_s2nc_tls13_negotiates_tls12(
-    managed_process, cipher, curve, certificate, protocol, provider, other_provider  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    other_provider,  # noqa: F811
 ):
     port = next(available_ports)
 
@@ -126,7 +132,13 @@ def test_s2nc_tls13_negotiates_tls12(
 @pytest.mark.parametrize("provider", [S2N, OpenSSL, GnuTLS], ids=get_parameter_name)
 @pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 def test_s2nd_tls13_negotiates_tls12(
-    managed_process, cipher, curve, certificate, protocol, provider, other_provider  # noqa: F811
+    managed_process,
+    cipher,
+    curve,
+    certificate,
+    protocol,
+    provider,
+    other_provider,  # noqa: F811
 ):
     port = next(available_ports)
 


### PR DESCRIPTION
### Description of changes: 

s2n currently shows numerous linting warnings (F401 and F811) for code that is intentionally written this way (e.g., for test fixtures or managed processes). This PR adds inline # noqa directives to suppress these warnings, cleaning up the output without changing the code’s behavior.
