### PR TITLE
ci: Disable Github actions cache

### DIFF
--- a/.github/workflows/usage_guide.yml
+++ b/.github/workflows/usage_guide.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: camshaft/install@v1
         with:
           crate: mdbook
+          use-cache: false
 
       - name: Build book
         run: |


### PR DESCRIPTION
### Description of changes: 

Requests to the Github actions cache recently started returning 422. In order to unblock the CI, this PR disables cacheing in `camshaft/install@v1` until we figure out what the issue is.

### Testing:

The CI should now succeed for this PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
