### PR TITLE
Necessary changes were made in the s2n module to support AIX OS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ if(S2N_LTO)
     endif()
 endif()
 
-if(NOT APPLE)
+if(NOT APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL "AIX")
     set(CMAKE_SHARED_LINKER_FLAGS -Wl,-z,noexecstack,-z,relro,-z,now)
 endif()
 


### PR DESCRIPTION

# Goal
To support aws-sdk-cpp on AIX and to use the open source library.

## Why
Some of the linker flags are not supported on AIX.

## How
<!-- How is this PR accomplishing its goals? -->

## Callouts
<!-- Any specific item to callout? Non-optimal choices, future actions needed, etc -->

## Testing
Testing has been done through aws-sdk-cpp to use the S3 services.

### Related
<!-- E.g. "resolves #3456" -->

<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
