### PR TITLE
fix(benches): reuse config for handshakes

### DIFF
--- a/bindings/rust/standard/bench/Cargo.toml
+++ b/bindings/rust/standard/bench/Cargo.toml
@@ -14,7 +14,7 @@ rustls-pemfile = { version = "2" }
 openssl = { version = "0.10", features = ["vendored"] }
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = "0.6"
 pprof = { version = "0.14", features = ["criterion", "flamegraph"] }
 # env_logger and log are used to enable logging for rustls, which can help with
 # debugging interop failures

--- a/bindings/rust/standard/bench/benches/handshake.rs
+++ b/bindings/rust/standard/bench/benches/handshake.rs
@@ -3,13 +3,11 @@
 
 use bench::{
     harness::TlsBenchConfig, CipherSuite, CryptoConfig, HandshakeType, KXGroup, Mode,
-    OpenSslConnection, RustlsConnection, S2NConnection, SigType, TlsConnPair, TlsConnection,
-    PROFILER_FREQUENCY,
+    OpenSslConnection, RustlsConnection, S2NConnection, SigType, TlsConnPair, TlsConnection
 };
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, BatchSize, BenchmarkGroup, Criterion,
 };
-use pprof::criterion::{Output, PProfProfiler};
 use strum::IntoEnumIterator;
 
 fn bench_handshake_for_library<T>(
@@ -22,12 +20,22 @@ fn bench_handshake_for_library<T>(
     T::Config: TlsBenchConfig,
 {
     let crypto_config = CryptoConfig::new(CipherSuite::default(), kx_group, sig_type);
+    let client_config = &T::Config::make_config(Mode::Client, crypto_config, handshake_type).unwrap();
+    let server_config = &T::Config::make_config(Mode::Server, crypto_config, handshake_type).unwrap();
 
     // generate all harnesses (TlsConnPair structs) beforehand so that benchmarks
     // only include negotiation and not config/connection initialization
     bench_group.bench_function(T::name(), |b| {
         b.iter_batched_ref(
-            || -> TlsConnPair<T, T> { TlsConnPair::new_bench_pair(crypto_config, handshake_type).unwrap() },
+            || -> TlsConnPair<T, T> { 
+                if handshake_type == HandshakeType::Resumption {
+                    // generate a session ticket to store on the config
+                    let mut pair = TlsConnPair::<T, T>::from_configs(&client_config, &server_config);
+                    pair.handshake().unwrap();
+                    pair.round_trip_transfer(&mut [0]).unwrap();
+                }
+                TlsConnPair::from_configs(client_config,server_config)
+            },
             |conn_pair| {
                 conn_pair.handshake().unwrap();
                 match handshake_type {
@@ -98,9 +106,6 @@ pub fn bench_handshake_sig_types(c: &mut Criterion) {
 }
 
 criterion_group! {
-    name = benches;
-    // profile 100 samples/sec
-    config = Criterion::default().with_profiler(PProfProfiler::new(PROFILER_FREQUENCY, Output::Flamegraph(None)));
-    targets = bench_handshake_types, bench_handshake_kx_groups, bench_handshake_sig_types
+    benches, bench_handshake_types, bench_handshake_kx_groups, bench_handshake_sig_types
 }
 criterion_main!(benches);

--- a/bindings/rust/standard/bench/benches/throughput.rs
+++ b/bindings/rust/standard/bench/benches/throughput.rs
@@ -68,10 +68,5 @@ pub fn bench_throughput_cipher_suites(c: &mut Criterion) {
     }
 }
 
-criterion_group! {
-    name = benches;
-    // profile 100 samples/sec
-    config = Criterion::default().with_profiler(PProfProfiler::new(PROFILER_FREQUENCY, Output::Flamegraph(None)));
-    targets = bench_throughput_cipher_suites
-}
+criterion_group! {benches, bench_throughput_cipher_suites}
 criterion_main!(benches);


### PR DESCRIPTION
### Description of changes: 

We noticed some odd benchmark results from the recent change: #5305 . Notably the benchmark caused the performance of rustls and openssl handshakes to significantly degrade on RSA certs.

This change was ultimately the result of switching to a fresh config for each handshake. This is because the libcrypto EVP_PKEY rsa key will cache/precompute certain parts of the sign operation. This causes the first sign to be slower, later signs to be faster. In TLS, this causes the first handshake to be slower, and subsequent handshakes to be faster.

This PR changes the benchmarking setup to reuse the config across the measured handshakes, as that is a more "customer similar" environment.

### Testing:
I remove the pkey_match implementation and observed the same handshake regression in s2n-tls.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
