### PR TITLE
fix: Update policy writer to print if a rule is met but not required

### DIFF
--- a/tests/policy_snapshot/snapshots/20200207
+++ b/tests/policy_snapshot/snapshots/20200207
@@ -1,6 +1,6 @@
 min version: SSLv3
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/20210816
+++ b/tests/policy_snapshot/snapshots/20210816
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes (required)
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
 - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384

--- a/tests/policy_snapshot/snapshots/20210816_GCM
+++ b/tests/policy_snapshot/snapshots/20210816_GCM
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes (required)
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/20230317
+++ b/tests/policy_snapshot/snapshots/20230317
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes (required)
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/20240331
+++ b/tests/policy_snapshot/snapshots/20240331
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes (required)
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/20240416
+++ b/tests/policy_snapshot/snapshots/20240416
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes (required)
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/20240501
+++ b/tests/policy_snapshot/snapshots/20240501
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/20240502
+++ b/tests/policy_snapshot/snapshots/20240502
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes (required)
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/20240503
+++ b/tests/policy_snapshot/snapshots/20240503
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/20240730
+++ b/tests/policy_snapshot/snapshots/20240730
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/20241001
+++ b/tests/policy_snapshot/snapshots/20241001
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/20241001_pq_mixed
+++ b/tests/policy_snapshot/snapshots/20241001_pq_mixed
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/20250211
+++ b/tests/policy_snapshot/snapshots/20250211
@@ -1,7 +1,7 @@
 min version: TLS1.3
 rules:
-- Perfect Forward Secrecy: yes
-- FIPS 140-3 (2019): no
+- Perfect Forward Secrecy: yes (required)
+- FIPS 140-3 (2019): yes
 cipher suites:
 - TLS_AES_256_GCM_SHA384
 signature schemes:

--- a/tests/policy_snapshot/snapshots/20250414
+++ b/tests/policy_snapshot/snapshots/20250414
@@ -1,7 +1,7 @@
 min version: TLS1.3
 rules:
-- Perfect Forward Secrecy: yes
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes (required)
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_AES_256_GCM_SHA384
 signature schemes:

--- a/tests/policy_snapshot/snapshots/20250512
+++ b/tests/policy_snapshot/snapshots/20250512
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/20250721
+++ b/tests/policy_snapshot/snapshots/20250721
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/20251013
+++ b/tests/policy_snapshot/snapshots/20251013
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes (required)
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/20251014
+++ b/tests/policy_snapshot/snapshots/20251014
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/20251015
+++ b/tests/policy_snapshot/snapshots/20251015
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes (required)
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_AES_128_GCM_SHA256
 - TLS_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/20251113
+++ b/tests/policy_snapshot/snapshots/20251113
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: no
-- FIPS 140-3 (2019): no
+- Perfect Forward Secrecy: yes
+- FIPS 140-3 (2019): yes
 cipher suites:
 - TLS_AES_256_GCM_SHA384
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/20251114
+++ b/tests/policy_snapshot/snapshots/20251114
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: no
-- FIPS 140-3 (2019): no
+- Perfect Forward Secrecy: yes
+- FIPS 140-3 (2019): yes
 cipher suites:
 - TLS_AES_256_GCM_SHA384
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/20251117
+++ b/tests/policy_snapshot/snapshots/20251117
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: no
-- FIPS 140-3 (2019): no
+- Perfect Forward Secrecy: yes
+- FIPS 140-3 (2019): yes
 cipher suites:
 - TLS_AES_256_GCM_SHA384
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.2-2025
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.2-2025
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes (required)
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_AES_128_GCM_SHA256
 - TLS_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.3
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.3
@@ -1,6 +1,6 @@
 min version: TLS1.3
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.3-2023
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.3-2023
@@ -1,6 +1,6 @@
 min version: TLS1.3
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.3-2025-PQ
+++ b/tests/policy_snapshot/snapshots/AWS-CRT-SDK-TLSv1.3-2025-PQ
@@ -1,6 +1,6 @@
 min version: TLS1.3
 rules:
-- Perfect Forward Secrecy: no
+- Perfect Forward Secrecy: yes
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2019
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2019
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2019-Legacy
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2019-Legacy
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2019-no-sha1
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2019-no-sha1
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2019-no-sha1-no-pq
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2019-no-sha1-no-pq
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2021
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2021
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2021-Chacha20-Boosted
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2021-Chacha20-Boosted
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - chacha20 boosting enabled

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2021-no-sha1
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2021-no-sha1
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2021-no-sha1-PQ-Beta
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2021-no-sha1-PQ-Beta
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2021-no-sha1-no-pq
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2021-no-sha1-no-pq
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2025
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2025
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes (required)
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_AES_128_GCM_SHA256
 - TLS_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2025-no-pq
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-2-2025-no-pq
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes (required)
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_AES_128_GCM_SHA256
 - TLS_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-3-2025
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-3-2025
@@ -1,6 +1,6 @@
 min version: TLS1.3
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/CloudFront-TLS-1-3-2025-no-pq
+++ b/tests/policy_snapshot/snapshots/CloudFront-TLS-1-3-2025-no-pq
@@ -1,6 +1,6 @@
 min version: TLS1.3
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/CloudFront-Upstream-TLS-1-3-2025
+++ b/tests/policy_snapshot/snapshots/CloudFront-Upstream-TLS-1-3-2025
@@ -1,6 +1,6 @@
 min version: TLS1.3
 rules:
-- Perfect Forward Secrecy: no
+- Perfect Forward Secrecy: yes
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/CloudFront-Upstream-TLS-1-3-2025-PQ
+++ b/tests/policy_snapshot/snapshots/CloudFront-Upstream-TLS-1-3-2025-PQ
@@ -1,6 +1,6 @@
 min version: TLS1.3
 rules:
-- Perfect Forward Secrecy: no
+- Perfect Forward Secrecy: yes
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/ELBSecurityPolicy-FS-1-1-2019-08
+++ b/tests/policy_snapshot/snapshots/ELBSecurityPolicy-FS-1-1-2019-08
@@ -1,6 +1,6 @@
 min version: TLS1.1
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/ELBSecurityPolicy-FS-1-2-2019-08
+++ b/tests/policy_snapshot/snapshots/ELBSecurityPolicy-FS-1-2-2019-08
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/ELBSecurityPolicy-FS-1-2-Res-2019-08
+++ b/tests/policy_snapshot/snapshots/ELBSecurityPolicy-FS-1-2-Res-2019-08
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/ELBSecurityPolicy-FS-2018-06
+++ b/tests/policy_snapshot/snapshots/ELBSecurityPolicy-FS-2018-06
@@ -1,6 +1,6 @@
 min version: TLS1.0
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/KMS-FIPS-TLS-1-2-2018-10
+++ b/tests/policy_snapshot/snapshots/KMS-FIPS-TLS-1-2-2018-10
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/KMS-FIPS-TLS-1-2-2021-08
+++ b/tests/policy_snapshot/snapshots/KMS-FIPS-TLS-1-2-2021-08
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/KMS-FIPS-TLS-1-2-2024-10
+++ b/tests/policy_snapshot/snapshots/KMS-FIPS-TLS-1-2-2024-10
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes (required)
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_AES_128_GCM_SHA256
 - TLS_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/KMS-TLS-1-0-2018-10
+++ b/tests/policy_snapshot/snapshots/KMS-TLS-1-0-2018-10
@@ -1,6 +1,6 @@
 min version: TLS1.0
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/KMS-TLS-1-0-2021-08
+++ b/tests/policy_snapshot/snapshots/KMS-TLS-1-0-2021-08
@@ -1,6 +1,6 @@
 min version: TLS1.0
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/KMS-TLS-1-2-2023-06
+++ b/tests/policy_snapshot/snapshots/KMS-TLS-1-2-2023-06
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-0-2023-01-24
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-0-2023-01-24
@@ -1,6 +1,6 @@
 min version: TLS1.0
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-09
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-04-09
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-09
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-10-09
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-12-14
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-12-14
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: no
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_AES_128_GCM_SHA256
 - TLS_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-12-15
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2023-12-15
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: no
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_AES_128_GCM_SHA256
 - TLS_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-09
+++ b/tests/policy_snapshot/snapshots/PQ-TLS-1-2-2024-10-09
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/default
+++ b/tests/policy_snapshot/snapshots/default
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/default_fips
+++ b/tests/policy_snapshot/snapshots/default_fips
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes (required)
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_AES_128_GCM_SHA256
 - TLS_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/default_pq
+++ b/tests/policy_snapshot/snapshots/default_pq
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/default_tls13
+++ b/tests/policy_snapshot/snapshots/default_tls13
@@ -1,6 +1,6 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/rfc9151
+++ b/tests/policy_snapshot/snapshots/rfc9151
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: yes
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes (required)
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384

--- a/tests/policy_snapshot/snapshots/test_all_ecdsa
+++ b/tests/policy_snapshot/snapshots/test_all_ecdsa
@@ -1,6 +1,6 @@
 min version: TLS1.0
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA

--- a/tests/policy_snapshot/snapshots/test_all_fips
+++ b/tests/policy_snapshot/snapshots/test_all_fips
@@ -1,7 +1,7 @@
 min version: TLS1.2
 rules:
-- Perfect Forward Secrecy: no
-- FIPS 140-3 (2019): yes
+- Perfect Forward Secrecy: yes
+- FIPS 140-3 (2019): yes (required)
 cipher suites:
 - TLS_DHE_RSA_WITH_AES_128_CBC_SHA
 - TLS_DHE_RSA_WITH_AES_256_CBC_SHA

--- a/tests/policy_snapshot/snapshots/test_all_tls13
+++ b/tests/policy_snapshot/snapshots/test_all_tls13
@@ -1,6 +1,6 @@
 min version: SSLv3
 rules:
-- Perfect Forward Secrecy: yes
+- Perfect Forward Secrecy: yes (required)
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tests/policy_snapshot/snapshots/test_pq_only
+++ b/tests/policy_snapshot/snapshots/test_pq_only
@@ -1,6 +1,6 @@
 min version: TLS1.3
 rules:
-- Perfect Forward Secrecy: no
+- Perfect Forward Secrecy: yes
 - FIPS 140-3 (2019): no
 cipher suites:
 - TLS_AES_128_GCM_SHA256

--- a/tls/s2n_security_rules.h
+++ b/tls/s2n_security_rules.h
@@ -48,6 +48,9 @@ struct s2n_security_rule {
     S2N_RESULT (*validate_version)(uint8_t version, bool *valid);
 };
 
+S2N_RESULT s2n_security_rule_validate_policy(const struct s2n_security_rule *rule,
+        const struct s2n_security_policy *policy, struct s2n_security_rule_result *result);
+
 S2N_RESULT s2n_security_policy_validate_security_rules(
         const struct s2n_security_policy *policy,
         struct s2n_security_rule_result *result);


### PR DESCRIPTION
# Goal
Never print `Perfect Forward Secrecy: no` or `FIPS 140-3 (2019): no` if a TLS Policy does actually meet PerfectForwardSecrecy or FIPS requirements.

## Why
s2n-tls users may refer to TLS Policy snapshot files when deciding which TLS Policy to use. If a snapshot file lists a `no` for a given rule when it actually does meet that rule, s2n-tls users may be confused and incorrectly choose a different TLS Policy.

## How
Adds an extra evaluation to the policy writer to check if a rule is met before printing `no`.

## Callouts
None.

## Testing
Manual review of TLS snapshot files. 

### Related


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
