### PR TITLE
chore(bindings): bump standard toolchain to latest

### DIFF
--- a/bindings/rust/standard/rust-toolchain.toml
+++ b/bindings/rust/standard/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.84.0"


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

The Rust CI [is failing](https://github.com/aws/s2n-tls/actions/runs/13685200370/job/38267545998?pr=5158) with:
```
error[E0599]: no method named `is_none_or` found for enum `Option` in the current scope
  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/symbolic-common-12.14.0/src/path.rs:57:32
   |
57 |             return path.get(2).is_none_or(is_windows_separator);
   |                                ^^^^^^^^^^ help: there is a method with a similar name: `is_none`
For more information about this error, try `rustc --explain E0599`.
error: could not compile `symbolic-common` (lib) due to previous error
warning: build failed, waiting for other jobs to finish...
```

Looks like one of our dependencies, "symbolic", started using the is_none_or in their latest release: https://github.com/getsentry/symbolic/commit/0ba5f9cef6904da0e48d26b685f66f0dcc880b8e That was JUST stabilized in 1.84.0.

Since this is standard instead of extended, we can just bump our toolchain rather than pin :)


### Testing:

CI now passes, specifically "Standard Workspace Tests" in the generate action.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
