### PR TITLE
feat: add s2n_connection_get_key_exchange_group_name

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -3294,6 +3294,8 @@ S2N_API extern int s2n_connection_is_valid_for_cipher_preferences(struct s2n_con
 
 /**
  * Function to get the human readable elliptic curve name for the connection.
+ * 
+ * @deprecated Use `s2n_connection_get_key_exchange_group_name` instead
  *
  * @param conn A pointer to the s2n connection
  * @returns A string indicating the elliptic curve used during ECDHE key exchange. The string "NONE" is returned if no curve was used.
@@ -3318,11 +3320,25 @@ S2N_API extern const char *s2n_connection_get_kem_name(struct s2n_connection *co
  * @note PQ key exchange will not occur if the connection is < TLS1.3 or the configured security
  * policy has no KEM groups on it. It also will not occur if the peer does not support PQ key exchange.
  * In these instances this function will return "NONE".
+ * 
+ * @deprecated Use `s2n_connection_get_key_exchange_group_name` instead
  *
  * @param conn A pointer to the s2n connection
  * @returns A human readable string for the KEM group. Returns "NONE" if no PQ key exchange occurred.
  */
 S2N_API extern const char *s2n_connection_get_kem_group_name(struct s2n_connection *conn);
+
+/**
+ * Function to get the human readable key exchange group name for the connection.
+ *
+ * @note This function replaces `s2n_connection_get_curve` and `s2n_connection_get_kem_group_name`, returning
+ * the named group regardless if a hybrid PQ group was negotiated or not. 
+ *
+ * @param conn A pointer to the s2n connection
+ * @param group_name A pointer that will be set to point to a const char* containing the group name
+ * @returns S2N_SUCCESS on success, S2N_FAILURE otherwise. `group_name` will be set on success.
+ */
+S2N_API extern int s2n_connection_get_key_exchange_group_name(struct s2n_connection *conn, const char **group_name);
 
 /**
  * Function to get the alert that caused a connection to close. s2n-tls considers all

--- a/bin/https.c
+++ b/bin/https.c
@@ -113,6 +113,10 @@ int https(struct s2n_connection *conn, uint32_t bench)
     BUFFER("Curve: %s\n", s2n_connection_get_curve(conn));
     BUFFER("KEM: %s\n", s2n_connection_get_kem_name(conn));
     BUFFER("KEM Group: %s\n", s2n_connection_get_kem_group_name(conn));
+    const char* group_name = NULL;
+    if (s2n_connection_get_key_exchange_group_name(conn, &group_name)) {
+        BUFFER("Key Exchange Group: %s\n", group_name);
+    }
     BUFFER("Cipher negotiated: %s\n", s2n_connection_get_cipher(conn));
     BUFFER("Session resumption: %s\n", s2n_connection_is_session_resumed(conn) ? "true" : "false");
 

--- a/tests/unit/s2n_connection_preferences_test.c
+++ b/tests/unit/s2n_connection_preferences_test.c
@@ -274,11 +274,16 @@ int main(int argc, char **argv)
         /* No curve negotiated yet */
         EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));
         EXPECT_BYTEARRAY_EQUAL(curve_name, no_curve, strlen(no_curve));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_key_exchange_group_name(conn, &curve_name), S2N_ERR_INVALID_STATE);
 
         /* TLS1.3 always returns a curve */
         conn->actual_protocol_version = S2N_TLS13;
         conn->kex_params.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
         EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));
+        EXPECT_BYTEARRAY_EQUAL(curve_name, s2n_ecc_curve_secp256r1.name, strlen(s2n_ecc_curve_secp256r1.name));
+        curve_name = NULL;
+        s2n_connection_get_key_exchange_group_name(conn, &curve_name);
+        EXPECT_NOT_NULL(curve_name);
         EXPECT_BYTEARRAY_EQUAL(curve_name, s2n_ecc_curve_secp256r1.name, strlen(s2n_ecc_curve_secp256r1.name));
 
         /* TLS1.2 returns a curve if ECDHE cipher negotiated */
@@ -287,6 +292,10 @@ int main(int argc, char **argv)
         conn->kex_params.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
         EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));
         EXPECT_BYTEARRAY_EQUAL(curve_name, s2n_ecc_curve_secp256r1.name, strlen(s2n_ecc_curve_secp256r1.name));
+        curve_name = NULL;
+        s2n_connection_get_key_exchange_group_name(conn, &curve_name);
+        EXPECT_NOT_NULL(curve_name);
+        EXPECT_BYTEARRAY_EQUAL(curve_name, s2n_ecc_curve_secp256r1.name, strlen(s2n_ecc_curve_secp256r1.name));
 
         /* TLS1.2 does not return a curve if ECDHE cipher was not negotiated */
         conn->actual_protocol_version = S2N_TLS12;
@@ -294,6 +303,7 @@ int main(int argc, char **argv)
         conn->kex_params.server_ecc_evp_params.negotiated_curve = &s2n_ecc_curve_secp256r1;
         EXPECT_NOT_NULL(curve_name = s2n_connection_get_curve(conn));
         EXPECT_BYTEARRAY_EQUAL(curve_name, no_curve, strlen(no_curve));
+        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_key_exchange_group_name(conn, &curve_name), S2N_ERR_INVALID_STATE);
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     };

--- a/tests/unit/s2n_tls13_pq_handshake_test.c
+++ b/tests/unit/s2n_tls13_pq_handshake_test.c
@@ -243,6 +243,16 @@ int s2n_test_tls13_pq_handshake(const struct s2n_security_policy *client_sec_pol
         POSIX_ENSURE_EQ(memcmp(expected_kem_group->name, s2n_connection_get_kem_group_name(server_conn), strlen(expected_kem_group->name)), 0);
         POSIX_ENSURE_EQ(strlen(expected_kem_group->name), strlen(s2n_connection_get_kem_group_name(client_conn)));
         POSIX_ENSURE_EQ(memcmp(expected_kem_group->name, s2n_connection_get_kem_group_name(client_conn), strlen(expected_kem_group->name)), 0);
+
+        /* Ensure s2n_connection_get_key_exchange_group_name() gives the correct answer for both client and server */
+        const char* server_group_name = NULL;
+        const char* client_group_name = NULL;
+        POSIX_GUARD(s2n_connection_get_key_exchange_group_name(server_conn, &server_group_name));
+        POSIX_GUARD(s2n_connection_get_key_exchange_group_name(client_conn, &client_group_name));
+        POSIX_ENSURE_EQ(strlen(expected_kem_group->name), strlen(server_group_name));
+        POSIX_ENSURE_EQ(memcmp(expected_kem_group->name, server_group_name, strlen(expected_kem_group->name)), 0);
+        POSIX_ENSURE_EQ(strlen(expected_kem_group->name), strlen(client_group_name));
+        POSIX_ENSURE_EQ(memcmp(expected_kem_group->name, client_group_name, strlen(expected_kem_group->name)), 0);
     } else {
         POSIX_ENSURE_EQ(NULL, client_conn->kex_params.server_kem_group_params.kem_group);
         POSIX_ENSURE_EQ(NULL, client_conn->kex_params.server_kem_group_params.kem_params.kem);
@@ -259,6 +269,16 @@ int s2n_test_tls13_pq_handshake(const struct s2n_security_policy *client_sec_pol
         POSIX_ENSURE_EQ(memcmp(expected_curve->name, s2n_connection_get_curve(server_conn), strlen(expected_curve->name)), 0);
         POSIX_ENSURE_EQ(strlen(expected_curve->name), strlen(s2n_connection_get_curve(client_conn)));
         POSIX_ENSURE_EQ(memcmp(expected_curve->name, s2n_connection_get_curve(client_conn), strlen(expected_curve->name)), 0);
+
+        /* Ensure s2n_connection_get_key_exchange_group_name() gives the correct answer for both client and server */
+        const char* server_group_name = NULL;
+        const char* client_group_name = NULL;
+        POSIX_GUARD(s2n_connection_get_key_exchange_group_name(server_conn, &server_group_name));
+        POSIX_GUARD(s2n_connection_get_key_exchange_group_name(client_conn, &client_group_name));
+        POSIX_ENSURE_EQ(strlen(expected_curve->name), strlen(server_group_name));
+        POSIX_ENSURE_EQ(memcmp(expected_curve->name, server_group_name, strlen(expected_curve->name)), 0);
+        POSIX_ENSURE_EQ(strlen(expected_curve->name), strlen(client_group_name));
+        POSIX_ENSURE_EQ(memcmp(expected_curve->name, client_group_name, strlen(expected_curve->name)), 0);
     }
 
     /* Verify basic properties of secrets */

--- a/tls/s2n_tls13_handshake.c
+++ b/tls/s2n_tls13_handshake.c
@@ -129,7 +129,7 @@ int s2n_tls13_compute_pq_hybrid_shared_secret(struct s2n_connection *conn, struc
     return S2N_SUCCESS;
 }
 
-static int s2n_tls13_pq_hybrid_supported(struct s2n_connection *conn)
+int s2n_tls13_pq_hybrid_supported(struct s2n_connection *conn)
 {
     return conn->kex_params.server_kem_group_params.kem_group != NULL;
 }

--- a/tls/s2n_tls13_handshake.h
+++ b/tls/s2n_tls13_handshake.h
@@ -35,6 +35,7 @@ int s2n_tls13_mac_verify(struct s2n_tls13_keys *keys, struct s2n_blob *finished_
 int s2n_tls13_keys_from_conn(struct s2n_tls13_keys *keys, struct s2n_connection *conn);
 
 int s2n_tls13_compute_shared_secret(struct s2n_connection *conn, struct s2n_blob *shared_secret);
+int s2n_tls13_pq_hybrid_supported(struct s2n_connection *conn);
 int s2n_update_application_traffic_keys(struct s2n_connection *conn, s2n_mode mode, keyupdate_status status);
 
 int s2n_server_hello_retry_recreate_transcript(struct s2n_connection *conn);


### PR DESCRIPTION
### Release Summary:
* Adds `s2n_connection_get_key_exchange_group_name` for getting the negotiated named group

### Resolved issues:

resolves #4123

### Description of changes: 

This change combines the functionality of `s2n_connection_get_curve()` and `s2n_connection_get_kem_group_name()` to return the full named group regardless of whether hybrid PQ was negotiated or not. See #4123 for more details on why this is necessary. 

### Call-outs:

I deprecated both `s2n_connection_get_curve()` and `s2n_connection_get_kem_group_name()`, but I'm wondering if we should just keep `s2n_connection_get_kem_group_name()` as not deprecated, since its the only way I think to easily confirm if hybrid PQ was negotiated, without doing some string matching or key length checks, etc. Or I could add another api, like `s2n_connection_pq_supported`

### Testing:

Updated existing unit test to call this new API

Remember:
* Any change to the library source code should at least include unit tests.
* Any change to the core stuffer or blob methods should include [CBMC proofs](https://github.com/aws/s2n-tls/tree/main/tests/cbmc).
* Any change to the CI or tests should:
   1. prove that the test succeeds for good input
   2. prove that the test fails for bad input (eg, a test for memory leaks fails when a memory leak is committed)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
