### PR TITLE
Make -fPIC flag private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,7 @@ if(S2N_BLOCK_NONPORTABLE_OPTIMIZATIONS)
     target_compile_options(${PROJECT_NAME} PUBLIC -DS2N_BLOCK_NONPORTABLE_OPTIMIZATIONS=1)
 endif()
 
-target_compile_options(${PROJECT_NAME} PUBLIC -fPIC)
+target_compile_options(${PROJECT_NAME} PRIVATE -fPIC)
 
 set(S2N_PRELUDE "${CMAKE_CURRENT_LIST_DIR}/utils/s2n_prelude.h")
 target_compile_options(${PROJECT_NAME} PRIVATE -include "${S2N_PRELUDE}")


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/5188

### Description of changes: 

Change fPIC flag to PRIVATE so that it is not propagated to targets that link s2n

### Call-outs:

### Testing:

Built successfully.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
