### PR TITLE
ci: don't include tls/extensions in SAW build

### DIFF
--- a/tls/extensions/Makefile
+++ b/tls/extensions/Makefile
@@ -16,8 +16,9 @@
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)
 
-BCS_1=$(SRCS:.c=.bc)
-BCS=$(addprefix $(BITCODE_DIR), $(BCS_1))
+# We currently don't need any of these files
+# Update this list as necessary. See tls/Makefile.
+BCS=
 
 .PHONY : all
 all: $(OBJS)


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

I noticed while debugging my SAW issues with https://github.com/aws/s2n-tls/pull/5464 that we only build the small subset of files in the "tls" folder that SAW actually needs:
https://github.com/aws/s2n-tls/blob/6dcbffedad0d7dfa3edd50bc21ecf11749e1dba6/tls/Makefile#L22-L23
But we automatically build all the files in "tls/extensions". This is unnecessary-- the SAW proofs don't need any of the extensions code. It just potentially complicates the build and makes the build take longer. Every file we add to the SAW build increases the potential for strange, development-blocking errors.

### Testing:

CI still passes, including the SAW build in s2nGeneralBatch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
