### PR TITLE
ci: document how to manually run the codebuild jobs

### DIFF
--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -59,5 +59,9 @@ jobs:
             ./codebuild/bin/start_codebuild.sh $source_pr
           else
             echo "$pr_author does not have write permissions."
-            echo "A maintainer will need to manually run start_codebuild.sh."
+            echo "A maintainer will need to manually run the Codebuild jobs."
+            echo ""
+            echo "Review the latest version of the PR to ensure that the code is safe to execute."
+            echo "Note the SHA of the commit that you are reviewing."
+            echo "Run: start_codebuild.sh <sha>"
           fi

--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -62,6 +62,7 @@ jobs:
             echo "A maintainer will need to manually run the Codebuild jobs."
             echo ""
             echo "Review the latest version of the PR to ensure that the code is safe to execute."
-            echo "Note the SHA of the commit that you are reviewing."
-            echo "Run: ./codebuild/bin/start_codebuild.sh <sha>"
+            echo "Note the full SHA of the commit that you are reviewing."
+            echo "Run: ./codebuild/bin/start_codebuild.sh <full sha>"
+            ehco "Warning: use the full SHA, NOT the PR number. The PR could be updated after your review."
           fi

--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -63,5 +63,5 @@ jobs:
             echo ""
             echo "Review the latest version of the PR to ensure that the code is safe to execute."
             echo "Note the SHA of the commit that you are reviewing."
-            echo "Run: start_codebuild.sh <sha>"
+            echo "Run: ./codebuild/bin/start_codebuild.sh <sha>"
           fi


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

Expand on what "manually run start_codebuild.sh" means.

### Testing:
I have tested the process I'm documented manually. I ran:
```
./codebuild/bin/start_codebuild.sh 8b60f4463a1650456da280f6ab88c58bf5d8df69
AddressSanitizer:ae7fb7b0-1006-4a0c-9192-fb9197a2a5d0
S2nIntegrationV2SmallBatch:52de9800-fff4-4296-be08-0ef7786e4f15
Valgrind:6687dab5-d5c9-4087-98aa-8941bc864a2c
s2nFuzzBatch:dec39582-b1ef-43d8-b5a6-b30ad69cbaae
s2nGeneralBatch:3fdf9e70-b21e-4b27-858d-ddbb5421b04e
s2nUnitNix:f4b8f837-0ccd-4d63-9e7a-53fe1a497a8e
Integv2NixBatchBF1FB83F-7tcZOiMDWPH0:f89bfc12-cdda-4703-8932-d86017ed8548
kTLS:075d5c8b-ee43-4a3c-93be-89adb3f75708
All builds successfully started
```
The jobs successfully ran and updated the status of the PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
