### PR TITLE
fix: add required metadata for subscriber

### DIFF
--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "s2n-tls-metrics-subscriber"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2024"
+description = "Telemetry provider for s2n-tls"
+authors = ["AWS s2n"]
+repository = "https://github.com/aws/s2n-tls"
+license = "Apache-2.0"
 
 [dependencies]
 tracing = "0.1.43"


### PR DESCRIPTION
# Goal
Publish the s2n-tls-metric-subscriber crate.

## Why
These fields are required

## How
Add the required fields.

## Testing
`cargo publish --dry-run`
```
   Uploading s2n-tls-metrics-subscriber v0.0.1 (/home/ubuntu/workspace/s2n-tls/bindings/rust/standard/s2n-tls-metrics-subscriber)
warning: aborting upload due to dry run
```
And it seems to have made it all the way through.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
