### PR TITLE
fix: update test_pq_only policy snapshot

### DIFF
--- a/tests/policy_snapshot/snapshots/test_pq_only
+++ b/tests/policy_snapshot/snapshots/test_pq_only
@@ -1,4 +1,3 @@
-name: test_pq_only
 min version: TLS1.3
 rules:
 - Perfect Forward Secrecy: no


### PR DESCRIPTION
### Description of changes: 

Jou's PR #5502 changed the security policy snapshot format while my PR #5545 uploaded a new snapshot for `test_pq_only` policy. These two PRs were added to the merge queue roughly at the same time so they both got merged.

Now the [snapshot test failed](https://github.com/aws/s2n-tls/actions/runs/18791707608/job/53623315446) on our main branch. This PR will update the `test_pq_only` policy snapshot to the latest format.

### Testing:

CI should pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
