### PR TITLE
feat: Add `as_ptr()` API for Config

### DIFF
--- a/codebuild/bin/grep_simple_mistakes.sh
+++ b/codebuild/bin/grep_simple_mistakes.sh
@@ -43,6 +43,7 @@ KNOWN_MISSES=(
     "s2n_config_set_ctx"
     "s2n_client_hello_has_extension"
     "s2n_async_pkey_op_perform"
+    "s2n_config_get_client_auth_type"
 )
 C_DOCS_FAILED=0
 for api in $C_APIS; do


### PR DESCRIPTION
### Description of changes: 

Allows access to the underlying s2n_tls_sys s2n_config pointer from the `config::Builder` for external builds, similar to https://github.com/aws/s2n-tls/pull/5229. This allows applications to directly call s2n_tls_sys s2n_config APIs when a higher-level API isn't provided.

### Testing:

I added a new test to ensure that the new API can be used to call an s2n-tls-sys API. The external build test added in https://github.com/aws/s2n-tls/pull/5229 ensures that this test is running in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
