### PR TITLE
ci: add rust integration test to codebuild start script

### DIFF
--- a/codebuild/bin/start_codebuild.sh
+++ b/codebuild/bin/start_codebuild.sh
@@ -26,6 +26,7 @@ BUILDS=(
     "s2nFuzzBatch"
     "s2nGeneralBatch"
     "s2nUnitNix"
+    "IntegRustNixBatch"
     "Integv2NixBatch"
     "kTLS us-west-2 no-batch"
     "kTLSKeyUpdate us-west-2 no-batch"


### PR DESCRIPTION
# Goal
Add the Rust integration test job ([IntegRustNixBatch](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiZGNqTXFPRU1FdzRFaWltbmRkWDZjaUhoekhrMGZtYVdPUWQyUUZaREJUWUdCbXplRVM0cG1qSXdXZ083T0U4WHlDanJpQUVsR3l1R2pRNXBtMDZaN2MzVHIwMTRIMTFobkl3R3lXY3o3NmlFY3c9PSIsIml2UGFyYW1ldGVyU3BlYyI6InJVTm90NnZoeGx2eExrcloiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D?tab=builds)) to the CodeBuild batch list so it runs automatically as part of the CI pipeline.

## Why
The Rust integration test was recently added to Codebuild and is now stable after the [dynamic record sizing in TLS 1.2 PR](https://github.com/aws/s2n-tls/pull/5614) and the [capability gating fixes PR](https://github.com/aws/s2n-tls/pull/5621). However, it is not yet being executed in CI because it was never added to the start_codebuild script.

## How
This PR adds a single entry to the BUILDS array in codebuild/bin/start_codebuild.sh

## Testing
Ran the updated script locally and confirmed that the Rust integration job is invoked and succeeds. The script ran on this PR, you can see the batch build for the IntegRustNixBatch as part of the checks on this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
