### PR TITLE
docs: clarify integrity protection requirements for connection serialization

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -3947,9 +3947,9 @@ S2N_API int s2n_connection_serialization_length(struct s2n_connection *conn, uin
  * connection object that can talk to the original peer with the same encryption keys.
  *
  * @warning This feature is dangerous because it provides cryptographic material from a TLS session
- * in plaintext. Users MUST both encrypt and MAC the contents of the outputted material to provide
- * secrecy and integrity if this material is transported off-box. DO NOT store or send this material off-box
- * without encryption.
+ * in plaintext. The serialized blob also does not include a MAC or signature, so a modified blob
+ * will be deserialized and used as-is. Users MUST both encrypt and MAC the serialized connection to
+ * provide secrecy and integrity before storing or sending it off-box.
  *
  * @note You MUST have used `s2n_config_set_serialization_version()` to set a version on the
  * s2n_config object associated with this connection before this connection began its TLS handshake.
@@ -3970,10 +3970,12 @@ S2N_API int s2n_connection_serialize(struct s2n_connection *conn, uint8_t *buffe
 /**
  * Deserializes the provided buffer into the `s2n_connection` parameter.
  *
- * @warning s2n-tls DOES NOT check the integrity of the provided buffer. s2n-tls may successfully 
- * deserialize a corrupted buffer which WILL cause a connection failure when attempting to resume
- * sending/receiving encrypted data. To avoid this, it is recommended to MAC and encrypt the serialized 
- * connection before sending it off-box and deserializing it.
+ * @warning s2n-tls does not check the integrity of the provided buffer. The serialized blob does
+ * not include a MAC or signature, so a modified buffer will be deserialized and used as-is. A
+ * corrupted buffer will cause a connection failure when attempting to resume sending or receiving
+ * encrypted data. To avoid this, callers MUST MAC and encrypt the serialized connection before
+ * storing or sending it off-box. Encrypt-then-MAC using a key not stored alongside the blob is
+ * the recommended approach.
  *
  * @warning Only a minimal amount of information about the original TLS connection is serialized.
  * Therefore, after deserialization, the connection will behave like a new `s2n_connection` from the 

--- a/docs/usage-guide/topics/ch14-connection-serialization.md
+++ b/docs/usage-guide/topics/ch14-connection-serialization.md
@@ -3,9 +3,9 @@
 Connection Serialization allows TLS connection state to be serialized into a byte string. This allows the connection to be transported to a different host or stored to disk.
 
 <div class="warning">
-This feature is dangerous. It provides cryptographic material from a TLS session in plaintext. An attacker with access to the serialized connection can decrypt any past and future communications from the connection. Users MUST both encrypt and MAC the contents of the serialized connection to provide secrecy and integrity. 
+This feature is dangerous. The serialized connection contains cryptographic secrets, sequence numbers, the cipher suite, and the protocol version in plaintext. An attacker with access to this data can decrypt any past and future communications from the connection. Additionally, s2n-tls does not include a MAC or signature over the serialized data, so a modified blob will be deserialized and used as-is.
 
-The simplest way to provide secrecy and integrity is to transport the serialized connection using a protocol like TLS which protects the secrecy and integrity of all transported data.
+Users MUST both encrypt and MAC the serialized connection to provide secrecy and integrity. The simplest way to do this is to transport the serialized connection using a protocol like TLS. If the blob is stored in a database, shared cache, or sent over a network, it must be protected before storage or transmission.
 </div>
 
 ## Use Case

--- a/tls/s2n_connection_serialize.c
+++ b/tls/s2n_connection_serialize.c
@@ -345,6 +345,11 @@ int s2n_connection_deserialize(struct s2n_connection *conn, uint8_t *buffer, uin
     POSIX_ENSURE_REF(conn->secure);
     POSIX_ENSURE_REF(buffer);
 
+    /* The serialized blob does not include a MAC or signature. All values from the buffer
+     * are trusted after basic format validation. Callers must verify the integrity of the
+     * buffer before calling this function. See the s2n_connection_deserialize API docs.
+     */
+
     /* Read parsed values into a temporary struct so that the connection is unaltered if parsing fails */
     struct s2n_connection_deserialize parsed_values = { 0 };
     POSIX_ENSURE(s2n_result_is_ok(s2n_connection_deserialize_parse(buffer, buffer_length, &parsed_values)),


### PR DESCRIPTION
# Goal
<!-- What is the PR doing? -->
Strengthen the documentation around connection serialization to make the lack of built-in integrity protection explicit and actionable.

## Why
<!-- Why is this PR necessary? -->
The serialized connection blob contains cryptographic secrets and security-critical parameters (cipher suite, sequence numbers, protocol version) but does not include a MAC or signature. The existing documentation mentioned that users should "MAC and encrypt" the blob, but did not explain *why* integrity protection matters or what happens when it's missing. This could lead users to overlook the integrity requirement, especially if they only read one of the three documentation surfaces (usage guide, serialize API doc, or deserialize API doc).

## How
<!-- How is this PR accomplishing its goals? -->
- **`docs/usage-guide/topics/ch14-connection-serialization.md`**: Rewrote the warning block as a single cohesive piece that explains what the blob contains, that it has no MAC or signature, and that users must provide both secrecy and integrity.
- **`api/s2n.h` (`s2n_connection_serialize` and `s2n_connection_deserialize`)**: Updated the warning to note that the blob has no MAC or signature and that a modified buffer will be deserialized as-is. Upgraded the recommendation from "it is recommended" to "callers MUST" to match the serialize doc's tone. Added encrypt-then-MAC as the recommended approach.
- **`tls/s2n_connection_serialize.c`**: Added a brief comment at the `s2n_connection_deserialize` entry point noting the trust assumption and pointing to the API docs.

## Testing
<!-- How is it tested? -->
Documentation-only change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
