### PR TITLE
refactor: remove conn->client_hello_version

### DIFF
--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -106,6 +106,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_conn->client_hello.sslv2, true);
         EXPECT_EQUAL(server_conn->client_hello.legacy_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->client_hello.callback_invoked, 1);
+        EXPECT_EQUAL(s2n_connection_get_client_hello_version(server_conn), S2N_SSLv2);
 
         s2n_connection_free(server_conn);
 
@@ -545,6 +546,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server->client_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server->client_hello.legacy_version, S2N_TLS12);
         EXPECT_TRUE(server->client_hello.sslv2);
+        EXPECT_EQUAL(s2n_connection_get_client_hello_version(server_conn), S2N_SSLv2);
     };
 
     s2n_config_free(tls12_config);

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -101,7 +101,6 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_hello));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
 
-        EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->client_hello.sslv2, true);

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -546,7 +546,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server->client_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server->client_hello.legacy_version, S2N_TLS12);
         EXPECT_TRUE(server->client_hello.sslv2);
-        EXPECT_EQUAL(s2n_connection_get_client_hello_version(server_conn), S2N_SSLv2);
+        EXPECT_EQUAL(s2n_connection_get_client_hello_version(server), S2N_SSLv2);
     };
 
     s2n_config_free(tls12_config);

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -83,8 +83,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, tls13_config));
 
         /* Record version and protocol version are in the header for SSLv2 */
-        server_conn->client_hello_version = S2N_SSLv2;
-        server_conn->client_protocol_version = S2N_TLS12;
+        server_conn->client_hello.sslv2 = true;
+        server_conn->client_hello.legacy_version = S2N_TLS12;
 
         uint8_t sslv2_client_hello[] = {
             SSLv2_CLIENT_HELLO_PREFIX,
@@ -101,9 +101,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_hello));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
 
+        EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
-        EXPECT_EQUAL(server_conn->client_hello_version, S2N_SSLv2);
+        EXPECT_EQUAL(server_conn->client_hello.sslv2, true);
+        EXPECT_EQUAL(server_conn->client_hello.legacy_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->client_hello.callback_invoked, 1);
 
         s2n_connection_free(server_conn);
@@ -122,7 +124,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
         EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS12);
-        EXPECT_EQUAL(client_conn->client_hello_version, S2N_TLS12);
+        EXPECT_EQUAL(client_conn->client_hello.legacy_version, S2N_TLS12);
 
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
@@ -147,7 +149,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
         EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS12);
-        EXPECT_EQUAL(client_conn->client_hello_version, S2N_TLS12);
+        EXPECT_EQUAL(client_conn->client_hello.legacy_version, S2N_TLS12);
 
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
@@ -155,7 +157,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
-        EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS12);
+        EXPECT_EQUAL(server_conn->client_hello.legacy_version, S2N_TLS12);
 
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
@@ -177,7 +179,7 @@ int main(int argc, char **argv)
         client_conn->client_protocol_version = S2N_TLS11;
 
         EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
-        EXPECT_EQUAL(client_conn->client_hello_version, S2N_TLS11);
+        EXPECT_EQUAL(client_conn->client_hello.legacy_version, S2N_TLS11);
 
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
@@ -185,7 +187,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS11);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS11);
-        EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS11);
+        EXPECT_EQUAL(server_conn->client_hello.legacy_version, S2N_TLS11);
 
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
@@ -205,7 +207,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
         EXPECT_EQUAL(client_conn->client_protocol_version, S2N_TLS12);
-        EXPECT_EQUAL(client_conn->client_hello_version, S2N_TLS12);
+        EXPECT_EQUAL(client_conn->client_hello.legacy_version, S2N_TLS12);
 
         EXPECT_SUCCESS(s2n_stuffer_write(&server_conn->handshake.io, &client_conn->handshake.io.blob));
         EXPECT_SUCCESS(s2n_client_hello_recv(server_conn));
@@ -213,7 +215,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
-        EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS12);
+        EXPECT_EQUAL(server_conn->client_hello.legacy_version, S2N_TLS12);
 
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
@@ -247,12 +249,12 @@ int main(int argc, char **argv)
 
         EXPECT_EQUAL(client_conn->actual_protocol_version, s2n_get_highest_fully_supported_tls_version());
         EXPECT_EQUAL(client_conn->client_protocol_version, s2n_get_highest_fully_supported_tls_version());
-        EXPECT_EQUAL(client_conn->client_hello_version, S2N_TLS12);
+        EXPECT_EQUAL(client_conn->client_hello.legacy_version, S2N_TLS12);
 
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->actual_protocol_version, s2n_get_highest_fully_supported_tls_version());
         EXPECT_EQUAL(server_conn->client_protocol_version, s2n_get_highest_fully_supported_tls_version());
-        EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS12);
+        EXPECT_EQUAL(server_conn->client_hello.legacy_version, S2N_TLS13);
 
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
@@ -279,7 +281,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->actual_protocol_version, s2n_get_highest_fully_supported_tls_version());
         EXPECT_EQUAL(server_conn->client_protocol_version, s2n_get_highest_fully_supported_tls_version());
-        EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS12);
+        EXPECT_EQUAL(server_conn->client_hello.legacy_version, S2N_TLS12);
 
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
@@ -313,7 +315,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_conn->server_protocol_version, s2n_get_highest_fully_supported_tls_version());
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
-        EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS12);
+        EXPECT_EQUAL(server_conn->client_hello.legacy_version, S2N_TLS13);
 
         s2n_connection_free(server_conn);
         s2n_connection_free(client_conn);
@@ -352,8 +354,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, tls12_config));
 
         /* Record version and protocol version are in the header for SSLv2 */
-        server_conn->client_hello_version = S2N_SSLv2;
-        server_conn->client_protocol_version = S2N_TLS12;
+        server_conn->client_hello.sslv2 = true;
+        server_conn->client_hello.legacy_version = S2N_TLS12;
 
         /* Writing a sslv2 client hello with a length 0 cipher suite list */
         uint8_t sslv2_client_hello[] = {
@@ -501,7 +503,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
-        EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS12);
+        EXPECT_EQUAL(server_conn->client_hello.legacy_version, S2N_TLS12);
 
         s2n_connection_free(server_conn);
         EXPECT_SUCCESS(s2n_disable_tls13_in_test());
@@ -542,7 +544,7 @@ int main(int argc, char **argv)
         /* Successfully read the full message */
         EXPECT_OK(s2n_negotiate_until_message(server, &blocked, SERVER_HELLO));
         EXPECT_EQUAL(server->client_protocol_version, S2N_TLS12);
-        EXPECT_EQUAL(server->client_hello_version, S2N_SSLv2);
+        EXPECT_EQUAL(server->client_hello.legacy_version, S2N_TLS12);
         EXPECT_TRUE(server->client_hello.sslv2);
     };
 

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -749,7 +749,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_send(conn));
             EXPECT_EQUAL(conn->actual_protocol_version, s2n_get_highest_fully_supported_tls_version());
             EXPECT_EQUAL(conn->client_protocol_version, s2n_get_highest_fully_supported_tls_version());
-            EXPECT_EQUAL(conn->client_hello_version, S2N_TLS12);
+            EXPECT_EQUAL(conn->client_hello.legacy_version, S2N_TLS12);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         };
@@ -768,7 +768,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_send(conn));
             EXPECT_EQUAL(conn->actual_protocol_version, S2N_TLS12);
             EXPECT_EQUAL(conn->client_protocol_version, S2N_TLS12);
-            EXPECT_EQUAL(conn->client_hello_version, S2N_TLS12);
+            EXPECT_EQUAL(conn->client_hello.legacy_version, S2N_TLS12);
 
             EXPECT_SUCCESS(s2n_connection_free(conn));
         };
@@ -789,7 +789,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_client_hello_send(client_conn));
             EXPECT_EQUAL(client_conn->actual_protocol_version, s2n_get_highest_fully_supported_tls_version());
             EXPECT_EQUAL(client_conn->client_protocol_version, s2n_get_highest_fully_supported_tls_version());
-            EXPECT_EQUAL(client_conn->client_hello_version, S2N_TLS12);
+            EXPECT_EQUAL(client_conn->client_hello.legacy_version, S2N_TLS12);
 
             /* Server configured with TLS 1.2 negotiates TLS12 version */
             EXPECT_NOT_NULL(server_conn = s2n_connection_new(S2N_SERVER));
@@ -809,7 +809,7 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(server_conn->server_protocol_version, S2N_TLS12);
             EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
             EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS12);
-            EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS12);
+            EXPECT_EQUAL(server_conn->client_hello.legacy_version, S2N_TLS12);
 
             EXPECT_SUCCESS(s2n_connection_free(server_conn));
             EXPECT_SUCCESS(s2n_connection_free(client_conn));
@@ -1538,12 +1538,12 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_handshake_type_set_tls13_flag(server_conn, HELLO_RETRY_REQUEST));
 
         /* Second client hello has version SSLv2 */
-        server_conn->client_hello_version = S2N_SSLv2;
+        server_conn->client_hello.sslv2 = true;
 
         /* Mock having some data in the client hello */
         EXPECT_SUCCESS(s2n_stuffer_write_uint16(&server_conn->handshake.io, 100));
 
-        EXPECT_FAILURE_WITH_ERRNO(s2n_parse_client_hello(server_conn), S2N_ERR_SAFETY);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_parse_client_hello(server_conn), S2N_ERR_BAD_MESSAGE);
     };
 
     /* Test s2n_client_hello_parse_message

--- a/tests/unit/s2n_client_supported_versions_extension_test.c
+++ b/tests/unit/s2n_client_supported_versions_extension_test.c
@@ -440,7 +440,7 @@ int main(int argc, char **argv)
         /* The server does not use the protocol version in the Client Hello to set the actual protocol version. */
         EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS13);
         EXPECT_EQUAL(server_conn->client_protocol_version, S2N_TLS13);
-        EXPECT_EQUAL(server_conn->client_hello_version, S2N_TLS10);
+        EXPECT_EQUAL(server_conn->client_hello.legacy_version, S2N_TLS10);
     }
 
     /* Ensure that TLS 1.3 is enforced in the supported versions extension for ClientHellos sent in

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -1259,8 +1259,8 @@ int main(int argc, char **argv)
             server_conn->config = NULL;
 
             /* Record version and protocol version are in the header for SSLv2 */
-            server_conn->client_hello_version = S2N_SSLv2;
-            server_conn->client_protocol_version = S2N_TLS12;
+            server_conn->client_hello.sslv2 = true;
+            server_conn->client_hello.legacy_version = S2N_TLS12;
 
             /* S2N_ERR_CONFIG_NULL_BEFORE_CH_CALLBACK is only called in one location, just before the
              * client hello callback. Therefore, we can assert that if we hit this error, we

--- a/tests/unit/s2n_connection_protocol_versions_test.c
+++ b/tests/unit/s2n_connection_protocol_versions_test.c
@@ -76,7 +76,7 @@ static int s2n_overwrite_client_hello_cb(struct s2n_connection *conn, void *ctx)
      * with a different version.
      */
     if (context->client_hello_version) {
-        conn->client_hello_version = context->client_hello_version;
+        conn->client_hello.legacy_version = context->client_hello_version;
         conn->client_protocol_version = context->client_hello_version;
     }
 

--- a/tests/unit/s2n_fingerprint_ja3_test.c
+++ b/tests/unit/s2n_fingerprint_ja3_test.c
@@ -253,8 +253,8 @@ int main(int argc, char **argv)
              * not when processing the actual ClientHello message.
              * So we need to set the versions manually.
              */
-            server->client_hello_version = S2N_SSLv2;
-            server->client_protocol_version = S2N_TLS12;
+            server->client_hello.sslv2 = true;
+            server->client_hello.legacy_version = S2N_TLS12;
 
             uint8_t sslv2_client_hello[] = {
                 SSLv2_CLIENT_HELLO_PREFIX,

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -354,7 +354,6 @@ static S2N_RESULT s2n_client_hello_verify_for_retry(struct s2n_connection *conn,
 }
 
 S2N_RESULT s2n_client_hello_parse_raw(struct s2n_client_hello *client_hello,
-        uint8_t client_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN],
         uint8_t client_random[S2N_TLS_RANDOM_DATA_LEN])
 {
     RESULT_ENSURE_REF(client_hello);
@@ -383,6 +382,7 @@ S2N_RESULT s2n_client_hello_parse_raw(struct s2n_client_hello *client_hello,
      **/
 
     /* legacy_version */
+    uint8_t client_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN] = { 0 };
     RESULT_GUARD_POSIX(s2n_stuffer_read_bytes(in, client_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
 
     /* Encode the version as a 1 byte representation of the two protocol version bytes, with the
@@ -428,6 +428,11 @@ int s2n_parse_client_hello(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
 
+    /* SSLv2 ClientHellos are not allowed during a HelloRetryRequest */
+    if (s2n_is_hello_retry_handshake(conn)) {
+        POSIX_ENSURE(!conn->client_hello.sslv2, S2N_ERR_BAD_MESSAGE);
+    }
+
     /* If a retry, move the old version of the client hello
      * somewhere safe so we can compare it to the new client hello later.
      */
@@ -439,12 +444,7 @@ int s2n_parse_client_hello(struct s2n_connection *conn)
 
     POSIX_GUARD(s2n_collect_client_hello(&conn->client_hello, &conn->handshake.io));
 
-    /* The ClientHello version must be TLS12 after a HelloRetryRequest */
-    if (s2n_is_hello_retry_handshake(conn)) {
-        POSIX_ENSURE_EQ(conn->client_hello_version, S2N_TLS12);
-    }
-
-    if (conn->client_hello_version == S2N_SSLv2) {
+    if (conn->client_hello.sslv2) {
         POSIX_GUARD(s2n_sslv2_client_hello_parse(conn));
         return S2N_SUCCESS;
     }
@@ -455,16 +455,14 @@ int s2n_parse_client_hello(struct s2n_connection *conn)
             S2N_TLS_RANDOM_DATA_LEN);
 
     /* Parse raw, collected client hello */
-    uint8_t client_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN] = { 0 };
     POSIX_GUARD_RESULT(s2n_client_hello_parse_raw(&conn->client_hello,
-            client_protocol_version, conn->handshake_params.client_random));
+            conn->handshake_params.client_random));
 
     /* Protocol version in the ClientHello is fixed at 0x0303(TLS 1.2) for
      * future versions of TLS. Therefore, we will negotiate down if a client sends
      * an unexpected value above 0x0303.
      */
-    conn->client_protocol_version = MIN((client_protocol_version[0] * 10) + client_protocol_version[1], S2N_TLS12);
-    conn->client_hello_version = conn->client_protocol_version;
+    conn->client_protocol_version = MIN(conn->client_hello.legacy_version, S2N_TLS12);
 
     /* Copy the session id to the connection. */
     conn->session_id_len = conn->client_hello.session_id.size;
@@ -502,9 +500,8 @@ static S2N_RESULT s2n_client_hello_parse_message_impl(struct s2n_client_hello **
     RESULT_GUARD_POSIX(s2n_collect_client_hello(client_hello, &in));
     RESULT_ENSURE(s2n_stuffer_data_available(&in) == 0, S2N_ERR_BAD_MESSAGE);
 
-    uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN] = { 0 };
     uint8_t random[S2N_TLS_RANDOM_DATA_LEN] = { 0 };
-    RESULT_GUARD(s2n_client_hello_parse_raw(client_hello, protocol_version, random));
+    RESULT_GUARD(s2n_client_hello_parse_raw(client_hello, random));
 
     *result = client_hello;
     ZERO_TO_DISABLE_DEFER_CLEANUP(client_hello);
@@ -593,7 +590,7 @@ int s2n_process_client_hello(struct s2n_connection *conn)
     POSIX_CHECKED_MEMCPY(previous_cipher_suite_iana, conn->secure->cipher_suite->iana_value, S2N_TLS_CIPHER_SUITE_LEN);
 
     /* Now choose the ciphers we have certs for. */
-    if (conn->client_hello_version == S2N_SSLv2) {
+    if (conn->client_hello.sslv2) {
         POSIX_GUARD(s2n_set_cipher_as_sslv2_server(conn, client_hello->cipher_suites.data,
                 client_hello->cipher_suites.size / S2N_SSLv2_CIPHER_SUITE_LEN));
     } else {
@@ -725,9 +722,9 @@ int s2n_client_hello_send(struct s2n_connection *conn)
     uint8_t client_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN] = { 0 };
 
     uint8_t reported_protocol_version = MIN(conn->client_protocol_version, S2N_TLS12);
+    conn->client_hello.legacy_version = reported_protocol_version;
     client_protocol_version[0] = reported_protocol_version / 10;
     client_protocol_version[1] = reported_protocol_version % 10;
-    conn->client_hello_version = reported_protocol_version;
     POSIX_GUARD(s2n_stuffer_write_bytes(out, client_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
 
     struct s2n_blob client_random = { 0 };
@@ -815,8 +812,8 @@ int s2n_client_hello_send(struct s2n_connection *conn)
  * Clients may send SSLv2 ClientHellos advertising higher protocol versions for
  * backwards compatibility reasons. See https://tools.ietf.org/rfc/rfc2246 Appendix E.
  *
- * In this case, conn->client_hello_version will be SSLv2, but conn->client_protocol_version
- * will likely be higher.
+ * In this case, conn->client_hello.legacy_version and conn->client_protocol_version
+ * will be higher than SSLv2.
  *
  * See http://www-archive.mozilla.org/projects/security/pki/nss/ssl/draft02.html Section 2.5
  * for a description of the expected SSLv2 format.
@@ -826,7 +823,7 @@ int s2n_client_hello_send(struct s2n_connection *conn)
 int s2n_sslv2_client_hello_parse(struct s2n_connection *conn)
 {
     struct s2n_client_hello *client_hello = &conn->client_hello;
-    client_hello->sslv2 = true;
+    conn->client_protocol_version = MIN(client_hello->legacy_version, S2N_TLS12);
 
     struct s2n_stuffer in_stuffer = { 0 };
     POSIX_GUARD(s2n_stuffer_init(&in_stuffer, &client_hello->raw_message));

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -48,6 +48,8 @@ static int s2n_rsa_client_key_recv_complete(struct s2n_connection *conn, bool rs
 static S2N_RESULT s2n_client_key_exchange_get_rsa_client_version(struct s2n_connection *conn,
         uint8_t client_version[S2N_TLS_PROTOCOL_VERSION_LEN])
 {
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(client_version);
     uint8_t client_version_for_rsa = MIN(conn->client_protocol_version, S2N_TLS12);
     client_version[0] = client_version_for_rsa / 10;
     client_version[1] = client_version_for_rsa % 10;

--- a/tls/s2n_client_key_exchange.c
+++ b/tls/s2n_client_key_exchange.c
@@ -31,12 +31,28 @@
 #include "utils/s2n_random.h"
 #include "utils/s2n_safety.h"
 
-#define get_client_hello_protocol_version(conn) (conn->client_hello_version == S2N_SSLv2 ? conn->client_protocol_version : conn->client_hello_version)
-
 typedef S2N_RESULT s2n_kex_client_key_method(const struct s2n_kex *kex, struct s2n_connection *conn, struct s2n_blob *shared_key);
 typedef void *s2n_stuffer_action(struct s2n_stuffer *stuffer, uint32_t data_len);
 
 static int s2n_rsa_client_key_recv_complete(struct s2n_connection *conn, bool rsa_failed, struct s2n_blob *shared_key);
+
+/*
+ *= https://www.rfc-editor.org/rfc/rfc5246#section-7.4.7.1
+ *#   client_version
+ *#      The latest (newest) version supported by the client.  This is
+ *#      used to detect version rollback attacks.
+ *
+ * However, TLS1.2 rsa kex does not account for the existence of TLS1.3.
+ * Therefore "latest" actually means "latest up to TLS1.2".
+ */
+static S2N_RESULT s2n_client_key_exchange_get_rsa_client_version(struct s2n_connection *conn,
+        uint8_t client_version[S2N_TLS_PROTOCOL_VERSION_LEN])
+{
+    uint8_t client_version_for_rsa = MIN(conn->client_protocol_version, S2N_TLS12);
+    client_version[0] = client_version_for_rsa / 10;
+    client_version[1] = client_version_for_rsa % 10;
+    return S2N_RESULT_OK;
+}
 
 static int s2n_hybrid_client_action(struct s2n_connection *conn, struct s2n_blob *combined_shared_key,
         s2n_kex_client_key_method kex_method, uint32_t *cursor, s2n_stuffer_action stuffer_action)
@@ -109,7 +125,6 @@ int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared
     S2N_ASYNC_PKEY_GUARD(conn);
 
     struct s2n_stuffer *in = &conn->handshake.io;
-    uint8_t client_hello_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
     uint16_t length = 0;
 
     if (conn->actual_protocol_version == S2N_SSLv3) {
@@ -120,13 +135,8 @@ int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared
 
     S2N_ERROR_IF(length > s2n_stuffer_data_available(in), S2N_ERR_BAD_MESSAGE);
 
-    /* Keep a copy of the client hello version in wire format, which should be
-     * either the protocol version supported by client if the supported version is <= TLS1.2,
-     * or TLS1.2 (the legacy version) if client supported version is TLS1.3
-     */
-    uint8_t legacy_client_hello_protocol_version = get_client_hello_protocol_version(conn);
-    client_hello_protocol_version[0] = legacy_client_hello_protocol_version / 10;
-    client_hello_protocol_version[1] = legacy_client_hello_protocol_version % 10;
+    uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN] = { 0 };
+    POSIX_GUARD_RESULT(s2n_client_key_exchange_get_rsa_client_version(conn, protocol_version));
 
     /* Decrypt the pre-master secret */
     struct s2n_blob encrypted = { 0 };
@@ -136,8 +146,8 @@ int s2n_rsa_client_key_recv(struct s2n_connection *conn, struct s2n_blob *shared
 
     /* First: use a random pre-master secret */
     POSIX_GUARD_RESULT(s2n_get_private_random_data(shared_key));
-    conn->secrets.version.tls12.rsa_premaster_secret[0] = client_hello_protocol_version[0];
-    conn->secrets.version.tls12.rsa_premaster_secret[1] = client_hello_protocol_version[1];
+    conn->secrets.version.tls12.rsa_premaster_secret[0] = protocol_version[0];
+    conn->secrets.version.tls12.rsa_premaster_secret[1] = protocol_version[1];
 
     S2N_ASYNC_PKEY_DECRYPT(conn, &encrypted, shared_key, s2n_rsa_client_key_recv_complete);
 }
@@ -153,15 +163,13 @@ int s2n_rsa_client_key_recv_complete(struct s2n_connection *conn, bool rsa_faile
     }
 
     /* Get client hello protocol version for comparison with decrypted data */
-    uint8_t legacy_client_hello_protocol_version = get_client_hello_protocol_version(conn);
-    uint8_t client_hello_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
-    client_hello_protocol_version[0] = legacy_client_hello_protocol_version / 10;
-    client_hello_protocol_version[1] = legacy_client_hello_protocol_version % 10;
+    uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN] = { 0 };
+    POSIX_GUARD_RESULT(s2n_client_key_exchange_get_rsa_client_version(conn, protocol_version));
 
     conn->handshake.rsa_failed = rsa_failed;
 
     /* Set rsa_failed to true, if it isn't already, if the protocol version isn't what we expect */
-    conn->handshake.rsa_failed |= !s2n_constant_time_equals(client_hello_protocol_version,
+    conn->handshake.rsa_failed |= !s2n_constant_time_equals(protocol_version,
             conn->secrets.version.tls12.rsa_premaster_secret, S2N_TLS_PROTOCOL_VERSION_LEN);
 
     /* Required to protect against Bleichenbacher attack.
@@ -169,8 +177,8 @@ int s2n_rsa_client_key_recv_complete(struct s2n_connection *conn, bool rsa_faile
      * We choose the first option: always setting the version in the rsa_premaster_secret
      * from our local view of the client_hello value.
      */
-    conn->secrets.version.tls12.rsa_premaster_secret[0] = client_hello_protocol_version[0];
-    conn->secrets.version.tls12.rsa_premaster_secret[1] = client_hello_protocol_version[1];
+    conn->secrets.version.tls12.rsa_premaster_secret[0] = protocol_version[0];
+    conn->secrets.version.tls12.rsa_premaster_secret[1] = protocol_version[1];
 
     return 0;
 }
@@ -260,10 +268,8 @@ int s2n_ecdhe_client_key_send(struct s2n_connection *conn, struct s2n_blob *shar
 
 int s2n_rsa_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared_key)
 {
-    uint8_t client_hello_protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
-    uint8_t legacy_client_hello_protocol_version = get_client_hello_protocol_version(conn);
-    client_hello_protocol_version[0] = legacy_client_hello_protocol_version / 10;
-    client_hello_protocol_version[1] = legacy_client_hello_protocol_version % 10;
+    uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN] = { 0 };
+    POSIX_GUARD_RESULT(s2n_client_key_exchange_get_rsa_client_version(conn, protocol_version));
 
     shared_key->data = conn->secrets.version.tls12.rsa_premaster_secret;
     shared_key->size = S2N_TLS_SECRET_LEN;
@@ -274,7 +280,7 @@ int s2n_rsa_client_key_send(struct s2n_connection *conn, struct s2n_blob *shared
      * The latest version supported by client (as seen from the the client hello version) are <= TLS1.2
      * for all clients, because TLS 1.3 clients freezes the TLS1.2 legacy version in client hello.
      */
-    POSIX_CHECKED_MEMCPY(conn->secrets.version.tls12.rsa_premaster_secret, client_hello_protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN);
+    POSIX_CHECKED_MEMCPY(conn->secrets.version.tls12.rsa_premaster_secret, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN);
 
     uint32_t encrypted_size = 0;
     POSIX_GUARD_RESULT(s2n_pkey_size(&conn->handshake_params.server_public_key, &encrypted_size));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1097,7 +1097,11 @@ int s2n_connection_get_client_hello_version(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
 
-    return conn->client_hello_version;
+    if (conn->client_hello.sslv2) {
+        return S2N_SSLv2;
+    } else {
+        return MIN(conn->client_hello.legacy_version, S2N_TLS12);
+    }
 }
 
 int s2n_connection_client_cert_used(struct s2n_connection *conn)

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -203,7 +203,6 @@ struct s2n_connection {
     /* The version advertised by the client, by the
      * server, and the actual version we are currently
      * speaking. */
-    uint8_t client_hello_version;
     uint8_t client_protocol_version;
     uint8_t server_protocol_version;
     uint8_t actual_protocol_version;

--- a/tls/s2n_establish_session.c
+++ b/tls/s2n_establish_session.c
@@ -37,7 +37,7 @@ int s2n_establish_session(struct s2n_connection *conn)
     POSIX_GUARD_RESULT(s2n_early_data_accept_or_reject(conn));
     POSIX_GUARD(s2n_conn_set_handshake_type(conn));
 
-    if (conn->client_hello_version != S2N_SSLv2) {
+    if (!conn->client_hello.sslv2) {
         /* We've selected the parameters for the handshake, update the required hashes for this connection */
         POSIX_GUARD(s2n_conn_update_required_handshake_hashes(conn));
     }

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1326,8 +1326,7 @@ static int s2n_handshake_handle_sslv2(struct s2n_connection *conn)
 
     /* Handle an SSLv2 client hello */
     POSIX_GUARD(s2n_stuffer_copy(&conn->in, &conn->handshake.io, s2n_stuffer_data_available(&conn->in)));
-    /* Set the client hello version */
-    conn->client_hello_version = S2N_SSLv2;
+    conn->client_hello.sslv2 = true;
     /* Execute the state machine handler */
     int r = ACTIVE_STATE(conn).handler[conn->mode](conn);
     POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -119,7 +119,7 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t *record_type, int 
     /* If the first bit is set then this is an SSLv2 record */
     if (conn->header_in.blob.data[0] & S2N_TLS_SSLV2_HEADER_FLAG) {
         *isSSLv2 = 1;
-        WITH_ERROR_BLINDING(conn, POSIX_GUARD(s2n_sslv2_record_header_parse(conn, record_type, &conn->client_protocol_version, &fragment_length)));
+        WITH_ERROR_BLINDING(conn, POSIX_GUARD(s2n_sslv2_record_header_parse(conn, record_type, &conn->client_hello.legacy_version, &fragment_length)));
     } else {
         WITH_ERROR_BLINDING(conn, POSIX_GUARD(s2n_record_header_parse(conn, record_type, &fragment_length)));
     }


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

While poking around at the SSLv2 logic, I was very frustrated by our protocol version handling.

We have several closely related fields:
* `conn->client_hello.sslv2`: indicates whether the ClientHello was an SSLv2 ClientHello message instead of the standard TLS record + TLS ClientHello handshake message.
* `conn->client_hello.legacy_version`: represents the legacy version as written in the ClientHello.
* `conn->client_hello_version`: If client_hello.sslv2, then always "S2N_SSLv2", even though client_hello.legacy_version != S2N_SSLv2. If not client_hello.sslv2, then MIN(client_hello.legacy_version, S2N_TLS12). So it's both a duplicate, and a very confusing duplicate.

When we use `conn->client_hello_version`, we generally actually want `conn->client_hello.sslv2`, `conn->client_hello.legacy_version`, or even `conn->client_protocol_version`. I went through and replaced client_hello_version with the more accurate values.

### Testing:
Existing tests pass, including the sslv2 integration test.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
