### PR TITLE
ci: pytest generate junit reports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -640,6 +640,7 @@ if (BUILD_TESTING)
                         COMMAND
                         pytest
                         -x -n=${N} --reruns=2 --durations=10 --cache-clear -rpfsq
+			--junitxml=../../build/junit/${test_target}.xml
                         -o log_cli=true --log-cli-level=DEBUG --provider-version=$ENV{S2N_LIBCRYPTO}
                         ${test_file_path}
                         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/integrationv2

--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -20,6 +20,7 @@ commands =
     pytest -x \
         -n=2 \
         --reruns=2 \
+	--junitxml=../../build/junit/{env:TOX_TEST_NAME:""}.xml \
         --cache-clear \
         -rpfsq \
         --durations=10 \

--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -17,7 +17,7 @@ deps =
 # -rpfsq : print a (r)eport with (p)assed tests, (f)ailed tests, and (s)kipped tests
 # --durations=10 : print the 10 slowest tests
 commands =
-    bash -c 'export TEST_NAME=$(basename $TOX_TEST_NAME | sed 's/test_//;s/.py//'); \
+    sh -c 'export TEST_NAME=$(basename $TOX_TEST_NAME | sed 's/test_//;s/.py//'); \
     pytest -x \
         -n=2 \
         --reruns=2 \

--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -3,6 +3,7 @@ envlist = py39
 skipsdist = True
 
 [testenv]
+allowlist_external=bash
 # install pytest in the virtualenv where commands will be executed
 setenv = S2N_INTEG_TEST = 1
 passenv = DYLD_LIBRARY_PATH, LD_LIBRARY_PATH, OQS_OPENSSL_1_1_1_INSTALL_DIR, OPENSSL_1_0_2_INSTALL_DIR, HOME, TOX_TEST_NAME
@@ -17,7 +18,7 @@ deps =
 # -rpfsq : print a (r)eport with (p)assed tests, (f)ailed tests, and (s)kipped tests
 # --durations=10 : print the 10 slowest tests
 commands =
-    sh -c 'export TEST_NAME=$(basename $TOX_TEST_NAME | sed 's/test_//;s/.py//'); \
+    bash -c 'export TEST_NAME=$(basename $TOX_TEST_NAME | sed 's/test_//;s/.py//'); \
     pytest -x \
         -n=2 \
         --reruns=2 \

--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -19,7 +19,7 @@ deps =
 # -rpfsq : print a (r)eport with (p)assed tests, (f)ailed tests, and (s)kipped tests
 # --durations=10 : print the 10 slowest tests
 commands =
-    bash -c 'export TEST_NAME=$(basename $TOX_TEST_NAME | /usr/bin/sed ''s/test_//''| /usr/bin/sed ''s/.py//''); \
+    bash -c 'export TEST_NAME=$(basename $TOX_TEST_NAME | sed ''s/test_//''| sed ''s/.py//''); \
     pytest -x \
         -n=2 \
         --reruns=2 \

--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -19,7 +19,7 @@ deps =
 # -rpfsq : print a (r)eport with (p)assed tests, (f)ailed tests, and (s)kipped tests
 # --durations=10 : print the 10 slowest tests
 commands =
-    bash -c 'export TEST_NAME=$(basename $TOX_TEST_NAME | sed ''s/test_//''| sed ''s/.py//''); \
+    bash -c 'set -e;export TEST_NAME=$(basename $TOX_TEST_NAME | sed ''s/test_//''| sed ''s/.py//''); \
     pytest -x \
         -n=2 \
         --reruns=2 \

--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -17,10 +17,11 @@ deps =
 # -rpfsq : print a (r)eport with (p)assed tests, (f)ailed tests, and (s)kipped tests
 # --durations=10 : print the 10 slowest tests
 commands =
+    export TEST_NAME=$(basename $TOX_TEST_NAME | sed 's/test_//;s/.py//'); \
     pytest -x \
         -n=2 \
         --reruns=2 \
-	--junitxml=../../build/junit/{env:TOX_TEST_NAME:""}.xml \
+	--junitxml=../../build/junit/{env:TEST_NAME:"junit"}.xml \
         --cache-clear \
         -rpfsq \
         --durations=10 \

--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -17,14 +17,14 @@ deps =
 # -rpfsq : print a (r)eport with (p)assed tests, (f)ailed tests, and (s)kipped tests
 # --durations=10 : print the 10 slowest tests
 commands =
-    export TEST_NAME=$(basename $TOX_TEST_NAME | sed 's/test_//;s/.py//'); \
+    bash -c 'export TEST_NAME=$(basename $TOX_TEST_NAME | sed 's/test_//;s/.py//'); \
     pytest -x \
         -n=2 \
         --reruns=2 \
-	--junitxml=../../build/junit/{env:TEST_NAME:"junit"}.xml \
+	--junitxml=../../build/junit/$TEST_NAME.xml \
         --cache-clear \
         -rpfsq \
         --durations=10 \
         -o log_cli=true --log-cli-level=INFO \
         --provider-version={env:S2N_LIBCRYPTO} \
-        {env:TOX_TEST_NAME:""}
+        {env:TOX_TEST_NAME:""} '

--- a/tests/integrationv2/tox.ini
+++ b/tests/integrationv2/tox.ini
@@ -3,7 +3,8 @@ envlist = py39
 skipsdist = True
 
 [testenv]
-allowlist_external=bash
+allowlist_externals=bash
+                    sed
 # install pytest in the virtualenv where commands will be executed
 setenv = S2N_INTEG_TEST = 1
 passenv = DYLD_LIBRARY_PATH, LD_LIBRARY_PATH, OQS_OPENSSL_1_1_1_INSTALL_DIR, OPENSSL_1_0_2_INSTALL_DIR, HOME, TOX_TEST_NAME
@@ -18,7 +19,7 @@ deps =
 # -rpfsq : print a (r)eport with (p)assed tests, (f)ailed tests, and (s)kipped tests
 # --durations=10 : print the 10 slowest tests
 commands =
-    bash -c 'export TEST_NAME=$(basename $TOX_TEST_NAME | sed 's/test_//;s/.py//'); \
+    bash -c 'export TEST_NAME=$(basename $TOX_TEST_NAME | /usr/bin/sed ''s/test_//''| /usr/bin/sed ''s/.py//''); \
     pytest -x \
         -n=2 \
         --reruns=2 \


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

n/a

### Description of changes: 

Add flags so pytest generates a junit report, for both nix and the legacy integration tests.

### Call-outs:

Replaces https://github.com/aws/s2n-tls/pull/5190. 

Tox's ini file is a pita to work with.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
