### PR TITLE
chore: remove codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-/codebuild @dougch


### PR DESCRIPTION
# Goal
Reduce bus factor on PR reviews.

## Why

After deprecating webhooks, we're using [other mechanisms](https://github.com/aws/s2n-tls/pull/5383) to ensure review is done by core members of the team.

## How
Getting rid of CODEOWNERS means @dougch is no longer a required reviewer on codebuild/*

## Callouts
We could go the [s2n-quic](https://github.com/aws/s2n-quic/blob/main/.github/CODEOWNERS) route and use `@aws/s2n-core`, but this leads to everyone getting notified they have something to review, which might be unnecessary noise.

## Testing
We've managed this repo without a CODEOWNERS file before.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
