### PR TITLE
ci: fix wikipedia network test + better error message

### DIFF
--- a/bindings/rust/standard/integration/src/network/https_client.rs
+++ b/bindings/rust/standard/integration/src/network/https_client.rs
@@ -53,7 +53,7 @@ const TEST_CASES: &[TestCase] = &[
     TestCase::new("https://www.openssl.org", &[200]),
     TestCase::new("https://www.t-mobile.com", &[200]),
     TestCase::new("https://www.verizon.com", &[200]),
-    TestCase::new("https://www.wikipedia.org", &[200]),
+    TestCase::new("https://www.wikipedia.org", &[200, 403]),
     TestCase::new("https://www.yahoo.com", &[200, 429]),
     TestCase::new("https://www.youtube.com", &[200]),
     TestCase::new("https://www.github.com", &[301]),
@@ -100,7 +100,11 @@ async fn http_get_test() -> Result<(), Box<dyn std::error::Error>> {
             if !status_was_expected {
                 tracing::error!("unexpected status code: {status_code}");
             }
-            assert!(status_was_expected);
+            assert!(
+                status_was_expected,
+                "Unexpected status code \"{status_code}\" for test case {:#?}",
+                test_case
+            );
 
             if status_code == StatusCode::OK.as_u16() {
                 let body = response.into_body().collect().await?.to_bytes();


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

The network tests started failing with a 403 for wikipedia: https://github.com/aws/s2n-tls/actions/runs/17061315544/job/48368580444?pr=5464 This PR adds 403 to the allowed statuses for wikipedia.

I also added a better assertion error. Right now you have to scroll way up to the previous "info" log line that records the test case in order to figure out which test case failed. The error should just state the failing case.

### Testing:
The test is now passing.

With the new message, the old error looks like:
```
thread 'network::https_client::http_get_test' panicked at integration/src/network/https_client.rs:103:13:
Unexpected status code "403" for test case TestCase {
    query_target: "https://www.wikipedia.org",
    expected_status_codes: [
        200,
    ],
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
