### PR TITLE
feat: add method to get signature scheme name

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2716,15 +2716,33 @@ S2N_API extern int s2n_connection_get_selected_client_cert_digest_algorithm(stru
 /**
  * Get the human readable signature scheme for the connection.
  *
- * This method will return the IANA "description" for the negotiated signature scheme.
- * See: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-signaturescheme
+ * This method will return:
+ * 1. The IANA "description" for the negotiated signature scheme.
+ *    For example, rsa_pss_rsae_sha384 or ecdsa_secp256r1_sha256.
+ * 2. An unofficial description, if the server signature did not use an official
+ *    IANA signature scheme. This description will take the form
+ *    "legacy_<signature_algorithm>_<hash_algorithm>".
+ *    For example, legacy_rsa_sha224 or legacy_ecdsa_sha256.
+ * 3. "none", if the handshake did not include a server signature.
+ *    This may happen if session resumption or RSA key exchange are used.
  *
- * If TLS1.2 or earlier is negotiated, an official signature scheme may not be chosen.
- * Before TLS1.3, a combination of "signature algorithm" and "hash algorithm" were
- * used instead of signature schemes. Not all combinations were assigned to official
- * signature schemes. If no signature scheme exists for the combination negotiated,
- * this method will instead return "legacy_<signature algorithm>_<hash_algorithm>". See:
+ * If the connection has not yet performed a handshake, this method will error.
+ *
+ * A note on unofficial descriptions: If TLS1.2 or earlier is negotiated,
+ * an official IANA signature scheme may not be chosen. Before TLS1.3, a combination
+ * of "signature algorithm" and "hash algorithm" were used instead of signature schemes.
+ * Not all combinations were later assigned to official signature schemes.
+ *
+ * A note on ECDSA signature schemes: TLS1.3 and TLS1.2 ECDSA "signature schemes"
+ * share the same IANA value. However, this method assigns them different descriptions
+ * because the TLS1.3 versions (like ecdsa_secp256r1_sha256) imply specific curves,
+ * while the TLS1.2 versions (like legacy_ecdsa_sha256) do not.
+ *
+ * IANA signature schemes:
+ * https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-signaturescheme
+ * IANA signature algorithms:
  * https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-16
+ * IANA hash algorithms:
  * https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-18
  *
  * @param conn A pointer to the s2n connection

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2714,6 +2714,26 @@ S2N_API extern int s2n_connection_get_selected_client_cert_signature_algorithm(s
 S2N_API extern int s2n_connection_get_selected_client_cert_digest_algorithm(struct s2n_connection *conn, s2n_tls_hash_algorithm *chosen_alg);
 
 /**
+ * Get the human readable signature scheme for the connection.
+ *
+ * This method will return the IANA "description" for the negotiated signature scheme.
+ * See: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-signaturescheme
+ *
+ * If TLS1.2 or earlier is negotiated, an official signature scheme may not be chosen.
+ * Before TLS1.3, a combination of "signature algorithm" and "hash algorithm" were
+ * used instead of signature schemes. Not all combinations were assigned to official
+ * signature schemes. If no signature scheme exists for the combination negotiated,
+ * this method will instead return "legacy_<signature algorithm>_<hash_algorithm>". See:
+ * https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-16
+ * https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-18
+ *
+ * @param conn A pointer to the s2n connection
+ * @param group_name A pointer that will be set to the signature scheme name.
+ * @returns S2N_SUCCESS on success, S2N_FAILURE otherwise.
+ */
+S2N_API extern int s2n_connection_get_signature_scheme(struct s2n_connection *conn, const char **scheme_name);
+
+/**
  * Get the certificate used during the TLS handshake
  *
  * - If `conn` is a server connection, the certificate selected will depend on the

--- a/bin/policy.c
+++ b/bin/policy.c
@@ -74,7 +74,7 @@ int main(int argc, char *const *argv)
 
     printf("signature schemes:\n");
     for (size_t i = 0; i < policy->signature_preferences->count; i++) {
-        printf("- %s\n", policy->signature_preferences->signature_schemes[i]->iana_name);
+        printf("- %s\n", policy->signature_preferences->signature_schemes[i]->name);
     }
 
     printf("curves:\n");
@@ -88,7 +88,7 @@ int main(int argc, char *const *argv)
         }
         printf("certificate signature schemes:\n");
         for (size_t i = 0; i < policy->certificate_signature_preferences->count; i++) {
-            printf("- %s\n", policy->certificate_signature_preferences->signature_schemes[i]->iana_name);
+            printf("- %s\n", policy->certificate_signature_preferences->signature_schemes[i]->name);
         }
     }
 

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -1017,9 +1017,9 @@ int main(int argc, char **argv)
             struct s2n_connection conn = { 0 };
             const char *name = NULL;
             EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_signature_scheme(&conn, NULL),
-                S2N_ERR_NULL);
+                    S2N_ERR_NULL);
             EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_signature_scheme(NULL, &name),
-                S2N_ERR_NULL);
+                    S2N_ERR_NULL);
         };
 
         /* Test: connection without a chosen signature scheme fails */
@@ -1028,7 +1028,7 @@ int main(int argc, char **argv)
                     s2n_connection_ptr_free);
             const char *name = NULL;
             EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_signature_scheme(conn, &name),
-                S2N_ERR_INVALID_STATE);
+                    S2N_ERR_INVALID_STATE);
         };
 
         /* Test: all valid signature schemes succeed */

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -1010,6 +1010,90 @@ int main(int argc, char **argv)
         };
     };
 
+    /* Test s2n_connection_get_signature_scheme */
+    {
+        /* Safety */
+        {
+            struct s2n_connection conn = { 0 };
+            const char *name = NULL;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_signature_scheme(&conn, NULL),
+                S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_signature_scheme(NULL, &name),
+                S2N_ERR_NULL);
+        };
+
+        /* Test: connection without a chosen signature scheme fails */
+        {
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            const char *name = NULL;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_signature_scheme(conn, &name),
+                S2N_ERR_INVALID_STATE);
+        };
+
+        /* Test: all valid signature schemes succeed */
+        {
+            const struct s2n_signature_preferences *all_prefs = &s2n_signature_preferences_all;
+            for (size_t i = 0; i < all_prefs->count; i++) {
+                for (size_t version = 0; version <= S2N_TLS13; version++) {
+                    DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                            s2n_connection_ptr_free);
+                    conn->handshake_params.server_cert_sig_scheme = all_prefs->signature_schemes[i];
+                    conn->actual_protocol_version = version;
+
+                    const char *name = NULL;
+                    EXPECT_SUCCESS(s2n_connection_get_signature_scheme(conn, &name));
+                    EXPECT_NOT_NULL(name);
+                }
+            }
+        };
+
+        /* Test: simple known values */
+        {
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+
+            conn->handshake_params.server_cert_sig_scheme = &s2n_rsa_pss_rsae_sha256;
+            const char *rsa_name = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_signature_scheme(conn, &rsa_name));
+            EXPECT_STRING_EQUAL(rsa_name, "rsa_pss_rsae_sha256");
+
+            conn->handshake_params.server_cert_sig_scheme = &s2n_mldsa65;
+            const char *mldsa_name = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_signature_scheme(conn, &mldsa_name));
+            EXPECT_STRING_EQUAL(mldsa_name, "mldsa65");
+
+            conn->handshake_params.server_cert_sig_scheme = &s2n_ecdsa_sha224;
+            const char *legacy_ecdsa = NULL;
+            EXPECT_SUCCESS(s2n_connection_get_signature_scheme(conn, &legacy_ecdsa));
+            EXPECT_STRING_EQUAL(legacy_ecdsa, "legacy_ecdsa_sha224");
+        };
+
+        /* Test: chooses ECDSA name based on version */
+        {
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                    s2n_connection_ptr_free);
+            conn->handshake_params.server_cert_sig_scheme = &s2n_ecdsa_sha256;
+
+            const char *tls13_name = NULL;
+            conn->actual_protocol_version = S2N_TLS13;
+            EXPECT_SUCCESS(s2n_connection_get_signature_scheme(conn, &tls13_name));
+            EXPECT_STRING_EQUAL(tls13_name, s2n_ecdsa_sha256.tls13_name);
+            EXPECT_STRING_EQUAL(tls13_name, "ecdsa_secp256r1_sha256");
+
+            const char *tls12_name = NULL;
+            conn->actual_protocol_version = S2N_TLS12;
+            EXPECT_SUCCESS(s2n_connection_get_signature_scheme(conn, &tls12_name));
+            EXPECT_STRING_EQUAL(tls12_name, s2n_ecdsa_sha256.legacy_name);
+            EXPECT_STRING_EQUAL(tls12_name, "legacy_ecdsa_sha256");
+
+            const char *tls10_name = NULL;
+            conn->actual_protocol_version = S2N_TLS10;
+            EXPECT_SUCCESS(s2n_connection_get_signature_scheme(conn, &tls10_name));
+            EXPECT_STRING_EQUAL(tls10_name, s2n_ecdsa_sha256.legacy_name);
+        };
+    };
+
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(ecdsa_chain_and_key));
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(rsa_chain_and_key));
     END_TEST();

--- a/tests/unit/s2n_signature_scheme_test.c
+++ b/tests/unit/s2n_signature_scheme_test.c
@@ -49,6 +49,9 @@ int main(int argc, char **argv)
             if (sig_scheme->sig_alg == S2N_SIGNATURE_ECDSA
                     && sig_scheme->maximum_protocol_version != S2N_TLS12) {
                 EXPECT_NOT_NULL(sig_scheme->signature_curve);
+                /* These schemes also require additional naming information */
+                EXPECT_NOT_NULL(sig_scheme->legacy_name);
+                EXPECT_NOT_NULL(sig_scheme->tls13_name);
             } else {
                 EXPECT_NULL(sig_scheme->signature_curve);
             }

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1715,14 +1715,15 @@ int s2n_connection_get_signature_scheme(struct s2n_connection *conn, const char 
 {
     POSIX_ENSURE_REF(conn);
     POSIX_ENSURE_REF(scheme_name);
+    POSIX_ENSURE(IS_NEGOTIATED(conn), S2N_ERR_INVALID_STATE);
 
     const struct s2n_signature_scheme *scheme = conn->handshake_params.server_cert_sig_scheme;
-    POSIX_ENSURE(scheme, S2N_ERR_INVALID_STATE);
-    /* We use a placeholder to represent a missing signature scheme */
-    POSIX_ENSURE(scheme->iana_value, S2N_ERR_INVALID_STATE);
+    /* The scheme should never be NULL. A "none" placeholder is used if no
+     * scheme has been negotiated.
+     */
+    POSIX_ENSURE_REF(scheme);
 
     *scheme_name = scheme->name;
-
     if (scheme->signature_curve) {
         /* Some TLS1.2 and TLS1.3 signature schemes share an IANA value,
          * but are NOT the same. The TLS1.3 version implies a specific curve.

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1711,6 +1711,33 @@ int s2n_connection_get_selected_client_cert_signature_algorithm(struct s2n_conne
     return S2N_SUCCESS;
 }
 
+int s2n_connection_get_signature_scheme(struct s2n_connection *conn, const char **scheme_name)
+{
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(scheme_name);
+
+    const struct s2n_signature_scheme *scheme = conn->handshake_params.server_cert_sig_scheme;
+    POSIX_ENSURE(scheme, S2N_ERR_INVALID_STATE);
+    /* We use a placeholder to represent a missing signature scheme */
+    POSIX_ENSURE(scheme->iana_value, S2N_ERR_INVALID_STATE);
+
+    *scheme_name = scheme->name;
+
+    if (scheme->signature_curve) {
+        /* Some TLS1.2 and TLS1.3 signature schemes share an IANA value,
+         * but are NOT the same. The TLS1.3 version implies a specific curve.
+         */
+        if (conn->actual_protocol_version >= S2N_TLS13) {
+            *scheme_name = scheme->tls13_name;
+        } else {
+            *scheme_name = scheme->legacy_name;
+        }
+    }
+
+    POSIX_ENSURE_REF(*scheme_name);
+    return S2N_SUCCESS;
+}
+
 /*
  * Gets the config set on the connection.
  */

--- a/tls/s2n_security_rules.c
+++ b/tls/s2n_security_rules.c
@@ -145,7 +145,7 @@ S2N_RESULT s2n_security_rule_validate_policy(const struct s2n_security_rule *rul
         RESULT_GUARD(rule->validate_sig_scheme(sig_scheme, &is_valid));
         RESULT_GUARD(s2n_security_rule_result_process(result, is_valid,
                 error_msg_format_name, rule->name, policy_name,
-                "signature scheme", sig_scheme->iana_name));
+                "signature scheme", sig_scheme->name));
     }
 
     const struct s2n_signature_preferences *cert_sig_prefs = policy->certificate_signature_preferences;
@@ -158,7 +158,7 @@ S2N_RESULT s2n_security_rule_validate_policy(const struct s2n_security_rule *rul
             RESULT_GUARD(rule->validate_cert_sig_scheme(sig_scheme, &is_valid));
             RESULT_GUARD(s2n_security_rule_result_process(result, is_valid,
                     error_msg_format_name, rule->name, policy_name,
-                    "certificate signature scheme", sig_scheme->iana_name));
+                    "certificate signature scheme", sig_scheme->name));
         }
     }
 

--- a/tls/s2n_signature_scheme.c
+++ b/tls/s2n_signature_scheme.c
@@ -25,7 +25,7 @@
 
 const struct s2n_signature_scheme s2n_null_sig_scheme = {
     .iana_value = 0,
-    .name = "null",
+    .name = "none",
     .hash_alg = S2N_HASH_NONE,
     .sig_alg = S2N_SIGNATURE_ANONYMOUS,
     .libcrypto_nid = 0,

--- a/tls/s2n_signature_scheme.c
+++ b/tls/s2n_signature_scheme.c
@@ -25,7 +25,7 @@
 
 const struct s2n_signature_scheme s2n_null_sig_scheme = {
     .iana_value = 0,
-    .iana_name = "null",
+    .name = "null",
     .hash_alg = S2N_HASH_NONE,
     .sig_alg = S2N_SIGNATURE_ANONYMOUS,
     .libcrypto_nid = 0,
@@ -36,7 +36,7 @@ const struct s2n_signature_scheme s2n_null_sig_scheme = {
 /* RSA PKCS1 */
 const struct s2n_signature_scheme s2n_rsa_pkcs1_md5_sha1 = {
     .iana_value = TLS_SIGNATURE_SCHEME_PRIVATE_INTERNAL_RSA_PKCS1_MD5_SHA1,
-    .iana_name = "legacy_rsa_md5_sha1",
+    .name = "legacy_rsa_md5_sha1",
     .hash_alg = S2N_HASH_MD5_SHA1,
     .sig_alg = S2N_SIGNATURE_RSA,
     .libcrypto_nid = NID_md5_sha1,
@@ -46,7 +46,7 @@ const struct s2n_signature_scheme s2n_rsa_pkcs1_md5_sha1 = {
 
 const struct s2n_signature_scheme s2n_rsa_pkcs1_sha1 = {
     .iana_value = TLS_SIGNATURE_SCHEME_RSA_PKCS1_SHA1,
-    .iana_name = "rsa_pkcs1_sha1",
+    .name = "rsa_pkcs1_sha1",
     .hash_alg = S2N_HASH_SHA1,
     .sig_alg = S2N_SIGNATURE_RSA,
     .libcrypto_nid = NID_sha1WithRSAEncryption,
@@ -56,7 +56,7 @@ const struct s2n_signature_scheme s2n_rsa_pkcs1_sha1 = {
 
 const struct s2n_signature_scheme s2n_rsa_pkcs1_sha224 = {
     .iana_value = TLS_SIGNATURE_SCHEME_RSA_PKCS1_SHA224,
-    .iana_name = "legacy_rsa_sha224",
+    .name = "legacy_rsa_sha224",
     .hash_alg = S2N_HASH_SHA224,
     .sig_alg = S2N_SIGNATURE_RSA,
     .libcrypto_nid = NID_sha224WithRSAEncryption,
@@ -66,7 +66,7 @@ const struct s2n_signature_scheme s2n_rsa_pkcs1_sha224 = {
 
 const struct s2n_signature_scheme s2n_rsa_pkcs1_sha256 = {
     .iana_value = TLS_SIGNATURE_SCHEME_RSA_PKCS1_SHA256,
-    .iana_name = "rsa_pkcs1_sha256",
+    .name = "rsa_pkcs1_sha256",
     .hash_alg = S2N_HASH_SHA256,
     .sig_alg = S2N_SIGNATURE_RSA,
     .libcrypto_nid = NID_sha256WithRSAEncryption,
@@ -76,7 +76,7 @@ const struct s2n_signature_scheme s2n_rsa_pkcs1_sha256 = {
 
 const struct s2n_signature_scheme s2n_rsa_pkcs1_sha384 = {
     .iana_value = TLS_SIGNATURE_SCHEME_RSA_PKCS1_SHA384,
-    .iana_name = "rsa_pkcs1_sha384",
+    .name = "rsa_pkcs1_sha384",
     .hash_alg = S2N_HASH_SHA384,
     .sig_alg = S2N_SIGNATURE_RSA,
     .libcrypto_nid = NID_sha384WithRSAEncryption,
@@ -86,7 +86,7 @@ const struct s2n_signature_scheme s2n_rsa_pkcs1_sha384 = {
 
 const struct s2n_signature_scheme s2n_rsa_pkcs1_sha512 = {
     .iana_value = TLS_SIGNATURE_SCHEME_RSA_PKCS1_SHA512,
-    .iana_name = "rsa_pkcs1_sha512",
+    .name = "rsa_pkcs1_sha512",
     .hash_alg = S2N_HASH_SHA512,
     .sig_alg = S2N_SIGNATURE_RSA,
     .libcrypto_nid = NID_sha512WithRSAEncryption,
@@ -97,7 +97,7 @@ const struct s2n_signature_scheme s2n_rsa_pkcs1_sha512 = {
 /* TLS 1.2 Compatible ECDSA Signature Schemes */
 const struct s2n_signature_scheme s2n_ecdsa_sha1 = {
     .iana_value = TLS_SIGNATURE_SCHEME_ECDSA_SHA1,
-    .iana_name = "ecdsa_sha1",
+    .name = "ecdsa_sha1",
     .hash_alg = S2N_HASH_SHA1,
     .sig_alg = S2N_SIGNATURE_ECDSA,
     .libcrypto_nid = NID_ecdsa_with_SHA1,
@@ -107,7 +107,7 @@ const struct s2n_signature_scheme s2n_ecdsa_sha1 = {
 
 const struct s2n_signature_scheme s2n_ecdsa_sha224 = {
     .iana_value = TLS_SIGNATURE_SCHEME_ECDSA_SHA224,
-    .iana_name = "legacy_ecdsa_sha224",
+    .name = "legacy_ecdsa_sha224",
     .hash_alg = S2N_HASH_SHA224,
     .sig_alg = S2N_SIGNATURE_ECDSA,
     .libcrypto_nid = NID_ecdsa_with_SHA224,
@@ -117,29 +117,38 @@ const struct s2n_signature_scheme s2n_ecdsa_sha224 = {
 
 const struct s2n_signature_scheme s2n_ecdsa_sha256 = {
     .iana_value = TLS_SIGNATURE_SCHEME_ECDSA_SHA256,
-    .iana_name = "ecdsa_sha256",
+    .name = "ecdsa_sha256",
     .hash_alg = S2N_HASH_SHA256,
     .sig_alg = S2N_SIGNATURE_ECDSA,
     .libcrypto_nid = NID_ecdsa_with_SHA256,
-    .signature_curve = &s2n_ecc_curve_secp256r1, /* Hardcoded for TLS 1.3 */
+    /* Curve is hardcoded for TLS 1.3 */
+    .signature_curve = &s2n_ecc_curve_secp256r1,
+    .legacy_name = "legacy_ecdsa_sha256",
+    .tls13_name = "ecdsa_secp256r1_sha256",
 };
 
 const struct s2n_signature_scheme s2n_ecdsa_sha384 = {
     .iana_value = TLS_SIGNATURE_SCHEME_ECDSA_SHA384,
-    .iana_name = "ecdsa_sha384",
+    .name = "ecdsa_sha384",
     .hash_alg = S2N_HASH_SHA384,
     .sig_alg = S2N_SIGNATURE_ECDSA,
     .libcrypto_nid = NID_ecdsa_with_SHA384,
-    .signature_curve = &s2n_ecc_curve_secp384r1, /* Hardcoded for TLS 1.3 */
+    /* Curve is hardcoded for TLS 1.3 */
+    .signature_curve = &s2n_ecc_curve_secp384r1,
+    .legacy_name = "legacy_ecdsa_sha384",
+    .tls13_name = "ecdsa_secp384r1_sha384",
 };
 
 const struct s2n_signature_scheme s2n_ecdsa_sha512 = {
     .iana_value = TLS_SIGNATURE_SCHEME_ECDSA_SHA512,
-    .iana_name = "ecdsa_sha512",
+    .name = "ecdsa_sha512",
     .hash_alg = S2N_HASH_SHA512,
     .sig_alg = S2N_SIGNATURE_ECDSA,
     .libcrypto_nid = NID_ecdsa_with_SHA512,
-    .signature_curve = &s2n_ecc_curve_secp521r1, /* Hardcoded for TLS 1.3 */
+    /* Curve is hardcoded for TLS 1.3 */
+    .signature_curve = &s2n_ecc_curve_secp521r1,
+    .legacy_name = "legacy_ecdsa_sha512",
+    .tls13_name = "ecdsa_secp521r1_sha512",
 };
 
 /**
@@ -147,7 +156,7 @@ const struct s2n_signature_scheme s2n_ecdsa_sha512 = {
  */
 const struct s2n_signature_scheme s2n_rsa_pss_rsae_sha256 = {
     .iana_value = TLS_SIGNATURE_SCHEME_RSA_PSS_RSAE_SHA256,
-    .iana_name = "rsa_pss_rsae_sha256",
+    .name = "rsa_pss_rsae_sha256",
     .hash_alg = S2N_HASH_SHA256,
     .sig_alg = S2N_SIGNATURE_RSA_PSS_RSAE,
     .libcrypto_nid = NID_rsassaPss,
@@ -156,7 +165,7 @@ const struct s2n_signature_scheme s2n_rsa_pss_rsae_sha256 = {
 
 const struct s2n_signature_scheme s2n_rsa_pss_rsae_sha384 = {
     .iana_value = TLS_SIGNATURE_SCHEME_RSA_PSS_RSAE_SHA384,
-    .iana_name = "rsa_pss_rsae_sha384",
+    .name = "rsa_pss_rsae_sha384",
     .hash_alg = S2N_HASH_SHA384,
     .sig_alg = S2N_SIGNATURE_RSA_PSS_RSAE,
     .libcrypto_nid = NID_rsassaPss,
@@ -165,7 +174,7 @@ const struct s2n_signature_scheme s2n_rsa_pss_rsae_sha384 = {
 
 const struct s2n_signature_scheme s2n_rsa_pss_rsae_sha512 = {
     .iana_value = TLS_SIGNATURE_SCHEME_RSA_PSS_RSAE_SHA512,
-    .iana_name = "rsa_pss_rsae_sha512",
+    .name = "rsa_pss_rsae_sha512",
     .hash_alg = S2N_HASH_SHA512,
     .sig_alg = S2N_SIGNATURE_RSA_PSS_RSAE,
     .libcrypto_nid = NID_rsassaPss,
@@ -177,7 +186,7 @@ const struct s2n_signature_scheme s2n_rsa_pss_rsae_sha512 = {
  */
 const struct s2n_signature_scheme s2n_rsa_pss_pss_sha256 = {
     .iana_value = TLS_SIGNATURE_SCHEME_RSA_PSS_PSS_SHA256,
-    .iana_name = "rsa_pss_pss_sha256",
+    .name = "rsa_pss_pss_sha256",
     .hash_alg = S2N_HASH_SHA256,
     .sig_alg = S2N_SIGNATURE_RSA_PSS_PSS,
     .libcrypto_nid = NID_rsassaPss,
@@ -187,7 +196,7 @@ const struct s2n_signature_scheme s2n_rsa_pss_pss_sha256 = {
 
 const struct s2n_signature_scheme s2n_rsa_pss_pss_sha384 = {
     .iana_value = TLS_SIGNATURE_SCHEME_RSA_PSS_PSS_SHA384,
-    .iana_name = "rsa_pss_pss_sha384",
+    .name = "rsa_pss_pss_sha384",
     .hash_alg = S2N_HASH_SHA384,
     .sig_alg = S2N_SIGNATURE_RSA_PSS_PSS,
     .libcrypto_nid = NID_rsassaPss,
@@ -197,7 +206,7 @@ const struct s2n_signature_scheme s2n_rsa_pss_pss_sha384 = {
 
 const struct s2n_signature_scheme s2n_rsa_pss_pss_sha512 = {
     .iana_value = TLS_SIGNATURE_SCHEME_RSA_PSS_PSS_SHA512,
-    .iana_name = "rsa_pss_pss_sha512",
+    .name = "rsa_pss_pss_sha512",
     .hash_alg = S2N_HASH_SHA512,
     .sig_alg = S2N_SIGNATURE_RSA_PSS_PSS,
     .libcrypto_nid = NID_rsassaPss,
@@ -209,7 +218,7 @@ const struct s2n_signature_scheme s2n_rsa_pss_pss_sha512 = {
 
 const struct s2n_signature_scheme s2n_mldsa44 = {
     .iana_value = TLS_SIGNATURE_SCHEME_MLDSA44,
-    .iana_name = "mldsa44",
+    .name = "mldsa44",
     .hash_alg = S2N_HASH_SHAKE256_64,
     .sig_alg = S2N_SIGNATURE_MLDSA,
     .libcrypto_nid = S2N_NID_MLDSA44,
@@ -218,7 +227,7 @@ const struct s2n_signature_scheme s2n_mldsa44 = {
 
 const struct s2n_signature_scheme s2n_mldsa65 = {
     .iana_value = TLS_SIGNATURE_SCHEME_MLDSA65,
-    .iana_name = "mldsa65",
+    .name = "mldsa65",
     .hash_alg = S2N_HASH_SHAKE256_64,
     .sig_alg = S2N_SIGNATURE_MLDSA,
     .libcrypto_nid = S2N_NID_MLDSA65,
@@ -227,7 +236,7 @@ const struct s2n_signature_scheme s2n_mldsa65 = {
 
 const struct s2n_signature_scheme s2n_mldsa87 = {
     .iana_value = TLS_SIGNATURE_SCHEME_MLDSA87,
-    .iana_name = "mldsa87",
+    .name = "mldsa87",
     .hash_alg = S2N_HASH_SHAKE256_64,
     .sig_alg = S2N_SIGNATURE_MLDSA,
     .libcrypto_nid = S2N_NID_MLDSA87,

--- a/tls/s2n_signature_scheme.h
+++ b/tls/s2n_signature_scheme.h
@@ -24,7 +24,7 @@
 
 struct s2n_signature_scheme {
     uint16_t iana_value;
-    const char *iana_name;
+    const char *name;
     s2n_hash_algorithm hash_alg;
     s2n_signature_algorithm sig_alg;
     uint8_t minimum_protocol_version;
@@ -33,6 +33,12 @@ struct s2n_signature_scheme {
 
     /* Curve is only defined for TLS1.3 ECDSA Signatures */
     struct s2n_ecc_named_curve const *signature_curve;
+    /* Because of the different curve behavior, we should refer
+     * to TLS1.3 and pre-TLS1.3 versions of this scheme differently.
+     * Where the version is unknown, use the standard "name" field.
+     */
+    const char *legacy_name;
+    const char *tls13_name;
 };
 
 struct s2n_signature_preferences {


### PR DESCRIPTION
### Release Summary:
Add new `s2n_connection_get_signature_scheme` method to retrieve the IANA description of the server signature scheme

### Resolved issues:

### Description of changes: 

Add a getter for signature_schemes, modeled after [s2n_connection_get_key_exchange_group](https://github.com/aws/s2n-tls/blob/e8042c0918db6b941a7a78093d8259a6a81ad0ff/api/s2n.h#L3330-L3342).

This meets a customer request for easier logging, specifically for PQ signatures (MLDSA). That means that the customer is primarily interested in actual, official TLS1.3 signature schemes.

### Call-outs:

#### How should we handle non-IANA signature schemes?

We could:
1. Error if no official signature scheme
2. Return a combo of "signature algorithm" and "hash algorithm"

I went with 2. I worry that 1 would be awkward for customers to use. The primary use case for this API is for logging, but 1 would probably require checking the actual protocol version every time you perform the logging to avoid errors. Since TLS1.2 can also *sometimes* choose an official signature scheme, the behavior might be even more confusing and inconsistent if we didn't always treat actual_protocol_version<S2N_TLS13 as an error.

#### How should we format non-IANA signature scheme names?
We could use:
1. "<signature_algorithm>+<hash_algorithm>"
2. "legacy_<signature_algorithm>_<hash_algorithm>"
3. "legacy_<signature_algorithm, with '\_pkcs1' if 'rsa'>_<hash_algorithm>"

I went with 2. I think the "legacy" in front is a clear indicator for non-IANA names.

I initially liked 1, but I think seeing it appear in policy snapshots made how odd it would look very clear:
```
- rsa_pkcs1_sha384
- rsa_pkcs1_sha512
- rsa+sha224
- ecdsa_sha256
- ecdsa_sha384
- ecdsa_sha512
- ecdsa+sha224
- rsa_pkcs1_sha1
- ecdsa_sha1
```
To me, it's jarring to see the random "+" but also simultaneously not obvious that the "+" indicates non-IANA / legacy.

Our names currently follow 3. I like how that matches the official names, but I worry that's not well defined enough: it's easier to say "combine the IANA descriptions of the signature algorithm and hash algorithm" than "combine the IANA descriptions of the signature algorithm and hash algorithm, and append \_pkcsa1 to any rsa signature algorithms". Like documenting that would probably get confusing. We'll need to merge https://github.com/aws/s2n-tls/pull/5472 first if we want 2 instead of 3.

#### How should we handle no signature at all?

No signature scheme will be chosen if no signature is used, such as for session resumption. In that case, we could:
1. Treat it as an error.
2. Return NULL
3. Return "none"

I'd vote for "none". NULL also seems reasonable, but I worry about the usual issues around handling unexpected NULLs. And if a customer was using this method for logging / metrics, they'd still probably need to map NULL -> "none".

I really don't want to treat it as an error because that will make the method very hard to use. Customers shouldn't need to determine whether their connection negotiated a signature scheme or not in order to call this method or handle its errors.

### Testing:

New unit tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
