### PR TITLE
chore(ci): Pin parking_lot_core, lock_api

### DIFF
--- a/bindings/rust/extended/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls-tokio/Cargo.toml
@@ -24,3 +24,5 @@ s2n-tls = { path = "../s2n-tls", features = ["unstable-testing"] }
 rand = { version = "0.9" }
 tokio = { version = "1", features = [ "io-std", "io-util", "macros", "net", "rt-multi-thread", "test-util", "time"] }
 tokio-macros = "=2.3.0" # newer versions require rust 1.70, see https://github.com/aws/s2n-tls/issues/4395
+parking_lot_core = "=0.9.10" # newer versions require rust 1.64, see https://github.com/aws/s2n-tls/issues/5339
+lock_api = "=0.4.12" # newer versions require rust 1.64, see https://github.com/aws/s2n-tls/issues/5339


### PR DESCRIPTION
### Description of changes: 

A new version of [`parking_lot_core`](https://github.com/aws/s2n-tls/actions/runs/15330918443/job/43137208946#step:7:60) and [`lock_api`](https://github.com/aws/s2n-tls/actions/runs/15330918443/job/43137208962#step:7:60) requires rust 1.64. This PR pins these crates to workaround the MSRV bumps.

### Testing:

The Rust bindings tests should succeed on this PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
