### PR TITLE
chore: bindings release 0.3.28

### DIFF
--- a/bindings/rust/extended/s2n-tls-sys/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-sys"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.3.27"
+version = "0.3.28"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.72.0"

--- a/bindings/rust/extended/s2n-tls-sys/templates/Cargo.template
+++ b/bindings/rust/extended/s2n-tls-sys/templates/Cargo.template
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-sys"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.3.27"
+version = "0.3.28"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.72.0"

--- a/bindings/rust/extended/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls-tokio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-tokio"
 description = "An implementation of TLS streams for Tokio built on top of s2n-tls"
-version = "0.3.27"
+version = "0.3.28"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.72.0"
@@ -16,7 +16,7 @@ errno = { version = "0.3" }
 # A minimum libc version of 0.2.121 is required by aws-lc-sys 0.14.0.
 libc = { version = "0.2.121" }
 pin-project-lite = { version = "0.2" }
-s2n-tls = { version = "=0.3.27", path = "../s2n-tls" }
+s2n-tls = { version = "=0.3.28", path = "../s2n-tls" }
 tokio = { version = "1", features = ["net", "time"] }
 
 [dev-dependencies]

--- a/bindings/rust/extended/s2n-tls/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.3.27"
+version = "0.3.28"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.72.0"
@@ -25,7 +25,7 @@ unstable-testing = []
 errno = { version = "0.3" }
 # A minimum libc version of 0.2.121 is required by aws-lc-sys 0.14.0.
 libc = "0.2.121"
-s2n-tls-sys = { version = "=0.3.27", path = "../s2n-tls-sys", features = ["internal"] }
+s2n-tls-sys = { version = "=0.3.28", path = "../s2n-tls-sys", features = ["internal"] }
 pin-project-lite = "0.2"
 hex = "0.4"
 

--- a/bindings/rust/standard/s2n-tls-hyper/Cargo.toml
+++ b/bindings/rust/standard/s2n-tls-hyper/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-hyper"
 description = "A compatbility crate allowing s2n-tls to be used with the hyper HTTP library"
-version = "0.0.19"
+version = "0.0.20"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.74.0"
@@ -12,8 +12,8 @@ license = "Apache-2.0"
 default = []
 
 [dependencies]
-s2n-tls = { version = "=0.3.27", path = "../../extended/s2n-tls" }
-s2n-tls-tokio = { version = "=0.3.27", path = "../../extended/s2n-tls-tokio" }
+s2n-tls = { version = "=0.3.28", path = "../../extended/s2n-tls" }
+s2n-tls-tokio = { version = "=0.3.28", path = "../../extended/s2n-tls-tokio" }
 # A minimum hyper version of 1.3 is required by hyper-util 0.1.4:
 # https://github.com/hyperium/hyper-util/blob/3f6a92ecd019b8d534d2945564d3ab8a92ff1f41/Cargo.toml#L34
 hyper = { version = "1.3" }


### PR DESCRIPTION
### Description of changes: 

Bumps the rust bindings versions for the 0.3.28 release.

### Call-outs:

None

### Testing:

CI should succeed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
