### PR TITLE
docs: update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,9 @@
 ## How
 <!-- How is this PR accomplishing its goals? -->
 
+## Callouts
+<!-- Any specific item to callout? Non-optimal choices, future actions needed, etc -->
+
 ## Testing
 <!-- How is it tested? -->
 


### PR DESCRIPTION
# Goal

Simplify the PR template

## Why

Our current PR template includes lots of "developer documentation" which is not applicable to most PRs. Additionally, the most important item to document for a PR is _why_ it is being done. This new PR format forces contributors to specify that.

## How

We delete the old template and add a new one

Note that this might require some changes to the release note script
## Testing

None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
