### PR TITLE
fix(bindings): replace bare as usize casts in Tokio I/O callbacks

### DIFF
--- a/bindings/rust/extended/s2n-tls-tokio/src/lib.rs
+++ b/bindings/rust/extended/s2n-tls-tokio/src/lib.rs
@@ -241,7 +241,8 @@ where
 
     unsafe extern "C" fn recv_io_cb(ctx: *mut c_void, buf: *mut u8, len: u32) -> c_int {
         Self::poll_io(ctx, |stream, async_context| {
-            let mut dest = ReadBuf::new(std::slice::from_raw_parts_mut(buf, len as usize));
+            let len: usize = len.try_into().unwrap();
+            let mut dest = ReadBuf::new(std::slice::from_raw_parts_mut(buf, len));
             stream
                 .poll_read(async_context, &mut dest)
                 .map_ok(|_| dest.filled().len())
@@ -250,7 +251,8 @@ where
 
     unsafe extern "C" fn send_io_cb(ctx: *mut c_void, buf: *const u8, len: u32) -> c_int {
         Self::poll_io(ctx, |stream, async_context| {
-            let src = std::slice::from_raw_parts(buf, len as usize);
+            let len: usize = len.try_into().unwrap();
+            let src = std::slice::from_raw_parts(buf, len);
             stream.poll_write(async_context, src)
         })
     }


### PR DESCRIPTION
# Goal
Replace unsafe `len as usize` casts with checked `len.try_into().unwrap()` in the Tokio I/O callbacks (`recv_io_cb` and `send_io_cb`).

## Why
The `recv_io_cb` and `send_io_cb` callbacks receive a `len: u32` from the C library and cast it directly to `usize` with `len as usize` when constructing slices via `std::slice::from_raw_parts_mut` and `std::slice::from_raw_parts`. On 64-bit platforms this is always safe, but on a hypothetical platform where `usize` is smaller than `u32`, the cast would silently truncate, creating a slice smaller than the C library expects and leading to a buffer overread/overwrite.

## How
Changed both `recv_io_cb` and `send_io_cb` to convert `len` using `len.try_into().unwrap()` instead of `len as usize`. This will panic with a clear error message instead of silently truncating if the value ever doesn't fit in `usize`.

This matches the existing pattern used throughout the s2n-tls Rust bindings (e.g., `connection.rs`, `cert_chain.rs`, `renegotiate.rs`).

## Callouts
- This is a defense-in-depth change. On all currently supported 64-bit platforms, `u32` always fits in `usize`, so the behavior is unchanged.
- The `unwrap()` is acceptable here because a failure would indicate a fundamentally unsupported platform, and there is no reasonable recovery path inside an `extern "C"` callback.

## Testing
Existing tests cover these code paths. No new tests needed since the behavior is identical on all supported (64-bit) platforms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
