### PR TITLE
ci: enable daily CI run for rust bindings

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -9,6 +9,9 @@ on:
   merge_group:
     types: [checks_requested]
     branches: [main]
+  schedule:
+    # Run daily job at 8:00 PM PT
+    - cron: '0 3 * * *'
 
 env:
   # Pin the nightly toolchain to prevent breakage.
@@ -517,3 +520,21 @@ jobs:
           from s2n-tls-sys/templates/Cargo.template has been found. Please ensure that the committed \
           Cargo.toml is up-to-date by regenerating it with ${{env.ROOT_PATH}}/generate.sh"
           exit 1
+
+  scheduled-ci-status-report:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [generate, external-build-test, harness-interop-tests, s2n-tls-binding-examples,
+      generate-openssl-102, fips, asan-unit-tests, rustfmt, clippy, msrv, pcaps, minimal-versions, check-generated-cargo-toml]
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4.2.1
+        if: github.event_name == 'schedule'
+        with:
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2nQuicGHASession
+          aws-region: us-west-2
+      - name: Report daily CI run to CloudWatch
+        if: github.event_name == 'schedule'
+        run: |
+          METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
+          aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

Similar to https://github.com/aws/s2n-quic/pull/2624.

### Description of changes: 

Similar to what we have done in S2N-QUIC, we want the S2N-TLS' rust bindings CI to run daily at 8 PM every day. The run should detect if there are any failures with other jobs. If every jobs succeed, then it would report the value of zero to Cloud Watch metrics, otherwise it would report one. When the Cloud Watch metrics detect one is report, it should fire a Cloud Watch Alarm and cut tickets to our ticketing queue.

The benefits of this daily run is that we can preemptively detect any MSRV bumps of our dependencies. If that should fail the CI, we will receive a notification of that. Engineers shouldn't be surprised by MSRV bump that breaks our CI.

### Call-outs:

This code can not be tested without merging. Once this is merged, we should monitor several things daily:
1. We should verify the result of the daily run.
2. We should verify that the correct code (zero for success, one for failure) is sent to Cloud Watch.

After about 5 days without any problems, we can set up an Cloud Watch Alarm to actually cutting tickets.

### Testing:

As mentioned in the `Call-outs` section, this code can not be tested without merging. However, we can use this PR to verify that the last job will be called once all of the previous jobs are finished.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
