### PR TITLE
chore: Fix new clippy warning

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/cert_chain.rs
+++ b/bindings/rust/extended/s2n-tls/src/cert_chain.rs
@@ -375,7 +375,7 @@ mod tests {
 
     /// Create a test pair using SNI certs
     /// * `certs`: takes references to already created cert chains. This is useful
-    ///            to assert on expected reference counts.
+    ///   to assert on expected reference counts.
     /// * `types`: Used to find the CA paths for the client configs
     fn sni_test_pair(
         certs: Vec<CertificateChain<'static>>,


### PR DESCRIPTION
### Description of changes: 

Clippy started [complaining about a new issue](https://github.com/aws/s2n-tls/actions/runs/14251165289/job/39944019785?pr=5242):
```
error: doc list item overindented
   --> s2n-tls/src/cert_chain.rs:378:9
    |
378 |     ///            to assert on expected reference counts.
    |         ^^^^^^^^^^^ help: try using `  ` (2 spaces)
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items
    = note: `-D clippy::doc-overindented-list-items` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::doc_overindented_list_items)]`
```

This PR fixes the warning.

### Testing:

Clippy should no longer error on this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
