### PR TITLE
chore: Updates ktls buildspec to work with nix

### DIFF
--- a/codebuild/spec/buildspec_ktls_keyupdate.yml
+++ b/codebuild/spec/buildspec_ktls_keyupdate.yml
@@ -36,6 +36,10 @@ phases:
       - echo "Checking that the TLS kernel mod loaded..."; test $(sudo lsmod|grep -c tls) = 1
   build:
     commands:
-      - nix develop .#awslc --command bash -c  'source ./nix/shell.sh && clean && configure && unit'
-      - S2N_CMAKE_OPTIONS="-DASAN=ON" nix develop .#awslc --command bash -c  'source ./nix/shell.sh && clean && configure && unit'
-
+      # We need to install linux kernel headers. Our ktls key update feature probe requires it.
+      - sudo apt install linux-libc-dev
+      # Nix comes with its own linux header files. These are older than the linux kernel version that includes
+      # the key update patch. Therefore, we reference the /usr/include directory when running nix so that
+      # nix knows to use the system's /usr/include directory instead of its own.
+      - nix develop .#awslc --command bash -c  'source ./nix/shell.sh && clean && NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem /usr/include" configure && S2N_NO_HEADBUILD=1 build && unit'
+      - S2N_CMAKE_OPTIONS="-DASAN=ON" nix develop .#awslc --command bash -c  'source ./nix/shell.sh && clean && NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem /usr/include" configure && S2N_NO_HEADBUILD=1 build && unit'

--- a/tests/features/S2N_KTLS_KEYUPDATE_SUPPORTED.flags
+++ b/tests/features/S2N_KTLS_KEYUPDATE_SUPPORTED.flags
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* Gate kTLS support only to Linux. Add other platforms once they have been tested. */
+#if defined(__linux__)
+    #include <linux/snmp.h>
+#endif
+
+int main()
+{
+    int counters[] = { LINUX_MIB_TLSRXREKEYOK, LINUX_MIB_TLSRXREKEYERROR, LINUX_MIB_TLSTXREKEYOK, LINUX_MIB_TLSTXREKEYERROR, LINUX_MIB_TLSRXREKEYRECEIVED };
+
+    return 0;
+}


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 
The previous buildspec I made for the ktls keyupdate job #5476 didn't actually result in the feature probe I wanted to use being turned on. This PR changes the buildspec and includes the feature probe to prove that this buildspec actually results in the feature probe turning on.

### Call-outs:
This makes the buildspec more complicated.
### Testing:
[Link to codebuild job that uses this new buildspec](https://tiny.amazon.com/w214h433/IsenLink), see that the S2N_KTLS_KEYUPDATE_SUPPORTED flag is true.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
