### PR TITLE
ci: add openssl-3.0-fips to valgrind

### DIFF
--- a/codebuild/spec/buildspec_valgrind.yml
+++ b/codebuild/spec/buildspec_valgrind.yml
@@ -36,6 +36,13 @@ batch:
         variables:
           S2N_LIBCRYPTO: openssl-3.0
           COMPILER: gcc
+    - identifier: gcc_openssl_3_fips
+      env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
+        variables:
+          S2N_LIBCRYPTO: openssl-3.0-fips
+          COMPILER: gcc
     - identifier: gcc_openssl_1_1_1
       env:
         compute-type: BUILD_GENERAL1_LARGE

--- a/tests/unit/s2n_seccomp_handshake_test.c
+++ b/tests/unit/s2n_seccomp_handshake_test.c
@@ -19,7 +19,7 @@
 
 int main(int argc, char **argv)
 {
-    /* We need to execute BEGIN_TEST() before the seccomp filter is applied.
+    /* We need to execute s2n_init before the seccomp filter is applied.
      * Some one-time initialization involves opening files, like "dev/urandom".
      * If built with aws-lc, s2n-tls also needs to call CRYPTO_pre_sandbox_init()
      * before seccomp starts sandboxing.

--- a/tests/unit/s2n_seccomp_handshake_test.c
+++ b/tests/unit/s2n_seccomp_handshake_test.c
@@ -19,7 +19,7 @@
 
 int main(int argc, char **argv)
 {
-    BEGIN_TEST_NO_INIT();
+    BEGIN_TEST();
 
     /* One of the primary purposes of seccomp is to block opening new files.
      * So before we enable seccomp, we need to open any files that the test would
@@ -33,15 +33,6 @@ int main(int argc, char **argv)
             cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_ECDSA_TEST_PRIVATE_KEY,
             private_key_pem, S2N_MAX_TEST_PEM_SIZE));
-
-    /* We need to execute s2n_init before the seccomp filter is applied.
-     * Some one-time initialization involves opening files, like "dev/urandom".
-     * If built with aws-lc, s2n-tls also needs to call CRYPTO_pre_sandbox_init()
-     * before seccomp starts sandboxing.
-     *
-     * An application using s2n-tls with seccomp would need to do the same.
-     */
-    EXPECT_SUCCESS(s2n_init());
 
     /* No unexpected syscalls allowed beyond this point */
     EXPECT_OK(s2n_seccomp_init());

--- a/tests/unit/s2n_seccomp_handshake_test.c
+++ b/tests/unit/s2n_seccomp_handshake_test.c
@@ -19,6 +19,13 @@
 
 int main(int argc, char **argv)
 {
+    /* We need to execute BEGIN_TEST() before the seccomp filter is applied.
+     * Some one-time initialization involves opening files, like "dev/urandom".
+     * If built with aws-lc, s2n-tls also needs to call CRYPTO_pre_sandbox_init()
+     * before seccomp starts sandboxing.
+     *
+     * An application using s2n-tls with seccomp would need to do the same.
+     */
     BEGIN_TEST();
 
     /* One of the primary purposes of seccomp is to block opening new files.


### PR DESCRIPTION
### Resolved issues:

related to https://github.com/aws/s2n-tls/issues/5036

### Description of changes:
* Add missing openssl-3.0-fips build for valgrind.
* fixed valgrind memory leak by initializing immediately rather then calling `s2n_init()` later

### Testing
* Valgrind did not produce memory leak error (https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/Valgrind/batch/Valgrind%3Aca683ef4-7d5b-460b-8824-121894a39ce2?region=us-west-2)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
