### PR TITLE
chore(bindings): change in rustup behavior

### DIFF
--- a/bindings/rust/extended/generate.sh
+++ b/bindings/rust/extended/generate.sh
@@ -55,6 +55,7 @@ cargo publish --dry-run --allow-dirty --all-features
 popd
 
 pushd ../standard/integration
+rustc --version || rustup toolchain install
 cargo run
 popd
 

--- a/bindings/rust/extended/generate.sh
+++ b/bindings/rust/extended/generate.sh
@@ -37,6 +37,7 @@ cp -r \
 pushd generate
 # Behavior change from https://github.com/rust-lang/rustup/pull/3985
 rustc --version || rustup toolchain install
+rustup component add rustfmt
 cargo run -- ../s2n-tls-sys
 popd
 

--- a/bindings/rust/extended/generate.sh
+++ b/bindings/rust/extended/generate.sh
@@ -35,6 +35,8 @@ cp -r \
 
 # generate the bindings modules from the copied sources
 pushd generate
+# Behavior change from https://github.com/rust-lang/rustup/pull/3985
+rustc --version || rustup toolchain install
 cargo run -- ../s2n-tls-sys
 popd
 


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

none

### Description of changes: 

Our rust related GitHub actions are failing on the `generate.sh` step with: 

```
+ cargo run -- ../s2n-tls-sys
error: toolchain '1.63.0-x86_64-unknown-linux-gnu' is not installed
help: run `rustup toolchain install 1.63.0-x86_64-unknown-linux-gnu` to install it
```

Which appears related to https://github.com/rust-lang/rustup/pull/3985

Adds a test to see if the toolchain is available and if not, install it.

### Call-outs

This seems like it should belong in a rust setup related action instead?

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? locally
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
