### PR TITLE
chore(ci): revert nix installer pin

### DIFF
--- a/codebuild/spec/buildspec_ktls.yml
+++ b/codebuild/spec/buildspec_ktls.yml
@@ -20,8 +20,7 @@ env:
   shell: bash
   variables:
     NIX_CACHE_BUCKET: "s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2"
-    # AWS Support was removed - pin it for now. https://github.com/aws/s2n-tls/issues/5244
-    NIX_INSTALLER: "https://releases.nixos.org/nix/nix-2.15.0/install"
+    NIX_INSTALLER: "https://nixos.org/nix/install"
     S2N_KTLS_TESTING_EXPECTED: 1
 phases:
   install:


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/5244

### Description of changes: 

Nix updated the installer to be bucket aware in https://github.com/NixOS/nix/issues/12928 .

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? in CI


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
