### PR TITLE
ci: add openssl-3.0-fips to general batch

### DIFF
--- a/codebuild/spec/buildspec_generalbatch.yml
+++ b/codebuild/spec/buildspec_generalbatch.yml
@@ -66,6 +66,18 @@ batch:
           S2N_LIBCRYPTO: openssl-3.0
           TESTS: unit
       identifier: s2nUnitOpenssl3Gcc9
+    - buildspec: codebuild/spec/buildspec_ubuntu.yml
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu18codebuild
+        privileged-mode: true
+        variables:
+          BUILD_S2N: true
+          GCC_VERSION: 9
+          S2N_COVERAGE: true
+          S2N_LIBCRYPTO: openssl-3.0-fips
+          TESTS: unit
+      identifier: s2nUnitOpenssl3FIPSGcc9
     ### Ubuntu24 ###
     # Openssl-1.1.1 + gcc-13: Prefer more widely used Openssl on the default
     #   Ubuntu24 compiler.


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

related to https://github.com/aws/s2n-tls/issues/5036

### Description of changes: 
Add openssl-3.0-fips to s2nGeneralBatch, copying our openssl-3.0-fips builds where possible. I did not add any AL builds, even though we have openssl-3.0 AL builds, because openssl-3.0-fips is not present on amazonlinux2-x86_64-standard:5.0 or amazonlinux2-aarch64-standard:3.0.

### Testing:
s2nGeneralBatch passes with the new openssl-3.0-fips build.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
