### PR TITLE
build(deps): update aws-lc-rs version to remove paste deps

### DIFF
--- a/bindings/rust/extended/s2n-tls-sys/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls-sys/Cargo.toml
@@ -43,8 +43,10 @@ unstable-renegotiate = []
 [dependencies]
 # aws-lc-rs 1.6.4 adds DEP_AWS_LC environment variables which are required to build s2n-tls-sys:
 # https://github.com/aws/aws-lc-rs/pull/335
-aws-lc-rs = { version = "1.6.4" }
-# aws-lc-rs 1.6.4 depends on aws-lc-sys 0.14.0, which requires libc 0.2.121:
+# aws-lc-rs >=1.12.6 removes unmaintained paste dependencies:
+# https://github.com/aws/aws-lc-rs/pull/731
+aws-lc-rs = { version = ">=1.12.6" }
+# aws-lc-rs >=1.6.4 depends on aws-lc-sys 0.14.0, which requires libc 0.2.121:
 # https://github.com/aws/aws-lc-rs/blob/2298ca861234d4f43aecef2c7d7e822c60bc488a/aws-lc-sys/Cargo.toml#L65
 libc = "0.2.121"
 

--- a/bindings/rust/extended/s2n-tls-sys/templates/Cargo.template
+++ b/bindings/rust/extended/s2n-tls-sys/templates/Cargo.template
@@ -38,8 +38,10 @@ stacktrace = []
 [dependencies]
 # aws-lc-rs 1.6.4 adds DEP_AWS_LC environment variables which are required to build s2n-tls-sys:
 # https://github.com/aws/aws-lc-rs/pull/335
-aws-lc-rs = { version = "1.6.4" }
-# aws-lc-rs 1.6.4 depends on aws-lc-sys 0.14.0, which requires libc 0.2.121:
+# aws-lc-rs >=1.12.6 removes unmaintained paste dependencies:
+# https://github.com/aws/aws-lc-rs/pull/731
+aws-lc-rs = { version = ">=1.12.6" }
+# aws-lc-rs >=1.6.4 depends on aws-lc-sys 0.14.0, which requires libc 0.2.121:
 # https://github.com/aws/aws-lc-rs/blob/2298ca861234d4f43aecef2c7d7e822c60bc488a/aws-lc-sys/Cargo.toml#L65
 libc = "0.2.121"
 


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/5171

### Description of changes: 

`Paste` is archived, but it is a dependencies of `aws-ls-rs`. AWS-LC has remove that dependencies and release their `aws-lc-rs` and `aws-lc-fips-sys` crates. We should use the most up to date `aws-lc-rs` crate, so that `paste` will not be one of our dependencies.

Cargo tree before:
```
paste v1.0.15 (proc-macro)
├── aws-lc-rs v1.12.2
│   └── s2n-tls-sys v0.3.13 (/home/ubuntu/workspace/s2n-tls/bindings/rust/extended/s2n-tls-sys)
│       └── s2n-tls v0.3.13 (/home/ubuntu/workspace/s2n-tls/bindings/rust/extended/s2n-tls)
│           └── s2n-tls-tokio v0.3.13 (/home/ubuntu/workspace/s2n-tls/bindings/rust/extended/s2n-tls-tokio)
│           [dev-dependencies]
│           └── s2n-tls-tokio v0.3.13 (/home/ubuntu/workspace/s2n-tls/bindings/rust/extended/s2n-tls-tokio)
└── aws-lc-sys v0.25.1
    └── aws-lc-rs v1.12.2 (*)
```

Cargo tree after such change:
```
ubuntu@ip-172-31-59-74:~/workspace/s2n-tls/bindings/rust/extended$ cargo tree --invert paste
error: package ID specification `paste` did not match any packages
```

### Call-outs:

I am aware of the comments that were put in `Cargo.toml` to specify `aws-lc-rs` deps:
https://github.com/aws/s2n-tls/blob/785ed148882ecadb82aea18cc607b1badb3e6291/bindings/rust/extended/s2n-tls-sys/templates/Cargo.template#L38-L44

I check the previous PR that updates this part: https://github.com/aws/s2n-tls/pull/5028
@goatgoose said:
> There are currently dependency versions in the s2n-tls rust bindings that are specified as acceptable but are impossible to actually use. For example, [we specify "1" as an acceptable aws-lc-rs version](https://github.com/aws/s2n-tls/blob/1c38961ddca45243b73c684dd4ddcc9ae454b2e3/bindings/rust/extended/s2n-tls-sys/templates/Cargo.template#L39), but versions before 1.6.4 result in a build failure. This PR updates these dependency versions to the correct minimum versions

Hence, we just need to make sure that the `aws-lc-rs` is later than v1.6.4. I am proposing to use v1.12.6 and later which shouldn't have any problems.

### Testing:

CI test should show that such change will not cause issues in the binding.
I have show that `paste` will be removed from the codebase in `Description of Changes`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
