### PR TITLE
ci: exclude `validate-pr-title` from merge queue

### DIFF
--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -155,6 +155,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: PR Conventional Commit Validation
         id: cc_check
+        if: github.event_name == 'pull_request_target'
         uses: ytanikin/pr-conventional-commits@1.4.2
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert","build"]'


### PR DESCRIPTION
# Goal
`validate-pr-title` job should succeed on the main branch.

## Why
Currently, the `validate-pr-title` job [failed on the main branch](https://github.com/aws/s2n-tls/actions/runs/19247247438/job/55024129742) even if it succeeded on PR.

## How
Add an `if` statement to each step in the job; thus it's not executed when PRs are merged to main.

## Testing
CI should pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
