### PR TITLE
tests: fix flaky test_serialization

### DIFF
--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -755,6 +755,7 @@ class ProviderOptions(object):
         signature_algorithm=None,
         record_size=None,
         verbose=True,
+        echo=True,
     ):
         # Client or server
         self.mode = mode
@@ -833,3 +834,7 @@ class ProviderOptions(object):
         # Useful if you find that debugging information is printed between
         # application data you expect the provider to print on stdout.
         self.verbose = verbose
+
+        # Should the provider echo any data sent / received?
+        # If not, the connection will be closed after one handshake.
+        self.echo = echo

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -250,9 +250,8 @@ class S2N(Provider):
             cmd_line.append("s2nc")
         cmd_line.append("--non-blocking")
 
-        # Tests requiring reconnects can't wait on echo data,
-        # but all other tests can.
-        if self.options.reconnect is not True:
+        # Tests requiring reconnects can't wait on echo data
+        if self.options.echo and not self.options.reconnect:
             cmd_line.append("-e")
 
         if self.options.use_session_ticket is False:
@@ -335,6 +334,9 @@ class S2N(Provider):
             cipher_prefs = self.options.cipher.name
 
         cmd_line.extend(["-c", cipher_prefs])
+
+        if not self.options.echo:
+            cmd_line.append("-n")
 
         if self.options.use_client_auth is True:
             cmd_line.append("-m")

--- a/tests/integrationv2/test_serialization.py
+++ b/tests/integrationv2/test_serialization.py
@@ -73,6 +73,7 @@ def test_server_serialization_backwards_compat(
         port=next(available_ports),
         cipher=S2N_TEST_POLICIES[protocol.value],
         insecure=True,
+        echo=False,
     )
 
     client_options = copy.copy(options)
@@ -117,7 +118,10 @@ def test_server_serialization_backwards_compat(
         else:
             client_options.use_mainline_version = True
 
+    server_options.echo = True
     server_options.data_to_send = SERVER_DATA.encode()
+
+    client_options.echo = True
     client_options.data_to_send = CLIENT_DATA.encode()
 
     server = managed_process(S2N, server_options, send_marker=CLIENT_DATA)


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

Part 2 of https://github.com/aws/s2n-tls/pull/5282

Our integ tests have been failing more often lately. I suspect it's a Codebuild noisy neighbor problem. The main tests I see fail are "test_renegotiate" and "test_serialization". I ran the integ tests on an ec2 instance also running `stress`. It was almost comically effective. I was able to consistently repro the failures from the CI. 

https://github.com/aws/s2n-tls/pull/5282 fixed test_renegotiate. This PR fixes test_serialization.

### Description of changes: 

We don't shutdown connections when serializing. It wouldn't really make sense, since closing a connection involves sending and receiving data and sending and receiving data changes the state of the connection so that the serialization is no longer valid. So we skip s2n_shutdown: https://github.com/aws/s2n-tls/blob/main/bin/s2nc.c#L804-L808

However, if a connection has completed a handshake and is just idling on `echo`, then we're calling s2n_send / s2n_recv. So when the peer closes the underlying TCP connection because the process ended, we receive that EOF event and throw an error for improper shutdown of the TLS connection.

The fix is not to call `echo`, since we're not sending or receiving anything anyway.

### Testing:
Hard to prove lack of flakiness. But it now passes locally with `stress` running.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
