### PR TITLE
refactor: cleanup hash to better support multiple implementations

### DIFF
--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -170,20 +170,12 @@ static int s2n_evp_hash_new(struct s2n_hash_state *state)
     if (s2n_hash_use_custom_md5_sha1()) {
         POSIX_ENSURE_REF(state->digest.high_level.evp_md5_secondary.ctx = S2N_EVP_MD_CTX_NEW());
     }
-
-    state->is_ready_for_input = 0;
-    state->currently_in_hash = 0;
-
     return S2N_SUCCESS;
 }
 
 static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 {
     POSIX_ENSURE_REF(state->digest.high_level.evp.ctx);
-
-    state->alg = alg;
-    state->is_ready_for_input = 1;
-    state->currently_in_hash = 0;
 
     if (alg == S2N_HASH_NONE) {
         return S2N_SUCCESS;
@@ -210,10 +202,6 @@ static int s2n_evp_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm al
 
 static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
-    POSIX_ENSURE(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
-    POSIX_ENSURE(size <= (UINT64_MAX - state->currently_in_hash), S2N_ERR_INTEGER_OVERFLOW);
-    state->currently_in_hash += size;
-
     if (state->alg == S2N_HASH_NONE) {
         return S2N_SUCCESS;
     }
@@ -231,11 +219,6 @@ static int s2n_evp_hash_update(struct s2n_hash_state *state, const void *data, u
 
 static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 {
-    POSIX_ENSURE(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
-
-    state->currently_in_hash = 0;
-    state->is_ready_for_input = 0;
-
     unsigned int digest_size = size;
     uint8_t expected_digest_size = 0;
     POSIX_GUARD(s2n_hash_digest_size(state->alg, &expected_digest_size));
@@ -271,11 +254,6 @@ static int s2n_evp_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
 
 static int s2n_evp_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
 {
-    to->hash_impl = from->hash_impl;
-    to->alg = from->alg;
-    to->is_ready_for_input = from->is_ready_for_input;
-    to->currently_in_hash = from->currently_in_hash;
-
     if (from->alg == S2N_HASH_NONE) {
         return S2N_SUCCESS;
     }
@@ -297,22 +275,17 @@ static int s2n_evp_hash_reset(struct s2n_hash_state *state)
     if (state->alg == S2N_HASH_MD5_SHA1 && s2n_hash_use_custom_md5_sha1()) {
         POSIX_GUARD_OSSL(S2N_EVP_MD_CTX_RESET(state->digest.high_level.evp_md5_secondary.ctx), S2N_ERR_HASH_WIPE_FAILED);
     }
-
-    /* hash_init resets the ready_for_input and currently_in_hash fields. */
-    return s2n_evp_hash_init(state, state->alg);
+    return S2N_SUCCESS;
 }
 
 static int s2n_evp_hash_free(struct s2n_hash_state *state)
 {
     S2N_EVP_MD_CTX_FREE(state->digest.high_level.evp.ctx);
     state->digest.high_level.evp.ctx = NULL;
-
     if (s2n_hash_use_custom_md5_sha1()) {
         S2N_EVP_MD_CTX_FREE(state->digest.high_level.evp_md5_secondary.ctx);
         state->digest.high_level.evp_md5_secondary.ctx = NULL;
     }
-
-    state->is_ready_for_input = 0;
     return S2N_SUCCESS;
 }
 
@@ -326,23 +299,17 @@ static const struct s2n_hash s2n_evp_hash = {
     .free = &s2n_evp_hash_free,
 };
 
-static int s2n_hash_set_impl(struct s2n_hash_state *state)
-{
-    state->hash_impl = &s2n_evp_hash;
-    return S2N_SUCCESS;
-}
-
 int s2n_hash_new(struct s2n_hash_state *state)
 {
     POSIX_ENSURE_REF(state);
-    /* Set hash_impl on initial hash creation.
-     * When in FIPS mode, the EVP API's must be used for hashes.
-     */
-    POSIX_GUARD(s2n_hash_set_impl(state));
 
+    state->hash_impl = &s2n_evp_hash;
     POSIX_ENSURE_REF(state->hash_impl->alloc);
-
     POSIX_GUARD(state->hash_impl->alloc(state));
+
+    state->alg = S2N_HASH_NONE;
+    state->is_ready_for_input = 0;
+    state->currently_in_hash = 0;
     return S2N_SUCCESS;
 }
 
@@ -355,57 +322,72 @@ S2N_RESULT s2n_hash_state_validate(struct s2n_hash_state *state)
 int s2n_hash_init(struct s2n_hash_state *state, s2n_hash_algorithm alg)
 {
     POSIX_ENSURE_REF(state);
-    /* Ensure that hash_impl is set, as it may have been reset for s2n_hash_state on s2n_connection_wipe.
-     * When in FIPS mode, the EVP API's must be used for hashes.
-     */
-    POSIX_GUARD(s2n_hash_set_impl(state));
+    POSIX_ENSURE(s2n_hash_is_available(alg), S2N_ERR_HASH_INVALID_ALGORITHM);
 
-    if (s2n_hash_is_available(alg)) {
-        POSIX_ENSURE_REF(state->hash_impl->init);
-        return state->hash_impl->init(state, alg);
-    } else {
-        POSIX_BAIL(S2N_ERR_HASH_INVALID_ALGORITHM);
-    }
+    POSIX_ENSURE_REF(state->hash_impl);
+    POSIX_ENSURE_REF(state->hash_impl->init);
+    POSIX_GUARD(state->hash_impl->init(state, alg));
+
+    state->alg = alg;
+    state->is_ready_for_input = 1;
+    state->currently_in_hash = 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_hash_update(struct s2n_hash_state *state, const void *data, uint32_t size)
 {
     POSIX_PRECONDITION(s2n_hash_state_validate(state));
     POSIX_ENSURE(S2N_MEM_IS_READABLE(data, size), S2N_ERR_PRECONDITION_VIOLATION);
-    POSIX_ENSURE_REF(state->hash_impl->update);
+    POSIX_ENSURE(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
-    return state->hash_impl->update(state, data, size);
+    POSIX_ENSURE_REF(state->hash_impl);
+    POSIX_ENSURE_REF(state->hash_impl->update);
+    POSIX_GUARD(state->hash_impl->update(state, data, size));
+
+    POSIX_ENSURE(size <= (UINT64_MAX - state->currently_in_hash), S2N_ERR_INTEGER_OVERFLOW);
+    state->currently_in_hash += size;
+    return S2N_SUCCESS;
 }
 
 int s2n_hash_digest(struct s2n_hash_state *state, void *out, uint32_t size)
 {
     POSIX_PRECONDITION(s2n_hash_state_validate(state));
     POSIX_ENSURE(S2N_MEM_IS_READABLE(out, size), S2N_ERR_PRECONDITION_VIOLATION);
-    POSIX_ENSURE_REF(state->hash_impl->digest);
+    POSIX_ENSURE(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
 
-    return state->hash_impl->digest(state, out, size);
+    POSIX_ENSURE_REF(state->hash_impl);
+    POSIX_ENSURE_REF(state->hash_impl->digest);
+    POSIX_GUARD(state->hash_impl->digest(state, out, size));
+
+    state->currently_in_hash = 0;
+    state->is_ready_for_input = 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *from)
 {
     POSIX_PRECONDITION(s2n_hash_state_validate(to));
     POSIX_PRECONDITION(s2n_hash_state_validate(from));
-    POSIX_ENSURE_REF(from->hash_impl->copy);
 
-    return from->hash_impl->copy(to, from);
+    POSIX_ENSURE_REF(from->hash_impl);
+    POSIX_ENSURE_REF(from->hash_impl->copy);
+    POSIX_GUARD(from->hash_impl->copy(to, from));
+
+    to->hash_impl = from->hash_impl;
+    to->alg = from->alg;
+    to->is_ready_for_input = from->is_ready_for_input;
+    to->currently_in_hash = from->currently_in_hash;
+    return S2N_SUCCESS;
 }
 
 int s2n_hash_reset(struct s2n_hash_state *state)
 {
     POSIX_ENSURE_REF(state);
-    /* Ensure that hash_impl is set, as it may have been reset for s2n_hash_state on s2n_connection_wipe.
-     * When in FIPS mode, the EVP API's must be used for hashes.
-     */
-    POSIX_GUARD(s2n_hash_set_impl(state));
-
+    POSIX_ENSURE_REF(state->hash_impl);
     POSIX_ENSURE_REF(state->hash_impl->reset);
-
-    return state->hash_impl->reset(state);
+    POSIX_GUARD(state->hash_impl->reset(state));
+    POSIX_GUARD(s2n_hash_init(state, state->alg));
+    return S2N_SUCCESS;
 }
 
 int s2n_hash_free(struct s2n_hash_state *state)
@@ -413,14 +395,15 @@ int s2n_hash_free(struct s2n_hash_state *state)
     if (state == NULL) {
         return S2N_SUCCESS;
     }
-    /* Ensure that hash_impl is set, as it may have been reset for s2n_hash_state on s2n_connection_wipe.
-     * When in FIPS mode, the EVP API's must be used for hashes.
-     */
-    POSIX_GUARD(s2n_hash_set_impl(state));
 
+    POSIX_ENSURE_REF(state->hash_impl);
     POSIX_ENSURE_REF(state->hash_impl->free);
+    POSIX_GUARD(state->hash_impl->free(state));
 
-    return state->hash_impl->free(state);
+    state->alg = S2N_HASH_NONE;
+    state->is_ready_for_input = 0;
+    state->currently_in_hash = 0;
+    return S2N_SUCCESS;
 }
 
 int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t *out)
@@ -428,7 +411,6 @@ int s2n_hash_get_currently_in_hash_total(struct s2n_hash_state *state, uint64_t 
     POSIX_PRECONDITION(s2n_hash_state_validate(state));
     POSIX_ENSURE(S2N_MEM_IS_WRITABLE_CHECK(out, sizeof(*out)), S2N_ERR_PRECONDITION_VIOLATION);
     POSIX_ENSURE(state->is_ready_for_input, S2N_ERR_HASH_NOT_READY);
-
     *out = state->currently_in_hash;
     return S2N_SUCCESS;
 }

--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -299,11 +299,20 @@ static const struct s2n_hash s2n_evp_hash = {
     .free = &s2n_evp_hash_free,
 };
 
+/* This method looks unnecessary, but our CBMC proofs are
+ * dependent on it. Search for:
+ * __CPROVER_file_local_s2n_hash_c_s2n_hash_set_evp_impl
+ */
+static void s2n_hash_set_evp_impl(struct s2n_hash_state *state)
+{
+    state->hash_impl = &s2n_evp_hash;
+}
+
 int s2n_hash_new(struct s2n_hash_state *state)
 {
     POSIX_ENSURE_REF(state);
 
-    state->hash_impl = &s2n_evp_hash;
+    s2n_hash_set_evp_impl(state);
     POSIX_ENSURE_REF(state->hash_impl->alloc);
     POSIX_GUARD(state->hash_impl->alloc(state));
 

--- a/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/s2n_hash_const_time_get_currently_in_hash_block_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_const_time_get_currently_in_hash_block/s2n_hash_const_time_get_currently_in_hash_block_harness.c
@@ -19,8 +19,6 @@
 
 #include <assert.h>
 
-int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
-
 void s2n_hash_const_time_get_currently_in_hash_block_harness()
 {
     /* Non-deterministic inputs. */
@@ -29,10 +27,6 @@ void s2n_hash_const_time_get_currently_in_hash_block_harness()
 
     /* Assumptions. */
     __CPROVER_assume(s2n_result_is_ok(s2n_hash_state_validate(state)));
-    if (state != NULL)
-    {
-        __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(state);
-    }
 
     /* Operation under verification. */
     if (s2n_hash_const_time_get_currently_in_hash_block(state, out) == S2N_SUCCESS)

--- a/tests/cbmc/proofs/s2n_hash_copy/s2n_hash_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_copy/s2n_hash_copy_harness.c
@@ -19,8 +19,6 @@
 
 #include <assert.h>
 
-int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
-
 void s2n_hash_copy_harness()
 {
     /* Non-deterministic inputs. */
@@ -30,8 +28,6 @@ void s2n_hash_copy_harness()
     /* Assumptions. */
     __CPROVER_assume(s2n_result_is_ok(s2n_hash_state_validate(to)));
     __CPROVER_assume(s2n_result_is_ok(s2n_hash_state_validate(from)));
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(to);
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(from);
 
     /* Operation under verification. */
     if (s2n_hash_copy(to, from) == S2N_SUCCESS)

--- a/tests/cbmc/proofs/s2n_hash_digest/s2n_hash_digest_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_digest/s2n_hash_digest_harness.c
@@ -19,8 +19,6 @@
 
 #include <assert.h>
 
-int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
-
 void s2n_hash_digest_harness()
 {
     /* Non-deterministic inputs. */
@@ -30,7 +28,6 @@ void s2n_hash_digest_harness()
 
     /* Assumptions. */
     __CPROVER_assume(s2n_result_is_ok(s2n_hash_state_validate(state)));
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(state);
 
     /* Operation under verification. */
     if (s2n_hash_digest(state, out, size) == S2N_SUCCESS)

--- a/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/s2n_hash_get_currently_in_hash_total_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_get_currently_in_hash_total/s2n_hash_get_currently_in_hash_total_harness.c
@@ -19,8 +19,6 @@
 
 #include <assert.h>
 
-int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
-
 void s2n_hash_get_currently_in_hash_total_harness()
 {
     /* Non-deterministic inputs. */
@@ -29,10 +27,6 @@ void s2n_hash_get_currently_in_hash_total_harness()
 
     /* Assumptions. */
     __CPROVER_assume(s2n_result_is_ok(s2n_hash_state_validate(state)));
-    if (state != NULL)
-    {
-        __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(state);
-    }
 
     /* Operation under verification. */
     if (s2n_hash_get_currently_in_hash_total(state, out) == S2N_SUCCESS)

--- a/tests/cbmc/proofs/s2n_hash_update/s2n_hash_update_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_update/s2n_hash_update_harness.c
@@ -19,8 +19,6 @@
 
 #include <assert.h>
 
-int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
-
 void s2n_hash_update_harness()
 {
     /* Non-deterministic inputs. */
@@ -30,7 +28,6 @@ void s2n_hash_update_harness()
 
     /* Assumptions. */
     __CPROVER_assume(s2n_result_is_ok(s2n_hash_state_validate(state)));
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(state);
 
     /* Operation under verification. */
     if (s2n_hash_update(state, data, size) == S2N_SUCCESS)

--- a/tests/cbmc/proofs/s2n_hmac_copy/s2n_hmac_copy_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_copy/s2n_hmac_copy_harness.c
@@ -19,8 +19,6 @@
 
 #include <assert.h>
 
-int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
-
 void s2n_hmac_copy_harness()
 {
     /* Non-deterministic inputs. */
@@ -30,14 +28,6 @@ void s2n_hmac_copy_harness()
     /* Assumptions. */
     __CPROVER_assume(s2n_result_is_ok(s2n_hmac_state_validate(to)));
     __CPROVER_assume(s2n_result_is_ok(s2n_hmac_state_validate(from)));
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&to->inner);
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&to->inner_just_key);
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&to->outer);
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&to->outer_just_key);
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&from->inner);
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&from->inner_just_key);
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&from->outer);
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&from->outer_just_key);
 
     /* Operation under verification. */
     if (s2n_hmac_copy(to, from) == S2N_SUCCESS)

--- a/tests/cbmc/proofs/s2n_hmac_digest/s2n_hmac_digest_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_digest/s2n_hmac_digest_harness.c
@@ -19,8 +19,6 @@
 
 #include <assert.h>
 
-int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
-
 void s2n_hmac_digest_harness()
 {
     /* Non-deterministic inputs. */
@@ -30,9 +28,6 @@ void s2n_hmac_digest_harness()
 
     /* Assumptions. */
     __CPROVER_assume(s2n_result_is_ok(s2n_hmac_state_validate(state)));
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->inner);
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->outer);
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->outer_just_key);
 
     /* Operation under verification. */
     if (s2n_hmac_digest(state, out, size) == S2N_SUCCESS)

--- a/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/s2n_hmac_digest_two_compression_rounds_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_digest_two_compression_rounds/s2n_hmac_digest_two_compression_rounds_harness.c
@@ -19,8 +19,6 @@
 
 #include <assert.h>
 
-int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
-
 void s2n_hmac_digest_two_compression_rounds_harness()
 {
     /* Non-deterministic inputs. */
@@ -30,9 +28,6 @@ void s2n_hmac_digest_two_compression_rounds_harness()
 
     /* Assumptions. */
     __CPROVER_assume(s2n_result_is_ok(s2n_hmac_state_validate(state)));
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->inner);
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->outer);
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->outer_just_key);
 
     /* Operation under verification. */
     if (s2n_hmac_digest_two_compression_rounds(state, out, size) == S2N_SUCCESS)

--- a/tests/cbmc/proofs/s2n_hmac_reset/s2n_hmac_reset_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_reset/s2n_hmac_reset_harness.c
@@ -19,8 +19,6 @@
 
 #include <assert.h>
 
-int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
-
 void s2n_hmac_reset_harness()
 {
     /* Non-deterministic inputs. */
@@ -28,8 +26,6 @@ void s2n_hmac_reset_harness()
 
     /* Assumptions. */
     __CPROVER_assume(s2n_result_is_ok(s2n_hmac_state_validate(state)));
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->inner);
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->inner_just_key);
 
     /* Operation under verification. */
     if (s2n_hmac_reset(state) == S2N_SUCCESS)

--- a/tests/cbmc/proofs/s2n_hmac_update/s2n_hmac_update_harness.c
+++ b/tests/cbmc/proofs/s2n_hmac_update/s2n_hmac_update_harness.c
@@ -19,8 +19,6 @@
 
 #include <assert.h>
 
-int __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(struct s2n_hash_state *);
-
 void s2n_hmac_update_harness()
 {
     /* Non-deterministic inputs. */
@@ -30,7 +28,6 @@ void s2n_hmac_update_harness()
 
     /* Assumptions. */
     __CPROVER_assume(s2n_result_is_ok(s2n_hmac_state_validate(state)));
-    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_impl(&state->inner);
 
     /* Operation under verification. */
     if (s2n_hmac_update(state, in, size) == S2N_SUCCESS)

--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -225,15 +225,15 @@ struct s2n_evp_digest* cbmc_allocate_s2n_evp_digest()
     return evp_digest;
 }
 
+void __CPROVER_file_local_s2n_hash_c_s2n_hash_set_evp_impl(struct s2n_hash_state *);
+
 void cbmc_populate_s2n_hash_state(struct s2n_hash_state* state)
 {
     CBMC_ENSURE_REF(state);
-    /* `state->hash_impl` is never allocated.
-     * It is always initialized based on the hashing algorithm.
-     * If required, this initialization should be done in the validation function.
-     */
     cbmc_populate_s2n_evp_digest(&state->digest.high_level.evp);
     cbmc_populate_s2n_evp_digest(&state->digest.high_level.evp_md5_secondary);
+    /* By populating the EVP fields, we have chosen to test the EVP implementation */
+    __CPROVER_file_local_s2n_hash_c_s2n_hash_set_evp_impl(state);
 }
 
 struct s2n_hash_state* cbmc_allocate_s2n_hash_state()


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:
related to https://github.com/aws/s2n-tls/issues/5257

### Description of changes: 

See https://github.com/aws/s2n-tls/issues/5257 for a high-level description of why I need to touch the hashing code.

Handling both hashes and raw input interchangeably requires a new hash implementation. However, our current hash code isn't organized in a way that makes it easy to get consistent behavior between implementations. Before I add the new implementation, I want to reorganize the existing code: the "s2n_hash_" methods should handle the fields shared between all implementations, and the specific "s2n_evp_hash_" methods should only handle the fields in the "digest" union that are specific to the EVP hashing implementation.

### Testing:

There should be no behavior changes here, so existing tests should be sufficient. I'm just moving code around.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
