### PR TITLE
fix: OpenSSL 3 "no-deprecated" support

### DIFF
--- a/crypto/s2n_aead_cipher_aes_gcm.c
+++ b/crypto/s2n_aead_cipher_aes_gcm.c
@@ -366,7 +366,7 @@ static S2N_RESULT s2n_aead_cipher_aes_gcm_init(struct s2n_session_key *key)
 
 static S2N_RESULT s2n_aead_cipher_aes_gcm_destroy_key(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_cleanup(key->evp_cipher_ctx);
+    s2n_evp_ctx_cleanup(key->evp_cipher_ctx);
 
     return S2N_RESULT_OK;
 }

--- a/crypto/s2n_aead_cipher_chacha20_poly1305.c
+++ b/crypto/s2n_aead_cipher_chacha20_poly1305.c
@@ -157,7 +157,7 @@ static S2N_RESULT s2n_aead_chacha20_poly1305_init(struct s2n_session_key *key)
 
 static S2N_RESULT s2n_aead_chacha20_poly1305_destroy_key(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_cleanup(key->evp_cipher_ctx);
+    s2n_evp_ctx_cleanup(key->evp_cipher_ctx);
 
     return S2N_RESULT_OK;
 }

--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -83,7 +83,7 @@ static S2N_RESULT s2n_cbc_cipher_3des_init(struct s2n_session_key *key)
 
 static S2N_RESULT s2n_cbc_cipher_3des_destroy_key(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_cleanup(key->evp_cipher_ctx);
+    s2n_evp_ctx_cleanup(key->evp_cipher_ctx);
 
     return S2N_RESULT_OK;
 }

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -109,7 +109,7 @@ static S2N_RESULT s2n_cbc_cipher_aes_init(struct s2n_session_key *key)
 
 static S2N_RESULT s2n_cbc_cipher_aes_destroy_key(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_cleanup(key->evp_cipher_ctx);
+    s2n_evp_ctx_cleanup(key->evp_cipher_ctx);
 
     return S2N_RESULT_OK;
 }

--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -721,7 +721,11 @@ static int s2n_utf8_string_from_extension_data(const uint8_t *extension_data, ui
         * Since this is an internal pointer it should not be freed or modified in any way.
         * Ref: https://www.openssl.org/docs/man1.0.2/man3/ASN1_STRING_data.html.
         */
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
+        const unsigned char *internal_data = ASN1_STRING_get0_data(asn1_str);
+#else
         unsigned char *internal_data = ASN1_STRING_data(asn1_str);
+#endif
         POSIX_ENSURE_REF(internal_data);
         POSIX_CHECKED_MEMCPY(out_data, internal_data, len);
     }
@@ -827,7 +831,11 @@ static int s2n_parse_x509_extension(struct s2n_cert *cert, const uint8_t *oid,
                  * Since this is an internal pointer it should not be freed or modified in any way.
                  * Ref: https://www.openssl.org/docs/man1.0.2/man3/ASN1_STRING_data.html.
                  */
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
+                const unsigned char *internal_data = ASN1_STRING_get0_data(asn1_str);
+#else
                 unsigned char *internal_data = ASN1_STRING_data(asn1_str);
+#endif
                 POSIX_ENSURE_REF(internal_data);
                 POSIX_CHECKED_MEMCPY(ext_value, internal_data, len);
             }

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -296,7 +296,7 @@ static S2N_RESULT s2n_composite_cipher_aes_sha_init(struct s2n_session_key *key)
 
 static S2N_RESULT s2n_composite_cipher_aes_sha_destroy_key(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_cleanup(key->evp_cipher_ctx);
+    s2n_evp_ctx_cleanup(key->evp_cipher_ctx);
 
     return S2N_RESULT_OK;
 }

--- a/crypto/s2n_drbg.c
+++ b/crypto/s2n_drbg.c
@@ -229,7 +229,7 @@ S2N_RESULT s2n_drbg_wipe(struct s2n_drbg *drbg)
     RESULT_ENSURE_REF(drbg);
 
     if (drbg->ctx) {
-        RESULT_GUARD_OSSL(EVP_CIPHER_CTX_cleanup(drbg->ctx), S2N_ERR_DRBG);
+        RESULT_GUARD_OSSL(s2n_evp_ctx_cleanup(drbg->ctx), S2N_ERR_DRBG);
 
         EVP_CIPHER_CTX_free(drbg->ctx);
         drbg->ctx = NULL;

--- a/crypto/s2n_libcrypto.c
+++ b/crypto/s2n_libcrypto.c
@@ -57,7 +57,11 @@
  */
 const char *s2n_libcrypto_get_version_name(void)
 {
-    return SSLeay_version(SSLEAY_VERSION);
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+    return OpenSSL_version(OPENSSL_VERSION);
+#else
+     return SSLeay_version(SSLEAY_VERSION);
+#endif
 }
 
 static S2N_RESULT s2n_libcrypto_validate_expected_version_prefix(const char *expected_name_prefix)

--- a/crypto/s2n_libcrypto.c
+++ b/crypto/s2n_libcrypto.c
@@ -93,6 +93,8 @@ static S2N_RESULT s2n_libcrypto_validate_expected_version_number(void)
  */
 #if defined(LIBRESSL_VERSION_NUMBER)
     unsigned long run_time_version_number = s2n_get_openssl_version() & VERSION_NUMBER_MASK;
+#elif (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+    unsigned long run_time_version_number = OpenSSL_version_num() & VERSION_NUMBER_MASK;
 #else
     unsigned long run_time_version_number = SSLeay() & VERSION_NUMBER_MASK;
 #endif

--- a/crypto/s2n_openssl.h
+++ b/crypto/s2n_openssl.h
@@ -41,9 +41,11 @@
     (OPENSSL_VERSION_NUMBER >= ((major << 28) + (minor << 20) + (fix << 12)))
 
 #if (S2N_OPENSSL_VERSION_AT_LEAST(1, 1, 0)) && (!defined(OPENSSL_IS_BORINGSSL)) && (!defined(OPENSSL_IS_AWSLC)) && (!defined(LIBRESSL_VERSION_NUMBER))
-    #define s2n_evp_ctx_init(ctx)    POSIX_GUARD_OSSL(EVP_CIPHER_CTX_init(ctx), S2N_ERR_DRBG)
-    #define RESULT_EVP_CTX_INIT(ctx) RESULT_GUARD_OSSL(EVP_CIPHER_CTX_init(ctx), S2N_ERR_DRBG)
+    #define s2n_evp_ctx_init(ctx)    POSIX_GUARD_OSSL(EVP_CIPHER_CTX_reset(ctx), S2N_ERR_DRBG)
+    #define s2n_evp_ctx_cleanup(ctx) EVP_CIPHER_CTX_reset(ctx)
+    #define RESULT_EVP_CTX_INIT(ctx) RESULT_GUARD_OSSL(EVP_CIPHER_CTX_reset(ctx), S2N_ERR_DRBG)
 #else
     #define s2n_evp_ctx_init(ctx)    EVP_CIPHER_CTX_init(ctx)
+    #define s2n_evp_ctx_cleanup(ctx) EVP_CIPHER_CTX_cleanup(ctx)
     #define RESULT_EVP_CTX_INIT(ctx) EVP_CIPHER_CTX_init(ctx)
 #endif

--- a/crypto/s2n_stream_cipher_rc4.c
+++ b/crypto/s2n_stream_cipher_rc4.c
@@ -93,7 +93,7 @@ static S2N_RESULT s2n_stream_cipher_rc4_init(struct s2n_session_key *key)
 
 static S2N_RESULT s2n_stream_cipher_rc4_destroy_key(struct s2n_session_key *key)
 {
-    EVP_CIPHER_CTX_cleanup(key->evp_cipher_ctx);
+    s2n_evp_ctx_cleanup(key->evp_cipher_ctx);
 
     return S2N_RESULT_OK;
 }

--- a/tests/unit/s2n_build_test.c
+++ b/tests/unit/s2n_build_test.c
@@ -155,7 +155,11 @@ int main()
         } else {
             /* Any other library should have the name of the library (modulo case) in its version string.  */
             char ssleay_version_text[MAX_LIBCRYPTO_NAME_LEN] = { 0 };
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+            EXPECT_OK(s2n_test_lowercase_copy(OpenSSL_version(OPENSSL_VERSION), &ssleay_version_text[0], MAX_LIBCRYPTO_NAME_LEN));
+#else
             EXPECT_OK(s2n_test_lowercase_copy(SSLeay_version(SSLEAY_VERSION), &ssleay_version_text[0], MAX_LIBCRYPTO_NAME_LEN));
+#endif
             EXPECT_NOT_NULL(strstr(ssleay_version_text, name));
         }
     };
@@ -163,7 +167,11 @@ int main()
     /* Check libcrypto version matches the intent of the CI.  */
     {
         if (version != NULL) {
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+            const char *ssleay_version_text = OpenSSL_version(OPENSSL_VERSION);
+#else
             const char *ssleay_version_text = SSLeay_version(SSLEAY_VERSION);
+#endif
             if (strstr(ssleay_version_text, version) == NULL) {
                 char fail_msg[256] = { 0 };
                 snprintf(

--- a/tls/s2n_crl.c
+++ b/tls/s2n_crl.c
@@ -116,7 +116,11 @@ int s2n_crl_validate_not_expired(struct s2n_crl *crl)
     POSIX_ENSURE_REF(crl);
     POSIX_ENSURE_REF(crl->crl);
 
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
+    const ASN1_TIME *next_update = X509_CRL_get0_nextUpdate(crl->crl);
+#else
     ASN1_TIME *next_update = X509_CRL_get_nextUpdate(crl->crl);
+#endif
     if (next_update == NULL) {
         /* If the CRL has no nextUpdate field, assume it will never expire */
         return S2N_SUCCESS;

--- a/tls/s2n_crl.c
+++ b/tls/s2n_crl.c
@@ -97,7 +97,11 @@ int s2n_crl_validate_active(struct s2n_crl *crl)
     POSIX_ENSURE_REF(crl);
     POSIX_ENSURE_REF(crl->crl);
 
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
+    const ASN1_TIME *this_update = X509_CRL_get0_lastUpdate(crl->crl);
+#else
     ASN1_TIME *this_update = X509_CRL_get_lastUpdate(crl->crl);
+#endif
     POSIX_ENSURE_REF(this_update);
 
     int ret = X509_cmp_time(this_update, NULL);

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -221,7 +221,11 @@ static S2N_RESULT s2n_verify_host_information_san_entry(struct s2n_connection *c
     if (current_name->type == GEN_DNS || current_name->type == GEN_URI) {
         *san_found = true;
 
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
+        const char *name = (const char *) ASN1_STRING_get0_data(current_name->d.ia5);
+#else
         const char *name = (const char *) ASN1_STRING_data(current_name->d.ia5);
+#endif
         RESULT_ENSURE_REF(name);
         int name_len = ASN1_STRING_length(current_name->d.ia5);
         RESULT_ENSURE_GT(name_len, 0);
@@ -336,7 +340,11 @@ static S2N_RESULT s2n_verify_host_information_common_name(struct s2n_connection 
     RESULT_ENSURE_GT(cn_len, 0);
     uint32_t len = (uint32_t) cn_len;
     RESULT_ENSURE_LTE(len, s2n_array_len(peer_cn) - 1);
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L)
+    RESULT_CHECKED_MEMCPY(peer_cn, ASN1_STRING_get0_data(common_name), len);
+#else
     RESULT_CHECKED_MEMCPY(peer_cn, ASN1_STRING_data(common_name), len);
+#endif
     RESULT_ENSURE(conn->verify_host_fn(peer_cn, len, conn->data_for_verify_host), S2N_ERR_CERT_INVALID_HOSTNAME);
 
     return S2N_RESULT_OK;


### PR DESCRIPTION
# Goal
Use newer OpenSSL functions when available.

## Why
To support building s2n-tls with OpenSSL 3.6.1 (api 1.1.1 but built with with "no deprecated").

## How
Checking for OpenSSL version and using newer functions where possible.

## Callouts
-

## Testing
Built a conan package of aws-sdk-cpp with these changes as patch for a Linux service.

### Related
release summary: support OpenSSL 3.6 in s2n-tls

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
