### PR TITLE
ci: install missing rust component for gitthub action workflows

### DIFF
--- a/.github/workflows/ci_aws_kms_tls_auth.yml
+++ b/.github/workflows/ci_aws_kms_tls_auth.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install Rust toolchain
         run: |
-          rustup toolchain install stable
+          rustup toolchain install stable --component rustfmt,clippy
           rustup override set stable
 
       - run: cargo fmt --all -- --check

--- a/.github/workflows/ci_aws_kms_tls_auth.yml
+++ b/.github/workflows/ci_aws_kms_tls_auth.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install Rust toolchain
         run: |
-          rustup toolchain install stable --component rustfmt
+          rustup toolchain install stable --component clippy,rustfmt
           rustup override set stable
 
       - run: cargo fmt --all -- --check

--- a/.github/workflows/ci_aws_kms_tls_auth.yml
+++ b/.github/workflows/ci_aws_kms_tls_auth.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install Rust toolchain
         run: |
-          rustup toolchain install stable --component rustfmt,clippy
+          rustup toolchain install stable --component rustfmt
           rustup override set stable
 
       - run: cargo fmt --all -- --check

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -411,7 +411,7 @@ jobs:
       - name: Install Rust toolchain
         id: toolchain
         run: |
-          rustup toolchain install stable --component clippy
+          rustup toolchain install stable --component clippy,rustfmt
           rustup override set stable
 
       - name: Install tshark


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

`cargo fmt` commands are failing in CI for [aws-kms-tls-auth](https://github.com/aws/s2n-tls/actions/runs/18016289572/job/51261957959?pr=5519) and [Rust Bindings](https://github.com/aws/s2n-tls/actions/runs/18016289611/job/51261958168?pr=5519) presumably because of latest rust release, changing what gets packaged when installing rust via stable channel.

### Description of changes: 

Explicitly install missing components during installation of rust. 

### Testing:
CI is now passing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
