### PR TITLE
test: fix self-talk pkey offload test for openssl-3.0-fips

### DIFF
--- a/codebuild/spec/buildspec_openssl3fips.yml
+++ b/codebuild/spec/buildspec_openssl3fips.yml
@@ -35,4 +35,4 @@ phases:
     commands:
       - export CTEST_PARALLEL_LEVEL=$(nproc)
       # openssl3fips is still a work-in-progress. Not all tests pass.
-      - make -C build test -- ARGS="-E 's2n_self_talk_offload_signing_test'"
+      - make -C build test

--- a/tests/unit/s2n_self_talk_offload_signing_test.c
+++ b/tests/unit/s2n_self_talk_offload_signing_test.c
@@ -19,11 +19,8 @@
 
 #define S2N_TEST_CERT_MEM 5000
 
-int s2n_ecdsa_sign_digest(const struct s2n_pkey *priv, struct s2n_blob *digest, struct s2n_blob *signature);
-int s2n_rsa_pkcs1v15_sign_digest(const struct s2n_pkey *priv, s2n_hash_algorithm hash_alg,
-        struct s2n_blob *digest, struct s2n_blob *signature);
-int s2n_rsa_pss_sign_digest(const struct s2n_pkey *priv, s2n_hash_algorithm hash_alg,
-        struct s2n_blob *digest_in, struct s2n_blob *signature_out);
+S2N_RESULT s2n_async_pkey_op_copy_hash_state_for_testing(struct s2n_async_pkey_op *op,
+        struct s2n_hash_state *copy);
 
 struct s2n_async_pkey_op *pkey_op = NULL;
 struct s2n_connection *pkey_op_conn = NULL;
@@ -32,6 +29,36 @@ static int s2n_test_async_pkey_cb(struct s2n_connection *conn, struct s2n_async_
     pkey_op = op;
     pkey_op_conn = conn;
     return S2N_SUCCESS;
+}
+
+static S2N_RESULT s2n_test_pkey_sign(const struct s2n_pkey *pkey,
+        struct s2n_blob *input, struct s2n_blob *output,
+        s2n_signature_algorithm sig_alg)
+{
+    /* We're going to cheat a little here.
+     * Our pkey signing methods operate on hash states, not raw digests.
+     * So we need to use the hash state from the operation directly.
+     */
+
+    /* First, make sure that the actual input matches the digest
+     * produced by digesting the hash state.
+     * This proves the two are equivalent and we can use the hash state.
+     */
+    DEFER_CLEANUP(struct s2n_blob digest = { 0 }, s2n_free);
+    RESULT_GUARD_POSIX(s2n_alloc(&digest, input->size));
+    DEFER_CLEANUP(struct s2n_hash_state digest_copy = { 0 }, s2n_hash_free);
+    RESULT_GUARD_POSIX(s2n_hash_new(&digest_copy));
+    RESULT_GUARD(s2n_async_pkey_op_copy_hash_state_for_testing(pkey_op, &digest_copy));
+    RESULT_GUARD_POSIX(s2n_hash_digest(&digest_copy, digest.data, digest.size));
+    EXPECT_BYTEARRAY_EQUAL(digest.data, input->data, input->size);
+
+    /* Use the hash state instead of the input to calculate the signature */
+    DEFER_CLEANUP(struct s2n_hash_state sign_copy = { 0 }, s2n_hash_free);
+    RESULT_GUARD_POSIX(s2n_hash_new(&sign_copy));
+    RESULT_GUARD(s2n_async_pkey_op_copy_hash_state_for_testing(pkey_op, &sign_copy));
+    RESULT_GUARD_POSIX(s2n_pkey_sign(pkey, sig_alg, &sign_copy, output));
+
+    return S2N_RESULT_OK;
 }
 
 static S2N_RESULT s2n_async_pkey_sign(struct s2n_cert_chain_and_key *complete_chain)
@@ -73,14 +100,9 @@ static S2N_RESULT s2n_async_pkey_sign(struct s2n_cert_chain_and_key *complete_ch
     if (op_type == S2N_ASYNC_DECRYPT) {
         output.size = S2N_TLS_SECRET_LEN;
         RESULT_GUARD_POSIX(s2n_pkey_decrypt(complete_chain->private_key, &input, &output));
-    } else if (sig_alg == S2N_TLS_SIGNATURE_ECDSA) {
-        RESULT_GUARD_POSIX(s2n_ecdsa_sign_digest(complete_chain->private_key, &input, &output));
-    } else if (sig_alg == S2N_TLS_SIGNATURE_RSA) {
-        RESULT_GUARD_POSIX(s2n_rsa_pkcs1v15_sign_digest(
-                complete_chain->private_key, sig_scheme->hash_alg, &input, &output));
-    } else if (sig_alg == S2N_TLS_SIGNATURE_RSA_PSS_RSAE) {
-        RESULT_GUARD_POSIX(s2n_rsa_pss_sign_digest(
-                complete_chain->private_key, sig_scheme->hash_alg, &input, &output));
+    } else if (op_type == S2N_ASYNC_SIGN) {
+        RESULT_GUARD(s2n_test_pkey_sign(complete_chain->private_key, &input, &output,
+                sig_scheme->sig_alg));
     } else {
         RESULT_BAIL(S2N_ERR_UNIMPLEMENTED);
     }

--- a/tls/s2n_async_pkey.c
+++ b/tls/s2n_async_pkey.c
@@ -632,3 +632,11 @@ static S2N_RESULT s2n_async_pkey_op_set_output_sign(struct s2n_async_pkey_op *op
 
     return S2N_RESULT_OK;
 }
+
+S2N_RESULT s2n_async_pkey_op_copy_hash_state_for_testing(struct s2n_async_pkey_op *op,
+        struct s2n_hash_state *copy)
+{
+    RESULT_ENSURE_REF(op);
+    RESULT_GUARD_POSIX(s2n_hash_copy(copy, &op->op.sign.digest));
+    return S2N_RESULT_OK;
+}

--- a/tls/s2n_async_pkey.c
+++ b/tls/s2n_async_pkey.c
@@ -637,6 +637,7 @@ S2N_RESULT s2n_async_pkey_op_copy_hash_state_for_testing(struct s2n_async_pkey_o
         struct s2n_hash_state *copy)
 {
     RESULT_ENSURE_REF(op);
+    RESULT_ENSURE_EQ(op->type, S2N_ASYNC_SIGN);
     RESULT_GUARD_POSIX(s2n_hash_copy(copy, &op->op.sign.digest));
     return S2N_RESULT_OK;
 }


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

related to https://github.com/aws/s2n-tls/issues/4993

### Description of changes: 

Fix the last failing test.

The pkey offload test is using legacy methods to perform the offloaded signing operation. That doesn't work when built with openssl-3.0-fips.

The problem is a little trickier than just substituting the proper signing methods, because the proper signing methods require an un-digested hash state. Our offloaded signing operation only provides the digest bytes. We COULD theoretically refactor the signing logic to provide a method usable with digest bytes-- it looks like that's what the legacy signing methods did. But that led to messy, harder to follow code in the legacy signing methods, and I don't want to repeat that mistake in the new signing methods.

Instead, I'm solving the problem in a less direct way. The hash state does exist on the pkey operation, it's just not surfaced by the public APIs. So I rewrote the test signing operation to use that hash state (and verify it matches the actual input).

### Call-outs:

I'll add openssl-3.0-fips to other builds and delete the special openssl-3.0-fips build in a separate PR. This PR just fixes the test.

### Testing:
This is a test.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
