### PR TITLE
chore: pin to older pytest-rerunfailures

### DIFF
--- a/tests/integrationv2/pyproject.toml
+++ b/tests/integrationv2/pyproject.toml
@@ -5,9 +5,11 @@ description = "Integration tests for s2n-tls"
 readme = "README.md"
 requires-python = ">=3.12"
 
+# Pin rerunfailures until this issue is addressed
+# https://github.com/pytest-dev/pytest-rerunfailures/issues/302
 dependencies = [
     "pytest>=8.3.4",
-    "pytest-rerunfailures>=15.0",
+    "pytest-rerunfailures==15.1",
     "pytest-xdist>=3.6.1",
     "ruff>=0.9.7",
     "sslyze>=6.1.0",


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

n/a

### Description of changes: 

Pytest-rerunfailures released version 16.0 recently, which appears to have broken our CI, similar to the issue reported at https://github.com/pytest-dev/pytest-rerunfailures/issues/302.

Pin to the previous version until the newer one is fixed.

### Call-outs:

This reproduces locally on my aarch64 dev instance.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? local/Ci

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
