### PR TITLE
docs: comments for blob, stuffer methods

### DIFF
--- a/docs/DEVELOPMENT-GUIDE.md
+++ b/docs/DEVELOPMENT-GUIDE.md
@@ -260,12 +260,14 @@ C has a history of issues around memory and buffer handling. To avoid problems i
 
 ### s2n_blob: keeping track of memory ranges
 
-`s2n_blob` is a very simple data structure:
+`s2n_blob` is a data structure representing allocated, "owned" memory or a reference to some other slice of memory.
 
 ```c
 struct s2n_blob {
     uint8_t *data;
     uint32_t size;
+    uint32_t allocated;
+    unsigned growable: 1;
 };
 ```
 

--- a/stuffer/s2n_stuffer.c
+++ b/stuffer/s2n_stuffer.c
@@ -60,6 +60,12 @@ S2N_RESULT s2n_stuffer_reservation_validate(const struct s2n_stuffer_reservation
     return S2N_RESULT_OK;
 }
 
+/**
+ * Initialize a stuffer to reference some mutable data `in`.
+ * 
+ * `stuffer` will not own the data, and the caller is responsible for ensuring that
+ * the data pointed to by `in` outlives `stuffer`.
+ */
 int s2n_stuffer_init(struct s2n_stuffer *stuffer, struct s2n_blob *in)
 {
     POSIX_ENSURE_MUT(stuffer);
@@ -174,6 +180,11 @@ int s2n_stuffer_resize_if_empty(struct s2n_stuffer *stuffer, const uint32_t size
     return S2N_SUCCESS;
 }
 
+/**
+ * Reset read and write progress.
+ * 
+ * This sets the read and write cursors to zero.
+ */
 int s2n_stuffer_rewrite(struct s2n_stuffer *stuffer)
 {
     POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
@@ -192,6 +203,11 @@ int s2n_stuffer_rewind_read(struct s2n_stuffer *stuffer, const uint32_t size)
     return S2N_SUCCESS;
 }
 
+/**
+ * Reset read progress.
+ * 
+ * This sets the read cursor to zero.
+ */
 int s2n_stuffer_reread(struct s2n_stuffer *stuffer)
 {
     POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));
@@ -422,6 +438,11 @@ int s2n_stuffer_copy(struct s2n_stuffer *from, struct s2n_stuffer *to, const uin
     return S2N_SUCCESS;
 }
 
+/**
+ * Copy the internal data of `stuffer` to `out`.
+ * 
+ * This will allocate memory for `out` if necessary, internally calling `s2n_realloc`.
+ */
 int s2n_stuffer_extract_blob(struct s2n_stuffer *stuffer, struct s2n_blob *out)
 {
     POSIX_PRECONDITION(s2n_stuffer_validate(stuffer));

--- a/utils/s2n_blob.c
+++ b/utils/s2n_blob.c
@@ -36,6 +36,12 @@ S2N_RESULT s2n_blob_validate(const struct s2n_blob *b)
     return S2N_RESULT_OK;
 }
 
+/**
+ * Initialize a blob to reference some mutable data.
+ *  
+ * `b` will not free `data`. The caller is responsible for making sure that
+ * `data` outlives `b`.
+ */
 int s2n_blob_init(struct s2n_blob *b, uint8_t *data, uint32_t size)
 {
     POSIX_ENSURE_REF(b);
@@ -53,6 +59,12 @@ int s2n_blob_zero(struct s2n_blob *b)
     return S2N_SUCCESS;
 }
 
+/**
+ * Set `slice` to reference some portion of `b`.
+ * 
+ * The caller is responsible for ensuring that the data pointed to by `b` outlives
+ * `slice`.
+ */
 int s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob *slice, uint32_t offset, uint32_t size)
 {
     POSIX_PRECONDITION(s2n_blob_validate(b));

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -172,6 +172,14 @@ S2N_RESULT s2n_mem_get_callbacks(s2n_mem_init_callback *mem_init_callback, s2n_m
     return S2N_RESULT_OK;
 }
 
+/**
+ * Allocate a new blob on the heap.
+ * 
+ * The blob will be _growable_.
+ * 
+ * This blob owns the underlying memory, which will be freed when `s2n_free` is 
+ * called on `b`.
+ */
 int s2n_alloc(struct s2n_blob *b, uint32_t size)
 {
     POSIX_ENSURE(initialized, S2N_ERR_NOT_INITIALIZED);
@@ -188,9 +196,13 @@ bool s2n_blob_is_growable(const struct s2n_blob *b)
     return b && (b->growable || (b->data == NULL && b->size == 0 && b->allocated == 0));
 }
 
-/* Tries to realloc the requested bytes.
- * If successful, updates *b.
- * If failed, *b remains unchanged
+/**
+ * Resize a blob to `size`. The blob must be allocated or empty.
+ * 
+ * This will allocate more memory if necessary, or reuse the existing allocation
+ * if the requested size is smaller than the current size.
+ *
+ * If failed, *b remains unchanged.
  */
 int s2n_realloc(struct s2n_blob *b, uint32_t size)
 {
@@ -252,6 +264,9 @@ int s2n_free_object(uint8_t **p_data, uint32_t size)
     return s2n_free(&b);
 }
 
+/**
+ * Copy the data in `from` to a new allocated blob.
+ */
 int s2n_dup(struct s2n_blob *from, struct s2n_blob *to)
 {
     POSIX_ENSURE(initialized, S2N_ERR_NOT_INITIALIZED);


### PR DESCRIPTION
### Description of changes: 
Add comments for some stuffer and blob methods.

I have reread the implementations of a lot of stuffer/blob methods many times because I keep forgetting what they do, and can't tell from the name.

I acknowledge that most of the methods are small so reading them shouldn't be a big deal, but having to jump in and out of the files when I am reviewing PR's is not fun. By adding comments, my IDE will just tell me what the functions do when I mouse over them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
