### PR TITLE
fix: perform fallable checks before interting into domain name map

### DIFF
--- a/bindings/rust/standard/integration/src/handshake/cert_aware_sig_selection.rs
+++ b/bindings/rust/standard/integration/src/handshake/cert_aware_sig_selection.rs
@@ -37,7 +37,7 @@ fn trial(server_policy: &Policy, cert_materials: &CertMaterials) -> SignatureSch
 
     let mut pair: TlsConnPair<OpenSslConnection, S2NConnection> = {
         let mut configs =
-            TlsConfigBuilderPair::<SslContextBuilder, s2n_tls::config::Builder>::default();
+            TlsConfigBuilderPair::<SslContextBuilder, s2n_tls::config::Builder>::default_without_certs();
         // Setup OpenSSL client
         configs.client.set_ca_file(&cert_materials.ca_path).unwrap();
 

--- a/bindings/rust/standard/integration/src/handshake/cert_aware_sig_selection.rs
+++ b/bindings/rust/standard/integration/src/handshake/cert_aware_sig_selection.rs
@@ -82,7 +82,7 @@ fn trial(server_policy: &Policy, cert_materials: &CertMaterials) -> SignatureSch
 #[test]
 fn signature_selection() {
     // ECDSA
-    required_capability(&[Capability::Tls13], || {
+    {
         let secp256r1 = CertMaterials::from_permutation("ec_ecdsa_p256_sha256");
         let secp521r1 = CertMaterials::from_permutation("ec_ecdsa_p521_sha512");
 
@@ -97,7 +97,7 @@ fn signature_selection() {
             trial(&policy, &secp521r1),
             iana::constants::ecdsa_secp521r1_sha512
         );
-    });
+    }
 
     // MLDSA
     required_capability(&[Capability::MLDsa], || {

--- a/bindings/rust/standard/integration/src/handshake/pq.rs
+++ b/bindings/rust/standard/integration/src/handshake/pq.rs
@@ -69,7 +69,7 @@ fn s2n_mldsa_server() {
 
         let mut pair: TlsConnPair<OpenSslConnection, S2NConnection> = {
             let mut configs =
-                TlsConfigBuilderPair::<SslContextBuilder, s2n_tls::config::Builder>::default();
+                TlsConfigBuilderPair::<SslContextBuilder, s2n_tls::config::Builder>::default_without_certs();
 
             // Setup OpenSSL client
             configs.client.set_ca_file(&mldsa87.ca_path).unwrap();
@@ -143,7 +143,7 @@ fn s2n_mlkem_server() {
 
         let mut pair: TlsConnPair<OpenSslConnection, S2NConnection> = {
             let mut configs =
-                TlsConfigBuilderPair::<SslContextBuilder, s2n_tls::config::Builder>::default();
+                TlsConfigBuilderPair::<SslContextBuilder, s2n_tls::config::Builder>::default_without_certs();
 
             // Setup OpenSSL client restricted to SecP384r1MLKEM1024
             configs.client.set_ca_file(&certs.ca_path).unwrap();

--- a/tests/unit/s2n_cert_chain_and_key_test.c
+++ b/tests/unit/s2n_cert_chain_and_key_test.c
@@ -157,9 +157,12 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(config, cert_chain, private_key));
             EXPECT_EQUAL(config->cert_ownership, S2N_LIB_OWNED);
 
-            /* Try to add second chain of same type */
+            /* Try to add second chain of same type.
+             * The deprecated API only allows a single call, so this is
+             * rejected at the ownership check.
+             */
             EXPECT_FAILURE_WITH_ERRNO(s2n_config_add_cert_chain_and_key(config, cert_chain, private_key),
-                    S2N_ERR_MULTIPLE_DEFAULT_CERTIFICATES_PER_AUTH_TYPE);
+                    S2N_ERR_CERT_OWNERSHIP);
             EXPECT_EQUAL(config->cert_ownership, S2N_LIB_OWNED);
 
             /* Try to add chain using other method */

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -456,6 +456,62 @@ int main(int argc, char **argv)
         };
     };
 
+    /* Test: a failed second call to s2n_config_add_cert_chain_and_key does not
+     * leave dangling pointers in the domain_name_to_cert_map.
+     */
+    {
+        /* The second call is rejected before any state is mutated */
+        {
+            DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+            EXPECT_NOT_NULL(config);
+
+            /* First call succeeds and populates the map */
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key(config, cert, key));
+            EXPECT_EQUAL(config->cert_ownership, S2N_LIB_OWNED);
+
+            uint32_t map_size_after_first = 0;
+            EXPECT_OK(s2n_map_size(config->domain_name_to_cert_map, &map_size_after_first));
+
+            /* Second call with the same cert type fails at the ownership guard */
+            EXPECT_FAILURE_WITH_ERRNO(s2n_config_add_cert_chain_and_key(config, cert, key),
+                    S2N_ERR_CERT_OWNERSHIP);
+
+            /* The map must be unchanged — no new entries were inserted */
+            uint32_t map_size_after_second = 0;
+            EXPECT_OK(s2n_map_size(config->domain_name_to_cert_map, &map_size_after_second));
+            EXPECT_EQUAL(map_size_after_first, map_size_after_second);
+
+            /* The original default cert is still valid and reachable */
+            EXPECT_NOT_NULL(s2n_config_get_single_default_cert(config));
+        };
+
+        /* s2n_config_add_cert_chain_and_key still allows adding two certs of the
+         * same type. The map entry is updated in-place (no new entries).
+         */
+        {
+            DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_a = NULL, s2n_cert_chain_and_key_ptr_free);
+            EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_a,
+                    S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+            DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_b = NULL, s2n_cert_chain_and_key_ptr_free);
+            EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&chain_b,
+                    S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+
+            DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+            EXPECT_NOT_NULL(config);
+
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_a));
+
+            uint32_t map_size_after_first = 0;
+            EXPECT_OK(s2n_map_size(config->domain_name_to_cert_map, &map_size_after_first));
+
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_b));
+
+            uint32_t map_size_after_second = 0;
+            EXPECT_OK(s2n_map_size(config->domain_name_to_cert_map, &map_size_after_second));
+            EXPECT_EQUAL(map_size_after_first, map_size_after_second);
+        };
+    };
+
     /* Test s2n_config_set_cert_chain_and_key_defaults */
     {
         /* Succeeds if chains owned by app */

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -547,22 +547,29 @@ static int s2n_config_add_cert_chain_and_key_impl(struct s2n_config *config, str
     s2n_pkey_type cert_type = s2n_cert_chain_and_key_get_pkey_type(cert_key_pair);
     config->is_rsa_cert_configured |= (cert_type == S2N_PKEY_TYPE_RSA);
 
-    POSIX_GUARD(s2n_config_build_domain_name_to_cert_map(config, cert_key_pair));
-
+    /* Perform all fallible checks BEFORE inserting into the domain name map.
+     * If we insert into the map first and then fail, the caller's DEFER_CLEANUP
+     * will free cert_key_pair while the map still holds pointers to it,
+     * resulting in dangling pointers and a use-after-free during SNI lookup.
+     */
     if (!config->default_certs_are_explicit) {
         POSIX_ENSURE(cert_type >= 0, S2N_ERR_CERT_TYPE_UNSUPPORTED);
         POSIX_ENSURE(cert_type < S2N_CERT_TYPE_COUNT, S2N_ERR_CERT_TYPE_UNSUPPORTED);
-        /* Attempt to auto set default based on ordering. ie: first RSA cert is the default, first ECDSA cert is the
-         * default, etc. */
-        if (config->default_certs_by_type.certs[cert_type] == NULL) {
-            config->default_certs_by_type.certs[cert_type] = cert_key_pair;
-        } else {
+        if (config->default_certs_by_type.certs[cert_type] != NULL) {
             /* Because library-owned certificates are tracked and cleaned up via the
              * default_certs_by_type mapping, library-owned chains MUST be set as the default
              * to avoid a memory leak. If they're not the default, they're not freed.
              */
             POSIX_ENSURE(config->cert_ownership != S2N_LIB_OWNED,
                     S2N_ERR_MULTIPLE_DEFAULT_CERTIFICATES_PER_AUTH_TYPE);
+        }
+    }
+
+    POSIX_GUARD(s2n_config_build_domain_name_to_cert_map(config, cert_key_pair));
+
+    if (!config->default_certs_are_explicit) {
+        if (config->default_certs_by_type.certs[cert_type] == NULL) {
+            config->default_certs_by_type.certs[cert_type] = cert_key_pair;
         }
     }
 
@@ -630,7 +637,12 @@ S2N_RESULT s2n_config_validate_loaded_certificates(const struct s2n_config *conf
 int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cert_chain_pem, const char *private_key_pem)
 {
     POSIX_ENSURE_REF(config);
-    POSIX_ENSURE(config->cert_ownership != S2N_APP_OWNED, S2N_ERR_CERT_OWNERSHIP);
+    /* Only allow this deprecated API to be called once. Library-owned certs are
+     * tracked via default_certs_by_type, so adding a second cert that can't be
+     * stored there would leak or, worse, leave dangling pointers in the domain
+     * name map when DEFER_CLEANUP fires on failure.
+     */
+    POSIX_ENSURE(config->cert_ownership == S2N_NOT_OWNED, S2N_ERR_CERT_OWNERSHIP);
 
     DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = s2n_cert_chain_and_key_new(),
             s2n_cert_chain_and_key_ptr_free);
@@ -648,7 +660,8 @@ int s2n_config_add_cert_chain(struct s2n_config *config,
         uint8_t *cert_chain_pem, uint32_t cert_chain_pem_size)
 {
     POSIX_ENSURE_REF(config);
-    POSIX_ENSURE(config->cert_ownership != S2N_APP_OWNED, S2N_ERR_CERT_OWNERSHIP);
+    /* Only allow this deprecated API to be called once. */
+    POSIX_ENSURE(config->cert_ownership == S2N_NOT_OWNED, S2N_ERR_CERT_OWNERSHIP);
 
     DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = s2n_cert_chain_and_key_new(),
             s2n_cert_chain_and_key_ptr_free);


### PR DESCRIPTION
# Goal

Fix a use after free issue in `s2n_config_add_cert_chain_and_key` method, which might be called twice at the moment.

## Why

`s2n_config_add_cert_chain_and_key_impl` inserted cert pointers into the `domain_name_to_cert_map` before checking whether the default cert slot was already occupied. On a second call with the same cert type, the slot check failed, the function returned an error, and `DEFER_CLEANUP` in the caller freed the cert, but the map still held pointers to it. A subsequent TLS handshake with a matching SNI would dereference freed memory.

## How

In `s2n_config_add_cert_chain_and_key_impl`, moved the `default-cert-slot-occupied` check before the `s2n_config_build_domain_name_to_cert_map` call. If the check fails, no state has been mutated, so `DEFER_CLEANUP` can safely free the cert.

Furthermore, we change the ownership guard from `!= S2N_APP_OWNED` to `== S2N_NOT_OWNED`, which will reject a second function call.

## Callouts

## Testing

Added a new test in `s2n_config_test.c` that verifies a failed second call does not increase the domain name map size (no entries inserted before failure). Also, adding a test to verify that it can still handle duplicate same-type certs correctly by making an update. All existing tests should also pass.

I have to update the `s2n_mldsa_server`, `s2n_mlkem_server`, and `trail` methods to use `default_without_certs` for config initialization. This PR tightens ownership check (== S2N_NOT_OWNED instead of != S2N_APP_OWNED) in the `s2n_config_add_cert_chain_and_key` API now rejects a second call on an already-configured config. Those rust tests  were calling `TlsConfigBuilderPair::default()`, which pre-loads an RSA2048 cert via load_pem, and then calling load_pem again with a different cert. Switched those tests to `default_without_certs()` since they already configure both client trust and server certs explicitly.

### Related

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
