### PR TITLE
ci: defend against unset version number in awslc installer

### DIFF
--- a/codebuild/bin/install_awslc.sh
+++ b/codebuild/bin/install_awslc.sh
@@ -43,7 +43,8 @@ cd "$BUILD_DIR"
 echo "Checking out tag=$AWSLC_VERSION"
 # --branch can also take tags and detaches the HEAD at that commit in the resulting repository
 # --depth 1 Create a shallow clone with a history truncated to 1 commit
-git clone https://github.com/awslabs/aws-lc.git --branch "$AWSLC_VERSION" --depth 1
+# If the curl above is throttled, fall back to a known version.
+git clone https://github.com/awslabs/aws-lc.git --branch "${AWSLC_VERSION:-v1.48.4}" --depth 1
 
 install_awslc() {
     echo "Building with shared library=$1"

--- a/codebuild/bin/install_awslc.sh
+++ b/codebuild/bin/install_awslc.sh
@@ -44,7 +44,7 @@ echo "Checking out tag=$AWSLC_VERSION"
 # --branch can also take tags and detaches the HEAD at that commit in the resulting repository
 # --depth 1 Create a shallow clone with a history truncated to 1 commit
 # If the curl above is throttled, fall back to a known version.
-git clone https://github.com/awslabs/aws-lc.git --branch "${AWSLC_VERSION:-v1.48.4}" --depth 1
+git clone https://github.com/awslabs/aws-lc.git --branch "${AWSLC_VERSION:-main}" --depth 1
 
 install_awslc() {
     echo "Building with shared library=$1"


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

N/A

### Description of changes: 

In [#5156](https://github.com/aws/s2n-tls/pull/5156) we change the aws-lc setup script to fetch the latest release from a GitHub API.  This is occasionally failing, likely throttled, causing failures with the musl test, which rebuild aws-lc every run.
Put a fallback version in place so we have a minimum version.

### Call-outs:

Doing it this way could lead us to testing an older version occasionally, when the CI is busy.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
