### PR TITLE
ci: add clang-tidy to CI

### DIFF
--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -117,6 +117,24 @@ jobs:
         with:
           clang-format-version: '18'
           include-regex: '^(\.\/)?(api|bin|crypto|stuffer|error|tls|utils|tests\/unit|tests\/testlib|docs\/examples).*\.(c|h)$'
+  
+  clang-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup
+        run: source ./codebuild/bin/s2n_setup_env.sh
+
+      - name: Install clang-tidy
+        run: sudo apt update && sudo apt install -y clang-tidy clang-tools-extra cmake ninja-build
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      - name: Run clang-tidy
+        run: run-clang-tidy -p build
+
   nixflake:
     # The nix develop changes contain broken nixpkg dependenecies; the allow/impure flags workaround this.
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Goal

Add `clang-tidy` to the linting CI workflow so C/C++ static analysis is run automatically on pull requests, pushes to `main`, and merge groups.

## Why

The repository currently runs several linting and formatting checks in CI, but does not run `clang-tidy`. Adding it helps catch potential code quality and maintainability issues earlier in the development process.

## How

This PR adds a new `clang-tidy` job to `.github/workflows/ci_linting.yml`.

The new job:

* Checks out the repository
* Runs the existing environment setup script
* Installs `clang-tidy`, `clang-tools-extra`, `cmake`, and `ninja-build`
* Configures the project with `CMAKE_EXPORT_COMPILE_COMMANDS=ON`
* Runs `run-clang-tidy -p build`

## Callouts

* This implementation uses `run-clang-tidy`, which relies on `compile_commands.json` generated during the CMake configure step.
* `clang-tools-extra` is installed because it provides the `run-clang-tidy` utility on Ubuntu runners.
* No `.clang-tidy` configuration file was added in this PR, so the default `clang-tidy` checks will be used.

## Testing

* Verified the workflow YAML structure and indentation
* Confirmed that the new job follows the existing lint workflow style
* Confirmed that `run-clang-tidy` is invoked against the generated build directory

### Related

Resolves #5250
