### PR TITLE
ci: pin nix installer to older version

### DIFF
--- a/codebuild/spec/buildspec_ktls.yml
+++ b/codebuild/spec/buildspec_ktls.yml
@@ -20,7 +20,7 @@ env:
   shell: bash
   variables:
     NIX_CACHE_BUCKET: "s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2"
-    # AWS Support was removed as of ver 2.8 - pin it for now. https://github.com/aws/s2n-tls/issues/5244
+    # AWS Support was removed - pin it for now. https://github.com/aws/s2n-tls/issues/5244
     NIX_INSTALLER: "https://releases.nixos.org/nix/nix-2.15.0/install"
     S2N_KTLS_TESTING_EXPECTED: 1
 phases:

--- a/codebuild/spec/buildspec_ktls.yml
+++ b/codebuild/spec/buildspec_ktls.yml
@@ -20,6 +20,8 @@ env:
   shell: bash
   variables:
     NIX_CACHE_BUCKET: "s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2"
+    # AWS Support was removed as of ver 2.8 - pin it for now. https://github.com/aws/s2n-tls/issues/5244
+    NIX_INSTALLER: "https://releases.nixos.org/nix/nix-2.15.0/install"
     S2N_KTLS_TESTING_EXPECTED: 1
 phases:
   install:
@@ -33,7 +35,7 @@ phases:
         echo "Working around the faulty yaml parser..."
         echo 'nix ALL=NOPASSWD: ALL' > /etc/sudoers.d/nix
       # (Re)Install nix
-      - sh <(curl -L https://nixos.org/nix/install) --no-daemon
+      - sh <(curl -L "$NIX_INSTALLER") --no-daemon
       # Make sure nix exists in the PATH
       - export PATH=$HOME/.nix-profile/bin:$PATH
       # Turn on flakes


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

Mitigates https://github.com/aws/s2n-tls/issues/5244

### Description of changes: 

Pin the nix installer version to an older one that still has AWS(s3) support.

### Call-outs:

Open an issue with nix.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? What manual testing was performed? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

Remember:
* Any change to the library source code should at least include unit tests.
* Any change to the core stuffer or blob methods should include [CBMC proofs](https://github.com/aws/s2n-tls/tree/main/tests/cbmc).
* Any change to the CI or tests should:
   1. prove that the test succeeds for good input
   2. prove that the test fails for bad input (eg, a test for memory leaks fails when a memory leak is committed)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
