### PR TITLE
chore: s2n-tls-hyper version bump

### DIFF
--- a/bindings/rust/standard/s2n-tls-hyper/Cargo.toml
+++ b/bindings/rust/standard/s2n-tls-hyper/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-hyper"
 description = "A compatbility crate allowing s2n-tls to be used with the hyper HTTP library"
-version = "0.0.21"
+version = "0.0.22"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.74.0"


### PR DESCRIPTION
# Goal
<!-- What is the PR doing? -->
Bump the s2n-tls-hyper crate versions.

## Why
<!-- Why is this PR necessary? -->
We did not bump this as part of https://github.com/aws/s2n-tls/pull/5633

## How
<!-- How is this PR accomplishing its goals? -->
Bump the patch version

## Testing
<!-- How is it tested? -->
`cargo test`

<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
