### PR TITLE
Revert "ci: exclude new setuptools (#5215)"

### DIFF
--- a/tests/integrationv2/pyproject.toml
+++ b/tests/integrationv2/pyproject.toml
@@ -12,10 +12,3 @@ dependencies = [
     "ruff>=0.9.7",
     "sslyze>=6.1.0",
 ]
-
-# setuptools made a breaking change in setup file validation: https://github.com/pypa/setuptools/blob/main/NEWS.rst#deprecations-and-removals
-# This is affecting tls_parser, a dependency of sslyze: https://github.com/nabla-c0d3/tls_parser/pull/11
-# We use `exclude-newer` to temporarily workaround this issue, as suggested by
-# uv: https://github.com/astral-sh/uv/issues/12440
-[tool.uv]
-exclude-newer = "2025-03-24T00:00:00Z"


### PR DESCRIPTION
This reverts commit 87ef3eb2dfd753546e91d1b8d3448bc2881af702.

### Resolved issues:

#5216 

### Description of changes: 

We no longer have to pin, as setuptools reverted the breaking enforcement, so we are good to unpin until 2026 🫠 

> Postponed removals of deprecated dash-separated and uppercase fields in setup.cfg. All packages with deprecated configurations are advised to move before 2026.
> https://setuptools.pypa.io/en/stable/history.html#bugfixes

### Testing:

CI should pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
