### PR TITLE
fix: make get_alert idempotent

### DIFF
--- a/tests/unit/s2n_alerts_protocol_test.c
+++ b/tests/unit/s2n_alerts_protocol_test.c
@@ -635,5 +635,24 @@ int main(int argc, char **argv)
         };
     };
 
+    /* Test: s2n_connection_get_alert is idempotent */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+
+        /* Write a fatal alert directly into alert_in */
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->alert_in, S2N_TLS_ALERT_LEVEL_FATAL));
+        EXPECT_SUCCESS(s2n_stuffer_write_uint8(&conn->alert_in, S2N_TLS_ALERT_HANDSHAKE_FAILURE));
+
+        /* Repeated calls should all return the same alert */
+        for (size_t i = 0; i < 5; i++) {
+            EXPECT_EQUAL(s2n_connection_get_alert(conn), S2N_TLS_ALERT_HANDSHAKE_FAILURE);
+        }
+
+        /* The stuffer should still have the original data */
+        EXPECT_EQUAL(s2n_stuffer_data_available(&conn->alert_in), 2);
+    };
+
     END_TEST();
 }

--- a/tests/unit/s2n_shutdown_test.c
+++ b/tests/unit/s2n_shutdown_test.c
@@ -170,7 +170,6 @@ int main(int argc, char **argv)
          * https://github.com/aws/s2n-tls/issues/3933 doesn't affect shutdown.
          */
         EXPECT_EQUAL(s2n_connection_get_alert(conn), S2N_TLS_ALERT_INTERNAL_ERROR);
-        EXPECT_FAILURE_WITH_ERRNO(s2n_connection_get_alert(conn), S2N_ERR_NO_ALERT);
 
         /* Shutdown should succeed, since it's a no-op */
         EXPECT_SUCCESS(s2n_shutdown(conn, &blocked));

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1133,9 +1133,12 @@ int s2n_connection_get_alert(struct s2n_connection *conn)
 
     S2N_ERROR_IF(s2n_stuffer_data_available(&conn->alert_in) != 2, S2N_ERR_NO_ALERT);
 
+    /* Shallow copy the stuffer. We assume that multiple threads might call this
+     * function concurrently, so we must not mutate anything outside of the function scope */
+    struct s2n_stuffer alert_stuffer = conn->alert_in;
     uint8_t alert_code = 0;
-    POSIX_GUARD(s2n_stuffer_read_uint8(&conn->alert_in, &alert_code));
-    POSIX_GUARD(s2n_stuffer_read_uint8(&conn->alert_in, &alert_code));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&alert_stuffer, &alert_code));
+    POSIX_GUARD(s2n_stuffer_read_uint8(&alert_stuffer, &alert_code));
 
     return alert_code;
 }


### PR DESCRIPTION
# Goal
Make `s2n_connection_get_alert` idempotent and thread-safe.

## Why
`s2n_connection_get_alert` currently consumes the alert which is ... odd behavior.

It is also not safe to call concurrently, because it mutates the stuffer.

## How
We shallow copy the stuffer, so that the write/read cursor increments are local to the function.

## Callouts
Technically a behavior change, but I consider this low risk because the scenario where someone is relying on the non-idempotency of this behavior seems unlikely.

## Testing
Added a unit test.

### Related

#5756 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
