### PR TITLE
Revert "build: add pull requests limit for dependabot"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,4 +35,3 @@ updates:
       - "/bindings/rust/extended"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10


### PR DESCRIPTION
### Description of Change:

Reverts aws/s2n-tls#5299.


### Call-out:

Discussed offline with @lrstewart. We decided that this is not entirely helpful, and we didn't find a way to fully verify the behavior of this change.

We might have resolved every single dependency updates now. We will know that tomorrow when dependabot runs again.

### Testing:

This is a reverting change, so no testing.
