### PR TITLE
doc: tainted stuffer reset operation

### DIFF
--- a/docs/DEVELOPMENT-GUIDE.md
+++ b/docs/DEVELOPMENT-GUIDE.md
@@ -348,7 +348,6 @@ Note that this may be past the `write_cursor` if `s2n_stuffer_rewrite()` has bee
 Explicitly tracking the `high_water_mark` allows us to track the bytes which need to be wiped, and helps avoids needless zeroing of memory.
 The next two bits of state track whether a stuffer was dynamically allocated (and so should be free'd later) and whether or not it is growable.
 `tainted` is set to true whenever `s2n_stuffer_raw_read/write()` are called.
-A `tainted` stuffer therefore implies that a pointer currently exists from a previous `s2n_stuffer_raw_read/write()` call which points to memory within the stuffer.
 If a stuffer is currently tainted then it can not be resized and it becomes ungrowable due to memory safety constraints mentioned above.
 This is reset when a stuffer is explicitly wiped, which begins the life-cycle anew.
 So any pointers returned by the `s2n_stuffer_raw_read/write()` are legal only until `s2n_stuffer_wipe()` is called.

--- a/docs/DEVELOPMENT-GUIDE.md
+++ b/docs/DEVELOPMENT-GUIDE.md
@@ -348,10 +348,9 @@ Note that this may be past the `write_cursor` if `s2n_stuffer_rewrite()` has bee
 Explicitly tracking the `high_water_mark` allows us to track the bytes which need to be wiped, and helps avoids needless zeroing of memory.
 The next two bits of state track whether a stuffer was dynamically allocated (and so should be free'd later) and whether or not it is growable.
 `tainted` is set to true whenever `s2n_stuffer_raw_read/write()` are called.
-If a stuffer is currently tainted then it can not be resized and it becomes ungrowable due to memory safety constraints mentioned above.
+If a stuffer is currently tainted then it can not be resized and it becomes ungrowable due to memory safety constraints.
 This is reset when a stuffer is explicitly wiped, which begins the life-cycle anew.
-So any pointers returned by the `s2n_stuffer_raw_read/write()` are legal only until `s2n_stuffer_wipe()` is called.
-Ideally, a `tainted` stuffer should be wiped before further write operations. If that is not an option, you may need to manually reset the `tainted` flag to false. When resetting the `tainted` flag, be very careful that the pointer is really no longer accessible and that a future developer won't unknowingly change the lifetime of the pointer. Include a comment explaining why resetting the `tainted` flag is safe.
+So any pointers returned by `s2n_stuffer_raw_read/write()` are legal only until `s2n_stuffer_wipe()` is called.
 The end result is that this kind of pattern is legal:
 
 ```c
@@ -374,6 +373,8 @@ GUARD(s2n_stuffer_write(&in, &some_more_data_blob));
 /* Stuffer life cycle is now complete, reset everything and wipe */
 GUARD(s2n_stuffer_wipe(&in));
 ```
+
+Ideally, a `tainted` stuffer should be wiped before further write operations. If that is not an option, you may need to manually reset the `tainted` flag to false. When resetting the `tainted` flag, be very careful that the pointer is really no longer accessible and that a future developer won't unknowingly change the lifetime of the pointer. Include a comment explaining why resetting the `tainted` flag is safe.
 
 ## s2n_connection and the TLS state machine
 

--- a/docs/DEVELOPMENT-GUIDE.md
+++ b/docs/DEVELOPMENT-GUIDE.md
@@ -348,10 +348,11 @@ Note that this may be past the `write_cursor` if `s2n_stuffer_rewrite()` has bee
 Explicitly tracking the `high_water_mark` allows us to track the bytes which need to be wiped, and helps avoids needless zeroing of memory.
 The next two bits of state track whether a stuffer was dynamically allocated (and so should be free'd later) and whether or not it is growable.
 `tainted` is set to true whenever `s2n_stuffer_raw_read/write()` are called.
-A `tainted` stuffer therefore implies that a pointer currently exists from a previous `s2n_stuffer_raw_read/write()` call which points to memory within the stuffer. Of course, the tainted mark is not needed once the pointer goes out of scope. Therefore, the stuffer's tainted flag can be safely set to false when the pointer no longer exists, in a sense, the danger has passed.
+A `tainted` stuffer therefore implies that a pointer currently exists from a previous `s2n_stuffer_raw_read/write()` call which points to memory within the stuffer.
 If a stuffer is currently tainted then it can not be resized and it becomes ungrowable due to memory safety constraints mentioned above.
 This is reset when a stuffer is explicitly wiped, which begins the life-cycle anew.
 So any pointers returned by the `s2n_stuffer_raw_read/write()` are legal only until `s2n_stuffer_wipe()` is called.
+Ideally, a `tainted` stuffer should be wiped before further write operations. If that is not an option, you may need to manually reset the `tainted` flag to false. When resetting the `tainted` flag, be very careful that the pointer is really no longer accessible and that a future developer won't unknowingly change the lifetime of the pointer. Include a comment explaining why resetting the `tainted` flag is safe.
 The end result is that this kind of pattern is legal:
 
 ```c


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

Our development guide doesn't have definition for `tainted` when it is introducing raw access functions. `tainted` definition is crucial to understand `s2n_stuffer_raw_read/write()`. This PR fix the knowledge gap.

The current flow to introduce `s2n_stuffer_raw_read/write()` is:
1. Discuss what use case that `s2n_stuffer_raw_read/write()` might serve.
2. Talk about dangling pointer issue.
3. Introduce tainted definition and how can we safely set the tainted flag.

### Call-outs:

* I changed the wording from `raw access functions` to specifically `s2n_stuffer_raw_read/write()`. This will make it clearer.
* I used the phrase `marked as tainted` to emphasize that either the function or us need to manually set the flag.
* Instead of saying `tainted` flag is set to 1, we should say the flag is set to true. That's a more modern definition.
* I found a missing parenthesis in the later doc. I added that one in this PR as well.

### Testing:

Proofread this doc with S2N-TLS team members.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
