### PR TITLE
ci: fix expectations when using system default libcrypto

### DIFF
--- a/.github/install_osx_dependencies.sh
+++ b/.github/install_osx_dependencies.sh
@@ -26,4 +26,4 @@ brew_install_if_not_installed coreutils
 brew_install_if_not_installed cppcheck
 brew_install_if_not_installed pkg-config  # for gnutls compilation
 brew_install_if_not_installed ninja
-brew_install_if_not_installed openssl@3 # for libcrypto
+brew_install_if_not_installed openssl # for libcrypto

--- a/.github/s2n_osx.sh
+++ b/.github/s2n_osx.sh
@@ -15,16 +15,15 @@
 #
 set -eu
 
-export S2N_LIBCRYPTO=openssl-3.4
 export CTEST_OUTPUT_ON_FAILURE=1
-BREWINSTLLPATH=$(brew --prefix openssl@3)
-OPENSSL_3_INSTALL_DIR="${BREWINSTLLPATH:-"/opt/homebrew/Cellar/openssl@3"}"
+BREWINSTLLPATH=$(brew --prefix openssl)
+OPENSSL_INSTALL_DIR="${BREWINSTLLPATH:-"/opt/homebrew/Cellar/openssl"}"
 
-echo "Using OpenSSL at $OPENSSL_3_INSTALL_DIR"
-# Build with debug symbols and a specific OpenSSL version
+echo "Using OpenSSL at $OPENSSL_INSTALL_DIR"
+# Build with debug symbols
 cmake . -Bbuild -GNinja \
 -DCMAKE_BUILD_TYPE=Debug \
--DCMAKE_PREFIX_PATH=${OPENSSL_3_INSTALL_DIR} ..
+-DCMAKE_PREFIX_PATH=${OPENSSL_INSTALL_DIR} ..
 
 cmake --build ./build -j $(nproc)
 time CTEST_PARALLEL_LEVEL=$(nproc) ninja -C build test
@@ -32,7 +31,7 @@ time CTEST_PARALLEL_LEVEL=$(nproc) ninja -C build test
 # Build shared library
 cmake . -Bbuild -GNinja \
 -DCMAKE_BUILD_TYPE=Debug \
--DCMAKE_PREFIX_PATH=${OPENSSL_3_INSTALL_DIR} .. \
+-DCMAKE_PREFIX_PATH=${OPENSSL_INSTALL_DIR} .. \
 -DBUILD_SHARED_LIBS=ON
 
 cmake --build ./build -j $(nproc)

--- a/codebuild/bin/install_al_dependencies.sh
+++ b/codebuild/bin/install_al_dependencies.sh
@@ -18,7 +18,7 @@ source ./codebuild/bin/s2n_setup_env.sh
 
 al2023_main(){
     case "$S2N_LIBCRYPTO" in
-    "openssl-3.0"|"default") echo "Installing AL2023 packages";;
+    "default") echo "Using default system libcrypto";;
     *) echo "${S2N_LIBCRYPTO} is not installed on this platform."; exit 1;;
     esac
     common_packages

--- a/codebuild/bin/install_al_dependencies.sh
+++ b/codebuild/bin/install_al_dependencies.sh
@@ -18,7 +18,7 @@ source ./codebuild/bin/s2n_setup_env.sh
 
 al2023_main(){
     case "$S2N_LIBCRYPTO" in
-    "openssl-3.0"|"openssl-3.2.2"|"default") echo "Installing AL2023 packages";;
+    "openssl-3.0"|"default") echo "Installing AL2023 packages";;
     *) echo "${S2N_LIBCRYPTO} is not installed on this platform."; exit 1;;
     esac
     common_packages

--- a/codebuild/spec/buildspec_generalbatch.yml
+++ b/codebuild/spec/buildspec_generalbatch.yml
@@ -135,8 +135,8 @@ batch:
         privileged-mode: true
         variables:
           TESTS: unit
-          S2N_LIBCRYPTO: openssl-3.0
-      identifier: UnitAl2023x86Openssl30
+          S2N_LIBCRYPTO: default
+      identifier: UnitAl2023x86
     - buildspec: codebuild/spec/buildspec_amazonlinux.yml
       env:
         compute-type: BUILD_GENERAL1_SMALL
@@ -145,8 +145,8 @@ batch:
         type: ARM_CONTAINER
         variables:
           TESTS: unit
-          S2N_LIBCRYPTO: openssl-3.0
-      identifier: UnitAl2023armOpenssl30
+          S2N_LIBCRYPTO: default
+      identifier: UnitAl2023arm
     - buildspec: codebuild/spec/buildspec_ubuntu.yml
       env:
         compute-type: BUILD_GENERAL1_LARGE

--- a/codebuild/spec/buildspec_generalbatch.yml
+++ b/codebuild/spec/buildspec_generalbatch.yml
@@ -135,7 +135,7 @@ batch:
         privileged-mode: true
         variables:
           TESTS: unit
-          S2N_LIBCRYPTO: openssl-3.2.2
+          S2N_LIBCRYPTO: openssl-3.0
       identifier: UnitAl2023x86Openssl30
     - buildspec: codebuild/spec/buildspec_amazonlinux.yml
       env:

--- a/tests/unit/s2n_build_test.c
+++ b/tests/unit/s2n_build_test.c
@@ -86,7 +86,6 @@ S2N_RESULT s2n_check_supported_libcrypto(const char *s2n_libcrypto)
         { .libcrypto = "openssl-1.1.1", .is_openssl = true },
         { .libcrypto = "openssl-3.0", .is_openssl = true },
         { .libcrypto = "openssl-3.0-fips", .is_openssl = true, .is_opensslfips = true },
-        { .libcrypto = "openssl-3.4", .is_openssl = true },
     };
 
     for (size_t i = 0; i < s2n_array_len(supported_libcrypto); i++) {
@@ -164,7 +163,15 @@ int main()
     {
         if (version != NULL) {
             const char *ssleay_version_text = SSLeay_version(SSLEAY_VERSION);
-            EXPECT_NOT_NULL(strstr(ssleay_version_text, version));
+            if (strstr(ssleay_version_text, version) == NULL) {
+                char fail_msg[256] = { 0 };
+                snprintf(
+                        fail_msg, sizeof(fail_msg),
+                        "Libcrypto version mismatch: expected version '%s' "
+                        "not found in actual libcrypto version string '%s'",
+                        version, ssleay_version_text);
+                FAIL_MSG(fail_msg);
+            }
         }
     };
 

--- a/tests/unit/s2n_build_test.c
+++ b/tests/unit/s2n_build_test.c
@@ -86,7 +86,6 @@ S2N_RESULT s2n_check_supported_libcrypto(const char *s2n_libcrypto)
         { .libcrypto = "openssl-1.1.1", .is_openssl = true },
         { .libcrypto = "openssl-3.0", .is_openssl = true },
         { .libcrypto = "openssl-3.0-fips", .is_openssl = true, .is_opensslfips = true },
-        { .libcrypto = "openssl-3.2.2", .is_openssl = true },
         { .libcrypto = "openssl-3.4", .is_openssl = true },
     };
 
@@ -165,14 +164,7 @@ int main()
     {
         if (version != NULL) {
             const char *ssleay_version_text = SSLeay_version(SSLEAY_VERSION);
-            if (strstr(ssleay_version_text, version) == NULL) {
-                char fail_msg[256];
-                snprintf(
-                        fail_msg, sizeof(fail_msg),
-                        "Libcrypto version mismatch - expected version '%s' not found in '%s'",
-                        version, ssleay_version_text);
-                FAIL_MSG(fail_msg);
-            }
+            EXPECT_NOT_NULL(strstr(ssleay_version_text, version));
         }
     };
 


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 
Our MacOS builds were failing because openssl was updated from openssl-3.4 to openssl-3.5, and we were asserting via S2N_LIBCRYPTO that we expected openssl-3.4. This was a similar problem to https://github.com/aws/s2n-tls/commit/eb4167f148ccdb21a8fa22bf07cb91044ba2d7f0, so I fixed both problems at once.

The s2n_build_test (and S2N_LIBCRYPTO in general) is meant to assert a specific libcrypto version that MUST be used. If we don't want a specific version, we shouldn't be using S2N_LIBCRYPTO or checking our assertions with s2n_buid_test.

If we cared about the libcrypto version, we'd need to install / configure a specific libcrypto version rather than relying on defaults.

### Testing:
* CI passes again
* All the libcryptos called out in the s2n_build_test are now libcryptos we properly install in the CI. For openssl, that's just 1.0.2, 1.1.1, and 3.0 (and someday 3.5?).

You can also check [the MacOs build](runs/14764224342/job/41451938125?pr=5279#step:4:32) to confirm it's still using Openssl3, even though I removed the "3" qualifier:
```
-- Found crypto: /opt/homebrew/opt/openssl@3/lib/libcrypto.a
-- LibCrypto Include Dir: /opt/homebrew/opt/openssl@3/include
-- LibCrypto Shared Lib:  /opt/homebrew/opt/openssl@3/lib/libcrypto.dylib
-- LibCrypto Static Lib:  /opt/homebrew/opt/openssl@3/lib/libcrypto.a
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
