### PR TITLE
fix: mark chachapoly as unavailable with openssl-3.0-fips

### DIFF
--- a/codebuild/spec/buildspec_openssl3fips.yml
+++ b/codebuild/spec/buildspec_openssl3fips.yml
@@ -35,7 +35,4 @@ phases:
     commands:
       - export CTEST_PARALLEL_LEVEL=$(nproc)
       # openssl3fips is still a work-in-progress. Not all tests pass.
-      - make -C build test -- ARGS="-R 's2n_build_test|s2n_fips_test'"
-      - make -C build test -- ARGS="-R 's2n_hash_test|s2n_hash_all_algs_test|s2n_openssl_test|s2n_init_test'"
-      - make -C build test -- ARGS="-R 's2n_evp_signing_test'"
-      - make -C build test -- ARGS="-R 's2n_tls_prf_test|s2n_tls_hybrid_prf_test'"
+      - make -C build test -- ARGS="-E 's2n_self_talk_offload_signing_test'"

--- a/crypto/s2n_aead_cipher_chacha20_poly1305.c
+++ b/crypto/s2n_aead_cipher_chacha20_poly1305.c
@@ -16,6 +16,7 @@
 #include <openssl/evp.h>
 
 #include "crypto/s2n_cipher.h"
+#include "crypto/s2n_libcrypto.h"
 #include "crypto/s2n_openssl.h"
 #include "tls/s2n_crypto.h"
 #include "utils/s2n_blob.h"
@@ -37,7 +38,11 @@
 static bool s2n_aead_chacha20_poly1305_available(void)
 {
 #if defined(S2N_CHACHA20_POLY1305_AVAILABLE_OSSL) || defined(S2N_CHACHA20_POLY1305_AVAILABLE_BSSL_AWSLC)
-    return true;
+    /* We could support ChaChaPoly with openssl-3.0-fips,
+     * but it would require more branching and logic to fetch a non-fips EVP_CIPHER.
+     * For now, just consider ChaChaPoly unsupported by openssl-3.0-fips.
+     */
+    return !s2n_libcrypto_is_openssl_fips();
 #else
     return false;
 #endif


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

related to https://github.com/aws/s2n-tls/issues/4993

### Description of changes: 

Unlike many of the non-fips options in s2n-tls, ciphers have an easily modified "is_available" method already implemented. Just mark chachapoly as unavailable rather than try to get the algorithm from a non-fips provider. If necessary, we can add the extra logic later to support chachapoly with fips.

### Call-outs:

There's still one test failing, but it doesn't look related to chachapoly. Something to do with signing. I still need to investigate.

### Testing:
Almost all the tests now work for openssl-3.0-fips! I switched from "-F" (run tests that match pattern) to "-E" (run tests that do NOT match pattern)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
