### PR TITLE
ci: fix failed renegotiation tests in the Rust bindings

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/renegotiate.rs
+++ b/bindings/rust/extended/s2n-tls/src/renegotiate.rs
@@ -579,6 +579,8 @@ mod tests {
             }
         }
 
+        // Send a renegotiation HelloRequest and drain the 1-byte flush
+        // payload so callers don't have to deal with it.
         fn send_renegotiate_request(&mut self) -> Result<(), crate::error::Error> {
             let openssl_ptr = self.server.ssl().as_ptr();
 
@@ -594,9 +596,9 @@ mod tests {
             assert_eq!(requested, 1, "Renegotiation should be pending");
 
             // SSL_renegotiate only schedules the HelloRequest internally.
-            // A subsequent SSL_write flushes it. Some OpenSSL versions
-            // ignore a zero-length write, so we send a single byte of
-            // application data to reliably trigger the flush.
+            // A subsequent SSL_write flushes it. OpenSSL 3.6.1 changed
+            // this behavior such that zero-length writes are now no-ops,
+            // so we now write a single byte to force the flush.
             assert_eq!(
                 self.server
                     .write(&[0])
@@ -604,7 +606,12 @@ mod tests {
                 1
             );
 
-            Ok(())
+            // Drain the 1-byte flush payload
+            match self.client.poll_recv(&mut [0; 1]) {
+                Ready(Ok(1)) => Ok(()),
+                Ready(Err(e)) => Err(e),
+                other => panic!("Expected to drain flush byte, got {:?}", other),
+            }
         }
 
         // Send and receive application data.
@@ -660,16 +667,12 @@ mod tests {
         // Drive both sides until the renegotiation handshake completes,
         // without sending or expecting application data.
         fn finish_renegotiate(&mut self) {
-            for _ in 0..20 {
+            while self.client.is_renegotiating() || self.openssl_is_handshaking() {
                 let _ = self.client.poll_recv(&mut [0; 1]);
                 // Use a non-zero-length buffer so SSL_read actually
                 // processes incoming handshake messages from the client.
                 let _ = self.server.read(&mut [0; 1]);
-                if !self.client.is_renegotiating() && !self.openssl_is_handshaking() {
-                    return;
-                }
             }
-            panic!("renegotiation did not complete");
         }
     }
 
@@ -723,10 +726,9 @@ mod tests {
         let mut pair = RenegotiateTestPair::from(builder)?;
 
         pair.handshake().expect("Initial handshake");
-        pair.send_renegotiate_request()
-            .expect("Server sends request");
-        // Expect receiving the hello request to be an error
-        let error = unwrap_poll(pair.client.poll_recv(&mut [0; 1])).unwrap_err();
+        // send_renegotiate_request() returns Err if the client's renegotiate
+        // callback errors when processing the HelloRequest during the drain.
+        let error = pair.send_renegotiate_request().unwrap_err();
         assert_eq!(error.name(), "S2N_ERR_CANCELLED");
 
         Ok(())
@@ -807,9 +809,6 @@ mod tests {
             .write_all(server_data)
             .expect("server app data after hello request");
 
-        // Drain the flush byte from send_renegotiate_request
-        unwrap_poll(pair.client.poll_recv(&mut [0; 1]))?;
-
         // First poll reads both the hello request and the app data
         let mut buffer = [0; 100];
         let read = unwrap_poll(pair.client.poll_recv(&mut buffer))?;
@@ -833,9 +832,6 @@ mod tests {
         // Server sends hello request, but initially no app data
         pair.send_renegotiate_request()
             .expect("server hello request");
-
-        // Drain the flush byte from send_renegotiate_request
-        unwrap_poll(pair.client.poll_recv(&mut [0; 1]))?;
 
         // Client can read the hello request
         let mut buffer = [0; 100];
@@ -873,9 +869,6 @@ mod tests {
         pair.send_renegotiate_request()
             .expect("server hello request");
 
-        // Drain the flush byte from send_renegotiate_request
-        unwrap_poll(pair.client.poll_recv(&mut [0; 1]))?;
-
         // Client and server renegotiate while never reading app data
         pair.finish_renegotiate();
 
@@ -901,11 +894,6 @@ mod tests {
             pair.server.write(server_data).expect("server app data"),
             server_data.len()
         );
-
-        // send_renegotiate_request writes a 1-byte app data payload to
-        // flush the HelloRequest. Drain it before reading server_data.
-        let read = unwrap_poll(pair.client.poll_recv(&mut [0; 1])).expect("Drain flush byte");
-        assert_eq!(read, 1);
 
         // Read only the first byte of the server data
         let mut buffer = [0; 100];
@@ -952,8 +940,6 @@ mod tests {
         // The client fails to start renegotiation due to pending send.
         pair.send_renegotiate_request()
             .expect("Server sends request");
-        // Drain the flush byte from send_renegotiate_request
-        unwrap_poll(pair.client.poll_recv(&mut [0; 1]))?;
         let error = unwrap_poll(pair.client.poll_recv(&mut [0; 1])).unwrap_err();
         assert_eq!(error.kind(), ErrorType::UsageError);
         assert!(error.message().contains(RENEG_ERR_MARKER));
@@ -974,8 +960,6 @@ mod tests {
         // Read the hello request and start renegotiation
         pair.send_renegotiate_request()
             .expect("server HELLO_REQUEST");
-        // Drain the flush byte from send_renegotiate_request
-        unwrap_poll(pair.client.poll_recv(&mut [0; 1]))?;
         assert!(pair.client.poll_recv(&mut [0; 1]).is_pending());
         assert!(pair.client.is_renegotiating());
 

--- a/bindings/rust/extended/s2n-tls/src/renegotiate.rs
+++ b/bindings/rust/extended/s2n-tls/src/renegotiate.rs
@@ -904,8 +904,7 @@ mod tests {
 
         // send_renegotiate_request writes a 1-byte app data payload to
         // flush the HelloRequest. Drain it before reading server_data.
-        let read = unwrap_poll(pair.client.poll_recv(&mut [0; 1]))
-            .expect("Drain flush byte");
+        let read = unwrap_poll(pair.client.poll_recv(&mut [0; 1])).expect("Drain flush byte");
         assert_eq!(read, 1);
 
         // Read only the first byte of the server data

--- a/bindings/rust/extended/s2n-tls/src/renegotiate.rs
+++ b/bindings/rust/extended/s2n-tls/src/renegotiate.rs
@@ -593,13 +593,15 @@ mod tests {
             let requested = unsafe { SSL_renegotiate_pending(openssl_ptr) };
             assert_eq!(requested, 1, "Renegotiation should be pending");
 
-            // SSL_renegotiate doesn't actually send the message.
-            // Like s2n-tls, a call to send / write is required.
+            // SSL_renegotiate only schedules the HelloRequest internally.
+            // A subsequent SSL_write flushes it. Some OpenSSL versions
+            // ignore a zero-length write, so we send a single byte of
+            // application data to reliably trigger the flush.
             assert_eq!(
                 self.server
-                    .write(&[0; 0])
+                    .write(&[0])
                     .expect("Failed to write hello request"),
-                0
+                1
             );
 
             Ok(())
@@ -629,42 +631,20 @@ mod tests {
         // application data written by the server after the new handshake.
         fn assert_renegotiate(&mut self) -> Result<(), Box<dyn Error>> {
             const APP_DATA: &[u8] = b"Renegotiation complete";
+
+            // Complete the renegotiation handshake first.
+            self.finish_renegotiate();
+
+            // Now send and receive application data to confirm the
+            // renegotiated connection works.
+            self.server
+                .write_all(APP_DATA)
+                .expect("server app data after renegotiation");
+
             let mut buffer = [0; APP_DATA.len()];
-
-            for _ in 0..20 {
-                let client_read_poll = self.client.poll_recv(&mut buffer);
-                match client_read_poll {
-                    Pending => {
-                        assert!(self.client.is_renegotiating(), "s2n-tls not renegotiating");
-                    }
-                    Ready(Ok(bytes_read)) => {
-                        assert_eq!(bytes_read, APP_DATA.len());
-                        assert_eq!(&buffer, APP_DATA);
-                        break;
-                    }
-                    Ready(err) => err.map(|_| ())?,
-                };
-
-                // Openssl needs to read the new ClientHello in order to know
-                // that s2n-tls is actually renegotiating.
-                // But after the initial read, writes can progress the handshake.
-                if !self.openssl_is_handshaking() {
-                    let _ = self.server.read(&mut [0; 0]);
-                } else {
-                    let server_write_result = self.server.write(APP_DATA);
-                    println!(
-                        "openssl result: {:?}, state: {:?}",
-                        server_write_result,
-                        self.server.ssl().state_string_long()
-                    );
-                    match server_write_result {
-                        Ok(bytes_written) => assert_eq!(bytes_written, APP_DATA.len()),
-                        Err(_) => {
-                            assert!(self.openssl_is_handshaking(), "openssl not renegotiating");
-                        }
-                    }
-                }
-            }
+            let bytes_read = unwrap_poll(self.client.poll_recv(&mut buffer))?;
+            assert_eq!(bytes_read, APP_DATA.len());
+            assert_eq!(&buffer, APP_DATA);
 
             assert!(
                 !self.client.is_renegotiating(),
@@ -675,6 +655,21 @@ mod tests {
                 "openssl renegotiation not complete"
             );
             Ok(())
+        }
+
+        // Drive both sides until the renegotiation handshake completes,
+        // without sending or expecting application data.
+        fn finish_renegotiate(&mut self) {
+            for _ in 0..20 {
+                let _ = self.client.poll_recv(&mut [0; 1]);
+                // Use a non-zero-length buffer so SSL_read actually
+                // processes incoming handshake messages from the client.
+                let _ = self.server.read(&mut [0; 1]);
+                if !self.client.is_renegotiating() && !self.openssl_is_handshaking() {
+                    return;
+                }
+            }
+            panic!("renegotiation did not complete");
         }
     }
 
@@ -812,6 +807,9 @@ mod tests {
             .write_all(server_data)
             .expect("server app data after hello request");
 
+        // Drain the flush byte from send_renegotiate_request
+        unwrap_poll(pair.client.poll_recv(&mut [0; 1]))?;
+
         // First poll reads both the hello request and the app data
         let mut buffer = [0; 100];
         let read = unwrap_poll(pair.client.poll_recv(&mut buffer))?;
@@ -835,6 +833,9 @@ mod tests {
         // Server sends hello request, but initially no app data
         pair.send_renegotiate_request()
             .expect("server hello request");
+
+        // Drain the flush byte from send_renegotiate_request
+        unwrap_poll(pair.client.poll_recv(&mut [0; 1]))?;
 
         // Client can read the hello request
         let mut buffer = [0; 100];
@@ -872,16 +873,11 @@ mod tests {
         pair.send_renegotiate_request()
             .expect("server hello request");
 
+        // Drain the flush byte from send_renegotiate_request
+        unwrap_poll(pair.client.poll_recv(&mut [0; 1]))?;
+
         // Client and server renegotiate while never reading app data
-        assert!(pair.client.poll_recv(&mut [0; 1]).is_pending());
-        assert!(pair.client.is_renegotiating());
-        loop {
-            let _ = pair.server.read(&mut [0; 0]);
-            assert!(pair.client.poll_recv(&mut [0; 1]).is_pending());
-            if !pair.client.is_renegotiating() {
-                break;
-            }
-        }
+        pair.finish_renegotiate();
 
         // Send and receive application data after renegotiation
         pair.send_and_receive()
@@ -905,6 +901,12 @@ mod tests {
             pair.server.write(server_data).expect("server app data"),
             server_data.len()
         );
+
+        // send_renegotiate_request writes a 1-byte app data payload to
+        // flush the HelloRequest. Drain it before reading server_data.
+        let read = unwrap_poll(pair.client.poll_recv(&mut [0; 1]))
+            .expect("Drain flush byte");
+        assert_eq!(read, 1);
 
         // Read only the first byte of the server data
         let mut buffer = [0; 100];
@@ -951,6 +953,8 @@ mod tests {
         // The client fails to start renegotiation due to pending send.
         pair.send_renegotiate_request()
             .expect("Server sends request");
+        // Drain the flush byte from send_renegotiate_request
+        unwrap_poll(pair.client.poll_recv(&mut [0; 1]))?;
         let error = unwrap_poll(pair.client.poll_recv(&mut [0; 1])).unwrap_err();
         assert_eq!(error.kind(), ErrorType::UsageError);
         assert!(error.message().contains(RENEG_ERR_MARKER));
@@ -971,6 +975,8 @@ mod tests {
         // Read the hello request and start renegotiation
         pair.send_renegotiate_request()
             .expect("server HELLO_REQUEST");
+        // Drain the flush byte from send_renegotiate_request
+        unwrap_poll(pair.client.poll_recv(&mut [0; 1]))?;
         assert!(pair.client.poll_recv(&mut [0; 1]).is_pending());
         assert!(pair.client.is_renegotiating());
 

--- a/bindings/rust/standard/integration/src/features/renegotiate.rs
+++ b/bindings/rust/standard/integration/src/features/renegotiate.rs
@@ -49,11 +49,16 @@ fn renegotiate_pair(
         assert_eq!(&buffer[0..data.len()], data);
     }
 
-    // client sends key material + finished
-    let _ = pair.client.connection_mut().poll_recv(&mut [0]);
-
-    // server sends finished
-    let _ = pair.server.connection.read(&mut [0]);
+    // Drive both sides in a loop until the renegotiation handshake completes.
+    // The number of IO calls needed to finish the handshake can vary across
+    // OpenSSL versions, so we avoid assuming a fixed number of round-trips.
+    for _ in 0..10 {
+        let _ = pair.client.connection_mut().poll_recv(&mut [0]);
+        let _ = pair.server.connection.read(&mut [0]);
+        if !pair.server.connection.ssl().renegotiate_pending() {
+            break;
+        }
+    }
 
     // client reads finished
     let _ = pair.client.connection_mut().poll_recv(&mut [0]);

--- a/bindings/rust/standard/integration/src/features/renegotiate.rs
+++ b/bindings/rust/standard/integration/src/features/renegotiate.rs
@@ -52,12 +52,9 @@ fn renegotiate_pair(
     // Drive both sides in a loop until the renegotiation handshake completes.
     // The number of IO calls needed to finish the handshake can vary across
     // OpenSSL versions, so we avoid assuming a fixed number of round-trips.
-    for _ in 0..10 {
+    while pair.server.connection.ssl().renegotiate_pending() {
         let _ = pair.client.connection_mut().poll_recv(&mut [0]);
         let _ = pair.server.connection.read(&mut [0]);
-        if !pair.server.connection.ssl().renegotiate_pending() {
-            break;
-        }
     }
 
     // client reads finished


### PR DESCRIPTION
# Goal
Unblock CI and fix the renegotiation tests broken by the latest OpenSSL release

## Why
The `renegotiate_pair()` function manually drives the renegotiation handshake and assumes each IO call processes exactly one "flight" of handshake messages. However, OpenSSL's `SSL_read()/SSL_write()` during renegotiation doesn't guarantee that — the number of messages processed per call depends on internal buffering and the specific OpenSSL version.

In the new OpenSSL release (v0.10.78), `SSL_write` with zero-length data no longer flushes a pending HelloRequest; `SSL_read` with a zero-length buffer no longer processes incoming handshake messages. This breaks the IO loops and assertions in the renegotiation tests of the s2n-tls crate.

## How
In `standard/integration`, replace the step-by-step sequence in `renegotiate_pair()` with a loop that continues driving IO on both sides until `renegotiate_pending()` returns false.

In `extended/s2n-tls`, use `write(&[0])` (1 byte) instead of `write(&[0; 0])` in `send_renegotiate_request()`. This reliably flushes the HelloRequest but introduces a stray byte that the client sees as app data. We drain the flush byte internally and return any error from the drain.

I also added a function `finish_renegotiate()` to simplify `assert_renegotiate()`. Instead of trying to interleave app data writes with the handshake, it now calls `finish_renegotiate()` first, then does a straightforward write/read of app data on the completed connection.

## Testing
CI should pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
