### PR TITLE
ci: Fix cppcheck build

### DIFF
--- a/codebuild/bin/install_cppcheck.sh
+++ b/codebuild/bin/install_cppcheck.sh
@@ -36,9 +36,9 @@ cd cppcheck-src
 # updated: https://github.com/aws/s2n-tls/issues/5239
 sed -i '1s/^/#include <limits>\n/' ./lib/programmemory.cpp
 
-# See https://github.com/danmar/cppcheck#gnu-make for build recommendations
 # -DNO_UNIX_SIGNAL_HANDLING is added to support the cppcheck 2.3 build, and should also be removed
 # after cppcheck is updated: https://github.com/aws/s2n-tls/issues/5239
+# These build instructions are based on https://github.com/danmar/cppcheck#gnu-make.
 make -j $JOBS MATCHCOMPILER=yes CXXFLAGS="-O2 -DNDEBUG -DNO_UNIX_SIGNAL_HANDLING"
 
 mv cppcheck ..

--- a/codebuild/bin/install_cppcheck.sh
+++ b/codebuild/bin/install_cppcheck.sh
@@ -32,8 +32,14 @@ cd "$INSTALL_DIR"
 git clone --branch 2.3 --depth 1 https://github.com/danmar/cppcheck.git cppcheck-src
 cd cppcheck-src
 
+# The cppcheck 2.3 build fails without this import. This should be removed after cppcheck is
+# updated: https://github.com/aws/s2n-tls/issues/5239
+sed -i '1s/^/#include <limits>\n/' ./lib/programmemory.cpp
+
 # See https://github.com/danmar/cppcheck#gnu-make for build recommendations
-make -j $JOBS MATCHCOMPILER=yes CXXFLAGS="-O2 -DNDEBUG -Wall -Wno-sign-compare -Wno-unused-function"
+# -DNO_UNIX_SIGNAL_HANDLING is added to support the cppcheck 2.3 build, and should also be removed
+# after cppcheck is updated: https://github.com/aws/s2n-tls/issues/5239
+make -j $JOBS MATCHCOMPILER=yes CXXFLAGS="-O2 -DNDEBUG -DNO_UNIX_SIGNAL_HANDLING"
 
 mv cppcheck ..
 mv cfg ..


### PR DESCRIPTION
### Description of changes: 

The cppcheck CI job started failing. I think this is because I deleted the Github actions cache while debugging another issue, so cppcheck needed to be rebuilt rather than fetching the build from the cache.

This fix is definitely not ideal, but it does get it to work and unblocks the CI. Ideally we would bump the cppcheck version instead, which also fixes the build issues. I tried doing this but it resulted in many new findings that I didn't want to resolve before getting the CI working again. I opened an issue so we can do this later: https://github.com/aws/s2n-tls/issues/5239

### Testing:

cppcheck should succeed on this PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
