### PR TITLE
refactor: add evp pkey size/encrypt/decrypt methods

### DIFF
--- a/crypto/s2n_ecdsa.c
+++ b/crypto/s2n_ecdsa.c
@@ -20,9 +20,9 @@
 #include <openssl/x509.h>
 
 #include "crypto/s2n_ecc_evp.h"
-#include "crypto/s2n_evp_signing.h"
 #include "crypto/s2n_hash.h"
 #include "crypto/s2n_pkey.h"
+#include "crypto/s2n_pkey_evp.h"
 #include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"
 #include "utils/s2n_blob.h"
@@ -184,7 +184,7 @@ S2N_RESULT s2n_ecdsa_pkey_init(struct s2n_pkey *pkey)
     pkey->decrypt = NULL; /* No function for decryption */
     pkey->free = &s2n_ecdsa_key_free;
     pkey->check_key = &s2n_ecdsa_check_key_exists;
-    RESULT_GUARD(s2n_evp_signing_set_pkey_overrides(pkey));
+    RESULT_GUARD(s2n_pkey_evp_set_overrides(pkey));
     return S2N_RESULT_OK;
 }
 

--- a/crypto/s2n_pkey_evp.c
+++ b/crypto/s2n_pkey_evp.c
@@ -272,6 +272,7 @@ S2N_RESULT s2n_pkey_evp_size(const struct s2n_pkey *pkey, uint32_t *size_out)
 {
     RESULT_ENSURE_REF(pkey);
     RESULT_ENSURE_REF(pkey->pkey);
+    RESULT_ENSURE_REF(size_out);
 
     const int size = EVP_PKEY_size(pkey->pkey);
     RESULT_ENSURE_GT(size, 0);

--- a/crypto/s2n_pkey_evp.c
+++ b/crypto/s2n_pkey_evp.c
@@ -274,7 +274,7 @@ S2N_RESULT s2n_pkey_evp_size(const struct s2n_pkey *pkey, uint32_t *size_out)
     RESULT_ENSURE_REF(pkey->pkey);
 
     const int size = EVP_PKEY_size(pkey->pkey);
-    RESULT_GUARD_POSIX(size);
+    RESULT_ENSURE_GT(size, 0);
     *size_out = size;
 
     return S2N_RESULT_OK;

--- a/crypto/s2n_pkey_evp.c
+++ b/crypto/s2n_pkey_evp.c
@@ -13,7 +13,10 @@
  * permissions and limitations under the License.
  */
 
-#include "crypto/s2n_evp_signing.h"
+#include "crypto/s2n_pkey_evp.h"
+
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
 
 #include "crypto/s2n_evp.h"
 #include "crypto/s2n_libcrypto.h"
@@ -21,6 +24,7 @@
 #include "crypto/s2n_rsa_pss.h"
 #include "error/s2n_errno.h"
 #include "tls/s2n_signature_algorithms.h"
+#include "utils/s2n_random.h"
 #include "utils/s2n_safety.h"
 
 DEFINE_POINTER_CLEANUP_FUNC(EVP_PKEY_CTX *, EVP_PKEY_CTX_free);
@@ -43,19 +47,6 @@ static S2N_RESULT s2n_evp_pkey_set_rsa_pss_saltlen(EVP_PKEY_CTX *pctx)
 #else
     RESULT_BAIL(S2N_ERR_RSA_PSS_NOT_SUPPORTED);
 #endif
-}
-
-/* Always use EVP signing.
- *
- * TODO: Migrate the rest of the s2n_pkey methods to EVP and delete the legacy
- * pkey logic and this method.
- */
-S2N_RESULT s2n_evp_signing_set_pkey_overrides(struct s2n_pkey *pkey)
-{
-    RESULT_ENSURE_REF(pkey);
-    pkey->sign = &s2n_evp_sign;
-    pkey->verify = &s2n_evp_verify;
-    return S2N_RESULT_OK;
 }
 
 static S2N_RESULT s2n_evp_signing_validate_sig_alg(const struct s2n_pkey *key, s2n_signature_algorithm sig_alg)
@@ -275,4 +266,91 @@ int s2n_evp_verify(const struct s2n_pkey *pub, s2n_signature_algorithm sig_alg,
     }
 
     return S2N_SUCCESS;
+}
+
+S2N_RESULT s2n_pkey_evp_size(const struct s2n_pkey *pkey, uint32_t *size_out)
+{
+    RESULT_ENSURE_REF(pkey);
+    RESULT_ENSURE_REF(pkey->pkey);
+
+    const int size = EVP_PKEY_size(pkey->pkey);
+    RESULT_GUARD_POSIX(size);
+    *size_out = size;
+
+    return S2N_RESULT_OK;
+}
+
+int s2n_pkey_evp_encrypt(const struct s2n_pkey *key, struct s2n_blob *in, struct s2n_blob *out)
+{
+    POSIX_ENSURE_REF(key);
+    POSIX_ENSURE_REF(in);
+    POSIX_ENSURE_REF(out);
+    POSIX_ENSURE_REF(key->pkey);
+
+    s2n_pkey_type type = 0;
+    POSIX_GUARD_RESULT(s2n_pkey_get_type(key->pkey, &type));
+    POSIX_ENSURE(type == S2N_PKEY_TYPE_RSA, S2N_ERR_UNIMPLEMENTED);
+
+    DEFER_CLEANUP(EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new(key->pkey, NULL), EVP_PKEY_CTX_free_pointer);
+    POSIX_ENSURE_REF(pctx);
+    POSIX_GUARD_OSSL(EVP_PKEY_encrypt_init(pctx), S2N_ERR_PKEY_CTX_INIT);
+    POSIX_GUARD_OSSL(EVP_PKEY_CTX_set_rsa_padding(pctx, RSA_PKCS1_PADDING), S2N_ERR_PKEY_CTX_INIT);
+
+    size_t out_size = out->size;
+    POSIX_GUARD_OSSL(EVP_PKEY_encrypt(pctx, out->data, &out_size, in->data, in->size), S2N_ERR_ENCRYPT);
+    POSIX_ENSURE(out_size == out->size, S2N_ERR_SIZE_MISMATCH);
+
+    return S2N_SUCCESS;
+}
+
+int s2n_pkey_evp_decrypt(const struct s2n_pkey *key, struct s2n_blob *in, struct s2n_blob *out)
+{
+    POSIX_ENSURE_REF(key);
+    POSIX_ENSURE_REF(in);
+    POSIX_ENSURE_REF(out);
+    POSIX_ENSURE_REF(key->pkey);
+
+    s2n_pkey_type type = 0;
+    POSIX_GUARD_RESULT(s2n_pkey_get_type(key->pkey, &type));
+    POSIX_ENSURE(type == S2N_PKEY_TYPE_RSA, S2N_ERR_UNIMPLEMENTED);
+
+    uint32_t expected_size = 0;
+    POSIX_GUARD_RESULT(s2n_pkey_size(key, &expected_size));
+
+    /* RSA decryption requires more output memory than the size of the final decrypted message */
+    struct s2n_blob buffer = { 0 };
+    uint8_t buffer_bytes[4096] = { 0 };
+    POSIX_GUARD(s2n_blob_init(&buffer, buffer_bytes, sizeof(buffer_bytes)));
+    POSIX_ENSURE(out->size <= buffer.size, S2N_ERR_NOMEM);
+    POSIX_ENSURE(expected_size <= buffer.size, S2N_ERR_NOMEM);
+
+    DEFER_CLEANUP(EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new(key->pkey, NULL), EVP_PKEY_CTX_free_pointer);
+    POSIX_ENSURE_REF(pctx);
+    POSIX_GUARD_OSSL(EVP_PKEY_decrypt_init(pctx), S2N_ERR_PKEY_CTX_INIT);
+    /* The padding is actually RSA_PKCS1_PADDING, but we'll handle the padding later */
+    POSIX_GUARD_OSSL(EVP_PKEY_CTX_set_rsa_padding(pctx, RSA_NO_PADDING), S2N_ERR_PKEY_CTX_INIT);
+
+    size_t out_size = buffer.size;
+    POSIX_GUARD_OSSL(EVP_PKEY_decrypt(pctx, buffer.data, &out_size, in->data, in->size), S2N_ERR_DECRYPT);
+    POSIX_ENSURE(out_size == expected_size, S2N_ERR_SIZE_MISMATCH);
+
+    /* Handle padding in constant time to avoid Bleichenbacher oracles.
+     * If the padding is wrong, we return random output rather than failing.
+     * That ensures that padding failures are treated the same as wrong outputs.
+     */
+    POSIX_GUARD_RESULT(s2n_get_public_random_data(out));
+    s2n_constant_time_pkcs1_unpad_or_dont(out->data, buffer.data, out_size, out->size);
+
+    return S2N_SUCCESS;
+}
+
+S2N_RESULT s2n_pkey_evp_set_overrides(struct s2n_pkey *pkey)
+{
+    RESULT_ENSURE_REF(pkey);
+    pkey->size = &s2n_pkey_evp_size;
+    pkey->sign = &s2n_evp_sign;
+    pkey->verify = &s2n_evp_verify;
+    pkey->encrypt = s2n_pkey_evp_encrypt;
+    pkey->decrypt = s2n_pkey_evp_decrypt;
+    return S2N_RESULT_OK;
 }

--- a/crypto/s2n_pkey_evp.h
+++ b/crypto/s2n_pkey_evp.h
@@ -20,7 +20,7 @@
 #include "crypto/s2n_signature.h"
 #include "utils/s2n_blob.h"
 
-S2N_RESULT s2n_evp_signing_set_pkey_overrides(struct s2n_pkey *pkey);
+S2N_RESULT s2n_pkey_evp_set_overrides(struct s2n_pkey *pkey);
 int s2n_evp_sign(const struct s2n_pkey *priv, s2n_signature_algorithm sig_alg,
         struct s2n_hash_state *digest, struct s2n_blob *signature);
 int s2n_evp_verify(const struct s2n_pkey *pub, s2n_signature_algorithm sig_alg,

--- a/crypto/s2n_rsa.c
+++ b/crypto/s2n_rsa.c
@@ -20,10 +20,10 @@
 #include <stdint.h>
 
 #include "crypto/s2n_drbg.h"
-#include "crypto/s2n_evp_signing.h"
 #include "crypto/s2n_hash.h"
 #include "crypto/s2n_openssl.h"
 #include "crypto/s2n_pkey.h"
+#include "crypto/s2n_pkey_evp.h"
 #include "crypto/s2n_rsa_signing.h"
 #include "error/s2n_errno.h"
 #include "stuffer/s2n_stuffer.h"
@@ -201,6 +201,6 @@ S2N_RESULT s2n_rsa_pkey_init(struct s2n_pkey *pkey)
     pkey->decrypt = &s2n_rsa_decrypt;
     pkey->free = &s2n_rsa_key_free;
     pkey->check_key = &s2n_rsa_check_key_exists;
-    RESULT_GUARD(s2n_evp_signing_set_pkey_overrides(pkey));
+    RESULT_GUARD(s2n_pkey_evp_set_overrides(pkey));
     return S2N_RESULT_OK;
 }

--- a/crypto/s2n_rsa_pss.c
+++ b/crypto/s2n_rsa_pss.c
@@ -19,9 +19,9 @@
 #include <openssl/rsa.h>
 #include <stdint.h>
 
-#include "crypto/s2n_evp_signing.h"
 #include "crypto/s2n_hash.h"
 #include "crypto/s2n_pkey.h"
+#include "crypto/s2n_pkey_evp.h"
 #include "crypto/s2n_rsa.h"
 #include "crypto/s2n_rsa_signing.h"
 #include "error/s2n_errno.h"
@@ -146,7 +146,7 @@ S2N_RESULT s2n_rsa_pss_pkey_init(struct s2n_pkey *pkey)
 
     pkey->free = &s2n_rsa_pss_key_free;
 
-    RESULT_GUARD(s2n_evp_signing_set_pkey_overrides(pkey));
+    RESULT_GUARD(s2n_pkey_evp_set_overrides(pkey));
     return S2N_RESULT_OK;
 }
 

--- a/tests/unit/s2n_evp_signing_test.c
+++ b/tests/unit/s2n_evp_signing_test.c
@@ -13,11 +13,10 @@
  * permissions and limitations under the License.
  */
 
-#include "crypto/s2n_evp_signing.h"
-
 #include "crypto/s2n_ecdsa.h"
 #include "crypto/s2n_fips.h"
 #include "crypto/s2n_libcrypto.h"
+#include "crypto/s2n_pkey_evp.h"
 #include "crypto/s2n_rsa_pss.h"
 #include "crypto/s2n_rsa_signing.h"
 #include "s2n_test.h"

--- a/tests/unit/s2n_pkey_test.c
+++ b/tests/unit/s2n_pkey_test.c
@@ -19,6 +19,12 @@
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 
+/* The rsa encrypt/decrypt methods are static.
+ * This is temporary, and will be removed when legacy rsa pkeys are removed.
+ * We do the same to test signing.
+ */
+#include "crypto/s2n_rsa.c"
+
 struct s2n_test_pkeys {
     struct s2n_pkey pub_key;
     struct s2n_pkey *priv_key;
@@ -121,6 +127,105 @@ int main(int argc, char **argv)
                         S2N_ERR_KEY_MISMATCH);
             }
         }
+    };
+
+    /* Test s2n_pkey_size */
+    {
+        /* Compare to known values */
+        uint32_t expected_sizes[] = { 104, 256, 256 };
+        EXPECT_EQUAL(s2n_array_len(test_pkeys), s2n_array_len(expected_sizes));
+
+        for (size_t i = 0; i < s2n_array_len(test_pkeys); i++) {
+            if (!test_pkeys[i].supported) {
+                continue;
+            }
+
+            uint32_t pub_size = 0;
+            EXPECT_OK(s2n_pkey_size(&test_pkeys[i].pub_key, &pub_size));
+            EXPECT_EQUAL(pub_size, expected_sizes[i]);
+
+            uint32_t priv_size = 0;
+            EXPECT_OK(s2n_pkey_size(test_pkeys[i].priv_key, &priv_size));
+            EXPECT_EQUAL(priv_size, expected_sizes[i]);
+        }
+    };
+
+    /* Test: s2n_pkey_encrypt / s2n_pkey_decrypt */
+    {
+        struct s2n_blob in = { 0 }, out = { 0 };
+
+        /* Test: not supported for ECDSA */
+        {
+            EXPECT_FAILURE_WITH_ERRNO(
+                    s2n_pkey_encrypt(ecdsa_pkeys.priv_key, &in, &out),
+                    S2N_ERR_UNIMPLEMENTED);
+            EXPECT_FAILURE_WITH_ERRNO(
+                    s2n_pkey_decrypt(&ecdsa_pkeys.pub_key, &in, &out),
+                    S2N_ERR_UNIMPLEMENTED);
+        };
+
+        /* Test: not supported for RSA-PSS */
+        if (rsa_pss_pkeys.supported) {
+            EXPECT_FAILURE_WITH_ERRNO(
+                    s2n_pkey_encrypt(rsa_pss_pkeys.priv_key, &in, &out),
+                    S2N_ERR_UNIMPLEMENTED);
+            EXPECT_FAILURE_WITH_ERRNO(
+                    s2n_pkey_decrypt(&rsa_pss_pkeys.pub_key, &in, &out),
+                    S2N_ERR_UNIMPLEMENTED);
+        };
+
+        /* Test: supported for RSA */
+        {
+            uint8_t message_bytes[] = "hello world";
+            struct s2n_blob message = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&message, message_bytes, sizeof(message_bytes)));
+
+            const char ciphertext_hex[] =
+                    "38 ab 9c 83 57 17 13 46 3d 5b 6f c6 44 30 8e 40 78 ac d2 "
+                    "c5 69 98 8b 99 51 14 23 c6 af 98 67 6f 58 d5 28 9e 23 12 "
+                    "6f 5b 73 56 d9 f9 b2 10 4f d6 53 5c 70 a5 a6 c6 a2 53 83 "
+                    "7d ec 3b 7c c0 ff 6a 30 8d 98 a3 6c be c6 e3 b4 4d b6 3d "
+                    "cc 94 67 f8 24 9a 91 13 52 57 02 0c d9 5a 00 98 1f ff df "
+                    "5e 47 e0 ca 15 87 f0 92 1e 95 af ef 49 b2 6b f2 b6 be d5 "
+                    "3b 65 d3 94 92 f5 c1 f0 65 56 20 85 7f 18 95 a5 d9 e7 6c "
+                    "43 07 dd 5d 03 60 ac 4d c5 a0 c8 3d f9 99 24 fc 30 8f c2 "
+                    "66 9d df 5c 80 90 a7 c5 7a 37 ee be 1d 30 a7 a3 67 73 ae "
+                    "7d ee 64 37 22 77 9a a5 0d 47 f0 a5 50 ee 85 82 2e 88 32 "
+                    "e9 0b bc 25 5f 09 b7 d3 13 58 88 84 9d 07 03 5e 37 6b af "
+                    "08 56 14 fd 64 58 29 5b 81 a5 72 72 62 5d c1 72 bb 13 76 "
+                    "b6 17 96 7b d9 87 ec 49 71 dc 33 3e b2 f5 76 54 ad 13 ed "
+                    "23 1c 34 53 d1 12 03 be f6";
+            S2N_BLOB_FROM_HEX(ciphertext, ciphertext_hex);
+
+            /* Test: legacy RSA decryption accepts known good value */
+            {
+                DEFER_CLEANUP(struct s2n_blob output = { 0 }, s2n_free);
+                EXPECT_SUCCESS(s2n_alloc(&output, message.size));
+
+                EXPECT_SUCCESS(s2n_rsa_decrypt(rsa_pkeys.priv_key, &ciphertext, &output));
+                EXPECT_BYTEARRAY_EQUAL(output.data, message.data, message.size);
+            };
+
+            /* Test: decryption works for known good value */
+            {
+                DEFER_CLEANUP(struct s2n_blob output = { 0 }, s2n_free);
+                EXPECT_SUCCESS(s2n_alloc(&output, message.size));
+
+                EXPECT_SUCCESS(s2n_pkey_decrypt(rsa_pkeys.priv_key, &ciphertext, &output));
+                EXPECT_BYTEARRAY_EQUAL(output.data, message.data, message.size);
+            };
+
+            /* Test: decryption works for result of encryption */
+            {
+                DEFER_CLEANUP(struct s2n_blob encrypt_out = { 0 }, s2n_free);
+                EXPECT_SUCCESS(s2n_alloc(&encrypt_out, ciphertext.size));
+                EXPECT_SUCCESS(s2n_pkey_encrypt(&rsa_pkeys.pub_key, &message, &encrypt_out));
+
+                DEFER_CLEANUP(struct s2n_blob decrypt_out = { 0 }, s2n_free);
+                EXPECT_SUCCESS(s2n_alloc(&decrypt_out, message.size));
+                EXPECT_SUCCESS(s2n_pkey_decrypt(rsa_pkeys.priv_key, &encrypt_out, &decrypt_out));
+            };
+        };
     };
 
     END_TEST();

--- a/tests/unit/s2n_pkey_test.c
+++ b/tests/unit/s2n_pkey_test.c
@@ -224,6 +224,7 @@ int main(int argc, char **argv)
                 DEFER_CLEANUP(struct s2n_blob decrypt_out = { 0 }, s2n_free);
                 EXPECT_SUCCESS(s2n_alloc(&decrypt_out, message.size));
                 EXPECT_SUCCESS(s2n_pkey_decrypt(rsa_pkeys.priv_key, &encrypt_out, &decrypt_out));
+                EXPECT_BYTEARRAY_EQUAL(decrypt_out.data, message.data, message.size);
             };
 
             /* Test: decryption does not fail for invalid ciphertexts


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

related to https://github.com/aws/s2n-tls/issues/5149

### Description of changes: 

Step two of cleaning up the legacy pkey logic: add the remaining missing pkey methods to our evp implementation. That means size, encrypt, and decrypt.

### Call-outs:
I know the override logic is a little silly at this point, but I'm trying to limit the renames / moves / unimportant noise in this PR so that reviewers can focus on the more important cryptography-related code. The next PR will cleanup all the structural mess.

### Testing:

I added new pkey tests. Rather than implement them specifically for evp pkey, I think it makes more sense for them to (admittedly theoretically at this point, given the evp overrides) work for any pkey implementation. I plan to switch the s2n_evp_signing_test over to a similar model (and rename it to s2n_pkey_signing_test) in a later PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
