### PR TITLE
feat: add secp384r1_mlkem_1024

### DIFF
--- a/crypto/s2n_fips_rules.c
+++ b/crypto/s2n_fips_rules.c
@@ -116,7 +116,8 @@ S2N_RESULT s2n_fips_validate_curve(const struct s2n_ecc_named_curve *curve, bool
 
 /* https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf */
 const struct s2n_kem *fips_kems[] = {
-    &s2n_mlkem_768
+    &s2n_mlkem_768,
+    &s2n_mlkem_1024
 };
 
 S2N_RESULT s2n_fips_validate_kem(const struct s2n_kem *kem, bool *valid)

--- a/tests/features/S2N_LIBCRYPTO_SUPPORTS_MLKEM.c
+++ b/tests/features/S2N_LIBCRYPTO_SUPPORTS_MLKEM.c
@@ -22,10 +22,12 @@ int main()
     if (ctx == NULL) {
         return 1;
     }
-    if (!EVP_PKEY_CTX_kem_set_params(ctx, NID_MLKEM768)) {
+    if (!EVP_PKEY_CTX_kem_set_params(ctx, NID_MLKEM768)
+            || !EVP_PKEY_CTX_kem_set_params(ctx, NID_MLKEM1024)) {
         EVP_PKEY_CTX_free(ctx);
         return 1;
     }
+
     EVP_PKEY_CTX_free(ctx);
     return 0;
 }

--- a/tests/unit/s2n_kem_test.c
+++ b/tests/unit/s2n_kem_test.c
@@ -195,6 +195,25 @@ int main(int argc, char **argv)
         EXPECT_FAILURE_WITH_ERRNO(s2n_get_kem_from_extension_id(non_existent_kem_id, &returned_kem), S2N_ERR_KEM_UNSUPPORTED_PARAMS);
     };
 
+    /* Test: s2n_kem_is_available() returns correct availability for known and unknown KEMs */
+    {
+        bool mlkem_supported = s2n_libcrypto_supports_mlkem();
+        EXPECT_EQUAL(s2n_kem_is_available(&s2n_mlkem_768), mlkem_supported);
+        EXPECT_EQUAL(s2n_kem_is_available(&s2n_mlkem_1024), mlkem_supported);
+
+        bool evp_supported = s2n_libcrypto_supports_evp_kem();
+        EXPECT_EQUAL(s2n_kem_is_available(&s2n_kyber_512_r3), evp_supported);
+        EXPECT_EQUAL(s2n_kem_is_available(&s2n_kyber_768_r3), evp_supported);
+        EXPECT_EQUAL(s2n_kem_is_available(&s2n_kyber_1024_r3), evp_supported);
+
+        EXPECT_FALSE(s2n_kem_is_available(NULL));
+        const struct s2n_kem bogus_kem = {
+            .name = "bogus",
+            .kem_nid = NID_undef,
+        };
+        EXPECT_FALSE(s2n_kem_is_available(&bogus_kem));
+    };
+
     /* If KEM tests depend on len_prefix, test with both possible values */
     for (int len_prefixed = 0; len_prefixed < 2; len_prefixed++) {
         {

--- a/tests/unit/s2n_pq_kem_test.c
+++ b/tests/unit/s2n_pq_kem_test.c
@@ -25,6 +25,7 @@
 
 static const struct s2n_kem *test_vectors[] = {
     &s2n_mlkem_768,
+    &s2n_mlkem_1024,
     &s2n_kyber_512_r3,
     &s2n_kyber_768_r3,
     &s2n_kyber_1024_r3,

--- a/tests/unit/s2n_pq_mlkem_policies_test.c
+++ b/tests/unit/s2n_pq_mlkem_policies_test.c
@@ -89,7 +89,8 @@ static S2N_RESULT s2n_policy_in_list(const char *policy_name, const char **excep
 
 /* List of all ML-KEM Parameter sizes */
 const struct s2n_kem *mlkem_list[] = {
-    &s2n_mlkem_768
+    &s2n_mlkem_768,
+    &s2n_mlkem_1024
 };
 
 /* Ciphers that should not be present in TLS Policies that have ML-KEM */

--- a/tls/s2n_kem.c
+++ b/tls/s2n_kem.c
@@ -36,6 +36,19 @@ const struct s2n_kem s2n_mlkem_768 = {
     .decapsulate = &s2n_evp_kem_decapsulate,
 };
 
+const struct s2n_kem s2n_mlkem_1024 = {
+    .name = "mlkem1024",
+    .kem_nid = S2N_NID_MLKEM1024,
+    .kem_extension_id = 0, /* This is not used in TLS 1.2's KEM extension */
+    .public_key_length = S2N_MLKEM_1024_PUBLIC_KEY_BYTES,
+    .private_key_length = S2N_MLKEM_1024_SECRET_KEY_BYTES,
+    .shared_secret_key_length = S2N_MLKEM_1024_SHARED_SECRET_BYTES,
+    .ciphertext_length = S2N_MLKEM_1024_CIPHERTEXT_BYTES,
+    .generate_keypair = &s2n_evp_kem_generate_keypair,
+    .encapsulate = &s2n_evp_kem_encapsulate,
+    .decapsulate = &s2n_evp_kem_decapsulate,
+};
+
 const struct s2n_kem s2n_kyber_512_r3 = {
     .name = "kyber512r3",
     .kem_nid = S2N_NID_KYBER512,
@@ -467,14 +480,7 @@ bool s2n_kem_is_available(const struct s2n_kem *kem)
         return false;
     }
 
-    bool available = s2n_libcrypto_supports_evp_kem();
-
-    /* Only newer versions of libcrypto have ML-KEM support. */
-    if (kem == &s2n_mlkem_768) {
-        available &= s2n_libcrypto_supports_mlkem();
-    }
-
-    return available;
+    return s2n_libcrypto_supports_evp_kem();
 }
 
 bool s2n_kem_group_is_available(const struct s2n_kem_group *kem_group)

--- a/tls/s2n_kem.h
+++ b/tls/s2n_kem.h
@@ -42,9 +42,11 @@ typedef uint16_t kem_ciphertext_key_size;
 #endif
 
 #if defined(S2N_LIBCRYPTO_SUPPORTS_MLKEM)
-    #define S2N_NID_MLKEM768 NID_MLKEM768
+    #define S2N_NID_MLKEM768  NID_MLKEM768
+    #define S2N_NID_MLKEM1024 NID_MLKEM1024
 #else
-    #define S2N_NID_MLKEM768 NID_undef
+    #define S2N_NID_MLKEM768  NID_undef
+    #define S2N_NID_MLKEM1024 NID_undef
 #endif
 
 struct s2n_kem {
@@ -95,6 +97,7 @@ struct s2n_kem_group_params {
 };
 
 extern const struct s2n_kem s2n_mlkem_768;
+extern const struct s2n_kem s2n_mlkem_1024;
 extern const struct s2n_kem s2n_kyber_512_r3;
 extern const struct s2n_kem s2n_kyber_768_r3;
 extern const struct s2n_kem s2n_kyber_1024_r3;
@@ -140,6 +143,12 @@ bool s2n_kem_group_is_available(const struct s2n_kem_group *kem_group);
 #define S2N_MLKEM_768_SECRET_KEY_BYTES    2400
 #define S2N_MLKEM_768_CIPHERTEXT_BYTES    1088
 #define S2N_MLKEM_768_SHARED_SECRET_BYTES 32
+
+/* mlkem1024 */
+#define S2N_MLKEM_1024_PUBLIC_KEY_BYTES    1568
+#define S2N_MLKEM_1024_SECRET_KEY_BYTES    3168
+#define S2N_MLKEM_1024_CIPHERTEXT_BYTES    1568
+#define S2N_MLKEM_1024_SHARED_SECRET_BYTES 32
 
 /* kyber512r3 */
 #define S2N_KYBER_512_R3_PUBLIC_KEY_BYTES    800


### PR DESCRIPTION
### Release Summary

### Resolved issues:
Partially addresses [#5152](https://github.com/aws/s2n-tls/issues/5152)

### Description of changes: 

* Created a new hybrid KEM group: `s2n_secp384r1_mlkem_1024`

### Call-outs:

MLKEM1024_SECRET test vector is taken from:
https://raw.githubusercontent.com/aws/aws-lc/refs/heads/main/crypto/fipsmodule/ml_kem/kat/mlkem1024.txt

AES secrets in the test are generated via:
https://github.com/aws/s2n-tls/blob/main/tests/unit/kats/generate_pq_hybrid_tls13_handshake_kats.py

MLKEM-1024 is based on the [CNSA 2.0 draft](https://datatracker.ietf.org/doc/draft-becker-cnsa2-tls-profile/)
and is not yet IETF-approved:
https://datatracker.ietf.org/doc/draft-ietf-tls-mlkem/

### Testing:

* Added availability checks 
* Added hybrid test vectors using AES-128 and AES-256 to validate shared secret and traffic secret derivation.
* Verify that ML-KEM-1024 hybrid KEM negotiation works between a client and server using the same security policy. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
