### PR TITLE
fix: check pr author on codebuild start

### DIFF
--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -4,6 +4,9 @@ name: Codebuild
 on:
   push:
     branches: [main]
+  # This event can use aws credentials, but runs against upstream code instead of PR code.
+  # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
+  # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
   pull_request_target:
     branches: [main]
   merge_group:
@@ -17,22 +20,30 @@ jobs:
       id-token: write
       contents: read
     env:
-      event_name: ${{ github.event_name }}
       source_pr: pr/${{ github.event.pull_request.number }}
       source_sha: ${{ github.sha }}
+      pr_author: ${{ github.event.pull_request.user.login }}
     steps:
       - uses: actions/checkout@v4
+
       - name: Get credentials
         uses: aws-actions/configure-aws-credentials@v4.2.1
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: ${{ github.run_id }}
           aws-region: us-west-2
-      - name: Start Codebuild
+
+      - name: Start Codebuild for SHA
+        if: github.event_name != 'pull_request_target'
+        run: ./codebuild/bin/start_codebuild.sh $source_sha
+
+      - name: Start Codebuild for PR
+        if: github.event_name == 'pull_request_target'
         run: |
-          if [[ "$event_name" == "pull_request_target" ]]; then
-            source=$source_pr
+          pattern="^  - '@$pr_author'$"
+          if grep "$pattern" .github/teams.yml; then
+            ./codebuild/bin/start_codebuild.sh $source_pr
           else
-            source=$source_sha
+            echo "$pr_author is not part of s2n-core."
+            echo "A member of s2n-core will need to start the Codebuild jobs manually using the start_codebuild.sh script."
           fi
-          ./codebuild/bin/start_codebuild.sh $source


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 
Add a team membership check to the codebuild github action.

### Testing:

1. The action calls the start_codebuild.sh script with lrstewart is listed as part of the team: https://github.com/lrstewart/s2n/pull/68 The action fails because my branch does not have the codebuild credentials.
2. The action doesn't call the start_codebuild.sh script when lrstewart is not listed as part of the team: https://github.com/lrstewart/s2n/pull/68 The action succeeds because it is a no-op.
3. I double-checked that an external user is unable to push to a PR opened by someone else. Only contributors can, if given permission.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
