### PR TITLE
tests(integ): add more debug logging

### DIFF
--- a/tests/integrationv2/fixtures.py
+++ b/tests/integrationv2/fixtures.py
@@ -66,6 +66,7 @@ def managed_process(request: pytest.FixtureRequest):
         p = ManagedProcess(
             cmd_line,
             provider.set_provider_ready,
+            name=provider.get_name(cmd_line),
             wait_for_marker=provider.ready_to_test_marker,
             send_marker_list=provider.ready_to_send_input_marker,
             close_marker=close_marker,

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -106,6 +106,10 @@ class Provider(object):
     def supports_certificate(cls, cert: Cert):
         return True
 
+    @classmethod
+    def get_name(cls, cmd_line):
+        return cmd_line[0]
+
 
 class Tcpdump(Provider):
     """
@@ -594,6 +598,10 @@ class OpenSSL(Provider):
             cmd_line.extend(self.options.extra_flags)
 
         return cmd_line
+
+    @classmethod
+    def get_name(cls, cmd_line):
+        return cmd_line[1]
 
 
 class SSLv3Provider(OpenSSL):


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

related to https://github.com/aws/s2n-tls/pull/5362

### Description of changes: 

Add more debugging messages in an attempt to clarify some really sneaky behavior. See inline comments.

### Testing:

I forced a test to timeout. The openssl timeout logging now looks like:
```
s2nd: Handling process IO: 
    wait_for_marker: Listening on 
    send_markers: None 
    close_marker: None 
    kill_marker: None
s2nd: stdout available
s2nd: looking for wait_for_marker Listening on in b'libcrypto: AWS-LC FIPS 1.52.1\nListening on localhost:8000\n'
s2nd: Unregistering (stdout + stderr), found wait_for_marker
s2nd: Handling process IO: 
    wait_for_marker: None 
    send_markers: None 
    close_marker: None 
    kill_marker: None
s_client: Handling process IO: 
    wait_for_marker: None 
    send_markers: ['this does not exist'] 
    close_marker: None 
    kill_marker: None
... more messages...
s_client: TIMEOUT. Killing process.
s_client: TIMEOUT. Reading remaining output.
s_client: Handling process IO: 
    wait_for_marker: None 
    send_markers: None 
    close_marker: None 
    kill_marker: None
s_client: stderr available
```
Previously, it would have just looked the s_client call to _communicate continued, but mysteriously had no send marker.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
