### PR TITLE
fix: policy util should ignore deprecated TLS1.2 kems if missing

### DIFF
--- a/bin/policy.c
+++ b/bin/policy.c
@@ -102,9 +102,11 @@ int main(int argc, char *const *argv)
     if (policy->kem_preferences && policy->kem_preferences != &kem_preferences_null) {
         printf("pq:\n");
         printf("- revision: %i\n", policy->kem_preferences->tls13_pq_hybrid_draft_revision);
-        printf("- kems:\n");
-        for (size_t i = 0; i < policy->kem_preferences->kem_count; i++) {
-            printf("-- %s\n", policy->kem_preferences->kems[i]->name);
+        if (policy->kem_preferences->kem_count > 0) {
+            printf("- kems:\n");
+            for (size_t i = 0; i < policy->kem_preferences->kem_count; i++) {
+                printf("-- %s\n", policy->kem_preferences->kems[i]->name);
+            }
         }
         printf("- kem groups:\n");
         for (size_t i = 0; i < policy->kem_preferences->tls13_kem_group_count; i++) {

--- a/tests/policy_snapshot/snapshots/20240730
+++ b/tests/policy_snapshot/snapshots/20240730
@@ -52,7 +52,6 @@ certificate signature schemes:
 - legacy_ecdsa_sha224
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- SecP256r1Kyber768Draft00
 -- X25519Kyber768Draft00

--- a/tests/policy_snapshot/snapshots/20241001
+++ b/tests/policy_snapshot/snapshots/20241001
@@ -52,7 +52,6 @@ certificate signature schemes:
 - legacy_ecdsa_sha224
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- X25519MLKEM768
 -- SecP256r1MLKEM768

--- a/tests/policy_snapshot/snapshots/20241001_pq_mixed
+++ b/tests/policy_snapshot/snapshots/20241001_pq_mixed
@@ -52,7 +52,6 @@ certificate signature schemes:
 - legacy_ecdsa_sha224
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- X25519MLKEM768
 -- SecP256r1MLKEM768

--- a/tests/policy_snapshot/snapshots/20250512
+++ b/tests/policy_snapshot/snapshots/20250512
@@ -58,7 +58,6 @@ certificate signature schemes:
 - legacy_ecdsa_sha224
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- X25519MLKEM768
 -- SecP256r1MLKEM768

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.2-2023-PQ
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.2-2023-PQ
@@ -50,7 +50,6 @@ curves:
 - secp384r1
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- X25519MLKEM768
 -- SecP256r1MLKEM768

--- a/tests/policy_snapshot/snapshots/KMS-FIPS-TLS-1-2-2024-10
+++ b/tests/policy_snapshot/snapshots/KMS-FIPS-TLS-1-2-2024-10
@@ -31,7 +31,6 @@ curves:
 - secp521r1
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- X25519MLKEM768
 -- SecP256r1MLKEM768

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-0-2023-01-24
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-0-2023-01-24
@@ -40,7 +40,6 @@ curves:
 - secp384r1
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- x25519_kyber-512-r3
 -- secp256r1_kyber-512-r3

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-07
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-07
@@ -48,7 +48,6 @@ curves:
 - secp384r1
 pq:
 - revision: 0
-- kems:
 - kem groups:
 -- x25519_kyber-512-r3
 -- secp256r1_kyber-512-r3

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-08
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-08
@@ -55,7 +55,6 @@ curves:
 - secp384r1
 pq:
 - revision: 0
-- kems:
 - kem groups:
 -- x25519_kyber-512-r3
 -- secp256r1_kyber-512-r3

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-09
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-09
@@ -40,7 +40,6 @@ curves:
 - secp384r1
 pq:
 - revision: 0
-- kems:
 - kem groups:
 -- x25519_kyber-512-r3
 -- secp256r1_kyber-512-r3

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-10
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-10
@@ -55,7 +55,6 @@ curves:
 - secp384r1
 pq:
 - revision: 0
-- kems:
 - kem groups:
 -- x25519_kyber-512-r3
 -- secp256r1_kyber-512-r3

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-07
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-07
@@ -48,7 +48,6 @@ curves:
 - secp384r1
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- SecP256r1Kyber768Draft00
 -- X25519Kyber768Draft00

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-08
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-08
@@ -55,7 +55,6 @@ curves:
 - secp384r1
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- SecP256r1Kyber768Draft00
 -- X25519Kyber768Draft00

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-09
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-09
@@ -40,7 +40,6 @@ curves:
 - secp384r1
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- SecP256r1Kyber768Draft00
 -- X25519Kyber768Draft00

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-10
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-10
@@ -55,7 +55,6 @@ curves:
 - secp384r1
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- SecP256r1Kyber768Draft00
 -- X25519Kyber768Draft00

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-12-13
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-12-13
@@ -37,7 +37,6 @@ curves:
 - secp521r1
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- SecP256r1Kyber768Draft00
 -- secp384r1_kyber-768-r3

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-12-14
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-12-14
@@ -33,7 +33,6 @@ curves:
 - secp521r1
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- SecP256r1Kyber768Draft00
 -- secp384r1_kyber-768-r3

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-12-15
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-12-15
@@ -31,7 +31,6 @@ curves:
 - secp521r1
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- SecP256r1Kyber768Draft00
 -- secp384r1_kyber-768-r3

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-07
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-07
@@ -48,7 +48,6 @@ curves:
 - secp384r1
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- X25519MLKEM768
 -- SecP256r1MLKEM768

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-08
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-08
@@ -54,7 +54,6 @@ curves:
 - secp384r1
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- X25519MLKEM768
 -- SecP256r1MLKEM768

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-08_gcm
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-08_gcm
@@ -54,7 +54,6 @@ curves:
 - secp384r1
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- X25519MLKEM768
 -- SecP256r1MLKEM768

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-09
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-09
@@ -39,7 +39,6 @@ curves:
 - secp384r1
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- X25519MLKEM768
 -- SecP256r1MLKEM768

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-3-2023-06-01
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-3-2023-06-01
@@ -55,7 +55,6 @@ curves:
 - secp521r1
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- SecP256r1Kyber768Draft00
 -- X25519Kyber768Draft00

--- a/tests/policy_snapshot/snapshots/default_pq
+++ b/tests/policy_snapshot/snapshots/default_pq
@@ -58,7 +58,6 @@ certificate signature schemes:
 - legacy_ecdsa_sha224
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- X25519MLKEM768
 -- SecP256r1MLKEM768

--- a/tests/policy_snapshot/snapshots/test_all
+++ b/tests/policy_snapshot/snapshots/test_all
@@ -68,7 +68,6 @@ curves:
 - secp521r1
 pq:
 - revision: 5
-- kems:
 - kem groups:
 -- X25519MLKEM768
 -- SecP256r1MLKEM768

--- a/tests/policy_snapshot/snapshots/test_all_tls12
+++ b/tests/policy_snapshot/snapshots/test_all_tls12
@@ -60,7 +60,6 @@ curves:
 - secp521r1
 pq:
 - revision: 0
-- kems:
 - kem groups:
 -- x25519_kyber-512-r3
 -- secp256r1_kyber-512-r3


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

@jmayclin pointed out the ugly "kems" field in all our snapshots :) No policy currently includes kems, so we shouldn't print them. However, I left in the possibility of printing them if the field exists, for visibility just in case. We can remove the print when we completely remove the field.

### Testing:
No policy snapshots now include kems, verified via "grep -r "kems" tests/policy_snapshot/snapshots".
This is correct because no kem_preferences currently include kems:
```
% grep -c ".kem_count =" tls/s2n_kem_preferences.c     
8
%  grep ".kem_count =" tls/s2n_kem_preferences.c | grep -cv "0"     
0
%  grep -c ".kems =" tls/s2n_kem_preferences.c     
8
%  grep ".kems =" tls/s2n_kem_preferences.c | grep -cv "NULL"      
0
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
