### PR TITLE
refactor(bench): unify IO methods

### DIFF
--- a/bindings/rust/standard/bench/src/harness/io.rs
+++ b/bindings/rust/standard/bench/src/harness/io.rs
@@ -1,16 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{cell::RefCell, collections::VecDeque, io::ErrorKind, pin::Pin, rc::Rc};
+use std::{cell::RefCell, collections::VecDeque, io::ErrorKind, rc::Rc};
 
 pub type LocalDataBuffer = RefCell<VecDeque<u8>>;
 
 #[derive(Debug)]
 pub struct TestPairIO {
     /// a data buffer that the server writes to and the client reads from
-    pub server_tx_stream: Pin<Rc<LocalDataBuffer>>,
+    pub server_tx_stream: Rc<LocalDataBuffer>,
     /// a data buffer that the client writes to and the server reads from
-    pub client_tx_stream: Pin<Rc<LocalDataBuffer>>,
+    pub client_tx_stream: Rc<LocalDataBuffer>,
 }
 
 impl TestPairIO {
@@ -38,8 +38,8 @@ impl TestPairIO {
 // which implements read and write. This is not used by s2n-tls, which relies on
 // lower level callbacks.
 pub struct ViewIO {
-    pub send_ctx: Pin<Rc<LocalDataBuffer>>,
-    pub recv_ctx: Pin<Rc<LocalDataBuffer>>,
+    pub send_ctx: Rc<LocalDataBuffer>,
+    pub recv_ctx: Rc<LocalDataBuffer>,
 }
 
 impl std::io::Read for ViewIO {

--- a/bindings/rust/standard/bench/src/lib.rs
+++ b/bindings/rust/standard/bench/src/lib.rs
@@ -5,6 +5,8 @@ pub mod harness;
 pub mod openssl;
 pub mod rustls;
 pub mod s2n_tls;
+#[cfg(test)]
+pub mod test_utilities;
 
 pub use crate::{
     harness::{

--- a/bindings/rust/standard/bench/src/openssl.rs
+++ b/bindings/rust/standard/bench/src/openssl.rs
@@ -285,7 +285,7 @@ mod tests {
 
     #[test]
     fn sanity_check() {
-        test_utilities::sanity_check::<OpenSslConnection>();
+        test_utilities::basic_handshake::<OpenSslConnection>();
     }
 
     #[test]

--- a/bindings/rust/standard/bench/src/openssl.rs
+++ b/bindings/rust/standard/bench/src/openssl.rs
@@ -204,16 +204,18 @@ impl TlsConnection for OpenSslConnection {
         self.connection.ssl().is_init_finished()
     }
 
-    fn send(&mut self, data: &[u8]) -> Result<(), Box<dyn Error>> {
+    fn send(&mut self, data: &[u8]) {
         let mut write_offset = 0;
         while write_offset < data.len() {
-            write_offset += self.connection.write(&data[write_offset..data.len()])?;
-            self.connection.flush()?; // make sure internal buffers don't fill up
+            write_offset += self
+                .connection
+                .write(&data[write_offset..data.len()])
+                .unwrap();
+            self.connection.flush().unwrap(); // make sure internal buffers don't fill up
         }
-        Ok(())
     }
 
-    fn recv(&mut self, data: &mut [u8]) -> Result<(), Box<dyn Error>> {
+    fn recv(&mut self, data: &mut [u8]) -> std::io::Result<()> {
         let data_len = data.len();
         let mut read_offset = 0;
         while read_offset < data.len() {
@@ -272,5 +274,27 @@ impl TlsInfo for OpenSslConnection {
 
     fn resumed_connection(&self) -> bool {
         self.connection.ssl().session_reused()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utilities;
+
+    use super::*;
+
+    #[test]
+    fn sanity_check() {
+        test_utilities::sanity_check::<OpenSslConnection>();
+    }
+
+    #[test]
+    fn all_handshakes() {
+        test_utilities::all_handshakes::<OpenSslConnection>();
+    }
+
+    #[test]
+    fn transfer() {
+        test_utilities::transfer::<OpenSslConnection>();
     }
 }

--- a/bindings/rust/standard/bench/src/rustls.rs
+++ b/bindings/rust/standard/bench/src/rustls.rs
@@ -326,7 +326,7 @@ mod tests {
 
     #[test]
     fn sanity_check() {
-        test_utilities::sanity_check::<RustlsConnection>();
+        test_utilities::basic_handshake::<RustlsConnection>();
     }
 
     #[test]

--- a/bindings/rust/standard/bench/src/rustls.rs
+++ b/bindings/rust/standard/bench/src/rustls.rs
@@ -44,6 +44,16 @@ impl RustlsConnection {
     }
 
     /// Treat `WouldBlock` as an `Ok` value for when blocking is expected
+    ///
+    /// Blocking is expected during the initial negotiation. Calls to "read_tls"
+    /// will eventually block, because the peer hasn't actually responded to the
+    /// written messages.
+    ///
+    /// Blocking is expected during the reading of application data, because rustls
+    /// will return a WouldBlock error when the record is too large to fit into
+    /// its internal buffer. Following this error Rustls will increase the size
+    /// of the buffer, so that the read call eventually succeeds.
+    /// https://github.com/rustls/rustls/blob/87f37dd44e32b2771fa471a5d8111749ca9e7aa7/rustls/src/msgs/deframer/buffers.rs#L220
     fn ignore_block<T: Default>(res: Result<T, std::io::Error>) -> Result<T, std::io::Error> {
         match res {
             Ok(t) => Ok(t),
@@ -236,20 +246,20 @@ impl TlsConnection for RustlsConnection {
         !self.connection.is_handshaking()
     }
 
-    fn send(&mut self, data: &[u8]) -> Result<(), Box<dyn Error>> {
+    fn send(&mut self, data: &[u8]) {
         let mut write_offset = 0;
         while write_offset < data.len() {
             write_offset += self
                 .connection
                 .writer()
-                .write(&data[write_offset..data.len()])?;
-            self.connection.writer().flush()?;
-            self.connection.complete_io(&mut self.io)?;
+                .write(&data[write_offset..data.len()])
+                .unwrap();
+            self.connection.writer().flush().unwrap();
+            self.connection.complete_io(&mut self.io).unwrap();
         }
-        Ok(())
     }
 
-    fn recv(&mut self, data: &mut [u8]) -> Result<(), Box<dyn Error>> {
+    fn recv(&mut self, data: &mut [u8]) -> std::io::Result<()> {
         let data_len = data.len();
         let mut read_offset = 0;
         while read_offset < data.len() {
@@ -268,14 +278,12 @@ impl TlsConnection for RustlsConnection {
             Connection::Client(client_connection) => client_connection.send_close_notify(),
             Connection::Server(server_connection) => server_connection.send_close_notify(),
         }
-        // this sends the close notify, but never reads
-        let (read, written) = self.connection.complete_io(&mut self.io).unwrap();
-        assert_eq!(read, 0);
-        assert!(written > 0);
+        self.connection.write_tls(&mut self.io).unwrap();
     }
 
     fn shutdown_finish(&mut self) -> bool {
-        self.connection.complete_io(&mut self.io).unwrap();
+        self.connection.read_tls(&mut self.io).unwrap();
+        self.connection.process_new_packets().unwrap();
 
         let res = self.connection.reader().read(&mut [0]);
         matches!(res, Ok(0))
@@ -307,5 +315,27 @@ impl TlsInfo for RustlsConnection {
         } else {
             panic!("rustls connection resumption status must be check on the server side");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utilities;
+
+    use super::*;
+
+    #[test]
+    fn sanity_check() {
+        test_utilities::sanity_check::<RustlsConnection>();
+    }
+
+    #[test]
+    fn all_handshakes() {
+        test_utilities::all_handshakes::<RustlsConnection>();
+    }
+
+    #[test]
+    fn transfer() {
+        test_utilities::transfer::<RustlsConnection>();
     }
 }

--- a/bindings/rust/standard/bench/src/s2n_tls.rs
+++ b/bindings/rust/standard/bench/src/s2n_tls.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     harness::{
-        self, read_to_bytes, CipherSuite, CryptoConfig, HandshakeType, KXGroup,
-        Mode, TlsConnection, TlsInfo, ViewIO,
+        self, read_to_bytes, CipherSuite, CryptoConfig, HandshakeType, KXGroup, Mode,
+        TlsConnection, TlsInfo, ViewIO,
     },
     PemType::*,
 };
@@ -197,7 +197,7 @@ impl crate::harness::TlsBenchConfig for S2NConfig {
     }
 }
 
-// We allow dead_code, because otherwise the compiler sees `io` as unused because 
+// We allow dead_code, because otherwise the compiler sees `io` as unused because
 // it can't reason through the pointers that were passed into the s2n-tls connection
 // io contexts.
 #[allow(dead_code)]

--- a/bindings/rust/standard/bench/src/s2n_tls.rs
+++ b/bindings/rust/standard/bench/src/s2n_tls.rs
@@ -239,10 +239,9 @@ impl TlsConnection for S2NConnection {
             .set_send_callback(Some(generic_send_cb::<ViewIO>))?
             .set_receive_callback(Some(generic_recv_cb::<ViewIO>))?;
         unsafe {
-            let raw_view_io = *(&mut io as *mut Pin<Box<ViewIO>> as *mut *mut ViewIO);
             connection
-                .set_send_context(raw_view_io as *mut c_void)?
-                .set_receive_context(raw_view_io as *mut c_void)?;
+                .set_send_context(&mut *io as *mut ViewIO as *mut c_void)?
+                .set_receive_context(&mut *io as *mut ViewIO as *mut c_void)?;
         }
 
         if let Some(ticket) = config.ticket_storage.0.lock().unwrap().borrow_mut().take() {
@@ -295,6 +294,7 @@ impl TlsConnection for S2NConnection {
         }
         Ok(())
     }
+
     fn shutdown_send(&mut self) {
         assert!(matches!(
             self.connection.poll_shutdown_send(),
@@ -341,7 +341,7 @@ mod tests {
 
     #[test]
     fn sanity_check() {
-        test_utilities::sanity_check::<S2NConnection>();
+        test_utilities::basic_handshake::<S2NConnection>();
     }
 
     #[test]

--- a/bindings/rust/standard/bench/src/s2n_tls.rs
+++ b/bindings/rust/standard/bench/src/s2n_tls.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     harness::{
-        self, read_to_bytes, CipherSuite, CryptoConfig, HandshakeType, KXGroup, LocalDataBuffer,
-        Mode, TlsConnection, TlsInfo,
+        self, read_to_bytes, CipherSuite, CryptoConfig, HandshakeType, KXGroup,
+        Mode, TlsConnection, TlsInfo, ViewIO,
     },
     PemType::*,
 };
@@ -19,8 +19,9 @@ use std::{
     borrow::BorrowMut,
     error::Error,
     ffi::c_void,
-    io::{Read, Write},
+    io::ErrorKind,
     os::raw::c_int,
+    pin::Pin,
     sync::{Arc, Mutex},
     task::Poll,
     time::SystemTime,
@@ -34,6 +35,44 @@ struct HostNameHandler {
 impl VerifyHostNameCallback for HostNameHandler {
     fn verify_host_name(&self, hostname: &str) -> bool {
         self.expected_server_name == hostname
+    }
+}
+
+/// An s2n send callback for some generic type `T` where `T: Write`.
+///
+/// # Safety
+/// The context must be semantically `Pin`, because it is stored as a raw pointer.
+/// The pointer must be one layer of indirection, e.g. `*mut T`.
+pub unsafe extern "C" fn generic_send_cb<T: std::io::Write>(
+    context: *mut c_void,
+    data: *const u8,
+    len: u32,
+) -> c_int {
+    let context: &mut T = &mut *(context as *mut T);
+    let data = core::slice::from_raw_parts(data, len as _);
+    let bytes_written = context.write(data).unwrap();
+    bytes_written as c_int
+}
+
+/// An s2n recv callback for some generic type `T` where `T: Read`.
+///
+/// # Safety
+/// The context must be semantically `Pin`, because it is stored as a raw pointer.
+/// The pointer must be one layer of indirection, e.g. `*mut T`.
+pub unsafe extern "C" fn generic_recv_cb<T: std::io::Read>(
+    context: *mut c_void,
+    data: *mut u8,
+    len: u32,
+) -> c_int {
+    let context: &mut T = &mut *(context as *mut T);
+    let data = core::slice::from_raw_parts_mut(data, len as _);
+    match context.read(data) {
+        Ok(len) => len as c_int,
+        Err(err) if err.kind() == ErrorKind::WouldBlock => {
+            errno::set_errno(errno::Errno(libc::EWOULDBLOCK));
+            -1
+        }
+        Err(unrecognized) => panic!("unexpected error: {unrecognized}"),
     }
 }
 
@@ -158,48 +197,16 @@ impl crate::harness::TlsBenchConfig for S2NConfig {
     }
 }
 
+// We allow dead_code, because otherwise the compiler sees `io` as unused because 
+// it can't reason through the pointers that were passed into the s2n-tls connection
+// io contexts.
+#[allow(dead_code)]
 pub struct S2NConnection {
+    io: Pin<Box<ViewIO>>,
     connection: Connection,
-    handshake_completed: bool,
 }
 
 impl S2NConnection {
-    /// Unsafe callback for custom IO C API
-    ///
-    /// s2n-tls IO is usually used with file descriptors to a TCP socket, but we
-    /// reduce overhead and outside noise with a local buffer for benchmarking
-    unsafe extern "C" fn send_cb(context: *mut c_void, data: *const u8, len: u32) -> c_int {
-        let context = &*(context as *const LocalDataBuffer);
-        let data = core::slice::from_raw_parts(data, len as _);
-        let bytes_written = context.borrow_mut().write(data).unwrap();
-        bytes_written as c_int
-    }
-
-    // Note: this callback will be invoked multiple times in the event that
-    // the byte-slices of the VecDeque are not contiguous (wrap around).
-    unsafe extern "C" fn recv_cb(context: *mut c_void, data: *mut u8, len: u32) -> c_int {
-        let context = &*(context as *const LocalDataBuffer);
-        let data = core::slice::from_raw_parts_mut(data, len as _);
-        match context.borrow_mut().read(data) {
-            Ok(len) => {
-                if len == 0 {
-                    // returning a length of 0 indicates a channel close (e.g. a
-                    // TCP Close) which would not be correct. To just communicate
-                    // "no more data", we instead set the errno to WouldBlock and
-                    // return -1.
-                    errno::set_errno(errno::Errno(libc::EWOULDBLOCK));
-                    -1
-                } else {
-                    len as c_int
-                }
-            }
-            Err(err) => {
-                // VecDeque IO Operations should never fail
-                panic!("{err:?}");
-            }
-        }
-    }
-
     pub fn connection(&self) -> &Connection {
         &self.connection
     }
@@ -223,71 +230,71 @@ impl TlsConnection for S2NConnection {
             Mode::Server => io.server_view(),
         };
 
-        let io = Box::pin(io);
+        let mut io = Box::pin(io);
 
         let mut connection = Connection::new(s2n_mode);
         connection
             .set_blinding(Blinding::SelfService)?
             .set_config(config.config.clone())?
-            .set_send_callback(Some(Self::send_cb))?
-            .set_receive_callback(Some(Self::recv_cb))?;
+            .set_send_callback(Some(generic_send_cb::<ViewIO>))?
+            .set_receive_callback(Some(generic_recv_cb::<ViewIO>))?;
         unsafe {
+            let raw_view_io = *(&mut io as *mut Pin<Box<ViewIO>> as *mut *mut ViewIO);
             connection
-                .set_send_context(
-                    &io.send_ctx as &LocalDataBuffer as *const LocalDataBuffer as *mut c_void,
-                )?
-                .set_receive_context(
-                    &io.recv_ctx as &LocalDataBuffer as *const LocalDataBuffer as *mut c_void,
-                )?;
+                .set_send_context(raw_view_io as *mut c_void)?
+                .set_receive_context(raw_view_io as *mut c_void)?;
         }
 
         if let Some(ticket) = config.ticket_storage.0.lock().unwrap().borrow_mut().take() {
             connection.set_session_ticket(&ticket)?;
         }
 
-        Ok(Self {
-            connection,
-            handshake_completed: false,
-        })
+        Ok(Self { io, connection })
     }
 
     fn handshake(&mut self) -> Result<(), Box<dyn Error>> {
-        self.handshake_completed = self
-            .connection
-            .poll_negotiate()
-            .map(|res| res.unwrap()) // unwrap `Err` if present
-            .is_ready();
-        Ok(())
-    }
-
-    fn handshake_completed(&self) -> bool {
-        self.handshake_completed
-    }
-
-    fn send(&mut self, data: &[u8]) -> Result<(), Box<dyn Error>> {
-        let mut write_offset = 0;
-        while write_offset < data.len() {
-            match self.connection.poll_send(&data[write_offset..]) {
-                Poll::Ready(bytes_written) => write_offset += bytes_written?,
-                Poll::Pending => return Err("blocking".into()),
-            }
-            assert!(self.connection.poll_flush().is_ready());
+        if let Poll::Ready(res) = self.connection.poll_negotiate() {
+            res?;
         }
         Ok(())
     }
 
-    fn recv(&mut self, data: &mut [u8]) -> Result<(), Box<dyn Error>> {
+    fn handshake_completed(&self) -> bool {
+        let complete = self
+            .connection
+            .handshake_type()
+            .unwrap()
+            .contains("NEGOTIATED");
+        complete
+    }
+
+    fn send(&mut self, data: &[u8]) {
+        let mut write_offset = 0;
+        while write_offset < data.len() {
+            match self.connection.poll_send(&data[write_offset..]) {
+                Poll::Ready(bytes_written) => write_offset += bytes_written.unwrap(),
+                Poll::Pending => panic!("unexpected `Pending` poll"),
+            }
+            assert!(self.connection.poll_flush().is_ready());
+        }
+    }
+
+    fn recv(&mut self, data: &mut [u8]) -> std::io::Result<()> {
         let data_len = data.len();
         let mut read_offset = 0;
         while read_offset < data_len {
             match self.connection.poll_recv(data) {
                 Poll::Ready(bytes_read) => read_offset += bytes_read?,
-                Poll::Pending => return Err("blocking".into()),
+                Poll::Pending => {
+                    return Err(std::io::Error::new(
+                        ErrorKind::WouldBlock,
+                        "poll_recv returned pending",
+                    ))
+                }
             }
         }
         Ok(())
     }
-
     fn shutdown_send(&mut self) {
         assert!(matches!(
             self.connection.poll_shutdown_send(),
@@ -323,5 +330,27 @@ impl TlsInfo for S2NConnection {
             .handshake_type()
             .unwrap()
             .contains("FULL_HANDSHAKE")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utilities;
+
+    use super::*;
+
+    #[test]
+    fn sanity_check() {
+        test_utilities::sanity_check::<S2NConnection>();
+    }
+
+    #[test]
+    fn all_handshakes() {
+        test_utilities::all_handshakes::<S2NConnection>();
+    }
+
+    #[test]
+    fn transfer() {
+        test_utilities::transfer::<S2NConnection>();
     }
 }

--- a/bindings/rust/standard/bench/src/test_utilities.rs
+++ b/bindings/rust/standard/bench/src/test_utilities.rs
@@ -9,7 +9,7 @@ use std::io::ErrorKind;
 use strum::IntoEnumIterator;
 
 /// Perform a simple server-auth handshake.
-pub fn sanity_check<T>()
+pub fn basic_handshake<T>()
 where
     T: TlsConnection,
     T::Config: TlsBenchConfig,

--- a/bindings/rust/standard/bench/src/test_utilities.rs
+++ b/bindings/rust/standard/bench/src/test_utilities.rs
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::harness::{TlsBenchConfig, TlsInfo};
 use crate::{
+    harness::{TlsBenchConfig, TlsInfo},
     CipherSuite, CryptoConfig, HandshakeType, KXGroup, SigType, TlsConnPair, TlsConnection,
 };
 use std::io::ErrorKind;

--- a/bindings/rust/standard/bench/src/test_utilities.rs
+++ b/bindings/rust/standard/bench/src/test_utilities.rs
@@ -1,0 +1,77 @@
+use crate::harness::{TlsBenchConfig, TlsInfo};
+use crate::{
+    CipherSuite, CryptoConfig, HandshakeType, KXGroup, SigType, TlsConnPair, TlsConnection,
+};
+use std::io::ErrorKind;
+use strum::IntoEnumIterator;
+
+/// Perform a simple server-auth handshake.
+pub fn sanity_check<T>()
+where
+    T: TlsConnection,
+    T::Config: TlsBenchConfig,
+{
+    let crypto_config = CryptoConfig::default();
+    let mut conn_pair =
+        TlsConnPair::<T, T>::new_bench_pair(crypto_config, HandshakeType::ServerAuth).unwrap();
+
+    assert!(!conn_pair.handshake_completed());
+    conn_pair.handshake().unwrap();
+    assert!(conn_pair.handshake_completed());
+
+    conn_pair.round_trip_transfer(&mut [0, 1, 2, 3, 4]).unwrap();
+
+    conn_pair.shutdown().unwrap();
+}
+
+/// Transfer a large amount of application data
+pub fn transfer<T>()
+where
+    T: TlsConnection,
+    T::Config: TlsBenchConfig,
+{
+    // use a large buffer to test across TLS record boundaries
+    let mut buf = [0x56u8; 1000000];
+    for cipher_suite in CipherSuite::iter() {
+        let crypto_config = CryptoConfig::new(cipher_suite, KXGroup::default(), SigType::default());
+        let mut conn_pair =
+            TlsConnPair::<T, T>::new_bench_pair(crypto_config, HandshakeType::default()).unwrap();
+        conn_pair.handshake().unwrap();
+        conn_pair.round_trip_transfer(&mut buf).unwrap();
+        conn_pair.shutdown().unwrap();
+    }
+}
+
+/// Perform all of the different handshake types across a permutation of ciphers,
+/// key exchange groups, and certificate types.
+pub fn all_handshakes<T>()
+where
+    T: TlsConnection + TlsInfo,
+    T::Config: TlsBenchConfig,
+{
+    for handshake_type in HandshakeType::iter() {
+        for cipher_suite in CipherSuite::iter() {
+            for kx_group in KXGroup::iter() {
+                for sig_type in SigType::iter() {
+                    let crypto_config = CryptoConfig::new(cipher_suite, kx_group, sig_type);
+                    let mut conn_pair =
+                        TlsConnPair::<T, T>::new_bench_pair(crypto_config, handshake_type).unwrap();
+
+                    assert!(!conn_pair.handshake_completed());
+                    conn_pair.handshake().unwrap();
+                    assert!(conn_pair.handshake_completed());
+
+                    assert!(conn_pair.negotiated_tls13());
+                    assert_eq!(cipher_suite, conn_pair.get_negotiated_cipher_suite());
+
+                    // read in "application data" handshake messages.
+                    // "NewSessionTicket" in the case of resumption
+                    let err = conn_pair.client_mut().recv(&mut [0]).unwrap_err();
+                    assert_eq!(err.kind(), ErrorKind::WouldBlock);
+
+                    conn_pair.shutdown().unwrap();
+                }
+            }
+        }
+    }
+}

--- a/bindings/rust/standard/bench/src/test_utilities.rs
+++ b/bindings/rust/standard/bench/src/test_utilities.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::harness::{TlsBenchConfig, TlsInfo};
 use crate::{
     CipherSuite, CryptoConfig, HandshakeType, KXGroup, SigType, TlsConnPair, TlsConnection,


### PR DESCRIPTION
### Description of changes: 

- s2n-tls now writes through ViewIO. Previously it just directly captured the Pinned local data buffer pointer. This change is preparing for a future feature to record a "transcript" of the conversation between server and client.
- `send` is now infaillable, and recv returns a `std::io::Error`. This simplifies error handling, because the explicit `std::io::ErrorKind` can be matched on.

This PR also includes some changes to make the unit tests a bit more verbose. I kept running into issues where I'd change a small thing and then _everything_ would fail, but seeing that wasn't useful because I couldn't tell what I actually broke. Did I break application data transfer? session resumption? Who knows 🤷 . Now with the individual unit tests that output of `cargo test` is much more informative.

### Testing:

Existing unit tests should pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
