### PR TITLE
tests: turn verbose mode off by default in integ tests

### DIFF
--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -754,7 +754,7 @@ class ProviderOptions(object):
         ocsp_response=None,
         signature_algorithm=None,
         record_size=None,
-        verbose=True,
+        verbose=None,
         echo=True,
     ):
         # Client or server

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -878,11 +878,10 @@ class GnuTLS(Provider):
             "--port",
             str(self.options.port),
             self.options.host,
-            "--debug",
-            "9999",
         ]
 
-        if self.options.verbose:
+        # Most GnuTLS tests expect verbose output, so default to True.
+        if self.options.verbose is not False:
             cmd_line.append("--verbose")
 
         if self.options.cert and self.options.key:
@@ -913,7 +912,6 @@ class GnuTLS(Provider):
             "gnutls-serv",
             f"--port={self.options.port}",
             "--echo",
-            "--debug=9999",
         ]
 
         if self.options.cert is not None:

--- a/tests/integrationv2/test_hello_retry_requests.py
+++ b/tests/integrationv2/test_hello_retry_requests.py
@@ -74,6 +74,9 @@ def test_hrr_with_s2n_as_client(
     server_options.cert = certificate.cert
     server_options.extra_flags = None
     server_options.curve = curve
+    # We need the full bytes of the messages to find the specific
+    # ServerRandom bytes that indicate a HelloRetryRequest
+    server_options.verbose = True
 
     # Passing the type of client and server as a parameter will
     # allow us to use a fixture to enumerate all possibilities.
@@ -86,6 +89,7 @@ def test_hrr_with_s2n_as_client(
         assert to_bytes("Curve: {}".format(CURVE_NAMES[curve.name])) in results.stdout
         assert S2N_HRR_MARKER in results.stdout
 
+    # These are the special HelloRetryRequest bytes from the Server Random field
     marker_part1 = b"cf 21 ad 74 e5"
     marker_part2 = b"9a 61 11 be 1d"
 
@@ -135,6 +139,9 @@ def test_hrr_with_s2n_as_server(
         curve=curve,
         extra_flags=["-msg", "-curves", "X448:" + str(curve)],
         protocol=protocol,
+        # We need the full bytes of the messages to find the specific
+        # ServerRandom bytes that indicate a HelloRetryRequest
+        verbose=True,
     )
 
     server_options = copy.copy(client_options)
@@ -214,6 +221,9 @@ def test_hrr_with_default_keyshare(
     server_options.cert = certificate.cert
     server_options.extra_flags = None
     server_options.curve = curve
+    # We need the full bytes of the messages to find the specific
+    # ServerRandom bytes that indicate a HelloRetryRequest
+    server_options.verbose = True
 
     # Passing the type of client and server as a parameter will
     # allow us to use a fixture to enumerate all possibilities.
@@ -226,6 +236,7 @@ def test_hrr_with_default_keyshare(
         assert to_bytes("Curve: {}".format(CURVE_NAMES[curve.name])) in results.stdout
         assert S2N_HRR_MARKER in results.stdout
 
+    # These are the special HelloRetryRequest bytes from the Server Random field
     marker_part1 = b"cf 21 ad 74 e5"
     marker_part2 = b"9a 61 11 be 1d"
 

--- a/tests/integrationv2/test_record_padding.py
+++ b/tests/integrationv2/test_record_padding.py
@@ -107,6 +107,7 @@ def test_s2n_server_handles_padded_records(
         insecure=True,
         protocol=protocol,
         extra_flags=["-record_padding", padding_size],
+        verbose=True,
     )
 
     server_options = copy.copy(client_options)
@@ -178,6 +179,7 @@ def test_s2n_client_handles_padded_records(
         protocol=protocol,
         data_to_send=server_random_bytes,
         extra_flags=["-record_padding", padding_size],
+        verbose=True,
     )
 
     client_options = copy.copy(server_options)


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

### Description of changes: 

I'm really not a fan of the Openssl verbose output. I've never found it useful for debugging, and it mostly seems to get in the way. It's just too much unnecessary visual data. I feel similarly about the GnuTLS "--debug" option.

This PR makes the "verbose" method False by default for Openssl. I then enabled it for the tests that actually rely on it.

### Call-outs:
I've found that running the commands and capturing the data in a pcap for analysis is much more helpful.

The arguments could still be manually added / enabled when trying to debug locally. They would just no longer be enabled during the CI runs.

### Testing:
Integration tests all pass in CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
