### PR TITLE
ci: accept 400 from ebay.com in https_client network test

### DIFF
--- a/bindings/rust/standard/integration/src/network/https_client.rs
+++ b/bindings/rust/standard/integration/src/network/https_client.rs
@@ -46,7 +46,9 @@ const TEST_CASES: &[TestCase] = &[
     TestCase::new("https://www.apple.com", &[200]),
     TestCase::new("https://www.att.com", &[200]),
     TestCase::new("https://www.cloudflare.com", &[200]),
-    TestCase::new("https://www.ebay.com", &[200]),
+    // 2026-04-28: ebay.com returns 400 under
+    // `cargo test --no-default-features --features pq`.
+    TestCase::new("https://www.ebay.com", &[200, 400]),
     TestCase::new("https://www.google.com", &[200]),
     TestCase::new("https://www.mozilla.org", &[200]),
     TestCase::new("https://www.netflix.com", &[200]),


### PR DESCRIPTION
# Goal
Unblock CI by getting the `http_get_test` integration test passing again.

## Why
The test is failing on every PR ([example](https://github.com/aws/s2n-tls/actions/runs/25065372172/job/73430911489)). `https://www.ebay.com` now returns a `400` to the hyper client used by the test, while the test case only accepts `200`. Reproduced localy with the same command CI runs:
```
RUST_LOG=TRACE cargo test --no-default-features --features pq
```
## How
Add `400` to the accepted status codes for the ebay test case, with a dated comment noting the reproducer, consistent with the microsoft entry.

## Callouts
- Other sites in this list have had similar updates historically (see prior commits for [wikipedia](https://github.com/aws/s2n-tls/pull/5470) and [yahoo](https://github.com/aws/s2n-tls/pull/5280)).

## Testing
Ran the same command locally before and after the change:
Before:
```
test network::https_client::http_get_test ... FAILED Unexpected status code "400" for test case TestCase { query_target: "https://www.ebay.com", expected_status_codes: [200] }
```
After: test passes. CI re-run should confirm this end-to-end.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
