### PR TITLE
fix: unchecked NULL return from X509_EXTENSION_get_data

### DIFF
--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -817,6 +817,7 @@ static int s2n_parse_x509_extension(struct s2n_cert *cert, const uint8_t *oid,
              * Ref: https://www.openssl.org/docs/man1.1.0/man3/X509_EXTENSION_get_data.html.
              */
             asn1_str = X509_EXTENSION_get_data(x509_ext);
+            POSIX_ENSURE_REF(asn1_str);
             /* ASN1_STRING_length() returns the length of the content of `asn1_str`.
             * Ref: https://www.openssl.org/docs/man1.1.0/man3/ASN1_STRING_length.html.
             */


### PR DESCRIPTION
# Goal

Resolves potential unchecked NULL return from `X509_EXNTESION_get_data` function.

## Why

The `X509_EXNTESION_get_data` function return the extension data from an X509 certificate. However, there is not check to validate that the return value is not NULL. We need to make sure that the returned value is not NULL, otherwise, we might encounter segmentation fault, since we store this value and use it in the future.

## How

`POSIX_ENSURE_REF` for the value that is returned by `X509_EXNTESION_get_data`.

## Callouts

N/A

## Testing

Exiting tests should pass. No additional tests were added for this PR.

### Related

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
