### PR TITLE
ci: fix install_awslc_fips script

### DIFF
--- a/codebuild/bin/install_awslc_fips.sh
+++ b/codebuild/bin/install_awslc_fips.sh
@@ -59,11 +59,11 @@ FIPS2_RELEASE_URL="https://api.github.com/repos/aws/aws-lc/releases/tags/AWS-LC-
 # building main with FIPS enabled is the next candidate FIPS branch.
 case $VERSION in
   "2022")
-    AWSLC_BRANCH=$(curl $FIPS2_RELEASE_URL \
+    AWSLC_BRANCH=$(curl --silent $FIPS2_RELEASE_URL \
       |grep -Po '"tag_name": "\KAWS-LC-FIPS-2.*?(?=")' |head -1)
     ;;
   "2024")
-    AWSLC_BRANCH=$(curl $GH_RELEASE_URL \
+    AWSLC_BRANCH=$(curl --silent $GH_RELEASE_URL \
       |grep -Po '"tag_name": "\KAWS-LC-FIPS-3.*?(?=")' |head -1)
     ;;
   "next")


### PR DESCRIPTION
# Goal
Fix the error I ran into when rebuilding the CI Docker images

## Why
The `GH_RELEASE_URL` is subject to pagination (default `per_page` value is 30). AWS-LC-FIPS-2.x releases are truncated in the output, causing `AWSLC_BRANCH` to be null and failing to build the Docker containers. 

## How
Since `awslc-fips-2.x` is no longer updated, I created a separate URL for the latest release of this major version (v2.0.17). We still use `GH_RELEASE_URL` for `awslc_fips_2024` as `awslc-fips-3.x` is the current major version.

## Testing
```
bash -c "./codebuild/bin/install_awslc_fips_2022.sh $(mktemp -d) /usr/local/awslc-fips-2022"
```
I ran the above command locally and confirmed that `AWS-LC-FIPS-2.0.17` was built successfully. Same for `install_awslc_fips_2024.sh`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
