### PR TITLE
Fix: Unpin the rust nightly toolchain version

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -11,8 +11,6 @@ on:
     branches: [main]
 
 env:
-  # Pin the nightly toolchain to prevent breakage.
-  # This should be occasionally updated.
   RUST_NIGHTLY_TOOLCHAIN: nightly
   # Extended support MSRV
   ROOT_PATH: bindings/rust/extended


### PR DESCRIPTION
# Goal
Unpins the rust toolchain version of nightly

## Why
If we pin the nightly version, it doesn't seem like we're getting much benefit from testing with it.

## How
Unpinning the version of nightly makes it effective to run with the test

### Related
resolves #5350


<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.