### PR TITLE
refactor(bindings): use implicit linking for aws-lc

### DIFF
--- a/bindings/rust/extended/generate/src/main.rs
+++ b/bindings/rust/extended/generate/src/main.rs
@@ -125,6 +125,9 @@ const PRELUDE: &str = r#"
 #![allow(unused_imports, non_camel_case_types)]
 
 use libc::{iovec, FILE, off_t};
+// specify that aws-lc-rs is used, so that the rust compiler will link in the appropriate
+// libcrypto artifact.
+use aws_lc_rs as _;
 "#;
 
 fn base_builder() -> bindgen::Builder {

--- a/bindings/rust/extended/generate/src/main.rs
+++ b/bindings/rust/extended/generate/src/main.rs
@@ -127,6 +127,7 @@ const PRELUDE: &str = r#"
 use libc::{iovec, FILE, off_t};
 // specify that aws-lc-rs is used, so that the rust compiler will link in the appropriate
 // libcrypto artifact.
+#[cfg(not(s2n_tls_external_build))]
 extern crate aws_lc_rs as _;
 "#;
 

--- a/bindings/rust/extended/generate/src/main.rs
+++ b/bindings/rust/extended/generate/src/main.rs
@@ -127,7 +127,7 @@ const PRELUDE: &str = r#"
 use libc::{iovec, FILE, off_t};
 // specify that aws-lc-rs is used, so that the rust compiler will link in the appropriate
 // libcrypto artifact.
-use aws_lc_rs as _;
+extern crate aws_lc_rs as _;
 "#;
 
 fn base_builder() -> bindgen::Builder {

--- a/bindings/rust/extended/s2n-tls-sys/build.rs
+++ b/bindings/rust/extended/s2n-tls-sys/build.rs
@@ -147,7 +147,7 @@ fn build_vendored() {
     build.compile("s2n-tls");
 
     // linking to the libcrypto is handled by the rust compiler through the
-    // `use aws_lc_rs as _;` statement included in the generated source files. 
+    // `use aws_lc_rs as _;` statement included in the generated source files.
     // This is less brittle than manually linking the libcrypto artifact.
 
     // let consumers know where to find our header files

--- a/bindings/rust/extended/s2n-tls-sys/build.rs
+++ b/bindings/rust/extended/s2n-tls-sys/build.rs
@@ -3,7 +3,11 @@
 
 use std::path::{Path, PathBuf};
 
+const EXTERNAL_BUILD_CFG_NAME: &str = "s2n_tls_external_build";
+
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg({EXTERNAL_BUILD_CFG_NAME})");
+
     let external = External::default();
     if external.is_enabled() {
         external.link();
@@ -251,6 +255,8 @@ impl External {
     }
 
     fn link(&self) {
+        println!("cargo:rustc-cfg={EXTERNAL_BUILD_CFG_NAME}");
+
         println!(
             "cargo:rustc-link-search={}",
             self.lib_dir.as_ref().unwrap().display()

--- a/bindings/rust/extended/s2n-tls-sys/build.rs
+++ b/bindings/rust/extended/s2n-tls-sys/build.rs
@@ -146,8 +146,9 @@ fn build_vendored() {
 
     build.compile("s2n-tls");
 
-    // tell rust we're linking with libcrypto
-    println!("cargo:rustc-link-lib={}", libcrypto.link);
+    // linking to the libcrypto is handled by the rust compiler through the
+    // `use aws_lc_rs as _;` statement included in the generated source files. 
+    // This is less brittle than manually linking the libcrypto artifact.
 
     // let consumers know where to find our header files
     let include_dir = out_dir.join("include");

--- a/bindings/rust/extended/s2n-tls-sys/build.rs
+++ b/bindings/rust/extended/s2n-tls-sys/build.rs
@@ -147,8 +147,8 @@ fn build_vendored() {
     build.compile("s2n-tls");
 
     // linking to the libcrypto is handled by the rust compiler through the
-    // `use aws_lc_rs as _;` statement included in the generated source files.
-    // This is less brittle than manually linking the libcrypto artifact.
+    // `extern crate aws_lc_rs as _;` statement included in the generated source
+    // files. This is less brittle than manually linking the libcrypto artifact.
 
     // let consumers know where to find our header files
     let include_dir = out_dir.join("include");


### PR DESCRIPTION
### Description of changes: 

Currently, `s2n-tls-sys` bindings manually link against the libcrypto. 
https://github.com/aws/s2n-tls/blob/9e0259bff0543323ed57444b63c262ee41f608a1/bindings/rust/extended/s2n-tls-sys/build.rs#L149-L150
This approach is brittle. It broke last week when aws-lc split s2n-bignum into it's own artifact.

Ideally, s2n-tls wouldn't have to be aware of how aws-lc is shipping it's symbols. 
- `aws-lc-rs`: responsible for compiling `aws-lc` symbols  & linking them to the rust application
- `s2n-tls-sys`: reponsible for compiling `s2n-tls` symbols & linking them to the rust application
    - NOT responsible for linking `aws-lc` symbols to the application* 

`aws-lc-rs` actually already handles this functionality, and emits link instructions to the rust compiler in it's build script. The issue is that the rust-compiler won't use any of that logic if it can't detect usage of any aws-lc symbols.

To fix this we add a `use aws_lc_rs as _;` statement to let the rust compiler know that we actually _are_ relying on the aws-lc-rs crate, even through it might not look like it.

### Call-outs:

If a customers is using the "External Build" functionality, their artifact size is going to increase after this PR. Also, this might result in build failures if a customer is
- using the external build feature AND
- using AWS-LC

Because s2n-bignum symbols are not currently prefixed. Before we merge this we should
- wait for aws-lc-rs to merge/release symbol prefixing for s2n-bignum AND
- confirm whether this increase in artifact size is acceptable

If either of these conditions are not satisfied,  then we'll need to complete #5219 before merging this.

We use `aws-lc-rs` rather than `aws-lc-rs-sys` so that we can toggle between the fips/standard versions.

### Testing:

All CI should pass

I also patching out the aws-lc-rs dependency to use mainline
```
aws-lc-rs = { git = "https://github.com/aws/aws-lc-rs" }
```
And confirmed that it didn't fail, and all tests passed successfully.

I then repeated this with mainline and confirmed that it _did_ fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
