### PR TITLE
Fix HKDF on big-endian

### DIFF
--- a/crypto/s2n_hkdf.c
+++ b/crypto/s2n_hkdf.c
@@ -82,7 +82,8 @@ static int s2n_custom_hkdf_expand(struct s2n_hmac_state *hmac, s2n_hmac_algorith
             POSIX_GUARD(s2n_hmac_update(hmac, prev, hash_len));
         }
         POSIX_GUARD(s2n_hmac_update(hmac, info->data, info->size));
-        POSIX_GUARD(s2n_hmac_update(hmac, &curr_round, 1));
+        uint8_t curr_round_byte = curr_round;
+        POSIX_GUARD(s2n_hmac_update(hmac, &curr_round_byte, 1));
         POSIX_GUARD(s2n_hmac_digest(hmac, prev, hash_len));
 
         cat_len = hash_len;


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

resolves #4097

### Description of changes: 

Using the "first" byte of a uint32_t is endian dependent. Casting curr_round to a single byte type fist makes sure endianes doesn't have any affect.

### Call-outs:

I am not entirely sure if there should may be a `& 0xff` before the cast.

### Testing:

This has been tested on alpine linux s390x and ppc by running the unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
