### PR TITLE
fix: do not use "digest and sign" for ML-DSA in FIPS mode

### DIFF
--- a/crypto/s2n_pkey_evp.c
+++ b/crypto/s2n_pkey_evp.c
@@ -84,7 +84,7 @@ static EVP_PKEY_CTX *s2n_evp_pkey_ctx_new(EVP_PKEY *pkey, s2n_hash_algorithm has
 
 /* Our "digest-and-sign" EVP signing logic is intended to support FIPS 140-3.
  * FIPS 140-3 does not allow signing or verifying externally calculated digests
- * (except for signing, but not verifying, with ECDSA).
+ * for RSA and ECDSA verify.
  * See https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/Digital-Signatures,
  * and note that "component" tests only exist for ECDSA sign.
  *
@@ -145,6 +145,16 @@ static int s2n_pkey_evp_digest_and_sign(EVP_PKEY_CTX *pctx, s2n_signature_algori
     return S2N_SUCCESS;
 }
 
+/* See s2n_evp_digest_and_sign for more information */
+static bool s2n_pkey_evp_digest_and_sign_is_required(s2n_signature_algorithm sig_alg)
+{
+    if (sig_alg == S2N_SIGNATURE_MLDSA) {
+        /* The FIPS restrictions do not apply to ML-DSA */
+        return false;
+    }
+    return s2n_libcrypto_is_awslc_fips();
+}
+
 /* "digest-then-sign" means that we calculate the digest for a hash state,
  * then sign the digest bytes. That is not allowed by FIPS 140-3, but is allowed
  * in all other cases.
@@ -192,7 +202,7 @@ int s2n_pkey_evp_sign(const struct s2n_pkey *priv, s2n_signature_algorithm sig_a
         POSIX_GUARD_RESULT(s2n_evp_pkey_set_rsa_pss_saltlen(pctx));
     }
 
-    if (s2n_libcrypto_is_awslc_fips()) {
+    if (s2n_pkey_evp_digest_and_sign_is_required(sig_alg)) {
         POSIX_GUARD(s2n_pkey_evp_digest_and_sign(pctx, sig_alg, hash_state, signature));
     } else {
         POSIX_GUARD(s2n_pkey_evp_digest_then_sign(pctx, hash_state, signature));
@@ -265,7 +275,7 @@ int s2n_pkey_evp_verify(const struct s2n_pkey *pub, s2n_signature_algorithm sig_
         POSIX_GUARD_RESULT(s2n_evp_pkey_set_rsa_pss_saltlen(pctx));
     }
 
-    if (s2n_libcrypto_is_awslc_fips()) {
+    if (s2n_pkey_evp_digest_and_sign_is_required(sig_alg)) {
         POSIX_GUARD(s2n_pkey_evp_digest_and_verify(pctx, sig_alg, hash_state, signature));
     } else {
         POSIX_GUARD(s2n_pkey_evp_digest_then_verify(pctx, hash_state, signature));


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/5343

### Description of changes: 

The error from https://github.com/aws/s2n-tls/issues/5343 is actually related to signing, not to supporting / loading ML-DSA certificates. It just occurs during certificate loading because we perform a sign/verify operation to test the certificates.

The issue is that to support FIPS for RSA and ECDSA, we have to support a rather hacky "digest_and_sign" variation of signing. The same variation isn't required for ML-DSA, and won't actually work, hence the signing error in FIPS mode. The error didn't occur with the current validated version of AWS-LC-FIPS because that version of AWS-LC doesn't support ML-DSA at all.

The fix is fairly simple: don't use the "digest_and_sign" signing method when using ML-DSA + FIPS. Stick to the more standard "digest_then_sign" method.

### Testing:

Our CI does not currently support a version of AWS-LC-FIPS that supports ML-DSA. @dougch is working on that.
In the meantime, I tested locally with the mainline version of AWS-LC built in FIPS mode (`./codebuild/bin/install_awslc_fips.sh "$(mktemp -d)" test-deps/awslc-fips-next next` from our build scripts).

Without this fix, s2n_handshake_test and s2n_mldsa_test failed with:
```
Error Message: 'error signing data'
 Debug String: 'Error encountered in /home/ubuntu/s2n-tls/crypto/s2n_pkey_evp.c:140'
```
which is the same error the customer observed in https://github.com/aws/s2n-tls/issues/5343.

With this fix, all tests pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
