### PR TITLE
Include application message in Debug impl

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/error.rs
+++ b/bindings/rust/extended/s2n-tls/src/error.rs
@@ -343,6 +343,12 @@ impl From<Error> for std::io::Error {
 
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Application errors don't carry any interesting s2n context, so
+        // forward directly to the underyling error.
+        if let Self(Context::Application(err)) = self {
+            return err.fmt(f);
+        }
+
         let mut s = f.debug_struct("Error");
         if let Context::Code(code, _) = self.0 {
             s.field("code", &code);
@@ -468,6 +474,11 @@ mod tests {
 
             let app_error = error.application_error().unwrap();
             let _custom_error = app_error.downcast_ref::<CustomError>().unwrap();
+
+            let display = format!("{}", error);
+            assert_eq!(display, "custom error");
+            let debug = format!("{:?}", error);
+            assert_eq!(debug, "CustomError");
         }
 
         // make sure nested errors work


### PR DESCRIPTION
### Release Summary:

* The `fmt::Debug` message for application errors in the Rust bindings now use the application error's `fmt::Debug` implementation, rather than a generic message.

### Resolved issues:

n/a

### Description of changes: 

This avoids all application messages getting rendered the same way:

```
Error {
    name: "ApplicationError",
    message: "An error occurred while executing application code",
    kind: Application,
    source: Application
}
```

which is not very helpful to consumers.

### Call-outs:

n/a

### Testing:

See added unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
