### PR TITLE
chore: include Need By Date section in github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -17,6 +17,10 @@ AWS Security via our [vulnerability reporting page](http://aws.amazon.com/securi
 
 A short description of what the problem is and why we need to fix it. Add reproduction steps if necessary.
 
+### Need By Date:
+
+Do you have a date that you need this issue resolved by? What is the reason for that date, and what are the consequences of missing it? Any additional information you can provide to help prioritize the issue is appreciated. However, we cannot guarantee that this issue will be fixed by the requested date.
+
 ### Solution:
 
 A description of the possible solution in terms of S2N architecture. Highlight and explain any potentially controversial design decisions taken.
@@ -35,10 +39,6 @@ What must a solution address in order to solve the problem? How do we know the s
 * **Testing:** How will this change be tested? Call out new integration tests, functional tests, or particularly interesting/important unit tests.
   * **Will this change trigger SAW changes?** Changes to the state machine, the s2n_handshake_io code that controls state transitions, the DRBG, or the corking/uncorking logic could trigger SAW failures.
   * **Should this change be fuzz tested?** Will it handle untrusted input? Create a separate issue to track the fuzzing work.
-
-### Need By Date:
-
-Do you have a date that you need this issue resolved by? What is the reason for that date, and what are the consequences of missing it? Any additional information you can provide to help prioritize the issue is appreciated. However, we cannot guarantee that this issue will be fixed by the requested date.
 
 ### Out of scope: 
 

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -38,7 +38,7 @@ What must a solution address in order to solve the problem? How do we know the s
 
 ### Need By Date:
 
-Any information you can give us to help prioritize the issue is appreciated. However, we cannot guarantee that this issue will be fixed by your timeline.
+Do you have a date that you need this issue resolved by? What is the reason for that date, and what are the consequences of missing it? Any additional information you can provide to help prioritize the issue is appreciated. However, we cannot guarantee that this issue will be fixed by the requested date.
 
 ### Out of scope: 
 

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -36,9 +36,9 @@ What must a solution address in order to solve the problem? How do we know the s
   * **Will this change trigger SAW changes?** Changes to the state machine, the s2n_handshake_io code that controls state transitions, the DRBG, or the corking/uncorking logic could trigger SAW failures.
   * **Should this change be fuzz tested?** Will it handle untrusted input? Create a separate issue to track the fuzzing work.
 
-### Timeline:
+### Need By Date:
 
-An estimated timeline for this issue to be fixed.
+Any information you can give us to help prioritize the issue is appreciated. However, we cannot guarantee that this issue will be fixed by your timeline.
 
 ### Out of scope: 
 

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -36,6 +36,10 @@ What must a solution address in order to solve the problem? How do we know the s
   * **Will this change trigger SAW changes?** Changes to the state machine, the s2n_handshake_io code that controls state transitions, the DRBG, or the corking/uncorking logic could trigger SAW failures.
   * **Should this change be fuzz tested?** Will it handle untrusted input? Create a separate issue to track the fuzzing work.
 
+### Timeline:
+
+An estimated timeline for this issue to be fixed.
+
 ### Out of scope: 
 
 Is there anything the solution will intentionally NOT address?

--- a/.github/ISSUE_TEMPLATE/s2n-issue.md
+++ b/.github/ISSUE_TEMPLATE/s2n-issue.md
@@ -37,7 +37,7 @@ What must a solution address in order to solve the problem? How do we know the s
 
 ### Need By Date:
 
-Any information you can give us to help prioritize the issue is appreciated. However, we cannot guarantee that this issue will be fixed by your timeline.
+Do you have a date that you need this issue resolved by? What is the reason for that date, and what are the consequences of missing it? Any additional information you can provide to help prioritize the issue is appreciated. However, we cannot guarantee that this issue will be fixed by the requested date.
 
 ### Out of scope:
 

--- a/.github/ISSUE_TEMPLATE/s2n-issue.md
+++ b/.github/ISSUE_TEMPLATE/s2n-issue.md
@@ -16,6 +16,10 @@ AWS Security via our [vulnerability reporting page](http://aws.amazon.com/securi
 
 A short description of what the problem is and why we need to fix it. Add reproduction steps if necessary.
 
+### Need By Date:
+
+Do you have a date that you need this issue resolved by? What is the reason for that date, and what are the consequences of missing it? Any additional information you can provide to help prioritize the issue is appreciated. However, we cannot guarantee that this issue will be fixed by the requested date.
+
 ### Solution:
 
 A description of the possible solution in terms of S2N architecture. Highlight and explain any potentially controversial design decisions taken.
@@ -34,10 +38,6 @@ What must a solution address in order to solve the problem? How do we know the s
 * **Testing:** How will this change be tested? Call out new integration tests, functional tests, or particularly interesting/important unit tests.
   * **Will this change trigger SAW changes?** Changes to the state machine, the s2n_handshake_io code that controls state transitions, the DRBG, or the corking/uncorking logic could trigger SAW failures.
   * **Should this change be fuzz tested?** Will it handle untrusted input? Create a separate issue to track the fuzzing work.
-
-### Need By Date:
-
-Do you have a date that you need this issue resolved by? What is the reason for that date, and what are the consequences of missing it? Any additional information you can provide to help prioritize the issue is appreciated. However, we cannot guarantee that this issue will be fixed by the requested date.
 
 ### Out of scope:
 

--- a/.github/ISSUE_TEMPLATE/s2n-issue.md
+++ b/.github/ISSUE_TEMPLATE/s2n-issue.md
@@ -35,9 +35,9 @@ What must a solution address in order to solve the problem? How do we know the s
   * **Will this change trigger SAW changes?** Changes to the state machine, the s2n_handshake_io code that controls state transitions, the DRBG, or the corking/uncorking logic could trigger SAW failures.
   * **Should this change be fuzz tested?** Will it handle untrusted input? Create a separate issue to track the fuzzing work.
 
-### Timeline:
+### Need By Date:
 
-An estimated timeline for this issue to be fixed.
+Any information you can give us to help prioritize the issue is appreciated. However, we cannot guarantee that this issue will be fixed by your timeline.
 
 ### Out of scope:
 

--- a/.github/ISSUE_TEMPLATE/s2n-issue.md
+++ b/.github/ISSUE_TEMPLATE/s2n-issue.md
@@ -35,6 +35,10 @@ What must a solution address in order to solve the problem? How do we know the s
   * **Will this change trigger SAW changes?** Changes to the state machine, the s2n_handshake_io code that controls state transitions, the DRBG, or the corking/uncorking logic could trigger SAW failures.
   * **Should this change be fuzz tested?** Will it handle untrusted input? Create a separate issue to track the fuzzing work.
 
+### Timeline:
+
+An estimated timeline for this issue to be fixed.
+
 ### Out of scope:
 
 Is there anything the solution will intentionally NOT address?


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

Add a `Need by Date` section in the Github Issue template for customer to provide information about their estimated timeline or deadlines.

### Call-outs:

Need to change both `s2n-issue.md` and `custom.md`. Per the last update of the template: https://github.com/aws/s2n-tls/pull/2175.

Will do the same for `S2N-QUIC` once this PR is merged.

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
