### PR TITLE
fix: make get_handshake_type_name procotol aware

### DIFF
--- a/tests/unit/s2n_tls12_handshake_test.c
+++ b/tests/unit/s2n_tls12_handshake_test.c
@@ -520,5 +520,39 @@ int main(int argc, char **argv)
         }
     };
 
+    /* Test: ensure that there isn't a collision between TLS 1.2 and TLS 1.3 flags
+     * that share the same bit.
+     */
+    {
+        /* sanity check: these flags are the same bit */
+        EXPECT_EQUAL(TLS12_PERFECT_FORWARD_SECRECY, HELLO_RETRY_REQUEST);
+
+        uint32_t tls12_type = NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY;
+        uint32_t tls13_type = NEGOTIATED | FULL_HANDSHAKE | HELLO_RETRY_REQUEST;
+
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(conn);
+
+        /* Clear the cache entries so we start fresh */
+        memset(handshake_type_str_tls12ish[tls12_type], 0, MAX_HANDSHAKE_TYPE_LEN);
+        memset(handshake_type_str_tls13[tls13_type], 0, MAX_HANDSHAKE_TYPE_LEN);
+
+        /* First: populate cache via TLS 1.2 */
+        conn->actual_protocol_version = S2N_TLS12;
+        conn->handshake.handshake_type = tls12_type;
+        const char *tls12_name = s2n_connection_get_handshake_type_name(conn);
+        EXPECT_NOT_NULL(tls12_name);
+        EXPECT_STRING_EQUAL(tls12_name, "NEGOTIATED|FULL_HANDSHAKE|TLS12_PERFECT_FORWARD_SECRECY");
+
+        /* Second: query cache via TLS 1.3 with same bitmap — should not collide */
+        conn->actual_protocol_version = S2N_TLS13;
+        conn->handshake.handshake_type = tls13_type;
+        const char *tls13_name = s2n_connection_get_handshake_type_name(conn);
+        EXPECT_NOT_NULL(tls13_name);
+        EXPECT_STRING_EQUAL(tls13_name, "NEGOTIATED|FULL_HANDSHAKE|HELLO_RETRY_REQUEST");
+
+        EXPECT_SUCCESS(s2n_connection_free(conn));
+    };
+
     END_TEST();
 }

--- a/tests/unit/s2n_tls12_handshake_test.c
+++ b/tests/unit/s2n_tls12_handshake_test.c
@@ -525,7 +525,7 @@ int main(int argc, char **argv)
      */
     {
         /* sanity check: these flags are the same bit */
-        EXPECT_EQUAL(TLS12_PERFECT_FORWARD_SECRECY, HELLO_RETRY_REQUEST);
+        EXPECT_EQUAL((int) TLS12_PERFECT_FORWARD_SECRECY, (int) HELLO_RETRY_REQUEST);
 
         uint32_t tls12_type = NEGOTIATED | FULL_HANDSHAKE | TLS12_PERFECT_FORWARD_SECRECY;
         uint32_t tls13_type = NEGOTIATED | FULL_HANDSHAKE | HELLO_RETRY_REQUEST;

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1157,7 +1157,7 @@ const char *s2n_connection_get_handshake_type_name(struct s2n_connection *conn)
 
     const char **handshake_labels = tls13_handshake_type_names;
     size_t handshake_labels_len = s2n_array_len(tls13_handshake_type_names);
-    char (*names)[MAX_HANDSHAKE_TYPE_LEN] = handshake_type_str_tls13;
+    char(*names)[MAX_HANDSHAKE_TYPE_LEN] = handshake_type_str_tls13;
     if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
         handshake_labels = tls12_handshake_type_names;
         handshake_labels_len = s2n_array_len(tls12_handshake_type_names);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -798,7 +798,11 @@ static message_type_t tls13_handshakes[S2N_HANDSHAKES_COUNT][S2N_MAX_HANDSHAKE_L
 /* clang-format on */
 
 #define MAX_HANDSHAKE_TYPE_LEN 142
-static char handshake_type_str[S2N_HANDSHAKES_COUNT][MAX_HANDSHAKE_TYPE_LEN] = { 0 };
+/* The handshake type labels used for TLS 1.0 - TLS 1.2, e.g. `NEGOTIATED|WITH_SESSION_TICKET` */
+static char handshake_type_str_tls12ish[S2N_HANDSHAKES_COUNT][MAX_HANDSHAKE_TYPE_LEN] = { 0 };
+
+/* The handshake type labels used for TLS 1.3, e.g. `NEGOTIATED|HELLO_RETRY_REQUEST` */
+static char handshake_type_str_tls13[S2N_HANDSHAKES_COUNT][MAX_HANDSHAKE_TYPE_LEN] = { 0 };
 
 static const char *tls12_handshake_type_names[] = {
     "NEGOTIATED|",
@@ -1151,44 +1155,46 @@ const char *s2n_connection_get_handshake_type_name(struct s2n_connection *conn)
         return "INITIAL";
     }
 
-    const char **handshake_type_names = tls13_handshake_type_names;
-    size_t handshake_type_names_len = s2n_array_len(tls13_handshake_type_names);
+    const char **handshake_labels = tls13_handshake_type_names;
+    size_t handshake_labels_len = s2n_array_len(tls13_handshake_type_names);
+    char (*names)[MAX_HANDSHAKE_TYPE_LEN] = handshake_type_str_tls13;
     if (s2n_connection_get_protocol_version(conn) < S2N_TLS13) {
-        handshake_type_names = tls12_handshake_type_names;
-        handshake_type_names_len = s2n_array_len(tls12_handshake_type_names);
+        handshake_labels = tls12_handshake_type_names;
+        handshake_labels_len = s2n_array_len(tls12_handshake_type_names);
+        names = handshake_type_str_tls12ish;
     }
 
     /* Not all handshake strings will be created already. If the handshake string
      * is not null, we can just return the handshake. Otherwise we have to compute
      * it down below. */
-    if (handshake_type_str[handshake_type][0] != '\0') {
-        return handshake_type_str[handshake_type];
+    if (names[handshake_type][0] != '\0') {
+        return names[handshake_type];
     }
 
-    /* Compute handshake_type_str[handshake_type] by concatenating
-     * each applicable handshake_type.
+    /* Compute the cached string by concatenating each applicable handshake_type.
      *
-     * Unit tests enforce that the elements of handshake_type_str are always
+     * Unit tests enforce that the elements of the cache are always
      * long enough to contain the longest possible valid handshake_type, but
      * for safety we still handle the case where we need to truncate.
      */
-    char *p = handshake_type_str[handshake_type];
-    size_t remaining = sizeof(handshake_type_str[0]);
-    for (size_t i = 0; i < handshake_type_names_len; i++) {
-        if (handshake_type & (1 << i)) {
-            size_t bytes_to_copy = MIN(remaining, strlen(handshake_type_names[i]));
-            PTR_CHECKED_MEMCPY(p, handshake_type_names[i], bytes_to_copy);
+    char *p = names[handshake_type];
+    size_t remaining = MAX_HANDSHAKE_TYPE_LEN;
+    for (size_t i = 0; i < handshake_labels_len; i++) {
+        bool label_applies = handshake_type & (1 << i);
+        if (label_applies) {
+            size_t bytes_to_copy = MIN(remaining, strlen(handshake_labels[i]));
+            PTR_CHECKED_MEMCPY(p, handshake_labels[i], bytes_to_copy);
             p[bytes_to_copy] = '\0';
             p += bytes_to_copy;
             remaining -= bytes_to_copy;
         }
     }
 
-    if (p != handshake_type_str[handshake_type] && '|' == *(p - 1)) {
+    if (p != names[handshake_type] && '|' == *(p - 1)) {
         *(p - 1) = '\0';
     }
 
-    return handshake_type_str[handshake_type];
+    return names[handshake_type];
 }
 
 S2N_RESULT s2n_handshake_message_send(struct s2n_connection *conn, uint8_t content_type, s2n_blocked_status *blocked)


### PR DESCRIPTION
# Goal
Fix incorrect results from `s2n_connection_get_handshake_type`

## Why
The type names are lazily calculated. However the static array that stores the type names has collisions between TLS 1.2 and TLS 1.3 labels.

## How
We introduce different type name containers for TLS 1.2ish and TLS 1.3 connections.

## Testing
Added a unit test. Confirmed that it failed before my fix, and confirmed that it passes after my fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
