### PR TITLE
tests: fix flaky ja4 test

### DIFF
--- a/tests/unit/s2n_fingerprint_ja4_test.c
+++ b/tests/unit/s2n_fingerprint_ja4_test.c
@@ -145,9 +145,11 @@ static S2N_RESULT s2n_test_ja4_hash_from_cipher_count(uint16_t cipher_count,
     };
     RESULT_GUARD_POSIX(s2n_stuffer_write_bytes(&bytes, before_ciphers, sizeof(before_ciphers)));
 
-    size_t ciphers_size = cipher_count * S2N_TLS_CIPHER_SUITE_LEN;
+    size_t ciphers_size = cipher_count * sizeof(uint16_t);
     RESULT_GUARD_POSIX(s2n_stuffer_write_uint16(&bytes, ciphers_size));
-    RESULT_GUARD_POSIX(s2n_stuffer_skip_write(&bytes, ciphers_size));
+    for (size_t i = 0; i < cipher_count; i++) {
+        RESULT_GUARD_POSIX(s2n_stuffer_write_uint16(&bytes, 0));
+    }
 
     uint8_t after_ciphers[] = {
         S2N_TEST_CLIENT_HELLO_AFTER_CIPHERS,


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

The JA4 test has been failing on AL2 randomly. See [this](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoidUpNb2QzNjZzQ3lrWm1UQ2xzdFZMN1ZGYWE5dVlSQ1ZKd1BnZzZ6aXN1dlZXTmFuZWdvNnR0SitPaFlIcUdjaDZ6RU9KemY2Mi9ybXVBajF0RXo4NmZ1Rnl4dkZrT241UUY4MTVQMkRuNTQ9IiwiaXZQYXJhbWV0ZXJTcGVjIjoiemFRUDgvZUMreVhER0RKaiIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D/build/f8fafce5-ad94-49ac-8efe-75e694383def) test run. It fails with:
>  (output[S2N_JA4_A_CIPHER_COUNT_1]) == (count_test_cases[i].str[0]) is not true  (/codebuild/output/src3856958814/src/github.com/aws/s2n-tls/tests/unit/s2n_fingerprint_ja4_test.c:516)

I think the problem is this chunk of code from the test setup: 
https://github.com/lrstewart/s2n/blob/2c0f038397a8660732a5c15eebca085373d7569b/tests/unit/s2n_fingerprint_ja4_test.c#L148-L150

Basically, instead of writing individual cipher suite ianas, since we didn't care what the ianas were we just skipped over the right size chunk of data. But stuffers don't initialize their memory, so the data that ends up representing cipher ianas is whatever malloc returns. I suspect in most environments that memory is 0s, but AL2 is giving more random values, some of which happen to be grease values. JA4 doesn't count grease values when counting cipher suites, so the test fails.

### Testing:
Hard to prove, since it's flaky. So far I've failed to repro the failures by:
- spinning up my own AL2 instance and running the test for a few minutes in a while loop
- putting a for(0..1000000) loop around the test and running it in s2nGeneralBatch

But this change doesn't break anything, is more correct, and /may/ fix the flakiness.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
