### PR TITLE
perf(cbmc): optimize s2n_stuffer_private_key_from_pem proof

### DIFF
--- a/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/Makefile
@@ -17,7 +17,6 @@ DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
 
 CHECKFLAGS +=
 
-USE_EXTERNAL_SAT_SOLVER ?= --external-sat-solver cadical
 PROOF_UID = s2n_stuffer_private_key_from_pem
 HARNESS_ENTRY = $(PROOF_UID)_harness
 HARNESS_FILE = $(HARNESS_ENTRY).c
@@ -48,7 +47,6 @@ REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_stuffer_resize
 REMOVE_FUNCTION_BODY += s2n_stuffer_rewrite
 REMOVE_FUNCTION_BODY += s2n_add_overflow
-REMOVE_FUNCTION_BODY += s2n_stuffer_skip_whitespace
 
 UNWINDSET += strlen.0:5 # size of S2N_PEM_PKCS1_RSA_PRIVATE_KEY
 UNWINDSET += strncmp.0:5 # size of S2N_PEM_END_TOKEN

--- a/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/Makefile
+++ b/tests/cbmc/proofs/s2n_stuffer_private_key_from_pem/Makefile
@@ -11,8 +11,8 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Enough to get full coverage with 7 minutes of runtime.
-MAX_BLOB_SIZE = 10
+# Enough to get full coverage with a reasonable runtime.
+MAX_BLOB_SIZE = 8
 DEFINES += -DMAX_BLOB_SIZE=$(MAX_BLOB_SIZE)
 
 CHECKFLAGS +=
@@ -48,6 +48,7 @@ REMOVE_FUNCTION_BODY += __CPROVER_file_local_s2n_mem_c_s2n_mem_cleanup_impl
 REMOVE_FUNCTION_BODY += s2n_stuffer_resize
 REMOVE_FUNCTION_BODY += s2n_stuffer_rewrite
 REMOVE_FUNCTION_BODY += s2n_add_overflow
+REMOVE_FUNCTION_BODY += s2n_stuffer_skip_whitespace
 
 UNWINDSET += strlen.0:5 # size of S2N_PEM_PKCS1_RSA_PRIVATE_KEY
 UNWINDSET += strncmp.0:5 # size of S2N_PEM_END_TOKEN


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

none

### Description of changes: 

Reduce overall CBMC runtime from 30 min to 10, by updating s2n_stuffer_private_key_from_pem, without impacting coverage.

### Call-outs:


### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? CBMC runs in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
