### PR TITLE
chore: bump linting action Ubuntu version

### DIFF
--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -10,10 +10,7 @@ on:
     branches: [main]
 jobs:
   cppcheck:
-    # ubuntu-latest introduced a newer gcc version that cannot compile cppcheck 2.3
-    # TODO: upgrade to latest cppcheck and revert to ubuntu-latest
-    #       see https://github.com/aws/s2n-tls/issues/3656
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CPPCHECK_INSTALL_DIR: test-deps/cppcheck
     steps:


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

Resolves https://github.com/aws/s2n-tls/issues/5162. Related to https://github.com/aws/s2n-tls/issues/3656.

### Description of changes: 

Bump CI linting Ubuntu version to `ubuntu-latest`.

### Call-outs:

* The [test](https://github.com/aws/s2n-tls/actions/runs/13842230564/job/38732260077?pr=5186) for such change shows that simply update to `ubuntu-lastest` while running `cppcheck v2.3` has no problems.
* I didn't notice any performance regression for `cppcheck` after the Ubuntu version update.
* We need to finish this update, since Ubuntu20 will be deprecated by Github on 2025-04-01.

### Testing:

CI Testing. https://github.com/aws/s2n-tls/actions/runs/13842230564/job/38732260077?pr=5186

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
