### PR TITLE
chore: remove slow aead test for valgrind

### DIFF
--- a/codebuild/spec/buildspec_valgrind.yml
+++ b/codebuild/spec/buildspec_valgrind.yml
@@ -73,6 +73,8 @@ phases:
           cd third-party-src;
         fi
       - /usr/bin/$COMPILER --version
+      - valgrind --version
+      - rm ./tests/unit/s2n_aead_aes_test.c
   build:
     on-failure: ABORT
     commands:


### PR DESCRIPTION
# Goal

Reduce the runtime of the valgrind CodeBuild job

## Why
To bring the CI runtimes under 20 minutes.

## How

The s2n-aead-aes test is a long pole, using a core for over 16 minutes [in this example](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/024603541914/projects/Valgrind/build/Valgrind%3A3392890c-13f8-4e67-ad57-a0f1b23a00af/log?region=us-west-2). Increasing the core count won't address this single test runtime.

## Callouts

Bit of a [known-issue](https://github.com/aws/s2n-tls/issues/4472).

## Testing
locally/ci.

### Related

related: https://github.com/aws/s2n-tls/issues/4472

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
