### PR TITLE
ci: fix typo in readme

### DIFF
--- a/tests/saw/README.md
+++ b/tests/saw/README.md
@@ -25,7 +25,7 @@ specification/implementation of HMAC. Cryptol can be seen as an
 implementation because it is executable. It can be given a message and
 a key as input, and produce output. It is a specification because the
 cryptol language looks like the mathematical language that
-cryptographers like to specify cryptograpy in. It does not have many
+cryptographers like to specify cryptography in. It does not have many
 of the safety risks that a C program has, and it is typically much
 easier to read and understand than a C program.
 


### PR DESCRIPTION
# Goal
Fix the `typos` CI failure

## How
Correct the typo listed in https://github.com/aws/s2n-tls/actions/runs/21602562167/job/62252075663?pr=5705

## Testing
CI should pass

### Related
#5705 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
