### PR TITLE
refactor: signature scheme name adjustment

### DIFF
--- a/tests/policy_snapshot/snapshots/20140601
+++ b/tests/policy_snapshot/snapshots/20140601
@@ -16,7 +16,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20141001
+++ b/tests/policy_snapshot/snapshots/20141001
@@ -16,7 +16,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20150202
+++ b/tests/policy_snapshot/snapshots/20150202
@@ -14,7 +14,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20150214
+++ b/tests/policy_snapshot/snapshots/20150214
@@ -16,7 +16,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20150306
+++ b/tests/policy_snapshot/snapshots/20150306
@@ -18,7 +18,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20160411
+++ b/tests/policy_snapshot/snapshots/20160411
@@ -21,7 +21,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20160804
+++ b/tests/policy_snapshot/snapshots/20160804
@@ -21,7 +21,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20160824
+++ b/tests/policy_snapshot/snapshots/20160824
@@ -16,7 +16,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20170210
+++ b/tests/policy_snapshot/snapshots/20170210
@@ -17,7 +17,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20170328
+++ b/tests/policy_snapshot/snapshots/20170328
@@ -27,7 +27,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20170328_gcm
+++ b/tests/policy_snapshot/snapshots/20170328_gcm
@@ -27,7 +27,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20170405
+++ b/tests/policy_snapshot/snapshots/20170405
@@ -19,7 +19,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20170405_gcm
+++ b/tests/policy_snapshot/snapshots/20170405_gcm
@@ -19,7 +19,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20170718
+++ b/tests/policy_snapshot/snapshots/20170718
@@ -20,7 +20,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20170718_gcm
+++ b/tests/policy_snapshot/snapshots/20170718_gcm
@@ -20,7 +20,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20190120
+++ b/tests/policy_snapshot/snapshots/20190120
@@ -22,7 +22,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20190121
+++ b/tests/policy_snapshot/snapshots/20190121
@@ -22,7 +22,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20190122
+++ b/tests/policy_snapshot/snapshots/20190122
@@ -22,7 +22,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20190214
+++ b/tests/policy_snapshot/snapshots/20190214
@@ -33,7 +33,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20190214_gcm
+++ b/tests/policy_snapshot/snapshots/20190214_gcm
@@ -33,7 +33,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20190801
+++ b/tests/policy_snapshot/snapshots/20190801
@@ -26,7 +26,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20190802
+++ b/tests/policy_snapshot/snapshots/20190802
@@ -26,7 +26,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20200207
+++ b/tests/policy_snapshot/snapshots/20200207
@@ -17,7 +17,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20201021
+++ b/tests/policy_snapshot/snapshots/20201021
@@ -28,7 +28,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20210825
+++ b/tests/policy_snapshot/snapshots/20210825
@@ -42,7 +42,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20210825_gcm
+++ b/tests/policy_snapshot/snapshots/20210825_gcm
@@ -42,7 +42,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20240417
+++ b/tests/policy_snapshot/snapshots/20240417
@@ -32,7 +32,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512
@@ -53,7 +53,7 @@ certificate signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20240502
+++ b/tests/policy_snapshot/snapshots/20240502
@@ -39,7 +39,7 @@ certificate signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20240503
+++ b/tests/policy_snapshot/snapshots/20240503
@@ -45,7 +45,7 @@ certificate signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20240603
+++ b/tests/policy_snapshot/snapshots/20240603
@@ -65,7 +65,7 @@ certificate signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20240730
+++ b/tests/policy_snapshot/snapshots/20240730
@@ -45,7 +45,7 @@ certificate signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20241001
+++ b/tests/policy_snapshot/snapshots/20241001
@@ -45,7 +45,7 @@ certificate signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20241001_pq_mixed
+++ b/tests/policy_snapshot/snapshots/20241001_pq_mixed
@@ -45,7 +45,7 @@ certificate signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20241106
+++ b/tests/policy_snapshot/snapshots/20241106
@@ -36,7 +36,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20250211
+++ b/tests/policy_snapshot/snapshots/20250211
@@ -22,7 +22,7 @@ certificate signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20250414
+++ b/tests/policy_snapshot/snapshots/20250414
@@ -30,7 +30,7 @@ certificate signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20250512
+++ b/tests/policy_snapshot/snapshots/20250512
@@ -51,7 +51,7 @@ certificate signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/20250721
+++ b/tests/policy_snapshot/snapshots/20250721
@@ -51,7 +51,7 @@ certificate signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-SSLv3.0
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-SSLv3.0
@@ -39,7 +39,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-SSLv3.0-2023
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-SSLv3.0-2023
@@ -39,7 +39,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.0
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.0
@@ -37,7 +37,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.0-2023
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.0-2023
@@ -37,7 +37,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.0-2025-PQ
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.0-2025-PQ
@@ -37,7 +37,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.1
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.1
@@ -37,7 +37,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.1-2023
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.1-2023
@@ -37,7 +37,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.2
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.2
@@ -37,7 +37,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.2-2023
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.2-2023
@@ -37,7 +37,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.2-2023-PQ
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.2-2023-PQ
@@ -37,7 +37,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.2-2025-PQ
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.2-2025-PQ
@@ -37,7 +37,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.3
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.3
@@ -17,7 +17,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.3-2023
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.3-2023
@@ -17,7 +17,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.3-2025-PQ
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.3-2025-PQ
@@ -17,7 +17,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-SSL-v-3
+++ b/tests/policy_snapshot/snapshots/CloudFront-SSL-v-3
@@ -31,7 +31,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-SSL-v-3-Legacy
+++ b/tests/policy_snapshot/snapshots/CloudFront-SSL-v-3-Legacy
@@ -27,7 +27,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-0-2014
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-0-2014
@@ -37,7 +37,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-0-2014-Legacy
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-0-2014-Legacy
@@ -26,7 +26,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-0-2016
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-0-2016
@@ -36,7 +36,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-0-2016-Legacy
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-0-2016-Legacy
@@ -25,7 +25,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-1-2016
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-1-2016
@@ -36,7 +36,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-1-2016-Legacy
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-1-2016-Legacy
@@ -25,7 +25,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2017
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2017
@@ -34,7 +34,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2018
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2018
@@ -30,7 +30,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2018-Legacy
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2018-Legacy
@@ -19,7 +19,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2019
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2019
@@ -27,7 +27,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2019-Legacy
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2019-Legacy
@@ -16,7 +16,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2021
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2021
@@ -23,7 +23,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2021-Chacha20-Boosted
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2021-Chacha20-Boosted
@@ -24,7 +24,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-Upstream
+++ b/tests/policy_snapshot/snapshots/CloudFront-Upstream
@@ -27,7 +27,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-Upstream-TLS-1-0
+++ b/tests/policy_snapshot/snapshots/CloudFront-Upstream-TLS-1-0
@@ -27,7 +27,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-Upstream-TLS-1-1
+++ b/tests/policy_snapshot/snapshots/CloudFront-Upstream-TLS-1-1
@@ -27,7 +27,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/CloudFront-Upstream-TLS-1-2
+++ b/tests/policy_snapshot/snapshots/CloudFront-Upstream-TLS-1-2
@@ -27,7 +27,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/ELBSecurityPolicy-2016-08
+++ b/tests/policy_snapshot/snapshots/ELBSecurityPolicy-2016-08
@@ -26,7 +26,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/ELBSecurityPolicy-FS-1-1-2019-08
+++ b/tests/policy_snapshot/snapshots/ELBSecurityPolicy-FS-1-1-2019-08
@@ -20,7 +20,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/ELBSecurityPolicy-FS-1-2-2019-08
+++ b/tests/policy_snapshot/snapshots/ELBSecurityPolicy-FS-1-2-2019-08
@@ -20,7 +20,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/ELBSecurityPolicy-FS-1-2-Res-2019-08
+++ b/tests/policy_snapshot/snapshots/ELBSecurityPolicy-FS-1-2-Res-2019-08
@@ -16,7 +16,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/ELBSecurityPolicy-FS-2018-06
+++ b/tests/policy_snapshot/snapshots/ELBSecurityPolicy-FS-2018-06
@@ -20,7 +20,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/ELBSecurityPolicy-TLS-1-0-2015-04
+++ b/tests/policy_snapshot/snapshots/ELBSecurityPolicy-TLS-1-0-2015-04
@@ -27,7 +27,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/ELBSecurityPolicy-TLS-1-0-2015-05
+++ b/tests/policy_snapshot/snapshots/ELBSecurityPolicy-TLS-1-0-2015-05
@@ -26,7 +26,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/ELBSecurityPolicy-TLS-1-1-2017-01
+++ b/tests/policy_snapshot/snapshots/ELBSecurityPolicy-TLS-1-1-2017-01
@@ -26,7 +26,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/ELBSecurityPolicy-TLS-1-2-2017-01
+++ b/tests/policy_snapshot/snapshots/ELBSecurityPolicy-TLS-1-2-2017-01
@@ -20,7 +20,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/ELBSecurityPolicy-TLS-1-2-Ext-2018-06
+++ b/tests/policy_snapshot/snapshots/ELBSecurityPolicy-TLS-1-2-Ext-2018-06
@@ -26,7 +26,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/KMS-FIPS-TLS-1-2-2018-10
+++ b/tests/policy_snapshot/snapshots/KMS-FIPS-TLS-1-2-2018-10
@@ -14,7 +14,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/KMS-FIPS-TLS-1-2-2021-08
+++ b/tests/policy_snapshot/snapshots/KMS-FIPS-TLS-1-2-2021-08
@@ -22,7 +22,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/KMS-TLS-1-0-2018-10
+++ b/tests/policy_snapshot/snapshots/KMS-TLS-1-0-2018-10
@@ -18,7 +18,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/KMS-TLS-1-0-2021-08
+++ b/tests/policy_snapshot/snapshots/KMS-TLS-1-0-2021-08
@@ -27,7 +27,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/KMS-TLS-1-2-2023-06
+++ b/tests/policy_snapshot/snapshots/KMS-TLS-1-2-2023-06
@@ -27,7 +27,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-0-2023-01-24
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-0-2023-01-24
@@ -27,7 +27,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-07
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-07
@@ -35,7 +35,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-08
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-08
@@ -42,7 +42,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-09
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-09
@@ -27,7 +27,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-10
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-10
@@ -42,7 +42,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-07
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-07
@@ -35,7 +35,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-08
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-08
@@ -42,7 +42,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-09
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-09
@@ -27,7 +27,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-10
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-10
@@ -42,7 +42,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-07
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-07
@@ -35,7 +35,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-08
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-08
@@ -41,7 +41,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-08_gcm
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-08_gcm
@@ -41,7 +41,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-09
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-09
@@ -26,7 +26,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-3-2023-06-01
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-3-2023-06-01
@@ -42,7 +42,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/default_fips
+++ b/tests/policy_snapshot/snapshots/default_fips
@@ -39,7 +39,7 @@ certificate signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/default_pq
+++ b/tests/policy_snapshot/snapshots/default_pq
@@ -51,7 +51,7 @@ certificate signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/default_tls13
+++ b/tests/policy_snapshot/snapshots/default_tls13
@@ -45,7 +45,7 @@ certificate signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/test_all
+++ b/tests/policy_snapshot/snapshots/test_all
@@ -41,9 +41,9 @@ cipher suites:
 - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
 - TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256
 signature schemes:
-- legacy_rsa_pkcs1_md5_sha1
+- legacy_rsa_md5_sha1
 - rsa_pkcs1_sha1
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512

--- a/tests/policy_snapshot/snapshots/test_all_ecdsa
+++ b/tests/policy_snapshot/snapshots/test_all_ecdsa
@@ -21,7 +21,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/test_all_fips
+++ b/tests/policy_snapshot/snapshots/test_all_fips
@@ -34,7 +34,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/test_all_rsa_kex
+++ b/tests/policy_snapshot/snapshots/test_all_rsa_kex
@@ -18,7 +18,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/test_all_tls12
+++ b/tests/policy_snapshot/snapshots/test_all_tls12
@@ -47,7 +47,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tests/policy_snapshot/snapshots/test_all_tls13
+++ b/tests/policy_snapshot/snapshots/test_all_tls13
@@ -8,9 +8,9 @@ cipher suites:
 - TLS_AES_256_GCM_SHA384
 - TLS_CHACHA20_POLY1305_SHA256
 signature schemes:
-- legacy_rsa_pkcs1_md5_sha1
+- legacy_rsa_md5_sha1
 - rsa_pkcs1_sha1
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512

--- a/tests/policy_snapshot/snapshots/test_ecdsa_priority
+++ b/tests/policy_snapshot/snapshots/test_ecdsa_priority
@@ -47,7 +47,7 @@ signature schemes:
 - rsa_pkcs1_sha256
 - rsa_pkcs1_sha384
 - rsa_pkcs1_sha512
-- legacy_rsa_pkcs1_sha224
+- legacy_rsa_sha224
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512

--- a/tls/s2n_signature_scheme.c
+++ b/tls/s2n_signature_scheme.c
@@ -25,7 +25,7 @@
 
 const struct s2n_signature_scheme s2n_null_sig_scheme = {
     .iana_value = 0,
-    .iana_name = "null_sha0",
+    .iana_name = "null",
     .hash_alg = S2N_HASH_NONE,
     .sig_alg = S2N_SIGNATURE_ANONYMOUS,
     .libcrypto_nid = 0,
@@ -36,7 +36,7 @@ const struct s2n_signature_scheme s2n_null_sig_scheme = {
 /* RSA PKCS1 */
 const struct s2n_signature_scheme s2n_rsa_pkcs1_md5_sha1 = {
     .iana_value = TLS_SIGNATURE_SCHEME_PRIVATE_INTERNAL_RSA_PKCS1_MD5_SHA1,
-    .iana_name = "legacy_rsa_pkcs1_md5_sha1",
+    .iana_name = "legacy_rsa_md5_sha1",
     .hash_alg = S2N_HASH_MD5_SHA1,
     .sig_alg = S2N_SIGNATURE_RSA,
     .libcrypto_nid = NID_md5_sha1,
@@ -56,7 +56,7 @@ const struct s2n_signature_scheme s2n_rsa_pkcs1_sha1 = {
 
 const struct s2n_signature_scheme s2n_rsa_pkcs1_sha224 = {
     .iana_value = TLS_SIGNATURE_SCHEME_RSA_PKCS1_SHA224,
-    .iana_name = "legacy_rsa_pkcs1_sha224",
+    .iana_name = "legacy_rsa_sha224",
     .hash_alg = S2N_HASH_SHA224,
     .sig_alg = S2N_SIGNATURE_RSA,
     .libcrypto_nid = NID_sha224WithRSAEncryption,


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:
related to ADD OTHER PR

### Description of changes: 

Drop "pkcs1" from the legacy RSA signature scheme names. The "pkcs1" is implied by "legacy", and removing it makes the RSA options match the "legacy_<signature_algorithm>_<hash_algorithm>" format.

The 100+ snapshot files are automatically generated and checked by the CI, so shouldn't need review. The only actual changes are in tls/s2n_signature_scheme.c, the last file in the diff.

### Testing:

Just a name change. The correctness of the snapshot files is checked by the snapshot test in the CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
