### PR TITLE
ci: PR conventional commit lint GHA

### DIFF
--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -149,3 +149,18 @@ jobs:
           exit 1
       - name: Success
         run: echo "All nix files passed format check"
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: PR Conventional Commit Validation
+        id: cc_check
+        uses: ytanikin/pr-conventional-commits@1.4.0
+        with:
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          add_label: 'false'
+      - name: Failure case
+        if: steps.cc_check.outcome != 'success'
+        run: |
+          echo "Make sure the PR title/commit follows https://www.conventionalcommits.org/"
+          exit 1


### PR DESCRIPTION
# Goal

Ensure automated release note generation can find relevant comments in the PR/commit history.

## Why
Enforce consistency.

## How

The GitHub action will parse the PR title/final squashed commit message and make sure it follows the [conventional commit](https://www.conventionalcommits.org) formatting.

## Callouts


## Testing
CI.

### Related

Replaces https://github.com/aws/s2n-tls/pull/5598

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
