### PR TITLE
fix(benches): use session ticket for resumption

### DIFF
--- a/bindings/rust/standard/bench/benches/handshake.rs
+++ b/bindings/rust/standard/bench/benches/handshake.rs
@@ -21,7 +21,6 @@ fn bench_handshake_for_library<T>(
     T: TlsConnection,
     T::Config: TlsBenchConfig,
 {
-    // make configs before benching to reuse
     let crypto_config = CryptoConfig::new(CipherSuite::default(), kx_group, sig_type);
 
     // generate all harnesses (TlsConnPair structs) beforehand so that benchmarks

--- a/bindings/rust/standard/bench/benches/handshake.rs
+++ b/bindings/rust/standard/bench/benches/handshake.rs
@@ -30,6 +30,10 @@ fn bench_handshake_for_library<T>(
             || -> TlsConnPair<T, T> { TlsConnPair::new_bench_pair(crypto_config, handshake_type).unwrap() },
             |conn_pair| {
                 conn_pair.handshake().unwrap();
+                match handshake_type {
+                    HandshakeType::ServerAuth | HandshakeType::MutualAuth => assert!(!conn_pair.server.resumed_connection()),
+                    HandshakeType::Resumption => assert!(conn_pair.server.resumed_connection()),
+                }
             },
             BatchSize::SmallInput,
         )

--- a/bindings/rust/standard/bench/benches/handshake.rs
+++ b/bindings/rust/standard/bench/benches/handshake.rs
@@ -23,16 +23,12 @@ fn bench_handshake_for_library<T>(
 {
     // make configs before benching to reuse
     let crypto_config = CryptoConfig::new(CipherSuite::default(), kx_group, sig_type);
-    let client_config =
-        T::Config::make_config(Mode::Client, crypto_config, handshake_type).unwrap();
-    let server_config =
-        T::Config::make_config(Mode::Server, crypto_config, handshake_type).unwrap();
 
     // generate all harnesses (TlsConnPair structs) beforehand so that benchmarks
     // only include negotiation and not config/connection initialization
     bench_group.bench_function(T::name(), |b| {
         b.iter_batched_ref(
-            || -> TlsConnPair<T, T> { TlsConnPair::from_configs(&client_config, &server_config) },
+            || -> TlsConnPair<T, T> { TlsConnPair::new_bench_pair(crypto_config, handshake_type).unwrap() },
             |conn_pair| {
                 conn_pair.handshake().unwrap();
             },


### PR DESCRIPTION
### Description of changes: 

Resumption benchmarks are currently incorrect.

During my earlier refactor to separate out config creation logic, I switched the `handshake` benchmark to use these simpler methods. However `make_config` is not the same as `new_benchmark_pair`. 

`make_config` will make a config that is capable of session resumption, but will not actually generate the session ticket. `new_benchmark_pair` has considerably more magic, and will actually do a "pre-handshake" to get a session ticket loaded into the session ticket storage.

### Testing:

Ran the benchmarks locally, and confirmed that we were seeing the correct numbers.
```
handshake-server-auth/s2n-tls
                        time:   [1.0968 ms 1.0971 ms 1.0973 ms]
```

```
handshake-resumption/s2n-tls
                        time:   [153.66 µs 153.88 µs 154.14 µs]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
