### PR TITLE
feat: add alert codes to alert errors

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -637,7 +637,8 @@ impl Connection {
     pub fn poll_negotiate(&mut self) -> Poll<Result<&mut Self, Error>> {
         let mut blocked = s2n_blocked_status::NOT_BLOCKED;
         self.poll_negotiate_method(|conn| unsafe {
-            s2n_negotiate(conn.as_ptr(), &mut blocked).into_poll()
+            let result = s2n_negotiate(conn.as_ptr(), &mut blocked);
+            (conn, result).into_poll()
         })
         .map_ok(|_| self)
     }
@@ -653,7 +654,10 @@ impl Connection {
         let mut blocked = s2n_blocked_status::NOT_BLOCKED;
         let buf_len: isize = buf.len().try_into().map_err(|_| Error::INVALID_INPUT)?;
         let buf_ptr = buf.as_ptr() as *const ::libc::c_void;
-        unsafe { s2n_send(self.connection.as_ptr(), buf_ptr, buf_len, &mut blocked).into_poll() }
+        unsafe {
+            let result = s2n_send(self.connection.as_ptr(), buf_ptr, buf_len, &mut blocked);
+            (self, result).into_poll()
+        }
     }
 
     #[cfg(not(feature = "unstable-renegotiate"))]
@@ -663,7 +667,10 @@ impl Connection {
         buf_len: isize,
     ) -> Poll<Result<usize, Error>> {
         let mut blocked = s2n_blocked_status::NOT_BLOCKED;
-        unsafe { s2n_recv(self.connection.as_ptr(), buf_ptr, buf_len, &mut blocked).into_poll() }
+        unsafe {
+            let result = s2n_recv(self.connection.as_ptr(), buf_ptr, buf_len, &mut blocked);
+            (self, result).into_poll()
+        }
     }
 
     /// Reads and decrypts data from a connection where
@@ -718,9 +725,8 @@ impl Connection {
     pub fn poll_flush(&mut self) -> Poll<Result<&mut Self, Error>> {
         let mut blocked = s2n_blocked_status::NOT_BLOCKED;
         unsafe {
-            s2n_flush(self.connection.as_ptr(), &mut blocked)
-                .into_poll()
-                .map_ok(|_| self)
+            let result = s2n_flush(self.connection.as_ptr(), &mut blocked);
+            (&self, result).into_poll().map_ok(|_| self)
         }
     }
 
@@ -744,9 +750,8 @@ impl Connection {
         }
         let mut blocked = s2n_blocked_status::NOT_BLOCKED;
         unsafe {
-            s2n_shutdown(self.connection.as_ptr(), &mut blocked)
-                .into_poll()
-                .map_ok(|_| self)
+            let result = s2n_shutdown(self.connection.as_ptr(), &mut blocked);
+            (&self, result).into_poll().map_ok(|_| self)
         }
     }
 
@@ -762,9 +767,8 @@ impl Connection {
         }
         let mut blocked = s2n_blocked_status::NOT_BLOCKED;
         unsafe {
-            s2n_shutdown_send(self.connection.as_ptr(), &mut blocked)
-                .into_poll()
-                .map_ok(|_| self)
+            let result = s2n_shutdown_send(self.connection.as_ptr(), &mut blocked);
+            (&self, result).into_poll().map_ok(|_| self)
         }
     }
 


### PR DESCRIPTION
# Goal
Make the actual alert received available when s2n-tls reports an ErrorType::Alert error.

## Why
ErrorType::Alert is not helpful without the actual alert code, and implementing error handling logic everywhere it's required is tedious. It's also fun when you don't notice the alert isn't being logged until the code has been deployed :grimacing:

## How
I add an option to provide the connection when converting low level return values into Errors. If the connection is provided, then information like the alert can be retrieved and stored on the Error.

## Callouts
<!-- Any specific item to callout? Non-optimal choices, future actions needed, etc -->

## Testing
I added a unit test that intentionally sends a hard coded plain text alert as part of the handshake, then ensures that the proper alert description is reported.

### Related
<!-- E.g. "resolves #3456" -->

<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
