### PR TITLE
fix: no server signature scheme expected with rsa kex

### DIFF
--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -634,6 +634,7 @@ class Signature(object):
 
 
 class Signatures(object):
+    NONE = Signature("None+None", max_protocol=Protocols.TLS13)
     RSA_SHA1 = Signature("RSA+SHA1", max_protocol=Protocols.TLS12)
     RSA_SHA224 = Signature("RSA+SHA224", max_protocol=Protocols.TLS12)
     RSA_SHA256 = Signature("RSA+SHA256", max_protocol=Protocols.TLS12)

--- a/tests/integrationv2/test_signature_algorithms.py
+++ b/tests/integrationv2/test_signature_algorithms.py
@@ -33,8 +33,20 @@ all_sigs = [
 ]
 
 
-def expected_signature(protocol, signature):
-    if protocol < Protocols.TLS12:
+def signature_marker(mode, protocol, cipher, signature):
+    # In versions before TLS1.3, the server uses the negotiated signature scheme for the
+    # ServerKeyExchange message. The server only sends the ServerKeyExchange message when using
+    # a key exchange method that provides forward secrecy, ie, NOT static RSA.
+    # So if using RSA key exchange, there is no actual "negotiated" signature scheme, because
+    # the server never sends the client a signature scheme.
+    #
+    # This mostly has to be inferred from the RFCs, but this blog post is a pretty good summary
+    # of the situation: https://timtaubert.de/blog/2016/07/the-evolution-of-signatures-in-tls/
+    if mode == Provider.ServerMode and cipher.iana_standard_name.startswith(
+        "TLS_RSA_WITH_"
+    ):
+        signature = Signatures.NONE
+    elif protocol < Protocols.TLS12:
         # ECDSA by default hashes with SHA-1.
         #
         # This is inferred from extended version of TLS1.1 rfc- https://www.rfc-editor.org/rfc/rfc4492#section-5.10
@@ -42,10 +54,7 @@ def expected_signature(protocol, signature):
             signature = Signatures.ECDSA_SHA1
         else:
             signature = Signatures.RSA_MD5_SHA1
-    return signature
 
-
-def signature_marker(mode, signature):
     return to_bytes(
         "{mode} signature negotiated: {type}+{digest}".format(
             mode=mode.title(), type=signature.sig_type, digest=signature.sig_digest
@@ -146,15 +155,11 @@ def test_s2n_server_signature_algorithms(
             in results.stdout
         )
         assert (
-            signature_marker(
-                Provider.ServerMode, expected_signature(protocol, signature)
-            )
+            signature_marker(Provider.ServerMode, protocol, cipher, signature)
             in results.stdout
         )
         assert (
-            signature_marker(
-                Provider.ClientMode, expected_signature(protocol, signature)
-            )
+            signature_marker(Provider.ClientMode, protocol, cipher, signature)
             in results.stdout
         ) == client_auth
         assert random_bytes in results.stdout
@@ -224,16 +229,6 @@ def test_s2n_client_signature_algorithms(
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
-    # In versions before TLS1.3, the server uses the negotiated signature scheme for the
-    # ServerKeyExchange message. The server only sends the ServerKeyExchange message when using
-    # a key exchange method that provides forward secrecy, ie, NOT static RSA.
-    # So if using RSA key exchange, there is no actual "negotiated" signature scheme, because
-    # the server never sends the client a signature scheme.
-    #
-    # This mostly has to be inferred from the RFCs, but this blog post is a pretty good summary
-    # of the situation: https://timtaubert.de/blog/2016/07/the-evolution-of-signatures-in-tls/
-    server_sigalg_used = not cipher.iana_standard_name.startswith("TLS_RSA_WITH_")
-
     for results in client.get_results():
         results.assert_success()
         assert (
@@ -241,15 +236,10 @@ def test_s2n_client_signature_algorithms(
             in results.stdout
         )
         assert (
-            signature_marker(
-                Provider.ServerMode, expected_signature(protocol, signature)
-            )
+            signature_marker(Provider.ServerMode, protocol, cipher, signature)
             in results.stdout
-            or not server_sigalg_used
         )
         assert (
-            signature_marker(
-                Provider.ClientMode, expected_signature(protocol, signature)
-            )
+            signature_marker(Provider.ClientMode, protocol, cipher, signature)
             in results.stdout
         ) == client_auth

--- a/tests/testlib/s2n_testlib.h
+++ b/tests/testlib/s2n_testlib.h
@@ -220,12 +220,12 @@ int s2n_test_cert_chain_and_key_new(struct s2n_cert_chain_and_key **chain_and_ke
  * See https://github.com/aws/s2n-tls/issues/4651 for more information.
  */
 int s2n_test_cert_permutation_load_server_chain(struct s2n_cert_chain_and_key **chain_and_key,
-        const char *type, const char *siganture, const char *size, const char *digest);
+        const char *type, const char *signature, const char *size, const char *digest);
 
-int s2n_test_cert_permutation_get_ca_path(char *output, const char *type, const char *siganture,
+int s2n_test_cert_permutation_get_ca_path(char *output, const char *type, const char *signature,
         const char *size, const char *digest);
 S2N_RESULT s2n_test_cert_permutation_get_server_chain_path(char *output, const char *type,
-        const char *siganture, const char *size, const char *digest);
+        const char *signature, const char *size, const char *digest);
 
 S2N_RESULT s2n_test_cert_chain_data_from_pem(struct s2n_connection *conn, const char *pem_path,
         struct s2n_stuffer *cert_chain_stuffer);

--- a/tests/unit/s2n_client_signature_algorithms_extension_test.c
+++ b/tests/unit/s2n_client_signature_algorithms_extension_test.c
@@ -81,6 +81,7 @@ int main(int argc, char **argv)
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_SERVER));
         POSIX_GUARD(s2n_connection_set_config(conn, config));
         conn->actual_protocol_version = S2N_TLS12;
+        conn->secure->cipher_suite = &s2n_ecdhe_rsa_with_aes_256_gcm_sha384;
 
         struct s2n_stuffer signature_algorithms_extension = { 0 };
         EXPECT_SUCCESS(s2n_stuffer_alloc(&signature_algorithms_extension, 2 + (sig_hash_algs.len * 2)));

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -129,7 +129,7 @@ static int try_handshake(struct s2n_connection *server_conn, struct s2n_connecti
 }
 
 int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config *client_config,
-        struct s2n_cert_chain_and_key *expected_cert_chain, s2n_signature_algorithm expected_sig_alg)
+        struct s2n_cert_chain_and_key *expected_cert_chain, s2n_signature_algorithm sig_alg)
 {
     const struct s2n_security_policy *security_policy = server_config->security_policy;
     EXPECT_NOT_NULL(security_policy);
@@ -152,6 +152,12 @@ int test_cipher_preferences(struct s2n_config *server_config, struct s2n_config 
         /* Expect failure if the libcrypto we're building with can't support the cipher */
         if (!expected_cipher->available) {
             expect_failure = 1;
+        }
+
+        s2n_signature_algorithm expected_sig_alg = sig_alg;
+        /* Expect no server signature algorithm if RSA kex */
+        if (expected_cipher->key_exchange_alg == &s2n_rsa) {
+            expected_sig_alg = S2N_SIGNATURE_ANONYMOUS;
         }
 
         TEST_DEBUG_PRINT("Testing %s in %s mode, expect_failure=%d\n", expected_cipher->name,

--- a/tests/unit/s2n_signature_algorithms_test.c
+++ b/tests/unit/s2n_signature_algorithms_test.c
@@ -30,9 +30,10 @@
 #define LENGTH       (s2n_array_len(test_signature_schemes))
 #define STUFFER_SIZE (LENGTH * TLS_SIGNATURE_SCHEME_LEN + 10)
 
-#define RSA_CIPHER_SUITE   &s2n_ecdhe_rsa_with_aes_128_cbc_sha
-#define ECDSA_CIPHER_SUITE &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha
-#define TLS13_CIPHER_SUITE &s2n_tls13_aes_128_gcm_sha256
+#define RSA_CIPHER_SUITE     &s2n_ecdhe_rsa_with_aes_128_cbc_sha
+#define RSA_KEX_CIPHER_SUITE &s2n_rsa_with_aes_256_gcm_sha384
+#define ECDSA_CIPHER_SUITE   &s2n_ecdhe_ecdsa_with_aes_128_cbc_sha
+#define TLS13_CIPHER_SUITE   &s2n_tls13_aes_128_gcm_sha256
 
 /* The only TLS1.3-only signature schemes are RSA-PSS-PSS, which
  * are difficult to test with due to mixed libcrypto support.
@@ -233,6 +234,36 @@ int main(int argc, char **argv)
         /* TLS1.2 defaults defined by the RFC */
         const struct s2n_signature_scheme *ecdsa_default = &s2n_ecdsa_sha1;
         const struct s2n_signature_scheme *rsa_default = &s2n_rsa_pkcs1_sha1;
+
+        /* Test: do not choose a server signature scheme for RSA kex */
+        {
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_SUCCESS(s2n_connection_set_config(conn, client_rsa_config));
+
+            /* Support a wide variety of signature schemes */
+            const struct s2n_signature_scheme *test_schemes[] = {
+                &s2n_ecdsa_sha384,
+                &s2n_rsa_pss_rsae_sha256,
+                &s2n_rsa_pss_pss_sha256,
+                &s2n_rsa_pkcs1_sha256,
+            };
+            struct s2n_local_sig_schemes_context local_context = { 0 };
+            EXPECT_OK(s2n_test_set_local_sig_schemes(conn, &local_context,
+                    test_schemes, s2n_array_len(test_schemes)));
+            EXPECT_OK(s2n_test_set_peer_sig_schemes(&conn->handshake_params.peer_sig_scheme_list,
+                    test_schemes, s2n_array_len(test_schemes)));
+
+            /* Test: If RSA kex is chosen, a server signature scheme is NOT chosen. */
+            conn->secure->cipher_suite = RSA_KEX_CIPHER_SUITE;
+            EXPECT_OK(s2n_signature_algorithm_select(conn));
+            EXPECT_EQUAL(conn->handshake_params.server_cert_sig_scheme, &s2n_null_sig_scheme);
+
+            /* Test: A client signature scheme is chosen even for RSA kex */
+            conn->mode = S2N_CLIENT;
+            EXPECT_OK(s2n_signature_algorithm_select(conn));
+            EXPECT_NOT_EQUAL(conn->handshake_params.client_cert_sig_scheme, &s2n_null_sig_scheme);
+        };
 
         /* Test: choose legacy default for <TLS1.2 */
         {
@@ -1497,6 +1528,40 @@ int main(int argc, char **argv)
                     &s2n_ecc_curve_secp384r1);
         }
     }
+
+    /* Self-Talk test: no server signature scheme is chosen for RSA kex */
+    {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, rsa_cert_chain));
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all_rsa_kex"));
+        EXPECT_SUCCESS(s2n_config_set_client_auth_type(config, S2N_CERT_AUTH_REQUIRED));
+
+        DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_SUCCESS(s2n_connection_set_config(client, config));
+
+        DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_SUCCESS(s2n_connection_set_config(server, config));
+
+        DEFER_CLEANUP(struct s2n_test_io_stuffer_pair io_pair, s2n_io_stuffer_pair_free);
+        EXPECT_OK(s2n_io_stuffer_pair_init(&io_pair));
+        EXPECT_OK(s2n_connections_set_io_stuffer_pair(client, server, &io_pair));
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server, client));
+
+        /* RSA kex negotiated */
+        EXPECT_EQUAL(server->secure->cipher_suite->key_exchange_alg, &s2n_rsa);
+
+        /* No server signature scheme */
+        EXPECT_EQUAL(server->handshake_params.server_cert_sig_scheme, &s2n_null_sig_scheme);
+        EXPECT_EQUAL(client->handshake_params.server_cert_sig_scheme, &s2n_null_sig_scheme);
+
+        /* Client signature scheme negotiated */
+        EXPECT_EQUAL(server->handshake_params.client_cert_sig_scheme, &s2n_rsa_pkcs1_sha256);
+        EXPECT_EQUAL(client->handshake_params.client_cert_sig_scheme, &s2n_rsa_pkcs1_sha256);
+    };
 
     END_TEST();
 

--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -188,6 +188,12 @@ S2N_RESULT s2n_signature_algorithm_select(struct s2n_connection *conn)
         chosen_sig_scheme = &conn->handshake_params.server_cert_sig_scheme;
     }
 
+    /* No server signature is needed for RSA kex */
+    if (conn->mode == S2N_SERVER && cipher_suite->key_exchange_alg == &s2n_rsa) {
+        RESULT_ENSURE_EQ(*chosen_sig_scheme, &s2n_null_sig_scheme);
+        return S2N_RESULT_OK;
+    }
+
     /* Before TLS1.2, signature algorithms were fixed instead of negotiated */
     if (conn->actual_protocol_version < S2N_TLS12) {
         RESULT_GUARD(s2n_signature_algorithms_get_legacy_default(conn, conn->mode, chosen_sig_scheme));


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

resolves #5477

### Description of changes: 

s2n-tls was choosing a server signature scheme even when no server signature is necessary due to RSA kex. This change fixes that.

### Call-outs:

We could instead just fix all the getters that report server signature scheme, but I don't think that's the right choice because:
1. We would have to apply the same fix to all getters. There are currently 2, I'm adding a 3rd in another PR, there may be more someday.
2. Future internal logic might assume a server signature scheme and not account for none
3. Client and server will not agree. The client correctly marks all these situations as "none" because the server never sends it a server signature.

### Testing:

In addition to the new unit tests, I repeated the manual s2nc/s2nd test from the issue. New server output:
```
s2nd localhost 8000 --ciphers test_all_rsa_kex
libcrypto: AWS-LC 1.49.1
Listening on localhost:8000
CONNECTED:
Handshake: NEGOTIATED|FULL_HANDSHAKE|WITH_SESSION_TICKET
Client hello version: 33
Client protocol version: 33
Server protocol version: 33
Actual protocol version: 33
Server name: localhost
Curve: NONE
Cipher negotiated: AES128-SHA
Server signature negotiated: None+None <-- CORRECT NOW
Early Data status: NOT REQUESTED
JA3: a24955ad4bc89eb0c960d34b2a6f1486
Wire bytes in: 498
Wire bytes out: 2704
s2n is ready
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
