### PR TITLE
feat(metrics): add compatibility metrics

### DIFF
--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/resources/emf_sample.json
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/resources/emf_sample.json
@@ -186,6 +186,18 @@
             "Name": "signature_scheme.supported.rsa_pss_rsae_sha512"
           },
           {
+            "Name": "compatibility.general20251201"
+          },
+          {
+            "Name": "compatibility.fips20251201"
+          },
+          {
+            "Name": "compatibility.cnsa1"
+          },
+          {
+            "Name": "compatibility.cnsa2"
+          },
+          {
             "Name": "sslv2_client_hello"
           },
           {
@@ -201,7 +213,7 @@
         "Namespace": "tls/s2n-tls"
       }
     ],
-    "Timestamp": 1773180205683
+    "Timestamp": 1775868366418
   },
   "cipher.negotiated.TLS_AES_128_GCM_SHA256": 1,
   "cipher.negotiated.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256": 1,
@@ -235,14 +247,18 @@
   "cipher.supported.TLS_RSA_WITH_AES_256_CBC_SHA": 1,
   "cipher.supported.TLS_RSA_WITH_AES_256_CBC_SHA256": 1,
   "cipher.supported.TLS_RSA_WITH_AES_256_GCM_SHA384": 1,
+  "compatibility.cnsa1": 2,
+  "compatibility.cnsa2": 0,
+  "compatibility.fips20251201": 2,
+  "compatibility.general20251201": 2,
   "group.negotiated.secp256r1": 2,
   "group.supported.secp256r1": 2,
   "group.supported.secp384r1": 2,
   "group.supported.secp521r1": 1,
   "group.supported.x25519": 1,
-  "handshake_compute_us": 12416,
+  "handshake_compute_us": 12432,
   "handshake_count": 2,
-  "handshake_duration_us": 13524,
+  "handshake_duration_us": 13515,
   "resource": "cute-kitten",
   "service_name": "test_server",
   "signature_scheme.negotiated.rsa_pkcs1_sha256": 1,

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/compatibility.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/compatibility.rs
@@ -1,0 +1,306 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module holds utilities for checking when a client is compatible with some
+//! particular TLS Profile.
+
+use crate::{
+    parsing::ClientHelloSupportedParameters,
+    static_lists::{Cipher, Group, Signature, Version},
+};
+
+pub(crate) trait TlsProfile {
+    const ALLOWED_VERSIONS: &[Version];
+    const ALLOWED_CIPHERS: &[Cipher];
+    const ALLOWED_GROUPS: &[Group];
+    const ALLOWED_SIGNATURES: &[Signature];
+
+    /// returns true if a client could handshake with this [`TlsProfile`]
+    fn supported(client_hello: &ClientHelloSupportedParameters) -> bool {
+        let supported_version = client_hello
+            .supported_versions()
+            .map(|client_versions| {
+                client_versions
+                    .iter()
+                    .any(|client_version| Self::ALLOWED_VERSIONS.contains(client_version))
+            })
+            .unwrap_or(false);
+
+        let supported_cipher = client_hello
+            .supported_ciphers()
+            .map(|client_ciphers| {
+                client_ciphers
+                    .iter()
+                    .any(|client_cipher| Self::ALLOWED_CIPHERS.contains(client_cipher))
+            })
+            .unwrap_or(false);
+
+        let supported_signature = client_hello
+            .supported_signatures()
+            .ok()
+            .flatten()
+            .map(|client_signatures| {
+                client_signatures
+                    .iter()
+                    .any(|client_signature| Self::ALLOWED_SIGNATURES.contains(client_signature))
+            })
+            .unwrap_or(false);
+
+        let supported_group = client_hello
+            .supported_groups()
+            .ok()
+            .flatten()
+            .map(|client_groups| {
+                client_groups
+                    .iter()
+                    .any(|client_group| Self::ALLOWED_GROUPS.contains(client_group))
+            })
+            .unwrap_or(false);
+
+        supported_version && supported_cipher && supported_group && supported_signature
+    }
+}
+
+pub(crate) struct General20251201;
+impl TlsProfile for General20251201 {
+    const ALLOWED_VERSIONS: &[Version] = &[Version::TLS_1_2, Version::TLS_1_3];
+
+    const ALLOWED_CIPHERS: &[Cipher] = &[
+        Cipher::TLS_AES_128_GCM_SHA256,
+        Cipher::TLS_AES_256_GCM_SHA384,
+        Cipher::TLS_CHACHA20_POLY1305_SHA256,
+        Cipher::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        Cipher::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+        Cipher::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        Cipher::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+        // omission of TLS 1.2 CHACHA ciphers is deliberate, because they
+        // aren't supported in ELB security policies.
+    ];
+
+    const ALLOWED_GROUPS: &[Group] = &[
+        Group::x25519,
+        Group::secp256r1,
+        Group::secp384r1,
+        Group::secp521r1,
+        Group::X25519MLKEM768,
+        Group::SecP256r1MLKEM768,
+        Group::SecP384r1MLKEM1024,
+    ];
+
+    const ALLOWED_SIGNATURES: &[Signature] = &[
+        Signature::rsa_pss_pss_sha256,
+        Signature::rsa_pss_pss_sha384,
+        Signature::rsa_pss_pss_sha512,
+        Signature::rsa_pss_rsae_sha256,
+        Signature::rsa_pss_rsae_sha384,
+        Signature::rsa_pss_rsae_sha512,
+        Signature::ecdsa_secp256r1_sha256,
+        Signature::ecdsa_secp384r1_sha384,
+        Signature::ecdsa_secp521r1_sha512,
+    ];
+}
+
+pub(crate) struct Fips20251201;
+impl TlsProfile for Fips20251201 {
+    const ALLOWED_VERSIONS: &[Version] = &[Version::TLS_1_2, Version::TLS_1_3];
+
+    const ALLOWED_CIPHERS: &[Cipher] = &[
+        Cipher::TLS_AES_128_GCM_SHA256,
+        Cipher::TLS_AES_256_GCM_SHA384,
+        Cipher::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        Cipher::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+        Cipher::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        Cipher::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+    ];
+
+    const ALLOWED_GROUPS: &[Group] = &[
+        Group::secp256r1,
+        Group::secp384r1,
+        Group::secp521r1,
+        Group::X25519MLKEM768,
+        Group::SecP256r1MLKEM768,
+        Group::SecP384r1MLKEM1024,
+    ];
+
+    const ALLOWED_SIGNATURES: &[Signature] = &[
+        Signature::rsa_pss_pss_sha256,
+        Signature::rsa_pss_pss_sha384,
+        Signature::rsa_pss_pss_sha512,
+        Signature::rsa_pss_rsae_sha256,
+        Signature::rsa_pss_rsae_sha384,
+        Signature::rsa_pss_rsae_sha512,
+        Signature::ecdsa_secp256r1_sha256,
+        Signature::ecdsa_secp384r1_sha384,
+        Signature::ecdsa_secp521r1_sha512,
+    ];
+}
+
+pub(crate) struct Cnsa1;
+impl TlsProfile for Cnsa1 {
+    const ALLOWED_VERSIONS: &[Version] = &[Version::TLS_1_2, Version::TLS_1_3];
+
+    const ALLOWED_CIPHERS: &[Cipher] = &[
+        Cipher::TLS_AES_256_GCM_SHA384,
+        Cipher::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+    ];
+
+    const ALLOWED_GROUPS: &[Group] = &[Group::secp384r1];
+
+    const ALLOWED_SIGNATURES: &[Signature] = &[Signature::ecdsa_secp384r1_sha384];
+}
+
+pub(crate) struct Cnsa2;
+impl TlsProfile for Cnsa2 {
+    const ALLOWED_VERSIONS: &[Version] = &[Version::TLS_1_3];
+
+    const ALLOWED_CIPHERS: &[Cipher] = &[Cipher::TLS_AES_256_GCM_SHA384];
+
+    const ALLOWED_GROUPS: &[Group] = &[Group::MLKEM1024];
+
+    const ALLOWED_SIGNATURES: &[Signature] = &[Signature::mldsa87];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use s2n_tls::{
+        config::Builder,
+        security::Policy,
+        testing::{CertKeyPair, InsecureAcceptAllCertificatesHandler, TestPair},
+    };
+
+    /// Build a TestPair where the client uses `policy_name` and the server uses
+    /// a permissive policy with certs compatible with the client policy.
+    /// Returns the server connection (which holds the parsed client hello).
+    fn handshake_with_policy(
+        policy_name: &str,
+        cert: &CertKeyPair,
+    ) -> s2n_tls::connection::Connection {
+        let policy = Policy::from_version(policy_name).unwrap();
+
+        // client config: just the policy + trust
+        let client_config = {
+            let mut b = Builder::new();
+            b.set_security_policy(&policy).unwrap();
+            b.with_system_certs(false).unwrap();
+            b.trust_pem(cert.ca_cert()).unwrap();
+            b.set_verify_host_callback(InsecureAcceptAllCertificatesHandler {})
+                .unwrap();
+            b.build().unwrap()
+        };
+
+        // server config: permissive policy so it can always accept, with matching certs
+        let server_config = {
+            let mut b = Builder::new();
+            b.set_security_policy(&Policy::from_version("test_all").unwrap())
+                .unwrap();
+            b.with_system_certs(false).unwrap();
+            b.load_pem(cert.cert(), cert.key()).unwrap();
+            b.trust_pem(cert.ca_cert()).unwrap();
+            b.set_verify_host_callback(InsecureAcceptAllCertificatesHandler {})
+                .unwrap();
+            b.build().unwrap()
+        };
+
+        let mut pair = TestPair::from_configs(&client_config, &server_config);
+        pair.handshake().unwrap();
+        pair.server
+    }
+
+    fn default_cert() -> CertKeyPair {
+        CertKeyPair::default()
+    }
+
+    fn ecdsa_p384_cert() -> CertKeyPair {
+        CertKeyPair::from_path(
+            "permutations/ec_ecdsa_p384_sha384/",
+            "server-chain",
+            "server-key",
+            "ca-cert",
+        )
+    }
+
+    /// ML-DSA files don't use .pem extension, so we build configs directly
+    /// instead of using CertKeyPair.
+    fn mldsa87_configs(policy_name: &str) -> (s2n_tls::config::Config, s2n_tls::config::Config) {
+        let pems = concat!(env!("CARGO_MANIFEST_DIR"), "/../../../../tests/pems/mldsa/");
+        let cert = std::fs::read(format!("{pems}ML-DSA-87.crt")).unwrap();
+        let key = std::fs::read(format!("{pems}ML-DSA-87-seed.priv")).unwrap();
+
+        let client_config = {
+            let mut b = Builder::new();
+            b.set_security_policy(&Policy::from_version(policy_name).unwrap())
+                .unwrap();
+            b.with_system_certs(false).unwrap();
+            b.trust_pem(&cert).unwrap();
+            b.set_verify_host_callback(InsecureAcceptAllCertificatesHandler {})
+                .unwrap();
+            b.build().unwrap()
+        };
+        let server_config = {
+            let mut b = Builder::new();
+            b.set_security_policy(&Policy::from_version("test_all").unwrap())
+                .unwrap();
+            b.with_system_certs(false).unwrap();
+            b.load_pem(&cert, &key).unwrap();
+            b.trust_pem(&cert).unwrap();
+            b.set_verify_host_callback(InsecureAcceptAllCertificatesHandler {})
+                .unwrap();
+            b.build().unwrap()
+        };
+        (client_config, server_config)
+    }
+
+    #[test]
+    fn default_compatible_with_general() {
+        let server = handshake_with_policy("default", &default_cert());
+        let ch = server.client_hello().unwrap();
+        assert!(General20251201::supported(
+            &ClientHelloSupportedParameters::new(ch)
+        ));
+    }
+
+    #[test]
+    fn default_fips_compatible_with_fips() {
+        let server = handshake_with_policy("default_fips", &default_cert());
+        let ch = server.client_hello().unwrap();
+        assert!(Fips20251201::supported(
+            &ClientHelloSupportedParameters::new(ch)
+        ));
+    }
+
+    #[test]
+    fn cnsa_1_compatible_with_cnsa1() {
+        let server = handshake_with_policy("cnsa_1", &ecdsa_p384_cert());
+        let ch = server.client_hello().unwrap();
+        assert!(Cnsa1::supported(&ClientHelloSupportedParameters::new(ch)));
+    }
+
+    #[test]
+    fn cnsa_2_compatible_with_cnsa2() {
+        let (client_config, server_config) = mldsa87_configs("cnsa_2");
+        let mut pair = TestPair::from_configs(&client_config, &server_config);
+        pair.handshake().unwrap();
+        let ch = pair.server.client_hello().unwrap();
+        let supported_parameters = ClientHelloSupportedParameters::new(ch);
+
+        assert!(Cnsa2::supported(&supported_parameters));
+        // doesn't support required groups/signatures
+        assert!(!Cnsa1::supported(&supported_parameters));
+        // doesn't support required groups
+        assert!(!Fips20251201::supported(&supported_parameters));
+        // doesn't support required groups
+        assert!(!General20251201::supported(&supported_parameters));
+    }
+
+    #[test]
+    fn cnsa_1_2_interop_compatible_with_cnsa1_and_cnsa2() {
+        // cnsa_1_2_interop should be compatible with both Cnsa1 and Cnsa2 profiles
+        let cert = ecdsa_p384_cert();
+        let server = handshake_with_policy("cnsa_1_2_interop", &cert);
+        let ch = server.client_hello().unwrap();
+        let supported_parameters = ClientHelloSupportedParameters::new(ch);
+        assert!(Cnsa1::supported(&supported_parameters));
+        assert!(Cnsa2::supported(&supported_parameters));
+    }
+}

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/emf_emitter.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/emf_emitter.rs
@@ -218,6 +218,7 @@ mod tests {
         assert!(record.contains("version.negotiated.TLSv1_3"));
         assert!(record.contains("cipher.negotiated.TLS_AES_128_GCM_SHA256"));
         assert!(record.contains("signature_scheme.negotiated.rsa_pss_rsae_sha256"));
+        assert!(record.contains("compatibility.general20251201"));
     }
 
     /// if finish_record is called multiple times without writing, the finished

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/lib.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod compatibility;
 mod emf_emitter;
 mod label;
 mod parsing;

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use crate::{
+    compatibility::{Cnsa1, Cnsa2, Fips20251201, General20251201, TlsProfile},
     label::{State, metric_label},
     parsing::ClientHelloSupportedParameters,
     static_lists::{
@@ -67,6 +68,11 @@ pub(crate) struct HandshakeRecordInProgress {
     supported_groups: [AtomicU64; GROUP_COUNT],
     supported_signatures: [AtomicU64; SIGNATURE_COUNT],
 
+    compatibility_general20251201: AtomicU64,
+    compatibility_fips20251201: AtomicU64,
+    compatibility_cnsa1: AtomicU64,
+    compatibility_cnsa2: AtomicU64,
+
     /// sum of handshake duration, including network latency and waiting
     ///
     /// To get the average, divide this by handshake_count.
@@ -101,6 +107,11 @@ impl HandshakeRecordInProgress {
             supported_ciphers,
             supported_protocols: Default::default(),
             supported_signatures: Default::default(),
+
+            compatibility_general20251201: AtomicU64::default(),
+            compatibility_fips20251201: AtomicU64::default(),
+            compatibility_cnsa1: AtomicU64::default(),
+            compatibility_cnsa2: AtomicU64::default(),
 
             handshake_duration_us: Default::default(),
             handshake_compute_us: Default::default(),
@@ -172,6 +183,21 @@ impl HandshakeRecordInProgress {
                         counter.fetch_add(1, Ordering::Relaxed);
                     });
             }
+
+            if General20251201::supported(&supported_parameter) {
+                self.compatibility_general20251201
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            if Fips20251201::supported(&supported_parameter) {
+                self.compatibility_fips20251201
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            if Cnsa1::supported(&supported_parameter) {
+                self.compatibility_cnsa1.fetch_add(1, Ordering::Relaxed);
+            }
+            if Cnsa2::supported(&supported_parameter) {
+                self.compatibility_cnsa2.fetch_add(1, Ordering::Relaxed);
+            }
         }
 
         ////////////////////////////////////////////////////////////////////////
@@ -231,6 +257,13 @@ impl HandshakeRecordInProgress {
             supported_groups: relaxed_freeze(&self.supported_groups),
             supported_signatures: relaxed_freeze(&self.supported_signatures),
 
+            compatibility_general20251201: self
+                .compatibility_general20251201
+                .load(Ordering::Relaxed),
+            compatibility_fips20251201: self.compatibility_fips20251201.load(Ordering::Relaxed),
+            compatibility_cnsa1: self.compatibility_cnsa1.load(Ordering::Relaxed),
+            compatibility_cnsa2: self.compatibility_cnsa2.load(Ordering::Relaxed),
+
             handshake_duration_us: self.handshake_duration_us.load(Ordering::Relaxed),
             handshake_compute_us: self.handshake_compute_us.load(Ordering::Relaxed),
         }
@@ -262,6 +295,11 @@ pub(crate) struct FrozenHandshakeRecord {
     supported_groups: [u64; GROUP_COUNT],
     supported_signatures: [u64; SIGNATURE_COUNT],
 
+    compatibility_general20251201: u64,
+    compatibility_fips20251201: u64,
+    compatibility_cnsa1: u64,
+    compatibility_cnsa2: u64,
+
     handshake_duration_us: u64,
     handshake_compute_us: u64,
 }
@@ -283,6 +321,10 @@ impl Default for FrozenHandshakeRecord {
             supported_ciphers: [0; CIPHER_COUNT],
             supported_groups: [0; GROUP_COUNT],
             supported_signatures: [0; SIGNATURE_COUNT],
+            compatibility_general20251201: 0,
+            compatibility_fips20251201: 0,
+            compatibility_cnsa1: 0,
+            compatibility_cnsa2: 0,
             handshake_duration_us: 0,
             handshake_compute_us: 0,
         }
@@ -545,6 +587,23 @@ mod tests {
         // ignore the freeze time, since that "default" value is set to the Unix Epoch.
         record.freeze_time = SystemTime::UNIX_EPOCH;
         assert_eq!(record, FrozenHandshakeRecord::default());
+    }
+
+    /// ARBITRARY_POLICY_1 (20240503 / default_tls13) should be compatible with
+    /// General, Fips, and Cnsa1 profiles, but not CNSA2 (which requires MLKEM1024
+    /// and mldsa87).
+    #[test]
+    fn record_contents_compatibility_metrics() {
+        let endpoint = TestEndpoint::<Receiver<MetricRecord>>::new();
+
+        endpoint.client_handshake(&ARBITRARY_POLICY_1);
+        endpoint.subscriber.finish_record();
+        let record = endpoint.exporter.recv().unwrap().handshake;
+
+        assert_eq!(record.compatibility_general20251201, 1);
+        assert_eq!(record.compatibility_fips20251201, 1);
+        assert_eq!(record.compatibility_cnsa1, 1);
+        assert_eq!(record.compatibility_cnsa2, 0);
     }
 
     /// Make sure that the compute time is less than the overall handshake time.

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
@@ -395,6 +395,11 @@ impl metrique_writer::Entry for FrozenHandshakeRecord {
                 });
         }
 
+        writer.value("compatibility.general20251201", &self.compatibility_general20251201);
+        writer.value("compatibility.fips20251201", &self.compatibility_fips20251201);
+        writer.value("compatibility.cnsa1", &self.compatibility_cnsa1);
+        writer.value("compatibility.cnsa2", &self.compatibility_cnsa2);
+
         writer.value("sslv2_client_hello", &self.sslv2_client_hello);
         writer.value("handshake_count", &self.handshake_count);
         writer.value("handshake_duration_us", &self.handshake_duration_us);

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
@@ -395,8 +395,14 @@ impl metrique_writer::Entry for FrozenHandshakeRecord {
                 });
         }
 
-        writer.value("compatibility.general20251201", &self.compatibility_general20251201);
-        writer.value("compatibility.fips20251201", &self.compatibility_fips20251201);
+        writer.value(
+            "compatibility.general20251201",
+            &self.compatibility_general20251201,
+        );
+        writer.value(
+            "compatibility.fips20251201",
+            &self.compatibility_fips20251201,
+        );
         writer.value("compatibility.cnsa1", &self.compatibility_cnsa1);
         writer.value("compatibility.cnsa2", &self.compatibility_cnsa2);
 

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/static_lists.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/static_lists.rs
@@ -164,6 +164,14 @@ pub(crate) struct Cipher(pub(crate) [u8; 2]);
 impl Cipher {
     pub(crate) const TLS_EMPTY_RENEGOTIATION_INFO_SCSV: Self = Cipher([0, 255]);
 
+    pub(crate) const TLS_AES_128_GCM_SHA256: Self = Cipher([0x13, 0x01]);
+    pub(crate) const TLS_AES_256_GCM_SHA384: Self = Cipher([0x13, 0x02]);
+    pub(crate) const TLS_CHACHA20_POLY1305_SHA256: Self = Cipher([0x13, 0x03]);
+    pub(crate) const TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: Self = Cipher([0xC0, 0x2B]);
+    pub(crate) const TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: Self = Cipher([0xC0, 0x2C]);
+    pub(crate) const TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256: Self = Cipher([0xC0, 0x2F]);
+    pub(crate) const TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384: Self = Cipher([0xC0, 0x30]);
+
     /// e.g. "TLS_AES_256_GCM_SHA384"
     ///
     /// `None` if the cipher is not supported by s2n-tls
@@ -179,7 +187,25 @@ impl Cipher {
 #[repr(C)]
 pub(crate) struct Signature(pub(crate) s2n_codec::zerocopy::U16);
 
+// we allow non-upper case globals to let the constants exactly match the IANA description
+#[allow(non_upper_case_globals)]
 impl Signature {
+    pub(crate) const rsa_pss_rsae_sha256: Self = Signature(U16::new(0x0804));
+    pub(crate) const rsa_pss_rsae_sha384: Self = Signature(U16::new(0x0805));
+    pub(crate) const rsa_pss_rsae_sha512: Self = Signature(U16::new(0x0806));
+
+    pub(crate) const rsa_pss_pss_sha256: Self = Signature(U16::new(0x0809));
+    pub(crate) const rsa_pss_pss_sha384: Self = Signature(U16::new(0x080A));
+    pub(crate) const rsa_pss_pss_sha512: Self = Signature(U16::new(0x080B));
+
+    pub(crate) const ecdsa_secp256r1_sha256: Self = Signature(U16::new(0x0403));
+    pub(crate) const ecdsa_secp384r1_sha384: Self = Signature(U16::new(0x0503));
+    pub(crate) const ecdsa_secp521r1_sha512: Self = Signature(U16::new(0x0603));
+
+    pub(crate) const mldsa44: Self = Signature(U16::new(0x0904));
+    pub(crate) const mldsa65: Self = Signature(U16::new(0x0905));
+    pub(crate) const mldsa87: Self = Signature(U16::new(0x0906));
+
     pub fn known_description(&self) -> Option<&'static str> {
         SIGNATURE_SCHEMES_AVAILABLE_IN_S2N
             .iter()
@@ -192,7 +218,20 @@ impl Signature {
 #[repr(C)]
 pub(crate) struct Group(pub(crate) s2n_codec::zerocopy::U16);
 
+// we allow non-upper case globals to let the constants exactly match the IANA description
+#[allow(non_upper_case_globals)]
 impl Group {
+    pub(crate) const x25519: Self = Group(U16::new(29));
+    pub(crate) const secp256r1: Self = Group(U16::new(23));
+    pub(crate) const secp384r1: Self = Group(U16::new(24));
+    pub(crate) const secp521r1: Self = Group(U16::new(25));
+
+    pub(crate) const SecP256r1MLKEM768: Self = Group(U16::new(4587));
+    pub(crate) const X25519MLKEM768: Self = Group(U16::new(4588));
+    pub(crate) const SecP384r1MLKEM1024: Self = Group(U16::new(4589));
+
+    pub(crate) const MLKEM1024: Self = Group(U16::new(514));
+
     /// e.g. "secp256r1"
     ///
     /// `None` if the group is not supported by s2n-tls
@@ -465,6 +504,80 @@ mod tests {
     fn all_signature_schemes_in_static_list() {
         let schemes = all_available_signatures();
         assert_eq!(&schemes, SIGNATURE_SCHEMES_AVAILABLE_IN_S2N);
+    }
+
+    /// Verify that the named Cipher constants have IANA values matching s2n-tls.
+    /// The static lists are already validated against s2n-tls by the tests above,
+    /// so we validate constants against the lists via known_description().
+    #[test]
+    fn cipher_constants_match_s2n() {
+        let cases: &[(Cipher, &str)] = &[
+            (Cipher::TLS_AES_128_GCM_SHA256, "TLS_AES_128_GCM_SHA256"),
+            (Cipher::TLS_AES_256_GCM_SHA384, "TLS_AES_256_GCM_SHA384"),
+            (
+                Cipher::TLS_CHACHA20_POLY1305_SHA256,
+                "TLS_CHACHA20_POLY1305_SHA256",
+            ),
+            (
+                Cipher::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            ),
+            (
+                Cipher::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+                "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+            ),
+            (
+                Cipher::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+                "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+            ),
+            (
+                Cipher::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+                "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            ),
+        ];
+        for (constant, expected_name) in cases {
+            assert_eq!(constant.known_description().unwrap(), *expected_name);
+        }
+    }
+
+    /// Verify that the named Group constants have IANA values matching s2n-tls.
+    #[test]
+    fn group_constants_match_s2n() {
+        let cases: &[(Group, &str)] = &[
+            (Group::x25519, "x25519"),
+            (Group::secp256r1, "secp256r1"),
+            (Group::secp384r1, "secp384r1"),
+            (Group::secp521r1, "secp521r1"),
+            (Group::SecP256r1MLKEM768, "SecP256r1MLKEM768"),
+            (Group::X25519MLKEM768, "X25519MLKEM768"),
+            (Group::SecP384r1MLKEM1024, "SecP384r1MLKEM1024"),
+            (Group::MLKEM1024, "MLKEM1024"),
+        ];
+        for (constant, expected_name) in cases {
+            assert_eq!(constant.known_description().unwrap(), *expected_name);
+        }
+    }
+
+    /// Verify that the named Signature constants have IANA values matching s2n-tls.
+    #[test]
+    fn signature_constants_match_s2n() {
+        let cases: &[(Signature, &str)] = &[
+            (Signature::rsa_pss_rsae_sha256, "rsa_pss_rsae_sha256"),
+            (Signature::rsa_pss_rsae_sha384, "rsa_pss_rsae_sha384"),
+            (Signature::rsa_pss_rsae_sha512, "rsa_pss_rsae_sha512"),
+            (Signature::rsa_pss_pss_sha256, "rsa_pss_pss_sha256"),
+            (Signature::rsa_pss_pss_sha384, "rsa_pss_pss_sha384"),
+            (Signature::rsa_pss_pss_sha512, "rsa_pss_pss_sha512"),
+            (Signature::ecdsa_secp256r1_sha256, "ecdsa_sha256"),
+            (Signature::ecdsa_secp384r1_sha384, "ecdsa_sha384"),
+            (Signature::ecdsa_secp521r1_sha512, "ecdsa_sha512"),
+            (Signature::mldsa44, "mldsa44"),
+            (Signature::mldsa65, "mldsa65"),
+            (Signature::mldsa87, "mldsa87"),
+        ];
+        for (constant, expected_name) in cases {
+            assert_eq!(constant.known_description().unwrap(), *expected_name);
+        }
     }
 
     #[test]


### PR DESCRIPTION
# Goal
Provide counters to determine compatibility of targeted TLS profiles.

## Why
To determine if it is safe to update to a new TLS policy, some connection level information is necessary.

Pretend there is a server with the following negotiation counts and supported parameters
```
negotiated groups
A: 100
B: 0
C: 0

supported groups
A: 100
B: 50
C: 50
```

Is it safe to drop support for group A? The problem is that we don't know without additional information. It's possible that either 50 clients support A and B, or 100 clients support A xor B.

## How
So we add compatibility counters that will help us determine when server endpoints can adopt each of our target profiles.

## Testing
Added unit tests to confirm that we are correctly determining compatibility and that the counters are showing up in the metric record. Also added unit tests to make sure that the constants have the correct IANA values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
