### PR TITLE
fix: update memory snapshots

### DIFF
--- a/bindings/rust/standard/integration/tests/memory.rs
+++ b/bindings/rust/standard/integration/tests/memory.rs
@@ -270,16 +270,15 @@ mod memory_test {
             table
         }
 
-        /// return a table showing the diff between each step in the connection
-        /// lifecycle. The static memory row is an absolute measurement, not a diff.
         fn assert_expected(&self) {
+            /// The allocated memory expected at each step of the connection lifecycle
             const EXPECTED_MEMORY: &[(Lifecycle, usize)] = &[
                 (Lifecycle::ConnectionInit, 61_466),
-                (Lifecycle::AfterClientHello, 88_294),
-                (Lifecycle::AfterServerHello, 116_661),
-                (Lifecycle::AfterClientFinished, 107_968),
-                (Lifecycle::HandshakeComplete, 90_555),
-                (Lifecycle::ApplicationData, 90_555),
+                (Lifecycle::AfterClientHello, 89_062),
+                (Lifecycle::AfterServerHello, 117_429),
+                (Lifecycle::AfterClientFinished, 108_736),
+                (Lifecycle::HandshakeComplete, 91_323),
+                (Lifecycle::ApplicationData, 91_323),
             ];
             let actual_memory: Vec<(Lifecycle, usize)> = Lifecycle::all_stages()
                 .into_iter()


### PR DESCRIPTION
# Goal
Fix CI to have the correct memory assertions.

## Why
The latest version of AWS-LC uses slightly more memory. Hypothesis is that it was caused by this change: 

https://github.com/aws/aws-lc/pull/2963

```
state = OPENSSL_zalloc(sizeof(struct rand_thread_local_state));
```
Basically, new thread-local state is being allocated to account for the public/private stuff.

## How
Update the snapshots.

## Testing
CI should now pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
