### PR TITLE
build: prevent needless rebuild with S2N_INTERN_LIBCRYPTO=ON and Ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,7 +437,7 @@ if (S2N_INTERN_LIBCRYPTO)
         add_custom_command(
             TARGET ${PROJECT_NAME} PRE_LINK
             COMMAND
-              find "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${PROJECT_NAME}.dir" -name '*.c.o' -exec objcopy --redefine-syms libcrypto.symbols {} \\\;
+              find "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${PROJECT_NAME}.dir" -name '*.c.o' -exec objcopy --redefine-syms libcrypto.symbols --preserve-dates {} \\\;
         )
     endif()
 


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves #5355

### Description of changes: 

The current `objcopy --redefine-syms` in `PRE_LINK` changes timestamp of `*.o`:
https://github.com/aws/s2n-tls/blob/f2d7429b1d4e4ad79a0ebb8d7d6aa2e4b61e9090/CMakeLists.txt#L437-L441

This change avoid it to prevent needless rebuild.

This is only needed for Ninja. This isn't needed for UNIX Makefiles.

### Call-outs:

None.

### Testing:

```console
$ rm -rf ../s2n-tls.build
$ cmake -S . -B ../s2n-tls.build -DCMAKE_INSTALL_PREFIX=/var/tmp/local -DCMAKE_BUILD_TYPE=Debug -DS2N_INTERN_LIBCRYPTO=ON -GNinja -DBUILD_TESTING=OFF
$ cmake --build ../s2n-tls.build
[175/175] Linking C static library lib/libs2n.a
$ cmake --build ../s2n-tls.build
ninja: no work to do.
```

The second `cmake --build` is the important part. It outputs "ninja: no work to do.". It shows that this prevents needless rebuild.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
