### PR TITLE
fix(typo): fix a typo in codebuild.yml

### DIFF
--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -64,5 +64,5 @@ jobs:
             echo "Review the latest version of the PR to ensure that the code is safe to execute."
             echo "Note the full SHA of the commit that you are reviewing."
             echo "Run: ./codebuild/bin/start_codebuild.sh <full sha>"
-            ehco "Warning: use the full SHA, NOT the PR number. The PR could be updated after your review."
+            echo "Warning: use the full SHA, NOT the PR number. The PR could be updated after your review."
           fi


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

We found a typo in `codebuild.yml`:
https://github.com/aws/s2n-tls/blob/4df766442c9e271b2c34c6ffac395e04d74d3246/.github/workflows/codebuild.yml#L67
It should be `echo` but not `ehco`.

### Call-outs:

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
