### PR TITLE
ci: pin to older kissat version to unblock CBMC

### DIFF
--- a/.github/workflows/proof_ci_resources/config.yaml
+++ b/.github/workflows/proof_ci_resources/config.yaml
@@ -1,7 +1,7 @@
 cadical-tag: latest
 cbmc-version: "6.2.0"
 cbmc-viewer-version: latest
-kissat-tag: latest
+kissat-tag: "rel-4.0.3"
 litani-version: latest
 z3-version: "4.13.0"
 bitwuzla-version: "0.5.0"


### PR DESCRIPTION
### Description of changes: 

Looks like something in last week's kissat release is causing one or more of our CBMC proofs to hang indefinitely: https://github.com/arminbiere/kissat/releases/tag/rel-4.0.4

For now, pin to the last release.

### Call-outs:

I notice we have a couple other CBMC dependencies in there pinned. We probably need to do some cleanup.

### Testing:

CBMC job now succeeds.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
