### PR TITLE
fix(bindings): tie ClientHello lifetime to Fingerprint

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/fingerprint.rs
+++ b/bindings/rust/extended/s2n-tls/src/fingerprint.rs
@@ -267,7 +267,10 @@ impl Builder {
     ///     builder.build(&ch)
     /// };
     /// ```
-    pub fn build<'a>(&'a mut self, client_hello: &'a ClientHello) -> Result<Fingerprint<'a>, Error> {
+    pub fn build<'a>(
+        &'a mut self,
+        client_hello: &'a ClientHello,
+    ) -> Result<Fingerprint<'a>, Error> {
         unsafe {
             s2n_fingerprint_set_client_hello(self.ptr.as_ptr(), client_hello.deref_mut_ptr())
                 .into_result()


### PR DESCRIPTION
# Goal
Tie the `ClientHello` lifetime to the returned `Fingerprint` in the ClientHello fingerprinting builder.

We would like to thank Joshua Rogers (https://joshua.hu/) of AISLE Research Team (https://aisle.com/) for reporting this issue.

## Why
`Builder::build` previously accepted `client_hello: &ClientHello` with an anonymous lifetime, meaning the borrow checker didn't enforce that the `ClientHello` outlives the `Fingerprint`. Since the underlying C code holds a raw pointer to the `ClientHello`, a caller could drop the `ClientHello` while the `Fingerprint` still references it.

## How
Changed the `client_hello` parameter from `&ClientHello` to `&'a ClientHello`, binding it to the same lifetime `'a` as `&'a mut self` and the returned `Fingerprint<'a>`.

## Callouts
This is a source-compatible change for correct usage. Any existing code where the `ClientHello` already outlives the `Fingerprint` will continue to compile. Code that relied on the missing lifetime bound was unsound and will now fail to compile.

## Testing
- `compile_fail,E0597` doctest verifies the compiler rejects dangling `ClientHello` references.
- Run with: `cargo test --manifest-path bindings/rust/extended/s2n-tls/Cargo.toml --features unstable-fingerprint --doc fingerprint`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
