### PR TITLE
ci: require repo write permissions for codebuild

### DIFF
--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -4,6 +4,9 @@ name: Codebuild
 on:
   push:
     branches: [main]
+  # This event can use aws credentials, but runs against upstream code instead of PR code.
+  # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
+  # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
   pull_request_target:
     branches: [main]
   merge_group:
@@ -17,22 +20,44 @@ jobs:
       id-token: write
       contents: read
     env:
-      event_name: ${{ github.event_name }}
       source_pr: pr/${{ github.event.pull_request.number }}
       source_sha: ${{ github.sha }}
+      pr_author: ${{ github.event.pull_request.user.login }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Get permissions
+        id: get_permission
+        if: github.event_name == 'pull_request_target'
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/{repo}/collaborators/{author}/permission
+          repo: ${{ github.repository }}
+          author: ${{ github.event.pull_request.user.login }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Get credentials
         uses: aws-actions/configure-aws-credentials@v4.2.1
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: ${{ github.run_id }}
           aws-region: us-west-2
-      - name: Start Codebuild
+
+      - name: Start Codebuild for SHA
+        # This version runs when PRs are added to the merge queue or merged to main
+        if: github.event_name != 'pull_request_target'
+        run: ./codebuild/bin/start_codebuild.sh $source_sha
+
+      - name: Start Codebuild for PR
+        # This version runs when PRs are created or updated
+        if: github.event_name == 'pull_request_target'
         run: |
-          if [[ "$event_name" == "pull_request_target" ]]; then
-            source=$source_pr
+          permission=$(jq -r '.permission' <<< '${{ steps.get_permission.outputs.data }}')
+          echo "$pr_author has permission '$permission'".
+          if [[ "$permission" == "admin" || "$permission" == "write" ]]; then
+            ./codebuild/bin/start_codebuild.sh $source_pr
           else
-            source=$source_sha
+            echo "$pr_author does not have write permissions."
+            echo "A maintainer will need to manually run start_codebuild.sh."
           fi
-          ./codebuild/bin/start_codebuild.sh $source


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

Add a team membership check to the codebuild github action. This version goes further than https://github.com/aws/s2n-tls/pull/5412 and calls a Github API to check for write permissions, rather than using our hard-coded teams.yml. This is more complex, but probably safer.

### Callouts

I originally stumbled on the pull_request.author_association field instead, but that does not appear to work for orgs without public membership. I was only marked as "contributor", not "member". But that led me to [this](https://michaelheap.com/github-actions-check-permission/) article, which describes both the pull_request.author_association approach and the /repos/{repo}/collaborators/{author}/permission approach.

### Testing:

* Here's a test PR from me: https://github.com/aws/s2n-tls/pull/5419 It successfully identifies my permissions as "admin" and runs the codebuild jobs.
* Here's a test PR from confusedpheasant: https://github.com/aws/s2n-tls/pull/5420 It successfully identifies the permissions as only "read", so does NOT run the codebuild jobs.
* Here's a test PR from @boquan-fang: https://github.com/aws/s2n-tls/pull/5423 It successfully identifies the permissions as "write" and runs the codebuild jobs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
