### PR TITLE
chore(ci): once a week, clean the nix store for the kTLS job.

### DIFF
--- a/codebuild/spec/buildspec_ktls.yml
+++ b/codebuild/spec/buildspec_ktls.yml
@@ -39,6 +39,8 @@ phases:
       - export PATH=$HOME/.nix-profile/bin:$PATH
       # Turn on flakes
       - mkdir -p ~/.config/nix; echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+      # On Sunday, run a nix store cleanup
+      - if [[ $(date +%u) -eq 0 ]]; then nix store gc;fi
       # Populate the store from the nix cache
       - nix copy --from $NIX_CACHE_BUCKET --all  --no-check-sigs
       # Load the TLS kernel module


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->


### Description of changes: 

For kTLS, we're using reserved instances, which unlike docker containers, don't get discarded and cleaned up. This has lead to some `out of space` failures.  Add in a `nix store gc` to clean the nix store prior to refreshing from cache.

### Call-outs:

If we expand the use of reserved instances, this cleanup should probably be moved into a central location.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? ad-hoc
How can you convince your reviewers that this PR is safe and effective? Some runtime metrics will prove we're not impacting runtimes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
