### PR TITLE
build: add pull requests limit for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
     directory: "/.github/workflows"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
     groups:
       all-gha-updates:
         patterns:
@@ -24,7 +23,6 @@ updates:
       - "/tests/regression"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
     groups:
       all-cargo-updates:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     directory: "/.github/workflows"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
     groups:
       all-gha-updates:
         patterns:
@@ -23,6 +24,7 @@ updates:
       - "/tests/regression"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
     groups:
       all-cargo-updates:
         patterns:
@@ -35,3 +37,4 @@ updates:
       - "/bindings/rust/extended"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

By default, dependabot will only open five pull requests to [update our rust dependency](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit-):
>Dependabot default behavior:
> * If five pull requests with version updates are open, 
> no further pull requests are raised until some of those open requests are merged or closed.

When dependabot's PR is not reviewed by our team, it stop issues new PR to update deps. The default five PRs are too small for our rust bindings, since our dependency updates are very backed up.

Hence, I will add a `open-pull-requests-limit` to dependabot, so that it will open 10 PRs for dependabot updates. 

### Call-outs:

I believe 10 PRs are enough for our codebase. We don't want to open too many PRs that spam our github repo. Please let me know your takes on this.

### Testing:

Monitor new PRs to see if it generate more than five PRs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
