### PR TITLE
ci: add openssl-3.0-fips to asan build properly

### DIFF
--- a/codebuild/spec/buildspec_sanitizer.yml
+++ b/codebuild/spec/buildspec_sanitizer.yml
@@ -51,6 +51,12 @@ batch:
         variables:
           S2N_LIBCRYPTO: openssl-3.0
           COMPILER: clang
+    - identifier: clang_openssl_3_fips
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          S2N_LIBCRYPTO: openssl-3.0-fips
+          COMPILER: clang
     - identifier: clang_openssl_1_1_1
       env:
         compute-type: BUILD_GENERAL1_LARGE
@@ -78,7 +84,6 @@ batch:
     - identifier: gcc_openssl_3_fips
       env:
         compute-type: BUILD_GENERAL1_LARGE
-        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu24_20250214
         variables:
           S2N_LIBCRYPTO: openssl-3.0-fips
           COMPILER: gcc


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

related to https://github.com/aws/s2n-tls/issues/5036

### Description of changes: 

Add missing openssl-3.0-fips build for parity with openssl-3.0, and remove the special-cased image from the existing openssl-3.0-fips job. Doug added openssl-3.0-fips to the standard images we use, so it no longer requires special casing and should work anywhere the standard images work. 

### Testing:
New tests pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
