### PR TITLE
docs: note that s2n_shutdown may keep reading

### DIFF
--- a/docs/usage-guide/topics/ch07-io.md
+++ b/docs/usage-guide/topics/ch07-io.md
@@ -190,6 +190,11 @@ unless a close_notify alert is successfully both sent and received. As a result,
 `s2n_shutdown()` may fail when interacting with a non-conformant TLS implementation
 or if called on a connection in a bad state.
 
+`s2n_shutdown()` may also read and decrypt multiple application data records while waiting
+for the close_notify alert. This could result in calls to `s2n_shutdown()` taking a long
+time to complete. If this is a problem, `s2n_shutdown_send()` may be preferrable.
+See [Closing the connection for writes](#closing-the-connection-for-writes) below.
+
 Once `s2n_shutdown()` is complete:
 * The s2n_connection handle cannot be used for reading or writing.
 * The underlying transport can be closed, most likely via `shutdown()` or `close()`.


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

A customer noted that their calls to s2n_shutdown were taking a long time due to the peer continuing to send application data that they then had to read and decrypt. I'm updating the documentation to call out this behavior.


### Testing:

Just a documentation change.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
