### PR TITLE
refactor: add raw data hash implementation

### DIFF
--- a/crypto/s2n_hash.c
+++ b/crypto/s2n_hash.c
@@ -333,6 +333,7 @@ static int s2n_raw_hash_digest(struct s2n_hash_state *state, void *out, uint32_t
 {
     POSIX_ENSURE_REF(state);
     struct s2n_stuffer *raw_data = &state->digest.raw_data;
+    POSIX_ENSURE_EQ(raw_data->read_cursor, 0);
     POSIX_ENSURE_EQ(size, s2n_stuffer_data_available(raw_data));
     POSIX_GUARD(s2n_stuffer_read_bytes(raw_data, out, size));
     return S2N_SUCCESS;
@@ -345,6 +346,7 @@ static int s2n_raw_hash_copy(struct s2n_hash_state *to, struct s2n_hash_state *f
 
     struct s2n_stuffer *to_raw_data = &to->digest.raw_data;
     struct s2n_stuffer *from_raw_data = &from->digest.raw_data;
+    POSIX_ENSURE_EQ(from_raw_data->read_cursor, 0);
 
     uint32_t size = s2n_stuffer_data_available(from_raw_data);
     POSIX_GUARD(s2n_stuffer_alloc(to_raw_data, size));

--- a/crypto/s2n_pkey_evp.c
+++ b/crypto/s2n_pkey_evp.c
@@ -132,6 +132,7 @@ static int s2n_pkey_evp_digest_and_sign(EVP_PKEY_CTX *pctx, s2n_signature_algori
      */
     POSIX_ENSURE(s2n_libcrypto_is_awslc_fips(), S2N_ERR_SAFETY);
 
+    POSIX_ENSURE_EQ(s2n_hash_get_type(hash_state), S2N_HASH_TYPE_EVP);
     EVP_MD_CTX *ctx = hash_state->digest.high_level.evp.ctx;
     POSIX_ENSURE_REF(ctx);
     POSIX_GUARD_RESULT(s2n_evp_md_ctx_set_pkey_ctx(ctx, pctx));
@@ -210,6 +211,7 @@ static int s2n_pkey_evp_digest_and_verify(EVP_PKEY_CTX *pctx, s2n_signature_algo
     POSIX_ENSURE(!s2n_hash_use_custom_md5_sha1(), S2N_ERR_SAFETY);
     POSIX_ENSURE(s2n_libcrypto_is_awslc_fips(), S2N_ERR_SAFETY);
 
+    POSIX_ENSURE_EQ(s2n_hash_get_type(hash_state), S2N_HASH_TYPE_EVP);
     EVP_MD_CTX *ctx = hash_state->digest.high_level.evp.ctx;
     POSIX_ENSURE_REF(ctx);
     POSIX_GUARD_RESULT(s2n_evp_md_ctx_set_pkey_ctx(ctx, pctx));

--- a/tests/cbmc/proofs/s2n_hash_is_available/s2n_hash_is_available_harness.c
+++ b/tests/cbmc/proofs/s2n_hash_is_available/s2n_hash_is_available_harness.c
@@ -38,6 +38,7 @@ void s2n_hash_is_available_harness()
         case S2N_HASH_SHA256:
         case S2N_HASH_SHA384:
         case S2N_HASH_SHA512:
+        case S2N_HASH_INTRINSIC:
             assert(is_available); break;
         default:
             __CPROVER_assert(!is_available, "Unsupported algorithm.");

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -245,12 +245,14 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_get_selected_digest_algorithm(conn, &output));
         EXPECT_EQUAL(S2N_TLS_HASH_NONE, output);
 
-        s2n_tls_hash_algorithm expected_output[] = {
-            S2N_TLS_HASH_NONE, S2N_TLS_HASH_MD5,
-            S2N_TLS_HASH_SHA1, S2N_TLS_HASH_SHA224,
-            S2N_TLS_HASH_SHA256, S2N_TLS_HASH_SHA384,
-            S2N_TLS_HASH_SHA512, S2N_TLS_HASH_MD5_SHA1,
-            S2N_TLS_HASH_NONE
+        s2n_tls_hash_algorithm expected_output[S2N_HASH_ALGS_COUNT] = {
+            [S2N_HASH_MD5] = S2N_TLS_HASH_MD5,
+            [S2N_HASH_SHA1] = S2N_TLS_HASH_SHA1,
+            [S2N_HASH_SHA224] = S2N_TLS_HASH_SHA224,
+            [S2N_HASH_SHA256] = S2N_TLS_HASH_SHA256,
+            [S2N_HASH_SHA384] = S2N_TLS_HASH_SHA384,
+            [S2N_HASH_SHA512] = S2N_TLS_HASH_SHA512,
+            [S2N_HASH_MD5_SHA1] = S2N_TLS_HASH_MD5_SHA1,
         };
 
         for (size_t i = S2N_TLS_HASH_NONE; i <= UINT16_MAX; i++) {
@@ -258,7 +260,7 @@ int main(int argc, char **argv)
             test_scheme.hash_alg = i;
             conn->handshake_params.client_cert_sig_scheme = &test_scheme;
             conn->handshake_params.server_cert_sig_scheme = &test_scheme;
-            if (i <= S2N_HASH_ALGS_COUNT) {
+            if (i < S2N_HASH_ALGS_COUNT) {
                 EXPECT_SUCCESS(s2n_connection_get_selected_client_cert_digest_algorithm(conn, &output));
                 EXPECT_EQUAL(expected_output[i], output);
 

--- a/tests/unit/s2n_handshake_hashes_test.c
+++ b/tests/unit/s2n_handshake_hashes_test.c
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
 
             /* Allocates all hashes */
             for (s2n_hash_algorithm alg = 0; alg < S2N_HASH_ALGS_COUNT; alg++) {
-                if (alg == S2N_HASH_NONE) {
+                if (alg == S2N_HASH_NONE || alg == S2N_HASH_INTRINSIC) {
                     continue;
                 }
 
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
             uint8_t data[100] = { 0 };
 
             for (s2n_hash_algorithm alg = 0; alg < S2N_HASH_ALGS_COUNT; alg++) {
-                if (alg == S2N_HASH_NONE) {
+                if (alg == S2N_HASH_NONE || alg == S2N_HASH_INTRINSIC) {
                     continue;
                 }
 

--- a/tests/unit/s2n_hash_raw_test.c
+++ b/tests/unit/s2n_hash_raw_test.c
@@ -1,0 +1,247 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "crypto/s2n_hash.h"
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test: s2n_hash_new_raw */
+    {
+        /* Test: matches s2n_hash_new, minus hash_impl */
+        {
+            struct s2n_blob buffer = { 0 };
+            DEFER_CLEANUP(struct s2n_hash_state raw_state = { 0 }, s2n_hash_free);
+            EXPECT_OK(s2n_hash_new_raw(&raw_state, &buffer));
+
+            DEFER_CLEANUP(struct s2n_hash_state hash_state = { 0 }, s2n_hash_free);
+            EXPECT_SUCCESS(s2n_hash_new(&hash_state));
+
+            EXPECT_EQUAL(raw_state.alg, hash_state.alg);
+            EXPECT_EQUAL(raw_state.currently_in_hash, hash_state.currently_in_hash);
+            EXPECT_EQUAL(raw_state.is_ready_for_input, hash_state.is_ready_for_input);
+
+            EXPECT_NOT_EQUAL(raw_state.hash_impl, hash_state.hash_impl);
+            EXPECT_EQUAL(s2n_hash_get_type(&raw_state), S2N_HASH_TYPE_RAW);
+        };
+
+        /* Test: properly configure the raw data buffer */
+        {
+            uint8_t buffer_bytes[10] = { 0 };
+            struct s2n_blob buffer = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&buffer, buffer_bytes, sizeof(buffer_bytes)));
+
+            DEFER_CLEANUP(struct s2n_hash_state raw_state = { 0 }, s2n_hash_free);
+            EXPECT_OK(s2n_hash_new_raw(&raw_state, &buffer));
+
+            struct s2n_stuffer *raw_data = &raw_state.digest.raw_data;
+            EXPECT_EQUAL(raw_data->blob.size, buffer.size);
+            EXPECT_EQUAL(raw_data->blob.data, buffer.data);
+            EXPECT_EQUAL(s2n_stuffer_data_available(raw_data), 0);
+            EXPECT_EQUAL(s2n_stuffer_space_remaining(raw_data), buffer.size);
+        };
+    };
+
+    /* Test: s2n_hash_init */
+    {
+        for (s2n_hash_algorithm hash_alg = 0; hash_alg < S2N_HASH_ALGS_COUNT; hash_alg++) {
+            struct s2n_blob buffer = { 0 };
+            DEFER_CLEANUP(struct s2n_hash_state raw_state = { 0 }, s2n_hash_free);
+            EXPECT_OK(s2n_hash_new_raw(&raw_state, &buffer));
+            EXPECT_SUCCESS(s2n_hash_init(&raw_state, hash_alg));
+
+            EXPECT_EQUAL(raw_state.alg, hash_alg);
+            EXPECT_EQUAL(raw_state.is_ready_for_input, 1);
+            EXPECT_EQUAL(raw_state.currently_in_hash, 0);
+        }
+    };
+
+    /* Test: s2n_hash_update */
+    {
+        uint8_t test_data[] = "this is some test data";
+        uint8_t write_sizes[] = { 5, 3, 5, 5, 5 };
+
+        /* Test: single update */
+        {
+            uint8_t buffer_bytes[sizeof(test_data)] = { 0 };
+            struct s2n_blob buffer = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&buffer, buffer_bytes, sizeof(buffer_bytes)));
+
+            DEFER_CLEANUP(struct s2n_hash_state raw_state = { 0 }, s2n_hash_free);
+            EXPECT_OK(s2n_hash_new_raw(&raw_state, &buffer));
+            EXPECT_SUCCESS(s2n_hash_init(&raw_state, S2N_HASH_SHA256));
+
+            EXPECT_SUCCESS(s2n_hash_update(&raw_state, test_data, sizeof(test_data)));
+
+            struct s2n_stuffer *raw_data = &raw_state.digest.raw_data;
+            EXPECT_EQUAL(raw_state.currently_in_hash, sizeof(test_data));
+            EXPECT_EQUAL(s2n_stuffer_data_available(raw_data), sizeof(test_data));
+            EXPECT_BYTEARRAY_EQUAL(test_data, buffer_bytes, sizeof(test_data));
+        };
+
+        /* Test: multiple updates */
+        {
+            uint8_t buffer_bytes[sizeof(test_data)] = { 0 };
+            struct s2n_blob buffer = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&buffer, buffer_bytes, sizeof(buffer_bytes)));
+
+            DEFER_CLEANUP(struct s2n_hash_state raw_state = { 0 }, s2n_hash_free);
+            EXPECT_OK(s2n_hash_new_raw(&raw_state, &buffer));
+            EXPECT_SUCCESS(s2n_hash_init(&raw_state, S2N_HASH_SHA384));
+
+            size_t written = 0;
+            for (size_t i = 0; i < s2n_array_len(write_sizes); i++) {
+                EXPECT_SUCCESS(s2n_hash_update(&raw_state, test_data + written,
+                        write_sizes[i]));
+                written += write_sizes[i];
+            }
+
+            struct s2n_stuffer *raw_data = &raw_state.digest.raw_data;
+            EXPECT_EQUAL(raw_state.currently_in_hash, sizeof(test_data));
+            EXPECT_EQUAL(s2n_stuffer_data_available(raw_data), sizeof(test_data));
+            EXPECT_BYTEARRAY_EQUAL(test_data, buffer_bytes, sizeof(test_data));
+        };
+
+        /* Test: update too large for buffer */
+        {
+            /* Configure the buffer smaller than the test data */
+            uint8_t buffer_bytes[sizeof(test_data) / 2] = { 0 };
+            struct s2n_blob buffer = { 0 };
+            EXPECT_SUCCESS(s2n_blob_init(&buffer, buffer_bytes, sizeof(buffer_bytes)));
+
+            DEFER_CLEANUP(struct s2n_hash_state raw_state = { 0 }, s2n_hash_free);
+            EXPECT_OK(s2n_hash_new_raw(&raw_state, &buffer));
+            EXPECT_SUCCESS(s2n_hash_init(&raw_state, S2N_HASH_SHA512));
+
+            EXPECT_FAILURE_WITH_ERRNO(s2n_hash_update(&raw_state, test_data, sizeof(test_data)),
+                    S2N_ERR_STUFFER_IS_FULL);
+        };
+    };
+
+    /* Test: s2n_hash_digest */
+    {
+        uint8_t test_data[] = "this is some test data";
+
+        uint8_t buffer_bytes[sizeof(test_data)] = { 0 };
+        struct s2n_blob buffer = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&buffer, buffer_bytes, sizeof(buffer_bytes)));
+
+        DEFER_CLEANUP(struct s2n_hash_state raw_state = { 0 }, s2n_hash_free);
+        EXPECT_OK(s2n_hash_new_raw(&raw_state, &buffer));
+        EXPECT_SUCCESS(s2n_hash_init(&raw_state, S2N_HASH_SHA384));
+        EXPECT_SUCCESS(s2n_hash_update(&raw_state, test_data, sizeof(test_data)));
+        EXPECT_EQUAL(raw_state.is_ready_for_input, 1);
+
+        /* Test: Too little data requested */
+        {
+            uint8_t result_data[sizeof(test_data)] = { 0 };
+            EXPECT_FAILURE_WITH_ERRNO(s2n_hash_digest(&raw_state, result_data, 1),
+                    S2N_ERR_SAFETY);
+            EXPECT_EQUAL(raw_state.is_ready_for_input, 1);
+        }
+
+        /* Test: Too much data requested */
+        {
+            uint8_t result_data[sizeof(test_data)] = { 0 };
+            EXPECT_FAILURE_WITH_ERRNO(s2n_hash_digest(&raw_state, result_data, sizeof(test_data) * 2),
+                    S2N_ERR_SAFETY);
+            EXPECT_EQUAL(raw_state.is_ready_for_input, 1);
+        }
+
+        /* Test: Correct digest size requested */
+        {
+            uint8_t result_data[sizeof(test_data)] = { 0 };
+            EXPECT_SUCCESS(s2n_hash_digest(&raw_state, result_data, sizeof(result_data)));
+            EXPECT_EQUAL(raw_state.is_ready_for_input, 0);
+            EXPECT_EQUAL(raw_state.currently_in_hash, 0);
+
+            /* Despite the name, s2n_hash_digest just returns the raw test data */
+            EXPECT_BYTEARRAY_EQUAL(result_data, test_data, sizeof(test_data));
+        }
+
+        /* Test: Cannot digest again */
+        {
+            uint8_t result_data[sizeof(test_data)] = { 0 };
+            EXPECT_FAILURE_WITH_ERRNO(s2n_hash_digest(&raw_state, result_data, sizeof(result_data)),
+                    S2N_ERR_HASH_NOT_READY);
+        }
+    };
+
+    /* Test: s2n_hash_new_copy */
+    {
+        uint8_t test_data[] = "data for copying";
+
+        uint8_t buffer_bytes[sizeof(test_data)] = { 0 };
+        struct s2n_blob buffer = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&buffer, buffer_bytes, sizeof(buffer_bytes)));
+
+        DEFER_CLEANUP(struct s2n_hash_state raw_state = { 0 }, s2n_hash_free);
+        EXPECT_OK(s2n_hash_new_raw(&raw_state, &buffer));
+        EXPECT_SUCCESS(s2n_hash_init(&raw_state, S2N_HASH_SHA256));
+        EXPECT_SUCCESS(s2n_hash_update(&raw_state, test_data, sizeof(test_data)));
+
+        DEFER_CLEANUP(struct s2n_hash_state copy_state = { 0 }, s2n_hash_free);
+        EXPECT_OK(s2n_hash_new_copy(&copy_state, &raw_state));
+
+        /* Copy fields match original fields */
+        EXPECT_EQUAL(raw_state.alg, copy_state.alg);
+        EXPECT_EQUAL(raw_state.currently_in_hash, copy_state.currently_in_hash);
+        EXPECT_EQUAL(raw_state.is_ready_for_input, copy_state.is_ready_for_input);
+        EXPECT_EQUAL(raw_state.hash_impl, copy_state.hash_impl);
+
+        /* Stuffer data in copy matches original */
+        EXPECT_EQUAL(s2n_stuffer_data_available(&raw_state.digest.raw_data),
+                s2n_stuffer_data_available(&copy_state.digest.raw_data));
+        EXPECT_BYTEARRAY_EQUAL(raw_state.digest.raw_data.blob.data, test_data, sizeof(test_data));
+        EXPECT_BYTEARRAY_EQUAL(copy_state.digest.raw_data.blob.data, test_data, sizeof(test_data));
+
+        /* Both digests can be calculated separately */
+        uint8_t original_result[sizeof(test_data)] = { 0 };
+        uint8_t copy_result[sizeof(test_data)] = { 0 };
+        EXPECT_SUCCESS(s2n_hash_digest(&raw_state, original_result, sizeof(original_result)));
+        EXPECT_SUCCESS(s2n_hash_digest(&copy_state, copy_result, sizeof(copy_result)));
+        EXPECT_BYTEARRAY_EQUAL(original_result, test_data, sizeof(test_data));
+        EXPECT_BYTEARRAY_EQUAL(copy_result, test_data, sizeof(test_data));
+    };
+
+    /* Test: s2n_hash_reset */
+    {
+        uint8_t test_data[] = "data for reseting";
+
+        uint8_t buffer_bytes[sizeof(test_data)] = { 0 };
+        struct s2n_blob buffer = { 0 };
+        EXPECT_SUCCESS(s2n_blob_init(&buffer, buffer_bytes, sizeof(buffer_bytes)));
+
+        DEFER_CLEANUP(struct s2n_hash_state raw_state = { 0 }, s2n_hash_free);
+        EXPECT_OK(s2n_hash_new_raw(&raw_state, &buffer));
+        EXPECT_SUCCESS(s2n_hash_init(&raw_state, S2N_HASH_SHA256));
+        EXPECT_SUCCESS(s2n_hash_update(&raw_state, test_data, sizeof(test_data)));
+
+        struct s2n_stuffer *raw_data = &raw_state.digest.raw_data;
+
+        EXPECT_NOT_EQUAL(s2n_stuffer_data_available(raw_data), 0);
+        EXPECT_EQUAL(s2n_hash_get_type(&raw_state), S2N_HASH_TYPE_RAW);
+
+        EXPECT_SUCCESS(s2n_hash_reset(&raw_state));
+
+        EXPECT_EQUAL(s2n_stuffer_data_available(raw_data), 0);
+        EXPECT_EQUAL(s2n_hash_get_type(&raw_state), S2N_HASH_TYPE_RAW);
+    };
+
+    END_TEST();
+}

--- a/tls/s2n_tls13_certificate_verify.c
+++ b/tls/s2n_tls13_certificate_verify.c
@@ -48,14 +48,18 @@ const uint8_t S2N_CLIENT_CERT_VERIFY_CONTEXT[] = { 0x54, 0x4c, 0x53, 0x20, 0x31,
     0x2c, 0x20, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x20, 0x43, 0x65, 0x72, 0x74, 0x69,
     0x66, 0x69, 0x63, 0x61, 0x74, 0x65, 0x56, 0x65, 0x72, 0x69, 0x66, 0x79, 0x00 };
 
+#define S2N_CERT_VERIFY_MAX_CONTEXT_SIZE \
+    (MAX(sizeof(S2N_SERVER_CERT_VERIFY_CONTEXT), sizeof(S2N_CLIENT_CERT_VERIFY_CONTEXT))
+#define S2N_CERT_VERIFY_MAX_DATA_SIZE \
+    (sizeof(S2N_CERT_VERIFY_PREFIX) + S2N_MAX_DIGEST_LEN + S2N_CERT_VERIFY_MAX_CONTEXT_SIZE))
+
 static int s2n_tls13_write_cert_verify_signature(struct s2n_connection *conn,
         const struct s2n_signature_scheme *chosen_sig_scheme);
 static int s2n_tls13_write_signature(struct s2n_connection *conn, struct s2n_blob *signature);
-static int s2n_tls13_generate_unsigned_cert_verify_content(struct s2n_connection *conn,
-        struct s2n_stuffer *unsigned_content, s2n_mode mode);
+int s2n_tls13_generate_unsigned_cert_verify_content(struct s2n_connection *conn,
+        struct s2n_hash_state *signing_input, s2n_mode mode);
 static int s2n_tls13_cert_read_and_verify_signature(struct s2n_connection *conn,
         const struct s2n_signature_scheme *chosen_sig_scheme);
-static uint8_t s2n_tls13_cert_verify_header_length(s2n_mode mode);
 
 int s2n_tls13_cert_verify_send(struct s2n_connection *conn)
 {
@@ -72,6 +76,18 @@ int s2n_tls13_cert_verify_send(struct s2n_connection *conn)
     return 0;
 }
 
+static S2N_RESULT s2n_pkey_signing_input(struct s2n_hash_state *hash_state,
+        s2n_hash_algorithm hash_alg, struct s2n_blob *buffer)
+{
+    if (hash_alg == S2N_HASH_INTRINSIC) {
+        RESULT_GUARD(s2n_hash_new_raw(hash_state, buffer));
+    } else {
+        RESULT_GUARD_POSIX(s2n_hash_new(hash_state));
+    }
+    RESULT_GUARD_POSIX(s2n_hash_init(hash_state, hash_alg));
+    return S2N_RESULT_OK;
+}
+
 int s2n_tls13_write_cert_verify_signature(struct s2n_connection *conn,
         const struct s2n_signature_scheme *chosen_sig_scheme)
 {
@@ -81,17 +97,16 @@ int s2n_tls13_write_cert_verify_signature(struct s2n_connection *conn,
     struct s2n_stuffer *out = &conn->handshake.io;
     POSIX_GUARD(s2n_stuffer_write_uint16(out, chosen_sig_scheme->iana_value));
 
-    DEFER_CLEANUP(struct s2n_hash_state message_hash = { 0 }, s2n_hash_free);
-    POSIX_GUARD(s2n_hash_new(&message_hash));
-    POSIX_GUARD(s2n_hash_init(&message_hash, chosen_sig_scheme->hash_alg));
+    uint8_t buffer_data[S2N_CERT_VERIFY_MAX_DATA_SIZE] = { 0 };
+    struct s2n_blob buffer = { 0 };
+    DEFER_CLEANUP(struct s2n_hash_state signing_input = { 0 }, s2n_hash_free);
+    POSIX_GUARD(s2n_blob_init(&buffer, buffer_data, sizeof(buffer_data)));
+    POSIX_GUARD_RESULT(s2n_pkey_signing_input(&signing_input,
+            chosen_sig_scheme->hash_alg, &buffer));
 
-    DEFER_CLEANUP(struct s2n_stuffer unsigned_content = { 0 }, s2n_stuffer_free);
-    POSIX_GUARD(s2n_tls13_generate_unsigned_cert_verify_content(conn, &unsigned_content, conn->mode));
+    POSIX_GUARD(s2n_tls13_generate_unsigned_cert_verify_content(conn, &signing_input, conn->mode));
 
-    POSIX_GUARD(s2n_hash_update(&message_hash, unsigned_content.blob.data,
-            s2n_stuffer_data_available(&unsigned_content)));
-
-    S2N_ASYNC_PKEY_SIGN(conn, chosen_sig_scheme->sig_alg, &message_hash, s2n_tls13_write_signature);
+    S2N_ASYNC_PKEY_SIGN(conn, chosen_sig_scheme->sig_alg, &signing_input, s2n_tls13_write_signature);
 }
 
 int s2n_tls13_write_signature(struct s2n_connection *conn, struct s2n_blob *signature)
@@ -105,42 +120,31 @@ int s2n_tls13_write_signature(struct s2n_connection *conn, struct s2n_blob *sign
 }
 
 int s2n_tls13_generate_unsigned_cert_verify_content(struct s2n_connection *conn,
-        struct s2n_stuffer *unsigned_content, s2n_mode mode)
+        struct s2n_hash_state *signing_input, s2n_mode mode)
 {
     s2n_tls13_connection_keys(tls13_ctx, conn);
 
     uint8_t hash_digest_length = tls13_ctx.size;
-    uint8_t digest_out[S2N_MAX_DIGEST_LEN];
+    uint8_t digest_out[S2N_MAX_DIGEST_LEN] = { 0 };
 
-    /* Get current handshake hash */
+    /* Get current handshake transcript digest */
     POSIX_ENSURE_REF(conn->handshake.hashes);
     struct s2n_hash_state *hash_state = &conn->handshake.hashes->hash_workspace;
     POSIX_GUARD_RESULT(s2n_handshake_copy_hash_state(conn, tls13_ctx.hash_algorithm, hash_state));
     POSIX_GUARD(s2n_hash_digest(hash_state, digest_out, hash_digest_length));
 
-    /* Concatenate the content to be signed/verified */
-    POSIX_GUARD(s2n_stuffer_alloc(unsigned_content, hash_digest_length + s2n_tls13_cert_verify_header_length(mode)));
-    POSIX_GUARD(s2n_stuffer_write_bytes(unsigned_content, S2N_CERT_VERIFY_PREFIX, sizeof(S2N_CERT_VERIFY_PREFIX)));
-
+    /* Write the content to be signed/verified */
+    POSIX_GUARD(s2n_hash_update(signing_input, S2N_CERT_VERIFY_PREFIX, sizeof(S2N_CERT_VERIFY_PREFIX)));
     if (mode == S2N_CLIENT) {
-        POSIX_GUARD(s2n_stuffer_write_bytes(unsigned_content, S2N_CLIENT_CERT_VERIFY_CONTEXT,
+        POSIX_GUARD(s2n_hash_update(signing_input, S2N_CLIENT_CERT_VERIFY_CONTEXT,
                 sizeof(S2N_CLIENT_CERT_VERIFY_CONTEXT)));
     } else {
-        POSIX_GUARD(s2n_stuffer_write_bytes(unsigned_content, S2N_SERVER_CERT_VERIFY_CONTEXT,
+        POSIX_GUARD(s2n_hash_update(signing_input, S2N_SERVER_CERT_VERIFY_CONTEXT,
                 sizeof(S2N_SERVER_CERT_VERIFY_CONTEXT)));
     }
+    POSIX_GUARD(s2n_hash_update(signing_input, digest_out, hash_digest_length));
 
-    POSIX_GUARD(s2n_stuffer_write_bytes(unsigned_content, digest_out, hash_digest_length));
-
-    return 0;
-}
-
-uint8_t s2n_tls13_cert_verify_header_length(s2n_mode mode)
-{
-    if (mode == S2N_CLIENT) {
-        return sizeof(S2N_CERT_VERIFY_PREFIX) + sizeof(S2N_CLIENT_CERT_VERIFY_CONTEXT);
-    }
-    return sizeof(S2N_CERT_VERIFY_PREFIX) + sizeof(S2N_SERVER_CERT_VERIFY_CONTEXT);
+    return S2N_SUCCESS;
 }
 
 int s2n_tls13_cert_verify_recv(struct s2n_connection *conn)
@@ -162,10 +166,6 @@ int s2n_tls13_cert_read_and_verify_signature(struct s2n_connection *conn,
         const struct s2n_signature_scheme *chosen_sig_scheme)
 {
     struct s2n_stuffer *in = &conn->handshake.io;
-    DEFER_CLEANUP(struct s2n_blob signed_content = { 0 }, s2n_free);
-    DEFER_CLEANUP(struct s2n_stuffer unsigned_content = { 0 }, s2n_stuffer_free);
-    DEFER_CLEANUP(struct s2n_hash_state message_hash = { 0 }, s2n_hash_free);
-    POSIX_GUARD(s2n_hash_new(&message_hash));
 
     /* Get signature size */
     uint16_t signature_size = 0;
@@ -173,28 +173,26 @@ int s2n_tls13_cert_read_and_verify_signature(struct s2n_connection *conn,
     S2N_ERROR_IF(signature_size > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
 
     /* Get wire signature */
-    POSIX_GUARD(s2n_alloc(&signed_content, signature_size));
-    signed_content.size = signature_size;
-    POSIX_GUARD(s2n_stuffer_read_bytes(in, signed_content.data, signature_size));
+    struct s2n_blob signed_content = { 0 };
+    uint8_t *signature_data = s2n_stuffer_raw_read(in, signature_size);
+    POSIX_ENSURE_REF(signature_data);
+    POSIX_GUARD(s2n_blob_init(&signed_content, signature_data, signature_size));
 
-    /* Verify signature. We send the opposite mode as we are trying to verify what was sent to us */
-    if (conn->mode == S2N_CLIENT) {
-        POSIX_GUARD(s2n_tls13_generate_unsigned_cert_verify_content(conn, &unsigned_content, S2N_SERVER));
-    } else {
-        POSIX_GUARD(s2n_tls13_generate_unsigned_cert_verify_content(conn, &unsigned_content, S2N_CLIENT));
-    }
+    uint8_t buffer_data[S2N_CERT_VERIFY_MAX_DATA_SIZE] = { 0 };
+    struct s2n_blob buffer = { 0 };
+    DEFER_CLEANUP(struct s2n_hash_state signing_input = { 0 }, s2n_hash_free);
+    POSIX_GUARD(s2n_blob_init(&buffer, buffer_data, sizeof(buffer_data)));
+    POSIX_GUARD_RESULT(s2n_pkey_signing_input(&signing_input,
+            chosen_sig_scheme->hash_alg, &buffer));
 
-    POSIX_GUARD(s2n_hash_init(&message_hash, chosen_sig_scheme->hash_alg));
-    POSIX_GUARD(s2n_hash_update(&message_hash, unsigned_content.blob.data,
-            s2n_stuffer_data_available(&unsigned_content)));
+    /* We generate cert verify content for the peer's mode, not our own,
+     * because we are verifying the peer's signature rather than signing. */
+    POSIX_GUARD(s2n_tls13_generate_unsigned_cert_verify_content(conn, &signing_input, S2N_PEER_MODE(conn->mode)));
 
-    if (conn->mode == S2N_CLIENT) {
-        POSIX_GUARD(s2n_pkey_verify(&conn->handshake_params.server_public_key, chosen_sig_scheme->sig_alg,
-                &message_hash, &signed_content));
-    } else {
-        POSIX_GUARD(s2n_pkey_verify(&conn->handshake_params.client_public_key, chosen_sig_scheme->sig_alg,
-                &message_hash, &signed_content));
-    }
+    const struct s2n_pkey *pkey = (conn->mode == S2N_CLIENT) ?
+            &conn->handshake_params.server_public_key :
+            &conn->handshake_params.client_public_key;
 
-    return 0;
+    POSIX_GUARD(s2n_pkey_verify(pkey, chosen_sig_scheme->sig_alg, &signing_input, &signed_content));
+    return S2N_SUCCESS;
 }


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

related to https://github.com/aws/s2n-tls/issues/5257

### Description of changes: 

I added a new implementation of s2n_hash that is capable of handling "implicit" hash algorithms by storing raw data instead of calculating a running hash. I also integrated the new hash implementation into the TLS1.3 Cert Verify code to demonstrate how it works.

### Call-outs:

My primary concern with this "raw hash" solution was that it could cause confusion. s2n-tls uses hashes for use cases other than signing, like HMACs and PRFs, where a hash algorithm that doesn't actually hash doesn't make any sense. I think that concern is somewhat mitigated because:
1) raw hashes can't be created via the old s2n_hash_new method. You have to specifically call s2n_hash_new_raw.
2) there are already two "not real" hash algorithm enum values: S2N_HASH_NONE and S2N_HASH_ALGS_COUNT

### Testing:

I added new unit tests for the raw hash.
I should probably add CBMC proofs for the new hash methods (or at least for s2n_hash_new_copy, since our proofs only care about evp hashes) in a follow-up PR, but honestly my belief that the hash CBMC proofs are useful has been pretty shaken.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
