### PR TITLE
ci: disable go when build awslc

### DIFF
--- a/codebuild/bin/install_awslc.sh
+++ b/codebuild/bin/install_awslc.sh
@@ -55,7 +55,8 @@ install_awslc() {
       -DCMAKE_BUILD_TYPE=relwithdebinfo \
       -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
       -DCMAKE_C_COMPILER=$(which clang) \
-      -DCMAKE_CXX_COMPILER=$(which clang++)
+      -DCMAKE_CXX_COMPILER=$(which clang++) \
+      -DDISABLE_GO=ON
     ninja -j "$(nproc)" -C build install
     ninja -C build clean
 }


### PR DESCRIPTION
# Goal

Unblock s2n-tls GeneralBatch CI job.

## Why

The job is failing currently which blocks the CI.

## How

Temporarily disable Go in AWS-LC build.

```
CMake Error at cmake/go.cmake:19 (message):
Go compiler version must be at least 1.20.  Found version 1.18.1
``` 

AWS-LC recently upgrade their Go dependency to 1.20, which is higher than what we have in the docker image. However, seems like Go is only used for testing in AWS-LC which we don't really need it. They also provide a compilation flag to disable Go. https://github.com/aws/aws-lc/pull/3159

## Callouts

## Testing

s2nGeneralBatch job should no longer be blocked.

### Related

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
