### PR TITLE
test: Adds test for serializing a previously-serialized connection

### DIFF
--- a/tests/unit/s2n_connection_serialize_test.c
+++ b/tests/unit/s2n_connection_serialize_test.c
@@ -638,7 +638,6 @@ int main(int argc, char **argv)
             server_ptr = new_server;
         }
         EXPECT_SUCCESS(s2n_connection_free(server_ptr));
-
     };
 
     /* Self-talk: Test interaction between TLS1.2 session resumption and serialization */

--- a/tests/unit/s2n_connection_serialize_test.c
+++ b/tests/unit/s2n_connection_serialize_test.c
@@ -637,6 +637,8 @@ int main(int argc, char **argv)
             }
             server_ptr = new_server;
         }
+        EXPECT_SUCCESS(s2n_connection_free(server_ptr));
+
     };
 
     /* Self-talk: Test interaction between TLS1.2 session resumption and serialization */

--- a/tests/unit/s2n_connection_serialize_test.c
+++ b/tests/unit/s2n_connection_serialize_test.c
@@ -592,6 +592,70 @@ int main(int argc, char **argv)
         }
     };
 
+    /* Self-talk: A deserialized session can be serialized */
+    for (size_t i = 0; i < s2n_array_len(config_array); i++) {
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+        DEFER_CLEANUP(struct s2n_connection *first_server = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(first_server);
+
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config_array[i]));
+        EXPECT_SUCCESS(s2n_connection_set_config(first_server, config_array[i]));
+
+        DEFER_CLEANUP(struct s2n_test_io_stuffer_pair io_pair = { 0 }, s2n_io_stuffer_pair_free);
+        EXPECT_OK(s2n_io_stuffer_pair_init(&io_pair));
+        EXPECT_OK(s2n_connections_set_io_stuffer_pair(client_conn, first_server, &io_pair));
+
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(first_server, client_conn));
+
+        /* Preliminary send and receive */
+        EXPECT_OK(s2n_send_and_recv_test(first_server, client_conn));
+        EXPECT_OK(s2n_send_and_recv_test(client_conn, first_server));
+
+        /* First serialization */
+        uint8_t first_serialization[S2N_SERIALIZED_CONN_TLS12_SIZE] = { 0 };
+        EXPECT_SUCCESS(s2n_connection_serialize(first_server, first_serialization, sizeof(first_serialization)));
+
+        /* Second deserialization */
+        DEFER_CLEANUP(struct s2n_connection *second_server = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(second_server);
+        EXPECT_SUCCESS(s2n_connection_deserialize(second_server, first_serialization, sizeof(first_serialization)));
+
+        /* Wipe and re-initialize IO pipes */
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&io_pair.client_in));
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&io_pair.server_in));
+        EXPECT_OK(s2n_connections_set_io_stuffer_pair(client_conn, second_server, &io_pair));
+
+        /* Another send and recv */
+        EXPECT_OK(s2n_send_and_recv_test(second_server, client_conn));
+        EXPECT_OK(s2n_send_and_recv_test(client_conn, second_server));
+
+        /* Second serialization. Note that the server needs a config with the serialization version set. */
+        EXPECT_SUCCESS(s2n_connection_set_config(second_server, config_array[i]));
+        uint8_t second_serialization[S2N_SERIALIZED_CONN_TLS12_SIZE] = { 0 };
+        EXPECT_SUCCESS(s2n_connection_serialize(second_server, second_serialization, sizeof(second_serialization)));
+
+        /* Second deserialization */
+        DEFER_CLEANUP(struct s2n_connection *third_server = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(third_server);
+        EXPECT_SUCCESS(s2n_connection_deserialize(third_server, second_serialization, sizeof(second_serialization)));
+
+        /* Wipe and re-initialize IO pipes */
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&io_pair.client_in));
+        EXPECT_SUCCESS(s2n_stuffer_wipe(&io_pair.server_in));
+        EXPECT_OK(s2n_connections_set_io_stuffer_pair(client_conn, third_server, &io_pair));
+
+        /* Server can send and recv as usual */
+        for (size_t idx = 0; idx < 1000; idx++) {
+            EXPECT_OK(s2n_send_and_recv_test(third_server, client_conn));
+            EXPECT_OK(s2n_send_and_recv_test(client_conn, third_server));
+        }
+    };
+
     /* Self-talk: Test interaction between TLS1.2 session resumption and serialization */
     {
         DEFER_CLEANUP(struct s2n_config *resumption_config = s2n_config_new(), s2n_config_ptr_free);

--- a/tests/unit/s2n_connection_serialize_test.c
+++ b/tests/unit/s2n_connection_serialize_test.c
@@ -598,28 +598,28 @@ int main(int argc, char **argv)
                 s2n_connection_ptr_free);
         EXPECT_NOT_NULL(client_conn);
         EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config_array[i]));
-        
-        uint8_t serialized_data[S2N_SERIALIZED_CONN_TLS12_SIZE] = { 0 };    
+
+        uint8_t serialized_data[S2N_SERIALIZED_CONN_TLS12_SIZE] = { 0 };
         for (size_t j = 0; j < 10; j++) {
             DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
                     s2n_connection_ptr_free);
             EXPECT_NOT_NULL(server);
             EXPECT_SUCCESS(s2n_connection_set_config(server, config_array[i]));
-            
+
             DEFER_CLEANUP(struct s2n_test_io_stuffer_pair io_pair = { 0 }, s2n_io_stuffer_pair_free);
             EXPECT_OK(s2n_io_stuffer_pair_init(&io_pair));
             EXPECT_OK(s2n_connections_set_io_stuffer_pair(client_conn, server, &io_pair));
-            
+
             if (j == 0) {
                 EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server, client_conn));
             } else {
                 EXPECT_SUCCESS(s2n_connection_deserialize(server, serialized_data, sizeof(serialized_data)));
             }
-            
+
             /* Can send and receive after either negotiating or deserializing */
             EXPECT_OK(s2n_send_and_recv_test(server, client_conn));
             EXPECT_OK(s2n_send_and_recv_test(client_conn, server));
-            
+
             memset(serialized_data, 0, S2N_SERIALIZED_CONN_TLS12_SIZE);
             EXPECT_SUCCESS(s2n_connection_serialize(server, serialized_data, sizeof(serialized_data)));
         };


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

N/A

### Description of changes: 

Just noticed that we don't have test coverage for the case where a connection is serialized, deserialized, and then serialized again. It's a weird usecase but it is completely valid and should work fine.

### Call-outs:
N/A

### Testing:
Adds new test.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
