### PR TITLE
build(deps): unpin test-log because of MSRV updates

### DIFF
--- a/bindings/rust/standard/integration/Cargo.toml
+++ b/bindings/rust/standard/integration/Cargo.toml
@@ -29,9 +29,7 @@ tokio = { version = "1", features = ["macros", "test-util"] }
 
 tracing = "0.1"
 tracing-subscriber = "0.3"
-# TODO: Unpin when s2n-tls MSRV >= 1.71, https://github.com/aws/s2n-tls/issues/4893
-test-log = { version = "=0.2.14", default-features = false, features = ["trace"]}
-test-log-macros = "=0.2.17"
+test-log = { version = "0.2", default-features = false, features = ["trace"]}
 
 http = "1.1"
 http-body-util = "0.1"


### PR DESCRIPTION
### Release Summary:


### Resolved issues:

resolves https://github.com/aws/s2n-tls/pull/5291, and resolves https://github.com/aws/s2n-tls/pull/5290.
They are dependabot PRs.

Resolves https://github.com/aws/s2n-tls/issues/4893.

### Description of changes: 

We should unpin those two dependencies as mentioned in code:
https://github.com/aws/s2n-tls/blob/4925e4002838c933c6f6df9431408ef9d2252e0a/bindings/rust/standard/integration/Cargo.toml#L32-L34

We have updated the MSRV, so these two dependencies can be unpined: https://github.com/aws/s2n-tls/pull/5295.

### Call-outs:

### Testing:

CI testing.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
