### PR TITLE
ci: fix clippy

### DIFF
--- a/bindings/rust/aws-kms-tls-auth/.clippy.toml
+++ b/bindings/rust/aws-kms-tls-auth/.clippy.toml
@@ -1,0 +1,2 @@
+# This should match rust-toolchain
+msrv = "1.88.0"

--- a/bindings/rust/standard/.clippy.toml
+++ b/bindings/rust/standard/.clippy.toml
@@ -1,0 +1,2 @@
+# This should match rust-toolchain
+msrv = "1.82.0"

--- a/bindings/rust/standard/integration/src/features/record_padding.rs
+++ b/bindings/rust/standard/integration/src/features/record_padding.rs
@@ -33,7 +33,7 @@ fn record_padding() {
         // skip the first two records, because unencrypted records are not padded
         record_sizes.iter().skip(2).all(|record_length| {
             let record_without_tag = record_length - AES_GCM_TAG_LEN;
-            record_without_tag % (pad_to as u16) == 0
+            record_without_tag.is_multiple_of(pad_to as u16)
         })
     }
 

--- a/bindings/rust/standard/integration/src/features/record_padding.rs
+++ b/bindings/rust/standard/integration/src/features/record_padding.rs
@@ -33,7 +33,7 @@ fn record_padding() {
         // skip the first two records, because unencrypted records are not padded
         record_sizes.iter().skip(2).all(|record_length| {
             let record_without_tag = record_length - AES_GCM_TAG_LEN;
-            record_without_tag.is_multiple_of(pad_to as u16)
+            record_without_tag % (pad_to as u16) == 0
         })
     }
 


### PR DESCRIPTION
### Description of changes: 

The newer versions of `clippy` forbids the manual implementation of `.is_multiple_of()`. This function was introduced in `rust 1.87.0` on 15 May, 2025. We commit to at least 6 months of stability in our rust bindings, thus we are unable to bump the MSRV right now. Instead, this PR pins the clippy config to work around the CI failure.

### Testing:

CI should pass


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
