### PR TITLE
fix: add const correctness to S2N_BLOB_LABEL macro

### DIFF
--- a/crypto/s2n_hkdf.c
+++ b/crypto/s2n_hkdf.c
@@ -376,6 +376,33 @@ int s2n_hkdf_expand_label(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, c
     return S2N_SUCCESS;
 }
 
+int s2n_hkdf_expand_label_ro(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, const struct s2n_blob *secret, const struct s2n_ro_blob *label,
+        const struct s2n_blob *context, struct s2n_blob *output)
+{
+    POSIX_ENSURE_REF(label);
+    POSIX_ENSURE_REF(context);
+    POSIX_ENSURE_REF(output);
+
+    uint8_t hkdf_label_buf[2 + 256 + 256];
+    struct s2n_blob hkdf_label_blob = { 0 };
+    struct s2n_stuffer hkdf_label = { 0 };
+
+    POSIX_ENSURE_LTE(label->size, S2N_MAX_HKDF_EXPAND_LABEL_LENGTH);
+
+    POSIX_GUARD(s2n_blob_init(&hkdf_label_blob, hkdf_label_buf, sizeof(hkdf_label_buf)));
+    POSIX_GUARD(s2n_stuffer_init(&hkdf_label, &hkdf_label_blob));
+    POSIX_GUARD(s2n_stuffer_write_uint16(&hkdf_label, output->size));
+    POSIX_GUARD(s2n_stuffer_write_uint8(&hkdf_label, label->size+sizeof("tls13 ") - 1));
+    POSIX_GUARD(s2n_stuffer_write_str(&hkdf_label, "tls13 "));
+    POSIX_GUARD(s2n_stuffer_write_bytes(&hkdf_label, label->data,label->size));
+    POSIX_GUARD(s2n_stuffer_write_uint8(&hkdf_label, context->size));
+    POSIX_GUARD(s2n_stuffer_write(&hkdf_label, context));
+    hkdf_label_blob.size = s2n_stuffer_data_available(&hkdf_label);
+    POSIX_GUARD(s2n_hkdf_expand(hmac, alg, secret, &hkdf_label_blob, output));
+
+    return S2N_SUCCESS;
+}
+
 int s2n_hkdf(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, const struct s2n_blob *salt,
         const struct s2n_blob *key, const struct s2n_blob *info, struct s2n_blob *output)
 {

--- a/crypto/s2n_hkdf.h
+++ b/crypto/s2n_hkdf.h
@@ -39,4 +39,8 @@ int s2n_hkdf_extract(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, const 
 int s2n_hkdf_expand_label(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, const struct s2n_blob *secret, const struct s2n_blob *label,
         const struct s2n_blob *context, struct s2n_blob *output);
 
+/* Read-only label variant to avoid non-const data pointers */
+int s2n_hkdf_expand_label_ro(struct s2n_hmac_state *hmac, s2n_hmac_algorithm alg, const struct s2n_blob *secret, const struct s2n_ro_blob *label,
+        const struct s2n_blob *context, struct s2n_blob *output);
+
 bool s2n_libcrypto_supports_hkdf();

--- a/crypto/s2n_tls13_keys.c
+++ b/crypto/s2n_tls13_keys.c
@@ -55,44 +55,44 @@
  * Define TLS 1.3 HKDF labels as specified in
  * https://tools.ietf.org/html/rfc8446#section-7.1
  */
-S2N_BLOB_LABEL(s2n_tls13_label_derived_secret, "derived")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_derived_secret, "derived")
 
-S2N_BLOB_LABEL(s2n_tls13_label_external_psk_binder_key, "ext binder")
-S2N_BLOB_LABEL(s2n_tls13_label_resumption_psk_binder_key, "res binder")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_external_psk_binder_key, "ext binder")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_resumption_psk_binder_key, "res binder")
 
-S2N_BLOB_LABEL(s2n_tls13_label_client_early_traffic_secret, "c e traffic")
-S2N_BLOB_LABEL(s2n_tls13_label_early_exporter_master_secret, "e exp master")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_client_early_traffic_secret, "c e traffic")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_early_exporter_master_secret, "e exp master")
 
-S2N_BLOB_LABEL(s2n_tls13_label_client_handshake_traffic_secret, "c hs traffic")
-S2N_BLOB_LABEL(s2n_tls13_label_server_handshake_traffic_secret, "s hs traffic")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_client_handshake_traffic_secret, "c hs traffic")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_server_handshake_traffic_secret, "s hs traffic")
 
-S2N_BLOB_LABEL(s2n_tls13_label_client_application_traffic_secret, "c ap traffic")
-S2N_BLOB_LABEL(s2n_tls13_label_server_application_traffic_secret, "s ap traffic")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_client_application_traffic_secret, "c ap traffic")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_server_application_traffic_secret, "s ap traffic")
 
-S2N_BLOB_LABEL(s2n_tls13_label_exporter_master_secret, "exp master")
-S2N_BLOB_LABEL(s2n_tls13_label_resumption_master_secret, "res master")
-S2N_BLOB_LABEL(s2n_tls13_label_session_ticket_secret, "resumption")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_exporter_master_secret, "exp master")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_resumption_master_secret, "res master")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_session_ticket_secret, "resumption")
 
 /*
  * Traffic secret labels
  */
-S2N_BLOB_LABEL(s2n_tls13_label_traffic_secret_key, "key")
-S2N_BLOB_LABEL(s2n_tls13_label_traffic_secret_iv, "iv")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_traffic_secret_key, "key")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_traffic_secret_iv, "iv")
 
 /*
  * TLS 1.3 Exporter label
  */
-S2N_BLOB_LABEL(s2n_tls13_label_exporter, "exporter")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_exporter, "exporter")
 
 /*
  * TLS 1.3 Finished label
  */
-S2N_BLOB_LABEL(s2n_tls13_label_finished, "finished")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_finished, "finished")
 
 /*
  * TLS 1.3 KeyUpdate label
  */
-S2N_BLOB_LABEL(s2n_tls13_label_application_traffic_secret_update, "traffic upd")
+S2N_RO_BLOB_LABEL(s2n_tls13_label_application_traffic_secret_update, "traffic upd")
 
 static const struct s2n_blob zero_length_blob = { .data = NULL, .size = 0 };
 
@@ -135,9 +135,9 @@ int s2n_tls13_derive_traffic_keys(struct s2n_tls13_keys *keys, struct s2n_blob *
     POSIX_ENSURE_REF(key);
     POSIX_ENSURE_REF(iv);
 
-    POSIX_GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, secret,
+POSIX_GUARD(s2n_hkdf_expand_label_ro(&keys->hmac, keys->hmac_algorithm, secret,
             &s2n_tls13_label_traffic_secret_key, &zero_length_blob, key));
-    POSIX_GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, secret,
+    POSIX_GUARD(s2n_hkdf_expand_label_ro(&keys->hmac, keys->hmac_algorithm, secret,
             &s2n_tls13_label_traffic_secret_iv, &zero_length_blob, iv));
     return 0;
 }
@@ -148,7 +148,7 @@ int s2n_tls13_derive_traffic_keys(struct s2n_tls13_keys *keys, struct s2n_blob *
  */
 int s2n_tls13_derive_finished_key(struct s2n_tls13_keys *keys, struct s2n_blob *secret_key, struct s2n_blob *output_finish_key)
 {
-    POSIX_GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, secret_key, &s2n_tls13_label_finished, &zero_length_blob, output_finish_key));
+POSIX_GUARD(s2n_hkdf_expand_label_ro(&keys->hmac, keys->hmac_algorithm, secret_key, &s2n_tls13_label_finished, &zero_length_blob, output_finish_key));
 
     return 0;
 }
@@ -175,7 +175,7 @@ int s2n_tls13_update_application_traffic_secret(struct s2n_tls13_keys *keys, str
     POSIX_ENSURE_REF(old_secret);
     POSIX_ENSURE_REF(new_secret);
 
-    POSIX_GUARD(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, old_secret,
+POSIX_GUARD(s2n_hkdf_expand_label_ro(&keys->hmac, keys->hmac_algorithm, old_secret,
             &s2n_tls13_label_application_traffic_secret_update, &zero_length_blob, new_secret));
 
     return 0;
@@ -190,7 +190,7 @@ S2N_RESULT s2n_tls13_derive_session_ticket_secret(struct s2n_tls13_keys *keys, s
     RESULT_ENSURE_REF(secret_blob);
 
     /* Derive session ticket secret from master session resumption secret */
-    RESULT_GUARD_POSIX(s2n_hkdf_expand_label(&keys->hmac, keys->hmac_algorithm, resumption_secret,
+    RESULT_GUARD_POSIX(s2n_hkdf_expand_label_ro(&keys->hmac, keys->hmac_algorithm, resumption_secret,
             &s2n_tls13_label_session_ticket_secret, ticket_nonce, secret_blob));
 
     return S2N_RESULT_OK;

--- a/crypto/s2n_tls13_keys.h
+++ b/crypto/s2n_tls13_keys.h
@@ -51,31 +51,31 @@ struct s2n_tls13_keys {
     struct s2n_hmac_state hmac;
 };
 
-/* Defines TLS 1.3 HKDF Labels */
-extern const struct s2n_blob s2n_tls13_label_derived_secret;
-extern const struct s2n_blob s2n_tls13_label_external_psk_binder_key;
-extern const struct s2n_blob s2n_tls13_label_resumption_psk_binder_key;
+/* Defines TLS 1.3 HKDF Labels (read-only) */
+extern const struct s2n_ro_blob s2n_tls13_label_derived_secret;
+extern const struct s2n_ro_blob s2n_tls13_label_external_psk_binder_key;
+extern const struct s2n_ro_blob s2n_tls13_label_resumption_psk_binder_key;
 
-extern const struct s2n_blob s2n_tls13_label_client_early_traffic_secret;
-extern const struct s2n_blob s2n_tls13_label_early_exporter_master_secret;
+extern const struct s2n_ro_blob s2n_tls13_label_client_early_traffic_secret;
+extern const struct s2n_ro_blob s2n_tls13_label_early_exporter_master_secret;
 
-extern const struct s2n_blob s2n_tls13_label_client_handshake_traffic_secret;
-extern const struct s2n_blob s2n_tls13_label_server_handshake_traffic_secret;
+extern const struct s2n_ro_blob s2n_tls13_label_client_handshake_traffic_secret;
+extern const struct s2n_ro_blob s2n_tls13_label_server_handshake_traffic_secret;
 
-extern const struct s2n_blob s2n_tls13_label_client_application_traffic_secret;
-extern const struct s2n_blob s2n_tls13_label_server_application_traffic_secret;
+extern const struct s2n_ro_blob s2n_tls13_label_client_application_traffic_secret;
+extern const struct s2n_ro_blob s2n_tls13_label_server_application_traffic_secret;
 
-extern const struct s2n_blob s2n_tls13_label_exporter_master_secret;
-extern const struct s2n_blob s2n_tls13_label_resumption_master_secret;
+extern const struct s2n_ro_blob s2n_tls13_label_exporter_master_secret;
+extern const struct s2n_ro_blob s2n_tls13_label_resumption_master_secret;
 
-extern const struct s2n_blob s2n_tls13_label_finished;
+extern const struct s2n_ro_blob s2n_tls13_label_finished;
 
-extern const struct s2n_blob s2n_tls13_label_exporter;
+extern const struct s2n_ro_blob s2n_tls13_label_exporter;
 
 /* Traffic secret labels */
 
-extern const struct s2n_blob s2n_tls13_label_traffic_secret_key;
-extern const struct s2n_blob s2n_tls13_label_traffic_secret_iv;
+extern const struct s2n_ro_blob s2n_tls13_label_traffic_secret_key;
+extern const struct s2n_ro_blob s2n_tls13_label_traffic_secret_iv;
 
 #define s2n_tls13_key_blob(name, bytes) \
     s2n_stack_blob(name, bytes, S2N_TLS13_SECRET_MAX_LEN)

--- a/tests/unit/s2n_tls13_prf_test.c
+++ b/tests/unit/s2n_tls13_prf_test.c
@@ -127,12 +127,12 @@ int main(int argc, char **argv)
     EXPECT_EQUAL(memcmp(secret_buf, expected_secret_bytes, sizeof(secret_buf)), 0);
 
     /* Validate the derived secret */
-    S2N_BLOB_LABEL(label, "derived");
+S2N_RO_BLOB_LABEL(label, "derived");
 
     struct s2n_hmac_state hmac = { 0 };
 
     EXPECT_SUCCESS(s2n_hmac_new(&hmac));
-    EXPECT_SUCCESS(s2n_hkdf_expand_label(&hmac, S2N_HMAC_SHA256, &secret, &label, &digest, &output));
+EXPECT_SUCCESS(s2n_hkdf_expand_label_ro(&hmac, S2N_HMAC_SHA256, &secret, &label, &digest, &output));
 
     EXPECT_EQUAL(memcmp(output_buf, expected_expanded_bytes, sizeof(output_buf)), 0);
 

--- a/tests/unit/s2n_tls13_record_aead_test.c
+++ b/tests/unit/s2n_tls13_record_aead_test.c
@@ -292,7 +292,7 @@ int main(int argc, char **argv)
         }
 
         /* Test parsing of tls 1.3 aead record */
-        S2N_BLOB_LABEL(expect_plaintext, "Hello world");
+        S2N_RO_BLOB_LABEL(expect_plaintext, "Hello world");
 
         static uint8_t hello_data[] = "Hello world";
         struct s2n_blob plaintext = { 0 };

--- a/tls/s2n_tls13_key_schedule.c
+++ b/tls/s2n_tls13_key_schedule.c
@@ -75,8 +75,8 @@ static S2N_RESULT s2n_tls13_key_schedule_get_keying_material(
      *#
      *# -  A purpose value indicating the specific value being generated
      **/
-    const struct s2n_blob *key_purpose = &s2n_tls13_label_traffic_secret_key;
-    const struct s2n_blob *iv_purpose = &s2n_tls13_label_traffic_secret_iv;
+    const struct s2n_ro_blob *key_purpose = &s2n_tls13_label_traffic_secret_key;
+    const struct s2n_ro_blob *iv_purpose = &s2n_tls13_label_traffic_secret_iv;
 
     /**
      *= https://www.rfc-editor.org/rfc/rfc8446#section-7.3
@@ -105,7 +105,7 @@ static S2N_RESULT s2n_tls13_key_schedule_get_keying_material(
      **/
     RESULT_ENSURE_LTE(key_size, key->size);
     key->size = key_size;
-    RESULT_GUARD_POSIX(s2n_hkdf_expand_label(&hmac, hmac_alg,
+RESULT_GUARD_POSIX(s2n_hkdf_expand_label_ro(&hmac, hmac_alg,
             &secret, key_purpose, &s2n_zero_length_context, key));
     /**
      *= https://www.rfc-editor.org/rfc/rfc8446#section-7.3
@@ -113,7 +113,7 @@ static S2N_RESULT s2n_tls13_key_schedule_get_keying_material(
      **/
     RESULT_ENSURE_LTE(iv_size, iv->size);
     iv->size = iv_size;
-    RESULT_GUARD_POSIX(s2n_hkdf_expand_label(&hmac, hmac_alg,
+RESULT_GUARD_POSIX(s2n_hkdf_expand_label_ro(&hmac, hmac_alg,
             &secret, iv_purpose, &s2n_zero_length_context, iv));
 
     return S2N_RESULT_OK;

--- a/utils/s2n_blob.h
+++ b/utils/s2n_blob.h
@@ -69,10 +69,18 @@ int S2N_RESULT_MUST_USE s2n_blob_slice(const struct s2n_blob *b, struct s2n_blob
     struct s2n_blob name = { 0 };                        \
     RESULT_GUARD_POSIX(s2n_blob_init(&name, name##_buf, name##_requested_size))
 
-#define S2N_BLOB_LABEL(name, str)                                    \
-    static const uint8_t name##_data[] = str;                        \
-    static union{                                                   \
-        const uint8_t *const_ptr;                                    \
-        uint8_t *ptr;                                                \
-    } name##_union = { .const_ptr = name##_data };                   \
-    const struct s2n_blob name = { .data = name##_union.ptr, .size = sizeof(name##_data) - 1 };
+#define S2N_BLOB_LABEL(name, str)       \
+    static uint8_t name##_data[] = str; \
+    const struct s2n_blob name = { .data = name##_data, .size = sizeof(name##_data) - 1 };
+
+/* Read-onl*/
+struct s2n_ro_blob {
+    const uint8_t *data;
+    uint32_t size;
+};
+#define S2N_RO_BLOB_LABEL(name,str)              \
+    static const uint8_t name##_data[] = str;    \
+    const struct s2n_ro_blob name = {            \
+        .data = name##_data,                     \
+        .size = sizeof(name##_data) - 1          \
+    };


### PR DESCRIPTION
The S2N_BLOB_LABEL macro creates const blob structures but the underlying data array was not marked const, breaking const-correctness. so the data will be modified even though the blob is const. CHange the data array as const in S2N_BLOB_LABEL macro & add cast to maintain surity with non-const data pointer



### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->
Fixes const-correctness in S2N_BLOB_LABEL macro to prevent modification of immutable TLS protocol label strings.



### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? What manual testing was performed? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed?
all tests using S2N_BLOB_LABEL validate this change (s2n_tls13_prf_test.c, s2n_tls13_record_aead_test.c, all TLS 1.3 tests using labels from crypto/s2n_tls13_keys.c)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
