### PR TITLE
build: cppcheck updates to the latest

### DIFF
--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -25,7 +25,7 @@ jobs:
         continue-on-error: true
         with:
           path: ${{ env.CPPCHECK_INSTALL_DIR }}
-          key: cppcheck-2.3-${{ env.CPPCHECK_INSTALL_DIR }}
+          key: cppcheck-2.17-${{ env.CPPCHECK_INSTALL_DIR }}
 
       - name: Install
         if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/3656

### Description of changes: 

In https://github.com/aws/s2n-tls/pull/5186, we have shown that `cppcheck` v2.3 can run on the `ubuntu-latest`. I have a hypothesis that we can now updates our `cppcheck` version to v2.17 without any performance or compilation issue.

### Call-outs:

The runtime of the cppcheck is 25 minutes for the whole test. I don't think we need to divide it up as mentioned in https://github.com/aws/s2n-tls/issues/3656.

### Testing:

We should check the result for the `cppcheck`'s test result. Verify that v2.17 is install and it is compiled and ran.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
