### PR TITLE
chore: pin once_cell version to unblock the CI

### DIFF
--- a/bindings/rust/extended/s2n-tls/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls/Cargo.toml
@@ -28,6 +28,7 @@ hex = "0.4"
 
 [dev-dependencies]
 futures-test = "0.3"
+once_cell = "=1.20.3" # newer versions require rust 1.70.0
 openssl = "0.10"
 openssl-sys = "0.9"
 foreign-types = "0.3"


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

S2N-TLS rust binding CI is detecting failure: https://github.com/aws/s2n-tls/actions/runs/13776965529/job/38528019456?pr=5173. The error message is:
```
error: package `once_cell v1.21.0` cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.63.0.
```

According to [`once_cell`](https://crates.io/crates/once_cell), they did a release today which bump their MSRV to 1.70.0, while our MSRV is 1.63.0. I did a `cargo tree --invert once_cell` check and found out that `once_cell` is a dependency of `openssl`.

To solve this issue, we need to pin `once_cell` to v1.20.3, so that it is compatible with our MSRV.

### Call-outs:

This PR is related to https://github.com/aws/s2n-tls/issues/4395.

### Testing:

The CI test for rust binding should pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
