### PR TITLE
fix: typos in s2n-tls codebase

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -998,7 +998,7 @@ typedef uint8_t (*s2n_verify_host_fn)(const char *host_name, size_t host_name_le
  * Sets the callback to use for verifying that a hostname from an X.509 certificate is trusted.
  *
  * The default behavior is to require that the hostname match the server name set with s2n_set_server_name().
- * This will likely lead to all client certificates being rejected, so the callback will need to be overriden when using
+ * This will likely lead to all client certificates being rejected, so the callback will need to be overridden when using
  *  client authentication.
  *
  * This change will be inherited by s2n_connections using this config. If a separate callback for different connections
@@ -2009,7 +2009,7 @@ S2N_API extern int s2n_connection_set_dynamic_record_threshold(struct s2n_connec
  * Sets the callback to use for verifying that a hostname from an X.509 certificate is trusted.
  *
  * The default behavior is to require that the hostname match the server name set with s2n_set_server_name(). This will
- * likely lead to all client certificates being rejected, so the callback will need to be overriden when using client authentication.
+ * likely lead to all client certificates being rejected, so the callback will need to be overridden when using client authentication.
  *
  * If a single callback for different connections using the same config is desired, see s2n_config_set_verify_host_callback().
  *

--- a/api/unstable/events.h
+++ b/api/unstable/events.h
@@ -54,7 +54,7 @@ S2N_API extern int s2n_config_set_subscriber(struct s2n_config *config, void *su
  * Set a callback to receive a handshake event.
  * 
  * The `struct s2n_event_handshake *event` is only valid over the lifetime of the 
- * callbacks, and must not be reference after the callback returned.
+ * callbacks, and must not be referenced after the callback returned.
  * 
  * An event is not emitted if the handshake fails.
  */

--- a/crypto/s2n_libcrypto.c
+++ b/crypto/s2n_libcrypto.c
@@ -184,7 +184,7 @@ S2N_RESULT s2n_libcrypto_validate_runtime(void)
     /* If we know the expected version name, we can validate it. */
     if (s2n_libcrypto_is_awslc()) {
         const char *expected_awslc_name_prefix = NULL;
-        /* For backwards compatability, also check the AWS-LC API version see
+        /* For backwards compatibility, also check the AWS-LC API version see
          * https://github.com/awslabs/aws-lc/pull/467. When we are confident we
          * don't meet anymore "old" AWS-LC libcrypto's, this API version check
          * can be removed.

--- a/crypto/s2n_openssl_x509.h
+++ b/crypto/s2n_openssl_x509.h
@@ -42,7 +42,7 @@ S2N_RESULT s2n_openssl_x509_parse(struct s2n_blob *asn1der, X509 **cert_out);
  * This function is used to convert an s2n_blob into an openssl X509 cert.
  * Unlike `s2n_openssl_x509_parse` no additional validation is done. This
  * function should only be used in places where it is necessary to maintain
- * compatability with previous permissive parsing behavior.
+ * compatibility with previous permissive parsing behavior.
  */
 S2N_RESULT s2n_openssl_x509_parse_without_length_validation(struct s2n_blob *asn1der, X509 **cert_out);
 

--- a/docs/usage-guide/topics/ch16-post-quantum.md
+++ b/docs/usage-guide/topics/ch16-post-quantum.md
@@ -12,7 +12,7 @@ s2n-tls supports both hybrid and pure PQ key exchange.
 
 - Pure PQ key exchange involves only post-quantum key exchange, without classic ECC components. It is a simpler long-term architecture compared to hybrid PQ algorithms. However, Pure PQ key exchange might lead to potential incompatibility with older devices as it takes no dependence on traditional ECC algorithms.
 
-Careful: An s2n-tls server that enables post-quantum cryptography will mandate post-quantum key exchange with any client advertising post-quantum algorithms. This can result in a retry and an extra round trip if the client does not initially send a post-quantum key share. The rational behind this behavior is that post-quantum users prioritize security over the potential cost of an extra round trip.
+Careful: An s2n-tls server that enables post-quantum cryptography will mandate post-quantum key exchange with any client advertising post-quantum algorithms. This can result in a retry and an extra round trip if the client does not initially send a post-quantum key share. The rationale behind this behavior is that post-quantum users prioritize security over the potential cost of an extra round trip.
 
 ## Authentication: ML-DSA
 

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -349,7 +349,7 @@ S2N_RESULT s2n_alerts_write_error_or_close_notify(struct s2n_connection *conn)
      * By default, s2n-tls sends a generic close_notify alert, even in
      * response to fatal errors. This is done to avoid potential
      * side-channel attacks since specific alerts could reveal information
-     * about why the error occured.
+     * about why the error occurred.
      */
     uint8_t code = S2N_TLS_ALERT_CLOSE_NOTIFY;
     uint8_t level = S2N_TLS_ALERT_LEVEL_WARNING;

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -151,7 +151,7 @@ struct s2n_config {
 
     s2n_ct_support_level ct_type;
 
-    /* Track whether the application has overriden the default client auth type.
+    /* Track whether the application has overridden the default client auth type.
      * Clients and servers have different default client auth behavior, and this
      * config could apply to either.
      * This should be a bitflag, but that change is blocked on the SAW proofs.

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1271,7 +1271,7 @@ S2N_RESULT s2n_connection_calculate_blinding(struct s2n_connection *conn, int64_
     RESULT_ENSURE_REF(conn->config);
 
     /*
-     * The default delay is a random value between 10-30s. The rational behind the range is that the
+     * The default delay is a random value between 10-30s. The rationale behind the range is that the
      * floor is the fixed cost that an attacker must pay per attempt, in this case, 10s. The length of
      * the range then affects the number of attempts that an attacker must perform in order to recover a
      * byte of plaintext with a certain degree of confidence.

--- a/tls/s2n_connection_serialize.c
+++ b/tls/s2n_connection_serialize.c
@@ -250,7 +250,7 @@ static S2N_RESULT s2n_connection_deserialize_parse(uint8_t *buffer, uint32_t buf
  * Therefore the provided nonce cannot be considered to be the implicit IV because n ^ iv != iv.
  * This inability to get the correct implicit IV causes issues with encryption later on.
  *
- * To resolve this we preform one throwaway encryption call with a zero sequence number after
+ * To resolve this we perform one throwaway encryption call with a zero sequence number after
  * deserialization. This allows the libcrypto to recover the implicit IV correctly.
  */
 static S2N_RESULT s2n_initialize_implicit_iv(struct s2n_connection *conn, struct s2n_connection_deserialize *parsed_values)

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -1920,7 +1920,7 @@ int s2n_connection_is_valid_for_cipher_preferences(struct s2n_connection *conn, 
     POSIX_GUARD(s2n_find_security_policy_from_version(version, &security_policy));
     POSIX_ENSURE_REF(security_policy);
 
-    /* make sure we dont use a tls version lower than that configured by the version */
+    /* make sure we don't use a tls version lower than that configured by the version */
     if (s2n_connection_get_actual_protocol_version(conn) < security_policy->minimum_protocol_version) {
         return 0;
     }


### PR DESCRIPTION
# Goal

Fix typos that we can find right now.

## Why

Fixing typos in the our codebase improves readability.

## How

Go through the entire codebase and fix every typos that we can find.

## Callouts

Our typos check can't find everything. I think it has a set dictionary.

## Testing

Existing test.

### Related

resolves https://github.com/aws/s2n-tls/pull/5829.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
