### PR TITLE
tests(integ): fix nondeterministic ocsp test shutdown behavior

### DIFF
--- a/tests/integrationv2/test_ocsp.py
+++ b/tests/integrationv2/test_ocsp.py
@@ -17,7 +17,6 @@ OCSP_CERTS = [Certificates.OCSP, Certificates.OCSP_ECDSA]
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [S2N, OpenSSL, GnuTLS], ids=get_parameter_name)
-@pytest.mark.parametrize("other_provider", [S2N], ids=get_parameter_name)
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", OCSP_CERTS, ids=get_parameter_name)
@@ -25,7 +24,6 @@ def test_s2n_client_ocsp_response(
     managed_process,  # noqa: F811
     cipher,
     provider,
-    other_provider,
     curve,
     protocol,
     certificate,
@@ -62,9 +60,18 @@ def test_s2n_client_ocsp_response(
     )
 
     kill_marker = None
-
     if provider == GnuTLS:
-        kill_marker = random_bytes
+        # The gnutls-serv process will never exit on its own, so should be killed
+        # to avoid a long timeout. However, we must NOT kill it until it sends
+        # the close_notify that the s2n-tls client expects. The only good signal
+        # for this is a debug message indicating that the alert was sent.
+        #
+        # The full debug message is something like:
+        # "Sent Packet[4] Alert(21) in epoch 2 and length: 24"
+        # but the packet number and epoch can vary. We are therefore forced to
+        # only match on a very narrow substring, which could prove brittle.
+        kill_marker = b"Alert(21) in epoch"
+        server_options.extra_flags = ["-d", "5"]
 
     server = managed_process(
         provider, server_options, timeout=30, kill_marker=kill_marker
@@ -87,7 +94,6 @@ def test_s2n_client_ocsp_response(
 @pytest.mark.uncollect_if(func=invalid_test_parameters)
 @pytest.mark.parametrize("cipher", ALL_TEST_CIPHERS, ids=get_parameter_name)
 @pytest.mark.parametrize("provider", [GnuTLS, OpenSSL], ids=get_parameter_name)
-@pytest.mark.parametrize("other_provider", [S2N])
 @pytest.mark.parametrize("curve", ALL_TEST_CURVES, ids=get_parameter_name)
 @pytest.mark.parametrize("protocol", PROTOCOLS, ids=get_parameter_name)
 @pytest.mark.parametrize("certificate", OCSP_CERTS, ids=get_parameter_name)
@@ -95,7 +101,6 @@ def test_s2n_server_ocsp_response(
     managed_process,  # noqa: F811
     cipher,
     provider,
-    other_provider,
     curve,
     protocol,
     certificate,
@@ -129,20 +134,11 @@ def test_s2n_server_ocsp_response(
         }.get(certificate.algorithm),
     )
 
-    kill_marker = None
-    if provider == GnuTLS:
-        # The GnuTLS client hangs for a while after sending. Speed up the tests by killing
-        # it immediately after sending the message.
-        kill_marker = b"Sent: "
-
     server = managed_process(S2N, server_options, timeout=90)
-    client = managed_process(
-        provider, client_options, timeout=90, kill_marker=kill_marker
-    )
+    client = managed_process(provider, client_options, timeout=90)
 
     for client_results in client.get_results():
         client_results.assert_success()
-
         assert any(
             [
                 {


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:


### Description of changes: 

Fixing some more flakiness that @dougch and @johubertj hit. I used the same `stress` strategy from https://github.com/aws/s2n-tls/commit/5df734c958872504bf44c26305252bdab42c6504 and https://github.com/aws/s2n-tls/commit/cc8fb188c335ec58eea47cfbd678e20a09bdb075.

The problem was shutdown behavior again. We were killing the gnutls process after it received the client's app data, which might or might not mean killing it before it sent a close_notify message. I fixed the tests by ensuring the process was not killed early, and it now succeeds even with `stress` running.

### Call-outs:
We might have the same problem with other gnutls tests, since the gnutls server's behavior does not work well with our test framework. I did not investigate other tests, but if we see other gnutls tests failing this problem should probably be the first thing we check for.

### Testing:
I ran the ocsp integ test on a test EC2 instance with `stress -c 4 -i 10 -m 4 -d 4` chugging along in the background.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
