### PR TITLE
add cnsa 1 alias

### DIFF
--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -1145,6 +1145,20 @@ const struct s2n_security_policy security_policy_rfc9151 = {
 };
 
 /*
+ * CNSA_1.0 policy is an alias for the existing rfc9151 TLS Security policy.
+ */
+const struct s2n_security_policy security_policy_cnsa_1_20250616 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_rfc9151,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_rfc9151,
+    .certificate_signature_preferences = &s2n_certificate_signature_preferences_rfc9151,
+    .certificate_key_preferences = &s2n_certificate_key_preferences_rfc9151,
+    .ecc_preferences = &s2n_ecc_preferences_20210816,
+    .certificate_preferences_apply_locally = true
+};
+
+/*
  * This security policy is a mix of default_tls13 (20240503) and rfc9151, with
  * a primary requirement that AES-256 is the ciphersuite chosen. Other
  * requirements are generally picked to raise minimum thresholds (e.g.,
@@ -1382,6 +1396,7 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "20250211", .security_policy = &security_policy_20250211, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20250414", .security_policy = &security_policy_20250414, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "rfc9151", .security_policy = &security_policy_rfc9151, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "cnsa_1", .security_policy = &security_policy_cnsa_1_20250616, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "test_all", .security_policy = &security_policy_test_all, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "test_all_fips", .security_policy = &security_policy_test_all_fips, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "test_all_ecdsa", .security_policy = &security_policy_test_all_ecdsa, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },


### PR DESCRIPTION
Release Summary:

Resolved issues:
Partially addresses https://github.com/aws/s2n-tls/issues/5152

Description of changes:
Added new security policy: cnsa_1 (points to existing RFC 9151 existing fields)

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? What manual testing was performed? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

Remember:
* Any change to the library source code should at least include unit tests.
* Any change to the core stuffer or blob methods should include [CBMC proofs](https://github.com/aws/s2n-tls/tree/main/tests/cbmc).
* Any change to the CI or tests should:
   1. prove that the test succeeds for good input
   2. prove that the test fails for bad input (eg, a test for memory leaks fails when a memory leak is committed)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
