### PR TITLE
chore: bump standard MSRV to 1.82.0

### DIFF
--- a/bindings/rust/standard/bench/Cargo.toml
+++ b/bindings/rust/standard/bench/Cargo.toml
@@ -20,7 +20,6 @@ pprof = { version = "0.14", features = ["criterion", "flamegraph"] }
 # debugging interop failures
 env_logger = "0.10"
 log = "0.4"
-symbolic-common = { version = "=12.13.4" }
 
 [[bench]]
 name = "handshake"

--- a/bindings/rust/standard/bench/Cargo.toml
+++ b/bindings/rust/standard/bench/Cargo.toml
@@ -20,7 +20,7 @@ pprof = { version = "0.14", features = ["criterion", "flamegraph"] }
 # debugging interop failures
 env_logger = "0.10"
 log = "0.4"
-symbolic-common = { version = "=12.13.4" } # newer versions require rust 1.82.0, see https://github.com/aws/s2n-tls/issues/5165
+symbolic-common = { version = "=12.13.4" }
 
 [[bench]]
 name = "handshake"

--- a/bindings/rust/standard/rust-toolchain.toml
+++ b/bindings/rust/standard/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.83.0"

--- a/bindings/rust/standard/rust-toolchain.toml
+++ b/bindings/rust/standard/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.82.0"


### PR DESCRIPTION
### Description of changes: 

* Updated the rust version based on the version released 6 months ago 
* 1.82.0 was released on 17 October, 2024
* https://releases.rs/docs/1.82.0/
* Removed all 1.82.0 pins

The MSRV bump will fix [5293](https://github.com/aws/s2n-tls/pull/5293) and [5292](https://github.com/aws/s2n-tls/pull/5292) dependabot PRs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
