### PR TITLE
chore: Adds build file to get new codebuild project running in CI

### DIFF
--- a/codebuild/bin/start_codebuild.sh
+++ b/codebuild/bin/start_codebuild.sh
@@ -28,6 +28,7 @@ BUILDS=(
     "s2nUnitNix"
     "Integv2NixBatchBF1FB83F-7tcZOiMDWPH0 us-east-2 batch"
     "kTLS us-west-2 no-batch"
+    "kTLSKeyUpdate us-west-2 no-batch"
 )
 
 usage() {

--- a/codebuild/spec/buildspec_ktls_keyupdate.yml
+++ b/codebuild/spec/buildspec_ktls_keyupdate.yml
@@ -1,0 +1,41 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+# this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 0.2
+# This is designed to work with CodeBuild's reserved instances fleet and
+# curated Ec2 AMI for Ubuntu25.
+#
+# Because the Ec2 reserved instance disks persist between runs,
+# we need to do periodic clean up; The `nix store gc` command runs on Sunday to 
+# prevent the disk from filling up.
+env:
+  shell: bash
+  variables:
+    NIX_CACHE_BUCKET: "s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2"
+    NIX_INSTALLER: "https://nixos.org/nix/install"
+    S2N_KTLS_TESTING_EXPECTED: 1
+phases:
+  pre_build:
+    commands:
+      - if [[ $(date +%u) -eq 0 ]]; then nix store gc;fi
+      # Populate the store from the nix cache
+      - nix copy --from $NIX_CACHE_BUCKET --all  --no-check-sigs
+      # Load the TLS kernel module
+      - sudo modprobe tls
+      - echo "Checking that the TLS kernel mod loaded..."; test $(sudo lsmod|grep -c tls) = 1
+  build:
+    commands:
+      - nix develop .#awslc --command bash -c  'source ./nix/shell.sh && clean && configure && unit'
+      - S2N_CMAKE_OPTIONS="-DASAN=ON" nix develop .#awslc --command bash -c  'source ./nix/shell.sh && clean && configure && unit'
+


### PR DESCRIPTION
### Release Summary:
### Resolved issues:
### Description of changes: 

Adds a new buildspec that builds s2n-tls with aws-lc and runs the unit tests. We will be using this buildspec in our CI on our new Ubuntu25 codebuild project. With this newest build we will be able to do KTLS key updates. This buildspec is roughly the same as the existing ktls buildspec, but with several steps removed. Those steps are not necessary for the fleet we're using for ktls_keyupdates, because we now know how to create an AMI where those steps have already been performed. You can see a successful [run of this buildspec here.](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/kTLSKeyUpdate/build/kTLSKeyUpdate%3A4de6809b-88a6-42cd-a9f6-b92bd551507c/log?region=us-west-2)

### Call-outs:
I need this buildspec in our CI before I start opening ktls keyupdate PRs. Once this PR is merged [I can change the build](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/kTLSKeyUpdate?region=us-west-2&builds-meta=eyJmIjp7InRleHQiOiIiLCJzdGF0dXMiOiIifSwicyI6e30sIm4iOjIwLCJpIjowfQ) to use this buildspec.
### Testing:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
