### PR TITLE
ci: handle 429 from yahoo.com network integ test

### DIFF
--- a/bindings/rust/standard/integration/src/network/https_client.rs
+++ b/bindings/rust/standard/integration/src/network/https_client.rs
@@ -54,7 +54,7 @@ const TEST_CASES: &[TestCase] = &[
     TestCase::new("https://www.t-mobile.com", &[200]),
     TestCase::new("https://www.verizon.com", &[200]),
     TestCase::new("https://www.wikipedia.org", &[200]),
-    TestCase::new("https://www.yahoo.com", &[200]),
+    TestCase::new("https://www.yahoo.com", &[200, 429]),
     TestCase::new("https://www.youtube.com", &[200]),
     TestCase::new("https://www.github.com", &[301]),
     TestCase::new("https://www.samsung.com", &[301]),


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

### Description of changes: 
yahoo.com has started often returning 429 errors in our network integ tests. See [here](https://github.com/aws/s2n-tls/actions/runs/14769237627/job/41466382597).

### Testing:
I retried the "generate (ubuntu latest)" job 5 times, and it succeeded every time: https://github.com/aws/s2n-tls/actions/runs/14769543319/job/41469062674?pr=5280 Meanwhile, I can't get another PR I'm trying to merge to succeed once -_-


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
