### PR TITLE
ci: workaround for nix + gnutls + ubuntu24 issue

### DIFF
--- a/nix/shell.sh
+++ b/nix/shell.sh
@@ -2,6 +2,10 @@ echo nix/shell.sh: Entering a devShell
 export SRC_ROOT=$(pwd)
 export PATH=$SRC_ROOT/build/bin:$PATH
 
+# The GnuTlS config may restrict TLS versions in some environments,
+# so do not use any existing config file.
+export GNUTLS_SYSTEM_PRIORITY_FILE=
+
 # Function to display a formatted banner with the provided text
 banner()
 {


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

### Description of changes: 

@johubertj ran into an interesting issue where he couldn't run our integration tests even using Nix because GnuTLS flagged any priority string containing TLS1.0 or TLS1.1 as invalid. We traced the problem to the "etc/gnutls/config" file on his Ubuntu24 instance, which disabled TLS1.0 and TLS1.1. Nix wasn't overriding the config file when installing or running gnutls, so the system config file was used. See https://www.gnutls.org/manual/html_node/System_002dwide-configuration-of-the-library.html.

We should probably fix this in the upstream Nix repo, but we can work around the problem for now by setting the GNUTLS_SYSTEM_PRIORITY_FILE in our own Nix shell.


### Testing:
I created an /etc/gnutls/config file on my EC2 instance:
```
[overrides]
disabled-version = tls1.0
```
GnuTLS run from `nix develop` then report no TLS1.0 support:
```
[nix openssl-3.0] $ gnutls-cli --list | grep Protocols
Protocols: VERS-TLS1.1, VERS-TLS1.2, VERS-TLS1.3, VERS-DTLS0.9, VERS-DTLS1.0, VERS-DTLS1.2
```
After applying this fix, even with the config file still in place, GnuTLS started reporting TLS1.0 support again:
```
[nix openssl-3.0] $ gnutls-cli --list | grep Protocols
Protocols: VERS-TLS1.0, VERS-TLS1.1, VERS-TLS1.2, VERS-TLS1.3, VERS-DTLS0.9, VERS-DTLS1.0, VERS-DTLS1.2
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
