### PR TITLE
ci: rebalance integV2 testcases

### DIFF
--- a/codebuild/spec/buildspec_ubuntu_integrationv2.yml
+++ b/codebuild/spec/buildspec_ubuntu_integrationv2.yml
@@ -36,11 +36,17 @@ batch:
             - openssl-1.1.1_gcc9
             - openssl-3.0
             - openssl-3.0-fips
+          # Group 1 and Group 2 (test_happy_path and test_buffered_send) each take approximately 1300 seconds to run.
+          # Group 3 is kept under 1000 seconds and uses the next slowest testcases
+          # Group 4 contains the remaining faster test cases.
           INTEGV2_TEST:
             - "test_happy_path"
             - "test_buffered_send"
             - "test_signature_algorithms test_session_resumption test_early_data test_external_psk"
-            - "test_version_negotiation test_ocsp test_renegotiate test_serialization test_record_padding test_npn test_cross_compatibility test_renegotiate_apache test_hello_retry_requests test_sni_match test_pq_handshake test_fragmentation test_key_update test_client_authentication test_dynamic_record_sizes test_sslyze test_sslv2_client_hello"
+            - "test_version_negotiation test_ocsp test_renegotiate test_serialization test_record_padding
+               test_npn test_cross_compatibility test_renegotiate_apache test_hello_retry_requests
+               test_sni_match test_pq_handshake test_fragmentation test_key_update
+               test_client_authentication test_dynamic_record_sizes test_sslyze test_sslv2_client_hello"
 
 env:
   variables:

--- a/codebuild/spec/buildspec_ubuntu_integrationv2.yml
+++ b/codebuild/spec/buildspec_ubuntu_integrationv2.yml
@@ -39,10 +39,10 @@ batch:
           INTEGV2_TEST:
             - "test_client_authentication test_dynamic_record_sizes test_sslyze test_sslv2_client_hello"
             - "test_happy_path"
-            - "test_cross_compatibility"
+            - "test_buffered_send"
             - "test_early_data test_hello_retry_requests test_sni_match test_pq_handshake test_fragmentation test_key_update"
-            - "test_session_resumption test_renegotiate_apache test_buffered_send"
-            - "test_npn test_signature_algorithms"
+            - "test_session_resumption test_renegotiate_apache"
+            - "test_npn test_signature_algorithms test_cross_compatibility"
             - "test_version_negotiation test_external_psk test_ocsp test_renegotiate test_serialization test_record_padding"
 
 env:

--- a/codebuild/spec/buildspec_ubuntu_integrationv2.yml
+++ b/codebuild/spec/buildspec_ubuntu_integrationv2.yml
@@ -37,7 +37,7 @@ batch:
             - openssl-3.0
             - openssl-3.0-fips
           # Group 1 and Group 2 (test_happy_path and test_buffered_send) each take approximately 1300 seconds to run.
-          # Group 3 is kept under 1000 seconds and uses the next slowest testcases
+          # Group 3 is kept under 1000 seconds (bottlenecked by the slowest testcase which is 1300)
           # Group 4 contains the remaining faster test cases.
           INTEGV2_TEST:
             - "test_happy_path"

--- a/codebuild/spec/buildspec_ubuntu_integrationv2.yml
+++ b/codebuild/spec/buildspec_ubuntu_integrationv2.yml
@@ -37,13 +37,10 @@ batch:
             - openssl-3.0
             - openssl-3.0-fips
           INTEGV2_TEST:
-            - "test_client_authentication test_dynamic_record_sizes test_sslyze test_sslv2_client_hello"
             - "test_happy_path"
             - "test_buffered_send"
-            - "test_early_data test_hello_retry_requests test_sni_match test_pq_handshake test_fragmentation test_key_update"
-            - "test_session_resumption test_renegotiate_apache"
-            - "test_npn test_signature_algorithms test_cross_compatibility"
-            - "test_version_negotiation test_external_psk test_ocsp test_renegotiate test_serialization test_record_padding"
+            - "test_signature_algorithms test_session_resumption test_early_data test_external_psk"
+            - "test_version_negotiation test_ocsp test_renegotiate test_serialization test_record_padding test_npn test_cross_compatibility test_renegotiate_apache test_hello_retry_requests test_sni_match test_pq_handshake test_fragmentation test_key_update test_client_authentication test_dynamic_record_sizes test_sslyze test_sslv2_client_hello"
 
 env:
   variables:


### PR DESCRIPTION
### Description of changes: 

* Moved the two slowest test cases into a separate group to isolate long-running tests.

* Regrouped the remaining tests into two balanced categories to ensure each group completes in under 1300 seconds — addressing the bottleneck caused by test_happy_path and test_buffered_send.

### Testing:
* I counted 23 test cases before the change, and confirmed that there was the same number after the switch

* I checked code build and it's correctly parsing the string (when I moved several testcases to the next line for formatting purposes)

![Screenshot 2025-04-01 at 3 29 33 PM](https://github.com/user-attachments/assets/73ea962f-fa85-4f95-a247-775085744073)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
