### PR TITLE
revert: "revert: "fix: rust alert getter should not modify""

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -3423,6 +3423,9 @@ S2N_API extern int s2n_connection_get_key_exchange_group(struct s2n_connection *
  * Function to get the alert that caused a connection to close. s2n-tls considers all
  * TLS alerts fatal and shuts down a connection whenever one is received.
  *
+ * @warning This method mutates the connection and consumes any available alert.
+ * Calling it twice without receiving a second alert will cause an error.
+ *
  * @param conn A pointer to the s2n connection
  * @returns The TLS alert code that caused a connection to be shut down
  */

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -775,10 +775,11 @@ impl Connection {
 
     /// Returns the TLS alert code, if any
     ///
-    /// Corresponds to [s2n_connection_get_alert].
+    /// Corresponds to [s2n_connection_get_alert], but does not modify the connection
+    /// or consume the alert.
     pub fn alert(&self) -> Option<u8> {
         let alert =
-            unsafe { s2n_connection_get_alert(self.connection.as_ptr()).into_result() }.ok()?;
+            unsafe { s2n_connection_peek_alert(self.connection.as_ptr()).into_result() }.ok()?;
         Some(alert as u8)
     }
 

--- a/tls/s2n_internal.h
+++ b/tls/s2n_internal.h
@@ -59,3 +59,8 @@ S2N_PRIVATE_API int s2n_config_add_cert_chain(struct s2n_config *config,
  * is still waiting for encryption.
  */
 S2N_PRIVATE_API int s2n_flush(struct s2n_connection *conn, s2n_blocked_status *blocked);
+
+/*
+ * An alternative to s2n_connection_get_alert that does not mutate the connection.
+ */
+S2N_PRIVATE_API int s2n_connection_peek_alert(struct s2n_connection *conn);


### PR DESCRIPTION
This restores the changes originally introduced in #5756, which were temporarily reverted to unblock the v1.7.1 release. With that release now published, I'm opening this PR to reapply the change.