### PR TITLE
chore: release metrics subscriber v0.0.2

### DIFF
--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-tls-metrics-subscriber"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 description = "Telemetry provider for s2n-tls"
 authors = ["AWS s2n"]
@@ -8,7 +8,7 @@ repository = "https://github.com/aws/s2n-tls"
 license = "Apache-2.0"
 
 [dependencies]
-s2n-codec = {git = "https://github.com/aws/s2n-quic"}
+s2n-codec = "0.77"
 static_assertions = "1.1.0"
 zerocopy = "0.8.33"
 tracing = "0.1.43"
@@ -19,9 +19,9 @@ arc-swap = "1.8.0"
 # minimum versions set for workspace-wide cargo minimal-versions compatibility
 serde = { version = "1.0.203", features = ["derive"] }
 serde-big-array = "0.5"
-# we at least need 0.3.33, because that is when the event APIs were introduced
-s2n-tls = { version = "0.3.33", path = "../../extended/s2n-tls", features = ["unstable-events", "unstable-testing"] }
-s2n-tls-sys = { version = "0.3.33", path = "../../extended/s2n-tls-sys"}
+# we at least need 0.3.36, because that is when the CNSA security policies were introduced
+s2n-tls = { version = "0.3.36", path = "../../extended/s2n-tls", features = ["unstable-events", "unstable-testing"] }
+s2n-tls-sys = { version = "0.3.36", path = "../../extended/s2n-tls-sys"}
 
 [dev-dependencies]
 s2n-tls-sys-internal = { path = "../s2n-tls-sys-internal" }


### PR DESCRIPTION
# Goal
Bump s2n-tls-metrics-subscriber version to 0.0.2

## Why
This will enable consumers to gain visibility into supported parameters, compataibility metrics, and per-resource visibility.

## How
Updates to Cargo.toml: crates.io does not allow packages to be published with git dependencies, so I replaced the s2n-codec git dependency with a crates.io version (0.77). I also bumped the minimum version for s2n-tls and s2n-tls-sys from 0.3.33 to 0.3.36 so that consumers pulling from crates.io get a version that includes the CNSA security policies.

## Callouts
N/A

## Testing
cargo publish -p s2n-tls-metrics-subscriber --dry-run passes

### Related
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
