### PR TITLE
test(aead): Sample fragment sizes in AEAD record tests

### DIFF
--- a/tests/unit/s2n_aead_aes_test.c
+++ b/tests/unit/s2n_aead_aes_test.c
@@ -73,7 +73,47 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(setup_server_keys(conn, &aes128));
 
     int max_fragment = S2N_SMALL_FRAGMENT_LENGTH;
-    for (size_t i = 0; i <= max_fragment + 1; i++) {
+    /* Sample fragment sizes that cover interesting boundaries (AES block size,
+     * powers of two, the fragment length limit) rather than iterating over
+     * every possible size.
+     * See https://github.com/aws/s2n-tls/issues/5704 */
+    const size_t fragment_sizes[] = {
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        15,
+        16,
+        17,
+        31,
+        32,
+        33,
+        63,
+        64,
+        65,
+        127,
+        128,
+        129,
+        255,
+        256,
+        257,
+        511,
+        512,
+        513,
+        1023,
+        1024,
+        1025,
+        (size_t) max_fragment - 1,
+        (size_t) max_fragment,
+        (size_t) max_fragment + 1,
+    };
+    for (size_t s = 0; s < s2n_array_len(fragment_sizes); s++) {
+        size_t i = fragment_sizes[s];
         struct s2n_blob in = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
         int bytes_written = 0;
@@ -271,7 +311,8 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(setup_server_keys(conn, &aes256));
     conn->actual_protocol_version = S2N_TLS12;
 
-    for (size_t i = 0; i <= max_fragment + 1; i++) {
+    for (size_t s = 0; s < s2n_array_len(fragment_sizes); s++) {
+        size_t i = fragment_sizes[s];
         struct s2n_blob in = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
         int bytes_written = 0;

--- a/tests/unit/s2n_aead_chacha20_poly1305_test.c
+++ b/tests/unit/s2n_aead_chacha20_poly1305_test.c
@@ -76,7 +76,47 @@ int main(int argc, char **argv)
     POSIX_GUARD(setup_server_keys(conn, &chacha20_poly1305_key));
 
     int max_fragment = S2N_SMALL_FRAGMENT_LENGTH;
-    for (size_t i = 0; i <= max_fragment + 1; i++) {
+    /* Sample fragment sizes that cover interesting boundaries (AES block size,
+     * powers of two, the fragment length limit) rather than iterating over
+     * every possible size.
+     * See https://github.com/aws/s2n-tls/issues/5704 */
+    const size_t fragment_sizes[] = {
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        15,
+        16,
+        17,
+        31,
+        32,
+        33,
+        63,
+        64,
+        65,
+        127,
+        128,
+        129,
+        255,
+        256,
+        257,
+        511,
+        512,
+        513,
+        1023,
+        1024,
+        1025,
+        (size_t) max_fragment - 1,
+        (size_t) max_fragment,
+        (size_t) max_fragment + 1,
+    };
+    for (size_t s = 0; s < s2n_array_len(fragment_sizes); s++) {
+        size_t i = fragment_sizes[s];
         struct s2n_blob in = { 0 };
         EXPECT_SUCCESS(s2n_blob_init(&in, random_data, i));
         int bytes_written = 0;


### PR DESCRIPTION
# Goal

Reduce the runtime of the two slowest s2n-tls unit tests, `s2n_aead_aes_test` and `s2n_aead_chacha20_poly1305_test`.

## Why

See: https://github.com/aws/s2n-tls/issues/5704

These two tests dominated local unit test iteration time on developer machines:
- `s2n_aead_aes_test`: 232.37 sec
- `s2n_aead_chacha20_poly1305_test`: 121.70 sec

Both tests iterated over every fragment size from `0` to `S2N_SMALL_FRAGMENT_LENGTH + 1` (1437 iterations), and for each size ran inner tamper-detection loops that scaled linearly with the payload size. This quadratic structure made them the longest-running unit tests in the suite without providing meaningfully better coverage than sampling representative sizes would.

**Before this change:**
```
278/279 Test   #3: s2n_aead_chacha20_poly1305_test ..................   Passed  121.70 sec
279/279 Test   #2: s2n_aead_aes_test ................................   Passed  232.37 sec
```

**After this change:**
```
256/279 Test   #3: s2n_aead_chacha20_poly1305_test ..................   Passed    3.28 sec
264/279 Test   #2: s2n_aead_aes_test ................................   Passed    5.10 sec
```

**Runtime comparison:**

|                            Test | Before    | After    | Speedup |
| ------------------------------: | :-------- | :------- | :------ |
|              `s2n_aead_aes_test` | 232.37 sec | 5.10 sec | ~45x    |
| `s2n_aead_chacha20_poly1305_test` | 121.70 sec | 3.28 sec | ~37x    |

## How

Replace the exhaustive `for (size_t i = 0; i <= max_fragment + 1; i++)` outer loop in both test files with iteration over a fixed set of 33 fragment sizes chosen to cover the boundaries that actually matter:

- All sizes 0-8 (small-payload edge cases)
- Values around each power of two through 1024 (n-1, n, n+1 for 16, 32, 64, 128, 256, 512, 1024)
- The fragment length limit boundary (max-1, max, max+1)

The inner tamper-detection and validation logic is unchanged. The AES test still covers both AES128-GCM and AES256-GCM; the ChaCha20-Poly1305 test is unchanged in scope.

## Callouts

- This is a coverage trade-off. An AEAD construction does not have "weak byte positions" or "weak payload sizes" that require exhaustive enumeration to catch, once tamper detection is verified at representative sizes, additional sizes provide diminishing returns.
- The inner payload-tamper loops (`for (j = 0; j < i; j++)`) are still O(N) per outer iteration. That's why the max-fragment case (size 1435) still dominates the remaining runtime.
## Testing

Ran unit tests locally on an M4 MacBook Pro. Both tests pass, and all other unit tests continue to pass.

### Related

 - https://github.com/aws/s2n-tls/issues/5704

<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
