### PR TITLE
ossl fips 140 3

### DIFF
--- a/codebuild/bin/s2n_fips_openssl.cnf
+++ b/codebuild/bin/s2n_fips_openssl.cnf
@@ -56,10 +56,10 @@ alg_section = algorithm_sect
 
 # List of providers to load
 [provider_sect]
-default = default_sect
+base = base_sect
 fips = fips_sect
 
-[default_sect]
+[base_sect]
 activate = 1
 
 [algorithm_sect]

--- a/crypto/s2n_fips.c
+++ b/crypto/s2n_fips.c
@@ -57,16 +57,6 @@ int s2n_fips_init(void)
 {
     s2n_fips_mode_enabled = s2n_libcrypto_is_fips();
 
-    /* When using Openssl, ONLY 3.0 currently supports FIPS.
-     * openssl-1.0.2-fips is no longer supported.
-     * openssl >= 3.5 will likely have a FIPS 140-3 certificate instead of a
-     * FIPS 140-2 certificate, which will require additional review in order
-     * to properly integrate.
-     */
-#if defined(OPENSSL_FIPS) || S2N_OPENSSL_VERSION_AT_LEAST(3, 5, 0)
-    POSIX_ENSURE(!s2n_fips_mode_enabled, S2N_ERR_FIPS_MODE_UNSUPPORTED);
-#endif
-
     return S2N_SUCCESS;
 }
 

--- a/crypto/s2n_pkey_evp.c
+++ b/crypto/s2n_pkey_evp.c
@@ -85,6 +85,10 @@ static EVP_PKEY_CTX *s2n_evp_pkey_ctx_new(EVP_PKEY *pkey, s2n_hash_algorithm has
 /* Our "digest-and-sign" EVP signing logic is intended to support FIPS 140-3.
  * FIPS 140-3 does not allow signing or verifying externally calculated digests
  * for RSA and ECDSA verify.
+ *
+ * However most FIPS 140-3 implementation raise an indicator and allow
+ * doing so. This implementation does not rely on such indicators.
+ *
  * See https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/Digital-Signatures,
  * and note that "component" tests only exist for ECDSA sign.
  *
@@ -155,9 +159,10 @@ static bool s2n_pkey_evp_digest_and_sign_is_required(s2n_signature_algorithm sig
     return s2n_libcrypto_is_awslc_fips();
 }
 
-/* "digest-then-sign" means that we calculate the digest for a hash state,
- * then sign the digest bytes. That is not allowed by FIPS 140-3, but is allowed
- * in all other cases.
+/* "digest-then-sign" means that we calculate the digest for a hash state, then
+ * sign the digest bytes. That is not allowed by FIPS 140-3 (for specific padding
+ * methods can succeed whilst raising an indicator but dependes on vendor specific
+ * implementation details), but is allowed in all other cases.
  */
 static int s2n_pkey_evp_digest_then_sign(EVP_PKEY_CTX *pctx,
         struct s2n_hash_state *hash_state, struct s2n_blob *signature)

--- a/tls/s2n_cipher_suites.c
+++ b/tls/s2n_cipher_suites.c
@@ -1037,6 +1037,7 @@ int s2n_cipher_suites_init(void)
         /*https://wiki.openssl.org/index.php/Manual:OpenSSL_add_all_algorithms(3)*/
         OpenSSL_add_all_algorithms();
 #else
+        /* Note implicit init may have already happened in s2n_hash_algorithms_init() with OpenSSL with providers */
         OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS | OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS, NULL);
 #endif
     }


### PR DESCRIPTION
- **s2n_fips: lift a heuristic check of libcrypto which doesn't check FIPS provider**
  In OpenSSL providers can be mixed and matched. Meaning whilst one is compiling
  against libcrypto 3.5, the FIPS provider can be 3.0.8, 3.0.9, 3.1.2 or even from
  a non-openssl codebase (symcrypt, wolfcrypt, etc).
  
  Thus this heuristic check of libcrypto is incorrect. For example both
  Ubuntu 22.04 and Amazon Linux 2023 have 3.0 OpenSSL provider with FIPS
  140-3 certification. OpenSSL upstream has 3.1.2 with FIPS 140-3. Etc.
  
  Making this check test the version of the FIPS provider would also be
  incorrect, as there are FIPS providers of 3.0.x versions for both FIPS
  140-2 and FIPS 140-3. Also there are providers based on OpenSSL code
  that do not use OpenSSL upstream versioning scheme (SUSE) or the ones
  not based on OpenSSL code at all (notably symcrypt, wolfcrypt).
  
  Thus simply remove this restriction, and start supporting FIPS 140-3
  certified modules.
  

- **docs: Improve docs and comments**
  Correct statements around FIPS 140-3 which have evolved, based on
  updated IG guidance and security policies of validated FIPS 140-3
  modules for OpenSSL.
  

- **s2n_hash_algorithms_init: auto load default provider**
  Asking users to change global openssl config is cumbersome, and
  instead it is easier to self-load default provider anyway.
  
  Separately, maybe MD5, MD5-SHA1, SHA1, SHA224 support should be
  removed altogether, or only loaded opportunistically, as it is
  unlikely to be used by any default policies anymore. Or is at all
  relevant in OpenSSL FIPS context.
  
  Note that some deployments already default to loading the default
  provider - for example Azure Linux in FIPS. Whilst others choose not
  to - Ubuntu & Chainguard.
  