### PR TITLE
fix: replace `uint8_t` in for loops

### DIFF
--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -1844,7 +1844,7 @@ bool s2n_security_policy_supports_tls13(const struct s2n_security_policy *securi
         return false;
     }
 
-    for (uint8_t i = 0; security_policy_selection[i].version != NULL; i++) {
+    for (size_t i = 0; security_policy_selection[i].version != NULL; i++) {
         if (security_policy_selection[i].security_policy == security_policy) {
             return security_policy_selection[i].supports_tls13 == 1;
         }
@@ -1941,7 +1941,7 @@ S2N_RESULT s2n_security_policy_get_version(const struct s2n_security_policy *sec
 {
     RESULT_ENSURE_REF(version);
     *version = NULL;
-    for (uint8_t i = 0; security_policy_selection[i].version != NULL; i++) {
+    for (size_t i = 0; security_policy_selection[i].version != NULL; i++) {
         if (security_policy_selection[i].security_policy == security_policy) {
             *version = security_policy_selection[i].version;
             return S2N_RESULT_OK;


### PR DESCRIPTION
# Goal
Prevent potential timeout in unit tests

## Why
The for loops in `s2n_security_policy_get_version()` and `s2n_security_policy_supports_tls13()` use `uint8_t i = 0`, which can only hold values from 0 to 255. Currently, s2n-tls has only 140 security policies, so everything is fine. However, as we add more policies in the future, the number of policies will eventually exceed the range of `uint8_t`.

Additionally, some unit tests define their own testing policies that do not exist in the `security_policy_selection` array. In this case, the only way to exit these for loops is to hit the `security_policy_selection[i].version == NULL` condition (i.e. the last element in `security_policy_selection`). If the last policy with `version = NULL` is out of range, these two for loops will become infinite and lead to timeout failure.

## How
Replace `uint8_t` with another date type of a larger range like `size_t`

## Testing
I found timeout failure in 25 s2n-tls unit tests by creating 120 copies of the `test_all` policy and exceeding the `uint8_t` range. After applying the fix in this PR, all the timeout failures went away.

I don't think our CI jobs enable the `--timeout` flag, so I only ran the testing locally via
```
CTEST_PARALLEL_LEVEL=$(nproc) ctest --test-dir build --timeout 120
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
