### PR TITLE
ci: exclude new setuptools

### DIFF
--- a/tests/integrationv2/pyproject.toml
+++ b/tests/integrationv2/pyproject.toml
@@ -12,3 +12,10 @@ dependencies = [
     "ruff>=0.9.7",
     "sslyze>=6.1.0",
 ]
+
+# setuptools made a breaking change in setup file validation: https://github.com/pypa/setuptools/blob/main/NEWS.rst#deprecations-and-removals
+# This is affecting tls_parser, a dependency of sslyze: https://github.com/nabla-c0d3/tls_parser/pull/11
+# We use `exclude-newer` to temporarily workaround this issue, as suggested by
+# uv: https://github.com/astral-sh/uv/issues/12440
+[tool.uv]
+exclude-newer = "2025-03-24T00:00:00Z"


### PR DESCRIPTION
### Description of changes: 
setuptools made a breaking change in setup file validation: https://github.com/pypa/setuptools/blob/main/NEWS.rst#deprecations-and-removals

We use `exclude-newer` to temporarily workaround this issue, as suggested by uv: https://github.com/astral-sh/uv/issues/12440

### Testing:

CI should now pass.

### Tracing Issue:
#5216 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
