### PR TITLE
ci: move the integnix job to us-west-2

### DIFF
--- a/codebuild/bin/start_codebuild.sh
+++ b/codebuild/bin/start_codebuild.sh
@@ -26,7 +26,7 @@ BUILDS=(
     "s2nFuzzBatch"
     "s2nGeneralBatch"
     "s2nUnitNix"
-    "Integv2NixBatchBF1FB83F-7tcZOiMDWPH0 us-east-2 batch"
+    "Integv2NixBatch"
     "kTLS us-west-2 no-batch"
     "kTLSKeyUpdate us-west-2 no-batch"
 )

--- a/codebuild/spec/buildspec_integ_rust.yml
+++ b/codebuild/spec/buildspec_integ_rust.yml
@@ -18,7 +18,7 @@ batch:
         variables:
           NIXDEV_ARGS: --max-jobs auto
           NIXDEV_LIBCRYPTO: .#default
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
 
     # Cache Job for aarch64
     - identifier: nixCache_aarch64
@@ -27,7 +27,7 @@ batch:
         variables:
           NIXDEV_ARGS: --max-jobs auto
           NIXDEV_LIBCRYPTO: .#default
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
     # OpenSSL 1.0.2 x86
     - identifier: Rust_openssl102_x86_0
@@ -37,7 +37,7 @@ batch:
         fleet: ubuntu24_x86_64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#rust_openssl102
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
 
     # OpenSSL 1.0.2 aarch64
     - identifier: Rust_openssl102_aarch64_0
@@ -47,7 +47,7 @@ batch:
         fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#rust_openssl102
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
     # OpenSSL 1.1.1 x86
     - identifier: Rust_openssl111_x86_0
@@ -57,7 +57,7 @@ batch:
         fleet: ubuntu24_x86_64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#rust_openssl111
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
 
     # OpenSSL 1.1.1 aarch64
     - identifier: Rust_openssl111_aarch64_0
@@ -67,7 +67,7 @@ batch:
         fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#rust_openssl111
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
     # OpenSSL 3.0 x86
     - identifier: Rust_openssl30_x86_0
@@ -77,7 +77,7 @@ batch:
         fleet: ubuntu24_x86_64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#rust_openssl30
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
 
     # OpenSSL 3.0 aarch64
     - identifier: Rust_openssl30_aarch64_0
@@ -87,7 +87,7 @@ batch:
         fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#rust_openssl30
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
     # AWS-LC x86
     - identifier: Rust_awslc_x86_0
@@ -97,7 +97,7 @@ batch:
         fleet: ubuntu24_x86_64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#rust_awslc
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
 
     # AWS-LC aarch64
     - identifier: Rust_awslc_aarch64_0
@@ -107,7 +107,7 @@ batch:
         fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#rust_awslc
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
     # AWS-LC FIPS 2024 x86
     - identifier: Rust_awslcfips2024_x86_0
@@ -117,7 +117,7 @@ batch:
         fleet: ubuntu24_x86_64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#rust_awslcfips2024
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
 
     # AWS-LC FIPS 2024 aarch64
     - identifier: Rust_awslcfips2024_aarch64_0
@@ -127,7 +127,7 @@ batch:
         fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#rust_awslcfips2024
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
 phases:
   install:

--- a/codebuild/spec/buildspec_integv2_nix.yml
+++ b/codebuild/spec/buildspec_integv2_nix.yml
@@ -19,7 +19,7 @@ batch:
           # max-jobs tell nix to use all available cores for building derivations.
           NIXDEV_ARGS: --max-jobs auto
           NIXDEV_LIBCRYPTO: .#default
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
 
     # Cache Job for aarch64
     - identifier: nixCache_aarch64
@@ -29,7 +29,7 @@ batch:
           # max-jobs tell nix to use all available cores for building derivations.
           NIXDEV_ARGS: --max-jobs auto
           NIXDEV_LIBCRYPTO: .#default
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
     # AWSLC  x86
     - identifier: Integ_awslc_x86_0
@@ -39,7 +39,7 @@ batch:
         fleet: ubuntu24_x86_64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#awslc
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
 
     # AWSLC aarch64
     - identifier: Integ_awslc_aarch64_0
@@ -49,7 +49,7 @@ batch:
         fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#awslc
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
     # AWSLC-FIPS-2022
     - identifier: Integ_awslcfips2022_x86_64_0
@@ -59,7 +59,7 @@ batch:
         fleet: ubuntu24_x86_64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#awslcfips2022
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
 
     # AWSLC-FIPS-2024
     - identifier: Integ_awslcfips2024_aarch64_0
@@ -69,7 +69,7 @@ batch:
         fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#awslcfips2024
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
     # Openssl30 x86
     - identifier: Integ_openssl30_x86_0
@@ -79,7 +79,7 @@ batch:
         fleet: ubuntu24_x86_64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#default
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodx861-ehnvuoswh2yr?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
 
     # Openssl30 aarch64
     - identifier: Integ_openssl30_aarch64_0
@@ -89,7 +89,7 @@ batch:
         fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#default
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
     # Openssl111 aarch64 only
     - identifier: Integ_openssl111_aarch64_0
@@ -99,7 +99,7 @@ batch:
         fleet: ubuntu24_aarch64_nix
         variables:
           NIXDEV_LIBCRYPTO: .#openssl111
-          NIX_CACHE_BUCKET: s3://codebuildnixinteg-prod-nixcachebucketintegprodaarc-rqyksjxh6wxa?region=us-east-2
+          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
 
 phases:
   install:


### PR DESCRIPTION
# Goal
Move the Nix Integ job from us-east-2 to us-west-2.

## Why

Change of plans; we no longer expect an explosion of platform dimensions in our testing.

## How

This re-uses the existing s3 nix cache buckets in the region, and just updates the buildspec and the name of the job.

## Callouts

This CR points the job at the s3 cache buckets in us-west-2, to make them live in the same region as the CodeBuild job runs in. These buckets were from the inital nix cache s3 work.  Once this move is done, the jobs and s3 buckets in us-east-2 will no longer be used and can be cleaned up.

The Ec2 fleets are also regional, with one fleet in each region, using the same name. Like the buckets, these can be cleaned after.

## Testing

Ad-hoc jobs in CodeBuild

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
