### PR TITLE
chore: fix sidetrail timings

### DIFF
--- a/tests/sidetrail/working/s2n-cbc/cbc.c
+++ b/tests/sidetrail/working/s2n-cbc/cbc.c
@@ -64,7 +64,10 @@ int simple_cbc_wrapper(int currently_in_hash_block, int size, int *xor_pad, int 
   struct s2n_crypto_parameters client;
   struct s2n_connection conn = {
     .client = &client,
-    .mode = S2N_SERVER
+    .mode = S2N_SERVER,
+    .extension_requests_sent = { 0 },
+    .extension_requests_received = { 0 },
+    .extension_responses_received = { 0 }
   };
 
   /* Data represents the decrypted data handed to the process.


### PR DESCRIPTION
# Goal
Reduce sidetrail runtime from 40min back to 15min.

## Why
We recently noticed a huge leap in sidetrail runtimes, from 15min to 40min after PR #5719.

## How
I initialized the fields of the extension bitfield in the proof setup on the advice of the automated reasoning team. These fields don't change the behavior of the s2n_cbc_verify function, which is what we're trying to prove anyways. [The function doesn't even touch these connection fields](https://github.com/aws/s2n-tls/blob/main/tls/s2n_cbc.c#L46-L99).

## Callouts
I think this solution is strictly better than #5727, where we're locking the proof to 15 loop unrolls.
## Testing
The runtime in the general batch for the sidetrail test is now 10 minutes.

### Related

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
