### PR TITLE
refactor(stuffer): Rename s2n_stuffer_has_pem_encapsulated_block

### DIFF
--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -47,7 +47,7 @@ int s2n_create_cert_chain_from_stuffer(struct s2n_cert_chain *cert_chain_out, st
 
     struct s2n_cert **insert = &cert_chain_out->head;
     uint32_t chain_size = 0;
-    while (s2n_stuffer_pem_has_certificate(chain_in_stuffer)) {
+    while (s2n_stuffer_has_pem_encapsulated_block(chain_in_stuffer)) {
         int result = s2n_stuffer_certificate_from_pem(chain_in_stuffer, &cert_out_stuffer);
         POSIX_ENSURE(result == S2N_SUCCESS, S2N_ERR_INVALID_PEM);
 

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -221,7 +221,7 @@ int S2N_RESULT_MUST_USE s2n_stuffer_private_key_from_pem(struct s2n_stuffer *pem
 
 /* Read a certificate from a PEM encoded stuffer to an ASN1/DER encoded one */
 int S2N_RESULT_MUST_USE s2n_stuffer_certificate_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer *asn1);
-bool s2n_stuffer_pem_has_certificate(struct s2n_stuffer *pem);
+bool s2n_stuffer_has_pem_encapsulated_block(struct s2n_stuffer *pem);
 
 /* Read a CRL from a PEM encoded stuffer to an ASN1/DER encoded one */
 int S2N_RESULT_MUST_USE s2n_stuffer_crl_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer *asn1);

--- a/stuffer/s2n_stuffer_pem.c
+++ b/stuffer/s2n_stuffer_pem.c
@@ -187,13 +187,16 @@ int s2n_stuffer_private_key_from_pem(struct s2n_stuffer *pem, struct s2n_stuffer
     POSIX_BAIL(S2N_ERR_INVALID_PEM);
 }
 
-/* We define a pem containing a certificate as a pem containing the delimiter chars.
- * If the delimiter chars exist but the certificate keyword doesn't, that is a parsing error.
- * That ensures that we don't ignore unexpected keywords like "END CERTIFICATE"
- * instead of "BEGIN CERTIFICATE" or malformed keywords like "BEGAN CERTIFICATE"
- * instead of "BEGIN CERTIFICATE".
+/*
+ * We identify strings containing a PEM-encapsulated block by searching for the
+ * PEM delimiter chars.
+ *
+ * Although it isn't checked here, the delimiter should also imply the existence
+ * of the BEGIN keyword. This ensures that we don't ignore unexpected keywords
+ * like "END CERTIFICATE" instead of "BEGIN CERTIFICATE" or malformed keywords
+ * like "BEGAN CERTIFICATE" instead of "BEGIN CERTIFICATE".
  */
-bool s2n_stuffer_pem_has_certificate(struct s2n_stuffer *pem)
+bool s2n_stuffer_has_pem_encapsulated_block(struct s2n_stuffer *pem)
 {
     /* Operate on a copy of pem to avoid modifying pem */
     struct s2n_stuffer pem_copy = *pem;


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

N/A

### Description of changes: 

This commit is extracted from a forthcoming PR.

Right now, the `s2n_stuffer_pem_has_certificate` function just checks for the PEM-encapsulation delimiter. This name's slightly misleading, as the validation it performs has nothing to do with certificates.

### Call-outs:

It would be nice to make the function stricter by adding an additional check for a `BEGIN` token. This adds an extra stuffer read in some cases.

### Testing:

> How is this change tested (unit tests, fuzz tests, etc.)? What manual testing was performed? Are there any testing steps to be verified by the reviewer?
> How can you convince your reviewers that this PR is safe and effective?
> Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?

Unit tests still pass locally.

Remember:
* Any change to the library source code should at least include unit tests.
* Any change to the core stuffer or blob methods should include [CBMC proofs](https://github.com/aws/s2n-tls/tree/main/tests/cbmc).
* Any change to the CI or tests should:
   1. prove that the test succeeds for good input
   2. prove that the test fails for bad input (eg, a test for memory leaks fails when a memory leak is committed)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
