### PR TITLE
refactor(examples): remove connection pool

### DIFF
--- a/bindings/rust-examples/tokio-server-client/src/bin/server.rs
+++ b/bindings/rust-examples/tokio-server-client/src/bin/server.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
-use s2n_tls::{config::Config, enums::Mode, pool::ConfigPoolBuilder, security::DEFAULT_TLS13};
+use s2n_tls::{config::Config, enums::Mode, security::DEFAULT_TLS13};
 use s2n_tls_tokio::TlsAcceptor;
 use std::{error::Error, fs};
 use tokio::{io::AsyncWriteExt, net::TcpListener};
@@ -24,16 +24,13 @@ struct Args {
 async fn run_server(cert_pem: &[u8], key_pem: &[u8], addr: &str) -> Result<(), Box<dyn Error>> {
     // Set up the configuration for new connections.
     // Minimally you will need a certificate and private key.
-    let mut config = Config::builder();
-    config.set_security_policy(&DEFAULT_TLS13)?;
-    config.load_pem(cert_pem, key_pem)?;
-
-    // Create a connection pool to reuse connections.
-    let mut pool = ConfigPoolBuilder::new(Mode::Server, config.build()?);
-    pool.set_max_pool_size(10);
+    let mut builder = Config::builder();
+    builder.set_security_policy(&DEFAULT_TLS13)?;
+    builder.load_pem(cert_pem, key_pem)?;
+    let config = builder.build()?;
 
     // Create the TlsAcceptor based on the pool.
-    let server = TlsAcceptor::new(pool.build());
+    let server = TlsAcceptor::new(config);
 
     // Bind to an address and listen for connections.
     // ":0" can be used to automatically assign a port.


### PR DESCRIPTION
### Description of changes: 

Connection Pooling introduces extra complexity for very little benefit (~ 2 microseconds saved per connection on modern allocators). We shouldn't use it in our examples.

### Testing:
Ran the example locally.

```
     Running `/home/ubuntu/workspace/s2n-tls/bindings/rust-examples/target/debug/server`
Listening on 127.0.0.1:42887
Connection from 127.0.0.1:58304
TlsStream {
    connection: Connection {
        handshake_type: "NEGOTIATED|FULL_HANDSHAKE|MIDDLEBOX_COMPAT",
        cipher_suite: "TLS_AES_128_GCM_SHA256",
        actual_protocol_version: TLS13,
        selected_key_exchange_group: "secp256r1",
        ..
    },
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
