### PR TITLE
revert: "fix: rust alert getter should not modify"

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -3423,9 +3423,6 @@ S2N_API extern int s2n_connection_get_key_exchange_group(struct s2n_connection *
  * Function to get the alert that caused a connection to close. s2n-tls considers all
  * TLS alerts fatal and shuts down a connection whenever one is received.
  *
- * @warning This method mutates the connection and consumes any available alert.
- * Calling it twice without receiving a second alert will cause an error.
- *
  * @param conn A pointer to the s2n connection
  * @returns The TLS alert code that caused a connection to be shut down
  */

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -775,11 +775,10 @@ impl Connection {
 
     /// Returns the TLS alert code, if any
     ///
-    /// Corresponds to [s2n_connection_get_alert], but does not modify the connection
-    /// or consume the alert.
+    /// Corresponds to [s2n_connection_get_alert].
     pub fn alert(&self) -> Option<u8> {
         let alert =
-            unsafe { s2n_connection_peek_alert(self.connection.as_ptr()).into_result() }.ok()?;
+            unsafe { s2n_connection_get_alert(self.connection.as_ptr()).into_result() }.ok()?;
         Some(alert as u8)
     }
 

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -1109,40 +1109,6 @@ int main(int argc, char **argv)
         };
     };
 
-    /* Test s2n_connection_peek_alert */
-    {
-        /* Safety */
-        {
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_peek_alert(NULL), S2N_ERR_NULL);
-        }
-
-        /* Test: no alert */
-        {
-            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
-                    s2n_connection_ptr_free);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_peek_alert(conn), S2N_ERR_NO_ALERT);
-        }
-
-        /* Test: Does not interfere with s2n_connection_get_alert */
-        {
-            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
-                    s2n_connection_ptr_free);
-            const uint8_t alert_code = 42;
-            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->alert_in, 0));
-            EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->alert_in, alert_code));
-
-            /* We can repeatedly peek at alerts */
-            for (size_t i = 0; i < 10; i++) {
-                EXPECT_EQUAL(s2n_connection_peek_alert(conn), alert_code);
-            }
-
-            /* We can still read the alert once */
-            EXPECT_EQUAL(s2n_connection_get_alert(conn), alert_code);
-            /* But we can't read the alert twice */
-            EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_alert(conn), S2N_ERR_NO_ALERT);
-        }
-    }
-
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(ecdsa_chain_and_key));
     EXPECT_SUCCESS(s2n_cert_chain_and_key_free(rsa_chain_and_key));
     END_TEST();

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1127,28 +1127,17 @@ int s2n_connection_client_cert_used(struct s2n_connection *conn)
     return 0;
 }
 
-static int s2n_connection_get_alert_impl(struct s2n_stuffer *alert)
-{
-    S2N_ERROR_IF(s2n_stuffer_data_available(alert) != 2, S2N_ERR_NO_ALERT);
-
-    uint8_t alert_code = 0;
-    POSIX_GUARD(s2n_stuffer_read_uint8(alert, &alert_code));
-    POSIX_GUARD(s2n_stuffer_read_uint8(alert, &alert_code));
-
-    return alert_code;
-}
-
 int s2n_connection_get_alert(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
-    return s2n_connection_get_alert_impl(&conn->alert_in);
-}
 
-int s2n_connection_peek_alert(struct s2n_connection *conn)
-{
-    POSIX_ENSURE_REF(conn);
-    struct s2n_stuffer alert_in_copy = conn->alert_in;
-    return s2n_connection_get_alert_impl(&alert_in_copy);
+    S2N_ERROR_IF(s2n_stuffer_data_available(&conn->alert_in) != 2, S2N_ERR_NO_ALERT);
+
+    uint8_t alert_code = 0;
+    POSIX_GUARD(s2n_stuffer_read_uint8(&conn->alert_in, &alert_code));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&conn->alert_in, &alert_code));
+
+    return alert_code;
 }
 
 int s2n_set_server_name(struct s2n_connection *conn, const char *server_name)

--- a/tls/s2n_internal.h
+++ b/tls/s2n_internal.h
@@ -59,8 +59,3 @@ S2N_PRIVATE_API int s2n_config_add_cert_chain(struct s2n_config *config,
  * is still waiting for encryption.
  */
 S2N_PRIVATE_API int s2n_flush(struct s2n_connection *conn, s2n_blocked_status *blocked);
-
-/*
- * An alternative to s2n_connection_get_alert that does not mutate the connection.
- */
-S2N_PRIVATE_API int s2n_connection_peek_alert(struct s2n_connection *conn);


### PR DESCRIPTION
Reverts aws/s2n-tls#5756. We will re-open this after the latest release.