### PR TITLE
fix: enable FIPS mode with validated 3+ providers and OpenSSL 3.5+

### DIFF
--- a/crypto/s2n_fips.c
+++ b/crypto/s2n_fips.c
@@ -57,13 +57,10 @@ int s2n_fips_init(void)
 {
     s2n_fips_mode_enabled = s2n_libcrypto_is_fips();
 
-    /* When using Openssl, ONLY 3.0 currently supports FIPS.
+    /* When using Openssl, ONLY 3.0+ currently supports FIPS.
      * openssl-1.0.2-fips is no longer supported.
-     * openssl >= 3.5 will likely have a FIPS 140-3 certificate instead of a
-     * FIPS 140-2 certificate, which will require additional review in order
-     * to properly integrate.
      */
-#if defined(OPENSSL_FIPS) || S2N_OPENSSL_VERSION_AT_LEAST(3, 5, 0)
+#if defined(OPENSSL_FIPS)
     POSIX_ENSURE(!s2n_fips_mode_enabled, S2N_ERR_FIPS_MODE_UNSUPPORTED);
 #endif
 


### PR DESCRIPTION
Lift a heuristic check of libcrypto which doesn't check FIPS provider version.

In OpenSSL 3+ providers can be mixed and matched. Meaning whilst one is
compiling against libcrypto 3.5, and at runtime running against
libcrypto 3.5 - the FIPS provider can be 3.0.8, 3.0.9, 3.1.2 or even
from a non-openssl codebase (symcrypt, wolfcrypt, etc).

Thus this heuristic check of libcrypto 3+ version is incorrect. For
example both Ubuntu 22.04 and Amazon Linux 2023 have 3.0 OpenSSL
provider with FIPS 140-3 certification. OpenSSL upstream has 3.1.2
with FIPS 140-3. Etc.

And recent update to Amazon Linux 2023 upgraded runtime libcrypto,
whilst the fips provider can and is of a lower version (Either AL2023
certificate/submission, or the rebrand of the 3.1.2 module).

Making this check test the version of the FIPS provider would also be
incorrect, as there are FIPS providers of 3.0.x versions for both FIPS
140-2 and FIPS 140-3. Also there are providers based on OpenSSL code
that do not use OpenSSL upstream versioning scheme (SUSE) or the ones
not based on OpenSSL code at all (notably symcrypt, wolfcrypt).

Thus simply remove this restriction, and start supporting FIPS 140-3
certified modules as is supported by this codebase throughout, and
enforced by the fips modules on AL2023 and other OSes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes: https://github.com/aws/s2n-tls/issues/5832
