### PR TITLE
feat(bindings): expose certificate match api

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -1682,9 +1682,7 @@ mod tests {
             pair.handshake()?;
             let cert_match = pair.server.certificate_match()?;
 
-            assert_eq!(
-                cert_match, expected,
-            );
+            assert_eq!(cert_match, expected,);
         }
 
         Ok(())

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -1647,14 +1647,13 @@ mod tests {
         assert!(connection.application_context::<u32>().is_some());
     }
 
-    /// Test that `certificate_match` executes safely and returns a result.
+    /// Test that `certificate_match` wrapper correctly maps C values to CertSNIMatch and handles unknown input.
     #[test]
-    fn test_certificate_match_executes_safely() {
-        let config = Config::new();
-        let mut connection = Connection::new_server();
-        connection.set_config(config).unwrap();
-
-        let result = connection.certificate_match();
-        assert!(result.is_ok() || result.is_err());
+    fn test_cert_sni_match_conversion() {
+        assert_eq!(
+            CertSNIMatch::try_from(s2n_cert_sni_match::SNI_EXACT_MATCH).unwrap(),
+            CertSNIMatch::ExactMatch
+        );
+        assert!(CertSNIMatch::try_from(9999).is_err());
     }
 }

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -1641,7 +1641,7 @@ mod tests {
         assert!(connection.application_context::<u32>().is_some());
     }
 
-    /// Test that the `certificate_match` Rust wrapper correctly calls the underlying C API
+    /// Test that the `certificate_match` Rust wrapper returns NoMatch enum
     #[test]
     fn test_certificate_match_returns_no_match() {
         let config = build_config(&security::DEFAULT_TLS13).expect("Failed to build config");
@@ -1655,9 +1655,9 @@ mod tests {
         assert_eq!(cert_match, CertSNIMatch::NoMatch);
     }
 
-    /// Test that the `certificate_match` Rust wrapper returns NoSNI
+    /// Test that the `certificate_match` Rust wrapper returns NoSNI enum
     #[test]
-    fn test_certificate_match_returns_exact_match() {
+    fn test_certificate_match_returns_no_sni_match() {
         let config = build_config(&security::DEFAULT_TLS13).expect("Failed to build config");
         let mut pair = TestPair::from_config(&config);
 
@@ -1665,5 +1665,22 @@ mod tests {
         let cert_match = pair.server.certificate_match().expect("Failed to get certificate match");
 
         assert_eq!(cert_match, CertSNIMatch::NoSNI);
+    }
+
+    /// Test that the `certificate_match` Rust wrapper returns ExactMatch enum
+    #[test]
+    fn test_certificate_match_returns_exact_match() {
+        let config = build_config(&security::DEFAULT_TLS13).expect("Failed to build config");
+        let mut pair = TestPair::from_config(&config);
+
+        // Use an SNI that matches the certificate
+        pair.client.set_server_name("127.0.0.1").expect("Failed to set SNI");
+
+        pair.handshake().expect("Handshake failed");
+
+        let cert_match = pair.server.certificate_match().expect("Failed to get certificate match");
+        dbg!(&cert_match);
+
+        assert_eq!(cert_match, CertSNIMatch::ExactMatch);
     }
 }

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -168,22 +168,6 @@ impl Connection {
         self.context().mode
     }
 
-    /// This method safely wraps the C function and returns the certificate match result
-    /// (e.g., Exact, Wildcard, or No Match) as a Rust enum.
-    /// Corresponds to [s2n_connection_get_certificate_match].
-    pub fn certificate_match(&self) -> Result<CertSNIMatch, Error> {
-        // Create a mutable variable to store the output value from the C function.
-        // We initialize it to a default (NO_MATCH), but the C function will overwrite it.
-        let mut version = s2n_cert_sni_match::SNI_NO_MATCH;
-
-        // Call the raw C function via FFI.
-        // It takes a raw pointer to the connection, and a pointer to where the match result should go.
-        unsafe { s2n_connection_get_certificate_match(self.connection.as_ptr(), &mut version) }
-            .into_result()?; // handles error conversion
-
-            version.try_into()
-    }
-
     /// can be used to configure s2n to either use built-in blinding (set blinding
     /// to Blinding::BuiltIn) or self-service blinding (set blinding to
     /// Blinding::SelfService).
@@ -1157,6 +1141,23 @@ impl Connection {
                 .into_result()?;
         }
         hash_alg.try_into()
+    }
+
+    /// This method safely wraps the C function and returns the certificate match result
+    /// (e.g., Exact, Wildcard, or No Match) as a Rust enum.
+    /// Corresponds to [s2n_connection_get_certificate_match].
+    pub fn certificate_match(&self) -> Result<CertSNIMatch, Error> {
+        // Create a mutable variable to store the output value from the C function.
+        // We initialize it to a default (NO_MATCH), but the C function will overwrite it.
+        let mut version = s2n_cert_sni_match::SNI_NO_MATCH;
+
+        // Call the raw C function via FFI.
+        // It takes a raw pointer to the connection, and a pointer to where the match result should go.
+        unsafe {
+            s2n_connection_get_certificate_match(self.connection.as_ptr(), &mut version)
+                .into_result()?;
+        }
+        version.try_into()
     }
 
     /// Corresponds to [s2n_connection_get_selected_client_cert_signature_algorithm].

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -1654,4 +1654,16 @@ mod tests {
 
         assert_eq!(cert_match, CertSNIMatch::NoMatch);
     }
+
+    /// Test that the `certificate_match` Rust wrapper returns NoSNI
+    #[test]
+    fn test_certificate_match_returns_exact_match() {
+        let config = build_config(&security::DEFAULT_TLS13).expect("Failed to build config");
+        let mut pair = TestPair::from_config(&config);
+
+        pair.handshake().expect("Handshake failed");
+        let cert_match = pair.server.certificate_match().expect("Failed to get certificate match");
+
+        assert_eq!(cert_match, CertSNIMatch::NoSNI);
+    }
 }

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -13,7 +13,6 @@ use crate::{
     error::{Error, Fallible, Pollable},
     psk::Psk,
     security,
-    testing::{build_config, SniTestCerts, TestPair},
 };
 
 use core::{
@@ -1579,6 +1578,7 @@ impl Drop for Connection {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testing::{build_config, SniTestCerts, TestPair};
 
     // ensure the connection context is send
     #[test]

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -1672,15 +1672,11 @@ mod tests {
     /// Test that `certificate_match` executes safely and returns a result.
     #[test]
     fn test_certificate_match_executes_safely() {
-        use crate::config::Config;
-
         let config = Config::new();
-        let mut connection = Connection::new_client();
+        let mut connection = Connection::new_server();
         connection.set_config(config).unwrap();
 
         let result = connection.certificate_match();
-
-        // Just make sure it runs and returns something
         assert!(result.is_ok() || result.is_err());
     }
 }

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -1143,16 +1143,9 @@ impl Connection {
         hash_alg.try_into()
     }
 
-    /// This method safely wraps the C function and returns the certificate match result
-    /// (e.g., Exact, Wildcard, or No Match) as a Rust enum.
     /// Corresponds to [s2n_connection_get_certificate_match].
     pub fn certificate_match(&self) -> Result<CertSNIMatch, Error> {
-        // Create a mutable variable to store the output value from the C function.
-        // We initialize it to a default (NO_MATCH), but the C function will overwrite it.
         let mut version = s2n_cert_sni_match::SNI_NO_MATCH;
-
-        // Call the raw C function via FFI.
-        // It takes a raw pointer to the connection, and a pointer to where the match result should go.
         unsafe {
             s2n_connection_get_certificate_match(self.connection.as_ptr(), &mut version)
                 .into_result()?;

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -1684,8 +1684,6 @@ mod tests {
 
             assert_eq!(
                 cert_match, expected,
-                "Expected {:?}, got {:?} (SNI: {:?})",
-                expected, cert_match, sni_opt
             );
         }
 

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -199,10 +199,8 @@ impl Connection {
 
         // Call the raw C function via FFI.
         // It takes a raw pointer to the connection, and a pointer to where the match result should go.
-        unsafe {
-            s2n_connection_get_certificate_match(self.connection.as_ptr(), &mut match_type)
-        }
-        .into_result()?; // handles error conversion
+        unsafe { s2n_connection_get_certificate_match(self.connection.as_ptr(), &mut match_type) }
+            .into_result()?; // handles error conversion
 
         Ok(CertSNIMatch::from(match_type))
     }

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -195,7 +195,7 @@ impl Connection {
     pub fn certificate_match(&self) -> Result<CertSNIMatch, Error> {
         // Create a mutable variable to store the output value from the C function.
         // We initialize it to a default (NO_MATCH), but the C function will overwrite it.
-        let mut match_type = s2n_cert_sni_match::SNI_NO_MATCH;
+        let mut match = s2n_cert_sni_match::SNI_NO_MATCH;
 
         // Call the raw C function via FFI.
         // It takes a raw pointer to the connection, and a pointer to where the match result should go.

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -1647,7 +1647,7 @@ mod tests {
         let config = build_config(&security::DEFAULT_TLS13).expect("Failed to build config");
         let mut pair = TestPair::from_config(&config);
 
-        pair.client.set_server_name("localhost").expect("Failed to set SNI");
+        pair.client.set_server_name("nonmatching_sni").expect("Failed to set SNI");
 
         pair.handshake().expect("Handshake failed");
         let cert_match = pair.server.certificate_match().expect("Failed to get certificate match");

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -1165,12 +1165,12 @@ impl Connection {
 
     /// Corresponds to [s2n_connection_get_certificate_match].
     pub fn certificate_match(&self) -> Result<CertSNIMatch, Error> {
-        let mut version = s2n_cert_sni_match::SNI_NO_MATCH;
+        let mut cert_match = s2n_cert_sni_match::SNI_NO_MATCH;
         unsafe {
-            s2n_connection_get_certificate_match(self.connection.as_ptr(), &mut version)
+            s2n_connection_get_certificate_match(self.connection.as_ptr(), &mut cert_match)
                 .into_result()?;
         }
-        version.try_into()
+        cert_match.try_into()
     }
 
     /// Corresponds to [s2n_connection_get_selected_client_cert_signature_algorithm].

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -60,27 +60,6 @@ pub struct Connection {
     connection: NonNull<s2n_connection>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CertSNIMatch {
-    None,
-    ExactMatch,
-    WildcardMatch,
-    NoMatch,
-    Unknown(i32),
-}
-
-impl From<u32> for CertSNIMatch {
-    fn from(value: u32) -> Self {
-        match value {
-            s2n_cert_sni_match::SNI_NONE => CertSNIMatch::None,
-            s2n_cert_sni_match::SNI_EXACT_MATCH => CertSNIMatch::ExactMatch,
-            s2n_cert_sni_match::SNI_WILDCARD_MATCH => CertSNIMatch::WildcardMatch,
-            s2n_cert_sni_match::SNI_NO_MATCH => CertSNIMatch::NoMatch,
-            other => CertSNIMatch::Unknown(other as i32),
-        }
-    }
-}
-
 impl fmt::Debug for Connection {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut debug = f.debug_struct("Connection");
@@ -195,14 +174,14 @@ impl Connection {
     pub fn certificate_match(&self) -> Result<CertSNIMatch, Error> {
         // Create a mutable variable to store the output value from the C function.
         // We initialize it to a default (NO_MATCH), but the C function will overwrite it.
-        let mut match = s2n_cert_sni_match::SNI_NO_MATCH;
+        let mut version = s2n_cert_sni_match::SNI_NO_MATCH;
 
         // Call the raw C function via FFI.
         // It takes a raw pointer to the connection, and a pointer to where the match result should go.
-        unsafe { s2n_connection_get_certificate_match(self.connection.as_ptr(), &mut match_type) }
+        unsafe { s2n_connection_get_certificate_match(self.connection.as_ptr(), &mut version) }
             .into_result()?; // handles error conversion
 
-        Ok(CertSNIMatch::from(match_type))
+            version.try_into()
     }
 
     /// can be used to configure s2n to either use built-in blinding (set blinding

--- a/bindings/rust/extended/s2n-tls/src/enums.rs
+++ b/bindings/rust/extended/s2n-tls/src/enums.rs
@@ -105,6 +105,30 @@ impl TryFrom<s2n_tls_version::Type> for Version {
 
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Copy, Clone)]
+pub enum CertSNIMatch {
+    None,
+    ExactMatch,
+    WildcardMatch,
+    NoMatch,
+    Unknown(i32),
+}
+
+impl TryFrom<u32> for CertSNIMatch {
+    type Error = Error;
+    fn try_from(input: u32) -> Result<Self, Self::Error> {
+        let version = match input {
+            s2n_cert_sni_match::SNI_NONE => Self::None,
+            s2n_cert_sni_match::SNI_EXACT_MATCH => Self::ExactMatch,
+            s2n_cert_sni_match::SNI_WILDCARD_MATCH => Self::WildcardMatch,
+            s2n_cert_sni_match::SNI_NO_MATCH => Self::NoMatch,
+            _ => return Err(Error::INVALID_INPUT),
+        };
+        Ok(version)
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, PartialEq, Copy, Clone)]
 /// Corresponds to [s2n_blinding].
 pub enum Blinding {
     SelfService,

--- a/bindings/rust/extended/s2n-tls/src/enums.rs
+++ b/bindings/rust/extended/s2n-tls/src/enums.rs
@@ -116,14 +116,14 @@ pub enum CertSNIMatch {
 impl TryFrom<s2n_cert_sni_match::Type> for CertSNIMatch {
     type Error = Error;
     fn try_from(input: s2n_cert_sni_match::Type) -> Result<Self, Self::Error> {
-        let version = match input {
+        let match_type = match input {
             s2n_cert_sni_match::SNI_NONE => Self::NoSNI,
             s2n_cert_sni_match::SNI_EXACT_MATCH => Self::ExactMatch,
             s2n_cert_sni_match::SNI_WILDCARD_MATCH => Self::WildcardMatch,
             s2n_cert_sni_match::SNI_NO_MATCH => Self::NoMatch,
             _ => return Err(Error::INVALID_INPUT),
         };
-        Ok(version)
+        Ok(match_type)
     }
 }
 

--- a/bindings/rust/extended/s2n-tls/src/enums.rs
+++ b/bindings/rust/extended/s2n-tls/src/enums.rs
@@ -112,7 +112,7 @@ pub enum CertSNIMatch {
     NoMatch,
 }
 
-impl TryFrom<u32> for CertSNIMatch {
+impl TryFrom<s2n_cert_sni_match::Type> for CertSNIMatch {
     type Error = Error;
     fn try_from(input: s2n_cert_sni_match::Type) -> Result<Self, Self::Error> {
         let version = match input {

--- a/bindings/rust/extended/s2n-tls/src/enums.rs
+++ b/bindings/rust/extended/s2n-tls/src/enums.rs
@@ -115,7 +115,7 @@ pub enum CertSNIMatch {
 
 impl TryFrom<u32> for CertSNIMatch {
     type Error = Error;
-    fn try_from(input: u32) -> Result<Self, Self::Error> {
+    fn try_from(input: s2n_cert_sni_match::Type) -> Result<Self, Self::Error> {
         let version = match input {
             s2n_cert_sni_match::SNI_NONE => Self::None,
             s2n_cert_sni_match::SNI_EXACT_MATCH => Self::ExactMatch,

--- a/bindings/rust/extended/s2n-tls/src/enums.rs
+++ b/bindings/rust/extended/s2n-tls/src/enums.rs
@@ -110,7 +110,6 @@ pub enum CertSNIMatch {
     ExactMatch,
     WildcardMatch,
     NoMatch,
-    Unknown(i32),
 }
 
 impl TryFrom<u32> for CertSNIMatch {

--- a/bindings/rust/extended/s2n-tls/src/enums.rs
+++ b/bindings/rust/extended/s2n-tls/src/enums.rs
@@ -106,7 +106,7 @@ impl TryFrom<s2n_tls_version::Type> for Version {
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum CertSNIMatch {
-    None,
+    NoSNI,
     ExactMatch,
     WildcardMatch,
     NoMatch,
@@ -116,7 +116,7 @@ impl TryFrom<u32> for CertSNIMatch {
     type Error = Error;
     fn try_from(input: s2n_cert_sni_match::Type) -> Result<Self, Self::Error> {
         let version = match input {
-            s2n_cert_sni_match::SNI_NONE => Self::None,
+            s2n_cert_sni_match::SNI_NONE => Self::NoSNI,
             s2n_cert_sni_match::SNI_EXACT_MATCH => Self::ExactMatch,
             s2n_cert_sni_match::SNI_WILDCARD_MATCH => Self::WildcardMatch,
             s2n_cert_sni_match::SNI_NO_MATCH => Self::NoMatch,

--- a/bindings/rust/extended/s2n-tls/src/enums.rs
+++ b/bindings/rust/extended/s2n-tls/src/enums.rs
@@ -106,6 +106,7 @@ impl TryFrom<s2n_tls_version::Type> for Version {
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum CertSNIMatch {
+    /// The client did not supply an SNI
     NoSNI,
     ExactMatch,
     WildcardMatch,

--- a/bindings/rust/extended/s2n-tls/src/testing.rs
+++ b/bindings/rust/extended/s2n-tls/src/testing.rs
@@ -67,6 +67,7 @@ pub enum SniTestCerts {
     AlligatorRsa,
     AlligatorEcdsa,
     BeaverRsa,
+    WildcardInsectRsa,
 }
 
 impl SniTestCerts {
@@ -75,6 +76,7 @@ impl SniTestCerts {
             SniTestCerts::AlligatorRsa => "alligator_",
             SniTestCerts::AlligatorEcdsa => "alligator_ecdsa_",
             SniTestCerts::BeaverRsa => "beaver_",
+            SniTestCerts::WildcardInsectRsa => "wildcard_insect_rsa_",
         };
         CertKeyPair::from_path(&format!("sni/{prefix}"), "cert", "key", "cert")
     }


### PR DESCRIPTION
### Resolved issues:

resolves #5185

### Description of changes: 

Adds a safe Rust wrapper method, `Connection::certificate_match()`, to expose the `s2n_connection_get_certificate_match` C API. Previously, this functionality was only accessible through the low-level FFI 

### Testing:
Added four unit tests to validate the behavior of the certificate_match Rust wrapper and ensure it correctly reflects the results of the underlying s2n_connection_get_certificate_match C API:

* `test_certificate_match_returns_exact_match`: Verifies ExactMatch is returned when the client's SNI exactly matches the certificate.

* `test_certificate_match_returns_wildcard_match`: Verifies WildcardMatch is returned when the SNI matches a wildcard domain in the certificate. (format - *.insect.hexapod)

* `test_certificate_match_returns_no_sni_match`: Verifies NoSNI is returned when the client does not send an SNI.

* `test_certificate_match_returns_no_match`: Verifies NoMatch is returned when the SNI does not match any certificate.

These tests provide coverage for all possible enum outcomes and ensure correct integration with the C layer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
