### PR TITLE
chore: bump instance size for Valgrind

### DIFF
--- a/codebuild/spec/buildspec_valgrind.yml
+++ b/codebuild/spec/buildspec_valgrind.yml
@@ -17,49 +17,49 @@ batch:
   build-list:
     - identifier: gcc_awslc
       env:
-        compute-type: BUILD_GENERAL1_LARGE
+        compute-type: BUILD_GENERAL1_XLARGE
         image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu24
         variables:
           S2N_LIBCRYPTO: awslc
           COMPILER: gcc
     - identifier: gcc_awslc_fips
       env:
-        compute-type: BUILD_GENERAL1_LARGE
+        compute-type: BUILD_GENERAL1_XLARGE
         image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu24
         variables:
           S2N_LIBCRYPTO: awslc-fips-2022
           COMPILER: gcc
     - identifier: gcc_openssl_3_0
       env:
-        compute-type: BUILD_GENERAL1_LARGE
+        compute-type: BUILD_GENERAL1_XLARGE
         image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
         variables:
           S2N_LIBCRYPTO: openssl-3.0
           COMPILER: gcc
     - identifier: gcc_openssl_3_fips
       env:
-        compute-type: BUILD_GENERAL1_LARGE
+        compute-type: BUILD_GENERAL1_XLARGE
         image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
         variables:
           S2N_LIBCRYPTO: openssl-3.0-fips
           COMPILER: gcc
     - identifier: gcc_openssl_1_1_1
       env:
-        compute-type: BUILD_GENERAL1_LARGE
+        compute-type: BUILD_GENERAL1_XLARGE
         image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu24
         variables:
           S2N_LIBCRYPTO: openssl-1.1.1
           COMPILER: gcc
     - identifier: gcc_openssl_1_0_2
       env:
-        compute-type: BUILD_GENERAL1_LARGE
+        compute-type: BUILD_GENERAL1_XLARGE
         image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
         variables:
           S2N_LIBCRYPTO: openssl-1.0.2
           COMPILER: gcc
     - identifier: gcc_openssl_1_0_2_fips
       env:
-        compute-type: BUILD_GENERAL1_LARGE
+        compute-type: BUILD_GENERAL1_XLARGE
         image: 024603541914.dkr.ecr.us-west-2.amazonaws.com/docker:ubuntu22codebuild
         variables:
           S2N_LIBCRYPTO: openssl-1.0.2-fips


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

n/a

### Description of changes: 

Move the valgrind jobs to 36vCPU instances, saving ~5minutes of runtime.

### Call-outs:

This is a least-effort approach, nix or ec2 are other solutions.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
