### PR TITLE
revert: "fix: pin aws crt cpp to resolve general batch failures"

### DIFF
--- a/codebuild/bin/build_aws_crt_cpp.sh
+++ b/codebuild/bin/build_aws_crt_cpp.sh
@@ -36,14 +36,7 @@ mkdir -p "$BUILD_DIR/s2n"
 # In case $BUILD_DIR is a subdirectory of current directory
 for file in *;do test "$file" != "$BUILD_DIR" && cp -r "$file" "$BUILD_DIR/s2n";done
 cd "$BUILD_DIR"
-# Pin to commit before "Mqtt test refactor" PR which broke WS test skip logic
-# in CI environments without IoT credentials. See: https://github.com/awslabs/aws-crt-cpp
-# TODO: Unpin once aws-crt-cpp fixes the skip logic for WS tests
-git clone --recurse-submodules https://github.com/awslabs/aws-crt-cpp.git
-cd aws-crt-cpp
-git checkout 7cb4eaa18cfbcabcc24f8ef3b9e4c2f18c77348c
-git submodule update --init --recursive
-cd ..
+git clone --depth 1 --shallow-submodules --recurse-submodules https://github.com/awslabs/aws-crt-cpp.git
 # Replace S2N
 rm -r aws-crt-cpp/crt/s2n
 mv s2n aws-crt-cpp/crt/


### PR DESCRIPTION
Reverts aws/s2n-tls#5822

The issue which caused us to pin the version of crt cpp has been resolved upstream, so this change should now be safe to revert, see https://github.com/awslabs/aws-crt-cpp/pull/845.