### PR TITLE
feat(build): Add OpenSSL CMake config step to libcrypto search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,37 +261,70 @@ if (S2N_INTERN_LIBCRYPTO)
     set(BUILD_SHARED_LIBS OFF)
 endif()
 
+function(find_libcrypto)
+    # Begin the search for a libcrypto.
+    #
+    # User-provided directories such as CMAKE_PREFIX_PATH are exclusively searched first. If no
+    # libcrypto can be found in any user path, then the search is broadened to system paths.
+    # https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure
+    foreach(search_strategy "USER" "SYSTEM")
+        set(find_filters "")
+        if (search_strategy STREQUAL "USER")
+            list(
+                APPEND find_filters
+                "NO_SYSTEM_ENVIRONMENT_PATH"
+                "NO_CMAKE_PACKAGE_REGISTRY"
+                "NO_CMAKE_SYSTEM_PATH"
+                "NO_CMAKE_SYSTEM_PACKAGE_REGISTRY"
+            )
+        elseif (search_strategy STREQUAL "SYSTEM")
+            list(APPEND find_filters "")
+        else()
+            message(FATAL_ERROR "invalid search strategy: ${search_strategy}")
+        endif()
+
+        # Start by searching for the cmake config file from AWS-LC:
+        # https://github.com/aws/aws-lc/blob/0fed4dbc456406bdaf7158fd55d05a52d9998ce4/crypto/cmake/crypto-config.cmake
+        find_package(crypto CONFIG QUIET ${find_filters})
+        if(crypto_FOUND)
+            message(STATUS "Using libcrypto config from ${crypto_CONFIG}")
+            # If a crypto-config.cmake file is found, it's assumed to be from AWS-LC, which defines the
+            # AWS::crypto target.
+            set(LINK_LIB "AWS::crypto" PARENT_SCOPE)
+            return()
+        else()
+            # Next, if a crypto-config.cmake file isn't found, search for the OpenSSL cmake config file.
+            find_package(OpenSSL CONFIG QUIET ${find_filters})
+            if(OpenSSL_FOUND)
+                message(STATUS "Using OpenSSL libcrypto config from ${OpenSSL_CONFIG}")
+                set(LINK_LIB "OpenSSL::Crypto" PARENT_SCOPE)
+                return()
+            else()
+                # Next, if an OpenSSL config isn't found, search directly for libcrypto artifacts with
+                # the Findcrypto.cmake module as a last resort.
+                find_package(crypto MODULE QUIET)
+                if (crypto_FOUND)
+                    message(STATUS "Using libcrypto discovered by Findcrypto.cmake.")
+                    # Findcrypto.cmake defines the AWS::crypto target for whatever libcrypto it
+                    # manages to discover.
+                    set(LINK_LIB "AWS::crypto" PARENT_SCOPE)
+                    return()
+                endif()
+            endif()
+        endif()
+    endforeach()
+
+    if(NOT DEFINED LINK_LIB)
+        message(FATAL_ERROR "Failed to find a libcrypto.")
+    endif()
+endfunction()
+
 # Work around target differences
 if (TARGET crypto)
     message(STATUS "S2N found target: crypto")
     set(LINK_LIB "crypto")
 else()
-    # Begin the search for a libcrypto.
-    #
-    # Start by searching for the cmake config file from AWS-LC:
-    # https://github.com/aws/aws-lc/blob/0fed4dbc456406bdaf7158fd55d05a52d9998ce4/crypto/cmake/crypto-config.cmake
-    find_package(crypto CONFIG)
-    if(crypto_FOUND)
-        message(STATUS "Using libcrypto config from ${crypto_CONFIG}")
-        # If a crypto-config.cmake file is found, it's assumed to be from AWS-LC, which defines the
-        # AWS::crypto target.
-        set(LINK_LIB "AWS::crypto")
-    else()
-        # Next, if a crypto-config.cmake file isn't found, search for the OpenSSL cmake config file.
-        find_package(OpenSSL CONFIG)
-        if(OpenSSL_FOUND)
-            message(STATUS "Using OpenSSL libcrypto config from ${OpenSSL_CONFIG}")
-            set(LINK_LIB "OpenSSL::Crypto")
-        else()
-            # Next, if an OpenSSL config isn't found, search directly for libcrypto artifacts with
-            # the Findcrypto.cmake module as a last resort.
-            find_package(crypto REQUIRED MODULE)
-            message(STATUS "Using libcrypto discovered by Findcrypto.cmake")
-            # Findcrypto.cmake defines the AWS::crypto target for whatever libcrypto it manages to
-            # discover.
-            set(LINK_LIB "AWS::crypto")
-        endif()
-    endif()
+    find_libcrypto()
 endif()
 
 if (S2N_INTERN_LIBCRYPTO)

--- a/cmake/modules/Findcrypto.cmake
+++ b/cmake/modules/Findcrypto.cmake
@@ -37,6 +37,7 @@ else()
         "${CMAKE_PREFIX_PATH}"
         "${CMAKE_INSTALL_PREFIX}"
         PATH_SUFFIXES include
+        ${find_filters}
     )
 
     find_library(crypto_SHARED_LIBRARY
@@ -45,6 +46,7 @@ else()
         "${CMAKE_PREFIX_PATH}"
         "${CMAKE_INSTALL_PREFIX}"
         PATH_SUFFIXES build/crypto build lib64 lib
+        ${find_filters}
     )
 
     find_library(crypto_STATIC_LIBRARY
@@ -53,6 +55,7 @@ else()
         "${CMAKE_PREFIX_PATH}"
         "${CMAKE_INSTALL_PREFIX}"
         PATH_SUFFIXES build/crypto build lib64 lib
+        ${find_filters}
     )
 
     if (NOT crypto_LIBRARY)


### PR DESCRIPTION
### Release Summary:
- OpenSSL CMake configs are now discoverable when searching for a libcrypto to link to, allowing s2n-tls to more easily link to OpenSSL installations with complex linking requirements such as a dependency on zlib.

### Resolved issues:

resolves https://github.com/aws/s2n-tls/issues/5078

### Description of changes: 

Currently, s2n-tls has a two-step process for discovering a libcrypto to link to. First, we search for [AWS-LC's crypto-config.cmake file](https://github.com/aws/aws-lc/blob/2e0d2bd2dd1b303de102ab2cfb7ff1ee69a0f4c9/crypto/cmake/crypto-config.cmake) somewhere on the system or in the user's provided paths, which provides the `AWS::crypto` target populated with everything we need to link to AWS-LC. Secondly, if we can't find AWS-LC's config, we search directly for `libcrypto.a`/`libcrypto.so` artifacts using [our Findcrypto.cmake module](https://github.com/aws/s2n-tls/blob/73720795dbc37d295592f427e8c225cfafef39a0/cmake/modules/Findcrypto.cmake). This search is performed by [find_package()](https://github.com/aws/s2n-tls/blob/73720795dbc37d295592f427e8c225cfafef39a0/CMakeLists.txt#L271), which [we configure to prefer AWS-LC's CMake config vs our Findcrypto module](https://github.com/aws/s2n-tls/blob/73720795dbc37d295592f427e8c225cfafef39a0/CMakeLists.txt#L15C5-L15C37).

In some cases, the libcrypto is configured with complex linking requirements that cannot be resolved by our Findcrypto module. For example, some OpenSSL installations are configured with a dependency on zlib. With this configuration, s2n-tls must link to zlib in addition to the libcrypto or the build will fail (see https://github.com/aws/s2n-tls/issues/5075#issuecomment-2629986416). However, our Findcrypto module can't know information like this without being told. So, the current solution is to manually provide s2n-tls with additional linking flags with something like:
```
export LDFLAGS="-Wl,--no-as-needed -lcrypto -lz -lzstd -ldl -pthread"
```

This PR adds a new step to the libcrypto discovery process to search for a CMake config provided by OpenSSL, which includes the necessary information to properly link to the particular OpenSSL installation. The search order is now as follows:
1. Look for AWS-LC's CMake config
2. Look for OpenSSL's CMake config
3. Use our Findcrypto module as a last resort to search for libcrypto artifacts. If the libcrypto requires additional linker flags, the user must provide them.

### Call-outs:

If implemented naively, this new search order could lead to unexpected behavior. Consider, for example, the user provides a path to the libcrypto they want to link to, but the libcrypto installation they point to doesn't contain an AWS-LC CMake config or an OpenSSL CMake config. Then, s2n-tls must use the Findcrypto module to discover their desired libcrypto. However, their system will likely contain an OpenSSL installation with an OpenSSL config. With the new search step added, s2n-tls will discover this system installation before the provided installation. This wasn't a problem before since AWS-LC is typically not included in a system path.

To resolve this issue, we first search for configs/libcrypto artifacts only from user-provided paths (like `CMAKE_PREFIX_PATH`). Then, if we don't find anything, we search in system paths. So the actual search process is the following:
1. Look for AWS-LC's CMake config in user paths
2. Look for OpenSSL's CMake config in user paths
3. Look for libcrypto artifacts with Findcrypto in user paths
4. Look for AWS-LC's CMake config in system paths
5. Look for OpenSSL's CMake config in system paths
6. Look for libcrypto artifacts with Findcrypto in system paths

### Testing:

Ubuntu 25 is an example of an operating system that has a system OpenSSL installation with a zlib dependency. Without this change, the build fails:
```
> cmake . -Bbuild \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_INSTALL_PREFIX=./s2n-tls-install
...
-- Found crypto: /usr/lib/x86_64-linux-gnu/libcrypto.a
-- LibCrypto Include Dir: /usr/include
-- LibCrypto Shared Lib:  /usr/lib/x86_64-linux-gnu/libcrypto.so
-- LibCrypto Static Lib:  /usr/lib/x86_64-linux-gnu/libcrypto.a
...
> cmake --build build
...
[ 26%] Built target testss2n
[ 26%] Building C object CMakeFiles/s2n_3des_test.dir/tests/unit/s2n_3des_test.c.o
[ 26%] Linking C executable bin/s2n_3des_test
/usr/bin/ld: /usr/lib/x86_64-linux-gnu/libcrypto.a(libcrypto-lib-c_zlib.o): in function `zlib_stateful_expand_block':
(.text+0x89): undefined reference to `inflate'
/usr/bin/ld: /usr/lib/x86_64-linux-gnu/libcrypto.a(libcrypto-lib-c_zlib.o): in function `zlib_stateful_compress_block':
(.text+0x133): undefined reference to `deflate'
```

With this change the build succeeds:
```
> cmake . -Bbuild
    -DCMAKE_BUILD_TYPE=Release
    -DCMAKE_INSTALL_PREFIX=./s2n-tls-install
...
-- Using OpenSSL libcrypto config from /usr/lib/x86_64-linux-gnu/cmake/OpenSSL/OpenSSLConfig.cmake
...
> cmake --build build
...
[100%] Built target s2nd
[100%] Building C object CMakeFiles/policy.dir/bin/policy.c.o
[100%] Linking C executable bin/policy
[100%] Built target policy
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
