### PR TITLE
ci: Use official libcrypto verification model repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "tests/cbmc/aws-verification-model-for-libcrypto"]
 	path = tests/cbmc/aws-verification-model-for-libcrypto
-	url = https://github.com/goatgoose/aws-verification-model-for-libcrypto.git
-    branch = cbmc-test
+	url = https://github.com/awslabs/aws-verification-model-for-libcrypto.git


### PR DESCRIPTION
### Description of changes: 

https://github.com/aws/s2n-tls/pull/5321 changed the aws-verification-model-for-libcrypto repository to my fork, to workaround https://github.com/awslabs/aws-verification-model-for-libcrypto/pull/47 not being merged upstream yet. Now that https://github.com/awslabs/aws-verification-model-for-libcrypto/pull/47 is merged, the repository can be switched back to the official repo.

### Testing:

The CBMC tests should succeed on this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
