### PR TITLE
chore(nix): Move nix integ jobs to ec2 fleets

### DIFF
--- a/codebuild/bin/install_s2n_head.sh
+++ b/codebuild/bin/install_s2n_head.sh
@@ -52,6 +52,10 @@ if [[ -f "$s2nc_head" ]]; then
     fi
 fi
 
+# Workaround cases where the CI only featches one branch.
+git fetch
+git switch -c PR
+git switch main
 git clone --branch main --single-branch "$CLONE_SRC" "$BUILD_DIR"
 
 cmake "$BUILD_DIR" -B"$BUILD_DIR"/build "$EXTRA_BUILD_FLAGS" \
@@ -64,4 +68,6 @@ cmake --build "$BUILD_DIR"/build --target s2nd -- -j $(nproc)
 cp -f "$BUILD_DIR"/build/bin/s2nc "$s2nc_head"
 cp -f "$BUILD_DIR"/build/bin/s2nd "$DEST_DIR"/s2nd_head
 
+# Put us back on the PR branch.
+git switch PR
 exit 0

--- a/codebuild/bin/install_s2n_head.sh
+++ b/codebuild/bin/install_s2n_head.sh
@@ -52,9 +52,9 @@ if [[ -f "$s2nc_head" ]]; then
     fi
 fi
 
-# Workaround cases where the CI only featches one branch.
-git fetch
+# Workaround cases where the CI only fetches one branch.
 git switch -c PR
+git fetch origin main
 git switch main
 git clone --branch main --single-branch "$CLONE_SRC" "$BUILD_DIR"
 

--- a/codebuild/bin/setup_ec2.sh
+++ b/codebuild/bin/setup_ec2.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Is $HOME set? Is $USER set?"
+echo "=== Setting up sudo for the nix user ==="
+sudo bash -c "echo 'nix ALL=NOPASSWD: ALL' > /etc/sudoers.d/nix"
+sudo groupadd nixbld
+sudo useradd -m -g nixbld -G nixbld nix
+sudo chmod 755 /home/nix
+
+echo "=== Installing Nix ==="
+sudo -u nix bash -c "sh <(curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install) --no-daemon"
+echo "=== Enabling Nix flakes ==="
+sudo -u nix bash -c 'mkdir -p ~/.config/nix; echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf'
+# This sidesteps the need to update PATH
+sudo ln -s /home/nix/.nix-profile/bin/nix /usr/local/bin
+
+echo "=== Setting up Nix for root ==="
+sudo -u root bash -c "ln -s /home/nix/.nix-profile ~/"
+sudo -u root bash -c "ln -s /home/nix/.config ~/"
+
+sudo apt update
+sudo apt upgrade -y

--- a/codebuild/spec/buildspec_integv2_nix.yml
+++ b/codebuild/spec/buildspec_integv2_nix.yml
@@ -48,14 +48,14 @@ batch:
           NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
     # AWSLC-FIPS-2022
-    - identifier: Integ_awslcfips2022_aarch64_0
+    - identifier: Integ_awslcfips2022_x86_64_0
       depend-on:
         - nixCache_aarch64
       env:
-        fleet: ubuntu24_aarch64_nix
+        fleet: ubuntu24_x86_64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#awslcfips2022
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
 
     # AWSLC-FIPS-2024
     - identifier: Integ_awslcfips2024_aarch64_0

--- a/codebuild/spec/buildspec_integv2_nix.yml
+++ b/codebuild/spec/buildspec_integv2_nix.yml
@@ -10,10 +10,7 @@ batch:
     # Cache job for x86
     - identifier: nixCache_x86_64
       env:
-        compute-type: BUILD_GENERAL1_XLARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
-        privileged-mode: false
-        type: LINUX_CONTAINER
+        fleet: ubuntu24_x86_64_nix
         variables:
           # max-jobs tell nix to use all available cores for building derivations.
           NIXDEV_ARGS: --max-jobs auto
@@ -23,10 +20,7 @@ batch:
     # Cache Job for aarch64
     - identifier: nixCache_aarch64
       env:
-        compute-type: BUILD_GENERAL1_XLARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
-        privileged-mode: false
-        type: ARM_CONTAINER
+        fleet: ubuntu24_aarch64_nix
         variables:
           # max-jobs tell nix to use all available cores for building derivations.
           NIXDEV_ARGS: --max-jobs auto
@@ -38,10 +32,7 @@ batch:
       depend-on:
         - nixCache_x86_64
       env:
-        compute-type: BUILD_GENERAL1_XLARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
-        privileged-mode: true
-        type: LINUX_CONTAINER
+        fleet: ubuntu24_x86_64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#awslc
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
@@ -51,10 +42,7 @@ batch:
       depend-on:
         - nixCache_aarch64
       env:
-        compute-type: BUILD_GENERAL1_XLARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
-        privileged-mode: true
-        type: ARM_CONTAINER
+        fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#awslc
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
@@ -64,10 +52,7 @@ batch:
       depend-on:
         - nixCache_aarch64
       env:
-        compute-type: BUILD_GENERAL1_XLARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
-        privileged-mode: true
-        type: ARM_CONTAINER
+        fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#awslcfips2022
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
@@ -77,10 +62,7 @@ batch:
       depend-on:
         - nixCache_aarch64
       env:
-        compute-type: BUILD_GENERAL1_XLARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
-        privileged-mode: true
-        type: ARM_CONTAINER
+        fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#awslcfips2024
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
@@ -90,10 +72,7 @@ batch:
       depend-on:
         - nixCache_x86_64
       env:
-        compute-type: BUILD_GENERAL1_XLARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
-        privileged-mode: true
-        type: LINUX_CONTAINER
+        fleet: ubuntu24_x86_64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#default
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
@@ -103,10 +82,7 @@ batch:
       depend-on:
         - nixCache_aarch64
       env:
-        compute-type: BUILD_GENERAL1_XLARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
-        privileged-mode: true
-        type: ARM_CONTAINER
+        fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#default
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
@@ -116,10 +92,7 @@ batch:
       depend-on:
         - nixCache_aarch64
       env:
-        compute-type: BUILD_GENERAL1_XLARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
-        privileged-mode: true
-        type: ARM_CONTAINER
+        fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#openssl111
           NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2

--- a/codebuild/spec/buildspec_integv2_nix.yml
+++ b/codebuild/spec/buildspec_integv2_nix.yml
@@ -15,7 +15,7 @@ batch:
           # max-jobs tell nix to use all available cores for building derivations.
           NIXDEV_ARGS: --max-jobs auto
           NIXDEV_LIBCRYPTO: .#default
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
 
     # Cache Job for aarch64
     - identifier: nixCache_aarch64
@@ -25,7 +25,7 @@ batch:
           # max-jobs tell nix to use all available cores for building derivations.
           NIXDEV_ARGS: --max-jobs auto
           NIXDEV_LIBCRYPTO: .#default
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
     # AWSLC  x86
     - identifier: Integ_awslc_x86_0
@@ -35,7 +35,7 @@ batch:
         fleet: ubuntu24_x86_64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#awslc
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
 
     # AWSLC aarch64
     - identifier: Integ_awslc_aarch64_0
@@ -45,7 +45,7 @@ batch:
         fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#awslc
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
     # AWSLC-FIPS-2022
     - identifier: Integ_awslcfips2022_aarch64_0
@@ -55,7 +55,7 @@ batch:
         fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#awslcfips2022
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
     # AWSLC-FIPS-2024
     - identifier: Integ_awslcfips2024_aarch64_0
@@ -65,7 +65,7 @@ batch:
         fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#awslcfips2024
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
     # Openssl30 x86
     - identifier: Integ_openssl30_x86_0
@@ -75,7 +75,7 @@ batch:
         fleet: ubuntu24_x86_64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#default
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
 
     # Openssl30 aarch64
     - identifier: Integ_openssl30_aarch64_0
@@ -85,7 +85,7 @@ batch:
         fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#default
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
     # Openssl111 aarch64 only
     - identifier: Integ_openssl111_aarch64_0
@@ -95,7 +95,7 @@ batch:
         fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#openssl111
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
 phases:
   install:


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

n/a

### Description of changes: 

Move the Nix Integration CodeBuild jobs to Ec2 fleets.

### Call-outs:

none

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? CI, adhoc jobs


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
