### PR TITLE
fix: pin aws crt cpp to resolve general batch failures

### DIFF
--- a/codebuild/bin/build_aws_crt_cpp.sh
+++ b/codebuild/bin/build_aws_crt_cpp.sh
@@ -39,9 +39,8 @@ cd "$BUILD_DIR"
 # Pin to commit before "Mqtt test refactor" PR which broke WS test skip logic
 # in CI environments without IoT credentials. See: https://github.com/awslabs/aws-crt-cpp
 # TODO: Unpin once aws-crt-cpp fixes the skip logic for WS tests
-git clone --shallow-submodules --recurse-submodules https://github.com/awslabs/aws-crt-cpp.git
+git clone --recurse-submodules https://github.com/awslabs/aws-crt-cpp.git
 cd aws-crt-cpp
-git fetch --depth=50 origin main
 git checkout 7cb4eaa18cfbcabcc24f8ef3b9e4c2f18c77348c
 git submodule update --init --recursive
 cd ..

--- a/codebuild/bin/build_aws_crt_cpp.sh
+++ b/codebuild/bin/build_aws_crt_cpp.sh
@@ -36,7 +36,15 @@ mkdir -p "$BUILD_DIR/s2n"
 # In case $BUILD_DIR is a subdirectory of current directory
 for file in *;do test "$file" != "$BUILD_DIR" && cp -r "$file" "$BUILD_DIR/s2n";done
 cd "$BUILD_DIR"
-git clone --depth 1 --shallow-submodules --recurse-submodules https://github.com/awslabs/aws-crt-cpp.git
+# Pin to commit before "Mqtt test refactor" PR which broke WS test skip logic
+# in CI environments without IoT credentials. See: https://github.com/awslabs/aws-crt-cpp
+# TODO: Unpin once aws-crt-cpp fixes the skip logic for WS tests
+git clone --shallow-submodules --recurse-submodules https://github.com/awslabs/aws-crt-cpp.git
+cd aws-crt-cpp
+git fetch --depth=50 origin main
+git checkout 7cb4eaa18cfbcabcc24f8ef3b9e4c2f18c77348c
+git submodule update --init --recursive
+cd ..
 # Replace S2N
 rm -r aws-crt-cpp/crt/s2n
 mv s2n aws-crt-cpp/crt/


### PR DESCRIPTION
# Goal
This PR pins our dependency on aws-crt-cpp to commit 7cb4eaa18cfbcabcc24f8ef3b9e4c2f18c77348c in order to resolve CI failures in general batch [(example)](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoidUpNb2QzNjZzQ3lrWm1UQ2xzdFZMN1ZGYWE5dVlSQ1ZKd1BnZzZ6aXN1dlZXTmFuZWdvNnR0SitPaFlIcUdjaDZ6RU9KemY2Mi9ybXVBajF0RXo4NmZ1Rnl4dkZrT241UUY4MTVQMkRuNTQ9IiwiaXZQYXJhbWV0ZXJTcGVjIjoiemFRUDgvZUMreVhER0RKaiIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D/batch/0c2b4883-d61f-4267-8196-84077fdd7a3b)
## Why
A recent aws-crt-cpp PR ("Mqtt test refactor") broke the skip logic for 5 MQTT5 WebSocket tests. In CI environments without IoT credentials, these tests now crash with a fatal assertion instead of gracefully skipping. This is failing the s2nUnitCRT job in our general batch.

## How
Pin the git clone in build_aws_crt_cpp.sh to the commit immediately before the refactor PR.
## Callouts
Temporary fix, we should unpin once aws-crt-cpp resolves the skip logic. There's a TODO comment marking this.
I opened an issue upstream reporting this regression: https://github.com/awslabs/aws-crt-cpp/issues/844

## Testing
The pinned commit matches the last green run of s2nUnitCRT (222 tests, all passing/skipping). s2nGeneralBatch will run on this PR

### Related
https://github.com/awslabs/aws-crt-cpp/issues/844

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
