### PR TITLE
ci: add 'style' to PR title check

### DIFF
--- a/.github/workflows/ci_pr_title.yml
+++ b/.github/workflows/ci_pr_title.yml
@@ -19,7 +19,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: ytanikin/pr-conventional-commits@1.5.2
         with:
-          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert","build"]'
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert","build","style"]'
           add_label: 'false'
       - name: Failure case
         if: failure() && github.event_name == 'pull_request'


### PR DESCRIPTION
# Goal
Expand the valid PR title types

## Why
The `style` type is allowed by [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).

> types other than fix: and feat: are allowed, for example [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) (based on the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)) recommends build:, chore:, ci:, docs:, style:, refactor:, perf:, test:, and others.

## How
Add the `style` keyword to the `task_types` array in the `validate-pr-title` job.

## Testing
The initial title of this PR started with `style` and the PR title check passed.

### Related
#5791

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
