### PR TITLE
ci: Add aws-lc-fips to nix jobs

### DIFF
--- a/codebuild/bin/install_awslc.sh
+++ b/codebuild/bin/install_awslc.sh
@@ -16,7 +16,8 @@ set -eu
 pushd "$(pwd)"
 
 usage() {
-    echo "install_awslc.sh build_dir install_dir is_fips"
+    echo -e "\tinstall_awslc.sh build_dir install_dir\n"
+    echo -e "\tIf you need FIPS, use the FIPS specific install script.\n"
     exit 1
 }
 
@@ -26,7 +27,6 @@ fi
 
 BUILD_DIR=$1
 INSTALL_DIR=$2
-IS_FIPS=$3
 
 if [[ ! -f "$(which clang)" ]]; then
   echo "Could not find clang"
@@ -35,12 +35,9 @@ fi
 
 # These tags represents the latest versions that S2N is compatible
 # with. It prevents our build system from breaking when AWS-LC
-# is updated, last done on 2023-02-22.
-if [ "$IS_FIPS" == "1" ]; then
-  AWSLC_VERSION=AWS-LC-FIPS-1.0.3
-else
-  AWSLC_VERSION=v1.36.0
-fi
+# is updated.
+AWSLC_VERSION=v1.47.0
+
 mkdir -p "$BUILD_DIR"||true
 cd "$BUILD_DIR"
 echo "Checking out tag=$AWSLC_VERSION"

--- a/codebuild/bin/install_awslc.sh
+++ b/codebuild/bin/install_awslc.sh
@@ -16,34 +16,35 @@ set -eu
 pushd "$(pwd)"
 
 usage() {
-    echo -e "\tinstall_awslc.sh build_dir install_dir\n"
+    echo -e "\ninstall_awslc.sh build_dir install_dir"
     echo -e "\tIf you need FIPS, use the FIPS specific install script.\n"
     exit 1
 }
 
-if [ "$#" -ne "3" ]; then
+if [ "$#" -ne "2" ]; then
     usage
 fi
 
 BUILD_DIR=$1
 INSTALL_DIR=$2
+GH_RELEASE_URL="https://api.github.com/repos/aws/aws-lc/releases"
 
 if [[ ! -f "$(which clang)" ]]; then
   echo "Could not find clang"
   exit 1
 fi
 
-# These tags represents the latest versions that S2N is compatible
-# with. It prevents our build system from breaking when AWS-LC
-# is updated.
-AWSLC_VERSION=v1.47.0
+# Ask GitHub for the latest v1.x release.
+AWSLC_VERSION=$(curl --silent "$GH_RELEASE_URL" | \
+        grep -Po '"tag_name": "\Kv1\..*?(?=")' |head -1)
 
 mkdir -p "$BUILD_DIR"||true
 cd "$BUILD_DIR"
 echo "Checking out tag=$AWSLC_VERSION"
 # --branch can also take tags and detaches the HEAD at that commit in the resulting repository
 # --depth 1 Create a shallow clone with a history truncated to 1 commit
-git clone https://github.com/awslabs/aws-lc.git --branch "$AWSLC_VERSION" --depth 1
+# If the curl above is throttled, fall back to a known version.
+git clone https://github.com/awslabs/aws-lc.git --branch "${AWSLC_VERSION:-main}" --depth 1
 
 install_awslc() {
     echo "Building with shared library=$1"
@@ -54,16 +55,12 @@ install_awslc() {
       -DCMAKE_BUILD_TYPE=relwithdebinfo \
       -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
       -DCMAKE_C_COMPILER=$(which clang) \
-      -DCMAKE_CXX_COMPILER=$(which clang++) \
-      -DFIPS="${IS_FIPS}"
+      -DCMAKE_CXX_COMPILER=$(which clang++)
     ninja -j "$(nproc)" -C build install
     ninja -C build clean
 }
 
-if [ "$IS_FIPS" != "1" ]; then
-  install_awslc 0
-fi
-
+install_awslc 0
 install_awslc 1
 
 exit 0

--- a/codebuild/bin/install_awslc_fips.sh
+++ b/codebuild/bin/install_awslc_fips.sh
@@ -50,13 +50,17 @@ INSTALL_DIR=$2
 VERSION=$3
 
 # Map version to a specific feature branch/tag.
+# Note: since the next FIPS validation will be split off from main
+# building main with FIPS enabled is essentially the next FIPS release.
 case $VERSION in
   "2022")
-    AWSLC_BRANCH=AWS-LC-FIPS-2.0.17
+    AWSLC_BRANCH=fips-2024-09-27
     ;;
   "2024")
-    AWSLC_BRANCH=AWS-LC-FIPS-3.0.0
+    AWSLC_BRANCH=fips-2022-11-02
     ;;
+  "next")
+    AWSLC_BRANCH=main
   *)
     echo "Unknown version: $VERSION"
     usage

--- a/codebuild/bin/install_awslc_fips.sh
+++ b/codebuild/bin/install_awslc_fips.sh
@@ -4,7 +4,8 @@
 set -eu
 
 usage() {
-    echo "install_awslc_fips.sh build_dir install_dir version"
+    echo -e "\ninstall_awslc_fips.sh build_dir install_dir version"
+    echo -e "\tversion: 2022|2024|next\n"
     exit 1
 }
 
@@ -48,19 +49,23 @@ check_dep go
 BUILD_DIR=$1
 INSTALL_DIR=$2
 VERSION=$3
+GH_RELEASE_URL="https://api.github.com/repos/aws/aws-lc/releases"
 
-# Map version to a specific feature branch/tag.
+# Map version to the latest release of the certificate year.
 # Note: since the next FIPS validation will be split off from main
-# building main with FIPS enabled is essentially the next FIPS release.
+# building main with FIPS enabled is the next candidate FIPS branch.
 case $VERSION in
   "2022")
-    AWSLC_BRANCH=fips-2024-09-27
+    AWSLC_BRANCH=$(curl --silent $GH_RELEASE_URL \
+      |grep -Po '"tag_name": "\KAWS-LC-FIPS-2.*?(?=")' |head -1)
     ;;
   "2024")
-    AWSLC_BRANCH=fips-2022-11-02
+    AWSLC_BRANCH=$(curl --silent $GH_RELEASE_URL \
+      |grep -Po '"tag_name": "\KAWS-LC-FIPS-3.*?(?=")' |head -1)
     ;;
   "next")
     AWSLC_BRANCH=main
+    ;;
   *)
     echo "Unknown version: $VERSION"
     usage

--- a/codebuild/spec/buildspec_integv2_nix.yaml
+++ b/codebuild/spec/buildspec_integv2_nix.yaml
@@ -1,0 +1,226 @@
+---
+version: 0.2
+env:
+  shell: bash
+  variables:
+    NIXDEV_ARGS: --max-jobs auto --ignore-environment
+    NIX_CACHE_BUCKET_X86: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+    NIX_CACHE_BUCKET_AARCH64: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+batch:
+  build-graph:
+    - env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
+        privileged-mode: false
+        type: LINUX_CONTAINER
+        variables:
+          NIXDEV_ARGS: --max-jobs auto .#default
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
+      identifier: nixCache_x86_64
+    - env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: false
+        type: ARM_CONTAINER
+        variables:
+          NIXDEV_ARGS: --max-jobs auto .#default
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+      identifier: nixCache_aarch64
+    - depend-on:
+        - nixCache_x86_64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            happy_path client_authentication sni_match buffered_send npn
+            signature_algorithms ocsp external_psk pq_handshake serialization
+          NIXDEV_ARGS: --max-jobs auto .#awslc
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
+      identifier: Integ_awslc_x86_0
+    - depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            happy_path client_authentication sni_match buffered_send npn
+            signature_algorithms ocsp external_psk pq_handshake serialization
+          NIXDEV_ARGS: --max-jobs auto .#awslc
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+      identifier: Integ_awslc_aarch64_0
+    - depend-on:
+        - nixCache_x86_64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            happy_path client_authentication sni_match buffered_send npn
+            signature_algorithms ocsp external_psk pq_handshake serialization
+          NIXDEV_ARGS: --max-jobs auto .#default
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
+      identifier: Integ_openssl30_x86_0
+    - depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            happy_path client_authentication sni_match buffered_send npn
+            signature_algorithms ocsp external_psk pq_handshake serialization
+          NIXDEV_ARGS: --max-jobs auto .#default
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+      identifier: Integ_openssl30_aarch64_0
+    - depend-on:
+        - nixCache_x86_64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            happy_path client_authentication sni_match buffered_send npn
+            signature_algorithms ocsp external_psk pq_handshake serialization
+          NIXDEV_ARGS: --max-jobs auto .#openssl111
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
+      identifier: Integ_openssl111_x86_0
+    - depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            happy_path client_authentication sni_match buffered_send npn
+            signature_algorithms ocsp external_psk pq_handshake serialization
+          NIXDEV_ARGS: --max-jobs auto .#openssl111
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+      identifier: Integ_openssl111_aarch64_0
+    - depend-on:
+        - nixCache_x86_64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            renegotiate cross_compatibility early_data hello_retry_requests
+            fragmentation key_update session_resumption version_negotiation
+          NIXDEV_ARGS: --max-jobs auto .#awslc
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
+      identifier: Integ_awslc_x86_1
+    - depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            renegotiate cross_compatibility early_data hello_retry_requests
+            fragmentation key_update session_resumption version_negotiation
+          NIXDEV_ARGS: --max-jobs auto .#awslc
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+      identifier: Integ_awslc_aarch64_1
+    - depend-on:
+        - nixCache_x86_64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            renegotiate cross_compatibility early_data hello_retry_requests
+            fragmentation key_update session_resumption version_negotiation
+          NIXDEV_ARGS: --max-jobs auto .#default
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
+      identifier: Integ_openssl30_x86_1
+    - depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            renegotiate cross_compatibility early_data hello_retry_requests
+            fragmentation key_update session_resumption version_negotiation
+          NIXDEV_ARGS: --max-jobs auto .#default
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+      identifier: Integ_openssl30_aarch64_1
+    - depend-on:
+        - nixCache_x86_64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            renegotiate cross_compatibility early_data hello_retry_requests
+            fragmentation key_update session_resumption version_negotiation
+          NIXDEV_ARGS: --max-jobs auto .#openssl111
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
+      identifier: Integ_openssl111_x86_1
+    - depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            renegotiate cross_compatibility early_data hello_retry_requests
+            fragmentation key_update session_resumption version_negotiation
+          NIXDEV_ARGS: --max-jobs auto .#openssl111
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+      identifier: Integ_openssl111_aarch64_1
+
+phases:
+  install:
+    commands:
+      - |
+        if [[ $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*\"nixCache\".* ]]; then
+         nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
+         nix build .#devShell
+         nix copy --to $NIX_CACHE_BUCKET .#devShell
+        fi
+  pre_build:
+    commands:
+      - |
+        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
+          nix copy --from  $NIX_CACHE_BUCKET --all  --no-check-sigs
+          nix develop $NIXDEV_ARGS --command bash -c "source ./nix/shell.sh; configure"
+        fi
+  build:
+    commands:
+      - if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
+        nix copy --from  $NIX_CACHE_BUCKET --all  --no-check-sigs
+        nix develop $NIXDEV_ARGS --command bash -c "source ./nix/shell.sh; build"
+        fi
+  post_build:
+    commands:
+      - |
+        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
+          nix copy --from $NIX_CACHE_BUCKET --all  --no-check-sigs
+          nix develop $NIXDEV_ARGS --command bash -c "source ./nix/shell.sh;integ $INTEGV2_TEST"
+        fi

--- a/codebuild/spec/buildspec_integv2_nix.yaml
+++ b/codebuild/spec/buildspec_integv2_nix.yaml
@@ -4,29 +4,33 @@ env:
   shell: bash
   variables:
     NIXDEV_ARGS: --max-jobs auto --ignore-environment
-    NIX_CACHE_BUCKET_X86: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
-    NIX_CACHE_BUCKET_AARCH64: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
 batch:
   build-graph:
-    - env:
+    # Cache job for x86
+    - identifier: nixCache_x86_64
+      env:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
         privileged-mode: false
         type: LINUX_CONTAINER
         variables:
           NIXDEV_ARGS: --max-jobs auto .#default
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
-      identifier: nixCache_x86_64
-    - env:
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+
+    # Cache Job for aarch64
+    - identifier: nixCache_aarch64
+      env:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
         privileged-mode: false
         type: ARM_CONTAINER
         variables:
           NIXDEV_ARGS: --max-jobs auto .#default
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
-      identifier: nixCache_aarch64
-    - depend-on:
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+
+    # AWSLC  x86
+    - identifier: Integ_awslc_x86_0
+      depend-on:
         - nixCache_x86_64
       env:
         compute-type: BUILD_GENERAL1_XLARGE
@@ -38,79 +42,9 @@ batch:
             happy_path client_authentication sni_match buffered_send npn
             signature_algorithms ocsp external_psk pq_handshake serialization
           NIXDEV_ARGS: --max-jobs auto .#awslc
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
-      identifier: Integ_awslc_x86_0
-    - depend-on:
-        - nixCache_aarch64
-      env:
-        compute-type: BUILD_GENERAL1_XLARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
-        privileged-mode: true
-        type: ARM_CONTAINER
-        variables:
-          INTEGV2_TEST:
-            happy_path client_authentication sni_match buffered_send npn
-            signature_algorithms ocsp external_psk pq_handshake serialization
-          NIXDEV_ARGS: --max-jobs auto .#awslc
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
-      identifier: Integ_awslc_aarch64_0
-    - depend-on:
-        - nixCache_x86_64
-      env:
-        compute-type: BUILD_GENERAL1_XLARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
-        privileged-mode: true
-        type: LINUX_CONTAINER
-        variables:
-          INTEGV2_TEST:
-            happy_path client_authentication sni_match buffered_send npn
-            signature_algorithms ocsp external_psk pq_handshake serialization
-          NIXDEV_ARGS: --max-jobs auto .#default
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
-      identifier: Integ_openssl30_x86_0
-    - depend-on:
-        - nixCache_aarch64
-      env:
-        compute-type: BUILD_GENERAL1_XLARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
-        privileged-mode: true
-        type: ARM_CONTAINER
-        variables:
-          INTEGV2_TEST:
-            happy_path client_authentication sni_match buffered_send npn
-            signature_algorithms ocsp external_psk pq_handshake serialization
-          NIXDEV_ARGS: --max-jobs auto .#default
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
-      identifier: Integ_openssl30_aarch64_0
-    - depend-on:
-        - nixCache_x86_64
-      env:
-        compute-type: BUILD_GENERAL1_XLARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
-        privileged-mode: true
-        type: LINUX_CONTAINER
-        variables:
-          INTEGV2_TEST:
-            happy_path client_authentication sni_match buffered_send npn
-            signature_algorithms ocsp external_psk pq_handshake serialization
-          NIXDEV_ARGS: --max-jobs auto .#openssl111
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
-      identifier: Integ_openssl111_x86_0
-    - depend-on:
-        - nixCache_aarch64
-      env:
-        compute-type: BUILD_GENERAL1_XLARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
-        privileged-mode: true
-        type: ARM_CONTAINER
-        variables:
-          INTEGV2_TEST:
-            happy_path client_authentication sni_match buffered_send npn
-            signature_algorithms ocsp external_psk pq_handshake serialization
-          NIXDEV_ARGS: --max-jobs auto .#openssl111
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
-      identifier: Integ_openssl111_aarch64_0
-    - depend-on:
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+    - identifier: Integ_awslc_x86_1
+      depend-on:
         - nixCache_x86_64
       env:
         compute-type: BUILD_GENERAL1_XLARGE
@@ -122,9 +56,25 @@ batch:
             renegotiate cross_compatibility early_data hello_retry_requests
             fragmentation key_update session_resumption version_negotiation
           NIXDEV_ARGS: --max-jobs auto .#awslc
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
-      identifier: Integ_awslc_x86_1
-    - depend-on:
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+
+    # AWSLC aarch64
+    - identifier: Integ_awslc_aarch64_0
+      depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            happy_path client_authentication sni_match buffered_send npn
+            signature_algorithms ocsp external_psk pq_handshake serialization
+          NIXDEV_ARGS: --max-jobs auto .#awslc
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+    - identifier: Integ_awslc_aarch64_1
+      depend-on:
         - nixCache_aarch64
       env:
         compute-type: BUILD_GENERAL1_XLARGE
@@ -136,9 +86,85 @@ batch:
             renegotiate cross_compatibility early_data hello_retry_requests
             fragmentation key_update session_resumption version_negotiation
           NIXDEV_ARGS: --max-jobs auto .#awslc
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
-      identifier: Integ_awslc_aarch64_1
-    - depend-on:
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+
+    # AWSLC-FIPS-2022
+    - identifier: Integ_awslcfips2022_aarch64_0
+      depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            happy_path client_authentication sni_match buffered_send npn
+            signature_algorithms ocsp external_psk pq_handshake serialization
+          NIXDEV_ARGS: --max-jobs auto .#awslcfips2022
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+    - identifier: Integ_awslcfips2022_aarch64_1
+      depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            renegotiate cross_compatibility early_data hello_retry_requests
+            fragmentation key_update session_resumption version_negotiation
+          NIXDEV_ARGS: --max-jobs auto .#awslcfips2022
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+
+    # AWSLC-FIPS-2024
+    - identifier: Integ_awslcfips2024_aarch64_0
+      depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            happy_path client_authentication sni_match buffered_send npn
+            signature_algorithms ocsp external_psk pq_handshake serialization
+          NIXDEV_ARGS: --max-jobs auto .#awslcfips2024
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+    - identifier: Integ_awslcfips2024_aarch64_1
+      depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            renegotiate cross_compatibility early_data hello_retry_requests
+            fragmentation key_update session_resumption version_negotiation
+          NIXDEV_ARGS: --max-jobs auto .#awslcfips2024
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+
+    # Openssl30 x86
+    - identifier: Integ_openssl30_x86_0
+      depend-on:
+        - nixCache_x86_64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
+        privileged-mode: true
+        type: LINUX_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            happy_path client_authentication sni_match buffered_send npn
+            signature_algorithms ocsp external_psk pq_handshake serialization
+          NIXDEV_ARGS: --max-jobs auto .#default
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+    - identifier: Integ_openssl30_x86_1
+      depend-on:
         - nixCache_x86_64
       env:
         compute-type: BUILD_GENERAL1_XLARGE
@@ -150,9 +176,25 @@ batch:
             renegotiate cross_compatibility early_data hello_retry_requests
             fragmentation key_update session_resumption version_negotiation
           NIXDEV_ARGS: --max-jobs auto .#default
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
-      identifier: Integ_openssl30_x86_1
-    - depend-on:
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+
+    # Openssl30 aarch
+    - identifier: Integ_openssl30_aarch64_0
+      depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_XLARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          INTEGV2_TEST:
+            happy_path client_authentication sni_match buffered_send npn
+            signature_algorithms ocsp external_psk pq_handshake serialization
+          NIXDEV_ARGS: --max-jobs auto .#default
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+    - identifier: Integ_openssl30_aarch64_1
+      depend-on:
         - nixCache_aarch64
       env:
         compute-type: BUILD_GENERAL1_XLARGE
@@ -164,23 +206,25 @@ batch:
             renegotiate cross_compatibility early_data hello_retry_requests
             fragmentation key_update session_resumption version_negotiation
           NIXDEV_ARGS: --max-jobs auto .#default
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
-      identifier: Integ_openssl30_aarch64_1
-    - depend-on:
-        - nixCache_x86_64
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+
+    # Openssl111 aarch64 only
+    - identifier: Integ_openssl111_aarch64_0
+      depend-on:
+        - nixCache_aarch64
       env:
         compute-type: BUILD_GENERAL1_XLARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
         privileged-mode: true
-        type: LINUX_CONTAINER
+        type: ARM_CONTAINER
         variables:
           INTEGV2_TEST:
-            renegotiate cross_compatibility early_data hello_retry_requests
-            fragmentation key_update session_resumption version_negotiation
+            happy_path client_authentication sni_match buffered_send npn
+            signature_algorithms ocsp external_psk pq_handshake serialization
           NIXDEV_ARGS: --max-jobs auto .#openssl111
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
-      identifier: Integ_openssl111_x86_1
-    - depend-on:
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+    - identifier: Integ_openssl111_aarch64_1
+      depend-on:
         - nixCache_aarch64
       env:
         compute-type: BUILD_GENERAL1_XLARGE
@@ -192,17 +236,20 @@ batch:
             renegotiate cross_compatibility early_data hello_retry_requests
             fragmentation key_update session_resumption version_negotiation
           NIXDEV_ARGS: --max-jobs auto .#openssl111
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
-      identifier: Integ_openssl111_aarch64_1
+          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
 
 phases:
   install:
     commands:
       - |
         if [[ $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
-         nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
-         nix build .#devShell
-         nix copy --to $NIX_CACHE_BUCKET .#devShell
+          echo "Refreshing nix cache..."
+          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
+          nix build .#devShell
+          nix copy --to $NIX_CACHE_BUCKET .#devShell
+        else
+          echo "Downloading cache"
+          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
         fi
   pre_build:
     commands:
@@ -215,13 +262,11 @@ phases:
     commands:
       - |
         if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
-          nix copy --from  $NIX_CACHE_BUCKET --all  --no-check-sigs
           nix develop $NIXDEV_ARGS --command bash -c "source ./nix/shell.sh; build"
         fi
   post_build:
     commands:
       - |
         if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
-          nix copy --from $NIX_CACHE_BUCKET --all  --no-check-sigs
           nix develop $NIXDEV_ARGS --command bash -c "source ./nix/shell.sh;integ $INTEGV2_TEST"
         fi

--- a/codebuild/spec/buildspec_integv2_nix.yaml
+++ b/codebuild/spec/buildspec_integv2_nix.yaml
@@ -213,9 +213,10 @@ phases:
         fi
   build:
     commands:
-      - if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
-        nix copy --from  $NIX_CACHE_BUCKET --all  --no-check-sigs
-        nix develop $NIXDEV_ARGS --command bash -c "source ./nix/shell.sh; build"
+      - |
+        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
+          nix copy --from  $NIX_CACHE_BUCKET --all  --no-check-sigs
+          nix develop $NIXDEV_ARGS --command bash -c "source ./nix/shell.sh; build"
         fi
   post_build:
     commands:

--- a/codebuild/spec/buildspec_integv2_nix.yaml
+++ b/codebuild/spec/buildspec_integv2_nix.yaml
@@ -199,7 +199,7 @@ phases:
   install:
     commands:
       - |
-        if [[ $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*\"nixCache\".* ]]; then
+        if [[ $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
          nix build .#devShell
          nix copy --to $NIX_CACHE_BUCKET .#devShell

--- a/codebuild/spec/buildspec_unit_nix.yaml
+++ b/codebuild/spec/buildspec_unit_nix.yaml
@@ -1,5 +1,10 @@
 ---
+version: 0.2
 env:
+  variables:
+    NIXDEV_ARGS: --max-jobs auto
+    NIX_CACHE_BUCKET_X86: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
+    NIX_CACHE_BUCKET_AARCH64: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
   shell: bash
 batch:
   build-graph:
@@ -8,16 +13,14 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
         variables:
-          NIXDEV_ARGS: --max-jobs auto
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
       identifier: nixCache_x86_64
     - env:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
         type: ARM_CONTAINER
         variables:
-          NIXDEV_ARGS: --max-jobs auto
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
       identifier: nixCache_aarch64
     - depend-on:
         - nixCache_x86_64
@@ -26,8 +29,7 @@ batch:
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
         privileged-mode: true
         variables:
-          NIXDEV_ARGS: --ignore-environment --max-jobs auto
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitOpenssl30_x86_64
@@ -39,8 +41,7 @@ batch:
         privileged-mode: true
         type: ARM_CONTAINER
         variables:
-          NIXDEV_ARGS: --ignore-environment --max-jobs auto
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitOpenssl30_aarch64
@@ -52,7 +53,7 @@ batch:
         privileged-mode: true
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#openssl111
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitOpenssl111_x86_64
@@ -65,7 +66,7 @@ batch:
         type: ARM_CONTAINER
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#openssl111
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitOpenssl111_aarch64
@@ -77,7 +78,7 @@ batch:
         privileged-mode: true
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#openssl102
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitOpenssl102_x86_64
@@ -90,7 +91,7 @@ batch:
         type: ARM_CONTAINER
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#openssl102
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitOpenssl102_aarch64
@@ -102,7 +103,7 @@ batch:
         privileged-mode: true
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#libressl
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitLibressl_x86_64
@@ -115,7 +116,7 @@ batch:
         type: ARM_CONTAINER
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#libressl
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitLibressl_aarch64
@@ -127,7 +128,7 @@ batch:
         privileged-mode: true
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#awslc
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitAwslc_x86_64
@@ -140,16 +141,44 @@ batch:
         type: ARM_CONTAINER
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#awslc
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitAwslc_aarch64
+
+    - depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#awslcfips2022
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+          S2N_NO_HEADBUILD: "1"
+          S2N_TEST: unit
+      identifier: UnitAwslcFips2022_aarch64
+
+    - depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#awslcfips2024
+          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+          S2N_NO_HEADBUILD: "1"
+          S2N_TEST: unit
+      identifier: UnitAwslcFips2024_aarch64
 
 phases:
   install:
     commands:
       - |
-        if [[ "$CODEBUILD_BATCH_BUILD_IDENTIFIER" =~ .*\"nixCache\".* ]]; then
+        if [[ "$CODEBUILD_BATCH_BUILD_IDENTIFIER" =~ .*"nixCache".* ]]; then
           nix copy --from $NIX_CACHE_BUCKET --all  --no-check-sigs
           echo "Running nix build..."
           nix build $NIXDEV_ARGS .#devShell
@@ -162,7 +191,7 @@ phases:
   pre_build:
     commands:
       - |
-        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*\"nixCache\".* ]]; then
+        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
           nix develop $NIXDEV_ARGS --command bash -c \"source ./nix/shell.sh; configure";
         fi
   build:
@@ -174,6 +203,6 @@ phases:
   post_build:
     commands:
       - |
-        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*\"nixCache\".* ]]; then
+        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
           nix develop $NIXDEV_ARGS --command bash -c "source ./nix/shell.sh; unit"
         fi

--- a/codebuild/spec/buildspec_unit_nix.yaml
+++ b/codebuild/spec/buildspec_unit_nix.yaml
@@ -1,11 +1,9 @@
 ---
 version: 0.2
 env:
+  shell: bash
   variables:
     NIXDEV_ARGS: --max-jobs auto
-    NIX_CACHE_BUCKET_X86: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
-    NIX_CACHE_BUCKET_AARCH64: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
-  shell: bash
 batch:
   build-graph:
     - comment: identifiers can not contain dashes
@@ -13,14 +11,14 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
         variables:
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
       identifier: nixCache_x86_64
     - env:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
         type: ARM_CONTAINER
         variables:
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
       identifier: nixCache_aarch64
     - depend-on:
         - nixCache_x86_64
@@ -29,7 +27,7 @@ batch:
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
         privileged-mode: true
         variables:
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitOpenssl30_x86_64
@@ -41,7 +39,7 @@ batch:
         privileged-mode: true
         type: ARM_CONTAINER
         variables:
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitOpenssl30_aarch64
@@ -53,7 +51,7 @@ batch:
         privileged-mode: true
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#openssl111
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitOpenssl111_x86_64
@@ -66,7 +64,7 @@ batch:
         type: ARM_CONTAINER
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#openssl111
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitOpenssl111_aarch64
@@ -78,7 +76,7 @@ batch:
         privileged-mode: true
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#openssl102
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitOpenssl102_x86_64
@@ -91,7 +89,7 @@ batch:
         type: ARM_CONTAINER
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#openssl102
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitOpenssl102_aarch64
@@ -103,7 +101,7 @@ batch:
         privileged-mode: true
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#libressl
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitLibressl_x86_64
@@ -116,7 +114,7 @@ batch:
         type: ARM_CONTAINER
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#libressl
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitLibressl_aarch64
@@ -128,7 +126,7 @@ batch:
         privileged-mode: true
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#awslc
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_X86
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitAwslc_x86_64
@@ -141,7 +139,7 @@ batch:
         type: ARM_CONTAINER
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#awslc
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitAwslc_aarch64
@@ -155,7 +153,7 @@ batch:
         type: ARM_CONTAINER
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#awslcfips2022
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitAwslcFips2022_aarch64
@@ -169,7 +167,7 @@ batch:
         type: ARM_CONTAINER
         variables:
           NIXDEV_ARGS: --ignore-environment --max-jobs auto .#awslcfips2024
-          NIX_CACHE_BUCKET: $NIX_CACHE_BUCKET_AARCH64
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
       identifier: UnitAwslcFips2024_aarch64
@@ -179,20 +177,20 @@ phases:
     commands:
       - |
         if [[ "$CODEBUILD_BATCH_BUILD_IDENTIFIER" =~ .*"nixCache".* ]]; then
-          nix copy --from $NIX_CACHE_BUCKET --all  --no-check-sigs
-          echo "Running nix build..."
+          echo "Refreshing nix cache..."
+          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
           nix build $NIXDEV_ARGS .#devShell
-          echo "Copying derivations to s3..."
           nix copy --to $NIX_CACHE_BUCKET .#devShell;
         else
-          echo "downloading cache.."
+          echo "Downloading cache"
           nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
         fi
   pre_build:
     commands:
       - |
         if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
-          nix develop $NIXDEV_ARGS --command bash -c \"source ./nix/shell.sh; configure";
+          nix copy --from  $NIX_CACHE_BUCKET --all  --no-check-sigs
+          nix develop $NIXDEV_ARGS --command bash -c "source ./nix/shell.sh; configure";
         fi
   build:
     commands:

--- a/codebuild/spec/buildspec_unit_nix.yaml
+++ b/codebuild/spec/buildspec_unit_nix.yaml
@@ -1,0 +1,179 @@
+---
+env:
+  shell: bash
+batch:
+  build-graph:
+    - comment: identifiers can not contain dashes
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
+        variables:
+          NIXDEV_ARGS: --max-jobs auto
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
+      identifier: nixCache_x86_64
+    - env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        type: ARM_CONTAINER
+        variables:
+          NIXDEV_ARGS: --max-jobs auto
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
+      identifier: nixCache_aarch64
+    - depend-on:
+        - nixCache_x86_64
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
+        privileged-mode: true
+        variables:
+          NIXDEV_ARGS: --ignore-environment --max-jobs auto
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
+          S2N_NO_HEADBUILD: "1"
+          S2N_TEST: unit
+      identifier: UnitOpenssl30_x86_64
+    - depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          NIXDEV_ARGS: --ignore-environment --max-jobs auto
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
+          S2N_NO_HEADBUILD: "1"
+          S2N_TEST: unit
+      identifier: UnitOpenssl30_aarch64
+    - depend-on:
+        - nixCache_x86_64
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
+        privileged-mode: true
+        variables:
+          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#openssl111
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
+          S2N_NO_HEADBUILD: "1"
+          S2N_TEST: unit
+      identifier: UnitOpenssl111_x86_64
+    - depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#openssl111
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
+          S2N_NO_HEADBUILD: "1"
+          S2N_TEST: unit
+      identifier: UnitOpenssl111_aarch64
+    - depend-on:
+        - nixCache_x86_64
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
+        privileged-mode: true
+        variables:
+          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#openssl102
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
+          S2N_NO_HEADBUILD: "1"
+          S2N_TEST: unit
+      identifier: UnitOpenssl102_x86_64
+    - depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#openssl102
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
+          S2N_NO_HEADBUILD: "1"
+          S2N_TEST: unit
+      identifier: UnitOpenssl102_aarch64
+    - depend-on:
+        - nixCache_x86_64
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
+        privileged-mode: true
+        variables:
+          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#libressl
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
+          S2N_NO_HEADBUILD: "1"
+          S2N_TEST: unit
+      identifier: UnitLibressl_x86_64
+    - depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#libressl
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
+          S2N_NO_HEADBUILD: "1"
+          S2N_TEST: unit
+      identifier: UnitLibressl_aarch64
+    - depend-on:
+        - nixCache_x86_64
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
+        privileged-mode: true
+        variables:
+          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#awslc
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
+          S2N_NO_HEADBUILD: "1"
+          S2N_TEST: unit
+      identifier: UnitAwslc_x86_64
+    - depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#awslc
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
+          S2N_NO_HEADBUILD: "1"
+          S2N_TEST: unit
+      identifier: UnitAwslc_aarch64
+
+phases:
+  install:
+    commands:
+      - |
+        if [[ "$CODEBUILD_BATCH_BUILD_IDENTIFIER" =~ .*\"nixCache\".* ]]; then
+          nix copy --from $NIX_CACHE_BUCKET --all  --no-check-sigs
+          echo "Running nix build..."
+          nix build $NIXDEV_ARGS .#devShell
+          echo "Copying derivations to s3..."
+          nix copy --to $NIX_CACHE_BUCKET .#devShell;
+        else
+          echo "downloading cache.."
+          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
+        fi
+  pre_build:
+    commands:
+      - |
+        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*\"nixCache\".* ]]; then
+          nix develop $NIXDEV_ARGS --command bash -c \"source ./nix/shell.sh; configure";
+        fi
+  build:
+    commands:
+      - |
+        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
+          nix develop $NIXDEV_ARGS --command bash -c "source ./nix/shell.sh; build";
+        fi
+  post_build:
+    commands:
+      - |
+        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*\"nixCache\".* ]]; then
+          nix develop $NIXDEV_ARGS --command bash -c "source ./nix/shell.sh; unit"
+        fi

--- a/codebuild/spec/buildspec_unit_nix.yaml
+++ b/codebuild/spec/buildspec_unit_nix.yaml
@@ -6,21 +6,25 @@ env:
     NIXDEV_ARGS: --max-jobs auto
 batch:
   build-graph:
-    - comment: identifiers can not contain dashes
+    # Cache job for x86
+    - identifier: nixCache_x86_64
+      comment: identifiers can not contain dashes
       env:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
         variables:
           NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
-      identifier: nixCache_x86_64
-    - env:
+    # Cache job for aarch64
+    - identifier: nixCache_aarch64
+      env:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
         type: ARM_CONTAINER
         variables:
           NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
-      identifier: nixCache_aarch64
-    - depend-on:
+    # Openssl30 x86
+    - identifier: UnitOpenssl30_x86_64
+      depend-on:
         - nixCache_x86_64
       env:
         compute-type: BUILD_GENERAL1_LARGE
@@ -30,8 +34,9 @@ batch:
           NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
-      identifier: UnitOpenssl30_x86_64
-    - depend-on:
+    # Openssl30 aarch64
+    - identifier: UnitOpenssl30_aarch64
+      depend-on:
         - nixCache_aarch64
       env:
         compute-type: BUILD_GENERAL1_LARGE
@@ -42,20 +47,9 @@ batch:
           NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
-      identifier: UnitOpenssl30_aarch64
-    - depend-on:
-        - nixCache_x86_64
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
-        privileged-mode: true
-        variables:
-          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#openssl111
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
-          S2N_NO_HEADBUILD: "1"
-          S2N_TEST: unit
-      identifier: UnitOpenssl111_x86_64
-    - depend-on:
+    # Openssl111 aarch64
+    - identifier: UnitOpenssl111_aarch64
+      depend-on:
         - nixCache_aarch64
       env:
         compute-type: BUILD_GENERAL1_LARGE
@@ -67,84 +61,52 @@ batch:
           NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
-      identifier: UnitOpenssl111_aarch64
-    - depend-on:
-        - nixCache_x86_64
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
-        privileged-mode: true
-        variables:
-          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#openssl102
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
-          S2N_NO_HEADBUILD: "1"
-          S2N_TEST: unit
-      identifier: UnitOpenssl102_x86_64
-    - depend-on:
-        - nixCache_aarch64
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
-        privileged-mode: true
-        type: ARM_CONTAINER
-        variables:
-          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#openssl102
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
-          S2N_NO_HEADBUILD: "1"
-          S2N_TEST: unit
-      identifier: UnitOpenssl102_aarch64
-    - depend-on:
-        - nixCache_x86_64
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
-        privileged-mode: true
-        variables:
-          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#libressl
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
-          S2N_NO_HEADBUILD: "1"
-          S2N_TEST: unit
-      identifier: UnitLibressl_x86_64
-    - depend-on:
-        - nixCache_aarch64
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
-        privileged-mode: true
-        type: ARM_CONTAINER
-        variables:
-          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#libressl
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
-          S2N_NO_HEADBUILD: "1"
-          S2N_TEST: unit
-      identifier: UnitLibressl_aarch64
-    - depend-on:
-        - nixCache_x86_64
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
-        privileged-mode: true
-        variables:
-          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#awslc
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
-          S2N_NO_HEADBUILD: "1"
-          S2N_TEST: unit
-      identifier: UnitAwslc_x86_64
-    - depend-on:
-        - nixCache_aarch64
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
-        privileged-mode: true
-        type: ARM_CONTAINER
-        variables:
-          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#awslc
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
-          S2N_NO_HEADBUILD: "1"
-          S2N_TEST: unit
-      identifier: UnitAwslc_aarch64
 
-    - depend-on:
+    # Openssl102 aarch64
+    - identifier: UnitOpenssl102_aarch64
+      depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#openssl102
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
+          S2N_NO_HEADBUILD: "1"
+          S2N_TEST: unit
+
+    # awslc x86
+    - identifier: UnitAwslc_x86_64
+      depend-on:
+        - nixCache_x86_64
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
+        privileged-mode: true
+        variables:
+          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#awslc
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
+          S2N_NO_HEADBUILD: "1"
+          S2N_TEST: unit
+    # awslc aarch64
+    - identifier: UnitAwslc_aarch64
+      depend-on:
+        - nixCache_aarch64
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          NIXDEV_ARGS: --ignore-environment --max-jobs auto .#awslc
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
+          S2N_NO_HEADBUILD: "1"
+          S2N_TEST: unit
+    # awslcfips 2022 aarch64
+    - identifier: UnitAwslcFips2022_aarch64
+      depend-on:
         - nixCache_aarch64
       env:
         compute-type: BUILD_GENERAL1_LARGE
@@ -156,9 +118,9 @@ batch:
           NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
-      identifier: UnitAwslcFips2022_aarch64
-
-    - depend-on:
+    # awslcfips 2024 aarch64
+    - identifier: UnitAwslcFips2024_aarch64
+      depend-on:
         - nixCache_aarch64
       env:
         compute-type: BUILD_GENERAL1_LARGE
@@ -170,7 +132,6 @@ batch:
           NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
           S2N_NO_HEADBUILD: "1"
           S2N_TEST: unit
-      identifier: UnitAwslcFips2024_aarch64
 
 phases:
   install:


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

https://github.com/aws/s2n-tls/issues/5180

### Description of changes: 

Adds the aws-lc-fips-2022 and 2024 libcryptos to the nix based unit and integration jobs. These buildspecs were being built with internal CDK, now moved to github.

### Call-outs:

Dropping some older libcryptos, and reducing to one architecture for:


### Testing:

How is this change tested (unit tests, fuzz tests, etc.)?  Locally and ad-hoc CodeBuild (links)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
