### PR TITLE
fix(ci): add `build` to the validate-pr-title CI job

### DIFF
--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -157,7 +157,7 @@ jobs:
         id: cc_check
         uses: ytanikin/pr-conventional-commits@1.4.0
         with:
-          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert","build"]'
           add_label: 'false'
       - name: Failure case
         if: steps.cc_check.outcome != 'success'


### PR DESCRIPTION
# Goal
Enable dependabot PRs to pass the CI

## Why
Dependabot PRs always start with `build`. Currently, it's not allowed by the validate-pr-title CI job, causing dependabot PRs to [fail the CI](https://github.com/aws/s2n-tls/actions/runs/19182455526/job/55008221207?pr=5605). This PR will fix it.

## How
Add the keyword `build` to the valid PR title list specified in the validate-pr-title job.

## Testing
CI should pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
