### PR TITLE
chore(ci): add gcc-4.8 with openssl-1.0.2-fips sanitizer job

### DIFF
--- a/codebuild/spec/buildspec_sanitizer.yml
+++ b/codebuild/spec/buildspec_sanitizer.yml
@@ -12,7 +12,8 @@
 # implied. See the License for the specific language governing permissions and
 # limitations under the License.
 version: 0.2
-
+env:
+  shell: bash
 # This buildspec runs on an Ubuntu22 image. That configuration is a property of
 # the codebuild job itself.
 


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

partial for https://github.com/aws/s2n-tls/issues/5503

### Description of changes: 

Add an address sanitizer job for an older compiler/libcrypto combination.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? This is the test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
