### PR TITLE
fix: remove unnecessary RC4 restriction

### DIFF
--- a/crypto/s2n_stream_cipher_rc4.c
+++ b/crypto/s2n_stream_cipher_rc4.c
@@ -32,9 +32,6 @@ static const EVP_CIPHER *s2n_evp_rc4()
 
 static bool s2n_stream_cipher_rc4_available(void)
 {
-    if (s2n_is_in_fips_mode()) {
-        return false;
-    }
     /* RC4 MIGHT be available in Openssl-3.0, depending on whether or not the
      * "legacy" provider is loaded. However, for simplicity, assume that RC4
      * is unavailable.

--- a/tests/unit/s2n_rc4_test.c
+++ b/tests/unit/s2n_rc4_test.c
@@ -38,11 +38,6 @@ int main(int argc, char **argv)
         EXPECT_FALSE(s2n_rc4.is_available());
     }
 
-    /* Test FIPS does not support RC4 */
-    if (s2n_is_in_fips_mode()) {
-        EXPECT_FALSE(s2n_rc4.is_available());
-    }
-
     struct s2n_connection *conn = NULL;
     uint8_t mac_key[] = "sample mac key";
     uint8_t rc4_key[] = "123456789012345";
@@ -53,11 +48,6 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_blob_init(&r, random_data, sizeof(random_data)));
 
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
-
-    if (s2n_is_in_fips_mode()) {
-        /* Skip when FIPS mode is set as FIPS mode does not support RC4 */
-        END_TEST();
-    }
 
     EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
     EXPECT_OK(s2n_get_public_random_data(&r));


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

Customers switching between awslc and awslc-fips noted the lack of RC4 as a difference that could cause issues, although they're unclear whether or not they actually need RC4 on awslc-fips.

### Description of changes: 

RC4 is very deprecated, but technically still supported by s2n-tls with the right policy. 

### Call-outs:

Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development? If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? What manual testing was performed? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

Remember:
* Any change to the library source code should at least include unit tests.
* Any change to the core stuffer or blob methods should include [CBMC proofs](https://github.com/aws/s2n-tls/tree/main/tests/cbmc).
* Any change to the CI or tests should:
   1. prove that the test succeeds for good input
   2. prove that the test fails for bad input (eg, a test for memory leaks fails when a memory leak is committed)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
