### PR TITLE
ci: add libcrypto openssl-3.0-fips to integ tests

### DIFF
--- a/codebuild/bin/install_default_dependencies.sh
+++ b/codebuild/bin/install_default_dependencies.sh
@@ -37,6 +37,12 @@ if [[ "$S2N_LIBCRYPTO" == "openssl-3.0" && ! -d "$OPENSSL_3_0_INSTALL_DIR" ]]; t
     codebuild/bin/install_openssl_3_0.sh "$(mktemp -d)" "$OPENSSL_3_0_INSTALL_DIR" "$OS_NAME" > /dev/null ;
 fi
 
+# Download and Install Openssl 3.0 FIPS
+if [[ "$S2N_LIBCRYPTO" == "openssl-3.0-fips" && ! -d "$OPENSSL_3_FIPS_INSTALL_DIR" ]]; then
+    mkdir -p "$OPENSSL_3_FIPS_INSTALL_DIR"
+    codebuild/bin/install_openssl_3_0.sh "$(mktemp -d)" "$OPENSSL_3_FIPS_INSTALL_DIR" "$OS_NAME" fips > /dev/null ;
+fi
+
 # Download and Install Openssl 1.0.2
 if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2" && ! -d "$OPENSSL_1_0_2_INSTALL_DIR" ]]; then
     mkdir -p "$OPENSSL_1_0_2_INSTALL_DIR"||true

--- a/codebuild/bin/s2n_set_build_preset.sh
+++ b/codebuild/bin/s2n_set_build_preset.sh
@@ -75,5 +75,9 @@ case "${S2N_BUILD_PRESET-default}" in
         : "${S2N_LIBCRYPTO:=openssl-3.0}"
         : "${GCC_VERSION:=9}"
         ;;
+    "openssl-3.0-fips")
+        : "${S2N_LIBCRYPTO:=openssl-3.0-fips}"
+        : "${GCC_VERSION:=9}"
+        ;;
 esac
 

--- a/codebuild/bin/s2n_setup_env.sh
+++ b/codebuild/bin/s2n_setup_env.sh
@@ -40,6 +40,7 @@ source codebuild/bin/s2n_set_build_preset.sh
 : "${SCAN_BUILD_INSTALL_DIR:=$TEST_DEPS_DIR/scan-build}"
 : "${OPENSSL_1_1_1_INSTALL_DIR:=$TEST_DEPS_DIR/openssl-1.1.1}"
 : "${OPENSSL_3_0_INSTALL_DIR:=$TEST_DEPS_DIR/openssl-3.0}"
+: "${OPENSSL_3_FIPS_INSTALL_DIR:=$TEST_DEPS_DIR/openssl-3.0-fips}"
 : "${OPENSSL_1_0_2_INSTALL_DIR:=$TEST_DEPS_DIR/openssl-1.0.2}"
 : "${OQS_OPENSSL_1_1_1_INSTALL_DIR:=$TEST_DEPS_DIR/oqs_openssl-1.1.1}"
 : "${OPENSSL_1_0_2_FIPS_INSTALL_DIR:=$TEST_DEPS_DIR/openssl-1.0.2-fips}"
@@ -98,6 +99,7 @@ export LATEST_CLANG_INSTALL_DIR
 export SCAN_BUILD_INSTALL_DIR
 export OPENSSL_1_1_1_INSTALL_DIR
 export OPENSSL_3_0_INSTALL_DIR
+export OPENSSL_3_FIPS_INSTALL_DIR
 export OPENSSL_1_0_2_INSTALL_DIR
 export OPENSSL_1_0_2_FIPS_INSTALL_DIR
 export OQS_OPENSSL_1_1_1_INSTALL_DIR
@@ -127,6 +129,7 @@ fi
 if [[ -z $S2N_LIBCRYPTO ]]; then export LIBCRYPTO_ROOT=$OPENSSL_1_1_1_INSTALL_DIR ; fi
 if [[ "$S2N_LIBCRYPTO" == "openssl-1.1.1" ]]; then export LIBCRYPTO_ROOT=$OPENSSL_1_1_1_INSTALL_DIR ; fi
 if [[ "$S2N_LIBCRYPTO" == "openssl-3.0" ]]; then export LIBCRYPTO_ROOT=$OPENSSL_3_0_INSTALL_DIR ; fi
+if [[ "$S2N_LIBCRYPTO" == "openssl-3.0-fips" ]]; then export LIBCRYPTO_ROOT=$OPENSSL_3_FIPS_INSTALL_DIR ; fi
 if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2" ]]; then export LIBCRYPTO_ROOT=$OPENSSL_1_0_2_INSTALL_DIR ; fi
 if [[ "$S2N_LIBCRYPTO" == "openssl-1.0.2-fips" ]]; then
     export LIBCRYPTO_ROOT=$OPENSSL_1_0_2_FIPS_INSTALL_DIR ;

--- a/codebuild/spec/buildspec_ubuntu_integrationv2.yml
+++ b/codebuild/spec/buildspec_ubuntu_integrationv2.yml
@@ -35,6 +35,7 @@ batch:
             - openssl-1.0.2-fips
             - openssl-1.1.1_gcc9
             - openssl-3.0
+            - openssl-3.0-fips
           INTEGV2_TEST:
             - "test_client_authentication test_dynamic_record_sizes test_sslyze test_sslv2_client_hello"
             - "test_happy_path"

--- a/crypto/s2n_evp_kem.c
+++ b/crypto/s2n_evp_kem.c
@@ -86,7 +86,7 @@ int s2n_evp_kem_decapsulate(IN const struct s2n_kem *kem, OUT uint8_t *shared_se
 
     size_t shared_secret_size = kem->shared_secret_key_length;
     POSIX_GUARD_OSSL(EVP_PKEY_decapsulate(kem_pkey_ctx, shared_secret, &shared_secret_size,
-                             (uint8_t *) ciphertext, kem->ciphertext_length),
+                             (uint8_t *) (uintptr_t) ciphertext, kem->ciphertext_length),
             S2N_ERR_PQ_CRYPTO);
     POSIX_ENSURE_EQ(kem->shared_secret_key_length, shared_secret_size);
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -146,7 +146,7 @@ But if you must use Openssl instead of AWS-LC, then s2n-tls does support FIPS mo
 
 Note that currently s2n-tls only supports the Openssl-3.0 version of FIPS-validated Openssl. Openssl-3.0 has a FIPS 140-2 certificate, NOT a FIPS 140-3 certificate. If you require FIPS 140-3, consider using AWS-LC instead. Once Openssl releases a FIPS 140-3 validated version (currently planned for Openssl-3.5), then the s2n-tls integration can be updated. Because of the significant changes made in FIPS 140-3, simply building s2n-tls with a FIPS 140-3 validated version of Openssl will not meet all FIPS 140-3 requirements.
 
-When running in FIPS mode with Openssl, s2n-tls does not support ChaChaPoly, even if the configured security policy allows ChaChaPoly. As with non-FIPS Openssl, RC4 is also not supported.
+When running in FIPS mode with Openssl, s2n-tls does not support RSA 1024 certificates (https://github.com/aws/s2n-tls/issues/5200) or ChaChaPoly (https://github.com/aws/s2n-tls/issues/5199), even if allowed by the configured security policy. As with non-FIPS Openssl, RC4 is also not supported.
 
 s2n-tls requires that Openssl be configured with the standard provider in addition to the FIPS provider. The base provider is NOT sufficient. If you are following the [Openssl documentation for how to configure FIPS](https://docs.openssl.org/master/man7/fips_module/), your openssl.cnf must include:
 ```

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -176,7 +176,10 @@ class S2N(Provider):
         if not cls._pss_supported() and cert.algorithm == "RSAPSS":
             return False
         # https://github.com/aws/s2n-tls/issues/5200
-        if "openssl-3.0-fips" in get_flag(S2N_PROVIDER_VERSION) and "RSA_1024" in cert.name:
+        if (
+            "openssl-3.0-fips" in get_flag(S2N_PROVIDER_VERSION)
+            and "RSA_1024" in cert.name
+        ):
             return False
         return True
 

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -175,6 +175,9 @@ class S2N(Provider):
     def supports_certificate(cls, cert: Cert):
         if not cls._pss_supported() and cert.algorithm == "RSAPSS":
             return False
+        # https://github.com/aws/s2n-tls/issues/5200
+        if "openssl-3.0-fips" in get_flag(S2N_PROVIDER_VERSION) and "RSA_1024" in cert.name:
+            return False
         return True
 
     @classmethod

--- a/tests/integrationv2/test_renegotiate_apache.py
+++ b/tests/integrationv2/test_renegotiate_apache.py
@@ -23,6 +23,15 @@ CHANGE_CIPHER_SUITE_ENDPOINT = "/change_cipher_suite/"
 MUTUAL_AUTH_ENDPOINT = "/mutual_auth/"
 
 
+# The apache server uses RSA 1024 certificates,
+# which s2n-tls does not support when built with openssl-3.0-fips.
+def skip_for_openssl3_fips():
+    if "openssl-3.0-fips" in get_flag(S2N_PROVIDER_VERSION):
+        pytest.skip(
+            "Certs not supported: https://github.com/aws/s2n-tls/issues/5200"
+        )
+
+
 def create_get_request(route):
     return f"GET {route} HTTP/1.1\r\nHost: localhost\r\n\r\n"
 
@@ -33,6 +42,8 @@ def create_get_request(route):
     "endpoint", [CHANGE_CIPHER_SUITE_ENDPOINT, MUTUAL_AUTH_ENDPOINT]
 )
 def test_apache_endpoints_fail_with_no_reneg(managed_process, protocol, endpoint):  # noqa: F811
+    skip_for_openssl3_fips()
+
     options = ProviderOptions(
         mode=Provider.ClientMode,
         host=APACHE_SERVER_IP,
@@ -67,6 +78,8 @@ def test_apache_endpoints_fail_with_no_reneg(managed_process, protocol, endpoint
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 def test_change_cipher_suite_endpoint(managed_process, curve, protocol):  # noqa: F811
+    skip_for_openssl3_fips()
+
     options = ProviderOptions(
         mode=Provider.ClientMode,
         host=APACHE_SERVER_IP,
@@ -96,6 +109,8 @@ def test_change_cipher_suite_endpoint(managed_process, curve, protocol):  # noqa
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", TEST_PROTOCOLS, ids=get_parameter_name)
 def test_mutual_auth_endpoint(managed_process, curve, protocol):  # noqa: F811
+    skip_for_openssl3_fips()
+
     options = ProviderOptions(
         mode=Provider.ClientMode,
         host=APACHE_SERVER_IP,

--- a/tests/integrationv2/test_renegotiate_apache.py
+++ b/tests/integrationv2/test_renegotiate_apache.py
@@ -27,9 +27,7 @@ MUTUAL_AUTH_ENDPOINT = "/mutual_auth/"
 # which s2n-tls does not support when built with openssl-3.0-fips.
 def skip_for_openssl3_fips():
     if "openssl-3.0-fips" in get_flag(S2N_PROVIDER_VERSION):
-        pytest.skip(
-            "Certs not supported: https://github.com/aws/s2n-tls/issues/5200"
-        )
+        pytest.skip("Certs not supported: https://github.com/aws/s2n-tls/issues/5200")
 
 
 def create_get_request(route):

--- a/tests/integrationv2/test_renegotiate_apache.py
+++ b/tests/integrationv2/test_renegotiate_apache.py
@@ -6,6 +6,7 @@ import tempfile
 from configuration import ALL_TEST_CURVES
 from common import ProviderOptions
 from fixtures import managed_process  # noqa: F401
+from global_flags import get_flag, S2N_PROVIDER_VERSION
 from providers import Provider, S2N
 from utils import invalid_test_parameters, get_parameter_name
 from constants import TEST_CERT_DIRECTORY


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:
related to https://github.com/aws/s2n-tls/issues/5036

### Description of changes: 
Run integration tests for s2n-tls built with openssl-3.0-fips. I found one issue: https://github.com/aws/s2n-tls/issues/5200 Not sure it's really worth fixing though, so I just created the issue and added skips to the tests.

Because the integration tests use the old build logic in codebuild/s2n_codebuild.sh, I added openssl-3.0-fips to all the old scripts everywhere openssl-3.0 appeared.

### Testing:
New tests pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
