### PR TITLE
ci: use correct openssl version for updated AL2023 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,5 +176,3 @@ If you are interested in contributing to s2n-tls, please see our [development gu
 
 ## Language Bindings for s2n-tls
 See our [language bindings list](https://github.com/aws/s2n-tls/blob/main/docs/BINDINGS.md) for language bindings for s2n-tls that we're aware of.
-
-Just for testing CI failure

--- a/README.md
+++ b/README.md
@@ -176,3 +176,5 @@ If you are interested in contributing to s2n-tls, please see our [development gu
 
 ## Language Bindings for s2n-tls
 See our [language bindings list](https://github.com/aws/s2n-tls/blob/main/docs/BINDINGS.md) for language bindings for s2n-tls that we're aware of.
+
+Just for testing CI failure

--- a/codebuild/bin/install_al_dependencies.sh
+++ b/codebuild/bin/install_al_dependencies.sh
@@ -18,7 +18,7 @@ source ./codebuild/bin/s2n_setup_env.sh
 
 al2023_main(){
     case "$S2N_LIBCRYPTO" in
-    "openssl-3.0"|"default") echo "Installing AL2023 packages";;
+    "openssl-3.2.2"|"default") echo "Installing AL2023 packages";;
     *) echo "${S2N_LIBCRYPTO} is not installed on this platform."; exit 1;;
     esac
     common_packages

--- a/codebuild/bin/install_al_dependencies.sh
+++ b/codebuild/bin/install_al_dependencies.sh
@@ -18,7 +18,7 @@ source ./codebuild/bin/s2n_setup_env.sh
 
 al2023_main(){
     case "$S2N_LIBCRYPTO" in
-    "openssl-3.2.2"|"default") echo "Installing AL2023 packages";;
+    "openssl-3.0"|"openssl-3.2.2"|"default") echo "Installing AL2023 packages";;
     *) echo "${S2N_LIBCRYPTO} is not installed on this platform."; exit 1;;
     esac
     common_packages

--- a/codebuild/spec/buildspec_generalbatch.yml
+++ b/codebuild/spec/buildspec_generalbatch.yml
@@ -135,7 +135,7 @@ batch:
         privileged-mode: true
         variables:
           TESTS: unit
-          S2N_LIBCRYPTO: openssl-3.0
+          S2N_LIBCRYPTO: openssl-3.2.2
       identifier: UnitAl2023x86Openssl30
     - buildspec: codebuild/spec/buildspec_amazonlinux.yml
       env:

--- a/tests/unit/s2n_build_test.c
+++ b/tests/unit/s2n_build_test.c
@@ -166,7 +166,12 @@ int main()
             printf("version is: %s\n", version);
             const char *ssleay_version_text = SSLeay_version(SSLEAY_VERSION);
             printf("ssleay_version_text is: %s\n", ssleay_version_text);
-            EXPECT_NOT_NULL(strstr(ssleay_version_text, version));
+            if (strstr(ssleay_version_text, version) == NULL) {
+                const char* fail_msg = sprintf(
+                    "OpenSSL version mismatch - expected version '%s' not found in '%s'", version, ssleay_version_text
+                );
+                FAIL_MSG(fail_msg);
+            }
         }
     };
 

--- a/tests/unit/s2n_build_test.c
+++ b/tests/unit/s2n_build_test.c
@@ -166,12 +166,12 @@ int main()
             const char *ssleay_version_text = SSLeay_version(SSLEAY_VERSION);
             if (strstr(ssleay_version_text, version) == NULL) {
                 char fail_msg[256];
-                snprintf(fail_msg, sizeof(fail_msg),
-                    "Libcrypto version mismatch - expected version '%s' not found in '%s'", 
+                snprintf(
+                    fail_msg, sizeof(fail_msg),
+                    "Libcrypto version mismatch - expected version '%s' not found in '%s'",
                     version, ssleay_version_text);
                 FAIL_MSG(fail_msg);
             }
-            // EXPECT_NOT_NULL(strstr(ssleay_version_text, version));
         }
     };
 

--- a/tests/unit/s2n_build_test.c
+++ b/tests/unit/s2n_build_test.c
@@ -85,6 +85,7 @@ S2N_RESULT s2n_check_supported_libcrypto(const char *s2n_libcrypto)
         { .libcrypto = "openssl-1.1.1", .is_openssl = true },
         { .libcrypto = "openssl-3.0", .is_openssl = true },
         { .libcrypto = "openssl-3.0-fips", .is_openssl = true, .is_opensslfips = true },
+        { .libcrypto = "openssl-3.2.2", .is_openssl = true },
         { .libcrypto = "openssl-3.4", .is_openssl = true },
     };
 

--- a/tests/unit/s2n_build_test.c
+++ b/tests/unit/s2n_build_test.c
@@ -162,9 +162,9 @@ int main()
     /* Check libcrypto version matches the intent of the CI.  */
     {
         if (version != NULL) {
-            printf("version is:: ", version);
+            printf("version is: %s\n", version);
             const char *ssleay_version_text = SSLeay_version(SSLEAY_VERSION);
-            printf("ssleay_version_text is: ", ssleay_version_text);
+            printf("ssleay_version_text is: %s\n", ssleay_version_text);
             EXPECT_NOT_NULL(strstr(ssleay_version_text, version));
         }
     };

--- a/tests/unit/s2n_build_test.c
+++ b/tests/unit/s2n_build_test.c
@@ -164,14 +164,7 @@ int main()
     {
         if (version != NULL) {
             const char *ssleay_version_text = SSLeay_version(SSLEAY_VERSION);
-            if (strstr(ssleay_version_text, version) == NULL) {
-                char fail_msg[256];
-                snprintf(
-                        fail_msg, sizeof(fail_msg),
-                        "Libcrypto version mismatch - expected version '%s' not found in '%s'",
-                        version, ssleay_version_text);
-                FAIL_MSG(fail_msg);
-            }
+            EXPECT_EQUAL(ssleay_version_text, version);
         }
     };
 

--- a/tests/unit/s2n_build_test.c
+++ b/tests/unit/s2n_build_test.c
@@ -164,7 +164,14 @@ int main()
     {
         if (version != NULL) {
             const char *ssleay_version_text = SSLeay_version(SSLEAY_VERSION);
-            EXPECT_EQUAL(ssleay_version_text, version);
+            if (strstr(ssleay_version_text, version) == NULL) {
+                char fail_msg[256];
+                snprintf(
+                        fail_msg, sizeof(fail_msg),
+                        "Libcrypto version mismatch - expected version '%s' not found in '%s'",
+                        version, ssleay_version_text);
+                FAIL_MSG(fail_msg);
+            }
         }
     };
 

--- a/tests/unit/s2n_build_test.c
+++ b/tests/unit/s2n_build_test.c
@@ -163,15 +163,15 @@ int main()
     /* Check libcrypto version matches the intent of the CI.  */
     {
         if (version != NULL) {
-            printf("version is: %s\n", version);
             const char *ssleay_version_text = SSLeay_version(SSLEAY_VERSION);
-            printf("ssleay_version_text is: %s\n", ssleay_version_text);
             if (strstr(ssleay_version_text, version) == NULL) {
-                const char* fail_msg = sprintf(
-                    "OpenSSL version mismatch - expected version '%s' not found in '%s'", version, ssleay_version_text
-                );
+                char fail_msg[256];
+                snprintf(fail_msg, sizeof(fail_msg),
+                    "Libcrypto version mismatch - expected version '%s' not found in '%s'", 
+                    version, ssleay_version_text);
                 FAIL_MSG(fail_msg);
             }
+            // EXPECT_NOT_NULL(strstr(ssleay_version_text, version));
         }
     };
 

--- a/tests/unit/s2n_build_test.c
+++ b/tests/unit/s2n_build_test.c
@@ -162,7 +162,9 @@ int main()
     /* Check libcrypto version matches the intent of the CI.  */
     {
         if (version != NULL) {
+            printf("version is:: ", version);
             const char *ssleay_version_text = SSLeay_version(SSLEAY_VERSION);
+            printf("ssleay_version_text is: ", ssleay_version_text);
             EXPECT_NOT_NULL(strstr(ssleay_version_text, version));
         }
     };

--- a/tests/unit/s2n_build_test.c
+++ b/tests/unit/s2n_build_test.c
@@ -167,9 +167,9 @@ int main()
             if (strstr(ssleay_version_text, version) == NULL) {
                 char fail_msg[256];
                 snprintf(
-                    fail_msg, sizeof(fail_msg),
-                    "Libcrypto version mismatch - expected version '%s' not found in '%s'",
-                    version, ssleay_version_text);
+                        fail_msg, sizeof(fail_msg),
+                        "Libcrypto version mismatch - expected version '%s' not found in '%s'",
+                        version, ssleay_version_text);
                 FAIL_MSG(fail_msg);
             }
         }


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

This unblocked failing s2nGeneralBatch in CI: [example build failure](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoidUpNb2QzNjZzQ3lrWm1UQ2xzdFZMN1ZGYWE5dVlSQ1ZKd1BnZzZ6aXN1dlZXTmFuZWdvNnR0SitPaFlIcUdjaDZ6RU9KemY2Mi9ybXVBajF0RXo4NmZ1Rnl4dkZrT241UUY4MTVQMkRuNTQ9IiwiaXZQYXJhbWV0ZXJTcGVjIjoiemFRUDgvZUMreVhER0RKaiIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D/batch/c6294d97-a3f3-4a7b-aeba-444de4ead768)

### Description of changes: 

AL2023 had a recent version release which upgraded some of the underlying libraries installed on the machine. Release note: https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes-2023.7.20250331.html

OpenSSL version was affected by this, being upgraded to OpenSSL 3.2.2. Because we were expecting OpenSSL 3.0, this caused version mismatch in one of our tests, where it was expecting version 3.0, but failed because the actual version was 3.2.2.

This PR updates the expected version for OpenSSL for AL2023 to be 3.2.2.

This also updates the error handling so the failure cause is more obvious if this happens again in the future. Previously, the error outputs:
```

11/271 Test  #12: s2n_build_test ...................................***Failed    0.02 sec
--
1633 | Running /codebuild/output/src3305363800/src/github.com/aws/s2n-tls/tests/unit/s2n_build_test.c ... NOTE: Some details are omitted, run with S2N_PRINT_STACKTRACE=1 for a verbose backtrace.
1634 | See https://github.com/aws/s2n-tls/blob/main/docs/usage-guide
1635 | FAILED test 9
1636 | !((strstr(ssleay_version_text, version)) == (((void *)0))) is not true  (/codebuild/output/src3305363800/src/github.com/aws/s2n-tls/tests/unit/s2n_build_test.c:168)
1637 | Error Message: 'no error'
1638 | Debug String: 'no error'
1639 | System Error: Success (0)
```

### Call-outs:
Despite the new AL2023 version, it does not seem to be consistent across platforms. The failing test was using x86, and the same test configuration on arm was not failing. This may suggest we need to also adjust the expected versions for arm in the near future

### Testing:
All tests passed in CI


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
