### PR TITLE
chore: add a cargo timing buildspec

### DIFF
--- a/bindings/rust/extended/Cargo.toml
+++ b/bindings/rust/extended/Cargo.toml
@@ -12,6 +12,8 @@ exclude = [
     "bench"
 ]
 
+resolver = "2"
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/codebuild/spec/buildspec_timing.yml
+++ b/codebuild/spec/buildspec_timing.yml
@@ -1,0 +1,35 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+version: 0.2
+env:
+  shell: bash
+  variables:
+    # This assumes you have a Rust toolchain installed
+    CARGO: "cargo +nightly"
+    OPENSSL_DIR: "/usr/local/openssl-3.0"
+phases:
+  install:
+    commands:
+      - echo "Installing Rust ..."
+      - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - . $HOME/.cargo/env
+      - rustup toolchain install 1.63.0-x86_64-unknown-linux-gnu
+  pre_build:
+    commands:
+      - |
+        cd bindings/rust/extended
+        ./generate.sh
+        cargo clean
+  build:
+    commands:
+      - cargo build --timings
+  post_build:
+    commands:
+      - cargo test --timings
+
+artifacts:
+  # upload timing reports
+  files:
+    - '**/*'
+  base-directory: bindings/rust/extended/target/cargo-timings


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

none

### Description of changes: 

This buildspec is for a daily scheduled job that tracks `cargo build` and `cargo test` timings, generating an html report that will be visible via a CloudFront distribution, e.g. https://dx1inn44oyl7n.cloudfront.net/cargotiming/cargo-timing.html

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? job is already running in CI, this just captures the buildspec.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
