### PR TITLE
chore: Add comments to track dependency requirements

### DIFF
--- a/bindings/rust/extended/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls-tokio/Cargo.toml
@@ -23,4 +23,4 @@ tokio = { version = "1", features = ["net", "time"] }
 s2n-tls = { path = "../s2n-tls", features = ["unstable-testing"] }
 rand = { version = "0.9" }
 tokio = { version = "1", features = [ "io-std", "io-util", "macros", "net", "rt-multi-thread", "test-util", "time"] }
-tokio-macros = "=2.3.0"
+tokio-macros = "=2.3.0" # newer versions require rust 1.70, see https://github.com/aws/s2n-tls/issues/4395

--- a/bindings/rust/extended/s2n-tls/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls/Cargo.toml
@@ -31,6 +31,6 @@ futures-test = "0.3"
 once_cell = "=1.20.3" # newer versions require rust 1.70.0
 openssl = "0.10"
 openssl-sys = "0.9"
-foreign-types = "0.3"
+foreign-types = "0.3 "# newer versions require updated ForeignTypeRef, see https://github.com/sfackler/rust-openssl/issues/2298
 temp-env = "0.3"
 checkers = "0.6"

--- a/bindings/rust/extended/s2n-tls/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls/Cargo.toml
@@ -31,6 +31,6 @@ futures-test = "0.3"
 once_cell = "=1.20.3" # newer versions require rust 1.70.0
 openssl = "0.10"
 openssl-sys = "0.9"
-foreign-types = "0.3 "# newer versions require updated ForeignTypeRef, see https://github.com/sfackler/rust-openssl/issues/2298
+foreign-types = "0.3" # newer versions require updated ForeignTypeRef, see https://github.com/sfackler/rust-openssl/issues/2298
 temp-env = "0.3"
 checkers = "0.6"


### PR DESCRIPTION
### Description of changes: 

Added comments to keep track of minimum supported rust version for `tokio-macros` and rust-openssl updates for `foreign-types`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
