### PR TITLE
fix: Use logical OR instead of bitwise OR

### DIFF
--- a/tls/s2n_signature_algorithms.c
+++ b/tls/s2n_signature_algorithms.c
@@ -427,7 +427,7 @@ S2N_RESULT s2n_signature_scheme_params_match(struct s2n_connection *conn, const 
     RESULT_ENSURE_REF(pub_key);
     RESULT_ENSURE_REF(wire_scheme);
 
-    s2n_pkey_type pkey_type = { 0 };
+    s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
     EVP_PKEY *evp_key = pub_key->pkey;
     RESULT_ENSURE_REF(evp_key);
 
@@ -465,7 +465,7 @@ S2N_RESULT s2n_signature_scheme_params_match(struct s2n_connection *conn, const 
     } else if (pkey_type == S2N_PKEY_TYPE_MLDSA) {
         /* TODO: https://github.com/aws/s2n-tls/issues/5740 */
         return S2N_RESULT_OK;
-    } else if ((pkey_type == S2N_PKEY_TYPE_RSA) | (pkey_type == S2N_PKEY_TYPE_RSA_PSS)) {
+    } else if ((pkey_type == S2N_PKEY_TYPE_RSA) || (pkey_type == S2N_PKEY_TYPE_RSA_PSS)) {
         return S2N_RESULT_OK;
     } else {
         RESULT_BAIL(S2N_ERR_UNIMPLEMENTED);


### PR DESCRIPTION
# Goal
Fixing bugs from a recent PR.

## Why
Well they're bugs so...

## How
Use logical OR instead of bitwise OR. Also apparently I initialized s2n_pkey_type wrong, as that is actually a enum and not a struct.

## Callouts
<!-- Any specific item to callout? Non-optimal choices, future actions needed, etc -->
related to #5736
## Testing
<!-- How is it tested? -->

### Related
<!-- E.g. "resolves #3456" -->

<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
