### PR TITLE
refactor: implement match the same for all pkeys

### DIFF
--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -135,32 +135,6 @@ static int s2n_ecdsa_verify(const struct s2n_pkey *pub, s2n_signature_algorithm 
     return 0;
 }
 
-static int s2n_ecdsa_keys_match(const struct s2n_pkey *pub, const struct s2n_pkey *priv)
-{
-    uint8_t input[16] = { 1 };
-    DEFER_CLEANUP(struct s2n_blob signature = { 0 }, s2n_free);
-    DEFER_CLEANUP(struct s2n_hash_state state_in = { 0 }, s2n_hash_free);
-    DEFER_CLEANUP(struct s2n_hash_state state_out = { 0 }, s2n_hash_free);
-
-    /* s2n_hash_new only allocates memory when using high-level EVP hashes, currently restricted to FIPS mode. */
-    POSIX_GUARD(s2n_hash_new(&state_in));
-    POSIX_GUARD(s2n_hash_new(&state_out));
-
-    POSIX_GUARD(s2n_hash_init(&state_in, S2N_HASH_SHA1));
-    POSIX_GUARD(s2n_hash_init(&state_out, S2N_HASH_SHA1));
-    POSIX_GUARD(s2n_hash_update(&state_in, input, sizeof(input)));
-    POSIX_GUARD(s2n_hash_update(&state_out, input, sizeof(input)));
-
-    uint32_t size = 0;
-    POSIX_GUARD_RESULT(s2n_ecdsa_der_signature_size(priv, &size));
-    POSIX_GUARD(s2n_alloc(&signature, size));
-
-    POSIX_GUARD(s2n_ecdsa_sign(priv, S2N_SIGNATURE_ECDSA, &state_in, &signature));
-    POSIX_GUARD(s2n_ecdsa_verify(pub, S2N_SIGNATURE_ECDSA, &state_out, &signature));
-
-    return 0;
-}
-
 static int s2n_ecdsa_key_free(struct s2n_pkey *pkey)
 {
     POSIX_ENSURE_REF(pkey);
@@ -208,7 +182,6 @@ S2N_RESULT s2n_ecdsa_pkey_init(struct s2n_pkey *pkey)
     pkey->verify = &s2n_ecdsa_verify;
     pkey->encrypt = NULL; /* No function for encryption */
     pkey->decrypt = NULL; /* No function for decryption */
-    pkey->match = &s2n_ecdsa_keys_match;
     pkey->free = &s2n_ecdsa_key_free;
     pkey->check_key = &s2n_ecdsa_check_key_exists;
     RESULT_GUARD(s2n_evp_signing_set_pkey_overrides(pkey));

--- a/crypto/s2n_pkey.h
+++ b/crypto/s2n_pkey.h
@@ -50,7 +50,6 @@ struct s2n_pkey {
             struct s2n_hash_state *digest, struct s2n_blob *signature);
     int (*encrypt)(const struct s2n_pkey *key, struct s2n_blob *in, struct s2n_blob *out);
     int (*decrypt)(const struct s2n_pkey *key, struct s2n_blob *in, struct s2n_blob *out);
-    int (*match)(const struct s2n_pkey *pub_key, const struct s2n_pkey *priv_key);
     int (*free)(struct s2n_pkey *key);
     int (*check_key)(const struct s2n_pkey *key);
 };

--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -152,28 +152,6 @@ static int s2n_rsa_decrypt(const struct s2n_pkey *priv, struct s2n_blob *in, str
     return 0;
 }
 
-static int s2n_rsa_keys_match(const struct s2n_pkey *pub, const struct s2n_pkey *priv)
-{
-    uint8_t plain_inpad[36] = { 1 }, plain_outpad[36] = { 0 }, encpad[8192];
-    struct s2n_blob plain_in = { 0 }, plain_out = { 0 }, enc = { 0 };
-
-    plain_in.data = plain_inpad;
-    plain_in.size = sizeof(plain_inpad);
-
-    enc.data = encpad;
-    POSIX_GUARD_RESULT(s2n_rsa_encrypted_size(pub, &enc.size));
-    POSIX_ENSURE_LTE(enc.size, sizeof(encpad));
-    POSIX_GUARD(s2n_rsa_encrypt(pub, &plain_in, &enc));
-
-    plain_out.data = plain_outpad;
-    plain_out.size = sizeof(plain_outpad);
-    POSIX_GUARD(s2n_rsa_decrypt(priv, &enc, &plain_out));
-
-    POSIX_ENSURE(s2n_constant_time_equals(plain_in.data, plain_out.data, plain_in.size), S2N_ERR_KEY_MISMATCH);
-
-    return 0;
-}
-
 static int s2n_rsa_key_free(struct s2n_pkey *pkey)
 {
     POSIX_ENSURE_REF(pkey);
@@ -221,7 +199,6 @@ S2N_RESULT s2n_rsa_pkey_init(struct s2n_pkey *pkey)
     pkey->verify = &s2n_rsa_verify;
     pkey->encrypt = &s2n_rsa_encrypt;
     pkey->decrypt = &s2n_rsa_decrypt;
-    pkey->match = &s2n_rsa_keys_match;
     pkey->free = &s2n_rsa_key_free;
     pkey->check_key = &s2n_rsa_check_key_exists;
     RESULT_GUARD(s2n_evp_signing_set_pkey_overrides(pkey));

--- a/crypto/s2n_rsa_pss.c
+++ b/crypto/s2n_rsa_pss.c
@@ -88,89 +88,6 @@ int s2n_rsa_pss_key_verify(const struct s2n_pkey *pub, s2n_signature_algorithm s
     return s2n_rsa_pss_verify(pub, digest, signature_in);
 }
 
-static int s2n_rsa_pss_validate_sign_verify_match(const struct s2n_pkey *pub, const struct s2n_pkey *priv)
-{
-    /* Generate a random blob to sign and verify */
-    s2n_stack_blob(random_data, RSA_PSS_SIGN_VERIFY_RANDOM_BLOB_SIZE, RSA_PSS_SIGN_VERIFY_RANDOM_BLOB_SIZE);
-    POSIX_GUARD_RESULT(s2n_get_private_random_data(&random_data));
-
-    /* Sign/Verify API's only accept Hashes, so hash our Random Data */
-    DEFER_CLEANUP(struct s2n_hash_state sign_hash = { 0 }, s2n_hash_free);
-    DEFER_CLEANUP(struct s2n_hash_state verify_hash = { 0 }, s2n_hash_free);
-    POSIX_GUARD(s2n_hash_new(&sign_hash));
-    POSIX_GUARD(s2n_hash_new(&verify_hash));
-    POSIX_GUARD(s2n_hash_init(&sign_hash, S2N_HASH_SHA256));
-    POSIX_GUARD(s2n_hash_init(&verify_hash, S2N_HASH_SHA256));
-    POSIX_GUARD(s2n_hash_update(&sign_hash, random_data.data, random_data.size));
-    POSIX_GUARD(s2n_hash_update(&verify_hash, random_data.data, random_data.size));
-
-    /* Sign and Verify the Hash of the Random Blob */
-    s2n_stack_blob(signature_data, RSA_PSS_SIGN_VERIFY_SIGNATURE_SIZE, RSA_PSS_SIGN_VERIFY_SIGNATURE_SIZE);
-    POSIX_GUARD(s2n_pkey_sign(priv, S2N_SIGNATURE_RSA_PSS_PSS, &sign_hash, &signature_data));
-    POSIX_GUARD(s2n_pkey_verify(pub, S2N_SIGNATURE_RSA_PSS_PSS, &verify_hash, &signature_data));
-
-    return 0;
-}
-
-static int s2n_rsa_validate_params_equal(const RSA *pub, const RSA *priv)
-{
-    const BIGNUM *pub_val_e = NULL;
-    const BIGNUM *pub_val_n = NULL;
-    RSA_get0_key(pub, &pub_val_n, &pub_val_e, NULL);
-
-    const BIGNUM *priv_val_e = NULL;
-    const BIGNUM *priv_val_n = NULL;
-    RSA_get0_key(priv, &priv_val_n, &priv_val_e, NULL);
-
-    if (pub_val_e == NULL || priv_val_e == NULL) {
-        POSIX_BAIL(S2N_ERR_KEY_CHECK);
-    }
-
-    if (pub_val_n == NULL || priv_val_n == NULL) {
-        POSIX_BAIL(S2N_ERR_KEY_CHECK);
-    }
-
-    S2N_ERROR_IF(BN_cmp(pub_val_e, priv_val_e) != 0, S2N_ERR_KEY_MISMATCH);
-    S2N_ERROR_IF(BN_cmp(pub_val_n, priv_val_n) != 0, S2N_ERR_KEY_MISMATCH);
-
-    return 0;
-}
-
-static int s2n_rsa_validate_params_match(const struct s2n_pkey *pub, const struct s2n_pkey *priv)
-{
-    POSIX_ENSURE_REF(pub);
-    POSIX_ENSURE_REF(priv);
-
-    /* OpenSSL Documentation Links:
-     *  - https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_get1_RSA.html
-     *  - https://www.openssl.org/docs/manmaster/man3/RSA_get0_key.html
-     */
-    const RSA *pub_rsa_key = pub->key.rsa_key.rsa;
-    const RSA *priv_rsa_key = priv->key.rsa_key.rsa;
-
-    POSIX_ENSURE_REF(pub_rsa_key);
-    POSIX_ENSURE_REF(priv_rsa_key);
-
-    POSIX_GUARD(s2n_rsa_validate_params_equal(pub_rsa_key, priv_rsa_key));
-
-    return 0;
-}
-
-static int s2n_rsa_pss_keys_match(const struct s2n_pkey *pub, const struct s2n_pkey *priv)
-{
-    POSIX_ENSURE_REF(pub);
-    POSIX_ENSURE_REF(pub->pkey);
-    POSIX_ENSURE_REF(priv);
-    POSIX_ENSURE_REF(priv->pkey);
-
-    POSIX_GUARD(s2n_rsa_validate_params_match(pub, priv));
-
-    /* Validate that verify(sign(message)) for a random message is verified correctly */
-    POSIX_GUARD(s2n_rsa_pss_validate_sign_verify_match(pub, priv));
-
-    return 0;
-}
-
 static int s2n_rsa_pss_key_free(struct s2n_pkey *pkey)
 {
     POSIX_ENSURE_REF(pkey);
@@ -227,7 +144,6 @@ S2N_RESULT s2n_rsa_pss_pkey_init(struct s2n_pkey *pkey)
     pkey->encrypt = NULL; /* No function for encryption */
     pkey->decrypt = NULL; /* No function for decryption */
 
-    pkey->match = &s2n_rsa_pss_keys_match;
     pkey->free = &s2n_rsa_pss_key_free;
 
     RESULT_GUARD(s2n_evp_signing_set_pkey_overrides(pkey));

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -394,7 +394,6 @@ void cbmc_populate_s2n_pkey(struct s2n_pkey *s2n_pkey)
      * `s2n_pkey->verify`
      * `s2n_pkey->encrypt`
      * `s2n_pkey->decrypt`
-     * `s2n_pkey->match`
      * `s2n_pkey->free`
      * `s2n_pkey->check_key` are never allocated.
      * If required, these initializations should be done in the proof harness.

--- a/tests/unit/s2n_cert_chain_and_key_load_test.c
+++ b/tests/unit/s2n_cert_chain_and_key_load_test.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "crypto/s2n_rsa_pss.h"
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+    EXPECT_SUCCESS(s2n_disable_tls13_in_test());
+
+    /* Test each combination of s2n_pkey_types to validate that only keys of
+     * the same type can be compared */
+    {
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
+        char rsa_cert_chain_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+        char rsa_pss_cert_chain_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+        char ecdsa_cert_chain_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+        char rsa_private_key_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+        char rsa_pss_private_key_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+        char ecdsa_private_key_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_RSA_2048_PKCS1_CERT_CHAIN, rsa_cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_RSA_PSS_2048_SHA256_CA_CERT, rsa_pss_cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_CERT_CHAIN, ecdsa_cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_RSA_2048_PKCS1_KEY, rsa_private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_RSA_PSS_2048_SHA256_CA_KEY, rsa_pss_private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem(S2N_ECDSA_P384_PKCS1_KEY, ecdsa_private_key_pem, S2N_MAX_TEST_PEM_SIZE));
+
+        /* Keys of the same type can be compared */
+        EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, rsa_cert_chain_pem, rsa_private_key_pem));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+
+        if (s2n_is_rsa_pss_certs_supported()) {
+            EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+            EXPECT_SUCCESS(
+                    s2n_cert_chain_and_key_load_pem(chain_and_key, rsa_pss_cert_chain_pem, rsa_pss_private_key_pem));
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        }
+
+        EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, ecdsa_cert_chain_pem, ecdsa_private_key_pem));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+
+        /* Keys of different types cannot be compared */
+        EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+        EXPECT_FAILURE_WITH_ERRNO(s2n_cert_chain_and_key_load_pem(chain_and_key, rsa_cert_chain_pem, ecdsa_private_key_pem),
+                S2N_ERR_KEY_MISMATCH);
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+
+        EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+        EXPECT_FAILURE_WITH_ERRNO(s2n_cert_chain_and_key_load_pem(chain_and_key, ecdsa_cert_chain_pem, rsa_private_key_pem),
+                S2N_ERR_KEY_MISMATCH);
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+
+        if (s2n_is_rsa_pss_certs_supported()) {
+            EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+            EXPECT_FAILURE_WITH_ERRNO(
+                    s2n_cert_chain_and_key_load_pem(chain_and_key, rsa_cert_chain_pem, rsa_pss_private_key_pem),
+                    S2N_ERR_KEY_MISMATCH);
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+
+            EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_chain_and_key_load_pem(chain_and_key, rsa_pss_cert_chain_pem, rsa_private_key_pem),
+                    S2N_ERR_KEY_MISMATCH);
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+
+            EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_chain_and_key_load_pem(chain_and_key, rsa_pss_cert_chain_pem, ecdsa_private_key_pem),
+                    S2N_ERR_KEY_MISMATCH);
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+
+            EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_chain_and_key_load_pem(chain_and_key, ecdsa_cert_chain_pem, rsa_pss_private_key_pem),
+                    S2N_ERR_KEY_MISMATCH);
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        }
+    };
+
+    /* Test the same as above but with non null terminated chain and key and
+     * api that accepts length  */
+    {
+        struct s2n_cert_chain_and_key *chain_and_key = NULL;
+        uint8_t rsa_cert_chain_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+        uint8_t rsa_pss_cert_chain_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+        uint8_t ecdsa_cert_chain_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+        uint8_t rsa_private_key_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+        uint8_t rsa_pss_private_key_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+        uint8_t ecdsa_private_key_pem[S2N_MAX_TEST_PEM_SIZE] = { 0 };
+
+        uint32_t rsa_cert_chain_len = 0;
+        uint32_t rsa_pss_cert_chain_len = 0;
+        uint32_t ecdsa_cert_chain_len = 0;
+        uint32_t rsa_private_key_len = 0;
+        uint32_t rsa_pss_private_key_len = 0;
+        uint32_t ecdsa_private_key_len = 0;
+
+        EXPECT_SUCCESS(s2n_read_test_pem_and_len(S2N_RSA_2048_PKCS1_CERT_CHAIN, rsa_cert_chain_pem, &rsa_cert_chain_len, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem_and_len(S2N_RSA_PSS_2048_SHA256_CA_CERT, rsa_pss_cert_chain_pem, &rsa_pss_cert_chain_len, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem_and_len(S2N_ECDSA_P384_PKCS1_CERT_CHAIN, ecdsa_cert_chain_pem, &ecdsa_cert_chain_len, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem_and_len(S2N_RSA_2048_PKCS1_KEY, rsa_private_key_pem, &rsa_private_key_len, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem_and_len(S2N_RSA_PSS_2048_SHA256_CA_KEY, rsa_pss_private_key_pem, &rsa_pss_private_key_len, S2N_MAX_TEST_PEM_SIZE));
+        EXPECT_SUCCESS(s2n_read_test_pem_and_len(S2N_ECDSA_P384_PKCS1_KEY, ecdsa_private_key_pem, &ecdsa_private_key_len, S2N_MAX_TEST_PEM_SIZE));
+
+        /* Keys of the same type can be compared */
+        EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem_bytes(chain_and_key, rsa_cert_chain_pem, rsa_cert_chain_len, rsa_private_key_pem, rsa_private_key_len));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+
+        if (s2n_is_rsa_pss_certs_supported()) {
+            EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+            EXPECT_SUCCESS(
+                    s2n_cert_chain_and_key_load_pem_bytes(chain_and_key, rsa_pss_cert_chain_pem, rsa_pss_cert_chain_len, rsa_pss_private_key_pem, rsa_pss_private_key_len));
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        }
+
+        EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem_bytes(chain_and_key, ecdsa_cert_chain_pem, ecdsa_cert_chain_len, ecdsa_private_key_pem, ecdsa_private_key_len));
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+
+        /* Keys of different types cannot be compared */
+        EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+        EXPECT_FAILURE_WITH_ERRNO(s2n_cert_chain_and_key_load_pem_bytes(chain_and_key, rsa_cert_chain_pem, rsa_cert_chain_len, ecdsa_private_key_pem, ecdsa_private_key_len),
+                S2N_ERR_KEY_MISMATCH);
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+
+        EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+        EXPECT_FAILURE_WITH_ERRNO(s2n_cert_chain_and_key_load_pem_bytes(chain_and_key, ecdsa_cert_chain_pem, ecdsa_cert_chain_len, rsa_private_key_pem, rsa_private_key_len),
+                S2N_ERR_KEY_MISMATCH);
+        EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+
+        if (s2n_is_rsa_pss_certs_supported()) {
+            EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+            EXPECT_FAILURE_WITH_ERRNO(
+                    s2n_cert_chain_and_key_load_pem_bytes(chain_and_key, rsa_cert_chain_pem, rsa_cert_chain_len, rsa_pss_private_key_pem, rsa_pss_private_key_len),
+                    S2N_ERR_KEY_MISMATCH);
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+
+            EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_chain_and_key_load_pem_bytes(chain_and_key, rsa_pss_cert_chain_pem, rsa_pss_cert_chain_len, rsa_private_key_pem, rsa_private_key_len),
+                    S2N_ERR_KEY_MISMATCH);
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+
+            EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_chain_and_key_load_pem_bytes(chain_and_key, rsa_pss_cert_chain_pem, rsa_pss_cert_chain_len, ecdsa_private_key_pem, ecdsa_private_key_len),
+                    S2N_ERR_KEY_MISMATCH);
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+
+            EXPECT_NOT_NULL(chain_and_key = s2n_cert_chain_and_key_new());
+            EXPECT_FAILURE_WITH_ERRNO(s2n_cert_chain_and_key_load_pem_bytes(chain_and_key, ecdsa_cert_chain_pem, ecdsa_cert_chain_len, rsa_pss_private_key_pem, rsa_pss_private_key_len),
+                    S2N_ERR_KEY_MISMATCH);
+            EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
+        }
+    };
+
+    END_TEST();
+}

--- a/tests/unit/s2n_security_policy_cert_preferences_test.c
+++ b/tests/unit/s2n_security_policy_cert_preferences_test.c
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+#include "crypto/s2n_libcrypto.h"
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 #include "tls/s2n_certificate_keys.h"
@@ -310,8 +311,11 @@ int main(int argc, char **argv)
      * 
      * This test ensures that such a breaking change would be visible and
      * deliberate.
+     *
+     * Skip this test for openssl-3.0-fips, which does not support RSA 1024:
+     * https://github.com/aws/s2n-tls/issues/5200
      */
-    {
+    if (!s2n_libcrypto_is_openssl_fips()) {
         DEFER_CLEANUP(struct s2n_cert_chain_and_key *cert = NULL, s2n_cert_chain_and_key_ptr_free);
         /* use a very insecure cert that would not be included in any reasonable cert preferences */
         EXPECT_SUCCESS(s2n_test_cert_permutation_load_server_chain(&cert, "rsae", "pkcs", "1024", "sha1"));


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:
related to https://github.com/aws/s2n-tls/issues/5149

### Description of changes: 

Step one of cleaning up the legacy pkey logic: move the `match` method out of the individual pkey implementations and into the main shared logic. `match` should always be implemented the same, rather than each implementation re-writing the same sign/verify logic.

### Call-outs:

RSA-PSS was doing some additional validation, not just sign/verify. However, I don't believe that logic is necessary if we're going to sign/verify anyway. Seems unnecessary. But let me know if you think I'm missing something that makes it necessary / useful.

### Testing:
Added a new unit test. Future PRs will add more tests to the new s2n_pkey_test file.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
