### PR TITLE
chore(ci): tell crt to not check submodule version

### DIFF
--- a/codebuild/bin/build_aws_crt_cpp.sh
+++ b/codebuild/bin/build_aws_crt_cpp.sh
@@ -41,7 +41,13 @@ git clone --depth 1 --shallow-submodules --recurse-submodules https://github.com
 rm -r aws-crt-cpp/crt/s2n
 mv s2n aws-crt-cpp/crt/
 
-cmake ./aws-crt-cpp -Bbuild -GNinja -DBUILD_DEPS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
+cmake ./aws-crt-cpp \
+    -Bbuild \
+    -GNinja \
+    -DENFORCE_SUBMODULE_VERSIONS=off \
+    -DBUILD_DEPS=ON \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
 ninja -C ./build install
 CTEST_OUTPUT_ON_FAILURE=1 CTEST_PARALLEL_LEVEL=$(nproc) ninja -C ./build test
 


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/5449

### Description of changes: 

Turn off `ENFORCE_SUBMODULE_VERSIONS` for CRT builds so we can test PR changes against the crt build. 

### Call-outs:



### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? local, ci

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
