### PR TITLE
ci: pin libloading which requires MSRV 1.71

### DIFF
--- a/bindings/rust/extended/generate/Cargo.toml
+++ b/bindings/rust/extended/generate/Cargo.toml
@@ -12,3 +12,4 @@ bindgen = "0.65"
 glob = "0.3"
 regex = "=1.9.6" # newer versions require rust 1.65, see https://github.com/aws/s2n-tls/issues/4242
 home = "=0.5.5" # newer versions require rust 1.70, see https://github.com/aws/s2n-tls/issues/4395
+libloading = "=0.8.8" # newer versions require rust 1.71, see https://github.com/aws/s2n-tls/issues/4395


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

### Description of changes: 

New version of libloading requires MSRV 1.71. This CR pins its version to previous version 0.8.8

### Call-outs:

### Testing:
CI tests pass


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
