### PR TITLE
fix(bindings): use max_align_t for allocator alignment

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/init.rs
+++ b/bindings/rust/extended/s2n-tls/src/init.rs
@@ -65,7 +65,7 @@ pub fn fips_mode() -> Result<FipsMode, Error> {
 mod mem {
     use super::*;
     use alloc::alloc::{alloc, dealloc, Layout};
-    use core::{ffi::c_void, mem::size_of};
+    use core::{ffi::c_void, mem::align_of};
 
     /// Corresponds to [s2n_mem_set_callbacks].
     pub unsafe fn init() -> Result<(), Error> {
@@ -128,7 +128,11 @@ mod mem {
         //# The malloc() and calloc() functions return a pointer to the
         //# allocated memory, which is suitably aligned for any built-in
         //# type.
-        const ALIGNMENT: usize = size_of::<usize>();
+
+        // `max_align_t` is a type with the largest alignment of any scalar
+        // type, so aligning to its requirement will produce an alignment
+        // suitable to the C requirement for malloc.
+        const ALIGNMENT: usize = align_of::<libc::max_align_t>();
 
         // * align must not be zero,
         //


### PR DESCRIPTION
# Goal
Fix the alignment used in the Rust bindings custom allocator to match the C malloc alignment contract.

We would like to thank Joshua Rogers (https://joshua.hu/) of AISLE Research Team (https://aisle.com/) for reporting this issue.

## Why
The custom allocator was using `size_of::<usize>()` (8 bytes on 64-bit) for alignment, but C's `malloc` is required to return memory "suitably aligned for any built-in type." On platforms like x86_64 Linux, `max_align_t` has a 16-byte alignment requirement (due to `long double`), so the previous alignment could return under-aligned memory for C code.

## How
Changed the alignment constant from `size_of::<usize>()` to `align_of::<libc::max_align_t>()`, which matches the C standard's alignment guarantee for `malloc`.

## Callouts
This isn't expected to have an effect in practice as most allocators I tested (default Rust allocator, jemalloc, mimalloc), already align to 16-bytes regardless of the specified alignment. 

## Testing
Existing tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
