### PR TITLE
fix(usage-guide): Update book.toml for mdbook 0.5 release

### DIFF
--- a/docs/usage-guide/book.toml
+++ b/docs/usage-guide/book.toml
@@ -1,5 +1,4 @@
 [book]
 authors = []
 language = "en"
-multilingual = false
 src = "topics"


### PR DESCRIPTION
### Description of changes: 

mdbook 0.5 [removed the `multilingual` field](https://github.com/rust-lang/mdBook/blob/4e41c844c305bc6f34b79bf5580b9169b1fc6364/CHANGELOG.md?plain=1#L33-L34) from the `book` configuration file. This [caused our CI to fail](https://github.com/aws/s2n-tls/actions/runs/18104898548/job/51520150812?pr=5357), because [we are setting this option](https://github.com/aws/s2n-tls/blob/aac581bc1e007e41231defb4c4971a2952b4b9b6/docs/usage-guide/book.toml#L4) (but just setting it to false).

This PR removes this option from our book.toml.

### Call-outs:

None

### Testing:

The usage-guide job [succeeds on this PR](https://github.com/aws/s2n-tls/actions/runs/18106408037/job/51521985876?pr=5535#step:6:1).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
