### PR TITLE
feat: Expose `as_ptr()` for external build

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -20,6 +20,8 @@ env:
   STANDARD_PATH: bindings/rust/standard
   EXAMPLE_WORKSPACE: bindings/rust-examples
   PCAP_TEST_PATH: tests/pcap
+  # The name of a s2n-tls test gated behind the external build cfg flag.
+  EXTERNAL_BUILD_TEST_NAME: test_unstable_as_ptr
 
 jobs:
   generate:
@@ -75,6 +77,17 @@ jobs:
         # invoked on the `cargo test --all-features` pattern.
         run: RUST_LOG=TRACE cargo test --no-default-features --features pq
 
+      - name: Test external build cfg
+        working-directory: ${{env.ROOT_PATH}}/s2n-tls
+        run: |
+          echo "Using the external build feature should set a cfg flag in s2n-tls. Ensure that"
+          echo "this flag is NOT set when the external build feature isn't used. The"
+          echo "${{env.EXTERNAL_BUILD_TEST_NAME}} test is gated behind this flag, so ensure this test"
+          echo "is NOT run."
+          output=$(cargo test ${{env.EXTERNAL_BUILD_TEST_NAME}})
+          echo "${output}"
+          echo "${output}" | grep -q "test result: ok. 0 passed; 0 failed; 0 ignored;"
+
   external-build-test:
     runs-on: ubuntu-latest
     steps:
@@ -112,8 +125,6 @@ jobs:
         # means that if the linker can't resolve foo_method in tls/foo.c, you
         # forgot to include api/unstable/foo.h in tls/foo.c
         run: |
-          set -e
-
           cmake . -Bbuild \
             -DBUILD_SHARED_LIBS=on \
             -DBUILD_TESTING=off \
@@ -137,8 +148,10 @@ jobs:
 
           echo ""
           echo "Test that the external build will enable the proper cfg flag in s2n-tls. The"
-          echo "test_unstable_as_ptr test is gated behind this flag, so ensure this test is run."
-          output=$(cargo test --manifest-path ${{env.ROOT_PATH}}/s2n-tls/Cargo.toml test_unstable_as_ptr)
+          echo "${{env.EXTERNAL_BUILD_TEST_NAME}} test is gated behind this flag, so ensure this"
+          echo "test is run."
+          manifest_path="${{env.ROOT_PATH}}/s2n-tls/Cargo.toml"
+          output=$(cargo test --manifest-path ${manifest_path} ${{env.EXTERNAL_BUILD_TEST_NAME}})
           echo "${output}"
           echo "${output}" | grep -q "test result: ok. 1 passed; 0 failed; 0 ignored;"
 

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -75,6 +75,35 @@ jobs:
         # invoked on the `cargo test --all-features` pattern.
         run: RUST_LOG=TRACE cargo test --no-default-features --features pq
 
+  external-build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        id: toolchain
+        run: |
+          rustup toolchain install stable
+          rustup override set stable
+
+      - uses: camshaft/rust-cache@v1
+
+      - name: Checkout aws-lc
+        uses: actions/checkout@v4
+        with:
+          repository: aws/aws-lc
+          path: aws-lc
+
+      - name: Build aws-lc
+        working-directory: aws-lc
+        run: |
+          cmake -Bbuild \
+            -DBUILD_SHARED_LIBS=off \
+            -DBUILD_LIBSSL=off \
+            -DCMAKE_INSTALL_PREFIX=./install
+          cmake --build build -j $(nproc)
+          cmake --install build
+
       - name: Test external build
         # if this test is failing, make sure that api headers are appropriately
         # included. For a symbol to be visible in a shared lib, the
@@ -82,9 +111,14 @@ jobs:
         # in the same unit of compilation as the definition. Generally this just
         # means that if the linker can't resolve foo_method in tls/foo.c, you
         # forgot to include api/unstable/foo.h in tls/foo.c
-        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          cmake . -Bbuild -DBUILD_SHARED_LIBS=on -DBUILD_TESTING=off
+          set -e
+
+          cmake . -Bbuild \
+            -DBUILD_SHARED_LIBS=on \
+            -DBUILD_TESTING=off \
+            -DCMAKE_PREFIX_PATH=./aws-lc/install \
+            -DS2N_INTERN_LIBCRYPTO=on
           cmake --build build -- -j $(nproc)
 
           export S2N_TLS_LIB_DIR=`pwd`/build/lib
@@ -96,6 +130,17 @@ jobs:
           # Relative paths
           cd ../../..
           ldd ${{env.STANDARD_PATH}}/target/debug/integration | grep libs2n.so
+
+          # Run tests with the external build
+          cargo test --manifest-path ${{env.ROOT_PATH}}/Cargo.toml
+          cargo test --manifest-path ${{env.STANDARD_PATH}}/Cargo.toml
+
+          echo ""
+          echo "Test that the external build will enable the proper cfg flag in s2n-tls. The"
+          echo "test_unstable_as_ptr test is gated behind this flag, so ensure this test is run."
+          output=$(cargo test --manifest-path ${{env.ROOT_PATH}}/s2n-tls/Cargo.toml test_unstable_as_ptr)
+          echo "${output}"
+          echo "${output}" | grep -q "test result: ok. 1 passed; 0 failed; 0 ignored;"
 
   # our benchmark testing includes interop tests between s2n-tls, rustls, and
   # openssl

--- a/bindings/rust/extended/s2n-tls-sys/build.rs
+++ b/bindings/rust/extended/s2n-tls-sys/build.rs
@@ -257,7 +257,8 @@ impl External {
     fn link(&self) {
         println!("cargo:rustc-cfg={EXTERNAL_BUILD_CFG_NAME}");
 
-        // Propagate an external build flag to dependents.
+        // Propagate an external build flag to dependents, of the form
+        // `DEP_S2N_TLS_EXTERNAL_BUILD=true`.
         println!("cargo:external_build=true");
 
         println!(

--- a/bindings/rust/extended/s2n-tls-sys/build.rs
+++ b/bindings/rust/extended/s2n-tls-sys/build.rs
@@ -257,6 +257,9 @@ impl External {
     fn link(&self) {
         println!("cargo:rustc-cfg={EXTERNAL_BUILD_CFG_NAME}");
 
+        // Propagate an external build flag to dependents.
+        println!("cargo:external_build=true");
+
         println!(
             "cargo:rustc-link-search={}",
             self.lib_dir.as_ref().unwrap().display()

--- a/bindings/rust/extended/s2n-tls/build.rs
+++ b/bindings/rust/extended/s2n-tls/build.rs
@@ -12,7 +12,7 @@ fn main() {
          * linked. Set a cfg attribute in this case to allow s2n-tls to be aware of the external
          * build.
          */
-        if name == "DEP_S2M_TLS_EXTERNAL_BUILD" {
+        if name == EXTERNAL_BUILD_ENV_NAME {
             println!("cargo:rerun-if-env-changed={EXTERNAL_BUILD_ENV_NAME}");
 
             let external_build: bool = value.parse().unwrap();

--- a/bindings/rust/extended/s2n-tls/build.rs
+++ b/bindings/rust/extended/s2n-tls/build.rs
@@ -7,18 +7,15 @@ const EXTERNAL_BUILD_CFG_NAME: &str = "s2n_tls_external_build";
 fn main() {
     println!("cargo:rustc-check-cfg=cfg({EXTERNAL_BUILD_CFG_NAME})");
 
-    for (name, value) in std::env::vars() {
-        /* s2n-tls-sys exports the external build environment variable when libs2n is externally
-         * linked. Set a cfg attribute in this case to allow s2n-tls to be aware of the external
-         * build.
-         */
-        if name == EXTERNAL_BUILD_ENV_NAME {
-            println!("cargo:rerun-if-env-changed={EXTERNAL_BUILD_ENV_NAME}");
+    /* s2n-tls-sys exports the external build environment variable when libs2n is externally
+     * linked. Set a cfg attribute in this case to allow s2n-tls to be aware of the external build.
+     */
+    if let Ok(external_build_var) = std::env::var(EXTERNAL_BUILD_ENV_NAME) {
+        println!("cargo:rerun-if-env-changed={EXTERNAL_BUILD_ENV_NAME}");
 
-            let external_build: bool = value.parse().unwrap();
-            if external_build {
-                println!("cargo:rustc-cfg={EXTERNAL_BUILD_CFG_NAME}");
-            }
+        let external_build: bool = external_build_var.parse().unwrap();
+        if external_build {
+            println!("cargo:rustc-cfg={EXTERNAL_BUILD_CFG_NAME}");
         }
     }
 }

--- a/bindings/rust/extended/s2n-tls/build.rs
+++ b/bindings/rust/extended/s2n-tls/build.rs
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const EXTERNAL_BUILD_ENV_NAME: &str = "DEP_S2N_TLS_EXTERNAL_BUILD";
+const EXTERNAL_BUILD_CFG_NAME: &str = "s2n_tls_external_build";
+
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg({EXTERNAL_BUILD_CFG_NAME})");
+
+    for (name, value) in std::env::vars() {
+        /* s2n-tls-sys exports the external build environment variable when libs2n is externally
+         * linked. Set a cfg attribute in this case to allow s2n-tls to be aware of the external
+         * build.
+         */
+        if name == EXTERNAL_BUILD_ENV_NAME {
+            println!("cargo:rerun-if-env-changed={EXTERNAL_BUILD_ENV_NAME}");
+
+            let external_build: bool = value.parse().unwrap();
+            if external_build {
+                println!("cargo:rustc-cfg={EXTERNAL_BUILD_CFG_NAME}");
+            }
+        }
+    }
+}

--- a/bindings/rust/extended/s2n-tls/build.rs
+++ b/bindings/rust/extended/s2n-tls/build.rs
@@ -12,7 +12,7 @@ fn main() {
          * linked. Set a cfg attribute in this case to allow s2n-tls to be aware of the external
          * build.
          */
-        if name == EXTERNAL_BUILD_ENV_NAME {
+        if name == "DEP_S2M_TLS_EXTERNAL_BUILD" {
             println!("cargo:rerun-if-env-changed={EXTERNAL_BUILD_ENV_NAME}");
 
             let external_build: bool = value.parse().unwrap();


### PR DESCRIPTION
### Description of changes: 

While the low-level `s2n-tls-sys` APIs should typically never be used directly, it's sometimes necessary to do so when a higher-level API isn't provided. However, it's currently difficult to call an `s2n-tls-sys` API from an `s2n-tls` `Connection` struct, since we don't provide a way to get the underlying `s2n-tls-sys` `s2n_connection` pointer.

This PR adds a new unstable API for this purpose, currently gated behind the external build feature.

### Call-outs:

`s2n-tls-sys` [sets the `s2n_tls_external_build` cfg attribute](https://github.com/aws/s2n-tls/blob/0ece10f42bcbeb4067631a1be93632744e1d3dfe/bindings/rust/extended/s2n-tls-sys/build.rs#L258) when the external build feature is used. However, this is only accessible to the `s2n-tls-sys` crate itself, not dependent crates like `s2n-tls`. In order to inform `s2n-tls` that the external build feature is used, I made `s2n-tls-sys` propagate this information via an environment variable that's read during the `s2n-tls` build, similar to how [`aws-lc-rs` propagates build information to `s2n-tls-sys`](https://github.com/aws/s2n-tls/blob/0ece10f42bcbeb4067631a1be93632744e1d3dfe/bindings/rust/extended/s2n-tls-sys/build.rs#L203-L212). If anyone knows of a better way to do this, please let me know!

### Testing:

- I added a new test to ensure that `s2n-tls-sys` APIs are callable from an `s2n-tls` `Connection` with the new API.
- I added the unit tests to the external build test, which allows this test to be run in CI.
- I added a new test in the external build test to make sure the external build information is propagated to s2n-tls correctly. To make sure this test works, I [committed a typo to the s2n-tls `build.rs`](https://github.com/aws/s2n-tls/pull/5229/commits/9070c1b465eee41f052a314fa87fd3d4b5c919f0) which results in the cfg attribute not being set, which [caused this test to fail](https://github.com/aws/s2n-tls/actions/runs/14360374956/job/40260027354?pr=5229#step:7:2511).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
