### PR TITLE
ci: use ruff --diff instead of --check

### DIFF
--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Run Ruff formatting check
         working-directory: tests/integrationv2
         id: ruff_format
-        run: uv run ruff format --check .
+        run: uv run ruff format --diff .
         continue-on-error: true
 
       - name: Check exit code


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

I will readily admit this is (maybe misdirected) laziness, but I don't want to have to figure out how to install a new tool to fix a one-line python formatting mistake when I almost never touch python :) No matter how easy uv is.

The CI should just tell me what one-line fix I need.

From the ruff --help message:
```
      --check
          Avoid writing any formatted files back; instead, exit with a non-zero status code if any files would have
          been modified, and zero otherwise

      --diff
          Avoid writing any formatted files back; instead, exit with a non-zero status code and the difference between
          the current file and how the formatted file would look like

```

### Testing:

I made [a formatting mistake](https://github.com/lrstewart/s2n/pull/64/commits/64b3dc314b785baf22744c05eedd581c2dacbd5c) in [a PR on my fork](https://github.com/lrstewart/s2n/pull/64) that includes this change: https://github.com/lrstewart/s2n/actions/runs/13796362955/job/38588863235?pr=64


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
