### PR TITLE
refactor: reset d2i pointer before private key type-hint fallback

### DIFF
--- a/crypto/s2n_pkey.c
+++ b/crypto/s2n_pkey.c
@@ -209,6 +209,12 @@ S2N_RESULT s2n_asn1der_to_private_key(struct s2n_pkey *priv_key, struct s2n_blob
      * If d2i_AutoPrivateKey fails, try once more with the type we parsed from the PEM.
      */
     if (evp_private_key == NULL) {
+        /* libcrypto implementations leave key_to_parse unchanged on failure,
+         * but OpenSSL only documents the successful-advance behavior.
+         * Reset key_to_parse defensively so the retry always starts from the
+         * beginning of the buffer, regardless of underlying libcrypto behavior.
+         */
+        key_to_parse = asn1der->data;
         evp_private_key = d2i_PrivateKey(type_hint, NULL, &key_to_parse, asn1der->size);
     }
     RESULT_ENSURE(evp_private_key, S2N_ERR_DECODE_PRIVATE_KEY);


### PR DESCRIPTION
# Goal
Reset the input buffer cursor before the `d2i_PrivateKey` type-hint fallback in `s2n_asn1der_to_private_key`, so the fallback does not depend on undocumented libcrypto behavior.

## Why
`s2n_asn1der_to_private_key` calls `d2i_AutoPrivateKey` first and, if that fails to detect the key type, falls back to `d2i_PrivateKey(type_hint, ...)` against the same buffer. Every mainstream libcrypto (OpenSSL 1.0.2, 1.1.x, 3.x, BoringSSL, AWS-LC) leaves the caller's cursor unchanged on failure, so the fallback works correctly today. However, the OpenSSL man page only documents the advance-on-success behavior; the failure-path invariant lives in the source code, not the contract.

Resetting the cursor removes the dependency on that undocumented invariant and makes the code robust against any future libcrypto that might not preserve it.

## How
Before the fallback `d2i_PrivateKey` call, set `key_to_parse = asn1der->data`.

## Callouts
Purely defense in depth. No known libcrypto exhibits the risky behavior today, and the path is not peer-reachable, it runs when an application loads its own private key.

## Testing
Existing tests cover this code

### Related
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
