### PR TITLE
chore: Fix increase in Rust unit test timings

### DIFF
--- a/bindings/rust/extended/s2n-tls-tokio/tests/handshake.rs
+++ b/bindings/rust/extended/s2n-tls-tokio/tests/handshake.rs
@@ -144,7 +144,7 @@ async fn handshake_error_without_blinding() -> Result<(), Box<dyn std::error::Er
     builder.set_security_policy(&TESTING_TLS12)?;
 
     let server_config = builder.build()?;
-    let client_config = common::client_config()?.build()?; // Now has pq and no cbc
+    let client_config = common::client_config()?.build()?;
 
     let client = TlsConnector::new(client_config);
     let server = TlsAcceptor::new(server_config);


### PR DESCRIPTION
# Goal
This change will fix a regression we noticed in our Rust bindings unit tests.

## Why
I unknowingly caused a regression in a unit test when I added TLS13 ciphersuites to the default policy (#5560). The test was originally erroring without blinding, and my change made it error _with_ blinding. Therefore the unit test timings increased quite a lot.

## How
I just changed the server config to use the fixed TLS12 policy, instead of the default policy. I also added some time checks to assert that this test does not trigger blinding, as that was missing from the original test.

## Callouts
Another notch for #5557
## Testing
Handshake tests should now pass in one second instead of a varying between 10 and 30s.
Mainline test timing:
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 28.54s
PR test timing:
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.13s

### Related
N/A
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
