### PR TITLE
feature: new TLS1.2 + FIPS CRT security policy

### DIFF
--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.2-2025
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.2-2025
@@ -1,0 +1,28 @@
+name: AWS-CRT-SDK-TLSv1.2-2025
+min version: TLS1.2
+rules:
+- Perfect Forward Secrecy: yes
+- FIPS 140-3 (2019): yes
+cipher suites:
+- TLS_AES_128_GCM_SHA256
+- TLS_AES_256_GCM_SHA384
+- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+signature schemes:
+- ecdsa_sha256
+- ecdsa_sha384
+- ecdsa_sha512
+- rsa_pss_pss_sha256
+- rsa_pss_pss_sha384
+- rsa_pss_pss_sha512
+- rsa_pss_rsae_sha256
+- rsa_pss_rsae_sha384
+- rsa_pss_rsae_sha512
+- rsa_pkcs1_sha256
+- rsa_pkcs1_sha384
+- rsa_pkcs1_sha512
+curves:
+- secp256r1
+- secp384r1

--- a/tls/s2n_cipher_preferences.c
+++ b/tls/s2n_cipher_preferences.c
@@ -1556,6 +1556,21 @@ const struct s2n_cipher_preferences cipher_preferences_aws_crt_sdk_default = {
     .allow_chacha20_boosting = false,
 };
 
+struct s2n_cipher_suite *cipher_suites_aws_crt_sdk_2025[] = {
+    &s2n_tls13_aes_128_gcm_sha256,
+    &s2n_tls13_aes_256_gcm_sha384,
+    &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_rsa_with_aes_128_gcm_sha256,
+    &s2n_ecdhe_ecdsa_with_aes_256_gcm_sha384,
+    &s2n_ecdhe_rsa_with_aes_256_gcm_sha384,
+};
+
+const struct s2n_cipher_preferences cipher_preferences_aws_crt_sdk_2025 = {
+    .count = s2n_array_len(cipher_suites_aws_crt_sdk_2025),
+    .suites = cipher_suites_aws_crt_sdk_2025,
+    .allow_chacha20_boosting = false,
+};
+
 struct s2n_cipher_suite *cipher_suites_aws_crt_sdk_tls_13[] = {
     S2N_TLS13_CLOUDFRONT_CIPHER_SUITES_20200716
 };

--- a/tls/s2n_cipher_preferences.h
+++ b/tls/s2n_cipher_preferences.h
@@ -117,6 +117,7 @@ extern const struct s2n_cipher_preferences cipher_preferences_cloudfront_tls_1_2
 extern const struct s2n_cipher_preferences cipher_preferences_aws_crt_sdk_ssl_v3;
 extern const struct s2n_cipher_preferences cipher_preferences_aws_crt_sdk_default;
 extern const struct s2n_cipher_preferences cipher_preferences_aws_crt_sdk_tls_13;
+extern const struct s2n_cipher_preferences cipher_preferences_aws_crt_sdk_2025;
 
 /* AWS KMS Cipher Preferences */
 extern const struct s2n_cipher_preferences cipher_preferences_kms_tls_1_0_2018_10;

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -557,6 +557,18 @@ const struct s2n_security_policy security_policy_aws_crt_sdk_tls_12_06_23 = {
     .ecc_preferences = &s2n_ecc_preferences_20230623,
 };
 
+const struct s2n_security_policy security_policy_aws_crt_sdk_tls_30_06_25 = {
+    .minimum_protocol_version = S2N_TLS12,
+    .cipher_preferences = &cipher_preferences_aws_crt_sdk_2025,
+    .kem_preferences = &kem_preferences_null,
+    .signature_preferences = &s2n_signature_preferences_20240501,
+    .ecc_preferences = &s2n_ecc_preferences_20140601,
+    .rules = {
+            [S2N_PERFECT_FORWARD_SECRECY] = true,
+            [S2N_FIPS_140_3] = true,
+    },
+};
+
 const struct s2n_security_policy security_policy_aws_crt_sdk_tls_13_06_23 = {
     .minimum_protocol_version = S2N_TLS13,
     .cipher_preferences = &cipher_preferences_aws_crt_sdk_tls_13,
@@ -1325,6 +1337,7 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "AWS-CRT-SDK-TLSv1.1-2023", .security_policy = &security_policy_aws_crt_sdk_tls_11_06_23, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "AWS-CRT-SDK-TLSv1.2-2023", .security_policy = &security_policy_aws_crt_sdk_tls_12_06_23, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "AWS-CRT-SDK-TLSv1.2-2023-PQ", .security_policy = &security_policy_aws_crt_sdk_tls_12_06_23_pq, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "AWS-CRT-SDK-TLSv1.2-2025", .security_policy = &security_policy_aws_crt_sdk_tls_30_06_25, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "AWS-CRT-SDK-TLSv1.3-2023", .security_policy = &security_policy_aws_crt_sdk_tls_13_06_23, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     /* KMS TLS Policies*/
     { .version = "KMS-TLS-1-0-2018-10", .security_policy = &security_policy_kms_tls_1_0_2018_10, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

CRT requested a new security policy based off of AWS-CRT-SDK-TLSv1.2-2023, that supports TLS1.2 and FIPS and does not include CBC cipher suites.

The new policy:
1. Add the "FIPS" rule
2. Add the "forward secrecy" rule
1. Removes the cipher suites:
   - TLS_CHACHA20_POLY1305_SHA256
   - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
   - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
   - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
   - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
   - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
   - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
   - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
   - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
   - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
   - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
   - TLS_RSA_WITH_AES_128_GCM_SHA256
   - TLS_RSA_WITH_AES_256_GCM_SHA384
   - TLS_RSA_WITH_AES_128_CBC_SHA256
   - TLS_RSA_WITH_AES_256_CBC_SHA256
   - TLS_RSA_WITH_AES_128_CBC_SHA
   - TLS_RSA_WITH_AES_256_CBC_SHA
3. Removes the signature schemes:
   - legacy_rsa_pkcs1_sha224
   - legacy_ecdsa_sha224
   - rsa_pkcs1_sha1
   - ecdsa_sha1
4. Prefers EC certs over RSA certs, if multiple certs are configured
5. Removes the named group:
   - x25519

The full diff between AWS-CRT-SDK-TLSv1.2-2023 and the new policy (AWS-CRT-SDK-TLSv1.2-2025):
```
diff AWS-CRT-SDK-TLSv1.2-2023 AWS-CRT-SDK-TLSv1.2-2025 

1c1
< name: AWS-CRT-SDK-TLSv1.2-2023
---
> name: AWS-CRT-SDK-TLSv1.2-2025
4,5c4,5
< - Perfect Forward Secrecy: no
< - FIPS 140-3 (2019): no
---
> - Perfect Forward Secrecy: yes
> - FIPS 140-3 (2019): yes
9d8
< - TLS_CHACHA20_POLY1305_SHA256
14,29d12
< - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
< - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
< - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
< - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
< - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
< - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
< - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
< - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
< - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
< - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
< - TLS_RSA_WITH_AES_128_GCM_SHA256
< - TLS_RSA_WITH_AES_256_GCM_SHA384
< - TLS_RSA_WITH_AES_128_CBC_SHA256
< - TLS_RSA_WITH_AES_256_CBC_SHA256
< - TLS_RSA_WITH_AES_128_CBC_SHA
< - TLS_RSA_WITH_AES_256_CBC_SHA
30a14,16
> - ecdsa_sha256
> - ecdsa_sha384
> - ecdsa_sha512
40,46d25
< - legacy_rsa_pkcs1_sha224
< - ecdsa_sha256
< - ecdsa_sha384
< - ecdsa_sha512
< - legacy_ecdsa_sha224
< - rsa_pkcs1_sha1
< - ecdsa_sha1
49d27
< - x25519
```

### Testing:
The new security policy is described above. It also now includes the "fips" and "forward secret" policy rules, which are enforced by unit tests and s2n_init.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
